### PR TITLE
feat: handle localhost for agent-up

### DIFF
--- a/deploy/determined_deploy/local/cluster_utils.py
+++ b/deploy/determined_deploy/local/cluster_utils.py
@@ -167,6 +167,8 @@ def agent_up(
 ) -> None:
     if version is None:
         version = determined_deploy.__version__
+    if master_host == "localhost":
+        master_host = get_proxy_addr()
     image = "determinedai/determined-agent:{}".format(version)
     environment = {
         "DET_MASTER_HOST": master_host,

--- a/docs/how-to/installation/deploy.txt
+++ b/docs/how-to/installation/deploy.txt
@@ -89,12 +89,6 @@ This will create an agent on that machine. To verify whether it has
 successfully connected to the master, navigate to the WebUI and check
 whether slots have appeared on the ``Cluster`` page.
 
-.. note::
-
-   The hostname used must be reachable from within Docker containers
-   running on the agent machine. In particular, ``localhost`` will
-   usually not work, even if the master and agent are running on the
-   same machine. Use the ``--agents`` option in that case instead.
 
 Managing the Cluster
 --------------------


### PR DESCRIPTION
Changed `det-deploy local agent-up` so that it if the hostname provided is `localhost`, it will replace it with the proper hostname to actually connect the trial runners to the master.