### PR TITLE
test: adjust confidence threshold for a successful convergence

### DIFF
--- a/e2e_tests/tests/test_convergence.py
+++ b/e2e_tests/tests/test_convergence.py
@@ -20,7 +20,7 @@ def test_cifar10_pytorch_accuracy() -> None:
         if step.validation
     ]
 
-    target_accuracy = 0.745
+    target_accuracy = 0.74
     assert max(validation_errors) > target_accuracy, (
         "cifar10_cnn_pytorch did not reach minimum target accuracy {} in {} steps."
         " full validation error history: {}".format(


### PR DESCRIPTION
0.745 seems to have resulted in a pretty quick flake: https://app.circleci.com/pipelines/github/determined-ai/determined/1253/workflows/6e5ab66b-d030-45fc-a032-be8935b945fc/jobs/21072/steps. tweak it lower.