### PR TITLE
docs: various improvements

### DIFF
--- a/docs/how-to/hyperparameter-tuning.txt
+++ b/docs/how-to/hyperparameter-tuning.txt
@@ -15,6 +15,7 @@ they:
 
 Configuring Hyperparameter Ranges
 ---------------------------------
+
 The first step toward automatic hyperparameter tuning is to define the
 hyperparameter space, e.g., by :ref:`listing the
 decisions<topic-guides_hp-tuning-basics-example-hyperparameters>` that may
@@ -48,31 +49,35 @@ and their associated options.
 Instrumenting Model Code
 ------------------------
 
-Determined injects hyperparameters from the experiment configuration into model
-code via a context object in the Trial base class. This :class:`TrialContext
-<determined.TrialContext>` object exposes a ``get_hparam`` method that takes
-the hyperparameter name.  At trial runtime, Determined injects a value for the
-hyperparameter. For example, to inject the previous section's
-``dropout_probability`` into the constructor of a PyTorch `Dropout
+Determined injects hyperparameters from the experiment configuration
+into model code via a context object in the Trial base class. This
+:class:`TrialContext <determined.TrialContext>` object exposes a
+:func:`get_hparam <determined.TrialContext.get_hparam>` method that
+takes the hyperparameter name.  At trial runtime, Determined injects a
+value for the hyperparameter. For example, to inject the value of the
+``dropout_probability`` hyperparameter defined above into the
+constructor of a PyTorch `Dropout
 <https://pytorch.org/docs/stable/nn.html#dropout>`_ layer:
 
 .. code:: python
 
   nn.Dropout(p=self.context.get_hparam("dropout_probability"))
 
-To see hyperparameter injection throughout a complete Trial implementation:
-:ref:`pytorch-mnist-tutorial`.
+To see hyperparameter injection throughout a complete Trial
+implementation, refer to the :ref:`pytorch-mnist-tutorial`.
 
-Specifying the Searcher
------------------------
-The model developer configures a searcher to implement one of many
-:ref:`supported hyperparameter tuning algorithms<topic-guides_hp-tuning-det>`.
-Aside from the ``single`` searcher, a searcher runs multiple trials and decides
-the hyperparameter values to use in each trial.  Every searcher requires the
-optimization objective ``metric`` field in addition to searcher-specific
-options. For instance, the ``adaptive_simple`` searcher implements adaptive
-downsampling given the maximum number of trials to run and the maximum number of
-training steps allowed per trial:
+Specifying the Search Algorithm
+-------------------------------
+
+Determined supports a :ref:`variety of hyperparameter search algorithms
+<topic-guides_hp-tuning-det>`.  Aside from the ``single`` searcher, a
+searcher runs multiple trials and decides the hyperparameter values to
+use in each trial.  Every searcher is configured with the name of the
+validation metric to optimize (via the ``metric`` field), in addition to
+other searcher-specific options. For example, the ``adaptive_simple``
+searcher implements adaptive downsampling, and is configured with the
+maximum number of trials to run and the maximum number of training steps
+allowed per trial:
 
 .. code:: yaml
 
@@ -83,13 +88,13 @@ training steps allowed per trial:
     max_trials: 32
 
 For details on the supported searchers and their respective configuration
-options: :ref:`topic-guides_hp-tuning-det`.
+options, refer to :ref:`topic-guides_hp-tuning-det`.
 
-That's it!  After submitting a multi-trial hyperparameter tuning experiment to
-Determined, the machine learning engineer can visualize the best validation
-metric observed across all trials over time.  On experiment completion, they can
-view the best hyperparameter settings and also export the associated checkpoint
-for downstream serving.
+That's it!  After submitting a hyperparameter tuning experiment, users
+can easily see the best validation metric observed across all trials
+over time in the WebUI.  After the experiment has completed, they can
+view the hyperparameter values for the best-performing trials, and also
+export the associated model checkpoint for downstream serving.
 
 .. image:: /assets/images/adaptive-experiment-detail.png
 

--- a/docs/how-to/install-cli.txt
+++ b/docs/how-to/install-cli.txt
@@ -3,10 +3,10 @@
 Install Determined CLI
 ======================
 
-Determined includes a **command-line tool** called ``det`` that ML developers
+Determined includes a **command-line tool** called ``det`` that ML engineers
 can use to launch new workloads and interact with Determined.
 
-Each ML developer that wants to use Determined should install a copy of the
+Each ML engineer that wants to use Determined should install a copy of the
 Determined CLI on their local development machine. The CLI can be
 installed via ``pip``:
 
@@ -30,5 +30,5 @@ by setting the ``DET_MASTER`` environment variable:
 You may want to place this into the appropriate configuration file for
 your login shell (e.g., ``.bashrc``).
 
-More information about using the Determined CLI can be found with the command
-``det --help``.
+More information about using the Determined CLI can be found in the
+:ref:`reference documentation <cli>` or by running ``det --help``.

--- a/docs/how-to/install-main.txt
+++ b/docs/how-to/install-main.txt
@@ -11,45 +11,22 @@ cluster should be installed in your training environment.
 
 Install the Determined CLI
 ----------------------------
-The :ref:`Determined CLI <install-cli>` is the command line tool that allows you
-to launch new experiments and interact with a Determined cluster.
+
+The Determined CLI is a command line tool that allows you to launch new
+experiments and interact with a Determined cluster. To install the CLI,
+refer to the :ref:`installation instructions <install-cli>`.
 
 
 .. _install-cluster:
 
 Install a Determined Cluster
 -----------------------------
-A :ref:`Determined cluster <install-cluster>` is comprised of the :ref:`Determined master
-and Determined agents <det-system-architecture>` to run and manage experiments. A
-Determined cluster can be installed on Amazon Web Services (AWS), Google Cloud Platform
-(GCP), or an on-premise cluster.
 
-Within each cluster, Determined runs two third-party services:
-
-- `PostgreSQL <https://www.postgresql.org/>`_ database
-- `Hasura <https://hasura.io>`_ server.
-
-Determined can be installed to use `Docker <https://www.docker.com/>`_ containers
-to run the master and agents. Depending on your installation method, some of these
-services will be installed for you:
-
-- On a cloud provider using ``det-deploy``, the third-party services will be installed for you.
-- On-premise using ``det-deploy``, Docker will need to be installed.
-- Manual install, you will have to install each service yourself.
-
-More information on a Determined cluster can be found:
-
-- :ref:`requirements`
-- :ref:`upgrades`
-- :ref:`troubleshoot`
-
-.. toctree::
-   :titlesonly:
-   :hidden:
-
-   installation/requirements
-   installation/upgrades-troubleshoot
-
+A :ref:`Determined cluster <install-cluster>` is comprised of a
+:ref:`master and one or more agents <det-system-architecture>`. A
+Determined cluster can be installed on Amazon Web Services (AWS), Google
+Cloud Platform (GCP), an on-premise cluster, or on a local development
+machine.
 
 On-premise Deployments
 ~~~~~~~~~~~~~~~~~~~~~~
@@ -88,10 +65,36 @@ to access more computational resources than you might have local access
 to; Determined can also manage your cloud resources for you
 automatically.
 
-To install on the cloud, please follow the instructions for your preferred cloud deployment:
+To install on the cloud, please follow the instructions for your preferred cloud vendor:
 
 .. toctree::
    :titlesonly:
 
    installation/aws
    installation/gcp
+
+Notes
+~~~~~
+
+Each Determined cluster requires two third-party services, `PostgreSQL
+<https://www.postgresql.org/>`_ and `Hasura <https://hasura.io>`_. In
+addition, Determined can use `Docker <https://www.docker.com/>`_ to run
+the master and agents. Depending on your installation method, some of
+these services will be installed for you:
+
+- On a cloud provider using ``det-deploy``, the third-party services will be installed for you.
+- On-premise using ``det-deploy``, Docker will need to be installed.
+- When doing a manual installation, you will have to install each service yourself.
+
+More information on a Determined cluster can be found:
+
+- :ref:`requirements`
+- :ref:`upgrades`
+- :ref:`troubleshoot`
+
+.. toctree::
+   :titlesonly:
+   :hidden:
+
+   installation/requirements
+   installation/upgrades-troubleshoot

--- a/docs/how-to/installation/deploy.txt
+++ b/docs/how-to/installation/deploy.txt
@@ -43,9 +43,9 @@ directory).
    not need to be set.
 
 
-
 Deploying a Single Node Cluster
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 For local development or small clusters (such as a GPU workstation), you may wish to
 to install both a master and an agent on the same node.  To do this, run:
 
@@ -79,7 +79,8 @@ If you want to create more than one agent locally, you can use:
 
 Stopping a Single Node Cluster
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-To stop a determined cluster, on the machine where a determined cluster is currently running, run
+
+To stop a Determined cluster, on the machine where a Determined cluster is currently running, run
 
 .. code::
 
@@ -94,6 +95,7 @@ To stop a determined cluster, on the machine where a determined cluster is curre
 
 Deploying a Standalone Master
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 In many cases, your Determined cluster will be split across multiple nodes.  In this case
 you will need to start a master and agents separately.  In order to start a standalone master, run:
 
@@ -116,7 +118,8 @@ To stop a running master, run:
 
 Deploying Agents
 ~~~~~~~~~~~~~~~~
-To deploy a standalone agent, on the machine you want to run the agent run:
+
+To deploy a standalone agent on a machine, run this command:
 
 .. code::
 

--- a/docs/how-to/installation/docker.txt
+++ b/docs/how-to/installation/docker.txt
@@ -7,9 +7,9 @@ Preliminary Setup
 -----------------
 
 #. :ref:`Install Docker <install-docker>` on all machines in the
-   cluster. If the agents have GPUs, ensure that the
-   :ref:`nvidia-docker2 installation <validate-nvidia-docker2>` on each
-   one is working as expected.
+   cluster. If the agents have GPUs, ensure that the :ref:`Nvidia
+   Container Toolkit <validate-nvidia-container-toolkit>` on each one is
+   working as expected.
 
 #. Pull the official Docker images for PostgreSQL and Hasura. We
    recommend using the versions listed below.

--- a/docs/how-to/installation/packages.txt
+++ b/docs/how-to/installation/packages.txt
@@ -34,8 +34,8 @@ Master and Agent
 
 Before running the Determined agent, you will have to :ref:`install
 Docker <install-docker>` on each agent machine and, if the machine
-has GPUs, ensure that the :ref:`nvidia-docker2 installation
-<validate-nvidia-docker2>` is working as expected.
+has GPUs, ensure that the :ref:`Nvidia Container Toolkit
+<validate-nvidia-container-toolkit>` is working as expected.
 
 Apart from that, the agent follows the same process as the master,
 except that "master" should be replaced by "agent" everywhere it

--- a/docs/how-to/installation/requirements.txt
+++ b/docs/how-to/installation/requirements.txt
@@ -50,13 +50,14 @@ Hardware
 Installing Docker
 -----------------
 
-Every agent node must have Docker installed to allow it to run
-containerized workloads.
+Docker is a dependency of several components of the Determined
+system. For example, every agent node must have Docker installed to
+allow it to run containerized workloads. Similarly, 
 
 Install on Linux
 ~~~~~~~~~~~~~~~~~
 
-#. Install the latest release of Docker and nvidia-docker2.
+#. Install the latest release of Docker and the Nvidia Container Toolkit:
 
    On Ubuntu:
 
@@ -120,3 +121,13 @@ Install on MacOS
    .. code::
 
       brew cask install docker
+
+#. Start Docker.
+
+    .. code::
+
+      open /Applications/Docker.app
+
+Docker on MacOS does not support running containers that use GPUs. As a
+result, Determined agents on MacOS will only be able to run CPU-based
+workloads.

--- a/docs/how-to/installation/upgrades-troubleshoot.txt
+++ b/docs/how-to/installation/upgrades-troubleshoot.txt
@@ -50,10 +50,10 @@ old version of the CLI.
 Troubleshooting Tips
 --------------------
 
-.. _validate-nvidia-docker2:
+.. _validate-nvidia-container-toolkit:
 
-Validating the nvidia-docker2 installation
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Validating Nvidia Container Toolkit
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 To verify that a Determined agent instance can run containers that use GPUs,
 run:

--- a/docs/reference/index.txt
+++ b/docs/reference/index.txt
@@ -6,7 +6,7 @@ Reference guides are raw technical references for our product. They describe how
 **Model Definitions**
   - :ref:`tf-keras-trial`
   - :ref:`pytorch-trial`
-  - :ref:`tensorpack`
+  - :ref:`tensorpack-trial`
   - :ref:`estimator-trial`
 
 **Configurations**

--- a/docs/topic-guides/terminology-concepts.txt
+++ b/docs/topic-guides/terminology-concepts.txt
@@ -38,16 +38,19 @@ experiment
    the main grouping mechanism for training tasks.
 
 master
-   The central component of the Determined system. The master serves the
-   frontend, manages the provisioning and deprovisioning of agents in
-   cloud settings, and schedules trials onto agents. More information
+   The central component of the Determined system. The master schedules
+   workloads onto agents, manages the provisioning and deprovisioning of
+   agents in cloud settings, and serves the frontend. More information
    can be found at :ref:`det-system-architecture`.
 
 model definition
    A specification of a deep learning model written in a supported deep
    learning framework. The model definition contains training code that
    inherits from a Python class provided by Determined
-   (``TFKerasTrial``, ``PyTorchTrial``, or ``EstimatorTrial``). More
+   (:class:`TFKerasTrial <determined.keras.TFKerasTrial>`,
+   :class:`PyTorchTrial <determined.pytorch.PyTorchTrial>`,
+   :class:`EstimatorTrial <determined.estimator.EstimatorTrial>`, or
+   :class:`TensorpackTrial <determined.tensorpack.TensorpackTrial>`). More
    information can be found at :ref:`model-definitions`.
 
 searcher, search algorithm

--- a/docs/tutorials/quick-start.txt
+++ b/docs/tutorials/quick-start.txt
@@ -11,9 +11,9 @@ Prerequisites
 --------------
 - Access to an installation of Determined, either on your own machine or the public cloud. If you have not yet installed Determined, refer to the :ref:`installation instructions <install-cluster>`.
 - The Determined CLI should be installed on your local machine. For installation instructions, see :ref:`here <install-cli>`. After installing the CLI, configure it to connect to your Determined cluster by setting the ``DET_MASTER`` environment variable to the hostname or IP address where Determined is running.
-- For Determined clusters running through ``det-deploy local``: When you run your first experiment, Determined needs to pull down Docker images that contain environment information. The Docker images are then cached for future experiments. We suggest running the following commands to help speed up this process.
+- For Determined clusters installed using ``det-deploy local``: when you run your first experiment, Determined needs to download Docker images with the dependencies needed to run deep learning workloads. This initial download can take some time, depending on the speed of your Internet connection (these images are then cached for future experiments). We suggest running the following commands to help speed up this process:
 
-.. code::
+.. code:: text
 
     # For CPU computations
     docker pull determinedai/environments:py-3.6.9-pytorch-1.4-tf-1.14-cpu-4bd937a
@@ -25,7 +25,7 @@ Prerequisites
 Preparing Your First Job
 -------------------------
 
-In this guide, we will build an image classification model for the MNIST dataset.  MNIST is a dataset consisting of grayscale images of handwritten digits, commonly used to test image classification models as seen below.
+In this guide, we will build an image classification model for the MNIST dataset.  MNIST is a dataset consisting of grayscale images of handwritten digits (as seen below); it is commonly used to test image classification models.
 
 |
 
@@ -36,7 +36,7 @@ In this guide, we will build an image classification model for the MNIST dataset
 
 The code for this guide can be downloaded here: :download:`mnist_pytorch.tgz </examples/mnist_pytorch.tgz>`.
 
-Next, open a terminal window and ``cd`` into the extracted ``mnist_pytorch`` directory. The directory should contain the following files:
+After downloading and extracting the code, open a terminal window and ``cd`` into the ``mnist_pytorch`` directory. The directory should contain the following files:
 
 .. code::
 
@@ -48,7 +48,7 @@ Next, open a terminal window and ``cd`` into the extracted ``mnist_pytorch`` dir
        ├── layers.py
        ├── model_def.py
 
-The directory contains Python and YAML files. The Python files contain the model and data pipeline definitions. The ``.yaml`` files are configuration files that specify the dataset location, hyperparameters, and the number of batches for training. This file also tells Determined the entry point, or where the model class is located. For example, below is the ``const.yaml`` file:
+The Python files contain the model and data pipeline definitions. The ``.yaml`` files are configuration files that specify the dataset location, hyperparameters, and the number of batches of data to use training. The configuration file also tells Determined the entry point, or where the model class is located. For example, below is the ``const.yaml`` file:
 
 .. code:: yaml
 
@@ -87,7 +87,7 @@ We will start by training a single model for a fixed number of batches and with 
 
     det experiment create const.yaml .
 
-This command tells Determined to create a new experiment using the ``const.yaml`` configuration file. Determined also needs the directory containing the model code to upload it to the cluster. In the case above, we run the command in the ``mnist_pytorch`` directory, so we tell the model to upload all the current directory files by using ``.``.
+This command tells Determined to create a new experiment using the ``const.yaml`` configuration file. Determined also needs the directory containing the model code to upload it to the cluster. In the case above, we run the command in the ``mnist_pytorch`` directory, so we tell the CLI to upload all the files in the current directory by using ``.``.
 
 Once the experiment has been submitted, you should see the following output:
 

--- a/docs/tutorials/tf-mnist-tutorial.txt
+++ b/docs/tutorials/tf-mnist-tutorial.txt
@@ -118,7 +118,7 @@ The implementation of ``build_validation_data_loader`` is similar:
         return test_images, test_labels
 
 .. note::
-    When using ``tf.keras.utils.Sequence`` or ``tf.data.Dataset``, users should specify the batch size using ``self.context.get_per_slot_batch_size()``.
+    When loading data from a ``tf.keras.utils.Sequence`` or ``tf.data.Dataset``, users should specify the batch size using :func:`self.context.get_per_slot_batch_size() <determined.TrialContext.get_per_slot_batch_size>`.
 
 Training the Model
 ------------------


### PR DESCRIPTION
* Mention that Docker must be started after installing it via Homebrew
  on MacOS
* Call it "Nvidia Container Toolkit", not "nvidia-docker2"
* Streamline main installation page
* Minor fixes and cleanups elsewhere

# Test Plan
- UI change:
  - [ ] add screenshots
  - [ ] React? build & check storybooks
- [ ] user-facing api change: modify documentation and examples
- [ ] user-facing api change: add the "User-facing API Change" label
- [ ] bug fix: add regression test
- [ ] bug fix: determine if there are other similar bugs in the codebase
- [ ] new feature: add test coverage for any user-facing aspects
- [ ] refactor: maintain existing code coverage
