### PR TITLE
test: fix nightly nas and iris tf keras tests [DET-3264]

### DIFF
--- a/e2e_tests/tests/nightly/test_convergence.py
+++ b/e2e_tests/tests/nightly/test_convergence.py
@@ -137,6 +137,7 @@ def test_object_detection_accuracy() -> None:
 @pytest.mark.nightly  # type: ignore
 def test_iris_tf_keras() -> None:
     config = conf.load_config(conf.official_examples_path("iris_tf_keras/const.yaml"))
+    config = conf.set_random_seed(config, 1591280374)
     experiment_id = exp.run_basic_test_with_temp_config(
         config, conf.official_examples_path("iris_tf_keras"), 1
     )

--- a/examples/experimental/nas_search/arch_search.yaml
+++ b/examples/experimental/nas_search/arch_search.yaml
@@ -1,6 +1,6 @@
 description: NAS_Search
 hyperparameters:
-  clip_grad_l2_norm: .25
+  clip_gradients_l2_norm: .25
   global_batch_size: 64
   bptt: 35
   learning_rate: 20

--- a/examples/experimental/nas_search/model_def.py
+++ b/examples/experimental/nas_search/model_def.py
@@ -25,7 +25,7 @@ from torch import nn
 from torch.optim.lr_scheduler import _LRScheduler
 
 import determined as det
-from determined.pytorch import DataLoader, PyTorchTrial, LRScheduler
+from determined.pytorch import ClipGradsL2Norm, DataLoader, PyTorchCallback, PyTorchTrial, LRScheduler
 
 
 import data
@@ -343,3 +343,6 @@ class NASModel(PyTorchTrial):
             ),
             collate_fn=data.PadSequence(),
         )
+
+    def build_callbacks(self) -> Dict[str, PyTorchCallback]:
+        return {"clip_grads": ClipGradsL2Norm(self.context.get_hparam("clip_gradients_l2_norm"))}

--- a/examples/experimental/nas_search/train_one_arch.yaml
+++ b/examples/experimental/nas_search/train_one_arch.yaml
@@ -1,6 +1,6 @@
 description: NAS_ASHA
 hyperparameters:
-  clip_grad_l2_norm: .25
+  clip_gradients_l2_norm: .25
   global_batch_size: 64
   bptt: 35
   learning_rate: 20


### PR DESCRIPTION
## Description
NAS was using the old form of gradient clipping. Iris test needed to have a random seed set to reduce flakiness.


## Test Plan
Tested locally. 
