### PR TITLE
chore: Tag metrics streaming APIs as Internal due to their less-stable or less-supported status [DET-4546]

### DIFF
--- a/proto/src/determined/api/v1/api.proto
+++ b/proto/src/determined/api/v1/api.proto
@@ -733,7 +733,7 @@ service Determined {
       get: "/api/v1/experiments/{experiment_id}/metrics-stream/metric-names"
     };
     option (grpc.gateway.protoc_gen_swagger.options.openapiv2_operation) = {
-      tags: "Experiments"
+      tags: "Internal"
     };
   }
 
@@ -745,7 +745,7 @@ service Determined {
       get: "/api/v1/experiments/{experiment_id}/metrics-stream/batches"
     };
     option (grpc.gateway.protoc_gen_swagger.options.openapiv2_operation) = {
-      tags: "Experiments"
+      tags: "Internal"
     };
   }
 
@@ -757,7 +757,7 @@ service Determined {
       get: "/api/v1/experiments/{experiment_id}/metrics-stream/trials-snapshot"
     };
     option (grpc.gateway.protoc_gen_swagger.options.openapiv2_operation) = {
-      tags: "Experiments"
+      tags: "Internal"
     };
   }
 }


### PR DESCRIPTION
Adding this new "Internal" tag for APIs that are possibly subject to change in the future or are otherwise not (yet) intended for use by end-users.