### PR TITLE
feat: make agent starting period configurable [DET-3219]

### DIFF
--- a/deploy/determined_deploy/aws/cli.py
+++ b/deploy/determined_deploy/aws/cli.py
@@ -64,6 +64,9 @@ def make_up_subparser(subparsers: argparse._SubParsersAction):
         "--max-idle-agent-period", type=str, help="max agent idle time",
     )
     subparser.add_argument(
+        "--max-agent-starting-period", type=str, help="max agent starting time",
+    )
+    subparser.add_argument(
         "--max-dynamic-agents",
         type=int,
         help="maximum number of dynamic agent instances at one time",

--- a/deploy/determined_deploy/aws/constants.py
+++ b/deploy/determined_deploy/aws/constants.py
@@ -34,6 +34,7 @@ class cloudformation:
     BOTO3_SESSION = "Boto3Session"
     AGENT_TAG_NAME = "AgentTagName"
     MAX_IDLE_AGENT_PERIOD = "MaxIdleAgentPeriod"
+    MAX_AGENT_STARTING_PERIOD = "MaxAgentStartingPeriod"
     MAX_DYNAMIC_AGENTS = "MaxDynamicAgents"
     LOG_GROUP = "LogGroup"
     REGION = "Region"

--- a/deploy/determined_deploy/aws/deployment_types/secure.py
+++ b/deploy/determined_deploy/aws/deployment_types/secure.py
@@ -32,6 +32,7 @@ class Secure(base.DeterminedDeployment):
         constants.cloudformation.VERSION,
         constants.cloudformation.DB_PASSWORD,
         constants.cloudformation.MAX_IDLE_AGENT_PERIOD,
+        constants.cloudformation.MAX_AGENT_STARTING_PERIOD,
         constants.cloudformation.MAX_DYNAMIC_AGENTS,
     ]
 

--- a/deploy/determined_deploy/aws/deployment_types/simple.py
+++ b/deploy/determined_deploy/aws/deployment_types/simple.py
@@ -26,6 +26,7 @@ class Simple(base.DeterminedDeployment):
         constants.cloudformation.VERSION,
         constants.cloudformation.DB_PASSWORD,
         constants.cloudformation.MAX_IDLE_AGENT_PERIOD,
+        constants.cloudformation.MAX_AGENT_STARTING_PERIOD,
         constants.cloudformation.MAX_DYNAMIC_AGENTS,
     ]
 

--- a/deploy/determined_deploy/aws/deployment_types/vpc.py
+++ b/deploy/determined_deploy/aws/deployment_types/vpc.py
@@ -25,6 +25,7 @@ class VPC(base.DeterminedDeployment):
         constants.cloudformation.VERSION,
         constants.cloudformation.DB_PASSWORD,
         constants.cloudformation.MAX_IDLE_AGENT_PERIOD,
+        constants.cloudformation.MAX_AGENT_STARTING_PERIOD,
         constants.cloudformation.MAX_DYNAMIC_AGENTS,
     ]
 

--- a/deploy/determined_deploy/aws/templates/secure.yaml
+++ b/deploy/determined_deploy/aws/templates/secure.yaml
@@ -71,6 +71,11 @@ Parameters:
     Description: How long before idle agents are shutdown
     Default: 10m
 
+  MaxAgentStartingPeriod:
+    Type: String
+    Decription: How long for agent starting before retrying
+    Default: 10m
+
   MaxDynamicAgents:
     Type: Number
     Description: Maximum number of agents to launch simultaneously
@@ -586,6 +591,7 @@ Resources:
               log_stream: determined-agent
               master_url: http://local-ipv4:8080
               max_idle_agent_period: ${MaxIdleAgentPeriod}
+              max_agent_starting_period: ${MaxAgentStartingPeriod}
               max_instances: ${MaxDynamicAgents}
               network_interface:
                 public_ip: false

--- a/deploy/determined_deploy/aws/templates/simple.yaml
+++ b/deploy/determined_deploy/aws/templates/simple.yaml
@@ -45,6 +45,11 @@ Parameters:
     Description: How long before idle agents are shutdown
     Default: 10m
 
+  MaxAgentStartingPeriod:
+    Type: String
+    Decription: How long for agent starting before retrying
+    Default: 10m
+
   MaxDynamicAgents:
     Type: Number
     Description: Maximum number of agents to launch simultaneously
@@ -382,6 +387,7 @@ Resources:
               log_stream: determined-agent
               master_url: http://local-ipv4:8080
               max_idle_agent_period: ${MaxIdleAgentPeriod}
+              max_agent_starting_period: ${MaxAgentStartingPeriod}
               max_instances: ${MaxDynamicAgents}
               network_interface:
                 public_ip: true

--- a/deploy/determined_deploy/aws/templates/vpc.yaml
+++ b/deploy/determined_deploy/aws/templates/vpc.yaml
@@ -59,6 +59,11 @@ Parameters:
     Description: How long before idle agents are shutdown
     Default: 10m
 
+  MaxAgentStartingPeriod:
+    Type: String
+    Decription: How long for agent starting before retrying
+    Default: 10m
+
   MaxDynamicAgents:
     Type: Number
     Description: Maximum number of agents to launch simultaneously
@@ -508,6 +513,7 @@ Resources:
               log_stream: determined-agent
               master_url: http://local-ipv4:8080
               max_idle_agent_period: ${MaxIdleAgentPeriod}
+              max_agent_starting_period: ${MaxAgentStartingPeriod}
               max_instances: ${MaxDynamicAgents}
               network_interface:
                 public_ip: true

--- a/deploy/determined_deploy/gcp/cli.py
+++ b/deploy/determined_deploy/gcp/cli.py
@@ -118,6 +118,12 @@ def make_up_subparser(subparsers: argparse._SubParsersAction) -> None:
         help="max agent idle time before it is shut down, e.g. 30m for 30 minutes",
     )
     optional_named.add_argument(
+        "--max-agent-starting-period",
+        type=str,
+        default=constants.defaults.MAX_AGENT_STARTING_PERIOD,
+        help="max agent starting time before retrying, e.g. 30m for 30 minutes",
+    )
+    optional_named.add_argument(
         "--port",
         type=int,
         default=constants.defaults.PORT,

--- a/deploy/determined_deploy/gcp/constants.py
+++ b/deploy/determined_deploy/gcp/constants.py
@@ -7,6 +7,7 @@ class defaults:
     GPU_TYPE = "nvidia-tesla-k80"
     MASTER_INSTANCE_TYPE = "n1-standard-2"
     MAX_IDLE_AGENT_PERIOD = "10m"
+    MAX_AGENT_STARTING_PERIOD = "10m"
     OPERATION_TIMEOUT_PERIOD = "5m"
     MAX_DYNAMIC_AGENTS = 5
     STATIC_AGENTS = 0

--- a/deploy/determined_deploy/gcp/terraform/main.tf
+++ b/deploy/determined_deploy/gcp/terraform/main.tf
@@ -125,6 +125,7 @@ module "compute" {
   agent_docker_network = var.agent_docker_network
   agent_instance_type = var.agent_instance_type
   max_idle_agent_period = var.max_idle_agent_period
+  max_agent_starting_period: var.max_agent_starting_period
   gpu_type = var.gpu_type
   gpu_num = var.gpu_num
   max_dynamic_agents = var.max_dynamic_agents

--- a/deploy/determined_deploy/gcp/terraform/modules/compute/main.tf
+++ b/deploy/determined_deploy/gcp/terraform/modules/compute/main.tf
@@ -43,6 +43,7 @@ resource "google_compute_instance" "master_instance" {
       master_url: ${var.scheme}://internal-ip:${var.port}
       agent_docker_network: ${var.agent_docker_network}
       max_idle_agent_period: ${var.max_idle_agent_period}
+      max_agent_starting_period: ${var.max_agent_starting_period}
       provider: gcp
       name_prefix: det-dynamic-agent-${var.unique_id}-
       network_interface:

--- a/deploy/determined_deploy/gcp/terraform/modules/compute/variables.tf
+++ b/deploy/determined_deploy/gcp/terraform/modules/compute/variables.tf
@@ -40,6 +40,9 @@ variable "agent_docker_network" {
 variable "max_idle_agent_period" {
 }
 
+variable "max_agent_starting_period" {
+}
+
 variable "tag_master_port" {
 }
 

--- a/deploy/determined_deploy/gcp/terraform/variables.tf
+++ b/deploy/determined_deploy/gcp/terraform/variables.tf
@@ -105,6 +105,11 @@ variable "max_idle_agent_period" {
   default = "10m"
 }
 
+variable "max_agent_starting_period" {
+  type = string
+  default = "10m"
+}
+
 variable "min_cpu_platform_master" {
   type = string
   default = "Intel Skylake"

--- a/docs/reference/cluster-config.txt
+++ b/docs/reference/cluster-config.txt
@@ -274,6 +274,11 @@ The master supports the following configuration settings:
     with optional fraction and a unit suffix, such as "30s", "1h", or
     "1m30s". Valid time units are "s", "m", "h". The default value is ``5m``.
 
+  - ``max_agent_starting_period``: How long to wait for agents starting before
+    retrying. This string is a sequence of decimal numbers, each
+    with optional fraction and a unit suffix, such as "30s", "1h", or
+    "1m30s". Valid time units are "s", "m", "h". The default value is ``5m``.
+
   - ``provider: aws``: Specifies running dynamic agents on AWS.
     (*Required*)
 

--- a/docs/topic-guides/elastic-infra/dynamic-agents-aws.txt
+++ b/docs/topic-guides/elastic-infra/dynamic-agents-aws.txt
@@ -126,8 +126,10 @@ an example configuration. See :ref:`cluster-configuration` for details.
     master_url: <scheme://host:port>
     startup_script: <startup script>
     container_startup_script: <container startup script>
-    agent_docker_network: determined
+    agent_docker_network: host
+    agent_docker_image: <agent docker image>
     max_idle_agent_period: 5m
+    max_agent_starting_period: 5m
 
     provider: aws
     region: <region>

--- a/docs/topic-guides/elastic-infra/dynamic-agents-gcp.txt
+++ b/docs/topic-guides/elastic-infra/dynamic-agents-gcp.txt
@@ -103,8 +103,10 @@ an example configuration. See :ref:`cluster-configuration` for details.
      master_url: <scheme://host:port>
      startup_script: <startup script>
      container_startup_script: <container startup script>
-     agent_docker_network: determined
+     agent_docker_network: host
+     agent_docker_image: <agent docker image>
      max_idle_agent_period: 5m
+     max_agent_starting_period: 5m
 
      provider: gcp
      base_config: <instance resource base configuration>

--- a/master/internal/config_test.go
+++ b/master/internal/config_test.go
@@ -31,6 +31,7 @@ scheduler:
 
 provisioner:
   max_idle_agent_period: 30s
+  max_agent_starting_period: 30s
 `
 	expected := Config{
 		Log: logger.Config{
@@ -45,9 +46,10 @@ provisioner:
 		},
 		Scheduler: scheduler.Config{Fit: "best"},
 		Provisioner: &provisioner.Config{
-			AgentDockerRuntime: "runc",
-			AgentDockerNetwork: "default",
-			MaxIdleAgentPeriod: provisioner.Duration(30 * time.Second),
+			AgentDockerRuntime:     "runc",
+			AgentDockerNetwork:     "default",
+			MaxIdleAgentPeriod:     provisioner.Duration(30 * time.Second),
+			MaxAgentStartingPeriod: provisioner.Duration(30 * time.Second),
 		},
 	}
 

--- a/master/internal/provisioner/config.go
+++ b/master/internal/provisioner/config.go
@@ -53,14 +53,16 @@ type Config struct {
 	AWS                    *AWSClusterConfig `union:"provider,aws" json:"-"`
 	GCP                    *GCPClusterConfig `union:"provider,gcp" json:"-"`
 	MaxIdleAgentPeriod     Duration          `json:"max_idle_agent_period"`
+	MaxAgentStartingPeriod Duration          `json:"max_agent_starting_period"`
 }
 
 // DefaultConfig returns the default configuration of the provisioner.
 func DefaultConfig() *Config {
 	return &Config{
-		AgentDockerRuntime: "runc",
-		AgentDockerNetwork: "default",
-		MaxIdleAgentPeriod: Duration(300 * time.Second),
+		AgentDockerRuntime:     "runc",
+		AgentDockerNetwork:     "default",
+		MaxIdleAgentPeriod:     Duration(300 * time.Second),
+		MaxAgentStartingPeriod: Duration(300 * time.Second),
 	}
 }
 
@@ -100,6 +102,8 @@ func (c Config) Validate() []error {
 		check.False(c.AWS == nil && c.GCP == nil, "must configure aws or gcp cluster"),
 		check.GreaterThan(
 			int64(c.MaxIdleAgentPeriod), int64(0), "max idle agent period must be greater than 0"),
+		check.GreaterThan(
+			int64(c.MaxAgentStartingPeriod), int64(0), "max agent starting period must be greater than 0"),
 	}...)
 	return errs
 }

--- a/master/internal/provisioner/config_test.go
+++ b/master/internal/provisioner/config_test.go
@@ -18,9 +18,10 @@ func TestProvisionerConfigMissingFields(t *testing.T) {
 	err = check.Validate(&config)
 	assert.ErrorContains(t, err, "must configure aws or gcp cluster")
 	expected := Config{
-		MaxIdleAgentPeriod: Duration(5 * time.Minute),
-		AgentDockerRuntime: "runc",
-		AgentDockerNetwork: "default",
+		MaxIdleAgentPeriod:     Duration(5 * time.Minute),
+		MaxAgentStartingPeriod: Duration(5 * time.Minute),
+		AgentDockerRuntime:     "runc",
+		AgentDockerNetwork:     "default",
 	}
 	assert.DeepEqual(t, config, expected)
 }
@@ -33,7 +34,8 @@ func TestUnmarshalProvisionerConfigMasterURL(t *testing.T) {
 "region": "test.region3",
 "image_id": "test.image3",
 "ssh_key_name": "test-key3",
-"max_idle_agent_period": "30s"
+"max_idle_agent_period": "30s",
+"max_agent_starting_period": "30s"
 }`
 	config := Config{}
 	err := json.Unmarshal([]byte(configRaw), &config)
@@ -47,12 +49,13 @@ func TestUnmarshalProvisionerConfigMasterURL(t *testing.T) {
 	awsConfig.ImageID = "test.image3"
 	awsConfig.SSHKeyName = "test-key3"
 	unmarshaled := Config{
-		MasterURL:          "http://test.master:8080",
-		AgentDockerImage:   "test_image",
-		AgentDockerRuntime: "runc",
-		AgentDockerNetwork: "default",
-		AWS:                &awsConfig,
-		MaxIdleAgentPeriod: Duration(30 * time.Second),
+		MasterURL:              "http://test.master:8080",
+		AgentDockerImage:       "test_image",
+		AgentDockerRuntime:     "runc",
+		AgentDockerNetwork:     "default",
+		AWS:                    &awsConfig,
+		MaxIdleAgentPeriod:     Duration(30 * time.Second),
+		MaxAgentStartingPeriod: Duration(30 * time.Second),
 	}
 	assert.DeepEqual(t, config, unmarshaled)
 }
@@ -80,7 +83,8 @@ func TestUnmarshalProvisionerConfigWithAWS(t *testing.T) {
 "region": "test.region2",
 "image_id": "test.image2",
 "ssh_key_name": "test-key2",
-"max_idle_agent_period": "30s"
+"max_idle_agent_period": "30s",
+"max_agent_starting_period": "30s"
 }`
 	config := Config{}
 	err := json.Unmarshal([]byte(configRaw), &config)
@@ -94,12 +98,13 @@ func TestUnmarshalProvisionerConfigWithAWS(t *testing.T) {
 	awsConfig.ImageID = "test.image2"
 	awsConfig.SSHKeyName = "test-key2"
 	unmarshaled := Config{
-		MasterURL:          "http://test.master:8080",
-		AWS:                &awsConfig,
-		AgentDockerImage:   "test_image",
-		AgentDockerRuntime: "runc",
-		AgentDockerNetwork: "default",
-		MaxIdleAgentPeriod: Duration(30 * time.Second),
+		MasterURL:              "http://test.master:8080",
+		AWS:                    &awsConfig,
+		AgentDockerImage:       "test_image",
+		AgentDockerRuntime:     "runc",
+		AgentDockerNetwork:     "default",
+		MaxIdleAgentPeriod:     Duration(30 * time.Second),
+		MaxAgentStartingPeriod: Duration(30 * time.Second),
 	}
 	assert.DeepEqual(t, config, unmarshaled)
 }
@@ -125,12 +130,13 @@ func TestUnmarshalProvisionerConfigWithGCP(t *testing.T) {
 	expected.Zone = "test-zone2"
 	expected.BootDiskSourceImage = "test-source_image2"
 	unmarshaled := Config{
-		MasterURL:          "http://test.master:8080",
-		GCP:                &expected,
-		AgentDockerImage:   "test_image",
-		AgentDockerRuntime: "runc",
-		AgentDockerNetwork: "default",
-		MaxIdleAgentPeriod: Duration(5 * time.Minute),
+		MasterURL:              "http://test.master:8080",
+		GCP:                    &expected,
+		AgentDockerImage:       "test_image",
+		AgentDockerRuntime:     "runc",
+		AgentDockerNetwork:     "default",
+		MaxIdleAgentPeriod:     Duration(5 * time.Minute),
+		MaxAgentStartingPeriod: Duration(5 * time.Minute),
 	}
 	assert.DeepEqual(t, config, unmarshaled)
 }

--- a/master/internal/provisioner/provisioner.go
+++ b/master/internal/provisioner/provisioner.go
@@ -62,8 +62,11 @@ func New(config *Config) (*Provisioner, error) {
 	}
 
 	return &Provisioner{
-		provider:     cluster,
-		scaleDecider: newScaleDecider(time.Duration(config.MaxIdleAgentPeriod)),
+		provider: cluster,
+		scaleDecider: newScaleDecider(
+			time.Duration(config.MaxIdleAgentPeriod),
+			time.Duration(config.MaxAgentStartingPeriod),
+		),
 	}, nil
 }
 

--- a/master/internal/provisioner/scale_decider_test.go
+++ b/master/internal/provisioner/scale_decider_test.go
@@ -27,208 +27,253 @@ func assertEqualInstancesMarked(t *testing.T, left, right map[string]time.Time) 
 	}
 }
 
+func TestNeedScale(t *testing.T) {
+	type testcase struct {
+		name string
+
+		scaleDecider scaleDecider
+
+		needScale bool
+	}
+	var tcs = []testcase{
+		{
+			name: "no need to scale",
+			scaleDecider: scaleDecider{
+				maxIdlePeriod:        time.Minute,
+				lastProviderUpdated:  time.Now().Add(-time.Hour),
+				lastSchedulerUpdated: time.Now().Add(-time.Hour),
+				lastProvision:        time.Now(),
+			},
+			needScale: false,
+		},
+		{
+			name: "minimum retrying interval",
+			scaleDecider: scaleDecider{
+				maxIdlePeriod:        time.Minute,
+				lastProviderUpdated:  time.Now().Add(-time.Hour),
+				lastSchedulerUpdated: time.Now().Add(-time.Hour),
+				lastProvision:        time.Now().Add(-time.Minute),
+			},
+			needScale: true,
+		},
+		{
+			name: "last provision < last update + the maximum agent idle period",
+			scaleDecider: scaleDecider{
+				maxIdlePeriod:        time.Hour,
+				lastProviderUpdated:  time.Now().Add(-time.Minute),
+				lastSchedulerUpdated: time.Now().Add(-time.Minute),
+				lastProvision:        time.Now(),
+			},
+			needScale: true,
+		},
+	}
+	for idx := range tcs {
+		tc := tcs[idx]
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.scaleDecider.needScale(), tc.needScale)
+		})
+	}
+}
+
 func TestFindInstancesToTerminate(t *testing.T) {
 	type testcase struct {
 		name string
 
-		maxIdleAgentPeriod    time.Duration
-		instancesMarkedBefore map[string]time.Time
-		instancesMarkedAfter  map[string]time.Time
-
-		idleAgents     []*scheduler.AgentSummary
-		instances      []*Instance
+		scaleDecider   scaleDecider
 		maxInstanceNum int
 
-		toTerminate []string
+		pastIdleInstanceAfter map[string]time.Time
+		toTerminate           []string
 	}
 	var tcs = []testcase{
 		{
-			name: "stopped instances",
-			instances: []*Instance{
-				testInstances[5],
+			name: "terminate stopped instances",
+			scaleDecider: scaleDecider{
+				instanceSnapshot: map[string]*Instance{
+					"instance1": {
+						ID:        "instance1",
+						AgentName: "agent1",
+						State:     Stopped,
+					},
+					"instance2": {
+						ID:         "instance2",
+						LaunchTime: time.Now().Add(-time.Hour),
+						AgentName:  "agent2",
+						State:      Running,
+					},
+				},
+			},
+			maxInstanceNum:        10,
+			pastIdleInstanceAfter: map[string]time.Time{},
+			toTerminate: []string{
+				"instance1",
+			},
+		},
+		{
+			name: "terminate agents that are idle for a long time",
+			scaleDecider: scaleDecider{
+				maxIdlePeriod: 10 * time.Minute,
+				agentSnapshot: map[string]*scheduler.AgentSummary{
+					"agent1": {
+						Name: "agent1",
+					},
+					"agent2": {
+						Name: "agent2",
+					},
+					"agent3": {
+						Name: "agent3",
+					},
+				},
+				instanceSnapshot: map[string]*Instance{
+					"instance1": {
+						ID:         "instance1",
+						LaunchTime: time.Now().Add(-time.Hour),
+						AgentName:  "agent1",
+						State:      Running,
+					},
+					"instance2": {
+						ID:         "instance2",
+						LaunchTime: time.Now().Add(-time.Hour),
+						AgentName:  "agent2",
+						State:      Running,
+					},
+					"instance3": {
+						ID:         "instance3",
+						LaunchTime: time.Now().Add(-time.Hour),
+						AgentName:  "agent3",
+						State:      Running,
+					},
+					"instance4": {
+						ID:         "instance4",
+						LaunchTime: time.Now().Add(-time.Hour),
+						AgentName:  "agent4",
+						State:      Running,
+					},
+				},
+				pastIdleInstances: map[string]time.Time{
+					"instance1": time.Now().Add(-time.Hour),
+					"instance2": time.Now().Add(-time.Minute),
+				},
+			},
+			maxInstanceNum: 10,
+			pastIdleInstanceAfter: map[string]time.Time{
+				"instance2": time.Now(),
+				"instance3": time.Now(),
 			},
 			toTerminate: []string{
-				testInstances[5].ID,
+				"instance1",
 			},
 		},
 		{
-			name:                 "empty agents",
-			instancesMarkedAfter: map[string]time.Time{},
-			idleAgents:           []*scheduler.AgentSummary{},
-			instances: []*Instance{
-				testInstances[0],
-				testInstances[1],
-			},
-			maxInstanceNum: 100,
-		},
-		{
-			name:               "duplicate agents",
-			maxIdleAgentPeriod: testTenMin,
-			instancesMarkedBefore: map[string]time.Time{
-				testInstances[0].ID: testOneHourAgo,
-			},
-			instancesMarkedAfter: map[string]time.Time{},
-			idleAgents: []*scheduler.AgentSummary{
-				testAgents[0],
-				testAgents[4],
-			},
-			instances: []*Instance{
-				testInstances[0],
-			},
-			maxInstanceNum: 100,
-			toTerminate: []string{
-				testInstances[0].ID,
-			},
-		},
-		{
-			name:               "idle agents",
-			maxIdleAgentPeriod: testTenMin,
-			instancesMarkedBefore: map[string]time.Time{
-				testInstances[0].ID: testOneHourAgo,
-				testInstances[1].ID: testOneHourAgo,
-			},
-			instancesMarkedAfter: map[string]time.Time{},
-			idleAgents: []*scheduler.AgentSummary{
-				testAgents[0],
-				testAgents[1],
-			},
-			instances: []*Instance{
-				testInstances[0],
-				testInstances[1],
-			},
-			maxInstanceNum: 100,
-			toTerminate: []string{
-				testInstances[0].ID,
-				testInstances[1].ID,
-			},
-		},
-		{
-			name:               "unhealthy instances",
-			maxIdleAgentPeriod: testTenMin,
-			instancesMarkedBefore: map[string]time.Time{
-				testInstances[1].ID: testOneHourAgo,
-				testInstances[2].ID: testOneHourAgo,
-				testInstances[3].ID: testOneHourAgo,
-			},
-			instancesMarkedAfter: map[string]time.Time{},
-			instances: []*Instance{
-				testInstances[0],
-				testInstances[1],
-				testInstances[2],
-				testInstances[3],
-			},
-			maxInstanceNum: 100,
-			toTerminate: []string{
-				testInstances[1].ID,
-				testInstances[2].ID,
-				testInstances[3].ID,
-			},
-		},
-		{
-			name:               "mark new idle instances without terminating",
-			maxIdleAgentPeriod: testTenMin,
-			idleAgents: []*scheduler.AgentSummary{
-				testAgents[0],
-			},
-			instances: []*Instance{
-				testInstances[0],
-			},
-			instancesMarkedAfter: map[string]time.Time{
-				testInstances[0].ID: testNow,
-			},
-			maxInstanceNum: 100,
-		},
-		{
-			name:               "terminate marked instances",
-			maxIdleAgentPeriod: testTenMin,
-			idleAgents: []*scheduler.AgentSummary{
-				testAgents[0],
-				testAgents[1],
-			},
-			instances: []*Instance{
-				testInstances[0],
-				testInstances[1],
-			},
-			instancesMarkedBefore: map[string]time.Time{
-				testInstances[0].ID: testOneMinuteAgo,
-				testInstances[1].ID: testOneHourAgo,
-			},
-			maxInstanceNum: 100,
-			toTerminate: []string{
-				testInstances[1].ID,
-			},
-			instancesMarkedAfter: map[string]time.Time{
-				testInstances[0].ID: testOneMinuteAgo,
-			},
-		},
-		{
-			name:                  "terminate instances to the instance limit",
-			maxIdleAgentPeriod:    testTenMin,
-			instancesMarkedBefore: map[string]time.Time{},
-			idleAgents: []*scheduler.AgentSummary{
-				testAgents[0],
-				testAgents[1],
-			},
-			instances: []*Instance{
-				testInstances[0],
-				testInstances[1],
-				testInstances[4],
+			name: "terminate instances to the instance limit",
+			scaleDecider: scaleDecider{
+				maxIdlePeriod: 10 * time.Minute,
+				agentSnapshot: map[string]*scheduler.AgentSummary{
+					"agent1": {
+						Name: "agent1",
+					},
+				},
+				instanceSnapshot: map[string]*Instance{
+					"instance1": {
+						ID:         "instance1",
+						LaunchTime: time.Now().Add(-time.Hour),
+						AgentName:  "agent1",
+						State:      Running,
+					},
+					"instance2": {
+						ID:         "instance2",
+						LaunchTime: time.Now().Add(-time.Hour),
+						AgentName:  "agent2",
+						State:      Running,
+					},
+					"instance3": {
+						ID:         "instance3",
+						LaunchTime: time.Now().Add(-time.Minute),
+						AgentName:  "agent3",
+						State:      Running,
+					},
+				},
+				pastIdleInstances: map[string]time.Time{},
 			},
 			maxInstanceNum: 1,
 			toTerminate: []string{
-				testInstances[0].ID,
-				testInstances[1].ID,
+				"instance1",
+				"instance3",
 			},
 		},
 		{
-			name:               "overall besides the instance limit",
-			maxIdleAgentPeriod: testTenMin,
-			instancesMarkedBefore: map[string]time.Time{
-				testInstances[0].ID: testOneHourAgo,
-				testInstances[1].ID: testOneHourAgo,
-				testInstances[2].ID: testOneHourAgo,
-				testInstances[3].ID: testOneHourAgo,
+			name: "overall besides the instance limit",
+			scaleDecider: scaleDecider{
+				maxIdlePeriod: 10 * time.Minute,
+				agentSnapshot: map[string]*scheduler.AgentSummary{
+					"agent1": {
+						Name: "agent1",
+					},
+					"agent2": {
+						Name: "agent2",
+					},
+					"agent3": {
+						Name: "agent3",
+					},
+					"agent4": {
+						Name: "agent4",
+					},
+				},
+				instanceSnapshot: map[string]*Instance{
+					"instance1": {
+						ID:         "instance1",
+						LaunchTime: time.Now().Add(-time.Hour),
+						AgentName:  "agent1",
+						State:      Stopped,
+					},
+					"instance2": {
+						ID:         "instance2",
+						LaunchTime: time.Now().Add(-time.Hour),
+						AgentName:  "agent2",
+						State:      Running,
+					},
+					"instance3": {
+						ID:         "instance3",
+						LaunchTime: time.Now().Add(-time.Hour),
+						AgentName:  "agent3",
+						State:      Running,
+					},
+					"instance4": {
+						ID:         "instance4",
+						LaunchTime: time.Now().Add(-time.Hour),
+						AgentName:  "agent4",
+						State:      Running,
+					},
+					"instance5": {
+						ID:         "instance5",
+						LaunchTime: time.Now().Add(-time.Hour),
+						AgentName:  "agent5",
+						State:      Running,
+					},
+				},
+				pastIdleInstances: map[string]time.Time{
+					"instance1": time.Now().Add(-time.Hour),
+					"instance2": time.Now().Add(-time.Hour),
+					"instance3": time.Now().Add(-time.Minute),
+				},
 			},
-			instancesMarkedAfter: map[string]time.Time{},
-			idleAgents: []*scheduler.AgentSummary{
-				testAgents[0],
-				testAgents[1],
-				testAgents[2],
-				testAgents[3],
-				testAgents[4],
+			maxInstanceNum: 10,
+			pastIdleInstanceAfter: map[string]time.Time{
+				"instance3": time.Now(),
+				"instance4": time.Now(),
 			},
-			instances: []*Instance{
-				testInstances[0],
-				testInstances[1],
-				testInstances[2],
-				testInstances[3],
-				testInstances[4],
-				testInstances[5],
-			},
-			maxInstanceNum: 100,
 			toTerminate: []string{
-				testInstances[0].ID,
-				testInstances[1].ID,
-				testInstances[2].ID,
-				testInstances[3].ID,
-				testInstances[5].ID,
+				"instance1",
+				"instance2",
 			},
 		},
 	}
 	for idx := range tcs {
 		tc := tcs[idx]
 		t.Run(tc.name, func(t *testing.T) {
-			s := &scaleDecider{
-				maxIdleAgentPeriod: tc.maxIdleAgentPeriod,
-				instancesMarked:    tc.instancesMarkedBefore,
-				schedulerSnapshot: &scheduler.ViewSnapshot{
-					Agents: tc.idleAgents,
-				},
-				instanceSnapshot: tc.instances,
-			}
-			toTerminate := s.findInstancesToTerminate(tc.maxInstanceNum)
+			toTerminate := tc.scaleDecider.findInstancesToTerminate(tc.maxInstanceNum)
 			assert.DeepEqual(t, newInstanceIDSet(toTerminate), newInstanceIDSet(tc.toTerminate))
-			assertEqualInstancesMarked(t, s.instancesMarked, tc.instancesMarkedAfter)
+			assertEqualInstancesMarked(t, tc.scaleDecider.pastIdleInstances, tc.pastIdleInstanceAfter)
 		})
 	}
 }
@@ -239,109 +284,170 @@ func TestCalculateNumInstancesToLaunch(t *testing.T) {
 
 		maxAgentStartingPeriod time.Duration
 
-		slotsNeeded    []int
-		instances      []*Instance
-		instanceType   instanceType
-		maxInstanceNum int
+		slotsNeeded      []int
+		instanceSnapshot map[string]*Instance
+		instanceType     instanceType
+		maxInstanceNum   int
 
 		numToLaunch int
 	}
 	var tcs = []testcase{
 		{
 			name:                   "empty pending tasks",
-			maxAgentStartingPeriod: testTenMin,
+			maxAgentStartingPeriod: 10 * time.Minute,
 			slotsNeeded:            nil,
-			instanceType:           testInstanceTypes[1],
-			maxInstanceNum:         10,
-			numToLaunch:            0,
-		},
-		{
-			name:           "zero instance slot",
-			slotsNeeded:    []int{1, 2, 1, 1},
-			instanceType:   testInstanceTypes[0],
+			instanceType: TestInstanceType{
+				Name:  "test.instanceType",
+				Slots: 1,
+			},
 			maxInstanceNum: 10,
 			numToLaunch:    0,
 		},
 		{
-			name:           "zero size task",
-			slotsNeeded:    []int{0, 0, 0, 0},
-			instanceType:   testInstanceTypes[2],
+			name:        "zero instance slot",
+			slotsNeeded: []int{1, 2, 1, 1},
+			instanceType: TestInstanceType{
+				Name:  "test.instanceType",
+				Slots: 0,
+			},
+			maxInstanceNum: 10,
+			numToLaunch:    0,
+		},
+		{
+			name:        "zero size task",
+			slotsNeeded: []int{0, 0, 0, 0},
+			instanceType: TestInstanceType{
+				Name:  "test.instanceType",
+				Slots: 2,
+			},
 			maxInstanceNum: 10,
 			numToLaunch:    1,
 		},
 		{
-			name:           "zero size task",
-			slotsNeeded:    []int{0, 2},
-			instanceType:   testInstanceTypes[2],
+			name:        "zero size task",
+			slotsNeeded: []int{0, 2},
+			instanceType: TestInstanceType{
+				Name:  "test.instanceType",
+				Slots: 2,
+			},
 			maxInstanceNum: 10,
 			numToLaunch:    1,
 		},
 		{
-			name:           "oversized task",
-			slotsNeeded:    []int{1, 2, 3, 1},
-			instanceType:   testInstanceTypes[1],
+			name:        "oversized task",
+			slotsNeeded: []int{1, 2, 3, 1},
+			instanceType: TestInstanceType{
+				Name:  "test.instanceType",
+				Slots: 1,
+			},
 			maxInstanceNum: 10,
 			numToLaunch:    7,
 		},
 		{
-			name:           "big task",
-			slotsNeeded:    []int{3, 3, 3, 3},
-			instanceType:   testInstanceTypes[4],
+			name:        "big task",
+			slotsNeeded: []int{3, 3, 3, 3},
+			instanceType: TestInstanceType{
+				Name:  "test.instanceType",
+				Slots: 4,
+			},
 			maxInstanceNum: 10,
 			numToLaunch:    3,
 		},
 		{
-			name:           "fill small gap",
-			slotsNeeded:    []int{3, 3, 3, 1},
-			instanceType:   testInstanceTypes[4],
+			name:        "fill small gap",
+			slotsNeeded: []int{3, 3, 3, 1},
+			instanceType: TestInstanceType{
+				Name:  "test.instanceType",
+				Slots: 4,
+			},
 			maxInstanceNum: 10,
 			numToLaunch:    3,
 		},
 		{
-			name:           "fill gaps",
-			slotsNeeded:    []int{3, 2, 1, 1, 3},
-			instanceType:   testInstanceTypes[4],
+			name:        "fill gaps",
+			slotsNeeded: []int{3, 2, 1, 1, 3},
+			instanceType: TestInstanceType{
+				Name:  "test.instanceType",
+				Slots: 4,
+			},
 			maxInstanceNum: 10,
 			numToLaunch:    3,
 		},
 		{
-			name:           "fill gaps",
-			slotsNeeded:    []int{3, 2, 1, 1, 3},
-			instanceType:   testInstanceTypes[4],
+			name:        "fill gaps",
+			slotsNeeded: []int{3, 2, 1, 1, 3},
+			instanceType: TestInstanceType{
+				Name:  "test.instanceType",
+				Slots: 4,
+			},
 			maxInstanceNum: 10,
 			numToLaunch:    3,
 		},
 		{
 			name:        "max instance num",
 			slotsNeeded: []int{3, 3, 3, 3},
-			instances: []*Instance{
-				testInstances[0],
+			instanceSnapshot: map[string]*Instance{
+				"instance1": {
+					ID:         "instance1",
+					LaunchTime: time.Now().Add(-time.Hour),
+					AgentName:  "agent1",
+					State:      Running,
+				},
 			},
-			instanceType:   testInstanceTypes[4],
+			instanceType: TestInstanceType{
+				Name:  "test.instanceType",
+				Slots: 4,
+			},
 			maxInstanceNum: 2,
 			numToLaunch:    1,
 		},
 		{
 			name:                   "provision less if having starting instances",
-			maxAgentStartingPeriod: testTenMin,
+			maxAgentStartingPeriod: 10 * time.Minute,
 			slotsNeeded:            []int{3, 3, 3, 3},
-			instances: []*Instance{
-				testInstances[0],
-				testInstances[1],
+			instanceSnapshot: map[string]*Instance{
+				"instance1": {
+					ID:         "instance1",
+					LaunchTime: time.Now().Add(-time.Hour),
+					AgentName:  "agent1",
+					State:      Running,
+				},
+				"instance2": {
+					ID:         "instance2",
+					LaunchTime: time.Now().Add(-time.Minute),
+					AgentName:  "agent2",
+					State:      Running,
+				},
 			},
-			instanceType:   testInstanceTypes[3],
+			instanceType: TestInstanceType{
+				Name:  "test.instanceType",
+				Slots: 3,
+			},
 			maxInstanceNum: 10,
 			numToLaunch:    3,
 		},
 		{
 			name:                   "starting instances already more than needed",
-			maxAgentStartingPeriod: testTenMin,
+			maxAgentStartingPeriod: 10 * time.Minute,
 			slotsNeeded:            []int{3},
-			instances: []*Instance{
-				testInstances[0],
-				testInstances[1],
+			instanceSnapshot: map[string]*Instance{
+				"instance1": {
+					ID:         "instance1",
+					LaunchTime: time.Now().Add(-time.Hour),
+					AgentName:  "agent1",
+					State:      Running,
+				},
+				"instance2": {
+					ID:         "instance2",
+					LaunchTime: time.Now().Add(-time.Minute),
+					AgentName:  "agent2",
+					State:      Running,
+				},
 			},
-			instanceType:   testInstanceTypes[3],
+			instanceType: TestInstanceType{
+				Name:  "test.instanceType",
+				Slots: 3,
+			},
 			maxInstanceNum: 10,
 			numToLaunch:    0,
 		},
@@ -351,11 +457,9 @@ func TestCalculateNumInstancesToLaunch(t *testing.T) {
 		tc := tcs[idx]
 		t.Run(tc.name, func(t *testing.T) {
 			s := &scaleDecider{
-				maxAgentStartingPeriod: tc.maxAgentStartingPeriod,
-				schedulerSnapshot: &scheduler.ViewSnapshot{
-					Tasks: newTasks(tc.slotsNeeded),
-				},
-				instanceSnapshot: tc.instances,
+				maxStartingPeriod: tc.maxAgentStartingPeriod,
+				taskSnapshot:      newTasks(tc.slotsNeeded),
+				instanceSnapshot:  tc.instanceSnapshot,
 			}
 			actual := s.calculateNumInstancesToLaunch(tc.instanceType, tc.maxInstanceNum)
 			assert.Equal(t, actual, tc.numToLaunch)

--- a/master/packaging/master.yaml
+++ b/master/packaging/master.yaml
@@ -40,8 +40,12 @@
 #  agent_docker_image: determinedai/determined-agent:<version>
 
 ## The maximum idle period of agents. The master waits for this period of time
-## before shutting down the idle agents. Defaults to 5 min.
+## before shutting down idle agents. Defaults to 5 min.
 #  max_idle_agent_period: 5m
+
+## The maximum starting period of agents. The master waits for this period of time
+## for starting agents before retrying. Defaults to 5 min.
+#  max_agent_starting_period: 5m
 
 ## Configure AWS dynamic agents. The `provider`, `image_id`, `security_group`, and
 ## `ssh_key_name` are required to be set to use AWS dynamic agents.


### PR DESCRIPTION
## Description

The provisioner would retry launching an agent after reaching
a duration, which is set by max agent starting period. Previously,
this configuration is hardcoded to 300 seconds. Now, change it to
be in the configuration of the provisioner.

## Test Plan

1. Manually test.

The goal of the test is to test if the functionality has been changed and the agent starting period is configurable as planned.

Use the following provisioner config:
```
provisioner:
  agent_docker_network: host
  agent_docker_image: determinedai/determined-dev:determined-agent-d90294d941964f104b50204232002fa551daa648
  max_idle_agent_period: 1m
  max_agent_starting_period: 10s
  operation_timeout_period: 1m
  provider: gcp
  boot_disk_size: 200
  boot_disk_source_image: projects/determined-ai/global/images/pedl-environments-4e98289
  network_interface:
    network: projects/determined-ai/global/networks/default
    subnetwork: projects/determined-ai/regions/us-central1/subnetworks/default
    external_ip: false
  instance_type:
    machine_type: n1-standard-8
    gpu_type: nvidia-tesla-v100
    gpu_num: 2
    preemptible: false
  max_instances: 2
```

2. Add unit tests for the refactoring.

## Commentary (optional)

Also rewrite some code to add more readability without changing the functionality.

<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

## Description

Lead with the intended commit body in this description field. For breaking changes, please include "BREAKING CHANGE:" at the beginning of your commit body. At minimum, this section should include a bracketed reference to the Jira ticket, e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.

## Test Plan

Describe the situations in which you've tested your change, and/or a screenshot as appropriate. Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.

## Commentary (optional)

It's best to review this PR commit by commit. This PR refactors the scale decider to become more developer-friendly.

--->

[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234