### PR TITLE
chore: lock static query map [DET-3633]

### DIFF
--- a/master/internal/db/static_query_map.go
+++ b/master/internal/db/static_query_map.go
@@ -1,0 +1,26 @@
+package db
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/determined-ai/determined/master/pkg/etc"
+)
+
+type staticQueryMap struct {
+	queries map[string]string
+	sync.RWMutex
+}
+
+func (q *staticQueryMap) getOrLoad(queryName string) string {
+	q.RLock()
+	query, ok := q.queries[queryName]
+	q.RUnlock()
+	if !ok {
+		query = string(etc.MustStaticFile(fmt.Sprintf("%s.sql", queryName)))
+		q.Lock()
+		q.queries[queryName] = query
+		q.Unlock()
+	}
+	return query
+}

--- a/master/internal/db/static_query_map.go
+++ b/master/internal/db/static_query_map.go
@@ -9,18 +9,16 @@ import (
 
 type staticQueryMap struct {
 	queries map[string]string
-	sync.RWMutex
+	sync.Mutex
 }
 
 func (q *staticQueryMap) getOrLoad(queryName string) string {
-	q.RLock()
+	q.Lock()
+	defer q.Unlock()
 	query, ok := q.queries[queryName]
-	q.RUnlock()
 	if !ok {
 		query = string(etc.MustStaticFile(fmt.Sprintf("%s.sql", queryName)))
-		q.Lock()
 		q.queries[queryName] = query
-		q.Unlock()
 	}
 	return query
 }


### PR DESCRIPTION
## Description
This change locks concurrent access to the queries map in `db.PgDB`. Technically two concurrent queries could come in, both see the value doesn't exist, and both populate it (the entire critical section isn't locked), but they would overwrite each other with the same value and the write lock stops the go runtime from barfing over concurrent map writes. I think being able to use `RLock` for the read portion is worth this, since we'll almost never have writes.
<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234