### PR TITLE
feat: add callback support to EstimatorTrial

### DIFF
--- a/docs/reference/api/estimator.txt
+++ b/docs/reference/api/estimator.txt
@@ -47,6 +47,40 @@ API or Native API.
     :members: cache_train_dataset, cache_validation_dataset
     :member-order: bysource
 
+
+Callbacks
+~~~~~~~~~
+
+To execute arbitrary Python functionality during the lifecycle of a
+``EstimatorTrial``, ``determined.estimator.RunHook`` extends
+`tf.estimator.SessionRunHook <https://www.tensorflow.org/api_docs/python/tf/estimator/SessionRunHook/>`_.
+
+.. autoclass:: determined.estimator.RunHook
+    :members: on_checkpoint_load, on_checkpoint_end
+
+
+Example usage of ``determined.estimator.RunHook`` which adds custom metadata checkpoints:
+
+.. code:: python
+
+    class MyHook(determined.estimator.RunHook):
+        def __init__(self, context, metadata) -> None:
+            self._context = context
+            self._metadata = metadata
+
+        def on_checkpoint_end(self, checkpoint_path) -> None:
+            with open(str(checkpoint_dir.joinpath("metadata.txt")), "w") as fp:
+                fp.write(self._metadata)
+
+    class MyEstimatorTrial(determined.estimator.EstimatorTrial) -> None:
+        ...
+
+        def build_train_spec(self) -> tf.estimator.TrainSpec:
+            return tf.estimator.TrainSpec(
+                make_input_fn(),
+                hooks=[MyHook(self.context, "my_metadata")],
+            )
+
 Examples
 --------
 

--- a/harness/determined/estimator/__init__.py
+++ b/harness/determined/estimator/__init__.py
@@ -1,3 +1,4 @@
+from determined.estimator._callback import RunHook
 from determined.estimator._estimator_context import (
     EstimatorNativeContext,
     EstimatorContext,

--- a/harness/determined/estimator/_callback.py
+++ b/harness/determined/estimator/_callback.py
@@ -1,0 +1,32 @@
+import pathlib
+
+import tensorflow as tf
+
+
+class RunHook(tf.estimator.SessionRunHook):  # type: ignore
+    """
+    Abstract base class which extends
+    `SessionRunHook <https://www.tensorflow.org/api_docs/python/tf/estimator/SessionRunHook>`_
+    and is used to define callbacks that should execute during the lifetime of a EstimatorTrial.
+
+    Hooks should be passed in to
+    `Train Spec <https://www.tensorflow.org/api_docs/python/tf/estimator/TrainSpec>`_.
+
+    """
+
+    def on_checkpoint_load(self, checkpoint_dir: pathlib.Path) -> None:
+        """
+        Run at startup when the task environment starts up. If not resuming
+        from checkpoint this is never called.
+        """
+        pass
+
+    def on_checkpoint_end(self, checkpoint_dir: pathlib.Path) -> None:
+        """
+        Run after every checkpoint.
+
+        .. warning::
+            If distributed or parallel training is enabled, this callback is executed
+            only on the chief GPU (rank = 0) which performs the checkpoint.
+        """
+        pass

--- a/harness/determined/util.py
+++ b/harness/determined/util.py
@@ -142,6 +142,12 @@ def json_encode(obj: Any, indent: Optional[str] = None, sort_keys: bool = False)
 def write_checkpoint_metadata(path: pathlib.Path, env: EnvContext, extras: Dict[str, Any]) -> None:
     code_path = path.joinpath("code")
 
+    # When restarting from checkpoint, it is possible that the code path is already present
+    # in the checkpoint directory. This happens for EstimatorTrial because we overwrite the
+    # estimator model directory with the checkpoint folder at the start of training.
+    if code_path.exists():
+        shutil.rmtree(str(code_path))
+
     # Pytorch and tf.1 keras models can only be restored from a checkpoint if
     # the original code is present. The model code is the current working
     # directory. Therefore we save the current directory with the checkpoint.

--- a/harness/tests/experiment/fixtures/estimator_xor_model_native.py
+++ b/harness/tests/experiment/fixtures/estimator_xor_model_native.py
@@ -4,13 +4,13 @@ from typing import Callable, Dict, Tuple
 
 import tensorflow as tf
 
-from determined.estimator import EstimatorNativeContext, ServingInputReceiverFn
-from determined.experimental import estimator
+from determined import estimator
+from determined.experimental import estimator as estimator_experimental
 from tests.experiment import utils
 
 
 def xor_input_fn(
-    context: EstimatorNativeContext, batch_size: int, shuffle: bool = False
+    context: estimator.EstimatorNativeContext, batch_size: int, shuffle: bool = False
 ) -> Callable[[], Tuple[tf.Tensor, tf.Tensor]]:
     def _input_fn() -> Tuple[tf.Tensor, tf.Tensor]:
         data, labels = utils.xor_data()
@@ -30,7 +30,7 @@ def xor_input_fn(
     return _input_fn
 
 
-def build_estimator(context: EstimatorNativeContext) -> tf.estimator.Estimator:
+def build_estimator(context: estimator.EstimatorNativeContext) -> tf.estimator.Estimator:
     optimizer = context.get_hparam("optimizer")
     learning_rate = context.get_hparam("learning_rate")
     hidden_size = context.get_hparam("hidden_size")
@@ -58,7 +58,7 @@ def build_estimator(context: EstimatorNativeContext) -> tf.estimator.Estimator:
     )
 
 
-def build_serving_input_receiver_fns() -> Dict[str, ServingInputReceiverFn]:
+def build_serving_input_receiver_fns() -> Dict[str, estimator.ServingInputReceiverFn]:
     _input = tf.feature_column.numeric_column("input", shape=(2,), dtype=tf.int64)
     return {
         "inference": tf.estimator.export.build_parsing_serving_input_receiver_fn(
@@ -83,7 +83,7 @@ if __name__ == "__main__":
         }
     }
 
-    context = estimator.init(
+    context = estimator_experimental.init(
         config=config, local=args.local, test=args.test, context_dir=str(pathlib.Path.cwd())
     )
 


### PR DESCRIPTION
## Description
Most callback functionality can be handled via native support in tf.estimator using `tf.estimator.SessionRunHook`. However our checkpoint mechanism does use `CheckpointSaverHook`, thus checkpoint callbacks can not be performed via `tf.estimator.SessionRunHook`. To support such use cases (e.g., adding custom meta-data file to a checkpoint) we are adding support for deteremined callbacks in EstimatorTrial. Currently we are adding support for `on_checkpoint_load` and `on_checkpoint_end`.

Additionally as part of this PR, removed copies of checkpoint files that are no longer necessary. 

[DET-3100](https://determinedai.atlassian.net/browse/DET-3100)

## Test Plan
Added a unit test to test callback support. Also performed manual test confirming that changes do not break checkpoint/restart for multi-gpu. 


