### PR TITLE
style: fix the height of the content panel of the dashboard

### DIFF
--- a/webui/react/src/App.module.scss
+++ b/webui/react/src/App.module.scss
@@ -9,6 +9,7 @@
     display: flex;
     flex-grow: 1;
 
+    & > * { height: 100%; }
     & > *:first-child { flex-grow: 0; }
     & > *:last-child { flex-grow: 1; }
   }


### PR DESCRIPTION
## Description

On the dashboard the content panel is short about 50 pixels on the bottom.

![2020-05-18 at 9 40 PM](https://user-images.githubusercontent.com/220971/82282185-7229d900-9950-11ea-87ca-29b313c5d99e.png)

## Test Plan

visually inspect to check the fix was applied properly on all the pages
