### PR TITLE
[DET-2963] Add a capability test to `mnist_pytorch_multi_output`

### DIFF
--- a/tests/integrations/nightly/test_capability.py
+++ b/tests/integrations/nightly/test_capability.py
@@ -45,3 +45,13 @@ def test_resnet50() -> None:
     config = conf.set_max_steps(config, 2)
 
     exp.run_basic_test_with_temp_config(config, conf.experimental_path("resnet50_tf_keras"), 1)
+
+
+@pytest.mark.nightly  # type: ignore
+def test_mnist_pytorch_multi_output() -> None:
+    config = conf.load_config(conf.experimental_path("mnist_pytorch_multi_output/const.yaml"))
+    config = conf.set_max_steps(config, 2)
+
+    exp.run_basic_test_with_temp_config(
+        config, conf.experimental_path("mnist_pytorch_multi_output"), 1
+    )


### PR DESCRIPTION
After adding this test, all `experimental` examples should now have capability coverage. 