### PR TITLE
style: add enforcement of reST formatting

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -842,6 +842,16 @@ jobs:
       - run: make -C master test
       - run: make -C agent test
 
+  lint-docs:
+    docker:
+      - image: determinedai/cimg-base:stable
+    steps:
+      - checkout
+      - setup-python-venv:
+          extra-requirements-file: "docs/requirements.txt"
+          executor: determinedai/cimg-base:stable
+      - run: make -C docs check
+
   lint-python:
     docker:
       - image: determinedai/cimg-base:stable
@@ -1165,6 +1175,7 @@ workflows:
       - build-and-package-ts-sdk:
           requires:
             - build-proto
+      - lint-docs
       - lint-python
       - lint-go
       - lint-react:

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ clean: clean-tools clean-proto clean-common clean-harness clean-cli clean-deploy
 check-%:
 	$(MAKE) -C $(subst -,/,$*) check
 .PHONY: check
-check: check-common check-proto check-harness check-cli check-deploy check-e2e_tests check-tools check-master check-agent check-webui check-examples
+check: check-common check-proto check-harness check-cli check-deploy check-e2e_tests check-tools check-master check-agent check-webui check-examples check-docs
 
 .PHONY: fmt-%
 fmt-%:

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -38,7 +38,11 @@ live:
 
 .PHONY: fmt
 fmt:
-	git ls-files -z '*.txt' ':!:requirements.txt' | xargs -0 rstfmt -i
+	git ls-files -z '*.txt' ':!:requirements.txt' | xargs -0 rstfmt
+
+.PHONY: check
+check:
+	git ls-files -z '*.txt' ':!:requirements.txt' | xargs -0 rstfmt --check
 
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).

--- a/docs/examples.txt
+++ b/docs/examples.txt
@@ -1,8 +1,8 @@
 .. _examples:
 
-####################################################
+##########
  Examples
-####################################################
+##########
 
 Determined includes several example machine learning models that have
 been ported to Determined's APIs. These examples can be found in the
@@ -10,178 +10,200 @@ been ported to Determined's APIs. These examples can be found in the
 <https://github.com/determined-ai/determined/tree/master/examples>`__;
 download links to each example can also be found below.
 
-Each example consists of a model definition, along with one or more experiment
-configuration files. To run one of these examples, download the appropriate
-``.tgz`` file, extract it, ``cd`` into the directory, and use ``det experiment
-create`` to create a new experiment, passing in the appropriate configuration
-file. For example, here is how to train the ``mnist_pytorch`` example with a
-fixed set of hyperparameters:
+Each example consists of a model definition, along with one or more
+experiment configuration files. To run one of these examples, download
+the appropriate ``.tgz`` file, extract it, ``cd`` into the directory,
+and use ``det experiment create`` to create a new experiment, passing in
+the appropriate configuration file. For example, here is how to train
+the ``mnist_pytorch`` example with a fixed set of hyperparameters:
 
 .. code::
 
-    tar xzvf mnist_pytorch.tgz
-    cd mnist_pytorch
-    det experiment create const.yaml .
+   tar xzvf mnist_pytorch.tgz
+   cd mnist_pytorch
+   det experiment create const.yaml .
 
-For an introduction to using the Trial API, refer to the :ref:`PyTorch MNIST <pytorch-mnist-tutorial>` and
-:ref:`tf.keras MNIST <tf-mnist-tutorial>` tutorials.
+For an introduction to using the Trial API, refer to the :ref:`PyTorch
+MNIST <pytorch-mnist-tutorial>` and :ref:`tf.keras MNIST
+<tf-mnist-tutorial>` tutorials.
 
-Computer Vision
-===============
-
-.. list-table::
-  :header-rows: 1
-
-  * - Framework
-    - Dataset
-    - Filename
-
-  * - PyTorch
-    - CIFAR-10
-    - :download:`cifar10_pytorch.tgz </examples/cifar10_pytorch.tgz>`
-
-  * - PyTorch
-    - MNIST
-    - :download:`mnist_pytorch.tgz </examples/mnist_pytorch.tgz>`
-
-  * - PyTorch
-    - MNIST
-    - :download:`mnist_multi_output_pytorch.tgz </examples/mnist_multi_output_pytorch.tgz>`
-
-  * - PyTorch
-    - Penn-Fudan Dataset
-    - :download:`fasterrcnn_coco_pytorch.tgz </examples/fasterrcnn_coco_pytorch.tgz>`
-
-  * - TensorFlow (Estimator API)
-    - MNIST
-    - :download:`mnist_estimator.tgz </examples/mnist_estimator.tgz>`
-
-  * - TensorFlow (tf.layers via Estimator API)
-    - MNIST
-    - :download:`mnist_tf_layers.tgz </examples/mnist_tf_layers.tgz>`
-
-  * - TensorFlow (tf.keras)
-    - Fashion MNIST
-    - :download:`fashion_mnist_tf_keras.tgz </examples/fashion_mnist_tf_keras.tgz>`
-
-  * - TensorFlow (tf.keras)
-    - CIFAR-10
-    - :download:`cifar10_tf_keras.tgz </examples/cifar10_tf_keras.tgz>`
-
-  * - TensorFlow (tf.keras)
-    - Iris Dataset
-    - :download:`iris_tf_keras.tgz </examples/iris_tf_keras.tgz>`
-
-  * - TensorFlow (tf.keras)
-    - Oxford-IIIT Pet Dataset
-    - :download:`unets_tf_keras.tgz </examples/unets_tf_keras.tgz>`
-
-Natural Language Processing (NLP)
-=================================
+*****************
+ Computer Vision
+*****************
 
 .. list-table::
-  :header-rows: 1
+   :header-rows: 1
 
-  * - Framework
-    - Dataset
-    - Filename
+   -  -  Framework
+      -  Dataset
+      -  Filename
 
-  * - PyTorch
-    - SQuAD
-    - :download:`bert_squad_pytorch.tgz </examples/bert_squad_pytorch.tgz>`
+   -  -  PyTorch
+      -  CIFAR-10
+      -  :download:`cifar10_pytorch.tgz </examples/cifar10_pytorch.tgz>`
 
-  * - PyTorch
-    - GLUE
-    - :download:`bert_glue_pytorch.tgz </examples/bert_glue_pytorch.tgz>`
+   -  -  PyTorch
+      -  MNIST
+      -  :download:`mnist_pytorch.tgz </examples/mnist_pytorch.tgz>`
 
-HP Search Benchmarking
-======================
+   -  -  PyTorch
+      -  MNIST
+      -  :download:`mnist_multi_output_pytorch.tgz
+         </examples/mnist_multi_output_pytorch.tgz>`
 
-.. list-table::
-  :header-rows: 1
+   -  -  PyTorch
+      -  Penn-Fudan Dataset
+      -  :download:`fasterrcnn_coco_pytorch.tgz
+         </examples/fasterrcnn_coco_pytorch.tgz>`
 
-  * - Framework
-    - Dataset
-    - Filename
+   -  -  TensorFlow (Estimator API)
+      -  MNIST
+      -  :download:`mnist_estimator.tgz </examples/mnist_estimator.tgz>`
 
-  * - PyTorch
-    - CIFAR-10
-    - :download:`darts_cifar10_pytorch.tgz </examples/darts_cifar10_pytorch.tgz>`
+   -  -  TensorFlow (tf.layers via Estimator API)
+      -  MNIST
+      -  :download:`mnist_tf_layers.tgz </examples/mnist_tf_layers.tgz>`
 
-  * - PyTorch
-    - Penn Treebank Dataset
-    - :download:`darts_penntreebank_pytorch.tgz </examples/darts_penntreebank_pytorch.tgz>`
+   -  -  TensorFlow (tf.keras)
+      -  Fashion MNIST
+      -  :download:`fashion_mnist_tf_keras.tgz
+         </examples/fashion_mnist_tf_keras.tgz>`
 
-Neural Architecture Search (NAS)
-================================
+   -  -  TensorFlow (tf.keras)
+      -  CIFAR-10
+      -  :download:`cifar10_tf_keras.tgz
+         </examples/cifar10_tf_keras.tgz>`
 
-.. list-table::
-  :header-rows: 1
+   -  -  TensorFlow (tf.keras)
+      -  Iris Dataset
+      -  :download:`iris_tf_keras.tgz </examples/iris_tf_keras.tgz>`
 
-  * - Framework
-    - Dataset
-    - Filename
+   -  -  TensorFlow (tf.keras)
+      -  Oxford-IIIT Pet Dataset
+      -  :download:`unets_tf_keras.tgz </examples/unets_tf_keras.tgz>`
 
-  * - PyTorch
-    - DARTS
-    - :download:`gaea_pytorch.tgz </examples/gaea_pytorch.tgz>`
-
-Meta Learning
-=============
-
-.. list-table::
-  :header-rows: 1
-
-  * - Framework
-    - Dataset
-    - Filename
-
-  * - PyTorch
-    - Omniglot
-    - :download:`protonet_omniglot_pytorch.tgz </examples/protonet_omniglot_pytorch.tgz>`
-
-Generative Adversarial Networks (GANs)
-======================================
+***********************************
+ Natural Language Processing (NLP)
+***********************************
 
 .. list-table::
-  :header-rows: 1
+   :header-rows: 1
 
-  * - Framework
-    - Dataset
-    - Filename
+   -  -  Framework
+      -  Dataset
+      -  Filename
 
-  * - PyTorch
-    - MNIST
-    - :download:`gan_mnist_pytorch.tgz </examples/gan_mnist_pytorch.tgz>`
+   -  -  PyTorch
+      -  SQuAD
+      -  :download:`bert_squad_pytorch.tgz
+         </examples/bert_squad_pytorch.tgz>`
 
-Decision Trees
-==============
+   -  -  PyTorch
+      -  GLUE
+      -  :download:`bert_glue_pytorch.tgz
+         </examples/bert_glue_pytorch.tgz>`
 
-.. list-table::
-  :header-rows: 1
-
-  * - Framework
-    - Dataset
-    - Filename
-
-  * - TensorFlow (Estimator API)
-    - Titanic
-    - :download:`gbt_titanic_estimator.tgz </examples/gbt_titanic_estimator.tgz>`
-
-Data Layer
-==========
+************************
+ HP Search Benchmarking
+************************
 
 .. list-table::
-  :header-rows: 1
+   :header-rows: 1
 
-  * - Framework
-    - Dataset
-    - Filename
+   -  -  Framework
+      -  Dataset
+      -  Filename
 
-  * - TensorFlow (Estimator API)
-    - MNIST
-    - :download:`data_layer_mnist_estimator.tgz </examples/data_layer_mnist_estimator.tgz>`
+   -  -  PyTorch
+      -  CIFAR-10
+      -  :download:`darts_cifar10_pytorch.tgz
+         </examples/darts_cifar10_pytorch.tgz>`
 
-  * - TensorFlow (tf.keras)
-    - MNIST
-    - :download:`data_layer_mnist_tf_keras.tgz </examples/data_layer_mnist_tf_keras.tgz>`
+   -  -  PyTorch
+      -  Penn Treebank Dataset
+      -  :download:`darts_penntreebank_pytorch.tgz
+         </examples/darts_penntreebank_pytorch.tgz>`
+
+**********************************
+ Neural Architecture Search (NAS)
+**********************************
+
+.. list-table::
+   :header-rows: 1
+
+   -  -  Framework
+      -  Dataset
+      -  Filename
+
+   -  -  PyTorch
+      -  DARTS
+      -  :download:`gaea_pytorch.tgz </examples/gaea_pytorch.tgz>`
+
+***************
+ Meta Learning
+***************
+
+.. list-table::
+   :header-rows: 1
+
+   -  -  Framework
+      -  Dataset
+      -  Filename
+
+   -  -  PyTorch
+      -  Omniglot
+      -  :download:`protonet_omniglot_pytorch.tgz
+         </examples/protonet_omniglot_pytorch.tgz>`
+
+****************************************
+ Generative Adversarial Networks (GANs)
+****************************************
+
+.. list-table::
+   :header-rows: 1
+
+   -  -  Framework
+      -  Dataset
+      -  Filename
+
+   -  -  PyTorch
+      -  MNIST
+      -  :download:`gan_mnist_pytorch.tgz
+         </examples/gan_mnist_pytorch.tgz>`
+
+****************
+ Decision Trees
+****************
+
+.. list-table::
+   :header-rows: 1
+
+   -  -  Framework
+      -  Dataset
+      -  Filename
+
+   -  -  TensorFlow (Estimator API)
+      -  Titanic
+      -  :download:`gbt_titanic_estimator.tgz
+         </examples/gbt_titanic_estimator.tgz>`
+
+************
+ Data Layer
+************
+
+.. list-table::
+   :header-rows: 1
+
+   -  -  Framework
+      -  Dataset
+      -  Filename
+
+   -  -  TensorFlow (Estimator API)
+      -  MNIST
+      -  :download:`data_layer_mnist_estimator.tgz
+         </examples/data_layer_mnist_estimator.tgz>`
+
+   -  -  TensorFlow (tf.keras)
+      -  MNIST
+      -  :download:`data_layer_mnist_tf_keras.tgz
+         </examples/data_layer_mnist_tf_keras.tgz>`

--- a/docs/how-to/ide-setup.txt
+++ b/docs/how-to/ide-setup.txt
@@ -7,8 +7,8 @@
 Model developers may develop and debug models with their preferred IDE.
 In this guide, we show how to configure `PyCharm
 <https://www.jetbrains.com/pycharm/>`__ in order to develop and debug
-experiments submitted from Python, i.e. :ref:`this
-pattern <model-definitions_trial-api-create>` for the Trial API.
+experiments submitted from Python, i.e. :ref:`this pattern
+<model-definitions_trial-api-create>` for the Trial API.
 
 ***************
  Prerequisites

--- a/docs/how-to/installation/gcp.txt
+++ b/docs/how-to/installation/gcp.txt
@@ -234,10 +234,8 @@ Optional Arguments:
       -  Intel Broadwell
 
    -  -  ``--local-state-path``
-
       -  Directory used to store cluster metadata. The same directory
          cannot be used for multiple clusters at the same time.
-
       -  Current working directory
 
 The following ``gcloud`` commands will help to validate your

--- a/docs/how-to/installation/kubernetes.txt
+++ b/docs/how-to/installation/kubernetes.txt
@@ -21,8 +21,7 @@ the following prerequisites are satisfied:
    support enabled.
 -  You should have access to the cluster via `kubectl
    <https://kubernetes.io/docs/tasks/tools/install-kubectl/>`_.
--  `Helm 3 <https://helm.sh/docs/intro/install/>`_ should be
-   installed.
+-  `Helm 3 <https://helm.sh/docs/intro/install/>`_ should be installed.
 
 You should also download a copy of the :download:`Determined Helm Chart
 </helm/determined-helm-chart.tgz>` and extract it on your local machine.

--- a/docs/how-to/rest-apis.txt
+++ b/docs/how-to/rest-apis.txt
@@ -24,13 +24,11 @@ As Swagger puts it:
    Specification, with the visual documentation making it easy for back
    end implementation and client-side consumption."
 
-
-A static version of the Swagger UI is bundled with these docs
-`here
-<../rest-api/index.html>`__. If
-you have access to a running Determined cluster you can checkout the
-live-interact version by clicking the API icon from the Determined WebUI or
-by visiting the path `/docs/rest-api/` on your Determined cluster.
+A static version of the Swagger UI is bundled with these docs `here
+<../rest-api/index.html>`__. If you have access to a running Determined
+cluster you can checkout the live-interact version by clicking the API
+icon from the Determined WebUI or by visiting the path `/docs/rest-api/`
+on your Determined cluster.
 
 The Swagger UI gives you an up-to-date view of the APIs your Determined
 cluster provides in a readable and interactive fashion.

--- a/docs/index.txt
+++ b/docs/index.txt
@@ -63,7 +63,8 @@ Each user should also :ref:`install the Determined command-line tools
 Next Steps
 ==========
 
-We recommend starting with the :ref:`quick-start` if you're new to Determined.
+We recommend starting with the :ref:`quick-start` if you're new to
+Determined.
 
 Next, learn more about Determined's Python APIs by following a tutorial.
 Follow the tutorial for your preferred framework:

--- a/docs/reference/api/pytorch.txt
+++ b/docs/reference/api/pytorch.txt
@@ -184,8 +184,7 @@ places in your code:
  Examples
 **********
 
--  :download:`cifar10_pytorch.tgz
-   </examples/cifar10_pytorch.tgz>`
+-  :download:`cifar10_pytorch.tgz </examples/cifar10_pytorch.tgz>`
 -  :download:`mnist_pytorch.tgz </examples/mnist_pytorch.tgz>`
 -  :download:`fasterrcnn_coco_pytorch.tgz
    </examples/fasterrcnn_coco_pytorch.tgz>`

--- a/docs/reference/cluster-config.txt
+++ b/docs/reference/cluster-config.txt
@@ -502,8 +502,7 @@ The master supports the following configuration settings:
          version of the Determined agent image from a specific project,
          it should be set in the format:
          ``projects/<project-id>/global/images/<image-id>``. Defaults to
-         the latest GCP agent image.
-         (*Optional*)
+         the latest GCP agent image. (*Optional*)
 
       -  ``label_key``: Key for labeling the Determined agent instances.
          Defaults to ``managed-by``.

--- a/docs/reference/helm-config.txt
+++ b/docs/reference/helm-config.txt
@@ -75,14 +75,16 @@ Helm Chart </helm/determined-helm-chart.tgz>`.
 
    -  ``cpuRequest``: The CPU requirements for the Determined database.
 
-   -  ``memRequest``: The memory requirements for the Determined database.
+   -  ``memRequest``: The memory requirements for the Determined
+      database.
 
-   -  ``storageClassName``: Optional configuration to indicate StorageClass
-      that should be used by the PersistentVolumeClaim for the Determined
-      deployed database. This can be left blank if a default storage class
-      is specified in the cluster. If dynamic provisioning of PersistentVolumes
-      is disabled, users must manually create a PersistentVolume that will
-      match the PersistentVolumeClaim.
+   -  ``storageClassName``: Optional configuration to indicate
+      StorageClass that should be used by the PersistentVolumeClaim for
+      the Determined deployed database. This can be left blank if a
+      default storage class is specified in the cluster. If dynamic
+      provisioning of PersistentVolumes is disabled, users must manually
+      create a PersistentVolume that will match the
+      PersistentVolumeClaim.
 
 -  ``checkpointStorage``: Specifies where model checkpoints will be
    stored. This can be overridden on a per-experiment basis in the

--- a/docs/release-notes.txt
+++ b/docs/release-notes.txt
@@ -15,29 +15,45 @@ Version 0.13.6
 
 **Improvements**
 
-- Agent: The ``boot_disk_source_image`` field for GCP dynamic agents and ``image_id`` field for AWS dynamic agents are now optional. If omitted, the default value is the Determined agent image that matches the Determined master being used.
+-  Agent: The ``boot_disk_source_image`` field for GCP dynamic agents
+   and ``image_id`` field for AWS dynamic agents are now optional. If
+   omitted, the default value is the Determined agent image that matches
+   the Determined master being used.
 
-- Documentation: Ship Swagger UI with Determined documentation.  The ``/swagger-ui`` endpoint has been renamed to ``/docs/rest-api``.
+-  Documentation: Ship Swagger UI with Determined documentation. The
+   ``/swagger-ui`` endpoint has been renamed to ``/docs/rest-api``.
 
-- Documentation: Add a :ref:`guide on configuring TLS <tls>` in Determined.
+-  Documentation: Add a :ref:`guide on configuring TLS <tls>` in
+   Determined.
 
-- Kubernetes: Add support for configuring memory and CPU requirements for the Determined database when installing via the Determined Helm Chart.
+-  Kubernetes: Add support for configuring memory and CPU requirements
+   for the Determined database when installing via the Determined Helm
+   Chart.
 
-- Kubernetes: Add support for configuring the `storageClass <https://kubernetes.io/docs/concepts/storage/storage-classes/>`__ that is used when deploying a database using the Determined Helm Chart.
+-  Kubernetes: Add support for configuring the `storageClass
+   <https://kubernetes.io/docs/concepts/storage/storage-classes/>`__
+   that is used when deploying a database using the Determined Helm
+   Chart.
 
 **Bug Fixes**
 
-- Harness: Do not require the master to present a full TLS certificate chain when the certificate is signed by a well-known Certificate Authority.
+-  Harness: Do not require the master to present a full TLS certificate
+   chain when the certificate is signed by a well-known Certificate
+   Authority.
 
-- Harness: Fix a bug which affected ``TFKerasTrial`` using TensorFlow 2 with ``gradient_aggregation`` > 1.
+-  Harness: Fix a bug which affected ``TFKerasTrial`` using TensorFlow 2
+   with ``gradient_aggregation`` > 1.
 
-- Master: Fix a bug where the master instance would fail if an experiment could not be read from the database.
+-  Master: Fix a bug where the master instance would fail if an
+   experiment could not be read from the database.
 
-- WebUI: Preserve the colors used for multiple metrics on the metric chart.
+-  WebUI: Preserve the colors used for multiple metrics on the metric
+   chart.
 
-- WebUI: Fix the ability to cancel a batch of experiments.
+-  WebUI: Fix the ability to cancel a batch of experiments.
 
-- WebUI: Fix a bug which caused the Experiment Details page to not render when the latest validation metric is not available.
+-  WebUI: Fix a bug which caused the Experiment Details page to not
+   render when the latest validation metric is not available.
 
 Version 0.13.5
 ==============
@@ -46,49 +62,73 @@ Version 0.13.5
 
 **Improvements**
 
-- Security: Use one TCP port for all incoming connections to the master and use TLS for all connections if configured.
+-  Security: Use one TCP port for all incoming connections to the master
+   and use TLS for all connections if configured.
 
-  - **Breaking Change:** The ``http_port`` and ``https_port`` options in the master configuration have been replaced by the single ``port`` option. The ``security.http`` option is no longer accepted; the master can no longer be configured to listen over HTTP and HTTPS simultaneously.
+   -  **Breaking Change:** The ``http_port`` and ``https_port`` options
+      in the master configuration have been replaced by the single
+      ``port`` option. The ``security.http`` option is no longer
+      accepted; the master can no longer be configured to listen over
+      HTTP and HTTPS simultaneously.
 
-- Security: Support configuring TLS encryption when deploying Determined on Kubernetes. For more details please see :ref:`install-on-kubernetes`.
+-  Security: Support configuring TLS encryption when deploying
+   Determined on Kubernetes. For more details please see
+   :ref:`install-on-kubernetes`.
 
-- Agent: Increase default max agent starting and idle timeouts to 20 minutes and increase max disconnected period from 5 to 10 minutes.
+-  Agent: Increase default max agent starting and idle timeouts to 20
+   minutes and increase max disconnected period from 5 to 10 minutes.
 
-- Deployment: Add support for ``det-deploy aws`` in the following new regions: ``ap-northeast-1``, ``eu-central-1``, ``eu-west-1``, ``us-east-2``.
+-  Deployment: Add support for ``det-deploy aws`` in the following new
+   regions: ``ap-northeast-1``, ``eu-central-1``, ``eu-west-1``,
+   ``us-east-2``.
 
-- Docker: Publish new Docker task containers that upgrade TensorFlow versions from 1.15.0 to 1.15.4, and 2.2.0 to 2.2.1.
+-  Docker: Publish new Docker task containers that upgrade TensorFlow
+   versions from 1.15.0 to 1.15.4, and 2.2.0 to 2.2.1.
 
-- Documentation: Add extra documentation and reorganize examples by use case.
+-  Documentation: Add extra documentation and reorganize examples by use
+   case.
 
-- Documentation: Add a ``tf.layers-in-Estimator`` example.
+-  Documentation: Add a ``tf.layers-in-Estimator`` example.
 
-- Kubernetes: Add support for users to specify ``initContainers`` and ``containers`` as part of their custom pod specs. Please see :ref:`custom-pod-specs` for details.
+-  Kubernetes: Add support for users to specify ``initContainers`` and
+   ``containers`` as part of their custom pod specs. Please see
+   :ref:`custom-pod-specs` for details.
 
-- Kubernetes: Publish version 0.2.0 of the Determined Helm chart.
+-  Kubernetes: Publish version 0.2.0 of the Determined Helm chart.
 
-- Native API: Deprecate Native API. Removed related examples and docs.
+-  Native API: Deprecate Native API. Removed related examples and docs.
 
-- Trials: Remove support for ``TensorpackTrial``.
+-  Trials: Remove support for ``TensorpackTrial``.
 
-- WebUI: Improve polling behavior for experiment and trial details pages to avoid hanging indefinitely for very large experiments/trials.
+-  WebUI: Improve polling behavior for experiment and trial details
+   pages to avoid hanging indefinitely for very large
+   experiments/trials.
 
 **Bug Fixes**
 
-- Trials: Fix a bug where if only a subset of workers on a machine executed the ``on_trial_close()`` ``EstimatorTrial`` callback, the container would terminate as soon as one worker exited.
+-  Trials: Fix a bug where if only a subset of workers on a machine
+   executed the ``on_trial_close()`` ``EstimatorTrial`` callback, the
+   container would terminate as soon as one worker exited.
 
-- Trials: Fix a bug where ``det e create --test`` would succeed when there were checkpointing failures.
+-  Trials: Fix a bug where ``det e create --test`` would succeed when
+   there were checkpointing failures.
 
-- WebUI: Fix the issue of multiple selected rows dissappearing after a successful table batch action.
+-  WebUI: Fix the issue of multiple selected rows dissappearing after a
+   successful table batch action.
 
-- WebUI: Remove unused TensorBoard sources column from the task list page.
+-  WebUI: Remove unused TensorBoard sources column from the task list
+   page.
 
-- WebUI: Fix rendering metrics with the same name on the metric chart.
+-  WebUI: Fix rendering metrics with the same name on the metric chart.
 
-- WebUI: Make several fixes to improve select appearance and user experience.
+-  WebUI: Make several fixes to improve select appearance and user
+   experience.
 
-- WebUI: Fix the issue of agent and cluster info not loading on slow connections.
+-  WebUI: Fix the issue of agent and cluster info not loading on slow
+   connections.
 
-- WebUI: Fix the issue where the chart in the Experiment page does not have the metric name in the legend.
+-  WebUI: Fix the issue where the chart in the Experiment page does not
+   have the metric name in the legend.
 
 Version 0.13.4
 ==============
@@ -722,24 +762,17 @@ Version 0.12.10
 **Improvements**
 
 -  WebUI: Add a dedicated page for master logs at ``/det/logs``.
-
 -  WebUI: Provide a Swagger UI for exploring the Determined REST API.
    This can be accessed via the API link on the WebUI.
-
 -  WebUI: Default the Experiments view list length to 25 entries. More
    entries can be shown as needed.
-
 -  WebUI: Improve detection of situations where the WebUI version
    doesn't match the master version as a result of browser caching.
-
 -  CLI: Improve performance when retrieving trial logs.
-
 -  CLI: Add the ``det user rename`` command for administrators to change
    the username of existing users.
-
 -  Expand documentation on :ref:`use-trained-models` by including
    checkpoint metadata management.
-
 -  Reorganize examples by splitting :ref:`model-definitions_trial-api`
    examples into separate folders.
 

--- a/docs/release-notes/1441-tensorboard-sources.txt
+++ b/docs/release-notes/1441-tensorboard-sources.txt
@@ -2,8 +2,10 @@
 
 **BUG FIXES**
 
-- WebUI: Show TensorBoard sources correctly when starting TensorBoard from the CLI.
+-  WebUI: Show TensorBoard sources correctly when starting TensorBoard
+   from the CLI.
 
 **NEW FEATURES**
 
-- WebUI: Show both experiment and trial TensorBoard sources simultaneously if applicable on the experiment list page.
+-  WebUI: Show both experiment and trial TensorBoard sources
+   simultaneously if applicable on the experiment list page.

--- a/docs/release-notes/1446-style-and-copy-fix.txt
+++ b/docs/release-notes/1446-style-and-copy-fix.txt
@@ -2,5 +2,6 @@
 
 **BUG FIXES**
 
-- WebUI: Allow long checkpoint names to wrap in the checkpoint modal.
-- WebUI: Correct the confirmation message when performing batch operations for tasks.
+-  WebUI: Allow long checkpoint names to wrap in the checkpoint modal.
+-  WebUI: Correct the confirmation message when performing batch
+   operations for tasks.

--- a/docs/release-notes/1451-update-trial-id-for-new-trials.txt
+++ b/docs/release-notes/1451-update-trial-id-for-new-trials.txt
@@ -2,5 +2,5 @@
 
 **BUG FIXES**
 
-- Fix issue where trial ids were sometimes not displayed when running
-  ``det task list`` or ``det slot list`` in the CLI.
+-  Fix issue where trial ids were sometimes not displayed when running
+   ``det task list`` or ``det slot list`` in the CLI.

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -5,5 +5,5 @@ sphinx-argparse>=0.2.5
 git+https://github.com/determined-ai/determined_sphinx_theme.git@9edfa7c6ce6926def9fc69b8ddd7666f3419a907
 sphinx-sitemap>=2.2.0
 pillow
-rstfmt==0.0.5
+rstfmt==0.0.6
 sphinx-copybutton

--- a/docs/topic-guides/custom-pod-specs.txt
+++ b/docs/topic-guides/custom-pod-specs.txt
@@ -23,16 +23,17 @@ In this topic guide, we will cover:
 #. How to configuring default pod specs.
 #. How to configuring per-task pods specs.
 
-*****************************
-How Determined Uses Pod Specs
-*****************************
+*******************************
+ How Determined Uses Pod Specs
+*******************************
 
-All Determined tasks are launched as pods. Determined pods consists of an
-initContainer named ``determined-init-container`` and a container named
-``determined-container`` which execute the workload. When users provide a
-pod spec, Determined inserts the ``determined-init-container`` and
-``determined-container`` into the provided pod spec. As described below
-users may also configure some of the fields for the ``determined-container``.
+All Determined tasks are launched as pods. Determined pods consists of
+an initContainer named ``determined-init-container`` and a container
+named ``determined-container`` which execute the workload. When users
+provide a pod spec, Determined inserts the ``determined-init-container``
+and ``determined-container`` into the provided pod spec. As described
+below users may also configure some of the fields for the
+``determined-container``.
 
 *****************************
  Ways to Configure Pod Specs
@@ -186,7 +187,6 @@ Example of configuring a pod spec for an individual task:
          # Specify a pull secret for task container image.
          imagePullSecrets:
            name: regcred
-
 
 ************
  Next Steps

--- a/docs/topic-guides/tls.txt
+++ b/docs/topic-guides/tls.txt
@@ -5,20 +5,20 @@
 ##########################
 
 **Transport Layer Security** (TLS) is a protocol for secure network
-communication. TLS prevents the data being transmitted from
-being modified or read while it is in transit and allows clients to
-verify the identity of the server (in this case, the Determined master).
-Determined can be configured to use TLS for all connections made to the
-master. That means that all CLI and WebUI connections will be secured by
-TLS, as well as connections from agents and tasks to the master.
-Communication between agents that occur as part of
-:ref:`distributed training <multi-gpu-training>` will not use TLS, nor will
-proxied connections from the master to a :ref:`TensorBoard
-<how-to-tensorboard>` or :ref:`notebook <how-to-notebooks>` instance.
+communication. TLS prevents the data being transmitted from being
+modified or read while it is in transit and allows clients to verify the
+identity of the server (in this case, the Determined master). Determined
+can be configured to use TLS for all connections made to the master.
+That means that all CLI and WebUI connections will be secured by TLS, as
+well as connections from agents and tasks to the master. Communication
+between agents that occur as part of :ref:`distributed training
+<multi-gpu-training>` will not use TLS, nor will proxied connections
+from the master to a :ref:`TensorBoard <how-to-tensorboard>` or
+:ref:`notebook <how-to-notebooks>` instance.
 
-*******************************
+*****************
  Configuring TLS
-*******************************
+*****************
 
 Master
 ======
@@ -27,8 +27,8 @@ In order to :ref:`configure the master <master-configuration>` to use
 TLS, set the ``security.tls.cert`` and ``security.tls.key`` options to
 paths to a TLS certificate file and key file.
 
-When TLS is in use, the master will listen on TCP port 8443 by default, rather
-than 8080.
+When TLS is in use, the master will listen on TCP port 8443 by default,
+rather than 8080.
 
 .. note::
 
@@ -52,9 +52,9 @@ configuration, the agent will be unable to verify the identity of the
 master, but the data sent over the connection will still be protected by
 TLS.
 
-When :ref:`dynamic agents <elastic-infra-index>` and TLS are both in use, the
-dynamic agents that the master creates will automatically be configured to
-connect securely to the master over TLS.
+When :ref:`dynamic agents <elastic-infra-index>` and TLS are both in
+use, the dynamic agents that the master creates will automatically be
+configured to connect securely to the master over TLS.
 
 CLI
 ===

--- a/docs/tutorials/pytorch-mnist-tutorial.txt
+++ b/docs/tutorials/pytorch-mnist-tutorial.txt
@@ -1,8 +1,8 @@
 .. _pytorch-mnist-tutorial:
 
-###################################
+########################
  PyTorch MNIST Tutorial
-###################################
+########################
 
 This tutorial describes how to port an existing PyTorch model to
 Determined. We will port a simple image classification model for the

--- a/docs/tutorials/tf-mnist-tutorial.txt
+++ b/docs/tutorials/tf-mnist-tutorial.txt
@@ -1,8 +1,8 @@
 .. _tf-mnist-tutorial:
 
-####################################################
+#########################################
  TensorFlow Keras Fashion MNIST Tutorial
-####################################################
+#########################################
 
 This tutorial describes how to port an existing ``tf.keras`` model to
 Determined. We will port a simple image classification model for the


### PR DESCRIPTION
## Description

We previously added a formatter for the reST files, but left out
enforcement of the formatting for stability's sake. But now it's been
long enough; let's make the checking automatic.

## Test Plan

- [x] run `make fmt-docs` and inspect the differences
- [x] run `make check-docs` with formatted/unformatted files and check that it succeeds/fails
- [x] check that CI fails with an unformatted file
- [x] check that CI passes with all formatted files

## Commentary

I went ahead and made a new CircleCI job, `lint-docs`, for this, since that feels proper. But I wouldn't mind tucking it into `lint-python`, which would be simpler (I think it would only require one line added to the config), especially if doing so, say, saved us any money.