### PR TITLE
[DET-2879 DET-2882] Prevent hangs in multi-GPU trials

### DIFF
--- a/harness/determined/exec/worker_process.py
+++ b/harness/determined/exec/worker_process.py
@@ -44,7 +44,13 @@ def main() -> None:
             worker_process_env.rendezvous_info,
             worker_process_env.hvd_config,
         )
-        controller.run()
+
+        try:
+            controller.run()
+
+        except Exception as e:
+            broadcast_client.send_exception_message()
+            raise e
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_ipc.py
+++ b/tests/unit/test_ipc.py
@@ -110,12 +110,12 @@ def test_broadcast_server_client() -> None:
                 for subproc in subprocs:
                     assert subproc.is_alive()
 
-            gathered = broadcast_server.gather_with_polling(health_check)
+            gathered, _ = broadcast_server.gather_with_polling(health_check)
             assert all(isinstance(g, ipc.ReadyMessage) for g in gathered)
 
             for msg in msgs:
                 broadcast_server.broadcast(msg)
-                gathered = broadcast_server.gather_with_polling(health_check)
+                gathered, _ = broadcast_server.gather_with_polling(health_check)
                 assert all(g == 2 * msg for g in gathered)
 
 


### PR DESCRIPTION
Previously during multi-GPU training if a worker process died, if there was no hvd.allreduce() call prior to the next barrier (e.g., if the error occurred while reducing metrics) the worker would die but the trial would hang. This would happen because the  SubProcessLauncher monitors the liveliness of the horovodrun process on the chief machine and the liveliness of the sshd process on the non-chief machines. These processes fail when a worker process fails during or before a hvd.allreduce() call.

Performed a number of manual tests to verify the fix including crashing the chief process and/or a non-chief process during training and validation. 