### PR TITLE
fix: don't double count failed trial completions [DET-3986]

### DIFF
--- a/docs/release-notes/1176-fix-adaptive-asha-progress.txt
+++ b/docs/release-notes/1176-fix-adaptive-asha-progress.txt
@@ -1,0 +1,5 @@
+:orphan:
+
+**Bug Fixes**
+
+- Fix ``adaptive_asha`` progress in the event of failed trials.

--- a/master/pkg/searcher/asha.go
+++ b/master/pkg/searcher/asha.go
@@ -245,6 +245,5 @@ func (s *asyncHalvingSearch) trialExitedEarly(
 ) ([]Operation, error) {
 	s.earlyExitTrials[requestID] = true
 	s.closedTrials[requestID] = true
-	s.trialsCompleted++
 	return s.promoteAsync(ctx, requestID, ashaExitedMetricValue), nil
 }


### PR DESCRIPTION
## Description
This change removes the code from asha calls to `trialExitedEarly`, since `trialClosed` is still called for early exit calls and this causes trials to get counted as completed twice.
<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan
- [x] run an `adaptive_asha` searcher with failed trials and ensure if completes with 100% progress
<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.
-->


## Checklist

- [x] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234