### PR TITLE
feat: add connection checks into provisioner [DET-4081]

### DIFF
--- a/docs/release-notes/1264-connection-checks-for-dynamic-agents.txt
+++ b/docs/release-notes/1264-connection-checks-for-dynamic-agents.txt
@@ -3,4 +3,4 @@
 **Improvements**
 
 - Add connection checks for dynamic agents. If a dynamically provisioned agent is not
-  actively connected to the master, it is terminated.
+  actively connected for a periods of 5 minutes to the master, it is terminated.

--- a/docs/release-notes/1264-connection-checks-for-dynamic-agents.txt
+++ b/docs/release-notes/1264-connection-checks-for-dynamic-agents.txt
@@ -1,0 +1,6 @@
+:orphan:
+
+**Improvements**
+
+- Add connection checks for dynamic agents. If a dynamically provisioned agent is not
+  actively connected to the master, it is terminated.

--- a/docs/release-notes/1264-connection-checks-for-dynamic-agents.txt
+++ b/docs/release-notes/1264-connection-checks-for-dynamic-agents.txt
@@ -3,4 +3,4 @@
 **Improvements**
 
 - Add connection checks for dynamic agents. If a dynamically provisioned agent is not
-  actively connected for a periods of 5 minutes to the master, it is terminated.
+  actively connected for a period of 5 minutes to the master, it is terminated.

--- a/master/internal/provisioner/provisioner.go
+++ b/master/internal/provisioner/provisioner.go
@@ -109,7 +109,7 @@ func (p *Provisioner) provision(ctx *actor.Context) {
 
 	ctx.Log().Debug("scale happening")
 	toTerminate := p.scaleDecider.findInstancesToTerminate(
-		p.provider.maxInstanceNum(),
+		ctx, p.provider.maxInstanceNum(),
 	)
 	if len(toTerminate) > 0 {
 		p.provider.terminate(ctx, toTerminate)

--- a/master/internal/provisioner/provisioner_test.go
+++ b/master/internal/provisioner/provisioner_test.go
@@ -42,7 +42,6 @@ func newInstanceIDSet(instanceIDs []string) map[string]bool {
 }
 
 type mockConfig struct {
-	initTime               time.Time
 	maxAgentStartingPeriod time.Duration
 	maxIdleAgentPeriod     time.Duration
 	maxDisconnectPeriod    time.Duration
@@ -155,7 +154,6 @@ func (c *mockProvider) terminate(ctx *actor.Context, instanceIDs []string) {
 
 func TestProvisionerScaleUp(t *testing.T) {
 	setup := &mockConfig{
-		initTime:            time.Now(),
 		maxDisconnectPeriod: 5 * time.Minute,
 		instanceType: TestInstanceType{
 			Name:  "test.instanceType",
@@ -181,7 +179,6 @@ func TestProvisionerScaleUp(t *testing.T) {
 
 func TestProvisionerScaleUpNotPastMax(t *testing.T) {
 	setup := &mockConfig{
-		initTime:            time.Now(),
 		maxDisconnectPeriod: 5 * time.Minute,
 		instanceType: TestInstanceType{
 			Name:  "test.instanceType",
@@ -207,7 +204,6 @@ func TestProvisionerScaleUpNotPastMax(t *testing.T) {
 
 func TestProvisionerScaleDown(t *testing.T) {
 	setup := &mockConfig{
-		initTime:            time.Now(),
 		maxIdleAgentPeriod:  50 * time.Millisecond,
 		maxDisconnectPeriod: 5 * time.Minute,
 		instanceType: TestInstanceType{
@@ -267,7 +263,6 @@ func TestProvisionerScaleDown(t *testing.T) {
 
 func TestProvisionerNotProvisionExtraInstances(t *testing.T) {
 	setup := &mockConfig{
-		initTime:               time.Now(),
 		maxAgentStartingPeriod: 100 * time.Millisecond,
 		maxIdleAgentPeriod:     100 * time.Millisecond,
 		maxDisconnectPeriod:    5 * time.Minute,
@@ -323,7 +318,6 @@ func TestProvisionerNotProvisionExtraInstances(t *testing.T) {
 
 func TestProvisionerTerminateUnconnectedInstances(t *testing.T) {
 	setup := &mockConfig{
-		initTime:               time.Now().Add(-time.Hour),
 		maxAgentStartingPeriod: 3 * time.Minute,
 		maxIdleAgentPeriod:     50 * time.Millisecond,
 		maxDisconnectPeriod:    50 * time.Millisecond,

--- a/master/internal/provisioner/scale_decider.go
+++ b/master/internal/provisioner/scale_decider.go
@@ -134,8 +134,6 @@ func (s *scaleDecider) findInstancesToTerminate(
 			if _, connected := s.connectedAgentSnapshot[inst.AgentName]; connected {
 				continue
 			}
-			// If instance instance is still in the start-up period, do not terminate it for
-			// being disconnected.
 			if inst.LaunchTime.Add(s.maxStartingPeriod).After(now) {
 				continue
 			}

--- a/master/internal/provisioner/scale_decider.go
+++ b/master/internal/provisioner/scale_decider.go
@@ -119,7 +119,7 @@ func (s *scaleDecider) findInstancesToTerminate(
 	idleInstances := make(map[string]bool)
 	disconnectedInstances := make(map[string]bool)
 
-	// Terminate stopped instances and find idle and stopping instances.
+	// Terminate stopped instances and find idle and disconnected instances.
 	now := time.Now()
 	for _, inst := range s.instanceSnapshot {
 		switch inst.State {
@@ -131,17 +131,14 @@ func (s *scaleDecider) findInstancesToTerminate(
 				idleInstances[inst.ID] = true
 			}
 
-			// If instance is connected no need to do anything here.
 			if _, connected := s.connectedAgentSnapshot[inst.AgentName]; connected {
 				continue
 			}
-
 			// If instance instance is still in the start-up period, do not terminate it for
 			// being disconnected.
 			if inst.LaunchTime.Add(s.maxStartingPeriod).After(now) {
 				continue
 			}
-
 			disconnectedInstances[inst.ID] = true
 		}
 	}

--- a/master/internal/provisioner/scale_decider.go
+++ b/master/internal/provisioner/scale_decider.go
@@ -82,7 +82,7 @@ func (s *scaleDecider) updateSchedulerSnapshot(snapshot *scheduler.ViewSnapshot)
 		s.idleAgentSnapshot[agent.Name] = agent
 	}
 
-	s.connectedAgentSnapshot =  make(map[string]*scheduler.AgentSummary)
+	s.connectedAgentSnapshot = make(map[string]*scheduler.AgentSummary)
 	for _, agent := range snapshot.ConnectedAgents {
 		s.connectedAgentSnapshot[agent.Name] = agent
 	}
@@ -148,9 +148,14 @@ func (s *scaleDecider) findInstancesToTerminate(
 			continue
 		}
 
-		ctx.Log().Infof(
-			"terminating instance %s because it is not connected to the master", inst.AgentName)
-		toTerminate[inst.AgentName] = true
+		if ctx != nil {
+			// nil during testing.
+			ctx.Log().Infof(
+				"terminating instance %s because it is not connected to the master",
+				inst.AgentName,
+			)
+		}
+		toTerminate[inst.ID] = true
 	}
 
 	// Terminate instances that are idle for a long time.

--- a/master/internal/provisioner/scale_decider_test.go
+++ b/master/internal/provisioner/scale_decider_test.go
@@ -110,7 +110,6 @@ func TestFindInstancesToTerminate(t *testing.T) {
 						Name: "agent2",
 					},
 				},
-				launchTime: time.Now(),
 			},
 			maxInstanceNum:        10,
 			pastIdleInstanceAfter: map[string]time.Time{},
@@ -177,7 +176,6 @@ func TestFindInstancesToTerminate(t *testing.T) {
 					"instance1": time.Now().Add(-time.Hour),
 					"instance2": time.Now().Add(-time.Minute),
 				},
-				launchTime: time.Now(),
 			},
 			maxInstanceNum: 10,
 			pastIdleInstanceAfter: map[string]time.Time{
@@ -229,7 +227,6 @@ func TestFindInstancesToTerminate(t *testing.T) {
 					},
 				},
 				pastIdleInstances: map[string]time.Time{},
-				launchTime:        time.Now(),
 			},
 			maxInstanceNum: 1,
 			toTerminate: []string{
@@ -309,7 +306,6 @@ func TestFindInstancesToTerminate(t *testing.T) {
 					"instance2": time.Now().Add(-time.Hour),
 					"instance3": time.Now().Add(-time.Minute),
 				},
-				launchTime: time.Now(),
 			},
 			maxInstanceNum: 10,
 			pastIdleInstanceAfter: map[string]time.Time{
@@ -343,7 +339,9 @@ func TestFindInstancesToTerminate(t *testing.T) {
 						Name: "agent2",
 					},
 				},
-				launchTime: time.Now().Add(-time.Hour),
+				pastDisconnectedInstances: map[string]time.Time{
+					"instance1": time.Now().Add(-time.Hour),
+				},
 			},
 			maxInstanceNum:        10,
 			pastIdleInstanceAfter: map[string]time.Time{},

--- a/master/internal/scheduler/filterable_view.go
+++ b/master/internal/scheduler/filterable_view.go
@@ -133,9 +133,9 @@ func (v *FilterableView) newSnapshot() ViewSnapshot {
 	for _, agent := range v.connectedAgents {
 		connectedAgents = append(connectedAgents, agent)
 	}
-	idleAgents := make([]*AgentSummary, 0, len(v.filteredAgents))
+	filteredAgents := make([]*AgentSummary, 0, len(v.filteredAgents))
 	for _, agent := range v.filteredAgents {
-		idleAgents = append(idleAgents, agent)
+		filteredAgents = append(filteredAgents, agent)
 	}
-	return ViewSnapshot{Tasks: tasks, ConnectedAgents: connectedAgents, IdleAgents: idleAgents}
+	return ViewSnapshot{Tasks: tasks, ConnectedAgents: connectedAgents, IdleAgents: filteredAgents}
 }

--- a/master/internal/scheduler/filterable_view.go
+++ b/master/internal/scheduler/filterable_view.go
@@ -6,20 +6,22 @@ import "github.com/determined-ai/determined/master/pkg/actor"
 // The `TaskSummary`s and `AgentSummary` should not be modified because a reference to
 // this struct is contained in another goroutine.
 type FilterableView struct {
-	tasks       map[TaskID]*TaskSummary
-	agents      map[*actor.Ref]*AgentSummary
-	taskFilter  func(*Task) bool
-	agentFilter func(*agentState) bool
+	tasks           map[TaskID]*TaskSummary
+	filteredAgents  map[*actor.Ref]*AgentSummary
+	connectedAgents map[*actor.Ref]*AgentSummary
+	taskFilter      func(*Task) bool
+	agentFilter     func(*agentState) bool
 }
 
 // Return a view of the scheduler state that is relevant to the provisioner. Specifically, the
 // provisioner cares about (1) idle agents (2) pending tasks.
 func newProvisionerView(provisionerSlotsPerInstance int) *FilterableView {
 	return &FilterableView{
-		tasks:       make(map[TaskID]*TaskSummary),
-		agents:      make(map[*actor.Ref]*AgentSummary),
-		taskFilter:  schedulableTaskFilter(provisionerSlotsPerInstance),
-		agentFilter: idleAgentFilter,
+		tasks:           make(map[TaskID]*TaskSummary),
+		filteredAgents:  make(map[*actor.Ref]*AgentSummary),
+		connectedAgents: make(map[*actor.Ref]*AgentSummary),
+		taskFilter:      schedulableTaskFilter(provisionerSlotsPerInstance),
+		agentFilter:     idleAgentFilter,
 	}
 }
 
@@ -88,29 +90,38 @@ func (v *FilterableView) updateTasks(rp *DefaultRP) bool {
 }
 
 func (v *FilterableView) updateAgents(rp *DefaultRP) bool {
-	newAgents := make(map[*actor.Ref]*AgentSummary)
+	newFilteredAgents := make(map[*actor.Ref]*AgentSummary)
+	newConnectedAgents := make(map[*actor.Ref]*AgentSummary)
 
 	for actorRef, state := range rp.agents {
+		agentSummary := newAgentSummary(state)
 		if v.agentFilter(state) {
-			agentSummary := newAgentSummary(state)
-			newAgents[actorRef] = &agentSummary
+			newFilteredAgents[actorRef] = &agentSummary
 		}
+		newConnectedAgents[actorRef] = &agentSummary
 	}
 
-	updateMade := false
-	if len(newAgents) != len(v.agents) {
-		updateMade = true
-	} else {
-		for agentRef, newAgent := range newAgents {
-			oldAgent, ok := v.agents[agentRef]
-			if !ok || !oldAgent.equals(newAgent) {
-				updateMade = true
+	haveAgentsUpdated := func(updatedAgents, previousAgents map[*actor.Ref]*AgentSummary) bool {
+		updateMade := false
+		if len(updatedAgents) != len(previousAgents) {
+			updateMade = true
+		} else {
+			for agentRef, newAgent := range updatedAgents {
+				oldAgent, ok := previousAgents[agentRef]
+				if !ok || !oldAgent.equals(newAgent) {
+					updateMade = true
+				}
 			}
 		}
+		return updateMade
 	}
 
-	v.agents = newAgents
-	return updateMade
+	agentsUpdated := haveAgentsUpdated(newFilteredAgents, v.filteredAgents) || haveAgentsUpdated(
+		newConnectedAgents, v.connectedAgents)
+
+	v.filteredAgents = newFilteredAgents
+	v.connectedAgents = newConnectedAgents
+	return agentsUpdated
 }
 
 func (v *FilterableView) newSnapshot() ViewSnapshot {
@@ -118,9 +129,13 @@ func (v *FilterableView) newSnapshot() ViewSnapshot {
 	for _, taskSummary := range v.tasks {
 		tasks = append(tasks, taskSummary)
 	}
-	agents := make([]*AgentSummary, 0, len(v.agents))
-	for _, agent := range v.agents {
-		agents = append(agents, agent)
+	connectedAgents := make([]*AgentSummary, 0, len(v.connectedAgents))
+	for _, agent := range v.connectedAgents {
+		connectedAgents = append(connectedAgents, agent)
 	}
-	return ViewSnapshot{Tasks: tasks, Agents: agents}
+	idleAgents := make([]*AgentSummary, 0, len(v.filteredAgents))
+	for _, agent := range v.filteredAgents {
+		idleAgents = append(idleAgents, agent)
+	}
+	return ViewSnapshot{Tasks: tasks, ConnectedAgents: connectedAgents, IdleAgents: idleAgents}
 }

--- a/master/internal/scheduler/view.go
+++ b/master/internal/scheduler/view.go
@@ -7,6 +7,7 @@ type View interface {
 
 // ViewSnapshot is an immutable snapshot of a View.
 type ViewSnapshot struct {
-	Tasks  []*TaskSummary
-	Agents []*AgentSummary
+	Tasks           []*TaskSummary
+	ConnectedAgents []*AgentSummary
+	IdleAgents      []*AgentSummary
 }


### PR DESCRIPTION
## Description
We now compare the list of actively connected instances to the list of provisioned
instances, and remove instances that are failing to connect.


## Test Plan
- [x]  Add unit tests.
- [x] Test manually on AWS.
- [x]  Test manually on GCP.

