### PR TITLE
feat: use str instead of pathlib.Path in checkpoint callbacks

### DIFF
--- a/docs/reference/api/estimator.txt
+++ b/docs/reference/api/estimator.txt
@@ -68,8 +68,8 @@ Example usage of ``determined.estimator.RunHook`` which adds custom metadata che
             self._context = context
             self._metadata = metadata
 
-        def on_checkpoint_end(self, checkpoint_path) -> None:
-            with open(str(checkpoint_dir.joinpath("metadata.txt")), "w") as fp:
+        def on_checkpoint_end(self, checkpoint_dir) -> None:
+            with open(os.path.join(checkpoint_dir, "metadata.txt"), "w") as fp:
                 fp.write(self._metadata)
 
     class MyEstimatorTrial(determined.estimator.EstimatorTrial) -> None:

--- a/harness/determined/estimator/_callback.py
+++ b/harness/determined/estimator/_callback.py
@@ -1,5 +1,3 @@
-import pathlib
-
 import tensorflow as tf
 
 
@@ -14,14 +12,14 @@ class RunHook(tf.estimator.SessionRunHook):  # type: ignore
 
     """
 
-    def on_checkpoint_load(self, checkpoint_dir: pathlib.Path) -> None:
+    def on_checkpoint_load(self, checkpoint_dir: str) -> None:
         """
         Run at startup when the task environment starts up. If not resuming
         from checkpoint this is never called.
         """
         pass
 
-    def on_checkpoint_end(self, checkpoint_dir: pathlib.Path) -> None:
+    def on_checkpoint_end(self, checkpoint_dir: str) -> None:
         """
         Run after every checkpoint.
 

--- a/harness/determined/estimator/_estimator_trial.py
+++ b/harness/determined/estimator/_estimator_trial.py
@@ -220,7 +220,7 @@ class DeterminedControlHook(tf.estimator.SessionRunHook):  # type: ignore
 
         for callback in self.estimator_trial_controller.train_hooks:
             if isinstance(callback, estimator.RunHook):
-                callback.on_checkpoint_end(checkpoint_path)
+                callback.on_checkpoint_end(str(checkpoint_path))
 
         return {}
 
@@ -576,7 +576,7 @@ class EstimatorTrialController(det.LoopTrialController):
 
         for callback in self.train_hooks:
             if isinstance(callback, estimator.RunHook):
-                callback.on_checkpoint_load(self.load_path)
+                callback.on_checkpoint_load(str(self.load_path))
 
         self.estimator_dir = pathlib.Path(tempfile.mkdtemp(suffix=suffix))
         if self.estimator_dir.exists():

--- a/harness/determined/pytorch/_callback.py
+++ b/harness/determined/pytorch/_callback.py
@@ -1,4 +1,3 @@
-import pathlib
 from typing import Any, Dict
 
 
@@ -55,7 +54,7 @@ class PyTorchCallback:
         """
         pass
 
-    def on_checkpoint_end(self, checkpoint_dir: pathlib.Path) -> None:
+    def on_checkpoint_end(self, checkpoint_dir: str) -> None:
         """
         Run after every checkpoint.
 

--- a/harness/determined/pytorch/_pytorch_trial.py
+++ b/harness/determined/pytorch/_pytorch_trial.py
@@ -729,7 +729,7 @@ class PyTorchTrialController(det.LoopTrialController):
         )
 
         for callback in self.callbacks.values():
-            callback.on_checkpoint_end(path)
+            callback.on_checkpoint_end(str(path))
 
         return {}
 

--- a/harness/tests/experiment/fixtures/estimator_xor_model.py
+++ b/harness/tests/experiment/fixtures/estimator_xor_model.py
@@ -1,4 +1,4 @@
-import pathlib
+import os
 from typing import Any, Callable, Dict, Tuple, Union
 
 import tensorflow as tf
@@ -191,13 +191,13 @@ class CustomHook(estimator.RunHook):
     def __init__(self):
         self._num_checkpoints = 0
 
-    def on_checkpoint_load(self, checkpoint_dir: pathlib.Path) -> None:
-        with open(str(checkpoint_dir.joinpath("custom.log")), "r") as fp:
+    def on_checkpoint_load(self, checkpoint_dir: str) -> None:
+        with open(os.path.join(checkpoint_dir, "custom.log"), "r") as fp:
             self._num_checkpoints = int(fp.readline())
 
-    def on_checkpoint_end(self, checkpoint_dir: pathlib.Path) -> None:
+    def on_checkpoint_end(self, checkpoint_dir: str) -> None:
         self._num_checkpoints += 1
-        with open(str(checkpoint_dir.joinpath("custom.log")), "w") as fp:
+        with open(os.path.join(checkpoint_dir, "custom.log"), "w") as fp:
             fp.write(f"{self._num_checkpoints}")
 
 

--- a/harness/tests/experiment/fixtures/pytorch_xor_model.py
+++ b/harness/tests/experiment/fixtures/pytorch_xor_model.py
@@ -1,4 +1,3 @@
-import pathlib
 from typing import Any, Dict, cast
 
 import numpy as np
@@ -314,7 +313,7 @@ class Counter(det.pytorch.PyTorchCallback):
     def on_validation_step_end(self, metrics: Dict[str, Any]) -> None:
         self.validation_steps_ended += 1
 
-    def on_checkpoint_end(self, checkpoint_dir: pathlib.Path):
+    def on_checkpoint_end(self, checkpoint_dir: str):
         self.checkpoints_ended += 1
 
     def state_dict(self) -> Dict[str, Any]:


### PR DESCRIPTION
## Description
Updated docs and code to use `str` instead of `pathlib.Path`.


## Test Plan
Updated tests.