### PR TITLE
chore: remove steps from the CLI [DET-3625]

### DIFF
--- a/cli/determined_cli/checkpoint.py
+++ b/cli/determined_cli/checkpoint.py
@@ -84,7 +84,7 @@ def list(args: Namespace) -> None:
     values = [
         [
             c["trial_id"],
-            c["step"]["num_batches"],
+            c["step"]["total_batches_processed"] + c["step"]["num_batches"],
             c["state"],
             api.metric.get_validation_metric(searcher_metric, c["step"]["validation"]),
             c["uuid"],

--- a/cli/determined_cli/checkpoint.py
+++ b/cli/determined_cli/checkpoint.py
@@ -74,7 +74,7 @@ def list(args: Namespace) -> None:
 
     headers = [
         "Trial ID",
-        "Train Workload #",
+        "# of Batches",
         "State",
         "Validation Metric",
         "UUID",
@@ -84,7 +84,7 @@ def list(args: Namespace) -> None:
     values = [
         [
             c["trial_id"],
-            c["step_id"],
+            c["step"]["num_batches"],
             c["state"],
             api.metric.get_validation_metric(searcher_metric, c["step"]["validation"]),
             c["uuid"],

--- a/cli/determined_cli/checkpoint.py
+++ b/cli/determined_cli/checkpoint.py
@@ -72,7 +72,15 @@ def list(args: Namespace) -> None:
     ).json()
     searcher_metric = r["metric_name"]
 
-    headers = ["Trial ID", "Step ID", "State", "Validation Metric", "UUID", "Resources", "Size"]
+    headers = [
+        "Trial ID",
+        "Train Workload #",
+        "State",
+        "Validation Metric",
+        "UUID",
+        "Resources",
+        "Size",
+    ]
     values = [
         [
             c["trial_id"],

--- a/cli/determined_cli/experiment.py
+++ b/cli/determined_cli/experiment.py
@@ -280,7 +280,7 @@ def describe(args: Namespace) -> None:
         v_metrics_headers = []
 
     headers = (
-        ["Trial ID", "Step ID", "State", "Start Time", "End Time"]
+        ["Trial ID", "Train Workload #", "State", "Start Time", "End Time"]
         + t_metrics_headers
         + [
             "Checkpoint State",
@@ -357,9 +357,9 @@ def describe(args: Namespace) -> None:
 
     if not args.outdir:
         outfile = None
-        print("\nSteps:")
+        print("\nWorkloads:")
     else:
-        outfile = args.outdir.joinpath("steps.csv")
+        outfile = args.outdir.joinpath("workloads.csv")
     render.tabulate_or_csv(headers, values, args.csv, outfile)
 
 
@@ -492,7 +492,7 @@ def list_trials(args: Namespace) -> None:
     r = api.get(args.master, "experiments/{}/summary".format(args.experiment_id))
     experiment = r.json()
 
-    headers = ["Trial ID", "State", "H-Params", "Start Time", "End Time", "# of Steps"]
+    headers = ["Trial ID", "State", "H-Params", "Start Time", "End Time", "# of Train Workloads"]
     values = [
         [
             t["id"],
@@ -562,7 +562,7 @@ def set_gc_policy(args: Namespace) -> None:
 
         headers = [
             "Trial ID",
-            "Step ID",
+            "Train Workload #",
             "State",
             "Validation Metric\n({})".format(metric_name),
             "UUID",
@@ -741,7 +741,7 @@ args_description = Cmd(
                         help="Test the experiment configuration and model "
                         "definition by creating and scheduling a very small "
                         "experiment. This command will verify that a training "
-                        "step and validation step run successfully and that "
+                        "workload and validation workload run successfully and that "
                         "checkpoints can be saved. The test experiment will "
                         "be archived on creation.",
                     ),

--- a/cli/determined_cli/experiment.py
+++ b/cli/determined_cli/experiment.py
@@ -298,7 +298,7 @@ def describe(args: Namespace) -> None:
         for trial in doc["trials"]:
             batch_number = 0
             for step in trial["steps"]:
-                batch_number += step['num_batches']
+                batch_number += step["num_batches"]
                 t_metrics_fields = []
                 if step.get("metrics"):
                     avg_metrics = step["metrics"]["avg_metrics"]
@@ -502,7 +502,7 @@ def list_trials(args: Namespace) -> None:
             json.dumps(t["hparams"], indent=4),
             render.format_time(t["start_time"]),
             render.format_time(t["end_time"]),
-            t['num_batches'],
+            t["num_batches"],
         ]
         for t in experiment["trials"]
     ]

--- a/cli/determined_cli/experiment.py
+++ b/cli/determined_cli/experiment.py
@@ -280,7 +280,7 @@ def describe(args: Namespace) -> None:
         v_metrics_headers = []
 
     headers = (
-        ["Trial ID", "Train Workload #", "State", "Start Time", "End Time"]
+        ["Trial ID", "# of Batches", "State", "Start Time", "End Time"]
         + t_metrics_headers
         + [
             "Checkpoint State",
@@ -296,7 +296,9 @@ def describe(args: Namespace) -> None:
     values = []
     for doc in docs:
         for trial in doc["trials"]:
+            batch_number = 0
             for step in trial["steps"]:
+                batch_number += step['num_batches']
                 t_metrics_fields = []
                 if step.get("metrics"):
                     avg_metrics = step["metrics"]["avg_metrics"]
@@ -337,7 +339,7 @@ def describe(args: Namespace) -> None:
                 row = (
                     [
                         step["trial_id"],
-                        step["id"],
+                        batch_number,
                         step["state"],
                         render.format_time(step.get("start_time")),
                         render.format_time(step.get("end_time")),
@@ -492,7 +494,7 @@ def list_trials(args: Namespace) -> None:
     r = api.get(args.master, "experiments/{}/summary".format(args.experiment_id))
     experiment = r.json()
 
-    headers = ["Trial ID", "State", "H-Params", "Start Time", "End Time", "# of Train Workloads"]
+    headers = ["Trial ID", "State", "H-Params", "Start Time", "End Time", "# of Batches"]
     values = [
         [
             t["id"],
@@ -500,7 +502,7 @@ def list_trials(args: Namespace) -> None:
             json.dumps(t["hparams"], indent=4),
             render.format_time(t["start_time"]),
             render.format_time(t["end_time"]),
-            t["num_steps"],
+            t['num_batches'],
         ]
         for t in experiment["trials"]
     ]
@@ -562,7 +564,7 @@ def set_gc_policy(args: Namespace) -> None:
 
         headers = [
             "Trial ID",
-            "Train Workload #",
+            "# of Batches",
             "State",
             "Validation Metric\n({})".format(metric_name),
             "UUID",
@@ -571,7 +573,7 @@ def set_gc_policy(args: Namespace) -> None:
         values = [
             [
                 c["trial_id"],
-                c["step_id"],
+                c["step"]["num_batches"],
                 c["state"],
                 api.metric.get_validation_metric(metric_name, c["step"]["validation"]),
                 c["uuid"],

--- a/cli/determined_cli/experiment.py
+++ b/cli/determined_cli/experiment.py
@@ -296,9 +296,9 @@ def describe(args: Namespace) -> None:
     values = []
     for doc in docs:
         for trial in doc["trials"]:
-            batch_number = 0
+            total_batches_processed = 0
             for step in trial["steps"]:
-                batch_number += step["num_batches"]
+                total_batches_processed += step["num_batches"]
                 t_metrics_fields = []
                 if step.get("metrics"):
                     avg_metrics = step["metrics"]["avg_metrics"]
@@ -339,7 +339,7 @@ def describe(args: Namespace) -> None:
                 row = (
                     [
                         step["trial_id"],
-                        batch_number,
+                        total_batches_processed,
                         step["state"],
                         render.format_time(step.get("start_time")),
                         render.format_time(step.get("end_time")),

--- a/cli/determined_cli/experiment.py
+++ b/cli/determined_cli/experiment.py
@@ -296,9 +296,7 @@ def describe(args: Namespace) -> None:
     values = []
     for doc in docs:
         for trial in doc["trials"]:
-            total_batches_processed = 0
             for step in trial["steps"]:
-                total_batches_processed += step["num_batches"]
                 t_metrics_fields = []
                 if step.get("metrics"):
                     avg_metrics = step["metrics"]["avg_metrics"]
@@ -339,7 +337,7 @@ def describe(args: Namespace) -> None:
                 row = (
                     [
                         step["trial_id"],
-                        total_batches_processed,
+                        step["num_batches"] + step["total_batches_processed"],
                         step["state"],
                         render.format_time(step.get("start_time")),
                         render.format_time(step.get("end_time")),
@@ -502,7 +500,7 @@ def list_trials(args: Namespace) -> None:
             json.dumps(t["hparams"], indent=4),
             render.format_time(t["start_time"]),
             render.format_time(t["end_time"]),
-            t["num_batches"],
+            t["total_batches_processed"],
         ]
         for t in experiment["trials"]
     ]
@@ -573,7 +571,7 @@ def set_gc_policy(args: Namespace) -> None:
         values = [
             [
                 c["trial_id"],
-                c["step"]["num_batches"],
+                c["step"]["num_batches"] + c["step"]["total_batches_processed"],
                 c["state"],
                 api.metric.get_validation_metric(metric_name, c["step"]["validation"]),
                 c["uuid"],

--- a/cli/determined_cli/trial.py
+++ b/cli/determined_cli/trial.py
@@ -46,7 +46,7 @@ def describe_trial(args: Namespace) -> None:
 
     # Print information about individual steps.
     headers = [
-        "Training Workload #",
+        "# of Batches",
         "State",
         "Start Time",
         "End Time",
@@ -59,18 +59,20 @@ def describe_trial(args: Namespace) -> None:
     if args.metrics:
         headers.append("Workload Metrics")
 
-    values = [
-        [
-            s["id"],
+
+    total_batches = 0
+    values = [] 
+    for s in trial["steps"]:
+        total_batches += s["num_batches"]
+        values += [[
+            total_batches,
             s["state"],
             render.format_time(s["start_time"]),
             render.format_time(s["end_time"]),
             *format_checkpoint(s["checkpoint"]),
             *format_validation(s["validation"]),
             *([json.dumps(s["metrics"], indent=4)] if args.metrics else []),
-        ]
-        for s in trial["steps"]
-    ]
+        ]]
 
     print()
     print("Workloads:")

--- a/cli/determined_cli/trial.py
+++ b/cli/determined_cli/trial.py
@@ -59,13 +59,13 @@ def describe_trial(args: Namespace) -> None:
     if args.metrics:
         headers.append("Workload Metrics")
 
-    total_batches = 0
+    total_processed_batches = 0
     values = []
     for s in trial["steps"]:
-        total_batches += s["num_batches"]
+        total_processed_batches += s["num_batches"]
         values += [
             [
-                total_batches,
+                total_processed_batches,
                 s["state"],
                 render.format_time(s["start_time"]),
                 render.format_time(s["end_time"]),

--- a/cli/determined_cli/trial.py
+++ b/cli/determined_cli/trial.py
@@ -59,13 +59,11 @@ def describe_trial(args: Namespace) -> None:
     if args.metrics:
         headers.append("Workload Metrics")
 
-    total_processed_batches = 0
     values = []
     for s in trial["steps"]:
-        total_processed_batches += s["num_batches"]
         values += [
             [
-                total_processed_batches,
+                s["total_batches_processed"] + s["num_batches"],
                 s["state"],
                 render.format_time(s["start_time"]),
                 render.format_time(s["end_time"]),

--- a/cli/determined_cli/trial.py
+++ b/cli/determined_cli/trial.py
@@ -46,7 +46,7 @@ def describe_trial(args: Namespace) -> None:
 
     # Print information about individual steps.
     headers = [
-        "Step #",
+        "Training Workload #",
         "State",
         "Start Time",
         "End Time",
@@ -57,7 +57,7 @@ def describe_trial(args: Namespace) -> None:
         "Validation Metrics",
     ]
     if args.metrics:
-        headers.append("Step Metrics")
+        headers.append("Workload Metrics")
 
     values = [
         [
@@ -73,7 +73,7 @@ def describe_trial(args: Namespace) -> None:
     ]
 
     print()
-    print("Steps:")
+    print("Workloads:")
     render.tabulate_or_csv(headers, values, args.csv)
 
 

--- a/cli/determined_cli/trial.py
+++ b/cli/determined_cli/trial.py
@@ -59,19 +59,18 @@ def describe_trial(args: Namespace) -> None:
     if args.metrics:
         headers.append("Workload Metrics")
 
-    values = []
-    for s in trial["steps"]:
-        values += [
-            [
-                s["total_batches_processed"] + s["num_batches"],
-                s["state"],
-                render.format_time(s["start_time"]),
-                render.format_time(s["end_time"]),
-                *format_checkpoint(s["checkpoint"]),
-                *format_validation(s["validation"]),
-                *([json.dumps(s["metrics"], indent=4)] if args.metrics else []),
-            ]
+    values = [
+        [
+            s["total_batches_processed"] + s["num_batches"],
+            s["state"],
+            render.format_time(s["start_time"]),
+            render.format_time(s["end_time"]),
+            *format_checkpoint(s["checkpoint"]),
+            *format_validation(s["validation"]),
+            *([json.dumps(s["metrics"], indent=4)] if args.metrics else []),
         ]
+        for s in trial["steps"]
+    ]
 
     print()
     print("Workloads:")

--- a/cli/determined_cli/trial.py
+++ b/cli/determined_cli/trial.py
@@ -59,20 +59,21 @@ def describe_trial(args: Namespace) -> None:
     if args.metrics:
         headers.append("Workload Metrics")
 
-
     total_batches = 0
-    values = [] 
+    values = []
     for s in trial["steps"]:
         total_batches += s["num_batches"]
-        values += [[
-            total_batches,
-            s["state"],
-            render.format_time(s["start_time"]),
-            render.format_time(s["end_time"]),
-            *format_checkpoint(s["checkpoint"]),
-            *format_validation(s["validation"]),
-            *([json.dumps(s["metrics"], indent=4)] if args.metrics else []),
-        ]]
+        values += [
+            [
+                total_batches,
+                s["state"],
+                render.format_time(s["start_time"]),
+                render.format_time(s["end_time"]),
+                *format_checkpoint(s["checkpoint"]),
+                *format_validation(s["validation"]),
+                *([json.dumps(s["metrics"], indent=4)] if args.metrics else []),
+            ]
+        ]
 
     print()
     print("Workloads:")

--- a/e2e_tests/tests/experiment/experiment.py
+++ b/e2e_tests/tests/experiment/experiment.py
@@ -291,7 +291,7 @@ def run_describe_cli_tests(experiment_id: int) -> None:
         )
 
         assert os.path.exists(os.path.join(tmpdir, "experiments.csv"))
-        assert os.path.exists(os.path.join(tmpdir, "steps.csv"))
+        assert os.path.exists(os.path.join(tmpdir, "workloads.csv"))
         assert os.path.exists(os.path.join(tmpdir, "trials.csv"))
 
     # "det experiment describe" with metrics.
@@ -311,7 +311,7 @@ def run_describe_cli_tests(experiment_id: int) -> None:
         )
 
         assert os.path.exists(os.path.join(tmpdir, "experiments.csv"))
-        assert os.path.exists(os.path.join(tmpdir, "steps.csv"))
+        assert os.path.exists(os.path.join(tmpdir, "workloads.csv"))
         assert os.path.exists(os.path.join(tmpdir, "trials.csv"))
 
 

--- a/master/go.mod
+++ b/master/go.mod
@@ -12,7 +12,6 @@ require (
 	github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 // indirect
 	github.com/bufbuild/buf v0.16.0
 	github.com/containerd/containerd v1.3.2 // indirect
-	github.com/davecgh/go-spew v1.1.1
 	github.com/determined-ai/determined/proto v0.0.0-00010101000000-000000000000
 	github.com/docker/distribution v2.7.1+incompatible // indirect
 	github.com/docker/docker v1.13.1

--- a/master/go.mod
+++ b/master/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 // indirect
 	github.com/bufbuild/buf v0.16.0
 	github.com/containerd/containerd v1.3.2 // indirect
+	github.com/davecgh/go-spew v1.1.1
 	github.com/determined-ai/determined/proto v0.0.0-00010101000000-000000000000
 	github.com/docker/distribution v2.7.1+incompatible // indirect
 	github.com/docker/docker v1.13.1

--- a/master/internal/db/postgres.go
+++ b/master/internal/db/postgres.go
@@ -334,7 +334,7 @@ FROM (
                        t.warm_start_checkpoint_id,
                 (SELECT coalesce(jsonb_agg(s ORDER BY id ASC), '[]'::jsonb)
                  FROM (
-                     SELECT s.end_time, s.id, s.start_time, s.state, s.trial_id,
+                     SELECT s.end_time, s.id, s.start_time, s.state, s.trial_id, s.num_batches,
                      -- Drop batch_metrics field from metrics column because it
                      -- can be very large and compute average on the fly for legacy
                      -- metrics.

--- a/master/internal/db/postgres.go
+++ b/master/internal/db/postgres.go
@@ -212,9 +212,9 @@ FROM (
                         FROM steps s
                         WHERE s.trial_id = t.id
                        ) AS num_steps,
-                       (SELECT sum(s.num_batches)
+                       (SELECT coalesce(sum(s.num_batches), 0)
                         FROM steps s
-                        WHERE s.trial_id = t.id
+                        WHERE s.trial_id = t.id AND s.state = 'COMPLETED'
                        ) AS total_batches_processed,
                        (SELECT v.metrics
                         FROM validations v

--- a/master/internal/db/postgres.go
+++ b/master/internal/db/postgres.go
@@ -411,19 +411,19 @@ FROM (
                            c.resources, c.metadata,
                            (SELECT row_to_json(s)
                             FROM (
-								SELECT s.end_time, s.id, s.start_time, s.state, s.trial_id,
-									(SELECT sum(ss.num_batches)
-									FROM steps ss
-									WHERE ss.id <= s.id AND ss.trial_id = c.trial_id
-									) AS num_batches,
-									(SELECT row_to_json(v)
-									FROM (
-										SELECT v.end_time, v.id, v.metrics, v.start_time,
-												v.state, v.step_id, v.trial_id
-										FROM validations v
-										WHERE v.trial_id = s.trial_id AND v.step_id = s.id
-									) v
-									) AS validation
+                                SELECT s.end_time, s.id, s.start_time, s.state, s.trial_id,
+                                    (SELECT sum(ss.num_batches)
+                                    FROM steps ss
+                                    WHERE ss.id <= s.id AND ss.trial_id = c.trial_id
+                                    ) AS num_batches,
+                                    (SELECT row_to_json(v)
+                                    FROM (
+                                        SELECT v.end_time, v.id, v.metrics, v.start_time,
+                                            v.state, v.step_id, v.trial_id
+                                        FROM validations v
+                                        WHERE v.trial_id = s.trial_id AND v.step_id = s.id
+                                    ) v
+                                    ) AS validation
                                 FROM steps s
                                 WHERE s.id = c.step_id AND s.trial_id = c.trial_id
                             ) s
@@ -1002,15 +1002,15 @@ WITH const AS (
                    c.resources, c.metadata,
                    (SELECT row_to_json(s)
                     FROM (
-						SELECT s.end_time, s.id, s.start_time, s.state, s.trial_id,
-								(SELECT sum(ss.num_batches)
-								FROM steps ss
-								WHERE ss.id <= s.id AND ss.trial_id = c.trial_id
-								) AS num_batches,
-                               (SELECT row_to_json(v)
-                                FROM (
-                                    SELECT v.end_time, v.id, v.metrics, v.start_time,
-                                           v.state, v.step_id, v.trial_id
+                        SELECT s.end_time, s.id, s.start_time, s.state, s.trial_id,
+                            (SELECT sum(ss.num_batches)
+                            FROM steps ss
+                            WHERE ss.id <= s.id AND ss.trial_id = c.trial_id
+                            ) AS num_batches,
+                            (SELECT row_to_json(v)
+                            FROM (
+                                SELECT v.end_time, v.id, v.metrics, v.start_time,
+                                    v.state, v.step_id, v.trial_id
                                     FROM validations v
                                     WHERE v.trial_id = t.id AND v.step_id = s.id
                                 ) v

--- a/master/internal/experiment_utils.go
+++ b/master/internal/experiment_utils.go
@@ -122,7 +122,7 @@ func checkpointFromCheckpointMetrics(metrics searcher.CheckpointMetrics) model.C
 func saveWorkload(db *db.PgDB, w searcher.Workload) error {
 	switch w.Kind {
 	case searcher.RunStep:
-		return db.AddStep(model.NewStep(w.TrialID, w.StepID, w.NumBatches))
+		return db.AddStep(model.NewStep(w.TrialID, w.StepID, w.NumBatches, w.TotalBatchesProcessed))
 	case searcher.CheckpointModel:
 		return db.AddCheckpoint(model.NewCheckpoint(w.TrialID, w.StepID))
 	case searcher.ComputeValidationMetrics:

--- a/master/pkg/model/experiment.go
+++ b/master/pkg/model/experiment.go
@@ -284,23 +284,25 @@ func NewTrial(
 
 // Step represents a row from the `steps` table.
 type Step struct {
-	TrialID    int        `db:"trial_id"`
-	ID         int        `db:"id"`
-	State      State      `db:"state"`
-	StartTime  time.Time  `db:"start_time"`
-	EndTime    *time.Time `db:"end_time"`
-	NumBatches int        `db:"num_batches"`
-	Metrics    JSONObj    `db:"metrics"`
+	TrialID               int        `db:"trial_id"`
+	ID                    int        `db:"id"`
+	State                 State      `db:"state"`
+	StartTime             time.Time  `db:"start_time"`
+	EndTime               *time.Time `db:"end_time"`
+	NumBatches            int        `db:"num_batches"`
+	TotalBatchesProcessed int        `db:"total_batches_processed"`
+	Metrics               JSONObj    `db:"metrics"`
 }
 
 // NewStep creates a new step in the active state.
-func NewStep(trialID, stepID, numBatches int) *Step {
+func NewStep(trialID, stepID, numBatches, totalBatchesProcessed int) *Step {
 	return &Step{
-		TrialID:    trialID,
-		ID:         stepID,
-		State:      ActiveState,
-		StartTime:  time.Now().UTC(),
-		NumBatches: numBatches,
+		TrialID:               trialID,
+		ID:                    stepID,
+		State:                 ActiveState,
+		StartTime:             time.Now().UTC(),
+		NumBatches:            numBatches,
+		TotalBatchesProcessed: totalBatchesProcessed,
 	}
 }
 

--- a/master/static/migrations/20200729211811_extend-steps-table.down.sql
+++ b/master/static/migrations/20200729211811_extend-steps-table.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE public.steps DROP COLUMN total_batches_processed;

--- a/master/static/migrations/20200729211811_extend-steps-table.up.sql
+++ b/master/static/migrations/20200729211811_extend-steps-table.up.sql
@@ -9,24 +9,18 @@ WITH legacy_num_batches AS (
 -- first backfill num_batches for each step with the value of batches_per_step, if missing.
 UPDATE public.steps AS s
 SET num_batches = (
-    CASE WHEN num_batches is NULL THEN (
-        SELECT num_batches
-        FROM legacy_num_batches b
-        JOIN public.trials t ON t.experiment_id = b.experiment_id
-        WHERE t.id = s.trial_id
-    )
-    ELSE s.num_batches
-    END
-);
+    SELECT num_batches
+    FROM legacy_num_batches b
+    JOIN public.trials t ON t.experiment_id = b.experiment_id
+    WHERE t.id = s.trial_id
+)
+WHERE s.num_batches IS NULL;
 
 -- then backfill total_batches_processed using the value of num_batches we just backfilled.
 UPDATE public.steps AS s
-SET total_batches_processed = ( 
-    CASE WHEN s.total_batches_processed is NULL THEN (
-        SELECT coalesce(sum(ss.num_batches), 0)
-        FROM public.steps ss
-        WHERE ss.id < s.id
-    )
-    ELSE s.total_batches_processed
-    END
-);
+SET total_batches_processed = (
+    SELECT coalesce(sum(ss.num_batches), 0)
+    FROM public.steps ss
+    WHERE ss.id < s.id
+)
+WHERE s.total_batches_processed IS NULL;

--- a/master/static/migrations/20200729211811_extend-steps-table.up.sql
+++ b/master/static/migrations/20200729211811_extend-steps-table.up.sql
@@ -1,0 +1,32 @@
+ALTER TABLE public.steps ADD COLUMN total_batches_processed integer NULL;
+
+WITH legacy_num_batches AS (
+    SELECT
+        id experiment_id,
+        (e.config->>'batches_per_step')::int num_batches
+    FROM public.experiments e
+)
+-- first backfill num_batches for each step with the value of batches_per_step, if missing.
+UPDATE public.steps AS s
+SET num_batches = (
+    CASE WHEN num_batches is NULL THEN (
+        SELECT num_batches
+        FROM legacy_num_batches b
+        JOIN public.trials t ON t.experiment_id = b.experiment_id
+        WHERE t.id = s.trial_id
+    )
+    ELSE s.num_batches
+    END
+);
+
+-- then backfill total_batches_processed using the value of num_batches we just backfilled.
+UPDATE public.steps AS s
+SET total_batches_processed = ( 
+    CASE WHEN s.total_batches_processed is NULL THEN (
+        SELECT coalesce(sum(ss.num_batches), 0)
+        FROM public.steps ss
+        WHERE ss.id < s.id
+    )
+    ELSE s.total_batches_processed
+    END
+);

--- a/master/static/srv/get_trial.sql
+++ b/master/static/srv/get_trial.sql
@@ -17,6 +17,7 @@ FROM
                 s.state,
                 s.start_time,
                 s.end_time,
+                s.num_batches,
 
            (SELECT row_to_json(r3)
             FROM

--- a/master/static/srv/get_trial.sql
+++ b/master/static/srv/get_trial.sql
@@ -18,6 +18,7 @@ FROM
                 s.start_time,
                 s.end_time,
                 s.num_batches,
+                s.total_batches_processed,
 
            (SELECT row_to_json(r3)
             FROM

--- a/master/static/srv/get_trial_metrics.sql
+++ b/master/static/srv/get_trial_metrics.sql
@@ -17,6 +17,8 @@ FROM
                 s.state,
                 s.start_time,
                 s.end_time,
+                s.num_batches,
+                s.total_batches_processed,
                 s.metrics,
 
            (SELECT row_to_json(r3)


### PR DESCRIPTION
## Description
This change removes any references to the concept "step" in the CLI and replaces them with references to training workloads.

## Test Plan
- [x] use the cli, end the correct text appears.
For `e2e_tests/tests/fixtures/single.yaml` with 300 batches:

```
(determined) ➜  no_op git:(remove-steps-demo) ✗ det e describe 4
Experiment:
   Experiment ID | State     | Progress   | Start Time               | End Time                 | Description   | Archived   | Labels
-----------------+-----------+------------+--------------------------+--------------------------+---------------+------------+----------
               4 | COMPLETED |            | 2020-07-30 13:56:52+0000 | 2020-07-30 13:56:57+0000 | noop_single   | False      |

Trials:
   Trial ID |   Experiment ID | State     | Start Time               | End Time                 | H-Params
------------+-----------------+-----------+--------------------------+--------------------------+-----------------------------------------
         62 |               4 | COMPLETED | 2020-07-30 13:56:52+0000 | 2020-07-30 13:56:57+0000 | {
            |                 |           |                          |                          |     "metrics_base": 0.9,
            |                 |           |                          |                          |     "metrics_sigma": 0,
            |                 |           |                          |                          |     "global_batch_size": 32,
            |                 |           |                          |                          |     "metrics_progression": "decreasing"
            |                 |           |                          |                          | }

Workloads:
   Trial ID |   # of Batches | State     | Start Time               | End Time                 | Checkpoint State   | Checkpoint Start Time    | Checkpoint End Time      | Validation State   | Validation Start Time    | Validation End Time
------------+----------------+-----------+--------------------------+--------------------------+--------------------+--------------------------+--------------------------+--------------------+--------------------------+--------------------------
         62 |            100 | COMPLETED | 2020-07-30 13:56:52+0000 | 2020-07-30 13:56:57+0000 | COMPLETED          | 2020-07-30 13:56:57+0000 | 2020-07-30 13:56:57+0000 | COMPLETED          | 2020-07-30 13:56:57+0000 | 2020-07-30 13:56:57+0000
         62 |            200 | COMPLETED | 2020-07-30 13:56:57+0000 | 2020-07-30 13:56:57+0000 | COMPLETED          | 2020-07-30 13:56:57+0000 | 2020-07-30 13:56:57+0000 | COMPLETED          | 2020-07-30 13:56:57+0000 | 2020-07-30 13:56:57+0000
         62 |            300 | COMPLETED | 2020-07-30 13:56:57+0000 | 2020-07-30 13:56:57+0000 | COMPLETED          | 2020-07-30 13:56:57+0000 | 2020-07-30 13:56:57+0000 | COMPLETED          | 2020-07-30 13:56:57+0000 | 2020-07-30 13:56:57+0000
(determined) ➜  no_op git:(remove-steps-demo) ✗ det e describe 4 --metrics
Experiment:
   Experiment ID | State     | Progress   | Start Time               | End Time                 | Description   | Archived   | Labels
-----------------+-----------+------------+--------------------------+--------------------------+---------------+------------+----------
               4 | COMPLETED |            | 2020-07-30 13:56:52+0000 | 2020-07-30 13:56:57+0000 | noop_single   | False      |

Trials:
   Trial ID |   Experiment ID | State     | Start Time               | End Time                 | H-Params
------------+-----------------+-----------+--------------------------+--------------------------+-----------------------------------------
         62 |               4 | COMPLETED | 2020-07-30 13:56:52+0000 | 2020-07-30 13:56:57+0000 | {
            |                 |           |                          |                          |     "metrics_base": 0.9,
            |                 |           |                          |                          |     "metrics_sigma": 0,
            |                 |           |                          |                          |     "global_batch_size": 32,
            |                 |           |                          |                          |     "metrics_progression": "decreasing"
            |                 |           |                          |                          | }

Workloads:
   Trial ID |   # of Batches | State     | Start Time               | End Time                 |   Training Metric: loss | Checkpoint State   | Checkpoint Start Time    | Checkpoint End Time      | Validation State   | Validation Start Time    | Validation End Time      |   Validation Metric: validation_error
------------+----------------+-----------+--------------------------+--------------------------+-------------------------+--------------------+--------------------------+--------------------------+--------------------+--------------------------+--------------------------+---------------------------------------
         62 |            100 | COMPLETED | 2020-07-30 13:56:52+0000 | 2020-07-30 13:56:57+0000 |                   0.9   | COMPLETED          | 2020-07-30 13:56:57+0000 | 2020-07-30 13:56:57+0000 | COMPLETED          | 2020-07-30 13:56:57+0000 | 2020-07-30 13:56:57+0000 |                                 0.9
         62 |            200 | COMPLETED | 2020-07-30 13:56:57+0000 | 2020-07-30 13:56:57+0000 |                   0.81  | COMPLETED          | 2020-07-30 13:56:57+0000 | 2020-07-30 13:56:57+0000 | COMPLETED          | 2020-07-30 13:56:57+0000 | 2020-07-30 13:56:57+0000 |                                 0.81
         62 |            300 | COMPLETED | 2020-07-30 13:56:57+0000 | 2020-07-30 13:56:57+0000 |                   0.729 | COMPLETED          | 2020-07-30 13:56:57+0000 | 2020-07-30 13:56:57+0000 | COMPLETED          | 2020-07-30 13:56:57+0000 | 2020-07-30 13:56:57+0000 |                                 0.729
(determined) ➜  no_op git:(remove-steps-demo) ✗ det e lt 4
   Trial ID | State     | H-Params                                | Start Time               | End Time                 |   # of Batches
------------+-----------+-----------------------------------------+--------------------------+--------------------------+----------------
         62 | COMPLETED | {                                       | 2020-07-30 13:56:52+0000 | 2020-07-30 13:56:57+0000 |            300
            |           |     "metrics_base": 0.9,                |                          |                          |
            |           |     "metrics_sigma": 0,                 |                          |                          |
            |           |     "global_batch_size": 32,            |                          |                          |
            |           |     "metrics_progression": "decreasing" |                          |                          |
            |           | }                                       |                          |                          |
(determined) ➜  no_op git:(remove-steps-demo) ✗ det e lc 4
   Trial ID |   # of Batches | State     |   Validation Metric | UUID                                 | Resources        | Size
------------+----------------+-----------+---------------------+--------------------------------------+------------------+--------
         62 |            100 | COMPLETED |               0.9   | eb83d118-74f4-439a-b47f-f97171628bac | no_op_checkpoint | 14.0B
         62 |            200 | COMPLETED |               0.81  | e151d9a2-57fc-4808-808c-4209e55e9814 | no_op_checkpoint | 26.0B
         62 |            300 | COMPLETED |               0.729 | fb51ef0c-2f91-4c96-96b9-ed182a916062 | no_op_checkpoint | 38.0B
(determined) ➜  no_op git:(remove-steps-demo) ✗ det e set gc-policy --save-experiment-best 0 --save-trial-best 0  --save-trial-latest 0 4
The following checkpoints with validation will be deleted by applying this GC Policy:
   Trial ID |   # of Batches | State     |    Validation Metric | UUID                                 | Resources
            |                |           |   (validation_error) |                                      |
------------+----------------+-----------+----------------------+--------------------------------------+------------------
         62 |            100 | COMPLETED |                0.9   | eb83d118-74f4-439a-b47f-f97171628bac | no_op_checkpoint
         62 |            200 | COMPLETED |                0.81  | e151d9a2-57fc-4808-808c-4209e55e9814 | no_op_checkpoint
         62 |            300 | COMPLETED |                0.729 | fb51ef0c-2f91-4c96-96b9-ed182a916062 | no_op_checkpoint
This policy will delete 3 checkpoints with validations and 0 checkpoints without validations.
Changing the checkpoint garbage collection policy of an experiment may result
in the unrecoverable deletion of checkpoints.  Do you wish to proceed? [y/n]: ^C
Aborting operations.
(determined) ➜  no_op git:(remove-steps-demo) ✗ det t describe 62
   Experiment ID | State     | H-Params                                | Start Time               | End Time
-----------------+-----------+-----------------------------------------+--------------------------+--------------------------
               4 | COMPLETED | {                                       | 2020-07-30 13:56:52+0000 | 2020-07-30 13:56:57+0000
                 |           |     "metrics_base": 0.9,                |                          |
                 |           |     "metrics_sigma": 0,                 |                          |
                 |           |     "global_batch_size": 32,            |                          |
                 |           |     "metrics_progression": "decreasing" |                          |
                 |           | }                                       |                          |

Workloads:
   # of Batches | State     | Start Time               | End Time                 | Checkpoint   | Checkpoint UUID                      | Checkpoint Metadata   | Validation   | Validation Metrics
----------------+-----------+--------------------------+--------------------------+--------------+--------------------------------------+-----------------------+--------------+------------------------------------------------
            100 | COMPLETED | 2020-07-30 13:56:52+0000 | 2020-07-30 13:56:57+0000 | COMPLETED    | eb83d118-74f4-439a-b47f-f97171628bac | {}                    | COMPLETED    | {
                |           |                          |                          |              |                                      |                       |              |     "num_inputs": 1024,
                |           |                          |                          |              |                                      |                       |              |     "validation_metrics": {
                |           |                          |                          |              |                                      |                       |              |         "validation_error": 0.9
                |           |                          |                          |              |                                      |                       |              |     }
                |           |                          |                          |              |                                      |                       |              | }
            200 | COMPLETED | 2020-07-30 13:56:57+0000 | 2020-07-30 13:56:57+0000 | COMPLETED    | e151d9a2-57fc-4808-808c-4209e55e9814 | {}                    | COMPLETED    | {
                |           |                          |                          |              |                                      |                       |              |     "num_inputs": 1024,
                |           |                          |                          |              |                                      |                       |              |     "validation_metrics": {
                |           |                          |                          |              |                                      |                       |              |         "validation_error": 0.81
                |           |                          |                          |              |                                      |                       |              |     }
                |           |                          |                          |              |                                      |                       |              | }
            300 | COMPLETED | 2020-07-30 13:56:57+0000 | 2020-07-30 13:56:57+0000 | COMPLETED    | fb51ef0c-2f91-4c96-96b9-ed182a916062 | {}                    | COMPLETED    | {
                |           |                          |                          |              |                                      |                       |              |     "num_inputs": 1024,
                |           |                          |                          |              |                                      |                       |              |     "validation_metrics": {
                |           |                          |                          |              |                                      |                       |              |         "validation_error": 0.7290000000000001
                |           |                          |                          |              |                                      |                       |              |     }
                |           |                          |                          |              |                                      |                       |              | }
(determined) ➜  no_op git:(remove-steps-demo) ✗ det t describe 62 --metrics
   Experiment ID | State     | H-Params                                | Start Time               | End Time
-----------------+-----------+-----------------------------------------+--------------------------+--------------------------
               4 | COMPLETED | {                                       | 2020-07-30 13:56:52+0000 | 2020-07-30 13:56:57+0000
                 |           |     "metrics_base": 0.9,                |                          |
                 |           |     "metrics_sigma": 0,                 |                          |
                 |           |     "global_batch_size": 32,            |                          |
                 |           |     "metrics_progression": "decreasing" |                          |
                 |           | }                                       |                          |

Workloads:
   # of Batches | State     | Start Time               | End Time                 | Checkpoint   | Checkpoint UUID                      | Checkpoint Metadata   | Validation   | Validation Metrics                             | Workload Metrics
----------------+-----------+--------------------------+--------------------------+--------------+--------------------------------------+-----------------------+--------------+------------------------------------------------+----------------------------------------
            100 | COMPLETED | 2020-07-30 13:56:52+0000 | 2020-07-30 13:56:57+0000 | COMPLETED    | eb83d118-74f4-439a-b47f-f97171628bac | {}                    | COMPLETED    | {                                              | {
                |           |                          |                          |              |                                      |                       |              |     "num_inputs": 1024,                        |     "num_inputs": 3200,
                |           |                          |                          |              |                                      |                       |              |     "validation_metrics": {                    |     "avg_metrics": {
                |           |                          |                          |              |                                      |                       |              |         "validation_error": 0.9                |         "loss": 0.9000000000000005
                |           |                          |                          |              |                                      |                       |              |     }                                          |     },
                |           |                          |                          |              |                                      |                       |              | }                                              |     "batch_metrics": [
                |           |                          |                          |              |                                      |                       |              |                                                |         {
                |           |                          |                          |              |                                      |                       |              |                                                |             "loss": 0.9
                |           |                          |                          |              |                                      |                       |              |                                                |         },
                |           |                          |                          |              |                                      |                       |              |                                                |         {
                |           |                          |                          |              |                                      |                       |              |                                                |             "loss": 0.9
                |           |                          |                          |              |                                      |                       |              |                                                |         },
                |           |                          |                          |              |                                      |                       |              |                                                |         {
                |           |                          |                          |              |                                      |                       |              |                                                |             "loss": 0.9
                |           |                          |                          |              |                                      |                       |              |                                                |         },
                |           |                          |                          |              |                                      |                       |              |                                                |         {
                |           |                          |                          |              |                                      |                       |              |                                                |             "loss": 0.9
                |           |                          |                          |              |                                      |                       |              |                                                |         },
                |           |                          |                          |              |                                      |                       |              |                                                |         {
                |           |                          |                          |              |                                      |                       |              |                                                |             "loss": 0.9
                |           |                          |                          |              |                                  
```

## Commentary (optional)
This is bare-minimum effort for this since the new CLI is coming along currently.
