### PR TITLE
test: fix nightly objection detection convergence test

### DIFF
--- a/e2e_tests/tests/config.py
+++ b/e2e_tests/tests/config.py
@@ -113,3 +113,10 @@ def set_s3_data_layer(config: Dict[Any, Any]) -> Dict[Any, Any]:
     config["data_layer"]["bucket"] = "yogadl-test"
     config["data_layer"]["bucket_directory_path"] = "pedl_integration_tests"
     return config
+
+
+def set_random_seed(config: Dict[Any, Any], seed: int) -> Dict[Any, Any]:
+    config = config.copy()
+    config.setdefault("reproducibility", {})
+    config["reproducibility"]["experiment_seed"] = seed
+    return config

--- a/e2e_tests/tests/nightly/test_convergence.py
+++ b/e2e_tests/tests/nightly/test_convergence.py
@@ -111,6 +111,7 @@ def test_mnist_pytorch_accuracy() -> None:
 @pytest.mark.nightly  # type: ignore
 def test_object_detection_accuracy() -> None:
     config = conf.load_config(conf.official_examples_path("object_detection_pytorch/const.yaml"))
+    config = conf.set_random_seed(config, 1590497309)
     experiment_id = exp.run_basic_test_with_temp_config(
         config, conf.official_examples_path("object_detection_pytorch"), 1
     )


### PR DESCRIPTION
## Description
Nightly test for PyTorch obj detection has been missing the target accuracy. Set random seed to reduce randomness.


## Test Plan
Ran twice locally, both times reached accuracy of 0.56, which exceeds the target accuracy of 0.42. 
