### PR TITLE
fix: gaea_nas const.yaml config for testing

### DIFF
--- a/examples/experimental/trial/gaea_nas/eval/const.yaml
+++ b/examples/experimental/trial/gaea_nas/eval/const.yaml
@@ -71,7 +71,7 @@ hyperparameters:
 resources:
   # We recommend 8 slots with V100
   # and at least 16 slots with K80 GPUs.
-  slots_per_trial: 2
+  slots_per_trial: 1
   shm_size: 30000000000
 
 searcher:


### PR DESCRIPTION
## Description
Change slots_per_trial in the const.yaml config to 1 so that CI tests do not fail.  
