### PR TITLE
fix: patch request body parsing for model metadata [DET-3939]

### DIFF
--- a/common/determined_common/experimental/model.py
+++ b/common/determined_common/experimental/model.py
@@ -176,7 +176,7 @@ class Model:
         api.patch(
             self._master,
             "/api/v1/models/{}".format(self.name),
-            body={"model": {"metadata": self.metadata}},
+            body={"model": {"metadata": self.metadata, "description": self.description}},
         )
 
     def remove_metadata(self, keys: List[str]) -> None:
@@ -194,7 +194,7 @@ class Model:
         api.patch(
             self._master,
             "/api/v1/models/{}".format(self.name),
-            body={"model": {"metadata": self.metadata}},
+            body={"model": {"metadata": self.metadata, "description": self.description}},
         )
 
     def to_json(self) -> Dict[str, Any]:

--- a/master/internal/api_model.go
+++ b/master/internal/api_model.go
@@ -73,19 +73,8 @@ func (a *apiServer) PatchModel(
 		return nil, err
 	}
 
-	paths := req.UpdateMask.GetPaths()
-	for _, path := range paths {
-		switch {
-		case path == "model.description":
-			getResp.Model.Description = req.Model.Description
-		case strings.HasPrefix(path, "model.metadata"):
-			getResp.Model.Metadata = req.Model.Metadata
-		case !strings.HasPrefix(path, "update_mask"):
-			return nil, status.Errorf(
-				codes.InvalidArgument,
-				"only description and metadata fields are mutable. cannot update %s", path)
-		}
-	}
+	getResp.Model.Description = req.Model.Description
+	getResp.Model.Metadata = req.Model.Metadata
 
 	b, err := protojson.Marshal(getResp.Model.Metadata)
 	if err != nil {

--- a/proto/scripts/swagger.py
+++ b/proto/scripts/swagger.py
@@ -47,7 +47,6 @@ def clean(fn: str) -> None:
         paths[key.replace(".", "_")] = value
     spec["paths"] = paths
 
-    del spec["definitions"]["protobufFieldMask"]
     for key, value in spec["definitions"].items():
         # Remove definitions that should be hidden from the user.
         if key == "protobufAny":

--- a/proto/src/determined/api/v1/api.proto
+++ b/proto/src/determined/api/v1/api.proto
@@ -294,7 +294,7 @@ service Determined {
     }
     // Update model fields
     rpc PatchModel(PatchModelRequest) returns (PatchModelResponse) {
-        option (google.api.http) = {patch: "/api/v1/models/{model.name}" body: "model"};
+        option (google.api.http) = {patch: "/api/v1/models/{model.name}" body: "*"};
         option (grpc.gateway.protoc_gen_swagger.options.openapiv2_operation) = {tags: "Models"};
     }
     // Get a list of models.

--- a/proto/src/determined/api/v1/model.proto
+++ b/proto/src/determined/api/v1/model.proto
@@ -3,8 +3,6 @@ syntax = "proto3";
 package determined.api.v1;
 option go_package = "github.com/determined-ai/determined/proto/pkg/apiv1";
 
-import "google/protobuf/field_mask.proto";
-
 import "determined/api/v1/pagination.proto";
 import "determined/model/v1/model.proto";
 

--- a/proto/src/determined/api/v1/model.proto
+++ b/proto/src/determined/api/v1/model.proto
@@ -77,8 +77,6 @@ message PostModelResponse {
 message PatchModelRequest {
   // The model desired model fields and values.
   determined.model.v1.Model model = 1;
-  // An update mask for the above model.
-  google.protobuf.FieldMask update_mask = 2;
 }
 
 // Response to PatchModelRequest.


### PR DESCRIPTION
## Description
It is unclear why this changed, however patch requests weren't parsing the request body. The update mask was automatically filled in though. I suspect something in the grpc reverse proxy is to blame but wasn't able to root cause this issue. This PR offers the same functionality as before but uses the `body: "*"` request parsing.


## Test Plan
Adding a better E2E test as a follow on.


## Commentary (optional)


<!-- User-facing API changes need the "User-facing API Change" label -->

<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

## Description

Lead with the intended commit body in this description field. For breaking changes, please include "BREAKING CHANGE:" at the beginning of your commit body. At minimum, this section should include a bracketed reference to the Jira ticket, e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.

## Test Plan

Describe the situations in which you've tested your change, and/or a screenshot as appropriate. Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.

## Commentary (optional)

Use this section of your description to add context to the PR. Could be for particularly tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc. You may intentionally leave this section blank and remove the title.
--->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234