### PR TITLE
ci: make CircleCI even better and faster

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,6 +22,10 @@ parameters:
 
 
 commands:
+  fix-circle-working-directory:
+    description: "Fix CIRCLE_WORKING_DIRECTORY"
+    steps:
+      - run: echo 'CIRCLE_WORKING_DIRECTORY="${CIRCLE_WORKING_DIRECTORY/#\~/$HOME}"' >> $BASH_ENV
   install-node:
     description: Install Node 12.x
     steps:
@@ -37,57 +41,57 @@ commands:
     steps:
       - restore_cache:
           keys:
-            - det-py-deps-v1dev-{{ checksum  "combined-reqs.txt" }}
+            - det-py-deps-v1dev3-{{ checksum  "combined-reqs.txt" }}
   restore-go-cache:
     description: Restore Go dependency cache
     steps:
       - restore_cache:
           keys:
-            - det-go-deps-v1dev-{{ checksum  "master/go.sum" }}-{{ checksum  "agent/go.sum" }}
+            - det-go-deps-v1dev3-{{ checksum  "master/go.sum" }}-{{ checksum  "agent/go.sum" }}
   restore-elm-cache:
     description: Restore Elm dependency cache
     steps:
       - restore_cache:
           keys:
-            - det-elm-deps-v1dev-{{ checksum  "webui/elm/package-lock.json" }}
+            - det-elm-deps-v1dev3-{{ checksum  "webui/elm/package-lock.json" }}
   restore-react-cache:
     description: Restore React dependency cache
     steps:
       - restore_cache:
           keys:
-            - det-react-deps-v1dev-{{ checksum  "webui/react/package-lock.json" }}
+            - det-react-deps-v1dev3-{{ checksum  "webui/react/package-lock.json" }}
   save-python-cache:
     description: Save Python dependency cache
     steps:
       - save_cache:
-          key: det-py-deps-v1dev-{{ checksum  "combined-reqs.txt" }}
+          key: det-py-deps-v1dev3-{{ checksum  "combined-reqs.txt" }}
           paths:
             - "/tmp/venv"
   save-go-cache:
     description: Save Go dependency cache
     steps:
       - save_cache:
-          key: det-go-deps-v1dev-{{ checksum  "master/go.sum" }}-{{ checksum  "agent/go.sum" }}
+          key: det-go-deps-v1dev3-{{ checksum  "master/go.sum" }}-{{ checksum  "agent/go.sum" }}
           paths:
             - "/go/pkg/mod/"
   save-elm-cache:
     description: Save Elm dependency cache
     steps:
       - save_cache:
-          key: det-elm-deps-v1dev-{{ checksum  "webui/elm/package-lock.json" }}
+          key: det-elm-deps-v1dev3-{{ checksum  "webui/elm/package-lock.json" }}
           paths:
             - "webui/elm/node_modules"
   save-react-cache:
     description: Save React dependency cache
     steps:
       - save_cache:
-          key: det-react-deps-v1dev-{{ checksum  "webui/react/package-lock.json" }}
+          key: det-react-deps-v1dev3-{{ checksum  "webui/react/package-lock.json" }}
           paths:
             - "webui/react/node_modules"
   python-venv-setup:
     description: Create Python venv and install combined dependencies.
     steps:
-      - run: python3.6 -m venv /tmp/venv --system-site-packages
+      - run: python3.6 -m venv /tmp/venv
       - run: pip install --upgrade pip\<20
       - restore-python-cache
       - run: pip install -r combined-reqs.txt
@@ -99,34 +103,160 @@ commands:
           at: build
       - run: make -C master build-docker
       - run: make -C agent build-docker
+  setup-python-venv:
+    description: Set up and create Python venv.
+    parameters:
+      determined:
+        type: boolean
+        default: false
+      determined-common:
+        type: boolean
+        default: false
+      determined-cli:
+        type: boolean
+        default: false
+      determined-deploy:
+        type: boolean
+        default: false
+      extras-requires:
+        type: string
+        default: ""
+      extra-requirements-file:
+        type: string
+        default: ""
+      executor:
+        type: string
+    steps:
+      - run: python3.6 -m venv /tmp/venv
+      - run: /tmp/venv/bin/python -m pip install --upgrade pip\<20 wheel setuptools
+
+
+      # Write dependencies to cachefile to help create the cachekey
+      - run: echo <<parameters.executor>> > /tmp/cachefile
+      - when:
+          condition: <<parameters.determined-common>>
+          steps:
+            - run: cat common/setup.py >> /tmp/cachefile
+      - when:
+          condition: <<parameters.determined>>
+          steps:
+            - run: cat harness/setup.py >> /tmp/cachefile
+      - when:
+          condition: <<parameters.determined-cli>>
+          steps:
+            - run: cat cli/setup.py >> /tmp/cachefile
+      - when:
+          condition: <<parameters.determined-deploy>>
+          steps:
+            - run: cat deploy/setup.py >> /tmp/cachefile
+      - run: echo <<parameters.extras-requires>> >> /tmp/cachefile
+
+
+      # Install dependencies
+      - run: |
+          if [ -n <<parameters.extra-requirements-file>> ]; then cat <<parameters.extra-requirements-file>> >> /tmp/cachefile; fi
+      - restore_cache:
+          keys:
+            - det-python-deps-v1dev0-{{ checksum "/tmp/cachefile" }}
+      - when:
+          condition: <<parameters.determined-common>>
+          steps:
+            - run: cd common; /tmp/venv/bin/python setup.py bdist_wheel -d ../build
+            - run: /tmp/venv/bin/python -m pip install --find-links build determined-common==<< pipeline.parameters.det-version >>
+            - run: /tmp/venv/bin/python -m pip install --no-deps --force-reinstall --find-links build determined-common==<< pipeline.parameters.det-version >>
+      - when:
+          condition: <<parameters.determined>>
+          steps:
+            - run: cd harness; /tmp/venv/bin/python setup.py bdist_wheel -d ../build
+            - run: /tmp/venv/bin/python -m pip install --find-links build determined==<< pipeline.parameters.det-version >>
+            - run: /tmp/venv/bin/python -m pip install --no-deps --force-reinstall --find-links build determined==<< pipeline.parameters.det-version >>
+      - when:
+          condition: <<parameters.determined-cli>>
+          steps:
+            - run: cd cli; /tmp/venv/bin/python setup.py bdist_wheel -d ../build
+            - run: /tmp/venv/bin/python -m pip install --find-links build determined-cli==<< pipeline.parameters.det-version >>
+            - run: /tmp/venv/bin/python -m pip install --no-deps --force-reinstall --find-links build determined-cli==<< pipeline.parameters.det-version >>
+      - when:
+          condition: <<parameters.determined-deploy>>
+          steps:
+            - run: cd deploy; /tmp/venv/bin/python setup.py bdist_wheel -d ../build
+            - run: /tmp/venv/bin/python -m pip install --find-links build determined-deploy==<< pipeline.parameters.det-version >>
+            - run: /tmp/venv/bin/python -m pip install --no-deps --force-reinstall --find-links build determined-deploy==<< pipeline.parameters.det-version >>
+      - run: |
+          if [ -n "<<parameters.extras-requires>>" ]; then /tmp/venv/bin/python -m pip install <<parameters.extras-requires>>; fi
+      - run: |
+          if [ -n "<<parameters.extra-requirements-file>>" ]; then /tmp/venv/bin/python -m pip install -r <<parameters.extra-requirements-file>>; fi
+      - save_cache:
+          key: det-python-deps-v1dev0-{{ checksum "/tmp/cachefile" }}
+          paths:
+            - "/tmp/venv"
 
 
 jobs:
+  build-docs:
+    docker:
+      - image: python:3.6.9
+    environment:
+      PATH: /tmp/venv/bin:/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+    steps:
+      - checkout
+      - setup-python-venv:
+          determined-common: true
+          determined-cli: true
+          determined: true
+          extras-requires: "tensorflow==1.14 torch==1.4"
+          extra-requirements-file: "docs-requirements.txt"
+          executor: python:3.6.9
+      - run: make -C master build-python-packages
+      - run: make -C docs build
+      - persist_to_workspace:
+          root: build
+          paths:
+            - "share/determined/master/webui/docs"
+            - "share/determined/master/wheels"
+
+  build-elm:
+    docker:
+      - image: cimg/node:12.16
+    steps:
+      - checkout
+      - restore-elm-cache
+      - run: make -C webui/elm build
+      - save-elm-cache
+      - persist_to_workspace:
+          root: build
+          paths:
+            - "share/determined/master/webui/elm"
+
+  build-react:
+    docker:
+      - image: cimg/node:12.16
+    steps:
+      - checkout
+      - restore-react-cache
+      - run: make -C webui/react build
+      - save-react-cache
+      - persist_to_workspace:
+          root: build
+          paths:
+            - "share/determined/master/webui/react"
+
+
   build-debs:
     docker:
-      - image: python:3.6.9-stretch
+      - image: cimg/go:1.13
         environment:
           GO111MODULE: "on"
-          PATH: /tmp/venv/bin:/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/go/bin
     steps:
-      - run: python3.6 -m venv /tmp/venv
-      - install-node
-      - install-go
-
       - checkout
+      - attach_workspace:
+          at: build
 
-      - restore-python-cache
       - restore-go-cache
-      - restore-elm-cache
-      - restore-react-cache
-      - run: make get-deps
-      - save-python-cache
+      - run: make go-get-deps
       - save-go-cache
-      - save-elm-cache
-      - save-react-cache
 
-      - run: make -C webui/elm build
-      - run: make -C webui/react build
+      - run: make -C master build-files
       - run: make debs
 
       - persist_to_workspace:
@@ -147,12 +277,14 @@ jobs:
       - run: sudo systemctl restart docker
       - build-docker
 
-      - run: |
-          pyenv global 3.6.5
-          python3.6 -m venv /tmp/venv
-          . /tmp/venv/bin/activate
-          pip install --upgrade pip\<20 setuptools
-          make python-get-deps
+      - run: pyenv global 3.6.5
+      - setup-python-venv:
+          determined-common: true
+          determined-cli: true
+          determined: true
+          determined-deploy: true
+          extra-requirements-file: "tests/integrations/requirements.txt"
+          executor: ubuntu-1604:201903-01
 
       - run: docker pull determinedai/environments:py-3.6.9-pytorch-1.4-tf-1.14-cpu-4bd937a
 
@@ -162,7 +294,7 @@ jobs:
 
   lint-elm:
     docker:
-      - image: node:12
+      - image: cimg/node:12.16
     steps:
       - checkout
       - restore-elm-cache
@@ -172,7 +304,7 @@ jobs:
 
   test-unit-elm:
     docker:
-      - image: node:12
+      - image: cimg/node:12.16
     steps:
       - checkout
       - restore-elm-cache
@@ -184,7 +316,7 @@ jobs:
 
   lint-react:
     docker:
-      - image: node:12
+      - image: cimg/node:12.16
     steps:
       - checkout
       - restore-react-cache
@@ -194,7 +326,7 @@ jobs:
 
   test-unit-react:
     docker:
-      - image: node:12
+      - image: cimg/node:12.16
     steps:
       - checkout
       - restore-react-cache
@@ -206,7 +338,7 @@ jobs:
 
   lint-go:
     docker:
-      - image: golang:1.13-stretch
+      - image: cimg/go:1.13
         environment:
           GO111MODULE: "on"
     steps:
@@ -220,7 +352,7 @@ jobs:
 
   test-unit-go:
     docker:
-      - image: golang:1.13-stretch
+      - image: cimg/go:1.13
         environment:
           GO111MODULE: "on"
     steps:
@@ -241,7 +373,9 @@ jobs:
       PATH: /tmp/venv/bin:/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
     steps:
       - checkout
-      - python-venv-setup
+      - setup-python-venv:
+          extra-requirements-file: "combined-reqs.txt"
+          executor: python:3.6.9
       - run: make check-python
 
   test-unit-harness:
@@ -251,22 +385,12 @@ jobs:
       PATH: /tmp/venv/bin:/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
     steps:
       - checkout
-      - run: python3.6 -m venv /tmp/venv
-      - restore_cache:
-          keys:
-            - det-harness-deps-tf114-torch14-v1-{{ checksum  "harness/setup.py" }}--{{ checksum  "common/setup.py" }}
-      - run: pip install --upgrade pip\<20
-      - run: pip install wheel
-      - run: cd common; python setup.py bdist_wheel -d ../build
-      - run: cd harness; python setup.py bdist_wheel -d ../build
-      - run: pip install tensorflow==1.14.0 torch==1.4.0 torchvision==0.5.0 mypy==0.740 pytest
-      - run: pip install --find-links build determined==<< pipeline.parameters.det-version >>
-      - save_cache:
-          key: det-harness-deps-tf114-torch14-v1-{{ checksum  "harness/setup.py" }}--{{ checksum  "common/setup.py" }}
-          paths:
-            - "/tmp/venv"
-      # We force reinstall without dependencies to ensure that the code gets updated from whatever was cached.
-      - run: pip install --no-deps --force-reinstall --find-links build determined==<< pipeline.parameters.det-version >> determined_common==<< pipeline.parameters.det-version >>
+      - setup-python-venv:
+          determined-common: true
+          determined: true
+          extras-requires: "tensorflow==1.14.0 torch==1.4.0 torchvision==0.5.0"
+          extra-requirements-file: "tests/unit/requirements.txt"
+          executor: python:3.6.9
       - run: make test-harness
 
   test-unit-harness-tf2:
@@ -276,22 +400,12 @@ jobs:
       PATH: /tmp/venv/bin:/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
     steps:
       - checkout
-      - run: python3.6 -m venv /tmp/venv
-      - restore_cache:
-          keys:
-            - det-harness-deps-tf21-v1-{{ checksum  "harness/setup.py" }}--{{ checksum  "common/setup.py" }}
-      - run: pip install --upgrade pip\<20
-      - run: pip install wheel
-      - run: cd common; python setup.py bdist_wheel -d ../build
-      - run: cd harness; python setup.py bdist_wheel -d ../build
-      - run: pip install tensorflow==2.1.0 mypy==0.740 pytest
-      - run: pip install --find-links build determined==<< pipeline.parameters.det-version >>
-      - save_cache:
-          key: det-harness-deps-tf21-v1-{{ checksum  "harness/setup.py" }}--{{ checksum  "common/setup.py" }}
-          paths:
-            - "/tmp/venv"
-      # We force reinstall without dependencies to ensure that the code gets updated from whatever was cached.
-      - run: pip install --no-deps --force-reinstall --find-links build determined==<< pipeline.parameters.det-version >> determined_common==<< pipeline.parameters.det-version >>
+      - setup-python-venv:
+          determined-common: true
+          determined: true
+          extras-requires: "tensorflow==2.1.0"
+          extra-requirements-file: "tests/unit/requirements.txt"
+          executor: python:3.6.9
       - run: make test-tf2
 
   test-cli:
@@ -320,7 +434,15 @@ workflows:
               executor-name: ["python-35", "python-36", "python-37", "win/default"]
   test-e2e:
     jobs:
-      - build-debs
+      - build-elm
+      - build-react
+      - build-docs
+      - build-debs:
+          requires:
+            - build-elm
+            - build-react
+            - build-docs
+
       - test-e2e:
           requires:
             - build-debs

--- a/Makefile
+++ b/Makefile
@@ -117,11 +117,11 @@ build-agent:
 build-master:
 	$(MAKE) -C master build
 
-debs: build
+debs:
 	cp -r packaging "$(BUILDDIR)"
 	cd "$(BUILDDIR)" && GORELEASER_CURRENT_TAG=$(VERSION) $(GOBIN)/goreleaser -f $(CURDIR)/.goreleaser.yml --snapshot --rm-dist
 
-build-docker: debs
+build-docker: build debs
 	$(MAKE) build-master-docker build-agent-docker
 
 build-agent-docker:

--- a/combined-reqs.txt
+++ b/combined-reqs.txt
@@ -36,7 +36,7 @@ dai-sgqlc-3.5==0.0.1.dev20200211  # via determined-common
 git+https://github.com/determined-ai/determined_sphinx_theme.git@3849905ea870226a4bd5b3731edf9771523cecf3  # via -r docs-requirements.txt
 dill==0.3.1.1             # via determined
 docker-compose==1.25.4    # via determined-deploy
-docker[ssh]==4.2.0        # via determined-deploy, docker-compose
+docker[ssh]==4.2.0        # via -r dev-requirements.txt, determined-deploy, docker-compose
 dockerpty==0.4.1          # via docker-compose
 docopt==0.6.2             # via docker-compose, hdfs
 docutils==0.15.2          # via botocore, readme-renderer, sphinx
@@ -74,7 +74,7 @@ jinja2==2.11.1            # via ansible, sphinx
 jmespath==0.9.5           # via boto3, botocore
 jsonschema==3.2.0         # via docker-compose
 keras-applications==1.0.8  # via tensorflow
-keras-preprocessing[image]==1.1.0  # via -r tests/integrations/requirements.txt, tensorflow
+keras-preprocessing==1.1.0  # via tensorflow
 keyring==21.2.0           # via twine
 kiwisolver==1.1.0         # via matplotlib
 lmdb==0.98                # via yogadl
@@ -85,13 +85,13 @@ matplotlib==3.2.1         # via determined
 mccabe==0.6.1             # via flake8
 more-itertools==8.2.0     # via pytest
 mypy-extensions==0.4.3    # via mypy
-mypy==0.740               # via -r dev-requirements.txt
-numpy==1.18.2             # via -r tests/integrations/requirements.txt, determined, h5py, keras-applications, keras-preprocessing, matplotlib, scipy, tensorboard, tensorflow, torchvision
+mypy==0.740               # via -r dev-requirements.txt, -r tests/unit/requirements.txt
+numpy==1.18.2             # via -r tests/integrations/requirements.txt, determined, h5py, keras-applications, keras-preprocessing, matplotlib, tensorboard, tensorflow, torchvision
 packaging==19.0           # via determined, determined-cli, pytest, sphinx
 paramiko==2.7.1           # via docker
 pathspec==0.7.0           # via black, determined-common
 pexpect==4.8.0            # via -r tests/integrations/requirements.txt
-pillow==7.0.0             # via keras-preprocessing, torchvision
+pillow==7.0.0             # via -r docs-requirements.txt, torchvision
 pip-tools==4.5.1          # via -r dev-requirements.txt
 pkginfo==1.5.0.1          # via twine
 pluggy==0.13.1            # via pytest
@@ -125,7 +125,6 @@ ruamel.yaml.clib==0.2.0   # via ruamel.yaml
 ruamel.yaml==0.16.10      # via determined-cli, determined-common
 rx==1.6.1                 # via graphql-core
 s3transfer==0.3.3         # via boto3
-scipy==1.4.1              # via keras-preprocessing
 simplejson==3.16.0        # via determined, determined-common
 six==1.14.0               # via absl-py, bcrypt, bleach, cryptography, cycler, docker, docker-compose, dockerpty, flake8-tuple, google-api-core, google-auth, google-pasta, google-resumable-media, graphql-core, grpcio, h5py, hdfs, jsonschema, keras-preprocessing, lomond, packaging, pip-tools, promise, protobuf, pynacl, pyrsistent, python-dateutil, readme-renderer, requests-mock, tensorboard, tensorflow, torchvision, websocket-client
 smmap==3.0.1              # via gitdb
@@ -142,12 +141,12 @@ sphinxcontrib-serializinghtml==1.1.4  # via sphinx
 tabulate==0.8.7           # via determined-cli
 tensorboard==1.14.0       # via tensorflow
 tensorflow-estimator==1.14.0  # via tensorflow
-tensorflow==1.14.0        # via -r tests/unit/requirements.txt
+tensorflow==1.14          # via -r tests/integrations/requirements.txt
 termcolor==1.1.0          # via determined-cli, tensorflow
 texttable==1.6.2          # via docker-compose
 toml==0.10.0              # via black
-torch==1.4.0              # via -r tests/integrations/requirements.txt, -r tests/unit/requirements.txt, torchvision
-torchvision==0.5.0        # via -r tests/unit/requirements.txt
+torch==1.4.0              # via -r tests/integrations/requirements.txt, torchvision
+torchvision==0.5.0        # via -r tests/integrations/requirements.txt
 tqdm==4.45.0              # via twine
 twine==3.1.1              # via -r release-requirements.txt
 typed-ast==1.4.1          # via black, mypy

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -8,6 +8,6 @@ flake8-comprehensions>=2.2.0
 flake8-docstrings>=1.4.0
 flake8-quotes>=2.1.0
 flake8-tuple>=0.4.0
-isort
+isort==4.3.21
 mypy==0.740
 pip-tools>=4.5

--- a/docs-requirements.txt
+++ b/docs-requirements.txt
@@ -1,4 +1,5 @@
-Sphinx>=2.2.0
+sphinx==2.4.4
 sphinx-argparse>=0.2.5
 git+https://github.com/determined-ai/determined_sphinx_theme.git@3849905ea870226a4bd5b3731edf9771523cecf3
 sphinx-gallery>=0.6.1
+pillow

--- a/tests/integrations/requirements.txt
+++ b/tests/integrations/requirements.txt
@@ -1,7 +1,6 @@
 pytest
 pexpect
-# TODO(DET-2653): Remove this line after supporting run test mode integration test
-#                 on tf2 using command.
-Keras-Preprocessing[image]
-torch
+torch==1.4
+torchvision==0.5.0
+tensorflow==1.14
 numpy

--- a/tests/unit/requirements.txt
+++ b/tests/unit/requirements.txt
@@ -1,4 +1,2 @@
 pytest
-tensorflow==1.14.0
-torch==1.4.0
-torchvision==0.5.0
+mypy==0.740


### PR DESCRIPTION
- use CircleCI highly cached images where possible
  * we cannot use the Python one since they do not install python-dev
- only install Python dependencies we need
- make the Python venv install/caching logic templated to reduce risk
- split up the build into independent parts and remove need for polyglot
  images