### PR TITLE
fix: use correctly set visible devices for keras/estimators [DET-4076]

### DIFF
--- a/harness/determined/_data_layer/_data_layer.py
+++ b/harness/determined/_data_layer/_data_layer.py
@@ -75,9 +75,7 @@ class _CacheableDecorator:
             # that for each instantiation of `tf.Session`, the process is mapped
             # to the same GPU.
             session_config = tf.compat.v1.ConfigProto()
-            session_config.gpu_options.visible_device_list = str(
-                self._env.slot_ids[hvd.local_rank()]
-            )
+            session_config.gpu_options.visible_device_list = str(hvd.local_rank())
 
         rw_coordinator_url = f"ws://{self._env.master_addr}:{self._env.master_port}/ws/data-layer/"
         data_layer_type = self._env.experiment_config.get_data_layer_type()

--- a/harness/determined/estimator/_estimator_trial.py
+++ b/harness/determined/estimator/_estimator_trial.py
@@ -586,9 +586,7 @@ class EstimatorTrialController(det.LoopTrialController):
         # so there is no need to set visible devices for TF.
         # TODO (DET-3762): Remove this once it's no longer necessary.
         if not env.experiment_config.get("data", {}).get("set_cuda_visible_devices", False):
-            session_config.gpu_options.visible_device_list = str(
-                env.slot_ids[horovod.hvd.local_rank()]
-            )
+            session_config.gpu_options.visible_device_list = str(horovod.hvd.local_rank())
 
         return session_config
 

--- a/harness/determined/keras/_tf_keras_trial.py
+++ b/harness/determined/keras/_tf_keras_trial.py
@@ -247,7 +247,7 @@ class TFKerasTrialController(det.LoopTrialController):
             if hvd_config.use:
                 # We launch a horovod process per GPU. Each process
                 # needs to bind to a unique GPU.
-                session_config.gpu_options.visible_device_list = str(env.slot_ids[hvd.local_rank()])
+                session_config.gpu_options.visible_device_list = str(hvd.local_rank())
 
             session = tf.compat.v1.Session(
                 graph=tf.compat.v1.get_default_graph(), config=session_config


### PR DESCRIPTION
## Description
Use `hvd.local_rank()` to determined visible devices, not slot ids.
<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan
- [ ] test mutliple dtrain single node with keras
<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.
-->

<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
