### PR TITLE
feat: support configuring default task images [DET-4079]

### DIFF
--- a/docs/how-to/custom-env.txt
+++ b/docs/how-to/custom-env.txt
@@ -208,6 +208,11 @@ Images will be fetched via HTTPS by default. An HTTPS proxy can be
 configured using the ``https_proxy`` field as part of the :ref:`agent
 configuration <agent-configuration>`.
 
+Your custom image and credentials can also be set as the defaults for all tasks launched
+in Determined. This can be done under ``image`` and ``registry_auth`` in the
+:ref:`master-configuration`. Please note that for this to take effect you
+will have to restart the master.
+
 Next Steps
 ==========
 

--- a/docs/reference/cluster-config.txt
+++ b/docs/reference/cluster-config.txt
@@ -322,7 +322,10 @@ The master supports the following configuration settings:
    -  ``force_pull_image``: Defines the default policy for forcibly pulling images from
       the docker registry and bypassing the docker cache. If a pull policy is specified
       in the :ref:`experiment config <exp-environment-image>` this default value is
-      overriden. Defaults to ``false``.
+      overriden. Please note that as of November 1st, 2020 unauthenticated users will be
+      `capped at 100 pulls from Docker per 6 hours
+      <https://www.docker.com/blog/scaling-docker-to-serve-millions-more-developers-network-egress/>`__.
+      Defaults to ``false``.
 
    -  ``registry_auth``: Defines the default `docker registry credentials
       <https://docs.docker.com/engine/api/v1.30/#operation/SystemAuth>`__ to use

--- a/docs/reference/cluster-config.txt
+++ b/docs/reference/cluster-config.txt
@@ -309,6 +309,32 @@ The master supports the following configuration settings:
       applied to all GPU tasks when running on Kubernetes. See
       :ref:`custom-pod-specs` for details.
 
+   -  ``image``: Defines the default docker image to use when executing the workload.
+      If a docker image is specified in the :ref:`experiment config <exp-environment-image>`
+      this default is overriden. This image must be accessible via ``docker pull`` to every
+      Determined agent machine in the cluster. Users can use different container images for GPU
+      vs. CPU agents differently by specifying a dict with two keys, ``cpu`` and ``gpu``.
+      Default values:
+
+      - ``determinedai/environments:py-3.6.9-pytorch-1.4-tf-1.15-cpu-0.5.0`` for CPU agents
+      - ``determinedai/environments:cuda-10.0-pytorch-1.4-tf-1.15-gpu-0.5.0`` for GPU agents.
+
+   -  ``force_pull_image``: Defines the default policy for forcibly pulling images from
+      the docker registry and bypassing the docker cache. If a pull policy is specified
+      in the :ref:`experiment config <exp-environment-image>` this default value is
+      overriden. Defaults to ``false``.
+
+   -  ``registry_auth``: Defines the default `docker registry credentials
+      <https://docs.docker.com/engine/api/v1.30/#operation/SystemAuth>`__ to use
+      when pulling a custom base docker image, if needed. If credentials are specified is
+      in the :ref:`experiment config <exp-environment-image>` this default value is
+      overriden. Credentials are specified as the following nested fields:
+
+      - ``username`` (required)
+      - ``password`` (required)
+      - ``server`` (optional)
+      - ``email`` (optional)
+
 -  ``root``: Specifies the root directory of the state files. Defaults
    to ``/usr/share/determined/master``.
 

--- a/docs/reference/helm-config.txt
+++ b/docs/reference/helm-config.txt
@@ -165,12 +165,12 @@ Helm Chart </helm/determined-helm-chart.tgz>`.
 
    -  ``cpuImage``: Sets the default docker image for all non-gpu tasks. If a docker image
       is specified in the :ref:`experiment config <exp-environment-image>`
-      this default is overriden. Default to:
+      this default is overriden. Defaults to:
       ``determinedai/environments:py-3.6.9-pytorch-1.4-tf-1.15-cpu-0.5.0``.
 
-  -   ``gpuImage``: Sets the default docker image for all gpu tasks. If a docker image
+   -  ``gpuImage``: Sets the default docker image for all gpu tasks. If a docker image
       is specified in the :ref:`experiment config <exp-environment-image>`
-      this default is overriden. Default to:
+      this default is overriden. Defaults to:
       ``determinedai/environments:cuda-10.0-pytorch-1.4-tf-1.15-gpu-0.5.0``.
 
 -  ``enterpriseEdition``: Specifies whether to use Determined enterprise

--- a/docs/reference/helm-config.txt
+++ b/docs/reference/helm-config.txt
@@ -155,6 +155,9 @@ Helm Chart </helm/determined-helm-chart.tgz>`.
    -  ``forcePullImage``: Defines the default policy for forcibly pulling images from
       the docker registry and bypassing the docker cache. If a pull policy is specified
       in the :ref:`experiment config <exp-environment-image>` this default  is overriden.
+      Please note that as of November 1st, 2020 unauthenticated users will be
+      `capped at 100 pulls from Docker per 6 hours
+      <https://www.docker.com/blog/scaling-docker-to-serve-millions-more-developers-network-egress/>`__.
       Defaults to ``false``.
 
    -  ``cpuPodSpec``: Sets the default pod spec for all non-gpu tasks.

--- a/docs/reference/helm-config.txt
+++ b/docs/reference/helm-config.txt
@@ -152,11 +152,26 @@ Helm Chart </helm/determined-helm-chart.tgz>`.
       use during distributed training. A valid port range is in the
       format of ``MIN:MAX``.
 
+   -  ``forcePullImage``: Defines the default policy for forcibly pulling images from
+      the docker registry and bypassing the docker cache. If a pull policy is specified
+      in the :ref:`experiment config <exp-environment-image>` this default  is overriden.
+      Defaults to ``false``.
+
    -  ``cpuPodSpec``: Sets the default pod spec for all non-gpu tasks.
       See :ref:`custom-pod-specs` for details.
 
    -  ``gpuPodSpec``: Sets the default pod spec for all ngpu tasks. See
       :ref:`custom-pod-specs` for details.
+
+   -  ``cpuImage``: Sets the default docker image for all non-gpu tasks. If a docker image
+      is specified in the :ref:`experiment config <exp-environment-image>`
+      this default is overriden. Default to:
+      ``determinedai/environments:py-3.6.9-pytorch-1.4-tf-1.15-cpu-0.5.0``.
+
+  -   ``gpuImage``: Sets the default docker image for all gpu tasks. If a docker image
+      is specified in the :ref:`experiment config <exp-environment-image>`
+      this default is overriden. Default to:
+      ``determinedai/environments:cuda-10.0-pytorch-1.4-tf-1.15-gpu-0.5.0``.
 
 -  ``enterpriseEdition``: Specifies whether to use Determined enterprise
    edition.

--- a/docs/release-notes/1274-configurable-default-task-images.txt
+++ b/docs/release-notes/1274-configurable-default-task-images.txt
@@ -1,0 +1,7 @@
+:orphan:
+
+**Improvements**
+
+- Added support for configuring the default task images, docker pull policy and docker registry
+  credentials via the :ref:`master-configuration` and :ref:`helm-config`. Please note that
+  individual task configurations will continue to overwrite these defaults.

--- a/helm/charts/determined/templates/master-config.yaml
+++ b/helm/charts/determined/templates/master-config.yaml
@@ -64,6 +64,19 @@ data:
       {{- if .Values.taskContainerDefaults.gpuPodSpec }}
       gpu_pod_spec: {{ .Values.taskContainerDefaults.gpuPodSpec | toJson }}
       {{- end }}
+      {{- if and .Values.taskContainerDefaults.cpuImage .Values.taskContainerDefaults.gpuImage }}
+      image:
+         cpu_image: {{ .Values.taskContainerDefaults.cpuImage | quote }}
+         gpu_iamge: {{ .Values.taskContainerDefaults.gpuImage | quote }}
+      {{- else }}
+      {{- if or .Values.taskContainerDefaults.cpuImage .Values.taskContainerDefaults.gpuImage }}
+        {{ required "A valid .Values.taskContainerDefaults.cpuImage entry is required if setting .Values.taskContainerDefaults.gpuImage!" .Values.taskContainerDefaults.cpuImage }}
+        {{ required "A valid .Values.taskContainerDefaults.gpuImage entry is required if setting .Values.taskContainerDefaults.cpuImage!" .Values.taskContainerDefaults.gpuImage }}
+      {{- end }}
+      {{- end }}
+      {{- if .Values.taskContainerDefaults.forcePullImage }}
+      force_pull_image: {{ .Values.taskContainerDefaults.forcePullImage }}
+      {{- end }}
     {{ end }}
 
     {{- if .Values.telemetry }}

--- a/helm/charts/determined/templates/master-config.yaml
+++ b/helm/charts/determined/templates/master-config.yaml
@@ -66,8 +66,8 @@ data:
       {{- end }}
       {{- if and .Values.taskContainerDefaults.cpuImage .Values.taskContainerDefaults.gpuImage }}
       image:
-         cpu_image: {{ .Values.taskContainerDefaults.cpuImage | quote }}
-         gpu_iamge: {{ .Values.taskContainerDefaults.gpuImage | quote }}
+         cpu: {{ .Values.taskContainerDefaults.cpuImage | quote }}
+         gpu: {{ .Values.taskContainerDefaults.gpuImage | quote }}
       {{- else }}
       {{- if or .Values.taskContainerDefaults.cpuImage .Values.taskContainerDefaults.gpuImage }}
         {{ required "A valid .Values.taskContainerDefaults.cpuImage entry is required if setting .Values.taskContainerDefaults.gpuImage!" .Values.taskContainerDefaults.cpuImage }}

--- a/helm/charts/determined/values.yaml
+++ b/helm/charts/determined/values.yaml
@@ -67,6 +67,7 @@ taskContainerDefaults:
   # dtrainNetworkInterface: <network interface name>
   # ncclPortRange: <MIN:MAX>
   # glooPortRange: <MIN:MAX>
+  # forcePullImage: <true or false>
 
   # Configure a default pod spec for all GPU tasks (experiments, notebooks, commands) and
   # CPU tasks (cpu notebooks, tensorboards, zero slot commands). If a pod spec is defined
@@ -75,10 +76,19 @@ taskContainerDefaults:
   # cpuPodSpec:
   # gpuPodSpec:
 
+
+  # Configure default docker images for all GPU tasks (experiments, notebooks, commands) and
+  # CPU tasks (cpu notebooks, tensorboards, zero slot commands). If a docker image is defined
+  # for an individual task, that image will replace the default one that is defined here.
+  # If specifying a default image, both GPU and CPU default images must be defined.
+  # cpuImage:
+  # gpuImage:
+
 # Configure Determined enterprise edition.
 enterpriseEdition: false
 
-# Should be configured if using the Determined enterprise edition master.
+# Should be configured if using the Determined enterprise edition master. Used to access
+# the master image.
 # imagePullSecretName: regcred
 
 ## Configure whether we collect anonymous information about the usage of Determined.

--- a/master/internal/api_experiment.go
+++ b/master/internal/api_experiment.go
@@ -118,7 +118,7 @@ func (a *apiServer) PreviewHPSearch(
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "error parsing experiment config: %s", err)
 	}
-	config := model.DefaultExperimentConfig()
+	config := model.DefaultExperimentConfig(&a.m.config.TaskContainerDefaults)
 	if err = json.Unmarshal(bytes, &config); err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "error parsing experiment config: %s", err)
 	}

--- a/master/internal/command/command.go
+++ b/master/internal/command/command.go
@@ -49,8 +49,8 @@ type commandOwner struct {
 // DefaultConfig is the default configuration used by all
 // commands (e.g., commands, notebooks, shells) if a request
 // does not specify any configuration options.
-func DefaultConfig() model.CommandConfig {
-	environment := model.DefaultExperimentConfig().Environment
+func DefaultConfig(taskContainerDefaults *model.TaskContainerDefaultsConfig) model.CommandConfig {
+	environment := model.DefaultExperimentConfig(taskContainerDefaults).Environment
 	return model.CommandConfig{
 		Resources: model.ResourcesConfig{
 			Slots:  1,

--- a/master/internal/command/command_manager.go
+++ b/master/internal/command/command_manager.go
@@ -60,7 +60,7 @@ func (c *commandManager) handleAPIRequest(ctx *actor.Context, apiCtx echo.Contex
 			return
 		}
 
-		req, err := parseCommandRequest(apiCtx, c.db, &params)
+		req, err := parseCommandRequest(apiCtx, c.db, &params, &c.taskContainerDefaults)
 		if err != nil {
 			respondBadRequest(ctx, err)
 			return

--- a/master/internal/command/manager.go
+++ b/master/internal/command/manager.go
@@ -46,8 +46,9 @@ func parseCommandRequest(
 	c echo.Context,
 	db *db.PgDB,
 	params *commandParams,
+	taskContainerDefaults *model.TaskContainerDefaultsConfig,
 ) (*commandRequest, error) {
-	config := DefaultConfig()
+	config := DefaultConfig(taskContainerDefaults)
 	if params.Template != nil {
 		template, err := db.TemplateByName(*params.Template)
 		if err != nil {

--- a/master/internal/command/notebook_manager.go
+++ b/master/internal/command/notebook_manager.go
@@ -139,7 +139,7 @@ func (n *notebookManager) handleAPIRequest(ctx *actor.Context, apiCtx echo.Conte
 			return
 		}
 
-		req, err := parseCommandRequest(apiCtx, n.db, &params)
+		req, err := parseCommandRequest(apiCtx, n.db, &params, &n.taskContainerDefaults)
 		if err != nil {
 			respondBadRequest(ctx, err)
 			return

--- a/master/internal/command/shell_manager.go
+++ b/master/internal/command/shell_manager.go
@@ -73,7 +73,7 @@ func (s *shellManager) handleAPIRequest(ctx *actor.Context, apiCtx echo.Context)
 			return
 		}
 
-		req, err := parseCommandRequest(apiCtx, s.db, &params)
+		req, err := parseCommandRequest(apiCtx, s.db, &params, &s.taskContainerDefaults)
 		if err != nil {
 			respondBadRequest(ctx, err)
 			return

--- a/master/internal/command/tensorboard_manager.go
+++ b/master/internal/command/tensorboard_manager.go
@@ -116,7 +116,7 @@ func (t *tensorboardManager) handleAPIRequest(ctx *actor.Context, apiCtx echo.Co
 			return
 		}
 
-		commandReq, err := parseCommandRequest(apiCtx, t.db, &req.commandParams)
+		commandReq, err := parseCommandRequest(apiCtx, t.db, &req.commandParams, &t.taskContainerDefaults)
 		if err != nil {
 			respondBadRequest(ctx, err)
 			return

--- a/master/internal/config.go
+++ b/master/internal/config.go
@@ -22,7 +22,7 @@ var (
 
 // DefaultConfig returns the default configuration of the master.
 func DefaultConfig() *Config {
-	defaultExp := model.DefaultExperimentConfig()
+	defaultExp := model.DefaultExperimentConfig(nil)
 	var c CheckpointStorageConfig
 	if err := c.FromModel(&defaultExp.CheckpointStorage); err != nil {
 		panic(err)

--- a/master/internal/core_experiment.go
+++ b/master/internal/core_experiment.go
@@ -354,7 +354,7 @@ func (m *Master) parseExperiment(body []byte) (*model.Experiment, bool, error) {
 		return nil, false, errors.Wrap(err, "invalid experiment params")
 	}
 
-	config := model.DefaultExperimentConfig()
+	config := model.DefaultExperimentConfig(&m.config.TaskContainerDefaults)
 
 	checkpointStorage, err := m.config.CheckpointStorage.ToModel()
 	if err != nil {

--- a/master/internal/core_searcher.go
+++ b/master/internal/core_searcher.go
@@ -17,7 +17,7 @@ func (m *Master) getSearcherPreview(c echo.Context) (interface{}, error) {
 	if err != nil {
 		return nil, err
 	}
-	config := model.DefaultExperimentConfig()
+	config := model.DefaultExperimentConfig(&m.config.TaskContainerDefaults)
 	if uerr := yaml.Unmarshal(body, &config); uerr != nil {
 		return nil, uerr
 	}

--- a/master/internal/trial_workload_sequencer_test.go
+++ b/master/internal/trial_workload_sequencer_test.go
@@ -35,7 +35,7 @@ reproducibility:
 checkpoint_policy: none
 `
 
-	expConfig := model.DefaultExperimentConfig()
+	expConfig := model.DefaultExperimentConfig(nil)
 	assert.NilError(t, yaml.Unmarshal([]byte(yam), &expConfig, yaml.DisallowUnknownFields))
 
 	experiment := &model.Experiment{ID: 1, State: model.ActiveState, Config: expConfig}
@@ -45,7 +45,7 @@ checkpoint_policy: none
 		model.GlobalBatchSize: 64,
 	}, model.TrialWorkloadSequencerType)
 
-	schedulingUnit := model.DefaultExperimentConfig().SchedulingUnit
+	schedulingUnit := model.DefaultExperimentConfig(nil).SchedulingUnit
 	train := searcher.NewTrain(create.RequestID, model.NewLength(model.Batches, 500))
 	validate := searcher.NewValidate(create.RequestID)
 	checkpoint := searcher.NewCheckpoint(create.RequestID)
@@ -283,7 +283,7 @@ checkpoint_policy: none
 }
 
 func TestTrialWorkloadSequencerFailedWorkloads(t *testing.T) {
-	expConfig := model.DefaultExperimentConfig()
+	expConfig := model.DefaultExperimentConfig(nil)
 	expConfig.MinCheckpointPeriod = model.NewLengthInBatches(100)
 	experiment := &model.Experiment{ID: 1, State: model.ActiveState, Config: expConfig}
 
@@ -329,7 +329,7 @@ func TestTrialWorkloadSequencerFailedWorkloads(t *testing.T) {
 }
 
 func TestTrialWorkloadSequencerOperationLessThanBatchSize(t *testing.T) {
-	expConfig := model.DefaultExperimentConfig()
+	expConfig := model.DefaultExperimentConfig(nil)
 	experiment := &model.Experiment{ID: 1, State: model.ActiveState, Config: expConfig}
 
 	rand := nprand.New(0)

--- a/master/pkg/model/defaults.go
+++ b/master/pkg/model/defaults.go
@@ -35,14 +35,6 @@ func DefaultExperimentConfig(taskContainerDefaults *TaskContainerDefaultsConfig)
 		"Experiment (%s)",
 		petname.Generate(TaskNameGeneratorWords, TaskNameGeneratorSep))
 
-	cpuImage := defaultCPUImage
-	gpuImage := defaultGPUImage
-
-	if taskContainerDefaults != nil && taskContainerDefaults.Image != nil {
-		cpuImage = taskContainerDefaults.Image.CPU
-		gpuImage = taskContainerDefaults.Image.GPU
-	}
-
 	defaultConfig := ExperimentConfig{
 		Description: defaultDescription,
 		CheckpointStorage: CheckpointStorageConfig{
@@ -111,8 +103,8 @@ func DefaultExperimentConfig(taskContainerDefaults *TaskContainerDefaultsConfig)
 		SchedulingUnit:  100,
 		Environment: Environment{
 			Image: RuntimeItem{
-				CPU: cpuImage,
-				GPU: gpuImage,
+				CPU: defaultCPUImage,
+				GPU: defaultGPUImage,
 			},
 		},
 		Reproducibility: ReproducibilityConfig{
@@ -121,9 +113,16 @@ func DefaultExperimentConfig(taskContainerDefaults *TaskContainerDefaultsConfig)
 		MaxRestarts: 5,
 	}
 
-	if taskContainerDefaults != nil {
-		defaultConfig.Environment.RegistryAuth = taskContainerDefaults.RegistryAuth
-		defaultConfig.Environment.ForcePullImage = taskContainerDefaults.ForcePullImage
+	if taskContainerDefaults == nil {
+		return defaultConfig
+	}
+
+	defaultConfig.Environment.RegistryAuth = taskContainerDefaults.RegistryAuth
+	defaultConfig.Environment.ForcePullImage = taskContainerDefaults.ForcePullImage
+
+	if taskContainerDefaults.Image != nil {
+		defaultConfig.Environment.Image.CPU = taskContainerDefaults.Image.CPU
+		defaultConfig.Environment.Image.GPU = taskContainerDefaults.Image.GPU
 	}
 
 	return defaultConfig

--- a/master/pkg/model/defaults.go
+++ b/master/pkg/model/defaults.go
@@ -121,8 +121,7 @@ func DefaultExperimentConfig(taskContainerDefaults *TaskContainerDefaultsConfig)
 	defaultConfig.Environment.ForcePullImage = taskContainerDefaults.ForcePullImage
 
 	if taskContainerDefaults.Image != nil {
-		defaultConfig.Environment.Image.CPU = taskContainerDefaults.Image.CPU
-		defaultConfig.Environment.Image.GPU = taskContainerDefaults.Image.GPU
+		defaultConfig.Environment.Image = *taskContainerDefaults.Image
 	}
 
 	return defaultConfig

--- a/master/pkg/model/experiment_config.go
+++ b/master/pkg/model/experiment_config.go
@@ -125,7 +125,7 @@ func (e *ExperimentConfig) Scan(src interface{}) error {
 	if !ok {
 		return errors.Errorf("unable to convert to []byte: %v", src)
 	}
-	config := DefaultExperimentConfig()
+	config := DefaultExperimentConfig(nil)
 	if err := json.Unmarshal(data, &config); err != nil {
 		return err
 	}

--- a/master/pkg/model/experiment_config_test.go
+++ b/master/pkg/model/experiment_config_test.go
@@ -25,13 +25,13 @@ func zeroizeRandomSeedsBeforeCompare(a *ExperimentConfig, b *ExperimentConfig) {
 }
 
 func TestLabelsMap(t *testing.T) {
-	actual := DefaultExperimentConfig()
+	actual := DefaultExperimentConfig(nil)
 	assert.NilError(t, json.Unmarshal([]byte(`{
   "description": "provided",
   "labels": {"l1": true, "l2": true}
 }`), &actual))
 
-	expected := DefaultExperimentConfig()
+	expected := DefaultExperimentConfig(nil)
 	expected.Description = description
 	expected.Labels = map[string]bool{
 		"l1": true, "l2": true,
@@ -41,13 +41,13 @@ func TestLabelsMap(t *testing.T) {
 }
 
 func TestLabelsList(t *testing.T) {
-	actual := DefaultExperimentConfig()
+	actual := DefaultExperimentConfig(nil)
 	assert.NilError(t, json.Unmarshal([]byte(`{
   "description": "provided",
   "labels": ["l1", "l2"]
 }`), &actual))
 
-	expected := DefaultExperimentConfig()
+	expected := DefaultExperimentConfig(nil)
 	expected.Description = description
 	expected.Labels = map[string]bool{
 		"l1": true, "l2": true,
@@ -57,14 +57,14 @@ func TestLabelsList(t *testing.T) {
 }
 
 func TestLabelsJoin(t *testing.T) {
-	actual := DefaultExperimentConfig()
+	actual := DefaultExperimentConfig(nil)
 	actual.Labels = map[string]bool{"l3": true}
 	assert.NilError(t, json.Unmarshal([]byte(`{
   "description": "provided",
   "labels": {"l1": true, "l2": true}
 }`), &actual))
 
-	expected := DefaultExperimentConfig()
+	expected := DefaultExperimentConfig(nil)
 	expected.Description = description
 	expected.Labels = map[string]bool{
 		"l1": true, "l2": true, "l3": true,
@@ -74,7 +74,7 @@ func TestLabelsJoin(t *testing.T) {
 }
 
 func TestRecordsPerEpochMissing(t *testing.T) {
-	conf := DefaultExperimentConfig()
+	conf := DefaultExperimentConfig(nil)
 	assert.NilError(t, json.Unmarshal([]byte(`{
   "searcher": {
     "name": "single",
@@ -103,23 +103,23 @@ func TestDefaultDescription(t *testing.T) {
 }`)
 
 	// Check that user provided description persists.
-	config1 := DefaultExperimentConfig()
+	config1 := DefaultExperimentConfig(nil)
 	assert.NilError(t, json.Unmarshal(json1, &config1))
 	assert.DeepEqual(t, config1.Description, "test")
 
 	// Check that user provided null string persists.
-	config2 := DefaultExperimentConfig()
+	config2 := DefaultExperimentConfig(nil)
 	assert.NilError(t, json.Unmarshal(json2, &config2))
 	assert.DeepEqual(t, config2.Description, "")
 
 	// Check that unprovided description field will get filled.
-	config3 := DefaultExperimentConfig()
+	config3 := DefaultExperimentConfig(nil)
 	assert.NilError(t, json.Unmarshal(json3, &config3))
 	assert.Assert(t, strings.HasPrefix(config3.Description, "Experiment"))
 }
 
 func validGridSearchConfig() ExperimentConfig {
-	config := DefaultExperimentConfig()
+	config := DefaultExperimentConfig(nil)
 
 	// This is unrelated to grid search but must be set to make the default config pass validation.
 	config.CheckpointStorage.SharedFSConfig.HostPath = "/"
@@ -295,7 +295,7 @@ func TestExperiment(t *testing.T) {
 	}
   }
 }`)
-	config1 := DefaultExperimentConfig()
+	config1 := DefaultExperimentConfig(nil)
 	assert.NilError(t, json.Unmarshal(json1, &config1))
 
 	accessKey := "my key"

--- a/master/pkg/model/hyperparameters_config_test.go
+++ b/master/pkg/model/hyperparameters_config_test.go
@@ -69,7 +69,7 @@ func TestValidateGlobalBatchSize(t *testing.T) {
 
 	runTestCase := func(t *testing.T, tc testCase) {
 		t.Run(tc.name, func(t *testing.T) {
-			conf := DefaultExperimentConfig()
+			conf := DefaultExperimentConfig(nil)
 			assert.NilError(t, json.Unmarshal([]byte(tc.config), &conf))
 			if tc.errorMessage != "" {
 				assert.ErrorContains(t, check.Validate(conf.Hyperparameters), tc.errorMessage)

--- a/master/pkg/model/searcher_config_test.go
+++ b/master/pkg/model/searcher_config_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestASHAMaxConcurrentTrials(t *testing.T) {
-	var actual = DefaultExperimentConfig().Searcher
+	var actual = DefaultExperimentConfig(nil).Searcher
 	assert.NilError(t, json.Unmarshal([]byte(`
 {
   "name": "adaptive_asha",
@@ -33,7 +33,7 @@ func TestASHAMaxConcurrentTrials(t *testing.T) {
 }
 
 func TestDefaultSmallerIsBetter(t *testing.T) {
-	var actual1 = DefaultExperimentConfig().Searcher
+	var actual1 = DefaultExperimentConfig(nil).Searcher
 	assert.NilError(t, json.Unmarshal([]byte(`
 {
   "name": "adaptive_simple",
@@ -55,7 +55,7 @@ func TestDefaultSmallerIsBetter(t *testing.T) {
 	}
 	assert.DeepEqual(t, actual1, expected1)
 
-	var actual2 = DefaultExperimentConfig().Searcher
+	var actual2 = DefaultExperimentConfig(nil).Searcher
 	assert.NilError(t, json.Unmarshal([]byte(`
 {
   "name": "adaptive_simple",
@@ -76,7 +76,7 @@ func TestDefaultSmallerIsBetter(t *testing.T) {
 	}
 	assert.DeepEqual(t, actual2, expected2)
 
-	var actual3 = DefaultExperimentConfig().Searcher
+	var actual3 = DefaultExperimentConfig(nil).Searcher
 	assert.NilError(t, json.Unmarshal([]byte(`
 {
   "name": "adaptive_simple",

--- a/master/pkg/model/task_container_defaults.go
+++ b/master/pkg/model/task_container_defaults.go
@@ -4,6 +4,8 @@ import (
 	"regexp"
 	"strconv"
 
+	"github.com/docker/docker/api/types"
+
 	k8sV1 "k8s.io/api/core/v1"
 
 	"github.com/docker/docker/api/types/container"
@@ -21,6 +23,9 @@ type TaskContainerDefaultsConfig struct {
 	NetworkMode            container.NetworkMode `json:"network_mode,omitempty"`
 	CPUPodSpec             *k8sV1.Pod            `json:"cpu_pod_spec"`
 	GPUPodSpec             *k8sV1.Pod            `json:"gpu_pod_spec"`
+	Image                  *RuntimeItem          `json:"image,omitempty"`
+	RegistryAuth           *types.AuthConfig     `json:"registry_auth,omitempty"`
+	ForcePullImage         bool                  `json:"force_pull_image,omitempty"`
 }
 
 func validatePortRange(portRange string) []error {


### PR DESCRIPTION
## Description
It is not possible to configure the default task images, pull policy and registry credentials
via the `master.yaml`. Additionally made it configurable via the Helm chart as well.


## Test Plan
- [x] Add unit tests
- [x] Test on a local cluster
- [x] Test on a kubernetes cluster