### PR TITLE
feat: support GCP static agent instances in det-deploy

### DIFF
--- a/deploy/determined_deploy/aws/cli.py
+++ b/deploy/determined_deploy/aws/cli.py
@@ -76,9 +76,10 @@ def make_up_subparser(subparsers: argparse._SubParsersAction):
         "--max-idle-agent-period", type=str, help="max agent idle time",
     )
     subparser.add_argument(
-        "--max-instances", type=int, help="max instances",
+        "--max-dynamic-agents",
+        type=int,
+        help="maximum number of dynamic agent instances at one time",
     )
-
     subparser.add_argument(
         "--dry-run", action="store_true", help="print deployment template",
     )
@@ -130,7 +131,7 @@ def deploy_aws(args: argparse.Namespace) -> None:
         constants.cloudformation.DB_PASSWORD: args.db_password,
         constants.cloudformation.HASURA_SECRET: args.hasura_secret,
         constants.cloudformation.MAX_IDLE_AGENT_PERIOD: args.max_idle_agent_period,
-        constants.cloudformation.MAX_INSTANCES: args.max_instances,
+        constants.cloudformation.MAX_DYNAMIC_AGENTS: args.max_dynamic_agents,
     }
 
     deployment_object = deployment_type_map[args.deployment_type](det_configs)

--- a/deploy/determined_deploy/aws/constants.py
+++ b/deploy/determined_deploy/aws/constants.py
@@ -39,7 +39,7 @@ class cloudformation:
     BOTO3_SESSION = "Boto3Session"
     AGENT_TAG_NAME = "AgentTagName"
     MAX_IDLE_AGENT_PERIOD = "MaxIdleAgentPeriod"
-    MAX_INSTANCES = "MaxInstances"
+    MAX_DYNAMIC_AGENTS = "MaxDynamicAgents"
     LOG_GROUP = "LogGroup"
     REGION = "Region"
 

--- a/deploy/determined_deploy/aws/deployment_types/secure.py
+++ b/deploy/determined_deploy/aws/deployment_types/secure.py
@@ -35,7 +35,7 @@ class Secure(base.DeterminedDeployment):
         constants.cloudformation.DB_PASSWORD,
         constants.cloudformation.HASURA_SECRET,
         constants.cloudformation.MAX_IDLE_AGENT_PERIOD,
-        constants.cloudformation.MAX_INSTANCES,
+        constants.cloudformation.MAX_DYNAMIC_AGENTS,
     ]
 
     def __init__(self, parameters: List) -> None:

--- a/deploy/determined_deploy/aws/deployment_types/simple.py
+++ b/deploy/determined_deploy/aws/deployment_types/simple.py
@@ -29,7 +29,7 @@ class Simple(base.DeterminedDeployment):
         constants.cloudformation.DB_PASSWORD,
         constants.cloudformation.HASURA_SECRET,
         constants.cloudformation.MAX_IDLE_AGENT_PERIOD,
-        constants.cloudformation.MAX_INSTANCES,
+        constants.cloudformation.MAX_DYNAMIC_AGENTS,
     ]
 
     def __init__(self, parameters: List) -> None:

--- a/deploy/determined_deploy/aws/deployment_types/vpc.py
+++ b/deploy/determined_deploy/aws/deployment_types/vpc.py
@@ -28,7 +28,7 @@ class VPC(base.DeterminedDeployment):
         constants.cloudformation.DB_PASSWORD,
         constants.cloudformation.HASURA_SECRET,
         constants.cloudformation.MAX_IDLE_AGENT_PERIOD,
-        constants.cloudformation.MAX_INSTANCES,
+        constants.cloudformation.MAX_DYNAMIC_AGENTS,
     ]
 
     def __init__(self, parameters: List) -> None:

--- a/deploy/determined_deploy/aws/templates/secure.yaml
+++ b/deploy/determined_deploy/aws/templates/secure.yaml
@@ -76,7 +76,7 @@ Parameters:
     Description: How long before idle agents are shutdown
     Default: 10m
 
-  MaxInstances:
+  MaxDynamicAgents:
     Type: Number
     Description: Maximum number of agents to launch simultaneously
     Default: 5
@@ -582,7 +582,7 @@ Resources:
             log_stream: determined-agent
             master_url: http://local-ipv4:8080
             max_idle_agent_period: ${MaxIdleAgentPeriod}
-            max_instances: ${MaxInstances}
+            max_instances: ${MaxDynamicAgents}
             network_interface:
               public_ip: false
               security_group_id: ${AgentSecurityGroup.GroupId}

--- a/deploy/determined_deploy/aws/templates/simple.yaml
+++ b/deploy/determined_deploy/aws/templates/simple.yaml
@@ -51,7 +51,7 @@ Parameters:
     Description: How long before idle agents are shutdown
     Default: 10m
 
-  MaxInstances:
+  MaxDynamicAgents:
     Type: Number
     Description: Maximum number of agents to launch simultaneously
     Default: 5
@@ -382,7 +382,7 @@ Resources:
             log_stream: determined-agent
             master_url: http://local-ipv4:8080
             max_idle_agent_period: ${MaxIdleAgentPeriod}
-            max_instances: ${MaxInstances}
+            max_instances: ${MaxDynamicAgents}
             network_interface:
               public_ip: true
               security_group_id: ${AgentSecurityGroup.GroupId}

--- a/deploy/determined_deploy/aws/templates/vpc.yaml
+++ b/deploy/determined_deploy/aws/templates/vpc.yaml
@@ -66,7 +66,7 @@ Parameters:
     Description: How long before idle agents are shutdown
     Default: 10m
 
-  MaxInstances:
+  MaxDynamicAgents:
     Type: Number
     Description: Maximum number of agents to launch simultaneously
     Default: 5
@@ -508,7 +508,7 @@ Resources:
             log_stream: determined-agent
             master_url: http://local-ipv4:8080
             max_idle_agent_period: ${MaxIdleAgentPeriod}
-            max_instances: ${MaxInstances}
+            max_instances: ${MaxDynamicAgents}
             network_interface:
               public_ip: true
               security_group_id: ${AgentSecurityGroup.GroupId}

--- a/deploy/determined_deploy/gcp/cli.py
+++ b/deploy/determined_deploy/gcp/cli.py
@@ -136,10 +136,16 @@ def make_up_subparser(subparsers: argparse._SubParsersAction) -> None:
         help="number of GPUs per agent instance",
     )
     optional_named.add_argument(
-        "--max-instances",
+        "--max-dynamic-agents",
         type=int,
-        default=constants.defaults.MAX_INSTANCES,
-        help="maximum number of agent instances at one time",
+        default=constants.defaults.MAX_DYNAMIC_AGENTS,
+        help="maximum number of dynamic agent instances at one time",
+    )
+    optional_named.add_argument(
+        "--static-agents",
+        type=int,
+        default=constants.defaults.STATIC_AGENTS,
+        help="number of static agent instances",
     )
     optional_named.add_argument(
         "--min-cpu-platform-master",

--- a/deploy/determined_deploy/gcp/constants.py
+++ b/deploy/determined_deploy/gcp/constants.py
@@ -8,7 +8,8 @@ class defaults:
     HASURA_SECRET = "secret"
     MASTER_INSTANCE_TYPE = "n1-standard-2"
     MAX_IDLE_AGENT_PERIOD = "10m"
-    MAX_INSTANCES = 5
+    MAX_DYNAMIC_AGENTS = 5
+    STATIC_AGENTS = 0
     MIN_CPU_PLATFORM_MASTER = "Intel Skylake"
     MIN_CPU_PLATFORM_AGENT = "Intel Broadwell"
     NETWORK = "det-default"

--- a/deploy/determined_deploy/gcp/terraform/main.tf
+++ b/deploy/determined_deploy/gcp/terraform/main.tf
@@ -127,7 +127,8 @@ module "compute" {
   max_idle_agent_period = var.max_idle_agent_period
   gpu_type = var.gpu_type
   gpu_num = var.gpu_num
-  max_instances = var.max_instances
+  max_dynamic_agents = var.max_dynamic_agents
+  static_agents = var.static_agents
   min_cpu_platform_master = var.min_cpu_platform_master
   min_cpu_platform_agent = var.min_cpu_platform_agent
   preemptible = var.preemptible

--- a/deploy/determined_deploy/gcp/terraform/modules/compute/outputs.tf
+++ b/deploy/determined_deploy/gcp/terraform/modules/compute/outputs.tf
@@ -1,15 +1,15 @@
 output "web_ui" {
-  value = "${var.scheme}://${google_compute_instance.default.network_interface.0.access_config.0.nat_ip}:${var.port}"
+  value = "${var.scheme}://${google_compute_instance.master_instance.network_interface.0.access_config.0.nat_ip}:${var.port}"
 }
 
 output "internal_ip" {
-  value = google_compute_instance.default.network_interface.0.network_ip
+  value = google_compute_instance.master_instance.network_interface.0.network_ip
 }
 
 output "master_instance_name" {
-  value = google_compute_instance.default.name
+  value = google_compute_instance.master_instance.name
 }
 
 output "master_zone" {
-  value = google_compute_instance.default.zone
+  value = google_compute_instance.master_instance.zone
 }

--- a/deploy/determined_deploy/gcp/terraform/modules/compute/variables.tf
+++ b/deploy/determined_deploy/gcp/terraform/modules/compute/variables.tf
@@ -58,7 +58,10 @@ variable "gpu_type" {
 variable "gpu_num" {
 }
 
-variable "max_instances" {
+variable "max_dynamic_agents" {
+}
+
+variable "static_agents" {
 }
 
 variable "preemptible" {

--- a/deploy/determined_deploy/gcp/terraform/outputs.tf
+++ b/deploy/determined_deploy/gcp/terraform/outputs.tf
@@ -1,33 +1,37 @@
 output "A1--Network" {
-  value = "                   ${module.network.network_name}"
+  value = "                           ${module.network.network_name}"
 }
 
 output "A2--Region" {
-  value = "                    ${var.region}"
+  value = "                            ${var.region}"
 }
 
 output "A3--Zone" {
-  value = "                      ${module.compute.master_zone}\n"
+  value = "                              ${module.compute.master_zone}\n"
 }
 
 output "B1--Master-Instance-Name" {
-  value = "      ${module.compute.master_instance_name}"
+  value = "              ${module.compute.master_instance_name}"
 }
 
 output "B2--Master-Instance-Type" {
-  value = "      ${var.master_instance_type}"
+  value = "              ${var.master_instance_type}"
 }
 
 output "B3--Agent-Instance-Type" {
-  value = "       ${var.agent_instance_type}"
+  value = "               ${var.agent_instance_type}"
 }
 
-output "B4--Max-number-of-Agents" {
-  value = "      ${var.max_instances}"
+output "B4--Max-Number-of-Dynamic-Agents" {
+  value = "      ${var.max_dynamic_agents}"
+}
+
+output "B4--Number-of-Static-Agents" {
+  value = "           ${var.static_agents}"
 }
 
 output "B5--GPUs-per-Agent" {
-  value = "            ${var.gpu_num}\n"
+  value = "                    ${var.gpu_num}\n"
 }
 
 output "NOTE" {

--- a/deploy/determined_deploy/gcp/terraform/variables.tf
+++ b/deploy/determined_deploy/gcp/terraform/variables.tf
@@ -70,9 +70,14 @@ variable "gpu_num" {
   default = 8
 }
 
-variable "max_instances" {
+variable "max_dynamic_agents" {
   type = number
   default = 5
+}
+
+variable "static_agents" {
+  type = number
+  default = 0
 }
 
 variable "preemptible" {

--- a/docs/how-to/installation/aws.txt
+++ b/docs/how-to/installation/aws.txt
@@ -148,8 +148,8 @@ Spinning up the cluster
      - 10m (10 minutes)
      - False
 
-   * - ``--max-instances``
-     - Maximum instances that the master instance can allocate to the cluster
+   * - ``--max-dynamic-agents``
+     - Maximum number of dynamic agent instances at one time
      - 5
      - False
 

--- a/docs/how-to/installation/gcp.txt
+++ b/docs/how-to/installation/gcp.txt
@@ -130,9 +130,14 @@ ___________________
      - 8
      - False
 
-   * - ``--max-instances``
-     - The maximum number of agent instances at one time.
+   * - ``--max-dynamic-agents``
+     - Maximum number of dynamic agent instances at one time.
      - 5
+     - False
+
+   * - ``--static-agents``
+     - Number of static agent instances.
+     - 0
      - False
 
    * - ``--max-idle-agent-period``


### PR DESCRIPTION
1. new --static-agents argument to det-deploy gcp specifying the static
   agent count
2. rename --max-instances to --max-dynamic-agents for AWS and GCP to
   distinguish it as the dynamic agent pool size

DET-2912 #Done.