### PR TITLE
feat: allow task requests to receive a resource pool field [DET-4342]

### DIFF
--- a/master/internal/api_agents.go
+++ b/master/internal/api_agents.go
@@ -7,7 +7,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
-	"github.com/determined-ai/determined/master/pkg/actor"
+	"github.com/determined-ai/determined/master/internal/sproto"
 	"github.com/determined-ai/determined/proto/pkg/apiv1"
 )
 
@@ -15,10 +15,10 @@ func (a *apiServer) GetAgents(
 	_ context.Context, req *apiv1.GetAgentsRequest,
 ) (resp *apiv1.GetAgentsResponse, err error) {
 	switch {
-	case a.m.system.Get(actor.Addr("agents")) != nil:
-		err = a.actorRequest("/agents", req, &resp)
-	case a.m.system.Get(actor.Addr("pods")) != nil:
-		err = a.actorRequest("/pods", req, &resp)
+	case sproto.UseAgentRM(a.m.system):
+		err = a.actorRequest(sproto.AgentsAddr.String(), req, &resp)
+	case sproto.UseK8sRM(a.m.system):
+		err = a.actorRequest(sproto.PodsAddr.String(), req, &resp)
 	default:
 		err = status.Error(codes.NotFound, "cannot find agents or pods actor")
 	}

--- a/master/internal/command/command_manager.go
+++ b/master/internal/command/command_manager.go
@@ -68,8 +68,8 @@ func (c *commandManager) processLaunchRequest(
 	ctx *actor.Context,
 	req CommandLaunchRequest,
 ) (*summary, int, error) {
-	commandReq, err := parseCommandRequest(*req.User, c.db, req.CommandParams,
-		&c.taskSpec.TaskContainerDefaults,
+	commandReq, err := parseCommandRequest(
+		ctx.Self().System(), c.db, *req.User, req.CommandParams, &c.taskSpec.TaskContainerDefaults,
 	)
 	if err != nil {
 		return nil, http.StatusBadRequest, err

--- a/master/internal/command/notebook_manager.go
+++ b/master/internal/command/notebook_manager.go
@@ -121,7 +121,7 @@ func (n *notebookManager) processLaunchRequest(
 	req NotebookLaunchRequest,
 ) (*summary, int, error) {
 	commandReq, err := parseCommandRequest(
-		*req.User, n.db, req.CommandParams, &n.taskSpec.TaskContainerDefaults,
+		ctx.Self().System(), n.db, *req.User, req.CommandParams, &n.taskSpec.TaskContainerDefaults,
 	)
 	if err != nil {
 		return nil, http.StatusBadRequest, err

--- a/master/internal/command/shell_manager.go
+++ b/master/internal/command/shell_manager.go
@@ -79,8 +79,7 @@ func (s *shellManager) processLaunchRequest(
 	req ShellLaunchRequest,
 ) (*summary, int, error) {
 	commandReq, err := parseCommandRequest(
-		*req.User, s.db, req.CommandParams,
-		&s.taskSpec.TaskContainerDefaults,
+		ctx.Self().System(), s.db, *req.User, req.CommandParams, &s.taskSpec.TaskContainerDefaults,
 	)
 	if err != nil {
 		return nil, http.StatusBadRequest, err

--- a/master/internal/command/tensorboard_manager.go
+++ b/master/internal/command/tensorboard_manager.go
@@ -124,7 +124,8 @@ func (t *tensorboardManager) processLaunchRequest(
 	req *TensorboardRequest,
 ) (*summary, int, error) {
 	commandReq, err := parseCommandRequest(
-		*user, t.db, req.CommandParams, &t.taskSpec.TaskContainerDefaults)
+		ctx.Self().System(), t.db, *user, req.CommandParams, &t.taskSpec.TaskContainerDefaults,
+	)
 	if err != nil {
 		return nil, http.StatusBadRequest, err
 	}

--- a/master/internal/experiment.go
+++ b/master/internal/experiment.go
@@ -100,6 +100,11 @@ type experiment struct {
 // the returned object's ID appropriately.
 func newExperiment(master *Master, expModel *model.Experiment) (*experiment, error) {
 	conf := expModel.Config
+
+	if err := sproto.ValidateRP(master.system, conf.Resources.ResourcePool); err != nil {
+		return nil, err
+	}
+
 	method := searcher.NewSearchMethod(conf.Searcher)
 	search := searcher.NewSearcher(conf.Reproducibility.ExperimentSeed, method, conf.Hyperparameters)
 

--- a/master/internal/resourcemanagers/setup.go
+++ b/master/internal/resourcemanagers/setup.go
@@ -6,12 +6,10 @@ import (
 	"github.com/labstack/echo"
 	"github.com/sirupsen/logrus"
 
-	aproto "github.com/determined-ai/determined/master/pkg/agent"
-
 	"github.com/determined-ai/determined/master/internal/agent"
 	"github.com/determined-ai/determined/master/internal/kubernetes"
-
 	"github.com/determined-ai/determined/master/pkg/actor"
+	aproto "github.com/determined-ai/determined/master/pkg/agent"
 )
 
 // Setup setups the actor and endpoints for resource managers.
@@ -55,7 +53,7 @@ func setupAgentResourceManager(
 	system.Ask(ref, actor.Ping{}).Get()
 
 	logrus.Infof("initializing endpoints for agents")
-	agent.Initialize(system, echo, ref, opts)
+	agent.Initialize(system, echo, opts)
 	return ref
 }
 

--- a/master/internal/sproto/globals.go
+++ b/master/internal/sproto/globals.go
@@ -1,0 +1,49 @@
+package sproto
+
+import (
+	"github.com/pkg/errors"
+
+	"github.com/determined-ai/determined/master/pkg/actor"
+)
+
+var (
+	// ResourceManagerAddr is the actor address of the resource manager router.
+	ResourceManagerAddr = actor.Addr("resourceManagers")
+	// AgentRMAddr is the actor address of the agent resource manager.
+	AgentRMAddr = actor.Addr("agentRM")
+	// AgentsAddr is the actor address of the agents.
+	AgentsAddr = actor.Addr("agents")
+	// PodsAddr is the actor address of the pods.
+	PodsAddr = actor.Addr("pods")
+)
+
+// GetRM returns the resource manager router.
+func GetRM(system *actor.System) *actor.Ref {
+	return system.Get(ResourceManagerAddr)
+}
+
+// UseAgentRM returns if using the agent resource manager.
+func UseAgentRM(system *actor.System) bool {
+	return system.Get(AgentsAddr) != nil
+}
+
+// UseK8sRM returns if using the kubernetes resource manager.
+func UseK8sRM(system *actor.System) bool {
+	return system.Get(PodsAddr) != nil
+}
+
+// GetRP returns the resource pool.
+func GetRP(system *actor.System, name string) *actor.Ref {
+	if rm := system.Get(AgentRMAddr); rm != nil {
+		return rm.Child(name)
+	}
+	return nil
+}
+
+// ValidateRP validates if the resource pool exists when using the agent resource manager.
+func ValidateRP(system *actor.System, name string) error {
+	if name == "" || UseAgentRM(system) && GetRP(system, name) != nil {
+		return nil
+	}
+	return errors.Errorf("cannot find resource pool: %s", name)
+}

--- a/master/pkg/model/experiment_config.go
+++ b/master/pkg/model/experiment_config.go
@@ -193,6 +193,7 @@ type ResourcesConfig struct {
 	NativeParallel bool    `json:"native_parallel"`
 	ShmSize        *int    `json:"shm_size,omitempty"`
 	AgentLabel     string  `json:"agent_label"`
+	ResourcePool   string  `json:"resource_pool"`
 	Priority       *int    `json:"priority,omitempty"`
 }
 


### PR DESCRIPTION
## Description

Allow experiment and commands to be configured with a `resources.resource_pool` field to be scheduled on the specified resource pool.

## Test Plan

Will add an e2e test as a follow-up PR.

## Commentary (optional)

N/A

## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
