### PR TITLE
refactor: add a new global trialLogger actor

### DIFF
--- a/master/internal/core.go
+++ b/master/internal/core.go
@@ -59,6 +59,7 @@ type Master struct {
 	rwCoordinator *actor.Ref
 	provisioner   *actor.Ref
 	db            *db.PgDB
+	trialLogger   *actor.Ref
 }
 
 // New creates an instance of the Determined master.
@@ -389,6 +390,7 @@ func (m *Master) Run() error {
 	// +- Cluster (scheduler.Cluster: cluster)
 	// +- Service Proxy (proxy.Proxy: proxy)
 	// +- Telemetry (telemetry.telemetryActor: telemetry)
+	// +- TrialLogger (internal.trialLogger: trialLogger)
 	// +- Experiments (actors.Group: experiments)
 	//     +- Experiment (internal.experiment: <experiment-id>)
 	//         +- Trial (internal.trial: <trial-request-id>)
@@ -397,6 +399,8 @@ func (m *Master) Run() error {
 	//     +- Agent (internal.agent: <agent-id>)
 	//         +- Websocket (actors.WebSocket: <remote-address>)
 	m.system = actor.NewSystem("master")
+
+	m.trialLogger, _ = m.system.ActorOf(actor.Addr("trialLogger"), newTrialLogger(m.db))
 
 	userService, err := user.New(m.db, m.system)
 	if err != nil {

--- a/master/internal/experiment.go
+++ b/master/internal/experiment.go
@@ -61,6 +61,7 @@ type experiment struct {
 	*model.Experiment
 	modelDefinition     archive.Archive
 	cluster             *actor.Ref
+	trialLogger         *actor.Ref
 	db                  *db.PgDB
 	searcher            *searcher.Searcher
 	warmStartCheckpoint *model.Checkpoint
@@ -114,6 +115,7 @@ func newExperiment(master *Master, expModel *model.Experiment) (*experiment, err
 		Experiment:          expModel,
 		modelDefinition:     modelDefinition,
 		cluster:             master.cluster,
+		trialLogger:         master.trialLogger,
 		db:                  master.db,
 		searcher:            search,
 		warmStartCheckpoint: checkpoint,

--- a/master/internal/trial_logger.go
+++ b/master/internal/trial_logger.go
@@ -1,0 +1,75 @@
+package internal
+
+import (
+	"time"
+
+	"github.com/determined-ai/determined/master/internal/db"
+	"github.com/determined-ai/determined/master/pkg/actor"
+	"github.com/determined-ai/determined/master/pkg/actor/actors"
+	"github.com/determined-ai/determined/master/pkg/model"
+)
+
+const (
+	// logFlushInterval is the longest time that the trialLogger will buffer logs in memory before
+	// flushing them to the database. This is set low to ensure a good user experience.
+	logFlushInterval = 20 * time.Millisecond
+	// logBuffer is the largest number of logs lines that can be buffered before flushing them to
+	// the database. For the strategy of many-rows-per-insert, performance was significantly worse
+	// below 500, and no improvements after 1000.
+	logBuffer = 1000
+)
+
+type (
+	// flushLogs is a message that the trial actor sends to itself via
+	// NotifyAfter(), which is used to guarantee that logs are not held too
+	// long without flushing.
+	flushLogs struct{}
+)
+
+type trialLogger struct {
+	db           *db.PgDB
+	pending      []*model.TrialLog
+	lastLogFlush time.Time
+}
+
+// newTrialLogger creates an actor which can buffer up trial logs and flush them periodically.
+// There should only be one trialLogger shared across the entire system.
+func newTrialLogger(db *db.PgDB) actor.Actor {
+	return &trialLogger{
+		db:           db,
+		lastLogFlush: time.Now(),
+		pending:      make([]*model.TrialLog, 0, logBuffer),
+	}
+}
+
+func (l *trialLogger) Receive(ctx *actor.Context) error {
+	switch msg := ctx.Message().(type) {
+	case actor.PreStart:
+		actors.NotifyAfter(ctx, logFlushInterval, flushLogs{})
+
+	case flushLogs:
+		l.tryFlushLogs(ctx, true)
+		actors.NotifyAfter(ctx, logFlushInterval, flushLogs{})
+
+	case model.TrialLog:
+		l.pending = append(l.pending, &msg)
+		l.tryFlushLogs(ctx, false)
+
+	case actor.PostStop:
+		// Flush any final logs.
+		l.tryFlushLogs(ctx, true)
+
+	default:
+		return actor.ErrUnexpectedMessage(ctx)
+	}
+	return nil
+}
+
+func (l *trialLogger) tryFlushLogs(ctx *actor.Context, forceFlush bool) {
+	if forceFlush || len(l.pending) >= logBuffer {
+		if err := l.db.AddTrialLogs(l.pending); err != nil {
+			ctx.Log().WithError(err).Errorf("failed to save trial logs")
+		}
+		l.pending = l.pending[:0]
+	}
+}


### PR DESCRIPTION
Reduce cpu usage by about 400% on a t2.x2large instance by doing log
buffering and flushing globally for all trials rather than on a
per-trial basis, as measured in a master with 50,000 trial actors
sitting active in memory.

With per-trial buffering, there is a direct tradeoff between user
experience and efficiency. By combining all trial log insertions
through a single actor, we can flush more often and also better
optimize for large simultaneous insertions better. This change brings
down the user-visible log latency from 1000ms to 20ms.

Check out `htop` before the change (50,000 trial actors in memory):
![htop-before](https://user-images.githubusercontent.com/47791514/78944848-1e3bf280-7a7c-11ea-851b-b4eae093c733.png)

And after the change (still 50,000 trial actors in memory):
![htop-after](https://user-images.githubusercontent.com/47791514/78944903-3e6bb180-7a7c-11ea-9ad2-187b8dc3bb3e.png)
