### PR TITLE
fix: avoid hangs during validation for TFKeras [DET-4434]

### DIFF
--- a/docs/release-notes/1555-tf-keras-hang.txt
+++ b/docs/release-notes/1555-tf-keras-hang.txt
@@ -1,0 +1,6 @@
+:orphan:
+
+**Bug Fixes**
+
+-  Fix issue that occasionally made TFKerasTrial hang for multi-GPU
+   training during COMPUTE_VALIDATION_STEP.

--- a/harness/determined/keras/_tf_keras_trial.py
+++ b/harness/determined/keras/_tf_keras_trial.py
@@ -21,7 +21,7 @@ from tensorflow.python.keras.saving.hdf5_format import (
 from tensorflow.python.keras.utils.mode_keys import ModeKeys
 
 import determined as det
-from determined import horovod, ipc, keras, util, workload
+from determined import horovod, keras, util, workload
 from determined.horovod import hvd
 from determined_common import check
 
@@ -762,25 +762,6 @@ class TFKerasTrialController(det.LoopTrialController):
             return workload.Skipped()
 
         return {"num_inputs": num_inputs, "validation_metrics": metrics}
-
-    def _global_barrier(self) -> None:
-        # Executes a barrier by communicating directly between worker processes via ZMQ.
-        logging.debug(f"Worker {self.context.distributed.get_rank()} entering global barrier.")
-        if self.is_chief:
-            self.train_process_comm_chief = cast(
-                ipc.ZMQBroadcastServer, self.train_process_comm_chief
-            )
-            self.train_process_comm_chief.gather_with_polling(lambda: None)
-            self.train_process_comm_chief.broadcast(None)
-        else:
-            self.train_process_comm_worker = cast(
-                ipc.ZMQBroadcastClient, self.train_process_comm_worker
-            )
-            self.train_process_comm_worker.send([None])
-            # Synchronize with the chief so that there is no risk of accidentally calling send()
-            # for a future gather before all workers have called send() on this gather.
-            _ = self.train_process_comm_worker.recv()
-        logging.debug(f"Worker {self.context.distributed.get_rank()} exiting global barrier.")
 
     def _stop_training_check(self) -> None:
         # Detect when users set stop_training and convert it to a set_stop_requested.


### PR DESCRIPTION
## Description
We have observed an issue where `hvd.allreduce()` may hang if different workers
call into it minutes apart. This can occur if workers in TFKerasTrial complete 
`model.evaluate()` at different speeds.


## Test Plan
Added the following snippet into `compute_validation_metrics()` and confirmed that 
we no longer hang:

```
delays = {
            0: 0,
            1: 7,
            2: 6,
            3: 6,
            14: 3,
            15: 3,
            20: 3,
            13: 2,
            22: 2,
            23: 2,
            21: 2,
            5: 2,
            12: 1,
            7: 1,
            6: 1,
            8: 1,
            4: 1,
            10: 1,
            18: 1,
        }

        my_delay = 0
        if self.context.distributed.get_rank() in delays:
            my_delay = delays[self.context.distributed.get_rank()]

        my_delay *= 60
        my_delay += random.randint(1,30)

        import time
        print(f"Worker {self.context.distributed.get_rank()} sleeping for {my_delay}.")
        time.sleep(my_delay)
        print(f"Worker {self.context.distributed.get_rank()} fininshed sleeping.")
```


