### PR TITLE
feat: support Pytorch flexible primitives [DET-3194, DET-3195, DET-3196, DET-3197, DET-3198]

### DIFF
--- a/common/determined_common/experimental/checkpoint/_torch.py
+++ b/common/determined_common/experimental/checkpoint/_torch.py
@@ -17,6 +17,9 @@ def load_model(ckpt_dir: pathlib.Path, metadata: Dict[str, Any], **kwargs: Any) 
     trial = cast(PyTorchTrial, trial)
     model = trial.build_model()
     checkpoint = torch.load(ckpt_dir.joinpath("state_dict.pth"), map_location="cpu")  # type: ignore
-    model.load_state_dict(checkpoint["model_state_dict"])
+
+    # TODO(DET-3456): The checkpoint schema is changed for mutliple models so this function should
+    #       be updated accordingly.
+    model.load_state_dict(checkpoint["models_state_dict"][0])
 
     return model

--- a/harness/determined/_experiment_config.py
+++ b/harness/determined/_experiment_config.py
@@ -23,6 +23,7 @@ class ExperimentConfig(dict):
     def native_parallel_enabled(self) -> bool:
         return bool(self["resources"]["native_parallel"])
 
+    # TODO(DET-3262): remove this backward compatibility.
     def mixed_precision_enabled(self) -> bool:
         return bool(self["optimizations"]["mixed_precision"] != "O0")
 

--- a/harness/determined/pytorch/_callback.py
+++ b/harness/determined/pytorch/_callback.py
@@ -47,6 +47,7 @@ class PyTorchCallback:
         after gradient updates have been communicated. Typically used to perform gradient
         clipping.
         """
+        # TODO(DET-3267): deprecate this when releasing pytorch flexible primitives.
         pass
 
     def on_validation_step_start(self) -> None:
@@ -87,6 +88,7 @@ class PyTorchCallback:
         pass
 
 
+# TODO(DET-3267): deprecate this when releasing pytorch flexible primitives.
 class ClipGradsL2Norm(PyTorchCallback):
     """
     Callback that performs gradient clipping using
@@ -100,6 +102,7 @@ class ClipGradsL2Norm(PyTorchCallback):
         torch.nn.utils.clip_grad_norm_(parameters, self._clip_value)  # type: ignore
 
 
+# TODO(DET-3267): deprecate this when releasing pytorch flexible primitives.
 class ClipGradsL2Value(PyTorchCallback):
     """
     Callback that performs gradient clipping using

--- a/harness/determined/pytorch/_lr_scheduler.py
+++ b/harness/determined/pytorch/_lr_scheduler.py
@@ -10,9 +10,10 @@ class LRScheduler:
     """Wrapper for a PyTorch LRScheduler.
 
     This wrapper fulfills two main functions:
-        1. Save and restore the learning rate when a trial is paused, preempted, etc.
-        2. Step the learning rate scheduler at the configured frequency
-           (e.g., every batch or every epoch).
+
+    1. Save and restore the learning rate when a trial is paused, preempted, etc.
+    2. Step the learning rate scheduler at the configured frequency
+       (e.g., every batch or every epoch).
     """
 
     class StepMode(enum.Enum):

--- a/harness/determined/pytorch/_pytorch_context.py
+++ b/harness/determined/pytorch/_pytorch_context.py
@@ -1,27 +1,71 @@
-from typing import Any, Optional, cast
+import enum
+import logging
+from typing import Any, Callable, Dict, Iterator, List, Optional, Tuple, Union
 
 import torch
 import torch.nn as nn
 
 import determined as det
 from determined import pytorch
+from determined.horovod import hvd
 from determined_common import check
+
+# Apex is included only for GPU trials.
+try:
+    import apex
+except ImportError:
+    if torch.cuda.is_available():
+        logging.warning("Failed to import apex.")
+    pass
+
+
+class _WarningLogs(enum.Enum):
+    FAILED_MOVING_TO_DEVICE = 1
 
 
 class PyTorchTrialContext(det.TrialContext):
-    """
-    Base context class that contains runtime information for any Determined
-    workflow that uses the ``pytorch`` API.
-    """
+    """Contains runtime information for any Determined workflow that uses the ``pytorch`` API."""
+
+    # TODO(DET-3204): Add the following comments to the docstring.
+    #
+    #     With this class, users can do the following things:
+    #
+    #     1. Wrap Pytorch models, optimizers, and LR schedulers with their Determined-compatible
+    #        counterparts using :meth:`Model`, :meth:`Optimizer`, :meth:`LRScheduler`,
+    #        respectively. The Determined-compatible objects are capable of transparent
+    #        distributed training, checkpointing and exporting, mixed-precision training,
+    #        and gradient aggregation.
+    #     2. Configure apex amp by :meth:`_configure_apex_amp`.
+    #     3. Calculate the gradients with :meth:`backward` on a specified loss.
+    #     4. Run an optimization step with :meth:`step_optimizer`.
+    #     5. Functionalities inherited from TrialContext, including getting the runtime
+    #        information and properly handling training data in distributed training.
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
+        self._init_device()
+        # Track whether a warning logging category has already been issued to the user.
+        self.warning_logged = {_WarningLogs.FAILED_MOVING_TO_DEVICE: False}
+
         # The following three attributes are initialized during the lifetime of
         # a PyTorchTrialContext.
-        self.model = None  # type: Optional[nn.Module]
-        self.optimizer = None
-        self.lr_scheduler = None  # type: Optional[pytorch.LRScheduler]
+        self.models = []  # type: List[nn.Module]
+        self.optimizers = []  # type: List[torch.optim.Optimizer] #  type: ignore
+        self.lr_schedulers = []  # type: List[pytorch.LRScheduler]
+
+        # Use a main model to contain all of the models because when using horovod
+        # to broadcast the states of models we want to avoid name conflicts for these
+        # states so we set all the models to be sub-module of the main model with
+        # different names using __setattr__ and use the state_dict of the main model
+        # for broadcasting. Note that broadcast_parameters only accepts state_dict()
+        # although its doc says it also accepts named_parameters()
+        self._main_model = nn.Module()  # type: nn.Module
+        self._use_amp = False
+        self._loss_ids = {}  # type: Dict[torch.Tensor, int]
+        self._last_backward_batch_idx = None  # type: Optional[int]
+
+        self._current_batch_idx = None  # type: Optional[int]
 
     def get_model(self) -> torch.nn.Module:
         """
@@ -31,9 +75,9 @@ class PyTorchTrialContext(det.TrialContext):
             * ``__init__``
             * ``build_model()``
         """
-
-        check.check_not_none(self.model)
-        return cast(torch.nn.Module, self.model)
+        # TODO(DET-3267): deprecate this when releasing pytorch flexible primitives.
+        check.len_eq(self.models, 1)
+        return self.models[0]
 
     def get_optimizer(self) -> torch.optim.Optimizer:  # type: ignore
         """
@@ -44,8 +88,9 @@ class PyTorchTrialContext(det.TrialContext):
             * ``build_model()``
             * ``optimizer()``
         """
-        check.check_not_none(self.optimizer)
-        return self.optimizer
+        # TODO(DET-3267): deprecate this when releasing pytorch flexible primitives.
+        check.len_eq(self.optimizers, 1)
+        return self.optimizers[0]
 
     def get_lr_scheduler(self) -> Optional[pytorch.LRScheduler]:
         """
@@ -57,4 +102,358 @@ class PyTorchTrialContext(det.TrialContext):
             * ``optimizer()``
             * ``create_lr_scheduler()``
         """
-        return self.lr_scheduler
+        # TODO(DET-3267): deprecate this when releasing pytorch flexible primitives.
+        check.lt_eq(len(self.lr_schedulers), 1)
+        if len(self.lr_schedulers) == 1:
+            return self.lr_schedulers[0]
+        return None
+
+    def _Model(self, model: torch.nn.Module) -> torch.nn.Module:
+        """Wraps a model. It returns a wrapped model."""
+
+        check.false(self._use_amp, "Must call Model() before _configure_apex_amp.")
+
+        model = model.to(self.device)
+        if not self.hvd_config.use and self.n_gpus > 1:
+            check.eq(
+                self.hvd_config.aggregation_frequency,
+                1,
+                "Please enable `optimized_parallel` to use aggregation "
+                "frequency greater than 1 for single machine multi-GPU "
+                "training.",
+            )
+            model = nn.DataParallel(model)
+            logging.debug("Initialized model for native parallel training.")
+
+        model_id = len(self.models)
+        self._main_model.__setattr__(f"model_{model_id}", model)
+
+        self.models.append(model)
+        return model
+
+    def _Optimizer(self, optimizer: torch.optim.Optimizer) -> torch.optim.Optimizer:  # type: ignore
+        """Wraps an optimizer. It returns a wrapped optimizer.
+
+        The optimizer must use the models wrapped by :meth:`Model`. This function
+        creates a ``horovod.DistributedOptimizer`` if using parallel/distributed training.
+        """
+
+        check.false(self._use_amp, "Must call Optimizer() before _configure_apex_amp.")
+
+        if self.hvd_config.use:
+            use_compression = self.hvd_config.fp16_compression
+            optimizer = hvd.DistributedOptimizer(
+                optimizer,
+                named_parameters=self._filter_named_parameters(optimizer),
+                backward_passes_per_step=self.hvd_config.aggregation_frequency,
+                compression=hvd.Compression.fp16 if use_compression else hvd.Compression.none,
+            )
+            logging.debug("Initialized optimizer for distributed and optimized parallel training.")
+
+        self.optimizers.append(optimizer)
+        return optimizer
+
+    def _LRScheduler(
+        self,
+        lr_scheduler: torch.optim.lr_scheduler._LRScheduler,
+        step_mode: pytorch.LRScheduler.StepMode,
+    ) -> pytorch.LRScheduler:
+        """Wraps a LR scheduler. It returns a wrapped LR scheduler.
+
+        The LR scheduler must use an optimizer wrapped by :meth:`Optimizer` and configured with
+        :meth:`configure_apex_amp`.
+        """
+
+        check.is_in(
+            lr_scheduler.optimizer,  # type: ignore
+            self.optimizers,
+            "Must use an optimizer that is returned by Optimizer()",
+        )
+        wrapped = pytorch.LRScheduler(lr_scheduler, step_mode)
+        self.lr_schedulers.append(wrapped)
+        return wrapped
+
+    def _filter_named_parameters(self, optimizer: torch.optim.Optimizer) -> List:  # type: ignore
+        """_filter_named_parameters filters the named parameters of a specified optimizer out
+        of all the named parameters from a specified model. We need this function because
+        a ``torch.optim.Optimizer`` doesn't store parameter names and we need the names of
+        the parameters when mapping parameters to each ``horovod.DistributedOptimizer``.
+        """
+        opt_params = {p for group in optimizer.param_groups for p in group.get("params", [])}
+        return [(name, p) for name, p in self._main_model.named_parameters() if p in opt_params]
+
+    def _init_device(self) -> None:
+        self.n_gpus = len(self.env.container_gpus)
+        if self.hvd_config.use:
+            check.gt(self.n_gpus, 0)
+            # We launch a horovod process per GPU. Each process
+            # needs to bind to a unique GPU.
+            self.device = torch.device(hvd.local_rank())
+            torch.cuda.set_device(self.device)
+        elif self.n_gpus > 0:
+            self.device = torch.device("cuda", 0)
+        else:
+            self.device = torch.device("cpu")
+        check.is_not_none(self.device)
+
+    def _to_device(self, data: pytorch._Data) -> pytorch.TorchData:
+        return pytorch.to_device(
+            data, self.device, self.warning_logged[_WarningLogs.FAILED_MOVING_TO_DEVICE]
+        )
+
+    def _configure_apex_amp(
+        self,
+        models: Union[torch.nn.Module, List[torch.nn.Module]],
+        optimizers: Union[torch.optim.Optimizer, List[torch.optim.Optimizer]],  # type: ignore
+        enabled: Optional[bool] = True,
+        opt_level: Optional[str] = "O1",
+        cast_model_type: Optional[torch.dtype] = None,
+        patch_torch_functions: Optional[bool] = None,
+        keep_batchnorm_fp32: Optional[Union[bool, str]] = None,
+        master_weights: Optional[bool] = None,
+        loss_scale: Optional[Union[float, str]] = None,
+        cast_model_outputs: Optional[torch.dtype] = None,
+        num_losses: Optional[int] = 1,
+        verbosity: Optional[int] = 1,
+        min_loss_scale: Optional[float] = None,
+        max_loss_scale: Optional[float] = 2.0 ** 24,
+    ) -> Tuple:
+        """
+        Configure automatic mixed precision for your models and optimizers. Note that details
+        for apex.amp are handled automatically within Determined after this call.
+
+        This function must be called **after** you have finished constructing your models and
+        optimizers with :meth:`Model` and :meth:`Optimizer`.
+
+        This function has the same arguments as
+        `apex.amp.initialize <https://nvidia.github.io/apex/amp.html#apex.amp.initialize>`_.
+
+        .. warning::
+            When using distributed training and automatic mixed precision,
+            we only support ``num_losses=1`` and calling backward on the loss once.
+
+        Args:
+            models (``torch.nn.Module`` or list of ``torch.nn.Module`` s):  Model(s) to modify/cast.
+            optimizers (``torch.optim.Optimizer`` or list of ``torch.optim.Optimizer`` s):
+                Optimizers to modify/cast. REQUIRED for training.
+            enabled (bool, optional, default=True):  If False, renders all Amp calls no-ops,
+                so your script should run as if Amp were not present.
+            opt_level (str, optional, default="O1"):  Pure or mixed precision optimization level.
+                Accepted values are "O0", "O1", "O2", and "O3", explained in detail above.
+            cast_model_type (``torch.dtype``, optional, default=None):  Optional property override,
+                see above.
+            patch_torch_functions (bool, optional, default=None):  Optional property override.
+            keep_batchnorm_fp32 (bool or str, optional, default=None):  Optional property override.
+                If passed as a string, must be the string "True" or "False".
+            master_weights (bool, optional, default=None):  Optional property override.
+            loss_scale (float or str, optional, default=None):  Optional property override.
+                If passed as a string, must be a string representing a number, e.g., "128.0",
+                or the string "dynamic".
+            cast_model_outputs (torch.dtype, optional, default=None):  Option to ensure that
+                the outputs of your model is always cast to a particular type regardless of
+                ``opt_level``.
+            num_losses (int, optional, default=1):  Option to tell Amp in advance how many
+                losses/backward passes you plan to use.  When used in conjunction with the
+                ``loss_id`` argument to ``amp.scale_loss``, enables Amp to use a different
+                loss scale per loss/backward pass, which can improve stability.
+                If ``num_losses`` is left to 1, Amp will still support multiple losses/backward
+                passes, but use a single global loss scale for all of them.
+            verbosity (int, default=1):  Set to 0 to suppress Amp-related output.
+            min_loss_scale (float, default=None):  Sets a floor for the loss scale values that
+                can be chosen by dynamic loss scaling.  The default value of None means that no
+                floor is imposed. If dynamic loss scaling is not used, `min_loss_scale` is ignored.
+            max_loss_scale (float, default=2.**24):  Sets a ceiling for the loss scale values
+                that can be chosen by dynamic loss scaling.  If dynamic loss scaling is not used,
+                `max_loss_scale` is ignored.
+
+        Returns:
+            Model(s) and optimizer(s) modified according to the ``opt_level``.
+            If  ``optimizers`` args were lists, the corresponding return value will
+            also be a list.
+        """
+        check.false(self._use_amp, "Please only call configure_apex_amp once.")
+        if self.hvd_config.use:
+            check.eq(
+                num_losses,
+                1,
+                "When using parallel/distributed training, "
+                "Determined only supports configure_apex_amp with num_losses = 1",
+            )
+
+        self._use_amp = True
+
+        if self.hvd_config.use:
+            check.eq(
+                self.hvd_config.aggregation_frequency,
+                1,
+                "Mixed precision training (AMP) is not supported with "
+                "aggregation frequency > 1.",
+            )
+
+        check.true(
+            torch.cuda.is_available(),
+            "Mixed precision training (AMP) is supported only on GPU slots.",
+        )
+
+        logging.info(f"Enabling mixed precision training with opt_level: {opt_level}.")
+        models, optimizers = apex.amp.initialize(
+            models=models,
+            optimizers=optimizers,
+            enabled=enabled,
+            opt_level=opt_level,
+            cast_model_type=cast_model_type,
+            patch_torch_functions=patch_torch_functions,
+            keep_batchnorm_fp32=keep_batchnorm_fp32,
+            master_weights=master_weights,
+            loss_scale=loss_scale,
+            cast_model_outputs=cast_model_outputs,
+            num_losses=num_losses,
+            min_loss_scale=min_loss_scale,
+            max_loss_scale=max_loss_scale,
+            verbosity=verbosity
+            if self.distributed.get_rank() == 0 or self.env.experiment_config.debug_enabled()
+            else 0,
+        )
+        if not isinstance(models, list):
+            self.models = [models]
+        if not isinstance(optimizers, list):
+            self.optimizers = [optimizers]
+        return models, optimizers
+
+    def _should_communicate_and_update(self) -> bool:
+        if self._current_batch_idx is None:
+            raise det.errors.InternalException("Training hasn't started.")
+        return (self._current_batch_idx + 1) % self.hvd_config.aggregation_frequency == 0
+
+    def _backward(
+        self,
+        loss: torch.Tensor,
+        gradient: Optional[torch.Tensor] = None,
+        retain_graph: bool = False,
+        create_graph: bool = False,
+    ) -> None:
+        """Compute the gradient of current tensor w.r.t. graph leaves.
+
+        The arguments are used in the same way as ``torch.Tensor.backward``.
+        See https://pytorch.org/docs/1.4.0/_modules/torch/tensor.html#Tensor.backward for details.
+
+        .. warning::
+
+            When using distributed training, we don't support manual gradient accumulation.
+            That means the gradient on each parameter can only be calculated once on each batch.
+            If a parameter is associated with multiple losses, you can either choose to call
+            backward on only one of those losses or you could set require_grads flag of a
+            parameter or module to false to avoid manual gradient accumulation on that parameter.
+            However, you could do gradient accumulation across batches by setting the aggregation
+            frequency in the experiment configuration to be more than 1.
+
+        Arguments:
+            gradient (Tensor or None): Gradient w.r.t. the
+                tensor. If it is a tensor, it will be automatically converted
+                to a Tensor that does not require grad unless ``create_graph`` is True.
+                None values can be specified for scalar Tensors or ones that
+                don't require grad. If a None value would be acceptable then
+                this argument is optional.
+            retain_graph (bool, optional): If ``False``, the graph used to compute
+                the grads will be freed. Note that in nearly all cases setting
+                this option to True is not needed and often can be worked around
+                in a much more efficient way. Defaults to the value of
+                ``create_graph``.
+            create_graph (bool, optional): If ``True``, graph of the derivative will
+                be constructed, allowing to compute higher order derivative
+                products. Defaults to ``False``.
+        """
+        if self._use_amp:
+            if (
+                self._last_backward_batch_idx is None
+                or self._current_batch_idx is None
+                or self._last_backward_batch_idx < self._current_batch_idx
+            ):
+                self._last_backward_batch_idx = self._current_batch_idx
+            else:
+                raise det.errors.InvalidExperimentException(
+                    "Calling context.backward(loss) multiple times is not supported "
+                    "while using apex.amp and parallel/distributed training"
+                )
+
+            if loss not in self._loss_ids:
+                self._loss_ids[loss] = len(self._loss_ids)
+            with apex.amp.scale_loss(
+                loss, self.optimizers, loss_id=self._loss_ids[loss]
+            ) as scaled_loss:
+                scaled_loss.backward(
+                    gradient=gradient, retain_graph=retain_graph, create_graph=create_graph
+                )
+
+                if self.hvd_config.use and self._should_communicate_and_update():
+                    # When we exit out of this context manager, we need to finish
+                    # communicating gradient updates before they are unscaled.
+                    #
+                    # Unfortunately, there is no clean way to support unscaling
+                    # happening after synchronizing the optimizer on apex.amp.
+                    # A short-term solution is to not support multiple losses nor
+                    # multiple backward passes on one loss. A long-term solution is
+                    # to integrate torch native AMP (https://pytorch.org/docs/stable/amp.html),
+                    # which will come out soon.
+                    for optimizer in self.optimizers:
+                        optimizer.synchronize()
+        else:
+            loss.backward(  # type: ignore
+                gradient=gradient, retain_graph=retain_graph, create_graph=create_graph,
+            )
+
+    def _average_gradients(self, parameters: Any, divisor: int) -> None:
+        check.gt_eq(divisor, 1)
+        if divisor == 1:
+            return
+
+        divisor_value = float(divisor)
+        for p in filter(lambda param: param.grad is not None, parameters):
+            p.grad.data.div_(divisor_value)
+
+    def _step_optimizer(
+        self,
+        optimizer: torch.optim.Optimizer,  # type: ignore
+        clip_grads: Optional[Callable[[Iterator], None]] = None,
+    ) -> None:
+        """
+        Perform a single optimization step.
+
+        This function must be called once for each optimizer. However, the order of
+        different optimizers' optimization steps can be specified by calling
+        this function in different orders. Also, gradient accumulation across iterations
+        is performed by the Determined training loop by setting the experiment configuration
+        optimization.aggregation_frequency.
+
+        Arguments:
+            optimizer(``torch.optim.Optimizer``): Which optimizer should be stepped.
+            clip_grads(a function, optional): This function should have one argument for
+                parameters in order to clip the gradients
+        """
+
+        if self._should_communicate_and_update():
+            # Communication needs to be synchronized so that is completed
+            # before we apply gradient clipping and `step()`.
+            if self.hvd_config.use and not self._use_amp:
+                optimizer.synchronize()
+
+            parameters = (
+                [p for group in optimizer.param_groups for p in group.get("params", [])]
+                if not self._use_amp
+                else apex.amp.master_params(optimizer)
+            )
+
+            if self.hvd_config.average_aggregated_gradients:
+                self._average_gradients(
+                    parameters=parameters, divisor=self.hvd_config.aggregation_frequency
+                )
+
+            if clip_grads is not None:
+                clip_grads(parameters)
+
+            if self.hvd_config.use:
+                with optimizer.skip_synchronize():
+                    optimizer.step()
+            else:
+                optimizer.step()
+            optimizer.zero_grad()

--- a/harness/determined/pytorch/_pytorch_trial.py
+++ b/harness/determined/pytorch/_pytorch_trial.py
@@ -1,9 +1,8 @@
-import enum
 import logging
 import pathlib
 import random
 from abc import abstractmethod
-from typing import Any, Dict, List, Optional, Tuple, Union, cast
+from typing import Any, Dict, Iterator, List, Optional, Tuple, Union, cast
 
 import cloudpickle
 import numpy as np
@@ -20,24 +19,10 @@ from determined.pytorch import (
     Reducer,
     TorchData,
     _callback,
-    _Data,
     _reduce_metrics,
     data_length,
-    to_device,
 )
 from determined_common import check
-
-# Apex is included only for GPU trials.
-try:
-    import apex
-except ImportError:
-    if torch.cuda.is_available():
-        logging.warning("Failed to import apex.")
-    pass
-
-
-class _WarningLogs(enum.Enum):
-    FAILED_MOVING_TO_DEVICE = 1
 
 
 class PyTorchTrialController(det.LoopTrialController):
@@ -46,29 +31,85 @@ class PyTorchTrialController(det.LoopTrialController):
 
         check.is_instance(trial_inst, PyTorchTrial, "PyTorchTrialController needs an PyTorchTrial")
         self.trial = cast(PyTorchTrial, trial_inst)
-        self._check_evaluate_implementation()
+        self.context = cast(PyTorchTrialContext, self.context)
+        self.callbacks = self.trial.build_callbacks()
 
-        self._init_model_and_optimizer()
+        # TODO(DET-3262): remove this backward compatibility of old interface.
+        if (
+            util.is_overridden(self.trial.build_model, PyTorchTrial)
+            or util.is_overridden(self.trial.optimizer, PyTorchTrial)
+            or util.is_overridden(self.trial.create_lr_scheduler, PyTorchTrial)
+        ):
+            check.true(
+                util.is_overridden(self.trial.build_model, PyTorchTrial)
+                and util.is_overridden(self.trial.optimizer, PyTorchTrial),
+                "Both build_model() and optimizer() must be defined "
+                "if any of build_model(), optimizer(), and create_lr_scheduler() are defined. "
+                "If you want to use the new interface, you should instead instantiate your models, "
+                "optimizers, and LR schedulers in __init__ and call context.backward(loss) "
+                "and context.step_optimizer(optimizer) in train_batch.",
+            )
+
+            model = self.context._Model(self.trial.build_model())
+            optim = self.context._Optimizer(self.trial.optimizer(model))
+
+            lr_scheduler = self.trial.create_lr_scheduler(optim)
+            if lr_scheduler is not None:
+                self.context.lr_schedulers.append(lr_scheduler)
+
+            if det.ExperimentConfig(self.context.get_experiment_config()).mixed_precision_enabled():
+                self.context._configure_apex_amp(
+                    models=model,
+                    optimizers=optim,
+                    opt_level=self.context.get_experiment_config()
+                    .get("optimizations", {})
+                    .get("mixed_precision", "O0"),
+                )
+
+            train_batch = self.trial.train_batch
+
+            def new_train_batch(
+                batch: TorchData, model: nn.Module, epoch_idx: int, batch_idx: int
+            ) -> Union[torch.Tensor, Dict[str, Any]]:
+                tr_metrics = train_batch(batch, model, epoch_idx, batch_idx)
+                if isinstance(tr_metrics, torch.Tensor):
+                    tr_metrics = {"loss": tr_metrics}
+                check.is_instance(
+                    tr_metrics,
+                    dict,
+                    "train_batch() must return a dictionary "
+                    f"mapping string names to Tensor metrics, got {type(tr_metrics)}",
+                )
+                check.is_in(
+                    "loss", tr_metrics.keys(), 'Please include "loss" in you training metrics.'
+                )
+
+                def clip_grads(parameters: Iterator) -> None:
+                    for callback in self.callbacks.values():
+                        callback.on_before_optimizer_step(parameters)
+
+                self.context._backward(tr_metrics["loss"])
+                self.context._step_optimizer(self.context.optimizers[0], clip_grads=clip_grads)
+                return tr_metrics
+
+            self.trial.__setattr__("train_batch", new_train_batch)
+
+        check.gt_eq(len(self.context.models), 1, "Must have at least one model")
+        check.gt_eq(len(self.context.optimizers), 1, "Must have at least one optimizer")
+        self._check_evaluate_implementation()
 
         # Validation loader will be undefined on process ranks > 0
         # when the user defines `validate_full_dataset()`.
         self.validation_loader = None  # type: Optional[torch.utils.data.DataLoader]
         self._set_data_loaders()
 
-        # Track whether a warning logging category has already been issued to the user.
-        self.warning_logged = {_WarningLogs.FAILED_MOVING_TO_DEVICE: False}
-
-        self.context.lr_scheduler = self.trial.create_lr_scheduler(self.context.optimizer)
-
-        self.callbacks = self.trial.build_callbacks()
-
         # If a load path is provided load weights and restore the data location.
         self._load()
-        self._configure_amp()
 
         if self.hvd_config.use:
-            hvd.broadcast_parameters(self.context.model.state_dict(), root_rank=0)
-            hvd.broadcast_optimizer_state(self.context.optimizer, root_rank=0)
+            hvd.broadcast_parameters(self.context._main_model.state_dict(), root_rank=0)
+            for optimizer in self.context.optimizers:
+                hvd.broadcast_optimizer_state(optimizer, root_rank=0)
 
         self.training_iterator = iter(self.training_loader)
 
@@ -100,54 +141,11 @@ class PyTorchTrialController(det.LoopTrialController):
 
     @staticmethod
     def from_native(*args: Any, **kwargs: Any) -> det.TrialController:
-        raise NotImplementedError("PyTorchTrial only supports the Native API")
+        raise NotImplementedError("PyTorchTrial only supports the Trial API")
 
     @staticmethod
     def support_determined_native() -> bool:
         return True
-
-    def _init_device(self) -> None:
-        self.n_gpus = len(self.env.container_gpus)
-        if self.hvd_config.use:
-            check.gt(self.n_gpus, 0)
-            # We launch a horovod process per GPU. Each process
-            # needs to bind to a unique GPU.
-            self.device = torch.device(hvd.local_rank())
-            torch.cuda.set_device(self.device)
-        elif self.n_gpus > 0:
-            self.device = torch.device("cuda", 0)
-        else:
-            self.device = torch.device("cpu")
-        check.is_not_none(self.device)
-
-    def _init_model_and_optimizer(self) -> None:
-        self.context.model = self.trial.build_model()
-
-        # TODO: Check that optimizer is not an amp optimizer.
-        self.context.optimizer = self.trial.optimizer(self.context.model)
-
-        self._init_device()
-        self.context.model = self.context.model.to(self.device)
-
-        if self.hvd_config.use:
-            use_compression = self.hvd_config.fp16_compression
-            self.context.optimizer = hvd.DistributedOptimizer(
-                self.context.optimizer,
-                named_parameters=self.context.model.named_parameters(),
-                backward_passes_per_step=self.hvd_config.aggregation_frequency,
-                compression=hvd.Compression.fp16 if use_compression else hvd.Compression.none,
-            )
-            logging.debug("Initialized optimizer for distributed and optimized parallel training.")
-        elif self.n_gpus > 1:
-            check.eq(
-                self.hvd_config.aggregation_frequency,
-                1,
-                "Please enable `optimized_parallel` to use aggregation "
-                "frequency greater than 1 for single machine multi-GPU "
-                "training.",
-            )
-            self.context.model = nn.DataParallel(self.context.model)
-            logging.debug("Initialized mode for native parallel training.")
 
     def _check_evaluate_implementation(self) -> None:
         """
@@ -163,53 +161,6 @@ class PyTorchTrialController(det.LoopTrialController):
             "For most use cases `evaluate_batch()` is recommended is recommended because "
             "it can be parallelized across all devices.",
         )
-
-    def _get_amp_setting(self) -> str:
-        amp_setting = self.env.experiment_config.get("optimizations", {}).get(
-            "mixed_precision", None
-        )
-        check.is_not_none(amp_setting)
-        check.not_in(
-            "amp",
-            self.env.hparams,
-            "Please move `amp` setting from `hyperparameters` "
-            "to `optimizations[`mixed_precision`]`.",
-        )
-
-        return cast(str, amp_setting)
-
-    def use_amp(self) -> bool:
-        return self._get_amp_setting() != "O0"
-
-    def _configure_amp(self) -> None:
-        if self.use_amp():
-            if self.hvd_config.use:
-                check.eq(
-                    self.hvd_config.aggregation_frequency,
-                    1,
-                    "Mixed precision training (AMP) is not supported with "
-                    "aggregation frequency > 1.",
-                )
-
-            check.true(
-                torch.cuda.is_available(),
-                "Mixed precision training (AMP) is supported only on GPU slots.",
-            )
-            check.false(
-                not self.hvd_config.use and self.n_gpus > 1,
-                "To enable mixed precision training (AMP) for parallel training, "
-                'please set `resources["optimized_parallel"] = True`.',
-            )
-
-            logging.info(
-                f"Enabling mixed precision training with opt_level: {self._get_amp_setting()}."
-            )
-            self.context.model, self.context.optimizer = apex.amp.initialize(
-                self.context.model,
-                self.context.optimizer,
-                opt_level=self._get_amp_setting(),
-                verbosity=1 if self.is_chief or self.env.experiment_config.debug_enabled() else 0,
-            )
 
     def _evaluate_batch_defined(self) -> bool:
         return util.is_overridden(self.trial.evaluate_batch, PyTorchTrial)
@@ -278,21 +229,6 @@ class PyTorchTrialController(det.LoopTrialController):
     def get_epoch_idx(self, batch_id: int) -> int:
         return batch_id // len(self.training_loader)
 
-    def _to_device(self, data: _Data) -> TorchData:
-        return to_device(
-            data, self.device, self.warning_logged[_WarningLogs.FAILED_MOVING_TO_DEVICE]
-        )
-
-    @staticmethod
-    def _average_gradients(parameters: Any, divisor: int) -> None:
-        check.gt_eq(divisor, 1)
-        if divisor == 1:
-            return
-
-        divisor_value = float(divisor)
-        for p in filter(lambda param: param.grad is not None, parameters):
-            p.grad.data.div_(divisor_value)
-
     def _average_training_metrics(
         self, per_batch_metrics: List[Dict[str, Any]]
     ) -> List[Dict[str, Any]]:
@@ -356,7 +292,8 @@ class PyTorchTrialController(det.LoopTrialController):
 
         # Set the behavior of certain layers (e.g., dropout) that are different
         # between training and inference.
-        self.context.model.train()
+        for model in self.context.models:
+            model.train()
 
         for callback in self.callbacks.values():
             callback.on_train_step_start(step_id)
@@ -370,78 +307,28 @@ class PyTorchTrialController(det.LoopTrialController):
         for batch_idx in range(start, end):
             batch = next(self.training_iterator)
             num_inputs += data_length(batch)
+            batch = self.context._to_device(batch)
 
-            batch = self._to_device(batch)
-            # Forward pass.
+            self.context._current_batch_idx = batch_idx
             tr_metrics = self.trial.train_batch(
                 batch=batch,
-                model=self.context.model,
+                model=self.context.models[0],
                 epoch_idx=self.get_epoch_idx(batch_idx),
                 batch_idx=batch_idx,
             )
-
             if isinstance(tr_metrics, torch.Tensor):
                 tr_metrics = {"loss": tr_metrics}
-
             check.is_instance(
                 tr_metrics,
                 dict,
                 "train_batch() must return a dictionary "
-                "mapping string names to Tensor metrics, got {type(tr_metrics)}",
+                f"mapping string names to Tensor metrics, got {type(tr_metrics)}",
             )
             check.is_in("loss", tr_metrics.keys(), 'Please include "loss" in you training metrics.')
 
-            # Backwards pass.
-            loss = tr_metrics["loss"]
-            communicate_and_update = (batch_idx + 1) % self.hvd_config.aggregation_frequency == 0
-            if self.use_amp():
-                with apex.amp.scale_loss(loss, self.context.optimizer) as scaled_loss:
-                    scaled_loss.backward()
-                    if self.hvd_config.use and communicate_and_update:
-                        # When using horovod, we need to finish communicating gradient
-                        # updates before they are unscaled which happens when we exit
-                        # of this context manager.
-                        self.context.optimizer.synchronize()
-            else:
-                loss.backward()
-
-                # Communication needs to be synchronized so that is completed
-                # before we apply gradient clipping and `step()`.
-                if communicate_and_update and self.hvd_config.use:
-                    self.context.optimizer.synchronize()
-
-            if communicate_and_update:
-                parameters = (
-                    self.context.model.parameters()
-                    if not self.use_amp()
-                    else apex.amp.master_params(self.context.optimizer)
-                )
-
-                if self.hvd_config.average_aggregated_gradients:
-                    self._average_gradients(
-                        parameters=parameters, divisor=self.hvd_config.aggregation_frequency
-                    )
-
-                # TODO: Remove this check in v0.12.8.
-                check.false(
-                    self.env.hparams.get("clip_grad_l2_norm", None)
-                    or self.env.hparams.get("clip_grad_val", None),
-                    "Please specify gradient clipping via callbacks.",
-                )
-
-                for callback in self.callbacks.values():
-                    callback.on_before_optimizer_step(parameters)
-
-                if self.hvd_config.use:
-                    with self.context.optimizer.skip_synchronize():
-                        self.context.optimizer.step()
-                else:
-                    self.context.optimizer.step()
-                self.context.optimizer.zero_grad()
-
-                # Step learning rate of a LRScheduler.
-                if self.context.lr_scheduler is not None:
-                    self._auto_step_lr_scheduler_per_batch(batch_idx, self.context.lr_scheduler)
+            # Step learning rate of a LRScheduler.
+            for lr_scheduler in self.context.lr_schedulers:
+                self._auto_step_lr_scheduler_per_batch(batch_idx, lr_scheduler)
 
             for name, metric in tr_metrics.items():
                 # Convert PyTorch metric values to NumPy, so that
@@ -454,18 +341,18 @@ class PyTorchTrialController(det.LoopTrialController):
             check.is_in("loss", tr_metrics, 'Please include "loss" in your training metrics.')
             per_batch_metrics.append(tr_metrics)
 
+        # Aggregate and reduce training metrics from all the training processes.
         if self.hvd_config.use and self.hvd_config.average_training_metrics:
             per_batch_metrics = self._average_training_metrics(per_batch_metrics)
-
         if self.hvd_config.use:
             num_inputs *= hvd.size()
-
         metrics = det.util.make_metrics(num_inputs, per_batch_metrics)
 
         for callback in self.callbacks.values():
             callback.on_train_step_end(step_id, metrics)
 
         if not self.is_chief:
+            # The training metrics are reported only in the chief process.
             return workload.Skipped()
 
         logging.debug(f"Done training step: {num_inputs} records in {num_batches} batches.")
@@ -475,9 +362,7 @@ class PyTorchTrialController(det.LoopTrialController):
     @staticmethod
     def _convert_metrics_to_numpy(metrics: Dict[str, Any]) -> Dict[str, Any]:
         for metric_name, metric_val in metrics.items():
-            logging.debug(f"Value of metric {metric_name}: {metric_val}")
             if isinstance(metric_val, torch.Tensor):
-                logging.debug(f"Converting {metric_name} to CPU.")
                 metrics[metric_name] = metric_val.cpu().numpy()
         return metrics
 
@@ -485,7 +370,8 @@ class PyTorchTrialController(det.LoopTrialController):
     def _compute_validation_metrics(self) -> workload.Response:
         # Set the behavior of certain layers (e.g., dropout) that are
         # different between training and inference.
-        self.context.model.eval()
+        for model in self.context.models:
+            model.eval()
 
         for callback in self.callbacks.values():
             callback.on_validation_step_start()
@@ -500,10 +386,10 @@ class PyTorchTrialController(det.LoopTrialController):
             self.validation_loader = cast(torch.utils.data.DataLoader, self.validation_loader)
             check.gt(len(self.validation_loader), 0)
             for batch in self.validation_loader:
-                batch = self._to_device(batch)
+                batch = self.context._to_device(batch)
                 num_inputs += data_length(batch)
 
-                vld_metrics = self.trial.evaluate_batch(batch=batch, model=self.context.model)
+                vld_metrics = self.trial.evaluate_batch(batch=batch, model=self.context.models[0])
                 # Verify validation metric names are the same across batches.
                 if keys is None:
                     keys = vld_metrics.keys()
@@ -537,7 +423,7 @@ class PyTorchTrialController(det.LoopTrialController):
             self.validation_loader = cast(torch.utils.data.DataLoader, self.validation_loader)
             if self.is_chief:
                 metrics = self.trial.evaluate_full_dataset(
-                    data_loader=self.validation_loader, model=self.context.model
+                    data_loader=self.validation_loader, model=self.context.models[0]
                 )
 
                 check.is_instance(
@@ -560,7 +446,7 @@ class PyTorchTrialController(det.LoopTrialController):
             metrics = hvd.broadcast_object(metrics, root_rank=0)
 
         for callback in self.callbacks.values():
-            callback.on_validation_step_end(metrics)  # type: ignore
+            callback.on_validation_step_end(cast(Dict[str, Any], metrics))
 
         if not self.is_chief:
             return workload.Skipped()
@@ -585,7 +471,7 @@ class PyTorchTrialController(det.LoopTrialController):
         for key in keys:
             check.true(
                 isinstance(metrics_reducers[key], Reducer),
-                "Please select `det.pytorch.Reducer` " "for reducing validation metrics.",
+                "Please select `det.pytorch.Reducer` for reducing validation metrics.",
             )
 
         return metrics_reducers
@@ -677,10 +563,32 @@ class PyTorchTrialController(det.LoopTrialController):
                 checkpoint = torch.load(maybe_ckpt, map_location="cpu")  # type: ignore
                 break
 
-        self.context.model.load_state_dict(checkpoint["model_state_dict"])
-        self.context.optimizer.load_state_dict(checkpoint["optimizer_state_dict"])
-        if self.context.lr_scheduler is not None:
-            self.context.lr_scheduler.load_state_dict(checkpoint.get("lr_scheduler"))
+        if "model_state_dict" in checkpoint:
+            # Backward compatible with older checkpoint format.
+            check.not_in("models_state_dict", checkpoint)
+            check.eq(len(self.context.models), 1)
+            self.context.models[0].load_state_dict(checkpoint["model_state_dict"])
+        else:
+            for idx, model in enumerate(self.context.models):
+                model.load_state_dict(checkpoint["models_state_dict"][idx])
+
+        if "optimizer_state_dict" in checkpoint:
+            # Backward compatible with older checkpoint format.
+            check.not_in("optimizers_state_dict", checkpoint)
+            check.eq(len(self.context.optimizers), 1)
+            self.context.optimizers[0].load_state_dict(checkpoint["optimizer_state_dict"])
+        else:
+            for idx, optimizer in enumerate(self.context.optimizers):
+                optimizer.load_state_dict(checkpoint["optimizers_state_dict"][idx])
+
+        if "lr_scheduler" in checkpoint:
+            # Backward compatible with older checkpoint format.
+            check.not_in("lr_schedulers_state_dict", checkpoint)
+            check.eq(len(self.context.lr_schedulers), 1)
+            self.context.lr_schedulers[0].load_state_dict(checkpoint["lr_scheduler"])
+        else:
+            for idx, lr_scheduler in enumerate(self.context.lr_schedulers):
+                lr_scheduler.load_state_dict(checkpoint["lr_schedulers_state_dict"][idx])
 
         callback_state = checkpoint.get("callbacks", {})
         for name in self.callbacks:
@@ -710,16 +618,15 @@ class PyTorchTrialController(det.LoopTrialController):
         # objects) to avoid breaking the connection between the model and the
         # optimizer.
         checkpoint = {
-            "model_state_dict": self.context.model.state_dict(),
-            "optimizer_state_dict": self.context.optimizer.state_dict(),
+            "models_state_dict": [model.state_dict() for model in self.context.models],
+            "optimizers_state_dict": [
+                optimizer.state_dict() for optimizer in self.context.optimizers
+            ],
+            "lr_schedulers_state_dict": [
+                lr_scheduler.state_dict() for lr_scheduler in self.context.lr_schedulers
+            ],
+            "callbacks": {name: callback.state_dict() for name, callback in self.callbacks.items()},
         }
-
-        if self.context.lr_scheduler is not None:
-            checkpoint["lr_scheduler"] = self.context.lr_scheduler.state_dict()
-
-        for name, callback in self.callbacks.items():
-            checkpoint.setdefault("callbacks", {})
-            checkpoint["callbacks"][name] = callback.state_dict()
 
         torch.save(  # type: ignore
             checkpoint, str(path.joinpath("state_dict.pth")), pickle_module=cloudpickle
@@ -740,28 +647,95 @@ class PyTorchTrialController(det.LoopTrialController):
 class PyTorchTrial(det.Trial):
     """
     PyTorch trials are created by subclassing the abstract class
-    :class:`PyTorchTrial`.  Users must define all abstract methods to create the
-    deep learning model associated with a specific trial, and to subsequently
-    train and evaluate it.
+    :class:`PyTorchTrial`.
     """
+
+    # TODO(DET-3204): Add the following comments to the docstring.
+    # There are two different methods to define models, optimizers, and LR schedulers.
+    #
+    # 1. Define the abstract methods for the only model, optimizer, and LR scheduler and
+    #    Determine will initialize them for the users. Note this method doesn't support
+    #    multiple models, optimizers, and LR schedulers.
+    #
+    # 2. Initialize models, optimizers, and LR schedulers in the :meth:`__init__`.
+    #    If using this way, users should calculate the gradients with the losses and call an
+    #    optimization step for the optimizers on your own in :meth:`train_batch`.
+    #    Users are able to use arbitrary number of models, optimizers, and LR schedulers
+    #    and run the forward and backward passes and step optimizers in arbitrary orders.
 
     trial_controller_class = PyTorchTrialController
     trial_context_class = PyTorchTrialContext
 
     @abstractmethod
+    def __init__(self, trial_context: PyTorchTrialContext) -> None:
+        """
+        Initializes a trial using the provided trial context.
+
+        Override this function to initialize any shared state between the
+        function implementations.
+
+        Models, optimizers, and LR schedulers can be defined in the abstract methods.
+        """
+
+        # TODO(DET-3204): Add the following comments to the docstring.
+        # Alternatively, we could initialize them with the methods provided by
+        # :py:class:`det.pytorch.PytorchTrialContext`, including ``Model``,
+        # ``Optimizer``, ``LRScheduler``, ``_configure_apex_amp``.
+        # Here is a code example.
+        #
+        # .. code-block:: python
+        #
+        #     self.context = trial_context
+        #
+        #     self.a = self.context.Model(MyModelA())
+        #     self.b = self.context.Model(MyModelB())
+        #     self.opt1 = self.context.Optimizer(torch.optm.Adam(self.a))
+        #     self.opt2 = self.context.Optimizer(torch.optm.Adam(self.b))
+        #
+        #     (self.a, self.b), (self.opt1, self.opt2) = self.context._configure_apex_amp(
+        #         models=[self.a, self.b],
+        #         optimizers=[self.opt1, self.opt2],
+        #         num_losses=2,
+        #     )
+        #
+        #     self.lrs1 = context.LRScheduler(
+        #         lr_scheduler=LambdaLR(self.opt1, lr_lambda=lambda epoch: 0.95 ** epoch),
+        #         step_mode=LRScheduler.StepMode.STEP_EVERY_EPOCH,
+        #     ))
+        pass
+
     def build_model(self) -> nn.Module:
         """
         Defines the deep learning architecture associated with a trial. This method
         returns the model as an instance or subclass of :py:class:`nn.Module`.
         """
+        # TODO(DET-3267): deprecate this when releasing pytorch flexible primitives.
         pass
 
-    @abstractmethod
     def optimizer(self, model: nn.Module) -> torch.optim.Optimizer:  # type: ignore
         """
         Describes the optimizer to be used during training of the given model,
         an instance of :py:class:`torch.optim.Optimizer`.
         """
+        # TODO(DET-3267): deprecate this when releasing pytorch flexible primitives.
+        pass
+
+    def create_lr_scheduler(
+        self, optimizer: torch.optim.Optimizer  # type: ignore
+    ) -> Optional[LRScheduler]:
+        """
+        Create a learning rate scheduler for the trial given an instance of the
+        optimizer.
+
+        Arguments:
+            optimizer (torch.optim.Optimizer): instance of the optimizer to be
+                used for training
+
+        Returns:
+            :py:class:`det.pytorch.LRScheduler`:
+                Wrapper around a :obj:`torch.optim.lr_scheduler._LRScheduler`.
+        """
+        # TODO(DET-3267): deprecate this when releasing pytorch flexible primitives.
         pass
 
     @abstractmethod
@@ -773,6 +747,35 @@ class PyTorchTrial(det.Trial):
         :py:obj:`batch_idx` represents the total number of batches processed per
         device (slot) since the start of training.
         """
+
+        # TODO(DET-3204): Add the following comments to the docstring.
+        # If the models, optimizers, and LR schedulers are initialized in :meth:`__init__`
+        # by users, users should calculate the gradients with the losses with :meth:`backward`
+        # and call an optimization step for the optimizers with :meth:`step_optimizer`
+        # on your own. Here is a code example.
+        #
+        # .. code-block:: python
+        #
+        #     # Assume having initialized models, optimizers, and LR schedulers (when
+        #     # using manual mode): self.model1, self.model2, self.opt1, self.opt2, and self.lrs1.
+        #
+        #     # Calculate the losses using the models.
+        #     loss1 = self.model1(batch)
+        #     loss2 = self.model2(batch)
+        #
+        #     # Run backward passes on losses and step optimizers. These can happen
+        #     # in arbitrary orders.
+        #     self.context.backward(loss1)
+        #     self.context.backward(loss2)
+        #     self.context.step_optimizer(self.opt1)
+        #     self.context.step_optimizer(self.opt2)
+        #
+        #     # Step the learning rate.
+        #     self.lrs1.step()
+        #
+        #     return {"loss1": loss1, "loss2": loss2}
+
+        # TODO(DET-3267): deprecate the model argument when releasing pytorch flexible primitives.
         pass
 
     @abstractmethod
@@ -790,23 +793,6 @@ class PyTorchTrial(det.Trial):
         Defines the data loader to use during validation.
 
         Must return an instance of :py:class:`determined.pytorch.DataLoader`.
-        """
-        pass
-
-    def create_lr_scheduler(
-        self, optimizer: torch.optim.Optimizer  # type: ignore
-    ) -> Optional[LRScheduler]:
-        """
-        Create a learning rate scheduler for the trial given an instance of the
-        optimizer.
-
-        Arguments:
-            optimizer (torch.optim.Optimizer): instance of the optimizer to be
-                used for training
-
-        Returns:
-            :py:class:`det.pytorch.LRScheduler`:
-                Wrapper around a :obj:`torch.optim.lr_scheduler._LRScheduler`.
         """
         pass
 
@@ -836,6 +822,7 @@ class PyTorchTrial(det.Trial):
 
         The metrics returned from this function must be JSON-serializable.
         """
+        # TODO(DET-3267): deprecate the model argument when releasing pytorch flexible primitives.
         pass
 
     def evaluation_reducer(self) -> Union[Reducer, Dict[str, Reducer]]:
@@ -861,6 +848,7 @@ class PyTorchTrial(det.Trial):
 
         The metrics returned from this function must be JSON-serializable.
         """
+        # TODO(DET-3267): deprecate the model argument when releasing pytorch flexible primitives.
         pass
 
 

--- a/harness/tests/experiment/utils.py
+++ b/harness/tests/experiment/utils.py
@@ -432,7 +432,13 @@ def create_trial_instance(trial_def: Type[det.Trial]) -> None:
     with tempfile.TemporaryDirectory() as td:
         trial_instance = experimental.create_trial_instance(
             trial_def=trial_def,
-            config={"hyperparameters": {"global_batch_size": det.Constant(16)}},
+            config={
+                "hyperparameters": {
+                    "global_batch_size": det.Constant(16),
+                    "hidden_size": 4,
+                    "learning_rate": 0.01,
+                }
+            },
             checkpoint_dir=td,
         )
     check.check_isinstance(trial_instance, det.Trial)


### PR DESCRIPTION
## Description

This PR supports flexible primitives in Pytorch, i.e. supporting multiple optimizers and LR schedulers. It also modifies the current interface to be more Pytorch-y, making porting Pytorch models easier than before.

### Interface

1. Users need to initialize the model, optimizers, and LR schedulers in the constructor of the trial class themselves as opposed to providing a callback for Determined to call in the old interface. Note that all the functions provided in the trial interface start with an underscore. These underscores will be removed when officially releasing this feature. They need to call the wrapping functions of the context object to wrap the model, optimizers, and LR schedulers.

2. Users need to run backward passes and perform one optimizer step for all the optimizers in the train_batch. They can decide in which order to run them.

3. All the interfaces have backward compatibility with the old interface.

Here is a code example:
```
class ModelA(nn.Module):
   def __init__(self, latent_dim, img_shape):
      ...
   def forward(self, z):
      ...

class ModelB(nn.Module):
   def __init__(self, img_shape):
      ...
   def forward(self, img):
      ...

class Model(nn.Module):
   def __init__(self, context):
        self.context = context
        # Initialize 
        mnist_shape = (1, 28, 28)
        self.model_a = ModelA(latent_dim=self.get_hparam("latent_dim"), img_shape=mnist_shape)
        self.model_b = ModelB(img_shape=mnist_shape)

   def forward(self, z):
       return self.model_a(z)

class MultiModelExample(PyTorchTrial):
    def __init__(self, trial_context: det.TrialContext):
        self.context = trial_context

        # Initialize a model with multiple sub-models.
        mnist_shape = (1, 28, 28)
        self.model = self.context._Model(Model(self.context))
        self.model_a, self.model_b = self.model.model_a, self.model.model_b

        # Initialize multiple optimizers with AMP.
        b1, b2 = self.context.get_hparam("b1"), self.context.get_hparam("b2")
        lr = self.context.get_hparam("lr")
        self.opt_a = self.context._Optimizer(torch.optim.Adam(self.model_a.parameters(), lr=lr, betas=(b1, b2)))
        self.opt_b = self.context._Optimizer(torch.optim.Adam(self.model_b.parameters(), lr=lr, betas=(b1, b2)))
        (self.model_a, self.model_b), (self.opt_a, self.opt_b) = self.context.amp_init(
            model=self.model,
            optimizers=[self.opt_a, self.opt_b],
            opt_level="O0",
        )

        # Initialize LR scheduler.
        lambda1 = lambda epoch: epoch // 30
        lambda2 = lambda epoch: 0.95 ** epoch
        self.scheduler1 = self.context._LRScheduler(LambdaLR(self.opt_a, lr_lambda=[lambda1, lambda2]))

    def train_batch(self, batch, epoch_idx: int, batch_idx: int):
        # forward pass for model A
        loss_a=...

        # backward pass for model A
        self.context.backward(loss_a)
        self.context.step_optimizer(self.opt_a)
        self.context.step_lr_scheduler(self.scheduler1)

        # forward pass for model B
        loss_b = ...

        # backward pass for model B
        self.context.backward(loss_b)
        self.context.step_optimizer(opt_b)

        train_metrics = OrderedDict({
            'loss': d_loss,
            'progress_bar': tqdm_dict,
            'log': tqdm_dict
        })

        return train_metrics
```

## Test Plan

The backward compatibility is tested using the test suite in the CI system. Additional tests will be added in a follow-up PR. 

## Commentary (optional)

Please review the second commit. The first commit is in https://github.com/determined-ai/determined/pull/715.
<!-- User-facing API changes need the "User-facing API Change" label -->

<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

## Description

Lead with the intended commit body in this description field. For breaking changes, please include "BREAKING CHANGE:" at the beginning of your commit body. At minimum, this section should include a bracketed reference to the Jira ticket, e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.

## Test Plan

Describe the situations in which you've tested your change, and/or a screenshot as appropriate. Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.

## Commentary (optional)

Use this section of your description to add context to the PR. Could be for particularly tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc. You may intentionally leave this section blank and remove the title.
--->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234