### PR TITLE
build: clean before copying static files

### DIFF
--- a/master/Makefile
+++ b/master/Makefile
@@ -56,6 +56,7 @@ build: build-docs build-elm build-files build-python-packages build-react
 
 build-files:
 	mkdir -p "$(BUILDDIR)"/share/determined/master
+	rm -rf "$(BUILDDIR)"/share/determined/master/static
 	cp -r static "$(BUILDDIR)"/share/determined/master
 
 # This depends on `build-python-packages` for the sake of parallel builds: the


### PR DESCRIPTION
After changes where files are deleted, the old behavior would sometimes
leave old static files laying around in the new build directory, due the
the behavior of cp.
