### PR TITLE
[DET-2979] fix: resize the Ace editor when an error pops up

### DIFF
--- a/webui/elm/src/Modals/CreateExperiment.elm
+++ b/webui/elm/src/Modals/CreateExperiment.elm
@@ -216,7 +216,7 @@ updateOpenContinue msg openModel trialDetail =
                         , badSyntax = c.badSyntax
                     }
             in
-            ( OpenContinue subModel trialDetail, Cmd.none, Nothing )
+            ( OpenContinue subModel trialDetail, YamlEditor.resize openModel.editorState, Nothing )
 
         CreateExperiment ->
             ( OpenContinue openModel trialDetail, doCreateExperiment openModel, Nothing )


### PR DESCRIPTION

![DeepinScreenshot_select-area_20200508164911](https://user-images.githubusercontent.com/12127420/81457660-e04def00-914b-11ea-868f-139bf2ea25c3.png)

# Test Plan
- UI change:
  - [x] add screenshots

