### PR TITLE
feat: remove steps from pytorch callbacks [DET-3252]

### DIFF
--- a/docs/reference/api/pytorch.txt
+++ b/docs/reference/api/pytorch.txt
@@ -116,7 +116,7 @@ class with ``PyTorchTrial``, implement the following callback:
                 context.get_optimizer(), "min", verbose=True
             )  # customize arguments as desired here
 
-        def on_validation_step_end(self, metrics):
+        def on_validation_end(self, metrics):
             self.reduce_lr.step(metrics["validation_error"])
 
         def state_dict(self):

--- a/harness/determined/pytorch/_callback.py
+++ b/harness/determined/pytorch/_callback.py
@@ -31,14 +31,6 @@ class PyTorchCallback:
     def on_batch_end(self, batch_idx: int, metrics: Dict[str, Any]) -> None:
         """
         Run after every batch is trained.
-
-        .. warning::
-            If distributed training is enabled, every GPU will execute a copy of
-            this callback at the end of every training step. If
-            ``optimizations.average_training_metrics`` is enabled, then the
-            ``metrics`` will be averaged across all GPUs before the callback is
-            executed.  If ``optimizations.average_training_metrics`` is
-            disabled, then the ``metrics`` will be local to the GPU.
         """
         pass
 
@@ -51,14 +43,6 @@ class PyTorchCallback:
     def on_epoch_end(self, epoch_idx: int, metrics: Dict[str, Any]) -> None:
         """
         Run after every epoch ends.
-
-        .. warning::
-            If distributed training is enabled, every GPU will execute a copy of
-            this callback at the end of every training step. If
-            ``optimizations.average_training_metrics`` is enabled, then the
-            ``metrics`` will be averaged across all GPUs before the callback is
-            executed.  If ``optimizations.average_training_metrics`` is
-            disabled, then the ``metrics`` will be local to the GPU.
         """
         pass
 

--- a/harness/determined/pytorch/_callback.py
+++ b/harness/determined/pytorch/_callback.py
@@ -49,6 +49,7 @@ class PyTorchCallback:
         """
         Run before every validation step begins.
         """
+        # TODO(DET-3555): remove this once it has been deprecated long enough.
         pass
 
     def on_validation_step_end(self, metrics: Dict[str, Any]) -> None:
@@ -58,6 +59,7 @@ class PyTorchCallback:
         .. warning::
             This callback only executes on the chief GPU when doing distributed training.
         """
+        # TODO(DET-3555): remove this once it has been deprecated long enough.
         pass
 
     def on_checkpoint_end(self, checkpoint_dir: str) -> None:

--- a/harness/determined/pytorch/_callback.py
+++ b/harness/determined/pytorch/_callback.py
@@ -34,7 +34,7 @@ class PyTorchCallback:
 
         .. warning::
             If distributed training is enabled, every GPU will execute a copy of this callback at
-            the end of every training step and the ``metrics``will be local to the GPU.
+            the end of every training step and the ``metrics`` will be local to the GPU.
         """
         pass
 
@@ -51,7 +51,7 @@ class PyTorchCallback:
 
         .. warning::
             If distributed training is enabled, every GPU will execute a copy of this callback at
-            the end of every training step and the ``metrics``will be local to the GPU.
+            the end of every training step and the ``metrics`` will be local to the GPU.
         """
         pass
 

--- a/harness/determined/pytorch/_callback.py
+++ b/harness/determined/pytorch/_callback.py
@@ -16,44 +16,10 @@ class PyTorchCallback:
 
     .. warning::
         If distributed training is enabled, every GPU will execute a copy of this callback
-        (except for :meth:`on_validation_end` and :meth:`on_checkpoint_end`).  To
-        configure a callback implementation to execute on a subset of GPUs, please condition
-        your implementation on ``trial.context.distributed.get_rank()``.
+        (except for :meth:`on_validation_end`, :meth:`on_validation_step_end` and
+        :meth:`on_checkpoint_end`). To configure a callback implementation to execute on a subset of
+        GPUs, please condition your implementation on ``trial.context.distributed.get_rank()``.
     """
-
-    def on_train_batch_start(self, batch_idx: int) -> None:
-        """
-        Run before every batch begins training.
-        """
-        pass
-
-    def on_train_batch_end(self, batch_idx: int, metrics: Dict[str, Any]) -> None:
-        """
-        Run after every batch finishes training. ``metrics`` are the metrics returned from calling
-        ``PyTorchTrail.train_batch`` on batch ``batch_idx``.
-
-        .. warning::
-            If distributed training is enabled, every GPU will execute a copy of this callback at
-            the end of every training step and the ``metrics`` will be local to the GPU.
-        """
-        pass
-
-    def on_train_epoch_start(self, epoch_idx: int) -> None:
-        """
-        Run before every epoch begins.
-        """
-        pass
-
-    def on_train_epoch_end(self, epoch_idx: int, metrics: Dict[str, Any]) -> None:
-        """
-        Run after every epoch finishes training. ``metrics`` are the metrics returned from calling
-        ``PyTorchTrail.train_batch`` on the last batch of epoch ``epoch_idx``.
-
-        .. warning::
-            If distributed training is enabled, every GPU will execute a copy of this callback at
-            the end of every training step and the ``metrics`` will be local to the GPU.
-        """
-        pass
 
     def on_before_optimizer_step(self, parameters: Iterator) -> None:
         """
@@ -73,6 +39,21 @@ class PyTorchCallback:
     def on_validation_end(self, metrics: Dict[str, Any]) -> None:
         """
         Run after every validation ends.
+
+        .. warning::
+            This callback only executes on the chief GPU when doing distributed training.
+        """
+        pass
+
+    def on_validation_step_start(self) -> None:
+        """
+        Run before every validation step begins.
+        """
+        pass
+
+    def on_validation_step_end(self, metrics: Dict[str, Any]) -> None:
+        """
+        Run after every validation step ends.
 
         .. warning::
             This callback only executes on the chief GPU when doing distributed training.

--- a/harness/determined/pytorch/_callback.py
+++ b/harness/determined/pytorch/_callback.py
@@ -21,13 +21,13 @@ class PyTorchCallback:
         your implementation on ``trial.context.distributed.get_rank()``.
     """
 
-    def on_batch_start(self, batch_idx: int) -> None:
+    def on_train_batch_start(self, batch_idx: int) -> None:
         """
         Run before every batch begins training.
         """
         pass
 
-    def on_batch_end(self, batch_idx: int, metrics: Dict[str, Any]) -> None:
+    def on_train_batch_end(self, batch_idx: int, metrics: Dict[str, Any]) -> None:
         """
         Run after every batch finishes training. ``metrics`` are the metrics returned from calling
         ``PyTorchTrail.train_batch`` on batch ``batch_idx``.
@@ -38,7 +38,7 @@ class PyTorchCallback:
         """
         pass
 
-    def on_epoch_start(self, epoch_idx: int) -> None:
+    def on_train_epoch_start(self, epoch_idx: int) -> None:
         """
         Run before every epoch begins.
         """

--- a/harness/determined/pytorch/_callback.py
+++ b/harness/determined/pytorch/_callback.py
@@ -24,7 +24,6 @@ class PyTorchCallback:
     def on_batch_start(self, batch_idx: int) -> None:
         """
         Run before every batch is trained.
-
         """
         pass
 

--- a/harness/determined/pytorch/_callback.py
+++ b/harness/determined/pytorch/_callback.py
@@ -23,13 +23,13 @@ class PyTorchCallback:
 
     def on_batch_start(self, batch_idx: int) -> None:
         """
-        Run before every batch is trained.
+        Run before every batch begins training.
         """
         pass
 
     def on_batch_end(self, batch_idx: int, metrics: Dict[str, Any]) -> None:
         """
-        Run after every batch is trained.
+        Run after every batch finishes training.
         """
         pass
 
@@ -39,9 +39,9 @@ class PyTorchCallback:
         """
         pass
 
-    def on_epoch_end(self, epoch_idx: int, metrics: Dict[str, Any]) -> None:
+    def on_train_epoch_end(self, epoch_idx: int, metrics: Dict[str, Any]) -> None:
         """
-        Run after every epoch ends.
+        Run after every epoch finishes training.
         """
         pass
 

--- a/harness/determined/pytorch/_callback.py
+++ b/harness/determined/pytorch/_callback.py
@@ -16,20 +16,41 @@ class PyTorchCallback:
 
     .. warning::
         If distributed training is enabled, every GPU will execute a copy of this callback
-        (except for :meth:`on_validation_step_end` and :meth:`on_checkpoint_end`).  To
+        (except for :meth:`on_validation_end` and :meth:`on_checkpoint_end`).  To
         configure a callback implementation to execute on a subset of GPUs, please condition
         your implementation on ``trial.context.distributed.get_rank()``.
     """
 
-    def on_train_step_start(self, step_id: int) -> None:
+    def on_batch_start(self, batch_idx: int) -> None:
         """
-        Run before every training step begins.
+        Run before every batch is trained.
+
         """
         pass
 
-    def on_train_step_end(self, step_id: int, metrics: Dict[str, Any]) -> None:
+    def on_batch_end(self, batch_idx: int, metrics: Dict[str, Any]) -> None:
         """
-        Run after every training step ends.
+        Run after every batch is trained.
+
+        .. warning::
+            If distributed training is enabled, every GPU will execute a copy of
+            this callback at the end of every training step. If
+            ``optimizations.average_training_metrics`` is enabled, then the
+            ``metrics`` will be averaged across all GPUs before the callback is
+            executed.  If ``optimizations.average_training_metrics`` is
+            disabled, then the ``metrics`` will be local to the GPU.
+        """
+        pass
+
+    def on_epoch_start(self, epoch_idx: int) -> None:
+        """
+        Run before every epoch begins.
+        """
+        pass
+
+    def on_epoch_end(self, epoch_idx: int, metrics: Dict[str, Any]) -> None:
+        """
+        Run after every epoch ends.
 
         .. warning::
             If distributed training is enabled, every GPU will execute a copy of
@@ -50,15 +71,15 @@ class PyTorchCallback:
         # TODO(DET-3267): deprecate this when releasing pytorch flexible primitives.
         pass
 
-    def on_validation_step_start(self) -> None:
+    def on_validation_start(self) -> None:
         """
-        Run before every validation step begins.
+        Run before every validation begins.
         """
         pass
 
-    def on_validation_step_end(self, metrics: Dict[str, Any]) -> None:
+    def on_validation_end(self, metrics: Dict[str, Any]) -> None:
         """
-        Run after every validation step ends.
+        Run after every validation ends.
 
         .. warning::
             This callback only executes on the chief GPU when doing distributed training.

--- a/harness/determined/pytorch/_callback.py
+++ b/harness/determined/pytorch/_callback.py
@@ -29,7 +29,12 @@ class PyTorchCallback:
 
     def on_batch_end(self, batch_idx: int, metrics: Dict[str, Any]) -> None:
         """
-        Run after every batch finishes training.
+        Run after every batch finishes training. ``metrics`` are the metrics returned from calling
+        ``PyTorchTrail.train_batch`` on batch ``batch_idx``.
+
+        .. warning::
+            If distributed training is enabled, every GPU will execute a copy of this callback at
+            the end of every training step and the ``metrics``will be local to the GPU.
         """
         pass
 
@@ -41,7 +46,12 @@ class PyTorchCallback:
 
     def on_train_epoch_end(self, epoch_idx: int, metrics: Dict[str, Any]) -> None:
         """
-        Run after every epoch finishes training.
+        Run after every epoch finishes training. ``metrics`` are the metrics returned from calling
+        ``PyTorchTrail.train_batch`` on the last batch of epoch ``epoch_idx``.
+
+        .. warning::
+            If distributed training is enabled, every GPU will execute a copy of this callback at
+            the end of every training step and the ``metrics``will be local to the GPU.
         """
         pass
 

--- a/harness/determined/pytorch/_pytorch_context.py
+++ b/harness/determined/pytorch/_pytorch_context.py
@@ -460,15 +460,27 @@ class PyTorchTrialContext(det.TrialContext):
             optimizer.zero_grad()
 
     def is_epoch_start(self) -> bool:
+        """
+        Returns true if the current batch is the first batch of the epoch.
+
+        .. warning::
+            Not accurate for variable size epochs.
+        """
         if self._current_batch_idx is None:
             raise det.errors.InternalException("Training hasn't started.")
-        if self._current_epoch_len is None:
+        if self._epoch_len is None:
             raise det.errors.InternalException("Training DataLoader uninitialized.")
         return self._current_batch_idx % self._epoch_len == 0
 
     def is_epoch_end(self) -> bool:
+        """
+        Returns true if the current batch is the last batch of the epoch.
+
+        .. warning::
+            Not accurate for variable size epochs.
+        """
         if self._current_batch_idx is None:
             raise det.errors.InternalException("Training hasn't started.")
-        if self._current_epoch_len is None:
+        if self._epoch_len is None:
             raise det.errors.InternalException("Training DataLoader uninitialized.")
         return self._current_batch_idx % self._epoch_len == self._epoch_len - 1

--- a/harness/determined/pytorch/_pytorch_trial.py
+++ b/harness/determined/pytorch/_pytorch_trial.py
@@ -308,12 +308,12 @@ class PyTorchTrialController(det.LoopTrialController):
         num_inputs = 0
 
         for batch_idx in range(start, end):
-            for callback in self.callbacks.values():
-                callback.on_batch_start(batch_idx)
-
             if self.is_epoch_start(batch_idx):
                 for callback in self.callbacks.values():
                     callback.on_epoch_start(self.get_epoch_idx(batch_idx))
+
+            for callback in self.callbacks.values():
+                callback.on_batch_start(batch_idx)
 
             batch = next(self.training_iterator)
             num_inputs += data_length(batch)
@@ -357,7 +357,7 @@ class PyTorchTrialController(det.LoopTrialController):
 
             if self.is_epoch_end(batch_idx):
                 for callback in self.callbacks.values():
-                    callback.on_epoch_end(self.get_epoch_idx(batch_idx), tr_metrics)
+                    callback.on_train_epoch_end(self.get_epoch_idx(batch_idx), tr_metrics)
 
         # Aggregate and reduce training metrics from all the training processes.
         if self.hvd_config.use and self.hvd_config.average_training_metrics:

--- a/harness/determined/pytorch/_pytorch_trial.py
+++ b/harness/determined/pytorch/_pytorch_trial.py
@@ -229,6 +229,12 @@ class PyTorchTrialController(det.LoopTrialController):
     def get_epoch_idx(self, batch_id: int) -> int:
         return batch_id // len(self.training_loader)
 
+    def is_epoch_start(self, batch_id: int) -> bool:
+        return batch_id % len(self.training_loader) == 0
+
+    def is_epoch_end(self, batch_id: int) -> bool:
+        return batch_id % len(self.training_loader) == len(self.training_loader) - 1
+
     def _average_training_metrics(
         self, per_batch_metrics: List[Dict[str, Any]]
     ) -> List[Dict[str, Any]]:
@@ -295,9 +301,6 @@ class PyTorchTrialController(det.LoopTrialController):
         for model in self.context.models:
             model.train()
 
-        for callback in self.callbacks.values():
-            callback.on_train_step_start(step_id)
-
         start = total_batches_processed
         end = start + num_batches
 
@@ -305,6 +308,13 @@ class PyTorchTrialController(det.LoopTrialController):
         num_inputs = 0
 
         for batch_idx in range(start, end):
+            for callback in self.callbacks.values():
+                callback.on_batch_start(batch_idx)
+
+            if self.is_epoch_start(batch_idx):
+                for callback in self.callbacks.values():
+                    callback.on_epoch_start(self.get_epoch_idx(batch_idx))
+
             batch = next(self.training_iterator)
             num_inputs += data_length(batch)
             batch = self.context._to_device(batch)
@@ -342,15 +352,19 @@ class PyTorchTrialController(det.LoopTrialController):
             check.is_in("loss", tr_metrics, 'Please include "loss" in your training metrics.')
             per_batch_metrics.append(tr_metrics)
 
+            for callback in self.callbacks.values():
+                callback.on_batch_end(batch_idx, tr_metrics)
+
+            if self.is_epoch_end(batch_idx):
+                for callback in self.callbacks.values():
+                    callback.on_epoch_end(self.get_epoch_idx(batch_idx), tr_metrics)
+
         # Aggregate and reduce training metrics from all the training processes.
         if self.hvd_config.use and self.hvd_config.average_training_metrics:
             per_batch_metrics = self._average_training_metrics(per_batch_metrics)
         if self.hvd_config.use:
             num_inputs *= hvd.size()
         metrics = det.util.make_metrics(num_inputs, per_batch_metrics)
-
-        for callback in self.callbacks.values():
-            callback.on_train_step_end(step_id, metrics)
 
         if not self.is_chief:
             # The training metrics are reported only in the chief process.
@@ -375,7 +389,7 @@ class PyTorchTrialController(det.LoopTrialController):
             model.eval()
 
         for callback in self.callbacks.values():
-            callback.on_validation_step_start()
+            callback.on_validation_start()
 
         num_inputs = 0
         metrics = {}  # type: Optional[Dict[str, Any]]
@@ -436,7 +450,7 @@ class PyTorchTrialController(det.LoopTrialController):
 
         if self.hvd_config.use and any(
             map(
-                lambda c: util.is_overridden(c.on_validation_step_end, _callback.PyTorchCallback),
+                lambda c: util.is_overridden(c.on_validation_end, _callback.PyTorchCallback),
                 self.callbacks.values(),
             )
         ):
@@ -447,7 +461,7 @@ class PyTorchTrialController(det.LoopTrialController):
             metrics = hvd.broadcast_object(metrics, root_rank=0)
 
         for callback in self.callbacks.values():
-            callback.on_validation_step_end(cast(Dict[str, Any], metrics))
+            callback.on_validation_end(cast(Dict[str, Any], metrics))
 
         if not self.is_chief:
             return workload.Skipped()

--- a/harness/determined/pytorch/_pytorch_trial.py
+++ b/harness/determined/pytorch/_pytorch_trial.py
@@ -189,6 +189,7 @@ class PyTorchTrialController(det.LoopTrialController):
         self.training_loader = self.trial.build_training_data_loader().get_data_loader(
             repeat=True, skip=skip_batches, num_replicas=nreplicas, rank=rank
         )
+        self.context._epoch_len = len(self.training_loader)
 
         validation_dataset = self.trial.build_validation_data_loader()
         if self._evaluate_batch_defined():

--- a/harness/determined/pytorch/_pytorch_trial.py
+++ b/harness/determined/pytorch/_pytorch_trial.py
@@ -370,7 +370,7 @@ class PyTorchTrialController(det.LoopTrialController):
 
         for callback in self.callbacks.values():
             logging.warning(
-                "on_validation_step_start is now deprecated, please use on_validation_start instead."
+                "on_validation_step_start is now deprecated, please use on_validation_start instead"
             )
             callback.on_validation_step_start()
 
@@ -449,7 +449,7 @@ class PyTorchTrialController(det.LoopTrialController):
 
         for callback in self.callbacks.values():
             logging.warning(
-                "on_validation_step_end is now deprecated, please use on_validation_end instead."
+                "on_validation_step_end is now deprecated, please use on_validation_end instead"
             )
             callback.on_validation_step_end(cast(Dict[str, Any], metrics))
 

--- a/harness/determined/pytorch/_pytorch_trial.py
+++ b/harness/determined/pytorch/_pytorch_trial.py
@@ -369,6 +369,12 @@ class PyTorchTrialController(det.LoopTrialController):
             model.eval()
 
         for callback in self.callbacks.values():
+            logging.warning(
+                "on_validation_step_start is now deprecated, please use on_validation_start instead."
+            )
+            callback.on_validation_step_start()
+
+        for callback in self.callbacks.values():
             callback.on_validation_start()
 
         num_inputs = 0

--- a/harness/determined/pytorch/_pytorch_trial.py
+++ b/harness/determined/pytorch/_pytorch_trial.py
@@ -310,10 +310,10 @@ class PyTorchTrialController(det.LoopTrialController):
         for batch_idx in range(start, end):
             if self.is_epoch_start(batch_idx):
                 for callback in self.callbacks.values():
-                    callback.on_epoch_start(self.get_epoch_idx(batch_idx))
+                    callback.on_train_epoch_start(self.get_epoch_idx(batch_idx))
 
             for callback in self.callbacks.values():
-                callback.on_batch_start(batch_idx)
+                callback.on_train_batch_start(batch_idx)
 
             batch = next(self.training_iterator)
             num_inputs += data_length(batch)
@@ -353,7 +353,7 @@ class PyTorchTrialController(det.LoopTrialController):
             per_batch_metrics.append(tr_metrics)
 
             for callback in self.callbacks.values():
-                callback.on_batch_end(batch_idx, tr_metrics)
+                callback.on_train_batch_end(batch_idx, tr_metrics)
 
             if self.is_epoch_end(batch_idx):
                 for callback in self.callbacks.values():

--- a/harness/tests/experiment/fixtures/pytorch_xor_model.py
+++ b/harness/tests/experiment/fixtures/pytorch_xor_model.py
@@ -303,25 +303,9 @@ class XORTrialPerMetricReducers(XORTrialWithMultiValidation):
 
 class Counter(det.pytorch.PyTorchCallback):
     def __init__(self) -> None:
-        self.batches_started = 0
-        self.batches_ended = 0
-        self.epochs_started = 0
-        self.epochs_ended = 0
         self.validation_steps_started = 0
         self.validation_steps_ended = 0
         self.checkpoints_ended = 0
-
-    def on_train_batch_start(self, step_id: int) -> None:
-        self.batches_started += 1
-
-    def on_train_batch_end(self, step_id: int, metrics: Dict[str, Any]) -> None:
-        self.batches_ended += 1
-
-    def on_train_epoch_start(self, step_id: int) -> None:
-        self.epochs_started += 1
-
-    def on_train_epoch_end(self, step_id: int, metrics: Dict[str, Any]) -> None:
-        self.epochs_ended += 1
 
     def on_validation_start(self) -> None:
         self.validation_steps_started += 1

--- a/harness/tests/experiment/fixtures/pytorch_xor_model.py
+++ b/harness/tests/experiment/fixtures/pytorch_xor_model.py
@@ -311,13 +311,13 @@ class Counter(det.pytorch.PyTorchCallback):
         self.validation_steps_ended = 0
         self.checkpoints_ended = 0
 
-    def on_batch_start(self, step_id: int) -> None:
+    def on_train_batch_start(self, step_id: int) -> None:
         self.batches_started += 1
 
-    def on_batch_end(self, step_id: int, metrics: Dict[str, Any]) -> None:
+    def on_train_batch_end(self, step_id: int, metrics: Dict[str, Any]) -> None:
         self.batches_ended += 1
 
-    def on_epoch_start(self, step_id: int) -> None:
+    def on_train_epoch_start(self, step_id: int) -> None:
         self.epochs_started += 1
 
     def on_train_epoch_end(self, step_id: int, metrics: Dict[str, Any]) -> None:

--- a/harness/tests/experiment/fixtures/pytorch_xor_model.py
+++ b/harness/tests/experiment/fixtures/pytorch_xor_model.py
@@ -320,7 +320,7 @@ class Counter(det.pytorch.PyTorchCallback):
     def on_epoch_start(self, step_id: int) -> None:
         self.epochs_started += 1
 
-    def on_epoch_end(self, step_id: int, metrics: Dict[str, Any]) -> None:
+    def on_train_epoch_end(self, step_id: int, metrics: Dict[str, Any]) -> None:
         self.epochs_ended += 1
 
     def on_validation_start(self) -> None:

--- a/harness/tests/experiment/fixtures/pytorch_xor_model.py
+++ b/harness/tests/experiment/fixtures/pytorch_xor_model.py
@@ -303,22 +303,30 @@ class XORTrialPerMetricReducers(XORTrialWithMultiValidation):
 
 class Counter(det.pytorch.PyTorchCallback):
     def __init__(self) -> None:
-        self.train_steps_started = 0
-        self.train_steps_ended = 0
+        self.batches_started = 0
+        self.batches_ended = 0
+        self.epochs_started = 0
+        self.epochs_ended = 0
         self.validation_steps_started = 0
         self.validation_steps_ended = 0
         self.checkpoints_ended = 0
 
-    def on_train_step_start(self, step_id: int) -> None:
-        self.train_steps_started += 1
+    def on_batch_start(self, step_id: int) -> None:
+        self.batches_started += 1
 
-    def on_train_step_end(self, step_id: int, metrics: Dict[str, Any]) -> None:
-        self.train_steps_ended += 1
+    def on_batch_end(self, step_id: int, metrics: Dict[str, Any]) -> None:
+        self.batches_ended += 1
 
-    def on_validation_step_start(self) -> None:
+    def on_epoch_start(self, step_id: int) -> None:
+        self.epochs_started += 1
+
+    def on_epoch_end(self, step_id: int, metrics: Dict[str, Any]) -> None:
+        self.epochs_ended += 1
+
+    def on_validation_start(self) -> None:
         self.validation_steps_started += 1
 
-    def on_validation_step_end(self, metrics: Dict[str, Any]) -> None:
+    def on_validation_end(self, metrics: Dict[str, Any]) -> None:
         self.validation_steps_ended += 1
 
     def on_checkpoint_end(self, checkpoint_dir: str):

--- a/harness/tests/experiment/pytorch/test_pytorch_trial.py
+++ b/harness/tests/experiment/pytorch/test_pytorch_trial.py
@@ -452,10 +452,6 @@ class TestPyTorchTrial:
         )
         controller._train_for_step(1, 1, 0)
         assert controller.trial.counter.__dict__ == {
-            "batches_started": 1,
-            "batches_ended": 1,
-            "epochs_started": 1,
-            "epochs_ended": 1,
             "validation_steps_started": 0,
             "validation_steps_ended": 0,
             "checkpoints_ended": 0,
@@ -463,10 +459,6 @@ class TestPyTorchTrial:
 
         controller._compute_validation_metrics()
         assert controller.trial.counter.__dict__ == {
-            "batches_started": 1,
-            "batches_ended": 1,
-            "epochs_started": 1,
-            "epochs_ended": 1,
             "validation_steps_started": 1,
             "validation_steps_ended": 1,
             "checkpoints_ended": 0,
@@ -474,10 +466,6 @@ class TestPyTorchTrial:
 
         controller._save(checkpoint_dir)
         assert controller.trial.counter.__dict__ == {
-            "batches_started": 1,
-            "batches_ended": 1,
-            "epochs_started": 1,
-            "epochs_ended": 1,
             "validation_steps_started": 1,
             "validation_steps_ended": 1,
             "checkpoints_ended": 1,
@@ -493,10 +481,6 @@ class TestPyTorchTrial:
         )
         controller._load()
         assert controller.trial.counter.__dict__ == {
-            "batches_started": 1,
-            "batches_ended": 1,
-            "epochs_started": 1,
-            "epochs_ended": 1,
             "validation_steps_started": 1,
             "validation_steps_ended": 1,
             "checkpoints_ended": 0,

--- a/harness/tests/experiment/pytorch/test_pytorch_trial.py
+++ b/harness/tests/experiment/pytorch/test_pytorch_trial.py
@@ -452,8 +452,10 @@ class TestPyTorchTrial:
         )
         controller._train_for_step(1, 1, 0)
         assert controller.trial.counter.__dict__ == {
-            "train_steps_started": 1,
-            "train_steps_ended": 1,
+            "batches_started": 1,
+            "batches_ended": 1,
+            "epochs_started": 1,
+            "epochs_ended": 1,
             "validation_steps_started": 0,
             "validation_steps_ended": 0,
             "checkpoints_ended": 0,
@@ -461,8 +463,10 @@ class TestPyTorchTrial:
 
         controller._compute_validation_metrics()
         assert controller.trial.counter.__dict__ == {
-            "train_steps_started": 1,
-            "train_steps_ended": 1,
+            "batches_started": 1,
+            "batches_ended": 1,
+            "epochs_started": 1,
+            "epochs_ended": 1,
             "validation_steps_started": 1,
             "validation_steps_ended": 1,
             "checkpoints_ended": 0,
@@ -470,8 +474,10 @@ class TestPyTorchTrial:
 
         controller._save(checkpoint_dir)
         assert controller.trial.counter.__dict__ == {
-            "train_steps_started": 1,
-            "train_steps_ended": 1,
+            "batches_started": 1,
+            "batches_ended": 1,
+            "epochs_started": 1,
+            "epochs_ended": 1,
             "validation_steps_started": 1,
             "validation_steps_ended": 1,
             "checkpoints_ended": 1,
@@ -487,8 +493,10 @@ class TestPyTorchTrial:
         )
         controller._load()
         assert controller.trial.counter.__dict__ == {
-            "train_steps_started": 1,
-            "train_steps_ended": 1,
+            "batches_started": 1,
+            "batches_ended": 1,
+            "epochs_started": 1,
+            "epochs_ended": 1,
             "validation_steps_started": 1,
             "validation_steps_ended": 1,
             "checkpoints_ended": 0,


### PR DESCRIPTION
## Description
As part of #remove-steps, we also need to remove the concept of steps from the `PytorchCallback`s API.

## Test Plan
- [x] update unit tests

## Commentary (optional)
Currently, this is looking to be the only breaking change of #remove-steps. Everything else has been done by allowing new and old interfaces to coexist and deprecating the old ones. Open to suggestions on when/how to land this, or to leave the old interfaces intact and mark them as deprecated for at least a while.

<!-- User-facing API changes need the "User-facing API Change" label -->

<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

## Description

Lead with the intended commit body in this description field. For breaking changes, please include "BREAKING CHANGE:" at the beginning of your commit body. At minimum, this section should include a bracketed reference to the Jira ticket, e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.

## Test Plan

Describe the situations in which you've tested your change, and/or a screenshot as appropriate. Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.

## Commentary (optional)

Use this section of your description to add context to the PR. Could be for particularly tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc. You may intentionally leave this section blank and remove the title.
--->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234