### PR TITLE
fix: set `CGO_ENABLED=0` in GoReleaser builds

### DIFF
--- a/agent/.goreleaser.yml
+++ b/agent/.goreleaser.yml
@@ -1,5 +1,8 @@
 project_name: determined-agent
 
+env:
+  - CGO_ENABLED=0
+
 snapshot:
   name_template: "{{ .Env.VERSION }}"
 

--- a/master/.goreleaser.yml
+++ b/master/.goreleaser.yml
@@ -1,5 +1,8 @@
 project_name: determined-master
 
+env:
+  - CGO_ENABLED=0
+
 before:
   hooks:
     - make pre-package


### PR DESCRIPTION
## Description

Without cgo explicitly disabled, Go on Linux produces binaries that are
linked against the local libc and therefore can't run with older libc
versions (such as might be found in the Debian Docker images our master
and agent images are based on).

## Test Plan

- [x] `make package && docker run determinedai/determined-master:0.13.4dev0`, which starts the master successfully with this change but leads to ``version `GLIBC_2.32' not found`` without it