### PR TITLE
feat: get checkpoints for trial endpoint [DET-3735]

### DIFF
--- a/master/static/srv/get_checkpoints_for_trial.sql
+++ b/master/static/srv/get_checkpoints_for_trial.sql
@@ -1,5 +1,6 @@
 SELECT
-    c.uuid AS uuid,
+    c.uuid::text AS uuid,
+    'STATE_' || c.state AS state,
     e.config AS experiment_config,
     e.id AS  experiment_id,
     t.id AS trial_id,
@@ -13,7 +14,7 @@ SELECT
     COALESCE(c.format, '') as format,
     COALESCE(c.determined_version, '') as determined_version,
     v.metrics AS metrics,
-    v.state AS validation_state
+    'STATE_' || v.state AS validation_state
 FROM checkpoints c
 JOIN steps s ON c.step_id = s.id AND c.trial_id = s.trial_id
 LEFT JOIN validations v ON v.step_id = s.id AND v.trial_id = s.trial_id

--- a/proto/src/determined/api/v1/api.proto
+++ b/proto/src/determined/api/v1/api.proto
@@ -175,6 +175,12 @@ service Determined {
         option (grpc.gateway.protoc_gen_swagger.options.openapiv2_operation) = {tags: "Experiments"};
     }
 
+    // Get a list of checkpoints for a trial.
+    rpc GetTrialCheckpoints(GetTrialCheckpointsRequest) returns (GetTrialCheckpointsResponse) {
+      option (google.api.http) = {get: "/api/v1/trials/{id}/checkpoints"};
+      option (grpc.gateway.protoc_gen_swagger.options.openapiv2_operation) = {tags: "Experiments"};
+    }
+
     // Get a list of templates.
     rpc GetTemplates(GetTemplatesRequest) returns (GetTemplatesResponse) {
         option (google.api.http) = {get: "/api/v1/templates"};

--- a/proto/src/determined/api/v1/trial.proto
+++ b/proto/src/determined/api/v1/trial.proto
@@ -3,6 +3,9 @@ syntax = "proto3";
 package determined.api.v1;
 option go_package = "github.com/determined-ai/determined/proto/pkg/apiv1";
 
+import "determined/api/v1/pagination.proto";
+import "determined/checkpoint/v1/checkpoint.proto";
+
 // Stream Trial logs.
 message TrialLogsRequest {
     // The id of the trial.
@@ -21,4 +24,49 @@ message TrialLogsResponse {
     int32 id = 1;
     // The log message.
     string message = 2;
+}
+
+// Get a list of checkpoints for a trial.
+message GetTrialCheckpointsRequest {
+    // Sorts checkpoints by the given field.
+    enum SortBy {
+        // Returns checkpoints in an unsorted list.
+        SORT_BY_UNSPECIFIED = 0;
+        // Returns checkpoints sorted by UUID.
+        SORT_BY_UUID = 1;
+        // Returns checkpoints sorted by batch number.
+        SORT_BY_BATCH_NUMBER = 6;
+        // Returns checkpoints sorted by start time.
+        SORT_BY_START_TIME = 7;
+        // Returns checkpoints sorted by end time.
+        SORT_BY_END_TIME = 8;
+        // Returns checkpoints sorted by validation state.
+        SORT_BY_VALIDATION_STATE = 15;
+        // Returns checkpoints sorted by state.
+        SORT_BY_STATE = 16;
+    }
+    // The trial id.
+    int32 id = 1;
+    // Sort checkpoints by the given field
+    SortBy sort_by = 2;
+    // Order checkpoints in either ascending or descending order.
+    OrderBy order_by = 3;
+    // Skip the number of checkpoints before returning results. Negative values
+    // denote number of checkpoints to skip from the end before returning results.
+    int32 offset = 4;
+    // Limit the number of checkpoints. A value of 0 denotes no limit.
+    int32 limit = 5;
+
+    // Limit the checkpoints to those that match the validation states.
+    repeated determined.checkpoint.v1.State validation_states = 6;
+    // Limit the checkpoints to those that match the states.
+    repeated determined.checkpoint.v1.State states = 7;
+}
+
+// Response to GetTrialCheckpointsRequest.
+message GetTrialCheckpointsResponse {
+    // The list of returned checkpoints.
+    repeated determined.checkpoint.v1.Checkpoint checkpoints = 1;
+    // Pagination information of the full dataset.
+    Pagination pagination = 2;
 }


### PR DESCRIPTION
## Description
Adds `/api/v1/trials/id/checkpoints` which returns a list of checkpoints for the given trial.


## Test Plan
Checkpoint export APIs use the new endpoint and therefore existing test cases provide coverage.


## Commentary (optional)
Depends on #1046 