### PR TITLE
docs: fix custom env tf.2 snippet

### DIFF
--- a/docs/how-to/custom-env.txt
+++ b/docs/how-to/custom-env.txt
@@ -105,8 +105,8 @@ This can be configured in your experiment configuration like below:
 
    environment:
      image:
-     - gpu: "determinedai/environments:cuda-10.1-pytorch-1.4-tf-2.1-gpu-0.3.0"
-     - cpu: "determinedai/environments:py-3.6.9-pytorch-1.4-tf-2.1-cpu-0.3.0"
+       gpu: "determinedai/environments:cuda-10.1-pytorch-1.4-tf-2.1-gpu-0.3.0"
+       cpu: "determinedai/environments:py-3.6.9-pytorch-1.4-tf-2.1-cpu-0.3.0"
 
 
 Custom Docker Images in Determined


### PR DESCRIPTION
The environment.image configuration field used to contain a list of
images for CPU and GPU containers. This is now a dictionary and
therefore the snippet was not a valid experiment configuration.

See: https://github.com/determined-ai/determined/blob/8bdda0087a17a7b107e626b6bda879a637bb4418/master/pkg/model/environment_config.go#L14-L27

# Test Plan
- [x] rendered the docs
