### PR TITLE
feat: kill idle tensorboards [DET-3808]

### DIFF
--- a/docs/reference/cluster-config.txt
+++ b/docs/reference/cluster-config.txt
@@ -233,6 +233,9 @@ The master supports the following configuration settings:
 - ``root``: Specifies the root directory of the state files. Defaults to
   ``/usr/share/determined/master``.
 
+- ``tensorboard_timeout``: Specifies the duration in seconds a TensorBoard
+  instance can be idle before it is automatically killed.
+
 - ``provisioner``: Specifies the configuration of dynamic agents.
 
   - ``master_url``: The full URL of the master. A valid URL is in the

--- a/master/internal/command/api.go
+++ b/master/internal/command/api.go
@@ -1,6 +1,8 @@
 package command
 
 import (
+	"time"
+
 	"github.com/labstack/echo"
 
 	"github.com/determined-ai/determined/master/internal/db"
@@ -15,6 +17,8 @@ func RegisterAPIHandler(
 	echo *echo.Echo,
 	db *db.PgDB,
 	cID string,
+	proxyRef *actor.Ref,
+	timeout int,
 	defaultAgentUserGroup model.AgentUserGroup,
 	middleware ...echo.MiddlewareFunc,
 ) {
@@ -43,6 +47,8 @@ func RegisterAPIHandler(
 		defaultAgentUserGroup: defaultAgentUserGroup,
 		db:                    db,
 		clusterID:             cID,
+		proxyRef:              proxyRef,
+		timeout:               time.Duration(timeout) * time.Second,
 	})
 	echo.Any("/tensorboard*", api.Route(system, nil), middleware...)
 }

--- a/master/internal/command/tensorboard_manager.go
+++ b/master/internal/command/tensorboard_manager.go
@@ -8,17 +8,21 @@ import (
 	"net/url"
 	"sort"
 	"strings"
+	"time"
 
 	petname "github.com/dustinkirkland/golang-petname"
 	"github.com/labstack/echo"
 	"github.com/pkg/errors"
 
 	"github.com/determined-ai/determined/master/internal/db"
+	"github.com/determined-ai/determined/master/internal/proxy"
 	"github.com/determined-ai/determined/master/internal/scheduler"
 	"github.com/determined-ai/determined/master/internal/sproto"
 	"github.com/determined-ai/determined/master/pkg/actor"
+	"github.com/determined-ai/determined/master/pkg/actor/actors"
 	"github.com/determined-ai/determined/master/pkg/archive"
 	"github.com/determined-ai/determined/master/pkg/check"
+	"github.com/determined-ai/determined/master/pkg/container"
 	"github.com/determined-ai/determined/master/pkg/etc"
 	"github.com/determined-ai/determined/master/pkg/model"
 	"github.com/determined-ai/determined/proto/pkg/apiv1"
@@ -27,12 +31,13 @@ import (
 
 const (
 	expConfPath = "/run/determined/workdir/experiment_config.json"
-	// Agent ports 2600 - 3500 are split between TensorBoards, Notebooks, and Shells.
+	// Agent port range is 2600 - 3200. Ports are split between TensorBoard and Notebooks.
 	minTensorBoardPort        = 2600
 	maxTensorBoardPort        = minTensorBoardPort + 299
 	tensorboardEntrypointFile = "/run/determined/workdir/tensorboard-entrypoint.sh"
 	tensorboardResourcesSlots = 0
 	tensorboardServiceAddress = "/proxy/%s/"
+	tickInterval              = 5 * time.Second
 )
 
 type tensorboardRequest struct {
@@ -52,10 +57,16 @@ type tensorboardManager struct {
 
 	defaultAgentUserGroup model.AgentUserGroup
 	clusterID             string
+	timeout               time.Duration
+	proxyRef              *actor.Ref
 }
+
+type tensorboardTick struct{}
 
 func (t *tensorboardManager) Receive(ctx *actor.Context) error {
 	switch msg := ctx.Message().(type) {
+	case actor.PreStart:
+		actors.NotifyAfter(ctx, tickInterval, tensorboardTick{})
 	case *apiv1.GetTensorboardsRequest:
 		resp := &apiv1.GetTensorboardsResponse{}
 		for _, tensorboard := range ctx.AskAll(&tensorboardv1.Tensorboard{}, ctx.Children()...).GetAll() {
@@ -65,7 +76,28 @@ func (t *tensorboardManager) Receive(ctx *actor.Context) error {
 
 	case echo.Context:
 		t.handleAPIRequest(ctx, msg)
+	case tensorboardTick:
+		services := ctx.Ask(t.proxyRef, proxy.GetSummary{}).Get().(map[string]proxy.Service)
+		for _, v := range ctx.Children() {
+			boardSummary := ctx.Ask(v, getSummary{}).Get().(summary)
+			if boardSummary.State != container.Running.String() {
+				continue
+			}
+
+			service, ok := services[string(boardSummary.ID)]
+			if !ok {
+				continue
+			}
+
+			if time.Now().After(service.LastRequested.Add(t.timeout)) {
+				ctx.Log().Infof("Killing %s due to inactivity", boardSummary.Config.Description)
+				ctx.Ask(ctx.Child(boardSummary.ID), &apiv1.KillTensorboardRequest{})
+			}
+		}
+
+		actors.NotifyAfter(ctx, tickInterval, tensorboardTick{})
 	}
+
 	return nil
 }
 

--- a/master/internal/command/tensorboard_manager.go
+++ b/master/internal/command/tensorboard_manager.go
@@ -78,8 +78,8 @@ func (t *tensorboardManager) Receive(ctx *actor.Context) error {
 		t.handleAPIRequest(ctx, msg)
 	case tensorboardTick:
 		services := ctx.Ask(t.proxyRef, proxy.GetSummary{}).Get().(map[string]proxy.Service)
-		for _, v := range ctx.Children() {
-			boardSummary := ctx.Ask(v, getSummary{}).Get().(summary)
+		for _, boardRef := range ctx.Children() {
+			boardSummary := ctx.Ask(boardRef, getSummary{}).Get().(summary)
 			if boardSummary.State != container.Running.String() {
 				continue
 			}
@@ -91,7 +91,7 @@ func (t *tensorboardManager) Receive(ctx *actor.Context) error {
 
 			if time.Now().After(service.LastRequested.Add(t.timeout)) {
 				ctx.Log().Infof("Killing %s due to inactivity", boardSummary.Config.Description)
-				ctx.Ask(ctx.Child(boardSummary.ID), &apiv1.KillTensorboardRequest{})
+				ctx.Ask(boardRef, &apiv1.KillTensorboardRequest{})
 			}
 		}
 

--- a/master/internal/command/tensorboard_manager.go
+++ b/master/internal/command/tensorboard_manager.go
@@ -31,7 +31,7 @@ import (
 
 const (
 	expConfPath = "/run/determined/workdir/experiment_config.json"
-	// Agent port range is 2600 - 3200. Ports are split between TensorBoard and Notebooks.
+	// Agent ports 2600 - 3500 are split between TensorBoards, Notebooks, and Shells.
 	minTensorBoardPort        = 2600
 	maxTensorBoardPort        = minTensorBoardPort + 299
 	tensorboardEntrypointFile = "/run/determined/workdir/tensorboard-entrypoint.sh"

--- a/master/internal/config.go
+++ b/master/internal/config.go
@@ -36,7 +36,8 @@ func DefaultConfig() *Config {
 			ShmSizeBytes: 4294967296,
 			NetworkMode:  "bridge",
 		},
-		Scheduler: *scheduler.DefaultConfig(),
+		TensorBoardTimeout: 5 * 60,
+		Scheduler:          *scheduler.DefaultConfig(),
 		Security: SecurityConfig{
 			DefaultTask: model.AgentUserGroup{
 				UID:   0,
@@ -71,6 +72,7 @@ type Config struct {
 	DB                    db.Config                         `json:"db"`
 	Scheduler             scheduler.Config                  `json:"scheduler"`
 	Provisioner           *provisioner.Config               `json:"provisioner"`
+	TensorBoardTimeout    int                               `json:"tensorboard_timeout"`
 	Security              SecurityConfig                    `json:"security"`
 	CheckpointStorage     CheckpointStorageConfig           `json:"checkpoint_storage"`
 	TaskContainerDefaults model.TaskContainerDefaultsConfig `json:"task_container_defaults"`

--- a/master/internal/core.go
+++ b/master/internal/core.go
@@ -578,7 +578,7 @@ func (m *Master) Run() error {
 	m.echo.Any("/debug/pprof/symbol", echo.WrapHandler(http.HandlerFunc(pprof.Symbol)))
 	m.echo.Any("/debug/pprof/trace", echo.WrapHandler(http.HandlerFunc(pprof.Trace)))
 
-	handler := m.system.AskAt(actor.Addr("proxy"), proxy.NewProxyHandler{ServiceKey: "service"})
+	handler := m.system.AskAt(actor.Addr("proxy"), proxy.NewProxyHandler{ServiceID: "service"})
 	m.echo.Any("/proxy/:service/*", handler.Get().(echo.HandlerFunc))
 
 	handler = m.system.AskAt(actor.Addr("proxy"), proxy.NewConnectHandler{})
@@ -590,6 +590,8 @@ func (m *Master) Run() error {
 		m.echo,
 		m.db,
 		m.ClusterID,
+		proxyRef,
+		m.config.TensorBoardTimeout,
 		m.config.Security.DefaultTask,
 		authFuncs...,
 	)

--- a/master/internal/proxy/proxy.go
+++ b/master/internal/proxy/proxy.go
@@ -21,7 +21,7 @@ type (
 	// format ".../:service-name/*" are forwarded to the service via the target URL.
 	Register struct {
 		ServiceID string
-		Target    *url.URL
+		URL       *url.URL
 	}
 	// Unregister removes the service from the proxy. All future requests until the service name is
 	// registered again will be responded with a 404 response. If the service is not registered with
@@ -62,8 +62,8 @@ func (p *Proxy) Receive(ctx *actor.Context) error {
 		}
 		p.lock.Lock()
 		defer p.lock.Unlock()
-		ctx.Log().Infof("registering service: %s (%v)", msg.ServiceID, msg.Target)
-		p.services[msg.ServiceID] = &Service{msg.Target, time.Now()}
+		ctx.Log().Infof("registering service: %s (%v)", msg.ServiceID, msg.URL)
+		p.services[msg.ServiceID] = &Service{msg.URL, time.Now()}
 
 		if ctx.ExpectingResponse() {
 			ctx.Respond(nil)
@@ -92,8 +92,6 @@ func (p *Proxy) getTargetURL(serviceName string) (*url.URL, bool) {
 	defer p.lock.Unlock()
 	service, ok := p.services[serviceName]
 	service.LastRequested = time.Now()
-	fmt.Printf("p.services = %+v\n", p.services)
-	fmt.Printf("service = %+v\n", service)
 	// Make a copy to avoid callers mutating the url outside of this locked
 	// method.
 	sURL := *service.URL

--- a/master/internal/scheduler/default_resource_provider.go
+++ b/master/internal/scheduler/default_resource_provider.go
@@ -422,7 +422,7 @@ func (d *DefaultRP) receiveContainerStartedOnAgent(
 		// assigned to an agent.
 		ctx.Ask(d.proxy, proxy.Register{
 			ServiceID: string(task.ID),
-			Target: &url.URL{
+			URL: &url.URL{
 				Scheme: "http",
 				Host:   fmt.Sprintf("%s:%d", address.HostIP, address.HostPort),
 			},

--- a/master/internal/scheduler/default_resource_provider.go
+++ b/master/internal/scheduler/default_resource_provider.go
@@ -421,7 +421,7 @@ func (d *DefaultRP) receiveContainerStartedOnAgent(
 		// proxy multi-container tasks or when containers are created prior to being
 		// assigned to an agent.
 		ctx.Ask(d.proxy, proxy.Register{
-			Service: string(task.ID),
+			ServiceID: string(task.ID),
 			Target: &url.URL{
 				Scheme: "http",
 				Host:   fmt.Sprintf("%s:%d", address.HostIP, address.HostPort),
@@ -456,7 +456,7 @@ func (d *DefaultRP) receiveContainerTerminated(
 	container := task.containers[id]
 	if names, ok := d.registeredNames[container]; ok {
 		for _, name := range names {
-			ctx.Tell(d.proxy, proxy.Unregister{Service: name})
+			ctx.Tell(d.proxy, proxy.Unregister{ServiceID: name})
 		}
 		delete(d.registeredNames, container)
 	}

--- a/master/internal/scheduler/kubernetes_resource_provider.go
+++ b/master/internal/scheduler/kubernetes_resource_provider.go
@@ -285,7 +285,7 @@ func (k *kubernetesResourceProvider) receivePodStarted(ctx *actor.Context, msg s
 		// assigned to an agent.
 		ctx.Ask(k.proxy, proxy.Register{
 			ServiceID: string(task.ID),
-			Target: &url.URL{
+			URL: &url.URL{
 				Scheme: "http",
 				Host:   fmt.Sprintf("%s:%d", msg.IP, port),
 			},

--- a/master/internal/scheduler/kubernetes_resource_provider.go
+++ b/master/internal/scheduler/kubernetes_resource_provider.go
@@ -284,7 +284,7 @@ func (k *kubernetesResourceProvider) receivePodStarted(ctx *actor.Context, msg s
 		// proxy multi-container tasks or when containers are created prior to being
 		// assigned to an agent.
 		ctx.Ask(k.proxy, proxy.Register{
-			Service: string(task.ID),
+			ServiceID: string(task.ID),
 			Target: &url.URL{
 				Scheme: "http",
 				Host:   fmt.Sprintf("%s:%d", msg.IP, port),
@@ -314,7 +314,7 @@ func (k *kubernetesResourceProvider) receivePodTerminated(
 	container.exitStatus = msg.ContainerStopped
 
 	for _, name := range k.registeredNames[container] {
-		ctx.Tell(k.proxy, proxy.Unregister{Service: name})
+		ctx.Tell(k.proxy, proxy.Unregister{ServiceID: name})
 	}
 
 	delete(container.agent.containers, container.id)


### PR DESCRIPTION
## Description
Idle TensorBoard instances are spun down after a configurable amount of time (via master.yaml). Adds `LastRequestedTime` to the services registered in the proxy. The tensorboard manager calls itself on a tick. Every 5 seconds it checks for TensorBoard instances that haven't received traffic after the configured amount of time. These instances are killed.


## Test Plan
Manually tested using local browser.
