### PR TITLE
fix: set default TF session in EstimatorTrial

### DIFF
--- a/docs/release-notes/1213-set-default-session.txt
+++ b/docs/release-notes/1213-set-default-session.txt
@@ -1,0 +1,5 @@
+:orphan:
+
+**Bug Fixes**
+
+- Fix issue that was causing OOM for some distributed EstimatorTrial experiments.


### PR DESCRIPTION
## Description
By setting the default session before we import any user code,
if users call any TF code that detects GPUs, we prevent these
calls from causing issues when we pin processes to individual GPUs.

## Test Plan
Inserted: 

```
from tensorflow.python.keras.backend import _get_available_gpus
gpus = _get_available_gpus()
```

in different parts of user code, and confirmed that w/o this fix we see same issues as before (N processes per GPU) and with this fix we see only one process per GPU and no other issues. 