### PR TITLE
fix: upgrade scheme when using websockets [DET-3230]

### DIFF
--- a/common/determined_common/api/request.py
+++ b/common/determined_common/api/request.py
@@ -29,6 +29,16 @@ def make_url(master_address: str, suffix: str) -> str:
     return parse.urljoin(parsed.geturl(), suffix)
 
 
+def maybe_upgrade_ws_scheme(master_address: str) -> str:
+    parsed = parse.urlparse(master_address)
+    if parsed.scheme == "https":
+        return parsed._replace(scheme="wss").geturl()
+    elif parsed.scheme == "http":
+        return parsed._replace(scheme="ws").geturl()
+    else:
+        return master_address
+
+
 def add_token_to_headers(headers: Dict[str, str]) -> Dict[str, str]:
     token = authentication.Authentication.instance().get_session_token()
 
@@ -192,7 +202,7 @@ def ws(host: str, path: str) -> WebSocket:
     """
     Connect to a web socket at the remote API.
     """
-    websocket = lomond.WebSocket(make_url(host, path))
+    websocket = lomond.WebSocket(maybe_upgrade_ws_scheme(make_url(host, path)))
     token = authentication.Authentication.instance().get_session_token()
     websocket.add_header("Authorization".encode(), "Bearer {}".format(token).encode())
     return WebSocket(websocket)


### PR DESCRIPTION
When we use websockets to connect to the master, historically we
have not changed the protocol to ws/wss. This works fine for ws
but in the case of wss, it causes lomond (the python library we
use) to perform the ws upgrade before a tls handshake is
completed---causing the connection to be rejected.

## Description

The offending line of code is https://github.com/wildfoundry/dataplicity-lomond/blob/f7d0476c85777a4ce874323428a62ef085e76dd4/lomond/websocket.py#L102 which causes Lomond to not think our url with https is not secure so it tries to upgrade the connection before performing a tls handshake. My guess is a PR into Lomond to check for `https` also would be declined since `lomond.WebSocket` states a protocol of ws/wss is required https://github.com/wildfoundry/dataplicity-lomond/blob/f7d0476c85777a4ce874323428a62ef085e76dd4/lomond/websocket.py#L37.

## Test Plan

Tested with `https` configured locally and I can successfully open a shell.

```
(determined) ➜  cli git:(fix-wss-cli) ✗ det -m https://localhost:8443 cmd run nvidia-smi
/Users/bradleylaney/.virtualenvs/determined/lib/python3.6/site-packages/urllib3/connection.py:394: SubjectAltNameWarning: Certificate for localhost has no `subjectAltName`, falling back to check for a `commonName` for now. This feature is being removed by major browsers and deprecated by RFC 2818. (See https://github.com/urllib3/urllib3/issues/497 for details.)
  SubjectAltNameWarning,
/Users/bradleylaney/.virtualenvs/determined/lib/python3.6/site-packages/urllib3/connection.py:394: SubjectAltNameWarning: Certificate for localhost has no `subjectAltName`, falling back to check for a `commonName` for now. This feature is being removed by major browsers and deprecated by RFC 2818. (See https://github.com/urllib3/urllib3/issues/497 for details.)
  SubjectAltNameWarning,
/Users/bradleylaney/.virtualenvs/determined/lib/python3.6/site-packages/urllib3/connection.py:394: SubjectAltNameWarning: Certificate for localhost has no `subjectAltName`, falling back to check for a `commonName` for now. This feature is being removed by major browsers and deprecated by RFC 2818. (See https://github.com/urllib3/urllib3/issues/497 for details.)
  SubjectAltNameWarning,
Scheduling Command (neatly-allowing-dog) (id: cac9533c-a378-415d-9272-ae33ebdbc123)...
Command (neatly-allowing-dog) was assigned to an agent...
[2020-06-12T15:48:54Z] 633cc550 [PULLING] || image already found, skipping pull phase: docker.io/determinedai/environments:py-3.6.9-pytorch-1.4-tf-1.14-cpu-0c9e956
[2020-06-12T15:48:55Z] 633cc550 [STARTING] || copying files to container: /
[2020-06-12T15:48:55Z] 633cc550 [STARTING] || copying files to container: /run/determined/workdir
[2020-06-12T15:48:55Z] 633cc550 [STARTING] || copying files to container: /
[2020-06-12T15:48:55Z] 633cc550 [STARTING] || copying files to container: /
Container of Command (neatly-allowing-dog) has started...
[2020-06-12T15:48:55Z] 633cc550 [RUNNING] ||  /bin/sh: 1: nvidia-smi: not found
Command (neatly-allowing-dog) was terminated: container failed with non-zero exit code: container failed with non-zero exit code: 127
```

## Commentary (optional)


<!-- User-facing API changes need the "User-facing API Change" label -->

<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

## Description

Lead with the intended commit body in this description field. For breaking changes, please include "BREAKING CHANGE:" at the beginning of your commit body. At minimum, this section should include a bracketed reference to the Jira ticket, e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.

## Test Plan

Describe the situations in which you've tested your change, and/or a screenshot as appropriate. Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.

## Commentary (optional)

Use this section of your description to add context to the PR. Could be for particularly tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc. You may intentionally leave this section blank and remove the title.
--->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234