### PR TITLE
chore: upgrade agent VM image to newer kernel version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,11 +96,11 @@ commands:
       - when:
           condition: <<parameters.tf1>>
           steps:
-            - run: docker pull determinedai/environments:py-3.6.9-pytorch-1.4-tf-1.14-cpu-0c9e956
+            - run: docker pull determinedai/environments:py-3.6.9-pytorch-1.4-tf-1.14-cpu-9c8c0bd
       - when:
           condition: <<parameters.tf2>>
           steps:
-            - run: docker pull determinedai/environments:py-3.6.9-pytorch-1.4-tf-2.2-cpu-0c9e956
+            - run: docker pull determinedai/environments:py-3.6.9-pytorch-1.4-tf-2.2-cpu-9c8c0bd
 
   login-docker:
     steps:

--- a/deploy/determined_deploy/aws/templates/secure.yaml
+++ b/deploy/determined_deploy/aws/templates/secure.yaml
@@ -4,11 +4,11 @@ Mappings:
   RegionMap:
     us-east-1:
       Master: ami-66506c1c
-      Agent: ami-007d24256bc2cc5ca
+      Agent: ami-05e22bfd09b7b25f3
       Bastion: ami-0a1262fb77d0911ef
     us-west-2:
       Master: ami-79873901
-      Agent: ami-0f00cd8ac6e73a52d
+      Agent: ami-038842e6cb3f1bbb8
       Bastion: ami-0ec8cdd8937453529
 
 Parameters:

--- a/deploy/determined_deploy/aws/templates/simple.yaml
+++ b/deploy/determined_deploy/aws/templates/simple.yaml
@@ -5,10 +5,10 @@ Mappings:
   RegionMap:
     us-east-1:
       Master: ami-66506c1c
-      Agent: ami-007d24256bc2cc5ca
+      Agent: ami-05e22bfd09b7b25f3
     us-west-2:
       Master: ami-79873901
-      Agent: ami-0f00cd8ac6e73a52d
+      Agent: ami-038842e6cb3f1bbb8
 
 Parameters:
   Keypair:

--- a/deploy/determined_deploy/aws/templates/vpc.yaml
+++ b/deploy/determined_deploy/aws/templates/vpc.yaml
@@ -4,10 +4,10 @@ Mappings:
   RegionMap:
     us-east-1:
       Master: ami-66506c1c
-      Agent: ami-007d24256bc2cc5ca
+      Agent: ami-05e22bfd09b7b25f3
     us-west-2:
       Master: ami-79873901
-      Agent: ami-0f00cd8ac6e73a52d
+      Agent: ami-038842e6cb3f1bbb8
 
 Parameters:
   VpcCIDR:

--- a/deploy/determined_deploy/gcp/constants.py
+++ b/deploy/determined_deploy/gcp/constants.py
@@ -2,7 +2,7 @@ class defaults:
 
     AGENT_INSTANCE_TYPE = "n1-standard-32"
     DB_PASSWORD = "postgres"
-    ENVIRONMENT_IMAGE = "pedl-environments-0c9e956"
+    ENVIRONMENT_IMAGE = "pedl-environments-9c8c0bd"
     GPU_NUM = 8
     GPU_TYPE = "nvidia-tesla-k80"
     MASTER_INSTANCE_TYPE = "n1-standard-2"

--- a/e2e_tests/tests/config.py
+++ b/e2e_tests/tests/config.py
@@ -10,10 +10,10 @@ MAX_TASK_SCHEDULED_SECS = 30
 MAX_TRIAL_BUILD_SECS = 90
 
 
-TF1_CPU_IMAGE = "determinedai/environments:py-3.6.9-pytorch-1.4-tf-1.14-cpu-0c9e956"
-TF2_CPU_IMAGE = "determinedai/environments:py-3.6.9-pytorch-1.4-tf-2.2-cpu-0c9e956"
-TF1_GPU_IMAGE = "determinedai/environments:cuda-10.0-pytorch-1.4-tf-1.14-gpu-0c9e956"
-TF2_GPU_IMAGE = "determinedai/environments:cuda-10.1-pytorch-1.4-tf-2.2-gpu-0c9e956"
+TF1_CPU_IMAGE = "determinedai/environments:py-3.6.9-pytorch-1.4-tf-1.14-cpu-9c8c0bd"
+TF2_CPU_IMAGE = "determinedai/environments:py-3.6.9-pytorch-1.4-tf-2.2-cpu-9c8c0bd"
+TF1_GPU_IMAGE = "determinedai/environments:cuda-10.0-pytorch-1.4-tf-1.14-gpu-9c8c0bd"
+TF2_GPU_IMAGE = "determinedai/environments:cuda-10.1-pytorch-1.4-tf-2.2-gpu-9c8c0bd"
 
 
 def fixtures_path(path: str) -> str:

--- a/master/pkg/model/defaults.go
+++ b/master/pkg/model/defaults.go
@@ -96,8 +96,8 @@ func DefaultExperimentConfig() ExperimentConfig {
 		BatchesPerStep: 100,
 		Environment: Environment{
 			Image: RuntimeItem{
-				CPU: "determinedai/environments:py-3.6.9-pytorch-1.4-tf-1.14-cpu-0c9e956",
-				GPU: "determinedai/environments:cuda-10.0-pytorch-1.4-tf-1.14-gpu-0c9e956",
+				CPU: "determinedai/environments:py-3.6.9-pytorch-1.4-tf-1.14-cpu-9c8c0bd",
+				GPU: "determinedai/environments:cuda-10.0-pytorch-1.4-tf-1.14-gpu-9c8c0bd",
 			},
 		},
 		Reproducibility: ReproducibilityConfig{


### PR DESCRIPTION
## Description

Upgrade the agent VM image to one built on top of a newer version of Ubuntu 16.04. This was motivated by a desire to mount a Lustre filesystem onto agent VMs, but the Lustre client requires a kernel version that is newer than what our base Ubuntu 16.04 image had.

The Docker contents did not change, but the change to the Environments repo changed the hash in the tag name, so we upgrade all references to the old hash to make the codebase consistent/easy to understand/easy to search.

## Test Plan

- [x] Manually confirm that the new environment image has a new enough kernel
- [ ] Run automated tests
- [x] Double check that the AMI ids are correct for both regions.

## Commentary (optional)

This PR is a replacement to https://github.com/determined-ai/determined/pull/801, with the branch created from the main Determined repo so that we can manually trigger all tests.
