### PR TITLE
fix: read correct failure status for terminated containers [DET-3435]

### DIFF
--- a/master/internal/trial.go
+++ b/master/internal/trial.go
@@ -741,11 +741,10 @@ func (t *trial) processContainerTerminated(
 		})
 	}
 
-	status := agent.ContainerError(agent.AgentError, errors.New("no error status provided"))
-	if s := msg.ContainerStopped; s.Failure != nil {
-		status = *s
-	}
-	if c == nil || c.IsLeader() || status.Failure != nil {
+	// Terminate the task if the container never started (since this prevents the gang
+	// from ever being able to start), if the leader of the gang has exited out, or if
+	// one of the containers exited with a failure.
+	if c == nil || c.IsLeader() || msg.ContainerStopped.Failure != nil {
 		ctx.Tell(t.rp, scheduler.TerminateTask{TaskID: t.task.ID, Forcible: true})
 	}
 }


### PR DESCRIPTION
## Description
Previously, for every container termination, we inserted a failure
status, which would result in us terminating the whole gang prematurely.


## Test Plan
Tested this manually.
