### PR TITLE
feat: improved metric selector [DET-4122]

### DIFF
--- a/docs/release-notes/1421-improve-metric-selector.txt
+++ b/docs/release-notes/1421-improve-metric-selector.txt
@@ -4,5 +4,5 @@
 
 - Allow users to select all metrics in Trial detail page.
 - Allow users to select all results when filtering metrics in the Trial detail page.
-- Allow users to clear all metrics in Trial detail page.
+- Allow users to reset selected metrics back to default selection in Trial detail page.
 - Make the text in the dropdown more informative when dropdown is closed.

--- a/docs/release-notes/1421-improve-metric-selector.txt
+++ b/docs/release-notes/1421-improve-metric-selector.txt
@@ -2,7 +2,8 @@
 
 **Improvements**
 
-- Allow users to select all metrics in Trial detail page.
-- Allow users to select all results when filtering metrics in the Trial detail page.
-- Allow users to reset selected metrics back to default selection in Trial detail page.
-- Make the text in the dropdown more informative when dropdown is closed.
+- Improve metric selector in Trial detail page.
+  - Users can now select all metrics, select all results that match filter, and reset
+    selected metrics back to defaults. Selecting an option while filtering will no
+    longer close the selector and clear the filter. Also made the text shown when
+    dropdown is closed mor informative.

--- a/docs/release-notes/1421-improve-metric-selector.txt
+++ b/docs/release-notes/1421-improve-metric-selector.txt
@@ -1,0 +1,8 @@
+:orphan:
+
+**Improvements**
+
+- Allow users to select all metrics in Trial detail page.
+- Allow users to select all results when filtering metrics in the Trial detail page.
+- Allow users to clear all metrics in Trial detail page.
+- Make the text in the dropdown more informative when dropdown is closed.

--- a/docs/release-notes/1421-improve-metric-selector.txt
+++ b/docs/release-notes/1421-improve-metric-selector.txt
@@ -2,8 +2,10 @@
 
 **Improvements**
 
-- Improve metric selector in Trial detail page.
-  - Users can now select all metrics, select all results that match filter, and reset
-    selected metrics back to defaults. Selecting an option while filtering will no
-    longer close the selector and clear the filter. Also made the text shown when
-    dropdown is closed mor informative.
+-  Improve metric selector in Trial detail page.
+
+   -  Users can now select all metrics, select all results that match
+      the filter, and reset selected metrics back to the defaults.
+      Selecting an option while filtering will no longer close the
+      selector and clear the filter. Also made the text shown when
+      dropdown is closed more informative.

--- a/webui/react/src/components/MetricSelectFilter.tsx
+++ b/webui/react/src/components/MetricSelectFilter.tsx
@@ -86,13 +86,6 @@ const MetricSelectFilter: React.FC<Props> = ({ metricNames, multiple, onChange, 
   }, [ multiple, onChange, value ]);
 
   const handleFiltering = useCallback((search: string, option) => {
-    // Almost identical to callback in SelectFilter, but handles ALL option
-    /*
-     * `option.children` is one of the following:
-     * - undefined
-     * - string
-     * - string[]
-     */
     if (option.key === allOptionId) {
       return true;
     }

--- a/webui/react/src/components/MetricSelectFilter.tsx
+++ b/webui/react/src/components/MetricSelectFilter.tsx
@@ -116,13 +116,6 @@ const MetricSelectFilter: React.FC<Props> = ({ metricNames, multiple, onChange, 
     setFilterString(searchInput);
   };
 
-  const handleClear = useCallback(() => {
-    setFilterString('');
-    if (multiple) {
-      (onChange as MultipleHandler)([ ]);
-    }
-  }, [ multiple, onChange ]);
-
   const handleBlur = () => {
     setFilterString('');
   };
@@ -160,7 +153,6 @@ const MetricSelectFilter: React.FC<Props> = ({ metricNames, multiple, onChange, 
   }, [ metricValues, totalNumMetrics ]);
 
   return <SelectFilter
-    allowClear={multiple}
     disableTags
     dropdownMatchSelectWidth={400}
     filterOption={handleFiltering}
@@ -172,7 +164,6 @@ const MetricSelectFilter: React.FC<Props> = ({ metricNames, multiple, onChange, 
     style={{ width: 200 }}
     value={metricValues}
     onBlur={handleBlur}
-    onClear={multiple ? handleClear : undefined }
     onDeselect={handleMetricDeselect}
     onSearch={handleSearchInputChange}
     onSelect={handleMetricSelect}>

--- a/webui/react/src/components/MetricSelectFilter.tsx
+++ b/webui/react/src/components/MetricSelectFilter.tsx
@@ -176,7 +176,7 @@ const MetricSelectFilter: React.FC<Props> = ({
 
     { multiple && visibleMetrics.length > 0 &&
     <Option key={resetOptionId} value={resetOptionId}>
-      <BadgeTag label='Reset To Default' />
+      <BadgeTag label='Reset to Default' />
     </Option>}
 
     { multiple && visibleMetrics.length > 1 && allOption}

--- a/webui/react/src/components/MetricSelectFilter.tsx
+++ b/webui/react/src/components/MetricSelectFilter.tsx
@@ -1,13 +1,13 @@
 import { Select } from 'antd';
 import { SelectValue } from 'antd/es/select';
-import React, { createRef, useCallback, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useMemo, useRef, useState } from 'react';
 
 import { MetricName, MetricType } from 'types';
 import { metricNameSorter } from 'utils/data';
 import { metricNameFromValue, metricNameToValue, valueToMetricName } from 'utils/trial';
 
 import BadgeTag from './BadgeTag';
-import SelectFilter, { SelectFilterHandles } from './SelectFilter';
+import SelectFilter from './SelectFilter';
 
 const { OptGroup, Option } = Select;
 const allOptionId = 'ALL_RESULTS';

--- a/webui/react/src/components/MetricSelectFilter.tsx
+++ b/webui/react/src/components/MetricSelectFilter.tsx
@@ -110,7 +110,7 @@ const MetricSelectFilter: React.FC<Props> = ({
     const metricName = metricNameFromValue(option.value);
     if (metricName === undefined) {
       // Handle metric values that don't start with 'training|' or 'validation|'. This
-      // shouldn't happen and metricNameFromValue logs an error to console if it does.
+      // shouldn't ever happen and metricNameFromValue logs an error if it does.
       return false;
     }
     return filterFn(search, metricName.name);
@@ -174,7 +174,7 @@ const MetricSelectFilter: React.FC<Props> = ({
 
     { multiple && visibleMetrics.length > 0 &&
     <Option key={resetOptionId} value={resetOptionId}>
-      <BadgeTag label='Reset To Default Metric' />
+      <BadgeTag label='Reset To Defaults' />
     </Option>}
 
     { multiple && visibleMetrics.length > 1 && allOption}

--- a/webui/react/src/components/MetricSelectFilter.tsx
+++ b/webui/react/src/components/MetricSelectFilter.tsx
@@ -66,12 +66,10 @@ const MetricSelectFilter: React.FC<Props> = ({
 
     if ((newValue as string) === allOptionId) {
       (onChange as MultipleHandler)(visibleMetrics.sort(metricNameSorter));
-      setFilterString('');
       return;
     }
     if ((newValue as string) === resetOptionId) {
       (onChange as MultipleHandler)(defaultMetricNames.sort(metricNameSorter));
-      setFilterString('');
       return;
     }
 
@@ -85,7 +83,6 @@ const MetricSelectFilter: React.FC<Props> = ({
     } else {
       (onChange as SingleHandler)(metricName);
     }
-    setFilterString('');
   }, [ multiple, onChange, value, visibleMetrics, defaultMetricNames ]);
 
   const handleMetricDeselect = useCallback((newValue: SelectValue) => {
@@ -157,6 +154,7 @@ const MetricSelectFilter: React.FC<Props> = ({
   }, [ metricValues, totalNumMetrics ]);
 
   return <SelectFilter
+    autoClearSearchValue={false}
     disableTags
     dropdownMatchSelectWidth={400}
     filterOption={handleFiltering}

--- a/webui/react/src/components/MetricSelectFilter.tsx
+++ b/webui/react/src/components/MetricSelectFilter.tsx
@@ -1,13 +1,13 @@
 import { Select } from 'antd';
 import { SelectValue } from 'antd/es/select';
-import React, { useCallback, useMemo, useState } from 'react';
+import React, { createRef, useCallback, useMemo, useRef, useState } from 'react';
 
 import { MetricName, MetricType } from 'types';
 import { metricNameSorter } from 'utils/data';
 import { metricNameFromValue, metricNameToValue, valueToMetricName } from 'utils/trial';
 
 import BadgeTag from './BadgeTag';
-import SelectFilter from './SelectFilter';
+import SelectFilter, { SelectFilterHandles } from './SelectFilter';
 
 const { OptGroup, Option } = Select;
 const allOptionId = 'ALL_RESULTS';
@@ -36,6 +36,7 @@ const MetricSelectFilter: React.FC<Props> = ({
   defaultMetricNames,
 }: Props) => {
   const [ filterString, setFilterString ] = useState('');
+  const selectRef = useRef<Select<SelectValue>>(null);
 
   const metricValues = useMemo(() => {
     if (multiple && Array.isArray(value)) return value.map(metric => metricNameToValue(metric));
@@ -66,10 +67,12 @@ const MetricSelectFilter: React.FC<Props> = ({
 
     if ((newValue as string) === allOptionId) {
       (onChange as MultipleHandler)(visibleMetrics.sort(metricNameSorter));
+      selectRef.current?.blur();
       return;
     }
     if ((newValue as string) === resetOptionId) {
       (onChange as MultipleHandler)(defaultMetricNames.sort(metricNameSorter));
+      selectRef.current?.blur();
       return;
     }
 
@@ -162,6 +165,7 @@ const MetricSelectFilter: React.FC<Props> = ({
     maxTagCount={maxTagCount}
     maxTagPlaceholder={selectorPlaceholder}
     mode={multiple ? 'multiple' : undefined}
+    ref={selectRef}
     showArrow
     style={{ width: 200 }}
     value={metricValues}

--- a/webui/react/src/components/MetricSelectFilter.tsx
+++ b/webui/react/src/components/MetricSelectFilter.tsx
@@ -44,15 +44,16 @@ const MetricSelectFilter: React.FC<Props> = ({ metricNames, multiple, onChange, 
 
   const visibleMetrics = useMemo(() => {
     return metricNames.filter((metricName: MetricName) => {
+      console.log('Filtering metricName', filterInput, metricName);
       if (metricName.name.includes(filterInput)) {
         return true;
       }
-      if (metricName.type === MetricType.Training && 'training'.includes(filterInput)) {
-        return true;
-      }
-      if (metricName.type === MetricType.Validation && 'validation'.includes(filterInput)) {
-        return true;
-      }
+      // if (metricName.type === MetricType.Training && 'training'.includes(filterInput)) {
+      //   return true;
+      // }
+      // if (metricName.type === MetricType.Validation && 'validation'.includes(filterInput)) {
+      //   return true;
+      // }
       return false;
 
       // metricName.name !== 'All' && metricName.name !== 'None'
@@ -113,7 +114,21 @@ const MetricSelectFilter: React.FC<Props> = ({ metricNames, multiple, onChange, 
       return true;
     } else {
       // TODO: Split on pipe (as long as there is only one) so 'ion|' doesn't return results
-      return option.key.includes(filterInput);
+      let metricNameOnly = option.key;
+      const trainingPrefix = 'training|';
+      const validationPrefix = 'validation|';
+      let typeForSearch = '';
+      if (metricNameOnly.startsWith(trainingPrefix)) {
+        metricNameOnly = metricNameOnly.slice(trainingPrefix.length);
+        typeForSearch = 'training';
+      } else if (metricNameOnly.startsWith(validationPrefix)) {
+        metricNameOnly = metricNameOnly.slice(validationPrefix.length);
+        typeForSearch = 'validation';
+      }
+
+      console.log('handleFiltering', filterInput, option);
+      // return metricNameOnly.includes(filterInput) || typeForSearch.includes(filterInput);
+      return metricNameOnly.includes(filterInput);
     }
   };
 
@@ -122,11 +137,11 @@ const MetricSelectFilter: React.FC<Props> = ({ metricNames, multiple, onChange, 
     setFilterInput(searchInput);
   };
 
-  const handleDropdownVisibleChange = useCallback((open: boolean) => {
-    if (!open) {
-      setFilterInput('');
-    }
-  }, []);
+  // const handleDropdownVisibleChange = useCallback((open: boolean) => {
+  //   if (!open) {
+  //     setFilterInput('');
+  //   }
+  // }, []);
 
   // const handleClear = useCallback(() => {
   //   setFilterInput('');
@@ -161,6 +176,7 @@ const MetricSelectFilter: React.FC<Props> = ({ metricNames, multiple, onChange, 
   const handleBlur = () => {
     // On blur the inputFilter gets cleared
     console.log('handleBlur');
+    setFilterInput('');
   };
 
   const allSelector = useMemo(() => {
@@ -204,12 +220,12 @@ const MetricSelectFilter: React.FC<Props> = ({ metricNames, multiple, onChange, 
     maxTagPlaceholder={selectorPlaceholder}
     mode={multiple ? 'multiple' : undefined}
     showArrow
-    style={{ width: 150 }}
+    style={{ width: 200 }}
     value={metricValues}
     onBlur={handleBlur}
     onClear={handleClear}
     onDeselect={handleMetricDeselect}
-    onDropdownVisibleChange={handleDropdownVisibleChange}
+    // onDropdownVisibleChange={handleDropdownVisibleChange}
     onSearch={handleSearchInputChange}
     onSelect={handleMetricSelect}>
 

--- a/webui/react/src/components/MetricSelectFilter.tsx
+++ b/webui/react/src/components/MetricSelectFilter.tsx
@@ -174,7 +174,7 @@ const MetricSelectFilter: React.FC<Props> = ({
 
     { multiple && visibleMetrics.length > 0 &&
     <Option key={resetOptionId} value={resetOptionId}>
-      <BadgeTag label='Reset To Defaults' />
+      <BadgeTag label='Reset To Default' />
     </Option>}
 
     { multiple && visibleMetrics.length > 1 && allOption}

--- a/webui/react/src/components/MetricSelectFilter.tsx
+++ b/webui/react/src/components/MetricSelectFilter.tsx
@@ -69,7 +69,7 @@ const MetricSelectFilter: React.FC<Props> = ({ metricNames, multiple, onChange, 
       (onChange as SingleHandler)(metricName);
     }
     setFilterInput('');
-  }, [ multiple, onChange, value, filterInput ]);
+  }, [ multiple, onChange, value, visibleMetrics ]);
 
   const handleMetricDeselect = useCallback((newValue: SelectValue) => {
     if (!onChange || !multiple) return;
@@ -122,7 +122,7 @@ const MetricSelectFilter: React.FC<Props> = ({ metricNames, multiple, onChange, 
     setFilterInput('');
   };
 
-  const allSelector = useMemo(() => {
+  const allOption = useMemo(() => {
     let allOptionLabel;
     const numVisibleOptions = visibleMetrics.length;
     if (numVisibleOptions === totalNumMetrics) {
@@ -136,7 +136,7 @@ const MetricSelectFilter: React.FC<Props> = ({ metricNames, multiple, onChange, 
       </Option>
     );
 
-  }, [ filterInput, metricNames, visibleMetrics ]);
+  }, [ totalNumMetrics, visibleMetrics ]);
 
   const [ maxTagCount, selectorPlaceholder ] = useMemo(() => {
     // This should never happen, but fall back to inoffensive empty placeholder
@@ -172,7 +172,7 @@ const MetricSelectFilter: React.FC<Props> = ({ metricNames, multiple, onChange, 
     onSearch={handleSearchInputChange}
     onSelect={handleMetricSelect}>
 
-    { multiple && visibleMetrics.length > 1 && allSelector}
+    { multiple && visibleMetrics.length > 1 && allOption}
 
     {validationMetricNames.length > 0 && <OptGroup label="Validation Metrics">
       {validationMetricNames.map(key => {

--- a/webui/react/src/components/MetricSelectFilter.tsx
+++ b/webui/react/src/components/MetricSelectFilter.tsx
@@ -47,6 +47,8 @@ const MetricSelectFilter: React.FC<Props> = ({ metricNames, multiple, onChange, 
     return metricName.toLocaleLowerCase().indexOf(search.toLocaleLowerCase()) !== -1;
   };
 
+  // visibleMetrics should always match the list of metrics that antd displays to
+  // the user, including any filtering.
   const visibleMetrics = useMemo(() => {
     return metricNames.filter((metricName: MetricName) => {
       return filterFn(filterString, metricName.name);
@@ -109,7 +111,6 @@ const MetricSelectFilter: React.FC<Props> = ({ metricNames, multiple, onChange, 
 
   const handleClear = useCallback(() => {
     setFilterString('');
-
     if (multiple) {
       (onChange as MultipleHandler)([ ]);
     }

--- a/webui/react/src/components/MetricSelectFilter.tsx
+++ b/webui/react/src/components/MetricSelectFilter.tsx
@@ -54,8 +54,10 @@ const MetricSelectFilter: React.FC<Props> = ({
 
   const totalNumMetrics = useMemo(() => { return metricNames.length; }, [ metricNames ]);
 
-  // visibleMetrics should always match the list of metrics that antd displays to
-  // the user, including any filtering.
+  /*
+   * visibleMetrics should always match the list of metrics that antd displays to
+   * the user, including any filtering.
+   */
   const visibleMetrics = useMemo(() => {
     return metricNames.filter((metricName: MetricName) => {
       return filterFn(filterString, metricName.name);
@@ -103,14 +105,18 @@ const MetricSelectFilter: React.FC<Props> = ({
       return true;
     }
     if (!option.value) {
-      // Handle optionGroups that don't have a value to make TS happy. They aren't
-      // impacted by filtering anyway
+      /*
+       * Handle optionGroups that don't have a value to make TS happy. They aren't
+       * impacted by filtering anyway
+       */
       return false;
     }
     const metricName = metricNameFromValue(option.value);
     if (metricName === undefined) {
-      // Handle metric values that don't start with 'training|' or 'validation|'. This
-      // shouldn't ever happen and metricNameFromValue logs an error if it does.
+      /*
+       * Handle metric values that don't start with 'training|' or 'validation|'. This
+       * shouldn't ever happen and metricNameFromValue logs an error if it does.
+       */
       return false;
     }
     return filterFn(search, metricName.name);

--- a/webui/react/src/components/MetricSelectFilter.tsx
+++ b/webui/react/src/components/MetricSelectFilter.tsx
@@ -43,24 +43,12 @@ const MetricSelectFilter: React.FC<Props> = ({ metricNames, multiple, onChange, 
     return metricNames.length;
   }, [ metricNames ]);
 
-  const filterFn = (search: string, key?: string) => {
-    if (!key) {
-      return false;
-    }
-
-    if (key === allOptionId) {
-      return true;
-    }
-
-    return key.toLocaleLowerCase().indexOf(search.toLocaleLowerCase()) !== -1;
+  const filterFn = (search: string, metricName: string) => {
+    return metricName.toLocaleLowerCase().indexOf(search.toLocaleLowerCase()) !== -1;
   };
 
   const visibleMetrics = useMemo(() => {
     return metricNames.filter((metricName: MetricName) => {
-      // Don't include the ALL option as an actual metric
-      if (metricName.name === allOptionId) {
-        return false;
-      }
       return filterFn(filterString, metricName.name);
     });
   }, [ metricNames, filterString ]);

--- a/webui/react/src/components/MetricSelectFilter.tsx
+++ b/webui/react/src/components/MetricSelectFilter.tsx
@@ -10,6 +10,7 @@ import BadgeTag from './BadgeTag';
 import SelectFilter from './SelectFilter';
 
 const { OptGroup, Option } = Select;
+const allOptionId = 'ALL_RESULTS';
 
 type SingleHandler = (value: MetricName) => void;
 type MultipleHandler = (value: MetricName[]) => void;
@@ -51,7 +52,7 @@ const MetricSelectFilter: React.FC<Props> = ({ metricNames, multiple, onChange, 
   const handleMetricSelect = useCallback((newValue: SelectValue) => {
     if (!onChange) return;
 
-    if ((newValue as string) === 'All') {
+    if ((newValue as string) === allOptionId) {
       (onChange as MultipleHandler)(visibleMetrics.sort(metricNameSorter));
       setFilterInput('');
       return;
@@ -88,7 +89,7 @@ const MetricSelectFilter: React.FC<Props> = ({ metricNames, multiple, onChange, 
      * - string
      * - string[]
      */
-    if (option.key === 'All') {
+    if (option.key === allOptionId) {
       return true;
     }
 
@@ -130,7 +131,7 @@ const MetricSelectFilter: React.FC<Props> = ({ metricNames, multiple, onChange, 
       allOptionLabel =`All ${numVisibleOptions} results`;
     }
     return (
-      <Option key={'All'} value={'All'}>
+      <Option key={allOptionId} value={allOptionId}>
         <BadgeTag label={allOptionLabel} />
       </Option>
     );

--- a/webui/react/src/components/MetricSelectFilter.tsx
+++ b/webui/react/src/components/MetricSelectFilter.tsx
@@ -51,25 +51,19 @@ const MetricSelectFilter: React.FC<Props> = ({ metricNames, multiple, onChange, 
   const handleMetricSelect = useCallback((newValue: SelectValue) => {
     if (!onChange) return;
 
-    let metricName;
-    if ((newValue as string) !== 'All') {
-      metricName = valueToMetricName(newValue as string);
-      if (!metricName) return;
-    } else {
-      metricName = {
-        name: newValue as string,
-        type: MetricType.Placeholder,
-      };
+    if ((newValue as string) === 'All') {
+      (onChange as MultipleHandler)(visibleMetrics.sort(metricNameSorter));
+      setFilterInput('');
+      return;
     }
 
+    const metricName = valueToMetricName(newValue as string);
+    if (!metricName) return;
+
     if (multiple) {
-      if (newValue === 'All') {
-        (onChange as MultipleHandler)(visibleMetrics.sort(metricNameSorter));
-      } else {
-        const newMetric = Array.isArray(value) ? [ ...value ] : [];
-        if (newMetric.indexOf(metricName) === -1) newMetric.push(metricName);
-        (onChange as MultipleHandler)(newMetric.sort(metricNameSorter));
-      }
+      const newMetric = Array.isArray(value) ? [ ...value ] : [];
+      if (newMetric.indexOf(metricName) === -1) newMetric.push(metricName);
+      (onChange as MultipleHandler)(newMetric.sort(metricNameSorter));
     } else {
       (onChange as SingleHandler)(metricName);
     }
@@ -86,27 +80,8 @@ const MetricSelectFilter: React.FC<Props> = ({ metricNames, multiple, onChange, 
     (onChange as MultipleHandler)(newMetric.sort(metricNameSorter));
   }, [ multiple, onChange, value ]);
 
-  // const handleFiltering = (inputValue: string, option: any) => {
-  //   if (option.key === 'All') {
-  //     return true;
-  //   } else {
-  //     let metricNameOnly = option.key;
-  //     const trainingPrefix = 'training|';
-  //     const validationPrefix = 'validation|';
-  //     if (metricNameOnly.startsWith(trainingPrefix)) {
-  //       metricNameOnly = metricNameOnly.slice(trainingPrefix.length);
-  //     } else if (metricNameOnly.startsWith(validationPrefix)) {
-  //       metricNameOnly = metricNameOnly.slice(validationPrefix.length);
-  //     } else {
-  //       console.log("")
-  //     }
-  //
-  //     console.log('handleFiltering', filterInput, option);
-  //     // return metricNameOnly.includes(filterInput) || typeForSearch.includes(filterInput);
-  //     return metricNameOnly.includes(filterInput);
-  //   }
-  // };
   const handleFiltering = useCallback((search: string, option) => {
+    // Almost identical to callback in SelectFilter, but handles ALL option
     /*
      * `option.children` is one of the following:
      * - undefined
@@ -134,27 +109,6 @@ const MetricSelectFilter: React.FC<Props> = ({ metricNames, multiple, onChange, 
     setFilterInput(searchInput);
   };
 
-  // const handleClear = useCallback(() => {
-  //   setFilterInput('');
-  //   let newMetric;
-  //   if (validationMetricNames.length > 0) {
-  //     newMetric = validationMetricNames[0];
-  //   } else if (trainingMetricNames.length > 0){
-  //     newMetric = trainingMetricNames[0];
-  //   }
-  //   if (multiple) {
-  //     if (newMetric) {
-  //       (onChange as MultipleHandler)([ newMetric ]);
-  //     } else {
-  //       (onChange as MultipleHandler)([]);
-  //     }
-  //   } else {
-  //     if (newMetric){
-  //       (onChange as SingleHandler)(newMetric);
-  //     }
-  //   }
-  // }, [ onChange, validationMetricNames, trainingMetricNames ]);
-
   const handleClear = useCallback(() => {
     setFilterInput('');
 
@@ -164,7 +118,6 @@ const MetricSelectFilter: React.FC<Props> = ({ metricNames, multiple, onChange, 
   }, [ multiple, onChange ]);
 
   const handleBlur = () => {
-    // On blur, the antd clears the filter
     setFilterInput('');
   };
 
@@ -185,7 +138,7 @@ const MetricSelectFilter: React.FC<Props> = ({ metricNames, multiple, onChange, 
   }, [ filterInput, metricNames, visibleMetrics ]);
 
   const [ maxTagCount, selectorPlaceholder ] = useMemo(() => {
-    // This should never happen, but fall back to inoffensive empty label
+    // This should never happen, but fall back to inoffensive empty placeholder
     if (metricValues === undefined) {
       return [ 0, '' ];
     }
@@ -213,12 +166,12 @@ const MetricSelectFilter: React.FC<Props> = ({ metricNames, multiple, onChange, 
     style={{ width: 200 }}
     value={metricValues}
     onBlur={handleBlur}
-    onClear={multiple ? handleClear : () => {}}
+    onClear={multiple ? handleClear : undefined }
     onDeselect={handleMetricDeselect}
     onSearch={handleSearchInputChange}
     onSelect={handleMetricSelect}>
 
-    {visibleMetrics.length > 1 && allSelector}
+    { multiple && visibleMetrics.length > 1 && allSelector}
 
     {validationMetricNames.length > 0 && <OptGroup label="Validation Metrics">
       {validationMetricNames.map(key => {

--- a/webui/react/src/components/MetricSelectFilter.tsx
+++ b/webui/react/src/components/MetricSelectFilter.tsx
@@ -23,7 +23,7 @@ interface Props {
 }
 
 const MetricSelectFilter: React.FC<Props> = ({ metricNames, multiple, onChange, value }: Props) => {
-  const [ filterInput, setFilterInput ] = useState('');
+  const [ filterString, setFilterString ] = useState('');
 
   const metricValues = useMemo(() => {
     if (multiple && Array.isArray(value)) return value.map(metric => metricNameToValue(metric));
@@ -45,16 +45,16 @@ const MetricSelectFilter: React.FC<Props> = ({ metricNames, multiple, onChange, 
 
   const visibleMetrics = useMemo(() => {
     return metricNames.filter((metricName: MetricName) => {
-      return (metricName.name.includes(filterInput));
+      return (metricName.name.includes(filterString));
     });
-  }, [ metricNames, filterInput ]);
+  }, [ metricNames, filterString ]);
 
   const handleMetricSelect = useCallback((newValue: SelectValue) => {
     if (!onChange) return;
 
     if ((newValue as string) === allOptionId) {
       (onChange as MultipleHandler)(visibleMetrics.sort(metricNameSorter));
-      setFilterInput('');
+      setFilterString('');
       return;
     }
 
@@ -68,7 +68,7 @@ const MetricSelectFilter: React.FC<Props> = ({ metricNames, multiple, onChange, 
     } else {
       (onChange as SingleHandler)(metricName);
     }
-    setFilterInput('');
+    setFilterString('');
   }, [ multiple, onChange, value, visibleMetrics ]);
 
   const handleMetricDeselect = useCallback((newValue: SelectValue) => {
@@ -107,11 +107,11 @@ const MetricSelectFilter: React.FC<Props> = ({ metricNames, multiple, onChange, 
   }, []);
 
   const handleSearchInputChange = (searchInput: string) => {
-    setFilterInput(searchInput);
+    setFilterString(searchInput);
   };
 
   const handleClear = useCallback(() => {
-    setFilterInput('');
+    setFilterString('');
 
     if (multiple) {
       (onChange as MultipleHandler)([ ]);
@@ -119,7 +119,7 @@ const MetricSelectFilter: React.FC<Props> = ({ metricNames, multiple, onChange, 
   }, [ multiple, onChange ]);
 
   const handleBlur = () => {
-    setFilterInput('');
+    setFilterString('');
   };
 
   const allOption = useMemo(() => {

--- a/webui/react/src/components/MetricSelectFilter.tsx
+++ b/webui/react/src/components/MetricSelectFilter.tsx
@@ -24,7 +24,17 @@ interface Props {
   value?: MetricName | MetricName[];
 }
 
-const MetricSelectFilter: React.FC<Props> = ({ metricNames, multiple, onChange, value, defaultMetricNames }: Props) => {
+const filterFn = (search: string, metricName: string) => {
+  return metricName.toLocaleLowerCase().indexOf(search.toLocaleLowerCase()) !== -1;
+};
+
+const MetricSelectFilter: React.FC<Props> = ({
+  metricNames,
+  multiple,
+  onChange,
+  value,
+  defaultMetricNames,
+}: Props) => {
   const [ filterString, setFilterString ] = useState('');
 
   const metricValues = useMemo(() => {
@@ -41,13 +51,7 @@ const MetricSelectFilter: React.FC<Props> = ({ metricNames, multiple, onChange, 
     return metricNames.filter(metric => metric.type === MetricType.Validation);
   }, [ metricNames ]);
 
-  const totalNumMetrics = useMemo(() => {
-    return metricNames.length;
-  }, [ metricNames ]);
-
-  const filterFn = (search: string, metricName: string) => {
-    return metricName.toLocaleLowerCase().indexOf(search.toLocaleLowerCase()) !== -1;
-  };
+  const totalNumMetrics = useMemo(() => { return metricNames.length; }, [ metricNames ]);
 
   // visibleMetrics should always match the list of metrics that antd displays to
   // the user, including any filtering.

--- a/webui/react/src/components/MetricSelectFilter.tsx
+++ b/webui/react/src/components/MetricSelectFilter.tsx
@@ -105,50 +105,62 @@ const MetricSelectFilter: React.FC<Props> = ({ metricNames, multiple, onChange, 
     (onChange as MultipleHandler)(newMetric.sort(metricNameSorter));
   }, [ multiple, onChange, value ]);
 
-  const handleFiltering = useCallback((inputValue: string, option) => {
-    if (inputValue !== filterInput) {
-      setFilterInput(inputValue);
-    }
+  const handleFiltering = (inputValue: string, option: any) => {
+    // if (inputValue !== "") {
+    //   setFilterInput(inputValue);
+    // }
     if (option.key === 'All') {
       return true;
     } else {
       // TODO: Split on pipe (as long as there is only one) so 'ion|' doesn't return results
       return option.key.includes(filterInput);
     }
-  }, [ filterInput ]);
+  };
 
   const handleSearchInputChange = (searchInput: string) => {
+    console.log('Search Input', searchInput);
     setFilterInput(searchInput);
   };
 
-  const handleDropdownVisibleChange = (open: boolean) => {
+  const handleDropdownVisibleChange = useCallback((open: boolean) => {
     if (!open) {
       setFilterInput('');
     }
-  };
+  }, []);
 
-  const handleClear = () => {
+  // const handleClear = useCallback(() => {
+  //   setFilterInput('');
+  //   let newMetric;
+  //   if (validationMetricNames.length > 0) {
+  //     newMetric = validationMetricNames[0];
+  //   } else if (trainingMetricNames.length > 0){
+  //     newMetric = trainingMetricNames[0];
+  //   }
+  //   if (multiple) {
+  //     if (newMetric) {
+  //       (onChange as MultipleHandler)([ newMetric ]);
+  //     } else {
+  //       (onChange as MultipleHandler)([]);
+  //     }
+  //   } else {
+  //     if (newMetric){
+  //       (onChange as SingleHandler)(newMetric);
+  //     }
+  //   }
+  // }, [ onChange, validationMetricNames, trainingMetricNames ]);
+
+  const handleClear = useCallback(() => {
+    console.log('handleClear');
     setFilterInput('');
-    let newMetric;
-    if (validationMetricNames.length > 0) {
-      newMetric = validationMetricNames[0];
-    } else if (trainingMetricNames.length > 0){
-      newMetric = trainingMetricNames[0];
-    }
+
     if (multiple) {
-      if (newMetric) {
-        (onChange as MultipleHandler)([ newMetric ]);
-      } else {
-        (onChange as MultipleHandler)([]);
-      }
-
-    } else {
-
-      if (newMetric){
-        (onChange as SingleHandler)(newMetric);
-      }
-
+      (onChange as MultipleHandler)([ ]);
     }
+  }, [ multiple, onChange ]);
+
+  const handleBlur = () => {
+    // On blur the inputFilter gets cleared
+    console.log('handleBlur');
   };
 
   const allSelector = useMemo(() => {
@@ -165,16 +177,20 @@ const MetricSelectFilter: React.FC<Props> = ({ metricNames, multiple, onChange, 
       </Option>
     );
 
-  }, [ filterInput, metricNames ]);
+  }, [ filterInput, metricNames, visibleMetrics ]);
 
-  const selectorPlaceholder = useMemo(() => {
+  const [ maxTagCount, selectorPlaceholder ] = useMemo(() => {
+    console.log('metricValues', metricValues);
     if (metricValues === undefined) {
-      return '';
+      return [ 0, '' ];
     }
-    if (metricValues.length === totalNumMetrics) {
-      return `All ${totalNumMetrics} selected`;
+    if (metricValues.length === 0) {
+      // return [ -1, `None of ${totalNumMetrics} selected` ];
+      return [ -1, 'None selected' ];
+    } else if (metricValues.length === totalNumMetrics) {
+      return [ 0, `All ${totalNumMetrics} selected` ];
     } else {
-      return `${metricValues.length} of ${totalNumMetrics} selected`;
+      return [ 0, `${metricValues.length} of ${totalNumMetrics} selected` ];
     }
   }, [ metricValues, totalNumMetrics ]);
 
@@ -184,11 +200,13 @@ const MetricSelectFilter: React.FC<Props> = ({ metricNames, multiple, onChange, 
     dropdownMatchSelectWidth={400}
     filterOption={handleFiltering}
     label="Metrics"
+    maxTagCount={maxTagCount}
     maxTagPlaceholder={selectorPlaceholder}
     mode={multiple ? 'multiple' : undefined}
     showArrow
     style={{ width: 150 }}
     value={metricValues}
+    onBlur={handleBlur}
     onClear={handleClear}
     onDeselect={handleMetricDeselect}
     onDropdownVisibleChange={handleDropdownVisibleChange}

--- a/webui/react/src/components/MetricSelectFilter.tsx
+++ b/webui/react/src/components/MetricSelectFilter.tsx
@@ -11,18 +11,20 @@ import SelectFilter from './SelectFilter';
 
 const { OptGroup, Option } = Select;
 const allOptionId = 'ALL_RESULTS';
+const resetOptionId = 'RESET_RESULTS';
 
 type SingleHandler = (value: MetricName) => void;
 type MultipleHandler = (value: MetricName[]) => void;
 
 interface Props {
   metricNames: MetricName[];
+  defaultMetricNames: MetricName[];
   multiple?: boolean;
   onChange?: SingleHandler | MultipleHandler;
   value?: MetricName | MetricName[];
 }
 
-const MetricSelectFilter: React.FC<Props> = ({ metricNames, multiple, onChange, value }: Props) => {
+const MetricSelectFilter: React.FC<Props> = ({ metricNames, multiple, onChange, value, defaultMetricNames }: Props) => {
   const [ filterString, setFilterString ] = useState('');
 
   const metricValues = useMemo(() => {
@@ -63,6 +65,11 @@ const MetricSelectFilter: React.FC<Props> = ({ metricNames, multiple, onChange, 
       setFilterString('');
       return;
     }
+    if ((newValue as string) === resetOptionId) {
+      (onChange as MultipleHandler)(defaultMetricNames.sort(metricNameSorter));
+      setFilterString('');
+      return;
+    }
 
     const metricName = valueToMetricName(newValue as string);
     if (!metricName) return;
@@ -75,7 +82,7 @@ const MetricSelectFilter: React.FC<Props> = ({ metricNames, multiple, onChange, 
       (onChange as SingleHandler)(metricName);
     }
     setFilterString('');
-  }, [ multiple, onChange, value, visibleMetrics ]);
+  }, [ multiple, onChange, value, visibleMetrics, defaultMetricNames ]);
 
   const handleMetricDeselect = useCallback((newValue: SelectValue) => {
     if (!onChange || !multiple) return;
@@ -88,7 +95,7 @@ const MetricSelectFilter: React.FC<Props> = ({ metricNames, multiple, onChange, 
   }, [ multiple, onChange, value ]);
 
   const handleFiltering = useCallback((search: string, option) => {
-    if (option.key === allOptionId) {
+    if (option.key === allOptionId || option.key === resetOptionId) {
       return true;
     }
     if (!option.value) {
@@ -169,6 +176,11 @@ const MetricSelectFilter: React.FC<Props> = ({ metricNames, multiple, onChange, 
     onDeselect={handleMetricDeselect}
     onSearch={handleSearchInputChange}
     onSelect={handleMetricSelect}>
+
+    { multiple && visibleMetrics.length > 0 &&
+    <Option key={resetOptionId} value={resetOptionId}>
+      <BadgeTag label='Reset To Default Metric' />
+    </Option>}
 
     { multiple && visibleMetrics.length > 1 && allOption}
 

--- a/webui/react/src/components/SelectFilter.tsx
+++ b/webui/react/src/components/SelectFilter.tsx
@@ -1,6 +1,12 @@
 import { Select } from 'antd';
 import { SelectProps, SelectValue } from 'antd/es/select';
-import React, { PropsWithChildren, useCallback, useMemo, useState } from 'react';
+import React, {
+  forwardRef,
+  PropsWithChildren,
+  useCallback,
+  useMemo,
+  useState,
+} from 'react';
 
 import Icon from './Icon';
 import Label from './Label';
@@ -13,6 +19,11 @@ interface Props<T = SelectValue> extends SelectProps<T> {
   enableSearchFilter?: boolean;
   label: string;
   style?: React.CSSProperties;
+  ref?: React.Ref<Select<SelectValue>>;
+}
+
+export interface SelectFilterHandles {
+  blur: () => void;
 }
 
 export const ALL_VALUE = 'all';
@@ -32,16 +43,20 @@ const countOptions = (children: React.ReactNode): number => {
   return count;
 };
 
-const SelectFilter: React.FC<PropsWithChildren<Props>> = ({
-  className = '',
-  disableTags = false,
-  dropdownMatchSelectWidth = false,
-  enableSearchFilter = true,
-  showSearch = true,
-  ...props
-}: PropsWithChildren<Props>) => {
+const SelectFilter: React.FC<PropsWithChildren<Props>> = forwardRef((
+  {
+    className = '',
+    disableTags = false,
+    dropdownMatchSelectWidth = false,
+    enableSearchFilter = true,
+    showSearch = true,
+    ...props
+  }: PropsWithChildren<Props>,
+  ref?: React.Ref<Select<SelectValue>>,
+) => {
+
   const [ isOpen, setIsOpen ] = useState(false);
-  const classes = [ className, css.base ];
+  const classes = [ css.base ];
 
   if (disableTags) classes.push(css.disableTags);
 
@@ -90,6 +105,7 @@ const SelectFilter: React.FC<PropsWithChildren<Props>> = ({
         getPopupContainer={getPopupContainer}
         maxTagCount={maxTagCount}
         maxTagPlaceholder={maxTagPlaceholder}
+        ref={ref}
         showSearch={showSearch}
         suffixIcon={<Icon name="arrow-down" size="tiny" />}
         onDropdownVisibleChange={handleDropdownVisibleChange}
@@ -98,6 +114,6 @@ const SelectFilter: React.FC<PropsWithChildren<Props>> = ({
       </Select>
     </div>
   );
-};
+});
 
 export default SelectFilter;

--- a/webui/react/src/components/SelectFilter.tsx
+++ b/webui/react/src/components/SelectFilter.tsx
@@ -22,10 +22,6 @@ interface Props<T = SelectValue> extends SelectProps<T> {
   ref?: React.Ref<Select<SelectValue>>;
 }
 
-export interface SelectFilterHandles {
-  blur: () => void;
-}
-
 export const ALL_VALUE = 'all';
 
 const countOptions = (children: React.ReactNode): number => {
@@ -43,7 +39,7 @@ const countOptions = (children: React.ReactNode): number => {
   return count;
 };
 
-const SelectFilter: React.FC<PropsWithChildren<Props>> = forwardRef((
+const SelectFilter: React.FC<PropsWithChildren<Props>> = forwardRef(function SelectFilter(
   {
     className = '',
     disableTags = false,
@@ -53,10 +49,10 @@ const SelectFilter: React.FC<PropsWithChildren<Props>> = forwardRef((
     ...props
   }: PropsWithChildren<Props>,
   ref?: React.Ref<Select<SelectValue>>,
-) => {
+) {
 
   const [ isOpen, setIsOpen ] = useState(false);
-  const classes = [ css.base ];
+  const classes = [ className, css.base ];
 
   if (disableTags) classes.push(css.disableTags);
 

--- a/webui/react/src/pages/TrialDetails.tsx
+++ b/webui/react/src/pages/TrialDetails.tsx
@@ -24,8 +24,7 @@ import useStorage from 'hooks/useStorage';
 import TrialActions, { Action as TrialAction } from 'pages/TrialDetails/TrialActions';
 import TrialInfoBox from 'pages/TrialDetails/TrialInfoBox';
 import { routeAll } from 'routes/utils';
-import { forkExperiment } from 'services/api';
-import { getExperimentDetails, getTrialDetails, isNotFound } from 'services/api';
+import { forkExperiment, getExperimentDetails, getTrialDetails, isNotFound } from 'services/api';
 import { ApiState } from 'services/types';
 import {
   CheckpointDetail, ExperimentDetails, MetricName, MetricType, RawJson, Step, TrialDetails,

--- a/webui/react/src/pages/TrialDetails.tsx
+++ b/webui/react/src/pages/TrialDetails.tsx
@@ -107,6 +107,7 @@ const TrialDetailsComp: React.FC = () => {
   const [ form ] = Form.useForm();
   const [ activeCheckpoint, setActiveCheckpoint ] = useState<CheckpointDetail>();
   const [ metrics, setMetrics ] = useState<MetricName[]>([]);
+  const [ defaultMetrics, setDefaultMetrics ] = useState<MetricName[]>([]);
   const [ experiment, setExperiment ] = useState<ExperimentDetails>();
   const [ trialDetails, setTrialDetails ] = useState<ApiState<TrialDetails>>({
     data: undefined,
@@ -292,11 +293,11 @@ If the problem persists please contact support.',
     if (!experimentId) return;
     const updatedConfig = updateStatesFromForm();
     try {
-      const newExperiementId = await forkExperiment({
+      const newExperimentId = await forkExperiment({
         experimentConfig: JSON.stringify(updatedConfig),
         parentId: experimentId,
       });
-      routeAll(`/det/experiments/${newExperiementId}`);
+      routeAll(`/det/experiments/${newExperimentId}`);
     } catch (e) {
       handleError({
         error: e,
@@ -390,6 +391,7 @@ If the problem persists please contact support.',
           return metricName.name === searcherName && metricName.type === MetricType.Validation;
         });
         const defaultMetrics = defaultMetric ? [ defaultMetric ] : [];
+        setDefaultMetrics(defaultMetrics);
         const initMetrics = storage.getWithDefault(storageTableMetricsKey || '', defaultMetrics);
         setMetrics(initMetrics);
       } catch (e) {
@@ -428,6 +430,7 @@ If the problem persists please contact support.',
         {Object.values(TrialInfoFilter).map(key => <Option key={key} value={key}>{key}</Option>)}
       </SelectFilter>
       {metrics && <MetricSelectFilter
+        defaultMetricNames={defaultMetrics}
         metricNames={metricNames}
         multiple
         value={metrics}
@@ -460,6 +463,7 @@ If the problem persists please contact support.',
         </Col>
         <Col lg={14} span={24} xl={16} xxl={18}>
           <TrialChart
+            defaultMetricNames={defaultMetrics}
             metricNames={metricNames}
             steps={trial?.steps}
             storageKey={storageChartMetricsKey}

--- a/webui/react/src/pages/TrialDetails/TrialChart.tsx
+++ b/webui/react/src/pages/TrialDetails/TrialChart.tsx
@@ -9,6 +9,7 @@ import { MetricName, MetricType, Step } from 'types';
 interface Props {
   id?: string;
   metricNames: MetricName[];
+  defaultMetricNames: MetricName[];
   steps?: Step[];
   storageKey?: string;
   validationMetric?: string;
@@ -44,6 +45,7 @@ const TrialChart: React.FC<Props> = ({
   metricNames,
   storageKey,
   validationMetric,
+  defaultMetricNames,
   ...props
 }: Props) => {
   const storage = useStorage(STORAGE_PATH);
@@ -111,6 +113,7 @@ const TrialChart: React.FC<Props> = ({
     data={data}
     id={props.id}
     options={<MetricSelectFilter
+      defaultMetricNames={defaultMetricNames}
       metricNames={metricNames}
       multiple
       value={metrics}

--- a/webui/react/src/types.ts
+++ b/webui/react/src/types.ts
@@ -228,7 +228,6 @@ export enum CheckpointState {
 export enum MetricType {
   Training = 'training',
   Validation = 'validation',
-  Placeholder = 'placeholder',  // Fake metrics like 'ALL' or 'NONE'
 }
 
 export interface MetricName {

--- a/webui/react/src/types.ts
+++ b/webui/react/src/types.ts
@@ -228,6 +228,7 @@ export enum CheckpointState {
 export enum MetricType {
   Training = 'training',
   Validation = 'validation',
+  Placeholder = 'placeholder',  // Fake metrics like 'ALL' or 'NONE'
 }
 
 export interface MetricName {

--- a/webui/react/src/utils/trial.ts
+++ b/webui/react/src/utils/trial.ts
@@ -43,6 +43,26 @@ export const metricNameToValue = (metricName: MetricName): string => {
   return `${metricName.type}|${metricName.name}`;
 };
 
+export const metricNameFromValue = (metricValue: string): MetricName | undefined => {
+  const trainingPrefix = `${MetricType.Training}|`;
+  const validationPrefix = `${MetricType.Validation}|`;
+  if (metricValue.startsWith(trainingPrefix)) {
+    return {
+      name: metricValue.slice(trainingPrefix.length),
+      type: MetricType.Training,
+    };
+  } else if (metricValue.startsWith(validationPrefix)) {
+    return {
+      name: metricValue.slice(validationPrefix.length),
+      type: MetricType.Validation,
+    };
+  } else {
+    console.error("metricNameFromValue was called, but the metricName doesn't appear to " +
+        'be a training metric or a validation metric');
+    return undefined;
+  }
+};
+
 export const valueToMetricName = (value: string): MetricName | undefined => {
   const parts = value.split('|');
   if (parts.length === 2) return { name: parts[1], type: parts[0] as MetricType };

--- a/webui/react/src/utils/trial.ts
+++ b/webui/react/src/utils/trial.ts
@@ -61,12 +61,11 @@ export const metricNameFromValue = (metricValue: string): MetricName | undefined
   } else {
     const errName = 'metricNameFromValueUnrecognizedMetricType';
     const errSlug = 'metricnamefromvalue-unrecognized-metric-type';
-    const errMessage = `metricNameFromValue was called, but the metricName doesn't appear to " +
-        'be a training metric or a validation metric (${metricValue})`;
-    let silent = true;
-    if (process.env.IS_DEV) {
-      silent = false;
-    }
+    const errMessage = `
+      metricNameFromValue was called, but the metricName doesn't appear to 
+      be a training metric or a validation metric (${metricValue})
+    `;
+
     const daErr: DaError = {
       error: {
         message: errMessage,
@@ -76,7 +75,7 @@ export const metricNameFromValue = (metricValue: string): MetricName | undefined
       isUserTriggered: false,
       level: ErrorLevel.Error,
       message: errMessage,
-      silent: silent,
+      silent: !process.env.IS_DEV,
       type: ErrorType.Ui,
     };
     handleError(daErr);

--- a/webui/react/src/utils/trial.ts
+++ b/webui/react/src/utils/trial.ts
@@ -1,6 +1,8 @@
 import { MetricName, MetricType, Step } from 'types';
 import { isNumber, metricNameSorter } from 'utils/data';
 
+import handleError, { DaError, ErrorLevel, ErrorType } from '../ErrorHandler';
+
 export const extractMetricValue = (step: Step, metricName: MetricName): number | undefined => {
   if (metricName.type === MetricType.Training) {
     const source = step.avgMetrics || {};
@@ -57,8 +59,27 @@ export const metricNameFromValue = (metricValue: string): MetricName | undefined
       type: MetricType.Validation,
     };
   } else {
-    console.error("metricNameFromValue was called, but the metricName doesn't appear to " +
-        'be a training metric or a validation metric');
+    const errName = 'metricNameFromValueUnrecognizedMetricType';
+    const errSlug = 'metricnamefromvalue-unrecognized-metric-type';
+    const errMessage = `metricNameFromValue was called, but the metricName doesn't appear to " +
+        'be a training metric or a validation metric (${metricValue})`;
+    let silent = true;
+    if (process.env.IS_DEV) {
+      silent = false;
+    }
+    const daErr: DaError = {
+      error: {
+        message: errMessage,
+        name: errName,
+      },
+      id: errSlug,
+      isUserTriggered: false,
+      level: ErrorLevel.Error,
+      message: errMessage,
+      silent: silent,
+      type: ErrorType.Ui,
+    };
+    handleError(daErr);
     return undefined;
   }
 };


### PR DESCRIPTION
## Description

Improve the metric selector. 

Allow users to select all metrics. Allow users to select all metrics that match the filter. Allow users to deselect all metrics. Improve placeholders to be more informative about how many metrics are selected and how many metric are available in total.


## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

User facing:

- Added ALL option to dropdown
- While filtering, have ALL option select all options that meet the filter. 
- Adjust the appearance of the ALL option when filtering (when no filter = `All`, when filter has filtered down to N results = `All N results`, when filter has only a single result = do not display ALL option)
- Add a clear icon (antd out-of-the-box) that deselects all options. Upgrade antd to access the `onClear` callback to enable this behavior.
- Changed the text in the dropdown when it is not open. When all N options are selected, it is 'All N selected'. When X of the N options are selected, it is 'X of N selected'. When no options are selected, it is 'None selected'

Internal Notes:
- antd doesn't give us access to the string used to filter or how many results are shown after the filter, so we need to internally track the filter and the number of results that match so we can adjust the ALL option appearance.

---

@hkang1  @vishnu2kmohan 
- TODO: Do we want to be able to search for 'validation' and select all validation metrics? We don't currently include the metric type during the filtering, but we easily can.
- TODO: Should any of the Placeholder strings be improved?




## Checklist


- [x] Release notes should be added as a separate file under `docs/release-notes/`.



