### PR TITLE
feat: support local and test modes separately

### DIFF
--- a/cli/determined_cli/experiment.py
+++ b/cli/determined_cli/experiment.py
@@ -273,13 +273,20 @@ def submit_experiment(args: Namespace) -> None:
 
 
 def local_experiment(args: Namespace) -> None:
-    experiment_config = _parse_config_file_or_exit(args.config_file)
-
     try:
         from determined import experimental, load
     except ImportError as e:
         print("--local requires that the `determined` package is installed.")
         raise e
+
+    if not args.test_mode:
+        raise NotImplementedError(
+            "Local training mode (--local mode without --test mode) is not yet supported. Please "
+            "try local test mode by adding the --test flag or cluster training mode by removing "
+            "the --local flag."
+        )
+
+    experiment_config = _parse_config_file_or_exit(args.config_file)
 
     # Python typically initializes sys.path[0] as the empty string when
     # invoked interactively, which directs Python to search modules in the
@@ -836,8 +843,7 @@ args_description = Cmd(
                     "--local",
                     action="store_true",
                     help="Create the experiment in local mode instead of submitting it to the "
-                    "cluster. For more information, see documentation on det.experimental.create() "
-                    "and det.experimental.Mode.LOCAL",
+                    "cluster. For more information, see documentation on det.experimental.create()",
                 ),
                 Arg(
                     "--template",

--- a/docs/reference/api/experimental.txt
+++ b/docs/reference/api/experimental.txt
@@ -4,7 +4,7 @@ determined.experimental
 =======================
 
 .. automodule:: determined.experimental
-    :members: create, create_trial_instance, Mode
+    :members: create, create_trial_instance
 
 
 ``Determined``

--- a/docs/topic-guides/model-definitions/native-api.txt
+++ b/docs/topic-guides/model-definitions/native-api.txt
@@ -22,7 +22,7 @@ that conforms to the Native API:
 
 .. code::
 
-    context = det.experimental.keras.init(config, mode=experimental.Mode.CLUSTER, context_dir=".")
+    context = det.experimental.keras.init(config, context_dir=".")
     model = ...
     model = context.wrap_model(model)
     model.compile(...)
@@ -30,12 +30,19 @@ that conforms to the Native API:
 
 The ``init()`` APIs require a *context directory* (``context_dir``) argument.
 The context directory specifies the root directory of the code containing the
-trial implementation -- for a majority of users this is the current working
-directory (``.``). ``init()`` also requires a
-:py:class:`determined.expeirmental.Mode` argument set to
-``determined.experimental.Mode.CLUSTER`` to submit an experiment.
-Alternatively, we can use ``determined.experimental.Mode.LOCAL`` to test an
-experiment on our local environment without submitting it to the cluster.
+native implementation -- for a majority of users this is the current working
+directory (``.``). ``init()`` also accepts two boolean keyword arguments:
+
+``local`` (``bool``):
+      ``local=False`` will sumbit the experiment to a Determined cluster.
+      ``local=True`` will execute the the training loop in your local Python
+      environment (although currently, local training is not implemented, so
+      you must also set ``test=True``). Defaults to False.
+
+``test`` (``bool``):
+      ``test=True`` will execute a minimal trianing loop rather than a full
+      experiment. This can be useful for porting or debugging a model because
+      many common errors will surface quickly. Defaults to False.
 
 Determined requires that the Native Python script contains a high-level
 training loop that it can intercept.  Currently, the following training loop
@@ -57,8 +64,7 @@ Life of a Native API Experiment
 .. TODO: Add a link to show what an experiment in local development mode looks like
 
 The diagram above demonstrates the flow of execution when an experiment is
-created in :py:class:`determined.experimental.Mode.CLUSTER
-<determined.experimental.Mode>` mode.
+created cluster mode.
 
 The Python script will first be executed by us in the *User environment*, such
 as a Python virtualenv or a Jupyter notebook where the ``determined`` Python

--- a/docs/topic-guides/model-definitions/trial-api.txt
+++ b/docs/topic-guides/model-definitions/trial-api.txt
@@ -30,20 +30,24 @@ A user can submit an experiment from Python by executing the
     class MyTrial(...):
         ...
 
-    det.experimental.create(
-        trial_def=MyTrial,
-        context_dir=".",
-        mode=determined.experimental.Mode.CLUSTER
-    )
+    det.experimental.create(trial_def=MyTrial, context_dir=".")
 
 In addition to a trial class definition, the ``create()`` API requires a
 *context directory* (``context_dir``). The context directory specifies the root
 directory of the code containing the trial implementation -- for a majority of
 users this is the current working directory (`.`). The ``create()`` API also
-requires a :py:class:`determined.expeirmental.Mode` argument set to
-``determined.experimental.Mode.CLUSTER`` to submit an experiment.
-Alternatively, we can use ``determined.experimental.Mode.LOCAL`` to test an
-experiment on our local environment without submitting it to the cluster.
+accepts two boolean keyword arguments:
+
+``local`` (``bool``):
+      ``local=False`` will sumbit the experiment to a Determined cluster.
+      ``local=True`` will execute the the training loop in your local Python
+      environment (although currently, local training is not implemented, so
+      you must also set ``test=True``). Defaults to False.
+
+``test`` (``bool``):
+      ``test=True`` will execute a minimal trianing loop rather than a full
+      experiment. This can be useful for porting or debugging a model because
+      many common errors will surface quickly. Defaults to False.
 
 Create an Experiment via the CLI
 --------------------------------

--- a/examples/experimental/native_fashion_mnist_tf_keras/native_impl.py
+++ b/examples/experimental/native_fashion_mnist_tf_keras/native_impl.py
@@ -42,9 +42,8 @@ if __name__ == "__main__":
         help="Specifies Determined Experiment configuration.",
         default="{}",
     )
-    parser.add_argument(
-        "--mode", dest="mode", help="Specifies local mode or cluster mode.", default="cluster"
-    )
+    parser.add_argument("--local", action="store_true", help="Specifies local mode")
+    parser.add_argument("--test", action="store_true", help="Specifies test mode")
     parser.add_argument(
         "--use-fit",
         action="store_true",
@@ -61,7 +60,7 @@ if __name__ == "__main__":
     }
     config.update(json.loads(args.config))
 
-    context = init(config, mode=experimental.Mode(args.mode), context_dir=str(pathlib.Path.cwd()))
+    context = init(config, local=args.local, test=args.test, context_dir=str(pathlib.Path.cwd()))
 
     train_images, train_labels = data.load_training_data()
     train_images = train_images / 255.0

--- a/examples/experimental/native_fashion_mnist_tf_keras/trial_impl.py
+++ b/examples/experimental/native_fashion_mnist_tf_keras/trial_impl.py
@@ -20,9 +20,8 @@ if __name__ == "__main__":
         help="Specifies Determined Experiment configuration.",
         default="{}",
     )
-    parser.add_argument(
-        "--mode", dest="mode", help="Specifies local mode or cluster mode.", default="cluster"
-    )
+    parser.add_argument("--local", action="store_true", help="Specifies local mode")
+    parser.add_argument("--test", action="store_true", help="Specifies test mode")
     args = parser.parse_args()
 
     config = {
@@ -37,6 +36,7 @@ if __name__ == "__main__":
     experimental.create(
         trial_def=model_def.FashionMNISTTrial,
         config=config,
-        mode=experimental.Mode(args.mode),
+        local=args.local,
+        test=args.test,
         context_dir=str(pathlib.Path.cwd()),
     )

--- a/examples/experimental/native_mnist_estimator/native_impl.py
+++ b/examples/experimental/native_mnist_estimator/native_impl.py
@@ -137,9 +137,8 @@ if __name__ == "__main__":
         help="Specifies Determined Experiment configuration.",
         default="{}",
     )
-    parser.add_argument(
-        "--mode", dest="mode", help="Specifies local mode or cluster mode.", default="cluster"
-    )
+    parser.add_argument("--local", action="store_true", help="Specifies local mode")
+    parser.add_argument("--test", action="store_true", help="Specifies test mode")
     args = parser.parse_args()
 
     config = {
@@ -161,7 +160,7 @@ if __name__ == "__main__":
     config.update(json.loads(args.config))
 
     context = estimator.init(
-        config, mode=experimental.Mode(args.mode), context_dir=str(pathlib.Path.cwd())
+        config, local=args.local, test=args.test, context_dir=str(pathlib.Path.cwd())
     )
 
     # Create a unique download directory for each rank so they don't overwrite each other.

--- a/examples/experimental/native_mnist_estimator/trial_impl.py
+++ b/examples/experimental/native_mnist_estimator/trial_impl.py
@@ -19,9 +19,8 @@ if __name__ == "__main__":
         help="Specifies Determined Experiment configuration.",
         default="{}",
     )
-    parser.add_argument(
-        "--mode", dest="mode", help="Specifies local mode or cluster mode.", default="cluster"
-    )
+    parser.add_argument("--local", action="store_true", help="Specifies local mode")
+    parser.add_argument("--test", action="store_true", help="Specifies test mode")
     args = parser.parse_args()
 
     config = {
@@ -45,6 +44,7 @@ if __name__ == "__main__":
     experimental.create(
         trial_def=model_def.MNistTrial,
         config=config,
-        mode=experimental.Mode(args.mode),
+        local=args.local,
+        test=args.test,
         context_dir=str(pathlib.Path.cwd()),
     )

--- a/examples/experimental/native_mnist_pytorch/trial_impl.py
+++ b/examples/experimental/native_mnist_pytorch/trial_impl.py
@@ -20,9 +20,8 @@ if __name__ == "__main__":
         help="Specifies Determined Experiment configuration.",
         default="{}",
     )
-    parser.add_argument(
-        "--mode", dest="mode", help="Specifies local mode or cluster mode.", default="cluster"
-    )
+    parser.add_argument("--local", action="store_true", help="Specifies local mode")
+    parser.add_argument("--test", action="store_true", help="Specifies test mode")
     args = parser.parse_args()
 
     config = {
@@ -48,6 +47,7 @@ if __name__ == "__main__":
     experimental.create(
         trial_def=model_def.MNistTrial,
         config=config,
-        mode=experimental.Mode(args.mode),
+        local=args.local,
+        test=args.test,
         context_dir=str(pathlib.Path.cwd()),
     )

--- a/examples/experimental/native_object_detection_pytorch/trial_impl.py
+++ b/examples/experimental/native_object_detection_pytorch/trial_impl.py
@@ -14,9 +14,8 @@ if __name__ == "__main__":
         help="Specifies Determined Experiment configuration.",
         default="{}",
     )
-    parser.add_argument(
-        "--mode", dest="mode", help="Specifies local or cluster mode.", default="cluster"
-    )
+    parser.add_argument("--local", action="store_true", help="Specifies local mode")
+    parser.add_argument("--test", action="store_true", help="Specifies test mode")
     args = parser.parse_args()
 
     dataset_url = (
@@ -44,6 +43,7 @@ if __name__ == "__main__":
     experimental.create(
         trial_def=model_def.ObjectDetectionTrial,
         config=config,
-        mode=experimental.Mode(args.mode),
+        local=args.local,
+        test=args.test,
         context_dir=str(pathlib.Path.cwd()),
     )

--- a/examples/tutorials/native-tf-keras/tf_keras_native.py
+++ b/examples/tutorials/native-tf-keras/tf_keras_native.py
@@ -41,7 +41,7 @@ config = {
 
 # When running from this code from a notebook, add a `command` argument to
 # init() specifying the notebook file name.
-context = init(config, mode=experimental.Mode.CLUSTER, context_dir=".")
+context = init(config, context_dir=".")
 model = tf.keras.models.Sequential(
     [
         tf.keras.layers.Flatten(input_shape=(28, 28)),
@@ -104,24 +104,29 @@ config = {
 #
 # .. code:: python
 #
-#     context = init(config, mode=experimental.Mode.CLUSTER, context_dir=".")
+#     context = init(config, local=False, test=False, context_dir=".")
 #
 # :ref:`keras-init` is the function that initializes the Determined training
 # context. We can think of it as the moment in the training script where
 # Determined will "assume control" of the execution of your code. It has two
-# required arguments in addition to the configuration:
+# three in addition to the configuration:
 #
-# ``mode`` (:py:class:`determined.experimenal.Mode`):
-#       :py:class:`determined.experimenal.Mode.CLUSTER` will submit the
-#       experiment to a Determined cluster.
-#       :py:class:`determined.experimenal.Mode.LOCAL` will execute a minimal
-#       training loop in your local Python environment.
+# ``local`` (``bool``):
+#       ``local=False`` will sumbit the experiment to a Determined cluster.
+#       ``local=True`` will execute the the training loop in your local Python
+#       environment (although currently, local training is not implemented, so
+#       you must also set ``test=True``). Defaults to False.
+#
+# ``test`` (``bool``):
+#       ``test=True`` will execute a minimal trianing loop rather than a full
+#       experiment. This can be useful for porting or debugging a model because
+#       many common errors will surface quickly. Defaults to False.
 #
 # ``context_dir`` (``str``):
 #       Specifies the location of the code you want submitted to the cluster.
 #       This is required by Determined to execute your training script in a
-#       remote environment. In the common case, "." submits your entire working
-#       directory to the Determined cluster.
+#       remote environment (``local=false``). In the common case, "." submits
+#       your entire working directory to the Determined cluster.
 #
 # Wrap Model (``tf.keras`` only)
 # ------------------------------

--- a/examples/tutorials/native-tf-keras/tf_keras_native_dtrain.py
+++ b/examples/tutorials/native-tf-keras/tf_keras_native_dtrain.py
@@ -12,7 +12,6 @@ minimal set of code changes. This example builds on top of
 """
 import tensorflow as tf
 import determined as det
-from determined import experimental
 from determined.experimental.keras import init
 
 config = {
@@ -36,7 +35,7 @@ x_train, x_test = x_train / 255.0, x_test / 255.0
 
 # When running from this code from a notebook, add a `command` argument to
 # init() specifying the notebook file name.
-context = init(config, mode=experimental.Mode.CLUSTER, context_dir=".")
+context = init(config, context_dir=".")
 model = tf.keras.models.Sequential(
     [
         tf.keras.layers.Flatten(input_shape=(28, 28)),

--- a/examples/tutorials/native-tf-keras/tf_keras_native_hparam_search.py
+++ b/examples/tutorials/native-tf-keras/tf_keras_native_hparam_search.py
@@ -12,7 +12,6 @@ this.
 """
 import tensorflow as tf
 import determined as det
-from determined import experimental
 from determined.experimental.keras import init
 
 config = {
@@ -44,7 +43,7 @@ x_train, x_test = x_train / 255.0, x_test / 255.0
 
 # When running from this code from a notebook, add a `command` argument to
 # init() specifying the notebook file name.
-context = init(config, mode=experimental.Mode.CLUSTER, context_dir=".")
+context = init(config, context_dir=".")
 model = tf.keras.models.Sequential(
     [
         tf.keras.layers.Flatten(input_shape=(28, 28)),

--- a/harness/determined/experimental/__init__.py
+++ b/harness/determined/experimental/__init__.py
@@ -6,7 +6,6 @@ from determined_common.experimental import (
 )
 
 from determined.experimental._native import (
-    Mode,
     create,
     create_trial_instance,
     test_one_batch,

--- a/harness/determined/experimental/keras/_tf_keras_native.py
+++ b/harness/determined/experimental/keras/_tf_keras_native.py
@@ -5,7 +5,8 @@ from determined import experimental, keras
 
 def init(
     config: Optional[Dict[str, Any]] = None,
-    mode: experimental.Mode = experimental.Mode.CLUSTER,
+    local: bool = False,
+    test: bool = False,
     context_dir: str = "",
     command: Optional[List[str]] = None,
     master_url: Optional[str] = None,
@@ -18,48 +19,59 @@ def init(
         config:
             A dictionary representing the experiment configuration to be
             associated with the experiment.
-        mode:
-            The :py:class:`determined.experimental.Mode` used when creating an
-            experiment
 
-            1. ``Mode.CLUSTER`` (default): Submit the experiment to a remote
-            Determined cluster.
+        local:
+            A boolean indicating if training will happen locally. When
+            ``False``, the experiment will be submitted to the Determined
+            cluster. Defaults to ``False``.
 
-            2. ``Mode.LOCAL``: Test the experiment in the calling
-            Python process for development / debugging purposes. Run through a
-            minimal loop of training, validation, and checkpointing steps.
+        test:
+            A boolean indicating if the experiment should be shortened to a
+            minimal loop of training, validation, and checkpointing.
+            ``test=True`` is useful quick iterating during model porting or
+            debugging. Defaults to ``False``.
 
         context_dir:
             A string filepath that defines the context directory. All model
             code will be executed with this as the current working directory.
 
-            In CLUSTER mode, this argument is required. All files in this
+            When ``local=False``, this argument is required. All files in this
             directory will be uploaded to the Determined cluster. The total
             size of this directory must be under 96 MB.
 
-            In LOCAL mode, this argument is optional and assumed to be the
+            When ``local=True``, this argument is optional and assumed to be the
             current working directory by default.
+
         command:
             A list of strings that is used as the entrypoint of the training
             script in the Determined task environment. When executing this
             function via a python script, this argument is inferred to be
             ``sys.argv`` by default. When executing this function via IPython
             or Jupyter notebook, this argument is required.
+
         master_url:
-            An optional string to use as the Determined master URL in submit
-            mode. Will default to the value of environment variable
-            ``DET_MASTER`` if not provided.
+            An optional string to use as the Determined master URL when
+            ``local=False``. If not specified, will be inferred from the
+            environment variable ``DET_MASTER``.
 
     Returns:
         :py:class:`determined.keras.TFKerasNativeContext`
     """
+
+    if local and not test:
+        raise NotImplementedError(
+            "keras.init(local=True, test=False) is not yet implemented. Please set local=False "
+            "or test=True."
+        )
+
     return cast(
         keras.TFKerasNativeContext,
         experimental._native.init_native(
             controller_cls=keras.TFKerasTrialController,
             native_context_cls=keras.TFKerasNativeContext,
             config=config,
-            mode=mode,
+            local=local,
+            test=test,
             context_dir=context_dir,
             command=command,
             master_url=master_url,

--- a/harness/tests/experiment/fixtures/estimator_xor_model_native.py
+++ b/harness/tests/experiment/fixtures/estimator_xor_model_native.py
@@ -4,7 +4,6 @@ from typing import Callable, Dict, Tuple
 
 import tensorflow as tf
 
-from determined import experimental
 from determined.estimator import EstimatorNativeContext, ServingInputReceiverFn
 from determined.experimental import estimator
 from tests.experiment import utils
@@ -70,7 +69,8 @@ def build_serving_input_receiver_fns() -> Dict[str, ServingInputReceiverFn]:
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
-    parser.add_argument("--mode", dest="mode", default="cluster")
+    parser.add_argument("--local", action="store_true")
+    parser.add_argument("--test", action="store_true")
     args = parser.parse_args()
 
     config = {
@@ -84,7 +84,7 @@ if __name__ == "__main__":
     }
 
     context = estimator.init(
-        config=config, mode=experimental.Mode(args.mode), context_dir=str(pathlib.Path.cwd())
+        config=config, local=args.local, test=args.test, context_dir=str(pathlib.Path.cwd())
     )
 
     batch_size = context.get_per_slot_batch_size()

--- a/harness/tests/experiment/fixtures/tf_keras_runtime_error.py
+++ b/harness/tests/experiment/fixtures/tf_keras_runtime_error.py
@@ -46,6 +46,7 @@ if __name__ == "__main__":
             "searcher": {"metric": "accuracy"},
             "data_layer": {"type": "lfs", "container_storage_path": "/tmp"},
         },
-        mode=experimental.Mode.LOCAL,
+        local=True,
+        test=True,
         context_dir=str(pathlib.Path.cwd()),
     )

--- a/harness/tests/experiment/fixtures/tf_keras_xor_model_native.py
+++ b/harness/tests/experiment/fixtures/tf_keras_xor_model_native.py
@@ -8,7 +8,6 @@ from tensorflow.keras.metrics import categorical_accuracy
 from tensorflow.keras.models import Sequential
 from tensorflow.keras.optimizers import SGD
 
-from determined import experimental
 from determined.experimental.keras import init
 from tests.experiment import utils
 
@@ -23,7 +22,8 @@ def predictions(y_true: tf.Tensor, y_pred: tf.Tensor) -> tf.Tensor:
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
-    parser.add_argument("--mode", dest="mode", default="cluster")
+    parser.add_argument("--local", action="store_true")
+    parser.add_argument("--test", action="store_true")
     parser.add_argument("--use-dataset", action="store_true")
     args = parser.parse_args()
 
@@ -37,7 +37,7 @@ if __name__ == "__main__":
     }
 
     context = init(
-        config=config, mode=experimental.Mode(args.mode), context_dir=str(pathlib.Path.cwd())
+        config=config, local=args.local, test=args.test, context_dir=str(pathlib.Path.cwd())
     )
 
     model = Sequential()

--- a/harness/tests/experiment/keras/test_tf_keras_trial.py
+++ b/harness/tests/experiment/keras/test_tf_keras_trial.py
@@ -299,7 +299,7 @@ def test_surface_native_error():
 
 
 def test_local_mode() -> None:
-    utils.run_local_mode(utils.fixtures_path("tf_keras_xor_model_native.py"))
+    utils.run_local_test_mode(utils.fixtures_path("tf_keras_xor_model_native.py"))
 
 
 def test_create_trial_instance() -> None:

--- a/harness/tests/experiment/tensorflow/test_estimator_trial.py
+++ b/harness/tests/experiment/tensorflow/test_estimator_trial.py
@@ -199,7 +199,7 @@ class TestXORTrial:
 
 
 def test_local_mode() -> None:
-    utils.run_local_mode(utils.fixtures_path("estimator_xor_model_native.py"))
+    utils.run_local_test_mode(utils.fixtures_path("estimator_xor_model_native.py"))
 
 
 def test_create_trial_instance() -> None:

--- a/harness/tests/experiment/utils.py
+++ b/harness/tests/experiment/utils.py
@@ -383,9 +383,9 @@ def list_all_files(directory: str) -> List[str]:
     return [f for _, _, files in os.walk(directory) for f in files]
 
 
-def run_local_mode(implementation: str) -> None:
+def run_local_test_mode(implementation: str) -> None:
     subprocess.check_call(
-        args=["python", implementation, "--mode", "local"],
+        args=["python", implementation, "--local", "--test"],
         cwd=fixtures_path(""),
         env={
             "PYTHONUNBUFFERED": "1",


### PR DESCRIPTION
## Description
This is sort of a bare-minimum PR to have a concrete discussion around the API change.

Mostly I think this API matches what we have already agreed on for the cli, which will look something like this:
```
det e create ...
det e create --local ...
det e create --test ...
det e create --local --test ...
```

IMO, this is best reflected by a `det.create()` function like:

```
def create(..., local: bool = False, test: bool = False, ...):
    ...
```

I thought about making two enums but I had a bit of a crisis of naming.  Which one got to be called "mode"?  What would the other one be called?  And combining them into a single enum like `LOCAL_TRAIN`, `LOCAL_TEST`, `SUBMIT_TRAIN`, `SUBMIT_TEST` felt wrong.

Ultimately, I like the boolean thing because it is utterly simple to understand from just reading the function parameters.  Using a boolean instead of an enum is inherently non-extensible, and therefore a risk, but if we think it's highly unlikely to ever extend it then I see having a silly two-value enum for all time as its own risk.

## Test Plan
I'll update tests after we agree on an API.