### PR TITLE
feat: lower default instance sizes

### DIFF
--- a/deploy/determined_deploy/aws/templates/secure.yaml
+++ b/deploy/determined_deploy/aws/templates/secure.yaml
@@ -44,7 +44,7 @@ Parameters:
   AgentInstanceType:
     Type: String
     Description: Instance Type of Agent
-    Default: p2.8xlarge
+    Default: p2.xlarge
 
   BastionInstanceType:
     Type: String

--- a/deploy/determined_deploy/aws/templates/simple.yaml
+++ b/deploy/determined_deploy/aws/templates/simple.yaml
@@ -23,7 +23,7 @@ Parameters:
   AgentInstanceType:
     Type: String
     Description: Instance Type of Agent
-    Default: p2.8xlarge
+    Default: p2.xlarge
 
   InboundCIDRRange:
     Type: String

--- a/deploy/determined_deploy/aws/templates/vpc.yaml
+++ b/deploy/determined_deploy/aws/templates/vpc.yaml
@@ -37,7 +37,7 @@ Parameters:
   AgentInstanceType:
     Type: String
     Description: Instance Type of Agent
-    Default: p2.8xlarge
+    Default: p2.xlarge
 
   InboundCIDRRange:
     Type: String

--- a/deploy/determined_deploy/gcp/constants.py
+++ b/deploy/determined_deploy/gcp/constants.py
@@ -1,9 +1,9 @@
 class defaults:
 
-    AGENT_INSTANCE_TYPE = "n1-standard-32"
+    AGENT_INSTANCE_TYPE = "n1-standard-8"
     DB_PASSWORD = "postgres"
     ENVIRONMENT_IMAGE = "pedl-environments-4e98289"
-    GPU_NUM = 8
+    GPU_NUM = 1
     GPU_TYPE = "nvidia-tesla-k80"
     MASTER_INSTANCE_TYPE = "n1-standard-2"
     MAX_IDLE_AGENT_PERIOD = "10m"

--- a/docs/how-to/installation/aws.txt
+++ b/docs/how-to/installation/aws.txt
@@ -121,7 +121,7 @@ Spinning up the Cluster
 
    * - ``--agent-instance-type``
      - Instance type for agent instances.
-     - p2.8xlarge
+     - p2.xlarge
 
    * - ``--deployment-type``
      - The :ref:`deployment template <determined-deploy-deployment-types>` to use.
@@ -150,6 +150,21 @@ Spinning up the Cluster
    * - ``--dry-run``
      - Print the template but do not execute it.
      - False
+
+
+
+Updating the Cluster
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+If you need to make changes to your cluster, you can rerun ``det-deploy aws up [args]`` in the same directory and your
+cluster will be updated. The ``det-deploy`` tool will only replace resources that need to be replaced based on the
+changes you've made in the updated execution.
+
+Example command to update the cluster to have 8 GPUs per agent for multi GPU training:
+
+.. code::
+
+   det-deploy aws up --cluster-id CLUSTER_ID --keypair KEYPAIR --agent-instance-type p2.8xlarge
 
 
 Tearing Down the Cluster

--- a/docs/how-to/installation/gcp.txt
+++ b/docs/how-to/installation/gcp.txt
@@ -119,7 +119,7 @@ ___________________
 
    * - ``--gpu-num``
      - The number of GPUs on each agent instance. Between 1 and 8 (more GPUs require a more powerful ``agent-instance-type``). Refer to the `GPUs on Compute Engine <https://cloud.google.com/compute/docs/gpus>`__ page for specific GCP requirements.
-     - 8
+     - 1
 
    * - ``--max-dynamic-agents``
      - Maximum number of dynamic agent instances at one time.
@@ -151,7 +151,7 @@ ___________________
 
    * - ``--agent-instance-type``
      - Instance type to use for the agent instances.
-     - n1-standard-32
+     - n1-standard-8
 
    * - ``--min-cpu-platform-master``
      - Minimum CPU platform for the master instance.
@@ -189,6 +189,12 @@ If you need to make changes to your cluster, you can rerun ``det-deploy gcp up [
 
 .. note::
   If you'd like to change the ``region`` of a deployment after it has already been deployed, we recommend deleting the cluster first, then redeploying the cluster with the new ``region``.
+
+Example command to update the cluster to have 8 GPUs per agent for multi GPU training:
+
+.. code::
+
+  det-deploy gcp up --cluster-id CLUSTER_ID --project-id PROJECT_ID --agent-instance-type n1-standard-32 --gpu-num 8
 
 
 Destroying A Cluster


### PR DESCRIPTION
## Description
Reduce the default instance sizes for AWS and GCP to single GPU instances.


## Test Plan
Deployed clusters to both AWS and GCP and ran the updated examples against them.
