### PR TITLE
feat: support proxying for k8 [DET-3422]

### DIFF
--- a/master/internal/kubernetes/pod.go
+++ b/master/internal/kubernetes/pod.go
@@ -37,6 +37,7 @@ const (
 
 type pod struct {
 	cluster                  *actor.Ref
+	clusterID                string
 	taskHandler              *actor.Ref
 	clientSet                *k8sClient.Clientset
 	namespace                string
@@ -59,6 +60,7 @@ type pod struct {
 
 func newPod(
 	cluster *actor.Ref,
+	clusterID string,
 	taskHandler *actor.Ref,
 	clientSet *k8sClient.Clientset,
 	namespace string,
@@ -79,6 +81,7 @@ func newPod(
 
 	return &pod{
 		cluster:                  cluster,
+		clusterID:                clusterID,
 		taskHandler:              taskHandler,
 		clientSet:                clientSet,
 		namespace:                namespace,
@@ -348,7 +351,7 @@ func (p *pod) configureEnvVars(
 		slotIds = append(slotIds, strconv.Itoa(i))
 	}
 
-	envVarsMap["DET_CLUSTER_ID"] = "k8cluster"
+	envVarsMap["DET_CLUSTER_ID"] = p.clusterID
 	envVarsMap["DET_MASTER"] = fmt.Sprintf("%s:%d", p.masterIP, p.masterPort)
 	envVarsMap["DET_MASTER_HOST"] = p.masterIP
 	envVarsMap["DET_MASTER_ADDR"] = p.masterIP

--- a/master/internal/kubernetes/pod.go
+++ b/master/internal/kubernetes/pod.go
@@ -339,11 +339,12 @@ func (p *pod) configureEnvVars(
 	environment model.Environment,
 	deviceType device.Type,
 ) ([]k8sV1.EnvVar, error) {
-	// TODO (DET-3457): Include env variables set in experiment config.
-	if len(environment.EnvironmentVariables.For(deviceType)) > 0 {
-		return nil, errors.Errorf(
-			"kubernetes resource provider does not currently support environment " +
-				"variables set in the experiment config; use startup-hook.sh instead")
+	for _, envVar := range environment.EnvironmentVariables.For(deviceType) {
+		envVarSplit := strings.Split(envVar, "=")
+		if len(envVarSplit) != 2 {
+			return nil, errors.Errorf("unable to split envVar %s", envVar)
+		}
+		envVarsMap[envVarSplit[0]] = envVarSplit[1]
 	}
 
 	var slotIds []string

--- a/master/internal/kubernetes/pod.go
+++ b/master/internal/kubernetes/pod.go
@@ -543,6 +543,10 @@ func (p *pod) startPodForCommand(ctx *actor.Context) error {
 		return err
 	}
 
+	for _, port := range cmd.Config.Environment.Ports {
+		p.ports = append(p.ports, port)
+	}
+
 	envVars, err := p.configureEnvVars(
 		tasks.CommandEnvVars(p.taskSpec),
 		p.taskSpec.StartCommand.Config.Environment,

--- a/master/internal/kubernetes/pods.go
+++ b/master/internal/kubernetes/pods.go
@@ -28,6 +28,7 @@ type podMetadata struct {
 
 type pods struct {
 	cluster                  *actor.Ref
+	clusterID                string
 	namespace                string
 	masterServiceName        string
 	leaveKubernetesResources bool
@@ -50,12 +51,14 @@ func Initialize(
 	s *actor.System,
 	_ *echo.Echo,
 	c *actor.Ref,
+	clusterID string,
 	namespace string,
 	masterServiceName string,
 	leaveKubernetesResources bool,
 ) *actor.Ref {
 	podsActor, ok := s.ActorOf(actor.Addr("pods"), &pods{
 		cluster:                  c,
+		clusterID:                clusterID,
 		namespace:                namespace,
 		masterServiceName:        masterServiceName,
 		podNameToPodHandler:      make(map[string]*actor.Ref),
@@ -193,7 +196,7 @@ func (p *pods) startPodInformer(ctx *actor.Context) {
 
 func (p *pods) receiveStartPod(ctx *actor.Context, msg sproto.StartPod) error {
 	newPodHandler := newPod(
-		p.cluster, msg.TaskHandler, p.clientSet, p.namespace, p.masterIP,
+		p.cluster, p.clusterID, msg.TaskHandler, p.clientSet, p.namespace, p.masterIP,
 		p.masterPort, msg.Spec, msg.Slots, msg.Rank, p.podInterface,
 		p.configMapInterface, p.leaveKubernetesResources,
 	)

--- a/master/internal/scheduler/kubernetes_resource_provider.go
+++ b/master/internal/scheduler/kubernetes_resource_provider.go
@@ -68,6 +68,7 @@ func (k *kubernetesResourceProvider) Receive(ctx *actor.Context) error {
 			msg.System,
 			msg.Echo,
 			ctx.Self(),
+			k.clusterID,
 			k.config.Namespace,
 			k.config.MasterServiceName,
 			k.config.LeaveKubernetesResources,


### PR DESCRIPTION
## Description
This enables proxying for notebooks and Tensorboards. As part of this change we added support for parsing environment variables from strings to a map for the k8 RP. This was necessary to support Tensorboard. 

<s>This PR is blocked by: #839, #865, and #873. The last 3 commits are what make up this PR.</s>

## Test Plan
Tested manually by spinning a k8 cluster. 