### PR TITLE
feat: make AWS and GCP agent image optional [DET-4201]

### DIFF
--- a/docs/reference/cluster-config.txt
+++ b/docs/reference/cluster-config.txt
@@ -431,7 +431,8 @@ The master supports the following configuration settings:
       -  ``root_volume_size``: Size of the root volume of the Determined
          agent in GB. We recommend at least 100GB. Defaults to ``200``.
 
-      -  ``image_id``: The AMI ID of the Determined agent. (*Required*)
+      -  ``image_id``: The AMI ID of the Determined agent. Defaults to
+         the latest GCP agent image. (*Optional*)
 
       -  ``tag_key``: Key for tagging the Determined agent instances.
          Defaults to ``managed-by``.
@@ -500,8 +501,9 @@ The master supports the following configuration settings:
          Determined agent that was shared with you. To use a specific
          version of the Determined agent image from a specific project,
          it should be set in the format:
-         ``projects/<project-id>/global/images/<image-id>``.
-         (*Required*)
+         ``projects/<project-id>/global/images/<image-id>``. Defaults to
+         the latest GCP agent image.
+         (*Optional*)
 
       -  ``label_key``: Key for labeling the Determined agent instances.
          Defaults to ``managed-by``.

--- a/docs/release-notes/1417-default-boot-disk-image.txt
+++ b/docs/release-notes/1417-default-boot-disk-image.txt
@@ -1,0 +1,6 @@
+:orphan:
+
+**Improvements**
+
+- The ``boot_disk_source_image`` field for GCP dynamic agents and `image_id` field for AWS
+  dynamic agents are now optional. They default to the latest agent images.

--- a/master/internal/provisioner/gcp_config.go
+++ b/master/internal/provisioner/gcp_config.go
@@ -47,8 +47,9 @@ type GCPClusterConfig struct {
 // DefaultGCPClusterConfig returns the default configuration of the gcp cluster.
 func DefaultGCPClusterConfig() *GCPClusterConfig {
 	return &GCPClusterConfig{
-		BootDiskSize: 200,
-		LabelKey:     "managed-by",
+		BootDiskSize:        200,
+		BootDiskSourceImage: "projects/determined-ai/global/images/det-environments-825decd",
+		LabelKey:            "managed-by",
 		InstanceType: gceInstanceType{
 			MachineType: "n1-standard-32",
 			GPUType:     "nvidia-tesla-v100",


### PR DESCRIPTION
## Description

The ``boot_disk_source_image`` field for GCP dynamic agents and `image_id` field for AWS dynamic agents are now optional. They default to the latest agent images.

## Test Plan

1. Test bumpenv tool.
2. Test AWS and GCP dynamic agents.

## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234