### PR TITLE
feat: list models endpoint [DET-3278]

### DIFF
--- a/master/static/srv/get_models.sql
+++ b/master/static/srv/get_models.sql
@@ -1,0 +1,2 @@
+SELECT name, description, metadata, creation_time, last_updated_time FROM models;
+

--- a/proto/src/determined/api/v1/api.proto
+++ b/proto/src/determined/api/v1/api.proto
@@ -78,4 +78,6 @@ service Determined {
     rpc PostModel(PostModelRequest) returns (PostModelResponse) { option (google.api.http) = {post: "/api/v1/models/{model.name}" body: "model"}; }
     // Update model fields
     rpc PatchModel(PatchModelRequest) returns (PatchModelResponse) { option (google.api.http) = {patch: "/api/v1/models/{model.name}" body: "*"}; }
+    // Get the requested model.
+    rpc GetModels(GetModelsRequest) returns (GetModelsResponse)  { option (google.api.http) = {get: "/api/v1/models"}; }
 }

--- a/proto/src/determined/api/v1/model.proto
+++ b/proto/src/determined/api/v1/model.proto
@@ -3,8 +3,10 @@ syntax = "proto3";
 package determined.api.v1;
 option go_package = "github.com/determined-ai/determined/proto/pkg/apiv1";
 
-import "google/protobuf/struct.proto";
 import "google/protobuf/field_mask.proto";
+import "google/protobuf/struct.proto";
+
+import "determined/api/v1/pagination.proto";
 import "determined/model/v1/model.proto";
 
 // Get the requested model.
@@ -17,6 +19,33 @@ message GetModelRequest {
 message GetModelResponse {
   // The model requested.
   determined.model.v1.Model model = 1;
+}
+
+message GetModelsRequest {
+  enum SortBy {
+    SORT_BY_UNSPECIFIED = 0;
+    SORT_BY_NAME = 1;
+    SORT_BY_DESCRIPTION = 2;
+
+    SORT_BY_CREATION_TIME = 4;
+    SORT_BY_LAST_UPDATED_TIME = 5;
+  }
+
+  SortBy sort_by = 1;
+  OrderBy order_by = 2;
+
+  int32 offset = 3;
+
+  // Limit the number of experiments. A value of 0 denotes no limit.
+  int32 limit = 4;
+
+  string name = 5;
+  string description = 6;
+}
+
+message GetModelsResponse {
+  repeated determined.model.v1.Model models = 1;
+  Pagination pagination = 2;
 }
 
 // Request for creating a model in the registry.

--- a/proto/src/determined/api/v1/model.proto
+++ b/proto/src/determined/api/v1/model.proto
@@ -21,30 +21,44 @@ message GetModelResponse {
   determined.model.v1.Model model = 1;
 }
 
+// Get a list of models.
 message GetModelsRequest {
+  // Sort models by the given field.
   enum SortBy {
+    // Returns models in an unsorted list.
     SORT_BY_UNSPECIFIED = 0;
+    // Returns models sorted by name.
     SORT_BY_NAME = 1;
+    // Returns models sorted by description.
     SORT_BY_DESCRIPTION = 2;
-
+    // Returns models sorted by creation time.
     SORT_BY_CREATION_TIME = 4;
+    // Returns models sorted by last updated time.
     SORT_BY_LAST_UPDATED_TIME = 5;
   }
 
+  // Sort the models by the given field.
   SortBy sort_by = 1;
+  // Order models in either ascending or descending order.
   OrderBy order_by = 2;
 
+  // Skip the number of models before returning results. Negative values
+  // denote number of models to skip from the end before returning results.
   int32 offset = 3;
-
-  // Limit the number of experiments. A value of 0 denotes no limit.
+  // Limit the number of models. A value of 0 denotes no limit.
   int32 limit = 4;
 
+  // Limit the models to those matching the name.
   string name = 5;
+  // Limit the models to those matching the description.
   string description = 6;
 }
 
+// Response to GetModelsRequest
 message GetModelsResponse {
+  // The list of returned models.
   repeated determined.model.v1.Model models = 1;
+  // Pagination information of the full dataset.
   Pagination pagination = 2;
 }
 


### PR DESCRIPTION
## Description
Endpoint for returning a paginated list of all models in the database.

## Test Plan
Integration tests will cover the endpoint once we have the python client.