### PR TITLE
ci: allow manual approvals to be provided immediately

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -940,8 +940,6 @@ workflows:
               ignore:
                 - /pull\/.*/
                 - master
-          requires:
-            - build-and-push-docker-images
 
       - request-dev-deploy:
           type: approval
@@ -950,8 +948,6 @@ workflows:
               ignore:
                 - /pull\/.*/
                 - master
-          requires:
-            - build-and-push-docker-images
 
       - deploy:
           context: aws
@@ -970,6 +966,7 @@ workflows:
                 - /pull\/.*/
           requires:
             - request-dev-deploy
+            - build-and-push-docker-images
 
       - parallel-tests:
           context: aws
@@ -998,6 +995,7 @@ workflows:
                 - master
           requires:
             - request-gpu-tests
+            - build-and-push-docker-images
 
 
       - e2e-gpu-tests:
@@ -1009,6 +1007,7 @@ workflows:
                 - master
           requires:
             - request-gpu-tests
+            - build-and-push-docker-images
 
 
   nightly:


### PR DESCRIPTION
The manual approval request steps (for GPU tests and deploying) in CircleCI had dependencies on the Docker build steps, which meant we had to wait a few minutes after pushing to provide the approvals. Removing the dependencies will mean we can immediately approve after pushing and then let the build and tests/deployment run from there.

# Test Plan
- [x] push this branch to the central repo and check that the request steps are available immediately (though I didn't see the need to actually do the approval)