### PR TITLE
[DET-2886] chore: fix event replay synchronization

### DIFF
--- a/master/internal/experiment.go
+++ b/master/internal/experiment.go
@@ -183,10 +183,12 @@ func newSearcherEventCallback(master *Master, ref *actor.Ref) func(model.Searche
 
 			// Pass the workload completed message to the Trial. It will pass the event along to
 			// the experiment before this Ask gets a response.
+			// TODO(1): starts here, ask and get child workload completed
 			master.system.AskAt(ref.Address().Child(requestIDs[msg.Workload.TrialID]), msg).Get()
 
 			// Wait for the experiment to handle any searcher operations due to the completed
 			// workload.
+			// TODO(7) And so this invariant isn't true and in, apparently a 1 in 6000 chance, it comes up.
 			master.system.Ask(ref, doneProcessingSearcherOperations{}).Get()
 
 		case TrialClosedEventType:

--- a/master/internal/trial.go
+++ b/master/internal/trial.go
@@ -307,6 +307,7 @@ func (t *trial) runningReceive(ctx *actor.Context) error {
 		}
 
 	case searcher.CompletedMessage:
+		// TODO(2) keeps going here
 		if err := t.processCompletedWorkload(ctx, msg); err != nil {
 			return err
 		}
@@ -472,8 +473,10 @@ func (t *trial) processCompletedWorkload(ctx *actor.Context, msg searcher.Comple
 	// Now that we have marked the workload as completed in the database, we can relay the message
 	// to the Experiment. We use Ask and not Tell because in the case of completed validation
 	// metrics, the Experiment will respond with whether or not we should take a checkpoint.
+	// TODO(3): to here.. here we just grab a future, this is supposed to synchronize us
 	experimentFuture := ctx.Ask(ctx.Self().Parent(), msg)
 
+	// TODO(4): and hop into this method with it, notice it is NOT used below here
 	if err := t.sequencer.WorkloadCompleted(msg, experimentFuture); err != nil {
 		return errors.Wrap(err, "Error passing CompletedMessage to sequencer")
 	}

--- a/master/internal/trial_workload_sequencer.go
+++ b/master/internal/trial_workload_sequencer.go
@@ -122,6 +122,7 @@ func (s *trialWorkloadSequencer) WorkloadCompleted(
 
 	switch msg.Workload.Kind {
 	case searcher.RunStep:
+		// TODO(6): so a run workload can be processed without synchronization
 		s.curStep++
 		s.curStepDone = stepInfo{}
 		if s.minValidationNeeded() {
@@ -154,6 +155,7 @@ func (s *trialWorkloadSequencer) WorkloadCompleted(
 		case model.AllCheckpointPolicy:
 			s.steps[msg.Workload.StepID].hasCheckpoint = true
 		case model.BestCheckpointPolicy:
+			// TODO(5) and it comes ONLY gets polled here
 			if isBestValidation := experimentFuture.Get().(bool); isBestValidation {
 				s.steps[msg.Workload.StepID].hasCheckpoint = true
 			}
@@ -161,6 +163,9 @@ func (s *trialWorkloadSequencer) WorkloadCompleted(
 	default:
 		return errors.New("invalid operation for trialWorkloadSequencer")
 	}
+
+	// for synchronization with searcher event replay in experiment restart
+	experimentFuture.Get()
 	s.curWorkloadValid = false
 	return nil
 }


### PR DESCRIPTION
Left this with a bunch of TODO(#)'s in it, I was using them to keep my train of thought and I feel it explains what the issue was pretty well. I'll remove them before committing and add a good commit message. Just wanted to get some 👀 to make sure I'm not losing my mind.

Glad I found this or I would've just stared at the code for 8 hours without any reason.

Sort of to add to the how I tracked this down, I noticed what happened in both cases was some how run step 2 showed up before 1 when replaying.
<img width="1583" alt="Screen Shot 2020-04-24 at 12 36 08 AM" src="https://user-images.githubusercontent.com/9650546/80175515-c3e67a00-85c3-11ea-9467-21e8ad5f0973.png">
<img width="1580" alt="Screen Shot 2020-04-24 at 12 36 30 AM" src="https://user-images.githubusercontent.com/9650546/80175519-c5b03d80-85c3-11ea-8857-dac9e9e6a864.png">

I searched all over in the event flushing code but nothing looked off, I looked at db logs to see if Postgres had a blip. It was also unfortunate the second experiment that did this blew up restoring it's best trial, so I had a weird rabbit hole for that. Ultimately, I thought it was just too random and must be a nasty concurrency bug. I think this is it.
