### PR TITLE
fix: send Terminate response after on_trial_close callback [DET-3433]

### DIFF
--- a/harness/determined/estimator/_estimator_trial.py
+++ b/harness/determined/estimator/_estimator_trial.py
@@ -316,9 +316,7 @@ class DeterminedControlHook(tf.estimator.SessionRunHook):  # type: ignore
                 path = cast(pathlib.Path, args[0])
                 response_func(self._checkpoint_model(path))
             elif wkld.kind == workload.Workload.Kind.TERMINATE:
-                response_func(
-                    {} if self.estimator_trial_controller.is_chief else workload.Skipped()
-                )
+                self.estimator_trial_controller.exit_response_func = response_func
                 raise det.errors.WorkerFinishedGracefully("Exiting normally.")
             else:
                 raise AssertionError(f"Unknown wkld kind {wkld.kind}.")
@@ -341,6 +339,9 @@ class EstimatorTrialController(det.LoopTrialController):
         self.user_train_spec = user_train_spec
         self.val_spec = val_spec
         self.serving_input_receiver_fns = serving_input_receiver_fns
+
+        # Used to send Terminate response following post-trial close callback.
+        self.exit_response_func = None  # type: Optional[workload.ResponseFunc]
 
         self._init_model()
 
@@ -585,10 +586,13 @@ class EstimatorTrialController(det.LoopTrialController):
                 "a user callback causing the training loop to exit, which is not supported at this "
                 "time."
             )
+        finally:
+            for callback in self.train_hooks:
+                if isinstance(callback, estimator.RunHook):
+                    callback.on_trial_close()
 
-        for callback in self.train_hooks:
-            if isinstance(callback, estimator.RunHook):
-                callback.on_trial_close()
+        if self.exit_response_func:
+            self.exit_response_func({} if self.is_chief else workload.Skipped())
 
     def _init_paths(self) -> None:
         """


### PR DESCRIPTION
## Description
If the response is sent before the callback, the socket to the master
may close and the container may get SigKilled before the callback
completes.


## Test Plan
Tested this manually. Further testing should be done once [DET-3435](https://determinedai.atlassian.net/browse/DET-3435) is fixed and we should hold off merging this until then.


