### PR TITLE
[DET-2937] fix: add missing order for steps in `det t describe`

### DIFF
--- a/cli/determined_cli/trial.py
+++ b/cli/determined_cli/trial.py
@@ -51,7 +51,7 @@ def describe_trial(args: Namespace) -> None:
     trial.start_time()
     trial.state()
 
-    steps = trial.steps()
+    steps = trial.steps(order_by=[gql.steps_order_by(id=gql.order_by.asc)])
     steps.metrics()
     steps.id()
     steps.state()


### PR DESCRIPTION
# Test Plan
- [x] check that `det t describe` returns steps in sorted order when it didn't before
- [x] bug fix: determine if there are other similar bugs in the codebase (I took a quick spin through other CLI queries, but they're all slated to be removed anyway, so I can't say I looked super hard)