### PR TITLE
chore: remove a direct ruamel import

### DIFF
--- a/cli/determined_cli/render.py
+++ b/cli/determined_cli/render.py
@@ -8,9 +8,8 @@ from typing import Any, Dict, Iterable, List, Optional, Sequence
 
 import dateutil.parser
 import tabulate
-from ruamel import yaml
 
-from determined_common import util
+from determined_common import util, yaml
 
 # Avoid reporting BrokenPipeError when piping `tabulate` output through
 # a filter like `head`.


### PR DESCRIPTION
## Description

Somehow I missed one earlier.

To verify this was the last one, I grep'd for `ruamel` and didn't see anything.  But... I swear that's what I did before as well.