### PR TITLE
feat: support storageClass configuration in Helm Chart [DET-4357]

### DIFF
--- a/docs/reference/helm-config.txt
+++ b/docs/reference/helm-config.txt
@@ -77,6 +77,13 @@ Helm Chart </helm/determined-helm-chart.tgz>`.
 
    -  ``memRequest``: The memory requirements for the Determined database.
 
+   -  ``storageClassName``: Optional configuration to indicate StorageClass
+      that should be used by the PersistentVolumeClaim for the Determined
+      deployed database. This can be left blank if a default storage class
+      is specified in the cluster. If dynamic provisioning of PersistentVolumes
+      is disabled, users must manually create a PersistentVolume that will
+      match the PersistentVolumeClaim.
+
 -  ``checkpointStorage``: Specifies where model checkpoints will be
    stored. This can be overridden on a per-experiment basis in the
    :ref:`experiment-configuration`. A checkpoint contains the

--- a/docs/release-notes/1412-db-helm-configs.txt
+++ b/docs/release-notes/1412-db-helm-configs.txt
@@ -1,6 +1,6 @@
 :orphan:
 
-**Improvments**
+**Improvements**
 
 - Added support for configuring memory and cpu requirements for the Determined
   database when installing via the Determined Helm Chart.

--- a/docs/release-notes/1434-congure-storage-class.txt
+++ b/docs/release-notes/1434-congure-storage-class.txt
@@ -1,0 +1,6 @@
+:orphan:
+
+**Improvements**
+
+- Added support for configuring the storageClass that is used when deploying
+  a database using the Determined Helm Chart.

--- a/helm/charts/determined/templates/db-deployment.yaml
+++ b/helm/charts/determined/templates/db-deployment.yaml
@@ -39,12 +39,14 @@ spec:
             value: {{ .Values.db.password | quote }}
           - name: PGDATA
             value: /var/lib/postgresql/data/pgdata
+        args: ["--max_connections=96", "--shared_buffers=512MB"]
+      {{- if not .Values.db.disablePVC }}
         volumeMounts:
           - mountPath: "/var/lib/postgresql/data"
             name: determined-db-storage
-        args: ["--max_connections=96", "--shared_buffers=512MB"]
       volumes:
         - name: determined-db-storage
           persistentVolumeClaim:
             claimName: determined-db-pvc-{{ .Release.Name }}
+      {{ end }}
 {{ end}}

--- a/helm/charts/determined/templates/db-persitent-volume-claim.yaml
+++ b/helm/charts/determined/templates/db-persitent-volume-claim.yaml
@@ -14,4 +14,7 @@ spec:
   resources:
     requests:
       storage: {{ required  "A valid Values.db.storageSize entry is required!" .Values.db.storageSize }}
+  {{- if .Values.db.storageClassName }}
+  storageClassName: {{ .Values.db.storageClassName }}
+  {{ end }}
 {{ end }}

--- a/helm/charts/determined/templates/db-persitent-volume-claim.yaml
+++ b/helm/charts/determined/templates/db-persitent-volume-claim.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.db.hostAddress }}
+{{- if or .Values.db.hostAddress .Values.db.disablePVC }}
 {{ else }}
 apiVersion: v1
 kind: PersistentVolumeClaim

--- a/helm/charts/determined/values.yaml
+++ b/helm/charts/determined/values.yaml
@@ -38,6 +38,13 @@ db:
   cpuRequest: "2"
   memRequest: "8Gi"
 
+  # storageClassName configures the StorageClass used by the PersistentVolumeClaim
+  # for the Determined deployed database. This can be left blank if a default
+  # storage class is specified in the cluster. If dynamic provisioning of
+  # PersistentVolumes is disabled, users must manually create a PersistentVolume
+  # that will match the PersistentVolumeClaim.
+  # storageClassName:
+
 # checkpointStorage controls where checkpoints are stored.
 # supported types include `shared_fs`, `gcs`, and `s3.
 checkpointStorage:


### PR DESCRIPTION
## Description
This PR adds support for configuring the storageClass for the PVC deployed
as part of the Determined Helm Chart. Users need to set this when a default
storageClass is not configured.


## Test Plan
Tested this on a k8s cluster.

