### PR TITLE
fix: always load default system TLS certificates in the harness [DET-4293]

### DIFF
--- a/docs/release-notes/1409-default-certs.txt
+++ b/docs/release-notes/1409-default-certs.txt
@@ -1,0 +1,6 @@
+:orphan:
+
+**Bug Fixes**
+
+-  Make the harness not require the master to present a full TLS
+   certificate chain when the certificate is signed by a well-known CA.

--- a/harness/determined/layers/_socket_manager.py
+++ b/harness/determined/layers/_socket_manager.py
@@ -22,10 +22,9 @@ class CustomSSLWebsocketSession(lomond.session.WebsocketSession):  # type: ignor
         self.ctx = ssl.SSLContext(ssl.PROTOCOL_TLSv1_2)
         self.ctx.verify_mode = ssl.CERT_REQUIRED
         self.ctx.check_hostname = True
+        self.ctx.load_default_certs()
         if env.master_cert_file is not None:
             self.ctx.load_verify_locations(cafile=env.master_cert_file)
-        else:
-            self.ctx.load_default_certs()
 
     def _wrap_socket(self, sock: socket.SocketType, host: str) -> socket.SocketType:
         return self.ctx.wrap_socket(sock, server_hostname=host)


### PR DESCRIPTION
## Description

This obviates the need to supply a full certificate chain (going all the
way to a root certificate) when the master certificate is signed by a
well-known CA.

## Test Plan

- [x] run a master with a Let's Encrypt cert, check that the harness runs with this change and fails without it