### PR TITLE
feat: add min-cpu-platform to gcp deployment

### DIFF
--- a/deploy/determined_deploy/gcp/cli.py
+++ b/deploy/determined_deploy/gcp/cli.py
@@ -119,7 +119,7 @@ def make_up_subparser(subparsers: argparse._SubParsersAction) -> None:
     )
     optional_named.add_argument(
         "--port",
-        type=str,
+        type=int,
         default=constants.defaults.PORT,
         help="port to use for communication on master instance",
     )
@@ -140,6 +140,18 @@ def make_up_subparser(subparsers: argparse._SubParsersAction) -> None:
         type=int,
         default=constants.defaults.MAX_INSTANCES,
         help="maximum number of agent instances at one time",
+    )
+    optional_named.add_argument(
+        "--min-cpu-platform-master",
+        type=str,
+        default=constants.defaults.MIN_CPU_PLATFORM_MASTER,
+        help="minimum cpu platform for master instances",
+    )
+    optional_named.add_argument(
+        "--min-cpu-platform-agent",
+        type=str,
+        default=constants.defaults.MIN_CPU_PLATFORM_AGENT,
+        help="minimum cpu platform for agent instances",
     )
 
 

--- a/deploy/determined_deploy/gcp/constants.py
+++ b/deploy/determined_deploy/gcp/constants.py
@@ -9,6 +9,8 @@ class defaults:
     MASTER_INSTANCE_TYPE = "n1-standard-2"
     MAX_IDLE_AGENT_PERIOD = "10m"
     MAX_INSTANCES = 5
+    MIN_CPU_PLATFORM_MASTER = "Intel Skylake"
+    MIN_CPU_PLATFORM_AGENT = "Intel Broadwell"
     NETWORK = "det-default"
     PORT = 8080
     REGION = "us-west1"

--- a/deploy/determined_deploy/gcp/terraform/main.tf
+++ b/deploy/determined_deploy/gcp/terraform/main.tf
@@ -128,6 +128,8 @@ module "compute" {
   gpu_type = var.gpu_type
   gpu_num = var.gpu_num
   max_instances = var.max_instances
+  min_cpu_platform_master = var.min_cpu_platform_master
+  min_cpu_platform_agent = var.min_cpu_platform_agent
   preemptible = var.preemptible
   db_username = var.db_username
   db_password = var.db_password

--- a/deploy/determined_deploy/gcp/terraform/modules/compute/main.tf
+++ b/deploy/determined_deploy/gcp/terraform/modules/compute/main.tf
@@ -17,6 +17,10 @@ resource "google_compute_instance" "default" {
     scopes = ["https://www.googleapis.com/auth/cloud-platform"]
   }
 
+  min_cpu_platform = var.min_cpu_platform_master
+
+  allow_stopping_for_update = true
+
   metadata_startup_script = <<-EOT
     mkdir -p /usr/local/determined/etc
     cat << EOF > /usr/local/determined/etc/master.yaml
@@ -58,6 +62,8 @@ resource "google_compute_instance" "default" {
         gpu_num: ${var.gpu_num}
         preemptible: ${var.preemptible}
       max_instances: ${var.max_instances}
+      base_config:
+        minCpuPlatform: ${var.min_cpu_platform_agent}
     EOF
 
     apt-get remove docker docker-engine docker.io containerd runc

--- a/deploy/determined_deploy/gcp/terraform/modules/compute/variables.tf
+++ b/deploy/determined_deploy/gcp/terraform/modules/compute/variables.tf
@@ -90,3 +90,9 @@ variable "region" {
 
 variable "zone" {
 }
+
+variable "min_cpu_platform_master" {
+}
+
+variable "min_cpu_platform_agent" {
+}

--- a/deploy/determined_deploy/gcp/terraform/variables.tf
+++ b/deploy/determined_deploy/gcp/terraform/variables.tf
@@ -95,6 +95,15 @@ variable "max_idle_agent_period" {
   default = "10m"
 }
 
+variable "min_cpu_platform_master" {
+  type = string
+  default = "Intel Skylake"
+}
+
+variable "min_cpu_platform_agent" {
+  type = string
+  default = "Intel Broadwell"
+}
 
 // DETERMINED
 

--- a/docs/how-to/installation/gcp.txt
+++ b/docs/how-to/installation/gcp.txt
@@ -39,7 +39,7 @@ ___________
 
 1. Use `gcloud <https://cloud.google.com/sdk/docs/downloads-interactive#installation_options>`__ to authenticate your user account:
 
-.. code::
+.. code:: sh
 
    gcloud auth application-default login
 
@@ -55,9 +55,9 @@ Install
 1. Install `Terraform <https://learn.hashicorp.com/terraform/getting-started/install.html>`__.
 2. Install ``determined-deploy``
 
-.. code::
+.. code:: sh
 
-   pip install -U determined-deploy
+   pip install determined-deploy
 
 
 Deploying
@@ -70,7 +70,7 @@ We recommend creating a new directory and running the commands below inside that
 
 To deploy the cluster, run:
 
-.. code::
+.. code:: sh
 
    det-deploy gcp up --cluster-id CLUSTER_ID --project-id PROJECT_ID
 
@@ -149,6 +149,16 @@ To deploy the cluster, run:
      - n1-standard-32
      - False
 
+   * - ``--min-cpu-platform-master``
+     - Minimum cpu platform for the master instance.
+     - Intel Skylake
+     - False
+
+   * - ``--min-cpu-platform-agent``
+     - Minimum cpu platform for the agent instances. Ensure the platform is compatible with your selected ``gpu-type`` and available in your selected ``region`` and ``zone``.
+     - Intel Broadwell
+     - False
+
 .. note::
   The deployment process may take 5-10 minutes and will return the ``web_ui`` to indicate that the resources have been created. It may take a few minutes from this point for the master instance to fully boot up and you're able to use the ``web_ui`` address to access the cluster. 
 
@@ -161,7 +171,7 @@ To deploy the cluster, run:
 
 The following ``gcloud`` commands will help to validate your configuration, including resource availability in your desired region and zone:
 
-.. code::
+.. code:: sh
 
     # Validate that the GCP Project ID exists
     gcloud projects list
@@ -193,7 +203,7 @@ De-provisioning the cluster
 
 To bring down the cluster, run the following in the same directory where you ran the deploy command:
 
-.. code::
+.. code:: sh
 
     det-deploy gcp down [optional args]
 


### PR DESCRIPTION
* add `min-cpu-platform-master` and `min-cpu-platform-agent` to set the minimum cpu platform
* updated `docs/install-gcp.txt` accordingly