### PR TITLE
test: install pandas to fix iris test

### DIFF
--- a/e2e_tests/tests/requirements.txt
+++ b/e2e_tests/tests/requirements.txt
@@ -4,3 +4,4 @@ torch==1.4
 torchvision==0.5.0
 tensorflow==1.14
 numpy
+pandas


### PR DESCRIPTION
## Description
We don't run startup-hook.sh as part of checkpoint export, so pandas which is installed in the startup-hook for iris is not present in our environment. 


## Test Plan
Tested locally to confirm issue is solved.


