### PR TITLE
feat: get checkpoint endpoint [DET-3734]

### DIFF
--- a/common/determined_common/experimental/determined.py
+++ b/common/determined_common/experimental/determined.py
@@ -44,8 +44,8 @@ class Determined:
         Get the :class:`~determined.experimental.Checkpoint` representing the
         checkpoint with the provided UUID.
         """
-        r = api.get(self._session._master, "checkpoints/{}".format(uuid)).json()
-        return Checkpoint.from_json(r, master=self._session._master)
+        r = api.get(self._session._master, "/api/v1/checkpoints/{}".format(uuid)).json()
+        return Checkpoint.from_json(r["checkpoint"], master=self._session._master)
 
     def create_model(
         self, name: str, description: Optional[str] = "", metadata: Optional[Dict[str, Any]] = None

--- a/master/internal/api_checkpoint.go
+++ b/master/internal/api_checkpoint.go
@@ -9,13 +9,13 @@ import (
 
 	"github.com/determined-ai/determined/master/internal/db"
 	"github.com/determined-ai/determined/proto/pkg/apiv1"
-	"github.com/determined-ai/determined/proto/pkg/experimentv1"
+	"github.com/determined-ai/determined/proto/pkg/checkpointv1"
 )
 
 func (a *apiServer) GetCheckpoint(
 	_ context.Context, req *apiv1.GetCheckpointRequest) (*apiv1.GetCheckpointResponse, error) {
 	resp := &apiv1.GetCheckpointResponse{}
-	resp.Checkpoint = &experimentv1.Checkpoint{}
+	resp.Checkpoint = &checkpointv1.Checkpoint{}
 	switch err := a.m.db.QueryProto("get_checkpoint", resp.Checkpoint, req.CheckpointUuid); err {
 	case db.ErrNotFound:
 		return nil, status.Errorf(

--- a/master/internal/api_checkpoint.go
+++ b/master/internal/api_checkpoint.go
@@ -1,0 +1,27 @@
+package internal
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/determined-ai/determined/master/internal/db"
+	"github.com/determined-ai/determined/proto/pkg/apiv1"
+	"github.com/determined-ai/determined/proto/pkg/experimentv1"
+)
+
+func (a *apiServer) GetCheckpoint(
+	_ context.Context, req *apiv1.GetCheckpointRequest) (*apiv1.GetCheckpointResponse, error) {
+	resp := &apiv1.GetCheckpointResponse{}
+	resp.Checkpoint = &experimentv1.Checkpoint{}
+	switch err := a.m.db.QueryProto("get_checkpoint", resp.Checkpoint, req.CheckpointUuid); err {
+	case db.ErrNotFound:
+		return nil, status.Errorf(
+			codes.NotFound, "checkpoint %s not found", req.CheckpointUuid)
+	default:
+		return resp,
+			errors.Wrapf(err, "error fetching checkpoint %s from database", req.CheckpointUuid)
+	}
+}

--- a/master/internal/api_model.go
+++ b/master/internal/api_model.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/determined-ai/determined/master/internal/db"
 	"github.com/determined-ai/determined/proto/pkg/apiv1"
-	"github.com/determined-ai/determined/proto/pkg/experimentv1"
+	"github.com/determined-ai/determined/proto/pkg/checkpointv1"
 	"github.com/determined-ai/determined/proto/pkg/modelv1"
 )
 
@@ -140,7 +140,7 @@ func (a *apiServer) PostModelVersion(
 	}
 
 	// make sure the checkpoint exists
-	c := &experimentv1.Checkpoint{}
+	c := &checkpointv1.Checkpoint{}
 
 	switch getCheckpointErr := a.m.db.QueryProto("get_checkpoint", c, req.CheckpointUuid); {
 	case getCheckpointErr == db.ErrNotFound:
@@ -150,7 +150,7 @@ func (a *apiServer) PostModelVersion(
 		return nil, getCheckpointErr
 	}
 
-	if c.State != experimentv1.Checkpoint_STATE_COMPLETED {
+	if c.State != checkpointv1.Checkpoint_STATE_COMPLETED {
 		return nil, errors.Errorf(
 			"checkpoint %s is in %s state. checkpoints for model versions must be in a COMPLETED state",
 			c.Uuid, c.State,

--- a/proto/src/determined/api/v1/api.proto
+++ b/proto/src/determined/api/v1/api.proto
@@ -8,6 +8,7 @@ import "protoc-gen-swagger/options/annotations.proto";
 
 import "determined/api/v1/agent.proto";
 import "determined/api/v1/auth.proto";
+import "determined/api/v1/checkpoint.proto";
 import "determined/api/v1/command.proto";
 import "determined/api/v1/experiment.proto";
 import "determined/api/v1/master.proto";
@@ -287,5 +288,11 @@ service Determined {
     rpc PostModelVersion(PostModelVersionRequest) returns (PostModelVersionResponse) {
       option (google.api.http) = {post: "/api/v1/models/{model_name}/versions" body: "*"};
       option (grpc.gateway.protoc_gen_swagger.options.openapiv2_operation) = {tags: "Models"};
+    }
+
+    // Get the requested checkpoint.
+    rpc GetCheckpoint(GetCheckpointRequest) returns (GetCheckpointResponse) {
+      option (google.api.http) = {get: "/api/v1/checkpoints/{checkpoint_uuid}"};
+      option (grpc.gateway.protoc_gen_swagger.options.openapiv2_operation) = {tags: "Checkpoints"};
     }
 }

--- a/proto/src/determined/api/v1/checkpoint.proto
+++ b/proto/src/determined/api/v1/checkpoint.proto
@@ -1,0 +1,18 @@
+syntax = "proto3";
+
+package determined.api.v1;
+option go_package = "github.com/determined-ai/determined/proto/pkg/apiv1";
+
+import "determined/experiment/v1/checkpoint.proto";
+
+// Get the requested checkpoint.
+message GetCheckpointRequest {
+  // The uuid for the requested checkpoint.
+  string checkpoint_uuid = 1;
+}
+
+// Response to GetCheckpointRequest.
+message GetCheckpointResponse {
+  // The requested checkpoint.
+  determined.experiment.v1.Checkpoint checkpoint = 1;
+}

--- a/proto/src/determined/api/v1/checkpoint.proto
+++ b/proto/src/determined/api/v1/checkpoint.proto
@@ -3,7 +3,7 @@ syntax = "proto3";
 package determined.api.v1;
 option go_package = "github.com/determined-ai/determined/proto/pkg/apiv1";
 
-import "determined/experiment/v1/checkpoint.proto";
+import "determined/checkpoint/v1/checkpoint.proto";
 
 // Get the requested checkpoint.
 message GetCheckpointRequest {
@@ -14,5 +14,5 @@ message GetCheckpointRequest {
 // Response to GetCheckpointRequest.
 message GetCheckpointResponse {
   // The requested checkpoint.
-  determined.experiment.v1.Checkpoint checkpoint = 1;
+  determined.checkpoint.v1.Checkpoint checkpoint = 1;
 }

--- a/proto/src/determined/checkpoint/v1/checkpoint.proto
+++ b/proto/src/determined/checkpoint/v1/checkpoint.proto
@@ -1,7 +1,7 @@
 syntax = "proto3";
 
-package determined.experiment.v1;
-option go_package = "github.com/determined-ai/determined/proto/pkg/experimentv1";
+package determined.checkpoint.v1;
+option go_package = "github.com/determined-ai/determined/proto/pkg/checkpointv1";
 
 import "google/protobuf/struct.proto";
 import "google/protobuf/timestamp.proto";

--- a/proto/src/determined/experiment/v1/checkpoint.proto
+++ b/proto/src/determined/experiment/v1/checkpoint.proto
@@ -5,6 +5,7 @@ option go_package = "github.com/determined-ai/determined/proto/pkg/experimentv1"
 
 import "google/protobuf/struct.proto";
 import "google/protobuf/timestamp.proto";
+import "protoc-gen-swagger/options/annotations.proto";
 
 // Metrics calculated during validation.
 message Metrics {
@@ -16,6 +17,11 @@ message Metrics {
 
 // Checkpoint is an artifact created by a trial during training.
 message Checkpoint {
+  option (grpc.gateway.protoc_gen_swagger.options.openapiv2_schema) = {
+      json_schema: {
+          required: ["uuid", "state"]
+      }
+  };
   // The current state of the checkpoint.
   enum State {
     // The state of the checkpoint is unknown.

--- a/proto/src/determined/model/v1/model.proto
+++ b/proto/src/determined/model/v1/model.proto
@@ -3,7 +3,7 @@ syntax = "proto3";
 package determined.model.v1;
 option go_package = "github.com/determined-ai/determined/proto/pkg/modelv1";
 
-import "determined/experiment/v1/checkpoint.proto";
+import "determined/checkpoint/v1/checkpoint.proto";
 
 import "google/protobuf/struct.proto";
 import "google/protobuf/timestamp.proto";
@@ -35,7 +35,7 @@ message ModelVersion {
   // The model the version is related to.
   Model model = 1;
   // The checkpoint of the model version.
-  determined.experiment.v1.Checkpoint checkpoint = 2;
+  determined.checkpoint.v1.Checkpoint checkpoint = 2;
   // The version number.
   int32 version = 3;
   // The time the model version was created.


### PR DESCRIPTION
## Description
Singular get checkpoint endpoint. Accepts the uuid of the checkpoint and returns the entire checkpoint.

## Test Plan
Manually tested the endpoint.


## Commentary (optional)
In the future we likely want checkpoint export methods to reference the new API endpoint.