### PR TITLE
feat: propagate task priorities to resource pools [DET-4510]

### DIFF
--- a/master/internal/experiment.go
+++ b/master/internal/experiment.go
@@ -287,6 +287,10 @@ func (e *experiment) Receive(ctx *actor.Context) error {
 			Handler:  ctx.Self(),
 		})
 		ctx.Tell(e.rm, sproto.SetGroupWeight{Weight: e.Config.Resources.Weight, Handler: ctx.Self()})
+		ctx.Tell(e.rm, sproto.SetGroupPriority{
+			Priority: e.Config.Resources.Priority,
+			Handler:  ctx.Self(),
+		})
 		ops, err := e.searcher.InitialOperations()
 		e.processOperations(ctx, ops, err)
 	case trialCreated:

--- a/master/internal/resourcemanagers/group.go
+++ b/master/internal/resourcemanagers/group.go
@@ -13,4 +13,5 @@ type group struct {
 	handler  *actor.Ref
 	maxSlots *int
 	weight   float64
+	priority *int
 }

--- a/master/internal/resourcemanagers/kubernetes_resource_manager.go
+++ b/master/internal/resourcemanagers/kubernetes_resource_manager.go
@@ -62,6 +62,7 @@ func (k *kubernetesResourceManager) Receive(ctx *actor.Context) error {
 		groupActorStopped,
 		sproto.SetGroupMaxSlots,
 		sproto.SetGroupWeight,
+		sproto.SetGroupPriority,
 		SetTaskName,
 		AllocateRequest,
 		ResourcesReleased:
@@ -103,8 +104,8 @@ func (k *kubernetesResourceManager) receiveRequestMsg(ctx *actor.Context) error 
 	case sproto.SetGroupMaxSlots:
 		k.getOrCreateGroup(ctx, msg.Handler).maxSlots = msg.MaxSlots
 
-	case sproto.SetGroupWeight:
-		// SetGroupWeight is not supported by the Kubernetes RP.
+	case sproto.SetGroupWeight, sproto.SetGroupPriority:
+		// SetGroupWeight and SetGroupPriority are not supported by the Kubernetes RP.
 
 	case SetTaskName:
 		k.receiveSetTaskName(ctx, msg)

--- a/master/internal/resourcemanagers/resource_managers.go
+++ b/master/internal/resourcemanagers/resource_managers.go
@@ -55,7 +55,8 @@ func (rm *ResourceManagers) Receive(ctx *actor.Context) error {
 	case
 		AllocateRequest, ResourcesReleased,
 		sproto.SetGroupMaxSlots, sproto.SetGroupWeight,
-		GetTaskSummary, GetTaskSummaries, SetTaskName:
+		sproto.SetGroupPriority, GetTaskSummary,
+		GetTaskSummaries, SetTaskName:
 		rm.forward(ctx, msg)
 
 	default:

--- a/master/internal/sproto/task_actor.go
+++ b/master/internal/sproto/task_actor.go
@@ -52,6 +52,12 @@ type (
 		ResourcePool string
 		Handler      *actor.Ref
 	}
+	// SetGroupPriority sets the priority of the group in the priority scheduler.
+	SetGroupPriority struct {
+		Priority     *int
+		ResourcePool string
+		Handler      *actor.Ref
+	}
 )
 
 func (c ContainerLog) String() string {


### PR DESCRIPTION
## Description
This PR supports propagating task configured priorities to the resource pools.

## Test Plan
Tested manually & added unit test coverage.

<s>Note: Only the last two commits are related to this PR.</s>