### PR TITLE
fix: catch all keyboard exits when tailing trial logs

### DIFF
--- a/cli/determined_cli/trial.py
+++ b/cli/determined_cli/trial.py
@@ -162,8 +162,8 @@ def logs(args: Namespace) -> None:
         state_query.op.trials_by_pk(id=args.trial_id).state()
 
         no_change_count = 0
-        while True:
-            try:
+        try:
+            while True:
                 # Poll for new logs every 100 ms.
                 time.sleep(0.1)
 
@@ -180,17 +180,16 @@ def logs(args: Namespace) -> None:
                     resp = state_query.send()
                     if resp.trials_by_pk.state in constants.TERMINAL_STATES:
                         raise KeyboardInterrupt()
-            except KeyboardInterrupt:
-                resp = state_query.send()
+        except KeyboardInterrupt:
+            resp = state_query.send()
 
-                print(
-                    colored(
-                        "Trial is in the {} state. To reopen log stream, run: "
-                        "det trial logs -f {}".format(resp.trials_by_pk.state, args.trial_id),
-                        "green",
-                    )
+            print(
+                colored(
+                    "Trial is in the {} state. To reopen log stream, run: "
+                    "det trial logs -f {}".format(resp.trials_by_pk.state, args.trial_id),
+                    "green",
                 )
-                break
+            )
 
 
 @authentication_required


### PR DESCRIPTION
Previously some keyboard exists were not caught, resulting
in us not printing information about how to further look
up trial logs.
