### PR TITLE
chore: remove tests for native parallel

### DIFF
--- a/e2e_tests/tests/config.py
+++ b/e2e_tests/tests/config.py
@@ -70,13 +70,6 @@ def set_slots_per_trial(config: Dict[Any, Any], slots: int) -> Dict[Any, Any]:
     return config
 
 
-def set_native_parallel(config: Dict[Any, Any], native_parallel: bool) -> Dict[Any, Any]:
-    config = config.copy()
-    config.setdefault("resources", {})
-    config["resources"]["native_parallel"] = native_parallel
-    return config
-
-
 def set_max_length(config: Dict[Any, Any], max_length: Dict[str, int]) -> Dict[Any, Any]:
     config = config.copy()
     config["searcher"]["max_length"] = max_length

--- a/e2e_tests/tests/experiment/test_pytorch.py
+++ b/e2e_tests/tests/experiment/test_pytorch.py
@@ -97,16 +97,6 @@ def test_pytorch_const_warm_start() -> None:
 
 
 @pytest.mark.parallel  # type: ignore
-def test_pytorch_const_native_parallel() -> None:
-    config = conf.load_config(conf.tutorials_path("mnist_pytorch/const.yaml"))
-    config = conf.set_slots_per_trial(config, 8)
-    config = conf.set_native_parallel(config, True)
-    config = conf.set_max_length(config, {"batches": 200})
-
-    exp.run_basic_test_with_temp_config(config, conf.tutorials_path("mnist_pytorch"), 1)
-
-
-@pytest.mark.parallel  # type: ignore
 @pytest.mark.parametrize("aggregation_frequency", [1, 4])  # type: ignore
 @pytest.mark.parametrize("use_amp", [True, False])  # type: ignore
 def test_pytorch_const_parallel(aggregation_frequency: int, use_amp: bool) -> None:
@@ -115,7 +105,6 @@ def test_pytorch_const_parallel(aggregation_frequency: int, use_amp: bool) -> No
 
     config = conf.load_config(conf.tutorials_path("mnist_pytorch/const.yaml"))
     config = conf.set_slots_per_trial(config, 8)
-    config = conf.set_native_parallel(config, False)
     config = conf.set_max_length(config, {"batches": 200})
     config = conf.set_aggregation_frequency(config, aggregation_frequency)
     if use_amp:

--- a/e2e_tests/tests/experiment/test_tf_estimator.py
+++ b/e2e_tests/tests/experiment/test_tf_estimator.py
@@ -22,15 +22,10 @@ def test_mnist_estimator_load() -> None:
 
 
 @pytest.mark.parallel  # type: ignore
-@pytest.mark.parametrize("native_parallel", [True, False])  # type: ignore
 @pytest.mark.parametrize("tf2", [False, True])  # type: ignore
-def test_mnist_estimmator_const_parallel(native_parallel: bool, tf2: bool) -> None:
-    if tf2 and native_parallel:
-        pytest.skip("TF2 native parallel training is not currently supported.")
-
+def test_mnist_estimator_const_parallel(tf2: bool) -> None:
     config = conf.load_config(conf.fixtures_path("mnist_estimator/single-multi-slot.yaml"))
     config = conf.set_slots_per_trial(config, 8)
-    config = conf.set_native_parallel(config, native_parallel)
     config = conf.set_max_length(config, {"batches": 200})
     config = conf.set_tf2_image(config) if tf2 else conf.set_tf1_image(config)
     config = conf.set_perform_initial_validation(config, True)

--- a/e2e_tests/tests/experiment/test_tf_keras.py
+++ b/e2e_tests/tests/experiment/test_tf_keras.py
@@ -6,22 +6,6 @@ from tests import config as conf
 from tests import experiment as exp
 
 
-@pytest.mark.parallel  # type: ignore
-@pytest.mark.parametrize("tf2", [False])  # type: ignore
-def test_tf_keras_native_parallel(tf2: bool) -> None:
-    config = conf.load_config(conf.cv_examples_path("cifar10_tf_keras/const.yaml"))
-    config = conf.set_slots_per_trial(config, 8)
-    config = conf.set_native_parallel(config, True)
-    config = conf.set_max_length(config, {"batches": 200})
-    config = conf.set_tf2_image(config) if tf2 else conf.set_tf1_image(config)
-
-    experiment_id = exp.run_basic_test_with_temp_config(
-        config, conf.cv_examples_path("cifar10_tf_keras"), 1
-    )
-    trials = exp.experiment_trials(experiment_id)
-    assert len(trials) == 1
-
-
 @pytest.mark.parametrize(  # type: ignore
     "tf2",
     [
@@ -67,7 +51,6 @@ def test_tf_keras_const_warm_start(tf2: bool) -> None:
 def test_tf_keras_parallel(aggregation_frequency: int, tf2: bool) -> None:
     config = conf.load_config(conf.cv_examples_path("cifar10_tf_keras/const.yaml"))
     config = conf.set_slots_per_trial(config, 8)
-    config = conf.set_native_parallel(config, False)
     config = conf.set_max_length(config, {"batches": 200})
     config = conf.set_aggregation_frequency(config, aggregation_frequency)
     config = conf.set_tf2_image(config) if tf2 else conf.set_tf1_image(config)
@@ -98,7 +81,6 @@ def test_tf_keras_single_gpu(tf2: bool) -> None:
 def test_tf_keras_mnist_parallel() -> None:
     config = conf.load_config(conf.tutorials_path("fashion_mnist_tf_keras/const.yaml"))
     config = conf.set_slots_per_trial(config, 8)
-    config = conf.set_native_parallel(config, False)
     config = conf.set_max_length(config, {"batches": 200})
 
     experiment_id = exp.run_basic_test_with_temp_config(

--- a/e2e_tests/tests/fixtures/templates/template.yaml
+++ b/e2e_tests/tests/fixtures/templates/template.yaml
@@ -1,7 +1,6 @@
 description: test_template
 resources:
   agent_label: ""
-  native_parallel: False
   slots: 100
   slots_per_trial: 100
   weight: 1

--- a/e2e_tests/tests/test_system.py
+++ b/e2e_tests/tests/test_system.py
@@ -480,7 +480,6 @@ def test_s3_no_creds(secrets: Dict[str, str]) -> None:
 def test_pytorch_parallel() -> None:
     config = conf.load_config(conf.tutorials_path("mnist_pytorch/const.yaml"))
     config = conf.set_slots_per_trial(config, 8)
-    config = conf.set_native_parallel(config, False)
     config = conf.set_max_length(config, {"batches": 200})
     config = conf.set_tensor_auto_tuning(config, True)
     config = conf.set_perform_initial_validation(config, True)

--- a/harness/determined/_trial_controller.py
+++ b/harness/determined/_trial_controller.py
@@ -100,10 +100,6 @@ class TrialController(metaclass=abc.ABCMeta):
         pass
 
     @staticmethod
-    def supports_multi_gpu_training() -> bool:
-        return False
-
-    @staticmethod
     def supports_mixed_precision() -> bool:
         return False
 
@@ -119,13 +115,6 @@ class TrialController(metaclass=abc.ABCMeta):
         return False
 
     def _check_if_trial_supports_configurations(self, env: det.EnvContext) -> None:
-        if self.env.experiment_config.slots_per_trial() > 1:
-            check.true(
-                self.supports_multi_gpu_training(),
-                "Multi-gpu training is not supported for this "
-                "framework interface. Please set slots_per_task = 1.",
-            )
-
         if self.env.experiment_config.mixed_precision_enabled():
             check.true(
                 self.supports_mixed_precision(),

--- a/harness/determined/estimator/_estimator_trial.py
+++ b/harness/determined/estimator/_estimator_trial.py
@@ -464,10 +464,6 @@ class EstimatorTrialController(det.LoopTrialController):
         )
 
     @staticmethod
-    def supports_multi_gpu_training() -> bool:
-        return True
-
-    @staticmethod
     def support_determined_native() -> bool:
         return True
 

--- a/harness/determined/keras/_tf_keras_trial.py
+++ b/harness/determined/keras/_tf_keras_trial.py
@@ -391,10 +391,6 @@ class TFKerasTrialController(det.LoopTrialController):
     def support_determined_native() -> bool:
         return True
 
-    @staticmethod
-    def supports_multi_gpu_training() -> bool:
-        return True
-
     def _load(self) -> None:
         if not self.load_path:
             return

--- a/harness/determined/pytorch/_pytorch_trial.py
+++ b/harness/determined/pytorch/_pytorch_trial.py
@@ -107,10 +107,6 @@ class PyTorchTrialController(det.LoopTrialController):
         return True
 
     @staticmethod
-    def supports_multi_gpu_training() -> bool:
-        return True
-
-    @staticmethod
     def supports_mixed_precision() -> bool:
         return True
 


### PR DESCRIPTION
Save money on CI by not testing features which are known to be buggy and
which have never really been properly supported.

Leaving the feature intact as AMLEs report it is occasionally useful and it
amounts to very few lines of code.