### PR TITLE
fix: webui tweak select for better layout [DET-4123]

### DIFF
--- a/docs/release-notes/1351-webui-select-improvements.txt
+++ b/docs/release-notes/1351-webui-select-improvements.txt
@@ -1,0 +1,5 @@
+:orphan:
+
+**BUG FIXES**
+
+- WebUI: Made several fixes to improve select appearence and user experience.

--- a/webui/react/src/components/MetricSelectFilter.tsx
+++ b/webui/react/src/components/MetricSelectFilter.tsx
@@ -64,10 +64,11 @@ const MetricSelectFilter: React.FC<Props> = ({ metricNames, multiple, onChange, 
 
   return <SelectFilter
     disableTags
+    dropdownMatchSelectWidth={400}
     label="Metrics"
     mode={multiple ? 'multiple' : undefined}
     showArrow
-    style={{ width: 320 }}
+    style={{ width: 150 }}
     value={metricValues}
     onDeselect={handleMetricDeselect}
     onSelect={handleMetricSelect}>

--- a/webui/react/src/components/StateSelectFilter.tsx
+++ b/webui/react/src/components/StateSelectFilter.tsx
@@ -55,7 +55,12 @@ const StateSelectFilter: React.FC<Props> = ({
   }, [ onChange ]);
 
   return (
-    <SelectFilter label="State" value={value} onSelect={handleSelect}>
+    <SelectFilter
+      dropdownMatchSelectWidth={150}
+      label="State"
+      value={value}
+      onSelect={handleSelect}
+    >
       <Option key={ALL_VALUE} value={ALL_VALUE}>All</Option>
       {options}
     </SelectFilter>

--- a/webui/react/src/components/UserSelectFilter.tsx
+++ b/webui/react/src/components/UserSelectFilter.tsx
@@ -48,7 +48,13 @@ const UserSelectFilter: React.FC<Props> = ({ onChange, value }: Props) => {
   }, [ auth.user, users.data ]);
 
   return (
-    <SelectFilter label="Users" value={value || ALL_VALUE} onSelect={handleSelect}>
+    <SelectFilter
+      dropdownMatchSelectWidth={200}
+      label="Users"
+      style={{ maxWidth: 200 }}
+      value={value || ALL_VALUE}
+      onSelect={handleSelect}
+    >
       {options}
     </SelectFilter>
   );

--- a/webui/react/src/pages/TrialDetails.tsx
+++ b/webui/react/src/pages/TrialDetails.tsx
@@ -413,8 +413,8 @@ If the problem persists please contact support.',
   const options = (
     <Space size="middle">
       <SelectFilter
+        dropdownMatchSelectWidth={300}
         label="Show"
-        style={{ width: 242 }}
         value={hasCheckpointOrValidation}
         onSelect={handleHasCheckpointOrValidationSelect}>
         <Option key={ALL_VALUE} value={ALL_VALUE}>All</Option>

--- a/webui/react/src/styles/antd.scss
+++ b/webui/react/src/styles/antd.scss
@@ -115,10 +115,10 @@ html {
     border-radius: var(--theme-sizes-border-radius);
     box-shadow: var(--theme-shadow);
   }
-  .ant-select-single:not(.ant-select-customize-input) .ant-select-selector {
+  .ant-select:not(.ant-select-customize-input) .ant-select-selector {
     border-radius: var(--theme-sizes-border-radius);
   }
-  .ant-select-focused.ant-select-single:not(.ant-select-customize-input) .ant-select-selector {
+  .ant-select-focused.ant-select:not(.ant-select-customize-input) .ant-select-selector {
     box-shadow: var(--theme-focus-shadow);
   }
 


### PR DESCRIPTION
## Description

I spent a bit of time playing with [Ant Select](https://ant.design/components/select/) config and I think those small tweaks will improve webui UX in those cases:

1. MetricSelectFilter:
    - made the input width smaller (no need for it to be larger since the text will always be "N selected"
    - dropdownMatchSelectWidth=400 will make the dropdown width be 400 pixel, and in case labels are longer, they won't overflow the screen.
![Schermata 2020-09-25 alle 17 54 21](https://user-images.githubusercontent.com/5413702/94288974-5c5c9e00-ff58-11ea-8ea1-4f4f9d184ce3.png)

2. StateSelectFilter:
    - dropdownMatchSelectWidth=150 will make the dropdown width be 150 pixel
![Schermata 2020-09-25 alle 17 58 23](https://user-images.githubusercontent.com/5413702/94289265-c412e900-ff58-11ea-9f9a-8725eaade0a3.png)

3. UserSelectFilter:
    - set a maxWidth=200 on the input element to prevent super long usernames to break the UI
    - set a dropdownMatchSelectWidth=200 to avoid having a dropdown too small (and names partially unreadable when a short username is selected - like "all").

(example of the missing maxwidth=200 bug)
![Schermata 2020-09-24 alle 17 30 37](https://user-images.githubusercontent.com/5413702/94289498-13f1b000-ff59-11ea-96a1-4c8c9fa10bd4.png)

(result)
![Schermata 2020-09-25 alle 18 01 16](https://user-images.githubusercontent.com/5413702/94289584-3257ab80-ff59-11ea-9b50-8a570fc513a1.png)

4. "Show" select on trial details:
    - no need to have a fixed width (removed width=242) that takes spaces in the UI if we set dropdownMatchSelectWidth=300 (that will cause the dropdown width to be 300px).
![Schermata 2020-09-25 alle 18 03 01](https://user-images.githubusercontent.com/5413702/94289756-7e0a5500-ff59-11ea-9acf-015db4392ee9.png)

NOTES:

1) Tweaked some CSS to make sure that both types of select (single and multiple) will have the same border-radius, before those 2 had a different border-radius:
![Schermata 2020-09-25 alle 18 04 42](https://user-images.githubusercontent.com/5413702/94289849-a1350480-ff59-11ea-82aa-548c3cdc27f8.png)

2) It looks like ant select avoids dropdown to go out of the browser window borders if the dropdownMatchSelectWidth is set to true or a number (but not when set to false, that's the default set on SelectFilter.tsx on line 37).


## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
