### PR TITLE
chore: make Go tests and Python installs quieter

### DIFF
--- a/master/Makefile
+++ b/master/Makefile
@@ -30,7 +30,7 @@ fmt:
 
 .PHONY: test
 test:
-	go test -v -short -coverprofile=coverage.out -covermode count -cover ./...
+	go test -short -coverprofile=coverage.out -covermode count -cover ./...
 
 .PHONY: pre-package
 pre-package:

--- a/master/static/srv/entrypoint.sh
+++ b/master/static/srv/entrypoint.sh
@@ -18,7 +18,7 @@ if [ "$HOME" = "/" ] ; then
     export HOME
 fi
 
-python3.6 -m pip install --user /opt/determined/wheels/determined*.whl
+python3.6 -m pip install -q --user /opt/determined/wheels/determined*.whl
 
 cd ${WORKING_DIR} && test -f "${STARTUP_HOOK}" && source "${STARTUP_HOOK}"
 exec python3.6 -m determined.exec.harness "$@"

--- a/master/static/srv/gc-checkpoints-entrypoint.sh
+++ b/master/static/srv/gc-checkpoints-entrypoint.sh
@@ -4,6 +4,6 @@ set -e
 
 export PATH="/run/determined/pythonuserbase/bin:$PATH"
 
-python3.6 -m pip install --user /opt/determined/wheels/determined*.whl
+python3.6 -m pip install -q --user /opt/determined/wheels/determined*.whl
 
 exec python3.6 -m determined.exec.gc_checkpoints "$@"

--- a/master/static/srv/notebook-entrypoint.sh
+++ b/master/static/srv/notebook-entrypoint.sh
@@ -15,6 +15,6 @@ if [ "$HOME" = "/" ] ; then
     export HOME
 fi
 
-python3.6 -m pip install --user /opt/determined/wheels/determined*.whl
+python3.6 -m pip install -q --user /opt/determined/wheels/determined*.whl
 
 jupyter lab --config /run/determined/workdir/jupyter-conf.py --port=${NOTEBOOK_PORT}

--- a/master/static/srv/shell-entrypoint.sh
+++ b/master/static/srv/shell-entrypoint.sh
@@ -8,7 +8,7 @@ export PATH="/run/determined/pythonuserbase/bin:$PATH"
 # modified in this entrypoint because the HOME in the user's ssh session is set
 # by sshd at a later time.
 
-python3.6 -m pip install --user /opt/determined/wheels/determined*.whl
+python3.6 -m pip install -q --user /opt/determined/wheels/determined*.whl
 
 # Prepend each key in authorized_keys with a set of environment="KEY=VALUE"
 # options to inject the entire docker environment into the eventual ssh

--- a/master/static/srv/tensorboard-entrypoint.sh
+++ b/master/static/srv/tensorboard-entrypoint.sh
@@ -7,7 +7,7 @@ WORKING_DIR="/run/determined/workdir"
 STARTUP_HOOK="startup-hook.sh"
 export PATH="/run/determined/pythonuserbase/bin:$PATH"
 
-python3.6 -m pip install --user /opt/determined/wheels/determined*.whl
+python3.6 -m pip install -q --user /opt/determined/wheels/determined*.whl
 
 cd ${WORKING_DIR} && test -f "${STARTUP_HOOK}" && source "${STARTUP_HOOK}"
 


### PR DESCRIPTION
## Description

Both Go tests and Python package installations were printing out a bunch
of lines about successful things, which is noisy and unhelpful.

## Test Plan

- [x] run experiments/notebooks/shells/`make test-master` and see that they function as usual, except without printing out dozens of useless lines about requirements or successful tests

## Commentary (optional)

There are some other `pip install`s in various places (setting up in CI, the top-level `get-deps`, test Dockerfiles, some example startup hooks), but the output from those doesn't come up often in normal usage like it does for these things, so I'm inclined to let them be verbose.
