### PR TITLE
chore: support .dev and rc tags in determined version

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -2,6 +2,17 @@
 current_version = 0.12.1
 commit = true
 message = chore: bump version: {current_version} -> {new_version}
+parse = (?P<major>\d+)\.(?P<minor>\d+)(\.(?P<patch>\d+)((?P<pre>\.dev|a|b|rc|final|post)?((\.dev)?(?P<dev>\d+))?))?
+serialize = 
+	{major}.{minor}.{patch}{pre}{dev}
+	{major}.{minor}.{patch}
+
+[bumpversion:part:pre]
+optional_value = final
+values = 
+	.dev
+	rc
+	final
 
 [bumpversion:file:VERSION]
 


### PR DESCRIPTION
Out of scope: updating the release documentation. That is already out-of-date and will be updated as separate work.

# Test Plan
Verified that the version cycles correctly with the right commands:

```
commit c0ab30d664e98f93b9c94cd2cf876baf98ae0b1f
Author: brian <brian@determined.ai>
Date:   Mon Apr 20 15:30:10 2020 -0700
    chore: bump version: 0.12.2rc1 -> 0.12.2

commit bc396541231207ada60d03c6b388dc8721a9f2d4
Author: brian <brian@determined.ai>
Date:   Mon Apr 20 15:29:52 2020 -0700
    chore: bump version: 0.12.2rc0 -> 0.12.2rc1

commit 709fe2b53276901eea1e78d70d8710a2487c2990
Author: brian <brian@determined.ai>
Date:   Mon Apr 20 15:29:43 2020 -0700
    chore: bump version: 0.12.2.dev0 -> 0.12.2rc0

commit 7d22d0d7ac8a8be132ee5ef09a1b1e42ff3c3a80
Author: brian <brian@determined.ai>
Date:   Mon Apr 20 15:29:33 2020 -0700
    chore: bump version: 0.12.1 -> 0.12.2.dev0

commit 5dcf4b417592970c12ae0d78eef406259c2082dd
Author: brian <brian@determined.ai>
Date:   Mon Apr 20 15:29:21 2020 -0700
    chore: support .dev and rc tags in determined version
```