### PR TITLE
[DET-2933] feat: make Link component to be based on HTML anchor tag

### DIFF
--- a/webui/react/src/components/Link.module.scss
+++ b/webui/react/src/components/Link.module.scss
@@ -1,1 +1,8 @@
-.base { cursor: pointer; }
+.base {
+  color: inherit;
+  cursor: pointer;
+
+  &:hover {
+    color: inherit;
+  }
+}

--- a/webui/react/src/components/Link.tsx
+++ b/webui/react/src/components/Link.tsx
@@ -19,7 +19,7 @@ const Link: React.FC<Props> = ({
   crossover, disabled, path, popout, onClick, children,
 }: PropsWithChildren<Props>) => {
   const history = useHistory();
-  const classes = [];
+  const classes = [ css.base ];
 
   if (!disabled) classes.push(css.link);
 
@@ -41,7 +41,7 @@ const Link: React.FC<Props> = ({
     }
   }, [ history, crossover, onClick, path, popout ]);
 
-  return <div className={classes.join(' ')} onClick={handleClick}>{children}</div>;
+  return <a className={classes.join(' ')} href={path} onClick={handleClick}>{children}</a>;
 };
 
 Link.defaultProps = defaultProps;


### PR DESCRIPTION
The anchor tag was not initially used due to the nesting limitation with
anchor tags. Going forward we will need to avoid this situation.

before (anchor tags in the page):
![Screen Capture_select-area_20200512134551](https://user-images.githubusercontent.com/12127420/81744027-7f7a2b80-9457-11ea-885e-33e08383f771.png)

after (anchor tags in the page):
![Screen Capture_select-area_20200512134620](https://user-images.githubusercontent.com/12127420/81744024-7ee19500-9457-11ea-83eb-e0968c7a8626.png)

