### PR TITLE
fix: update task names for new trials [DET-4832]

### DIFF
--- a/docs/release-notes/1451-update-trial-id-for-new-trials.txt
+++ b/docs/release-notes/1451-update-trial-id-for-new-trials.txt
@@ -1,0 +1,6 @@
+:orphan:
+
+**BUG FIXES**
+
+- Fix issue where trial ids were sometimes not displayed when running
+  ``det task list`` or ``det slot list`` in the CLI.

--- a/master/internal/resourcemanagers/agent_resource_manager.go
+++ b/master/internal/resourcemanagers/agent_resource_manager.go
@@ -42,7 +42,7 @@ func (a *agentResourceManager) Receive(ctx *actor.Context) error {
 	case
 		AllocateRequest, ResourcesReleased,
 		sproto.SetGroupMaxSlots, sproto.SetGroupWeight,
-		GetTaskSummary, GetTaskSummaries,
+		GetTaskSummary, GetTaskSummaries, SetTaskName,
 		sproto.ConfigureEndpoints, sproto.GetEndpointActorAddress:
 		a.forward(ctx, msg)
 

--- a/master/internal/resourcemanagers/kubernetes_resource_manager.go
+++ b/master/internal/resourcemanagers/kubernetes_resource_manager.go
@@ -64,6 +64,7 @@ func (k *kubernetesResourceManager) Receive(ctx *actor.Context) error {
 		groupActorStopped,
 		sproto.SetGroupMaxSlots,
 		sproto.SetGroupWeight,
+		SetTaskName,
 		AllocateRequest,
 		ResourcesReleased:
 		return k.receiveRequestMsg(ctx)
@@ -111,6 +112,9 @@ func (k *kubernetesResourceManager) receiveRequestMsg(ctx *actor.Context) error 
 	case sproto.SetGroupWeight:
 		// SetGroupWeight is not supported by the Kubernetes RP.
 
+	case SetTaskName:
+		k.receiveSetTaskName(ctx, msg)
+
 	case AllocateRequest:
 		k.addTask(ctx, msg)
 
@@ -142,6 +146,12 @@ func (k *kubernetesResourceManager) addTask(ctx *actor.Context, msg AllocateRequ
 		msg.TaskActor.Address(), msg.ID,
 	)
 	k.reqList.AddTask(&msg)
+}
+
+func (k *kubernetesResourceManager) receiveSetTaskName(ctx *actor.Context, msg SetTaskName) {
+	if task, found := k.reqList.GetTaskByHandler(msg.TaskHandler); found {
+		task.Name = msg.Name
+	}
 }
 
 func (k *kubernetesResourceManager) assignResources(ctx *actor.Context, req *AllocateRequest) {

--- a/master/internal/resourcemanagers/resource_managers.go
+++ b/master/internal/resourcemanagers/resource_managers.go
@@ -55,7 +55,7 @@ func (rm *ResourceManagers) Receive(ctx *actor.Context) error {
 	case
 		AllocateRequest, ResourcesReleased,
 		sproto.SetGroupMaxSlots, sproto.SetGroupWeight,
-		GetTaskSummary, GetTaskSummaries,
+		GetTaskSummary, GetTaskSummaries, SetTaskName,
 		sproto.ConfigureEndpoints, sproto.GetEndpointActorAddress:
 		rm.forward(ctx, msg)
 

--- a/master/internal/resourcemanagers/resource_pool.go
+++ b/master/internal/resourcemanagers/resource_pool.go
@@ -81,6 +81,12 @@ func (d *ResourcePool) addTask(ctx *actor.Context, msg AllocateRequest) {
 	d.taskList.AddTask(&msg)
 }
 
+func (d *ResourcePool) receiveSetTaskName(ctx *actor.Context, msg SetTaskName) {
+	if task, found := d.taskList.GetTaskByHandler(msg.TaskHandler); found {
+		task.Name = msg.Name
+	}
+}
+
 // allocateResources assigns resources based on a request and notifies the request
 // handler of the assignment. It returns true if it is successfully allocated.
 func (d *ResourcePool) allocateResources(req *AllocateRequest) bool {
@@ -184,6 +190,7 @@ func (d *ResourcePool) Receive(ctx *actor.Context) error {
 		groupActorStopped,
 		sproto.SetGroupMaxSlots,
 		sproto.SetGroupWeight,
+		SetTaskName,
 		AllocateRequest,
 		ResourcesReleased:
 		return d.receiveRequestMsg(ctx)
@@ -281,6 +288,9 @@ func (d *ResourcePool) receiveRequestMsg(ctx *actor.Context) error {
 
 	case sproto.SetGroupWeight:
 		d.getOrCreateGroup(ctx, msg.Handler).weight = msg.Weight
+
+	case SetTaskName:
+		d.receiveSetTaskName(ctx, msg)
 
 	case AllocateRequest:
 		d.addTask(ctx, msg)

--- a/master/internal/resourcemanagers/task.go
+++ b/master/internal/resourcemanagers/task.go
@@ -25,6 +25,11 @@ type (
 	GetTaskSummary struct{ ID *TaskID }
 	// GetTaskSummaries returns the summaries of all the tasks in the cluster.
 	GetTaskSummaries struct{}
+	// SetTaskName sets the name of the task.
+	SetTaskName struct {
+		Name        string
+		TaskHandler *actor.Ref
+	}
 )
 
 // Incoming task actor messages; task actors must accept these messages.

--- a/master/internal/trial.go
+++ b/master/internal/trial.go
@@ -544,6 +544,10 @@ func (t *trial) processAllocated(
 				return nil
 			}
 		}
+		ctx.Tell(t.rp, resourcemanagers.SetTaskName{
+			Name:        fmt.Sprintf("Trial %d (Experiment %d)", t.id, t.experiment.ID),
+			TaskHandler: ctx.Self(),
+		})
 		ctx.Tell(ctx.Self().Parent(), trialCreated{create: t.create, trialID: t.id})
 	}
 


### PR DESCRIPTION
## Description
Previously trial that did not have an id (so new trials) when requesting 
resources never updated their names. This meant that `det task list`
and `det slot list` would omit the trial id for these trials. This PR fixes
this by updating task names once trial id is set.

## Test Plan
Tested locally and on a k8 cluster.
