### PR TITLE
feat: use k8 timestamps for logs [DET-3541]

### DIFF
--- a/master/internal/agent/agent.go
+++ b/master/internal/agent/agent.go
@@ -136,7 +136,7 @@ func (a *agent) handleIncomingWSMessage(ctx *actor.Context, msg aproto.MasterMes
 			"container not assigned to agent: container %s", msg.ContainerLog.Container.ID))
 		ctx.Tell(ref, sproto.ContainerLog{
 			Container:   msg.ContainerLog.Container,
-			Timestamp:   msg.ContainerLog.Timestamp,
+			Timestamp:   &msg.ContainerLog.Timestamp,
 			PullMessage: msg.ContainerLog.PullMessage,
 			RunMessage:  msg.ContainerLog.RunMessage,
 			AuxMessage:  msg.ContainerLog.AuxMessage,

--- a/master/internal/kubernetes/log.go
+++ b/master/internal/kubernetes/log.go
@@ -2,7 +2,6 @@ package kubernetes
 
 import (
 	"io"
-	"time"
 
 	"github.com/docker/docker/pkg/stdcopy"
 
@@ -33,9 +32,8 @@ func newPodLogStreamer(
 	podHandler *actor.Ref,
 ) (*podLogStreamer, error) {
 	logs := podInterface.GetLogs(podName, &k8sV1.PodLogOptions{
-		Follow: true,
-		// TODO(DET-3541): switch over to using k8 timestamps.
-		Timestamps: false,
+		Follow:     true,
+		Timestamps: true,
 	})
 
 	logReader, err := logs.Stream()
@@ -67,7 +65,6 @@ func (p *podLogStreamer) Receive(ctx *actor.Context) error {
 // Write implements the io.Writer interface.
 func (p *podLogStreamer) Write(log []byte) (n int, err error) {
 	p.ctx.Tell(p.podHandler, sproto.ContainerLog{
-		Timestamp: time.Now(),
 		RunMessage: &agent.RunMessage{
 			Value:   string(log),
 			StdType: stdcopy.Stdout,

--- a/master/internal/sproto/resource_providers.go
+++ b/master/internal/sproto/resource_providers.go
@@ -8,10 +8,9 @@ import (
 
 	"github.com/labstack/echo"
 
-	"github.com/determined-ai/determined/master/pkg/actor"
-
 	"github.com/docker/docker/pkg/jsonmessage"
 
+	"github.com/determined-ai/determined/master/pkg/actor"
 	"github.com/determined-ai/determined/master/pkg/agent"
 	"github.com/determined-ai/determined/master/pkg/container"
 )
@@ -20,7 +19,7 @@ import (
 // It is used by the resource providers to communicate internally and with the task handlers.
 type ContainerLog struct {
 	Container container.Container
-	Timestamp time.Time
+	Timestamp *time.Time
 
 	PullMessage *jsonmessage.JSONMessage
 	RunMessage  *agent.RunMessage
@@ -50,8 +49,11 @@ func (c ContainerLog) String() string {
 		panic("unknown log message received")
 	}
 	shortID := c.Container.ID[:8]
-	timestamp := c.Timestamp.UTC().Format(time.RFC3339)
-	return fmt.Sprintf("[%s] %s [%s] || %s", timestamp, shortID, c.Container.State, msg)
+	timestamp := ""
+	if c.Timestamp != nil {
+		timestamp = fmt.Sprintf("[%s]", c.Timestamp.UTC().Format(time.RFC3339))
+	}
+	return fmt.Sprintf("%s %s [%s] || %s", timestamp, shortID, c.Container.State, msg)
 }
 
 // ContainerStateChanged notifies that the recipient container state has been transitioned.

--- a/master/internal/trial.go
+++ b/master/internal/trial.go
@@ -741,10 +741,11 @@ func (t *trial) processContainerTerminated(
 
 	t.killAndRemoveSocket(ctx, scheduler.ContainerID(msg.Container.ID))
 
+	timeNow := time.Now()
 	exitMsg := msg.ContainerStopped.String()
 	t.processLog(ctx, sproto.ContainerLog{
 		Container:  msg.Container,
-		Timestamp:  time.Now(),
+		Timestamp:  &timeNow,
 		AuxMessage: &exitMsg,
 	})
 


### PR DESCRIPTION
## Description
Instead of manually generating timestamps, we re-use those that are provided by k8s.

<s>This PR is blocked by: #865 #873 #877 #891 and #900. Only the last commit is part of this PR.</s>

## Test Plan
Ran manually on a k8 cluster.
