### PR TITLE
fix: update model registry to new api

### DIFF
--- a/common/determined_common/experimental/model.py
+++ b/common/determined_common/experimental/model.py
@@ -110,7 +110,7 @@ class Model:
             resp = api.get(self._master, "/api/v1/models/{}/versions/{}".format(self.name, version))
 
         data = resp.json()
-        return Checkpoint.from_json(data["model_version"]["checkpoint"], self._master)
+        return Checkpoint.from_json(data["modelVersion"]["checkpoint"], self._master)
 
     def get_versions(self, order_by: ModelOrderBy = ModelOrderBy.DESC) -> List[Checkpoint]:
         """


### PR DESCRIPTION
## Description
Due to a holdover from the old API, the model registry did not allow users to specify a model version.  Fixed the typo to restore functionality here.


## Test Plan
Tested locally to validate the fix works.
