### PR TITLE
[DET-2693] fix: update modal to support flexible height content with auto content scrolling

### DIFF
--- a/webui/elm/src/Modals/Logs.elm
+++ b/webui/elm/src/Modals/Logs.elm
@@ -166,18 +166,10 @@ subscriptions model =
 
 
 renderModal : H.Html Msg -> H.Html Msg
-renderModal c =
+renderModal content =
     Modal.view
-        { content =
-            H.div [ HA.class "overflow-y-hidden", HA.style "height" "60vh" ]
-                [ H.div [ HA.style "height" "100%", HA.class "relative" ]
-                    [ H.div [ HA.class "absolute inset-0" ]
-                        [ c ]
-                    ]
-                ]
-        , attributes =
-            [ HA.style "width" "60vw"
-            ]
+        { content = content
+        , attributes = [ HA.style "width" "60vw" ]
         , closeMsg = CloseModal
         }
 

--- a/webui/elm/src/View/Modal.elm
+++ b/webui/elm/src/View/Modal.elm
@@ -37,7 +37,7 @@ contentView content =
     [ H.div [ HA.class "pl-4 p-2 flex-shrink" ]
         [ content.header ]
     , H.div
-        [ HA.class "flex-grow pl-4 p-2 overflow-y-hidden"
+        [ HA.class "flex-grow pl-4 p-2 overflow-auto"
         ]
         [ content.body ]
     ]
@@ -59,7 +59,7 @@ contentView content =
             else
                 []
            )
-        |> H.div [ HA.class "flex flex-col h-full" ]
+        |> H.div [ HA.class "flex flex-col w-full" ]
 
 
 view : Config msg -> H.Html msg
@@ -86,7 +86,7 @@ view conf =
         , H.div [ HA.class "p-1 fixed inset-0 flex justify-center items-center z-50" ]
             [ H.div
                 (conf.attributes
-                    ++ [ HA.class "p-2 bg-white rounded shadow modal relative"
+                    ++ [ HA.class "flex p-2 bg-white rounded shadow modal relative"
                        , HA.style "min-width" "25rem"
                        , HA.style "max-width" "80vw"
                        , HA.style "max-height" "80vh"


### PR DESCRIPTION
# Test Plan
- UI change:
  - [x] add screenshots

<img width="976" alt="Screen Shot 2020-04-17 at 1 34 01 PM" src="https://user-images.githubusercontent.com/220971/79607580-a93a6f80-80b0-11ea-942b-9d81a3c64349.png">
<img width="975" alt="Screen Shot 2020-04-17 at 1 34 28 PM" src="https://user-images.githubusercontent.com/220971/79607586-ab9cc980-80b0-11ea-8fdc-8c34ac5ef3ef.png">
<img width="976" alt="Screen Shot 2020-04-17 at 1 34 49 PM" src="https://user-images.githubusercontent.com/220971/79607587-ac356000-80b0-11ea-8e27-40177be4a601.png">
<img width="975" alt="Screen Shot 2020-04-17 at 1 35 01 PM" src="https://user-images.githubusercontent.com/220971/79607589-ac356000-80b0-11ea-9747-408e91c7ac8d.png">

