### PR TITLE
fix: hide table pagination when unnecessary [DET-3859]

### DIFF
--- a/webui/react/src/pages/ExperimentDetails.tsx
+++ b/webui/react/src/pages/ExperimentDetails.tsx
@@ -216,6 +216,7 @@ const ExperimentDetailsComp: React.FC = () => {
               columns={columns}
               dataSource={experiment?.trials}
               loading={!experimentResponse.hasLoaded}
+              pagination={{ defaultPageSize: 10, hideOnSinglePage: true }}
               rowClassName={defaultRowClassName()}
               rowKey="id"
               showSorterTooltip={false}

--- a/webui/react/src/pages/ExperimentList.tsx
+++ b/webui/react/src/pages/ExperimentList.tsx
@@ -315,6 +315,7 @@ const ExperimentList: React.FC = () => {
           columns={columns}
           dataSource={filteredExperiments}
           loading={!experimentsResponse.hasLoaded}
+          pagination={{ defaultPageSize: 10, hideOnSinglePage: true }}
           rowClassName={defaultRowClassName()}
           rowKey="id"
           rowSelection={{ onChange: handleTableRowSelect, selectedRowKeys }}

--- a/webui/react/src/pages/TaskList.tsx
+++ b/webui/react/src/pages/TaskList.tsx
@@ -304,6 +304,7 @@ const TaskList: React.FC = () => {
           columns={columns}
           dataSource={filteredTasks}
           loading={!hasLoaded}
+          pagination={{ defaultPageSize: 10, hideOnSinglePage: true }}
           rowClassName={record => defaultRowClassName(canBeOpened(record))}
           rowKey="id"
           rowSelection={{ onChange: handleTableRowSelect, selectedRowKeys }}


### PR DESCRIPTION
#238  Description

Pagination is not shown when there is only one page worth of items or less (empty case as well).

![2020-08-14 at 11 34 AM](https://user-images.githubusercontent.com/220971/90277120-42d91a00-de22-11ea-94ef-8b8ca305c789.png)


## Test Plan



## Commentary (optional)


<!-- User-facing API changes need the "User-facing API Change" label -->

<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

## Description

Lead with the intended commit body in this description field. For breaking changes, please include "BREAKING CHANGE:" at the beginning of your commit body. At minimum, this section should include a bracketed reference to the Jira ticket, e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.

## Test Plan

Describe the situations in which you've tested your change, and/or a screenshot as appropriate. Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.

## Commentary (optional)

Use this section of your description to add context to the PR. Could be for particularly tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc. You may intentionally leave this section blank and remove the title.
--->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234