### PR TITLE
feat: support config file for tensorboard [DET-3900]

### DIFF
--- a/cli/determined_cli/tensorboard.py
+++ b/cli/determined_cli/tensorboard.py
@@ -1,5 +1,5 @@
 import sys
-from argparse import ONE_OR_MORE, Namespace
+from argparse import ONE_OR_MORE, FileType, Namespace
 from collections import namedtuple
 from typing import Any, Dict, List
 
@@ -10,7 +10,7 @@ from determined_common.api.authentication import authentication_required
 from determined_common.check import check_eq
 
 from . import render
-from .command import Command, render_event_stream
+from .command import Command, launch_command, parse_config, render_event_stream
 from .declarative_argparse import Arg, Cmd
 
 Tensorboard = namedtuple(
@@ -33,20 +33,21 @@ def to_tensorboard(command: Command) -> Tensorboard:
 
 @authentication_required
 def start_tensorboard(args: Namespace) -> None:
+    # this is the place where you add some stuff related to importing the config
+    # think about if you need to add the option for manual config options
     if args.trial_ids is None and args.experiment_ids is None:
         print("Either experiment_ids or trial_ids must be specified.")
         sys.exit(1)
 
-    req_body = {"trial_ids": args.trial_ids, "experiment_ids": args.experiment_ids}
-    resp = api.post(args.master, "tensorboard", body=req_body)
-
-    res_body = resp.json()
+    config = parse_config(args.config_file, None, [], [])
+    req_body = {"config": config, "trial_ids": args.trial_ids, "experiment_ids": args.experiment_ids}
+    resp = api.post(args.master, "tensorboard", body=req_body).json()
 
     if args.detach:
-        print(res_body["id"])
+        print(resp["id"])
         return
 
-    url = "tensorboard/{}/events".format(res_body["id"])
+    url = "tensorboard/{}/events".format(resp["id"])
     with api.ws(args.master, url) as ws:
         for msg in ws:
             if msg["log_event"] is not None:
@@ -57,9 +58,9 @@ def start_tensorboard(args: Namespace) -> None:
 
             if msg["service_ready_event"]:
                 if args.no_browser:
-                    url = api.make_url(args.master, res_body["service_address"])
+                    url = api.make_url(args.master, resp["service_address"])
                 else:
-                    url = api.open(args.master, res_body["service_address"])
+                    url = api.open(args.master, resp["service_address"])
 
                 print(colored("TensorBoard is running at: {}".format(url), "green"))
                 render_event_stream(msg)
@@ -135,6 +136,8 @@ args_description = [
                      "the specified experiment will be loaded into TensorBoard. If the "
                      "experiment has more trials, the 100 best-performing trials will "
                      "be used."),
+            Arg("--config-file", default=None, type=FileType("r"),
+                help="command config file (.yaml)"),
             Arg("-t", "--trial-ids", nargs=ONE_OR_MORE, type=int,
                 help="trial IDs to load into TensorBoard; at most 100 trials are "
                      "allowed per TensorBoard instance"),

--- a/cli/determined_cli/tensorboard.py
+++ b/cli/determined_cli/tensorboard.py
@@ -10,7 +10,7 @@ from determined_common.api.authentication import authentication_required
 from determined_common.check import check_eq
 
 from . import render
-from .command import Command, launch_command, parse_config, render_event_stream
+from .command import Command, parse_config, render_event_stream
 from .declarative_argparse import Arg, Cmd
 
 Tensorboard = namedtuple(
@@ -33,14 +33,16 @@ def to_tensorboard(command: Command) -> Tensorboard:
 
 @authentication_required
 def start_tensorboard(args: Namespace) -> None:
-    # this is the place where you add some stuff related to importing the config
-    # think about if you need to add the option for manual config options
     if args.trial_ids is None and args.experiment_ids is None:
         print("Either experiment_ids or trial_ids must be specified.")
         sys.exit(1)
 
     config = parse_config(args.config_file, None, [], [])
-    req_body = {"config": config, "trial_ids": args.trial_ids, "experiment_ids": args.experiment_ids}
+    req_body = {
+        "config": config,
+        "trial_ids": args.trial_ids,
+        "experiment_ids": args.experiment_ids,
+    }
     resp = api.post(args.master, "tensorboard", body=req_body).json()
 
     if args.detach:

--- a/cli/determined_cli/tensorboard.py
+++ b/cli/determined_cli/tensorboard.py
@@ -120,6 +120,12 @@ def kill_tensorboard(args: Namespace) -> None:
             print(colored("Skipping: {} ({})".format(e, type(e).__name__), "red"))
 
 
+@authentication_required
+def tensorboard_config(args: Namespace) -> None:
+    res_json = api.get(args.master, "tensorboard/{}".format(args.tensorboard_id)).json()
+    print(render.format_object_as_yaml(res_json["config"]))
+
+
 # fmt: off
 
 args_description = [
@@ -146,6 +152,10 @@ args_description = [
             Arg("-d", "--detach", action="store_true",
                 help="run in the background and print the ID")
         ]),
+        Cmd("config", tensorboard_config,
+            "display TensorBoard config", [
+                Arg("tensorboard_id", type=str, help="TensorBoard ID")
+            ]),
         Cmd("open", open_tensorboard,
             "open existing TensorBoard instance", [
                 Arg("tensorboard_id", help="TensorBoard ID")

--- a/docs/how-to/tensorboard.txt
+++ b/docs/how-to/tensorboard.txt
@@ -51,6 +51,32 @@ TensorBoard for multiple experiments use
   metrics from persistent storage. It may take up to 5 minutes for TensorBoard
   to receive data and render visualizations.
 
+Customizing Tensorboards
+------------------------
+
+Determined supports initializing TensorBoard with a YAML configuration file.
+For example, this feature can be useful for running TensorBoard with a
+specific container image or for enabling access to additional data with a
+bind-mount.
+
+.. code:: yaml
+
+  environment:
+    image: determinedai/environments:cuda-10.0-pytorch-1.4-tf-1.15-cpu-0.5.0
+  bind_mounts:
+    - host_path: /my/agent/path
+      container_path: /my/container/path
+      read_only: true
+
+Details of configuration settings can be found in the
+:ref:`command-notebook-configuration`.
+
+To launch Tensorboard with a config file, use
+``det tensorboard start <experiment-id> --config-file=my_config.yaml``.
+
+To view the configuration of a running Tensorboard instance, use
+``det tensorboard config <tensorboard_id>``.
+
 Analyzing Specific Trials
 -------------------------
 

--- a/docs/reference/command-notebook-config.txt
+++ b/docs/reference/command-notebook-config.txt
@@ -1,28 +1,37 @@
 .. _command-notebook-configuration:
 
-Command and Notebook Configuration
-==================================
+Tensorboard and Notebook Configuration
+======================================
 
-The behavior of command and notebook workloads can be influenced by
+The behavior of tensorboard and notebook workloads can be influenced by
 setting a variety of configuration variables. Configuration settings can
 be specified by passing a YAML configuration file when launching the
 workload via the Determined CLI:
 
 .. code::
 
-  $ det cmd run --config-file=my_config.yaml
+  $ det tensorboard start experiment_id --config-file=my_config.yaml
   $ det notebook start --config-file=my_config.yaml
 
-Configuration variables can also be set directly on the command-line
-when the workload is launched:
+For notebooks, configuration variables can also be set directly on the
+command-line when the workload is launched:
 
 .. code::
 
-  $ det cmd run --config resources.slots=2 ...
   $ det notebook start --config resources.slots=2
 
 Options set via ``--config`` take precedence over values specified in
 the configuration file.
+
+The same configuration methods also work for commands and shells:
+
+.. code::
+
+    $ det cmd run --config-file=my_config.yaml
+    $ det cmd run --config resources.slots=2 ...
+
+    $ det shell start --config-file=my_config.yaml
+    $ det shell start --config resources.slots=2 ...
 
 Configuration Settings
 **********************
@@ -69,7 +78,8 @@ The following configuration settings are supported:
     number of slots on the agent in the cluster with the most slots.
     For example, Determined will be unable to schedule a command that
     requests 4 slots if the Determined cluster is composed of agents with 2
-    slots each.
+    slots each. The number of slots for Tensorboard is fixed at ``0`` and
+    may not be changed.
 
   - ``agent_label``: If set, the command/notebook will _only_ be scheduled on
     agents that have the given label set. If this is not set (the default

--- a/master/internal/command/tensorboard_manager.go
+++ b/master/internal/command/tensorboard_manager.go
@@ -299,8 +299,11 @@ func (t *tensorboardManager) newTensorBoard(
 	)
 	config.Entrypoint = []string{tensorboardEntrypointFile, "--logdir", strings.Join(logDirs, ",")}
 	config.Resources.Slots = tensorboardResourcesSlots
-	config.Environment.EnvironmentVariables = model.RuntimeItems{CPU: envVars, GPU: envVars}
-	config.BindMounts = getMounts(uniqMounts)
+
+	cpuEnvVars := append(config.Environment.EnvironmentVariables.CPU, envVars...)
+	gpuEnvVars := append(config.Environment.EnvironmentVariables.GPU, envVars...)
+	config.Environment.EnvironmentVariables = model.RuntimeItems{CPU: cpuEnvVars, GPU: gpuEnvVars}
+	config.BindMounts = append(config.BindMounts, getMounts(uniqMounts)...)
 
 	setPodSpec(&config, t.taskContainerDefaults)
 

--- a/tools/run-server.py
+++ b/tools/run-server.py
@@ -50,7 +50,7 @@ def tail_db_logs():
 def run_master():
     return proc(
         "master",
-        ["../master/build/determined-master", "--config-file", "master.yaml"],
+        ["../master/build/determined-master", "--config-file", "/usr/local/determined/etc/master.yaml"],
         logs_handler=lambda line: f"{MAGENTA}determined-master  |{CLEAR} {line}"
     )
 
@@ -83,26 +83,26 @@ def main():
     db, master, agent, db_logs = False, None, None, None
     try:
         master = run_master()
-        agent = run_agent()
-        db_logs = tail_db_logs()
-        if not is_db_running():
-            db = True
-            subprocess.check_call(["docker-compose", "up", "-d"])
+        # agent = run_agent()
+        # db_logs = tail_db_logs()
+        # if not is_db_running():
+        #     db = True
+        #     subprocess.check_call(["docker-compose", "up", "-d"])
 
-        wait_for_server(5432)
-        db_logs.start()
+        # wait_for_server(5432)
+        # db_logs.start()
         master.start()
         wait_for_server(8080)
-        agent.start()
+        # agent.start()
 
         # Join the agent first so we can exit if the agent fails to connect to
         # the master.
-        agent.join()
-        if agent.exitcode != 0:
-            raise Exception(f"agent failed with non-zero exit code {agent.exitcode}")
+        # agent.join()
+        # if agent.exitcode != 0:
+        #     raise Exception(f"agent failed with non-zero exit code {agent.exitcode}")
 
         master.join()
-        db_logs.join()
+        # db_logs.join()
     except KeyboardInterrupt:
         pass
     finally:

--- a/tools/run-server.py
+++ b/tools/run-server.py
@@ -50,7 +50,7 @@ def tail_db_logs():
 def run_master():
     return proc(
         "master",
-        ["../master/build/determined-master", "--config-file", "/usr/local/determined/etc/master.yaml"],
+        ["../master/build/determined-master", "--config-file", "master.yaml"],
         logs_handler=lambda line: f"{MAGENTA}determined-master  |{CLEAR} {line}"
     )
 
@@ -83,26 +83,26 @@ def main():
     db, master, agent, db_logs = False, None, None, None
     try:
         master = run_master()
-        # agent = run_agent()
-        # db_logs = tail_db_logs()
-        # if not is_db_running():
-        #     db = True
-        #     subprocess.check_call(["docker-compose", "up", "-d"])
+        agent = run_agent()
+        db_logs = tail_db_logs()
+        if not is_db_running():
+            db = True
+            subprocess.check_call(["docker-compose", "up", "-d"])
 
-        # wait_for_server(5432)
-        # db_logs.start()
+        wait_for_server(5432)
+        db_logs.start()
         master.start()
         wait_for_server(8080)
-        # agent.start()
+        agent.start()
 
         # Join the agent first so we can exit if the agent fails to connect to
         # the master.
-        # agent.join()
-        # if agent.exitcode != 0:
-        #     raise Exception(f"agent failed with non-zero exit code {agent.exitcode}")
+        agent.join()
+        if agent.exitcode != 0:
+            raise Exception(f"agent failed with non-zero exit code {agent.exitcode}")
 
         master.join()
-        # db_logs.join()
+        db_logs.join()
     except KeyboardInterrupt:
         pass
     finally:


### PR DESCRIPTION
## Description
Allow a yaml file to be passed as an argument into the tensorboard start command, providing the option of running tensorboard in different container types. Additionally adds the `config` arg to print the config of a specified tensorboard.

<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan
Tested manually. Tensorboard uses a cpu-only container by default, so specify a config file that uses a different container type (e.g. a gpu container). Use `det tensorboard config tensorboard_id` to verify that the specified container is being used.

<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234