### PR TITLE
feat: support configuring TLS via Helm chart [DET-4030]

### DIFF
--- a/docs/how-to/installation/kubernetes.txt
+++ b/docs/how-to/installation/kubernetes.txt
@@ -43,13 +43,21 @@ When the Determined Helm chart is installed, the following entities will
 be created:
 
 #. Deployment of the Determined master.
+
 #. ConfigMap containing configurations for the Determined master.
-#. LoadBalancer service to make the Determined master accessible.
+
+#. LoadBalancer service to make the Determined master accessible. Later
+   in this guide, we descrive how it is possible to replace this with a
+   NodePort service.
+
 #. ServiceAcccount which will be used by the Determined master.
+
 #. Deployment of a Postgres database. Later in this guide, we describe
    how an external database can be used instead.
+
 #. PersistentVolumeClaim for the Postgres database. Omitted if using an
    external database.
+
 #. Service to allow the Determined master to communicate with the
    Postgres database. Omitted if using an external database.
 
@@ -151,6 +159,78 @@ undesirable, users can configure the Helm chart to use an external
 Postgres database by setting ``db.hostAddress`` to the IP address of
 their database. If ``db.hostAddress`` is configured, the Determined Helm
 chart will not deploy a database.
+
+TLS (Optional)
+==============
+
+By default, the Helm chart will deploy a load-balancer which makes the
+Determined master accessible over HTTP. To secure your cluster, Determined
+supports configuring `TLS encryption
+<https://en.wikipedia.org/wiki/Transport_Layer_Security>`__ which can be
+configured to terminate inside a load-balancer or inside the Determined
+master itself. To configure TLS, users should set ``useNodePortForMaster``
+to ``true``. This will instruct Determined to deploy a NodePort service
+for the master. Users can then configure an `Ingress
+<https://kubernetes.io/docs/concepts/services-networking/ingress/#tls>`__
+that performs TLS termination in the load balancer and forward plain test
+to the NodePort service, or forwards TLS encrypted data. Please note
+when configuring an Ingress that you need to have an `Ingress controller
+<https://github.com/bitnami/charts/tree/master/bitnami/nginx-ingress-controller>`__
+runing your cluster.
+
+#. **TLS termination in a load-balancer (e.g., nginx).** This option will
+   provide TLS encryption between the client and the load-balancer, with all
+   communication inside the cluster performed via http. To configure
+   this option set ``useNodePortForMaster`` to ``true`` and then configure an
+   Ingress service to perform TLS termination and forward the plain text traffic
+   to the Determined master.
+
+
+#. **TLS termination in the Determined master.** This option will provide TLS
+   encrytption inside the Kubernetes cluster. All communication with the
+   master will encrypted. Communication between task containers
+   (distributed triaining) will not be encrypted.  To configure
+   this option create a Kuberentes TLS secret within the
+   namespace where Determined is being installed and set ``tlsSecret``
+   to be the name of this secret. When using TLS termination in the master,
+   ``masterPort`` must be configured to a value other than 8080 (e.g., 8443).
+   Users will also have to set ``useNodePortForMaster`` to ``true``. Once the
+   the NodePort service is created, users can configure an Ingress to
+   forward TLS encrypted data to the NodePord service.
+
+An example of how to configure an Ingress, by default this Ingress will perform
+TLS termination in the load-balancer:
+
+.. code:: yaml
+
+     apiVersion: networking.k8s.io/v1beta1
+     kind: Ingress
+     metadata:
+       name: determined-ingress
+       annotations:
+         kubernetes.io/ingress.class: "nginx"
+
+         # Uncommenting this option instucts the created load-balancer
+         # to forward TLS encrypted data to the NodePort service and
+         # perform TLS termination in the Determined master. In order
+         # to configure ssl-passthrough, your nginx ingress controller
+         # must be running with --enable-ssl-passthrough option enabled.
+         #
+         # nginx.ingress.kubernetes.io/ssl-passthrough: "true"
+     spec:
+       tls:
+       - hosts:
+         - your-hostname-for-determined.ai
+         secretName: your-tls-secret-name
+       rules:
+       - host: your-hostname-for-determined.ai
+         http:
+           paths:
+             - path: /
+               backend:
+                 serviceName: determined-master-service-<name for your deployment>
+                 servicePort: masterPort configured in values.yaml
+
 
 ***********************
  Installing Determined

--- a/docs/how-to/installation/kubernetes.txt
+++ b/docs/how-to/installation/kubernetes.txt
@@ -47,7 +47,7 @@ be created:
 #. ConfigMap containing configurations for the Determined master.
 
 #. LoadBalancer service to make the Determined master accessible. Later
-   in this guide, we descrive how it is possible to replace this with a
+   in this guide, we describe how it is possible to replace this with a
    NodePort service.
 
 #. ServiceAcccount which will be used by the Determined master.

--- a/docs/how-to/installation/kubernetes.txt
+++ b/docs/how-to/installation/kubernetes.txt
@@ -192,8 +192,7 @@ runing your cluster.
    (distributed triaining) will not be encrypted.  To configure
    this option create a Kuberentes TLS secret within the
    namespace where Determined is being installed and set ``tlsSecret``
-   to be the name of this secret. When using TLS termination in the master,
-   ``masterPort`` must be configured to a value other than 8080 (e.g., 8443).
+   to be the name of this secret.
    Users will also have to set ``useNodePortForMaster`` to ``true``. Once the
    the NodePort service is created, users can configure an Ingress to
    forward TLS encrypted data to the NodePord service.

--- a/docs/reference/helm-config.txt
+++ b/docs/reference/helm-config.txt
@@ -33,8 +33,25 @@ Helm Chart </helm/determined-helm-chart.tgz>`.
  ``values.yaml`` Settings
 **************************
 
--  ``httpPort``: The port at which the Determined master listens for
+-  ``masterPort``: The port at which the Determined master listens for
    connections on. (*Required*)
+
+-  ``useNodePortForMaster``: When set to false
+   (default), a LoadBalancer service is deployed to make the Determined
+   master reachable from outside the cluster. When set to true, the master
+   will instead be exposed behind a NodePort service. When using a NodePort
+   service users will typically have to configure an Ingress to make the
+   Determined master reachable from outside the cluster. NodePort service is
+   recommended when configuring TLS termination in a load-balancer.
+
+-  ``tlsSecret``: enables TLS encryption for all communication with the
+   Determined master (TLS termination is performed in the Determined
+   master). This includes communication between the Determined master
+   and the task containers it launches, but does not include
+   communication between the task containers (distributed
+   training). The specified Secret of type tls must already exist in the
+   same namespace in which Determined is being installed. If a ``tlsSecret``
+   is specified, ``masterPort`` can not be set to 8080 (8443 recommended).
 
 -  ``db``: Specifies the configuration of the database.
 
@@ -152,10 +169,11 @@ Helm Chart </helm/determined-helm-chart.tgz>`.
       use during distributed training. A valid port range is in the
       format of ``MIN:MAX``.
 
-   -  ``forcePullImage``: Defines the default policy for forcibly pulling images from
-      the docker registry and bypassing the docker cache. If a pull policy is specified
-      in the :ref:`experiment config <exp-environment-image>` this default  is overriden.
-      Please note that as of November 1st, 2020 unauthenticated users will be
+   -  ``forcePullImage``: Defines the default policy for forcibly
+      pulling images from the docker registry and bypassing the docker
+      cache. If a pull policy is specified in the :ref:`experiment
+      config <exp-environment-image>` this default is overriden. Please
+      note that as of November 1st, 2020 unauthenticated users will be
       `capped at 100 pulls from Docker per 6 hours
       <https://www.docker.com/blog/scaling-docker-to-serve-millions-more-developers-network-egress/>`__.
       Defaults to ``false``.
@@ -166,14 +184,14 @@ Helm Chart </helm/determined-helm-chart.tgz>`.
    -  ``gpuPodSpec``: Sets the default pod spec for all ngpu tasks. See
       :ref:`custom-pod-specs` for details.
 
-   -  ``cpuImage``: Sets the default docker image for all non-gpu tasks. If a docker image
-      is specified in the :ref:`experiment config <exp-environment-image>`
-      this default is overriden. Defaults to:
+   -  ``cpuImage``: Sets the default docker image for all non-gpu tasks.
+      If a docker image is specified in the :ref:`experiment config
+      <exp-environment-image>` this default is overriden. Defaults to:
       ``determinedai/environments:py-3.6.9-pytorch-1.4-tf-1.15-cpu-0.5.0``.
 
-   -  ``gpuImage``: Sets the default docker image for all gpu tasks. If a docker image
-      is specified in the :ref:`experiment config <exp-environment-image>`
-      this default is overriden. Defaults to:
+   -  ``gpuImage``: Sets the default docker image for all gpu tasks. If
+      a docker image is specified in the :ref:`experiment config
+      <exp-environment-image>` this default is overriden. Defaults to:
       ``determinedai/environments:cuda-10.0-pytorch-1.4-tf-1.15-gpu-0.5.0``.
 
 -  ``enterpriseEdition``: Specifies whether to use Determined enterprise

--- a/docs/reference/helm-config.txt
+++ b/docs/reference/helm-config.txt
@@ -50,8 +50,7 @@ Helm Chart </helm/determined-helm-chart.tgz>`.
    and the task containers it launches, but does not include
    communication between the task containers (distributed
    training). The specified Secret of type tls must already exist in the
-   same namespace in which Determined is being installed. If a ``tlsSecret``
-   is specified, ``masterPort`` can not be set to 8080 (8443 recommended).
+   same namespace in which Determined is being installed.
 
 -  ``db``: Specifies the configuration of the database.
 

--- a/docs/release-notes/1310-support-tls-configuring-in-helm.txt
+++ b/docs/release-notes/1310-support-tls-configuring-in-helm.txt
@@ -1,0 +1,6 @@
+:orphan:
+
+**Improvements**
+
+-  Support configuring TLS encryption when deploying Determined on Kubernetes.
+   For more details please see :ref:`install-on-kubernetes`.

--- a/helm/charts/determined/Chart.yaml
+++ b/helm/charts/determined/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: determined
 description: A Helm chart for Determined
-version: 0.1.0
+version: 0.2.0
 icon: https://github.com/determined-ai/determined/blob/master/determined-logo.png?raw=true
 home: https://github.com/determined-ai/determined.git
 

--- a/helm/charts/determined/templates/NOTES.txt
+++ b/helm/charts/determined/templates/NOTES.txt
@@ -18,7 +18,7 @@ kubectl get service determined-master-service-{{ .Release.Name }} -n {{ .Release
 {{ end -}}
 
 {{ $httpOrHttps := "http" }}
-{{- if .Values.tlsSecret }}
+{{- if .Values.tlsSecret -}}
   {{ $httpOrHttps = "https" }}
   {{ $secret := (lookup "v1" "Secret" .Release.Namespace (.Values.tlsSecret | toString) ) }}
   {{- if eq (len $secret) 0 }}

--- a/helm/charts/determined/templates/NOTES.txt
+++ b/helm/charts/determined/templates/NOTES.txt
@@ -1,10 +1,43 @@
 Thank you for installing {{ .Chart.Name }}. Your release is named: {{ .Release.Name }}.
+It may take several minutes for your deployment to start up.
 
-It may take several minutes for your deployment to start up. 
+{{- if .Values.useNodePortForMaster }}
+
+You have configured Determined to deploy the master service with NodePort. To make the
+Determined master accessible from outside the cluster you will likely need to configure
+an Ingress for: determined-master-service-{{ .Release.Name }}.
+
+To have Determined configure an externally accessible load balancer for the
+maser, please set "Values.useNodePortForMaster" to false.
+{{ else }}
+
 Once it is up you can get the IP address of your deployment by running:
 
-kubectl get service determined-master-service-{{ .Release.Name }} -n {{ .Release.Namespace}} --output jsonpath='{.status.loadBalancer.ingress[0].ip}'
+kubectl get service determined-master-service-{{ .Release.Name }} -n {{ .Release.Namespace }} --output jsonpath='{.status.loadBalancer.ingress[0].ip}'
 
-Once you have the IP address set the master address with `export DET_MASTER=<ip address>`.
+{{ end -}}
+
+{{ $httpOrHttps := "http" }}
+{{- if .Values.tlsSecret }}
+{{ $httpOrHttps = "https" }}
+{{- if eq ($.Values.masterPort | toString) "8080" }}
+ERROR: TLS termination is configured in the master but .Values.masterPort is set to 8080.
+If you wish to perform TLS termination in the master please set .Values.masterPort to a
+different value (e.g., 8443).
+{{ end -}}
+
+{{ $secret := (lookup "v1" "Secret" .Release.Namespace (.Values.tlsSecret | toString) ) }}
+{{- if eq (len $secret) 0 }}
+ERROR: Secret {{ .Values.tlsSecret }} does not exist in namespace: {{ .Release.Namespace }}. Please update ".Values.tlsSecret".
+{{ end }}
+{{- else }}
+{{- if eq ($.Values.masterPort | toString) "8443" }}
+ERROR: TLS termination is not configured but the  .Values.masterPort is set to 8443.
+If you do not with perform TLS termination in the master please set .Values.masterPort
+to a different value (e.g., 8080).
+{{ end }}
+{{ end -}}
+
+Once you have the IP address, configure master address locally by running: `export DET_MASTER=<ip address>:{{ .Values.masterPort }}`.
 To submit experiments please install the Determined CLI locally: `pip install determined-cli`.
-To access the WebUI go to: http://<ip address>:{{ .Values.httpPort }}.
+To access the WebUI go to: {{ $httpOrHttps }}://<ip address>:{{ .Values.masterPort }}.

--- a/helm/charts/determined/templates/NOTES.txt
+++ b/helm/charts/determined/templates/NOTES.txt
@@ -19,23 +19,11 @@ kubectl get service determined-master-service-{{ .Release.Name }} -n {{ .Release
 
 {{ $httpOrHttps := "http" }}
 {{- if .Values.tlsSecret }}
-{{ $httpOrHttps = "https" }}
-{{- if eq ($.Values.masterPort | toString) "8080" }}
-ERROR: TLS termination is configured in the master but .Values.masterPort is set to 8080.
-If you wish to perform TLS termination in the master please set .Values.masterPort to a
-different value (e.g., 8443).
-{{ end -}}
-
-{{ $secret := (lookup "v1" "Secret" .Release.Namespace (.Values.tlsSecret | toString) ) }}
-{{- if eq (len $secret) 0 }}
+  {{ $httpOrHttps = "https" }}
+  {{ $secret := (lookup "v1" "Secret" .Release.Namespace (.Values.tlsSecret | toString) ) }}
+  {{- if eq (len $secret) 0 }}
 ERROR: Secret {{ .Values.tlsSecret }} does not exist in namespace: {{ .Release.Namespace }}. Please update ".Values.tlsSecret".
-{{ end }}
-{{- else }}
-{{- if eq ($.Values.masterPort | toString) "8443" }}
-ERROR: TLS termination is not configured but the  .Values.masterPort is set to 8443.
-If you do not with perform TLS termination in the master please set .Values.masterPort
-to a different value (e.g., 8080).
-{{ end }}
+  {{ end }}
 {{ end -}}
 
 Once you have the IP address, configure master address locally by running: `export DET_MASTER=<ip address>:{{ .Values.masterPort }}`.

--- a/helm/charts/determined/templates/NOTES.txt
+++ b/helm/charts/determined/templates/NOTES.txt
@@ -3,7 +3,7 @@ It may take several minutes for your deployment to start up.
 
 {{- if .Values.useNodePortForMaster }}
 
-You have configured Determined to deploy the master service with NodePort. To make the
+You have configured Determined to deploy the master with a NodePort service. To make the
 Determined master accessible from outside the cluster you will likely need to configure
 an Ingress for: determined-master-service-{{ .Release.Name }}.
 

--- a/helm/charts/determined/templates/_helpers.tpl
+++ b/helm/charts/determined/templates/_helpers.tpl
@@ -1,0 +1,7 @@
+{{- define "determined.secretPath" -}}
+/mount/determined/secrets/
+{{- end -}}
+
+{{- define "determined.masterPort" -}}
+8081
+{{- end -}}

--- a/helm/charts/determined/templates/master-config.yaml
+++ b/helm/charts/determined/templates/master-config.yaml
@@ -38,10 +38,10 @@ data:
     {{- if .Values.tlsSecret }}
     security:
       tls:
-        cert: {{- include "determined.secretPath" . | indent 1 -}}tls.crt
-        key: {{- include "determined.secretPath" . | indent 1 -}}tls.key
+        cert: {{ include "determined.secretPath" . }}tls.crt
+        key: {{ include "determined.secretPath" . }}tls.key
     {{ end }}
-    port: {{- include "determined.masterPort" . | indent 1 }}
+    port: {{ include "determined.masterPort" . }}
 
     scheduler:
       resource_provider:

--- a/helm/charts/determined/templates/master-config.yaml
+++ b/helm/charts/determined/templates/master-config.yaml
@@ -36,14 +36,13 @@ data:
       name: {{ .Values.db.name | quote }}
 
     {{- if .Values.tlsSecret }}
-    https_port: {{ required "A valid Values.masterPort entry required!" .Values.masterPort }}
     security:
       tls:
         cert: /mount/determined/secrets/tls.crt
         key: /mount/determined/secrets/tls.key
-    {{ else }}
-    http_port: {{ required "A valid Values.masterPort entry required!" .Values.masterPort }}
-    {{- end }}
+    {{ end }}
+    http_port: 8080
+    https_port: 8443
 
     scheduler:
       resource_provider:

--- a/helm/charts/determined/templates/master-config.yaml
+++ b/helm/charts/determined/templates/master-config.yaml
@@ -38,11 +38,10 @@ data:
     {{- if .Values.tlsSecret }}
     security:
       tls:
-        cert: /mount/determined/secrets/tls.crt
-        key: /mount/determined/secrets/tls.key
+        cert: {{- include "determined.secretPath" . | indent 1 -}}tls.crt
+        key: {{- include "determined.secretPath" . | indent 1 -}}tls.key
     {{ end }}
-    http_port: 8080
-    https_port: 8443
+    port: {{- include "determined.masterPort" . | indent 1 }}
 
     scheduler:
       resource_provider:

--- a/helm/charts/determined/templates/master-config.yaml
+++ b/helm/charts/determined/templates/master-config.yaml
@@ -35,7 +35,15 @@ data:
       port: {{ .Values.db.port }}
       name: {{ .Values.db.name | quote }}
 
-    http_port: {{ .Values.httpPort }}
+    {{- if .Values.tlsSecret }}
+    https_port: {{ required "A valid Values.masterPort entry required!" .Values.masterPort }}
+    security:
+      tls:
+        cert: /mount/determined/secrets/tls.crt
+        key: /mount/determined/secrets/tls.key
+    {{ else }}
+    http_port: {{ required "A valid Values.masterPort entry required!" .Values.masterPort }}
+    {{- end }}
 
     scheduler:
       resource_provider:

--- a/helm/charts/determined/templates/master-deployment.yaml
+++ b/helm/charts/determined/templates/master-deployment.yaml
@@ -45,7 +45,7 @@ spec:
             readOnly: true
           {{- if .Values.tlsSecret }}
           - name: tls-secret
-            mountPath: /mount/determined/secrets/
+            mountPath: {{- include "determined.secretPath" . | indent 1 }}
             readOnly: true
           {{ end }}
         resources:

--- a/helm/charts/determined/templates/master-deployment.yaml
+++ b/helm/charts/determined/templates/master-deployment.yaml
@@ -45,7 +45,7 @@ spec:
             readOnly: true
           {{- if .Values.tlsSecret }}
           - name: tls-secret
-            mountPath: {{- include "determined.secretPath" . | indent 1 }}
+            mountPath: {{ include "determined.secretPath" . }}
             readOnly: true
           {{ end }}
         resources:

--- a/helm/charts/determined/templates/master-deployment.yaml
+++ b/helm/charts/determined/templates/master-deployment.yaml
@@ -43,6 +43,11 @@ spec:
           - name: master-config
             mountPath: /etc/determined/
             readOnly: true
+          {{- if .Values.tlsSecret }}
+          - name: tls-secret
+            mountPath: /mount/determined/secrets/
+            readOnly: true
+          {{ end }}
         resources:
           requests:
             {{- if .Values.masterCpuRequest }}
@@ -59,3 +64,8 @@ spec:
         - name: master-config
           configMap:
             name: determined-master-config-{{ .Release.Name }}
+        {{- if .Values.tlsSecret }}
+        - name: tls-secret
+          secret:
+            secretName: {{ .Values.tlsSecret }}
+        {{ end }}

--- a/helm/charts/determined/templates/master-service.yaml
+++ b/helm/charts/determined/templates/master-service.yaml
@@ -11,10 +11,6 @@ spec:
   - port: {{ required "A valid Values.masterPort entry required!" .Values.masterPort }}
     targetPort: {{- include "determined.masterPort" . | indent 1 }}
     protocol: TCP
-  {{ $serviceType := "LoadBalancer" }}
-  {{- if .Values.useNodePortForMaster | default false -}}
-    {{ $serviceType = "NodePort" }}
-  {{- end }}
-  type: {{ $serviceType }}
+  type: {{ if (.Values.useNodePortForMaster | default false) }}NodePort{{ else }}LoadBalancer{{ end }}
   selector:
     app: determined-master-{{ .Release.Name }}

--- a/helm/charts/determined/templates/master-service.yaml
+++ b/helm/charts/determined/templates/master-service.yaml
@@ -9,6 +9,11 @@ metadata:
 spec:
   ports:
   - port: {{ required "A valid Values.masterPort entry required!" .Values.masterPort }}
+    {{ $targetPort := 8080 }}
+    {{- if .Values.tlsSecret -}}
+      {{ $targetPort = 8443 }}
+    {{- end }}
+    targetPort: {{ $targetPort }}
     protocol: TCP
   {{ $serviceType := "LoadBalancer" }}
   {{- if .Values.useNodePortForMaster | default false -}}

--- a/helm/charts/determined/templates/master-service.yaml
+++ b/helm/charts/determined/templates/master-service.yaml
@@ -9,11 +9,7 @@ metadata:
 spec:
   ports:
   - port: {{ required "A valid Values.masterPort entry required!" .Values.masterPort }}
-    {{ $targetPort := 8080 }}
-    {{- if .Values.tlsSecret -}}
-      {{ $targetPort = 8443 }}
-    {{- end }}
-    targetPort: {{ $targetPort }}
+    targetPort: {{- include "determined.masterPort" . | indent 1 }}
     protocol: TCP
   {{ $serviceType := "LoadBalancer" }}
   {{- if .Values.useNodePortForMaster | default false -}}

--- a/helm/charts/determined/templates/master-service.yaml
+++ b/helm/charts/determined/templates/master-service.yaml
@@ -10,6 +10,10 @@ spec:
   ports:
   - port: {{ .Values.httpPort | default 8080 }}
     protocol: TCP
-  type: LoadBalancer
+  {{ $serviceType := "LoadBalancer" }}
+  {{- if .Values.useNodePortForMaster | default false -}}
+    {{ $serviceType = "NodePort" }}
+  {{- end }}
+  type: {{ $serviceType }}
   selector:
     app: determined-master-{{ .Release.Name }}

--- a/helm/charts/determined/templates/master-service.yaml
+++ b/helm/charts/determined/templates/master-service.yaml
@@ -8,7 +8,7 @@ metadata:
     release: {{ .Release.Name }}
 spec:
   ports:
-  - port: {{ .Values.httpPort | default 8080 }}
+  - port: {{ required "A valid Values.masterPort entry required!" .Values.masterPort }}
     protocol: TCP
   {{ $serviceType := "LoadBalancer" }}
   {{- if .Values.useNodePortForMaster | default false -}}

--- a/helm/charts/determined/values.yaml
+++ b/helm/charts/determined/values.yaml
@@ -1,13 +1,21 @@
-# httpPort configures the port at which the Determined master listens for connections on.
-httpPort: 8080
+# masterPort configures the port at which the Determined master listens for connections on.
+masterPort: 8080
 
 # When useNodePortForMaster is set to false (default), a LoadBalancer service is deployed
 # to make the Determined master reachable from outside the cluster. When useNodePortForMaster
 # is set to true, the master will instead be exposed behind a NodePort service. When using a
-# NodePort service, users will typically have to configure an Ingress to make the Determined
+# NodePort service users will typically have to configure an Ingress to make the Determined
 # master reachable from outside the cluster. NodePort service is recommended when configuring
 # TLS termination in a load-balancer.
 useNodePortForMaster: false
+
+# tlsSecret enables TLS encryption for all communication with the Determined master (TLS
+# termination is performed in the Determined master). This includes communication between
+# the Determined master and the task containers it launches, but does not include communication
+# between the task containers (distributed training). The specified Secret of type tls must
+# already exist in the same namespace in which Determined is being installed. If a tlsSecret
+# is specified, masterPort can not be set to 8080 (8443 recommended).
+# tlsSecret:
 
 # db sets the configurations for the database.
 db:

--- a/helm/charts/determined/values.yaml
+++ b/helm/charts/determined/values.yaml
@@ -9,7 +9,7 @@ masterPort: 8080
 # TLS termination in a load-balancer.
 useNodePortForMaster: false
 
-# tlsSecret enables TLS encryption for all communication with the Determined master (TLS
+# tlsSecret enables TLS encryption for all communication made to the Determined master (TLS
 # termination is performed in the Determined master). This includes communication between
 # the Determined master and the task containers it launches, but does not include communication
 # between the task containers (distributed training). The specified Secret of type tls must

--- a/helm/charts/determined/values.yaml
+++ b/helm/charts/determined/values.yaml
@@ -13,8 +13,7 @@ useNodePortForMaster: false
 # termination is performed in the Determined master). This includes communication between
 # the Determined master and the task containers it launches, but does not include communication
 # between the task containers (distributed training). The specified Secret of type tls must
-# already exist in the same namespace in which Determined is being installed. If a tlsSecret
-# is specified, masterPort can not be set to 8080 (8443 recommended).
+# already exist in the same namespace in which Determined is being installed.
 # tlsSecret:
 
 # db sets the configurations for the database.

--- a/helm/charts/determined/values.yaml
+++ b/helm/charts/determined/values.yaml
@@ -1,5 +1,13 @@
 # httpPort configures the port at which the Determined master listens for connections on.
-httpPort: 8080 
+httpPort: 8080
+
+# When useNodePortForMaster is set to false (default), a LoadBalancer service is deployed
+# to make the Determined master reachable from outside the cluster. When useNodePortForMaster
+# is set to true, the master will instead be exposed behind a NodePort service. When using a
+# NodePort service, users will typically have to configure an Ingress to make the Determined
+# master reachable from outside the cluster. NodePort service is recommended when configuring
+# TLS termination in a load-balancer.
+useNodePortForMaster: false
 
 # db sets the configurations for the database.
 db:


### PR DESCRIPTION
## Description
Added support for configuring TLS to terminate inside a load-balancer or inside the Determined
master. 

## Test Plan
Deployed both methods on a running k8 cluster and confirmed that TLS encryption worked 
(with certificates signed by LetsEncrypt). 