### PR TITLE
ci: update from deprecated remote docker versions and machine images [DET-4262]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -594,7 +594,8 @@ jobs:
       - attach_workspace:
           at: .
       - go-get-deps
-      - setup_remote_docker
+      - setup_remote_docker:
+          version: 19.03.12
       - run: make -C proto build
       - run: make package
       - run: mkdir -p build/
@@ -619,7 +620,8 @@ jobs:
       - attach_workspace:
           at: .
       - go-get-deps
-      - setup_remote_docker
+      - setup_remote_docker:
+          version: 19.03.12
       - run: make -C proto build
       - run: make package
       - login-docker
@@ -636,7 +638,8 @@ jobs:
       - attach_workspace:
           at: .
       - go-get-deps
-      - setup_remote_docker
+      - setup_remote_docker:
+          version: 19.03.12
       - run: make -C proto build
       - run: make package
       - login-docker
@@ -653,7 +656,8 @@ jobs:
       - attach_workspace:
           at: .
       - go-get-deps
-      - setup_remote_docker
+      - setup_remote_docker:
+          version: 19.03.12
       - login-docker
       - run: make -C proto build
       - run: make -C master release
@@ -699,7 +703,7 @@ jobs:
 
   test-debian-packaging:
     machine:
-      image: ubuntu-1604:202004-01
+      image: ubuntu-2004:202008-01
     steps:
       - checkout
       - attach_workspace:
@@ -717,7 +721,7 @@ jobs:
 
   test-e2e-webui:
     machine:
-      image: ubuntu-1604:202004-01
+      image: ubuntu-2004:202008-01
     resource_class: large
     steps:
       - checkout
@@ -733,7 +737,7 @@ jobs:
           determined-cli: true
           determined-deploy: true
           extra-requirements-file: "webui/tests/requirements.txt"
-          executor: ubuntu-1604:202004-01
+          executor: ubuntu-2004:202008-01
       - setup-local-cluster:
           det-version: ${CIRCLE_SHA1}
       - run-e2e-webui-tests
@@ -927,7 +931,7 @@ jobs:
       parallelism:
         type: integer
     machine:
-      image: ubuntu-1604:202004-01
+      image: ubuntu-2004:202008-01
     resource_class: large
     parallelism: <<parameters.parallelism>>
     steps:
@@ -942,7 +946,7 @@ jobs:
           determined: true
           determined-deploy: true
           extra-requirements-file: "e2e_tests/tests/requirements.txt"
-          executor: ubuntu-1604:202004-01
+          executor: ubuntu-2004:202008-01
 
       - run:
           name: Start database
@@ -1127,7 +1131,7 @@ jobs:
       det-version:
         type: string
     machine:
-      image: ubuntu-1604:202004-01
+      image: ubuntu-2004:202008-01
     resource_class: large
     parallelism: <<parameters.parallelism>>
     steps:
@@ -1144,7 +1148,7 @@ jobs:
           determined: true
           determined-deploy: true
           extra-requirements-file: "e2e_tests/tests/requirements.txt"
-          executor: ubuntu-1604:202004-01
+          executor: ubuntu-2004:202008-01
 
       - pull-task-images:
           tf1: True

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -703,7 +703,7 @@ jobs:
 
   test-debian-packaging:
     machine:
-      image: ubuntu-2004:202008-01
+      image: ubuntu-1604:202004-01
     steps:
       - checkout
       - attach_workspace:
@@ -721,7 +721,7 @@ jobs:
 
   test-e2e-webui:
     machine:
-      image: ubuntu-2004:202008-01
+      image: ubuntu-1604:202004-01
     resource_class: large
     steps:
       - checkout
@@ -737,7 +737,7 @@ jobs:
           determined-cli: true
           determined-deploy: true
           extra-requirements-file: "webui/tests/requirements.txt"
-          executor: ubuntu-2004:202008-01
+          executor: ubuntu-1604:202004-01
       - setup-local-cluster:
           det-version: ${CIRCLE_SHA1}
       - run-e2e-webui-tests
@@ -931,7 +931,7 @@ jobs:
       parallelism:
         type: integer
     machine:
-      image: ubuntu-2004:202008-01
+      image: ubuntu-1604:202004-01
     resource_class: large
     parallelism: <<parameters.parallelism>>
     steps:
@@ -946,7 +946,7 @@ jobs:
           determined: true
           determined-deploy: true
           extra-requirements-file: "e2e_tests/tests/requirements.txt"
-          executor: ubuntu-2004:202008-01
+          executor: ubuntu-1604:202004-01
 
       - run:
           name: Start database
@@ -1131,7 +1131,7 @@ jobs:
       det-version:
         type: string
     machine:
-      image: ubuntu-2004:202008-01
+      image: ubuntu-1604:202004-01
     resource_class: large
     parallelism: <<parameters.parallelism>>
     steps:
@@ -1148,7 +1148,7 @@ jobs:
           determined: true
           determined-deploy: true
           extra-requirements-file: "e2e_tests/tests/requirements.txt"
-          executor: ubuntu-2004:202008-01
+          executor: ubuntu-1604:202004-01
 
       - pull-task-images:
           tf1: True


### PR DESCRIPTION
## Description

Context for this change can be found here: https://discuss.circleci.com/t/old-linux-machine-image-remote-docker-deprecation/37572. Especially the note about using remote docker without a version. The original PR included a switch from 16.04 images to 20.04 images, but that is more complicated: we have some hard-coded references to Python 3.6.10 that break when you make that switch, the 20.04 image is in beta anyway, and the 16.04 images aren't QUITE EOL'd - they last for 5 years (longer than I thought). I filed a JIRA to follow-up on that one.