### PR TITLE
fix: deselect selected rows when table batch actions are done [DET-4128]

### DIFF
--- a/docs/release-notes/1299-fix-deselect-rows-after-table-batch-actions.txt
+++ b/docs/release-notes/1299-fix-deselect-rows-after-table-batch-actions.txt
@@ -1,0 +1,5 @@
+:orphan:
+
+**BUG FIXES**
+
+- Fix the issue of multiple selected rows dissappearing after a successful table batch action.

--- a/webui/react/src/pages/ExperimentList.tsx
+++ b/webui/react/src/pages/ExperimentList.tsx
@@ -253,6 +253,12 @@ const ExperimentList: React.FC = () => {
         if (url) openBlank(url);
       }
 
+      /*
+       * Deselect selected rows since their states may have changed where they
+       * are no longer part of the filter criteria.
+       */
+      setSelectedRowKeys([]);
+
       // Refetch experiment list to get updates based on batch action.
       await fetchExperiments();
     } catch (e) {

--- a/webui/react/src/pages/TaskList.tsx
+++ b/webui/react/src/pages/TaskList.tsx
@@ -230,6 +230,14 @@ const TaskList: React.FC = () => {
         .filter(task => isTaskKillable(task))
         .map(task => killCommand({ commandId: task.id, commandType: task.type }));
       await Promise.all(promises);
+
+      /*
+       * Deselect selected rows since their states may have changed where they
+       * are no longer part of the filter criteria.
+       */
+      setSelectedRowKeys([]);
+
+      // Refetch task list to get updates based on batch action.
       fetchTasks();
       await checkForTaskListUpdate();
     } catch (e) {


### PR DESCRIPTION
## Description

Deselect previously selected table rows upon a successful table batch action. Affected pages:
- Experiment List
- Task List

<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan

Run through each table batch action for both pages and make sure that all of the table rows are deselected upon completion.

<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234