### PR TITLE
feat: support AWS spot instances

### DIFF
--- a/agent/go.sum
+++ b/agent/go.sum
@@ -137,6 +137,7 @@ github.com/aws/aws-sdk-go v1.19.18/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpi
 github.com/aws/aws-sdk-go v1.20.6/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/aws/aws-sdk-go v1.31.13 h1:UeWMTRTL0XAKLR7vxDL4/u7KOtz/LtfJr+lXtxN4YEQ=
 github.com/aws/aws-sdk-go v1.31.13/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
+github.com/aws/aws-sdk-go v1.34.32/go.mod h1:H7NKnBqNVzoTJpGfLrQkkD+ytBA93eiDYi/+8rV9s48=
 github.com/aybabtme/rgbterm v0.0.0-20170906152045-cc83f3b3ce59/go.mod h1:q/89r3U2H7sSsE2t6Kca0lfwTK8JdoNGS/yzM/4iH5I=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
@@ -471,6 +472,8 @@ github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af h1:pmfjZENx5i
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jmespath/go-jmespath v0.3.0 h1:OS12ieG61fsCg5+qLJ+SsW9NicxNkg3b25OyT2yCeUc=
 github.com/jmespath/go-jmespath v0.3.0/go.mod h1:9QtRXoHjLGCJ5IBSaohpXITPlowMeeYCZ7fLUTSywik=
+github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
+github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
 github.com/jmoiron/sqlx v1.2.0/go.mod h1:1FEQNm3xlJgrMD+FBdI9+xvCksHtbpVBBw5dYhBSsks=
 github.com/jmoiron/sqlx v1.2.1-0.20190826204134-d7d95172beb5/go.mod h1:1FEQNm3xlJgrMD+FBdI9+xvCksHtbpVBBw5dYhBSsks=
 github.com/joho/godotenv v1.3.0/go.mod h1:7hK45KPybAkOC6peb+G5yklZfMxEjkZhHbwpqxOKXbg=

--- a/deploy/determined_deploy/aws/templates/efs.yaml
+++ b/deploy/determined_deploy/aws/templates/efs.yaml
@@ -445,6 +445,10 @@ Resources:
                   - ec2:TerminateInstances
                   - ec2:CreateTags
                   - ec2:RunInstances
+                  - ec2:DescribeSpotPriceHistory
+                  - ec2:CancelSpotInstanceRequests
+                  - ec2:RequestSpotInstances
+                  - ec2:DescribeSpotInstanceRequests
                 Resource: "*"
         - PolicyName: pass-role
           PolicyDocument:

--- a/deploy/determined_deploy/aws/templates/fsx.yaml
+++ b/deploy/determined_deploy/aws/templates/fsx.yaml
@@ -461,6 +461,10 @@ Resources:
                   - ec2:TerminateInstances
                   - ec2:CreateTags
                   - ec2:RunInstances
+                  - ec2:DescribeSpotPriceHistory
+                  - ec2:CancelSpotInstanceRequests
+                  - ec2:RequestSpotInstances
+                  - ec2:DescribeSpotInstanceRequests
                 Resource: "*"
         - PolicyName: pass-role
           PolicyDocument:

--- a/deploy/determined_deploy/aws/templates/secure.yaml
+++ b/deploy/determined_deploy/aws/templates/secure.yaml
@@ -504,6 +504,10 @@ Resources:
                   - ec2:TerminateInstances
                   - ec2:CreateTags
                   - ec2:RunInstances
+                  - ec2:DescribeSpotPriceHistory
+                  - ec2:CancelSpotInstanceRequests
+                  - ec2:RequestSpotInstances
+                  - ec2:DescribeSpotInstanceRequests
                 Resource: "*"
         - PolicyName: pass-role
           PolicyDocument:

--- a/deploy/determined_deploy/aws/templates/simple.yaml
+++ b/deploy/determined_deploy/aws/templates/simple.yaml
@@ -301,6 +301,10 @@ Resources:
                   - ec2:TerminateInstances
                   - ec2:CreateTags
                   - ec2:RunInstances
+                  - ec2:DescribeSpotPriceHistory
+                  - ec2:CancelSpotInstanceRequests
+                  - ec2:RequestSpotInstances
+                  - ec2:DescribeSpotInstanceRequests
                 Resource: "*"
         - PolicyName: pass-role
           PolicyDocument:

--- a/deploy/determined_deploy/aws/templates/vpc.yaml
+++ b/deploy/determined_deploy/aws/templates/vpc.yaml
@@ -406,6 +406,10 @@ Resources:
                   - ec2:TerminateInstances
                   - ec2:CreateTags
                   - ec2:RunInstances
+                  - ec2:DescribeSpotPriceHistory
+                  - ec2:CancelSpotInstanceRequests
+                  - ec2:RequestSpotInstances
+                  - ec2:DescribeSpotInstanceRequests
                 Resource: "*"
         - PolicyName: pass-role
           PolicyDocument:

--- a/docs/release-notes/1380-aws-spot.txt
+++ b/docs/release-notes/1380-aws-spot.txt
@@ -1,0 +1,8 @@
+:orphan:
+
+    **New Features**
+
+    - Add support for AWS spot instances.
+
+      - Add an option to the AWS provisioner that allows users to automatically use spot
+        instances for dynamic agents. The maximum spot price can optionally be set.

--- a/master/go.mod
+++ b/master/go.mod
@@ -4,7 +4,8 @@ require (
 	cloud.google.com/go v0.58.0
 	github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78 // indirect
 	github.com/Microsoft/go-winio v0.4.9 // indirect
-	github.com/aws/aws-sdk-go v1.31.13
+	github.com/apex/log v1.5.0
+	github.com/aws/aws-sdk-go v1.34.32
 	github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 // indirect
 	github.com/bufbuild/buf v0.16.0
 	github.com/containerd/containerd v1.3.2 // indirect

--- a/master/go.mod
+++ b/master/go.mod
@@ -4,7 +4,6 @@ require (
 	cloud.google.com/go v0.58.0
 	github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78 // indirect
 	github.com/Microsoft/go-winio v0.4.9 // indirect
-	github.com/apex/log v1.5.0
 	github.com/aws/aws-sdk-go v1.34.32
 	github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 // indirect
 	github.com/bufbuild/buf v0.16.0

--- a/master/go.sum
+++ b/master/go.sum
@@ -143,6 +143,8 @@ github.com/aws/aws-sdk-go v1.19.18/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpi
 github.com/aws/aws-sdk-go v1.20.6/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/aws/aws-sdk-go v1.31.13 h1:UeWMTRTL0XAKLR7vxDL4/u7KOtz/LtfJr+lXtxN4YEQ=
 github.com/aws/aws-sdk-go v1.31.13/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
+github.com/aws/aws-sdk-go v1.34.32 h1:EHjowHEGXyLHWhcO7M7AVA+oA2c8aLE9WfRvqHwxd3A=
+github.com/aws/aws-sdk-go v1.34.32/go.mod h1:H7NKnBqNVzoTJpGfLrQkkD+ytBA93eiDYi/+8rV9s48=
 github.com/aybabtme/rgbterm v0.0.0-20170906152045-cc83f3b3ce59/go.mod h1:q/89r3U2H7sSsE2t6Kca0lfwTK8JdoNGS/yzM/4iH5I=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
@@ -494,6 +496,9 @@ github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af h1:pmfjZENx5i
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jmespath/go-jmespath v0.3.0 h1:OS12ieG61fsCg5+qLJ+SsW9NicxNkg3b25OyT2yCeUc=
 github.com/jmespath/go-jmespath v0.3.0/go.mod h1:9QtRXoHjLGCJ5IBSaohpXITPlowMeeYCZ7fLUTSywik=
+github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
+github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
+github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
 github.com/jmoiron/sqlx v1.2.0/go.mod h1:1FEQNm3xlJgrMD+FBdI9+xvCksHtbpVBBw5dYhBSsks=
 github.com/jmoiron/sqlx v1.2.1-0.20190826204134-d7d95172beb5 h1:lrdPtrORjGv1HbbEvKWDUAy97mPpFm4B8hp77tcCUJY=
 github.com/jmoiron/sqlx v1.2.1-0.20190826204134-d7d95172beb5/go.mod h1:1FEQNm3xlJgrMD+FBdI9+xvCksHtbpVBBw5dYhBSsks=

--- a/master/internal/provisioner/aws.go
+++ b/master/internal/provisioner/aws.go
@@ -54,6 +54,7 @@ type awsCluster struct {
 
 	// Only used if spot instances are enabled
 	activeSpotRequests map[string]*spotRequest
+	spotLoopState *spotLoopState
 }
 
 func newAWSCluster(config *Config, cert *tls.Certificate) (*awsCluster, error) {
@@ -124,6 +125,7 @@ func newAWSCluster(config *Config, cert *tls.Certificate) (*awsCluster, error) {
 
 	if cluster.SpotInstanceEnabled {
 		cluster.activeSpotRequests = make(map[string]*spotRequest)
+		cluster.spotLoopState = &spotLoopState{}
 	}
 
 	return cluster, nil

--- a/master/internal/provisioner/aws.go
+++ b/master/internal/provisioner/aws.go
@@ -329,6 +329,9 @@ func (c *awsCluster) describeInstances(dryRun bool) ([]*ec2.Instance, error) {
 }
 
 func (c *awsCluster) describeInstancesById(instanceIds []*string, dryRun bool) ([]*ec2.Instance, error) {
+	if len(instanceIds) == 0 {
+		return make([]*ec2.Instance, 0, 0), nil
+	}
 	input := &ec2.DescribeInstancesInput{
 		DryRun:      aws.Bool(dryRun),
 		InstanceIds: instanceIds,

--- a/master/internal/provisioner/aws.go
+++ b/master/internal/provisioner/aws.go
@@ -53,7 +53,7 @@ type awsCluster struct {
 	client      *ec2.EC2
 
 	// Only used if spot instances are enabled
-	pendingSpotRequestIds []*string
+	activeSpotRequests map[string]*spotRequest
 }
 
 func newAWSCluster(config *Config, cert *tls.Certificate) (*awsCluster, error) {
@@ -121,6 +121,11 @@ func newAWSCluster(config *Config, cert *tls.Certificate) (*awsCluster, error) {
 			LogOptions:                   config.AWS.buildDockerLogString(),
 		}),
 	}
+
+	if cluster.SpotInstanceEnabled {
+		cluster.activeSpotRequests = make(map[string]*spotRequest)
+	}
+
 	return cluster, nil
 }
 

--- a/master/internal/provisioner/aws.go
+++ b/master/internal/provisioner/aws.go
@@ -141,6 +141,7 @@ var ec2InstanceStates = map[string]InstanceState{
 	"pending": Starting,
 	"running": Running,
 	"stopped": Stopped,
+	"stopping": Stopping,
 }
 
 func (c *awsCluster) stateFromEC2State(state *ec2.InstanceState) InstanceState {

--- a/master/internal/provisioner/aws.go
+++ b/master/internal/provisioner/aws.go
@@ -5,15 +5,17 @@ import (
 	"encoding/base64"
 	"encoding/pem"
 	"fmt"
+	"net/url"
+
 	"github.com/apex/log"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/ec2metadata"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ec2"
-	"github.com/determined-ai/determined/master/pkg/actor"
 	"github.com/pkg/errors"
-	"net/url"
+
+	"github.com/determined-ai/determined/master/pkg/actor"
 )
 
 const awsAgentID = `$(ec2metadata --instance-id)`
@@ -42,8 +44,6 @@ func onEC2() bool {
 	return ec2Metadata.Available()
 }
 
-
-
 // awsCluster wraps an EC2 client. Determined recognizes agent EC2 instances by:
 // 1. A specific key/value pair tag.
 // 2. Names of agents that are equal to the instance IDs.
@@ -56,7 +56,6 @@ type awsCluster struct {
 	// Only used if spot instances are enabled
 	pendingSpotRequestIds []*string
 }
-
 
 func newAWSCluster(config *Config, cert *tls.Certificate) (*awsCluster, error) {
 	if err := config.AWS.initDefaultValues(); err != nil {
@@ -125,7 +124,6 @@ func newAWSCluster(config *Config, cert *tls.Certificate) (*awsCluster, error) {
 			LogOptions:                   config.AWS.buildDockerLogString(),
 		}),
 	}
-
 
 	return cluster, nil
 }
@@ -209,9 +207,6 @@ func (c *awsCluster) terminate(ctx *actor.Context, instanceIDs []string) {
 	}
 }
 
-
-
-
 func (c *awsCluster) listOnDemand(ctx *actor.Context) ([]*Instance, error) {
 	instances, err := c.describeInstances(false)
 	if err != nil {
@@ -225,8 +220,6 @@ func (c *awsCluster) listOnDemand(ctx *actor.Context) ([]*Instance, error) {
 	}
 	return res, nil
 }
-
-
 
 func (c *awsCluster) launchOnDemand(
 	ctx *actor.Context,
@@ -255,8 +248,6 @@ func (c *awsCluster) launchOnDemand(
 		fmtInstances(launched),
 	)
 }
-
-
 
 func (c *awsCluster) terminateOnDemand(ctx *actor.Context, instanceIDs []*string) {
 	if len(instanceIDs) == 0 {
@@ -344,7 +335,7 @@ func (c *awsCluster) describeInstances(dryRun bool) ([]*ec2.Instance, error) {
 
 func (c *awsCluster) describeInstancesById(instanceIds []*string, dryRun bool) ([]*ec2.Instance, error) {
 	input := &ec2.DescribeInstancesInput{
-		DryRun: aws.Bool(dryRun),
+		DryRun:      aws.Bool(dryRun),
 		InstanceIds: instanceIds,
 	}
 	result, err := c.client.DescribeInstances(input)

--- a/master/internal/provisioner/aws.go
+++ b/master/internal/provisioner/aws.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/apex/log"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/ec2metadata"
@@ -105,8 +104,6 @@ func newAWSCluster(config *Config, cert *tls.Certificate) (*awsCluster, error) {
 	}
 	masterCertBase64 := base64.StdEncoding.EncodeToString(certBytes)
 
-	log.Info("Checking logs work inside AWS provider creation")
-
 	cluster := &awsCluster{
 		AWSClusterConfig: config.AWS,
 		masterURL:        *masterURL,
@@ -124,7 +121,6 @@ func newAWSCluster(config *Config, cert *tls.Certificate) (*awsCluster, error) {
 			LogOptions:                   config.AWS.buildDockerLogString(),
 		}),
 	}
-
 	return cluster, nil
 }
 
@@ -155,7 +151,6 @@ func (c *awsCluster) stateFromEC2State(state *ec2.InstanceState) InstanceState {
 }
 
 func (c *awsCluster) dryRunRequests() error {
-	// TODO: Spot
 	const (
 		DryRunOperationErrorCode  = "DryRunOperation"
 		InstanceLimitExceededCode = "InstanceLimitExceeded"

--- a/master/internal/provisioner/aws.go
+++ b/master/internal/provisioner/aws.go
@@ -43,6 +43,10 @@ func onEC2() bool {
 	return ec2Metadata.Available()
 }
 
+type pendingSpotRequest struct {
+
+}
+
 // awsCluster wraps an EC2 client. Determined recognizes agent EC2 instances by:
 // 1. A specific key/value pair tag.
 // 2. Names of agents that are equal to the instance IDs.
@@ -51,6 +55,8 @@ type awsCluster struct {
 	masterURL   url.URL
 	ec2UserData []byte
 	client      *ec2.EC2
+
+	pendingSpotRequests []pendingSpotRequest
 }
 
 func newAWSCluster(config *Config, cert *tls.Certificate) (*awsCluster, error) {
@@ -148,6 +154,7 @@ func (c *awsCluster) stateFromEC2State(state *ec2.InstanceState) InstanceState {
 }
 
 func (c *awsCluster) dryRunRequests() error {
+	// TODO: Spot
 	const (
 		DryRunOperationErrorCode  = "DryRunOperation"
 		InstanceLimitExceededCode = "InstanceLimitExceeded"
@@ -166,6 +173,34 @@ func (c *awsCluster) dryRunRequests() error {
 }
 
 func (c *awsCluster) list(ctx *actor.Context) ([]*Instance, error) {
+	if c.SpotInstanceEnabled {
+		return c.listSpot(ctx)
+	} else {
+		return c.listOnDemand(ctx)
+	}
+}
+
+
+func (c *awsCluster) listSpot(ctx *actor.Context) ([]*Instance, error) {
+	// 1. List all spot instance requests
+	// 2. For any requests that indicate a failure, write out an error message and clean up the spot request (if needed)
+	// 3. For each spot instance request, find the matching instances
+	// 4. Keep track of the spot requests that haven't been fulfilled
+	// TODO: Spot
+	instances, err := c.describeInstances(false)
+	if err != nil {
+		return nil, errors.Wrap(err, "cannot describe EC2 instances")
+	}
+	res := c.newInstances(instances)
+	for _, inst := range res {
+		if inst.State == Unknown {
+			ctx.Log().Errorf("unknown instance state for instance %v", inst.ID)
+		}
+	}
+	return res, nil
+}
+
+func (c *awsCluster) listOnDemand(ctx *actor.Context) ([]*Instance, error) {
 	instances, err := c.describeInstances(false)
 	if err != nil {
 		return nil, errors.Wrap(err, "cannot describe EC2 instances")
@@ -180,6 +215,18 @@ func (c *awsCluster) list(ctx *actor.Context) ([]*Instance, error) {
 }
 
 func (c *awsCluster) launch(
+	ctx *actor.Context,
+	instanceType instanceType,
+	instanceNum int,
+) {
+	if c.SpotInstanceEnabled {
+		c.launchSpot(ctx, instanceType, instanceNum)
+	} else {
+		c.launchOnDemand(ctx, instanceType, instanceNum)
+	}
+}
+
+func (c *awsCluster) launchOnDemand(
 	ctx *actor.Context,
 	instanceType instanceType,
 	instanceNum int,
@@ -207,7 +254,77 @@ func (c *awsCluster) launch(
 	)
 }
 
+func (c *awsCluster) launchSpot(
+	ctx *actor.Context,
+	instanceType instanceType,
+	instanceNum int,
+) {
+	// 1. Take the number of instances to launch + the number of pending spot requests to calculate how many instances to launch or shut down
+	// 2. Launch or terminate the appropriate number of requests
+	// TODO: Spot
+	instType, ok := instanceType.(ec2InstanceType)
+	if !ok {
+		panic("cannot pass non-ec2InstanceType to ec2Cluster")
+	}
+
+	if instanceNum <= 0 {
+		return
+	}
+	ctx.Log().Infof("launching %d EC2 instances", instanceNum)
+	instances, err := c.launchInstances(instType, instanceNum, false)
+	if err != nil {
+		ctx.Log().WithError(err).Error("cannot launch EC2 instances")
+		return
+	}
+	launched := c.newInstances(instances.Instances)
+	ctx.Log().Infof(
+		"launched %d/%d EC2 instances: %s",
+		len(launched),
+		instanceNum,
+		fmtInstances(launched),
+	)
+}
+
 func (c *awsCluster) terminate(ctx *actor.Context, instanceIDs []string) {
+	if c.SpotInstanceEnabled {
+		c.terminateSpot(ctx, instanceIDs)
+	} else {
+		c.terminateOnDemand(ctx, instanceIDs)
+	}
+}
+
+
+func (c *awsCluster) terminateSpot(ctx *actor.Context, instanceIDs []string) {
+	// TODO: Spot
+	if len(instanceIDs) == 0 {
+		return
+	}
+
+	ctx.Log().Infof(
+		"terminating %d EC2 instances: %s",
+		len(instanceIDs),
+		instanceIDs,
+	)
+	ids := make([]*string, 0, len(instanceIDs))
+	for _, id := range instanceIDs {
+		idCopy := id
+		ids = append(ids, &idCopy)
+	}
+	res, err := c.terminateInstances(ids, false)
+	if err != nil {
+		ctx.Log().WithError(err).Error("cannot terminate EC2 instances")
+		return
+	}
+	terminated := c.newInstancesFromTerminateInstancesOutput(res)
+	ctx.Log().Infof(
+		"terminated %d/%d EC2 instances: %s",
+		len(terminated),
+		len(instanceIDs),
+		fmtInstances(terminated),
+	)
+}
+
+func (c *awsCluster) terminateOnDemand(ctx *actor.Context, instanceIDs []string) {
 	if len(instanceIDs) == 0 {
 		return
 	}

--- a/master/internal/provisioner/aws_config.go
+++ b/master/internal/provisioner/aws_config.go
@@ -60,24 +60,24 @@ func (c *AWSClusterConfig) buildDockerLogString() string {
 }
 
 func (c *AWSClusterConfig) initDefaultValues() error {
-	//metadata, err := getEC2MetadataSess()
-	//if err != nil {
-	//	return err
-	//}
+	metadata, err := getEC2MetadataSess()
+	if err != nil {
+		return err
+	}
 
-	//if len(c.Region) == 0 {
-	//	if c.Region, err = metadata.Region(); err != nil {
-	//		return err
-	//	}
-	//}
+	if len(c.Region) == 0 {
+		if c.Region, err = metadata.Region(); err != nil {
+			return err
+		}
+	}
 
 	// One common reason that metadata.GetInstanceIdentityDocument() fails is that the master is not
 	// running in EC2. Use a default name here rather than holding up initializing the provider.
 	identifier := pkg.DeterminedIdentifier
-	//idDoc, err := metadata.GetInstanceIdentityDocument()
-	//if err == nil {
-	//	identifier = idDoc.InstanceID
-	//}
+	idDoc, err := metadata.GetInstanceIdentityDocument()
+	if err == nil {
+		identifier = idDoc.InstanceID
+	}
 
 	if len(c.TagValue) == 0 {
 		c.TagValue = identifier

--- a/master/internal/provisioner/aws_config.go
+++ b/master/internal/provisioner/aws_config.go
@@ -31,9 +31,8 @@ type AWSClusterConfig struct {
 	LogGroup  string `json:"log_group"`
 	LogStream string `json:"log_stream"`
 
-	SpotInstanceEnabled bool `json:"spot_instance_enabled"`
-	SpotMaxPrice string `json:"spot_max_price"`
-
+	SpotInstanceEnabled bool   `json:"spot_instance_enabled"`
+	SpotMaxPrice        string `json:"spot_max_price"`
 }
 
 var defaultAWSClusterConfig = AWSClusterConfig{
@@ -43,10 +42,10 @@ var defaultAWSClusterConfig = AWSClusterConfig{
 	NetworkInterface: ec2NetworkInterface{
 		PublicIP: true,
 	},
-	InstanceType: "p3.8xlarge",
-	MaxInstances: 5,
+	InstanceType:        "p3.8xlarge",
+	MaxInstances:        5,
 	SpotInstanceEnabled: false,
-	SpotMaxPrice: "100",
+	SpotMaxPrice:        "100",
 }
 
 func (c *AWSClusterConfig) buildDockerLogString() string {

--- a/master/internal/provisioner/aws_config.go
+++ b/master/internal/provisioner/aws_config.go
@@ -46,7 +46,7 @@ var defaultAWSClusterConfig = AWSClusterConfig{
 	InstanceType: "p3.8xlarge",
 	MaxInstances: 5,
 	SpotInstanceEnabled: false,
-	SpotMaxPrice: "NA",
+	SpotMaxPrice: "100",
 }
 
 func (c *AWSClusterConfig) buildDockerLogString() string {
@@ -61,24 +61,24 @@ func (c *AWSClusterConfig) buildDockerLogString() string {
 }
 
 func (c *AWSClusterConfig) initDefaultValues() error {
-	metadata, err := getEC2MetadataSess()
-	if err != nil {
-		return err
-	}
+	//metadata, err := getEC2MetadataSess()
+	//if err != nil {
+	//	return err
+	//}
 
-	if len(c.Region) == 0 {
-		if c.Region, err = metadata.Region(); err != nil {
-			return err
-		}
-	}
+	//if len(c.Region) == 0 {
+	//	if c.Region, err = metadata.Region(); err != nil {
+	//		return err
+	//	}
+	//}
 
 	// One common reason that metadata.GetInstanceIdentityDocument() fails is that the master is not
 	// running in EC2. Use a default name here rather than holding up initializing the provider.
 	identifier := pkg.DeterminedIdentifier
-	idDoc, err := metadata.GetInstanceIdentityDocument()
-	if err == nil {
-		identifier = idDoc.InstanceID
-	}
+	//idDoc, err := metadata.GetInstanceIdentityDocument()
+	//if err == nil {
+	//	identifier = idDoc.InstanceID
+	//}
 
 	if len(c.TagValue) == 0 {
 		c.TagValue = identifier

--- a/master/internal/provisioner/aws_config.go
+++ b/master/internal/provisioner/aws_config.go
@@ -30,6 +30,10 @@ type AWSClusterConfig struct {
 
 	LogGroup  string `json:"log_group"`
 	LogStream string `json:"log_stream"`
+
+	SpotInstanceEnabled bool `json:"spot_instance_enabled"`
+	SpotMaxPrice string `json:"spot_max_price"`
+
 }
 
 var defaultAWSClusterConfig = AWSClusterConfig{
@@ -41,6 +45,8 @@ var defaultAWSClusterConfig = AWSClusterConfig{
 	},
 	InstanceType: "p3.8xlarge",
 	MaxInstances: 5,
+	SpotInstanceEnabled: false,
+	SpotMaxPrice: "NA",
 }
 
 func (c *AWSClusterConfig) buildDockerLogString() string {

--- a/master/internal/provisioner/aws_spot.go
+++ b/master/internal/provisioner/aws_spot.go
@@ -130,7 +130,7 @@ func (c *awsCluster) listSpot(ctx *actor.Context) ([]*Instance, error) {
 			if _, ok2 := inactiveSpotRequestIds[previousSpotRequestInfo.SpotRequestId]; !ok2 {
 				// This requests was also not one of the inactive spotRequests returned by the API.
 				// This means that it is a fresh spot request and the API just hasn't updated yet.
-				// Include it in the snapshot as it
+				// Include it in the snapshot as is.
 				newActiveSpotRequestSnapshot[previousSpotRequestInfo.SpotRequestId] = previousSpotRequestInfo
 			}
 		}

--- a/master/internal/provisioner/aws_spot.go
+++ b/master/internal/provisioner/aws_spot.go
@@ -61,6 +61,8 @@ type spotRequest struct {
 	StatusCode    *string
 	StatusMessage *string
 	InstanceId    *string
+	CreationTime *time.Time
+
 }
 
 func (c *awsCluster) listSpot(ctx *actor.Context) ([]*Instance, error) {
@@ -105,6 +107,7 @@ func (c *awsCluster) listSpot(ctx *actor.Context) ([]*Instance, error) {
 			StatusCode:    request.Status.Code,
 			StatusMessage: request.Status.Message,
 			InstanceId:    request.InstanceId,
+			CreationTime: request.CreateTime,
 		}
 	}
 
@@ -140,7 +143,7 @@ func (c *awsCluster) listSpot(ctx *actor.Context) ([]*Instance, error) {
 		} else {
 			pendingSpotRequestsAsInstances = append(pendingSpotRequestsAsInstances, &Instance{
 				ID:         activeRequest.SpotRequestId,
-				LaunchTime: time.Now(),
+				LaunchTime: *activeRequest.CreationTime,
 				AgentName:  activeRequest.SpotRequestId,
 				State:      SpotRequestPendingAWS,
 			})
@@ -256,6 +259,7 @@ func (c *awsCluster) launchSpot(
 			State:         *request.State,
 			StatusCode:    request.Status.Code,
 			StatusMessage: request.Status.Message,
+			CreationTime:  request.CreateTime,
 			InstanceId:    nil,
 		}
 

--- a/master/internal/provisioner/aws_spot.go
+++ b/master/internal/provisioner/aws_spot.go
@@ -158,6 +158,10 @@ func (c *awsCluster) listSpot(ctx *actor.Context) ([]*Instance, error) {
 	}
 
 	combined := append(realInstances, pendingSpotRequestsAsInstances...)
+	ctx.Log().
+		WithField("log-type", "listSpot.returnCombinedList").
+		Infof("Returning list of instances: %d EC2 instances and %d dummy spot instances for %d total.",
+			len(realInstances), len(pendingSpotRequestsAsInstances), len(combined))
 	return combined, nil
 }
 

--- a/master/internal/provisioner/aws_spot.go
+++ b/master/internal/provisioner/aws_spot.go
@@ -52,7 +52,7 @@ import (
 // https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/spot-request-status.html#spot-instance-bid-status-understand
 
 func (c *awsCluster) listSpot(ctx *actor.Context) ([]*Instance, error) {
-	// 1. List all non-terminal spot instance requests
+	// 1. List all non-terminal spot instance request
 	// 2. For any requests that indicate a failure, write out an error message
 	//    and clean up the spot request (if needed).
 	// 3. For each spot instance request, find the matching instances

--- a/master/internal/provisioner/aws_spot.go
+++ b/master/internal/provisioner/aws_spot.go
@@ -496,7 +496,7 @@ func parseDescribeSpotInstanceRequestsResponse(
 	runningInstanceIds = make([]*string, 0, 0)
 
 	for i, request := range response.SpotInstanceRequests {
-		fmt.Println("Parsing spot instance request response number", i)
+		fmt.Println("Parsing spot instance request response number", i, *request.SpotInstanceRequestId, *request.State, *request.Status.Code, *request.Status.Message)
 		if spotRequestIsUnfulfillable(*request) {
 			unfulfillableRequests = append(unfulfillableRequests, &unfulfillableSpotRequest{
 				SpotRequestId: *request.SpotInstanceRequestId,

--- a/master/internal/provisioner/aws_spot.go
+++ b/master/internal/provisioner/aws_spot.go
@@ -65,6 +65,10 @@ func (c *awsCluster) listSpot(ctx *actor.Context) ([]*Instance, error) {
 	runningSpotInstances, pendingRequests, unfulfillableRequests := parseDescribeSpotInstanceRequestsResponse(resp)
 	c.handleUnfulfillableRequests(ctx, unfulfillableRequests)
 
+	ctx.Log().
+		WithField("log-type", "listSpot.trackPendingRequests").
+		Infof("about to save pendingRequests so launch is aware of them. Running requests: %d. Pending requests: %d. Unfulfillable: %d", len(runningSpotInstances), len(pendingRequests), len(unfulfillableRequests))
+
 	c.pendingSpotRequestIds = pendingRequests
 
 	instancesToReturn, err := c.describeInstancesById(runningSpotInstances, false)

--- a/master/internal/provisioner/aws_spot.go
+++ b/master/internal/provisioner/aws_spot.go
@@ -423,6 +423,25 @@ func (c *awsCluster) listActiveSpotInstanceRequests(
 		ctx.Log().Debug("dry run of listActiveSpotInstanceRequests.")
 	}
 
+	//input := &ec2.DescribeSpotInstanceRequestsInput{
+	//	DryRun: aws.Bool(dryRun),
+	//	Filters: []*ec2.Filter{
+	//		{
+	//			Name: aws.String(fmt.Sprintf("tag:%s", c.TagKey)),
+	//			Values: []*string{
+	//				aws.String(c.TagValue),
+	//			},
+	//		},
+	//		{
+	//			Name: aws.String("state"),
+	//			Values: []*string{
+	//				aws.String("open"),
+	//				aws.String("active"),
+	//			},
+	//		},
+	//	},
+	//}
+
 	input := &ec2.DescribeSpotInstanceRequestsInput{
 		DryRun: aws.Bool(dryRun),
 		Filters: []*ec2.Filter{
@@ -430,13 +449,6 @@ func (c *awsCluster) listActiveSpotInstanceRequests(
 				Name: aws.String(fmt.Sprintf("tag:%s", c.TagKey)),
 				Values: []*string{
 					aws.String(c.TagValue),
-				},
-			},
-			{
-				Name: aws.String("state"),
-				Values: []*string{
-					aws.String("open"),
-					aws.String("active"),
 				},
 			},
 		},

--- a/master/internal/provisioner/aws_spot.go
+++ b/master/internal/provisioner/aws_spot.go
@@ -318,7 +318,7 @@ func (c *awsCluster) handleUnfulfillableRequests(ctx *actor.Context, unfulfillab
 			continue
 		case "request-canceled-and-instance-running":
 			// Unfulfillable, maybe requiring cleanup
-			c.terminateSpot(ctx, []*string{unfulfillableRequest.InstanceId})
+			//c.terminateSpot(ctx, []*string{unfulfillableRequest.InstanceId})
 			continue
 		case
 			"bad-parameters",
@@ -495,8 +495,9 @@ func parseDescribeSpotInstanceRequestsResponse(
 	healthyPendingRequests = make([]*string, 0, 0)
 	runningInstanceIds = make([]*string, 0, 0)
 
-	for i, request := range response.SpotInstanceRequests {
-		fmt.Println("Parsing spot instance request response number", i, *request.SpotInstanceRequestId, *request.State, *request.Status.Code, *request.Status.Message)
+	for _, request := range response.SpotInstanceRequests {
+	//for i, request := range response.SpotInstanceRequests {
+		//fmt.Println("Parsing spot instance request response number", i, *request.SpotInstanceRequestId, *request.State, *request.Status.Code, *request.Status.Message)
 		if spotRequestIsUnfulfillable(*request) {
 			unfulfillableRequests = append(unfulfillableRequests, &unfulfillableSpotRequest{
 				SpotRequestId: *request.SpotInstanceRequestId,

--- a/master/internal/provisioner/aws_spot.go
+++ b/master/internal/provisioner/aws_spot.go
@@ -442,11 +442,9 @@ func (c *awsCluster) listSpotRequestsById(
 		ctx.Log().Debug("dry run of listSpotRequestsById.")
 	}
 
-	// TODO: Catch the case where there are no ids? At least test it
-	ctx.Log().
-		WithField("log-type", "list-spot-requests-by-ids").
-		Infof("num spot request ids: %d", len(spotRequestIds))
-
+	if len(spotRequestIds) == 0 {
+		return &ec2.DescribeSpotInstanceRequestsOutput{}, nil
+	}
 
 	input := &ec2.DescribeSpotInstanceRequestsInput{
 		DryRun:                 aws.Bool(dryRun),

--- a/master/internal/provisioner/aws_spot.go
+++ b/master/internal/provisioner/aws_spot.go
@@ -442,6 +442,12 @@ func (c *awsCluster) listSpotRequestsById(
 		ctx.Log().Debug("dry run of listSpotRequestsById.")
 	}
 
+	// TODO: Catch the case where there are no ids? At least test it
+	ctx.Log().
+		WithField("log-type", "list-spot-requests-by-ids").
+		Infof("num spot request ids: %d", len(spotRequestIds))
+
+
 	input := &ec2.DescribeSpotInstanceRequestsInput{
 		DryRun:                 aws.Bool(dryRun),
 		SpotInstanceRequestIds: spotRequestIds,
@@ -494,6 +500,10 @@ func (c *awsCluster) getSpotRequestIdsGivenInstanceIds(
 
 	if dryRun {
 		ctx.Log().Debug("dry run of getSpotRequestIdsGivenInstanceIds.")
+	}
+
+	if len(instanceIds) == 0 {
+		return make([]*string, 0, 0), nil
 	}
 
 	input := &ec2.DescribeSpotInstanceRequestsInput{

--- a/master/internal/provisioner/aws_spot.go
+++ b/master/internal/provisioner/aws_spot.go
@@ -62,6 +62,11 @@ func (c *awsCluster) listSpot(ctx *actor.Context) ([]*Instance, error) {
 		return nil, errors.Wrap(err, "cannot describe EC2 spot requests")
 	}
 
+	ctx.Log().
+		WithField("log-type", "listSpot.querySpotRequest").
+		Infof("Retrieved active spot requests: %d", len(resp.SpotInstanceRequests))
+
+
 	runningSpotInstances, pendingRequests, unfulfillableRequests := parseDescribeSpotInstanceRequestsResponse(resp)
 	c.handleUnfulfillableRequests(ctx, unfulfillableRequests)
 
@@ -478,7 +483,8 @@ func parseDescribeSpotInstanceRequestsResponse(
 	healthyPendingRequests = make([]*string, 0, 0)
 	runningInstanceIds = make([]*string, 0, 0)
 
-	for _, request := range response.SpotInstanceRequests {
+	for i, request := range response.SpotInstanceRequests {
+		fmt.Println("Parsing spot instance request response number", i)
 		if spotRequestIsUnfulfillable(*request) {
 			unfulfillableRequests = append(unfulfillableRequests, &unfulfillableSpotRequest{
 				SpotRequestId: *request.SpotInstanceRequestId,

--- a/master/internal/provisioner/aws_spot.go
+++ b/master/internal/provisioner/aws_spot.go
@@ -349,7 +349,7 @@ func (c *awsCluster) createSpotInstanceRequest(
 	}
 	idempotencyToken := uuid.New().String()
 
-	validFrom := time.Now().Local().Add(time.Second * time.Duration(2))
+	validFrom := time.Now().Local().Add(time.Second * time.Duration(10))  // Potential bug with clock skew?
 	spotInput := &ec2.RequestSpotInstancesInput{
 		ClientToken:                  aws.String(idempotencyToken),
 		DryRun:                       aws.Bool(dryRun),

--- a/master/internal/provisioner/aws_spot.go
+++ b/master/internal/provisioner/aws_spot.go
@@ -187,7 +187,7 @@ func (c *awsCluster) terminateSpot(ctx *actor.Context, instanceIDs []*string) {
 		pendingSpotRequestsToTerminate,
 	)
 
-	terminateInstancesResponse, err := c.terminateInstances(instanceIDs, false)
+	terminateInstancesResponse, err := c.terminateInstances(instancesToTerminate, false)
 	if err != nil {
 		ctx.Log().WithError(err).Error("cannot terminate EC2 instances")
 	} else {
@@ -195,7 +195,7 @@ func (c *awsCluster) terminateSpot(ctx *actor.Context, instanceIDs []*string) {
 		ctx.Log().Infof(
 			"terminated %d/%d EC2 instances: %s",
 			len(terminated),
-			len(instanceIDs),
+			len(instancesToTerminate),
 			fmtInstances(terminated),
 		)
 	}

--- a/master/internal/provisioner/aws_spot.go
+++ b/master/internal/provisioner/aws_spot.go
@@ -1,0 +1,175 @@
+package provisioner
+
+import (
+	"encoding/base64"
+	"fmt"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/determined-ai/determined/master/pkg/actor"
+	"github.com/google/uuid"
+	"time"
+)
+
+func (c *awsCluster) createSpotInstanceRequest(
+	ctx *actor.Context,
+	numInstances int,
+	dryRun bool,
+	instanceType ec2InstanceType,
+) (*ec2.RequestSpotInstancesOutput, error) {
+
+	if dryRun {
+		ctx.Log().Debug("dry run of createSpotInstanceRequest.")
+	}
+	idempotencyToken := uuid.New().String()
+
+	validFrom := time.Now().Local().Add(time.Second * time.Duration(10))
+	spotInput := &ec2.RequestSpotInstancesInput{
+		ClientToken:                  aws.String(idempotencyToken),
+		DryRun:                       aws.Bool(dryRun),
+		InstanceCount:                aws.Int64(int64(numInstances)),
+		InstanceInterruptionBehavior: aws.String("terminate"),
+		LaunchSpecification:          &ec2.RequestSpotLaunchSpecification{
+			BlockDeviceMappings: []*ec2.BlockDeviceMapping{
+				{
+					DeviceName: aws.String("/dev/sda1"),
+					Ebs: &ec2.EbsBlockDevice{
+						DeleteOnTermination: aws.Bool(true),
+						VolumeSize:          aws.Int64(int64(c.RootVolumeSize)),
+						VolumeType:          aws.String("gp2"),
+					},
+				},
+			},
+			EbsOptimized:        nil,  // TODO: We should enable this.
+			ImageId:      aws.String(c.ImageID),
+			InstanceType: aws.String(instanceType.name()),
+			KeyName:      aws.String(c.SSHKeyName),
+			UserData:            aws.String(base64.StdEncoding.EncodeToString(c.ec2UserData)),
+		},
+		SpotPrice:                    aws.String(c.AWSClusterConfig.SpotMaxPrice),
+		ValidFrom:                    aws.Time(validFrom),
+	}
+
+	// TODO: Add tags
+	//input := &ec2.RunInstancesInput{
+	//	TagSpecifications: []*ec2.TagSpecification{
+	//		{
+	//			ResourceType: aws.String("instance"),
+	//			Tags: []*ec2.Tag{
+	//				{
+	//					Key:   aws.String("Name"),
+	//					Value: aws.String(c.InstanceName),
+	//				},
+	//				{
+	//					Key:   aws.String(c.TagKey),
+	//					Value: aws.String(c.TagValue),
+	//				},
+	//				{
+	//					Key:   aws.String("determined-master-address"),
+	//					Value: aws.String(c.masterURL.String()),
+	//				},
+	//			},
+	//		},
+	//	},
+	//}
+
+	spotInput.LaunchSpecification.NetworkInterfaces = []*ec2.InstanceNetworkInterfaceSpecification{
+		{
+			AssociatePublicIpAddress: aws.Bool(c.NetworkInterface.PublicIP),
+			DeleteOnTermination:      aws.Bool(true),
+			Description:              aws.String("network interface created by Determined"),
+			DeviceIndex:              aws.Int64(0),
+		},
+	}
+	if c.NetworkInterface.SubnetID != "" {
+		spotInput.LaunchSpecification.NetworkInterfaces[0].SubnetId = aws.String(c.NetworkInterface.SubnetID)
+	}
+	if c.NetworkInterface.SecurityGroupID != "" {
+		spotInput.LaunchSpecification.NetworkInterfaces[0].Groups = []*string{
+			aws.String(c.NetworkInterface.SecurityGroupID),
+		}
+	}
+
+	if c.IamInstanceProfileArn != "" {
+		spotInput.LaunchSpecification.IamInstanceProfile = &ec2.IamInstanceProfileSpecification{
+			Arn: aws.String(c.IamInstanceProfileArn),
+		}
+	}
+
+	return c.client.RequestSpotInstances(spotInput)
+}
+
+// List all Determined-managed spot instance requests in an active state
+func (c *awsCluster) listActiveSpotInstanceRequests(
+	ctx *actor.Context,
+	dryRun bool,
+) (*ec2.DescribeSpotInstanceRequestsOutput, error) {
+
+	if dryRun {
+		ctx.Log().Debug("dry run of listActiveSpotInstanceRequests.")
+	}
+
+	input := &ec2.DescribeSpotInstanceRequestsInput{
+		DryRun:                 aws.Bool(dryRun),
+		Filters:                []*ec2.Filter{
+			{
+				Name: aws.String(fmt.Sprintf("tag:%s", c.TagKey)),
+				Values: []*string{
+					aws.String(c.TagValue),
+				},
+			},
+			{
+				Name: aws.String("state"),
+				Values: []*string{
+					aws.String("open"),
+					aws.String("active"),
+				},
+			},
+		},
+	}
+
+	return c.client.DescribeSpotInstanceRequests(input)
+}
+
+
+func (c *awsCluster) getSpotRequestIdsGivenInstanceIds(
+	ctx *actor.Context,
+	instanceId string,
+	dryRun bool,
+) (*ec2.DescribeSpotInstanceRequestsOutput, error) {
+
+	if dryRun {
+		ctx.Log().Debug("dry run of getSpotRequestIdsGivenInstanceIds.")
+	}
+
+	input := &ec2.DescribeSpotInstanceRequestsInput{
+		DryRun:                 aws.Bool(dryRun),
+		Filters:                []*ec2.Filter{
+			{
+				Name: aws.String("instance-id"),
+				Values: []*string{
+					aws.String(instanceId),
+				},
+			},
+		},
+	}
+
+	return c.client.DescribeSpotInstanceRequests(input)
+}
+
+
+func (c *awsCluster) terminateSpotInstanceRequest(
+	ctx *actor.Context,
+	spotRequestIds []*string,
+	dryRun bool,
+) (*ec2.CancelSpotInstanceRequestsOutput, error) {
+	if len(spotRequestIds) == 0 {
+		return &ec2.CancelSpotInstanceRequestsOutput{}, nil
+	}
+	input := &ec2.CancelSpotInstanceRequestsInput{
+		DryRun:                 aws.Bool(dryRun),
+		SpotInstanceRequestIds: spotRequestIds,
+	}
+
+	return c.client.CancelSpotInstanceRequests(input)
+
+}

--- a/master/internal/provisioner/aws_spot.go
+++ b/master/internal/provisioner/aws_spot.go
@@ -349,7 +349,7 @@ func (c *awsCluster) createSpotInstanceRequest(
 	}
 	idempotencyToken := uuid.New().String()
 
-	validFrom := time.Now().Local().Add(time.Second * time.Duration(10))
+	validFrom := time.Now().Local().Add(time.Second * time.Duration(2))
 	spotInput := &ec2.RequestSpotInstancesInput{
 		ClientToken:                  aws.String(idempotencyToken),
 		DryRun:                       aws.Bool(dryRun),

--- a/master/internal/provisioner/aws_spot.go
+++ b/master/internal/provisioner/aws_spot.go
@@ -442,16 +442,20 @@ func (c *awsCluster) listActiveSpotInstanceRequests(
 	//	},
 	//}
 
+	//input := &ec2.DescribeSpotInstanceRequestsInput{
+	//	DryRun: aws.Bool(dryRun),
+	//	Filters: []*ec2.Filter{
+	//		{
+	//			Name: aws.String(fmt.Sprintf("tag:%s", c.TagKey)),
+	//			Values: []*string{
+	//				aws.String(c.TagValue),
+	//			},
+	//		},
+	//	},
+	//}
+
 	input := &ec2.DescribeSpotInstanceRequestsInput{
 		DryRun: aws.Bool(dryRun),
-		Filters: []*ec2.Filter{
-			{
-				Name: aws.String(fmt.Sprintf("tag:%s", c.TagKey)),
-				Values: []*string{
-					aws.String(c.TagValue),
-				},
-			},
-		},
 	}
 
 	return c.client.DescribeSpotInstanceRequests(input)

--- a/master/internal/provisioner/instance.go
+++ b/master/internal/provisioner/instance.go
@@ -26,6 +26,8 @@ const (
 	Stopping InstanceState = "Stopping"
 	// Stopped describes the instance is stopped.
 	Stopped InstanceState = "Stopped"
+	// SpotRequestPendingAWS indicates that the instance is actually a pending AWS spot request
+	SpotRequestPendingAWS InstanceState = "SpotRequestPendingAWS"
 )
 
 // Instance connects a provider's name for a compute resource to the Determined agent name.

--- a/master/internal/provisioner/provisioner.go
+++ b/master/internal/provisioner/provisioner.go
@@ -97,7 +97,6 @@ func (p *Provisioner) SlotsPerInstance() int {
 }
 
 func (p *Provisioner) provision(ctx *actor.Context) {
-	// AWS Spot instance support relies on provider.list always taking place before provider.launch.
 	instances, err := p.provider.list(ctx)
 	if err != nil {
 		ctx.Log().WithError(err).Error("cannot list instances")

--- a/master/internal/provisioner/provisioner.go
+++ b/master/internal/provisioner/provisioner.go
@@ -97,6 +97,7 @@ func (p *Provisioner) SlotsPerInstance() int {
 }
 
 func (p *Provisioner) provision(ctx *actor.Context) {
+	// AWS Spot instance support relies on provider.list always taking place before provider.launch.
 	instances, err := p.provider.list(ctx)
 	if err != nil {
 		ctx.Log().WithError(err).Error("cannot list instances")

--- a/master/internal/provisioner/scale_decider.go
+++ b/master/internal/provisioner/scale_decider.go
@@ -197,7 +197,7 @@ func (s *scaleDecider) calculateNumInstancesToLaunch(
 	instances := make([]*Instance, 0, len(s.instanceSnapshot))
 	for _, inst := range s.instanceSnapshot {
 		switch inst.State {
-		case Starting, Running:
+		case Starting, Running, SpotRequestPendingAWS:
 			instances = append(instances, inst)
 		}
 	}


### PR DESCRIPTION
WIP, but the core logic is there if anyone wants to comment on the architecture. 

## Description

Add support for spot instances in AWS

## Test Plan




## Commentary (optional)

- Upgraded AWS SDK so that we can tag spot requests.
- Spot requests are treated like instances in a special state so the scaleDecider knows that there is compute on the way.

Current todo list:

- [ ] Rebase and fix conflicts
- [x] Improve comments. Too many right now and not sure all are still accurate
- [x] Add validation around spot price and improve how we do default value
- [x] Handle performance concerns around querying spot instance requests. Also make sure that, if the spot request can never be fulfilled (e.g. instances of that type do not exist in the AZ), that we don't end up flooding AWS with pointless spot requests, which would make the query operation expensive.
- [x] Add state to ensure make sure that we don't log errors that we've already logged
- [x] Add spot query IAM perms to det-deploy
- [x] Confirm that we can enable EBSOptimized instances 
- [ ] Add tests? This is not the easiest thing to test since spot is non-deterministic. But maybe p2.xlarge instances are available often enough to have reliable testing.
- [x] Manual testing of instances
- [x] Release notes

## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.

