### PR TITLE
docs: configure `rstfmt` for formatting docs files [DET-3784]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ check: check-common check-proto check-harness check-cli check-deploy check-e2e_t
 fmt-%:
 	$(MAKE) -C $(subst -,/,$*) fmt
 .PHONY: fmt
-fmt: fmt-common fmt-harness fmt-cli fmt-deploy fmt-e2e_tests fmt-master fmt-agent fmt-webui fmt-examples
+fmt: fmt-common fmt-harness fmt-cli fmt-deploy fmt-e2e_tests fmt-master fmt-agent fmt-webui fmt-examples fmt-docs
 
 .PHONY: test-%
 test-%:

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -21,6 +21,10 @@ publish: clean
 live:
 	npx nodemon --ext txt --exec "$(MAKE) build" --ignore site
 
+.PHONY: fmt
+fmt:
+	git ls-files -z '*.txt' ':!:requirements.txt' | xargs -0 rstfmt -i
+
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 .PHONY: ALWAYS

--- a/docs/reference/api/estimator.txt
+++ b/docs/reference/api/estimator.txt
@@ -90,7 +90,7 @@ Example usage of ``determined.estimator.RunHook`` which adds custom metadata che
             with open(os.path.join(checkpoint_dir, "metadata.txt"), "w") as fp:
                 fp.write(self._metadata)
 
-    class MyEstimatorTrial(determined.estimator.EstimatorTrial) -> None:
+    class MyEstimatorTrial(determined.estimator.EstimatorTrial):
         ...
 
         def build_train_spec(self) -> tf.estimator.TrainSpec:

--- a/docs/release-notes.txt
+++ b/docs/release-notes.txt
@@ -452,6 +452,7 @@ Version 0.12.2
   .. code:: python
 
      def __init__(self, context) -> None:
+         ...
 
   where ``context`` is an instance of the new ``det.TrialContext`` class. This new object is the primary mechanism for querying information about the system. Some of its methods include:
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -6,4 +6,5 @@ git+https://github.com/determined-ai/determined_sphinx_theme.git@23d12b0c0f11f75
 sphinx-gallery>=0.6.1
 sphinx-sitemap>=2.2.0
 pillow
+rstfmt==0.0.5
 sphinx-copybutton


### PR DESCRIPTION
## Description

We lacked a tool for formatting our reStructuredText files the way we
have for Python and Go; this adds configuration and Makefile targets for
using such a tool that I developed.

## Test Plan

- [x] run `make -C docs fmt`, skim the [changes](https://github.com/determined-ai/determined/compare/master...dzhu:rstfmt-changes), check that Sphinx still builds everything

## Commentary

Several people recently expressed an interest in adding this sort of thing, so I finally got around to making this PR after having the pieces sitting around for a while.

Because of the rather experimental status of [`rstfmt`](https://github.com/dzhu/rstfmt), I'm not yet adding a corresponding `check` target; that way, we don't get blocked if something goes wrong with it. If it looks good for a while, I'll add that later.

(That also means I can leave the actual formatting changes out of this PR so that we can keep them separate from the config changes and not have to squash them together.)