### PR TITLE
[DET-2809] test: fix flaky never ending e2e test process

### DIFF
--- a/webui/tests/cypress/integration/02-notebooks.spec.ts
+++ b/webui/tests/cypress/integration/02-notebooks.spec.ts
@@ -32,7 +32,7 @@ describe('Notebooks List', () => {
         cy.get('tr:first-child td:last-child button').should('have.lengthOf', 3);
       });
 
-      it.skip('should open the logs modal when clicking the logs button', () => {
+      it('should open the logs modal when clicking the logs button', () => {
         cy.get('tr:first-child').contains(/logs/i).click();
         cy.get('.modal').contains(/logs for notebook/i);
         cy.get('.modal .fa-times').click();

--- a/webui/tests/cypress/support/index.js
+++ b/webui/tests/cypress/support/index.js
@@ -16,8 +16,8 @@
 import './commands';
 
 Cypress.Cookies.defaults({
-  whitelist: /auth/
-})
+  whitelist: /auth/,
+});
 
 Cypress.on('window:before:load', (window) => {
   Cypress.log({
@@ -32,7 +32,12 @@ Cypress.on('window:before:load', (window) => {
       message: args,
     });
   };
-});
+
+  // disable actions that would result in opening new tabs/windows
+  // https://docs.cypress.io/guides/references/trade-offs.html#Permanent-trade-offs-1
+  window.open = () => {};
+
+}); // end of before:load
 
 Cypress.on('log:added', (options) => {
   if (options.instrument === 'command') {


### PR DESCRIPTION
some interactions with our UI, if given enough time, open new tabs which then refuse to close (notebook) without confirmation and cypress doesn't support any control over multiple tab/windows (https://docs.cypress.io/guides/references/trade-offs.html#Permanent-trade-offs-1) 

# Test Plan
- UI change:
  - [ ] add screenshots
  - [ ] React? build & check storybooks
- [ ] user-facing api change: modify documentation and examples
- [ ] user-facing api change: add the "User-facing API Change" label
- [ ] bug fix: add regression test
- [ ] bug fix: determine if there are other similar bugs in the codebase
- [ ] new feature: add test coverage for any user-facing aspects
- [ ] refactor: maintain existing code coverage
