### PR TITLE
chore: upgrade agent VM image to newer kernel version

### DIFF
--- a/deploy/determined_deploy/aws/templates/secure.yaml
+++ b/deploy/determined_deploy/aws/templates/secure.yaml
@@ -4,11 +4,11 @@ Mappings:
   RegionMap:
     us-east-1:
       Master: ami-66506c1c
-      Agent: ami-007d24256bc2cc5ca
+      Agent: ami-05e22bfd09b7b25f3
       Bastion: ami-0a1262fb77d0911ef
     us-west-2:
       Master: ami-79873901
-      Agent: ami-0f00cd8ac6e73a52d
+      Agent: ami-038842e6cb3f1bbb8
       Bastion: ami-0ec8cdd8937453529
 
 Parameters:

--- a/deploy/determined_deploy/aws/templates/simple.yaml
+++ b/deploy/determined_deploy/aws/templates/simple.yaml
@@ -5,10 +5,10 @@ Mappings:
   RegionMap:
     us-east-1:
       Master: ami-66506c1c
-      Agent: ami-007d24256bc2cc5ca
+      Agent: ami-05e22bfd09b7b25f3
     us-west-2:
       Master: ami-79873901
-      Agent: ami-0f00cd8ac6e73a52d
+      Agent: ami-038842e6cb3f1bbb8
 
 Parameters:
   Keypair:

--- a/deploy/determined_deploy/aws/templates/vpc.yaml
+++ b/deploy/determined_deploy/aws/templates/vpc.yaml
@@ -4,10 +4,10 @@ Mappings:
   RegionMap:
     us-east-1:
       Master: ami-66506c1c
-      Agent: ami-007d24256bc2cc5ca
+      Agent: ami-05e22bfd09b7b25f3
     us-west-2:
       Master: ami-79873901
-      Agent: ami-0f00cd8ac6e73a52d
+      Agent: ami-038842e6cb3f1bbb8
 
 Parameters:
   VpcCIDR:

--- a/deploy/determined_deploy/gcp/constants.py
+++ b/deploy/determined_deploy/gcp/constants.py
@@ -2,7 +2,7 @@ class defaults:
 
     AGENT_INSTANCE_TYPE = "n1-standard-32"
     DB_PASSWORD = "postgres"
-    ENVIRONMENT_IMAGE = "pedl-environments-0c9e956"
+    ENVIRONMENT_IMAGE = "pedl-environments-9c8c0bd"
     GPU_NUM = 8
     GPU_TYPE = "nvidia-tesla-k80"
     MASTER_INSTANCE_TYPE = "n1-standard-2"


### PR DESCRIPTION
## Description

Upgrade the agent VM image to one built on top of a newer version of Ubuntu 16.04. This was motivated by a desire to mount a Lustre filesystem onto agent VMs, but the Lustre client requires a kernel version that is newer than what our base Ubuntu 16.04 image had.


## Test Plan

- [x] Manually confirm that the new environment image has a new enough kernel
- [x] Run automated tests
- [ ] Double check that the AMI ids are correct for both regions.

## Commentary (optional)
