### PR TITLE
fix: use correct python in subprocesses [DET-4148]

### DIFF
--- a/cli/determined_cli/shell.py
+++ b/cli/determined_cli/shell.py
@@ -1,5 +1,6 @@
 import getpass
 import subprocess
+import sys
 import tempfile
 from argparse import ONE_OR_MORE, FileType, Namespace
 from pathlib import Path
@@ -78,7 +79,8 @@ def _open_shell(master: str, shell: Command, additional_opts: List[str]) -> None
 
         # Use determined_cli.tunnel as a portable script for using the HTTP CONNECT mechanism,
         # similar to `nc -X CONNECT -x ...` but without any dependency on external binaries.
-        proxy_cmd = "python -m determined_cli.tunnel {} %h".format(master)
+        python = sys.executable
+        proxy_cmd = "{} -m determined_cli.tunnel {} %h".format(python, master)
         if request.get_master_cert_bundle():
             proxy_cmd += ' "{}"'.format(request.get_master_cert_bundle())
 

--- a/harness/determined/horovod.py
+++ b/harness/determined/horovod.py
@@ -151,8 +151,9 @@ def create_run_command(
     if debug:
         horovod_process_cmd.append("--verbose")
     horovod_process_cmd.extend(optional_args)
+    # Use "python3" instead of sys.executable since the remote machine may have differing paths.
     horovod_process_cmd += [
-        "python",
+        "python3",
         "-m",
         "determined.exec.worker_process",
         str(worker_process_env_path),

--- a/harness/determined/layers/_worker_process.py
+++ b/harness/determined/layers/_worker_process.py
@@ -3,6 +3,7 @@ import os
 import pathlib
 import pickle
 import subprocess
+import sys
 import time
 from typing import Any, Dict, List, Optional, Tuple, cast
 
@@ -231,8 +232,9 @@ class SubprocessLauncher:
         self._python_subprocess_entrypoint = cast(str, self._python_subprocess_entrypoint)
 
         # Construct the command to launch the non-horovod training subprocess.
+        python = sys.executable
         python_cmd = [
-            "python",
+            python,
             "-m",
             self._python_subprocess_entrypoint,
             str(self._worker_process_env_path),

--- a/harness/tests/test_horovod.py
+++ b/harness/tests/test_horovod.py
@@ -98,7 +98,7 @@ def test_create_run_command(
     )
     if debug:
         expected_horovod_run_cmd.append("--verbose")
-    expected_horovod_run_cmd.extend(["python", "-m", "determined.exec.worker_process", "env_path"])
+    expected_horovod_run_cmd.extend(["python3", "-m", "determined.exec.worker_process", "env_path"])
 
     created_horovod_run_cmd = horovod.create_run_command(
         num_gpus_per_machine=num_gpus_per_machine,


### PR DESCRIPTION
## Description

For `det shell`, be explicit that the python subprocess used for tunnelling ssh through the master is started with the same python interpreter as what the `det` command is using.

Also, locate instances in the harness which were using making similar calls and make them either use the same interpreter (for same-machine subprocesses) or `python3` for subprocesses started on other machines.

## Test Plan

@davidhershey please confirm this fix works for you.  I reproduced the error by adding a link `python2` named as `python` on my PATH and confirmed the fix, but I'd feel better if you confirmed based on whatever environment you originally encountered the bug in.