### PR TITLE
test: fix flake with experiment_config_test

### DIFF
--- a/master/pkg/model/experiment_config_test.go
+++ b/master/pkg/model/experiment_config_test.go
@@ -17,6 +17,13 @@ func intP(x int) *int {
 	return &x
 }
 
+func zeroizeRandomSeedsBeforeCompare(a *ExperimentConfig, b *ExperimentConfig) {
+	// Because the default random seed is determined by the time, once in a great while these tests
+	// will fail due to the experiment configs being created at different times.
+	a.Reproducibility.ExperimentSeed = 0
+	b.Reproducibility.ExperimentSeed = 0
+}
+
 func TestLabelsMap(t *testing.T) {
 	actual := DefaultExperimentConfig()
 	assert.NilError(t, json.Unmarshal([]byte(`{
@@ -29,6 +36,7 @@ func TestLabelsMap(t *testing.T) {
 	expected.Labels = map[string]bool{
 		"l1": true, "l2": true,
 	}
+	zeroizeRandomSeedsBeforeCompare(&actual, &expected)
 	assert.DeepEqual(t, actual, expected)
 }
 
@@ -44,6 +52,7 @@ func TestLabelsList(t *testing.T) {
 	expected.Labels = map[string]bool{
 		"l1": true, "l2": true,
 	}
+	zeroizeRandomSeedsBeforeCompare(&actual, &expected)
 	assert.DeepEqual(t, actual, expected)
 }
 
@@ -60,6 +69,7 @@ func TestLabelsJoin(t *testing.T) {
 	expected.Labels = map[string]bool{
 		"l1": true, "l2": true, "l3": true,
 	}
+	zeroizeRandomSeedsBeforeCompare(&actual, &expected)
 	assert.DeepEqual(t, actual, expected)
 }
 


### PR DESCRIPTION
## Description

Because the default random seed is determined by the time, once in a great while these tests will fail due to the experiment configs being created at different times.

One example is here: https://app.circleci.com/pipelines/github/determined-ai/determined/5069/workflows/5c3e9bf7-985b-49be-8e94-5562f53b4912/jobs/128772