### PR TITLE
ci: update webui e2e tests to kill experiment instead of cancel [DET-3543]

### DIFF
--- a/webui/tests/cypress/integration/01-setup.spec.ts
+++ b/webui/tests/cypress/integration/01-setup.spec.ts
@@ -40,10 +40,10 @@ describe('setup', () => {
     cy.get(recordSelector).should('contain', 'Active');
   });
 
-  it('should cancel experiment 2', () => {
+  it('should kill experiment 2', () => {
     cy.get(recordSelector + ' td:nth-child(2)').contains('2').click();
-    cy.contains('Cancel').click();
-    cy.get('.modal button').contains(/cancel/i).click();
+    cy.contains('Kill').click();
+    cy.get('.modal button').contains(/kill/i).click();
     cy.contains('Canceled', { timeout: Cypress.config('responseTimeout') });
   });
 


### PR DESCRIPTION
## Description

webui e2e-tests are getting blocked on the experiment cancelation step due to the experiment taking a while to pull a docker image. The pulling is taking longer than the 30 second cypress time limit on the response. The solution is to use the kill step instead.

## Test Plan

Check for CI stability around webui e2e-tests. Specifically a reduction in test flakes for experiment cancelation, starting in `01-setup` test suite.

## Commentary (optional)


<!-- User-facing API changes need the "User-facing API Change" label -->

<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

## Description

Lead with the intended commit body in this description field. For breaking changes, please include "BREAKING CHANGE:" at the beginning of your commit body. At minimum, this section should include a bracketed reference to the Jira ticket, e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.

## Test Plan

Describe the situations in which you've tested your change, and/or a screenshot as appropriate. Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.

## Commentary (optional)

Use this section of your description to add context to the PR. Could be for particularly tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc. You may intentionally leave this section blank and remove the title.
--->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234