### PR TITLE
feat: implement API endpoint for sampling streams of metrics from the best trials [DET-4441]

### DIFF
--- a/e2e_tests/tests/experiment/test_metrics.py
+++ b/e2e_tests/tests/experiment/test_metrics.py
@@ -140,6 +140,16 @@ def request_valid_metric_batches(experiment_id):  # type: ignore
     return None
 
 
+def validate_hparam_types(hparams: dict) -> Union[None, str]:
+    for hparam in ["dropout1", "dropout2", "learning_rate"]:
+        if type(hparams[hparam]) != float:
+            return "hparam %s of unexpected type" % hparam
+    for hparam in ["global_batch_size", "n_filters1", "n_filters2"]:
+        if type(hparams[hparam]) != int:
+            return "hparam %s of unexpected type" % hparam
+    return None
+
+
 def request_train_trials_snapshot(experiment_id):  # type: ignore
     response = api.get(
         conf.make_master_url(),
@@ -161,26 +171,11 @@ def request_train_trials_snapshot(experiment_id):  # type: ignore
     for i in range(1, len(results)):
         for trial in results[i]["trials"]:
             trials.add(trial["trialId"])
-            for param in ["dropout1", "dropout2", "learning_rate"]:
-                if type(trial["hparams"][param]) != float:
-                    return ("hparam %s of unexpected type" % param, results)
-            for param in ["global_batch_size", "n_filters1", "n_filters2"]:
-                if type(trial["hparams"][param]) != int:
-                    return ("hparam %s of unexpected type" % param, results)
+            validate_hparam_types(trial["hparams"])
             if type(trial["metric"]) != float:
                 return ("metric of unexpected type", results)
     if len(trials) != 5:
         return ("unexpected number of trials received", results)
-    return None
-
-
-def validate_hparam_types(hparams: dict) -> Union[None, str]:
-    for hparam in ["dropout1", "dropout2", "learning_rate"]:
-        if type(hparams[hparam]) != float:
-            return "hparam %s of unexpected type" % hparam
-    for hparam in ["global_batch_size", "n_filters1", "n_filters2"]:
-        if type(hparams[hparam]) != int:
-            return "hparam %s of unexpected type" % hparam
     return None
 
 

--- a/e2e_tests/tests/experiment/test_metrics.py
+++ b/e2e_tests/tests/experiment/test_metrics.py
@@ -1,5 +1,6 @@
 import json
 import multiprocessing as mp
+from typing import Set, Union
 
 import pytest
 
@@ -14,7 +15,7 @@ from tests import experiment as exp
 def test_streaming_metrics_api() -> None:
     auth.initialize_session(conf.make_master_url(), try_reauth=True)
 
-    pool = mp.pool.ThreadPool(processes=5)
+    pool = mp.pool.ThreadPool(processes=7)
 
     experiment_id = exp.create_experiment(
         conf.fixtures_path("mnist_pytorch/adaptive_short.yaml"),
@@ -29,12 +30,16 @@ def test_streaming_metrics_api() -> None:
     valid_metric_batches_thread = pool.apply_async(request_valid_metric_batches, (experiment_id,))
     train_trials_snapshot_thread = pool.apply_async(request_train_trials_snapshot, (experiment_id,))
     valid_trials_snapshot_thread = pool.apply_async(request_valid_trials_snapshot, (experiment_id,))
+    train_trials_sample_thread = pool.apply_async(request_train_trials_sample, (experiment_id,))
+    valid_trials_sample_thread = pool.apply_async(request_valid_trials_sample, (experiment_id,))
 
     metric_names_results = metric_names_thread.get()
     train_metric_batches_results = train_metric_batches_thread.get()
     valid_metric_batches_results = valid_metric_batches_thread.get()
     train_trials_snapshot_results = train_trials_snapshot_thread.get()
     valid_trials_snapshot_results = valid_trials_snapshot_thread.get()
+    train_trials_sample_results = train_trials_sample_thread.get()
+    valid_trials_sample_results = valid_trials_sample_thread.get()
 
     if metric_names_results is not None:
         pytest.fail("metric-names: %s. Results: %s" % metric_names_results)
@@ -46,6 +51,10 @@ def test_streaming_metrics_api() -> None:
         pytest.fail("trials-snapshot (training): %s. Results: %s" % train_trials_snapshot_results)
     if valid_trials_snapshot_results is not None:
         pytest.fail("trials-snapshot (validation): %s. Results: %s" % valid_trials_snapshot_results)
+    if train_trials_sample_results is not None:
+        pytest.fail("trials-sample (training): %s. Results: %s" % train_trials_sample_results)
+    if valid_trials_sample_results is not None:
+        pytest.fail("trials-sample (validation): %s. Results: %s" % valid_trials_sample_results)
 
 
 def request_metric_names(experiment_id):  # type: ignore
@@ -165,6 +174,16 @@ def request_train_trials_snapshot(experiment_id):  # type: ignore
     return None
 
 
+def validate_hparam_types(hparams: dict) -> Union[None, str]:
+    for hparam in ["dropout1", "dropout2", "learning_rate"]:
+        if type(hparams[hparam]) != float:
+            return "hparam %s of unexpected type" % hparam
+    for hparam in ["global_batch_size", "n_filters1", "n_filters2"]:
+        if type(hparams[hparam]) != int:
+            return "hparam %s of unexpected type" % hparam
+    return None
+
+
 def request_valid_trials_snapshot(experiment_id):  # type: ignore
     response = api.get(
         conf.make_master_url(),
@@ -186,14 +205,72 @@ def request_valid_trials_snapshot(experiment_id):  # type: ignore
     for i in range(1, len(results)):
         for trial in results[i]["trials"]:
             trials.add(trial["trialId"])
-            for param in ["dropout1", "dropout2", "learning_rate"]:
-                if type(trial["hparams"][param]) != float:
-                    return ("hparam %s of unexpected type" % param, results)
-            for param in ["global_batch_size", "n_filters1", "n_filters2"]:
-                if type(trial["hparams"][param]) != int:
-                    return ("hparam %s of unexpected type" % param, results)
+            hparam_error = validate_hparam_types(trial["hparams"])
+            if hparam_error is not None:
+                return (hparam_error, results)
             if type(trial["metric"]) != float:
                 return ("metric of unexpected type", results)
     if len(trials) != 5:
         return ("unexpected number of trials received", results)
     return None
+
+
+def check_trials_sample_result(results: list) -> Union[None, tuple]:
+    # First let's verify an empty response was sent back before any real work was done
+    if (
+        results[0]["trials"] != []
+        or results[0]["promotedTrials"] != []
+        or results[0]["demotedTrials"] != []
+    ):
+        return ("unexpected trials in first response", results)
+
+    # Then we verify that we receive the expected number of trials and the right types
+    trials: Set[int] = set()
+    datapoints = {}
+    for i in range(1, len(results)):
+        newTrials = set()
+        for trial in results[i]["promotedTrials"]:
+            if trial in trials:
+                return ("trial lists as promoted twice", results)
+            newTrials.add(trial)
+            datapoints[trial] = 0
+        for trial in results[i]["trials"]:
+            if trial["trialId"] in newTrials:
+                hparam_error = validate_hparam_types(trial["hparams"])
+                if hparam_error is not None:
+                    return (hparam_error, results)
+            else:
+                if trial["hparams"] is not None:
+                    return ("hparams repeated for trial", results)
+            for point in trial["data"]:
+                if point["batches"] > datapoints[trial["trialId"]]:
+                    datapoints[trial["trialId"]] = point["batches"]
+                else:
+                    return ("data received out of order: " + str(trial["trialId"]), results)
+    return None
+
+
+def request_train_trials_sample(experiment_id):  # type: ignore
+    response = api.get(
+        conf.make_master_url(),
+        "api/v1/experiments/{}/metrics-stream/trials-sample".format(experiment_id),
+        params={
+            "metric_name": "loss",
+            "metric_type": "METRIC_TYPE_TRAINING",
+        },
+    )
+    results = [message["result"] for message in map(json.loads, response.text.splitlines())]
+    return check_trials_sample_result(results)
+
+
+def request_valid_trials_sample(experiment_id):  # type: ignore
+    response = api.get(
+        conf.make_master_url(),
+        "api/v1/experiments/{}/metrics-stream/trials-sample".format(experiment_id),
+        params={
+            "metric_name": "accuracy",
+            "metric_type": "METRIC_TYPE_VALIDATION",
+        },
+    )
+    results = [message["result"] for message in map(json.loads, response.text.splitlines())]
+    return check_trials_sample_result(results)

--- a/master/internal/db/postgres_experiments.go
+++ b/master/internal/db/postgres_experiments.go
@@ -316,8 +316,8 @@ SELECT t.id FROM (
 }
 
 type metricsSeriesWrapper struct {
-	Batches int       `db:"batches" json:"batches"`
-	Value   float64   `db:"value" json:"value"`
+	Batches int       `db:"batches"`
+	Value   float64   `db:"value"`
 	EndTime time.Time `db:"end_time"`
 }
 

--- a/master/internal/db/postgres_experiments.go
+++ b/master/internal/db/postgres_experiments.go
@@ -7,8 +7,16 @@ import (
 
 	"github.com/pkg/errors"
 
+	"github.com/determined-ai/determined/master/internal/lttb"
 	"github.com/determined-ai/determined/master/pkg/protoutils"
 	"github.com/determined-ai/determined/proto/pkg/apiv1"
+)
+
+const (
+	asc  = "" // This is blank because ascending is the default
+	desc = "DESC"
+	max  = "max"
+	min  = "min"
 )
 
 // ExperimentLabelUsage returns a flattened and deduplicated list of all the
@@ -251,4 +259,127 @@ ORDER BY v.end_time;`, &rows, metricName, experimentID, batchesProcessed, startT
 	}
 
 	return trials, endTime, nil
+}
+
+// TopTrialsByMetric chooses the subset of trials from an experiment that recorded the best values
+// for the specified metric at any point during the trial.
+func (db *PgDB) TopTrialsByMetric(experimentID int, maxTrials int, metric string,
+	smallerIsBetter bool) (trials []int32, err error) {
+	order := desc
+	aggregate := max
+	if smallerIsBetter {
+		order = asc
+		aggregate = min
+	}
+	err = db.sql.Select(&trials, fmt.Sprintf(`
+SELECT t.id FROM (
+  SELECT t.id,
+    %s((v.metrics->'validation_metrics'->$1)::text::numeric) as best_metric
+  FROM trials t
+    INNER JOIN steps s ON t.id=s.trial_id
+    RIGHT JOIN validations v ON s.id=v.step_id AND s.trial_id=v.trial_id
+  WHERE t.experiment_id=$2
+    AND v.state = 'COMPLETED'
+  GROUP BY t.id
+  ORDER BY best_metric %s
+  LIMIT $3
+);`, aggregate, order), metric, experimentID, maxTrials)
+	return trials, err
+}
+
+// TopTrialsByTrainingLength chooses the subset of trials that has been training for the highest
+// number of batches, using the specified metric as a tie breaker.
+func (db *PgDB) TopTrialsByTrainingLength(experimentID int, maxTrials int, metric string,
+	smallerIsBetter bool) (trials []int32, err error) {
+	order := desc
+	aggregate := max
+	if smallerIsBetter {
+		order = asc
+		aggregate = min
+	}
+
+	err = db.sql.Select(&trials, fmt.Sprintf(`
+SELECT t.id FROM (
+  SELECT t.id,
+    max(s.prior_batches_processed) as progress,
+    %s((v.metrics->'validation_metrics'->$1)::text::numeric) as best_metric
+  FROM trials t
+    INNER JOIN steps s ON t.id=s.trial_id
+    RIGHT JOIN validations v ON s.id=v.step_id AND s.trial_id=v.trial_id
+  WHERE t.experiment_id=$2
+    AND v.state = 'COMPLETED'
+  GROUP BY t.id
+  ORDER BY progress DESC, best_metric %s
+  LIMIT $3
+) t;`, aggregate, order), metric, experimentID, maxTrials)
+	return trials, err
+}
+
+type metricsSeriesWrapper struct {
+	Batches int       `db:"batches" json:"batches"`
+	Value   float64   `db:"value" json:"value"`
+	EndTime time.Time `db:"end_time"`
+}
+
+// TrainingMetricsSeries returns a time-series of the specified training metric in the specified
+// trial.
+func (db *PgDB) TrainingMetricsSeries(trialID int32, startTime time.Time, metricName string,
+	startBatches int, endBatches int) (metricSeries []lttb.Point, endTime time.Time,
+	err error) {
+	var rows []metricsSeriesWrapper
+	err = db.queryRows(`
+SELECT 
+  (prior_batches_processed + num_batches) AS batches,
+  s.metrics->'avg_metrics'->$1 AS value,
+  s.end_time as end_time
+FROM trials t
+  INNER JOIN steps s ON t.id=s.trial_id
+WHERE t.id=$2
+  AND s.state = 'COMPLETED'
+  AND (prior_batches_processed + num_batches) >= $3
+  AND (prior_batches_processed + num_batches) <= $4
+  AND s.end_time > $5
+ORDER BY batches;`, &rows, metricName, trialID, startBatches, endBatches, startTime)
+	if err != nil {
+		return nil, endTime, errors.Wrapf(err, "failed to get metrics to sample for experiment")
+	}
+	for _, row := range rows {
+		metricSeries = append(metricSeries, lttb.Point{X: float64(row.Batches), Y: row.Value})
+		if row.EndTime.After(endTime) {
+			endTime = row.EndTime
+		}
+	}
+	return metricSeries, endTime, nil
+}
+
+// ValidationMetricsSeries returns a time-series of the specified validation metric in the specified
+// trial.
+func (db *PgDB) ValidationMetricsSeries(trialID int32, startTime time.Time, metricName string,
+	startBatches int, endBatches int) (metricSeries []lttb.Point, endTime time.Time,
+	err error) {
+	var rows []metricsSeriesWrapper
+	err = db.queryRows(`
+SELECT 
+  (prior_batches_processed + num_batches) AS batches,
+  v.metrics->'validation_metrics'->$1 AS value,
+  v.end_time as end_time
+FROM trials t
+  INNER JOIN steps s ON t.id=s.trial_id
+  LEFT OUTER JOIN validations v ON s.id=v.step_id AND s.trial_id=v.trial_id
+WHERE t.id=$2
+  AND v.state = 'COMPLETED'
+  AND (prior_batches_processed + num_batches) >= $3
+  AND (prior_batches_processed + num_batches) <= $4
+  AND v.end_time > $5
+ORDER BY batches;`, &rows, metricName, trialID, startBatches, endBatches, startTime)
+	if err != nil {
+		return nil, endTime, errors.Wrapf(err, "failed to get metrics to sample for experiment")
+	}
+	for _, row := range rows {
+		metricSeries = append(metricSeries, lttb.Point{X: float64(row.Batches), Y: row.Value})
+		if row.EndTime.After(endTime) {
+			endTime = row.EndTime
+		}
+	}
+	return metricSeries, endTime, nil
 }

--- a/master/internal/db/postgres_experiments.go
+++ b/master/internal/db/postgres_experiments.go
@@ -283,7 +283,7 @@ SELECT t.id FROM (
   GROUP BY t.id
   ORDER BY best_metric %s
   LIMIT $3
-);`, aggregate, order), metric, experimentID, maxTrials)
+) t;`, aggregate, order), metric, experimentID, maxTrials)
 	return trials, err
 }
 

--- a/master/internal/lttb/lttb.go
+++ b/master/internal/lttb/lttb.go
@@ -1,0 +1,112 @@
+/*
+Package lttb includes a Go rewrite of Sveinn Steinarsson's reference implementation (written in
+JavaScript) of the Largest-Triangle-Three-Buckets algorithm as described in his thesis,
+"Downsampling Time Series for Visual Representation":
+
+Advisors: Jóhann Pétur Malmquist, Kristján Jónasson
+Faculty Representative: Bjarni Júlíusson
+Faculty of Industrial Engineering, Mechanical Engineering and Computer Science
+School of Engineering and Natural Sciences
+University of Iceland
+Reykjavik, June 2013
+https://skemman.is/bitstream/1946/15343/3/SS_MSthesis.pdf
+
+As far as translation makes possible, the original algorithm, variable names, and comments are
+unmodified. The accompanying tests were added after the Go rewrite. The following copyright notice
+and the MIT license pertain to the original implementation:
+
+Copyright (c) 2013 by Sveinn Steinarsson
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package lttb
+
+import (
+	"math"
+)
+
+// Point represents a Cartesian coordinate pair.
+type Point struct {
+	X float64
+	Y float64
+}
+
+// Downsample selects the most visually significant points from a series.
+func Downsample(data []Point, threshold int) (sampled []Point) {
+	dataLength := len(data)
+	if threshold >= dataLength || threshold == 0 {
+		return data // Nothing to do
+	}
+	sampled = make([]Point, threshold)
+
+	// Bucket size. Leave room for start and end data points
+	every := float64(dataLength-2) / float64(threshold-2)
+
+	var a, nextA int // Initially a is the first point in the triangle
+	var maxArea, area float64
+
+	sampled[0] = data[a] // Always add the first point
+	sampledIndex := 1
+	for i := 0; i < threshold-2; i++ {
+		// Calculate point average for next bucket (containing c)
+		var avgX, avgY float64
+		avgRangeStart := int(float64(i+1)*every) + 1
+		avgRangeEnd := int(float64(i+2)*every) + 1
+		if avgRangeEnd >= dataLength {
+			avgRangeEnd = dataLength
+		}
+		avgRangeLength := avgRangeEnd - avgRangeStart
+
+		for ; avgRangeStart < avgRangeEnd; avgRangeStart++ {
+			avgX += data[avgRangeStart].X
+			avgY += data[avgRangeStart].Y
+		}
+		avgX /= float64(avgRangeLength)
+		avgY /= float64(avgRangeLength)
+
+		// Get the range for this bucket
+		rangeOffs := int(float64(i+0)*every) + 1
+		rangeTo := int(float64(i+1)*every) + 1
+
+		// Point a
+		pointAX := data[a].X
+		pointAY := data[a].Y
+
+		maxArea = -1.0
+
+		var maxAreaPoint Point
+		for ; rangeOffs < rangeTo; rangeOffs++ {
+			// Calculate triangle area over three buckets
+			area = math.Abs(
+				(pointAX-avgX)*(data[rangeOffs].Y-pointAY)-
+					(pointAX-data[rangeOffs].X)*(avgY-pointAY)) * 0.5
+			if area > maxArea {
+				maxArea = area
+				maxAreaPoint = data[rangeOffs]
+				nextA = rangeOffs // Next a is this b
+			}
+		}
+
+		sampled[sampledIndex] = maxAreaPoint // Pick this point from the bucket
+		sampledIndex++
+		a = nextA // This a is the next a (chosen b)
+	}
+
+	sampled[sampledIndex] = data[dataLength-1] // Always add last
+
+	return sampled
+}

--- a/master/internal/lttb/lttb_test.go
+++ b/master/internal/lttb/lttb_test.go
@@ -35,19 +35,3 @@ func TestLTTB(t *testing.T) {
 		t.Errorf("Unexpected result from LTTB, expected %v, actual %v", expected, actual)
 	}
 }
-
-func TestScale(t *testing.T) {
-	input := make([]Point, 1000000)
-	for i := 0; i < len(input); i++ {
-		input[i] = Point{float64(i), rand.Float64()}
-	}
-
-	start := time.Now()
-	Downsample(input, 1000)
-	finish := time.Now()
-	elapsed := finish.Sub(start)
-
-	if elapsed > (50 * time.Millisecond) {
-		t.Errorf("Downsampling from 1M to 1K expected to be less than 50ms. Took %s", elapsed)
-	}
-}

--- a/master/internal/lttb/lttb_test.go
+++ b/master/internal/lttb/lttb_test.go
@@ -1,0 +1,53 @@
+package lttb
+
+import (
+	"math/rand"
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestLTTB(t *testing.T) {
+	input := []Point{
+		{0.0, 0.8784277338451055},
+		{1.0, 0.1499321530254274},
+		{2.0, 0.49489164039056865},
+		{3.0, 0.296325207554909},
+		{4.0, 0.7954332017957191},
+		{5.0, 0.37920694146084544},
+		{6.0, 0.262280416971284},
+		{7.0, 0.2115412028253334},
+		{8.0, 0.6010906649928144},
+		{9.0, 0.8143458607144891},
+	}
+
+	expected := []Point{
+		input[0],
+		input[1],
+		input[4],
+		input[7],
+		input[9],
+	}
+
+	actual := Downsample(input, 5)
+
+	if !reflect.DeepEqual(expected, actual) {
+		t.Errorf("Unexpected result from LTTB, expected %v, actual %v", expected, actual)
+	}
+}
+
+func TestScale(t *testing.T) {
+	input := make([]Point, 1000000)
+	for i := 0; i < len(input); i++ {
+		input[i] = Point{float64(i), rand.Float64()}
+	}
+
+	start := time.Now()
+	Downsample(input, 1000)
+	finish := time.Now()
+	elapsed := finish.Sub(start)
+
+	if elapsed > (50 * time.Millisecond) {
+		t.Errorf("Downsampling from 1M to 1K expected to be less than 50ms. Took %s", elapsed)
+	}
+}

--- a/master/internal/lttb/lttb_test.go
+++ b/master/internal/lttb/lttb_test.go
@@ -1,10 +1,8 @@
 package lttb
 
 import (
-	"math/rand"
 	"reflect"
 	"testing"
-	"time"
 )
 
 func TestLTTB(t *testing.T) {

--- a/proto/src/determined/api/v1/api.proto
+++ b/proto/src/determined/api/v1/api.proto
@@ -766,7 +766,7 @@ service Determined {
       get: "/api/v1/experiments/{experiment_id}/metrics-stream/trials-sample"
     };
     option (grpc.gateway.protoc_gen_swagger.options.openapiv2_operation) = {
-      tags: "Experiments"
+      tags: "Internal"
     };
   }
 }

--- a/proto/src/determined/api/v1/api.proto
+++ b/proto/src/determined/api/v1/api.proto
@@ -759,4 +759,14 @@ service Determined {
       tags: "Internal"
     };
   }
+
+  // Get a sample of the metrics over time for a sample of the trials.
+  rpc TrialsSample(TrialsSampleRequest) returns (stream TrialsSampleResponse) {
+    option (google.api.http) = {
+      get: "/api/v1/experiments/{experiment_id}/metrics-stream/trials-sample"
+    };
+    option (grpc.gateway.protoc_gen_swagger.options.openapiv2_operation) = {
+      tags: "Experiments"
+    };
+  }
 }

--- a/proto/src/determined/api/v1/experiment.proto
+++ b/proto/src/determined/api/v1/experiment.proto
@@ -317,3 +317,48 @@ message TrialsSnapshotResponse {
   // A list of trials.
   repeated Trial trials = 1;
 }
+
+// Request a sample of metrics over time for a sample of trials.
+message TrialsSampleRequest {
+  // The id of the experiment.
+  int32 experiment_id = 1;
+  // A metric name.
+  string metric_name = 2;
+  // The type of metric.
+  MetricType metric_type = 3;
+  // Maximum number of trials to fetch data for.
+  int32 max_trials = 4;
+  // Maximum number of initial / historical data points.
+  int32 max_datapoints = 5;
+  // Beginning of window (inclusive) to fetch data for.
+  int32 start_batches = 6;
+  // Ending of window (inclusive) to fetch data for.
+  int32 end_batches = 7;
+}
+
+// Response to TrialsSampleRequest
+message TrialsSampleResponse {
+  // One datapoint in a series of metrics from a trial.
+  message DataPoint {
+    // Total batches processed by the time this measurement is taken.
+    int32 batches = 1;
+    // Value of the requested metric at this point in the trial.
+    double value = 2;
+  }
+  // Metadata and metrics stream from a trial.
+  message Trial {
+    // The id of the trial.
+    int32 trial_id = 1;
+    // Hyperparamters values for this specific trial.
+    google.protobuf.Struct hparams = 2;
+    // A possibly down-sampled series of metric readings through the progress of
+    // the trial.
+    repeated DataPoint data = 3;
+  }
+  // A historical or incremental series of data points for the trials.
+  repeated Trial trials = 1;
+  // IDs of trials that are newly included in the data.
+  repeated int32 promoted_trials = 2;
+  // IDs of trials that are no loger included in the top N trials.
+  repeated int32 demoted_trials = 3;
+}


### PR DESCRIPTION
This is the last in a series of streaming endpoints being added for a UI to explore metrics, hyperparameters, and the relationships between them. It is very closely related to previous pull requests in style and design choices. See https://github.com/determined-ai/determined/pull/1562 for prior context.