### PR TITLE
chore: add post experiment endpoint docs to Swagger UI

### DIFF
--- a/proto/scripts/swagger.py
+++ b/proto/scripts/swagger.py
@@ -1,6 +1,22 @@
 import json
 import os
 import sys
+import collections
+
+
+def merge_dict(d1, d2):
+    """
+    Modifies d1 in-place to contain values from d2.  If any value
+    in d1 is a dictionary (or dict-like), *and* the corresponding
+    value in d2 is also a dictionary, then merge them in-place.
+    """
+
+    for k, v2 in d2.items():
+        v1 = d1.get(k) # returns None if v1 has no value for this key
+        if (isinstance(v1, collections.Mapping) and isinstance(v2, collections.Mapping)):
+            merge_dict(v1, v2)
+        else:
+            d1[k] = v2
 
 
 def capitalize(s: str) -> str:
@@ -57,6 +73,10 @@ def clean(fn: str) -> None:
         # Clean up titles.
         if "title" not in value:
             value["title"] = "".join(capitalize(k) for k in key.split(sep="v1"))
+
+    with open("swagger-patch.json", "r") as diff_f:
+        diff = json.load(diff_f)
+        merge_dict(spec, diff)
 
     with open(fn, "w") as fp:
         json.dump(spec, fp)

--- a/proto/swagger-patch.json
+++ b/proto/swagger-patch.json
@@ -1,0 +1,134 @@
+{
+  "paths": {
+    "/api/v1/experiments": {
+      "post": {
+        "summary": "Post a new experiment. (Alias)",
+        "operationId": "Determined_PostExperiment",
+        "responses": {
+          "200": {
+            "description": "Created experiment.",
+            "schema": {
+              "$ref": "#/definitions/v1PostExperimentResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response",
+            "schema": {
+              "$ref": "#/definitions/runtimeError"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1PostExperimentRequest"
+            }
+          }
+
+        ],
+        "tags": [
+          "Experiments"
+        ]
+      }
+    }
+  },
+
+  "definitions": {
+    "v1PostExperimentRequest": {
+      "type": "object",
+      "properties": {
+        "validate_only": {
+          "type": "boolean",
+          "description": "Just validate the experiment."
+        },
+        "experiment_config": {
+          "type": "object",
+          "description": "The experiment config."
+        },
+        "model_definition": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/v1File"
+          },
+          "description": "Experiment context."
+        },
+        "parent_id": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Parent experiment ID."
+        }
+      },
+      "description": "Request to create a new experiment.",
+      "title": "GetExperimentResponse"
+    },
+
+    "v1File": {
+      "type": "object",
+      "properties": {
+        "path": {
+          "type": "string",
+          "description": "Path to the file and or directory."
+        },
+        "type": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "content": {
+          "type": "string",
+          "format": "byte",
+          "description": "base64 encoded file content."
+        },
+        "mtime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Last modified time"
+        },
+        "mode": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "uid": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "gid": {
+          "type": "integer",
+          "format": "int32"
+        }
+      },
+      "title": "File"
+    },
+
+    "v1PostExperimentResponse": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The requested experiment."
+        },
+        "labels": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Labels attached to the experiment."
+        },
+        "archived": {
+          "type": "boolean",
+          "format": "boolean",
+          "description": "Boolean denoting whether the experiment was archived."
+        },
+        "config": {
+          "type": "object",
+          "description": "The experiment config."
+        }
+      },
+      "description": "Response to GetExperimentRequest.",
+      "title": "GetExperimentResponse"
+    }
+  }
+}


### PR DESCRIPTION
## Description

post-experiment supports creating a new experiment, forking an existing experiment, or continuing a trial.

- add swagger.json spec file merging support.
- add specs for post-experiment endpoint.

<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234