### PR TITLE
fix: use custom TLS cert only for Determined API requests [DET-3360]

### DIFF
--- a/cli/determined_cli/cli.py
+++ b/cli/determined_cli/cli.py
@@ -238,7 +238,7 @@ def main(args: List[str] = sys.argv[1:]) -> None:
 
         cert_fn = str(auth.get_config_path().joinpath("master.crt"))
         if os.path.exists(cert_fn):
-            os.environ["REQUESTS_CA_BUNDLE"] = cert_fn
+            api.request.set_master_cert_bundle(cert_fn)
 
         try:
             try:
@@ -274,7 +274,7 @@ def main(args: List[str] = sys.argv[1:]) -> None:
 
                 with open(cert_fn, "w") as out:
                     out.write(cert_pem_data)
-                os.environ["REQUESTS_CA_BUNDLE"] = cert_fn
+                api.request.set_master_cert_bundle(cert_fn)
 
                 check_version(parsed_args)
 

--- a/common/determined_common/api/request.py
+++ b/common/determined_common/api/request.py
@@ -9,6 +9,14 @@ import simplejson
 
 from determined_common.api import authentication, errors
 
+# The path to a file containing an SSL certificate to trust specifically for the master, if any.
+_master_cert_bundle = None
+
+
+def set_master_cert_bundle(path: str) -> None:
+    global _master_cert_bundle
+    _master_cert_bundle = path
+
 
 def parse_master_address(master_address: str) -> parse.ParseResult:
     if master_address.startswith("https://"):
@@ -66,7 +74,14 @@ def do_request(
         h = add_token_to_headers(h)
 
     try:
-        r = requests.request(method, make_url(host, path), params=params, json=body, headers=h)
+        r = requests.request(
+            method,
+            make_url(host, path),
+            params=params,
+            json=body,
+            headers=h,
+            verify=_master_cert_bundle,
+        )
     except requests.exceptions.SSLError:
         raise
     except requests.exceptions.ConnectionError as e:


### PR DESCRIPTION
## Description

Previously, if the CLI found a custom trusted master certificate, it
would be used for all requests made using Requests; that was the
simplest thing to write, but it meant that other HTTPS requests would
fail (e.g., checkpoint downloads from GCS, which go through Requests
internally). This change restricts the cert to only be applied to
requests made to the master.

## Test Plan

- [x] check that the CLI can, within one invocation, use Requests to connect to a master with a custom cert and then another host using TLS, which would fail before
- [x] check that the CLI can still make HTTP connections and HTTPS connections not requiring custom certs

## Commentary (optional)

The global variable is unfortunate, as always, but it's still better-scoped than the environment variable and anything else I can think of would be way overkill (doing some sort of singleton thing or having contexts everywhere).

<!-- User-facing API changes need the "User-facing API Change" label -->

<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

## Description

Lead with the intended commit body in this description field. For breaking changes, please include "BREAKING CHANGE:" at the beginning of your commit body. At minimum, this section should include a bracketed reference to the Jira ticket, e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.

## Test Plan

Describe the situations in which you've tested your change, and/or a screenshot as appropriate. Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.

## Commentary (optional)

Use this section of your description to add context to the PR. Could be for particularly tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc. You may intentionally leave this section blank and remove the title.
--->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234