### PR TITLE
feat: allow tensorboard to accept arbitrary arguments

### DIFF
--- a/docs/reference/command-notebook-config.txt
+++ b/docs/reference/command-notebook-config.txt
@@ -124,3 +124,6 @@ The following configuration settings are supported:
       behavior
       <https://docs.docker.com/storage/bind-mounts/#configure-bind-propagation>`__
       for replicas of the bind-mount. Defaults to ``rprivate``.
+
+- ``tensorboard_args``: Lists optional arguments for launching Tensorboard.
+  Each element of the list should be a string of the form ``NAME=VALUE``.

--- a/harness/determined/exec/tensorboard.py
+++ b/harness/determined/exec/tensorboard.py
@@ -74,6 +74,7 @@ def main(args: List[str]) -> int:
     tensorboard_addr = f"http://localhost:{port}/proxy/{task_id}"
     url = f"{tensorboard_addr}/data/plugin/scalars/tags"
 
+    print(f"Running: tensorboard --port{port} --path_prefix=/proxy/{task_id}", *args)
     p = subprocess.Popen(
         ["tensorboard", f"--port={port}", f"--path_prefix=/proxy/{task_id}", *args]
     )

--- a/master/internal/command/tensorboard_manager.go
+++ b/master/internal/command/tensorboard_manager.go
@@ -303,7 +303,12 @@ func (t *tensorboardManager) newTensorBoard(
 		"TensorBoard (%s)",
 		petname.Generate(model.TaskNameGeneratorWords, model.TaskNameGeneratorSep),
 	)
-	config.Entrypoint = append(entrypoint, config.Entrypoint...)
+
+	refineArgs(config.TensorBoardArgs)
+	config.Entrypoint = append(
+		[]string{tensorboardEntrypointFile, "--logdir", strings.Join(logDirs, ",")},
+		config.TensorBoardArgs...)
+
 	config.Resources.Slots = tensorboardResourcesSlots
 
 	cpuEnvVars := append(config.Environment.EnvironmentVariables.CPU, envVars...)
@@ -399,4 +404,16 @@ func getEnvVars(m map[string]string) []string {
 	}
 
 	return envVars
+}
+
+func refineArgs(s []string) {
+	trimmed := ""
+	for x := range s {
+		trimmed = strings.TrimLeft(s[x], "-")
+		if trimmed == "h" {
+			s[x] = "-h"
+		} else {
+			s[x] = "--" + trimmed
+		}
+	}
 }

--- a/master/internal/command/tensorboard_manager.go
+++ b/master/internal/command/tensorboard_manager.go
@@ -303,7 +303,7 @@ func (t *tensorboardManager) newTensorBoard(
 		"TensorBoard (%s)",
 		petname.Generate(model.TaskNameGeneratorWords, model.TaskNameGeneratorSep),
 	)
-	config.Entrypoint = []string{tensorboardEntrypointFile, "--logdir", strings.Join(logDirs, ",")}
+	config.Entrypoint = append(entrypoint, config.Entrypoint...)
 	config.Resources.Slots = tensorboardResourcesSlots
 
 	cpuEnvVars := append(config.Environment.EnvironmentVariables.CPU, envVars...)

--- a/master/internal/command/tensorboard_manager_test.go
+++ b/master/internal/command/tensorboard_manager_test.go
@@ -1,0 +1,36 @@
+package command
+
+import (
+	"testing"
+
+	"gotest.tools/assert"
+)
+
+func TestRefineArgs(t *testing.T) {
+	args := []string{
+		"first",
+		"-second",
+		"--third",
+		"-fourth-one",
+		"-----fifth",
+		"h",
+		"-h",
+		"--h",
+		"------h",
+	}
+
+	expected := []string{
+		"--first",
+		"--second",
+		"--third",
+		"--fourth-one",
+		"--fifth",
+		"-h",
+		"-h",
+		"-h",
+		"-h",
+	}
+	refineArgs(args)
+
+	assert.DeepEqual(t, args, expected)
+}

--- a/master/pkg/model/command_config.go
+++ b/master/pkg/model/command_config.go
@@ -7,11 +7,12 @@ import (
 // CommandConfig holds the necessary configurations to launch a command task in
 // the cluster.
 type CommandConfig struct {
-	Description string          `json:"description"`
-	BindMounts  []BindMount     `json:"bind_mounts"`
-	Environment Environment     `json:"environment"`
-	Resources   ResourcesConfig `json:"resources"`
-	Entrypoint  []string        `json:"entrypoint"`
+	Description     string          `json:"description"`
+	BindMounts      []BindMount     `json:"bind_mounts"`
+	Environment     Environment     `json:"environment"`
+	Resources       ResourcesConfig `json:"resources"`
+	Entrypoint      []string        `json:"entrypoint"`
+	TensorBoardArgs []string        `json:"tensorboard_args"`
 }
 
 // Validate implements the check.Validatable interface.


### PR DESCRIPTION
## Description
To address requests from the community, this change allows arbitrary arguments to be passed into tensorboard. It also provides the option of setting the `--purge_orphaned_data` flag, giving us more time to debug some tensorboard issues.

To set tensorboard arguments, users should use a tensorboard configuration file with arguments listed under the `entrypoint` field. For instance:
```
entrypoint: 
  - "purge_orphaned_data=False"
  - "window_title=Experiment 1"
```

Note: not all arguments are supported in determined tensorboard, such as `host`, `port`, and `path_prefix`. 
<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan
Added a unit tests for formatting arguments and manually tested tensorboard with optional arguments. `det tensorboard config` can be used to verify that settings have made it to the entrypoint.

<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234