### PR TITLE
chore: Adding NVIDIA Tesla A100 details for GCE [DET-4583]

### DIFF
--- a/master/internal/provisioner/gcp.go
+++ b/master/internal/provisioner/gcp.go
@@ -206,6 +206,8 @@ func (c *gcpCluster) launch(ctx *actor.Context, instanceNum int) {
 		}
 		rb.Metadata.Items = append(c.metadata, rb.Metadata.Items...)
 
+		rb.MinCpuPlatform = getCPUPlatform(rb.MachineType)
+
 		resp, err := c.client.Instances.Insert(c.Project, c.Zone, rb).Context(clientCtx).Do()
 		if err != nil {
 			ctx.Log().WithError(err).Errorf("cannot insert GCE instance")

--- a/master/internal/provisioner/gcp_config.go
+++ b/master/internal/provisioner/gcp_config.go
@@ -214,6 +214,8 @@ var gceMachineTypes = []string{
 	"m2-ultramem",
 	"n1-megamem",
 	"c2-standard",
+	"a2-highgpu",
+	"a2-megagpu",
 	"custom",
 }
 
@@ -224,6 +226,25 @@ var gceGPUTypes = map[string][]int{
 	"nvidia-tesla-p4":   {0, 1, 2, 4},
 	"nvidia-tesla-v100": {0, 1, 2, 4, 8},
 	"nvidia-tesla-k80":  {0, 1, 2, 4, 8},
+	"nvidia-tesla-a100": {0, 1, 2, 4, 8, 16},
+}
+
+func getCPUPlatform(machineType string) string {
+	fields := strings.Split(machineType, "/")
+	instanceType := fields[len(fields)-1]
+
+	for typePrefix, cpuPlatform := range gceCPUPlatforms {
+		if strings.HasPrefix(instanceType, typePrefix) {
+			return cpuPlatform
+		}
+	}
+	return "Intel Broadwell"
+}
+
+// First prefix match found is applied
+var gceCPUPlatforms = map[string]string{
+	"a2-highgpu": "Intel Cascade Lake",
+	"a2-megagpu": "Intel Cascade Lake",
 }
 
 type gceInstanceType struct {


### PR DESCRIPTION
Unable to use A100 instances on Google, adding them to the whitelist. Also adding the ability specify a minimum CPU platform for the instance, as the default (Intel Broadwell) doesn't work when it's Intel Cascade Lake.