### PR TITLE
fix: ensure properly wrapping in pytorch. [DET-3745]

### DIFF
--- a/docs/faq.txt
+++ b/docs/faq.txt
@@ -135,6 +135,21 @@ Core APIs, we recommend porting your model to use :ref:`Estimator Trial <estimat
 <https://github.com/determined-ai/determined/blob/master/examples/experimental/trial/mnist_tp_to_estimator/model_def.py>`_.
 
 
+Pytorch Supporrt
+----------------
+
+Why am I seeing significantly different metrics for trials which are paused and later continued (jumps in loss, worse convergence, etc) than trials which aren't paused?
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Please verify the following in the model code:
+
+* The model is wrapped with :meth:`wrap_model <determined.pytorch.PyTorchTrialContext.wrap_model>`.
+* The optimizer is wrapped with :meth:`wrap_optimizer <determined.pytorch.PyTorchTrialContext.wrap_optimizer>`
+  and based on the output of ``wrap_model``, not the original unwrapped model.
+* The LR scheduler is wrapped with :meth:`wrap_lr_scheduler <determined.pytorch.PyTorchTrialContext.wrap_lr_scheduler>`
+  and based on the output of ``wrap_optimizer``, not the original unwrapped optimizer.
+
+
 TensorBoard Support
 -------------------
 

--- a/docs/release-notes/1114-ensure-proper-wrapping.txt
+++ b/docs/release-notes/1114-ensure-proper-wrapping.txt
@@ -1,0 +1,6 @@
+:orphan:
+
+**Improvements**
+
+- Warn out if not properly refer Pytorch LR schedulers with a optimizer wrapped with
+  :meth:`determined.pytorch.PytorchTrialContext.wrap_optimizer`.

--- a/harness/determined/pytorch/_pytorch_context.py
+++ b/harness/determined/pytorch/_pytorch_context.py
@@ -189,12 +189,14 @@ class PyTorchTrialContext(det.TrialContext):
         The LR scheduler must use an optimizer wrapped by :meth:`wrap_optimizer`.  If ``apex.amp``
         is in use, the optimizer must also have been configured with :meth:`configure_apex_amp`.
         """
+        opt = getattr(lr_scheduler, "optimizer", None)
+        if opt is not None:
+            check.is_in(
+                opt,
+                self.optimizers,
+                "Must use an optimizer that is returned by wrap_optimizer()",
 
-        check.is_in(
-            lr_scheduler.optimizer,  # type: ignore
-            self.optimizers,
-            "Must use an optimizer that is returned by wrap_optimizer()",
-        )
+            )
         wrapped = pytorch.LRScheduler(lr_scheduler, step_mode)
         self.lr_schedulers.append(wrapped)
 

--- a/harness/determined/pytorch/_pytorch_context.py
+++ b/harness/determined/pytorch/_pytorch_context.py
@@ -192,10 +192,7 @@ class PyTorchTrialContext(det.TrialContext):
         opt = getattr(lr_scheduler, "optimizer", None)
         if opt is not None:
             check.is_in(
-                opt,
-                self.optimizers,
-                "Must use an optimizer that is returned by wrap_optimizer()",
-
+                opt, self.optimizers, "Must use an optimizer that is returned by wrap_optimizer()",
             )
         wrapped = pytorch.LRScheduler(lr_scheduler, step_mode)
         self.lr_schedulers.append(wrapped)

--- a/harness/determined/pytorch/_pytorch_trial.py
+++ b/harness/determined/pytorch/_pytorch_trial.py
@@ -171,6 +171,14 @@ class PyTorchTrialController(det.LoopTrialController):
 
             lr_scheduler = self.trial.create_lr_scheduler(optim)
             if lr_scheduler is not None:
+                opt = getattr(lr_scheduler._scheduler, "optimizer", None)
+                if opt is not None:
+                    check.is_in(
+                        opt,
+                        self.context.optimizers,
+                        "Must use a wrapped optimizer that is passed in by the optimizer argument of "
+                        "create_lr_scheduler",
+                    )
                 self.context.lr_schedulers.append(lr_scheduler)
 
             if det.ExperimentConfig(self.context.get_experiment_config()).mixed_precision_enabled():

--- a/harness/determined/pytorch/_pytorch_trial.py
+++ b/harness/determined/pytorch/_pytorch_trial.py
@@ -176,8 +176,8 @@ class PyTorchTrialController(det.LoopTrialController):
                     check.is_in(
                         opt,
                         self.context.optimizers,
-                        "Must use a wrapped optimizer that is passed in by the optimizer argument of "
-                        "create_lr_scheduler",
+                        "Must use a wrapped optimizer that is passed in by the optimizer "
+                        "argument of create_lr_scheduler",
                     )
                 self.context.lr_schedulers.append(lr_scheduler)
 


### PR DESCRIPTION
## Description

Users might not refer to the wrapped optimizer when creating an LR scheduler. We used to have checks in `wrap_lr_scheduler` but not in the backward compatibility code with the old API. This PR fixes that and adds a debugging FAQ to the Pytorch trial documentation for those kind of issues.

## Test Plan

Use the CI test suite.

## Commentary (optional)

N/A

<!-- User-facing API changes need the "User-facing API Change" label -->

<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

## Description

Lead with the intended commit body in this description field. For breaking changes, please include "BREAKING CHANGE:" at the beginning of your commit body. At minimum, this section should include a bracketed reference to the Jira ticket, e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.

## Test Plan

Describe the situations in which you've tested your change, and/or a screenshot as appropriate. Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.

## Commentary (optional)

Use this section of your description to add context to the PR. Could be for particularly tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc. You may intentionally leave this section blank and remove the title.
--->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234