### PR TITLE
fix: pass checkpoint gc metadata as a file

### DIFF
--- a/harness/determined/exec/gc_checkpoints.py
+++ b/harness/determined/exec/gc_checkpoints.py
@@ -33,6 +33,11 @@ def delete_checkpoints(
     logging.info("Finished deleting {} checkpoints".format(len(to_delete)))
 
 
+def json_file_arg(val: str) -> Any:
+    with open(val) as f:
+        return json.load(f)
+
+
 def main(argv: List[str]) -> None:
     parser = argparse.ArgumentParser(description="Determined checkpoint GC")
 
@@ -49,15 +54,15 @@ def main(argv: List[str]) -> None:
     )
     parser.add_argument(
         "--experiment-config",
-        type=json.loads,
+        type=json_file_arg,
         default=os.getenv("DET_EXPERIMENT_CONFIG", {}),
-        help="Experiment config (JSON-formatted string)",
+        help="Experiment config (JSON-formatted file)",
     )
     parser.add_argument(
         "--delete",
-        type=json.loads,
+        type=json_file_arg,
         default=os.getenv("DET_DELETE", []),
-        help="Checkpoints to delete (JSON-formatted string)",
+        help="Checkpoints to delete (JSON-formatted file)",
     )
     parser.add_argument(
         "--dry-run",


### PR DESCRIPTION
## Description

There's a limit to how much you can pass in environment variables, which I hit while playing with Estimators, which generate a large number of verbose filenames in checkpoints.

This change passes information into the checkpoint gc script as files instead of as environment variables.

## Test Plan

Regular tests are fine, IMO.