### PR TITLE
feat: add ability to save Horovod timeline

### DIFF
--- a/docs/reference/experiment-config.txt
+++ b/docs/reference/experiment-config.txt
@@ -608,8 +608,8 @@ created with the Determined CLI. It may contain the following fields:
   - ``horovod_timeline``: The path in the container where the Horovod timeline should be saved,
     e.g. ``/root/horovod_timeline.json``. The
     Horovod timeline is a trace file that can be analyzed to investigate distributed
-    training performance. When this field is ``null``, the timeline is not created.
-    The timeline can grow very large during long training runs so it is recommended
+    training performance. When this field is ``null`` or an empty string, the timeline is
+    not created. The timeline can grow very large during long training runs so it is recommended
     that timeline generation is disabled when not actively investigating performance.
     Defaults to ``null``.
 

--- a/docs/reference/experiment-config.txt
+++ b/docs/reference/experiment-config.txt
@@ -611,7 +611,7 @@ created with the Determined CLI. It may contain the following fields:
     training performance. When this field is ``null``, the timeline is not created.
     The timeline can grow very large during long training runs so it is recommended
     that timeline generation is disabled when not actively investigating performance.
-    Defaults to ``null``
+    Defaults to ``null``.
 
 
 .. _data-layer_exp_config:

--- a/docs/reference/experiment-config.txt
+++ b/docs/reference/experiment-config.txt
@@ -605,6 +605,13 @@ created with the Determined CLI. It may contain the following fields:
     ``tensor_fusion_threshold`` and ``tensor_fusion_cycle_time`` automatically.
     Defaults to ``false``.
 
+  - ``horovod_timeline``: The path where the Horovod should be timeline saved. The
+    Horovod timeline is a trace file that can be analyzed to investigate distributed
+    training performance. When this field is ``None`` or an empty string, the timeline is not created.
+    The timeline can grow very large during long training runs so it is recommended
+    that timeline generation is disabled when not actively investigating performance.
+    Defaults to ``None``
+
 
 .. _data-layer_exp_config:
 

--- a/docs/reference/experiment-config.txt
+++ b/docs/reference/experiment-config.txt
@@ -605,12 +605,13 @@ created with the Determined CLI. It may contain the following fields:
     ``tensor_fusion_threshold`` and ``tensor_fusion_cycle_time`` automatically.
     Defaults to ``false``.
 
-  - ``horovod_timeline``: The path where the Horovod should be timeline saved. The
+  - ``horovod_timeline``: The path in the container where the Horovod timeline should be saved,
+    e.g. ``/root/horovod_timeline.json``. The
     Horovod timeline is a trace file that can be analyzed to investigate distributed
-    training performance. When this field is ``None``, the timeline is not created.
+    training performance. When this field is ``null``, the timeline is not created.
     The timeline can grow very large during long training runs so it is recommended
     that timeline generation is disabled when not actively investigating performance.
-    Defaults to ``None``
+    Defaults to ``null``
 
 
 .. _data-layer_exp_config:

--- a/docs/reference/experiment-config.txt
+++ b/docs/reference/experiment-config.txt
@@ -607,7 +607,7 @@ created with the Determined CLI. It may contain the following fields:
 
   - ``horovod_timeline``: The path where the Horovod should be timeline saved. The
     Horovod timeline is a trace file that can be analyzed to investigate distributed
-    training performance. When this field is ``None`` or an empty string, the timeline is not created.
+    training performance. When this field is ``None``, the timeline is not created.
     The timeline can grow very large during long training runs so it is recommended
     that timeline generation is disabled when not actively investigating performance.
     Defaults to ``None``

--- a/harness/determined/constants.py
+++ b/harness/determined/constants.py
@@ -27,6 +27,7 @@ DEFAULT_OPTIMIZATIONS = {
     "average_training_metrics": False,
     "gradient_compression": False,
     "mixed_precision": "O0",
+    "horovod_timeline": None
 }
 DEFAULT_EXP_CFG = {
     "searcher": DEFAULT_SEARCHER_CFG,

--- a/harness/determined/horovod.py
+++ b/harness/determined/horovod.py
@@ -197,6 +197,10 @@ class HorovodContext:
         self.grad_updates_size_file = grad_updates_size_file
         self.average_aggregated_gradients = average_aggregated_gradients
         self.average_training_metrics = average_training_metrics
+
+        if horovod_timeline == "":
+            horovod_timeline = None
+
         self.horovod_timeline = horovod_timeline
 
     @staticmethod

--- a/harness/determined/horovod.py
+++ b/harness/determined/horovod.py
@@ -189,7 +189,7 @@ class HorovodContext:
         grad_updates_size_file: str,
         average_aggregated_gradients: bool,
         average_training_metrics: bool,
-        horovod_timeline: str
+        horovod_timeline: Optional[str]
     ) -> None:
         self.use = use
         self.aggregation_frequency = aggregation_frequency
@@ -197,9 +197,6 @@ class HorovodContext:
         self.grad_updates_size_file = grad_updates_size_file
         self.average_aggregated_gradients = average_aggregated_gradients
         self.average_training_metrics = average_training_metrics
-
-        if horovod_timeline == "":
-            horovod_timeline = None
         self.horovod_timeline = horovod_timeline
 
     @staticmethod
@@ -264,7 +261,7 @@ class HorovodContext:
                 bool, optimizations_config.get("average_training_metrics")
             ),
             horovod_timeline=cast(
-                str, optimizations_config.get("horovod_timeline", "")
+                Optional[str], optimizations_config.get("horovod_timeline")
             ),
         )
 

--- a/harness/tests/experiment/utils.py
+++ b/harness/tests/experiment/utils.py
@@ -93,6 +93,7 @@ def make_default_exp_config(hparams: Dict[str, Any], batches_per_step: int) -> D
             "aggregation_frequency": 1,
             "gradient_compression": False,
             "average_training_metrics": False,
+            "horovod_timeline": "",
         },
         "data_layer": {"type": "shared_fs"},
     }
@@ -152,6 +153,7 @@ def make_default_hvd_config() -> horovod.HorovodContext:
         grad_updates_size_file="",
         average_aggregated_gradients=True,
         average_training_metrics=False,
+        horovod_timeline=None,
     )
 
 

--- a/harness/tests/experiment/utils.py
+++ b/harness/tests/experiment/utils.py
@@ -93,7 +93,7 @@ def make_default_exp_config(hparams: Dict[str, Any], batches_per_step: int) -> D
             "aggregation_frequency": 1,
             "gradient_compression": False,
             "average_training_metrics": False,
-            "horovod_timeline": "",
+            "horovod_timeline": None,
         },
         "data_layer": {"type": "shared_fs"},
     }

--- a/master/pkg/model/defaults.go
+++ b/master/pkg/model/defaults.go
@@ -92,6 +92,7 @@ func DefaultExperimentConfig() ExperimentConfig {
 			TensorFusionThreshold:      64,
 			TensorFusionCycleTime:      5,
 			AutoTuneTensorFusion:       false,
+			HorovodTimeline:       		"",
 		},
 		BatchesPerStep: 100,
 		Environment: Environment{

--- a/master/pkg/model/defaults.go
+++ b/master/pkg/model/defaults.go
@@ -92,7 +92,7 @@ func DefaultExperimentConfig() ExperimentConfig {
 			TensorFusionThreshold:      64,
 			TensorFusionCycleTime:      5,
 			AutoTuneTensorFusion:       false,
-			HorovodTimeline:       		nil,
+			HorovodTimeline:            "",
 		},
 		BatchesPerStep: 100,
 		Environment: Environment{

--- a/master/pkg/model/defaults.go
+++ b/master/pkg/model/defaults.go
@@ -92,7 +92,7 @@ func DefaultExperimentConfig() ExperimentConfig {
 			TensorFusionThreshold:      64,
 			TensorFusionCycleTime:      5,
 			AutoTuneTensorFusion:       false,
-			HorovodTimeline:       		"",
+			HorovodTimeline:       		nil,
 		},
 		BatchesPerStep: 100,
 		Environment: Environment{

--- a/master/pkg/model/experiment_config.go
+++ b/master/pkg/model/experiment_config.go
@@ -192,7 +192,7 @@ type OptimizationsConfig struct {
 	TensorFusionThreshold      int    `json:"tensor_fusion_threshold"`
 	TensorFusionCycleTime      int    `json:"tensor_fusion_cycle_time"`
 	AutoTuneTensorFusion       bool   `json:"auto_tune_tensor_fusion"`
-	HorovodTimeline       	   string `json:"horoovd_timeline"`
+	HorovodTimeline            string `json:"horovod_timeline"`
 }
 
 // Validate implements the check.Validatable interface.

--- a/master/pkg/model/experiment_config.go
+++ b/master/pkg/model/experiment_config.go
@@ -192,6 +192,7 @@ type OptimizationsConfig struct {
 	TensorFusionThreshold      int    `json:"tensor_fusion_threshold"`
 	TensorFusionCycleTime      int    `json:"tensor_fusion_cycle_time"`
 	AutoTuneTensorFusion       bool   `json:"auto_tune_tensor_fusion"`
+	HorovodTimeline       	   string `json:"horoovd_timeline"`
 }
 
 // Validate implements the check.Validatable interface.

--- a/master/pkg/model/experiment_config_test.go
+++ b/master/pkg/model/experiment_config_test.go
@@ -335,6 +335,7 @@ func TestExperiment(t *testing.T) {
 			TensorFusionThreshold:      64,
 			TensorFusionCycleTime:      5,
 			AutoTuneTensorFusion:       false,
+			HorovodTimeline:			"",
 		},
 		BatchesPerStep: 32,
 		BindMounts: []BindMount{

--- a/master/pkg/model/experiment_config_test.go
+++ b/master/pkg/model/experiment_config_test.go
@@ -335,7 +335,7 @@ func TestExperiment(t *testing.T) {
 			TensorFusionThreshold:      64,
 			TensorFusionCycleTime:      5,
 			AutoTuneTensorFusion:       false,
-			HorovodTimeline:			nil,
+			HorovodTimeline:            "",
 		},
 		BatchesPerStep: 32,
 		BindMounts: []BindMount{

--- a/master/pkg/model/experiment_config_test.go
+++ b/master/pkg/model/experiment_config_test.go
@@ -335,7 +335,7 @@ func TestExperiment(t *testing.T) {
 			TensorFusionThreshold:      64,
 			TensorFusionCycleTime:      5,
 			AutoTuneTensorFusion:       false,
-			HorovodTimeline:			"",
+			HorovodTimeline:			nil,
 		},
 		BatchesPerStep: 32,
 		BindMounts: []BindMount{


### PR DESCRIPTION
## Description

The goal of this PR is to enables advanced users to generate and save the Horovod timeline. In particular, this PR is intended to make it easier for us to help customers investigate DTrain performance because previously generating the timeline was quite involved.

There is some work that would need to be done in terms of smoothing out rough edges before the timeline would be valuable for non-expert users (the file grows too large, we haven't investigated what happens to the timeline file after recovering from a failure, the timeline is difficult for the average user to understand). This is why the documentation for this feature is limited.

## Test Plan

- [ ] Manually test (in-progress)


## Commentary (optional)


