### PR TITLE
feat: add `--head` option for printing trial logs [DET-3527]

### DIFF
--- a/cli/determined_cli/trial.py
+++ b/cli/determined_cli/trial.py
@@ -189,11 +189,19 @@ args_description = [
                         action="store_true",
                         help="follow the logs of a running trial, similar to tail -f",
                     ),
-                    Arg(
-                        "--tail",
-                        type=int,
-                        help="number of lines to show, counting from the end "
-                        "of the log (default is all)",
+                    Group(
+                        Arg(
+                            "--head",
+                            type=int,
+                            help="number of lines to show, counting from the beginning "
+                            "of the log (default is all)",
+                        ),
+                        Arg(
+                            "--tail",
+                            type=int,
+                            help="number of lines to show, counting from the end "
+                            "of the log (default is all)",
+                        ),
                     ),
                 ],
             ),

--- a/common/determined_common/api/experiment.py
+++ b/common/determined_common/api/experiment.py
@@ -40,6 +40,9 @@ def logs(args: Namespace) -> None:
         return logs[-1]["id"] if logs else last_offset
 
     try:
+        if args.head is not None:
+            print_logs(0, args.head)
+            return
         if args.tail is not None:
             last_offset = print_logs(None, args.tail)
         else:
@@ -82,7 +85,9 @@ def follow_experiment_logs(master_url: str, exp_id: int) -> None:
     print("Following first trial with ID {}".format(first_trial_id))
 
     # Call `logs --follow` on the new trial.
-    logs_args = Namespace(trial_id=first_trial_id, follow=True, master=master_url, tail=None)
+    logs_args = Namespace(
+        trial_id=first_trial_id, master=master_url, head=None, tail=None, follow=True
+    )
     logs(logs_args)
 
 
@@ -157,7 +162,9 @@ def follow_test_experiment_logs(master_url: str, exp_id: int) -> None:
         elif r["state"] == constants.ERROR:
             print_progress(active_stage, ended=True)
             trial_id = r["trials"][0]["id"]
-            logs_args = Namespace(trial_id=trial_id, master=master_url, tail=None, follow=False)
+            logs_args = Namespace(
+                trial_id=trial_id, master=master_url, head=None, tail=None, follow=False
+            )
             logs(logs_args)
             sys.exit(1)
         else:

--- a/e2e_tests/tests/test_system.py
+++ b/e2e_tests/tests/test_system.py
@@ -287,6 +287,9 @@ def test_trial_logs() -> None:
     trial_id = exp.experiment_trials(experiment_id)[0]["id"]
     subprocess.check_call(["det", "-m", conf.make_master_url(), "trial", "logs", str(trial_id)])
     subprocess.check_call(
+        ["det", "-m", conf.make_master_url(), "trial", "logs", "--head", "10", str(trial_id)],
+    )
+    subprocess.check_call(
         ["det", "-m", conf.make_master_url(), "trial", "logs", "--tail", "10", str(trial_id)],
     )
 


### PR DESCRIPTION
## Description

In order to make it more convenient to work with long trial logs, this
change makes it possible to request and view a given number of entries
from the start of a trial's log with the `--head` option.

## Test Plan

- [x] run some trials and check that using `--head` does the right thing
- [x] check in the tests that the command at least runs without crashing

## Commentary (optional)

There are other log-printing CLI commands that could conceivably have the same option added, but the request was for trial logs, and I imagine that that's by far the most important case anyway.
