### PR TITLE
chore: add TLS by default for cloud deployments

### DIFF
--- a/deploy/determined_deploy/aws/templates/secure.yaml
+++ b/deploy/determined_deploy/aws/templates/secure.yaml
@@ -573,6 +573,8 @@ Resources:
               host: "${Database.Endpoint.Address}"
               port: 5432
               name: determined
+              ssl_mode: verify-ca
+              ssl_root_cert: /etc/determined/etc/db_ssl_root_cert.pem
 
             provisioner:
               iam_instance_profile_arn: ${AgentInstanceProfile.Arn}
@@ -612,6 +614,9 @@ Resources:
             apt-get update
             apt-get install -y docker-ce docker-ce-cli containerd.io
 
+            curl -fsSL https://www.amazontrust.com/repository/AmazonRootCA1.pem > \
+              /usr/local/determined/etc/AmazonRootCA1.pem
+
             docker network create determined
 
             docker stop $(docker ps -a -q)
@@ -626,6 +631,7 @@ Resources:
                 --log-opt awslogs-stream=determined-master \
                 -p 8080:8080 \
                 -v /usr/local/determined/etc/master.yaml:/etc/determined/master.yaml \
+                -v /usr/local/determined/etc/AmazonRootCA1.pem:/etc/determined/etc/db_ssl_root_cert.pem \
                 determinedai/determined-master:${Version}
             --//
 

--- a/deploy/determined_deploy/aws/templates/simple.yaml
+++ b/deploy/determined_deploy/aws/templates/simple.yaml
@@ -369,6 +369,8 @@ Resources:
               host: "${Database.Endpoint.Address}"
               port: 5432
               name: determined
+              ssl_mode: verify-ca
+              ssl_root_cert: /etc/determined/etc/db_ssl_root_cert.pem
 
             provisioner:
               iam_instance_profile_arn: ${AgentInstanceProfile.Arn}
@@ -407,6 +409,9 @@ Resources:
             apt-get update
             apt-get install -y docker-ce docker-ce-cli containerd.io
 
+            curl -fsSL https://www.amazontrust.com/repository/AmazonRootCA1.pem > \
+              /usr/local/determined/etc/AmazonRootCA1.pem
+
             docker network create determined
 
             docker stop $(docker ps -a -q)
@@ -421,6 +426,7 @@ Resources:
                 --log-opt awslogs-stream=determined-master \
                 -p 8080:8080 \
                 -v /usr/local/determined/etc/master.yaml:/etc/determined/master.yaml \
+                -v /usr/local/determined/etc/AmazonRootCA1.pem:/etc/determined/etc/db_ssl_root_cert.pem \
                 determinedai/determined-master:${Version}
             --//
           -  AgentAmi: !FindInMap [RegionMap, !Ref "AWS::Region", Agent]

--- a/deploy/determined_deploy/aws/templates/vpc.yaml
+++ b/deploy/determined_deploy/aws/templates/vpc.yaml
@@ -495,6 +495,8 @@ Resources:
               host: "${Database.Endpoint.Address}"
               port: 5432
               name: determined
+              ssl_mode: verify-ca
+              ssl_root_cert: /etc/determined/etc/db_ssl_root_cert.pem
 
             provisioner:
               iam_instance_profile_arn: ${AgentInstanceProfile.Arn}
@@ -534,6 +536,9 @@ Resources:
             apt-get update
             apt-get install -y docker-ce docker-ce-cli containerd.io
 
+            curl -fsSL https://www.amazontrust.com/repository/AmazonRootCA1.pem > \
+              /usr/local/determined/etc/AmazonRootCA1.pem
+
             docker network create determined
 
             docker stop $(docker ps -a -q)
@@ -548,6 +553,7 @@ Resources:
                 --log-opt awslogs-stream=determined-master \
                 -p 8080:8080 \
                 -v /usr/local/determined/etc/master.yaml:/etc/determined/master.yaml \
+                -v /usr/local/determined/etc/AmazonRootCA1.pem:/etc/determined/etc/db_ssl_root_cert.pem \
                 determinedai/determined-master:${Version}
             --//
           - AgentAmi: !FindInMap [RegionMap, !Ref "AWS::Region", Agent]

--- a/deploy/determined_deploy/gcp/terraform/main.tf
+++ b/deploy/determined_deploy/gcp/terraform/main.tf
@@ -142,6 +142,8 @@ module "compute" {
   gcs_bucket = module.gcs.gcs_bucket
   database_hostname = module.database.database_hostname
   database_name = module.database.database_name
+  database_ssl_enabled = var.db_ssl_enabled
+  database_ssl_root_cert = module.database.database_ssl_root_cert
   tag_master_port = module.firewall.tag_master_port
   tag_allow_internal = module.firewall.tag_allow_internal
   tag_allow_ssh = module.firewall.tag_allow_ssh

--- a/deploy/determined_deploy/gcp/terraform/modules/compute/variables.tf
+++ b/deploy/determined_deploy/gcp/terraform/modules/compute/variables.tf
@@ -82,6 +82,12 @@ variable "db_password" {
 variable "database_name" {
 }
 
+variable "database_ssl_enabled"{
+}
+
+variable "database_ssl_root_cert" {
+}
+
 variable "master_instance_type" {
 }
 

--- a/deploy/determined_deploy/gcp/terraform/modules/database/outputs.tf
+++ b/deploy/determined_deploy/gcp/terraform/modules/database/outputs.tf
@@ -5,3 +5,7 @@ output "database_hostname" {
 output "database_name" {
   value = google_sql_database.database.name
 }
+
+output "database_ssl_root_cert" {
+  value = google_sql_database_instance.db_instance.server_ca_cert.0.cert
+}

--- a/deploy/determined_deploy/gcp/terraform/variables.tf
+++ b/deploy/determined_deploy/gcp/terraform/variables.tf
@@ -155,3 +155,8 @@ variable "db_password" {
   type = string
   default = "postgres"
 }
+
+variable "db_ssl_enabled" {
+  type = bool
+  default = true
+}

--- a/master/cmd/determined-master/init.go
+++ b/master/cmd/determined-master/init.go
@@ -80,6 +80,10 @@ func registerConfig() {
 		defaults.DB.Port, "database port")
 	registerString(flags, name("db", "name"),
 		defaults.DB.Name, "database name")
+	registerString(flags, name("db", "ssl-mode"),
+		defaults.DB.SSLMode, "database ssl mode (disable, verify-ca, ...)")
+	registerString(flags, name("db", "ssl-root-cert"),
+		defaults.DB.SSLRootCert, "database ssl root cert path")
 
 	registerString(flags, name("scheduler", "fit"),
 		defaults.Scheduler.Fit, "scheduler fit method")

--- a/master/internal/db/config.go
+++ b/master/internal/db/config.go
@@ -4,15 +4,18 @@ package db
 func DefaultConfig() *Config {
 	return &Config{
 		Migrations: "file://static/migrations",
+		SSLMode:    sslModeDisable,
 	}
 }
 
 // Config hosts configuration fields of the database.
 type Config struct {
-	User       string `json:"user"`
-	Password   string `json:"password"`
-	Migrations string `json:"migrations"`
-	Host       string `json:"host"`
-	Port       string `json:"port"`
-	Name       string `json:"name"`
+	User        string `json:"user"`
+	Password    string `json:"password"`
+	Migrations  string `json:"migrations"`
+	Host        string `json:"host"`
+	Port        string `json:"port"`
+	Name        string `json:"name"`
+	SSLMode     string `json:"ssl_mode"`
+	SSLRootCert string `json:"ssl_root_cert"`
 }

--- a/master/internal/db/setup.go
+++ b/master/internal/db/setup.go
@@ -9,15 +9,20 @@ import (
 
 const maxOpenConns = 48
 
-const cnxTpl = "postgres://%s:%s@%s:%s/%s?sslmode=disable&application_name=determined-master"
+const (
+	cnxTpl         = "postgres://%s:%s@%s:%s/%s?application_name=determined-master"
+	sslTpl         = "&sslmode=%s&sslrootcert=%s"
+	sslModeDisable = "disable"
+)
 
 // Setup connects to the database and run any necessary migrations.
 func Setup(opts *Config) (*PgDB, error) {
 	dbURL := fmt.Sprintf(cnxTpl, opts.User, opts.Password, opts.Host, opts.Port, opts.Name)
+	dbURL += fmt.Sprintf(sslTpl, opts.SSLMode, opts.SSLRootCert)
 	log.Infof("connecting to database %s:%s", opts.Host, opts.Port)
 	db, err := ConnectPostgres(dbURL)
 	if err != nil {
-		return nil, errors.Wrapf(err, "connecting to database: %s", dbURL)
+		return nil, errors.Wrapf(err, "error connecting to database: %s:%s", opts.Host, opts.Port)
 	}
 
 	db.sql.SetMaxOpenConns(maxOpenConns)


### PR DESCRIPTION
We should, in cloud setups, setup TLS for communication with
the postgres database, since credentials and models are
sent between it.

# Test Plan
- [x] run terraform and verify we connect to db
- [x] run cloudformation (make upstream branch)
