### PR TITLE
fix: fix a coroutine leak in streaming API handlers [DET-4088]

### DIFF
--- a/docs/release-notes/1289-streaming-ednpoints-coroutine-leak
+++ b/docs/release-notes/1289-streaming-ednpoints-coroutine-leak
@@ -1,0 +1,7 @@
+:orphan:
+
+**BUG FIXES**
+
+- The log stream handlers could get into a situation where the requester
+has abandoned the request yet the handler still stays up and polls for
+new entries indefinitely. This fixes that by checking the context.

--- a/master/internal/api_master.go
+++ b/master/internal/api_master.go
@@ -88,5 +88,9 @@ func (a *apiServer) MasterLogs(
 		} else if req.Follow {
 			limit = -1
 		}
+		if err := resp.Context().Err(); err != nil {
+			// context is closed
+			return nil
+		}
 	}
 }

--- a/master/internal/api_trials.go
+++ b/master/internal/api_trials.go
@@ -81,6 +81,10 @@ func (a *apiServer) TrialLogs(
 			}
 		}
 		time.Sleep(batchWaitTime)
+		if err := resp.Context().Err(); err != nil {
+			// context is closed
+			return nil
+		}
 	}
 }
 


### PR DESCRIPTION
the log stream handlers could get into a situation where the requester
has abandoned the request yet the handler still stays up and polls for
new entries indefinitely. This fixes that by checking the context.

## Description

<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234