### PR TITLE
feat: support passing reduced validation metrics to all workers

### DIFF
--- a/harness/determined/ipc.py
+++ b/harness/determined/ipc.py
@@ -80,7 +80,7 @@ class ZMQBroadcastServer:
     are ConnectedMessages.
 
     ZMQBroadcastServer uses ZMQ PUB-SUB pattern to transmit messages to worker processes, and uses
-    the PUSH-PULL pattern to collect responses from workers. The reason for this assymetry is that
+    the PUSH-PULL pattern to collect responses from workers. The reason for this asymmetry is that
     PUSH-PULL connections block during send() if the remote end is dead. Therefore, PUSH-PULL
     cannot be used to transmitting from server to worker, because if all the workers die, the
     server would hang.

--- a/harness/determined/pytorch/_pytorch_trial.py
+++ b/harness/determined/pytorch/_pytorch_trial.py
@@ -832,6 +832,8 @@ class PyTorchTrial(det.Trial):
         :meth:`evaluate_full_dataset()` cannot. Only one of
         :meth:`evaluate_full_dataset` and :meth:`evaluate_batch` should be
         overridden by a trial.
+
+        The metrics returned from this function must be JSON-serializable.
         """
         pass
 
@@ -856,6 +858,8 @@ class PyTorchTrial(det.Trial):
         device, even when multiple devices (slots) are used for training. Only
         one of :meth:`evaluate_full_dataset` and :meth:`evaluate_batch` should
         be overridden by a trial.
+
+        The metrics returned from this function must be JSON-serializable.
         """
         pass
 


### PR DESCRIPTION
## Description
Previously, on_validation_end callbacks only executed on the chief if
the trial was training in a multi-GPU context. Now, the callback is
executed on all workers, allowing for callbacks that modify the state of
the optimizer such as lr schedulers.

[DET-3033]: https://determinedai.atlassian.net/browse/DET-3033

## Test Plan
* e2e gpu tests: https://app.circleci.com/pipelines/github/determined-ai/determined/1769/workflows/7f01fad6-23f8-437c-aa5e-3c9c405d3a2a
* TODO(yoavz): Test an implementation of ReduceLROnPlateau with distributed training and observe that the LR is appropriately reduced.

## Commentary (optional)

<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

## Description

Lead with the intended commit body in this description field. For breaking changes, please include "BREAKING CHANGE:" at the beginning of your commit body. At minimum, this section should include a bracketed reference to the Jira ticket, e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.

## Test Plan

Describe the situations in which you've tested your change, and/or a screenshot as appropriate. Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.

## Commentary (optional)

Use this section of your description to add context to the PR. Could be for particularly tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc. You may intentionally leave this section blank and remove the title.
--->

[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234