### PR TITLE
build: use `$*` in Makefile pattern rules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ package:
 
 .PHONY: build-%
 build-%:
-	$(MAKE) -C $(subst -,/,$(@:build-%=%)) build
+	$(MAKE) -C $(subst -,/,$*) build
 .PHONY: build-docs
 build-docs: build-common build-harness build-cli build-deploy build-examples
 	$(MAKE) -C docs build
@@ -29,24 +29,24 @@ build: build-master build-agent
 
 .PHONY: clean-%
 clean-%:
-	$(MAKE) -C $(subst -,/,$(@:clean-%=%)) clean
+	$(MAKE) -C $(subst -,/,$*) clean
 .PHONY: clean
 clean: clean-tools clean-common clean-harness clean-cli clean-deploy clean-examples clean-docs clean-webui clean-master clean-agent
 
 .PHONY: check-%
 check-%:
-	$(MAKE) -C $(subst -,/,$(@:check-%=%)) check
+	$(MAKE) -C $(subst -,/,$*) check
 .PHONY: check
 check: check-common check-harness check-cli check-deploy check-e2e_tests check-master check-agent check-webui
 
 .PHONY: fmt-%
 fmt-%:
-	$(MAKE) -C $(subst -,/,$(@:fmt-%=%)) fmt
+	$(MAKE) -C $(subst -,/,$*) fmt
 .PHONY: fmt
 fmt: fmt-common fmt-harness fmt-cli fmt-deploy fmt-e2e_tests fmt-master fmt-agent fmt-webui
 
 .PHONY: test-%
 test-%:
-	$(MAKE) -C $(subst -,/,$(@:test-%=%)) test
+	$(MAKE) -C $(subst -,/,$*) test
 .PHONY: test
 test: test-harness test-cli test-master test-agent test-webui


### PR DESCRIPTION
`$*` expands to the stem with which an implicit rule matches (that is, whatever the `%` corresponds to).

For more information, see the manual (https://www.gnu.org/software/make/manual/html_node/Automatic-Variables.html).

# Test Plan
- [x] run various `make` targets and check that they do the right thing