### PR TITLE
[DET-2945] fix: exit out of non-chief containers gracefully

### DIFF
--- a/harness/determined/estimator/_estimator_trial.py
+++ b/harness/determined/estimator/_estimator_trial.py
@@ -292,6 +292,9 @@ class DeterminedControlHook(tf.estimator.SessionRunHook):  # type: ignore
                 path = cast(pathlib.Path, args[0])
                 response_func(self._checkpoint_model(path))
             elif wkld.kind == workload.Workload.Kind.TERMINATE:
+                response_func(
+                    {} if self.estimator_trial_controller.is_chief else workload.Skipped()
+                )
                 raise det.errors.WorkerFinishedGracefully("Exiting normally.")
             else:
                 raise AssertionError(f"Unknown wkld kind {wkld.kind}.")

--- a/harness/determined/keras/_tf_keras_trial.py
+++ b/harness/determined/keras/_tf_keras_trial.py
@@ -466,6 +466,7 @@ class TFKerasTrialController(det.LoopTrialController):
             elif wkld.kind == workload.Workload.Kind.TERMINATE:
                 self.model.stop_training = True
                 self.expect_terminate = True
+                response_func({} if self.is_chief else workload.Skipped())
                 break
             else:
                 raise AssertionError(f"Unknown wkld kind {wkld.kind}.")

--- a/harness/determined/pytorch/_pytorch_trial.py
+++ b/harness/determined/pytorch/_pytorch_trial.py
@@ -257,6 +257,7 @@ class PyTorchTrialController(det.LoopTrialController):
                 path = cast(pathlib.Path, args[0])
                 response_func(self._save(path))
             elif w.kind == workload.Workload.Kind.TERMINATE:
+                response_func({} if self.is_chief else workload.Skipped())
                 break
             else:
                 raise AssertionError("Unexpected workload: {}".format(w.kind))

--- a/harness/determined/tensorpack/_tensorpack_trial.py
+++ b/harness/determined/tensorpack/_tensorpack_trial.py
@@ -250,6 +250,7 @@ class ManagerCallback(tp.callbacks.Callback):  # type: ignore
                 path = cast(pathlib.Path, args[0])
                 response_func(self.save_checkpoint(path))
             elif wkld.kind == workload.Workload.Kind.TERMINATE:
+                response_func({} if self.is_chief else workload.Skipped())
                 raise det.errors.WorkerFinishedGracefully("Exiting normally.")
             else:
                 raise AssertionError(f"Unknown wkld kind {wkld.kind}")


### PR DESCRIPTION
To exit out of a trial, the harness processes a Terminate message. When using a subprocess
to train (multi-GPU), the subrprocess launcher waits to receive a reply from all the subprocesses
or until a health check fails while a Terminate message is being process to reply to the socket and
workload manager that the Terminate has completed. Previously, the trial controllers would not respond to the Terminate message. On the chief agent that started  horvodrun, the health check would fail because the horovodrun process would exit out once all the subprocesses completed, and the containers would terminate with error code of 0. On the other agents, the sshd process would remain alive, thus the health checks would never fail, and the container would not exit until forcibly being killed, resulting in a 137 error code. Now all processes respond to the terminate message, allowing all containers to self-terminate.

Tested manually.
