### PR TITLE
feat: be more lenient about errors in running `nvidia-smi`

### DIFF
--- a/agent/internal/detect.go
+++ b/agent/internal/detect.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/shirou/gopsutil/cpu"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/determined-ai/determined/master/pkg/device"
 )
@@ -69,7 +70,8 @@ func detectGPUs(visibleGPUs string) ([]device.Device, error) {
 	if execError, ok := err.(*exec.Error); ok && execError.Err == exec.ErrNotFound {
 		return nil, nil
 	} else if err != nil {
-		return nil, errors.Wrapf(err, "error while executing nvidia-smi (output: %s)", string(out))
+		log.WithError(err).WithField("output", string(out)).Warnf("error while executing nvidia-smi")
+		return nil, nil
 	}
 
 	devices := make([]device.Device, 0)

--- a/agent/internal/nvidia.go
+++ b/agent/internal/nvidia.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/docker/docker/client"
 	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
 )
 
 const (
@@ -24,7 +25,8 @@ func getNvidiaVersion() (string, error) {
 	if execError, ok := err.(*exec.Error); ok && execError.Err == exec.ErrNotFound {
 		return "", nil
 	} else if err != nil {
-		return "", errors.Wrapf(err, "error while executing nvidia-smi (output: %s)", string(out))
+		log.WithError(err).WithField("output", string(out)).Warnf("error while executing nvidia-smi")
+		return "", nil
 	}
 
 	r := csv.NewReader(strings.NewReader(string(out)))


### PR DESCRIPTION
When an agent Docker image is built with the Nvidia runtime and run without it, the container winds up with an empty `/usr/bin/nvidia-smi` file, which would cause the agent to get an unexpected error and fall over. This changes the agent to log any such errors and continue running instead. It is perhaps a bit broad to handle _all_ errors like so, but it doesn't seem that helpful to add a bunch of code for ferreting out very specific errors, and I think it does make sense to allow the agent to be robust here.

# Test Plan
- [x] run agent normally and check that it detects devices
- [x] run agent modified to run an existing but empty file instead of `nvidia-smi` (or with the environment modified so that searching the path for `nvidia-smi` yields such a file) and check that it prints a reasonable error and falls back to CPU devices
