### PR TITLE
chore: install setuptools_scm before pytest [DET-3709]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -835,6 +835,7 @@ jobs:
       - run: pip install --find-links build determined-cli==<< pipeline.parameters.det-version >>
       # Ensure Determined cli can run without installing cli test requirements
       - run: det --help
+      - run: pip install setuptools_scm
       - run: pip install -r cli/tests/requirements.txt
       - run: pytest cli/tests
 

--- a/cli/tests/requirements.txt
+++ b/cli/tests/requirements.txt
@@ -1,4 +1,3 @@
 requests
-setuptools_scm
 pytest
 requests_mock

--- a/cli/tests/requirements.txt
+++ b/cli/tests/requirements.txt
@@ -1,4 +1,4 @@
 requests
-iniconfig
+setuptools_scm
 pytest
 requests_mock

--- a/cli/tests/requirements.txt
+++ b/cli/tests/requirements.txt
@@ -1,3 +1,4 @@
 requests
+iniconfig
 pytest
 requests_mock


### PR DESCRIPTION
# Description
This change manually installs `setuptools_scm` in CI before calling `pip install -r cli/tests/requirements.txt` to avoid a bug that occurs with packages that still rely on `setup_requires` in their `setup.py`.

# Commentary
This is the same issue described here: https://github.com/pypa/pip/issues/6133.