### PR TITLE
fix: check for error when converting k8s watch objects

### DIFF
--- a/docs/release-notes/1572-k8s-watch.txt
+++ b/docs/release-notes/1572-k8s-watch.txt
@@ -1,0 +1,6 @@
+:orphan:
+
+**Fixes**
+
+-  Gracefully handle cases where the Kubernetes API server responds with
+   unexpected object types.

--- a/master/internal/kubernetes/events.go
+++ b/master/internal/kubernetes/events.go
@@ -74,7 +74,7 @@ func (e *eventListener) startEventListener(ctx *actor.Context) error {
 	for event := range watch.ResultChan() {
 		newEvent, ok := event.Object.(*k8sV1.Event)
 		if !ok {
-			ctx.Log().Warnf("error converting object type %T to *k8sV1.Event", event)
+			ctx.Log().Warnf("error converting object type %T to *k8sV1.Event: %+v", event, event)
 			continue
 		}
 		e.modMessage(newEvent)

--- a/master/internal/kubernetes/events.go
+++ b/master/internal/kubernetes/events.go
@@ -72,7 +72,11 @@ func (e *eventListener) startEventListener(ctx *actor.Context) error {
 
 	ctx.Log().Info("event listener is starting")
 	for event := range watch.ResultChan() {
-		newEvent := event.Object.(*k8sV1.Event)
+		newEvent, ok := event.Object.(*k8sV1.Event)
+		if !ok {
+			ctx.Log().Warnf("error converting object type %T to *k8sV1.Event", event)
+			continue
+		}
 		e.modMessage(newEvent)
 		ctx.Tell(e.podsHandler, podEventUpdate{event: newEvent})
 	}

--- a/master/internal/kubernetes/informer.go
+++ b/master/internal/kubernetes/informer.go
@@ -71,7 +71,7 @@ func (i *informer) startInformer(ctx *actor.Context) error {
 	for event := range watch.ResultChan() {
 		pod, ok := event.Object.(*k8sV1.Pod)
 		if !ok {
-			ctx.Log().Errorf("error converting event of type %T to *k8sV1.Pod", event)
+			ctx.Log().Errorf("error converting event of type %T to *k8sV1.Pod: %+v", event, event)
 			continue
 		}
 

--- a/master/internal/kubernetes/informer.go
+++ b/master/internal/kubernetes/informer.go
@@ -69,7 +69,12 @@ func (i *informer) startInformer(ctx *actor.Context) error {
 
 	ctx.Log().Info("pod informer is starting")
 	for event := range watch.ResultChan() {
-		pod := event.Object.(*k8sV1.Pod)
+		pod, ok := event.Object.(*k8sV1.Pod)
+		if !ok {
+			ctx.Log().Errorf("error converting event of type %T to *k8sV1.Pod", event)
+			continue
+		}
+
 		if pod.Namespace != i.namespace {
 			continue
 		}

--- a/master/internal/kubernetes/nodes.go
+++ b/master/internal/kubernetes/nodes.go
@@ -63,19 +63,31 @@ func (n *nodeInformer) startNodeInformer(ctx *actor.Context) error {
 	nodeInformer := n.informer.Core().V1().Nodes().Informer()
 	nodeInformer.AddEventHandler(&cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
-			node := obj.(*k8sV1.Node)
-			ctx.Log().Debugf("node added %s", node.Name)
-			ctx.Tell(n.podsHandler, nodeStatusUpdate{updatedNode: node})
+			node, ok := obj.(*k8sV1.Node)
+			if ok {
+				ctx.Log().Debugf("node added %s", node.Name)
+				ctx.Tell(n.podsHandler, nodeStatusUpdate{updatedNode: node})
+			} else {
+				ctx.Log().Warnf("error converting event of type %T to *k8sV1.Node", obj)
+			}
 		},
 		UpdateFunc: func(oldObj, newObj interface{}) {
-			node := newObj.(*k8sV1.Node)
-			ctx.Log().Debugf("node updated %s", node.Name)
-			ctx.Tell(n.podsHandler, nodeStatusUpdate{updatedNode: node})
+			node, ok := newObj.(*k8sV1.Node)
+			if ok {
+				ctx.Log().Debugf("node updated %s", node.Name)
+				ctx.Tell(n.podsHandler, nodeStatusUpdate{updatedNode: node})
+			} else {
+				ctx.Log().Warnf("error converting event of type %T to *k8sV1.Node", newObj)
+			}
 		},
 		DeleteFunc: func(obj interface{}) {
-			node := obj.(*k8sV1.Node)
-			ctx.Log().Debugf("node stopped %s", node.Name)
-			ctx.Tell(n.podsHandler, nodeStatusUpdate{deletedNode: node})
+			node, ok := obj.(*k8sV1.Node)
+			if ok {
+				ctx.Log().Debugf("node stopped %s", node.Name)
+				ctx.Tell(n.podsHandler, nodeStatusUpdate{deletedNode: node})
+			} else {
+				ctx.Log().Warnf("error converting event of type %T to *k8sV1.Node", obj)
+			}
 		},
 	})
 

--- a/master/internal/kubernetes/nodes.go
+++ b/master/internal/kubernetes/nodes.go
@@ -68,7 +68,7 @@ func (n *nodeInformer) startNodeInformer(ctx *actor.Context) error {
 				ctx.Log().Debugf("node added %s", node.Name)
 				ctx.Tell(n.podsHandler, nodeStatusUpdate{updatedNode: node})
 			} else {
-				ctx.Log().Warnf("error converting event of type %T to *k8sV1.Node", obj)
+				ctx.Log().Warnf("error converting event of type %T to *k8sV1.Node: %+v", obj, obj)
 			}
 		},
 		UpdateFunc: func(oldObj, newObj interface{}) {
@@ -77,7 +77,7 @@ func (n *nodeInformer) startNodeInformer(ctx *actor.Context) error {
 				ctx.Log().Debugf("node updated %s", node.Name)
 				ctx.Tell(n.podsHandler, nodeStatusUpdate{updatedNode: node})
 			} else {
-				ctx.Log().Warnf("error converting event of type %T to *k8sV1.Node", newObj)
+				ctx.Log().Warnf("error converting event of type %T to *k8sV1.Node: %+v", newObj, newObj)
 			}
 		},
 		DeleteFunc: func(obj interface{}) {
@@ -86,7 +86,7 @@ func (n *nodeInformer) startNodeInformer(ctx *actor.Context) error {
 				ctx.Log().Debugf("node stopped %s", node.Name)
 				ctx.Tell(n.podsHandler, nodeStatusUpdate{deletedNode: node})
 			} else {
-				ctx.Log().Warnf("error converting event of type %T to *k8sV1.Node", obj)
+				ctx.Log().Warnf("error converting event of type %T to *k8sV1.Node: %+v", obj, obj)
 			}
 		},
 	})


### PR DESCRIPTION
## Description
Handle errors where k8s sent unexpected types in response to `watch()` gracefully.
