### PR TITLE
chore: rename websocket actors to be more descriptive

### DIFF
--- a/agent/internal/agent.go
+++ b/agent/internal/agent.go
@@ -317,7 +317,7 @@ func (a *agent) connectToMaster(ctx *actor.Context) error {
 	}
 	ctx.Log().Infof("successfully connected to master")
 
-	a.socket, _ = ctx.ActorOf("socket", api.WrapSocket(conn, proto.AgentMessage{}, true))
+	a.socket, _ = ctx.ActorOf("websocket", api.WrapSocket(conn, proto.AgentMessage{}, true))
 
 	started := proto.MasterMessage{AgentStarted: &proto.AgentStarted{
 		Version: a.Version, Devices: a.Devices, Label: a.Label}}

--- a/master/pkg/actor/api/ws.go
+++ b/master/pkg/actor/api/ws.go
@@ -47,7 +47,7 @@ func (w WebSocketConnected) Accept(
 		ctx.Respond(errors.Wrap(err, "websocket connection error"))
 		return nil, false
 	}
-	a, _ := ctx.ActorOf("websocket", WrapSocket(conn, msgType, usePing))
+	a, _ := ctx.ActorOf("websocket-" + uuid.New().String(), WrapSocket(conn, msgType, usePing))
 	ctx.Respond(a)
 	return a, true
 }

--- a/master/pkg/actor/api/ws.go
+++ b/master/pkg/actor/api/ws.go
@@ -47,7 +47,7 @@ func (w WebSocketConnected) Accept(
 		ctx.Respond(errors.Wrap(err, "websocket connection error"))
 		return nil, false
 	}
-	a, _ := ctx.ActorOf("websocket-" + uuid.New().String(), WrapSocket(conn, msgType, usePing))
+	a, _ := ctx.ActorOf("websocket-"+uuid.New().String(), WrapSocket(conn, msgType, usePing))
 	ctx.Respond(a)
 	return a, true
 }

--- a/master/pkg/actor/api/ws.go
+++ b/master/pkg/actor/api/ws.go
@@ -47,7 +47,7 @@ func (w WebSocketConnected) Accept(
 		ctx.Respond(errors.Wrap(err, "websocket connection error"))
 		return nil, false
 	}
-	a, _ := ctx.ActorOf(uuid.New(), WrapSocket(conn, msgType, usePing))
+	a, _ := ctx.ActorOf("websocket", WrapSocket(conn, msgType, usePing))
 	ctx.Respond(a)
 	return a, true
 }


### PR DESCRIPTION
## Description

Currently, the names of the websocket actors leads to uninformative logs. Improve naming to be consistent across agent/master and to be more descriptive.

Old:
```
determined-master  | INFO[2020-08-19T00:14:23-07:00] Creating actor       actorCreated=/agents/Armands-MBP.attlocal.net actorType="*agent.agent" logType=ActorEvents
determined-master  | INFO[2020-08-19T00:14:23-07:00] Creating actor       actorCreated=/agents/Armands-MBP.attlocal.net/37ca9e2f-12fb-4fec-8c11-fefea285b0f9 actorType="*api.websocketActor" logType=ActorEvents
determined-agent   | INFO[2020-08-19T00:14:23-07:00] Creating actor       actorCreated=/agent/socket actorType="*api.websocketActor" logType=ActorEvents
```

New:
```
determined-master  | INFO[2020-08-19T00:17:34-07:00] Creating actor       actorCreated=/agents/Armands-MBP.attlocal.net actorType="*agent.agent" logType=ActorEvents
determined-master  | INFO[2020-08-19T00:17:34-07:00] Creating actor       actorCreated=/agents/Armands-MBP.attlocal.net/websocket actorType="*api.websocketActor" logType=ActorEvents
determined-agent   | INFO[2020-08-19T00:17:34-07:00] Creating actor       actorCreated=/agent/websocket actorType="*api.websocketActor" logType=ActorEvents
```

## Test Plan

N/A

## Commentary (optional)

This PR brings up the concern of naming collisions if two websocket actors are created with the same parent actor. This doesn't appear to happen and I don't think there is ever a case where it should happen. Even if this were a case we cared about, relying on UUIDs to not collide isn't a great solution since we can use descriptive names that are guaranteed not to collide (although that would require a touch of refactoring given the current state of the code).

I also considered changing `ws.go` to
```
a, _ := ctx.ActorOf("websocket-" + uuid.New().String(), WrapSocket(conn, msgType, usePing))
```
but decided the we would be sacrificing log clarity to prevent a case which doesn't happen and probably shouldn't ever happen.