### PR TITLE
build: separate webui clean deps from clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,12 @@ all:
 	$(MAKE) get-deps
 	$(MAKE) build
 
+.PHONY: clean-deps
+clean-deps:
+	$(MAKE) -C webui $@
+
 .PHONY: get-deps
-get-deps:
+get-deps: clean-deps
 	GO111MODULE=on go get github.com/talos-systems/conform@fa7df19996ece307285da44c73f210c6cbec9207
 	pip install -r requirements.txt
 	$(MAKE) -C master $@

--- a/webui/Makefile
+++ b/webui/Makefile
@@ -22,6 +22,11 @@ get-deps:
 	$(MAKE) -C elm $@
 	$(MAKE) -C tests $@
 
+clean-deps:
+	$(MAKE) -C react $@
+	$(MAKE) -C elm $@
+	$(MAKE) -C tests $@
+
 build:
 	$(MAKE) -C react $@
 	$(MAKE) -C elm $@

--- a/webui/elm/Makefile
+++ b/webui/elm/Makefile
@@ -16,6 +16,9 @@ clean:
 	rm -f npm-debug.log
 	rm -f public/style.css
 	rm -f public/determined-ui.js
+
+.PHONY: clean-deps
+clean-deps:
 	rm -rf elm-stuff/ tests/elm-stuff/ node_modules/
 
 .PHONY: live

--- a/webui/react/Makefile
+++ b/webui/react/Makefile
@@ -10,7 +10,11 @@ build:
 
 .PHONY: clean
 clean:
-	rm -rf build node_modules/
+	rm -rf build
+
+.PHONY: clean-deps
+clean-deps:
+	rm -rf node_modules
 
 .PHONY: live
 live:

--- a/webui/tests/Makefile
+++ b/webui/tests/Makefile
@@ -7,11 +7,11 @@ get-deps:
 		npm ci --no-audit && break ; \
 	done
 
-clean-test-artifacts:
+clean:
 	rm -rf cypress/screenshots/*
 	rm -rf cypress/videos/*
 
-clean: clean-test-artifacts
+clean-deps:
 	rm -rf node_modules/
 
 test: docker-e2e-tests


### PR DESCRIPTION
When running clean and then build, the WebUI module fails because we also clean the dependencies. This separates the workflow so we can clean all the build artifacts separately from the dependency artifacts.

# Test Plan
- UI change:
  - [ ] add screenshots
  - [ ] React? build & check storybooks
- [ ] user-facing api change: modify documentation and examples
- [ ] user-facing api change: add the "User-facing API Change" label
- [ ] bug fix: add regression test
- [ ] bug fix: determine if there are other similar bugs in the codebase
- [ ] new feature: add test coverage for any user-facing aspects
- [ ] refactor: maintain existing code coverage
