### PR TITLE
feat: create generic callback support for PyTorch

### DIFF
--- a/docs/reference/api/pytorch.txt
+++ b/docs/reference/api/pytorch.txt
@@ -81,6 +81,15 @@ structures of the following types, which will be fed directly to the
           "label": (torch.Tensor([0, 0]), torch.Tensor([[0, 0], [0, 0]])),
       }
 
+Trial Context
+~~~~~~~~~~~~~
+
+``determined.pytorch.PyTorchTrialContext`` subclasses :ref:`trial-context`.
+It provides useful methods for writing ``Trial`` subclasses.
+
+.. autoclass:: determined.pytorch.PyTorchTrialContext
+    :members:
+
 Examples
 --------
 

--- a/docs/reference/api/pytorch.txt
+++ b/docs/reference/api/pytorch.txt
@@ -20,6 +20,9 @@ determined.pytorch
 .. autoclass:: determined.pytorch.Reducer
     :members:
 
+.. autoclass:: determined.pytorch.PyTorchCallback
+    :members:
+
 .. _pytorch-data-loading:
 
 Data Loading

--- a/docs/reference/api/trial_context.txt
+++ b/docs/reference/api/trial_context.txt
@@ -8,7 +8,7 @@ All ``Trial`` subclasses receive a ``TrialContext`` object as an argument to
 their ``__init__()`` method:
 
 - :class:`~determined.pytorch.PyTorchTrial` subclasses receive a
-  plain :class:`~determined.TrialContext`.
+  plain :class:`~determined.PyTorchTrialContext`.
 
 - :class:`~determined.keras.TFKerasTrial` subclasses receive a
   :class:`~determined.keras.TFKerasTrialContext`.

--- a/harness/determined/errors.py
+++ b/harness/determined/errors.py
@@ -17,9 +17,6 @@ class InvalidExperimentException(BaseException):
     InvalidExperimentException is used if an experiment is invalid.
     """
 
-    def __init__(self, message: str) -> None:
-        super().__init__(message)
-
 
 class InvalidDataTypeException(InvalidExperimentException):
     """

--- a/harness/determined/pytorch/__init__.py
+++ b/harness/determined/pytorch/__init__.py
@@ -9,6 +9,7 @@ from determined.pytorch._data import (
     data_length,
     to_device,
 )
+from determined.pytorch._callback import PyTorchCallback
 from determined.pytorch._lr_scheduler import LRScheduler, _LRHelper
 from determined.pytorch._reducer import Reducer, _reduce_metrics
 from determined.pytorch._pytorch_trial import PyTorchTrial, PyTorchTrialController, reset_parameters

--- a/harness/determined/pytorch/__init__.py
+++ b/harness/determined/pytorch/__init__.py
@@ -12,4 +12,5 @@ from determined.pytorch._data import (
 from determined.pytorch._callback import PyTorchCallback
 from determined.pytorch._lr_scheduler import LRScheduler, _LRHelper
 from determined.pytorch._reducer import Reducer, _reduce_metrics
+from determined.pytorch._pytorch_context import PyTorchTrialContext
 from determined.pytorch._pytorch_trial import PyTorchTrial, PyTorchTrialController, reset_parameters

--- a/harness/determined/pytorch/_callback.py
+++ b/harness/determined/pytorch/_callback.py
@@ -15,9 +15,9 @@ class PyTorchCallback:
         over checkpoints.
 
     .. warning::
-        If distributed or parallel training is enabled, every shard will
+        If distributed or parallel training is enabled, every GPU will
         execute a copy of this callback (except for on_validation_step_end).
-        To configure a callback implementation to execute on a subset of shards,
+        To configure a callback implementation to execute on a subset of GPUs,
         please condition your implementation on
         ``trial.context.distributed.get_rank()``.
     """
@@ -33,12 +33,12 @@ class PyTorchCallback:
         Run after every training step ends.
 
         ..warning::
-            If distributed or parallel training is enabled, every shard will
+            If distributed or parallel training is enabled, every GPU will
             execute a copy of this callback on train step end. If
             ``optimizations.average_training_metrics`` is enabled, then the
-            ``metrics`` will be averaged across all shards before the callback
+            ``metrics`` will be averaged across all GPUs before the callback
             is executed.  If ``optimizations.average_training_metrics`` is
-            disabled, then the ``metrics`` will be local to the shard.
+            disabled, then the ``metrics`` will be local to the GPU.
         """
         pass
 
@@ -53,7 +53,7 @@ class PyTorchCallback:
         Run after every validation step ends.
 
         .. warning::
-            This callback currently only executes on the chief shard in the
+            This callback currently only executes on the chief GPU in the
             distributed and/or parallel training setting.
         """
         pass

--- a/harness/determined/pytorch/_callback.py
+++ b/harness/determined/pytorch/_callback.py
@@ -1,0 +1,89 @@
+from typing import Any, Dict
+
+import torch
+
+
+class PyTorchCallback:
+    """
+    Abstract base class used to define a callback that should execute during
+    the lifetime of a PyTorchTrial.
+
+    .. warning::
+        If you are defining a stateful callback (e.g. it mutates a self
+        attribute over it's lifetime), you must also override state_dict() and
+        load_state_dict() to ensure this state can be serialized and deserialized
+        over checkpoints.
+
+    .. warning::
+        If distributed or parallel training is enabled, every shard will
+        execute a copy of this callback (except for on_validation_step_end).
+        To configure a callback implementation to execute on a subset of shards,
+        please condition your implementation on
+        ``trial.context.distributed.get_rank()``.
+    """
+
+    def on_train_step_start(self, step_id: int) -> None:
+        """
+        Run before every training step begins.
+        """
+        pass
+
+    def on_train_step_end(self, step_id: int, metrics: Dict[str, Any]) -> None:
+        """
+        Run after every training step ends.
+
+        ..warning::
+            If distributed or parallel training is enabled, every shard will
+            execute a copy of this callback on train step end. If
+            ``optimizations.average_training_metrics`` is enabled, then the
+            ``metrics`` will be averaged across all shards before the callback
+            is executed.  If ``optimizations.average_training_metrics`` is
+            disabled, then the ``metrics`` will be local to the shard.
+        """
+        pass
+
+    def on_validation_step_start(self) -> None:
+        """
+        Run before every validation step begins.
+        """
+        pass
+
+    def on_validation_step_end(self, metrics: Dict[str, Any]) -> None:
+        """
+        Run after every validation step ends.
+
+        .. warning::
+            This callback currently only executes on the chief shard in the
+            distributed and/or parallel training setting.
+        """
+        pass
+
+    def state_dict(self) -> Dict[str, Any]:
+        """
+        Serialize the state of this callback to a dictionary. Return value must
+        be pickle-able.
+        """
+        return {}
+
+    def load_state_dict(self, state_dict: Dict[str, Any]) -> None:
+        """
+        Load the state of this using the deserialized state_dict.
+        """
+        pass
+
+
+class ReduceLROnPlateauEveryValidationStep(PyTorchCallback):
+    def __init__(
+        self, reduce_lr_on_plateau: torch.optim.lr_scheduler.ReduceLROnPlateau, metric_name: str
+    ):
+        self.reduce_lr_on_plateau = reduce_lr_on_plateau
+        self.metric_name = metric_name
+
+    def on_validation_step_end(self, metrics: Dict[str, Any]) -> None:
+        self.reduce_lr_on_plateau.step(metrics[self.metric_name])
+
+    def state_dict(self) -> Dict[str, Any]:
+        return self.reduce_lr_on_plateau.state_dict()
+
+    def load_state_dict(self, state_dict: Dict[str, Any]) -> None:
+        self.reduce_lr_on_plateau.load_state_dict(state_dict)

--- a/harness/determined/pytorch/_pytorch_context.py
+++ b/harness/determined/pytorch/_pytorch_context.py
@@ -1,0 +1,57 @@
+from typing import Any, Optional, cast
+
+import torch
+import torch.nn as nn
+
+import determined as det
+from determined import pytorch
+from determined_common import check
+
+
+class PyTorchTrialContext(det.TrialContext):
+    """
+    Base context class that contains runtime information for any Determined
+    workflow that uses the ``pytorch`` API.
+    """
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+
+        # The following three attributes are initialized during the lifetime of
+        # a PyTorchTrialContext.
+        self.model = None  # type: Optional[nn.Module]
+        self.optimizer = None
+        self.lr_scheduler = None  # type: Optional[pytorch.LRScheduler]
+
+    def get_model(self) -> torch.nn.Module:
+        """
+        Get the model associated with the trial. This function should not be
+        called from:
+            * ``__init__``
+            * ``build_model()``
+        """
+
+        check.check_not_none(self.model)
+        return cast(torch.nn.Module, self.model)
+
+    def get_optimizer(self) -> torch.optim.Optimizer:  # type: ignore
+        """
+        Get the optimizer associated with the trial. This function should not be
+        called from:
+            * ``__init__``
+            * ``build_model()``
+            * ``optimizer()``
+        """
+        check.check_not_none(self.optimizer)
+        return self.optimizer
+
+    def get_lr_scheduler(self) -> Optional[pytorch.LRScheduler]:
+        """
+        Get the scheduler associated with the trial, if one is defined. This
+        function should not be called from:
+            * ``__init__``
+            * ``build_model()``
+            * ``optimizer()``
+            * ``create_lr_scheduler()``
+        """
+        return self.lr_scheduler

--- a/harness/determined/pytorch/_pytorch_context.py
+++ b/harness/determined/pytorch/_pytorch_context.py
@@ -27,6 +27,7 @@ class PyTorchTrialContext(det.TrialContext):
         """
         Get the model associated with the trial. This function should not be
         called from:
+
             * ``__init__``
             * ``build_model()``
         """
@@ -38,6 +39,7 @@ class PyTorchTrialContext(det.TrialContext):
         """
         Get the optimizer associated with the trial. This function should not be
         called from:
+
             * ``__init__``
             * ``build_model()``
             * ``optimizer()``
@@ -49,6 +51,7 @@ class PyTorchTrialContext(det.TrialContext):
         """
         Get the scheduler associated with the trial, if one is defined. This
         function should not be called from:
+
             * ``__init__``
             * ``build_model()``
             * ``optimizer()``

--- a/harness/determined/pytorch/_pytorch_trial.py
+++ b/harness/determined/pytorch/_pytorch_trial.py
@@ -20,6 +20,7 @@ from determined.pytorch import (
     LRScheduler,
     Reducer,
     TorchData,
+    _callback,
     _Data,
     _LRHelper,
     _reduce_metrics,
@@ -60,7 +61,20 @@ class PyTorchTrialController(det.LoopTrialController):
         # Track whether a warning logging category has already been issued to the user.
         self.warning_logged = {_WarningLogs.FAILED_MOVING_TO_DEVICE: False}
 
-        self._init_model()
+        self._init_model_and_optimizer()
+
+        self.callbacks = self.trial.build_callbacks()
+
+        # If a load path is provided load weights and restore the data location.
+        self._load()
+
+        self._configure_amp()
+
+        if self.hvd_config.use:
+            hvd.broadcast_parameters(self.model.state_dict(), root_rank=0)
+            hvd.broadcast_optimizer_state(self.optimizer, root_rank=0)
+
+        self.training_iterator = iter(self.training_loader)
 
     @staticmethod
     def pre_execute_hook(env: det.EnvContext, hvd_config: horovod.HorovodContext) -> None:
@@ -110,7 +124,7 @@ class PyTorchTrialController(det.LoopTrialController):
             self.device = torch.device("cpu")
         check.is_not_none(self.device)
 
-    def _init_model(self) -> None:
+    def _init_model_and_optimizer(self) -> None:
         self.optimizer = self.trial.optimizer(self.model)
         # TODO: Check that optimizer is not an amp optimizer.
 
@@ -138,18 +152,6 @@ class PyTorchTrialController(det.LoopTrialController):
             logging.debug("Initialized mode for native parallel training.")
 
         self.lr_helper = _LRHelper(self.trial.create_lr_scheduler(self.optimizer))
-
-        # If a load path is provided load weights and restore the data location.
-        self._load()
-
-        self._configure_amp()
-
-        if self.hvd_config.use:
-            hvd.broadcast_parameters(self.model.state_dict(), root_rank=0)
-            hvd.broadcast_optimizer_state(self.optimizer, root_rank=0)
-
-        # Initialize training and validation iterators.
-        self.training_iterator = iter(self.training_loader)
 
     def _check_evaluate_implementation(self) -> None:
         """
@@ -346,13 +348,16 @@ class PyTorchTrialController(det.LoopTrialController):
     def _train_for_step(self, step_id: int, batches_per_step: int) -> workload.Response:
         check.gt(step_id, 0)
 
-        step_idx = step_id - 1
-        start = step_idx * batches_per_step
-        end = start + batches_per_step
-
         # Set the behavior of certain layers (e.g., dropout) that are different
         # between training and inference.
         self.model.train()
+
+        for callback in self.callbacks.values():
+            callback.on_train_step_start(step_id)
+
+        step_idx = step_id - 1
+        start = step_idx * batches_per_step
+        end = start + batches_per_step
 
         per_batch_metrics = []  # type: List[Dict]
         num_inputs = 0
@@ -434,14 +439,20 @@ class PyTorchTrialController(det.LoopTrialController):
         if self.hvd_config.use and self.hvd_config.average_training_metrics:
             per_batch_metrics = self._average_training_metrics(per_batch_metrics)
 
-        if not self.is_chief:
-            return workload.Skipped()
-
         if self.hvd_config.use:
             num_inputs *= hvd.size()
 
+        metrics = det.util.make_metrics(num_inputs, per_batch_metrics)
+
+        for callback in self.callbacks.values():
+            callback.on_train_step_end(step_id, metrics)
+
+        if not self.is_chief:
+            return workload.Skipped()
+
         logging.debug(f"Done training step: {num_inputs} records in {batches_per_step} batches.")
-        return det.util.make_metrics(num_inputs, per_batch_metrics)
+
+        return metrics
 
     @staticmethod
     def _convert_metrics_to_numpy(metrics: Dict[str, Any]) -> Dict[str, Any]:
@@ -457,6 +468,10 @@ class PyTorchTrialController(det.LoopTrialController):
         # Set the behavior of certain layers (e.g., dropout) that are
         # different between training and inference.
         self.model.eval()
+
+        for callback in self.callbacks.values():
+            callback.on_validation_step_start()
+
         num_inputs = 0
         metrics = {}  # type: Optional[Dict[str, Any]]
 
@@ -515,8 +530,15 @@ class PyTorchTrialController(det.LoopTrialController):
                 metrics = self._convert_metrics_to_numpy(metrics)
                 num_inputs = self.context.get_per_slot_batch_size() * len(self.validation_loader)
 
+        # TODO(yoavz): If any validation step end callbacks are defined,
+        # broadcast metrics across all shards here and execute the callback
+        # function on all shards.
+
         if not self.is_chief:
             return workload.Skipped()
+
+        for callback in self.callbacks.values():
+            callback.on_validation_step_end(metrics)  # type: ignore
 
         return {"num_inputs": num_inputs, "validation_metrics": metrics}
 
@@ -634,6 +656,19 @@ class PyTorchTrialController(det.LoopTrialController):
         self.optimizer.load_state_dict(checkpoint["optimizer_state_dict"])
         self.lr_helper.load_state_dict(checkpoint.get("lr_scheduler"))
 
+        callback_state = checkpoint.get("callbacks", {})
+        for name in self.callbacks:
+            if name in callback_state:
+                self.callbacks[name].load_state_dict(callback_state[name])
+            elif util.is_overridden(
+                self.callbacks[name].load_state_dict, _callback.PyTorchCallback
+            ):
+                logging.warning(
+                    "Callback '{}' implements load_state_dict(), but no callback state "
+                    "was found for that name when restoring from checkpoint. This "
+                    "callback will be initialized from scratch"
+                )
+
     def _save(self, path: pathlib.Path) -> workload.Response:
         if not self.is_chief:
             return workload.Skipped()
@@ -673,6 +708,10 @@ class PyTorchTrialController(det.LoopTrialController):
 
         if self.lr_helper:
             checkpoint["lr_scheduler"] = self.lr_helper.state_dict()
+
+        for name, callback in self.callbacks.items():
+            checkpoint.setdefault("callbacks", {})
+            checkpoint["callbacks"][name] = callback.state_dict()
 
         torch.save(  # type: ignore
             checkpoint, str(path.joinpath("state_dict.pth")), pickle_module=cloudpickle
@@ -738,6 +777,33 @@ class PyTorchTrial(det.Trial):
         """
         pass
 
+    def create_lr_scheduler(
+        self, optimizer: torch.optim.Optimizer  # type: ignore
+    ) -> Optional[LRScheduler]:
+        """
+        Create a learning rate scheduler for the trial given an instance of the
+        optimizer.
+
+        Arguments:
+            optimizer (torch.optim.Optimizer): instance of the optimizer to be
+                used for training
+
+        Returns:
+            :py:class:`det.pytorch.LRScheduler`:
+                Wrapper around a :obj:`torch.optim.lr_scheduler._LRScheduler`.
+        """
+        pass
+
+    def build_callbacks(self) -> Dict[str, _callback.PyTorchCallback]:
+        """
+        Defines a dictionary of string names to callbacks (if any) to be used
+        during training and/or validation.
+
+        The string name will be used as the key to save and restore callback
+        state for any callback that defines load_state_dict() and state_dict().
+        """
+        return {}
+
     def evaluate_batch(self, batch: TorchData, model: nn.Module) -> Dict[str, Any]:
         """
         Calculate evaluation metrics for a batch and return them as a
@@ -775,23 +841,6 @@ class PyTorchTrial(det.Trial):
         device, even when multiple devices (slots) are used for training. Only
         one of :meth:`evaluate_full_dataset` and :meth:`evaluate_batch` should
         be overridden by a trial.
-        """
-        pass
-
-    def create_lr_scheduler(
-        self, optimizer: torch.optim.Optimizer  # type: ignore
-    ) -> Optional[LRScheduler]:
-        """
-        Create a learning rate scheduler for the trial given an instance of the
-        optimizer.
-
-        Arguments:
-            optimizer (torch.optim.Optimizer): instance of the optimizer to be
-                used for training
-
-        Returns:
-            :py:class:`det.pytorch.LRScheduler`:
-                Wrapper around a :obj:`torch.optim.lr_scheduler._LRScheduler`.
         """
         pass
 

--- a/harness/determined/pytorch/_pytorch_trial.py
+++ b/harness/determined/pytorch/_pytorch_trial.py
@@ -18,6 +18,7 @@ from determined.horovod import hvd
 from determined.pytorch import (
     DataLoader,
     LRScheduler,
+    PyTorchTrialContext,
     Reducer,
     TorchData,
     _callback,
@@ -50,29 +51,31 @@ class PyTorchTrialController(det.LoopTrialController):
         self.trial = cast(PyTorchTrial, trial_inst)
         self._check_evaluate_implementation()
 
-        self.model = self.trial.build_model()
+        self._init_device()
+        self._init_model()
 
         # Validation loader will be undefined on process ranks > 0
         # when the user defines `validate_full_dataset()`.
         self.validation_loader = None  # type: Optional[torch.utils.data.DataLoader]
-
         self._set_data_loaders()
 
         # Track whether a warning logging category has already been issued to the user.
         self.warning_logged = {_WarningLogs.FAILED_MOVING_TO_DEVICE: False}
 
-        self._init_model_and_optimizer()
+        self._init_optimizer()
+
+        self.context.lr_scheduler = self.trial.create_lr_scheduler(self.context.optimizer)
+        self.lr_helper = _LRHelper(self.context.lr_scheduler)
 
         self.callbacks = self.trial.build_callbacks()
 
         # If a load path is provided load weights and restore the data location.
         self._load()
-
         self._configure_amp()
 
         if self.hvd_config.use:
-            hvd.broadcast_parameters(self.model.state_dict(), root_rank=0)
-            hvd.broadcast_optimizer_state(self.optimizer, root_rank=0)
+            hvd.broadcast_parameters(self.context.model.state_dict(), root_rank=0)
+            hvd.broadcast_optimizer_state(self.context.optimizer, root_rank=0)
 
         self.training_iterator = iter(self.training_loader)
 
@@ -124,23 +127,11 @@ class PyTorchTrialController(det.LoopTrialController):
             self.device = torch.device("cpu")
         check.is_not_none(self.device)
 
-    def _init_model_and_optimizer(self) -> None:
-        self.optimizer = self.trial.optimizer(self.model)
-        # TODO: Check that optimizer is not an amp optimizer.
+    def _init_model(self) -> None:
+        self.context.model = self.trial.build_model()
+        self.context.model = self.context.model.to(self.device)
 
-        self._init_device()
-        self.model = self.model.to(self.device)
-
-        if self.hvd_config.use:
-            use_compression = self.hvd_config.fp16_compression
-            self.optimizer = hvd.DistributedOptimizer(
-                self.optimizer,
-                named_parameters=self.model.named_parameters(),
-                backward_passes_per_step=self.hvd_config.aggregation_frequency,
-                compression=hvd.Compression.fp16 if use_compression else hvd.Compression.none,
-            )
-            logging.debug("Initialized optimizer for distributed and optimized parallel training.")
-        elif self.n_gpus > 1:
+        if self.n_gpus > 1:
             check.eq(
                 self.hvd_config.aggregation_frequency,
                 1,
@@ -148,10 +139,22 @@ class PyTorchTrialController(det.LoopTrialController):
                 "frequency greater than 1 for single machine multi-GPU "
                 "training.",
             )
-            self.model = nn.DataParallel(self.model)
+            self.context.model = nn.DataParallel(self.context.model)
             logging.debug("Initialized mode for native parallel training.")
 
-        self.lr_helper = _LRHelper(self.trial.create_lr_scheduler(self.optimizer))
+    def _init_optimizer(self) -> None:
+        # TODO: Check that optimizer is not an amp optimizer.
+        self.context.optimizer = self.trial.optimizer(self.context.model)
+
+        if self.hvd_config.use:
+            use_compression = self.hvd_config.fp16_compression
+            self.context.optimizer = hvd.DistributedOptimizer(
+                self.context.optimizer,
+                named_parameters=self.context.model.named_parameters(),
+                backward_passes_per_step=self.hvd_config.aggregation_frequency,
+                compression=hvd.Compression.fp16 if use_compression else hvd.Compression.none,
+            )
+            logging.debug("Initialized optimizer for distributed and optimized parallel training.")
 
     def _check_evaluate_implementation(self) -> None:
         """
@@ -200,9 +203,9 @@ class PyTorchTrialController(det.LoopTrialController):
             logging.info(
                 f"Enabling mixed precision training with opt_level: {self._get_amp_setting()}."
             )
-            self.model, self.optimizer = apex.amp.initialize(
-                self.model,
-                self.optimizer,
+            self.context.model, self.context.optimizer = apex.amp.initialize(
+                self.context.model,
+                self.context.optimizer,
                 opt_level=self._get_amp_setting(),
                 verbosity=1 if self.is_chief or self.env.experiment_config.debug_enabled() else 0,
             )
@@ -350,7 +353,7 @@ class PyTorchTrialController(det.LoopTrialController):
 
         # Set the behavior of certain layers (e.g., dropout) that are different
         # between training and inference.
-        self.model.train()
+        self.context.model.train()
 
         for callback in self.callbacks.values():
             callback.on_train_step_start(step_id)
@@ -370,7 +373,7 @@ class PyTorchTrialController(det.LoopTrialController):
             # Forward pass.
             tr_metrics = self.trial.train_batch(
                 batch=batch,
-                model=self.model,
+                model=self.context.model,
                 epoch_idx=self.get_epoch_idx(batch_idx),
                 batch_idx=batch_idx,
             )
@@ -390,18 +393,18 @@ class PyTorchTrialController(det.LoopTrialController):
             loss = tr_metrics["loss"]
             communicate_and_update = (batch_idx + 1) % self.hvd_config.aggregation_frequency == 0
             if self.use_amp():
-                with apex.amp.scale_loss(loss, self.optimizer) as scaled_loss:
+                with apex.amp.scale_loss(loss, self.context.optimizer) as scaled_loss:
                     scaled_loss.backward()
                     if self.hvd_config.use and communicate_and_update:
-                        self.optimizer.synchronize()
+                        self.context.optimizer.synchronize()
             else:
                 loss.backward()
 
             if communicate_and_update:
                 parameters = (
-                    self.model.parameters()
+                    self.context.model.parameters()
                     if not self.use_amp()
-                    else apex.amp.master_params(self.optimizer)
+                    else apex.amp.master_params(self.context.optimizer)
                 )
 
                 if self.hvd_config.average_aggregated_gradients:
@@ -412,11 +415,11 @@ class PyTorchTrialController(det.LoopTrialController):
                 self._clip_grads(parameters)
 
                 if self.hvd_config.use and self.use_amp():
-                    with self.optimizer.skip_synchronize():
-                        self.optimizer.step()
+                    with self.context.optimizer.skip_synchronize():
+                        self.context.optimizer.step()
                 else:
-                    self.optimizer.step()
-                self.optimizer.zero_grad()
+                    self.context.optimizer.step()
+                self.context.optimizer.zero_grad()
 
                 if self.lr_helper.should_step_lr(
                     batches_completed=batch_idx + 1,
@@ -467,7 +470,7 @@ class PyTorchTrialController(det.LoopTrialController):
     def _compute_validation_metrics(self) -> workload.Response:
         # Set the behavior of certain layers (e.g., dropout) that are
         # different between training and inference.
-        self.model.eval()
+        self.context.model.eval()
 
         for callback in self.callbacks.values():
             callback.on_validation_step_start()
@@ -485,7 +488,7 @@ class PyTorchTrialController(det.LoopTrialController):
                 batch = self._to_device(batch)
                 num_inputs += data_length(batch)
 
-                vld_metrics = self.trial.evaluate_batch(batch=batch, model=self.model)
+                vld_metrics = self.trial.evaluate_batch(batch=batch, model=self.context.model)
                 # Verify validation metric names are the same across batches.
                 if keys is None:
                     keys = vld_metrics.keys()
@@ -505,7 +508,6 @@ class PyTorchTrialController(det.LoopTrialController):
                 # TODO: For performance perform -> cpu() only at the end of validation.
                 batch_metrics.append(self._convert_metrics_to_numpy(vld_metrics))
 
-            keys = cast(Any, keys)
             metrics = self._reduce_metrics(
                 batch_metrics=batch_metrics,
                 keys=keys,
@@ -520,7 +522,7 @@ class PyTorchTrialController(det.LoopTrialController):
             self.validation_loader = cast(torch.utils.data.DataLoader, self.validation_loader)
             if self.is_chief:
                 metrics = self.trial.evaluate_full_dataset(
-                    data_loader=self.validation_loader, model=self.model
+                    data_loader=self.validation_loader, model=self.context.model
                 )
 
                 check.is_instance(
@@ -652,8 +654,8 @@ class PyTorchTrialController(det.LoopTrialController):
                 checkpoint = torch.load(maybe_ckpt, map_location="cpu")  # type: ignore
                 break
 
-        self.model.load_state_dict(checkpoint["model_state_dict"])
-        self.optimizer.load_state_dict(checkpoint["optimizer_state_dict"])
+        self.context.model.load_state_dict(checkpoint["model_state_dict"])
+        self.context.optimizer.load_state_dict(checkpoint["optimizer_state_dict"])
         self.lr_helper.load_state_dict(checkpoint.get("lr_scheduler"))
 
         callback_state = checkpoint.get("callbacks", {})
@@ -682,7 +684,9 @@ class PyTorchTrialController(det.LoopTrialController):
         pickled_model_path = path.joinpath("model.pth")
         code_path = path.joinpath("code")
 
-        torch.save(self.model, pickled_model_path, pickle_module=cloudpickle)  # type: ignore
+        torch.save(  # type: ignore
+            self.context.model, pickled_model_path, pickle_module=cloudpickle
+        )
 
         # The model code is the current working directory.
         shutil.copytree(os.getcwd(), code_path, ignore=shutil.ignore_patterns("__pycache__"))
@@ -702,8 +706,8 @@ class PyTorchTrialController(det.LoopTrialController):
         # objects) to avoid breaking the connection between the model and the
         # optimizer.
         checkpoint = {
-            "model_state_dict": self.model.state_dict(),
-            "optimizer_state_dict": self.optimizer.state_dict(),
+            "model_state_dict": self.context.model.state_dict(),
+            "optimizer_state_dict": self.context.optimizer.state_dict(),
         }
 
         if self.lr_helper:
@@ -729,6 +733,7 @@ class PyTorchTrial(det.Trial):
     """
 
     trial_controller_class = PyTorchTrialController
+    trial_context_class = PyTorchTrialContext
 
     @abstractmethod
     def build_model(self) -> nn.Module:

--- a/harness/tests/experiment/fixtures/pytorch_xor_model.py
+++ b/harness/tests/experiment/fixtures/pytorch_xor_model.py
@@ -291,3 +291,38 @@ class XORTrialUserStepLR(XORTrialMulti):
 class XORTrialPerMetricReducers(XORTrialWithMultiValidation):
     def evaluation_reducer(self) -> Dict[str, det.pytorch.Reducer]:
         return {"accuracy": det.pytorch.Reducer.AVG, "binary_error": det.pytorch.Reducer.AVG}
+
+
+class Counter(det.pytorch.PyTorchCallback):
+    def __init__(self) -> None:
+        self.train_steps_started = 0
+        self.train_steps_ended = 0
+        self.validation_steps_started = 0
+        self.validation_steps_ended = 0
+
+    def on_train_step_start(self, step_id: int) -> None:
+        self.train_steps_started += 1
+
+    def on_train_step_end(self, step_id: int, metrics: Dict[str, Any]) -> None:
+        self.train_steps_ended += 1
+
+    def on_validation_step_start(self) -> None:
+        self.validation_steps_started += 1
+
+    def on_validation_step_end(self, metrics: Dict[str, Any]) -> None:
+        self.validation_steps_ended += 1
+
+    def state_dict(self) -> Dict[str, Any]:
+        return self.__dict__
+
+    def load_state_dict(self, state_dict: Dict[str, Any]) -> None:
+        self.__dict__ = state_dict
+
+
+class XORTrialCallbacks(XORTrialMulti):
+    def __init__(self, context: det.TrialContext) -> None:
+        self.context = context
+        self.counter = Counter()
+
+    def build_callbacks(self) -> Dict[str, det.pytorch.PyTorchCallback]:
+        return {"counter": self.counter}

--- a/harness/tests/experiment/fixtures/pytorch_xor_model.py
+++ b/harness/tests/experiment/fixtures/pytorch_xor_model.py
@@ -326,3 +326,21 @@ class XORTrialCallbacks(XORTrialMulti):
 
     def build_callbacks(self) -> Dict[str, det.pytorch.PyTorchCallback]:
         return {"counter": self.counter}
+
+
+class XORTrialAccessContext(XORTrialStepEveryEpoch):
+    def train_batch(
+        self, batch: TorchData, model: nn.Module, epoch_idx: int, batch_idx: int
+    ) -> Dict[str, torch.Tensor]:
+        assert self.context.get_model()
+        assert self.context.get_optimizer()
+        assert self.context.get_lr_scheduler()
+
+        return super().train_batch(batch, model, epoch_idx, batch_idx)
+
+    def evaluate_batch(self, batch: TorchData, model: nn.Module) -> Dict[str, Any]:
+        assert self.context.get_model()
+        assert self.context.get_optimizer()
+        assert self.context.get_lr_scheduler()
+
+        return super().evaluate_batch(batch, model)

--- a/harness/tests/experiment/pytorch/test_pytorch_trial.py
+++ b/harness/tests/experiment/pytorch/test_pytorch_trial.py
@@ -499,6 +499,20 @@ class TestPyTorchTrial:
             "validation_steps_ended": 1,
         }
 
+    def test_context(self) -> None:
+        def make_workloads() -> workload.Stream:
+            trainer = utils.TrainAndValidate()
+            yield from trainer.send(steps=1, validation_freq=1, batches_per_step=1)
+            yield workload.terminate_workload(), [], workload.ignore_workload_response
+
+        controller = utils.make_trial_controller_from_trial_implementation(
+            trial_class=pytorch_xor_model.XORTrialAccessContext,
+            hparams=self.hparams,
+            workloads=make_workloads(),
+            trial_seed=self.trial_seed,
+        )
+        controller.run()
+
 
 def test_create_trial_instance() -> None:
     utils.create_trial_instance(pytorch_xor_model.XORTrial)


### PR DESCRIPTION
First phase of https://determinedai.atlassian.net/browse/DET-3033 to add support for a generic callback interface in PyTorchTrial. Second phase will involve fixing the `on_validation_step_end()` case in the distributed / parallel context.

Test Plan:
Added unit tests.