### PR TITLE
test: fix CircleCI timing-based splitting for E2E tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -281,7 +281,10 @@ commands:
       - run:
           name: Split tests
           working_directory: ~/project/e2e_tests
-          command: circleci tests glob "tests/**/test*.py" | circleci tests split --split-by=timings > /tmp/tests-to-run
+          command: |
+            circleci tests glob "tests/**/test*.py" | circleci tests split --split-by=timings > /tmp/tests-to-run
+            echo "Running tests from these files:"
+            sed 's/^/- /' </tmp/tests-to-run
 
       - wait-for-master:
           host: <<parameters.master-host>>
@@ -296,8 +299,9 @@ commands:
             --durations=0 \
             --master-host="<<parameters.master-host>>" \
             --master-port="<<parameters.master-port>>" \
+            -o junit_family=xunit1 \
             --junit-xml="<<parameters.junit-path>>" \
-            $(cat /tmp/tests-to-run)
+            $(< /tmp/tests-to-run)
 
   run-det-deploy-tests:
     parameters:


### PR DESCRIPTION
## Description

pytest was producing JUnit XML files in a slightly wrong format, causing
CircleCI to fail to find timing information for E2E tests and preventing
it from doing the automatic timing-based test splitting we wanted it to
do. This fixes the format so that the splitting works, reducing the time
for running E2E CPU tests from 20 minutes to 12, roughly. That doesn't
totally translate into a reduction in time for the overall E2E workflow,
since the affected job is no longer the longest one, but total time is
down by 5 or so minutes.

## Test Plan

- [x] [run CI](https://app.circleci.com/pipelines/github/determined-ai/determined?branch=ci-splits)
