### PR TITLE
fix: use TF Tensorboard writer by default [DET-3353]

### DIFF
--- a/harness/determined/estimator/_estimator_trial.py
+++ b/harness/determined/estimator/_estimator_trial.py
@@ -636,7 +636,7 @@ class EstimatorTrialController(det.LoopTrialController):
                 logging.debug(f"Averaged validation metrics: {metrics}.")
 
         estimator._cleanup_after_validation_step(
-            self.estimator._model_dir, self.hvd_config.use, self.is_chief
+            pathlib.Path(self.estimator._model_dir), self.is_chief
         )
 
         if not self.is_chief:

--- a/harness/determined/load/_load_trial_controller.py
+++ b/harness/determined/load/_load_trial_controller.py
@@ -147,15 +147,15 @@ def prepare_tensorboard(
         env, env.experiment_config["checkpoint_storage"], container_path
     )
     try:
-        from determined.tensorboard.metric_writers import pytorch
-
-        writer: tensorboard.MetricWriter = pytorch.TorchWriter()
-
-    except ImportError:
-        print("PYTORCH WRITER NOT FOUND")
         from determined.tensorboard.metric_writers import tensorflow
 
-        writer = tensorflow.TFWriter()
+        writer: tensorboard.MetricWriter = tensorflow.TFWriter()
+
+    except ModuleNotFoundError:
+        logging.warning("Tensorflow writer not found")
+        from determined.tensorboard.metric_writers import pytorch
+
+        writer = pytorch.TorchWriter()
 
     return (
         tensorboard_mgr,


### PR DESCRIPTION
## Description
It appears that using the PyTorch TensorBoard writer lead to TF events coming out in a "strange" state. 


## Test Plan
Ran several experiments and observed that file naming changed from always having a file ending `1.0` to not having it, this file seemed to have been the cause of some of the issues. 

Going to test this out with a container that doesn't have TF.
