### PR TITLE
feat: add archived status column to Experiment list [DET-3540]

### DIFF
--- a/webui/react/src/components/Table.tsx
+++ b/webui/react/src/components/Table.tsx
@@ -107,6 +107,5 @@ export const experimentProgressRenderer: ExperimentRenderer = (_, record) => {
 };
 
 export const experimentArchivedRenderer: ExperimentRenderer = (_, record) => {
-  if (!record.archived) return null;
-  return <CheckOutlined />;
+  return record.archived ? <CheckOutlined /> : null;
 };

--- a/webui/react/src/components/Table.tsx
+++ b/webui/react/src/components/Table.tsx
@@ -1,3 +1,4 @@
+import { CheckOutlined } from '@ant-design/icons';
 import { Tooltip } from 'antd';
 import React from 'react';
 import TimeAgo from 'timeago-react';
@@ -75,7 +76,7 @@ export const taskTypeRenderer: TaskRenderer = (_, record) => (
   </Tooltip>
 );
 
-/* Experiemnt Table Column Renderers */
+/* Experiment Table Column Renderers */
 
 export const experimentActionRenderer: ExperimentRenderer = (_, record) => (
   <TaskActionDropdown task={experimentToTask(record)} />
@@ -103,4 +104,9 @@ export const experimentProgressRenderer: ExperimentRenderer = (_, record) => {
     percent={record.progress * 100}
     state={record.state}
     title={floatToPercent(record.progress, 0)} />;
+};
+
+export const experimentArchivedRenderer: ExperimentRenderer = (_, record) => {
+  if (!record.archived) return null;
+  return <CheckOutlined />;
 };

--- a/webui/react/src/pages/ExperimentList.table.tsx
+++ b/webui/react/src/pages/ExperimentList.table.tsx
@@ -1,4 +1,4 @@
-import { ColumnsType } from 'antd/lib/table';
+import { ColumnType } from 'antd/lib/table';
 import React from 'react';
 
 import {
@@ -10,17 +10,11 @@ import { ExperimentItem } from 'types';
 import { alphanumericSorter, runStateSorter, stringTimeSorter } from 'utils/data';
 import { getDuration } from 'utils/time';
 
-export const columns: ColumnsType<ExperimentItem> = [
+export const columns: ColumnType<ExperimentItem>[] = [
   {
     dataIndex: 'id',
     sorter: (a: ExperimentItem, b: ExperimentItem): number => alphanumericSorter(a.id, b.id),
     title: 'ID',
-  },
-  {
-    dataIndex: 'name',
-    render: experimentDescriptionRenderer,
-    sorter: (a: ExperimentItem, b: ExperimentItem): number => alphanumericSorter(a.name, b.name),
-    title: 'Name',
   },
   {
     defaultSortOrder: 'descend',

--- a/webui/react/src/pages/ExperimentList.table.tsx
+++ b/webui/react/src/pages/ExperimentList.table.tsx
@@ -1,19 +1,26 @@
-import { ColumnType } from 'antd/lib/table';
+import { ColumnsType } from 'antd/lib/table';
 import React from 'react';
 
 import {
-  experimentActionRenderer, experimentProgressRenderer, expermentDurationRenderer,
-  relativeTimeRenderer, stateRenderer, userRenderer,
+  experimentActionRenderer, experimentArchivedRenderer, experimentDescriptionRenderer,
+  experimentProgressRenderer, expermentDurationRenderer, relativeTimeRenderer, stateRenderer,
+  userRenderer,
 } from 'components/Table';
 import { ExperimentItem } from 'types';
 import { alphanumericSorter, runStateSorter, stringTimeSorter } from 'utils/data';
 import { getDuration } from 'utils/time';
 
-export const columns: ColumnType<ExperimentItem>[] = [
+export const columns: ColumnsType<ExperimentItem> = [
   {
     dataIndex: 'id',
     sorter: (a: ExperimentItem, b: ExperimentItem): number => alphanumericSorter(a.id, b.id),
     title: 'ID',
+  },
+  {
+    dataIndex: 'name',
+    render: experimentDescriptionRenderer,
+    sorter: (a: ExperimentItem, b: ExperimentItem): number => alphanumericSorter(a.name, b.name),
+    title: 'Name',
   },
   {
     defaultSortOrder: 'descend',
@@ -42,6 +49,13 @@ export const columns: ColumnType<ExperimentItem>[] = [
     render: experimentProgressRenderer,
     sorter: (a: ExperimentItem, b: ExperimentItem): number => (a.progress || 0) - (b.progress || 0),
     title: 'Progress',
+  },
+  {
+    align: 'center',
+    render: experimentArchivedRenderer,
+    sorter: (a: ExperimentItem, b: ExperimentItem): number =>
+      (a.archived === b.archived)? 0 : a.archived? 1 : -1,
+    title: 'Archived',
   },
   {
     render: userRenderer,

--- a/webui/react/src/pages/ExperimentList.table.tsx
+++ b/webui/react/src/pages/ExperimentList.table.tsx
@@ -54,7 +54,7 @@ export const columns: ColumnsType<ExperimentItem> = [
     align: 'center',
     render: experimentArchivedRenderer,
     sorter: (a: ExperimentItem, b: ExperimentItem): number =>
-      (a.archived === b.archived)? 0 : a.archived? 1 : -1,
+      (a.archived === b.archived) ? 0 : (a.archived ? 1 : -1),
     title: 'Archived',
   },
   {

--- a/webui/react/src/pages/ExperimentList.table.tsx
+++ b/webui/react/src/pages/ExperimentList.table.tsx
@@ -2,9 +2,8 @@ import { ColumnType } from 'antd/lib/table';
 import React from 'react';
 
 import {
-  experimentActionRenderer, experimentArchivedRenderer, experimentDescriptionRenderer,
-  experimentProgressRenderer, expermentDurationRenderer, relativeTimeRenderer, stateRenderer,
-  userRenderer,
+  experimentActionRenderer, experimentArchivedRenderer, experimentProgressRenderer,
+  expermentDurationRenderer, relativeTimeRenderer, stateRenderer, userRenderer,
 } from 'components/Table';
 import { ExperimentItem } from 'types';
 import { alphanumericSorter, runStateSorter, stringTimeSorter } from 'utils/data';


### PR DESCRIPTION
## Description

Add column to Experiment list that uses a checkmark to indicate whether the Experiment is archived.

## Test Plan

Tested manually.  

<img width="1625" alt="Screen Shot 2020-07-29 at 4 57 33 AM" src="https://user-images.githubusercontent.com/13806811/88798602-fc18ce00-d159-11ea-8c40-ba605a01c398.png">

Tested sorting - when using descending order, `archived=True` is at the top.

<img width="182" alt="Screen Shot 2020-07-29 at 4 57 48 AM" src="https://user-images.githubusercontent.com/13806811/88798612-ffac5500-d159-11ea-8c39-fdca4d25c98a.png">

## Commentary (optional)

I found a checkmark in Ant Design that I think looks good, but let me know if we want to go with Yes/No text for now.
