### PR TITLE
fix: handle failed stack deletion

### DIFF
--- a/deploy/determined_deploy/aws/cli.py
+++ b/deploy/determined_deploy/aws/cli.py
@@ -108,6 +108,8 @@ def deploy_aws(args: argparse.Namespace) -> None:
         except Exception as e:
             print(e)
             print("Stack Deletion Failed. Check the AWS CloudFormation Console for details.")
+            sys.exit(1)
+
         print("Delete Successful")
         return
 


### PR DESCRIPTION
## Description
det-deploy aws did not properly handle stack deletions. 


## Test Plan
Manually tested creating and terminating stacks.

