### PR TITLE
feat: allow the master to do everything over just one port [DET-3949]

### DIFF
--- a/docs/how-to/installation/network-requirements.txt
+++ b/docs/how-to/installation/network-requirements.txt
@@ -55,10 +55,10 @@ Master
 
 The Determined master needs the following network access:
 
--  Inbound TCP to the master's HTTP and/or HTTPS ports from the
-   Determined agent instances, as well as all machines where developers
-   want to use the Determined CLI. The default HTTP port is ``8080``. If
-   HTTPS is enabled, the default HTTPS port is ``8443``.
+-  Inbound TCP to the master's network port from the Determined agent
+   instances, as well as all machines where developers want to use the
+   Determined CLI or WebUI. The default port is ``8443`` if TLS is
+   enabled and ``8080`` if not.
 
 -  Outbound TCP to all ports on the Determined agents.
 
@@ -69,8 +69,8 @@ Determined agents need the following network access:
 
 -  Inbound TCP from all ports on the master to all ports on the agent.
 
--  Outbound TCP from all ports on the agent to the master's HTTP port
-   (``8080`` by default).
+-  Outbound TCP from all ports on the agent to the master's network
+   port.
 
 -  Inbound and outbound TCP on all ports to and from each Determined
    agent.

--- a/docs/reference/cluster-config.txt
+++ b/docs/reference/cluster-config.txt
@@ -87,19 +87,19 @@ Master Port
 ===========
 
 By default, the master listens on TCP port 8080. This can be configured
-via the ``http_port`` option.
+via the ``port`` option.
 
 .. _security:
 
 Security
 ========
 
-The master is capable of serving over HTTPS in addition to HTTP. Doing
-so requires a TLS private key and certificate; to configure them, set
+The master can secure all incoming connections using `TLS
+<https://en.wikipedia.org/wiki/Transport_Layer_Security>`__. That
+ability requires a TLS private key and certificate to be provided; set
 the options ``security.tls.cert`` and ``security.tls.key`` to paths to a
-PEM-encoded TLS certificate and private key, respectively. The
-``https_port`` option determines the HTTPS listening port (default
-8443).
+PEM-encoded TLS certificate and private key, respectively, to do so. If
+TLS is enabled, the default port becomes 8443 rather than 8080.
 
 .. _agent-network-proxy:
 
@@ -263,6 +263,9 @@ The master supports the following configuration settings:
 
          -  ``master_service_name``: The service account Determined uses
             to interact with the Kubernetes API.
+
+-  ``port``: The TCP port on which the master accepts all incoming
+   connections. Defaults to ``8080``.
 
 -  ``task_container_defaults``: Specifies Docker defaults for all task
    containers. A task represents a single schedulable unit, such as a
@@ -657,6 +660,14 @@ The master supports the following configuration settings:
    -  ``host``: The database host to use. (*Required*)
    -  ``port``: The database port to use. (*Required*)
    -  ``name``: The database name to use. (*Required*)
+
+-  ``security``: Specifies security-related configuration settings.
+
+   -  ``tls``: Specifies TLS-related configuration settings. TLS is
+      enabled if certificate and key files are both specified.
+
+      -  ``cert``: Certificate file to use for serving TLS.
+      -  ``key``: Key file to use for serving TLS.
 
 -  ``telemetry``: Specifies whether we collect and report anonymous
    information about the usage of Determined. See :ref:`telemetry` for

--- a/docs/release-notes/1320-one-port.txt
+++ b/docs/release-notes/1320-one-port.txt
@@ -1,0 +1,12 @@
+:orphan:
+
+**Improvements**
+
+-  Use one TCP port for all incoming connections to the master and use
+   TLS for all connections if configured.
+
+   -  **BREAKING CHANGE:** The ``http_port`` and ``https_port`` options
+      in the master configuration have been replaced by the single
+      ``port`` option. The ``security.http`` option is no longer
+      accepted; the master can no longer be configured to listen over
+      HTTP and HTTPS simultaneously.

--- a/master/cmd/determined-master/init.go
+++ b/master/cmd/determined-master/init.go
@@ -99,19 +99,13 @@ func registerConfig() {
 	registerString(flags, name("security", "default-task", "group"),
 		defaults.Security.DefaultTask.Group, "security default task group name")
 
-	registerBool(flags, name("security", "http"),
-		defaults.Security.HTTP, "set whether to serve insecurely over HTTP")
 	registerString(flags, name("security", "tls", "cert"),
 		defaults.Security.TLS.Cert, "TLS cert file")
 	registerString(flags, name("security", "tls", "key"),
 		defaults.Security.TLS.Key, "TLS key file")
 
-	registerInt(flags, name("grpc-port"),
-		defaults.GRPCPort, "GRPC server port")
-	registerInt(flags, name("http-port"),
-		defaults.HTTPPort, "HTTP server port")
-	registerInt(flags, name("https-port"),
-		defaults.HTTPSPort, "HTTPS server port")
+	registerInt(flags, name("port"),
+		defaults.Port, "server port")
 
 	registerString(flags, name("root"),
 		defaults.Root, "static file root directory")

--- a/master/cmd/determined-master/root.go
+++ b/master/cmd/determined-master/root.go
@@ -127,11 +127,25 @@ func getConfig(configMap map[string]interface{}) (*internal.Config, error) {
 		return nil, errors.Wrap(err, "cannot unmarshal configuration")
 	}
 
+	setDefaultPort(config)
+
 	if err = resolveConfigPaths(config); err != nil {
 		return nil, err
 	}
 
 	return config, nil
+}
+
+func setDefaultPort(config *internal.Config) {
+	if config.Port != 0 {
+		return
+	}
+
+	if config.Security.TLS.Enabled() {
+		config.Port = 8443
+	} else {
+		config.Port = 8080
+	}
 }
 
 func resolveConfigPaths(config *internal.Config) error {

--- a/master/cmd/determined-master/root_test.go
+++ b/master/cmd/determined-master/root_test.go
@@ -43,6 +43,7 @@ provisioner:
 	}
 	err := resolveConfigPaths(expected)
 	assert.NilError(t, err)
+	setDefaultPort(expected)
 	err = mergeConfigBytesIntoViper([]byte(raw))
 	assert.NilError(t, err)
 	config, err := getConfig(viper.AllSettings())

--- a/master/go.mod
+++ b/master/go.mod
@@ -37,6 +37,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/segmentio/backo-go v0.0.0-20200129164019-23eae7c10bd3 // indirect
 	github.com/sirupsen/logrus v1.6.0
+	github.com/soheilhy/cmux v0.1.4
 	github.com/spf13/cobra v1.0.0
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.7.0

--- a/master/go.sum
+++ b/master/go.sum
@@ -713,6 +713,7 @@ github.com/smartystreets/go-aws-auth v0.0.0-20180515143844-0c1422d1fdb9/go.mod h
 github.com/smartystreets/goconvey v1.6.4 h1:fv0U8FUIMPNf1L9lnHLvLhgicrIVChEkdzIKYqbNC9s=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 github.com/smartystreets/gunit v1.0.0/go.mod h1:qwPWnhz6pn0NnRBP++URONOVyNkPyr4SauJk4cUOwJs=
+github.com/soheilhy/cmux v0.1.4 h1:0HKaf1o97UwFjHH9o5XsHUOF+tqmdA7KEzXLpiyaw0E=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=
 github.com/sonatard/noctx v0.0.1 h1:VC1Qhl6Oxx9vvWo3UDgrGXYCeKCe3Wbw7qAWL6FrmTY=
 github.com/sonatard/noctx v0.0.1/go.mod h1:9D2D/EoULe8Yy2joDHJj7bv3sZoq9AaSb8B4lqBjiZI=


### PR DESCRIPTION
## Description

BREAKING CHANGE: The `http_port` and `https_port` options in the master
configuration have been replaced by the single `port` option. The
`security.http` option is no longer accepted; the master can no longer
be configured to listen over HTTP and HTTPS simultaneously.

Previously, the master could listen on up to three ports at the same
time: one each for HTTP, HTTPS, and gRPC. This streamlines everything to
always work through one port.

One part of that is disallowing the use of both TLS and non-TLS
connections at the same time. Another part is using a connection
multiplexing library to handle both HTTP and gRPC connections over the
same port.

(Conceivably, one could multiplex TLS and non-TLS connections too, but
we want to discourage that anyway for simplicity and security.)

## Test Plan

- [x] check that the right port is opened with TLS on and off and no port specified
- [x] check that the right port is opened with TLS on and off and a port specified
- [x] run some experiments and poke around in the WebUI with TLS on
- [x] run some queries in the Swagger UI with TLS on (to check the gRPC proxying)

## Commentary

This should wait for #1313 to avoid a regression in dynamic agents functionality.
