### PR TITLE
fix: don't automatically import tf with determined

### DIFF
--- a/harness/determined/__init__.py
+++ b/harness/determined/__init__.py
@@ -1,6 +1,6 @@
 from determined.__version__ import __version__
 from determined._env_context import EnvContext
-from determined._train_context import _DataLayerContext, NativeContext, TrialContext
+from determined._train_context import NativeContext, TrialContext
 from determined._trial import Trial
 from determined._experiment_config import ExperimentConfig
 from determined._hparam import Categorical, Constant, Double, Integer, Log

--- a/harness/determined/_data_layer/__init__.py
+++ b/harness/determined/_data_layer/__init__.py
@@ -1,0 +1,2 @@
+from determined._data_layer._data_layer import _CacheableDecorator
+from determined._data_layer._context import DataLayerContext

--- a/harness/determined/_data_layer/_context.py
+++ b/harness/determined/_data_layer/_context.py
@@ -1,0 +1,114 @@
+from typing import Callable, Union
+
+import determined as det
+from determined import _data_layer, horovod
+
+
+class DataLayerContext:
+    def __init__(
+        self,
+        env: det.EnvContext,
+        hvd_config: horovod.HorovodContext,
+        train_context: Union[det.NativeContext, det.TrialContext],
+    ) -> None:
+        self._training_cacheable = _data_layer._CacheableDecorator(
+            env=env,
+            hvd_config=hvd_config,
+            training=True,
+            per_slot_batch_size=train_context.get_per_slot_batch_size(),
+        )
+        self._validation_cacheable = _data_layer._CacheableDecorator(
+            env=env,
+            hvd_config=hvd_config,
+            training=False,
+            per_slot_batch_size=train_context.get_per_slot_batch_size(),
+        )
+
+    def cache_train_dataset(
+        self,
+        dataset_id: str,
+        dataset_version: str,
+        shuffle: bool = False,
+        skip_shuffle_at_epoch_end: bool = False,
+    ) -> Callable:
+        """cache_train_dataset is a decorator for creating your training dataset.  It should
+        decorate a function that outputs a ``tf.data.Dataset`` object. The dataset will be
+        stored in a cache, keyed by ``dataset_id`` and ``dataset_version``. The cache is re-used
+        re-used in subsequent calls.
+
+        Args:
+            dataset_id: A string that will be used as part of the
+                unique identifier for this dataset.
+
+            dataset_version: A string that will be used as part of the
+                unique identifier for this dataset.
+
+            shuffle: A bool indicating if the dataset should be shuffled. Shuffling will
+                be performed with the trial's random seed which can be set in
+                :ref:`experiment-configuration`.
+
+            skip_shuffle_at_epoch_end: A bool indicating if shuffling should be skipped
+                at the end of epochs.
+
+
+        Example Usage:
+
+        .. code-block:: python
+
+            def make_train_dataset(self):
+                @self.context.experimental.cache_train_dataset("range_dataset", "v1")
+                def make_dataset():
+                    ds = tf.data.Dataset.range(10)
+                    return ds
+
+                dataset = make_dataset()
+                dataset = dataset.batch(self.context.get_per_slot_batch_size())
+                dataset = dataset.map(...)
+                return dataset
+
+        .. note::
+            ``dataset.batch()`` and runtime augmentation should be done after caching.
+            Additionally, users should never need to call ``dataset.repeat()``.
+
+        """
+
+        return self._training_cacheable.cache_dataset(
+            dataset_id=dataset_id,
+            dataset_version=dataset_version,
+            shuffle=shuffle,
+            skip_shuffle_at_epoch_end=skip_shuffle_at_epoch_end,
+        )
+
+    def cache_validation_dataset(
+        self, dataset_id: str, dataset_version: str, shuffle: bool = False,
+    ) -> Callable:
+        """cache_validation_dataset is a decorator for creating your validation dataset.  It should
+        decorate a function that outputs a ``tf.data.Dataset`` object. The dataset will be
+        stored in a cache, keyed by ``dataset_id`` and ``dataset_version``. The cache is re-used
+        re-used in subsequent calls.
+
+        Args:
+            dataset_id: A string that will be used as part of the
+                unique identifier for this dataset.
+
+            dataset_version: A string that will be used as part of the
+                unique identifier for this dataset.
+
+            shuffle: A bool indicating if the dataset should be shuffled. Shuffling will
+                be performed with the trial's random seed which can be set in
+                :ref:`experiment-configuration`.
+
+        """
+
+        return self._validation_cacheable.cache_dataset(
+            dataset_id=dataset_id,
+            dataset_version=dataset_version,
+            shuffle=shuffle,
+            skip_shuffle_at_epoch_end=True,
+        )
+
+    def get_train_cacheable(self) -> _data_layer._CacheableDecorator:
+        return self._training_cacheable
+
+    def get_validation_cacheable(self) -> _data_layer._CacheableDecorator:
+        return self._validation_cacheable

--- a/harness/determined/_train_context.py
+++ b/harness/determined/_train_context.py
@@ -1,9 +1,9 @@
 import abc
 import logging
-from typing import Any, Callable, Dict, Optional, Union, cast
+from typing import Any, Callable, Dict, Optional, cast
 
 import determined as det
-from determined import data_layer, horovod
+from determined import horovod
 
 
 class _TrainContext(metaclass=abc.ABCMeta):
@@ -152,113 +152,3 @@ class DistributedContext:
             return 1
 
         return cast(int, self.get_size() // horovod.hvd.local_size())
-
-
-class _DataLayerContext:
-    def __init__(
-        self,
-        env: det.EnvContext,
-        hvd_config: horovod.HorovodContext,
-        train_context: Union[NativeContext, TrialContext],
-    ) -> None:
-        self._training_cacheable = data_layer.CacheableDecorator(
-            env=env,
-            hvd_config=hvd_config,
-            training=True,
-            per_slot_batch_size=train_context.get_per_slot_batch_size(),
-        )
-        self._validation_cacheable = data_layer.CacheableDecorator(
-            env=env,
-            hvd_config=hvd_config,
-            training=False,
-            per_slot_batch_size=train_context.get_per_slot_batch_size(),
-        )
-
-    def cache_train_dataset(
-        self,
-        dataset_id: str,
-        dataset_version: str,
-        shuffle: bool = False,
-        skip_shuffle_at_epoch_end: bool = False,
-    ) -> Callable:
-        """cache_train_dataset is a decorator for creating your training dataset.  It should
-        decorate a function that outputs a ``tf.data.Dataset`` object. The dataset will be
-        stored in a cache, keyed by ``dataset_id`` and ``dataset_version``. The cache is re-used
-        re-used in subsequent calls.
-
-        Args:
-            dataset_id: A string that will be used as part of the
-                unique identifier for this dataset.
-
-            dataset_version: A string that will be used as part of the
-                unique identifier for this dataset.
-
-            shuffle: A bool indicating if the dataset should be shuffled. Shuffling will
-                be performed with the trial's random seed which can be set in
-                :ref:`experiment-configuration`.
-
-            skip_shuffle_at_epoch_end: A bool indicating if shuffling should be skipped
-                at the end of epochs.
-
-
-        Example Usage:
-
-        .. code-block:: python
-
-            def make_train_dataset(self):
-                @self.context.experimental.cache_train_dataset("range_dataset", "v1")
-                def make_dataset():
-                    ds = tf.data.Dataset.range(10)
-                    return ds
-
-                dataset = make_dataset()
-                dataset = dataset.batch(self.context.get_per_slot_batch_size())
-                dataset = dataset.map(...)
-                return dataset
-
-        .. note::
-            ``dataset.batch()`` and runtime augmentation should be done after caching.
-            Additionally, users should never need to call ``dataset.repeat()``.
-
-        """
-
-        return self._training_cacheable.cache_dataset(
-            dataset_id=dataset_id,
-            dataset_version=dataset_version,
-            shuffle=shuffle,
-            skip_shuffle_at_epoch_end=skip_shuffle_at_epoch_end,
-        )
-
-    def cache_validation_dataset(
-        self, dataset_id: str, dataset_version: str, shuffle: bool = False,
-    ) -> Callable:
-        """cache_validation_dataset is a decorator for creating your validation dataset.  It should
-        decorate a function that outputs a ``tf.data.Dataset`` object. The dataset will be
-        stored in a cache, keyed by ``dataset_id`` and ``dataset_version``. The cache is re-used
-        re-used in subsequent calls.
-
-        Args:
-            dataset_id: A string that will be used as part of the
-                unique identifier for this dataset.
-
-            dataset_version: A string that will be used as part of the
-                unique identifier for this dataset.
-
-            shuffle: A bool indicating if the dataset should be shuffled. Shuffling will
-                be performed with the trial's random seed which can be set in
-                :ref:`experiment-configuration`.
-
-        """
-
-        return self._validation_cacheable.cache_dataset(
-            dataset_id=dataset_id,
-            dataset_version=dataset_version,
-            shuffle=shuffle,
-            skip_shuffle_at_epoch_end=True,
-        )
-
-    def get_train_cacheable(self) -> data_layer.CacheableDecorator:
-        return self._training_cacheable
-
-    def get_validation_cacheable(self) -> data_layer.CacheableDecorator:
-        return self._validation_cacheable

--- a/harness/determined/estimator/_estimator_context.py
+++ b/harness/determined/estimator/_estimator_context.py
@@ -4,7 +4,7 @@ from typing import Any, Callable, Dict, Union
 import tensorflow as tf
 
 import determined as det
-from determined import horovod
+from determined import _data_layer, horovod
 from determined.horovod import hvd
 from determined_common import check
 
@@ -129,7 +129,7 @@ class EstimatorNativeContext(det.NativeContext, EstimatorContext):
             self._train_fn()
 
 
-class EstimatorExperimentalContext(det._DataLayerContext):
+class EstimatorExperimentalContext(_data_layer.DataLayerContext):
     """
     Context class that contains experimental runtime information and features
     for any Determined workflow that uses the ``tf.estimator`` API.

--- a/harness/determined/keras/__init__.py
+++ b/harness/determined/keras/__init__.py
@@ -15,7 +15,7 @@ from determined.keras._tf_keras_context import (
     TFKerasTrainConfig,
     TFKerasTrialContext,
 )
-from determined.keras._tf_keras_inputs import _init_input_manager
+from determined.keras._tf_keras_inputs import _init_input_managers
 from determined.keras._tf_keras_multi_gpu import _get_multi_gpu_model_and_optimizer
 from determined.keras._tf_keras_trial import TFKerasTrial, TFKerasTrialController
 from determined.keras._tf_keras_native import init

--- a/harness/determined/keras/_tf_keras_context.py
+++ b/harness/determined/keras/_tf_keras_context.py
@@ -5,7 +5,7 @@ from typing import Any, Callable, List, NamedTuple, Optional, Union
 import tensorflow as tf
 
 import determined as det
-from determined import errors, horovod, keras
+from determined import _data_layer, errors, horovod, keras
 from determined.horovod import hvd
 
 
@@ -219,7 +219,7 @@ class TFKerasNativeContext(det.NativeContext, TFKerasContext):
         return self._wrap_model_with_train_fn(model, self._train_fn)
 
 
-class TFKerasExperimentalContext(det._DataLayerContext):
+class TFKerasExperimentalContext(_data_layer.DataLayerContext):
     """
     Context class that contains experimental runtime information and features
     for any Determined workflow that uses the ``tf.keras`` API.

--- a/harness/determined/keras/_tf_keras_inputs.py
+++ b/harness/determined/keras/_tf_keras_inputs.py
@@ -269,7 +269,7 @@ class _ValidationSequenceAdapterManager(_ValidationInputManager):
         return len(sequence_adapter) * self._context.get_per_slot_batch_size()
 
 
-def _init_input_manager(
+def _init_input_managers(
     context: Union[keras.TFKerasTrialContext, keras.TFKerasNativeContext],
     train_config: keras.TFKerasTrainConfig,
 ) -> Tuple[_TrainingInputManager, _ValidationInputManager]:

--- a/harness/determined/keras/_tf_keras_trial.py
+++ b/harness/determined/keras/_tf_keras_trial.py
@@ -175,7 +175,7 @@ class TFKerasTrialController(det.LoopTrialController):
         self.model = model
         self.session = session
 
-        self._train_input_manager, self._validation_input_manager = keras._init_input_manager(
+        self._train_input_manager, self._validation_input_manager = keras._init_input_managers(
             context=self.context, train_config=train_config
         )
 


### PR DESCRIPTION
Previously we imported data_layer (which imports tf) with
the default train_context. We now import it only for the
contexts for estimators and tf.keras, which already have
tf imported.
