### PR TITLE
feat: Add support for G4 instances on AWS [DET-1771]

### DIFF
--- a/docs/how-to/installation/aws.txt
+++ b/docs/how-to/installation/aws.txt
@@ -131,9 +131,7 @@ Spinning up the Cluster
      - m5.large
 
    * - ``--agent-instance-type``
-     - AWS instance type to use for the agents. Must be one of the following
-       instance types: ``p2.xlarge``, ``p2.8xlarge``, ``p2.16xlarge``, ``p3.2xlarge``,
-       ``p3.8xlarge``, ``p3.16xlarge``, or ``p3dn.24xlarge``.
+     - AWS instance type to use for the agents. Must be one of the following instance types: ``g4dn.xlarge``, ``g4dn.2xlarge``, ``g4dn.4xlarge``, ``g4dn.8xlarge``, ``g4dn.16xlarge``, ``g4dn.12xlarge``, ``g4dn.metal``, ``p2.xlarge``, ``p2.8xlarge``, ``p2.16xlarge``, ``p3.2xlarge``, ``p3.8xlarge``, ``p3.16xlarge``, or ``p3dn.24xlarge``.
      - p2.8xlarge
 
    * - ``--deployment-type``

--- a/docs/reference/cluster-config.txt
+++ b/docs/reference/cluster-config.txt
@@ -343,9 +343,11 @@ The master supports the following configuration settings:
     - ``max_instances``: Max number of Determined agent instances. Defaults
       to ``5``.
 
-    - ``instance_type``: AWS instance type to use for dynamic agents. This
-      must be one of the following: ``p2.xlarge``, ``p2.8xlarge``, ``p2.16xlarge``, ``p3.2xlarge``,
-      ``p3.8xlarge``, ``p3.16xlarge``, or ``p3dn.24xlarge``. Defaults to ``p3.8xlarge``.
+    - ``instance_type``: AWS instance type to use for dynamic agents. This must be one of
+      the following: ``g4dn.xlarge``, ``g4dn.2xlarge``, ``g4dn.4xlarge``,
+      ``g4dn.8xlarge``, ``g4dn.16xlarge``, ``g4dn.12xlarge``, ``g4dn.metal``,
+      ``p2.xlarge``, ``p2.8xlarge``, ``p2.16xlarge``, ``p3.2xlarge``, ``p3.8xlarge``,
+      ``p3.16xlarge``, or ``p3dn.24xlarge``. Defaults to ``p3.8xlarge``.
 
   - ``provider: gcp``: Specifies running dynamic agents on GCP.
     (*Required*)

--- a/docs/topic-guides/elastic-infra/dynamic-agents-aws.txt
+++ b/docs/topic-guides/elastic-infra/dynamic-agents-aws.txt
@@ -36,8 +36,9 @@ EC2 Instance Types
    >= 2 CPUs (Intel Broadwell or later), 4GB of RAM, and 100GB of disk
    storage. This corresponds to an EC2 ``t2.medium`` instance or better.
 
--  Each Determined agent node must be any of the P3 or P2 instances on AWS.
-   This can be configured in the :ref:`aws-cluster-configuration`.
+- All Determined agent nodes must be the same AWS instance type; any G4,
+  P2, or P3 instance type is supported. This can be configured in the
+  :ref:`aws-cluster-configuration`.
 
 .. _master-iam-role:
 

--- a/master/internal/provisioner/aws_config.go
+++ b/master/internal/provisioner/aws_config.go
@@ -106,6 +106,13 @@ type ec2NetworkInterface struct {
 type ec2InstanceType string
 
 var ec2InstanceSlots = map[ec2InstanceType]int{
+	"g4dn.xlarge":   1,
+	"g4dn.2xlarge":  1,
+	"g4dn.4xlarge":  1,
+	"g4dn.8xlarge":  1,
+	"g4dn.16xlarge": 1,
+	"g4dn.12xlarge": 4,
+	"g4dn.metal":    8,
 	"p2.xlarge":     1,
 	"p2.8xlarge":    8,
 	"p2.16xlarge":   16,


### PR DESCRIPTION
We previously excluded G4s from the instance type whitelist; this commit
adds them to the whitelist and updates the documentation accordingly.

Note that the previous default agent AMI did not work with G4 instances.
The exact cause is unclear, but upgrading the Nvidia display driver from
410.104 to 450.51.05 appears to fix the problem (despite the fact that
Nvidia's docs claim that 410.104 supports T4 GPUs). The upshot is that
actually using G4 instances on AWS will require using an updated AMI.

**Testing**

I tested this by
* Launching a `g4dn.xlarge` using the current agent AMI
* Confirming that `nvidia-smi` did not work
* Upgrading the nvidia drivers on the instance
* Saving the instance state to a new AMI (`ami-07dda244ef15ff2eb`)
* Deploying a new Determined master with this PR
* Configured the master to use the new agent AMI and the `g4dn.4xlarge` instance type for dynamic agents
* Launched `fashion_mnist_tf_keras` and `mnist_pytorch` experiments that ran successfully

**NOT TESTED**

* TF2 and/or different versions of CUDA
* Running Determined workloads on other flavors of the G4 instance type
* dtrain, HPO, etc.