### PR TITLE
fix: naming for model registry CLI commands and entities [DET-3767]

### DIFF
--- a/cli/determined_cli/model.py
+++ b/cli/determined_cli/model.py
@@ -36,7 +36,7 @@ def render_model_version(checkpoint: Checkpoint) -> None:
 
     values = [
         [
-            checkpoint.version,
+            checkpoint.model_version,
             checkpoint.trial_id,
             checkpoint.batch_number,
             checkpoint.uuid,
@@ -88,7 +88,7 @@ def list_versions(args: Namespace) -> None:
 
         values = [
             [
-                ckpt.version,
+                ckpt.model_version,
                 ckpt.trial_id,
                 ckpt.batch_number,
                 ckpt.uuid,
@@ -123,6 +123,7 @@ def describe(args: Namespace) -> None:
             render_model_version(checkpoint)
 
 
+@authentication_required
 def register_version(args: Namespace) -> None:
     if args.json:
         resp = api.post(
@@ -170,7 +171,7 @@ args_description = [
                 is_default=True,
             ),
             Cmd(
-                "register_version",
+                "register-version",
                 register_version,
                 "register a new version of a model",
                 [
@@ -195,7 +196,7 @@ args_description = [
                 ],
             ),
             Cmd(
-                "list_versions",
+                "list-versions",
                 list_versions,
                 "list the versions of a model",
                 [

--- a/common/determined_common/experimental/checkpoint/_checkpoint.py
+++ b/common/determined_common/experimental/checkpoint/_checkpoint.py
@@ -37,7 +37,7 @@ class Checkpoint(object):
         determined_version: Optional[str] = None,
         framework: Optional[str] = None,
         format: Optional[str] = None,
-        version: Optional[int] = None,
+        model_version: Optional[int] = None,
         model_name: Optional[str] = None,
         metadata: Optional[Dict[str, Any]] = None,
         master: Optional[str] = None,
@@ -80,7 +80,7 @@ class Checkpoint(object):
         self.framework = framework
         self.format = format
         self.determined_version = determined_version
-        self.version = version
+        self.model_version = model_version
         self.model_name = model_name
         self.metadata = metadata
         self._master = master
@@ -318,7 +318,7 @@ class Checkpoint(object):
             framework=data.get("framework"),
             format=data.get("format"),
             determined_version=data.get("determined_version", data.get("determinedVersion")),
-            version=data.get("version"),
+            model_version=data.get("model_version"),
             model_name=data.get("model_name"),
             master=master,
         )

--- a/common/determined_common/experimental/model.py
+++ b/common/determined_common/experimental/model.py
@@ -92,7 +92,7 @@ class Model:
             if data["versions"] == []:
                 return None
 
-            latest_version = data["versions"][0]
+            latest_version = data["model_versions"][0]
             return Checkpoint.from_json(
                 {
                     **latest_version["checkpoint"],

--- a/common/determined_common/experimental/model.py
+++ b/common/determined_common/experimental/model.py
@@ -122,9 +122,6 @@ class Model:
         )
         data = resp.json()
 
-        for v in data["modelVersions"]:
-            print(v["version"])
-
         return [
             Checkpoint.from_json(
                 {

--- a/common/determined_common/experimental/model.py
+++ b/common/determined_common/experimental/model.py
@@ -89,7 +89,7 @@ class Model:
             )
 
             data = resp.json()
-            if data["versions"] == []:
+            if data["modelVersions"] == []:
                 return None
 
             latest_version = data["modelVersions"][0]

--- a/common/determined_common/experimental/model.py
+++ b/common/determined_common/experimental/model.py
@@ -92,7 +92,7 @@ class Model:
             if data["versions"] == []:
                 return None
 
-            latest_version = data["model_versions"][0]
+            latest_version = data["modelVersions"][0]
             return Checkpoint.from_json(
                 {
                     **latest_version["checkpoint"],

--- a/common/determined_common/experimental/model.py
+++ b/common/determined_common/experimental/model.py
@@ -96,7 +96,7 @@ class Model:
             return Checkpoint.from_json(
                 {
                     **latest_version["checkpoint"],
-                    "version": latest_version["version"],
+                    "model_version": latest_version["version"],
                     "model_name": data["model"]["name"],
                 }
             )
@@ -104,7 +104,7 @@ class Model:
             resp = api.get(self._master, "/api/v1/models/{}/versions/{}".format(self.name, version))
 
         data = resp.json()
-        return Checkpoint.from_json(data["version"]["checkpoint"], self._master)
+        return Checkpoint.from_json(data["model_version"]["checkpoint"], self._master)
 
     def get_versions(self, order_by: ModelOrderBy = ModelOrderBy.DESC) -> List[Checkpoint]:
         """
@@ -122,16 +122,19 @@ class Model:
         )
         data = resp.json()
 
+        for v in data["modelVersions"]:
+            print(v["version"])
+
         return [
             Checkpoint.from_json(
                 {
                     **version["checkpoint"],
-                    "version": version["version"],
+                    "model_version": version["version"],
                     "model_name": data["model"]["name"],
                 },
                 self._master,
             )
-            for version in data["versions"]
+            for version in data["modelVersions"]
         ]
 
     def register_version(self, checkpoint_uuid: str) -> Checkpoint:
@@ -153,9 +156,9 @@ class Model:
 
         return Checkpoint.from_json(
             {
-                **data["version"]["checkpoint"],
-                "version": data["version"]["version"],
-                "model_name": data["version"]["model"]["name"],
+                **data["modelVersion"]["checkpoint"],
+                "model_version": data["modelVersion"]["version"],
+                "model_name": data["modelVersion"]["model"]["name"],
             },
             self._master,
         )

--- a/e2e_tests/tests/test_system.py
+++ b/e2e_tests/tests/test_system.py
@@ -410,7 +410,8 @@ def test_model_registry() -> None:
 
     checkpoint = d.get_experiment(exp_id).top_checkpoint()
     model_version = mnist.register_version(checkpoint.uuid)
-    assert model_version.version == 1
+
+    assert model_version.model_version == 1
 
     latest_version = mnist.get_version()
     assert latest_version is not None

--- a/master/internal/api_model.go
+++ b/master/internal/api_model.go
@@ -2,7 +2,6 @@ package internal
 
 import (
 	"context"
-	"fmt"
 	"strings"
 	"time"
 
@@ -129,9 +128,6 @@ func (a *apiServer) GetModelVersions(
 	}
 
 	a.sort(resp.ModelVersions, req.OrderBy, req.SortBy, apiv1.GetModelVersionsRequest_SORT_BY_VERSION)
-	for _, v := range resp.ModelVersions {
-		fmt.Printf("v: %v, uuid: %v\n", v.Version, v.Checkpoint.Uuid)
-	}
 	return resp, a.paginate(&resp.Pagination, &resp.ModelVersions, req.Offset, req.Limit)
 }
 

--- a/proto/src/determined/api/v1/model.proto
+++ b/proto/src/determined/api/v1/model.proto
@@ -99,7 +99,7 @@ message GetModelVersionRequest {
 // Response for GetModelVersionRequest.
 message GetModelVersionResponse {
   // The model version requested.
-  determined.model.v1.ModelVersion version = 1;
+  determined.model.v1.ModelVersion model_version = 1;
 }
 
 
@@ -133,7 +133,7 @@ message GetModelVersionsResponse {
   // The model requested.
   determined.model.v1.Model model = 1;
   // The list of returned model versions.
-  repeated determined.model.v1.ModelVersion versions = 2;
+  repeated determined.model.v1.ModelVersion model_versions = 2;
   // Pagination information of the full dataset.
   Pagination pagination = 3;
 }
@@ -149,5 +149,5 @@ message PostModelVersionRequest {
 // Response for PostModelVersionRequest.
 message PostModelVersionResponse {
   // The model version requested.
-  determined.model.v1.ModelVersion version = 1;
+  determined.model.v1.ModelVersion model_version = 1;
 }


### PR DESCRIPTION
## Description
Changes `version` to `model_version` in the REST API
Changes underscores to hyphens in the CLI


## Test Plan

