### PR TITLE
feat: decouple container logs from agents [DET-3175]

### DIFF
--- a/master/internal/agent/agent.go
+++ b/master/internal/agent/agent.go
@@ -133,7 +133,14 @@ func (a *agent) handleIncomingWSMessage(ctx *actor.Context, msg aproto.MasterMes
 			// be dead so we ignore the logs.
 			break
 		}
-		ctx.Tell(ref, *msg.ContainerLog)
+
+		ctx.Tell(ref, scheduler.ContainerLog{
+			Container:   msg.ContainerLog.Container,
+			Timestamp:   msg.ContainerLog.Timestamp,
+			PullMessage: msg.ContainerLog.PullMessage,
+			RunMessage:  msg.ContainerLog.RunMessage,
+			AuxMessage:  msg.ContainerLog.AuxMessage,
+		})
 	default:
 		check.Panic(errors.Errorf("error parsing incoming message"))
 	}

--- a/master/internal/checkpoint_gc.go
+++ b/master/internal/checkpoint_gc.go
@@ -20,7 +20,7 @@ type checkpointGCTask struct {
 	agentUserGroup *model.AgentUserGroup
 
 	// TODO (DET-789): Set up proper log handling for checkpoint GC.
-	logs []agent.ContainerLog
+	logs []scheduler.ContainerLog
 }
 
 func (t *checkpointGCTask) Receive(ctx *actor.Context) error {
@@ -69,7 +69,7 @@ func (t *checkpointGCTask) Receive(ctx *actor.Context) error {
 		}
 		ctx.Self().Stop()
 
-	case agent.ContainerLog:
+	case scheduler.ContainerLog:
 		t.logs = append(t.logs, msg)
 
 	case scheduler.TerminateRequest:

--- a/master/internal/command/command.go
+++ b/master/internal/command/command.go
@@ -25,7 +25,7 @@ const containerLostDuration = 5 * time.Minute
 
 // TODO: readinessCheck should be defined at the agent level. Temporarily we will use log
 // messages as a proxy.
-type readinessCheck func(agent.ContainerLog) bool
+type readinessCheck func(scheduler.ContainerLog) bool
 
 // terminateForGC is an internal message indicating that the command actor
 // should stop and garbage collect its state.
@@ -158,7 +158,7 @@ func (c *command) Receive(ctx *actor.Context) error {
 	case scheduler.TaskTerminated:
 		// This message is being deprecated; ignore it.
 
-	case agent.ContainerLog:
+	case scheduler.ContainerLog:
 		if !c.readinessMessageSent && c.readinessChecksPass(ctx, msg) {
 			c.readinessMessageSent = true
 			ctx.Tell(c.eventStream, event{Snapshot: newSummary(c), ServiceReadyEvent: &msg})
@@ -210,7 +210,7 @@ func (c *command) terminate(ctx *actor.Context) {
 	}
 }
 
-func (c *command) readinessChecksPass(ctx *actor.Context, log agent.ContainerLog) bool {
+func (c *command) readinessChecksPass(ctx *actor.Context, log scheduler.ContainerLog) bool {
 	for name, check := range c.readinessChecks {
 		if check(log) {
 			delete(c.readinessChecks, name)

--- a/master/internal/command/events.go
+++ b/master/internal/command/events.go
@@ -13,7 +13,6 @@ import (
 	"github.com/determined-ai/determined/master/internal/scheduler"
 	"github.com/determined-ai/determined/master/pkg/actor"
 	"github.com/determined-ai/determined/master/pkg/actor/api"
-	"github.com/determined-ai/determined/master/pkg/agent"
 	"github.com/determined-ai/determined/master/pkg/check"
 )
 
@@ -34,7 +33,7 @@ type event struct {
 	ContainerStartedEvent *scheduler.ContainerStarted `json:"container_started_event"`
 	// ServiceReadyEvent is triggered when the service running in the container is ready to serve.
 	// TODO: Move to ServiceReadyEvent type to a specialized event with readiness checks.
-	ServiceReadyEvent *agent.ContainerLog `json:"service_ready_event"`
+	ServiceReadyEvent *scheduler.ContainerLog `json:"service_ready_event"`
 	// TerminateRequestEvent is triggered when the scheduler has requested the container to
 	// terminate.
 	TerminateRequestEvent *scheduler.TerminateRequest `json:"terminate_request_event"`

--- a/master/internal/command/notebook_manager.go
+++ b/master/internal/command/notebook_manager.go
@@ -14,7 +14,6 @@ import (
 	"github.com/determined-ai/determined/master/internal/db"
 	"github.com/determined-ai/determined/master/internal/scheduler"
 	"github.com/determined-ai/determined/master/pkg/actor"
-	"github.com/determined-ai/determined/master/pkg/agent"
 	"github.com/determined-ai/determined/master/pkg/archive"
 	"github.com/determined-ai/determined/master/pkg/check"
 	"github.com/determined-ai/determined/master/pkg/etc"
@@ -209,7 +208,7 @@ func (n *notebookManager) newNotebook(req *commandRequest) (*command, error) {
 		},
 
 		readinessChecks: map[string]readinessCheck{
-			"notebook": func(log agent.ContainerLog) bool {
+			"notebook": func(log scheduler.ContainerLog) bool {
 				return strings.Contains(log.String(), "Jupyter Notebook is running")
 			},
 		},

--- a/master/internal/command/tensorboard_manager.go
+++ b/master/internal/command/tensorboard_manager.go
@@ -18,7 +18,6 @@ import (
 	"github.com/determined-ai/determined/master/internal/db"
 	"github.com/determined-ai/determined/master/internal/scheduler"
 	"github.com/determined-ai/determined/master/pkg/actor"
-	"github.com/determined-ai/determined/master/pkg/agent"
 	"github.com/determined-ai/determined/master/pkg/archive"
 	"github.com/determined-ai/determined/master/pkg/check"
 	"github.com/determined-ai/determined/master/pkg/etc"
@@ -271,7 +270,7 @@ func (t *tensorboardManager) newTensorBoard(
 			"trial_ids":      req.TrialIDs,
 		},
 		readinessChecks: map[string]readinessCheck{
-			"tensorboard": func(log agent.ContainerLog) bool {
+			"tensorboard": func(log scheduler.ContainerLog) bool {
 				return strings.Contains(log.String(), "TensorBoard contains metrics")
 			},
 		},

--- a/master/internal/scheduler/resource_provider.go
+++ b/master/internal/scheduler/resource_provider.go
@@ -1,0 +1,50 @@
+package scheduler
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/docker/docker/pkg/jsonmessage"
+
+	"github.com/determined-ai/determined/master/pkg/agent"
+	containerInfo "github.com/determined-ai/determined/master/pkg/container"
+)
+
+// ContainerLog notifies the task actor that a new log message is available for the container.
+type ContainerLog struct {
+	Container containerInfo.Container
+	Timestamp time.Time
+
+	PullMessage *jsonmessage.JSONMessage
+	RunMessage  *agent.RunMessage
+	AuxMessage  *string
+}
+
+func (c ContainerLog) String() string {
+	msg := ""
+	switch {
+	case c.AuxMessage != nil:
+		msg = *c.AuxMessage
+	case c.RunMessage != nil:
+		msg = strings.TrimSuffix(c.RunMessage.Value, "\n")
+	case c.PullMessage != nil:
+		buf := new(bytes.Buffer)
+		if err := c.PullMessage.Display(buf, false); err != nil {
+			msg = err.Error()
+		} else {
+			msg = buf.String()
+			// Docker disables printing the progress bar in non-terminal mode.
+			if msg == "" && c.PullMessage.Progress != nil {
+				msg = c.PullMessage.Progress.String()
+			}
+			msg = strings.TrimSpace(msg)
+		}
+	default:
+		panic("unknown log message received")
+	}
+	shortID := c.Container.ID[:8]
+	timestamp := c.Timestamp.UTC().Format(time.RFC3339)
+	return fmt.Sprintf("[%s] %s [%s] || %s", timestamp, shortID, c.Container.State, msg)
+}

--- a/master/internal/trial.go
+++ b/master/internal/trial.go
@@ -235,7 +235,7 @@ func (t *trial) Receive(ctx *actor.Context) error {
 		t.replaying = false
 
 	// Log-related messages.
-	case agent.ContainerLog:
+	case scheduler.ContainerLog:
 		t.processLog(ctx, msg)
 
 	case actor.PostStop:
@@ -714,7 +714,7 @@ func (t *trial) processContainerTerminated(ctx *actor.Context, msg agent.Contain
 	t.killAndRemoveSocket(ctx, scheduler.ContainerID(msg.Container.ID))
 
 	exitMsg := msg.ContainerStopped.String()
-	t.processLog(ctx, agent.ContainerLog{
+	t.processLog(ctx, scheduler.ContainerLog{
 		Container:  msg.Container,
 		Timestamp:  time.Now(),
 		AuxMessage: &exitMsg,
@@ -738,7 +738,7 @@ func (t *trial) processContainerTerminated(ctx *actor.Context, msg agent.Contain
 	}
 }
 
-func (t *trial) processLog(ctx *actor.Context, msg agent.ContainerLog) {
+func (t *trial) processLog(ctx *actor.Context, msg scheduler.ContainerLog) {
 	// Log messages should never come in before the trial ID is set, since no trial runners are
 	// launched until after the trial ID is set. But for futureproofing, we will log an error while
 	// we protect the database.

--- a/master/pkg/agent/master_message.go
+++ b/master/pkg/agent/master_message.go
@@ -1,9 +1,6 @@
 package agent
 
 import (
-	"bytes"
-	"fmt"
-	"strings"
 	"time"
 
 	"github.com/docker/docker/api/types"
@@ -89,31 +86,4 @@ type ContainerLog struct {
 type RunMessage struct {
 	Value   string
 	StdType stdcopy.StdType
-}
-
-func (c ContainerLog) String() string {
-	msg := ""
-	switch {
-	case c.AuxMessage != nil:
-		msg = *c.AuxMessage
-	case c.RunMessage != nil:
-		msg = strings.TrimSuffix(c.RunMessage.Value, "\n")
-	case c.PullMessage != nil:
-		buf := new(bytes.Buffer)
-		if err := c.PullMessage.Display(buf, false); err != nil {
-			msg = err.Error()
-		} else {
-			msg = buf.String()
-			// Docker disables printing the progress bar in non-terminal mode.
-			if msg == "" && c.PullMessage.Progress != nil {
-				msg = c.PullMessage.Progress.String()
-			}
-			msg = strings.TrimSpace(msg)
-		}
-	default:
-		panic("unknown log message received")
-	}
-	shortID := c.Container.ID[:8]
-	timestamp := c.Timestamp.UTC().Format(time.RFC3339)
-	return fmt.Sprintf("[%s] %s [%s] || %s", timestamp, shortID, c.Container.State, msg)
 }


### PR DESCRIPTION
## Description
Start of decoupling agents and workflows. Have container log messages come from resource providers.

[DET-3175](https://determinedai.atlassian.net/browse/DET-3175)

## Test Plan
Tested manually by spinning up a cluster and trying trials and notebooks. 
