### PR TITLE
feat: support setting CUDA_VISIBLE_DEVICES for estimator_trial

### DIFF
--- a/harness/determined/estimator/_estimator_trial.py
+++ b/harness/determined/estimator/_estimator_trial.py
@@ -562,6 +562,8 @@ class EstimatorTrialController(det.LoopTrialController):
                 session_config = tf.compat.v1.ConfigProto()
             session_config.gpu_options.allow_growth = True
 
+            # If using CUDA_VISIBLE_DEVICES there is only one visible GPU
+            # so there is no need to set visible devices for TF.
             if not self.env.experiment_config.get("data", {}).get(
                 "set_cuda_visible_devices", False
             ):

--- a/harness/determined/estimator/_estimator_trial.py
+++ b/harness/determined/estimator/_estimator_trial.py
@@ -354,6 +354,7 @@ class EstimatorTrialController(det.LoopTrialController):
             hvd.init()
 
             # This is option is available for when TF ignores `gpu_options.visible_device_list`.
+            # TODO (DET-3762): Remove this once it's no longer necessary.
             if env.experiment_config.get("data", {}).get("set_cuda_visible_devices", False):
                 logging.info(
                     "Setting `CUDA_VISIBLE_DEVICES` environment variables "
@@ -564,6 +565,7 @@ class EstimatorTrialController(det.LoopTrialController):
 
             # If using CUDA_VISIBLE_DEVICES there is only one visible GPU
             # so there is no need to set visible devices for TF.
+            # TODO (DET-3762): Remove this once it's no longer necessary.
             if not self.env.experiment_config.get("data", {}).get(
                 "set_cuda_visible_devices", False
             ):


### PR DESCRIPTION
## Description
This is meant as a workaround for cases where TF ignores `gpu_options.visible_device_list`. 


## Test Plan
Going to spin  up a cluster and take it for a spin. 
