### PR TITLE
fix: avoid crash in PyTorch trial when debug mode is on

### DIFF
--- a/harness/determined/pytorch/_pytorch_trial.py
+++ b/harness/determined/pytorch/_pytorch_trial.py
@@ -446,7 +446,7 @@ class PyTorchTrialController(det.LoopTrialController):
     @staticmethod
     def _convert_metrics_to_numpy(metrics: Dict[str, Any]) -> Dict[str, Any]:
         for metric_name, metric_val in metrics.items():
-            logging.debug(metric_name, metric_val)
+            logging.debug("Value of metric {metric_name}: {metric_val}")
             if isinstance(metric_val, torch.Tensor):
                 logging.debug(f"Converting {metric_name} to CPU.")
                 metrics[metric_name] = metric_val.cpu().numpy()


### PR DESCRIPTION
The `logging.debug` that was present before would interpret the metric name as a format string and attempt to interpolate the metric value into it.

# Test Plan
- [x] run a PyTorch experiment (`examples/official/mnist_pytorch`) with `debug: true` and see that it prints something instead of crashing