### PR TITLE
feat: add allgather_metrics to EstimatorContext

### DIFF
--- a/harness/determined/constants.py
+++ b/harness/determined/constants.py
@@ -44,7 +44,8 @@ HOROVOD_GLOO_RENDEZVOUS_PORT = 12355
 
 # Port for communicating between training processes. Used for reducing
 # validation metrics.
-INTER_TRAIN_PROCESS_COMM_PORT = 12360
+INTER_TRAIN_PROCESS_COMM_PORT_1 = 12360
+INTER_TRAIN_PROCESS_COMM_PORT_2 = 12361
 
 # Default trial runner interface. For distributed training this
 # specifies that the network interface must be auto-detected.

--- a/harness/determined/estimator/_estimator_context.py
+++ b/harness/determined/estimator/_estimator_context.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any, Callable, Dict, Union
+from typing import Any, Callable, Dict, List, Optional, Union
 
 import tensorflow as tf
 
@@ -133,3 +133,12 @@ class EstimatorExperimentalContext(_data_layer.DataLayerContext):
 
     def __init__(self, env: det.EnvContext, hvd_config: horovod.HorovodContext) -> None:
         super().__init__(env=env, hvd_config=hvd_config)
+        self._allgather_fn = None  # type: Optional[Callable[[Any], List]]
+
+    def _set_allgather_fn(self, fn: Callable[[Any], List]) -> None:
+        self._allgather_fn = fn
+
+    def allgather_metrics(self, metrics: Any) -> List:
+        if self._allgather_fn is None:
+            raise AssertionError("allgather_metrics must not be called before training begins")
+        return self._allgather_fn(metrics)

--- a/harness/determined/estimator/_estimator_trial.py
+++ b/harness/determined/estimator/_estimator_trial.py
@@ -641,13 +641,14 @@ class EstimatorTrialController(det.LoopTrialController):
         return {"validation_metrics": metrics}
 
     def average_metrics(self, metrics: Dict[str, Any]) -> Optional[Dict[str, Any]]:
-        # The chief receives the metric from every worker and computes
-        # the average.
         check.true(self.hvd_config.use)
         if self.is_chief:
-            self.train_process_comm_chief = cast(ipc.ZMQServer, self.train_process_comm_chief)
+            self.train_process_comm_chief = cast(
+                ipc.ZMQBroadcastServer, self.train_process_comm_chief
+            )
             logging.debug(f"Chief {hvd.rank()} beginning receiving validation metrics.")
-            worker_metrics = self.train_process_comm_chief.barrier(num_connections=hvd.size() - 1)
+            worker_metrics, _ = self.train_process_comm_chief.gather_with_polling(lambda: None)
+            self.train_process_comm_chief.broadcast(None)
             logging.debug(f"Chief {hvd.rank()} done receiving validation metrics.")
             for metric_name in metrics:
                 if isinstance(metrics[metric_name], numbers.Number):
@@ -660,9 +661,14 @@ class EstimatorTrialController(det.LoopTrialController):
                         metrics[metric_name] += worker_metric[metric_name] / hvd.size()
             return metrics
         else:
-            self.train_process_comm_worker = cast(ipc.ZMQClient, self.train_process_comm_worker)
+            self.train_process_comm_worker = cast(
+                ipc.ZMQBroadcastClient, self.train_process_comm_worker
+            )
             logging.debug(f"Worker {hvd.rank()} sending metrics.")
-            self.train_process_comm_worker.barrier(message=metrics)
+            self.train_process_comm_worker.send(metrics)
+            # Synchronize with the chief so that there is no risk of accidentally calling send()
+            # for a future gather before all workers have called send() on this gather.
+            _ = self.train_process_comm_worker.recv()
             return None
 
 

--- a/harness/determined/estimator/_estimator_trial.py
+++ b/harness/determined/estimator/_estimator_trial.py
@@ -328,10 +328,11 @@ class EstimatorTrialController(det.LoopTrialController):
         user_train_spec: tf.estimator.TrainSpec,
         val_spec: tf.estimator.EvalSpec,
         serving_input_receiver_fns: Dict[str, estimator.ServingInputReceiverFn],
+        context: estimator.EstimatorContext,
         *args: Any,
         **kwargs: Any,
     ) -> None:
-        super().__init__(*args, **kwargs)
+        super().__init__(context, *args, **kwargs)  # type: ignore
 
         self.estimator = estimator
         self.user_train_spec = user_train_spec
@@ -340,6 +341,8 @@ class EstimatorTrialController(det.LoopTrialController):
 
         # Used to send Terminate response following post-trial close callback.
         self.exit_response_func = None  # type: Optional[workload.ResponseFunc]
+
+        context.experimental._set_allgather_fn(self.allgather_metrics)
 
         self._init_model()
 
@@ -385,6 +388,7 @@ class EstimatorTrialController(det.LoopTrialController):
             estimator.EstimatorTrialContext,
             "EstimatorTrialController needs an EstimatorTrialContext",
         )
+        context = cast(estimator.EstimatorTrialContext, context)
 
         check.is_instance(
             trial_inst, EstimatorTrial, "EstimatorTrialController needs an EstimatorTrial"
@@ -670,6 +674,28 @@ class EstimatorTrialController(det.LoopTrialController):
             # for a future gather before all workers have called send() on this gather.
             _ = self.train_process_comm_worker.recv()
             return None
+
+    def allgather_metrics(self, metrics: Any) -> List:
+        if not self.hvd_config.use:
+            return [metrics]
+
+        if self.is_chief:
+            self.train_process_comm_chief = cast(
+                ipc.ZMQBroadcastServer, self.train_process_comm_chief
+            )
+            logging.debug(f"Chief {hvd.rank()} beginning allgathering metrics.")
+            worker_stuff, _ = self.train_process_comm_chief.gather_with_polling(lambda: None)
+            logging.debug(f"Chief {hvd.rank()} done allgathering metrics.")
+            all_metrics = [metrics, *worker_stuff]
+            self.train_process_comm_chief.broadcast(all_metrics)
+            return all_metrics
+        else:
+            self.train_process_comm_worker = cast(
+                ipc.ZMQBroadcastClient, self.train_process_comm_worker
+            )
+            logging.debug(f"Worker {hvd.rank()} allgathering metrics.")
+            self.train_process_comm_worker.send(metrics)
+            return self.train_process_comm_worker.recv()  # type: ignore
 
 
 class EstimatorTrial(det.Trial):

--- a/harness/determined/ipc.py
+++ b/harness/determined/ipc.py
@@ -98,7 +98,9 @@ class ZMQBroadcastServer:
     http://zguide.zeromq.org/page:all#Node-Coordination
     """
 
-    def __init__(self, num_connections: int, port_range: Optional[Tuple[int, int]] = None) -> None:
+    def __init__(
+        self, num_connections: int, pub_port: Optional[int] = None, pull_port: Optional[int] = None
+    ) -> None:
         self._num_connections = num_connections
 
         context = zmq.Context()
@@ -106,13 +108,15 @@ class ZMQBroadcastServer:
         self._pub_socket = context.socket(zmq.PUB)
         self._pull_socket = context.socket(zmq.PULL)
 
-        if port_range is None:
+        if pub_port is None:
             self._pub_port = self._pub_socket.bind_to_random_port("tcp://*")  # type: int
+        else:
+            self._pub_port = self._pub_socket.bind(f"tcp://*:{pub_port}")
+
+        if pull_port is None:
             self._pull_port = self._pull_socket.bind_to_random_port("tcp://*")  # type: int
         else:
-            port_min, port_max = port_range
-            self._pub_port = self._pub_socket.bind_to_random_port("tcp://*", port_min, port_max)
-            self._pull_port = self._pull_socket.bind_to_random_port("tcp://*", port_min, port_max)
+            self._pull_port = self._pull_socket.bind(f"tcp://*:{pull_port}")
 
         self._send_serial = 0
         self._recv_serial = 0

--- a/harness/determined/layers/_socket_manager.py
+++ b/harness/determined/layers/_socket_manager.py
@@ -1,5 +1,4 @@
 import logging
-import os
 from typing import Any, Optional
 
 import lomond
@@ -127,11 +126,6 @@ class SocketManager(workload.Source):
                 rendezvous_ports = self.env.rendezvous_ports()
                 addrs[rank] = f"0.0.0.0:{rendezvous_ports[0]}"
                 addrs2[rank] = f"0.0.0.0:{rendezvous_ports[1]}"
-
-                # TODO(ryan): remove rendezvous info as a environment variable.
-                os.environ["DET_RENDEZVOUS_INFO"] = simplejson.dumps(
-                    {"addrs": addrs, "addrs2": addrs2, "rank": rank}
-                )
 
                 return det.RendezvousInfo(addrs, addrs2, rank)
 


### PR DESCRIPTION
## Description

Add an _allgather_metrics() method to EstimatorContext.  A followup-PR will either provide a useful API for calculating custom metrics that uses _allgather_metrics() or it will rename allgather_metrics() to be part of the (experimental) public API.

Part of this change involved replacing the ZMQServer and ZMQClient which are currently used as trial_controller.train_process_comm with ZMQBroadcastServer and ZMQBroadcastClient, since the ZMQServer and ZMQClient are not capable of allgather operations.  The existing behavior should not be affected at all by this change.

## Test Plan

Manually ran python and estimator multi-machine dtrain experiments to verify the changes to those frameworks.
