### PR TITLE
fix: support loading old exp confs from GET /api/v1/experiment

### DIFF
--- a/master/internal/api_experiment.go
+++ b/master/internal/api_experiment.go
@@ -47,10 +47,16 @@ func (a *apiServer) GetExperiment(
 			"error fetching experiment from database: %d", req.ExperimentId)
 	}
 
-	conf, err := a.m.db.ExperimentConfig(int(req.ExperimentId))
+	confBytes, err := a.m.db.ExperimentConfigRaw(int(req.ExperimentId))
 	if err != nil {
 		return nil, errors.Wrapf(err,
 			"error fetching experiment config from database: %d", req.ExperimentId)
+	}
+	var conf map[string]interface{}
+	err = json.Unmarshal(confBytes, &conf)
+	if err != nil {
+		return nil, errors.Wrapf(err,
+			"error unmarshalling experiment config: %d", req.ExperimentId)
 	}
 	return &apiv1.GetExperimentResponse{Experiment: exp, Config: protoutils.ToStruct(conf)}, nil
 }


### PR DESCRIPTION
## Description

<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan
- [x] use new api to load an old experiment.
<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)
Noticed this working on another endpoint.
<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [x] no release notes, since new api isn't released.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234