### PR TITLE
feat: support MaxSlots in k8 RP [DET-3830]

### DIFF
--- a/master/internal/scheduler/default_resource_provider.go
+++ b/master/internal/scheduler/default_resource_provider.go
@@ -6,7 +6,6 @@ import (
 	"net/url"
 	"strconv"
 	"syscall"
-	"time"
 
 	"github.com/determined-ai/determined/master/pkg/device"
 
@@ -24,13 +23,6 @@ import (
 	"github.com/determined-ai/determined/master/pkg/model"
 	image "github.com/determined-ai/determined/master/pkg/tasks"
 )
-
-const (
-	actionCooldown = 500 * time.Millisecond
-)
-
-// schedulerTick periodically triggers the scheduler to act.
-type schedulerTick struct{}
 
 // DefaultRP manages the agent and task lifecycles.
 type DefaultRP struct {
@@ -225,7 +217,7 @@ func (d *DefaultRP) Receive(ctx *actor.Context) error {
 
 	switch msg := ctx.Message().(type) {
 	case actor.PreStart:
-		actors.NotifyAfter(ctx, actionCooldown, schedulerTick{})
+		actors.NotifyAfter(ctx, actionCoolDown, schedulerTick{})
 
 	case sproto.ConfigureEndpoints:
 		ctx.Log().Infof("initializing endpoints for agents")
@@ -316,7 +308,7 @@ func (d *DefaultRP) Receive(ctx *actor.Context) error {
 		}
 		d.reschedule = false
 		reschedule = false
-		actors.NotifyAfter(ctx, actionCooldown, schedulerTick{})
+		actors.NotifyAfter(ctx, actionCoolDown, schedulerTick{})
 
 	default:
 		reschedule = false

--- a/master/internal/scheduler/resource_providers.go
+++ b/master/internal/scheduler/resource_providers.go
@@ -1,9 +1,18 @@
 package scheduler
 
 import (
+	"time"
+
 	"github.com/determined-ai/determined/master/internal/sproto"
 	"github.com/determined-ai/determined/master/pkg/actor"
 )
+
+const (
+	actionCoolDown = 500 * time.Millisecond
+)
+
+// schedulerTick periodically triggers the scheduler to act.
+type schedulerTick struct{}
 
 // ResourceProviders manages the configured resource providers.
 // Currently support only one resource provider at a time.


### PR DESCRIPTION
## Description
As part of this PR added a scheduling tick to the k8 RP similar to the one we have in default RP.


## Test Plan
Tested manually by spinning up a cluster and running adaptive experiments with and w/o MaxSlots set.