### PR TITLE
fix: make webui chart legend transparent to show data behind [DET-4218]

### DIFF
--- a/webui/react/src/components/MetricChart.tsx
+++ b/webui/react/src/components/MetricChart.tsx
@@ -42,7 +42,7 @@ type PlotArguments = [
 const defaultLayout: Partial<Plotly.Layout> = {
   height: 400,
   hovermode: 'x unified',
-  legend: { xanchor: 'right' },
+  legend: { bgcolor: 'rgba(255,255,255,0.75)', xanchor: 'right' },
   margin: { b: 50, l: 50, pad: 6, r: 10, t: 10 },
   showlegend: true,
   xaxis: { hoverformat: '' },


### PR DESCRIPTION
## Description

Opacity can be tweaked, is currently 75%.

Result is like this:
<img width="539" alt="Schermata 2020-10-08 alle 08 31 33" src="https://user-images.githubusercontent.com/5413702/95423509-7e372700-0941-11eb-9bf5-fd2012f28ecd.png">



## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
