### PR TITLE
fix: proxy shell through master via HTTP CONNECT

### DIFF
--- a/cli/determined_cli/tunnel.py
+++ b/cli/determined_cli/tunnel.py
@@ -1,0 +1,97 @@
+"""
+tunnel.py will tunnel a TCP connection through Determined master at MASTER_ADDR to SERVICE_UUID.
+
+This is used to tunnel ssh connections through the master, where the hostname in the SERVICE_UUID
+should be the shell ID of the shell in question.
+"""
+
+import http.client
+import os
+import socket
+import ssl
+import sys
+import threading
+from typing import Optional
+
+from determined_common.api import request
+
+
+class Copier(threading.Thread):
+    """
+    A thread to copy from one file descriptor to another.  Only copies in one direction; use two
+    threads to deal with bidirectional file descriptors.  The choice to use a pair of threads as
+    opposed to select.select or select.poll ensures that this code will run nicely on Windows.
+    """
+
+    def __init__(self, src: int, dst: int):
+        super().__init__()
+        self.src = src
+        self.dst = dst
+
+    def run(self) -> None:
+        try:
+            while True:
+                try:
+                    buf = os.read(self.src, 4096)
+                except OSError:
+                    break
+                if not buf:
+                    break
+                try:
+                    os.write(self.dst, buf)
+                except OSError:
+                    break
+        finally:
+            # We're ok with double-closing some sockets.
+            try:
+                os.close(self.src)
+            except OSError:
+                pass
+
+            try:
+                os.close(self.dst)
+            except OSError:
+                pass
+
+
+def http_connect_tunnel(master: str, service: str, master_cert: Optional[str]) -> None:
+    parsed_master = request.parse_master_address(master)
+    assert parsed_master.hostname is not None, "Failed to parse master address: {}".format(master)
+
+    if parsed_master.scheme == "https":
+        context = ssl.create_default_context(cafile=master_cert)
+        client = http.client.HTTPSConnection(
+            parsed_master.hostname, parsed_master.port, context=context
+        )  # type: http.client.HTTPConnection
+    else:
+        client = http.client.HTTPConnection(parsed_master.hostname, parsed_master.port)
+
+    client.set_tunnel(service)
+
+    try:
+        client.connect()
+    except socket.gaierror:
+        print("failed to look up host:", master, file=sys.stderr)
+        raise
+
+    with client.sock as sock:
+        c1 = Copier(sock.fileno(), sys.stdout.fileno())
+        c2 = Copier(sys.stdin.fileno(), sock.fileno())
+        c1.start()
+        c2.start()
+        c1.join()
+        c2.join()
+
+
+if __name__ == "__main__":
+    if len(sys.argv) not in (3, 4):
+        print(
+            "usage: {} MASTER_ADDR SERVICE_UUID [MASTER_CERT]".format(sys.argv[0]), file=sys.stderr
+        )
+        sys.exit(1)
+
+    master = sys.argv[1]
+    service = sys.argv[2]
+    master_cert = None if len(sys.argv) < 4 else sys.argv[3]
+
+    http_connect_tunnel(master, service, master_cert)

--- a/common/determined_common/api/request.py
+++ b/common/determined_common/api/request.py
@@ -18,6 +18,10 @@ def set_master_cert_bundle(path: str) -> None:
     _master_cert_bundle = path
 
 
+def get_master_cert_bundle() -> Optional[str]:
+    return _master_cert_bundle
+
+
 def parse_master_address(master_address: str) -> parse.ParseResult:
     if master_address.startswith("https://"):
         default_port = 443

--- a/e2e_tests/tests/command/test_shell.py
+++ b/e2e_tests/tests/command/test_shell.py
@@ -8,11 +8,8 @@ from tests import command as cmd
 @pytest.mark.slow  # type: ignore
 @pytest.mark.e2e_gpu  # type: ignore
 def test_start_and_write_to_shell(tmp_path: Path) -> None:
-    pytest.skip("This is an extremely flaky test that needs to be rewritten")
-    """Start a shell, extract its task ID, and then kill it."""
-
     with cmd.interactive_command("shell", "start") as shell:
-        shell.stdin.write(b"echo hello world")
+        shell.stdin.write(b"echo hello world\n")
         shell.stdin.close()
 
         for line in shell.stdout:

--- a/e2e_tests/tests/test_users.py
+++ b/e2e_tests/tests/test_users.py
@@ -602,3 +602,20 @@ def test_link_without_agent_user(auth: Authentication) -> None:
                 break
         else:
             raise AssertionError(f"Did not find {expected_output} in output")
+
+
+@pytest.mark.e2e_cpu  # type: ignore
+def test_non_root_shell(auth: Authentication, tmp_path: pathlib.Path) -> None:
+    user = create_linked_user(1234, "someuser", 1234, "somegroup")
+
+    expected_output = "someuser:1234:somegroup:1234"
+
+    with logged_in_user(user), command.interactive_command("shell", "start") as shell:
+        shell.stdin.write(b"echo $(id -u -n):$(id -u):$(id -g -n):$(id -g)\n")
+        shell.stdin.close()
+
+        for line in shell.stdout:
+            if expected_output in line:
+                break
+        else:
+            raise AssertionError(f"Did not find {expected_output} in output")

--- a/master/internal/command/shell_manager.go
+++ b/master/internal/command/shell_manager.go
@@ -126,6 +126,10 @@ func (n *shellManager) newShell(
 			petname.Generate(model.TaskNameGeneratorWords, model.TaskNameGeneratorSep),
 		)
 	}
+
+	taskID := scheduler.NewTaskID()
+	serviceAddress := fmt.Sprintf("/proxy/%s/", taskID)
+
 	config.Environment.Ports = shellPorts
 	config.Entrypoint = shellEntrypoint
 
@@ -149,7 +153,7 @@ func (n *shellManager) newShell(
 	}
 
 	return &command{
-		taskID:          scheduler.NewTaskID(),
+		taskID:          taskID,
 		config:          config,
 		userFiles:       req.UserFiles,
 		additionalFiles: additionalFiles,
@@ -158,6 +162,7 @@ func (n *shellManager) newShell(
 			"publicKey":  string(keyPair.PublicKey),
 		},
 
+		serviceAddress: &serviceAddress,
 		owner:          req.Owner,
 		agentUserGroup: req.AgentUserGroup,
 	}

--- a/master/internal/core.go
+++ b/master/internal/core.go
@@ -561,8 +561,11 @@ func (m *Master) Run() error {
 	m.echo.Any("/debug/pprof/symbol", echo.WrapHandler(http.HandlerFunc(pprof.Symbol)))
 	m.echo.Any("/debug/pprof/trace", echo.WrapHandler(http.HandlerFunc(pprof.Trace)))
 
-	handler := m.system.AskAt(actor.Addr("proxy"), proxy.NewHandler{ServiceKey: "service"})
+	handler := m.system.AskAt(actor.Addr("proxy"), proxy.NewProxyHandler{ServiceKey: "service"})
 	m.echo.Any("/proxy/:service/*", handler.Get().(echo.HandlerFunc))
+
+	handler = m.system.AskAt(actor.Addr("proxy"), proxy.NewConnectHandler{})
+	m.echo.CONNECT("*", handler.Get().(echo.HandlerFunc))
 
 	user.RegisterAPIHandler(m.echo, userService, authFuncs...)
 	command.RegisterAPIHandler(


### PR DESCRIPTION
## Description

Add a CONNECT handler to our Echo framework.  The new handler is part of
the old proxy, which now supports proxying raw TCP trafic as well as
HTTP and websocket traffic.  The tunneled traffic is plaintext
naturally, but it is TLS-encrypted between master and client if
connecting to the master over TLS, and it is also end-to-end
ssh-encrypted for all `det shell` traffic.

Introduce an executable determined_cli.tunnel module, which will tunnel
its stdin and stdout through an HTTP CONNECT proxy, exactly the way
`nc -X CONNECT -x` would work, but without introducing an external
dependency on netcat.

Fix `det shell` to add a ProxyCommand="..." option to the ssh invocation
so that ssh calls the determined_cli.tunnel tool to tunnel traffic
though the master.

This fix allows shells to work in cloud environments.

## Test Plan

Re-enable the old e2e test for determined shell, which is marked as a
GPU test so it will execute in a cloud context.

Add a new CPU e2e test for nonroot shell support.