### PR TITLE
test: use single machine for k8 ci [DET-4004]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1376,8 +1376,8 @@ workflows:
               parallelism: [1]
               slack-mentions: ["${SLACK_USER_ID}"]
               machine-type: ["n1-standard-32"]
-              gpus-per-machine: [4]
-              num-machines: [2]
+              gpus-per-machine: [8]
+              num-machines: [1]
 
       - request-k8-tests:
           type: approval
@@ -1411,8 +1411,8 @@ workflows:
               parallelism: [1]
               slack-mentions: ["${SLACK_USER_ID}"]
               machine-type: ["n1-standard-32"]
-              gpus-per-machine: [4]
-              num-machines: [2]
+              gpus-per-machine: [8]
+              num-machines: [1]
 
 
   nightly:


### PR DESCRIPTION

## Description
Previously parallel tests were being run on two 4-GPU machines. This will speed up GKE tests and reduce CI infra issues.

## Test Plan
https://app.circleci.com/pipelines/github/determined-ai/determined/5135/workflows/c8ec656c-c1e2-4dbe-9e0f-21e4d3c3fe00/jobs/130829

