### PR TITLE
fix: asha searcher progress for brackets with one rung [DET-3914]

### DIFF
--- a/master/pkg/searcher/asha.go
+++ b/master/pkg/searcher/asha.go
@@ -158,6 +158,13 @@ func (s *asyncHalvingSearch) promoteAsync(
 	var ops []Operation
 	// If the trial has completed the top rung's validation, close the trial.
 	if rungIndex == s.NumRungs-1 {
+		rung.metrics = append(rung.metrics,
+			trialMetric{
+				requestID: requestID,
+				metric:    metric,
+			},
+		)
+
 		if !s.earlyExitTrials[requestID] {
 			ops = append(ops, NewClose(requestID))
 			s.closedTrials[requestID] = true
@@ -228,7 +235,7 @@ func (s *asyncHalvingSearch) progress(float64) float64 {
 	// Give ourselves an overhead of 20% of maxTrials when calculating progress.
 	progress := float64(allTrials) / (1.2 * float64(s.maxTrials))
 	if allTrials == s.maxTrials {
-		return math.Max(float64(s.trialsCompleted)/float64(s.maxTrials), progress)
+		progress = math.Max(float64(s.trialsCompleted)/float64(s.maxTrials), progress)
 	}
 	return progress
 }

--- a/master/pkg/searcher/asha_test.go
+++ b/master/pkg/searcher/asha_test.go
@@ -209,6 +209,29 @@ func TestASHASearchMethod(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "single rung bracket",
+			expectedTrials: []predefinedTrial{
+				// The first trial is promoted due to asynchronous
+				// promotions despite being below top 1/3 of trials in
+				// base rung.
+				newConstantPredefinedTrial(toOps("9000B V"), 0.05),
+				newConstantPredefinedTrial(toOps("9000B V"), 0.06),
+				newConstantPredefinedTrial(toOps("9000B V"), 0.07),
+				newConstantPredefinedTrial(toOps("9000B V"), 0.08),
+			},
+			config: model.SearcherConfig{
+				AsyncHalvingConfig: &model.AsyncHalvingConfig{
+					Metric:              "error",
+					NumRungs:            1,
+					SmallerIsBetter:     true,
+					MaxLength:           model.NewLengthInBatches(9000),
+					MaxTrials:           4,
+					Divisor:             3,
+					MaxConcurrentTrials: maxConcurrentTrials,
+				},
+			},
+		},
 	}
 
 	runValueSimulationTestCases(t, testCases)


### PR DESCRIPTION
## Description
Progress is calculated incorrectly for brackets with a single rung since metrics are never added to the top rung.  This is fixed by adding metrics to the top rung when validationCompleted is called.  Note that this issue was not exposed through our adaptive_asha experiments because aggressive and standard mode would rarely run a bracket with a single rung.  


## Test Plan
I tested manually with the experiment config in https://determinedai.atlassian.net/browse/DET-3914 and also added an edge case test to asha_test.go.



## Commentary (optional)


<!-- User-facing API changes need the "User-facing API Change" label -->

<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

## Description

Lead with the intended commit body in this description field. For breaking changes, please include "BREAKING CHANGE:" at the beginning of your commit body. At minimum, this section should include a bracketed reference to the Jira ticket, e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.

## Test Plan

Describe the situations in which you've tested your change, and/or a screenshot as appropriate. Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.

## Commentary (optional)

Use this section of your description to add context to the PR. Could be for particularly tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc. You may intentionally leave this section blank and remove the title.
--->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234