### PR TITLE
feat: clean up kubernetes resources on startup [DET-3421]

### DIFF
--- a/master/internal/kubernetes/pod.go
+++ b/master/internal/kubernetes/pod.go
@@ -382,7 +382,7 @@ func (p *pod) configureRunArchives(
 	// Create configMap of AdditionalFiles as .tar.gz archive.
 	archiveConfigMap, err := startConfigMap(
 		ctx,
-		createConfigMapSpec(p.podName, tarredArchives, p.namespace),
+		createConfigMapSpec(p.podName, tarredArchives, p.namespace, p.taskSpec.TaskID),
 		p.configMapInterface,
 	)
 	if err != nil {
@@ -397,7 +397,8 @@ func (p *pod) configureRunArchives(
 	}
 	initContainerEntrypointConfigMap, err := startConfigMap(
 		ctx,
-		createConfigMapSpec(p.podName, initContainerEntrypointArchive, p.namespace),
+		createConfigMapSpec(
+			p.podName, initContainerEntrypointArchive, p.namespace, p.taskSpec.TaskID),
 		p.configMapInterface,
 	)
 	if err != nil {

--- a/master/internal/kubernetes/volumes.go
+++ b/master/internal/kubernetes/volumes.go
@@ -84,11 +84,13 @@ func createConfigMapSpec(
 	namePrefix string,
 	data map[string][]byte,
 	namespace string,
+	taskID string,
 ) *k8sV1.ConfigMap {
 	return &k8sV1.ConfigMap{
 		ObjectMeta: metaV1.ObjectMeta{
 			GenerateName: namePrefix,
 			Namespace:    namespace,
+			Labels:       map[string]string{determinedLabel: taskID},
 		},
 		BinaryData: data,
 	}


### PR DESCRIPTION
## Description
We find all resources associated with the Determined label and delete them at start-up.

<s>This PR is blocker on #839 and #865. Only the last commit in this PR is part of this PR.</s>


## Test Plan
Tested this manually by spinning up a k8 cluster. 
