### PR TITLE
chore: standardize gcp within det-deploy

### DIFF
--- a/deploy/determined_deploy/gcp/cli.py
+++ b/deploy/determined_deploy/gcp/cli.py
@@ -1,176 +1,199 @@
 import argparse
-import json
 import os
 
 import determined_deploy
 from determined_deploy.gcp import constants, gcp
 
 
-def make_gcp_parser(subparsers: argparse._SubParsersAction) -> None:
-    parser_aws = subparsers.add_parser("gcp", help="gcp help")
-    parser_aws.add_argument("--delete", action="store_true", help="delete Determined from account")
-    parser_aws.add_argument(
-        "--plan",
-        action="store_true",
-        help="return the Terraform infrastructure plan for the current configuration",
+def make_down_subparser(subparsers: argparse._SubParsersAction) -> None:
+    subparser = subparsers.add_parser("down", help="delete gcp cluster")
+
+    optional_named = subparser.add_argument_group("optional named arguments")
+    optional_named.add_argument(
+        "--local-state-path", type=str, default=os.getcwd(), help=argparse.SUPPRESS,
     )
-    parser_aws.add_argument(
+    optional_named.add_argument(
         "--keypath",
         type=str,
         default=None,
-        required=True,
-        help="Path to service account key, or `gcloud` if using default credentials",
+        help="path to service account key if not using default credentials",
     )
-    parser_aws.add_argument(
-        "--identifier",
+
+
+def make_up_subparser(subparsers: argparse._SubParsersAction) -> None:
+    parser_gcp = subparsers.add_parser("up", help="create gcp cluster")
+
+    required_named = parser_gcp.add_argument_group("required named arguments")
+    required_named.add_argument(
+        "--cluster-id",
         type=str,
         default=None,
         required=True,
         help="unique identifier to name and tag resources",
     )
-    parser_aws.add_argument(
-        "--project_id",
+    required_named.add_argument(
+        "--project-id",
         type=str,
         default=None,
         required=True,
         help="project ID to create the cluster in",
     )
-    parser_aws.add_argument(
+
+    optional_named = parser_gcp.add_argument_group("optional named arguments")
+    optional_named.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="return the infrastructure plan to be executed based on your arguments",
+    )
+    optional_named.add_argument(
+        "--keypath",
+        type=str,
+        default=None,
+        help="path to service account key if not using default credentials",
+    )
+    optional_named.add_argument(
         "--network",
         type=str,
         default="det-default",
-        help="network name to use (the network will be created if it doesn't exist)",
+        help="network name to create (the network should not already exist in the project)",
     )
-    parser_aws.add_argument(
-        "--det_version",
-        type=str,
-        default=determined_deploy.__version__,
-        help="Determined version or commit to deploy",
+    optional_named.add_argument(
+        "--det-version", type=str, default=determined_deploy.__version__, help=argparse.SUPPRESS,
     )
-    parser_aws.add_argument(
+    optional_named.add_argument(
         "--region",
         type=str,
         default=constants.defaults.REGION,
-        help="region to create the cluster in (defaults to us-central1)",
+        help="region to create the cluster in (defaults to us-west1)",
     )
-    parser_aws.add_argument(
+    optional_named.add_argument(
         "--zone",
         type=str,
         default=None,
-        help="zone to create the cluster in (defaults to us-central1-a)",
+        help="zone to create the cluster in (defaults to `region`-b)",
     )
-    parser_aws.add_argument(
-        "--environment_image",
+    optional_named.add_argument(
+        "--environment-image",
         type=str,
         default=constants.defaults.ENVIRONMENT_IMAGE,
-        help="base environment image for agents",
+        help=argparse.SUPPRESS,
     )
-    parser_aws.add_argument(
-        "--local_state_path",
-        type=str,
-        default=os.getcwd(),
-        help="base path to store the .tfstate file; defaults to the current directory",
+    optional_named.add_argument(
+        "--local-state-path", type=str, default=os.getcwd(), help=argparse.SUPPRESS,
     )
-    parser_aws.add_argument(
+    optional_named.add_argument(
         "--preemptible",
         type=str,
         default="false",
         help="whether to use preemptible instances for agents",
     )
-    parser_aws.add_argument(
-        "--master_instance_type",
+    optional_named.add_argument(
+        "--master-instance-type",
         type=str,
         default=constants.defaults.MASTER_INSTANCE_TYPE,
         help="instance type for master",
     )
-    parser_aws.add_argument(
-        "--agent_instance_type",
+    optional_named.add_argument(
+        "--agent-instance-type",
         type=str,
         default=constants.defaults.AGENT_INSTANCE_TYPE,
         help="instance type for agent",
     )
-    parser_aws.add_argument(
-        "--db_password",
+    optional_named.add_argument(
+        "--db-password",
         type=str,
         default=constants.defaults.DB_PASSWORD,
         help="password for master database",
     )
-    parser_aws.add_argument(
-        "--hasura_secret",
+    optional_named.add_argument(
+        "--hasura-secret",
         type=str,
         default=constants.defaults.HASURA_SECRET,
         help="password for hasura service",
     )
-    parser_aws.add_argument(
-        "--max_idle_agent_period",
+    optional_named.add_argument(
+        "--max-idle-agent-period",
         type=str,
         default=constants.defaults.MAX_IDLE_AGENT_PERIOD,
         help="max agent idle time before it is shut down, e.g. 30m for 30 minutes",
     )
-    parser_aws.add_argument(
+    optional_named.add_argument(
         "--port",
         type=str,
         default=constants.defaults.PORT,
         help="port to use for communication on master instance",
     )
-    parser_aws.add_argument(
-        "--gpu_type", type=str, default=constants.defaults.GPU_TYPE, help="max instances",
+    optional_named.add_argument(
+        "--gpu-type",
+        type=str,
+        default=constants.defaults.GPU_TYPE,
+        help="type of GPU to use on agents",
     )
-    parser_aws.add_argument(
-        "--gpu_num",
+    optional_named.add_argument(
+        "--gpu-num",
         type=int,
         default=constants.defaults.GPU_NUM,
         help="number of GPUs per agent instance",
     )
-    parser_aws.add_argument(
-        "--max_instances",
+    optional_named.add_argument(
+        "--max-instances",
         type=int,
         default=constants.defaults.MAX_INSTANCES,
-        help="Maximum number of agent instances at one time",
+        help="maximum number of agent instances at one time",
     )
+
+
+def make_gcp_parser(subparsers: argparse._SubParsersAction):
+    parser_gcp = subparsers.add_parser("gcp", help="gcp help")
+    gcp_subparsers = parser_gcp.add_subparsers(help="command", dest="command")
+    make_up_subparser(gcp_subparsers)
+    make_down_subparser(gcp_subparsers)
 
 
 def deploy_gcp(args: argparse.Namespace) -> None:
 
+    # Set the TF_DATA_DIR where Terraform will store its supporting files
+    env = os.environ.copy()
+    env["TF_DATA_DIR"] = os.path.join(args.local_state_path, "terraform_data")
+
+    # Create det_configs dictionary
     det_configs = {}
-
-    # Get project_id from keyfile or args
-    if args.keypath != "gcloud":
-        with open(args.keypath) as keyfile:
-            keyfile_dict = json.load(keyfile)
-            project_id_from_key = keyfile_dict["project_id"]
-
-        # Set det_configs based on arguments
-        det_configs["project_id"] = project_id_from_key
 
     # Add args to det_configs dict
     for arg in vars(args):
         if vars(args)[arg] is not None:
             det_configs[arg] = vars(args)[arg]
 
-    # Set the TF_DATA_DIR where Terraform will store its supporting files
-    env = os.environ.copy()
-    env["TF_DATA_DIR"] = os.path.join(args.local_state_path, "terraform_data")
-
     # Not all args will be passed to Terraform, list the ones that won't be
     variables_to_exclude = [
-        "delete",
-        "plan",
+        "command",
+        "dry_run",
         "environment",
         "local_state_path",
     ]
 
-    # Plan flag
-    if args.plan:
-        gcp.plan(det_configs, env, variables_to_exclude)
-        return
+    # Delete
+    if args.command == "down":
 
-    # Delete flag
-    if args.delete:
+        # Set placeholders for required variables
+        det_configs["cluster_id"] = "will_be_ignored"
+        det_configs["project_id"] = "will_be_ignored"
+        det_configs["network"] = "will_be_ignored"
+        det_configs["region"] = "will_be_ignored"
+        det_configs["det_version"] = "will_be_ignored"
+        det_configs["environment_image"] = "will_be_ignored"
+
         gcp.delete(det_configs, env, variables_to_exclude)
         print("Delete Successful")
+        return
+
+    # Dry-run flag
+    if args.dry_run:
+        gcp.dry_run(det_configs, env, variables_to_exclude)
+        print("Printed plan. To execute, run `det-deploy gcp`")
         return
 
     print("Starting Determined Deployment")
     gcp.deploy(det_configs, env, variables_to_exclude)
     print("Determined Deployment Successful")
+    print("Please allow 1-5 minutes for the master instance to be accessible via the web-ui")

--- a/deploy/determined_deploy/gcp/constants.py
+++ b/deploy/determined_deploy/gcp/constants.py
@@ -1,14 +1,14 @@
 class defaults:
 
-    AGENT_INSTANCE_TYPE = "n1-standard-16"
+    AGENT_INSTANCE_TYPE = "n1-standard-32"
     DB_PASSWORD = "postgres"
     ENVIRONMENT_IMAGE = "pedl-environments-f0545f2"
-    GPU_NUM = 2
-    GPU_TYPE = "nvidia-tesla-v100"
+    GPU_NUM = 8
+    GPU_TYPE = "nvidia-tesla-k80"
     HASURA_SECRET = "secret"
-    MASTER_INSTANCE_TYPE = "n1-standard-16"
+    MASTER_INSTANCE_TYPE = "n1-standard-2"
     MAX_IDLE_AGENT_PERIOD = "10m"
-    MAX_INSTANCES = 4
+    MAX_INSTANCES = 5
+    NETWORK = "det-default"
     PORT = 8080
-    PREEMPTIBLE = False
-    REGION = "us-central1"
+    REGION = "us-west1"

--- a/deploy/determined_deploy/gcp/gcp.py
+++ b/deploy/determined_deploy/gcp/gcp.py
@@ -8,17 +8,17 @@ terraform_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "terraf
 
 def deploy(configs: Dict, env: Dict, variables: List):
 
-    terraform_init(configs, env, variables)
+    terraform_init(configs, env)
     return terraform_apply(configs, env, variables)
 
 
-def plan(configs: Dict, env: Dict, variables: List):
+def dry_run(configs: Dict, env: Dict, variables: List):
 
-    terraform_init(configs, env, variables)
+    terraform_init(configs, env)
     return terraform_plan(configs, env, variables)
 
 
-def terraform_init(configs: Dict, env: Dict, variables: List):
+def terraform_init(configs: Dict, env: Dict):
 
     command = ["terraform init"]
     command += [

--- a/deploy/determined_deploy/gcp/terraform/main.tf
+++ b/deploy/determined_deploy/gcp/terraform/main.tf
@@ -1,26 +1,20 @@
 // Configure GCP provider
 provider "google" {
-  credentials = var.keypath != "gcloud" ? file(var.keypath) : null
+  credentials = var.keypath != null ? file(var.keypath) : null
   project = var.project_id
   region = var.region
-  zone = var.zone != null ? var.zone : "${var.region}-a"
+  zone = var.zone != null ? var.zone : "${var.region}-b"
 }
 
 provider "google-beta" {
-  credentials = var.keypath != "gcloud" ? file(var.keypath) : null
+  credentials = var.keypath != null ? file(var.keypath) : null
   project = var.project_id
   region = var.region
-  zone = var.zone != null ? var.zone : "${var.region}-a"
-}
-
-// Random integer to use if identifier not given
-resource "random_integer" "naming_int" {
-  min = 1000
-  max = 9999
+  zone = var.zone != null ? var.zone : "${var.region}-b"
 }
 
 locals {
-  unique_id = "${var.identifier}-${random_integer.naming_int.result}"
+  unique_id = "${var.cluster_id}"
   det_version_key = "${substr(replace(var.det_version, ".", "-"), 0, 8)}"
 }
 
@@ -94,7 +88,6 @@ module "database" {
   db_version = var.db_version
   network_self_link = module.network.network_self_link
   service_networking_connection = module.network.service_networking_connection
-
 }
 
 
@@ -122,6 +115,7 @@ module "compute" {
   det_version_key = local.det_version_key
   project_id = var.project_id
   region = var.region
+  zone = var.zone
   environment_image = var.environment_image
   det_version = var.det_version
   scheme = var.scheme

--- a/deploy/determined_deploy/gcp/terraform/modules/compute/main.tf
+++ b/deploy/determined_deploy/gcp/terraform/modules/compute/main.tf
@@ -3,6 +3,7 @@
 resource "google_compute_instance" "default" {
   name = "det-master-${var.unique_id}-${var.det_version_key}"
   machine_type = var.master_instance_type
+  zone = var.zone
   tags = [var.tag_master_port, var.tag_allow_internal, var.tag_allow_ssh]
 
   boot_disk {
@@ -81,6 +82,7 @@ resource "google_compute_instance" "default" {
         -d \
         --name determined-graphql \
         --network ${var.master_docker_network} \
+        --restart unless-stopped \
         -e HASURA_GRAPHQL_ADMIN_SECRET="${var.hasura_secret}" \
         -e HASURA_GRAPHQL_CONSOLE_ASSETS_DIR=/srv/console-assets \
         -e HASURA_GRAPHQL_DATABASE_URL=postgres://postgres:${var.db_password}@${var.database_hostname}:5432/${var.database_name} \

--- a/deploy/determined_deploy/gcp/terraform/modules/compute/outputs.tf
+++ b/deploy/determined_deploy/gcp/terraform/modules/compute/outputs.tf
@@ -9,3 +9,7 @@ output "internal_ip" {
 output "master_instance_name" {
   value = google_compute_instance.default.name
 }
+
+output "master_zone" {
+  value = google_compute_instance.default.zone
+}

--- a/deploy/determined_deploy/gcp/terraform/modules/compute/variables.tf
+++ b/deploy/determined_deploy/gcp/terraform/modules/compute/variables.tf
@@ -87,3 +87,6 @@ variable "master_instance_type" {
 
 variable "region" {
 }
+
+variable "zone" {
+}

--- a/deploy/determined_deploy/gcp/terraform/modules/database/main.tf
+++ b/deploy/determined_deploy/gcp/terraform/modules/database/main.tf
@@ -4,10 +4,16 @@ locals {
   service_networking_connection_exists = var.service_networking_connection != null ? 1 : 0
 }
 
+// Random integer to use
+resource "random_integer" "naming_int" {
+  min = 100000
+  max = 999999
+}
+
 // Create Database
 
 resource "google_sql_database_instance" "db_instance" {
-  name   = "det-db-instance-${var.unique_id}"
+  name   = "det-db-instance-${var.unique_id}-${random_integer.naming_int.result}"
   database_version = var.db_version
 
   depends_on = [var.network_self_link, var.service_networking_connection]

--- a/deploy/determined_deploy/gcp/terraform/modules/firewall/main.tf
+++ b/deploy/determined_deploy/gcp/terraform/modules/firewall/main.tf
@@ -2,9 +2,9 @@
 
 locals {
   tags = {
-    open_master_port = "det-port-${var.port}-${var.unique_id}"
-    allow_internal = "det-internal-${var.unique_id}"
-    allow_ssh = "det-ssh-${var.unique_id}"
+    open_master_port = "det-port-${var.port}-${var.network_name}"
+    allow_internal = "det-internal-${var.network_name}"
+    allow_ssh = "det-ssh-${var.network_name}"
   }
 }
 

--- a/deploy/determined_deploy/gcp/terraform/modules/gcs/main.tf
+++ b/deploy/determined_deploy/gcp/terraform/modules/gcs/main.tf
@@ -1,26 +1,28 @@
-// Create GCS bucket
+// Set random integer for uniqueness
 
-locals {
-  create_gcs_bucket =  var.gcs_bucket == null ? 1 : 0
+// Random integer to use
+resource "random_integer" "naming_int" {
+  min = 100000
+  max = 999999
 }
 
+// Create GCS bucket
+
 resource "google_storage_bucket" "checkpoint_store" {
-  name = "det-checkpoints-${var.unique_id}"
+  name = "det-checkpoints-${var.unique_id}-${random_integer.naming_int.result}"
   force_destroy = true
 
-  count = local.create_gcs_bucket
 }
 
 resource "google_storage_bucket_iam_binding" "checkpoint_editor" {
-  bucket = google_storage_bucket.checkpoint_store.0.name
+  bucket = google_storage_bucket.checkpoint_store.name
   role = "roles/storage.admin"
   members = [
     "serviceAccount:${var.service_account_email}"
   ]
 
-  count = local.create_gcs_bucket
 }
 
 locals {
-  gcs_bucket = local.create_gcs_bucket == 1 ? google_storage_bucket.checkpoint_store.0.name : var.gcs_bucket
+  gcs_bucket = google_storage_bucket.checkpoint_store.name
 }

--- a/deploy/determined_deploy/gcp/terraform/modules/service_account/main.tf
+++ b/deploy/determined_deploy/gcp/terraform/modules/service_account/main.tf
@@ -1,36 +1,27 @@
-// Check if user supplied service account email (existing service account)
-locals {
-  create_service_account = var.service_account_email == null ? 1 : 0
-}
-
 // Create Service Account
 resource "google_service_account" "service_account" {
   account_id   = "det-${var.unique_id}"
   display_name = "DET Service Account ${var.unique_id}"
-  count = local.create_service_account
 }
 
 resource "google_project_iam_member" "project_compute" {
   project = var.project_id
   role    = "roles/compute.admin"
-  member  = "serviceAccount:${google_service_account.service_account.0.email}"
-  count = local.create_service_account
+  member  = "serviceAccount:${google_service_account.service_account.email}"
 }
 
 resource "google_project_iam_member" "project_service" {
   project = var.project_id
   role    = "roles/iam.serviceAccountUser"
-  member  = "serviceAccount:${google_service_account.service_account.0.email}"
-  count = local.create_service_account
+  member  = "serviceAccount:${google_service_account.service_account.email}"
 }
 
 resource "google_project_iam_member" "project_iam" {
   project = var.project_id
   role    = "roles/compute.imageUser" 
-  member  = "serviceAccount:${google_service_account.service_account.0.email}"
-  count = local.create_service_account
+  member  = "serviceAccount:${google_service_account.service_account.email}"
 }
 
 locals {
-  service_account_email = local.create_service_account == 1 ? google_service_account.service_account.0.email : var.service_account_email
+  service_account_email = google_service_account.service_account.email
 }

--- a/deploy/determined_deploy/gcp/terraform/outputs.tf
+++ b/deploy/determined_deploy/gcp/terraform/outputs.tf
@@ -1,11 +1,41 @@
-output "web_ui" {
-  value = module.compute.web_ui 
+output "A1--Network" {
+  value = module.network.network_name
 }
 
-output "internal_ip" {
-  value = module.compute.internal_ip
+output "A2--Region" {
+  value = var.region
 }
 
-output "master_instance_name" {
+output "A3--Zone" {
+  value = "${module.compute.master_zone}\n"
+}
+
+output "B1--Master-Instance-Type" {
+  value = var.master_instance_type
+}
+
+output "B2--Agent-Instance-Type" {
+  value = var.agent_instance_type
+}
+
+output "B3--Max-number-of-Agents" {
+  value = var.max_instances
+}
+
+output "B4--GPUs-per-Agent" {
+  value = "${var.gpu_num}\n"
+}
+
+output "C1--Master-Instance-Name" {
   value = module.compute.master_instance_name
 }
+
+output "C2--Web-UI" {
+  value = "${module.compute.web_ui}\n" 
+}
+
+output "NOTE" {
+  value = "> To use the Determined CLI without needing to specify the master in each command:\n\nexport DET_MASTER=${module.compute.web_ui}"
+}
+
+

--- a/deploy/determined_deploy/gcp/terraform/variables.tf
+++ b/deploy/determined_deploy/gcp/terraform/variables.tf
@@ -1,15 +1,20 @@
 // AUTH
 variable "keypath" {
   type = string
+  default = null
 }
 
 // GCP
 
-variable "identifier" {
+variable "cluster_id" {
   type = string
 }
 
 variable "project_id" {
+  type = string
+}
+
+variable "network" {
   type = string
 }
 
@@ -20,10 +25,6 @@ variable "region" {
 variable "zone" {
   type = string
   default = null
-}
-
-variable "network" {
-  type = string
 }
 
 variable "subnetwork" {
@@ -46,17 +47,12 @@ variable "create_static_ip" {
   default = true
 }
 
-variable "create_database" {
-  type = bool
-  default = true
-}
-
 
 // CLUSTER
 
 variable "master_instance_type" {
   type = string
-  default = "n1-standard-16"
+  default = "n1-standard-2"
 }
 
 variable "agent_instance_type" {
@@ -66,7 +62,7 @@ variable "agent_instance_type" {
 
 variable "gpu_type" {
   type = string
-  default = "nvidia-tesla-v100"
+  default = "nvidia-tesla-k80"
 }
 
 variable "gpu_num" {
@@ -76,7 +72,7 @@ variable "gpu_num" {
 
 variable "max_instances" {
   type = number
-  default = 8
+  default = 5
 }
 
 variable "preemptible" {
@@ -96,7 +92,7 @@ variable "master_docker_network" {
 
 variable "max_idle_agent_period" {
   type = string
-  default = "5m"
+  default = "10m"
 }
 
 
@@ -112,11 +108,6 @@ variable "det_version" {
 
 
 // MASTER
-
-variable "instance_name" {
-  type = string
-  default = "det-master"
-}
 
 variable "scheme" {
   type = string
@@ -139,16 +130,6 @@ variable "db_version" {
 variable "db_tier" {
   type = string
   default = "db-f1-micro"
-}
-
-variable "db_instance_name" {
-  type = string
-  default = "det-postgres-db"
-}
-
-variable "db_name" {
-  type = string
-  default = "determined"
 }
 
 variable "db_username" {

--- a/docs/how-to/install-gcp.txt
+++ b/docs/how-to/install-gcp.txt
@@ -27,9 +27,9 @@ To get started on GCP, you will need to create a `project <https://cloud.google.
 The following GCP APIs must be enabled on your GCP project:
 
 * `Cloud Resource Manager API <https://console.developers.google.com/apis/library/cloudresourcemanager.googleapis.com>`__
-* `Cloud SQL Admin API <https://cloud.google.com/sql/docs/mysql/admin-api>`__
+* `Cloud SQL Admin API <https://console.developers.google.com/apis/library/sqladmin.googleapis.com>`__
 * `IAM API <https://console.developers.google.com/apis/api/iam.googleapis.com/overview>`__
-* `Service Networking API <https://cloud.google.com/service-infrastructure/docs/service-networking/getting-started>`__
+* `Service Networking API <https://console.cloud.google.com/apis/library/servicenetworking.googleapis.com>`__
 
 
 Credentials
@@ -43,24 +43,11 @@ ___________
 
    gcloud auth application-default login
 
-This command will open a login page on your browser where you can sign-in to the Google account with access to your project. Ensure your user account has at least ``Editor`` access to the project you want to deploy your cluster in.
+This command will open a login page on your browser where you can sign-in to the Google account with access to your project. Ensure your user account has ``Owner`` access to the project you want to deploy your cluster in.
 
+2. Or alternatively, you can use :ref:`Service Account credentials <gcp-service-account-credentials>`.
 
-2. For more security controls, you can create a `Service Account <https://cloud.google.com/docs/authentication/getting-started>`__ or select an existing Service Account from the `service account key page in the Cloud Console <https://console.cloud.google.com/apis/credentials/serviceaccountkey>`__ and ensure it has the following IAM Roles:
-
-   - Cloud SQL Admin
-   - Compute Admin
-   - Compute Network Admin
-   - Security Admin
-   - Service Account Admin
-   - Service Account User
-   - Service Networking Admin
-   - Storage Admin
-
-Roles provide the Service Account permissions to create specific resources in your project. You can add roles to Service Accounts following this `guide <https://cloud.google.com/iam/docs/granting-roles-to-service-accounts>`__.
-
-Once you have a Service Account with the appropriate roles, go to the `service account key page in the Cloud Console <https://console.cloud.google.com/apis/credentials/serviceaccountkey>`__ and create a JSON key file. Save it to a location you'll remember; we'll refer to the  path to this key file as the ``keypath`` going forward.
-
+.. _gcp-install:
 
 Install
 ~~~~~~~
@@ -85,94 +72,88 @@ To deploy the cluster, run:
 
 .. code::
 
-   det-deploy gcp [required args] [options]
+   det-deploy gcp up --cluster-id CLUSTER_ID --project-id PROJECT_ID
 
-The three required arguments are:
 
 .. list-table::
-   :widths: 25 50 25
+   :widths: 25 50 25 25
    :header-rows: 1
 
    * - Argument
      - Description
      - Default Value
+     - Required
 
-   * - ``--keypath``
-     - The path to the Service Account JSON key file or the string ``gcloud`` if you've authenticated with gcloud (option 1) above.
-     - None
-
-   * - ``--identifier``
+   * - ``--cluster-id``
      - A string appended to resources to uniquely identify the cluster.
      - None
+     - True
 
-   * - ``--project_id``
+   * - ``--project-id``
      - The project to deploy the cluster in.
      - None
+     - True
 
-
-The following are optional arguments that may be useful when deploying your Determined cluster:
-
-.. list-table::
-   :widths: 25 50 25
-   :header-rows: 1
-
-   * - Argument
-     - Description
-     - Default Value
-
-   * - ``--det_version``
-     - The Determined version or commit id to deploy. 
-     - The version of ``determined-deploy``.
-
-   * - ``--local_state_path``
-     - The absolute path to store ``.tfstate`` files. The `.tfstate` file tracks the resources you've deployed, which allows you to update or delete deployments later.
-     - The current working directory where ``determined-deploy`` is being run.
+   * - ``--keypath``
+     - The path to the Service Account JSON key file if using a Service Account. Including this flag will supersede default Google Cloud user credentials.
+     - None
+     - False
 
    * - ``--preemptible``
      - Whether to use preemptible instances.
      - false
+     - False
 
-   * - ``--gpu_type``
-     - The type of GPU to use for the agent instances.
-     - nvidia-tesla-v100
+   * - ``--gpu-type``
+     - The type of GPU to use for the agent instances. Ensure ``gpu_type`` is available in your selected ``region`` and ``zone``.
+     - nvidia-tesla-k80
+     - False
 
-   * - ``--gpu_num``
+   * - ``--gpu-num``
      - The number of GPUs on each agent instance. Between 1-8 (more GPUs require more powerful ``agent_instance_type``)
-     - 2
+     - 8
+     - False
 
-   * - ``--max_instances``
+   * - ``--max-instances``
      - The maximum number of agent instances at one time.
-     - 4
+     - 5
+     - False
 
-   * - ``--max_idle_agent_period``
+   * - ``--max-idle-agent-period``
      - The maximum amount of time an aagent can sit idle before being shut down.
-     - 30m
+     - 10m
+     - False
 
    * - ``--network``
-     - The name of the network to deploy the cluster in. The network will be created if it doesn't exist.
-     - det-default 
+     - The network to create (ensure there isn't a network with the same name already in the project, otherwise the deployment will fail)
+     - det-default-<cluster-id>
+     - False
 
    * - ``--region``
      - The region to deploy the cluster in.
-     - us-central-1
+     - us-west1
+     - False
 
    * - ``--zone``
      - The zone to deploy the cluster in.
-     - us-central-1a
+     - ``region``-b
+     - False
 
-   * - ``--master_instance_type``
+   * - ``--master-instance-type``
      - Instance type to use for the master instance.
-     - n1-standard-16
+     - n1-standard-2
+     - False
 
-   * - ``--agent_instance_type``
+   * - ``--agent-instance-type``
      - Instance type to use for the agent instances.
-     - n1-standard-16
+     - n1-standard-32
+     - False
 
 .. note::
   The deployment process may take 5-10 minutes and will return the ``web_ui`` to indicate that the resources have been created. It may take a few minutes from this point for the master instance to fully boot up and you're able to use the ``web_ui`` address to access the cluster. 
 
 .. warning::
-  Changes to ``--gpu_num`` should correspond to appropriate changes to ``--agent_instance_type``, as enforced by Google Cloud. For example, when using ``nvidia-tesla-v100`` GPUs, each GPU can correspond to at most 12vCPUs, i.e. if ``--gpu_num 2``, then ``--agent_instance_type n1-standard-16`` is the highest number of vCPUs (16) that can be used.
+  Changes to ``--gpu-num`` should correspond to appropriate changes to ``--agent-instance-type``, as enforced by GCP. For example, when using ``nvidia-tesla-k80`` GPUs, each GPU can correspond to at most 12vCPUs, i.e. if ``--gpu-num 2``, then ``--agent-instance-type n1-standard-16`` is the highest number of vCPUs (16) that can be used. You can check GPU requirements and regional availabilities on the `GPUs on Compute Engine <https://cloud.google.com/compute/docs/gpus>` page. 
 
 .. warning::
   If ``det-deploy`` is set to use an existing network, the VPC being used must have an `IP range allocated <https://cloud.google.com/vpc/docs/configure-private-services-access#procedure>`__ and a `private service connection created <https://cloud.google.com/vpc/docs/configure-private-services-access#creating-connection>`__.
@@ -201,25 +182,64 @@ The following ``gcloud`` commands will help to validate your configuration, incl
 Updating the cluster
 ~~~~~~~~~~~~~~~~~~~~
 
-If you need to make changes to your cluster, you can re-run ``det-deploy [required args] [options]`` in the same directory and your cluster will be updated. ``determined-deploy`` will only replace resources that need to be replaced based on the changes you've made in the updated execution. 
-
-.. note::
-  If you previously created your cluster and set a ``local_state_path`` other than the default, you will need to include that argument again as well.
+If you need to make changes to your cluster, you can re-run ``det-deploy gcp up [args]`` in the same directory and your cluster will be updated. ``determined-deploy`` will only replace resources that need to be replaced based on the changes you've made in the updated execution. 
 
 .. note::
   If you'd like to change the ``region`` of a deployment after it has already been deployed, we recommend deleting the cluster first, then redeploying the cluster with the new ``region``.
 
+
 De-provisioning the cluster
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-To bring down the cluster:
+To bring down the cluster, run the following in the same directory where you ran the deploy command:
 
 .. code::
 
-    det-deploy --delete [required args]
+    det-deploy gcp down [optional args]
+
+By default, ``determined-deploy`` will use the ``.tfstate`` file in the current directory to determined which resources to de-provision. In addition, the following are optional arguments:
+
+.. list-table::
+   :widths: 25 50 25 25
+   :header-rows: 1
+
+   * - Argument
+     - Description
+     - Default Value
+     - Required
+
+   * - ``--keypath``
+     - The path to the Service Account JSON key file if using a Service Account. Including this flag will supersede default Google Cloud user credentials.
+     - None
+     - False
+
 
 .. warning::
-  ``determined-deploy`` will not delete active agent instances when you de-provision the cluster. Generally, the master instance will shut down any inactive agents after an idle period, but if you'd like to de-provision the cluster while these agent instances exist, you must delete all agent instances first. You can find these agent instances by filtering for instances named ``det-agent-<identifier>`` and these agent(s) will have a full name in the form ``det-agent-<identifier>-<random integer>-<version>-<pet name>``.
+  ``determined-deploy`` will not delete active agent instances when you de-provision the cluster. Generally, the master instance will shut down any inactive agents after an idle period, but if you'd like to de-provision the cluster while these agent instances exist, you must delete all agent instances first. You can find these agent instances by filtering for instances named ``det-agent-<cluster-id>`` and these agent(s) will have a full name in the form ``det-agent-<cluster-id>-<pet name>``.
+
+
+Appendix
+~~~~~~~~
+
+.. _gcp-service-account-credentials:
+
+Using Service Account Credentials
+_________________________________
+
+For more security controls, you can create a `Service Account <https://cloud.google.com/docs/authentication/getting-started>`__ or select an existing Service Account from the `service account key page in the Cloud Console <https://console.cloud.google.com/apis/credentials/serviceaccountkey>`__ and ensure it has the following IAM Roles:
+
+   - Cloud SQL Admin
+   - Compute Admin
+   - Compute Network Admin
+   - Security Admin
+   - Service Account Admin
+   - Service Account User
+   - Service Networking Admin
+   - Storage Admin
+
+Roles provide the Service Account permissions to create specific resources in your project. You can add roles to Service Accounts following this `guide <https://cloud.google.com/iam/docs/granting-roles-to-service-accounts>`__.
+
+Once you have a Service Account with the appropriate roles, go to the `service account key page in the Cloud Console <https://console.cloud.google.com/apis/credentials/serviceaccountkey>`__ and create a JSON key file. Save it to a location you'll remember; we'll refer to the path to this key file as the ``keypath``, which is an additional argument you can supply when using ``determined-deploy``. Once you have the ``keypath`` you can use it to deploy a GCP cluster continuing from the :ref:`installation <gcp-install>` section.
 
 
 Next Steps


### PR DESCRIPTION
* Main changes are to standardize `gcp` arguments and functionality with `aws` and `local`, and updating docs appropriately.

Changes:
* CLI arguments use `-` format
* arguments group into `required named arguments` and `optional named arguments`
* required arguments reduced to `project-id` and `cluster-id`
* default to GCP application-default credentials
* added `dry-run` flag
* added deployment summary at end of deployment (formatting is limited by Terraform output formatting)
* defaults updated for `det-version`, `environment-image`, `master-instance-type`, `agent-instance-type`, `gpu-num`, `gpu-type`, `max-instances`
* `det-version` and `environment-image` suppressed in `--help`
* updated `install-gcp.txt` accordingly

Additional Notable changes:
* the script will no longer accept existing networks, service_accounts (compute instance level, not terraform credentials level), or gcs_buckets. The logic that previously enabled this is not best practice and causes issues when updating the cluster.