### PR TITLE
fix: fix make check

### DIFF
--- a/cli/tests/requirements.txt
+++ b/cli/tests/requirements.txt
@@ -1,3 +1,4 @@
 requests
-pytest
+# pytest 6.0 has linter-breaking changes
+pytest>=6.0.1
 requests_mock

--- a/e2e_tests/tests/command/command.py
+++ b/e2e_tests/tests/command/command.py
@@ -32,11 +32,11 @@ def interactive_command(*args: str) -> Generator:
             self.task_id = None  # type: Optional[str]
 
             if self.detach:
-                iterator = iter(self.process.stdout)
+                iterator = iter(self.process.stdout)  # type: ignore
                 line = next(iterator)
                 self.task_id = line.decode().strip()
             else:
-                iterator = iter(self.process.stdout)
+                iterator = iter(self.process.stdout)  # type: ignore
                 line = next(iterator)
                 m = re.search(rb"Scheduling .* \(id: (.*)\)\.\.\.", line)
                 assert m is not None
@@ -44,15 +44,18 @@ def interactive_command(*args: str) -> Generator:
 
         @property
         def stdout(self) -> Generator[str, None, None]:
+            assert self.process.stdout is not None
             for line in self.process.stdout:
                 yield line.decode()
 
         @property
         def stderr(self) -> Generator[str, None, None]:
+            assert self.process.stderr is not None
             return (line.decode() for line in self.process.stderr)
 
         @property
         def stdin(self) -> IO:
+            assert self.process.stdin is not None
             return self.process.stdin
 
     with subprocess.Popen(

--- a/e2e_tests/tests/conftest.py
+++ b/e2e_tests/tests/conftest.py
@@ -90,7 +90,7 @@ def pytest_itemcollected(item: Any) -> None:
         pytest.exit(f"{item.nodeid} is missing an integration test mark (any of {_INTEG_MARKERS})")
 
 
-@pytest.fixture(scope="session")  # type: ignore
+@pytest.fixture(scope="session")
 def secrets(request: SubRequest) -> Dict[str, str]:
     """
     Connect to S3 secretsmanager to get the secret values used in integrations tests.

--- a/e2e_tests/tests/experiment/experiment.py
+++ b/e2e_tests/tests/experiment/experiment.py
@@ -26,6 +26,7 @@ def maybe_create_native_experiment(context_dir: str, command: List[str]) -> Opti
     with subprocess.Popen(
         command, stdin=subprocess.PIPE, stdout=subprocess.PIPE, cwd=context_dir, env=target_env
     ) as p:
+        assert p.stdout is not None
         for line in p.stdout:
             m = re.search(r"Created experiment (\d+)\n", line.decode())
             if m is not None:
@@ -39,7 +40,7 @@ def create_native_experiment(context_dir: str, command: List[str]) -> int:
     if experiment_id is None:
         pytest.fail(f"Failed to create experiment in {context_dir}: {command}")
 
-    return experiment_id  # type: ignore
+    return experiment_id
 
 
 def maybe_create_experiment(

--- a/e2e_tests/tests/experiment/test_native.py
+++ b/e2e_tests/tests/experiment/test_native.py
@@ -129,6 +129,7 @@ def maybe_create_experiment(implementation: NativeImplementation) -> typing.Opti
         cwd=implementation.cwd,
         env=target_env,
     ) as p:
+        assert p.stdout is not None
         for line in p.stdout:
             m = re.search(r"Created experiment (\d+)\n", line.decode())
             if m is not None:

--- a/e2e_tests/tests/requirements.txt
+++ b/e2e_tests/tests/requirements.txt
@@ -1,5 +1,6 @@
 appdirs
-pytest
+# pytest 6.0 has linter-breaking changes
+pytest>=6.0.1
 pexpect
 torch==1.4
 torchvision==0.5.0

--- a/examples/tests/requirements.txt
+++ b/examples/tests/requirements.txt
@@ -1,4 +1,5 @@
-pytest
+# pytest 6.0 has linter-breaking changes
+pytest>=6.0.1
 tensorflow==2.2.0
 torch==1.4.0
 torchvision==0.5.0

--- a/harness/determined/gpu.py
+++ b/harness/determined/gpu.py
@@ -38,7 +38,7 @@ def get_gpus() -> List[GPU]:
 
     gpus = []
     with proc:
-        for field_list in csv.reader(proc.stdout):
+        for field_list in csv.reader(proc.stdout.read()):  # type: ignore
             if len(field_list) != len(gpu_fields):
                 logging.warning(f"Ignoring unexpected nvidia-smi output: {field_list}")
                 continue

--- a/harness/tests/conftest.py
+++ b/harness/tests/conftest.py
@@ -20,7 +20,7 @@ def pytest_collection_modifyitems(config: Any, items: List[Any]) -> None:
             item.add_marker(skip_slow)
 
 
-@pytest.fixture(scope="function")  # type: ignore
+@pytest.fixture(scope="function")
 def expose_gpus() -> Generator:
     """
     Set the environment variables to mimic what the agent uses to control which

--- a/harness/tests/requirements.txt
+++ b/harness/tests/requirements.txt
@@ -1,2 +1,4 @@
-pytest
-mypy==0.740
+# pytest 6.0 has linter-breaking changes
+pytest>=6.0.1
+# pytest 6.0 is based on mypy 0.780
+mypy==0.780

--- a/harness/tests/storage/test_s3.py
+++ b/harness/tests/storage/test_s3.py
@@ -11,7 +11,7 @@ from tests import s3
 from tests.storage import util
 
 
-@pytest.fixture  # type: ignore
+@pytest.fixture
 def manager(tmp_path: Path, monkeypatch: MonkeyPatch) -> storage.S3StorageManager:
     monkeypatch.setattr("boto3.client", s3.s3_client)
     return storage.S3StorageManager(

--- a/harness/tests/storage/test_shared_fs.py
+++ b/harness/tests/storage/test_shared_fs.py
@@ -9,7 +9,7 @@ from determined_common.storage import shared
 from tests.storage import util
 
 
-@pytest.fixture()  # type: ignore
+@pytest.fixture()
 def manager(tmp_path: Path) -> storage.SharedFSStorageManager:
     return storage.SharedFSStorageManager(str(tmp_path))
 

--- a/harness/tests/test_gc_harness.py
+++ b/harness/tests/test_gc_harness.py
@@ -11,12 +11,12 @@ from determined_common import storage
 from tests.storage import util as storage_util
 
 
-@pytest.fixture()  # type: ignore
+@pytest.fixture()
 def manager(tmp_path: Path) -> storage.StorageManager:
     return storage.SharedFSStorageManager(str(tmp_path))
 
 
-@pytest.fixture(params=[0, 1, 5])  # type: ignore
+@pytest.fixture(params=[0, 1, 5])
 def to_delete(request: Any, manager: storage.StorageManager) -> List[Dict[str, Any]]:
     metadata = []
     for _ in range(request.param):

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,5 +18,6 @@ flake8-docstrings>=1.4.0
 flake8-quotes>=2.1.0
 flake8-tuple>=0.4.0
 isort==4.3.21
-mypy==0.740
+# pytest 6.0 is based on mypy 0.780
+mypy==0.780
 bump2version>=1.0.0


### PR DESCRIPTION
    pytest recently released major version 6.0. It introduces some
    significant typing fixes. pytest 6.0 requires mypy==0.750, but is
    actually developed against mypy==0.780.

    This supports pytest 6.0 and explicitly requires pytest>=6.0.1 and
    mypy==0.780.


## Test Plan

CI should pass again.