### PR TITLE
refactor: add get-or-else support

### DIFF
--- a/webui/react/src/pages/Dashboard.tsx
+++ b/webui/react/src/pages/Dashboard.tsx
@@ -20,7 +20,7 @@ import {
   ALL_VALUE, Command, CommandType, RecentTask, ResourceType,
   TaskFilters, TaskType,
 } from 'types';
-import { getOrElse } from 'utils/data';
+import { getPath } from 'utils/data';
 import { filterTasks } from 'utils/task';
 import { activeCommandStates, commandToTask, experimentToTask } from 'utils/types';
 
@@ -52,7 +52,7 @@ const Dashboard: React.FC = () => {
 
   const storage = useStorage('dashboard/tasks');
   const initFilters = storage.getWithDefault('filters', {
-    ...defaultFilters, username: getOrElse(auth, 'user.username'),
+    ...defaultFilters, username: getPath<string>(auth, 'user.username'),
   });
   const [ filters, setFilters ] = useState<TaskFilters>(initFilters);
 

--- a/webui/react/src/pages/Dashboard.tsx
+++ b/webui/react/src/pages/Dashboard.tsx
@@ -20,6 +20,7 @@ import {
   ALL_VALUE, Command, CommandType, RecentTask, ResourceType,
   TaskFilters, TaskType,
 } from 'types';
+import { getOrElse } from 'utils/data';
 import { filterTasks } from 'utils/task';
 import { activeCommandStates, commandToTask, experimentToTask } from 'utils/types';
 
@@ -50,8 +51,9 @@ const Dashboard: React.FC = () => {
   const tensorboards = Tensorboards.useStateContext();
 
   const storage = useStorage('dashboard/tasks');
-  const initFilters = storage.getWithDefault('filters',
-    { ...defaultFilters, username: (auth.user || {}).username });
+  const initFilters = storage.getWithDefault('filters', {
+    ...defaultFilters, username: getOrElse(auth, 'user.username'),
+  });
   const [ filters, setFilters ] = useState<TaskFilters>(initFilters);
 
   /* Overview */

--- a/webui/react/src/pages/SignIn.tsx
+++ b/webui/react/src/pages/SignIn.tsx
@@ -12,7 +12,7 @@ import useAuthCheck from 'hooks/useAuthCheck';
 import usePolling from 'hooks/usePolling';
 import { routeAll } from 'routes';
 import { defaultAppRoute } from 'routes';
-import { getOrElse } from 'utils/data';
+import { getPath } from 'utils/data';
 import { locationToPath } from 'utils/routes';
 
 import css from './SignIn.module.scss';
@@ -51,7 +51,7 @@ const SignIn: React.FC = () => {
       if (queries.cli) notification.open({ description: <AuthToken />, duration: 0, message: '' });
 
       // Reroute the authenticated user to the app.
-      const loginRedirect = getOrElse(location, 'state.loginRedirect');
+      const loginRedirect = getPath<Location>(location, 'state.loginRedirect');
       const redirect = queries.redirect || locationToPath(loginRedirect);
       routeAll(redirect || defaultAppRoute.path);
     } else if (auth.checked) {

--- a/webui/react/src/pages/SignIn.tsx
+++ b/webui/react/src/pages/SignIn.tsx
@@ -12,6 +12,7 @@ import useAuthCheck from 'hooks/useAuthCheck';
 import usePolling from 'hooks/usePolling';
 import { routeAll } from 'routes';
 import { defaultAppRoute } from 'routes';
+import { getOrElse } from 'utils/data';
 import { locationToPath } from 'utils/routes';
 
 import css from './SignIn.module.scss';
@@ -50,7 +51,8 @@ const SignIn: React.FC = () => {
       if (queries.cli) notification.open({ description: <AuthToken />, duration: 0, message: '' });
 
       // Reroute the authenticated user to the app.
-      const redirect = queries.redirect || locationToPath((location.state || {}).loginRedirect);
+      const loginRedirect = getOrElse(location, 'state.loginRedirect');
+      const redirect = queries.redirect || locationToPath(loginRedirect);
       routeAll(redirect || defaultAppRoute.path);
     } else if (auth.checked) {
       setUI({ type: UI.ActionType.HideSpinner });
@@ -58,7 +60,7 @@ const SignIn: React.FC = () => {
   }, [
     auth.checked,
     auth.isAuthenticated,
-    location.state,
+    location,
     queries,
     setUI,
     ui,

--- a/webui/react/src/pages/TaskList.tsx
+++ b/webui/react/src/pages/TaskList.tsx
@@ -14,7 +14,7 @@ import Users from 'contexts/Users';
 import useStorage from 'hooks/useStorage';
 import { killCommand } from 'services/api';
 import { ALL_VALUE, CommandTask, CommandType, TaskFilters } from 'types';
-import { getOrElse } from 'utils/data';
+import { getPath } from 'utils/data';
 import { canBeOpened, filterTasks } from 'utils/task';
 import { commandToTask, isTaskKillable } from 'utils/types';
 
@@ -42,7 +42,7 @@ const TaskList: React.FC = () => {
   const tensorboards = Tensorboards.useStateContext();
   const storage = useStorage('task-list');
   const initFilters = storage.getWithDefault('filters', {
-    ...defaultFilters, username: getOrElse(auth, 'user.username'),
+    ...defaultFilters, username: getPath<string>(auth, 'user.username'),
   });
   const [ filters, setFilters ] = useState<TaskFilters<CommandType>>(initFilters);
   const [ search, setSearch ] = useState('');

--- a/webui/react/src/pages/TaskList.tsx
+++ b/webui/react/src/pages/TaskList.tsx
@@ -14,6 +14,7 @@ import Users from 'contexts/Users';
 import useStorage from 'hooks/useStorage';
 import { killCommand } from 'services/api';
 import { ALL_VALUE, CommandTask, CommandType, TaskFilters } from 'types';
+import { getOrElse } from 'utils/data';
 import { canBeOpened, filterTasks } from 'utils/task';
 import { commandToTask, isTaskKillable } from 'utils/types';
 
@@ -40,8 +41,9 @@ const TaskList: React.FC = () => {
   const shells = Shells.useStateContext();
   const tensorboards = Tensorboards.useStateContext();
   const storage = useStorage('task-list');
-  const initFilters = storage.getWithDefault('filters',
-    { ...defaultFilters, username: (auth.user || {}).username });
+  const initFilters = storage.getWithDefault('filters', {
+    ...defaultFilters, username: getOrElse(auth, 'user.username'),
+  });
   const [ filters, setFilters ] = useState<TaskFilters<CommandType>>(initFilters);
   const [ search, setSearch ] = useState('');
   const [ selectedRowKeys, setSelectedRowKeys ] = useState<string[]>([]);

--- a/webui/react/src/utils/data.test.ts
+++ b/webui/react/src/utils/data.test.ts
@@ -1,5 +1,6 @@
 import {
   clone,
+  getOrElse,
   isAsyncFunction,
   isFunction,
   isMap,
@@ -70,10 +71,9 @@ const tests = [
   { type: [ Type.Set, Type.Object ], value: new Set([ 'abc', 'def', 'ghi' ]) },
   { type: [ Type.Set, Type.Object ], value: new Set([ -1.5, Number.MAX_VALUE, null, undefined ]) },
 ];
+const object = { a: true, b: null, c: { x: { y: -1.2e10 }, z: undefined } };
 
 describe('data utility', () => {
-  const object = { a: true, b: null, c: { x: { y: -1.2e10 }, z: undefined } };
-
   describe('clone', () => {
     it('should preserve primitives', () => {
       expect(clone(-1.23e-8)).toBe(-1.23e-8);
@@ -109,6 +109,21 @@ describe('data utility', () => {
       expect(deepClone).not.toBe(object);
       expect(deepClone.c).not.toBe(object.c);
       expect(deepClone.c.x).not.toBe(object.c.x);
+    });
+  });
+
+  describe('get', () => {
+    it('should get-or-else objects', () => {
+      expect(getOrElse(object, 'a', false)).toBe(true);
+      expect(getOrElse(object, 'b', 'junk')).toBeNull();
+      expect(getOrElse(object, 'c.x.y', 0)).toBe(-1.2e10);
+    });
+
+    it('should get-or-else fallbacks', () => {
+      const fallback = 'fallback';
+      expect(getOrElse(object, 'a.b.c', fallback)).toBe(fallback);
+      expect(getOrElse(object, 'c.x.w', fallback)).toBe(fallback);
+      expect(getOrElse(object, 'c.x.z', undefined)).toBeUndefined();
     });
   });
 

--- a/webui/react/src/utils/data.test.ts
+++ b/webui/react/src/utils/data.test.ts
@@ -1,6 +1,7 @@
 import {
   clone,
-  getOrElse,
+  getPath,
+  getPathOrElse,
   isAsyncFunction,
   isFunction,
   isMap,
@@ -112,18 +113,26 @@ describe('data utility', () => {
     });
   });
 
-  describe('get', () => {
+  describe('getPath', () => {
+    it('should get object value based on paths', () => {
+      expect(getPath<boolean>(object, 'a')).toBe(true);
+      expect(getPath<string>(object, 'x.x')).toBeUndefined();
+      expect(getPath<number>(object, 'c.x.y')).toBe(-1.2e10);
+    });
+  });
+
+  describe('getPathOrElse', () => {
     it('should get-or-else objects', () => {
-      expect(getOrElse(object, 'a', false)).toBe(true);
-      expect(getOrElse(object, 'b', 'junk')).toBeNull();
-      expect(getOrElse(object, 'c.x.y', 0)).toBe(-1.2e10);
+      expect(getPathOrElse<boolean>(object, 'a', false)).toBe(true);
+      expect(getPathOrElse<string>(object, 'b', 'junk')).toBeNull();
+      expect(getPathOrElse<number>(object, 'c.x.y', 0)).toBe(-1.2e10);
     });
 
     it('should get-or-else fallbacks', () => {
       const fallback = 'fallback';
-      expect(getOrElse(object, 'a.b.c', fallback)).toBe(fallback);
-      expect(getOrElse(object, 'c.x.w', fallback)).toBe(fallback);
-      expect(getOrElse(object, 'c.x.z', undefined)).toBeUndefined();
+      expect(getPathOrElse<string>(object, 'a.b.c', fallback)).toBe(fallback);
+      expect(getPathOrElse<string>(object, 'c.x.w', fallback)).toBe(fallback);
+      expect(getPathOrElse<string | undefined>(object, 'c.x.z', undefined)).toBeUndefined();
     });
   });
 

--- a/webui/react/src/utils/data.ts
+++ b/webui/react/src/utils/data.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { CommandState, RunState, State } from 'types';
 
 export const isMap = <T>(data: T): boolean => data instanceof Map;
@@ -19,12 +20,23 @@ export const isSyncFunction = (fn: unknown): boolean => {
   return isFunction(fn) && !isAsyncFunction(fn);
 };
 
-/* eslint-disable-next-line @typescript-eslint/no-explicit-any */
 export const clone = (data: any, deep = true): any => {
   if (isPrimitive(data)) return data;
   if (isMap(data)) return new Map(data);
   if (isSet(data)) return new Set(data);
   return deep ? JSON.parse(JSON.stringify(data)) : { ...data };
+};
+
+export const getOrElse = <T = any>(
+  obj: Record<string, any>,
+  path: string,
+  fallback?: T,
+): T | undefined => {
+  if (!obj) return fallback;
+
+  // Reassigns to obj[key] on each array.every iteration
+  let value = obj;
+  return path.split('.').every(key => ((value = value[key]) !== undefined)) ? value as T : fallback;
 };
 
 export const categorize = <T>(array: T[], keyFn: ((arg0: T) => string)): Record<string, T[]> => {

--- a/webui/react/src/utils/data.ts
+++ b/webui/react/src/utils/data.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import { CommandState, RunState, State } from 'types';
 
 export const isMap = <T>(data: T): boolean => data instanceof Map;
@@ -20,6 +19,7 @@ export const isSyncFunction = (fn: unknown): boolean => {
   return isFunction(fn) && !isAsyncFunction(fn);
 };
 
+/* eslint-disable-next-line @typescript-eslint/no-explicit-any */
 export const clone = (data: any, deep = true): any => {
   if (isPrimitive(data)) return data;
   if (isMap(data)) return new Map(data);
@@ -27,16 +27,21 @@ export const clone = (data: any, deep = true): any => {
   return deep ? JSON.parse(JSON.stringify(data)) : { ...data };
 };
 
-export const getOrElse = <T = any>(
-  obj: Record<string, any>,
-  path: string,
-  fallback?: T,
-): T | undefined => {
-  if (!obj) return fallback;
-
+/* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+export const getPath = <T>(obj: Record<string, any>, path: string): T | undefined => {
   // Reassigns to obj[key] on each array.every iteration
-  let value = obj;
-  return path.split('.').every(key => ((value = value[key]) !== undefined)) ? value as T : fallback;
+  let value = obj || {};
+  return path.split('.').every(key => ((value = value[key]) !== undefined)) ?
+    value as T : undefined;
+};
+
+export const getPathOrElse = <T>(
+  obj: Record<string, unknown>,
+  path: string,
+  fallback: T,
+): T => {
+  const value = getPath<T>(obj, path);
+  return value !== undefined ? value : fallback;
 };
 
 export const categorize = <T>(array: T[], keyFn: ((arg0: T) => string)): Record<string, T[]> => {


### PR DESCRIPTION
## Description

It's common to access a deeply nested property in an object but with multiple levels of optional properties. For example, one might need to access `window.obj.key1.key2` but both `key1` and `key2` are optional properties. `getOrElse` allows us to attempt to fetch the object property by full path with the option to specify a fallback value if nothing matches.

## Test Plan



## Commentary (optional)


<!-- User-facing API changes need the "User-facing API Change" label -->

<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

## Description

Lead with the intended commit body in this description field. For breaking changes, please include "BREAKING CHANGE:" at the beginning of your commit body. At minimum, this section should include a bracketed reference to the Jira ticket, e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.

## Test Plan

Describe the situations in which you've tested your change, and/or a screenshot as appropriate. Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.

## Commentary (optional)

Use this section of your description to add context to the PR. Could be for particularly tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc. You may intentionally leave this section blank and remove the title.
--->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234