### PR TITLE
[DET-2797] fix: order rendezvous ports deterministically

### DIFF
--- a/master/pkg/tasks/ports.go
+++ b/master/pkg/tasks/ports.go
@@ -16,8 +16,8 @@ const (
 	hostMode container.NetworkMode = "host"
 )
 
-func rendezvousPorts(devices []device.Device, networkMode container.NetworkMode) nat.PortSet {
-	ports := make(nat.PortSet)
+func rendezvousPorts(devices []device.Device, networkMode container.NetworkMode) []nat.Port {
+	ports := make([]nat.Port, 0)
 	var min int
 	if networkMode == hostMode {
 		min = devices[0].ID
@@ -27,9 +27,9 @@ func rendezvousPorts(devices []device.Device, networkMode container.NetworkMode)
 			}
 		}
 	}
-	ports[nat.Port(fmt.Sprintf("%d/tcp", localRendezvousPort+min))] = struct{}{}
-	ports[nat.Port(fmt.Sprintf("%d/tcp",
-		localRendezvousPort+min+localRendezvousPortOffset))] = struct{}{}
+	ports = append(ports, nat.Port(fmt.Sprintf("%d/tcp", localRendezvousPort+min)))
+	ports = append(
+		ports, nat.Port(fmt.Sprintf("%d/tcp", localRendezvousPort+min+localRendezvousPortOffset)))
 	return ports
 }
 

--- a/master/pkg/tasks/task.go
+++ b/master/pkg/tasks/task.go
@@ -123,16 +123,16 @@ func startContainer(t TaskSpec) container.Spec {
 			},
 		})
 	}
-	ports := make(nat.PortSet)
 	networkMode := t.ContainerDefaults.NetworkMode
 	if exp.ExperimentConfig.Resources.SlotsPerTrial > 1 {
 		networkMode = hostMode
 	}
 	rPorts := rendezvousPorts(t.Devices, networkMode)
+	ports := make(nat.PortSet)
 	var rPortsEnvVars []string
-	for port, v := range rPorts {
+	for _, port := range rPorts {
 		rPortsEnvVars = append(rPortsEnvVars, port.Port())
-		ports[port] = v
+		ports[port] = struct{}{}
 	}
 
 	networkInterface := exp.TrialRunnerConfig.NetworkInterface


### PR DESCRIPTION
ZMQ was not the problem.

Previously the rendezvous ports for containers were set in a random ordering.
When the master receives the ports from all containers to send around rendezvous
info, it orders them from smallest to largest port. Each trial runner, then
replaces its local rendezvous address received from the master (ordered from
smallest to largest) with the port originally received (that was being sent
in random order). This caused trial runners to start up connections on the wrong
ports, leading to timeouts/hangs.

- [x] Test this change manually
