### PR TITLE
feat: make spot instances available in det-deploy [DET-4339]

### DIFF
--- a/deploy/determined_deploy/aws/aws.py
+++ b/deploy/determined_deploy/aws/aws.py
@@ -289,14 +289,8 @@ def terminate_running_agents(agent_tag_name: str, boto3_session: boto3.session.S
 
     response = ec2.describe_instances(
         Filters=[
-            {
-                "Name": "tag:Name",
-                "Values": [agent_tag_name],
-            },  # TODO: This does not follow our normal logic for selecting instances managed by Determined
-            {
-                "Name": "instance-state-name",
-                "Values": ["running"],
-            },  # TODO: Shouldn't this catch instances that are spinning up?
+            {"Name": "tag:Name", "Values": [agent_tag_name]},
+            {"Name": "instance-state-name", "Values": ["running", "pending"]},
         ]
     )
 

--- a/deploy/determined_deploy/aws/aws.py
+++ b/deploy/determined_deploy/aws/aws.py
@@ -328,19 +328,19 @@ def list_spot_requests_for_stack(
     response = ec2.describe_spot_instance_requests(
         Filters=[
             {"Name": f"tag:{tag_key}", "Values": [tag_val]},
-            {"Name": f"state", "Values": ["open", "active"]},
+            {"Name": "state", "Values": ["open", "active"]},
         ]
     )
     spot_requests = response["SpotInstanceRequests"]
     reqs = []
     for s in spot_requests:
-        req = dict(
-            id=s["SpotInstanceRequestId"],
-            state=s["State"],
-            statusCode=s["Status"]["Code"],
-            statusMessage=s["Status"]["Message"],
-            instanceId=s.get("InstanceId", None),
-        )
+        req = {
+            "id": s["SpotInstanceRequestId"],
+            "state": s["State"],
+            "statusCode": s["Status"]["Code"],
+            "statusMessage": s["Status"]["Message"],
+            "instanceId": s.get("InstanceId", None),
+        }
         reqs.append(req)
     return reqs
 

--- a/deploy/determined_deploy/aws/aws.py
+++ b/deploy/determined_deploy/aws/aws.py
@@ -373,7 +373,7 @@ def delete_spot_requests_and_agents(
 
 def clean_up_spot(
     stack_name: str, boto3_session: boto3.session.Session, disable_tqdm: bool = False
-):
+) -> None:
 
     # The spot API is eventually consistent and the only way to guarantee
     # that we don't leave any spot requests alive (that may eventually be
@@ -393,7 +393,7 @@ def clean_up_spot(
         bar_format=format_str,
         disable=disable_tqdm,
     )
-    progress_bar_state = 0
+    progress_bar_state = 0.0
     while True:
         elapsed_time = time.time() - start_time
         if elapsed_time >= SPOT_WAIT_SECONDS:

--- a/deploy/determined_deploy/aws/aws.py
+++ b/deploy/determined_deploy/aws/aws.py
@@ -310,7 +310,7 @@ def terminate_running_agents(agent_tag_name: str, boto3_session: boto3.session.S
 
 
 # EC2 Spot
-def list_spot_requests_for_stack(stack_name: str, boto3_session: boto3.session.Session):  # TODO: Add return type
+def list_spot_requests_for_stack(stack_name: str, boto3_session: boto3.session.Session) -> List[Dict]:
     tag_key, tag_val = get_management_tag_key_value(stack_name)
     ec2 = boto3_session.client("ec2")
     response = ec2.describe_spot_instance_requests(
@@ -333,7 +333,7 @@ def list_spot_requests_for_stack(stack_name: str, boto3_session: boto3.session.S
             state=s["State"],
             statusCode=s["Status"]["Code"],
             statusMessage=s["Status"]["Message"],
-            instanceId=s.get("InstanceId", None),  # TODO: Test this doesn't fail if there isn't an associated spot instance
+            instanceId=s.get("InstanceId", None),
         )
         reqs.append(req)
     return reqs
@@ -349,7 +349,7 @@ def delete_spot_requests_and_agents(stack_name: str, boto3_session: boto3.sessio
     the spot requests.
 
     Returns the list of instance_ids that were deleted so at the end of spot
-    cleanup, we have wait until all instances have been terminated.
+    cleanup, we can wait until all instances have been terminated.
     """
     spot_reqs = list_spot_requests_for_stack(stack_name, boto3_session)
     instances_to_del = []
@@ -434,13 +434,3 @@ def empty_bucket(bucket_name: str, boto3_session: boto3.session.Session) -> None
     except ClientError as e:
         if e.response["Error"]["Code"] != "NoSuchBucket":
             raise e
-
-
-
-if __name__ == '__main__':
-    REGION = "us-east-1"
-    STACK_NAME = "armand-spot-det-deploy-3"
-    # STACK_NAME = "armand-0-13-6"
-    boto3_session = boto3.Session(region_name=REGION)
-
-    clean_up_spot(STACK_NAME, boto3_session)

--- a/deploy/determined_deploy/aws/aws.py
+++ b/deploy/determined_deploy/aws/aws.py
@@ -1,5 +1,7 @@
 import sys
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Tuple
+import time
+import tqdm
 
 import boto3
 from botocore.exceptions import ClientError, WaiterError
@@ -55,9 +57,14 @@ def delete(stack_name: str, boto3_session: boto3.session.Session) -> None:
 
     # Second, terminate the agents so nothing can write to the checkpoint bucket. We create agent
     # instances outside of cloudformation, so we have to manually terminate them.
-    print("Terminating Running Agents")
-    terminate_running_agents(stack_output[constants.cloudformation.AGENT_TAG_NAME], boto3_session)
-    print("Agents Terminated")
+    if stack_uses_spot(stack_name, boto3_session):
+        print("Terminating Running Agents and Pending Spot Requests")
+        clean_up_spot(stack_name, boto3_session)
+        print("Agents and Spot Requests Terminated")
+    else:
+        print("Terminating Running Agents")
+        terminate_running_agents(stack_output[constants.cloudformation.AGENT_TAG_NAME], boto3_session)
+        print("Agents Terminated")
 
     # Third, empty the bucket that was created for this stack.
     bucket_name = get_output(stack_name, boto3_session).get(
@@ -118,7 +125,11 @@ def update_stack(
     stack_output = get_output(stack_name, boto3_session)
 
     stop_master(stack_output[constants.cloudformation.MASTER_ID], boto3_session)
-    terminate_running_agents(stack_output[constants.cloudformation.AGENT_TAG_NAME], boto3_session)
+
+    if stack_uses_spot(stack_name, boto3_session):
+        clean_up_spot(stack_name, boto3_session, disable_tqdm=True)
+    else:
+        terminate_running_agents(stack_output[constants.cloudformation.AGENT_TAG_NAME], boto3_session)
 
     try:
         if parameters:
@@ -188,6 +199,36 @@ def get_output(stack_name: str, boto3_session: boto3.session.Session) -> Dict[st
     return response_dict
 
 
+def get_params(stack_name: str, boto3_session: boto3.session.Session) -> Dict[str, str]:
+    cfn = boto3_session.client("cloudformation")
+    response = cfn.describe_stacks(StackName=stack_name)
+    response_dict = {}
+    params = response["Stacks"][0]["Parameters"]
+    for param_obj in params:
+        k = param_obj["ParameterKey"]
+        v = param_obj["ParameterValue"]
+        response_dict[k] = v
+    return response_dict
+
+
+def stack_uses_spot(stack_name: str, boto3_session: boto3.session.Session) -> bool:
+    params = get_params(stack_name, boto3_session)
+    if constants.cloudformation.SPOT_ENABLED not in params.keys():
+        return False
+
+    spot_enabled_str_val = params[constants.cloudformation.SPOT_ENABLED]
+    if spot_enabled_str_val.lower() == 'true':
+        return True
+    else:
+        return False
+
+
+def get_management_tag_key_value(stack_name: str) -> Tuple[str, str]:
+    tag_key = f"det-{stack_name}"
+    tag_val = f"det-agent-{stack_name}"
+    return tag_key, tag_val
+
+
 def deploy_stack(
     stack_name: str,
     template_body: str,
@@ -244,8 +285,8 @@ def terminate_running_agents(agent_tag_name: str, boto3_session: boto3.session.S
 
     response = ec2.describe_instances(
         Filters=[
-            {"Name": "tag:Name", "Values": [agent_tag_name]},
-            {"Name": "instance-state-name", "Values": ["running"]},
+            {"Name": "tag:Name", "Values": [agent_tag_name]},  # TODO: This does not follow our normal logic for selecting instances managed by Determined
+            {"Name": "instance-state-name", "Values": ["running"]},  # TODO: Shouldn't this catch instances that are spinning up?
         ]
     )
 
@@ -268,6 +309,121 @@ def terminate_running_agents(agent_tag_name: str, boto3_session: boto3.session.S
                     raise e
 
 
+# EC2 Spot
+def list_spot_requests_for_stack(stack_name: str, boto3_session: boto3.session.Session):  # TODO: Add return type
+    tag_key, tag_val = get_management_tag_key_value(stack_name)
+    ec2 = boto3_session.client("ec2")
+    response = ec2.describe_spot_instance_requests(
+        Filters=[
+            {
+                'Name': f'tag:{tag_key}',
+                'Values': [tag_val]
+            },
+            {
+                'Name': f'state',
+                'Values': ['open', 'active']
+            }
+        ]
+    )
+    spot_requests = response["SpotInstanceRequests"]
+    reqs = []
+    for s in spot_requests:
+        req = dict(
+            id=s["SpotInstanceRequestId"],
+            state=s["State"],
+            statusCode=s["Status"]["Code"],
+            statusMessage=s["Status"]["Message"],
+            instanceId=s.get("InstanceId", None),  # TODO: Test this doesn't fail if there isn't an associated spot instance
+        )
+        reqs.append(req)
+    return reqs
+
+
+
+
+def delete_spot_requests_and_agents(stack_name: str, boto3_session: boto3.session.Session) -> List[str]:
+    """
+    List all spot requests. Any requests that have an associated instance,
+    terminate the instances (this will automatically cancel the spot
+    request). Any requests that do not have an associated instance, cancel
+    the spot requests.
+
+    Returns the list of instance_ids that were deleted so at the end of spot
+    cleanup, we have wait until all instances have been terminated.
+    """
+    spot_reqs = list_spot_requests_for_stack(stack_name, boto3_session)
+    instances_to_del = []
+    requests_to_term = []
+    for req in spot_reqs:
+        if req["instanceId"] is not None:
+            instances_to_del.append(req["instanceId"])
+        else:
+            requests_to_term.append(req["id"])
+
+    ec2 = boto3_session.client("ec2")
+
+    if len(instances_to_del) > 0:
+        ec2.terminate_instances(InstanceIds=instances_to_del)
+
+    if len(requests_to_term) > 0:
+        ec2.cancel_spot_instance_requests(SpotInstanceRequestIds=requests_to_term)
+
+    return instances_to_del
+
+
+def clean_up_spot(stack_name: str, boto3_session: boto3.session.Session, disable_tqdm: bool = False):
+
+    # The spot API is eventually consistent and the only way to guarantee
+    # that we don't leave any spot requests alive (that may eventually be
+    # fulfilled and lead to running EC2 instances) is to wait a long enough
+    # period that any created spot requests will have shown up in the API.
+    # 60 seconds seems like a relatively safe amount of time.
+    SPOT_WAIT_SECONDS = 60
+
+    start_time = time.time()
+
+    all_terminated_instance_ids = set()
+
+    format_str = '{l_bar}{bar}| (remaining time: {remaining})'
+    pbar = tqdm.tqdm(total=SPOT_WAIT_SECONDS,
+                     desc="Cleaning up spot instances and spot instance requests",
+                     bar_format=format_str, disable=disable_tqdm)
+    progress_bar_state = 0
+    while True:
+        elapsed_time = time.time() - start_time
+        if elapsed_time >= SPOT_WAIT_SECONDS:
+            pbar.update(SPOT_WAIT_SECONDS - progress_bar_state)  # Exit TQDM with it showing 100%
+            pbar.close()
+            break
+
+        tqdm_update = elapsed_time - progress_bar_state
+        pbar.update(tqdm_update)
+        progress_bar_state = elapsed_time
+
+        instance_ids = delete_spot_requests_and_agents(stack_name, boto3_session)
+        for i in instance_ids:
+            all_terminated_instance_ids.add(i)
+
+    # Final cleanup
+    instance_ids = delete_spot_requests_and_agents(stack_name, boto3_session)
+    for i in instance_ids:
+        all_terminated_instance_ids.add(i)
+
+    if len(instance_ids) > 0:
+        ec2 = boto3_session.client("ec2")
+        waiter = ec2.get_waiter("instance_terminated")
+        for n in range(NUM_WAITS):
+            print("Waiting For Spot Agents To Terminate")
+            try:
+                waiter.wait(InstanceIds=instance_ids, WaiterConfig={"Delay": 10})
+                break
+            except WaiterError as e:
+                if n == NUM_WAITS - 1:
+                    raise e
+
+
+
+
 # S3
 def empty_bucket(bucket_name: str, boto3_session: boto3.session.Session) -> None:
     s3 = boto3_session.resource("s3")
@@ -278,3 +434,13 @@ def empty_bucket(bucket_name: str, boto3_session: boto3.session.Session) -> None
     except ClientError as e:
         if e.response["Error"]["Code"] != "NoSuchBucket":
             raise e
+
+
+
+if __name__ == '__main__':
+    REGION = "us-east-1"
+    STACK_NAME = "armand-spot-det-deploy-3"
+    # STACK_NAME = "armand-0-13-6"
+    boto3_session = boto3.Session(region_name=REGION)
+
+    clean_up_spot(STACK_NAME, boto3_session)

--- a/deploy/determined_deploy/aws/cli.py
+++ b/deploy/determined_deploy/aws/cli.py
@@ -1,7 +1,7 @@
 import argparse
 import re
 import sys
-from typing import Dict, Type, Union, Callable
+from typing import Callable, Dict, Type, Union
 
 import boto3
 
@@ -17,7 +17,9 @@ def validate_spot_max_price() -> Callable:
             if not (char.isdigit() or char == "."):
                 raise argparse.ArgumentTypeError("must only contain digits and a decimal point")
         return s
+
     return validate
+
 
 def make_down_subparser(subparsers: argparse._SubParsersAction) -> None:
     subparser = subparsers.add_parser("down", help="delete CloudFormation stack")

--- a/deploy/determined_deploy/aws/cli.py
+++ b/deploy/determined_deploy/aws/cli.py
@@ -197,7 +197,7 @@ def deploy_aws(args: argparse.Namespace) -> None:
         constants.cloudformation.MAX_AGENT_STARTING_PERIOD: args.max_agent_starting_period,
         constants.cloudformation.MIN_DYNAMIC_AGENTS: args.min_dynamic_agents,
         constants.cloudformation.MAX_DYNAMIC_AGENTS: args.max_dynamic_agents,
-        constants.cloudformation.SPOT_ENABLED: str(args.spot).lower(),
+        constants.cloudformation.SPOT_ENABLED: args.spot,
         constants.cloudformation.SPOT_MAX_PRICE: args.spot_max_price,
     }
 

--- a/deploy/determined_deploy/aws/cli.py
+++ b/deploy/determined_deploy/aws/cli.py
@@ -185,7 +185,7 @@ def deploy_aws(args: argparse.Namespace) -> None:
 
     det_configs = {
         constants.cloudformation.KEYPAIR: args.keypair,
-        constants.cloudformation.ENABLE_CORS: args.enable_cors,  # TODO: Has this been tested? Based on spot handling of bools, I wouldn't expect this to work correctly...
+        constants.cloudformation.ENABLE_CORS: args.enable_cors,
         constants.cloudformation.MASTER_INSTANCE_TYPE: args.master_instance_type,
         constants.cloudformation.AGENT_INSTANCE_TYPE: args.agent_instance_type,
         constants.cloudformation.CLUSTER_ID: args.cluster_id,

--- a/deploy/determined_deploy/aws/cli.py
+++ b/deploy/determined_deploy/aws/cli.py
@@ -183,7 +183,7 @@ def deploy_aws(args: argparse.Namespace) -> None:
 
     det_configs = {
         constants.cloudformation.KEYPAIR: args.keypair,
-        constants.cloudformation.ENABLE_CORS: args.enable_cors,
+        constants.cloudformation.ENABLE_CORS: args.enable_cors,  # TODO: Has this been tested? Based on spot handling of bools, I wouldn't expect this to work correctly...
         constants.cloudformation.MASTER_INSTANCE_TYPE: args.master_instance_type,
         constants.cloudformation.AGENT_INSTANCE_TYPE: args.agent_instance_type,
         constants.cloudformation.CLUSTER_ID: args.cluster_id,
@@ -195,7 +195,7 @@ def deploy_aws(args: argparse.Namespace) -> None:
         constants.cloudformation.MAX_AGENT_STARTING_PERIOD: args.max_agent_starting_period,
         constants.cloudformation.MIN_DYNAMIC_AGENTS: args.min_dynamic_agents,
         constants.cloudformation.MAX_DYNAMIC_AGENTS: args.max_dynamic_agents,
-        constants.cloudformation.SPOT_ENABLED: args.spot,
+        constants.cloudformation.SPOT_ENABLED: str(args.spot).lower(),
         constants.cloudformation.SPOT_MAX_PRICE: args.spot_max_price,
     }
 

--- a/deploy/determined_deploy/aws/cli.py
+++ b/deploy/determined_deploy/aws/cli.py
@@ -199,8 +199,6 @@ def deploy_aws(args: argparse.Namespace) -> None:
         constants.cloudformation.SPOT_MAX_PRICE: args.spot_max_price,
     }
 
-    print(det_configs)
-
     deployment_object = deployment_type_map[args.deployment_type](det_configs)
 
     if args.dry_run:

--- a/deploy/determined_deploy/aws/constants.py
+++ b/deploy/determined_deploy/aws/constants.py
@@ -42,6 +42,8 @@ class cloudformation:
     MAX_DYNAMIC_AGENTS = "MaxDynamicAgents"
     LOG_GROUP = "LogGroup"
     REGION = "Region"
+    SPOT_ENABLED = "SpotEnabled"
+    SPOT_MAX_PRICE = "SpotMaxPrice"
 
 
 class misc:

--- a/deploy/determined_deploy/aws/deployment_types/secure.py
+++ b/deploy/determined_deploy/aws/deployment_types/secure.py
@@ -32,6 +32,8 @@ class Secure(base.DeterminedDeployment):
         constants.cloudformation.MAX_IDLE_AGENT_PERIOD,
         constants.cloudformation.MAX_AGENT_STARTING_PERIOD,
         constants.cloudformation.MAX_DYNAMIC_AGENTS,
+        constants.cloudformation.SPOT_ENABLED,
+        constants.cloudformation.SPOT_MAX_PRICE,
     ]
 
     def deploy(self) -> None:

--- a/deploy/determined_deploy/aws/deployment_types/simple.py
+++ b/deploy/determined_deploy/aws/deployment_types/simple.py
@@ -26,6 +26,8 @@ class Simple(base.DeterminedDeployment):
         constants.cloudformation.MAX_IDLE_AGENT_PERIOD,
         constants.cloudformation.MAX_AGENT_STARTING_PERIOD,
         constants.cloudformation.MAX_DYNAMIC_AGENTS,
+        constants.cloudformation.SPOT_ENABLED,
+        constants.cloudformation.SPOT_MAX_PRICE,
     ]
 
     def deploy(self) -> None:

--- a/deploy/determined_deploy/aws/deployment_types/vpc.py
+++ b/deploy/determined_deploy/aws/deployment_types/vpc.py
@@ -25,6 +25,8 @@ class VPC(base.DeterminedDeployment):
         constants.cloudformation.MAX_IDLE_AGENT_PERIOD,
         constants.cloudformation.MAX_AGENT_STARTING_PERIOD,
         constants.cloudformation.MAX_DYNAMIC_AGENTS,
+        constants.cloudformation.SPOT_ENABLED,
+        constants.cloudformation.SPOT_MAX_PRICE,
     ]
 
     def deploy(self) -> None:

--- a/deploy/determined_deploy/aws/templates/efs.yaml
+++ b/deploy/determined_deploy/aws/templates/efs.yaml
@@ -606,7 +606,7 @@ Resources:
               min_instances: ${MinDynamicAgents}
               max_instances: ${MaxDynamicAgents}
               spot_instance_enabled: ${SpotEnabled}
-              spot_max_price: ${SpotMaxPrice}
+              spot_max_price: "${SpotMaxPrice}"
               network_interface:
                 public_ip: true
                 security_group_id: ${AgentSecurityGroup.GroupId}

--- a/deploy/determined_deploy/aws/templates/efs.yaml
+++ b/deploy/determined_deploy/aws/templates/efs.yaml
@@ -99,6 +99,18 @@ Parameters:
     Description: Maximum number of agents to launch simultaneously
     Default: 5
 
+  SpotEnabled:
+    Type: String
+    Description: Whether to use spot instances or not
+    Default: false
+
+  SpotMaxPrice:
+    Type: String
+    Description: |
+      The maximum hourly price you are willing to pay for the spot instance.
+      Should be a number without a currency option, e.g. "5.00"
+    Default: ''
+
   EnableCORS:
     Type: String
     Description: Whether to allow CORS requests or not
@@ -593,6 +605,8 @@ Resources:
               max_agent_starting_period: ${MaxAgentStartingPeriod}
               min_instances: ${MinDynamicAgents}
               max_instances: ${MaxDynamicAgents}
+              spot_instance_enabled: ${SpotEnabled}
+              spot_max_price: ${SpotMaxPrice}
               network_interface:
                 public_ip: true
                 security_group_id: ${AgentSecurityGroup.GroupId}

--- a/deploy/determined_deploy/aws/templates/efs.yaml
+++ b/deploy/determined_deploy/aws/templates/efs.yaml
@@ -605,7 +605,7 @@ Resources:
               max_agent_starting_period: ${MaxAgentStartingPeriod}
               min_instances: ${MinDynamicAgents}
               max_instances: ${MaxDynamicAgents}
-              spot_instance_enabled: ${SpotEnabled}
+              spot: ${SpotEnabled}
               spot_max_price: "${SpotMaxPrice}"
               network_interface:
                 public_ip: true

--- a/deploy/determined_deploy/aws/templates/fsx.yaml
+++ b/deploy/determined_deploy/aws/templates/fsx.yaml
@@ -624,7 +624,7 @@ Resources:
               min_instances: ${MinDynamicAgents}
               max_instances: ${MaxDynamicAgents}
               spot_instance_enabled: ${SpotEnabled}
-              spot_max_price: ${SpotMaxPrice}
+              spot_max_price: "${SpotMaxPrice}"
               network_interface:
                 public_ip: true
                 security_group_id: ${AgentSecurityGroup.GroupId}

--- a/deploy/determined_deploy/aws/templates/fsx.yaml
+++ b/deploy/determined_deploy/aws/templates/fsx.yaml
@@ -98,6 +98,18 @@ Parameters:
     Description: Maximum number of agents to launch simultaneously
     Default: 5
 
+  SpotEnabled:
+    Type: String
+    Description: Whether to use spot instances or not
+    Default: false
+
+  SpotMaxPrice:
+    Type: String
+    Description: |
+      The maximum hourly price you are willing to pay for the spot instance.
+      Should be a number without a currency option, e.g. "5.00"
+    Default: ''
+
   EnableCORS:
     Type: String
     Description: Whether to allow CORS requests or not
@@ -611,6 +623,8 @@ Resources:
               max_agent_starting_period: ${MaxAgentStartingPeriod}
               min_instances: ${MinDynamicAgents}
               max_instances: ${MaxDynamicAgents}
+              spot_instance_enabled: ${SpotEnabled}
+              spot_max_price: ${SpotMaxPrice}
               network_interface:
                 public_ip: true
                 security_group_id: ${AgentSecurityGroup.GroupId}

--- a/deploy/determined_deploy/aws/templates/fsx.yaml
+++ b/deploy/determined_deploy/aws/templates/fsx.yaml
@@ -623,7 +623,7 @@ Resources:
               max_agent_starting_period: ${MaxAgentStartingPeriod}
               min_instances: ${MinDynamicAgents}
               max_instances: ${MaxDynamicAgents}
-              spot_instance_enabled: ${SpotEnabled}
+              spot: ${SpotEnabled}
               spot_max_price: "${SpotMaxPrice}"
               network_interface:
                 public_ip: true

--- a/deploy/determined_deploy/aws/templates/secure.yaml
+++ b/deploy/determined_deploy/aws/templates/secure.yaml
@@ -119,6 +119,18 @@ Parameters:
     Description: Maximum number of agents to launch simultaneously
     Default: 5
 
+  SpotEnabled:
+    Type: String
+    Description: Whether to use spot instances or not
+    Default: false
+
+  SpotMaxPrice:
+    Type: String
+    Description: |
+      The maximum hourly price you are willing to pay for the spot instance.
+      Should be a number without a currency option, e.g. "5.00"
+    Default: ''
+
   EnableCORS:
     Type: String
     Description: Whether to allow CORS requests or not
@@ -642,6 +654,8 @@ Resources:
               max_agent_starting_period: ${MaxAgentStartingPeriod}
               min_instances: ${MinDynamicAgents}
               max_instances: ${MaxDynamicAgents}
+              spot_instance_enabled: ${SpotEnabled}
+              spot_max_price: ${SpotMaxPrice}
               network_interface:
                 public_ip: false
                 security_group_id: ${AgentSecurityGroup.GroupId}

--- a/deploy/determined_deploy/aws/templates/secure.yaml
+++ b/deploy/determined_deploy/aws/templates/secure.yaml
@@ -654,7 +654,7 @@ Resources:
               max_agent_starting_period: ${MaxAgentStartingPeriod}
               min_instances: ${MinDynamicAgents}
               max_instances: ${MaxDynamicAgents}
-              spot_instance_enabled: ${SpotEnabled}
+              spot: ${SpotEnabled}
               spot_max_price: "${SpotMaxPrice}"
               network_interface:
                 public_ip: false

--- a/deploy/determined_deploy/aws/templates/secure.yaml
+++ b/deploy/determined_deploy/aws/templates/secure.yaml
@@ -655,7 +655,7 @@ Resources:
               min_instances: ${MinDynamicAgents}
               max_instances: ${MaxDynamicAgents}
               spot_instance_enabled: ${SpotEnabled}
-              spot_max_price: ${SpotMaxPrice}
+              spot_max_price: "${SpotMaxPrice}"
               network_interface:
                 public_ip: false
                 security_group_id: ${AgentSecurityGroup.GroupId}

--- a/deploy/determined_deploy/aws/templates/simple.yaml
+++ b/deploy/determined_deploy/aws/templates/simple.yaml
@@ -443,7 +443,7 @@ Resources:
               max_agent_starting_period: ${MaxAgentStartingPeriod}
               min_instances: ${MinDynamicAgents}
               max_instances: ${MaxDynamicAgents}
-              spot_instance_enabled: ${SpotEnabled}
+              spot: ${SpotEnabled}
               spot_max_price: "${SpotMaxPrice}"
               network_interface:
                 public_ip: true

--- a/deploy/determined_deploy/aws/templates/simple.yaml
+++ b/deploy/determined_deploy/aws/templates/simple.yaml
@@ -444,7 +444,7 @@ Resources:
               min_instances: ${MinDynamicAgents}
               max_instances: ${MaxDynamicAgents}
               spot_instance_enabled: ${SpotEnabled}
-              spot_max_price: ${SpotMaxPrice}
+              spot_max_price: "${SpotMaxPrice}"
               network_interface:
                 public_ip: true
                 security_group_id: ${AgentSecurityGroup.GroupId}

--- a/deploy/determined_deploy/aws/templates/simple.yaml
+++ b/deploy/determined_deploy/aws/templates/simple.yaml
@@ -90,6 +90,18 @@ Parameters:
     Description: Whether to allow CORS requests or not
     Default: false
 
+  SpotEnabled:
+    Type: String
+    Description: Whether to use spot instances or not
+    Default: false
+
+  SpotMaxPrice:
+    Type: String
+    Description: |
+                 The maximum hourly price you are willing to pay for the spot instance.
+                 Should be a number without a currency option, e.g. "5.00"
+    Default: ''
+
 Resources:
   CheckpointBucket:
     Type: AWS::S3::Bucket
@@ -431,6 +443,8 @@ Resources:
               max_agent_starting_period: ${MaxAgentStartingPeriod}
               min_instances: ${MinDynamicAgents}
               max_instances: ${MaxDynamicAgents}
+              spot_instance_enabled: ${SpotEnabled}
+              spot_max_price: ${SpotMaxPrice}
               network_interface:
                 public_ip: true
                 security_group_id: ${AgentSecurityGroup.GroupId}

--- a/deploy/determined_deploy/aws/templates/vpc.yaml
+++ b/deploy/determined_deploy/aws/templates/vpc.yaml
@@ -99,6 +99,18 @@ Parameters:
     Description: Maximum number of agents to launch simultaneously
     Default: 5
 
+  SpotEnabled:
+    Type: String
+    Description: Whether to use spot instances or not
+    Default: false
+
+  SpotMaxPrice:
+    Type: String
+    Description: |
+      The maximum hourly price you are willing to pay for the spot instance.
+      Should be a number without a currency option, e.g. "5.00"
+    Default: ''
+
   EnableCORS:
     Type: String
     Description: Whether to allow CORS requests or not
@@ -554,6 +566,8 @@ Resources:
               max_agent_starting_period: ${MaxAgentStartingPeriod}
               min_instances: ${MinDynamicAgents}
               max_instances: ${MaxDynamicAgents}
+              spot_instance_enabled: ${SpotEnabled}
+              spot_max_price: ${SpotMaxPrice}
               network_interface:
                 public_ip: true
                 security_group_id: ${AgentSecurityGroup.GroupId}

--- a/deploy/determined_deploy/aws/templates/vpc.yaml
+++ b/deploy/determined_deploy/aws/templates/vpc.yaml
@@ -567,7 +567,7 @@ Resources:
               min_instances: ${MinDynamicAgents}
               max_instances: ${MaxDynamicAgents}
               spot_instance_enabled: ${SpotEnabled}
-              spot_max_price: ${SpotMaxPrice}
+              spot_max_price: "${SpotMaxPrice}"
               network_interface:
                 public_ip: true
                 security_group_id: ${AgentSecurityGroup.GroupId}

--- a/deploy/determined_deploy/aws/templates/vpc.yaml
+++ b/deploy/determined_deploy/aws/templates/vpc.yaml
@@ -566,7 +566,7 @@ Resources:
               max_agent_starting_period: ${MaxAgentStartingPeriod}
               min_instances: ${MinDynamicAgents}
               max_instances: ${MaxDynamicAgents}
-              spot_instance_enabled: ${SpotEnabled}
+              spot: ${SpotEnabled}
               spot_max_price: "${SpotMaxPrice}"
               network_interface:
                 public_ip: true

--- a/deploy/setup.py
+++ b/deploy/setup.py
@@ -24,6 +24,7 @@ setup(
         # botocore>1.19.0 has stricter urllib3 requirements than boto3, and pip will not reliably
         # resolve it until the --use-feature=2020-resolver behavior in pip 20.3, so we list it here.
         "urllib3>=1.25.4,<1.26",
+        "tqdm",
     ],
     entry_points={"console_scripts": ["det-deploy = determined_deploy.__main__:main"]},
 )

--- a/docs/how-to/installation/aws.txt
+++ b/docs/how-to/installation/aws.txt
@@ -189,9 +189,11 @@ Spinning up the Cluster
       -  False
 
    -  -  ``--spot-max-price``
-      -  A maximum price for the spot instances. If the price
-         on the spot market exceeds this value, Determined will
-         not create new instances. Optional
+
+      -  A maximum price for the spot instances. If the price on the
+         spot market exceeds this value, Determined will not create new
+         instances. Optional
+
       -  The on-demand price for the instance type.
 
    -  -  ``--dry-run``

--- a/docs/how-to/installation/aws.txt
+++ b/docs/how-to/installation/aws.txt
@@ -184,6 +184,16 @@ Spinning up the Cluster
       -  Maximum number of dynamic agent instances at one time.
       -  5
 
+   -  -  ``--spot``
+      -  Use spot instances.
+      -  False
+
+   -  -  ``--spot-max-price``
+      -  A maximum price for the spot instances. If the price
+         on the spot market exceeds this value, Determined will
+         not create new instances. Optional
+      -  The on-demand price for the instance type.
+
    -  -  ``--dry-run``
       -  Print the template but do not execute it.
       -  False


### PR DESCRIPTION
## Description

Make spot instances available via det-deploy

## Test Plan

Manually test with simple configuration.


## Commentary (optional)

Tearing down agents is a little more complicated with spot instances. The spot API is eventually consistent so if we clean up all requests naively, there could be additional requests that exist, but just haven't become visible in the API. Requests usually show up after around 20-40 seconds (more or less), so 60 seconds seems like a safe amount of time.

## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.

This is part of the overall spot instance release so there are no specific release notes as part of this PR.
