### PR TITLE
fix: shared_fs checkpoint validation

### DIFF
--- a/common/determined_common/experimental/checkpoint/_checkpoint.py
+++ b/common/determined_common/experimental/checkpoint/_checkpoint.py
@@ -132,7 +132,9 @@ class Checkpoint(object):
                 shutil.copytree(str(src_ckpt_dir), str(local_ckpt_dir))
             else:
                 local_ckpt_dir.mkdir(parents=True, exist_ok=True)
-                manager = storage.build(self.experiment_config["checkpoint_storage"])
+                manager = storage.build(
+                    self.experiment_config["checkpoint_storage"], container_path=None,
+                )
                 if not isinstance(manager, (storage.S3StorageManager, storage.GCSStorageManager)):
                     raise AssertionError(
                         "Downloading from S3 or GCS requires the experiment to be configured with "

--- a/common/determined_common/storage/__init__.py
+++ b/common/determined_common/storage/__init__.py
@@ -106,5 +106,5 @@ def validate_manager(manager: StorageManager) -> None:
     manager.delete(metadata)
 
 
-def validate_config(config: Dict[str, Any]) -> None:
-    validate_manager(build(config))
+def validate_config(config: Dict[str, Any], container_path: Optional[str] = None) -> None:
+    validate_manager(build(config, container_path=container_path))

--- a/common/determined_common/storage/__init__.py
+++ b/common/determined_common/storage/__init__.py
@@ -28,7 +28,7 @@ _STORAGE_MANAGERS = {
 }  # type: Dict[str, Type[StorageManager]]
 
 
-def build(config: Dict[str, Any], container_path: Optional[str] = None) -> StorageManager:
+def build(config: Dict[str, Any], container_path: Optional[str]) -> StorageManager:
     """
     Return a checkpoint manager defined by the value of the `type` key in
     the configuration dictionary. Throws a `TypeError` if no storage manager
@@ -106,5 +106,5 @@ def validate_manager(manager: StorageManager) -> None:
     manager.delete(metadata)
 
 
-def validate_config(config: Dict[str, Any], container_path: Optional[str] = None) -> None:
-    validate_manager(build(config, container_path=container_path))
+def validate_config(config: Dict[str, Any], container_path: Optional[str]) -> None:
+    validate_manager(build(config, container_path))

--- a/e2e_tests/tests/fixtures/no_op/model_def.py
+++ b/e2e_tests/tests/fixtures/no_op/model_def.py
@@ -134,6 +134,8 @@ class NoOpTrialController(det.CallbackTrialController):
         logging.info("Saving checkpoint {}, steps_trained {}".format(fpath, self.steps_trained()))
         with fpath.open("w") as f:
             json.dump(self.trained_steps, f, sort_keys=True, indent=4)
+        path.chmod(0o777)
+        fpath.chmod(0o777)
 
     def load(self, path: pathlib.Path) -> None:
         self.chaos_failure(self.chaos_probability_checkpoint)

--- a/e2e_tests/tests/requirements.txt
+++ b/e2e_tests/tests/requirements.txt
@@ -1,3 +1,4 @@
+appdirs
 pytest
 pexpect
 torch==1.4

--- a/harness/determined/exec/harness.py
+++ b/harness/determined/exec/harness.py
@@ -200,7 +200,10 @@ def main() -> None:
     )
 
     try:
-        storage.validate_config(env.experiment_config["checkpoint_storage"])
+        storage.validate_config(
+            env.experiment_config["checkpoint_storage"],
+            container_path=constants.SHARED_FS_CONTAINER_PATH,
+        )
     except Exception as e:
         logging.error("Checkpoint storage validation failed: {}".format(e))
         sys.exit(1)

--- a/harness/tests/storage/test_s3.py
+++ b/harness/tests/storage/test_s3.py
@@ -60,5 +60,5 @@ def test_verify_s3_upload_error(tmp_path: Path, monkeypatch: MonkeyPatch) -> Non
     }
     assert len(os.listdir(tmpdir_s)) == 0
     with pytest.raises(S3UploadFailedError):
-        storage.validate_config(config)
+        storage.validate_config(config, container_path=None)
     assert len(os.listdir(tmpdir_s)) == 0

--- a/harness/tests/storage/test_storage_base.py
+++ b/harness/tests/storage/test_storage_base.py
@@ -10,23 +10,23 @@ from determined_common.storage import StorageManager
 def test_unknown_type() -> None:
     config = {"type": "unknown"}
     with pytest.raises(TypeError, match="Unknown storage type: unknown"):
-        storage.build(config)
+        storage.build(config, container_path=None)
 
 
 def test_missing_type() -> None:
     with pytest.raises(CheckFailedError, match="Missing 'type' parameter"):
-        storage.build({})
+        storage.build({}, container_path=None)
 
 
 def test_illegal_type() -> None:
     config = {"type": 4}
     with pytest.raises(CheckFailedError, match="must be a string"):
-        storage.build(config)
+        storage.build(config, container_path=None)
 
 
 def test_build_with_container_path() -> None:
     config = {"type": "shared_fs", "host_path": "/host_path", "storage_path": "storage_path"}
-    manager = storage.build(config)
+    manager = storage.build(config, container_path=None)
     assert manager._base_path == "/host_path/storage_path"
     manager = storage.build(config, container_path="/container_path")
     assert manager._base_path == "/container_path/storage_path"


### PR DESCRIPTION
## Description

    fix: support storage validation in container


    test: regression test for host_path in container


    chore: require container_path in storage.build()

    It was never really optional, it was only very easy to forget that it
    not passing container_path was only allowed in the host environment.

This was blatantly wrong, but it went unnoticed for weeks because it only arose when running experiments as non-root AND when using a non-`/tmp` `host_path` for a shared_fs storage.

This change also includes an improvement to an internal API to make it more difficult to make the same mistake.

## Test Plan

PR includes a regression test, which fails when applied without the `fix` commit.

@sidneyw please confirm that the new test runs properly on a mac, and that it cleans up the checkpoint directories that it creates.