### PR TITLE
chore: add license to pip metadata

### DIFF
--- a/cli/setup.py
+++ b/cli/setup.py
@@ -8,6 +8,7 @@ setup(
     url="https://determined.ai/",
     description="Determined Deep Learning Training Platform",
     long_description="See https://docs.determined.ai/ for more information.",
+    license="Apache License 2.0",
     classifiers=["License :: OSI Approved :: Apache Software License"],
     packages=find_packages(exclude=["*.tests", "*.tests.*", "tests.*", "tests"]),
     python_requires=">=3.5",

--- a/common/setup.py
+++ b/common/setup.py
@@ -8,6 +8,7 @@ setup(
     url="https://determined.ai/",
     description="Determined Deep Learning Training Platform",
     long_description="See https://docs.determined.ai/ for more information.",
+    license="Apache License 2.0",
     classifiers=["License :: OSI Approved :: Apache Software License"],
     packages=find_packages(exclude=["*.tests", "*.tests.*", "tests.*", "tests"]),
     python_requires=">=3.5",

--- a/deploy/setup.py
+++ b/deploy/setup.py
@@ -8,6 +8,7 @@ setup(
     url="https://determined.ai/",
     description="Determined Deep Learning Training Platform",
     long_description="See https://docs.determined.ai/ for more information.",
+    license="Apache License 2.0",
     classifiers=["License :: OSI Approved :: Apache Software License"],
     packages=find_packages(exclude=["*.tests", "*.tests.*", "tests.*", "tests"]),
     include_package_data=True,

--- a/harness/setup.py
+++ b/harness/setup.py
@@ -8,6 +8,7 @@ setup(
     url="https://determined.ai/",
     description="Determined Deep Learning Training Platform",
     long_description="See https://docs.determined.ai/ for more information.",
+    license="Apache License 2.0",
     classifiers=["License :: OSI Approved :: Apache Software License"],
     packages=find_packages(exclude=["*.tests", "*.tests.*", "tests.*", "tests"]),
     python_requires=">=3.6",


### PR DESCRIPTION
Without this change, `pip show determined-cli | grep License` returns:

    License: UNKNOWN