### PR TITLE
docs: tweak dev prerequisites

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,8 +42,9 @@ git clone git@github.com:determined-ai/determined.git
 #### Prerequisites
 
 - Go (>= 1.13)
-- Python (>= 3.6)
+- Python (>= 3.6, < 3.8)
 - Node (>= 12)
+- NPM (>= 6.12)
 - Docker (>= 19.03)
 - Protoc (>= 3.0)
 - Java (>= 7)


### PR DESCRIPTION
I had to install `npm` to be able to build from source on a new machine. We also don't work with Python >= 3.8 right now.