### PR TITLE
fix: preserve rank_id in logs [DET-4413]

### DIFF
--- a/harness/determined/exec/worker_process_wrapper.py
+++ b/harness/determined/exec/worker_process_wrapper.py
@@ -13,7 +13,7 @@ from typing import List, TextIO
 from determined import constants
 
 
-def forward_stream(src_stream: TextIO, dst_stream: TextIO, rank: int) -> None:
+def forward_stream(src_stream: TextIO, dst_stream: TextIO, rank: str) -> None:
     for line in iter(src_stream.readline, None):
         if line is None:
             break
@@ -23,7 +23,7 @@ def forward_stream(src_stream: TextIO, dst_stream: TextIO, rank: int) -> None:
             break
         line = "[rank={rank}] {line}".format(
             line=line,
-            rank=str(rank),
+            rank=rank,
         )
         os.write(dst_stream.fileno(), line.encode("utf-8"))
 
@@ -46,7 +46,7 @@ def run_all(fwds: List[threading.Thread]) -> None:
 
 
 def main() -> None:
-    rank = os.environ["HOROVOD_RANK"]
+    rank = os.environ.get("HOROVOD_RANK")
     proc = subprocess.Popen(
         [
             sys.executable,

--- a/harness/determined/exec/worker_process_wrapper.py
+++ b/harness/determined/exec/worker_process_wrapper.py
@@ -3,24 +3,69 @@ worker_process_wrapper.py is the entrypoint for Horovod worker processes.
 It exists to redirect stdout/stderr to the docker logging without needing
 to package a shell script.
 """
+import itertools
 import os
+import subprocess
 import sys
+import threading
+from typing import List, TextIO
 
 from determined import constants
 
 
+def forward_stream(src_stream: TextIO, dst_stream: TextIO, rank: int) -> None:
+    for line in iter(src_stream.readline, None):
+        if line is None:
+            break
+        if not isinstance(line, str):
+            line = line.decode("utf-8")
+        if not line:
+            break
+        line = "[rank={rank}] {line}".format(
+            line=line,
+            rank=str(rank),
+        )
+        os.write(dst_stream.fileno(), line.encode("utf-8"))
+
+
+def run_all(fwds: List[threading.Thread]) -> None:
+    for fwd in fwds:
+        fwd.start()
+
+    done = {}
+    for fwd in itertools.cycle(fwds):
+        if fwd.name in done:
+            continue
+
+        fwd.join(timeout=1)
+        if not fwd.isAlive():
+            done[fwd.name] = True
+
+        if len(done) == len(fwds):
+            return
+
+
 def main() -> None:
-    os.dup2(os.open(constants.CONTAINER_STDOUT, os.O_WRONLY), sys.stdout.fileno())
-    os.dup2(os.open(constants.CONTAINER_STDERR, os.O_WRONLY), sys.stderr.fileno())
-    os.execv(
-        sys.executable,
+    rank = os.environ["HOROVOD_RANK"]
+    proc = subprocess.Popen(
         [
             sys.executable,
             "-m",
             "determined.exec.worker_process",
             *sys.argv[1:],
         ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
     )
+    with open(constants.CONTAINER_STDOUT, "w") as cstdout:
+        with open(constants.CONTAINER_STDERR, "w") as cstderr:
+            with proc:
+                run_all(
+                    [
+                        threading.Thread(target=forward_stream, args=(proc.stdout, cstdout, rank)),
+                        threading.Thread(target=forward_stream, args=(proc.stderr, cstderr, rank)),
+                    ]
+                )
 
 
 if __name__ == "__main__":

--- a/harness/determined/exec/worker_process_wrapper.py
+++ b/harness/determined/exec/worker_process_wrapper.py
@@ -3,46 +3,26 @@ worker_process_wrapper.py is the entrypoint for Horovod worker processes.
 It exists to redirect stdout/stderr to the docker logging without needing
 to package a shell script.
 """
-import itertools
 import os
 import subprocess
 import sys
 import threading
-from typing import List, TextIO
+from typing import BinaryIO, List
 
 from determined import constants
 
 
-def forward_stream(src_stream: TextIO, dst_stream: TextIO, rank: str) -> None:
-    for line in iter(src_stream.readline, None):
-        if line is None:
-            break
-        if not isinstance(line, str):
-            line = line.decode("utf-8")
-        if not line:
-            break
-        line = "[rank={rank}] {line}".format(
-            line=line,
-            rank=rank,
-        )
-        os.write(dst_stream.fileno(), line.encode("utf-8"))
+def forward_stream(src_stream: BinaryIO, dst_stream: BinaryIO, rank: str) -> None:
+    for line in iter(src_stream.readline, b""):
+        line = f"[rank={rank}] ".encode() + line
+        os.write(dst_stream.fileno(), line)
 
 
-def run_all(fwds: List[threading.Thread]) -> None:
-    for fwd in fwds:
-        fwd.start()
-
-    done = {}
-    for fwd in itertools.cycle(fwds):
-        if fwd.name in done:
-            continue
-
-        fwd.join(timeout=1)
-        if not fwd.isAlive():
-            done[fwd.name] = True
-
-        if len(done) == len(fwds):
-            return
+def run_all(ts: List[threading.Thread]) -> None:
+    for t in ts:
+        t.start()
+    for t in ts:
+        t.join()
 
 
 def main() -> None:
@@ -57,15 +37,15 @@ def main() -> None:
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
     )
-    with open(constants.CONTAINER_STDOUT, "w") as cstdout:
-        with open(constants.CONTAINER_STDERR, "w") as cstderr:
-            with proc:
-                run_all(
-                    [
-                        threading.Thread(target=forward_stream, args=(proc.stdout, cstdout, rank)),
-                        threading.Thread(target=forward_stream, args=(proc.stderr, cstderr, rank)),
-                    ]
-                )
+    with open(constants.CONTAINER_STDOUT, "w") as cstdout, open(
+        constants.CONTAINER_STDERR, "w"
+    ) as cstderr, proc:
+        run_all(
+            [
+                threading.Thread(target=forward_stream, args=(proc.stdout, cstdout, rank)),
+                threading.Thread(target=forward_stream, args=(proc.stderr, cstderr, rank)),
+            ]
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description
This change prepends rank_id to logs from our worker process launched by horovod. This is in line with what was provided by horovod previous, after logs returned to agent 0 by SSH.
<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan
- [x] make sure logs before and after look the same, but with rank_id present in the logs
- [x] make sure errors are detectable, but not necessarily handled (the logs show an error but the child process continues)
- [x] run a bunch of dtrain experiments and make sure the rank_id is correct
<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)
This is pretty similar to what horovod would do on agent0 if the output from stdout/stderr were still getting back there (see https://github.com/horovod/horovod/blob/master/horovod/runner/common/util/safe_shell_exec.py#L198-L199 as pointed out be @aaron276h in the first place as to why this is missing). Because of this, I'm not too concerned about performance (since it was happened already and all on one machine).

I didn't do much in the way of error handling in the forwarding thread - any error is encounters would be a programming error, or something unhandleable and if there is an error, it _will_ show up in the logs. I don't want to go down the road trying to propering manage the harness subprocess in the event of error because it seems more complicated for no real gain; at that point, we should just move the log rerouting to horovod where we're launched and try to upstream the effort.

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234