### PR TITLE
fix: add explicit searcher sync before close trial [DET-3889]

### DIFF
--- a/master/internal/experiment.go
+++ b/master/internal/experiment.go
@@ -306,6 +306,12 @@ func (e *experiment) Receive(ctx *actor.Context) error {
 	case trialExitedEarly:
 		ops, err := e.searcher.TrialExitedEarly(msg.trialID)
 		e.processOperations(ctx, ops, err)
+	case continueTrial:
+		requestID, ok := e.searcher.RequestID(msg.trialID)
+		if !ok {
+			return fmt.Errorf("requested continuation of non-existent trial %d", msg.trialID)
+		}
+		ctx.Tell(ctx.Child(requestID), msg)
 	case actor.ChildFailed:
 		ctx.Log().WithError(msg.Error).Error("trial failed unexpectedly")
 		requestID := searcher.MustParse(msg.Child.Address().Local())

--- a/master/internal/experiment.go
+++ b/master/internal/experiment.go
@@ -307,11 +307,9 @@ func (e *experiment) Receive(ctx *actor.Context) error {
 		ops, err := e.searcher.TrialExitedEarly(msg.trialID)
 		e.processOperations(ctx, ops, err)
 	case sendNextWorkload:
-		requestID, ok := e.searcher.RequestID(msg.trialID)
-		if !ok {
-			return fmt.Errorf("requested continuation of non-existent trial %d", msg.trialID)
-		}
-		ctx.Tell(ctx.Child(requestID), msg)
+		// Pass this back to the trial; this message is just used to allow the trial to synchronize
+		// with the searcher.
+		ctx.Tell(ctx.Sender(), msg)
 	case actor.ChildFailed:
 		ctx.Log().WithError(msg.Error).Error("trial failed unexpectedly")
 		requestID := searcher.MustParse(msg.Child.Address().Local())

--- a/master/internal/experiment.go
+++ b/master/internal/experiment.go
@@ -306,7 +306,7 @@ func (e *experiment) Receive(ctx *actor.Context) error {
 	case trialExitedEarly:
 		ops, err := e.searcher.TrialExitedEarly(msg.trialID)
 		e.processOperations(ctx, ops, err)
-	case continueTrial:
+	case sendNextWorkload:
 		requestID, ok := e.searcher.RequestID(msg.trialID)
 		if !ok {
 			return fmt.Errorf("requested continuation of non-existent trial %d", msg.trialID)

--- a/master/internal/trial.go
+++ b/master/internal/trial.go
@@ -71,8 +71,7 @@ type (
 	// completing a searcher operation before the trial decides to tell the scheduler it is
 	// done, since stopping and restarting trials has relatively high overhead.
 	sendNextWorkload struct {
-		trialID int
-		runID   int
+		runID int
 	}
 
 	// When we issue a TERMINATE workload, we send a delayed terminateTimeout message with a record
@@ -569,7 +568,7 @@ func (t *trial) processCompletedWorkload(ctx *actor.Context, msg searcher.Comple
 	// If we completed a searcher operation, synchronize with the searcher to allow it to relay any
 	// new operations to the trial. Otherwise just continue the trial immediately.
 	if completedSearcherOp {
-		ctx.Tell(ctx.Self().Parent(), sendNextWorkload{trialID: t.id, runID: t.runID})
+		ctx.Tell(ctx.Self().Parent(), sendNextWorkload{runID: t.runID})
 		return nil
 	}
 	return t.sendNextWorkload(ctx)


### PR DESCRIPTION
## Description
This change fixes a regression introduced within the development for 0.13.0. There was a decision made in #infra-ag to always checkpoint before searcher requested validations. In the event that we're running adaptive and that validation causes a promotion decision, we have to do this for consistency and reproducibility. Changing this order broke existing, implicit behavior in the trial actor. For example, if an asha trial is running and completes a validation that results in its promotion, on old versions of the master (<= 0.12.13) a preclose checkpoint workload would be issued. While the trial is performing this checkpoint workload, the searcher is able to synchronize the operations is wants the trial to do with the trial. On the current version of the master (0.13.0.dev0), since there is a checkpoint before the searcher requested validation, there is no preclose checkpoint to run. Because of this, the searcher is not able to synchronize with the trial before it decides to close because it has nothing left to run. This change makes synchronizing with the searcher explicit rather than implicit, by adding a `sendNextWorkload` message and using it if the searcher completes a workload that will result in a state change in the searcher.

## Test Plan
- [x] run a large adaptive searcher, verify if a trial is promoted immediately following a validation then it continues without stopping and restarting.

e.g. two rungs run back to back.
```
[2020-08-17, 19:20:10] b565538e [RUNNING] ||  INFO: Connected to master
[2020-08-17, 19:20:10] b565538e [RUNNING] ||  INFO: Established WebSocket session with master
[2020-08-17, 19:20:10] b565538e [RUNNING] ||  INFO: Got rendezvous information: {'addrs': ['[::1]:1734'], 'addrs2': ['[::1]:1750'], 'containers': [{'addresses': [{'container_ip': '[::1]', 'container_port': 1734, 'host_ip': '[::1]', 'host_port': 1734}, {'container_ip': '[::1]', 'container_port': 1750, 'host_ip': '[::1]', 'host_port': 1750}]}], 'rank': 0, 'type': 'RENDEZVOUS_INFO'}
[2020-08-17, 19:20:11] b565538e [RUNNING] ||  INFO: Horovod config: {'use': False, 'aggregation_frequency': 1, 'fp16_compression': False, 'grad_updates_size_file': None, 'average_aggregated_gradients': True, 'average_training_metrics': False}.
[2020-08-17, 19:20:11] b565538e [RUNNING] ||  INFO: Loading Trial implementation with entrypoint model_def:NoOpTrial.
[2020-08-17, 19:20:11] b565538e [RUNNING] ||  INFO: Creating NoOpTrialController with NoOpTrial.
[2020-08-17, 19:20:11] b565538e [RUNNING] ||  INFO: Running workload <RUN_STEP (100 Batches): (1,40,1)>
[2020-08-17, 19:20:11] b565538e [RUNNING] ||  INFO: Workload completed: <RUN_STEP (100 Batches): (1,40,1)> (duration 0:00:00.012894)
[2020-08-17, 19:20:11] b565538e [RUNNING] ||  INFO: Running workload <RUN_STEP (60 Batches): (1,40,2)>
[2020-08-17, 19:20:11] b565538e [RUNNING] ||  INFO: Workload completed: <RUN_STEP (60 Batches): (1,40,2)> (duration 0:00:00.004803)
[2020-08-17, 19:20:11] b565538e [RUNNING] ||  INFO: Running workload <CHECKPOINT_MODEL: (1,40,2)>
[2020-08-17, 19:20:11] b565538e [RUNNING] ||  INFO: Saving checkpoint /determined_shared_fs/determined-integration-checkpoints/3d5c563c-e47f-4868-8280-12ba70d92236/no_op_checkpoint, steps_trained 2
[2020-08-17, 19:20:11] b565538e [RUNNING] ||  INFO: Saved trial to checkpoint 3d5c563c-e47f-4868-8280-12ba70d92236
[2020-08-17, 19:20:11] b565538e [RUNNING] ||  INFO: Workload completed: <CHECKPOINT_MODEL: (1,40,2)> (duration 0:00:00.007100)
[2020-08-17, 19:20:11] b565538e [RUNNING] ||  INFO: Running workload <COMPUTE_VALIDATION_METRICS: (1,40,2)>
[2020-08-17, 19:20:11] b565538e [RUNNING] ||  INFO: Workload completed: <COMPUTE_VALIDATION_METRICS: (1,40,2)> (duration 0:00:00.000900)
[2020-08-17, 19:20:11] b565538e [RUNNING] ||  INFO: Running workload <RUN_STEP (100 Batches): (1,40,3)>
[2020-08-17, 19:20:11] b565538e [RUNNING] ||  INFO: Workload completed: <RUN_STEP (100 Batches): (1,40,3)> (duration 0:00:00.018860)
[2020-08-17, 19:20:11] b565538e [RUNNING] ||  INFO: Running workload <RUN_STEP (100 Batches): (1,40,4)>
[2020-08-17, 19:20:11] b565538e [RUNNING] ||  INFO: Workload completed: <RUN_STEP (100 Batches): (1,40,4)> (duration 0:00:00.007913)
[2020-08-17, 19:20:11] b565538e [RUNNING] ||  INFO: Running workload <RUN_STEP (100 Batches): (1,40,5)>
[2020-08-17, 19:20:11] b565538e [RUNNING] ||  INFO: Workload completed: <RUN_STEP (100 Batches): (1,40,5)> (duration 0:00:00.007990)
[2020-08-17, 19:20:11] b565538e [RUNNING] ||  INFO: Running workload <RUN_STEP (100 Batches): (1,40,6)>
[2020-08-17, 19:20:11] b565538e [RUNNING] ||  INFO: Workload completed: <RUN_STEP (100 Batches): (1,40,6)> (duration 0:00:00.007970)
[2020-08-17, 19:20:11] b565538e [RUNNING] ||  INFO: Running workload <RUN_STEP (80 Batches): (1,40,7)>
[2020-08-17, 19:20:11] b565538e [RUNNING] ||  INFO: Workload completed: <RUN_STEP (80 Batches): (1,40,7)> (duration 0:00:00.007070)
[2020-08-17, 19:20:11] b565538e [RUNNING] ||  INFO: Running workload <CHECKPOINT_MODEL: (1,40,7)>
[2020-08-17, 19:20:11] b565538e [RUNNING] ||  INFO: Saving checkpoint /determined_shared_fs/determined-integration-checkpoints/63c02fac-b698-45bb-94d7-908cb20e70fb/no_op_checkpoint, steps_trained 7
[2020-08-17, 19:20:11] b565538e [RUNNING] ||  INFO: Saved trial to checkpoint 63c02fac-b698-45bb-94d7-908cb20e70fb
[2020-08-17, 19:20:11] b565538e [RUNNING] ||  INFO: Workload completed: <CHECKPOINT_MODEL: (1,40,7)> (duration 0:00:00.006717)
[2020-08-17, 19:20:11] b565538e [RUNNING] ||  INFO: Running workload <COMPUTE_VALIDATION_METRICS: (1,40,7)>
[2020-08-17, 19:20:11] b565538e [RUNNING] ||  INFO: Workload completed: <COMPUTE_VALIDATION_METRICS: (1,40,7)> (duration 0:00:00.001091)
[2020-08-17, 19:20:11] b565538e [RUNNING] ||  INFO: Running workload <TERMINATE: (1,40,7)>
[2020-08-17, 19:20:11] b565538e [RUNNING] ||  INFO: WebSocket closed
[2020-08-17, 19:20:11] b565538e [RUNNING] ||  INFO: Disconnected from master, exiting gracefully
[2020-08-17, 19:20:11] b565538e [TERMINATED] || container exited successfully with a zero exit code
```

## Commentary (optional)


<!-- User-facing API changes need the "User-facing API Change" label -->

<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

## Description

Lead with the intended commit body in this description field. For breaking changes, please include "BREAKING CHANGE:" at the beginning of your commit body. At minimum, this section should include a bracketed reference to the Jira ticket, e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.

## Test Plan

Describe the situations in which you've tested your change, and/or a screenshot as appropriate. Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.

## Commentary (optional)

Use this section of your description to add context to the PR. Could be for particularly tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc. You may intentionally leave this section blank and remove the title.
--->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234