### PR TITLE
test: fix broken k8 test

### DIFF
--- a/e2e_tests/tests/experiment/test_pytorch.py
+++ b/e2e_tests/tests/experiment/test_pytorch.py
@@ -15,7 +15,12 @@ def test_pytorch_11_const(aggregation_frequency: int, using_k8s: bool) -> None:
         pod_spec = {
             "metadata": {"labels": {"ci": "testing"}},
             "spec": {
-                "containers": [{"volumeMounts": [{"name": "temp1", "mountPath": "/random"}]}],
+                "containers": [
+                    {
+                        "name": "determined-container",
+                        "volumeMounts": [{"name": "temp1", "mountPath": "/random"}],
+                    }
+                ],
                 "volumes": [{"name": "temp1", "emptyDir": {}}],
             },
         }


### PR DESCRIPTION
## Test Plan
Tested manually on a k8 cluster, checking tests that failed: https://app.circleci.com/pipelines/github/determined-ai/determined/6055/workflows/8f0e06a1-9ef8-4cca-b96b-335c67ea577a/jobs/158568
