### PR TITLE
[DET-2973] feat: make agent work with `nvidia-container-toolkit`

### DIFF
--- a/agent/internal/agent.go
+++ b/agent/internal/agent.go
@@ -183,24 +183,11 @@ func (a *agent) setup(ctx *actor.Context) error {
 				ID: i, Brand: "Artificial", UUID: id, Type: device.CPU})
 		}
 	} else {
-		switch ok, err := nvidiaRuntimeInstalled(); {
-		case err != nil:
+		d, err := detectDevices(a.Options.VisibleGPUs)
+		if err != nil {
 			return err
-		case ok:
-			ctx.Log().Info("Nvidia runtime detected")
-			d, err := detectDevices(a.Options.VisibleGPUs)
-			if err != nil {
-				return err
-			}
-			a.Devices = d
-		default:
-			ctx.Log().Warn("Nvidia runtime not found; defaulting to CPU devices")
-			d, err := detectCPUs()
-			if err != nil {
-				return err
-			}
-			a.Devices = d
 		}
+		a.Devices = d
 	}
 	ctx.Log().Info("detected compute devices:")
 	for _, d := range a.Devices {

--- a/agent/internal/nvidia.go
+++ b/agent/internal/nvidia.go
@@ -1,19 +1,16 @@
 package internal
 
 import (
-	"context"
 	"encoding/csv"
 	"io"
 	"os/exec"
 	"strings"
 
-	"github.com/docker/docker/client"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 )
 
 const (
-	nvidiaRuntime        = "nvidia"
 	unknownNvidiaVersion = "Unknown"
 )
 
@@ -41,19 +38,4 @@ func getNvidiaVersion() (string, error) {
 			"error parsing output of nvidia-smi; GPU record should have exactly 1 field")
 	}
 	return record[0], nil
-}
-
-func nvidiaRuntimeInstalled() (bool, error) {
-	c, err := client.NewClientWithOpts(client.FromEnv)
-	if err != nil {
-		return false, errors.Wrap(err, "error connecting to docker daemon")
-	}
-
-	info, err := c.Info(context.Background())
-	if err != nil {
-		return false, errors.Wrap(err, "error retrieving docker system info")
-	}
-
-	_, ok := info.Runtimes[nvidiaRuntime]
-	return ok, nil
 }

--- a/docs/how-to/installation/deploy.txt
+++ b/docs/how-to/installation/deploy.txt
@@ -47,12 +47,16 @@ Deploying a Single Node Cluster
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 For local development or small clusters (such as a GPU workstation), you may wish to
-to install both a master and an agent on the same node.  To do this, run:
+install both a master and an agent on the same node. To do this, run one of the
+following commands:
 
 .. code::
 
+   # If the machine has GPUs:
    det-deploy local fixture-up
 
+   # If the machine doesn't have GPUs:
+   det-deploy local fixture-up --no-gpu
 
 This will start a master and an agent on that machine. To verify that the
 master is running, navigate to ``http://<master-hostname>:8080`` in a
@@ -78,7 +82,7 @@ If you want to create more than one agent locally, you can use:
 
 
 Stopping a Single Node Cluster
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 To stop a Determined cluster, on the machine where a Determined cluster is currently running, run
 
@@ -119,11 +123,15 @@ To stop a running master, run:
 Deploying Agents
 ~~~~~~~~~~~~~~~~
 
-To deploy a standalone agent on a machine, run this command:
+To deploy a standalone agent on a machine, run one of the following commands:
 
 .. code::
 
+   # If the machine has GPUs:
    det-deploy local agent-up <master_hostname>
+
+   # If the machine doesn't have GPUs:
+   det-deploy local agent-up --no-gpu <master_hostname>
 
 This will create an agent on that machine. To verify whether it has
 successfully connected to the master, navigate to the WebUI and check

--- a/docs/how-to/installation/docker.txt
+++ b/docs/how-to/installation/docker.txt
@@ -84,13 +84,24 @@ for Docker:
 Note that the agent requires ``run`` as the first argument if any
 arguments are provided.
 
-By default, the agent will use all the GPUs on the machine to run
-Determined tasks; this behavior can be changed at startup using the
-`NVIDIA_VISIBLE_DEVICES
-<https://github.com/NVIDIA/nvidia-container-runtime#nvidia_visible_devices>`_
-environment variable. GPUs can also be disabled and enabled at runtime
-using the ``det slot disable`` and ``det slot enable`` CLI commands,
-respectively.
+Selecting GPUs
+~~~~~~~~~~~~~~
+
+The ``--gpus`` flag should be used to specify which GPUs the agent will
+have access to; without it, the agent will not have access to any GPUs.
+For example:
+
+.. code::
+
+   # Use all GPUs.
+   docker run --gpus all ...
+   # Use any four GPUs (selected by Docker).
+   docker run --gpus 4 ...
+   # Use the GPUs with the given IDs or UUIDs.
+   docker run --gpus '"device=1,3"' ...
+
+GPUs can also be disabled and enabled at runtime using the ``det slot
+disable`` and ``det slot enable`` CLI commands, respectively.
 
 Docker Networking for Master and Agents
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/how-to/installation/requirements.txt
+++ b/docs/how-to/installation/requirements.txt
@@ -1,9 +1,9 @@
 .. _requirements:
 
 Installation Requirements
-==========================
+=========================
 
-.. _system-requirements: 
+.. _system-requirements:
 
 System Requirements
 -------------------
@@ -55,9 +55,10 @@ system. For example, every agent node must have Docker installed to
 allow it to run containerized workloads.
 
 Install on Linux
-~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~
 
-#. Install the latest release of Docker and the Nvidia Container Toolkit:
+#. Install Docker. We require the version of Docker 19.03 or newer on
+   the machine where the agent is running.
 
    On Ubuntu:
 
@@ -67,11 +68,7 @@ Install on Linux
       curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
       sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
 
-      curl -fsSL https://nvidia.github.io/nvidia-docker/gpgkey | sudo apt-key add -
-      distribution=$(. /etc/os-release;echo $ID$VERSION_ID)
-      curl -s -L https://nvidia.github.io/nvidia-docker/$distribution/nvidia-docker.list | sudo tee /etc/apt/sources.list.d/nvidia-docker.list
-
-      sudo apt-get update && sudo apt-get install -y --no-install-recommends docker-ce nvidia-docker2
+      sudo apt-get update && sudo apt-get install -y --no-install-recommends docker-ce
       sudo systemctl reload docker
       sudo usermod -aG docker $USER
 
@@ -82,20 +79,45 @@ Install on Linux
       sudo yum install -y yum-utils device-mapper-persistent-data lvm2
       sudo yum-config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo
 
+      sudo yum install -y docker-ce
+      sudo systemctl start docker
+
+
+#. If the machine has GPUs that you would like to use with Determined,
+   install the Nvidia Container Toolkit to allow Docker to run
+   containers that use them. For more information, see the `Nvidia
+   documentation <https://github.com/NVIDIA/nvidia-docker>`__.
+
+   On Ubuntu:
+
+   .. code::
+
+      curl -fsSL https://nvidia.github.io/nvidia-docker/gpgkey | sudo apt-key add -
+      distribution=$(. /etc/os-release;echo $ID$VERSION_ID)
+      curl -s -L https://nvidia.github.io/nvidia-docker/$distribution/nvidia-docker.list | sudo tee /etc/apt/sources.list.d/nvidia-docker.list
+      sudo apt-get update
+
+      sudo apt-get install -y --no-install-recommends nvidia-container-toolkit
+      sudo systemctl restart docker
+
+   On CentOS:
+
+   .. code::
+
       distribution=$(. /etc/os-release;echo $ID$VERSION_ID)
       curl -fsSL https://nvidia.github.io/nvidia-docker/$distribution/nvidia-docker.repo | sudo tee /etc/yum.repos.d/nvidia-docker.repo
 
-      sudo yum install -y docker-ce nvidia-docker2
-      sudo systemctl start docker
+      sudo yum install -y nvidia-container-toolkit
+      sudo systemctl restart docker
 
-#. Log out and start a new terminal session. Verify that the current user
-   is in the ``docker`` group and that the ``nvidia`` Docker runtime is
-   installed:
+#. Log out and start a new terminal session. Verify that the current
+   user is in the ``docker`` group and, if the machine has GPUs, that
+   Docker can start a container using them.
 
    .. code::
 
       groups
-      docker info | grep Runtimes
+      docker run --gpus all --rm debian:10-slim nvidia-smi
 
 #. If using CentOS 7, `enable the persistent storage
    <https://unix.stackexchange.com/a/159390>`_ of journalctl log

--- a/docs/how-to/installation/upgrades-troubleshoot.txt
+++ b/docs/how-to/installation/upgrades-troubleshoot.txt
@@ -1,4 +1,3 @@
-
 .. _upgrades-troubleshootings:
 
 .. _upgrades:
@@ -45,7 +44,7 @@ All users should also upgrade the CLI by running
 Be sure to do this for every user or virtualenv that has installed the
 old version of the CLI.
 
-.. _troubleshoot: 
+.. _troubleshoot:
 
 Troubleshooting Tips
 --------------------
@@ -60,7 +59,7 @@ run:
 
 .. code::
 
-   docker run --runtime=nvidia --rm nvidia/cuda:10.0-runtime nvidia-smi
+   docker run --gpus all --rm debian:10-slim nvidia-smi
 
 You should see output that describes the GPUs available on the agent
 instance, such as:
@@ -101,11 +100,13 @@ Error messages
    docker: Error response from daemon: OCI runtime create failed: container_linux.go:345: starting container process caused "process_linux.go:424: container init caused \"process_linux.go:407: running prestart hook 1 caused \\\"error running hook: exit status 1, stdout: , stderr: exec command: [/usr/bin/nvidia-container-cli --load-kmods configure --ldconfig=@/sbin/ldconfig --device=all --compute --utility --require=cuda>=10.0 brand=tesla,driver>=384,driver<385 brand=tesla,driver>=410,driver<411 --pid=35777 /var/lib/docker/devicemapper/mnt/7b5b6d59cd4fe9307b7523f1cc9ce3bc37438cc793ff4a5a18a0c0824ec03982/rootfs]\\\\nnvidia-container-cli: requirement error: unsatisfied condition: brand = tesla\\\\n\\\"\"": unknown.
 
 If you see the above error message, the GPU hardware and/or NVIDIA
-drivers installed on the agent are not compatible with CUDA 10.0. Please
-try re-running the Docker command with a version of CUDA that is
-compatible with the hardware and driver setup, e.g., the following for
-CUDA 9.0:
+drivers installed on the agent are not compatible with CUDA 10, but you
+are trying to run a Docker image that depends on CUDA 10. Please run the
+commands below; if the first succeeds and the second fails, you should
+be able to use Determined as long as you use Docker images based on
+CUDA 9.
 
 .. code::
 
-   docker run --runtime=nvidia --rm nvidia/cuda:9.0-runtime nvidia-smi
+   docker run --gpus all --rm nvidia/cuda:9.0-runtime nvidia-smi
+   docker run --gpus all --rm nvidia/cuda:10.0-runtime nvidia-smi

--- a/docs/reference/cluster-config.txt
+++ b/docs/reference/cluster-config.txt
@@ -231,7 +231,7 @@ The master supports the following configuration settings:
     For example, it can be used for formatting and mounting a disk. Defaults
     to an empty string.
 
-  - ``container_startup_script``: Startup script for the container 
+  - ``container_startup_script``: Startup script for the container
     ``determined-agent`` runs in. This script will run right away when
     the agent's container starts up. For example, this script can be used
     to configure docker so the agent can pull task images from GCR securely.
@@ -242,7 +242,7 @@ The master supports the following configuration settings:
     "determined".
 
   - ``agent_docker_runtime``: The Docker runtime to use for the Determined
-    agent and task containers. Defaults to ``nvidia``.
+    agent and task containers. Defaults to ``runc``.
 
   - ``agent_docker_image``: The Docker image to use for the Determined agents.
     A valid form is ``determinedai/determined-agent:<version>``. (*Required*)

--- a/master/internal/config_test.go
+++ b/master/internal/config_test.go
@@ -45,7 +45,7 @@ provisioner:
 		},
 		Scheduler: scheduler.Config{Fit: "best"},
 		Provisioner: &provisioner.Config{
-			AgentDockerRuntime: "nvidia",
+			AgentDockerRuntime: "runc",
 			AgentDockerNetwork: "default",
 			MaxIdleAgentPeriod: provisioner.Duration(30 * time.Second),
 		},

--- a/master/internal/provisioner/agent_setup_test.go
+++ b/master/internal/provisioner/agent_setup_test.go
@@ -21,7 +21,7 @@ func TestAgentSetupScript(t *testing.T) {
 		StartupScriptBase64:          encodedScript,
 		ContainerStartupScriptBase64: encodedContainerScript,
 		AgentDockerImage:             "test_docker_image",
-		AgentDockerRuntime:           "nvidia",
+		AgentDockerRuntime:           "runc",
 		AgentNetwork:                 "default",
 		AgentID:                      "test.id",
 	}
@@ -42,7 +42,7 @@ echo "#### PRINTING CONTAINER STARTUP SCRIPT START ####"
 cat /usr/local/determined/container_startup_script
 echo "#### PRINTING CONTAINER STARTUP SCRIPT END ####"
 
-docker run --init --name determined-agent  --restart always --network default --runtime=nvidia \
+docker run --init --name determined-agent  --restart always --network default --runtime=runc --gpus all \
     -e DET_AGENT_ID="test.id" \
     -e DET_MASTER_HOST="test.master" \
     -e DET_MASTER_PORT="8080" \

--- a/master/internal/provisioner/config.go
+++ b/master/internal/provisioner/config.go
@@ -58,7 +58,7 @@ type Config struct {
 // DefaultConfig returns the default configuration of the provisioner.
 func DefaultConfig() *Config {
 	return &Config{
-		AgentDockerRuntime: "nvidia",
+		AgentDockerRuntime: "runc",
 		AgentDockerNetwork: "default",
 		MaxIdleAgentPeriod: Duration(300 * time.Second),
 	}

--- a/master/internal/provisioner/config_test.go
+++ b/master/internal/provisioner/config_test.go
@@ -19,7 +19,7 @@ func TestProvisionerConfigMissingFields(t *testing.T) {
 	assert.ErrorContains(t, err, "must configure aws or gcp cluster")
 	expected := Config{
 		MaxIdleAgentPeriod: Duration(5 * time.Minute),
-		AgentDockerRuntime: "nvidia",
+		AgentDockerRuntime: "runc",
 		AgentDockerNetwork: "default",
 	}
 	assert.DeepEqual(t, config, expected)
@@ -49,7 +49,7 @@ func TestUnmarshalProvisionerConfigMasterURL(t *testing.T) {
 	unmarshaled := Config{
 		MasterURL:          "http://test.master:8080",
 		AgentDockerImage:   "test_image",
-		AgentDockerRuntime: "nvidia",
+		AgentDockerRuntime: "runc",
 		AgentDockerNetwork: "default",
 		AWS:                &awsConfig,
 		MaxIdleAgentPeriod: Duration(30 * time.Second),
@@ -97,7 +97,7 @@ func TestUnmarshalProvisionerConfigWithAWS(t *testing.T) {
 		MasterURL:          "http://test.master:8080",
 		AWS:                &awsConfig,
 		AgentDockerImage:   "test_image",
-		AgentDockerRuntime: "nvidia",
+		AgentDockerRuntime: "runc",
 		AgentDockerNetwork: "default",
 		MaxIdleAgentPeriod: Duration(30 * time.Second),
 	}
@@ -128,7 +128,7 @@ func TestUnmarshalProvisionerConfigWithGCP(t *testing.T) {
 		MasterURL:          "http://test.master:8080",
 		GCP:                &expected,
 		AgentDockerImage:   "test_image",
-		AgentDockerRuntime: "nvidia",
+		AgentDockerRuntime: "runc",
 		AgentDockerNetwork: "default",
 		MaxIdleAgentPeriod: Duration(5 * time.Minute),
 	}

--- a/master/pkg/container/container.go
+++ b/master/pkg/container/container.go
@@ -28,3 +28,14 @@ func (c Container) Transition(new State) Container {
 	return Container{
 		Parent: c.Parent, ID: c.ID, State: new, Devices: c.Devices, Recoverable: c.Recoverable}
 }
+
+// GPUDeviceUUIDs returns the UUIDs of the devices for this container that are GPUs.
+func (c Container) GPUDeviceUUIDs() []string {
+	var uuids []string
+	for _, d := range c.Devices {
+		if d.Type == device.GPU {
+			uuids = append(uuids, d.UUID)
+		}
+	}
+	return uuids
+}

--- a/master/static/srv/agent_setup_script.sh.template
+++ b/master/static/srv/agent_setup_script.sh.template
@@ -13,7 +13,7 @@ echo "#### PRINTING CONTAINER STARTUP SCRIPT START ####"
 cat /usr/local/determined/container_startup_script
 echo "#### PRINTING CONTAINER STARTUP SCRIPT END ####"
 
-docker run --init --name determined-agent {{.LogOptions}} --restart always --network {{.AgentNetwork}} --runtime={{.AgentDockerRuntime}} \
+docker run --init --name determined-agent {{.LogOptions}} --restart always --network {{.AgentNetwork}} --runtime={{.AgentDockerRuntime}} --gpus all \
     -e DET_AGENT_ID="{{.AgentID}}" \
     -e DET_MASTER_HOST="{{.MasterHost}}" \
     -e DET_MASTER_PORT="{{.MasterPort}}" \

--- a/packaging/master.yaml
+++ b/packaging/master.yaml
@@ -32,8 +32,8 @@
 ## set to "host", Docker host-mode networking will be used instead. Defaults to "default".
 #  agent_docker_network: default
 
-## The docker runtime to use for the agent when using dynamic agent. Defaults to "nvidia".
-#  agent_docker_runtime: nvidia
+## The docker runtime to use for the agent when using dynamic agent. Defaults to "runc.
+#  agent_docker_runtime: runc
 
 ## The docker image to use for the agent when using dynamic agents. This value
 ## must be configured.


### PR DESCRIPTION
Things are a bit confusing due to unclear messaging by Nvidia, but here's what's going on:

- There is a repo called [`nvidia-docker`](https://github.com/NVIDIA/nvidia-docker). `nvidia-docker` is not the name of any package currently described there.
- That repo currently recommends a package called `nvidia-container-toolkit` (or "the NVIDIA Container Toolkit") that works on Docker >= 19.03.
- That repo used to describe (and still references in a few places) a now-deprecated package called `nvidia-docker2` that was for Docker < 19.03 (though it still works for newer versions).
- They make a big deal about the newer version of Docker having "native" support for GPUs, but the only user-facing change is the name of the package and the flag used to select GPUs.

(The above points led to some confusion earlier, since `nvidia-container-toolkit` could reasonably be described as "`nvidia-docker`", "not `nvidia-docker`", or "a newer version of `nvidia-docker2`" depending on exactly which parts of that page you're thinking about.)

The method of setting up containers with GPUs in the API is totally different between the two packages; this change moves the agent, the provisioner, and `det-deploy` (the last requiring monkey patching, unfortunately) to the new method so that people following the recommended Nvidia+Docker instructions get working GPU slots. I chose to strip out the old method entirely, which forces a dependency on Docker 19.03 but saves on detecting and branching for different versions. (The agent already implicitly depended on Docker 19.03 by default, by virtue of the Docker library defaulting to an API version requiring it; that could've been worked around that by overriding the API version with an environment variable, but I don't think anyone is doing that.)

There'll need to be more changes to the provisioner to handle dynamic agents without GPUs if that's a case we care about, but I'm aiming to put those in a separate PR.

# Test Plan
- [x] Run `det-deploy` with the toolkit installed and not and check that the agent picks up on GPUs

Run the agent under the following circumstances:
- [x] GPUs, `nvidia-container-toolkit` installed (GPUs are exposed as slots)
- [x] GPUs, `nvidia-container-toolkit` not installed (agent doesn't get confused about whether there are GPUs or not and doesn't expose GPU slots)
- [x] no GPUs, `nvidia-container-toolkit` installed (agent doesn't expose GPU slots)
- [x] no GPUs, `nvidia-container-toolkit` not installed (agent doesn't expose GPU slots)

