### PR TITLE
feat: change scheduler to allow multiple dtrain jobs per node [DET-3819]

### DIFF
--- a/master/internal/experiment.go
+++ b/master/internal/experiment.go
@@ -89,7 +89,8 @@ type experiment struct {
 
 	pendingEvents []*model.SearcherEvent
 
-	agentUserGroup *model.AgentUserGroup
+	agentUserGroup        *model.AgentUserGroup
+	taskContainerDefaults *model.TaskContainerDefaultsConfig
 }
 
 // Create a new experiment object from the given model experiment object, along with its searcher
@@ -138,7 +139,8 @@ func newExperiment(master *Master, expModel *model.Experiment) (*experiment, err
 		warmStartCheckpoint: checkpoint,
 		pendingEvents:       make([]*model.SearcherEvent, 0, searcherEventBuffer),
 
-		agentUserGroup: agentUserGroup,
+		agentUserGroup:        agentUserGroup,
+		taskContainerDefaults: &master.config.TaskContainerDefaults,
 	}, nil
 }
 

--- a/master/internal/scheduler/fitting.go
+++ b/master/internal/scheduler/fitting.go
@@ -100,6 +100,10 @@ func findDedicatedAgentFits(
 		return nil
 	}
 
+	if task.slotsNeeded < 1 {
+		return nil
+	}
+
 	// Scheduling assumption(s):
 	// 1) Multi-agent tasks will receive the same number of slots on every agent. This is
 	//    a valid assumption, because the only multi-agent tasks are distributed experiments

--- a/master/internal/scheduler/fitting.go
+++ b/master/internal/scheduler/fitting.go
@@ -129,7 +129,7 @@ func findMultiAgentFits(
 			continue
 		}
 
-		if s := task.SlotsNeeded(); s > n && s%n != 0 {
+		if s := task.SlotsNeeded(); s%n != 0 {
 			continue
 		}
 
@@ -141,9 +141,9 @@ func findMultiAgentFits(
 	}
 
 	if candidateNumSlots == 0 {
-		log.Infof("Task: %s which requires %d slots, can not be scheduled in the current "+
-			"cluster configuration. The number of slots per trial must be either set to 1 or "+
-			"a multiple of the GPUs per agent.", task.ID, task.SlotsNeeded(),
+		log.Infof("Task: %s which requires %d slots, can not be scheduled onto multiple agents "+
+			"in the current cluster configuration. The number of slots per trial must be either "+
+			"set to 1 or a multiple of the GPUs per agent.", task.ID, task.SlotsNeeded(),
 		)
 		return nil
 	}
@@ -157,19 +157,10 @@ func findMultiAgentFits(
 		})
 	}
 
-	numContainers := task.SlotsNeeded() / candidateNumSlots
-	slotsPerContainer := task.SlotsNeeded() / numContainers
-
-	if len(candidates) < numContainers {
-		log.Infof("Task: %s requires %d machines with %d slots to be scheduled. There are "+
-			"currently %d machines fully available.", task.ID, numContainers,
-			candidateNumSlots, len(candidates),
-		)
-		return nil
-	}
-
 	sort.Sort(candidates)
 
+	numContainers := task.SlotsNeeded() / candidateNumSlots
+	slotsPerContainer := task.SlotsNeeded() / numContainers
 	fits := candidates[:numContainers]
 	for _, c := range fits {
 		c.Slots = slotsPerContainer
@@ -198,8 +189,6 @@ func findSingleAgentFit(
 		return nil
 	}
 
-	// For the single agent case, we want prioritize using the smallest
-	// available agents.
 	sort.Sort(candidates)
 
 	candidates[0].Slots = task.SlotsNeeded()

--- a/master/internal/scheduler/fitting_test.go
+++ b/master/internal/scheduler/fitting_test.go
@@ -246,7 +246,7 @@ func TestFindFit(t *testing.T) {
 	}
 }
 
-func TestFindMultiAgentFits(t *testing.T) {
+func TestFindDedicatedAgentFits(t *testing.T) {
 	system := actor.NewSystem(t.Name())
 
 	type testCase struct {
@@ -310,7 +310,7 @@ func TestFindMultiAgentFits(t *testing.T) {
 				agentIndex[agent] = idx
 			}
 
-			fits := findMultiAgentFits(newTask(&Task{
+			fits := findDedicatedAgentFits(newTask(&Task{
 				slotsNeeded:         tc.SlotsNeeded,
 				fittingRequirements: tc.FittingRequirements,
 			}), agents, WorstFit)

--- a/master/internal/scheduler/fitting_test.go
+++ b/master/internal/scheduler/fitting_test.go
@@ -3,7 +3,6 @@ package scheduler
 import (
 	"fmt"
 	"sort"
-	"strconv"
 	"testing"
 
 	"gotest.tools/assert"
@@ -27,6 +26,7 @@ func TestFindFit(t *testing.T) {
 	system := actor.NewSystem(t.Name())
 
 	type testCase struct {
+		Name                string
 		SlotsNeeded         int
 		AgentCapacities     []int
 		AgentOccupiedSlots  []int
@@ -39,40 +39,45 @@ func TestFindFit(t *testing.T) {
 
 	testCases := []testCase{
 		{
+			Name:             "2-slot multiple fits",
 			SlotsNeeded:      2,
 			AgentCapacities:  []int{2, 4},
 			FittingMethod:    BestFit,
 			ExpectedAgentFit: 0,
 			FittingRequirements: FittingRequirements{
-				SingleAgent:    false,
-				DedicatedAgent: true,
+				SingleAgent: false,
 			},
 		},
 		{
+			Name:             "1-slot multiple fits",
 			SlotsNeeded:      1,
 			AgentCapacities:  []int{1, 4},
 			FittingMethod:    BestFit,
 			ExpectedAgentFit: 0,
 		},
 		{
+			Name:             "1-slot out-of-order multiple fits",
 			SlotsNeeded:      1,
 			AgentCapacities:  []int{4, 1},
 			FittingMethod:    BestFit,
 			ExpectedAgentFit: 1,
 		},
 		{
+			Name:             "4-slot single fit",
 			SlotsNeeded:      4,
 			AgentCapacities:  []int{4, 1},
 			FittingMethod:    BestFit,
 			ExpectedAgentFit: 0,
 		},
 		{
+			Name:             "4-slot multiple fits",
 			SlotsNeeded:      4,
 			AgentCapacities:  []int{4, 4},
 			FittingMethod:    BestFit,
 			ExpectedAgentFit: 1,
 		},
 		{
+			Name:               "2-slot multiple fits, in-use agents",
 			SlotsNeeded:        2,
 			AgentCapacities:    []int{2, 4},
 			AgentOccupiedSlots: []int{0, 2},
@@ -80,6 +85,7 @@ func TestFindFit(t *testing.T) {
 			ExpectedAgentFit:   0,
 		},
 		{
+			Name:               "1-slot multiple fits, in-use agents",
 			SlotsNeeded:        1,
 			AgentCapacities:    []int{2, 4},
 			AgentOccupiedSlots: []int{1, 1},
@@ -87,6 +93,7 @@ func TestFindFit(t *testing.T) {
 			ExpectedAgentFit:   1,
 		},
 		{
+			Name:               "1-slot multiple fits, in-use agents, out of order",
 			SlotsNeeded:        1,
 			AgentCapacities:    []int{4, 2},
 			AgentOccupiedSlots: []int{1, 1},
@@ -94,6 +101,7 @@ func TestFindFit(t *testing.T) {
 			ExpectedAgentFit:   0,
 		},
 		{
+			Name:               "1-slot multiple fits, in-use-agents, odd numbers",
 			SlotsNeeded:        1,
 			AgentCapacities:    []int{2, 5},
 			AgentOccupiedSlots: []int{1, 3},
@@ -101,6 +109,7 @@ func TestFindFit(t *testing.T) {
 			ExpectedAgentFit:   0,
 		},
 		{
+			Name:               "2-slot multiple fits, in-use-agents, odd numbers",
 			SlotsNeeded:        2,
 			AgentCapacities:    []int{2, 5},
 			AgentOccupiedSlots: []int{0, 3},
@@ -108,6 +117,7 @@ func TestFindFit(t *testing.T) {
 			ExpectedAgentFit:   0,
 		},
 		{
+			Name:               "4-slot multiple fits, unoccupied",
 			SlotsNeeded:        4,
 			AgentCapacities:    []int{4, 4},
 			AgentOccupiedSlots: []int{0, 0},
@@ -115,39 +125,29 @@ func TestFindFit(t *testing.T) {
 			ExpectedAgentFit:   1,
 		},
 		{
+			Name:               "4-slot multiple fits, one exact",
 			SlotsNeeded:        4,
 			AgentCapacities:    []int{8, 4},
 			AgentOccupiedSlots: []int{0, 0},
 			FittingMethod:      WorstFit,
 			ExpectedAgentFit:   1,
 			FittingRequirements: FittingRequirements{
-				SingleAgent:    false,
-				DedicatedAgent: true,
+				SingleAgent: false,
 			},
 		},
 		{
+			Name:               "4-slot multiple fits, one exact, single agent",
 			SlotsNeeded:        4,
 			AgentCapacities:    []int{8, 4},
 			AgentOccupiedSlots: []int{0, 0},
 			FittingMethod:      WorstFit,
 			ExpectedAgentFit:   1,
 			FittingRequirements: FittingRequirements{
-				SingleAgent:    true,
-				DedicatedAgent: false,
+				SingleAgent: true,
 			},
 		},
 		{
-			SlotsNeeded:        4,
-			AgentCapacities:    []int{8, 4},
-			AgentOccupiedSlots: []int{0, 0},
-			FittingMethod:      WorstFit,
-			ExpectedAgentFit:   0,
-			FittingRequirements: FittingRequirements{
-				SingleAgent:    false,
-				DedicatedAgent: false,
-			},
-		},
-		{
+			Name:             "4-slot multiple fits, label hard constraint",
 			SlotsNeeded:      4,
 			AgentCapacities:  []int{4, 4},
 			AgentLabels:      [2]string{"label1", "label2"},
@@ -156,11 +156,52 @@ func TestFindFit(t *testing.T) {
 			ExpectedAgentFit: 1,
 		},
 		{
+			Name:             "0-slot multiple fits, label hard constraint",
 			SlotsNeeded:      0,
 			AgentCapacities:  []int{4, 4},
 			AgentLabels:      [2]string{"label1", "label2"},
 			FittingMethod:    BestFit,
 			TaskLabel:        "label2",
+			ExpectedAgentFit: 1,
+		},
+		{
+			Name:            "2-slot multiple inexact fits",
+			SlotsNeeded:     2,
+			AgentCapacities: []int{4, 4},
+			FittingMethod:   BestFit,
+			FittingRequirements: FittingRequirements{
+				SingleAgent: false,
+			},
+			ExpectedAgentFit: 1,
+		},
+		{
+			Name:            "2-slot multiple inexact fits, single agent",
+			SlotsNeeded:     2,
+			AgentCapacities: []int{4, 4},
+			FittingMethod:   BestFit,
+			FittingRequirements: FittingRequirements{
+				SingleAgent: true,
+			},
+			ExpectedAgentFit: 0,
+		},
+		{
+			Name:            "2-slot fit, single agent",
+			SlotsNeeded:     2,
+			AgentCapacities: []int{1, 3},
+			FittingMethod:   BestFit,
+			FittingRequirements: FittingRequirements{
+				SingleAgent: true,
+			},
+			ExpectedAgentFit: 1,
+		},
+		{
+			Name:            "2-slot fit, no single agent requirement",
+			SlotsNeeded:     2,
+			AgentCapacities: []int{1, 3},
+			FittingMethod:   BestFit,
+			FittingRequirements: FittingRequirements{
+				SingleAgent: false,
+			},
 			ExpectedAgentFit: 1,
 		},
 	}
@@ -169,7 +210,7 @@ func TestFindFit(t *testing.T) {
 		tc := testCases[idx]
 		taskID := TaskID(fmt.Sprintf("task%d", idx))
 
-		t.Run(strconv.Itoa(idx), func(t *testing.T) {
+		t.Run(tc.Name, func(t *testing.T) {
 			task := newTask(&Task{
 				ID:                  taskID,
 				slotsNeeded:         tc.SlotsNeeded,
@@ -205,7 +246,7 @@ func TestFindFit(t *testing.T) {
 	}
 }
 
-func TestFindMultiSlotFits(t *testing.T) {
+func TestFindMultiAgentFits(t *testing.T) {
 	system := actor.NewSystem(t.Name())
 
 	type testCase struct {
@@ -230,8 +271,7 @@ func TestFindMultiSlotFits(t *testing.T) {
 			AgentCapacities:  []int{8, 7, 7, 4, 4, 4, 4},
 			ExpectedAgentFit: []int{3, 4, 5, 6},
 			FittingRequirements: FittingRequirements{
-				SingleAgent:    false,
-				DedicatedAgent: true,
+				SingleAgent: false,
 			},
 		},
 		{
@@ -250,37 +290,7 @@ func TestFindMultiSlotFits(t *testing.T) {
 			AgentCapacities: []int{4, 4, 4, 4, 4},
 			ExpectedLength:  2,
 			FittingRequirements: FittingRequirements{
-				SingleAgent:    false,
-				DedicatedAgent: true,
-			},
-		},
-		{
-			Name:            "Scheduling a multi-slot command",
-			SlotsNeeded:     2,
-			AgentCapacities: []int{4, 4, 4, 4, 4},
-			ExpectedLength:  1,
-			FittingRequirements: FittingRequirements{
-				SingleAgent:    true,
-				DedicatedAgent: false,
-			},
-		},
-		{
-			Name:             "Scheduling a multi-slot command should pick smallest possible agent",
-			SlotsNeeded:      2,
-			AgentCapacities:  []int{4, 1, 3, 4, 4},
-			ExpectedAgentFit: []int{2},
-			FittingRequirements: FittingRequirements{
-				SingleAgent:    true,
-				DedicatedAgent: false,
-			},
-		},
-		{
-			Name:            "Scheduling a multi-slot command that's too big",
-			SlotsNeeded:     8,
-			AgentCapacities: []int{4, 4, 4},
-			FittingRequirements: FittingRequirements{
-				SingleAgent:    true,
-				DedicatedAgent: false,
+				SingleAgent: false,
 			},
 		},
 	}
@@ -300,7 +310,7 @@ func TestFindMultiSlotFits(t *testing.T) {
 				agentIndex[agent] = idx
 			}
 
-			fits := findMultiSlotFits(newTask(&Task{
+			fits := findMultiAgentFits(newTask(&Task{
 				slotsNeeded:         tc.SlotsNeeded,
 				fittingRequirements: tc.FittingRequirements,
 			}), agents, WorstFit)

--- a/master/internal/trial.go
+++ b/master/internal/trial.go
@@ -190,7 +190,8 @@ type trial struct {
 	// sockets maps each running container for this trial to the corresponding websocket actor.
 	sockets map[scheduler.ContainerID]*actor.Ref
 
-	agentUserGroup *model.AgentUserGroup
+	agentUserGroup        *model.AgentUserGroup
+	taskContainerDefaults *model.TaskContainerDefaultsConfig
 }
 
 // newTrial creates a trial which will try to schedule itself after it receives its first workload.
@@ -222,7 +223,8 @@ func newTrial(
 		containers:        make(map[scheduler.ContainerID]scheduler.Container),
 		sockets:           make(map[scheduler.ContainerID]*actor.Ref),
 
-		agentUserGroup: exp.agentUserGroup,
+		agentUserGroup:        exp.agentUserGroup,
+		taskContainerDefaults: exp.taskContainerDefaults,
 	}
 }
 
@@ -314,7 +316,8 @@ func (t *trial) Receive(ctx *actor.Context) error {
 				CanTerminate: true,
 				Label:        label,
 				FittingRequirements: scheduler.FittingRequirements{
-					SingleAgent: false,
+					SingleAgent:    false,
+					DedicatedAgent: t.taskContainerDefaults.NetworkMode.IsHost() && slotsNeeded > 1,
 				},
 				TaskHandler: ctx.Self(),
 			}).Get().(*scheduler.Task)

--- a/master/internal/trial.go
+++ b/master/internal/trial.go
@@ -314,8 +314,7 @@ func (t *trial) Receive(ctx *actor.Context) error {
 				CanTerminate: true,
 				Label:        label,
 				FittingRequirements: scheduler.FittingRequirements{
-					SingleAgent:    false,
-					DedicatedAgent: slotsNeeded > 1,
+					SingleAgent: false,
 				},
 				TaskHandler: ctx.Self(),
 			}).Get().(*scheduler.Task)


### PR DESCRIPTION
## Description
This change allows the scheduler to fit multiple dtrain jobs to a single node. There was spike work done to ensure horovod can handle this.

<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan
- [x] update test cases.
- [x] deploy a cluster and try to run multiple dtrain jobs on a single node (with docker bridge networking).
<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.
-->

## Commentary
Previously `findFits` was divided into `findSingleSlotFit` and `findMultiSlotFits`. This seems to be rooted in 1-slot tasks all being scheduled the same, where n-slot tasks were scheduled differently whether they were experiments or other tasks. I changed this to `findSingleAgentFit` and `findMultiAgentFits` because now all n-slot tasks are scheduled this same, where n fits on a single agent, and n-slot tasks, where n does not fit on a single agent, are only scheduled when they are experiments (as indicated by `SingleAgent: false`).

## Checklist

- [x] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details. (To be done as a part of the corresponding docs PR)


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234