### PR TITLE
feat: add master, agent subcommands for det-deploy local

### DIFF
--- a/deploy/determined_deploy/local/cli.py
+++ b/deploy/determined_deploy/local/cli.py
@@ -2,59 +2,197 @@ import argparse
 
 from determined_deploy.local import cluster_utils
 
-OPERATION_TO_FN = {
-    "fixture-up": cluster_utils.fixture_up,
-    "fixture-down": cluster_utils.fixture_down,
-    "logs": cluster_utils.logs,
-}
+
+def add_fixture_up_subparser(subparsers: argparse._SubParsersAction) -> None:
+    parser = subparsers.add_parser(
+        "fixture-up",
+        help="Create a Determined cluster",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument("--etc-root", type=str, default=None, help="path to etc directory")
+    parser.add_argument(
+        "--agents", type=int, default=1, help="number of agents to start (on this machine)"
+    )
+    parser.add_argument("--master-port", type=int, default=8080, help="port to expose master on")
+    parser.add_argument(
+        "--cluster-name", type=str, default="determined", help="name for the cluster resources"
+    )
+    parser.add_argument("--det-version", type=str, default=None, help="version or commit to use")
+    parser.add_argument(
+        "--db-password", type=str, default="postgres", help="password for master database",
+    )
+    parser.add_argument(
+        "--hasura-secret", type=str, default="hasura", help="password for hasura service",
+    )
+    parser.add_argument(
+        "--delete-db", action="store_true", help="remove current master database",
+    )
+    parser.add_argument("--no-gpu", help="enable GPU support for agent", action="store_true")
+
+
+def add_fixture_down_subparser(subparsers: argparse._SubParsersAction) -> None:
+    parser = subparsers.add_parser(
+        "fixture-down",
+        help="Stop a Determined cluster",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument(
+        "--cluster-name", type=str, default="determined", help="name for the cluster resources"
+    )
+    parser.add_argument(
+        "--delete-db", action="store_true", help="remove current master database",
+    )
+
+
+def add_master_up_subparser(subparsers: argparse._SubParsersAction) -> None:
+    parser = subparsers.add_parser(
+        "master-up",
+        help="Start a Determined master",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument("--etc-root", type=str, default=None, help="path to etc directory")
+    parser.add_argument("--master-port", type=int, default=8080, help="port to expose master on")
+    parser.add_argument(
+        "--master-name", type=str, default="determined", help="name for the cluster resources"
+    )
+    parser.add_argument("--det-version", type=str, default=None, help="version or commit to use")
+    parser.add_argument(
+        "--db-password", type=str, default="postgres", help="password for master database",
+    )
+    parser.add_argument(
+        "--hasura-secret", type=str, default="hasura", help="password for hasura service",
+    )
+    parser.add_argument(
+        "--delete-db", action="store_true", help="remove current master database",
+    )
+
+
+def add_master_down_subparser(subparsers: argparse._SubParsersAction) -> None:
+    parser = subparsers.add_parser(
+        "master-down",
+        help="Stop a Determined master",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument(
+        "--master-name", type=str, default="determined", help="name for the cluster resources"
+    )
+    parser.add_argument(
+        "--delete-db", action="store_true", help="remove current master database",
+    )
+
+
+def add_logs_subparser(subparsers: argparse._SubParsersAction) -> None:
+    parser = subparsers.add_parser(
+        "logs",
+        help="Show the logs of a Determined cluster",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument(
+        "--cluster-name", type=str, default="determined", help="name for the cluster resources"
+    )
+
+
+def add_agent_up_subparser(subparsers: argparse._SubParsersAction) -> None:
+    parser = subparsers.add_parser(
+        "agent-up",
+        help="Start a Determined agent",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument("master_host", type=str, help="master hostname")
+    parser.add_argument("--master-port", type=int, default=8080, help="master port")
+    parser.add_argument("--det-version", type=str, default=None, help="version or commit to use")
+    parser.add_argument("--agent-name", type=str, default="det-agent", help="agent name")
+    parser.add_argument("--no-gpu", help="disable GPU support", action="store_true")
+
+
+def add_agent_down_subparser(subparsers: argparse._SubParsersAction) -> None:
+    parser = subparsers.add_parser(
+        "agent-down",
+        help="Stop a Determined agent",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument("--agent-name", type=str, default="det-agent", help="agent name")
+    parser.add_argument("--all", help="stop all running agents", action="store_true")
 
 
 def make_local_parser(subparsers: argparse._SubParsersAction) -> None:
     parser_local = subparsers.add_parser(
         "local", help="local help", formatter_class=argparse.ArgumentDefaultsHelpFormatter
     )
-    parser_local.add_argument(
-        "operations",
-        type=str,
-        choices=OPERATION_TO_FN.keys(),
-        nargs="+",
-        help="a list of operations",
+    subparsers = parser_local.add_subparsers(help="command", dest="command")
+    add_fixture_up_subparser(subparsers)
+    add_fixture_down_subparser(subparsers)
+    add_logs_subparser(subparsers)
+    add_master_up_subparser(subparsers)
+    add_master_down_subparser(subparsers)
+    add_agent_up_subparser(subparsers)
+    add_agent_down_subparser(subparsers)
+
+
+def handle_fixture_up(args):
+    cluster_utils.fixture_up(
+        num_agents=args.agents,
+        port=args.master_port,
+        etc_path=args.etc_root,
+        cluster_name=args.cluster_name,
+        version=args.det_version,
+        db_password=args.db_password,
+        hasura_secret=args.hasura_secret,
+        delete_db=args.delete_db,
+        no_gpu=args.no_gpu,
     )
-    parser_local.add_argument("--etc-root", type=str, default=None, help="path to etc directory")
-    parser_local.add_argument(
-        "--agents", type=int, default=0, help="number of agents to start (on this machine)"
+
+
+def handle_fixture_down(args):
+    cluster_utils.fixture_down(cluster_name=args.cluster_name, delete_db=args.delete_db)
+
+
+def handle_logs(args):
+    cluster_utils.logs(cluster_name=args.cluster_name)
+
+
+def handle_master_up(args):
+    cluster_utils.master_up(
+        port=args.master_port,
+        etc_path=args.etc_root,
+        master_name=args.master_name,
+        version=args.det_version,
+        db_password=args.db_password,
+        hasura_secret=args.hasura_secret,
+        delete_db=args.delete_db,
     )
-    parser_local.add_argument(
-        "--master-port", type=int, default=8080, help="port to expose master on"
+
+
+def handle_master_down(args):
+    cluster_utils.master_down(master_name=args.master_name, delete_db=args.delete_db)
+
+
+def handle_agent_up(args):
+    cluster_utils.agent_up(
+        master_host=args.master_host,
+        master_port=args.master_port,
+        no_gpu=args.no_gpu,
+        agent_name=args.agent_name,
+        version=args.det_version,
+        labels=None,
     )
-    parser_local.add_argument(
-        "--cluster-name", type=str, default="determined", help="name for the cluster resources"
-    )
-    parser_local.add_argument(
-        "--db-password", type=str, default="postgres", help="password for master database",
-    )
-    parser_local.add_argument(
-        "--hasura-secret", type=str, default="hasura", help="password for hasura service",
-    )
-    parser_local.add_argument(
-        "--delete-db", action="store_true", help="remove current master database",
-    )
+
+
+def handle_agent_down(args):
+    if args.all:
+        cluster_utils.stop_all_agents()
+    else:
+        cluster_utils.stop_agent(agent_name=args.agent_name)
 
 
 def deploy_local(args: argparse.Namespace) -> None:
-    for op in args.operations:
-        fn = OPERATION_TO_FN.get(op)
-        if fn is cluster_utils.fixture_up:
-            fn(
-                num_agents=args.agents,
-                etc_path=args.etc_root,
-                port=args.master_port,
-                cluster_name=args.cluster_name,
-                db_password="postgres",
-                hasura_secret="hasura",
-                delete_db=args.delete_db,
-            )
-        elif fn is cluster_utils.fixture_down:
-            fn(cluster_name=args.cluster_name, delete_db=args.delete_db)
-        else:
-            fn(cluster_name=args.cluster_name)
+    OPERATION_TO_FN = {
+        "agent-up": handle_agent_up,
+        "agent-down": handle_agent_down,
+        "fixture-up": handle_fixture_up,
+        "fixture-down": handle_fixture_down,
+        "logs": handle_logs,
+        "master-up": handle_master_up,
+        "master-down": handle_master_down,
+    }
+    OPERATION_TO_FN.get(args.command)(args)

--- a/deploy/determined_deploy/local/cluster_utils.py
+++ b/deploy/determined_deploy/local/cluster_utils.py
@@ -6,6 +6,7 @@ import time
 from pathlib import Path
 from typing import Dict, List, Optional, Sequence
 
+import docker
 import requests
 
 import determined_deploy
@@ -55,7 +56,6 @@ def docker_compose(
     if env is not None:
         # raise ValueError(str(env))
         process_env.update(env)
-    process_env["DET_VERSION"] = determined_deploy.__version__
     process_env["INTEGRATIONS_PROXY_ADDR"] = get_proxy_addr()
     base_command = ["docker-compose", "-f", str(path), "-p", cluster_name]
     if extra_files is not None:
@@ -65,7 +65,7 @@ def docker_compose(
     subprocess.run(args, env=process_env)
 
 
-def _wait_for_master(port: int) -> None:
+def _wait_for_master() -> None:
     for _ in range(50):
         try:
             r = api.get(config.make_master_url(), "info", authenticated=False)
@@ -78,40 +78,155 @@ def _wait_for_master(port: int) -> None:
     raise ConnectionError("Timed out connecting to Master")
 
 
-def fixture_up(
-    num_agents: Optional[int],
+def master_up(
     port: Optional[int],
     etc_path: Path,
-    cluster_name: str,
+    master_name: str,
+    version: str,
     db_password: str,
     hasura_secret: str,
     delete_db: bool,
-) -> str:
+):
     config.MASTER_PORT = port
-
-    command = ["up", "-d", "--scale", f"determined-agent={num_agents}"]
+    command = ["up", "-d"]
     extra_files = []
     if etc_path is not None:
         etc_path = Path(etc_path).resolve()
-        mount_yaml = Path(__file__).parent.joinpath("mount.yaml")
+        mount_yaml = Path(__file__).parent.joinpath("mount.yaml").resolve()
         extra_files.append(str(mount_yaml))
+    if version is None:
+        version = determined_deploy.__version__
     env = {
         "INTEGRATIONS_HOST_PORT": str(port),
         "DET_ETC_ROOT": str(etc_path),
         "DET_DB_PASSWORD": db_password,
         "DET_HASURA_SECRET": hasura_secret,
+        "DET_VERSION": version,
     }
-    fixture_down(cluster_name, delete_db)
-    docker_compose(command, cluster_name, env, extra_files=extra_files)
-    _wait_for_master(port)
+    master_down(master_name, delete_db)
+    docker_compose(command, master_name, env, extra_files=extra_files)
+    _wait_for_master()
+
+
+def master_down(master_name: str, delete_db: bool) -> None:
+    if delete_db:
+        docker_compose(["down", "--volumes", "-t", "1"], master_name)
+    else:
+        docker_compose(["down", "-t", "1"], master_name)
+
+
+def fixture_up(
+    num_agents: Optional[int],
+    port: Optional[int],
+    etc_path: Path,
+    cluster_name: str,
+    version: str,
+    db_password: str,
+    hasura_secret: str,
+    delete_db: bool,
+    no_gpu: bool,
+):
+    master_up(
+        port=port,
+        etc_path=etc_path,
+        master_name=cluster_name,
+        version=version,
+        db_password=db_password,
+        hasura_secret=hasura_secret,
+        delete_db=delete_db,
+    )
+    for agent_number in range(num_agents):
+        agent_name = cluster_name + f"-agent-{agent_number}"
+        labels = {"determined.cluster": cluster_name}
+        agent_up(
+            master_host=get_proxy_addr(),
+            master_port=port,
+            agent_name=agent_name,
+            version=version,
+            labels=labels,
+            no_gpu=no_gpu,
+        )
 
 
 def fixture_down(cluster_name: str, delete_db: bool) -> None:
-    if delete_db:
-        docker_compose(["down", "--volumes", "-t", "1"], cluster_name)
-    else:
-        docker_compose(["down", "-t", "1"], cluster_name)
+    master_down(master_name=cluster_name, delete_db=delete_db)
+    stop_cluster_agents(cluster_name=cluster_name)
 
 
 def logs(cluster_name: str) -> None:
     docker_compose(["logs", "-f"], cluster_name)
+
+
+def agent_up(
+    master_host: Optional[str],
+    master_port: Optional[int],
+    agent_name: Optional[str],
+    version: Optional[str],
+    no_gpu: bool,
+    labels: Dict = None,
+) -> None:
+    if version is None:
+        version = determined_deploy.__version__
+    image = "determinedai/determined-agent:{}".format(version)
+    environment = {
+        "DET_MASTER_HOST": master_host,
+        "DET_MASTER_PORT": master_port,
+        "DET_AGENT_ID": agent_name,
+    }
+    init = True
+    volumes = ["/var/run/docker.sock:/var/run/docker.sock"]
+    mounts = []
+    if labels is None:
+        labels = {}
+    labels["ai.determined.type"] = "agent"
+    config.MASTER_HOST = master_host
+    config.MASTER_PORT = master_port
+    _wait_for_master()
+    docker_client = docker.from_env()
+    if "nvidia" in docker_client.info()["Runtimes"] and not no_gpu:
+        runtime = "nvidia"
+    else:
+        runtime = None
+    print(f"Starting {agent_name}")
+    docker_client.containers.run(
+        image=image,
+        environment=environment,
+        init=init,
+        mounts=mounts,
+        volumes=volumes,
+        network_mode="host",
+        name=agent_name,
+        detach=True,
+        runtime=runtime,
+        labels=labels,
+    )
+
+
+def _kill_containers(containers):
+    for container in containers:
+        print(f"Stopping {container.name}")
+        container.stop(timeout=20)
+        print(f"Removing {container.name}")
+        container.remove()
+
+
+def stop_all_agents():
+    docker_client = docker.from_env()
+    filters = {"label": ["ai.determined.type=agent"]}
+    to_stop = docker_client.containers.list(all=True, filters=filters)
+    _kill_containers(to_stop)
+
+
+def stop_cluster_agents(cluster_name: str):
+    docker_client = docker.from_env()
+    labels = [f"determined.cluster={cluster_name}"]
+    filters = {"label": labels}
+    to_stop = docker_client.containers.list(all=True, filters=filters)
+    _kill_containers(to_stop)
+
+
+def stop_agent(agent_name: str) -> None:
+    docker_client = docker.from_env()
+    filters = {"name": [agent_name]}
+    to_stop = docker_client.containers.list(all=True, filters=filters)
+    _kill_containers(to_stop)

--- a/deploy/determined_deploy/local/docker-compose.yaml
+++ b/deploy/determined_deploy/local/docker-compose.yaml
@@ -39,21 +39,5 @@ services:
       DET_DB_PASSWORD: ${DET_DB_PASSWORD}
       DET_HASURA_SECRET: ${DET_HASURA_SECRET}
 
-  determined-agent:
-    init: true
-    restart: always
-    depends_on:
-      - determined-master
-    image: determinedai/determined-agent:${DET_VERSION}
-    environment:
-      DET_LOG_LEVEL: ${INTEGRATIONS_LOG_LEVEL:-info}
-      DET_ARTIFICIAL_SLOTS: ${INTEGRATIONS_ARTIFICIAL_SLOTS:-0}
-      DET_PROXY_ADDR: host.docker.internal
-      DET_MASTER_HOST: ${INTEGRATIONS_PROXY_ADDR}
-      DET_MASTER_PORT: ${INTEGRATIONS_HOST_PORT:-8080}
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
-    # TODO: Add runtime as an option if docker-compose re-supports it
-
 volumes:
   determined-db-volume: {}

--- a/deploy/setup.py
+++ b/deploy/setup.py
@@ -20,6 +20,7 @@ setup(
     package_data={"determined-deploy": [str(version_file)]},
     install_requires=[
         "requests>=2.20.0",
+        "docker>=3.7.3",
         "docker-compose>=1.13.0",
         f"determined-common=={version}",
     ],

--- a/tests/integrations/conftest.py
+++ b/tests/integrations/conftest.py
@@ -61,6 +61,8 @@ def cluster_log_manager(request: SubRequest) -> Optional[ClusterLogManager]:
             db_password="postgres",
             hasura_secret="hasura",
             delete_db=False,
+            version=None,
+            no_gpu=False,
         )
         with ClusterLogManager("integrations") as clm:
             # Yield instead of return so that `__exit__` is called when the

--- a/webui/tests/bin/e2e-tests.py
+++ b/webui/tests/bin/e2e-tests.py
@@ -23,13 +23,22 @@ def run(cmd: List[str], config) -> None:
 
 
 def run_cluster_cmd(subcommand: List[str], config):
-    run(["det-deploy", "local", "--cluster-name", config["CLUSTER_NAME"]] + subcommand, config)
+    run(["det-deploy", "local"] + subcommand + ["--cluster-name", config["CLUSTER_NAME"]], config)
 
 
 def pre_e2e_tests(config):
     run(["docker", "pull", DOCKER_CYPRESS_IMAGE], config)
     run_cluster_cmd(
-        ["fixture-up", "--agents", "1", "--master-port", config["INTEGRATIONS_HOST_PORT"]], config
+        [
+            "fixture-up",
+            "--agents",
+            "1",
+            "--no-gpu",
+            "--delete-db",
+            "--master-port",
+            config["INTEGRATIONS_HOST_PORT"],
+        ],
+        config,
     )
     test_setup_path = tests_dir.joinpath("bin", "createUserAndExperiments.py")
     run(["python", str(test_setup_path)], config)


### PR DESCRIPTION
Added a bunch of subcommands to `det-deploy local` to provide more flexibility

- `det-deploy local fixture-up` - now creates a master + agents (default = 1 agent)
- `det-deploy local fixture-down` - now stops any cluster created with `det-deploy local fixture-up`
- `det-deploy local master-up` - starts a determined master
- `det-deploy local master-down` - stops a determined master
- `det-deploy local agent-up` - starts a determined agent
- `det-deploy local agent-down` - stops a determined agent

Additionally, refactored the argparser to accommodate this.

Notably this uses the docker-py API to create agents -- this was decided to avoid having to hackily configure the default docker runtime in order to start an agent with GPU support.

