### PR TITLE
ci: fix branch name cannot contain slash for ci [DET-4104]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1034,7 +1034,7 @@ jobs:
           determined-deploy: true
           executor: determinedai/cimg-base:stable
       - deploy-aws-cluster:
-          cluster-id: determined-${CIRCLE_BRANCH}
+          cluster-id: determined-${CIRCLE_BRANCH////--}
           det-version: ${CIRCLE_SHA1}
           agent-instance-type: <<parameters.agent-instance-type>>
           max-dynamic-agents: <<parameters.max-dynamic-agents>>


### PR DESCRIPTION
## Description

Previously, the branch name cannot contain slash because it is used in the cluster id when deploying a cluster. Now fix it to replace a slash with two dashes.

## Test Plan

Push the branch to the main repo and see if it passes the CI.

## Commentary (optional)

N/A

## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
