### PR TITLE
feat: enable overriding nested package dependencies

### DIFF
--- a/webui/elm/package-lock.json
+++ b/webui/elm/package-lock.json
@@ -674,6 +674,14 @@
         "acorn-node": "^1.6.1",
         "defined": "^1.0.0",
         "minimist": "^1.1.1"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+          "dev": true
+        }
       }
     },
     "dir-glob": {
@@ -732,6 +740,11 @@
         "ws": "3.3.1"
       },
       "dependencies": {
+        "minimist": {
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+        },
         "punycode": {
           "version": "1.4.1",
           "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
@@ -1095,6 +1108,12 @@
           "requires": {
             "graceful-fs": "^4.1.6"
           }
+        },
+        "minimist": {
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+          "dev": true
         },
         "path-key": {
           "version": "3.1.1",
@@ -2098,11 +2117,6 @@
       "requires": {
         "brace-expansion": "^1.1.7"
       }
-    },
-    "minimist": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
     },
     "minipass": {
       "version": "2.9.0",

--- a/webui/elm/package.json
+++ b/webui/elm/package.json
@@ -20,6 +20,7 @@
     "tailwindcss": "^1.2.0"
   },
   "scripts": {
+    "preinstall": "npx npm-force-resolutions",
     "build-elm": "elm make src/Main.elm",
     "build-css": "postcss styles-in.css",
     "live-workaround": "elm-live --pushstate --proxyPrefix /api --proxyHost http://localhost:8080 src/Main.elm --",
@@ -28,5 +29,8 @@
     "lint": "elm-analyse && elm-format",
     "test": "elm-test",
     "graphql": "elm-graphql --base DetQL --scalar-codecs CustomScalarCodecs --introspection-file ../../master/graphql-schema.json"
+  },
+  "resolutions": {
+    "minimist": "^1.2.3"
   }
 }

--- a/webui/react/package-lock.json
+++ b/webui/react/package-lock.json
@@ -15509,12 +15509,6 @@
         "unquote": "^1.1.0"
       }
     },
-    "marked": {
-      "version": "0.3.19",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.19.tgz",
-      "integrity": "sha512-ea2eGWOqNxPcXv8dyERdSr/6FmzvWwzjMxpfGB/sbMccXoct+xY+YukPD+QTUZwyvK7BZwcr4m21WBOW41pAkg==",
-      "dev": true
-    },
     "marksy": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/marksy/-/marksy-8.0.0.tgz",
@@ -15524,6 +15518,14 @@
         "@babel/standalone": "^7.4.5",
         "he": "^1.2.0",
         "marked": "^0.3.12"
+      },
+      "dependencies": {
+        "marked": {
+          "version": "0.7.0",
+          "resolved": "https://registry.npmjs.org/marked/-/marked-0.7.0.tgz",
+          "integrity": "sha512-c+yYdCZJQrsRjTPhUx7VKkApw9bwDkNbHUKo1ovgcfDjb2kc8rLuRbIFyXL5WOEUwzSSKo3IXpph2K6DqB/KZg==",
+          "dev": true
+        }
       }
     },
     "material-colors": {

--- a/webui/react/package.json
+++ b/webui/react/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
+    "preinstall": "npx npm-force-resolutions",
     "start": "react-app-rewired start",
     "build": "react-app-rewired build",
     "lint": "npm run lint:js && npm run lint:css",
@@ -83,5 +84,8 @@
     "stylelint-config-standard": "^20.0.0",
     "stylelint-order": "^4.0.0",
     "typescript": "^3.8.3"
+  },
+  "resolutions": {
+    "marked": "^0.7.0"
   }
 }

--- a/webui/tests/package.json
+++ b/webui/tests/package.json
@@ -21,6 +21,7 @@
     "webpack": "^4.42.1"
   },
   "scripts": {
+    "preinstall": "npx npm-force-resolutions",
     "test": "make e2e-tests",
     "cypress-dev": "make pre-e2e-tests && npx cypress open; make post-e2e-tests",
     "postcypress-dev": "make post-e2e-tests",


### PR DESCRIPTION
Some packages may still be using old and vulnerable dependencies.
To override these vulnerabilities, using npm-force-resolutions to
force overriding nested dependencies with specific version via the
"resolutions" field under package.json, which npm-force-resolutions
will use. npm-force-resolutions will get installed during preinstall
if it does not exist already.
