### PR TITLE
feat: allow yogadl to connect to the master over TLS

### DIFF
--- a/harness/setup.py
+++ b/harness/setup.py
@@ -27,7 +27,7 @@ setup(
         "pyzmq>=18.1.0",
         "requests>=2.20.0",
         "simplejson",
-        "yogadl==0.1.1",
+        "yogadl==0.1.2",
     ],
     extras_require={
         "tf-114-cuda100": ["tensorflow-gpu==1.14.0"],


### PR DESCRIPTION
## Description

This takes advantage of the new TLS option of yogadl to pass along the
received master TLS certificate, which removes the last known blocker to
running a cluster with the master serving entirely over TLS.

## Test Plan

- [x] run the experiment in `examples/data_layer/data_layer_mnist_estimator` with a `data_layer` config pointing to an S3 bucket

(Didn't test GCP, but the code paths are equivalent as far as the TLS configuration support is concerned.)

## Commentary (optional)

Blocked on https://github.com/determined-ai/yogadl/pull/26 (and a subsequent release and version bump).
