### PR TITLE
feat: allow the master to automatically generate a TLS certificate

### DIFF
--- a/master/cmd/determined-master/init.go
+++ b/master/cmd/determined-master/init.go
@@ -98,6 +98,9 @@ func registerConfig() {
 		defaults.Security.TLS.Cert, "TLS cert file")
 	registerString(flags, name("security", "tls", "key"),
 		defaults.Security.TLS.Key, "TLS key file")
+	registerString(flags, name("security", "tls", "autogenerate-names"),
+		defaults.Security.TLS.AutoGenerateNames, "use an automatically generated certificate valid"+
+			" for the given names (comma-separated list)")
 
 	registerInt(flags, name("port"),
 		defaults.Port, "server port")

--- a/master/internal/core.go
+++ b/master/internal/core.go
@@ -1,7 +1,9 @@
 package internal
 
 import (
+	"crypto/sha256"
 	"crypto/tls"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -294,6 +296,15 @@ func (m *Master) Run() error {
 	cert, err := m.config.Security.TLS.ReadCertificate()
 	if err != nil {
 		return errors.Wrap(err, "failed to read TLS certificate")
+	}
+	if cert != nil {
+		hashBytes := sha256.Sum256(cert.Certificate[0])
+		hash := hex.EncodeToString(hashBytes[:])
+		var chunks []string
+		for i := 0; i < len(hash); i += 2 {
+			chunks = append(chunks, hash[i:i+2])
+		}
+		log.Infof("using a TLS certificate with SHA256 hash %s", strings.Join(chunks, ":"))
 	}
 	m.taskSpec = &tasks.TaskSpec{
 		ClusterID:             m.ClusterID,


### PR DESCRIPTION
## Description

For testing purposes and to allow a not-entirely-insecure setup with
minimal configuration, this teaches the master how to generate a TLS
certificate on startup given a set of names to include in the
certificate. The master now also prints a fingerprint of its certificate
(whether generated or not) to aid in connecting with the CLI.

## Test Plan

- [x] check that the CLI connects can connect, prompting with a matching fingerprint
- [x] check that the agent can connect and run experiments if TLS verification is skipped
