### PR TITLE
fix: don't support AMP w/ aggregation_frequency > 1

### DIFF
--- a/e2e_tests/tests/experiment/test_pytorch.py
+++ b/e2e_tests/tests/experiment/test_pytorch.py
@@ -97,6 +97,9 @@ def test_pytorch_const_native_parallel() -> None:
 @pytest.mark.parametrize("aggregation_frequency", [1, 4])  # type: ignore
 @pytest.mark.parametrize("use_amp", [True, False])  # type: ignore
 def test_pytorch_const_parallel(aggregation_frequency: int, use_amp: bool) -> None:
+    if use_amp and aggregation_frequency > 1:
+        pytest.skip("Mixed precision is not support with aggregation frequency > 1.")
+
     config = conf.load_config(conf.official_examples_path("mnist_pytorch/const.yaml"))
     config = conf.set_slots_per_trial(config, 8)
     config = conf.set_native_parallel(config, False)

--- a/harness/determined/pytorch/_pytorch_trial.py
+++ b/harness/determined/pytorch/_pytorch_trial.py
@@ -187,6 +187,14 @@ class PyTorchTrialController(det.LoopTrialController):
 
     def _configure_amp(self) -> None:
         if self.use_amp():
+            if self.hvd_config.use:
+                check.eq(
+                    self.hvd_config.aggregation_frequency,
+                    1,
+                    "Mixed precision training (AMP) is not supported with "
+                    "aggregation frequency > 1.",
+                )
+
             check.true(
                 torch.cuda.is_available(),
                 "Mixed precision training (AMP) is supported only on GPU slots.",


### PR DESCRIPTION
## Description
Currently, AMP w/ Horovod w/ aggregation_frequency > 1 leads to convergence errors.

DET-3028  #Done.



## Test Plan
Updated tests.


## Commentary (optional)
There are at least two current issues. First, when overflows happen, they only happen on some of the workers, those workers end up skipping `step()`, which leads to different model parameters on different GPUs. The second issue, is that `parameters.grad.data` from prior steps (that haven't been zeroed out) are being used as part of subsequent loss scaling. Even after addressing these two issues (with debugging hacks) there are still other unknown issues that lead to convergence issues. 

One possible workaround is to limit `max_loss_scaling` to a lower number, which would prevent overflows and prevent the convergence issues. However, this may cause issues with gradients zeroing out. 

For now disabling this configuration and filing https://determinedai.atlassian.net/browse/DET-3074 to track.