### PR TITLE
fix: fix a deadlock when gracefully terminate a trial [DET-3879]

### DIFF
--- a/e2e_tests/tests/experiment/experiment.py
+++ b/e2e_tests/tests/experiment/experiment.py
@@ -199,12 +199,6 @@ def cancel_single(experiment_id: int, should_have_trial: bool = False) -> None:
         trial = trials[0]
         assert trial["state"] == "CANCELED"
 
-        last_step = trial["steps"][-1]
-        assert last_step["state"] == "COMPLETED"
-
-        checkpoint = last_step["checkpoint"]
-        assert checkpoint["state"] == "COMPLETED"
-
 
 def is_terminal_state(state: str) -> bool:
     return state in ("CANCELED", "COMPLETED", "ERROR")

--- a/master/internal/trial.go
+++ b/master/internal/trial.go
@@ -270,7 +270,6 @@ func (t *trial) Receive(ctx *actor.Context) error {
 		t.restore(ctx)
 		t.replaying = false
 
-	// Log-related messages.
 	case sproto.ContainerLog:
 		t.processLog(ctx, msg)
 
@@ -338,16 +337,14 @@ func (t *trial) Receive(ctx *actor.Context) error {
 
 func (t *trial) runningReceive(ctx *actor.Context) error {
 	switch msg := ctx.Message().(type) {
-	case *websocket.Conn:
-		a := api.WrapSocket(msg, searcher.CompletedMessage{}, false)
-		if ref, created := ctx.ActorOf("socket", a); created {
-			ctx.Respond(ref)
-		}
+	case scheduler.TaskAssigned, scheduler.TerminateRequest, scheduler.TaskAborted, scheduler.TaskTerminated, scheduler.ContainerStarted:
+		return t.processScheduler(ctx)
 
-	case containerConnected:
-		if err := t.processContainerConnected(ctx, msg); err != nil {
-			return err
-		}
+	case containerConnected, sproto.ContainerStateChanged:
+		return t.processContainer(ctx)
+
+	case *websocket.Conn, *apiv1.KillTrialRequest:
+		return t.processAPI(ctx)
 
 	case searcher.CompletedMessage:
 		if err := t.processCompletedWorkload(ctx, msg); err != nil {
@@ -366,6 +363,27 @@ func (t *trial) runningReceive(ctx *actor.Context) error {
 	case actor.ChildFailed:
 		ctx.Tell(t.rp, scheduler.TerminateTask{TaskID: t.task.ID, Forcible: true})
 
+	case killTrial:
+		t.killTrial(ctx)
+
+	case terminateTimeout:
+		if t.task != nil && msg.runID == t.runID {
+			ctx.Log().Info("killing unresponsive trial after timeout")
+			ctx.Tell(t.rp, scheduler.TerminateTask{TaskID: t.task.ID, Forcible: true})
+		}
+
+	case actor.ChildStopped:
+
+	default:
+		return actor.ErrUnexpectedMessage(ctx)
+	}
+
+	return nil
+}
+
+func (t *trial) processScheduler(ctx *actor.Context) error {
+	switch msg := ctx.Message().(type) {
+
 	case scheduler.TaskAssigned:
 		if err := t.processAssigned(ctx, msg); err != nil {
 			return err
@@ -374,6 +392,31 @@ func (t *trial) runningReceive(ctx *actor.Context) error {
 	case scheduler.TerminateRequest:
 		ctx.Log().Info("trial runner requested to terminate")
 		t.pendingGracefulTermination = true
+
+	case scheduler.TaskAborted:
+
+	case scheduler.TaskTerminated:
+		t.processTaskTerminated(ctx, msg)
+
+	case scheduler.ContainerStarted:
+		t.containers[msg.Container.ID()] = msg.Container
+
+		if err := t.pushRendezvous(ctx); err != nil {
+			return errors.Wrap(err, "failed to push rendezvous to trial containers")
+		}
+
+	default:
+		return actor.ErrUnexpectedMessage(ctx)
+	}
+	return nil
+}
+
+func (t *trial) processContainer(ctx *actor.Context) error {
+	switch msg := ctx.Message().(type) {
+	case containerConnected:
+		if err := t.processContainerConnected(ctx, msg); err != nil {
+			return err
+		}
 
 	case sproto.ContainerStateChanged:
 		if msg.Container.State != container.Assigned {
@@ -384,28 +427,19 @@ func (t *trial) runningReceive(ctx *actor.Context) error {
 			t.processContainerTerminated(ctx, msg)
 		}
 
-	case scheduler.TaskAborted:
+	default:
+		return actor.ErrUnexpectedMessage(ctx)
+	}
+	return nil
+}
 
-	case scheduler.TaskTerminated:
-		t.processTaskTerminated(ctx, msg)
-
-	case killTrial:
-		t.killTrial(ctx)
-
-	case terminateTimeout:
-		if t.task != nil && msg.runID == t.runID {
-			ctx.Log().Info("killing unresponsive trial after timeout")
-			ctx.Tell(t.rp, scheduler.TerminateTask{TaskID: t.task.ID, Forcible: true})
+func (t *trial) processAPI(ctx *actor.Context) error {
+	switch msg := ctx.Message().(type) {
+	case *websocket.Conn:
+		a := api.WrapSocket(msg, searcher.CompletedMessage{}, false)
+		if ref, created := ctx.ActorOf("socket", a); created {
+			ctx.Respond(ref)
 		}
-
-	case scheduler.ContainerStarted:
-		t.containers[msg.Container.ID()] = msg.Container
-
-		if err := t.pushRendezvous(ctx); err != nil {
-			return errors.Wrap(err, "failed to push rendezvous to trial containers")
-		}
-
-	case actor.ChildStopped:
 
 	case *apiv1.KillTrialRequest:
 		t.killTrial(ctx)
@@ -414,7 +448,6 @@ func (t *trial) runningReceive(ctx *actor.Context) error {
 	default:
 		return actor.ErrUnexpectedMessage(ctx)
 	}
-
 	return nil
 }
 


### PR DESCRIPTION
## Description

<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->

This PR fixes a deadlock in the trial actor. It happens when a trial is terminated gracefully and the trial containers are still starting. Before all the trial containers are started, the trial would not send the rendezvous information, which blocks trial containers sending back completed workload messages. This issue exists on both the default and k8s resource providers. In the default resource provider only when the instances are launched. However, on k8s, containers are started one by one. There might be a situation that some containers would never start up. This PR adds a timeout for all graceful trial terminating and directly handles as killing if not all containers are connected.

The solution is to check if all containers are ready when gracefully terminating it. If not, rather than waiting for the completed workloads, kill all the containers. Also, add a timeout to check if the trial has waited too long for all containers are connected.

## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.
-->

1. Use the CI suite.
2. Test it manually by spinning up a k8s cluster, launch an experiment, and cancel it when the containers are still starting up.

## Commentary (optional)

Review it by commit.

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234