### PR TITLE
fix: read docker config file from HOME directory

### DIFF
--- a/agent/internal/docker_credential_store.go
+++ b/agent/internal/docker_credential_store.go
@@ -42,8 +42,7 @@ func getAllCredentialStores() (map[string]*credentialStore, error) {
 		return credentialsStores, err
 	}
 
-    // #nosec: G304
-	configFile, err := os.Open(dockerConfigFile)
+	configFile, err := os.Open(dockerConfigFile) // #nosec: G304
 	if err != nil {
 		return credentialsStores, errors.Wrap(err, "can't open docker config")
 	}

--- a/agent/internal/docker_credential_store.go
+++ b/agent/internal/docker_credential_store.go
@@ -42,6 +42,7 @@ func getAllCredentialStores() (map[string]*credentialStore, error) {
 		return credentialsStores, err
 	}
 
+    // #nosec: G304
 	configFile, err := os.Open(dockerConfigFile)
 	if err != nil {
 		return credentialsStores, errors.Wrap(err, "can't open docker config")

--- a/agent/internal/docker_credential_store.go
+++ b/agent/internal/docker_credential_store.go
@@ -26,7 +26,7 @@ func getDockerConfigPath() (string, error) {
 	if err != nil {
 		return homeDir, errors.Wrap(err, "unable to find user's HOME directory")
 	}
-	return path.Join(homeDir, ".docker/config.json"), nil
+	return path.Join(homeDir, ".docker", "config.json"), nil
 }
 
 // getAllCredentialStores returns the credential helpers configured in the default docker


### PR DESCRIPTION
## Description

The path to the docker config file varies depending on location of HOME directory. When an agent was run somewhere where /root is not the HOME directory, this prevented using docker credential stores. 

## Test Plan

Manually tested that we are able to pull from GCR when running the agent outside of a container on Ubuntu.
