### PR TITLE
build: add a pre-release script [DET-4414]

### DIFF
--- a/proto/Makefile
+++ b/proto/Makefile
@@ -50,7 +50,9 @@ $(swagger_out): $(source_files) build/swagger
 
 # Update buf image for breaking change check.
 .PHONY: gen-buf-image
-gen-buf-image:
+gen-buf-image: check
+	# disallow untracked or dirty files.
+	test -z "$(shell git status --porcelain)"
 	buf image build -o $(buf_image)
 
 .PHONY: check

--- a/tools/scripts/README.md
+++ b/tools/scripts/README.md
@@ -40,7 +40,6 @@ be registered in the determined repo. Here is the process:
    in the repository, replacing the `old` values with the `new` values for
    every image type identified in `bumpenvs.yaml`.
 
-
 ## `gen-attributions.py`: Automated OSS Compliance
 
 OSS License compliance is is important for being good OSS citizens and it is
@@ -83,3 +82,10 @@ The relevant metadata are:
 * `Webui`: boolean indicating if this is a dependency of the WebUI
 
 For instructions on how to use `gen-attributions.py`, just run it with no arguments.
+
+## `lock-api-state.sh`: Lock-in current API state
+
+We use [buf.build](https://docs.buf.build/) to provide backward compatibility check
+for API changes in Determined. By running this script on each release, we store a
+snapshot of the API state and on each following change `buf` compares the new state
+with the old to ensure that backward compatibility is preserved.

--- a/tools/scripts/lock-api-state.sh
+++ b/tools/scripts/lock-api-state.sh
@@ -1,8 +1,7 @@
 #!/bin/bash -ex
 
-## Pre release hook. Run from the root of the project. Any arguments passed in are directly
-## sent to `bumpversion`
-
+# Buf image binary
+BUF_IMAGE=buf.image.bin
 PROJECT_ROOT=$(pwd)
 
 if [[ $(git diff --shortstat 2> /dev/null | tail -n1) != "" ]]; then
@@ -14,13 +13,9 @@ elif [[ $(git status --porcelain 2>/dev/null| grep "^??") ]]; then
 fi
 
 ## lock in current protobuf state
-# Buf image binary
-BUF_IMAGE=buf.image.bin
 cd proto
+make check
 make gen-buf-image
 git add $BUF_IMAGE
-git commit -m "lock backward buf compatibility check" || echo "buf image is already up to date"
+git commit -m "chore: lock api state for backward compatibility check" || echo "buf image is already up to date"
 cd $PROJECT_ROOT
-
-## bump version
-bumpversion $@

--- a/tools/scripts/lock-api-state.sh
+++ b/tools/scripts/lock-api-state.sh
@@ -1,12 +1,12 @@
 #!/bin/bash -ex
 
-# Buf image binary
-BUF_IMAGE=buf.image.bin
-PROJECT_ROOT=$(pwd)
-
 ## lock in current protobuf state
-cd proto
-make gen-buf-image
-git add $BUF_IMAGE
-git commit -m "chore: lock api state for backward compatibility check" || echo "buf image is already up to date"
-cd $PROJECT_ROOT
+
+# make gen-buf-iamge ensures that it starts with a clean git state
+make -C proto gen-buf-image
+if [[ -z "$(git status --porcelain)" ]]; then
+    echo "buf image is already up to date"
+    exit 0
+fi
+git add --all
+git commit -m "chore: lock api state for backward compatibility check"

--- a/tools/scripts/lock-api-state.sh
+++ b/tools/scripts/lock-api-state.sh
@@ -4,17 +4,8 @@
 BUF_IMAGE=buf.image.bin
 PROJECT_ROOT=$(pwd)
 
-if [[ $(git diff --shortstat 2> /dev/null | tail -n1) != "" ]]; then
-    echo "git: there are dirty files."
-    exit 1
-elif [[ $(git status --porcelain 2>/dev/null| grep "^??") ]]; then
-    echo "git: there are untracked files."
-    exit 1
-fi
-
 ## lock in current protobuf state
 cd proto
-make check
 make gen-buf-image
 git add $BUF_IMAGE
 git commit -m "chore: lock api state for backward compatibility check" || echo "buf image is already up to date"

--- a/tools/scripts/lock-api-state.sh
+++ b/tools/scripts/lock-api-state.sh
@@ -2,8 +2,9 @@
 
 ## lock in current protobuf state
 
-# make gen-buf-iamge ensures that it starts with a clean git state
+# make gen-buf-image ensures that it starts with a clean git state
 make -C proto gen-buf-image
+# check to see if gen-buf-image resulted in any file changes or not
 if [[ -z "$(git status --porcelain)" ]]; then
     echo "buf image is already up to date"
     exit 0

--- a/tools/scripts/lock-api-state.sh
+++ b/tools/scripts/lock-api-state.sh
@@ -9,5 +9,5 @@ if [[ -z "$(git status --porcelain)" ]]; then
     echo "buf image is already up to date"
     exit 0
 fi
-git add --all
+git add --update
 git commit -m "chore: lock api state for backward compatibility check"

--- a/tools/scripts/pre-release.sh
+++ b/tools/scripts/pre-release.sh
@@ -1,0 +1,26 @@
+#!/bin/bash -ex
+
+## Pre release hook. Run from the root of the project. Any arguments passed in are directly
+## sent to `bumpversion`
+
+PROJECT_ROOT=$(pwd)
+
+if [[ $(git diff --shortstat 2> /dev/null | tail -n1) != "" ]]; then
+    echo "git: there are dirty files."
+    exit 1
+elif [[ $(git status --porcelain 2>/dev/null| grep "^??") ]]; then
+    echo "git: there are untracked files."
+    exit 1
+fi
+
+## lock in current protobuf state
+# Buf image binary
+BUF_IMAGE=buf.image.bin
+cd proto
+make gen-buf-image
+git add $BUF_IMAGE
+git commit -m "lock backward buf compatibility check" || echo "buf image is already up to date"
+cd $PROJECT_ROOT
+
+## bump version
+bumpversion $@


### PR DESCRIPTION
## Description

Added a script to update `buf` image on each release to ensure changes after this point are backwards compatible.


<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan

ran the script to make test 
- it fails if there are dirty files
- it creates a commit if there is an updated image
- moves on if there is no updated image to create commit of


<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

1. ensure a clean git state
2. update the buf image
3. create a commit for updating buf image if necessary/changed

- once this is in we should update the release process doc to refer to this script
- suggestion on where we host this script? we have the devops-scripts repo

buf referring to https://docs.buf.build/


## Checklist

- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234