### PR TITLE
feat: decouple agent information from workloads starting tasks [DET-3178]

### DIFF
--- a/master/internal/agent/agent.go
+++ b/master/internal/agent/agent.go
@@ -64,7 +64,7 @@ func (a *agent) Receive(ctx *actor.Context) error {
 		}
 	case aproto.SignalContainer:
 		ctx.Ask(a.socket, ws.WriteMessage{Message: aproto.AgentMessage{SignalContainer: &msg}})
-	case scheduler.StartTask:
+	case scheduler.StartTaskOnAgent:
 		start := ws.WriteMessage{Message: aproto.AgentMessage{StartContainer: &msg.StartContainer}}
 		ctx.Ask(a.socket, start)
 		ctx.Tell(a.slots, msg.StartContainer)

--- a/master/internal/checkpoint_gc.go
+++ b/master/internal/checkpoint_gc.go
@@ -32,7 +32,7 @@ func (t *checkpointGCTask) Receive(ctx *actor.Context) error {
 			},
 		})
 
-	case scheduler.Assigned:
+	case scheduler.TaskAssigned:
 		config := t.experiment.Config.CheckpointStorage
 
 		checkpoints, err := t.db.ExperimentCheckpointsToGCRaw(t.experiment.ID,
@@ -43,12 +43,14 @@ func (t *checkpointGCTask) Receive(ctx *actor.Context) error {
 
 		ctx.Log().Info("starting checkpoint garbage collection")
 
-		msg.StartTask(tasks.TaskSpec{
-			GCCheckpoints: &tasks.GCCheckpoints{
-				AgentUserGroup:   t.agentUserGroup,
-				ExperimentID:     t.experiment.ID,
-				ExperimentConfig: t.experiment.Config,
-				ToDelete:         checkpoints,
+		ctx.Tell(t.cluster, scheduler.StartTask{
+			Spec: tasks.TaskSpec{
+				GCCheckpoints: &tasks.GCCheckpoints{
+					AgentUserGroup:   t.agentUserGroup,
+					ExperimentID:     t.experiment.ID,
+					ExperimentConfig: t.experiment.Config,
+					ToDelete:         checkpoints,
+				},
 			},
 		})
 

--- a/master/internal/command/command.go
+++ b/master/internal/command/command.go
@@ -111,15 +111,17 @@ func (c *command) Receive(ctx *actor.Context) error {
 			c.exit(ctx, exitStatus)
 		}
 
-	case scheduler.Assigned:
-		msg.StartTask(tasks.TaskSpec{
-			StartCommand: &tasks.StartCommand{
-				AgentUserGroup:  c.agentUserGroup,
-				Config:          c.config,
-				UserFiles:       c.userFiles,
-				AdditionalFiles: c.additionalFiles,
+	case scheduler.TaskAssigned:
+		ctx.Tell(c.cluster, scheduler.StartTask{
+			Spec: tasks.TaskSpec{
+				StartCommand: &tasks.StartCommand{
+					AgentUserGroup:  c.agentUserGroup,
+					Config:          c.config,
+					UserFiles:       c.userFiles,
+					AdditionalFiles: c.additionalFiles,
+				},
+				HarnessPath: c.harnessPath,
 			},
-			HarnessPath: c.harnessPath,
 		})
 		ctx.Tell(c.eventStream, event{Snapshot: newSummary(c), AssignedEvent: &msg})
 

--- a/master/internal/command/events.go
+++ b/master/internal/command/events.go
@@ -28,7 +28,7 @@ type event struct {
 
 	ScheduledEvent *scheduler.TaskID `json:"scheduled_event"`
 	// AssignedEvent is triggered when the parent was assigned to an agent.
-	AssignedEvent *scheduler.Assigned `json:"assigned_event"`
+	AssignedEvent *scheduler.TaskAssigned `json:"assigned_event"`
 	// ContainerStartedEvent is triggered when the container started on an agent.
 	ContainerStartedEvent *scheduler.ContainerStarted `json:"container_started_event"`
 	// ServiceReadyEvent is triggered when the service running in the container is ready to serve.

--- a/master/internal/scheduler/agent.go
+++ b/master/internal/scheduler/agent.go
@@ -42,8 +42,8 @@ type (
 
 // Incoming agent actor messages; agent actors must accept these messages.
 type (
-	// StartTask notifies the agent to start the task with the provided task spec.
-	StartTask struct {
+	// StartTaskOnAgent notifies the agent to start the task with the provided task spec.
+	StartTaskOnAgent struct {
 		Task *actor.Ref
 		agent.StartContainer
 	}

--- a/master/internal/scheduler/cluster_test.go
+++ b/master/internal/scheduler/cluster_test.go
@@ -20,7 +20,7 @@ var errMock = errors.New("mock error")
 type mockActor struct {
 	system             *actor.System
 	cluster            *actor.Ref
-	onAssigned         func(Assigned) error
+	onAssigned         func(TaskAssigned) error
 	onContainerStarted func(ContainerStarted) error
 	onTaskTerminated   func(TaskTerminated) error
 }
@@ -48,14 +48,14 @@ func (h *mockActor) Receive(ctx *actor.Context) error {
 	case ThrowPanic:
 		panic(errMock)
 
-	case Assigned:
+	case TaskAssigned:
 		if h.onAssigned != nil {
 			return h.onAssigned(msg)
 		}
 
 		h.system.Tell(h.cluster, ContainerStateChanged{
 			Container: cproto.Container{
-				ID:    cproto.ID(msg.container.id),
+				ID:    cproto.ID("random-container-name"),
 				State: cproto.Running,
 			},
 			ContainerStarted: &agent.ContainerStarted{

--- a/master/internal/scheduler/resource_provider.go
+++ b/master/internal/scheduler/resource_provider.go
@@ -56,3 +56,14 @@ type ContainerStateChanged struct {
 	ContainerStarted *agent.ContainerStarted
 	ContainerStopped *agent.ContainerStopped
 }
+
+// TaskAssigned is a message that tells the task actor that it has been assigned to run
+// with a specified number of containers.
+type TaskAssigned struct {
+	numContainers int
+}
+
+// NumContainers returns the number of containers to which the task has been assigned.
+func (t *TaskAssigned) NumContainers() int {
+	return t.numContainers
+}

--- a/master/internal/scheduler/scheduler_test.go
+++ b/master/internal/scheduler/scheduler_test.go
@@ -79,9 +79,9 @@ func newMockTask(
 }
 
 func (t *mockTask) Receive(ctx *actor.Context) error {
-	switch msg := ctx.Message().(type) {
-	case Assigned:
-		msg.StartTask(tasks.TaskSpec{})
+	switch ctx.Message().(type) {
+	case TaskAssigned:
+		ctx.Respond(StartTask{Spec: tasks.TaskSpec{}})
 	case getSlots:
 		ctx.Respond(t.slotsNeeded)
 	case getGroup:
@@ -115,7 +115,7 @@ func newMockAgent(
 
 func (m mockAgent) Receive(ctx *actor.Context) error {
 	switch msg := ctx.Message().(type) {
-	case StartTask:
+	case StartTaskOnAgent:
 		if ctx.ExpectingResponse() {
 			ctx.Respond(newTask(&Task{
 				handler: msg.Task,

--- a/master/internal/scheduler/task.go
+++ b/master/internal/scheduler/task.go
@@ -6,6 +6,7 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/determined-ai/determined/master/pkg/actor"
+	"github.com/determined-ai/determined/master/pkg/tasks"
 )
 
 // Task-related cluster level messages.
@@ -19,6 +20,10 @@ type (
 		CanTerminate        bool
 		Label               string
 		FittingRequirements FittingRequirements
+	}
+	// StartTask signals that a scheduled task should be launched.
+	StartTask struct {
+		Spec tasks.TaskSpec
 	}
 	// taskStopped notifies that the task actor is stopped.
 	taskStopped struct {


### PR DESCRIPTION
## Description
As part of this change, Tasks now receive a single `TaskAssigned` message
when they are assigned rather than one `Assigned` message per container.
They also start containers by sending specs back to the cluster rather than directly to agents.


## Test Plan
Updated existing tests which should provide coverage. Additionally going to perform manual testing to test multi-container changes, and sanity check commands. 
