### PR TITLE
chore: revert "chore: fix "Sign in/out" cypress test with waiting"

### DIFF
--- a/webui/tests/cypress/integration/02-loginout.spec.ts
+++ b/webui/tests/cypress/integration/02-loginout.spec.ts
@@ -4,17 +4,16 @@ describe('Sign in/out', () => {
     // Check for the presence/absence of the icons for the user dropdown and
     // cluster page link in the top bar, which should be present if and only if
     // the user is logged in.
-    cy.visit('/ui/experiments');
     cy.get('#avatar').should('exist');
     cy.get('#avatar').should('have.text', username.charAt(0).toUpperCase());
   }
 
   function checkLoggedOut(): void {
-    cy.visit('/ui/logout');
     cy.get('#avatar').should('not.exist');
   }
 
   it('should log in', () => {
+    cy.visit('/ui/experiments');
     checkLoggedIn('determined');
   });
 
@@ -23,12 +22,14 @@ describe('Sign in/out', () => {
     cy.get('#avatar').click();
     cy.get('nav a[href="/ui/logout"]').should('have.lengthOf', 1);
     cy.get('nav a[href="/ui/logout"]').click();
+    cy.visit('/ui/logout');
     checkLoggedOut();
   });
 
   it('should log back in after logging out', () => {
     // Logging out above should put us on the login page, so enter the login
     // information directly.
+    cy.visit('/ui/logout');
     cy.get('input#input-username').type('determined');
     cy.get('button[type="submit"]').click();
     checkLoggedIn('determined');


### PR DESCRIPTION
This reverts commit c0a8e9027e7a450fc12458bae5765e9bcc350641.
context: https://github.com/determined-ai/determined/pull/3#discussion_r405107478

> with 1. the long wait it currently has it doesn't seem very likely (more verbose logs should help)
> 2. having auto login means we wouldn't be able to use the visit command without nullifying the test