### PR TITLE
fix: use correct request path for `det trial logs --tail`

### DIFF
--- a/cli/determined_cli/trial.py
+++ b/cli/determined_cli/trial.py
@@ -88,7 +88,7 @@ def logs(args: Namespace) -> None:
         nonlocal offset, state
         path = "trials/{}/logsv2?offset={}".format(args.trial_id, offset)
         if limit:
-            path = "{}&limit=?".format(limit)
+            path += "&limit={}".format(limit)
         for log in api.get(args.master, path).json():
             print(log["message"], end="")
             offset, state = log["id"], log["state"]

--- a/e2e_tests/tests/test_system.py
+++ b/e2e_tests/tests/test_system.py
@@ -280,6 +280,18 @@ def test_create_test_mode() -> None:
 
 
 @pytest.mark.e2e_cpu  # type: ignore
+def test_trial_logs() -> None:
+    experiment_id = exp.run_basic_test(
+        conf.fixtures_path("no_op/single.yaml"), conf.fixtures_path("no_op"), 1
+    )
+    trial_id = exp.experiment_trials(experiment_id)[0]["id"]
+    subprocess.check_call(["det", "-m", conf.make_master_url(), "trial", "logs", str(trial_id)])
+    subprocess.check_call(
+        ["det", "-m", conf.make_master_url(), "trial", "logs", "--tail", "10", str(trial_id)],
+    )
+
+
+@pytest.mark.e2e_cpu  # type: ignore
 def test_labels() -> None:
     experiment_id = exp.create_experiment(
         conf.fixtures_path("no_op/single-one-short-step.yaml"), conf.fixtures_path("no_op"), None


### PR DESCRIPTION
## Description

An incorrect format string meant that any use of `det trial logs --tail`
would attempt to hit a nonexistent path on the master and fail.

## Test Plan

- [x] run some commands manually using `--tail`
- [x] add a new test that passes now but fails without the fix