### PR TITLE
refactor: clean up code for master-sent messages

### DIFF
--- a/master/internal/trial.go
+++ b/master/internal/trial.go
@@ -106,6 +106,7 @@ type (
 // Trial-specific external messages.
 type trialMessage struct {
 	RendezvousInfo *rendezvousInfoMessage `union:"type,RENDEZVOUS_INFO" json:"-"`
+	RunWorkload    *runWorkload           `union:"type,RUN_WORKLOAD" json:"-"`
 }
 
 func (m trialMessage) MarshalJSON() ([]byte, error) {
@@ -143,6 +144,10 @@ type rendezvousAddress struct {
 	ContainerIP   string `json:"container_ip"`
 	HostPort      int    `json:"host_port"`
 	HostIP        string `json:"host_ip"`
+}
+
+type runWorkload struct {
+	Workload workload.Workload `json:"workload"`
 }
 
 // terminatedContainerWithState records the terminatedContainer message with some state about the
@@ -708,8 +713,8 @@ func (t *trial) sendNextWorkload(ctx *actor.Context) error {
 		var msg interface{}
 		if terminateNow {
 			w = *t.sequencer.TerminateWorkload()
-			msg = &tasks.TaskSpec{
-				RunWorkload: &tasks.RunWorkload{
+			msg = &trialMessage{
+				RunWorkload: &runWorkload{
 					Workload: w,
 				},
 			}
@@ -720,8 +725,8 @@ func (t *trial) sendNextWorkload(ctx *actor.Context) error {
 			if err := saveWorkload(t.db, w); err != nil {
 				ctx.Log().WithError(err).Error("failed to save workload to the database")
 			}
-			msg = &tasks.TaskSpec{
-				RunWorkload: &tasks.RunWorkload{
+			msg = &trialMessage{
+				RunWorkload: &runWorkload{
 					Workload: w,
 				},
 			}

--- a/master/pkg/tasks/task_spec.go
+++ b/master/pkg/tasks/task_spec.go
@@ -6,93 +6,64 @@ import (
 
 	"github.com/determined-ai/determined/master/pkg/workload"
 
-	"github.com/pkg/errors"
-
 	"github.com/determined-ai/determined/master/pkg/archive"
 	"github.com/determined-ai/determined/master/pkg/device"
 	"github.com/determined-ai/determined/master/pkg/model"
-	"github.com/determined-ai/determined/master/pkg/union"
 )
 
 // TaskSpec provides the necessary information for an agent to start a task.
 type TaskSpec struct {
-	TaskID      string          `json:"task_id"`
-	ContainerID string          `json:"container_id"`
-	Devices     []device.Device `json:"devices"`
+	TaskID      string
+	ContainerID string
+	Devices     []device.Device
 
-	ClusterID             string                            `json:"cluster_id"`
-	HarnessPath           string                            `json:"harness_path"`
-	TaskContainerDefaults model.TaskContainerDefaultsConfig `json:"task_container_defaults"`
-	MasterCert            *tls.Certificate                  `json:"master_cert"`
+	ClusterID             string
+	HarnessPath           string
+	TaskContainerDefaults model.TaskContainerDefaultsConfig
+	MasterCert            *tls.Certificate
 
-	StartCommand   *StartCommand   `union:"type,START_TASK" json:"-"`
-	StartContainer *StartContainer `union:"type,START_CONTAINER" json:"-"`
-	GCCheckpoints  *GCCheckpoints  `union:"type,GC_CHECKPOINTS" json:"-"`
-	KillContainer  *KillContainer  `union:"type,KILL_CONTAINER" json:"-"`
-	RunWorkload    *RunWorkload    `union:"type,RUN_WORKLOAD" json:"-"`
-}
-
-// MarshalJSON serializes a TaskSpec.
-func (t TaskSpec) MarshalJSON() ([]byte, error) {
-	return union.Marshal(t)
-}
-
-// UnmarshalJSON deserializes a TaskSpec.
-func (t *TaskSpec) UnmarshalJSON(data []byte) error {
-	if err := union.Unmarshal(data, t); err != nil {
-		return err
-	}
-
-	type DefaultParser *TaskSpec
-	return errors.Wrap(json.Unmarshal(data, DefaultParser(t)), "failed to parse task specification")
+	StartCommand   *StartCommand
+	StartContainer *StartContainer
+	GCCheckpoints  *GCCheckpoints
 }
 
 // StartCommand is the information sent to an agent to start a command.
 type StartCommand struct {
 	// AgentUserGroup is the user and group to run this task as.
-	AgentUserGroup *model.AgentUserGroup `json:"agent_user_group,omitempty"`
+	AgentUserGroup *model.AgentUserGroup
 
-	Config          model.CommandConfig `json:"config"`
-	UserFiles       archive.Archive     `json:"user_files"`
-	AdditionalFiles archive.Archive     `json:"additional_files"`
+	Config          model.CommandConfig
+	UserFiles       archive.Archive
+	AdditionalFiles archive.Archive
 }
 
 // GCCheckpoints is the information sent to an agent to garbage collect a checkpoint.
 type GCCheckpoints struct {
 	// AgentUserGroup is the user and group to run this task as.
-	AgentUserGroup *model.AgentUserGroup `json:"agent_user_group,omitempty"`
+	AgentUserGroup *model.AgentUserGroup
 
-	ExperimentID     int                    `json:"experiment_id"`
-	ExperimentConfig model.ExperimentConfig `json:"experiment_config"`
-	ToDelete         json.RawMessage        `json:"to_delete"`
+	ExperimentID     int
+	ExperimentConfig model.ExperimentConfig
+	ToDelete         json.RawMessage
 }
 
 // StartContainer is the information sent to an agent to start a container (trial).
 type StartContainer struct {
 	// AgentUserGroup is the user and group to run this task as.
-	AgentUserGroup *model.AgentUserGroup `json:"agent_user_group,omitempty"`
+	AgentUserGroup *model.AgentUserGroup
 
-	ExperimentConfig    model.ExperimentConfig    `json:"experiment_config"`
-	ModelDefinition     archive.Archive           `json:"model_definition"`
-	HParams             map[string]interface{}    `json:"hparams"`
-	TrialSeed           uint32                    `json:"trial_seed"`
-	LatestCheckpoint    *model.Checkpoint         `json:"latest_checkpoint"`
-	InitialWorkload     workload.Workload         `json:"initial_workload"`
-	WorkloadManagerType model.WorkloadManagerType `json:"workload_manager_type"`
-	AdditionalFiles     archive.Archive           `json:"additional_files"`
+	ExperimentConfig    model.ExperimentConfig
+	ModelDefinition     archive.Archive
+	HParams             map[string]interface{}
+	TrialSeed           uint32
+	LatestCheckpoint    *model.Checkpoint
+	InitialWorkload     workload.Workload
+	WorkloadManagerType model.WorkloadManagerType
+	AdditionalFiles     archive.Archive
 
 	// This is used to hint the resource manager to override defaults and start
 	// the container in host mode iff it has been scheduled across multiple agents.
-	IsMultiAgent bool `json:"is_multi_agent"`
+	IsMultiAgent bool
 
-	Rank int `json:"rank"`
-}
-
-// KillContainer is the information sent to an agent to kill a task (i.e., container or
-// command).
-type KillContainer struct{}
-
-// RunWorkload is the information sent to an agent to run a workload.
-type RunWorkload struct {
-	Workload workload.Workload `json:"workload"`
+	Rank int
 }


### PR DESCRIPTION
## Description

A bunch of code relating to the `TaskSpec` struct was left over from
when that type was serialized and sent to the old Python agent; that
code is now removed, since `TaskSpec` is no longer sent directly but
instead translated into a `container.Spec` within the master.

This also deletes the unused `KillContainer` and moves the message for
running a workload, which was stuck in among all the container start
messages, to a more appropriate place in the trial code.

## Test Plan

- [x] run trials, commands, and shells and see that the containers (including GC) start up with no issues

## Commentary (optional)

I was originally imagining a somewhat larger refactor of the task/container spec translation stuff; some more might come later, but I do think, after looking at this code, that something like the current pattern more or less makes sense.
