### PR TITLE
fix: make master cert file world-readable in containers

### DIFF
--- a/master/pkg/tasks/copy.go
+++ b/master/pkg/tasks/copy.go
@@ -83,7 +83,7 @@ func masterCertArchive(cert *tls.Certificate) container.RunArchive {
 
 	var arch archive.Archive
 	if len(certBytes) != 0 {
-		arch = append(arch, archive.RootItem(certPath, certBytes, 0600, tar.TypeReg))
+		arch = append(arch, archive.RootItem(certPath, certBytes, 0644, tar.TypeReg))
 	}
 	return wrapArchive(arch, "/")
 }


### PR DESCRIPTION
## Description

The master certificate file must be readable even for a non-root task,
of course.

## Test Plan

- [x] run a non-root experiment and see that it failed before but succeeds with this