### PR TITLE
feat: add pause/activate and cancel actions to task cards 

### DIFF
--- a/webui/react/src/services/api.ts
+++ b/webui/react/src/services/api.ts
@@ -2,8 +2,8 @@ import { CancelToken } from 'axios';
 
 import { generateApi } from 'services/apiBuilder';
 import * as Config from 'services/apiConfig';
-import { ExperimentsParams, KillCommandParams, KillExpParams,
-  PatchExperimentParams } from 'services/types';
+import { ExperimentsParams, KillCommandParams, KillExpParams, LaunchTensorboardParams,
+  PatchExperimentParams, PatchExperimentState } from 'services/types';
 import { CommandType, Credentials, Experiment, RecentTask, TaskType, User } from 'types';
 
 /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
@@ -28,6 +28,9 @@ export const killCommand = generateApi<KillCommandParams, void>(Config.killComma
 
 export const patchExperiment = generateApi<PatchExperimentParams, void>(Config.patchExperiment);
 
+export const launchTensorboard =
+  generateApi<LaunchTensorboardParams, void>(Config.launchTensorboard);
+
 export const killTask =
   async (task: RecentTask, cancelToken?: CancelToken): Promise<void> => {
     if (task.type === TaskType.Experiment) {
@@ -48,3 +51,11 @@ export const archiveExperiment =
 export const login = generateApi<Credentials, void>(Config.login);
 
 export const logout = generateApi<{}, void>(Config.logout);
+
+export const setExperimentState =
+  async ({ state, ...rest }: PatchExperimentState): Promise<void> => {
+    return patchExperiment({
+      body: { state },
+      ...rest,
+    });
+  };

--- a/webui/react/src/services/apiConfig.ts
+++ b/webui/react/src/services/apiConfig.ts
@@ -4,8 +4,8 @@ import { decode, ioTypeUser, ioUser } from 'ioTypes';
 import { Api } from 'services/apiBuilder';
 import { jsonToExperiments } from 'services/decoder';
 import { ExperimentsParams, KillCommandParams, KillExpParams,
-  PatchExperimentParams } from 'services/types';
-import { CommandType, Credentials, Experiment, User } from 'types';
+  LaunchTensorboardParams, PatchExperimentParams } from 'services/types';
+import { CommandType, Credentials, Experiment, TBSourceType, User } from 'types';
 
 /* Helpers */
 
@@ -69,6 +69,20 @@ export const killCommand: Api<KillCommandParams, void> = {
     };
   },
   name: 'killCommand',
+};
+
+export const launchTensorboard: Api<LaunchTensorboardParams, void> = {
+  httpOptions: (params) => {
+    const attrName = params.type === TBSourceType.Trial ? 'trial_ids' : 'experiment_ids';
+    return {
+      body: {
+        [attrName]: params.ids,
+      },
+      method: 'POST',
+      url: `${commandToEndpoint[CommandType.Tensorboard]}`,
+    };
+  },
+  name: 'launchTensorboard',
 };
 
 /* Experiment */

--- a/webui/react/src/services/types.ts
+++ b/webui/react/src/services/types.ts
@@ -1,8 +1,10 @@
-import { CommandType } from 'types';
+import { CommandType, RunState, TBSourceType } from 'types';
 
 export interface ExperimentsParams {
   states?: string[];
 }
+
+// TODO in the following types the default id should probably be just "id"
 
 export interface KillExpParams {
   experimentId: number;
@@ -16,4 +18,15 @@ export interface KillCommandParams {
 export interface PatchExperimentParams {
   experimentId: number;
   body: Record<keyof unknown, unknown> | string;
+}
+
+export interface PatchExperimentState {
+  experimentId: number;
+  state: RunState;
+}
+
+export interface LaunchTensorboardParams {
+  // currently we don't support launching from a mix of both trial ids and experiment ids
+  ids: number[];
+  type: TBSourceType;
 }

--- a/webui/react/src/types.ts
+++ b/webui/react/src/types.ts
@@ -179,3 +179,8 @@ export interface RecentTask {
 }
 
 export type PropsWithClassName<T> = T & {className?: string};
+
+export enum TBSourceType {
+  Trial,
+  Experiment
+}

--- a/webui/react/src/utils/types.ts
+++ b/webui/react/src/utils/types.ts
@@ -57,6 +57,7 @@ export const experimentToTask = (experiment: Experiment): RecentTask => {
 };
 
 export const killableRunStates = [ RunState.Active, RunState.Paused, RunState.StoppingCanceled ];
+export const cancellableRunStates = [ RunState.Active, RunState.Paused ];
 export const killableCmdStates = [
   CommandState.Assigned,
   CommandState.Pending,


### PR DESCRIPTION
## Description

[DET-2934]

depends on https://github.com/determined-ai/determined/pull/584

## Test Plan



## Commentary (optional)

<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

## Description

Lead with the intended commit body in this description field. For breaking changes, please include "BREAKING CHANGE:" at the beginning of your commit body. At minimum, this section should include a bracketed reference to the Jira ticket, e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.

## Test Plan

Describe the situations in which you've tested your change, and/or a screenshot as appropriate. Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.

## Commentary (optional)

Use this section of your description to add context to the PR. Could be for particularly tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc. You may intentionally leave this section blank and remove the title.
--->

[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234

[DET-2934]: https://determinedai.atlassian.net/browse/DET-2934