### PR TITLE
[DET-2796] remove useless internal.framework from experiment configuration

### DIFF
--- a/master/pkg/model/experiment_config.go
+++ b/master/pkg/model/experiment_config.go
@@ -252,6 +252,5 @@ type InternalConfig struct {
 
 // NativeConfig represents configuration set by Determined native implementations.
 type NativeConfig struct {
-	Command   []string `json:"command"`
-	Framework string   `json:"framework"`
+	Command []string `json:"command"`
 }


### PR DESCRIPTION
`internal.frameworks` used to help load the right trial controller for Native API but now it's replaced by passing the trial controller class from the `init` function into the `load` module.

No need to test.
Checked if there is any place using `internal.frameworks`.