### PR TITLE
fix: restore previous checkpoint export functionality

### DIFF
--- a/common/determined_common/experimental/checkpoint/_checkpoint.py
+++ b/common/determined_common/experimental/checkpoint/_checkpoint.py
@@ -196,7 +196,7 @@ class Checkpoint(object):
                 <https://pytorch.org/docs/stable/torch.html?highlight=torch%20load#torch.load>`_.
         """
         ckpt_path = self.download(path)
-        return Checkpoint.load_from_path(ckpt_path, tags=tags)
+        return Checkpoint.load_from_path(ckpt_path, tags=tags, **kwargs)
 
     def add_metadata(self, metadata: Dict[str, Any]) -> None:
         """
@@ -231,7 +231,7 @@ class Checkpoint(object):
             self.metadata = r.json()
 
     @staticmethod
-    def load_from_path(path: str, tags: Optional[List[str]] = None) -> Any:
+    def load_from_path(path: str, tags: Optional[List[str]] = None, **kwargs: Any) -> Any:
         """
         Loads a Determined checkpoint from a local file system path into
         memory. If the checkpoint is a PyTorch model, a ``torch.nn.Module`` is returned.
@@ -254,7 +254,7 @@ class Checkpoint(object):
             import determined_common.experimental.checkpoint._torch
 
             return determined_common.experimental.checkpoint._torch.load_model(
-                checkpoint_dir, metadata,
+                checkpoint_dir, metadata, **kwargs
             )
 
         elif checkpoint_type == ModelFramework.TENSORFLOW:

--- a/common/determined_common/experimental/checkpoint/_torch.py
+++ b/common/determined_common/experimental/checkpoint/_torch.py
@@ -10,7 +10,7 @@ from determined.pytorch import PyTorchTrial, PyTorchTrialContext
 def load_model(
     ckpt_dir: pathlib.Path, metadata: Dict[str, Any], **kwargs: Any
 ) -> Union[PyTorchTrial, torch.nn.Module]:
-    checkpoint = torch.load(ckpt_dir.joinpath("state_dict.pth"), map_location="cpu")  # type: ignore
+    checkpoint = torch.load(ckpt_dir.joinpath("state_dict.pth"), **kwargs)  # type: ignore
 
     trial_cls, trial_context = experimental._load_trial_on_local(
         ckpt_dir.joinpath("code"),
@@ -20,13 +20,16 @@ def load_model(
 
     trial_context = cast(PyTorchTrialContext, trial_context)
     trial = cast(PyTorchTrial, trial_cls(trial_context))
-
     if "model_state_dict" in checkpoint:
         # Backward compatible with older checkpoint format.
         model = trial.build_model()
         model.load_state_dict(checkpoint["model_state_dict"])
         return model
     else:
-        for idx, model in enumerate(trial_context.models):
-            model.load_state_dict(checkpoint["models_state_dict"][idx])
-        return trial
+        model = trial.build_model()
+        model.load_state_dict(checkpoint["models_state_dict"][0])
+        return model
+        # TODO: Fix for multiple model case
+        # for idx, model in enumerate(trial_context.models):
+        #     model.load_state_dict(checkpoint["models_state_dict"][idx])
+        # return trial

--- a/e2e_tests/tests/experiment/test_pytorch.py
+++ b/e2e_tests/tests/experiment/test_pytorch.py
@@ -1,6 +1,5 @@
 import pytest
 
-from determined import pytorch
 from determined.experimental import Determined
 from tests import config as conf
 from tests import experiment as exp
@@ -25,8 +24,12 @@ def test_pytorch_load() -> None:
         config, conf.official_examples_path("trial/mnist_pytorch"), 1
     )
 
-    nn = Determined(conf.make_master_url()).get_experiment(experiment_id).top_checkpoint().load()
-    assert isinstance(nn, pytorch.PyTorchTrial)
+    (
+        Determined(conf.make_master_url())
+        .get_experiment(experiment_id)
+        .top_checkpoint()
+        .load(map_location="cpu")
+    )
 
 
 @pytest.mark.e2e_gpu  # type: ignore
@@ -133,10 +136,9 @@ def test_pytorch_cifar10_parallel() -> None:
         config, conf.official_examples_path("trial/cifar10_cnn_pytorch"), 1
     )
     trials = exp.experiment_trials(experiment_id)
-    nn = (
+    (
         Determined(conf.make_master_url())
         .get_trial(trials[0]["id"])
         .select_checkpoint(latest=True)
-        .load()
+        .load(map_location="cpu")
     )
-    assert isinstance(nn, pytorch.PyTorchTrial)


### PR DESCRIPTION
## Description
Reverted a change to checkpoint export that was built to accommodate the flexible primitives API.  The checkpoint export API was heavily changed in that update, and we wanted more time to decide on if we want to move forward with that API.

Also reintroduced passing `**kwargs` into the `pytorch.load(..)` call when loading pytorch checkpoints.  This is most useful for the `map_location` argument, which was previously hard coded.


## Test Plan
Tested manually with both new and old checkpoint formats.
