### PR TITLE
feat: make /api/v1/experiment/id/checkpoints sortable by searcher metric [DET-4067]

### DIFF
--- a/master/static/srv/get_checkpoints_for_experiment.sql
+++ b/master/static/srv/get_checkpoints_for_experiment.sql
@@ -16,7 +16,8 @@ SELECT
     COALESCE(c.format, '') as format,
     COALESCE(c.determined_version, '') as determined_version,
     v.metrics AS metrics,
-    'STATE_' || v.state AS validation_state
+    'STATE_' || v.state AS validation_state,
+    (v.metrics->'validation_metrics'->>(e.config->'searcher'->>'metric'))::float8 AS searcher_metric
 FROM checkpoints c
 JOIN steps s ON c.step_id = s.id AND c.trial_id = s.trial_id
 LEFT JOIN validations v ON v.step_id = s.id AND v.trial_id = s.trial_id

--- a/proto/src/determined/api/v1/experiment.proto
+++ b/proto/src/determined/api/v1/experiment.proto
@@ -174,6 +174,8 @@ message GetExperimentCheckpointsRequest {
         SORT_BY_VALIDATION_STATE = 15;
         // Returns checkpoints sorted by state.
         SORT_BY_STATE = 16;
+        // Returns checkpoints sorted by the experiment's `searcher.metric` configuration setting.
+        SORT_BY_SEARCHER_METRIC = 17;
     }
     // The experiment id.
     int32 id = 1;

--- a/proto/src/determined/checkpoint/v1/checkpoint.proto
+++ b/proto/src/determined/checkpoint/v1/checkpoint.proto
@@ -68,4 +68,6 @@ message Checkpoint {
   State validation_state = 15;
   // The state of the checkpoint.
   State state = 16;
+  // The value of the metric specified by `searcher.metric` for this metric.
+  float searcher_metric = 17;
 }


### PR DESCRIPTION
## Description
This change add `SORT_BY_SEARCHER_METRIC` to `/api/v1/experiments/$ID/checkpoints` so we can retrieve the best checkpoints for an experiment.
<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan
- [x] make sure checkpoints are sorted correctly
```
{
    "checkpoints": [
        {
            "uuid": "4474c16a-62b2-47b3-98f7-928f8d092562",
...
            "searcherMetric": 0.3486784401000001
        },
        {
            "uuid": "20b17a2c-eb7f-4ee4-968d-99139bcf9c1d",
...
            "searcherMetric": 0.81
        },
        {
            "uuid": "5a9e87da-af29-427e-9d8f-d336cabb18f0",
...
            "searcherMetric": 0.9
        }
    ],
    "pagination": {
        "offset": 0,
        "limit": 0,
        "startIndex": 0,
        "endIndex": 10,
        "total": 10
    }
}
```
<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)
It's a tad unfortunate that with the framework that was built up for new api, a field must be in a small set of types at the root level to sort/filter on it.
In theory, we might be able add a block where we try to compare `pref.MessageKind` in `apiServer.sort` and do something like try to type assert it to `type Lesser interface { Less(i, j int) bool }` and just call the underlying object's less method, but then we also need to define Less for proto objects (so extend auto generated code) and I'm not sure a clean way to do that in go (in c# i'd just hesitantly use extension methods, but yeah).
<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234