### PR TITLE
fix: include trial_id in get_checkpoints queries [DET-3732]

### DIFF
--- a/master/static/srv/get_checkpoints_for_experiment.sql
+++ b/master/static/srv/get_checkpoints_for_experiment.sql
@@ -2,6 +2,7 @@ SELECT
     c.uuid AS uuid,
     e.config AS experiment_config,
     e.id AS  experiment_id,
+    t.id AS trial_id,
     t.hparams as hparams,
     s.id * (e.config->>'batches_per_step')::int AS batch_number,
     s.start_time AS start_time,

--- a/master/static/srv/get_checkpoints_for_trial.sql
+++ b/master/static/srv/get_checkpoints_for_trial.sql
@@ -2,6 +2,7 @@ SELECT
     c.uuid AS uuid,
     e.config AS experiment_config,
     e.id AS  experiment_id,
+    t.id AS trial_id,
     t.hparams as hparams,
     s.id * (e.config->>'batches_per_step')::int AS batch_number,
     s.start_time AS start_time,


### PR DESCRIPTION
## Description
Add the `trial_id` field to get checkpoint queries.

## Test Plan
- [x] repro the issue described in DET-3732 and confirm this works.