### PR TITLE
test: add nightly test for pytorch flexible primitive example [DET-3534]

### DIFF
--- a/e2e_tests/tests/nightly/test_capability.py
+++ b/e2e_tests/tests/nightly/test_capability.py
@@ -79,3 +79,15 @@ def test_gbt_estimator() -> None:
     config = conf.set_max_steps(config, 2)
 
     exp.run_basic_test_with_temp_config(config, conf.experimental_path("trial/gbt_estimator"), 1)
+
+
+@pytest.mark.nightly  # type: ignore
+def test_flexible_primitives_mnist_pytorch() -> None:
+    config = conf.load_config(
+        conf.experimental_path("trial/flexible_primitives_mnist_pytorch/const.yaml")
+    )
+    config = conf.set_max_steps(config, 2)
+
+    exp.run_basic_test_with_temp_config(
+        config, conf.experimental_path("trial/flexible_primitives_mnist_pytorch"), 1
+    )

--- a/examples/experimental/trial/flexible_primitives_mnist_pytorch/const.yaml
+++ b/examples/experimental/trial/flexible_primitives_mnist_pytorch/const.yaml
@@ -12,3 +12,4 @@ searcher:
   metric: loss
   max_steps: 200
   smaller_is_better: True
+entrypoint: model_def:GANTrial

--- a/examples/experimental/trial/flexible_primitives_mnist_pytorch/distributed.yaml
+++ b/examples/experimental/trial/flexible_primitives_mnist_pytorch/distributed.yaml
@@ -12,5 +12,6 @@ searcher:
   metric: loss
   max_steps: 200
   smaller_is_better: True
+entrypoint: model_def:GANTrial
 resources:
   slots_per_trial: 8

--- a/examples/experimental/trial/flexible_primitives_mnist_pytorch/model_def.py
+++ b/examples/experimental/trial/flexible_primitives_mnist_pytorch/model_def.py
@@ -74,7 +74,7 @@ class Discriminator(nn.Module):
         return validity
 
 
-class MNistTrial(PyTorchTrial):
+class GANTrial(PyTorchTrial):
     def __init__(self, trial_context: PyTorchTrialContext) -> None:
         self.context = trial_context
         self.logger = TorchWriter()


### PR DESCRIPTION
## Description

Add nightly e2e test for pytorch flexible primitive example. Train only two steps.

## Test Plan

N/A

## Commentary (optional)

N/A

<!-- User-facing API changes need the "User-facing API Change" label -->

<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

## Description

Lead with the intended commit body in this description field. For breaking changes, please include "BREAKING CHANGE:" at the beginning of your commit body. At minimum, this section should include a bracketed reference to the Jira ticket, e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.

## Test Plan

Describe the situations in which you've tested your change, and/or a screenshot as appropriate. Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.

## Commentary (optional)

Use this section of your description to add context to the PR. Could be for particularly tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc. You may intentionally leave this section blank and remove the title.
--->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234