### PR TITLE
fix: correct logic for checking if a validation is the best one seen

### DIFF
--- a/master/internal/experiment.go
+++ b/master/internal/experiment.go
@@ -459,19 +459,14 @@ func (e *experiment) isBestValidation(msg searcher.CompletedMessage) bool {
 		// TODO: Better error handling here.
 		return false
 	}
-	if e.bestValidation == nil {
-		e.bestValidation = &validation
-		return true
-	}
 	smallerIsBetter := e.Config.Searcher.SmallerIsBetter
-	if smallerIsBetter && validation < *e.bestValidation {
+	isBest := (e.bestValidation == nil) ||
+		(smallerIsBetter && validation < *e.bestValidation) ||
+		(!smallerIsBetter && validation > *e.bestValidation)
+	if isBest {
 		e.bestValidation = &validation
-		return true
-	} else if validation > *e.bestValidation {
-		e.bestValidation = &validation
-		return true
 	}
-	return false
+	return isBest
 }
 
 func (e *experiment) updateState(ctx *actor.Context, state model.State) {

--- a/master/internal/experiment_test.go
+++ b/master/internal/experiment_test.go
@@ -1,0 +1,51 @@
+package internal
+
+import (
+	"testing"
+
+	"gotest.tools/assert"
+
+	"github.com/determined-ai/determined/master/pkg/model"
+	"github.com/determined-ai/determined/master/pkg/searcher"
+)
+
+type metricCase struct {
+	value  float64
+	isBest bool
+}
+
+func testBestValidationCase(t *testing.T, smallerIsBetter bool, metrics []metricCase) {
+	exp := &experiment{
+		Experiment: &model.Experiment{
+			Config: model.ExperimentConfig{
+				Searcher: model.SearcherConfig{
+					Metric:          "metric",
+					SmallerIsBetter: smallerIsBetter,
+				},
+			},
+		},
+	}
+
+	for _, metric := range metrics {
+		msg := searcher.CompletedMessage{
+			ValidationMetrics: &searcher.ValidationMetrics{
+				Metrics: map[string]interface{}{"metric": metric.value},
+			},
+		}
+		isBest := exp.isBestValidation(msg)
+		assert.Equal(t, metric.isBest, isBest, "failed on metric value %f", metric.value)
+	}
+}
+
+func TestBestValidation(t *testing.T) {
+	testBestValidationCase(
+		t,
+		true,
+		[]metricCase{{5, true}, {9, false}, {4, true}, {10, false}, {7, false}, {3, true}},
+	)
+	testBestValidationCase(
+		t,
+		false,
+		[]metricCase{{5, true}, {9, true}, {4, false}, {10, true}, {7, false}, {3, false}},
+	)
+}


### PR DESCRIPTION
## Description

Previously, every validation would be marked as the best one seen when `smallerIsBetter` was true. The new version avoids that and also separates the code a bit more cleanly into "decide whether the validation is best" followed by "do things accordingly".

## Test Plan

- [x] write a new test that failed with the old code and passes with the new code
- [x] run an experiment with `checkpoint_policy: best`, `smaller_is_better: true`, `min_validation_period: 1`, and no `min_checkpoint_period`; check that checkpoints are taken when appropriate rather than after every validation
