### PR TITLE
feat: allow dynamic agents to use TLS to connect to the master [DET-3988]

### DIFF
--- a/master/internal/core.go
+++ b/master/internal/core.go
@@ -364,7 +364,7 @@ func (m *Master) Run() error {
 	authFuncs := []echo.MiddlewareFunc{userService.ProcessAuthentication}
 
 	var p *provisioner.Provisioner
-	p, m.provisioner, err = provisioner.Setup(m.system, m.config.Provisioner)
+	p, m.provisioner, err = provisioner.Setup(m.system, m.config.Provisioner, cert)
 	if err != nil {
 		return err
 	}

--- a/master/internal/provisioner/agent_setup.go
+++ b/master/internal/provisioner/agent_setup.go
@@ -12,6 +12,7 @@ type agentSetupScriptConfig struct {
 	MasterPort                   string
 	StartupScriptBase64          string
 	ContainerStartupScriptBase64 string
+	MasterCertBase64             string
 	AgentDockerRuntime           string
 	AgentNetwork                 string
 	AgentDockerImage             string

--- a/master/internal/provisioner/agent_setup_test.go
+++ b/master/internal/provisioner/agent_setup_test.go
@@ -15,11 +15,13 @@ func TestAgentSetupScript(t *testing.T) {
 
 	encodedScript := base64.StdEncoding.EncodeToString([]byte("sleep 5\n echo \"hello world\""))
 	encodedContainerScript := base64.StdEncoding.EncodeToString([]byte("sleep"))
+	encodedMasterCert := base64.StdEncoding.EncodeToString([]byte("==== cert ===="))
 	conf := agentSetupScriptConfig{
 		MasterHost:                   "test.master",
 		MasterPort:                   "8080",
 		StartupScriptBase64:          encodedScript,
 		ContainerStartupScriptBase64: encodedContainerScript,
+		MasterCertBase64:             encodedMasterCert,
 		AgentDockerImage:             "test_docker_image",
 		AgentDockerRuntime:           "runc",
 		AgentNetwork:                 "default",
@@ -29,6 +31,8 @@ func TestAgentSetupScript(t *testing.T) {
 	// nolint
 	expected := `#!/bin/bash
 
+docker_args=()
+
 mkdir -p /usr/local/determined
 echo c2xlZXAgNQogZWNobyAiaGVsbG8gd29ybGQi | base64 --decode > /usr/local/determined/startup_script
 echo "#### PRINTING STARTUP SCRIPT START ####"
@@ -36,6 +40,17 @@ cat /usr/local/determined/startup_script
 echo "#### PRINTING STARTUP SCRIPT END ####"
 chmod +x /usr/local/determined/startup_script
 /usr/local/determined/startup_script
+
+cert_b64=PT09PSBjZXJ0ID09PT0=
+if [ -n "$cert_b64" ]; then
+    echo "$cert_b64" | base64 --decode > /usr/local/determined/master.crt
+    echo "#### PRINTING MASTER CERT START ####"
+    cat /usr/local/determined/master.crt
+    echo "#### PRINTING MASTER CERT END ####"
+    docker_args+=(-v /usr/local/determined/master.crt:/usr/local/determined/master.crt)
+    docker_args+=(-e DET_SECURITY_TLS_ENABLED=true)
+    docker_args+=(-e DET_SECURITY_TLS_MASTER_CERT=/usr/local/determined/master.crt)
+fi
 
 echo c2xlZXA= | base64 --decode > /usr/local/determined/container_startup_script
 echo "#### PRINTING CONTAINER STARTUP SCRIPT START ####"
@@ -48,6 +63,7 @@ docker run --init --name determined-agent  --restart always --network default --
     -e DET_MASTER_PORT="8080" \
     -v /var/run/docker.sock:/var/run/docker.sock \
     -v /usr/local/determined/container_startup_script:/usr/local/determined/container_startup_script \
+    "${docker_args[@]}" \
     "test_docker_image"
 `
 

--- a/master/internal/provisioner/api.go
+++ b/master/internal/provisioner/api.go
@@ -1,6 +1,8 @@
 package provisioner
 
 import (
+	"crypto/tls"
+
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 
@@ -8,7 +10,11 @@ import (
 )
 
 // Setup initializes and registers the actor for the provisioner.
-func Setup(system *actor.System, config *Config) (*Provisioner, *actor.Ref, error) {
+func Setup(
+	system *actor.System,
+	config *Config,
+	cert *tls.Certificate,
+) (*Provisioner, *actor.Ref, error) {
 	if config == nil {
 		log.Info("cannot find provisioner configuration, disabling provisioner")
 		return nil, nil, nil
@@ -20,7 +26,7 @@ func Setup(system *actor.System, config *Config) (*Provisioner, *actor.Ref, erro
 	if config.GCP != nil {
 		log.Info("connecting to GCP")
 	}
-	provisioner, err := New(config)
+	provisioner, err := New(config, cert)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "error creating provisioner")
 	}

--- a/master/internal/provisioner/aws_test.go
+++ b/master/internal/provisioner/aws_test.go
@@ -39,7 +39,7 @@ func TestAWSRequestWorkflowCloud(t *testing.T) {
 	err := check.Validate(config)
 	assert.NilError(t, err)
 
-	cluster, err := newAWSCluster(config)
+	cluster, err := newAWSCluster(config, nil)
 	assert.NilError(t, err)
 	err = cluster.dryRunRequests()
 	assert.NilError(t, err)

--- a/master/internal/provisioner/provisioner.go
+++ b/master/internal/provisioner/provisioner.go
@@ -1,6 +1,7 @@
 package provisioner
 
 import (
+	"crypto/tls"
 	"time"
 
 	"github.com/pkg/errors"
@@ -12,6 +13,7 @@ import (
 
 const (
 	actionCooldown = 5 * time.Second
+	secureScheme   = "https"
 )
 
 // provisionerTick periodically triggers the provisioner to act.
@@ -43,7 +45,7 @@ type provider interface {
 }
 
 // New creates a new Provisioner.
-func New(config *Config) (*Provisioner, error) {
+func New(config *Config, cert *tls.Certificate) (*Provisioner, error) {
 	if err := config.initMasterAddress(); err != nil {
 		return nil, err
 	}
@@ -51,12 +53,12 @@ func New(config *Config) (*Provisioner, error) {
 	switch {
 	case config.AWS != nil:
 		var err error
-		if cluster, err = newAWSCluster(config); err != nil {
+		if cluster, err = newAWSCluster(config, cert); err != nil {
 			return nil, errors.Wrap(err, "cannot create an EC2 cluster")
 		}
 	case config.GCP != nil:
 		var err error
-		if cluster, err = newGCPCluster(config); err != nil {
+		if cluster, err = newGCPCluster(config, cert); err != nil {
 			return nil, errors.Wrap(err, "cannot create a GCP cluster")
 		}
 	}

--- a/master/static/srv/agent_setup_script.sh.template
+++ b/master/static/srv/agent_setup_script.sh.template
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+docker_args=()
+
 mkdir -p /usr/local/determined
 echo {{.StartupScriptBase64}} | base64 --decode > /usr/local/determined/startup_script
 echo "#### PRINTING STARTUP SCRIPT START ####"
@@ -7,6 +9,17 @@ cat /usr/local/determined/startup_script
 echo "#### PRINTING STARTUP SCRIPT END ####"
 chmod +x /usr/local/determined/startup_script
 /usr/local/determined/startup_script
+
+cert_b64={{.MasterCertBase64}}
+if [ -n "$cert_b64" ]; then
+    echo "$cert_b64" | base64 --decode > /usr/local/determined/master.crt
+    echo "#### PRINTING MASTER CERT START ####"
+    cat /usr/local/determined/master.crt
+    echo "#### PRINTING MASTER CERT END ####"
+    docker_args+=(-v /usr/local/determined/master.crt:/usr/local/determined/master.crt)
+    docker_args+=(-e DET_SECURITY_TLS_ENABLED=true)
+    docker_args+=(-e DET_SECURITY_TLS_MASTER_CERT=/usr/local/determined/master.crt)
+fi
 
 echo {{.ContainerStartupScriptBase64}} | base64 --decode > /usr/local/determined/container_startup_script
 echo "#### PRINTING CONTAINER STARTUP SCRIPT START ####"
@@ -19,4 +32,5 @@ docker run --init --name determined-agent {{.LogOptions}} --restart always --net
     -e DET_MASTER_PORT="{{.MasterPort}}" \
     -v /var/run/docker.sock:/var/run/docker.sock \
     -v /usr/local/determined/container_startup_script:/usr/local/determined/container_startup_script \
+    "${docker_args[@]}" \
     "{{.AgentDockerImage}}"


### PR DESCRIPTION
## Description

This adds logic to encode the master cert, when configured, into the
dynamic agents startup script, allowing agents and trials to connect
back to the master over TLS.

## Test Plan

- [x] set up masters using TLS in AWS and GCP and confirm that connections from dynamic agents over TLS work

## Commentary

~~It feels a little odd to add the cert into the provisioner config, but I thought it was less awkward than passing it around as a separate argument in a bunch of places. I could be convinced otherwise, though.~~ Changed on request.