### PR TITLE
fix: fix off-by-one error in master logs

### DIFF
--- a/master/internal/trial.go
+++ b/master/internal/trial.go
@@ -799,9 +799,9 @@ func (t *trial) resetTrial(
 		return
 	}
 
-	t.restarts++
-	ctx.Log().Errorf("unexpected failure of trial (%d/%d): %v",
+	ctx.Log().Errorf("unexpected failure of trial after restart %d/%d: %v",
 		t.restarts, t.experiment.Config.MaxRestarts, status)
+	t.restarts++
 	if t.restarts <= t.experiment.Config.MaxRestarts {
 		t.restore(ctx)
 		return


### PR DESCRIPTION
## Description

Before fix, after a `max_restarts: 0` experiment fails:
```
unexpected failure of trial (1/0): ...
```

After fix:
```
unexpected failure of trial after restart 0/0: ...
```