### PR TITLE
feat: add support for kubernetes trial log entries

### DIFF
--- a/webui/react/src/services/decoder.ts
+++ b/webui/react/src/services/decoder.ts
@@ -227,11 +227,21 @@ export const jsonToLogs = (data: unknown): Log[] => {
 
 export const jsonToTrialLogs = (data: unknown): Log[] => {
   const ioType = decode<ioTypeLogs>(ioLogs, data);
+  const defaultRegex = /^\[([^\]]+)\]\s(.*)$/im;
+  const kubernetesRegex = /^\s*([0-9a-f]+)\s+(\[[^\]]+\])\s\|\|\s(\S+)\s(.*)$/im;
   return ioType.map(log => {
-    const matches = log.message.match(/\[([^\]]+)\] (.*)/);
-    const time = matches && matches[1] ? matches[1] : undefined;
-    const message = matches && matches[2] ? matches[2] : '';
-    return { id: log.id, message, time };
+    if (defaultRegex.test(log.message)) {
+      const matches = log.message.match(defaultRegex) || [];
+      const time = matches[1];
+      const message = matches[2] || '';
+      return { id: log.id, message, time };
+    } else if (kubernetesRegex.test(log.message)) {
+      const matches = log.message.match(kubernetesRegex) || [];
+      const time = matches[3];
+      const message = [ matches[1], matches[2], matches[4] ].join(' ');
+      return { id: log.id, message, time };
+    }
+    return { id: log.id, message: log.message };
   });
 };
 


### PR DESCRIPTION
## Description

add support for parsing kubernetes log entries
```
 045b68a5 [RUNNING] || 2020-07-20T15:35:38.548199278Z INFO: Running workload <RUN_STEP (100): (141,137,9)>
 045b68a5 [RUNNING] || 2020-07-20T15:35:41.197537494Z INFO: Workload completed: <RUN_STEP (100): (141,137,9)> (duration 0:00:02.649047)
 045b68a5 [RUNNING] || 2020-07-20T15:35:41.208223876Z INFO: Running workload <COMPUTE_VALIDATION_METRICS: (141,137,9)>
 045b68a5 [RUNNING] || 2020-07-20T15:35:43.607370553Z INFO: Workload completed: <COMPUTE_VALIDATION_METRICS: (141,137,9)> (duration 0:00:02.398744)
 045b68a5 [RUNNING] || 2020-07-20T15:35:43.620408964Z INFO: Running workload <CHECKPOINT_MODEL: (141,137,9)>
 045b68a5 [RUNNING] || 2020-07-20T15:35:43.64517623Z INFO: Saved trial to checkpoint b5258099-0138-4ed7-9ff7-d01ee4b24ef0
 045b68a5 [RUNNING] || 2020-07-20T15:35:43.646657674Z INFO: Uploading checkpoint b5258099-0138-4ed7-9ff7-d01ee4b24ef0 to GCS
 045b68a5 [RUNNING] || 2020-07-20T15:35:46.372110929Z INFO: Workload completed: <CHECKPOINT_MODEL: (141,137,9)> (duration 0:00:00.025378)
 045b68a5 [RUNNING] || 2020-07-20T15:35:46.377021261Z INFO: Running workload <TERMINATE: (141,137,9)>
```

current default format looks like:
```
[2020-07-22T17:21:31Z] 89d54fe1 [PULLING] || image already found, skipping pull phase: docker.io/determinedai/environments:py-3.6.9-pytorch-1.4-tf-1.15-cpu-f2038fa
[2020-07-22T17:21:31Z] 89d54fe1 [STARTING] || copying files to container: 
[2020-07-22T17:21:31Z] 89d54fe1 [STARTING] || copying files to container: 
```

## Test Plan



## Commentary (optional)


<!-- User-facing API changes need the "User-facing API Change" label -->

<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

## Description

Lead with the intended commit body in this description field. For breaking changes, please include "BREAKING CHANGE:" at the beginning of your commit body. At minimum, this section should include a bracketed reference to the Jira ticket, e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.

## Test Plan

Describe the situations in which you've tested your change, and/or a screenshot as appropriate. Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.

## Commentary (optional)

Use this section of your description to add context to the PR. Could be for particularly tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc. You may intentionally leave this section blank and remove the title.
--->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234