### PR TITLE
[DET-2776] fix: respect shared_fs storage_path configuration in tensorboard

### DIFF
--- a/harness/determined/tensorboard/build.py
+++ b/harness/determined/tensorboard/build.py
@@ -54,7 +54,11 @@ def build(env: det.EnvContext, checkpoint_config: Dict[str, Any]) -> base.Tensor
 
     if type_name == "shared_fs":
         return shared.SharedFSTensorboardManager(
-            checkpoint_config["container_path"], base_path, sync_path
+            checkpoint_config["host_path"],
+            checkpoint_config["container_path"],
+            checkpoint_config.get("storage_path", None),
+            base_path,
+            sync_path,
         )
 
     elif type_name == "gcs":

--- a/harness/determined/tensorboard/shared.py
+++ b/harness/determined/tensorboard/shared.py
@@ -1,9 +1,10 @@
 import os
 import pathlib
 import shutil
-from typing import Any
+from typing import Any, Optional
 
 from determined.tensorboard import base
+from determined_common.storage.shared import _full_storage_dir
 
 
 class SharedFSTensorboardManager(base.TensorboardManager):
@@ -12,9 +13,18 @@ class SharedFSTensorboardManager(base.TensorboardManager):
     The host_path must be present on each agent machine.
     """
 
-    def __init__(self, container_path: str, *args: Any, **kwargs: Any) -> None:
+    def __init__(
+        self,
+        host_path: str,
+        container_path: str,
+        storage_path: Optional[str],
+        *args: Any,
+        **kwargs: Any
+    ) -> None:
         super().__init__(*args, **kwargs)
-        self.container_path = pathlib.Path(container_path)
+        self.container_path = pathlib.Path(
+            _full_storage_dir(host_path, container_path, storage_path)
+        )
         self.shared_fs_base = self.container_path.joinpath(self.sync_path)
 
         # Set umask to 0 in order that the storage dir allows future containers of any owner to

--- a/tests/unit/tensorboard/test_base.py
+++ b/tests/unit/tensorboard/test_base.py
@@ -6,25 +6,48 @@ from determined import tensorboard
 from determined.tensorboard import SharedFSTensorboardManager
 from tests.unit.tensorboard import test_util
 
+HOST_PATH = pathlib.Path(__file__).resolve().parent.joinpath("test_tensorboard_host")
+STORAGE_PATH = HOST_PATH.joinpath("test_storage_path")
 CONTAINER_PATH = pathlib.Path(__file__).resolve().parent.joinpath("test_tensorboard")
 BASE_PATH = pathlib.Path(__file__).resolve().parent.joinpath("fixtures")
 
 
 def test_getting_manager_instance(tmp_path: pathlib.Path) -> None:
-    checkpoint_config = {"type": "shared_fs", "container_path": tmp_path}
+    checkpoint_config = {"type": "shared_fs", "host_path": HOST_PATH, "container_path": tmp_path}
     manager = tensorboard.build(test_util.get_dummy_env(), checkpoint_config)
     assert isinstance(manager, SharedFSTensorboardManager)
 
 
 def test_setting_optional_variable(tmp_path: pathlib.Path) -> None:
-    checkpoint_config = {"type": "shared_fs", "base_path": "test_value", "container_path": tmp_path}
+    checkpoint_config = {
+        "type": "shared_fs",
+        "base_path": "test_value",
+        "host_path": HOST_PATH,
+        "container_path": tmp_path,
+    }
     manager = tensorboard.build(test_util.get_dummy_env(), checkpoint_config)
     assert isinstance(manager, SharedFSTensorboardManager)
     assert manager.base_path == pathlib.Path("test_value/tensorboard")
 
 
+def test_setting_storage_path(tmp_path: pathlib.Path) -> None:
+    checkpoint_config = {
+        "type": "shared_fs",
+        "host_path": str(HOST_PATH),
+        "container_path": tmp_path,
+        "storage_path": str(STORAGE_PATH),
+    }
+    manager = tensorboard.build(test_util.get_dummy_env(), checkpoint_config)
+    assert isinstance(manager, SharedFSTensorboardManager)
+    assert manager.container_path == tmp_path.joinpath("test_storage_path")
+
+
 def test_unknown_type() -> None:
-    checkpoint_config = {"type": "unknown", "container_path": CONTAINER_PATH}
+    checkpoint_config = {
+        "type": "unknown",
+        "host_path": HOST_PATH,
+        "container_path": CONTAINER_PATH,
+    }
     with pytest.raises(TypeError, match="Unknown storage type: unknown"):
         tensorboard.build(test_util.get_dummy_env(), checkpoint_config)
 
@@ -41,7 +64,12 @@ def test_illegal_type() -> None:
 
 
 def test_list_directory(tmp_path: pathlib.Path) -> None:
-    checkpoint_config = {"type": "shared_fs", "base_path": BASE_PATH, "container_path": tmp_path}
+    checkpoint_config = {
+        "type": "shared_fs",
+        "base_path": BASE_PATH,
+        "host_path": HOST_PATH,
+        "container_path": tmp_path,
+    }
     manager = tensorboard.build(test_util.get_dummy_env(), checkpoint_config)
 
     full_event_path = BASE_PATH.joinpath("tensorboard", "events.out.tfevents.example")
@@ -51,7 +79,12 @@ def test_list_directory(tmp_path: pathlib.Path) -> None:
 
 def test_list_nonexistent_directory(tmp_path: pathlib.Path) -> None:
     base_path = "/non-existent-directory"
-    checkpoint_config = {"type": "shared_fs", "base_path": base_path, "container_path": tmp_path}
+    checkpoint_config = {
+        "type": "shared_fs",
+        "base_path": base_path,
+        "host_path": HOST_PATH,
+        "container_path": tmp_path,
+    }
 
     manager = tensorboard.build(test_util.get_dummy_env(), checkpoint_config)
     assert not pathlib.Path(base_path).exists()


### PR DESCRIPTION
Previously, tensorboard.shared_fs manager did not use the storage_path
configuration to calculate its base path. Now it uses the same logic as
the shared_fs storage manager.

# Test Plan
- UI change:
  - [ ] add screenshots
  - [ ] React? build & check storybooks
- [ ] user-facing api change: modify documentation and examples
- [ ] user-facing api change: add the "User-facing API Change" label
- [x] bug fix: add regression test
- [ ] bug fix: determine if there are other similar bugs in the codebase
- [ ] new feature: add test coverage for any user-facing aspects
- [ ] refactor: maintain existing code coverage
