### PR TITLE
fix: correctly set steps for eval in EstimatorTrial

### DIFF
--- a/examples/official/trial/mnist_estimator/model_def.py
+++ b/examples/official/trial/mnist_estimator/model_def.py
@@ -144,4 +144,4 @@ class MNistTrial(EstimatorTrial):
             self.data_downloaded = True
 
         val_files = self._get_filenames(os.path.join(self.download_directory, "validation"))
-        return tf.estimator.EvalSpec(self._input_fn(val_files, shuffle=False))
+        return tf.estimator.EvalSpec(self._input_fn(val_files, shuffle=False), steps=None)


### PR DESCRIPTION
## Description
Previously we were dividing by the number of workers, but the number of steps is set based on global batch size, thus the division is not necessary.


## Test Plan
Tested this manually. 
