### PR TITLE
feat: make GCP operation tracker timeout configuration [DET-3182]

### DIFF
--- a/deploy/determined_deploy/gcp/cli.py
+++ b/deploy/determined_deploy/gcp/cli.py
@@ -88,6 +88,12 @@ def make_up_subparser(subparsers: argparse._SubParsersAction) -> None:
         help="whether to use preemptible instances for agents",
     )
     optional_named.add_argument(
+        "--operation-timeout-period",
+        type=str,
+        default=constants.defaults.OPERATION_TIMEOUT_PERIOD,
+        help="operation timeout before retrying, e.g. 5m for 5 minutes",
+    )
+    optional_named.add_argument(
         "--master-instance-type",
         type=str,
         default=constants.defaults.MASTER_INSTANCE_TYPE,

--- a/deploy/determined_deploy/gcp/constants.py
+++ b/deploy/determined_deploy/gcp/constants.py
@@ -7,6 +7,7 @@ class defaults:
     GPU_TYPE = "nvidia-tesla-k80"
     MASTER_INSTANCE_TYPE = "n1-standard-2"
     MAX_IDLE_AGENT_PERIOD = "10m"
+    OPERATION_TIMEOUT_PERIOD = "5m"
     MAX_DYNAMIC_AGENTS = 5
     STATIC_AGENTS = 0
     MIN_CPU_PLATFORM_MASTER = "Intel Skylake"

--- a/deploy/determined_deploy/gcp/terraform/main.tf
+++ b/deploy/determined_deploy/gcp/terraform/main.tf
@@ -132,6 +132,7 @@ module "compute" {
   min_cpu_platform_master = var.min_cpu_platform_master
   min_cpu_platform_agent = var.min_cpu_platform_agent
   preemptible = var.preemptible
+  operation_timeout_period = var.operation_timeout_period
   db_username = var.db_username
   db_password = var.db_password
 

--- a/deploy/determined_deploy/gcp/terraform/modules/compute/main.tf
+++ b/deploy/determined_deploy/gcp/terraform/modules/compute/main.tf
@@ -59,6 +59,7 @@ resource "google_compute_instance" "master_instance" {
         gpu_num: ${var.gpu_num}
         preemptible: ${var.preemptible}
       max_instances: ${var.max_dynamic_agents}
+      operation_timeout_period: ${var.operation_timeout_period}
       base_config:
         minCpuPlatform: ${var.min_cpu_platform_agent}
     EOF

--- a/deploy/determined_deploy/gcp/terraform/modules/compute/variables.tf
+++ b/deploy/determined_deploy/gcp/terraform/modules/compute/variables.tf
@@ -67,6 +67,9 @@ variable "static_agents" {
 variable "preemptible" {
 }
 
+variable "operation_timeout_period" {
+}
+
 variable "gcs_bucket" {
 }
 

--- a/deploy/determined_deploy/gcp/terraform/variables.tf
+++ b/deploy/determined_deploy/gcp/terraform/variables.tf
@@ -85,6 +85,11 @@ variable "preemptible" {
   default = false
 }
 
+variable "operation_timeout_period" {
+  type = string
+  default = "5m"
+}
+
 variable "agent_docker_network" {
   type = string
   default = "host"

--- a/docs/reference/cluster-config.txt
+++ b/docs/reference/cluster-config.txt
@@ -421,6 +421,11 @@ The master supports the following configuration settings:
     - ``max_instances``: Max number of Determined agent instances. Defaults
       to 5.
 
+    - ``operation_timeout_period``: The timeout period for tracking a GCP
+      operation. This string is a sequence of decimal numbers, each
+      with optional fraction and a unit suffix, such as "30s", "1h", or
+      "1m30s". Valid time units are "s", "m", "h". The default value is ``5m``.
+
 - ``checkpoint_storage``: Specifies where model checkpoints will be
   stored. This can be overridden on a per-experiment basis in the
   :ref:`experiment-configuration`. A checkpoint contains the

--- a/docs/topic-guides/elastic-infra/dynamic-agents-gcp.txt
+++ b/docs/topic-guides/elastic-infra/dynamic-agents-gcp.txt
@@ -129,6 +129,7 @@ an example configuration. See :ref:`cluster-configuration` for details.
        gpu_num: 4
        preemptible: false
      max_instances: 5
+     operation_timeout_period: 5m
 
 .. _gcp-attach-disk:
 

--- a/master/internal/provisioner/gcp_config.go
+++ b/master/internal/provisioner/gcp_config.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"time"
 
 	"cloud.google.com/go/compute/metadata"
 	"github.com/pkg/errors"
@@ -40,6 +41,8 @@ type GCPClusterConfig struct {
 
 	InstanceType gceInstanceType `json:"instance_type"`
 	MaxInstances int             `json:"max_instances"`
+
+	OperationTimeoutPeriod Duration `json:"operation_timeout_period"`
 }
 
 // DefaultGCPClusterConfig returns the default configuration of the gcp cluster.
@@ -52,7 +55,8 @@ func DefaultGCPClusterConfig() *GCPClusterConfig {
 			GPUType:     "nvidia-tesla-v100",
 			GPUNum:      4,
 		},
-		MaxInstances: 5,
+		MaxInstances:           5,
+		OperationTimeoutPeriod: Duration(5 * time.Minute),
 	}
 }
 

--- a/master/internal/provisioner/gcp_config_test.go
+++ b/master/internal/provisioner/gcp_config_test.go
@@ -3,6 +3,7 @@ package provisioner
 import (
 	"encoding/json"
 	"testing"
+	"time"
 
 	"gotest.tools/assert"
 
@@ -53,7 +54,8 @@ func TestUnmarshalGCPClusterConfig(t *testing.T) {
 		"gpu_type": "nvidia-tesla-v100",
 		"gpu_num": 2
 	},
-	"max_instances": 100
+	"max_instances": 100,
+	"operation_timeout_period": "5m"
 }`,
 		unmarshaled: GCPClusterConfig{
 			Project:             "test-project",
@@ -78,7 +80,8 @@ func TestUnmarshalGCPClusterConfig(t *testing.T) {
 				GPUType:     "nvidia-tesla-v100",
 				GPUNum:      2,
 			},
-			MaxInstances: 100,
+			MaxInstances:           100,
+			OperationTimeoutPeriod: Duration(5 * time.Minute),
 		},
 	}
 

--- a/master/packaging/master.yaml
+++ b/master/packaging/master.yaml
@@ -85,6 +85,7 @@
 #    gpu_type: nvidia-tesla-v100
 #    gpu_num: 4
 #  max_instances: 5
+#  operation_timeout_period: 5m
 
 
 ## Configure default checkpoint storage configuration.


### PR DESCRIPTION
## Description

When creating or terminating an instance, the GCP provider sends a request to the GCP API and the response will be a GCP operation. By tracking the GCP operation, we are able to know if the instance is successfully created/terminated. There is a timeout before we consider a GCP operation no longer effective and we might retry after hitting the timeout. This PR intends to make that timeout period configurable. This PR changes the code and the doc relates to it.

[DET-3182](https://determinedai.atlassian.net/browse/DET-3182)

## Test Plan

Manually test it with the following provisioner config and see if the timeout is configurable:
```
provisioner:
  agent_docker_network: host
  agent_docker_image: determinedai/determined-dev:determined-agent-d90294d941964f104b50204232002fa551daa648
  max_idle_agent_period: 1m
  **operation_timeout_period: 10s**
  provider: gcp
  boot_disk_size: 200
  boot_disk_source_image: projects/determined-ai/global/images/pedl-environments-4e98289
  network_interface:
    network: projects/determined-ai/global/networks/default
    subnetwork: projects/determined-ai/regions/us-central1/subnetworks/default
    external_ip: false
  instance_type:
    machine_type: n1-standard-8
    gpu_type: nvidia-tesla-v100
    gpu_num: 2
    preemptible: false
  max_instances: 2
```