### PR TITLE
fix: fix not being able to find resource pool [DET-4477]

### DIFF
--- a/docs/release-notes/1544-fix-cannot-find-resource-pool.txt
+++ b/docs/release-notes/1544-fix-cannot-find-resource-pool.txt
@@ -1,0 +1,5 @@
+:orphan:
+
+**Bug Fixes**
+
+-  Fix not being able to find resource pools for experiments.

--- a/master/internal/resourcemanagers/agent_resource_manager.go
+++ b/master/internal/resourcemanagers/agent_resource_manager.go
@@ -44,14 +44,12 @@ func (a *agentResourceManager) Receive(ctx *actor.Context) error {
 		}
 		a.forwardToPool(ctx, msg.ResourcePool, msg)
 	case ResourcesReleased:
-		for name := range a.pools {
-			a.forwardToPool(ctx, name, msg)
-		}
+		a.forwardToAllPools(ctx, msg)
 
 	case sproto.SetGroupMaxSlots:
-		a.forwardToPool(ctx, msg.ResourcePool, msg)
+		a.forwardToAllPools(ctx, msg)
 	case sproto.SetGroupWeight:
-		a.forwardToPool(ctx, msg.ResourcePool, msg)
+		a.forwardToAllPools(ctx, msg)
 	case GetTaskSummary:
 		if summary := a.aggregateTaskSummary(a.forwardToAllPools(ctx, msg)); summary != nil {
 			ctx.Respond(summary)
@@ -96,7 +94,8 @@ func (a *agentResourceManager) forwardToPool(
 	ctx *actor.Context, resourcePool string, msg actor.Message,
 ) {
 	if a.pools[resourcePool] == nil {
-		err := errors.Errorf("cannot find resource pool: %s", resourcePool)
+		err := errors.Errorf("cannot find resource pool %s for message %s from actor %s",
+			resourcePool, ctx.Message(), ctx.Sender().Address().String())
 		ctx.Log().WithError(err).Error("")
 		if ctx.ExpectingResponse() {
 			ctx.Respond(err)

--- a/master/internal/resourcemanagers/agent_resource_manager.go
+++ b/master/internal/resourcemanagers/agent_resource_manager.go
@@ -94,7 +94,7 @@ func (a *agentResourceManager) forwardToPool(
 	ctx *actor.Context, resourcePool string, msg actor.Message,
 ) {
 	if a.pools[resourcePool] == nil {
-		err := errors.Errorf("cannot find resource pool %s for message %s from actor %s",
+		err := errors.Errorf("cannot find resource pool %s for message %T from actor %s",
 			resourcePool, ctx.Message(), ctx.Sender().Address().String())
 		ctx.Log().WithError(err).Error("")
 		if ctx.ExpectingResponse() {


### PR DESCRIPTION
## Description

FIx not being able to find a resource pool.

## Test Plan

Use the CI test suite.

## Commentary (optional)

N/A

## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
