### PR TITLE
fix: fix nonroot dtrain and nonroot shell [DET-3111]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,11 +96,11 @@ commands:
       - when:
           condition: <<parameters.tf1>>
           steps:
-            - run: docker pull determinedai/environments:py-3.6.9-pytorch-1.4-tf-1.15-cpu-f2038fa
+            - run: docker pull determinedai/environments:py-3.6.9-pytorch-1.4-tf-1.15-cpu-23863bb
       - when:
           condition: <<parameters.tf2>>
           steps:
-            - run: docker pull determinedai/environments:py-3.6.9-pytorch-1.4-tf-2.2-cpu-f2038fa
+            - run: docker pull determinedai/environments:py-3.6.9-pytorch-1.4-tf-2.2-cpu-23863bb
 
   login-docker:
     steps:

--- a/cli/determined_cli/command.py
+++ b/cli/determined_cli/command.py
@@ -36,7 +36,17 @@ _CONFIG_PATHS_COERCE_TO_LIST = {
 
 Command = namedtuple(
     "Command",
-    ["id", "owner", "registered_time", "config", "state", "addresses", "exit_status", "misc"],
+    [
+        "id",
+        "owner",
+        "registered_time",
+        "config",
+        "state",
+        "addresses",
+        "exit_status",
+        "misc",
+        "agent_user_group",
+    ],
 )
 
 CommandDescription = namedtuple(

--- a/deploy/determined_deploy/aws/templates/secure.yaml
+++ b/deploy/determined_deploy/aws/templates/secure.yaml
@@ -4,11 +4,11 @@ Mappings:
   RegionMap:
     us-east-1:
       Master: ami-66506c1c
-      Agent: ami-0a44078fce383b003
+      Agent: ami-0c6f00e65049f009c
       Bastion: ami-0a1262fb77d0911ef
     us-west-2:
       Master: ami-79873901
-      Agent: ami-07d56bd3ddf1702ed
+      Agent: ami-00eb27f81ce3b3211
       Bastion: ami-0ec8cdd8937453529
 
 Parameters:

--- a/deploy/determined_deploy/aws/templates/simple.yaml
+++ b/deploy/determined_deploy/aws/templates/simple.yaml
@@ -5,10 +5,10 @@ Mappings:
   RegionMap:
     us-east-1:
       Master: ami-66506c1c
-      Agent: ami-0a44078fce383b003
+      Agent: ami-0c6f00e65049f009c
     us-west-2:
       Master: ami-79873901
-      Agent: ami-07d56bd3ddf1702ed
+      Agent: ami-00eb27f81ce3b3211
 
 Parameters:
   Keypair:

--- a/deploy/determined_deploy/aws/templates/vpc.yaml
+++ b/deploy/determined_deploy/aws/templates/vpc.yaml
@@ -4,10 +4,10 @@ Mappings:
   RegionMap:
     us-east-1:
       Master: ami-66506c1c
-      Agent: ami-0a44078fce383b003
+      Agent: ami-0c6f00e65049f009c
     us-west-2:
       Master: ami-79873901
-      Agent: ami-07d56bd3ddf1702ed
+      Agent: ami-00eb27f81ce3b3211
 
 Parameters:
   VpcCIDR:

--- a/deploy/determined_deploy/gcp/constants.py
+++ b/deploy/determined_deploy/gcp/constants.py
@@ -2,7 +2,7 @@ class defaults:
 
     AGENT_INSTANCE_TYPE = "n1-standard-32"
     DB_PASSWORD = "postgres"
-    ENVIRONMENT_IMAGE = "pedl-environments-f2038fa"
+    ENVIRONMENT_IMAGE = "pedl-environments-23863bb"
     GPU_NUM = 8
     GPU_TYPE = "nvidia-tesla-k80"
     MASTER_INSTANCE_TYPE = "n1-standard-2"

--- a/e2e_tests/tests/config.py
+++ b/e2e_tests/tests/config.py
@@ -10,10 +10,10 @@ MAX_TASK_SCHEDULED_SECS = 30
 MAX_TRIAL_BUILD_SECS = 90
 
 
-TF1_CPU_IMAGE = "determinedai/environments:py-3.6.9-pytorch-1.4-tf-1.15-cpu-f2038fa"
-TF2_CPU_IMAGE = "determinedai/environments:py-3.6.9-pytorch-1.4-tf-2.2-cpu-f2038fa"
-TF1_GPU_IMAGE = "determinedai/environments:cuda-10.0-pytorch-1.4-tf-1.15-gpu-f2038fa"
-TF2_GPU_IMAGE = "determinedai/environments:cuda-10.1-pytorch-1.4-tf-2.2-gpu-f2038fa"
+TF1_CPU_IMAGE = "determinedai/environments:py-3.6.9-pytorch-1.4-tf-1.15-cpu-23863bb"
+TF2_CPU_IMAGE = "determinedai/environments:py-3.6.9-pytorch-1.4-tf-2.2-cpu-23863bb"
+TF1_GPU_IMAGE = "determinedai/environments:cuda-10.0-pytorch-1.4-tf-1.15-gpu-23863bb"
+TF2_GPU_IMAGE = "determinedai/environments:cuda-10.1-pytorch-1.4-tf-2.2-gpu-23863bb"
 
 
 def fixtures_path(path: str) -> str:

--- a/master/internal/command/summary.go
+++ b/master/internal/command/summary.go
@@ -28,6 +28,7 @@ type (
 		ExitStatus     *string                `json:"exit_status"`
 		Misc           map[string]interface{} `json:"misc"`
 		IsReady        bool                   `json:"is_ready"`
+		AgentUserGroup *model.AgentUserGroup  `json:"agent_user_group"`
 	}
 )
 
@@ -51,5 +52,6 @@ func newSummary(c *command) summary {
 		ExitStatus:     c.exitStatus,
 		Misc:           c.metadata,
 		IsReady:        c.readinessMessageSent,
+		AgentUserGroup: c.agentUserGroup,
 	}
 }

--- a/master/pkg/model/defaults.go
+++ b/master/pkg/model/defaults.go
@@ -96,8 +96,8 @@ func DefaultExperimentConfig() ExperimentConfig {
 		BatchesPerStep: 100,
 		Environment: Environment{
 			Image: RuntimeItem{
-				CPU: "determinedai/environments:py-3.6.9-pytorch-1.4-tf-1.15-cpu-f2038fa",
-				GPU: "determinedai/environments:cuda-10.0-pytorch-1.4-tf-1.15-gpu-f2038fa",
+				CPU: "determinedai/environments:py-3.6.9-pytorch-1.4-tf-1.15-cpu-23863bb",
+				GPU: "determinedai/environments:cuda-10.0-pytorch-1.4-tf-1.15-gpu-23863bb",
 			},
 		},
 		Reproducibility: ReproducibilityConfig{

--- a/master/static/srv/entrypoint.sh
+++ b/master/static/srv/entrypoint.sh
@@ -7,6 +7,17 @@ WORKING_DIR="/run/determined/workdir"
 STARTUP_HOOK="startup-hook.sh"
 export PATH="/run/determined/pythonuserbase/bin:$PATH"
 
+# If HOME is not explicitly set for a container, libcontainer (Docker) will
+# try to guess it by reading /etc/password directly, which will not work with
+# our linss_determined plugin (or any user-defined NSS plugin in a container).
+# The default is "/", but HOME must be a writable location for distributed
+# training, so we try to query the user system for a valid HOME, or default to
+# the working directory otherwise.
+if [ "$HOME" = "/" ] ; then
+    HOME="$(getent passwd "$(whoami)" | cut -d: -f6)" || HOME="$WORKING_DIR"
+    export HOME
+fi
+
 python3.6 -m pip install --user /opt/determined/wheels/determined*.whl
 
 cd ${WORKING_DIR} && test -f "${STARTUP_HOOK}" && source "${STARTUP_HOOK}"

--- a/master/static/srv/sshd_config
+++ b/master/static/srv/sshd_config
@@ -73,4 +73,4 @@ Subsystem sftp /usr/lib/openssh/sftp-server
 # If you just want the PAM account and session checks to run without
 # PAM authentication, then enable this but set PasswordAuthentication
 # and ChallengeResponseAuthentication to 'no'.
-UsePAM yes
+UsePAM no


### PR DESCRIPTION
## Description

Inject auxiliary passwd, shadow, and group files to augment the user
system inside the container.  This functionality depends on
libnss_determined being installed in the container.

This change also augments the command summary to include the
AgentUserGroup that each command is running with, and that information
is used by the CLI to choose the username when connecting to the sshd
server inside a shell container.

Finally, UsePAM was disabled in the sshd_config file, since the man page
explains that UsePAM is incompatible with running sshd as a non-root
user.  An alternate solution would be to run sshd as root but only
inject keys for the nonroot user, but that would have introduced the
following drawbacks:
  - It might not have satisfied some security-sensitive organizations.
  - It would not have worked for dtrain, which needs to run as non-root.
  - It would have been a larger divergence from the other command infra.

## Test Plan

Manual testing for shell and dtrain are both passing.

e2e tests for shell can only land after the default environment image is updated.  Order of landing this change, the environment change, and the e2e tests is flexible based on reviewer input.