### PR TITLE
feat: priority scheduler with preemption [DET-4512]

### DIFF
--- a/master/internal/resourcemanagers/agent.go
+++ b/master/internal/resourcemanagers/agent.go
@@ -79,3 +79,28 @@ func (a *agentState) allocateFreeDevices(slots int, id cproto.ID) []device.Devic
 	check.Panic(check.True(len(devices) == slots, "not enough devices"))
 	return devices
 }
+
+func (a *agentState) deepCopy() *agentState {
+	copiedAgent := &agentState{
+		handler:            a.handler,
+		label:              a.label,
+		devices:            make(map[device.Device]*cproto.ID),
+		zeroSlotContainers: make(map[cproto.ID]bool),
+	}
+
+	for originalDevice, id := range a.devices {
+		copiedDevice := device.Device{
+			ID:    originalDevice.ID,
+			Brand: originalDevice.Brand,
+			UUID:  originalDevice.UUID,
+			Type:  originalDevice.Type,
+		}
+		copiedAgent.devices[copiedDevice] = id
+	}
+
+	for originalKey, originalValue := range a.zeroSlotContainers {
+		copiedAgent.zeroSlotContainers[originalKey] = originalValue
+	}
+
+	return copiedAgent
+}

--- a/master/internal/resourcemanagers/agent.go
+++ b/master/internal/resourcemanagers/agent.go
@@ -82,10 +82,11 @@ func (a *agentState) allocateFreeDevices(slots int, id cproto.ID) []device.Devic
 
 func (a *agentState) deepCopy() *agentState {
 	copiedAgent := &agentState{
-		handler:            a.handler,
-		label:              a.label,
-		devices:            make(map[device.Device]*cproto.ID),
-		zeroSlotContainers: make(map[cproto.ID]bool),
+		handler:               a.handler,
+		label:                 a.label,
+		devices:               make(map[device.Device]*cproto.ID),
+		zeroSlotContainers:    make(map[cproto.ID]bool),
+		maxZeroSlotContainers: a.maxZeroSlotContainers,
 	}
 
 	for originalDevice, id := range a.devices {

--- a/master/internal/resourcemanagers/fitting.go
+++ b/master/internal/resourcemanagers/fitting.go
@@ -141,7 +141,7 @@ func findDedicatedAgentFits(
 	}
 
 	if candidateNumSlots == 0 {
-		log.Infof("Task: %s which requires %d slots, can not be scheduled onto multiple agents "+
+		log.Debugf("Task: %s which requires %d slots, can not be scheduled onto multiple agents "+
 			"in the current cluster configuration. When running on multiple agents, number of "+
 			"slots per trial must be either set to 1 or a multiple of the GPUs per agent.",
 			req.ID, req.SlotsNeeded,

--- a/master/internal/resourcemanagers/priority.go
+++ b/master/internal/resourcemanagers/priority.go
@@ -79,7 +79,7 @@ func (p *priorityScheduler) priorityScheduleByLabel(
 		// have been scheduled.
 		if startTasks {
 			for _, allocatedTask := range successfulAllocations {
-				log.Infof("scheduled task: %s", allocatedTask.Name)
+				log.Debugf("scheduled task: %s", allocatedTask.Name)
 			}
 			toAllocate = append(toAllocate, successfulAllocations...)
 		}
@@ -100,7 +100,7 @@ func (p *priorityScheduler) priorityScheduleByLabel(
 		for _, prioritizedAllocation := range unSuccessfulAllocations {
 			// Check if we still need to preempt tasks to schedule this task.
 			if fits := findFits(prioritizedAllocation, localAgentsState, fittingMethod); len(fits) > 0 {
-				log.Infof(
+				log.Debugf(
 					"Not preempting tasks for task %s as it will be able to launch "+
 						"once already scheduled preemptions complete", prioritizedAllocation.Name)
 				addTaskToAgents(fits)
@@ -114,7 +114,7 @@ func (p *priorityScheduler) priorityScheduleByLabel(
 			if taskPlaced {
 				localAgentsState = updatedLocalAgentState
 				for preemptedTask := range preemptedTasks {
-					log.Infof("preempting task %s for task %s",
+					log.Debugf("preempting task %s for task %s",
 						preemptedTask.Address().Local(), prioritizedAllocation.Name)
 					toRelease[preemptedTask] = true
 				}

--- a/master/internal/resourcemanagers/priority.go
+++ b/master/internal/resourcemanagers/priority.go
@@ -1,0 +1,195 @@
+package resourcemanagers
+
+import (
+	"fmt"
+	"sort"
+
+	log "github.com/sirupsen/logrus"
+
+	"github.com/determined-ai/determined/master/pkg/actor"
+)
+
+type priorityScheduler struct{}
+
+// NewPriorityScheduler creates a new scheduler that schedules tasks via priority.
+func NewPriorityScheduler() Scheduler {
+	return &priorityScheduler{}
+}
+
+func (p *priorityScheduler) Schedule(rp *ResourcePool) ([]*AllocateRequest, []*actor.Ref) {
+	return p.prioritySchedule(rp.taskList, rp.groups, rp.agents, rp.fittingMethod)
+}
+
+func (p *priorityScheduler) prioritySchedule(
+	taskList *taskList,
+	groups map[*actor.Ref]*group,
+	agents map[*actor.Ref]*agentState,
+	fittingMethod SoftConstraint,
+) ([]*AllocateRequest, []*actor.Ref) {
+	agentsSplitByLabel := splitAgentsByLabel(agents)
+	toAllocate := make([]*AllocateRequest, 0)
+	toRelease := make([]*actor.Ref, 0)
+
+	// Since labels are a hard scheduling constraint, process every
+	// label independently.
+	for label, agentsWithLabel := range agentsSplitByLabel {
+		toAllocatedForLabel, toReleaseForLabel := p.priorityScheduleByLabel(
+			taskList, groups, agentsWithLabel, fittingMethod, label)
+		toAllocate = append(toAllocate, toAllocatedForLabel...)
+		toRelease = append(toRelease, toReleaseForLabel...)
+	}
+
+	return toAllocate, toRelease
+}
+
+func (p *priorityScheduler) priorityScheduleByLabel(
+	taskList *taskList,
+	groups map[*actor.Ref]*group,
+	agents map[*actor.Ref]*agentState,
+	fittingMethod SoftConstraint,
+	label string,
+) ([]*AllocateRequest, []*actor.Ref) {
+	// All pending zero slot tasks get scheduled right away.
+	toAllocate := getAllPendingZeroSlotTasks(taskList, label)
+
+	// Sort tasks by priorities and timestamps.
+	priorityToPendingTasksMap, _ := sortTasksByPriorityAndTimestamp(taskList, groups, label)
+
+	// Make a local copy of the agent state that we will modify.
+	localAgentsState := deepCopyAgents(agents)
+
+	for _, priority := range getOrderedPriorities(priorityToPendingTasksMap) {
+		allocationRequests := priorityToPendingTasksMap[priority]
+		log.Infof("processing priority %d with %d pending tasks", priority, len(allocationRequests))
+
+		successfulAllocations := make([]*AllocateRequest, 0)
+		for _, allocationRequest := range allocationRequests {
+			log.Infof("trying to schedule task: %s", allocationRequest.ID)
+			fits := findFits(allocationRequest, localAgentsState, fittingMethod)
+			if len(fits) == 0 {
+				continue
+			}
+			log.Infof("successfully scheduled task: %s", allocationRequest.ID)
+			simulateFitsPlacement(fits)
+			successfulAllocations = append(successfulAllocations, allocationRequest)
+		}
+		toAllocate = append(toAllocate, successfulAllocations...)
+		// If not all requests were fulfilled we do not scheduler lower priority tasks.
+		if len(successfulAllocations) < len(allocationRequests) {
+			log.Infof(
+				"scheduled only %d tasks in priority level thus breaking out",
+				len(successfulAllocations))
+			break
+		}
+	}
+
+	return toAllocate, make([]*actor.Ref, 0)
+}
+
+func getAllPendingZeroSlotTasks(taskList *taskList, label string) []*AllocateRequest {
+	pendingZeroSlotTasks := make([]*AllocateRequest, 0)
+	for it := taskList.iterator(); it.next(); {
+		req := it.value()
+		if req.Label != label || req.SlotsNeeded > 0 {
+			continue
+		}
+
+		assigned := taskList.GetAllocations(req.TaskActor)
+		if assigned == nil || len(assigned.Allocations) == 0 {
+			log.Infof("scheduling pending zero-slot task: %s", req.ID)
+			pendingZeroSlotTasks = append(pendingZeroSlotTasks, req)
+		}
+	}
+	return pendingZeroSlotTasks
+}
+
+func sortTasksByPriorityAndTimestamp(
+	taskList *taskList,
+	groups map[*actor.Ref]*group,
+	label string,
+) (map[int][]*AllocateRequest, map[int][]*AllocateRequest) {
+	// Sort all non-zero slot tasks by priority.
+	priorityToPendingTasksMap := make(map[int][]*AllocateRequest)
+	priorityToScheduledTaskMap := make(map[int][]*AllocateRequest)
+
+	for it := taskList.iterator(); it.next(); {
+		req := it.value()
+		if req.Label != label || req.SlotsNeeded == 0 {
+			continue
+		}
+
+		priority := groups[req.Group].priority
+		if priority == nil {
+			panic(fmt.Sprintf("priority not set for task %s", req.Name))
+		}
+
+		assigned := taskList.GetAllocations(req.TaskActor)
+		switch {
+		case assigned == nil || len(assigned.Allocations) == 0:
+			if _, ok := priorityToPendingTasksMap[*priority]; !ok {
+				priorityToPendingTasksMap[*priority] = make([]*AllocateRequest, 0)
+			}
+			priorityToPendingTasksMap[*priority] = append(priorityToPendingTasksMap[*priority], req)
+
+		default:
+			if _, ok := priorityToScheduledTaskMap[*priority]; !ok {
+				priorityToScheduledTaskMap[*priority] = make([]*AllocateRequest, 0)
+			}
+			priorityToScheduledTaskMap[*priority] = append(priorityToScheduledTaskMap[*priority], req)
+		}
+	}
+
+	// For each priority sort pending tasks by longest to shortest time of existence.
+	for priority := range priorityToPendingTasksMap {
+		pendingTasks := priorityToPendingTasksMap[priority]
+		sort.Slice(pendingTasks, func(i, j int) bool {
+			first, second := pendingTasks[i], pendingTasks[j]
+			return second.TaskActor.RegisteredTime().Before(first.TaskActor.RegisteredTime())
+		})
+	}
+
+	// For each priority sort scheduled tasks by shortest to longest time of existence.
+	for priority := range priorityToScheduledTaskMap {
+		scheduledTasks := priorityToScheduledTaskMap[priority]
+		sort.Slice(scheduledTasks, func(i, j int) bool {
+			first, second := scheduledTasks[i], scheduledTasks[j]
+			return first.TaskActor.RegisteredTime().Before(second.TaskActor.RegisteredTime())
+		})
+	}
+
+	return priorityToPendingTasksMap, priorityToScheduledTaskMap
+}
+
+func deepCopyAgents(agents map[*actor.Ref]*agentState) map[*actor.Ref]*agentState {
+	copiedAgents := make(map[*actor.Ref]*agentState)
+	for key, agent := range agents {
+		copiedAgents[key] = agent.deepCopy()
+	}
+	return copiedAgents
+}
+
+func simulateFitsPlacement(fits []*fittingState) {
+	for _, fit := range fits {
+		fit.Agent.allocateFreeDevices(fit.Slots, "simulation")
+	}
+}
+
+func getOrderedPriorities(allocationsByPriority map[int][]*AllocateRequest) []int {
+	keys := make([]int, 0, len(allocationsByPriority))
+	for k := range allocationsByPriority {
+		keys = append(keys, k)
+	}
+	sort.Ints(keys)
+	return keys
+}
+
+func splitAgentsByLabel(agents map[*actor.Ref]*agentState) map[string]map[*actor.Ref]*agentState {
+	agentsSplitByLabel := make(map[string]map[*actor.Ref]*agentState)
+	for agentRef, agent := range agents {
+		if _, ok := agentsSplitByLabel[agent.label]; !ok {
+			agentsSplitByLabel[agent.label] = make(map[*actor.Ref]*agentState)
+		}
+		agentsSplitByLabel[agent.label][agentRef] = agent
+	}
+	return agentsSplitByLabel
+}

--- a/master/internal/resourcemanagers/priority_test.go
+++ b/master/internal/resourcemanagers/priority_test.go
@@ -55,37 +55,28 @@ func TestSortTasksByPriorityAndTimestamps(t *testing.T) {
 	taskList, mockGroups, _ := setupSchedulerStates(t, system, tasks, groups, agents)
 
 	pendingTasksByPriority, _ := sortTasksByPriorityAndTimestamp(taskList, mockGroups, "")
-	for priority, tasksInPriority := range pendingTasksByPriority {
-		switch priority {
-		case lowerPriority:
-			expectedTasks := []*mockTask{tasks[0], tasks[1]}
-			assertEqualToAllocate(t, tasksInPriority, expectedTasks)
-		case higherPriority:
-			expectedTasks := []*mockTask{tasks[4]}
-			assertEqualToAllocate(t, tasksInPriority, expectedTasks)
-		default:
-			panic("unexpected priority")
-		}
-	}
+
+	tasksInLowerPriority := pendingTasksByPriority[lowerPriority]
+	expectedTasksInLowerPriority := []*mockTask{tasks[0], tasks[1]}
+	assertEqualToAllocate(t, tasksInLowerPriority, expectedTasksInLowerPriority)
+
+	tasksInHigherPriority := pendingTasksByPriority[higherPriority]
+	expectedTasksInHigherPriority := []*mockTask{tasks[4]}
+	assertEqualToAllocate(t, tasksInHigherPriority, expectedTasksInHigherPriority)
 
 	setTaskAllocations(t, taskList, "task5", 1)
-
 	_, scheduledTasksByPriority := sortTasksByPriorityAndTimestamp(taskList, mockGroups, "")
-	for priority, tasksInPriority := range scheduledTasksByPriority {
-		switch priority {
-		case lowerPriority:
-			expectedTasks := make([]*mockTask, 0)
-			assertEqualToAllocate(t, tasksInPriority, expectedTasks)
-		case higherPriority:
-			expectedTasks := []*mockTask{tasks[4]}
-			assertEqualToAllocate(t, tasksInPriority, expectedTasks)
-		default:
-			panic("unexpected priority")
-		}
-	}
+
+	tasksInLowerPriority = scheduledTasksByPriority[lowerPriority]
+	expectedTasksInLowerPriority = make([]*mockTask, 0)
+	assertEqualToAllocate(t, tasksInLowerPriority, expectedTasksInLowerPriority)
+
+	tasksInHigherPriority = scheduledTasksByPriority[higherPriority]
+	expectedTasksInHigherPriority = []*mockTask{tasks[4]}
+	assertEqualToAllocate(t, tasksInHigherPriority, expectedTasksInHigherPriority)
 }
 
-func TestPrioritySchedulingNoPreemption(t *testing.T) {
+func TestPrioritySchedulingPreemptionDisabled(t *testing.T) {
 	lowerPriority := 50
 	higherPriority := 40
 
@@ -121,7 +112,7 @@ func TestPrioritySchedulingNoPreemption(t *testing.T) {
 	}
 }
 
-func TestPrioritySchedulingNoPreemptionCase2(t *testing.T) {
+func TestPrioritySchedulingPreemptionDisabledHigherPriorityBlocksLowerPriority(t *testing.T) {
 	lowerPriority := 50
 	higherPriority := 40
 
@@ -154,7 +145,7 @@ func TestPrioritySchedulingNoPreemptionCase2(t *testing.T) {
 	}
 }
 
-func TestPrioritySchedulingNoPreemptionWithLabels(t *testing.T) {
+func TestPrioritySchedulingPreemptionDisabledWithLabels(t *testing.T) {
 	lowerPriority := 50
 	higherPriority := 40
 
@@ -213,7 +204,7 @@ func TestPrioritySchedulingPreemption(t *testing.T) {
 	assertEqualToRelease(t, taskList, toRelease, expectedToRelease)
 }
 
-func TestPrioritySchedulingNoSchedule(t *testing.T) {
+func TestPrioritySchedulingLowPriorityTasksAreBlockedByHigherPriority(t *testing.T) {
 	lowerPriority := 50
 	higherPriority := 40
 

--- a/master/internal/resourcemanagers/priority_test.go
+++ b/master/internal/resourcemanagers/priority_test.go
@@ -1,0 +1,205 @@
+package resourcemanagers
+
+import (
+	"testing"
+
+	"gotest.tools/assert"
+
+	"github.com/determined-ai/determined/master/pkg/actor"
+)
+
+func TestGetAllPendingZeroSlotTasks(t *testing.T) {
+	agents := make([]*mockAgent, 0)
+	groups := []*mockGroup{
+		{id: "group1", maxSlots: newMaxSlot(1), weight: 1},
+	}
+	tasks := []*mockTask{
+		{id: "task1", slotsNeeded: 4, group: groups[0]},
+		{id: "task2", slotsNeeded: 1, group: groups[0]},
+		{id: "task3", slotsNeeded: 0, group: groups[0]},
+		{id: "task4", slotsNeeded: 0, group: groups[0]},
+	}
+
+	system := actor.NewSystem(t.Name())
+	taskList, _, _ := setupSchedulerStates(t, system, tasks, groups, agents)
+
+	allocationRequests := make(map[string]*AllocateRequest)
+	for it := taskList.iterator(); it.next(); {
+		req := it.value()
+		allocationRequests[req.Name] = req
+	}
+
+	pendingZeroSlotTasks := getAllPendingZeroSlotTasks(taskList, "")
+	expectedZeroSlotTasksIds := []*mockTask{tasks[2], tasks[3]}
+	assertEqualToAllocate(t, pendingZeroSlotTasks, expectedZeroSlotTasksIds)
+
+	task4, _ := taskList.GetTaskByID("task4")
+	taskList.SetAllocations(
+		task4.TaskActor,
+		&ResourcesAllocated{
+			task4.ID,
+			"",
+			[]Allocation{containerAllocation{}},
+		},
+	)
+
+	pendingZeroSlotTasks = getAllPendingZeroSlotTasks(taskList, "")
+	expectedZeroSlotTasksIds = []*mockTask{tasks[2]}
+	assertEqualToAllocate(t, pendingZeroSlotTasks, expectedZeroSlotTasksIds)
+}
+
+func TestSortTasksByPriorityAndTimestamps(t *testing.T) {
+	lowerPriority := 50
+	higherPriority := 40
+
+	agents := make([]*mockAgent, 0)
+	groups := []*mockGroup{
+		{id: "group1", priority: &lowerPriority},
+		{id: "group2", priority: &higherPriority},
+	}
+	tasks := []*mockTask{
+		{id: "task1", slotsNeeded: 4, group: groups[0]},
+		{id: "task2", slotsNeeded: 1, group: groups[0]},
+		{id: "task3", slotsNeeded: 0, group: groups[1]},
+		{id: "task4", slotsNeeded: 0, group: groups[1]},
+		{id: "task5", slotsNeeded: 4, group: groups[1]},
+	}
+
+	system := actor.NewSystem(t.Name())
+	taskList, mockGroups, _ := setupSchedulerStates(t, system, tasks, groups, agents)
+
+	pendingTasksByPriority, _ := sortTasksByPriorityAndTimestamp(taskList, mockGroups, "")
+	for priority, tasksInPriority := range pendingTasksByPriority {
+		switch priority {
+		case lowerPriority:
+			expectedTasks := []*mockTask{tasks[0], tasks[1]}
+			assertEqualToAllocate(t, tasksInPriority, expectedTasks)
+		case higherPriority:
+			expectedTasks := []*mockTask{tasks[4]}
+			assertEqualToAllocate(t, tasksInPriority, expectedTasks)
+		default:
+			panic("unexpected priority")
+		}
+	}
+
+	task5, _ := taskList.GetTaskByID("task5")
+	taskList.SetAllocations(
+		task5.TaskActor,
+		&ResourcesAllocated{
+			task5.ID,
+			"",
+			[]Allocation{containerAllocation{}},
+		},
+	)
+
+	_, scheduledTasksByPriority := sortTasksByPriorityAndTimestamp(taskList, mockGroups, "")
+	for priority, tasksInPriority := range scheduledTasksByPriority {
+		switch priority {
+		case lowerPriority:
+			expectedTasks := make([]*mockTask, 0)
+			assertEqualToAllocate(t, tasksInPriority, expectedTasks)
+		case higherPriority:
+			expectedTasks := []*mockTask{tasks[4]}
+			assertEqualToAllocate(t, tasksInPriority, expectedTasks)
+		default:
+			panic("unexpected priority")
+		}
+	}
+}
+
+func TestPrioritySchedulingNoPreemption(t *testing.T) {
+	lowerPriority := 50
+	higherPriority := 40
+
+	agents := []*mockAgent{
+		{id: "agent1", slots: 4},
+		{id: "agent2", slots: 4},
+	}
+	groups := []*mockGroup{
+		{id: "group1", priority: &lowerPriority},
+		{id: "group2", priority: &higherPriority},
+	}
+	tasks := []*mockTask{
+		{id: "task1", slotsNeeded: 4, group: groups[0]},
+		{id: "task2", slotsNeeded: 1, group: groups[0]},
+		{id: "task3", slotsNeeded: 1, group: groups[1]},
+		{id: "task4", slotsNeeded: 0, group: groups[1]},
+		{id: "task5", slotsNeeded: 4, group: groups[1]},
+		{id: "task6", slotsNeeded: 0, group: groups[0]},
+	}
+
+	system := actor.NewSystem(t.Name())
+	taskList, groupMap, agentMap := setupSchedulerStates(t, system, tasks, groups, agents)
+
+	p := &priorityScheduler{}
+	toAllocate, _ := p.prioritySchedule(taskList, groupMap, agentMap, BestFit)
+
+	expectedToAllocate := []*mockTask{tasks[1], tasks[2], tasks[3], tasks[4], tasks[5]}
+	assertEqualToAllocate(t, toAllocate, expectedToAllocate)
+
+	// Check that agent stat has not changed.
+	for _, agent := range agentMap {
+		assert.Equal(t, agent.numEmptySlots(), 4)
+	}
+}
+
+func TestPrioritySchedulingNoPreemptionCase2(t *testing.T) {
+	lowerPriority := 50
+	higherPriority := 40
+
+	agents := []*mockAgent{
+		{id: "agent1", slots: 4},
+		{id: "agent2", slots: 4},
+	}
+	groups := []*mockGroup{
+		{id: "group1", priority: &lowerPriority},
+		{id: "group2", priority: &higherPriority},
+	}
+	tasks := []*mockTask{
+		{id: "task1", slotsNeeded: 4, group: groups[0]},
+		{id: "task2", slotsNeeded: 1, group: groups[0]},
+		{id: "task3", slotsNeeded: 12, group: groups[1]},
+	}
+
+	system := actor.NewSystem(t.Name())
+	taskList, groupMap, agentMap := setupSchedulerStates(t, system, tasks, groups, agents)
+
+	p := &priorityScheduler{}
+	toAllocate, _ := p.prioritySchedule(taskList, groupMap, agentMap, BestFit)
+
+	expectedToAllocate := []*mockTask{}
+	assertEqualToAllocate(t, toAllocate, expectedToAllocate)
+
+	// Check that agent stat has not changed.
+	for _, agent := range agentMap {
+		assert.Equal(t, agent.numEmptySlots(), 4)
+	}
+}
+
+func TestPrioritySchedulingNoPreemptionWithLabels(t *testing.T) {
+	lowerPriority := 50
+	higherPriority := 40
+
+	agents := []*mockAgent{
+		{id: "agent1", slots: 4, label: "label1"},
+		{id: "agent2", slots: 4, label: "label1"},
+	}
+	groups := []*mockGroup{
+		{id: "group1", priority: &lowerPriority},
+		{id: "group2", priority: &higherPriority},
+	}
+	tasks := []*mockTask{
+		{id: "task1", slotsNeeded: 4, group: groups[0], label: "label1"},
+		{id: "task2", slotsNeeded: 1, group: groups[0], label: "label1"},
+		{id: "task3", slotsNeeded: 4, group: groups[1], label: "label2"},
+	}
+
+	system := actor.NewSystem(t.Name())
+	taskList, groupMap, agentMap := setupSchedulerStates(t, system, tasks, groups, agents)
+
+	p := &priorityScheduler{}
+	toAllocate, _ := p.prioritySchedule(taskList, groupMap, agentMap, BestFit)
+
+	expectedToAllocate := []*mockTask{tasks[0], tasks[1]}
+	assertEqualToAllocate(t, toAllocate, expectedToAllocate)
+}

--- a/master/internal/resourcemanagers/priority_test.go
+++ b/master/internal/resourcemanagers/priority_test.go
@@ -1,7 +1,6 @@
 package resourcemanagers
 
 import (
-	"fmt"
 	"testing"
 
 	"gotest.tools/assert"
@@ -161,7 +160,7 @@ func TestPrioritySchedulingPreemptionDisabledWithLabels(t *testing.T) {
 	assertEqualToAllocate(t, toAllocate, expectedToAllocate)
 }
 
-func TestPrioritySchedulingPreemptionAaron(t *testing.T) {
+func TestPrioritySchedulingPreemption(t *testing.T) {
 	lowerPriority := 50
 	higherPriority := 40
 
@@ -241,11 +240,9 @@ func TestPrioritySchedulerPreemptZeroSlotTask(t *testing.T) {
 	p := &priorityScheduler{preemptionEnabled: true}
 	toAllocate, toRelease := p.prioritySchedule(taskList, groupMap, agentMap, BestFit)
 
-	fmt.Println("1")
 	expectedToAllocate := make([]*mockTask, 0)
 	assertEqualToAllocate(t, toAllocate, expectedToAllocate)
 
-	fmt.Println("2", toRelease)
 	expectedToRelease := []*mockTask{tasks[0]}
 	assertEqualToRelease(t, taskList, toRelease, expectedToRelease)
 }

--- a/master/internal/resourcemanagers/scheduler_test.go
+++ b/master/internal/resourcemanagers/scheduler_test.go
@@ -360,18 +360,7 @@ func setupSchedulerStates(
 			agentState := agents[agentRef]
 			container := newContainer(req, agentState, req.SlotsNeeded)
 
-			allocated := &ResourcesAllocated{
-				ID: req.ID,
-				Allocations: []Allocation{
-					containerAllocation{
-						req:       req,
-						agent:     agentState,
-						container: container,
-					},
-				},
-			}
-			taskList.SetAllocations(req.TaskActor, allocated)
-
+			devices := make([]device.Device, 0)
 			if mockTask.containerStarted {
 				if mockTask.slotsNeeded == 0 {
 					agentState.zeroSlotContainers[container.id] = true
@@ -383,6 +372,7 @@ func setupSchedulerStates(
 						}
 						if i < mockTask.slotsNeeded {
 							agentState.devices[d] = &container.id
+							devices = append(devices, d)
 							i++
 						}
 					}
@@ -390,6 +380,19 @@ func setupSchedulerStates(
 						"over allocated to agent %s", mockTask.allocatedAgent.id)
 				}
 			}
+
+			allocated := &ResourcesAllocated{
+				ID: req.ID,
+				Allocations: []Allocation{
+					&containerAllocation{
+						req:       req,
+						agent:     agentState,
+						container: container,
+						devices:   devices,
+					},
+				},
+			}
+			taskList.SetAllocations(req.TaskActor, allocated)
 		}
 	}
 

--- a/master/internal/resourcemanagers/scheduler_test.go
+++ b/master/internal/resourcemanagers/scheduler_test.go
@@ -24,6 +24,7 @@ type mockGroup struct {
 	id       string
 	maxSlots *int
 	weight   float64
+	priority *int
 }
 
 func (g *mockGroup) Receive(ctx *actor.Context) error {
@@ -326,6 +327,7 @@ func setupSchedulerStates(
 			handler:  ref,
 			maxSlots: mockGroup.maxSlots,
 			weight:   mockGroup.weight,
+			priority: mockGroup.priority,
 		}
 		groups[ref] = group
 		groupActors[mockGroup] = ref

--- a/master/pkg/container/container.go
+++ b/master/pkg/container/container.go
@@ -19,7 +19,7 @@ type Container struct {
 
 // New returns a new pending container.
 func New(parent actor.Address, devices []device.Device, recoverable bool) Container {
-	return Container{Parent: parent, ID: newID(), State: Assigned, Devices: devices}
+	return Container{Parent: parent, ID: NewID(), State: Assigned, Devices: devices}
 }
 
 // Transition transitions the container state to the new state. An illegal transition will panic.

--- a/master/pkg/container/id.go
+++ b/master/pkg/container/id.go
@@ -10,7 +10,8 @@ import (
 // ID is a unique ID assigned to the containers of tasks when started in the cluster.
 type ID string
 
-func newID() ID {
+// NewID provides a unique ID for a container.
+func NewID() ID {
 	return ID(uuid.New().String())
 }
 


### PR DESCRIPTION
## Description
Adding priority scheduler with pre-emption. This scheduler is not yet configurable without master 
code changes as we are not yet ready to release it. 

The priority scheduler will never scheduler lower priority (non-zero slot) task while a higher priority 
task is pending. It is able to run with and w/o pre-emption. When pre-emption is enabled, lower 
priority tasks will be terminated in order to schedule higher priority tasks. By default pre-emption
is disabled. 

## Test Plan
Tested manually and added basic unit test coverage. Extensive unit test coverage will be added as part
of [DET-4513](https://determinedai.atlassian.net/browse/DET-4513).
