### PR TITLE
fix: support shell with k8s

### DIFF
--- a/master/internal/command/shell_manager.go
+++ b/master/internal/command/shell_manager.go
@@ -25,7 +25,7 @@ import (
 
 const (
 	shellSSHDir             = "/run/determined/ssh"
-	shellAuthorizedKeysFile = "/run/determined/ssh/authorized_keys"
+	shellAuthorizedKeysFile = "/run/determined/ssh/authorized_keys_unmodified"
 	shellSSHDConfigFile     = "/run/determined/ssh/sshd_config"
 	shellHostPrivKeyFile    = "/run/determined/ssh/id_rsa"
 	shellHostPubKeyFile     = "/run/determined/ssh/id_rsa.pub"

--- a/master/static/srv/shell-entrypoint.sh
+++ b/master/static/srv/shell-entrypoint.sh
@@ -36,6 +36,12 @@ options="$(
         echo -n "environment=\"$var=$val\","
     done
 )"
-sed -i -e "s/^/$options /" "/run/determined/ssh/authorized_keys"
+
+# In k8s, the files we inject into the container are injected via individual
+# file-level bind mounts, which are effectively read-only in docker, so we are
+# unable to edit authorized_keys in place.
+unmodified="/run/determined/ssh/authorized_keys_unmodified"
+modified="/run/determined/ssh/authorized_keys"
+sed -e "s/^/$options /" "$unmodified" > "$modified"
 
 exec /usr/sbin/sshd "$@"


### PR DESCRIPTION
In k8s, the files we inject into the container are injected via
individual file-level bind mounts, which are effectively read-only in
docker.

As a result, shell-entrypoint.sh was unable to edit the authorized_keys
file in place, so it is now injected as authorized_keys_unmodified and
the modified version is written at runtime.