### PR TITLE
feat: support TF 2.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,11 +99,11 @@ commands:
       - when:
           condition: <<parameters.tf1>>
           steps:
-            - run: docker pull determinedai/environments:py-3.6.9-pytorch-1.4-tf-1.14-cpu-e6662e6
+            - run: docker pull determinedai/environments:py-3.6.9-pytorch-1.4-tf-1.14-cpu-3f3437e
       - when:
           condition: <<parameters.tf2>>
           steps:
-            - run: docker pull determinedai/environments:py-3.6.9-pytorch-1.4-tf-2.1-cpu-e6662e6
+            - run: docker pull determinedai/environments:py-3.6.9-pytorch-1.4-tf-2.2-cpu-3f3437e
 
   login-docker:
     steps:
@@ -762,7 +762,7 @@ jobs:
       - setup-python-venv:
           determined-common: true
           determined: true
-          extras-requires: "tensorflow==2.1.0"
+          extras-requires: "tensorflow==2.2.0"
           extra-requirements-file: "harness/tests/requirements.txt"
           executor: determinedai/cimg-base:stable
       - run: make -C harness test-tf2

--- a/deploy/determined_deploy/aws/templates/secure.yaml
+++ b/deploy/determined_deploy/aws/templates/secure.yaml
@@ -4,11 +4,11 @@ Mappings:
   RegionMap:
     us-east-1:
       Master: ami-66506c1c
-      Agent: ami-026c30b9ebbe3a29f
+      Agent: ami-09d883ba8e6bedd9d
       Bastion: ami-0a1262fb77d0911ef
     us-west-2:
       Master: ami-79873901
-      Agent: ami-0cd2f5f23b824f278
+      Agent: ami-02c1e326efef54ec3
       Bastion: ami-0ff280954dd7aafd5
 
 Parameters:

--- a/deploy/determined_deploy/aws/templates/simple.yaml
+++ b/deploy/determined_deploy/aws/templates/simple.yaml
@@ -5,10 +5,10 @@ Mappings:
   RegionMap:
     us-east-1:
       Master: ami-66506c1c
-      Agent: ami-026c30b9ebbe3a29f
+      Agent: ami-09d883ba8e6bedd9d
     us-west-2:
       Master: ami-79873901
-      Agent: ami-0cd2f5f23b824f278
+      Agent: ami-02c1e326efef54ec3
 
 Parameters:
   Keypair:

--- a/deploy/determined_deploy/aws/templates/vpc.yaml
+++ b/deploy/determined_deploy/aws/templates/vpc.yaml
@@ -4,10 +4,10 @@ Mappings:
   RegionMap:
     us-east-1:
       Master: ami-66506c1c
-      Agent: ami-026c30b9ebbe3a29f
+      Agent: ami-09d883ba8e6bedd9d
     us-west-2:
       Master: ami-79873901
-      Agent:ami-0cd2f5f23b824f278
+      Agent: ami-02c1e326efef54ec3
 
 Parameters:
   VpcCIDR:

--- a/deploy/determined_deploy/gcp/constants.py
+++ b/deploy/determined_deploy/gcp/constants.py
@@ -2,7 +2,7 @@ class defaults:
 
     AGENT_INSTANCE_TYPE = "n1-standard-32"
     DB_PASSWORD = "postgres"
-    ENVIRONMENT_IMAGE = "pedl-environments-fc3fb4b"
+    ENVIRONMENT_IMAGE = "pedl-environments-3f3437e"
     GPU_NUM = 8
     GPU_TYPE = "nvidia-tesla-k80"
     MASTER_INSTANCE_TYPE = "n1-standard-2"

--- a/docs/how-to/custom-env.txt
+++ b/docs/how-to/custom-env.txt
@@ -90,13 +90,13 @@ hyperparameters for the current trial.
 TF2 Environment
 ~~~~~~~~~~~~~~~
 
-Determined also supports TensorFlow 2.1 and has a Docker image you can use for
+Determined also supports TensorFlow 2.2 and has a Docker image you can use for
 experiments and commands containing the following:
 
 -  Ubuntu 18.04
 -  CUDA 10.0
 -  Python 3.6.9
--  TensorFlow 2.1.0
+-  TensorFlow 2.2.0
 -  PyTorch 1.4.0
 
 This can be configured in your experiment configuration like below:
@@ -105,8 +105,8 @@ This can be configured in your experiment configuration like below:
 
    environment:
      image:
-       gpu: "determinedai/environments:cuda-10.1-pytorch-1.4-tf-2.1-gpu-0.4.0"
-       cpu: "determinedai/environments:py-3.6.9-pytorch-1.4-tf-2.1-cpu-0.4.0"
+       gpu: "determinedai/environments:cuda-10.1-pytorch-1.4-tf-2.2-gpu-0.4.0"
+       cpu: "determinedai/environments:py-3.6.9-pytorch-1.4-tf-2.2-cpu-0.4.0"
 
 
 Custom Docker Images in Determined

--- a/docs/tutorials/quick-start.txt
+++ b/docs/tutorials/quick-start.txt
@@ -16,10 +16,10 @@ Prerequisites
 .. code::
 
     # For CPU computations
-    docker pull determinedai/environments:py-3.6.9-pytorch-1.4-tf-1.14-cpu-fc3fb4b
+    docker pull determinedai/environments:py-3.6.9-pytorch-1.4-tf-1.14-cpu-3f3437e
 
     # For GPU computations
-    docker pull determinedai/environments:cuda-10.0-pytorch-1.4-tf-1.14-gpu-fc3fb4b
+    docker pull determinedai/environments:cuda-10.0-pytorch-1.4-tf-1.14-gpu-3f3437e
 
 
 Preparing Your First Job

--- a/e2e_tests/tests/config.py
+++ b/e2e_tests/tests/config.py
@@ -10,10 +10,10 @@ MAX_TASK_SCHEDULED_SECS = 30
 MAX_TRIAL_BUILD_SECS = 90
 
 
-TF1_CPU_IMAGE = "determinedai/environments:py-3.6.9-pytorch-1.4-tf-1.14-cpu-fc3fb4b"
-TF2_CPU_IMAGE = "determinedai/environments:py-3.6.9-pytorch-1.4-tf-2.1-cpu-fc3fb4b"
-TF1_GPU_IMAGE = "determinedai/environments:cuda-10.0-pytorch-1.4-tf-1.14-gpu-fc3fb4b"
-TF2_GPU_IMAGE = "determinedai/environments:cuda-10.1-pytorch-1.4-tf-2.1-gpu-fc3fb4b"
+TF1_CPU_IMAGE = "determinedai/environments:py-3.6.9-pytorch-1.4-tf-1.14-cpu-3f3437e"
+TF2_CPU_IMAGE = "determinedai/environments:py-3.6.9-pytorch-1.4-tf-2.2-cpu-3f3437e"
+TF1_GPU_IMAGE = "determinedai/environments:cuda-10.0-pytorch-1.4-tf-1.14-gpu-3f3437e"
+TF2_GPU_IMAGE = "determinedai/environments:cuda-10.1-pytorch-1.4-tf-2.2-gpu-3f3437e"
 
 
 def fixtures_path(path: str) -> str:

--- a/harness/determined/estimator/_estimator_trial.py
+++ b/harness/determined/estimator/_estimator_trial.py
@@ -623,7 +623,7 @@ class EstimatorTrial(det.Trial):
     """
     By default, experiments run with TensorFlow 1.x. To configure your trial to
     use TensorFlow 2.x, set a TF 2.x image in the experiment configuration
-    (e.g. ``determinedai/environments:cuda-10.1-pytorch-1.4-tf-2.1-gpu-0.4.0``).
+    (e.g. ``determinedai/environments:cuda-10.1-pytorch-1.4-tf-2.2-gpu-0.4.0``).
 
     ``EstimatorTrial`` supports TF 2.x; however it uses TensorFlow V1
     behavior. We have disabled TensorFlow V2 behavior for ``EstimatorTrial``,

--- a/harness/determined/keras/_tf_keras_trial.py
+++ b/harness/determined/keras/_tf_keras_trial.py
@@ -566,7 +566,7 @@ class TFKerasTrial(det.Trial):
 
     By default, experiments run with TensorFlow 1.x. To configure your trial to
     use TensorFlow 2.x, set a TF 2.x image in the experiment configuration
-    (e.g. ``determinedai/environments:cuda-10.1-pytorch-1.4-tf-2.1-gpu-0.4.0``).
+    (e.g. ``determinedai/environments:cuda-10.1-pytorch-1.4-tf-2.2-gpu-0.4.0``).
 
     By default, trials using TF 2.x use execute eagerly, and trials using TF
     1.x do not execute eagerly. If you want to override the default, you must

--- a/harness/tests/experiment/keras/test_tf_keras_trial.py
+++ b/harness/tests/experiment/keras/test_tf_keras_trial.py
@@ -289,7 +289,11 @@ def test_surface_native_error():
         err = p.stderr.read()
         assert p.wait() != 0
         if tf.executing_eagerly():
-            assert b"ValueError: Shapes (None, 10) and (None, 1) are incompatible" in err
+            assert (
+                b"ValueError: Shapes (None, 10) and (None, 1) are incompatible" in err
+                or b"ValueError: Input 0 of layer sequential is incompatible with the "
+                b"layer: : expected min_ndim=2, found ndim=1. Full shape received: [1]" in err
+            )
         else:
             assert b"ValueError: Input 0 of layer sequential is incompatible with the layer" in err
 

--- a/harness/tests/experiment/tensorflow/test_estimator_trial.py
+++ b/harness/tests/experiment/tensorflow/test_estimator_trial.py
@@ -54,13 +54,6 @@ def xor_trial_controller(request):
             load_path: Optional[str] = None,
             exp_config: Optional[Dict] = None,
         ) -> det.TrialController:
-            if request.param == estimator_xor_model.XORTrialDataLayer:
-                exp_config = utils.make_default_exp_config(
-                    hparams=hparams, batches_per_step=batches_per_step
-                )
-                exp_config["data"] = exp_config.get("data", {})
-                exp_config["data"]["skip_checkpointing_input"] = True
-
             return utils.make_trial_controller_from_trial_implementation(
                 trial_class=request.param,
                 hparams=hparams,
@@ -68,6 +61,7 @@ def xor_trial_controller(request):
                 batches_per_step=batches_per_step,
                 load_path=load_path,
                 exp_config=exp_config,
+                trial_seed=325,
             )
 
         return _xor_trial_controller

--- a/master/pkg/model/defaults.go
+++ b/master/pkg/model/defaults.go
@@ -84,8 +84,8 @@ func DefaultExperimentConfig() ExperimentConfig {
 		BatchesPerStep: 100,
 		Environment: Environment{
 			Image: RuntimeItem{
-				CPU: "determinedai/environments:py-3.6.9-pytorch-1.4-tf-1.14-cpu-fc3fb4b",
-				GPU: "determinedai/environments:cuda-10.0-pytorch-1.4-tf-1.14-gpu-fc3fb4b",
+				CPU: "determinedai/environments:py-3.6.9-pytorch-1.4-tf-1.14-cpu-3f3437e",
+				GPU: "determinedai/environments:cuda-10.0-pytorch-1.4-tf-1.14-gpu-3f3437e",
 			},
 		},
 		Reproducibility: ReproducibilityConfig{


### PR DESCRIPTION
## Description
We now support TF 2.2 and have made it the default TF2 version. 

[DET-3088](https://determinedai.atlassian.net/browse/DET-3088)

## Test Plan
Tested manually and ran a full suite of tests: https://app.circleci.com/pipelines/github/determined-ai/determined/1735/workflows/041781c3-3e21-4758-82ef-4b52861e928b



