### PR TITLE
fix: target cpu for torch.load in integration tests

### DIFF
--- a/common/determined_common/experimental/checkpoint/_checkpoint.py
+++ b/common/determined_common/experimental/checkpoint/_checkpoint.py
@@ -123,7 +123,9 @@ class Checkpoint(object):
 
         return str(local_ckpt_dir)
 
-    def load(self, path: Optional[str] = None, tags: Optional[List[str]] = None) -> Any:
+    def load(
+        self, path: Optional[str] = None, tags: Optional[List[str]] = None, **kwargs: Any
+    ) -> Any:
         """
         Loads a Determined checkpoint into memory. If the checkpoint is not
         present on disk it will be downloaded from persistent storage.
@@ -136,12 +138,15 @@ class Checkpoint(object):
                 the tensoflow saved_model. See documentation for
                 `tf.compat.v1.saved_model.load_v2
                 <https://www.tensorflow.org/versions/r1.15/api_docs/python/tf/saved_model/load_v2>`_.
+            kwargs: Only relevant for PyTorch checkpoints. The keyword arguments
+                will be applied to torch.load. See documentation for `torch.load
+                <https://pytorch.org/docs/stable/torch.html?highlight=torch%20load#torch.load>`_.
         """
         ckpt_path = self.download(path)
-        return Checkpoint.load_from_path(ckpt_path, tags)
+        return Checkpoint.load_from_path(ckpt_path, tags, **kwargs)
 
     @staticmethod
-    def load_from_path(path: str, tags: Optional[List[str]] = None) -> Any:
+    def load_from_path(path: str, tags: Optional[List[str]] = None, **kwargs: Any) -> Any:
         """
         Loads a Determined checkpoint from a local file system path into
         memory. If the checkpoint is a pytorch model a ``torch.nn.Module`` is returned.
@@ -162,7 +167,9 @@ class Checkpoint(object):
         if checkpoint_type == ModelFramework.PYTORCH:
             import determined_common.experimental.checkpoint._torch
 
-            return determined_common.experimental.checkpoint._torch.load_model(checkpoint_dir)
+            return determined_common.experimental.checkpoint._torch.load_model(
+                checkpoint_dir, **kwargs
+            )
 
         elif checkpoint_type == ModelFramework.TENSORFLOW:
             import determined_common.experimental.checkpoint._tf

--- a/common/determined_common/experimental/checkpoint/_torch.py
+++ b/common/determined_common/experimental/checkpoint/_torch.py
@@ -1,11 +1,12 @@
 import pathlib
 import sys
+from typing import Any
 
 import cloudpickle
 import torch
 
 
-def load_model(ckpt_dir: pathlib.Path) -> torch.nn.Module:
+def load_model(ckpt_dir: pathlib.Path, **kwargs: Any) -> torch.nn.Module:
     code_path = ckpt_dir.joinpath("code")
 
     # We used MLflow's MLmodel checkpoint format in the past. This format
@@ -24,4 +25,4 @@ def load_model(ckpt_dir: pathlib.Path) -> torch.nn.Module:
     code_subdirs = [str(x) for x in code_path.iterdir() if x.is_dir()]
     sys.path = [str(code_path)] + code_subdirs + sys.path
 
-    return torch.load(maybe_model, pickle_module=cloudpickle.pickle)  # type: ignore
+    return torch.load(maybe_model, pickle_module=cloudpickle.pickle, **kwargs)  # type: ignore

--- a/tests/integrations/experiment/test_pytorch.py
+++ b/tests/integrations/experiment/test_pytorch.py
@@ -24,7 +24,12 @@ def test_pytorch_load() -> None:
         config, conf.official_examples_path("mnist_pytorch"), 1
     )
 
-    nn = Determined().get_experiment(experiment_id).top_checkpoint().load()
+    nn = (
+        Determined(conf.make_master_url())
+        .get_experiment(experiment_id)
+        .top_checkpoint()
+        .load(map_location=torch.device("cpu"))
+    )
     assert isinstance(nn, torch.nn.Module)
 
 
@@ -125,7 +130,12 @@ def test_pytorch_cifar10_const() -> None:
         config, conf.official_examples_path("cifar10_cnn_pytorch"), 1
     )
     trials = exp.experiment_trials(experiment_id)
-    nn = Determined().get_trial(trials[0].id).select_checkpoint(latest=True).load()
+    nn = (
+        Determined(conf.make_master_url())
+        .get_trial(trials[0].id)
+        .select_checkpoint(latest=True)
+        .load(map_location=torch.device("cpu"))
+    )
     assert isinstance(nn, torch.nn.Module)
 
 
@@ -140,5 +150,10 @@ def test_pytorch_cifar10_parallel() -> None:
         config, conf.official_examples_path("cifar10_cnn_pytorch"), 1
     )
     trials = exp.experiment_trials(experiment_id)
-    nn = Determined().get_trial(trials[0].id).select_checkpoint(latest=True).load()
+    nn = (
+        Determined(conf.make_master_url())
+        .get_trial(trials[0].id)
+        .select_checkpoint(latest=True)
+        .load(map_location=torch.device("cpu"))
+    )
     assert isinstance(nn, torch.nn.Module)

--- a/tests/integrations/experiment/test_tf_estimator.py
+++ b/tests/integrations/experiment/test_tf_estimator.py
@@ -64,7 +64,7 @@ def test_mnist_estimator_load() -> None:
     )
 
     trials = exp.experiment_trials(experiment_id)
-    model = Determined().get_trial(trials[0].id).top_checkpoint().load()
+    model = Determined(conf.make_master_url()).get_trial(trials[0].id).top_checkpoint().load()
     assert isinstance(model, AutoTrackable)
 
 

--- a/tests/integrations/experiment/test_tf_keras.py
+++ b/tests/integrations/experiment/test_tf_keras.py
@@ -106,7 +106,7 @@ def test_iris() -> None:
     exp_id = exp.run_basic_test_with_temp_config(
         config, conf.official_examples_path("iris_tf_keras"), 1
     )
-    exp_ref = Determined().get_experiment(exp_id)
+    exp_ref = Determined(conf.make_master_url()).get_experiment(exp_id)
     model = exp_ref.top_checkpoint().load()
     model.summary()
 

--- a/tests/integrations/test_system.py
+++ b/tests/integrations/test_system.py
@@ -352,7 +352,7 @@ def test_end_to_end_adaptive() -> None:
     # Check that ExperimentReference returns a sorted order of top checkpoints
     # without gaps. The top 2 checkpoints should be the first 2 of the top k
     # checkpoints if sorting is stable.
-    exp_ref = Determined().get_experiment(exp_id)
+    exp_ref = Determined(conf.make_master_url()).get_experiment(exp_id)
 
     top_2 = exp_ref.top_n_checkpoints(2)
     top_k = exp_ref.top_n_checkpoints(len(trials))


### PR DESCRIPTION
If models are trained on a GPU but loaded on a CPU pytorch throws an
error telling the user to explicitly target the CPU. This commit adds
the ability to pass the `map_location` parameter to `torch.load` in
order to target the CPU.

# Test Plan
- UI change:
  - [ ] add screenshots
  - [ ] React? build & check storybooks
- [ ] user-facing api change: modify documentation and examples
- [ ] user-facing api change: add the "User-facing API Change" label
- [ ] bug fix: add regression test
- [ ] bug fix: determine if there are other similar bugs in the codebase
- [ ] new feature: add test coverage for any user-facing aspects
- [ ] refactor: maintain existing code coverage
