### PR TITLE
fix: add ability to archive old experiments [DET-3867]

### DIFF
--- a/master/internal/core_experiment.go
+++ b/master/internal/core_experiment.go
@@ -259,7 +259,13 @@ func (m *Master) patchExperiment(c echo.Context) (interface{}, error) {
 
 	dbExp, err := m.db.ExperimentByID(args.ExperimentID)
 	if err != nil {
-		return nil, errors.Wrapf(err, "loading experiment %v", args.ExperimentID)
+		if patch.CheckpointStorage != nil {
+			return nil, errors.Wrapf(err, "loading experiment with config %v", args.ExperimentID)
+		}
+		dbExp, err = m.db.ExperimentWithoutConfigByID(args.ExperimentID)
+		if err != nil {
+			return nil, errors.Wrapf(err, "loading experiment %v", args.ExperimentID)
+		}
 	}
 
 	agentUserGroup, err := m.db.AgentUserGroup(*dbExp.OwnerID)

--- a/master/internal/db/postgres.go
+++ b/master/internal/db/postgres.go
@@ -663,6 +663,23 @@ WHERE id = $1`, &experiment, id); err != nil {
 	return &experiment, nil
 }
 
+// ExperimentWithoutConfigByID looks up an experiment by ID in a database, returning an error
+// if none exists. It loads it without a config so that experiments that have been around long
+// enough to see breaking changes can still be loaded.
+func (db *PgDB) ExperimentWithoutConfigByID(id int) (*model.Experiment, error) {
+	var experiment model.Experiment
+
+	if err := db.query(`
+SELECT id, state, model_definition, start_time, end_time, archived,
+       git_remote, git_commit, git_committer, git_commit_date, owner_id
+FROM experiments
+WHERE id = $1`, &experiment, id); err != nil {
+		return nil, err
+	}
+
+	return &experiment, nil
+}
+
 // ExperimentByTrialID looks up an experiment by a trial ID in the
 // database, returning an error if the experiment doesn't exist.
 func (db *PgDB) ExperimentByTrialID(id int) (*model.Experiment, error) {


### PR DESCRIPTION
## Description
This change adds logic to fallback, in the event a request to `PATCH /experiments/$ID` does not contain a patch for the experiment configuration, on loading the experiment without it's configuration. If the request is attempting to patch the experiment configuration (e.g. `checkpoint_storage`) and the experiment cannot be loaded with its configuration, an error is returned.


## Test Plan
- [ ] successfully archive an old experiment.


## Commentary (optional)
A little sloppy, but such a minuscule change and it gets the job done. I think there's a second half to this, about to fix it..

<!-- User-facing API changes need the "User-facing API Change" label -->

<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

## Description

Lead with the intended commit body in this description field. For breaking changes, please include "BREAKING CHANGE:" at the beginning of your commit body. At minimum, this section should include a bracketed reference to the Jira ticket, e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.

## Test Plan

Describe the situations in which you've tested your change, and/or a screenshot as appropriate. Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.

## Commentary (optional)

Use this section of your description to add context to the PR. Could be for particularly tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc. You may intentionally leave this section blank and remove the title.
--->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234