### PR TITLE
fix: space out WebUI plot x-axis ticks a bit more

### DIFF
--- a/webui/elm/src/Plot.elm
+++ b/webui/elm/src/Plot.elm
@@ -137,7 +137,7 @@ plotScalesWithLabels =
 padding : Padding
 padding =
     { top = 30
-    , right = 20
+    , right = 30
     , bottom = 40
     , left = 75
     }
@@ -358,7 +358,7 @@ plotView config model sz data =
                 ( List.length data, List.length data )
 
             else
-                ( round <| min (x1 - x0 + 1) ((cx1 - cx0) / 40), round <| (cy0 - cy1) / 30 )
+                ( round <| min (x1 - x0 + 1) ((cx1 - cx0) / 60), round <| (cy0 - cy1) / 30 )
 
         xScale =
             Scale.linear ( cx0, cx1 ) ( x0, x1 )


### PR DESCRIPTION
## Description

The ticks could get bunched up too much with long-running experiments
before; this just makes sure the spacing is a bit wider by enough to
work well in reasonable cases. The ticks may now occasionally look a
tiny bit wider than ideal with very short experiments, but it still
works fine in practice. Similarly, a long last tick could get cut off at
the end, so this also bumps the right side spacing correspondingly.

## Test Plan

- [x] look at a couple of different plots at various widths, check that the ticks look reasonable

## Commentary (optional)

Before:
![2020-06-05-12-05-12 604867188](https://user-images.githubusercontent.com/596106/83914485-289a0600-a726-11ea-8649-93423465b745.png)
After:
![2020-06-05-12-05-18 227101606](https://user-images.githubusercontent.com/596106/83914486-29329c80-a726-11ea-8715-cd5328816dfd.png)
