### PR TITLE
ci: reduce e2e-cpu parallelization

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1239,7 +1239,7 @@ workflows:
             - build-go
           matrix:
             parameters:
-              parallelism: [8]
+              parallelism: [6]
               tf1: [true]
               mark: ["e2e_cpu"]
 


### PR DESCRIPTION
If parallelization is too high, some test runners fail due to not
actually having any tests to run.