### PR TITLE
chore: remove useless support_determined_native calls

### DIFF
--- a/harness/determined/_trial_controller.py
+++ b/harness/determined/_trial_controller.py
@@ -110,10 +110,6 @@ class TrialController(metaclass=abc.ABCMeta):
     def initialize_wrapper(self) -> None:
         pass
 
-    @staticmethod
-    def support_determined_native() -> bool:
-        return False
-
     def _check_if_trial_supports_configurations(self, env: det.EnvContext) -> None:
         if self.env.experiment_config.mixed_precision_enabled():
             check.true(
@@ -121,9 +117,6 @@ class TrialController(metaclass=abc.ABCMeta):
                 "Mixed precision training is not supported for this framework interface. "
                 'Please set `mixed_precision = "O0"`.',
             )
-
-        if env.experiment_config.native_enabled():
-            check.true(self.support_determined_native())
 
         if env.experiment_config.averaging_training_metrics_enabled():
             check.true(self.supports_averaging_training_metrics())

--- a/harness/determined/estimator/_estimator_trial.py
+++ b/harness/determined/estimator/_estimator_trial.py
@@ -463,10 +463,6 @@ class EstimatorTrialController(det.LoopTrialController):
             **kwargs,
         )
 
-    @staticmethod
-    def support_determined_native() -> bool:
-        return True
-
     def _check_and_repeat_train_input_fn(self, f: Callable) -> Callable:
         """
         Modifies functions that returns a `tf.data.Dataset` to repeat. This is done

--- a/harness/determined/keras/_tf_keras_trial.py
+++ b/harness/determined/keras/_tf_keras_trial.py
@@ -387,10 +387,6 @@ class TFKerasTrialController(det.LoopTrialController):
         else:
             context.model.compile(*compile_args.args, **compile_args.kwargs)
 
-    @staticmethod
-    def support_determined_native() -> bool:
-        return True
-
     def _load(self) -> None:
         if not self.load_path:
             return

--- a/harness/determined/pytorch/_pytorch_trial.py
+++ b/harness/determined/pytorch/_pytorch_trial.py
@@ -103,10 +103,6 @@ class PyTorchTrialController(det.LoopTrialController):
         raise NotImplementedError("PyTorchTrial only supports the Trial API")
 
     @staticmethod
-    def support_determined_native() -> bool:
-        return True
-
-    @staticmethod
     def supports_mixed_precision() -> bool:
         return True
 


### PR DESCRIPTION
These calls have not been useful since `from_native()` took their place.