### PR TITLE
build: allow master's default Segment keys to be set at build time

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -13,6 +13,8 @@ builds:
       - CGO_ENABLED=0
     ldflags:
       - -X github.com/determined-ai/determined/master/version.Version={{.Env.VERSION}}
+      - -X github.com/determined-ai/determined/master/internal.DefaultSegmentMasterKey={{.Env.DET_SEGMENT_MASTER_KEY}}
+      - -X github.com/determined-ai/determined/master/internal.DefaultSegmentWebUIKey={{.Env.DET_SEGMENT_WEBUI_KEY}}
     goos:
       - linux
       - darwin

--- a/Makefile
+++ b/Makefile
@@ -72,6 +72,10 @@ DET_DEV_AGENT_IMAGE := determinedai/determined-dev:determined-agent-$(DET_GIT_CO
 DET_DEV_MASTER_IMAGE := determinedai/determined-dev:determined-master-$(DET_GIT_COMMIT)
 export DET_IMAGES := $(DET_DEV_AGENT_IMAGE),$(DET_DEV_MASTER_IMAGE)
 
+# These variables are used in the master build; the values here are the keys for the dev sources.
+export DET_SEGMENT_MASTER_KEY ?= rpkD9yaoFe16ZrrU8oYJwabaEYpqfsSn
+export DET_SEGMENT_WEBUI_KEY ?= M73ylQEXzfZ2iF2XHnqaXWlJh9aSCb0u
+
 all: get-deps build-docker
 
 # combined-reqs.txt contains the pinned versions for all development

--- a/master/internal/config.go
+++ b/master/internal/config.go
@@ -14,6 +14,12 @@ import (
 	"github.com/determined-ai/determined/master/pkg/model"
 )
 
+// These are package-level variables so that they can be set at link time.
+var (
+	DefaultSegmentMasterKey = ""
+	DefaultSegmentWebUIKey  = ""
+)
+
 // DefaultConfig returns the default configuration of the master.
 func DefaultConfig() *Config {
 	defaultExp := model.DefaultExperimentConfig()
@@ -51,8 +57,8 @@ func DefaultConfig() *Config {
 		Root: "/usr/share/determined/master",
 		Telemetry: TelemetryConfig{
 			Enabled:          true,
-			SegmentMasterKey: "rpkD9yaoFe16ZrrU8oYJwabaEYpqfsSn",
-			SegmentWebUIKey:  "M73ylQEXzfZ2iF2XHnqaXWlJh9aSCb0u",
+			SegmentMasterKey: DefaultSegmentMasterKey,
+			SegmentWebUIKey:  DefaultSegmentWebUIKey,
 		},
 	}
 }


### PR DESCRIPTION
In order to allow us to distinguish dev/internal data from that coming from outside users, this sets up build things so that the default Segment keys can be overridden by environment variables at build time (e.g., `DET_SEGMENT_MASTER_KEY=... make publish`). The idea is that the variables will be set to our production keys when the release is being cut, so that the released and uploaded binaries/packages use that key. Otherwise, they'll default to our dev keys. The production keys could also be baked into the `make publish` target, but maybe we don't want to have those in the repo or something. Heck, maybe we don't even want the dev ones in the repo. I'm not sure what the best policy is, but anyway this change allows us to manage the keys more easily.

# Test Plan
- [x] run the build and check that the key values show up and can be overridden by setting the environment variables during the build
