### PR TITLE
feat: add restart policy for fault-tolerance

### DIFF
--- a/deploy/determined_deploy/local/cli.py
+++ b/deploy/determined_deploy/local/cli.py
@@ -30,6 +30,11 @@ def add_fixture_up_subparser(subparsers: argparse._SubParsersAction) -> None:
         "--delete-db", action="store_true", help="remove current master database",
     )
     parser.add_argument("--no-gpu", help="enable GPU support for agent", action="store_true")
+    parser.add_argument(
+        "--no-autorestart",
+        help="disable container auto-restart (recommended for local development)",
+        action="store_true",
+    )
 
 
 def add_fixture_down_subparser(subparsers: argparse._SubParsersAction) -> None:
@@ -69,6 +74,11 @@ def add_master_up_subparser(subparsers: argparse._SubParsersAction) -> None:
     parser.add_argument(
         "--delete-db", action="store_true", help="remove current master database",
     )
+    parser.add_argument(
+        "--no-autorestart",
+        help="disable container auto-restart (recommended for local development)",
+        action="store_true",
+    )
 
 
 def add_master_down_subparser(subparsers: argparse._SubParsersAction) -> None:
@@ -107,6 +117,11 @@ def add_agent_up_subparser(subparsers: argparse._SubParsersAction) -> None:
     parser.add_argument("--det-version", type=str, default=None, help="version or commit to use")
     parser.add_argument("--agent-name", type=str, default="det-agent", help="agent name")
     parser.add_argument("--no-gpu", help="disable GPU support", action="store_true")
+    parser.add_argument(
+        "--no-autorestart",
+        help="disable container auto-restart (recommended for local development)",
+        action="store_true",
+    )
 
 
 def add_agent_down_subparser(subparsers: argparse._SubParsersAction) -> None:
@@ -145,6 +160,7 @@ def handle_fixture_up(args):
         hasura_secret=args.hasura_secret,
         delete_db=args.delete_db,
         no_gpu=args.no_gpu,
+        autorestart=(not args.no_autorestart),
     )
 
 
@@ -165,6 +181,7 @@ def handle_master_up(args):
         db_password=args.db_password,
         hasura_secret=args.hasura_secret,
         delete_db=args.delete_db,
+        autorestart=(not args.no_autorestart),
     )
 
 
@@ -180,6 +197,7 @@ def handle_agent_up(args):
         agent_name=args.agent_name,
         version=args.det_version,
         labels=None,
+        autorestart=(not args.no_autorestart),
     )
 
 

--- a/deploy/determined_deploy/local/docker-compose.yaml
+++ b/deploy/determined_deploy/local/docker-compose.yaml
@@ -5,7 +5,7 @@ services:
     image: postgres:10.8
     volumes:
       - determined-db-volume:/var/lib/postgresql/data
-    restart: always
+    restart: unless-stopped
     environment:
       POSTGRES_DB: determined
       POSTGRES_PASSWORD: ${DET_DB_PASSWORD}
@@ -15,7 +15,7 @@ services:
 
   determined-graphql:
     image: hasura/graphql-engine:v1.1.0
-    restart: always
+    restart: unless-stopped
     environment:
       HASURA_GRAPHQL_ADMIN_SECRET: "${DET_HASURA_SECRET}"
       HASURA_GRAPHQL_CONSOLE_ASSETS_DIR: /srv/console-assets
@@ -27,6 +27,7 @@ services:
 
   determined-master:
     init: true
+    restart: ${DET_RESTART_POLICY:-unless-stopped}
     depends_on:
       - determined-db
       - determined-graphql

--- a/tests/integrations/conftest.py
+++ b/tests/integrations/conftest.py
@@ -63,6 +63,7 @@ def cluster_log_manager(request: SubRequest) -> Optional[ClusterLogManager]:
             delete_db=False,
             version=None,
             no_gpu=False,
+            autorestart=False,
         )
         with ClusterLogManager("integrations") as clm:
             # Yield instead of return so that `__exit__` is called when the

--- a/webui/tests/bin/e2e-tests.py
+++ b/webui/tests/bin/e2e-tests.py
@@ -48,6 +48,7 @@ def pre_e2e_tests(config):
             "1",
             "--no-gpu",
             "--delete-db",
+            "--no-autorestart",
             "--master-port",
             config["INTEGRATIONS_HOST_PORT"],
         ],


### PR DESCRIPTION
Adding a restart policy to all of the docker containers made with `det-deploy local` so that they are tolerant against system restarts and Docker restarts.  Used the "unless-stopped" policy per @brain-good 's suggestion to avoid confusion if containers are manually killed.