### PR TITLE
feat: update to nccl 2.6.4 and fix multi-machine dtrain

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,11 +99,11 @@ commands:
       - when:
           condition: <<parameters.tf1>>
           steps:
-            - run: docker pull determinedai/environments:py-3.6.9-pytorch-1.4-tf-1.14-cpu-3f3437e
+            - run: docker pull determinedai/environments:py-3.6.9-pytorch-1.4-tf-1.14-cpu-4e98289
       - when:
           condition: <<parameters.tf2>>
           steps:
-            - run: docker pull determinedai/environments:py-3.6.9-pytorch-1.4-tf-2.2-cpu-3f3437e
+            - run: docker pull determinedai/environments:py-3.6.9-pytorch-1.4-tf-2.2-cpu-4e98289
 
   login-docker:
     steps:

--- a/deploy/determined_deploy/aws/templates/secure.yaml
+++ b/deploy/determined_deploy/aws/templates/secure.yaml
@@ -4,11 +4,11 @@ Mappings:
   RegionMap:
     us-east-1:
       Master: ami-66506c1c
-      Agent: ami-09d883ba8e6bedd9d
+      Agent: ami-0657cb09c0cb7dea0
       Bastion: ami-0a1262fb77d0911ef
     us-west-2:
       Master: ami-79873901
-      Agent: ami-02c1e326efef54ec3
+      Agent: ami-06b06da8bc64b5080
       Bastion: ami-0ff280954dd7aafd5
 
 Parameters:

--- a/deploy/determined_deploy/aws/templates/simple.yaml
+++ b/deploy/determined_deploy/aws/templates/simple.yaml
@@ -5,10 +5,10 @@ Mappings:
   RegionMap:
     us-east-1:
       Master: ami-66506c1c
-      Agent: ami-09d883ba8e6bedd9d
+      Agent: ami-0657cb09c0cb7dea0
     us-west-2:
       Master: ami-79873901
-      Agent: ami-02c1e326efef54ec3
+      Agent: ami-06b06da8bc64b5080
 
 Parameters:
   Keypair:

--- a/deploy/determined_deploy/aws/templates/vpc.yaml
+++ b/deploy/determined_deploy/aws/templates/vpc.yaml
@@ -4,10 +4,10 @@ Mappings:
   RegionMap:
     us-east-1:
       Master: ami-66506c1c
-      Agent: ami-09d883ba8e6bedd9d
+      Agent: ami-0657cb09c0cb7dea0
     us-west-2:
       Master: ami-79873901
-      Agent: ami-02c1e326efef54ec3
+      Agent: ami-06b06da8bc64b5080
 
 Parameters:
   VpcCIDR:

--- a/deploy/determined_deploy/gcp/constants.py
+++ b/deploy/determined_deploy/gcp/constants.py
@@ -2,7 +2,7 @@ class defaults:
 
     AGENT_INSTANCE_TYPE = "n1-standard-32"
     DB_PASSWORD = "postgres"
-    ENVIRONMENT_IMAGE = "pedl-environments-3f3437e"
+    ENVIRONMENT_IMAGE = "pedl-environments-4e98289"
     GPU_NUM = 8
     GPU_TYPE = "nvidia-tesla-k80"
     MASTER_INSTANCE_TYPE = "n1-standard-2"

--- a/docs/tutorials/quick-start.txt
+++ b/docs/tutorials/quick-start.txt
@@ -16,10 +16,10 @@ Prerequisites
 .. code::
 
     # For CPU computations
-    docker pull determinedai/environments:py-3.6.9-pytorch-1.4-tf-1.14-cpu-3f3437e
+    docker pull determinedai/environments:py-3.6.9-pytorch-1.4-tf-1.14-cpu-4e98289
 
     # For GPU computations
-    docker pull determinedai/environments:cuda-10.0-pytorch-1.4-tf-1.14-gpu-3f3437e
+    docker pull determinedai/environments:cuda-10.0-pytorch-1.4-tf-1.14-gpu-4e98289
 
 
 Preparing Your First Job

--- a/e2e_tests/tests/config.py
+++ b/e2e_tests/tests/config.py
@@ -10,10 +10,10 @@ MAX_TASK_SCHEDULED_SECS = 30
 MAX_TRIAL_BUILD_SECS = 90
 
 
-TF1_CPU_IMAGE = "determinedai/environments:py-3.6.9-pytorch-1.4-tf-1.14-cpu-3f3437e"
-TF2_CPU_IMAGE = "determinedai/environments:py-3.6.9-pytorch-1.4-tf-2.2-cpu-3f3437e"
-TF1_GPU_IMAGE = "determinedai/environments:cuda-10.0-pytorch-1.4-tf-1.14-gpu-3f3437e"
-TF2_GPU_IMAGE = "determinedai/environments:cuda-10.1-pytorch-1.4-tf-2.2-gpu-3f3437e"
+TF1_CPU_IMAGE = "determinedai/environments:py-3.6.9-pytorch-1.4-tf-1.14-cpu-4e98289"
+TF2_CPU_IMAGE = "determinedai/environments:py-3.6.9-pytorch-1.4-tf-2.2-cpu-4e98289"
+TF1_GPU_IMAGE = "determinedai/environments:cuda-10.0-pytorch-1.4-tf-1.14-gpu-4e98289"
+TF2_GPU_IMAGE = "determinedai/environments:cuda-10.1-pytorch-1.4-tf-2.2-gpu-4e98289"
 
 
 def fixtures_path(path: str) -> str:

--- a/master/pkg/model/defaults.go
+++ b/master/pkg/model/defaults.go
@@ -84,8 +84,8 @@ func DefaultExperimentConfig() ExperimentConfig {
 		BatchesPerStep: 100,
 		Environment: Environment{
 			Image: RuntimeItem{
-				CPU: "determinedai/environments:py-3.6.9-pytorch-1.4-tf-1.14-cpu-3f3437e",
-				GPU: "determinedai/environments:cuda-10.0-pytorch-1.4-tf-1.14-gpu-3f3437e",
+				CPU: "determinedai/environments:py-3.6.9-pytorch-1.4-tf-1.14-cpu-4e98289",
+				GPU: "determinedai/environments:cuda-10.0-pytorch-1.4-tf-1.14-gpu-4e98289",
 			},
 		},
 		Reproducibility: ReproducibilityConfig{


### PR DESCRIPTION
## Description
Previously following the recent Horovod upgrade  (#556), multi-machine distributed
training did not work unless the network interface was explicitly specified.

[DET-3096 ](https://determinedai.atlassian.net/browse/DET-3067)
[DET-3067](https://determinedai.atlassian.net/browse/DET-3096)


## Test Plan
Tested these changes manually, and going to run full suite of tests before merging. 