### PR TITLE
chore: for tensorpack, max_length.batches must be a multiple of scheduling unit

### DIFF
--- a/e2e_tests/tests/nightly/test_capability.py
+++ b/e2e_tests/tests/nightly/test_capability.py
@@ -25,7 +25,7 @@ def test_bert_glue() -> None:
 @pytest.mark.nightly  # type: ignore
 def test_faster_rcnn() -> None:
     config = conf.load_config(conf.experimental_path("trial/FasterRCNN_tp/16-gpus.yaml"))
-    config = conf.set_max_length(config, {"batches": 200})
+    config = conf.set_max_length(config, {"batches": 128})
     config = conf.set_slots_per_trial(config, 1)
 
     exp.run_basic_test_with_temp_config(
@@ -36,7 +36,7 @@ def test_faster_rcnn() -> None:
 @pytest.mark.nightly  # type: ignore
 def test_mnist_tp_to_estimator() -> None:
     config = conf.load_config(conf.experimental_path("trial/mnist_tp_to_estimator/const.yaml"))
-    config = conf.set_max_length(config, {"batches": 200})
+    config = conf.set_max_length(config, {"batches": 32})
 
     exp.run_basic_test_with_temp_config(
         config, conf.experimental_path("trial/mnist_tp_to_estimator"), 1


### PR DESCRIPTION
## Description
When we made the changes for remove steps, we did not fix tensorpack to be able to handle variable batches per workload - no matter what it is given it runs a full step. Because of this, the harness blows up when checking the length of batch metrics because tensorpack will in cases where the master decides to split a step, e.g. this test.


## Test Plan
None, I saw this in parallel tests but missed it in nightly.


## Commentary (optional)


<!-- User-facing API changes need the "User-facing API Change" label -->

<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

## Description

Lead with the intended commit body in this description field. For breaking changes, please include "BREAKING CHANGE:" at the beginning of your commit body. At minimum, this section should include a bracketed reference to the Jira ticket, e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.

## Test Plan

Describe the situations in which you've tested your change, and/or a screenshot as appropriate. Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.

## Commentary (optional)

Use this section of your description to add context to the PR. Could be for particularly tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc. You may intentionally leave this section blank and remove the title.
--->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234