### PR TITLE
fix: fix loading tensorboard from prior versions [DET-4008]

### DIFF
--- a/docs/release-notes/1201-fix-loading-old-tensorboards.txt
+++ b/docs/release-notes/1201-fix-loading-old-tensorboards.txt
@@ -1,0 +1,6 @@
+:orphan:
+
+**Bug Fixes**
+
+- Fix a bug that prevents tensorboards from experiments with old experiment configurations versions
+  from being loaded.

--- a/master/internal/command/tensorboard_manager.go
+++ b/master/internal/command/tensorboard_manager.go
@@ -162,7 +162,7 @@ func (t *tensorboardManager) newTensorBoard(
 	// Warning! Since certain fields are incompatible with the current model.Experiment,
 	// internally this avoids loading certain parts of the experiment configuration so
 	// we can load their tensorboards still.
-	// TODO(brad): Fix this in the experiment configuration backwards compatibility project.
+	// TODO(DET-4009): Fix this in the experiment configuration backwards compatibility project.
 	exps, err := t.getTensorBoardConfigs(req)
 	if err != nil {
 		return nil, echo.NewHTTPError(http.StatusInternalServerError, err.Error())

--- a/master/internal/command/tensorboard_manager.go
+++ b/master/internal/command/tensorboard_manager.go
@@ -2,7 +2,6 @@ package command
 
 import (
 	"archive/tar"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -160,6 +159,10 @@ func (t *tensorboardManager) newTensorBoard(
 	commandReq *commandRequest,
 	req tensorboardRequest,
 ) (*command, error) {
+	// Warning! Since certain fields are incompatible with the current model.Experiment,
+	// internally this avoids loading certain parts of the experiment configuration so
+	// we can load their tensorboards still.
+	// TODO(brad): Fix this in the experiment configuration backwards compatibility project.
 	exps, err := t.getTensorBoardConfigs(req)
 	if err != nil {
 		return nil, echo.NewHTTPError(http.StatusInternalServerError, err.Error())
@@ -267,18 +270,21 @@ func (t *tensorboardManager) newTensorBoard(
 		}
 	}
 
-	// Take the most recent experiment config and add it to the container. This
+	// Get the most recent experiment config as raw json and add it to the container. This
 	// is used to determine if the experiment is backed by S3.
-	finalExpConf := exps[len(exps)-1].Config
+	mostRecentExpID := exps[len(exps)-1].ID
+	confBytes, err := t.db.ExperimentConfigRaw(mostRecentExpID)
+	if err != nil {
+		return nil, errors.Wrapf(err, "error loading raw experiment config: %d", mostRecentExpID)
+	}
 
-	eConf, err := json.Marshal(finalExpConf)
 	if err != nil {
 		return nil, echo.NewHTTPError(http.StatusInternalServerError,
 			"unable to marshal experiment configuration")
 	}
 
 	additionalFiles = append(additionalFiles,
-		commandReq.AgentUserGroup.OwnedArchiveItem(expConfPath, eConf, 0700, tar.TypeReg))
+		commandReq.AgentUserGroup.OwnedArchiveItem(expConfPath, confBytes, 0700, tar.TypeReg))
 
 	// Multiple experiments may have different s3 credentials. We sort the
 	// experiments in ascending experiment ID order and dedupicate the
@@ -331,7 +337,7 @@ func (t *tensorboardManager) getTensorBoardConfigs(req tensorboardRequest) (
 	var err error
 
 	for _, id := range req.ExperimentIDs {
-		exp, err = t.db.ExperimentByID(id)
+		exp, err = t.db.ExperimentWithoutBackwardsIncompatibleFieldsByID(id)
 		if err != nil {
 			return nil, err
 		}
@@ -340,7 +346,12 @@ func (t *tensorboardManager) getTensorBoardConfigs(req tensorboardRequest) (
 	}
 
 	for _, id := range req.TrialIDs {
-		exp, err = t.db.ExperimentByTrialID(id)
+		expID, err := t.db.ExperimentIDByTrialID(id)
+		if err != nil {
+			return nil, err
+		}
+
+		exp, err = t.db.ExperimentWithoutBackwardsIncompatibleFieldsByID(expID)
 		if err != nil {
 			return nil, err
 		}

--- a/master/internal/db/postgres.go
+++ b/master/internal/db/postgres.go
@@ -686,9 +686,9 @@ func (db *PgDB) ExperimentWithoutBackwardsIncompatibleFieldsByID(
 
 	if err := db.query(`
 SELECT id, state,
-	   config #- '{searcher}' #- '{min_validation_period}' #- '{min_checkpoint_period}' AS config,
-	   model_definition, start_time, end_time, archived,
-       git_remote, git_commit, git_committer, git_commit_date, owner_id
+  config #- '{searcher}' #- '{min_validation_period}' #- '{min_checkpoint_period}' AS config,
+  model_definition, start_time, end_time, archived,
+  git_remote, git_commit, git_committer, git_commit_date, owner_id
 FROM experiments
 WHERE id = $1`, &experiment, id); err != nil {
 		return nil, err

--- a/master/internal/db/postgres.go
+++ b/master/internal/db/postgres.go
@@ -678,7 +678,7 @@ WHERE id = $1`, &experiment, id); err != nil {
 
 // ExperimentWithoutBackwardsIncompatibleFieldsByID looks up an experiment by ID in a database,
 // returning an error if none exists.
-// TODO(brad): remove when we have a better story for backwards compatibility.
+// TODO(DET-4009): Remove when we have a better story for backwards compatibility.
 func (db *PgDB) ExperimentWithoutBackwardsIncompatibleFieldsByID(
 	id int,
 ) (*model.Experiment, error) {
@@ -686,7 +686,7 @@ func (db *PgDB) ExperimentWithoutBackwardsIncompatibleFieldsByID(
 
 	if err := db.query(`
 SELECT id, state,
-	   config #- 'searcher' #- 'min_validation_period' #- 'min_checkpoint_period',
+	   config #- '{searcher}' #- '{min_validation_period}' #- '{min_checkpoint_period}' AS config,
 	   model_definition, start_time, end_time, archived,
        git_remote, git_commit, git_committer, git_commit_date, owner_id
 FROM experiments
@@ -718,9 +718,7 @@ WHERE id = $1`, &experiment, id); err != nil {
 func (db *PgDB) ExperimentIDByTrialID(trialID int) (int, error) {
 	var experimentID int
 	if err := db.sql.Get(&experimentID, `
-  SELECT e.id
-  FROM experiments e, trials t
-  WHERE t.id = $1 AND e.id = t.experiment_id
+SELECT experiment_id FROM trials where id = $1
 `, trialID); err != nil {
 		return 0, errors.Wrapf(err, "querying for experiment id for trial %v", trialID)
 	}

--- a/master/internal/db/postgres.go
+++ b/master/internal/db/postgres.go
@@ -676,6 +676,27 @@ WHERE id = $1`, &experiment, id); err != nil {
 	return &experiment, nil
 }
 
+// ExperimentWithoutBackwardsIncompatibleFieldsByID looks up an experiment by ID in a database,
+// returning an error if none exists.
+// TODO(brad): remove when we have a better story for backwards compatibility.
+func (db *PgDB) ExperimentWithoutBackwardsIncompatibleFieldsByID(
+	id int,
+) (*model.Experiment, error) {
+	var experiment model.Experiment
+
+	if err := db.query(`
+SELECT id, state,
+	   config #- 'searcher' #- 'min_validation_period' #- 'min_checkpoint_period',
+	   model_definition, start_time, end_time, archived,
+       git_remote, git_commit, git_committer, git_commit_date, owner_id
+FROM experiments
+WHERE id = $1`, &experiment, id); err != nil {
+		return nil, err
+	}
+
+	return &experiment, nil
+}
+
 // ExperimentWithoutConfigByID looks up an experiment by ID in a database, returning an error if
 // none exists. It loads the experiment without its configuration, for callers that do not need
 // it, or can't handle backwards incompatible changes.
@@ -691,6 +712,19 @@ WHERE id = $1`, &experiment, id); err != nil {
 	}
 
 	return &experiment, nil
+}
+
+// ExperimentIDByTrialID looks up an experiment ID by a trial ID.
+func (db *PgDB) ExperimentIDByTrialID(trialID int) (int, error) {
+	var experimentID int
+	if err := db.sql.Get(&experimentID, `
+  SELECT e.id
+  FROM experiments e, trials t
+  WHERE t.id = $1 AND e.id = t.experiment_id
+`, trialID); err != nil {
+		return 0, errors.Wrapf(err, "querying for experiment id for trial %v", trialID)
+	}
+	return experimentID, nil
 }
 
 // ExperimentByTrialID looks up an experiment by a trial ID in the

--- a/master/pkg/searcher/event_log_test.go
+++ b/master/pkg/searcher/event_log_test.go
@@ -54,5 +54,3 @@ func TestEventLog(t *testing.T) {
 	log.OperationsCreated(NewShutdown())
 	assert.Assert(t, log.Shutdown)
 }
-
-// TODO(brad) when we rollback the sequencer, rollback searcher events to the last checkpoint too


### PR DESCRIPTION
## Description
This change changes the `newTensorboard` code path to only load the parts of the experiment configuration that it needs, so that old tensorboards can still be loaded.
<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan
- [x] test old tensorboards can load
Tested by running `det-deploy local cluster-up --det-version 0.12.13` and an experiment that writes to tensorboard, followed by upgrading to 0.13.1.dev, checking the version, and ensuring the tensorboard still runs.
<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)
This is really hacky, but there's not really a good non-hacky way that doesn't in some regards basically do the experiment configuration project partly. If anyone has a huge problem with this, I can make some new model structs with only the fields that this needs and write new queries to load them.
<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [x] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234