### PR TITLE
fix: det-deploy deprovisions GCP agents despite long master names [DET-4271]

### DIFF
--- a/deploy/determined_deploy/gcp/cli.py
+++ b/deploy/determined_deploy/gcp/cli.py
@@ -1,8 +1,18 @@
 import argparse
 import os
+from typing import Callable
 
 import determined_deploy
 from determined_deploy.gcp import constants, gcp
+
+
+def validate_cluster_id() -> Callable:
+    def validate(s: str) -> str:
+        if isinstance(s, str) and len(s) <= 35:
+            return s
+        raise argparse.ArgumentTypeError("must be at most 35 characters")
+
+    return validate
 
 
 def make_down_subparser(subparsers: argparse._SubParsersAction) -> None:
@@ -23,7 +33,7 @@ def make_up_subparser(subparsers: argparse._SubParsersAction) -> None:
     required_named = parser_gcp.add_argument_group("required named arguments")
     required_named.add_argument(
         "--cluster-id",
-        type=str,
+        type=validate_cluster_id(),
         default=None,
         required=True,
         help="unique identifier to name and tag resources",

--- a/deploy/determined_deploy/gcp/terraform/modules/compute/main.tf
+++ b/deploy/determined_deploy/gcp/terraform/modules/compute/main.tf
@@ -1,5 +1,10 @@
 // Create Master instance
 resource "google_compute_instance" "master_instance" {
+  // The resource name must match the label_value in the dynamic agent
+  // provisioner config below in order for upstream tooling (det-deploy) to
+  // properly clean up dynamic agents during deprovisioning. During
+  // deprovisioning it filters for agents using this same label key / value.
+  // We copy the same string since a resource can't reference its own name.
   name = "det-master-${var.unique_id}-${var.det_version_key}"
   machine_type = var.master_instance_type
   zone = var.zone
@@ -46,6 +51,8 @@ resource "google_compute_instance" "master_instance" {
       max_agent_starting_period: ${var.max_agent_starting_period}
       provider: gcp
       name_prefix: det-dynamic-agent-${var.unique_id}-${var.det_version_key}-
+      label_key: managed-by
+      label_value: det-master-${var.unique_id}-${var.det_version_key}
       network_interface:
         network: projects/${var.project_id}/global/networks/${var.network_name}
         subnetwork: projects/${var.project_id}/regions/${var.region}/subnetworks/${var.subnetwork_name}


### PR DESCRIPTION
The provisioner default label_value for GCP is truncated to 30
characters. This was problematic for deprovisioning dynamic agents since
det-deploy looks up instances using the expected default label key /
value and failed to truncate in the same way. This truncation will be
relaxed in the future, but for now, det-deploy works around this by
explicitly setting label key/value in the cluster configuration.

## Description

<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234