### PR TITLE
fix: retry uploads on ConnectionError [DET-3358]

### DIFF
--- a/common/determined_common/storage/gcs.py
+++ b/common/determined_common/storage/gcs.py
@@ -4,6 +4,7 @@ import os
 import tempfile
 from typing import Iterator, Optional
 
+import requests.exceptions
 import urllib3.exceptions
 from google.api_core import retry
 from google.cloud import storage
@@ -11,7 +12,9 @@ from google.cloud import storage
 from determined_common.storage.base import StorageManager, StorageMetadata
 
 retry_network_errors = retry.Retry(
-    retry.if_exception_type(ConnectionError, urllib3.exceptions.ProtocolError)
+    retry.if_exception_type(
+        ConnectionError, urllib3.exceptions.ProtocolError, requests.exceptions.ConnectionError
+    )
 )
 
 


### PR DESCRIPTION
## Description
Uploading checkpoints to GCS fails intermittently, throwing a requests.exceptions.ConnectionError exception. The retry function retries the upload on a ConnectionError, which is different from requests.exceptions.ConnectionError. After adding this different exception type to the retry function, we see the checkpoints being uploaded successfully.

## Test Plan



## Commentary (optional)


<!-- User-facing API changes need the "User-facing API Change" label -->

<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

## Description

Lead with the intended commit body in this description field. For breaking changes, please include "BREAKING CHANGE:" at the beginning of your commit body. At minimum, this section should include a bracketed reference to the Jira ticket, e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.

## Test Plan

Describe the situations in which you've tested your change, and/or a screenshot as appropriate. Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.

## Commentary (optional)

Use this section of your description to add context to the PR. Could be for particularly tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc. You may intentionally leave this section blank and remove the title.
--->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234