### PR TITLE
fix: fixture-down before fixture-up

### DIFF
--- a/deploy/determined_deploy/local/cluster_utils.py
+++ b/deploy/determined_deploy/local/cluster_utils.py
@@ -126,6 +126,7 @@ def fixture_up(
     delete_db: bool,
     no_gpu: bool,
 ):
+    fixture_down(cluster_name, delete_db)
     master_up(
         port=port,
         etc_path=etc_path,


### PR DESCRIPTION
Bring the cluster down before doing `fixture-up`.  This allows for a cleaner upgrade path.