### PR TITLE
feat: handle missing PodFailed messages from k8

### DIFF
--- a/master/go.mod
+++ b/master/go.mod
@@ -46,6 +46,7 @@ require (
 	golang.org/x/net v0.0.0-20200602114024-627f9648deb9
 	golang.org/x/tools v0.0.0-20200702044944-0cc1aa72b347
 	google.golang.org/api v0.26.0
+	google.golang.org/genproto v0.0.0-20200608115520-7c474a2e3482
 	google.golang.org/grpc v1.29.1
 	google.golang.org/protobuf v1.24.0
 	gopkg.in/guregu/null.v3 v3.4.0


### PR DESCRIPTION
## Description
This PR handles the case where we delete pods and k8s never send a `PodFailed` message to us, instead we only get a `PodPending` message. 


## Test Plan
Tested this manually. Adding CI very soon!
