### PR TITLE
feat: add /api/v1/experiments/id/validation-history [DET-3729]

### DIFF
--- a/master/internal/api_experiment.go
+++ b/master/internal/api_experiment.go
@@ -98,6 +98,20 @@ func (a *apiServer) GetExperiments(
 	return resp, a.paginate(&resp.Pagination, &resp.Experiments, req.Offset, req.Limit)
 }
 
+func (a *apiServer) GetExperimentValidationHistory(
+	_ context.Context, req *apiv1.GetExperimentValidationHistoryRequest,
+) (*apiv1.GetExperimentValidationHistoryResponse, error) {
+	var resp apiv1.GetExperimentValidationHistoryResponse
+	switch err := a.m.db.QueryProto("proto_experiment_validation_history", &resp, req.ExperimentId); {
+	case err == db.ErrNotFound:
+		return nil, status.Errorf(codes.NotFound, "experiment not found: %d", req.ExperimentId)
+	case err != nil:
+		return nil, errors.Wrapf(err,
+			"error fetching validation history for experiment from database: %d", req.ExperimentId)
+	}
+	return &resp, nil
+}
+
 func (a *apiServer) PreviewHPSearch(
 	_ context.Context, req *apiv1.PreviewHPSearchRequest) (*apiv1.PreviewHPSearchResponse, error) {
 	bytes, err := protojson.Marshal(req.Config)

--- a/master/static/srv/proto_experiment_validation_history.sql
+++ b/master/static/srv/proto_experiment_validation_history.sql
@@ -1,0 +1,40 @@
+WITH const AS (
+    SELECT config->'searcher'->>'metric' AS metric_name,
+           (SELECT
+               CASE
+                   WHEN coalesce((config->'searcher'
+                                        ->>'smaller_is_better')::boolean, true)
+                   THEN 1
+                   ELSE -1
+               END) AS sign
+    FROM experiments WHERE id = $1
+)
+SELECT (WITH vals AS (
+            SELECT v.trial_id, v.end_time, v.state,
+                    (v.metrics->'validation_metrics'->>(e.config->'searcher'->>'metric'))::float8
+                    AS searcher_metric
+            FROM validations v, trials t
+            WHERE v.trial_id = t.id and t.experiment_id = e.id and v.state = 'COMPLETED'
+        )
+        SELECT coalesce(jsonb_agg(v), '[]'::jsonb)
+        FROM (
+            SELECT n.trial_id, n.end_time, n.searcher_metric
+            FROM (
+                SELECT v.trial_id, v.end_time, v.searcher_metric,
+                    min(const.sign * v.searcher_metric)
+                        OVER (ORDER BY v.end_time ASC
+                            ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING)
+                        AS prev_min_error
+                FROM vals v,
+                    trials t,
+                    const
+                WHERE v.trial_id = t.id
+                AND v.state = 'COMPLETED'
+                AND t.experiment_id = e.id
+            ) n, const
+            WHERE const.sign * n.searcher_metric < n.prev_min_error
+                OR n.prev_min_error IS NULL
+            ORDER BY n.end_time asc
+        ) v) as validation_history
+FROM experiments e
+WHERE e.id = $1

--- a/master/static/srv/proto_experiment_validation_history.sql
+++ b/master/static/srv/proto_experiment_validation_history.sql
@@ -1,19 +1,19 @@
-WITH const AS (
-    SELECT config->'searcher'->>'metric' AS metric_name,
-           (SELECT
-               CASE
-                   WHEN coalesce((config->'searcher'
-                                        ->>'smaller_is_better')::boolean, true)
-                   THEN 1
-                   ELSE -1
-               END) AS sign
-    FROM experiments WHERE id = $1
-)
-SELECT (WITH vals AS (
+
+SELECT (WITH const AS (
+        SELECT config->'searcher'->>'metric' AS metric_name,
+            (SELECT
+                CASE
+                    WHEN coalesce((config->'searcher'
+                                            ->>'smaller_is_better')::boolean, true)
+                    THEN 1
+                    ELSE -1
+                END) AS sign
+        FROM experiments WHERE id = e.id
+        ), vals AS (
             SELECT v.trial_id, v.end_time, v.state,
-                    (v.metrics->'validation_metrics'->>(e.config->'searcher'->>'metric'))::float8
+                    (v.metrics->'validation_metrics'->>(const.metric_name))::float8
                     AS searcher_metric
-            FROM validations v, trials t
+            FROM validations v, trials t, const
             WHERE v.trial_id = t.id and t.experiment_id = e.id and v.state = 'COMPLETED'
         )
         SELECT coalesce(jsonb_agg(v), '[]'::jsonb)

--- a/proto/src/determined/api/v1/api.proto
+++ b/proto/src/determined/api/v1/api.proto
@@ -142,6 +142,11 @@ service Determined {
         option (google.api.http) = {get: "/api/v1/experiments"};
         option (grpc.gateway.protoc_gen_swagger.options.openapiv2_operation) = {tags: "Experiments"};
     }
+    // Get the validation history for an experiment.
+    rpc GetExperimentValidationHistory(GetExperimentValidationHistoryRequest) returns (GetExperimentValidationHistoryResponse) {
+        option (google.api.http) = {get: "/api/v1/experiments/{experiment_id}/validation-history"};
+        option (grpc.gateway.protoc_gen_swagger.options.openapiv2_operation) = {tags: "Experiments"};
+    }
     // Activate an experiment.
     rpc ActivateExperiment(ActivateExperimentRequest) returns (ActivateExperimentResponse) {
         option (google.api.http) = {post: "/api/v1/experiments/{id}/activate" };

--- a/proto/src/determined/api/v1/experiment.proto
+++ b/proto/src/determined/api/v1/experiment.proto
@@ -200,3 +200,19 @@ message GetExperimentCheckpointsResponse {
   // Pagination information of the full dataset.
   Pagination pagination = 2;
 }
+
+// Get the validation history for the requested experiment. The
+// validation history is a time ordered list of the historical
+// best validations.
+message GetExperimentValidationHistoryRequest {
+    // The id of the experiment.
+    int32 experiment_id = 1;
+}
+
+// Response to GetExperimentValidationHistoryRequest.
+message GetExperimentValidationHistoryResponse {
+    // validation_history is a collection of zero or more validation metrics for an experiment,
+    // describing the best metrics as they were reported through the lifetime of an experiment.
+    // The historical list of best validations.
+    repeated determined.experiment.v1.ValidationHistoryEntry validation_history = 1;
+}

--- a/proto/src/determined/experiment/v1/experiment.proto
+++ b/proto/src/determined/experiment/v1/experiment.proto
@@ -67,5 +67,5 @@ message ValidationHistoryEntry {
     // The time at which the completed validation was reported.
     google.protobuf.Timestamp end_time = 2;
     // The value of the `searcher.metric`, indicated by the experiment config, for the validation.
-    double searcher_metric = 3;
+    float searcher_metric = 3;
 }

--- a/proto/src/determined/experiment/v1/experiment.proto
+++ b/proto/src/determined/experiment/v1/experiment.proto
@@ -53,3 +53,13 @@ message Experiment {
     // The username of the user that created the experiment.
     string username = 10;
 }
+
+// ValidationHistoryEntry is a single entry for a validation history for an experiment.
+message ValidationHistoryEntry {
+    // The id for the trial associated with this validation entry.
+    int32 trial_id = 1;
+    // The time at which the completed validation was reported.
+    google.protobuf.Timestamp end_time = 2;
+    // The value of the `searcher.metric`, indicated by the experiment config, for the validation.
+    double searcher_metric = 3;
+}

--- a/proto/src/determined/experiment/v1/experiment.proto
+++ b/proto/src/determined/experiment/v1/experiment.proto
@@ -4,6 +4,7 @@ package determined.experiment.v1;
 option go_package = "github.com/determined-ai/determined/proto/pkg/experimentv1";
 
 import "google/protobuf/timestamp.proto";
+import "protoc-gen-swagger/options/annotations.proto";
 
 // The current state of the experiment.
 enum State {
@@ -56,6 +57,11 @@ message Experiment {
 
 // ValidationHistoryEntry is a single entry for a validation history for an experiment.
 message ValidationHistoryEntry {
+    option (grpc.gateway.protoc_gen_swagger.options.openapiv2_schema) = {
+        json_schema: {
+            required: ["trial_id", "end_time", "searcher_metric"]
+        }
+    };
     // The id for the trial associated with this validation entry.
     int32 trial_id = 1;
     // The time at which the completed validation was reported.


### PR DESCRIPTION
## Description
This adds the `/api/v1/experiments/id/validation-history` endpoint to describe the historical best validations of an experiment. It is done as a separate endpoint because expressing it as a combination of sorts and filters isn't realistic.
<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan
- [x] test missing experiment returns 404
- [x] test present experiment returns correct history.
```
{
    "validationHistory": [
        {
            "trialId": 1,
            "endTime": "2020-09-02T13:27:55.607362Z",
 ...
            "searcherMetric": 0.4304672100000001
        },
        {
            "trialId": 1,
            "endTime": "2020-09-02T13:27:56.729405Z",
            "searcherMetric": 0.3874204890000001
        }
    ]
}
```
<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)
We could say something like, sort by time and add a "best" filter, that does a pass through and continually takes better metrics, but that doesn't seem intuitive (I would think best meant something else, and it's not really a filter at that point, it's some kind of window agg).

Also the query is a little complicated - I rewrote it once and even got what seemed to be a slightly better query plan (messing with the vals cte, mainly) but I figure this is a relatively complex query where it's easy to write something awful, so I just figured I'd rather leave it as is and be certain it will be fine than change it and need to worry about it on a release.
<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234