### PR TITLE
feat: add timeout to tensorboard startup

### DIFF
--- a/e2e_tests/tests/command/test_tensorboard.py
+++ b/e2e_tests/tests/command/test_tensorboard.py
@@ -8,6 +8,7 @@ from tests import config as conf
 from tests import experiment as exp
 from tests.filetree import FileTree
 
+AWAITING_METRICS = "TensorBoard is awaiting metrics"
 SERVICE_READY = "TensorBoard is running at: http://"
 num_trials = 1
 
@@ -69,6 +70,8 @@ def test_start_tensorboard_for_shared_fs_experiment(tmp_path: Path) -> None:
         for line in tensorboard.stdout:
             if SERVICE_READY in line:
                 break
+            if AWAITING_METRICS in line:
+                raise AssertionError("Tensorboard did not find metrics")
         else:
             raise AssertionError(f"Did not find {SERVICE_READY} in output")
 
@@ -142,5 +145,7 @@ def test_start_tensorboard_for_multi_experiment(tmp_path: Path, secrets: Dict[st
         for line in tensorboard.stdout:
             if SERVICE_READY in line:
                 break
+            if AWAITING_METRICS in line:
+                raise AssertionError("Tensorboard did not find metrics")
         else:
             raise AssertionError(f"Did not find {SERVICE_READY} in output")

--- a/master/static/srv/tensorboard-entrypoint.sh
+++ b/master/static/srv/tensorboard-entrypoint.sh
@@ -11,9 +11,4 @@ python3.6 -m pip install --user /opt/determined/wheels/determined*.whl
 
 cd ${WORKING_DIR} && test -f "${STARTUP_HOOK}" && source "${STARTUP_HOOK}"
 
-# S3 backed experiments must have AWS_REGION set in the environment.
-eval "$(python3.6 -m determined.exec.tensorboard s3)"
-
-python3.6 -m determined.exec.tensorboard service_ready &
-
-tensorboard --port=${TENSORBOARD_PORT} --path_prefix="/proxy/${DET_TASK_ID}" $@
+python3.6 -m determined.exec.tensorboard "$@"


### PR DESCRIPTION
## Description

Run TensorBoard as a subprocess rather than a peer process, making it easy to control with a timeout check.

## Test Plan

Will additionally check manually that an s3-based experiment continues to work.
