### PR TITLE
test: add trial logs navigation test.

### DIFF
--- a/webui/tests/cypress/integration/02-navigation.spec.ts
+++ b/webui/tests/cypress/integration/02-navigation.spec.ts
@@ -58,7 +58,7 @@ describe('Navigation', () => {
 
     it('path /det/trials/:id/logs should display Trial Logs', () => {
       cy.visit('/det/trials/1/logs');
-      cy.get(sectionTitleSelector).contains('Logs for Trials');
+      cy.get(sectionTitleSelector).contains('Logs for Trial');
     });
   });
 

--- a/webui/tests/cypress/integration/02-navigation.spec.ts
+++ b/webui/tests/cypress/integration/02-navigation.spec.ts
@@ -55,6 +55,11 @@ describe('Navigation', () => {
       cy.visit('/det/logs');
       cy.get(sectionTitleSelector).contains('Master Logs');
     });
+
+    it('path /det/trials/:id/logs should display Trial Logs', () => {
+      cy.visit('/det/trials/1/logs');
+      cy.get(sectionTitleSelector).contains('Logs for Trials');
+    });
   });
 
   describe('side menu buttons', () => {

--- a/webui/tests/cypress/integration/02-navigation.spec.ts
+++ b/webui/tests/cypress/integration/02-navigation.spec.ts
@@ -56,7 +56,7 @@ describe('Navigation', () => {
       cy.get(sectionTitleSelector).contains('Master Logs');
     });
 
-    it('path /det/trials/:id/logs should display Trial Logs', () => {
+    it.skip('path /det/trials/:id/logs should display Trial Logs', () => {
       cy.visit('/det/trials/1/logs');
       cy.get(sectionTitleSelector).contains('Logs for Trial');
     });


### PR DESCRIPTION
follow up for https://github.com/determined-ai/determined/pull/878

we add this test to see if it runs into the same problem as with #878 

## Description



## Test Plan

![Screen Capture_select-area_20200720120949](https://user-images.githubusercontent.com/12127420/87976457-f8ae8400-ca81-11ea-96b2-b924892c16da.png)


## Commentary (optional)


<!-- User-facing API changes need the "User-facing API Change" label -->

<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

## Description

Lead with the intended commit body in this description field. For breaking changes, please include "BREAKING CHANGE:" at the beginning of your commit body. At minimum, this section should include a bracketed reference to the Jira ticket, e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.

## Test Plan

Describe the situations in which you've tested your change, and/or a screenshot as appropriate. Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.

## Commentary (optional)

Use this section of your description to add context to the PR. Could be for particularly tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc. You may intentionally leave this section blank and remove the title.
--->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234