### PR TITLE
docs: reformat experiment config documentation.

### DIFF
--- a/docs/faq.txt
+++ b/docs/faq.txt
@@ -69,11 +69,12 @@ Multi-GPU Training
 Why do my multi-GPU training experiments never start?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-It might be that ``slots_per_trial`` in the experiment configuration is
-not a multiple of the number of GPUs on a machine or that there are
-running tasks preventing your multi-GPU trials from acquiring all the
-GPUs on a single machine. Consider adjusting ``slots_per_trial`` or
-terminating existing tasks to free up slots in your cluster.
+It might be that :ref:`slots_per_trial <exp-config-resources-slots-per-trial>`
+in the experiment configuration is not a multiple of the number of GPUs on a
+machine or that there are running tasks preventing your multi-GPU trials from
+acquiring all the GPUs on a single machine. Consider adjusting
+``slots_per_trial`` or terminating existing tasks to free up slots in your
+cluster.
 
 See :ref:`multi-gpu-training` for more details.
 

--- a/docs/reference/cluster-config.txt
+++ b/docs/reference/cluster-config.txt
@@ -184,7 +184,6 @@ The master supports the following configuration settings:
     - ``worst``: The worst-fit policy ensures that tasks will be
       placed on under-utilized agents.
 
-
   - ``type``: The scheduling policy to use when allocating resources
     between different tasks (experiments, notebooks, etc.).
 
@@ -193,7 +192,6 @@ The master supports the following configuration settings:
 
     - ``priority``: Tasks are scheduled in the order of the order in which
       they arrive at the cluster.
-
 
   - ``resource_provider``: The resource provider to use to acquire agents.
 

--- a/docs/reference/experiment-config.txt
+++ b/docs/reference/experiment-config.txt
@@ -3,480 +3,103 @@
 Experiment Configuration
 ========================
 
-An experiment configuration is a YAML file that provides the pertinent
-user settings needed to run an experiment in Determined. Typically, the
-configuration is passed as a command-line argument when an experiment is
-created with the Determined CLI. It may contain the following fields:
+The behavior of an experiment can be configured via a YAML file. A
+configuration file is typically passed as a command-line argument when
+an experiment is created with the Determined CLI. For example:
 
-- ``description``: A human-readable description of the experiment. This
-  does not need to be unique.
-- ``labels``: A list of label names (strings). Assigning labels to
-  experiments allows you to identify experiments that share the same
-  property or should be grouped together. You can add and remove labels
-  using either the CLI (``det experiment label``) or the WebUI.
-- ``data``: Specifies the location of the data used by the experiment.
-  The content and format of this field is user-specified: it should be
-  used to specify whatever configuration is needed for loading data for
-  use by the experiment's model definition. For example, if your
-  experiment loads data from Amazon S3, the ``data`` field might
-  contain the S3 bucket name, object prefix, and AWS authentication
-  credentials.
-- ``entrypoint``: Specifies the location of the trial class in a user's model
-  definition as an `entrypoint specification string
+.. code::
+
+  det experiment create config-file.yaml model-directory
+
+Top-Level Fields
+****************
+
+**Required Fields**
+
+``entrypoint``
+  The location of the trial class in a user's model definition as an `entrypoint
+  specification string
   <https://packaging.python.org/specifications/entry-points/>`_. The entrypoint
   specification is expected to take the form ``<module>:<object reference>``.
   ``<module>`` specifies the module containing the trial class within the model
   definition, relative to the root. ``<object reference>`` specifies the naming
   of the trial class within the module. It may be a nested object delimited by
   dots. For more information and examples, please see :ref:`model-definitions`.
-- ``checkpoint_storage``: Specifies where model checkpoints will be
-  stored. A checkpoint contains the architecture and weights of the
-  model being trained. Determined currently supports four kinds of checkpoint
-  storage, ``gcs``, ``hdfs``, ``s3``, and ``shared_fs``, identified by
-  the ``type`` subfield. Defaults to checkpoint storage configured in
-  :ref:`cluster-configuration`.
 
-  - ``type: gcs``: Checkpoints are stored on Google Cloud Storage
-    (GCS). Authentication is done using GCP's "`Application Default
-    Credentials <https://googleapis.dev/python/google-api-core/latest/auth.html>`__"
-    approach. When using Determined inside Google Compute Engine (GCE), the
-    simplest approach is to ensure that the VMs used by Determined are
-    running in a service account that has the "Storage Object Admin"
-    role on the GCS bucket being used for checkpoints. As an
-    alternative (or when running outside of GCE), you can add the
-    appropriate `service account
-    credentials <https://cloud.google.com/docs/authentication/production#obtaining_and_providing_service_account_credentials_manually>`__
-    to your container (e.g., via a bind-mount), and then set the
-    ``GOOGLE_APPLICATION_CREDENTIALS`` environment variable to the container
-    path where the credentials are located. See :ref:`environment-variables`
-    for more details on how to set environment variables in containers.
+**Optional Fields**
 
-    - ``bucket``: The GCS bucket name to use.
+``description``
+  A human-readable description of the experiment. This does not need to be
+  unique.
 
-  - ``type: hdfs``: Checkpoints are stored in HDFS using the
-    `WebHDFS <http://hadoop.apache.org/docs/current/hadoop-project-dist/hadoop-hdfs/WebHDFS.html>`__
-    API for reading and writing checkpoint resources.
+``labels``
+  A list of label names (strings). Assigning labels to experiments
+  allows you to identify experiments that share the same property or
+  should be grouped together. You can add and remove labels using either
+  the CLI (``det experiment label``) or the WebUI.
 
-    - ``hdfs_url``: Hostname or IP address of HDFS namenode, prefixed
-      with protocol, followed by WebHDFS port on namenode. Multiple
-      namenodes are allowed as a semicolon-separated list (e.g.,
-      ``"http://namenode1:50070;http://namenode2:50070"``).
-    - ``hdfs_path``: The prefix path where all checkpoints will be
-      written to and read from. The resources of each checkpoint will
-      be saved in a subdirectory of ``hdfs_path``, where the
-      subdirectory name is the checkpoint's UUID.
-    - ``user``: An optional string value that indicates the user to
-      use for all read and write requests. If left unspecified, the
-      default user of the trial runner container will be used.
+.. _experiment-config-data:
 
-  - ``type: s3``: Checkpoints are stored in Amazon S3.
+``data``
+  This field can be used to specify information about how the experiment
+  accesses and loads training data. The content and format of this field
+  is user-defined: it should be used to specify whatever configuration
+  is needed for loading data for use by the experiment's model
+  definition. For example, if your experiment loads data from Amazon S3,
+  the ``data`` field might contain the S3 bucket name, object prefix,
+  and AWS authentication credentials.
 
-    - ``bucket``: The S3 bucket name to use.
-    - ``access_key``: The AWS access key to use.
-    - ``secret_key``: The AWS secret key to use.
-    - ``endpoint_url``: The optional endpoint to use for S3 clones,
-      e.g., http://127.0.0.1:8080/.
+.. _experiment-config-min-validation-period:
 
-  - ``type: shared_fs``: Checkpoints are written to a directory on the
-    agent's file system. The assumption is that the system
-    administrator has arranged for the same directory to be mounted at
-    every agent host, and for the content of this directory to be the
-    same on all agent hosts (e.g., by using a distributed or network
-    file system such as GlusterFS or NFS).
+``min_validation_period``
+  Instructs Determined to periodically compute validation metrics for
+  each trial during training. If set, this variable specifies the
+  maximum number of training steps that can be completed for a given
+  trial since the last validation operation for that trial; if this
+  limit is reached, a new validation operation is performed. Validation
+  metrics can be computed more frequently than specified by this
+  parameter, depending on the hyperparameter search method being used by
+  the experiment.
 
-    - ``host_path``: The file system path on each agent to use. This directory
-      will be mounted to ``/determined_shared_fs`` inside the trial container.
-    - ``storage_path``: The optional path where checkpoints will be
-      written to and read from. Must be a subdirectory of the
-      ``host_path`` or an absolute path containing the ``host_path``.
-      If unset, checkpoints are written to and read from the
-      ``host_path``.
-    - ``propagation``: (Advanced users only) Optional `propagation
-      behavior <https://docs.docker.com/storage/bind-mounts/#configure-bind-propagation>`__
-      for replicas of the bind-mount. Defaults to ``rprivate``.
+.. _experiment-config-min-checkpoint-period:
 
-    .. warning::
+``min_checkpoint_period``
+  Instructs Determined to take periodic checkpoints of each trial during
+  training. If set, this variable specifies the maximum number of
+  training steps that can be completed for a given trial since the last
+  checkpoint of that trial; if this limit is reached, a checkpoint of
+  the trial is taken. There are two other situations in which a trial
+  might be checkpointed: (a) during training, a model may be
+  checkpointed to allow the trial's execution to be suspended and later
+  resumed on a different Determined agent (b) when the trial's
+  experiment is completed, to allow the resulting model to be exported
+  from Determined (e.g., for deployment).
 
-        When downloading checkpoints in a shared file system, we assume the same
-        shared file system is mounted locally.
-
-  - When an experiment finishes, the system will optionally delete
-    some checkpoints to reclaim space. The ``save_experiment_best``,
-    ``save_trial_best`` and ``save_trial_latest`` parameters specify which
-    checkpoints to save. See the documentation on
-    :ref:`checkpoint-garbage-collection` for more details.
-
-- ``min_validation_period``: Instructs Determined to periodically compute
-  validation metrics for each trial during training. If set, this
-  variable specifies the maximum number of training steps that can be
-  completed for a given trial since the last validation operation for
-  that trial; if this limit is reached, a new validation operation is
-  performed. Validation metrics can be computed more frequently than
-  specified by this parameter, depending on the hyperparameter search
-  method being used by the experiment.
-- ``checkpoint_policy``: Controls how Determined performs checkpoints after
-  validation operations, if at all. Should be set to one of the
-  following values:
+``checkpoint_policy``
+  Controls how Determined performs checkpoints after validation operations, if
+  at all. Should be set to one of the following values:
 
   - ``best`` (default): A checkpoint will be taken after every
     validation operation that performs better than all previous
     validations for this experiment. Validation metrics are compared
     according to the ``metric`` and ``smaller_is_better`` options in
-    the ``searcher`` configuration.
+    the :ref:`searcher configuration <experiment-configuration_searcher>`.
   - ``all``: A checkpoint will be taken after every validation step,
     no matter the validation performance of the step.
   - ``none``: A checkpoint will never be taken *due* to a validation
     step. However, even with this policy selected, checkpoints are
     still expected to be taken after the last training step of a
     trial, due to cluster scheduling decisions or due to
-    ``min_checkpoint_period``.
-
-- ``min_checkpoint_period``: Instructs Determined to take periodic
-  checkpoints of each trial during training. If set, this variable
-  specifies the maximum number of training steps that can be completed
-  for a given trial since the last checkpoint of that trial; if this
-  limit is reached, a checkpoint of the trial is taken. There are two
-  other situations in which a trial might be checkpointed: (a) during
-  training, a model may be checkpointed to allow the trial's execution
-  to be suspended and later resumed on a different Determined agent (b) when
-  the trial's experiment is completed, to allow the resulting model to
-  be exported from Determined (e.g., for deployment).
-
-.. _experiment-configuration_hyperparameters:
-
-- ``hyperparameters``: Specifies the hyperparameter space via a list of
-  user-defined subfields corresponding to the hyperparameters.
-
-  - In order to fully define a hyperparameter, the following subfields
-    can be specified:
-
-    - ``type``: Defines the type of the hyperparameter. Must be one
-      of ``const``, ``double``, ``int``, ``log``, and ``categorical``.
-    - ``const`` hyperparameters are fixed hyperparameters that take on a given
-      value.  These options apply to ``const`` hyperparameters:
-
-      - ``val``: Specifies the value of the hyperparameter, e.g., ``True``,
-        ``2``, or ``any_string``.
-
-    - ``double`` hyperparameters are floating point numerics, while ``int``
-      hyperparameters take on integer values.  These options apply to ``double``
-      and ``int`` hyperparameters:
-
-      - ``minval``, ``maxval``: Specifies the minimum and maximum
-        values for the hyperparameter.
-      - ``count``: Specifies the number of values for this
-        hyperparameter during ``grid`` search (see
-        :ref:`topic-guides_hp-tuning-det_grid`). It is ignored for any other
-        searcher.  Values are evenly spaced between ``minval`` and ``maxval``.
-
-    - ``log`` hyperparameters are floating point numerics that are searched on
-      a logarithmic scale.  These options apply to ``log`` hyperparameters:
-
-      - ``base``: The base of the logarithm.  Hyperparameter values are
-        exponents applied to this base.
-      - ``minval``, ``maxval``: Specifies the minimum and maximum
-        exponent values for the hyperparameter.
-      - ``count``: Specifies the number of values for this
-        hyperparameter during ``grid`` search (see
-        :ref:`topic-guides_hp-tuning-det_grid`). It is ignored for any other
-        searcher.  Values are exponents evenly spaced between ``minval`` and
-        ``maxval``.
-
-    - ``categorical`` hyperparameters can take on a value within a specified set of
-      values.  These additional options apply to ``categorical``
-      hyperparameters:
-
-      - ``vals``: Specifies the list of possible values.  Values can be of any
-        type, e.g., ``True`` or ``False`` booleans, numbers, unquoted
-        strings, or even lists like ``[1, False]``.
-
-  - If a scalar value is specified instead of the subfields above, the
-    hyperparameter type will be assumed to be ``const``.
-  - The value chosen for a hyperparameter in a given trial can be
-    accessed via the context using ``context.get_hparam()``.
-    For instance, the current value of a hyperparameter named ``learning_rate``
-    is stored in the context of the of trial and can be accessed by:
-    ``context.get_hparam("learning_rate")``.
-
-    .. note::
-
-      ``global_batch_size`` is a required hyperparameter.  Batch size per slot is
-      computed at runtime, based on the number of slots using to train a single trial
-      of this experiment (see ``resources.slots_per_trial``). The updated values
-      should be accessed via the trial context, using
-      :func:`context.get_per_slot_batch_size() <determined.TrialContext.get_per_slot_batch_size>`
-      and
-      :func:`context.get_global_batch_size() <determined.TrialContext.get_global_batch_size>`.
-
-.. _experiment-configuration_searcher:
-
-- ``searcher``: Specifies the procedure for searching through the
-  hyperparameter space. Determined supports six search methods (``single``,
-  ``random``, ``grid``, ``adaptive_simple``, ``adaptive``, and ``pbt``), and
-  the user can specify which one to use via the ``name`` subfield. See the
-  `hp-search` documentation for more details. To use one of these search
-  methods, the following subfields must be specified:
-
-  - ``name: single``: This search method trains a single trial for a
-    fixed number of steps. By default, validation metrics are only
-    computed once, after the specified number of training steps have
-    been completed; ``min_validation_period`` (see above) can be used
-    to specify that validation metrics should be computed more
-    frequently.
-
-    - ``metric``: Specifies the name of the validation metric used to
-      evaluate the performance of a hyperparameter configuration.
-    - ``smaller_is_better``: Specifies whether to minimize or
-      maximize the metric defined above. The default value is true
-      (minimize).
-    - ``max_steps``: Specifies how many steps to allocate to the
-      trial.
-    - (optional) ``source_trial_id``: If specified, the weights of
-      this trial will be initialized to the most recent checkpoint of
-      the given trial ID. Note that this will fail if the source
-      trial's model architecture is inconsistent with the model
-      architecture of this experiment.
-    - (optional) ``source_checkpoint_uuid``: Like
-      ``source_trial_id``, but specifies an arbitrary checkpoint from
-      which to initialize weights; only one of ``source_trial_id`` or
-      ``source_checkpoint_uuid`` should be set.
-
-  - ``name: random``: This search method performs a random search.
-    Each random trial configuration is trained for the specified
-    number of steps, and then validation metrics are computed.
-    ``min_validation_period`` (see above) can be used to specify that
-    validation metrics should be computed more frequently.
-
-    - ``metric``: Specifies the name of the validation metric used to
-      evaluate the quality of different hyperparameter
-      configurations. The metric name should be a key in the
-      dictionary returned by the ``validation_metrics()`` function in
-      a :ref:`model-definitions_trial-api`.
-    - ``smaller_is_better``: Specifies whether to minimize or
-      maximize the metric defined above. The default value is true
-      (minimize).
-    - ``max_trials``: Specifies how many trials, i.e., hyperparameter
-      configurations, to evaluate.
-    - ``max_steps``: Specifies the number of training steps to run
-      for each trial.
-    - (optional) ``source_trial_id``: If specified, the weights of
-      *every* trial in the search will be initialized to the most
-      recent checkpoint of the given trial ID. Note that this will
-      fail if the source trial's model architecture is incompatible
-      with the model architecture of any of the trials in this
-      experiment.
-    - (optional) ``source_checkpoint_uuid``: Like ``source_trial_id``
-      but specifies an arbitrary checkpoint from which to initialize
-      weights. Only one of ``source_trial_id`` or
-      ``source_checkpoint_uuid`` should be set.
-
-  - ``name: grid``: This search method performs a grid search. The
-    coordinates of the hyperparameter grid are specified through the
-    ``hyperparameters`` field. For more details see the
-    :ref:`topic-guides_hp-tuning-det_grid`.
-
-    - ``metric``: Specifies the name of the validation metric used to
-      evaluate the performance of a hyperparameter configuration.
-    - ``smaller_is_better``: Specifies whether to minimize or
-      maximize the metric defined above. The default value is true
-      (minimize).
-    - (optional) ``source_trial_id``: If specified, the weights of
-      this trial will be initialized to the most recent checkpoint of
-      the given trial ID. Note that this will fail if the source
-      trial's model architecture is inconsistent with the model
-      architecture of this experiment.
-    - (optional) ``source_checkpoint_uuid``: Like
-      ``source_trial_id``, but specifies an arbitrary checkpoint from
-      which to initialize weights; only one of ``source_trial_id`` or
-      ``source_checkpoint_uuid`` should be set.
-
-  - ``name: adaptive``: This search method is a theoretically
-    principled and empirically state-of-the-art method that adaptively
-    allocates resources to promising hyperparameter configurations
-    while quickly eliminating poor ones.
-
-    - ``metric``: Specifies the name of the validation metric used to
-      evaluate the performance of a hyperparameter configuration.
-    - ``smaller_is_better``: Specifies whether to minimize or
-      maximize the metric defined above. The default value is true
-      (minimize).
-    - ``mode``: Specifies how aggressively to perform early stopping.
-      There are three modes: ``aggressive``, ``standard``, and
-      ``conservative``. These three modes differ in the degree to
-      which early-stopping is used. In ``aggressive`` mode, the
-      searcher quickly stops underperforming trials, which enables
-      the searcher to explore more hyperparameter configurations, but
-      at the risk of discarding a configuration too soon. On the
-      other end of the spectrum, ``conservative`` mode performs
-      significantly less downsampling, but as a consequence does not
-      explore as many configurations given the same budget. We
-      suggest using either ``aggressive`` or ``standard`` mode.
-    - ``target_trial_steps``: Specifies the maximum number of
-      training steps to allocate to any one trial. The vast majority
-      of trials will be stopped early, and thus only a small fraction
-      of trials will actually be trained for this number of steps. We
-      suggest setting this to a multiple of
-      ``divisor^(max_rungs-1)``, which is 45-1 = 256 with the default
-      values.
-    - ``step_budget``: Specifies the total number of steps to
-      allocate across all trials. We suggest setting this to be a
-      multiple of ``target_trial_steps``, which implies interpreting
-      this subfield as the effective number of complete trials to
-      evaluate. Note that some trials might be in-progress when this
-      budget is exhausted; adaptive search will allocate some
-      additional steps to complete these in-progress trials.
-    - (optional) ``divisor``: Specifies the fraction of trials to
-      keep at each rung, and also determines how many steps are
-      allocated at each rung. The default setting is ``4``; only
-      advanced users should consider changing this value.
-    - (optional) ``max_rungs``: Specifies the maximum number of times
-      we evaluate intermediate results for a trial and terminate
-      poorly performing trials. The default value is ``5``; only
-      advanced users should consider changing this value.
-    - (optional) ``source_trial_id``: If specified, the weights of
-      *every* trial in the search will be initialized to the most
-      recent checkpoint of the given trial ID. This will fail if the
-      source trial's model architecture is inconsistent with the
-      model architecture of any of the trials in this experiment.
-    - (optional) ``source_checkpoint_uuid``: Like
-      ``source_trial_id``, but specifies an arbitrary checkpoint from
-      which to initialize weights. Only one of ``source_trial_id`` or
-      ``source_checkpoint_uuid`` should be set.
-
-  - ``name: adaptive_simple``: This search method is an alternative
-    configuration to the ``adaptive`` search method (see above).
-
-    - ``metric``: Specifies the name of the validation metric used to
-      evaluate the performance of a hyperparameter configuration.
-    - ``smaller_is_better``: Specifies whether to minimize or
-      maximize the metric defined above. The default value is true
-      (minimize).
-    - ``max_steps``: Specifies the maximum number of training steps
-      to allocate to any one trial. The vast majority of trials will
-      be stopped early, and thus only a small fraction of trials will
-      actually be trained for this number of steps.
-    - ``max_trials``: Specifies how many trials, i.e., hyperparameter
-      configurations, to evaluate.
-    - (optional) ``mode``: Specifies how aggressively to perform
-      early stopping. There are three modes: ``aggressive``,
-      ``standard``, and ``conservative``. These three modes differ in
-      the degree to which early-stopping is used. In ``aggressive``
-      mode, the searcher quickly stops underperforming trials, which
-      enables the searcher to explore more hyperparameter
-      configurations, but at the risk of discarding a configuration
-      too soon. On the other end of the spectrum, ``conservative``
-      mode performs significantly less downsampling, but as a
-      consequence does not explore as many configurations given the
-      same budget. We suggest using either ``aggressive`` or
-      ``standard`` mode.
-    - (optional) ``divisor``: Specifies the fraction of trials to
-      keep at each rung, and also determines how many steps are
-      allocated at each rung. The default setting is ``4``; only
-      advanced users should consider changing this value.
-    - (optional) ``max_rungs``: Specifies the maximum number of times
-      we evaluate intermediate results for a trial and terminate
-      poorly performing trials. The default value is ``5``; only
-      advanced users should consider changing this value.
-    - (optional) ``source_trial_id``: If specified, the weights of
-      *every* trial in the search will be initialized to the most
-      recent checkpoint of the given trial ID. This will fail if the
-      source trial's model architecture is inconsistent with the
-      model architecture of any of the trials in this experiment.
-    - (optional) ``source_checkpoint_uuid``: Like
-      ``source_trial_id``, but specifies an arbitrary checkpoint from
-      which to initialize weights. Only one of ``source_trial_id`` or
-      ``source_checkpoint_uuid`` should be set.
-
-  - ``name: pbt``: This search method uses `population-based
-    training <https://deepmind.com/blog/population-based-training-neural-networks/>`__,
-    which maintains a population of active trials to train. After each
-    trial has been trained for a certain number of steps, all the
-    trials are validated. The searcher then closes some trials and
-    replaces them with altered copies of other trials. This process
-    makes up one "round"; the searcher runs some number of rounds to
-    execute a complete search. The model definition class must be able
-    to restore from a checkpoint that was created with a different set
-    of hyperparameters; in particular, you will not be able to vary
-    any hyperparameters that change the sizes of weight matrices
-    without taking special steps to save or restore models.
-
-    - ``metric``: Specifies the name of the validation metric used to
-      evaluate the performance of a hyperparameter configuration.
-    - ``smaller_is_better``: Specifies whether to minimize or
-      maximize the metric defined above. The default value is true
-      (minimize).
-    - ``population_size``: The number of trials (i.e., different
-      hyperparameter configurations) to keep active at a time.
-    - ``steps_per_round``: The number of steps to train each trial
-      between validations.
-    - ``num_rounds``: The total number of rounds to execute.
-    - ``replace_function``: Describes how to choose which trials to
-      close and which trials to copy at the end of each round.
-
-      - ``truncate_fraction``: Defines *truncation selection*, in
-        which the worst ``truncate_fraction`` (multiplied by the
-        population size) trials, ranked by validation metric, are
-        closed and the same number of top trials are copied.
-
-    - ``explore_function``: Describes how to alter a set of
-      hyperparameters when a copy of a trial is made. Each parameter
-      is either resampled (i.e., its value is chosen from the
-      configured distribution) or perturbed (i.e., its value is
-      computed based on the value in the original set).
-
-      - ``resample_probability``: The probability that a parameter
-        is replaced with a new value sampled from the original
-        distribution specified in the configuration.
-      - ``perturb_factor``: The amount by which parameters that are
-        not resampled are perturbed. Each numerical hyperparameter
-        is multiplied by either ``1 + perturb_factor`` or
-        ``1 - perturb_factor`` with equal probability;
-        ``categorical`` and ``const`` hyperparameters are left
-        unchanged.
-
-.. _exp-config-resources:
-
-- ``resources``: Describes the resources Determined allows an experiment to
-  use.
-
-  - ``max_slots``: Specifies the maximum number of scheduler slots
-    that this experiment is allowed to use at any one time. The slot
-    limit of an active experiment can be changed using
-    ``det experiment set max-slots <id> <slots>``.
-
-    .. warning::
-
-        The ``max_slots`` configuration is only used for scheduling jobs, it is
-				not currently used for provisioning dynamic agents. This means that we
-				may provision more instances than the experiment can schedule.
-
-  - ``weight``: Specifies the weight of this experiment in the
-    scheduler. When multiple experiments are running at the same time,
-    the number of slots assigned to each one will be approximately
-    proportional to its weight. The weight of an active experiment can
-    be changed using ``det experiment set weight <id> <weight>``.
-  - ``slots_per_trial``: Specifies the number of slots to use for each
-    trial of this experiment. The default value is 1; specifying a
-    value greater than 1 means that multiple GPUs will be used in
-    parallel. Training on multiple GPUs is done using data
-    parallelism. Configuring ``slots_per_trial`` to be greater than
-    ``max_slots`` is not sensible and will result in an error.
-  - ``shm_size``: Specifies the size in bytes of the ``/dev/shm`` for
-    trial containers. Defaults to 4294967296 (4GiB). If set, this
-    value overrides the value specified in ``etc/agent.conf``.
-  - *NOTE:* Using ``slots_per_trial`` to enable data parallel training
-    for ``PyTorch`` can alter the behavior of certain models, `as
-    described in the PyTorch
-    documentation <https://pytorch.org/docs/stable/nn.html#torch.nn.DataParallel>`__.
+    :ref:`min_checkpoint_period <experiment-config-min-checkpoint-period>`.
 
 .. _batches-per-step:
 
-- ``batches_per_step``: Specifies the number of batches in a single
-  training step. As discussed above, Determined divides the training of a
-  single trial into a sequence of steps; each step corresponds to a
-  certain number of model updates. Therefore, this configuration
-  parameter can be used to control how long a trial is trained at a
-  single agent:
+``batches_per_step``
+  The number of batches in a single training step. As discussed above,
+  Determined divides the training of a single trial into a sequence of steps;
+  each step corresponds to a certain number of model updates. Therefore, this
+  configuration parameter can be used to control how long a trial is trained at
+  a single agent:
 
   - Doing more work in a step allows per-step overheads (such as
     downloading training data) to be amortized over more training
@@ -484,171 +107,877 @@ created with the Determined CLI. It may contain the following fields:
     be trained for a long time before Determined gets an opportunity to
     suspend training of that trial and replace it with a different
     workload.
-  - The default value is 100. As a rule of thumb, the step size should
+  - The default value is ``100``. As a rule of thumb, the step size should
     be set so that training a single step takes 60--180 seconds.
-  - *NOTE:* The step size is defined as a fixed number of *batches*;
-    the size (number of records) in a batch is controlled by the
-    ``global_batch_size`` hyperparameter in the experiment's model
-    definition.
 
-- ``bind_mounts``: Specifies a collection of directories that are
-  bind-mounted into the trial containers for this experiment. This can
-  be used to allow trials to access additional data that is not
-  contained in the trial-runner image. This field should consist of an
-  array of entries. Note that users should ensure that the specified
-  host paths are accessible on all agent hosts (e.g., by configuring a
-  network file system appropriately).
+  The step size is defined as a fixed number of *batches*; the number of records
+  in a batch is controlled by the ``global_batch_size`` hyperparameter.
 
-  - ``host_path``: (required) The file system path on each agent to
-    use. Must be an absolute filepath.
-  - ``container_path``: (required) The file system path in the
-    container to use. May be a relative filepath, in which case it
-    will be mounted relative to the working directory inside the
-    container. It is not allowed to mount directly into the working
-    directory (i.e., ``container_path == "."``) to reduce the risk of
-    cluttering the host filesystem.
-  - ``read_only``: Whether the bind-mount should be a read-only mount.
-    Defaults to ``false``.
-  - ``propagation``: (Advanced users only) Optional `propagation
-    behavior <https://docs.docker.com/storage/bind-mounts/#configure-bind-propagation>`__
-    for replicas of the bind-mount. Defaults to ``rprivate``.
+.. _max-restarts:
+
+``max_restarts``
+  The maximum number of times that trials in this experiment will be restarted
+  due to an error. If an error occurs while a trial is running (e.g., a
+  container crashes abruptly), the Determined master will automatically restart
+  the trial and continue running it. This parameter specifies a limit on the
+  number of times to try restarting a trial; this ensures that Determined does
+  not go into an infinite loop if a trial encounters the same error
+  repeatedly. Once ``max_restarts`` trial failures have occurred for a given
+  experiment, subsequent failed trials will not be restarted -- instead, they
+  will be marked as errored. The experiment itself will continue running; an
+  experiment is considered to complete successfully if at least one of its
+  trials completes successfully. The default value is ``5``.
+
+Checkpoint Storage
+******************
+
+The ``checkpoint_storage`` section defines how model checkpoints will be
+stored. A checkpoint contains the architecture and weights of the model being
+trained. Determined currently supports four kinds of checkpoint storage,
+``gcs``, ``hdfs``, ``s3``, and ``shared_fs``, identified by the ``type``
+subfield. Additional fields may also be required, depending on the type of
+checkpoint storage in use. For example, to store checkpoints on Google Cloud
+Storage:
+
+.. code:: yaml
+
+  checkpoint_storage:
+    type: gcs
+    bucket: <your-bucket-name>
+
+If this field is not specified, the experiment will default to the checkpoint
+storage configured in the :ref:`master-configuration`.
+
+When an experiment finishes, the system will optionally delete some
+checkpoints to reclaim space. The ``save_experiment_best``,
+``save_trial_best`` and ``save_trial_latest`` parameters specify which
+checkpoints to save. See the documentation on
+:ref:`checkpoint-garbage-collection` for more details.
+
+Google Cloud Storage
+--------------------
+
+If ``type: gcs`` is specified, checkpoints will be stored on Google Cloud
+Storage (GCS). Authentication is done using GCP's "`Application Default
+Credentials <https://googleapis.dev/python/google-api-core/latest/auth.html>`__"
+approach. When using Determined inside Google Compute Engine (GCE), the simplest
+approach is to ensure that the VMs used by Determined are running in a service
+account that has the "Storage Object Admin" role on the GCS bucket being used
+for checkpoints. As an alternative (or when running outside of GCE), you can add
+the appropriate `service account credentials
+<https://cloud.google.com/docs/authentication/production#obtaining_and_providing_service_account_credentials_manually>`__
+to your container (e.g., via a bind-mount), and then set the
+``GOOGLE_APPLICATION_CREDENTIALS`` environment variable to the container path
+where the credentials are located. See :ref:`environment-variables` for more
+details on how to set environment variables in containers.
+
+The following fields are required when using GCS checkpoint storage:
+
+``bucket``
+  The GCS bucket name to use.
+
+HDFS
+----
+
+If ``type: hdfs`` is specified, checkpoints will be stored in HDFS using the
+`WebHDFS
+<http://hadoop.apache.org/docs/current/hadoop-project-dist/hadoop-hdfs/WebHDFS.html>`__
+API for reading and writing checkpoint resources.
+
+**Required Fields**
+
+``hdfs_url``
+  Hostname or IP address of HDFS namenode, prefixed with protocol, followed by
+  WebHDFS port on namenode. Multiple namenodes are allowed as a
+  semicolon-separated list (e.g.,
+  ``"http://namenode1:50070;http://namenode2:50070"``).
+
+``hdfs_path``
+  The prefix path where all checkpoints will be written to and read from. The
+  resources of each checkpoint will be saved in a subdirectory of ``hdfs_path``,
+  where the subdirectory name is the checkpoint's UUID.
+
+**Optional Fields**
+
+``user``
+  The user name to use for all read and write requests. If not specified, this
+  defaults to the user of the trial runner container.
+
+Amazon S3
+---------
+
+If ``type: s3`` is specified, checkpoints will be stored in Amazon S3 or an
+S3-compatible object store such as `MinIO <https://min.io/>`__.
+
+**Required Fields**
+
+``bucket``
+  The S3 bucket name to use.
+
+``access_key``
+  The AWS access key to use.
+
+``secret_key``
+  The AWS secret key to use.
+
+**Optional Fields**
+
+``endpoint_url``
+  The endpoint to use for S3 clones, e.g., ``http://127.0.0.1:8080/``. If not
+  specified, Amazon S3 will be used.
+
+Shared File System
+------------------
+
+If ``type: shared_fs`` is specified, checkpoints will be written to a directory
+on the agent's file system. The assumption is that the system administrator has
+arranged for the same directory to be mounted at every agent machine, and for the
+content of this directory to be the same on all agent hosts (e.g., by using a
+distributed or network file system such as `GlusterFS
+<https://www.gluster.org/>`__ or `NFS <https://en.wikipedia.org/wiki/Network_File_System>`__).
+
+.. warning::
+
+  When downloading checkpoints from a shared file system (e.g., using ``det
+  checkpoint download``), we assume the same shared file system is mounted
+  locally at the same ``host_path``.
+
+**Required Fields**
+
+``host_path``
+  The file system path on each agent to use. This directory will be mounted to
+  ``/determined_shared_fs`` inside the trial container.
+
+**Optional Fields**
+
+``storage_path``
+  The path where checkpoints will be written to and read from. Must be
+  a subdirectory of the ``host_path`` or an absolute path containing the
+  ``host_path``. If not specified, checkpoints are written to and read from the
+  ``host_path``.
+
+``propagation``
+  `Propagation behavior
+  <https://docs.docker.com/storage/bind-mounts/#configure-bind-propagation>`__
+  for replicas of the bind-mount. Defaults to ``rprivate``.
+
+.. _experiment-configuration_hyperparameters:
+
+Hyperparameters
+***************
+
+The ``hyperparameters`` section defines the hyperparameter space for the
+experiment. Which hyperparameters are appropriate for a given model is up to the
+user and depends on the nature of the model being trained. In Determined, it is
+common to specify hyperparameters that influence many aspects of the model's
+behavior, including how data augmentation is done, the architecture of the
+neural network, and which optimizer to use, along with how that optimizer should
+be configured.
+
+The value chosen for a hyperparameter in a given trial can be accessed via the
+trial context using :func:`context.get_hparam()
+<determined.TrialContext.get_hparam>`.  For instance, the current value of a
+hyperparameter named ``learning_rate`` can be accessed by
+``context.get_hparam("learning_rate")``.
+
+.. note::
+
+  Every experiment must specify a hyperparameter named
+  ``global_batch_size``. This is because this hyperparameter is treated
+  specially: when doing distributed training, the global batch size must be
+  known so that the per-worker batch size can be computed appropriately. Batch
+  size per slot is computed at runtime, based on the number of slots used to
+  train a single trial of this experiment (see :ref:`resources.slots_per_trial
+  <exp-config-resources-slots-per-trial>`). The updated values should be
+  accessed via the trial context, using :func:`context.get_per_slot_batch_size()
+  <determined.TrialContext.get_per_slot_batch_size>` and
+  :func:`context.get_global_batch_size()
+  <determined.TrialContext.get_global_batch_size>`.
+
+The hyperparameter space is defined by a dictionary. Each key in the dictionary
+is the name of a hyperparameter; the associated value defines the range of the
+hyperparameter. If the value is a scalar, the hyperparameter is a constant;
+otherwise, the value should be a nested map. Here is an example:
+
+.. code:: yaml
+
+  hyperparameters:
+    global_batch_size: 64
+    optimizer:
+      type: categorical
+      vals:
+        - SGD
+        - Adam
+        - RMSprop
+    layer1_dropout:
+      type: double
+      minval: 0.2
+      maxval: 0.5
+    learning_rate:
+      type: log
+      minval: -5.0
+      maxval: 1.0
+      base: 10.0
+
+This configuration defines four hyperparameters: ``global_batch_size``,
+``optimizer``, ``layer1_dropout``, and ``learning_rate``. ``global_batch_size``
+is set to a constant value; the other hyperparameters can take on a range of
+possible values. A hyperparameter's range is configured by the ``type`` field of
+the map; it must be one of ``categorical``, ``double``, ``int``, or
+``log``. More details on these types are given below.
+
+Categorical
+-----------
+
+A ``categorical`` hyperparameter ranges over a set of specified values. The
+possible values are defined by the ``vals`` key. ``vals`` is a list; each
+element of the list can be of any valid YAML type, such as a boolean, a string,
+a number, or a collection.
+
+Double
+------
+
+A ``double`` hyperparameter is a floating point variable. The minimum and
+maximum values of the variable are defined by the ``minval`` and ``maxval``
+keys, respectively.
+
+When doing a grid search, the ``count`` key can also be specified; this defines
+the number of points in the grid for this hyperparameter. Grid points are evenly
+spaced between ``minval`` and ``maxval``. See
+:ref:`topic-guides_hp-tuning-det_grid` for details.
+
+Integer
+-------
+
+An ``int`` hyperparameter is an integer variable. The minimum and maximum values
+of the variable are defined by the ``minval`` and ``maxval`` keys, respectively.
+
+When doing a grid search, the ``count`` key can also be specified; this defines
+the number of points in the grid for this hyperparameter. Grid points are evenly
+spaced between ``minval`` and ``maxval``. See
+:ref:`topic-guides_hp-tuning-det_grid` for details.
+
+Log
+---
+
+A ``log`` hyperparameter is a floating point variable that is searched on a
+logarithmic scale. The base of the logarithm is specified by the ``base`` field;
+the minimum and maximum exponent values of the hyperparameter are given by the
+``minval`` and ``maxval`` fields, respectively.
+
+When doing a grid search, the ``count`` key can also be specified; this defines
+the number of points in the grid for this hyperparameter. Grid points are evenly
+spaced between ``minval`` and ``maxval``. See
+:ref:`topic-guides_hp-tuning-det_grid` for details.
+
+.. _experiment-configuration_searcher:
+
+Searcher
+********
+
+The ``searcher`` section defines how the experiment's hyperparameter space will
+be explored. To run an experiment that trains a single trial with fixed
+hyperparameters, specify the ``single`` searcher and specify constant values for
+the model's hyperparameters. Otherwise, Determined supports five different
+hyperparameter search algorithms: ``random``, ``grid``, ``adaptive_simple``,
+``adaptive``, and ``pbt``.
+
+The name of the hyperparameter search algorithm to use is configured via the
+``name`` field; the remaining fields configure the behavior of the searcher and
+depend on the searcher being used. For example, to configure a ``random``
+hyperparameter search that trains 5 trials for 10 steps each:
+
+.. code:: yaml
+
+  searcher:
+    name: random
+    metric: accuracy
+    max_trials: 5
+    max_steps: 10
+
+For details on using Determined to perform hyperparameter search, refer to
+:ref:`hyperparameter-tuning`. For more information on the search methods
+supported by Determined, refer to :ref:`topic-guides_hp-tuning-det`.
+
+Single
+------
+
+The ``single`` search method does not really perform a hyperparameter search at
+all; rather, it trains a single trial for a fixed number of steps. When using
+this search method, all of the hyperparameters specified in the
+:ref:`hyperparameters <experiment-configuration_hyperparameters>` section must
+be constants. By default, validation metrics are only computed once, after the
+specified number of training steps have been completed;
+:ref:`min_validation_period <experiment-config-min-validation-period>` can be
+used to specify that validation metrics should be computed more frequently.
+
+**Required Fields**
+
+``metric``
+  The name of the validation metric used to evaluate the performance of a
+  hyperparameter configuration.
+
+``max_steps``
+  The number of steps to train the model for.
+
+**Optional Fields**
+
+``smaller_is_better``
+  Whether to minimize or maximize the metric defined above. The default value is
+  ``true`` (minimize).
+
+``source_trial_id``
+  If specified, the weights of this trial will be initialized to the most recent
+  checkpoint of the given trial ID. This will fail if the source trial's model
+  architecture is inconsistent with the model architecture of this experiment.
+
+``source_checkpoint_uuid``
+  Like ``source_trial_id``, but specifies an arbitrary checkpoint from which to
+  initialize weights. At most one of ``source_trial_id`` or
+  ``source_checkpoint_uuid`` should be set.
+
+Random
+------
+
+The ``random`` search method implements a simple random search. The user
+specifies how many hyperparameter configurations should be trained and how long
+each configuration should be trained for; the configurations are sampled
+randomly from the hyperparameter space. Each trial is trained for the specified
+number of steps and then validation metrics are
+computed. :ref:`min_validation_period <experiment-config-min-validation-period>`
+can be used to specify that validation metrics should be computed more
+frequently.
+
+**Required Fields**
+
+``metric``
+  The name of the validation metric used to evaluate the performance of a
+  hyperparameter configuration.
+
+``max_trials``
+  The number of trials, i.e., hyperparameter configurations, to evaluate.
+
+``max_steps``
+  The number of steps to train each trial for.
+
+**Optional Fields**
+
+``smaller_is_better``
+  Whether to minimize or maximize the metric defined above. The default value is
+  ``true`` (minimize).
+
+``source_trial_id``
+  If specified, the weights of *every* trial in the search will be initialized
+  to the most recent checkpoint of the given trial ID. This will fail if the
+  source trial's model architecture is incompatible with the model architecture
+  of any of the trials in this experiment.
+
+``source_checkpoint_uuid``
+  Like ``source_trial_id`` but specifies an arbitrary checkpoint from which to
+  initialize weights. At most one of ``source_trial_id`` or
+  ``source_checkpoint_uuid`` should be set.
+
+Grid
+----
+
+The ``random`` search method performs a grid search. The coordinates of the
+hyperparameter grid are specified via the ``hyperparameters`` field. For
+more details see the :ref:`topic-guides_hp-tuning-det_grid`.
+
+**Required Fields**
+
+``metric``
+  The name of the validation metric used to evaluate the performance of a
+  hyperparameter configuration.
+
+**Optional Fields**
+
+``smaller_is_better``
+  Whether to minimize or maximize the metric defined above. The default value is
+  ``true`` (minimize).
+
+``source_trial_id``
+  If specified, the weights of this trial will be initialized to the most recent
+  checkpoint of the given trial ID. This will fail if the source trial's model
+  architecture is inconsistent with the model architecture of this experiment.
+
+``source_checkpoint_uuid``
+  Like ``source_trial_id``, but specifies an arbitrary checkpoint from which to
+  initialize weights. At most one of ``source_trial_id`` or
+  ``source_checkpoint_uuid`` should be set.
+
+.. _experiment-configuration-searcher-adaptive:
+
+Adaptive
+--------
+
+The ``adaptive`` search method is a theoretically principled and empirically
+state-of-the-art method that adaptively allocates resources to promising
+hyperparameter configurations while quickly eliminating poor ones.
+
+**Required Fields**
+
+``metric``
+  The name of the validation metric used to evaluate the performance of a
+  hyperparameter configuration.
+
+``target_trial_steps``
+  The maximum number of training steps to allocate to any one trial. The vast
+  majority of trials will be stopped early, and thus only a small fraction of
+  trials will actually be trained for this number of steps. We recommend setting
+  this to a multiple of ``divisor^(max_rungs-1)``, which is ``4^(5-1) = 256``
+  with the default values.
+
+``step_budget``
+  The total number of steps to allocate across all trials. We recommend setting
+  this to be a multiple of ``target_trial_steps``, which implies interpreting
+  this subfield as the effective number of complete trials to evaluate. Note
+  that some trials might be in-progress when this budget is exhausted; adaptive
+  search will allocate some additional steps to complete these in-progress
+  trials.
+
+**Optional Fields**
+
+``smaller_is_better``
+  Whether to minimize or maximize the metric defined above. The default value is
+  ``true`` (minimize).
+
+``mode``
+  How aggressively to perform early stopping. There are three modes:
+  ``aggressive``, ``standard``, and ``conservative``; the default is
+  ``standard``.
+
+  These modes differ in the degree to which early-stopping is used. In
+  ``aggressive`` mode, the searcher quickly stops underperforming trials, which
+  enables the searcher to explore more hyperparameter configurations, but at the
+  risk of discarding a configuration too soon. On the other end of the spectrum,
+  ``conservative`` mode performs significantly less downsampling, but as a
+  consequence does not explore as many configurations given the same budget. We
+  recommend using either ``aggressive`` or ``standard`` mode.
+
+``divisor``
+  The fraction of trials to keep at each rung, and also determines how many
+  steps are allocated at each rung. The default setting is ``4``; only advanced
+  users should consider changing this value.
+
+``max_rungs``
+  The maximum number of times we evaluate intermediate results for a trial and
+  terminate poorly performing trials. The default value is ``5``; only advanced
+  users should consider changing this value.
+
+``source_trial_id``
+  If specified, the weights of *every* trial in the search will be initialized
+  to the most recent checkpoint of the given trial ID. This will fail if the
+  source trial's model architecture is inconsistent with the model architecture
+  of any of the trials in this experiment.
+
+``source_checkpoint_uuid``
+  Like ``source_trial_id``, but specifies an arbitrary checkpoint from which to
+  initialize weights. At most one of ``source_trial_id`` or
+  ``source_checkpoint_uuid`` should be set.
+
+Adaptive (Simple)
+-----------------
+
+The ``adaptive_simple`` search method is a simpler interface to the
+:ref:`adaptive <experiment-configuration-searcher-adaptive>` search method described
+above. ``adaptive_simple`` is designed to be simpler to configure for most
+applications of hyperparameter search.
+
+**Required Fields**
+
+``metric``
+  The name of the validation metric used to evaluate the performance of a
+  hyperparameter configuration.
+
+``max_steps``
+  The maximum number of training steps to allocate to any one trial. The vast
+  majority of trials will be stopped early, and thus only a small fraction of
+  trials will actually be trained for this number of steps. This quantity is
+  domain-specific and should roughly reflect the number of training steps needed
+  for the model to converge on the data set.
+
+``max_trials``
+  The number of trials, i.e., hyperparameter configurations, to evaluate.
+
+**Optional Fields**
+
+``smaller_is_better``
+  Whether to minimize or maximize the metric defined above. The default value is
+  ``true`` (minimize).
+
+``mode``
+  How aggressively to perform early stopping. There are three modes:
+  ``aggressive``, ``standard``, and ``conservative``; the default is
+  ``standard``.
+
+  These modes differ in the degree to which early-stopping is used. In
+  ``aggressive`` mode, the searcher quickly stops underperforming trials, which
+  enables the searcher to explore more hyperparameter configurations, but at the
+  risk of discarding a configuration too soon. On the other end of the spectrum,
+  ``conservative`` mode performs significantly less downsampling, but as a
+  consequence does not explore as many configurations given the same budget. We
+  recommend using either ``aggressive`` or ``standard`` mode.
+
+``divisor``
+  The fraction of trials to keep at each rung, and also determines how many
+  steps are allocated at each rung. The default setting is ``4``; only advanced
+  users should consider changing this value.
+
+``max_rungs``
+  The maximum number of times we evaluate intermediate results for a trial and
+  terminate poorly performing trials. The default value is ``5``; only advanced
+  users should consider changing this value.
+
+``source_trial_id``
+  If specified, the weights of *every* trial in the search will be initialized
+  to the most recent checkpoint of the given trial ID. This will fail if the
+  source trial's model architecture is inconsistent with the model architecture
+  of any of the trials in this experiment.
+
+``source_checkpoint_uuid``
+  Like ``source_trial_id``, but specifies an arbitrary checkpoint from which to
+  initialize weights. At most one of ``source_trial_id`` or
+  ``source_checkpoint_uuid`` should be set.
+
+
+PBT
+---
+
+The ``pbt`` search method uses `population-based training
+<https://deepmind.com/blog/population-based-training-neural-networks/>`__, which
+maintains a population of active trials to train. After each trial has been
+trained for a certain number of steps, all the trials are validated. The
+searcher then closes some trials and replaces them with altered copies of other
+trials. This process makes up one "round"; the searcher runs some number of
+rounds to execute a complete search. The model definition class must be able to
+restore from a checkpoint that was created with a different set of
+hyperparameters; in particular, you will not be able to vary any hyperparameters
+that change the sizes of weight matrices without taking special steps to save or
+restore models.
+
+**Required Fields**
+
+``metric``
+  Specifies the name of the validation metric used to evaluate the performance
+  of a hyperparameter configuration.
+
+``population_size``
+  The number of trials (i.e., different hyperparameter configurations) to keep
+  active at a time.
+
+``steps_per_round``
+  The number of steps to train each trial between validations.
+
+``num_rounds``
+  The total number of rounds to execute.
+
+``replace_function``
+  How to choose which trials to close and which trials to copy at the end of
+  each round. At present, only a single replacement function is supported:
+
+  ``truncate_fraction``
+    Defines *truncation selection*, in which the worst ``truncate_fraction``
+    (multiplied by the population size) trials, ranked by validation metric, are
+    closed and the same number of top trials are copied.
+
+``explore_function``
+  How to alter a set of hyperparameters when a copy of a trial is made. Each
+  parameter is either resampled (i.e., its value is chosen from the configured
+  distribution) or perturbed (i.e., its value is computed based on the value in
+  the original set). ``explore_function`` has two required sub-fields:
+
+  ``resample_probability``
+    The probability that a parameter is replaced with a new value sampled from
+    the original distribution specified in the configuration.
+
+  ``perturb_factor``
+    The amount by which parameters that are not resampled are perturbed. Each
+    numerical hyperparameter is multiplied by either ``1 + perturb_factor`` or
+    ``1 - perturb_factor`` with equal probability; ``categorical`` and ``const``
+    hyperparameters are left unchanged.
+
+**Optional Fields**
+
+``smaller_is_better``
+  Whether to minimize or maximize the metric defined above. The default value is
+  ``true`` (minimize).
+
+.. _exp-config-resources:
+
+Resources
+*********
+
+The ``resources`` section defines the resources that an experiment is allowed to
+use.
+
+**Optional Fields**
+
+``max_slots``
+  The maximum number of scheduler slots that this experiment is allowed to use
+  at any one time. The slot limit of an active experiment can be changed using
+  ``det experiment set max-slots <id> <slots>``. By default, there is no limit
+  on the number of slots an experiment can use.
+
+  .. warning::
+
+    ``max_slots`` is only considered when scheduling jobs; it is not currently
+    used when provisioning dynamic agents. This means that we may provision more
+    instances than the experiment can schedule.
+
+``weight``
+  The weight of this experiment in the scheduler. When multiple experiments are
+  running at the same time, the number of slots assigned to each experiment will
+  be approximately proportional to its weight. The weight of an active
+  experiment can be changed using ``det experiment set weight <id>
+  <weight>``. The default weight is ``1``.
+
+.. _exp-config-resources-slots-per-trial:
+
+``slots_per_trial``
+  The number of slots to use for each trial of this experiment. The default
+  value is ``1``; specifying a value greater than 1 means that multiple GPUs will be
+  used in parallel. Training on multiple GPUs is done using data
+  parallelism. Configuring ``slots_per_trial`` to be greater than ``max_slots``
+  is not sensible and will result in an error.
+
+  .. note::
+
+    Using ``slots_per_trial`` to enable data parallel training for PyTorch
+    can alter the behavior of certain models, as described in the `PyTorch
+    documentation
+    <https://pytorch.org/docs/stable/generated/torch.nn.DataParallel.html#torch.nn.DataParallel>`__.
+
+``shm_size``
+  The size in bytes of ``/dev/shm`` for trial containers. Defaults to
+  ``4294967296`` (4GiB). If set, this value overrides the value specified in the
+  :ref:`master configuration <master-configuration>`.
+
+Bind Mounts
+***********
+
+The ``bind_mounts`` section specifies directories that are bind-mounted into
+every container launched for this experiment. Bind mounts are often used to
+enable trial containers to access additional data that is not part of the model
+definition directory.
+
+This field should consist of an array of entries; each entry has the form
+described below. Users must ensure that the specified host paths are accessible
+on all agent hosts (e.g., by configuring a network file system appropriately).
+
+For each bind mount, the following fields are required:
+
+``host_path``
+  The file system path on each agent to use. Must be an absolute
+  filepath.
+
+``container_path``
+  The file system path in the container to use. May be a relative filepath, in
+  which case it will be mounted relative to the working directory inside the
+  container. It is not allowed to mount directly into the working directory
+  (i.e., ``container_path == "."``) to reduce the risk of cluttering the host
+  filesystem.
+
+For each bind mount, the following optional fields may also be specified:
+
+``read_only``
+  Whether the bind-mount should be a read-only mount. Defaults to ``false``.
+
+``propagation``
+  `Propagation behavior
+  <https://docs.docker.com/storage/bind-mounts/#configure-bind-propagation>`__
+  for replicas of the bind-mount. Defaults to ``rprivate``.
 
 .. _exp-environment:
 
-- ``environment``: Specifies the environment of the container that is
-  used by the experiment for training the model.
+Environment
+***********
 
-  - ``image``: Specifies a Docker image to use when
-    executing the workload. The image must be available via
-    ``docker pull`` to every Determined agent machine in the cluster. Users
-    can customize environment variables for GPU vs. CPU agents differently by
-    specifying a dict with two keys, ``cpu`` and ``gpu``. Defaults to
-    ``determinedai/environments:py-3.6.9-pytorch-1.4-tf-1.15-cpu-0.5.0`` for CPU
-    agents and
-    ``determinedai/environments:cuda-10.0-pytorch-1.4-tf-1.15-gpu-0.5.0`` for
-    GPU agents.
-  - ``force_pull_image``: Forcibly pull the image from the Docker
-    registry and bypass the Docker cache. Defaults to ``false``.
-  - ``registry_auth``: Specifies the `Docker registry
-    credentials <https://docs.docker.com/engine/api/v1.30/#operation/SystemAuth>`__
-    to use when pulling a custom base Docker image, if needed.
+The ``environment`` section defines properties of the container environment
+that is used to execute workloads for this experiment. For more information on
+customizing the trial environment, refer to :ref:`custom-env`.
 
-    - ``username`` (required)
-    - ``password`` (required)
-    - ``server`` (optional)
-    - ``email`` (optional)
+**Optional Fields**
 
-  - ``environment_variables``: Specifies a list of environment variables for
-    the trial runner. Each element of the list should be a string of the form
-    ``NAME=VALUE``. See :ref:`environment-variables` for more details. Users
-    can customize environment variables for GPU vs. CPU agents differently by
-    specifying a dict with two keys, ``cpu`` and ``gpu``.
+``image``
+  The Docker image to use when executing the workload. This image must be
+  accessible via ``docker pull`` to every Determined agent machine in the
+  cluster. Users can use different container images for GPU vs. CPU agents
+  differently by specifying a dict with two keys, ``cpu`` and ``gpu``. Default
+  values:
 
-- ``reproducibility``: Specifies configuration options related to
-  reproducible experiments. This is an optional configuration field;
-  see :ref:`reproducibility` for more details.
+  - ``determinedai/environments:py-3.6.9-pytorch-1.4-tf-1.15-cpu-0.5.0`` for CPU agents
+  - ``determinedai/environments:cuda-10.0-pytorch-1.4-tf-1.15-gpu-0.5.0`` for GPU agents.
 
-  - ``experiment_seed``: Specifies the random seed to be associated
-    with the experiment. Must be an integer between 0 and 2\ :sup:`31`--1.
-    If an ``experiment_seed`` is not explicitly specified, the master
-    will automatically generate an experiment seed.
+``force_pull_image``
+  Forcibly pull the image from the Docker registry and bypass the Docker
+  cache. Defaults to ``false``.
 
-- ``max_restarts``: Specifies the maximum number of times that trials in
-  this experiment will be restarted due to an error. If an error occurs
-  while a trial is running (e.g., a container crashes abruptly), the
-  Determined master will automatically restart the trial and continue
-  running it. This parameter specifies a limit on the number of times to
-  try restarting a trial; this ensures that Determined does not go into
-  an infinite loop if a trial encounters the same error repeatedly. Once
-  ``max_restarts`` trial failures have occurred for a given experiment,
-  subsequent failed trials will not be restarted -- instead, they will
-  be marked as errored. The experiment itself will continue running; an
-  experiment is considered to complete successfully if at least one of
-  its trials completes successfully.
+``registry_auth``
+  The `Docker registry credentials
+  <https://docs.docker.com/engine/api/v1.30/#operation/SystemAuth>`__ to use
+  when pulling a custom base Docker image, if needed. Credentials are specified
+  as the following nested fields:
 
-- ``optimizations``: Specifies configuration options related to improving
-  performance.
+  - ``username`` (required)
+  - ``password`` (required)
+  - ``server`` (optional)
+  - ``email`` (optional)
 
-  - ``aggregation_frequency``: Specifies after how many batches gradients are
-    exchanged during :ref:`multi-gpu-training`. Defaults
-    to ``1``.
+``environment_variables``
+  A list of environment variables that will be set in every trial
+  container. Each element of the list should be a string of the form
+  ``NAME=VALUE``. See :ref:`environment-variables` for more details. Users can
+  customize environment variables for GPU vs. CPU agents differently by
+  specifying a dict with two keys, ``cpu`` and ``gpu``.
 
-  - ``average_aggregated_gradients``: Specifies whether gradients accumulated
-    across batches (when ``aggregation_frequency`` > 1) should be divided by
-    the ``aggregation_frequency``. Defaults to ``true``.
+Optimizations
+*************
 
-  - ``average_training_metrics``: For multi-GPU training, whether to
-    average the training metrics across GPUs instead of only using metrics from the
-    chief GPU. This impacts the metrics shown in the Determined UI and
-    TensorBoard, but does not impact the outcome of training or hyperparameter
-    search. This option is currently only supported in PyTorch. Defaults to ``false``.
+The ``optimizations`` section contains configuration options that influence the
+performance of the experiment.
 
-  - ``gradient_compression``: Whether to compress gradients when they are
-    exchanged during :ref:`multi-gpu-training`.
-    Compression may alter gradient values to achieve better space reduction.
-    Defaults to ``false``.
+**Optional Fields**
 
-  - ``mixed_precision``: Whether to use mixed precision training during
-    :ref:`multi-gpu-training`. Setting ``O1`` enables
-    mixed precision and loss scaling. Defaults to ``O0`` which disables
-    mixed precision training.
+``aggregation_frequency``
+  Specifies after how many batches gradients are exchanged during
+  :ref:`multi-gpu-training`. Defaults to ``1``.
 
-  - ``tensor_fusion_threshold``: Specifies the threshold in MB for batching
-    together gradients that are exchanged during
-    :ref:`multi-gpu-training`. Defaults to ``64``.
+``average_aggregated_gradients``
+  Whether gradients accumulated across batches (when ``aggregation_frequency`` >
+  1) should be divided by the ``aggregation_frequency``. Defaults to ``true``.
 
-  - ``tensor_fusion_cycle_time``: Specifies the delay between each tensor fusion
-    in milliseconds during :ref:`multi-gpu-training`. Defaults to ``5``.
+``average_training_metrics``
+  For multi-GPU training, whether to average the training metrics across GPUs
+  instead of only using metrics from the chief GPU. This impacts the metrics
+  shown in the Determined UI and TensorBoard, but does not impact the outcome of
+  training or hyperparameter search. This option is currently only supported in
+  PyTorch. Defaults to ``false``.
 
-  - ``auto_tune_tensor_fusion``: When enabled, configures
-    ``tensor_fusion_threshold`` and ``tensor_fusion_cycle_time`` automatically.
-    Defaults to ``false``.
+``gradient_compression``
+  Whether to compress gradients when they are exchanged during
+  :ref:`multi-gpu-training`. Compression may alter gradient values to achieve
+  better space reduction. Defaults to ``false``.
 
+``mixed_precision``
+  Whether to use mixed precision training during
+  :ref:`multi-gpu-training`. Setting ``O1`` enables mixed precision and loss
+  scaling. Defaults to ``O0`` which disables mixed precision training.
+
+``tensor_fusion_threshold``
+  The threshold in MB for batching together gradients that are exchanged during
+  :ref:`multi-gpu-training`. Defaults to ``64``.
+
+``tensor_fusion_cycle_time``
+  The delay (in milliseconds) between each tensor fusion during
+  :ref:`multi-gpu-training`. Defaults to ``5``.
+
+``auto_tune_tensor_fusion``
+  When enabled, configures ``tensor_fusion_threshold`` and
+  ``tensor_fusion_cycle_time`` automatically. Defaults to ``false``.
+
+Reproducibility
+***************
+
+The ``reproducibility`` section specifies configuration options related to
+reproducible experiments. See :ref:`reproducibility` for more details.
+
+**Optional Fields**
+
+``experiment_seed``
+  The random seed to use to initialize random number generators for all trials
+  in this experiment. Must be an integer between 0 and 2\ :sup:`31`--1. If an
+  ``experiment_seed`` is not explicitly specified, the master will automatically
+  generate an experiment seed.
 
 .. _data-layer_exp_config:
 
-- ``data_layer``: Specifies the configurations related to the :ref:`data-layer`.
-  Determined currently supports three types of storage for the ``data_layer``:
-  ``s3``, ``gcs``, and ``shared_fs``, identified by the ``type`` subfield.
-  Defaults to ``shared_fs``.
+Data Layer
+**********
 
-  -  ``type: shared_fs``:  Cache is stored in a directory on an agent's file
-     system.
+The ``data_layer`` section specifies configuration options related to the
+:ref:`data-layer`. Determined currently supports three types of storage for the
+``data_layer``: ``s3``, ``gcs``, and ``shared_fs``, identified by the ``type``
+subfield. Defaults to ``shared_fs``.
 
-     - ``host_storage_path``: The optional file system path on each agent to use.
-     - ``container_storage_path`` The optional file system path to use as the
-       mount point in the trial runner container.
+Shared File System
+------------------
 
-  -  ``type: s3``:  Cache is stored in Amazon S3.
+If ``type: shared_fs`` is specified, the cache will be stored in a directory on
+an agent's file system.
 
-     - ``bucket``: The S3 bucket name to use.
-     - ``bucket_directory_path``: The path in S3 bucket to store the cache.
-     - ``local_cache_host_path``: The optional file system path, to store a local
-       copy of the cache, which is synchronized with the S3 cache.
-     - ``local_cache_container_path``: The optional file system path to use as the
-       mount point in the trial runner container for storing the local cache.
-     - ``access_key``: The optional AWS access key to use.
-     - ``secret_key``: The optional AWS secret key to use.
-     - ``endpoint_url``: The optional endpoint to use for S3 clones, e.g., http://127.0.0.1:8080/.
+**Optional Fields**
 
-  -  ``type: gcs``:  Cache is stored in Google Cloud Storage (GCS).
-     Authentication is done using GCP's "`Application Default
-     Credentials <https://googleapis.dev/python/google-api-core/latest/auth.html>`__"
-     approach. When using Determined inside Google Compute Engine (GCE), the
-     simplest approach is to ensure that the VMs used by Determined are
-     running in a service account that has the "Storage Object Admin"
-     role on the GCS bucket being used for checkpoints. As an
-     alternative (or when running outside of GCE), you can add the
-     appropriate `service account
-     credentials <https://cloud.google.com/docs/authentication/production#obtaining_and_providing_service_account_credentials_manually>`__
-     to your container (e.g., via a bind-mount), and then set the
-     ``GOOGLE_APPLICATION_CREDENTIALS`` environment variable to the container
-     path where the credentials are located. See :ref:`environment-variables`
-     for more details on how to set environment variables in containers.
+``host_storage_path``
+  The file system path on each agent to use.
 
-     - ``bucket``: The GCS bucket name to use.
-     - ``bucket_directory_path``: The path in GCS bucket to store the cache.
-     - ``local_cache_host_path``: The optional file system path, to store a local
-       copy of the cache, which is synchronized with the GCS cache.
-     - ``local_cache_container_path``: The optional file system path to use as the
-       mount point in the trial runner container for storing the local cache.
+``container_storage_path``
+  The file system path to use as the mount point in the trial runner container.
+
+Amazon S3
+---------
+
+If ``type: s3`` is specified, the cache will be stored on Amazon S3 or an
+S3-compatible object store such as `MinIO <https://min.io/>`__.
+
+**Required Fields**
+
+``bucket``
+  The S3 bucket name to use.
+
+``bucket_directory_path``
+  The path in the S3 bucket to store the cache.
+
+**Optional Fields**
+
+``local_cache_host_path``
+  The file system path to store a local copy of the cache, which is
+  synchronized with the S3 cache.
+
+``local_cache_container_path``
+  The file system path to use as the mount point in the trial runner container
+  for storing the local cache.
+
+``access_key``
+  The AWS access key to use.
+
+``secret_key``
+  The AWS secret key to use.
+
+``endpoint_url``
+  The endpoint to use for S3 clones, e.g., ``http://127.0.0.1:8080/``.
+
+Google Cloud Storage
+--------------------
+
+If ``type: gcs`` is specified, the cache will be stored on Google Cloud Storage
+(GCS). Authentication is done using GCP's "`Application Default Credentials
+<https://googleapis.dev/python/google-api-core/latest/auth.html>`__"
+approach. When using Determined inside Google Compute Engine (GCE), the simplest
+approach is to ensure that the VMs used by Determined are running in a service
+account that has the "Storage Object Admin" role on the GCS bucket being used
+for checkpoints. As an alternative (or when running outside of GCE), you can add
+the appropriate `service account credentials
+<https://cloud.google.com/docs/authentication/production#obtaining_and_providing_service_account_credentials_manually>`__
+to your container (e.g., via a bind-mount), and then set the
+``GOOGLE_APPLICATION_CREDENTIALS`` environment variable to the container path
+where the credentials are located. See :ref:`environment-variables` for more
+details on how to set environment variables in containers.
+
+**Required Fields**
+
+``bucket``
+  The GCS bucket name to use.
+
+``bucket_directory_path``
+  The path in GCS bucket to store the cache.
+
+**Optional Fields**
+
+``local_cache_host_path``
+  The file system path, to store a local copy of the cache, which is
+  synchronized with the GCS cache.
+
+``local_cache_container_path``
+  The file system path to use as the mount point in the trial runner container
+  for storing the local cache.

--- a/docs/reference/index.txt
+++ b/docs/reference/index.txt
@@ -20,10 +20,10 @@ The full list of reference guides can be found below:
 .. toctree::
   :maxdepth: 1
 
-  cli
+  api/index
   cluster-config
+  cli
   command-notebook-config
   config-template
   experiment-config
-  api/index
   attributions

--- a/docs/topic-guides/checkpoints.txt
+++ b/docs/topic-guides/checkpoints.txt
@@ -50,9 +50,10 @@ experiment. Checkpoints are created in three situations:
 
 1. When Determined suspends training of a trial at one agent, before later
    resuming training that trial at a different agent.
-2. If ``min_checkpoint_period`` is set in the experiment configuration,
-   each trial will be checkpointed whenever the specified number of
-   training steps are completed since the last checkpoint.
+2. If :ref:`min_checkpoint_period <experiment-config-min-checkpoint-period>` is
+   set in the experiment configuration, each trial will be checkpointed whenever
+   the specified number of training steps are completed since the last
+   checkpoint.
 3. When a trial has been trained to completion (according to the
    configuration of the experiment's trial search method).
 

--- a/docs/topic-guides/hp-tuning-det/hp-grid.txt
+++ b/docs/topic-guides/hp-tuning-det/hp-grid.txt
@@ -42,10 +42,10 @@ type of hyperparameter:
    could be specified as a ``double`` hyperparameter with ``minval: 0.1``,
    ``maxval: 0.5``, ``count: 3``.
 -  ``log``: The set of ``count`` values is taken logarithmically evenly from the
-   range [baseminval, basemaxval], inclusive of endpoints. For example, the set
+   range ``[base^minval, base^maxval]``, inclusive of endpoints. For example, the set
    ``{0.00001, 0.0001, 0.001}`` could be specified as a ``log`` hyperparameter
    with ``base: 10``, ``minval: -5``, ``maxval: -3``, and ``count: 3``.
 
-Under the special case of ``count: 1`` for ``int``, ``double``, or ``log``, the
+In the special case of ``count: 1`` for ``int``, ``double``, or ``log``, the
 midpoint (with rounding for ``int`` and with base midpoint for ``log``) is
 returned.

--- a/docs/topic-guides/hp-tuning-det/index.txt
+++ b/docs/topic-guides/hp-tuning-det/index.txt
@@ -56,7 +56,7 @@ Handling Trial Errors and Early Stopping Requests
 
 When a trial encounters an error or fails unexpectedly, Determined will
 restart it from the latest checkpoint unless we have done so
-``max_restarts`` times, which is configured in the experiment
+:ref:`max_restarts <max-restarts>` times, which is configured in the experiment
 configuration. Once we have reached ``max_restarts``, any further trials
 that fail will be marked as errored and will not be restarted. For
 search methods that adapt to validation metric values (:ref:`Adaptive

--- a/docs/topic-guides/model-definitions/best-practices.txt
+++ b/docs/topic-guides/model-definitions/best-practices.txt
@@ -26,7 +26,8 @@ browsable via our WebUI, improving the **tracking** and
 
 Do:
 
-* Move any hardcoded scalar values to the ``hyperparameters`` or ``data`` field in
+* Move any hardcoded scalar values to the :ref:`hyperparameters
+  <experiment-configuration_hyperparameters>` or :ref:`data <experiment-config-data>` fields in
   the experiment configuration. Use :func:`context.get_hparam() <determined.TrialContext.get_hparam>` or
   :func:`context.get_data_config() <determined.TrialContext.get_data_config>` to reference them in code.
 * Move any hardcoded filesystem paths (e.g., ``/data/train.csv``) to the ``data``

--- a/docs/tutorials/quick-start.txt
+++ b/docs/tutorials/quick-start.txt
@@ -155,7 +155,7 @@ Running a Distributed Training Job
 
 Determined can coordinate multiple GPUs to train a single trial more quickly (*distributed training*). Distributed training performs best with complex models; therefore, the simple model used in this example may not demonstrate the full benefits of using distributed training.
 
-With Determined, moving from single-GPU training to distributed training is as simple as changing a single setting in the experiment config file! Specifically, ``resources.slots_per_trial`` controls the number of GPUs used to train a single trial. It is ``1`` by default; setting it to a larger value enables distributed training. You should set ``resources.slots_per_trial`` to a multiple of the number of GPUs in each machine in the cluster. For example, if your cluster has 8-GPU machines, you should use a value such as 8, 16, 24, etc. If using a Determined cluster deployed in the cloud, by default each agent will have eight GPUs.
+With Determined, moving from single-GPU training to distributed training is as simple as changing a single setting in the experiment config file. Specifically, :ref:`resources.slots_per_trial <exp-config-resources-slots-per-trial>` controls the number of GPUs used to train a single trial. It is ``1`` by default; setting it to a larger value enables distributed training. You should set ``resources.slots_per_trial`` to a multiple of the number of GPUs in each machine in the cluster. For example, if your cluster has 8-GPU machines, you should use a value such as 8, 16, 24, etc. If using a Determined cluster deployed in the cloud, by default each agent will have eight GPUs.
 
 Below is the ``distributed.yaml`` file, which is very similar to the ``const.yaml`` file except we now set ``resources.slots_per_trial``.
 


### PR DESCRIPTION
Replace the original giant bulleted list with a collection of sections
and sub-sections. This should hopefully make it easier to find content
within this documentation page, to link to the documentation for
specific configuration variables, and to include more discussion about
particular configuration settings when appropriate.

Along the way, add a few examples and fix/rewrite some of the docs for
different variables.