### PR TITLE
feat: add support for estimator eval hooks

### DIFF
--- a/harness/determined/estimator/_estimator_trial.py
+++ b/harness/determined/estimator/_estimator_trial.py
@@ -500,7 +500,9 @@ class EstimatorTrialController(det.LoopTrialController):
         repeating_train_fn = self._check_and_repeat_train_input_fn(self.user_train_spec.input_fn)
 
         self.train_spec = tf.estimator.TrainSpec(input_fn=repeating_train_fn, hooks=all_hooks)
-        self.eval_spec = tf.estimator.EvalSpec(input_fn=self.val_spec.input_fn, steps=None)
+        self.eval_spec = tf.estimator.EvalSpec(
+            input_fn=self.val_spec.input_fn, hooks=self.val_spec.hooks, steps=None
+        )
 
     def _init_run_config(self, config: tf.estimator.RunConfig) -> tf.estimator.RunConfig:
         logging.debug(f"Initializing RunConfig. Got RunConfig: {config} .")

--- a/harness/tests/experiment/fixtures/estimator_xor_model.py
+++ b/harness/tests/experiment/fixtures/estimator_xor_model.py
@@ -1,4 +1,4 @@
-from typing import Callable, Dict, Tuple, Union
+from typing import Any, Callable, Dict, Tuple, Union
 
 import tensorflow as tf
 
@@ -149,4 +149,43 @@ class XORTrialDataLayer(XORTrial):
                 batch_size=self.context.get_per_slot_batch_size(),
                 shuffle=False,
             )
+        )
+
+
+class CustomCallback(tf.estimator.SessionRunHook):
+    def __init__(self, file_path: str) -> None:
+        self._file_path = file_path
+        self._idx = 0
+
+    def after_run(self, run_context: Any, run_values: Any) -> None:
+        self._idx += 1
+        with open(self._file_path, "w") as fp:
+            fp.write(f"{self._idx}")
+
+
+class XORTrialWithCallbacks(XORTrial):
+    def __init__(self, context: EstimatorTrialContext) -> None:
+        self.context = context
+
+        self._train_hook = CustomCallback(file_path=self.context.get_hparam("training_log_path"))
+        self._val_hook = CustomCallback(file_path=self.context.get_hparam("val_log_path"))
+
+    def build_train_spec(self) -> tf.estimator.TrainSpec:
+        return tf.estimator.TrainSpec(
+            xor_input_fn(
+                context=self.context,
+                batch_size=self.context.get_per_slot_batch_size(),
+                shuffle=self.context.get_hparam("shuffle"),
+            ),
+            hooks=[self._train_hook],
+        )
+
+    def build_validation_spec(self) -> tf.estimator.EvalSpec:
+        return tf.estimator.EvalSpec(
+            xor_input_fn(
+                context=self.context,
+                batch_size=self.context.get_per_slot_batch_size(),
+                shuffle=False,
+            ),
+            hooks=[self._val_hook],
         )


### PR DESCRIPTION
## Description
We previously ignored hooks that were passed into `tf.estimator.EvalSpec`.

[DET-3097](https://determinedai.atlassian.net/browse/DET-3097)

## Test Plan
Tested manually, and also added a unit test for both training and eval hooks.