### PR TITLE
 chore: change search_metric to val_acc for tf_keras_native_dtrain 4bb2ab6 [DET-3794]

### DIFF
--- a/e2e_tests/tests/experiment/test_tutorials.py
+++ b/e2e_tests/tests/experiment/test_tutorials.py
@@ -22,6 +22,9 @@ def test_tutorial() -> None:
 
 @pytest.mark.parallel  # type: ignore
 def test_tutorial_dtrain() -> None:
-    create_native_experiment(
+    exp_id = create_native_experiment(
         conf.tutorials_path("native-tf-keras"), ["python", "tf_keras_native_dtrain.py"]
+    )
+    experiment.wait_for_experiment_state(
+        exp_id, "COMPLETED", max_wait_secs=conf.DEFAULT_MAX_WAIT_SECS
     )

--- a/examples/tutorials/native-tf-keras/tf_keras_native_dtrain.py
+++ b/examples/tutorials/native-tf-keras/tf_keras_native_dtrain.py
@@ -17,7 +17,7 @@ from determined.experimental.keras import init
 config = {
     "searcher": {
         "name": "single",
-        "metric": "val_accuracy", "max_length": {
+        "metric": "val_acc", "max_length": {
             "batches": 500,
         }},
     "hyperparameters": {"global_batch_size": 256},


### PR DESCRIPTION
## Description
The test before test_pytorch_parallel, tf_keras_native_dtrain, is failing causing it to fail. It's failing because it's looking for the wrong metric. This seems to have always be incorrect, but never been caught because the result wasn't properly checked.
```
Traceback (most recent call last): File "/opt/conda/lib/python3.6/runpy.py", line 193, in _run_module_as_main "__main__", mod_spec) File "/opt/conda/lib/python3.6/runpy.py", line 85, in _run_code exec(code, run_globals) File "/run/determined/pythonuserbase/lib/python3.6/site-packages/determined/exec/harness.py", line 215, in <module> main() File "/run/determined/pythonuserbase/lib/python3.6/site-packages/determined/exec/harness.py", line 211, in main build_and_run_training_pipeline(env) File "/run/determined/pythonuserbase/lib/python3.6/site-packages/determined/exec/harness.py", line 134, in build_and_run_training_pipeline subproc.run() File "/run/determined/pythonuserbase/lib/python3.6/site-packages/determined/layers/_worker_process.py", line 255, in run response_func(self._send_recv_workload(wkld, args)) File "/run/determined/pythonuserbase/lib/python3.6/site-packages/determined/layers/_workload_manager.py", line 206, in _respond searcher_metric, list(v_metrics.keys()) AssertionError: Search method is configured to use metric 'val_accuracy' but model definition returned validation metrics ['val_loss', 'val_acc']. The metric used by the search method must be one of the validation metrics returned by the model definition.
Expand all | Collapse all
```


## Test Plan



## Commentary (optional)


<!-- User-facing API changes need the "User-facing API Change" label -->

<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

## Description

Lead with the intended commit body in this description field. For breaking changes, please include "BREAKING CHANGE:" at the beginning of your commit body. At minimum, this section should include a bracketed reference to the Jira ticket, e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.

## Test Plan

Describe the situations in which you've tested your change, and/or a screenshot as appropriate. Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.

## Commentary (optional)

Use this section of your description to add context to the PR. Could be for particularly tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc. You may intentionally leave this section blank and remove the title.
--->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234