### PR TITLE
feat: support default gpu and cpu pod specs in master.yaml [DET-3942]

### DIFF
--- a/helm/charts/determined/templates/master-config.yaml
+++ b/helm/charts/determined/templates/master-config.yaml
@@ -61,6 +61,12 @@ data:
       {{- if .Values.taskContainerDefaults.glooPortRange }}
       gloo_port_range: {{ .Values.taskContainerDefaults.glooPortRange }}
       {{- end }}
+      {{- if .Values.taskContainerDefaults.cpuPodSpec }}
+      cpu_pod_spec: {{ .Values.taskContainerDefaults.cpuPodSpec | toJson }}
+      {{- end }}
+      {{- if .Values.taskContainerDefaults.gpuPodSpec }}
+      gpu_pod_spec: {{ .Values.taskContainerDefaults.gpuPodSpec | toJson }}
+      {{- end }}
     {{ end }}
 
     {{- if .Values.telemetry }}

--- a/helm/charts/determined/values.yaml
+++ b/helm/charts/determined/values.yaml
@@ -66,6 +66,12 @@ taskContainerDefaults:
   # ncclPortRange: <MIN:MAX>
   # glooPortRange: <MIN:MAX>
 
+  # Configure a default pod spec for all GPU tasks (experiments, notebooks, commands) and
+  # CPU tasks (cpu notebooks, tensorboards, zero slot commands). If a pod spec is defined
+  # for an individual task, that pod spec will replace the default one that is defined here.
+  # cpuPodSpec:
+  # gpuPodSpec:
+
 # Configure Determined enterprise edition.
 enterpriseEdition: false
 

--- a/master/internal/command/api.go
+++ b/master/internal/command/api.go
@@ -20,12 +20,14 @@ func RegisterAPIHandler(
 	proxyRef *actor.Ref,
 	timeout int,
 	defaultAgentUserGroup model.AgentUserGroup,
+	taskContainerDefaults model.TaskContainerDefaultsConfig,
 	middleware ...echo.MiddlewareFunc,
 ) {
 	system.ActorOf(actor.Addr("commands"), &commandManager{
 		defaultAgentUserGroup: defaultAgentUserGroup,
 		db:                    db,
 		clusterID:             cID,
+		taskContainerDefaults: taskContainerDefaults,
 	})
 	echo.Any("/commands*", api.Route(system, nil), middleware...)
 
@@ -33,6 +35,7 @@ func RegisterAPIHandler(
 		defaultAgentUserGroup: defaultAgentUserGroup,
 		db:                    db,
 		clusterID:             cID,
+		taskContainerDefaults: taskContainerDefaults,
 	})
 	echo.Any("/notebooks*", api.Route(system, nil), middleware...)
 
@@ -40,6 +43,7 @@ func RegisterAPIHandler(
 		defaultAgentUserGroup: defaultAgentUserGroup,
 		db:                    db,
 		clusterID:             cID,
+		taskContainerDefaults: taskContainerDefaults,
 	})
 	echo.Any("/shells*", api.Route(system, nil), middleware...)
 
@@ -49,6 +53,7 @@ func RegisterAPIHandler(
 		clusterID:             cID,
 		proxyRef:              proxyRef,
 		timeout:               time.Duration(timeout) * time.Second,
+		taskContainerDefaults: taskContainerDefaults,
 	})
 	echo.Any("/tensorboard*", api.Route(system, nil), middleware...)
 }

--- a/master/internal/command/command.go
+++ b/master/internal/command/command.go
@@ -341,3 +341,18 @@ func getPort(min, max int) int {
 	rand.Seed(time.Now().Unix())
 	return rand.Intn(max-min) + min
 }
+
+func setPodSpec(
+	config *model.CommandConfig,
+	taskContainerDefaults model.TaskContainerDefaultsConfig,
+) {
+	if config.Environment.PodSpec != nil {
+		return
+	}
+
+	if config.Resources.Slots == 0 {
+		config.Environment.PodSpec = taskContainerDefaults.CPUPodSpec
+	} else {
+		config.Environment.PodSpec = taskContainerDefaults.GPUPodSpec
+	}
+}

--- a/master/internal/command/command_manager.go
+++ b/master/internal/command/command_manager.go
@@ -27,6 +27,7 @@ type commandManager struct {
 
 	defaultAgentUserGroup model.AgentUserGroup
 	clusterID             string
+	taskContainerDefaults model.TaskContainerDefaultsConfig
 }
 
 func (c *commandManager) Receive(ctx *actor.Context) error {
@@ -99,6 +100,7 @@ func (c *commandManager) newCommand(req *commandRequest) *command {
 	if len(config.Entrypoint) == 1 {
 		config.Entrypoint = append(shellFormEntrypoint, config.Entrypoint...)
 	}
+	setPodSpec(&config, c.taskContainerDefaults)
 
 	return &command{
 		taskID:    scheduler.NewTaskID(),

--- a/master/internal/command/notebook_manager.go
+++ b/master/internal/command/notebook_manager.go
@@ -104,6 +104,7 @@ type notebookManager struct {
 
 	defaultAgentUserGroup model.AgentUserGroup
 	clusterID             string
+	taskContainerDefaults model.TaskContainerDefaultsConfig
 }
 
 func (n *notebookManager) Receive(ctx *actor.Context) error {
@@ -188,6 +189,8 @@ func (n *notebookManager) newNotebook(req *commandRequest) (*command, error) {
 		config.Environment.EnvironmentVariables.GPU, portVar)
 
 	config.Entrypoint = notebookEntrypoint
+
+	setPodSpec(&config, n.taskContainerDefaults)
 
 	if config.Description == "" {
 		var err error

--- a/master/internal/command/tensorboard_manager.go
+++ b/master/internal/command/tensorboard_manager.go
@@ -59,6 +59,7 @@ type tensorboardManager struct {
 	clusterID             string
 	timeout               time.Duration
 	proxyRef              *actor.Ref
+	taskContainerDefaults model.TaskContainerDefaultsConfig
 }
 
 type tensorboardTick struct{}
@@ -300,6 +301,8 @@ func (t *tensorboardManager) newTensorBoard(
 	config.Resources.Slots = tensorboardResourcesSlots
 	config.Environment.EnvironmentVariables = model.RuntimeItems{CPU: envVars, GPU: envVars}
 	config.BindMounts = getMounts(uniqMounts)
+
+	setPodSpec(&config, t.taskContainerDefaults)
 
 	return &command{
 		taskID:          taskID,

--- a/master/internal/core.go
+++ b/master/internal/core.go
@@ -593,6 +593,7 @@ func (m *Master) Run() error {
 		proxyRef,
 		m.config.TensorBoardTimeout,
 		m.config.Security.DefaultTask,
+		m.config.TaskContainerDefaults,
 		authFuncs...,
 	)
 	template.RegisterAPIHandler(m.echo, m.db, authFuncs...)

--- a/master/internal/core_experiment.go
+++ b/master/internal/core_experiment.go
@@ -379,6 +379,14 @@ func (m *Master) parseExperiment(body []byte) (*model.Experiment, bool, error) {
 		return nil, false, errors.Wrap(yerr, "invalid experiment configuration")
 	}
 
+	if config.Environment.PodSpec == nil {
+		if config.Resources.SlotsPerTrial == 0 {
+			config.Environment.PodSpec = m.config.TaskContainerDefaults.CPUPodSpec
+		} else {
+			config.Environment.PodSpec = m.config.TaskContainerDefaults.GPUPodSpec
+		}
+	}
+
 	if cerr := check.Validate(config); cerr != nil {
 		return nil, false, errors.Wrap(cerr, "invalid experiment configuration")
 	}

--- a/master/pkg/model/environment_config.go
+++ b/master/pkg/model/environment_config.go
@@ -99,21 +99,25 @@ func (r *RuntimeItems) For(deviceType device.Type) []string {
 
 // Validate implements the check.Validatable interface.
 func (e Environment) Validate() []error {
-	if e.PodSpec != nil {
+	return validatePodSpec(e.PodSpec)
+}
+
+func validatePodSpec(podSpec *k8sV1.Pod) []error {
+	if podSpec != nil {
 		podSpecErrors := []error{
-			check.Equal(e.PodSpec.Name, "", "pod Name is not a configurable option"),
-			check.Equal(e.PodSpec.Namespace, "", "pod Namespace is not a configurable option"),
-			check.False(e.PodSpec.Spec.HostNetwork, "host networking must be configured via master.yaml"),
+			check.Equal(podSpec.Name, "", "pod Name is not a configurable option"),
+			check.Equal(podSpec.Namespace, "", "pod Namespace is not a configurable option"),
+			check.False(podSpec.Spec.HostNetwork, "host networking must be configured via master.yaml"),
 			check.Equal(
-				len(e.PodSpec.Spec.InitContainers), 0,
+				len(podSpec.Spec.InitContainers), 0,
 				"init containers are not a configurable option"),
 			check.LessThanOrEqualTo(
-				len(e.PodSpec.Spec.Containers), 1,
+				len(podSpec.Spec.Containers), 1,
 				"can specify at most one container in pod_spec"),
 		}
 
-		if len(e.PodSpec.Spec.Containers) > 0 {
-			container := e.PodSpec.Spec.Containers[0]
+		if len(podSpec.Spec.Containers) > 0 {
+			container := podSpec.Spec.Containers[0]
 			containerSpecErrors := []error{
 				check.Equal(container.Name, "", "container Name is not configurable"),
 				check.Equal(container.Image, "",

--- a/master/pkg/model/task_container_defaults.go
+++ b/master/pkg/model/task_container_defaults.go
@@ -4,6 +4,8 @@ import (
 	"regexp"
 	"strconv"
 
+	k8sV1 "k8s.io/api/core/v1"
+
 	"github.com/docker/docker/api/types/container"
 	"github.com/pkg/errors"
 
@@ -17,6 +19,8 @@ type TaskContainerDefaultsConfig struct {
 	GLOOPortRange          string                `json:"gloo_port_range,omitempty"`
 	ShmSizeBytes           int64                 `json:"shm_size_bytes,omitempty"`
 	NetworkMode            container.NetworkMode `json:"network_mode,omitempty"`
+	CPUPodSpec             *k8sV1.Pod            `json:"cpu_pod_spec"`
+	GPUPodSpec             *k8sV1.Pod            `json:"gpu_pod_spec"`
 }
 
 func validatePortRange(portRange string) []error {
@@ -65,6 +69,9 @@ func (c TaskContainerDefaultsConfig) Validate() []error {
 	if err := validatePortRange(c.GLOOPortRange); err != nil {
 		errs = append(errs, err...)
 	}
+
+	errs = append(errs, validatePodSpec(c.CPUPodSpec)...)
+	errs = append(errs, validatePodSpec(c.GPUPodSpec)...)
 
 	return errs
 }


### PR DESCRIPTION
## Description
The default specified in the `master.yaml` can be overwritten on a per-task granularity. Docs for this 
change will be done as part of [DET-3905](https://determinedai.atlassian.net/browse/DET-3905).


## Test Plan
Spun up a cluster and tried out different combinations of default configs.
