### PR TITLE
docs: package-based install documentation improvements

### DIFF
--- a/docs/how-to/installation/packages.txt
+++ b/docs/how-to/installation/packages.txt
@@ -5,13 +5,81 @@ Install Determined Using Debian Packages
 
 For systems running Ubuntu 16.04 or 18.04, we support installing the
 Determined master and agent using Debian packages and running them as
-systemd services rather than Docker containers.
-
-For PostgreSQL, you should use either your Linux distribution's package
-and service or a :ref:`Docker container <install-using-docker>`.
+systemd services.
 
 Preliminary Setup
 -----------------
+
+PostgreSQL
+~~~~~~~~~~
+Determined uses a PostgreSQL database to store experiment and trial metadata.
+You may either use your Linux distribution's package and service or a Docker
+container.
+
+With either of the following installation methods, PostgreSQL will typically run
+with a default of 100 ``max_connections``, which is sufficient for Determined.
+You may validate by issuing the following query via a database client like
+``psql``:
+
+.. code::
+
+   SHOW max_connections;
+
+
+Installing PostgreSQL via ``apt``
+_________________________________
+We recommend installing the following version of PostgreSQL:
+
+.. code::
+
+   sudo apt install postgresql-10
+
+Next, configure a system account that Determined will use to connect to
+PostgreSQL. For example, to use the default ``postgres`` user but update its
+password:
+
+.. code::
+
+   sudo -u postgres psql postgres
+   postgres=# \password postgres
+
+Finally, create a database for Determined's use:
+
+.. code::
+
+   postgres=# CREATE DATABASE determined;
+
+Running PostgreSQL in Docker
+____________________________
+Pull the official Docker image for PostgreSQL. We recommend using the version
+listed below.
+
+.. code::
+
+   docker pull postgres:10
+
+This image is not provided by Determined AI; please see `its Docker Hub page
+<https://hub.docker.com/_/postgres>`_ for more information.
+
+Start PostgreSQL as follows:
+
+.. code::
+
+   docker run \
+       -d \
+       --restart unless-stopped \
+       --name determined-db \
+       -p 5432:5432 \
+       -v determined_db:/var/lib/postgresql/data \
+       -e POSTGRES_DB=determined \
+       -e POSTGRES_PASSWORD=<Database password> \
+       postgres:10
+
+If the master will connect to PostgreSQL via Docker networking, exposing port
+5432 via the ``-p`` argument isn't necessary; however, you may still want to
+expose it for administrative or debugging purposes. In order to expose the port
+only on the master machine's loopback network interface, pass ``-p
+127.0.0.1:5432:5432`` instead of ``-p 5432:5432``.
 
 Master and Agent
 ~~~~~~~~~~~~~~~~
@@ -27,7 +95,7 @@ Master and Agent
 
    .. code::
 
-      sudo apt-get install <path to downloaded file>
+      sudo apt install <path to downloaded file>
 
 Before running the Determined agent, you will have to :ref:`install
 Docker <install-docker>` on each agent machine and, if the machine
@@ -46,8 +114,19 @@ Configuring and Starting the Cluster
 
 #. Edit the :ref:`YAML configuration files <topic-guides_yaml>` at
    ``/etc/determined/master.yaml`` (for the master) and
-   ``/etc/determined/agent.yaml`` (for each agent) as appropriate for
-   your setup.
+   ``/etc/determined/agent.yaml`` (for each agent) as appropriate for your
+   setup.  Ensure that the user, password, and database name correspond to your
+   PostgreSQL configuration, e.g.:
+
+   .. code::
+
+     db:
+       host: <PostgreSQL server IP or hostname, e.g., 127.0.0.1 if running on the master>
+       port: <PostgreSQL port, e.g., 5432 by default>
+       name: <Database name, e.g., determined>
+       user: <PostgreSQL user, e.g., postgres>
+       password: <Database password>
+
 
 #. Start the master.
 
@@ -60,7 +139,20 @@ Configuring and Starting the Cluster
    Determined (e.g., testing different configuration options quickly
    before writing them to the configuration file).
 
-#. Start the agent on each agent machine.
+#. Verify that the master started successfully by viewing the log:
+
+   .. code::
+
+      journalctl -u determined-master
+
+   You should see logging indicating that the master can successfully connect to
+   the database, and the last line should indicate ``http server started`` on
+   the configured WebUI port (8080 by default). You can also validate that the
+   WebUI is running by navigating to ``http://<master>:8080`` with your web
+   browser (or ``https://<master>:8443`` if TLS is enabled). You should see ``No
+   Agents`` on the right-hand side of the top navigation bar.
+
+#. Start the agent on each agent machine:
 
    .. code::
 
@@ -69,14 +161,26 @@ Configuring and Starting the Cluster
    Similarly, the agent can be run with the command
    ``determined-agent``.
 
+#. Verify that each agent started successfully by viewing the log:
+
+   .. code::
+
+      journalctl -u determined-agent
+
+   You should see logging indicating that the agent started successfully,
+   detected compute devices, and connected to the master. On the Determined
+   WebUI, you should now see slots available, both on the right-hand side of the
+   top navigation bar, and if you select the ``Cluster`` view in the left-hand
+   navigation panel.
+
 Managing the Cluster
 --------------------
 
 To configure a service to start running automatically when its machine
 boots up, run ``sudo systemctl enable <service>``, where the service is
-``determined-master`` or ``determined-agent``. (You can
+``determined-master`` or ``determined-agent``. You can
 also use ``sudo systemctl enable --now <service>`` to enable and
-immediately start a service in one command.)
+immediately start a service in one command.
 
 To view the logging output of a service, run ``journalctl -u
 <service>``.


### PR DESCRIPTION
* Add more guidance and sample commands on installing PostgreSQL,
  including steps for package-based install
* Use apt rather than apt-get
* Add validation steps to installation to help users checkpoint
  that each install step succeeded