### PR TITLE
fix: better handle tasks with mixed TLS/non-TLS masters

### DIFF
--- a/agent/internal/containers.go
+++ b/agent/internal/containers.go
@@ -66,6 +66,15 @@ func (c *containerManager) Receive(ctx *actor.Context) error {
 			fmt.Sprintf("DET_MASTER_PORT=%d", masterPort),
 			fmt.Sprintf("DET_AGENT_ID=%s", c.Options.AgentID),
 		}
+
+		// The master might be listening over both TLS and non-TLS, in which case it will send out
+		// TLS-related fields to all tasks, since it doesn't keep track of which port each agent used. But
+		// if this agent is using a non-TLS connection, we have to make sure tasks do as well, since we
+		// don't know the TLS port.
+		if !c.Options.Security.TLS.Enabled {
+			c.GlobalEnvVars = append(c.GlobalEnvVars, "DET_USE_TLS=false")
+		}
+
 		c.Labels = map[string]string{
 			dockerContainerTypeLabel: dockerContainerTypeValue,
 			dockerAgentLabel:         c.Options.AgentID,


### PR DESCRIPTION
## Description

If the master is listening over both TLS and non-TLS, it will send TLS
connection information to all containers, since it doesn't keep track of
whether each agent connected over TLS or not. But an agent that
connected over non-TLS would then create a task that tried to use TLS on
the non-TLS port, which would fail.

This updates the agent to avoid that by forcibly disabling TLS when the
agent itself didn't use it. It's a bit of a hack, but the mixed
TLS/non-TLS will soon be made impossible on the master side anyway.

## Test Plan

- [x] run a master listening on both TLS and non-TLS, start an agent connecting to the non-TLS port, run an experiment