### PR TITLE
fix: support alternate ruamel packaging.

### DIFF
--- a/cli/determined_cli/cli.py
+++ b/cli/determined_cli/cli.py
@@ -11,7 +11,6 @@ import argcomplete.completers
 import OpenSSL
 import requests
 import tabulate
-from ruamel import yaml
 from termcolor import colored
 
 import determined_cli
@@ -31,7 +30,7 @@ from determined_cli.trial import args_description as trial_args_description
 from determined_cli.user import args_description as user_args_description
 from determined_cli.version import args_description as version_args_description
 from determined_cli.version import check_version
-from determined_common import api
+from determined_common import api, yaml
 from determined_common.api.authentication import authentication_required
 from determined_common.check import check_not_none
 from determined_common.util import chunks, debug_mode, get_default_master_address

--- a/cli/determined_cli/command.py
+++ b/cli/determined_cli/command.py
@@ -2,10 +2,9 @@ from collections import namedtuple
 from pathlib import Path
 from typing import IO, Any, Dict, Iterable, List, Optional, Tuple
 
-from ruamel import yaml
 from termcolor import colored
 
-from determined_common import api, context
+from determined_common import api, context, yaml
 
 CONFIG_DESC = """
 Additional configuration arguments for setting up a command.

--- a/cli/determined_cli/experiment.py
+++ b/cli/determined_cli/experiment.py
@@ -12,12 +12,11 @@ from pprint import pformat
 from typing import Any, Dict, List, Optional, Set, Tuple
 
 import tabulate
-from ruamel import yaml
 
 import determined_common
 from determined_cli import checkpoint, render
 from determined_cli.declarative_argparse import Arg, Cmd, Group
-from determined_common import api, constants, context
+from determined_common import api, constants, context, yaml
 from determined_common.api.authentication import authentication_required
 from determined_common.experimental import Determined
 

--- a/cli/determined_cli/template.py
+++ b/cli/determined_cli/template.py
@@ -3,10 +3,9 @@ from argparse import FileType, Namespace
 from collections import namedtuple
 from typing import Any, List
 
-from ruamel import yaml
 from termcolor import colored
 
-from determined_common import api
+from determined_common import api, yaml
 from determined_common.api.authentication import authentication_required
 
 from . import render

--- a/common/determined_common/__init__.py
+++ b/common/determined_common/__init__.py
@@ -1,3 +1,9 @@
+try:
+    from ruamel import yaml
+except ModuleNotFoundError:
+    # Inexplicably, sometimes ruamel.yaml is pacakged as ruamel_yaml instead.
+    import ruamel_yaml as yaml  # type: ignore
+
 from . import api, check, constants, context, storage, types, util
 from ._logging import set_logger
 from .__version__ import __version__

--- a/common/determined_common/api/experiment.py
+++ b/common/determined_common/api/experiment.py
@@ -6,10 +6,9 @@ import uuid
 from argparse import Namespace
 from typing import Any, Dict, Optional
 
-from ruamel import yaml
 from termcolor import colored
 
-from determined_common import api, constants, context
+from determined_common import api, constants, context, yaml
 from determined_common.api import request as req
 from determined_common.api.authentication import authentication_required
 

--- a/e2e_tests/tests/config.py
+++ b/e2e_tests/tests/config.py
@@ -1,7 +1,7 @@
 import os
 from typing import Any, Dict
 
-from ruamel import yaml
+from determined_common import yaml
 
 MASTER_IP = "localhost"
 MASTER_PORT = "8080"

--- a/e2e_tests/tests/experiment/experiment.py
+++ b/e2e_tests/tests/experiment/experiment.py
@@ -11,10 +11,9 @@ from typing import Any, Dict, List, Optional
 import dateutil.parser
 import pytest
 import requests
-from ruamel import yaml
 
 import determined_common.api.authentication as auth
-from determined_common import api
+from determined_common import api, yaml
 from tests import cluster
 from tests import config as conf
 

--- a/e2e_tests/tests/experiment/test_noop.py
+++ b/e2e_tests/tests/experiment/test_noop.py
@@ -3,9 +3,8 @@ import tempfile
 import time
 
 import pytest
-from ruamel import yaml
 
-from determined_common import check
+from determined_common import check, yaml
 from tests import config as conf
 from tests import experiment as exp
 

--- a/e2e_tests/tests/test_users.py
+++ b/e2e_tests/tests/test_users.py
@@ -10,9 +10,8 @@ import appdirs
 import pexpect
 import pytest
 from pexpect import spawn
-from ruamel import yaml
 
-from determined_common import constants
+from determined_common import constants, yaml
 from determined_common.api.authentication import Authentication, Credentials, TokenStore
 from tests import command
 from tests import config as conf


### PR DESCRIPTION
## Description

Inexplicably, sometimes ruamel.yaml is pacakged as ruamel_yaml instead.