### PR TITLE
chore: move workload out of searcher

### DIFF
--- a/master/internal/experiment.go
+++ b/master/internal/experiment.go
@@ -3,6 +3,7 @@ package internal
 import (
 	"encoding/json"
 	"fmt"
+
 	"github.com/determined-ai/determined/master/pkg/workload"
 
 	"github.com/pkg/errors"

--- a/master/internal/experiment_test.go
+++ b/master/internal/experiment_test.go
@@ -1,12 +1,12 @@
 package internal
 
 import (
+	"github.com/determined-ai/determined/master/pkg/workload"
 	"testing"
 
 	"gotest.tools/assert"
 
 	"github.com/determined-ai/determined/master/pkg/model"
-	"github.com/determined-ai/determined/master/pkg/searcher"
 )
 
 type metricCase struct {
@@ -27,8 +27,8 @@ func testBestValidationCase(t *testing.T, smallerIsBetter bool, metrics []metric
 	}
 
 	for _, metric := range metrics {
-		msg := searcher.CompletedMessage{
-			ValidationMetrics: &searcher.ValidationMetrics{
+		msg := workload.CompletedMessage{
+			ValidationMetrics: &workload.ValidationMetrics{
 				Metrics: map[string]interface{}{"metric": metric.value},
 			},
 		}

--- a/master/internal/experiment_test.go
+++ b/master/internal/experiment_test.go
@@ -1,8 +1,9 @@
 package internal
 
 import (
-	"github.com/determined-ai/determined/master/pkg/workload"
 	"testing"
+
+	"github.com/determined-ai/determined/master/pkg/workload"
 
 	"gotest.tools/assert"
 

--- a/master/internal/experiment_utils.go
+++ b/master/internal/experiment_utils.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"encoding/json"
+
 	"github.com/determined-ai/determined/master/pkg/workload"
 
 	"github.com/google/uuid"

--- a/master/internal/trial.go
+++ b/master/internal/trial.go
@@ -4,9 +4,10 @@ import (
 	"archive/tar"
 	"encoding/json"
 	"fmt"
-	"github.com/determined-ai/determined/master/pkg/workload"
 	"sort"
 	"time"
+
+	"github.com/determined-ai/determined/master/pkg/workload"
 
 	"github.com/gorilla/websocket"
 	"github.com/pkg/errors"

--- a/master/internal/trial_workload_sequencer.go
+++ b/master/internal/trial_workload_sequencer.go
@@ -1,8 +1,9 @@
 package internal
 
 import (
-	"github.com/determined-ai/determined/master/pkg/workload"
 	"math"
+
+	"github.com/determined-ai/determined/master/pkg/workload"
 
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"

--- a/master/internal/trial_workload_sequencer_test.go
+++ b/master/internal/trial_workload_sequencer_test.go
@@ -1,6 +1,7 @@
 package internal
 
 import (
+	"github.com/determined-ai/determined/master/pkg/workload"
 	"testing"
 
 	"github.com/ghodss/yaml"
@@ -50,90 +51,90 @@ checkpoint_policy: none
 	validate := searcher.NewValidate(create.RequestID)
 	checkpoint := searcher.NewCheckpoint(create.RequestID)
 
-	trainWorkload1 := searcher.Workload{
-		Kind:                  searcher.RunStep,
+	trainWorkload1 := workload.Workload{
+		Kind:                  workload.RunStep,
 		ExperimentID:          1,
 		TrialID:               1,
 		StepID:                1,
 		NumBatches:            schedulingUnit,
 		TotalBatchesProcessed: 0,
 	}
-	trainWorkload2 := searcher.Workload{
-		Kind:                  searcher.RunStep,
+	trainWorkload2 := workload.Workload{
+		Kind:                  workload.RunStep,
 		ExperimentID:          1,
 		TrialID:               1,
 		StepID:                2,
 		NumBatches:            schedulingUnit,
 		TotalBatchesProcessed: schedulingUnit,
 	}
-	trainWorkload3 := searcher.Workload{
-		Kind:                  searcher.RunStep,
+	trainWorkload3 := workload.Workload{
+		Kind:                  workload.RunStep,
 		ExperimentID:          1,
 		TrialID:               1,
 		StepID:                3,
 		NumBatches:            schedulingUnit,
 		TotalBatchesProcessed: 2 * schedulingUnit,
 	}
-	trainWorkload4 := searcher.Workload{
-		Kind:                  searcher.RunStep,
+	trainWorkload4 := workload.Workload{
+		Kind:                  workload.RunStep,
 		ExperimentID:          1,
 		TrialID:               1,
 		StepID:                4,
 		NumBatches:            schedulingUnit,
 		TotalBatchesProcessed: 3 * schedulingUnit,
 	}
-	trainWorkload5 := searcher.Workload{
-		Kind:                  searcher.RunStep,
+	trainWorkload5 := workload.Workload{
+		Kind:                  workload.RunStep,
 		ExperimentID:          1,
 		TrialID:               1,
 		StepID:                5,
 		NumBatches:            schedulingUnit,
 		TotalBatchesProcessed: 4 * schedulingUnit,
 	}
-	checkpointWorkload1 := searcher.Workload{
-		Kind:                  searcher.CheckpointModel,
+	checkpointWorkload1 := workload.Workload{
+		Kind:                  workload.CheckpointModel,
 		ExperimentID:          1,
 		TrialID:               1,
 		StepID:                1,
 		TotalBatchesProcessed: schedulingUnit,
 	}
-	checkpointWorkload2 := searcher.Workload{
-		Kind:                  searcher.CheckpointModel,
+	checkpointWorkload2 := workload.Workload{
+		Kind:                  workload.CheckpointModel,
 		ExperimentID:          1,
 		TrialID:               1,
 		StepID:                2,
 		TotalBatchesProcessed: schedulingUnit * 2,
 	}
-	checkpointWorkload4 := searcher.Workload{
-		Kind:                  searcher.CheckpointModel,
+	checkpointWorkload4 := workload.Workload{
+		Kind:                  workload.CheckpointModel,
 		ExperimentID:          1,
 		TrialID:               1,
 		StepID:                4,
 		TotalBatchesProcessed: schedulingUnit * 4,
 	}
-	checkpointWorkload5 := searcher.Workload{
-		Kind:                  searcher.CheckpointModel,
+	checkpointWorkload5 := workload.Workload{
+		Kind:                  workload.CheckpointModel,
 		ExperimentID:          1,
 		TrialID:               1,
 		StepID:                5,
 		TotalBatchesProcessed: schedulingUnit * 5,
 	}
-	validationWorkload2 := searcher.Workload{
-		Kind:                  searcher.ComputeValidationMetrics,
+	validationWorkload2 := workload.Workload{
+		Kind:                  workload.ComputeValidationMetrics,
 		ExperimentID:          1,
 		TrialID:               1,
 		StepID:                2,
 		TotalBatchesProcessed: schedulingUnit * 2,
 	}
-	validationWorkload4 := searcher.Workload{
-		Kind:                  searcher.ComputeValidationMetrics,
+	validationWorkload4 := workload.Workload{
+		Kind:                  workload.ComputeValidationMetrics,
 		ExperimentID:          1,
 		TrialID:               1,
 		StepID:                4,
 		TotalBatchesProcessed: schedulingUnit * 4,
 	}
-	validationWorkload5 := searcher.Workload{
-		Kind:                  searcher.ComputeValidationMetrics,
+	validationWorkload5 := workload.Workload{
+		Kind:                  workload.ComputeValidationMetrics,
 		ExperimentID:          1,
 		TrialID:               1,
 		StepID:                5,
@@ -165,7 +166,7 @@ checkpoint_policy: none
 	assert.Assert(t, s.PrecloseCheckpointWorkload() == nil)
 
 	// Complete first RUN_STEP.
-	op, _, err := s.WorkloadCompleted(searcher.CompletedMessage{Workload: trainWorkload1}, nil)
+	op, _, err := s.WorkloadCompleted(workload.CompletedMessage{Workload: trainWorkload1}, nil)
 	assert.NilError(t, err)
 	assert.Equal(t, op, nil, "should not have finished %v yet", op)
 	w, err = s.Workload()
@@ -174,7 +175,7 @@ checkpoint_policy: none
 	assert.Equal(t, *s.PrecloseCheckpointWorkload(), checkpointWorkload1)
 
 	// Complete second RUN_STEP.
-	op, _, err = s.WorkloadCompleted(searcher.CompletedMessage{Workload: trainWorkload2}, nil)
+	op, _, err = s.WorkloadCompleted(workload.CompletedMessage{Workload: trainWorkload2}, nil)
 	assert.NilError(t, err)
 	assert.Equal(t, op, nil, "should not have finished %v yet", op)
 	w, err = s.Workload()
@@ -183,7 +184,7 @@ checkpoint_policy: none
 	assert.Equal(t, *s.PrecloseCheckpointWorkload(), checkpointWorkload2)
 
 	// Complete first COMPUTE_VALIDATION_METRICS.
-	op, _, err = s.WorkloadCompleted(searcher.CompletedMessage{Workload: validationWorkload2}, nil)
+	op, _, err = s.WorkloadCompleted(workload.CompletedMessage{Workload: validationWorkload2}, nil)
 	assert.NilError(t, err)
 	assert.Equal(t, op, nil, "should not have finished %v yet", op)
 	w, err = s.Workload()
@@ -191,14 +192,14 @@ checkpoint_policy: none
 	assert.Equal(t, w, trainWorkload3)
 
 	// Complete third and fourth RUN_STEP.
-	op, _, err = s.WorkloadCompleted(searcher.CompletedMessage{Workload: trainWorkload3}, nil)
+	op, _, err = s.WorkloadCompleted(workload.CompletedMessage{Workload: trainWorkload3}, nil)
 	assert.NilError(t, err)
 	assert.Equal(t, op, nil, "should not have finished %v yet", op)
 	w, err = s.Workload()
 	assert.NilError(t, err)
 	assert.Equal(t, w, trainWorkload4)
 
-	op, _, err = s.WorkloadCompleted(searcher.CompletedMessage{Workload: trainWorkload4}, nil)
+	op, _, err = s.WorkloadCompleted(workload.CompletedMessage{Workload: trainWorkload4}, nil)
 	assert.NilError(t, err)
 	assert.Equal(t, op, nil, "should not have finished %v yet", op)
 	w, err = s.Workload()
@@ -206,9 +207,9 @@ checkpoint_policy: none
 	assert.Equal(t, w, validationWorkload4)
 
 	// Complete second COMPUTE_VALIDATION_METRICS.
-	op, _, err = s.WorkloadCompleted(searcher.CompletedMessage{
+	op, _, err = s.WorkloadCompleted(workload.CompletedMessage{
 		Workload:          validationWorkload4,
-		ValidationMetrics: &searcher.ValidationMetrics{},
+		ValidationMetrics: &workload.ValidationMetrics{},
 	}, nil)
 	assert.NilError(t, err)
 	assert.Equal(t, op, nil, "should not have finished %v yet", op)
@@ -217,8 +218,8 @@ checkpoint_policy: none
 	assert.Equal(t, w, checkpointWorkload4)
 
 	// Complete first CHECKPOINT_MODEL.
-	fakeCheckpointMetrics := searcher.CheckpointMetrics{UUID: uuid.New()}
-	op, _, err = s.WorkloadCompleted(searcher.CompletedMessage{
+	fakeCheckpointMetrics := workload.CheckpointMetrics{UUID: uuid.New()}
+	op, _, err = s.WorkloadCompleted(workload.CompletedMessage{
 		Workload:          checkpointWorkload4,
 		CheckpointMetrics: &fakeCheckpointMetrics,
 	}, nil)
@@ -227,7 +228,7 @@ checkpoint_policy: none
 	assert.Assert(t, s.PrecloseCheckpointWorkload() == nil)
 
 	// Complete last RUN_STEP.
-	op, _, err = s.WorkloadCompleted(searcher.CompletedMessage{Workload: trainWorkload5}, nil)
+	op, _, err = s.WorkloadCompleted(workload.CompletedMessage{Workload: trainWorkload5}, nil)
 	assert.NilError(t, err)
 	assert.Equal(t, op, train, "expected searcher op to be returned")
 	w, err = s.Workload()
@@ -241,7 +242,7 @@ checkpoint_policy: none
 	assert.Equal(t, w, trainWorkload5)
 
 	// Replay last RUN_STEP after rollback.
-	op, _, err = s.WorkloadCompleted(searcher.CompletedMessage{Workload: trainWorkload5}, nil)
+	op, _, err = s.WorkloadCompleted(workload.CompletedMessage{Workload: trainWorkload5}, nil)
 	assert.NilError(t, err)
 	assert.Equal(t, op, train, "expected searcher op to be returned")
 	w, err = s.Workload()
@@ -249,8 +250,8 @@ checkpoint_policy: none
 	assert.Equal(t, w, checkpointWorkload5)
 
 	// Complete last CHECKPOINT_MODEL.
-	fakeCheckpointMetrics = searcher.CheckpointMetrics{UUID: uuid.New()}
-	op, _, err = s.WorkloadCompleted(searcher.CompletedMessage{
+	fakeCheckpointMetrics = workload.CheckpointMetrics{UUID: uuid.New()}
+	op, _, err = s.WorkloadCompleted(workload.CompletedMessage{
 		Workload:          checkpointWorkload5,
 		CheckpointMetrics: &fakeCheckpointMetrics,
 	}, nil)
@@ -261,9 +262,9 @@ checkpoint_policy: none
 	assert.Equal(t, w, validationWorkload5)
 
 	// Complete last COMPUTE_VALIDATION_METRICS.
-	op, _, err = s.WorkloadCompleted(searcher.CompletedMessage{
+	op, _, err = s.WorkloadCompleted(workload.CompletedMessage{
 		Workload:          validationWorkload5,
-		ValidationMetrics: &searcher.ValidationMetrics{},
+		ValidationMetrics: &workload.ValidationMetrics{},
 	}, nil)
 	assert.NilError(t, err)
 	assert.Equal(t, op, validate, "expected searcher op to be returned")
@@ -299,9 +300,9 @@ func TestTrialWorkloadSequencerFailedWorkloads(t *testing.T) {
 		searcher.NewTrain(create.RequestID, model.NewLength(model.Batches, 500)),
 	))
 
-	_, _, err := s.WorkloadCompleted(searcher.CompletedMessage{
-		Workload: searcher.Workload{
-			Kind:                  searcher.RunStep,
+	_, _, err := s.WorkloadCompleted(workload.CompletedMessage{
+		Workload: workload.Workload{
+			Kind:                  workload.RunStep,
 			ExperimentID:          1,
 			TrialID:               1,
 			StepID:                1,
@@ -311,10 +312,10 @@ func TestTrialWorkloadSequencerFailedWorkloads(t *testing.T) {
 	}, nil)
 	assert.NilError(t, err)
 
-	exitedReason := searcher.ExitedReason("not ok")
-	op, _, err := s.WorkloadCompleted(searcher.CompletedMessage{
-		Workload: searcher.Workload{
-			Kind:                  searcher.CheckpointModel,
+	exitedReason := workload.ExitedReason("not ok")
+	op, _, err := s.WorkloadCompleted(workload.CompletedMessage{
+		Workload: workload.Workload{
+			Kind:                  workload.CheckpointModel,
 			ExperimentID:          1,
 			TrialID:               1,
 			StepID:                1,
@@ -345,9 +346,9 @@ func TestTrialWorkloadSequencerOperationLessThanBatchSize(t *testing.T) {
 		train,
 	))
 
-	op, _, err := s.WorkloadCompleted(searcher.CompletedMessage{
-		Workload: searcher.Workload{
-			Kind:                  searcher.RunStep,
+	op, _, err := s.WorkloadCompleted(workload.CompletedMessage{
+		Workload: workload.Workload{
+			Kind:                  workload.RunStep,
 			ExperimentID:          1,
 			TrialID:               1,
 			StepID:                1,

--- a/master/internal/trial_workload_sequencer_test.go
+++ b/master/internal/trial_workload_sequencer_test.go
@@ -1,8 +1,9 @@
 package internal
 
 import (
-	"github.com/determined-ai/determined/master/pkg/workload"
 	"testing"
+
+	"github.com/determined-ai/determined/master/pkg/workload"
 
 	"github.com/ghodss/yaml"
 	"github.com/google/uuid"

--- a/master/pkg/searcher/asha.go
+++ b/master/pkg/searcher/asha.go
@@ -1,6 +1,7 @@
 package searcher
 
 import (
+	"github.com/determined-ai/determined/master/pkg/workload"
 	"math"
 	"sort"
 
@@ -131,7 +132,7 @@ func (s *asyncHalvingSearch) trialClosed(ctx context, requestID RequestID) ([]Op
 }
 
 func (s *asyncHalvingSearch) validationCompleted(
-	ctx context, requestID RequestID, validate Validate, metrics ValidationMetrics,
+	ctx context, requestID RequestID, validate Validate, metrics workload.ValidationMetrics,
 ) ([]Operation, error) {
 	// Extract the relevant metric as a float.
 	metric, err := metrics.Metric(s.Metric)

--- a/master/pkg/searcher/asha.go
+++ b/master/pkg/searcher/asha.go
@@ -1,9 +1,10 @@
 package searcher
 
 import (
-	"github.com/determined-ai/determined/master/pkg/workload"
 	"math"
 	"sort"
+
+	"github.com/determined-ai/determined/master/pkg/workload"
 
 	"github.com/determined-ai/determined/master/pkg/model"
 )

--- a/master/pkg/searcher/event_log.go
+++ b/master/pkg/searcher/event_log.go
@@ -2,6 +2,7 @@ package searcher
 
 import (
 	"github.com/determined-ai/determined/master/pkg/model"
+	"github.com/determined-ai/determined/master/pkg/workload"
 )
 
 // Event is the type of searcher events stored by the event log.
@@ -82,7 +83,7 @@ func (el *EventLog) TrialExitedEarly(requestID RequestID) {
 }
 
 // WorkloadCompleted records that the workload has been completed.
-func (el *EventLog) WorkloadCompleted(msg CompletedMessage, unitsCompleted float64) {
+func (el *EventLog) WorkloadCompleted(msg workload.CompletedMessage, unitsCompleted float64) {
 	el.TotalUnitsCompleted += unitsCompleted
 	el.uncommitted = append(el.uncommitted, msg)
 }

--- a/master/pkg/searcher/event_log_test.go
+++ b/master/pkg/searcher/event_log_test.go
@@ -1,6 +1,7 @@
 package searcher
 
 import (
+	"github.com/determined-ai/determined/master/pkg/workload"
 	"testing"
 
 	"gotest.tools/assert"
@@ -30,8 +31,8 @@ func TestEventLog(t *testing.T) {
 
 	for i, trialID := range trialIDs {
 		// Check that units completed are recorded and workloads saved.
-		msg := CompletedMessage{
-			Workload: Workload{
+		msg := workload.CompletedMessage{
+			Workload: workload.Workload{
 				StepID: trialID*trialID + i,
 			},
 		}

--- a/master/pkg/searcher/event_log_test.go
+++ b/master/pkg/searcher/event_log_test.go
@@ -1,8 +1,9 @@
 package searcher
 
 import (
-	"github.com/determined-ai/determined/master/pkg/workload"
 	"testing"
+
+	"github.com/determined-ai/determined/master/pkg/workload"
 
 	"gotest.tools/assert"
 

--- a/master/pkg/searcher/pbt.go
+++ b/master/pkg/searcher/pbt.go
@@ -1,6 +1,7 @@
 package searcher
 
 import (
+	"github.com/determined-ai/determined/master/pkg/workload"
 	"math"
 	"sort"
 
@@ -52,7 +53,7 @@ func (s *pbtSearch) initialOperations(ctx context) ([]Operation, error) {
 }
 
 func (s *pbtSearch) validationCompleted(
-	ctx context, requestID RequestID, validate Validate, metrics ValidationMetrics,
+	ctx context, requestID RequestID, validate Validate, metrics workload.ValidationMetrics,
 ) ([]Operation, error) {
 	// Extract the relevant metric as a float.
 	rawMetric := metrics.Metrics[s.Metric]
@@ -194,7 +195,7 @@ func (s *pbtSearch) exploreParams(ctx context, old hparamSample) hparamSample {
 }
 
 func (s *pbtSearch) checkpointCompleted(
-	ctx context, requestID RequestID, checkpoint Checkpoint, metrics CheckpointMetrics,
+	ctx context, requestID RequestID, checkpoint Checkpoint, metrics workload.CheckpointMetrics,
 ) ([]Operation, error) {
 	ops := s.waitingOps[checkpoint]
 	delete(s.waitingOps, checkpoint)

--- a/master/pkg/searcher/pbt.go
+++ b/master/pkg/searcher/pbt.go
@@ -1,9 +1,10 @@
 package searcher
 
 import (
-	"github.com/determined-ai/determined/master/pkg/workload"
 	"math"
 	"sort"
+
+	"github.com/determined-ai/determined/master/pkg/workload"
 
 	"github.com/pkg/errors"
 

--- a/master/pkg/searcher/search_method.go
+++ b/master/pkg/searcher/search_method.go
@@ -3,6 +3,7 @@ package searcher
 import (
 	"github.com/determined-ai/determined/master/pkg/model"
 	"github.com/determined-ai/determined/master/pkg/nprand"
+	"github.com/determined-ai/determined/master/pkg/workload"
 )
 
 type context struct {
@@ -27,13 +28,13 @@ type SearchMethod interface {
 	// searcher has completed. It returns any new operations as a result of this workload
 	// completing.
 	checkpointCompleted(
-		ctx context, requestID RequestID, checkpoint Checkpoint, metrics CheckpointMetrics,
+		ctx context, requestID RequestID, checkpoint Checkpoint, metrics workload.CheckpointMetrics,
 	) ([]Operation, error)
 	// validationCompleted informs the searcher that the validation workload initiated by the same
 	// searcher has completed. It returns any new operations as a result of this workload
 	// completing.
 	validationCompleted(
-		ctx context, requestID RequestID, validate Validate, metrics ValidationMetrics,
+		ctx context, requestID RequestID, validate Validate, metrics workload.ValidationMetrics,
 	) ([]Operation, error)
 	// trialClosed informs the searcher that the trial has been closed as a result of a Close
 	// operation.
@@ -83,12 +84,12 @@ func (defaultSearchMethod) trainCompleted(context, RequestID, Train) ([]Operatio
 }
 
 func (defaultSearchMethod) checkpointCompleted(
-	context, RequestID, Checkpoint, CheckpointMetrics,
+	context, RequestID, Checkpoint, workload.CheckpointMetrics,
 ) ([]Operation, error) {
 	return nil, nil
 }
 func (defaultSearchMethod) validationCompleted(
-	context, RequestID, Validate, ValidationMetrics,
+	context, RequestID, Validate, workload.ValidationMetrics,
 ) ([]Operation, error) {
 	return nil, nil
 }

--- a/master/pkg/searcher/searcher.go
+++ b/master/pkg/searcher/searcher.go
@@ -1,6 +1,7 @@
 package searcher
 
 import (
+	"github.com/determined-ai/determined/master/pkg/workload"
 	"math"
 
 	"github.com/pkg/errors"
@@ -73,7 +74,7 @@ func (s *Searcher) TrialExitedEarly(trialID int) ([]Operation, error) {
 
 // WorkloadCompleted informs the searcher that the workload is completed. This relays the message
 // to the event log and records the units as complete for search method progress.
-func (s *Searcher) WorkloadCompleted(msg CompletedMessage, unitsCompleted float64) {
+func (s *Searcher) WorkloadCompleted(msg workload.CompletedMessage, unitsCompleted float64) {
 	s.eventLog.WorkloadCompleted(msg, unitsCompleted)
 }
 
@@ -95,10 +96,10 @@ func (s *Searcher) OperationCompleted(
 		operations, err = s.method.trainCompleted(s.context(), requestID, tOp)
 	case Checkpoint:
 		operations, err = s.method.checkpointCompleted(
-			s.context(), requestID, tOp, *metrics.(*CheckpointMetrics))
+			s.context(), requestID, tOp, *metrics.(*workload.CheckpointMetrics))
 	case Validate:
 		operations, err = s.method.validationCompleted(
-			s.context(), requestID, tOp, *metrics.(*ValidationMetrics))
+			s.context(), requestID, tOp, *metrics.(*workload.ValidationMetrics))
 	default:
 		return nil, errors.Errorf("unexpected op: %s", tOp)
 	}

--- a/master/pkg/searcher/searcher.go
+++ b/master/pkg/searcher/searcher.go
@@ -1,8 +1,9 @@
 package searcher
 
 import (
-	"github.com/determined-ai/determined/master/pkg/workload"
 	"math"
+
+	"github.com/determined-ai/determined/master/pkg/workload"
 
 	"github.com/pkg/errors"
 

--- a/master/pkg/searcher/sha.go
+++ b/master/pkg/searcher/sha.go
@@ -1,6 +1,7 @@
 package searcher
 
 import (
+	"github.com/determined-ai/determined/master/pkg/workload"
 	"math"
 	"sort"
 
@@ -135,7 +136,7 @@ func (s *syncHalvingSearch) initialOperations(ctx context) ([]Operation, error) 
 }
 
 func (s *syncHalvingSearch) validationCompleted(
-	ctx context, requestID RequestID, validate Validate, metrics ValidationMetrics,
+	ctx context, requestID RequestID, validate Validate, metrics workload.ValidationMetrics,
 ) ([]Operation, error) {
 	// Extract the relevant metric as a float.
 	metric, err := metrics.Metric(s.Metric)

--- a/master/pkg/searcher/sha.go
+++ b/master/pkg/searcher/sha.go
@@ -1,9 +1,10 @@
 package searcher
 
 import (
-	"github.com/determined-ai/determined/master/pkg/workload"
 	"math"
 	"sort"
+
+	"github.com/determined-ai/determined/master/pkg/workload"
 
 	"github.com/pkg/errors"
 

--- a/master/pkg/searcher/simulate.go
+++ b/master/pkg/searcher/simulate.go
@@ -3,6 +3,7 @@ package searcher
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/determined-ai/determined/master/pkg/workload"
 	"io"
 	"math/rand"
 	"sort"
@@ -130,8 +131,8 @@ func Simulate(
 			if train, ok := operation.(Train); ok {
 				// If it's a train simulate we ran it to the event log as one huge workload,
 				// so that progress is correctly updated.
-				s.WorkloadCompleted(CompletedMessage{Workload: Workload{
-					Kind:    RunStep,
+				s.WorkloadCompleted(workload.CompletedMessage{Workload: workload.Workload{
+					Kind:    workload.RunStep,
 					TrialID: trialIDs[requestID],
 					StepID:  trialOpIdxs[requestID],
 				}}, float64(train.Length.Units))
@@ -252,12 +253,12 @@ func generateMetrics(
 		if err != nil {
 			return nil, err
 		}
-		return &CheckpointMetrics{
+		return &workload.CheckpointMetrics{
 			UUID:      requestID,
 			Resources: map[string]int{},
 		}, nil
 	case Validate:
-		return &ValidationMetrics{
+		return &workload.ValidationMetrics{
 			NumInputs: 1,
 			Metrics: map[string]interface{}{
 				metric: valFunc(random, trialID, opIdx),

--- a/master/pkg/searcher/simulate.go
+++ b/master/pkg/searcher/simulate.go
@@ -3,12 +3,13 @@ package searcher
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/determined-ai/determined/master/pkg/workload"
 	"io"
 	"math/rand"
 	"sort"
 	"strings"
 	"time"
+
+	"github.com/determined-ai/determined/master/pkg/workload"
 
 	"github.com/google/uuid"
 	"github.com/pkg/errors"

--- a/master/pkg/searcher/tournament.go
+++ b/master/pkg/searcher/tournament.go
@@ -2,6 +2,7 @@ package searcher
 
 import (
 	"github.com/determined-ai/determined/master/pkg/model"
+	"github.com/determined-ai/determined/master/pkg/workload"
 )
 
 // tournamentSearch runs multiple search methods in tandem. Callbacks for completed operations
@@ -49,7 +50,7 @@ func (s *tournamentSearch) trainCompleted(
 }
 
 func (s *tournamentSearch) checkpointCompleted(
-	ctx context, requestID RequestID, checkpoint Checkpoint, metrics CheckpointMetrics,
+	ctx context, requestID RequestID, checkpoint Checkpoint, metrics workload.CheckpointMetrics,
 ) ([]Operation, error) {
 	subSearch := s.trialTable[requestID]
 	ops, err := subSearch.checkpointCompleted(ctx, requestID, checkpoint, metrics)
@@ -57,7 +58,7 @@ func (s *tournamentSearch) checkpointCompleted(
 }
 
 func (s *tournamentSearch) validationCompleted(
-	ctx context, requestID RequestID, validate Validate, metrics ValidationMetrics,
+	ctx context, requestID RequestID, validate Validate, metrics workload.ValidationMetrics,
 ) ([]Operation, error) {
 	subSearch := s.trialTable[requestID]
 	ops, err := subSearch.validationCompleted(ctx, requestID, validate, metrics)

--- a/master/pkg/searcher/util_test.go
+++ b/master/pkg/searcher/util_test.go
@@ -1,6 +1,7 @@
 package searcher
 
 import (
+	"github.com/determined-ai/determined/master/pkg/workload"
 	"strconv"
 	"strings"
 	"testing"
@@ -364,7 +365,7 @@ func simulateOperationComplete(
 		if vErr != nil {
 			return nil, errors.Wrap(err, "error checking Validate with predefinedTrial")
 		}
-		metrics := ValidationMetrics{
+		metrics := workload.ValidationMetrics{
 			Metrics: map[string]interface{}{
 				"error": val,
 			},
@@ -378,7 +379,7 @@ func simulateOperationComplete(
 		if err = trial.Checkpoint(opIndex); err != nil {
 			return nil, errors.Wrap(err, "error checking Checkpoint with predefinedTrial")
 		}
-		metrics := CheckpointMetrics{}
+		metrics := workload.CheckpointMetrics{}
 		ops, err = method.checkpointCompleted(ctx, operation.RequestID, operation, metrics)
 		if err != nil {
 			return nil, errors.Wrap(err, "checkpointCompleted")

--- a/master/pkg/searcher/util_test.go
+++ b/master/pkg/searcher/util_test.go
@@ -1,10 +1,11 @@
 package searcher
 
 import (
-	"github.com/determined-ai/determined/master/pkg/workload"
 	"strconv"
 	"strings"
 	"testing"
+
+	"github.com/determined-ai/determined/master/pkg/workload"
 
 	"github.com/pkg/errors"
 	"gotest.tools/assert"

--- a/master/pkg/tasks/task_spec.go
+++ b/master/pkg/tasks/task_spec.go
@@ -3,13 +3,13 @@ package tasks
 import (
 	"crypto/tls"
 	"encoding/json"
+	"github.com/determined-ai/determined/master/pkg/workload"
 
 	"github.com/pkg/errors"
 
 	"github.com/determined-ai/determined/master/pkg/archive"
 	"github.com/determined-ai/determined/master/pkg/device"
 	"github.com/determined-ai/determined/master/pkg/model"
-	"github.com/determined-ai/determined/master/pkg/searcher"
 	"github.com/determined-ai/determined/master/pkg/union"
 )
 
@@ -75,7 +75,7 @@ type StartContainer struct {
 	HParams             map[string]interface{}    `json:"hparams"`
 	TrialSeed           uint32                    `json:"trial_seed"`
 	LatestCheckpoint    *model.Checkpoint         `json:"latest_checkpoint"`
-	InitialWorkload     searcher.Workload         `json:"initial_workload"`
+	InitialWorkload     workload.Workload         `json:"initial_workload"`
 	WorkloadManagerType model.WorkloadManagerType `json:"workload_manager_type"`
 	AdditionalFiles     archive.Archive           `json:"additional_files"`
 
@@ -90,5 +90,5 @@ type KillContainer struct{}
 
 // RunWorkload is the information sent to an agent to run a workload.
 type RunWorkload struct {
-	Workload searcher.Workload `json:"workload"`
+	Workload workload.Workload `json:"workload"`
 }

--- a/master/pkg/tasks/task_spec.go
+++ b/master/pkg/tasks/task_spec.go
@@ -3,6 +3,7 @@ package tasks
 import (
 	"crypto/tls"
 	"encoding/json"
+
 	"github.com/determined-ai/determined/master/pkg/workload"
 
 	"github.com/pkg/errors"

--- a/master/pkg/workload/completed_message.go
+++ b/master/pkg/workload/completed_message.go
@@ -1,4 +1,4 @@
-package searcher
+package workload
 
 import (
 	"encoding/json"

--- a/master/pkg/workload/completed_message_test.go
+++ b/master/pkg/workload/completed_message_test.go
@@ -1,4 +1,4 @@
-package searcher
+package workload
 
 import (
 	"encoding/json"

--- a/master/pkg/workload/workload.go
+++ b/master/pkg/workload/workload.go
@@ -1,4 +1,4 @@
-package searcher
+package workload
 
 import (
 	"fmt"

--- a/master/pkg/workload/workload_test.go
+++ b/master/pkg/workload/workload_test.go
@@ -1,4 +1,4 @@
-package searcher
+package workload
 
 import (
 	"encoding/json"


### PR DESCRIPTION


## Description
After remove steps, the searcher is no longer concerned with
workloads or completed messages, just operations and metrics, so
this change moves those out of the searcher. There are future refactorings
to be done, and this makes them a lot less strange.
<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan

Used automatic refactoring tools for this, and unit tests/compiling should cover it.
<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)
Been meaning to do this since remove steps, and I finally broke down and got goland so it's 1-2 minutes not 30 miserable minutes.
<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->

See [Release Note](../docs/release-notes/README.md) for details.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234