### PR TITLE
docs: fix whitespace after lists

### DIFF
--- a/docs/topic-guides/reproducibility.txt
+++ b/docs/topic-guides/reproducibility.txt
@@ -25,7 +25,9 @@ Determined can control and reproduce the following sources of randomness:
 3. Shuffling of training data in a trial.
 4. Dropout or other random layers.
 
-Determined currently does not offer support for:
+|
+| Determined currently does not offer support for:
+|
 
 1. Controlling non-determinism in floating-point operations. Modern deep
    learning frameworks typically implement training using floating point

--- a/docs/tutorials/pytorch-mnist-tutorial.txt
+++ b/docs/tutorials/pytorch-mnist-tutorial.txt
@@ -16,7 +16,8 @@ At the end of this tutorial, the reader should know:
 #. How to Write a Determined YAML Experiment Configuration
 #. A General Procedure of a Determined Workflow
 
-Note: As we walk through the tutorial, some code has been omitted for demonstration purposes. A complete code example is available at :download:`MNIST PyTorch </examples/mnist_pytorch.tgz>`.
+|
+| Note: As we walk through the tutorial, some code has been omitted for demonstration purposes. A complete code example is available at :download:`MNIST PyTorch </examples/mnist_pytorch.tgz>`.
 
 Overview
 --------

--- a/docs/tutorials/tf-mnist-tutorial.txt
+++ b/docs/tutorials/tf-mnist-tutorial.txt
@@ -16,7 +16,8 @@ At the end of this tutorial, the reader should know:
 #. How to Write a Determined YAML Experiment Configuration.
 #. A General Procedure of a Determined Workflow
 
-Note: As we walk through the tutorial, some code has been omitted for demonstration purposes. A complete code example is available at :download:`MNIST TF.Keras </examples/mnist_tf_keras.tgz>`.
+|
+| Note: As we walk through the tutorial, some code has been omitted for demonstration purposes. A complete code example is available at :download:`MNIST TF.Keras </examples/mnist_tf_keras.tgz>`.
 
 Overview
 --------


### PR DESCRIPTION
# Test Plan
- UI change:
  - [ ] add screenshots
  - [ ] React? build & check storybooks
- [ ] user-facing api change: modify documentation and examples
- [ ] user-facing api change: add the "User-facing API Change" label
- [ ] bug fix: add regression test
- [ ] bug fix: determine if there are other similar bugs in the codebase
- [ ] new feature: add test coverage for any user-facing aspects
- [ ] refactor: maintain existing code coverage
