### PR TITLE
feat: get checkpoints for experiment endpoint

### DIFF
--- a/common/determined_common/experimental/checkpoint/__init__.py
+++ b/common/determined_common/experimental/checkpoint/__init__.py
@@ -1,1 +1,1 @@
-from determined_common.experimental.checkpoint._checkpoint import Checkpoint
+from determined_common.experimental.checkpoint._checkpoint import Checkpoint, CheckpointState

--- a/common/determined_common/experimental/checkpoint/_checkpoint.py
+++ b/common/determined_common/experimental/checkpoint/_checkpoint.py
@@ -13,6 +13,14 @@ class ModelFramework(enum.Enum):
     TENSORFLOW = 2
 
 
+class CheckpointState(enum.Enum):
+    UNSPECIFIED = 0
+    ACTIVE = 1
+    COMPLETED = 2
+    ERROR = 3
+    DELETED = 4
+
+
 class Checkpoint(object):
     """
     Class representing a checkpoint. Contains methods for downloading

--- a/common/determined_common/experimental/experiment.py
+++ b/common/determined_common/experimental/experiment.py
@@ -79,7 +79,7 @@ class ExperimentReference:
         )
         checkpoints = r.json()["checkpoints"]
 
-        if not r:
+        if not checkpoints:
             raise AssertionError("No checkpoint found for trial {}".format(self.id))
 
         if not sort_by:

--- a/common/determined_common/experimental/experiment.py
+++ b/common/determined_common/experimental/experiment.py
@@ -93,9 +93,9 @@ class ExperimentReference:
         # Ensure returned checkpoints are from distinct trials.
         t_ids = set()
         checkpoint_refs = []
-        for ckpt in checkpoints[:limit]:
+        for ckpt in checkpoints:
             if ckpt["trialId"] not in t_ids:
                 checkpoint_refs.append(checkpoint.Checkpoint.from_json(ckpt, self._master))
                 t_ids.add(ckpt["trialId"])
 
-        return checkpoint_refs
+        return checkpoint_refs[:limit]

--- a/e2e_tests/tests/test_system.py
+++ b/e2e_tests/tests/test_system.py
@@ -357,7 +357,7 @@ def test_end_to_end_adaptive() -> None:
     assert top_2_uuids == top_k_uuids[:2]
 
     # Check that metrics are truly in sorted order.
-    metrics = [c.validation["metrics"]["validation_metrics"]["validation_loss"] for c in top_k]
+    metrics = [c.validation["metrics"]["validationMetrics"]["validation_loss"] for c in top_k]
 
     assert metrics == sorted(metrics)
 

--- a/examples/official/trial/mnist_pytorch/const.yaml
+++ b/examples/official/trial/mnist_pytorch/const.yaml
@@ -13,6 +13,11 @@ searcher:
   name: single
   metric: validation_loss
   max_length:
-    epochs: 1
+    batches: 800
   smaller_is_better: true
 entrypoint: model_def:MNistTrial
+min_checkpoint_period:
+  batches: 100
+min_validation_period:
+  batches: 200
+max_restarts: 0

--- a/examples/official/trial/mnist_pytorch/const.yaml
+++ b/examples/official/trial/mnist_pytorch/const.yaml
@@ -13,11 +13,6 @@ searcher:
   name: single
   metric: validation_loss
   max_length:
-    batches: 800
+    epochs: 1
   smaller_is_better: true
 entrypoint: model_def:MNistTrial
-min_checkpoint_period:
-  batches: 100
-min_validation_period:
-  batches: 200
-max_restarts: 0

--- a/master/internal/api_experiment.go
+++ b/master/internal/api_experiment.go
@@ -12,11 +12,13 @@ import (
 
 	"github.com/pkg/errors"
 
+	"github.com/determined-ai/determined/master/internal/db"
 	"github.com/determined-ai/determined/master/pkg/actor"
 	"github.com/determined-ai/determined/master/pkg/check"
 	"github.com/determined-ai/determined/master/pkg/model"
 	"github.com/determined-ai/determined/master/pkg/searcher"
 	"github.com/determined-ai/determined/proto/pkg/apiv1"
+	"github.com/determined-ai/determined/proto/pkg/checkpointv1"
 	"github.com/determined-ai/determined/proto/pkg/experimentv1"
 )
 
@@ -226,4 +228,62 @@ func (a *apiServer) KillExperiment(
 		return &apiv1.KillExperimentResponse{}, nil
 	}
 	return resp, err
+}
+
+func (a *apiServer) GetExperimentCheckpoints(
+	ctx context.Context, req *apiv1.GetExperimentCheckpointsRequest,
+) (*apiv1.GetExperimentCheckpointsResponse, error) {
+	ok, err := a.m.db.CheckExperimentExists(int(req.Id))
+	switch {
+	case err != nil:
+		return nil, status.Errorf(codes.Internal, "failed to check if experiment exists: %s", err)
+	case !ok:
+		return nil, status.Errorf(codes.NotFound, "experiment %d not found", req.Id)
+	}
+
+	resp := &apiv1.GetExperimentCheckpointsResponse{}
+	resp.Checkpoints = []*checkpointv1.Checkpoint{}
+	switch err := a.m.db.QueryProto("get_checkpoints_for_experiment", &resp.Checkpoints, req.Id); {
+	case err == db.ErrNotFound:
+		return nil, status.Errorf(
+			codes.NotFound, "no checkpoints found for experiment %d", req.Id)
+	case err != nil:
+		return nil,
+			errors.Wrapf(err, "error fetching checkpoints for experiment %d from database", req.Id)
+	}
+
+	a.filter(&resp.Checkpoints, func(i int) bool {
+		v := resp.Checkpoints[i]
+		fmt.Printf("v.State = %+v\n", v.State)
+
+		found := false
+		for _, state := range req.States {
+			if state == v.State {
+				found = true
+				break
+			}
+		}
+
+		if len(req.States) != 0 && !found {
+			return false
+		}
+
+		found = false
+		for _, state := range req.ValidationStates {
+			if state == v.ValidationState {
+				found = true
+				break
+			}
+		}
+
+		if len(req.ValidationStates) != 0 && !found {
+			return false
+		}
+
+		return true
+	})
+
+	a.sort(
+		resp.Checkpoints, req.OrderBy, req.SortBy, apiv1.GetExperimentCheckpointsRequest_SORT_BY_TRIAL_ID)
+	return resp, a.paginate(&resp.Pagination, &resp.Checkpoints, req.Offset, req.Limit)
 }

--- a/master/internal/api_experiment.go
+++ b/master/internal/api_experiment.go
@@ -254,7 +254,6 @@ func (a *apiServer) GetExperimentCheckpoints(
 
 	a.filter(&resp.Checkpoints, func(i int) bool {
 		v := resp.Checkpoints[i]
-		fmt.Printf("v.State = %+v\n", v.State)
 
 		found := false
 		for _, state := range req.States {

--- a/master/internal/api_model.go
+++ b/master/internal/api_model.go
@@ -150,7 +150,7 @@ func (a *apiServer) PostModelVersion(
 		return nil, getCheckpointErr
 	}
 
-	if c.State != checkpointv1.Checkpoint_STATE_COMPLETED {
+	if c.State != checkpointv1.State_STATE_COMPLETED {
 		return nil, errors.Errorf(
 			"checkpoint %s is in %s state. checkpoints for model versions must be in a COMPLETED state",
 			c.Uuid, c.State,

--- a/master/static/srv/get_checkpoints_for_experiment.sql
+++ b/master/static/srv/get_checkpoints_for_experiment.sql
@@ -1,5 +1,6 @@
 SELECT
-    c.uuid AS uuid,
+    c.uuid::text AS uuid,
+    'STATE_' || c.state AS state,
     e.config AS experiment_config,
     e.id AS  experiment_id,
     t.id AS trial_id,
@@ -13,11 +14,11 @@ SELECT
     COALESCE(c.format, '') as format,
     COALESCE(c.determined_version, '') as determined_version,
     v.metrics AS metrics,
-    v.state AS validation_state
+    'STATE_' || v.state AS validation_state
 FROM checkpoints c
 JOIN steps s ON c.step_id = s.id AND c.trial_id = s.trial_id
-JOIN validations v ON v.step_id = s.id AND v.trial_id = s.trial_id
+LEFT JOIN validations v ON v.step_id = s.id AND v.trial_id = s.trial_id
 JOIN trials t ON s.trial_id = t.id
 JOIN experiments e ON t.experiment_id = e.id
-WHERE e.id = $1 AND c.state = 'COMPLETED' AND v.state = 'COMPLETED'
+WHERE e.id = $1
 ORDER BY start_time DESC

--- a/master/static/srv/get_checkpoints_for_experiment.sql
+++ b/master/static/srv/get_checkpoints_for_experiment.sql
@@ -1,4 +1,6 @@
 SELECT
+    /* We need to cast uuid to text here otherwise the db.QueryProto method
+       will try to deserialize the uuid as a []byte and parse it into json. */
     c.uuid::text AS uuid,
     'STATE_' || c.state AS state,
     e.config AS experiment_config,

--- a/proto/src/determined/api/v1/api.proto
+++ b/proto/src/determined/api/v1/api.proto
@@ -158,6 +158,12 @@ service Determined {
         option (grpc.gateway.protoc_gen_swagger.options.openapiv2_operation) = {tags: "Experiments"};
     }
 
+    // Get a list of checkpoints for an experiment.
+    rpc GetExperimentCheckpoints(GetExperimentCheckpointsRequest) returns (GetExperimentCheckpointsResponse) {
+        option (google.api.http) = {get: "/api/v1/experiments/{id}/checkpoints" };
+        option (grpc.gateway.protoc_gen_swagger.options.openapiv2_operation) = {tags: "Experiments"};
+    }
+
     // Preview hyperparameter search.
     rpc PreviewHPSearch(PreviewHPSearchRequest) returns (PreviewHPSearchResponse) {
         option (google.api.http) = {post: "/api/v1/preview-hp-search" body: "*"};

--- a/proto/src/determined/api/v1/experiment.proto
+++ b/proto/src/determined/api/v1/experiment.proto
@@ -7,6 +7,7 @@ import "google/protobuf/wrappers.proto";
 import "google/protobuf/struct.proto";
 
 import "determined/api/v1/pagination.proto";
+import "determined/checkpoint/v1/checkpoint.proto";
 import "determined/experiment/v1/experiment.proto";
 import "determined/experiment/v1/searcher.proto";
 
@@ -109,3 +110,49 @@ message KillExperimentRequest {
 message KillExperimentResponse {
 }
 
+// Get a list of checkpoints for an experiment.
+message GetExperimentCheckpointsRequest {
+    // Sorts experiments by the given field.
+    enum SortBy {
+        // Returns checkpoints in an unsorted list.
+        SORT_BY_UNSPECIFIED = 0;
+        // Returns checkpoints sorted by UUID.
+        SORT_BY_UUID = 1;
+        // Returns checkpoints sorted by trial id.
+        SORT_BY_TRIAL_ID = 4;
+        // Returns checkpoints sorted by batch number.
+        SORT_BY_BATCH_NUMBER = 6;
+        // Returns checkpoints sorted by start time.
+        SORT_BY_START_TIME = 7;
+        // Returns checkpoints sorted by end time.
+        SORT_BY_END_TIME = 8;
+        // Returns checkpoints sorted by validation state.
+        SORT_BY_VALIDATION_STATE = 15;
+        // Returns checkpoints sorted by state.
+        SORT_BY_STATE = 16;
+    }
+    // The experiment id.
+    int32 id = 1;
+    // Sort checkpoints by the given field
+    SortBy sort_by = 2;
+    // Order checkpoints in either ascending or descending order.
+    OrderBy order_by = 3;
+    // Skip the number of checkpoints before returning results. Negative values
+    // denote number of checkpoints to skip from the end before returning results.
+    int32 offset = 4;
+    // Limit the number of experiments. A value of 0 denotes no limit.
+    int32 limit = 5;
+
+    // Limit the checkpoints to those that match the validation states.
+    repeated determined.checkpoint.v1.State validation_states = 6;
+    // Limit the checkpoints to those that match the states.
+    repeated determined.checkpoint.v1.State states = 7;
+}
+
+// Response to GetExperimentCheckpointsRequest.
+message GetExperimentCheckpointsResponse {
+  // The list of returned checkpoints.
+  repeated determined.checkpoint.v1.Checkpoint checkpoints = 1;
+  // Pagination information of the full dataset.
+  Pagination pagination = 2;
+}

--- a/proto/src/determined/api/v1/experiment.proto
+++ b/proto/src/determined/api/v1/experiment.proto
@@ -112,7 +112,7 @@ message KillExperimentResponse {
 
 // Get a list of checkpoints for an experiment.
 message GetExperimentCheckpointsRequest {
-    // Sorts experiments by the given field.
+    // Sorts checkpoints by the given field.
     enum SortBy {
         // Returns checkpoints in an unsorted list.
         SORT_BY_UNSPECIFIED = 0;
@@ -140,7 +140,7 @@ message GetExperimentCheckpointsRequest {
     // Skip the number of checkpoints before returning results. Negative values
     // denote number of checkpoints to skip from the end before returning results.
     int32 offset = 4;
-    // Limit the number of experiments. A value of 0 denotes no limit.
+    // Limit the number of checkpoints. A value of 0 denotes no limit.
     int32 limit = 5;
 
     // Limit the checkpoints to those that match the validation states.

--- a/proto/src/determined/checkpoint/v1/checkpoint.proto
+++ b/proto/src/determined/checkpoint/v1/checkpoint.proto
@@ -15,6 +15,20 @@ message Metrics {
   map<string, float> validation_metrics = 2;
 }
 
+// The current state of the checkpoint.
+enum State {
+  // The state of the checkpoint is unknown.
+  STATE_UNSPECIFIED = 0;
+  // The checkpoint is in an active state.
+  STATE_ACTIVE = 1;
+  // The checkpoint is persisted to checkpoint storage.
+  STATE_COMPLETED = 2;
+  // The checkpoint errored.
+  STATE_ERROR = 3;
+  // The checkpoint has been deleted.
+  STATE_DELETED = 4;
+}
+
 // Checkpoint is an artifact created by a trial during training.
 message Checkpoint {
   option (grpc.gateway.protoc_gen_swagger.options.openapiv2_schema) = {
@@ -22,19 +36,6 @@ message Checkpoint {
           required: ["uuid", "state"]
       }
   };
-  // The current state of the checkpoint.
-  enum State {
-    // The state of the checkpoint is unknown.
-    STATE_UNSPECIFIED = 0;
-    // The checkpoint is in an active state.
-    STATE_ACTIVE = 1;
-    // The checkpoint is persisted to checkpoint storage.
-    STATE_COMPLETED = 2;
-    // The checkpoint errored.
-    STATE_ERROR = 3;
-    // The checkpoint has been deleted.
-    STATE_DELETED = 4;
-  }
   // UUID of the checkpoint.
   string uuid = 1;
   // The configuration of the experiment that created this checkpoint.


### PR DESCRIPTION
## Description

adds `/api/v1/experiments/id/checkpoints` which returns the checkpoints for an experiment.

## Test Plan
Coverage via checkpoint export integration tests.


## Commentary (optional)
This will be accompanied by the same endpoint for trials to complete DET-3735