### PR TITLE
test: create a test suite for examples

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -740,6 +740,7 @@ jobs:
       - run: make -C harness check
       - run: make -C deploy check
       - run: make -C e2e_tests check
+      - run: make -C examples check
 
   test-unit-harness:
     docker:
@@ -766,6 +767,19 @@ jobs:
           extra-requirements-file: "harness/tests/requirements.txt"
           executor: determinedai/cimg-base:stable
       - run: make -C harness test-tf2
+
+  test-examples:
+    docker:
+      - image: determinedai/cimg-base:stable
+    steps:
+      - checkout
+      - setup-python-venv:
+          determined-common: true
+          determined: true
+          determined-cli: true
+          extra-requirements-file: "examples/tests/requirements.txt"
+          executor: determinedai/cimg-base:stable
+      - run: make -C examples test
 
   test-cli:
     parameters:
@@ -981,6 +995,7 @@ workflows:
       - test-unit-react
       - test-unit-harness
       - test-unit-harness-tf2
+      - test-examples
 
   test-e2e:
     jobs:

--- a/Makefile
+++ b/Makefile
@@ -37,13 +37,13 @@ clean: clean-tools clean-common clean-harness clean-cli clean-deploy clean-examp
 check-%:
 	$(MAKE) -C $(subst -,/,$*) check
 .PHONY: check
-check: check-common check-harness check-cli check-deploy check-e2e_tests check-master check-agent check-webui
+check: check-common check-harness check-cli check-deploy check-e2e_tests check-master check-agent check-webui check-examples
 
 .PHONY: fmt-%
 fmt-%:
 	$(MAKE) -C $(subst -,/,$*) fmt
 .PHONY: fmt
-fmt: fmt-common fmt-harness fmt-cli fmt-deploy fmt-e2e_tests fmt-master fmt-agent fmt-webui
+fmt: fmt-common fmt-harness fmt-cli fmt-deploy fmt-e2e_tests fmt-master fmt-agent fmt-webui fmt-examples
 
 .PHONY: test-%
 test-%:

--- a/e2e_tests/tests/experiment/test_pytorch.py
+++ b/e2e_tests/tests/experiment/test_pytorch.py
@@ -115,26 +115,6 @@ def test_pytorch_const_with_amp() -> None:
     exp.run_basic_test_with_temp_config(config, conf.official_examples_path("mnist_pytorch"), 1)
 
 
-@pytest.mark.e2e_gpu  # type: ignore
-def test_pytorch_cifar10_const() -> None:
-    config = conf.load_config(conf.official_examples_path("cifar10_cnn_pytorch/const.yaml"))
-    config = conf.set_max_steps(config, 2)
-
-    experiment_id = exp.run_basic_test_with_temp_config(
-        config, conf.official_examples_path("cifar10_cnn_pytorch"), 1
-    )
-    trials = exp.experiment_trials(experiment_id)
-
-    nn = (
-        Determined(conf.make_master_url())
-        .get_trial(trials[0]["id"])
-        .select_checkpoint(latest=True)
-        .load()
-    )
-
-    assert isinstance(nn, torch.nn.Module)
-
-
 @pytest.mark.parallel  # type: ignore
 def test_pytorch_cifar10_parallel() -> None:
     config = conf.load_config(conf.official_examples_path("cifar10_cnn_pytorch/const.yaml"))

--- a/e2e_tests/tests/experiment/test_tf_keras.py
+++ b/e2e_tests/tests/experiment/test_tf_keras.py
@@ -1,6 +1,5 @@
 import pytest
 
-from determined.experimental import Determined
 from tests import config as conf
 from tests import experiment as exp
 
@@ -11,39 +10,6 @@ def test_tf_keras_native_parallel(tf2: bool) -> None:
     config = conf.load_config(conf.official_examples_path("cifar10_cnn_tf_keras/const.yaml"))
     config = conf.set_slots_per_trial(config, 8)
     config = conf.set_native_parallel(config, True)
-    config = conf.set_max_steps(config, 2)
-    config = conf.set_tf2_image(config) if tf2 else conf.set_tf1_image(config)
-
-    experiment_id = exp.run_basic_test_with_temp_config(
-        config, conf.official_examples_path("cifar10_cnn_tf_keras"), 1
-    )
-    trials = exp.experiment_trials(experiment_id)
-    assert len(trials) == 1
-
-
-@pytest.mark.parallel  # type: ignore
-@pytest.mark.parametrize("aggregation_frequency", [1, 4])  # type: ignore
-@pytest.mark.parametrize("tf2", [False, True])  # type: ignore
-def test_tf_keras_parallel(aggregation_frequency: int, tf2: bool) -> None:
-    config = conf.load_config(conf.official_examples_path("cifar10_cnn_tf_keras/const.yaml"))
-    config = conf.set_slots_per_trial(config, 8)
-    config = conf.set_native_parallel(config, False)
-    config = conf.set_max_steps(config, 2)
-    config = conf.set_aggregation_frequency(config, aggregation_frequency)
-    config = conf.set_tf2_image(config) if tf2 else conf.set_tf1_image(config)
-
-    experiment_id = exp.run_basic_test_with_temp_config(
-        config, conf.official_examples_path("cifar10_cnn_tf_keras"), 1
-    )
-    trials = exp.experiment_trials(experiment_id)
-    assert len(trials) == 1
-
-
-@pytest.mark.e2e_gpu  # type: ignore
-@pytest.mark.parametrize("tf2", [True, False])  # type: ignore
-def test_tf_keras_single_gpu(tf2: bool) -> None:
-    config = conf.load_config(conf.official_examples_path("cifar10_cnn_tf_keras/const.yaml"))
-    config = conf.set_slots_per_trial(config, 1)
     config = conf.set_max_steps(config, 2)
     config = conf.set_tf2_image(config) if tf2 else conf.set_tf1_image(config)
 
@@ -92,17 +58,37 @@ def test_tf_keras_const_warm_start(tf2: bool) -> None:
         assert trial["warm_start_checkpoint_id"] == first_checkpoint_id
 
 
-@pytest.mark.e2e_gpu  # type: ignore
-def test_iris() -> None:
-    config = conf.load_config(conf.official_examples_path("iris_tf_keras/const.yaml"))
+@pytest.mark.parallel  # type: ignore
+@pytest.mark.parametrize("aggregation_frequency", [1, 4])  # type: ignore
+@pytest.mark.parametrize("tf2", [False, True])  # type: ignore
+def test_tf_keras_parallel(aggregation_frequency: int, tf2: bool) -> None:
+    config = conf.load_config(conf.official_examples_path("cifar10_cnn_tf_keras/const.yaml"))
+    config = conf.set_slots_per_trial(config, 8)
+    config = conf.set_native_parallel(config, False)
     config = conf.set_max_steps(config, 2)
+    config = conf.set_aggregation_frequency(config, aggregation_frequency)
+    config = conf.set_tf2_image(config) if tf2 else conf.set_tf1_image(config)
 
-    exp_id = exp.run_basic_test_with_temp_config(
-        config, conf.official_examples_path("iris_tf_keras"), 1
+    experiment_id = exp.run_basic_test_with_temp_config(
+        config, conf.official_examples_path("cifar10_cnn_tf_keras"), 1
     )
-    exp_ref = Determined(conf.make_master_url()).get_experiment(exp_id)
-    model = exp_ref.top_checkpoint().load()
-    model.summary()
+    trials = exp.experiment_trials(experiment_id)
+    assert len(trials) == 1
+
+
+@pytest.mark.e2e_gpu  # type: ignore
+@pytest.mark.parametrize("tf2", [True, False])  # type: ignore
+def test_tf_keras_single_gpu(tf2: bool) -> None:
+    config = conf.load_config(conf.official_examples_path("cifar10_cnn_tf_keras/const.yaml"))
+    config = conf.set_slots_per_trial(config, 1)
+    config = conf.set_max_steps(config, 2)
+    config = conf.set_tf2_image(config) if tf2 else conf.set_tf1_image(config)
+
+    experiment_id = exp.run_basic_test_with_temp_config(
+        config, conf.official_examples_path("cifar10_cnn_tf_keras"), 1
+    )
+    trials = exp.experiment_trials(experiment_id)
+    assert len(trials) == 1
 
 
 @pytest.mark.parallel  # type: ignore

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -11,5 +11,8 @@ build/%.tgz: official/%/
 	mkdir -p $$(dirname "$@")
 	tar -czf "$@" -C $$(dirname "$<") $$(basename "$<")
 
+test:
+	pytest -vv -s --durations=0 tests
+
 .PHONY: build
 build: $(EXAMPLES_DIRS)

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -14,5 +14,11 @@ build/%.tgz: official/%/
 test:
 	pytest -vv -s --durations=0 tests
 
+fmt:
+	make -C tests fmt
+
+check:
+	make -C tests check
+
 .PHONY: build
 build: $(EXAMPLES_DIRS)

--- a/examples/tests/.flake8
+++ b/examples/tests/.flake8
@@ -1,0 +1,38 @@
+[flake8]
+max-line-length = 100
+
+# We ignore F401 in __init__.py because it is expected for there to be
+# "unused imports" when defining a "regular" package. (This file is
+# implicitly executed when the package is imported, and the imports would
+# be used by the importer.) We ignore patch_saver_restore.py because it includes
+# a near-verbatim TensorFlow function with a small patch.
+per-file-ignores = __init__.py:F401 patch_saver_restore.py:E111,E114,
+
+# Explanations for ignored error codes:
+# - D1* (no missing docstrings): too much effort to start enforcing
+# - D200 (short docstring must fit in one line with quotes): stylistic choice
+# - D202 (no blank lines after function docstrings): stylistic choice
+# - D203 (blank line before class docstring): stylistic choice
+# - D205 (blank line between summary and description): not enforcing single-line summaries
+# - D212 (docstring should start on first line): stylistic choice (prefer D213, docstrings start on second line)
+# - D4* (docstring content warnings): too much effort to start enforcing
+# - E203 (no space before colon): not PEP8-compliant; triggered by Black-formatted code
+# - W503 (no line breaks before binary operator): not PEP8-compliant; triggered by Black-formatted code
+# - C812-C816 (missing trailing comma): stylistic choice
+ignore = D1,D200,D202,D203,D205,D212,D4,E203,W503,C812,C813,C814,C815,C816
+
+show_source = true
+
+# flake8-colors
+format = ${cyan}%(path)s${reset}:${yellow_bold}%(row)d${reset}:${green_bold}%(col)d${reset}: ${red_bold}%(code)s${reset} %(text)s
+
+# flake8-docstrings
+docstring-convention = google
+
+# flake8-import-order
+application-import-names = determined
+import-order-style = edited
+
+# flake8-quotes
+inline-quotes = "
+multiline-quotes = """

--- a/examples/tests/.isort.cfg
+++ b/examples/tests/.isort.cfg
@@ -1,0 +1,10 @@
+[settings]
+skip_glob = **/__init__.py
+default_section = THIRDPARTY
+known_first_party = determined,determined_common,determined_deploy,determined_cli,tests
+known_third_party = packaging
+multi_line_output = 3
+include_trailing_comma = true
+force_grid_wrap = 0
+use_parentheses = true
+line_length = 100

--- a/examples/tests/Makefile
+++ b/examples/tests/Makefile
@@ -1,0 +1,10 @@
+.PHONY: fmt check
+
+fmt:
+	isort
+	black .
+
+check:
+	isort --check-only
+	black . --check
+	flake8

--- a/examples/tests/requirements.txt
+++ b/examples/tests/requirements.txt
@@ -1,3 +1,4 @@
+pytest
 tensorflow==2.2.0
 torch==1.4.0
 torchvision==0.5.0

--- a/examples/tests/requirements.txt
+++ b/examples/tests/requirements.txt
@@ -1,0 +1,4 @@
+tensorflow==2.2.0
+torch==1.4.0
+torchvision==0.5.0
+pandas==1.0.3

--- a/examples/tests/test_official.py
+++ b/examples/tests/test_official.py
@@ -1,11 +1,7 @@
-import os
 import pathlib
-import pytest
 import subprocess
-from ruamel import yaml
 
-from determined import experimental, load
-
+import pytest
 
 official_examples = [
     ("official/cifar10_cnn_pytorch", "official/cifar10_cnn_pytorch/const.yaml"),
@@ -14,8 +10,10 @@ official_examples = [
     ("official/iris_tf_keras", "official/iris_tf_keras/const.yaml"),
     ("official/mnist_estimator", "official/mnist_estimator/const.yaml"),
     ("official/mnist_pytorch", "official/mnist_pytorch/const.yaml"),
-    ("official/multiple_lr_schedulers_pytorch", "official/multiple_lr_schedulers_pytorch/const.yaml"),
-
+    (
+        "official/multiple_lr_schedulers_pytorch",
+        "official/multiple_lr_schedulers_pytorch/const.yaml",
+    ),
     # TODO(DET-2931): A full validation step in this example is too expensive
     # to run this test in under a few minutes. Add it back in once we can test
     # a single batch of validation.
@@ -30,4 +28,13 @@ def test_official(model_def: str, config_file: str) -> None:
     config_file_absolute = examples_dir.joinpath(config_file)
 
     subprocess.check_output(
-        ("det", "experiment", "create", "--local", "--test", str(config_file_absolute), str(model_def_absolute)))
+        (
+            "det",
+            "experiment",
+            "create",
+            "--local",
+            "--test",
+            str(config_file_absolute),
+            str(model_def_absolute),
+        )
+    )

--- a/examples/tests/test_official.py
+++ b/examples/tests/test_official.py
@@ -1,0 +1,33 @@
+import os
+import pathlib
+import pytest
+import subprocess
+from ruamel import yaml
+
+from determined import experimental, load
+
+
+official_examples = [
+    ("official/cifar10_cnn_pytorch", "official/cifar10_cnn_pytorch/const.yaml"),
+    ("official/cifar10_cnn_tf_keras", "official/cifar10_cnn_tf_keras/const.yaml"),
+    ("official/fashion_mnist_tf_keras", "official/fashion_mnist_tf_keras/const.yaml"),
+    ("official/iris_tf_keras", "official/iris_tf_keras/const.yaml"),
+    ("official/mnist_estimator", "official/mnist_estimator/const.yaml"),
+    ("official/mnist_pytorch", "official/mnist_pytorch/const.yaml"),
+    ("official/multiple_lr_schedulers_pytorch", "official/multiple_lr_schedulers_pytorch/const.yaml"),
+
+    # TODO(DET-2931): A full validation step in this example is too expensive
+    # to run this test in under a few minutes. Add it back in once we can test
+    # a single batch of validation.
+    # ("official/object_detection_pytorch", "official/object_detection_pytorch/const.yaml"),
+]
+
+
+@pytest.mark.parametrize("model_def,config_file", official_examples)
+def test_official(model_def: str, config_file: str) -> None:
+    examples_dir = pathlib.Path(__file__).parent.parent
+    model_def_absolute = examples_dir.joinpath(model_def)
+    config_file_absolute = examples_dir.joinpath(config_file)
+
+    subprocess.check_output(
+        ("det", "experiment", "create", "--local", "--test", str(config_file_absolute), str(model_def_absolute)))

--- a/harness/determined/experimental/_native.py
+++ b/harness/determined/experimental/_native.py
@@ -415,7 +415,6 @@ def init_native(
         if not test:
             logging.warn("local training is not supported, testing instead")
 
-        print(pathlib.Path(context_dir).resolve())
         with _local_execution_manager(pathlib.Path(context_dir).resolve()):
             return test_one_batch(
                 controller_cls=controller_cls,

--- a/harness/tests/experiment/pytorch/test_pytorch_trial.py
+++ b/harness/tests/experiment/pytorch/test_pytorch_trial.py
@@ -3,10 +3,9 @@ import typing
 
 import pytest
 import torch
-from ruamel import yaml
 
 import determined as det
-from determined import experimental, workload
+from determined import workload
 from determined_common import check
 from tests.experiment import utils  # noqa: I100
 from tests.experiment.fixtures import pytorch_xor_model
@@ -393,18 +392,6 @@ class TestPyTorchTrial:
             trial_seed=self.trial_seed,
         )
         controller.run()
-
-    def test_multi_lr_schedule_one_batch(self, tmp_path: pathlib.Path) -> None:
-        example_path = "../examples/official/multiple_lr_schedulers_pytorch"
-        yaml_file = "const.yaml"
-
-        with experimental._local_execution_manager(pathlib.Path(example_path)):
-            from multiple_lr_schedulers_pytorch import MNistTrial
-
-            with open(yaml_file) as f:
-                configs = yaml.safe_load(f.read())
-
-            experimental.test_one_batch(trial_class=MNistTrial, config=configs)
 
     def test_grad_clipping(self) -> None:
         training_metrics = {}


### PR DESCRIPTION
## Description
This PR creates a test suite associated with `examples`. It runs a minimal test on each example using `--local --test` mode. It is slightly more heavyweight than our unit tests since every example runs in a separate Python process, but more portable than full integration tests since no Determined cluster is required.

Run-time on my local macbook pro is 1 minute 42 seconds:

```
41.38s call     test_examples.py::test_official[official/cifar10_cnn_tf_keras-official/cifar10_cnn_tf_keras/const.yaml]
22.36s call     test_examples.py::test_official[official/cifar10_cnn_pytorch-official/cifar10_cnn_pytorch/const.yaml]
9.46s call     test_examples.py::test_official[official/multiple_lr_schedulers_pytorch-official/multiple_lr_schedulers_pytorch/const.yaml]
9.39s call     test_examples.py::test_official[official/mnist_pytorch-official/mnist_pytorch/const.yaml]
8.35s call     test_examples.py::test_official[official/mnist_estimator-official/mnist_estimator/const.yaml]
6.80s call     test_examples.py::test_official[official/fashion_mnist_tf_keras-official/fashion_mnist_tf_keras/const.yaml]
4.51s call     test_examples.py::test_official[official/iris_tf_keras-official/iris_tf_keras/const.yaml]
```

The runtime can likely further be improved by further optimizing `--local --test` mode with https://determinedai.atlassian.net/browse/DET-2931 

[DET-3110](https://determinedai.atlassian.net/browse/DET-3110)
[DET-2952](https://determinedai.atlassian.net/browse/DET-2952)


## Test Plan
N/A

## Commentary (optional)
I had initially aimed to set-up these as unit tests running sequentially in a single Python process with `test_one_batch`. However, I hit some problems with conflicting module namespaces in examples -- for example, `fashion_mnist_tf_keras` and `mnist_pytorch` have a `data.py` module they import in their entrypoint module with `import data`. When executed sequentially in a single Python process, the second time `import data` is called it still uses the initial `data` module and fails. I figured it would be easier to execute each model definition in a separate process instead of removing this restriction or hacking the Python module namespace in some way. 

<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

## Description

Lead with the intended commit body in this description field. For breaking changes, please include "BREAKING CHANGE:" at the beginning of your commit body. At minimum, this section should include a bracketed reference to the Jira ticket, e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.

## Test Plan

Describe the situations in which you've tested your change, and/or a screenshot as appropriate. Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.

## Commentary (optional)

Use this section of your description to add context to the PR. Could be for particularly tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc. You may intentionally leave this section blank and remove the title.
--->

[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234