### PR TITLE
feat: use Fluent Bit for trial logs [DET-4178]

### DIFF
--- a/agent/cmd/determined-agent/run.go
+++ b/agent/cmd/determined-agent/run.go
@@ -138,5 +138,9 @@ func newRunCmd() *cobra.Command {
 	cmd.Flags().StringVar(&opts.NoProxy, "no-proxy", "",
 		"Addresses that the agent's containers should not proxy")
 
+	// Logging flags.
+	cmd.Flags().StringVar(&opts.FluentLoggingImage, "fluent-logging-image", "fluent/fluent-bit:1.5",
+		"Docker image to use for the managed Fluent Bit daemon")
+
 	return cmd
 }

--- a/agent/cmd/determined-agent/run.go
+++ b/agent/cmd/determined-agent/run.go
@@ -139,8 +139,10 @@ func newRunCmd() *cobra.Command {
 		"Addresses that the agent's containers should not proxy")
 
 	// Logging flags.
-	cmd.Flags().StringVar(&opts.FluentLoggingImage, "fluent-logging-image", "fluent/fluent-bit:1.5",
+	cmd.Flags().StringVar(&opts.Fluent.Image, "fluent-image", "fluent/fluent-bit:1.5",
 		"Docker image to use for the managed Fluent Bit daemon")
+	cmd.Flags().IntVar(&opts.Fluent.Port, "fluent-port", 24224,
+		"TCP port for the Fluent Bit daemon to listen on")
 
 	return cmd
 }

--- a/agent/cmd/determined-agent/run.go
+++ b/agent/cmd/determined-agent/run.go
@@ -139,7 +139,7 @@ func newRunCmd() *cobra.Command {
 		"Addresses that the agent's containers should not proxy")
 
 	// Logging flags.
-	cmd.Flags().StringVar(&opts.Fluent.Image, "fluent-image", "fluent/fluent-bit:1.5",
+	cmd.Flags().StringVar(&opts.Fluent.Image, "fluent-image", "fluent/fluent-bit:1.6",
 		"Docker image to use for the managed Fluent Bit daemon")
 	cmd.Flags().IntVar(&opts.Fluent.Port, "fluent-port", 24224,
 		"TCP port for the Fluent Bit daemon to listen on")

--- a/agent/go.sum
+++ b/agent/go.sum
@@ -203,6 +203,7 @@ github.com/docker/go-connections v0.4.0/go.mod h1:Gbd7IOopHjR8Iph03tsViu4nIes5Xh
 github.com/docker/go-units v0.4.0 h1:3uh0PgVws3nIA0Q+MwDC8yjEPf9zjRfZZWXZYDct3Tw=
 github.com/docker/go-units v0.4.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96/go.mod h1:Qh8CwZgvJUkLughtfhJv5dyTYa91l1fOUCrgjqmcifM=
+github.com/dustinkirkland/golang-petname v0.0.0-20170921220637-d3c2ba80e75e h1:bRcq7ruHMqCVB/ugLbBylx+LrccNACFDEaqAD/aZ80Q=
 github.com/dustinkirkland/golang-petname v0.0.0-20170921220637-d3c2ba80e75e/go.mod h1:V+Qd57rJe8gd4eiGzZyg4h54VLHmYVVw54iMnlAMrF8=
 github.com/elazarl/goproxy v0.0.0-20170405201442-c4fc26588b6e/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=
 github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
@@ -369,6 +370,7 @@ github.com/google/go-replayers/grpcreplay v0.1.0/go.mod h1:8Ig2Idjpr6gifRd6pNVgg
 github.com/google/go-replayers/httpreplay v0.1.0 h1:AX7FUb4BjrrzNvblr/OlgwrmFiep6soj5K2QSDW7BGk=
 github.com/google/go-replayers/httpreplay v0.1.0/go.mod h1:YKZViNhiGgqdBlUbI2MwGpq4pXxNmhJLPHQ7cv2b5no=
 github.com/google/gofuzz v0.0.0-20161122191042-44d81051d367/go.mod h1:HP5RmnzzSNb993RKQDq4+1A4ia9nllfqcQFTQJedwGI=
+github.com/google/gofuzz v1.0.0 h1:A8PeW59pxE9IoFRqBp37U+mSNaQoZ46F1f0f863XSXw=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/martian v2.1.1-0.20190517191504-25dcb96d9e51+incompatible h1:xmapqc1AyLoB+ddYT6r04bD9lIjlOqGaREovi0SzFaE=
@@ -1122,7 +1124,9 @@ gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/fsnotify.v1 v1.4.7 h1:xOHLXZwVvI9hhs+cLKq5+I5onOuwQLhQwiu63xxlHs4=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
+gopkg.in/guregu/null.v3 v3.4.0 h1:AOpMtZ85uElRhQjEDsFx21BkXqFPwA7uoJukd4KErIs=
 gopkg.in/guregu/null.v3 v3.4.0/go.mod h1:E4tX2Qe3h7QdL+uZ3a0vqvYwKQsRSQKM5V4YltdgH9Y=
+gopkg.in/inf.v0 v0.9.0 h1:3zYtXIO92bvsdS3ggAdA8Gb4Azj0YU+TVY1uGYNFA8o=
 gopkg.in/inf.v0 v0.9.0/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
 gopkg.in/ini.v1 v1.51.0 h1:AQvPpx3LzTDM0AjnIRlVFwFFGC+npRopjZxLJj6gdno=
 gopkg.in/ini.v1 v1.51.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
@@ -1158,12 +1162,15 @@ honnef.co/go/tools v0.0.1-2020.1.3 h1:sXmLre5bzIR6ypkjXCDI3jHPssRhc8KD/Ome589sc3
 honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 honnef.co/go/tools v0.0.1-2020.1.4 h1:UoveltGrhghAA7ePc+e+QYDHXrBps2PqFZiHkGR/xK8=
 honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
+k8s.io/api v0.0.0-20191114100352-16d7abae0d2a h1:86XISgFlG7lPOWj6wYLxd+xqhhVt/WQjS4Tf39rP09s=
 k8s.io/api v0.0.0-20191114100352-16d7abae0d2a/go.mod h1:qetVJgs5i8jwdFIdoOZ70ks0ecgU+dYwqZ2uD1srwOU=
+k8s.io/apimachinery v0.0.0-20191028221656-72ed19daf4bb h1:ZUNsbuPdXWrj0rZziRfCWcFg9ZP31OKkziqCbiphznI=
 k8s.io/apimachinery v0.0.0-20191028221656-72ed19daf4bb/go.mod h1:llRdnznGEAqC3DcNm6yEj472xaFVfLM7hnYofMb12tQ=
 k8s.io/client-go v0.0.0-20191114101535-6c5935290e33/go.mod h1:4L/zQOBkEf4pArQJ+CMk1/5xjA30B5oyWv+Bzb44DOw=
 k8s.io/gengo v0.0.0-20190128074634-0689ccc1d7d6/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=
 k8s.io/klog v0.0.0-20181102134211-b9b56d5dfc92/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUcqjScdoY3a9IHpCEIOOfk=
 k8s.io/klog v0.3.0/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUcqjScdoY3a9IHpCEIOOfk=
+k8s.io/klog v0.4.0 h1:lCJCxf/LIowc2IGS9TPjWDyXY4nOmdGdfcwwDQCOURQ=
 k8s.io/klog v0.4.0/go.mod h1:4Bi6QPql/J/LkTDqv7R/cd3hPo4k2DG6Ptcz060Ez5I=
 k8s.io/kube-openapi v0.0.0-20190816220812-743ec37842bf/go.mod h1:1TqjTSzOxsLGIKfj0lK8EeCP7K1iUG65v09OM0/WG5E=
 k8s.io/utils v0.0.0-20190801114015-581e00157fb1/go.mod h1:sZAwmy6armz5eXlNoLmJcl4F1QuKu7sr+mFQ0byX7Ew=

--- a/agent/internal/agent.go
+++ b/agent/internal/agent.go
@@ -126,8 +126,10 @@ func (a *agent) Receive(ctx *actor.Context) error {
 		a.handleAPIRequest(ctx, msg)
 
 	case actor.PostStop:
-		if err := a.fluent.StopAndAwaitTermination(); err != nil {
-			ctx.Log().Errorf("error killing logging container %v", err)
+		if a.fluent != nil {
+			if err := a.fluent.StopAndAwaitTermination(); err != nil {
+				ctx.Log().Errorf("error killing logging container %v", err)
+			}
 		}
 
 		ctx.Log().Info("agent shut down")

--- a/agent/internal/container.go
+++ b/agent/internal/container.go
@@ -27,6 +27,8 @@ type (
 	containerReady      struct{}
 )
 
+type fluentLog map[string]interface{}
+
 func newContainerActor(msg aproto.StartContainer, client *client.Client) actor.Actor {
 	return &containerActor{Container: msg.Container, spec: &msg.Spec, client: client}
 }

--- a/agent/internal/container.go
+++ b/agent/internal/container.go
@@ -20,6 +20,12 @@ import (
 	"github.com/determined-ai/determined/master/pkg/model"
 )
 
+const (
+	agentIDEnvVar     = "DET_AGENT_ID"
+	containerIDEnvVar = "DET_CONTAINER_ID"
+	trialIDEnvVar     = "DET_TRIAL_ID"
+)
+
 type containerActor struct {
 	cproto.Container
 	spec          *cproto.Spec
@@ -53,12 +59,12 @@ func getBaseTrialLog(spec *cproto.Spec) model.TrialLog {
 		split := strings.SplitN(env, "=", 2)
 		value := split[1]
 		switch split[0] {
-		case "DET_TRIAL_ID":
-			log.TrialID, _ = strconv.Atoi(value)
-		case "DET_CONTAINER_ID":
-			log.ContainerID = &value
-		case "DET_AGENT_ID":
+		case agentIDEnvVar:
 			log.AgentID = &value
+		case containerIDEnvVar:
+			log.ContainerID = &value
+		case trialIDEnvVar:
+			log.TrialID, _ = strconv.Atoi(value)
 		}
 	}
 	return log

--- a/agent/internal/containers.go
+++ b/agent/internal/containers.go
@@ -35,7 +35,17 @@ type containerManager struct {
 	Labels        map[string]string `json:"labels"`
 	Devices       []device.Device   `json:"devices"`
 
-	docker *client.Client
+	fluentPort int
+	docker     *client.Client
+}
+
+func newContainerManager(a *agent, fluentPort int) (*containerManager, error) {
+	return &containerManager{
+		MasterInfo: a.MasterInfo,
+		Options:    a.Options,
+		Devices:    a.Devices,
+		fluentPort: fluentPort,
+	}, nil
 }
 
 func (c *containerManager) Receive(ctx *actor.Context) error {

--- a/agent/internal/containers.go
+++ b/agent/internal/containers.go
@@ -15,6 +15,7 @@ import (
 	proto "github.com/determined-ai/determined/master/pkg/agent"
 	cproto "github.com/determined-ai/determined/master/pkg/container"
 	"github.com/determined-ai/determined/master/pkg/device"
+	"github.com/determined-ai/determined/master/pkg/model"
 )
 
 const (
@@ -89,7 +90,7 @@ func (c *containerManager) Receive(ctx *actor.Context) error {
 			dockerMasterLabel:        c.MasterInfo.MasterID,
 		}
 
-	case proto.ContainerLog, proto.ContainerStateChanged, fluentLog:
+	case proto.ContainerLog, proto.ContainerStateChanged, model.TrialLog:
 		ctx.Tell(ctx.Self().Parent(), msg)
 
 	case proto.StartContainer:

--- a/agent/internal/fluent.go
+++ b/agent/internal/fluent.go
@@ -278,6 +278,10 @@ func startLoggingContainer(
 				// A port of 0 makes Docker automatically assign a free port, which we read back below.
 				exposedPort: []nat.PortBinding{{HostIP: "127.0.0.1", HostPort: "0"}},
 			},
+			Resources: container.Resources{
+				Memory:   1 << 30,
+				NanoCPUs: 1000000000,
+			},
 		},
 		nil,
 		containerName,

--- a/agent/internal/fluent.go
+++ b/agent/internal/fluent.go
@@ -265,8 +265,13 @@ func startLoggingContainer(
 			Cmd:   fluentArgs,
 		},
 		&container.HostConfig{
-			AutoRemove:  true,
+			// Set autoremove to reduce the number of states that the container is likely to be in and what
+			// we have to do to manage it cleanly. Restart on failure could be useful, but it conflcts with
+			// autoremove; we may want to consider switching to that instead at some point.
+			AutoRemove: true,
+			// Always use host mode to simplify the space of networking scenarios we have to consider.
 			NetworkMode: "host",
+			// Provide some reasonable resource limits on the container just to be safe.
 			Resources: container.Resources{
 				Memory:   1 << 30,
 				NanoCPUs: 1000000000,

--- a/agent/internal/fluent.go
+++ b/agent/internal/fluent.go
@@ -191,8 +191,8 @@ func startLoggingContainer(ctx *actor.Context, opts Options) (string, int, int, 
 		}
 	}()
 
-	const imageName = "fluent/fluent-bit:1.5"
 	const containerName = "determined-fluent"
+	imageName := opts.FluentLoggingImage
 	exposedPort := nat.Port(fmt.Sprintf("%d/tcp", fluentListenPort))
 
 	// Check for an old container and kill it if present.

--- a/agent/internal/fluent.go
+++ b/agent/internal/fluent.go
@@ -20,7 +20,7 @@ import (
 
 // The names of environment variables whose values should be included in log entries that Docker or
 // the agent sends to the Fluent Bit logger.
-var fluentEnvVarNames = []string{"DET_TRIAL_ID", "DET_CONTAINER_ID"}
+var fluentEnvVarNames = []string{containerIDEnvVar, trialIDEnvVar}
 
 // fluentConfig computes the command-line arguments and extra files needed to start Fluent Bit with
 // an appropriate configuration.
@@ -111,8 +111,8 @@ end
   Remove container_id
   Remove container_name
   # Rename environment variables to normal names.
-  Rename DET_TRIAL_ID trial_id
-  Rename DET_CONTAINER_ID container_id
+  Rename %s container_id
+  Rename %s trial_id
 
   Add agent_id %s
   Rename source stdtype
@@ -123,7 +123,7 @@ end
   Match *
   Script %s
   Call run
-`, opts.AgentID, luaPath)
+`, containerIDEnvVar, trialIDEnvVar, opts.AgentID, luaPath)
 
 	// HACK: If a host resolves to both IPv4 and IPv6 addresses, Fluent Bit seems to only try IPv6 and
 	// fail if that connection doesn't work. IPv6 doesn't play well with Docker and many Linux

--- a/agent/internal/fluent.go
+++ b/agent/internal/fluent.go
@@ -342,7 +342,12 @@ func startLoggingContainer(
 // is in Docker but on the host network, which should be treated equivalently.
 func getDockerNetwork(docker *client.Client) (string, error) {
 	f, err := os.Open("/proc/self/cgroup")
-	if err != nil {
+
+	switch {
+	// If the file is not found, we're probably running natively on non-Linux, which is fine.
+	case errors.Is(err, os.ErrNotExist):
+		return "", nil
+	case err != nil:
 		return "", errors.Wrap(err, "error opening cgroup file")
 	}
 

--- a/agent/internal/fluent.go
+++ b/agent/internal/fluent.go
@@ -1,0 +1,339 @@
+package internal
+
+import (
+	"archive/tar"
+	"context"
+	"fmt"
+	"io/ioutil"
+	"strconv"
+	"time"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/filters"
+	"github.com/docker/docker/client"
+	"github.com/docker/go-connections/nat"
+	"github.com/fluent/fluent-logger-golang/fluent"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+
+	"github.com/determined-ai/determined/master/pkg/actor"
+	"github.com/determined-ai/determined/master/pkg/archive"
+)
+
+// fluentConfig computes the command-line arguments and extra files needed to start Fluent Bit with
+// an appropriate configuration.
+func fluentConfig(opts Options) ([]string, archive.Archive, error) {
+	const baseDir = "/run/determined/fluent/"
+	const luaPath = baseDir + "tonumber.lua"
+	const configPath = baseDir + "fluent.conf"
+	const parserConfigPath = baseDir + "parsers.conf"
+	const masterCertPath = baseDir + "master.crt"
+
+	var files archive.Archive
+
+	luaCode := `
+-- Do some tweaking of values that can't be expressed with the normal filters.
+function run(tag, timestamp, record)
+    record.rank = tonumber(record.rank)
+    record.trial_id = tonumber(record.trial_id)
+
+    -- TODO: Only do this if it's not a partial record.
+    record.log = record.log .. '\n'
+
+    return 2, timestamp, record
+end
+`
+	files = append(files,
+		archive.Item{
+			Path:     luaPath,
+			Type:     tar.TypeReg,
+			FileMode: 0444,
+			Content:  []byte(luaCode),
+		},
+	)
+
+	parserConfig := `
+[PARSER]
+  Name log_level
+  Format regex
+  # Parse out something that looks like a log level at the start of the line (e.g., "INFO: xxx"); if
+  # nothing is found, return an empty log level and the full message back.
+  Regex ((?<level>^(DEBUG|INFO|WARNING|ERROR|CRITICAL)): |(?<level>))(?<log>.*)
+`
+
+	files = append(files,
+		archive.Item{
+			Path:     parserConfigPath,
+			Type:     tar.TypeReg,
+			FileMode: 0444,
+			Content:  []byte(parserConfig),
+		},
+	)
+
+	baseConfig := fmt.Sprintf(`
+[SERVICE]
+  # Flush every .05 seconds to reduce latency for users.
+  Flush .05
+  Parsers_File %s
+
+[INPUT]
+  Name forward
+`, parserConfigPath)
+
+	filterConfig := fmt.Sprintf(`
+# Attempt to parse the log level out of output lines.
+[FILTER]
+  Name parser
+  Match *
+  Key_Name log
+  Parser log_level
+  Reserve_Data true
+
+# Move around fields to create the desired shape of object.
+[FILTER]
+  Name modify
+  Match *
+  # Delete Docker's container information, which we don't want.
+  Remove container_id
+  Remove container_name
+  # Rename environment variables to normal names.
+  Rename DET_TRIAL_ID trial_id
+  Rename DET_CONTAINER_ID container_id
+
+  Add agent_id %s
+  Rename source stdtype
+
+# Apply the Lua code for miscellaneous field tweaking.
+[FILTER]
+  Name lua
+  Match *
+  Script %s
+  Call run
+`, opts.AgentID, luaPath)
+
+	outputConfig := fmt.Sprintf(`
+# TMP: Output to stdout as well.
+[OUTPUT]
+  Name stdout
+  Match *
+
+[OUTPUT]
+  Name http
+  Match *
+  Host %s
+  Port %d
+  URI /trial_logs
+  Header_tag X-Fluent-Tag
+  Format json
+  Json_date_key timestamp
+  Json_date_format iso8601
+`, opts.MasterHost, opts.MasterPort)
+
+	if opts.Security.TLS.Enabled {
+		outputConfig += "  tls On\n"
+
+		if opts.Security.TLS.SkipVerify {
+			outputConfig += "  tls.verify Off\n"
+		}
+		if opts.Security.TLS.MasterCert != "" {
+			outputConfig += "  tls.ca_file " + masterCertPath + "\n"
+
+			certBytes, cErr := ioutil.ReadFile(opts.Security.TLS.MasterCert)
+			if cErr != nil {
+				return nil, nil, cErr
+			}
+
+			files = append(files,
+				archive.Item{
+					Path:     masterCertPath,
+					Type:     tar.TypeReg,
+					FileMode: 0444,
+					Content:  certBytes,
+				},
+			)
+		}
+	}
+
+	files = append(files,
+		archive.Item{
+			Path:     configPath,
+			Type:     tar.TypeReg,
+			FileMode: 0444,
+			Content:  []byte(baseConfig + filterConfig + outputConfig),
+		})
+
+	args := []string{"/fluent-bit/bin/fluent-bit", "-c", configPath}
+
+	return args, files, nil
+}
+
+func startLoggingContainer(ctx *actor.Context, opts Options) (int, string, error) {
+	c, err := client.NewClientWithOpts(client.FromEnv, client.WithVersion("1.40"))
+	if err != nil {
+		return 0, "", errors.Wrap(err, "error connecting to Docker daemon")
+	}
+
+	defer func() {
+		if cErr := c.Close(); cErr != nil {
+			logrus.WithError(cErr).Warn("failed to close Docker connection")
+		}
+	}()
+
+	const imageName = "fluent/fluent-bit:1.5"
+	const exposedPort = "24224/tcp"
+	const containerName = "determined-fluent"
+
+	// Check for an old container and kill it if present.
+	containers, err := c.ContainerList(context.Background(), types.ContainerListOptions{
+		Filters: filters.NewArgs(
+			filters.Arg("name", containerName),
+		),
+	})
+	if err != nil {
+		return 0, "", err
+	}
+	for _, cont := range containers {
+		ctx.Log().Infof("killing found Fluent Bit container %s", cont.ID)
+		if err = c.ContainerKill(context.Background(), cont.ID, "KILL"); err != nil {
+			return 0, "", errors.Wrap(err, "failed to kill existing Fluent Bit container")
+		}
+	}
+
+	// Pull the image.
+	_, _, err = c.ImageInspectWithRaw(context.Background(), imageName)
+	switch {
+	case err == nil:
+		// No error means the image is present; do nothing.
+	case client.IsErrNotFound(err):
+		ctx.Log().Infof("pulling Fluent Bit Docker image %s", imageName)
+
+		// This error means the call to Docker went fine but the image doesn't exist; pull it.
+		pullResponse, pErr := c.ImagePull(context.Background(), imageName, types.ImagePullOptions{})
+		if pErr != nil {
+			return 0, "", pErr
+		}
+		if _, pErr = ioutil.ReadAll(pullResponse); pErr != nil {
+			return 0, "", pErr
+		}
+		if pErr = pullResponse.Close(); pErr != nil {
+			return 0, "", pErr
+		}
+	default:
+		// Something unexpected happened; propagate the error.
+		return 0, "", errors.Wrap(err, "failed to pull logging image")
+	}
+
+	fluentArgs, fluentFiles, err := fluentConfig(opts)
+	if err != nil {
+		return 0, "", err
+	}
+
+	createResponse, err := c.ContainerCreate(
+		context.Background(),
+		&container.Config{
+			Image:        imageName,
+			Cmd:          fluentArgs,
+			ExposedPorts: nat.PortSet{exposedPort: struct{}{}},
+		},
+		&container.HostConfig{
+			AutoRemove: true,
+			PortBindings: nat.PortMap{
+				// A port of 0 makes Docker automatically assign a free port, which we read back below.
+				exposedPort: []nat.PortBinding{{HostIP: "127.0.0.1", HostPort: "0"}},
+			},
+		},
+		nil,
+		containerName,
+	)
+	if err != nil {
+		return 0, "", err
+	}
+
+	filesReader, _ := archive.ToIOReader(fluentFiles)
+
+	err = c.CopyToContainer(context.Background(),
+		createResponse.ID,
+		"/",
+		filesReader,
+		types.CopyToContainerOptions{},
+	)
+	if err != nil {
+		return 0, "", err
+	}
+
+	err = c.ContainerStart(context.Background(), createResponse.ID, types.ContainerStartOptions{})
+	if err != nil {
+		return 0, "", err
+	}
+
+	container, _ := c.ContainerInspect(context.Background(), createResponse.ID)
+	portStr := container.NetworkSettings.Ports[exposedPort][0].HostPort
+	port, _ := strconv.Atoi(portStr)
+	ctx.Log().Infof("Fluent Bit listening on host port %d", port)
+
+	return port, createResponse.ID, nil
+}
+
+func killContainer(containerID string) error {
+	c, err := client.NewClientWithOpts(client.FromEnv, client.WithVersion("1.40"))
+	if err != nil {
+		return errors.Wrap(err, "error connecting to Docker daemon")
+	}
+
+	defer func() {
+		if cErr := c.Close(); cErr != nil {
+			logrus.WithError(cErr).Warn("failed to close Docker connection")
+		}
+	}()
+
+	return c.ContainerKill(context.Background(), containerID, "KILL")
+}
+
+// fluentActor manages the lifecycle of the Fluent Bit container that is run by the agent for the
+// purpose of forwarding container logs.
+type fluentActor struct {
+	opts        Options
+	client      *fluent.Fluent
+	port        int
+	containerID string
+}
+
+func newFluentActor(ctx *actor.Context, opts Options) (*fluentActor, error) {
+	t0 := time.Now()
+	port, cid, err := startLoggingContainer(ctx, opts)
+	if err != nil {
+		return nil, err
+	}
+	ctx.Log().Infof("Fluent Bit started in %s", time.Since(t0))
+
+	client, err := fluent.New(fluent.Config{
+		FluentHost:         "localhost",
+		FluentPort:         port,
+		SubSecondPrecision: true,
+		RequestAck:         true,
+	})
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to connect to Fluent Bit")
+	}
+
+	return &fluentActor{
+		opts:        opts,
+		client:      client,
+		port:        port,
+		containerID: cid,
+	}, nil
+}
+
+func (f *fluentActor) Receive(ctx *actor.Context) error {
+	switch msg := ctx.Message().(type) {
+	case fluentLog:
+		return f.client.Post("determined.agent", msg)
+	case actor.PostStop:
+		t0 := time.Now()
+		err := killContainer(f.containerID)
+		ctx.Log().Infof("Fluent Bit killed in %s", time.Since(t0))
+		return err
+	}
+	return nil
+}

--- a/agent/internal/fluent.go
+++ b/agent/internal/fluent.go
@@ -21,6 +21,10 @@ import (
 	"github.com/determined-ai/determined/master/pkg/archive"
 )
 
+// The names of environment variables whose values should be included in log entries that Docker or
+// the agent sends to the Fluent Bit logger.
+var fluentEnvVarNames = []string{"DET_TRIAL_ID", "DET_CONTAINER_ID"}
+
 // fluentConfig computes the command-line arguments and extra files needed to start Fluent Bit with
 // an appropriate configuration.
 func fluentConfig(opts Options) ([]string, archive.Archive, error) {
@@ -35,7 +39,6 @@ func fluentConfig(opts Options) ([]string, archive.Archive, error) {
 	luaCode := `
 -- Do some tweaking of values that can't be expressed with the normal filters.
 function run(tag, timestamp, record)
-    record.rank = tonumber(record.rank)
     record.trial_id = tonumber(record.trial_id)
 
     -- TODO: Only do this if it's not a partial record.

--- a/agent/internal/options.go
+++ b/agent/internal/options.go
@@ -41,7 +41,7 @@ type Options struct {
 
 	Security SecurityOptions `json:"security"`
 
-	FluentLoggingImage string `json:"fluent_logging_image"`
+	Fluent FluentOptions `json:"fluent"`
 }
 
 // Validate validates the state of the Options struct.
@@ -93,4 +93,10 @@ func (t TLSOptions) Validate() []error {
 		errs = append(errs, errors.New("cannot specify a master cert file with verification off"))
 	}
 	return errs
+}
+
+// FluentOptions stores configurable Fluent Bit-related options.
+type FluentOptions struct {
+	Image string `json:"image"`
+	Port  int    `json:"port"`
 }

--- a/agent/internal/options.go
+++ b/agent/internal/options.go
@@ -40,6 +40,8 @@ type Options struct {
 	NoProxy    string `json:"no_proxy"`
 
 	Security SecurityOptions `json:"security"`
+
+	FluentLoggingImage string `json:"fluent_logging_image"`
 }
 
 // Validate validates the state of the Options struct.

--- a/docs/how-to/installation/docker.txt
+++ b/docs/how-to/installation/docker.txt
@@ -170,6 +170,17 @@ Note that if an agent container is running on the same machine as the
 master container, you may use ``determined-master`` (or whatever the
 name of the master container is) as the ``DET_MASTER_HOST``.
 
+Determined internally makes use of `Fluent Bit
+<https://fluentbit.io>`__. The agent uses the ``fluent/fluent-bit:1.5``
+Docker image at runtime. It will attempt to pull the image
+automatically; if the agent machines in the cluster are not able to
+connect to Docker Hub, the image must be manually placed on them before
+Determined can run. In order to specify a different image to use for
+running Fluent Bit (generally to make use of a custom Docker
+registry---the image should not normally need to be changed otherwise),
+use the agent's ``--fluent-logging-image`` command-line option or
+``fluent_logging_image`` config file option.
+
 Selecting GPUs
 --------------
 

--- a/e2e_tests/tests/experiment/experiment.py
+++ b/e2e_tests/tests/experiment/experiment.py
@@ -236,7 +236,7 @@ def num_error_trials(experiment_id: int) -> int:
 
 def trial_logs(trial_id: int) -> List[str]:
     auth.initialize_session(conf.make_master_url(), try_reauth=True)
-    r = api.get(conf.make_master_url(), "trials/{}/logs".format(trial_id))
+    r = api.get(conf.make_master_url(), "trials/{}/logsv2?offset=0".format(trial_id))
     assert r.status_code == requests.codes.ok, r.text
     return [t["message"] for t in r.json()]
 

--- a/master/internal/config_test.go
+++ b/master/internal/config_test.go
@@ -48,6 +48,7 @@ provisioner:
 		Provisioner: &provisioner.Config{
 			AgentDockerRuntime:     "runc",
 			AgentDockerNetwork:     "default",
+			AgentFluentImage:       "fluent/fluent-bit:1.6",
 			MaxIdleAgentPeriod:     provisioner.Duration(30 * time.Second),
 			MaxAgentStartingPeriod: provisioner.Duration(30 * time.Second),
 			MaxInstances:           5,

--- a/master/internal/db/postgres.go
+++ b/master/internal/db/postgres.go
@@ -1369,8 +1369,8 @@ func (db *PgDB) AddTrialLogs(logs []*model.TrialLog) error {
 	var text strings.Builder
 	text.WriteString(`
 INSERT INTO trial_logs
-    (trial_id, message, log, agent_id, container_id, rank_id, timestamp, level, stdtype, source)
-VALUES
+  (trial_id, message, log, agent_id, container_id, rank_id, timestamp, level, stdtype, source)
+ VALUES
 `)
 
 	args := make([]interface{}, 0, len(logs)*10)
@@ -1379,7 +1379,7 @@ VALUES
 		if i > 0 {
 			text.WriteString(",")
 		}
-		fmt.Fprintf(&text, " ($%d, $%d, $%d, $%d, $%d, $%d, $%d, $%d, $%d)",
+		fmt.Fprintf(&text, " ($%d, $%d, $%d, $%d, $%d, $%d, $%d, $%d, $%d, $%d)",
 			i*10+1, i*10+2, i*10+3, i*10+4, i*10+5, i*10+6, i*10+7, i*10+8, i*10+9, i*10+10)
 
 		var l *model.RawString
@@ -1388,8 +1388,8 @@ VALUES
 			l = &r
 		}
 
-		args = append(args, log.TrialID, log.Message, l, log.AgentID, log.ContainerID,
-			log.RankID, log.Timestamp, log.Level, log.StdType, log.Source)
+		args = append(args, log.TrialID, log.Message, l, log.AgentID, log.ContainerID, log.RankID,
+			log.Timestamp, log.Level, log.StdType, log.Source)
 	}
 
 	if _, err := db.sql.Exec(text.String(), args...); err != nil {

--- a/master/internal/db/postgres.go
+++ b/master/internal/db/postgres.go
@@ -1369,21 +1369,26 @@ func (db *PgDB) AddTrialLogs(logs []*model.TrialLog) error {
 	var text strings.Builder
 	text.WriteString(`
 INSERT INTO trial_logs
-    (trial_id, message, agent_id, container_id, rank_id, timestamp, level, stdtype, source)
+    (trial_id, message, log, agent_id, container_id, rank_id, timestamp, level, stdtype, source)
 VALUES
 `)
 
-	args := make([]interface{}, 0, len(logs)*8)
+	args := make([]interface{}, 0, len(logs)*10)
 
 	for i, log := range logs {
-		// Add an argument to the SQL statement of the form: ($1, $2)
 		if i > 0 {
 			text.WriteString(",")
 		}
 		fmt.Fprintf(&text, " ($%d, $%d, $%d, $%d, $%d, $%d, $%d, $%d, $%d)",
-			i*9+1, i*9+2, i*9+3, i*9+4, i*9+5, i*9+6, i*9+7, i*9+8, i*9+9)
+			i*10+1, i*10+2, i*10+3, i*10+4, i*10+5, i*10+6, i*10+7, i*10+8, i*10+9, i*10+10)
 
-		args = append(args, log.TrialID, model.RawString(log.Message), log.AgentID, log.ContainerID,
+		var l *model.RawString
+		if log.Log != nil {
+			r := model.RawString(*log.Log)
+			l = &r
+		}
+
+		args = append(args, log.TrialID, log.Message, l, log.AgentID, log.ContainerID,
 			log.RankID, log.Timestamp, log.Level, log.StdType, log.Source)
 	}
 

--- a/master/internal/provisioner/agent_setup.go
+++ b/master/internal/provisioner/agent_setup.go
@@ -17,6 +17,7 @@ type agentSetupScriptConfig struct {
 	AgentDockerRuntime           string
 	AgentNetwork                 string
 	AgentDockerImage             string
+	AgentFluentImage             string
 	AgentID                      string
 	ResourcePool                 string
 	LogOptions                   string

--- a/master/internal/provisioner/agent_setup_test.go
+++ b/master/internal/provisioner/agent_setup_test.go
@@ -24,6 +24,7 @@ func TestAgentSetupScript(t *testing.T) {
 		MasterCertBase64:             encodedMasterCert,
 		AgentUseGPUs:                 true,
 		AgentDockerImage:             "test_docker_image",
+		AgentFluentImage:             "fluent-test",
 		AgentDockerRuntime:           "runc",
 		AgentNetwork:                 "default",
 		AgentID:                      "test.id",
@@ -78,6 +79,7 @@ docker run --init --name determined-agent  \
     -e DET_MASTER_HOST="test.master" \
     -e DET_MASTER_PORT="8080" \
     -e DET_RESOURCE_POOL="test-pool" \
+    -e DET_FLUENT_IMAGE="fluent-test" \
     -v /var/run/docker.sock:/var/run/docker.sock \
     -v /usr/local/determined/container_startup_script:/usr/local/determined/container_startup_script \
     "${docker_args[@]}" \

--- a/master/internal/provisioner/aws.go
+++ b/master/internal/provisioner/aws.go
@@ -125,6 +125,7 @@ func newAWSCluster(
 			AgentDockerRuntime:           config.AgentDockerRuntime,
 			AgentNetwork:                 config.AgentDockerNetwork,
 			AgentDockerImage:             config.AgentDockerImage,
+			AgentFluentImage:             config.AgentFluentImage,
 			AgentID:                      `$(ec2metadata --instance-id)`,
 			ResourcePool:                 resourcePool,
 			LogOptions:                   config.AWS.buildDockerLogString(),

--- a/master/internal/provisioner/config.go
+++ b/master/internal/provisioner/config.go
@@ -50,6 +50,7 @@ type Config struct {
 	AgentDockerNetwork     string            `json:"agent_docker_network"`
 	AgentDockerRuntime     string            `json:"agent_docker_runtime"`
 	AgentDockerImage       string            `json:"agent_docker_image"`
+	AgentFluentImage       string            `json:"agent_fluent_image"`
 	AWS                    *AWSClusterConfig `union:"provider,aws" json:"-"`
 	GCP                    *GCPClusterConfig `union:"provider,gcp" json:"-"`
 	MaxIdleAgentPeriod     Duration          `json:"max_idle_agent_period"`
@@ -63,6 +64,7 @@ func DefaultConfig() *Config {
 	return &Config{
 		AgentDockerRuntime:     "runc",
 		AgentDockerNetwork:     "default",
+		AgentFluentImage:       "fluent/fluent-bit:1.6",
 		MaxIdleAgentPeriod:     Duration(20 * time.Minute),
 		MaxAgentStartingPeriod: Duration(20 * time.Minute),
 		MinInstances:           0,

--- a/master/internal/provisioner/config_test.go
+++ b/master/internal/provisioner/config_test.go
@@ -23,6 +23,7 @@ func TestProvisionerConfigMissingFields(t *testing.T) {
 		MaxInstances:           5,
 		AgentDockerRuntime:     "runc",
 		AgentDockerNetwork:     "default",
+		AgentFluentImage:       "fluent/fluent-bit:1.6",
 	}
 	assert.DeepEqual(t, config, expected)
 }
@@ -32,6 +33,7 @@ func TestUnmarshalProvisionerConfigMasterURL(t *testing.T) {
 "master_url": "http://test.master",
 "provider": "aws",
 "agent_docker_image": "test_image",
+"agent_fluent_image": "fluent_image",
 "region": "test.region3",
 "image_id": "test.image3",
 "ssh_key_name": "test-key3",
@@ -52,6 +54,7 @@ func TestUnmarshalProvisionerConfigMasterURL(t *testing.T) {
 	unmarshaled := Config{
 		MasterURL:              "http://test.master:8080",
 		AgentDockerImage:       "test_image",
+		AgentFluentImage:       "fluent_image",
 		AgentDockerRuntime:     "runc",
 		AgentDockerNetwork:     "default",
 		AWS:                    &awsConfig,
@@ -103,6 +106,7 @@ func TestUnmarshalProvisionerConfigWithAWS(t *testing.T) {
 		MasterURL:              "http://test.master:8080",
 		AWS:                    &awsConfig,
 		AgentDockerImage:       "test_image",
+		AgentFluentImage:       "fluent/fluent-bit:1.6",
 		AgentDockerRuntime:     "runc",
 		AgentDockerNetwork:     "default",
 		MaxIdleAgentPeriod:     Duration(30 * time.Second),
@@ -136,6 +140,7 @@ func TestUnmarshalProvisionerConfigWithGCP(t *testing.T) {
 		MasterURL:              "http://test.master:8080",
 		GCP:                    &expected,
 		AgentDockerImage:       "test_image",
+		AgentFluentImage:       "fluent/fluent-bit:1.6",
 		AgentDockerRuntime:     "runc",
 		AgentDockerNetwork:     "default",
 		MaxIdleAgentPeriod:     Duration(20 * time.Minute),

--- a/master/internal/provisioner/gcp.go
+++ b/master/internal/provisioner/gcp.go
@@ -85,6 +85,7 @@ func newGCPCluster(
 		AgentNetwork:                 config.AgentDockerNetwork,
 		AgentDockerRuntime:           config.AgentDockerRuntime,
 		AgentDockerImage:             config.AgentDockerImage,
+		AgentFluentImage:             config.AgentFluentImage,
 		StartupScriptBase64:          startupScriptBase64,
 		ContainerStartupScriptBase64: containerScriptBase64,
 		MasterCertBase64:             masterCertBase64,

--- a/master/internal/sproto/task_actor.go
+++ b/master/internal/sproto/task_actor.go
@@ -78,5 +78,5 @@ func (c ContainerLog) String() string {
 	}
 	shortID := c.Container.ID[:8]
 	timestamp := c.Timestamp.UTC().Format(time.RFC3339)
-	return fmt.Sprintf("[%s] %s [%s] || %s", timestamp, shortID, c.Container.State, msg)
+	return fmt.Sprintf("[%s] %s || %s", timestamp, shortID, msg)
 }

--- a/master/pkg/container/spec.go
+++ b/master/pkg/container/spec.go
@@ -27,7 +27,8 @@ type RunSpec struct {
 	NetworkingConfig network.NetworkingConfig
 	ChecksConfig     ChecksConfig
 
-	Archives []RunArchive
+	Archives         []RunArchive
+	UseFluentLogging bool
 }
 
 // ChecksConfig describes the configuration for multiple readiness checks.

--- a/master/pkg/model/experiment.go
+++ b/master/pkg/model/experiment.go
@@ -397,6 +397,7 @@ type TrialLog struct {
 	RankID      *int       `db:"rank_id" json:"rank_id"`
 	Timestamp   *time.Time `db:"timestamp" json:"timestamp"`
 	Level       *string    `db:"level" json:"level"`
+	Log         *string    `db:"log" json:"log"`
 	Source      *string    `db:"source" json:"source"`
 	StdType     *string    `db:"stdtype" json:"stdtype"`
 }

--- a/master/pkg/tasks/task.go
+++ b/master/pkg/tasks/task.go
@@ -316,7 +316,8 @@ func startContainer(t TaskSpec) container.Spec {
 				Mounts:          mounts,
 				PublishAllPorts: true,
 			},
-			Archives: TrialArchives(t),
+			Archives:         TrialArchives(t),
+			UseFluentLogging: true,
 		},
 	}
 	spec.RunSpec.HostConfig.ShmSize = t.TaskContainerDefaults.ShmSizeBytes

--- a/master/static/srv/agent_setup_script.sh.template
+++ b/master/static/srv/agent_setup_script.sh.template
@@ -45,6 +45,7 @@ docker run --init --name determined-agent {{.LogOptions}} \
     -e DET_MASTER_HOST="{{.MasterHost}}" \
     -e DET_MASTER_PORT="{{.MasterPort}}" \
     -e DET_RESOURCE_POOL="{{.ResourcePool}}" \
+    -e DET_FLUENT_IMAGE="{{.AgentFluentImage}}" \
     -v /var/run/docker.sock:/var/run/docker.sock \
     -v /usr/local/determined/container_startup_script:/usr/local/determined/container_startup_script \
     "${docker_args[@]}" \

--- a/master/static/srv/get_logs.sql
+++ b/master/static/srv/get_logs.sql
@@ -6,6 +6,7 @@ SELECT
         coalesce(to_char(timestamp, '[YYYY-MM-DD"T"HH24:MI:SS"Z"]' ), '[UNKNOWN TIME]')
         || ' '
         || coalesce(substring(container_id, 1, 8), '[UNKNOWN CONTAINER]')
+        || coalesce(' [rank=' || (rank_id::text) || ']', '')
         || ' || '
         || coalesce(level || ': ', '')
         || encode(log, 'escape')

--- a/master/static/srv/get_logs.sql
+++ b/master/static/srv/get_logs.sql
@@ -1,7 +1,17 @@
 SELECT
-    trial_logs.id as id,
-    trials.state as state,
-    encode(message, 'escape') as message
+    trial_logs.id AS id,
+    trials.state AS state,
+    CASE
+      WHEN log IS NOT NULL THEN
+        coalesce(to_char(timestamp, '[YYYY-MM-DD"T"HH24:MI:SS"Z"]' ), '[UNKNOWN TIME]')
+        || ' '
+        || coalesce(substring(container_id, 1, 8), '[UNKNOWN CONTAINER]')
+        || ' || '
+        || coalesce(level || ': ', '')
+        || encode(log, 'escape')
+      ELSE encode(message, 'escape')
+    END
+    AS message
 FROM trial_logs JOIN trials
 ON trial_logs.trial_id = trials.id
 WHERE trials.id = $1 AND trial_logs.id > $2

--- a/master/static/srv/get_logs_limit.sql
+++ b/master/static/srv/get_logs_limit.sql
@@ -7,6 +7,7 @@ WITH logs AS (
             coalesce(to_char(timestamp, '[YYYY-MM-DD"T"HH24:MI:SS"Z"]' ), '[UNKNOWN TIME]')
             || ' '
             || coalesce(substring(container_id, 1, 8), '[UNKNOWN CONTAINER]')
+            || coalesce(' [rank=' || (rank_id::text) || ']', '')
             || ' || '
             || coalesce(level || ': ', '')
             || encode(log, 'escape')

--- a/master/static/srv/get_logs_limit.sql
+++ b/master/static/srv/get_logs_limit.sql
@@ -1,9 +1,19 @@
 WITH logs AS (
     SELECT
-        trial_logs.id as id,
-        trials.state as state,
-        encode(message, 'escape') as message
-    FROM trial_logs JOIN trials
+        trial_logs.id AS id,
+        trials.state AS state,
+        CASE
+          WHEN log IS NOT NULL THEN
+            coalesce(to_char(timestamp, '[YYYY-MM-DD"T"HH24:MI:SS"Z"]' ), '[UNKNOWN TIME]')
+            || ' '
+            || coalesce(substring(container_id, 1, 8), '[UNKNOWN CONTAINER]')
+            || ' || '
+            || coalesce(level || ': ', '')
+            || encode(log, 'escape')
+          ELSE encode(message, 'escape')
+        END
+        AS message
+        FROM trial_logs JOIN trials
     ON trial_logs.trial_id = trials.id
     WHERE trials.id = $1
     ORDER BY trial_logs.id DESC

--- a/master/static/srv/get_logs_offset_limit.sql
+++ b/master/static/srv/get_logs_offset_limit.sql
@@ -6,6 +6,7 @@ SELECT
         coalesce(to_char(timestamp, '[YYYY-MM-DD"T"HH24:MI:SS"Z"]' ), '[UNKNOWN TIME]')
         || ' '
         || coalesce(substring(container_id, 1, 8), '[UNKNOWN CONTAINER]')
+        || coalesce(' [rank=' || (rank_id::text) || ']', '')
         || ' || '
         || coalesce(level || ': ', '')
         || encode(log, 'escape')

--- a/master/static/srv/get_logs_offset_limit.sql
+++ b/master/static/srv/get_logs_offset_limit.sql
@@ -1,7 +1,17 @@
 SELECT
-    trial_logs.id as id,
-    trials.state as state,
-    encode(message, 'escape') as message
+    trial_logs.id AS id,
+    trials.state AS state,
+    CASE
+      WHEN log IS NOT NULL THEN
+        coalesce(to_char(timestamp, '[YYYY-MM-DD"T"HH24:MI:SS"Z"]' ), '[UNKNOWN TIME]')
+        || ' '
+        || coalesce(substring(container_id, 1, 8), '[UNKNOWN CONTAINER]')
+        || ' || '
+        || coalesce(level || ': ', '')
+        || encode(log, 'escape')
+      ELSE encode(message, 'escape')
+    END
+    AS message
 FROM trial_logs JOIN trials
 ON trial_logs.trial_id = trials.id
 WHERE trials.id = $1 AND trial_logs.id > $2


### PR DESCRIPTION
## Description

This PR moves trial logs to being sent through a Fluent Bit container running alongside each agent in the cluster. For the moment, doing so mostly just adds complexity, but the idea is to later add support for Elastic as a separate log backend, which will be made easier by the use of Fluent Bit.

The agent internally manages the lifecycle of the Fluent Bit container in order to keep administration simple and ensure that the daemon is started with the necessary configuration. The agent automatically configures Fluent Bit to connect back to the master and fill in the new fields being used for filtering. To simplify the required networking, the logs that the agent itself inserts are sent to the master rather than through Fluent Bit.

The master gains a new endpoint to accept POSTed trial logs, which it sends over to the trial logger actor. Only trial logs are sent through this new path; in the long term, that should also be unified with commands and other tasks, but those aren't the same currently anyway, so that's being left out of this project.

Features/todo:
- [x] start/stop Fluent Bit on agent startup/shutdown
- [x] handle existing Fluent Bit on startup
- [x] populate the new fields in the log records
- [x] send trial logs through Fluent and others through current mechanisms
- [x] port over agent-inserted meta logs
- [x] add new filtering fields for master-inserted logs
- [x] allow the agent to connect to Fluent while itself running inside Docker
- [x] improve compatibility by adding a new field for the log body
- [x] document installation requirements (new image to pre-pull for airgapped clusters)

## Test Plan

- [x] run trials and check that logs show up with reasonable formatting
- [x] run commands and check that logs show up as before
- [x] check logs of the Fluent Bit container while things are happening
- [x] start the agent with a Fluent Bit container already running
- [x] run a trial without this PR, migrate to the new version, check that logs still show up reasonably

## Commentary

Also includes the schema change PR (#1373) and some debugging code.