### PR TITLE
fix: include example name as prefix in example tarballs

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -33,7 +33,7 @@ build: $(EXAMPLES_DIRS) sp-html
 $(BUILDDIR)/docs-downloads/examples/%.tgz: ../examples/official/%/
 	find "$<" \( -name __pycache__ -o -name \*.pyc \) -delete
 	mkdir -p $$(dirname "$@")
-	$(TAR) -czf "$@" -C "$<" .
+	$(TAR) -czf "$@" -C $$(dirname "$<") $$(basename "$<")
 
 clean:
 	rm -rf $(TARGETDIR) $(OUTDIR)


### PR DESCRIPTION
We previously created tarballs for the examples without a directory
prefix. As a result, when extracted via `tar` or similar tools, files
would be placed in the shell's present working directory. That is
generally not considered good form.

Instead, we now prefix the files in the example tarballs with the name
of the example. For example, the contents of `mnist_pytorch.tgz` are now
nested under a top-level directory `mnist_pytorch`.

# Test Plan
- UI change:
  - [ ] add screenshots
  - [ ] React? build & check storybooks
- [ ] user-facing api change: modify documentation and examples
- [ ] user-facing api change: add the "User-facing API Change" label
- [ ] bug fix: add regression test
- [ ] bug fix: determine if there are other similar bugs in the codebase
- [ ] new feature: add test coverage for any user-facing aspects
- [ ] refactor: maintain existing code coverage
