### PR TITLE
fix: change _ to - for gcp down variable placeholder names

### DIFF
--- a/deploy/determined_deploy/gcp/cli.py
+++ b/deploy/determined_deploy/gcp/cli.py
@@ -176,12 +176,12 @@ def deploy_gcp(args: argparse.Namespace) -> None:
     if args.command == "down":
 
         # Set placeholders for required variables
-        det_configs["cluster_id"] = "will_be_ignored"
-        det_configs["project_id"] = "will_be_ignored"
-        det_configs["network"] = "will_be_ignored"
-        det_configs["region"] = "will_be_ignored"
-        det_configs["det_version"] = "will_be_ignored"
-        det_configs["environment_image"] = "will_be_ignored"
+        det_configs["cluster_id"] = "will-be-ignored"
+        det_configs["project_id"] = "will-be-ignored"
+        det_configs["network"] = "will-be-ignored"
+        det_configs["region"] = "will-be-ignored"
+        det_configs["det_version"] = "will-be-ignored"
+        det_configs["environment_image"] = "will-be-ignored"
 
         gcp.delete(det_configs, env, variables_to_exclude)
         print("Delete Successful")


### PR DESCRIPTION
`det-deploy gcp down` currently uses placeholder variables with `_` which may cause issues when Terraform checks the names of resources that are named with these variables. Changing all `_` to `-` in these placeholders avoids this issue.