### PR TITLE
fix: improve CLI's custom certificate handling [DET-3630]

### DIFF
--- a/cli/setup.py
+++ b/cli/setup.py
@@ -16,6 +16,7 @@ setup(
         "argcomplete==1.9.4",
         "gitpython==2.1.11",
         "packaging==19.0",
+        "pyOpenSSL>= 19.1.0",
         "python-dateutil==2.8.0",
         "requests>=2.20.0",
         "ruamel.yaml>=0.15.78",


### PR DESCRIPTION
## Description

Previously, the CLI used the standard library `ssl` module to store
unrecognized master certificates for future trusting, which only
supports extracting the leaf cert of the peer-provided chain [1]; it
therefore doesn't work well with internal CA setups, since Requests
needs but can't get the CA certificate. This shifts the logic to use
pyOpenSSL, which can extract the full chain and therefore satisfy
Requests's requests.

[1] https://bugs.python.org/issue18233

## Test Plan

- [x] connect to a server with a cert signed by an unrecognized CA (CLI prompts once to store the full cert chain, then works normally afterward)
- [x] connect to a server with a cert signed by a real CA (CLI works with no stored cert and no prompts)
- [x] connect to a server with a self-signed cert (CLI prompts once to store the cert, then works normally afterward)
- [x] connect to a server serving without TLS with an `https` master address (CLI catches the correct SSL error and prints the message about retrying without TLS)

(The first case is what didn't work before; the others are just staying the same.)

## Commentary

Somewhat relevant: If you have a stored cert and _then_ attempt to connect to a server with a real CA-signed cert, the cert won't be recognized, since we override the normal CA bundle. But that isn't made worse by this PR, shouldn't be a common occurrence, and will be annoying to fix (not a huge problem, but it'll lead to more refactoring than is happening here), so I'm not touching that case for now.
