### PR TITLE
feat: support multi-dtrain single-node in host mode [DET-3821]

### DIFF
--- a/harness/determined/_env_context.py
+++ b/harness/determined/_env_context.py
@@ -24,6 +24,7 @@ class EnvContext:
         debug: bool,
         workload_manager_type: str,
         det_rendezvous_ports: str,
+        det_trial_unique_port_offset: int,
         det_trial_runner_network_interface: str,
         det_trial_id: str,
         det_experiment_id: str,
@@ -46,6 +47,7 @@ class EnvContext:
         self.debug = debug
         self.workload_manager_type = workload_manager_type
         self.det_rendezvous_ports = det_rendezvous_ports
+        self.det_trial_unique_port_offset = det_trial_unique_port_offset
         self.det_trial_runner_network_interface = det_trial_runner_network_interface
         self.det_trial_id = det_trial_id
         self.det_experiment_id = det_experiment_id

--- a/harness/determined/_local_execution.py
+++ b/harness/determined/_local_execution.py
@@ -73,6 +73,7 @@ def _make_local_execution_env(
         debug=config.debug_enabled(),
         workload_manager_type="",
         det_rendezvous_ports=local_rendezvous_ports,
+        det_trial_unique_port_offset=0,
         det_trial_runner_network_interface=constants.AUTO_DETECT_TRIAL_RUNNER_NETWORK_INTERFACE,
         det_trial_id="",
         det_experiment_id="",

--- a/harness/determined/_trial_controller.py
+++ b/harness/determined/_trial_controller.py
@@ -287,8 +287,12 @@ class LoopTrialController(TrialController):
     def _initialize_train_process_comm(self) -> None:
         check.true(self.hvd_config.use)
 
-        srv_pub_port = constants.INTER_TRAIN_PROCESS_COMM_PORT_1
-        srv_pull_port = constants.INTER_TRAIN_PROCESS_COMM_PORT_2
+        srv_pub_port = (
+            constants.INTER_TRAIN_PROCESS_COMM_PORT_1 + self.env.det_trial_unique_port_offset
+        )
+        srv_pull_port = (
+            constants.INTER_TRAIN_PROCESS_COMM_PORT_2 + self.env.det_trial_unique_port_offset
+        )
 
         if self.is_chief:
             logging.debug(f"Chief setting up server with ports {srv_pub_port}/{srv_pull_port}.")

--- a/harness/determined/constants.py
+++ b/harness/determined/constants.py
@@ -5,7 +5,10 @@ from pathlib import Path
 # match LocalRendezvousPort in master/internal/trial.go.
 LOCAL_RENDEZVOUS_PORT = 1734
 
-# The maximum number of slots we expect any agent to have.
+# The maximum number of slots we expect any agent to have. Since we offset some ports
+# by the min(device_id) belonging to the trial, if we have two ports offset in this way,
+# we separate them by the max(min(device_id)) to avoid collisions. The two rendezvous ports
+# are examples of this.
 MAX_SLOTS_PER_AGENT = 16
 
 # The path used to serialize the training process environment variables

--- a/harness/determined/constants.py
+++ b/harness/determined/constants.py
@@ -5,6 +5,9 @@ from pathlib import Path
 # match LocalRendezvousPort in master/internal/trial.go.
 LOCAL_RENDEZVOUS_PORT = 1734
 
+# The maximum number of slots we expect any agent to have.
+MAX_SLOTS_PER_AGENT = 16
+
 # The path used to serialize the training process environment variables
 # inside the trial container.
 TRAIN_PROCESS_ENVIRONMENT_VARIABLE_PATH = Path("/tmp/det_train_process_env.json")
@@ -39,7 +42,7 @@ HOROVOD_GLOO_RENDEZVOUS_PORT = 12355
 # Port for communicating between training processes. Used for reducing
 # validation metrics.
 INTER_TRAIN_PROCESS_COMM_PORT_1 = 12360
-INTER_TRAIN_PROCESS_COMM_PORT_2 = 12361
+INTER_TRAIN_PROCESS_COMM_PORT_2 = INTER_TRAIN_PROCESS_COMM_PORT_1 + MAX_SLOTS_PER_AGENT
 
 # Default trial runner interface. For distributed training this
 # specifies that the network interface must be auto-detected.

--- a/harness/determined/exec/harness.py
+++ b/harness/determined/exec/harness.py
@@ -168,6 +168,7 @@ def main() -> None:
     slot_ids = json.loads(os.environ["DET_SLOT_IDS"])
     workload_manager_type = os.environ["DET_WORKLOAD_MANAGER_TYPE"]
     det_rendezvous_ports = os.environ["DET_RENDEZVOUS_PORTS"]
+    det_trial_unique_port_offset = int(os.environ["DET_TRIAL_UNIQUE_PORT_OFFSET"])
     det_trial_runner_network_interface = os.environ["DET_TRIAL_RUNNER_NETWORK_INTERFACE"]
     det_trial_id = os.environ["DET_TRIAL_ID"]
     det_experiment_id = os.environ["DET_EXPERIMENT_ID"]
@@ -192,6 +193,7 @@ def main() -> None:
         debug,
         workload_manager_type,
         det_rendezvous_ports,
+        det_trial_unique_port_offset,
         det_trial_runner_network_interface,
         det_trial_id,
         det_experiment_id,

--- a/harness/determined/layers/_worker_process.py
+++ b/harness/determined/layers/_worker_process.py
@@ -167,7 +167,9 @@ class SubprocessLauncher:
         subprocess_env = {
             **os.environ,
             "NCCL_DEBUG": "INFO",
-            "DET_HOROVOD_GLOO_RENDEZVOUS_PORT": str(constants.HOROVOD_GLOO_RENDEZVOUS_PORT),
+            "DET_HOROVOD_GLOO_RENDEZVOUS_PORT": str(
+                constants.HOROVOD_GLOO_RENDEZVOUS_PORT + self.env.det_trial_unique_port_offset
+            ),
         }
         return subprocess.Popen(horovod_process_cmd, env=subprocess_env)
 

--- a/harness/tests/experiment/utils.py
+++ b/harness/tests/experiment/utils.py
@@ -132,6 +132,7 @@ def make_default_env_context(
         debug=False,
         workload_manager_type="TRIAL_WORKLOAD_MANAGER",
         det_rendezvous_ports="",
+        det_trial_unique_port_offset=0,
         det_trial_runner_network_interface=constants.AUTO_DETECT_TRIAL_RUNNER_NETWORK_INTERFACE,
         det_trial_id="1",
         det_experiment_id="1",

--- a/harness/tests/tensorboard/test_util.py
+++ b/harness/tests/tensorboard/test_util.py
@@ -30,6 +30,7 @@ def get_dummy_env() -> det.EnvContext:
         workload_manager_type="",
         hparams={"global_batch_size": 1},
         det_rendezvous_ports="",
+        det_trial_unique_port_offset=0,
         det_trial_runner_network_interface=constants.AUTO_DETECT_TRIAL_RUNNER_NETWORK_INTERFACE,
         det_trial_id="1",
         det_experiment_id="1",

--- a/harness/tests/test_horovod.py
+++ b/harness/tests/test_horovod.py
@@ -33,6 +33,7 @@ def create_default_env_context(experiment_config: Dict[str, Any]) -> det.EnvCont
         debug=False,
         workload_manager_type="",
         det_rendezvous_ports="",
+        det_trial_unique_port_offset=0,
         det_trial_runner_network_interface=det_trial_runner_network_interface,
         det_trial_id="1",
         det_experiment_id="1",

--- a/master/internal/kubernetes/spec.go
+++ b/master/internal/kubernetes/spec.go
@@ -190,7 +190,7 @@ func (p *pod) createPodSpecForTrial(ctx *actor.Context) error {
 	}
 
 	envVars, err := p.configureEnvVars(
-		tasks.TrialEnvVars(p.taskSpec, rendezvousPorts),
+		tasks.TrialEnvVars(p.taskSpec, rendezvousPorts, 0),
 		p.taskSpec.StartContainer.ExperimentConfig.Environment,
 		deviceType,
 	)

--- a/master/internal/trial.go
+++ b/master/internal/trial.go
@@ -324,8 +324,7 @@ func (t *trial) Receive(ctx *actor.Context) error {
 				CanTerminate: true,
 				Label:        label,
 				FittingRequirements: scheduler.FittingRequirements{
-					SingleAgent:    false,
-					DedicatedAgent: t.taskContainerDefaults.NetworkMode.IsHost() && slotsNeeded > 1,
+					SingleAgent: false,
 				},
 				TaskHandler: ctx.Self(),
 			}).Get().(*scheduler.Task)

--- a/master/pkg/tasks/task_spec.go
+++ b/master/pkg/tasks/task_spec.go
@@ -79,7 +79,7 @@ type StartContainer struct {
 	WorkloadManagerType model.WorkloadManagerType `json:"workload_manager_type"`
 	AdditionalFiles     archive.Archive           `json:"additional_files"`
 
-	// TODO(DET-3821): This is used to hint the resource provider to override defaults and start
+	// This is used to hint the resource provider to override defaults and start
 	// the container in host mode iff it has been scheduled across multiple agents. Remove this
 	// when multiple horovod containers can run per agent in host-mode.
 	IsMultiAgent bool `json:"is_multi_agent"`

--- a/master/pkg/tasks/task_spec.go
+++ b/master/pkg/tasks/task_spec.go
@@ -80,8 +80,7 @@ type StartContainer struct {
 	AdditionalFiles     archive.Archive           `json:"additional_files"`
 
 	// This is used to hint the resource provider to override defaults and start
-	// the container in host mode iff it has been scheduled across multiple agents. Remove this
-	// when multiple horovod containers can run per agent in host-mode.
+	// the container in host mode iff it has been scheduled across multiple agents.
 	IsMultiAgent bool `json:"is_multi_agent"`
 }
 


### PR DESCRIPTION
## Description
This change adds the environment variable `DET_TRIAL_UNIQUE_PORT_OFFSET` to the harness. The master supplies this to the harness and it is guaranteed to be unique for each trial on an agent - for any trial, it will be equal to `min(deviceIds)` that the trial is assigned, so since different trials on the same agent will never share devices the value will be distinct for each trial. 

<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan

- [x] spin up a cluster and run multiple jobs in host and bridge networking mode
4 concurrent host-mode experiments 2-slot in host mode
<img width="1704" alt="Screen Shot 2020-08-27 at 6 02 06 PM" src="https://user-images.githubusercontent.com/9650546/91499500-82c2e700-e88f-11ea-8173-228f91c95782.png">

<img width="740" alt="Screen Shot 2020-08-27 at 5 41 40 PM" src="https://user-images.githubusercontent.com/9650546/91498222-63c35580-e88d-11ea-886c-676c4b96e6fd.png">

<img width="1531" alt="Screen Shot 2020-08-27 at 5 43 42 PM" src="https://user-images.githubusercontent.com/9650546/91498146-42626980-e88d-11ea-82d1-0c8b829e379c.png">
they converge:
<img width="1542" alt="Screen Shot 2020-08-27 at 5 43 58 PM" src="https://user-images.githubusercontent.com/9650546/91498186-5312df80-e88d-11ea-99de-8b394d4c7e66.png">
<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [x] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234