### PR TITLE
test: set seed for fashion mnist nightly convergence test [DET-3234]

### DIFF
--- a/e2e_tests/tests/nightly/test_convergence.py
+++ b/e2e_tests/tests/nightly/test_convergence.py
@@ -162,6 +162,7 @@ def test_iris_tf_keras() -> None:
 @pytest.mark.nightly  # type: ignore
 def test_fashion_mnist_tf_keras() -> None:
     config = conf.load_config(conf.official_examples_path("fashion_mnist_tf_keras/const.yaml"))
+    config = conf.set_random_seed(config, 1591110586)
     experiment_id = exp.run_basic_test_with_temp_config(
         config, conf.official_examples_path("fashion_mnist_tf_keras"), 1
     )


### PR DESCRIPTION
## Description
Without the random seed, the convergence sometimes falls just short of the target accuracy of `0.85`.


## Test Plan
Tested locally. 


