### PR TITLE
chore: fix old checkpoint export apis [DET-4538]

### DIFF
--- a/master/internal/core_checkpoints.go
+++ b/master/internal/core_checkpoints.go
@@ -28,6 +28,7 @@ type ExportableCheckpoint struct {
 	DeterminedVersion string          `db:"determined_version" json:"determined_version"`
 	ValidationMetrics json.RawMessage `db:"metrics" json:"metrics"`
 	ValidationState   string          `db:"validation_state" json:"validation_state"`
+	SearcherMetric    float64         `db:"searcher_metric" json:"searcher_metric"`
 }
 
 func (m *Master) getCheckpoint(c echo.Context) (interface{}, error) {

--- a/master/static/srv/get_checkpoint.sql
+++ b/master/static/srv/get_checkpoint.sql
@@ -13,6 +13,7 @@ SELECT
     COALESCE(c.format, '') as format,
     COALESCE(c.determined_version, '') as determined_version,
     v.metrics AS metrics,
+    (v.metrics->'validation_metrics'->>(e.config->'searcher'->>'metric'))::float8 AS searcher_metric,
     'STATE_' || v.state AS validation_state,
     'STATE_' || c.state AS state
 FROM checkpoints c

--- a/master/static/srv/get_checkpoints_for_trial.sql
+++ b/master/static/srv/get_checkpoints_for_trial.sql
@@ -14,7 +14,8 @@ SELECT
     COALESCE(c.format, '') as format,
     COALESCE(c.determined_version, '') as determined_version,
     v.metrics AS metrics,
-    'STATE_' || v.state AS validation_state
+    'STATE_' || v.state AS validation_state,
+    (v.metrics->'validation_metrics'->>(e.config->'searcher'->>'metric'))::float8 AS searcher_metric
 FROM checkpoints c
 JOIN steps s ON c.step_id = s.id AND c.trial_id = s.trial_id
 LEFT JOIN validations v ON v.step_id = s.id AND v.trial_id = s.trial_id


### PR DESCRIPTION
## Description
Fix a bug with the old API's checkpoint export endpoints arising from strict JSON de-serialization and an extra field in the source.
<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan
- [x] download an affected `determined-common` version (`<=0.12.13`) and check checkpoint export works
<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234