### PR TITLE
[DET-2747] feat: Average training metrics across GPUs in PyTorch

### DIFF
--- a/docs/reference/experiment-config.txt
+++ b/docs/reference/experiment-config.txt
@@ -563,6 +563,12 @@ created with the Determined CLI. It may contain the following fields:
     across batches (when aggregation_frequency > 1) should be divided by
     the aggregation_frequency. Defaults to ``true``.
 
+  - ``average_training_metrics``: For multi-GPU training, whether to
+    average the training metrics across GPUs instead of only using metrics from the
+    chief GPU. This impacts the metrics shown in the Determined UI and
+    TensorBoard, but does not impact the outcome of training or hyperparameter
+    search. This option is currently only supported in PyTorch. Defaults to ``false``.
+
   - ``gradient_compression``: Whether to compress gradients when they are
     exchanged during :ref:`multi-gpu-training`.
     Compression may alter gradient values to achieve better space reduction.

--- a/docs/topic-guides/optimizing-distributed-training.txt
+++ b/docs/topic-guides/optimizing-distributed-training.txt
@@ -83,6 +83,10 @@ the time it takes to transfer gradients between GPUs.
 The ``optimization.auto_tune_tensor_fusion`` option automatically identifies
 the optimal message size during gradient transfers, reducing
 communication overhead.
+The ``average_training_metrics`` option will average the training metrics
+across GPUs at the end of every step, which requires communication. Typically
+this will not have an impact on training performance, but if you have a very
+small ``batches_per_step``, ensuring it is disabled may improve performance.
 
 If you do not see improvement in performance, there might be a
 performance bottleneck in the model that cannot be directly alleviated

--- a/harness/determined/_experiment_config.py
+++ b/harness/determined/_experiment_config.py
@@ -26,6 +26,9 @@ class ExperimentConfig(dict):
     def mixed_precision_enabled(self) -> bool:
         return bool(self["optimizations"]["mixed_precision"] != "O0")
 
+    def averaging_training_metrics_enabled(self) -> bool:
+        return bool(self["optimizations"]["average_training_metrics"])
+
     def input_from_dataflow(self) -> bool:
         # When using tensorpack dataflows as input, it's inefficient
         # to apply sharding, so we only apply sharding to the test set.

--- a/harness/determined/_trial_controller.py
+++ b/harness/determined/_trial_controller.py
@@ -107,6 +107,10 @@ class TrialController(metaclass=abc.ABCMeta):
     def supports_mixed_precision() -> bool:
         return False
 
+    @staticmethod
+    def supports_averaging_training_metrics() -> bool:
+        return False
+
     def initialize_wrapper(self) -> None:
         pass
 
@@ -131,6 +135,9 @@ class TrialController(metaclass=abc.ABCMeta):
 
         if env.experiment_config.native_enabled():
             check.true(self.support_determined_native())
+
+        if env.experiment_config.averaging_training_metrics_enabled():
+            check.true(self.supports_averaging_training_metrics())
 
 
 class CallbackTrialController(TrialController):

--- a/harness/determined/constants.py
+++ b/harness/determined/constants.py
@@ -22,6 +22,7 @@ DEFAULT_BATCHES_PER_STEP = 100
 DEFAULT_OPTIMIZATIONS = {
     "aggregation_frequency": 1,
     "average_aggregated_gradients": True,
+    "average_training_metrics": False,
     "gradient_compression": False,
     "mixed_precision": "O0",
 }

--- a/harness/determined/horovod.py
+++ b/harness/determined/horovod.py
@@ -168,12 +168,14 @@ class HorovodContext:
         fp16_compression: bool,
         grad_updates_size_file: str,
         average_aggregated_gradients: bool,
+        average_training_metrics: bool,
     ) -> None:
         self.use = use
         self.aggregation_frequency = aggregation_frequency
         self.fp16_compression = fp16_compression
         self.grad_updates_size_file = grad_updates_size_file
         self.average_aggregated_gradients = average_aggregated_gradients
+        self.average_training_metrics = average_training_metrics
 
     @staticmethod
     def from_configs(
@@ -198,6 +200,7 @@ class HorovodContext:
 
         check.is_in("aggregation_frequency", optimizations_config)
         check.is_in("gradient_compression", optimizations_config)
+        check.is_in("average_training_metrics", optimizations_config)
 
         # Help users migrate from the old locations for these settings, in hparams.
         def error_message_removed_from_hparams(removed_hparam: str) -> str:
@@ -229,6 +232,9 @@ class HorovodContext:
             grad_updates_size_file=optimizations_config.get("grad_updates_size_file", None),
             average_aggregated_gradients=cast(
                 bool, optimizations_config.get("average_aggregated_gradients")
+            ),
+            average_training_metrics=cast(
+                bool, optimizations_config.get("average_training_metrics")
             ),
         )
 

--- a/harness/determined/util.py
+++ b/harness/determined/util.py
@@ -38,6 +38,27 @@ def _list_to_dict(list_of_dicts: List[Dict[str, Any]]) -> Dict[str, List[Any]]:
     return dict_of_lists
 
 
+def _dict_to_list(dict_of_lists: Dict[str, List]) -> List[Dict[str, Any]]:
+    """Transpose a dict of lists to a list of dicts.
+
+        dict_to_list({"a": [1, 2], "b": [3, 4]})) -> [{"a": 1, "b": 3}, {"a": 2, "b": 4}]
+
+    In some cases _dict_to_list is the inverse of _list_to_dict. This function assumes that
+    all lists have the same length.
+    """
+
+    list_len = len(list(dict_of_lists.values())[0])
+    for lst in dict_of_lists.values():
+        check.check_len(lst, list_len, "All lists in the dict must be the same length.")
+
+    output_list = [{} for _ in range(list_len)]  # type: List[Dict[str, Any]]
+    for i in range(list_len):
+        for k in dict_of_lists.keys():
+            output_list[i][k] = dict_of_lists[k][i]
+
+    return output_list
+
+
 def validate_batch_metrics(batch_metrics: List[Dict[str, Any]]) -> None:
     metric_dict = _list_to_dict(batch_metrics)
 

--- a/master/pkg/model/defaults.go
+++ b/master/pkg/model/defaults.go
@@ -71,6 +71,7 @@ func DefaultExperimentConfig() ExperimentConfig {
 		Optimizations: OptimizationsConfig{
 			AggregationFrequency:       1,
 			AverageAggregatedGradients: true,
+			AverageTrainingMetrics:     false,
 			GradientCompression:        false,
 			MixedPrecision:             "O0",
 			TensorFusionThreshold:      64,

--- a/master/pkg/model/experiment_config.go
+++ b/master/pkg/model/experiment_config.go
@@ -184,6 +184,7 @@ func (r ResourcesConfig) Validate() []error {
 type OptimizationsConfig struct {
 	AggregationFrequency       int    `json:"aggregation_frequency"`
 	AverageAggregatedGradients bool   `json:"average_aggregated_gradients"`
+	AverageTrainingMetrics     bool   `json:"average_training_metrics"`
 	GradientCompression        bool   `json:"gradient_compression"`
 	GradUpdateSizeFile         string `json:"grad_updates_size_file,omitempty"`
 	MixedPrecision             string `json:"mixed_precision"`

--- a/master/pkg/model/experiment_config_test.go
+++ b/master/pkg/model/experiment_config_test.go
@@ -326,6 +326,7 @@ func TestExperiment(t *testing.T) {
 		Optimizations: OptimizationsConfig{
 			AggregationFrequency:       1,
 			AverageAggregatedGradients: true,
+			AverageTrainingMetrics:     false,
 			GradientCompression:        false,
 			MixedPrecision:             "O0",
 			TensorFusionThreshold:      64,

--- a/tests/unit/frameworks/utils.py
+++ b/tests/unit/frameworks/utils.py
@@ -74,6 +74,7 @@ def make_default_exp_config(hparams: Dict[str, Any], batches_per_step: int) -> D
             "mixed_precision": "O0",
             "aggregation_frequency": 1,
             "gradient_compression": False,
+            "average_training_metrics": False,
         },
     }
 
@@ -126,6 +127,7 @@ def make_default_hvd_config() -> horovod.HorovodContext:
         fp16_compression=False,
         grad_updates_size_file="",
         average_aggregated_gradients=True,
+        average_training_metrics=False,
     )
 
 

--- a/tests/unit/test_util.py
+++ b/tests/unit/test_util.py
@@ -1,10 +1,15 @@
-from determined.util import _list_to_dict
+from determined.util import _dict_to_list, _list_to_dict
 from determined_common.util import sizeof_fmt
 
 
 def test_list_to_dict() -> None:
     r = _list_to_dict([{"a": 1}, {"b": 2}, {"a": 2}])
     assert r == {"a": [1, 2], "b": [2]}
+
+
+def test_dict_to_list() -> None:
+    r = _dict_to_list({"a": [1, 2], "b": [3, 4]})
+    assert r == [{"a": 1, "b": 3}, {"a": 2, "b": 4}]
 
 
 def test_sizeof_fmt() -> None:


### PR DESCRIPTION
Average training metrics across GPUs. 

~~By default this is enabled because the overhead should be low in comparison to the other cross-GPU communication that must happen in distributed training and it smoothes out the training metrics in TensorBoard.~~