### PR TITLE
fix: commands (TensorBoards, notebooks, etc.) should not be preempted [DET-4157]

### DIFF
--- a/master/internal/checkpoint_gc.go
+++ b/master/internal/checkpoint_gc.go
@@ -33,7 +33,8 @@ func (t *checkpointGCTask) Receive(ctx *actor.Context) error {
 			FittingRequirements: scheduler.FittingRequirements{
 				SingleAgent: true,
 			},
-			TaskActor: ctx.Self(),
+			TaskActor:      ctx.Self(),
+			NonPreemptible: true,
 		})
 
 	case scheduler.ResourcesAllocated:

--- a/master/internal/command/command.go
+++ b/master/internal/command/command.go
@@ -104,11 +104,11 @@ func (c *command) Receive(ctx *actor.Context) error {
 		c.proxy = ctx.Self().System().Get(actor.Addr("proxy"))
 
 		c.task = &scheduler.AllocateRequest{
-			ID:           c.taskID,
-			Name:         c.config.Description,
-			SlotsNeeded:  c.config.Resources.Slots,
-			Label:        c.config.Resources.AgentLabel,
-			CanTerminate: true,
+			ID:             c.taskID,
+			Name:           c.config.Description,
+			SlotsNeeded:    c.config.Resources.Slots,
+			Label:          c.config.Resources.AgentLabel,
+			NonPreemptible: true,
 			FittingRequirements: scheduler.FittingRequirements{
 				SingleAgent: true,
 			},

--- a/master/internal/command/command.go
+++ b/master/internal/command/command.go
@@ -120,7 +120,7 @@ func (c *command) Receive(ctx *actor.Context) error {
 	case actor.PostStop:
 		c.terminate(ctx)
 
-	case scheduler.ResourcesAllocated, scheduler.ReleaseResources:
+	case scheduler.ResourcesAllocated:
 		return c.receiveSchedulerMsg(ctx)
 
 	case getSummary:
@@ -297,9 +297,6 @@ func (c *command) receiveSchedulerMsg(ctx *actor.Context) error {
 		// TODO: Consider not storing the userFiles in memory at all.
 		c.userFiles = nil
 		c.additionalFiles = nil
-
-	case scheduler.ReleaseResources:
-		c.terminate(ctx)
 
 	default:
 		return actor.ErrUnexpectedMessage(ctx)

--- a/master/internal/scheduler/default_resource_provider_test.go
+++ b/master/internal/scheduler/default_resource_provider_test.go
@@ -118,11 +118,10 @@ func TestCleanUpTaskWhenTaskActorStopsWithError(t *testing.T) {
 
 	system.Ask(mockActor, AskSchedulerToAddTask{
 		task: AllocateRequest{
-			ID:           TaskID(uuid.New().String()),
-			Name:         "mock_task",
-			Group:        mockActor,
-			SlotsNeeded:  1,
-			CanTerminate: true,
+			ID:          TaskID(uuid.New().String()),
+			Name:        "mock_task",
+			Group:       mockActor,
+			SlotsNeeded: 1,
 		},
 	}).Get()
 	assert.Equal(t, c.taskList.len(), 1)
@@ -156,11 +155,10 @@ func TestCleanUpTaskWhenTaskActorPanics(t *testing.T) {
 
 	system.Ask(mockActor, AskSchedulerToAddTask{
 		task: AllocateRequest{
-			ID:           TaskID(uuid.New().String()),
-			Name:         "mock_task",
-			Group:        mockActor,
-			SlotsNeeded:  1,
-			CanTerminate: true,
+			ID:          TaskID(uuid.New().String()),
+			Name:        "mock_task",
+			Group:       mockActor,
+			SlotsNeeded: 1,
 		},
 	}).Get()
 
@@ -195,11 +193,10 @@ func TestCleanUpTaskWhenTaskActorStopsNormally(t *testing.T) {
 
 	system.Ask(mockActor, AskSchedulerToAddTask{
 		task: AllocateRequest{
-			ID:           TaskID(uuid.New().String()),
-			Name:         "mock_task",
-			Group:        mockActor,
-			SlotsNeeded:  1,
-			CanTerminate: true,
+			ID:          TaskID(uuid.New().String()),
+			Name:        "mock_task",
+			Group:       mockActor,
+			SlotsNeeded: 1,
 		},
 	}).Get()
 
@@ -232,11 +229,10 @@ func testWhenActorsStopOrTaskIsKilled(t *testing.T, r *rand.Rand) {
 
 	system.Ask(mockActor, AskSchedulerToAddTask{
 		task: AllocateRequest{
-			ID:           TaskID(uuid.New().String()),
-			Name:         "mock_task",
-			Group:        mockActor,
-			SlotsNeeded:  1,
-			CanTerminate: true,
+			ID:          TaskID(uuid.New().String()),
+			Name:        "mock_task",
+			Group:       mockActor,
+			SlotsNeeded: 1,
 		},
 	}).Get()
 

--- a/master/internal/scheduler/default_resource_provider_test.go
+++ b/master/internal/scheduler/default_resource_provider_test.go
@@ -81,13 +81,12 @@ func setupCluster(
 		label := system.Ask(handler, GetLabel{}).Get().(string)
 
 		d.addAllocatedTask(&AllocateRequest{
-			ID:           TaskID(handler.Address().String()),
-			Name:         handler.Address().Local(),
-			Group:        g,
-			TaskActor:    handler,
-			SlotsNeeded:  slots,
-			CanTerminate: true,
-			Label:        label,
+			ID:          TaskID(handler.Address().String()),
+			Name:        handler.Address().Local(),
+			Group:       g,
+			TaskActor:   handler,
+			SlotsNeeded: slots,
+			Label:       label,
 		}, nil)
 		_ = d.getOrCreateGroup(nil, g)
 		if resp := system.Ask(g, getMaxSlots{}); resp.Get() != nil {

--- a/master/internal/scheduler/fitting_methods_test.go
+++ b/master/internal/scheduler/fitting_methods_test.go
@@ -10,8 +10,8 @@ import (
 
 func consumeSlots(agent *agentState, consume int) *agentState {
 	req := &AllocateRequest{
-		SlotsNeeded:  consume,
-		CanTerminate: true,
+		SlotsNeeded:    consume,
+		NonPreemptible: false,
 	}
 	container := newContainer(req, agent, req.SlotsNeeded)
 	agent.allocateFreeDevices(req.SlotsNeeded, container.id)

--- a/master/internal/scheduler/scaling_test.go
+++ b/master/internal/scheduler/scaling_test.go
@@ -20,11 +20,10 @@ func addTask(
 	assert.Assert(t, created)
 
 	req := &AllocateRequest{
-		ID:           TaskID(taskID),
-		TaskActor:    ref,
-		Group:        ref,
-		SlotsNeeded:  slotsNeeded,
-		CanTerminate: true,
+		ID:          TaskID(taskID),
+		TaskActor:   ref,
+		Group:       ref,
+		SlotsNeeded: slotsNeeded,
 	}
 	taskList.AddTask(req)
 	setTaskAllocations(t, taskList, taskID, numAllocated)

--- a/master/internal/scheduler/scheduler_test.go
+++ b/master/internal/scheduler/scheduler_test.go
@@ -45,6 +45,7 @@ type mockTask struct {
 	label          string
 	group          *mockGroup
 	allocatedAgent *mockAgent
+	nonPreemptible bool
 }
 
 type (
@@ -194,10 +195,11 @@ func setupClusterStates(
 		groups[ref] = &group{handler: ref}
 
 		req := &AllocateRequest{
-			ID:          mockTask.id,
-			SlotsNeeded: mockTask.slotsNeeded,
-			Label:       mockTask.label,
-			TaskActor:   ref,
+			ID:             mockTask.id,
+			SlotsNeeded:    mockTask.slotsNeeded,
+			Label:          mockTask.label,
+			TaskActor:      ref,
+			NonPreemptible: mockTask.nonPreemptible,
 		}
 		if mockTask.group == nil {
 			req.Group = ref

--- a/master/internal/scheduler/task.go
+++ b/master/internal/scheduler/task.go
@@ -14,7 +14,7 @@ type (
 		Name                string
 		Group               *actor.Ref
 		SlotsNeeded         int
-		CanTerminate        bool
+		NonPreemptible      bool
 		Label               string
 		FittingRequirements FittingRequirements
 		TaskActor           *actor.Ref

--- a/master/internal/trial.go
+++ b/master/internal/trial.go
@@ -341,12 +341,12 @@ func (t *trial) Receive(ctx *actor.Context) error {
 			}
 
 			t.task = &scheduler.AllocateRequest{
-				ID:           scheduler.NewTaskID(),
-				Name:         name,
-				Group:        ctx.Self().Parent(),
-				SlotsNeeded:  slotsNeeded,
-				CanTerminate: true,
-				Label:        label,
+				ID:             scheduler.NewTaskID(),
+				Name:           name,
+				Group:          ctx.Self().Parent(),
+				SlotsNeeded:    slotsNeeded,
+				NonPreemptible: false,
+				Label:          label,
 				FittingRequirements: scheduler.FittingRequirements{
 					SingleAgent: false,
 				},


### PR DESCRIPTION
## Description

Commands (TensorBoards, Notebooks), being interactive, would cause more obvious disruption to an end-user if preempted. 

Implementing this requires changes in 2 aspects of the scheduler. First simply not sending the ReleaseResources message to such tasks (and closely related: commands will also ignore this unless something changes CanTerminate to true, and nothing does right now). Second, the scheduler will also take this into account when allocating slots so that a group cannot lose a slot it needs for non-preemptible tasks, so the system cannot oversubscribe itself.



## Test Plan

I've added unit tests that reproduced the original problem, including subtleties discovered during implementation. Some other unit tests needed to have CanTerminate added to their task definitions since it defaults to false, which triggers the new behavior.

## Commentary

This patch prevents these commands from being preempted using the existing CanTerminate flag. Because of Go's zero-value initialization, this means all tasks are now non-premptible by default. This feels backwards - I would actually prefer to replace this with a field call NonPreemptible (depending on how reviewers feel about it) and invert the logic. 

I also made garbage collection non-preemptible - I'm not sure if that's desirable or not.

## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.