### PR TITLE
chore: fix possible syntax error when parsing experiment labels request [DET-4265]

### DIFF
--- a/proto/src/determined/api/v1/api.proto
+++ b/proto/src/determined/api/v1/api.proto
@@ -144,7 +144,7 @@ service Determined {
     }
     // Get a list of unique experiment labels (sorted by popularity).
     rpc GetExperimentLabels(GetExperimentLabelsRequest) returns (GetExperimentLabelsResponse) {
-        option (google.api.http) = {get: "/api/v1/experiments/labels"};
+        option (google.api.http) = {get: "/api/v1/experiment/labels"};
         option (grpc.gateway.protoc_gen_swagger.options.openapiv2_operation) = {tags: "Experiments"};
     }
     // Get the validation history for an experiment.


### PR DESCRIPTION
Parsing /experiments/labels when /experiments/{id} is also defined
seems to be unreliable. Regardless of the reason, this seems to be an
unsafe practice that we shouldn't rely on.