### PR TITLE
refactor: introduce a more modular approach  to useRestApi

### DIFF
--- a/webui/react/src/hooks/useRestApi.ts
+++ b/webui/react/src/hooks/useRestApi.ts
@@ -148,10 +148,7 @@ export const useRestApiSimple =
 
     apiReq({ ...params, cancelToken: source.token })
       .then((result) => {
-        dispatch({
-          type: ActionType.SetData,
-          value: result,
-        });
+        dispatch({ type: ActionType.SetData, value: result });
 
       })
       .catch((error) => {
@@ -164,7 +161,6 @@ export const useRestApiSimple =
   }, [ apiReq, params ]);
 
   return [ state, setParams ];
-
 };
 
 export default useRestApi;

--- a/webui/react/src/hooks/useRestApi.ts
+++ b/webui/react/src/hooks/useRestApi.ts
@@ -147,15 +147,8 @@ export const useRestApiSimple =
     const source = axios.CancelToken.source();
 
     apiReq({ ...params, cancelToken: source.token })
-      .then((result) => {
-        dispatch({ type: ActionType.SetData, value: result });
-
-      })
-      .catch((error) => {
-        if (!axios.isCancel(error)) {
-          dispatch({ type: ActionType.SetError, value: error });
-        }
-      });
+      .then((result) => dispatch({ type: ActionType.SetData, value: result } ))
+      .catch((e) => (!axios.isCancel(e)) && dispatch({ type: ActionType.SetError, value: e }));
 
     return (): void => source.cancel();
   }, [ apiReq, params ]);

--- a/webui/react/src/hooks/useRestApi.ts
+++ b/webui/react/src/hooks/useRestApi.ts
@@ -129,4 +129,42 @@ const useRestApi = <T>(ioType: io.Mixed, options: HookOptions<T> = {}): Output<T
   return [ state, setHttpOptions ];
 };
 
+type SimpleOutput<In, Out> = [
+  State<Out>,
+  Dispatch<SetStateAction<In>>,
+];
+
+export const useRestApiSimple =
+<In, Out>(apiReq: (a: In) => Promise<Out>, initialParams: In): SimpleOutput<In, Out> => {
+  const [ params, setParams ] = useState<In>(initialParams);
+  const [ state, dispatch ] = useReducer<Reducer<State<Out>, Action<Out>>>(reducer, {
+    errorCount: 0,
+    hasLoaded: false,
+    isLoading: false,
+  });
+
+  useEffect(() => {
+    const source = axios.CancelToken.source();
+
+    apiReq({ ...params, cancelToken: source.token })
+      .then((result) => {
+        dispatch({
+          type: ActionType.SetData,
+          value: result,
+        });
+
+      })
+      .catch((error) => {
+        if (!axios.isCancel(error)) {
+          dispatch({ type: ActionType.SetError, value: error });
+        }
+      });
+
+    return (): void => source.cancel();
+  }, [ apiReq, params ]);
+
+  return [ state, setParams ];
+
+};
+
 export default useRestApi;

--- a/webui/react/src/pages/Dashboard.tsx
+++ b/webui/react/src/pages/Dashboard.tsx
@@ -12,10 +12,9 @@ import ClusterOverview from 'contexts/ClusterOverview';
 import { Commands, Notebooks, Shells, Tensorboards } from 'contexts/Commands';
 import Users from 'contexts/Users';
 import usePolling from 'hooks/usePolling';
-import useRestApi from 'hooks/useRestApi';
+import { useRestApiSimple } from 'hooks/useRestApi';
 import useStorage from 'hooks/useStorage';
-import { ioExperiments } from 'ioTypes';
-import { jsonToExperiments } from 'services/decoder';
+import { ExperimentsParams, getExperiments } from 'services/api';
 import { ShirtSize } from 'themes';
 import {
   Command, CommandState, Experiment, RecentTask, ResourceType, RunState, TaskType,
@@ -60,16 +59,14 @@ const Dashboard: React.FC = () => {
   const shells = Shells.useStateContext();
   const tensorboards = Tensorboards.useStateContext();
   const [ experimentsResponse, requestExperiments ] =
-    useRestApi<Experiment[]>(ioExperiments, { mappers: jsonToExperiments });
+    useRestApiSimple<ExperimentsParams, Experiment[]>(getExperiments, {});
   const storage = useStorage('dashboard/tasks');
   const initFilters = storage.getWithDefault('filters',
     { ...defaultFilters, username: (auth.user || {}).username });
   const [ filters, setFilters ] = useState<TaskFilters>(initFilters);
 
   const fetchExperiments = useCallback((): void => {
-    requestExperiments({
-      url: '/experiment-summaries',
-    });
+    requestExperiments({});
   }, [ requestExperiments ]);
 
   usePolling(fetchExperiments);

--- a/webui/react/src/pages/Determined.tsx
+++ b/webui/react/src/pages/Determined.tsx
@@ -8,11 +8,12 @@ import ClusterOverview from 'contexts/ClusterOverview';
 import { Commands, Notebooks, Shells, Tensorboards } from 'contexts/Commands';
 import Users from 'contexts/Users';
 import usePolling from 'hooks/usePolling';
-import useRestApi from 'hooks/useRestApi';
-import { ioAgents, ioExperiments, ioGenericCommands, ioUsers } from 'ioTypes';
+import useRestApi, { useRestApiSimple } from 'hooks/useRestApi';
+import { ioAgents, ioGenericCommands, ioUsers } from 'ioTypes';
 import { detRoutes } from 'routes';
+import { ExperimentsParams, getExperiments } from 'services/api';
 import {
-  jsonToAgents, jsonToCommands, jsonToExperiments, jsonToNotebooks,
+  jsonToAgents, jsonToCommands, jsonToNotebooks,
   jsonToShells, jsonToTensorboards, jsonToUsers,
 } from 'services/decoder';
 import { Agent, Command, Experiment, RunState, User } from 'types';
@@ -42,7 +43,7 @@ const Determined: React.FC = () => {
   const [ commandsResponse, requestCommands ] =
     useRestApi<Command[]>(ioGenericCommands, { mappers: jsonToCommands });
   const [ experimentsResponse, requestExperiments ] =
-    useRestApi<Experiment[]>(ioExperiments, { mappers: jsonToExperiments });
+    useRestApiSimple<ExperimentsParams, Experiment[]>(getExperiments, {});
   const [ notebooksResponse, requestNotebooks ] =
     useRestApi<Command[]>(ioGenericCommands, { mappers: jsonToNotebooks });
   const [ shellsResponse, requestShells ] =
@@ -56,7 +57,7 @@ const Determined: React.FC = () => {
     requestNotebooks({ url: '/notebooks' });
     requestShells({ url: '/shells' });
     requestTensorboards({ url: '/tensorboard' });
-    requestExperiments({ url: `/experiment-summaries?states=${activeStates.join(',')}` });
+    requestExperiments({ states: activeStates });
   }, [
     requestAgents,
     requestCommands,

--- a/webui/react/src/services/api.ts
+++ b/webui/react/src/services/api.ts
@@ -52,7 +52,7 @@ export interface ExperimentsParams {
 
 const experimentsApi:  Api<ExperimentsParams, Experiment[]> = {
   httpOptions: (params) => ({
-    url: '/experiment-summaries' + (params.states ? '?'+params.states.join(',') : ''),
+    url: '/experiment-summaries' + (params.states ? '?states='+params.states.join(',') : ''),
   }),
   name: 'getExperiments',
   postProcess: (response) => jsonToExperiments(response.data),

--- a/webui/react/src/services/api.ts
+++ b/webui/react/src/services/api.ts
@@ -55,7 +55,6 @@ const experimentsApi:  Api<ExperimentsParams, Experiment[]> = {
     url: '/experiment-summaries' + (params.states ? '?'+params.states.join(',') : ''),
   }),
   name: 'getExperiments',
-
   postProcess: (response) => jsonToExperiments(response.data),
 };
 

--- a/webui/react/src/services/api.ts
+++ b/webui/react/src/services/api.ts
@@ -3,7 +3,8 @@ import { sha512 }  from 'js-sha512';
 
 import { decode, ioTypeUser, ioUser } from 'ioTypes';
 import { Api, generateApi } from 'services/apiBuilder';
-import { CommandType, Credentials, RecentTask, TaskType, User } from 'types';
+import { jsonToExperiments } from 'services/decoder';
+import { CommandType, Credentials, Experiment, RecentTask, TaskType, User } from 'types';
 
 const commandToEndpoint: Record<CommandType, string> = {
   [CommandType.Command]: '/commands',
@@ -44,6 +45,21 @@ const userApi:  Api<{}, User> = {
 };
 
 export const getCurrentUser = generateApi<{}, User>(userApi);
+
+export interface ExperimentsParams {
+  states?: string[];
+}
+
+const experimentsApi:  Api<ExperimentsParams, Experiment[]> = {
+  httpOptions: (params) => ({
+    url: '/experiment-summaries' + (params.states ? '?'+params.states.join(',') : ''),
+  }),
+  name: 'getExperiments',
+
+  postProcess: (response) => jsonToExperiments(response.data),
+};
+
+export const getExperiments = generateApi<ExperimentsParams, Experiment[]>(experimentsApi);
 
 interface KillExpParams {
   experimentId: number;

--- a/webui/react/src/services/decoder.ts
+++ b/webui/react/src/services/decoder.ts
@@ -1,8 +1,10 @@
 import dayjs from 'dayjs';
 
 import {
-  ioTypeAgents, ioTypeCommandAddress, ioTypeDeterminedInfo,
-  ioTypeExperiments, ioTypeGenericCommand, ioTypeGenericCommands, ioTypeUsers,
+  decode,
+  ioExperiments, ioTypeAgents, ioTypeCommandAddress,
+  ioTypeDeterminedInfo, ioTypeExperiments, ioTypeGenericCommand, ioTypeGenericCommands,
+  ioTypeUsers,
 } from 'ioTypes';
 import {
   Agent, Command, CommandType, DeterminedInfo, Experiment, ResourceState, ResourceType, User,
@@ -110,8 +112,9 @@ export const jsonToTensorboards = (data: ioTypeGenericCommands): Command[] => {
   return jsonToGenericCommands(data, CommandType.Tensorboard);
 };
 
-export const jsonToExperiments = (data: ioTypeExperiments): Experiment[] => {
-  return data.map(experiment => {
+export const jsonToExperiments = (data: unknown): Experiment[] => {
+  const ioType = decode<ioTypeExperiments>(ioExperiments, data);
+  return ioType.map(experiment => {
     return {
       archived: experiment.archived,
       config: experiment.config,


### PR DESCRIPTION
- reuse the `apiBuilder` in rest API hooks
  - allow the same api use pattern that is used elsewhere in our app to be used in `hooks/useRestApi` as well
- limit all the decoding in the `decoder` module

once this looks good to everyone and is refined and is approved we can port the rest of the rest API hooks and future ones to use this pattern

https://determinedai.atlassian.net/browse/DET-3086