### PR TITLE
fix: allow clients to override the expected master cert address [DET-4547]

### DIFF
--- a/agent/cmd/determined-agent/run.go
+++ b/agent/cmd/determined-agent/run.go
@@ -112,6 +112,10 @@ func newRunCmd() *cobra.Command {
 	cmd.Flags().StringVar(
 		&opts.Security.TLS.MasterCert, "security-tls-master-cert", "", "CA cert file for the master",
 	)
+	cmd.Flags().StringVar(
+		&opts.Security.TLS.MasterCertName, "security-tls-master-cert-name", "",
+		"expected address in the master TLS certificate (if different than the one used for connecting)",
+	)
 
 	// Debug flags.
 	cmd.Flags().IntVar(&opts.ArtificialSlots, "artificial-slots", 0, "")

--- a/agent/internal/agent.go
+++ b/agent/internal/agent.go
@@ -222,6 +222,7 @@ func (a *agent) tlsConfig() (*tls.Config, error) {
 		InsecureSkipVerify: a.Options.Security.TLS.SkipVerify, //nolint:gosec
 		MinVersion:         tls.VersionTLS12,
 		RootCAs:            pool,
+		ServerName:         a.Options.Security.TLS.MasterCertName,
 	}, nil
 }
 

--- a/agent/internal/containers.go
+++ b/agent/internal/containers.go
@@ -83,6 +83,10 @@ func (c *containerManager) Receive(ctx *actor.Context) error {
 			fmt.Sprintf("DET_AGENT_ID=%s", c.Options.AgentID),
 		}
 
+		if a := c.Options.Security.TLS.MasterCertName; a != "" {
+			c.GlobalEnvVars = append(c.GlobalEnvVars, fmt.Sprintf("DET_MASTER_CERT_NAME=%s", a))
+		}
+
 		c.Labels = map[string]string{
 			dockerContainerTypeLabel: dockerContainerTypeValue,
 			dockerAgentLabel:         c.Options.AgentID,

--- a/agent/internal/options.go
+++ b/agent/internal/options.go
@@ -81,9 +81,10 @@ type SecurityOptions struct {
 
 // TLSOptions is the TLS connection configuration for the agent.
 type TLSOptions struct {
-	Enabled    bool   `json:"enabled"`
-	SkipVerify bool   `json:"skip_verify"`
-	MasterCert string `json:"master_cert"`
+	Enabled        bool   `json:"enabled"`
+	SkipVerify     bool   `json:"skip_verify"`
+	MasterCert     string `json:"master_cert"`
+	MasterCertName string `json:"master_cert_name"`
 }
 
 // Validate implements the check.Validatable interface.

--- a/common/determined_common/__init__.py
+++ b/common/determined_common/__init__.py
@@ -4,6 +4,6 @@ except ModuleNotFoundError:
     # Inexplicably, sometimes ruamel.yaml is pacakged as ruamel_yaml instead.
     import ruamel_yaml as yaml  # type: ignore
 
-from . import api, check, constants, context, storage, types, util
+from . import api, check, constants, context, requests, storage, types, util
 from ._logging import set_logger
 from .__version__ import __version__

--- a/common/determined_common/api/request.py
+++ b/common/determined_common/api/request.py
@@ -8,24 +8,33 @@ import lomond
 import requests
 import simplejson
 
+import determined_common.requests
 from determined_common.api import authentication, errors
 
 # The path to a file containing an SSL certificate to trust specifically for the master, if any.
 _master_cert_bundle = None
 
+# The name we use to verify the master.
+_master_cert_name = None
 
-def set_master_cert_bundle(path: str) -> None:
+
+def set_master_cert_bundle(path: Optional[str]) -> None:
     global _master_cert_bundle
     _master_cert_bundle = path
+
+
+def set_master_cert_name(name: Optional[str]) -> None:
+    global _master_cert_name
+    _master_cert_name = name
 
 
 # Set the bundle if one is specified by the environment. This is done on import since we can't
 # always count on having an entry point we control (e.g., if someone is importing this code in a
 # notebook).
-try:
-    set_master_cert_bundle(os.environ["DET_MASTER_CERT_FILE"])
-except KeyError:
-    pass
+set_master_cert_bundle(os.environ.get("DET_MASTER_CERT_FILE"))
+
+# Set the master servername from the environment.
+set_master_cert_name(os.environ.get("DET_MASTER_CERT_NAME"))
 
 
 def get_master_cert_bundle() -> Optional[str]:
@@ -89,7 +98,7 @@ def do_request(
         h = add_token_to_headers(h)
 
     try:
-        r = requests.request(
+        r = determined_common.requests.request(
             method,
             make_url(host, path),
             params=params,
@@ -97,6 +106,7 @@ def do_request(
             headers=h,
             verify=_master_cert_bundle,
             stream=stream,
+            server_hostname=_master_cert_name,
         )
     except requests.exceptions.SSLError:
         raise

--- a/common/determined_common/requests.py
+++ b/common/determined_common/requests.py
@@ -1,0 +1,33 @@
+"""
+A drop-in replacement for requests.request() which supports server name overriding.
+"""
+from typing import Any, Optional
+
+import requests
+
+
+class HTTPAdapter(requests.adapters.HTTPAdapter):
+    """A new HTTPAdapter which honors the ServerName as a value for the verify arg."""
+
+    def __init__(self, server_hostname: Optional[str]) -> None:
+        super().__init__()
+        self.server_hostname = server_hostname
+
+    def cert_verify(self, conn: Any, url: Any, verify: Any, cert: Any) -> None:
+        super().cert_verify(conn, url, verify, cert)  # type: ignore
+        if self.server_hostname is not None:
+            # Set the server_hostname value of the urllib3 connection.
+            conn.assert_hostname = self.server_hostname
+
+
+class Session(requests.sessions.Session):
+    def __init__(self, server_hostname: Optional[str]) -> None:
+        super().__init__()
+        # Override the https adapter.
+        self.mount("https://", HTTPAdapter(server_hostname))
+
+
+def request(method: str, url: str, **kwargs: Any) -> requests.Response:
+    server_hostname = kwargs.pop("server_hostname", None)
+    with Session(server_hostname) as session:
+        return session.request(method=method, url=url, **kwargs)

--- a/docs/reference/cluster-config.txt
+++ b/docs/reference/cluster-config.txt
@@ -377,6 +377,11 @@ The master supports the following configuration settings:
       to ``http`` as scheme, local IP address as host, and ``8080`` as
       port.
 
+   -  ``master_cert_name``: A hostname for which the master's TLS
+      certificate is valid, if the host specified by the ``master_url``
+      option is an IP address or is not contained in the certificate.
+      See :ref:`tls` for more information.
+
    -  ``startup_script``: One or more shell commands that will be run
       during agent instance start up. These commands are executed as
       root as soon as the agent cloud instance has started and before

--- a/docs/reference/cluster-config.txt
+++ b/docs/reference/cluster-config.txt
@@ -99,13 +99,8 @@ The master can secure all incoming connections using `TLS
 ability requires a TLS private key and certificate to be provided; set
 the options ``security.tls.cert`` and ``security.tls.key`` to paths to a
 PEM-encoded TLS certificate and private key, respectively, to do so. If
-TLS is enabled, the default port becomes 8443 rather than 8080.
-
-.. note::
-
-   To use Determined with TLS, you may need a private Certificate
-   Authority and Split-Horizon DNS, depending on where your
-   infrastructure resides.
+TLS is enabled, the default port becomes 8443 rather than 8080. See
+:ref:`tls` for more information.
 
 .. _agent-network-proxy:
 
@@ -782,3 +777,7 @@ The master supports the following configuration settings:
          reduce the security of your Determined cluster.
 
       -  ``master_cert``: CA cert file for the master when using TLS.
+
+      -  ``master_cert_name``: A hostname for which the master's TLS
+         certificate is valid, if the value of the ``master_host``
+         option is an IP address or is not contained in the certificate.

--- a/docs/release-notes/1588-agent-hostname-override.txt
+++ b/docs/release-notes/1588-agent-hostname-override.txt
@@ -1,0 +1,6 @@
+:orphan:
+
+**Features**
+
+-  Allow the agent to use different addresses for master certificate
+   verification and connecting to the master.

--- a/docs/topic-guides/tls.txt
+++ b/docs/topic-guides/tls.txt
@@ -52,6 +52,15 @@ configuration, the agent will be unable to verify the identity of the
 master, but the data sent over the connection will still be protected by
 TLS.
 
+If the master's certificate does not contain the address that the agent
+is using to connect to the master (but is otherwise valid), set the
+``security.tls.master_cert_name`` option to one of the addresses in the
+certificate. For example, the master's certificate may contain a DNS
+hostname corresponding to the public IP address of the master, while the
+agent connects to the master using its private IP address to prevent
+traffic from being routed over the public Internet. In that case, the
+option should be set to the DNS name contained in the certificate.
+
 When :ref:`dynamic agents <elastic-infra-index>` and TLS are both in
 use, the dynamic agents that the master creates will automatically be
 configured to connect securely to the master over TLS.

--- a/docs/topic-guides/tls.txt
+++ b/docs/topic-guides/tls.txt
@@ -61,6 +61,16 @@ agent connects to the master using its private IP address to prevent
 traffic from being routed over the public Internet. In that case, the
 option should be set to the DNS name contained in the certificate.
 
+.. note::
+
+   Due to a limitation of `Fluent Bit <https://fluentbit.io>`, which
+   Determined uses internally, the certificate must be valid for at
+   least one hostname that is not an IP address and the
+   ``security.tls.master_cert_name`` option must be set to that hostname
+   if the agent is configured to connect to the master using an IP
+   address. The hostname does not need to be an actual DNS name for the
+   master---it is only used for certificate verification.
+
 When :ref:`dynamic agents <elastic-infra-index>` and TLS are both in
 use, the dynamic agents that the master creates will automatically be
 configured to connect securely to the master over TLS.

--- a/harness/determined/_data_layer/_data_layer.py
+++ b/harness/determined/_data_layer/_data_layer.py
@@ -113,6 +113,7 @@ class _CacheableDecorator:
                 secret_key=self._env.experiment_config["data_layer"].get("secret_key"),
                 endpoint_url=self._env.experiment_config["data_layer"].get("endpoint_url"),
                 coordinator_cert_file=self._env.master_cert_file,
+                coordinator_cert_name=self._env.master_cert_name,
             )
             self._storage = storage.S3Storage(storage_config, tensorflow_config=session_config)
 
@@ -131,6 +132,7 @@ class _CacheableDecorator:
                 url=rw_coordinator_url,
                 local_cache_dir=str(local_cache_path),
                 coordinator_cert_file=self._env.master_cert_file,
+                coordinator_cert_name=self._env.master_cert_name,
             )
             self._storage = storage.GCSStorage(storage_config, tensorflow_config=session_config)
 

--- a/harness/determined/_env_context.py
+++ b/harness/determined/_env_context.py
@@ -13,6 +13,7 @@ class EnvContext:
         master_port: int,
         use_tls: bool,
         master_cert_file: Optional[str],
+        master_cert_name: Optional[str],
         container_id: str,
         experiment_config: Dict[str, Any],
         hparams: Dict[str, Any],
@@ -36,6 +37,7 @@ class EnvContext:
         self.master_port = master_port
         self.use_tls = use_tls
         self.master_cert_file = master_cert_file
+        self.master_cert_name = master_cert_name
         self.container_id = container_id
         self.experiment_config = det.ExperimentConfig(experiment_config)
         self.hparams = hparams

--- a/harness/determined/_execution.py
+++ b/harness/determined/_execution.py
@@ -74,6 +74,7 @@ def _make_local_execution_env(
         master_port=0,
         use_tls=False,
         master_cert_file=None,
+        master_cert_name=None,
         container_id="",
         experiment_config=config,
         hparams=hparams,

--- a/harness/determined/exec/harness.py
+++ b/harness/determined/exec/harness.py
@@ -160,6 +160,7 @@ def main() -> None:
     master_port = int(os.environ["DET_MASTER_PORT"])
     use_tls = distutils.util.strtobool(os.environ.get("DET_USE_TLS", "false"))
     master_cert_file = os.environ.get("DET_MASTER_CERT_FILE")
+    master_cert_name = os.environ.get("DET_MASTER_CERT_NAME")
     agent_id = os.environ["DET_AGENT_ID"]
     container_id = os.environ["DET_CONTAINER_ID"]
     hparams = simplejson.loads(os.environ["DET_HPARAMS"])
@@ -186,6 +187,7 @@ def main() -> None:
         master_port,
         use_tls,
         master_cert_file,
+        master_cert_name,
         container_id,
         experiment_config,
         hparams,

--- a/harness/determined/layers/_socket_manager.py
+++ b/harness/determined/layers/_socket_manager.py
@@ -25,9 +25,10 @@ class CustomSSLWebsocketSession(lomond.session.WebsocketSession):  # type: ignor
         self.ctx.load_default_certs()
         if env.master_cert_file is not None:
             self.ctx.load_verify_locations(cafile=env.master_cert_file)
+        self.master_cert_name = env.master_cert_name
 
     def _wrap_socket(self, sock: socket.SocketType, host: str) -> socket.SocketType:
-        return self.ctx.wrap_socket(sock, server_hostname=host)
+        return self.ctx.wrap_socket(sock, server_hostname=self.master_cert_name or host)
 
 
 class SocketManager(workload.Source):

--- a/harness/setup.py
+++ b/harness/setup.py
@@ -24,7 +24,7 @@ setup(
         "numpy>=1.16.2",
         "psutil",
         "pyzmq>=18.1.0",
-        "yogadl==0.1.2",
+        "yogadl==0.1.3",
     ],
     extras_require={
         "tf-114-cuda100": ["tensorflow-gpu==1.14.0"],

--- a/harness/tests/experiment/utils.py
+++ b/harness/tests/experiment/utils.py
@@ -123,6 +123,7 @@ def make_default_env_context(
         master_port=0,
         use_tls=False,
         master_cert_file=None,
+        master_cert_name=None,
         container_id="",
         hparams=hparams,
         latest_checkpoint=None,

--- a/harness/tests/tensorboard/test_util.py
+++ b/harness/tests/tensorboard/test_util.py
@@ -12,6 +12,7 @@ def get_dummy_env() -> det.EnvContext:
         master_port=0,
         use_tls=False,
         master_cert_file=None,
+        master_cert_name=None,
         container_id="",
         experiment_config={"resources": {"slots_per_trial": 1, "native_parallel": False}},
         initial_workload=workload.Workload(

--- a/harness/tests/test_horovod.py
+++ b/harness/tests/test_horovod.py
@@ -24,6 +24,7 @@ def create_default_env_context(experiment_config: Dict[str, Any]) -> det.EnvCont
         master_port=0,
         use_tls=False,
         master_cert_file=None,
+        master_cert_name=None,
         container_id="",
         hparams={"global_batch_size": 32},
         latest_checkpoint=None,

--- a/master/internal/provisioner/agent_setup.go
+++ b/master/internal/provisioner/agent_setup.go
@@ -10,6 +10,7 @@ import (
 type agentSetupScriptConfig struct {
 	MasterHost                   string
 	MasterPort                   string
+	MasterCertName               string
 	StartupScriptBase64          string
 	ContainerStartupScriptBase64 string
 	MasterCertBase64             string

--- a/master/internal/provisioner/agent_setup_test.go
+++ b/master/internal/provisioner/agent_setup_test.go
@@ -19,6 +19,7 @@ func TestAgentSetupScript(t *testing.T) {
 	conf := agentSetupScriptConfig{
 		MasterHost:                   "test.master",
 		MasterPort:                   "8080",
+		MasterCertName:               "certname",
 		StartupScriptBase64:          encodedScript,
 		ContainerStartupScriptBase64: encodedContainerScript,
 		MasterCertBase64:             encodedMasterCert,
@@ -78,6 +79,7 @@ docker run --init --name determined-agent  \
     -e DET_AGENT_ID="test.id" \
     -e DET_MASTER_HOST="test.master" \
     -e DET_MASTER_PORT="8080" \
+    -e DET_SECURITY_TLS_MASTER_CERT_NAME="certname" \
     -e DET_RESOURCE_POOL="test-pool" \
     -e DET_FLUENT_IMAGE="fluent-test" \
     -v /var/run/docker.sock:/var/run/docker.sock \

--- a/master/internal/provisioner/aws.go
+++ b/master/internal/provisioner/aws.go
@@ -118,6 +118,7 @@ func newAWSCluster(
 		ec2UserData: mustMakeAgentSetupScript(agentSetupScriptConfig{
 			MasterHost:                   masterURL.Hostname(),
 			MasterPort:                   masterURL.Port(),
+			MasterCertName:               config.MasterCertName,
 			StartupScriptBase64:          startupScriptBase64,
 			ContainerStartupScriptBase64: containerScriptBase64,
 			MasterCertBase64:             masterCertBase64,

--- a/master/internal/provisioner/config.go
+++ b/master/internal/provisioner/config.go
@@ -45,6 +45,7 @@ func (d *Duration) UnmarshalJSON(b []byte) error {
 // Config describes config for provisioner.
 type Config struct {
 	MasterURL              string            `json:"master_url"`
+	MasterCertName         string            `json:"master_cert_name"`
 	StartupScript          string            `json:"startup_script"`
 	ContainerStartupScript string            `json:"container_startup_script"`
 	AgentDockerNetwork     string            `json:"agent_docker_network"`

--- a/master/internal/provisioner/gcp.go
+++ b/master/internal/provisioner/gcp.go
@@ -81,6 +81,7 @@ func newGCPCluster(
 	startupScript := string(mustMakeAgentSetupScript(agentSetupScriptConfig{
 		MasterHost:                   masterURL.Hostname(),
 		MasterPort:                   masterURL.Port(),
+		MasterCertName:               config.MasterCertName,
 		AgentUseGPUs:                 config.GCP.InstanceType.slots() > 0,
 		AgentNetwork:                 config.AgentDockerNetwork,
 		AgentDockerRuntime:           config.AgentDockerRuntime,

--- a/master/static/srv/agent_setup_script.sh.template
+++ b/master/static/srv/agent_setup_script.sh.template
@@ -44,6 +44,7 @@ docker run --init --name determined-agent {{.LogOptions}} \
     -e DET_AGENT_ID="{{.AgentID}}" \
     -e DET_MASTER_HOST="{{.MasterHost}}" \
     -e DET_MASTER_PORT="{{.MasterPort}}" \
+    -e DET_SECURITY_TLS_MASTER_CERT_NAME="{{.MasterCertName}}" \
     -e DET_RESOURCE_POOL="{{.ResourcePool}}" \
     -e DET_FLUENT_IMAGE="{{.AgentFluentImage}}" \
     -v /var/run/docker.sock:/var/run/docker.sock \


### PR DESCRIPTION
## Description

To handle cases where the address the agent is using to connect to the
master is not one of the valid addresses for the master certificate
(e.g., public vs. private addresses of a cloud instance), this adds the
ability to the various parts of the stack to option to expect a
different address in the certificate from the address that is actually
being used to connect.

## Test Plan

- [x] connect agents to masters using certs with different addresses than the ones used for connecting, check that connections and tasks succeed with the new option set to the right value and fail without it
