### PR TITLE
feat: add container count to "det agent list"

### DIFF
--- a/cli/determined_cli/agent.py
+++ b/cli/determined_cli/agent.py
@@ -22,12 +22,13 @@ def list_agents(args: argparse.Namespace) -> None:
     r = api.get(args.master, "agents")
 
     agents = r.json()
-    headers = ["Agent Name", "Registered Time", "Slots", "Label"]
+    headers = ["Agent Name", "Registered Time", "Slots", "Containers", "Label"]
     values = [
         [
             local_id(agent_id),
             render.format_time(agent["registered_time"]),
             len(agent["slots"]),
+            agent["num_containers"],
             agent["label"],
         ]
         for agent_id, agent in sorted(agents.items())

--- a/master/internal/agent/agent.go
+++ b/master/internal/agent/agent.go
@@ -37,6 +37,7 @@ type agentSummary struct {
 	ID             string       `json:"id"`
 	RegisteredTime time.Time    `json:"registered_time"`
 	Slots          slotsSummary `json:"slots"`
+	NumContainers  int          `json:"num_containers"`
 	Label          string       `json:"label"`
 }
 
@@ -172,6 +173,7 @@ func (a *agent) summarize(ctx *actor.Context) agentSummary {
 		ID:             ctx.Self().Address().Local(),
 		RegisteredTime: ctx.Self().RegisteredTime(),
 		Slots:          ctx.Ask(a.slots, slotsSummary{}).Get().(slotsSummary),
+		NumContainers:  len(a.containers),
 		Label:          a.label,
 	}
 }


### PR DESCRIPTION
When working with dynamic agents on a cluster running a variety of
workload types (e.g., experiments, notebooks, tensorboards, etc.), it
can be difficult to tell whether an agent is idle or not. This commit
adds a simple way to do that via "det agent list".

Note: this breaks CLI backward compatibility, as "det agent list" with
CLI >= 0.12.5 won't work with masters < 0.12.5.
