### PR TITLE
chore: rename batches_per_step [DET-3627]

### DIFF
--- a/common/determined_common/api/experiment.py
+++ b/common/determined_common/api/experiment.py
@@ -255,7 +255,7 @@ def make_test_experiment_config(config: Dict[str, Any]) -> Dict[str, Any]:
             "description": "[test-mode] {}".format(
                 config_test.get("description", str(uuid.uuid4()))
             ),
-            "batches_per_step": 1,
+            "scheduling_unit": 1,
             "min_validation_period": {"batches": 1},
             "checkpoint_storage": {
                 **config_test.get("checkpoint_storage", {}),

--- a/docs/reference/cluster-config.txt
+++ b/docs/reference/cluster-config.txt
@@ -135,7 +135,7 @@ When an experiment is created, we report:
 - the ``searcher`` and ``resources`` sections of the experiment config
 - the name of the container image used
 - the total number of hyperparameters
-- the value of the ``batches_per_step`` configuration setting
+- the value of the ``scheduling_unit`` configuration setting
 
 When an experiment terminates, we report:
 

--- a/docs/reference/experiment-config.txt
+++ b/docs/reference/experiment-config.txt
@@ -481,9 +481,9 @@ created with the Determined CLI. It may contain the following fields:
     described in the PyTorch
     documentation <https://pytorch.org/docs/stable/nn.html#torch.nn.DataParallel>`__.
 
-.. _batches-per-step:
+.. _scheduling-unit:
 
-- ``batches_per_step``: Specifies the number of batches in a single
+- ``scheduling_unit``: Specifies the number of batches in a single
   training workload. As discussed above, Determined divides the training of a
   single trial into a sequence of training workloads; each workload corresponds
   to a certain number of model updates. Therefore, this configuration

--- a/docs/topic-guides/optimizing-distributed-training.txt
+++ b/docs/topic-guides/optimizing-distributed-training.txt
@@ -100,7 +100,7 @@ optimizations are available in :ref:`experiment-configuration` under ``optimizat
 * ``optimizations.average_training_metrics`` averages the training metrics across
   GPUs at the end of every training workload, which requires communication. This will
   typically not have a major impact on training performance, but if you have a very small
-  ``batches_per_step``, ensuring it is disabled may improve performance. If this
+  ``scheduling_unit``, ensuring it is disabled may improve performance. If this
   option is disabled (which is the default behavior), only the training metrics from
   the chief GPU are used. This impacts shown in the Determined UI and TensorBoard,
   but does not influence model behavior or hyperparameter search.

--- a/e2e_tests/tests/experiment/test_native.py
+++ b/e2e_tests/tests/experiment/test_native.py
@@ -43,7 +43,7 @@ class NativeImplementations:
             conf.official_examples_path("native/native_mnist_estimator/native_impl.py"),
         ],
         configuration={
-            "batches_per_step": 4,
+            "scheduling_unit": 4,
             "checkpoint_storage": experiment.shared_fs_checkpoint_config(),
             "searcher": {"name": "single", "max_length": {"batches": 4}, "metric": "accuracy"},
             "max_restarts": 0,
@@ -59,7 +59,7 @@ class NativeImplementations:
             conf.official_examples_path("native/native_mnist_estimator/trial_impl.py"),
         ],
         configuration={
-            "batches_per_step": 4,
+            "scheduling_unit": 4,
             "checkpoint_storage": experiment.shared_fs_checkpoint_config(),
             "searcher": {"name": "single", "max_length": {"batches": 4}, "metric": "accuracy"},
             "max_restarts": 0,
@@ -77,7 +77,7 @@ class NativeImplementations:
             "--use-fit",
         ],
         configuration={
-            "batches_per_step": 4,
+            "scheduling_unit": 4,
             "checkpoint_storage": experiment.shared_fs_checkpoint_config(),
             "searcher": {"name": "single", "max_length": {"batches": 4}, "metric": "val_accuracy"},
             "max_restarts": 2,
@@ -94,7 +94,7 @@ class NativeImplementations:
             conf.official_examples_path("native/native_fashion_mnist_tf_keras/native_impl.py"),
         ],
         configuration={
-            "batches_per_step": 4,
+            "scheduling_unit": 4,
             "checkpoint_storage": experiment.shared_fs_checkpoint_config(),
             "searcher": {"name": "single", "max_length": {"batches": 4}, "metric": "val_accuracy"},
             "max_restarts": 2,
@@ -110,7 +110,7 @@ class NativeImplementations:
             conf.official_examples_path("native/native_fashion_mnist_tf_keras/trial_impl.py"),
         ],
         configuration={
-            "batches_per_step": 4,
+            "scheduling_unit": 4,
             "checkpoint_storage": experiment.shared_fs_checkpoint_config(),
             "searcher": {"name": "single", "max_length": {"batches": 4}, "metric": "val_accuracy"},
             "max_restarts": 2,

--- a/e2e_tests/tests/experiment/test_tf_estimator.py
+++ b/e2e_tests/tests/experiment/test_tf_estimator.py
@@ -85,7 +85,7 @@ def test_mnist_estimator_warm_start(tf2: bool) -> None:
 
 def run_dataset_experiment(
     searcher_max_length: Dict[str, int],
-    batches_per_step: int,
+    scheduling_unit: int,
     secrets: Dict[str, str],
     tf2: bool,
     slots_per_trial: int = 1,
@@ -94,7 +94,7 @@ def run_dataset_experiment(
     config = conf.load_config(conf.fixtures_path("estimator_dataset/const.yaml"))
     config.setdefault("searcher", {})
     config["searcher"]["max_length"] = searcher_max_length
-    config["batches_per_step"] = batches_per_step
+    config["scheduling_unit"] = scheduling_unit
     config = conf.set_tf2_image(config) if tf2 else conf.set_tf1_image(config)
 
     if source_trial_id is not None:
@@ -115,9 +115,9 @@ def run_dataset_experiment(
 @pytest.mark.e2e_gpu  # type: ignore
 @pytest.mark.parametrize("tf2", [False])  # type: ignore
 def test_dataset_restore(secrets: Dict[str, str], tf2: bool) -> None:
-    for searcher_max_batches, batches_per_step in [(4, 1), (4, 2), (4, 4)]:
+    for searcher_max_batches, scheduling_unit in [(4, 1), (4, 2), (4, 4)]:
         trials = run_dataset_experiment(
-            {"batches": searcher_max_batches}, batches_per_step, secrets, tf2
+            {"batches": searcher_max_batches}, scheduling_unit, secrets, tf2
         )
         losses = exp.get_flat_metrics(trials[0]["id"], "loss")
         assert losses == DATASET_EXPERIMENT_EXPECTED_LOSSES

--- a/e2e_tests/tests/fixtures/estimator_dataset/const.yaml
+++ b/e2e_tests/tests/fixtures/estimator_dataset/const.yaml
@@ -12,7 +12,7 @@ searcher:
   max_length:
     batches: 1
 max_restarts: 0
-batches_per_step: 1
+scheduling_unit: 1
 entrypoint: model:EstimatorDatasetTrial
 min_validation_period:
   batches: 1

--- a/e2e_tests/tests/fixtures/estimator_dataset/distributed.yaml
+++ b/e2e_tests/tests/fixtures/estimator_dataset/distributed.yaml
@@ -12,7 +12,7 @@ searcher:
   max_length:
     batches: 1
 max_restarts: 0
-batches_per_step: 1
+scheduling_unit: 1
 entrypoint: model:EstimatorDatasetTrial
 min_validation_period:
   batches: 1

--- a/e2e_tests/tests/fixtures/metric_maker/metric_maker.py
+++ b/e2e_tests/tests/fixtures/metric_maker/metric_maker.py
@@ -85,17 +85,17 @@ class MetricMaker(det.CallbackTrialController):
     def pre_execute_hook(env: det.EnvContext, hvd_config: horovod.HorovodContext) -> None:
         pass
 
-    def train_for_step(self, step_id: int, scheduling_unit: int) -> Dict[str, Any]:
+    def train_for_step(self, step_id: int, num_batches: int) -> Dict[str, Any]:
         # Get the base value for each batch
-        batch_values = self.value + self.gain_per_batch * np.arange(scheduling_unit)
+        batch_values = self.value + self.gain_per_batch * np.arange(num_batches)
 
         # Get a training metric structure for each batch.
         batch_metrics = [structure_to_metrics(v, self.training_structure) for v in batch_values]
 
         # Update the overall base value for the trial..
-        self.value += self.gain_per_batch * scheduling_unit
+        self.value += self.gain_per_batch * num_batches
 
-        return {"metrics": {"batch_metrics": batch_metrics, "num_inputs": scheduling_unit}}
+        return {"metrics": {"batch_metrics": batch_metrics, "num_inputs": num_batches}}
 
     def compute_validation_metrics(self, step_id: int) -> Dict[str, Any]:
         return {

--- a/e2e_tests/tests/fixtures/metric_maker/metric_maker.py
+++ b/e2e_tests/tests/fixtures/metric_maker/metric_maker.py
@@ -85,17 +85,17 @@ class MetricMaker(det.CallbackTrialController):
     def pre_execute_hook(env: det.EnvContext, hvd_config: horovod.HorovodContext) -> None:
         pass
 
-    def train_for_step(self, step_id: int, batches_per_step: int) -> Dict[str, Any]:
+    def train_for_step(self, step_id: int, scheduling_unit: int) -> Dict[str, Any]:
         # Get the base value for each batch
-        batch_values = self.value + self.gain_per_batch * np.arange(batches_per_step)
+        batch_values = self.value + self.gain_per_batch * np.arange(scheduling_unit)
 
         # Get a training metric structure for each batch.
         batch_metrics = [structure_to_metrics(v, self.training_structure) for v in batch_values]
 
         # Update the overall base value for the trial..
-        self.value += self.gain_per_batch * batches_per_step
+        self.value += self.gain_per_batch * scheduling_unit
 
-        return {"metrics": {"batch_metrics": batch_metrics, "num_inputs": batches_per_step}}
+        return {"metrics": {"batch_metrics": batch_metrics, "num_inputs": scheduling_unit}}
 
     def compute_validation_metrics(self, step_id: int) -> Dict[str, Any]:
         return {

--- a/e2e_tests/tests/fixtures/no_op/model_def.py
+++ b/e2e_tests/tests/fixtures/no_op/model_def.py
@@ -84,11 +84,11 @@ class NoOpTrialController(det.CallbackTrialController):
         else:
             raise ValueError("Invalid `metrics_progression` {}".format(self.metrics_progression))
 
-    def train_for_step(self, step_id: int, scheduling_unit: int) -> Dict[str, Any]:
+    def train_for_step(self, step_id: int, num_batches: int) -> Dict[str, Any]:
         if self.request_stop:
             self.context.set_stop_requested(True)
         self.chaos_failure(self.chaos_probability_train)
-        time.sleep(self.train_batch_secs * scheduling_unit)
+        time.sleep(self.train_batch_secs * num_batches)
         if self.write_null:
             with open("/dev/stdout", "wb") as f:
                 f.write(b"\x00")
@@ -96,7 +96,7 @@ class NoOpTrialController(det.CallbackTrialController):
         metrics = {name: self.current_metric() for name in ["loss", *self.training_metrics()]}
         response = {
             "metrics": det.util.make_metrics(
-                self._batch_size * scheduling_unit, [metrics] * scheduling_unit
+                self._batch_size * num_batches, [metrics] * num_batches
             ),
             "stop_requested": self.context.get_stop_requested(),
         }

--- a/e2e_tests/tests/fixtures/no_op/model_def.py
+++ b/e2e_tests/tests/fixtures/no_op/model_def.py
@@ -84,11 +84,11 @@ class NoOpTrialController(det.CallbackTrialController):
         else:
             raise ValueError("Invalid `metrics_progression` {}".format(self.metrics_progression))
 
-    def train_for_step(self, step_id: int, batches_per_step: int) -> Dict[str, Any]:
+    def train_for_step(self, step_id: int, scheduling_unit: int) -> Dict[str, Any]:
         if self.request_stop:
             self.context.set_stop_requested(True)
         self.chaos_failure(self.chaos_probability_train)
-        time.sleep(self.train_batch_secs * batches_per_step)
+        time.sleep(self.train_batch_secs * scheduling_unit)
         if self.write_null:
             with open("/dev/stdout", "wb") as f:
                 f.write(b"\x00")
@@ -96,7 +96,7 @@ class NoOpTrialController(det.CallbackTrialController):
         metrics = {name: self.current_metric() for name in ["loss", *self.training_metrics()]}
         response = {
             "metrics": det.util.make_metrics(
-                self._batch_size * batches_per_step, [metrics] * batches_per_step
+                self._batch_size * scheduling_unit, [metrics] * scheduling_unit
             ),
             "stop_requested": self.context.get_stop_requested(),
         }

--- a/e2e_tests/tests/fixtures/no_op/single-many-long-steps.yaml
+++ b/e2e_tests/tests/fixtures/no_op/single-many-long-steps.yaml
@@ -3,7 +3,7 @@ checkpoint_storage:
   type: shared_fs
   host_path: /tmp
   storage_path: determined-integration-checkpoints
-batches_per_step: 100
+scheduling_unit: 100
 hyperparameters:
   global_batch_size: 32
   training_batch_seconds: 0.01

--- a/e2e_tests/tests/fixtures/no_op/single-one-short-step.yaml
+++ b/e2e_tests/tests/fixtures/no_op/single-one-short-step.yaml
@@ -9,7 +9,7 @@ hyperparameters:
   metrics_progression: decreasing
   metrics_base: 0.9
   metrics_sigma: 0
-batches_per_step: 1
+scheduling_unit: 1
 searcher:
   metric: validation_error
   smaller_is_better: true

--- a/e2e_tests/tests/fixtures/no_op/single-very-many-long-steps.yaml
+++ b/e2e_tests/tests/fixtures/no_op/single-very-many-long-steps.yaml
@@ -3,7 +3,7 @@ checkpoint_storage:
   type: shared_fs
   host_path: /tmp
   storage_path: determined-integration-checkpoints
-batches_per_step: 100
+scheduling_unit: 100
 hyperparameters:
   global_batch_size: 32
   training_batch_seconds: 0.01

--- a/e2e_tests/tests/fixtures/no_op/startup-hook.yaml
+++ b/e2e_tests/tests/fixtures/no_op/startup-hook.yaml
@@ -10,7 +10,7 @@ hyperparameters:
   metrics_base: 0.9
   metrics_sigma: 0
   check_startup_hook_ran: True
-batches_per_step: 1
+scheduling_unit: 1
 searcher:
   metric: validation_error
   smaller_is_better: true

--- a/e2e_tests/tests/test_system.py
+++ b/e2e_tests/tests/test_system.py
@@ -55,19 +55,19 @@ def test_metric_gathering() -> None:
     training_structure = config["hyperparameters"]["training_structure"]["val"]
     validation_structure = config["hyperparameters"]["validation_structure"]["val"]
 
-    batches_per_step = 100
+    scheduling_unit = 100
 
     # Check training metrics.
     full_trial_metrics = exp.trial_metrics(trials[0]["id"])
     for step in full_trial_metrics["steps"]:
         metrics = step["metrics"]
-        assert metrics["num_inputs"] == batches_per_step
+        assert metrics["num_inputs"] == scheduling_unit
 
         actual = metrics["batch_metrics"]
-        assert len(actual) == batches_per_step
+        assert len(actual) == scheduling_unit
 
-        first_base_value = base_value + (step["id"] - 1) * batches_per_step
-        batch_values = first_base_value + gain_per_batch * np.arange(batches_per_step)
+        first_base_value = base_value + (step["id"] - 1) * scheduling_unit
+        batch_values = first_base_value + gain_per_batch * np.arange(scheduling_unit)
         expected = [structure_to_metrics(value, training_structure) for value in batch_values]
         assert structure_equal(expected, actual)
 
@@ -77,7 +77,7 @@ def test_metric_gathering() -> None:
         metrics = validation["metrics"]
         actual = metrics["validation_metrics"]
 
-        value = base_value + step["id"] * batches_per_step
+        value = base_value + step["id"] * scheduling_unit
         expected = structure_to_metrics(value, validation_structure)
         assert structure_equal(expected, actual)
 

--- a/examples/experimental/trial/FasterRCNN_tp/16-gpus.yaml
+++ b/examples/experimental/trial/FasterRCNN_tp/16-gpus.yaml
@@ -28,7 +28,7 @@ min_validation_period:
 min_checkpoint_period:
   batches: 4096
 checkpoint_policy: none
-batches_per_step: 64
+scheduling_unit: 64
 reproducibility:
   experiment_seed: 12345
 

--- a/examples/experimental/trial/FasterRCNN_tp/64-gpus.yaml
+++ b/examples/experimental/trial/FasterRCNN_tp/64-gpus.yaml
@@ -27,7 +27,7 @@ min_validation_period:
 min_checkpoint_period:
   batches: 4096
 checkpoint_policy: none
-batches_per_step: 64
+scheduling_unit: 64
 reproducibility:
   experiment_seed: 12345
 

--- a/examples/experimental/trial/gbt_estimator/adaptive.yaml
+++ b/examples/experimental/trial/gbt_estimator/adaptive.yaml
@@ -40,6 +40,6 @@ searcher:
   max_trials: 100
   smaller_is_better: false
 entrypoint: model_def:BoostedTreesTrial
-batches_per_step: 1
+scheduling_unit: 1
 environment:
   image: "determinedai/environments:py-3.6.9-pytorch-1.4-tf-1.15-cpu-0.5.0"

--- a/examples/experimental/trial/gbt_estimator/const.yaml
+++ b/examples/experimental/trial/gbt_estimator/const.yaml
@@ -18,6 +18,6 @@ searcher:
     batches: 100
   smaller_is_better: false
 entrypoint: model_def:BoostedTreesTrial
-batches_per_step: 1
+scheduling_unit: 1
 environment:
   image: "determinedai/environments:py-3.6.9-pytorch-1.4-tf-1.15-cpu-0.5.0" 

--- a/examples/experimental/trial/mnist_tp_to_estimator/const.yaml
+++ b/examples/experimental/trial/mnist_tp_to_estimator/const.yaml
@@ -18,7 +18,7 @@ searcher:
     batches: 64
   smaller_is_better: true
 max_restarts: 0
-batches_per_step: 16
+scheduling_unit: 16
 min_checkpoint_period:
   batches: 32
 entrypoint: model_def:MnistTensorpackInEstimator

--- a/examples/experimental/trial/mnist_tp_to_estimator/const_visualize_synthetic.yaml
+++ b/examples/experimental/trial/mnist_tp_to_estimator/const_visualize_synthetic.yaml
@@ -18,7 +18,7 @@ searcher:
     batches: 2000
   smaller_is_better: true
 max_restarts: 0
-batches_per_step: 100
+scheduling_unit: 100
 min_checkpoint_period:
   batches: 2000
 entrypoint: model_def:MnistTensorpackInEstimator

--- a/examples/official/native/native_object_detection_pytorch/trial_impl.py
+++ b/examples/official/native/native_object_detection_pytorch/trial_impl.py
@@ -30,7 +30,7 @@ if __name__ == "__main__":
             "weight_decay": det.Constant(value=0.0005),
             "global_batch_size": det.Constant(value=2),
         },
-        "batches_per_step": 1,
+        "scheduling_unit": 1,
         "searcher": {
             "name": "single",
             "metric": "val_avg_iou",

--- a/examples/official/trial/mnist_tp/adaptive.yaml
+++ b/examples/official/trial/mnist_tp/adaptive.yaml
@@ -36,7 +36,7 @@ searcher:
     batches: 320
   max_trials: 16
   smaller_is_better: false
-batches_per_step: 16
+scheduling_unit: 16
 min_checkpoint_period:
   batches: 32
 entrypoint: model_def:MNISTTrial

--- a/examples/official/trial/mnist_tp/const.yaml
+++ b/examples/official/trial/mnist_tp/const.yaml
@@ -17,7 +17,7 @@ searcher:
   max_length:
     batches: 320
   smaller_is_better: false
-batches_per_step: 16
+scheduling_unit: 16
 min_checkpoint_period:
   batches: 32
 entrypoint: model_def:MNISTTrial

--- a/examples/official/trial/mnist_tp/distributed.yaml
+++ b/examples/official/trial/mnist_tp/distributed.yaml
@@ -20,7 +20,7 @@ searcher:
   max_length:
     batches: 320
   smaller_is_better: false
-batches_per_step: 16
+scheduling_unit: 16
 min_checkpoint_period:
   batches: 32
 entrypoint: model_def:MNISTTrial

--- a/harness/determined/_experiment_config.py
+++ b/harness/determined/_experiment_config.py
@@ -11,8 +11,8 @@ class ExperimentConfig(dict):
     def profile_frequency(self) -> int:
         return int(self.get("data", {}).get("__det_profile_frequency", 0))
 
-    def batches_per_step(self) -> int:
-        return int(self.get("batches_per_step", 100))
+    def scheduling_unit(self) -> int:
+        return int(self.get("scheduling_unit", 100))
 
     def native_enabled(self) -> bool:
         return "internal" in self and self["internal"] is not None and "native" in self["internal"]

--- a/harness/determined/_local_execution.py
+++ b/harness/determined/_local_execution.py
@@ -61,7 +61,7 @@ def _make_local_execution_env(
         container_id="",
         experiment_config=config,
         hparams=hparams,
-        initial_workload=workload.train_workload(1, 1, 1, config.batches_per_step()),
+        initial_workload=workload.train_workload(1, 1, 1, config.scheduling_unit()),
         latest_checkpoint=None,
         use_gpu=use_gpu,
         container_gpus=container_gpus,

--- a/harness/determined/_trial_controller.py
+++ b/harness/determined/_trial_controller.py
@@ -256,7 +256,7 @@ class LoopTrialController(TrialController):
         super().__init__(*args, **kwargs)  # type: ignore
 
         self.batch_size = self.context.get_per_slot_batch_size()
-        self.batches_per_step = self.env.experiment_config.batches_per_step()
+        self.scheduling_unit = self.env.experiment_config.scheduling_unit()
 
         logging.debug("Starting LoopTrialController initialization.")
 

--- a/harness/determined/constants.py
+++ b/harness/determined/constants.py
@@ -20,7 +20,7 @@ TRAIN_PROCESS_ENVIRONMENT_VARIABLE_PATH = Path("/tmp/det_train_process_env.json"
 # TODO: Unify the defaults used here with the defaults used in master.
 DEFAULT_SEARCHER_CFG = {"name": "single", "max_length": {"batches": 100}}
 DEFAULT_RESOURCES_CFG = {"slots_per_trial": 1, "native_parallel": False}
-DEFAULT_BATCHES_PER_STEP = 100
+DEFAULT_SCHEDULING_UNIT = 100
 DEFAULT_OPTIMIZATIONS = {
     "aggregation_frequency": 1,
     "average_aggregated_gradients": True,
@@ -30,7 +30,7 @@ DEFAULT_OPTIMIZATIONS = {
 }
 DEFAULT_EXP_CFG = {
     "searcher": DEFAULT_SEARCHER_CFG,
-    "batches_per_step": DEFAULT_BATCHES_PER_STEP,
+    "scheduling_unit": DEFAULT_SCHEDULING_UNIT,
     "resources": DEFAULT_RESOURCES_CFG,
     "optimizations": DEFAULT_OPTIMIZATIONS,
 }

--- a/harness/determined/estimator/_estimator_trial.py
+++ b/harness/determined/estimator/_estimator_trial.py
@@ -753,9 +753,9 @@ class EstimatorTrial(det.Trial):
         ``tf.data.Dataset`` object. A function that returns a tuple of features
         and labels is currently not supported by ``EstimatorTrial``.
         Additionally, the ``max_steps`` attribute of the training specification
-        will be ignored; instead, the ``batches_per_step`` option in the
+        will be ignored; instead, the ``scheduling_unit`` option in the
         experiment configuration is used to determine how many batches each
-        training step uses.
+        training workload uses.
         """
         pass
 

--- a/harness/determined/experimental/_native.py
+++ b/harness/determined/experimental/_native.py
@@ -94,7 +94,7 @@ def _make_test_workloads(
     yield from interceptor.send(workload.train_workload(1), [])
     metrics = interceptor.metrics_result()
     batch_metrics = metrics["metrics"]["batch_metrics"]
-    check.eq(len(batch_metrics), config.batches_per_step())
+    check.eq(len(batch_metrics), config.scheduling_unit())
     logging.debug(f"Finished training, metrics: {batch_metrics}")
 
     logging.info("Validating one step")
@@ -187,9 +187,9 @@ def test_one_batch(
     trial_class: Optional[Type[det.Trial]] = None,
     config: Optional[Dict[str, Any]] = None,
 ) -> Any:
-    # Override the batches_per_step value to 1.
+    # Override the scheduling_unit value to 1.
     # TODO(DET-2931): Make the validation step a single batch as well.
-    config = {**(config or {}), "batches_per_step": 1}
+    config = {**(config or {}), "scheduling_unit": 1}
 
     logging.info("Running a minimal test experiment locally")
     checkpoint_dir = tempfile.TemporaryDirectory()

--- a/harness/determined/keras/_tf_keras_inputs.py
+++ b/harness/determined/keras/_tf_keras_inputs.py
@@ -161,8 +161,8 @@ class _TrainingTFDatasetManager(_TrainingInputManager):
         return 0
 
     def get_training_input_and_batches_per_epoch(self) -> Tuple[tf.data.Dataset, int]:
-        # Tensorflow dataset doesn't provide length api so use the configured batches_per_step.
-        steps_per_epoch = self._context.env.experiment_config.batches_per_step()
+        # Tensorflow dataset doesn't provide length api so use the configured scheduling_unit.
+        steps_per_epoch = self._context.env.experiment_config.scheduling_unit()
         return self._training_dataset.repeat(), steps_per_epoch  # type: ignore
 
 

--- a/harness/determined/tensorpack/_tensorpack_trial.py
+++ b/harness/determined/tensorpack/_tensorpack_trial.py
@@ -494,7 +494,7 @@ class TensorpackTrialController(det.LoopTrialController):
             self.trainer.train_with_defaults(
                 callbacks=self.cbs,
                 monitors=self.trial.tensorpack_monitors(),
-                steps_per_epoch=self.batches_per_step,
+                steps_per_epoch=self.scheduling_unit,
                 starting_epoch=self.env.first_step(),
                 max_epoch=self.env.first_step() + IMPOSSIBLY_LARGE_EPOCHS,
                 session_init=self.session_init,

--- a/harness/tests/experiment/pytorch/test_pytorch_trial.py
+++ b/harness/tests/experiment/pytorch/test_pytorch_trial.py
@@ -323,7 +323,7 @@ class TestPyTorchTrial:
     def test_per_metric_reducers(self) -> None:
         def make_workloads() -> workload.Stream:
             trainer = utils.TrainAndValidate()
-            yield from trainer.send(steps=2, validation_freq=1, batches_per_step=1)
+            yield from trainer.send(steps=2, validation_freq=1, scheduling_unit=1)
             yield workload.terminate_workload(), [], workload.ignore_workload_response
 
         controller = utils.make_trial_controller_from_trial_implementation(
@@ -378,7 +378,7 @@ class TestPyTorchTrial:
     def test_context(self) -> None:
         def make_workloads() -> workload.Stream:
             trainer = utils.TrainAndValidate()
-            yield from trainer.send(steps=1, validation_freq=1, batches_per_step=1)
+            yield from trainer.send(steps=1, validation_freq=1, scheduling_unit=1)
             yield workload.terminate_workload(), [], workload.ignore_workload_response
 
         controller = utils.make_trial_controller_from_trial_implementation(

--- a/harness/tests/tensorboard/test_util.py
+++ b/harness/tests/tensorboard/test_util.py
@@ -17,7 +17,7 @@ def get_dummy_env() -> det.EnvContext:
             determined_common.types.ExperimentID(1),
             determined_common.types.TrialID(1),
             determined_common.types.StepID(1),
-            constants.DEFAULT_BATCHES_PER_STEP,
+            constants.DEFAULT_SCHEDULING_UNIT,
             0,
         ),
         latest_checkpoint=None,

--- a/harness/tests/test_horovod.py
+++ b/harness/tests/test_horovod.py
@@ -17,7 +17,7 @@ def create_default_env_context(experiment_config: Dict[str, Any]) -> det.EnvCont
             ExperimentID(1),
             TrialID(1),
             StepID(1),
-            det.ExperimentConfig(experiment_config).batches_per_step(),
+            det.ExperimentConfig(experiment_config).scheduling_unit(),
             0,
         ),
         master_addr="",

--- a/master/internal/telemetry/reports.go
+++ b/master/internal/telemetry/reports.go
@@ -41,7 +41,7 @@ func ReportExperimentCreated(system *actor.System, e model.Experiment) {
 		"resources":        e.Config.Resources,
 		"image":            e.Config.Environment.Image,
 		"num_hparams":      len(e.Config.Hyperparameters),
-		"batches_per_step": e.Config.BatchesPerStep,
+		"batches_per_step": e.Config.SchedulingUnit,
 	})
 }
 

--- a/master/internal/trial_workload_sequencer.go
+++ b/master/internal/trial_workload_sequencer.go
@@ -30,7 +30,7 @@ type trialWorkloadSequencer struct {
 
 	unitContext model.UnitContext
 
-	targetBatchesPerStep int
+	schedulingUnit int
 
 	trialID      int
 	trialIDValid bool
@@ -93,9 +93,9 @@ func newTrialWorkloadSequencer(
 		minCheckpointPeriod:               exp.Config.MinCheckpointPeriod,
 		unitContext: model.NewUnitContext(
 			exp.Config.Unit(), create.Hparams.GlobalBatchSize(), exp.Config.RecordsPerEpoch),
-		targetBatchesPerStep: exp.Config.BatchesPerStep,
-		create:               create,
-		experiment:           exp,
+		schedulingUnit: exp.Config.SchedulingUnit,
+		create:         create,
+		experiment:     exp,
 	}
 }
 
@@ -322,7 +322,7 @@ func (s trialWorkloadSequencer) Workload() (searcher.Workload, error) {
 			batchesLeft,
 			batchesTilVal,
 			batchesTilCkpt,
-			s.targetBatchesPerStep,
+			s.schedulingUnit,
 		)
 		return s.train(batchesThisStep), nil
 	default:

--- a/master/internal/trial_workload_sequencer_test.go
+++ b/master/internal/trial_workload_sequencer_test.go
@@ -46,7 +46,7 @@ checkpoint_policy: none
 	}, model.TrialWorkloadSequencerType)
 
 	// Sequencer input/output messages.
-	batchesPerStep := model.DefaultExperimentConfig().BatchesPerStep
+	schedulingUnit := model.DefaultExperimentConfig().SchedulingUnit
 	train := searcher.NewTrain(create.RequestID, model.NewLength(model.Batches, 500))
 	validate := searcher.NewValidate(create.RequestID)
 	checkpoint := searcher.NewCheckpoint(create.RequestID)
@@ -57,7 +57,7 @@ checkpoint_policy: none
 		ExperimentID:          1,
 		TrialID:               1,
 		StepID:                1,
-		NumBatches:            batchesPerStep,
+		NumBatches:            schedulingUnit,
 		TotalBatchesProcessed: 0,
 	}
 	trainWorkload2 := searcher.Workload{
@@ -65,81 +65,81 @@ checkpoint_policy: none
 		ExperimentID:          1,
 		TrialID:               1,
 		StepID:                2,
-		NumBatches:            batchesPerStep,
-		TotalBatchesProcessed: batchesPerStep,
+		NumBatches:            schedulingUnit,
+		TotalBatchesProcessed: schedulingUnit,
 	}
 	trainWorkload3 := searcher.Workload{
 		Kind:                  searcher.RunStep,
 		ExperimentID:          1,
 		TrialID:               1,
 		StepID:                3,
-		NumBatches:            batchesPerStep,
-		TotalBatchesProcessed: 2 * batchesPerStep,
+		NumBatches:            schedulingUnit,
+		TotalBatchesProcessed: 2 * schedulingUnit,
 	}
 	trainWorkload4 := searcher.Workload{
 		Kind:                  searcher.RunStep,
 		ExperimentID:          1,
 		TrialID:               1,
 		StepID:                4,
-		NumBatches:            batchesPerStep,
-		TotalBatchesProcessed: 3 * batchesPerStep,
+		NumBatches:            schedulingUnit,
+		TotalBatchesProcessed: 3 * schedulingUnit,
 	}
 	trainWorkload5 := searcher.Workload{
 		Kind:                  searcher.RunStep,
 		ExperimentID:          1,
 		TrialID:               1,
 		StepID:                5,
-		NumBatches:            batchesPerStep,
-		TotalBatchesProcessed: 4 * batchesPerStep,
+		NumBatches:            schedulingUnit,
+		TotalBatchesProcessed: 4 * schedulingUnit,
 	}
 	checkpointWorkload1 := searcher.Workload{
 		Kind:                  searcher.CheckpointModel,
 		ExperimentID:          1,
 		TrialID:               1,
 		StepID:                1,
-		TotalBatchesProcessed: batchesPerStep,
+		TotalBatchesProcessed: schedulingUnit,
 	}
 	checkpointWorkload2 := searcher.Workload{
 		Kind:                  searcher.CheckpointModel,
 		ExperimentID:          1,
 		TrialID:               1,
 		StepID:                2,
-		TotalBatchesProcessed: batchesPerStep * 2,
+		TotalBatchesProcessed: schedulingUnit * 2,
 	}
 	checkpointWorkload4 := searcher.Workload{
 		Kind:                  searcher.CheckpointModel,
 		ExperimentID:          1,
 		TrialID:               1,
 		StepID:                4,
-		TotalBatchesProcessed: batchesPerStep * 4,
+		TotalBatchesProcessed: schedulingUnit * 4,
 	}
 	checkpointWorkload5 := searcher.Workload{
 		Kind:                  searcher.CheckpointModel,
 		ExperimentID:          1,
 		TrialID:               1,
 		StepID:                5,
-		TotalBatchesProcessed: batchesPerStep * 5,
+		TotalBatchesProcessed: schedulingUnit * 5,
 	}
 	validationWorkload2 := searcher.Workload{
 		Kind:                  searcher.ComputeValidationMetrics,
 		ExperimentID:          1,
 		TrialID:               1,
 		StepID:                2,
-		TotalBatchesProcessed: batchesPerStep * 2,
+		TotalBatchesProcessed: schedulingUnit * 2,
 	}
 	validationWorkload4 := searcher.Workload{
 		Kind:                  searcher.ComputeValidationMetrics,
 		ExperimentID:          1,
 		TrialID:               1,
 		StepID:                4,
-		TotalBatchesProcessed: batchesPerStep * 4,
+		TotalBatchesProcessed: schedulingUnit * 4,
 	}
 	validationWorkload5 := searcher.Workload{
 		Kind:                  searcher.ComputeValidationMetrics,
 		ExperimentID:          1,
 		TrialID:               1,
 		StepID:                5,
-		TotalBatchesProcessed: batchesPerStep * 5,
+		TotalBatchesProcessed: schedulingUnit * 5,
 	}
 
 	s := newTrialWorkloadSequencer(experiment, create, nil)

--- a/master/pkg/model/defaults.go
+++ b/master/pkg/model/defaults.go
@@ -94,7 +94,7 @@ func DefaultExperimentConfig() ExperimentConfig {
 			AutoTuneTensorFusion:       false,
 		},
 		RecordsPerEpoch: 0,
-		BatchesPerStep:  100,
+		SchedulingUnit:  100,
 		Environment: Environment{
 			Image: RuntimeItem{
 				CPU: "determinedai/environments:py-3.6.9-pytorch-1.4-tf-1.15-cpu-23863bb",

--- a/master/pkg/model/experiment_config.go
+++ b/master/pkg/model/experiment_config.go
@@ -26,7 +26,7 @@ type ExperimentConfig struct {
 	Resources           ResourcesConfig           `json:"resources"`
 	Optimizations       OptimizationsConfig       `json:"optimizations"`
 	RecordsPerEpoch     int                       `json:"records_per_epoch"`
-	BatchesPerStep      int                       `json:"batches_per_step"`
+	SchedulingUnit      int                       `json:"scheduling_unit"`
 	BindMounts          []BindMount               `json:"bind_mounts,omitempty"`
 	Environment         Environment               `json:"environment"`
 	Reproducibility     ReproducibilityConfig     `json:"reproducibility"`

--- a/master/pkg/model/experiment_config_test.go
+++ b/master/pkg/model/experiment_config_test.go
@@ -244,7 +244,7 @@ func TestExperiment(t *testing.T) {
 		"batches": 1000
 	}
   },
-  "batches_per_step": 32,
+  "scheduling_unit": 32,
   "bind_mounts": [
     { "host_path": "/host/path",
       "container_path": "/container/path",
@@ -344,7 +344,7 @@ func TestExperiment(t *testing.T) {
 			TensorFusionCycleTime:      5,
 			AutoTuneTensorFusion:       false,
 		},
-		BatchesPerStep: 32,
+		SchedulingUnit: 32,
 		BindMounts: []BindMount{
 			{
 				HostPath:      "/host/path",

--- a/master/static/srv/get_checkpoint.sql
+++ b/master/static/srv/get_checkpoint.sql
@@ -4,7 +4,7 @@ SELECT
     e.id AS  experiment_id,
     t.id AS trial_id,
     t.hparams as hparams,
-    s.id * (e.config->>'batches_per_step')::int AS batch_number,
+    s.prior_batches_processed + s.num_batches AS batch_number,
     s.start_time AS start_time,
     s.end_time AS end_time,
     c.resources AS resources,

--- a/master/static/srv/get_checkpoints_for_experiment.sql
+++ b/master/static/srv/get_checkpoints_for_experiment.sql
@@ -3,7 +3,7 @@ SELECT
     e.config AS experiment_config,
     e.id AS  experiment_id,
     t.hparams as hparams,
-    s.id * (e.config->>'batches_per_step')::int AS batch_number,
+    s.prior_batches_processed + s.num_batches AS batch_number,
     s.start_time AS start_time,
     s.end_time AS end_time,
     c.resources AS resources,

--- a/master/static/srv/get_checkpoints_for_trial.sql
+++ b/master/static/srv/get_checkpoints_for_trial.sql
@@ -3,7 +3,7 @@ SELECT
     e.config AS experiment_config,
     e.id AS  experiment_id,
     t.hparams as hparams,
-    s.id * (e.config->>'batches_per_step')::int AS batch_number,
+    s.prior_batches_processed + s.num_batches AS batch_number,
     s.start_time AS start_time,
     s.end_time AS end_time,
     c.resources AS resources,

--- a/master/static/srv/get_model_version.sql
+++ b/master/static/srv/get_model_version.sql
@@ -13,7 +13,7 @@ c AS (
     e.id AS  experiment_id,
     t.id AS trial_id,
     t.hparams as hparams,
-    s.id * (e.config->>'batches_per_step')::int AS batch_number,
+    s.prior_batches_processed + s.num_batches AS batch_number,
     s.start_time AS start_time,
     s.end_time AS end_time,
     c.resources AS resources,

--- a/master/static/srv/get_model_versions.sql
+++ b/master/static/srv/get_model_versions.sql
@@ -13,7 +13,7 @@ c AS (
     e.id AS  experiment_id,
     t.id AS trial_id,
     t.hparams as hparams,
-    s.id * (e.config->>'batches_per_step')::int AS batch_number,
+    s.prior_batches_processed + s.num_batches AS batch_number,
     s.start_time AS start_time,
     s.end_time AS end_time,
     c.resources AS resources,


### PR DESCRIPTION
## Description
This change removes the configuration setting `batches_per_step` from Determined and replaces it with `scheduling_unit`. It also changes a few instances where `batches_per_step * step_id` was used in SQL queries to determine the batch # at a step to `prior_batches_processed + num_batches`.

## Test Plan
- [x] run examples with `scheduling_unit`

## Commentary
I would make `prior_batches_processed + num_batches` a generated column `total_batches_processed` since it's used everywhere but requiring pg 12 seems out of scope
