### PR TITLE
fix: apply user authentication to stream endpoints [DET-3935]

### DIFF
--- a/master/internal/grpc/api.go
+++ b/master/internal/grpc/api.go
@@ -40,6 +40,7 @@ func StartGRPCServer(db *db.PgDB, srv proto.DeterminedServer, port int) error {
 		grpc.StreamInterceptor(grpcmiddleware.ChainStreamServer(
 			grpclogrus.StreamServerInterceptor(logger, opts...),
 			grpcrecovery.StreamServerInterceptor(),
+			streamAuthInterceptor(db),
 		)),
 		grpc.UnaryInterceptor(grpcmiddleware.ChainUnaryServer(
 			grpclogrus.UnaryServerInterceptor(logger, opts...),
@@ -49,7 +50,7 @@ func StartGRPCServer(db *db.PgDB, srv proto.DeterminedServer, port int) error {
 					return status.Errorf(codes.Internal, "%s", p)
 				},
 			)),
-			authInterceptor(db),
+			unaryAuthInterceptor(db),
 		)),
 	)
 	proto.RegisterDeterminedServer(grpcS, srv)

--- a/master/internal/grpc/auth.go
+++ b/master/internal/grpc/auth.go
@@ -68,7 +68,18 @@ func GetUser(ctx context.Context, d *db.PgDB) (*model.User, *model.UserSession, 
 	}
 }
 
-func authInterceptor(db *db.PgDB) grpc.UnaryServerInterceptor {
+func streamAuthInterceptor(db *db.PgDB) grpc.StreamServerInterceptor {
+	return func(
+		srv interface{}, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler,
+	) error {
+		if _, _, err := GetUser(ss.Context(), db); err != nil {
+			return err
+		}
+		return handler(srv, ss)
+	}
+}
+
+func unaryAuthInterceptor(db *db.PgDB) grpc.UnaryServerInterceptor {
 	return func(
 		ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler,
 	) (resp interface{}, err error) {


### PR DESCRIPTION
## Description

We previously had an interceptor in place to ensure authentication for
unary gRPC endpoints, but it was missing for stream endpoints, allowing
stream endpoints to be accessed by anybody.

## Test Plan

- [x] verify that stream endpoints (`/api/v1/master/logs` and `/api/v1/trials/<id>/logs`) can't be accessed without valid credentials, which could happen before
