### PR TITLE
chore: remove dependency on React Plotly [DET-3724]

### DIFF
--- a/webui/react/package-lock.json
+++ b/webui/react/package-lock.json
@@ -21810,14 +21810,6 @@
         "prop-types": "^15.7.2"
       }
     },
-    "react-plotly.js": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/react-plotly.js/-/react-plotly.js-2.4.0.tgz",
-      "integrity": "sha512-BCkxMe8yWqu3nP/hw9A1KCIuoL67WV5/k68SL9yhEkF6UG+pAuIev9Q3cMKtNkQJZhsYFpOmlqrpPjIdUFACOQ==",
-      "requires": {
-        "prop-types": "^15.7.2"
-      }
-    },
     "react-popper": {
       "version": "1.3.7",
       "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-1.3.7.tgz",

--- a/webui/react/package.json
+++ b/webui/react/package.json
@@ -37,7 +37,6 @@
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-monaco-editor": "^0.37.0",
-    "react-plotly.js": "^2.4.0",
     "react-router-dom": "^5.2.0",
     "react-scripts": "^3.4.3",
     "react-transition-group": "^4.4.1",

--- a/webui/react/src/components/ResourceChart.tsx
+++ b/webui/react/src/components/ResourceChart.tsx
@@ -33,7 +33,7 @@ const initialTally = Object.values(ResourceState).reduce((acc, key) => {
   return acc;
 }, {} as Tally);
 
-const genPlotInfo = (title: string, resources: Resource[]): PlotInfo | null => {
+const genPlotInfo = (title: string, resources: Resource[]): PlotInfo => {
   const tally = clone(initialTally) as Tally;
 
   resources.forEach(resource => {
@@ -93,7 +93,7 @@ const genPlotInfo = (title: string, resources: Resource[]): PlotInfo | null => {
 const SlotChart: React.FC<Props> = (props: Props) => {
   const chartRef = useRef<HTMLDivElement>(null);
   const [ id ] = useState(generateAlphaNumeric());
-  const [ oldPlotInfo, setOldPlotInfo ] = useState<PlotInfo | null>(null);
+  const [ oldPlotInfo, setOldPlotInfo ] = useState<PlotInfo>(genPlotInfo(props.title, []));
 
   const plotInfo = useMemo(() => {
     const newPlotInfo = genPlotInfo(props.title, props.resources || []);
@@ -109,8 +109,6 @@ const SlotChart: React.FC<Props> = (props: Props) => {
     const args: PlotArguments = [ elementId, pInfo.data, pInfo.layout, pInfo.config ];
     await Plotly.react.apply(null, args);
   }, [ id, plotInfo, props.resources ]);
-
-  if (plotInfo === null) return <React.Fragment />;
 
   useEffect(() => {
     renderPlot(id, plotInfo);

--- a/webui/react/src/components/ResourceChart.tsx
+++ b/webui/react/src/components/ResourceChart.tsx
@@ -1,5 +1,4 @@
-import { PlotData } from 'plotly.js/lib/core';
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 
 import Plotly, { Data } from 'Plotly';
 import { getStateColor, lightTheme } from 'themes';
@@ -18,13 +17,6 @@ export interface PlotInfo {
   layout: Partial<Plotly.Layout>;
   config: Partial<Plotly.Config>
 }
-
-type PlotArguments = [
-  string,
-  Partial<PlotData>[],
-  Partial<Plotly.Layout>,
-  Partial<Plotly.Config>,
-];
 
 type Tally = Record<ResourceState, number>;
 
@@ -101,17 +93,9 @@ const SlotChart: React.FC<Props> = (props: Props) => {
     return newPlotInfo;
   }, [ oldPlotInfo, props.resources, props.title ]);
 
-  const renderPlot = useCallback(async (
-    elementId: string,
-    pInfo: PlotInfo,
-  ) => {
-    const args: PlotArguments = [ elementId, pInfo.data, pInfo.layout, pInfo.config ];
-    await Plotly.react.apply(null, args);
-  }, [ ]);
-
   useEffect(() => {
-    renderPlot(id, plotInfo);
-  }, [ id, plotInfo, renderPlot ]);
+    Plotly.react.apply(null, [ id, plotInfo.data, plotInfo.layout, plotInfo.config ]);
+  }, [ id, plotInfo ]);
 
   return (
     <div id={id} />

--- a/webui/react/src/components/ResourceChart.tsx
+++ b/webui/react/src/components/ResourceChart.tsx
@@ -91,7 +91,6 @@ const genPlotInfo = (title: string, resources: Resource[]): PlotInfo => {
 };
 
 const SlotChart: React.FC<Props> = (props: Props) => {
-  const chartRef = useRef<HTMLDivElement>(null);
   const [ id ] = useState(generateAlphaNumeric());
   const [ oldPlotInfo, setOldPlotInfo ] = useState<PlotInfo>(genPlotInfo(props.title, []));
 
@@ -108,17 +107,14 @@ const SlotChart: React.FC<Props> = (props: Props) => {
   ) => {
     const args: PlotArguments = [ elementId, pInfo.data, pInfo.layout, pInfo.config ];
     await Plotly.react.apply(null, args);
-  }, [ id, plotInfo, props.resources ]);
+  }, [ ]);
 
   useEffect(() => {
     renderPlot(id, plotInfo);
-  }, [ id, plotInfo, props.resources ]);
+  }, [ id, plotInfo, renderPlot ]);
 
   return (
-    // <div className={css.base}>
-    <div>
-      <div id={id} ref={chartRef} />
-    </div>
+    <div id={id} />
   );
 };
 

--- a/webui/react/src/components/ResourceChart.tsx
+++ b/webui/react/src/components/ResourceChart.tsx
@@ -97,9 +97,7 @@ const SlotChart: React.FC<Props> = (props: Props) => {
     Plotly.react.apply(null, [ id, plotInfo.data, plotInfo.layout, plotInfo.config ]);
   }, [ id, plotInfo ]);
 
-  return (
-    <div id={id} />
-  );
+  return <div id={id} />;
 };
 
 export default SlotChart;


### PR DESCRIPTION
## Description

Changed the `ResourceChart` to use Plotly directly and removed React Plotly as a dependency

## Commentary

I'm not 100% certain if I need `plotInfo`, `renderPlot` and a `useEffect` hooks.
