### PR TITLE
feat: support filtering in trial logs api [DET-4177]

### DIFF
--- a/master/internal/api/filters.go
+++ b/master/internal/api/filters.go
@@ -1,0 +1,20 @@
+package api
+
+// FilterOperation is an operation in a filter.
+type FilterOperation int
+
+const (
+	// FilterOperationIn checks set membership.
+	FilterOperationIn FilterOperation = iota
+	// FilterOperationGreaterThan checks if the field is greater than a value.
+	FilterOperationGreaterThan
+	// FilterOperationLessThan checks if the field is less than a value.
+	FilterOperationLessThan
+)
+
+// Filter is a general representation for a filter provided to an API.
+type Filter struct {
+	Field     string
+	Operation FilterOperation
+	Values    interface{}
+}

--- a/master/internal/api/logs.go
+++ b/master/internal/api/logs.go
@@ -101,7 +101,7 @@ func (l *LogStoreProcessor) Receive(ctx *actor.Context) error {
 					return nil
 				}
 			}
-			actors.NotifyAfter(ctx, 5*time.Second, tick{})
+			actors.NotifyAfter(ctx, 500*time.Millisecond, tick{})
 		default:
 			l.req.Limit -= batch.Size()
 			l.req.Offset += batch.Size()

--- a/master/internal/api/logs.go
+++ b/master/internal/api/logs.go
@@ -71,12 +71,10 @@ func NewLogStoreProcessor(
 	}
 }
 
-type (
-	tick struct{}
-)
 
 // Receive implements the actor.Actor interface.
 func (l *LogStoreProcessor) Receive(ctx *actor.Context) error {
+	type tick struct{}
 	switch msg := ctx.Message().(type) {
 	case actor.PreStart:
 		ctx.Tell(ctx.Self(), tick{})

--- a/master/internal/api/logs.go
+++ b/master/internal/api/logs.go
@@ -71,7 +71,6 @@ func NewLogStoreProcessor(
 	}
 }
 
-
 // Receive implements the actor.Actor interface.
 func (l *LogStoreProcessor) Receive(ctx *actor.Context) error {
 	type tick struct{}

--- a/master/internal/api/logs.go
+++ b/master/internal/api/logs.go
@@ -88,7 +88,7 @@ func (l *LogStoreProcessor) Receive(ctx *actor.Context) error {
 		switch batch, err := l.fetcher(l.req); {
 		case err != nil:
 			return errors.Wrapf(err, "failed to fetch logs")
-		case batch.Size() == 0:
+		case batch == nil, batch.Size() == 0:
 			if l.terminateCheck != nil {
 				terminate, err := (*l.terminateCheck)()
 				switch {

--- a/master/internal/api/logs.go
+++ b/master/internal/api/logs.go
@@ -6,86 +6,131 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+
+	"github.com/determined-ai/determined/master/pkg/actor/actors"
+
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
 	"github.com/determined-ai/determined/master/pkg/actor"
-	"github.com/determined-ai/determined/master/pkg/logger"
-	"github.com/determined-ai/determined/proto/pkg/logv1"
 )
-
-const logCheckWaitTime = 200 * time.Millisecond
 
 // LogsRequest describes the parameters needed to target a subset of logs.
 type LogsRequest struct {
-	Offset int
-	Limit  int
-	Follow bool
+	Offset  int
+	Limit   int
+	Follow  bool
+	Filters []Filter
 }
 
-// OnLogEntryFn is a callback called on each log entry.
-type OnLogEntryFn func(*logger.Entry) error
+// LogBatch represents a batch of logs.
+type LogBatch interface {
+	ForEach(func(interface{}) error) error
+	Size() int
+}
 
-// LogFetcherFn fetchs returns a subset of logs based on a LogRequest.
-type LogFetcherFn func(LogsRequest) ([]*logger.Entry, error)
+// OnLogBatchFn is a callback called on each batch of logs.
+type OnLogBatchFn func(LogBatch) error
+
+// LogFetcherFn fetches returns a batch of logs based on a LogRequest.
+type LogFetcherFn func(LogsRequest) (LogBatch, error)
 
 // TerminationCheckFn checks whether the log processing should stop or not.
 type TerminationCheckFn func() (bool, error)
 
-// LogEntryToProtoLogEntry turns a logger.LogEntry into logv1.LogEntry.
-func LogEntryToProtoLogEntry(logEntry *logger.Entry) *logv1.LogEntry {
-	return &logv1.LogEntry{Id: int32(logEntry.ID), Message: logEntry.Message}
+// LogStoreProcessor is a log processor that fetches logs and processes them with an OnLogBatchFn.
+// It handles common logic around limits, offsets and backpressure. The type of batches produced by
+// the Fetcher must match those handled by the OnLogBatchFn or the actor will panic.
+type LogStoreProcessor struct {
+	ctx            context.Context
+	req            LogsRequest
+	fetcher        LogFetcherFn
+	process        OnLogBatchFn
+	terminateCheck *TerminationCheckFn
+	batchWaitTime  *time.Duration
 }
 
-// ProcessLogs handles fetching and processing logs from a log store.
-func ProcessLogs(ctx context.Context,
+// NewLogStoreProcessor creates a new LogStoreProcessor.
+func NewLogStoreProcessor(
+	ctx context.Context,
 	req LogsRequest,
-	logFetcher LogFetcherFn,
-	cb OnLogEntryFn,
+	fetcher LogFetcherFn,
+	process OnLogBatchFn,
 	terminateCheck *TerminationCheckFn,
-) error {
-	for {
-		logEntries, err := logFetcher(req)
+	batchWaitTime *time.Duration,
+) *LogStoreProcessor {
+	return &LogStoreProcessor{
+		ctx:            ctx,
+		req:            req,
+		fetcher:        fetcher,
+		process:        process,
+		terminateCheck: terminateCheck,
+		batchWaitTime:  batchWaitTime,
+	}
+}
 
-		if err != nil {
-			return errors.Wrapf(err, "failed to fetch logs for %v", req)
+type (
+	tick struct{}
+)
+
+// Receive implements the actor.Actor interface.
+func (l *LogStoreProcessor) Receive(ctx *actor.Context) error {
+	switch msg := ctx.Message().(type) {
+	case actor.PreStart:
+		ctx.Tell(ctx.Self(), tick{})
+
+	case tick:
+		if l.ctx.Err() != nil {
+			ctx.Self().Stop()
+			return nil
 		}
-		for _, log := range logEntries {
-			req.Offset++
-			req.Limit--
-			if err := cb(log); err != nil {
-				return errors.Wrapf(err, "failed to process log entry %v", log)
-			}
-		}
-		if len(logEntries) == 0 {
-			if err := ctx.Err(); err != nil {
-				// context is closed
-				return nil
-			}
-			if terminateCheck != nil {
-				terminate, err := (*terminateCheck)()
+
+		switch batch, err := l.fetcher(l.req); {
+		case err != nil:
+			return errors.Wrapf(err, "failed to fetch logs")
+		case batch.Size() == 0:
+			if l.terminateCheck != nil {
+				terminate, err := (*l.terminateCheck)()
 				switch {
 				case err != nil:
 					return errors.Wrap(err, "failed to check the termination status.")
 				case terminate:
+					ctx.Self().Stop()
 					return nil
 				}
 			}
-			time.Sleep(logCheckWaitTime)
+			actors.NotifyAfter(ctx, 5*time.Second, tick{})
+		default:
+			l.req.Limit -= batch.Size()
+			l.req.Offset += batch.Size()
+			switch err := l.process(batch); {
+			case err != nil:
+				return fmt.Errorf("failed while processing batch: %w", err)
+			case !l.req.Follow && l.req.Limit <= 0:
+				ctx.Self().Stop()
+				return nil
+			}
+
+			if l.batchWaitTime != nil {
+				actors.NotifyAfter(ctx, *l.batchWaitTime, tick{})
+			} else {
+				ctx.Tell(ctx.Self(), tick{})
+			}
 		}
-		if !req.Follow || req.Limit == 0 {
-			return nil
-		} else if req.Follow {
-			req.Limit = -1
-		}
+
+	case actor.PostStop:
+
+	default:
+		return status.Errorf(codes.Internal, fmt.Sprintf("received unsupported message %v", msg))
 	}
+	return nil
 }
 
-// LogStreamActor handles streaming log messages.
-type LogStreamActor struct {
+// LogStreamProcessor handles streaming log messages.
+type LogStreamProcessor struct {
 	req         LogsRequest
 	ctx         context.Context
-	send        OnLogEntryFn
+	send        OnLogBatchFn
 	logStore    *actor.Ref
 	sendCounter int
 }
@@ -93,18 +138,18 @@ type LogStreamActor struct {
 // CloseStream indicates that the log stream should close.
 type CloseStream struct{}
 
-// NewLogStreamActor creates a new logStreamActor.
-func NewLogStreamActor(
+// NewLogStreamProcessor creates a new logStreamActor.
+func NewLogStreamProcessor(
 	ctx context.Context,
 	eventManager *actor.Ref,
 	request LogsRequest,
-	send OnLogEntryFn,
-) *LogStreamActor {
-	return &LogStreamActor{req: request, ctx: ctx, send: send, logStore: eventManager}
+	send OnLogBatchFn,
+) *LogStreamProcessor {
+	return &LogStreamProcessor{req: request, ctx: ctx, send: send, logStore: eventManager}
 }
 
 // Receive implements the actor.Actor interface.
-func (l *LogStreamActor) Receive(ctx *actor.Context) error {
+func (l *LogStreamProcessor) Receive(ctx *actor.Context) error {
 	switch msg := ctx.Message().(type) {
 	case actor.PreStart:
 		if response := ctx.Ask(l.logStore, l.req); response.Empty() {
@@ -112,15 +157,15 @@ func (l *LogStreamActor) Receive(ctx *actor.Context) error {
 			return status.Errorf(codes.NotFound, "logStore did not respond")
 		}
 
-	case logger.Entry:
+	case LogBatch:
 		if l.ctx.Err() != nil {
 			ctx.Self().Stop()
 			break
 		}
-		if err := l.send(&msg); err != nil {
-			return status.Errorf(codes.Internal, "failed to send log message %d", msg.ID)
+		if err := l.send(msg); err != nil {
+			return status.Errorf(codes.Internal, "failed to send batch starting at %d", l.sendCounter)
 		}
-		l.sendCounter++
+		l.sendCounter += msg.Size()
 		if l.req.Limit > 0 && l.sendCounter >= l.req.Limit {
 			ctx.Self().Stop()
 		}

--- a/master/internal/api/logs.go
+++ b/master/internal/api/logs.go
@@ -74,7 +74,7 @@ func NewLogStoreProcessor(
 // Receive implements the actor.Actor interface.
 func (l *LogStoreProcessor) Receive(ctx *actor.Context) error {
 	type tick struct{}
-	switch msg := ctx.Message().(type) {
+	switch ctx.Message().(type) {
 	case actor.PreStart:
 		ctx.Tell(ctx.Self(), tick{})
 
@@ -120,7 +120,7 @@ func (l *LogStoreProcessor) Receive(ctx *actor.Context) error {
 	case actor.PostStop:
 
 	default:
-		return status.Errorf(codes.Internal, fmt.Sprintf("received unsupported message %v", msg))
+		return actor.ErrUnexpectedMessage(ctx)
 	}
 	return nil
 }
@@ -179,7 +179,7 @@ func (l *LogStreamProcessor) Receive(ctx *actor.Context) error {
 		ctx.Tell(l.logStore, CloseStream{})
 
 	default:
-		return status.Errorf(codes.Internal, fmt.Sprintf("received unsupported message %v", msg))
+		return actor.ErrUnexpectedMessage(ctx)
 	}
 	return nil
 }

--- a/master/internal/api/params.go
+++ b/master/internal/api/params.go
@@ -55,9 +55,9 @@ func EffectiveLimit(limit int, offset int, total int) int {
 		panic("input offset has to be non-negative")
 	}
 	switch {
-	case limit <= 0:
+	case limit < 0:
 		return -1
-	case limit > total-offset:
+	case limit > total-offset, limit == 0: // Since limit is non-optional, 0 represents unsupplied.
 		return total - offset
 	default:
 		return limit

--- a/master/internal/api_master.go
+++ b/master/internal/api_master.go
@@ -46,6 +46,7 @@ func (a *apiServer) MasterLogs(
 	req *apiv1.MasterLogsRequest, resp apiv1.Determined_MasterLogsServer) error {
 	if err := grpc.ValidateRequest(
 		grpc.ValidateLimit(req.Limit),
+		grpc.ValidateFollow(req.Limit, req.Follow),
 	); err != nil {
 		return err
 	}

--- a/master/internal/api_master.go
+++ b/master/internal/api_master.go
@@ -3,13 +3,19 @@ package internal
 import (
 	"context"
 
+	"github.com/google/uuid"
+
+	"github.com/determined-ai/determined/master/pkg/actor"
+
 	structpb "github.com/golang/protobuf/ptypes/struct"
 	"github.com/pkg/errors"
 	"google.golang.org/protobuf/encoding/protojson"
 
+	"github.com/determined-ai/determined/master/pkg/logger"
+	"github.com/determined-ai/determined/proto/pkg/logv1"
+
 	"github.com/determined-ai/determined/master/internal/api"
 	"github.com/determined-ai/determined/master/internal/grpc"
-	"github.com/determined-ai/determined/master/pkg/logger"
 	"github.com/determined-ai/determined/proto/pkg/apiv1"
 )
 
@@ -36,12 +42,6 @@ func (a *apiServer) GetMasterConfig(
 	}, err
 }
 
-func fetchMasterLogs(logBuffer *logger.LogBuffer) api.LogFetcherFn {
-	return func(req api.LogsRequest) ([]*logger.Entry, error) {
-		return logBuffer.Entries(req.Offset, -1, req.Limit), nil
-	}
-}
-
 func (a *apiServer) MasterLogs(
 	req *apiv1.MasterLogsRequest, resp apiv1.Determined_MasterLogsServer) error {
 	if err := grpc.ValidateRequest(
@@ -49,22 +49,29 @@ func (a *apiServer) MasterLogs(
 	); err != nil {
 		return err
 	}
-	total := a.m.logs.Len()
-	offset, limit := api.EffectiveOffsetNLimit(int(req.Offset), int(req.Limit), total)
 
-	logRequest := api.LogsRequest{Offset: offset, Limit: limit, Follow: req.Follow}
-
-	onLogEntry := func(log *logger.Entry) error {
-		return resp.Send(&apiv1.MasterLogsResponse{
-			LogEntry: api.LogEntryToProtoLogEntry(log),
+	onBatch := func(b api.LogBatch) error {
+		return b.ForEach(func(r interface{}) error {
+			lr := r.(*logger.Entry)
+			return resp.Send(&apiv1.MasterLogsResponse{
+				LogEntry: &logv1.LogEntry{Id: int32(lr.ID), Message: lr.Message},
+			})
 		})
 	}
 
-	return api.ProcessLogs(
-		resp.Context(),
-		logRequest,
-		fetchMasterLogs(a.m.logs),
-		onLogEntry,
-		nil,
-	)
+	fetch := func(lr api.LogsRequest) (api.LogBatch, error) {
+		if lr.Follow {
+			lr.Limit = -1
+		}
+		return logger.EntriesBatch(a.m.logs.Entries(lr.Offset, -1, lr.Limit)), nil
+	}
+
+	total := a.m.logs.Len()
+	offset, limit := api.EffectiveOffsetNLimit(int(req.Offset), int(req.Limit), total)
+	lReq := api.LogsRequest{Offset: offset, Limit: limit, Follow: req.Follow}
+
+	return a.m.system.MustActorOf(
+		actor.Addr("logStore-"+uuid.New().String()),
+		api.NewLogStoreProcessor(resp.Context(), lReq, fetch, onBatch, nil, nil),
+	).AwaitTermination()
 }

--- a/master/internal/api_trials.go
+++ b/master/internal/api_trials.go
@@ -130,6 +130,13 @@ func constructTrialLogsFilters(req *apiv1.TrialLogsRequest) ([]api.Filter, error
 			Values:    req.ContainerIds,
 		})
 	}
+	if len(req.RankIds) > 0 {
+		filters = append(filters, api.Filter{
+			Field:     "rank_id",
+			Operation: api.FilterOperationIn,
+			Values:    req.RankIds,
+		})
+	}
 	if len(req.Level) > 0 {
 		var levels []string
 		for _, l := range req.Level {

--- a/master/internal/api_trials.go
+++ b/master/internal/api_trials.go
@@ -65,7 +65,7 @@ func (a *apiServer) TrialLogs(
 		return status.Error(codes.InvalidArgument, fmt.Sprintf("unsupported filter: %s", err))
 	}
 
-	logID := int32(-1) // WebUI assumes logs are 0-indexed
+	logID := int32(-1) // WebUI assumes logs are 0-indexed.
 	onBatch := func(b api.LogBatch) error {
 		return b.ForEach(func(r interface{}) error {
 			trialLog := r.(*model.TrialLog)

--- a/master/internal/api_trials.go
+++ b/master/internal/api_trials.go
@@ -2,9 +2,16 @@ package internal
 
 import (
 	"context"
+	"fmt"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/golang/protobuf/ptypes"
+
+	"github.com/determined-ai/determined/proto/pkg/logv1"
+
+	"github.com/google/uuid"
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -22,9 +29,10 @@ import (
 )
 
 const (
-	batchSize     = 1000
-	batchWaitTime = 100 * time.Millisecond
+	batchSize = 1000
 )
+
+var batchWaitTime = 100 * time.Millisecond
 
 func trialStatus(d *db.PgDB, trialID int32) (model.State, int, error) {
 	trialStatus := struct {
@@ -50,45 +58,139 @@ func (a *apiServer) TrialLogs(
 		return err
 	}
 
-	offset := api.EffectiveOffset(int(req.Offset), total)
+	filters, err := constructTrialLogsFilters(req)
+	if err != nil {
+		return status.Error(codes.InvalidArgument, fmt.Sprintf("unsupported filter: %s", err))
+	}
 
-	if limit := int32(total - offset); !req.Follow && (limit < req.Limit || req.Limit == 0) {
-		req.Limit = limit
+	logID := int32(-1)
+	onBatch := func(b api.LogBatch) error {
+		return b.ForEach(func(r interface{}) error {
+			trialLog := r.(*model.TrialLog)
+			logID++
+			return resp.Send(&apiv1.TrialLogsResponse{
+				Id:      logID, // WebUI assumes logs are 0-indexed
+				Message: trialLog.Message,
+			})
+		})
 	}
-	count := 0
-	for {
-		queryLimit := int(req.Limit) - count
-		if req.Limit == 0 || queryLimit > batchSize {
-			queryLimit = batchSize
+
+	fetch := func(lr api.LogsRequest) (api.LogBatch, error) {
+		switch {
+		case lr.Follow || lr.Limit > batchSize:
+			lr.Limit = batchSize
+		case lr.Limit <= 0:
+			return nil, nil
 		}
-		if queryLimit <= 0 {
-			return nil
+
+		b, err := a.m.db.TrialLogs(int(req.TrialId), lr.Offset, lr.Limit, lr.Filters)
+		if err != nil {
+			return nil, err
 		}
-		var logs []*apiv1.TrialLogsResponse
-		if err := a.m.db.QueryProto("stream_logs", &logs, req.TrialId, offset, queryLimit); err != nil {
-			return err
+
+		return model.TrialLogBatch(b), err
+	}
+
+	terminateCheck := api.TerminationCheckFn(func() (bool, error) {
+		state, _, err := trialStatus(a.m.db, req.TrialId)
+		if err != nil || model.TerminalStates[state] {
+			return true, err
 		}
-		for i, log := range logs {
-			log.Id = int32(offset + i)
-			if err := resp.Send(log); err != nil {
-				return err
+		return false, nil
+	})
+
+	offset, limit := api.EffectiveOffsetNLimit(int(req.Offset), int(req.Limit), total)
+	lReq := api.LogsRequest{Offset: offset, Limit: limit, Follow: req.Follow, Filters: filters}
+	return a.m.system.MustActorOf(
+		actor.Addr("logStore-"+uuid.New().String()),
+		api.NewLogStoreProcessor(
+			resp.Context(),
+			lReq,
+			fetch,
+			onBatch,
+			&terminateCheck,
+			&batchWaitTime,
+		),
+	).AwaitTermination()
+}
+
+func constructTrialLogsFilters(req *apiv1.TrialLogsRequest) ([]api.Filter, error) {
+	var filters []api.Filter
+	if len(req.AgentIds) > 0 {
+		filters = append(filters, api.Filter{
+			Field:     "agent_id",
+			Operation: api.FilterOperationIn,
+			Values:    req.AgentIds,
+		})
+	}
+	if len(req.ContainerIds) > 0 {
+		filters = append(filters, api.Filter{
+			Field:     "container_id",
+			Operation: api.FilterOperationIn,
+			Values:    req.ContainerIds,
+		})
+	}
+	if len(req.Level) > 0 {
+		var levels []string
+		for _, l := range req.Level {
+			switch l {
+			case logv1.LogLevel_LOG_LEVEL_UNSPECIFIED:
+				levels = append(levels, "DEBUG")
+			case logv1.LogLevel_LOG_LEVEL_DEBUG:
+				levels = append(levels, "DEBUG")
+			case logv1.LogLevel_LOG_LEVEL_INFO:
+				levels = append(levels, "INFO")
+			case logv1.LogLevel_LOG_LEVEL_WARNING:
+				levels = append(levels, "WARNING")
+			case logv1.LogLevel_LOG_LEVEL_ERROR:
+				levels = append(levels, "ERROR")
+			case logv1.LogLevel_LOG_LEVEL_CRITICAL:
+				levels = append(levels, "CRITICAL")
 			}
 		}
-		newRecords := len(logs)
-		count += newRecords
-		offset += newRecords
-		if newRecords < queryLimit {
-			state, _, err := trialStatus(a.m.db, req.TrialId)
-			if err != nil || model.TerminalStates[state] {
-				return err
-			}
-		}
-		time.Sleep(batchWaitTime)
-		if err := resp.Context().Err(); err != nil {
-			// context is closed
-			return nil
-		}
+		filters = append(filters, api.Filter{
+			Field:     "level",
+			Operation: api.FilterOperationIn,
+			Values:    levels,
+		})
 	}
+	if len(req.Stdtype) > 0 {
+		filters = append(filters, api.Filter{
+			Field:     "stdtype",
+			Operation: api.FilterOperationIn,
+			Values:    req.Stdtype,
+		})
+	}
+	if len(req.Source) > 0 {
+		filters = append(filters, api.Filter{
+			Field:     "source",
+			Operation: api.FilterOperationIn,
+			Values:    req.Source,
+		})
+	}
+	if req.TimestampBefore != nil {
+		t, err := ptypes.Timestamp(req.TimestampBefore)
+		if err != nil {
+			return nil, err
+		}
+		filters = append(filters, api.Filter{
+			Field:     "timestamp",
+			Operation: api.FilterOperationLessThan,
+			Values:    t,
+		})
+	}
+	if req.TimestampAfter != nil {
+		t, err := ptypes.Timestamp(req.TimestampAfter)
+		if err != nil {
+			return nil, err
+		}
+		filters = append(filters, api.Filter{
+			Field:     "timestamp",
+			Operation: api.FilterOperationGreaterThan,
+			Values:    t,
+		})
+	}
+	return filters, nil
 }
 
 func (a *apiServer) GetTrialCheckpoints(

--- a/master/internal/api_trials.go
+++ b/master/internal/api_trials.go
@@ -50,9 +50,11 @@ func (a *apiServer) TrialLogs(
 	req *apiv1.TrialLogsRequest, resp apiv1.Determined_TrialLogsServer) error {
 	if err := grpc.ValidateRequest(
 		grpc.ValidateLimit(req.Limit),
+		grpc.ValidateFollow(req.Limit, req.Follow),
 	); err != nil {
 		return err
 	}
+
 	_, total, err := trialStatus(a.m.db, req.TrialId)
 	if err != nil {
 		return err
@@ -77,7 +79,7 @@ func (a *apiServer) TrialLogs(
 
 	fetch := func(lr api.LogsRequest) (api.LogBatch, error) {
 		switch {
-		case lr.Follow || lr.Limit > batchSize:
+		case lr.Follow, lr.Limit > batchSize:
 			lr.Limit = batchSize
 		case lr.Limit <= 0:
 			return nil, nil

--- a/master/internal/db/postgres.go
+++ b/master/internal/db/postgres.go
@@ -1369,7 +1369,7 @@ func (db *PgDB) AddTrialLogs(logs []*model.TrialLog) error {
 	var text strings.Builder
 	text.WriteString(`
 INSERT INTO trial_logs
-    (trial_id, message, agent_id, container_id, timestamp, level, stdtype, source)
+    (trial_id, message, agent_id, container_id, rank_id, timestamp, level, stdtype, source)
 VALUES
 `)
 
@@ -1380,11 +1380,11 @@ VALUES
 		if i > 0 {
 			text.WriteString(",")
 		}
-		fmt.Fprintf(&text, " ($%d, $%d, $%d, $%d, $%d, $%d, $%d, $%d)",
-			i*8+1, i*8+2, i*8+3, i*8+4, i*8+5, i*8+6, i*8+7, i*8+8)
+		fmt.Fprintf(&text, " ($%d, $%d, $%d, $%d, $%d, $%d, $%d, $%d, $%d)",
+			i*9+1, i*9+2, i*9+3, i*9+4, i*9+5, i*9+6, i*9+7, i*9+8, i*9+9)
 
 		args = append(args, log.TrialID, model.RawString(log.Message), log.AgentID, log.ContainerID,
-			log.Timestamp, log.Level, log.StdType, log.Source)
+			log.RankID, log.Timestamp, log.Level, log.StdType, log.Source)
 	}
 
 	if _, err := db.sql.Exec(text.String(), args...); err != nil {

--- a/master/internal/db/postgres_filters.go
+++ b/master/internal/db/postgres_filters.go
@@ -2,19 +2,28 @@ package db
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 	"time"
 
 	"github.com/determined-ai/determined/master/internal/api"
 )
 
+var validField = regexp.MustCompile(`^[a-zA-Z0-9_]+$`)
+
 // filtersToSQL takes a slice of api.Filter and the params for the current state of the
 // returned fragment will be added to and constructs a query fragment representing
 // the provided filters and a full list of parameters.
+//
+// The user input to the filters should always be contained in api.Filter.Values and
+// never the field. If the field is taken from user input, SQL injection is possible.
 func filtersToSQL(fs []api.Filter, params []interface{}) (string, []interface{}) {
 	paramID := len(params) + 1
 	var fragments []string
 	for _, f := range fs {
+		if !validField.MatchString(f.Field) {
+			panic(fmt.Sprintf("field in filter %s contains possible SQL injection", f.Field))
+		}
 		filterParams := filterToParams(f)
 		fragments = append(fragments, filterToSQL(f, filterParams, paramID))
 		params = append(params, filterParams...)
@@ -58,7 +67,7 @@ func filterToParams(f api.Filter) []interface{} {
 	case time.Time:
 		params = append(params, vs)
 	default:
-		panic(fmt.Sprintf("cannot convert fitler values to params: %T", f.Values))
+		panic(fmt.Sprintf("cannot convert filter values to params: %T", f.Values))
 	}
 	return params
 }

--- a/master/internal/db/postgres_filters.go
+++ b/master/internal/db/postgres_filters.go
@@ -51,6 +51,10 @@ func filterToParams(f api.Filter) []interface{} {
 		for _, v := range vs {
 			params = append(params, v)
 		}
+	case []int32:
+		for _, v := range vs {
+			params = append(params, v)
+		}
 	case time.Time:
 		params = append(params, vs)
 	default:

--- a/master/internal/db/postgres_filters.go
+++ b/master/internal/db/postgres_filters.go
@@ -1,0 +1,60 @@
+package db
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/determined-ai/determined/master/internal/api"
+)
+
+// filtersToSQL takes a slice of api.Filter and the params for the current state of the
+// returned fragment will be added to and constructs a query fragment representing
+// the provided filters and a full list of parameters.
+func filtersToSQL(fs []api.Filter, params []interface{}) (string, []interface{}) {
+	paramID := len(params) + 1
+	var fragments []string
+	for _, f := range fs {
+		filterParams := filterToParams(f)
+		fragments = append(fragments, filterToSQL(f, filterParams, paramID))
+		params = append(params, filterParams...)
+		paramID += len(filterParams)
+	}
+	return strings.Join(fragments, "\n"), params
+}
+
+func filterToSQL(f api.Filter, values []interface{}, paramID int) string {
+	switch f.Operation {
+	case api.FilterOperationIn:
+		var fragment strings.Builder
+		_, _ = fragment.WriteString("AND %s IN (")
+		var paramFragments []string
+		for i := range values {
+			paramFragments = append(paramFragments, fmt.Sprintf("$%d", paramID+i))
+		}
+		_, _ = fragment.WriteString(strings.Join(paramFragments, ","))
+		_, _ = fragment.WriteString(")")
+		return fmt.Sprintf(fragment.String(), f.Field)
+	case api.FilterOperationGreaterThan:
+		return fmt.Sprintf("AND %s > $%d", f.Field, paramID)
+	case api.FilterOperationLessThan:
+		return fmt.Sprintf("AND %s < $%d", f.Field, paramID)
+	default:
+		panic(fmt.Sprintf("cannot convert operation %d to SQL", f.Operation))
+	}
+}
+
+func filterToParams(f api.Filter) []interface{} {
+	var params []interface{}
+	switch vs := f.Values.(type) {
+	case []string:
+		for _, v := range vs {
+			params = append(params, v)
+		}
+	case time.Time:
+		params = append(params, vs)
+	default:
+		panic(fmt.Sprintf("cannot convert fitler values to params: %T", f.Values))
+	}
+	return params
+}

--- a/master/internal/db/postgres_proto.go
+++ b/master/internal/db/postgres_proto.go
@@ -38,5 +38,5 @@ func (db *PgDB) QueryProto(queryName string, v interface{}, args ...interface{})
 		return errors.Wrapf(protojson.Unmarshal(bytes, message),
 			"error converting row to Protobuf struct")
 	}
-	return db.queryRows(queryName, parser, v, args...)
+	return db.queryRowsWithParser(db.queries.getOrLoad(queryName), parser, v, args...)
 }

--- a/master/internal/db/postgres_trial_logs.go
+++ b/master/internal/db/postgres_trial_logs.go
@@ -1,0 +1,36 @@
+package db
+
+import (
+	"fmt"
+
+	"github.com/determined-ai/determined/master/internal/api"
+
+	"github.com/determined-ai/determined/master/pkg/model"
+)
+
+// TrialLogs takes a trial ID and log offset, limit and filters and returns matching trial logs.
+func (db *PgDB) TrialLogs(
+	trialID, offset, limit int, fs []api.Filter,
+) ([]*model.TrialLog, error) {
+	params := []interface{}{trialID, offset, limit}
+	fragment, params := filtersToSQL(fs, params)
+	query := fmt.Sprintf(`
+SELECT
+    l.id,
+    l.trial_id,
+    encode(l.message, 'escape') as message,
+    l.agent_id,
+    l.container_id,
+    l.timestamp,
+    l.level,
+    l.stdtype,
+    l.source
+FROM trial_logs l
+WHERE l.trial_id = $1
+%s
+ORDER BY l.id ASC OFFSET $2 LIMIT $3
+`, fragment)
+
+	var b []*model.TrialLog
+	return b, db.queryRows(query, &b, params...)
+}

--- a/master/internal/db/postgres_trial_logs.go
+++ b/master/internal/db/postgres_trial_logs.go
@@ -18,7 +18,17 @@ func (db *PgDB) TrialLogs(
 SELECT
     l.id,
     l.trial_id,
-    encode(l.message, 'escape') as message,
+    CASE
+      WHEN log IS NOT NULL THEN
+        coalesce(to_char(timestamp, '[YYYY-MM-DD"T"HH24:MI:SS"Z"]' ), '[UNKNOWN TIME]')
+        || ' '
+        || coalesce(substring(container_id, 1, 8), '[UNKNOWN CONTAINER]')
+        || coalesce(' [rank=' || (rank_id::text) || ']', '')
+        || ' || '
+        || coalesce(level || ': ', '')
+        || encode(log, 'escape')
+      ELSE encode(message, 'escape')
+    END AS message,
     l.agent_id,
     l.container_id,
     l.timestamp,

--- a/master/internal/grpc/validate.go
+++ b/master/internal/grpc/validate.go
@@ -28,5 +28,7 @@ func ValidateLimit(limit int32) Check {
 
 // ValidateFollow validates Follow message fields.
 func ValidateFollow(limit int32, follow bool) Check {
-	return func() (bool, string) { return limit == 0 || !follow, "Limit must be = 0 when following" }
+	return func() (bool, string) {
+		return limit == 0 || !follow, "Limit cannot be specified when following"
+	}
 }

--- a/master/internal/grpc/validate.go
+++ b/master/internal/grpc/validate.go
@@ -25,3 +25,8 @@ func ValidateRequest(checks ...Check) error {
 func ValidateLimit(limit int32) Check {
 	return func() (bool, string) { return limit >= 0, "Limit must be >= 0" }
 }
+
+// ValidateFollow validates Follow message fields.
+func ValidateFollow(limit int32, follow bool) Check {
+	return func() (bool, string) { return limit == 0 || !follow, "Limit must be = 0 when following" }
+}

--- a/master/pkg/actor/system.go
+++ b/master/pkg/actor/system.go
@@ -98,3 +98,13 @@ func (s *System) ActorOf(address Address, actor Actor) (*Ref, bool) {
 	created := resp.Get().(childCreated)
 	return created.child, created.created
 }
+
+// MustActorOf adds the actor with the provided address.
+// It panics if a new actor was not created.
+func (s *System) MustActorOf(address Address, actor Actor) *Ref {
+	ref, created := s.ActorOf(address, actor)
+	if !created {
+		panic("actor was not created")
+	}
+	return ref
+}

--- a/master/pkg/logger/log_buffer.go
+++ b/master/pkg/logger/log_buffer.go
@@ -86,6 +86,24 @@ type Entry struct {
 	Level   logrus.Level `json:"level"`
 }
 
+// EntriesBatch is a batch of logger.Entry.
+type EntriesBatch []*Entry
+
+// Size implements logs.Batch.
+func (eb EntriesBatch) Size() int {
+	return len(eb)
+}
+
+// ForEach implements logs.Batch.
+func (eb EntriesBatch) ForEach(f func(interface{}) error) error {
+	for _, e := range eb {
+		if err := f(e); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // LogBuffer is an in-memory buffer based logger.
 type LogBuffer struct {
 	lock         sync.RWMutex

--- a/master/pkg/model/experiment.go
+++ b/master/pkg/model/experiment.go
@@ -401,6 +401,24 @@ type TrialLog struct {
 	StdType     *string    `db:"stdtype" json:"stdtype"`
 }
 
+// TrialLogBatch represents a batch of model.TrialLog.
+type TrialLogBatch []*TrialLog
+
+// Size implements logs.Batch.
+func (t TrialLogBatch) Size() int {
+	return len(t)
+}
+
+// ForEach implements logs.Batch.
+func (t TrialLogBatch) ForEach(f func(interface{}) error) error {
+	for _, tl := range t {
+		if err := f(tl); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // SearcherEvent represents a row from the `searcher_events` table.
 type SearcherEvent struct {
 	ID           int     `db:"id"`

--- a/master/static/migrations/20200929105146_add-trial-log-fields-for-filtering.down.sql
+++ b/master/static/migrations/20200929105146_add-trial-log-fields-for-filtering.down.sql
@@ -2,6 +2,7 @@ ALTER TABLE public.trial_logs
     DROP COLUMN agent_id,
     DROP COLUMN container_id,
     DROP COLUMN rank_id,
+    DROP COLUMN log,
     DROP COLUMN timestamp,
     DROP COLUMN level,
     DROP COLUMN source,

--- a/master/static/srv/stream_logs.sql
+++ b/master/static/srv/stream_logs.sql
@@ -1,5 +1,0 @@
-SELECT
-    encode(l.message, 'escape') as message
-FROM trial_logs l
-WHERE l.trial_id = $1
-ORDER BY l.id ASC OFFSET $2 LIMIT $3

--- a/proto/src/determined/api/v1/trial.proto
+++ b/proto/src/determined/api/v1/trial.proto
@@ -38,9 +38,9 @@ message TrialLogsRequest {
   repeated string stdtype = 10;
   // Limit the trial logs to a subset of sources.
   repeated string source = 11;
-  // Limit the trial logs where the timestamp is before a given time.
+  // Limit the trial logs to ones with a timestamp before a given time.
   google.protobuf.Timestamp timestamp_before = 12;
-  // Limit the trial logs where the timestamp is after a given time.
+  // Limit the trial logs to ones with a timestamp after a given time.
   google.protobuf.Timestamp timestamp_after = 13;
 }
 

--- a/proto/src/determined/api/v1/trial.proto
+++ b/proto/src/determined/api/v1/trial.proto
@@ -3,7 +3,10 @@ syntax = "proto3";
 package determined.api.v1;
 option go_package = "github.com/determined-ai/determined/proto/pkg/apiv1";
 
+import "google/protobuf/timestamp.proto";
+
 import "determined/experiment/v1/experiment.proto";
+import "determined/log/v1/log.proto";
 import "determined/trial/v1/trial.proto";
 import "determined/api/v1/pagination.proto";
 import "determined/checkpoint/v1/checkpoint.proto";
@@ -11,6 +14,9 @@ import "protoc-gen-swagger/options/annotations.proto";
 
 // Stream Trial logs.
 message TrialLogsRequest {
+  option (grpc.gateway.protoc_gen_swagger.options.openapiv2_schema) = {
+    json_schema: { required: [ "trial_id" ] }
+  };
   // The id of the trial.
   int32 trial_id = 1;
   // Skip the number of trial logs before returning results. Negative values
@@ -20,7 +26,22 @@ message TrialLogsRequest {
   int32 limit = 4;
   // Continue following logs until the trial stops or the limit is reached.
   bool follow = 5;
+  // Limit the trial logs a subset of agents.
+  repeated string agent_ids = 6;
+  // Limit the trial logs a subset of containers.
+  repeated string container_ids = 7;
+  // Limit the trial logs a subset agents.
+  repeated determined.log.v1.LogLevel level = 8;
+  // Limit the trial logs a subset of output streams.
+  repeated string stdtype = 9;
+  // Limit the trial logs a subset of sources.
+  repeated string source = 10;
+  // Limit the trial logs where the timestamp is before a given time.
+  google.protobuf.Timestamp timestamp_before = 11;
+  // Limit the trial logs where the timestamp is after a given time.
+  google.protobuf.Timestamp timestamp_after = 12;
 }
+
 // Response to TrialLogsRequest.
 message TrialLogsResponse {
   option (grpc.gateway.protoc_gen_swagger.options.openapiv2_schema) = {

--- a/proto/src/determined/api/v1/trial.proto
+++ b/proto/src/determined/api/v1/trial.proto
@@ -26,20 +26,22 @@ message TrialLogsRequest {
   int32 limit = 4;
   // Continue following logs until the trial stops or the limit is reached.
   bool follow = 5;
-  // Limit the trial logs a subset of agents.
+  // Limit the trial logs to a subset of agents.
   repeated string agent_ids = 6;
-  // Limit the trial logs a subset of containers.
+  // Limit the trial logs to a subset of containers.
   repeated string container_ids = 7;
+  // Limit the trial logs to a subset of ranks.
+  repeated int32 rank_ids = 8;
   // Limit the trial logs a subset agents.
-  repeated determined.log.v1.LogLevel level = 8;
+  repeated determined.log.v1.LogLevel level = 9;
   // Limit the trial logs a subset of output streams.
-  repeated string stdtype = 9;
+  repeated string stdtype = 10;
   // Limit the trial logs a subset of sources.
-  repeated string source = 10;
+  repeated string source = 11;
   // Limit the trial logs where the timestamp is before a given time.
-  google.protobuf.Timestamp timestamp_before = 11;
+  google.protobuf.Timestamp timestamp_before = 12;
   // Limit the trial logs where the timestamp is after a given time.
-  google.protobuf.Timestamp timestamp_after = 12;
+  google.protobuf.Timestamp timestamp_after = 13;
 }
 
 // Response to TrialLogsRequest.

--- a/proto/src/determined/api/v1/trial.proto
+++ b/proto/src/determined/api/v1/trial.proto
@@ -32,11 +32,11 @@ message TrialLogsRequest {
   repeated string container_ids = 7;
   // Limit the trial logs to a subset of ranks.
   repeated int32 rank_ids = 8;
-  // Limit the trial logs a subset agents.
+  // Limit the trial logs to a subset of agents.
   repeated determined.log.v1.LogLevel level = 9;
-  // Limit the trial logs a subset of output streams.
+  // Limit the trial logs to a subset of output streams.
   repeated string stdtype = 10;
-  // Limit the trial logs a subset of sources.
+  // Limit the trial logs to a subset of sources.
   repeated string source = 11;
   // Limit the trial logs where the timestamp is before a given time.
   google.protobuf.Timestamp timestamp_before = 12;

--- a/proto/src/determined/log/v1/log.proto
+++ b/proto/src/determined/log/v1/log.proto
@@ -5,6 +5,22 @@ option go_package = "github.com/determined-ai/determined/proto/pkg/logv1";
 
 import "protoc-gen-swagger/options/annotations.proto";
 
+// LogLevel specifies the level for a log.
+enum LogLevel {
+  // Unspecified log level.
+  LOG_LEVEL_UNSPECIFIED = 0;
+  // A log level of DEBUG.
+  LOG_LEVEL_DEBUG = 1;
+  // A log level of INFO.
+  LOG_LEVEL_INFO = 2;
+  // A log level of WARNING.
+  LOG_LEVEL_WARNING = 3;
+  // A log level of ERROR.
+  LOG_LEVEL_ERROR = 4;
+  // A log level of CRITICAL.
+  LOG_LEVEL_CRITICAL = 5;
+}
+
 // LogEntry is a log event.
 message LogEntry {
   option (grpc.gateway.protoc_gen_swagger.options.openapiv2_schema) = {


### PR DESCRIPTION
## Description
This change adds filtering support to `/api/v1/trial/{trial_id}/logs`. It also unifies the trial and master logs streaming code paths and provides a small internal filter representation and a not-too-general way to convert it to SQL.
<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan
- [x] add integration tests for the complex bits
- [x] test notebook, trial, master logs all still work as expected.
<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)
There were a lot of ways to do all this. For the most part, in the end, I settled back on the simpler way.

The only this in the PR I think now that is mildly controversial is the `api.ProcessLogs` is now an actor `LogStoreProcessor` or something. The idea here was mainly motivated by this opinion of mine: everything (especially things that are even remotely long-running, like streaming trial logs) should just be an actor. Now that some preliminary tracing support is going to land, it's even easier to get visibility into that plain-old goroutines, and the more things are actors, the more useful the actors become, imo.
<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [x] No release notes until there are fields to actually filter on populated.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234