### PR TITLE
feat: support gradient clipping in PyTorchTrial via callbacks [DET-3233]

### DIFF
--- a/docs/reference/api/pytorch.txt
+++ b/docs/reference/api/pytorch.txt
@@ -132,6 +132,18 @@ Then, implement the ``build_callbacks`` function in ``PyTorchTrial``:
     def build_callbacks(self):
         return {"reduce_lr": ReduceLROnPlateauEveryValidationStep(self.context)}
 
+
+``Gradient Clipping``
+^^^^^^^^^^^^^^^^^^^^^
+
+To perform gradient clipping Determined provides two pre-made callback classes:
+
+.. autoclass:: determined.pytorch.ClipGradsL2Norm
+    :members:
+
+.. autoclass:: determined.pytorch.ClipGradsL2Value
+    :members:
+
 Examples
 --------
 

--- a/harness/determined/pytorch/__init__.py
+++ b/harness/determined/pytorch/__init__.py
@@ -9,7 +9,7 @@ from determined.pytorch._data import (
     data_length,
     to_device,
 )
-from determined.pytorch._callback import PyTorchCallback
+from determined.pytorch._callback import PyTorchCallback, ClipGradsL2Norm, ClipGradsL2Value
 from determined.pytorch._lr_scheduler import LRScheduler, _LRHelper
 from determined.pytorch._reducer import Reducer, _reduce_metrics
 from determined.pytorch._pytorch_context import PyTorchTrialContext

--- a/harness/determined/pytorch/_callback.py
+++ b/harness/determined/pytorch/_callback.py
@@ -1,4 +1,6 @@
-from typing import Any, Dict
+from typing import Any, Dict, Iterator
+
+import torch
 
 
 class PyTorchCallback:
@@ -39,6 +41,14 @@ class PyTorchCallback:
         """
         pass
 
+    def on_before_optimizer_step(self, parameters: Iterator) -> None:
+        """
+        Run before every before `optimizer.step()`.  For multi-GPU training, executes
+        after gradient updates have been communicated. Typically used to perform gradient
+        clipping.
+        """
+        pass
+
     def on_validation_step_start(self) -> None:
         """
         Run before every validation step begins.
@@ -75,3 +85,29 @@ class PyTorchCallback:
         Load the state of this using the deserialized ``state_dict``.
         """
         pass
+
+
+class ClipGradsL2Norm(PyTorchCallback):
+    """
+    Callback that performs gradient clipping using
+    `L2 Norm <https://pytorch.org/docs/stable/nn.html#clip-grad-norm>`_.
+    """
+
+    def __init__(self, clip_value: float) -> None:
+        self._clip_value = clip_value
+
+    def on_before_optimizer_step(self, parameters: Iterator) -> None:
+        torch.nn.utils.clip_grad_norm_(parameters, self._clip_value)  # type: ignore
+
+
+class ClipGradsL2Value(PyTorchCallback):
+    """
+    Callback that performs gradient clipping using
+    `L2 Value <https://pytorch.org/docs/stable/nn.html#clip-grad-value>`_.
+    """
+
+    def __init__(self, clip_value: float) -> None:
+        self._clip_value = clip_value
+
+    def on_before_optimizer_step(self, parameters: Iterator) -> None:
+        torch.nn.utils.clip_grad_value_(parameters, self._clip_value)  # type: ignore

--- a/harness/tests/experiment/pytorch/test_pytorch_trial.py
+++ b/harness/tests/experiment/pytorch/test_pytorch_trial.py
@@ -415,9 +415,9 @@ class TestPyTorchTrial:
         )
         controller.run()
 
-        updated_hparams = {"clip_grad_l2_norm": 0.0001, **self.hparams}
+        updated_hparams = {"gradient_clipping_l2_norm": 0.0001, **self.hparams}
         controller = utils.make_trial_controller_from_trial_implementation(
-            trial_class=pytorch_xor_model.XORTrialMulti,
+            trial_class=pytorch_xor_model.XORTrialGradClipping,
             hparams=updated_hparams,
             workloads=make_workloads("clipped_by_norm"),
             trial_seed=self.trial_seed,
@@ -431,9 +431,9 @@ class TestPyTorchTrial:
                 continue
             assert original["loss"] != clipped["loss"]
 
-        updated_hparams = {"clip_grad_val": 0.0001, **self.hparams}
+        updated_hparams = {"gradient_clipping_value": 0.0001, **self.hparams}
         controller = utils.make_trial_controller_from_trial_implementation(
-            trial_class=pytorch_xor_model.XORTrialMulti,
+            trial_class=pytorch_xor_model.XORTrialGradClipping,
             hparams=updated_hparams,
             workloads=make_workloads("clipped_by_val"),
             trial_seed=self.trial_seed,


### PR DESCRIPTION
## Description
Previously we supported gradient clipping in PyTorch only via special hyperparameters. Moving to supporting it via callbacks will make it more transparent for users as well as allow users to apply more specialized clipping techniques.

As part of this PR also providing pre-made callbacks for the two types of gradient clipping we had previously supported. 

[DET-3233](https://determinedai.atlassian.net/browse/DET-3233)

## Test Plan
Updated existing tests.
