### PR TITLE
fix: squash bug in telemetry for trials with no completed steps

### DIFF
--- a/master/internal/db/postgres.go
+++ b/master/internal/db/postgres.go
@@ -414,7 +414,7 @@ WHERE id = $1`, id)
 func (db *PgDB) ExperimentTotalStepTime(id int) (float64, error) {
 	var seconds float64
 	if err := db.sql.Get(&seconds, `
-SELECT extract(epoch from sum(steps.end_time - steps.start_time))
+SELECT coalesce(extract(epoch from sum(steps.end_time - steps.start_time)), 0)
 FROM steps, trials
 WHERE trials.experiment_id = $1 AND steps.trial_id = trials.id
 `, id); err != nil {


### PR DESCRIPTION
In SQL, sum() has the surprising behavior that sum() over an empty set
is NULL, not 0 like you might expect.

# Test Plan
- UI change:
  - [ ] add screenshots
  - [ ] React? build & check storybooks
- [ ] user-facing api change: modify documentation and examples
- [ ] user-facing api change: add the "User-facing API Change" label
- [ ] bug fix: add regression test
- [ ] bug fix: determine if there are other similar bugs in the codebase
- [ ] new feature: add test coverage for any user-facing aspects
- [ ] refactor: maintain existing code coverage
