### PR TITLE
[DET-2972] Fix cifar10_cnn_pytorch bugs and add a convergence test

### DIFF
--- a/examples/official/cifar10_cnn_pytorch/adaptive-advanced.yaml
+++ b/examples/official/cifar10_cnn_pytorch/adaptive-advanced.yaml
@@ -31,3 +31,4 @@ searcher:
   target_trial_steps: 800
   step_budget: 4800
 entrypoint: model_def:CIFARTrial
+min_validation_period: 10

--- a/examples/official/cifar10_cnn_pytorch/adaptive.yaml
+++ b/examples/official/cifar10_cnn_pytorch/adaptive.yaml
@@ -30,3 +30,4 @@ searcher:
   max_steps: 800
   max_trials: 16
 entrypoint: model_def:CIFARTrial
+min_validation_period: 10

--- a/examples/official/cifar10_cnn_pytorch/const.yaml
+++ b/examples/official/cifar10_cnn_pytorch/const.yaml
@@ -14,3 +14,4 @@ searcher:
   max_steps: 50
   smaller_is_better: true
 entrypoint: model_def:CIFARTrial
+min_validation_period: 10

--- a/examples/official/cifar10_cnn_pytorch/const.yaml
+++ b/examples/official/cifar10_cnn_pytorch/const.yaml
@@ -1,3 +1,5 @@
+# Reaches an approximate validation error of ~74.9% after 500 steps (32 epochs).
+
 description: cifar10_pytorch_const
 data:
   url: https://s3-us-west-2.amazonaws.com/determined-ai-datasets/cifar10/cifar-10-python.tar.gz
@@ -11,7 +13,11 @@ hyperparameters:
 searcher:
   name: single
   metric: validation_error
-  max_steps: 50
   smaller_is_better: true
+
+  # 32 images per batch * 100 batches per step = 3,200 images per step
+  # 500 steps * 3,200 images per step = 1,600,000 total images
+  # 1,600,000 images / 50,000 images in training set = 32 epochs training
+  max_steps: 500
 entrypoint: model_def:CIFARTrial
 min_validation_period: 10

--- a/examples/official/cifar10_cnn_pytorch/distributed.yaml
+++ b/examples/official/cifar10_cnn_pytorch/distributed.yaml
@@ -17,3 +17,4 @@ searcher:
   max_steps: 50
   smaller_is_better: true
 entrypoint: model_def:CIFARTrial
+min_validation_period: 10

--- a/examples/official/cifar10_cnn_pytorch/model_def.py
+++ b/examples/official/cifar10_cnn_pytorch/model_def.py
@@ -68,7 +68,6 @@ class CIFARTrial(PyTorchTrial):
             nn.ReLU(),
             nn.Dropout2d(self.context.get_hparam("layer3_dropout")),
             nn.Linear(512, NUM_CLASSES),
-            nn.Softmax(dim=0),
         )
 
         # If loading backbone weights, do not call reset_parameters() or
@@ -91,7 +90,7 @@ class CIFARTrial(PyTorchTrial):
         data, labels = batch
 
         output = model(data)
-        loss = torch.nn.functional.nll_loss(output, labels)
+        loss = torch.nn.functional.cross_entropy(output, labels)
         error = error_rate(output, labels)
         return {"loss": loss, "train_error": error}
 

--- a/examples/official/cifar10_cnn_pytorch/parallel.yaml
+++ b/examples/official/cifar10_cnn_pytorch/parallel.yaml
@@ -17,3 +17,4 @@ searcher:
   max_steps: 50
   smaller_is_better: true
 entrypoint: model_def:CIFARTrial
+min_validation_period: 10

--- a/tests/integrations/test_convergence.py
+++ b/tests/integrations/test_convergence.py
@@ -1,0 +1,29 @@
+import pytest
+
+from tests.integrations import config as conf
+from tests.integrations import experiment as exp
+
+
+@pytest.mark.nightly  # type: ignore
+def test_cifar10_pytorch_accuracy() -> None:
+    config = conf.load_config(conf.official_examples_path("cifar10_cnn_pytorch/const.yaml"))
+    experiment_id = exp.run_basic_test_with_temp_config(
+        config, conf.official_examples_path("cifar10_cnn_pytorch"), 1
+    )
+
+    trials = exp.experiment_trials(experiment_id)
+    trial_metrics = exp.trial_metrics(trials[0].id)
+
+    validation_errors = [
+        step.validation.metrics["validation_metrics"]["validation_accuracy"]
+        for step in trial_metrics.steps
+        if step.validation
+    ]
+
+    target_accuracy = 0.745
+    assert max(validation_errors) > target_accuracy, (
+        "cifar10_cnn_pytorch did not reach minimum target accuracy {} in {} steps."
+        " full validation error history: {}".format(
+            target_accuracy, len(trial_metrics.steps), validation_errors
+        )
+    )


### PR DESCRIPTION
The convergence test will run `cifar10_cnn_pytorch` for 500 steps nightly and verify the validation accuracy is above 74.5%. 

The test experiment I ran takes about ~10 minutes to finish 500 steps and reaches a best validation accuracy of ~74.9%. I set the target threshold accuracy at slightly below that to give some slack for non-deterministic factors. We might need to revisit this based on how flaky this threshold ends up being. 