### PR TITLE
feat: add configurations for priority scheduler [DET-4507, DET-4509]

### DIFF
--- a/master/internal/resourcemanagers/agent_resource_manager.go
+++ b/master/internal/resourcemanagers/agent_resource_manager.go
@@ -69,11 +69,18 @@ func (a *agentResourceManager) createResourcePool(
 	ctx *actor.Context, config *ResourcePoolConfig, cert *tls.Certificate,
 ) *actor.Ref {
 	ctx.Log().Infof("creating resource pool: %s", config.PoolName)
+
+	scheduler := a.config.Scheduler
+	if config.Scheduler != nil {
+		scheduler = config.Scheduler
+		ctx.Log().Infof("pool %s using local scheduling config", config.PoolName)
+	}
+
 	rp := NewResourcePool(
 		config,
 		cert,
-		MakeScheduler(a.config.SchedulingPolicy),
-		MakeFitFunction(a.config.FittingPolicy),
+		MakeScheduler(scheduler.getType()),
+		MakeFitFunction(scheduler.FittingPolicy),
 	)
 	ref, ok := ctx.ActorOf(config.PoolName, rp)
 	if !ok {

--- a/master/internal/resourcemanagers/agent_resource_manager_test.go
+++ b/master/internal/resourcemanagers/agent_resource_manager_test.go
@@ -13,8 +13,7 @@ func TestAgentRMRoutingTaskRelatedMessages(t *testing.T) {
 
 	// Set up one CPU resource pool and one GPU resource pool.
 	rmConfig := &AgentResourceManagerConfig{
-		SchedulingPolicy:       "fair_share",
-		FittingPolicy:          "best",
+		Scheduler:              defaultSchedulerConfig(),
 		DefaultCPUResourcePool: "cpu-pool",
 		DefaultGPUResourcePool: "gpu-pool",
 	}

--- a/master/internal/resourcemanagers/deprecated_config.go
+++ b/master/internal/resourcemanagers/deprecated_config.go
@@ -13,6 +13,8 @@ type Config struct {
 	Type             string                  `json:"type"`
 	Fit              string                  `json:"fit"`
 	ResourceProvider *ResourceProviderConfig `json:"resource_provider"`
+	Preemption       bool                    `json:"preemption"`
+	DefaultPriority  *int                    `json:"default_priority"`
 }
 
 // ResourceProviderConfig hosts configuration fields for the resource manager.

--- a/master/internal/resourcemanagers/fitting_methods.go
+++ b/master/internal/resourcemanagers/fitting_methods.go
@@ -32,9 +32,9 @@ func WorstFit(_ *AllocateRequest, agent *agentState) float64 {
 // MakeFitFunction returns the corresponding fitting function.
 func MakeFitFunction(fittingPolicy string) func(*AllocateRequest, *agentState) float64 {
 	switch fittingPolicy {
-	case "worst":
+	case worst:
 		return WorstFit
-	case "best":
+	case best:
 		return BestFit
 	default:
 		panic(fmt.Sprintf("invalid scheduler fit: %s", fittingPolicy))

--- a/master/internal/resourcemanagers/resource_manager_config.go
+++ b/master/internal/resourcemanagers/resource_manager_config.go
@@ -36,17 +36,43 @@ func ResolveConfig(
 	switch {
 	case schedulerConf == nil && resourceManagerConf == nil:
 		resourceManagerConf = DefaultRMConfig()
-		resourceManagerConf.AgentRM.DefaultCPUResourcePool = defaultResourcePoolName
-		resourceManagerConf.AgentRM.DefaultGPUResourcePool = defaultResourcePoolName
 
 	case schedulerConf != nil && resourceManagerConf == nil:
 		switch {
 		case schedulerConf.ResourceProvider == nil ||
 			schedulerConf.ResourceProvider.DefaultRPConfig != nil:
+
+			// Fill in defaults for the old scheduler format.
+			if schedulerConf.Type == "" {
+				schedulerConf.Type = fairShareScheduling
+			}
+			if schedulerConf.Fit == "" {
+				schedulerConf.Fit = defaultFitPolicy
+			}
+			schedulerPolicyConf := &SchedulerConfig{
+				FittingPolicy: schedulerConf.Fit,
+			}
+
+			switch schedulerConf.Type {
+			case fairShareScheduling:
+				schedulerPolicyConf.FairShare = &FairShareSchedulerConfig{}
+			case priorityScheduling:
+				schedulerPolicyConf.Priority = &PrioritySchedulerConfig{
+					Preemption: schedulerConf.Preemption,
+				}
+
+				if schedulerConf.DefaultPriority != nil {
+					schedulerPolicyConf.Priority.DefaultPriority = schedulerConf.DefaultPriority
+				}
+			default:
+				return nil, nil, errors.Errorf(
+					"unsupported scheduler type %s; "+
+						"scheduler type must be `fair_share` or `priority`", schedulerConf.Type)
+			}
+
 			resourceManagerConf = &ResourceManagerConfig{
 				AgentRM: &AgentResourceManagerConfig{
-					SchedulingPolicy:       schedulerConf.Type,
-					FittingPolicy:          schedulerConf.Fit,
+					Scheduler:              schedulerPolicyConf,
 					DefaultCPUResourcePool: defaultResourcePoolName,
 					DefaultGPUResourcePool: defaultResourcePoolName,
 				},
@@ -63,13 +89,49 @@ func ResolveConfig(
 	}
 
 	if resourceManagerConf != nil && resourceManagerConf.AgentRM != nil {
-		if resourceManagerConf.AgentRM.SchedulingPolicy == "" {
-			resourceManagerConf.AgentRM.SchedulingPolicy = DefaultRMConfig().AgentRM.SchedulingPolicy
+		if resourceManagerConf.AgentRM.Scheduler == nil {
+			resourceManagerConf.AgentRM.Scheduler = defaultSchedulerConfig()
 		}
-		if resourceManagerConf.AgentRM.FittingPolicy == "" {
-			resourceManagerConf.AgentRM.FittingPolicy = DefaultRMConfig().AgentRM.FittingPolicy
+
+		// Fill in default fitting policy if unspecified.
+		if resourceManagerConf.AgentRM.Scheduler.FittingPolicy == "" {
+			resourceManagerConf.AgentRM.Scheduler.FittingPolicy = defaultFitPolicy
+		}
+
+		// Set default scheduling priority if it is not specified and priority scheduler
+		// is being used.
+		prioritySchedulerConf := resourceManagerConf.AgentRM.Scheduler.Priority
+		if prioritySchedulerConf != nil && prioritySchedulerConf.DefaultPriority == nil {
+			defaultPriority := DefaultSchedulingPriority
+			prioritySchedulerConf.DefaultPriority = &defaultPriority
+		}
+
+		// If a pool specifies a scheduler unique for that pool we overwrite the
+		// scheduler specified as part of the ResourceManager config and replace
+		// it completely. We go through the pools if they specify a scheduler and
+		// fill in defaults the same way we do for the ResourceManager.
+		if resourcePoolsConf != nil {
+			for _, resourcePool := range resourcePoolsConf.ResourcePools {
+				if resourcePool.Scheduler == nil {
+					continue
+				}
+
+				if resourcePool.Scheduler.FittingPolicy == "" {
+					resourcePool.Scheduler.FittingPolicy = defaultFitPolicy
+				}
+
+				if resourcePool.Scheduler.Priority == nil {
+					continue
+				}
+
+				if resourcePool.Scheduler.Priority.DefaultPriority == nil {
+					defaultPriority := DefaultSchedulingPriority
+					resourcePool.Scheduler.Priority.DefaultPriority = &defaultPriority
+				}
+			}
 		}
 	}
+
 	return resourceManagerConf, resourcePoolsConf, nil
 }
 
@@ -83,8 +145,9 @@ func DefaultRMConfig() *ResourceManagerConfig {
 // DefaultAgentRMConfig returns the default determined resource manager configuration.
 func DefaultAgentRMConfig() *AgentResourceManagerConfig {
 	return &AgentResourceManagerConfig{
-		SchedulingPolicy: "fair_share",
-		FittingPolicy:    "best",
+		Scheduler:              defaultSchedulerConfig(),
+		DefaultGPUResourcePool: defaultResourcePoolName,
+		DefaultCPUResourcePool: defaultResourcePoolName,
 	}
 }
 
@@ -110,21 +173,14 @@ func (r *ResourceManagerConfig) UnmarshalJSON(data []byte) error {
 
 // AgentResourceManagerConfig hosts configuration fields for the determined resource manager.
 type AgentResourceManagerConfig struct {
-	SchedulingPolicy       string `json:"scheduling_policy"`
-	FittingPolicy          string `json:"fitting_policy"`
-	DefaultCPUResourcePool string `json:"default_cpu_resource_pool"`
-	DefaultGPUResourcePool string `json:"default_gpu_resource_pool"`
+	Scheduler              *SchedulerConfig `json:"scheduler"`
+	DefaultCPUResourcePool string           `json:"default_cpu_resource_pool"`
+	DefaultGPUResourcePool string           `json:"default_gpu_resource_pool"`
 }
 
 // Validate implements the check.Validatable interface.
 func (a AgentResourceManagerConfig) Validate() []error {
 	return []error{
-		check.Contains(
-			a.SchedulingPolicy, []interface{}{"priority", "fair_share"}, "invalid scheduling policy",
-		),
-		check.Contains(
-			a.FittingPolicy, []interface{}{"best", "worst"}, "invalid fitting policy",
-		),
 		check.NotEmpty(a.DefaultCPUResourcePool, "default_cpu_resource_pool should be non-empty"),
 		check.NotEmpty(a.DefaultGPUResourcePool, "default_gpu_resource_pool should be non-empty"),
 	}

--- a/master/internal/resourcemanagers/resource_manager_config.go
+++ b/master/internal/resourcemanagers/resource_manager_config.go
@@ -93,41 +93,19 @@ func ResolveConfig(
 			resourceManagerConf.AgentRM.Scheduler = defaultSchedulerConfig()
 		}
 
-		// Fill in default fitting policy if unspecified.
-		if resourceManagerConf.AgentRM.Scheduler.FittingPolicy == "" {
-			resourceManagerConf.AgentRM.Scheduler.FittingPolicy = defaultFitPolicy
-		}
+		// Fill in default fitting policy and default priority if unspecified.
+		fillInSchedulerDefaults(resourceManagerConf.AgentRM.Scheduler)
 
-		// Set default scheduling priority if it is not specified and priority scheduler
-		// is being used.
-		prioritySchedulerConf := resourceManagerConf.AgentRM.Scheduler.Priority
-		if prioritySchedulerConf != nil && prioritySchedulerConf.DefaultPriority == nil {
-			defaultPriority := DefaultSchedulingPriority
-			prioritySchedulerConf.DefaultPriority = &defaultPriority
-		}
-
-		// If a pool specifies a scheduler unique for that pool we overwrite the
-		// scheduler specified as part of the ResourceManager config and replace
-		// it completely. We go through the pools if they specify a scheduler and
-		// fill in defaults the same way we do for the ResourceManager.
+		// If a pool specifies a scheduler, that pool will ignore the ResourceManager
+		// scheduler (e.g., it does not use the values in the ResourceManager scheduler
+		// as defaults). For pools that specify a scheduler, we fill in defaults the
+		// same way we do for the ResourceManager.
 		if resourcePoolsConf != nil {
 			for _, resourcePool := range resourcePoolsConf.ResourcePools {
 				if resourcePool.Scheduler == nil {
 					continue
 				}
-
-				if resourcePool.Scheduler.FittingPolicy == "" {
-					resourcePool.Scheduler.FittingPolicy = defaultFitPolicy
-				}
-
-				if resourcePool.Scheduler.Priority == nil {
-					continue
-				}
-
-				if resourcePool.Scheduler.Priority.DefaultPriority == nil {
-					defaultPriority := DefaultSchedulingPriority
-					resourcePool.Scheduler.Priority.DefaultPriority = &defaultPriority
-				}
+				fillInSchedulerDefaults(resourcePool.Scheduler)
 			}
 		}
 	}

--- a/master/internal/resourcemanagers/resource_pool_config.go
+++ b/master/internal/resourcemanagers/resource_pool_config.go
@@ -19,6 +19,7 @@ type ResourcePoolConfig struct {
 	PoolName    string              `json:"pool_name"`
 	Description string              `json:"description"`
 	Provider    *provisioner.Config `json:"provider"`
+	Scheduler   *SchedulerConfig    `json:"scheduler,omitempty"`
 }
 
 // Validate implements the check.Validatable interface.

--- a/master/internal/resourcemanagers/scheduler.go
+++ b/master/internal/resourcemanagers/scheduler.go
@@ -15,9 +15,9 @@ type Scheduler interface {
 // MakeScheduler returns the corresponding scheduler implementation.
 func MakeScheduler(schedulingPolicy string) Scheduler {
 	switch schedulingPolicy {
-	case "priority":
+	case priorityScheduling:
 		return NewPriorityScheduler()
-	case "fair_share":
+	case fairShareScheduling:
 		return NewFairShareScheduler()
 	default:
 		panic(fmt.Sprintf("invalid scheduler: %s", schedulingPolicy))

--- a/master/internal/resourcemanagers/scheduler_config.go
+++ b/master/internal/resourcemanagers/scheduler_config.go
@@ -45,7 +45,7 @@ func (s *SchedulerConfig) UnmarshalJSON(data []byte) error {
 func (s SchedulerConfig) Validate() []error {
 	return []error{
 		check.Contains(
-			s.FittingPolicy, []interface{}{"best", "worst"}, "invalid fitting policy",
+			s.FittingPolicy, []interface{}{best, worst}, "invalid fitting policy",
 		),
 	}
 }

--- a/master/internal/resourcemanagers/scheduler_config.go
+++ b/master/internal/resourcemanagers/scheduler_config.go
@@ -1,0 +1,90 @@
+package resourcemanagers
+
+import (
+	"github.com/determined-ai/determined/master/pkg/check"
+	"github.com/determined-ai/determined/master/pkg/union"
+)
+
+const (
+	// MinUserSchedulingPriority is the smallest priority users may specify.
+	MinUserSchedulingPriority = 1
+	// MaxUserSchedulingPriority is the largest priority users may specify.
+	MaxUserSchedulingPriority = 99
+	// DefaultSchedulingPriority is the default scheduling policy if users do not specify one.
+	DefaultSchedulingPriority = 42
+
+	fairShareScheduling = "fair_share"
+	priorityScheduling  = "priority"
+
+	best             = "best"
+	worst            = "worst"
+	defaultFitPolicy = best
+)
+
+func defaultSchedulerConfig() *SchedulerConfig {
+	return &SchedulerConfig{
+		FairShare:     &FairShareSchedulerConfig{},
+		FittingPolicy: defaultFitPolicy,
+	}
+}
+
+// SchedulerConfig holds the configurations for scheduling policies.
+type SchedulerConfig struct {
+	FairShare     *FairShareSchedulerConfig `union:"type,fair_share" json:"-"`
+	Priority      *PrioritySchedulerConfig  `union:"type,priority" json:"-"`
+	FittingPolicy string                    `json:"fitting_policy"`
+}
+
+// MarshalJSON implements the json.Marshaler interface.
+func (s SchedulerConfig) MarshalJSON() ([]byte, error) {
+	return union.Marshal(s)
+}
+
+// UnmarshalJSON implements the json.Unmarshaler interface.
+func (s *SchedulerConfig) UnmarshalJSON(data []byte) error {
+	return union.Unmarshal(data, s)
+}
+
+// Validate implements the check.Validatable interface.
+func (s SchedulerConfig) Validate() []error {
+	return []error{
+		check.Contains(
+			s.FittingPolicy, []interface{}{"best", "worst"}, "invalid fitting policy",
+		),
+	}
+}
+
+func (s *SchedulerConfig) getType() string {
+	switch {
+	case s.FairShare != nil:
+		return fairShareScheduling
+	case s.Priority != nil:
+		return priorityScheduling
+	default:
+		panic("neither scheduler type configured")
+	}
+}
+
+// FairShareSchedulerConfig holds configurations for the fair share scheduler.
+type FairShareSchedulerConfig struct{}
+
+// PrioritySchedulerConfig holds the configurations for the priority scheduler.
+type PrioritySchedulerConfig struct {
+	Preemption      bool `json:"preemption"`
+	DefaultPriority *int `json:"default_priority"`
+}
+
+// Validate implements the check.Validatable interface.
+func (p PrioritySchedulerConfig) Validate() []error {
+	errors := make([]error, 0)
+
+	if p.DefaultPriority != nil {
+		errors = append(errors, check.GreaterThanOrEqualTo(
+			*p.DefaultPriority, MinUserSchedulingPriority,
+			"scheduling priority must be greater than 0 and less than 100"))
+		errors = append(errors, check.LessThanOrEqualTo(
+			*p.DefaultPriority, MaxUserSchedulingPriority,
+			"scheduling priority must be greater than 0 and less than 100"))
+	}
+	return errors
+}


### PR DESCRIPTION
## Description
This PR adds the UX options for configuring the priority scheduler. For the 
`scheduler` (old way of configuring) we add `preemption` and `default_priority`
as top level configurations. For `resource_manager` (new way of configuring) we
make `scheduler` a nested configuration. This nested config can also be specified
for individual resource pools, allowing them overwrite the `scheduler` specified
in the `resource_manager`.  We also add an option to specify priority as part
of the `resources` field for individual experiments and tasks.

We are not adding documentation for any of this as these options are not yet 
supported in the product.


## Test Plan
Tested manually by starting up the master with different configurations.

@shiyuann I am adding you to this since it touches a lot of the code you recently worked on.