### PR TITLE
fix: enable pagination size picker when entries are at least 10 count [DET-3931]

### DIFF
--- a/docs/release-notes/1140-fix-archive-pagination.txt
+++ b/docs/release-notes/1140-fix-archive-pagination.txt
@@ -1,0 +1,12 @@
+:orphan:
+
+**Bug Fixes**
+
+- Correct table pagination behavior.
+
+  - Hide pagination when there are less than 10 items.
+  - Show pagination and page size picker when there are 10 or more items.
+  - Persist pagination and page size picker (both are strongly tied to each other
+    via Ant Design). This will ensure that the page size picker can stick around
+    to allow the user to change the page size even when the number of entries is
+    less than page size.

--- a/webui/react/src/components/Table.tsx
+++ b/webui/react/src/components/Table.tsx
@@ -18,6 +18,12 @@ import css from './Table.module.scss';
 
 type TableRecord = CommandTask | ExperimentItem | TrialItem;
 
+export interface TablePagination {
+  defaultPageSize: number;
+  hideOnSinglePage: boolean;
+  showSizeChanger: boolean;
+}
+
 export type Renderer<T = unknown> = (text: string, record: T, index: number) => React.ReactNode;
 
 export type GenericRenderer = <T extends TableRecord>(
@@ -26,6 +32,8 @@ export type GenericRenderer = <T extends TableRecord>(
 
 type ExperimentRenderer = (text: string, record: ExperimentItem, index: number) => React.ReactNode;
 export type TaskRenderer = (text: string, record: CommandTask, index: number) => React.ReactNode;
+
+const MINIMUM_PAGE_SIZE = 10;
 
 /* Table Column Renderers */
 
@@ -137,4 +145,12 @@ export const findColumnByTitle: <T>(c: ColumnType<T>[], s: string) => number = (
   search,
 ) => {
   return columns.findIndex(column => new RegExp(search, 'i').test(column.title as string));
+};
+
+export const getPaginationConfig = (count: number): TablePagination => {
+  return {
+    defaultPageSize: MINIMUM_PAGE_SIZE,
+    hideOnSinglePage: count < MINIMUM_PAGE_SIZE,
+    showSizeChanger: true,
+  };
 };

--- a/webui/react/src/components/Table.tsx
+++ b/webui/react/src/components/Table.tsx
@@ -33,7 +33,7 @@ export type GenericRenderer = <T extends TableRecord>(
 type ExperimentRenderer = (text: string, record: ExperimentItem, index: number) => React.ReactNode;
 export type TaskRenderer = (text: string, record: CommandTask, index: number) => React.ReactNode;
 
-const MINIMUM_PAGE_SIZE = 10;
+export const MINIMUM_PAGE_SIZE = 10;
 
 /* Table Column Renderers */
 

--- a/webui/react/src/pages/ExperimentDetails.tsx
+++ b/webui/react/src/pages/ExperimentDetails.tsx
@@ -13,7 +13,7 @@ import Message from 'components/Message';
 import Page from 'components/Page';
 import Section from 'components/Section';
 import Spinner, { Indicator } from 'components/Spinner';
-import { defaultRowClassName, findColumnByTitle } from 'components/Table';
+import { defaultRowClassName, findColumnByTitle, getPaginationConfig } from 'components/Table';
 import handleError, { ErrorType } from 'ErrorHandler';
 import usePolling from 'hooks/usePolling';
 import useRestApi from 'hooks/useRestApi';
@@ -193,7 +193,7 @@ const ExperimentDetailsComp: React.FC = () => {
                 indicator: <Indicator />,
                 spinning: !experimentResponse.hasLoaded,
               }}
-              pagination={{ defaultPageSize: 10, hideOnSinglePage: true }}
+              pagination={getPaginationConfig(experiment?.trials.length || 0)}
               rowClassName={defaultRowClassName()}
               rowKey="id"
               showSorterTooltip={false}

--- a/webui/react/src/pages/ExperimentList.tsx
+++ b/webui/react/src/pages/ExperimentList.tsx
@@ -8,7 +8,7 @@ import { makeClickHandler } from 'components/Link';
 import Page from 'components/Page';
 import { Indicator } from 'components/Spinner';
 import StateSelectFilter from 'components/StateSelectFilter';
-import { defaultRowClassName, isAlternativeAction } from 'components/Table';
+import { defaultRowClassName, getPaginationConfig, isAlternativeAction } from 'components/Table';
 import TableBatch from 'components/TableBatch';
 import TagList from 'components/TagList';
 import Toggle from 'components/Toggle';
@@ -319,7 +319,7 @@ const ExperimentList: React.FC = () => {
             indicator: <Indicator />,
             spinning: !experimentsResponse.hasLoaded,
           }}
-          pagination={{ defaultPageSize: 10, hideOnSinglePage: true }}
+          pagination={getPaginationConfig(filterExperiments.length)}
           rowClassName={defaultRowClassName()}
           rowKey="id"
           rowSelection={{ onChange: handleTableRowSelect, selectedRowKeys }}

--- a/webui/react/src/pages/ExperimentList.tsx
+++ b/webui/react/src/pages/ExperimentList.tsx
@@ -8,7 +8,9 @@ import { makeClickHandler } from 'components/Link';
 import Page from 'components/Page';
 import { Indicator } from 'components/Spinner';
 import StateSelectFilter from 'components/StateSelectFilter';
-import { defaultRowClassName, getPaginationConfig, isAlternativeAction } from 'components/Table';
+import {
+  defaultRowClassName, getPaginationConfig, isAlternativeAction, MINIMUM_PAGE_SIZE,
+} from 'components/Table';
 import TableBatch from 'components/TableBatch';
 import TagList from 'components/TagList';
 import Toggle from 'components/Toggle';
@@ -47,7 +49,7 @@ enum Action {
 }
 
 const defaultFilters: ExperimentFilters = {
-  limit: 25,
+  limit: MINIMUM_PAGE_SIZE,
   showArchived: false,
   states: [ ALL_VALUE ],
   username: undefined,
@@ -319,7 +321,7 @@ const ExperimentList: React.FC = () => {
             indicator: <Indicator />,
             spinning: !experimentsResponse.hasLoaded,
           }}
-          pagination={getPaginationConfig(filterExperiments.length)}
+          pagination={getPaginationConfig(filteredExperiments.length)}
           rowClassName={defaultRowClassName()}
           rowKey="id"
           rowSelection={{ onChange: handleTableRowSelect, selectedRowKeys }}

--- a/webui/react/src/pages/TaskList.tsx
+++ b/webui/react/src/pages/TaskList.tsx
@@ -6,7 +6,9 @@ import Icon from 'components/Icon';
 import { makeClickHandler } from 'components/Link';
 import Page from 'components/Page';
 import { Indicator } from 'components/Spinner';
-import { defaultRowClassName, getPaginationConfig, isAlternativeAction } from 'components/Table';
+import {
+  defaultRowClassName, getPaginationConfig, isAlternativeAction, MINIMUM_PAGE_SIZE,
+} from 'components/Table';
 import { TaskRenderer } from 'components/Table';
 import TableBatch from 'components/TableBatch';
 import TaskFilter from 'components/TaskFilter';
@@ -33,7 +35,7 @@ import { columns as defaultColumns } from './TaskList.table';
 const MAX_SOURCES = 5;
 
 const defaultFilters: TaskFilters<CommandType> = {
-  limit: 25,
+  limit: MINIMUM_PAGE_SIZE,
   states: [ ALL_VALUE ],
   types: {
     [CommandType.Command]: false,

--- a/webui/react/src/pages/TaskList.tsx
+++ b/webui/react/src/pages/TaskList.tsx
@@ -6,7 +6,7 @@ import Icon from 'components/Icon';
 import { makeClickHandler } from 'components/Link';
 import Page from 'components/Page';
 import { Indicator } from 'components/Spinner';
-import { defaultRowClassName, isAlternativeAction } from 'components/Table';
+import { defaultRowClassName, getPaginationConfig, isAlternativeAction } from 'components/Table';
 import { TaskRenderer } from 'components/Table';
 import TableBatch from 'components/TableBatch';
 import TaskFilter from 'components/TaskFilter';
@@ -308,7 +308,7 @@ const TaskList: React.FC = () => {
             indicator: <Indicator />,
             spinning: !hasLoaded,
           }}
-          pagination={{ defaultPageSize: 10, hideOnSinglePage: true }}
+          pagination={getPaginationConfig(filteredTasks.length)}
           rowClassName={record => defaultRowClassName(canBeOpened(record))}
           rowKey="id"
           rowSelection={{ onChange: handleTableRowSelect, selectedRowKeys }}

--- a/webui/react/src/pages/TrialDetails.tsx
+++ b/webui/react/src/pages/TrialDetails.tsx
@@ -15,7 +15,7 @@ import MetricSelectFilter from 'components/MetricSelectFilter';
 import Page from 'components/Page';
 import Section from 'components/Section';
 import Spinner, { Indicator } from 'components/Spinner';
-import { defaultRowClassName, findColumnByTitle } from 'components/Table';
+import { defaultRowClassName, findColumnByTitle, getPaginationConfig } from 'components/Table';
 import Toggle from 'components/Toggle';
 import handleError, { ErrorType } from 'ErrorHandler';
 import usePolling from 'hooks/usePolling';
@@ -378,7 +378,7 @@ If the problem persists please contact support.',
                 indicator: <Indicator />,
                 spinning: !trialResponse.hasLoaded,
               }}
-              pagination={{ defaultPageSize: 10, hideOnSinglePage: true }}
+              pagination={getPaginationConfig(steps.length)}
               rowClassName={defaultRowClassName(false)}
               rowKey="id"
               scroll={{ x: 1000 }}

--- a/webui/react/src/utils/task.ts
+++ b/webui/react/src/utils/task.ts
@@ -153,8 +153,7 @@ export const filterExperiments = (
         matchesUser<ExperimentItem>(experiment, users, filters.username) &&
         matchesState<ExperimentItem>(experiment, filters.states) &&
         matchesSearch<ExperimentItem>(experiment, search);
-    })
-    .slice(0, filters.limit);
+    });
 };
 
 export const filterTasks = <T extends TaskType = TaskType, A extends AnyTask = AnyTask>(
@@ -171,8 +170,7 @@ export const filterTasks = <T extends TaskType = TaskType, A extends AnyTask = A
         matchesSearch<A>(task, search) &&
         (!isExperiment || !(task as ExperimentTask).archived);
     })
-    .filter(task => matchesSearch<A>(task, search))
-    .slice(0, filters.limit);
+    .filter(task => matchesSearch<A>(task, search));
 };
 
 /*


### PR DESCRIPTION
## Description

### Bug Fix
There is a limit filter that is applied to experiment and task list tables. This is actually reserved for future filtering with the new list api endpoints, but they are prematurely being used. Removing the corresponding `slice(0, limit)` corrected the behavior. 

### Pagination Behavior Change
- Pagination only appears when there are at least 10 items.
- Once there are 10 items, pagination including a page size picker appears.
- Even when the page size is set to a number higher than the number of items (meaning all the entries can fit on one page), the pagination and the page size picker persists. This is to ensure that the page size picker can stick around to let the user chang the page size to something smaller. The pagination is directly tied to the page size picker, they are grouped as a single component so they can not be separated out.

![2020-08-20 at 10 41 AM](https://user-images.githubusercontent.com/220971/90800431-eb2f2880-e2d1-11ea-941b-e69676918486.png)


## Test Plan



## Commentary (optional)


<!-- User-facing API changes need the "User-facing API Change" label -->

<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

## Description

Lead with the intended commit body in this description field. For breaking changes, please include "BREAKING CHANGE:" at the beginning of your commit body. At minimum, this section should include a bracketed reference to the Jira ticket, e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.

## Test Plan

Describe the situations in which you've tested your change, and/or a screenshot as appropriate. Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.

## Commentary (optional)

Use this section of your description to add context to the PR. Could be for particularly tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc. You may intentionally leave this section blank and remove the title.
--->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234