### PR TITLE
ci: increase golangci-lint timeout

### DIFF
--- a/master/Makefile
+++ b/master/Makefile
@@ -22,7 +22,7 @@ build:
 
 .PHONY: check
 check:
-	golangci-lint run
+	golangci-lint run --timeout 10m
 
 .PHONY: fmt
 fmt:


### PR DESCRIPTION
Increase the timeout tenfold to avoid flakes.

See an instance of the flake at:
https://app.circleci.com/pipelines/github/determined-ai/determined/5532/workflows/0ff070f9-e776-4798-bb17-e7e5c71fc856/jobs/143181

You can play with different settings on your machine by running `golangci-lint cache clean` and then `golangci-lint run -j 1 --timeout 1s` (or something) which should produce a failure.