### PR TITLE
chore: make gen-attributions.py play nicer

### DIFF
--- a/agent/Makefile
+++ b/agent/Makefile
@@ -33,7 +33,7 @@ test:
 	go test ./...
 
 packaging/LICENSE: $(shell find ../tools/scripts/licenses -type f)
-	../tools/scripts/gen-attributions.py agent > $@
+	../tools/scripts/gen-attributions.py agent $@
 
 .PHONY: package
 package: export GORELEASER_CURRENT_TAG := $(VERSION)

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -12,7 +12,7 @@ build-helm:
 	$(MAKE) -C ../helm build
 
 reference/attributions.txt: $(shell find ../tools/scripts/licenses -type f)
-	../tools/scripts/gen-attributions.py sphinx > $@
+	../tools/scripts/gen-attributions.py sphinx $@
 
 .PHONY: build
 build: build-examples build-helm reference/attributions.txt

--- a/master/Makefile
+++ b/master/Makefile
@@ -46,7 +46,7 @@ pre-package:
 	cp ../harness/dist/*.whl build/wheels/
 
 packaging/LICENSE: $(shell find ../tools/scripts/licenses -type f)
-	../tools/scripts/gen-attributions.py agent > $@
+	../tools/scripts/gen-attributions.py agent $@
 
 .PHONY: package
 package: export DET_SEGMENT_MASTER_KEY ?=

--- a/tools/scripts/gen-attributions.py
+++ b/tools/scripts/gen-attributions.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 """
 gen-attributions.py: a tool for generating various OSS attributions docs.
@@ -6,7 +6,7 @@ gen-attributions.py: a tool for generating various OSS attributions docs.
 See tools/scripts/README.md for instructions on how to format license files.
 
 usage:
-    gen-attributions.py BUILD_TYPE > OUTPUT_FILE
+    gen-attributions.py BUILD_TYPE [OUTPUT_FILE]
 
 where BUILD_TYPE is one of:
     sphix   -- generate an ReST file for the sphinx documentation
@@ -214,7 +214,7 @@ def read_dir(path: str) -> List[License]:
     return licenses
 
 
-def main(build_type: str) -> int:
+def main(build_type: str, path_out: Optional[str]) -> int:
     if build_type not in ("master", "agent", "sphinx"):
         print(__doc__, file=sys.stderr)
         return 1
@@ -236,16 +236,21 @@ def main(build_type: str) -> int:
 
     gen = post_process(gen)
 
-    print(gen)
+    # Only write the output when we are sure we will not hit any other errors, to play nice
+    # with build systems that look at timestamps on files.
+    file_out = open(path_out, "w") if path_out is not None else sys.stdout
+    with file_out:
+        print(gen, file=file_out)
 
     return 0
 
 
 if __name__ == "__main__":
-    if len(sys.argv) != 2:
+    if len(sys.argv) not in (2, 3):
         print(__doc__, file=sys.stderr)
         sys.exit(1)
 
     build_type = sys.argv[1]
+    path_out = sys.argv[2] if len(sys.argv) == 3 else None
 
-    sys.exit(main(build_type))
+    sys.exit(main(build_type, path_out))


### PR DESCRIPTION
Use the right shebang line to play nice with Macs.

Don't write output files until the last moment to play nice with Make.