### PR TITLE
refactor: update filters to dynamically collapse when needed [DET-4584]

### DIFF
--- a/docs/release-notes/1629-fix-responsive-filters.txt
+++ b/docs/release-notes/1629-fix-responsive-filters.txt
@@ -1,0 +1,6 @@
+:orphan:
+
+**BUG FIXES**
+
+-  WebUI: Fix the tablet viewport for table and chart filters throughout
+   the WebUI.

--- a/webui/cypress/cypress-ci.json
+++ b/webui/cypress/cypress-ci.json
@@ -9,5 +9,7 @@
   },
   "screenshotsFolder": "results/recordings/screenshots",
   "supportFile": "cypress/support",
-  "videosFolder": "results/recordings/videos"
+  "videosFolder": "results/recordings/videos",
+  "viewportHeight": 960,
+  "viewportWidth": 1536
 }

--- a/webui/cypress/cypress.json
+++ b/webui/cypress/cypress.json
@@ -9,5 +9,7 @@
   },
   "screenshotsFolder": "results/recordings/screenshots",
   "supportFile": "cypress/support",
-  "videosFolder": "results/recordings/videos"
+  "videosFolder": "results/recordings/videos",
+  "viewportHeight": 960,
+  "viewportWidth": 1536
 }

--- a/webui/react/src/components/Dropdown.tsx
+++ b/webui/react/src/components/Dropdown.tsx
@@ -22,6 +22,7 @@ export enum Placement {
 interface Props {
   content: React.ReactNode;
   disableAutoDismiss?: boolean;
+  initVisible?: boolean;
   offset?: { x: number, y: number };
   onVisibleChange?: (visible: boolean) => void;
   placement?: Placement;
@@ -31,12 +32,13 @@ interface Props {
 const Dropdown: React.FC<Props> = ({
   disableAutoDismiss = false,
   offset = { x: 0, y: 0 },
+  initVisible = false,
   onVisibleChange,
   placement = Placement.BottomLeft,
   showArrow = true,
   ...props
 }: PropsWithChildren<Props>) => {
-  const [ isVisible, setIsVisible ] = useState(false);
+  const [ isVisible, setIsVisible ] = useState(initVisible);
   const dropdownRef = useRef<HTMLDivElement>(null);
   const triggerRef = useRef<HTMLDivElement>(null);
   const classes = [ css.base, css[placement] ];

--- a/webui/react/src/components/ResponsiveFilters.module.scss
+++ b/webui/react/src/components/ResponsiveFilters.module.scss
@@ -2,53 +2,46 @@
   .content {
     align-items: center;
     display: flex;
+    flex-wrap: wrap;
 
     & > * { margin-left: var(--theme-sizes-layout-enormous); }
-
-    @media only screen and (max-width: $breakpoint-tablet) {
-      align-items: stretch;
-      display: flex;
-      flex-direction: column;
-      // max-width: 32rem;
-      padding: var(--theme-sizes-layout-big);
-      // width: calc(100vw - 2 * var(--theme-sizes-layout-big));
-
-      & > * {
-        align-items: stretch;
-        display: flex;
-        flex-direction: column;
-        justify-content: flex-start;
-        margin-left: 0;
-      }
-      & > * > [class^=Label_base_] {
-        margin-left: 0;
-        padding: var(--theme-sizes-layout-big) 0 var(--theme-sizes-layout-medium) 0;
-        text-align: left;
-      }
-      & > *:first-child > [class^=Label_base_] {
-        padding: 0 0 var(--theme-sizes-layout-medium) 0;
-      }
-      & > * > *:not(:first-child) {
-        margin-left: 0;
-      }
-    }
   }
   .close {
     position: absolute;
     right: 0;
     top: 0;
   }
-  .filtersButton {
-    display: none;
-
-    @media only screen and (max-width: $breakpoint-tablet) {
-      display: block;
-    }
-  }
 }
 .filtersApplied {
   .filtersButton {
     border-color: var(--theme-colors-action-normal);
     color: var(--theme-colors-action-normal);
+  }
+}
+.collapsed {
+  .content {
+    align-items: stretch;
+    display: flex;
+    flex-direction: column;
+    padding: var(--theme-sizes-layout-big);
+
+    & > * {
+      align-items: stretch;
+      display: flex;
+      flex-direction: column;
+      justify-content: flex-start;
+      margin-left: 0;
+    }
+    & > * > [class^=Label_base_] {
+      margin-left: 0;
+      padding: var(--theme-sizes-layout-big) 0 var(--theme-sizes-layout-medium) 0;
+      text-align: left;
+    }
+    & > *:first-child > [class^=Label_base_] {
+      padding: 0 0 var(--theme-sizes-layout-medium) 0;
+    }
+    & > * > *:not(:first-child) {
+      margin-left: 0;
+    }
   }
 }

--- a/webui/react/src/components/ResponsiveFilters.tsx
+++ b/webui/react/src/components/ResponsiveFilters.tsx
@@ -1,5 +1,5 @@
 import { Button } from 'antd';
-import React from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 
 import Dropdown, { Placement } from 'components/Dropdown';
 import useResize from 'hooks/useResize';
@@ -11,26 +11,44 @@ interface Props {
   hasFiltersApplied?: boolean;
 }
 
-const BREAKPOINT = 768;
-
 const ResponsiveFilters: React.FC<Props> = ({ children, hasFiltersApplied }: Props) => {
-  const resize = useResize();
+  const container = useRef<HTMLDivElement>(null);
+  const resize = useResize(container);
+  const [ isCollapsed, setIsCollapsed ] = useState(false);
+  const [ initVisible, setInitVisible ] = useState(true);
   const classes = [ css.base ];
 
   if (hasFiltersApplied) classes.push(css.filtersApplied);
+  if (isCollapsed) classes.push(css.collapsed);
+
+  /*
+   * If the height of the container is more than 32,
+   * it means that the filter options are wrapping and
+   * needs to collapse into a filter/dropdown view.
+   */
+  useEffect(() => {
+    if (!isCollapsed && resize.height > 48) {
+      setInitVisible(false);
+      setIsCollapsed(true);
+    }
+  }, [ isCollapsed, resize.height ]);
 
   const content = <div className={css.content}>{children}</div>;
-  const wrappedContent = resize.width < BREAKPOINT ? (
-    <Dropdown
-      content={content}
-      disableAutoDismiss
-      offset={{ x: 0, y: 8 }}
-      placement={Placement.BottomRight}>
-      <Button className={css.filtersButton}>Filters</Button>
-    </Dropdown>
-  ) : content;
 
-  return <div className={classes.join(' ')}>{wrappedContent}</div>;
+  return (
+    <div className={classes.join(' ')} ref={container}>
+      {isCollapsed ? (
+        <Dropdown
+          content={content}
+          disableAutoDismiss
+          initVisible={initVisible}
+          offset={{ x: 0, y: 8 }}
+          placement={Placement.BottomRight}>
+          <Button className={css.filtersButton}>Filters</Button>
+        </Dropdown>
+      ) : content}
+    </div>
+  );
 };
 
 export default ResponsiveFilters;


### PR DESCRIPTION
## Description

Responsive filters renders poorly when exactly at portrait table breakpoint of 768.

Update the filters to dynamically check for when the filters run out of space and starts wrapping. That is the point where the filters should collapse into a filters button + dropdown view.

One minor caveat is that with this approach, once the collapse occurs, it does not return back to the uncollapsed state when resizing the viewport to something large enough. Unless the user navigates away and back to the page or reloads the page.

Issue
![2020-11-21 at 11 33 AM](https://user-images.githubusercontent.com/220971/99887258-17738180-2c00-11eb-9f7b-72a80bbda106.png)

Uncollapsed
<img width="1043" alt="Screen Shot 2020-11-21 at 1 39 18 PM" src="https://user-images.githubusercontent.com/220971/99887248-075ba200-2c00-11eb-8c8f-f385af418776.png">

Collapsed
<img width="995" alt="Screen Shot 2020-11-21 at 1 39 32 PM" src="https://user-images.githubusercontent.com/220971/99887253-10e50a00-2c00-11eb-8334-ef759039cbf0.png">


<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan

Check responsive filters on:
- [ ] Recent Task filters on the Dashboard page
- [ ] experiment table filters on the Experiment List page
- [ ] Metric Chart filters on the Trial Details page
- [ ] Trial Info table filters on the Trial Details page
- [ ] Task List page

<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234