### PR TITLE
feat: update helm chart for k8 RP [DET-3542]

### DIFF
--- a/helm/charts/determined/templates/master-config.yaml
+++ b/helm/charts/determined/templates/master-config.yaml
@@ -38,4 +38,34 @@ data:
     http_port: {{ .Values.httpPort }}
 
     scheduler:
-      type: fair_share
+      resource_provider:
+        type: "kubernetes"
+        namespace: {{ .Release.Namespace }}
+        slots_per_node: {{ required "A valid Values.slotsPerNode entry is required!" .Values.slotsPerNode }}
+        master_service_name: determined-master-service-{{ .Release.Name }}
+
+    {{ if .Values.taskContainerDefaults -}}
+    task_container_defaults:
+      {{- if .Values.taskContainerDefaults.shmSizeBytes }}
+      shm_size_bytes: {{ int $.Values.taskContainerDefaults.shmSizeBytes }}
+      {{- end }}
+      {{- if .Values.taskContainerDefaults.networkMode }}
+      network_mode: {{ .Values.taskContainerDefaults.networkMode }}
+      {{- end }}
+      {{- if .Values.taskContainerDefaults.dtrainNetworkInterface }}
+      dtrain_network_interface: {{ .Values.taskContainerDefaults.dtrainNetworkInterface }}
+      {{- end }}
+      {{- if .Values.taskContainerDefaults.ncclPortRange }}
+      nccl_port_range: {{ .Values.taskContainerDefaults.ncclPortRange }}
+      {{- end }}
+      {{- if .Values.taskContainerDefaults.glooPortRange }}
+      gloo_port_range: {{ .Values.taskContainerDefaults.glooPortRange }}
+      {{- end }}
+    {{ end }}
+
+    {{- if .Values.telemetry }}
+    {{- if .Values.telemetry.enabled }}
+    telemetry:
+      enabled: {{ .Values.telemetry.enabled }}
+    {{- end }}
+    {{- end }}

--- a/helm/charts/determined/templates/master-deployment.yaml
+++ b/helm/charts/determined/templates/master-deployment.yaml
@@ -34,6 +34,14 @@ spec:
           - name: master-config
             mountPath: /etc/determined/
             readOnly: true
+        resources:
+          requests:
+            {{- if .Values.masterCpuRequest }}
+            cpu: {{ .Values.masterCpuRequest  | quote }}
+            {{- end }}
+            {{- if .Values.masterMemRequest }}
+            memory: {{ .Values.masterMemRequest  | quote }}
+            {{- end}}
       volumes:
         - name: master-config
           configMap:

--- a/helm/charts/determined/templates/master-deployment.yaml
+++ b/helm/charts/determined/templates/master-deployment.yaml
@@ -23,7 +23,12 @@ spec:
       serviceAccount: determined-master-{{ .Release.Name }}
       containers:
       - name: determined-master-{{ .Release.Name }}
+        {{- if .Values.detVersion }}
+        # detVersion is used for CI to override the appVersion.
+        image: determinedai/determined-master:{{ .Values.detVersion }}
+        {{- else }}
         image: determinedai/determined-master:{{ required "A valid Chart.AppVersion entry required!" .Chart.AppVersion }}
+        {{- end }}
         imagePullPolicy: "Always"
         volumeMounts:
           - name: master-config

--- a/helm/charts/determined/templates/master-permissions.yaml
+++ b/helm/charts/determined/templates/master-permissions.yaml
@@ -24,8 +24,11 @@ rules:
     resources: ["services"]
     verbs: ["get"]
   - apiGroups: [""]
-    resources: ["pods"]
+    resources: ["pods", "events"]
     verbs: ["watch"]
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["list"]
 
 
 ---

--- a/helm/charts/determined/templates/master-permissions.yaml
+++ b/helm/charts/determined/templates/master-permissions.yaml
@@ -20,6 +20,12 @@ rules:
   - apiGroups: [""]
     resources: ["pods", "pods/status", "pods/log", "configmaps"]
     verbs: ["create", "get", "list", "delete"]
+  - apiGroups: [""]
+    resources: ["services"]
+    verbs: ["get"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["watch"]
 
 
 ---

--- a/helm/charts/determined/values.yaml
+++ b/helm/charts/determined/values.yaml
@@ -43,16 +43,18 @@ checkpointStorage:
   # endpointUrl: <endpoint_url>
 
 # This is the number of GPUs there are per machine. Determined uses this information when
-# scheduling multi-GPU tasks. Multi-gpu (distributed training) tasks will be scheduled as
-# slotsPerTask / slotsPerNode separate pods (tasks sizes that are not divisible by slotsPerNode
-# are never scheduled.
+# scheduling multi-GPU tasks. Each multi-GPU (distributed training) task will be scheduled as
+# a set of `slotsPerTask / slotsPerNode` separate pods, with each pod assigned to `slotsPerNode` GPUs.
+# Tasks sizes that are not divisible by `slotsPerNode` are never scheduled. If you have a cluster of
+# different size nodes (e.g., 4 and 8 GPUs per node), set the `slotsPerNode` to the smallest
+# common denominator.
 slotsPerNode:
 
 # Memory and CPU requirements for the master instance should be adjusted for scale.
 masterCpuRequest: "4"
 masterMemRequest: "8Gi"
 
-## Configure the task container defaults. Tasks include trials, commands, tensorboards and more.
+## Configure the task container defaults. Tasks include trials, commands, tensorboards notebooks and shells.
 ## For all task containers, shm_size_bytes and network_mode are configurable. For trials, the
 ## network interface used by distributed (multi-machine) training and ports used by the NCCL and
 ## GLOO libraries during distributed training are configurable. These default to auto-discovery and

--- a/helm/charts/determined/values.yaml
+++ b/helm/charts/determined/values.yaml
@@ -41,3 +41,25 @@ checkpointStorage:
   # accessKey: <access_key>
   # secretKey: <secret_key>
   # endpointUrl: <endpoint_url>
+
+# This is the number of GPUs there are per machine. Determined uses this information when
+# scheduling multi-GPU tasks. Multi-gpu (distributed training) tasks will be scheduled as
+# slotsPerTask / slotsPerNode separate pods (tasks sizes that are not divisible by slotsPerNode
+# are never scheduled.
+slotsPerNode:
+
+## Configure the task container defaults. Tasks include trials, commands, tensorboards and more.
+## For all task containers, shm_size_bytes and network_mode are configurable. For trials, the
+## network interface used by distributed (multi-machine) training and ports used by the NCCL and
+## GLOO libraries during distributed training are configurable. These default to auto-discovery and
+## random non-privileged ports, respectively.
+taskContainerDefaults:
+  shmSizeBytes: 4294967296
+  # networkMode: bridge
+  # dtrainNetworkInterface: <network interface name>
+  # ncclPortRange: <MIN:MAX>
+  # glooPortRange: <MIN:MAX>
+
+## Configure whether we collect anonymous information about the usage of Determined.
+telemetry:
+  enabled: true

--- a/helm/charts/determined/values.yaml
+++ b/helm/charts/determined/values.yaml
@@ -48,6 +48,10 @@ checkpointStorage:
 # are never scheduled.
 slotsPerNode:
 
+# Memory and CPU requirements for the master instance should be adjusted for scale.
+masterCpuRequest: "4"
+masterMemRequest: "8Gi"
+
 ## Configure the task container defaults. Tasks include trials, commands, tensorboards and more.
 ## For all task containers, shm_size_bytes and network_mode are configurable. For trials, the
 ## network interface used by distributed (multi-machine) training and ports used by the NCCL and


### PR DESCRIPTION
## Description
Added several missing configurations, made the k8 RP configurable, and added CPU and MEM request limits for the master.


## Test Plan
Tested manually by deploying on a k8 cluster. Automated testing will be added as part of M4.