### PR TITLE
feat: make agent's TLS verification level configurable [DET-3774]

### DIFF
--- a/agent/cmd/determined-agent/run.go
+++ b/agent/cmd/determined-agent/run.go
@@ -10,6 +10,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/determined-ai/determined/agent/internal"
+	"github.com/determined-ai/determined/master/pkg/check"
 )
 
 const defaultConfigPath = "/etc/determined/agent.yaml"
@@ -52,23 +53,20 @@ func newRunCmd() *cobra.Command {
 		if err = yaml.Unmarshal(bs, &opts, yaml.DisallowUnknownFields); err != nil {
 			return errors.Wrap(err, "cannot unmarshal configuration")
 		}
-		if err := bindEnv("DET_", cmd); err != nil {
+		if err = bindEnv("DET_", cmd); err != nil {
 			return err
 		}
 
 		if opts.AgentID == "" {
-			hostname, err := os.Hostname()
-			if err != nil {
-				return err
+			hostname, hErr := os.Hostname()
+			if hErr != nil {
+				return hErr
 			}
 			opts.AgentID = hostname
 		}
 
-		// TODO: Migrate to the check library.
-		for _, err := range opts.Validate() {
-			if err != nil {
-				return errors.Wrap(err, "command-line arguments specify illegal configuration")
-			}
+		if err = check.Validate(opts); err != nil {
+			return errors.Wrap(err, "command-line arguments specify illegal configuration")
 		}
 
 		if err := internal.Run(version, opts); err != nil {
@@ -89,11 +87,6 @@ func newRunCmd() *cobra.Command {
 	cmd.Flags().StringVar(&opts.Label, "label", "",
 		"Label attached to the agent for scheduling constraints")
 
-	// TLS flags.
-	cmd.Flags().BoolVar(&opts.TLS, "tls", false, "Use TLS for all connections")
-	cmd.Flags().StringVar(&opts.CertFile, "tls-cert", "", "Path to TLS certificate file")
-	cmd.Flags().StringVar(&opts.KeyFile, "tls-key", "", "Path to TLS key file")
-
 	// Container flags.
 	cmd.Flags().StringVar(&opts.ContainerMasterHost, "container-master-host", "",
 		"Hostname of the master that the container connect to")
@@ -103,9 +96,27 @@ func newRunCmd() *cobra.Command {
 	// Device flags.
 	cmd.Flags().StringVar(&opts.VisibleGPUs, "visible-gpus", "", "GPUs to expose as slots")
 
+	// Security flags.
+	cmd.Flags().BoolVar(
+		&opts.Security.TLS.Enabled, "security-tls-enabled", false,
+		"Whether to use TLS to connect to the master",
+	)
+	cmd.Flags().BoolVar(
+		&opts.Security.TLS.SkipVerify, "security-tls-skip-verify", false,
+		"Whether to skip verifying the master certificate when TLS is on (insecure!)",
+	)
+	cmd.Flags().StringVar(
+		&opts.Security.TLS.MasterCert, "security-tls-master-cert", "", "CA cert file for the master",
+	)
+
 	// Debug flags.
 	cmd.Flags().IntVar(&opts.ArtificialSlots, "artificial-slots", 0, "")
 	cmd.Flags().Lookup("artificial-slots").Hidden = true
+
+	// Endpoint TLS flags.
+	cmd.Flags().BoolVar(&opts.TLS, "tls", false, "Use TLS for the API server")
+	cmd.Flags().StringVar(&opts.CertFile, "tls-cert", "", "Path to TLS certificate file")
+	cmd.Flags().StringVar(&opts.KeyFile, "tls-key", "", "Path to TLS key file")
 
 	// Endpoint flags.
 	cmd.Flags().BoolVar(&opts.APIEnabled, "enable-api", false, "Enable agent API endpoints")

--- a/agent/internal/options.go
+++ b/agent/internal/options.go
@@ -34,6 +34,8 @@ type Options struct {
 	HTTPSProxy string `json:"https_proxy"`
 	FTPProxy   string `json:"ftp_proxy"`
 	NoProxy    string `json:"no_proxy"`
+
+	Security SecurityOptions `json:"security"`
 }
 
 // Validate validates the state of the Options struct.
@@ -63,4 +65,25 @@ func (o Options) Printable() ([]byte, error) {
 		return nil, errors.Wrap(err, "unable to convert config to JSON")
 	}
 	return optJSON, nil
+}
+
+// SecurityOptions stores configurable security-related options.
+type SecurityOptions struct {
+	TLS TLSOptions `json:"tls"`
+}
+
+// TLSOptions is the TLS connection configuration for the agent.
+type TLSOptions struct {
+	Enabled    bool   `json:"enabled"`
+	SkipVerify bool   `json:"skip_verify"`
+	MasterCert string `json:"master_cert"`
+}
+
+// Validate implements the check.Validatable interface.
+func (t TLSOptions) Validate() []error {
+	var errs []error
+	if t.MasterCert != "" && t.SkipVerify {
+		errs = append(errs, errors.New("cannot specify a master cert file with verification off"))
+	}
+	return errs
 }


### PR DESCRIPTION
## Description

This enhances the agent's configuration regarding use of TLS on the
master connection to better support a range of deployment scenarios:

- Verification can be turned on or off.
- A custom CA certificate chain can be specified.
- TLS can be toggled separately from TLS for the agent's own API.

This technically makes the agent config/CLI options
backward-incompatble; part of the previous `--tls` option is now
splitting into `--security-tls-enabled`. However, it is unlikely that
anyone was using that, since the system cannot currently be run fully
over TLS anyway.

## Test Plan

- [x] make non-TLS connection with default agent settings (connection succeeds)
- [x] make TLS connection with self-signed cert and the agent using `--security-tls-enabled` (connection fails)
- [x] make TLS connection with self-signed cert and the agent using `--security-tls-enabled` and `--security-tls-skip-verify` (connection succeeds)
- [x] make TLS connection with self-signed cert and the agent using `--security-tls-enabled` and `--security-tls-master-cert=<path to cert file>` (connection succeeds)
- [x] make TLS connection with real CA-signed cert and the agent using `--security-tls-enabled` (connection succeeds)
- [x] make TLS connection with real CA-signed cert and the agent using `--security-tls-enabled` and `--security-tls-master-cert=<path to file not containing certs that verify the master certs>` (connection fails)
- [x] make TLS connection with real CA-signed cert and the agent using `--security-tls-enabled` and `--security-tls-master-cert=<path to cert file>` (connection succeeds)

- [x] check that agent rejects various malformed cert files

## Commentary

The names for the CLI options are a bit long, but they conform to our usual pattern; I could remove a layer of nesting in the config structs and drop the `security-` from the options, but the current way matches the master.

This change isn't exactly useful by itself in practice, since the harness can't use TLS yet (and I'm not going to bother making it possible for the agent to use TLS while the harness does not). But, codewise, this is quite separate from the harness changes and can be tested and used by itself if you don't actually need to run anything, so here it is. I've also successfully run full experiments over TLS using a prototype version of TLS for the harness anyway, so there should be no issues there.