### PR TITLE
fix: allow OSX interactive session during det user create

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -606,6 +606,7 @@ jobs:
       - setup-python-venv:
           determined-common: true
           determined-cli: true
+          extra-requirements-file: "webui/tests/requirements.txt"
           executor: ubuntu-1604:202004-01
       - setup-local-cluster:
           det-version: ${CIRCLE_SHA1}

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@
 -r cli/tests/requirements.txt
 -r harness/tests/requirements.txt
 -r e2e_tests/tests/requirements.txt
+-r webui/tests/requirements.txt
 
 black>=19.3b0
 flake8>=3.8.0

--- a/webui/tests/bin/createUserAndExperiments.py
+++ b/webui/tests/bin/createUserAndExperiments.py
@@ -4,8 +4,9 @@ import pathlib
 import pexpect
 import subprocess
 
-test_username = "userwithpw"
-test_password = "specialpw"
+USER_WITH_PASSWORD_USERNAME = "user-w-pw"
+USER_WITH_PASSWORD_PASSWORD = "special-pw"
+USER_WITHOUT_PASSWORD_USERNAME = "user-wo-pw"
 
 
 def wait_for_process(process):
@@ -21,28 +22,38 @@ def wait_for_process(process):
         process.wait()
 
 
-# Create a non-default user for testing purposes. The CLI reads a password using `getpass`, which
-# reads from `/dev/tty`; Pexpect is a portable way to simulate the TTY input. (On Linux, `echo |
-# setsid -w determined ...` would work (https://unix.stackexchange.com/a/68591),
-# but the `setsid` command does not seem to be generally available on macOS.)
-p = pexpect.spawn("det", ["-u", "admin", "user", "create", test_username])
-p.expect("Password.*:")
-p.sendline("")
-wait_for_process(p)
+def login_as(username, password=""):
+    p = pexpect.spawn("det", ["user", "login", username])
+    p.expect("Password.*:")
+    p.sendline(password)
+    wait_for_process(p)
 
-# Change the password for the newly create user
-p = pexpect.spawn("det", ["-u", "admin", "user", "change-password", test_username])
-p.expect("New password.*:")
-p.sendline(test_password)
-p.expect("Confirm password:")
-p.sendline(test_password)
-wait_for_process(p)
 
-# Log into CLI as the newly created user
-p = pexpect.spawn("det", ["user", "login", test_username])
-p.expect("Password.*:")
-p.sendline(test_password)
-wait_for_process(p)
+def create_user(username, password=""):
+    p = pexpect.spawn("det", ["-u", "admin", "user", "create", username])
+    p.expect(pexpect.EOF)
+    wait_for_process(p)
+
+    if password != "":
+        p = pexpect.spawn("det", ["-u", "admin", "user", "change-password", username])
+        p.expect("New password.*:")
+        p.sendline(password)
+        p.expect("Confirm password:")
+        p.sendline(password)
+        wait_for_process(p)
+
+
+# First login as admin to avoid having to authenticate downstream
+login_as("admin")
+
+# Create a non-default user without a password
+create_user(USER_WITHOUT_PASSWORD_USERNAME)
+
+# Create a non-default user with a password
+create_user(USER_WITH_PASSWORD_USERNAME, USER_WITH_PASSWORD_PASSWORD)
+
+# Login as non-default user with password
+login_as(USER_WITH_PASSWORD_USERNAME, USER_WITH_PASSWORD_PASSWORD)
 
 # Create experiments
 determined_root_dir = pathlib.Path(__file__).absolute().parents[3]

--- a/webui/tests/bin/createUserAndExperiments.py
+++ b/webui/tests/bin/createUserAndExperiments.py
@@ -1,11 +1,52 @@
 #!/usr/bin/env python
 
 import pathlib
+import pexpect
 import subprocess
 
+test_username = "userwithpw"
+test_password = "specialpw"
+
+
+def wait_for_process(process):
+    # Avoid hang on macOS
+    # https://github.com/pytest-dev/pytest/issues/2022
+    while True:
+        try:
+            process.read_nonblocking()
+        except Exception:
+            break
+
+    if process.isalive():
+        process.wait()
+
+
+# Create a non-default user for testing purposes. The CLI reads a password using `getpass`, which
+# reads from `/dev/tty`; Pexpect is a portable way to simulate the TTY input. (On Linux, `echo |
+# setsid -w determined ...` would work (https://unix.stackexchange.com/a/68591),
+# but the `setsid` command does not seem to be generally available on macOS.)
+p = pexpect.spawn("det", ["-u", "admin", "user", "create", test_username])
+p.expect("Password.*:")
+p.sendline("")
+wait_for_process(p)
+
+# Change the password for the newly create user
+p = pexpect.spawn("det", ["-u", "admin", "user", "change-password", test_username])
+p.expect("New password.*:")
+p.sendline(test_password)
+p.expect("Confirm password:")
+p.sendline(test_password)
+wait_for_process(p)
+
+# Log into CLI as the newly created user
+p = pexpect.spawn("det", ["user", "login", test_username])
+p.expect("Password.*:")
+p.sendline(test_password)
+wait_for_process(p)
+
+# Create experiments
 determined_root_dir = pathlib.Path(__file__).absolute().parents[3]
 experiment_dir = determined_root_dir.joinpath("e2e_tests", "tests", "fixtures", "no_op")
-
 
 for _ in range(4):
     subprocess.run(
@@ -18,15 +59,3 @@ for _ in range(4):
         ],
         check=True,
     )
-
-
-# Create a non-default user for testing purposes. The CLI reads a password using `getpass`, which
-# reads from `/dev/tty`; Pexpect is a portable way to simulate the TTY input. (On Linux, `echo |
-# setsid -w determined ...` would work (https://unix.stackexchange.com/a/68591),
-# but the `setsid` command does not seem to be generally available on macOS.)
-# FIXME The script is blocking here on macOS. We disable this and its corresponding tests for the
-# time being until it's fixed.
-# p = pexpect.spawn("det", ["-u", "admin", "u", "create", "hoid"])
-# p.expect("Password.*:")
-# p.sendline("")
-# p.wait()

--- a/webui/tests/cypress/support/commands.js
+++ b/webui/tests/cypress/support/commands.js
@@ -3,12 +3,12 @@
 // https://on.cypress.io/custom-commands
 // ***********************************************
 
-const DEFAULT_TEST_USERNAME = 'userwithpw';
-const DEFAULT_TEST_PASSWORD = 'specialpw';
+const DEFAULT_TEST_USERNAME = 'user-w-pw';
+const DEFAULT_TEST_PASSWORD = 'special-pw';
 
 const sha512 = require('js-sha512').sha512;
 
-const saltAndHashPassword = (password) => {
+const saltAndHashPassword = password => {
   if (!password) return '';
   const passwordSalt = 'GubPEmmotfiK9TMD6Zdw';
   return sha512(passwordSalt + password);

--- a/webui/tests/cypress/support/commands.js
+++ b/webui/tests/cypress/support/commands.js
@@ -3,7 +3,16 @@
 // https://on.cypress.io/custom-commands
 // ***********************************************
 
-const DEFAULT_TEST_USER = 'determined';
+const DEFAULT_TEST_USERNAME = 'userwithpw';
+const DEFAULT_TEST_PASSWORD = 'specialpw';
+
+const sha512 = require('js-sha512').sha512;
+
+const saltAndHashPassword = (password) => {
+  if (!password) return '';
+  const passwordSalt = 'GubPEmmotfiK9TMD6Zdw';
+  return sha512(passwordSalt + password);
+};
 
 Cypress.Commands.add('dataCy', (value) => {
   return cy.get(`[data-test=${value}]`);
@@ -13,7 +22,7 @@ Cypress.Commands.add('checkLoggedIn', username => {
   // Check for the presence/absence of the icons for the user dropdown and
   // cluster page link in the top bar, which should be present if and only if
   // the user is logged in.
-  username = username || DEFAULT_TEST_USER;
+  username = username || DEFAULT_TEST_USERNAME;
   cy.visit('/');
   cy.get('#avatar').should('exist');
   cy.get('#avatar').should('have.text', username.charAt(0).toUpperCase());
@@ -26,7 +35,10 @@ Cypress.Commands.add('checkLoggedOut', () => {
 
 // TODO use Cypress.env to share (and bring in) some of the contants used.
 Cypress.Commands.add('login', credentials => {
-  credentials = credentials || { username: DEFAULT_TEST_USER };
+  credentials = credentials || {
+    password: saltAndHashPassword(DEFAULT_TEST_PASSWORD),
+    username: DEFAULT_TEST_USERNAME,
+  };
   cy.request('POST', '/login', credentials)
     .then(response => {
       expect(response.body).to.have.property('token');

--- a/webui/tests/package-lock.json
+++ b/webui/tests/package-lock.json
@@ -5134,6 +5134,12 @@
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
       "dev": true
     },
+    "js-sha512": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/js-sha512/-/js-sha512-0.8.0.tgz",
+      "integrity": "sha512-PWsmefG6Jkodqt+ePTvBZCSMFgN7Clckjd0O7su3I0+BW2QWUTJNzjktHsztGLhncP2h8mcF9V9Y2Ha59pAViQ==",
+      "dev": true
+    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -5162,12 +5168,6 @@
       "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
       "dev": true,
       "optional": true
-    },
-    "json-format": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json-format/-/json-format-1.0.1.tgz",
-      "integrity": "sha1-FD9n5irxKda//tKIpGJl6iPQ3ww=",
-      "dev": true
     },
     "json-parse-better-errors": {
       "version": "1.0.2",
@@ -5866,16 +5866,6 @@
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
       "dev": true
-    },
-    "npm-force-resolutions": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/npm-force-resolutions/-/npm-force-resolutions-0.0.3.tgz",
-      "integrity": "sha512-xbIPAGzD3nrJHDLtnRFt/O83teTA8ju5pWTf8W6OKL4D0XD9EjdRNJhzg4bSXWuucE+l1HGdTpOJR/l1Mi1Ycg==",
-      "dev": true,
-      "requires": {
-        "json-format": "^1.0.1",
-        "source-map-support": "^0.5.5"
-      }
     },
     "npm-run-path": {
       "version": "2.0.2",

--- a/webui/tests/package.json
+++ b/webui/tests/package.json
@@ -16,6 +16,7 @@
     "eslint": "^6.8.0",
     "eslint-plugin-cypress": "^2.10.3",
     "eslint-plugin-import": "^2.20.2",
+    "js-sha512": "^0.8.0",
     "ts-loader": "^6.2.2",
     "typescript": "^3.8.3",
     "webpack": "^4.42.1"

--- a/webui/tests/requirements.txt
+++ b/webui/tests/requirements.txt
@@ -1,0 +1,2 @@
+docker
+pexpect


### PR DESCRIPTION
terminal output on OSX
```
Waiting for master to be available...
Waiting for master to be available...
Waiting for master to be available...
Starting determined_integrations_5300-agent-0
+ python /Users/ck/Projects/determined/webui/tests/bin/createUserAndExperiments.py
Preparing files (/Users/ck/Projects/determined/tests/integrations/fixtures/no_op) to send to master... 17.0KB and 16 files
Created experiment 1
Preparing files (/Users/ck/Projects/determined/tests/integrations/fixtures/no_op) to send to master... 17.0KB and 16 files
Created experiment 2
Preparing files (/Users/ck/Projects/determined/tests/integrations/fixtures/no_op) to send to master... 17.0KB and 16 files
Created experiment 3
Preparing files (/Users/ck/Projects/determined/tests/integrations/fixtures/no_op) to send to master... 17.0KB and 16 files
Created experiment 4
+ yarn --cwd /Users/ck/Projects/determined/webui/tests run cypress run --config-file cypress.json --config defaultCommandTimeout=4000,baseUrl=http://localhost:5300 --browser chrome --headless
yarn run v1.22.4
```