### PR TITLE
[DET-2841] feat: add inbox logging to actor system

### DIFF
--- a/master/cmd/determined-master/init.go
+++ b/master/cmd/determined-master/init.go
@@ -66,7 +66,7 @@ func registerConfig() {
 		defaults.ConfigFile, "location of config file")
 
 	registerString(flags, name("log", "level"),
-		defaults.Log.Level, "choose logging level from [debug, info, warn, error, fatal]")
+		defaults.Log.Level, "choose logging level from [trace, debug, info, warn, error, fatal]")
 	registerBool(flags, name("log", "color"),
 		defaults.Log.Color, "output logs in color")
 

--- a/master/pkg/actor/inbox.go
+++ b/master/pkg/actor/inbox.go
@@ -57,6 +57,12 @@ func (i *inbox) get() *Context {
 	return i.queue.Remove(i.queue.Front()).(*Context)
 }
 
+func (i *inbox) len() int {
+	i.qLock.Lock()
+	defer i.qLock.Unlock()
+	return i.queue.Len()
+}
+
 func (i *inbox) close() {
 	i.qLock.Lock()
 	defer i.qLock.Unlock()

--- a/master/pkg/actor/ref.go
+++ b/master/pkg/actor/ref.go
@@ -150,6 +150,9 @@ func (r *Ref) deleteChild(address Address) {
 
 func (r *Ref) processMessage() bool {
 	context := r.inbox.get()
+
+	r.log.Tracef("get %T, inbox length: %v", context.message, r.inbox.len())
+
 	defer func() {
 		if context.ExpectingResponse() {
 			context.Respond(errNoResponse)


### PR DESCRIPTION
Inbox logging is a rudimentary form of profiling the system that has
proven useful on a couple of occasions. This change adds "trace"-level
structured logging to inbox data to the actor system. The runtime
overhead for non-trace levels of debug did not even register with pprof.
