### PR TITLE
feat: allow the harness to connect to the master over TLS [DET-3775]

### DIFF
--- a/harness/determined/_env_context.py
+++ b/harness/determined/_env_context.py
@@ -11,6 +11,8 @@ class EnvContext:
         self,
         master_addr: str,
         master_port: int,
+        use_tls: bool,
+        master_cert_file: Optional[str],
         container_id: str,
         experiment_config: Dict[str, Any],
         hparams: Dict[str, Any],
@@ -31,6 +33,8 @@ class EnvContext:
     ):
         self.master_addr = master_addr
         self.master_port = master_port
+        self.use_tls = use_tls
+        self.master_cert_file = master_cert_file
         self.container_id = container_id
         self.experiment_config = det.ExperimentConfig(experiment_config)
         self.hparams = hparams

--- a/harness/determined/_local_execution.py
+++ b/harness/determined/_local_execution.py
@@ -58,6 +58,8 @@ def _make_local_execution_env(
     env = det.EnvContext(
         master_addr="",
         master_port=0,
+        use_tls=False,
+        master_cert_file=None,
         container_id="",
         experiment_config=config,
         hparams=hparams,

--- a/harness/determined/exec/harness.py
+++ b/harness/determined/exec/harness.py
@@ -157,6 +157,8 @@ def main() -> None:
 
     master_addr = os.environ["DET_MASTER_ADDR"]
     master_port = int(os.environ["DET_MASTER_PORT"])
+    use_tls = distutils.util.strtobool(os.environ.get("DET_USE_TLS", "false"))
+    master_cert_file = os.environ.get("DET_MASTER_CERT_FILE")
     agent_id = os.environ["DET_AGENT_ID"]
     container_id = os.environ["DET_CONTAINER_ID"]
     hparams = simplejson.loads(os.environ["DET_HPARAMS"])
@@ -177,6 +179,8 @@ def main() -> None:
     env = det.EnvContext(
         master_addr,
         master_port,
+        use_tls,
+        master_cert_file,
         container_id,
         experiment_config,
         hparams,

--- a/harness/tests/experiment/utils.py
+++ b/harness/tests/experiment/utils.py
@@ -121,6 +121,8 @@ def make_default_env_context(
         ),
         master_addr="",
         master_port=0,
+        use_tls=False,
+        master_cert_file=None,
         container_id="",
         hparams=hparams,
         latest_checkpoint=None,

--- a/harness/tests/tensorboard/test_util.py
+++ b/harness/tests/tensorboard/test_util.py
@@ -10,6 +10,8 @@ def get_dummy_env() -> det.EnvContext:
     return det.EnvContext(
         master_addr="",
         master_port=0,
+        use_tls=False,
+        master_cert_file=None,
         container_id="",
         experiment_config={"resources": {"slots_per_trial": 1, "native_parallel": False}},
         initial_workload=workload.Workload(

--- a/harness/tests/test_horovod.py
+++ b/harness/tests/test_horovod.py
@@ -22,6 +22,8 @@ def create_default_env_context(experiment_config: Dict[str, Any]) -> det.EnvCont
         ),
         master_addr="",
         master_port=0,
+        use_tls=False,
+        master_cert_file=None,
         container_id="",
         hparams={"global_batch_size": 32},
         latest_checkpoint=None,

--- a/master/internal/scheduler/resource_providers_test.go
+++ b/master/internal/scheduler/resource_providers_test.go
@@ -20,6 +20,7 @@ func TestResourceProviderForwardMessage(t *testing.T) {
 		model.TaskContainerDefaultsConfig{},
 		nil,
 		0,
+		nil,
 	))
 	assert.Assert(t, created)
 

--- a/master/internal/trial_test.go
+++ b/master/internal/trial_test.go
@@ -96,6 +96,7 @@ func TestRendezvousInfo(t *testing.T) {
 			model.TaskContainerDefaultsConfig{},
 			nil,
 			0,
+			nil,
 		))
 	if !created {
 		t.Fatal("unable to create cluster")

--- a/master/pkg/tasks/copy.go
+++ b/master/pkg/tasks/copy.go
@@ -2,6 +2,8 @@ package tasks
 
 import (
 	"archive/tar"
+	"crypto/tls"
+	"encoding/pem"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -65,6 +67,25 @@ func harnessArchive(harnessPath string, aug *model.AgentUserGroup) container.Run
 		})
 	}
 	return wrapArchive(aug.OwnArchive(harnessFiles), "/")
+}
+
+func masterCertArchive(cert *tls.Certificate) container.RunArchive {
+	var certBytes []byte
+	if cert != nil {
+		for _, c := range cert.Certificate {
+			b := pem.EncodeToMemory(&pem.Block{
+				Type:  "CERTIFICATE",
+				Bytes: c,
+			})
+			certBytes = append(certBytes, b...)
+		}
+	}
+
+	var arch archive.Archive
+	if len(certBytes) != 0 {
+		arch = append(arch, archive.RootItem(certPath, certBytes, 0600, tar.TypeReg))
+	}
+	return wrapArchive(arch, "/")
 }
 
 func wrapArchive(archive archive.Archive, path string) container.RunArchive {

--- a/master/pkg/tasks/task.go
+++ b/master/pkg/tasks/task.go
@@ -26,6 +26,7 @@ const (
 	passwdPath        = "/run/determined/etc/passwd"
 	shadowPath        = "/run/determined/etc/shadow"
 	groupPath         = "/run/determined/etc/group"
+	certPath          = "/run/determined/etc/ssl/master.crt"
 )
 
 func defaultEnvVars() map[string]string {
@@ -219,6 +220,11 @@ func TrialEnvVars(t TaskSpec, rendezvousPorts []string) map[string]string {
 	envVars["DET_RENDEZVOUS_PORTS"] = strings.Join(rendezvousPorts, ",")
 	envVars["DET_TRIAL_RUNNER_NETWORK_INTERFACE"] = networkInterface
 
+	if t.MasterCert != nil {
+		envVars["DET_USE_TLS"] = "true"
+		envVars["DET_MASTER_CERT_FILE"] = certPath
+	}
+
 	if t.TaskContainerDefaults.NCCLPortRange != "" {
 		envVars["NCCL_PORT_RANGE"] = t.TaskContainerDefaults.NCCLPortRange
 	}
@@ -239,6 +245,7 @@ func TrialArchives(t TaskSpec) []container.RunArchive {
 		wrapArchive(exp.AdditionalFiles, rootDir),
 		wrapArchive(exp.AgentUserGroup.OwnArchive(exp.ModelDefinition), ContainerWorkDir),
 		harnessArchive(t.HarnessPath, exp.AgentUserGroup),
+		masterCertArchive(t.MasterCert),
 	}
 }
 

--- a/master/pkg/tasks/task_spec.go
+++ b/master/pkg/tasks/task_spec.go
@@ -1,6 +1,7 @@
 package tasks
 
 import (
+	"crypto/tls"
 	"encoding/json"
 
 	"github.com/pkg/errors"
@@ -20,6 +21,7 @@ type TaskSpec struct {
 	Devices               []device.Device                   `json:"devices"`
 	HarnessPath           string                            `json:"harness_path"`
 	TaskContainerDefaults model.TaskContainerDefaultsConfig `json:"task_container_defaults"`
+	MasterCert            *tls.Certificate                  `json:"master_cert"`
 
 	StartCommand   *StartCommand   `union:"type,START_TASK" json:"-"`
 	StartContainer *StartContainer `union:"type,START_CONTAINER" json:"-"`


### PR DESCRIPTION
## Description

This change allows experiments to be run with all communication to the
master going over TLS.

Since the containers are spawned by the master itself, we don't need to
allow for verification to be skipped or have any separate manual
configuration; the master injects its own certificate into each
container spec, and the client code picks it up.

## Test Plan

- [x] run an experiment with the master not listening over TLS
- [x] run an experiment with the master listening only over TLS with a self-signed cert
- [x] run an experiment with the master listening only over TLS with a non-self-signed cert (and the full chain given to the master)

## Commentary (optional)

Technically, the separate "use TLS" and "master cert file" options in the harness are redundant, since currently they're only set at the same time. But making it that implicit feels like going a bit too far.

If you can come up with a better way to thread the cert from the master config down to the task specs, I'm all ears.

It would be nice to be able to place the cert in the container so that it's automatically picked up at a system level. I don't see a way to do that when we might not have root in the container, though.