### PR TITLE
fix: add det command to PATH

### DIFF
--- a/master/static/srv/entrypoint.sh
+++ b/master/static/srv/entrypoint.sh
@@ -5,6 +5,7 @@ set -x
 
 WORKING_DIR="/run/determined/workdir"
 STARTUP_HOOK="./startup-hook.sh"
+export PATH="/run/determined/pythonuserbase/bin:$PATH"
 
 python3.6 -m pip install --user /opt/determined/wheels/determined*.whl
 

--- a/master/static/srv/gc-checkpoints-entrypoint.sh
+++ b/master/static/srv/gc-checkpoints-entrypoint.sh
@@ -2,6 +2,8 @@
 
 set -e
 
+export PATH="/run/determined/pythonuserbase/bin:$PATH"
+
 python3.6 -m pip install --user /opt/determined/wheels/determined*.whl
 
 exec python3.6 -m determined.exec.gc_checkpoints "$@"

--- a/master/static/srv/notebook-entrypoint.sh
+++ b/master/static/srv/notebook-entrypoint.sh
@@ -2,6 +2,8 @@
 
 set -e
 
+export PATH="/run/determined/pythonuserbase/bin:$PATH"
+
 python3.6 -m pip install --user /opt/determined/wheels/determined*.whl
 
 jupyter lab --config /run/determined/workdir/jupyter-conf.py

--- a/master/static/srv/tensorboard-entrypoint.sh
+++ b/master/static/srv/tensorboard-entrypoint.sh
@@ -2,6 +2,8 @@
 
 set -e
 
+export PATH="/run/determined/pythonuserbase/bin:$PATH"
+
 STARTUP_HOOK=${STARTUP_HOOK_SCRIPT:-startup-hook.sh}
 
 # Source `startup-hook.sh` before running tensorboard.


### PR DESCRIPTION
Add the det command to the PATH in the entrypoint scripts.

It cannot be set with other environment variables in the master because
the docker.Config object will not do environment variable expansion.

The alternative would be to somehow, in the master, inspect the metadata
for the docker container to get the PATH environment variable, then use
that to set the final PATH, but then you would need to have the image
present on the master for that to work.