### PR TITLE
fix: show more help text and version info in det-deploy [DET-4373]

### DIFF
--- a/deploy/determined_deploy/aws/cli.py
+++ b/deploy/determined_deploy/aws/cli.py
@@ -100,9 +100,10 @@ def make_up_subparser(subparsers: argparse._SubParsersAction) -> None:
 def make_aws_parser(subparsers: argparse._SubParsersAction) -> None:
     parser_aws = subparsers.add_parser("aws", help="AWS help")
 
-    aws_subparsers = parser_aws.add_subparsers(help="command", dest="command", required=True)
+    aws_subparsers = parser_aws.add_subparsers(help="command", dest="command")
     make_down_subparser(aws_subparsers)
     make_up_subparser(aws_subparsers)
+    aws_subparsers.required = True
 
 
 def deploy_aws(args: argparse.Namespace) -> None:

--- a/deploy/determined_deploy/aws/cli.py
+++ b/deploy/determined_deploy/aws/cli.py
@@ -100,7 +100,7 @@ def make_up_subparser(subparsers: argparse._SubParsersAction) -> None:
 def make_aws_parser(subparsers: argparse._SubParsersAction) -> None:
     parser_aws = subparsers.add_parser("aws", help="AWS help")
 
-    aws_subparsers = parser_aws.add_subparsers(help="command", dest="command")
+    aws_subparsers = parser_aws.add_subparsers(help="command", dest="command", required=True)
     make_down_subparser(aws_subparsers)
     make_up_subparser(aws_subparsers)
 

--- a/deploy/determined_deploy/cli.py
+++ b/deploy/determined_deploy/cli.py
@@ -17,9 +17,9 @@ def main() -> None:
         description="Manage Determined deployments.",
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
-    parser.add_argument('--version',
-        action='version',
-        version="%(prog)s {}".format(determined_deploy.__version__))
+    parser.add_argument(
+        "--version", action="version", version="%(prog)s {}".format(determined_deploy.__version__)
+    )
     subparsers = parser.add_subparsers(help="environment", dest="environment")
 
     determined_deploy.local.cli.make_local_parser(subparsers)

--- a/deploy/determined_deploy/cli.py
+++ b/deploy/determined_deploy/cli.py
@@ -17,6 +17,9 @@ def main() -> None:
         description="Manage Determined deployments.",
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
+    parser.add_argument('--version',
+        action='version',
+        version="%(prog)s {}".format(determined_deploy.__version__))
     subparsers = parser.add_subparsers(help="environment", dest="environment")
 
     determined_deploy.local.cli.make_local_parser(subparsers)

--- a/deploy/determined_deploy/gcp/cli.py
+++ b/deploy/determined_deploy/gcp/cli.py
@@ -182,9 +182,10 @@ def make_up_subparser(subparsers: argparse._SubParsersAction) -> None:
 
 def make_gcp_parser(subparsers: argparse._SubParsersAction) -> None:
     parser_gcp = subparsers.add_parser("gcp", help="gcp help")
-    gcp_subparsers = parser_gcp.add_subparsers(help="command", dest="command", required=True)
+    gcp_subparsers = parser_gcp.add_subparsers(help="command", dest="command")
     make_up_subparser(gcp_subparsers)
     make_down_subparser(gcp_subparsers)
+    gcp_subparsers.required = True
 
 
 def deploy_gcp(args: argparse.Namespace) -> None:

--- a/deploy/determined_deploy/gcp/cli.py
+++ b/deploy/determined_deploy/gcp/cli.py
@@ -23,7 +23,7 @@ def make_down_subparser(subparsers: argparse._SubParsersAction) -> None:
         "--local-state-path",
         type=str,
         default=os.getcwd(),
-        help=argparse.SUPPRESS,
+        help="local directory for storing cluster state",
     )
 
 
@@ -92,7 +92,7 @@ def make_up_subparser(subparsers: argparse._SubParsersAction) -> None:
         "--local-state-path",
         type=str,
         default=os.getcwd(),
-        help=argparse.SUPPRESS,
+        help="local directory for storing cluster state",
     )
     optional_named.add_argument(
         "--preemptible",
@@ -182,7 +182,7 @@ def make_up_subparser(subparsers: argparse._SubParsersAction) -> None:
 
 def make_gcp_parser(subparsers: argparse._SubParsersAction) -> None:
     parser_gcp = subparsers.add_parser("gcp", help="gcp help")
-    gcp_subparsers = parser_gcp.add_subparsers(help="command", dest="command")
+    gcp_subparsers = parser_gcp.add_subparsers(help="command", dest="command", required=True)
     make_up_subparser(gcp_subparsers)
     make_down_subparser(gcp_subparsers)
 

--- a/docs/how-to/installation/gcp.txt
+++ b/docs/how-to/installation/gcp.txt
@@ -233,6 +233,13 @@ Optional Arguments:
 
       -  Intel Broadwell
 
+   -  -  ``--local-state-path``
+
+      -  Directory used to store cluster metadata. The same directory
+         cannot be used for multiple clusters at the same time.
+
+      -  Current working directory
+
 The following ``gcloud`` commands will help to validate your
 configuration, including resource availability in your desired region
 and zone:


### PR DESCRIPTION
## Description

Things like `det-deploy gcp` or `det-deploy aws` just print errors because the code assumes you have either an environment AND command or neither. Now requiring the command before going into the environment code. This prompts the user to try --help, and I've added help text for the local_state_path flags on GCP. I also wanted a --version flag while I was debugging this to see if I was actually on a release version, or a development version, etc...

## Test Plan

I ran all combinations mentioned above.