### PR TITLE
test: add unit tests for k8 requestQueue [DET-4027]

### DIFF
--- a/master/internal/kubernetes/mock_client_test.go
+++ b/master/internal/kubernetes/mock_client_test.go
@@ -1,0 +1,183 @@
+package kubernetes
+
+import (
+	"sync"
+	"time"
+
+	"github.com/pkg/errors"
+
+	k8sV1 "k8s.io/api/core/v1"
+	"k8s.io/api/policy/v1beta1"
+	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/rest"
+)
+
+type mockConfigMapInterface struct {
+	configMaps map[string]*k8sV1.ConfigMap
+	mux        sync.Mutex
+}
+
+func (m *mockConfigMapInterface) Create(cm *k8sV1.ConfigMap) (*k8sV1.ConfigMap, error) {
+	m.mux.Lock()
+	defer m.mux.Unlock()
+
+	if _, present := m.configMaps[cm.Name]; present {
+		return nil, errors.Errorf("configMap with name %s already exists", cm.Name)
+	}
+
+	m.configMaps[cm.Name] = cm.DeepCopy()
+	return m.configMaps[cm.Name], nil
+}
+
+func (m *mockConfigMapInterface) Update(*k8sV1.ConfigMap) (*k8sV1.ConfigMap, error) {
+	panic("implement me")
+}
+
+func (m *mockConfigMapInterface) Delete(name string, options *metaV1.DeleteOptions) error {
+	m.mux.Lock()
+	defer m.mux.Unlock()
+
+	if _, present := m.configMaps[name]; !present {
+		return errors.Errorf("configMap with name %s doesn't exists", name)
+	}
+
+	delete(m.configMaps, name)
+	return nil
+}
+
+func (m *mockConfigMapInterface) DeleteCollection(
+	options *metaV1.DeleteOptions,
+	listOptions metaV1.ListOptions,
+) error {
+	panic("implement me")
+}
+
+func (m *mockConfigMapInterface) Get(
+	name string,
+	options metaV1.GetOptions,
+) (*k8sV1.ConfigMap, error) {
+	panic("implement me")
+}
+
+func (m *mockConfigMapInterface) List(opts metaV1.ListOptions) (*k8sV1.ConfigMapList, error) {
+	panic("implement me")
+}
+
+func (m *mockConfigMapInterface) Watch(opts metaV1.ListOptions) (watch.Interface, error) {
+	panic("implement me")
+}
+
+func (m *mockConfigMapInterface) Patch(
+	name string,
+	pt types.PatchType,
+	data []byte,
+	subresources ...string,
+) (result *k8sV1.ConfigMap, err error) {
+	panic("implement me")
+}
+
+type mockPodInterface struct {
+	pods map[string]*k8sV1.Pod
+	// Simulates latency of the real k8 API server.
+	operationalDelay time.Duration
+	mux              sync.Mutex
+}
+
+func (m *mockPodInterface) Create(pod *k8sV1.Pod) (*k8sV1.Pod, error) {
+	time.Sleep(m.operationalDelay)
+	m.mux.Lock()
+	defer m.mux.Unlock()
+
+	if _, present := m.pods[pod.Name]; present {
+		return nil, errors.Errorf("pod with name %s already exists", pod.Name)
+	}
+
+	m.pods[pod.Name] = pod.DeepCopy()
+	return m.pods[pod.Name], nil
+}
+
+func (m *mockPodInterface) Update(*k8sV1.Pod) (*k8sV1.Pod, error) {
+	panic("implement me")
+}
+
+func (m *mockPodInterface) UpdateStatus(*k8sV1.Pod) (*k8sV1.Pod, error) {
+	panic("implement me")
+}
+
+func (m *mockPodInterface) Delete(name string, options *metaV1.DeleteOptions) error {
+	time.Sleep(m.operationalDelay)
+	m.mux.Lock()
+	defer m.mux.Unlock()
+
+	if _, present := m.pods[name]; !present {
+		return errors.Errorf("pod with name %s doesn't exists", name)
+	}
+
+	delete(m.pods, name)
+	return nil
+}
+
+func (m *mockPodInterface) DeleteCollection(
+	options *metaV1.DeleteOptions,
+	listOptions metaV1.ListOptions,
+) error {
+	panic("implement me")
+}
+
+func (m *mockPodInterface) Get(name string, options metaV1.GetOptions) (*k8sV1.Pod, error) {
+	panic("implement me")
+}
+
+func (m *mockPodInterface) List(opts metaV1.ListOptions) (*k8sV1.PodList, error) {
+	time.Sleep(m.operationalDelay)
+	m.mux.Lock()
+	defer m.mux.Unlock()
+
+	podList := &k8sV1.PodList{}
+	for _, pod := range m.pods {
+		podList.Items = append(podList.Items, *pod)
+	}
+
+	return podList, nil
+}
+
+func (m *mockPodInterface) Watch(opts metaV1.ListOptions) (watch.Interface, error) {
+	panic("implement me")
+}
+
+func (m *mockPodInterface) Patch(
+	name string,
+	pt types.PatchType,
+	data []byte,
+	subresources ...string,
+) (result *k8sV1.Pod, err error) {
+	panic("implement me")
+}
+
+func (m *mockPodInterface) GetEphemeralContainers(
+	podName string,
+	options metaV1.GetOptions,
+) (*k8sV1.EphemeralContainers, error) {
+	panic("implement me")
+}
+
+func (m *mockPodInterface) UpdateEphemeralContainers(
+	podName string,
+	ephemeralContainers *k8sV1.EphemeralContainers,
+) (*k8sV1.EphemeralContainers, error) {
+	panic("implement me")
+}
+
+func (m *mockPodInterface) Bind(binding *k8sV1.Binding) error {
+	panic("implement me")
+}
+
+func (m *mockPodInterface) Evict(eviction *v1beta1.Eviction) error {
+	panic("implement me")
+}
+
+func (m *mockPodInterface) GetLogs(name string, opts *k8sV1.PodLogOptions) *rest.Request {
+	panic("implement me")
+}

--- a/master/internal/kubernetes/request_queue_test.go
+++ b/master/internal/kubernetes/request_queue_test.go
@@ -1,0 +1,211 @@
+package kubernetes
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	petName "github.com/dustinkirkland/golang-petname"
+	"gotest.tools/assert"
+
+	"github.com/determined-ai/determined/master/pkg/actor"
+
+	k8sV1 "k8s.io/api/core/v1"
+	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	typedV1 "k8s.io/client-go/kubernetes/typed/core/v1"
+)
+
+type (
+	mockPodActorPing struct{}
+	deleteMockPod    struct{}
+)
+
+type mockPodActor struct {
+	requestQueue *actor.Ref
+	name         string
+}
+
+func newMockPodActor(requestQueue *actor.Ref) *mockPodActor {
+	return &mockPodActor{
+		requestQueue: requestQueue,
+		name:         petName.Generate(3, "-"),
+	}
+}
+
+func (m *mockPodActor) Receive(ctx *actor.Context) error {
+	switch msg := ctx.Message().(type) {
+	case actor.PreStart:
+		podSpec := k8sV1.Pod{ObjectMeta: metaV1.ObjectMeta{Name: m.name}}
+		cmSpec := k8sV1.ConfigMap{ObjectMeta: metaV1.ObjectMeta{Name: m.name}}
+
+		ctx.Tell(m.requestQueue, createKubernetesResources{
+			handler:       ctx.Self(),
+			podSpec:       &podSpec,
+			configMapSpec: &cmSpec,
+		})
+
+	case mockPodActorPing:
+		ctx.Respond(mockPodActorPing{})
+
+	case deleteMockPod:
+		ctx.Ask(m.requestQueue, deleteKubernetesResources{
+			handler:       ctx.Self(),
+			podName:       m.name,
+			configMapName: m.name,
+		})
+
+	case resourceCreationCancelled:
+
+	case resourceCreationFailed, resourceDeletionFailed:
+		ctx.Log().Errorf("should not hit these messages during testing %T", msg)
+		return actor.ErrUnexpectedMessage(ctx)
+
+	default:
+		ctx.Log().Errorf("unexpected message %T", msg)
+		return actor.ErrUnexpectedMessage(ctx)
+	}
+
+	return nil
+}
+
+func getNumberOfActivePods(podInterface typedV1.PodInterface) int {
+	podList, err := podInterface.List(metaV1.ListOptions{})
+	if err != nil {
+		panic(err)
+	}
+
+	return len(podList.Items)
+}
+
+func waitForPendingRequestToFinish(k8RequestQueue *requestQueue) {
+	time.Sleep(time.Second)
+
+	// Wait for queue to finish all in flight requests.
+	for len(k8RequestQueue.queue) > 0 &&
+		len(k8RequestQueue.blockedResourceDeletions) == 0 &&
+		len(k8RequestQueue.availableWorkers) < numKubernetesWorkers {
+	}
+}
+
+func TestRequestQueueCreatingManyPod(t *testing.T) {
+	system := actor.NewSystem(t.Name())
+
+	podInterface := &mockPodInterface{pods: make(map[string]*k8sV1.Pod)}
+	configMapInterface := &mockConfigMapInterface{configMaps: make(map[string]*k8sV1.ConfigMap)}
+
+	k8RequestQueue := newRequestQueue(podInterface, configMapInterface)
+	requestQueueActor, _ := system.ActorOf(
+		actor.Addr("request-queue"),
+		k8RequestQueue,
+	)
+
+	numPods := 15
+	podActors := make([]*actor.Ref, 0)
+	for i := 0; i < numPods; i++ {
+		newMockPodActor, _ := system.ActorOf(
+			actor.Addr(fmt.Sprintf("mock-pod-%d", i)),
+			newMockPodActor(requestQueueActor),
+		)
+
+		podActors = append(podActors, newMockPodActor)
+	}
+	system.AskAll(mockPodActorPing{}, podActors...).GetAll()
+
+	waitForPendingRequestToFinish(k8RequestQueue)
+	assert.Equal(t, getNumberOfActivePods(podInterface), numPods)
+}
+
+func TestRequestQueueCreatingAndDeletingManyPod(t *testing.T) {
+	system := actor.NewSystem(t.Name())
+
+	podInterface := &mockPodInterface{pods: make(map[string]*k8sV1.Pod)}
+	configMapInterface := &mockConfigMapInterface{configMaps: make(map[string]*k8sV1.ConfigMap)}
+
+	k8RequestQueue := newRequestQueue(podInterface, configMapInterface)
+	requestQueueActor, _ := system.ActorOf(
+		actor.Addr("request-queue"),
+		k8RequestQueue,
+	)
+
+	numPods := 15
+	podActors := make([]*actor.Ref, 0)
+	for i := 0; i < numPods; i++ {
+		newMockPodActor, _ := system.ActorOf(
+			actor.Addr(fmt.Sprintf("mock-pod-%d", i)),
+			newMockPodActor(requestQueueActor),
+		)
+
+		podActors = append(podActors, newMockPodActor)
+	}
+	system.AskAll(deleteMockPod{}, podActors...)
+	system.AskAll(mockPodActorPing{}, podActors...).GetAll()
+
+	waitForPendingRequestToFinish(k8RequestQueue)
+	assert.Equal(t, getNumberOfActivePods(podInterface), 0)
+}
+
+func TestRequestQueueCreatingThenDeletingManyPods(t *testing.T) {
+	system := actor.NewSystem(t.Name())
+
+	podInterface := &mockPodInterface{pods: make(map[string]*k8sV1.Pod)}
+	configMapInterface := &mockConfigMapInterface{configMaps: make(map[string]*k8sV1.ConfigMap)}
+
+	k8RequestQueue := newRequestQueue(podInterface, configMapInterface)
+	requestQueueActor, _ := system.ActorOf(
+		actor.Addr("request-queue"),
+		k8RequestQueue,
+	)
+
+	numPods := 15
+	podActors := make([]*actor.Ref, 0)
+	for i := 0; i < numPods; i++ {
+		newMockPodActor, _ := system.ActorOf(
+			actor.Addr(fmt.Sprintf("mock-pod-%d", i)),
+			newMockPodActor(requestQueueActor),
+		)
+
+		podActors = append(podActors, newMockPodActor)
+	}
+	system.AskAll(mockPodActorPing{}, podActors...).GetAll()
+
+	waitForPendingRequestToFinish(k8RequestQueue)
+	assert.Equal(t, getNumberOfActivePods(podInterface), numPods)
+
+	system.AskAll(deleteMockPod{}, podActors...)
+	system.AskAll(mockPodActorPing{}, podActors...).GetAll()
+
+	waitForPendingRequestToFinish(k8RequestQueue)
+	assert.Equal(t, getNumberOfActivePods(podInterface), 0)
+}
+
+func TestRequestQueueCreatingAndDeletingManyPodWithDelay(t *testing.T) {
+	system := actor.NewSystem(t.Name())
+
+	podInterface := &mockPodInterface{
+		pods:             make(map[string]*k8sV1.Pod),
+		operationalDelay: time.Millisecond * 500,
+	}
+	configMapInterface := &mockConfigMapInterface{configMaps: make(map[string]*k8sV1.ConfigMap)}
+
+	k8RequestQueue := newRequestQueue(podInterface, configMapInterface)
+	requestQueueActor, _ := system.ActorOf(
+		actor.Addr("request-queue"),
+		k8RequestQueue,
+	)
+
+	numPods := 15
+	podActors := make([]*actor.Ref, 0)
+	for i := 0; i < numPods; i++ {
+		newMockPodActor, _ := system.ActorOf(
+			actor.Addr(fmt.Sprintf("mock-pod-%d", i)),
+			newMockPodActor(requestQueueActor),
+		)
+
+		podActors = append(podActors, newMockPodActor)
+	}
+	system.AskAll(deleteMockPod{}, podActors...)
+	system.AskAll(mockPodActorPing{}, podActors...).GetAll()
+
+	waitForPendingRequestToFinish(k8RequestQueue)
+	assert.Equal(t, getNumberOfActivePods(podInterface), 0)
+}

--- a/master/internal/kubernetes/request_queue_test.go
+++ b/master/internal/kubernetes/request_queue_test.go
@@ -80,6 +80,7 @@ func waitForPendingRequestToFinish(k8RequestQueue *requestQueue) {
 	for len(k8RequestQueue.queue) > 0 &&
 		len(k8RequestQueue.blockedResourceDeletions) == 0 &&
 		len(k8RequestQueue.availableWorkers) < numKubernetesWorkers {
+		time.Sleep(time.Millisecond * 100)
 	}
 }
 

--- a/master/internal/kubernetes/request_queue_test.go
+++ b/master/internal/kubernetes/request_queue_test.go
@@ -56,10 +56,6 @@ func (m *mockPodActor) Receive(ctx *actor.Context) error {
 
 	case resourceCreationCancelled:
 
-	case resourceCreationFailed, resourceDeletionFailed:
-		ctx.Log().Errorf("should not hit these messages during testing %T", msg)
-		return actor.ErrUnexpectedMessage(ctx)
-
 	default:
 		ctx.Log().Errorf("unexpected message %T", msg)
 		return actor.ErrUnexpectedMessage(ctx)
@@ -93,10 +89,10 @@ func TestRequestQueueCreatingManyPod(t *testing.T) {
 	podInterface := &mockPodInterface{pods: make(map[string]*k8sV1.Pod)}
 	configMapInterface := &mockConfigMapInterface{configMaps: make(map[string]*k8sV1.ConfigMap)}
 
-	k8RequestQueue := newRequestQueue(podInterface, configMapInterface)
+	k8sRequestQueue := newRequestQueue(podInterface, configMapInterface)
 	requestQueueActor, _ := system.ActorOf(
 		actor.Addr("request-queue"),
-		k8RequestQueue,
+		k8sRequestQueue,
 	)
 
 	numPods := 15
@@ -111,7 +107,7 @@ func TestRequestQueueCreatingManyPod(t *testing.T) {
 	}
 	system.AskAll(mockPodActorPing{}, podActors...).GetAll()
 
-	waitForPendingRequestToFinish(k8RequestQueue)
+	waitForPendingRequestToFinish(k8sRequestQueue)
 	assert.Equal(t, getNumberOfActivePods(podInterface), numPods)
 }
 
@@ -121,10 +117,10 @@ func TestRequestQueueCreatingAndDeletingManyPod(t *testing.T) {
 	podInterface := &mockPodInterface{pods: make(map[string]*k8sV1.Pod)}
 	configMapInterface := &mockConfigMapInterface{configMaps: make(map[string]*k8sV1.ConfigMap)}
 
-	k8RequestQueue := newRequestQueue(podInterface, configMapInterface)
+	k8sRequestQueue := newRequestQueue(podInterface, configMapInterface)
 	requestQueueActor, _ := system.ActorOf(
 		actor.Addr("request-queue"),
-		k8RequestQueue,
+		k8sRequestQueue,
 	)
 
 	numPods := 15
@@ -140,7 +136,7 @@ func TestRequestQueueCreatingAndDeletingManyPod(t *testing.T) {
 	system.AskAll(deleteMockPod{}, podActors...)
 	system.AskAll(mockPodActorPing{}, podActors...).GetAll()
 
-	waitForPendingRequestToFinish(k8RequestQueue)
+	waitForPendingRequestToFinish(k8sRequestQueue)
 	assert.Equal(t, getNumberOfActivePods(podInterface), 0)
 }
 
@@ -150,10 +146,10 @@ func TestRequestQueueCreatingThenDeletingManyPods(t *testing.T) {
 	podInterface := &mockPodInterface{pods: make(map[string]*k8sV1.Pod)}
 	configMapInterface := &mockConfigMapInterface{configMaps: make(map[string]*k8sV1.ConfigMap)}
 
-	k8RequestQueue := newRequestQueue(podInterface, configMapInterface)
+	k8sRequestQueue := newRequestQueue(podInterface, configMapInterface)
 	requestQueueActor, _ := system.ActorOf(
 		actor.Addr("request-queue"),
-		k8RequestQueue,
+		k8sRequestQueue,
 	)
 
 	numPods := 15
@@ -168,13 +164,13 @@ func TestRequestQueueCreatingThenDeletingManyPods(t *testing.T) {
 	}
 	system.AskAll(mockPodActorPing{}, podActors...).GetAll()
 
-	waitForPendingRequestToFinish(k8RequestQueue)
+	waitForPendingRequestToFinish(k8sRequestQueue)
 	assert.Equal(t, getNumberOfActivePods(podInterface), numPods)
 
 	system.AskAll(deleteMockPod{}, podActors...)
 	system.AskAll(mockPodActorPing{}, podActors...).GetAll()
 
-	waitForPendingRequestToFinish(k8RequestQueue)
+	waitForPendingRequestToFinish(k8sRequestQueue)
 	assert.Equal(t, getNumberOfActivePods(podInterface), 0)
 }
 
@@ -187,10 +183,10 @@ func TestRequestQueueCreatingAndDeletingManyPodWithDelay(t *testing.T) {
 	}
 	configMapInterface := &mockConfigMapInterface{configMaps: make(map[string]*k8sV1.ConfigMap)}
 
-	k8RequestQueue := newRequestQueue(podInterface, configMapInterface)
+	k8sRequestQueue := newRequestQueue(podInterface, configMapInterface)
 	requestQueueActor, _ := system.ActorOf(
 		actor.Addr("request-queue"),
-		k8RequestQueue,
+		k8sRequestQueue,
 	)
 
 	numPods := 15
@@ -206,6 +202,6 @@ func TestRequestQueueCreatingAndDeletingManyPodWithDelay(t *testing.T) {
 	system.AskAll(deleteMockPod{}, podActors...)
 	system.AskAll(mockPodActorPing{}, podActors...).GetAll()
 
-	waitForPendingRequestToFinish(k8RequestQueue)
+	waitForPendingRequestToFinish(k8sRequestQueue)
 	assert.Equal(t, getNumberOfActivePods(podInterface), 0)
 }


### PR DESCRIPTION
## Description
Brings back the unit test from before (which were reverted out due to flakiness). The issue in the prior version was the fake k8 client library that was being used. Instead we are now using our own implementation of pod and configMap interfaces. 


## Test Plan
Ran locally a bunch of times.