### PR TITLE
fix: record progress in partial units [DET-3869]

### DIFF
--- a/master/internal/experiment.go
+++ b/master/internal/experiment.go
@@ -33,7 +33,9 @@ type (
 	trialCompletedWorkload struct {
 		trialID          int
 		completedMessage searcher.CompletedMessage
-		unitsCompleted   model.Length
+		// unitsCompleted is passed as a float because while the searcher will only request integral
+		// units, a trial may complete partial units (especially in the case of epochs).
+		unitsCompleted float64
 	}
 	trialExitedEarly struct {
 		trialID      int

--- a/master/internal/trial.go
+++ b/master/internal/trial.go
@@ -519,7 +519,7 @@ func (t *trial) processCompletedWorkload(ctx *actor.Context, msg searcher.Comple
 
 	ctx.Log().Infof("trial completed workload: %v", msg.Workload)
 
-	units := model.NewLengthFromBatches(msg.Workload.NumBatches, t.sequencer.unitContext)
+	units := model.UnitsFromBatches(msg.Workload.NumBatches, t.sequencer.unitContext)
 	isBestValidation := ctx.Ask(ctx.Self().Parent(), trialCompletedWorkload{t.id, msg, units})
 	op, metrics, err := t.sequencer.WorkloadCompleted(msg, isBestValidation)
 	switch {

--- a/master/pkg/model/length.go
+++ b/master/pkg/model/length.go
@@ -3,7 +3,6 @@ package model
 import (
 	"encoding/json"
 	"fmt"
-	"math"
 
 	"github.com/pkg/errors"
 
@@ -105,16 +104,15 @@ func NewLengthInEpochs(epochs int) Length {
 	return Length{Unit: Epochs, Units: epochs}
 }
 
-// NewLengthFromBatches return the number of units completed by the given batches, rounded up.
-func NewLengthFromBatches(batches int, ctx UnitContext) Length {
+// UnitsFromBatches return the number of units completed by the given batches, rounded up.
+func UnitsFromBatches(batches int, ctx UnitContext) float64 {
 	switch ctx.defaultUnit {
 	case Records:
-		return NewLengthInRecords(batches * ctx.globalBatchSize)
+		return float64(batches * ctx.globalBatchSize)
 	case Batches:
-		return NewLengthInBatches(batches)
+		return float64(batches)
 	case Epochs:
-		numEpochs := math.Ceil(float64(batches*ctx.globalBatchSize) / float64(ctx.recordsPerEpoch))
-		return NewLengthInEpochs(int(numEpochs))
+		return float64(batches*ctx.globalBatchSize) / float64(ctx.recordsPerEpoch)
 	default:
 		panic(fmt.Sprintf("invalid unit in ctx: %s", ctx.defaultUnit))
 	}

--- a/master/pkg/searcher/asha.go
+++ b/master/pkg/searcher/asha.go
@@ -223,7 +223,7 @@ func (s *asyncHalvingSearch) closeOutRungs() []Operation {
 	return ops
 }
 
-func (s *asyncHalvingSearch) progress(unitsCompleted model.Length) float64 {
+func (s *asyncHalvingSearch) progress(float64) float64 {
 	allTrials := len(s.rungs[0].metrics)
 	// Give ourselves an overhead of 20% of maxTrials when calculating progress.
 	progress := float64(allTrials) / (1.2 * float64(s.maxTrials))

--- a/master/pkg/searcher/event_log.go
+++ b/master/pkg/searcher/event_log.go
@@ -25,7 +25,7 @@ type EventLog struct {
 
 	// Searcher state.
 	earlyExits          map[RequestID]bool
-	TotalUnitsCompleted model.Length
+	TotalUnitsCompleted float64
 	Shutdown            bool
 
 	// Trial state and metrics.
@@ -39,7 +39,7 @@ type EventLog struct {
 func NewEventLog(unit model.Unit) *EventLog {
 	return &EventLog{
 		earlyExits:          map[RequestID]bool{},
-		TotalUnitsCompleted: model.NewLength(unit, 0),
+		TotalUnitsCompleted: 0,
 		Shutdown:            false,
 		TrialsRequested:     0,
 		TrialsClosed:        0,
@@ -82,8 +82,8 @@ func (el *EventLog) TrialExitedEarly(requestID RequestID) {
 }
 
 // WorkloadCompleted records that the workload has been completed.
-func (el *EventLog) WorkloadCompleted(msg CompletedMessage, unitsCompleted model.Length) {
-	el.TotalUnitsCompleted = el.TotalUnitsCompleted.Add(unitsCompleted)
+func (el *EventLog) WorkloadCompleted(msg CompletedMessage, unitsCompleted float64) {
+	el.TotalUnitsCompleted += unitsCompleted
 	el.uncommitted = append(el.uncommitted, msg)
 }
 

--- a/master/pkg/searcher/event_log_test.go
+++ b/master/pkg/searcher/event_log_test.go
@@ -35,12 +35,12 @@ func TestEventLog(t *testing.T) {
 				StepID: trialID*trialID + i,
 			},
 		}
-		assert.Equal(t, log.TotalUnitsCompleted.Units, i*10)
-		log.WorkloadCompleted(msg, model.NewLengthInBatches(10))
-		assert.Equal(t, log.TotalUnitsCompleted.Units, (i+1)*10)
+		assert.Equal(t, log.TotalUnitsCompleted, float64(i*10))
+		log.WorkloadCompleted(msg, 10)
+		assert.Equal(t, log.TotalUnitsCompleted, float64((i+1)*10))
 	}
 
-	assert.Equal(t, log.TotalUnitsCompleted, model.NewLengthInBatches(10*len(trialIDs)))
+	assert.Equal(t, log.TotalUnitsCompleted, float64(10*len(trialIDs)))
 
 	for i, trialID := range trialIDs {
 		// Check that closing trials counts them correctly.

--- a/master/pkg/searcher/grid.go
+++ b/master/pkg/searcher/grid.go
@@ -33,8 +33,8 @@ func (s *gridSearch) initialOperations(ctx context) ([]Operation, error) {
 	return ops, nil
 }
 
-func (s *gridSearch) progress(unitsCompleted model.Length) float64 {
-	return float64(unitsCompleted.Units) / float64(s.GridConfig.MaxLength.MultInt(s.trials).Units)
+func (s *gridSearch) progress(unitsCompleted float64) float64 {
+	return unitsCompleted / float64(s.GridConfig.MaxLength.MultInt(s.trials).Units)
 }
 
 // trialExitedEarly does nothing since grid does not take actions based on

--- a/master/pkg/searcher/pbt.go
+++ b/master/pkg/searcher/pbt.go
@@ -201,8 +201,8 @@ func (s *pbtSearch) checkpointCompleted(
 	return ops, nil
 }
 
-func (s *pbtSearch) progress(unitsCompleted model.Length) float64 {
-	return float64(unitsCompleted.Units) / float64(
+func (s *pbtSearch) progress(unitsCompleted float64) float64 {
+	return unitsCompleted / float64(
 		s.LengthPerRound.MultInt(s.PopulationSize).MultInt(s.NumRounds).Units)
 }
 

--- a/master/pkg/searcher/random.go
+++ b/master/pkg/searcher/random.go
@@ -33,8 +33,8 @@ func (s *randomSearch) initialOperations(ctx context) ([]Operation, error) {
 	return ops, nil
 }
 
-func (s *randomSearch) progress(unitsCompleted model.Length) float64 {
-	return float64(unitsCompleted.Units) / float64(s.MaxLength.MultInt(s.MaxTrials).Units)
+func (s *randomSearch) progress(unitsCompleted float64) float64 {
+	return unitsCompleted / float64(s.MaxLength.MultInt(s.MaxTrials).Units)
 }
 
 // trialExitedEarly does nothing since random does not take actions based on

--- a/master/pkg/searcher/search_method.go
+++ b/master/pkg/searcher/search_method.go
@@ -40,7 +40,7 @@ type SearchMethod interface {
 	trialClosed(ctx context, requestID RequestID) ([]Operation, error)
 	// progress returns experiment progress as a float between 0.0 and 1.0. As search methods
 	// receive completed workloads, they should internally track progress.
-	progress(totalUnitsCompleted model.Length) float64
+	progress(totalUnitsCompleted float64) float64
 	// trialExitedEarly informs the searcher that the trial has exited earlier than expected.
 	trialExitedEarly(ctx context, requestID RequestID) ([]Operation, error)
 	// SearchMethod embeds the InUnits interface because it is in terms of a specific unit.

--- a/master/pkg/searcher/searcher.go
+++ b/master/pkg/searcher/searcher.go
@@ -73,7 +73,7 @@ func (s *Searcher) TrialExitedEarly(trialID int) ([]Operation, error) {
 
 // WorkloadCompleted informs the searcher that the workload is completed. This relays the message
 // to the event log and records the units as complete for search method progress.
-func (s *Searcher) WorkloadCompleted(msg CompletedMessage, unitsCompleted model.Length) {
+func (s *Searcher) WorkloadCompleted(msg CompletedMessage, unitsCompleted float64) {
 	s.eventLog.WorkloadCompleted(msg, unitsCompleted)
 }
 

--- a/master/pkg/searcher/sha.go
+++ b/master/pkg/searcher/sha.go
@@ -199,8 +199,8 @@ func (s *syncHalvingSearch) promoteSync(
 	return ops, nil
 }
 
-func (s *syncHalvingSearch) progress(unitsCompleted model.Length) float64 {
-	return math.Min(1, float64(unitsCompleted.Units)/float64(s.expectedUnits.Units))
+func (s *syncHalvingSearch) progress(unitsCompleted float64) float64 {
+	return math.Min(1, unitsCompleted/float64(s.expectedUnits.Units))
 }
 
 func (s *syncHalvingSearch) trialExitedEarly(

--- a/master/pkg/searcher/simulate.go
+++ b/master/pkg/searcher/simulate.go
@@ -134,7 +134,7 @@ func Simulate(
 					Kind:    RunStep,
 					TrialID: trialIDs[requestID],
 					StepID:  trialOpIdxs[requestID],
-				}}, train.Length)
+				}}, float64(train.Length.Units))
 			}
 			ops, err := s.OperationCompleted(trialIDs[requestID], operation, metrics)
 			if err != nil {


### PR DESCRIPTION
## Description
This change alters trials to report units completed as a `float64` so that partial units can be reported correctly. Previously, if the searcher was configured in terms of epochs and anything less than an epoch was completed in a workload, the reported completed `model.Length` was rounded to the nearest epoch; this usually ends up being 1 (except in the case of unusually small epochs or unusually large scheduling units) and makes progress appear completely wrong.


## Test Plan
- [x] test locally with an example that was broken previously
- [ ] add a unit test that checks searcher progress with records, batches and epochs.

## Commentary
The weird thing about "add a unit test that checks searcher progress with records, batches and epochs" is that when an experiment completed we destroy the progress, so it seems impossible to write without being _super_ flaky.

<!-- User-facing API changes need the "User-facing API Change" label -->

<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

## Description

Lead with the intended commit body in this description field. For breaking changes, please include "BREAKING CHANGE:" at the beginning of your commit body. At minimum, this section should include a bracketed reference to the Jira ticket, e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.

## Test Plan

Describe the situations in which you've tested your change, and/or a screenshot as appropriate. Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.

## Commentary (optional)

Use this section of your description to add context to the PR. Could be for particularly tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc. You may intentionally leave this section blank and remove the title.
--->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234