### PR TITLE
fix: validate records_per_epoch exists when epochs are used

### DIFF
--- a/master/pkg/model/experiment_config.go
+++ b/master/pkg/model/experiment_config.go
@@ -93,6 +93,13 @@ func (e ExperimentConfig) Validate() []error {
 			e.Entrypoint, "Must specify an entrypoint that references the trial class."))
 	}
 
+	// If any fields that are a model.Length are in epochs, validate records_per_epoch is non-zero.
+	if e.Searcher.Unit() == Epochs || e.MinCheckpointPeriod.Unit == Epochs ||
+		e.MinValidationPeriod.Unit == Epochs {
+		errs = append(errs, check.GreaterThan(e.RecordsPerEpoch, 0,
+			"Must specify records_per_epoch when any configuration is in terms of epochs"))
+	}
+
 	return append(errs, []error{
 		check.TrueSilent(len(noCountParams) == 0,
 			"these hyperparameters must specify counts for grid search: %s",

--- a/master/pkg/model/experiment_config_test.go
+++ b/master/pkg/model/experiment_config_test.go
@@ -63,6 +63,23 @@ func TestLabelsJoin(t *testing.T) {
 	assert.DeepEqual(t, actual, expected)
 }
 
+func TestRecordsPerEpochMissing(t *testing.T) {
+	conf := DefaultExperimentConfig()
+	assert.NilError(t, json.Unmarshal([]byte(`{
+  "searcher": {
+    "name": "single",
+    "metric": "loss",
+    "smaller_is_better": false,
+    "max_length": {
+      "batches": 1000
+    }
+  },
+  "min_checkpoint_period": {"epochs": 1}
+}`), &conf))
+
+	assert.ErrorContains(t, check.Validate(conf), "Must specify records_per_epoch")
+}
+
 func TestDefaultDescription(t *testing.T) {
 	json1 := []byte(`{
   "description": "test"


### PR DESCRIPTION
## Description
This change adds validation to ensure records_per_epoch is supplied when a configuration is in terms of epochs.
<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan
- [x] add a test
<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234