### PR TITLE
fix: webui trial chart render metrics with same name [DET-4169]

### DIFF
--- a/docs/release-notes/1350-render-metrics-chart-with-same-same.txt
+++ b/docs/release-notes/1350-render-metrics-chart-with-same-same.txt
@@ -1,0 +1,5 @@
+:orphan:
+
+**BUG FIXES**
+
+- WebUI: Fix rendering metrics with the same name on the metric chart.

--- a/webui/react/src/pages/TrialDetails/TrialChart.tsx
+++ b/webui/react/src/pages/TrialDetails/TrialChart.tsx
@@ -44,26 +44,28 @@ const TrialChart: React.FC<Props> = ({
         const y = metric.type === MetricType.Validation ?
           validationSource[metric.name] : trainingSource[metric.name];
 
+        const metricKey = `${metric.type}_${metric.name}`;
+
         const text = [
           `Batches: ${x}`,
           `Metric Value: ${y}`,
         ].join('<br>');
 
         if (text && x && y) {
-          if (!dataMap[metric.name]) {
-            dataMap[metric.name] = {
+          if (!dataMap[metricKey]) {
+            dataMap[metricKey] = {
               hovertemplate: '%{text}<extra></extra>',
               mode: 'lines+markers',
-              name: metric.name,
+              name: `${metric.name} (${metric.type})`,
               text: [],
               type: 'scatter',
               x: [],
               y: [],
             };
           }
-          (dataMap[metric.name].text as string[]).push(text);
-          (dataMap[metric.name].x as number[]).push(x);
-          (dataMap[metric.name].y as number[]).push(y);
+          (dataMap[metricKey].text as string[]).push(text);
+          (dataMap[metricKey].x as number[]).push(x);
+          (dataMap[metricKey].y as number[]).push(y);
         }
       });
     });


### PR DESCRIPTION
## Description

Metrics with the same name were conflicting in charts.
Issue fixed by grouping metrics with "<type>_<name>".

![Schermata 2020-09-25 alle 17 22 57](https://user-images.githubusercontent.com/5413702/94285301-c7f03c80-ff53-11ea-9d71-67e4ef39e4a1.png)

![Schermata 2020-09-25 alle 17 23 01](https://user-images.githubusercontent.com/5413702/94285310-caeb2d00-ff53-11ea-87bf-fbb21d4993c3.png)


## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
