### PR TITLE
chore: clean up _LRHelper [DET-3270]

### DIFF
--- a/harness/determined/pytorch/__init__.py
+++ b/harness/determined/pytorch/__init__.py
@@ -10,7 +10,7 @@ from determined.pytorch._data import (
     to_device,
 )
 from determined.pytorch._callback import PyTorchCallback, ClipGradsL2Norm, ClipGradsL2Value
-from determined.pytorch._lr_scheduler import LRScheduler, _LRHelper
+from determined.pytorch._lr_scheduler import LRScheduler
 from determined.pytorch._reducer import Reducer, _reduce_metrics
 from determined.pytorch._pytorch_context import PyTorchTrialContext
 from determined.pytorch._pytorch_trial import PyTorchTrial, PyTorchTrialController, reset_parameters

--- a/harness/determined/pytorch/_lr_scheduler.py
+++ b/harness/determined/pytorch/_lr_scheduler.py
@@ -1,5 +1,5 @@
 import enum
-import typing
+from typing import Any, Dict, List
 
 import torch
 
@@ -7,6 +7,14 @@ import determined_common.check as check
 
 
 class LRScheduler:
+    """Wrapper for a PyTorch LRScheduler.
+
+    This wrapper fulfills two main functions:
+        1. Save and restore the learning rate when a trial is paused, preempted, etc.
+        2. Step the learning rate scheduler at the configured frequency
+           (e.g., every batch or every epoch).
+    """
+
     class StepMode(enum.Enum):
         """Specifies when and how scheduler.step() should be executed.
 
@@ -20,15 +28,10 @@ class LRScheduler:
         STEP_EVERY_BATCH = 2
         MANUAL_STEP = 3
 
-    def __init__(self, scheduler: torch.optim.lr_scheduler._LRScheduler, step_mode: StepMode):
-        """Wrapper for a PyTorch LRScheduler.
-
-        Usage of this wrapper is required to properly schedule the optimizer's learning rate.
-
-        This wrapper fulfills two main functions:
-            1. Save and restore the learning rate when a trial is paused, preempted, etc.
-            2. Step the learning rate scheduler at the configured frequency
-               (e.g., every batch or every epoch).
+    def __init__(
+        self, scheduler: torch.optim.lr_scheduler._LRScheduler, step_mode: StepMode,
+    ):
+        """LRScheduler constructor
 
         Args:
             scheduler (:py:class:`torch.optim.lr_scheduler._LRScheduler`):
@@ -46,76 +49,20 @@ class LRScheduler:
                    It is up to the user to decide when to call scheduler.step(),
                    and whether to pass any arguments.
         """
-
         check.check_not_none(scheduler)
         check.check_isinstance(step_mode, LRScheduler.StepMode)
 
-        self.scheduler = scheduler
-        self.step_mode = step_mode
+        self._scheduler = scheduler
+        self._step_mode = step_mode
 
-    def step(self, *args: typing.Any, **kwargs: typing.Any) -> None:
-        """Call step() on the wrapped LRScheduler instance."""
-        check.check_eq(
-            self.step_mode,
-            LRScheduler.StepMode.MANUAL_STEP,
-            "Please use the MANUAL_STEP step mode to call step() on the scheduler.",
-        )
-        return self.scheduler.step(*args, **kwargs)
+    def step(self, *args: Any, **kwargs: Any) -> None:
+        self._scheduler.step(*args, **kwargs)
 
-    def get_last_lr(self) -> typing.List:
-        """Return last computed learning rate by current scheduler.
+    def get_last_lr(self) -> List:
+        return self._scheduler.get_last_lr()  # type: ignore
 
-        This function is equivalent to calling get_last_lr() on the wrapped LRScheduler.
-        """
+    def load_state_dict(self, state_dict: Dict[Any, Any]) -> None:
+        self._scheduler.load_state_dict(state_dict)
 
-        return self.scheduler.get_last_lr()  # type: ignore
-
-
-class _LRHelper:
-    def __init__(self, lr_scheduler: typing.Optional[LRScheduler]):
-        self._lr_scheduler = None
-        if lr_scheduler:
-            check.check_type(
-                lr_scheduler,
-                LRScheduler,
-                "`create_lr_scheduler` must return a `det.pytorch.LRScheduler`",
-            )
-            self._lr_scheduler = lr_scheduler
-            self._lr_scheduler_count = lr_scheduler.scheduler._step_count  # type: ignore
-
-    def __bool__(self) -> bool:
-        return self._lr_scheduler is not None
-
-    def should_step_lr(
-        self, batches_completed: int, epoch_length: int, aggregation_frequency: int
-    ) -> bool:
-        if self._lr_scheduler:
-            if self._lr_scheduler.step_mode == LRScheduler.StepMode.STEP_EVERY_BATCH:
-                return True
-            elif self._lr_scheduler.step_mode == LRScheduler.StepMode.STEP_EVERY_EPOCH:
-                mod = batches_completed % epoch_length
-                if mod == 0 or mod < aggregation_frequency:
-                    return True
-        return False
-
-    def step(self) -> None:
-        check.check_eq(
-            self._lr_scheduler.scheduler._step_count,  # type: ignore
-            self._lr_scheduler_count,
-            "You cannot call `scheduler.step()` if you have configured "
-            "Determined to manage the learning rate scheduler.",
-        )
-        self._lr_scheduler.scheduler.step()  # type: ignore
-        self._lr_scheduler_count += 1
-
-    def load_state_dict(
-        self, state_dict: typing.Optional[typing.Dict[typing.Any, typing.Any]]
-    ) -> None:
-        if self._lr_scheduler:
-            state_dict = typing.cast(typing.Dict[typing.Any, typing.Any], state_dict)
-            self._lr_scheduler.scheduler.load_state_dict(state_dict)
-            self._lr_scheduler_count = self._lr_scheduler.scheduler._step_count  # type: ignore
-
-    def state_dict(self) -> typing.Dict[typing.Any, typing.Any]:
-        self._lr_scheduler = typing.cast(LRScheduler, self._lr_scheduler)
-        return self._lr_scheduler.scheduler.state_dict()
+    def state_dict(self) -> Dict[Any, Any]:
+        return self._scheduler.state_dict()

--- a/harness/tests/experiment/pytorch/test_pytorch_trial.py
+++ b/harness/tests/experiment/pytorch/test_pytorch_trial.py
@@ -6,7 +6,6 @@ import torch
 
 import determined as det
 from determined import workload
-from determined_common import check
 from tests.experiment import utils  # noqa: I100
 from tests.experiment.fixtures import pytorch_xor_model
 
@@ -349,21 +348,6 @@ class TestPyTorchTrial:
         lrs = [metric["lr"] for metric in training_metrics]
         for i in range(1, len(lrs)):
             assert lrs[i] == lrs[i - 1] + 1
-
-    def test_lr_schedule_user_modify_fail(self, tmp_path: pathlib.Path) -> None:
-        def make_workloads() -> workload.Stream:
-            trainer = utils.TrainAndValidate()
-            yield from trainer.send(steps=10, validation_freq=10, batches_per_step=1)
-            yield workload.terminate_workload(), [], workload.ignore_workload_response
-
-        controller = utils.make_trial_controller_from_trial_implementation(
-            trial_class=pytorch_xor_model.XORTrialUserStepLRFail,
-            hparams=self.hparams,
-            workloads=make_workloads(),
-            trial_seed=self.trial_seed,
-        )
-        with pytest.raises(check.CheckFailedError):
-            controller.run()
 
     def test_lr_schedule_user_modify(self, tmp_path: pathlib.Path) -> None:
         def make_workloads() -> workload.Stream:


### PR DESCRIPTION
## Description

Clean up LR helper in our Pytorch support. Previously, `LRScheduler` is an user-facing object that lets users set how often an LR scheduler is stepped and `_LRHelper` is an internal object that lets the Determined step an LR scheduler. Keeping two objects is unnecessarily complicate especially in that part of the `_LRHelper` handles accepting an input of a None `LRScheduler`.

There are two different ways of calling the step() of a LR scheduler.

Method 1:
```
class MyTrial:
   def __init__(context):
       self.context = context
       self.lr_scheduler = self.context.LRScheduler(optimizer=optimizer, step_mode=MANUAL_STEP)

   def train_for_step(self, ...):
      ...
      self.lr_scheduler.step()
```

Method 2:
```
class MyTrial:
   def __init__(context):
       self.context = context
       self.lr_scheduler = self.context.LRScheduler(optimizer=optimizer, step_mode=STEP_EVERY_BATCH)

   def train_for_step(self, ...):
      ...
```
In the method 2, the scheduler step() is called for each batch.

These two methods are implemented both in the merged `LRScheduler`.

## Test Plan

Use the test suite for this. No need for additional tests.

## Commentary (optional)



<!-- User-facing API changes need the "User-facing API Change" label -->

<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

## Description

Lead with the intended commit body in this description field. For breaking changes, please include "BREAKING CHANGE:" at the beginning of your commit body. At minimum, this section should include a bracketed reference to the Jira ticket, e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.

## Test Plan

Describe the situations in which you've tested your change, and/or a screenshot as appropriate. Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.

## Commentary (optional)

Use this section of your description to add context to the PR. Could be for particularly tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc. You may intentionally leave this section blank and remove the title.
--->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234