### PR TITLE
chore: better logging for websocket failures [DET-3230]

### DIFF
--- a/common/determined_common/api/request.py
+++ b/common/determined_common/api/request.py
@@ -172,7 +172,7 @@ class WebSocket:
                 or isinstance(event, lomond.events.ProtocolError)
             ):
                 # Any unexpected failures raise the standard API exception.
-                raise errors.BadRequestException(message="WebSocket failure: {}".format(event.name))
+                raise errors.BadRequestException(message="WebSocket failure: {}".format(event))
             elif isinstance(event, lomond.events.Text):
                 # All web socket connections are expected to be in a JSON
                 # format.


### PR DESCRIPTION
## Description
The websocket library we use provides nice representations for events, example https://github.com/wildfoundry/dataplicity-lomond/blob/f7d0476c85777a4ce874323428a62ef085e76dd4/lomond/events.py#L130-L135 but we scrap that and just print the event name. To help trouble shooting issues, we should just print the entire event.


## Test Plan

Before:
```
Failed to fetch command logs: WebSocket failure: rejected
```

After:
```
Failed to create command: WebSocket failure: Rejected(response=<response HTTP/1.0 400 Bad Request>, reason='Websocket upgrade failed (code=400)')
```

## Commentary (optional)


<!-- User-facing API changes need the "User-facing API Change" label -->

<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

## Description

Lead with the intended commit body in this description field. For breaking changes, please include "BREAKING CHANGE:" at the beginning of your commit body. At minimum, this section should include a bracketed reference to the Jira ticket, e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.

## Test Plan

Describe the situations in which you've tested your change, and/or a screenshot as appropriate. Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.

## Commentary (optional)

Use this section of your description to add context to the PR. Could be for particularly tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc. You may intentionally leave this section blank and remove the title.
--->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234