### PR TITLE
fix: checkpoint export with custom python objects

### DIFF
--- a/common/determined_common/experimental/checkpoint/_checkpoint.py
+++ b/common/determined_common/experimental/checkpoint/_checkpoint.py
@@ -2,7 +2,7 @@ import enum
 import json
 import pathlib
 import shutil
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, cast
 
 from determined_common import api, storage
 
@@ -142,10 +142,10 @@ class Checkpoint(object):
                 <https://pytorch.org/docs/stable/torch.html?highlight=torch%20load#torch.load>`_.
         """
         ckpt_path = self.download(path)
-        return Checkpoint.load_from_path(ckpt_path, tags, **kwargs)
+        return Checkpoint.load_from_path(ckpt_path, tags=tags)
 
     @staticmethod
-    def load_from_path(path: str, tags: Optional[List[str]] = None, **kwargs: Any) -> Any:
+    def load_from_path(path: str, tags: Optional[List[str]] = None) -> Any:
         """
         Loads a Determined checkpoint from a local file system path into
         memory. If the checkpoint is a pytorch model a ``torch.nn.Module`` is returned.
@@ -161,42 +161,42 @@ class Checkpoint(object):
                 <https://www.tensorflow.org/versions/r1.15/api_docs/python/tf/saved_model/load_v2>`_.
         """
         checkpoint_dir = pathlib.Path(path)
+        metadata = Checkpoint.parse_metadata(checkpoint_dir)
+        checkpoint_type = Checkpoint.get_type(metadata)
 
-        checkpoint_type = Checkpoint.get_type(checkpoint_dir)
         if checkpoint_type == ModelFramework.PYTORCH:
             import determined_common.experimental.checkpoint._torch
 
             return determined_common.experimental.checkpoint._torch.load_model(
-                checkpoint_dir, **kwargs
+                checkpoint_dir, metadata,
             )
 
         elif checkpoint_type == ModelFramework.TENSORFLOW:
             import determined_common.experimental.checkpoint._tf
 
             return determined_common.experimental.checkpoint._tf.load_model(
-                checkpoint_dir, tags=tags
+                checkpoint_dir, metadata, tags=tags
             )
 
         raise AssertionError("Unknown checkpoint format at {}".format(checkpoint_dir))
 
     @staticmethod
-    def get_type(directory: pathlib.Path) -> ModelFramework:
-        # We used MLflow's MLmodel checkpoint format in the past for
-        # serializing pytorch models.
-        if directory.joinpath("MLmodel").exists():
-            return ModelFramework.PYTORCH
-
+    def parse_metadata(directory: pathlib.Path) -> Dict[str, Any]:
         metadata_path = directory.joinpath("metadata.json")
         with metadata_path.open() as f:
             metadata = json.load(f)
 
+        return cast(Dict[str, Any], metadata)
+
+    @staticmethod
+    def get_type(metadata: Dict[str, Any]) -> ModelFramework:
         if "torch_version" in metadata:
             return ModelFramework.PYTORCH
 
         elif "tensorflow_version" in metadata:
             return ModelFramework.TENSORFLOW
 
-        raise AssertionError("Unknown checkpoint format at {}".format(directory))
+        raise AssertionError("Unknown checkpoint format")
 
     def __repr__(self) -> str:
         return "Checkpoint(uuid={})".format(self.uuid)

--- a/common/determined_common/experimental/checkpoint/_tf.py
+++ b/common/determined_common/experimental/checkpoint/_tf.py
@@ -1,45 +1,57 @@
 import pathlib
-from typing import List, Optional
+from typing import Any, Dict, List, Optional, cast
 
 import tensorflow as tf
 from tensorflow.python.training.tracking.tracking import AutoTrackable
 
+from determined.experimental._native import _local_trial_from_context
+from determined.keras import TFKerasTrial
 
-def load_model(ckpt_dir: pathlib.Path, tags: Optional[List[str]] = None) -> AutoTrackable:
-    saved_model_paths = list(ckpt_dir.glob("**/saved_model.pb"))
-    h5_paths = list(ckpt_dir.glob("**/*.h5"))
 
-    if not h5_paths and not saved_model_paths:
-        raise AssertionError(
-            "No checkpoint saved_model.pb or h5 files found at {}".format(ckpt_dir)
-        )
+def load_model(
+    ckpt_dir: pathlib.Path, metadata: Dict[str, Any], tags: Optional[List[str]] = None
+) -> AutoTrackable:
+    save_format = metadata.get("format", None)
 
     # Tensorflow 1 favors saved_models for tf.estimators and h5 for tf.keras
     # models. Tensorflow is moving towards saved_model for both high level
-    # APIs in tf.2. For this reason we favor the saved_model below but also
-    # check for h5 models.
-    if saved_model_paths:
-        if len(saved_model_paths) > 1:
-            raise AssertionError(
-                "Checkpoint directory {} contains multiple \
-                nested saved_model.pb files: {}".format(
-                    ckpt_dir, saved_model_paths
-                )
-            )
+    # APIs in tf.2.
+    if not save_format or cast(str, save_format) == "saved_model":
+        return load_saved_model(ckpt_dir, tags=tags)
 
-        if tags is None:
-            print('No tags specified. Loading "serve" tag from saved_model.')
-            tags = ["serve"]
+    elif save_format == "h5":
+        trial = _local_trial_from_context(
+            ckpt_dir.joinpath("code"),
+            config=metadata["experiment_config"],
+            hparams=metadata["hparams"],
+        )
 
-        saved_model_path = saved_model_paths[0]
-        return tf.compat.v1.saved_model.load_v2(str(saved_model_path.parent), tags)
-
+        trial = cast(TFKerasTrial, trial)
+        model = trial.build_model()
+        model.load_weights(str(ckpt_dir.joinpath("determined-keras-model.h5")))
+        return model
     else:
-        if len(h5_paths) > 1:
-            raise AssertionError(
-                "Checkpoint directory {} contains multiple \
-                nested .h5 files: {}".format(
-                    ckpt_dir, h5_paths
-                )
+        raise AssertionError("Unknown checkpoint format at {}".format(str(ckpt_dir)))
+
+
+def load_saved_model(ckpt_dir: pathlib.Path, tags: Optional[List[str]] = None) -> AutoTrackable:
+    saved_model_paths = list(ckpt_dir.glob("**/saved_model.pb"))
+
+    if len(saved_model_paths) > 1:
+        raise AssertionError(
+            "Checkpoint directory {} contains multiple \
+            nested saved_model.pb files: {}".format(
+                ckpt_dir, saved_model_paths
             )
-        return tf.keras.models.load_model(h5_paths[0])
+        )
+
+    # Tensorflow uses tags to determine which metagraph to load. Most
+    # commonly, users will attempt to serve or otherwise use the model for
+    # inference. Therefore we default to the serve graph tag which disables
+    # operations that are only relevant for training.
+    if tags is None:
+        print('No tags specified. Loading "serve" tag from saved_model.')
+        tags = ["serve"]
+
+    saved_model_path = saved_model_paths[0]
+    return tf.compat.v1.saved_model.load_v2(str(saved_model_path.parent), tags)

--- a/common/determined_common/experimental/checkpoint/_torch.py
+++ b/common/determined_common/experimental/checkpoint/_torch.py
@@ -1,28 +1,22 @@
 import pathlib
-import sys
-from typing import Any
+from typing import Any, Dict, cast
 
-import cloudpickle
 import torch
 
+from determined.experimental._native import _local_trial_from_context
+from determined.pytorch import PyTorchTrial
 
-def load_model(ckpt_dir: pathlib.Path, **kwargs: Any) -> torch.nn.Module:
-    code_path = ckpt_dir.joinpath("code")
 
-    # We used MLflow's MLmodel checkpoint format in the past. This format
-    # nested the checkpoint in data/. Currently, we have the checkpoint at the
-    # top level of the checkpoint directory.
-    potential_model_paths = [["model.pth"], ["data", "model.pth"]]
+def load_model(ckpt_dir: pathlib.Path, metadata: Dict[str, Any], **kwargs: Any) -> torch.nn.Module:
+    trial = _local_trial_from_context(
+        ckpt_dir.joinpath("code"),
+        config=metadata["experiment_config"],
+        hparams=metadata["hparams"],
+    )
 
-    for nested_path in potential_model_paths:
-        maybe_model = ckpt_dir.joinpath(*nested_path)
-        if maybe_model.exists():
-            break
+    trial = cast(PyTorchTrial, trial)
+    model = trial.build_model()
+    checkpoint = torch.load(ckpt_dir.joinpath("state_dict.pth"), map_location="cpu")  # type: ignore
+    model.load_state_dict(checkpoint["model_state_dict"])
 
-    if not maybe_model.exists():
-        raise AssertionError("checkpoint at {} doesn't include a model.pth file".format(ckpt_dir))
-
-    code_subdirs = [str(x) for x in code_path.iterdir() if x.is_dir()]
-    sys.path = [str(code_path)] + code_subdirs + sys.path
-
-    return torch.load(maybe_model, pickle_module=cloudpickle.pickle, **kwargs)  # type: ignore
+    return model

--- a/e2e_tests/tests/experiment/test_pytorch.py
+++ b/e2e_tests/tests/experiment/test_pytorch.py
@@ -23,12 +23,7 @@ def test_pytorch_load() -> None:
         config, conf.official_examples_path("mnist_pytorch"), 1
     )
 
-    nn = (
-        Determined(conf.make_master_url())
-        .get_experiment(experiment_id)
-        .top_checkpoint()
-        .load(map_location=torch.device("cpu"))
-    )
+    nn = Determined(conf.make_master_url()).get_experiment(experiment_id).top_checkpoint().load()
     assert isinstance(nn, torch.nn.Module)
 
 
@@ -129,12 +124,14 @@ def test_pytorch_cifar10_const() -> None:
         config, conf.official_examples_path("cifar10_cnn_pytorch"), 1
     )
     trials = exp.experiment_trials(experiment_id)
+
     nn = (
         Determined(conf.make_master_url())
         .get_trial(trials[0]["id"])
         .select_checkpoint(latest=True)
-        .load(map_location=torch.device("cpu"))
+        .load()
     )
+
     assert isinstance(nn, torch.nn.Module)
 
 
@@ -152,6 +149,6 @@ def test_pytorch_cifar10_parallel() -> None:
         Determined(conf.make_master_url())
         .get_trial(trials[0]["id"])
         .select_checkpoint(latest=True)
-        .load(map_location=torch.device("cpu"))
+        .load()
     )
     assert isinstance(nn, torch.nn.Module)

--- a/harness/determined/estimator/_estimator_trial.py
+++ b/harness/determined/estimator/_estimator_trial.py
@@ -215,7 +215,7 @@ class DeterminedControlHook(tf.estimator.SessionRunHook):  # type: ignore
         det.util.write_checkpoint_metadata(
             checkpoint_path,
             self.estimator_trial_controller.env,
-            {"tensorflow_version": tf.__version__},
+            {"tensorflow_version": tf.__version__, "format": "saved_model"},
         )
 
         return {}

--- a/harness/determined/keras/_tf_keras_trial.py
+++ b/harness/determined/keras/_tf_keras_trial.py
@@ -428,7 +428,9 @@ class TFKerasTrialController(det.LoopTrialController):
         # Save model.
         self.model.save(path.joinpath("determined-keras-model.h5"), save_format="h5")
 
-        det.util.write_checkpoint_metadata(path, self.env, {"tensorflow_version": tf.__version__})
+        det.util.write_checkpoint_metadata(
+            path, self.env, {"tensorflow_version": tf.__version__, "format": "h5"}
+        )
 
         return {}
 

--- a/harness/determined/pytorch/_pytorch_trial.py
+++ b/harness/determined/pytorch/_pytorch_trial.py
@@ -1,9 +1,7 @@
 import enum
 import logging
-import os
 import pathlib
 import random
-import shutil
 from abc import abstractmethod
 from typing import Any, Dict, List, Optional, Tuple, Union, cast
 
@@ -687,16 +685,12 @@ class PyTorchTrialController(det.LoopTrialController):
         # method so long as the code is saved along with the pickled nn.Module.
         # https://pytorch.org/docs/stable/notes/serialization.html#recommend-saving-models
         pickled_model_path = path.joinpath("model.pth")
-        code_path = path.joinpath("code")
 
         torch.save(  # type: ignore
             self.context.model, pickled_model_path, pickle_module=cloudpickle
         )
 
         # The model code is the current working directory.
-        shutil.copytree(os.getcwd(), code_path, ignore=shutil.ignore_patterns("__pycache__"))
-        os.chmod(code_path, 0o755)
-
         util.write_checkpoint_metadata(
             path,
             self.env,


### PR DESCRIPTION
## Description
Re-apply https://github.com/determined-ai/determined/pull/459.

Fixes `tf.keras` trial checkpoint export by loading the users trial class, calling build_model, and loading the weights. This is necessary because custom object in keras are not serialized via `h5`. Loss functions and custom layers were therefore not recoverable in the previous iteration.

Custom layers in for torch trials were also not pickled correctly. Therefore, we are applying the same instantiate and load weights strategy to pytorch going forward.

[DET-3044]

## Test Plan
The current test suite covers these changes.

[DET-3044]: https://determinedai.atlassian.net/browse/DET-3044