### PR TITLE
chore: don't filter metrics with "/"

### DIFF
--- a/harness/determined/tensorboard/metric_writers/callback.py
+++ b/harness/determined/tensorboard/metric_writers/callback.py
@@ -27,9 +27,6 @@ class BatchMetricWriter(callback.Callback):
         if not util.is_numerical_scalar(metric_val):
             return
 
-        if "/" in metric_key:
-            return
-
         self.writer.add_scalar("Determined/" + metric_key, metric_val, step)
 
     def on_train_step_end(self, step_id: int, metrics: List[Dict[str, Any]]) -> None:


### PR DESCRIPTION
Tested by running some keras/pytorch/estimator experiments. After removing the filter, the estimator metrics show up and the keras/pytorch looks unchanged. Any more thoughts @sidneyw? (I'm git blame'ing to see where this got introduced).