### PR TITLE
fix: update state labels to be more user-friendly

### DIFF
--- a/webui/react/src/utils/types.ts
+++ b/webui/react/src/utils/types.ts
@@ -80,9 +80,9 @@ export const runStateToLabel: {[key in RunState]: string} = {
   [RunState.Deleted]: 'Deleted',
   [RunState.Errored]: 'Errored',
   [RunState.Paused]: 'Paused',
-  [RunState.StoppingCanceled]: 'StoppingCanceled',
-  [RunState.StoppingCompleted]: 'StoppingCompleted',
-  [RunState.StoppingError]: 'StoppingErrored',
+  [RunState.StoppingCanceled]: 'Canceling',
+  [RunState.StoppingCompleted]: 'Completing',
+  [RunState.StoppingError]: 'Erroring',
 };
 
 export const commandStateToLabel: {[key in CommandState]: string} = {


### PR DESCRIPTION
## Description

We have three states that are hard to understand.
`StoppingCanceled`, `StoppingCompleted` and `StoppingError`

Updated them to something easier to understand.
`Canceling`, `Completing` and `Erroring`

## Test Plan



## Commentary (optional)

<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

## Description

Lead with the intended commit body in this description field. For breaking changes, please include "BREAKING CHANGE:" at the beginning of your commit body. At minimum, this section should include a bracketed reference to the Jira ticket, e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.

## Test Plan

Describe the situations in which you've tested your change, and/or a screenshot as appropriate. Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.

## Commentary (optional)

Use this section of your description to add context to the PR. Could be for particularly tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc. You may intentionally leave this section blank and remove the title.
--->

[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234