### PR TITLE
chore: Making EagerTensor JSON serializable for TF 2.4 RCs [DET-4566]

### DIFF
--- a/harness/determined/util.py
+++ b/harness/determined/util.py
@@ -15,6 +15,13 @@ import simplejson
 import determined as det
 from determined_common import check, util
 
+try:
+    from tensorflow.python.framework.ops import EagerTensor
+
+    EagerTensorImported = True
+except Exception:
+    EagerTensorImported = False
+
 
 @util.preserve_random_state
 def download_gcs_blob_with_backoff(blob: Any, n_retries: int = 32, max_backoff: int = 32) -> Any:
@@ -139,6 +146,8 @@ def json_encode(obj: Any, indent: Optional[str] = None, sort_keys: bool = False)
         # Objects that provide their own custom JSON serialization.
         if hasattr(obj, "__json__"):
             return obj.__json__()
+        if EagerTensorImported and isinstance(obj, EagerTensor):
+            return obj._numpy().tolist()
 
         raise TypeError("Unserializable object {} of type {}".format(obj, type(obj)))
 


### PR DESCRIPTION
## Test Plan

Tested with some preliminary CUDA 11 environments and the failure went away. All other failures were accounted for.


## Commentary (optional)

I'm actually not sure if it's wrong that the harness is being asked to serialize an EagerTensor or what's changed to cause that. I'm assuming that we're *supposed* to be able to serialize them, and this appears to be the correct way.