### PR TITLE
docs: add docs on data access for dtrain [DET-3506]

### DIFF
--- a/docs/how-to/distributed-training.txt
+++ b/docs/how-to/distributed-training.txt
@@ -51,14 +51,20 @@ Example configuration with distributed training:
 Data Downloading
 -------------------
 
-In distributed training, we create one training process per GPU. Each process is given a unique ``rank`` which
-is just a unique number used to let the process know which GPU it was created on. In distributed training there
-can be multiple processes downloading data concurrently. To ensure that they don't accidentally overwrite
-each other, you should make sure to always download data to a directory whose name includes the ``rank`` of
-the process that is downloading the data.
+When performing distributed training, Determined will automatically
+create one process for every GPU that is being used for training. Each
+process will attempt to download training and/or validation data, so
+care should be taken to ensure that concurrent data downloads do not
+conflict with one another. One way to do this is to include a unique
+identifier in the local file system path where the downloaded data is
+stored. A convenient identifier is the ``rank`` of the current process:
+a process's ``rank`` is automatically assigned by Determined, and will
+be unique among all the processes in a trial.
 
 You can do this by leveraging the  :func:`self.context.distributed.get_rank() <determined._train_context.DistributedContext.get_rank>` function.
-Below is an example of how to do this when downloading data from S3.
+Below is an example of how to do this when downloading data from
+S3. In this example, the S3 bucket name is configured via a field
+``data.bucket`` in the experiment configuration.
 
 .. code:: python
 

--- a/docs/how-to/distributed-training.txt
+++ b/docs/how-to/distributed-training.txt
@@ -47,6 +47,37 @@ Example configuration with distributed training:
    resources:
      slots_per_trial: N
 
+
+Data Downloading
+-------------------
+
+In distributed training, we create one training process per GPU. Each process is given a unique ``rank`` which
+is just a unique number used to let the process know which GPU it was created on. In distributed training there
+can be multiple processes downloading data concurrently. To ensure that they don't accidentally overwrite
+each other, you should make sure to always download data to a directory whose name includes the ``rank`` of
+the process that is downloading the data.
+
+You can do this by leveraging the  :func:`self.context.distributed.get_rank() <determined._train_context.DistributedContext.get_rank>` function.
+Below is an example of how to do this when downloading data from S3.
+
+.. code:: python
+
+  import boto3
+  import os
+
+  def download_data_from_s3(self):
+      s3_bucket = self.context.get_data_config()["bucket"]
+      download_directory = f"/tmp/data-rank{self.context.distributed.get_rank()}"
+      data_file = "data.csv"
+
+      s3 = boto3.client("s3")
+      os.makedirs(download_directory, exist_ok=True)
+      filepath = os.path.join(download_directory, data_file)
+      if not os.path.exists(filepath):
+          s3.download_file(s3_bucket, data_file, filepath)
+      return download_directory
+
+
 Scheduling Behavior
 -------------------
 

--- a/docs/tutorials/data-access.txt
+++ b/docs/tutorials/data-access.txt
@@ -23,7 +23,7 @@ Once security access has been configured, we can use open-source libraries such 
 Downloading from Object Storage
 """""""""""""""""""""""""""""""
 
-The example below demonstrates how to download data from S3 using ``boto``. The S3 bucket name is specified in the experiment config file (using a field named ``data.bucket``). The ``download_directory`` variable defines where data that is downloaded from S3 will be stored. Note that we include :func:`self.context.distributed.get_rank() <determined._train_context.DistributedContext.get_rank>` in the name of this directory: when doing distributed training, multiple processes might be downloading data concurrently (one process per GPU), so embedding the rank in the directory name ensures that these processes do not conflict with one another.
+The example below demonstrates how to download data from S3 using ``boto``. The S3 bucket name is specified in the experiment config file (using a field named ``data.bucket``). The ``download_directory`` variable defines where data that is downloaded from S3 will be stored. Note that we include :func:`self.context.distributed.get_rank() <determined._train_context.DistributedContext.get_rank>` in the name of this directory: when doing distributed training, multiple processes might be downloading data concurrently (one process per GPU), so embedding the rank in the directory name ensures that these processes do not conflict with one another. For more detail, see the :ref:`Distributed Training How-To Guide<multi-gpu-training>`.
 
 Once the download directory has been created, ``s3.download_file(s3_bucket, data_file, filepath)`` fetches the file from S3 and stores it at the specified location. The data can then be accessed in the ``download_directory``.
 

--- a/harness/determined/_train_context.py
+++ b/harness/determined/_train_context.py
@@ -134,7 +134,7 @@ class DistributedContext:
     """
     DistributedContext extends all TrialContexts and NativeContexts under
     the ``context.distributed`` namespace. It provides useful methods for
-    effective multi-slot (parallel and distributed) training.
+    effective distributed training.
     """
 
     def __init__(self, env: det.EnvContext, hvd_config: horovod.HorovodContext):
@@ -143,7 +143,9 @@ class DistributedContext:
 
     def get_rank(self) -> int:
         """
-        Return the rank of the process in the trial.
+        Return the rank of the process in the trial. The rank of a process is a
+        unique ID within the trial; that is, no two processes in the same trial
+        will be assigned the same rank.
         """
         if not self._hvd_config.use:
             return 0
@@ -152,7 +154,10 @@ class DistributedContext:
 
     def get_local_rank(self) -> int:
         """
-        Return the rank of the process on the agent.
+        Return the rank of the process on the agent. The local rank of a process
+        is a unique ID within a given agent and trial; that is, no two processes
+        in the same trial that are executing on the same agent will be assigned
+        the same rank.
         """
         if not self._hvd_config.use:
             return 0


### PR DESCRIPTION
## Description

Add documentation around data access to the Distributed Training How-To Guide.

Briefly explain what ranks are and why data download directories should include the rank in their name. The motivation was that this is an important detail and was hidden in a subsection that distributed training users were unlikely to find.

## Test Plan



## Commentary (optional)

- @shiyuann The ticket says to link to the examples, but I'm not sure what examples we are talking about. If you point me in the right direction, I will update this PR accordingly.
- The docs are clearer if you go through the How-To Guide, but the data access tutorial still doesn't highlight this info. Should we add a new section to the Data Access Tutorial that talks about DTrain?

