### PR TITLE
perf: reduce unnecessary useRouteTracker re-creation

### DIFF
--- a/webui/react/src/hooks/useRouteTracker.ts
+++ b/webui/react/src/hooks/useRouteTracker.ts
@@ -11,7 +11,7 @@ const useRouteTracker = (): void => {
     recordPageAccess(location.pathname);
 
     // Listen for route changes
-    const unlisten = listen((location) => recordPageAccess(location.pathname));
+    const unlisten = listen((newLocation) => recordPageAccess(newLocation.pathname));
 
     // Return listener remover
     return unlisten;

--- a/webui/react/src/hooks/useRouteTracker.ts
+++ b/webui/react/src/hooks/useRouteTracker.ts
@@ -15,7 +15,14 @@ const useRouteTracker = (): void => {
 
     // Return listener remover
     return unlisten;
-  }, [ listen, location.pathname ]);
+
+    /*
+     * Explicitly avoid adding `location.pathname` as a dependency to avoid
+     * having the listener recreated each time `useRouteTracker` gets called
+     * during a render.
+     */
+    /* eslint-disable-next-line react-hooks/exhaustive-deps */
+  }, [ listen ]);
 };
 
 export default useRouteTracker;


### PR DESCRIPTION
## Description

`useRouteTracker`'s `useEffect` hook is called during each `location.pathname` change. Instead we want it called only when `listen` function changes (which is never during the lifecycle of the App).

<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234