### PR TITLE
[DET-2856] Allow tasks to specify fitting requirements

### DIFF
--- a/master/internal/checkpoint_gc.go
+++ b/master/internal/checkpoint_gc.go
@@ -27,7 +27,11 @@ func (t *checkpointGCTask) Receive(ctx *actor.Context) error {
 	switch msg := ctx.Message().(type) {
 	case actor.PreStart:
 		ctx.Tell(t.cluster, scheduler.AddTask{
-			Name: fmt.Sprintf("Checkpoint GC (Experiment %d)", t.experiment.ID)})
+			Name: fmt.Sprintf("Checkpoint GC (Experiment %d)", t.experiment.ID),
+			FittingRequirements: scheduler.FittingRequirements{
+				SingleAgent: true,
+			},
+		})
 
 	case scheduler.Assigned:
 		config := t.experiment.Config.CheckpointStorage

--- a/master/internal/command/command.go
+++ b/master/internal/command/command.go
@@ -98,6 +98,9 @@ func (c *command) Receive(ctx *actor.Context) error {
 			SlotsNeeded:  c.config.Resources.Slots,
 			Label:        c.config.Resources.AgentLabel,
 			CanTerminate: true,
+			FittingRequirements: scheduler.FittingRequirements{
+				SingleAgent: true,
+			},
 		})
 		ctx.Tell(c.eventStream, event{Snapshot: newSummary(c), ScheduledEvent: &c.taskID})
 

--- a/master/internal/scheduler/cluster.go
+++ b/master/internal/scheduler/cluster.go
@@ -322,13 +322,14 @@ func (c *Cluster) receiveAddTask(ctx *actor.Context, msg AddTask) {
 	}
 
 	task := newTask(&Task{
-		ID:           taskID,
-		group:        group,
-		handler:      ctx.Sender(),
-		name:         name,
-		slotsNeeded:  msg.SlotsNeeded,
-		canTerminate: msg.CanTerminate,
-		agentLabel:   msg.Label,
+		ID:                  taskID,
+		group:               group,
+		handler:             ctx.Sender(),
+		name:                name,
+		slotsNeeded:         msg.SlotsNeeded,
+		canTerminate:        msg.CanTerminate,
+		agentLabel:          msg.Label,
+		fittingRequirements: msg.FittingRequirements,
 	})
 
 	c.tasksByID[task.ID] = task

--- a/master/internal/scheduler/fair_share_test.go
+++ b/master/internal/scheduler/fair_share_test.go
@@ -235,7 +235,7 @@ func TestFairShare_Schedule_ActiveTasks(t *testing.T) {
 	}
 
 	expected := []schedulerState{
-		{state: taskPending},
+		{state: taskRunning, containers: map[*agentState]int{agents[0]: 3}},
 		{state: taskRunning, containers: map[*agentState]int{agents[1]: 1}},
 		{state: taskRunning, containers: map[*agentState]int{agents[1]: 1}},
 		{state: taskPending},

--- a/master/internal/scheduler/task.go
+++ b/master/internal/scheduler/task.go
@@ -12,12 +12,13 @@ import (
 type (
 	// AddTask adds the sender of the message to the cluster as a task.
 	AddTask struct {
-		ID           *TaskID
-		Name         string
-		Group        *actor.Ref
-		SlotsNeeded  int
-		CanTerminate bool
-		Label        string
+		ID                  *TaskID
+		Name                string
+		Group               *actor.Ref
+		SlotsNeeded         int
+		CanTerminate        bool
+		Label               string
+		FittingRequirements FittingRequirements
 	}
 	// taskStopped notifies that the task actor is stopped.
 	taskStopped struct {
@@ -102,15 +103,16 @@ func isValidTaskStateTransition(cur, next taskState) bool {
 // Task represents a single schedulable unit. A task has a lifecycle that it transitions through
 // in response to scheduling directives.
 type Task struct {
-	ID           TaskID
-	name         string
-	handler      *actor.Ref
-	group        *group
-	slotsNeeded  int
-	canTerminate bool
-	state        taskState
-	agentLabel   string
-	containers   map[ContainerID]*container
+	ID                  TaskID
+	name                string
+	handler             *actor.Ref
+	group               *group
+	slotsNeeded         int
+	canTerminate        bool
+	state               taskState
+	agentLabel          string
+	fittingRequirements FittingRequirements
+	containers          map[ContainerID]*container
 }
 
 // newTask constructs a single task in a pending state from a task template.

--- a/master/internal/trial.go
+++ b/master/internal/trial.go
@@ -284,6 +284,10 @@ func (t *trial) Receive(ctx *actor.Context) error {
 				SlotsNeeded:  slotsNeeded,
 				CanTerminate: true,
 				Label:        label,
+				FittingRequirements: scheduler.FittingRequirements{
+					SingleAgent:    false,
+					DedicatedAgent: slotsNeeded > 1,
+				},
 			}).Get().(*scheduler.Task)
 		}
 	} else if t.experimentState != model.ActiveState {


### PR DESCRIPTION
This will allow us to differentiate in how we schedule different type of tasks. Including allowing us to schedule multi-slot-notebooks that do not take up the entire agent, which was the original ask in this ticket.

In addition adding unit tests. I spun a cluster and launched several different experiments and notebook configurations that use the modified codepath.