### PR TITLE
chore: disambiguate logs in workload_sequencer

### DIFF
--- a/master/internal/trial_workload_sequencer.go
+++ b/master/internal/trial_workload_sequencer.go
@@ -115,7 +115,7 @@ func (s *trialWorkloadSequencer) WorkloadCompleted(
 		if msg.Workload != w {
 			if msg.Workload.Kind != searcher.CheckpointModel {
 				return errors.Errorf(
-					"illegal non-checkpoint workload completed message received: %s", msg.Workload)
+					"illegal completed message received: expected checkpoint or %s, got %s", w, msg.Workload)
 			}
 		}
 	}


### PR DESCRIPTION
While trying to debug DET-2886, we realized
two codepaths result in the same error and that
the error is not meaningful enough to assist in
debugging.

# Test Plan
- [ ] refactor: maintain existing code coverage
