### PR TITLE
fix: validate hyperparameter configs

### DIFF
--- a/master/pkg/model/experiment_config_test.go
+++ b/master/pkg/model/experiment_config_test.go
@@ -107,6 +107,11 @@ func validGridSearchConfig() ExperimentConfig {
 		},
 	}
 	config.Hyperparameters = map[string]Hyperparameter{
+		GlobalBatchSize: {
+			ConstHyperparameter: &ConstHyperparameter{
+				Val: 64,
+			},
+		},
 		"const": {
 			ConstHyperparameter: &ConstHyperparameter{
 				Val: map[string]interface{}{

--- a/master/pkg/model/hyperparameters_config.go
+++ b/master/pkg/model/hyperparameters_config.go
@@ -4,9 +4,10 @@ import (
 	"encoding/json"
 	"sort"
 
+	"github.com/pkg/errors"
+
 	"github.com/determined-ai/determined/master/pkg/check"
 	"github.com/determined-ai/determined/master/pkg/union"
-	"github.com/pkg/errors"
 )
 
 // GlobalBatchSize is the name of the hyperparameter for global_batch_size.
@@ -27,14 +28,14 @@ func (h Hyperparameters) Validate() []error {
 	case b.ConstHyperparameter != nil:
 		if !isNumeric(b.ConstHyperparameter.Val) {
 			return []error{
-				errors.New("global_batch_size must be a numeric value"),
+				errors.New("global_batch_size hyperparameter must be a numeric value"),
 			}
 		}
 	case b.CategoricalHyperparameter != nil:
 		for _, val := range b.CategoricalHyperparameter.Vals {
 			if !isNumeric(val) {
 				return []error{
-					errors.New("global_batch_size must be a numeric value"),
+					errors.New("global_batch_size hyperparameter must be a numeric value"),
 				}
 			}
 		}

--- a/master/pkg/model/hyperparameters_config.go
+++ b/master/pkg/model/hyperparameters_config.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/determined-ai/determined/master/pkg/check"
 	"github.com/determined-ai/determined/master/pkg/union"
+	"github.com/pkg/errors"
 )
 
 // GlobalBatchSize is the name of the hyperparameter for global_batch_size.
@@ -13,6 +14,39 @@ const GlobalBatchSize = "global_batch_size"
 
 // Hyperparameters holds a mapping from hyperparameter name to its configuration.
 type Hyperparameters map[string]Hyperparameter
+
+// Validate implements the check.Validatable interface.
+func (h Hyperparameters) Validate() []error {
+	b, ok := h[GlobalBatchSize]
+	if !ok {
+		return []error{
+			errors.New("global_batch_size hyperparameter must be specified"),
+		}
+	}
+	switch {
+	case b.ConstHyperparameter != nil:
+		if !isNumeric(b.ConstHyperparameter.Val) {
+			return []error{
+				errors.New("global_batch_size must be a numeric value"),
+			}
+		}
+	case b.CategoricalHyperparameter != nil:
+		for _, val := range b.CategoricalHyperparameter.Vals {
+			if !isNumeric(val) {
+				return []error{
+					errors.New("global_batch_size must be a numeric value"),
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func isNumeric(val interface{}) bool {
+	_, iOk := val.(int)
+	_, fOk := val.(float64)
+	return iOk || fOk
+}
 
 // Each applies the function to each hyperparameter in string order of the name.
 func (h Hyperparameters) Each(f func(name string, param Hyperparameter)) {

--- a/master/pkg/model/hyperparameters_config_test.go
+++ b/master/pkg/model/hyperparameters_config_test.go
@@ -41,7 +41,7 @@ func TestValidateGlobalBatchSize(t *testing.T) {
 					"val": "okok"
 				}
 			}}`,
-			"global_batch_size must be a numeric value",
+			"global_batch_size hyperparameter must be a numeric value",
 		},
 		{
 			"valid categorical global_batch_size",
@@ -63,7 +63,7 @@ func TestValidateGlobalBatchSize(t *testing.T) {
 				  "vals": ["32", "hello"]
 				}
 			}}`,
-			"global_batch_size must be a numeric value",
+			"global_batch_size hyperparameter must be a numeric value",
 		},
 	}
 

--- a/master/pkg/model/hyperparameters_config_test.go
+++ b/master/pkg/model/hyperparameters_config_test.go
@@ -1,0 +1,84 @@
+package model
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/determined-ai/determined/master/pkg/check"
+	"gotest.tools/assert"
+)
+
+func TestValidateGlobalBatchSize(t *testing.T) {
+	type testCase struct {
+		name         string
+		config       string
+		errorMessage string
+	}
+	testCases := []testCase{
+		{
+			"valid hyperparameters",
+			`{
+			"hyperparameters": {
+				"global_batch_size": {
+					"type": "const",
+					"val": 32
+				}
+			}}`,
+			"",
+		},
+		{
+			"missing global_batch_size",
+			`{"hyperparameters": {}}`,
+			"global_batch_size hyperparameter must be specified",
+		},
+		{
+			"invalid global_batch_size",
+			`{
+			"hyperparameters": {
+				"global_batch_size": {
+					"type": "const",
+					"val": "okok"
+				}
+			}}`,
+			"global_batch_size must be a numeric value",
+		},
+		{
+			"valid categorical global_batch_size",
+			`{
+			"hyperparameters": {
+				"global_batch_size": {
+				  "type": "categorical",
+				  "vals": [32, 64]
+				}
+			}}`,
+			"",
+		},
+		{
+			"invalid categorical global_batch_size",
+			`{
+			"hyperparameters": {
+				"global_batch_size": {
+				  "type": "categorical",
+				  "vals": ["32", "hello"]
+				}
+			}}`,
+			"global_batch_size must be a numeric value",
+		},
+	}
+
+	runTestCase := func(t *testing.T, tc testCase) {
+		t.Run(tc.name, func(t *testing.T) {
+			conf := DefaultExperimentConfig()
+			assert.NilError(t, json.Unmarshal([]byte(tc.config), &conf))
+			if tc.errorMessage != "" {
+				assert.ErrorContains(t, check.Validate(conf.Hyperparameters), tc.errorMessage)
+			} else {
+				assert.NilError(t, check.Validate(conf.Hyperparameters))
+			}
+		})
+	}
+
+	for _, tc := range testCases {
+		runTestCase(t, tc)
+	}
+}

--- a/master/pkg/model/hyperparameters_config_test.go
+++ b/master/pkg/model/hyperparameters_config_test.go
@@ -4,8 +4,9 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/determined-ai/determined/master/pkg/check"
 	"gotest.tools/assert"
+
+	"github.com/determined-ai/determined/master/pkg/check"
 )
 
 func TestValidateGlobalBatchSize(t *testing.T) {


### PR DESCRIPTION
## Description
This change adds validation to the `hyperparameter` configuration section, to check if `global_batch_size` has been specified and if it is numeric.


## Test Plan

- [x] add unit tests.

## Commentary (optional)
Before remove steps, we didn't use the hyperparameters in the master at all. Now we use `global_batch_size`, so we should check if it exists first.

<!-- User-facing API changes need the "User-facing API Change" label -->

<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

## Description

Lead with the intended commit body in this description field. For breaking changes, please include "BREAKING CHANGE:" at the beginning of your commit body. At minimum, this section should include a bracketed reference to the Jira ticket, e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.

## Test Plan

Describe the situations in which you've tested your change, and/or a screenshot as appropriate. Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.

## Commentary (optional)

Use this section of your description to add context to the PR. Could be for particularly tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc. You may intentionally leave this section blank and remove the title.
--->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234