### PR TITLE
feat: show experiments in increments [DET-3320]

### DIFF
--- a/webui/elm/src/Page/ExperimentList.elm
+++ b/webui/elm/src/Page/ExperimentList.elm
@@ -218,7 +218,7 @@ batchArchive =
 
 entriesShowIncrement : Int
 entriesShowIncrement =
-    50
+    25
 
 
 type alias TableExperiment =

--- a/webui/elm/src/Page/ExperimentList.elm
+++ b/webui/elm/src/Page/ExperimentList.elm
@@ -1747,7 +1747,7 @@ tableConfig sess m =
         , customizations =
             let
                 rowAttrs exp =
-                    [ HA.class "cursor-pointer hover:bg-orange-100"
+                    [ HA.class "record cursor-pointer hover:bg-orange-100"
                     , HE.on "click"
                         (D.map (SendOut << Comm.RouteRequested (Route.ExperimentDetail <| unpack .id .id exp.experimentResult))
                             (D.map2 (||) (D.field "ctrlKey" D.bool) (D.field "metaKey" D.bool))

--- a/webui/elm/src/Page/ExperimentList.elm
+++ b/webui/elm/src/Page/ExperimentList.elm
@@ -216,6 +216,11 @@ batchArchive =
     }
 
 
+entriesShowIncrement : Int
+entriesShowIncrement =
+    50
+
+
 type alias TableExperiment =
     { experimentResult : Types.ExperimentResult
     , labelWidgetState : LW.State
@@ -274,6 +279,7 @@ type alias LoadedModel =
     , killBtn : Button.Model Msg
     , pendingBatchRequest : Maybe ( BatchOperation, Set.Set Types.ID )
     , pendingTensorBoard : Maybe (Set.Set Types.ID)
+    , numEntriesToShow : Int
     }
 
 
@@ -462,6 +468,7 @@ initLoaded session filterState tableState experiments =
             , pendingBatchRequest = Nothing
             , pendingTensorBoard = Nothing
             , filterState = filterState
+            , numEntriesToShow = entriesShowIncrement
             }
 
         cmd =
@@ -538,6 +545,10 @@ type Msg
       -- that is routed through GotTensorBoardLaunchCycleMsg.
     | GotTensorBoardLaunchCycleMsg (Set.Set Types.ID) TensorBoard.TensorBoardLaunchCycleMsg
     | OpenTBOverSelectedExperiments
+      -- Table control.
+    | ShowLess Int
+    | ShowMore Int
+    | ShowAll
       -- Errors.
     | GotCriticalError Comm.SystemError
     | GotAPIErrorAction ExperimentUpdate Types.ID API.APIError
@@ -911,6 +922,21 @@ updateLoaded msg model session =
 
             else
                 ( model, Cmd.none, Nothing )
+
+        ShowLess n ->
+            ( { model | numEntriesToShow = model.numEntriesToShow - n }, Cmd.none, Nothing )
+
+        ShowMore n ->
+            ( { model | numEntriesToShow = model.numEntriesToShow + n }, Cmd.none, Nothing )
+
+        ShowAll ->
+            let
+                nEntries =
+                    model.experiments
+                        |> Maybe.withDefault []
+                        |> List.length
+            in
+            ( { model | numEntriesToShow = nEntries }, Cmd.none, Nothing )
 
         GotCriticalError crit ->
             ( model, Cmd.none, Comm.Error crit |> Just )
@@ -1440,7 +1466,12 @@ viewTableBody model sess =
                 |> Maybe.Extra.unwrap [] (List.filter (filterExperimentResults model))
     in
     H.div [ HA.class "p-2" ]
-        [ Table.view (tableConfig sess) model.tableSortState Nothing filteredExperiments ]
+        [ Table.view
+            (tableConfig sess model)
+            model.tableSortState
+            (Just model.numEntriesToShow)
+            filteredExperiments
+        ]
 
 
 labelDropdownConfig : DropdownConfig String Msg
@@ -1607,8 +1638,84 @@ checkboxColumn =
         }
 
 
-tableConfig : Session -> Table.Config TableExperiment Msg
-tableConfig sess =
+tableConfig : Session -> LoadedModel -> Table.Config TableExperiment Msg
+tableConfig sess m =
+    let
+        actionClasses =
+            HA.class "font-semibold text-blue-500 hover:text-blue-300 cursor-pointer"
+
+        nEntries =
+            m.experiments
+                |> Maybe.withDefault []
+                |> List.length
+
+        showMore =
+            if nEntries > m.numEntriesToShow then
+                let
+                    remainder =
+                        min entriesShowIncrement (nEntries - m.numEntriesToShow)
+                in
+                Just
+                    (H.span
+                        [ actionClasses, HE.onClick (ShowMore remainder) ]
+                        [ "Show " ++ String.fromInt remainder ++ " more" |> H.text ]
+                    )
+
+            else
+                Nothing
+
+        showLess =
+            if m.numEntriesToShow > entriesShowIncrement then
+                let
+                    reduceCount =
+                        let
+                            remainder =
+                                modBy entriesShowIncrement m.numEntriesToShow
+                        in
+                        if remainder /= 0 then
+                            remainder
+
+                        else
+                            entriesShowIncrement
+                in
+                Just
+                    (H.span
+                        [ actionClasses, HE.onClick (ShowLess reduceCount) ]
+                        [ "Show " ++ String.fromInt reduceCount ++ " fewer" |> H.text ]
+                    )
+
+            else
+                Nothing
+
+        showAll =
+            if nEntries > m.numEntriesToShow then
+                Just
+                    (H.span
+                        [ actionClasses, HE.onClick ShowAll ]
+                        [ "Show all (" ++ String.fromInt nEntries ++ ")" |> H.text ]
+                    )
+
+            else
+                Nothing
+
+        divider =
+            H.div [ HA.class "inline-block border-l border-black mx-4" ] []
+
+        showList =
+            [ showMore, showLess, showAll ]
+                |> Maybe.Extra.values
+                |> List.intersperse divider
+
+        footer =
+            { attributes = []
+            , children =
+                [ H.tr []
+                    [ H.td [ HA.colspan 100 ]
+                        [ H.div [ HA.class "flex flex-row justify-center" ] showList ]
+                    ]
+                ]
+            }
+    in
     Table.customConfig
         { toId = .experimentResult >> unpack .id .id >> String.fromInt
         , toMsg = NewTableState
@@ -1647,7 +1754,7 @@ tableConfig sess =
                         )
                     ]
             in
-            { tableCustomizations | rowAttrs = rowAttrs }
+            { tableCustomizations | rowAttrs = rowAttrs, tfoot = Just footer }
         }
 
 

--- a/webui/tests/cypress/integration/01-setup.spec.ts
+++ b/webui/tests/cypress/integration/01-setup.spec.ts
@@ -1,4 +1,6 @@
 describe('setup', () => {
+  const recordSelector = '#experimentsList tr.record';
+
   before(() => {
     cy.login();
   });
@@ -8,11 +10,11 @@ describe('setup', () => {
   });
 
   it('should have 4 experiments listed', () => {
-    cy.get('#experimentsList tr').should('have.lengthOf', 4);
+    cy.get(recordSelector).should('have.lengthOf', 4);
   });
 
   it('should have 4 active experiments listed', () => {
-    cy.get('#experimentsList tr').should('have.lengthOf', 4)
+    cy.get(recordSelector).should('have.lengthOf', 4)
       .each(($tr) => {
         cy.wrap($tr).should('contain', 'Active');
       });
@@ -24,7 +26,7 @@ describe('setup', () => {
     cy.get('.modal button').contains(/pause/i).click();
     /* eslint-disable-next-line cypress/no-unnecessary-waiting */
     cy.wait(5000);
-    cy.get('#experimentsList tr')
+    cy.get(recordSelector)
       .each(($tr) => {
         cy.wrap($tr).should('contain', 'Paused');
       });
@@ -32,26 +34,26 @@ describe('setup', () => {
   });
 
   it('should be able to unpause experiment 1', () => {
-    cy.get('#experimentsList tr td:nth-child(2)').contains('1').click();
+    cy.get(recordSelector + ' td:nth-child(2)').contains('1').click();
     cy.contains('Activate').click();
     cy.visit('/ui/experiments');
-    cy.get('#experimentsList tr').should('contain', 'Active');
+    cy.get(recordSelector).should('contain', 'Active');
   });
 
   it('should cancel experiment 2', () => {
-    cy.get('#experimentsList tr td:nth-child(2)').contains('2').click();
+    cy.get(recordSelector + ' td:nth-child(2)').contains('2').click();
     cy.contains('Cancel').click();
     cy.get('.modal button').contains(/cancel/i).click();
     cy.contains('Canceled', { timeout: Cypress.config('responseTimeout') });
   });
 
   it('should archive experiment 2', () => {
-    cy.get('#experimentsList tr td:nth-child(2)').contains('2').click();
+    cy.get(recordSelector + ' td:nth-child(2)').contains('2').click();
     cy.contains('Canceled');
     cy.get('body').should('not.contain', /archived/i);
     cy.contains('Archive').click();
     cy.contains(/archived/i);
     cy.visit('/ui/experiments');
-    cy.get('#experimentsList tr').should('have.lengthOf', 3);
+    cy.get(recordSelector).should('have.lengthOf', 3);
   });
 });

--- a/webui/tests/cypress/integration/02-experiments.spec.ts
+++ b/webui/tests/cypress/integration/02-experiments.spec.ts
@@ -1,4 +1,6 @@
 describe('experiment List', () => {
+  const recordSelector = '#experimentsList tr.record';
+
   before(() => {
     cy.login();
     cy.visit('/ui/experiments');
@@ -28,17 +30,17 @@ describe('experiment List', () => {
   describe('table filter', () => {
     describe('archive toggle', () => {
       it('should show archived experiments when clicked', () => {
-        cy.get('#experimentsList tr').should('have.length', 3);
+        cy.get(recordSelector).should('have.length', 3);
         cy.get('#experimentsList .filters input[type=checkbox]').click();
-        cy.get('#experimentsList tr').should('have.length', 4);
+        cy.get(recordSelector).should('have.length', 4);
         cy.get('#experimentsList .filters input[type=checkbox]').click();
-        cy.get('#experimentsList tr').should('have.length', 3);
+        cy.get(recordSelector).should('have.length', 3);
       });
 
       it('should default to hiding archived experiments', () => {
         cy.get('#experimentsList .filters input[type=checkbox]').should('not.have.attr', 'checked');
-        cy.get('#experimentsList tr').should('have.length', 3);
-        cy.get('#experimentsList tr').should('not.contain', 'Yes');
+        cy.get(recordSelector).should('have.length', 3);
+        cy.get(recordSelector).should('not.contain', 'Yes');
       });
     });
   });


### PR DESCRIPTION
## Description

show experiments in increments instead of rendering all at the same time by default. we still keep the full list in memory to enable search over description.

batch operations work as before.

## Test Plan



## Commentary (optional)

an alternative to full pagination

noop single experiments

1200 exps
- 2MB payload
- 0.19s master latency

4500
- 0.6s master latency (curl)
- 8.5MB payload

9500
- 0.98s master latency
- 18MB payload


~10k experiments 

![Screen Capture_select-area_20200611132330](https://user-images.githubusercontent.com/12127420/84435696-1a952b00-abe7-11ea-8058-6efa5d991b47.png)
![Screen Capture_select-area_20200611132534](https://user-images.githubusercontent.com/12127420/84435694-19fc9480-abe7-11ea-95ba-e280ee408efe.png)

before: load+3seconds
![3320-16](https://user-images.githubusercontent.com/12127420/84439722-9b572580-abed-11ea-9323-4206287b6cb4.png)

before load+16seconds
![Screen Capture_select-area_20200611111534](https://user-images.githubusercontent.com/12127420/84435889-66e06b00-abe7-11ea-9bcf-7a77b11af5d8.png)


after: load+3seconds (50 rows shown by default)
![master16](https://user-images.githubusercontent.com/12127420/84439745-a742e780-abed-11ea-9ea5-4e831c6e8a4c.png)

after: load+3seconds
![Screen Capture_select-area_20200611132214](https://user-images.githubusercontent.com/12127420/84435913-6d6ee280-abe7-11ea-85ea-2a2d3c54e861.png)


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234