### PR TITLE
[DET-2976] Fix openning a shell

### DIFF
--- a/cli/determined_cli/shell.py
+++ b/cli/determined_cli/shell.py
@@ -71,13 +71,15 @@ def open_shell(args: Namespace) -> None:
 
 
 def _open_shell(shell: Command, username: str, additional_opts: str) -> None:
+    LOOPBACK_ADDRESS = "[::1]"
     with tempfile.NamedTemporaryFile("w") as fp:
         fp.write(shell.misc["privateKey"])
         fp.flush()
         check_len(shell.addresses, 1, "Cannot find address for shell")
+        host, port = shell.addresses[0]["host_ip"], shell.addresses[0]["host_port"]
+        if host == LOOPBACK_ADDRESS:
+            host = "localhost"
 
-        _, port = shell.addresses[0]["host_ip"], shell.addresses[0]["host_port"]
-        host = "localhost"
         os.system(
             "ssh -o StrictHostKeyChecking=no -tt -o IdentitiesOnly=yes -i {} -p {} {} {}@{}".format(
                 fp.name, port, additional_opts, username, host

--- a/master/internal/agent/agent.go
+++ b/master/internal/agent/agent.go
@@ -53,7 +53,12 @@ func (a *agent) Receive(ctx *actor.Context) error {
 		socket, ok := msg.Accept(ctx, aproto.MasterMessage{}, true)
 		check.Panic(check.True(ok, "failed to accept websocket connection"))
 		a.socket = socket
-		a.address = strings.SplitN(msg.Ctx.Request().RemoteAddr, ":", 2)[0]
+		lastColonIndex := strings.LastIndex(msg.Ctx.Request().RemoteAddr, ":")
+		if lastColonIndex == -1 {
+			a.address = msg.Ctx.Request().RemoteAddr
+		} else {
+			a.address = msg.Ctx.Request().RemoteAddr[0:lastColonIndex]
+		}
 	case aproto.SignalContainer:
 		ctx.Ask(a.socket, ws.WriteMessage{Message: aproto.AgentMessage{SignalContainer: &msg}})
 	case scheduler.StartTask:


### PR DESCRIPTION
1. The ip address of agents might be parsed wrong if the agent is in the same machine as the master. This PR fixs the parsing.
2. When opening a shell, the address of an agent is hardcoded into localhost. This PR changes to use the host of the agent.