### PR TITLE
fix: add missing arguments to GraphQL schema update command

### DIFF
--- a/webui/elm/package.json
+++ b/webui/elm/package.json
@@ -27,6 +27,6 @@
     "format": "elm-format",
     "lint": "elm-analyse && elm-format",
     "test": "elm-test",
-    "graphql": "elm-graphql --base DetQL --scalar-codecs CustomScalarCodecs"
+    "graphql": "elm-graphql --base DetQL --scalar-codecs CustomScalarCodecs --introspection-file ../../master/graphql-schema.json"
   }
 }


### PR DESCRIPTION
Guess there was a copy/paste error during the npm migration.

# Test Plan
- [x] run `npm run graphql`