### PR TITLE
chore: bump environments version

### DIFF
--- a/deploy/determined_deploy/aws/templates/secure.yaml
+++ b/deploy/determined_deploy/aws/templates/secure.yaml
@@ -4,11 +4,11 @@ Mappings:
   RegionMap:
     us-east-1:
       Master: ami-66506c1c
-      Agent: ami-06a89515c09c669ab
+      Agent: ami-026c30b9ebbe3a29f
       Bastion: ami-0a1262fb77d0911ef
     us-west-2:
       Master: ami-79873901
-      Agent: ami-02e0ff379a7391b99
+      Agent: ami-0cd2f5f23b824f278
       Bastion: ami-0ff280954dd7aafd5
 
 Parameters:

--- a/deploy/determined_deploy/aws/templates/simple.yaml
+++ b/deploy/determined_deploy/aws/templates/simple.yaml
@@ -5,10 +5,10 @@ Mappings:
   RegionMap:
     us-east-1:
       Master: ami-66506c1c
-      Agent: ami-06a89515c09c669ab
+      Agent: ami-026c30b9ebbe3a29f
     us-west-2:
       Master: ami-79873901
-      Agent: ami-02e0ff379a7391b99
+      Agent: ami-0cd2f5f23b824f278
 
 Parameters:
   Keypair:

--- a/deploy/determined_deploy/aws/templates/vpc.yaml
+++ b/deploy/determined_deploy/aws/templates/vpc.yaml
@@ -4,10 +4,10 @@ Mappings:
   RegionMap:
     us-east-1:
       Master: ami-66506c1c
-      Agent: ami-06a89515c09c669ab
+      Agent: ami-026c30b9ebbe3a29f
     us-west-2:
       Master: ami-79873901
-      Agent: ami-02e0ff379a7391b99
+      Agent:ami-0cd2f5f23b824f278
 
 Parameters:
   VpcCIDR:

--- a/deploy/determined_deploy/gcp/constants.py
+++ b/deploy/determined_deploy/gcp/constants.py
@@ -2,7 +2,7 @@ class defaults:
 
     AGENT_INSTANCE_TYPE = "n1-standard-32"
     DB_PASSWORD = "postgres"
-    ENVIRONMENT_IMAGE = "pedl-environments-e6662e6"
+    ENVIRONMENT_IMAGE = "pedl-environments-fc3fb4b"
     GPU_NUM = 8
     GPU_TYPE = "nvidia-tesla-k80"
     MASTER_INSTANCE_TYPE = "n1-standard-2"

--- a/docs/how-to/custom-env.txt
+++ b/docs/how-to/custom-env.txt
@@ -83,8 +83,8 @@ hyperparameters for the current trial.
 .. note::
 
    The default images are
-   ``determinedai/environments:cuda-10.0-pytorch-1.4-tf-1.14-gpu-0.3.0`` and
-   ``determinedai/environments:py-3.6.9-pytorch-1.4-tf-1.14-cpu-0.3.0`` for GPU
+   ``determinedai/environments:cuda-10.0-pytorch-1.4-tf-1.14-gpu-0.4.0`` and
+   ``determinedai/environments:py-3.6.9-pytorch-1.4-tf-1.14-cpu-0.4.0`` for GPU
    and CPU respectively.
 
 TF2 Environment
@@ -105,8 +105,8 @@ This can be configured in your experiment configuration like below:
 
    environment:
      image:
-       gpu: "determinedai/environments:cuda-10.1-pytorch-1.4-tf-2.1-gpu-0.3.0"
-       cpu: "determinedai/environments:py-3.6.9-pytorch-1.4-tf-2.1-cpu-0.3.0"
+       gpu: "determinedai/environments:cuda-10.1-pytorch-1.4-tf-2.1-gpu-0.4.0"
+       cpu: "determinedai/environments:py-3.6.9-pytorch-1.4-tf-2.1-cpu-0.4.0"
 
 
 Custom Docker Images in Determined
@@ -134,7 +134,7 @@ on their respective dependency file format.
 
 .. code:: docker
 
-  FROM determinedai/environments:cuda-10.0-pytorch-1.4-tf-1.14-gpu-0.3.0
+  FROM determinedai/environments:cuda-10.0-pytorch-1.4-tf-1.14-gpu-0.4.0
   RUN apt-get update && apt-get install -y unzip python-opencv graphviz
   COPY environment.yml /tmp/environment.yml
   COPY pip_requirements.txt /tmp/pip_requirements.txt

--- a/docs/tutorials/quick-start.txt
+++ b/docs/tutorials/quick-start.txt
@@ -16,10 +16,10 @@ Prerequisites
 .. code::
 
     # For CPU computations
-    docker pull determinedai/environments:py-3.6.9-pytorch-1.4-tf-1.14-cpu-e6662e6
+    docker pull determinedai/environments:py-3.6.9-pytorch-1.4-tf-1.14-cpu-fc3fb4b
 
     # For GPU computations
-    docker pull determinedai/environments:cuda-10.0-pytorch-1.4-tf-1.14-gpu-e6662e6
+    docker pull determinedai/environments:cuda-10.0-pytorch-1.4-tf-1.14-gpu-fc3fb4b
 
 
 Preparing Your First Job

--- a/e2e_tests/tests/config.py
+++ b/e2e_tests/tests/config.py
@@ -10,10 +10,10 @@ MAX_TASK_SCHEDULED_SECS = 30
 MAX_TRIAL_BUILD_SECS = 90
 
 
-TF1_CPU_IMAGE = "determinedai/environments:py-3.6.9-pytorch-1.4-tf-1.14-cpu-e6662e6"
-TF2_CPU_IMAGE = "determinedai/environments:py-3.6.9-pytorch-1.4-tf-2.1-cpu-e6662e6"
-TF1_GPU_IMAGE = "determinedai/environments:cuda-10.0-pytorch-1.4-tf-1.14-gpu-e6662e6"
-TF2_GPU_IMAGE = "determinedai/environments:cuda-10.1-pytorch-1.4-tf-2.1-gpu-e6662e6"
+TF1_CPU_IMAGE = "determinedai/environments:py-3.6.9-pytorch-1.4-tf-1.14-cpu-fc3fb4b"
+TF2_CPU_IMAGE = "determinedai/environments:py-3.6.9-pytorch-1.4-tf-2.1-cpu-fc3fb4b"
+TF1_GPU_IMAGE = "determinedai/environments:cuda-10.0-pytorch-1.4-tf-1.14-gpu-fc3fb4b"
+TF2_GPU_IMAGE = "determinedai/environments:cuda-10.1-pytorch-1.4-tf-2.1-gpu-fc3fb4b"
 
 
 def fixtures_path(path: str) -> str:

--- a/harness/determined/estimator/_estimator_trial.py
+++ b/harness/determined/estimator/_estimator_trial.py
@@ -623,7 +623,7 @@ class EstimatorTrial(det.Trial):
     """
     By default, experiments run with TensorFlow 1.x. To configure your trial to
     use TensorFlow 2.x, set a TF 2.x image in the experiment configuration
-    (e.g. ``determinedai/environments:cuda-10.1-pytorch-1.4-tf-2.1-gpu-0.3.0``).
+    (e.g. ``determinedai/environments:cuda-10.1-pytorch-1.4-tf-2.1-gpu-0.4.0``).
 
     ``EstimatorTrial`` supports TF 2.x; however it uses TensorFlow V1
     behavior. We have disabled TensorFlow V2 behavior for ``EstimatorTrial``,

--- a/harness/determined/keras/_tf_keras_trial.py
+++ b/harness/determined/keras/_tf_keras_trial.py
@@ -544,7 +544,7 @@ class TFKerasTrial(det.Trial):
 
     By default, experiments run with TensorFlow 1.x. To configure your trial to
     use TensorFlow 2.x, set a TF 2.x image in the experiment configuration
-    (e.g. ``determinedai/environments:cuda-10.1-pytorch-1.4-tf-2.1-gpu-0.3.0``).
+    (e.g. ``determinedai/environments:cuda-10.1-pytorch-1.4-tf-2.1-gpu-0.4.0``).
 
     By default, trials using TF 2.x use execute eagerly, and trials using TF
     1.x do not execute eagerly. If you want to override the default, you must

--- a/master/pkg/model/defaults.go
+++ b/master/pkg/model/defaults.go
@@ -84,8 +84,8 @@ func DefaultExperimentConfig() ExperimentConfig {
 		BatchesPerStep: 100,
 		Environment: Environment{
 			Image: RuntimeItem{
-				CPU: "determinedai/environments:py-3.6.9-pytorch-1.4-tf-1.14-cpu-e6662e6",
-				GPU: "determinedai/environments:cuda-10.0-pytorch-1.4-tf-1.14-gpu-e6662e6",
+				CPU: "determinedai/environments:py-3.6.9-pytorch-1.4-tf-1.14-cpu-fc3fb4b",
+				GPU: "determinedai/environments:cuda-10.0-pytorch-1.4-tf-1.14-gpu-fc3fb4b",
 			},
 		},
 		Reproducibility: ReproducibilityConfig{


### PR DESCRIPTION
## Description
The new task envs include our Horovod repository rebased on top of v0.19.2.

[DET-3069](https://determinedai.atlassian.net/browse/DET-3069)


## Test Plan

These changes have been manually tests for TF 1 & 2 for keras and estimators. Also going to run the full suite of tests before merging.
