### PR TITLE
feat: override trial network mode to host only when multi-agent [DET-3820]

### DIFF
--- a/master/internal/trial.go
+++ b/master/internal/trial.go
@@ -530,6 +530,7 @@ func (t *trial) processAssigned(ctx *actor.Context, msg scheduler.TaskAssigned) 
 				WorkloadManagerType: t.sequencer.WorkloadManagerType(),
 				AdditionalFiles:     additionalFiles,
 				AgentUserGroup:      t.agentUserGroup,
+				IsMultiAgent:        t.numContainers > 1,
 			},
 		},
 		TaskHandler: ctx.Self(),

--- a/master/pkg/tasks/task.go
+++ b/master/pkg/tasks/task.go
@@ -264,7 +264,7 @@ func startContainer(t TaskSpec) container.Spec {
 	}
 	mounts := TrialDockerMounts(exp)
 	networkMode := t.TaskContainerDefaults.NetworkMode
-	if exp.ExperimentConfig.Resources.SlotsPerTrial > 1 {
+	if exp.IsMultiAgent {
 		networkMode = hostMode
 	}
 	rPorts := rendezvousPorts(t.Devices, networkMode)

--- a/master/pkg/tasks/task_spec.go
+++ b/master/pkg/tasks/task_spec.go
@@ -78,6 +78,11 @@ type StartContainer struct {
 	InitialWorkload     searcher.Workload         `json:"initial_workload"`
 	WorkloadManagerType model.WorkloadManagerType `json:"workload_manager_type"`
 	AdditionalFiles     archive.Archive           `json:"additional_files"`
+
+	// TODO(DET-3821): This is used to hint the resource provider to override defaults and start
+	// the container in host mode iff it has been scheduled across multiple agents. Remove this
+	// when multiple horovod containers can run per agent in host-mode.
+	IsMultiAgent bool `json:"is_multi_agent"`
 }
 
 // KillContainer is the information sent to an agent to kill a task (i.e., container or


### PR DESCRIPTION

## Description
This change updates the trial <-> scheduler relationship by adding a field `IsMultiAgent` to the task spec. This field is used to indicate when a container is started whether its default networking mode should be overriden. This distinction is because this should be the case for distributed training but not parallel.

<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan
- [x] spin up a cluster, schedule some jobs
With an experiment config for 2-slots per experiment (on mnist_pytorch):
<img width="782" alt="Screen Shot 2020-08-25 at 10 55 41 PM" src="https://user-images.githubusercontent.com/9650546/91250102-39a35380-e726-11ea-9dd5-47dd204c1e8d.png">

Run 4 copies concurrently with a single 8-slot gpu:
<img width="1788" alt="Screen Shot 2020-08-25 at 10 54 41 PM" src="https://user-images.githubusercontent.com/9650546/91250167-5d669980-e726-11ea-886a-6d7d540fe068.png">

Full utilization:
<img width="1791" alt="Screen Shot 2020-08-25 at 10 55 28 PM" src="https://user-images.githubusercontent.com/9650546/91250192-6a838880-e726-11ea-816c-5cd53f3847d7.png">

They all complete and converge:
<img width="1791" alt="Screen Shot 2020-08-25 at 10 55 05 PM" src="https://user-images.githubusercontent.com/9650546/91250177-62c3e400-e726-11ea-8bb8-a2569fd7f922.png">


<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)
Seems simple enough?
<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [x] Release notes should be added as a separate file under `docs/release-notes/`. (will do this in the follow-up docs change)
See [Release Note](../docs/release-notes/README.md) for details.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234