### PR TITLE
feat: add NVIDIA A100 support for GCP

### DIFF
--- a/docs/how-to/installation/requirements.txt
+++ b/docs/how-to/installation/requirements.txt
@@ -33,7 +33,7 @@ Hardware
 - Each Determined agent node should be configured with at least 2 CPUs
   (Intel Broadwell or later), 4GB of RAM, and 50GB of free disk space. If
   using GPUs, Nvidia GPUs with compute capability 3.7 or greater are
-  required (e.g., K80, P100, V100, GTX 1080, GTX 1080 Ti, TITAN, TITAN
+  required (e.g., K80, P100, V100, A100, GTX 1080, GTX 1080 Ti, TITAN, TITAN
   XP).
 
 .. note::

--- a/docs/topic-guides/elastic-infra/dynamic-agents-gcp.txt
+++ b/docs/topic-guides/elastic-infra/dynamic-agents-gcp.txt
@@ -88,6 +88,25 @@ Network Requirements
 
 See :ref:`network-requirements` for details.
 
+.. _gcp-gpu-requirements:
+
+Supported GPU Types
+~~~~~~~~~~~~~~~~~~~
+
+The following GPU types are supported by Determined:
+
+-  ``nvidia-tesla-t4``
+
+-  ``nvidia-tesla-p100``
+
+-  ``nvidia-tesla-p4``
+
+-  ``nvidia-tesla-v100``
+
+-  ``nvidia-tesla-k80``
+
+-  ``nvidia-tesla-a100`` (experimental)
+
 .. _gcp-cluster-configuration:
 
 Cluster Configuration

--- a/master/internal/provisioner/gcp_config.go
+++ b/master/internal/provisioner/gcp_config.go
@@ -215,6 +215,7 @@ var gceMachineTypes = []string{
 	"m2-ultramem",
 	"n1-megamem",
 	"c2-standard",
+	"a2-highgpu",
 	"custom",
 }
 
@@ -224,6 +225,7 @@ var gceGPUTypes = map[string][]int{
 	"nvidia-tesla-p4":   {1, 2, 4},
 	"nvidia-tesla-v100": {1, 2, 4, 8},
 	"nvidia-tesla-k80":  {1, 2, 4, 8},
+	"nvidia-tesla-a100": {1, 2, 4, 8},
 }
 
 type gceInstanceType struct {


### PR DESCRIPTION
## Description
Add support for the dynamic provisioning of NVIDIA A100's on GCP. 


## Test Plan
Spun up a cluster with A100 dynamic agents and tested provisioning.  Note: had to build a custom task environment to run, as the A100 requires CUDA 11.
