### PR TITLE
fix: restore keras TensorBoard wrapper

### DIFF
--- a/docs/how-to/tensorboard.txt
+++ b/docs/how-to/tensorboard.txt
@@ -146,19 +146,20 @@ TensorFlow Keras
 
 To add TensorBoard support for models that use
 :class:`~determined.keras.TFKerasTrial`, add a
-:class:`~determined.keras.TFKerasTensorBoard` callback to your trial
+:class:`determined.keras.callabacks.TensorBoard` callback to your trial
 class:
 
 .. code:: python
 
-   from determined.keras import TFKerasTensorBoard, TFKerasTrial
+   from determined.keras import TFKerasTrial
+   from determined.keras.callbacks import TensorBoard
 
 
    class MyModel(TFKerasTrial):
        ...
 
        def keras_callbacks(self):
-           return [TFKerasTensorBoard()]
+           return [TensorBoard()]
 
 Estimator
 =========

--- a/docs/reference/api/keras.txt
+++ b/docs/reference/api/keras.txt
@@ -112,6 +112,8 @@ the ``tf.keras.callbacks.Callbacks`` interface) and supply them to the
 
 .. autoclass:: determined.keras.callbacks.ReduceLROnPlateau
 
+.. autoclass:: determined.keras.callbacks.TensorBoard
+
 **********
  Examples
 **********

--- a/docs/release-notes/1458-fix-keras-callbacks.txt
+++ b/docs/release-notes/1458-fix-keras-callbacks.txt
@@ -26,3 +26,9 @@
       :class:`~determined.keras.callbacks.ReduceLROnPlateau` are both
       based on ``on_test_end``, which can be tuned using
       ``min_validation_period``.
+
+**Deprecated Features**
+
+-  Deprecate the name ``det.keras.TFKerasTensorBoard`` in favor of
+   ``det.keras.callbacks.TensorBoard``. The old name will be removed
+   eventually, and user code should be updated accordingly.

--- a/examples/computer_vision/cifar10_tf_keras/model_def.py
+++ b/examples/computer_vision/cifar10_tf_keras/model_def.py
@@ -109,7 +109,7 @@ class CIFARTrial(keras.TFKerasTrial):
         return model
 
     def keras_callbacks(self) -> List[tf.keras.callbacks.Callback]:
-        return [keras.TFKerasTensorBoard(update_freq="batch", profile_batch=0, histogram_freq=1)]
+        return [keras.callbacks.TensorBoard(update_freq="batch", profile_batch=0, histogram_freq=1)]
 
     def build_training_data_loader(self) -> keras.InputData:
         """

--- a/examples/computer_vision/iris_tf_keras/model_def.py
+++ b/examples/computer_vision/iris_tf_keras/model_def.py
@@ -78,7 +78,7 @@ class IrisTrial(keras.TFKerasTrial):
         return model
 
     def keras_callbacks(self) -> List[tf.keras.callbacks.Callback]:
-        return [keras.TFKerasTensorBoard(update_freq="batch", profile_batch=0, histogram_freq=1)]
+        return [keras.callbacks.TensorBoard(update_freq="batch", profile_batch=0, histogram_freq=1)]
 
     def build_training_data_loader(self) -> keras.InputData:
         # Ignore header line and read the training CSV observations into a pandas DataFrame.

--- a/examples/data_layer/data_layer_mnist_tf_keras/model_def.py
+++ b/examples/data_layer/data_layer_mnist_tf_keras/model_def.py
@@ -10,11 +10,8 @@ from tensorflow.keras.metrics import categorical_accuracy
 from tensorflow.keras.models import Sequential
 from tensorflow.keras.optimizers import RMSprop
 
-from determined.keras import (
-    TFKerasTensorBoard,
-    TFKerasTrial,
-    TFKerasTrialContext,
-)
+from determined.keras import TFKerasTrial, TFKerasTrialContext
+from determined.keras.callbacks import TensorBoard
 
 # Constants about the data set.
 IMAGE_SIZE = 32
@@ -72,7 +69,7 @@ class MnistTrial(TFKerasTrial):
         return model
 
     def keras_callbacks(self) -> List[tf.keras.callbacks.Callback]:
-        return [TFKerasTensorBoard(update_freq="batch", profile_batch=0, histogram_freq=1)]
+        return [TensorBoard(update_freq="batch", profile_batch=0, histogram_freq=1)]
 
     def build_training_data_loader(self) -> tf.data.Dataset:
         @self.context.experimental.cache_train_dataset("mnist-tf-keras", "v1", shuffle=True)

--- a/harness/determined/keras/_tensorboard_callback.py
+++ b/harness/determined/keras/_tensorboard_callback.py
@@ -1,34 +1,14 @@
+import logging
 from typing import Any
 
-import tensorflow as tf
-
-from determined import tensorboard
+from determined.keras import callbacks
 
 
-class TFKerasTensorBoard(tf.keras.callbacks.TensorBoard):  # type: ignore
-    """
-    This is a thin wrapper over the TensorBoard callback that ships with ``tf.keras``.  For more
-    information, see the :ref:`TensorBoard Guide <how-to-tensorboard>` or the upstream docs for
-    `tf.keras.callbacks.TensorBoard
-    <https://www.tensorflow.org/api_docs/python/tf/keras/callbacks/TensorBoard>`__.
-
-    Note that if a ``log_dir`` argument is passed to the constructor, it will be ignored.
-    """
-
+class TFKerasTensorBoard(callbacks.TensorBoard):
     def __init__(self, *args: Any, **kwargs: Any):
-        log_dir = str(tensorboard.get_base_path({}).resolve())
-        super().__init__(log_dir=log_dir, *args, **kwargs)
-
-    def _write_logs(self, *args: Any) -> None:
-        """
-        _write_logs calls the original _write_logs() function from the Keras
-        TensorBoard callback. After the logs are flushed to disk, we close and
-        reopen the tf event writer so that it serializes the next set of logs
-        to a new file. This allows the tensorboard manager to treat the
-        written files as immutable and upload them to persistent storage
-        without later having to append to them. This behavior is useful for
-        tensorboard backed by S3.
-        """
-        super()._write_logs(*args)
-        self.writer.close()
-        self.writer.reopen()
+        logging.warning(
+            "det.keras.TFKerasTensorBoard is a deprecated name for "
+            "det.keras.callbacks.TensorBoard, please update your code."
+        )
+        # Avoid using super() due to a diamond inheritance pattern.
+        callbacks.TensorBoard.__init__(self, *args, **kwargs)

--- a/harness/determined/keras/_tf_keras_trial.py
+++ b/harness/determined/keras/_tf_keras_trial.py
@@ -407,7 +407,9 @@ class TFKerasTrialController(det.LoopTrialController):
 
         if self.env.experiment_config.get_records_per_epoch() is None:
             for cb in callbacks:
-                if util.is_overridden(cb.on_epoch_end, tf.keras.callbacks.Callback):
+                if util.is_overridden(cb.on_epoch_end, tf.keras.callbacks.Callback) and not getattr(
+                    cb, "_skip_epoch_end_check", False
+                ):
                     if isinstance(cb, keras.callbacks.Callback):
                         # New callbacks must obey the rules.
                         raise AssertionError(

--- a/harness/tests/experiment/fixtures/tf_keras_one_var_model.py
+++ b/harness/tests/experiment/fixtures/tf_keras_one_var_model.py
@@ -74,7 +74,7 @@ class OneVarTrial(keras.TFKerasTrial):
         # Include a bunch of callbacks just to make sure they work.
         return [
             keras_cb_checker.CBChecker(epochs=epochs, validations=validations),
-            keras.TFKerasTensorBoard(),
+            keras.callbacks.TensorBoard(),
             keras.callbacks.ReduceLROnPlateau(monitor="val_loss"),
             keras.callbacks.EarlyStopping(restore_best_weights=True),
         ]


### PR DESCRIPTION
## Description

I broke the tensorboard callback when I stopped calling on_epoch_end with metrics, but this fixes it.