### PR TITLE
chore: replicate old client side hash in new api [DET-4211]

### DIFF
--- a/master/internal/api_auth.go
+++ b/master/internal/api_auth.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/sha512"
 	"fmt"
+
 	"github.com/determined-ai/determined/master/internal/db"
 	"github.com/determined-ai/determined/master/internal/grpc"
 	"github.com/determined-ai/determined/proto/pkg/apiv1"

--- a/master/internal/api_auth.go
+++ b/master/internal/api_auth.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/sha512"
 	"fmt"
-
 	"github.com/determined-ai/determined/master/internal/db"
 	"github.com/determined-ai/determined/master/internal/grpc"
 	"github.com/determined-ai/determined/proto/pkg/apiv1"
@@ -17,6 +16,9 @@ const clientSidePasswordSalt = "GubPEmmotfiK9TMD6Zdw" // #nosec G101
 // a password to password sync, it doesn't - so when we try to log in later, we get a weird,
 // unrecognizable sha512 hash from the frontend.
 func replicateClientSideSaltAndHash(password string) string {
+	if password == "" {
+		return password
+	}
 	sum := sha512.Sum512([]byte(clientSidePasswordSalt + password))
 	return fmt.Sprintf("%x", sum)
 }


### PR DESCRIPTION
## Description
This change replicates the old client side hash in the new api. This is mainly for backwards compatability; it would be remove entirely, but since the old passwords can't be migrated and it would be a painful migration to need to recreate all users, this just replicates it server side so we can remove it client side. This enables users up the new api to auth with it as expected, instead of needing to replicate the old client side hash on their passwords themselves, or being forced to use an sdk.
<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan
- [x] ensure auth with the new api works as expected
<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.
-->



<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234