### PR TITLE
fix: experiment chart legend labelling line as 'trace 0'

### DIFF
--- a/webui/react/src/pages/ExperimentDetails/ExperimentChart.tsx
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentChart.tsx
@@ -43,6 +43,7 @@ const ExperimentChart: React.FC<Props> = ({ validationMetric, ...props }: Props)
       hovermode: 'y unified',
       hovertemplate: '%{text}<extra></extra>',
       mode: 'lines+markers',
+      name: validationMetric,
       text: textData,
       type: 'scatter',
       x: xData,


### PR DESCRIPTION
## Description

Give the experiment chart the name of the metric so the legend doesn't use the generic name 'trace 0'.
