### PR TITLE
ci: ensure npm ci does not dirty package-lock via npm-force-resolutions

### DIFF
--- a/webui/elm/package.json
+++ b/webui/elm/package.json
@@ -20,7 +20,7 @@
     "tailwindcss": "^1.2.0"
   },
   "scripts": {
-    "preinstall": "npx npm-force-resolutions",
+    "postshrinkwrap": "npx npm-force-resolutions && npm install --ignore-scripts",
     "build-elm": "elm make src/Main.elm",
     "build-css": "postcss styles-in.css",
     "live-workaround": "elm-live --pushstate --proxyPrefix /api --proxyHost http://localhost:8080 src/Main.elm --",

--- a/webui/react/package.json
+++ b/webui/react/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "preinstall": "npx npm-force-resolutions",
+    "postshrinkwrap": "npx npm-force-resolutions && npm install --ignore-scripts",
     "start": "react-app-rewired start",
     "build": "react-app-rewired build",
     "lint": "npm run lint:js && npm run lint:css",


### PR DESCRIPTION
## Description

There are security vulnerabilities that are sometimes discovered in npm packages that are dependencies of dependencies which we do not directly control. To overcome this limitation, we us `npm-force-resolutions` and the `resolutions` field under `package.json` to forcibly resolve the packages to use the proper dependencies that resolved the security vulnerabilities. The problem is that the resolution process should only occur during the package installation step (`npm install`) but NOT during CI gathering of dependencies (`npm ci`). Currently it occurs in both. This PR uses a `postshrinkwrap` script to run `npm-force-resolutions`, which only occurs for `npm install` and not `npm ci`.

@hamidzr discovered this post that provides basis of this solution:
https://github.com/rogeriochaves/npm-force-resolutions/issues/10#issuecomment-601951821

## Test Plan

Check that...
1) `npm ci` does not alter any files, especially `package.json` and `package-lock.json`.
2) `npm install` does run `npx npm-force-resolutions` (`postshrinkwrap` script).

## Commentary (optional)


<!-- User-facing API changes need the "User-facing API Change" label -->

<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

## Description

Lead with the intended commit body in this description field. For breaking changes, please include "BREAKING CHANGE:" at the beginning of your commit body. At minimum, this section should include a bracketed reference to the Jira ticket, e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.

## Test Plan

Describe the situations in which you've tested your change, and/or a screenshot as appropriate. Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.

## Commentary (optional)

Use this section of your description to add context to the PR. Could be for particularly tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc. You may intentionally leave this section blank and remove the title.
--->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234