### PR TITLE
feat: persist master db by default

### DIFF
--- a/deploy/determined_deploy/local/cli.py
+++ b/deploy/determined_deploy/local/cli.py
@@ -36,6 +36,9 @@ def make_local_parser(subparsers: argparse._SubParsersAction) -> None:
     parser_local.add_argument(
         "--hasura-secret", type=str, default="hasura", help="password for hasura service",
     )
+    parser_local.add_argument(
+        "--delete-db", action="store_true", help="remove current master database",
+    )
 
 
 def deploy_local(args: argparse.Namespace) -> None:
@@ -49,6 +52,9 @@ def deploy_local(args: argparse.Namespace) -> None:
                 cluster_name=args.cluster_name,
                 db_password="postgres",
                 hasura_secret="hasura",
+                delete_db=args.delete_db,
             )
+        elif fn is cluster_utils.fixture_down:
+            fn(cluster_name=args.cluster_name, delete_db=args.delete_db)
         else:
             fn(cluster_name=args.cluster_name)

--- a/deploy/determined_deploy/local/cluster_utils.py
+++ b/deploy/determined_deploy/local/cluster_utils.py
@@ -85,6 +85,7 @@ def fixture_up(
     cluster_name: str,
     db_password: str,
     hasura_secret: str,
+    delete_db: bool,
 ) -> str:
     config.MASTER_PORT = port
 
@@ -100,13 +101,16 @@ def fixture_up(
         "DET_DB_PASSWORD": db_password,
         "DET_HASURA_SECRET": hasura_secret,
     }
-    fixture_down(cluster_name)
+    fixture_down(cluster_name, delete_db)
     docker_compose(command, cluster_name, env, extra_files=extra_files)
     _wait_for_master(port)
 
 
-def fixture_down(cluster_name: str) -> None:
-    docker_compose(["down", "--volumes", "-t", "1"], cluster_name)
+def fixture_down(cluster_name: str, delete_db: bool) -> None:
+    if delete_db:
+        docker_compose(["down", "--volumes", "-t", "1"], cluster_name)
+    else:
+        docker_compose(["down", "-t", "1"], cluster_name)
 
 
 def logs(cluster_name: str) -> None:

--- a/tests/integrations/conftest.py
+++ b/tests/integrations/conftest.py
@@ -60,12 +60,13 @@ def cluster_log_manager(request: SubRequest) -> Optional[ClusterLogManager]:
             cluster_name="integrations",
             db_password="postgres",
             hasura_secret="hasura",
+            delete_db=False,
         )
         with ClusterLogManager("integrations") as clm:
             # Yield instead of return so that `__exit__` is called when the
             # testing session is finished.
             yield clm
-        determined_deploy.local.cluster_utils.fixture_down("integrations")
+        determined_deploy.local.cluster_utils.fixture_down("integrations", True)
 
     return None
 

--- a/webui/tests/bin/e2e-tests.py
+++ b/webui/tests/bin/e2e-tests.py
@@ -41,7 +41,7 @@ def _cypress_container_name(config):
 
 def post_e2e_tests(config):
     clean_up_cypress(config)
-    run_cluster_cmd(["fixture-down"], config)
+    run_cluster_cmd(["fixture-down", "--delete-db"], config)
 
 
 # _cypress_arguments generates an array of cypress arguments.


### PR DESCRIPTION
Updated `det-deploy local` so that the database volume is persisted by default. 

Also added a new flag, `--destroy-db` that will remove any existing database volumes.  Updated the webui tests and integration tests to delete their database volumes after completion.