### PR TITLE
fix: send credentials for streaming endpoints in dev environment [DET-4240]

### DIFF
--- a/master/internal/grpc/api.go
+++ b/master/internal/grpc/api.go
@@ -81,6 +81,7 @@ func RegisterHTTPProxy(e *echo.Echo, port int, enableCORS bool, cert *tls.Certif
 		request := c.Request()
 		if origin := request.Header.Get("Origin"); enableCORS && origin != "" {
 			c.Response().Header().Set("Access-Control-Allow-Origin", origin)
+			c.Response().Header().Set("Access-Control-Allow-Credentials", "true")
 		}
 		if c.Request().Header.Get("Authorization") == "" {
 			if cookie, err := c.Cookie(cookieName); err == nil {

--- a/proto/src/determined/api/v1/trial.proto
+++ b/proto/src/determined/api/v1/trial.proto
@@ -23,6 +23,11 @@ message TrialLogsRequest {
 }
 // Response to TrialLogsRequest.
 message TrialLogsResponse {
+    option (grpc.gateway.protoc_gen_swagger.options.openapiv2_schema) = {
+        json_schema: {
+            required: ["id", "message"]
+        }
+    };
     // The id of the trial log.
     int32 id = 1;
     // The log message.

--- a/proto/src/determined/log/v1/log.proto
+++ b/proto/src/determined/log/v1/log.proto
@@ -9,7 +9,7 @@ import "protoc-gen-swagger/options/annotations.proto";
 message LogEntry {
     option (grpc.gateway.protoc_gen_swagger.options.openapiv2_schema) = {
         json_schema: {
-            required: ["id", "message"]
+            required: ["id"]
         }
     };
     // The id of the log.

--- a/proto/src/determined/log/v1/log.proto
+++ b/proto/src/determined/log/v1/log.proto
@@ -9,7 +9,7 @@ import "protoc-gen-swagger/options/annotations.proto";
 message LogEntry {
     option (grpc.gateway.protoc_gen_swagger.options.openapiv2_schema) = {
         json_schema: {
-            required: ["id"]
+            required: ["id", "message"]
         }
     };
     // The id of the log.

--- a/webui/react/src/services/utils.ts
+++ b/webui/react/src/services/utils.ts
@@ -3,6 +3,7 @@ import axios, { AxiosResponse, CancelToken } from 'axios';
 import handleError, { DaError, ErrorLevel, ErrorType, isDaError } from 'ErrorHandler';
 import { serverAddress } from 'routes/utils';
 import * as Api from 'services/api-ts-sdk';
+import { isObject } from 'utils/data';
 
 import { HttpApi } from './types';
 
@@ -92,7 +93,15 @@ export const consumeStream = async <T = unknown>(
   onEvent: (event: T) => void,
 ): Promise<void> => {
   try {
-    const response = await fetch(serverAddress(true, fetchArgs.url), fetchArgs.options);
+    const options = isObject(fetchArgs.options) ? fetchArgs.options : {};
+
+    /*
+     * Default fetch credentials is set to `same-origin`, but we need to change it
+     * to `include` for local dev because the ports do not match up (3000 vs 8080).
+     */
+    if (process.env.IS_DEV) options.credentials = 'include';
+
+    const response = await fetch(serverAddress(true, fetchArgs.url), options);
     const reader = ndjsonStream(response.body).getReader();
     let result;
     while (!result || !result.done) {


### PR DESCRIPTION
## Description

Trial log streaming endpoint is now protected and [requires a token](https://github.com/determined-ai/determined/commit/6ad5d763e218df4aa1c687172136ce73c82bd467). Update WebUI to pass credentials over CORS under the DEV environment with `enable_cors` config enabled.

More specifically, the default fetch credentials is set to `same-origin`, but we need to change it to `include` for local dev because the ports do not match up (3000 vs 8080). On the API side, not only do we need to allow `Access-Control-Allow-Origin`, but we also need to enable `Access-Control-Allow-Credentials` to be set to `true` when fetch `credentials` is set to `include`.

[specifications around JS Native Fetch and `credentials` header setting](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch#:~:text=If%20you%20only%20want%20to,%3A%20'same%2Dorigin'%20.&text=To%20instead%20ensure%20browsers%20don,use%20credentials%3A%20'omit'%20.)

<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan

Check to make sure the webui trial logs loads fine on the local dev cluster.

<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234