### PR TITLE
chore: update trial workload sequencer to ensure all state is snapshotted after a checkpoint

### DIFF
--- a/master/internal/trial_workload_sequencer.go
+++ b/master/internal/trial_workload_sequencer.go
@@ -259,11 +259,11 @@ func (s *trialWorkloadSequencer) computeValidationMetricsCompleted(
 func (s *trialWorkloadSequencer) checkpointModelCompleted(
 	msg searcher.CompletedMessage,
 ) (searcher.Runnable, interface{}) {
+	defer s.snapshotState()
 	checkpoint := checkpointFromCheckpointMetrics(*msg.CheckpointMetrics)
 	s.batchesSinceLastCkpt = 0
 	s.needPostValidationCkpt = false
 	s.latestCheckpoint = &checkpoint
-	s.snapshotState()
 	if !s.UpToDate() {
 		if tOp, ok := s.ops[s.curOpIdx].(searcher.Checkpoint); ok {
 			s.curOpIdx++


### PR DESCRIPTION
# Description
This change changes how `sequencer.snapshotState()` is called when the trial workload sequencer completes a checkpoint. Previously, if the checkpoint was a searcher requested checkpoint (e.g. PBT), we did not snapshot the opIdx being incremented, so a failure between that checkpoint and the next searcher op being completed would result in us redoing the checkpoint.

# Test plan
- [x] make sure master restart works