### PR TITLE
[DET-2757] grab back control after loading native implementation.

### DIFF
--- a/harness/determined/_native.py
+++ b/harness/determined/_native.py
@@ -212,6 +212,10 @@ def make_test_experiment_env(
     return env, workloads, rendezvous_info, hvd_config
 
 
+def _stop_loading_implementation() -> None:
+    raise det.errors.StopLoadingImplementation()
+
+
 def create_trial_instance(
     trial_def: Type[det.Trial], checkpoint_dir: str, config: Optional[Dict[str, Any]] = None
 ) -> det.Trial:
@@ -292,6 +296,7 @@ def create(
             load.RunpyGlobals.set_runpy_trial_result(
                 trial_def, cast(Type[det.TrialController], trial_def.trial_controller_class)
             )
+            _stop_loading_implementation()
 
         else:
             create_experiment(
@@ -345,6 +350,7 @@ def _init_native(
                 hvd_config=load.RunpyGlobals.get_instance().hvd_config,
             )
             load.RunpyGlobals.set_runpy_native_result(context, controller_cls)
+            context._set_train_fn(_stop_loading_implementation)
             return context
 
         else:

--- a/harness/determined/errors.py
+++ b/harness/determined/errors.py
@@ -39,6 +39,14 @@ class InvalidConfigurationException(InvalidExperimentException):
         super().__init__(f"Invalid configuration ({config}): {message}.")
 
 
+class StopLoadingImplementation(Exception):
+    """
+    Exception that intercepts loading the user code.
+    """
+
+    pass
+
+
 class WorkerError(Exception):
     """
     WorkerError indicates that a worker process failed but we do not know why.


### PR DESCRIPTION
grab back control after loading native implementation

1. Previously, when sys.exit() is called in user code, the trial 
process exits silently. Now, warn users not to exit in their code.

2. The harness grab back control when hit the call of Native 
training API, e.g. det.create(), model.fit(), and train_and_evaluate().


DET-2757 #Done.