### PR TITLE
[DET-2888] feat: experiment download cli command

### DIFF
--- a/common/determined_common/experimental/experiment.py
+++ b/common/determined_common/experimental/experiment.py
@@ -52,9 +52,10 @@ class ExperimentReference:
         self, limit: int, sort_by: Optional[str] = None, smaller_is_better: Optional[bool] = None
     ) -> List[checkpoint.Checkpoint]:
         """
-        Return the n :py:class:`det.experimental.Checkpoint` instances with the best
+        Return the N :py:class:`det.experimental.Checkpoint` instances with the best
         validation metric values as defined by the `sort_by` and `smaller_is_better`
-        arguments.
+        arguments. This command will return the best checkpoint from the
+        top N performing distinct trials of the experiment.
 
         Arguments:
             sort_by (string, optional): The name of the validation metric to


### PR DESCRIPTION
Adds `det experiment download` command for downloading n checkpoints in
sorted order by metric to a local directory.

# Test Plan
- UI change:
  - [ ] add screenshots
  - [ ] React? build & check storybooks
- [ ] user-facing api change: modify documentation and examples
- [ ] user-facing api change: add the "User-facing API Change" label
- [ ] bug fix: add regression test
- [ ] bug fix: determine if there are other similar bugs in the codebase
- [ ] new feature: add test coverage for any user-facing aspects
- [ ] refactor: maintain existing code coverage
