### PR TITLE
feat: forward k8 events to task logs [DET-3549]

### DIFF
--- a/master/internal/kubernetes/events.go
+++ b/master/internal/kubernetes/events.go
@@ -1,0 +1,79 @@
+package kubernetes
+
+import (
+	"github.com/pkg/errors"
+
+	k8sV1 "k8s.io/api/core/v1"
+	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sClient "k8s.io/client-go/kubernetes"
+
+	"github.com/determined-ai/determined/master/pkg/actor"
+)
+
+// messages that are sent to the event listener.
+type (
+	startEventListener struct{}
+)
+
+// messages that are sent by the event listener.
+type (
+	podEventUpdate struct {
+		event *k8sV1.Event
+	}
+)
+
+type eventListener struct {
+	clientSet   *k8sClient.Clientset
+	namespace   string
+	podsHandler *actor.Ref
+}
+
+func newEventListener(
+	clientSet *k8sClient.Clientset,
+	namespace string,
+	podsHandler *actor.Ref,
+) *eventListener {
+	return &eventListener{
+		clientSet:   clientSet,
+		namespace:   namespace,
+		podsHandler: podsHandler,
+	}
+}
+
+func (e *eventListener) Receive(ctx *actor.Context) error {
+	switch msg := ctx.Message().(type) {
+	case actor.PreStart:
+		ctx.Tell(ctx.Self(), startEventListener{})
+
+	case startEventListener:
+		if err := e.startEventListener(ctx); err != nil {
+			return err
+		}
+
+	case actor.PostStop:
+
+	default:
+		ctx.Log().Errorf("unexpected message %T", msg)
+		return actor.ErrUnexpectedMessage(ctx)
+	}
+
+	return nil
+}
+
+func (e *eventListener) startEventListener(ctx *actor.Context) error {
+	watch, err := e.clientSet.CoreV1().Events(e.namespace).Watch(metaV1.ListOptions{})
+	if err != nil {
+		return errors.Wrap(err, "error initializing event watch")
+	}
+
+	ctx.Log().Info("event listener is starting")
+	for event := range watch.ResultChan() {
+		newEvent := event.Object.(*k8sV1.Event)
+		ctx.Tell(e.podsHandler, podEventUpdate{event: newEvent})
+	}
+
+	ctx.Log().Warn("event listener stopped unexpectedly")
+	ctx.Tell(ctx.Self(), startEventListener{})
+
+	return nil
+}

--- a/master/internal/kubernetes/events.go
+++ b/master/internal/kubernetes/events.go
@@ -10,12 +10,12 @@ import (
 	"github.com/determined-ai/determined/master/pkg/actor"
 )
 
-// messages that are sent to the event listener.
+// Messages that are sent to the event listener.
 type (
 	startEventListener struct{}
 )
 
-// messages that are sent by the event listener.
+// Messages that are sent by the event listener.
 type (
 	podEventUpdate struct {
 		event *k8sV1.Event

--- a/master/internal/kubernetes/informer.go
+++ b/master/internal/kubernetes/informer.go
@@ -43,6 +43,7 @@ func newInformer(
 func (i *informer) Receive(ctx *actor.Context) error {
 	switch msg := ctx.Message().(type) {
 	case actor.PreStart:
+		ctx.Tell(ctx.Self(), startInformer{})
 
 	case startInformer:
 		if err := i.startInformer(ctx); err != nil {

--- a/master/internal/kubernetes/pod.go
+++ b/master/internal/kubernetes/pod.go
@@ -327,11 +327,9 @@ func (p *pod) receiveContainerLogs(ctx *actor.Context, msg sproto.ContainerLog) 
 }
 
 func (p *pod) receivePodEventUpdate(ctx *actor.Context, msg podEventUpdate) {
-	// We only forward messages for while pods are starting up.
+	// We only forward messages while pods are starting up.
 	switch p.container.State {
-	case container.Running:
-		return
-	case container.Terminated:
+	case container.Running, container.Terminated:
 		return
 	}
 

--- a/master/internal/kubernetes/pod.go
+++ b/master/internal/kubernetes/pod.go
@@ -108,6 +108,9 @@ func (p *pod) Receive(ctx *actor.Context) error {
 			return err
 		}
 
+	case podEventUpdate:
+		p.receivePodEventUpdate(ctx, msg)
+
 	case sproto.ContainerLog:
 		p.receiveContainerLogs(ctx, msg)
 
@@ -321,6 +324,25 @@ func (p *pod) finalizeTaskState(ctx *actor.Context) {
 func (p *pod) receiveContainerLogs(ctx *actor.Context, msg sproto.ContainerLog) {
 	msg.Container = p.container
 	ctx.Tell(p.taskHandler, msg)
+}
+
+func (p *pod) receivePodEventUpdate(ctx *actor.Context, msg podEventUpdate) {
+	// We only forward messages for while pods are starting up.
+	switch p.container.State {
+	case container.Running:
+		return
+	case container.Terminated:
+		return
+	}
+
+	message := fmt.Sprintf("Pod %s: %s", msg.event.InvolvedObject.Name, msg.event.Message)
+	ctx.Tell(p.taskHandler, sproto.ContainerLog{
+		Container:   p.container,
+		Timestamp:   msg.event.CreationTimestamp.Time,
+		PullMessage: nil,
+		RunMessage:  nil,
+		AuxMessage:  &message,
+	})
 }
 
 func (p *pod) configureResourcesRequirements() k8sV1.ResourceRequirements {

--- a/master/internal/kubernetes/pods.go
+++ b/master/internal/kubernetes/pods.go
@@ -245,7 +245,7 @@ func (p *pods) receivePodStatusUpdate(ctx *actor.Context, msg podStatusUpdate) {
 func (p *pods) receivePodEventUpdate(ctx *actor.Context, msg podEventUpdate) {
 	ref, ok := p.podNameToPodHandler[msg.event.InvolvedObject.Name]
 	if !ok {
-		// We set this to debug mode because we are unable to filter
+		// We log at the debug level because we are unable to filter
 		// pods based on their labels the way we do with pod status updates.
 		ctx.Log().WithField("pod-name", msg.event.InvolvedObject.Name).Debug(
 			"received pod event for an un-registered pod")

--- a/master/internal/kubernetes/pods.go
+++ b/master/internal/kubernetes/pods.go
@@ -37,6 +37,7 @@ type pods struct {
 	masterPort int32
 
 	informer                *actor.Ref
+	eventListener           *actor.Ref
 	podNameToPodHandler     map[string]*actor.Ref
 	containerIDToPodHandler map[string]*actor.Ref
 	podHandlerToMetadata    map[*actor.Ref]podMetadata
@@ -84,6 +85,7 @@ func (p *pods) Receive(ctx *actor.Context) error {
 			return err
 		}
 		p.startPodInformer(ctx)
+		p.startEventListener(ctx)
 
 	case sproto.StartPod:
 		if err := p.receiveStartPod(ctx, msg); err != nil {
@@ -92,6 +94,9 @@ func (p *pods) Receive(ctx *actor.Context) error {
 
 	case podStatusUpdate:
 		p.receivePodStatusUpdate(ctx, msg)
+
+	case podEventUpdate:
+		p.receivePodEventUpdate(ctx, msg)
 
 	case sproto.StopPod:
 		p.receiveStopPod(ctx, msg)
@@ -102,8 +107,11 @@ func (p *pods) Receive(ctx *actor.Context) error {
 		}
 
 	case actor.ChildFailed:
-		if msg.Child == p.informer {
+		switch msg.Child {
+		case p.informer:
 			return errors.Errorf("pod informer failed")
+		case p.eventListener:
+			return errors.Errorf("event listener failed")
 		}
 
 		if err := p.cleanUpPodHandler(ctx, msg.Child); err != nil {
@@ -188,7 +196,11 @@ func (p *pods) deleteExistingKubernetesResources(ctx *actor.Context) error {
 
 func (p *pods) startPodInformer(ctx *actor.Context) {
 	p.informer, _ = ctx.ActorOf("pod-informer", newInformer(p.podInterface, p.namespace, ctx.Self()))
-	ctx.Tell(p.informer, startInformer{})
+}
+
+func (p *pods) startEventListener(ctx *actor.Context) {
+	p.eventListener, _ = ctx.ActorOf(
+		"event-listener", newEventListener(p.clientSet, p.namespace, ctx.Self()))
 }
 
 func (p *pods) receiveStartPod(ctx *actor.Context, msg sproto.StartPod) error {
@@ -224,6 +236,19 @@ func (p *pods) receivePodStatusUpdate(ctx *actor.Context, msg podStatusUpdate) {
 	if !ok {
 		ctx.Log().WithField("pod-name", msg.updatedPod.Name).Warn(
 			"received pod status update for un-registered pod")
+		return
+	}
+
+	ctx.Tell(ref, msg)
+}
+
+func (p *pods) receivePodEventUpdate(ctx *actor.Context, msg podEventUpdate) {
+	ref, ok := p.podNameToPodHandler[msg.event.InvolvedObject.Name]
+	if !ok {
+		// We set this to debug mode because we are unable to filter
+		// pods based on their labels the way we do with pod status updates.
+		ctx.Log().WithField("pod-name", msg.event.InvolvedObject.Name).Debug(
+			"received pod event for an un-registered pod")
 		return
 	}
 


### PR DESCRIPTION
## Description
<s>This PR is blocker on #865 #873 #877 and #891. Only the last commit is part of this PR.</s>

As part of this PR, we add functionality to forward k8s event to the trial logs. This will improve users' observability into the state of their tasks.


## Test Plan
Tested by running in a k8 cluster.