### PR TITLE
docs: add docs for TLS usage and configuration [DET-4364]

### DIFF
--- a/docs/reference/cluster-config.txt
+++ b/docs/reference/cluster-config.txt
@@ -670,8 +670,8 @@ The master supports the following configuration settings:
 
 -  ``security``: Specifies security-related configuration settings.
 
-   -  ``tls``: Specifies TLS-related configuration settings. TLS is
-      enabled if certificate and key files are both specified.
+   -  ``tls``: Specifies configuration settings for :ref:`TLS <tls>`.
+      TLS is enabled if certificate and key files are both specified.
 
       -  ``cert``: Certificate file to use for serving TLS.
       -  ``key``: Key file to use for serving TLS.
@@ -728,7 +728,7 @@ The master supports the following configuration settings:
 
 -  ``security``: Security-related configuration settings.
 
-   -  ``tls``: TLS-related configuration settings.
+   -  ``tls``: Configuration settings for :ref:`TLS <tls>`.
 
       -  ``enabled``: Whether to use TLS to connect to the master.
          Defaults to ``false``.

--- a/docs/topic-guides/index.txt
+++ b/docs/topic-guides/index.txt
@@ -66,6 +66,7 @@ The full list of our topic guides can be found below:
    elastic-infra/dynamic-agents-aws
    elastic-infra/dynamic-agents-gcp
    terminology-concepts
+   tls
    user-interfaces
    users
    yaml

--- a/docs/topic-guides/tls.txt
+++ b/docs/topic-guides/tls.txt
@@ -1,0 +1,82 @@
+.. _tls:
+
+##########################
+ Transport Layer Security
+##########################
+
+**Transport Layer Security** (TLS) is a protocol for applying encryption
+to network communications. It prevents the data being transmitted from
+being modified or read while it is in transit and allows clients to
+verify the identity of the server (in this case, the Determined master).
+Determined can be set up to use TLS for all connections made to the
+master. That means that all CLI and WebUI connections will be secured by
+TLS, as well as connections from agents and tasks to the master.
+Communications within the cluster that occur as part of
+:ref:`distributed training <multi-gpu-training>` do not use TLS, nor do
+proxied connections from the master to a :ref:`TensorBoard
+<how-to-tensorboard>` or :ref:`notebook <how-to-notebooks>` instance.
+
+*******************************
+ Configuring TLS in Determined
+*******************************
+
+Master
+======
+
+In order to :ref:`configure the master <master-configuration>` to use
+TLS, set the ``security.tls.cert`` and ``security.tls.key`` options to
+paths to a TLS certificate file and key file.
+
+When TLS is in use, the default TCP port for the master to listen on if
+none is specified is 8443 rather than 8080.
+
+.. note::
+
+   If the master's certificate is not signed by a well-known CA, then
+   the configured certificate file must contain a full certificate chain
+   that goes all the way to a root certificate.
+
+Agents
+======
+
+When the Determined master is using TLS, set the
+``security.tls.enabled`` :ref:`agent configuration option
+<agent-configuration>` to ``true``. If the master's certificate is
+signed by a well-known CA, then no other TLS-specific configuration is
+necessary. Otherwise, for the best security, place the master's
+certificate file somewhere accessible to the agent and set the agent's
+``security.tls.master_cert`` option to the path to that file. For a more
+convenient but less secure setup, instead set the
+``security.tls.skip_verify`` option to ``true``. With the latter
+configuration, the agent will be unable to verify the identity of the
+master, but the data sent over the connection will still be protected by
+TLS.
+
+When :ref:`elastic infrastructure <elastic-infra-index>` and TLS are
+both in use, the dynamic agents that the master creates will
+automatically be configured to connect securely to the master over TLS.
+
+CLI
+===
+
+In order to use TLS, the CLI must be configured with a master address
+starting with ``https://`` using either the ``-m`` flag or
+``DET_MASTER`` environment variable.
+
+If the master's certificate is signed by a well-known CA, then the
+connection should proceed immediately. If not, the CLI will indicate on
+the first connection that the master is presenting an untrusted
+certificate and display a hash of the certificate. You may wish to
+confirm the hash with your system administrator; in any case, if you
+confirm the connection to the master, the certificate will be stored on
+the computer where the CLI is being run and future connections to the
+master will be made without confirmation.
+
+Tasks
+=====
+
+Once the master and agent are set up to use TLS, no further
+configuration is required for tasks that are run in the cluster. In
+shells and notebooks, the Determined :ref:`Python libraries
+<experimental>` will automatically make connections to the master using
+TLS with the appropriate certificate.

--- a/docs/topic-guides/tls.txt
+++ b/docs/topic-guides/tls.txt
@@ -4,20 +4,20 @@
  Transport Layer Security
 ##########################
 
-**Transport Layer Security** (TLS) is a protocol for applying encryption
-to network communications. It prevents the data being transmitted from
+**Transport Layer Security** (TLS) is a protocol for secure network
+communication. TLS prevents the data being transmitted from
 being modified or read while it is in transit and allows clients to
 verify the identity of the server (in this case, the Determined master).
-Determined can be set up to use TLS for all connections made to the
+Determined can be configured to use TLS for all connections made to the
 master. That means that all CLI and WebUI connections will be secured by
 TLS, as well as connections from agents and tasks to the master.
-Communications within the cluster that occur as part of
-:ref:`distributed training <multi-gpu-training>` do not use TLS, nor do
+Communication between agents that occur as part of
+:ref:`distributed training <multi-gpu-training>` will not use TLS, nor will
 proxied connections from the master to a :ref:`TensorBoard
 <how-to-tensorboard>` or :ref:`notebook <how-to-notebooks>` instance.
 
 *******************************
- Configuring TLS in Determined
+ Configuring TLS
 *******************************
 
 Master
@@ -27,8 +27,8 @@ In order to :ref:`configure the master <master-configuration>` to use
 TLS, set the ``security.tls.cert`` and ``security.tls.key`` options to
 paths to a TLS certificate file and key file.
 
-When TLS is in use, the default TCP port for the master to listen on if
-none is specified is 8443 rather than 8080.
+When TLS is in use, the master will listen on TCP port 8443 by default, rather
+than 8080.
 
 .. note::
 
@@ -52,9 +52,9 @@ configuration, the agent will be unable to verify the identity of the
 master, but the data sent over the connection will still be protected by
 TLS.
 
-When :ref:`elastic infrastructure <elastic-infra-index>` and TLS are
-both in use, the dynamic agents that the master creates will
-automatically be configured to connect securely to the master over TLS.
+When :ref:`dynamic agents <elastic-infra-index>` and TLS are both in use, the
+dynamic agents that the master creates will automatically be configured to
+connect securely to the master over TLS.
 
 CLI
 ===
@@ -75,7 +75,7 @@ master will be made without confirmation.
 Tasks
 =====
 
-Once the master and agent are set up to use TLS, no further
+Once the master and agent are configured to use TLS, no further
 configuration is required for tasks that are run in the cluster. In
 shells and notebooks, the Determined :ref:`Python libraries
 <experimental>` will automatically make connections to the master using


### PR DESCRIPTION
## Description

This adds a new topic guide page gathering together information on TLS
configuration. This initial version just covers Determined-specific
things, but more background on TLS and certificate creation might be
useful later on.

## Test Plan

- [x] render and examine docs

## Commentary (optional)

We probably want more here on how to generate certificates eventually, but I'm punting on that for now to get the most important Determined-specific information down.
