### PR TITLE
fix: update examples directory in docs build

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -4,8 +4,8 @@ export VERSION := $(shell cat ../VERSION)
 
 BUILDDIR ?= ../build
 
-EXAMPLES := $(wildcard ../projects/external/*/.)
-EXAMPLES_DIRS := $(patsubst ../projects/external/%/., $(BUILDDIR)/docs-downloads/examples/%.tgz, $(EXAMPLES))
+EXAMPLES := $(wildcard ../examples/official/*/.)
+EXAMPLES_DIRS := $(patsubst ../examples/official/%/., $(BUILDDIR)/docs-downloads/examples/%.tgz, $(EXAMPLES))
 
 # You can set these variables from the command line.
 SPHINXOPTS    = -W
@@ -30,7 +30,7 @@ build: $(EXAMPLES_DIRS) sp-html
 	mkdir -p $$(dirname $(TARGETDIR))
 	cp -r $(OUTDIR)/html $(TARGETDIR)
 
-$(BUILDDIR)/docs-downloads/examples/%.tgz: ../projects/external/%/
+$(BUILDDIR)/docs-downloads/examples/%.tgz: ../examples/official/%/
 	find "$<" \( -name __pycache__ -o -name \*.pyc \) -delete
 	mkdir -p $$(dirname "$@")
 	$(TAR) -czf "$@" -C "$<" .


### PR DESCRIPTION
Recently, `projects/external` was renamed to `examples/official`, but references to the old name remained in the docs build. All example file download links in the docs have been broken since then.

# Test Plan
- [x] `make -C docs build`; check that download links are generated and [warnings about unreadable files](https://jenkins.determined.ai/blue/organizations/jenkins/determined-integration-tests/detail/PR-5077/4/pipeline/15#step-24-log-129) go away