### PR TITLE
fix: return the original tf.keras model when not training. [DET-3718]

### DIFF
--- a/docs/release-notes/1112-fix-keras-wrap.txt
+++ b/docs/release-notes/1112-fix-keras-wrap.txt
@@ -1,0 +1,6 @@
+:orphan:
+
+**Bug Fixes**
+
+- Fix Keras and Estimator wrapping functions not returning the original objects
+  when exporting checkpoints.

--- a/harness/determined/estimator/_estimator_context.py
+++ b/harness/determined/estimator/_estimator_context.py
@@ -34,6 +34,7 @@ class EstimatorContext:
     """
 
     def __init__(self, env: det.EnvContext, hvd_config: horovod.HorovodContext) -> None:
+        self.env = env
         self.hvd_config = hvd_config
         # TODO (DET-3798): Remove once customers are migrated.
         self.input_from_dataflow = env.experiment_config.input_from_dataflow()
@@ -52,6 +53,9 @@ class EstimatorContext:
         ``build_estimator()``, they should call ``optimizer = wrap_optimizer(optimzer)``
         prior to passing the optimizer into their Estimator.
         """
+        if not self.env.training:
+            return optimizer
+
         self.optimizer_initialized = True
         if not self.hvd_config.use:
             return optimizer
@@ -93,6 +97,9 @@ class EstimatorContext:
                 configure each process to use unique data.
 
         """
+        if not self.env.training:
+            return dataset
+
         hvd.require_horovod_type("tensorflow", "EstimatorContext.wrap_dataset was called.")
 
         self.dataset_initialized = True

--- a/harness/determined/keras/_tf_keras_context.py
+++ b/harness/determined/keras/_tf_keras_context.py
@@ -179,6 +179,9 @@ class TFKerasContext:
                 (one per slot) sees unique data. If set to False, users must manually
                 configure each process to use unique data.
         """
+        if not self.env.training:
+            return dataset
+
         self.dataset_initialized = True
         if not self.hvd_config.use or not isinstance(dataset, tf.data.Dataset) or not shard_dataset:
 
@@ -207,6 +210,9 @@ class TFKerasTrialContext(det.TrialContext, TFKerasContext):
         Args:
             model: tf.keras.Model
         """
+
+        if not self.env.training:
+            return model
         return self._wrap_model_with_train_fn(model, None)
 
 
@@ -216,6 +222,8 @@ class TFKerasNativeContext(det.NativeContext, TFKerasContext):
         TFKerasContext.__init__(self, env, hvd_config)
 
     def wrap_model(self, model: Any) -> Any:
+        if not self.env.training:
+            return model
         return self._wrap_model_with_train_fn(model, self._train_fn)
 
 


### PR DESCRIPTION
## Description

Previously, we return the wrapped model for both training and
model exporting. When training, the wrapped model is designed
to get the arguments of users' call on compile and fit. However,
when exporting checkpoints, users expect to get the original model.
So fix wrap_model to be no-op when not training.

## Test Plan

Use the CI suite.

## Commentary (optional)

N/A

<!-- User-facing API changes need the "User-facing API Change" label -->

<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

## Description

Lead with the intended commit body in this description field. For breaking changes, please include "BREAKING CHANGE:" at the beginning of your commit body. At minimum, this section should include a bracketed reference to the Jira ticket, e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.

## Test Plan

Describe the situations in which you've tested your change, and/or a screenshot as appropriate. Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.

## Commentary (optional)

Use this section of your description to add context to the PR. Could be for particularly tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc. You may intentionally leave this section blank and remove the title.
--->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234