### PR TITLE
fix: recursively search log dir for tfevents [DET-3915]

### DIFF
--- a/harness/determined/tensorboard/base.py
+++ b/harness/determined/tensorboard/base.py
@@ -31,7 +31,7 @@ class TensorboardManager:
             )
             return []
 
-        return [f.resolve() for f in self.base_path.iterdir() if "tfevents" in f.name]
+        return [f.resolve() for f in self.base_path.glob("**/*tfevents*")]
 
     def to_sync(self) -> List[pathlib.Path]:
         """

--- a/harness/determined/tensorboard/gcs.py
+++ b/harness/determined/tensorboard/gcs.py
@@ -26,7 +26,7 @@ class GCSTensorboardManager(base.TensorboardManager):
     @util.preserve_random_state
     def sync(self) -> None:
         for path in self.to_sync():
-            blob_name = str(self.sync_path.joinpath(path.name))
+            blob_name = str(self.sync_path.joinpath(path.relative_to(self.base_path)))
             blob = self.bucket.blob(blob_name)
             logging.debug(f"Uploading to GCS: {blob_name}")
 

--- a/harness/determined/tensorboard/s3.py
+++ b/harness/determined/tensorboard/s3.py
@@ -33,7 +33,7 @@ class S3TensorboardManager(base.TensorboardManager):
     @util.preserve_random_state
     def sync(self) -> None:
         for path in self.to_sync():
-            key_name = str(self.sync_path.joinpath(path.name))
+            key_name = str(self.sync_path.joinpath(path.relative_to(self.base_path)))
 
             url = f"s3://{self.bucket}/{key_name}"
             logging.debug(f"Uploading {path} to {url}")

--- a/harness/determined/tensorboard/shared.py
+++ b/harness/determined/tensorboard/shared.py
@@ -27,7 +27,8 @@ class SharedFSTensorboardManager(base.TensorboardManager):
 
     def sync(self) -> None:
         for path in self.to_sync():
-            shared_fs_path = self.shared_fs_base.joinpath(path.name)
+            shared_fs_path = self.shared_fs_base.joinpath(path.relative_to(self.base_path))
+            pathlib.Path.mkdir(shared_fs_path.parent, exist_ok=True)
             shutil.copy(path, shared_fs_path)
 
             self._synced_event_sizes[path] = path.stat().st_size


### PR DESCRIPTION
## Description
The base tensorboard manager only identified tfevents files in the top level log directory. This change makes the search recursive to support subdirecties.


## Test Plan
Manually tested by uploading tfevents containing images to a subdirectory.