### PR TITLE
[DET-2940] fix: remove cd from startup-hook.sh in bert_glue_pytorch

### DIFF
--- a/examples/experimental/bert_glue_pytorch/startup-hook.sh
+++ b/examples/experimental/bert_glue_pytorch/startup-hook.sh
@@ -1,4 +1,1 @@
-git clone --branch v2.2.0 https://github.com/huggingface/transformers.git
-cd transformers
-pip install -e .
-pip install -r ./examples/requirements.txt
+pip install transformers==2.8.0 scikit-learn==0.22.2.post1


### PR DESCRIPTION
# Test Plan
There should be some nightly tests somewhere that test for this... will discuss how we can keep better tabs on these failures on #ml-ag.