### PR TITLE
feat: add streaming endpoints with metric metadata for future UI work [DET-4439]

### DIFF
--- a/e2e_tests/tests/experiment/test_metrics.py
+++ b/e2e_tests/tests/experiment/test_metrics.py
@@ -10,7 +10,7 @@ from tests import experiment as exp
 
 
 @pytest.mark.e2e_cpu  # type: ignore
-@pytest.mark.timeout(180)  # type: ignore
+@pytest.mark.timeout(300)  # type: ignore
 def test_streaming_metrics_api() -> None:
     auth.initialize_session(conf.make_master_url(), try_reauth=True)
 

--- a/e2e_tests/tests/experiment/test_metrics.py
+++ b/e2e_tests/tests/experiment/test_metrics.py
@@ -10,7 +10,7 @@ from tests import experiment as exp
 
 
 @pytest.mark.e2e_cpu  # type: ignore
-@pytest.mark.timeout(150)  # type: ignore
+@pytest.mark.timeout(180)  # type: ignore
 def test_streaming_metrics_api() -> None:
     auth.initialize_session(conf.make_master_url(), try_reauth=True)
 

--- a/e2e_tests/tests/experiment/test_metrics.py
+++ b/e2e_tests/tests/experiment/test_metrics.py
@@ -25,10 +25,8 @@ def test_streaming_metrics_api() -> None:
     # of the API calls on a single experiment, we spawn them all in threads.
 
     metric_names_thread = pool.apply_async(request_metric_names, (experiment_id,))
-    train_metric_batches_thread = pool.apply_async(request_train_metric_batches,
-        (experiment_id,))
-    valid_metric_batches_thread = pool.apply_async(request_valid_metric_batches,
-        (experiment_id,))
+    train_metric_batches_thread = pool.apply_async(request_train_metric_batches, (experiment_id,))
+    valid_metric_batches_thread = pool.apply_async(request_valid_metric_batches, (experiment_id,))
 
     metric_names_results = metric_names_thread.get()
     train_metric_batches_results = train_metric_batches_thread.get()
@@ -80,7 +78,7 @@ def request_train_metric_batches(experiment_id):  # type: ignore
     response = api.get(
         conf.make_master_url(),
         "api/v1/experiments/{}/metrics-stream/batches".format(experiment_id),
-        params={"metric_name": "loss", "metric_type": "training"},
+        params={"metric_name": "loss", "metric_type": "METRIC_TYPE_TRAINING"},
     )
     results = [message["result"] for message in map(json.loads, response.text.splitlines())]
 
@@ -104,7 +102,7 @@ def request_valid_metric_batches(experiment_id):  # type: ignore
     response = api.get(
         conf.make_master_url(),
         "api/v1/experiments/{}/metrics-stream/batches".format(experiment_id),
-        params={"metric_name": "accuracy", "metric_type": "validation"},
+        params={"metric_name": "accuracy", "metric_type": "METRIC_TYPE_VALIDATION"},
     )
     results = [message["result"] for message in map(json.loads, response.text.splitlines())]
 

--- a/e2e_tests/tests/experiment/test_metrics.py
+++ b/e2e_tests/tests/experiment/test_metrics.py
@@ -1,4 +1,5 @@
 import json
+import multiprocessing as mp
 
 import pytest
 
@@ -9,16 +10,32 @@ from tests import experiment as exp
 
 
 @pytest.mark.e2e_cpu  # type: ignore
-@pytest.mark.timeout(180)  # type: ignore
-def test_streaming_metric_names() -> None:
+@pytest.mark.timeout(150)  # type: ignore
+def test_streaming_metrics_api() -> None:
     auth.initialize_session(conf.make_master_url(), try_reauth=True)
 
-    experiment_id = exp.create_experiment(
-        conf.fixtures_path("no_op/single-medium-train-step.yaml"), conf.fixtures_path("no_op")
-    )
+    pool = mp.pool.ThreadPool(processes=2)
 
-    # This request starts immediately after the experiment, and will return when it completes.
-    # If we timeout, it means it failed to complete, or we didn't close the connection after it did
+    experiment_id = exp.create_experiment(
+        conf.fixtures_path("mnist_pytorch/adaptive_short.yaml"),
+        conf.tutorials_path("mnist_pytorch"),
+    )
+    # To fully test the streaming APIs, the requests need to start running immediately after the
+    # experiment, and then stay open until the experiment is complete. To accomplish this with all
+    # of the API calls on a single experiment, we spawn them all in threads.
+
+    metric_names_thread = pool.apply_async(request_metric_names, (experiment_id,))
+    metric_batches_thread = pool.apply_async(request_metric_batches, (experiment_id,))
+
+    metric_names_results = metric_names_thread.get()
+    metric_batches_results = metric_batches_thread.get()
+    if metric_names_results is not None:
+        pytest.fail("metric-names: %s. Results: %s" % metric_names_results)
+    if metric_batches_results is not None:
+        pytest.fail("metric-batches: %s. Results: %s" % metric_batches_results)
+
+
+def request_metric_names(experiment_id):  # type: ignore
     response = api.get(
         conf.make_master_url(),
         "api/v1/experiments/{}/metrics-stream/metric-names".format(experiment_id),
@@ -26,33 +43,34 @@ def test_streaming_metric_names() -> None:
     results = [message["result"] for message in map(json.loads, response.text.splitlines())]
 
     # First let's verify an empty response was sent back before any real work was done
-    assert results[0]["searcherMetric"] == "validation_error"
-    assert results[0]["trainingMetrics"] == []
-    assert results[0]["validationMetrics"] == []
+    if results[0]["searcherMetric"] != "validation_loss":
+        return ("unexpected searcher metric in first response", results)
+    if results[0]["trainingMetrics"] != []:
+        return ("unexpected training metric in first response", results)
+    if results[0]["validationMetrics"] != []:
+        return ("unexpected validation metric in first response", results)
 
     # Then we verify that all expected responses are eventually received exactly once
     accumulated_training = set()
     accumulated_validation = set()
     for i in range(1, len(results)):
         for training in results[i]["trainingMetrics"]:
-            assert training not in accumulated_training
+            if training in accumulated_training:
+                return ("training metric appeared twice", results)
             accumulated_training.add(training)
         for validation in results[i]["validationMetrics"]:
-            assert validation not in accumulated_validation
+            if validation in accumulated_validation:
+                return ("training metric appeared twice", results)
             accumulated_validation.add(validation)
-    assert accumulated_training == {"loss"}
-    assert accumulated_validation == {"validation_error"}
+
+    if accumulated_training != {"loss"}:
+        return ("unexpected set of training metrics", results)
+    if accumulated_validation != {"validation_loss", "accuracy"}:
+        return ("unexpected set of validation metrics", results)
+    return None
 
 
-@pytest.mark.e2e_cpu  # type: ignore
-@pytest.mark.timeout(90)  # type: ignore
-def test_streaming_metric_batches() -> None:
-    experiment_id = exp.create_experiment(
-        conf.fixtures_path("no_op/single-medium-train-step.yaml"), conf.fixtures_path("no_op")
-    )
-
-    # This request starts immediately after the experiment, and will return when it completes.
-    # If we timeout, it means it failed to complete, or we didn't close the connection after it did
+def request_metric_batches(experiment_id):  # type: ignore
     response = api.get(
         conf.make_master_url(),
         "api/v1/experiments/{}/metrics-stream/batches".format(experiment_id),
@@ -61,12 +79,16 @@ def test_streaming_metric_batches() -> None:
     results = [message["result"] for message in map(json.loads, response.text.splitlines())]
 
     # First let's verify an empty response was sent back before any real work was done
-    assert results[0]["batches"] == []
+    if results[0]["batches"] != []:
+        return ("unexpected batches in first response", results)
 
     # Then we verify that all expected responses are eventually received exactly once
     accumulated = set()
     for i in range(1, len(results)):
         for batch in results[i]["batches"]:
-            assert batch not in accumulated
+            if batch in accumulated:
+                return ("batch appears twice", results)
             accumulated.add(batch)
-    assert accumulated == {100, 200, 300, 400, 500}
+    if accumulated != {100, 200, 300, 400}:
+        return ("unexpected set of batches", results)
+    return None

--- a/e2e_tests/tests/experiment/test_metrics.py
+++ b/e2e_tests/tests/experiment/test_metrics.py
@@ -1,0 +1,72 @@
+import json
+
+import pytest
+
+import determined_common.api.authentication as auth
+from determined_common import api
+from tests import config as conf
+from tests import experiment as exp
+
+
+@pytest.mark.e2e_cpu  # type: ignore
+@pytest.mark.timeout(180)  # type: ignore
+def test_streaming_metric_names() -> None:
+    auth.initialize_session(conf.make_master_url(), try_reauth=True)
+
+    experiment_id = exp.create_experiment(
+        conf.fixtures_path("no_op/single-medium-train-step.yaml"), conf.fixtures_path("no_op")
+    )
+
+    # This request starts immediately after the experiment, and will return when it completes.
+    # If we timeout, it means it failed to complete, or we didn't close the connection after it did
+    response = api.get(
+        conf.make_master_url(),
+        "api/v1/experiments/{}/metrics-stream/metric-names".format(experiment_id),
+    )
+    results = [message["result"] for message in map(json.loads, response.text.splitlines())]
+
+    # First let's verify an empty response was sent back before any real work was done
+    assert results[0]["searcherMetric"] == "validation_error"
+    assert results[0]["trainingMetrics"] == []
+    assert results[0]["validationMetrics"] == []
+
+    # Then we verify that all expected responses are eventually received exactly once
+    accumulated_training = set()
+    accumulated_validation = set()
+    for i in range(1, len(results)):
+        for training in results[i]["trainingMetrics"]:
+            assert training not in accumulated_training
+            accumulated_training.add(training)
+        for validation in results[i]["validationMetrics"]:
+            assert validation not in accumulated_validation
+            accumulated_validation.add(validation)
+    assert accumulated_training == {"loss"}
+    assert accumulated_validation == {"validation_error"}
+
+
+@pytest.mark.e2e_cpu  # type: ignore
+@pytest.mark.timeout(90)  # type: ignore
+def test_streaming_metric_batches() -> None:
+    experiment_id = exp.create_experiment(
+        conf.fixtures_path("no_op/single-medium-train-step.yaml"), conf.fixtures_path("no_op")
+    )
+
+    # This request starts immediately after the experiment, and will return when it completes.
+    # If we timeout, it means it failed to complete, or we didn't close the connection after it did
+    response = api.get(
+        conf.make_master_url(),
+        "api/v1/experiments/{}/metrics-stream/batches".format(experiment_id),
+        params={"training_metric": "loss"},
+    )
+    results = [message["result"] for message in map(json.loads, response.text.splitlines())]
+
+    # First let's verify an empty response was sent back before any real work was done
+    assert results[0]["batches"] == []
+
+    # Then we verify that all expected responses are eventually received exactly once
+    accumulated = set()
+    for i in range(1, len(results)):
+        for batch in results[i]["batches"]:
+            assert batch not in accumulated
+            accumulated.add(batch)
+    assert accumulated == {100, 200, 300, 400, 500}

--- a/e2e_tests/tests/requirements.txt
+++ b/e2e_tests/tests/requirements.txt
@@ -1,6 +1,7 @@
 appdirs
 # pytest 6.0 has linter-breaking changes
 pytest>=6.0.1
+pytest-timeout
 pexpect
 torch==1.4
 torchvision==0.5.0

--- a/master/internal/api_experiment.go
+++ b/master/internal/api_experiment.go
@@ -599,8 +599,11 @@ func (a *apiServer) MetricBatches(req *apiv1.MetricBatchesRequest,
 	experimentID := int(req.ExperimentId)
 	metricName := req.MetricName
 	metricType := req.MetricType
+	if metricType == apiv1.MetricType_METRIC_TYPE_UNSPECIFIED {
+		return errors.New("must specify a metric type")
+	}
 	if metricName == "" {
-		return errors.New("Must provide metric name")
+		return errors.New("must provide metric name")
 	}
 
 	seenBatches := make(map[int32]bool)
@@ -611,7 +614,7 @@ func (a *apiServer) MetricBatches(req *apiv1.MetricBatchesRequest,
 		var newBatches []int32
 		var endTime time.Time
 		var err error
-		if metricType == apiv1.MetricType_training {
+		if metricType == apiv1.MetricType_METRIC_TYPE_TRAINING {
 			newBatches, endTime, err = a.m.db.TrainingMetricBatches(experimentID, metricName,
 				startTime)
 		} else {

--- a/master/internal/api_experiment.go
+++ b/master/internal/api_experiment.go
@@ -612,7 +612,7 @@ func (a *apiServer) MetricBatches(req *apiv1.MetricBatchesRequest,
 	validationMetric := req.ValidationMetric
 	if len(trainingMetric) == 0 && len(validationMetric) == 0 {
 		return errors.New(
-			"must provide a training metric, or a validation metric: neither provided")
+			"must provide a training metric or a validation metric, neither provided")
 	}
 	if len(trainingMetric) > 0 && len(validationMetric) > 0 {
 		return errors.New(

--- a/master/internal/api_experiment.go
+++ b/master/internal/api_experiment.go
@@ -616,7 +616,7 @@ func (a *apiServer) MetricBatches(req *apiv1.MetricBatchesRequest,
 	}
 	if len(trainingMetric) > 0 && len(validationMetric) > 0 {
 		return errors.New(
-			"must provide a training metric, or a validation metric: not both")
+			"must provide a training metric or a validation metric, not both")
 	}
 	var metricType string
 	var metricName string

--- a/master/internal/api_experiment.go
+++ b/master/internal/api_experiment.go
@@ -622,6 +622,8 @@ func (a *apiServer) MetricBatches(req *apiv1.MetricBatchesRequest,
 		metricName = validationMetric
 	}
 
+	seenBatches := make(map[int32]bool)
+
 	var startTime time.Time
 	for {
 		var response apiv1.MetricBatchesResponse
@@ -635,7 +637,12 @@ func (a *apiServer) MetricBatches(req *apiv1.MetricBatchesRequest,
 		}
 		startTime = endTime
 
-		response.Batches = newBatches
+		for _, batch := range newBatches {
+			if seen := seenBatches[batch]; !seen {
+				response.Batches = append(response.Batches, batch)
+				seenBatches[batch] = true
+			}
+		}
 
 		if err := resp.Send(&response); err != nil {
 			return errors.Wrapf(err, "error sending batches recorded for metrics")

--- a/master/internal/api_experiment.go
+++ b/master/internal/api_experiment.go
@@ -566,7 +566,8 @@ func (a *apiServer) MetricNames(req *apiv1.MetricNamesRequest,
 		var response apiv1.MetricNamesResponse
 		response.SearcherMetric = searcherMetric
 
-		newTrain, newValid, tEndTime, vEndTime, err := a.m.db.MetricNames(experimentID, tStartTime, vStartTime)
+		newTrain, newValid, tEndTime, vEndTime, err := a.m.db.MetricNames(experimentID,
+			tStartTime, vStartTime)
 		if err != nil {
 			return errors.Wrapf(err,
 				"error fetching metric names for experiment: %d", experimentID)

--- a/master/internal/db/postgres_experiments.go
+++ b/master/internal/db/postgres_experiments.go
@@ -41,31 +41,69 @@ func (db *PgDB) ExperimentLabelUsage() (labelUsage map[string]int, err error) {
 
 // MetricNames returns the set of training and validation metric names that have been recorded for
 // an experiment.
-func (db *PgDB) MetricNames(experimentID int) (training []string, validation []string, err error) {
-	err = db.sql.Select(&training, `
-SELECT DISTINCT
-jsonb_object_keys(s.metrics->'avg_metrics') AS name
-FROM trials t
-INNER JOIN steps s ON t.id=s.trial_id
-WHERE t.experiment_id=$1;`, experimentID)
-	if err != nil {
-		return nil, nil, errors.Wrapf(err,
-			"error querying training metric names for experiment %d", experimentID)
+func (db *PgDB) MetricNames(experimentID int, sStartTime time.Time, vStartTime time.Time) (training []string, validation []string, sEndTime time.Time, vEndTime time.Time, err error) {
+
+	type namesWrapper struct {
+		Name    string    `db:"name"`
+		EndTime time.Time `db:"end_time"`
 	}
 
-	err = db.sql.Select(&validation, `
-SELECT DISTINCT
-jsonb_object_keys(v.metrics->'validation_metrics') AS name
+	rows, err := db.sql.Queryx(`
+SELECT 
+  jsonb_object_keys(s.metrics->'avg_metrics') AS name,
+  max(s.end_time) AS end_time
+FROM trials t
+INNER JOIN steps s ON t.id=s.trial_id
+WHERE t.experiment_id=$1
+  AND s.end_time > $2
+GROUP BY name;`, experimentID, sStartTime)
+	if err != nil {
+		return nil, nil, sEndTime, vEndTime, errors.Wrapf(err,
+			"error querying training metric names for experiment %d", experimentID)
+	}
+	for rows.Next() {
+		var row namesWrapper
+		err = rows.StructScan(&row)
+		if err != nil {
+			return nil, nil, sEndTime, vEndTime, errors.Wrapf(err,
+				"error scanning training metric names for experiment %d",
+				experimentID)
+		}
+		training = append(training, row.Name)
+		if row.EndTime.After(sEndTime) {
+			sEndTime = row.EndTime
+		}
+	}
+
+	rows, err = db.sql.Queryx(`
+SELECT
+  jsonb_object_keys(v.metrics->'validation_metrics') AS name,
+  max(v.end_time) AS end_time
 FROM trials t
 INNER JOIN steps s ON t.id=s.trial_id
 LEFT OUTER JOIN validations v ON s.id=v.step_id AND s.trial_id=v.trial_id
-WHERE t.experiment_id=$1;`, experimentID)
+WHERE t.experiment_id=$1
+  AND v.end_time > $2
+GROUP BY name;`, experimentID, vStartTime)
 	if err != nil {
-		return nil, nil, errors.Wrapf(err,
+		return nil, nil, sEndTime, vEndTime, errors.Wrapf(err,
 			"error querying validation metric names for experiment %d", experimentID)
 	}
+	for rows.Next() {
+		var row namesWrapper
+		err = rows.StructScan(&row)
+		if err != nil {
+			return nil, nil, sEndTime, vEndTime, errors.Wrapf(err,
+				"error scanning validation metric names for experiment %d",
+				experimentID)
+		}
+		validation = append(validation, row.Name)
+		if row.EndTime.After(sEndTime) {
+			sEndTime = row.EndTime
+		}
+	}
 
-	return training, validation, err
+	return training, validation, sEndTime, vEndTime, err
 }
 
 // MetricBatches returns the milestones (in batches processed) at which a specific metric was
@@ -86,7 +124,7 @@ func (db *PgDB) MetricBatches(experimentID int, trainingMetric string, validatio
 		metricType = VALIDATION
 	}
 	if len(metricName) == 0 {
-		return nil, time.Unix(0, 0),
+		return nil, endTime,
 			errors.New("must provide one training metric, or one validation metric, but not both")
 	}
 
@@ -98,25 +136,25 @@ func (db *PgDB) MetricBatches(experimentID int, trainingMetric string, validatio
 	var query string
 	if metricType == TRAINING {
 		query = `
-SELECT DISTINCT s.end_time,
-  (s.prior_batches_processed + num_batches) AS batches_processed
+SELECT (s.prior_batches_processed + num_batches) AS batches_processed,
+  max(s.end_time) as end_time
 FROM trials t INNER JOIN steps s ON t.id=s.trial_id
 WHERE t.experiment_id=$1
   AND s.state = 'COMPLETED'
   AND s.metrics->'avg_metrics' ? $2
   AND s.end_time > $3
-ORDER BY s.end_time;`
+GROUP BY batches_processed;`
 	} else {
 		query = `
-SELECT DISTINCT v.end_time,
-  (s.prior_batches_processed + num_batches) AS batches_processed
+SELECT (s.prior_batches_processed + num_batches) AS batches_processed
+  max(v.end_time) as end_time
 FROM trials t INNER JOIN steps s ON t.id=s.trial_id
   LEFT OUTER JOIN validations v ON s.id=v.step_id AND s.trial_id=v.trial_id
 WHERE t.experiment_id=$1
   AND v.state = 'COMPLETED'
   AND v.metrics->'validation_metrics' ? $2
   AND v.end_time > $3
-ORDER BY v.end_time;`
+GROUP BY batches_processed;`
 	}
 
 	rows, err := db.sql.Queryx(query, experimentID, metricName, startTime)

--- a/master/internal/db/postgres_experiments.go
+++ b/master/internal/db/postgres_experiments.go
@@ -78,7 +78,7 @@ INNER JOIN steps s ON t.id=s.trial_id
 LEFT OUTER JOIN validations v ON s.id=v.step_id AND s.trial_id=v.trial_id
 WHERE t.experiment_id=$1
   AND v.end_time > $2
-GROUP BY name;`, experimentID, vStartTime)
+GROUP BY name;`, &rows, experimentID, vStartTime)
 	if err != nil {
 		return nil, nil, sEndTime, vEndTime, errors.Wrapf(err,
 			"error querying validation metric names for experiment %d", experimentID)

--- a/master/internal/db/postgres_experiments.go
+++ b/master/internal/db/postgres_experiments.go
@@ -41,8 +41,8 @@ func (db *PgDB) ExperimentLabelUsage() (labelUsage map[string]int, err error) {
 
 // MetricNames returns the set of training and validation metric names that have been recorded for
 // an experiment.
-func (db *PgDB) MetricNames(experimentID int, sStartTime time.Time, vStartTime time.Time) (training []string, validation []string, sEndTime time.Time, vEndTime time.Time, err error) {
-
+func (db *PgDB) MetricNames(experimentID int, sStartTime time.Time, vStartTime time.Time) (
+	training []string, validation []string, sEndTime time.Time, vEndTime time.Time, err error) {
 	type namesWrapper struct {
 		Name    string    `db:"name"`
 		EndTime time.Time `db:"end_time"`

--- a/master/internal/db/postgres_experiments.go
+++ b/master/internal/db/postgres_experiments.go
@@ -61,6 +61,8 @@ GROUP BY name;`, experimentID, sStartTime)
 		return nil, nil, sEndTime, vEndTime, errors.Wrapf(err,
 			"error querying training metric names for experiment %d", experimentID)
 	}
+	defer rows.Close()
+
 	for rows.Next() {
 		var row namesWrapper
 		err = rows.StructScan(&row)
@@ -89,6 +91,8 @@ GROUP BY name;`, experimentID, vStartTime)
 		return nil, nil, sEndTime, vEndTime, errors.Wrapf(err,
 			"error querying validation metric names for experiment %d", experimentID)
 	}
+	defer rows.Close()
+
 	for rows.Next() {
 		var row namesWrapper
 		err = rows.StructScan(&row)

--- a/master/internal/db/postgres_experiments.go
+++ b/master/internal/db/postgres_experiments.go
@@ -48,7 +48,8 @@ func (db *PgDB) MetricNames(experimentID int, sStartTime time.Time, vStartTime t
 		EndTime time.Time `db:"end_time"`
 	}
 
-	rows, err := db.sql.Queryx(`
+	var rows []namesWrapper
+	err = db.queryRows(`
 SELECT 
   jsonb_object_keys(s.metrics->'avg_metrics') AS name,
   max(s.end_time) AS end_time
@@ -56,28 +57,19 @@ FROM trials t
 INNER JOIN steps s ON t.id=s.trial_id
 WHERE t.experiment_id=$1
   AND s.end_time > $2
-GROUP BY name;`, experimentID, sStartTime)
+GROUP BY name;`, &rows, experimentID, sStartTime)
 	if err != nil {
 		return nil, nil, sEndTime, vEndTime, errors.Wrapf(err,
 			"error querying training metric names for experiment %d", experimentID)
 	}
-	defer rows.Close()
-
-	for rows.Next() {
-		var row namesWrapper
-		err = rows.StructScan(&row)
-		if err != nil {
-			return nil, nil, sEndTime, vEndTime, errors.Wrapf(err,
-				"error scanning training metric names for experiment %d",
-				experimentID)
-		}
+	for _, row := range rows {
 		training = append(training, row.Name)
 		if row.EndTime.After(sEndTime) {
 			sEndTime = row.EndTime
 		}
 	}
 
-	rows, err = db.sql.Queryx(`
+	err = db.queryRows(`
 SELECT
   jsonb_object_keys(v.metrics->'validation_metrics') AS name,
   max(v.end_time) AS end_time
@@ -91,16 +83,7 @@ GROUP BY name;`, experimentID, vStartTime)
 		return nil, nil, sEndTime, vEndTime, errors.Wrapf(err,
 			"error querying validation metric names for experiment %d", experimentID)
 	}
-	defer rows.Close()
-
-	for rows.Next() {
-		var row namesWrapper
-		err = rows.StructScan(&row)
-		if err != nil {
-			return nil, nil, sEndTime, vEndTime, errors.Wrapf(err,
-				"error scanning validation metric names for experiment %d",
-				experimentID)
-		}
+	for _, row := range rows {
 		validation = append(validation, row.Name)
 		if row.EndTime.After(sEndTime) {
 			sEndTime = row.EndTime
@@ -119,7 +102,8 @@ type batchesWrapper struct {
 // metric was recorded.
 func (db *PgDB) TrainingMetricBatches(experimentID int, metricName string, startTime time.Time) (
 	batches []int32, endTime time.Time, err error) {
-	query := `
+	var rows []*batchesWrapper
+	err = db.queryRows(`
 SELECT (s.prior_batches_processed + num_batches) AS batches_processed,
   max(s.end_time) as end_time
 FROM trials t INNER JOIN steps s ON t.id=s.trial_id
@@ -127,10 +111,7 @@ WHERE t.experiment_id=$1
   AND s.state = 'COMPLETED'
   AND s.metrics->'avg_metrics' ? $2
   AND s.end_time > $3
-GROUP BY batches_processed;`
-
-	var rows []*batchesWrapper
-	err = db.queryRows(query, &rows, experimentID, metricName, startTime)
+GROUP BY batches_processed;`, &rows, experimentID, metricName, startTime)
 	if err != nil {
 		return nil, endTime, errors.Wrapf(err, "error querying DB for training metric batches")
 	}
@@ -148,7 +129,8 @@ GROUP BY batches_processed;`
 // validation metric was recorded.
 func (db *PgDB) ValidationMetricBatches(experimentID int, metricName string, startTime time.Time) (
 	batches []int32, endTime time.Time, err error) {
-	query := `
+	var rows []*batchesWrapper
+	err = db.queryRows(`
 SELECT (s.prior_batches_processed + num_batches) AS batches_processed,
   max(v.end_time) as end_time
 FROM trials t INNER JOIN steps s ON t.id=s.trial_id
@@ -157,10 +139,7 @@ WHERE t.experiment_id=$1
   AND v.state = 'COMPLETED'
   AND v.metrics->'validation_metrics' ? $2
   AND v.end_time > $3
-GROUP BY batches_processed;`
-
-	var rows []*batchesWrapper
-	err = db.queryRows(query, &rows, experimentID, metricName, startTime)
+GROUP BY batches_processed;`, &rows, experimentID, metricName, startTime)
 	if err != nil {
 		return nil, endTime, errors.Wrapf(err, "error querying DB for validation metric batches")
 	}

--- a/master/internal/db/postgres_experiments.go
+++ b/master/internal/db/postgres_experiments.go
@@ -3,6 +3,9 @@ package db
 import (
 	"encoding/json"
 	"fmt"
+	"time"
+
+	"github.com/pkg/errors"
 )
 
 // ExperimentLabelUsage returns a flattened and deduplicated list of all the
@@ -34,4 +37,107 @@ func (db *PgDB) ExperimentLabelUsage() (labelUsage map[string]int, err error) {
 		}
 	}
 	return labelUsage, nil
+}
+
+// MetricNames returns the set of training and validation metric names that have been recorded for
+// an experiment.
+func (db *PgDB) MetricNames(experimentID int) (training []string, validation []string, err error) {
+	err = db.sql.Select(&training, `
+SELECT DISTINCT
+jsonb_object_keys(s.metrics->'avg_metrics') AS name
+FROM trials t
+INNER JOIN steps s ON t.id=s.trial_id
+WHERE t.experiment_id=$1;`, experimentID)
+	if err != nil {
+		return nil, nil, errors.Wrapf(err,
+			"error querying training metric names for experiment %d", experimentID)
+	}
+
+	err = db.sql.Select(&validation, `
+SELECT DISTINCT
+jsonb_object_keys(v.metrics->'validation_metrics') AS name
+FROM trials t
+INNER JOIN steps s ON t.id=s.trial_id
+LEFT OUTER JOIN validations v ON s.id=v.step_id AND s.trial_id=v.trial_id
+WHERE t.experiment_id=$1;`, experimentID)
+	if err != nil {
+		return nil, nil, errors.Wrapf(err,
+			"error querying validation metric names for experiment %d", experimentID)
+	}
+
+	return training, validation, err
+}
+
+// MetricBatches returns the milestones (in batches processed) at which a specific metric was
+// recorded.
+func (db *PgDB) MetricBatches(experimentID int, trainingMetric string, validationMetric string,
+	startTime time.Time) (batches []int32, endTime time.Time, err error) {
+	endTime = startTime
+	var metricName string
+	const TRAINING = "training"
+	const VALIDATION = "validation"
+	var metricType string
+	if len(trainingMetric) > 0 && len(validationMetric) == 0 {
+		metricName = trainingMetric
+		metricType = TRAINING
+	}
+	if len(trainingMetric) == 0 && len(validationMetric) > 0 {
+		metricName = validationMetric
+		metricType = VALIDATION
+	}
+	if len(metricName) == 0 {
+		return nil, time.Unix(0, 0),
+			errors.New("must provide one training metric, or one validation metric, but not both")
+	}
+
+	type batchesWrapper struct {
+		Batches int32     `db:"batches_processed"`
+		EndTime time.Time `db:"end_time"`
+	}
+
+	var query string
+	if metricType == TRAINING {
+		query = `
+SELECT DISTINCT s.end_time,
+  (s.prior_batches_processed + num_batches) AS batches_processed
+FROM trials t INNER JOIN steps s ON t.id=s.trial_id
+WHERE t.experiment_id=$1
+  AND s.state = 'COMPLETED'
+  AND s.metrics->'avg_metrics' ? $2
+  AND s.end_time > $3
+ORDER BY s.end_time;`
+	} else {
+		query = `
+SELECT DISTINCT v.end_time,
+  (s.prior_batches_processed + num_batches) AS batches_processed
+FROM trials t INNER JOIN steps s ON t.id=s.trial_id
+  LEFT OUTER JOIN validations v ON s.id=v.step_id AND s.trial_id=v.trial_id
+WHERE t.experiment_id=$1
+  AND v.state = 'COMPLETED'
+  AND v.metrics->'validation_metrics' ? $2
+  AND v.end_time > $3
+ORDER BY v.end_time;`
+	}
+
+	rows, err := db.sql.Queryx(query, experimentID, metricName, startTime)
+	if err != nil {
+		return nil, endTime, errors.Wrapf(err,
+			"failed to get metric batches for experiment %d and %s metric %s",
+			experimentID, metricType, metricName)
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var row batchesWrapper
+		err = rows.StructScan(&row)
+		if err != nil {
+			return nil, endTime, errors.Wrapf(err,
+				"error scanning training metric names for experiment %d",
+				experimentID)
+		}
+		batches = append(batches, row.Batches)
+		endTime = row.EndTime
+	}
+
+	return batches, endTime, nil
 }

--- a/proto/src/determined/api/v1/api.proto
+++ b/proto/src/determined/api/v1/api.proto
@@ -726,4 +726,26 @@ service Determined {
       tags: "Checkpoints"
     };
   }
+
+  // Get the set of metric names recorded for an experiment.
+  rpc MetricNames(MetricNamesRequest) returns (stream MetricNamesResponse) {
+    option (google.api.http) = {
+      get: "/api/v1/experiments/{experiment_id}/metrics-stream/metric-names"
+    };
+    option (grpc.gateway.protoc_gen_swagger.options.openapiv2_operation) = {
+      tags: "Experiments"
+    };
+  }
+
+  // Get the milestones (in batches processed) at which a metric is recorded by
+  // an experiment.
+  rpc MetricBatches(MetricBatchesRequest)
+      returns (stream MetricBatchesResponse) {
+    option (google.api.http) = {
+      get: "/api/v1/experiments/{experiment_id}/metrics-stream/batches"
+    };
+    option (grpc.gateway.protoc_gen_swagger.options.openapiv2_operation) = {
+      tags: "Experiments"
+    };
+  }
 }

--- a/proto/src/determined/api/v1/experiment.proto
+++ b/proto/src/determined/api/v1/experiment.proto
@@ -263,12 +263,14 @@ message MetricNamesResponse {
   repeated string validation_metrics = 3;
 }
 
-
+// To distinguish the 2 different categories of metrics.
 enum MetricType {
+  // Zero-value (not allowed).
+  METRIC_TYPE_UNSPECIFIED = 0;
   // For metrics emitted during training.
-  training = 0;
+  METRIC_TYPE_TRAINING = 1;
   // For metrics emitted during validation.
-  validation = 1;
+  METRIC_TYPE_VALIDATION = 2;
 }
 
 // Request the milestones (in batches processed) at which a metric is recorded

--- a/proto/src/determined/api/v1/experiment.proto
+++ b/proto/src/determined/api/v1/experiment.proto
@@ -263,15 +263,23 @@ message MetricNamesResponse {
   repeated string validation_metrics = 3;
 }
 
+
+enum MetricType {
+  // For metrics emitted during training.
+  training = 0;
+  // For metrics emitted during validation.
+  validation = 1;
+}
+
 // Request the milestones (in batches processed) at which a metric is recorded
 // by an experiment.
 message MetricBatchesRequest {
   // The id of the experiment.
   int32 experiment_id = 1;
-  // A training metric name (this or validation_metric required, not both).
-  string training_metric = 2;
-  // A validation metric name (this or training_metric required, not both).
-  string validation_metric = 3;
+  // A metric name
+  string metric_name = 2;
+  // The type of metric
+  MetricType metric_type = 3;
 }
 
 // Response to MetricBatchesRequest.

--- a/proto/src/determined/api/v1/experiment.proto
+++ b/proto/src/determined/api/v1/experiment.proto
@@ -246,3 +246,37 @@ message CreateExperimentResponse {
   // The created experiment config.
   google.protobuf.Struct config = 2;
 }
+
+// Request for the set of metrics recorded by an experiment.
+message MetricNamesRequest {
+  // The id of the experiment.
+  int32 experiment_id = 1;
+}
+
+// Request to MetricNamesRequest.
+message MetricNamesResponse {
+  // The name of the searcher metric
+  string searcher_metric = 1;
+  // List of training metric names.
+  repeated string training_metrics = 2;
+  // List of validation metric names.
+  repeated string validation_metrics = 3;
+}
+
+// Request the milestones (in batches processed) at which a metric is recorded
+// by an experiment.
+message MetricBatchesRequest {
+  // The id of the experiment.
+  int32 experiment_id = 1;
+  // A training metric name (this or validation_metric required, not both).
+  string training_metric = 2;
+  // A validation metric name (this or training_metric required, not both).
+  string validation_metric = 3;
+}
+
+// Request to MetricBatchesRequest.
+message MetricBatchesResponse {
+  // Milestones (in batches processed) at which the specified metric is
+  // recorded.
+  repeated int32 batches = 1;
+}

--- a/proto/src/determined/api/v1/experiment.proto
+++ b/proto/src/determined/api/v1/experiment.proto
@@ -253,7 +253,7 @@ message MetricNamesRequest {
   int32 experiment_id = 1;
 }
 
-// Request to MetricNamesRequest.
+// Response to MetricNamesRequest.
 message MetricNamesResponse {
   // The name of the searcher metric
   string searcher_metric = 1;
@@ -274,7 +274,7 @@ message MetricBatchesRequest {
   string validation_metric = 3;
 }
 
-// Request to MetricBatchesRequest.
+// Response to MetricBatchesRequest.
 message MetricBatchesResponse {
   // Milestones (in batches processed) at which the specified metric is
   // recorded.


### PR DESCRIPTION
## Description

These endpoints allow the web UI to populate menus for exploring metrics data interactively. They stream until the experiment completes to allow live updates of the UI as an experiment progresses.

## Test Plan

Integration tests are included and passed. Also did some manual testing via curl to validate expectations.

## Checklist

This is intended specifically for a web UI feature - not actually sure if we consider this a "feat" or a "chorse".

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.