### PR TITLE
fix: webui preserve colors on metrics chart [DET-4247]

### DIFF
--- a/docs/release-notes/1400-preserve-colors-on-metrics-chart.txt
+++ b/docs/release-notes/1400-preserve-colors-on-metrics-chart.txt
@@ -1,0 +1,5 @@
+:orphan:
+
+**BUG FIXES**
+
+- WebUI: Preserve the colors used for multiple metrics on the metric chart.

--- a/webui/react/src/pages/ExperimentDetails/ExperimentChart.tsx
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentChart.tsx
@@ -49,7 +49,7 @@ const ExperimentChart: React.FC<Props> = ({ validationMetric, ...props }: Props)
       x: xData,
       y: yData,
     } ];
-  }, [ props.startTime, props.validationHistory ]);
+  }, [ props.startTime, props.validationHistory, validationMetric ]);
 
   return <MetricChart
     data={data}

--- a/webui/react/src/pages/TrialDetails/TrialChart.tsx
+++ b/webui/react/src/pages/TrialDetails/TrialChart.tsx
@@ -16,6 +16,30 @@ interface Props {
 
 const STORAGE_PATH = 'trial-detail';
 
+// Plotly.js colors imported from node_modules/plotly.js/src/components/color/attributes.js
+const chartColorList = [
+  '#1f77b4',  // muted blue
+  '#ff7f0e',  // safety orange
+  '#2ca02c',  // cooked asparagus green
+  '#d62728',  // brick red
+  '#9467bd',  // muted purple
+  '#8c564b',  // chestnut brown
+  '#e377c2',  // raspberry yogurt pink
+  '#7f7f7f',  // middle gray
+  '#bcbd22',  // curry yellow-green
+  '#17becf',  // blue-teal
+];
+
+const metricColorByKey: { [metricKey: string]: string } = {};
+
+const getMetricColorByKey = (metricKey: string): string => {
+  if (!metricColorByKey[metricKey]) {
+    const index = Object.keys(metricColorByKey).length % chartColorList.length;
+    metricColorByKey[metricKey] = chartColorList[index];
+  }
+  return metricColorByKey[metricKey];
+};
+
 const TrialChart: React.FC<Props> = ({
   metricNames,
   storageKey,
@@ -55,6 +79,7 @@ const TrialChart: React.FC<Props> = ({
           if (!dataMap[metricKey]) {
             dataMap[metricKey] = {
               hovertemplate: '%{text}<extra></extra>',
+              line: { color: getMetricColorByKey(metricKey) },
               mode: 'lines+markers',
               name: `${metric.name} (${metric.type})`,
               text: [],


### PR DESCRIPTION
## Description

Notes:
- there's a linting fix on webui/react/src/pages/ExperimentDetails/ExperimentChart.tsx
- demo video uploaded on JIRA.

## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
