### PR TITLE
feat: support per command shmSize settings [DET-4577]

### DIFF
--- a/docs/reference/command-notebook-config.txt
+++ b/docs/reference/command-notebook-config.txt
@@ -99,6 +99,11 @@ The following configuration settings are supported:
       via the ``label`` field in the :ref:`agent configuration
       <agent-configuration>`.
 
+   -  ``shm_size``: The size in bytes of ``/dev/shm`` for trial
+      containers. Defaults to ``4294967296`` (4GiB). If set, this value
+      overrides the value specified in the :ref:`master configuration
+      <master-configuration>`.
+
 -  ``bind_mounts``: Specifies a collection of directories that are
    bind-mounted into the Docker containers for execution. This can be
    used to allow commands to access additional data that is not

--- a/docs/release-notes/1620-command-shm-size.txt
+++ b/docs/release-notes/1620-command-shm-size.txt
@@ -1,0 +1,7 @@
+:orphan:
+
+**Improvements**
+
+-  Support configuring shmSize for commands (e.g., notebooks, shells,
+   tensorboards) in :ref:`command configurations
+   <command-notebook-configuration>`.

--- a/master/pkg/tasks/task.go
+++ b/master/pkg/tasks/task.go
@@ -137,6 +137,12 @@ func startCommand(t TaskSpec) container.Spec {
 		envVars = append(envVars, fmt.Sprintf("%s=%s", envVarKey, envVarValue))
 	}
 	envVars = append(envVars, cmd.Config.Environment.EnvironmentVariables.For(deviceType)...)
+
+	shmSize := t.TaskContainerDefaults.ShmSizeBytes
+	if cmd.Config.Resources.ShmSize != nil {
+		shmSize = int64(*cmd.Config.Resources.ShmSize)
+	}
+
 	return container.Spec{
 		PullSpec: container.PullSpec{
 			Registry:  cmd.Config.Environment.RegistryAuth,
@@ -155,7 +161,7 @@ func startCommand(t TaskSpec) container.Spec {
 				NetworkMode:     t.TaskContainerDefaults.NetworkMode,
 				Mounts:          ToDockerMounts(cmd.Config.BindMounts),
 				PublishAllPorts: true,
-				ShmSize:         t.TaskContainerDefaults.ShmSizeBytes,
+				ShmSize:         shmSize,
 			},
 			Archives: CommandArchives(t),
 		},


### PR DESCRIPTION
## Description
Allows users to specify `shmSize` in command configurations.


## Test Plan
Tested manually.

