### PR TITLE
fix: preserve rng state for all cloud access [DET-3810]

### DIFF
--- a/common/determined_common/storage/s3.py
+++ b/common/determined_common/storage/s3.py
@@ -6,7 +6,7 @@ from typing import Iterator, Optional
 
 import boto3
 
-import determined_common.util as util
+from determined_common import util
 from determined_common.storage.base import StorageManager, StorageMetadata
 
 
@@ -53,6 +53,7 @@ class S3StorageManager(StorageManager):
         finally:
             self._remove_checkpoint_directory(metadata.storage_id)
 
+    @util.preserve_random_state
     def upload(self, metadata: StorageMetadata, storage_dir: str) -> None:
         for rel_path in metadata.resources.keys():
             key_name = "{}/{}".format(metadata.storage_id, rel_path)
@@ -67,6 +68,7 @@ class S3StorageManager(StorageManager):
                 abs_path = os.path.join(storage_dir, rel_path)
                 self.client.upload_file(abs_path, self.bucket, key_name)
 
+    @util.preserve_random_state
     def download(self, metadata: StorageMetadata, storage_dir: str) -> None:
         for rel_path in metadata.resources.keys():
             abs_path = os.path.join(storage_dir, rel_path)
@@ -84,6 +86,7 @@ class S3StorageManager(StorageManager):
 
             self.client.download_file(self.bucket, key_name, abs_path)
 
+    @util.preserve_random_state
     def delete(self, metadata: StorageMetadata) -> None:
         logging.info("Deleting checkpoint {} from S3".format(metadata.storage_id))
 

--- a/common/determined_common/util.py
+++ b/common/determined_common/util.py
@@ -1,5 +1,7 @@
+import functools
 import os
-from typing import Iterator, Sequence, TypeVar, Union, overload
+import random
+from typing import Any, Callable, Iterator, Sequence, TypeVar, Union, overload
 
 T = TypeVar("T")
 
@@ -42,3 +44,17 @@ def get_default_master_address() -> str:
 
 def debug_mode() -> bool:
     return os.getenv("DET_DEBUG", "").lower() in ("true", "1", "yes")
+
+
+def preserve_random_state(fn: Callable) -> Callable:
+    """A decorator to run a function with a fork of the random state."""
+
+    @functools.wraps(fn)
+    def wrapped(*arg: Any, **kwarg: Any) -> Any:
+        state = random.getstate()
+        try:
+            return fn(*arg, **kwarg)
+        finally:
+            random.setstate(state)
+
+    return wrapped

--- a/harness/determined/tensorboard/gcs.py
+++ b/harness/determined/tensorboard/gcs.py
@@ -4,6 +4,7 @@ from typing import Any
 from google.cloud import storage
 
 from determined.tensorboard import base
+from determined_common import util
 
 
 class GCSTensorboardManager(base.TensorboardManager):
@@ -22,6 +23,7 @@ class GCSTensorboardManager(base.TensorboardManager):
         self.client = storage.Client()
         self.bucket = self.client.bucket(bucket)
 
+    @util.preserve_random_state
     def sync(self) -> None:
         for path in self.to_sync():
             blob_name = str(self.sync_path.joinpath(path.name))

--- a/harness/determined/tensorboard/hdfs.py
+++ b/harness/determined/tensorboard/hdfs.py
@@ -4,6 +4,7 @@ from typing import Any, Optional
 from hdfs.client import InsecureClient
 
 from determined.tensorboard import base
+from determined_common import util
 
 
 class HDFSTensorboardManager(base.TensorboardManager):
@@ -11,6 +12,7 @@ class HDFSTensorboardManager(base.TensorboardManager):
     Store and tfevents files to HDFS.
     """
 
+    @util.preserve_random_state
     def __init__(
         self, hdfs_url: str, hdfs_path: str, user: Optional[str] = None, *args: Any, **kwargs: Any,
     ) -> None:
@@ -22,6 +24,7 @@ class HDFSTensorboardManager(base.TensorboardManager):
         self.client = InsecureClient(self.hdfs_url, root=self.hdfs_path, user=self.user)
         self.client.makedirs(str(self.sync_path))
 
+    @util.preserve_random_state
     def sync(self) -> None:
         for path in self.to_sync():
             file_name = str(self.sync_path.joinpath(path.name))

--- a/harness/determined/tensorboard/s3.py
+++ b/harness/determined/tensorboard/s3.py
@@ -4,6 +4,7 @@ from typing import Any, Optional
 import boto3
 
 from determined.tensorboard import base
+from determined_common import util
 
 
 class S3TensorboardManager(base.TensorboardManager):
@@ -29,6 +30,7 @@ class S3TensorboardManager(base.TensorboardManager):
             aws_secret_access_key=secret_key,
         )
 
+    @util.preserve_random_state
     def sync(self) -> None:
         for path in self.to_sync():
             key_name = str(self.sync_path.joinpath(path.name))

--- a/harness/determined/util.py
+++ b/harness/determined/util.py
@@ -13,9 +13,10 @@ import numpy as np
 import simplejson
 
 import determined as det
-from determined_common import check
+from determined_common import check, util
 
 
+@util.preserve_random_state
 def download_gcs_blob_with_backoff(blob: Any, n_retries: int = 32, max_backoff: int = 32) -> Any:
     for n in range(n_retries):
         try:


### PR DESCRIPTION
Lots of cloud storage APIs use the built-in random package RNG to do
automatic random backoffs, which affects the random state that we try to
preserve for ML reproducibility.

Take the heavy-handed solution, and just preserve the state for every
single StorageManager or TensorboardManager call that might affect the
RNG state.

## Test Plan

Manually ran `test_gpu_restore` 20 times with GCS storage and 20 times with S3 storage; no failures.  Also manually hacked the `random` module to puke if it ever got called outside of a `preserve_random_state` context and ran with GCS + S3; no failures.