### PR TITLE
feat: checkpoint metadata api

### DIFF
--- a/common/determined_common/experimental/checkpoint/_checkpoint.py
+++ b/common/determined_common/experimental/checkpoint/_checkpoint.py
@@ -31,6 +31,8 @@ class Checkpoint(object):
         end_time: str,
         resources: Dict[str, Any],
         validation: Dict[str, Any],
+        metadata: Optional[Dict[str, Any]] = None,
+        master: Optional[str] = None,
     ):
         """
         Arguments:
@@ -54,6 +56,8 @@ class Checkpoint(object):
         self.end_time = end_time
         self.resources = resources
         self.validation = validation
+        self.metadata = metadata
+        self._master = master
 
     def _find_shared_fs_path(self) -> pathlib.Path:
         host_path = self.storage_config["host_path"]
@@ -144,6 +148,22 @@ class Checkpoint(object):
         ckpt_path = self.download(path)
         return Checkpoint.load_from_path(ckpt_path, tags=tags)
 
+    def add_metadata(self, metadata: Dict[str, Any]) -> None:
+        if self._master:
+            r = api.post(
+                self._master,
+                "checkpoints/{}/metadata".format(self.uuid),
+                body={"metadata": metadata},
+            )
+            self.metadata = r.json()
+
+    def remove_metadata(self, keys: List[str]) -> None:
+        if self._master:
+            r = api.delete(
+                self._master, "checkpoints/{}/metadata".format(self.uuid), params={"keys": keys}
+            )
+            self.metadata = r.json()
+
     @staticmethod
     def load_from_path(path: str, tags: Optional[List[str]] = None) -> Any:
         """
@@ -204,10 +224,11 @@ class Checkpoint(object):
 
 def get_checkpoint(uuid: str, master: str) -> Checkpoint:
     r = api.get(master, "checkpoints/{}".format(uuid)).json()
-    return from_json(r)
+    return from_json(r, master)
 
 
-def from_json(data: Dict[str, Any]) -> Checkpoint:
+def from_json(data: Dict[str, Any], master: Optional[str] = None) -> Checkpoint:
+    # __import__("pprint").pprint(data)
     validation = {
         "metrics": data.get("metrics", {}),
         "state": data.get("validation_state", None),
@@ -220,4 +241,6 @@ def from_json(data: Dict[str, Any]) -> Checkpoint:
         data["end_time"],
         data["resources"],
         validation,
+        metadata=data.get("metadata"),
+        master=master,
     )

--- a/common/determined_common/experimental/experiment.py
+++ b/common/determined_common/experimental/experiment.py
@@ -81,4 +81,4 @@ class ExperimentReference:
             reverse=not smaller_is_better, key=lambda x: x["metrics"]["validation_metrics"][sort_by]
         )
 
-        return [checkpoint.from_json(ckpt) for ckpt in r[:limit]]
+        return [checkpoint.from_json(ckpt, self._master) for ckpt in r[:limit]]

--- a/common/determined_common/experimental/trial.py
+++ b/common/determined_common/experimental/trial.py
@@ -105,7 +105,7 @@ class TrialReference:
             raise AssertionError("No checkpoint found for trial {}".format(self.id))
 
         if latest:
-            return checkpoint.from_json(r[0])
+            return checkpoint.from_json(r[0], master=self._master)
 
         if not sort_by:
             sort_by = r[0]["metric"]
@@ -113,5 +113,6 @@ class TrialReference:
 
         best_checkpoint_func = min if smaller_is_better else max
         return checkpoint.from_json(
-            best_checkpoint_func(r, key=lambda x: x["metrics"]["validation_metrics"][sort_by])
+            best_checkpoint_func(r, key=lambda x: x["metrics"]["validation_metrics"][sort_by]),
+            master=self._master,
         )

--- a/common/determined_common/storage/base.py
+++ b/common/determined_common/storage/base.py
@@ -10,31 +10,31 @@ from determined_common.check import check_gt, check_not_none, check_true, check_
 
 class StorageMetadata:
     def __init__(
-        self, storage_id: str, resources: Dict[str, int], labels: Optional[Dict[str, str]] = None
+        self, storage_id: str, resources: Dict[str, int], metadata: Optional[Dict[str, str]] = None
     ) -> None:
         check_gt(len(storage_id), 0, "Invalid storage ID")
-        if labels is None:
-            labels = {}
+        if metadata is None:
+            metadata = {}
         self.storage_id = storage_id
         self.resources = resources
-        self.labels = labels
+        self.metadata = metadata
 
     def __json__(self) -> Dict[str, Any]:
-        return {"uuid": self.storage_id, "resources": self.resources, "labels": self.labels}
+        return {"uuid": self.storage_id, "resources": self.resources, "metadata": self.metadata}
 
     def __str__(self) -> str:
-        return "<storage {}, labels {}>".format(self.storage_id, self.labels)
+        return "<storage {}, metadata {}>".format(self.storage_id, self.metadata)
 
     def __repr__(self) -> str:
-        return "<storage {}, labels {}, resources {}>".format(
-            self.storage_id, self.labels, self.resources
+        return "<storage {}, metadata {}, resources {}>".format(
+            self.storage_id, self.metadata, self.resources
         )
 
     @staticmethod
     def from_json(record: Dict[str, Any]) -> "StorageMetadata":
         check_not_none(record["uuid"], "Storage ID is undefined")
         check_not_none(record["resources"], "Resources are undefined")
-        return StorageMetadata(record["uuid"], record["resources"], record.get("labels"))
+        return StorageMetadata(record["uuid"], record["resources"], record.get("metadata"))
 
 
 class StorageManager:

--- a/master/internal/core.go
+++ b/master/internal/core.go
@@ -474,6 +474,8 @@ func (m *Master) Run() error {
 	checkpointsGroup := m.echo.Group("/checkpoints", authFuncs...)
 	checkpointsGroup.GET("", api.Route(m.getCheckpoints))
 	checkpointsGroup.GET("/:checkpoint_uuid", api.Route(m.getCheckpoint))
+	checkpointsGroup.POST("/:checkpoint_uuid/metadata", api.Route(m.addCheckpointMetadata))
+	checkpointsGroup.DELETE("/:checkpoint_uuid/metadata", api.Route(m.deleteCheckpointMetadata))
 
 	m.echo.GET("/ws/trial/:experiment_id/:trial_id/:container_id",
 		api.WebSocketRoute(m.trialWebSocket))

--- a/master/internal/core_checkpoints.go
+++ b/master/internal/core_checkpoints.go
@@ -2,8 +2,11 @@ package internal
 
 import (
 	"encoding/json"
+	"fmt"
 
+	"github.com/google/uuid"
 	"github.com/labstack/echo"
+	"github.com/pkg/errors"
 )
 
 // ExportableCheckpoint is a checkpoint that can be downloaded via checkpoint export.
@@ -15,6 +18,7 @@ type ExportableCheckpoint struct {
 	BatchNumber       int             `db:"batch_number" json:"batch_number"`
 	StartTime         string          `db:"start_time" json:"start_time"`
 	EndTime           string          `db:"end_time" json:"end_time"`
+	Metadata          json.RawMessage `db:"metadata" json:"metadata"`
 	Resources         json.RawMessage `db:"resources" json:"resources"`
 	ValidationMetrics json.RawMessage `db:"metrics" json:"metrics"`
 	ValidationState   string          `db:"validation_state" json:"validation_state"`
@@ -39,4 +43,63 @@ func (m *Master) getCheckpoints(c echo.Context) (interface{}, error) {
 		}
 	}
 	return checkpoints, nil
+}
+
+func (m *Master) addCheckpointMetadata(c echo.Context) (interface{}, error) {
+	uuid, err := uuid.Parse(c.Param("checkpoint_uuid"))
+	if err != nil {
+		return nil, err
+	}
+
+	args := struct {
+		Metadata map[string]interface{} `json:"metadata"`
+	}{}
+
+	if err := c.Bind(&args); err != nil {
+		return nil, err
+	}
+
+	checkpoint, err := m.db.CheckpointByUUID(uuid)
+	if err != nil {
+		return nil, errors.Wrapf(err, "error querying for checkpoint (%v)", uuid)
+	}
+	if checkpoint == nil {
+		return nil, errors.Errorf("checkpoint (%v) does not exist", uuid)
+	}
+
+	for k, v := range args.Metadata {
+		checkpoint.Metadata[k] = v
+	}
+
+	return checkpoint.Metadata, m.db.UpdateCheckpointMetadata(checkpoint)
+}
+
+func (m *Master) deleteCheckpointMetadata(c echo.Context) (interface{}, error) {
+	uuid, err := uuid.Parse(c.Param("checkpoint_uuid"))
+	if err != nil {
+		return nil, err
+	}
+
+	args := struct {
+		Keys []string `query:"keys"`
+	}{}
+
+	if err := c.Bind(&args); err != nil {
+		return nil, err
+	}
+
+	fmt.Printf("args = %+v\n", args)
+	checkpoint, err := m.db.CheckpointByUUID(uuid)
+	if err != nil {
+		return nil, errors.Wrapf(err, "error querying for checkpoint (%v)", uuid)
+	}
+	if checkpoint == nil {
+		return nil, errors.Errorf("checkpoint (%v) does not exist", uuid)
+	}
+
+	for _, key := range args.Keys {
+		delete(checkpoint.Metadata, key)
+	}
+
+	return checkpoint.Metadata, m.db.UpdateCheckpointMetadata(checkpoint)
 }

--- a/master/internal/db/postgres.go
+++ b/master/internal/db/postgres.go
@@ -1644,6 +1644,24 @@ WHERE id = :id`, setClause(toUpdate)), checkpoint)
 	return nil
 }
 
+func (db *PgDB) UpdateCheckpointMetadata(checkpoint *model.Checkpoint) error {
+	if checkpoint == nil {
+		return errors.Errorf("checkpoint cannot be nil does not exist")
+	}
+
+	toUpdate := []string{"metadata"}
+
+	err := db.namedExecOne(fmt.Sprintf(`
+UPDATE checkpoints
+%v
+WHERE id = :id`, setClause(toUpdate)), checkpoint)
+	if err != nil {
+		return errors.Wrapf(err, "error updating (%v) in checkpoint (%v)",
+			strings.Join(toUpdate, ", "), checkpoint.UUID)
+	}
+	return nil
+}
+
 // AddSearcherEvents adds the searcher events to the database.
 func (db *PgDB) AddSearcherEvents(events []*model.SearcherEvent) error {
 	if len(events) == 0 {

--- a/master/internal/experiment_utils.go
+++ b/master/internal/experiment_utils.go
@@ -104,23 +104,17 @@ func convertSearcherEvent(id int, event searcher.Event) (
 }
 
 // checkpointFromCheckpointMetrics converts a workload.CheckpointMetrics into a model.Checkpoint
-// with the UUID, Resources, and Labels fields filled out.
+// with the UUID, and Resources fields filled out.
 func checkpointFromCheckpointMetrics(metrics searcher.CheckpointMetrics) model.Checkpoint {
 	resources := model.JSONObj{}
 	for key, value := range metrics.Resources {
 		resources[key] = value
 	}
 
-	labels := model.JSONObj{}
-	for key, value := range labels {
-		labels[key] = value
-	}
-
 	id := metrics.UUID.String()
 	return model.Checkpoint{
 		UUID:      &id,
 		Resources: resources,
-		Labels:    labels,
 	}
 }
 
@@ -159,7 +153,7 @@ func markWorkloadCompleted(db *db.PgDB, msg searcher.CompletedMessage) error {
 		checkpoint := checkpointFromCheckpointMetrics(*msg.CheckpointMetrics)
 		return db.UpdateCheckpoint(
 			msg.Workload.TrialID, msg.Workload.StepID, model.CompletedState,
-			*checkpoint.UUID, checkpoint.Resources, checkpoint.Labels)
+			*checkpoint.UUID, checkpoint.Resources, checkpoint.Metadata)
 	case searcher.ComputeValidationMetrics:
 		metrics := make(model.JSONObj)
 		metrics["num_inputs"] = msg.ValidationMetrics.NumInputs

--- a/master/pkg/model/experiment.go
+++ b/master/pkg/model/experiment.go
@@ -341,7 +341,7 @@ type Checkpoint struct {
 	EndTime   *time.Time `db:"end_time" json:"end_time"`
 	UUID      *string    `db:"uuid" json:"uuid"`
 	Resources JSONObj    `db:"resources" json:"resources"`
-	Labels    JSONObj    `db:"labels" json:"labels"`
+	Metadata  JSONObj    `db:"metadata" json:"metadata"`
 }
 
 // NewCheckpoint creates a new checkpoint in the active state.
@@ -357,7 +357,7 @@ func NewCheckpoint(trialID, stepID int) *Checkpoint {
 // IsNew checks whether this checkpoint describes a new, in-progress checkpoint operation.
 func (c *Checkpoint) IsNew() bool {
 	return c.State == ActiveState && c.ID == 0 && c.EndTime == nil &&
-		c.UUID == nil && len(c.Resources) == 0 && len(c.Labels) == 0
+		c.UUID == nil && len(c.Resources) == 0 && len(c.Metadata) == 0
 }
 
 // TrialLog represents a row from the `trial_logs` table.

--- a/master/static/migrations/20200601100734_add-checkpoints-metadata.down.sql
+++ b/master/static/migrations/20200601100734_add-checkpoints-metadata.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE public.checkpoints RENAME COLUMN metadata TO labels;;

--- a/master/static/migrations/20200601100734_add-checkpoints-metadata.up.sql
+++ b/master/static/migrations/20200601100734_add-checkpoints-metadata.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE public.checkpoints RENAME COLUMN labels TO metadata;

--- a/master/static/srv/get_checkpoint.sql
+++ b/master/static/srv/get_checkpoint.sql
@@ -6,6 +6,7 @@ SELECT
     s.id * (e.config->>'batches_per_step')::int AS batch_number,
     s.start_time AS start_time,
     s.end_time AS end_time,
+		c.metadata AS metadata,
     c.resources AS resources,
     v.metrics AS metrics,
     v.state AS validation_state

--- a/master/static/srv/get_trial.sql
+++ b/master/static/srv/get_trial.sql
@@ -28,7 +28,7 @@ FROM
                       c.end_time,
                       c.uuid,
                       c.resources,
-                      c.labels
+                      c.metadata
                FROM checkpoints c
                WHERE c.trial_id = t.id
                  AND c.step_id = s.id ) r3) AS CHECKPOINT,

--- a/master/static/srv/get_trial_metrics.sql
+++ b/master/static/srv/get_trial_metrics.sql
@@ -29,7 +29,7 @@ FROM
                       c.end_time,
                       c.uuid,
                       c.resources,
-                      c.labels
+                      c.metadata
                FROM checkpoints c
                WHERE c.trial_id = t.id
                  AND c.step_id = s.id ) r3) AS CHECKPOINT,


### PR DESCRIPTION
## Description
Adds checkpoint metadata management REST endpoints and python client methods. 

## Test Plan
Manual sanity testing
```python
from determined.experimental import Determined

checkpoint = Determined().get_trial(1).top_checkpoint()

checkpoint.add_metadata({"something": {"override": "value"}})

print("ADD")
__import__("pprint").pprint(checkpoint.metadata)

checkpoint.remove_metadata(["test", "something"])
print("REMOVE")
__import__("pprint").pprint(checkpoint.metadata)
```