### PR TITLE
fix: use random port for notebooks [DET-3648]

### DIFF
--- a/master/internal/command/command.go
+++ b/master/internal/command/command.go
@@ -1,6 +1,7 @@
 package command
 
 import (
+	"math/rand"
 	"net/http"
 	"time"
 
@@ -305,4 +306,12 @@ func (c *command) toTensorboard(ctx *actor.Context) *tensorboardv1.Tensorboard {
 		TrialIds:      tids,
 		Username:      c.owner.Username,
 	}
+}
+
+func getPort(min, max int) int {
+	// Set the seed here or else the compiler will generate a random number at
+	// compile time and each invocation of this function will return the same
+	// number.
+	rand.Seed(time.Now().Unix())
+	return rand.Intn(max-min) + min
 }

--- a/master/internal/command/notebook_manager.go
+++ b/master/internal/command/notebook_manager.go
@@ -179,11 +179,13 @@ func (n *notebookManager) newNotebook(req *commandRequest) (*command, error) {
 	// the same port on an agent.
 	port := getPort(minNotebookPort, maxNotebookPort)
 	notebookPorts := map[string]int{"notebook": port}
+	portVar := fmt.Sprintf("NOTEBOOK_PORT=%d", port)
+
 	config.Environment.Ports = notebookPorts
-	config.Environment.EnvironmentVariables = model.RuntimeItems{
-		CPU: []string{fmt.Sprintf("NOTEBOOK_PORT=%d", port)},
-		GPU: []string{fmt.Sprintf("NOTEBOOK_PORT=%d", port)},
-	}
+	config.Environment.EnvironmentVariables.CPU = append(
+		config.Environment.EnvironmentVariables.CPU, portVar)
+	config.Environment.EnvironmentVariables.GPU = append(
+		config.Environment.EnvironmentVariables.GPU, portVar)
 
 	config.Entrypoint = notebookEntrypoint
 

--- a/master/internal/command/notebook_manager.go
+++ b/master/internal/command/notebook_manager.go
@@ -30,7 +30,7 @@ const (
 	jupyterDataDir    = "/run/determined/jupyter/data"
 	jupyterRuntimeDir = "/run/determined/jupyter/runtime"
 	jupyterEntrypoint = "/run/determined/jupyter/notebook-entrypoint.sh"
-	// Agent port range is 2600 - 3200. Ports are split between TensorBoard and Notebooks
+	// Agent port range is 2600 - 3200. Ports are split between TensorBoard and Notebooks.
 	minNotebookPort     = 2900
 	maxNotebookPort     = minNotebookPort + 299
 	notebookConfigFile  = "/run/determined/workdir/jupyter-conf.py"

--- a/master/internal/command/notebook_manager.go
+++ b/master/internal/command/notebook_manager.go
@@ -30,7 +30,7 @@ const (
 	jupyterDataDir    = "/run/determined/jupyter/data"
 	jupyterRuntimeDir = "/run/determined/jupyter/runtime"
 	jupyterEntrypoint = "/run/determined/jupyter/notebook-entrypoint.sh"
-	// Agent port range is 2600 - 3000. Ports are split between TensorBoard and Notebooks
+	// Agent port range is 2600 - 3200. Ports are split between TensorBoard and Notebooks
 	minNotebookPort     = 2900
 	maxNotebookPort     = minNotebookPort + 299
 	notebookConfigFile  = "/run/determined/workdir/jupyter-conf.py"

--- a/master/internal/command/tensorboard_manager.go
+++ b/master/internal/command/tensorboard_manager.go
@@ -4,12 +4,10 @@ import (
 	"archive/tar"
 	"encoding/json"
 	"fmt"
-	"math/rand"
 	"net/http"
 	"net/url"
 	"sort"
 	"strings"
-	"time"
 
 	petname "github.com/dustinkirkland/golang-petname"
 	"github.com/labstack/echo"
@@ -28,7 +26,8 @@ import (
 )
 
 const (
-	expConfPath               = "/run/determined/workdir/experiment_config.json"
+	expConfPath = "/run/determined/workdir/experiment_config.json"
+	// Agent port range is 2600 - 3000. Ports are split between TensorBoard and Notebooks
 	minTensorBoardPort        = 2600
 	maxTensorBoardPort        = minTensorBoardPort + 299
 	tensorboardEntrypointFile = "/run/determined/workdir/tensorboard-entrypoint.sh"
@@ -331,14 +330,6 @@ func (t *tensorboardManager) getTensorBoardConfigs(req tensorboardRequest) (
 	}
 
 	return configs, nil
-}
-
-func getPort(min, max int) int {
-	// Set the seed here or else the compiler will generate a random number at
-	// compile time and each invocation of this function will return the same
-	// number.
-	rand.Seed(time.Now().Unix())
-	return rand.Intn(max-min) + min
 }
 
 func getMounts(m map[model.BindMount]bool) []model.BindMount {

--- a/master/internal/command/tensorboard_manager.go
+++ b/master/internal/command/tensorboard_manager.go
@@ -27,7 +27,7 @@ import (
 
 const (
 	expConfPath = "/run/determined/workdir/experiment_config.json"
-	// Agent port range is 2600 - 3000. Ports are split between TensorBoard and Notebooks
+	// Agent port range is 2600 - 3200. Ports are split between TensorBoard and Notebooks
 	minTensorBoardPort        = 2600
 	maxTensorBoardPort        = minTensorBoardPort + 299
 	tensorboardEntrypointFile = "/run/determined/workdir/tensorboard-entrypoint.sh"

--- a/master/internal/command/tensorboard_manager.go
+++ b/master/internal/command/tensorboard_manager.go
@@ -27,7 +27,7 @@ import (
 
 const (
 	expConfPath = "/run/determined/workdir/experiment_config.json"
-	// Agent port range is 2600 - 3200. Ports are split between TensorBoard and Notebooks
+	// Agent port range is 2600 - 3200. Ports are split between TensorBoard and Notebooks.
 	minTensorBoardPort        = 2600
 	maxTensorBoardPort        = minTensorBoardPort + 299
 	tensorboardEntrypointFile = "/run/determined/workdir/tensorboard-entrypoint.sh"

--- a/master/static/srv/notebook-entrypoint.sh
+++ b/master/static/srv/notebook-entrypoint.sh
@@ -6,4 +6,4 @@ export PATH="/run/determined/pythonuserbase/bin:$PATH"
 
 python3.6 -m pip install --user /opt/determined/wheels/determined*.whl
 
-jupyter lab --config /run/determined/workdir/jupyter-conf.py
+jupyter lab --config /run/determined/workdir/jupyter-conf.py --port=${NOTEBOOK_PORT}


### PR DESCRIPTION
## Description
Addresses the host mode networking issue where only a single notebook can start on an agent. This PR uses the same strategy as TensorBoards. We pick a random port per notebook within a range of ports. This is a mitigation. There is still a chance that 2 notebooks select the same port, although it is unlikely.


## Test Plan
Manually verified that notebooks start on different ports.