### PR TITLE
chore: rename fixture-up to cluster-up

### DIFF
--- a/deploy/determined_deploy/local/cli.py
+++ b/deploy/determined_deploy/local/cli.py
@@ -3,9 +3,9 @@ import argparse
 from determined_deploy.local import cluster_utils
 
 
-def add_fixture_up_subparser(subparsers: argparse._SubParsersAction) -> None:
+def add_cluster_up_subparser(subparsers: argparse._SubParsersAction) -> None:
     parser = subparsers.add_parser(
-        "fixture-up",
+        "cluster-up",
         help="Create a Determined cluster",
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
@@ -34,9 +34,9 @@ def add_fixture_up_subparser(subparsers: argparse._SubParsersAction) -> None:
     )
 
 
-def add_fixture_down_subparser(subparsers: argparse._SubParsersAction) -> None:
+def add_cluster_down_subparser(subparsers: argparse._SubParsersAction) -> None:
     parser = subparsers.add_parser(
-        "fixture-down",
+        "cluster-down",
         help="Stop a Determined cluster",
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
@@ -133,8 +133,8 @@ def make_local_parser(subparsers: argparse._SubParsersAction) -> None:
         "local", help="local help", formatter_class=argparse.ArgumentDefaultsHelpFormatter
     )
     subparsers = parser_local.add_subparsers(help="command", dest="command")
-    add_fixture_up_subparser(subparsers)
-    add_fixture_down_subparser(subparsers)
+    add_cluster_up_subparser(subparsers)
+    add_cluster_down_subparser(subparsers)
     add_logs_subparser(subparsers)
     add_master_up_subparser(subparsers)
     add_master_down_subparser(subparsers)
@@ -143,8 +143,8 @@ def make_local_parser(subparsers: argparse._SubParsersAction) -> None:
     subparsers.required = True
 
 
-def handle_fixture_up(args):
-    cluster_utils.fixture_up(
+def handle_cluster_up(args):
+    cluster_utils.cluster_up(
         num_agents=args.agents,
         port=args.master_port,
         master_config_path=args.master_config_path,
@@ -157,8 +157,8 @@ def handle_fixture_up(args):
     )
 
 
-def handle_fixture_down(args):
-    cluster_utils.fixture_down(cluster_name=args.cluster_name, delete_db=args.delete_db)
+def handle_cluster_down(args):
+    cluster_utils.cluster_down(cluster_name=args.cluster_name, delete_db=args.delete_db)
 
 
 def handle_logs(args):
@@ -204,8 +204,8 @@ def deploy_local(args: argparse.Namespace) -> None:
     OPERATION_TO_FN = {
         "agent-up": handle_agent_up,
         "agent-down": handle_agent_down,
-        "fixture-up": handle_fixture_up,
-        "fixture-down": handle_fixture_down,
+        "cluster-up": handle_cluster_up,
+        "cluster-down": handle_cluster_down,
         "logs": handle_logs,
         "master-up": handle_master_up,
         "master-down": handle_master_down,

--- a/deploy/determined_deploy/local/cluster_utils.py
+++ b/deploy/determined_deploy/local/cluster_utils.py
@@ -141,7 +141,7 @@ def master_down(master_name: str, delete_db: bool) -> None:
         docker_compose(["down", "-t", "1"], master_name)
 
 
-def fixture_up(
+def cluster_up(
     num_agents: Optional[int],
     port: Optional[int],
     master_config_path: Path,
@@ -152,7 +152,7 @@ def fixture_up(
     no_gpu: bool,
     autorestart: bool,
 ):
-    fixture_down(cluster_name, delete_db)
+    cluster_down(cluster_name, delete_db)
     master_up(
         port=port,
         master_config_path=master_config_path,
@@ -176,7 +176,7 @@ def fixture_up(
         )
 
 
-def fixture_down(cluster_name: str, delete_db: bool) -> None:
+def cluster_down(cluster_name: str, delete_db: bool) -> None:
     master_down(master_name=cluster_name, delete_db=delete_db)
     stop_cluster_agents(cluster_name=cluster_name)
 

--- a/docs/how-to/installation/deploy.txt
+++ b/docs/how-to/installation/deploy.txt
@@ -51,10 +51,10 @@ following commands:
 .. code::
 
    # If the machine has GPUs:
-   det-deploy local fixture-up
+   det-deploy local cluster-up
 
    # If the machine doesn't have GPUs:
-   det-deploy local fixture-up --no-gpu
+   det-deploy local cluster-up --no-gpu
 
 This will start a master and an agent on that machine. To verify that the
 master is running, navigate to ``http://<master-hostname>:8080`` in a
@@ -71,13 +71,13 @@ configuration file to ``det-deploy``, use:
 
 .. code::
 
-  det-deploy local fixture-up --master-config-path <path to master.yaml>
+  det-deploy local cluster-up --master-config-path <path to master.yaml>
 
 If you want to create more than one agent locally, you can use:
 
 .. code::
 
-  det-deploy local fixture-up --agents <number of agents>
+  det-deploy local cluster-up --agents <number of agents>
 
 
 Stopping a Single-Node Cluster
@@ -87,12 +87,12 @@ To stop a Determined cluster, on the machine where a Determined cluster is curre
 
 .. code::
 
-   det-deploy local fixture-down
+   det-deploy local cluster-down
 
 
 .. note::
 
-  ``det-deploy local fixture-down`` will not remove any agents created
+  ``det-deploy local cluster-down`` will not remove any agents created
   with ``det-deploy local agent-up``.  To remove these agents,
   use ``det-deploy local agent-down``.
 

--- a/webui/tests/bin/e2e-tests.py
+++ b/webui/tests/bin/e2e-tests.py
@@ -43,7 +43,7 @@ def pre_e2e_tests(config):
     run(["docker", "pull", DOCKER_CYPRESS_IMAGE], config)
     run_cluster_cmd(
         [
-            "fixture-up",
+            "cluster-up",
             "--agents",
             "1",
             "--no-gpu",
@@ -64,7 +64,7 @@ def _cypress_container_name(config):
 
 def post_e2e_tests(config):
     clean_up_cypress(config)
-    run_cluster_cmd(["fixture-down", "--delete-db"], config)
+    run_cluster_cmd(["cluster-down", "--delete-db"], config)
 
 
 # _cypress_arguments generates an array of cypress arguments.


### PR DESCRIPTION
We've heard feedback that `fixture` is not the clearest term when starting a local Determined cluster.  This PR renames `fixture` to `cluster`:

```
det-deploy local cluster-up
det-deploy local cluster-down
```