### PR TITLE
feat: modify k8 events to be more understandable [DET-3172]

### DIFF
--- a/master/internal/kubernetes/pod.go
+++ b/master/internal/kubernetes/pod.go
@@ -2,6 +2,7 @@ package kubernetes
 
 import (
 	"fmt"
+	"strconv"
 	"time"
 
 	"github.com/pkg/errors"
@@ -402,6 +403,10 @@ func (p *pod) receivePodEventUpdate(ctx *actor.Context, msg podEventUpdate) {
 	switch p.container.State {
 	case container.Running, container.Terminated:
 		return
+	}
+
+	if msg.event.Message[0:23] == gpuTextReplacement {
+		msg.event.Message += strconv.Itoa(p.gpus) + " GPUs required."
 	}
 
 	message := fmt.Sprintf("Pod %s: %s", msg.event.InvolvedObject.Name, msg.event.Message)


### PR DESCRIPTION
## Description
Previously, kubernetes pod events were difficult to interpret and essentially meaningless to data scientists. This change allows the events handler to intercept and modify certain events to be more human readable. The following events have been modified:

`x/y nodes are available: ...`   --> `Waiting for Resources. x GPUs available, y GPUs required.`
`pod triggered scale-up`        --> `Job requires additional resources, scaling up cluster.`
`Successfully assigned`.        --> `Pod resources allocated.`
`skip schedule deleting pod` --> `Deleting unscheduled pod.`

<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan
Manually tested by launching a kubernetes cluster and making sure that the logged pod events were properly replaced.
<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234