### PR TITLE
feat: support task and agent summaries for k8 RP [DET-3424, DET-3425]

### DIFF
--- a/agent/internal/agent.go
+++ b/agent/internal/agent.go
@@ -302,7 +302,7 @@ func Run(version string, options Options) error {
 	server.Use(middleware.Recover())
 	server.Pre(middleware.RemoveTrailingSlash())
 
-	server.Any("/*", api.Route(system))
+	server.Any("/*", api.Route(system, nil))
 	server.Any("/debug/pprof/*", echo.WrapHandler(http.HandlerFunc(pprof.Index)))
 	server.Any("/debug/pprof/cmdline", echo.WrapHandler(http.HandlerFunc(pprof.Cmdline)))
 	server.Any("/debug/pprof/profile", echo.WrapHandler(http.HandlerFunc(pprof.Profile)))

--- a/master/internal/agent/agent.go
+++ b/master/internal/agent/agent.go
@@ -35,10 +35,11 @@ type agent struct {
 	uuid uuid.UUID
 }
 
-type agentSummary struct {
+// AgentSummary summarizes the state on an agent.
+type AgentSummary struct {
 	ID             string       `json:"id"`
 	RegisteredTime time.Time    `json:"registered_time"`
-	Slots          slotsSummary `json:"slots"`
+	Slots          SlotsSummary `json:"slots"`
 	NumContainers  int          `json:"num_containers"`
 	Label          string       `json:"label"`
 }
@@ -49,7 +50,7 @@ func (a *agent) Receive(ctx *actor.Context) error {
 		a.uuid = uuid.New()
 		a.slots, _ = ctx.ActorOf("slots", &slots{cluster: a.cluster})
 		a.containers = make(map[container.ID]*actor.Ref)
-	case agentSummary:
+	case AgentSummary:
 		ctx.Respond(a.summarize(ctx))
 	case ws.WebSocketConnected:
 		check.Panic(check.True(a.socket == nil, "websocket already connected"))
@@ -178,11 +179,11 @@ func (a *agent) containerStateChanged(ctx *actor.Context, sc aproto.ContainerSta
 	}
 }
 
-func (a *agent) summarize(ctx *actor.Context) agentSummary {
-	return agentSummary{
+func (a *agent) summarize(ctx *actor.Context) AgentSummary {
+	return AgentSummary{
 		ID:             ctx.Self().Address().Local(),
 		RegisteredTime: ctx.Self().RegisteredTime(),
-		Slots:          ctx.Ask(a.slots, slotsSummary{}).Get().(slotsSummary),
+		Slots:          ctx.Ask(a.slots, SlotsSummary{}).Get().(SlotsSummary),
 		NumContainers:  len(a.containers),
 		Label:          a.label,
 	}

--- a/master/internal/agent/agent.go
+++ b/master/internal/agent/agent.go
@@ -73,7 +73,7 @@ func (a *agent) Receive(ctx *actor.Context) error {
 	case aproto.MasterMessage:
 		a.handleIncomingWSMessage(ctx, msg)
 	case *proto.GetAgentRequest:
-		ctx.Respond(&proto.GetAgentResponse{Agent: toProtoAgent(a.summarize(ctx))})
+		ctx.Respond(&proto.GetAgentResponse{Agent: ToProtoAgent(a.summarize(ctx))})
 	case *proto.GetSlotsRequest:
 		var slots []*agentv1.Slot
 		for _, s := range a.summarize(ctx).Slots {
@@ -83,10 +83,10 @@ func (a *agent) Receive(ctx *actor.Context) error {
 		ctx.Respond(&proto.GetSlotsResponse{Slots: slots})
 	case *proto.EnableAgentRequest:
 		ctx.Tell(a.slots, patchSlot{Enabled: true})
-		ctx.Respond(&proto.EnableAgentResponse{Agent: toProtoAgent(a.summarize(ctx))})
+		ctx.Respond(&proto.EnableAgentResponse{Agent: ToProtoAgent(a.summarize(ctx))})
 	case *proto.DisableAgentRequest:
 		ctx.Tell(a.slots, patchSlot{Enabled: false})
-		ctx.Respond(&proto.DisableAgentResponse{Agent: toProtoAgent(a.summarize(ctx))})
+		ctx.Respond(&proto.DisableAgentResponse{Agent: ToProtoAgent(a.summarize(ctx))})
 	case echo.Context:
 		a.handleAPIRequest(ctx, msg)
 	case actor.ChildFailed:

--- a/master/internal/agent/agents.go
+++ b/master/internal/agent/agents.go
@@ -16,14 +16,14 @@ import (
 func Initialize(s *actor.System, e *echo.Echo, c *actor.Ref) {
 	_, ok := s.ActorOf(actor.Addr("agents"), &agents{cluster: c})
 	check.Panic(check.True(ok, "agents address already taken"))
-	e.Any("/agents*", api.Route(s))
+	e.Any("/agents*", api.Route(s, nil))
 }
 
 type agents struct {
 	cluster *actor.Ref
 }
 
-type agentsSummary map[string]agentSummary
+type agentsSummary map[string]AgentSummary
 
 func (a *agents) Receive(ctx *actor.Context) error {
 	switch msg := ctx.Message().(type) {
@@ -64,10 +64,10 @@ func (a *agents) handleAPIRequest(ctx *actor.Context, apiCtx echo.Context) {
 }
 
 func (a *agents) summarize(ctx *actor.Context) agentsSummary {
-	results := ctx.AskAll(agentSummary{}, ctx.Children()...).GetAll()
-	summary := make(map[string]agentSummary, len(results))
+	results := ctx.AskAll(AgentSummary{}, ctx.Children()...).GetAll()
+	summary := make(map[string]AgentSummary, len(results))
 	for ref, result := range results {
-		summary[ref.Address().String()] = result.(agentSummary)
+		summary[ref.Address().String()] = result.(AgentSummary)
 	}
 	return summary
 }

--- a/master/internal/agent/agents.go
+++ b/master/internal/agent/agents.go
@@ -42,7 +42,7 @@ func (a *agents) Receive(ctx *actor.Context) error {
 	case *apiv1.GetAgentsRequest:
 		response := &apiv1.GetAgentsResponse{}
 		for _, a := range a.summarize(ctx) {
-			response.Agents = append(response.Agents, toProtoAgent(a))
+			response.Agents = append(response.Agents, ToProtoAgent(a))
 		}
 		ctx.Respond(response)
 	case echo.Context:

--- a/master/internal/agent/proto.go
+++ b/master/internal/agent/proto.go
@@ -8,7 +8,7 @@ import (
 	proto "github.com/determined-ai/determined/proto/pkg/agentv1"
 )
 
-func toProtoAgent(a agentSummary) *proto.Agent {
+func toProtoAgent(a AgentSummary) *proto.Agent {
 	slots := make(map[string]*proto.Slot)
 	for _, s := range a.Slots {
 		slots[s.ID] = toProtoSlot(s)
@@ -25,7 +25,7 @@ func toProtoAgent(a agentSummary) *proto.Agent {
 	}
 }
 
-func toProtoSlot(s slotSummary) *proto.Slot {
+func toProtoSlot(s SlotSummary) *proto.Slot {
 	var c *proto.Container
 	if s.Container != nil {
 		c = toProtoContainer(*s.Container)

--- a/master/internal/agent/proto.go
+++ b/master/internal/agent/proto.go
@@ -8,7 +8,8 @@ import (
 	proto "github.com/determined-ai/determined/proto/pkg/agentv1"
 )
 
-func toProtoAgent(a AgentSummary) *proto.Agent {
+// ToProtoAgent converts agent summary to a proto struct.
+func ToProtoAgent(a AgentSummary) *proto.Agent {
 	slots := make(map[string]*proto.Slot)
 	for _, s := range a.Slots {
 		slots[s.ID] = toProtoSlot(s)

--- a/master/internal/agent/proto.go
+++ b/master/internal/agent/proto.go
@@ -8,7 +8,7 @@ import (
 	proto "github.com/determined-ai/determined/proto/pkg/agentv1"
 )
 
-// ToProtoAgent converts agent summary to a proto struct.
+// ToProtoAgent converts an agent summary to a proto struct.
 func ToProtoAgent(a AgentSummary) *proto.Agent {
 	slots := make(map[string]*proto.Slot)
 	for _, s := range a.Slots {

--- a/master/internal/agent/slot.go
+++ b/master/internal/agent/slot.go
@@ -34,7 +34,8 @@ func (s slotEnabled) Enabled() bool {
 	return s.agentEnabled && s.userEnabled
 }
 
-type slotSummary struct {
+// SlotSummary summarizes the state of a slot.
+type SlotSummary struct {
 	ID        string               `json:"id"`
 	Device    device.Device        `json:"device"`
 	Enabled   bool                 `json:"enabled"`
@@ -51,7 +52,7 @@ func (s *slot) Receive(ctx *actor.Context) error {
 	switch msg := ctx.Message().(type) {
 	case actor.PreStart:
 		s.patch(ctx)
-	case slotSummary:
+	case SlotSummary:
 		ctx.Respond(s.summarize(ctx))
 	case patchSlot:
 		s.enabled.userEnabled = msg.Enabled
@@ -131,8 +132,8 @@ func (s *slot) deviceID(ctx *actor.Context) sproto.DeviceID {
 	return sproto.DeviceID{Agent: ctx.Self().Parent().Parent(), Device: s.device}
 }
 
-func (s *slot) summarize(ctx *actor.Context) slotSummary {
-	return slotSummary{
+func (s *slot) summarize(ctx *actor.Context) SlotSummary {
+	return SlotSummary{
 		ID:        ctx.Self().Address().Local(),
 		Device:    s.device,
 		Enabled:   s.enabled.Enabled(),

--- a/master/internal/agent/slots.go
+++ b/master/internal/agent/slots.go
@@ -18,11 +18,12 @@ type slots struct {
 	cluster *actor.Ref
 }
 
-type slotsSummary map[string]slotSummary
+// SlotsSummary contains a summary for a number of slots.
+type SlotsSummary map[string]SlotSummary
 
 func (s *slots) Receive(ctx *actor.Context) error {
 	switch msg := ctx.Message().(type) {
-	case slotsSummary:
+	case SlotsSummary:
 		ctx.Respond(s.summarize(ctx))
 	case aproto.AgentStarted:
 		for _, d := range msg.Devices {
@@ -70,11 +71,11 @@ func (s *slots) handleAPIRequest(ctx *actor.Context, apiCtx echo.Context) {
 	}
 }
 
-func (s *slots) summarize(ctx *actor.Context) slotsSummary {
-	results := ctx.AskAll(slotSummary{}, ctx.Children()...).GetAll()
-	summary := make(map[string]slotSummary, len(results))
+func (s *slots) summarize(ctx *actor.Context) SlotsSummary {
+	results := ctx.AskAll(SlotSummary{}, ctx.Children()...).GetAll()
+	summary := make(map[string]SlotSummary, len(results))
 	for ref, result := range results {
-		summary[ref.Address().String()] = result.(slotSummary)
+		summary[ref.Address().String()] = result.(SlotSummary)
 	}
 	return summary
 }

--- a/master/internal/api_agents.go
+++ b/master/internal/api_agents.go
@@ -12,7 +12,7 @@ import (
 func (a *apiServer) GetAgents(
 	_ context.Context, req *apiv1.GetAgentsRequest) (resp *apiv1.GetAgentsResponse, err error) {
 	response := a.m.system.AskAt(
-		actor.Addr("resourceProviders"), sproto.GetEndpointActorName{}).Get()
+		actor.Addr("resourceProviders"), sproto.GetEndpointActorAddress{}).Get()
 	endpointActorName := response.(string)
 
 	err = a.actorRequest(endpointActorName, req, &resp)

--- a/master/internal/api_agents.go
+++ b/master/internal/api_agents.go
@@ -4,12 +4,18 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/determined-ai/determined/master/internal/sproto"
+	"github.com/determined-ai/determined/master/pkg/actor"
 	"github.com/determined-ai/determined/proto/pkg/apiv1"
 )
 
 func (a *apiServer) GetAgents(
 	_ context.Context, req *apiv1.GetAgentsRequest) (resp *apiv1.GetAgentsResponse, err error) {
-	err = a.actorRequest("/agents", req, &resp)
+	response := a.m.system.AskAt(
+		actor.Addr("resourceProviders"), sproto.GetEndpointActorName{}).Get()
+	endpointActorName := response.(sproto.EndpointActorName).ActorName
+
+	err = a.actorRequest(endpointActorName, req, &resp)
 	if err != nil {
 		return nil, err
 	}

--- a/master/internal/api_agents.go
+++ b/master/internal/api_agents.go
@@ -13,7 +13,7 @@ func (a *apiServer) GetAgents(
 	_ context.Context, req *apiv1.GetAgentsRequest) (resp *apiv1.GetAgentsResponse, err error) {
 	response := a.m.system.AskAt(
 		actor.Addr("resourceProviders"), sproto.GetEndpointActorName{}).Get()
-	endpointActorName := response.(sproto.EndpointActorName).ActorName
+	endpointActorName := response.(string)
 
 	err = a.actorRequest(endpointActorName, req, &resp)
 	if err != nil {

--- a/master/internal/command/api.go
+++ b/master/internal/command/api.go
@@ -23,26 +23,26 @@ func RegisterAPIHandler(
 		db:                    db,
 		clusterID:             cID,
 	})
-	echo.Any("/commands*", api.Route(system), middleware...)
+	echo.Any("/commands*", api.Route(system, nil), middleware...)
 
 	system.ActorOf(actor.Addr("notebooks"), &notebookManager{
 		defaultAgentUserGroup: defaultAgentUserGroup,
 		db:                    db,
 		clusterID:             cID,
 	})
-	echo.Any("/notebooks*", api.Route(system), middleware...)
+	echo.Any("/notebooks*", api.Route(system, nil), middleware...)
 
 	system.ActorOf(actor.Addr("shells"), &shellManager{
 		defaultAgentUserGroup: defaultAgentUserGroup,
 		db:                    db,
 		clusterID:             cID,
 	})
-	echo.Any("/shells*", api.Route(system), middleware...)
+	echo.Any("/shells*", api.Route(system, nil), middleware...)
 
 	system.ActorOf(actor.Addr("tensorboard"), &tensorboardManager{
 		defaultAgentUserGroup: defaultAgentUserGroup,
 		db:                    db,
 		clusterID:             cID,
 	})
-	echo.Any("/tensorboard*", api.Route(system), middleware...)
+	echo.Any("/tensorboard*", api.Route(system, nil), middleware...)
 }

--- a/master/internal/kubernetes/pod.go
+++ b/master/internal/kubernetes/pod.go
@@ -57,6 +57,14 @@ type pod struct {
 	resourcesDeleted bool
 }
 
+type getPodNodeInfo struct{}
+
+type podNodeInfo struct {
+	nodeName  string
+	numGPUs   int
+	container *container.Container
+}
+
 func newPod(
 	cluster *actor.Ref,
 	taskHandler *actor.Ref,
@@ -116,6 +124,13 @@ func (p *pod) Receive(ctx *actor.Context) error {
 		if err := p.deleteKubernetesResources(ctx); err != nil {
 			return err
 		}
+
+	case getPodNodeInfo:
+		ctx.Respond(podNodeInfo{
+			nodeName:  p.pod.Spec.NodeName,
+			numGPUs:   p.gpus,
+			container: &p.container,
+		})
 
 	case actor.PostStop:
 		if !p.leaveKubernetesResources {

--- a/master/internal/kubernetes/pods.go
+++ b/master/internal/kubernetes/pods.go
@@ -72,7 +72,7 @@ func Initialize(
 	check.Panic(check.True(ok, "pods address already taken"))
 
 	// We re-use the agents endpoint for the default resource provider.
-	e.Any("/agents*", api.Route(s, podsActor))
+	e.Any("/agents", api.Route(s, podsActor))
 	return podsActor
 }
 
@@ -303,8 +303,8 @@ func (p *pods) summarize(ctx *actor.Context) map[string]agent.AgentSummary {
 	// Separate pods by nodes.
 	podByNode := make(map[string][]podNodeInfo)
 	for _, result := range results {
-		podByNode[result.(podNodeInfo).nodeName] = append(
-			podByNode[result.(podNodeInfo).nodeName], result.(podNodeInfo))
+		info := result.(podNodeInfo)
+		podByNode[info.nodeName] = append(podByNode[info.nodeName], info)
 	}
 
 	nodes, err := p.clientSet.CoreV1().Nodes().List(metaV1.ListOptions{})

--- a/master/internal/scheduler/default_resource_provider.go
+++ b/master/internal/scheduler/default_resource_provider.go
@@ -300,6 +300,10 @@ func (d *DefaultRP) Receive(ctx *actor.Context) error {
 		reschedule = false
 		ctx.Respond(d.taskList.TaskSummaries())
 
+	case sproto.GetEndpointActorName:
+		reschedule = false
+		ctx.Respond(sproto.EndpointActorName{ActorName: "/agents"})
+
 	case schedulerTick:
 		if d.reschedule {
 			d.scheduler.Schedule(d)

--- a/master/internal/scheduler/default_resource_provider.go
+++ b/master/internal/scheduler/default_resource_provider.go
@@ -300,7 +300,7 @@ func (d *DefaultRP) Receive(ctx *actor.Context) error {
 		reschedule = false
 		ctx.Respond(d.taskList.TaskSummaries())
 
-	case sproto.GetEndpointActorName:
+	case sproto.GetEndpointActorAddress:
 		reschedule = false
 		ctx.Respond("/agents")
 

--- a/master/internal/scheduler/default_resource_provider.go
+++ b/master/internal/scheduler/default_resource_provider.go
@@ -302,7 +302,7 @@ func (d *DefaultRP) Receive(ctx *actor.Context) error {
 
 	case sproto.GetEndpointActorName:
 		reschedule = false
-		ctx.Respond(sproto.EndpointActorName{ActorName: "/agents"})
+		ctx.Respond("/agents")
 
 	case schedulerTick:
 		if d.reschedule {

--- a/master/internal/scheduler/kubernetes_resource_provider.go
+++ b/master/internal/scheduler/kubernetes_resource_provider.go
@@ -105,7 +105,7 @@ func (k *kubernetesResourceProvider) Receive(ctx *actor.Context) error {
 	case GetTaskSummaries:
 		ctx.Respond(k.taskList.TaskSummaries())
 
-	case sproto.GetEndpointActorName:
+	case sproto.GetEndpointActorAddress:
 		ctx.Respond("/pods")
 
 	default:

--- a/master/internal/scheduler/kubernetes_resource_provider.go
+++ b/master/internal/scheduler/kubernetes_resource_provider.go
@@ -106,7 +106,7 @@ func (k *kubernetesResourceProvider) Receive(ctx *actor.Context) error {
 		ctx.Respond(k.taskList.TaskSummaries())
 
 	case sproto.GetEndpointActorName:
-		ctx.Respond(sproto.EndpointActorName{ActorName: "/pods"})
+		ctx.Respond("/pods")
 
 	default:
 		ctx.Log().Errorf("unexpected message %T", msg)

--- a/master/internal/scheduler/kubernetes_resource_provider.go
+++ b/master/internal/scheduler/kubernetes_resource_provider.go
@@ -17,6 +17,7 @@ type kubernetesResourceProvider struct {
 	harnessPath           string
 	taskContainerDefaults model.TaskContainerDefaultsConfig
 
+	taskList           *taskList
 	tasksByHandler     map[*actor.Ref]*Task
 	tasksByID          map[TaskID]*Task
 	tasksByContainerID map[ContainerID]*Task
@@ -43,6 +44,7 @@ func NewKubernetesResourceProvider(
 		harnessPath:           harnessPath,
 		taskContainerDefaults: taskContainerDefaults,
 
+		taskList:           newTaskList(),
 		tasksByHandler:     make(map[*actor.Ref]*Task),
 		tasksByID:          make(map[TaskID]*Task),
 		tasksByContainerID: make(map[ContainerID]*Task),
@@ -95,6 +97,14 @@ func (k *kubernetesResourceProvider) Receive(ctx *actor.Context) error {
 	case TerminateTask:
 		k.receiveTerminateTask(ctx, msg)
 
+	case GetTaskSummary:
+		if resp := k.getTaskSummary(*msg.ID); resp != nil {
+			ctx.Respond(*resp)
+		}
+
+	case GetTaskSummaries:
+		ctx.Respond(k.taskList.TaskSummaries())
+
 	default:
 		ctx.Log().Errorf("unexpected message %T", msg)
 		return actor.ErrUnexpectedMessage(ctx)
@@ -139,6 +149,7 @@ func (k *kubernetesResourceProvider) receiveAddTask(ctx *actor.Context, msg AddT
 		fittingRequirements: msg.FittingRequirements,
 	})
 
+	k.taskList.Add(task)
 	k.tasksByID[task.ID] = task
 	k.tasksByHandler[task.handler] = task
 
@@ -293,6 +304,7 @@ func (k *kubernetesResourceProvider) receivePodTerminated(
 func (k *kubernetesResourceProvider) taskTerminated(task *Task, aborted bool) {
 	task.mustTransition(taskTerminated)
 
+	k.taskList.Remove(task)
 	delete(k.tasksByID, task.ID)
 	delete(k.tasksByHandler, task.handler)
 
@@ -370,6 +382,14 @@ func (k *kubernetesResourceProvider) terminateTask(task *Task, forcible bool) {
 		}
 		task.handler.System().Tell(task.handler, TerminateRequest{})
 	}
+}
+
+func (k *kubernetesResourceProvider) getTaskSummary(id TaskID) *TaskSummary {
+	if task := k.tasksByID[id]; task != nil {
+		summary := newTaskSummary(task)
+		return &summary
+	}
+	return nil
 }
 
 func constructAddresses(ip string, ports []int) []Address {

--- a/master/internal/scheduler/kubernetes_resource_provider.go
+++ b/master/internal/scheduler/kubernetes_resource_provider.go
@@ -105,6 +105,9 @@ func (k *kubernetesResourceProvider) Receive(ctx *actor.Context) error {
 	case GetTaskSummaries:
 		ctx.Respond(k.taskList.TaskSummaries())
 
+	case sproto.GetEndpointActorName:
+		ctx.Respond(sproto.EndpointActorName{ActorName: "/pods"})
+
 	default:
 		ctx.Log().Errorf("unexpected message %T", msg)
 		return actor.ErrUnexpectedMessage(ctx)

--- a/master/internal/scheduler/resource_providers.go
+++ b/master/internal/scheduler/resource_providers.go
@@ -22,7 +22,8 @@ func NewResourceProviders(resourceProvider *actor.Ref) *ResourceProviders {
 func (rp *ResourceProviders) Receive(ctx *actor.Context) error {
 	switch msg := ctx.Message().(type) {
 	case AddTask, StartTask, sproto.ContainerStateChanged, SetMaxSlots, SetWeight,
-		SetTaskName, TerminateTask, GetTaskSummary, GetTaskSummaries, sproto.ConfigureEndpoints:
+		SetTaskName, TerminateTask, GetTaskSummary, GetTaskSummaries, sproto.ConfigureEndpoints,
+		sproto.GetEndpointActorName:
 		rp.forward(ctx, msg)
 
 	default:

--- a/master/internal/scheduler/resource_providers.go
+++ b/master/internal/scheduler/resource_providers.go
@@ -23,7 +23,7 @@ func (rp *ResourceProviders) Receive(ctx *actor.Context) error {
 	switch msg := ctx.Message().(type) {
 	case AddTask, StartTask, sproto.ContainerStateChanged, SetMaxSlots, SetWeight,
 		SetTaskName, TerminateTask, GetTaskSummary, GetTaskSummaries, sproto.ConfigureEndpoints,
-		sproto.GetEndpointActorName:
+		sproto.GetEndpointActorAddress:
 		rp.forward(ctx, msg)
 
 	default:

--- a/master/internal/sproto/resource_providers.go
+++ b/master/internal/sproto/resource_providers.go
@@ -45,8 +45,8 @@ type (
 		Echo   *echo.Echo
 	}
 
-	// GetEndpointActorName request the name of the actor that is managing the resources.
-	GetEndpointActorName struct{}
+	// GetEndpointActorAddress requests the name of the actor that is managing the resources.
+	GetEndpointActorAddress struct{}
 )
 
 func (c ContainerLog) String() string {

--- a/master/internal/sproto/resource_providers.go
+++ b/master/internal/sproto/resource_providers.go
@@ -16,16 +16,43 @@ import (
 	"github.com/determined-ai/determined/master/pkg/container"
 )
 
-// ContainerLog notifies the task actor that a new log message is available for the container.
-// It is used by the resource providers to communicate internally and with the task handlers.
-type ContainerLog struct {
-	Container container.Container
-	Timestamp time.Time
+// Outgoing messages.
+type (
+	// ContainerLog notifies the task actor that a new log message is available for the container.
+	// It is used by the resource providers to communicate internally and with the task handlers.
+	ContainerLog struct {
+		Container container.Container
+		Timestamp time.Time
 
-	PullMessage *jsonmessage.JSONMessage
-	RunMessage  *agent.RunMessage
-	AuxMessage  *string
-}
+		PullMessage *jsonmessage.JSONMessage
+		RunMessage  *agent.RunMessage
+		AuxMessage  *string
+	}
+
+	// ContainerStateChanged notifies that the recipient container state has been transitioned.
+	// It is used by the resource providers to communicate with the task handlers.
+	ContainerStateChanged struct {
+		Container        container.Container
+		ContainerStopped *agent.ContainerStopped
+	}
+
+	// EndpointActorName tells the recipient the name of the actor that is manging the resources.
+	EndpointActorName struct {
+		ActorName string
+	}
+)
+
+// Incoming messages.
+type (
+	// ConfigureEndpoints informs the resource provider to configure the endpoints resources.
+	ConfigureEndpoints struct {
+		System *actor.System
+		Echo   *echo.Echo
+	}
+
+	// GetEndpointActorName request the name of the actor that is managing the resources.
+	GetEndpointActorName struct{}
+)
 
 func (c ContainerLog) String() string {
 	msg := ""
@@ -52,18 +79,4 @@ func (c ContainerLog) String() string {
 	shortID := c.Container.ID[:8]
 	timestamp := c.Timestamp.UTC().Format(time.RFC3339)
 	return fmt.Sprintf("[%s] %s [%s] || %s", timestamp, shortID, c.Container.State, msg)
-}
-
-// ContainerStateChanged notifies that the recipient container state has been transitioned.
-// It is used by the resource providers to communicate with the task handlers.
-type ContainerStateChanged struct {
-	Container        container.Container
-	ContainerStopped *agent.ContainerStopped
-}
-
-// ConfigureEndpoints informs the resource provider to configure
-// the endpoints resources.
-type ConfigureEndpoints struct {
-	System *actor.System
-	Echo   *echo.Echo
 }

--- a/master/internal/sproto/resource_providers.go
+++ b/master/internal/sproto/resource_providers.go
@@ -35,11 +35,6 @@ type (
 		Container        container.Container
 		ContainerStopped *agent.ContainerStopped
 	}
-
-	// EndpointActorName tells the recipient the name of the actor that is manging the resources.
-	EndpointActorName struct {
-		ActorName string
-	}
 )
 
 // Incoming messages.

--- a/master/pkg/actor/api/api.go
+++ b/master/pkg/actor/api/api.go
@@ -27,10 +27,9 @@ func Route(system *actor.System, recipient *actor.Ref) echo.HandlerFunc {
 
 func handleWSRequest(system *actor.System, recipient *actor.Ref, ctx echo.Context) error {
 	var addr actor.Address
-	switch {
-	case recipient != nil:
+	if recipient != nil {
 		addr = recipient.Address()
-	default:
+	} else {
 		addr = parseAddr(ctx.Request().URL.Path)
 	}
 
@@ -56,10 +55,9 @@ func handleWSRequest(system *actor.System, recipient *actor.Ref, ctx echo.Contex
 
 func handleRequest(system *actor.System, recipient *actor.Ref, ctx echo.Context) error {
 	var addr actor.Address
-	switch {
-	case recipient != nil:
+	if recipient != nil {
 		addr = recipient.Address()
-	default:
+	} else {
 		addr = parseAddr(ctx.Request().URL.Path)
 	}
 


### PR DESCRIPTION
## Description
Support task summaries and agents endpoints. As part of this PR we do not attempt to change the structure of endpoints to be more suitable for k8s, instead we fit the k8s RP to work with existing endpoints. This means there is no support for `agents/*` endpoints. 

To simplify integration with our actor system which routs api requests (for old api) by actor name, I added a forwarding mechanism which supports a preset actor name as the destination, instead of parsing the request path. 

<s>This PR is blocked on: #839, #865, #873, and #877. The last 3 commits is what makes up this PR. </s>


## Test Plan
Tested this manually by spinning up a k8 cluster and doing `det agent list, det slot list, det task list`. Also verified that `/api/v1/agents` works via the Swagger UI.
