### PR TITLE
feat: remove steps from examples [DET-3624]

### DIFF
--- a/examples/experimental/trial/FasterRCNN_tp/16-gpus.yaml
+++ b/examples/experimental/trial/FasterRCNN_tp/16-gpus.yaml
@@ -14,7 +14,8 @@ searcher:
   smaller_is_better: false
   name: random
   max_trials: 1
-  max_steps: 2304
+  max_length:
+    batches: 147_456
 
 bind_mounts:
   - host_path: /tmp
@@ -22,8 +23,10 @@ bind_mounts:
 
 entrypoint: model:RCNNTrial
 max_restarts: 3
-min_validation_period: 256
-min_checkpoint_period: 64
+min_validation_period:
+  batches: 16_384
+min_checkpoint_period:
+  batches: 4096
 checkpoint_policy: none
 batches_per_step: 64
 reproducibility:

--- a/examples/experimental/trial/FasterRCNN_tp/16-gpus.yaml
+++ b/examples/experimental/trial/FasterRCNN_tp/16-gpus.yaml
@@ -15,7 +15,7 @@ searcher:
   name: random
   max_trials: 1
   max_length:
-    batches: 147_456
+    batches: 147456
 
 bind_mounts:
   - host_path: /tmp
@@ -24,7 +24,7 @@ bind_mounts:
 entrypoint: model:RCNNTrial
 max_restarts: 3
 min_validation_period:
-  batches: 16_384
+  batches: 16384
 min_checkpoint_period:
   batches: 4096
 checkpoint_policy: none

--- a/examples/experimental/trial/FasterRCNN_tp/64-gpus.yaml
+++ b/examples/experimental/trial/FasterRCNN_tp/64-gpus.yaml
@@ -13,7 +13,8 @@ searcher:
   smaller_is_better: false
   name: random
   max_trials: 1
-  max_steps: 576
+  max_length:
+    batches: 36_864
 
 bind_mounts:
   - host_path: /tmp
@@ -21,8 +22,10 @@ bind_mounts:
 
 entrypoint: model:RCNNTrial
 max_restarts: 3
-min_validation_period: 64
-min_checkpoint_period: 64
+min_validation_period:
+  batches: 4096
+min_checkpoint_period:
+  batches: 4096
 checkpoint_policy: none
 batches_per_step: 64
 reproducibility:

--- a/examples/experimental/trial/FasterRCNN_tp/64-gpus.yaml
+++ b/examples/experimental/trial/FasterRCNN_tp/64-gpus.yaml
@@ -14,7 +14,7 @@ searcher:
   name: random
   max_trials: 1
   max_length:
-    batches: 36_864
+    batches: 36864
 
 bind_mounts:
   - host_path: /tmp

--- a/examples/experimental/trial/bert_glue_pytorch/const.yaml
+++ b/examples/experimental/trial/bert_glue_pytorch/const.yaml
@@ -12,7 +12,8 @@ hyperparameters:
 searcher:
   name: single
   metric: acc
-  max_steps: 4
+  max_length:
+    batches: 400
   smaller_is_better: false
 max_restarts: 0
 data:

--- a/examples/experimental/trial/bert_glue_pytorch/trial_impl.py
+++ b/examples/experimental/trial/bert_glue_pytorch/trial_impl.py
@@ -14,7 +14,14 @@ if __name__ == "__main__":
 
     config = {
         "description": "PyTorch Bert",
-        "searcher": {"name": "single", "metric": "acc", "max_steps": 4, "smaller_is_better": True},
+        "searcher": {
+            "name": "single",
+            "metric": "acc",
+            "max_length": {
+                "batches": 400,
+            },
+            "smaller_is_better": True,
+        },
         "data": {
             "data_dir": "/tmp/data",
             "task": "MRPC",

--- a/examples/experimental/trial/bert_squad_pytorch/const.yaml
+++ b/examples/experimental/trial/bert_squad_pytorch/const.yaml
@@ -15,20 +15,20 @@ hyperparameters:
     max_answer_length: 30
     null_score_diff_threshold: 0.0
     max_grad_norm: 1.0
-    num_training_steps: 15_000 # This is the number of optimizer steps. Set it
-                               # to max_length.batches (assuming we step every
-                               # batch in the LR scheduler definition)
+    num_training_steps: 15000 # This is the number of optimizer steps. Set it
+                              # to max_length.batches (assuming we step every
+                              # batch in the LR scheduler definition)
 searcher:
     name: single
     metric: f1
     max_length:
-        records: 180_000 # There are ~90k examples in the training set, and we run for
-                         # 2 epochs as in the huggingface repo.
+        records: 180000 # There are ~90k examples in the training set, and we run for
+                        # 2 epochs as in the huggingface repo.
     smaller_is_better: false
 min_validation_period:
-    records: 12_000 # Validation is fairly costly (~10 minutes per), but
-                    # relative to overall runtime it's not that high, so
-                    # validate often to give more frequent feedback.
+    records: 12000 # Validation is fairly costly (~10 minutes per), but
+                   # relative to overall runtime it's not that high, so
+                   # validate often to give more frequent feedback.
 data:
     pretrained_model_name: "bert-base-uncased"
     download_data: False

--- a/examples/experimental/trial/bert_squad_pytorch/const.yaml
+++ b/examples/experimental/trial/bert_squad_pytorch/const.yaml
@@ -15,19 +15,20 @@ hyperparameters:
     max_answer_length: 30
     null_score_diff_threshold: 0.0
     max_grad_norm: 1.0
-    num_training_steps: 15000 # This is the number of optimizer steps. Set it
-                              # to max_steps * batches_per_step (assuming we
-                              # step every batch in the LR scheduler definition)
+    num_training_steps: 15_000 # This is the number of optimizer steps. Set it
+                               # to max_length.batches (assuming we step every
+                               # batch in the LR scheduler definition)
 searcher:
     name: single
     metric: f1
-    max_steps: 150 # There are ~90k examples in the training set, and we run for
-                   # 2 epochs as in the huggingface repo. We get 150 by:
-                   # 90k / global_batch_size / (100 batches per step) * 2 epochs
+    max_length:
+        records: 180_000 # There are ~90k examples in the training set, and we run for
+                         # 2 epochs as in the huggingface repo.
     smaller_is_better: false
-min_validation_period: 10 # Validation is fairly costly (~10 minutes per), but
-                          # relative to overall runtime it's not that high, so
-                          # validate often to give more frequent feedback.
+min_validation_period:
+    records: 12_000 # Validation is fairly costly (~10 minutes per), but
+                    # relative to overall runtime it's not that high, so
+                    # validate often to give more frequent feedback.
 data:
     pretrained_model_name: "bert-base-uncased"
     download_data: False

--- a/examples/experimental/trial/bert_squad_pytorch/distributed.yaml
+++ b/examples/experimental/trial/bert_squad_pytorch/distributed.yaml
@@ -15,22 +15,22 @@ hyperparameters:
     max_answer_length: 30
     null_score_diff_threshold: 0.0
     max_grad_norm: 1.0
-    num_training_steps: 15_000 # This is the number of optimizer steps. Set it
-                               # to max_length.batches (assuming we step every
-                               # batch in the LR scheduler definition)
+    num_training_steps: 15000 # This is the number of optimizer steps. Set it
+                              # to max_length.batches (assuming we step every
+                              # batch in the LR scheduler definition)
 resources:
     slots_per_trial: 8
 searcher:
     name: single
     metric: f1
     max_length:
-        records: 180_000 # There are ~90k examples in the training set, and we run for
-                         # 2 epochs as in the huggingface repo.
+        records: 180000 # There are ~90k examples in the training set, and we run for
+                        # 2 epochs as in the huggingface repo.
     smaller_is_better: false
 min_validation_period:
-    records: 12_000 # Validation is fairly costly (~10 minutes per), but
-                    # relative to overall runtime it's not that high, so
-                    # validate often to give more frequent feedback.
+    records: 12000 # Validation is fairly costly (~10 minutes per), but
+                   # relative to overall runtime it's not that high, so
+                   # validate often to give more frequent feedback.
 data:
     pretrained_model_name: "bert-base-uncased"
     download_data: False

--- a/examples/experimental/trial/bert_squad_pytorch/distributed.yaml
+++ b/examples/experimental/trial/bert_squad_pytorch/distributed.yaml
@@ -15,21 +15,22 @@ hyperparameters:
     max_answer_length: 30
     null_score_diff_threshold: 0.0
     max_grad_norm: 1.0
-    num_training_steps: 15000 # This is the number of optimizer steps. Set it
-                              # to max_steps * batches_per_step (assuming we
-                              # step every batch in the LR scheduler definition)
+    num_training_steps: 15_000 # This is the number of optimizer steps. Set it
+                               # to max_length.batches (assuming we step every
+                               # batch in the LR scheduler definition)
 resources:
     slots_per_trial: 8
 searcher:
     name: single
     metric: f1
-    max_steps: 150 # There are ~90k examples in the training set, and we run for
-                   # 2 epochs as in the huggingface repo. We get 150 by:
-                   # 90k / global_batch_size / (100 batches per step) * 2 epochs
+    max_length:
+        records: 180_000 # There are ~90k examples in the training set, and we run for
+                         # 2 epochs as in the huggingface repo.
     smaller_is_better: false
-min_validation_period: 10 # Validation is fairly costly (~10 minutes per), but
-                          # relative to overall runtime it's not that high, so
-                          # validate often to give more frequent feedback.
+min_validation_period:
+    records: 12_000 # Validation is fairly costly (~10 minutes per), but
+                    # relative to overall runtime it's not that high, so
+                    # validate often to give more frequent feedback.
 data:
     pretrained_model_name: "bert-base-uncased"
     download_data: False

--- a/examples/experimental/trial/data_layer_mnist_estimator/const.yaml
+++ b/examples/experimental/trial/data_layer_mnist_estimator/const.yaml
@@ -13,6 +13,7 @@ data_layer:
 searcher:
   name: single
   metric: accuracy
-  max_steps: 40
+  max_length:
+    batches: 4000
   smaller_is_better: false
 entrypoint: model_def:MNistTrial

--- a/examples/experimental/trial/data_layer_mnist_tf_keras/const.yaml
+++ b/examples/experimental/trial/data_layer_mnist_tf_keras/const.yaml
@@ -16,7 +16,9 @@ data_layer:
 searcher:
   name: single
   metric: val_loss
-  max_steps: 20
+  max_length:
+    batches: 2000
   smaller_is_better: true
-min_validation_period: 10
+min_validation_period:
+  batches: 1000
 entrypoint: model_def:MnistTrial

--- a/examples/experimental/trial/flexible_primitives_mnist_pytorch/const.yaml
+++ b/examples/experimental/trial/flexible_primitives_mnist_pytorch/const.yaml
@@ -10,6 +10,7 @@ hyperparameters:
 searcher:
   name: single
   metric: loss
-  max_steps: 200
+  max_length:
+    batches: 20_000
   smaller_is_better: True
 entrypoint: model_def:GANTrial

--- a/examples/experimental/trial/flexible_primitives_mnist_pytorch/const.yaml
+++ b/examples/experimental/trial/flexible_primitives_mnist_pytorch/const.yaml
@@ -11,6 +11,6 @@ searcher:
   name: single
   metric: loss
   max_length:
-    batches: 20_000
+    batches: 20000
   smaller_is_better: True
 entrypoint: model_def:GANTrial

--- a/examples/experimental/trial/flexible_primitives_mnist_pytorch/distributed.yaml
+++ b/examples/experimental/trial/flexible_primitives_mnist_pytorch/distributed.yaml
@@ -11,7 +11,7 @@ searcher:
   name: single
   metric: loss
   max_length:
-    batches: 20_000
+    batches: 20000
   smaller_is_better: True
 entrypoint: model_def:GANTrial
 resources:

--- a/examples/experimental/trial/flexible_primitives_mnist_pytorch/distributed.yaml
+++ b/examples/experimental/trial/flexible_primitives_mnist_pytorch/distributed.yaml
@@ -10,7 +10,8 @@ hyperparameters:
 searcher:
   name: single
   metric: loss
-  max_steps: 200
+  max_length:
+    batches: 20_000
   smaller_is_better: True
 entrypoint: model_def:GANTrial
 resources:

--- a/examples/experimental/trial/gbt_estimator/adaptive.yaml
+++ b/examples/experimental/trial/gbt_estimator/adaptive.yaml
@@ -35,7 +35,8 @@ hyperparameters:
 searcher:
   name: adaptive_simple
   metric: accuracy
-  max_steps: 500
+  max_length:
+    batches: 500
   max_trials: 100
   smaller_is_better: false
 entrypoint: model_def:BoostedTreesTrial

--- a/examples/experimental/trial/gbt_estimator/const.yaml
+++ b/examples/experimental/trial/gbt_estimator/const.yaml
@@ -14,7 +14,8 @@ hyperparameters:
 searcher:
   name: single
   metric: accuracy
-  max_steps: 100
+  max_length:
+    batches: 100
   smaller_is_better: false
 entrypoint: model_def:BoostedTreesTrial
 batches_per_step: 1

--- a/examples/experimental/trial/imagenet_nas_arch_pytorch/const.yaml
+++ b/examples/experimental/trial/imagenet_nas_arch_pytorch/const.yaml
@@ -67,7 +67,7 @@ searcher:
   name: single
   metric: top1_accuracy 
   max_length:
-    batches: 30_000 # 1.2 million images in training set of imagenet
+    batches: 30000 # 1.2 million images in training set of imagenet
   smaller_is_better: false 
 
 optimizations:

--- a/examples/experimental/trial/imagenet_nas_arch_pytorch/const.yaml
+++ b/examples/experimental/trial/imagenet_nas_arch_pytorch/const.yaml
@@ -34,7 +34,8 @@ data:
 #    container_path: /mnt/data
 #    read_only: false
 
-min_validation_period: 10
+min_validation_period:
+  batches: 1000
 
 hyperparameters:
   num_classes: 1000
@@ -65,7 +66,8 @@ resources:
 searcher:
   name: single
   metric: top1_accuracy 
-  max_steps: 300 # 1.2 million images in training set of imagenet
+  max_length:
+    batches: 30_000 # 1.2 million images in training set of imagenet
   smaller_is_better: false 
 
 optimizations:

--- a/examples/experimental/trial/imagenet_nas_arch_pytorch/distributed.yaml
+++ b/examples/experimental/trial/imagenet_nas_arch_pytorch/distributed.yaml
@@ -66,7 +66,7 @@ searcher:
   name: single
   metric: top1_accuracy 
   max_length:
-    batches: 30_000 # 1.2 million images in training set of imagenet
+    batches: 30000 # 1.2 million images in training set of imagenet
   smaller_is_better: false 
 
 optimizations:

--- a/examples/experimental/trial/imagenet_nas_arch_pytorch/distributed.yaml
+++ b/examples/experimental/trial/imagenet_nas_arch_pytorch/distributed.yaml
@@ -31,7 +31,8 @@ data:
 #    container_path: /mnt/data
 #    read_only: false
 
-min_validation_period: 10
+min_validation_period:
+  batches: 1000
 
 hyperparameters:
   num_classes: 1000
@@ -64,7 +65,8 @@ resources:
 searcher:
   name: single
   metric: top1_accuracy 
-  max_steps: 300 # 1.2 million images in training set of imagenet
+  max_length:
+    batches: 30_000 # 1.2 million images in training set of imagenet
   smaller_is_better: false 
 
 optimizations:

--- a/examples/experimental/trial/mnist_pytorch_multi_output/adaptive.yaml
+++ b/examples/experimental/trial/mnist_pytorch_multi_output/adaptive.yaml
@@ -26,7 +26,8 @@ searcher:
   name: adaptive_simple
   metric: validation_error
   smaller_is_better: true
-  max_steps: 32
+  max_length:
+    batches: 3200
   max_trials: 16
   mode: aggressive
   max_rungs: 3

--- a/examples/experimental/trial/mnist_pytorch_multi_output/const.yaml
+++ b/examples/experimental/trial/mnist_pytorch_multi_output/const.yaml
@@ -10,6 +10,7 @@ hyperparameters:
 searcher:
   name: single
   metric: validation_error
-  max_steps: 10
+  max_length:
+    batches: 1000
   smaller_is_better: true
 entrypoint: model_def:MultiMNistTrial

--- a/examples/experimental/trial/mnist_tp_to_estimator/const.yaml
+++ b/examples/experimental/trial/mnist_tp_to_estimator/const.yaml
@@ -14,9 +14,11 @@ hyperparameters:
 searcher:
   name: single
   metric: loss
-  max_steps: 4
+  max_length:
+    batches: 64
   smaller_is_better: true
 max_restarts: 0
 batches_per_step: 16
-min_checkpoint_period: 2
+min_checkpoint_period:
+  batches: 32
 entrypoint: model_def:MnistTensorpackInEstimator

--- a/examples/experimental/trial/mnist_tp_to_estimator/const_visualize_synthetic.yaml
+++ b/examples/experimental/trial/mnist_tp_to_estimator/const_visualize_synthetic.yaml
@@ -14,9 +14,11 @@ hyperparameters:
 searcher:
   name: single
   metric: loss
-  max_steps: 20
+  max_length:
+    batches: 2000
   smaller_is_better: true
 max_restarts: 0
 batches_per_step: 100
-min_checkpoint_period: 20
+min_checkpoint_period:
+  batches: 2000
 entrypoint: model_def:MnistTensorpackInEstimator

--- a/examples/experimental/trial/nas_search/README.md
+++ b/examples/experimental/trial/nas_search/README.md
@@ -40,4 +40,4 @@ This project can perform multiple functions:
    This project also allows for multiple architectures to be evaluate based on the same model. This is similar to weight sharing; however during training, only one architecture is used. This should only be used if you want to see what weight sharing might look like in Determined.
 
 ### Results
-   Running an experiment with train_one_arch.yaml after 434 steps should return about 71 perplexity while using the ASHA genotype. If you continue training over 300 epochs, perplexity should reach about 64.
+   Running an experiment with train_one_arch.yaml after 100 epochs should return about 71 perplexity while using the ASHA genotype. If you continue training over 300 epochs, perplexity should reach about 64.

--- a/examples/experimental/trial/nas_search/arch_search.yaml
+++ b/examples/experimental/trial/nas_search/arch_search.yaml
@@ -28,12 +28,15 @@ hyperparameters:
   arch_to_use: None
   eval_same_arch: True
   num_archs_to_eval: 0 # only used when eval_same_arch is False
-min_validation_period: 4
+min_validation_period:
+  epochs: 1
 entrypoint: model_def:NASModel
+records_per_epoch: 27776
 searcher:
   name: random
   metric: loss
-  max_steps:  1242
+  max_length: 
+    epochs: 300
   smaller_is_better: true
   max_trials: 15 # number of architectures you would like to independently search
 data:

--- a/examples/experimental/trial/nas_search/train_one_arch.yaml
+++ b/examples/experimental/trial/nas_search/train_one_arch.yaml
@@ -28,15 +28,18 @@ hyperparameters:
   arch_to_use: 'ASHA'
   eval_same_arch: True
   num_archs_to_eval: 0 # only used when eval_same_arch is False
-min_validation_period: 4
+min_validation_period:
+  epochs: 1
 entrypoint: model_def:NASModel
 reproducibility: # used to reproduce the same results of the arch
   experiment_seed: 300
 max_restarts: 0
+records_per_epoch: 27776
 searcher:
   name: single
   metric: loss
-  max_steps: 434 # is about 100 epochs = ~ 400 batches is 1 epoch for batch size 64
+  max_length:
+    epochs: 100
   smaller_is_better: true
 data:
   out_file: 'data/architecture_'

--- a/examples/experimental/trial/omniglot_protonet_pytorch/20way1shot.yaml
+++ b/examples/experimental/trial/omniglot_protonet_pytorch/20way1shot.yaml
@@ -34,8 +34,10 @@ searcher:
   metric: loss
   smaller_is_better: true
   # Original paper trained for 10,000 epochs with a plateau stopping condition
-  max_steps: 300
+  max_length:
+    batches: 30000
 
 entrypoint: model_def:OmniglotProtoNetTrial
-min_validation_period: 50
+min_validation_period:
+  batches: 5000
 checkpoint_policy: none

--- a/examples/experimental/trial/omniglot_protonet_pytorch/20way5shot.yaml
+++ b/examples/experimental/trial/omniglot_protonet_pytorch/20way5shot.yaml
@@ -34,8 +34,10 @@ searcher:
   metric: loss
   smaller_is_better: true
   # Original paper trained for 10,000 epochs with a plateau stopping condition
-  max_steps: 300
+  max_length:
+    batches: 30000
 
 entrypoint: model_def:OmniglotProtoNetTrial
-min_validation_period: 50
+min_validation_period:
+  batches: 5000
 checkpoint_policy: none

--- a/examples/experimental/trial/resnet50_tf_keras/const.yaml
+++ b/examples/experimental/trial/resnet50_tf_keras/const.yaml
@@ -5,7 +5,8 @@ hyperparameters:
 searcher:
   name: single
   metric: val_loss
-  max_steps: 2
+  max_length:
+    batches: 200
 data:
   run_eagerly: False
   use_tensor_lr: False

--- a/examples/experimental/trial/resnet50_tf_keras/native_impl.py
+++ b/examples/experimental/trial/resnet50_tf_keras/native_impl.py
@@ -24,10 +24,14 @@ if __name__ == "__main__":
         "searcher": {
             "name": "single",
             "metric": "val_loss",
-            "max_steps": 1,
+            "max_length": {
+                "batches": 100,
+            },
             "smaller_is_better": True,
         },
-        "min_validation_period": 1,
+        "min_validation_period": {
+            "batches": 100,
+        },
         "hyperparameters": {
             "global_batch_size": det.Constant(value=32),
             "learning_rate": det.Constant(value=0.1),

--- a/examples/experimental/trial/unets_tf_keras/const.yaml
+++ b/examples/experimental/trial/unets_tf_keras/const.yaml
@@ -11,15 +11,16 @@ hyperparameters:
   global_batch_size: 64
   OUTPUT_CHANNELS: 3
 
+records_per_epoch: 7400
 searcher:
   name: single
   metric: val_accuracy
-  smaller_is_better: false
-  max_steps: 230 # There are ~7400 examples (200 examples/class * 37 classes) in the training set
-                   # We run for 20 epochs as per the Tensorflow UNet tutorial. We get 230 by:
-                   # 7400 / global_batch_size / (1 batch per step) * 20 epochs
+  smaller_is_better: false 
+  max_length: 
+    epochs: 20
 
-min_validation_period: 10
+min_validation_period:
+  epochs: 1
 entrypoint: model_def:UNetsTrial
 environment:
   image:

--- a/examples/experimental/trial/unets_tf_keras/distributed.yaml
+++ b/examples/experimental/trial/unets_tf_keras/distributed.yaml
@@ -11,17 +11,18 @@ hyperparameters:
   global_batch_size: 512 # per slot batch size = 64
   OUTPUT_CHANNELS: 3
 
+records_per_epoch: 7400
 searcher:
   name: single
   metric: val_accuracy
   smaller_is_better: false
-  max_steps: 230 # There are ~7400 examples (200 examples/class * 37 classes) in the training set
-                   # We run for 20 epochs as per the Tensorflow UNet tutorial. We get 230 by:
-                   # 7400 / global_batch_size / (1 batch per step) * 20 epochs
+  max_length: 
+    epochs: 20
 resources:
     slots_per_trial: 8
 
-min_validation_period: 10
+min_validation_period:
+  epochs: 1
 entrypoint: model_def:UNetsTrial
 environment:
   image:

--- a/examples/official/native/native_fashion_mnist_tf_keras/model_def.py
+++ b/examples/official/native/native_fashion_mnist_tf_keras/model_def.py
@@ -5,8 +5,8 @@ classification model for the Fashion-MNIST dataset using tf.keras.
 Based on: https://www.tensorflow.org/tutorials/keras/classification.
 
 After about 5 training epochs, accuracy should be around > 85%.
-This mimics theoriginal implementation. Continue training or increase
-the number of steps to increase accuracy.
+This mimics the original implementation. Continue training or increase
+the number of epochs to increase accuracy.
 """
 import tensorflow as tf
 from tensorflow import keras

--- a/examples/official/native/native_fashion_mnist_tf_keras/native_impl.py
+++ b/examples/official/native/native_fashion_mnist_tf_keras/native_impl.py
@@ -56,7 +56,14 @@ if __name__ == "__main__":
             "global_batch_size": det.Constant(value=32),
             "dense1": det.Constant(value=128),
         },
-        "searcher": {"name": "single", "metric": "val_accuracy", "max_steps": 40},
+        "records_per_epoch": 50000,
+        "searcher": {
+            "name": "single",
+            "metric": "val_accuracy",
+            "max_length": {
+                "epochs": 5,
+            }
+        },
     }
     config.update(json.loads(args.config))
 

--- a/examples/official/native/native_fashion_mnist_tf_keras/trial_impl.py
+++ b/examples/official/native/native_fashion_mnist_tf_keras/trial_impl.py
@@ -29,7 +29,14 @@ if __name__ == "__main__":
             "global_batch_size": det.Constant(value=32),
             "dense1": det.Constant(value=128),
         },
-        "searcher": {"name": "single", "metric": "val_accuracy", "max_steps": 40},
+        "records_per_epoch": 50000,
+        "searcher": {
+            "name": "single",
+            "metric": "val_accuracy",
+            "max_length": {
+                "epochs": 5,
+            }
+        },
     }
     config.update(json.loads(args.config))
 

--- a/examples/official/native/native_mnist_estimator/native_impl.py
+++ b/examples/official/native/native_mnist_estimator/native_impl.py
@@ -153,7 +153,9 @@ if __name__ == "__main__":
         "searcher": {
             "name": "single",
             "metric": "accuracy",
-            "max_steps": 10,
+            "max_length": {
+                "batches": 1000,
+            },
             "smaller_is_better": False,
         },
     }

--- a/examples/official/native/native_mnist_estimator/trial_impl.py
+++ b/examples/official/native/native_mnist_estimator/trial_impl.py
@@ -35,7 +35,9 @@ if __name__ == "__main__":
         "searcher": {
             "name": "single",
             "metric": "accuracy",
-            "max_steps": 10,
+            "max_length": {
+                "batches": 1000,
+            },
             "smaller_is_better": False,
         },
     }

--- a/examples/official/native/native_mnist_pytorch/trial_impl.py
+++ b/examples/official/native/native_mnist_pytorch/trial_impl.py
@@ -38,7 +38,9 @@ if __name__ == "__main__":
         "searcher": {
             "name": "single",
             "metric": "validation_error",
-            "max_steps": 20,
+            "max_length": {
+                "batches": 2000,
+            },
             "smaller_is_better": True,
         },
     }

--- a/examples/official/native/native_object_detection_pytorch/trial_impl.py
+++ b/examples/official/native/native_object_detection_pytorch/trial_impl.py
@@ -34,7 +34,9 @@ if __name__ == "__main__":
         "searcher": {
             "name": "single",
             "metric": "val_avg_iou",
-            "max_steps": 16,
+            "max_length": {
+                "batches": 1600,
+            },
             "smaller_is_better": False,
         },
     }

--- a/examples/official/trial/cifar10_cnn_pytorch/adaptive-advanced.yaml
+++ b/examples/official/trial/cifar10_cnn_pytorch/adaptive-advanced.yaml
@@ -24,7 +24,7 @@ hyperparameters:
     type: int
     minval: 16
     maxval: 64
-records_per_epoch: 50_000
+records_per_epoch: 50000
 searcher:
   name: adaptive
   metric: validation_error

--- a/examples/official/trial/cifar10_cnn_pytorch/adaptive-advanced.yaml
+++ b/examples/official/trial/cifar10_cnn_pytorch/adaptive-advanced.yaml
@@ -24,11 +24,15 @@ hyperparameters:
     type: int
     minval: 16
     maxval: 64
+records_per_epoch: 50_000
 searcher:
   name: adaptive
   metric: validation_error
   mode: aggressive
-  target_trial_steps: 800
-  step_budget: 4800
+  max_length:
+    epochs: 50
+  budget:
+    epochs: 300
 entrypoint: model_def:CIFARTrial
-min_validation_period: 10
+min_validation_period:
+  epochs: 1

--- a/examples/official/trial/cifar10_cnn_pytorch/adaptive.yaml
+++ b/examples/official/trial/cifar10_cnn_pytorch/adaptive.yaml
@@ -24,10 +24,13 @@ hyperparameters:
     type: int
     minval: 16
     maxval: 64
+records_per_epoch: 50_000
 searcher:
   name: adaptive_simple
   metric: validation_error
-  max_steps: 800
+  max_length:
+    epochs: 50
   max_trials: 16
 entrypoint: model_def:CIFARTrial
-min_validation_period: 10
+min_validation_period:
+  epochs: 1

--- a/examples/official/trial/cifar10_cnn_pytorch/adaptive.yaml
+++ b/examples/official/trial/cifar10_cnn_pytorch/adaptive.yaml
@@ -24,7 +24,7 @@ hyperparameters:
     type: int
     minval: 16
     maxval: 64
-records_per_epoch: 50_000
+records_per_epoch: 50000
 searcher:
   name: adaptive_simple
   metric: validation_error

--- a/examples/official/trial/cifar10_cnn_pytorch/const.yaml
+++ b/examples/official/trial/cifar10_cnn_pytorch/const.yaml
@@ -10,7 +10,7 @@ hyperparameters:
   layer2_dropout: 0.25
   layer3_dropout: 0.5
   global_batch_size: 32
-records_per_epoch: 50_000
+records_per_epoch: 50000
 searcher:
   name: single
   metric: validation_error

--- a/examples/official/trial/cifar10_cnn_pytorch/const.yaml
+++ b/examples/official/trial/cifar10_cnn_pytorch/const.yaml
@@ -1,4 +1,4 @@
-# Reaches an approximate validation error of ~74.9% after 500 steps (32 epochs).
+# Reaches an approximate validation error of ~74.9% after 32 epochs.
 
 description: cifar10_pytorch_const
 data:
@@ -10,14 +10,13 @@ hyperparameters:
   layer2_dropout: 0.25
   layer3_dropout: 0.5
   global_batch_size: 32
+records_per_epoch: 50_000
 searcher:
   name: single
   metric: validation_error
   smaller_is_better: true
-
-  # 32 images per batch * 100 batches per step = 3,200 images per step
-  # 500 steps * 3,200 images per step = 1,600,000 total images
-  # 1,600,000 images / 50,000 images in training set = 32 epochs training
-  max_steps: 500
+  max_length:
+    epochs: 32
 entrypoint: model_def:CIFARTrial
-min_validation_period: 10
+min_validation_period:
+  epochs: 1

--- a/examples/official/trial/cifar10_cnn_pytorch/distributed.yaml
+++ b/examples/official/trial/cifar10_cnn_pytorch/distributed.yaml
@@ -14,7 +14,9 @@ resources:
 searcher:
   name: single
   metric: validation_error
-  max_steps: 50
+  max_length:
+    batches: 5000
   smaller_is_better: true
 entrypoint: model_def:CIFARTrial
-min_validation_period: 10
+min_validation_period:
+  batches: 1000

--- a/examples/official/trial/cifar10_cnn_pytorch/model_def.py
+++ b/examples/official/trial/cifar10_cnn_pytorch/model_def.py
@@ -1,8 +1,6 @@
 """
 CNN on Cifar10 from Keras example:
 https://github.com/fchollet/keras/blob/master/examples/cifar10_cnn.py
-- const.yaml, ~50% accuracy after 50 steps
-- adaptive.yaml, accuracy comparable to Keras example after 50 steps
 """
 
 import tempfile

--- a/examples/official/trial/cifar10_cnn_tf_keras/adaptive-advanced.yaml
+++ b/examples/official/trial/cifar10_cnn_tf_keras/adaptive-advanced.yaml
@@ -37,10 +37,13 @@ hyperparameters:
     vals:
       - True
       - False
+records_per_epoch: 50_000
 searcher:
   name: adaptive
   mode: aggressive
   metric: val_categorical_error
-  target_trial_steps: 800
-  step_budget: 4800
+  max_length:
+    epochs: 50
+  budget:
+    epochs: 300
 entrypoint: model_def:CIFARTrial

--- a/examples/official/trial/cifar10_cnn_tf_keras/adaptive-advanced.yaml
+++ b/examples/official/trial/cifar10_cnn_tf_keras/adaptive-advanced.yaml
@@ -37,7 +37,7 @@ hyperparameters:
     vals:
       - True
       - False
-records_per_epoch: 50_000
+records_per_epoch: 50000
 searcher:
   name: adaptive
   mode: aggressive

--- a/examples/official/trial/cifar10_cnn_tf_keras/adaptive.yaml
+++ b/examples/official/trial/cifar10_cnn_tf_keras/adaptive.yaml
@@ -37,10 +37,12 @@ hyperparameters:
     vals:
       - True
       - False
+records_per_epoch: 50_000
 searcher:
   name: adaptive_simple
   mode: aggressive
   metric: val_categorical_error
-  max_steps: 800
+  max_length:
+    epochs: 50
   max_trials: 16
 entrypoint: model_def:CIFARTrial

--- a/examples/official/trial/cifar10_cnn_tf_keras/adaptive.yaml
+++ b/examples/official/trial/cifar10_cnn_tf_keras/adaptive.yaml
@@ -37,7 +37,7 @@ hyperparameters:
     vals:
       - True
       - False
-records_per_epoch: 50_000
+records_per_epoch: 50000
 searcher:
   name: adaptive_simple
   mode: aggressive

--- a/examples/official/trial/cifar10_cnn_tf_keras/const.yaml
+++ b/examples/official/trial/cifar10_cnn_tf_keras/const.yaml
@@ -14,6 +14,8 @@ hyperparameters:
 searcher:
   name: single
   metric: val_categorical_error
-  max_steps: 50
-min_validation_period: 10
+  max_length:
+    batches: 5000
+min_validation_period:
+  batches: 1000
 entrypoint: model_def:CIFARTrial

--- a/examples/official/trial/cifar10_cnn_tf_keras/distributed.yaml
+++ b/examples/official/trial/cifar10_cnn_tf_keras/distributed.yaml
@@ -17,6 +17,8 @@ resources:
 searcher:
   name: single
   metric: val_categorical_error
-  max_steps: 50
-min_validation_period: 10
+  max_length:
+    batches: 5000
+min_validation_period:
+  batches: 1000
 entrypoint: model_def:CIFARTrial

--- a/examples/official/trial/fashion_mnist_tf_keras/adaptive.yaml
+++ b/examples/official/trial/fashion_mnist_tf_keras/adaptive.yaml
@@ -5,10 +5,12 @@ hyperparameters:
     type: int
     minval: 32
     maxval: 256
+records_per_epoch: 28800
 searcher:
   name: adaptive_simple
   metric: val_accuracy
   smaller_is_better: false
-  max_steps: 45 # num steps = number of desired epochs (5) * (total batches per epoch (~900) / batches per step (100))
+  max_length:
+    epochs: 5
   max_trials: 10
 entrypoint: model_def:FashionMNISTTrial

--- a/examples/official/trial/fashion_mnist_tf_keras/const.yaml
+++ b/examples/official/trial/fashion_mnist_tf_keras/const.yaml
@@ -2,8 +2,10 @@ description: fashion_mnist_tf_keras_const
 hyperparameters:
   global_batch_size: 32
   dense1: 128
+records_per_epoch: 28800
 searcher:
   name: single
   metric: val_accuracy
-  max_steps: 45 # num steps = number of desired epochs (5) * (total batches per epoch (~900) / batches per step (100))
+  max_length:
+    epochs: 5
 entrypoint: model_def:FashionMNISTTrial

--- a/examples/official/trial/fashion_mnist_tf_keras/distributed.yaml
+++ b/examples/official/trial/fashion_mnist_tf_keras/distributed.yaml
@@ -5,8 +5,10 @@ hyperparameters:
 resources:
   # Use 16 GPUs to train the model.
   slots_per_trial: 16
+records_per_epoch: 28800
 searcher:
   name: single
   metric: val_accuracy
-  max_steps: 9 # num steps = number of desired epochs (5) * (total batches per epoch (~900) / batches per step (100))
+  max_length:
+    epochs: 5
 entrypoint: model_def:FashionMNISTTrial

--- a/examples/official/trial/fashion_mnist_tf_keras/model_def.py
+++ b/examples/official/trial/fashion_mnist_tf_keras/model_def.py
@@ -6,7 +6,7 @@ Based on: https://www.tensorflow.org/tutorials/keras/classification.
 
 After about 5 training epochs, accuracy should be around > 85%.
 This mimics theoriginal implementation. Continue training or increase
-the number of steps to increase accuracy.
+the number of epochs to increase accuracy.
 """
 import tensorflow as tf
 from tensorflow import keras

--- a/examples/official/trial/iris_tf_keras/adaptive.yaml
+++ b/examples/official/trial/iris_tf_keras/adaptive.yaml
@@ -21,6 +21,7 @@ searcher:
   name: adaptive_simple
   metric: val_categorical_accuracy
   smaller_is_better: false
-  max_steps: 64
+  max_length:
+    batches: 6_400
   max_trials: 512
 entrypoint: model_def:IrisTrial

--- a/examples/official/trial/iris_tf_keras/adaptive.yaml
+++ b/examples/official/trial/iris_tf_keras/adaptive.yaml
@@ -22,6 +22,6 @@ searcher:
   metric: val_categorical_accuracy
   smaller_is_better: false
   max_length:
-    batches: 6_400
+    batches: 6400
   max_trials: 512
 entrypoint: model_def:IrisTrial

--- a/examples/official/trial/iris_tf_keras/const.yaml
+++ b/examples/official/trial/iris_tf_keras/const.yaml
@@ -11,5 +11,5 @@ searcher:
   name: single
   metric: val_categorical_accuracy
   max_length:
-    batches: 5_000
+    batches: 5000
 entrypoint: model_def:IrisTrial

--- a/examples/official/trial/iris_tf_keras/const.yaml
+++ b/examples/official/trial/iris_tf_keras/const.yaml
@@ -10,5 +10,6 @@ hyperparameters:
 searcher:
   name: single
   metric: val_categorical_accuracy
-  max_steps: 50
+  max_length:
+    batches: 5_000
 entrypoint: model_def:IrisTrial

--- a/examples/official/trial/iris_tf_keras/distributed.yaml
+++ b/examples/official/trial/iris_tf_keras/distributed.yaml
@@ -14,5 +14,5 @@ searcher:
   name: single
   metric: val_categorical_accuracy
   max_length:
-    batches: 5_000
+    batches: 5000
 entrypoint: model_def:IrisTrial

--- a/examples/official/trial/iris_tf_keras/distributed.yaml
+++ b/examples/official/trial/iris_tf_keras/distributed.yaml
@@ -13,5 +13,6 @@ resources:
 searcher:
   name: single
   metric: val_categorical_accuracy
-  max_steps: 50
+  max_length:
+    batches: 5_000
 entrypoint: model_def:IrisTrial

--- a/examples/official/trial/mnist_estimator/adaptive-advanced.yaml
+++ b/examples/official/trial/mnist_estimator/adaptive-advanced.yaml
@@ -26,9 +26,9 @@ searcher:
   name: adaptive
   metric: accuracy
   max_length:
-    batches: 3_200
+    batches: 3200
   budget:
-    batches: 10_000
+    batches: 10000
   mode: aggressive
   max_rungs: 3
   divisor: 4

--- a/examples/official/trial/mnist_estimator/adaptive-advanced.yaml
+++ b/examples/official/trial/mnist_estimator/adaptive-advanced.yaml
@@ -25,8 +25,10 @@ hyperparameters:
 searcher:
   name: adaptive
   metric: accuracy
-  target_trial_steps: 32 
-  step_budget: 100
+  max_length:
+    batches: 3_200
+  budget:
+    batches: 10_000
   mode: aggressive
   max_rungs: 3
   divisor: 4

--- a/examples/official/trial/mnist_estimator/adaptive.yaml
+++ b/examples/official/trial/mnist_estimator/adaptive.yaml
@@ -26,7 +26,7 @@ searcher:
   name: adaptive_simple
   metric: accuracy
   max_length:
-    batches: 6_400
+    batches: 6400
   max_trials: 16
   smaller_is_better: false
 entrypoint: model_def:MNistTrial

--- a/examples/official/trial/mnist_estimator/adaptive.yaml
+++ b/examples/official/trial/mnist_estimator/adaptive.yaml
@@ -25,7 +25,8 @@ hyperparameters:
 searcher:
   name: adaptive_simple
   metric: accuracy
-  max_steps: 64
+  max_length:
+    batches: 6_400
   max_trials: 16
   smaller_is_better: false
 entrypoint: model_def:MNistTrial

--- a/examples/official/trial/mnist_estimator/const.yaml
+++ b/examples/official/trial/mnist_estimator/const.yaml
@@ -10,6 +10,6 @@ searcher:
   name: single
   metric: accuracy
   max_length:
-    batches: 2_000
+    batches: 2000
   smaller_is_better: false
 entrypoint: model_def:MNistTrial

--- a/examples/official/trial/mnist_estimator/const.yaml
+++ b/examples/official/trial/mnist_estimator/const.yaml
@@ -9,6 +9,7 @@ hyperparameters:
 searcher:
   name: single
   metric: accuracy
-  max_steps: 20
+  max_length:
+    batches: 2_000
   smaller_is_better: false
 entrypoint: model_def:MNistTrial

--- a/examples/official/trial/mnist_estimator/distributed.yaml
+++ b/examples/official/trial/mnist_estimator/distributed.yaml
@@ -12,6 +12,7 @@ resources:
 searcher:
   name: single
   metric: accuracy
-  max_steps: 20
+  max_length:
+    batches: 2_000
   smaller_is_better: false
 entrypoint: model_def:MNistTrial

--- a/examples/official/trial/mnist_estimator/distributed.yaml
+++ b/examples/official/trial/mnist_estimator/distributed.yaml
@@ -13,6 +13,6 @@ searcher:
   name: single
   metric: accuracy
   max_length:
-    batches: 2_000
+    batches: 2000
   smaller_is_better: false
 entrypoint: model_def:MNistTrial

--- a/examples/official/trial/mnist_pytorch/adaptive.yaml
+++ b/examples/official/trial/mnist_pytorch/adaptive.yaml
@@ -25,10 +25,12 @@ hyperparameters:
     type: double
     minval: .2
     maxval: .8
+records_per_epoch: 50_000
 searcher:
   name: adaptive_simple
   metric: validation_loss
   smaller_is_better: true
-  max_steps: 9
+  max_length:
+    epochs: 1
   max_trials: 16
 entrypoint: model_def:MNistTrial

--- a/examples/official/trial/mnist_pytorch/adaptive.yaml
+++ b/examples/official/trial/mnist_pytorch/adaptive.yaml
@@ -25,7 +25,7 @@ hyperparameters:
     type: double
     minval: .2
     maxval: .8
-records_per_epoch: 50_000
+records_per_epoch: 50000
 searcher:
   name: adaptive_simple
   metric: validation_loss

--- a/examples/official/trial/mnist_pytorch/const.yaml
+++ b/examples/official/trial/mnist_pytorch/const.yaml
@@ -8,7 +8,7 @@ hyperparameters:
   n_filters2: 64
   dropout1: 0.25
   dropout2: 0.5
-records_per_epoch: 50_000
+records_per_epoch: 50000
 searcher:
   name: single
   metric: validation_loss

--- a/examples/official/trial/mnist_pytorch/const.yaml
+++ b/examples/official/trial/mnist_pytorch/const.yaml
@@ -8,9 +8,11 @@ hyperparameters:
   n_filters2: 64
   dropout1: 0.25
   dropout2: 0.5
+records_per_epoch: 50_000
 searcher:
   name: single
   metric: validation_loss
-  max_steps: 9 # 9 steps is ~ one epoch
+  max_length:
+    epochs: 1
   smaller_is_better: true
 entrypoint: model_def:MNistTrial

--- a/examples/official/trial/mnist_pytorch/distributed.yaml
+++ b/examples/official/trial/mnist_pytorch/distributed.yaml
@@ -11,7 +11,7 @@ hyperparameters:
 resources:
   # Use 16 GPUs to train the model.
   slots_per_trial: 16
-records_per_epoch: 50_000
+records_per_epoch: 50000
 searcher:
   name: single
   metric: validation_loss

--- a/examples/official/trial/mnist_pytorch/distributed.yaml
+++ b/examples/official/trial/mnist_pytorch/distributed.yaml
@@ -11,9 +11,11 @@ hyperparameters:
 resources:
   # Use 16 GPUs to train the model.
   slots_per_trial: 16
+records_per_epoch: 50_000
 searcher:
   name: single
   metric: validation_loss
-  max_steps: 9 # 9 steps is ~ one epoch
+  max_length:
+    epochs: 1
   smaller_is_better: true
 entrypoint: model_def:MNistTrial

--- a/examples/official/trial/mnist_tp/adaptive.yaml
+++ b/examples/official/trial/mnist_tp/adaptive.yaml
@@ -32,9 +32,11 @@ hyperparameters:
 searcher:
   name: adaptive_simple
   metric: val_accuracy
-  max_steps: 20
+  max_length:
+    batches: 320
   max_trials: 16
   smaller_is_better: false
 batches_per_step: 16
-min_checkpoint_period: 2
+min_checkpoint_period:
+  batches: 32
 entrypoint: model_def:MNISTTrial

--- a/examples/official/trial/mnist_tp/const.yaml
+++ b/examples/official/trial/mnist_tp/const.yaml
@@ -14,8 +14,10 @@ hyperparameters:
 searcher:
   name: single
   metric: val_accuracy
-  max_steps: 20
+  max_length:
+    batches: 320
   smaller_is_better: false
 batches_per_step: 16
-min_checkpoint_period: 2
+min_checkpoint_period:
+  batches: 32
 entrypoint: model_def:MNISTTrial

--- a/examples/official/trial/mnist_tp/distributed.yaml
+++ b/examples/official/trial/mnist_tp/distributed.yaml
@@ -17,8 +17,10 @@ resources:
 searcher:
   name: single
   metric: val_accuracy
-  max_steps: 20
+  max_length:
+    batches: 320
   smaller_is_better: false
 batches_per_step: 16
-min_checkpoint_period: 2
+min_checkpoint_period:
+  batches: 32
 entrypoint: model_def:MNISTTrial

--- a/examples/official/trial/multiple_lr_schedulers_pytorch/const.yaml
+++ b/examples/official/trial/multiple_lr_schedulers_pytorch/const.yaml
@@ -8,10 +8,12 @@ hyperparameters:
   n_filters2: 64
   dropout1: 0.25
   dropout2: 0.5
+records_per_epoch: 50_000
 searcher:
   name: single
   metric: validation_loss
-  max_steps: 9 # 9 steps is ~ one epoch
+  max_length:
+    epochs: 1
   smaller_is_better: true
 entrypoint: multiple_lr_schedulers_pytorch:MNistTrial
 max_restarts: 0

--- a/examples/official/trial/multiple_lr_schedulers_pytorch/const.yaml
+++ b/examples/official/trial/multiple_lr_schedulers_pytorch/const.yaml
@@ -8,7 +8,7 @@ hyperparameters:
   n_filters2: 64
   dropout1: 0.25
   dropout2: 0.5
-records_per_epoch: 50_000
+records_per_epoch: 50000
 searcher:
   name: single
   metric: validation_loss

--- a/examples/official/trial/object_detection_pytorch/adaptive.yaml
+++ b/examples/official/trial/object_detection_pytorch/adaptive.yaml
@@ -15,7 +15,8 @@ hyperparameters:
 searcher:
   name: adaptive_simple
   metric: val_avg_iou
-  max_steps: 8
+  max_length:
+    batches: 800
   smaller_is_better: false
   max_trials: 16
 entrypoint: model_def:ObjectDetectionTrial

--- a/examples/official/trial/object_detection_pytorch/const.yaml
+++ b/examples/official/trial/object_detection_pytorch/const.yaml
@@ -9,6 +9,7 @@ hyperparameters:
 searcher:
   name: single
   metric: val_avg_iou
-  max_steps: 8
+  max_length:
+    batches: 800
   smaller_is_better: false
 entrypoint: model_def:ObjectDetectionTrial

--- a/examples/tutorials/native-tf-keras/tf_keras_native.py
+++ b/examples/tutorials/native-tf-keras/tf_keras_native.py
@@ -35,7 +35,7 @@ from determined import experimental
 from determined.experimental.keras import init
 
 config = {
-    "searcher": {"name": "single", "metric": "val_acc", "max_steps": 5},
+    "searcher": {"name": "single", "metric": "val_acc", "max_length": {"batches": 500}},
     "hyperparameters": {"global_batch_size": 32},
 }
 
@@ -78,7 +78,7 @@ model.fit(x_train, y_train, validation_data=(x_test, y_test), epochs=5)
 # -------------
 
 config = {
-    "searcher": {"name": "single", "metric": "val_acc", "max_steps": 5},
+    "searcher": {"name": "single", "metric": "val_acc", "max_length": {"batches": 500}},
     "hyperparameters": {"global_batch_size": 16},
 }
 
@@ -92,8 +92,7 @@ config = {
 # ``searcher``:
 #       This field describes how many different :ref:`Trials <concept-trial>`
 #       (models) should be trained.  In this case, we've specified to
-#       train a ``"single"`` model for five :ref:`training steps
-#       <concept-step>`.
+#       train a ``"single"`` model for 500 batches.
 # ``hyperparameters``:
 #       This field describes the hyperparameters used. ``global_batch_size`` is
 #       a required hyperparameter for every experiment -- we'll revisit this

--- a/examples/tutorials/native-tf-keras/tf_keras_native_dtrain.py
+++ b/examples/tutorials/native-tf-keras/tf_keras_native_dtrain.py
@@ -15,7 +15,11 @@ import determined as det
 from determined.experimental.keras import init
 
 config = {
-    "searcher": {"name": "single", "metric": "val_accuracy", "max_steps": 5},
+    "searcher": {
+        "name": "single",
+        "metric": "val_accuracy", "max_length": {
+            "batches": 500,
+        }},
     "hyperparameters": {"global_batch_size": "256"},
     "resources": {"slots_per_trial": 8},
 }

--- a/examples/tutorials/native-tf-keras/tf_keras_native_hparam_search.py
+++ b/examples/tutorials/native-tf-keras/tf_keras_native_hparam_search.py
@@ -15,7 +15,8 @@ import determined as det
 from determined.experimental.keras import init
 
 config = {
-    "searcher": {"name": "adaptive_simple", "metric": "val_loss", "max_steps": 5, "max_trials": 5},
+    "searcher": {"name": "adaptive_simple", "metric": "val_loss",
+        "max_length": {"batches": 500}, "max_trials": 5},
     "hyperparameters": {
         "num_units": det.Integer(64, 256),
         "dropout": det.Double(0.0, 0.5),


### PR DESCRIPTION
## Description
This change updates all examples to use the configuration changes made by #937.

## Test Plan

- [x] self-review PR
- [x] submit all experiments to check configs

```
(determined) ➜  examples git:(remove-steps-from-docs-v2) ✗ paste <(print -l $(ls **/*.yaml)) <(print -l $(ls **/*.yaml | xargs -L 1 dirname)) | xargs -L 1 det e create
Preparing files (/Users/bradleylaney/Code/determined/examples/experimental/trial/FasterRCNN_tp) to send to master... 213.4KB and 30 files
Created experiment 55
Preparing files (/Users/bradleylaney/Code/determined/examples/experimental/trial/FasterRCNN_tp) to send to master... 213.4KB and 30 files
Created experiment 56
...
```

All are created successfully.

## Commentary (optional)
Tried to convert the configurations to epochs where it was obvious enough for a non ml-engineer (me) to figure it out.