### PR TITLE
fix: run atleast one batch per searcher op [DET-3877]

### DIFF
--- a/master/internal/trial_workload_sequencer.go
+++ b/master/internal/trial_workload_sequencer.go
@@ -324,12 +324,12 @@ func (s trialWorkloadSequencer) Workload() (searcher.Workload, error) {
 		batchesLeft := tOp.Length.ToNearestBatch(s.unitContext) - s.batchesTowardsCurrentOp
 		batchesTilVal := s.batchesUntilValNeeded()
 		batchesTilCkpt := s.batchesUntilCkptNeeded()
-		batchesThisStep := min(
+		batchesThisStep := max(min(
 			batchesLeft,
 			batchesTilVal,
 			batchesTilCkpt,
 			s.schedulingUnit,
-		)
+		), 1)
 		return s.train(batchesThisStep), nil
 	default:
 		return searcher.Workload{}, errors.New("unexpected op type determining workload")
@@ -452,4 +452,14 @@ func min(initial int, values ...int) int {
 		}
 	}
 	return minValue
+}
+
+func max(initial int, values ...int) int {
+	maxValue := initial
+	for _, value := range values {
+		if value > maxValue {
+			maxValue = value
+		}
+	}
+	return maxValue
 }


### PR DESCRIPTION
## Description
This change fixes a bug where a very small adaptive searcher, in which the first rung is less than one batch, would end up requesting to run zero batches because we decided in to round down to the nearest batch when using records or epochs. We now round down usually, but round up if the searcher requested we run a quantity less than the trial's global batch size.


## Test Plan
- [x] write a tests that fails and fix it.


<!-- User-facing API changes need the "User-facing API Change" label -->

<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

## Description

Lead with the intended commit body in this description field. For breaking changes, please include "BREAKING CHANGE:" at the beginning of your commit body. At minimum, this section should include a bracketed reference to the Jira ticket, e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.

## Test Plan

Describe the situations in which you've tested your change, and/or a screenshot as appropriate. Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.

## Commentary (optional)

Use this section of your description to add context to the PR. Could be for particularly tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc. You may intentionally leave this section blank and remove the title.
--->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234