### PR TITLE
fix: fix out of order boundary check [DET-4422]

### DIFF
--- a/master/internal/api.go
+++ b/master/internal/api.go
@@ -46,10 +46,14 @@ func (a *apiServer) paginate(p **apiv1.Pagination, values interface{}, offset, l
 		EndIndex:   endIndex,
 		Total:      total,
 	}
-	rv.Elem().Set(rv.Elem().Slice(int(startIndex), int(endIndex)))
-	return grpc.ValidateRequest(
+	err := grpc.ValidateRequest(
 		func() (bool, string) { return 0 <= startIndex && startIndex <= total, "offset out of bounds" },
 	)
+	if err != nil {
+		return err
+	}
+	rv.Elem().Set(rv.Elem().Slice(int(startIndex), int(endIndex)))
+	return nil
 }
 
 // sort sorts the provided slice in place. The second parameter denotes whether sorting should be


### PR DESCRIPTION
## Description

from 
`{"error":{"code":13,"reason":"Internal","error":"reflect.Value.Slice: slice index out of bounds"}}`
to 
`{"error":{"code":3,"reason":"InvalidArgument","error":"offset out of bounds"}}`

<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234