### PR TITLE
feat: make slot type configurable. [DET-4308]

### DIFF
--- a/agent/cmd/determined-agent/run.go
+++ b/agent/cmd/determined-agent/run.go
@@ -97,6 +97,7 @@ func newRunCmd() *cobra.Command {
 		"Master port that containers started by this agent will connect to")
 
 	// Device flags.
+	cmd.Flags().StringVar(&opts.SlotType, "slot-type", "auto", "slot type to expose")
 	cmd.Flags().StringVar(&opts.VisibleGPUs, "visible-gpus", "", "GPUs to expose as slots")
 
 	// Security flags.

--- a/agent/internal/agent.go
+++ b/agent/internal/agent.go
@@ -14,7 +14,6 @@ import (
 	"syscall"
 
 	"github.com/docker/docker/api/types/container"
-	"github.com/google/uuid"
 	"github.com/gorilla/websocket"
 	"github.com/labstack/echo"
 	"github.com/labstack/echo/middleware"
@@ -245,37 +244,8 @@ func (a *agent) setup(ctx *actor.Context) error {
 	ctx.Log().Infof("Determined agent %s (built with %s)", a.Version, runtime.Version())
 	actors.NotifyOnSignal(ctx, syscall.SIGINT, syscall.SIGTERM)
 
-	switch {
-	case a.ArtificialSlots > 0:
-		for i := 0; i < a.ArtificialSlots; i++ {
-			id := uuid.New().String()
-			a.Devices = append(a.Devices, device.Device{
-				ID: i, Brand: "Artificial", UUID: id, Type: device.CPU})
-		}
-	case a.SlotType == "gpu":
-		devices, err := detectGPUs(a.Options.VisibleGPUs)
-		if err != nil {
-			return errors.Wrap(err, "error while gathering GPU info through nvidia-smi command")
-		}
-		a.Devices = devices
-	case a.SlotType == "cpu":
-		devices, err := detectCPUs()
-		if err != nil {
-			return err
-		}
-		a.Devices = devices
-	case a.SlotType == "auto":
-		if devices, err := detectGPUs(a.Options.VisibleGPUs); err != nil {
-			return errors.Wrap(err, "error while gathering GPU info through nvidia-smi command")
-		} else if len(devices) != 0 {
-			a.Devices = devices
-		} else if devices, err = detectCPUs(); err != nil {
-			return err
-		} else {
-			a.Devices = devices
-		}
-	default:
-		panic("unrecognized slot type")
+	if err := a.detect(); err != nil {
+		return err
 	}
 	ctx.Log().Info("detected compute devices:")
 	for _, d := range a.Devices {

--- a/agent/internal/detect.go
+++ b/agent/internal/detect.go
@@ -15,30 +15,6 @@ import (
 	"github.com/determined-ai/determined/master/pkg/device"
 )
 
-// detectDevices returns a slice of Device's representing the devices exposed by the agent.
-// Autoconfigure the devices exposed by the agent.
-//
-// The most common case in deployed installs is to expose all GPU devices present. To support
-// various testing configurations, we also allow the agent to expose fake devices, a subset of CPU
-// resources or a subset of GPU resources, but this is not representative of deployed agents.
-//
-// The current policy is:
-// - Expose all GPUs present on the machine.
-// - If there are no GPUs, expose all CPUs present on the machine after applying the optional mask
-// `cpu_limit`.
-//
-// An error is returned instead if detection failed unexpectedly.
-func detectDevices(visibleGPUs string) ([]device.Device, error) {
-	switch devices, err := detectGPUs(visibleGPUs); {
-	case err != nil:
-		return nil, errors.Wrap(err, "error while gathering GPU info through nvidia-smi command")
-	case len(devices) != 0:
-		return devices, nil
-	}
-
-	return detectCPUs()
-}
-
 // detectCPUs returns the list of available CPUs; each core is returned as a single device.
 func detectCPUs() ([]device.Device, error) {
 	switch cpuInfo, err := cpu.Info(); {

--- a/agent/internal/detect.go
+++ b/agent/internal/detect.go
@@ -25,6 +25,8 @@ func (a *agent) detect() error {
 			a.Devices = append(a.Devices, device.Device{
 				ID: i, Brand: "Artificial", UUID: id, Type: device.CPU})
 		}
+	case a.SlotType == "none":
+		a.Devices = []device.Device{}
 	case a.SlotType == "gpu":
 		devices, err := detectGPUs(a.Options.VisibleGPUs)
 		if err != nil {

--- a/agent/internal/detect.go
+++ b/agent/internal/detect.go
@@ -33,12 +33,6 @@ func (a *agent) detect() error {
 			return errors.Wrap(err, "error while gathering GPU info through nvidia-smi command")
 		}
 		a.Devices = devices
-	case a.SlotType == "cpu":
-		devices, err := detectCPUs()
-		if err != nil {
-			return err
-		}
-		a.Devices = devices
 	case a.SlotType == "auto":
 		devices, err := detectGPUs(a.Options.VisibleGPUs)
 		if err != nil {

--- a/agent/internal/options.go
+++ b/agent/internal/options.go
@@ -3,6 +3,8 @@ package internal
 import (
 	"encoding/json"
 
+	"github.com/determined-ai/determined/master/pkg/check"
+
 	"github.com/pkg/errors"
 )
 
@@ -14,6 +16,7 @@ type Options struct {
 	MasterPort      int    `json:"master_port"`
 	AgentID         string `json:"agent_id"`
 	ArtificialSlots int    `json:"artificial_slots"`
+	SlotType        string `json:"slot_type"`
 
 	ContainerMasterHost string `json:"container_master_host"`
 	ContainerMasterPort int    `json:"container_master_port"`
@@ -43,6 +46,7 @@ type Options struct {
 func (o Options) Validate() []error {
 	return []error{
 		o.validateTLS(),
+		check.In(o.SlotType, []string{"cpu", "gpu", "auto"}),
 	}
 }
 

--- a/agent/internal/options.go
+++ b/agent/internal/options.go
@@ -46,7 +46,7 @@ type Options struct {
 func (o Options) Validate() []error {
 	return []error{
 		o.validateTLS(),
-		check.In(o.SlotType, []string{"cpu", "gpu", "auto"}),
+		check.In(o.SlotType, []string{"gpu", "auto", "none"}),
 	}
 }
 

--- a/docs/reference/cluster-config.txt
+++ b/docs/reference/cluster-config.txt
@@ -747,6 +747,18 @@ The master supports the following configuration settings:
    index, UUID, PCI bus ID, or board serial number. The 0-based index of
    NVIDIA GPUs can be obtained via the ``nvidia-smi`` command.
 
+-  ``slot_type``: The slot type that should be exposed. All the dynamic
+   agents are configured to ``gpu`` while for other agents this field
+   defaults to ``auto``.
+
+   -  ``auto``: Automatically detects the slot type. The agent will
+      detect if there are GPUs. If there are GPUs, it maps each GPU to
+      one slot. Otherwise, It creates a slot for all the CPUs.
+
+   -  ``cpu``: The agent will map all the CPUs to a slot.
+
+   -  ``gpu``: The agent will map each GPU to a slot.
+
 -  ``http_proxy``: The HTTP proxy address for the agent's containers.
 
 -  ``https_proxy``: The HTTPS proxy address for the agent's containers.

--- a/docs/reference/cluster-config.txt
+++ b/docs/reference/cluster-config.txt
@@ -753,7 +753,7 @@ The master supports the following configuration settings:
 
    -  ``auto``: Automatically detects the slot type. The agent will
       detect if there are GPUs. If there are GPUs, it maps each GPU to
-      one slot. Otherwise, It creates a slot for all the CPUs.
+      one slot. Otherwise, it creates a slot for all the CPUs.
 
    -  ``cpu``: The agent will map all the CPUs to a slot.
 

--- a/docs/reference/cluster-config.txt
+++ b/docs/reference/cluster-config.txt
@@ -747,17 +747,21 @@ The master supports the following configuration settings:
    index, UUID, PCI bus ID, or board serial number. The 0-based index of
    NVIDIA GPUs can be obtained via the ``nvidia-smi`` command.
 
--  ``slot_type``: The slot type that should be exposed. All the dynamic
-   agents are configured to ``gpu`` while for other agents this field
+-  ``slot_type``: The slot type that should be exposed. Dynamic agents
+   having GPUs will be configured to ``gpu`` while those agents having
+   no GPUs will be configured to ``none``. For static agents this field
    defaults to ``auto``.
 
    -  ``auto``: Automatically detects the slot type. The agent will
       detect if there are GPUs. If there are GPUs, it maps each GPU to
-      one slot. Otherwise, it creates a slot for all the CPUs.
+      one slot. Otherwise, it maps all the CPUs to a slot.
 
-   -  ``cpu``: The agent will map all the CPUs to a slot.
+   -  ``none``: The agent will not create any slots for detected
+      devices.
 
-   -  ``gpu``: The agent will map each GPU to a slot.
+   -  ``cpu``: The agent will map all the detected CPUs to a slot.
+
+   -  ``gpu``: The agent will map each detected GPU to a slot.
 
 -  ``http_proxy``: The HTTP proxy address for the agent's containers.
 

--- a/docs/reference/cluster-config.txt
+++ b/docs/reference/cluster-config.txt
@@ -759,8 +759,6 @@ The master supports the following configuration settings:
    -  ``none``: The agent will not create any slots for detected
       devices.
 
-   -  ``cpu``: The agent will map all the detected CPUs to a slot.
-
    -  ``gpu``: The agent will map each detected GPU to a slot.
 
 -  ``http_proxy``: The HTTP proxy address for the agent's containers.

--- a/docs/release-notes/1484-configurable-slot-type.txt
+++ b/docs/release-notes/1484-configurable-slot-type.txt
@@ -1,0 +1,12 @@
+:orphan:
+
+**Improvements**
+
+-  Support configurable slot type for agents. Previously, we only
+   supported auto-detecting the slot type for agents. It detected the
+   GPUs and if there were no GPUs the agents would fall back to mapping
+   one slot to all the CPUs. Now, this behavior can be configured to one
+   of ``gpu``, ``cpu``, and ``auto`` in the field ``slot_type`` of the
+   agent configuration ``agent.yaml`` and defaults to ``auto``. Also,
+   dynamic agents will be configured to ``gpu``. See the :ref:`Agent
+   configuration <agent-configuration>` for details.

--- a/docs/release-notes/1484-configurable-slot-type.txt
+++ b/docs/release-notes/1484-configurable-slot-type.txt
@@ -6,7 +6,9 @@
    supported auto-detecting the slot type for agents. It detected the
    GPUs and if there were no GPUs the agents would fall back to mapping
    one slot to all the CPUs. Now, this behavior can be configured to one
-   of ``gpu``, ``cpu``, and ``auto`` in the field ``slot_type`` of the
-   agent configuration ``agent.yaml`` and defaults to ``auto``. Also,
-   dynamic agents will be configured to ``gpu``. See the :ref:`Agent
-   configuration <agent-configuration>` for details.
+   of ``auto``, ``gpu``, ``cpu``, and ``none`` in the field
+   ``slot_type`` of the agent configuration ``agent.yaml``. Dynamic
+   agents having GPUs will be configured to ``gpu`` while those agents
+   having no GPUs will be configured to ``none``. For static agents this
+   field defaults to ``auto``. See the :ref:`Agent configuration
+   <agent-configuration>` for details.

--- a/docs/release-notes/1484-configurable-slot-type.txt
+++ b/docs/release-notes/1484-configurable-slot-type.txt
@@ -6,9 +6,9 @@
    supported auto-detecting the slot type for agents. It detected the
    GPUs and if there were no GPUs the agents would fall back to mapping
    one slot to all the CPUs. Now, this behavior can be configured to one
-   of ``auto``, ``gpu``, ``cpu``, and ``none`` in the field
-   ``slot_type`` of the agent configuration ``agent.yaml``. Dynamic
-   agents having GPUs will be configured to ``gpu`` while those agents
-   having no GPUs will be configured to ``none``. For static agents this
-   field defaults to ``auto``. See the :ref:`Agent configuration
-   <agent-configuration>` for details.
+   of ``auto``, ``gpu``, and ``none`` in the field ``slot_type`` of the
+   agent configuration ``agent.yaml``. Dynamic agents having GPUs will
+   be configured to ``gpu`` while those agents having no GPUs will be
+   configured to ``none``. For static agents this field defaults to
+   ``auto``. See the :ref:`Agent configuration <agent-configuration>`
+   for details.

--- a/master/internal/provisioner/agent_setup_test.go
+++ b/master/internal/provisioner/agent_setup_test.go
@@ -44,9 +44,12 @@ chmod +x /usr/local/determined/startup_script
 /usr/local/determined/startup_script
 
 use_gpus=true
-if $use_gpus; then
+if $use_gpus
+then
     echo "#### Starting agent with GPUs"
     docker_args+=(--gpus all)
+else
+    echo "#### Starting agent with no GPUs"
 fi
 
 cert_b64=PT09PSBjZXJ0ID09PT0=
@@ -73,6 +76,7 @@ docker run --init --name determined-agent  \
     -e DET_MASTER_HOST="test.master" \
     -e DET_MASTER_PORT="8080" \
     -e DET_RESOURCE_POOL="test-pool" \
+    -e DET_SLOT_TYPE=gpu \
     -v /var/run/docker.sock:/var/run/docker.sock \
     -v /usr/local/determined/container_startup_script:/usr/local/determined/container_startup_script \
     "${docker_args[@]}" \

--- a/master/internal/provisioner/agent_setup_test.go
+++ b/master/internal/provisioner/agent_setup_test.go
@@ -49,7 +49,7 @@ then
     echo "#### Starting agent with GPUs"
     docker_args+=(--gpus all)
 else
-    echo "#### Starting agent with no GPUs"
+    echo "#### Starting agent with only CPUs"
 fi
 
 cert_b64=PT09PSBjZXJ0ID09PT0=

--- a/master/internal/provisioner/agent_setup_test.go
+++ b/master/internal/provisioner/agent_setup_test.go
@@ -48,8 +48,10 @@ if $use_gpus
 then
     echo "#### Starting agent with GPUs"
     docker_args+=(--gpus all)
+    docker_args+=(-e DET_SLOT_TYPE=gpu)
 else
     echo "#### Starting agent with only CPUs"
+    docker_args+=(-e DET_SLOT_TYPE=none)
 fi
 
 cert_b64=PT09PSBjZXJ0ID09PT0=
@@ -76,7 +78,6 @@ docker run --init --name determined-agent  \
     -e DET_MASTER_HOST="test.master" \
     -e DET_MASTER_PORT="8080" \
     -e DET_RESOURCE_POOL="test-pool" \
-    -e DET_SLOT_TYPE=gpu \
     -v /var/run/docker.sock:/var/run/docker.sock \
     -v /usr/local/determined/container_startup_script:/usr/local/determined/container_startup_script \
     "${docker_args[@]}" \

--- a/master/internal/provisioner/gcp_config.go
+++ b/master/internal/provisioner/gcp_config.go
@@ -219,11 +219,11 @@ var gceMachineTypes = []string{
 
 var gceGPUTypes = map[string][]int{
 	"":                  {0},
-	"nvidia-tesla-t4":   {1, 2, 4},
-	"nvidia-tesla-p100": {1, 2, 4},
-	"nvidia-tesla-p4":   {1, 2, 4},
-	"nvidia-tesla-v100": {1, 2, 4, 8},
-	"nvidia-tesla-k80":  {1, 2, 4, 8},
+	"nvidia-tesla-t4":   {0, 1, 2, 4},
+	"nvidia-tesla-p100": {0, 1, 2, 4},
+	"nvidia-tesla-p4":   {0, 1, 2, 4},
+	"nvidia-tesla-v100": {0, 1, 2, 4, 8},
+	"nvidia-tesla-k80":  {0, 1, 2, 4, 8},
 }
 
 type gceInstanceType struct {

--- a/master/static/srv/agent_setup_script.sh.template
+++ b/master/static/srv/agent_setup_script.sh.template
@@ -16,7 +16,7 @@ then
     echo "#### Starting agent with GPUs"
     docker_args+=(--gpus all)
 else
-    echo "#### Starting agent with no GPUs"
+    echo "#### Starting agent with only CPUs"
 fi
 
 cert_b64={{.MasterCertBase64}}

--- a/master/static/srv/agent_setup_script.sh.template
+++ b/master/static/srv/agent_setup_script.sh.template
@@ -15,8 +15,10 @@ if $use_gpus
 then
     echo "#### Starting agent with GPUs"
     docker_args+=(--gpus all)
+    docker_args+=(-e DET_SLOT_TYPE=gpu)
 else
     echo "#### Starting agent with only CPUs"
+    docker_args+=(-e DET_SLOT_TYPE=none)
 fi
 
 cert_b64={{.MasterCertBase64}}
@@ -43,7 +45,6 @@ docker run --init --name determined-agent {{.LogOptions}} \
     -e DET_MASTER_HOST="{{.MasterHost}}" \
     -e DET_MASTER_PORT="{{.MasterPort}}" \
     -e DET_RESOURCE_POOL="{{.ResourcePool}}" \
-    -e DET_SLOT_TYPE=gpu \
     -v /var/run/docker.sock:/var/run/docker.sock \
     -v /usr/local/determined/container_startup_script:/usr/local/determined/container_startup_script \
     "${docker_args[@]}" \

--- a/master/static/srv/agent_setup_script.sh.template
+++ b/master/static/srv/agent_setup_script.sh.template
@@ -11,9 +11,12 @@ chmod +x /usr/local/determined/startup_script
 /usr/local/determined/startup_script
 
 use_gpus={{.AgentUseGPUs}}
-if $use_gpus; then
+if $use_gpus
+then
     echo "#### Starting agent with GPUs"
     docker_args+=(--gpus all)
+else
+    echo "#### Starting agent with no GPUs"
 fi
 
 cert_b64={{.MasterCertBase64}}
@@ -40,6 +43,7 @@ docker run --init --name determined-agent {{.LogOptions}} \
     -e DET_MASTER_HOST="{{.MasterHost}}" \
     -e DET_MASTER_PORT="{{.MasterPort}}" \
     -e DET_RESOURCE_POOL="{{.ResourcePool}}" \
+    -e DET_SLOT_TYPE=gpu \
     -v /var/run/docker.sock:/var/run/docker.sock \
     -v /usr/local/determined/container_startup_script:/usr/local/determined/container_startup_script \
     "${docker_args[@]}" \


### PR DESCRIPTION
## Description

Previously, we only support using autoconfiguring the slot type to be GPU and if there are no GPUs fall back to CPU. This applies to most use cases, including GPU-only cluster and testing infrastructure (typically users don't use purely CPU). However, we want to be able to support zero-slot resource pools for zero-slot tasks, such as Tensorboard, GC tasks, CPU-only notebooks, and etc,. And we don't want zero-slot resource pools to show any slots on the slot utilization.

Now, in order to support a zero-slot resource pool when we support multiple resource pools, we need to make slot type configurable for agents as opposed to always autoconfiguring the slot type. For dynamic agents, we always use GPUs as slot types so resource pools that use CPU agents will be considered to only run zero-slot tasks.

## Test Plan

1. Test the configuration on machines w/ and w/o GPUs manually.
2. Use the CI test suite.

## Commentary (optional)

N/A

## Checklist

- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
