### PR TITLE
docs: minor fixes for tutorials

### DIFF
--- a/docs/reference/api/pytorch.txt
+++ b/docs/reference/api/pytorch.txt
@@ -24,9 +24,9 @@ determined.pytorch
 Data Loading
 ~~~~~~~~~~~~
 
-Loading data into ``PyTorchTrial`` models is done by defining a
-``build_training_data_loader()`` and ``build_validation_data_loader()``
-function. These functions must each return an instance of
+Loading data into ``PyTorchTrial`` models is done by defining two functions,
+``build_training_data_loader()`` and ``build_validation_data_loader()``.
+These functions should each return an instance of
 ``determined.pytorch.DataLoader``.  ``determined.pytorch.DataLoader`` behaves
 the same as ``torch.utils.data.DataLoader`` and is a drop-in replacement.
 

--- a/docs/tutorials/pytorch-mnist-tutorial.txt
+++ b/docs/tutorials/pytorch-mnist-tutorial.txt
@@ -13,6 +13,7 @@ Prerequisites
 
 Overview
 --------
+
 To use a PyTorch model in Determined, you need to port the model to Determined's API. For most models, this porting process is straightforward, and once the model has been ported, all of the features of Determined will then be available: for example, you can do :ref:`distributed training <multi-gpu-training>` or :ref:`hyperparameter search <hyperparameter-tuning>` without changing your model code, and Determined will store and visualize your model metrics automatically.
 
 When training a PyTorch model, Determined provides a built-in training loop that feeds batches of data into your forward pass, performs backpropagation, and computes training metrics. Determined also handles checkpointing, log management, and device initialization. To plug your model code into the Determined training loop, you define methods to perform the following tasks:
@@ -30,6 +31,7 @@ The complete code for this tutorial can be found here: `mnist_pytorch <https://g
 
 Building a ``PyTorchTrial`` Class
 ---------------------------------
+
 Here is what the skeleton of our trial class looks like:
 
 .. code:: python
@@ -56,17 +58,17 @@ Here is what the skeleton of our trial class looks like:
             pass
 
         def evaluate_batch(self, batch: TorchData, model: nn.Module):
-            # Define how to evaluate the model by calculating loss and other metrics 
+            # Define how to evaluate the model by calculating loss and other metrics
             # for a batch of validation data.
             pass
 
         def build_training_data_loader(self):
-            # Create the training data loader. 
+            # Create the training data loader.
             # This should return a determined.pytorch.Dataset.
             pass
 
         def build_validation_data_loader(self):
-            # Create the validation data loader. 
+            # Create the validation data loader.
             # This should return a determined.pytorch.Dataset.
             pass
 
@@ -74,6 +76,7 @@ We now discuss how to implement each of these methods in more detail.
 
 Initialization
 """"""""""""""
+
 As with any Python class, the ``__init__`` method is invoked to construct our trial class. Determined passes this method a single parameter, :class:`TrialContext <determined.TrialContext>`. The trial context contains information about the trial, such as the values of the hyperparameters to use for training. For the time being, we don't need to access any properties from the trial context object, but we assign it to an instance variable so that we can use it later:
 
 .. code:: python
@@ -84,7 +87,8 @@ As with any Python class, the ``__init__`` method is invoked to construct our tr
 
 Building the Model
 """"""""""""""""""
-The ``build_model`` method returns a ``torch.Module`` or ``torch.Sequential`` object. The MNIST model code uses the Torch Sequential API and we can continue to use that API in our implementation of ``build_model``. We also access the hyperparameter for our model by the trial context with the function ``get_hparam()``. 
+
+The ``build_model`` method returns a ``torch.Module`` or ``torch.Sequential`` object. The MNIST model code uses the Torch Sequential API and we can continue to use that API in our implementation of ``build_model``. The current values of the model's hyperparameters can be accessed via the :func:`get_hparam <determined.TrialContext.get_hparam>` method of the trial context.
 
 .. code:: python
 
@@ -109,10 +113,12 @@ The ``build_model`` method returns a ``torch.Module`` or ``torch.Sequential`` ob
             nn.LogSoftmax(),
         )
 
+        reset_parameters(model)
+        return model
 
 Defining the Optimizer
 """"""""""""""""""""""
-The ``optimizer`` method returns a ``torch.optim`` object. The MNIST model code uses the ``torch.optim.Adadelta`` and we can continue to use that in our implementation of ``optimizer``.
+The ``optimizer`` method returns a ``torch.optim`` object. The MNIST model code uses ``torch.optim.Adadelta`` and we can continue to use that in our implementation of ``optimizer``.
 
 .. code:: python
 
@@ -122,8 +128,7 @@ The ``optimizer`` method returns a ``torch.optim`` object. The MNIST model code 
 Loading Data
 """"""""""""""""
 
-The last two methods we need to define are ``build_training_data_loader`` and ``build_validation_data_loader``. Determined uses these methods to load the training and validation datasets, respectively. This method should return a ``determined.pytorch.DataLoader``, which is very similar to ``torch.utils.data.DataLoader``.  
-
+The last two methods we need to define are ``build_training_data_loader`` and ``build_validation_data_loader``. Determined uses these methods to load the training and validation datasets, respectively. This method should return a :ref:`determined.pytorch.DataLoader <pytorch-data-loading>`, which is very similar to ``torch.utils.data.DataLoader``.
 
 .. code:: python
 
@@ -213,6 +218,7 @@ For more information on experiment configuration, see the :ref:`experiment confi
 
 Running an Experiment
 ---------------------
+
 The Determined CLI can be used to create a new experiment, which will immediately start running on the cluster. To do this, we run:
 
 .. code::
@@ -231,6 +237,7 @@ Once the experiment is started, you will see a notification:
 
 Evaluating the Model
 --------------------
+
 Model evaluation is done automatically for you by Determined.
 To access information on both training and validation performance,
 simply go to the WebUI by entering the address of the Determined master
@@ -241,6 +248,7 @@ either via the experiment ID (xxx) or via its description.
 
 Next Steps
 ----------
+
 - :ref:`tf-cifar-tutorial`
 - :ref:`experiment-configuration`
 - :ref:`command-configuration`

--- a/docs/tutorials/tf-mnist-tutorial.txt
+++ b/docs/tutorials/tf-mnist-tutorial.txt
@@ -129,7 +129,7 @@ To create an experiment, we start by writing a configuration file which defines 
 
 .. code:: yaml
 
-    description: fashion_mnist_keras_const_simple
+    description: fashion_mnist_keras_const
     hyperparameters:
         global_batch_size: 32
         dense1: 128
@@ -137,10 +137,9 @@ To create an experiment, we start by writing a configuration file which defines 
         name: single
         metric: val_accuracy
         max_steps: 45
-    min_validation_period: 10
     entrypoint: model_def:FashionMNISTTrial
 
-For this model, we have two hyperparameters: the size of the ``Dense`` layer and the batch size. RRather than specifying the number of batches to train for directly, we instead specify the number of :ref:`steps <concept-step>`. By default, a step consists of 100 batches, so the config file above specifies that the model should be trained on 4500 batches of data or about five epochs. We expect to see about 85% accuracy after five epochs which mimics the original ``tf.keras`` implementation. For higher performance, increase the number of max_steps or use the ``Continue Trial`` function in the WebUI.
+For this model, we have two hyperparameters: the size of the ``Dense`` layer and the batch size. Rather than specifying the number of batches to train for directly, we instead specify the number of :ref:`steps <concept-step>`. By default, a step consists of 100 batches, so the config file above specifies that the model should be trained on 4500 batches of data or about five epochs. The model should reach about 85% accuracy on the validation set after five epochs, which mimics the original ``tf.keras`` implementation.
 
 The ``entrypoint`` specifies the name of the trial class to use. This is useful if our model code contains more than one trial class. In this case, we use an entrypoint of ``model_def:FashionMNISTTrial`` because our trial class is named ``FashionMNISTTrial`` and it is defined in a Python file named ``model_def.py``.
 

--- a/harness/determined/_train_context.py
+++ b/harness/determined/_train_context.py
@@ -66,7 +66,7 @@ class _TrainContext(metaclass=abc.ABCMeta):
 
     def get_hparam(self, name: str) -> Any:
         """
-        Return the hyperparameter value for the given name.
+        Return the current value of the hyperparameter with the given name.
         """
         if name not in self.env.hparams:
             raise ValueError(


### PR DESCRIPTION
* remove min_validation_period from TF experiment config
* add a few links to API docs
* fix typos
* add missing code (returning the model) to PyTorch `build_model`

# Test Plan
- UI change:
  - [ ] add screenshots
  - [ ] React? build & check storybooks
- [ ] user-facing api change: modify documentation and examples
- [ ] user-facing api change: add the "User-facing API Change" label
- [ ] bug fix: add regression test
- [ ] bug fix: determine if there are other similar bugs in the codebase
- [ ] new feature: add test coverage for any user-facing aspects
- [ ] refactor: maintain existing code coverage
