### PR TITLE
chore: make `make -C proto build` idempotent [DET-4273]

### DIFF
--- a/proto/.gitignore
+++ b/proto/.gitignore
@@ -1,3 +1,2 @@
-# Proto generated files
-pkg/
 build/
+pkg/

--- a/proto/Makefile
+++ b/proto/Makefile
@@ -1,9 +1,26 @@
 export GO111MODULE := on
 
+# String constants.
+build_path := build/proto/github.com/determined-ai/determined/proto/pkg
+src_path := src/determined
+
+# Pre-defined list of all source files.
+source_files := $(shell find $(src_path) -type f -name '*.proto')
+
+# Currently only one file needs GRPC treatment.
+grpc_in := $(src_path)/api/v1/api.proto
+
+# Currently only one file needs Swagger treatment.
+swagger_in := $(src_path)/api/v1/api.proto
+swagger_out := build/swagger/determined/api/v1/api.swagger.json
+swagger_patch := patches/api.json
+
+.PHONY: build
+build: build/proto.stamp $(swagger_out)
+
 .PHONY: clean
 clean:
-	rm -rf build
-	rm -rf pkg
+	rm -rf build pkg
 
 get-deps:
 	go install github.com/bufbuild/buf/cmd/buf
@@ -12,23 +29,22 @@ get-deps:
 	go install github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway
 	go install github.com/grpc-ecosystem/grpc-gateway/protoc-gen-swagger
 
-.PHONY: build-dir
-build-dir:
+build/proto.stamp: $(source_files)
+	rm -rf build/proto pkg
 	mkdir -p build/proto
+	# Protobuf generation.
+	for source in $(source_files) ; do protoc -I src "$$source" --go_out=plugins=grpc:build/proto ; done
+	# GRPC generation.
+	protoc -I src $(grpc_in) --grpc-gateway_out=logtostderr=true:build/proto
+	mv $(build_path) pkg
+	touch $@
 
-%.pb.go: %.proto build-dir
-	protoc -I src $< --go_out=plugins=grpc:build/proto
-
-.PHONY: proto
-build: $(patsubst %.proto, %.pb.go, $(shell find src/determined -type f -name '*.proto'))
-	protoc -I src src/determined/api/v1/api.proto --grpc-gateway_out=logtostderr=true:build/proto
-	rm -rf pkg
-	mkdir -p pkg
-	cp -r build/proto/github.com/determined-ai/determined/proto/pkg/* ./pkg
-	rm -rf build/proto
+build/swagger:
 	mkdir -p build/swagger
-	protoc -I src src/determined/api/v1/api.proto --swagger_out=logtostderr=true:build/swagger
-	python3 scripts/swagger.py build/swagger
+
+$(swagger_out): $(swagger_in) build/swagger
+	protoc -I src $< --swagger_out=logtostderr=true:build/swagger
+	python3 scripts/swagger.py $@ $(swagger_patch)
 
 .PHONY: check
 check:

--- a/proto/patches/api.json
+++ b/proto/patches/api.json
@@ -1,4 +1,30 @@
 {
+  "tags": [
+    {
+      "name": "Authentication",
+      "description": "Log in to and out of the cluster"
+    },
+    {
+      "name": "Users",
+      "description": "Manage users"
+    },
+    {
+      "name": "Cluster",
+      "description": "Manage cluster components"
+    },
+    {
+      "name": "Experiments",
+      "description": "Manage experiments"
+    },
+    {
+      "name": "Templates",
+      "description": "Manage templates"
+    },
+    {
+      "name": "Models",
+      "description": "Manage models"
+    }
+  ],
   "paths": {
     "/api/v1/experiments": {
       "post": {


### PR DESCRIPTION
I had a few ideas for how to do this differently (in no particular order):

1. This PR symlinks from `proto/pkg` into the generated code tree.  I could imagine that instead of the symlink, you could instead copy some extra files (`go.mod` for instance) into the generated code tree and use `replace` commands in the `master/go.mod`, for instance.  This would be most similar to how a proper out-of-tree build would work I think.

1. Instead of the symlink step at the end, we could just mv each individual file after it is built into the `pkg` directory.  This would still require the callable functions I wrote for calculating inputs and outputs.

1. I think we could also accomplish something fairly similar in effect to this whole PR like so:

   ```make
   build/build.stamp: $(all_proto_files)
       # ... contents of the old build target
       touch $@

   .PHONY: build
   build: build/build.stamp
   ```

   That would effectively rebuild the whole module anytime any part of the module broke.  Hacky, but still a step above what we have now.
