### PR TITLE
feat: remove steps from preview-search [DET-3676]

### DIFF
--- a/master/internal/api_experiment.go
+++ b/master/internal/api_experiment.go
@@ -10,12 +10,13 @@ import (
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/encoding/protojson"
 
+	"github.com/pkg/errors"
+
 	"github.com/determined-ai/determined/master/pkg/check"
 	"github.com/determined-ai/determined/master/pkg/model"
 	"github.com/determined-ai/determined/master/pkg/searcher"
 	"github.com/determined-ai/determined/proto/pkg/apiv1"
 	"github.com/determined-ai/determined/proto/pkg/experimentv1"
-	"github.com/pkg/errors"
 )
 
 func (a *apiServer) GetExperiments(

--- a/master/pkg/searcher/simulate.go
+++ b/master/pkg/searcher/simulate.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"math/rand"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -31,28 +32,27 @@ func (s SimulationResults) MarshalJSON() ([]byte, error) {
 	summary := make(map[string]int)
 
 	for _, ops := range s {
-		key := ""
+		var keyParts []string
 		for _, op := range ops {
 			switch op := op.(type) {
 			case Train:
 				switch op.Length.Unit {
 				case model.Records:
-					key += fmt.Sprintf("%dR", op.Length.Units)
+					keyParts = append(keyParts, fmt.Sprintf("%dR", op.Length.Units))
 				case model.Batches:
-					key += fmt.Sprintf("%dB", op.Length.Units)
+					keyParts = append(keyParts, fmt.Sprintf("%dB", op.Length.Units))
 				case model.Epochs:
-					key += fmt.Sprintf("%dE", op.Length.Units)
+					keyParts = append(keyParts, fmt.Sprintf("%dE", op.Length.Units))
 				}
 			case Validate:
-				key += "V"
+				keyParts = append(keyParts, "V")
 			case Checkpoint:
-				key += "C"
+				keyParts = append(keyParts, "C")
 			default:
 				return nil, errors.Errorf("unexpected operation: %v", op)
 			}
-			key += " "
 		}
-		summary[key]++
+		summary[strings.Join(keyParts, " ")]++
 	}
 
 	return json.Marshal(summary)

--- a/proto/src/determined/experiment/v1/searcher.proto
+++ b/proto/src/determined/experiment/v1/searcher.proto
@@ -6,21 +6,49 @@ option go_package = "github.com/determined-ai/determined/proto/pkg/experimentv1"
 import "google/protobuf/struct.proto";
 
 // WorkloadKind defines the kind of workload that should be executed by trial runners.
-enum WorkloadKind {
-    // Denotes an unknown workload kind.
-    WORKLOAD_KIND_UNSPECIFIED = 0;
-    // Signals to a trial runner that it should run a training step.
-    WORKLOAD_KIND_RUN_STEP = 1;
+enum Unit {
+    // Denotes an unknown unit.
+    UNIT_UNSPECIFIED = 0;
+    // Unit type "Batches".
+    UNIT_BATCHES = 1;
+    // Unit type "Records".
+    UNIT_RECORDS = 2;
+    // Unit type "Epochs".
+    UNIT_EPOCHS = 3;
+}
+
+// TrainingLength represents a single runnable operation emitted by a searcher.
+message TrainingLength {
+    // This is the unit the TrainingLength is in terms of.
+    Unit unit = 1;
+    // This is the magnitude of the TrainingLength.
+    int32 units = 2;
+}
+
+// RunnableType defines the type of operation that should be executed by trial runners.
+enum RunnableType {
+    // Denotes an unknown operation type.
+    RUNNABLE_TYPE_UNSPECIFIED = 0;
+    // Signals to a trial runner that it should run a train.
+    RUNNABLE_TYPE_TRAIN = 1;
     // Signals to a trial runner it should compute validation metrics.
-    WORKLOAD_KIND_COMPUTE_VALIDATION_METRICS = 2;
+    RUNNABLE_TYPE_VALIDATE = 2;
     // Signals to the trial runner that the current model state should be checkpointed.
-    WORKLOAD_KIND_CHECKPOINT_MODEL = 3;
+    RUNNABLE_TYPE_CHECKPOINT = 3;
+}
+
+// RunnableOperation represents a single runnable operation emitted by a searcher.
+message RunnableOperation {
+    // This is the type of the operation.
+    RunnableType type = 1;
+    // If the type == WORKLOAD_KIND_TRAIN, this is the number of units
+    TrainingLength length = 2;
 }
 
 // TrialSimulation is a specific sequence of workloads that were run before the trial was completed.
 message TrialSimulation {
-    // The list of workloads that were run before the trial was completed.
-    repeated WorkloadKind workloads = 1;
+    // The list of operations that were run before the trial was completed.
+    repeated RunnableOperation operations = 1;
     // The number of times that this trial configuration has occurred during the simulation.
     int32 occurrences = 2;
 }

--- a/proto/src/determined/experiment/v1/searcher.proto
+++ b/proto/src/determined/experiment/v1/searcher.proto
@@ -7,34 +7,30 @@ import "google/protobuf/struct.proto";
 
 // WorkloadKind defines the kind of workload that should be executed by trial runners.
 enum Unit {
-    // Denotes an unknown unit.
-    UNIT_UNSPECIFIED = 0;
     // Unit type "Batches".
-    UNIT_BATCHES = 1;
+    UNIT_BATCHES = 0;
     // Unit type "Records".
-    UNIT_RECORDS = 2;
+    UNIT_RECORDS = 1;
     // Unit type "Epochs".
-    UNIT_EPOCHS = 3;
+    UNIT_EPOCHS = 2;
 }
 
-// TrainingLength represents a single runnable operation emitted by a searcher.
-message TrainingLength {
+// TrainingUnits represents a single runnable operation emitted by a searcher.
+message TrainingUnits {
     // This is the unit the TrainingLength is in terms of.
     Unit unit = 1;
     // This is the magnitude of the TrainingLength.
-    int32 units = 2;
+    int32 count = 2;
 }
 
 // RunnableType defines the type of operation that should be executed by trial runners.
 enum RunnableType {
-    // Denotes an unknown operation type.
-    RUNNABLE_TYPE_UNSPECIFIED = 0;
     // Signals to a trial runner that it should run a train.
-    RUNNABLE_TYPE_TRAIN = 1;
+    RUNNABLE_TYPE_TRAIN = 0;
     // Signals to a trial runner it should compute validation metrics.
-    RUNNABLE_TYPE_VALIDATE = 2;
+    RUNNABLE_TYPE_VALIDATE = 1;
     // Signals to the trial runner that the current model state should be checkpointed.
-    RUNNABLE_TYPE_CHECKPOINT = 3;
+    RUNNABLE_TYPE_CHECKPOINT = 2;
 }
 
 // RunnableOperation represents a single runnable operation emitted by a searcher.
@@ -42,7 +38,7 @@ message RunnableOperation {
     // This is the type of the operation.
     RunnableType type = 1;
     // If the type == WORKLOAD_KIND_TRAIN, this is the number of units
-    TrainingLength length = 2;
+    TrainingUnits length = 2;
 }
 
 // TrialSimulation is a specific sequence of workloads that were run before the trial was completed.

--- a/proto/src/determined/experiment/v1/searcher.proto
+++ b/proto/src/determined/experiment/v1/searcher.proto
@@ -7,12 +7,14 @@ import "google/protobuf/struct.proto";
 
 // WorkloadKind defines the kind of workload that should be executed by trial runners.
 enum Unit {
+    // Denotes an unknown Uz.
+    UNIT_UNSPECIFIED = 0;
     // Unit type "Batches".
-    UNIT_BATCHES = 0;
+    UNIT_BATCHES = 1;
     // Unit type "Records".
-    UNIT_RECORDS = 1;
+    UNIT_RECORDS = 2;
     // Unit type "Epochs".
-    UNIT_EPOCHS = 2;
+    UNIT_EPOCHS = 3;
 }
 
 // TrainingUnits represents a single runnable operation emitted by a searcher.
@@ -25,12 +27,14 @@ message TrainingUnits {
 
 // RunnableType defines the type of operation that should be executed by trial runners.
 enum RunnableType {
+    // Denotes an unknown runnable type.
+    RUNNABLE_TYPE_UNSPECIFIED = 0;
     // Signals to a trial runner that it should run a train.
-    RUNNABLE_TYPE_TRAIN = 0;
+    RUNNABLE_TYPE_TRAIN = 1;
     // Signals to a trial runner it should compute validation metrics.
-    RUNNABLE_TYPE_VALIDATE = 1;
+    RUNNABLE_TYPE_VALIDATE = 2;
     // Signals to the trial runner that the current model state should be checkpointed.
-    RUNNABLE_TYPE_CHECKPOINT = 2;
+    RUNNABLE_TYPE_CHECKPOINT = 3;
 }
 
 // RunnableOperation represents a single runnable operation emitted by a searcher.


### PR DESCRIPTION
## Description
This change updates the `det preview-search` functionality to work with the changes that removed steps from the UX of the system.

## Test Plan
- [x] test `det preview-search` with a number of configurations.
- [x] test `/api/v1/preview-hp-search` with a few configs.

## Commentary (optional)
Once again, like #940, I put a very minimal amount of effort into fixing the CLI since it is throwaway code.
