### PR TITLE
fix: fix setting default for fit field in master.yaml

### DIFF
--- a/docs/reference/cluster-config.txt
+++ b/docs/reference/cluster-config.txt
@@ -212,7 +212,7 @@ The master supports the following configuration settings:
 -  ``scheduler``: Specifies how Determined schedules tasks to agents.
 
    -  ``fit``: The scheduling policy to use when assigning tasks to
-      agents in the cluster.
+      agents in the cluster. Defaults to ``best``.
 
       -  ``best``: The best-fit policy ensures that tasks will be
          preferentially "packed" together on the smallest number of
@@ -222,7 +222,8 @@ The master supports the following configuration settings:
          placed on under-utilized agents.
 
    -  ``type``: The scheduling policy to use when allocating resources
-      between different tasks (experiments, notebooks, etc.).
+      between different tasks (experiments, notebooks, etc.). Defaults
+      to ``fair_share``.
 
       -  ``fair_share``: Tasks receive a proportional amount of the
          available resources depending on the resource they require and
@@ -232,7 +233,7 @@ The master supports the following configuration settings:
          which they arrive at the cluster.
 
    -  ``resource_provider``: The resource provider to use to acquire
-      agents.
+      agents. Defaults to the default resource provider.
 
       -  ``type: default``: The default resource provider includes
          static and dynamic agents.

--- a/docs/release-notes/1469-fix-fit-default.txt
+++ b/docs/release-notes/1469-fix-fit-default.txt
@@ -2,4 +2,5 @@
 
 **BUG FIXES**
 
-- Fix setting the default values for the `fit` field if the `scheduler` field exists in `master.yaml`.
+-  Fix setting the default values for the `fit` field if the `scheduler`
+   field exists in `master.yaml`.

--- a/docs/release-notes/1469-fix-fit-default.txt
+++ b/docs/release-notes/1469-fix-fit-default.txt
@@ -1,0 +1,5 @@
+:orphan:
+
+**BUG FIXES**
+
+- Fix setting the default values for the `fit` field if the `scheduler` field exists in `master.yaml`.

--- a/master/internal/resourcemanagers/resource_manager_config.go
+++ b/master/internal/resourcemanagers/resource_manager_config.go
@@ -53,6 +53,15 @@ func ResolveConfig(
 		return nil, nil, errors.New(
 			"cannot specify both the scheduler and resource_manager fields")
 	}
+
+	if resourceMangerConf != nil && resourceMangerConf.AgentRM != nil {
+		if resourceMangerConf.AgentRM.SchedulingPolicy == "" {
+			resourceMangerConf.AgentRM.SchedulingPolicy = DefaultRMConfig().AgentRM.SchedulingPolicy
+		}
+		if resourceMangerConf.AgentRM.FittingPolicy == "" {
+			resourceMangerConf.AgentRM.FittingPolicy = DefaultRMConfig().AgentRM.FittingPolicy
+		}
+	}
 	return resourceMangerConf, resourcePoolsConf, nil
 }
 


### PR DESCRIPTION
## Description
 
Fix setting the default values for the `fit` field if the `scheduler` field exists in `master.yaml`.

## Test Plan

Manual testing.

## Commentary (optional)

N/A

## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
