### PR TITLE
fix: dismiss trial log download warning modal upon confirmation [DET-3779]

### DIFF
--- a/webui/react/src/pages/TrialLogs.tsx
+++ b/webui/react/src/pages/TrialLogs.tsx
@@ -37,6 +37,7 @@ const TrialLogs: React.FC = () => {
   const [ isDownloading, setIsDownloading ] = useState(false);
   const [ isLoading, setIsLoading ] = useState(true);
   const [ isIdInvalid, setIsIdInvalid ] = useState(false);
+  const [ downloadModal, setDownloadModal ] = useState<{ destroy: () => void }>();
   const [ trial ] = useRestApi<TrialDetailsParams, TrialDetails>(getTrialDetails, { id });
 
   const handleScrollToTop = useCallback(() => {
@@ -61,6 +62,11 @@ const TrialLogs: React.FC = () => {
   }, [ id, offset, oldestId, oldestReached ]);
 
   const handleDownloadConfirm = useCallback(async () => {
+    if (downloadModal) {
+      downloadModal.destroy();
+      setDownloadModal(undefined);
+    }
+
     setIsDownloading(true);
 
     try {
@@ -79,10 +85,10 @@ const TrialLogs: React.FC = () => {
     }
 
     setIsDownloading(false);
-  }, [ id ]);
+  }, [ downloadModal, id ]);
 
   const handleDownloadLogs = useCallback(() => {
-    Modal.confirm({
+    const modal = Modal.confirm({
       content: <div>
         We recommend using the Determined CLI to download trial logs:
         <code className="block">
@@ -95,6 +101,7 @@ const TrialLogs: React.FC = () => {
       title: `Confirm Download for Trial ${id} Logs`,
       width: 640,
     });
+    setDownloadModal(modal);
   }, [ handleDownloadConfirm, id, trial.data, trialId ]);
 
   useEffect(() => setUI({ type: UI.ActionType.HideChrome }), [ setUI ]);


### PR DESCRIPTION
## Description

Confirming the continuation of downloading trial logs will dismiss the modal instead of waiting for the download to complete first.

![2020-08-05 at 3 51 PM](https://user-images.githubusercontent.com/220971/89467901-ad5bcd00-d733-11ea-8b00-b313105df988.png)


## Test Plan



## Commentary (optional)


<!-- User-facing API changes need the "User-facing API Change" label -->

<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

## Description

Lead with the intended commit body in this description field. For breaking changes, please include "BREAKING CHANGE:" at the beginning of your commit body. At minimum, this section should include a bracketed reference to the Jira ticket, e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.

## Test Plan

Describe the situations in which you've tested your change, and/or a screenshot as appropriate. Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.

## Commentary (optional)

Use this section of your description to add context to the PR. Could be for particularly tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc. You may intentionally leave this section blank and remove the title.
--->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234