### PR TITLE
chore: include offset in trial log IDs returned to webui [DET-4561]

### DIFF
--- a/docs/release-notes/1608-fix-trial-logs-viewer.txt
+++ b/docs/release-notes/1608-fix-trial-logs-viewer.txt
@@ -1,0 +1,6 @@
+:orphan:
+
+**Fixes**
+
+-  Fix an API bug that caused the log viewer fail to render older pages
+   of logs.

--- a/master/internal/api_trials.go
+++ b/master/internal/api_trials.go
@@ -69,7 +69,7 @@ func (a *apiServer) TrialLogs(
 		return status.Error(codes.InvalidArgument, fmt.Sprintf("unsupported filter: %s", err))
 	}
 
-	logID := int32(offset + -1) // WebUI assumes logs are 0-indexed.
+	logID := int32(offset - 1) // WebUI assumes logs are 0-indexed.
 	onBatch := func(b api.LogBatch) error {
 		return b.ForEach(func(r interface{}) error {
 			trialLog := r.(*model.TrialLog)

--- a/master/internal/api_trials.go
+++ b/master/internal/api_trials.go
@@ -62,13 +62,14 @@ func (a *apiServer) TrialLogs(
 	if err != nil {
 		return err
 	}
+	offset, limit := api.EffectiveOffsetNLimit(int(req.Offset), int(req.Limit), total)
 
 	filters, err := constructTrialLogsFilters(req)
 	if err != nil {
 		return status.Error(codes.InvalidArgument, fmt.Sprintf("unsupported filter: %s", err))
 	}
 
-	logID := int32(-1) // WebUI assumes logs are 0-indexed.
+	logID := int32(offset + -1) // WebUI assumes logs are 0-indexed.
 	onBatch := func(b api.LogBatch) error {
 		return b.ForEach(func(r interface{}) error {
 			trialLog := r.(*model.TrialLog)
@@ -104,7 +105,6 @@ func (a *apiServer) TrialLogs(
 		return false, nil
 	})
 
-	offset, limit := api.EffectiveOffsetNLimit(int(req.Offset), int(req.Limit), total)
 	lReq := api.LogsRequest{Offset: offset, Limit: limit, Follow: req.Follow, Filters: filters}
 	return a.m.system.MustActorOf(
 		actor.Addr("logStore-"+uuid.New().String()),


### PR DESCRIPTION
## Description
Fix a bug where unique ID's are not returned for trial logs, which resulted in the webui not rendering them properly.
<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan
- [x] run a trial with 100k+ logs, make sure when opening trial logs after many are already present that older logs are populated in viewer as expected as viewer is scrolled up.
<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.
-->

## Checklist

- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234