### PR TITLE
[DET-2875] shift naming of test and submit to local and cluster.

### DIFF
--- a/examples/experimental/native_mnist_estimator/native_impl.py
+++ b/examples/experimental/native_mnist_estimator/native_impl.py
@@ -136,7 +136,7 @@ if __name__ == "__main__":
         default="{}",
     )
     parser.add_argument(
-        "--mode", dest="mode", help="Specifies test mode or submit mode.", default="submit"
+        "--mode", dest="mode", help="Specifies local mode or cluster mode.", default="cluster"
     )
     args = parser.parse_args()
 

--- a/examples/experimental/native_mnist_estimator/trial_impl.py
+++ b/examples/experimental/native_mnist_estimator/trial_impl.py
@@ -19,7 +19,7 @@ if __name__ == "__main__":
         default="{}",
     )
     parser.add_argument(
-        "--mode", dest="mode", help="Specifies test mode or submit mode.", default="submit"
+        "--mode", dest="mode", help="Specifies local mode or cluster mode.", default="cluster"
     )
     args = parser.parse_args()
 

--- a/examples/experimental/native_mnist_pytorch/trial_impl.py
+++ b/examples/experimental/native_mnist_pytorch/trial_impl.py
@@ -20,7 +20,7 @@ if __name__ == "__main__":
         default="{}",
     )
     parser.add_argument(
-        "--mode", dest="mode", help="Specifies test mode or submit mode.", default="submit"
+        "--mode", dest="mode", help="Specifies local mode or cluster mode.", default="cluster"
     )
     args = parser.parse_args()
 

--- a/examples/experimental/native_mnist_tf_keras/native_impl.py
+++ b/examples/experimental/native_mnist_tf_keras/native_impl.py
@@ -66,7 +66,7 @@ if __name__ == "__main__":
         default="{}",
     )
     parser.add_argument(
-        "--mode", dest="mode", help="Specifies test mode or submit mode.", default="submit"
+        "--mode", dest="mode", help="Specifies local mode or cluster mode.", default="cluster"
     )
     parser.add_argument(
         "--use-fit",

--- a/examples/experimental/native_mnist_tf_keras/trial_impl.py
+++ b/examples/experimental/native_mnist_tf_keras/trial_impl.py
@@ -20,7 +20,7 @@ if __name__ == "__main__":
         default="{}",
     )
     parser.add_argument(
-        "--mode", dest="mode", help="Specifies test mode or submit mode.", default="submit"
+        "--mode", dest="mode", help="Specifies local mode or cluster mode.", default="cluster"
     )
     args = parser.parse_args()
 

--- a/harness/determined/estimator/_estimator_native.py
+++ b/harness/determined/estimator/_estimator_native.py
@@ -6,7 +6,7 @@ from determined import estimator
 
 def init(
     config: Optional[Dict[str, Any]] = None,
-    mode: det.Mode = det.Mode.SUBMIT,
+    mode: det.Mode = det.Mode.CLUSTER,
     context_dir: str = "",
     command: Optional[List[str]] = None,
     master_url: Optional[str] = None,
@@ -23,10 +23,10 @@ def init(
         mode:
             The :py:class:`determined.Mode` used when creating an experiment
 
-            1. ``Mode.SUBMIT`` (default): Submit the experiment to a remote
+            1. ``Mode.CLUSTER`` (default): Submit the experiment to a remote
             Determined cluster.
 
-            2. ``Mode.TEST`` (default): Test the experiment in the calling
+            2. ``Mode.LOCAL``: Test the experiment in the calling
             Python process for development / debugging purposes. Run through a
             minimal loop of training, validation, and checkpointing steps.
 

--- a/harness/determined/keras/_tf_keras_native.py
+++ b/harness/determined/keras/_tf_keras_native.py
@@ -6,7 +6,7 @@ from determined import keras
 
 def init(
     config: Optional[Dict[str, Any]] = None,
-    mode: det.Mode = det.Mode.SUBMIT,
+    mode: det.Mode = det.Mode.CLUSTER,
     context_dir: str = "",
     command: Optional[List[str]] = None,
     master_url: Optional[str] = None,
@@ -23,10 +23,10 @@ def init(
         mode:
             The :py:class:`determined.Mode` used when creating an experiment
 
-            1. ``Mode.SUBMIT`` (default): Submit the experiment to a remote
+            1. ``Mode.CLUSTER`` (default): Submit the experiment to a remote
             Determined cluster.
 
-            2. ``Mode.TEST`` (default): Test the experiment in the calling
+            2. ``Mode.LOCAL``: Test the experiment in the calling
             Python process for development / debugging purposes. Run through a
             minimal loop of training, validation, and checkpointing steps.
 

--- a/tests/integrations/experiment/test_native.py
+++ b/tests/integrations/experiment/test_native.py
@@ -198,13 +198,13 @@ def run_warm_start_test(implementation: NativeImplementation) -> None:
         assert trial.warm_start_checkpoint_id == first_checkpoint_id
 
 
-def run_test_mode(implementation: NativeImplementation) -> None:
+def run_local_mode(implementation: NativeImplementation) -> None:
     # TODO(DET-2653): Support run test mode integration test on tf2 using command.
     logging.debug(implementation)
 
     with subprocess.Popen(
         implementation.command
-        + ["--config", json.dumps(implementation.configuration), "--mode", "test"],
+        + ["--config", json.dumps(implementation.configuration), "--mode", "local"],
         cwd=implementation.cwd,
         env={"PYTHONUNBUFFERED": "1", **os.environ},
     ) as p:
@@ -275,6 +275,6 @@ def test_pytorch_warm_start(implementation: NativeImplementation) -> None:
     ],
 )
 @pytest.mark.integ4  # type: ignore
-def test_test_mode(implementation: NativeImplementation) -> None:
+def test_local_mode(implementation: NativeImplementation) -> None:
     cluster_utils.skip_if_not_enough_gpus(implementation.min_num_gpus_required)
-    run_test_mode(implementation)
+    run_local_mode(implementation)

--- a/tests/unit/frameworks/fixtures/estimator_xor_model_experiment.py
+++ b/tests/unit/frameworks/fixtures/estimator_xor_model_experiment.py
@@ -67,7 +67,7 @@ def build_serving_input_receiver_fns() -> Dict[str, ServingInputReceiverFn]:
 
 
 if __name__ == "__main__":
-    context = init(mode=det.Mode.SUBMIT, context_dir=str(pathlib.Path.cwd()))
+    context = init(mode=det.Mode.CLUSTER, context_dir=str(pathlib.Path.cwd()))
 
     batch_size = context.get_per_slot_batch_size()
     shuffle = context.get_hparam("shuffle")

--- a/tests/unit/frameworks/fixtures/tf_keras_runtime_error.py
+++ b/tests/unit/frameworks/fixtures/tf_keras_runtime_error.py
@@ -45,6 +45,6 @@ if __name__ == "__main__":
             "searcher": {"metric": "accuracy"},
             "data_layer": {"type": "lfs", "container_storage_path": "/tmp"},
         },
-        mode=det.Mode.TEST,
+        mode=det.Mode.LOCAL,
         context_dir=str(pathlib.Path.cwd()),
     )

--- a/tests/unit/frameworks/fixtures/tf_keras_xor_model_experiment.py
+++ b/tests/unit/frameworks/fixtures/tf_keras_xor_model_experiment.py
@@ -26,7 +26,7 @@ def make_xor_single_thread_loaders() -> Tuple[tf.keras.utils.Sequence, tf.keras.
 
 
 def train():
-    context = keras.init(mode=det.Mode.SUBMIT, context_dir=str(pathlib.Path.cwd()))
+    context = keras.init(mode=det.Mode.CLUSTER, context_dir=str(pathlib.Path.cwd()))
 
     model = Sequential()
     model.add(Dense(context.get_hparam("hidden_size"), activation="sigmoid", input_shape=(2,)))


### PR DESCRIPTION
Per discussion, the name "test" is unclear of what it does and where it runs. So we change that to be a less confusing name "local" and also "submit" to "cluster" accordingly.

# Test Plan
- [x] user-facing api change: modify documentation and examples
- [x] user-facing api change: add the "User-facing API Change" label
