### PR TITLE
feat: support terminating tasks in k8 RP [DET-3418]

### DIFF
--- a/master/internal/core.go
+++ b/master/internal/core.go
@@ -287,10 +287,7 @@ func (m *Master) initializeResourceProviders(proxyRef *actor.Ref, provisionerSlo
 			actor.Addr("kubernetesRP"),
 			scheduler.NewKubernetesResourceProvider(
 				m.ClusterID,
-				m.config.Scheduler.ResourceProvider.KubernetesRPConfig.Namespace,
-				m.config.Scheduler.ResourceProvider.KubernetesRPConfig.SlotsPerNode,
-				m.config.Scheduler.ResourceProvider.KubernetesRPConfig.MasterServiceName,
-				m.config.Scheduler.ResourceProvider.KubernetesRPConfig.LeaveKubernetesResources,
+				m.config.Scheduler.ResourceProvider.KubernetesRPConfig,
 				proxyRef,
 				filepath.Join(m.config.Root, "wheels"),
 				m.config.TaskContainerDefaults,

--- a/master/internal/core.go
+++ b/master/internal/core.go
@@ -290,6 +290,7 @@ func (m *Master) initializeResourceProviders(proxyRef *actor.Ref, provisionerSlo
 				m.config.Scheduler.ResourceProvider.KubernetesRPConfig.Namespace,
 				m.config.Scheduler.ResourceProvider.KubernetesRPConfig.SlotsPerNode,
 				m.config.Scheduler.ResourceProvider.KubernetesRPConfig.MasterServiceName,
+				m.config.Scheduler.ResourceProvider.KubernetesRPConfig.LeaveKubernetesResources,
 				proxyRef,
 				filepath.Join(m.config.Root, "wheels"),
 				m.config.TaskContainerDefaults,

--- a/master/internal/kubernetes/informer.go
+++ b/master/internal/kubernetes/informer.go
@@ -1,0 +1,80 @@
+package kubernetes
+
+import (
+	"github.com/pkg/errors"
+	v1 "k8s.io/api/core/v1"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	typedV1 "k8s.io/client-go/kubernetes/typed/core/v1"
+
+	"github.com/determined-ai/determined/master/pkg/actor"
+)
+
+// messages that are sent to the informer.
+type (
+	startInformer struct{}
+)
+
+// messages that are sent by the informer.
+type (
+	podStatusUpdate struct {
+		podName    string
+		updatedPod *v1.Pod
+	}
+)
+
+type informer struct {
+	podInterface typedV1.PodInterface
+	namespace    string
+	podsHandler  *actor.Ref
+}
+
+func newInformer(
+	podInterface typedV1.PodInterface,
+	namespace string,
+	podsHandler *actor.Ref,
+) *informer {
+	return &informer{
+		podInterface: podInterface,
+		namespace:    namespace,
+		podsHandler:  podsHandler,
+	}
+}
+
+func (i *informer) Receive(ctx *actor.Context) error {
+	switch msg := ctx.Message().(type) {
+	case actor.PreStart:
+
+	case startInformer:
+		if err := i.receiveStartInformer(ctx); err != nil {
+			return err
+		}
+
+	case actor.PostStop:
+
+	default:
+		ctx.Log().Error("unexpected message %T", msg)
+		return actor.ErrUnexpectedMessage(ctx)
+	}
+
+	return nil
+}
+
+func (i *informer) receiveStartInformer(ctx *actor.Context) error {
+	watch, err := i.podInterface.Watch(metav1.ListOptions{LabelSelector: determinedLabel})
+	if err != nil {
+		return errors.Wrap(err, "error initializing pod watch")
+	}
+
+	ctx.Log().Info("pod informer is starting")
+
+	for event := range watch.ResultChan() {
+		pod := event.Object.(*v1.Pod)
+		// TODO: change this to debug level
+		ctx.Log().Infof("informer got new pod event for pod: %s %s", pod.Name, pod.Status.Phase)
+		ctx.Tell(i.podsHandler, podStatusUpdate{podName: pod.Name, updatedPod: pod})
+	}
+
+	ctx.Log().Info("pod informer has started")
+	return nil
+}

--- a/master/internal/kubernetes/informer.go
+++ b/master/internal/kubernetes/informer.go
@@ -18,7 +18,6 @@ type (
 // messages that are sent by the informer.
 type (
 	podStatusUpdate struct {
-		podName    string
 		updatedPod *k8sV1.Pod
 	}
 )
@@ -70,7 +69,7 @@ func (i *informer) startInformer(ctx *actor.Context) error {
 	for event := range watch.ResultChan() {
 		pod := event.Object.(*k8sV1.Pod)
 		ctx.Log().Debugf("informer got new pod event for pod: %s %s", pod.Name, pod.Status.Phase)
-		ctx.Tell(i.podsHandler, podStatusUpdate{podName: pod.Name, updatedPod: pod})
+		ctx.Tell(i.podsHandler, podStatusUpdate{updatedPod: pod})
 	}
 
 	ctx.Log().Warn("pod informer stopped unexpectedly")

--- a/master/internal/kubernetes/informer.go
+++ b/master/internal/kubernetes/informer.go
@@ -46,7 +46,7 @@ func (i *informer) Receive(ctx *actor.Context) error {
 	case actor.PreStart:
 
 	case startInformer:
-		if err := i.receiveStartInformer(ctx); err != nil {
+		if err := i.startInformer(ctx); err != nil {
 			return err
 		}
 
@@ -60,7 +60,7 @@ func (i *informer) Receive(ctx *actor.Context) error {
 	return nil
 }
 
-func (i *informer) receiveStartInformer(ctx *actor.Context) error {
+func (i *informer) startInformer(ctx *actor.Context) error {
 	watch, err := i.podInterface.Watch(metaV1.ListOptions{LabelSelector: determinedLabel})
 	if err != nil {
 		return errors.Wrap(err, "error initializing pod watch")
@@ -73,5 +73,8 @@ func (i *informer) receiveStartInformer(ctx *actor.Context) error {
 		ctx.Tell(i.podsHandler, podStatusUpdate{podName: pod.Name, updatedPod: pod})
 	}
 
-	return errors.Errorf("pod informer stopped unexpectedly")
+	ctx.Log().Warn("pod informer stopped unexpectedly")
+	ctx.Tell(ctx.Self(), startInformer{})
+
+	return nil
 }

--- a/master/internal/kubernetes/informer.go
+++ b/master/internal/kubernetes/informer.go
@@ -67,14 +67,11 @@ func (i *informer) receiveStartInformer(ctx *actor.Context) error {
 	}
 
 	ctx.Log().Info("pod informer is starting")
-
 	for event := range watch.ResultChan() {
 		pod := event.Object.(*v1.Pod)
-		// TODO: change this to debug level
-		ctx.Log().Infof("informer got new pod event for pod: %s %s", pod.Name, pod.Status.Phase)
+		ctx.Log().Debugf("informer got new pod event for pod: %s %s", pod.Name, pod.Status.Phase)
 		ctx.Tell(i.podsHandler, podStatusUpdate{podName: pod.Name, updatedPod: pod})
 	}
 
-	ctx.Log().Info("pod informer has started")
-	return nil
+	return errors.Errorf("pod informer stopped unexpectedly")
 }

--- a/master/internal/kubernetes/log.go
+++ b/master/internal/kubernetes/log.go
@@ -90,7 +90,7 @@ func (p *podLogStreamer) receiveStreamLogs(ctx *actor.Context) error {
 	for {
 		_, err := io.Copy(p, logReader)
 		if err != nil {
-			ctx.Log().Debugf("error reading logs: ", err)
+			ctx.Log().Debug("error reading logs: ", err)
 			break
 		}
 	}

--- a/master/internal/kubernetes/log.go
+++ b/master/internal/kubernetes/log.go
@@ -2,7 +2,6 @@ package kubernetes
 
 import (
 	"io"
-	"reflect"
 	"time"
 
 	"github.com/docker/docker/pkg/stdcopy"
@@ -58,7 +57,7 @@ func (p *podLogStreamer) Receive(ctx *actor.Context) error {
 	case actor.PostStop:
 
 	default:
-		ctx.Log().Error("unexpected message: ", reflect.TypeOf(msg))
+		ctx.Log().Errorf("unexpected message: %T", msg)
 		return actor.ErrUnexpectedMessage(ctx)
 	}
 
@@ -81,7 +80,7 @@ func (p *podLogStreamer) receiveStreamLogs(ctx *actor.Context) {
 	p.ctx = ctx
 	_, err := io.Copy(p, p.logReader)
 	if err != nil {
-		ctx.Log().Debug("error reading logs: ", err)
+		ctx.Log().WithError(err).Debug("error reading logs")
 		ctx.Self().Stop()
 		return
 	}

--- a/master/internal/kubernetes/log.go
+++ b/master/internal/kubernetes/log.go
@@ -74,7 +74,7 @@ func (p *podLogStreamer) Write(log []byte) (n int, err error) {
 func (p *podLogStreamer) receiveStreamLogs(ctx *actor.Context) error {
 	logs := p.podInterface.GetLogs(p.podName, &v1.PodLogOptions{
 		Follow: true,
-		// TODO: switch over to using k8 timestamps.
+		// TODO(DET-3541): switch over to using k8 timestamps.
 		Timestamps: false,
 	})
 

--- a/master/internal/kubernetes/log.go
+++ b/master/internal/kubernetes/log.go
@@ -7,15 +7,14 @@ import (
 
 	"github.com/docker/docker/pkg/stdcopy"
 
-	"github.com/determined-ai/determined/master/internal/sproto"
-	"github.com/determined-ai/determined/master/pkg/agent"
-
 	"github.com/pkg/errors"
-	v1 "k8s.io/api/core/v1"
 
+	k8sV1 "k8s.io/api/core/v1"
 	typedV1 "k8s.io/client-go/kubernetes/typed/core/v1"
 
+	"github.com/determined-ai/determined/master/internal/sproto"
 	"github.com/determined-ai/determined/master/pkg/actor"
+	"github.com/determined-ai/determined/master/pkg/agent"
 )
 
 type (
@@ -34,7 +33,7 @@ func newPodLogStreamer(
 	podName string,
 	podHandler *actor.Ref,
 ) (*podLogStreamer, error) {
-	logs := podInterface.GetLogs(podName, &v1.PodLogOptions{
+	logs := podInterface.GetLogs(podName, &k8sV1.PodLogOptions{
 		Follow: true,
 		// TODO(DET-3541): switch over to using k8 timestamps.
 		Timestamps: false,

--- a/master/internal/kubernetes/log.go
+++ b/master/internal/kubernetes/log.go
@@ -1,0 +1,98 @@
+package kubernetes
+
+import (
+	"io"
+	"reflect"
+	"time"
+
+	"github.com/docker/docker/pkg/stdcopy"
+
+	"github.com/determined-ai/determined/master/internal/sproto"
+	"github.com/determined-ai/determined/master/pkg/agent"
+
+	"github.com/pkg/errors"
+	v1 "k8s.io/api/core/v1"
+
+	typedV1 "k8s.io/client-go/kubernetes/typed/core/v1"
+
+	"github.com/determined-ai/determined/master/pkg/actor"
+)
+
+type (
+	streamLogs struct{}
+)
+
+type podLogStreamer struct {
+	podInterface typedV1.PodInterface
+	podName      string
+	podHandler   *actor.Ref
+
+	ctx *actor.Context
+}
+
+func newPodLogStreamer(
+	podInterface typedV1.PodInterface,
+	podName string,
+	podHandler *actor.Ref,
+) *podLogStreamer {
+	return &podLogStreamer{
+		podInterface: podInterface,
+		podName:      podName,
+		podHandler:   podHandler,
+	}
+}
+
+func (p *podLogStreamer) Receive(ctx *actor.Context) error {
+	switch msg := ctx.Message().(type) {
+	case actor.PreStart:
+
+	case streamLogs:
+		if err := p.receiveStreamLogs(ctx); err != nil {
+			return err
+		}
+
+	default:
+		ctx.Log().Error("unexpected message: ", reflect.TypeOf(msg))
+		return actor.ErrUnexpectedMessage(ctx)
+	}
+
+	return nil
+}
+
+// Write implements the io.Writer interface.
+func (p *podLogStreamer) Write(log []byte) (n int, err error) {
+	p.ctx.Tell(p.podHandler, sproto.ContainerLog{
+		Timestamp: time.Now(),
+		RunMessage: &agent.RunMessage{
+			Value:   string(log),
+			StdType: stdcopy.Stdout,
+		},
+	})
+	return len(log), nil
+}
+
+func (p *podLogStreamer) receiveStreamLogs(ctx *actor.Context) error {
+	logs := p.podInterface.GetLogs(p.podName, &v1.PodLogOptions{
+		Follow: true,
+		// TODO: switch over to using k8 timestamps.
+		Timestamps: false,
+	})
+
+	logReader, err := logs.Stream()
+	if err != nil {
+		return errors.Wrapf(err, "failed to initialize log stream for pod: %s", p.podName)
+	}
+
+	p.ctx = ctx
+	ctx.Log().Debugf("starting log streaming for pod %s", p.podName)
+	for {
+		_, err := io.Copy(p, logReader)
+		if err != nil {
+			ctx.Log().Debugf("error reading logs: ", err)
+			break
+		}
+	}
+
+	ctx.Self().Stop()
+	return nil
+}

--- a/master/internal/kubernetes/log.go
+++ b/master/internal/kubernetes/log.go
@@ -51,6 +51,8 @@ func (p *podLogStreamer) Receive(ctx *actor.Context) error {
 			return err
 		}
 
+	case actor.PostStop:
+
 	default:
 		ctx.Log().Error("unexpected message: ", reflect.TypeOf(msg))
 		return actor.ErrUnexpectedMessage(ctx)

--- a/master/internal/kubernetes/pod.go
+++ b/master/internal/kubernetes/pod.go
@@ -6,14 +6,14 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/determined-ai/determined/master/pkg/agent"
-
 	"github.com/pkg/errors"
 
 	"github.com/docker/docker/api/types/mount"
+	petname "github.com/dustinkirkland/golang-petname"
 
 	"github.com/determined-ai/determined/master/internal/sproto"
 	"github.com/determined-ai/determined/master/pkg/actor"
+	"github.com/determined-ai/determined/master/pkg/agent"
 	"github.com/determined-ai/determined/master/pkg/archive"
 	"github.com/determined-ai/determined/master/pkg/container"
 	"github.com/determined-ai/determined/master/pkg/device"
@@ -618,17 +618,19 @@ func (p *pod) startPodForGC(ctx *actor.Context) error {
 }
 
 func configurePodName(t tasks.TaskSpec, rank int) string {
+	uniqueName := petname.Generate(2, "-")
 	switch {
 	case t.StartCommand != nil:
-		return fmt.Sprintf("cmd-%s", t.TaskID)
+		return fmt.Sprintf("cmd-%s-%s", t.TaskID, uniqueName)
 	case t.StartContainer != nil:
 		return fmt.Sprintf(
-			"exp-%d-trial-%d-%d",
+			"exp-%d-trial-%d-%d-%s",
 			t.StartContainer.InitialWorkload.ExperimentID,
 			t.StartContainer.InitialWorkload.TrialID, rank,
+			uniqueName,
 		)
 	case t.GCCheckpoints != nil:
-		return fmt.Sprintf("gc-%s", t.TaskID)
+		return fmt.Sprintf("gc-%s-%s", t.TaskID, uniqueName)
 	default:
 		return ""
 	}

--- a/master/internal/kubernetes/pod.go
+++ b/master/internal/kubernetes/pod.go
@@ -49,14 +49,13 @@ type pod struct {
 	configMapInterface       typedV1.ConfigMapInterface
 	leaveKubernetesResources bool
 
-	pod         *k8sV1.Pod
-	configMaps  []*k8sV1.ConfigMap
-	podName     string
-	logStreamer *actor.Ref
-	container   container.Container
-	ports       []int
+	pod              *k8sV1.Pod
+	configMaps       []*k8sV1.ConfigMap
+	podName          string
+	logStreamer      *actor.Ref
+	container        container.Container
+	ports            []int
 	resourcesDeleted bool
-
 }
 
 func newPod(
@@ -74,9 +73,9 @@ func newPod(
 	leaveKubernetesResources bool,
 ) *pod {
 	podContainer := container.Container{
-		Parent:  taskHandler.Address(),
-		ID:      container.ID(taskSpec.ContainerID),
-		State:   container.Assigned,
+		Parent: taskHandler.Address(),
+		ID:     container.ID(taskSpec.ContainerID),
+		State:  container.Assigned,
 	}
 
 	return &pod{

--- a/master/internal/kubernetes/pod.go
+++ b/master/internal/kubernetes/pod.go
@@ -150,8 +150,6 @@ func (p *pod) receivePodStatusUpdate(ctx *actor.Context, msg podStatusUpdate) er
 				p.container.State, containerState, p.podName)
 			p.container = p.container.Transition(containerState)
 
-			// TODO: Refactor the containerStarted part of this message
-			// to be less specific to agents.
 			rsc := sproto.ContainerStateChanged{Container: p.container}
 			ctx.Tell(p.taskHandler, rsc)
 		}
@@ -170,7 +168,6 @@ func (p *pod) receivePodStatusUpdate(ctx *actor.Context, msg podStatusUpdate) er
 			}
 
 			ctx.Tell(p.logStreamer, streamLogs{})
-
 			ctx.Tell(p.taskHandler, sproto.ContainerStateChanged{Container: p.container})
 			ctx.Tell(p.cluster, sproto.PodStarted{
 				ContainerID: p.container.ID,

--- a/master/internal/kubernetes/pods.go
+++ b/master/internal/kubernetes/pods.go
@@ -99,6 +99,10 @@ func (p *pods) Receive(ctx *actor.Context) error {
 		}
 
 	case actor.ChildFailed:
+		if msg.Child == p.informer {
+			return errors.Errorf("pod informer failed")
+		}
+
 		if err := p.cleanupPodHandler(ctx, msg.Child); err != nil {
 			return err
 		}
@@ -175,9 +179,9 @@ func (p *pods) receiveStartPod(ctx *actor.Context, msg sproto.StartPod) error {
 }
 
 func (p *pods) receivePodStatusUpdate(ctx *actor.Context, msg podStatusUpdate) {
-	ref, ok := p.podNameToPodHandler[msg.podName]
+	ref, ok := p.podNameToPodHandler[msg.updatedPod.Name]
 	if !ok {
-		ctx.Log().WithField("pod name", msg.podName).Warn(
+		ctx.Log().WithField("pod name", msg.updatedPod.Name).Warn(
 			"received pod status update for un-registered pod")
 		return
 	}

--- a/master/internal/kubernetes/pods.go
+++ b/master/internal/kubernetes/pods.go
@@ -12,8 +12,8 @@ import (
 	"github.com/determined-ai/determined/master/pkg/actor"
 	"github.com/determined-ai/determined/master/pkg/check"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	k8sclient "k8s.io/client-go/kubernetes"
+	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sClient "k8s.io/client-go/kubernetes"
 	typedV1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/rest"
 
@@ -27,7 +27,7 @@ type pods struct {
 	masterServiceName        string
 	leaveKubernetesResources bool
 
-	clientSet  *k8sclient.Clientset
+	clientSet  *k8sClient.Clientset
 	masterIP   string
 	masterPort int32
 
@@ -96,7 +96,7 @@ func (p *pods) startClientSet(ctx *actor.Context) error {
 		return errors.Wrap(err, "error building kubernetes config")
 	}
 
-	p.clientSet, err = k8sclient.NewForConfig(config)
+	p.clientSet, err = k8sClient.NewForConfig(config)
 	if err != nil {
 		return errors.Wrap(err, "failed to initialize kubernetes clientSet")
 	}
@@ -110,7 +110,7 @@ func (p *pods) startClientSet(ctx *actor.Context) error {
 
 func (p *pods) getMasterIPAndPort(ctx *actor.Context) error {
 	masterService, err := p.clientSet.CoreV1().Services(p.namespace).Get(
-		p.masterServiceName, metav1.GetOptions{})
+		p.masterServiceName, metaV1.GetOptions{})
 	if err != nil {
 		return errors.Wrap(err, "failed to get master service")
 	}

--- a/master/internal/kubernetes/pods.go
+++ b/master/internal/kubernetes/pods.go
@@ -159,6 +159,12 @@ func (p *pods) receiveStartPod(ctx *actor.Context, msg sproto.StartPod) error {
 
 	ctx.Log().WithField("pod", newPodHandler.podName).WithField(
 		"handler", ref.Address()).Infof("registering pod handler")
+
+	if _, alreadyExists := p.podNameToPodHandler[newPodHandler.podName]; alreadyExists {
+		return errors.Errorf(
+			"attempting to register same pod name: %s multiple times", newPodHandler.podName)
+	}
+
 	p.podNameToPodHandler[newPodHandler.podName] = ref
 	p.containerIDToPodHandler[msg.Spec.ContainerID] = ref
 	p.podHandlerToMetadata[ref] = podMetadata{

--- a/master/internal/kubernetes/pods.go
+++ b/master/internal/kubernetes/pods.go
@@ -94,7 +94,7 @@ func (p *pods) Receive(ctx *actor.Context) error {
 		p.receiveStopPod(ctx, msg)
 
 	case actor.ChildStopped:
-		if err := p.cleanupPodHandler(ctx, msg.Child); err != nil {
+		if err := p.cleanUpPodHandler(ctx, msg.Child); err != nil {
 			return err
 		}
 
@@ -103,7 +103,7 @@ func (p *pods) Receive(ctx *actor.Context) error {
 			return errors.Errorf("pod informer failed")
 		}
 
-		if err := p.cleanupPodHandler(ctx, msg.Child); err != nil {
+		if err := p.cleanUpPodHandler(ctx, msg.Child); err != nil {
 			return err
 		}
 
@@ -203,7 +203,7 @@ func (p *pods) receiveStopPod(ctx *actor.Context, msg sproto.StopPod) {
 	ctx.Tell(ref, msg)
 }
 
-func (p *pods) cleanupPodHandler(ctx *actor.Context, podHandler *actor.Ref) error {
+func (p *pods) cleanUpPodHandler(ctx *actor.Context, podHandler *actor.Ref) error {
 	podInfo, ok := p.podHandlerToMetadata[podHandler]
 	if !ok {
 		return errors.Errorf("unknown pod handler being deleted %s", podHandler.Address())

--- a/master/internal/kubernetes/pods.go
+++ b/master/internal/kubernetes/pods.go
@@ -81,6 +81,8 @@ func (p *pods) Receive(ctx *actor.Context) error {
 	case podStatusUpdate:
 		p.receivePodStatusUpdate(ctx, msg)
 
+	case actor.ChildStopped:
+
 	default:
 		ctx.Log().Errorf("unexpected message %T", msg)
 		return actor.ErrUnexpectedMessage(ctx)

--- a/master/internal/kubernetes/pods.go
+++ b/master/internal/kubernetes/pods.go
@@ -127,7 +127,7 @@ func (p *pods) receiveStartPod(ctx *actor.Context, msg sproto.StartPod) error {
 		p.masterPort, msg.Spec, msg.Slots, msg.Rank,
 		p.podInterface, p.configMapInterface,
 	)
-	ref, ok := ctx.ActorOf(fmt.Sprintf("pod-%s", msg.Spec.TaskID), newPodHandler)
+	ref, ok := ctx.ActorOf(fmt.Sprintf("pod-%s-%d", msg.Spec.TaskID, msg.Rank), newPodHandler)
 	if !ok {
 		return errors.Errorf("pod actor %s already exists", ref.Address().String())
 	}
@@ -139,7 +139,8 @@ func (p *pods) receiveStartPod(ctx *actor.Context, msg sproto.StartPod) error {
 func (p *pods) receivePodStatusUpdate(ctx *actor.Context, msg podStatusUpdate) {
 	ref, ok := p.podNameToPodHandler[msg.podName]
 	if !ok {
-		ctx.Log().Errorf("received pod status update for un-registered pod: %s", msg.podName)
+		ctx.Log().WithField("pod name", msg.podName).Warn(
+			"received pod status update for un-registered pod")
 		return
 	}
 

--- a/master/internal/kubernetes/pods.go
+++ b/master/internal/kubernetes/pods.go
@@ -181,7 +181,7 @@ func (p *pods) receiveStartPod(ctx *actor.Context, msg sproto.StartPod) error {
 func (p *pods) receivePodStatusUpdate(ctx *actor.Context, msg podStatusUpdate) {
 	ref, ok := p.podNameToPodHandler[msg.updatedPod.Name]
 	if !ok {
-		ctx.Log().WithField("pod name", msg.updatedPod.Name).Warn(
+		ctx.Log().WithField("pod-name", msg.updatedPod.Name).Warn(
 			"received pod status update for un-registered pod")
 		return
 	}
@@ -195,7 +195,7 @@ func (p *pods) receiveStopPod(ctx *actor.Context, msg sproto.StopPod) {
 		// For multi-pod tasks, when the the chief pod exits,
 		// the scheduler will request to terminate pods all other pods
 		// that have notified the scheduler that they have exited.
-		ctx.Log().WithField("container id", msg.ContainerID).Info(
+		ctx.Log().WithField("container-id", msg.ContainerID).Info(
 			"received stop pod command for unregistered container id")
 		return
 	}
@@ -206,7 +206,7 @@ func (p *pods) receiveStopPod(ctx *actor.Context, msg sproto.StopPod) {
 func (p *pods) cleanupPodHandler(ctx *actor.Context, podHandler *actor.Ref) error {
 	podInfo, ok := p.podHandlerToMetadata[podHandler]
 	if !ok {
-		return errors.Errorf("unknown pod handler being deleted %s", podHandler)
+		return errors.Errorf("unknown pod handler being deleted %s", podHandler.Address())
 	}
 
 	ctx.Log().WithField("pod", podInfo.podName).WithField(

--- a/master/internal/kubernetes/volumes.go
+++ b/master/internal/kubernetes/volumes.go
@@ -4,54 +4,54 @@ import (
 	"fmt"
 	"path"
 
-	"github.com/determined-ai/determined/master/pkg/actor"
-	"github.com/determined-ai/determined/master/pkg/container"
-
 	"github.com/pkg/errors"
 
 	"github.com/docker/docker/api/types/mount"
 
-	v1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sV1 "k8s.io/api/core/v1"
+	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	typedV1 "k8s.io/client-go/kubernetes/typed/core/v1"
+
+	"github.com/determined-ai/determined/master/pkg/actor"
+	"github.com/determined-ai/determined/master/pkg/container"
 )
 
-func configureMountPropagation(b *mount.BindOptions) *v1.MountPropagationMode {
+func configureMountPropagation(b *mount.BindOptions) *k8sV1.MountPropagationMode {
 	if b == nil {
 		return nil
 	}
 
 	switch b.Propagation {
 	case mount.PropagationPrivate:
-		p := v1.MountPropagationNone
+		p := k8sV1.MountPropagationNone
 		return &p
 	case mount.PropagationRSlave:
-		p := v1.MountPropagationHostToContainer
+		p := k8sV1.MountPropagationHostToContainer
 		return &p
 	case mount.PropagationRShared:
-		p := v1.MountPropagationBidirectional
+		p := k8sV1.MountPropagationBidirectional
 		return &p
 	default:
 		return nil
 	}
 }
 
-func dockerMountsToHostVolumes(dockerMounts []mount.Mount) ([]v1.VolumeMount, []v1.Volume) {
-	volumeMounts := make([]v1.VolumeMount, 0, len(dockerMounts))
-	volumes := make([]v1.Volume, 0, len(dockerMounts))
+func dockerMountsToHostVolumes(dockerMounts []mount.Mount) ([]k8sV1.VolumeMount, []k8sV1.Volume) {
+	volumeMounts := make([]k8sV1.VolumeMount, 0, len(dockerMounts))
+	volumes := make([]k8sV1.Volume, 0, len(dockerMounts))
 
 	for idx, d := range dockerMounts {
 		name := fmt.Sprintf("det-host-volume-%d", idx)
-		volumeMounts = append(volumeMounts, v1.VolumeMount{
+		volumeMounts = append(volumeMounts, k8sV1.VolumeMount{
 			Name:             name,
 			ReadOnly:         d.ReadOnly,
 			MountPath:        d.Target,
 			MountPropagation: configureMountPropagation(d.BindOptions),
 		})
-		volumes = append(volumes, v1.Volume{
+		volumes = append(volumes, k8sV1.Volume{
 			Name: name,
-			VolumeSource: v1.VolumeSource{
-				HostPath: &v1.HostPathVolumeSource{
+			VolumeSource: k8sV1.VolumeSource{
+				HostPath: &k8sV1.HostPathVolumeSource{
 					Path: d.Source,
 				},
 			},
@@ -61,20 +61,20 @@ func dockerMountsToHostVolumes(dockerMounts []mount.Mount) ([]v1.VolumeMount, []
 	return volumeMounts, volumes
 }
 
-func configureShmVolume(_ int64) (v1.VolumeMount, v1.Volume) {
+func configureShmVolume(_ int64) (k8sV1.VolumeMount, k8sV1.Volume) {
 	// Kubernetes does not support a native way to set shm size for
 	// containers. The workaround for this is to create an emptyDir
 	// volume and mount it to /dev/shm.
 	volumeName := "det-shm-volume"
-	volumeMount := v1.VolumeMount{
+	volumeMount := k8sV1.VolumeMount{
 		Name:      volumeName,
 		ReadOnly:  false,
 		MountPath: "/dev/shm",
 	}
-	volume := v1.Volume{
+	volume := k8sV1.Volume{
 		Name: volumeName,
-		VolumeSource: v1.VolumeSource{EmptyDir: &v1.EmptyDirVolumeSource{
-			Medium: v1.StorageMediumMemory,
+		VolumeSource: k8sV1.VolumeSource{EmptyDir: &k8sV1.EmptyDirVolumeSource{
+			Medium: k8sV1.StorageMediumMemory,
 		}},
 	}
 	return volumeMount, volume
@@ -84,9 +84,9 @@ func createConfigMapSpec(
 	namePrefix string,
 	data map[string][]byte,
 	namespace string,
-) *v1.ConfigMap {
-	return &v1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
+) *k8sV1.ConfigMap {
+	return &k8sV1.ConfigMap{
+		ObjectMeta: metaV1.ObjectMeta{
 			GenerateName: namePrefix,
 			Namespace:    namespace,
 		},
@@ -96,9 +96,9 @@ func createConfigMapSpec(
 
 func startConfigMap(
 	ctx *actor.Context,
-	configMapSpec *v1.ConfigMap,
+	configMapSpec *k8sV1.ConfigMap,
 	configMapInterface typedV1.ConfigMapInterface,
-) (*v1.ConfigMap, error) {
+) (*k8sV1.ConfigMap, error) {
 	configMap, err := configMapInterface.Create(configMapSpec)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create configMap")
@@ -109,29 +109,29 @@ func startConfigMap(
 }
 
 func configureAdditionalFilesVolumes(
-	archiveConfigMap *v1.ConfigMap,
-	entryPointConfigMap *v1.ConfigMap,
+	archiveConfigMap *k8sV1.ConfigMap,
+	entryPointConfigMap *k8sV1.ConfigMap,
 	runArchives []container.RunArchive,
-) ([]v1.VolumeMount, []v1.VolumeMount, []v1.Volume) {
-	initContainerVolumeMounts := make([]v1.VolumeMount, 0)
-	mainContainerVolumeMounts := make([]v1.VolumeMount, 0)
-	volumes := make([]v1.Volume, 0)
+) ([]k8sV1.VolumeMount, []k8sV1.VolumeMount, []k8sV1.Volume) {
+	initContainerVolumeMounts := make([]k8sV1.VolumeMount, 0)
+	mainContainerVolumeMounts := make([]k8sV1.VolumeMount, 0)
+	volumes := make([]k8sV1.Volume, 0)
 
 	// In order to inject additional files into k8 pods, we un-tar the archives
 	// in an initContainer from a configMap to an emptyDir, and then mount the
 	// emptyDir into the main container.
 
 	archiveVolumeName := "archive-volume"
-	archiveVolume := v1.Volume{
+	archiveVolume := k8sV1.Volume{
 		Name: archiveVolumeName,
-		VolumeSource: v1.VolumeSource{
-			ConfigMap: &v1.ConfigMapVolumeSource{
-				LocalObjectReference: v1.LocalObjectReference{Name: archiveConfigMap.Name},
+		VolumeSource: k8sV1.VolumeSource{
+			ConfigMap: &k8sV1.ConfigMapVolumeSource{
+				LocalObjectReference: k8sV1.LocalObjectReference{Name: archiveConfigMap.Name},
 			},
 		},
 	}
 	volumes = append(volumes, archiveVolume)
-	archiveVolumeMount := v1.VolumeMount{
+	archiveVolumeMount := k8sV1.VolumeMount{
 		Name:      archiveVolumeName,
 		MountPath: initContainerTarSrcPath,
 		ReadOnly:  true,
@@ -140,17 +140,17 @@ func configureAdditionalFilesVolumes(
 
 	entryPointVolumeName := "entrypoint-volume"
 	var entryPointVolumeMode int32 = 0700
-	entryPointVolume := v1.Volume{
+	entryPointVolume := k8sV1.Volume{
 		Name: entryPointVolumeName,
-		VolumeSource: v1.VolumeSource{
-			ConfigMap: &v1.ConfigMapVolumeSource{
-				LocalObjectReference: v1.LocalObjectReference{Name: entryPointConfigMap.Name},
+		VolumeSource: k8sV1.VolumeSource{
+			ConfigMap: &k8sV1.ConfigMapVolumeSource{
+				LocalObjectReference: k8sV1.LocalObjectReference{Name: entryPointConfigMap.Name},
 				DefaultMode:          &entryPointVolumeMode,
 			},
 		},
 	}
 	volumes = append(volumes, entryPointVolume)
-	entrypointVolumeMount := v1.VolumeMount{
+	entrypointVolumeMount := k8sV1.VolumeMount{
 		Name:      entryPointVolumeName,
 		MountPath: initContainerWorkDir,
 		ReadOnly:  true,
@@ -158,12 +158,12 @@ func configureAdditionalFilesVolumes(
 	initContainerVolumeMounts = append(initContainerVolumeMounts, entrypointVolumeMount)
 
 	additionalFilesVolumeName := "additional-files-volume"
-	dstVolume := v1.Volume{
+	dstVolume := k8sV1.Volume{
 		Name:         additionalFilesVolumeName,
-		VolumeSource: v1.VolumeSource{EmptyDir: &v1.EmptyDirVolumeSource{}},
+		VolumeSource: k8sV1.VolumeSource{EmptyDir: &k8sV1.EmptyDirVolumeSource{}},
 	}
 	volumes = append(volumes, dstVolume)
-	dstVolumeMount := v1.VolumeMount{
+	dstVolumeMount := k8sV1.VolumeMount{
 		Name:      additionalFilesVolumeName,
 		MountPath: initContainerTarDstPath,
 		ReadOnly:  false,
@@ -172,7 +172,7 @@ func configureAdditionalFilesVolumes(
 
 	for idx, runArchive := range runArchives {
 		for _, item := range runArchive.Archive {
-			mainContainerVolumeMounts = append(mainContainerVolumeMounts, v1.VolumeMount{
+			mainContainerVolumeMounts = append(mainContainerVolumeMounts, k8sV1.VolumeMount{
 				Name:      additionalFilesVolumeName,
 				MountPath: path.Join(runArchive.Path, item.Path),
 				SubPath:   path.Join(fmt.Sprintf("%d", idx), item.Path),

--- a/master/internal/scheduler/agent.go
+++ b/master/internal/scheduler/agent.go
@@ -8,15 +8,6 @@ import (
 	"github.com/determined-ai/determined/master/pkg/device"
 )
 
-// Outgoing agent actor messages; agent actors must send these events back to the cluster.
-type (
-	// containerStartedOnAgent notifies the cluster that the task container has started running.
-	containerStartedOnAgent struct {
-		ContainerID ContainerID
-		Addresses   []Address
-	}
-)
-
 // agentState holds the scheduler state for an agent. The implementation of agent-related operations
 // (e.g., socket I/O) is deferred to the actor.
 type agentState struct {

--- a/master/internal/scheduler/config.go
+++ b/master/internal/scheduler/config.go
@@ -86,9 +86,10 @@ type DefaultResourceProviderConfig struct{}
 
 // KubernetesResourceProviderConfig hosts configuration fields for the kubernetes resource provider.
 type KubernetesResourceProviderConfig struct {
-	Namespace         string `json:"namespace"`
-	SlotsPerNode      int    `json:"slots_per_node"`
-	MasterServiceName string `json:"master_service_name"`
+	Namespace                string `json:"namespace"`
+	SlotsPerNode             int    `json:"slots_per_node"`
+	MasterServiceName        string `json:"master_service_name"`
+	LeaveKubernetesResources bool   `json:"leave_kubernetes_resources"`
 }
 
 // Validate implements the check.Validatable interface.

--- a/master/internal/scheduler/container.go
+++ b/master/internal/scheduler/container.go
@@ -43,8 +43,6 @@ type Address struct {
 	// HostPort is the IP port from outside the container. This can be different
 	// than the ContainerPort because of network forwarding on the host machine.
 	HostPort int `json:"host_port"`
-
-	Protocol string `json:"protocol"`
 }
 
 // containerState represents the current status of the container.

--- a/master/internal/scheduler/default_resource_provider.go
+++ b/master/internal/scheduler/default_resource_provider.go
@@ -379,6 +379,7 @@ func (d *DefaultRP) receiveStartTask(ctx *actor.Context, msg StartTask) {
 	for _, a := range assignments {
 		a.StartTask(msg.Spec)
 	}
+	d.assigmentByHandler[msg.TaskHandler] = make([]containerAssignment, 0)
 }
 
 func (d *DefaultRP) receiveContainerStartedOnAgent(

--- a/master/internal/scheduler/default_resource_provider.go
+++ b/master/internal/scheduler/default_resource_provider.go
@@ -522,10 +522,7 @@ func (d *DefaultRP) taskTerminated(task *Task, aborted bool) {
 		delete(d.tasksByContainerID, id)
 	}
 
-	task.handler.System().Tell(task.handler, TaskTerminated{
-		Task:    newTaskSummary(task),
-		Aborted: aborted,
-	})
+	task.handler.System().Tell(task.handler, TaskTerminated{})
 	// This is somewhat redundant with the message above, but we're transitioning between them.
 	if aborted {
 		task.handler.System().Tell(task.handler, TaskAborted{})

--- a/master/internal/scheduler/default_resource_provider.go
+++ b/master/internal/scheduler/default_resource_provider.go
@@ -379,7 +379,7 @@ func (d *DefaultRP) receiveStartTask(ctx *actor.Context, msg StartTask) {
 	for _, a := range assignments {
 		a.StartTask(msg.Spec)
 	}
-	d.assigmentByHandler[msg.TaskHandler] = make([]containerAssignment, 0)
+	delete(d.assigmentByHandler, msg.TaskHandler)
 }
 
 func (d *DefaultRP) receiveContainerStartedOnAgent(

--- a/master/internal/scheduler/default_resource_provider.go
+++ b/master/internal/scheduler/default_resource_provider.go
@@ -544,7 +544,6 @@ func toAddresses(proxy string, info types.ContainerJSON) []Address {
 				ContainerPort: port.Int(),
 				HostIP:        proxy,
 				HostPort:      port.Int(),
-				Protocol:      port.Proto(),
 			})
 		}
 	default:
@@ -572,7 +571,6 @@ func toAddresses(proxy string, info types.ContainerJSON) []Address {
 						ContainerPort: port.Int(),
 						HostIP:        hostIP,
 						HostPort:      hostPort,
-						Protocol:      port.Proto(),
 					})
 				}
 			}

--- a/master/internal/scheduler/default_resource_provider_test.go
+++ b/master/internal/scheduler/default_resource_provider_test.go
@@ -55,11 +55,8 @@ func (h *mockActor) Receive(ctx *actor.Context) error {
 			return h.onAssigned(msg)
 		}
 
-		h.system.Tell(h.cluster, sproto.ContainerStateChanged{
-			Container: cproto.Container{
-				ID:    cproto.ID("random-container-name"),
-				State: cproto.Running,
-			},
+		h.system.Tell(h.cluster, sproto.TaskStartedOnAgent{
+			ContainerID: cproto.ID("random-container-name"),
 			ContainerStarted: &agent.ContainerStarted{
 				ContainerInfo: types.ContainerJSON{
 					ContainerJSONBase: &types.ContainerJSONBase{
@@ -75,11 +72,9 @@ func (h *mockActor) Receive(ctx *actor.Context) error {
 		if h.onContainerStarted != nil {
 			return h.onContainerStarted(msg)
 		}
-		h.system.Tell(h.cluster, sproto.ContainerStateChanged{
-			Container: cproto.Container{
-				ID:    cproto.ID(msg.Container.ID()),
-				State: cproto.Terminated,
-			},
+
+		h.system.Tell(h.cluster, sproto.TaskTerminatedOnAgent{
+			ContainerID:      cproto.ID(msg.Container.ID()),
 			ContainerStopped: &agent.ContainerStopped{},
 		})
 

--- a/master/internal/scheduler/kubernetes_resource_provider.go
+++ b/master/internal/scheduler/kubernetes_resource_provider.go
@@ -11,13 +11,14 @@ import (
 
 // kubernetesResourceProvider manages the lifecycle of k8s resources.
 type kubernetesResourceProvider struct {
-	clusterID             string
-	namespace             string
-	slotsPerNode          int
-	masterServiceName     string
-	proxy                 *actor.Ref
-	harnessPath           string
-	taskContainerDefaults model.TaskContainerDefaultsConfig
+	clusterID                string
+	namespace                string
+	slotsPerNode             int
+	masterServiceName        string
+	leaveKubernetesResources bool
+	proxy                    *actor.Ref
+	harnessPath              string
+	taskContainerDefaults    model.TaskContainerDefaultsConfig
 
 	tasksByHandler     map[*actor.Ref]*Task
 	tasksByID          map[TaskID]*Task
@@ -36,18 +37,20 @@ func NewKubernetesResourceProvider(
 	namespace string,
 	slotsPerNode int,
 	masterServiceName string,
+	leaveKubernetesResources bool,
 	proxy *actor.Ref,
 	harnessPath string,
 	taskContainerDefaults model.TaskContainerDefaultsConfig,
 ) actor.Actor {
 	return &kubernetesResourceProvider{
-		clusterID:             clusterID,
-		namespace:             namespace,
-		slotsPerNode:          slotsPerNode,
-		masterServiceName:     masterServiceName,
-		proxy:                 proxy,
-		harnessPath:           harnessPath,
-		taskContainerDefaults: taskContainerDefaults,
+		clusterID:                clusterID,
+		namespace:                namespace,
+		slotsPerNode:             slotsPerNode,
+		masterServiceName:        masterServiceName,
+		leaveKubernetesResources: leaveKubernetesResources,
+		proxy:                    proxy,
+		harnessPath:              harnessPath,
+		taskContainerDefaults:    taskContainerDefaults,
 
 		tasksByHandler:     make(map[*actor.Ref]*Task),
 		tasksByID:          make(map[TaskID]*Task),
@@ -70,6 +73,7 @@ func (k *kubernetesResourceProvider) Receive(ctx *actor.Context) error {
 			ctx.Self(),
 			k.namespace,
 			k.masterServiceName,
+			k.leaveKubernetesResources,
 		)
 
 		k.agent = newAgentState(sproto.AddAgent{Agent: podsActor})

--- a/master/internal/scheduler/kubernetes_resource_provider.go
+++ b/master/internal/scheduler/kubernetes_resource_provider.go
@@ -246,9 +246,9 @@ func (p *podAssignment) StartTask(spec image.TaskSpec) {
 	spec.HarnessPath = p.harnessPath
 	spec.TaskContainerDefaults = p.taskContainerDefaults
 	handler.System().Tell(handler, sproto.StartPod{
-		Task:  p.task.handler,
-		Spec:  spec,
-		Slots: p.container.Slots(),
-		Rank:  p.container.ordinal,
+		TaskHandler: p.task.handler,
+		Spec:        spec,
+		Slots:       p.container.Slots(),
+		Rank:        p.container.ordinal,
 	})
 }

--- a/master/internal/scheduler/kubernetes_resource_provider.go
+++ b/master/internal/scheduler/kubernetes_resource_provider.go
@@ -229,7 +229,7 @@ func (k *kubernetesResourceProvider) receiveSetTaskName(ctx *actor.Context, msg 
 func (k *kubernetesResourceProvider) receiveStartTask(ctx *actor.Context, msg StartTask) {
 	task := k.tasksByHandler[msg.TaskHandler]
 	if task == nil {
-		ctx.Log().WithField("address", msg.TaskHandler.Address()).Errorf("unknown task trying to start")
+		ctx.Log().WithField("address", msg.TaskHandler.Address()).Error("unknown task trying to start")
 		return
 	}
 

--- a/master/internal/scheduler/kubernetes_resource_provider.go
+++ b/master/internal/scheduler/kubernetes_resource_provider.go
@@ -262,7 +262,7 @@ func (k *kubernetesResourceProvider) receivePodTerminated(
 	cid := ContainerID(msg.ContainerID)
 	task := k.tasksByContainerID[cid]
 	if task == nil {
-		ctx.Log().WithField("container id", cid).Info(
+		ctx.Log().WithField("container-id", cid).Info(
 			"ignoring stale terminated message for container",
 		)
 		return

--- a/master/internal/scheduler/task.go
+++ b/master/internal/scheduler/task.go
@@ -56,7 +56,7 @@ type (
 	// scheduler.
 	TerminateRequest struct{}
 	// TaskTerminated notifies the task actor that all of its containers have terminated.
-	TaskTerminated struct {}
+	TaskTerminated struct{}
 	// TaskAborted notifies the task actor that it was terminated before being scheduled.
 	TaskAborted struct{}
 	// TaskAssigned notifies the task actor that it has been assigned to run

--- a/master/internal/scheduler/task.go
+++ b/master/internal/scheduler/task.go
@@ -56,10 +56,7 @@ type (
 	// scheduler.
 	TerminateRequest struct{}
 	// TaskTerminated notifies the task actor that all of its containers have terminated.
-	TaskTerminated struct {
-		Task    TaskSummary
-		Aborted bool
-	}
+	TaskTerminated struct {}
 	// TaskAborted notifies the task actor that it was terminated before being scheduled.
 	TaskAborted struct{}
 	// TaskAssigned notifies the task actor that it has been assigned to run

--- a/master/internal/sproto/default_resource_provider.go
+++ b/master/internal/sproto/default_resource_provider.go
@@ -47,3 +47,18 @@ type (
 		agent.StartContainer
 	}
 )
+
+// Messages from agents to the RP.
+type (
+	//TaskStartedOnAgent notifies the resource provider that the task started on the agent.
+	TaskStartedOnAgent struct {
+		ContainerID      container.ID
+		ContainerStarted *agent.ContainerStarted
+	}
+
+	//TaskTerminatedOnAgent notifies the resource provider that the task has been terminated.
+	TaskTerminatedOnAgent struct {
+		ContainerID      container.ID
+		ContainerStopped *agent.ContainerStopped
+	}
+)

--- a/master/internal/sproto/kubernetes_resource_provider.go
+++ b/master/internal/sproto/kubernetes_resource_provider.go
@@ -9,9 +9,9 @@ import (
 type (
 	// StartPod notifies the pods actor to start a pod with the task spec.
 	StartPod struct {
-		Task  *actor.Ref
-		Spec  tasks.TaskSpec
-		Slots int
-		Rank  int
+		TaskHandler *actor.Ref
+		Spec        tasks.TaskSpec
+		Slots       int
+		Rank        int
 	}
 )

--- a/master/internal/sproto/kubernetes_resource_provider.go
+++ b/master/internal/sproto/kubernetes_resource_provider.go
@@ -2,6 +2,8 @@ package sproto
 
 import (
 	"github.com/determined-ai/determined/master/pkg/actor"
+	"github.com/determined-ai/determined/master/pkg/container"
+
 	"github.com/determined-ai/determined/master/pkg/tasks"
 )
 
@@ -13,5 +15,16 @@ type (
 		Spec        tasks.TaskSpec
 		Slots       int
 		Rank        int
+	}
+)
+
+// Kubernetes resource provider must accept these messages.
+type (
+	// PodStarted notifies the RP that the pod is now running.
+	PodStarted struct {
+		ContainerID     container.ID
+		IP              string
+		Ports           []int
+		NetworkProtocol string
 	}
 )

--- a/master/internal/sproto/kubernetes_resource_provider.go
+++ b/master/internal/sproto/kubernetes_resource_provider.go
@@ -17,6 +17,11 @@ type (
 		Slots       int
 		Rank        int
 	}
+
+	// StopPod notifies the pod actor to stop a pod associated with the container id.
+	StopPod struct {
+		ContainerID string
+	}
 )
 
 // Kubernetes resource provider must accept these messages.

--- a/master/internal/sproto/kubernetes_resource_provider.go
+++ b/master/internal/sproto/kubernetes_resource_provider.go
@@ -2,6 +2,7 @@ package sproto
 
 import (
 	"github.com/determined-ai/determined/master/pkg/actor"
+	"github.com/determined-ai/determined/master/pkg/agent"
 	"github.com/determined-ai/determined/master/pkg/container"
 
 	"github.com/determined-ai/determined/master/pkg/tasks"
@@ -26,5 +27,11 @@ type (
 		IP              string
 		Ports           []int
 		NetworkProtocol string
+	}
+
+	// PodTerminated notifies the RP that the pod is not stopped.
+	PodTerminated struct {
+		ContainerID      container.ID
+		ContainerStopped *agent.ContainerStopped
 	}
 )

--- a/master/internal/sproto/resource_providers.go
+++ b/master/internal/sproto/resource_providers.go
@@ -55,7 +55,7 @@ func (c ContainerLog) String() string {
 }
 
 // ContainerStateChanged notifies that the recipient container state has been transitioned.
-// It used by the resource providers to communicate with the task handlers.
+// It is used by the resource providers to communicate with the task handlers.
 type ContainerStateChanged struct {
 	Container        container.Container
 	ContainerStopped *agent.ContainerStopped

--- a/master/internal/sproto/resource_providers.go
+++ b/master/internal/sproto/resource_providers.go
@@ -55,11 +55,9 @@ func (c ContainerLog) String() string {
 }
 
 // ContainerStateChanged notifies that the recipient container state has been transitioned.
-// It used by the resource providers to communicate internally and with the task handlers.
+// It used by the resource providers to communicate with the task handlers.
 type ContainerStateChanged struct {
-	Container container.Container
-
-	ContainerStarted *agent.ContainerStarted
+	Container        container.Container
 	ContainerStopped *agent.ContainerStopped
 }
 

--- a/master/internal/sproto/resource_providers.go
+++ b/master/internal/sproto/resource_providers.go
@@ -17,7 +17,7 @@ import (
 )
 
 // ContainerLog notifies the task actor that a new log message is available for the container.
-// It used by the resource providers to communicate internally and with the task handlers.
+// It is used by the resource providers to communicate internally and with the task handlers.
 type ContainerLog struct {
 	Container container.Container
 	Timestamp time.Time

--- a/master/internal/trial.go
+++ b/master/internal/trial.go
@@ -801,7 +801,7 @@ func (t *trial) processTaskTerminated(ctx *actor.Context, msg scheduler.TaskTerm
 		status = classifyStatus(leaderState)
 	}
 
-	t.resetTrial(ctx, msg, status)
+	t.resetTrial(ctx, status)
 }
 
 func classifyStatus(state terminatedContainerWithState) agent.ContainerStopped {
@@ -818,7 +818,6 @@ func classifyStatus(state terminatedContainerWithState) agent.ContainerStopped {
 
 func (t *trial) resetTrial(
 	ctx *actor.Context,
-	msg scheduler.TaskTerminated,
 	status agent.ContainerStopped,
 ) {
 	terminationSent := t.terminationSent

--- a/master/internal/trial.go
+++ b/master/internal/trial.go
@@ -118,7 +118,6 @@ type rendezvousAddress struct {
 	ContainerIP   string `json:"container_ip"`
 	HostPort      int    `json:"host_port"`
 	HostIP        string `json:"host_ip"`
-	Protocol      string `json:"protocol"`
 }
 
 // terminatedContainerWithState records the terminatedContainer message with some state about the
@@ -697,7 +696,6 @@ func (t *trial) pushRendezvous(ctx *actor.Context) error {
 				ContainerIP:   addr.ContainerIP,
 				HostPort:      addr.HostPort,
 				HostIP:        addr.HostIP,
-				Protocol:      addr.Protocol,
 			})
 		}
 

--- a/master/pkg/agent/exit.go
+++ b/master/pkg/agent/exit.go
@@ -14,7 +14,7 @@ type ContainerFailure struct {
 }
 
 func (c ContainerFailure) Error() string {
-	return fmt.Sprintf("%s: %s", c.FailureType, c.ErrMsg)
+	return fmt.Sprintf("%s: %s %d", c.FailureType, c.ErrMsg, *c.ExitCode)
 }
 
 // ExitCode is the process exit code of the container.

--- a/master/pkg/agent/exit.go
+++ b/master/pkg/agent/exit.go
@@ -14,7 +14,7 @@ type ContainerFailure struct {
 }
 
 func (c ContainerFailure) Error() string {
-	return fmt.Sprintf("%s: %s %d", c.FailureType, c.ErrMsg, *c.ExitCode)
+	return fmt.Sprintf("%s: %s (exit code %d)", c.FailureType, c.ErrMsg, *c.ExitCode)
 }
 
 // ExitCode is the process exit code of the container.

--- a/master/pkg/container/state.go
+++ b/master/pkg/container/state.go
@@ -30,7 +30,7 @@ const (
 )
 
 var validTransitions = map[State]map[State]bool{
-	Assigned:   {Pulling: true, Terminated: true, Starting: true},
+	Assigned:   {Pulling: true, Terminated: true},
 	Pulling:    {Starting: true, Terminated: true},
 	Starting:   {Running: true, Terminated: true},
 	Running:    {Terminated: true},

--- a/master/pkg/container/state.go
+++ b/master/pkg/container/state.go
@@ -30,7 +30,7 @@ const (
 )
 
 var validTransitions = map[State]map[State]bool{
-	Assigned:   {Pulling: true, Terminated: true},
+	Assigned:   {Pulling: true, Terminated: true, Starting: true},
 	Pulling:    {Starting: true, Terminated: true},
 	Starting:   {Running: true, Terminated: true},
 	Running:    {Terminated: true},


### PR DESCRIPTION
## Description
This PR support terminating tasks (killed by user, or by task handler). It also addresses a several corner cases including: 1) collision in pod names, 2) updating scheduler and task handler when an error occurs in the pod actor, 3) handle case where Kubernetes sometimes transitions pod statuses to pending while they are being deleted.

We are now reviewing #839 as part of this also. That included changes to track pod lifecycles and to processes logs. As part of this PR, I modified several message types that are part of the default RP as well, including `sproto.ContainerStateChanged` and `scheduler.TaskTerminated`.

<s>This PR is blocked by: #839 and #798. The last 5 commits are the new changes that make up this PR.</s>

## Test Plan
Tested manually by spinning up a cluster. Automated testing will be added as part of M4. 
