### PR TITLE
fix: filter det-deploy tests to master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1429,6 +1429,9 @@ workflows:
 
       - test-det-deploy:
           name: test-det-deploy-local
+          filters:
+            branches:
+              only: master
           requires:
             - package-and-push-system-local
           matrix:
@@ -1436,7 +1439,6 @@ workflows:
               parallelism: [2]
               mark: ["det_deploy_local"]
               det-version: [$CIRCLE_SHA1]
-
 
 
   nightly:


### PR DESCRIPTION
## Description
I accidentally merged the `det-deploy local` integration tests without addressing @rb-determined-ai 's comments about filtering the tests to only run on master.  Here is a fix for that.