### PR TITLE
feat: make sharding configurable in wrap_dataset

### DIFF
--- a/harness/determined/_experiment_config.py
+++ b/harness/determined/_experiment_config.py
@@ -27,7 +27,7 @@ class ExperimentConfig(dict):
     def averaging_training_metrics_enabled(self) -> bool:
         return bool(self["optimizations"]["average_training_metrics"])
 
-    # TODO (DET-3798): Remove input_from_dataflow in 0.12.14.
+    # TODO (DET-3798): Remove once customers are migrated.
     def input_from_dataflow(self) -> bool:
         # When using tensorpack dataflows as input, it's inefficient
         # to apply sharding, so we only apply sharding to the test set.

--- a/harness/determined/_experiment_config.py
+++ b/harness/determined/_experiment_config.py
@@ -27,6 +27,7 @@ class ExperimentConfig(dict):
     def averaging_training_metrics_enabled(self) -> bool:
         return bool(self["optimizations"]["average_training_metrics"])
 
+    # TODO (DET-3798): Remove input_from_dataflow in 0.12.14.
     def input_from_dataflow(self) -> bool:
         # When using tensorpack dataflows as input, it's inefficient
         # to apply sharding, so we only apply sharding to the test set.

--- a/harness/determined/estimator/_estimator_context.py
+++ b/harness/determined/estimator/_estimator_context.py
@@ -35,7 +35,7 @@ class EstimatorContext:
 
     def __init__(self, env: det.EnvContext, hvd_config: horovod.HorovodContext) -> None:
         self.hvd_config = hvd_config
-        # TODO (DET-3798): Remove input_from_dataflow in 0.12.14.
+        # TODO (DET-3798): Remove once customers are migrated.
         self.input_from_dataflow = env.experiment_config.input_from_dataflow()
 
         self.experimental = EstimatorExperimentalContext(env=env, hvd_config=hvd_config)
@@ -86,10 +86,11 @@ class EstimatorContext:
 
         Args:
             dataset: tf.data.Dataset
-            shard_dataset: When performing multi-slot (distributed) training, this
-            controls whether the dataset is sharded so that each training process
-            (one per slot) sees unique data. If set to False, users must manually
-            configure each process to see unique data.
+            shard_dataset:
+                When performing multi-slot (distributed) training, this
+                controls whether the dataset is sharded so that each training process
+                (one per slot) sees unique data. If set to False, users must manually
+                configure each process to use unique data.
 
         """
         hvd.require_horovod_type("tensorflow", "EstimatorContext.wrap_dataset was called.")

--- a/harness/determined/estimator/_estimator_context.py
+++ b/harness/determined/estimator/_estimator_context.py
@@ -35,6 +35,7 @@ class EstimatorContext:
 
     def __init__(self, env: det.EnvContext, hvd_config: horovod.HorovodContext) -> None:
         self.hvd_config = hvd_config
+        # TODO (DET-3798): Remove input_from_dataflow in 0.12.14.
         self.input_from_dataflow = env.experiment_config.input_from_dataflow()
 
         self.experimental = EstimatorExperimentalContext(env=env, hvd_config=hvd_config)
@@ -73,7 +74,7 @@ class EstimatorContext:
         logging.debug("Initialized optimizer for distributed and optimized parallel training.")
         return optimizer
 
-    def wrap_dataset(self, dataset: Any) -> Any:
+    def wrap_dataset(self, dataset: Any, shard_dataset: bool = True) -> Any:
         """
         This should be used to wrap ``tf.data.Dataset`` objects immediately after
         they have been created. Users should use the output of this wrapper as the
@@ -82,12 +83,23 @@ class EstimatorContext:
         independently. E.g., If users instantiate their training dataset within
         ``build_train_spec()``, they should call ``dataset = wrap_dataset(dataset)``
         prior to passing it into ``tf.estimator.TrainSpec``.
+
+        Args:
+            dataset: tf.data.Dataset
+            shard_dataset: When performing multi-slot (distributed) training, this
+            controls whether the dataset is sharded so that each training process
+            (one per slot) sees unique data. If set to False, users must manually
+            configure each process to see unique data.
+
         """
         hvd.require_horovod_type("tensorflow", "EstimatorContext.wrap_dataset was called.")
 
         self.dataset_initialized = True
-        if not self.hvd_config.use or self.input_from_dataflow:
+        if not self.hvd_config.use or self.input_from_dataflow or not shard_dataset:
+            if self.hvd_config and not shard_dataset:
+                logging.info("Dataset sharding skipped.")
             return dataset
+
         dataset = dataset.shard(hvd.size(), hvd.rank())
         logging.debug(f"Sharded dataset to index {hvd.rank()} of {hvd.size()}.")
         return dataset

--- a/harness/determined/estimator/_estimator_trial.py
+++ b/harness/determined/estimator/_estimator_trial.py
@@ -364,6 +364,7 @@ class EstimatorTrialController(det.LoopTrialController):
                 os.environ["NCCL_P2P_DISABLE"] = "1"
 
         # Initialize random seeds.
+        # TODO (DET-3798): Remove input_from_dataflow in 0.12.14.
         if env.experiment_config.input_from_dataflow():
             logging.debug("Using tensorpack dataflows as input.")
             process_rank = 0 if not hvd_config.use else hvd.rank()

--- a/harness/determined/estimator/_estimator_trial.py
+++ b/harness/determined/estimator/_estimator_trial.py
@@ -364,7 +364,7 @@ class EstimatorTrialController(det.LoopTrialController):
                 os.environ["NCCL_P2P_DISABLE"] = "1"
 
         # Initialize random seeds.
-        # TODO (DET-3798): Remove input_from_dataflow in 0.12.14.
+        # TODO (DET-3798): Remove once customers are migrated.
         if env.experiment_config.input_from_dataflow():
             logging.debug("Using tensorpack dataflows as input.")
             process_rank = 0 if not hvd_config.use else hvd.rank()

--- a/harness/determined/keras/_tf_keras_context.py
+++ b/harness/determined/keras/_tf_keras_context.py
@@ -173,10 +173,11 @@ class TFKerasContext:
 
         Args:
             dataset: tf.data.Dataset
-            shard_dataset: When performing multi-slot (distributed) training, this
-            controls whether the dataset is sharded so that each training process
-            (one per slot) sees unique data. If set to False, users must manually
-            configure each process to see unique data.
+            shard_dataset:
+                When performing multi-slot (distributed) training, this
+                controls whether the dataset is sharded so that each training process
+                (one per slot) sees unique data. If set to False, users must manually
+                configure each process to use unique data.
         """
         self.dataset_initialized = True
         if not self.hvd_config.use or not isinstance(dataset, tf.data.Dataset) or not shard_dataset:


### PR DESCRIPTION
## Description
Users have asked for the ability to perform dataset sharding themselves. Previously this was only supported via `data: dataflow_to_tf_dataset` in EstimatorTrial which was a hack. 
