### PR TITLE
chore: update OS setup scripts

### DIFF
--- a/scripts/setup-env-arch.sh
+++ b/scripts/setup-env-arch.sh
@@ -1,47 +1,44 @@
 #!/bin/bash
 
-set -e
+set -e -x
 
-## Specify the script/command that can install packages from both AUR and official Arch repos.
+# A command that can install both AUR and official packages; edit this if you use a different tool.
 PKG_INSTALL_COMMAND=(yay -S --needed)
 
-PKGS=(docker go python36 python-virtualenvwrapper)
+PKGS=(docker go npm python36)
 
-if which "${PKG_INSTALL_COMMAND[0]}" > /dev/null; then
-  echo "Installing packages: ${PKGS[@]}..."
-else
-  >&2 echo "Problem finding the install script!"
+if ! command -v "${PKG_INSTALL_COMMAND[0]}" >/dev/null; then
+  echo "Problem finding the install command ${PKG_INSTALL_COMMAND[0]}!" >&2
   exit 1
 fi
 
-"${PKG_INSTALL_COMMAND[@]}" "${PKGS[@]}"
-sudo usermod -aG docker "$USER"
-
-## Install Nvidia support for Docker.
-read -p "Do you have an Nvidia GPU and want to install Nvidia GPU support (y/n)? " -n 1 -r
-if [[ $REPLY =~ ^[Yy]$ ]]; then
-  echo "Installing nvidia-docker and setting the default configuration."
-  "${PKG_INSTALL_COMMAND[@]}" nvidia-docker
-
-  ## Set Docker's default runtime to the Nvidia one.
-  if [ -f /etc/docker/daemon.json ]; then
-    sudo tee -a /etc/docker/daemon.json.backup > /dev/null < /etc/docker/daemon.json 
-  fi
-  sudo sh -c 'echo <<EOT > /etc/docker/daemon.json
-  {
-    "default-runtime": "nvidia",
-    "runtimes": {
-      "nvidia": {
-        "path": "/usr/bin/nvidia-container-runtime",
-        "runtimeArgs": []
-      }
-    }
-  }
-  EOT'
+# Read user choices.
+read -r -p "Do you have an NVIDIA GPU and want to enable Docker GPU support? [y/n] "
+if [[ $REPLY =~ ^[Yy].*$ ]]; then
+  PKGS+=(nvidia-container-toolkit)
 fi
 
-sudo systemctl enable --now docker
+# Download things.
+echo "Installing packages: ${PKGS[*]}..."
+"${PKG_INSTALL_COMMAND[@]}" "${PKGS[@]}"
 
-## Set up Determined virtualenv.
-mkdir -p ~/.virtualenvs
-python3.6 -m venv ~/.virtualenvs/det
+# Configure local things.
+sudo usermod -aG docker "$USER"
+sudo systemctl enable docker
+sudo systemctl restart docker
+
+set +x
+echo -e '
+\x1b[32;1mInstallation complete!\x1b[m
+
+You may want to run the following commands:
+
+- To ensure that Go-related tools installed by Determined can be found:
+
+    export PATH="$(go env GOPATH)"/bin:"$PATH"
+
+  This command should also be added to your shell initialization script.
+
+- To set up a Python virtualenv for use with Determined:
+
+    python3.6 -m venv ~/.virtualenvs/determined'

--- a/scripts/setup-env-centos.sh
+++ b/scripts/setup-env-centos.sh
@@ -1,30 +1,56 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e -x
 
+PKGS=(docker-ce golang krb5-devel nodejs nvidia-container-toolkit python36 python36-devel)
+
+# Read user choices.
+read -r -p "Do you have an NVIDIA GPU and want to enable Docker GPU support? [y/n] "
+if [[ $REPLY =~ ^[Yy].*$ ]]; then
+    PKGS+=(nvidia-container-toolkit)
+fi
+
+# Download things.
 sudo yum install -y yum-utils device-mapper-persistent-data lvm2
 sudo yum-config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo
 
-distribution=$(. /etc/os-release;echo $ID$VERSION_ID)
-curl -fsSL https://nvidia.github.io/nvidia-docker/$distribution/nvidia-docker.repo | \
-    sudo tee /etc/yum.repos.d/nvidia-docker.repo
+distribution=$(
+  . /etc/os-release
+  echo "$ID$VERSION_ID"
+)
+curl -fsSL https://nvidia.github.io/nvidia-docker/"$distribution"/nvidia-docker.repo |
+  sudo tee /etc/yum.repos.d/nvidia-docker.repo
 
 sudo rpm --import https://mirror.go-repo.io/centos/RPM-GPG-KEY-GO-REPO
 curl -fsSL https://mirror.go-repo.io/centos/go-repo.repo | sudo tee /etc/yum.repos.d/go-repo.repo
 
-sudo yum install -y \
-  docker-ce \
-  golang \
-  krb5-devel \
-  nodejs \
-  nvidia-docker2 \
-  python36 \
-  python36-devel
-sudo systemctl start docker
+sudo yum install -y "${PKGS[@]}"
 
 curl -fsSL https://bootstrap.pypa.io/get-pip.py | sudo python3.6
 
 sudo pip3 install virtualenvwrapper
 
-sudo usermod -aG docker $USER
-echo "source /usr/bin/virtualenvwrapper.sh" >> ~/.bashrc
+# Configure local things.
+sudo usermod -aG docker "$USER"
+sudo systemctl enable docker
+sudo systemctl restart docker
+
+echo -e "\x1b[1mConsider adding the following line to your shell startup script:\x1b[m"
+echo
+echo "    . /usr/bin/virtualenvwrapper.sh"
+
+set +x
+echo -e '
+\x1b[32;1mInstallation complete!\x1b[m
+
+You may want to run the following commands:
+
+- To ensure that Go-related tools installed by Determined can be found:
+
+    export PATH="$(go env GOPATH)"/bin:"$PATH"
+
+  This command should also be added to your shell initialization script.
+
+- To set up a Python virtualenv for use with Determined:
+
+    mkvirtualenv ~/.virtualenvs/determined'

--- a/scripts/setup-env-macos.sh
+++ b/scripts/setup-env-macos.sh
@@ -1,31 +1,38 @@
 #!/bin/bash
 set -x
 
-# Quick install script for mac
-
-# Install homebrew
+# Install Homebrew.
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
 
-# Brew install all packages
+# Brew install all packages.
 brew upgrade
 
 brew install \
-	go \
-	libomp \
-	node \
-	git \
-	pyenv \
-	yarn
+  go \
+  node \
+  git \
+  pyenv \
+  yarn
 
 brew cask install \
-	docker
+  docker
 
-# Install Python 3.6 and virtualenv
-pyenv install 3.6.9
-python3 -m pip install virtualenv
+pyenv install 3.6.10
 
-# Set up go mono repo
-mkdir -p "$HOME/go"
-mkdir -p "$HOME/go/bin"
-mkdir -p "$HOME/go/pkg"
-mkdir -p "$HOME/go/src"
+# Set up Determined virtualenv.
+
+set +x
+echo -e '
+\x1b[32;1mInstallation complete!\x1b[m
+
+You may want to run the following commands:
+
+- To ensure that Go-related tools installed by Determined can be found:
+
+    export PATH="$(go env GOPATH)"/bin:"$PATH"
+
+  This command should also be added to your shell initialization script.
+
+- To set up a Python virtualenv for use with Determined:
+
+    "$(pyenv root)"/versions/3.6.10/bin/python -m venv ~/.virtualenvs/determined'

--- a/scripts/setup-env-ubuntu.sh
+++ b/scripts/setup-env-ubuntu.sh
@@ -1,7 +1,16 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e -x
 
+PKGS=(build-essential docker-ce golang-go libkrb5-dev nodejs python3-venv)
+
+# Read user choices.
+read -r -p "Do you have an NVIDIA GPU and want to enable Docker GPU support? [y/n] "
+if [[ $REPLY =~ ^[Yy].*$ ]]; then
+    PKGS+=(nvidia-container-toolkit)
+fi
+
+# Download things.
 sudo apt-get install -y --no-install-recommends curl software-properties-common
 
 curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
@@ -10,22 +19,29 @@ sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubun
 curl -fsSL https://nvidia.github.io/nvidia-docker/gpgkey | sudo apt-key add -
 curl -fsSL https://nvidia.github.io/nvidia-docker/ubuntu"$(lsb_release -rs)"/nvidia-docker.list | sudo tee /etc/apt/sources.list.d/nvidia-docker.list
 
-curl -fsSL https://deb.nodesource.com/setup_11.x | sudo -E bash -
+curl -fsSL https://deb.nodesource.com/setup_12.x | sudo -E bash -
 
-sudo add-apt-repository -y ppa:deadsnakes/ppa
 sudo add-apt-repository -y ppa:longsleep/golang-backports
 
-sudo apt-get update && sudo apt-get install -y --no-install-recommends \
-    build-essential \
-    docker-ce \
-    golang-go \
-    libkrb5-dev \
-    nodejs \
-    nvidia-docker2 \
-    python3.6 \
-    python3.6-dev \
-    virtualenvwrapper
-sudo systemctl reload docker
+sudo apt-get update && sudo apt-get install -y --no-install-recommends "${PKGS[@]}"
 
-sudo usermod -aG docker $USER
-echo "source /usr/share/virtualenvwrapper/virtualenvwrapper.sh" >> ~/.bashrc
+# Configure local things.
+sudo usermod -aG docker "$USER"
+sudo systemctl enable docker
+sudo systemctl restart docker
+
+set +x
+echo -e '
+\x1b[32;1mInstallation complete!\x1b[m
+
+You may want to run the following commands:
+
+- To ensure that Go-related tools installed by Determined can be found:
+
+    export PATH="$(go env GOPATH)"/bin:"$PATH"
+
+  This command should also be added to your shell initialization script.
+
+- To set up a Python virtualenv for use with Determined:
+
+    python3 -m venv ~/.virtualenvs/determined'


### PR DESCRIPTION
- Update the scripts to use the newer `nvidia-toolkit-container` package rather than the deprecated `nvidia-docker2` one, since the rest of the system has just switched over.

- Remove the use of `virtualenvwrapper` in favor of the Python-recommended `python -m venv` (except on CentOS, since it seems to be awkward to get the latter to work there).

- Reorder each script into "install things from the network" followed by "do local setup things".

- Make the scripts consistently handle the Docker service (they all enable it, to avoid somebody coming back after a reboot and being surprised that it's not running, and restart it, which is necessary to pick up GPU support after installing the toolkit).

- Apply `shfmt`.

# Test Plan
- [x] run the Linux scripts on fresh machines and check that they complete and do something reasonable (the `virtualenvwrapper` stuff is broken on CentOS, but no more than it was before, and I don't feel like figuring it out right now)