### PR TITLE
feat: support early trial termination

### DIFF
--- a/master/pkg/searcher/adaptive_simple.go
+++ b/master/pkg/searcher/adaptive_simple.go
@@ -68,7 +68,7 @@ func newAsyncHalvingSimpleSearch(config model.AsyncHalvingConfig, trials int) Se
 		AsyncHalvingConfig: config,
 		rungs:              rungs,
 		trialRungs:         make(map[RequestID]int),
-		earlyExitTrials:    make(map[RequestID]float64),
+		earlyExitTrials:    make(map[RequestID]bool),
 		expectedWorkloads:  expectedWorkloads,
 	}
 }

--- a/master/pkg/searcher/adaptive_simple.go
+++ b/master/pkg/searcher/adaptive_simple.go
@@ -59,7 +59,6 @@ func newAsyncHalvingSimpleSearch(config model.AsyncHalvingConfig, trials int) Se
 			&rung{
 				stepsNeeded: stepsNeeded,
 				startTrials: startTrials,
-				seenTrials:  make(map[RequestID]bool),
 			},
 		)
 	}

--- a/master/pkg/searcher/adaptive_simple.go
+++ b/master/pkg/searcher/adaptive_simple.go
@@ -55,13 +55,20 @@ func newAsyncHalvingSimpleSearch(config model.AsyncHalvingConfig, trials int) Se
 			expectedSteps += stepsNeeded * startTrials
 			expectedWorkloads += (stepsNeeded + 1) * startTrials
 		}
-		rungs = append(rungs, &rung{stepsNeeded: stepsNeeded, startTrials: startTrials})
+		rungs = append(rungs,
+			&rung{
+				stepsNeeded: stepsNeeded,
+				startTrials: startTrials,
+				seenTrials:  make(map[RequestID]bool),
+			},
+		)
 	}
 	config.StepBudget = expectedSteps
 	return &asyncHalvingSearch{
 		AsyncHalvingConfig: config,
 		rungs:              rungs,
 		trialRungs:         make(map[RequestID]int),
+		earlyExitTrials:    make(map[RequestID]float64),
 		expectedWorkloads:  expectedWorkloads,
 	}
 }

--- a/master/pkg/searcher/adaptive_simple_test.go
+++ b/master/pkg/searcher/adaptive_simple_test.go
@@ -67,6 +67,31 @@ func TestAdaptiveSimpleSearchMethod(t *testing.T) {
 			},
 		},
 		{
+			name: "early exit -- smaller is better",
+			expectedTrials: []predefinedTrial{
+				newConstantPredefinedTrial(0.1, 32, []int{1, 2, 3, 4, 32}, nil),
+				newConstantPredefinedTrial(0.2, 1, []int{1}, nil),
+				newConstantPredefinedTrial(0.3, 1, []int{1}, nil),
+
+				newEarlyExitPredefinedTrial(0.4, 1, nil, nil),
+				newConstantPredefinedTrial(0.5, 32, []int{1, 2, 3, 32}, nil),
+				newConstantPredefinedTrial(0.6, 1, []int{1}, nil),
+
+				newConstantPredefinedTrial(0.7, 32, []int{1, 2, 32}, nil),
+				newConstantPredefinedTrial(0.8, 1, []int{1}, nil),
+			},
+			config: model.SearcherConfig{
+				AdaptiveSimpleConfig: &model.AdaptiveSimpleConfig{
+					Metric:          "error",
+					SmallerIsBetter: true,
+					Mode:            model.StandardMode,
+					MaxTrials:       8,
+					MaxSteps:        32,
+					MaxRungs:        5,
+				},
+			},
+		},
+		{
 			name: "smaller is not better",
 			expectedTrials: []predefinedTrial{
 				newConstantPredefinedTrial(0.8, 32, []int{1, 2, 3, 4, 32}, nil),
@@ -75,6 +100,31 @@ func TestAdaptiveSimpleSearchMethod(t *testing.T) {
 
 				newConstantPredefinedTrial(0.5, 32, []int{1, 2, 3, 32}, nil),
 				newConstantPredefinedTrial(0.4, 1, []int{1}, nil),
+				newConstantPredefinedTrial(0.3, 1, []int{1}, nil),
+
+				newConstantPredefinedTrial(0.2, 32, []int{1, 2, 32}, nil),
+				newConstantPredefinedTrial(0.1, 1, []int{1}, nil),
+			},
+			config: model.SearcherConfig{
+				AdaptiveSimpleConfig: &model.AdaptiveSimpleConfig{
+					Metric:          "error",
+					SmallerIsBetter: false,
+					Mode:            model.StandardMode,
+					MaxTrials:       8,
+					MaxSteps:        32,
+					MaxRungs:        5,
+				},
+			},
+		},
+		{
+			name: "early exit -- smaller is not better",
+			expectedTrials: []predefinedTrial{
+				newConstantPredefinedTrial(0.8, 32, []int{1, 2, 3, 4, 32}, nil),
+				newConstantPredefinedTrial(0.7, 1, []int{1}, nil),
+				newConstantPredefinedTrial(0.6, 1, []int{1}, nil),
+
+				newConstantPredefinedTrial(0.5, 32, []int{1, 2, 3, 32}, nil),
+				newEarlyExitPredefinedTrial(0.4, 1, nil, nil),
 				newConstantPredefinedTrial(0.3, 1, []int{1}, nil),
 
 				newConstantPredefinedTrial(0.2, 32, []int{1, 2, 32}, nil),

--- a/master/pkg/searcher/adaptive_test.go
+++ b/master/pkg/searcher/adaptive_test.go
@@ -64,10 +64,48 @@ func TestAdaptiveSearchMethod(t *testing.T) {
 			},
 		},
 		{
+			name: "early exit -- smaller is better",
+			expectedTrials: []predefinedTrial{
+				newConstantPredefinedTrial(0.1, 32, []int{8, 32}, nil),
+				newEarlyExitPredefinedTrial(0.2, 8, nil, nil),
+				newConstantPredefinedTrial(0.3, 32, []int{32}, nil),
+			},
+			config: model.SearcherConfig{
+				AdaptiveConfig: &model.AdaptiveConfig{
+					Metric:           "error",
+					SmallerIsBetter:  true,
+					TargetTrialSteps: 32,
+					StepBudget:       64,
+					Mode:             model.StandardMode,
+					MaxRungs:         2,
+					Divisor:          4,
+				},
+			},
+		},
+		{
 			name: "smaller is not better",
 			expectedTrials: []predefinedTrial{
 				newConstantPredefinedTrial(0.3, 32, []int{8, 32}, nil),
 				newConstantPredefinedTrial(0.2, 8, []int{8}, nil),
+				newConstantPredefinedTrial(0.1, 32, []int{32}, nil),
+			},
+			config: model.SearcherConfig{
+				AdaptiveConfig: &model.AdaptiveConfig{
+					Metric:           "error",
+					SmallerIsBetter:  false,
+					TargetTrialSteps: 32,
+					StepBudget:       64,
+					Mode:             model.StandardMode,
+					MaxRungs:         2,
+					Divisor:          4,
+				},
+			},
+		},
+		{
+			name: "early exit -- smaller is not better",
+			expectedTrials: []predefinedTrial{
+				newConstantPredefinedTrial(0.3, 32, []int{8, 32}, nil),
+				newEarlyExitPredefinedTrial(0.2, 8, nil, nil),
 				newConstantPredefinedTrial(0.1, 32, []int{32}, nil),
 			},
 			config: model.SearcherConfig{

--- a/master/pkg/searcher/asha.go
+++ b/master/pkg/searcher/asha.go
@@ -87,7 +87,9 @@ type rung struct {
 // promotions handles bookkeeping of validation metrics and returns a RequestID to promote if
 // appropriate.
 func (r *rung) promotions(requestID RequestID, metric float64) []RequestID {
-	// Remove duplicate trial if we have one.
+	// Remove duplicate trial if we have one. This occurs when max_restarts > 0
+	// and we error a trial at a step ID that is less than one we have hit
+	// before.
 	var insertIndex int
 	if ok := r.seenTrials[requestID]; ok {
 		var ind int

--- a/master/pkg/searcher/asha.go
+++ b/master/pkg/searcher/asha.go
@@ -161,7 +161,7 @@ func (s *asyncHalvingSearch) promoteTrials(
 	if toPromote := rung.promotions(requestID, metric); len(toPromote) > 0 {
 		for _, promotionID := range toPromote {
 			s.trialRungs[promotionID] = rungIndex + 1
-			if ok := s.earlyExitTrials[promotionID]; !ok {
+			if !s.earlyExitTrials[promotionID] {
 				ops = append(ops, trainAndValidate(
 					promotionID, rung.stepsNeeded, s.rungs[rungIndex+1].stepsNeeded)...)
 			} else {
@@ -195,7 +195,7 @@ func (s *asyncHalvingSearch) promoteTrials(
 		if len(rung.metrics) == rung.startTrials {
 			for _, trialMetric := range rung.metrics[rung.promoteTrials:] {
 				s.trialsCompleted++
-				if ok := s.earlyExitTrials[trialMetric.requestID]; !ok {
+				if !s.earlyExitTrials[trialMetric.requestID] {
 					ops = append(ops, NewClose(trialMetric.requestID))
 				}
 			}

--- a/master/pkg/searcher/asha_test.go
+++ b/master/pkg/searcher/asha_test.go
@@ -55,6 +55,33 @@ func TestASHASearchMethod(t *testing.T) {
 			},
 		},
 		{
+			name: "early exit -- smaller is better",
+			expectedTrials: []predefinedTrial{
+				newConstantPredefinedTrial(0.01, 800, []int{12, 50, 200, 800}, nil),
+				newEarlyExitPredefinedTrial(0.02, 50, []int{12}, nil),
+				newConstantPredefinedTrial(0.03, 12, []int{12}, nil),
+				newConstantPredefinedTrial(0.04, 12, []int{12}, nil),
+				newConstantPredefinedTrial(0.05, 12, []int{12}, nil),
+				newConstantPredefinedTrial(0.06, 12, []int{12}, nil),
+				newConstantPredefinedTrial(0.07, 12, []int{12}, nil),
+				newConstantPredefinedTrial(0.08, 12, []int{12}, nil),
+				newConstantPredefinedTrial(0.09, 12, []int{12}, nil),
+				newConstantPredefinedTrial(0.10, 12, []int{12}, nil),
+				newEarlyExitPredefinedTrial(0.11, 11, nil, nil),
+			},
+			config: model.SearcherConfig{
+				AsyncHalvingConfig: &model.AsyncHalvingConfig{
+					Metric:           "error",
+					NumRungs:         4,
+					SmallerIsBetter:  true,
+					TargetTrialSteps: 800,
+					StepBudget:       480,
+					Divisor:          4,
+					TrainStragglers:  true,
+				},
+			},
+		},
+		{
 			name: "smaller is not better",
 			expectedTrials: []predefinedTrial{
 				newConstantPredefinedTrial(0.11, 800, []int{12, 50, 200, 800}, nil),
@@ -68,6 +95,33 @@ func TestASHASearchMethod(t *testing.T) {
 				newConstantPredefinedTrial(0.03, 12, []int{12}, nil),
 				newConstantPredefinedTrial(0.02, 12, []int{12}, nil),
 				newConstantPredefinedTrial(0.01, 12, []int{12}, nil),
+			},
+			config: model.SearcherConfig{
+				AsyncHalvingConfig: &model.AsyncHalvingConfig{
+					Metric:           "error",
+					NumRungs:         4,
+					SmallerIsBetter:  false,
+					TargetTrialSteps: 800,
+					StepBudget:       480,
+					Divisor:          4,
+					TrainStragglers:  true,
+				},
+			},
+		},
+		{
+			name: "early exit -- smaller is not better",
+			expectedTrials: []predefinedTrial{
+				newConstantPredefinedTrial(0.11, 800, []int{12, 50, 200, 800}, nil),
+				newEarlyExitPredefinedTrial(0.10, 50, []int{12}, nil),
+				newConstantPredefinedTrial(0.09, 12, []int{12}, nil),
+				newConstantPredefinedTrial(0.08, 12, []int{12}, nil),
+				newConstantPredefinedTrial(0.07, 12, []int{12}, nil),
+				newConstantPredefinedTrial(0.06, 12, []int{12}, nil),
+				newConstantPredefinedTrial(0.05, 12, []int{12}, nil),
+				newConstantPredefinedTrial(0.04, 12, []int{12}, nil),
+				newConstantPredefinedTrial(0.03, 12, []int{12}, nil),
+				newConstantPredefinedTrial(0.02, 12, []int{12}, nil),
+				newEarlyExitPredefinedTrial(0.01, 11, nil, nil),
 			},
 			config: model.SearcherConfig{
 				AsyncHalvingConfig: &model.AsyncHalvingConfig{

--- a/master/pkg/searcher/grid.go
+++ b/master/pkg/searcher/grid.go
@@ -36,6 +36,14 @@ func (s *gridSearch) progress(workloadsCompleted int) float64 {
 	return float64(workloadsCompleted) / float64((s.MaxSteps+1)*s.trials)
 }
 
+// trialExitedEarly does nothing since grid does not take actions based on
+// search status or progress.
+func (s *gridSearch) trialExitedEarly(
+	ctx context, requestID RequestID, message Workload,
+) ([]Operation, error) {
+	return nil, nil
+}
+
 func newHyperparameterGrid(params model.Hyperparameters) []hparamSample {
 	var names []string
 	var values [][]interface{}

--- a/master/pkg/searcher/grid_test.go
+++ b/master/pkg/searcher/grid_test.go
@@ -131,7 +131,7 @@ func TestGridSearchMethod(t *testing.T) {
 				newConstantPredefinedTrial(0.1, 3, []int{3}, nil),
 				newConstantPredefinedTrial(0.1, 3, []int{3}, nil),
 				newConstantPredefinedTrial(0.1, 3, []int{3}, nil),
-				newConstantPredefinedTrial(0.1, 3, []int{3}, nil),
+				newEarlyExitPredefinedTrial(.1, 3, nil, nil),
 			},
 			config: model.SearcherConfig{
 				GridConfig: &model.GridConfig{MaxSteps: 3},

--- a/master/pkg/searcher/message.go
+++ b/master/pkg/searcher/message.go
@@ -19,6 +19,7 @@ type CompletedMessage struct {
 	CheckpointMetrics *CheckpointMetrics
 	ValidationMetrics *ValidationMetrics
 	RunMetrics        map[string]interface{}
+	ExitedReason      *ExitedReason
 }
 
 // UnmarshalJSON unmarshals the provided bytes into a workload.CompletedMessage. An error is
@@ -74,3 +75,11 @@ func (metrics ValidationMetrics) Metric(name string) (float64, error) {
 	}
 	return metric, nil
 }
+
+// ExitedReason defines why a workload exited early.
+type ExitedReason string
+
+const (
+	// Errored signals the searcher that the workload errored out.
+	Errored ExitedReason = "ERRORED"
+)

--- a/master/pkg/searcher/operations.go
+++ b/master/pkg/searcher/operations.go
@@ -172,7 +172,9 @@ func (close Close) String() string {
 }
 
 // Shutdown marks the searcher as completed.
-type Shutdown struct{}
+type Shutdown struct {
+	Failure bool
+}
 
 // NewShutdown initializes a Shutdown operation for the searcher.
 func NewShutdown() Shutdown {

--- a/master/pkg/searcher/pbt.go
+++ b/master/pkg/searcher/pbt.go
@@ -85,7 +85,7 @@ func (s *pbtSearch) runNewTrials(
 	s.roundsCompleted++
 	if s.roundsCompleted >= s.NumRounds {
 		for requestID := range s.metrics {
-			if ok := s.earlyExitTrials[requestID]; !ok {
+			if !s.earlyExitTrials[requestID] {
 				ops = append(ops, NewClose(requestID))
 			}
 		}
@@ -115,7 +115,7 @@ func (s *pbtSearch) runNewTrials(
 
 	// Close the worst trials.
 	for i := len(trialIDs) - numTruncate; i < len(trialIDs); i++ {
-		if ok := s.earlyExitTrials[trialIDs[i]]; !ok {
+		if !s.earlyExitTrials[trialIDs[i]] {
 			// TODO specify the right kind of ID for ops
 			ops = append(ops, NewClose(trialIDs[i]))
 		}
@@ -123,7 +123,7 @@ func (s *pbtSearch) runNewTrials(
 
 	// Checkpoint and copy the best trials.
 	for _, requestID := range trialIDs[:numTruncate] {
-		if ok := s.earlyExitTrials[requestID]; !ok {
+		if !s.earlyExitTrials[requestID] {
 			checkpoint := NewCheckpoint(
 				requestID,
 				s.StepsPerRound*s.trialRoundsCompleted[requestID],
@@ -146,7 +146,7 @@ func (s *pbtSearch) runNewTrials(
 
 	// Continue all non-closed trials.
 	for _, requestID := range trialIDs[:len(trialIDs)-numTruncate] {
-		if ok := s.earlyExitTrials[requestID]; !ok {
+		if !s.earlyExitTrials[requestID] {
 			lastStep := s.trialRoundsCompleted[requestID] * s.StepsPerRound
 			nextStep := lastStep + s.StepsPerRound
 			ops = append(ops, trainAndValidate(requestID, lastStep, nextStep)...)

--- a/master/pkg/searcher/pbt_test.go
+++ b/master/pkg/searcher/pbt_test.go
@@ -393,10 +393,64 @@ func TestPBTSearchMethod(t *testing.T) {
 			},
 		},
 		{
+			name: "early exit -- smaller is better",
+			expectedTrials: []predefinedTrial{
+				// First generation.
+				newEarlyExitPredefinedTrial(0.5, 4, []int{2}, []int{2}),
+				newConstantPredefinedTrial(0.6, 2, []int{2}, nil),
+				// Second generation beats first generation.
+				newConstantPredefinedTrial(0.1, 6, []int{2, 4, 6}, []int{2, 4}),
+				// Third generation loses to second generation.
+				newConstantPredefinedTrial(0.2, 2, []int{2}, nil),
+				// Fourth generation loses to second generation also.
+				newConstantPredefinedTrial(0.3, 2, []int{2}, nil),
+			},
+			config: model.SearcherConfig{
+				PBTConfig: &model.PBTConfig{
+					Metric:          "error",
+					SmallerIsBetter: true,
+					PopulationSize:  2,
+					NumRounds:       4,
+					StepsPerRound:   2,
+					PBTReplaceConfig: model.PBTReplaceConfig{
+						TruncateFraction: .5,
+					},
+					PBTExploreConfig: model.PBTExploreConfig{},
+				},
+			},
+		},
+		{
 			name: "smaller is not better",
 			expectedTrials: []predefinedTrial{
 				// First generation.
 				newConstantPredefinedTrial(0.5, 4, []int{2, 4}, []int{2}),
+				newConstantPredefinedTrial(0.4, 2, []int{2}, nil),
+				// Second generation beats first generation.
+				newConstantPredefinedTrial(0.9, 6, []int{2, 4, 6}, []int{2, 4}),
+				// Third generation loses to second generation.
+				newConstantPredefinedTrial(0.8, 2, []int{2}, nil),
+				// Fourth generation loses to second generation also.
+				newConstantPredefinedTrial(0.7, 2, []int{2}, nil),
+			},
+			config: model.SearcherConfig{
+				PBTConfig: &model.PBTConfig{
+					Metric:          "error",
+					SmallerIsBetter: false,
+					PopulationSize:  2,
+					NumRounds:       4,
+					StepsPerRound:   2,
+					PBTReplaceConfig: model.PBTReplaceConfig{
+						TruncateFraction: .5,
+					},
+					PBTExploreConfig: model.PBTExploreConfig{},
+				},
+			},
+		},
+		{
+			name: "early exit -- smaller is not better",
+			expectedTrials: []predefinedTrial{
+				// First generation.
+				newEarlyExitPredefinedTrial(0.5, 4, []int{2}, []int{2}),
 				newConstantPredefinedTrial(0.4, 2, []int{2}, nil),
 				// Second generation beats first generation.
 				newConstantPredefinedTrial(0.9, 6, []int{2, 4, 6}, []int{2, 4}),

--- a/master/pkg/searcher/random.go
+++ b/master/pkg/searcher/random.go
@@ -34,3 +34,11 @@ func (s *randomSearch) initialOperations(ctx context) ([]Operation, error) {
 func (s *randomSearch) progress(workloadsCompleted int) float64 {
 	return float64(workloadsCompleted) / float64((s.MaxSteps+1)*s.MaxTrials)
 }
+
+// trialExitedEarly does nothing since random does not take actions based on
+// search status or progress.
+func (s *randomSearch) trialExitedEarly(
+	ctx context, requestID RequestID, message Workload,
+) ([]Operation, error) {
+	return nil, nil
+}

--- a/master/pkg/searcher/random_test.go
+++ b/master/pkg/searcher/random_test.go
@@ -31,7 +31,7 @@ func TestRandomSearchMethod(t *testing.T) {
 				newConstantPredefinedTrial(.1, 5, []int{5}, nil),
 				newConstantPredefinedTrial(.1, 5, []int{5}, nil),
 				newConstantPredefinedTrial(.1, 5, []int{5}, nil),
-				newConstantPredefinedTrial(.1, 5, []int{5}, nil),
+				newEarlyExitPredefinedTrial(.1, 5, nil, nil),
 			},
 			config: model.SearcherConfig{
 				RandomConfig: &model.RandomConfig{

--- a/master/pkg/searcher/search_method.go
+++ b/master/pkg/searcher/search_method.go
@@ -42,7 +42,7 @@ type SearchMethod interface {
 	trialClosed(ctx context, requestID RequestID) ([]Operation, error)
 	// progress returns experiment progress as a float between 0.0 and 1.0.
 	progress(workloadsCompleted int) float64
-	// trialExitedEarly informs the searcher that the trial has exited earlier than expected
+	// trialExitedEarly informs the searcher that the trial has exited earlier than expected.
 	trialExitedEarly(ctx context, requestID RequestID, message Workload) ([]Operation, error)
 }
 

--- a/master/pkg/searcher/search_method.go
+++ b/master/pkg/searcher/search_method.go
@@ -42,6 +42,8 @@ type SearchMethod interface {
 	trialClosed(ctx context, requestID RequestID) ([]Operation, error)
 	// progress returns experiment progress as a float between 0.0 and 1.0.
 	progress(workloadsCompleted int) float64
+	// trialExitedEarly informs the searcher that the trial has exited earlier than expected
+	trialExitedEarly(ctx context, requestID RequestID, message Workload) ([]Operation, error)
 }
 
 // NewSearchMethod returns a new search method for the provided searcher configuration.
@@ -88,4 +90,9 @@ func (defaultSearchMethod) validationCompleted(
 }
 func (defaultSearchMethod) trialClosed(context, RequestID) ([]Operation, error) {
 	return nil, nil
+}
+
+func (defaultSearchMethod) trialExitedEarly( //nolint: unused
+	ctx context, requestID RequestID, message Workload) ([]Operation, error) {
+	return []Operation{Shutdown{Failure: true}}, nil
 }

--- a/master/pkg/searcher/tournament.go
+++ b/master/pkg/searcher/tournament.go
@@ -69,6 +69,14 @@ func (s *tournamentSearch) trialClosed(ctx context, requestID RequestID) ([]Oper
 	return s.markCreates(subSearch, ops), err
 }
 
+func (s *tournamentSearch) trialExitedEarly(
+	ctx context, requestID RequestID, message Workload,
+) ([]Operation, error) {
+	subSearch := s.trialTable[requestID]
+	ops, err := subSearch.trialExitedEarly(ctx, requestID, message)
+	return s.markCreates(subSearch, ops), err
+}
+
 // progress returns experiment progress as a float between 0.0 and 1.0.
 func (s *tournamentSearch) progress(int) float64 {
 	sum := 0.0


### PR DESCRIPTION
## Description
We now support trials erroring without closing the experiment. The
behavior for how this is left up to each search method, and is handled
strictly internal to the search method. This means that any mocked
metrics are not saved in the db or exposed to the user.

  - Random: No further action is needed.
  - Grid: No further action is needed.
  - ASHA-based: Treat the trials as having a MaxFloat64 validation
    metric. Mock promotions and ensure that no further workloads are sent
    to the experiment.
  - PBT: treat the trials as having a MaxFloat64 validation metric.
    Ensure that no further workloads are sent to the experiment, and we
    do not create new trials based on the completed workload.

As part of this work, we have introduced a flag to the shutdown message
that indicates to the experiment whether the searcher has failed.
The current method that we use is we check that no trials
have exited early, which works for all search methods.

## Test Plan

- [x] unit tests for each search method
- [x] 5+ `adaptive_simple` examples, manually calling `det t kill` on trials. Verify completed experiment.
- [x] 1+ `random` examples, manually calling `det t kill` on trials. Verify completed experiment.
- [x] 1+ `grid` examples, manually calling `det t kill` on trials. Verify completed experiment.
- [x] 1+ single example, manually calling `det t kill` on it. Verify errors the experiment.
- [x] 3+ manual runs of `e2e_tests/tests/fixture/no_op/adaptive_chaos.yaml` with low max_restarts (0 and 1). Verified we error when all trials are errored.
- [x] 1+ searcher reload test with adaptive_chaos, verified that the experiment hits the expected number of trials and errors when all the trials error. Verified that we replay our searcher events as expected
- [x] more searcher reload tests

## Commentary (optional)

> The current method that we use is we check that no trials have exited early, which works for all search methods.

This is a _slight_ deviation from what was discussed during the ERD review. As part of this work, it was clear that what we originally discussed of going based off of `max_steps` is not possible for methods like PBT (it's not part of the search logic). Instead we take a simple approach of checking that there exists a trial that did not exit early. This gets us like 90% of the way there without having to write a bunch of custom logic for each searcher. Briefly discussed with @seanr15 and he thought it made sense 👍 . 

<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

## Description

Lead with the intended commit body in this description field. For breaking changes, please include "BREAKING CHANGE:" at the beginning of your commit body. At minimum, this section should include a bracketed reference to the Jira ticket, e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.

## Test Plan

Describe the situations in which you've tested your change, and/or a screenshot as appropriate. Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.

## Commentary (optional)

Use this section of your description to add context to the PR. Could be for particularly tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc. You may intentionally leave this section blank and remove the title.
--->

[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234