### PR TITLE
chore: deprecate pytorch.reset_parameters [DET-3578]

### DIFF
--- a/docs/tutorials/pytorch-mnist-tutorial.txt
+++ b/docs/tutorials/pytorch-mnist-tutorial.txt
@@ -83,8 +83,6 @@ The current values of the model's hyperparameters can be accessed via the :func:
 
 .. code:: python
 
-    from determined.pytorch import reset_parameters
-
     def __init__(self, context: PyTorchTrialContext):
         # Store trial context for later use.
         self.context = context
@@ -106,7 +104,6 @@ The current values of the model's hyperparameters can be accessed via the :func:
             nn.Linear(128, 10),
             nn.LogSoftmax(),
         ))
-        reset_parameters(self.model)
 
         # Initialize the optimizers and wrap them with self.context.wrap_optimizer().
         self.optimizer = self.context.wrap_optimizer(

--- a/examples/experimental/trial/imagenet_nas_arch_pytorch/model_def.py
+++ b/examples/experimental/trial/imagenet_nas_arch_pytorch/model_def.py
@@ -19,7 +19,7 @@ import torchvision.transforms as transforms
 from torch import nn
 
 from data import ImageNetDataset
-from determined.pytorch import DataLoader, LRScheduler, PyTorchTrial, PyTorchTrialContext, reset_parameters
+from determined.pytorch import DataLoader, LRScheduler, PyTorchTrial, PyTorchTrialContext
 from model import NetworkImageNet
 from utils import AutoAugment, CrossEntropyLabelSmooth, Cutout, HSwish, Swish, accuracy
 
@@ -73,10 +73,6 @@ class ImageNetTrial(PyTorchTrial):
             auxiliary=self.context.get_hparam("auxiliary"),
             do_SE=self.context.get_hparam("do_SE"),
         ))
-
-        # If loading backbone weights, do not call reset_parameters() or
-        # call before loading the backbone weights.
-        reset_parameters(self.model)
 
         self.optimizer = self.context.wrap_optimizer(torch.optim.SGD(
             self.model.parameters(),

--- a/examples/experimental/trial/mnist_pytorch_multi_output/model_def.py
+++ b/examples/experimental/trial/mnist_pytorch_multi_output/model_def.py
@@ -13,7 +13,7 @@ from torch import nn
 
 import determined as det
 from layers import Flatten, Squeeze  # noqa: I100
-from determined.pytorch import DataLoader, PyTorchTrial, PyTorchTrialContext, TorchData, reset_parameters
+from determined.pytorch import DataLoader, PyTorchTrial, PyTorchTrialContext, TorchData
 
 import data
 
@@ -105,10 +105,6 @@ class MultiMNistTrial(PyTorchTrial):
         self.data_downloaded = False
 
         self.model = self.context.wrap_model(MultiNet(self.context))
-
-        # If loading backbone weights, do not call reset_parameters() or
-        # call before loading the backbone weights.
-        reset_parameters(self.model)
 
         self.optimizer = self.context.wrap_optimizer(torch.optim.SGD(
             self.model.parameters(), lr=self.context.get_hparam("learning_rate"), momentum=0.9

--- a/examples/official/native/native_mnist_pytorch/model_def.py
+++ b/examples/official/native/native_mnist_pytorch/model_def.py
@@ -10,7 +10,7 @@ from torch import nn
 
 from layers import Flatten  # noqa: I100
 
-from determined.pytorch import DataLoader, PyTorchTrial, PyTorchTrialContext, reset_parameters
+from determined.pytorch import DataLoader, PyTorchTrial, PyTorchTrialContext
 
 import data
 
@@ -41,10 +41,6 @@ class MNistTrial(PyTorchTrial):
             nn.Linear(128, 10),
             nn.LogSoftmax(),
         ))
-
-        # If loading backbone weights, do not call reset_parameters() or
-        # call before loading the backbone weights.
-        reset_parameters(self.model)
 
         self.optimizer = self.context.wrap_optimizer(torch.optim.Adadelta(
             self.model.parameters(), lr=self.context.get_hparam("learning_rate"))

--- a/examples/official/trial/cifar10_cnn_pytorch/model_def.py
+++ b/examples/official/trial/cifar10_cnn_pytorch/model_def.py
@@ -13,7 +13,7 @@ import torchvision
 from torch import nn
 from torchvision import transforms
 
-from determined.pytorch import DataLoader, PyTorchTrial, PyTorchTrialContext, reset_parameters
+from determined.pytorch import DataLoader, PyTorchTrial, PyTorchTrialContext
 
 # Constants about the data set.
 IMAGE_SIZE = 32
@@ -67,10 +67,6 @@ class CIFARTrial(PyTorchTrial):
             nn.Dropout2d(self.context.get_hparam("layer3_dropout")),
             nn.Linear(512, NUM_CLASSES),
         ))
-
-        # If loading backbone weights, do not call reset_parameters() or
-        # call before loading the backbone weights.
-        reset_parameters(self.model)
 
         self.optimizer = self.context.wrap_optimizer(torch.optim.RMSprop(  # type: ignore
             self.model.parameters(),

--- a/examples/official/trial/mnist_pytorch/model_def.py
+++ b/examples/official/trial/mnist_pytorch/model_def.py
@@ -16,7 +16,7 @@ from torch import nn
 
 from layers import Flatten  # noqa: I100
 
-from determined.pytorch import DataLoader, PyTorchTrial, PyTorchTrialContext, reset_parameters
+from determined.pytorch import DataLoader, PyTorchTrial, PyTorchTrialContext
 
 import data
 
@@ -47,10 +47,6 @@ class MNistTrial(PyTorchTrial):
             nn.Linear(128, 10),
             nn.LogSoftmax(),
         ))
-
-        # If loading backbone weights, do not call reset_parameters() or
-        # call before loading the backbone weights.
-        reset_parameters(self.model)
 
         self.optimizer = self.context.wrap_optimizer(torch.optim.Adadelta(
             self.model.parameters(), lr=self.context.get_hparam("learning_rate"))

--- a/harness/determined/pytorch/_pytorch_trial.py
+++ b/harness/determined/pytorch/_pytorch_trial.py
@@ -959,12 +959,20 @@ class PyTorchTrial(det.Trial):
 
 def reset_parameters(model: torch.nn.Module) -> None:
     """
-    Recursively calls ``reset_parameters()`` for all modules.
+    .. warning::
+        ``det.pytorch.reset_parameters()`` is deprecated and should not be called. For custom
+        nn.Modules which do need a call to reset_parameters(), it is recommended to call
+        self.reset_parameters() directly in their __init__() function, as is standard in all
+        built-in nn.Modules.
 
-    Important: Call this prior to loading any backbone weights,
-    otherwise those weights will be overwritten.
+    Recursively calls ``reset_parameters()`` for all modules.
     """
-    logging.info("Resetting model parameters.")
+    logging.warning(
+        "det.pytorch.reset_parameters() is deprecated and should not be called.  For custom "
+        "nn.Modules which do need a call to reset_parameters(), it is recommended to call "
+        "self.reset_parameters() directly in their __init__() function, as is standard in all "
+        "built-in nn.Modules."
+    )
     for _, module in model.named_modules():
         reset_params = getattr(module, "reset_parameters", None)
         if callable(reset_params):

--- a/harness/tests/experiment/fixtures/pytorch_onevar_model.py
+++ b/harness/tests/experiment/fixtures/pytorch_onevar_model.py
@@ -1,0 +1,124 @@
+"""
+A one-variable linear model with no bias. The datset emits only pairs of (data, label) = (1, 1),
+meaning that the one weight in the model should approach 1 as gradient descent continues.
+
+We will use the mean squared error as the loss.  Since each record is the same, the "mean" part of
+mean squared error means we can analyze every batch as if were just one record.
+
+Now, we can calculate the mean squared error to ensure that we are getting the gradient we are
+expecting.
+
+let:
+    R = learning rate (constant)
+    l = loss
+    w0 = the starting value of the one weight
+    w' = the updated value of the one weight
+
+then calculate the loss:
+
+(1)     l = (label - (data * w0)) ** 2
+
+take derivative of loss WRT w
+
+(2)     dl/dw = - 2 * data * (label - (data * w0))
+
+gradient update:
+
+(3)     update = -R * dl/dw = 2 * R * data * (label - (data * w0))
+
+Finally, we can calculate the updated weight (w') in terms of w0:
+
+(4)     w' = w0 + update = w0 + 2 * R * data * (label - (data * w0))
+
+TODO(DET-1597): migrate the all pytorch XOR trial unit tests to variations of the OneVarTrial.
+"""
+
+from typing import Any, Dict, Tuple
+
+import numpy as np
+import torch
+
+from determined import pytorch
+
+
+class OnesDataset(torch.utils.data.Dataset):
+    def __len__(self) -> int:
+        return 64
+
+    def __getitem__(self, index: int) -> Tuple:
+        return torch.Tensor([float(1)]), torch.Tensor([float(1)])
+
+
+class OneVarTrial(pytorch.PyTorchTrial):
+    def __init__(self, context: pytorch.PyTorchTrialContext) -> None:
+        self.context = context
+
+        model = torch.nn.Linear(1, 1, False)
+
+        # Manually initialize the one weight to 0.
+        model.weight.data.fill_(0)
+
+        self.model = context.wrap_model(model)
+
+        self.lr = 0.001
+
+        opt = torch.optim.SGD(self.model.parameters(), self.lr)
+        self.opt = context.wrap_optimizer(opt)
+
+        self.loss_fn = torch.nn.MSELoss()
+
+    def train_batch(
+        self, batch: pytorch.TorchData, epoch_idx: int, batch_idx: int
+    ) -> Dict[str, torch.Tensor]:
+        data, label = batch
+
+        # Measure the weight right now.
+        w_before = self.model.weight.data.item()
+
+        # Calculate expected values for loss (eq 1) and weight (eq 4).
+        loss_exp = (label[0] - data[0] * w_before) ** 2
+        w_exp = w_before + 2 * self.lr * data[0] * (label[0] - (data[0] * w_before))
+
+        loss = self.loss_fn(self.model(data), label)
+
+        self.context.backward(loss)
+        self.context.step_optimizer(self.opt)
+
+        # Measure the weight after the update.
+        w_after = self.model.weight.data.item()
+
+        # Return values that we can compare as part of the tests.
+        return {
+            "loss": loss,
+            "loss_exp": loss_exp,
+            "w_before": w_before,
+            "w_after": w_after,
+            "w_exp": w_exp,
+        }
+
+    @staticmethod
+    def check_batch_metrics(metrics: Dict[str, Any], batch_idx: int) -> None:
+        """A check to be applied to the output of every train_batch in a test."""
+
+        def float_eq(a: np.ndarray, b: np.ndarray) -> bool:
+            epsilon = 0.000001
+            return (np.abs(a - b) < epsilon).all()
+
+        assert float_eq(
+            metrics["loss"], metrics["loss_exp"]
+        ), f'{metrics["loss"]} does not match {metrics["loss_exp"]} at batch {batch_idx}'
+
+        assert float_eq(
+            metrics["w_after"], metrics["w_exp"]
+        ), f'{metrics["w_after"]} does not match {metrics["w_exp"]} at batch {batch_idx}'
+
+    def evaluate_batch(self, batch: pytorch.TorchData) -> Dict[str, Any]:
+        data, label = batch
+        loss = self.loss_fn(self.model(data), label)
+        return {"val_loss": loss}
+
+    def build_training_data_loader(self) -> pytorch.DataLoader:
+        return pytorch.DataLoader(OnesDataset(), batch_size=self.context.get_per_slot_batch_size())
+
+    def build_validation_data_loader(self) -> pytorch.DataLoader:
+        return pytorch.DataLoader(OnesDataset(), batch_size=self.context.get_per_slot_batch_size())

--- a/harness/tests/experiment/fixtures/pytorch_xor_model.py
+++ b/harness/tests/experiment/fixtures/pytorch_xor_model.py
@@ -60,7 +60,6 @@ class XORNet(nn.Module):
             nn.Linear(context.get_hparam("hidden_size"), 1),
             nn.Sigmoid(),
         )
-        pytorch.reset_parameters(self.main_net)
 
     def forward(self, model_input: Any):
         return self.main_net(model_input)


### PR DESCRIPTION
# Description

We do not need to have users call `reset_parameters`, except for very specialized models (where the user needs to call `reset_parameters` on their own regardless of our system).  It should therefore not be a part of our API, since it only clutters our API for 99% of users.

The reason we do not need to call it is that `reset_parameters()` (or some similarly-named equivalent... they're not all named the same) is called at the end of `__init__()` for every built-in `nn.Module` in PyTorch.

## Appearances of `def .*reset.*param` in PyTorch 1.5

Found via `git grep -El 'def .*reset.*param'`:

### `torch/nn/intrinsic/qat/modules/conv_fused.py`

Note that `_ConvNd.__init__()` is going to call the overridden
`_ConvBnNd.reset_parameters`, which is what the `hasttr(self, 'gamma')` hack is
going to protect against.

```python
class _ConvBnNd(nn.modules.conv._ConvNd):
    def __init__(...):
        nn.modules.conv._ConvNd.__init__(...)
        ...
        self.gamma = nn.Parameter(torch.Tensor(out_channels))
        ...
        self.reset_bn_parameters()

    def reset_running_stats(self):
        self.running_mean.zero_()
        self.running_var.fill_(1)
        self.num_batches_tracked.zero_()

    def reset_bn_parameters(self):
        self.reset_running_stats()
        init.uniform_(self.gamma)
        init.zeros_(self.beta)

    def reset_parameters(self):
        super(_ConvBnNd, self).reset_parameters()
        # A hack to avoid resetting on undefined parameters
        if hasattr(self, 'gamma'):
            self.reset_bn_parameters()
```

### `torch/nn/modules/activation.py`

Notice that the `reset_parameters()` is actually called `_reset_parameters()`.

```python
class MultiheadAttention(Module):
    def __init__(...):
        super(MultiheadAttention, self).__init__()
        ...
        self._reset_parameters()

    def _reset_parameters(self):
        ...
```

### `torch/nn/modules/adaptive.py`

Notice that the `head` and each `tail` are all `Linear`s which get initialized
automatically, but `reset_parameters` is still definied if you want to
reinitialize them.

```python
class AdaptiveLogSoftmaxWithLoss(Module):
    def __init__(...):
        super(AdaptiveLogSoftmaxWithLoss, self).__init__()
        ...
        self.head = Linear(self.in_features, self.head_size, bias=self.head_bias)
        self.tail = ModuleList()

        for i in range(self.n_clusters):

            hsz = int(self.in_features // (self.div_value ** (i + 1)))
            osz = self.cutoffs[i + 1] - self.cutoffs[i]

            projection = Sequential(
                Linear(self.in_features, hsz, bias=False),
                Linear(hsz, osz, bias=False)
            )

            self.tail.append(projection)

    def reset_parameters(self):
        self.head.reset_parameters()
        for i2h, h2o in self.tail:
            i2h.reset_parameters()
            h2o.reset_parameters()
```

### `torch/nn/modules/batchnorm.py`

```python
class _NormBase(Module):
    def __init__(...):
        super(_NormBase, self).__init__()
        ...
        self.reset_parameters()

    def reset_running_stats(self):
        if self.track_running_stats:
            self.running_mean.zero_()
            self.running_var.fill_(1)
            self.num_batches_tracked.zero_()

    def reset_parameters(self):
        self.reset_running_stats()
        if self.affine:
            init.ones_(self.weight)
            init.zeros_(self.bias)
```

### `torch/nn/modules/conv.py`

```python
class _ConvNd(Module):
    def __init__(...):
        super(_ConvNd, self).__init__()
        ...
        self.reset_parameters()

    def reset_parameters(self):
        ...
```

### `torch/nn/modules/linear.py`

```python
class Linear(Module):
    def __init__(...):
        super(Linear, self).__init__()
        ...
        self.reset_parameters()

    def reset_parameters(self):
        init.kaiming_uniform_(self.weight, a=math.sqrt(5))
        if self.bias is not None:
            fan_in, _ = init._calculate_fan_in_and_fan_out(self.weight)
            bound = 1 / math.sqrt(fan_in)
            init.uniform_(self.bias, -bound, bound)

...

class Bilinear(Module):
    def __init__(...):
        super(Bilinear, self).__init__()
        ...
        self.reset_parameters()

    def reset_parameters(self):
        bound = 1 / math.sqrt(self.weight.size(1))
        init.uniform_(self.weight, -bound, bound)
        if self.bias is not None:
            init.uniform_(self.bias, -bound, bound)
```

### `torch/nn/modules/normalization.py`

```python
class LayerNorm(Module):
    def __init__(...):
        super(LayerNorm, self).__init__()
        ...
        self.reset_parameters()

    def reset_parameters(self):
        if self.elementwise_affine:
            init.ones_(self.weight)
            init.zeros_(self.bias)

...

class GroupNorm(Module):
    def __init__(...):
        super(GroupNorm, self).__init__()
        ...
        self.reset_parameters()

    def reset_parameters(self):
        if self.affine:
            init.ones_(self.weight)
            init.zeros_(self.bias)
```

### `torch/nn/modules/rnn.py`

```python
class RNNBase(Module):
    def __init__(...):
        super(RNNBase, self).__init__()
        ...
        self.reset_parameters()

    def __setattr__(self, attr, value):
        if hasattr(self, "_flat_weights_names") and attr in self._flat_weights_names:
            # keep self._flat_weights up to date if you do self.weight = ...
            idx = self._flat_weights_names.index(attr)
            self._flat_weights[idx] = value
        super(RNNBase, self).__setattr__(attr, value)

    def reset_parameters(self):
        stdv = 1.0 / math.sqrt(self.hidden_size)
        for weight in self.parameters():
            init.uniform_(weight, -stdv, stdv)

...


class RNNCellBase(Module):
    def __init__(...):
        super(RNNCellBase, self).__init__()
        self.reset_parameters()

    def reset_parameters(self):
        stdv = 1.0 / math.sqrt(self.hidden_size)
        for weight in self.parameters():
            init.uniform_(weight, -stdv, stdv)
```

### `torch/nn/modules/sparse.py`

```python
class Embedding(Module):
    def __init__(self, num_embeddings, embedding_dim, padding_idx=None,
                 max_norm=None, norm_type=2., scale_grad_by_freq=False,
                 sparse=False, _weight=None):
        super(Embedding, self).__init__()
        ...
        if _weight is None:
            self.weight = Parameter(torch.Tensor(num_embeddings, embedding_dim))
            self.reset_parameters()
        else:
            assert list(_weight.shape) == [num_embeddings, embedding_dim], \
                'Shape of weight does not match num_embeddings and embedding_dim'
            self.weight = Parameter(_weight)
        ...

    def reset_parameters(self):
        init.normal_(self.weight)
        if self.padding_idx is not None:
            with torch.no_grad():
                self.weight[self.padding_idx].fill_(0)

...

class EmbeddingBag(Module):
    def __init__(self, num_embeddings, embedding_dim,
                 max_norm=None, norm_type=2., scale_grad_by_freq=False,
                 mode='mean', sparse=False, _weight=None, include_last_offset=False):
        super(EmbeddingBag, self).__init__()
        ...
        if _weight is None:
            self.weight = Parameter(torch.Tensor(num_embeddings, embedding_dim))
            self.reset_parameters()
        else:
            assert list(_weight.shape) == [num_embeddings, embedding_dim], \
                'Shape of weight does not match num_embeddings and embedding_dim'
            self.weight = Parameter(_weight)
        ...

    def reset_parameters(self):
        init.normal_(self.weight)
```

### `torch/nn/modules/transformer.py`

Notice that the `reset_parameters()` is actually called `_reset_parameters()`.

```python
class Transformer(Module):
    def __init__(...):
        super(Transformer, self).__init__()
        ...
        self._reset_parameters()
        ...

    def _reset_parameters(self):
        for p in self.parameters():
            if p.dim() > 1:
                xavier_uniform_(p)
```
