### PR TITLE
fix: avoid saving pytorch model architecture

### DIFF
--- a/harness/determined/pytorch/_pytorch_trial.py
+++ b/harness/determined/pytorch/_pytorch_trial.py
@@ -688,16 +688,6 @@ class PyTorchTrialController(det.LoopTrialController):
 
         path.mkdir(parents=True, exist_ok=True)
 
-        # The pickled_model_path is the entire nn.Module saved to a file via
-        # pickle. This model can be recovered using the det.pytorch.checkpoint.load
-        # method so long as the code is saved along with the pickled nn.Module.
-        # https://pytorch.org/docs/stable/notes/serialization.html#recommend-saving-models
-        pickled_model_path = path.joinpath("model.pth")
-
-        torch.save(  # type: ignore
-            self.context.model, pickled_model_path, pickle_module=cloudpickle
-        )
-
         # The model code is the current working directory.
         util.write_checkpoint_metadata(
             path,


### PR DESCRIPTION
## Description

In a previous iteration of checkpoint export, we used `torch.save()` to save the entire model architecture.  We had to switch to only loading weights to make checkpoint export more robust.

This change removes the now unnecessary `torch.save()` which was failing with the Native API and custom PyTorch layers.

## Test Plan

Tested manually.

## Commentary (optional)

TBH, I'm not 100% certain that the `torch.save()` is actually unnecessary.