### PR TITLE
chore: stop handling request cancellation errors

### DIFF
--- a/webui/react/src/ErrorHandler.ts
+++ b/webui/react/src/ErrorHandler.ts
@@ -1,4 +1,5 @@
 import { notification } from 'antd';
+import axios from 'axios';
 
 import history from 'routes/history';
 import { isAsyncFunction } from 'utils/data';
@@ -61,6 +62,9 @@ const handleError = (e: DaError): Error => {
   e = { ...defaultErrorParameters, ...e };
 
   const error = e.error ? e.error : new Error(e.message);
+
+  // ignore request cancellation errors
+  if (axios.isCancel(e)) return error;
 
   if (e.type === ErrorType.Auth) {
     if (!window.location.pathname.endsWith('login')) {

--- a/webui/react/src/services/apiBuilder.ts
+++ b/webui/react/src/services/apiBuilder.ts
@@ -38,7 +38,7 @@ export function generateApi<Input, Output>(api: Api<Input, Output>) {
       return api.postProcess ? api.postProcess(response) : response.data as Output;
     } catch (e) {
       const isAuthError = isAuthFailure(e);
-      const error = handleError({
+      handleError({
         error: e,
         level: isAuthError ? ErrorLevel.Fatal : ErrorLevel.Error,
         message: isAuthError ?
@@ -46,7 +46,7 @@ export function generateApi<Input, Output>(api: Api<Input, Output>) {
         silent: true,
         type: isAuthError ? ErrorType.Auth : ErrorType.Server,
       });
-      throw error;
+      throw e;
     }
   };
 }


### PR DESCRIPTION
the requests are always cancelled at the explicit request of the caller (which most commonly happen when dismounting the component) we generally do not consider those as errors and as such don't pass them through ErrorHandler.

errorHandler is mainly for unifying logging, notification, and other forms of error response.