### PR TITLE
docs: describe tasks in cli help

### DIFF
--- a/cli/determined_cli/cli.py
+++ b/cli/determined_cli/cli.py
@@ -159,7 +159,7 @@ args_description = [
 
     checkpoint.args_description,
 
-    Cmd("task", None, "manage tasks", [
+    Cmd("task", None, "manage tasks (commands, experiments, notebooks, shells, tensorboards)", [
         Cmd("list", list_tasks, "list tasks in cluster", [
             Arg("--csv", action="store_true", help="print as CSV"),
         ], is_default=True),


### PR DESCRIPTION
So as @stoksc brought up today we have `det task` (something i didn't know or knew and forgot). To simplify this I expanded the CLI message, but it does end up with a line wrap, so not sure we want to go through with this change:

```
positional arguments:
  command
    help                show help for this command
    agent (a)           manage agents
    command (cmd)       manage commands
    checkpoint (c)      manage checkpoints
    experiment (e)      manage experiments
    master              manage master
    notebook            manage notebooks
    preview-search      preview search
    shell               manage shells
    slot (s)            manage slots
    task                manage tasks (commands, experiments, notebooks,
                        shells, tensorboards)
    template (tpl)      manage config templates
    tensorboard         manage TensorBoard instances
    trial (t)           manage trials
    user (u)            manage users
    version             show version information

optional arguments:
  -h, --help            show this help message and exit
  -u username, --user username
                        run as the given user (default: None)
  -m address, --master address
                        master address (default: localhost:8080)
  -v, --version         print CLI version and exit
```