### PR TITLE
ci: use a new set of Segment keys for CI and no keys by default

### DIFF
--- a/CI/jenkins/IntegrationTests.Jenkinsfile
+++ b/CI/jenkins/IntegrationTests.Jenkinsfile
@@ -24,8 +24,10 @@ config_uri = "s3://integrations-cluster-config/${config_root}/"
 pipeline {
   agent any
   environment {
-    INTEGRATIONS_RESOURCE_SUFFIX="-${env.BUILD_TAG}"
-    GOBIN="${env.WORKSPACE}/gobin"
+    DET_SEGMENT_MASTER_KEY = "1ads2YHMXEOfSNWx7dapghABlIzzzov7"
+    DET_SEGMENT_WEBUI_KEY = "Xaye00PGJfy2JBND3r52ifhHYhEUVccY"
+    GOBIN = "${env.WORKSPACE}/gobin"
+    INTEGRATIONS_RESOURCE_SUFFIX = "-${env.BUILD_TAG}"
   }
   stages {
     stage('Build and Push') {

--- a/CI/jenkins/NightlyTests.Jenkinsfile
+++ b/CI/jenkins/NightlyTests.Jenkinsfile
@@ -6,7 +6,9 @@ pipeline {
     cron('H 1 * * *')
   }
   environment {
-    INTEGRATIONS_RESOURCE_SUFFIX="-${env.BUILD_TAG}"
+    DET_SEGMENT_MASTER_KEY = "1ads2YHMXEOfSNWx7dapghABlIzzzov7"
+    DET_SEGMENT_WEBUI_KEY = "Xaye00PGJfy2JBND3r52ifhHYhEUVccY"
+    INTEGRATIONS_RESOURCE_SUFFIX = "-${env.BUILD_TAG}"
   }
   stages {
     stage('Nightly tests') {

--- a/CI/jenkins/PublishDevImages.Jenkinsfile
+++ b/CI/jenkins/PublishDevImages.Jenkinsfile
@@ -3,6 +3,8 @@ describeNode = "echo \"Running on \${NODE_NAME} (executor: \${EXECUTOR_NUMBER})\
 pipeline {
   agent any
   environment {
+    DET_SEGMENT_MASTER_KEY = "1ads2YHMXEOfSNWx7dapghABlIzzzov7"
+    DET_SEGMENT_WEBUI_KEY = "Xaye00PGJfy2JBND3r52ifhHYhEUVccY"
     DOCKER_REGISTRY = ""
     GOOGLE_APPLICATION_CREDENTIALS = "/home/ubuntu/gcp-creds.json"
     IMAGE_TYPE = sh(script: "printf ${env.BRANCH_NAME} | sed -r 's/\\//_/g' | sed -r 's/\\./-/g'", returnStdout: true)

--- a/CI/jenkins/WebUITests.Jenkinsfile
+++ b/CI/jenkins/WebUITests.Jenkinsfile
@@ -3,8 +3,10 @@ describeNode = "echo \"Running on \${NODE_NAME} (executor: \${EXECUTOR_NUMBER})\
 pipeline {
   agent any
     environment {
+      DET_SEGMENT_MASTER_KEY = "1ads2YHMXEOfSNWx7dapghABlIzzzov7"
+      DET_SEGMENT_WEBUI_KEY = "Xaye00PGJfy2JBND3r52ifhHYhEUVccY"
+      GOBIN = "${env.WORKSPACE}/gobin"
       INTEGRATIONS_HOST_PORT = sh(script: 'python ./CI/integrations/get_port.py --run-number $EXECUTOR_NUMBER', , returnStdout: true).trim()
-      GOBIN="${env.WORKSPACE}/gobin"
     }
     stages {
       stage('Environment Setup') {

--- a/Makefile
+++ b/Makefile
@@ -72,9 +72,9 @@ DET_DEV_AGENT_IMAGE := determinedai/determined-dev:determined-agent-$(DET_GIT_CO
 DET_DEV_MASTER_IMAGE := determinedai/determined-dev:determined-master-$(DET_GIT_COMMIT)
 export DET_IMAGES := $(DET_DEV_AGENT_IMAGE),$(DET_DEV_MASTER_IMAGE)
 
-# These variables are used in the master build; the values here are the keys for the dev sources.
-export DET_SEGMENT_MASTER_KEY ?= rpkD9yaoFe16ZrrU8oYJwabaEYpqfsSn
-export DET_SEGMENT_WEBUI_KEY ?= M73ylQEXzfZ2iF2XHnqaXWlJh9aSCb0u
+# These variables are picked up by GoReleaser for the master build; we default to including no keys.
+export DET_SEGMENT_MASTER_KEY ?=
+export DET_SEGMENT_WEBUI_KEY ?=
 
 all: get-deps build-docker
 

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -3,6 +3,8 @@ version: 0.2
 
 env:
   variables:
+    DET_SEGMENT_MASTER_KEY: 1ads2YHMXEOfSNWx7dapghABlIzzzov7
+    DET_SEGMENT_WEBUI_KEY: Xaye00PGJfy2JBND3r52ifhHYhEUVccY
     GO111MODULE: on
     PACKAGE: github.com/determined-ai/determined
     PATH: /usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/go/bin

--- a/master/internal/core.go
+++ b/master/internal/core.go
@@ -73,11 +73,13 @@ func New(version string, logStore *logger.LogBuffer, config *Config) *Master {
 }
 
 func (m *Master) getInfo(c echo.Context) (interface{}, error) {
+	enabled := m.config.Telemetry.Enabled && m.config.Telemetry.SegmentWebUIKey != ""
+
 	// It would look a bit weird to put a Segment key in the result even when telemetry is disabled.
 	telemetryInfo := aproto.TelemetryInfo{
-		Enabled: m.config.Telemetry.Enabled,
+		Enabled: enabled,
 	}
-	if m.config.Telemetry.Enabled {
+	if enabled {
 		telemetryInfo.SegmentKey = m.config.Telemetry.SegmentWebUIKey
 	}
 
@@ -552,7 +554,7 @@ func (m *Master) Run() error {
 		return err
 	}
 
-	if m.config.Telemetry.Enabled {
+	if m.config.Telemetry.Enabled && m.config.Telemetry.SegmentMasterKey != "" {
 		if telemetry, err := telemetry.NewActor(
 			m.db,
 			m.ClusterID,


### PR DESCRIPTION
After a bit of discussion, we decided we want to run telemetry in CI to keep the code active, but there's not much call to have it enabled by default for everybody's dev builds.

(I have the key hiding disabled just so I can easily check on whether it worked by looking at the CI logs on this PR; that is not to be merged.)

# Test Plan
- [x] run the master locally and check that telemetry doesn't start up by default
- [ ] run CI and check whether the keys show up in those runs and events appear in Segment