### PR TITLE
fix: undo a mistaken edit from 'fix make check'

### DIFF
--- a/harness/determined/gpu.py
+++ b/harness/determined/gpu.py
@@ -38,7 +38,7 @@ def get_gpus() -> List[GPU]:
 
     gpus = []
     with proc:
-        for field_list in csv.reader(proc.stdout.read()):  # type: ignore
+        for field_list in csv.reader(proc.stdout):  # type: ignore
             if len(field_list) != len(gpu_fields):
                 logging.warning(f"Ignoring unexpected nvidia-smi output: {field_list}")
                 continue


### PR DESCRIPTION
## Test Plan

Reproduced the breakage locally and confirmed that the change works correctly on gpu machines.