### PR TITLE
ci: release with Jenkins

### DIFF
--- a/CI/jenkins/Publish.Jenkinsfile
+++ b/CI/jenkins/Publish.Jenkinsfile
@@ -1,0 +1,26 @@
+describeNode = "echo \"Running on \${NODE_NAME} (executor: \${EXECUTOR_NUMBER})\""
+
+pipeline {
+  agent { label 'test' }
+  environment {
+    DET_SEGMENT_MASTER_KEY = credentials('prod-determinedai-segment-master-key')
+    DET_SEGMENT_WEBUI_KEY = credentials('prod-determinedai-segment-webui-key')
+    DET_DOCKERHUB_CREDS = credentials('dockerhub-determinedai-dev')
+    DET_TWINE_CREDS = credentials('determined-twine-credentials')
+    TWINE_USERNAME = "${env.DET_TWINE_CREDS_USR}"
+    TWINE_PASSWORD = "${env.DET_TWINE_CREDS_PSW}"
+    GITHUB_TOKEN = credentials('determined-ci-github-access')
+    DOCKER_REGISTRY = ""
+  }
+  stages {
+    stage('Publish') {
+      steps {
+        sh "${describeNode}"
+        sh "docker login -u ${env.DET_DOCKERHUB_CREDS_USR} -p ${env.DET_DOCKERHUB_CREDS_PSW}"
+        sh 'virtualenv --python="$(command -v python3.6)" venv'
+        sh '. venv/bin/activate && make get-deps'
+        sh '. venv/bin/activate && make publish'
+      }
+    }
+  }
+}

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,6 @@
   graphql-schema \
   pin-deps \
   upgrade-deps \
-  upload-try-now-template \
   publish \
   test \
   test-all \
@@ -165,6 +164,7 @@ publish: guard-publish clean all
 	$(MAKE) -C common $@
 	$(MAKE) -C harness $@
 	$(MAKE) -C cli $@
+	$(MAKE) -C deploy $@
 
 	cp -r packaging "$(BUILDDIR)"
 	cd "$(BUILDDIR)" && $(GOBIN)/goreleaser -f $(CURDIR)/.goreleaser.yml --rm-dist
@@ -172,13 +172,6 @@ publish: guard-publish clean all
 	# Upload the docs last because it updates the terraform state file,
 	# which dirties the working directory.
 	$(MAKE) -C docs $@
-
-upload-try-now-template: TRY_NOW_TEMPLATE = simple.yaml
-upload-try-now-template: TRY_NOW_URL := s3://determined-ai-public/$(TRY_NOW_TEMPLATE)
-upload-try-now-template: TEMPLATE_PATH := deploy/determined_deploy/aws/templates/$(TRY_NOW_TEMPLATE)
-upload-try-now-template:
-	aws s3 cp $(TEMPLATE_PATH) $(TRY_NOW_URL) --acl public-read
-
 
 # This target assumes that a Hasura instance is running and queries it to
 # retrieve the current schema files, producing a schema file that the

--- a/cli/Makefile
+++ b/cli/Makefile
@@ -4,8 +4,6 @@ VERSION := $(shell cat ../VERSION)
 BUILDDIR ?= ../build
 DIST_DIRECTORY := "$(BUILDDIR)"/share/determined/master/wheels
 CLI_WHEEL := $(DIST_DIRECTORY)/determined_cli-$(VERSION)-py3-none-any.whl
-CLI_WHEEL_URL := s3://determined-ai-artifacts/cli/$(shell basename $(CLI_WHEEL))
-CLI_WHEEL_LATEST_URL := s3://determined-ai-artifacts/cli/determined_cli-latest-py3-none-any.whl
 
 clean:
 	rm -rf .pytest_cache/
@@ -20,13 +18,6 @@ build:
 	python setup.py -q bdist_wheel -d $(DIST_DIRECTORY)
 
 publish:
-	aws s3 ls $(CLI_WHEEL_URL); \
-	if [ $$? -eq 0 ] ; then \
-	  echo "Cannot overwrite existing package: $(CLI_WHEEL_URL)"; exit 1; \
-	fi
-
-	aws s3 cp --content-type "binary/octet-stream" $(CLI_WHEEL) $(CLI_WHEEL_URL)
-	aws s3 cp --content-type "binary/octet-stream" $(CLI_WHEEL) $(CLI_WHEEL_LATEST_URL)
 	twine upload --non-interactive $(CLI_WHEEL)
 
 BLACK_CONFIG_FILE := ../pyproject.toml

--- a/common/Makefile
+++ b/common/Makefile
@@ -9,8 +9,6 @@ VERSION := $(shell cat ../VERSION)
 BUILDDIR ?= ../build
 DIST_DIRECTORY := "$(BUILDDIR)"/share/determined/master/wheels
 COMMON_WHEEL := $(DIST_DIRECTORY)/determined_common-$(VERSION)-py3-none-any.whl
-COMMON_WHEEL_URL := s3://determined-ai-artifacts/common/$(shell basename $(COMMON_WHEEL))
-COMMON_WHEEL_LATEST_URL := s3://determined-ai-artifacts/common/determined_common-latest-py3-none-any.whl
 
 clean:
 	rm -rf .pytest_cache/
@@ -23,13 +21,6 @@ build:
 	python setup.py -q bdist_wheel -d $(DIST_DIRECTORY)
 
 publish:
-	aws s3 ls $(COMMON_WHEEL_URL); \
-	if [ $$? -eq 0 ] ; then \
-	  echo "Cannot overwrite existing package: $(COMMON_WHEEL_URL)"; exit 1; \
-	fi
-
-	aws s3 cp --content-type "binary/octet-stream" $(COMMON_WHEEL) $(COMMON_WHEEL_URL)
-	aws s3 cp --content-type "binary/octet-stream" $(COMMON_WHEEL) $(COMMON_WHEEL_LATEST_URL)
 	twine upload --non-interactive $(COMMON_WHEEL)
 
 BLACK_CONFIG_FILE := ../pyproject.toml

--- a/deploy/Makefile
+++ b/deploy/Makefile
@@ -1,22 +1,20 @@
-.PHONY: clean build publish fmt check test
+.PHONY: clean build publish upload-try-now-template fmt check test
 
 VERSION := $(shell cat ../VERSION)
 BUILDDIR ?= ../build
 DEPLOY_WHEEL := $(BUILDDIR)/determined_deploy-$(VERSION)-py3-none-any.whl
-DEPLOY_WHEEL_URL := s3://determined-ai-artifacts/deploy/$(shell basename $(DEPLOY_WHEEL))
-DEPLOY_WHEEL_LATEST_URL := s3://determined-ai-artifacts/deploy/determined_deploy-latest-py3-none-any.whl
 
 build:
 	python setup.py bdist_wheel -d $(DIST_DIRECTORY)
 
-publish:
-	aws s3 ls $(DEPLOY_WHEEL_URL); \
-	if [ $$? -eq 0 ] ; then \
-	  echo "Cannot overwrite existing package: $(DEPLOY_WHEEL_URL)"; exit 1; \
-	fi
+upload-try-now-template: TRY_NOW_TEMPLATE = simple.yaml
+upload-try-now-template: TRY_NOW_URL := s3://determined-ai-public/$(TRY_NOW_TEMPLATE)
+upload-try-now-template: TEMPLATE_PATH := determined_deploy/aws/templates/$(TRY_NOW_TEMPLATE)
+upload-try-now-template:
+	aws s3 cp $(TEMPLATE_PATH) $(TRY_NOW_URL) --acl public-read
 
-	aws s3 cp --content-type "binary/octet-stream" $(DEPLOY_WHEEL) $(DEPLOY_WHEEL_URL)
-	aws s3 cp --content-type "binary/octet-stream" $(DEPLOY_WHEEL) $(DEPLOY_WHEEL_LATEST_URL)
+publish: upload-try-now-template
+	twine upload --non-interactive $(DEPLOY_WHEEL)
 
 clean:
 	rm -rf .pytest_cache/

--- a/harness/Makefile
+++ b/harness/Makefile
@@ -4,8 +4,6 @@ VERSION := $(shell cat ../VERSION)
 BUILDDIR ?= ../build
 DIST_DIRECTORY := "$(BUILDDIR)"/share/determined/master/wheels
 HARNESS_WHEEL := $(DIST_DIRECTORY)/determined-$(VERSION)-py3-none-any.whl
-HARNESS_WHEEL_URL := s3://determined-ai-artifacts/determined/$(shell basename $(HARNESS_WHEEL))
-HARNESS_WHEEL_LATEST_URL := s3://determined-ai-artifacts/determined/determined-latest-py3-none-any.whl
 
 clean:
 	rm -rf .pytest_cache/
@@ -20,13 +18,6 @@ build:
 	python setup.py -q bdist_wheel -d $(DIST_DIRECTORY)
 
 publish:
-	aws s3 ls $(HARNESS_WHEEL_URL); \
-	if [ $$? -eq 0 ] ; then \
-	  echo "Cannot overwrite existing package: $(HARNESS_WHEEL_URL)"; exit 1; \
-	fi
-
-	aws s3 cp --content-type "binary/octet-stream" $(HARNESS_WHEEL) $(HARNESS_WHEEL_URL)
-	aws s3 cp --content-type "binary/octet-stream" $(HARNESS_WHEEL) $(HARNESS_WHEEL_LATEST_URL)
 	twine upload --non-interactive $(HARNESS_WHEEL)
 
 BLACK_CONFIG_FILE := ../pyproject.toml


### PR DESCRIPTION
- remove the AWS S3 publish of Python packages now that we are using PyPI
- credentials are handled by Jenkins
- will be run based on git tags pushed to upstream