### PR TITLE
feat: add streaming endpoint for trial metrics at a specific point [DET-4440]

### DIFF
--- a/proto/src/determined/api/v1/api.proto
+++ b/proto/src/determined/api/v1/api.proto
@@ -748,4 +748,16 @@ service Determined {
       tags: "Experiments"
     };
   }
+
+  // Get a snapshot of a metric across all trials at a certain point of
+  // progress.
+  rpc TrialsSnapshot(TrialsSnapshotRequest)
+      returns (stream TrialsSnapshotResponse) {
+    option (google.api.http) = {
+      get: "/api/v1/experiments/{experiment_id}/metrics-stream/trials-snapshot"
+    };
+    option (grpc.gateway.protoc_gen_swagger.options.openapiv2_operation) = {
+      tags: "Experiments"
+    };
+  }
 }

--- a/proto/src/determined/api/v1/experiment.proto
+++ b/proto/src/determined/api/v1/experiment.proto
@@ -278,9 +278,9 @@ enum MetricType {
 message MetricBatchesRequest {
   // The id of the experiment.
   int32 experiment_id = 1;
-  // A metric name
+  // A metric name.
   string metric_name = 2;
-  // The type of metric
+  // The type of metric.
   MetricType metric_type = 3;
 }
 
@@ -289,4 +289,31 @@ message MetricBatchesResponse {
   // Milestones (in batches processed) at which the specified metric is
   // recorded.
   repeated int32 batches = 1;
+}
+
+// Request metrics from all trials at a progress point of progress.
+message TrialsSnapshotRequest {
+  // The id of the experiment.
+  int32 experiment_id = 1;
+  // The point of progress at which to query metrics.
+  int32 batches_processed = 2;
+  // A metric name.
+  string metric_name = 3;
+  // The type of metric.
+  MetricType metric_type = 4;
+}
+
+// Response to TrialSnapshotResponse
+message TrialsSnapshotResponse {
+  // Metric value and metadata for a trial that has progress this far.
+  message Trial {
+    // The id of the trial.
+    int32 trial_id = 1;
+    // A dictionary of hyperparameter values for this trial.
+    google.protobuf.Struct hparams = 2;
+    // The value of the metric in this trial at this point.
+    double metric = 3;
+  }
+  // A list of trials.
+  repeated Trial trials = 1;
 }


### PR DESCRIPTION
This is closely related to https://github.com/determined-ai/determined/pull/1538. It's an additional API endpoint that's part of the same project and addresses some final feedback there.