### PR TITLE
fix: don't set Segment key to quotes

### DIFF
--- a/master/Makefile
+++ b/master/Makefile
@@ -48,15 +48,15 @@ pre-package:
 	cp ../harness/dist/*.whl build/wheels/
 
 .PHONY: package
-package: export DET_SEGMENT_MASTER_KEY ?= ""
-package: export DET_SEGMENT_WEBUI_KEY ?= ""
+package: export DET_SEGMENT_MASTER_KEY ?=
+package: export DET_SEGMENT_WEBUI_KEY ?=
 package: export GORELEASER_CURRENT_TAG := $(VERSION)
 package:
 	goreleaser --snapshot --rm-dist
 
 .PHONY: release
-release: export DET_SEGMENT_MASTER_KEY ?= ""
-release: export DET_SEGMENT_WEBUI_KEY ?= ""
+release: export DET_SEGMENT_MASTER_KEY ?=
+release: export DET_SEGMENT_WEBUI_KEY ?=
 release: export GORELEASER_CURRENT_TAG := $(VERSION)
 release: export GORELEASER_PREVIOUS_TAG := $(shell git tag --sort=-creatordate | grep -v "rc\|v" | grep "$(VERSION)" -A1 | sed -n '2 p')
 release:


### PR DESCRIPTION
## Description

Because of how Make processes strings, the Segment keys were previously
being set to a string containing two quote characters rather than an
actual empty string.

## Test Plan

- [x] check that `make package` still runs (GoReleaser fails immediately if a variable it needs is unset)
- [x] change the body of the target to `set -u && echo $$DET_SEGMENT_MASTER_KEY`, which prints a blank line (it prints quotes without this change) and would fail if the variable were unset