### PR TITLE
chore: move task container ssh keygen to experiment

### DIFF
--- a/master/pkg/ssh/ssh.go
+++ b/master/pkg/ssh/ssh.go
@@ -11,7 +11,7 @@ import (
 )
 
 const (
-	trialKeySize      = 4096
+	trialKeySize      = 1024
 	trialPEMBlockType = "RSA PRIVATE KEY"
 )
 


### PR DESCRIPTION
When we have an experiment with thousands of trials, we generate an ssh
key for each trial. This becomes very expensive, since ssh keygen is a
cpu intensive operation. To remedy this, we move it to happen in the
experiment and have all trials share a key.

# Test Plan
- UI change:
  - [ ] add screenshots
  - [ ] React? build & check storybooks
- [ ] user-facing api change: modify documentation and examples
- [ ] user-facing api change: add the "User-facing API Change" label
- [ ] bug fix: add regression test
- [ ] bug fix: determine if there are other similar bugs in the codebase
- [ ] new feature: add test coverage for any user-facing aspects
- [ ] refactor: maintain existing code coverage
