### PR TITLE
fix: pass s3 endpoint url to tensorboard process

### DIFF
--- a/harness/determined/exec/tensorboard.py
+++ b/harness/determined/exec/tensorboard.py
@@ -10,7 +10,9 @@ import requests
 
 
 def set_s3_region(bucket: str) -> None:
-    client = boto3.client("s3")
+    endpoint_url = os.environ.get("DET_S3_ENDPOINT", None)
+
+    client = boto3.client("s3", endpoint_url=endpoint_url)
     bucketLocation = client.get_bucket_location(Bucket=bucket)
 
     region = bucketLocation["LocationConstraint"]


### PR DESCRIPTION
## Description
TensorBoard did not previously accept the `endpoint_url` parameter for s3 checkpoint configurations. Therefore, S3 compliant APIs could not be used with TensorBoard ie. MinIO. This Change adds support for the `endpoint_url`

[DET-3078]

## Test Plan
Spin up a test cluster backed by MinIO persistent storage.

[DET-3078]: https://determinedai.atlassian.net/browse/DET-3078