### PR TITLE
fix: refrain from loading experiment configs where they aren't needed

### DIFF
--- a/master/internal/api_experiment.go
+++ b/master/internal/api_experiment.go
@@ -231,7 +231,7 @@ func (a *apiServer) ArchiveExperiment(
 ) (*apiv1.ArchiveExperimentResponse, error) {
 	id := int(req.Id)
 
-	dbExp, err := a.m.db.ExperimentByID(id)
+	dbExp, err := a.m.db.ExperimentWithoutConfigByID(id)
 	if err != nil {
 		return nil, errors.Wrapf(err, "loading experiment %v", id)
 	}
@@ -259,7 +259,7 @@ func (a *apiServer) UnarchiveExperiment(
 ) (*apiv1.UnarchiveExperimentResponse, error) {
 	id := int(req.Id)
 
-	dbExp, err := a.m.db.ExperimentByID(id)
+	dbExp, err := a.m.db.ExperimentWithoutConfigByID(id)
 	if err != nil {
 		return nil, errors.Wrapf(err, "loading experiment %v", id)
 	}

--- a/master/internal/db/postgres.go
+++ b/master/internal/db/postgres.go
@@ -676,6 +676,23 @@ WHERE id = $1`, &experiment, id); err != nil {
 	return &experiment, nil
 }
 
+// ExperimentWithoutConfigByID looks up an experiment by ID in a database, returning an error if
+// none exists. It loads the experiment without its configuration, for callers that do not need
+// it, or can't handle backwards incompatible changes.
+func (db *PgDB) ExperimentWithoutConfigByID(id int) (*model.Experiment, error) {
+	var experiment model.Experiment
+
+	if err := db.query(`
+SELECT id, state, model_definition, start_time, end_time, archived,
+       git_remote, git_commit, git_committer, git_commit_date, owner_id
+FROM experiments
+WHERE id = $1`, &experiment, id); err != nil {
+		return nil, err
+	}
+
+	return &experiment, nil
+}
+
 // ExperimentByTrialID looks up an experiment by a trial ID in the
 // database, returning an error if the experiment doesn't exist.
 func (db *PgDB) ExperimentByTrialID(id int) (*model.Experiment, error) {


### PR DESCRIPTION

## Description
This change changes `/api/v1/experiments/1/unarchive` and `/api/v1/experiments/1/archive` to not load the entire experiment configuration when trying to check if an experiment is valid to be archived or unarchived. Without this, experiments whose configurations have been around through breaking changes cannot be archived.


## Test Plan
- [x] check I can archive an experiment with an old configuration

<img width="1456" alt="Screen Shot 2020-08-19 at 8 34 04 PM" src="https://user-images.githubusercontent.com/9650546/90703277-54278980-e25b-11ea-96c2-6f78acf9fba5.png">
## Commentary (optional)


<!-- User-facing API changes need the "User-facing API Change" label -->

<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

## Description

Lead with the intended commit body in this description field. For breaking changes, please include "BREAKING CHANGE:" at the beginning of your commit body. At minimum, this section should include a bracketed reference to the Jira ticket, e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.

## Test Plan

Describe the situations in which you've tested your change, and/or a screenshot as appropriate. Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.

## Commentary (optional)

Use this section of your description to add context to the PR. Could be for particularly tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc. You may intentionally leave this section blank and remove the title.
--->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234