### PR TITLE
feat: make DB service type configurable in Helm chart

### DIFF
--- a/docs/reference/helm-config.txt
+++ b/docs/reference/helm-config.txt
@@ -78,6 +78,10 @@ Helm Chart </helm/determined-helm-chart.tgz>`.
    -  ``memRequest``: The memory requirements for the Determined
       database.
 
+   -  ``useNodePortForDB``: Optional configuration that configures
+      whether ClusterIP or NodePort service type is used for the
+      Determined database. By default ClusterIP is used.
+
    -  ``storageClassName``: Optional configuration to indicate
       StorageClass that should be used by the PersistentVolumeClaim for
       the Determined deployed database. This can be left blank if a

--- a/docs/release-notes/1522-helm-db-service-type.txt
+++ b/docs/release-notes/1522-helm-db-service-type.txt
@@ -1,0 +1,6 @@
+:orphan:
+
+**NEW FEATURES**
+
+-  Add option to configure the service type of the Determined
+   deployed database in the Determined Helm Chart.

--- a/docs/release-notes/1522-helm-db-service-type.txt
+++ b/docs/release-notes/1522-helm-db-service-type.txt
@@ -2,5 +2,5 @@
 
 **NEW FEATURES**
 
--  Add option to configure the service type of the Determined
-   deployed database in the Determined Helm Chart.
+-  Add option to configure the service type of the Determined deployed
+   database in the Determined Helm Chart.

--- a/helm/charts/determined/templates/db-service.yaml
+++ b/helm/charts/determined/templates/db-service.yaml
@@ -12,6 +12,7 @@ spec:
   ports:
   - port: {{ .Values.db.port }}
     protocol: TCP
+  type: {{ if (.Values.db.useNodePortForDB | default false) }}NodePort{{ else }}ClusterIP{{ end }}
   selector:
     app: determined-db-{{ .Release.Name }}
 {{ end }}

--- a/helm/charts/determined/values.yaml
+++ b/helm/charts/determined/values.yaml
@@ -38,6 +38,11 @@ db:
   cpuRequest: "2"
   memRequest: "8Gi"
 
+  # useNodePortForDB configures whether ClusterIP or NodePort service
+  # type is used for the Determined deployed db. By default ClusterIP
+  # is used.
+  useNodePortForDB: false
+
   # storageClassName configures the StorageClass used by the PersistentVolumeClaim
   # for the Determined deployed database. This can be left blank if a default
   # storage class is specified in the cluster. If dynamic provisioning of


### PR DESCRIPTION
## Description
This came up as something that can be useful when @davetroiano was installing on a local 
cluster that did not have support for ClusterIP service types.

## Test Plan
Tested manually.
