### PR TITLE
style: add linting rule to require await for async functions

### DIFF
--- a/webui/react/.eslintrc.js
+++ b/webui/react/.eslintrc.js
@@ -62,6 +62,7 @@ module.exports = {
       component: true,
       html: true,
     } ],
+    'require-await': 'error',
     'semi': [ 'error', 'always' ],
     'sort-imports': [ 'error', {
       ignoreCase: true,

--- a/webui/react/src/services/api.ts
+++ b/webui/react/src/services/api.ts
@@ -36,34 +36,37 @@ export const patchExperiment = generateApi<PatchExperimentParams, void>(Config.p
 export const launchTensorboard =
   generateApi<LaunchTensorboardParams, void>(Config.launchTensorboard);
 
-export const killTask =
-  async (task: AnyTask, cancelToken?: CancelToken): Promise<void> => {
-    if (isExperimentTask(task)) {
-      return killExperiment({ cancelToken, experimentId: parseInt(task.id) });
-    }
-    return killCommand({
-      cancelToken,
-      commandId: task.id,
-      commandType: task.type as unknown as CommandType,
-    });
-  };
+export const killTask = async (task: AnyTask, cancelToken?: CancelToken): Promise<void> => {
+  if (isExperimentTask(task)) {
+    return await killExperiment({ cancelToken, experimentId: parseInt(task.id) });
+  }
+  return await killCommand({
+    cancelToken,
+    commandId: task.id,
+    commandType: task.type as unknown as CommandType,
+  });
+};
 
-export const archiveExperiment =
-  async (experimentId: number, isArchived: boolean, cancelToken?: CancelToken): Promise<void> => {
-    return patchExperiment({ body: { archived: isArchived }, cancelToken, experimentId });
-  };
+export const archiveExperiment = async (
+  experimentId: number,
+  isArchived: boolean,
+  cancelToken?: CancelToken,
+): Promise<void> => {
+  return await patchExperiment({ body: { archived: isArchived }, cancelToken, experimentId });
+};
 
 export const login = generateApi<Credentials, void>(Config.login);
 
 export const logout = generateApi<{}, void>(Config.logout);
 
-export const setExperimentState =
-  async ({ state, ...rest }: PatchExperimentState): Promise<void> => {
-    return patchExperiment({
-      body: { state },
-      ...rest,
-    });
-  };
+export const setExperimentState = async (
+  { state, ...rest }: PatchExperimentState,
+): Promise<void> => {
+  return await patchExperiment({
+    body: { state },
+    ...rest,
+  });
+};
 
 export const getMasterLogs = generateApi<LogsParams, Log[]>(Config.getMasterLogs);
 


### PR DESCRIPTION
## Description

Add lint rule to capture errors around async functions missing await functions. To avoid unnecessary async applications.

## Test Plan



## Commentary (optional)


<!-- User-facing API changes need the "User-facing API Change" label -->

<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

## Description

Lead with the intended commit body in this description field. For breaking changes, please include "BREAKING CHANGE:" at the beginning of your commit body. At minimum, this section should include a bracketed reference to the Jira ticket, e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.

## Test Plan

Describe the situations in which you've tested your change, and/or a screenshot as appropriate. Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.

## Commentary (optional)

Use this section of your description to add context to the PR. Could be for particularly tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc. You may intentionally leave this section blank and remove the title.
--->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234