### PR TITLE
chore: propagate horovod worker process retcode

### DIFF
--- a/harness/determined/exec/worker_process_wrapper.py
+++ b/harness/determined/exec/worker_process_wrapper.py
@@ -25,7 +25,7 @@ def run_all(ts: List[threading.Thread]) -> None:
         t.join()
 
 
-def main() -> None:
+def main() -> int:
     rank = os.environ.get("HOROVOD_RANK")
     proc = subprocess.Popen(
         [
@@ -47,6 +47,8 @@ def main() -> None:
             ]
         )
 
+    return proc.returncode
+
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())


### PR DESCRIPTION
## Description
The change propagates the horovod worker process's retcode through the worker process wrapper that is responsible for redirecting its stdout/stderr and starting it so, to horovod, it is still as if it ran the worker process directly.
<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan
- [ ] make sure the "horovod detected worker process exited.." message is present for failing processes
<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.
-->

## Commentary
Noticed peeking at CI failures.

[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234