### PR TITLE
fix: don't fail master if restoring non-terminal experiment from DB [DET-4074]

### DIFF
--- a/docs/release-notes/1397-no-fail-on-exp-restart.txt
+++ b/docs/release-notes/1397-no-fail-on-exp-restart.txt
@@ -1,0 +1,6 @@
+:orphan:
+
+**BUG FIXES**
+
+-  Fix a bug where the master instance would fail if an experiment
+   could not be read from the database.


### PR DESCRIPTION
## Description
Before, if the database can't read an experiment config on restart, it would cause the master to fail. Now, instead of failing, it will mark the experiment as failed and continue the restart.

<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan
Tested manually. 
- start an experiment on a AWS cluster running Determined 0.12.4
- pause the experiment, stop the master instance, and setup the latest version of Determined (with this fix)
- start master (should not fail with this fix) 
- previously paused experiments should now be errored

<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234