### PR TITLE
fix: correctly use mixed precision with multi-GPU in PyTorchTrial [DET-3285]

### DIFF
--- a/e2e_tests/tests/experiment/test_pytorch.py
+++ b/e2e_tests/tests/experiment/test_pytorch.py
@@ -99,9 +99,6 @@ def test_pytorch_const_parallel(aggregation_frequency: int, use_amp: bool) -> No
     if use_amp and aggregation_frequency > 1:
         pytest.skip("Mixed precision is not support with aggregation frequency > 1.")
 
-    if use_amp:
-        pytest.skip("AMP support NaNs right now, disabling until this is fixed.")
-
     config = conf.load_config(conf.official_examples_path("trial/mnist_pytorch/const.yaml"))
     config = conf.set_slots_per_trial(config, 8)
     config = conf.set_native_parallel(config, False)


### PR DESCRIPTION
## Description
When performing mixed precision multi-GPU training, we need to finalize gradient update communication prior to un-scaling.


## Test Plan
Re-enabled test and tested manually,
