### PR TITLE
chore: convert owner to user in react code [DET-3519]

### DIFF
--- a/webui/react/src/contexts/AppContexts.tsx
+++ b/webui/react/src/contexts/AppContexts.tsx
@@ -13,7 +13,7 @@ import {
   getTensorboards, getUsers,
 } from 'services/api';
 import { EmptyParams, ExperimentsParams } from 'services/types';
-import { Agent, Command, Experiment, User } from 'types';
+import { Agent, Command, DetailedUser, Experiment } from 'types';
 import { activeRunStates } from 'utils/types';
 
 const AppContexts: React.FC = () => {
@@ -27,7 +27,7 @@ const AppContexts: React.FC = () => {
   const setTensorboards = Tensorboards.useActionContext();
   const setOverview = ClusterOverview.useActionContext();
   const [ usersResponse, triggerUsersRequest ] =
-    useRestApi<EmptyParams, User[]>(getUsers, {});
+    useRestApi<EmptyParams, DetailedUser[]>(getUsers, {});
   const [ agentsResponse, triggerAgentsRequest ] =
     useRestApi<EmptyParams, Agent[]>(getAgents, {});
   const [ commandsResponse, triggerCommandsRequest ] =

--- a/webui/react/src/contexts/Users.tsx
+++ b/webui/react/src/contexts/Users.tsx
@@ -1,8 +1,8 @@
 import { generateContext } from 'contexts';
 import { RestApiState } from 'hooks/useRestApi';
-import { User } from 'types';
+import { DetailedUser } from 'types';
 
-const contextProvider = generateContext<RestApiState<User[]>>({
+const contextProvider = generateContext<RestApiState<DetailedUser[]>>({
   initialState: {
     errorCount: 0,
     hasLoaded: false,

--- a/webui/react/src/ioTypes.ts
+++ b/webui/react/src/ioTypes.ts
@@ -25,17 +25,17 @@ const ioNullOrUndefined = io.union([ io.null, io.undefined ]);
 
 /* User */
 
-export const ioUser = io.type({
+export const ioDetailedUser = io.type({
   active: io.boolean,
   admin: io.boolean,
   id: io.number,
   username: io.string,
 });
 
-export const ioUsers = io.array(ioUser);
+export const ioDetailedUsers = io.array(ioDetailedUser);
 
-export type ioTypeUser = io.TypeOf<typeof ioUser>;
-export type ioTypeUsers = io.TypeOf<typeof ioUsers>;
+export type ioTypeDetailedUser = io.TypeOf<typeof ioDetailedUser>;
+export type ioTypeDetailedUsers = io.TypeOf<typeof ioDetailedUsers>;
 
 /* Info */
 
@@ -90,7 +90,7 @@ export type ioTypeAgents = io.TypeOf<typeof ioAgents>;
 
 /* Generic Command */
 
-const ioOwner = io.type({
+const ioUser = io.type({
   id: io.number,
   username: io.string,
 });
@@ -121,7 +121,7 @@ export const ioGenericCommand = io.type({
   exit_status: io.union([ io.string, ioNullOrUndefined ]),
   id: io.string,
   misc: io.union([ ioCommandMisc, ioNullOrUndefined ]),
-  owner: ioOwner,
+  owner: ioUser,
   registered_time: io.string,
   service_address: io.union([ io.string, ioNullOrUndefined ]),
   state: commandStatesIoType,
@@ -287,7 +287,7 @@ export const ioExperimentDetails = io.type({
   config: ioExperimentConfig,
   end_time: io.union([ io.string, ioNullOrUndefined ]),
   id: io.number,
-  owner: ioOwner,
+  owner: ioUser,
   progress: io.union([ io.number, ioNullOrUndefined ]),
   start_time: io.string,
   state: runStatesIoType,

--- a/webui/react/src/services/api.ts
+++ b/webui/react/src/services/api.ts
@@ -9,8 +9,8 @@ import { CreateNotebookParams, CreateTensorboardParams, EmptyParams,
   TrialDetailsParams, TrialLogsParams,
 } from 'services/types';
 import {
-  Agent, AnyTask, Command, CommandType, Credentials, DeterminedInfo, Experiment, ExperimentDetails,
-  Log, TrialDetails, User,
+  Agent, AnyTask, Command, CommandType, Credentials, DetailedUser, DeterminedInfo, Experiment,
+  ExperimentDetails, Log, TrialDetails,
 } from 'types';
 import { serverAddress } from 'utils/routes';
 import { isExperimentTask } from 'utils/task';
@@ -38,9 +38,9 @@ export const isNotFound = (e: any): boolean => {
   return e.response && e.response.status && e.response.status === 404;
 };
 
-export const getCurrentUser = generateApi<EmptyParams, User>(Config.getCurrentUser);
+export const getCurrentUser = generateApi<EmptyParams, DetailedUser>(Config.getCurrentUser);
 
-export const getUsers = generateApi<EmptyParams, User[]>(Config.getUsers);
+export const getUsers = generateApi<EmptyParams, DetailedUser[]>(Config.getUsers);
 
 /* Info */
 

--- a/webui/react/src/services/apiConfig.ts
+++ b/webui/react/src/services/apiConfig.ts
@@ -1,7 +1,7 @@
 import { sha512 } from 'js-sha512';
 import queryString from 'query-string';
 
-import { decode, ioTypeUser, ioUser } from 'ioTypes';
+import { decode, ioDetailedUser, ioTypeDetailedUser } from 'ioTypes';
 import { Api } from 'services/apiBuilder';
 import {
   jsonToAgents, jsonToCommands, jsonToDeterminedInfo,
@@ -16,8 +16,8 @@ import {
   TaskLogsParams, TrialDetailsParams, TrialLogsParams,
 } from 'services/types';
 import {
-  Agent, Command, CommandType, Credentials, DeterminedInfo, Experiment, ExperimentDetails,
-  Log, TBSourceType, TrialDetails, User,
+  Agent, Command, CommandType, Credentials, DetailedUser, DeterminedInfo, Experiment,
+  ExperimentDetails, Log, TBSourceType, TrialDetails,
 } from 'types';
 
 /* Helpers */
@@ -48,11 +48,11 @@ export const login: Api<Credentials, void> = {
   name: 'login',
 };
 
-export const getCurrentUser: Api<EmptyParams, User> = {
+export const getCurrentUser: Api<EmptyParams, DetailedUser> = {
   httpOptions: () => ({ url: '/users/me' }),
   name: 'getCurrentUser',
   postProcess: (response) => {
-    const result = decode<ioTypeUser>(ioUser, response.data);
+    const result = decode<ioTypeDetailedUser>(ioDetailedUser, response.data);
     return {
       id: result.id,
       isActive: result.active,
@@ -62,7 +62,7 @@ export const getCurrentUser: Api<EmptyParams, User> = {
   },
 };
 
-export const getUsers: Api<EmptyParams, User[]> = {
+export const getUsers: Api<EmptyParams, DetailedUser[]> = {
   httpOptions: () => ({ url: '/users' }),
   name: 'getUsers',
   postProcess: (response) => jsonToUsers(response.data),

--- a/webui/react/src/services/decoder.ts
+++ b/webui/react/src/services/decoder.ts
@@ -8,8 +8,8 @@ import {
   ioLogs, ioTaskLogs, ioTrialDetails, ioTypeAgents,
   ioTypeCheckpoint, ioTypeDetailedUsers, ioTypeDeterminedInfo,
   ioTypeExperiment, ioTypeExperimentConfig, ioTypeExperimentDetails, ioTypeExperiments,
-  ioTypeGenericCommand, ioTypeGenericCommands, ioTypeLog, ioTypeLogs, ioTypeMetric, ioTypeStep, ioTypeTaskLogs,
-  ioTypeTrial, ioTypeTrialDetails, ioTypeValidationMetrics,
+  ioTypeGenericCommand, ioTypeGenericCommands, ioTypeLog, ioTypeLogs, ioTypeMetric, ioTypeStep,
+  ioTypeTaskLogs, ioTypeTrial, ioTypeTrialDetails, ioTypeValidationMetrics,
 } from 'ioTypes';
 import {
   Agent, Checkpoint, CheckpointState, CheckpointStorageType, Command, CommandState,

--- a/webui/react/src/services/decoder.ts
+++ b/webui/react/src/services/decoder.ts
@@ -3,19 +3,19 @@ import { isNumber } from 'util';
 import dayjs from 'dayjs';
 
 import {
-  decode, ioAgents, ioDeterminedInfo, ioExperiment,
-  ioExperimentDetails, ioExperiments, ioGenericCommand, ioGenericCommands, ioLog, ioLogs,
-  ioTaskLogs, ioTrialDetails, ioTypeAgents, ioTypeCheckpoint,
-  ioTypeDeterminedInfo, ioTypeExperiment, ioTypeExperimentConfig,
-  ioTypeExperimentDetails, ioTypeExperiments, ioTypeGenericCommand, ioTypeGenericCommands,
-  ioTypeLog, ioTypeLogs, ioTypeMetric, ioTypeStep, ioTypeTaskLogs, ioTypeTrial, ioTypeTrialDetails,
-  ioTypeUsers, ioTypeValidationMetrics, ioUsers,
+  decode, ioAgents, ioDetailedUsers, ioDeterminedInfo,
+  ioExperiment, ioExperimentDetails, ioExperiments, ioGenericCommand, ioGenericCommands, ioLog,
+  ioLogs, ioTaskLogs, ioTrialDetails, ioTypeAgents,
+  ioTypeCheckpoint, ioTypeDetailedUsers, ioTypeDeterminedInfo,
+  ioTypeExperiment, ioTypeExperimentConfig, ioTypeExperimentDetails, ioTypeExperiments,
+  ioTypeGenericCommand, ioTypeGenericCommands, ioTypeLog, ioTypeLogs, ioTypeMetric, ioTypeStep, ioTypeTaskLogs,
+  ioTypeTrial, ioTypeTrialDetails, ioTypeValidationMetrics,
 } from 'ioTypes';
 import {
   Agent, Checkpoint, CheckpointState, CheckpointStorageType, Command, CommandState,
-  CommandType, DeterminedInfo, Experiment, ExperimentConfig, ExperimentDetails,
-  Log, LogLevel, RawJson, ResourceState, ResourceType, RunState,
-  Step, TrialDetails, TrialItem, User, ValidationMetrics,
+  CommandType, DetailedUser, DeterminedInfo, Experiment, ExperimentConfig,
+  ExperimentDetails, Log, LogLevel, RawJson, ResourceState, ResourceType,
+  RunState, Step, TrialDetails, TrialItem, ValidationMetrics,
 } from 'types';
 import { capitalize } from 'utils/string';
 
@@ -27,8 +27,8 @@ const dropNullMetrics = (ioMetrics: ioTypeMetric): Record<string, number> => {
   return metrics;
 };
 
-export const jsonToUsers = (data: unknown): User[] => {
-  const io = decode<ioTypeUsers>(ioUsers, data);
+export const jsonToUsers = (data: unknown): DetailedUser[] => {
+  const io = decode<ioTypeDetailedUsers>(ioDetailedUsers, data);
   return io.map(user => ({
     id: user.id,
     isActive: user.active,
@@ -91,13 +91,13 @@ export const jsonToGenericCommand = (data: unknown, type: CommandType): Command 
       experimentIds: io.misc.experiment_ids || undefined,
       trialIds: io.misc.trial_ids || undefined,
     } : undefined,
-    owner: {
-      id: io.owner.id,
-      username: io.owner.username,
-    },
     registeredTime: io.registered_time,
     serviceAddress: io.service_address || undefined,
     state: io.state as CommandState,
+    user: {
+      id: io.owner.id,
+      username: io.owner.username,
+    },
   };
 };
 
@@ -168,10 +168,10 @@ export const jsonToExperiment = (data: unknown): Experiment => {
     configRaw: (data as { config: RawJson }).config,
     endTime: io.end_time || undefined,
     id: io.id,
-    ownerId: io.owner_id,
     progress: io.progress != null ? io.progress : undefined,
     startTime: io.start_time,
     state: io.state as RunState,
+    userId: io.owner_id,
   };
 };
 
@@ -268,11 +268,11 @@ export const jsonToExperimentDetails = (data: unknown): ExperimentDetails => {
     configRaw: (data as { config: RawJson }).config,
     endTime: io.end_time || undefined,
     id: io.id,
-    ownerId: io.owner.id,
     progress: io.progress != null ? io.progress : undefined,
     startTime: io.start_time,
     state: io.state as RunState,
     trials: io.trials.map(ioToTrial),
+    userId: io.owner.id,
     username: io.owner.username,
     validationHistory: io.validation_history.map(vh => ({
       endTime: vh.end_time,

--- a/webui/react/src/types.ts
+++ b/webui/react/src/types.ts
@@ -3,9 +3,12 @@ export type RawJson = Record<string, any>;
 
 export interface User {
   id: number;
+  username: string;
+}
+
+export interface DetailedUser extends User {
   isActive: boolean;
   isAdmin: boolean;
-  username: string;
 }
 
 export interface Auth {
@@ -116,11 +119,6 @@ export interface CommandAddress {
   protocol?: string;
 }
 
-export interface Owner {
-  id: number;
-  username: string;
-}
-
 export enum CommandType {
   Command = 'COMMAND',
   Notebook = 'NOTEBOOK',
@@ -144,7 +142,7 @@ export interface Command {
   exitStatus?: string;
   id: string;
   misc?: CommandMisc;
-  owner: Owner;
+  user: User;
   registeredTime: string;
   serviceAddress?: string;
   state: CommandState;
@@ -298,7 +296,7 @@ export interface Experiment {
   configRaw: RawJson; // Readonly unparsed config object.
   endTime?: string;
   id: number;
-  ownerId: number;
+  userId: number;
   progress?: number;
   startTime: string;
   state: RunState;
@@ -319,7 +317,7 @@ export interface ExperimentDetails extends Experiment {
 export interface Task {
   name: string;
   id: string;
-  ownerId: number;
+  userId: number;
   url?: string;
   startTime: string;
 }

--- a/webui/react/src/utils/task.ts
+++ b/webui/react/src/utils/task.ts
@@ -1,7 +1,7 @@
 import {
-  ALL_VALUE, AnyTask, CommandState, CommandTask, CommandType, Experiment, ExperimentFilters,
-  ExperimentItem, ExperimentTask, RecentCommandTask, RecentEvent, RecentExperimentTask,
-  RecentTask, RunState, Task, TaskFilters, TaskType, User,
+  ALL_VALUE, AnyTask, CommandState, CommandTask, CommandType, DetailedUser, Experiment,
+  ExperimentFilters, ExperimentItem, ExperimentTask, RecentCommandTask, RecentEvent,
+  RecentExperimentTask, RecentTask, RunState, Task, TaskFilters, TaskType, User,
 } from 'types';
 import { terminalCommandStates } from 'utils/types';
 
@@ -32,9 +32,9 @@ function generateTask(idx: number): Task & RecentEvent {
       name: 'opened',
     },
     name: `${idx}`,
-    ownerId: user.id,
     startTime,
     url: '#',
+    userId: user.id,
   };
 }
 
@@ -53,7 +53,7 @@ export function generateExperimentTask(idx: number): RecentExperimentTask {
 export function generateCommandTask(idx: number): RecentCommandTask {
   const state = getRandomElementOfEnum(CommandState);
   const task = generateTask(idx);
-  let username = sampleUsers.find(user => user.id === task.ownerId)?.username;
+  let username = sampleUsers.find(user => user.id === task.userId)?.username;
   if (!username)
     username = sampleUsers[Math.floor(Math.random() * sampleUsers.length)].username;
   return {
@@ -140,7 +140,7 @@ const matchesUser = <T extends AnyTask | ExperimentItem>(
 ): boolean => {
   if (!username) return true;
   const selectedUser = users.find(u => u.username === username);
-  return !!selectedUser && (task.ownerId === selectedUser.id);
+  return !!selectedUser && (task.userId === selectedUser.id);
 };
 
 export const filterExperiments = (
@@ -193,7 +193,7 @@ export const processExperiments = (experiments: Experiment[], users: User[]): Ex
       ...experiment,
       name: experiment.config.description,
       url: `/det/experiments/${experiment.id}`,
-      username: userMap[experiment.ownerId],
+      username: userMap[experiment.userId],
     };
   });
 };

--- a/webui/react/src/utils/task.ts
+++ b/webui/react/src/utils/task.ts
@@ -1,5 +1,5 @@
 import {
-  ALL_VALUE, AnyTask, CommandState, CommandTask, CommandType, DetailedUser, Experiment,
+  ALL_VALUE, AnyTask, CommandState, CommandTask, CommandType, Experiment,
   ExperimentFilters, ExperimentItem, ExperimentTask, RecentCommandTask, RecentEvent,
   RecentExperimentTask, RecentTask, RunState, Task, TaskFilters, TaskType, User,
 } from 'types';

--- a/webui/react/src/utils/types.ts
+++ b/webui/react/src/utils/types.ts
@@ -34,12 +34,12 @@ export const commandToTask = (command: Command): RecentCommandTask => {
     },
     misc: command.misc,
     name,
-    ownerId: command.owner.id,
     startTime: command.registeredTime,
     state: command.state as CommandState,
     type: command.kind,
     url: waitPageUrl(command),
-    username: command.owner.username,
+    userId: command.user.id,
+    username: command.user.username,
   };
   return task;
 };
@@ -53,11 +53,11 @@ export const experimentToTask = (experiment: Experiment): RecentExperimentTask =
     id: `${experiment.id}`,
     lastEvent,
     name: experiment.config.description,
-    ownerId: experiment.ownerId,
     progress: experiment.progress,
     startTime: experiment.startTime,
     state: experiment.state,
     url: `/det/experiments/${experiment.id}`,
+    userId: experiment.userId,
   };
   return task;
 };


### PR DESCRIPTION
## Description

Currently in the React code there is both a User type and an Owner type that are very similar. This PR standardizes the naming convention by changing the types to User and DetailedUser


## Test Plan

Tested as much as I could manually. I tried to hit all of the relevant endpoints and can't find anything broken.

## Commentary (optional)

One thing that is difficult to review: I renamed `User` to `DetailedUser` and `Owner` to `User` and I also converted some functions that did not need user details to use the less detailed type. This means that they were originally typed with `User`, they were then changed to `DetailedUser` as part of the renaming and then the were changed to use `User` (previously known as `Owner`) because they only needed the id/username. These examples don't show up in the diff at all. 

For example, this happens with the `Auth` type because it only ever uses `id`/`username`.


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234