### PR TITLE
fix: avoid d-train jobs from hanging [DET-3848]

### DIFF
--- a/docs/release-notes/1242-prevent-dtrain-hangs.txt
+++ b/docs/release-notes/1242-prevent-dtrain-hangs.txt
@@ -1,0 +1,5 @@
+:orphan:
+
+**Bug Fixes**
+
+- Handle rare corner cases where distributed training jobs would fail and hang indefinitely.

--- a/harness/determined/ipc.py
+++ b/harness/determined/ipc.py
@@ -32,9 +32,19 @@ class MetricsInfo:
 
 class ConnectedMessage:
     """
-    ConnectedMessage is sent by a ZMQBroadcastClient to a ZMQBroadcastServer as the very first
-    message. The ZMQBroadcastServer must gather one ConnectedMessage from each client before it is
-    safe to broadcast.
+    ConnectedMessage is sent by a SubprocessReceiver to the SubprocessLauncher when it is starts
+    and containers the SubprocessReceiver's process id so that the SubprocessLauncher can
+    perform health check on it.
+    """
+
+    def __init__(self, process_id: int) -> None:
+        self.process_id = process_id
+
+
+class ConnectedMessageAck:
+    """
+    ConnectedMessageAck is sent by the SubprocessLauncher to the SubprocessReceiver to acknowledge
+    receiving ConnectedMessage.
     """
 
     pass

--- a/harness/determined/ipc.py
+++ b/harness/determined/ipc.py
@@ -33,30 +33,12 @@ class MetricsInfo:
 class ConnectedMessage:
     """
     ConnectedMessage is sent by a SubprocessReceiver to the SubprocessLauncher when it is starts
-    and containers the SubprocessReceiver's process id so that the SubprocessLauncher can
+    and contains the SubprocessReceiver's process id so that the SubprocessLauncher can
     perform health check on it.
     """
 
     def __init__(self, process_id: int) -> None:
         self.process_id = process_id
-
-
-class ConnectedMessageAck:
-    """
-    ConnectedMessageAck is sent by the SubprocessLauncher to the SubprocessReceiver to acknowledge
-    receiving ConnectedMessage.
-    """
-
-    pass
-
-
-class ReadyMessage:
-    """
-    ReadyMessage is sent by a SubprocessReceiver to the SubprocessLauncher when it is ready to
-    start receiving workloads.
-    """
-
-    pass
 
 
 class _SerialMessage:

--- a/harness/determined/layers/_worker_process.py
+++ b/harness/determined/layers/_worker_process.py
@@ -6,6 +6,8 @@ import subprocess
 import time
 from typing import Any, Dict, List, Optional, Tuple, cast
 
+import psutil
+
 import determined as det
 from determined import constants, horovod, ipc, workload
 from determined_common import check
@@ -52,6 +54,14 @@ class SubprocessReceiver(workload.Source):
     def __init__(self, broadcast_client: ipc.ZMQBroadcastClient):
         self._broadcast_client = broadcast_client
 
+        self._broadcast_client.send(ipc.ConnectedMessage(process_id=os.getpid()))
+        response = self._broadcast_client.recv()
+        check.is_instance(
+            response,
+            ipc.ConnectedMessageAck,
+            f"Did not receive ConnectedMessageAck from worker. Got: {response}.",
+        )
+
     def __iter__(self) -> workload.Stream:
         # Signal to the CoordinatingTrialController that we are ready for workloads.
         self._broadcast_client.send(ipc.ReadyMessage())
@@ -83,6 +93,10 @@ class SubprocessLauncher:
         self.rendezvous_info = rendezvous_info
         self.hvd_config = hvd_config
         self._python_subprocess_entrypoint = python_subprocess_entrypoint
+
+        # The process ids for the workers that are launched by Horovod. These are different
+        # from the main horovod process and sshd processes.
+        self._worker_process_ids = []  # type: List[int]
 
         self.num_gpus = len(self.env.container_gpus)
         self.debug = self.env.experiment_config.debug_enabled()
@@ -231,13 +245,30 @@ class SubprocessLauncher:
         return subprocess.Popen(python_cmd)
 
     def _do_startup_message_sequence(self) -> None:
-        # Wait for a ReadyMessage from every worker.
+        # Wait for a ConnectedMessage from every worker.
         responses, exception_received = self.broadcast_server.gather_with_polling(
             self._health_check
         )
 
         if exception_received:
             raise det.errors.WorkerError("Training process died.")
+
+        for response in responses:
+            check.is_instance(
+                response,
+                ipc.ConnectedMessage,
+                f"Did not receive ConnectedMessage from worker. Got: {response}",
+            )
+            response = cast(ipc.ConnectedMessage, response)
+            self._worker_process_ids.append(response.process_id)
+
+        # Send an Ack so that worker process is able to send ReadyMessage once it is ready.
+        self.broadcast_server.broadcast(ipc.ConnectedMessageAck())
+
+        # Wait for a ReadyMessage from every worker.
+        responses, exception_received = self.broadcast_server.gather_with_polling(
+            self._health_check
+        )
 
         for response in responses:
             check.is_instance(
@@ -273,6 +304,10 @@ class SubprocessLauncher:
 
         if self._subproc.poll() is not None:
             raise det.errors.WorkerError("Training process died.")
+
+        for subprocess_id in self._worker_process_ids:
+            if not psutil.pid_exists(subprocess_id):
+                raise det.errors.WorkerError("Training process died.")
 
     def _send_recv_workload(self, wkld: workload.Workload, args: List[Any]) -> workload.Response:
         # Broadcast every workload to every worker on this machine.

--- a/harness/tests/test_ipc.py
+++ b/harness/tests/test_ipc.py
@@ -84,7 +84,7 @@ class BroadcastClientSubproc(Subproc):
     def main(self) -> None:
         with ipc.ZMQBroadcastClient(self._pub_url, self._pull_url) as broadcast_client:
             # Start the server-client communication test.
-            broadcast_client.send(ipc.ReadyMessage())
+            broadcast_client.send(ipc.ConnectedMessage(process_id=0))
             for exp in self._exp_msgs:
                 msg = broadcast_client.recv()
                 assert msg == exp
@@ -111,7 +111,7 @@ def test_broadcast_server_client() -> None:
                     assert subproc.is_alive()
 
             gathered, _ = broadcast_server.gather_with_polling(health_check)
-            assert all(isinstance(g, ipc.ReadyMessage) for g in gathered)
+            assert all(isinstance(g, ipc.ConnectedMessage) for g in gathered)
 
             for msg in msgs:
                 broadcast_server.broadcast(msg)


### PR DESCRIPTION
## Description
Previously in rare corner we would fail to detect that a worker subprocess
had died leading to indefinite hangs. We now perform health checks for
all worker processes.



## Test Plan
The only way I know how to reproduce this hang reliable in our system is by adding these lines into
`_init_session_config()` of `_estimator_trial`:

```
from tensorflow.python.keras.backend import _get_available_gpus, get_session
print(f"session {get_session}")
print(f"GPUS: {_get_available_gpus()}")
```
