### PR TITLE
feat: allow det-deploy aws to specify subnet for simple deployment type

### DIFF
--- a/deploy/determined_deploy/aws/cli.py
+++ b/deploy/determined_deploy/aws/cli.py
@@ -190,9 +190,11 @@ def deploy_aws(args: argparse.Namespace) -> None:
 
     if args.deployment_type != constants.deployment_types.SIMPLE:
         if args.agent_subnet_id != "":
-            raise ValueError(f"The agent-subnet-id can only be set if the deployment-type=simple. "
-                             f"The agent-subnet-id was set to '{args.agent_subnet_id}', but the "
-                             f"deployment-type={args.deployment_type}.")
+            raise ValueError(
+                f"The agent-subnet-id can only be set if the deployment-type=simple. "
+                f"The agent-subnet-id was set to '{args.agent_subnet_id}', but the "
+                f"deployment-type={args.deployment_type}."
+            )
 
     det_configs = {
         constants.cloudformation.KEYPAIR: args.keypair,

--- a/deploy/determined_deploy/aws/cli.py
+++ b/deploy/determined_deploy/aws/cli.py
@@ -76,6 +76,11 @@ def make_up_subparser(subparsers: argparse._SubParsersAction) -> None:
         help="inbound IP Range in CIDR format",
     )
     subparser.add_argument(
+        "--agent-subnet-id",
+        type=str,
+        help="subnet to deploy agents into. Optional. Only used with simple deployment type",
+    )
+    subparser.add_argument(
         "--det-version",
         type=str,
         help=argparse.SUPPRESS,
@@ -183,6 +188,12 @@ def deploy_aws(args: argparse.Namespace) -> None:
         constants.deployment_types.FSX: vpc.FSx,
     }  # type: Dict[str, Union[Type[base.DeterminedDeployment]]]
 
+    if args.deployment_type != constants.deployment_types.SIMPLE:
+        if args.agent_subnet_id != "":
+            raise ValueError(f"The agent-subnet-id can only be set if the deployment-type=simple. "
+                             f"The agent-subnet-id was set to '{args.agent_subnet_id}', but the "
+                             f"deployment-type={args.deployment_type}.")
+
     det_configs = {
         constants.cloudformation.KEYPAIR: args.keypair,
         constants.cloudformation.ENABLE_CORS: args.enable_cors,
@@ -199,6 +210,7 @@ def deploy_aws(args: argparse.Namespace) -> None:
         constants.cloudformation.MAX_DYNAMIC_AGENTS: args.max_dynamic_agents,
         constants.cloudformation.SPOT_ENABLED: args.spot,
         constants.cloudformation.SPOT_MAX_PRICE: args.spot_max_price,
+        constants.cloudformation.SUBNET_ID_KEY: args.agent_subnet_id,
     }
 
     deployment_object = deployment_type_map[args.deployment_type](det_configs)

--- a/deploy/determined_deploy/aws/deployment_types/simple.py
+++ b/deploy/determined_deploy/aws/deployment_types/simple.py
@@ -28,6 +28,7 @@ class Simple(base.DeterminedDeployment):
         constants.cloudformation.MAX_DYNAMIC_AGENTS,
         constants.cloudformation.SPOT_ENABLED,
         constants.cloudformation.SPOT_MAX_PRICE,
+        constants.cloudformation.SUBNET_ID_KEY,
     ]
 
     def deploy(self) -> None:

--- a/deploy/determined_deploy/aws/templates/simple.yaml
+++ b/deploy/determined_deploy/aws/templates/simple.yaml
@@ -55,6 +55,11 @@ Parameters:
     Description: Ip range for Inbound
     Default: 0.0.0.0/0
 
+  SubnetId:
+    Type: String
+    Description: The subnet to deploy instances into. Optional.
+    Default: ''
+
   Version:
     Type: String
     Description: Determined version or commit for master docker image
@@ -448,6 +453,7 @@ Resources:
               network_interface:
                 public_ip: true
                 security_group_id: ${AgentSecurityGroup.GroupId}
+                subnet_id: ${SubnetId}
               provider: aws
               root_volume_size: 200
               ssh_key_name: ${Keypair}

--- a/docs/release-notes/1515-det-deploy-specify-subnet.txt
+++ b/docs/release-notes/1515-det-deploy-specify-subnet.txt
@@ -1,0 +1,8 @@
+:orphan:
+
+**Feature**
+
+-  When using `det-deploy aws`, you can now specify the subnet that the
+   agents should be launched into (if you are using the simple
+   deployment type). This allows users to explicitly pick a
+   subnet/availability zone that has GPU instances.


### PR DESCRIPTION
## Description

Allow det-deploy aws to specify subnet that agents should be launched in for simple deployment type. This gives users a solution in the case where the master picks a subnet in an availability zone that does not have agent instances of the specified type.

## Test Plan

Tested manually with simple deployment type


## Commentary (optional)

When testing spot, I found that the cluster might be unable to launch GPU agents because the subnet did not support GPU instances and the only way to fix the issue is to SSH into the master and alter the config file.

## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
