### PR TITLE
docs: remove duplicate entry from API reference

### DIFF
--- a/docs/reference/api/experimental.txt
+++ b/docs/reference/api/experimental.txt
@@ -48,12 +48,3 @@ determined.experimental
     :members:
     :inherited-members:
     :member-order: bysource
-
-
-``Model``
-------------------
-
-.. autoclass:: determined.experimental.Model
-    :members:
-    :inherited-members:
-    :member-order: bysource


### PR DESCRIPTION
This got added twice accidently, due to two concurrent PRs.