### PR TITLE
fix: make local commands required

### DIFF
--- a/deploy/determined_deploy/local/cli.py
+++ b/deploy/determined_deploy/local/cli.py
@@ -127,6 +127,7 @@ def make_local_parser(subparsers: argparse._SubParsersAction) -> None:
     add_master_down_subparser(subparsers)
     add_agent_up_subparser(subparsers)
     add_agent_down_subparser(subparsers)
+    subparsers.required = True
 
 
 def handle_fixture_up(args):


### PR DESCRIPTION
Make the subcommand to `det-deploy local` required.  Results in:

```
$ det-deploy local
usage: det-deploy local [-h]
                        {fixture-up,fixture-down,logs,master-up,master-down,agent-up,agent-down}
                        ...
det-deploy local: error: the following arguments are required: command
```