### PR TITLE
fix: run agent startup_script inside docker

### DIFF
--- a/agent/Dockerfile
+++ b/agent/Dockerfile
@@ -15,5 +15,9 @@ RUN ldconfig
 COPY dist/determined-agent_${VERSION}_linux_amd64.deb /tmp/agent.deb
 RUN apt-get install -y /tmp/agent.deb
 
-ENTRYPOINT ["/usr/bin/determined-agent"]
+COPY share/determined/agent/scripts/entrypoint.sh /run/determined/workdir/entrypoint.sh
+RUN chmod +x /run/determined/workdir/entrypoint.sh
+
+WORKDIR /run/determined/workdir
+ENTRYPOINT [ "/run/determined/workdir/entrypoint.sh" ]
 CMD ["run"]

--- a/agent/Makefile
+++ b/agent/Makefile
@@ -1,6 +1,6 @@
 .PHONY: all \
 	clean get-deps \
-	build build-docker \
+	build build-docker build-files \
 	install-native \
 	test \
 	check fmt \
@@ -36,7 +36,7 @@ all: clean get-deps build
 ######################
 
 clean:
-	rm -f coverage.out "$(BUILDDIR)"/bin/determined-agent
+	rm -f coverage.out "$(BUILDDIR)"/bin/determined-agent "$(BUILDDIR)"/share/determined/agent/
 
 get-deps:
 	cd buildtools && go install golang.org/x/tools/cmd/goimports github.com/rakyll/gotest
@@ -49,7 +49,12 @@ get-deps:
 # Have this here to keep the master and agent symmetric, but nothing actually needs to happen.
 build: ;
 
-build-docker:
+build-files:
+	mkdir -p "$(BUILDDIR)"/share/determined/agent
+	rm -rf "$(BUILDDIR)"/share/determined/agent/scripts
+	cp -r scripts "$(BUILDDIR)"/share/determined/agent
+
+build-docker: build-files
 	docker build \
 		--build-arg VERSION=$(VERSION) \
 		-t determinedai/determined-$(COMPONENT):$(VERSION) \

--- a/agent/scripts/entrypoint.sh
+++ b/agent/scripts/entrypoint.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+chmod +x /usr/local/determined/container_startup_script
+/usr/local/determined/container_startup_script
+
+/usr/bin/determined-agent "$@"

--- a/docs/reference/cluster-config.txt
+++ b/docs/reference/cluster-config.txt
@@ -203,10 +203,15 @@ master starts. It may contain the following fields:
     Defaults to ``http`` as scheme, local IP address as host, and
     ``8080`` as port.
 
-  - ``startup_script``: Startup script for agents. This script will
-    run right away when agent instances start up. For example, it can
-    be used for formating and mounting a disk. Defaults to an empty
-    string.
+  - ``startup_script``: Startup script for the node the agent runs on.
+    This script will run right away when agent instances start up.
+    For example, it can be used for formating and mounting a disk. Defaults
+    to an empty string.
+
+  - ``container_startup_script``: Startup script for the container 
+    ``determined-agent`` runs in. This script will run right away when
+    the agent's container starts up. For example, this script can be used
+    to configure docker so the agent can pull task images from GCR securely.
 
   - ``agent_docker_network``: The Docker network to use for the Determined
     agent and task containers. If this is set to "host", Docker

--- a/docs/system-administration/dynamic-agents-aws.txt
+++ b/docs/system-administration/dynamic-agents-aws.txt
@@ -124,6 +124,7 @@ an example configuration. See :ref:`cluster-configuration` for details.
   provisioner:
     master_url: <scheme://host:port>
     startup_script: <startup script>
+    container_startup_script: <container startup script>
     agent_docker_network: determined
     max_idle_agent_period: 5m
 

--- a/docs/system-administration/dynamic-agents-gcp.txt
+++ b/docs/system-administration/dynamic-agents-gcp.txt
@@ -100,6 +100,7 @@ an example configuration. See :ref:`cluster-configuration` for details.
    provisioner:
      master_url: <scheme://host:port>
      startup_script: <startup script>
+     container_startup_script: <container startup script>
      agent_docker_network: determined
      max_idle_agent_period: 5m
 
@@ -180,6 +181,35 @@ validate if you could read and write on the attached disk.
    EOF
    # Test attached read-only disk.
    det command run --config-file command.yaml ls -l /second
+
+.. _gcp-pull-gcr:
+
+How to securely pull task images from GCR
+-----------------------------------------
+
+If you have time consuming tasks to perform at startup it can be useful to
+:ref:`add custom layers<custom-env>` to the task images Determined provides. If
+you have store these images in a secure registry, such as GCR, you can pull
+these images securely by using existing tooling like `docker-credential-gcr
+<https://github.com/GoogleCloudPlatform/docker-credential-gcr>`__.
+
+Here is an example master configuration of how to allow the agent to inherit the
+permissions of the service account associated with a GCE instance, for accessing GCR.
+
+.. code:: yaml
+
+   provisioner:
+     container_startup_script: |
+         export HOME=/root
+         apt-get update && apt-get install -y curl docker.io
+         curl -fsSL "https://github.com/GoogleCloudPlatform/docker-credential-gcr/releases/download/v1.5.0/docker-credential-gcr_linux_amd64-1.5.0.tar.gz" \
+               | tar xz --to-stdout > /usr/bin/docker-credential-gcr && chmod +x /usr/bin/docker-credential-gcr
+         docker-credential-gcr configure-docker
+
+.. note::
+  This is an example of a operation that requires use of ``container_startup_script``.
+  Because docker credential helpers alter the docker client configuration to depend on the
+  helper binary by name, it must be installed and configured in the container.
 
 Installation
 ------------

--- a/master/internal/provisioner/agent_setup.go
+++ b/master/internal/provisioner/agent_setup.go
@@ -8,14 +8,15 @@ import (
 )
 
 type agentSetupScriptConfig struct {
-	MasterHost          string
-	MasterPort          string
-	StartupScriptBase64 string
-	AgentDockerRuntime  string
-	AgentNetwork        string
-	AgentDockerImage    string
-	AgentID             string
-	LogOptions          string
+	MasterHost                   string
+	MasterPort                   string
+	StartupScriptBase64          string
+	ContainerStartupScriptBase64 string
+	AgentDockerRuntime           string
+	AgentNetwork                 string
+	AgentDockerImage             string
+	AgentID                      string
+	LogOptions                   string
 }
 
 func mustMakeAgentSetupScript(config agentSetupScriptConfig) []byte {

--- a/master/internal/provisioner/agent_setup_test.go
+++ b/master/internal/provisioner/agent_setup_test.go
@@ -13,16 +13,20 @@ func TestAgentSetupScript(t *testing.T) {
 	err := etc.SetRootPath("../../static/srv/")
 	assert.NilError(t, err)
 
-	encoded := base64.StdEncoding.EncodeToString([]byte("sleep 5\n echo \"hello world\""))
+	encodedScript := base64.StdEncoding.EncodeToString([]byte("sleep 5\n echo \"hello world\""))
+	encodedContainerScript := base64.StdEncoding.EncodeToString([]byte("sleep"))
 	conf := agentSetupScriptConfig{
-		MasterHost:          "test.master",
-		MasterPort:          "8080",
-		StartupScriptBase64: encoded,
-		AgentDockerImage:    "test_docker_image",
-		AgentDockerRuntime:  "nvidia",
-		AgentNetwork:        "default",
-		AgentID:             "test.id",
+		MasterHost:                   "test.master",
+		MasterPort:                   "8080",
+		StartupScriptBase64:          encodedScript,
+		ContainerStartupScriptBase64: encodedContainerScript,
+		AgentDockerImage:             "test_docker_image",
+		AgentDockerRuntime:           "nvidia",
+		AgentNetwork:                 "default",
+		AgentID:                      "test.id",
 	}
+
+	// nolint
 	expected := `#!/bin/bash
 
 mkdir -p /usr/local/determined
@@ -33,11 +37,17 @@ echo "#### PRINTING STARTUP SCRIPT END ####"
 chmod +x /usr/local/determined/startup_script
 /usr/local/determined/startup_script
 
+echo c2xlZXA= | base64 --decode > /usr/local/determined/container_startup_script
+echo "#### PRINTING CONTAINER STARTUP SCRIPT START ####"
+cat /usr/local/determined/container_startup_script
+echo "#### PRINTING CONTAINER STARTUP SCRIPT END ####"
+
 docker run --init --name determined-agent  --restart always --network default --runtime=nvidia \
     -e DET_AGENT_ID="test.id" \
     -e DET_MASTER_HOST="test.master" \
     -e DET_MASTER_PORT="8080" \
     -v /var/run/docker.sock:/var/run/docker.sock \
+    -v /usr/local/determined/container_startup_script:/usr/local/determined/container_startup_script \
     "test_docker_image"
 `
 

--- a/master/internal/provisioner/aws.go
+++ b/master/internal/provisioner/aws.go
@@ -85,19 +85,22 @@ func newAWSCluster(config *Config) (*awsCluster, error) {
 		return nil, errors.Wrap(err, "failed to parse master url")
 	}
 
+	startupScriptBase64 := base64.StdEncoding.EncodeToString([]byte(config.StartupScript))
+	containerScriptBase64 := base64.StdEncoding.EncodeToString([]byte(config.ContainerStartupScript))
 	cluster := &awsCluster{
 		AWSClusterConfig: config.AWS,
 		masterURL:        *masterURL,
 		client:           ec2.New(sess),
 		ec2UserData: mustMakeAgentSetupScript(agentSetupScriptConfig{
-			MasterHost:          masterURL.Hostname(),
-			MasterPort:          masterURL.Port(),
-			StartupScriptBase64: base64.StdEncoding.EncodeToString([]byte(config.StartupScript)),
-			AgentDockerRuntime:  config.AgentDockerRuntime,
-			AgentNetwork:        config.AgentDockerNetwork,
-			AgentDockerImage:    config.AgentDockerImage,
-			AgentID:             awsAgentID,
-			LogOptions:          config.AWS.buildDockerLogString(),
+			MasterHost:                   masterURL.Hostname(),
+			MasterPort:                   masterURL.Port(),
+			StartupScriptBase64:          startupScriptBase64,
+			ContainerStartupScriptBase64: containerScriptBase64,
+			AgentDockerRuntime:           config.AgentDockerRuntime,
+			AgentNetwork:                 config.AgentDockerNetwork,
+			AgentDockerImage:             config.AgentDockerImage,
+			AgentID:                      awsAgentID,
+			LogOptions:                   config.AWS.buildDockerLogString(),
 		}),
 	}
 	return cluster, nil

--- a/master/internal/provisioner/config.go
+++ b/master/internal/provisioner/config.go
@@ -44,14 +44,15 @@ func (d *Duration) UnmarshalJSON(b []byte) error {
 
 // Config describes config for provisioner.
 type Config struct {
-	MasterURL          string            `json:"master_url"`
-	StartupScript      string            `json:"startup_script"`
-	AgentDockerNetwork string            `json:"agent_docker_network"`
-	AgentDockerRuntime string            `json:"agent_docker_runtime"`
-	AgentDockerImage   string            `json:"agent_docker_image"`
-	AWS                *AWSClusterConfig `union:"provider,aws" json:"-"`
-	GCP                *GCPClusterConfig `union:"provider,gcp" json:"-"`
-	MaxIdleAgentPeriod Duration          `json:"max_idle_agent_period"`
+	MasterURL              string            `json:"master_url"`
+	StartupScript          string            `json:"startup_script"`
+	ContainerStartupScript string            `json:"container_startup_script"`
+	AgentDockerNetwork     string            `json:"agent_docker_network"`
+	AgentDockerRuntime     string            `json:"agent_docker_runtime"`
+	AgentDockerImage       string            `json:"agent_docker_image"`
+	AWS                    *AWSClusterConfig `union:"provider,aws" json:"-"`
+	GCP                    *GCPClusterConfig `union:"provider,gcp" json:"-"`
+	MaxIdleAgentPeriod     Duration          `json:"max_idle_agent_period"`
 }
 
 // DefaultConfig returns the default configuration of the provisioner.

--- a/master/internal/provisioner/gcp.go
+++ b/master/internal/provisioner/gcp.go
@@ -59,13 +59,16 @@ func newGCPCluster(config *Config) (*gcpCluster, error) {
 		return nil, errors.Wrap(err, "failed to parse master url")
 	}
 
+	startupScriptBase64 := base64.StdEncoding.EncodeToString([]byte(config.StartupScript))
+	containerScriptBase64 := base64.StdEncoding.EncodeToString([]byte(config.ContainerStartupScript))
 	startupScript := string(mustMakeAgentSetupScript(agentSetupScriptConfig{
-		MasterHost:          masterURL.Hostname(),
-		MasterPort:          masterURL.Port(),
-		AgentNetwork:        config.AgentDockerNetwork,
-		AgentDockerRuntime:  config.AgentDockerRuntime,
-		AgentDockerImage:    config.AgentDockerImage,
-		StartupScriptBase64: base64.StdEncoding.EncodeToString([]byte(config.StartupScript)),
+		MasterHost:                   masterURL.Hostname(),
+		MasterPort:                   masterURL.Port(),
+		AgentNetwork:                 config.AgentDockerNetwork,
+		AgentDockerRuntime:           config.AgentDockerRuntime,
+		AgentDockerImage:             config.AgentDockerImage,
+		StartupScriptBase64:          startupScriptBase64,
+		ContainerStartupScriptBase64: containerScriptBase64,
 		AgentID: `$(curl "http://metadata.google.internal/computeMetadata/v1/instance/` +
 			`name" -H "Metadata-Flavor: Google")`,
 	}))

--- a/master/static/srv/agent_setup_script.sh.template
+++ b/master/static/srv/agent_setup_script.sh.template
@@ -8,9 +8,15 @@ echo "#### PRINTING STARTUP SCRIPT END ####"
 chmod +x /usr/local/determined/startup_script
 /usr/local/determined/startup_script
 
+echo {{.ContainerStartupScriptBase64}} | base64 --decode > /usr/local/determined/container_startup_script
+echo "#### PRINTING CONTAINER STARTUP SCRIPT START ####"
+cat /usr/local/determined/container_startup_script
+echo "#### PRINTING CONTAINER STARTUP SCRIPT END ####"
+
 docker run --init --name determined-agent {{.LogOptions}} --restart always --network {{.AgentNetwork}} --runtime={{.AgentDockerRuntime}} \
     -e DET_AGENT_ID="{{.AgentID}}" \
     -e DET_MASTER_HOST="{{.MasterHost}}" \
     -e DET_MASTER_PORT="{{.MasterPort}}" \
     -v /var/run/docker.sock:/var/run/docker.sock \
+    -v /usr/local/determined/container_startup_script:/usr/local/determined/container_startup_script \
     "{{.AgentDockerImage}}"

--- a/packaging/master.yaml
+++ b/packaging/master.yaml
@@ -22,8 +22,11 @@
 ## The url of the Determined master.
 #  master_url: <scheme://host:port>
 
-## The startup script for the agent.
+## The startup script for the agent. This runs on the node the agent runs on.
 #  startup_script: <startup script>
+
+## The startup script for the agent's container. This runs in the container determined-agent runs in.
+#  container_startup_script: <container startup script>
 
 ## The Docker network to use for the agent when using dynamic agents. If this is
 ## set to "host", Docker host-mode networking will be used instead. Defaults to "default".


### PR DESCRIPTION
This change aims to address the issues with the original startup script without removing the
functionality since it is also useful. The problem with the original script is that it runs outside of the environment that the agent runs. Because of this things like configuring the docker client don't work well. Alternatives to this are supporting secrets for altering the experiment docker config (similar to docker login) or running the agent natively, both of which we aren't quite ready for yet.

Sort of tested it by building the agent and mounting an "echo 'hey'" script into it:
```
➜  determined git:(move_agent_startup) ✗ docker run -v /var/run/docker.sock:/var/run/docker.sock -v $(pwd)/container_startup_script:/usr/local/determined/container_startup_script determinedai/determined-agent:0.12.3.dev0
hey
INFO[2020-04-24T01:32:02Z] agent configuration: {"config_file":"","master_host":"","master_port":0,"agent_id":"bab9862ff9e6","artificial_slots":0,"label":"","api_enabled":false,"bind_ip":"0.0.0.0","bind_port":9090,"visible_gpus":"","tls":false,"cert_file":"","key_file":""} 
INFO[2020-04-24T01:32:02Z] Determined agent 0.12.3.dev0 (built with go1.13)  id=agent system=bab9862ff9e6 type=agent
WARN[2020-04-24T01:32:02Z] Nvidia runtime not found; defaulting to CPU devices  id=agent system=bab9862ff9e6 type=agent
INFO[2020-04-24T01:32:02Z] detected compute devices:                     id=agent system=bab9862ff9e6 type=agent
```

I've previously tested running `docker-credential-cgr` from without a container on GCE with success.