### PR TITLE
fix: increase GCP Cloud SQL default max connections

### DIFF
--- a/deploy/determined_deploy/gcp/terraform/modules/database/main.tf
+++ b/deploy/determined_deploy/gcp/terraform/modules/database/main.tf
@@ -18,6 +18,10 @@ resource "google_sql_database_instance" "db_instance" {
       ipv4_enabled = false
       private_network = var.network_self_link
     }
+    database_flags {
+      name = "max_connections"
+      value = 2000
+    }
   }
 
 }


### PR DESCRIPTION
For default GCP deployments, ensure that Cloud SQL instances comply with
our baseline recommendation of 2000 max_connections. This partially
addresses DET-2812.

# Test Plan
- UI change:
  - [ ] add screenshots
  - [ ] React? build & check storybooks
- [ ] user-facing api change: modify documentation and examples
- [ ] user-facing api change: add the "User-facing API Change" label
- [ ] bug fix: add regression test
- [ ] bug fix: determine if there are other similar bugs in the codebase
- [ ] new feature: add test coverage for any user-facing aspects
- [ ] refactor: maintain existing code coverage
