### PR TITLE
refactor: unify the code paths for local and cluster modes

### DIFF
--- a/harness/determined/experimental/__init__.py
+++ b/harness/determined/experimental/__init__.py
@@ -10,5 +10,6 @@ from determined.experimental._native import (
     create,
     create_trial_instance,
     test_one_batch,
-    _init_native,
+    init_native,
+    _local_execution_manager,
 )

--- a/harness/determined/experimental/estimator/_estimator_native.py
+++ b/harness/determined/experimental/estimator/_estimator_native.py
@@ -55,7 +55,7 @@ def init(
     """
     return cast(
         estimator.EstimatorNativeContext,
-        experimental._init_native(
+        experimental.init_native(
             controller_cls=estimator.EstimatorTrialController,
             native_context_cls=estimator.EstimatorNativeContext,
             config=config,

--- a/harness/determined/experimental/keras/_tf_keras_native.py
+++ b/harness/determined/experimental/keras/_tf_keras_native.py
@@ -55,7 +55,7 @@ def init(
     """
     return cast(
         keras.TFKerasNativeContext,
-        experimental._native._init_native(
+        experimental._native.init_native(
             controller_cls=keras.TFKerasTrialController,
             native_context_cls=keras.TFKerasNativeContext,
             config=config,

--- a/harness/tests/experiment/test_local.py
+++ b/harness/tests/experiment/test_local.py
@@ -5,10 +5,10 @@ from tests.experiment.fixtures import pytorch_xor_model
 
 
 def test_test_one_batch() -> None:
-    experimental.test_one_batch(
-        pathlib.Path(pytorch_xor_model.__file__).parent,
-        pytorch_xor_model.XORTrial,
-        config={
-            "hyperparameters": {"hidden_size": 2, "learning_rate": 0.5, "global_batch_size": 4}
-        },
-    )
+    with experimental._local_execution_manager(pathlib.Path(pytorch_xor_model.__file__).parent):
+        experimental.test_one_batch(
+            trial_class=pytorch_xor_model.XORTrial,
+            config={
+                "hyperparameters": {"hidden_size": 2, "learning_rate": 0.5, "global_batch_size": 4}
+            },
+        )


### PR DESCRIPTION
Previously, there are different code paths to run local and cluster modes. The code path to run local mode when using Tensorflow Keras and Estimator Native API has behaviors inconsistent with other code paths in:
1. training one step rather than one batch.
2. not setting the context directory to be the working directory

Now, unify these code paths to improve the ease of maintenance.

# Test Plan
- [x] bug fix: determine if there are other similar bugs in the codebase
- [x] refactor: maintain existing code coverage
