### PR TITLE
fix: let shell proxying work with master TLS [DET-3882]

### DIFF
--- a/cli/determined_cli/tunnel.py
+++ b/cli/determined_cli/tunnel.py
@@ -6,14 +6,51 @@ should be the shell ID of the shell in question.
 """
 
 import http.client
+import io
 import os
 import socket
 import ssl
 import sys
 import threading
-from typing import Optional
+from typing import Optional, Union
 
 from determined_common.api import request
+
+
+class HTTPSProxyConnection(http.client.HTTPSConnection):
+    """
+    A connection class that applies TLS to the entire connection, even for CONNECT requests.
+    """
+
+    def connect(self) -> None:
+        self.sock = self._create_connection(  # type: ignore
+            (self.host, self.port), self.timeout, self.source_address  # type: ignore
+        )
+        self.sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
+
+        # This is what differs from the base class: we wrap the socket *before* setting up the
+        # tunnel and verify against the proxy's hostname rather than the target's.
+        self.sock = self._context.wrap_socket(self.sock, server_hostname=self.host)  # type: ignore
+
+        if self._tunnel_host:  # type: ignore
+            self._tunnel()  # type: ignore
+
+
+class SocketWrapper:
+    """A small wrapper to provide file-like read/write methods on top of a socket object."""
+
+    def __init__(self, sock: socket.socket):
+        self.sock = sock
+
+    def read(self, n: int) -> bytes:
+        return self.sock.recv(n)
+
+    def write(self, s: bytes) -> int:
+        self.sock.sendall(s)
+        return len(s)
+
+    def close(self) -> None:
+        self.sock.close()
 
 
 class Copier(threading.Thread):
@@ -23,7 +60,9 @@ class Copier(threading.Thread):
     opposed to select.select or select.poll ensures that this code will run nicely on Windows.
     """
 
-    def __init__(self, src: int, dst: int):
+    def __init__(
+        self, src: Union[SocketWrapper, io.RawIOBase], dst: Union[SocketWrapper, io.RawIOBase]
+    ):
         super().__init__()
         self.src = src
         self.dst = dst
@@ -32,24 +71,24 @@ class Copier(threading.Thread):
         try:
             while True:
                 try:
-                    buf = os.read(self.src, 4096)
+                    buf = self.src.read(4096)
                 except OSError:
                     break
                 if not buf:
                     break
                 try:
-                    os.write(self.dst, buf)
+                    self.dst.write(buf)
                 except OSError:
                     break
         finally:
             # We're ok with double-closing some sockets.
             try:
-                os.close(self.src)
+                self.src.close()
             except OSError:
                 pass
 
             try:
-                os.close(self.dst)
+                self.dst.close()
             except OSError:
                 pass
 
@@ -60,7 +99,7 @@ def http_connect_tunnel(master: str, service: str, master_cert: Optional[str]) -
 
     if parsed_master.scheme == "https":
         context = ssl.create_default_context(cafile=master_cert)
-        client = http.client.HTTPSConnection(
+        client = HTTPSProxyConnection(
             parsed_master.hostname, parsed_master.port, context=context
         )  # type: http.client.HTTPConnection
     else:
@@ -75,8 +114,14 @@ def http_connect_tunnel(master: str, service: str, master_cert: Optional[str]) -
         raise
 
     with client.sock as sock:
-        c1 = Copier(sock.fileno(), sys.stdout.fileno())
-        c2 = Copier(sys.stdin.fileno(), sock.fileno())
+        sock = SocketWrapper(sock)
+        # Directly using sys.stdin.buffer.read or sys.stdout.buffer.write would block due to
+        # buffering; instead, we use unbuffered file objects based on the same file descriptors.
+        unbuffered_stdin = os.fdopen(sys.stdin.fileno(), "rb", buffering=0)
+        unbuffered_stdout = os.fdopen(sys.stdout.fileno(), "wb", buffering=0)
+
+        c1 = Copier(sock, unbuffered_stdout)
+        c2 = Copier(unbuffered_stdin, sock)
         c1.start()
         c2.start()
         c1.join()


### PR DESCRIPTION
## Description

This change updates the tunneling helper script to allow proxying shell
connections to work when the master is listening on TLS. The main change
is a new HTTP connection class that applies TLS to the entire
connection; the standard library class makes the CONNECT request
unencrypted and only applies TLS to the proxied connection, which
doesn't make much sense for us.

To allow the copier thread to easily work with SSL sockets (which don't
have a useful fileno), normal sockets (which don't have read/write
methods), and stdin/stdout, there's also a class that wraps sockets to
provide read/write methods.

## Test Plan

- [x] open and connect to shells with a master using only TLS
- [x] open and connect to shells with a master not using TLS
