### PR TITLE
feat: naive client-side trial logs download [DET-3521]

### DIFF
--- a/master/internal/core_trial.go
+++ b/master/internal/core_trial.go
@@ -67,39 +67,18 @@ func (m *Master) getTrialMetrics(c echo.Context) (interface{}, error) {
 
 func (m *Master) getTrialLogs(c echo.Context) error {
 	args := struct {
-		TrialID       int     `path:"trial_id"`
-		GreaterThanID *int    `query:"greater_than_id"`
-		LessThanID    *int    `query:"less_than_id"`
-		Limit         *int    `query:"tail"`
-		Format        *string `query:"format"`
+		TrialID       int  `path:"trial_id"`
+		GreaterThanID *int `query:"greater_than_id"`
+		LessThanID    *int `query:"less_than_id"`
+		Limit         *int `query:"tail"`
 	}{}
 	if err := api.BindArgs(&args, c); err != nil {
 		return err
 	}
-	trial, err := m.db.TrialByID(args.TrialID)
-	if err != nil {
-		return err
-	}
+
 	logs, err := m.db.TrialLogsRaw(args.TrialID, args.GreaterThanID, args.LessThanID, args.Limit)
 	if err != nil {
 		return err
-	}
-
-	if args.Format != nil && *args.Format == "raw" {
-		downloadable := ""
-		for _, log := range logs {
-			downloadable += string(log.Message)
-			logs = logs[1:]
-		}
-
-		c.Response().Header().Set(
-			"Content-Disposition",
-			fmt.Sprintf(
-				`attachment; filename="experiment_%d_trial_%d_logs.txt"`,
-				trial.ExperimentID,
-				args.TrialID))
-
-		return c.String(http.StatusOK, downloadable)
 	}
 
 	if len(logs) == 0 {

--- a/webui/react/src/components/LogViewer.stories.tsx
+++ b/webui/react/src/components/LogViewer.stories.tsx
@@ -1,5 +1,7 @@
 import React, { useEffect, useRef } from 'react';
 
+import { downloadText, simulateLogsDownload } from 'utils/browser';
+
 import LogViewer, { LogViewerHandles } from './LogViewer';
 
 export default {
@@ -7,13 +9,13 @@ export default {
   title: 'LogViewer',
 };
 
-export const Default = (): React.ReactNode => {
-  const logsRef = useRef<LogViewerHandles>(null);
-
-  const messageWithTags = `continuing trial: <COMPUTE_VALIDATION_METRICS: (10,10,30)>
+const messageWithTags = `continuing trial: <COMPUTE_VALIDATION_METRICS: (10,10,30)>
     experiment-id="10" id="c075adcd-5c31-4726-a5b3-0b87e141f1fe"
     system="master" trial-id="10" type="trial"
 `;
+
+export const Default = (): React.ReactNode => {
+  const logsRef = useRef<LogViewerHandles>(null);
 
   useEffect(() => {
     /* eslint-disable max-len */
@@ -90,4 +92,29 @@ export const Ansi = (): React.ReactNode => {
   });
 
   return <LogViewer ref={logsRef} title="ANSI Characters" />;
+};
+
+export const DefaultDownload = (): React.ReactNode => {
+  return <button onClick={() => downloadText('default-logs.txt', [ messageWithTags ])}>
+    Download Default Logs
+  </button>;
+};
+
+export const AnsiDownload = (): React.ReactNode => {
+  return <button onClick={() => downloadText('ansi-logs.txt', [ ansiText ])}>
+    Download Ansi Logs
+  </button>;
+};
+
+export const SimulatedDownload = (): React.ReactNode => {
+  const sizeRef = useRef<HTMLInputElement>(null);
+  return <div>
+    <div>
+      <label>Number of log characters to generate and download (rounded up): </label>
+      <input placeholder="Log size in characters" ref={sizeRef} type="number" />
+    </div>
+    <button onClick={() => simulateLogsDownload(parseInt(sizeRef.current?.value || '100000'))}>
+      Download
+    </button>
+  </div>;
 };

--- a/webui/react/src/components/LogViewer.tsx
+++ b/webui/react/src/components/LogViewer.tsx
@@ -14,7 +14,6 @@ import useScroll, { defaultScrollInfo } from 'hooks/useScroll';
 import { Log, LogLevel } from 'types';
 import { formatDatetime } from 'utils/date';
 import { ansiToHtml, copyToClipboard, toRem } from 'utils/dom';
-import { openBlank } from 'utils/routes';
 import { capitalize } from 'utils/string';
 
 import css from './LogViewer.module.scss';
@@ -23,12 +22,12 @@ interface Props {
   debugMode?: boolean;
   disableLevel?: boolean;
   disableLineNumber?: boolean;
-  downloadUrl?: string;
+  onDownload?: () => Promise<void>;
   isLoading?: boolean;
   noWrap?: boolean;
+  onScrollToTop?: (oldestLogId: number) => void;
   ref?: React.Ref<LogViewerHandles>;
   title: string;
-  onScrollToTop?: (oldestLogId: number) => void;
 }
 
 interface ViewerLog extends Log {
@@ -410,10 +409,6 @@ const LogViewer: React.FC<Props> = forwardRef((
     if (baseRef.current && screenfull.isEnabled) screenfull.toggle();
   }, []);
 
-  const handleDownload = useCallback(() => {
-    if (props.downloadUrl) openBlank(props.downloadUrl);
-  }, [ props.downloadUrl ]);
-
   const handleScrollToLatest = useCallback(() => {
     if (!container.current) return;
     container.current.scrollTo({ behavior: 'smooth', top: container.current.scrollHeight });
@@ -440,11 +435,11 @@ const LogViewer: React.FC<Props> = forwardRef((
           icon={<Icon name="fullscreen" />}
           onClick={handleFullScreen} />
       </Tooltip>
-      {props.downloadUrl && <Tooltip placement="bottomRight" title="Download Logs">
+      {props.onDownload && <Tooltip placement="bottomRight" title="Download Logs">
         <Button
           aria-label="Download Logs"
           icon={<Icon name="download" />}
-          onClick={handleDownload} />
+          onClick={props.onDownload} />
       </Tooltip>}
     </Space>
   );

--- a/webui/react/src/utils/browser.ts
+++ b/webui/react/src/utils/browser.ts
@@ -1,3 +1,7 @@
+import { getTrialDetails } from 'services/api';
+import * as DetSwagger from 'services/api-ts-sdk';
+import { consumeStream } from 'services/apiBuilder';
+
 const updateFavicon = (iconPath: string): void => {
   const linkEl: HTMLLinkElement | null = document.querySelector("link[rel*='shortcut icon']");
   if (!linkEl) return;
@@ -15,4 +19,63 @@ export const getCookie = (name: string): string | null => {
   const regex = new RegExp(`(?:(?:^|.*;\\s*)${name}\\s*\\=\\s*([^;]*).*$)|^.*$`);
   const value = document.cookie.replace(regex, '$1');
   return value ? value : null;
+};
+
+const downloadBlob = (filename: string, data: Blob): void => {
+  const url = window.URL.createObjectURL(data);
+  const element = document.createElement('a');
+  element.setAttribute('download', filename);
+  element.style.display = 'none';
+  element.href = url;
+  document.body.appendChild(element);
+  element.click();
+  window.URL.revokeObjectURL(url);
+  document.body.removeChild(element);
+};
+
+// Different JS engines impose different maximum string lenghts thus for downloading
+// large text we split it into different parts and then stich them together as a Blob
+export const downloadText = (filename: string, parts: BlobPart[]): void => {
+  const data = new Blob(parts, { type: 'text/plain' });
+  downloadBlob(filename, data);
+};
+
+export const downloadTrialLogs = async (trialId: number): Promise<void> => {
+  // String concatnation is fater than array.join https://jsben.ch/OJ3vo
+  // characters are utf16 encoded. v8 has different internal representations.
+  const MAX_PART_SIZE = 128 * Math.pow(2, 20); // 128m * CHAR_SIZE
+  const parts: BlobPart[] = [];
+  let downloadStringBuffer = '';
+  await consumeStream<DetSwagger.V1TrialLogsResponse>(
+    DetSwagger.ExperimentsApiFetchParamCreator().determinedTrialLogs(trialId),
+    (ev) => {
+      downloadStringBuffer += ev.message;
+      if (downloadStringBuffer.length > MAX_PART_SIZE) {
+        parts.push(downloadStringBuffer);
+        downloadStringBuffer = '';
+      }
+    },
+  );
+  if (downloadStringBuffer !== '') parts.push(downloadStringBuffer);
+  const trial = await getTrialDetails({ id: trialId });
+  downloadText(`experiment_${trial.experimentId}_trial_${trialId}_logs.txt`, parts);
+};
+
+const generateLogStringBuffer = (count: number, avgLength: number): string => {
+  const msg = new Array(avgLength).fill('a').join('') + '\n';
+  let stringBuffer = '';
+  for (let i=0; i<count; i++) {
+    stringBuffer += (i + msg);
+  }
+  return stringBuffer;
+};
+
+export const simulateLogsDownload = (numCharacters: number): number => {
+  const start = Date.now();
+  const MAX_PART_SIZE = 128 * Math.pow(2, 20); // 128m * CHAR_SIZE
+  const chunkCount = Math.ceil(numCharacters / MAX_PART_SIZE);
+  const parts = new Array(chunkCount).fill(0)
+    .map(() => generateLogStringBuffer(Math.pow(2, 20), 128));
+  downloadText('simulated-logs.txt', parts);
+  return (Date.now() - start);
 };


### PR DESCRIPTION
## Description

This changes buffering of trial logs from backend to client (the browser) and should eliminate the server crashes we've seen when downloading large trial logs. Same trial logs could still crash the browser but not the server. (the browser has no official API for streaming to file system more info on the ticket)
We can probably achieve a better memory footprint maybe using something like http://asmjs.org/ or reading more into how JS engines internally allocate and handle memory for different calls but we should see if we want to invest more time here or not.

## Test Plan

15643ms to buffer and download 3087007744 chars. total: ~3087007.744kB

client crashed at an attempt to buffer a 5GB Blob.

tested on chrome and firefox linux

## Commentary (optional)

we could look more into this and profile to see where we can get more wins.
dev usage of this depends on https://github.com/determined-ai/determined/pull/913

note: you'd have a problem downloading logs while the trial is running if you're using the react dev proxy and server. https://determinedai.atlassian.net/browse/DET-3638 will address that

<!-- User-facing API changes need the "User-facing API Change" label -->

<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

## Description

Lead with the intended commit body in this description field. For breaking changes, please include "BREAKING CHANGE:" at the beginning of your commit body. At minimum, this section should include a bracketed reference to the Jira ticket, e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.

## Test Plan

Describe the situations in which you've tested your change, and/or a screenshot as appropriate. Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.

## Commentary (optional)

Use this section of your description to add context to the PR. Could be for particularly tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc. You may intentionally leave this section blank and remove the title.
--->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234