### PR TITLE
feat: support `--csv`, `--json` in `slot list` and `agent list` in CLI

### DIFF
--- a/cli/determined_cli/render.py
+++ b/cli/determined_cli/render.py
@@ -4,7 +4,7 @@ import inspect
 import pathlib
 import sys
 from datetime import timezone
-from typing import Any, Dict, Iterable, List, Optional
+from typing import Any, Dict, Iterable, List, Optional, Sequence
 
 import dateutil.parser
 import tabulate
@@ -105,7 +105,7 @@ def format_resources(resources: Optional[Dict[str, int]]) -> str:
 
 def tabulate_or_csv(
     headers: List[str],
-    values: List[List[str]],
+    values: Sequence[Iterable[Any]],
     as_csv: bool,
     outfile: Optional[pathlib.Path] = None,
 ) -> None:


### PR DESCRIPTION
    This is useful as a stop-gap for folks that want to probe the state of
    the cluster, e.g., to determine if there are free GPUs to run
    low-priority batch inference jobs using the command infrastructure.

    To make JSON output consistent with non-JSON output, we now construct an
    intermediate list of dicts with the formatted version of the JSON we get
    from the master.

    Note that there are other `list` subcommands that might benefit from
    being treated consistently, but this commit does not attempt to add
    support for all of them.