### PR TITLE
fix: improve performance of agents endpoint for k8s [DET-4073]

### DIFF
--- a/docs/release-notes/1450-k8s-agents-endpoint.txt
+++ b/docs/release-notes/1450-k8s-agents-endpoint.txt
@@ -1,0 +1,9 @@
+:orphan:
+
+**Improvements**
+
+- Improved performance of agents endpoint for Kubernetes deployments, which
+  improves the performance of the cluster page in the WebUI as well as
+  ``det slot list`` and ``det task list`` in the CLI.
+
+- Release version ``0.3.0`` of the Determined Helm chart.

--- a/helm/charts/determined/Chart.yaml
+++ b/helm/charts/determined/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: determined
 description: A Helm chart for Determined
-version: 0.2.0
+version: 0.3.0
 icon: https://github.com/determined-ai/determined/blob/master/determined-logo.png?raw=true
 home: https://github.com/determined-ai/determined.git
 

--- a/helm/charts/determined/templates/master-permissions.yaml
+++ b/helm/charts/determined/templates/master-permissions.yaml
@@ -28,7 +28,7 @@ rules:
     verbs: ["watch"]
   - apiGroups: [""]
     resources: ["nodes"]
-    verbs: ["list"]
+    verbs: ["list", "watch"]
 
 
 ---

--- a/master/internal/kubernetes/events.go
+++ b/master/internal/kubernetes/events.go
@@ -92,8 +92,8 @@ func (e *eventListener) modMessage(msg *k8sV1.Event) {
 	}
 
 	for k, v := range replacements {
-		matched, error := regexp.MatchString(k, msg.Message)
-		if error != nil {
+		matched, err := regexp.MatchString(k, msg.Message)
+		if err != nil {
 			break
 		} else if matched {
 			if v == gpuTextReplacement {

--- a/master/internal/kubernetes/nodes.go
+++ b/master/internal/kubernetes/nodes.go
@@ -31,7 +31,7 @@ type nodeInformer struct {
 func newNodeInformer(clientSet k8sClient.Interface, podsHandler *actor.Ref) *nodeInformer {
 	return &nodeInformer{
 		informer: k8Informers.NewSharedInformerFactoryWithOptions(
-			clientSet, 30, []k8Informers.SharedInformerOption{}...),
+			clientSet, 0, []k8Informers.SharedInformerOption{}...),
 		podsHandler: podsHandler,
 		stop:        make(chan struct{}),
 	}
@@ -79,7 +79,7 @@ func (n *nodeInformer) startNodeInformer(ctx *actor.Context) error {
 		},
 	})
 
-	ctx.Log().Debug("starting node informer,")
+	ctx.Log().Debug("starting node informer")
 	n.informer.Start(n.stop)
 	for !nodeInformer.HasSynced() {
 	}

--- a/master/internal/kubernetes/nodes.go
+++ b/master/internal/kubernetes/nodes.go
@@ -1,0 +1,89 @@
+package kubernetes
+
+import (
+	"github.com/determined-ai/determined/master/pkg/actor"
+
+	k8sV1 "k8s.io/api/core/v1"
+	k8Informers "k8s.io/client-go/informers"
+	k8sClient "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+)
+
+// Messages sent by the nodeInformer to itself.
+type (
+	startNodeInformer struct{}
+)
+
+// Messages sent by the nodeInformer to the podsHandler.
+type (
+	nodeStatusUpdate struct {
+		updatedNode *k8sV1.Node
+		deletedNode *k8sV1.Node
+	}
+)
+
+type nodeInformer struct {
+	informer    k8Informers.SharedInformerFactory
+	podsHandler *actor.Ref
+	stop        chan struct{}
+}
+
+func newNodeInformer(clientSet k8sClient.Interface, podsHandler *actor.Ref) *nodeInformer {
+	return &nodeInformer{
+		informer: k8Informers.NewSharedInformerFactoryWithOptions(
+			clientSet, 30, []k8Informers.SharedInformerOption{}...),
+		podsHandler: podsHandler,
+		stop:        make(chan struct{}),
+	}
+}
+
+func (n *nodeInformer) Receive(ctx *actor.Context) error {
+	switch msg := ctx.Message().(type) {
+	case actor.PreStart:
+		ctx.Tell(ctx.Self(), startNodeInformer{})
+
+	case startNodeInformer:
+		if err := n.startNodeInformer(ctx); err != nil {
+			return err
+		}
+
+	case actor.PostStop:
+		ctx.Log().Infof("shutting down node informer")
+		close(n.stop)
+
+	default:
+		ctx.Log().Errorf("unexpected message %T", msg)
+		return actor.ErrUnexpectedMessage(ctx)
+	}
+
+	return nil
+}
+
+func (n *nodeInformer) startNodeInformer(ctx *actor.Context) error {
+	nodeInformer := n.informer.Core().V1().Nodes().Informer()
+	nodeInformer.AddEventHandler(&cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			node := obj.(*k8sV1.Node)
+			ctx.Log().Debugf("node added %s", node.Name)
+			ctx.Tell(n.podsHandler, nodeStatusUpdate{updatedNode: node})
+		},
+		UpdateFunc: func(oldObj, newObj interface{}) {
+			node := newObj.(*k8sV1.Node)
+			ctx.Log().Debugf("node updated %s", node.Name)
+			ctx.Tell(n.podsHandler, nodeStatusUpdate{updatedNode: node})
+		},
+		DeleteFunc: func(obj interface{}) {
+			node := obj.(*k8sV1.Node)
+			ctx.Log().Debugf("node stopped %s", node.Name)
+			ctx.Tell(n.podsHandler, nodeStatusUpdate{deletedNode: node})
+		},
+	})
+
+	ctx.Log().Debug("starting node informer,")
+	n.informer.Start(n.stop)
+	for !nodeInformer.HasSynced() {
+	}
+	ctx.Log().Info("node informer has started")
+
+	return nil
+}


### PR DESCRIPTION
## Description
Previously when we accessed the agents endpoint (WebUI, det slot list, det agent list)
while running on k8s, we would query the k8s API server for the current list of nodes
which was a blocking call. We now keep a running list of current nodes, so there is no
need to make blocking calls to the k8 API server while building the response for the 
agents endpoint.

## Test Plan
Tested manually on a k8 cluster.
