### PR TITLE
docs: rearrange structure of installation docs

### DIFF
--- a/docs/how-to/index.txt
+++ b/docs/how-to/index.txt
@@ -6,7 +6,7 @@ How-To guides are goal-oriented guides. They provide a detailed set of steps to 
 The full list of our how-to guides can be found below:
 
 .. toctree::
-  :maxdepth: 0
+  :maxdepth: 2
   :titlesonly:
 
   custom-env
@@ -14,11 +14,6 @@ The full list of our how-to guides can be found below:
   hyperparameter-tuning
   install-cli
   install-general
-  install-packages
-  install-docker
-  install-deploy
-  install-aws
-  install-gcp
   notebook-state
   notebook-configuration
   run-notebooks

--- a/docs/how-to/install-deploy.txt
+++ b/docs/how-to/install-deploy.txt
@@ -1,7 +1,7 @@
 .. _install-using-deploy:
 
 Install Determined Using det-deploy
-=======================================
+===================================
 
 This document shows how to deploy Determined locally or in a production
 cluster using the ``det-deploy`` command-line tool, which automates the

--- a/docs/how-to/install-general.txt
+++ b/docs/how-to/install-general.txt
@@ -3,8 +3,8 @@
 Install Determined
 ==================
 
-This document describes how to install and upgrade Determined.
-Determined consists of several components, primarily
+This document provides general information on how to install and upgrade
+Determined. Determined consists of several components, primarily
 
 -  a **master** that schedules workloads and stores metadata
 -  one or more **agents** that run workloads, typically using GPUs
@@ -69,11 +69,16 @@ Installing Determined
 We support running most components of Determined either under Docker or
 using standard package files and natively installed services. We also
 provide ``det-deploy``, a tool that helps automate the process of
-running Determined under Docker.
+running Determined under Docker either locally or on AWS instances, and
 
-- :ref:`install-using-packages`
-- :ref:`install-using-docker`
-- :ref:`install-using-deploy`
+.. toctree::
+   :titlesonly:
+
+   install-deploy
+   install-aws
+   install-gcp
+   install-packages
+   install-docker
 
 .. _install-docker:
 


### PR DESCRIPTION
Make the general installation information page a parent of the pages for specific methods and adjust TOC trees accordingly.

The relevant part of the how-to index page:
![2020-04-07-13-53-54 978121198](https://user-images.githubusercontent.com/596106/78718491-3b838c00-78d7-11ea-9d6f-1e34aee7e6f0.png)

And in the general installation page:
![2020-04-07-14-37-01 108411167](https://user-images.githubusercontent.com/596106/78721911-43dec580-78dd-11ea-838d-95aca83611ce.png)

# Test Plan
- [x] build and examine docs