### PR TITLE
feat: allow Python libraries in commands to use TLS for the master [DET-3899]

### DIFF
--- a/agent/internal/agent.go
+++ b/agent/internal/agent.go
@@ -29,6 +29,11 @@ import (
 	"github.com/determined-ai/determined/master/pkg/logger"
 )
 
+const (
+	insecureScheme = "http"
+	secureScheme   = "https"
+)
+
 type agent struct {
 	Version    string
 	Options    `json:"options"`
@@ -212,9 +217,9 @@ func (a *agent) getMasterInfo() error {
 		return errors.Wrap(err, "failed to construct TLS config")
 	}
 
-	masterProto := "http"
+	masterProto := insecureScheme
 	if tlsConfig != nil {
-		masterProto = "https"
+		masterProto = secureScheme
 	}
 	client := &http.Client{
 		Transport: &http.Transport{

--- a/agent/internal/containers.go
+++ b/agent/internal/containers.go
@@ -47,6 +47,11 @@ func (c *containerManager) Receive(ctx *actor.Context) error {
 		}
 		c.docker = d
 
+		masterScheme := insecureScheme
+		if c.Options.Security.TLS.Enabled {
+			masterScheme = secureScheme
+		}
+
 		masterHost := c.Options.ContainerMasterHost
 		if masterHost == "" {
 			masterHost = c.Options.MasterHost
@@ -60,7 +65,7 @@ func (c *containerManager) Receive(ctx *actor.Context) error {
 		c.GlobalEnvVars = []string{
 			fmt.Sprintf("DET_CLUSTER_ID=%s", c.MasterInfo.ClusterID),
 			fmt.Sprintf("DET_MASTER_ID=%s", c.MasterInfo.MasterID),
-			fmt.Sprintf("DET_MASTER=%s:%d", masterHost, masterPort),
+			fmt.Sprintf("DET_MASTER=%s://%s:%d", masterScheme, masterHost, masterPort),
 			fmt.Sprintf("DET_MASTER_HOST=%s", masterHost),
 			fmt.Sprintf("DET_MASTER_ADDR=%s", masterHost),
 			fmt.Sprintf("DET_MASTER_PORT=%d", masterPort),

--- a/common/determined_common/api/request.py
+++ b/common/determined_common/api/request.py
@@ -1,3 +1,4 @@
+import os
 import webbrowser
 from types import TracebackType
 from typing import Any, Dict, Iterator, Optional
@@ -16,6 +17,15 @@ _master_cert_bundle = None
 def set_master_cert_bundle(path: str) -> None:
     global _master_cert_bundle
     _master_cert_bundle = path
+
+
+# Set the bundle if one is specified by the environment. This is done on import since we can't
+# always count on having an entry point we control (e.g., if someone is importing this code in a
+# notebook).
+try:
+    set_master_cert_bundle(os.environ["DET_MASTER_CERT_FILE"])
+except KeyError:
+    pass
 
 
 def get_master_cert_bundle() -> Optional[str]:


### PR DESCRIPTION
## Description

This passes the same file and environment variables that we use for the
harness to command containers (which includes shells and notebooks (and
TensorBoards, though those won't actually use this)) to allow our Python
code within them to correctly connect to a master using TLS, including
the case of a custom certificate.

Having to handle the cert specially inside the container in the client
code is somewhat annoying, but I don't know of a way to install it
generally when we don't necessarily have root in the container.

## Test Plan

- [x] run `det shell start det e` on a master with TLS
- [x] run `subprocess.run(['det', 'e'])` in a notebook on a master with TLS
- [x] run `det cmd run bash -c "pip install -q /opt/determined/wheels/*; det e"` on a master with TLS
- [x] do the above on a master without TLS
