### PR TITLE
docs: spot instances docs and fixes [DET-4338]

### DIFF
--- a/docs/how-to/installation/aws.txt
+++ b/docs/how-to/installation/aws.txt
@@ -357,7 +357,7 @@ Master
 ------
 
 -  Allow EC2 to assume role
--  Allow EC2 to describe, create and terminate instances with agent role
+-  Allow EC2 to describe, create, and terminate instances with agent role
 -  Allow EC2 to describe, create, and terminate spot instance requests
    (only required if using spot instances)
 

--- a/docs/how-to/installation/aws.txt
+++ b/docs/how-to/installation/aws.txt
@@ -359,6 +359,7 @@ Master
 -  Allow EC2 to assume role
 -  Allow EC2 to dynamically create and terminate instances with agent
    role
+-  Allow EC2 to create and terminate spot instance requests (only required if using spot instances)
 
 .. code:: yaml
 
@@ -385,6 +386,9 @@ Master
                    - ec2:TerminateInstances
                    - ec2:CreateTags
                    - ec2:RunInstances
+                   - ec2:CancelSpotInstanceRequests      # Only required if using spot instances
+                   - ec2:RequestSpotInstances            # Only required if using spot instances
+                   - ec2:DescribeSpotInstanceRequests    # Only required if using spot instances
                  Resource: "*"
          - PolicyName: pass-role
            PolicyDocument:
@@ -480,6 +484,12 @@ Running Determined
       managed by the Determined master. This pair should be unique to
       your Determined installation. If it is not, Determined may
       inadvertently manage your non-Determined EC2 instances.
+
+      If using spot instances, Determined also assumes that any EC2 
+      spot instance requests with the configured tag_key:tag_value 
+      pair are managed by the Determined master.
+
+      
 
    .. code:: yaml
 

--- a/docs/how-to/installation/aws.txt
+++ b/docs/how-to/installation/aws.txt
@@ -359,7 +359,8 @@ Master
 -  Allow EC2 to assume role
 -  Allow EC2 to dynamically create and terminate instances with agent
    role
--  Allow EC2 to create and terminate spot instance requests (only required if using spot instances)
+-  Allow EC2 to create and terminate spot instance requests (only
+   required if using spot instances)
 
 .. code:: yaml
 
@@ -485,11 +486,9 @@ Running Determined
       your Determined installation. If it is not, Determined may
       inadvertently manage your non-Determined EC2 instances.
 
-      If using spot instances, Determined also assumes that any EC2 
-      spot instance requests with the configured tag_key:tag_value 
-      pair are managed by the Determined master.
-
-      
+      If using spot instances, Determined also assumes that any EC2 spot
+      instance requests with the configured tag_key:tag_value pair are
+      managed by the Determined master.
 
    .. code:: yaml
 

--- a/docs/how-to/installation/aws.txt
+++ b/docs/how-to/installation/aws.txt
@@ -357,10 +357,9 @@ Master
 ------
 
 -  Allow EC2 to assume role
--  Allow EC2 to describe, create and terminate instances with agent
-   role
--  Allow EC2 to describe, create, and terminate spot instance requests (only
-   required if using spot instances)
+-  Allow EC2 to describe, create and terminate instances with agent role
+-  Allow EC2 to describe, create, and terminate spot instance requests
+   (only required if using spot instances)
 
 .. code:: yaml
 

--- a/docs/how-to/installation/aws.txt
+++ b/docs/how-to/installation/aws.txt
@@ -357,7 +357,8 @@ Master
 ------
 
 -  Allow EC2 to assume role
--  Allow EC2 to describe, create, and terminate instances with agent role
+-  Allow EC2 to describe, create, and terminate instances with agent
+   role
 -  Allow EC2 to describe, create, and terminate spot instance requests
    (only required if using spot instances)
 

--- a/docs/how-to/installation/aws.txt
+++ b/docs/how-to/installation/aws.txt
@@ -357,9 +357,9 @@ Master
 ------
 
 -  Allow EC2 to assume role
--  Allow EC2 to dynamically create and terminate instances with agent
+-  Allow EC2 to describe, create and terminate instances with agent
    role
--  Allow EC2 to create and terminate spot instance requests (only
+-  Allow EC2 to describe, create, and terminate spot instance requests (only
    required if using spot instances)
 
 .. code:: yaml

--- a/docs/reference/cluster-config.txt
+++ b/docs/reference/cluster-config.txt
@@ -479,6 +479,17 @@ The master supports the following configuration settings:
          ``p2.xlarge``, ``p2.8xlarge``, ``p2.16xlarge``, ``p3.2xlarge``,
          ``p3.8xlarge``, ``p3.16xlarge``, or ``p3dn.24xlarge``. Defaults
          to ``p3.8xlarge``.
+      
+      - ``spot``: Whether to use spot instances. Defaults to ``false``.
+
+      - ``spot_max_price``: Optional field indicating the maximum price 
+         per hour that you are willing to pay for a spot instance. The 
+         market price for a spot instance varies based on supply and 
+         demand. If the market price exceeds the ``spot_max_price``, 
+         Determined will not launch instances. This field must be a 
+         string and must not include a currency sign. For example, $2.50 
+         should be represented as ``"2.50"``. Defaults to the on-demand 
+         price for the given instance type.
 
    -  ``provider: gcp``: Specifies running dynamic agents on GCP.
       (*Required*)

--- a/docs/reference/cluster-config.txt
+++ b/docs/reference/cluster-config.txt
@@ -479,17 +479,17 @@ The master supports the following configuration settings:
          ``p2.xlarge``, ``p2.8xlarge``, ``p2.16xlarge``, ``p3.2xlarge``,
          ``p3.8xlarge``, ``p3.16xlarge``, or ``p3dn.24xlarge``. Defaults
          to ``p3.8xlarge``.
-      
-      - ``spot``: Whether to use spot instances. Defaults to ``false``.
 
-      - ``spot_max_price``: Optional field indicating the maximum price
-        per hour that you are willing to pay for a spot instance. The
-        market price for a spot instance varies based on supply and
-        demand. If the market price exceeds the ``spot_max_price``,
-        Determined will not launch instances. This field must be a
-        string and must not include a currency sign. For example, $2.50
-        should be represented as ``"2.50"``. Defaults to the on-demand
-        price for the given instance type.
+      -  ``spot``: Whether to use spot instances. Defaults to ``false``.
+
+      -  ``spot_max_price``: Optional field indicating the maximum price
+         per hour that you are willing to pay for a spot instance. The
+         market price for a spot instance varies based on supply and
+         demand. If the market price exceeds the ``spot_max_price``,
+         Determined will not launch instances. This field must be a
+         string and must not include a currency sign. For example, $2.50
+         should be represented as ``"2.50"``. Defaults to the on-demand
+         price for the given instance type.
 
    -  ``provider: gcp``: Specifies running dynamic agents on GCP.
       (*Required*)

--- a/docs/reference/cluster-config.txt
+++ b/docs/reference/cluster-config.txt
@@ -481,6 +481,7 @@ The master supports the following configuration settings:
          to ``p3.8xlarge``.
 
       -  ``spot``: Whether to use spot instances. Defaults to ``false``.
+         See :ref:`aws-spot` for more details.
 
       -  ``spot_max_price``: Optional field indicating the maximum price
          per hour that you are willing to pay for a spot instance. The

--- a/docs/reference/cluster-config.txt
+++ b/docs/reference/cluster-config.txt
@@ -482,14 +482,14 @@ The master supports the following configuration settings:
       
       - ``spot``: Whether to use spot instances. Defaults to ``false``.
 
-      - ``spot_max_price``: Optional field indicating the maximum price 
-         per hour that you are willing to pay for a spot instance. The 
-         market price for a spot instance varies based on supply and 
-         demand. If the market price exceeds the ``spot_max_price``, 
-         Determined will not launch instances. This field must be a 
-         string and must not include a currency sign. For example, $2.50 
-         should be represented as ``"2.50"``. Defaults to the on-demand 
-         price for the given instance type.
+      - ``spot_max_price``: Optional field indicating the maximum price
+        per hour that you are willing to pay for a spot instance. The
+        market price for a spot instance varies based on supply and
+        demand. If the market price exceeds the ``spot_max_price``,
+        Determined will not launch instances. This field must be a
+        string and must not include a currency sign. For example, $2.50
+        should be represented as ``"2.50"``. Defaults to the on-demand
+        price for the given instance type.
 
    -  ``provider: gcp``: Specifies running dynamic agents on GCP.
       (*Required*)

--- a/docs/release-notes/1415-spot-instances.txt
+++ b/docs/release-notes/1415-spot-instances.txt
@@ -2,5 +2,6 @@
 
 **Feature**
 
--  Allow users to launch EC2 instances as spot instances to reduce costs by up to 90%.
-   This can be enabled simply by setting ``spot: true`` in the master configuration.
+-  Allow users to launch EC2 instances as spot instances to reduce costs
+   by up to 90%. This can be enabled simply by setting ``spot: true`` in
+   the master configuration.

--- a/docs/release-notes/1415-spot-instances.txt
+++ b/docs/release-notes/1415-spot-instances.txt
@@ -2,4 +2,5 @@
 
 **Feature**
 
--  Allow users to launch EC2 instances as spot instances to reduce costs by up to 90%. This can be enabled simple by setting ``spot: true`` in the master configuration. 
+-  Allow users to launch EC2 instances as spot instances to reduce costs by up to 90%.
+   This can be enabled simply by setting ``spot: true`` in the master configuration.

--- a/docs/release-notes/1415-spot-instances.txt
+++ b/docs/release-notes/1415-spot-instances.txt
@@ -4,4 +4,4 @@
 
 -  Allow users to launch EC2 instances as spot instances to reduce costs
    by up to 90%. This can be enabled simply by setting ``spot: true`` in
-   the master configuration.
+   the :ref:`cluster-configuration`.

--- a/docs/release-notes/1415-spot-instances.txt
+++ b/docs/release-notes/1415-spot-instances.txt
@@ -1,0 +1,5 @@
+:orphan:
+
+**Feature**
+
+-  Allow users to launch EC2 instances as spot instances to reduce costs by up to 90%. This can be enabled simple by setting ``spot: true`` in the master configuration. 

--- a/docs/topic-guides/elastic-infra/aws-spot.txt
+++ b/docs/topic-guides/elastic-infra/aws-spot.txt
@@ -39,11 +39,10 @@ good fault tolerance built into your software. Determined was built with
 fault-tolerance as a core feature, so using spot instances is usually as
 easy as setting ``spot: true`` in the master configuration.
 
-AWS might not always have the capacity to fulfill spot requests.
-When AWS is out of capacity, the Determined cluster will wait
-until AWS has capacity and can fulfill the requests. This will
-be visible in the master logs.
-
+AWS might not always have the capacity to fulfill spot requests. When
+AWS is out of capacity, the Determined cluster will wait until AWS has
+capacity and can fulfill the requests. This will be visible in the
+master logs.
 
 **************
  Spot Pricing

--- a/docs/topic-guides/elastic-infra/aws-spot.txt
+++ b/docs/topic-guides/elastic-infra/aws-spot.txt
@@ -59,7 +59,7 @@ Once the spot instance has been created, the hourly price is constant,
 but if you try to create another spot instance, the price may have
 changed. The spot price is typically around 70% less than the on-demand
 price (see `AWS's spot
-advisor<https://aws.amazon.com/ec2/spot/pricing/>` for up-to-date
+advisor<https://aws.amazon.com/ec2/spot/pricing/>_` for up-to-date
 information), but it can technically rise as high as the on-demand
 price.
 

--- a/docs/topic-guides/elastic-infra/aws-spot.txt
+++ b/docs/topic-guides/elastic-infra/aws-spot.txt
@@ -4,10 +4,21 @@
  AWS Spot Instances
 ####################
 
-This document describes how AWS spot instances work. Determined handles
-most details of working with spot instances, but knowing how spot
-instances work at a high level is helpful for understanding the behavior
-of Determined when provisioning spot instances.
+This document describes how to use AWS spot instances with Determined.
+Spot instances can be much cheaper than on-demand instances (up to 90%
+cheaper, but more often 70-80%) but they are unreliable, so software
+that runs on spot instances must be fault tolerant. Unfortunately, deep
+learning code is often not written with fault tolerance in mind,
+preventing many practitioners from using spot instances easily. Because
+Determined was built with fault tolerance as a core feature, it works
+seamlessly when run on top of spot instances, allowing users to reduce
+their training costs by setting a single flag in the
+:ref:`cluster-configuration`.
+
+Determined handles most details of working with spot instances, but
+knowing how spot instances work at a high level is helpful for
+understanding the behavior of Determined when provisioning spot
+instances.
 
 *******************
  On-Demand vs Spot
@@ -15,20 +26,25 @@ of Determined when provisioning spot instances.
 
 The standard way to create an EC2 instance is to create an on-demand
 instance. On-demand instances always have the same price and once you
-have created one, you are guaranteed to have that instance forever
-(barring hardware failure).
+have created one, you will keep that instance indefinitely.
 
 The number of EC2 instances desired by customers varies over time. AWS
 wants to have enough hardware so that during peak usage periods, all
 customers are able to get as many on-demand instances as they need. This
 means that during non-peak periods (which is most of the time), AWS has
 extra hardware capacity sitting around unused. AWS makes these extra
-instances available to customers via the spot market as spot instances.
-They can be rented at a much reduced cost, but the trade-off is that, if
-AWS needs instances to satisfy on-demand users, they can reclaim your
-spot instance and give it to the on-demand user. If all available
-instances are in use by on-demand customers, you will not be able to
-launch any spot instances.
+instances available to customers via the spot market as `spot instances
+<https://aws.amazon.com/ec2/spot/>`_. They can be rented at a much
+reduced cost, but the trade-off is that, if AWS needs instances to
+satisfy on-demand users, they can reclaim your spot instance and give it
+to the on-demand user. If all available instances are in use by
+on-demand customers, you will not be able to launch any spot instances.
+
+Because spot capacity depends on supply and demand, your ability to
+launch spot instances will vary by region/availability zone, as well as
+instance type. GPU instances, particularly those with the most modern
+GPUs, are often in high demand and they may sometimes be difficult to
+get as spot instances.
 
 ********************
  Spot On Determined
@@ -49,17 +65,17 @@ master logs.
 **************
 
 Unlike on-demand instances, the market price of a spot instance varies.
-Once the spot instance has been created, the hourly price is constant,
-but if you try to create another spot instance, the price may have
-changed. The spot price is typically around 70% less than the on-demand
-price (see `AWS's spot advisor
+Once the spot instance has been created, the hourly cost to run that
+instance is constant, but if you try to create another spot instance,
+the price may have changed. The spot price is typically around 70% less
+than the on-demand price (see `AWS's spot advisor
 <https://aws.amazon.com/ec2/spot/instance-advisor/>`_ for up-to-date
 information), but it can technically rise as high as the on-demand
 price.
 
 AWS and Determined allow you to specify the maximum price that you are
-willing to pay for a spot instance and, if the market price is above
-that number, the spot instance will not be created until the price falls
+willing to pay for a spot instance. If the market price is above that
+number, the spot instance will not be created until the price falls
 under your maximum price. You can set this value via the
 ``spot_max_price`` field in the master configuration. The market price
 being above your ``spot_max_price`` is another reason why Determined may

--- a/docs/topic-guides/elastic-infra/aws-spot.txt
+++ b/docs/topic-guides/elastic-infra/aws-spot.txt
@@ -39,16 +39,11 @@ good fault tolerance built into your software. Determined was built with
 fault-tolerance as a core feature, so using spot instances is usually as
 easy as setting ``spot: true`` in the master configuration.
 
-However, Determined cannot solve the problem of AWS not having enough
-capacity. If you are using Determined with spot instances and are
-expecting instances to be created, but you aren't seeing them get
-created, it is possible that Determined is sending requests to AWS to
-create spot instances, but AWS is out of capacity so the requests are
-stuck until capacity becomes available. Unfortunately, AWS's available
-capacity at any time is a tightly-guarded secret, so the best Determined
-can do is request instances and see how AWS responds. If Determined is
-unable to create spot instances due to lack of AWS capacity, this will
+AWS might not always have the capacity to fulfill spot requests.
+When AWS is out of capacity, the Determined cluster will wait
+until AWS has capacity and can fulfill the requests. This will
 be visible in the master logs.
+
 
 **************
  Spot Pricing

--- a/docs/topic-guides/elastic-infra/aws-spot.txt
+++ b/docs/topic-guides/elastic-infra/aws-spot.txt
@@ -1,0 +1,32 @@
+.. _aws-spot:
+
+#######################
+ AWS Spot Instances
+#######################
+
+This document describes how AWS spot instances work. Determined handles most details of working with spot instances, but knowing how spot instances work at a high level is helpful for understanding the behavior of Determined when provisioning spot instances.
+
+On-Demand vs Spot
+=================
+
+The standard way to create an EC2 instance is to create an on-demand instance. On-demand instances always have the same price and once you have created one, you are guaranteed to have that instance forever (barring hardware failure). 
+
+The number of EC2 instances desired by customers varies over time. AWS wants to have enough hardware so that during peak usage periods, all customers are able to get as many on-demand instances as they need. This means that during non-peak periods (which is most of the time), AWS has extra hardware capacity sitting around unused. AWS makes these extra instances available to customers via the spot market as spot instances. They can be rented at a much reduced cost, but the trade-off is that, if AWS needs instances to satisfy on-demand users, they can reclaim your spot instance and give it to the on-demand user. If all available instances are in use by on-demand customers, you will not be able to launch any spot instances.
+
+Spot On Determined
+==================
+
+Because they can be reclaimed, using spot instances requires you to have good fault tolerance built into your software. Determined was built with fault-tolerance as a core feature, so using spot instances is usually as easy as setting ``spot: true`` in the master configuration.
+
+However, Determined cannot solve the problem of AWS not having enough capacity. If you are using Determined with spot instances and are expecting instances to be created, but you aren't seeing them get created, it is possible that Determined is sending requests to AWS to create spot instances, but AWS is out of capacity so the requests are stuck until capacity becomes available. Unfortunately, AWS's available capacity at any time is a tightly-guarded secret, so the best Determined can do is request instances and see how AWS responds. If Determined is unable to create spot instances due to lack of AWS capacity, this will be visible in the master logs.
+
+Spot Pricing
+============
+
+Unlike on-demand instances, the market price of a spot instance varies. Once the spot instance has been created, the hourly price is constant, but if you try to create another spot instance, the price may have changed. The spot price is typically around 70% less than the on-demand price (see `AWS's spot advisor<https://aws.amazon.com/ec2/spot/pricing/>` for up-to-date information), but it can technically rise as high as the on-demand price. 
+
+AWS and Determined allow you to specify the maximum price that you are willing to pay for a spot instance and, if the market price is above that number, the spot instance will not be created until the price falls under your maximum price. You can set this value via the ``spot_maximum_price`` field in the master configuration. The market price being above your ``spot_maximum_price`` is another reason why Determined may not be creating spot instances when you expect it to. If this is preventing Determined from creating spot instances, this will be visible in the master logs.
+
+Many users want to reduce costs by using spot, but have deadlines and are not willing to delay their experiments. In this case, it may be best to not set ``spot_maximum_price`` and pay whatever the market price is. Your mileage may vary, but at Determined, we have regularly seen 70% cost reductions when using V100s, without specifying a ``spot_maximum_price``.
+
+

--- a/docs/topic-guides/elastic-infra/aws-spot.txt
+++ b/docs/topic-guides/elastic-infra/aws-spot.txt
@@ -4,29 +4,61 @@
  AWS Spot Instances
 #######################
 
-This document describes how AWS spot instances work. Determined handles most details of working with spot instances, but knowing how spot instances work at a high level is helpful for understanding the behavior of Determined when provisioning spot instances.
+This document describes how AWS spot instances work. Determined handles most details
+of working with spot instances, but knowing how spot instances work at a high level
+is helpful for understanding the behavior of Determined when provisioning spot instances.
 
 On-Demand vs Spot
 =================
 
-The standard way to create an EC2 instance is to create an on-demand instance. On-demand instances always have the same price and once you have created one, you are guaranteed to have that instance forever (barring hardware failure). 
+The standard way to create an EC2 instance is to create an on-demand instance. On-demand
+instances always have the same price and once you have created one, you are guaranteed to
+have that instance forever (barring hardware failure).
 
-The number of EC2 instances desired by customers varies over time. AWS wants to have enough hardware so that during peak usage periods, all customers are able to get as many on-demand instances as they need. This means that during non-peak periods (which is most of the time), AWS has extra hardware capacity sitting around unused. AWS makes these extra instances available to customers via the spot market as spot instances. They can be rented at a much reduced cost, but the trade-off is that, if AWS needs instances to satisfy on-demand users, they can reclaim your spot instance and give it to the on-demand user. If all available instances are in use by on-demand customers, you will not be able to launch any spot instances.
+The number of EC2 instances desired by customers varies over time. AWS wants to have enough
+hardware so that during peak usage periods, all customers are able to get as many on-demand
+instances as they need. This means that during non-peak periods (which is most of the time),
+AWS has extra hardware capacity sitting around unused. AWS makes these extra instances
+available to customers via the spot market as spot instances. They can be rented at a much
+reduced cost, but the trade-off is that, if AWS needs instances to satisfy on-demand users,
+they can reclaim your spot instance and give it to the on-demand user. If all available
+instances are in use by on-demand customers, you will not be able to launch any spot instances.
 
 Spot On Determined
 ==================
 
-Because they can be reclaimed, using spot instances requires you to have good fault tolerance built into your software. Determined was built with fault-tolerance as a core feature, so using spot instances is usually as easy as setting ``spot: true`` in the master configuration.
+Because they can be reclaimed, using spot instances requires you to have good fault tolerance
+built into your software. Determined was built with fault-tolerance as a core feature, so
+using spot instances is usually as easy as setting ``spot: true`` in the master configuration.
 
-However, Determined cannot solve the problem of AWS not having enough capacity. If you are using Determined with spot instances and are expecting instances to be created, but you aren't seeing them get created, it is possible that Determined is sending requests to AWS to create spot instances, but AWS is out of capacity so the requests are stuck until capacity becomes available. Unfortunately, AWS's available capacity at any time is a tightly-guarded secret, so the best Determined can do is request instances and see how AWS responds. If Determined is unable to create spot instances due to lack of AWS capacity, this will be visible in the master logs.
+However, Determined cannot solve the problem of AWS not having enough capacity. If you are
+using Determined with spot instances and are expecting instances to be created, but you aren't
+seeing them get created, it is possible that Determined is sending requests to AWS to create
+spot instances, but AWS is out of capacity so the requests are stuck until capacity becomes
+available. Unfortunately, AWS's available capacity at any time is a tightly-guarded secret,
+so the best Determined can do is request instances and see how AWS responds. If Determined is
+unable to create spot instances due to lack of AWS capacity, this will be visible in the master
+logs.
 
 Spot Pricing
 ============
 
-Unlike on-demand instances, the market price of a spot instance varies. Once the spot instance has been created, the hourly price is constant, but if you try to create another spot instance, the price may have changed. The spot price is typically around 70% less than the on-demand price (see `AWS's spot advisor<https://aws.amazon.com/ec2/spot/pricing/>` for up-to-date information), but it can technically rise as high as the on-demand price. 
+Unlike on-demand instances, the market price of a spot instance varies. Once the spot instance
+has been created, the hourly price is constant, but if you try to create another spot instance,
+the price may have changed. The spot price is typically around 70% less than the on-demand price
+(see `AWS's spot advisor<https://aws.amazon.com/ec2/spot/pricing/>` for up-to-date information),
+but it can technically rise as high as the on-demand price.
 
-AWS and Determined allow you to specify the maximum price that you are willing to pay for a spot instance and, if the market price is above that number, the spot instance will not be created until the price falls under your maximum price. You can set this value via the ``spot_maximum_price`` field in the master configuration. The market price being above your ``spot_maximum_price`` is another reason why Determined may not be creating spot instances when you expect it to. If this is preventing Determined from creating spot instances, this will be visible in the master logs.
+AWS and Determined allow you to specify the maximum price that you are willing to pay for a spot
+instance and, if the market price is above that number, the spot instance will not be created
+until the price falls under your maximum price. You can set this value via the ``spot_maximum_price``
+field in the master configuration. The market price being above your ``spot_maximum_price`` is
+another reason why Determined may not be creating spot instances when you expect it to. If this is
+preventing Determined from creating spot instances, this will be visible in the master logs.
 
-Many users want to reduce costs by using spot, but have deadlines and are not willing to delay their experiments. In this case, it may be best to not set ``spot_maximum_price`` and pay whatever the market price is. Your mileage may vary, but at Determined, we have regularly seen 70% cost reductions when using V100s, without specifying a ``spot_maximum_price``.
+Many users want to reduce costs by using spot, but have deadlines and are not willing to delay
+their experiments. In this case, it may be best to not set ``spot_maximum_price`` and pay whatever
+the market price is. Your mileage may vary, but at Determined, we have regularly seen 70% cost
+reductions when using V100s, without specifying a ``spot_maximum_price``.
 
 

--- a/docs/topic-guides/elastic-infra/aws-spot.txt
+++ b/docs/topic-guides/elastic-infra/aws-spot.txt
@@ -58,8 +58,8 @@ Unlike on-demand instances, the market price of a spot instance varies.
 Once the spot instance has been created, the hourly price is constant,
 but if you try to create another spot instance, the price may have
 changed. The spot price is typically around 70% less than the on-demand
-price (see `AWS's spot
-advisor<https://aws.amazon.com/ec2/spot/pricing/>_` for up-to-date
+price (see `AWS's spot advisor
+<https://aws.amazon.com/ec2/spot/instance-advisor/>`_ for up-to-date
 information), but it can technically rise as high as the on-demand
 price.
 

--- a/docs/topic-guides/elastic-infra/aws-spot.txt
+++ b/docs/topic-guides/elastic-infra/aws-spot.txt
@@ -1,64 +1,81 @@
 .. _aws-spot:
 
-#######################
+####################
  AWS Spot Instances
-#######################
+####################
 
-This document describes how AWS spot instances work. Determined handles most details
-of working with spot instances, but knowing how spot instances work at a high level
-is helpful for understanding the behavior of Determined when provisioning spot instances.
+This document describes how AWS spot instances work. Determined handles
+most details of working with spot instances, but knowing how spot
+instances work at a high level is helpful for understanding the behavior
+of Determined when provisioning spot instances.
 
-On-Demand vs Spot
-=================
+*******************
+ On-Demand vs Spot
+*******************
 
-The standard way to create an EC2 instance is to create an on-demand instance. On-demand
-instances always have the same price and once you have created one, you are guaranteed to
-have that instance forever (barring hardware failure).
+The standard way to create an EC2 instance is to create an on-demand
+instance. On-demand instances always have the same price and once you
+have created one, you are guaranteed to have that instance forever
+(barring hardware failure).
 
-The number of EC2 instances desired by customers varies over time. AWS wants to have enough
-hardware so that during peak usage periods, all customers are able to get as many on-demand
-instances as they need. This means that during non-peak periods (which is most of the time),
-AWS has extra hardware capacity sitting around unused. AWS makes these extra instances
-available to customers via the spot market as spot instances. They can be rented at a much
-reduced cost, but the trade-off is that, if AWS needs instances to satisfy on-demand users,
-they can reclaim your spot instance and give it to the on-demand user. If all available
-instances are in use by on-demand customers, you will not be able to launch any spot instances.
+The number of EC2 instances desired by customers varies over time. AWS
+wants to have enough hardware so that during peak usage periods, all
+customers are able to get as many on-demand instances as they need. This
+means that during non-peak periods (which is most of the time), AWS has
+extra hardware capacity sitting around unused. AWS makes these extra
+instances available to customers via the spot market as spot instances.
+They can be rented at a much reduced cost, but the trade-off is that, if
+AWS needs instances to satisfy on-demand users, they can reclaim your
+spot instance and give it to the on-demand user. If all available
+instances are in use by on-demand customers, you will not be able to
+launch any spot instances.
 
-Spot On Determined
-==================
+********************
+ Spot On Determined
+********************
 
-Because they can be reclaimed, using spot instances requires you to have good fault tolerance
-built into your software. Determined was built with fault-tolerance as a core feature, so
-using spot instances is usually as easy as setting ``spot: true`` in the master configuration.
+Because they can be reclaimed, using spot instances requires you to have
+good fault tolerance built into your software. Determined was built with
+fault-tolerance as a core feature, so using spot instances is usually as
+easy as setting ``spot: true`` in the master configuration.
 
-However, Determined cannot solve the problem of AWS not having enough capacity. If you are
-using Determined with spot instances and are expecting instances to be created, but you aren't
-seeing them get created, it is possible that Determined is sending requests to AWS to create
-spot instances, but AWS is out of capacity so the requests are stuck until capacity becomes
-available. Unfortunately, AWS's available capacity at any time is a tightly-guarded secret,
-so the best Determined can do is request instances and see how AWS responds. If Determined is
-unable to create spot instances due to lack of AWS capacity, this will be visible in the master
-logs.
+However, Determined cannot solve the problem of AWS not having enough
+capacity. If you are using Determined with spot instances and are
+expecting instances to be created, but you aren't seeing them get
+created, it is possible that Determined is sending requests to AWS to
+create spot instances, but AWS is out of capacity so the requests are
+stuck until capacity becomes available. Unfortunately, AWS's available
+capacity at any time is a tightly-guarded secret, so the best Determined
+can do is request instances and see how AWS responds. If Determined is
+unable to create spot instances due to lack of AWS capacity, this will
+be visible in the master logs.
 
-Spot Pricing
-============
+**************
+ Spot Pricing
+**************
 
-Unlike on-demand instances, the market price of a spot instance varies. Once the spot instance
-has been created, the hourly price is constant, but if you try to create another spot instance,
-the price may have changed. The spot price is typically around 70% less than the on-demand price
-(see `AWS's spot advisor<https://aws.amazon.com/ec2/spot/pricing/>` for up-to-date information),
-but it can technically rise as high as the on-demand price.
+Unlike on-demand instances, the market price of a spot instance varies.
+Once the spot instance has been created, the hourly price is constant,
+but if you try to create another spot instance, the price may have
+changed. The spot price is typically around 70% less than the on-demand
+price (see `AWS's spot
+advisor<https://aws.amazon.com/ec2/spot/pricing/>` for up-to-date
+information), but it can technically rise as high as the on-demand
+price.
 
-AWS and Determined allow you to specify the maximum price that you are willing to pay for a spot
-instance and, if the market price is above that number, the spot instance will not be created
-until the price falls under your maximum price. You can set this value via the ``spot_maximum_price``
-field in the master configuration. The market price being above your ``spot_maximum_price`` is
-another reason why Determined may not be creating spot instances when you expect it to. If this is
-preventing Determined from creating spot instances, this will be visible in the master logs.
+AWS and Determined allow you to specify the maximum price that you are
+willing to pay for a spot instance and, if the market price is above
+that number, the spot instance will not be created until the price falls
+under your maximum price. You can set this value via the
+``spot_maximum_price`` field in the master configuration. The market
+price being above your ``spot_maximum_price`` is another reason why
+Determined may not be creating spot instances when you expect it to. If
+this is preventing Determined from creating spot instances, this will be
+visible in the master logs.
 
-Many users want to reduce costs by using spot, but have deadlines and are not willing to delay
-their experiments. In this case, it may be best to not set ``spot_maximum_price`` and pay whatever
-the market price is. Your mileage may vary, but at Determined, we have regularly seen 70% cost
-reductions when using V100s, without specifying a ``spot_maximum_price``.
-
-
+Many users want to reduce costs by using spot, but have deadlines and
+are not willing to delay their experiments. In this case, it may be best
+to not set ``spot_maximum_price`` and pay whatever the market price is.
+Your mileage may vary, but at Determined, we have regularly seen 70%
+cost reductions when using V100s, without specifying a
+``spot_maximum_price``.

--- a/docs/topic-guides/elastic-infra/aws-spot.txt
+++ b/docs/topic-guides/elastic-infra/aws-spot.txt
@@ -67,15 +67,15 @@ AWS and Determined allow you to specify the maximum price that you are
 willing to pay for a spot instance and, if the market price is above
 that number, the spot instance will not be created until the price falls
 under your maximum price. You can set this value via the
-``spot_maximum_price`` field in the master configuration. The market
-price being above your ``spot_maximum_price`` is another reason why
+``spot_max_price`` field in the master configuration. The market
+price being above your ``spot_max_price`` is another reason why
 Determined may not be creating spot instances when you expect it to. If
 this is preventing Determined from creating spot instances, this will be
 visible in the master logs.
 
 Many users want to reduce costs by using spot, but have deadlines and
 are not willing to delay their experiments. In this case, it may be best
-to not set ``spot_maximum_price`` and pay whatever the market price is.
+to not set ``spot_max_price`` and pay whatever the market price is.
 Your mileage may vary, but at Determined, we have regularly seen 70%
 cost reductions when using V100s, without specifying a
-``spot_maximum_price``.
+``spot_max_price``.

--- a/docs/topic-guides/elastic-infra/aws-spot.txt
+++ b/docs/topic-guides/elastic-infra/aws-spot.txt
@@ -67,15 +67,14 @@ AWS and Determined allow you to specify the maximum price that you are
 willing to pay for a spot instance and, if the market price is above
 that number, the spot instance will not be created until the price falls
 under your maximum price. You can set this value via the
-``spot_max_price`` field in the master configuration. The market
-price being above your ``spot_max_price`` is another reason why
-Determined may not be creating spot instances when you expect it to. If
-this is preventing Determined from creating spot instances, this will be
-visible in the master logs.
+``spot_max_price`` field in the master configuration. The market price
+being above your ``spot_max_price`` is another reason why Determined may
+not be creating spot instances when you expect it to. If this is
+preventing Determined from creating spot instances, this will be visible
+in the master logs.
 
 Many users want to reduce costs by using spot, but have deadlines and
 are not willing to delay their experiments. In this case, it may be best
-to not set ``spot_max_price`` and pay whatever the market price is.
-Your mileage may vary, but at Determined, we have regularly seen 70%
-cost reductions when using V100s, without specifying a
-``spot_max_price``.
+to not set ``spot_max_price`` and pay whatever the market price is. Your
+mileage may vary, but at Determined, we have regularly seen 70% cost
+reductions when using V100s, without specifying a ``spot_max_price``.

--- a/docs/topic-guides/elastic-infra/dynamic-agents-aws.txt
+++ b/docs/topic-guides/elastic-infra/dynamic-agents-aws.txt
@@ -22,6 +22,8 @@ by the Determined master (See :ref:`aws-cluster-configuration`). This
 pair should be unique to your Determined installation. If it is not,
 Determined may inadvertently manage your non-Determined EC2 instances.
 
+If using spot instances, the same holds true for spot instance requests.
+
 EC2 AMIs
 ========
 
@@ -62,6 +64,18 @@ permissions:
 -  ``ec2:TerminateInstances``: used to terminate idle Determined agent
    instances.
 
+If using spot instances, the master also needs the following permissions:
+
+- ``ec2:RequestSpotInstances``: use to provision Determined agent instances 
+  as spot instances.
+
+- ``ec2:CancelSpotInstanceRequests``: used to adjust the number of spot 
+  instance requests to match the number of instances needed for the current 
+  workloads.
+
+- ``ec2:DescribeSpotInstanceRequests``: use to find open spot instance requests 
+  that, once fulfilled, will create Determined agent spot instances.
+
 An example IAM policy with the appropriate permissions is below:
 
 .. code:: json
@@ -76,7 +90,10 @@ An example IAM policy with the appropriate permissions is below:
             "ec2:DescribeInstances",
             "ec2:TerminateInstances",
             "ec2:CreateTags",
-            "ec2:RunInstances"
+            "ec2:RunInstances",
+            "ec2:CancelSpotInstanceRequests",
+            "ec2:RequestSpotInstances",
+            "ec2:DescribeSpotInstanceRequests",
           ],
           "Resource": "*"
         }
@@ -151,6 +168,8 @@ Below you'll find an example configuration. See
        subnet_id: <subnet ID>
      instance_type: p3.8xlarge
      max_instances: 5
+     spot: false
+
 
 **************
  Installation

--- a/docs/topic-guides/elastic-infra/dynamic-agents-aws.txt
+++ b/docs/topic-guides/elastic-infra/dynamic-agents-aws.txt
@@ -64,17 +64,19 @@ permissions:
 -  ``ec2:TerminateInstances``: used to terminate idle Determined agent
    instances.
 
-If using spot instances, the master also needs the following permissions:
+If using spot instances, the master also needs the following
+permissions:
 
-- ``ec2:RequestSpotInstances``: use to provision Determined agent instances 
-  as spot instances.
+-  ``ec2:RequestSpotInstances``: use to provision Determined agent
+   instances as spot instances.
 
-- ``ec2:CancelSpotInstanceRequests``: used to adjust the number of spot 
-  instance requests to match the number of instances needed for the current 
-  workloads.
+-  ``ec2:CancelSpotInstanceRequests``: used to adjust the number of spot
+   instance requests to match the number of instances needed for the
+   current workloads.
 
-- ``ec2:DescribeSpotInstanceRequests``: use to find open spot instance requests 
-  that, once fulfilled, will create Determined agent spot instances.
+-  ``ec2:DescribeSpotInstanceRequests``: use to find open spot instance
+   requests that, once fulfilled, will create Determined agent spot
+   instances.
 
 An example IAM policy with the appropriate permissions is below:
 
@@ -169,7 +171,6 @@ Below you'll find an example configuration. See
      instance_type: p3.8xlarge
      max_instances: 5
      spot: false
-
 
 **************
  Installation

--- a/docs/topic-guides/elastic-infra/dynamic-agents-aws.txt
+++ b/docs/topic-guides/elastic-infra/dynamic-agents-aws.txt
@@ -69,14 +69,14 @@ permissions:
 If using spot instances, the master also needs the following
 permissions:
 
--  ``ec2:RequestSpotInstances``: use to provision Determined agent
+-  ``ec2:RequestSpotInstances``: used to provision Determined agent
    instances as spot instances.
 
 -  ``ec2:CancelSpotInstanceRequests``: used to adjust the number of spot
    instance requests to match the number of instances needed for the
    current workloads.
 
--  ``ec2:DescribeSpotInstanceRequests``: use to find open spot instance
+-  ``ec2:DescribeSpotInstanceRequests``: used to find open spot instance
    requests that, once fulfilled, will create Determined agent spot
    instances.
 

--- a/docs/topic-guides/elastic-infra/dynamic-agents-aws.txt
+++ b/docs/topic-guides/elastic-infra/dynamic-agents-aws.txt
@@ -9,6 +9,10 @@ deployment of Determined with dynamic agents on AWS. See
 :ref:`elastic-infra-index` for an overview of using elastic
 infrastructure in Determined.
 
+Determined is able to launch dynamic agents as spot instances, which can
+be much cheaper than using standard on-demand instances. For more
+details on spot instances, see :ref:`aws-spot`.
+
 *********************
  System Requirements
 *********************

--- a/docs/topic-guides/elastic-infra/dynamic-agents-aws.txt
+++ b/docs/topic-guides/elastic-infra/dynamic-agents-aws.txt
@@ -22,7 +22,9 @@ by the Determined master (See :ref:`aws-cluster-configuration`). This
 pair should be unique to your Determined installation. If it is not,
 Determined may inadvertently manage your non-Determined EC2 instances.
 
-If using spot instances, the same holds true for spot instance requests.
+If using spot instances, Determined also assumes that any EC2 spot
+instance requests with the configured ``tag_key:tag_value`` pair are
+managed by the Determined master.
 
 EC2 AMIs
 ========

--- a/docs/topic-guides/elastic-infra/index.txt
+++ b/docs/topic-guides/elastic-infra/index.txt
@@ -54,5 +54,6 @@ The full list of our topic guides can be found below:
 .. toctree::
    :maxdepth: 1
 
-   dynamic-agents-aws
    dynamic-agents-gcp
+   dynamic-agents-aws
+   aws-spot

--- a/docs/topic-guides/index.txt
+++ b/docs/topic-guides/index.txt
@@ -26,8 +26,9 @@ explanation. Below you will find some suggested starting guides.
 **Elastic Infrastructure**
 
 -  :ref:`elastic-infra-index`
--  :ref:`dynamic-agents-aws`
 -  :ref:`dynamic-agents-gcp`
+-  :ref:`dynamic-agents-aws`
+-  :ref:`aws-spot`
 
 **Model Definitions**
 
@@ -63,8 +64,9 @@ The full list of our topic guides can be found below:
    aws
    gcp
    elastic-infra/index
-   elastic-infra/dynamic-agents-aws
    elastic-infra/dynamic-agents-gcp
+   elastic-infra/dynamic-agents-aws
+   elastic-infra/aws-spot
    terminology-concepts
    tls
    user-interfaces

--- a/master/internal/provisioner/aws.go
+++ b/master/internal/provisioner/aws.go
@@ -410,7 +410,6 @@ func (c *awsCluster) launchInstances(instanceNum int, dryRun bool) (*ec2.Reserva
 	return c.client.RunInstances(input)
 }
 
-
 func (c *awsCluster) terminateInstances(
 	ids []*string,
 ) (*ec2.TerminateInstancesOutput, error) {

--- a/master/internal/provisioner/aws.go
+++ b/master/internal/provisioner/aws.go
@@ -241,8 +241,7 @@ func (c *awsCluster) terminateOnDemand(ctx *actor.Context, instanceIDs []*string
 		return
 	}
 
-	input := &ec2.TerminateInstancesInput{InstanceIds: instanceIDs}
-	res, err := c.client.TerminateInstances(input)
+	res, err := c.terminateInstances(instanceIDs)
 	if err != nil {
 		ctx.Log().WithError(err).Error("cannot terminate EC2 instances")
 		return
@@ -409,4 +408,17 @@ func (c *awsCluster) launchInstances(instanceNum int, dryRun bool) (*ec2.Reserva
 	}
 
 	return c.client.RunInstances(input)
+}
+
+
+func (c *awsCluster) terminateInstances(
+	ids []*string,
+) (*ec2.TerminateInstancesOutput, error) {
+	if len(ids) == 0 {
+		return &ec2.TerminateInstancesOutput{}, nil
+	}
+	input := &ec2.TerminateInstancesInput{
+		InstanceIds: ids,
+	}
+	return c.client.TerminateInstances(input)
 }

--- a/master/internal/provisioner/aws.go
+++ b/master/internal/provisioner/aws.go
@@ -131,7 +131,7 @@ func newAWSCluster(
 		}),
 	}
 
-	if cluster.SpotInstanceEnabled {
+	if cluster.SpotEnabled {
 		cluster.spot = &spotState{
 			trackedReqs:          newSetOfSpotRequests(),
 			approximateClockSkew: time.Second * 0,
@@ -167,13 +167,13 @@ func (c *awsCluster) stateFromEC2State(state *ec2.InstanceState) InstanceState {
 }
 
 func (c *awsCluster) prestart(ctx *actor.Context) {
-	if c.SpotInstanceEnabled {
+	if c.SpotEnabled {
 		c.attemptToApproximateClockSkew(ctx)
 	}
 }
 
 func (c *awsCluster) list(ctx *actor.Context) ([]*Instance, error) {
-	if c.SpotInstanceEnabled {
+	if c.SpotEnabled {
 		return c.listSpot(ctx)
 	}
 	return c.listOnDemand(ctx)
@@ -183,7 +183,7 @@ func (c *awsCluster) launch(
 	ctx *actor.Context,
 	instanceNum int,
 ) {
-	if c.SpotInstanceEnabled {
+	if c.SpotEnabled {
 		c.launchSpot(ctx, instanceNum)
 	} else {
 		c.launchOnDemand(ctx, instanceNum)
@@ -197,7 +197,7 @@ func (c *awsCluster) terminate(ctx *actor.Context, instanceIDs []string) {
 		ids = append(ids, &idCopy)
 	}
 
-	if c.SpotInstanceEnabled {
+	if c.SpotEnabled {
 		c.terminateSpot(ctx, ids)
 	} else {
 		c.terminateOnDemand(ctx, ids)

--- a/master/internal/provisioner/aws_config.go
+++ b/master/internal/provisioner/aws_config.go
@@ -34,7 +34,7 @@ type AWSClusterConfig struct {
 	LogGroup  string `json:"log_group"`
 	LogStream string `json:"log_stream"`
 
-	SpotInstanceEnabled bool   `json:"spot_instance_enabled"`
+	SpotInstanceEnabled bool   `json:"spot"`
 	SpotMaxPrice        string `json:"spot_max_price"`
 }
 

--- a/master/internal/provisioner/aws_config.go
+++ b/master/internal/provisioner/aws_config.go
@@ -34,8 +34,8 @@ type AWSClusterConfig struct {
 	LogGroup  string `json:"log_group"`
 	LogStream string `json:"log_stream"`
 
-	SpotInstanceEnabled bool   `json:"spot"`
-	SpotMaxPrice        string `json:"spot_max_price"`
+	SpotEnabled  bool   `json:"spot"`
+	SpotMaxPrice string `json:"spot_max_price"`
 }
 
 var defaultAWSImageID = map[string]string{
@@ -58,8 +58,8 @@ var defaultAWSClusterConfig = AWSClusterConfig{
 	NetworkInterface: ec2NetworkInterface{
 		PublicIP: true,
 	},
-	InstanceType:        "p3.8xlarge",
-	SpotInstanceEnabled: false,
+	InstanceType: "p3.8xlarge",
+	SpotEnabled:  false,
 }
 
 func (c *AWSClusterConfig) buildDockerLogString() string {
@@ -121,7 +121,7 @@ func (c *AWSClusterConfig) UnmarshalJSON(data []byte) error {
 // Validate implements the check.Validatable interface.
 func (c AWSClusterConfig) Validate() []error {
 	var spotPriceIsNotValidNumberErr error
-	if c.SpotInstanceEnabled && c.SpotMaxPrice != spotPriceNotSetPlaceholder {
+	if c.SpotEnabled && c.SpotMaxPrice != spotPriceNotSetPlaceholder {
 		spotPriceIsNotValidNumberErr = validateMaxSpotPrice(c.SpotMaxPrice)
 	}
 	return []error{


### PR DESCRIPTION
## Description

Add documentation and release notes for spot instances. Also improve some parts of the spot implementation where writing documentation revealed gaps in the implementation. 

Rename the master.yaml field from spot_instance_enabled to spot to better match GCP's preemptible field. 

Add user-facing logging in cases where spot instances can't be created due to AWS capacity constraints or the user setting a spot_max_price that is too low. 

Remove confusing logging when cleaning up spot instances - the API is eventually consistent and we will repeatedly try to clean up spot instances until the API confirms that everything has been terminated. These operations should not produce user facing INFO logs because it leads to confusing output where the logs say the same instance has been terminated dozens of times.

Fix bug where we were trying to terminate instances by using the spot request id instead of the EC2 instance id.

## Test Plan

Tested changes manually.

## Commentary

While writing docs, it became clear that users wouldn't be able to understand Determined + spot with the existing logs.
