### PR TITLE
docs: revise data access tutorial

### DIFF
--- a/docs/tutorials/data-access.txt
+++ b/docs/tutorials/data-access.txt
@@ -1,44 +1,31 @@
 .. _data-access:
 
-Data Access for Experiments
-===========================
+Accessing Data
+==============
 
-Nearly all experiments require training and validation
-data. In Determined, data access depends on the cluster infrastructure and the data storage.
+Data plays a fundamental role in machine learning model development. The best way to load data into your ML models depends on several factors, including whether you are running on-premise or in the cloud, the size of your data sets, and your security requirements. Accordingly, Determined supports a variety of methods for accessing data.
 
-At the end of this tutorial, the reader should know best practices for:
+This tutorial discusses three methods for accessing data in Determined:
 
-#. Data Access Options
-#. How To Access Your Data
+#. **Object Storage**: Data stored in object stores such as `Amazon S3 <https://aws.amazon.com/s3/>`__.
+#. **Distributed File Systems**: Data stored on distributed file systems such as `NFS <https://en.wikipedia.org/wiki/Network_File_System>`__ or `Ceph <https://ceph.io/>`__.
+#. **Small Data**: Small data sets can be uploaded as part of the model definition.
 
-Overview
----------
-Data plays an important role in model development. Each user has different storage options depending on their data characteristics, such as privacy, internal infrastructure, and data size. Determined supports the most common data storage infrastructures to allow integration into the user development environment. This tutorial highlights three main methods for accessing data:
+Object Storage
+--------------
 
-#. **Data in the cloud (Recommended)**: Data stored in cloud providers, GCP or AWS
-#. **Data on premises**: Data available on the Determined cluster
-#. **Small Data**: Data smaller than 96MB
+Object stores manage data as a collection of key-value pairs. Object storage is particularly popular in cloud environments -- for example, Amazon's `Simple Storage Service <https://aws.amazon.com/s3/>`__ (S3) and `Google Cloud Storage <https://cloud.google.com/storage>`__ (GCS) are both object stores. When running Determined in the cloud, it is highly recommended that you store your data using the same cloud provider being used for the Determined cluster itself.
 
-The following sections will demonstrate each approach to access data.
+Unless you are accessing a publicly available data set, you will need to ensure that Determined trial containers can access data in the object storage service you are using. This can be done by configuring a :ref:`custom environment<custom-env>` with the appropriate credentials. When using :ref:`Dynamic Agents on GCP<dynamic-agents-gcp>`, a system administrator will need to configure a valid :ref:`service account<cluster-configuration>` with read credentials. When using :ref:`Dynamic Agents on AWS<dynamic-agents-aws>`, the system administrator will need to configure an :ref:`iam_instance_profile_arn<cluster-configuration>` with read credentials.
 
+Once security access has been configured, we can use open-source libraries such as `boto3 <https://boto3.amazonaws.com/>`__ or `gcsfs <https://gcsfs.readthedocs.io/en/latest/>`__ to access data from object storage. The simplest way to do this is for your model definition code to download the entire data set whenever a trial container starts up.
 
-Data in the cloud (Recommended)
--------------------------------
-This section describes how to access data stored in a cloud provider.
+Downloading from Object Storage
+"""""""""""""""""""""""""""""""
 
-A Determined cluster managed by :ref:`Elastic Infrastructure <elastic-infra-index>` requires data storage in the cloud and is recommended for on-premise deployments. It is highly recommended to store the data on the same cloud infrastructure as a Determined Cluster.
+The example below demonstrates how to download data from S3 using ``boto``. The S3 bucket name is specified in the experiment config file (using a field named ``data.bucket``). The ``download_directory`` variable defines where data that is downloaded from S3 will be stored. Note that we include :func:`self.context.distributed.get_rank() <determined._train_context.DistributedContext.get_rank>` in the name of this directory: when doing distributed training, multiple processes might be downloading data concurrently (one process per GPU), so embedding the rank in the directory name ensures that these processes do not conflict with one another.
 
-Object Storage Download
-"""""""""""""""""""""""""
-
-One method for managing data storage in the cloud is to use an object storage solution, such as `Amazon S3 <https://aws.amazon.com/s3/>`_ or `Google Cloud Storage <https://cloud.google.com/storage>`_.
-
-The agents and trial containers must have the proper authentication and authorization for accessing the object storage. A :ref:`custom environment<custom-env>` must be configured to ensure that the trial container image is properly configured with credentials. When using :ref:`Dynamic Agents on GCP<dynamic-agents-gcp>`, a system administrator of will need to configure a valid :ref:`service_account<cluster-configuration>` with read credentials. When using :ref:`Dynamic Agents on AWS<dynamic-agents-aws>`, the system administrator will need to configure an :ref:`iam_instance_profile_arn<cluster-configuration>` with read credentials.
-
-Once security access is configured, we can use a open-source libraries such as `boto3 <https://boto3.amazonaws.com/>`_ or `gcsfs
-<https://gcsfs.readthedocs.io/en/latest/>`_ to write our data loaders to stream directly from object storage in source code.
-
-The code below uses ``boto3`` to load data from an S3 bucket. The bucket name is accessed from the configuration file. The ``download_directory`` states where to store the data for this trial. The ``self.context.get_rank()`` helps prevent processes (one per GPU) from overriding data from each other. Once the data path has been created, ``s3.download_file(s3_bucket, data_file, filepath)`` fetches the file from S3 based on the bucket and stores in the defined file path. Now, the data can be accessed in the defined ``download_directory``. All functions that download data should be called in the trial's ``__init__`` function.
+Once the download directory has been created, ``s3.download_file(s3_bucket, data_file, filepath)`` fetches the file from S3 and stores it at the specified location. The data can then be accessed in the ``download_directory``.
 
 .. code:: python
 
@@ -46,24 +33,35 @@ The code below uses ``boto3`` to load data from an S3 bucket. The bucket name is
   import os
 
   def download_data_from_s3(self):
-      s3_bucket = self.context.get_data_config()['bucket']
-      download_directory = f"/tmp/data-rank{self.context.get_rank()}"
-      data_file = 'data.csv'
+      s3_bucket = self.context.get_data_config()["bucket"]
+      download_directory = f"/tmp/data-rank{self.context.distributed.get_rank()}"
+      data_file = "data.csv"
 
-      s3 = boto3.client('s3')
+      s3 = boto3.client("s3")
       os.makedirs(download_directory, exist_ok=True)
-      filepath = os.path.join(download_directory, f)
+      filepath = os.path.join(download_directory, data_file)
       if not os.path.exists(filepath):
           s3.download_file(s3_bucket, data_file, filepath)
       return download_directory
 
-Object Storage Streaming
-"""""""""""""""""""""""""
-Similar to Object Storage Download, data can be accessed through S3 or GCS. When streaming, the data is fetched from the cloud storage as needed for training to reduce the download overhead cost for every trial startup. However, the data should be pre-batched in the cloud storage with each batch stored as a separate file. Overall, this can increase performance depending on the data structure.
+To use this in your trial class, start by calling ``download_data_from_s3`` in the trial's ``__init__`` function. Next, implement the ``build_training_data_loader`` and ``build_validation_data_loader`` functions to load the training and validation data sets, respectively, from the downloaded data.
 
-For streaming data, a custom ``torch.utils.data.Dataset`` or ``tf.keras.utils.Sequence`` object is required for their respective framework. These classes require a declared ``__getitem__`` function that returns a batch or specific item based on provided an index. For streaming data, this function will fetch the required data from the cloud storage.
 
-Below, we create a custom ``tf.keras.utils.Sequence`` class. In the ``__getitem__`` function, ``boto3`` fetches the data based on the provided bucket and key.
+Streaming from Object Storage
+"""""""""""""""""""""""""""""
+
+Rather than downloading the entire training data set from object storage during trial startup, another way to load data is to *stream* batches of data from the training and validation sets as needed. This has several advantages:
+
+* It avoids downloading the entire data set during trial startup, allowing training tasks to start more quickly.
+* If a container doesn't need to access the entire data set, streaming can result in downloading less data. For example, when during hyperparameter search, many trials can often be terminated after having been trained for less than a full epoch.
+* If the data set is extremely large, streaming can avoid the need to store the entire data set on disk.
+* Streaming can allow model training and data downloading to happen in parallel, improving performance.
+
+To enable streaming data loading, the data must be stored in a format that allows efficient random access, so that the model code can fetch a specific batch of training or validation data. One way to do this is to store each batch of data as a separate object on the object store. Alternatively, if the data set consists of fixed-size records, you can use a single object and then read the appropriate byte range from it.
+
+To stream data, a custom ``torch.utils.data.Dataset`` or ``tf.keras.utils.Sequence`` object is required, depending on whether you are using PyTorch or TensorFlow Keras, respectively. These classes require a ``__getitem__`` function that returns a batch or specific item based on provided an index. When streaming data, the implementation of ``__getitem__`` should fetch the required data from the object store.
+
+For example, the code below demonstrates a custom ``tf.keras.utils.Sequence`` class that implements streaming data loading from Amazon S3. In the ``__getitem__`` function, ``boto3`` fetches the data based on the provided bucket and key.
 
 .. code:: python
 
@@ -73,7 +71,7 @@ Below, we create a custom ``tf.keras.utils.Sequence`` class. In the ``__getitem_
       ...
 
       def __init__(self):
-          self.s3_client = boto3.client('s3')
+          self.s3_client = boto3.client("s3")
 
       def __getitem__(self, idx):
           bucket, key = get_s3_loc_for_batch(idx)
@@ -81,57 +79,18 @@ Below, we create a custom ``tf.keras.utils.Sequence`` class. In the ``__getitem_
           return data_to_batch(blob_data)
 
 
-Network Attached Storage
-""""""""""""""""""""""""""
-`Network-attached storage <https://en.wikipedia.org/wiki/Network-attached_storage>`_ (e.g. an `NFS mount <https://en.wikipedia.org/wiki Network_File_System>`_) typically directly mounts a file system directly to the instance. This includes AWS's `Elastic File System <https://aws.amazon.com/efs/>`_ and GCP's `Cloud Filestore <https://cloud.google.com/filestore>`_. This section describes how to configure our experiment workflows to reference data stored in on-premises infrastructure.
+Distributed File System
+-----------------------
 
-This option assumes all Determined agent instances have the desired data available at the same filesystem path. The configuration options to automatically mount the file systems for each agent can be found :ref:`install-aws` and :ref:`install-gcp`.
+Another way to store data is to use a distributed file system, which enables a cluster of machines to access a shared data set via the familiar POSIX file system interface. Amazon's `Elastic File System <https://aws.amazon.com/efs/>`__ and Google's `Cloud Filestore <https://cloud.google.com/filestore>`__ are examples of distributed file systems that are available in cloud environments. For on-premise deployments, popular distributed file systems include `Ceph <https://ceph.io/>`__, `GlusterFS <https://www.gluster.org/>`__, and `NFS <https://en.wikipedia.org/wiki/Network_File_System>`__.
 
-The network attached storage must also be mounted to the trial containers. The :ref:`experiment-configuration` contains a ``bind_mounts`` sections. Each bind mount contains a ``host_path`` and ``container_path``.  The ``host_path`` specify the absolute path to the filesystem path where the data is available on each agent instance. In otherwords, the ``host_path`` points to where the network attached storage is located on the instance. The ``container_path`` specifies where the model definition source code can access the data from inside the container filesystem. It points to where the data should be mounted in the trial container.
+To access data on a distributed file system, you should first ensure that the file system is mounted at the same mount point on every Determined agent. For cloud deployments, the configuration options to automatically mount a distributed file system on each agent can be found in the :ref:`AWS <install-aws>` and :ref:`GCP <install-gcp>` installation instructions.
 
-For easier management, set the ``container_path`` to match the ``host_path`` to the same locations. It is recommended to set each bind mount setting ``read_only`` to true on each bind mount, for guarantees that the experiment should only _read_ this data instead of modifying it.
+Next, you will need to ensure the file system is accessible to each trial container. This can be done by configuring a bind mount in the :ref:`experiment configuration file <experiment-configuration>`. Each bind mount consists of a ``host_path`` and a ``container_path``; the host path specifies the absolute path where the distributed file system has been mounted on the agent, while the container path specifies the path within the container's file system where the distributed file system will be accessible.
 
-The following example assumes a Determined cluster is configured with some data available at ``/mnt/data`` on each agent. We
-configure our experiment configuration as follows:
+To avoid confusion, you may wish to set the ``container_path`` to be equal to the ``host_path``. You may also want to set ``read_only`` to ``true`` for each bind mount, to ensure that data sets are not modified by training code.
 
-.. code:: yaml
-
-    bind_mounts:
-      - host_path: /mnt/data
-        container_path: /mnt/data
-        read_only: true
-
-Now, we can write Python code in our :ref:`model-definitions` to access any data under the ``/mnt/data`` folder as follows:
-
-.. code:: python
-
-    def build_training_data_loader(self):
-        return make_data_loader(data_path="/mnt/data/training", ...)
-
-    def build_validation_data_loader(self):
-        return make_data_loader(data_path="/mnt/data/validation", ...)
-
-
-Data On-Premises
-----------------
-
-This section describes how to configure our experiment workflows to reference
-data stored in on-premises infrastructure. This option makes the following
-assumptions:
-
-* The Determined cluster and data storage are both managed on-premises.
-* All Determined agent instances have the desired data available at the same filesystem
-  path. In Determined clusters with more than a single agent, `Network-attached
-  storage <https://en.wikipedia.org/wiki/Network-attached_storage>`_ typically exposes
-  this data to each Determined agent instance at the same path.
-
-
-Similar to network attached storage, the network attached storage is mounted to the trial containers. The :ref:`experiment-configuration` contains a ``bind_mounts`` sections. Each bind mount contains a ``host_path`` and ``container_path``.  The ``host_path`` specify the absolute path to the filesystem path where the data is available on each agent instance. In otherwords, the ``host_path`` points to where the network attached storage is located on the instance. The ``container_path`` specifies where the model definition source code can access the data from inside the container filesystem. It points to where the data should be mounted in the trial container.
-
-For easier management, set the ``container_path`` to match the ``host_path`` to the same locations. It is recommended to set each bind mount setting ``read_only`` to true on each bind mount, for guarantees that the experiment should only _read_ this data instead of modifying it.
-
-The following example assumes a Determined cluster is configured with some data available at ``/mnt/data`` on each agent. We
-configure our experiment configuration as follows:
+The following example assumes a Determined cluster is configured with a distributed file system mounted at ``/mnt/data`` on each agent. To access data on this file system, we use an experiment configuration file as follows:
 
 .. code:: yaml
 
@@ -140,7 +99,7 @@ configure our experiment configuration as follows:
         container_path: /mnt/data
         read_only: true
 
-Now, we can write Python code in our :ref:`model-definitions` to access any data under the ``/mnt/data`` folder as follows:
+Our model definition code can then access data in the ``/mnt/data`` directory as follows:
 
 .. code:: python
 
@@ -152,32 +111,36 @@ Now, we can write Python code in our :ref:`model-definitions` to access any data
 
 Embed in Model Definition
 --------------------------
-Determined requires a submission to have a defined :ref:`Model Definition<model-definitions>` directory. The model definition directory references all the training code and must be less than ``96MB``. However, Determined does not restricted file types on submission, such as ``csv`` or ``pickle``. Therefore, data less than ``96MB`` can be included in the model definition directory.
 
-For example, the model definition directory below contains the model definition and a data ``.csv`` file.
+In Determined, each experiment has an associated :ref:`model definition <model-definitions>` directory. The model definition directory must include the model's source code, but it can also include other files related to the model, such as a data set. The size of this directory must not exceed 96MB, so this method is only appropriate when the size of the data set is small.
+
+For example, the model definition directory below contains the model definition, an experiment configuration file, and a CSV data file. All three files are small and hence the total size of the directory is much smaller than the 96MB limit:
 
 .. code::
 
         .
+        ├── const.yaml (0.3 KB)
         ├── data.csv (5 KB)
-        ├── __init__.py (0)
-        └── model_def.py (4.1 K)
+        └── model_def.py (4.1 KB)
 
-As seen above, the data is 5KB and the entire contents of the directory is less than 96MB. Therefore can be submitted with the model definition using the command:
+The data can be submitted along with the model definition using the command:
 
 .. code::
 
     det create experiment const.yaml .
 
-When a new experiment is created, Determined injects the model definition directory's contents on each agent for each trial to use. Any data placed in the directory can then be accessed through relative filepath. The code below uses the ``pandas`` library to load in the ``data.csv`` through relative filepath.
+Determined injects the contents of the model definition directory into each trial container that is launched for the experiment. Any file in that directory can then be accessed by your model code, e.g., by relative path (the model definition directory is the initial working directory for each trial container).
+
+For example, the code below uses `Pandas <https://pandas.pydata.org/>`__ to load ``data.csv`` into a `DataFrame <https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.html>`__:
 
 .. code:: python
 
-  df = pandas.read_csv('data.csv')
+  df = pandas.read_csv("data.csv")
 
 
 Next Steps
 -----------
+
 - :ref:`experiment-configuration`
 - :ref:`command-configuration`
 - :ref:`topic-guides_yaml`

--- a/docs/tutorials/pytorch-mnist-tutorial.txt
+++ b/docs/tutorials/pytorch-mnist-tutorial.txt
@@ -154,6 +154,7 @@ The last two methods we need to define are ``build_training_data_loader`` and ``
         validation_data = data.get_dataset(self.download_directory, train=False)
         return DataLoader(validation_data, batch_size=self.context.get_per_slot_batch_size())
 
+For more information on loading data in Determined, refer to the tutorial on :ref:`data-access`.
 
 Defining the Forward Pass
 """""""""""""""""""""""""

--- a/docs/tutorials/tf-mnist-tutorial.txt
+++ b/docs/tutorials/tf-mnist-tutorial.txt
@@ -97,7 +97,7 @@ Loading Data
 
 The last two methods we need to define are ``build_training_data_loader`` and ``build_validation_data_loader``. Determined uses these methods to load the training and validation datasets, respectively.
 
-Determined supports three ways of loading data into a ``tf.keras`` model: as a `tf.keras.utils.Sequence <https://www.tensorflow.org/api_docs/python/tf/keras/utils/Sequence>`__, a `tf.data.Dataset <https://www.tensorflow.org/api_docs/python/tf/data/Dataset>`__ or NumPy arrays. Because the training dataset is small, the Fashion MNIST model represents the data using NumPy arrays.
+Determined supports three ways of loading data into a ``tf.keras`` model: as a `tf.keras.utils.Sequence <https://www.tensorflow.org/api_docs/python/tf/keras/utils/Sequence>`__, a `tf.data.Dataset <https://www.tensorflow.org/api_docs/python/tf/data/Dataset>`__, or NumPy arrays. Because the training dataset is small, the Fashion MNIST model represents the data using NumPy arrays.
 
 .. code:: python
 
@@ -117,8 +117,7 @@ The implementation of ``build_validation_data_loader`` is similar:
 
         return test_images, test_labels
 
-.. note::
-    When loading data from a ``tf.keras.utils.Sequence`` or ``tf.data.Dataset``, users should specify the batch size using :func:`self.context.get_per_slot_batch_size() <determined.TrialContext.get_per_slot_batch_size>`.
+For more information on loading data in Determined, refer to the tutorial on :ref:`data-access`.
 
 Training the Model
 ------------------

--- a/examples/official/iris_tf_keras/model_def.py
+++ b/examples/official/iris_tf_keras/model_def.py
@@ -75,7 +75,7 @@ class IrisTrial(keras.TFKerasTrial):
         return [keras.TFKerasTensorBoard(update_freq="batch", profile_batch=0, histogram_freq=1)]
 
     def build_training_data_loader(self) -> keras.InputData:
-        # Ignore header line and read the training and test CSV observations into pandas DataFrame's
+        # Ignore header line and read the training CSV observations into a pandas DataFrame.
         train = pd.read_csv(self.context.get_data_config()["train_url"], names=DS_COLUMNS, header=0)
         train_features, train_labels = train, train.pop(LABEL_HEADER)
 
@@ -87,7 +87,7 @@ class IrisTrial(keras.TFKerasTrial):
         return train_features.values, train_labels_categorical
 
     def build_validation_data_loader(self) -> keras.InputData:
-        # Ignore header line and read the training and test CSV observations into pandas DataFrame's
+        # Ignore header line and read the test CSV observations into a pandas DataFrame.
         test = pd.read_csv(self.context.get_data_config()["test_url"], names=DS_COLUMNS, header=0)
         test_features, test_labels = test, test.pop(LABEL_HEADER)
 


### PR DESCRIPTION
* Object stores can be used on-prem and distributed file systems can be
  used in the cloud, so I thought it was a bit confusing to have "cloud"
  vs. "on-prem" as the top-level distinction. This also resulted in the
  "cloud NAS" and "on-prem NAS" sections being mostly identical.

* Use the term "distributed file system" instead of "network-attached
  storage" -- the latter is more closely associated with a hardware
  appliance.

* Move docs on security credentials from "object storage download" to
  the parent section, "object storage".

* Fix a bunch of typos and do various copy-editing.

* Simplify front-matter.

* Add links to this tutorial to the TF Keras and PyTorch tutorials.

# Test Plan
- UI change:
  - [ ] add screenshots
  - [ ] React? build & check storybooks
- [ ] user-facing api change: modify documentation and examples
- [ ] user-facing api change: add the "User-facing API Change" label
- [ ] bug fix: add regression test
- [ ] bug fix: determine if there are other similar bugs in the codebase
- [ ] new feature: add test coverage for any user-facing aspects
- [ ] refactor: maintain existing code coverage
