### PR TITLE
fix: use the correct target cancel state for canceling experiment [DET-4257]

### DIFF
--- a/docs/release-notes/1404-fix-batch-experiment-cancel.txt
+++ b/docs/release-notes/1404-fix-batch-experiment-cancel.txt
@@ -1,0 +1,5 @@
+:orphan:
+
+**BUG FIXES**
+
+- WebUI: Fix the abiity to cancel a batch of experiments.

--- a/webui/react/src/pages/ExperimentList.tsx
+++ b/webui/react/src/pages/ExperimentList.tsx
@@ -230,7 +230,10 @@ const ExperimentList: React.FC = () => {
           case Action.Archive:
             return archiveExperiment(experiment.id);
           case Action.Cancel:
-            return setExperimentState({ experimentId: experiment.id, state: RunState.StoppingCanceled });
+            return setExperimentState({
+              experimentId: experiment.id,
+              state: RunState.StoppingCanceled,
+            });
           case Action.Kill:
             return killExperiment({ experimentId: experiment.id });
           case Action.Pause:

--- a/webui/react/src/pages/ExperimentList.tsx
+++ b/webui/react/src/pages/ExperimentList.tsx
@@ -230,7 +230,7 @@ const ExperimentList: React.FC = () => {
           case Action.Archive:
             return archiveExperiment(experiment.id);
           case Action.Cancel:
-            return setExperimentState({ experimentId: experiment.id, state: RunState.Canceled });
+            return setExperimentState({ experimentId: experiment.id, state: RunState.StoppingCanceled });
           case Action.Kill:
             return killExperiment({ experimentId: experiment.id });
           case Action.Pause:


### PR DESCRIPTION
## Description

The correct target state for canceling an experiment is `StoppingCanceled` instead of `Canceled`.

<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234