### PR TITLE
[DET-2955] refactor: remove dependency on GPUtil

### DIFF
--- a/harness/determined/_env_context.py
+++ b/harness/determined/_env_context.py
@@ -18,7 +18,7 @@ class EnvContext:
         latest_checkpoint: Optional[Dict[str, Any]],
         use_gpu: bool,
         container_gpus: List[str],
-        slot_ids: List[str],
+        slot_ids: List[int],
         debug: bool,
         workload_manager_type: str,
         det_rendezvous_ports: str,

--- a/harness/determined/exec/harness.py
+++ b/harness/determined/exec/harness.py
@@ -26,6 +26,7 @@ Basic workflow is:
 import contextlib
 import distutils.util
 import faulthandler
+import json
 import logging
 import os
 import pathlib
@@ -156,7 +157,7 @@ def main() -> None:
     initial_work = workload.Workload.from_json(simplejson.loads(os.environ["DET_INITIAL_WORKLOAD"]))
     latest_checkpoint = simplejson.loads(os.environ["DET_LATEST_CHECKPOINT"])
     use_gpu = distutils.util.strtobool(os.environ.get("DET_USE_GPU", "false"))
-    slot_ids = os.environ["DET_SLOT_IDS"][1:-1].split(",")
+    slot_ids = json.loads(os.environ["DET_SLOT_IDS"])
     workload_manager_type = os.environ["DET_WORKLOAD_MANAGER_TYPE"]
     det_rendezvous_ports = os.environ["DET_RENDEZVOUS_PORTS"]
     det_trial_runner_network_interface = os.environ["DET_TRIAL_RUNNER_NETWORK_INTERFACE"]

--- a/harness/determined/experimental/_native.py
+++ b/harness/determined/experimental/_native.py
@@ -115,7 +115,7 @@ def create_experiment(
     return exp_id
 
 
-def get_gpus() -> Tuple[bool, List[str], List[str]]:
+def get_gpus() -> Tuple[bool, List[str], List[int]]:
     gpu_ids, gpu_uuids = gpu.get_gpu_ids_and_uuids()
     use_gpu = len(gpu_uuids) > 0
     return use_gpu, gpu_uuids, gpu_ids

--- a/harness/determined/gpu.py
+++ b/harness/determined/gpu.py
@@ -1,16 +1,66 @@
+import csv
+import logging
+import subprocess
 import sys
-from typing import List, Optional, Tuple
+from typing import List, NamedTuple, Optional, Tuple
 
 from determined_common import check
 
+gpu_fields = [
+    "index",
+    "uuid",
+    "utilization.gpu",
+    "memory.used",
+    "memory.total",
+]
 
-def get_gpu_ids_and_uuids() -> Tuple[List[str], List[str]]:
+
+class GPU(NamedTuple):
+    id: int
+    uuid: str
+    load: float
+    memoryUtil: float
+
+
+def get_gpus() -> List[GPU]:
     try:
-        import GPUtil
-    except ModuleNotFoundError:
-        return [], []
+        proc = subprocess.Popen(
+            ["nvidia-smi", "--query-gpu=" + ",".join(gpu_fields), "--format=csv,noheader,nounits"],
+            stdout=subprocess.PIPE,
+            universal_newlines=True,
+        )
+    except FileNotFoundError:
+        # This case is expected if NVIDIA drivers are not available.
+        return []
+    except Exception as e:
+        logging.warning(f"Couldn't query GPUs with `nvidia-smi`; assuming there are none: {e}")
+        return []
 
-    gpus = GPUtil.getGPUs()
+    gpus = []
+    with proc:
+        for field_list in csv.reader(proc.stdout):
+            if len(field_list) != len(gpu_fields):
+                logging.warning(f"Ignoring unexpected nvidia-smi output: {field_list}")
+                continue
+            fields = dict(zip(gpu_fields, field_list))
+            try:
+                gpus.append(
+                    GPU(
+                        id=int(fields["index"]),
+                        uuid=fields["uuid"].strip(),
+                        load=float(fields["utilization.gpu"]) / 100,
+                        memoryUtil=float(fields["memory.used"]) / float(fields["memory.total"]),
+                    )
+                )
+            except ValueError:
+                logging.warning(f"Ignoring unexpected nvidia-smi output: {fields}")
+    if proc.returncode:
+        logging.warning(f"`nvidia-smi` exited with failure status code {proc.returncode}")
+    return gpus
+
+
+def get_gpu_ids_and_uuids() -> Tuple[List[int], List[str]]:
+    gpus = get_gpus()
     return [gpu.id for gpu in gpus], [gpu.uuid for gpu in gpus]
 
 
@@ -19,7 +69,7 @@ def get_gpu_uuids_and_validate(use_gpu: bool, slot_ids: Optional[List[str]] = No
         # Sanity check: if this trial is expected to run on the GPU but
         # no GPUs are available, this indicates a misconfiguration.
         _, gpu_uuids = get_gpu_ids_and_uuids()
-        if len(gpu_uuids) == 0:
+        if not gpu_uuids:
             sys.exit("Failed to find GPUs for GPU-only trial")
 
         if slot_ids is not None:

--- a/harness/determined/layers/_harness_profiler.py
+++ b/harness/determined/layers/_harness_profiler.py
@@ -6,6 +6,8 @@ import matplotlib.pyplot as plt
 import psutil
 import simplejson
 
+import determined.gpu
+
 MeasurementHistory = List[Tuple[float, Any]]
 
 
@@ -97,9 +99,7 @@ class HarnessProfiler(object):
         )
 
         if self._use_gpu:
-            import GPUtil
-
-            gpu_list = GPUtil.getGPUs()
+            gpu_list = determined.gpu.get_gpus()
             self._gpu_loads = {g.id: Measurement("GPU {} Load (%)".format(g.id)) for g in gpu_list}
             self._gpu_utilizations = {
                 g.id: Measurement("GPU {} Memory Utilization (%)".format(g.id)) for g in gpu_list
@@ -128,10 +128,7 @@ class HarnessProfiler(object):
             self._process_write_chars.add_measurement(process_io_stats.write_chars)
 
             if self._use_gpu:
-                import GPUtil
-
-                gpus = GPUtil.getGPUs()
-                for g in gpus:
+                for g in determined.gpu.get_gpus():
                     self._gpu_loads[g.id].add_measurement(g.load)
                     self._gpu_utilizations[g.id].add_measurement(g.memoryUtil)
 

--- a/harness/setup.py
+++ b/harness/setup.py
@@ -25,7 +25,6 @@ setup(
         "pyzmq==18.1.0",
         "requests>=2.20.0",
         "simplejson==3.16.0",
-        "GPUtil==1.4.0",
         "determined-common==0.12.4.dev0",
         "yogadl==0.1.0",
     ],


### PR DESCRIPTION
Given the complexity of GPUtil and how little we need from it, it makes sense to remove that dependency and get what we need from `nvidia-smi` directly.

This code also provides better error handling in the face of strange output from `nvidia-smi`.

Also fix up some type annotations; GPUtil returns IDs as integers, and this code does the same, but the annotations thought they were strings.

# Test Plan
- [x] run the new code by itself and check that it returns good results
- [x] run an experiment in debug mode and check that profiler results come through
