### PR TITLE
feat: read logs from elasticsearch [DET-4621]

### DIFF
--- a/master/internal/api_trials.go
+++ b/master/internal/api_trials.go
@@ -37,6 +37,8 @@ var (
 	distinctFieldBatchWaitTime = 5 * time.Second
 )
 
+// TrialLogBackend is an interface trial log backends, such as elastic or postgres,
+// must support to provide the features surfaced in API.
 type TrialLogBackend interface {
 	TrialLogs(
 		trialID, offset, limit int, filters []api.Filter, state interface{},
@@ -94,7 +96,8 @@ func (a *apiServer) TrialLogs(
 			return nil, nil
 		}
 
-		b, state, err := a.m.trialLogBackend.TrialLogs(int(req.TrialId), lr.Offset, lr.Limit, lr.Filters, followState)
+		b, state, err := a.m.trialLogBackend.TrialLogs(
+			int(req.TrialId), lr.Offset, lr.Limit, lr.Filters, followState)
 		if err != nil {
 			return nil, err
 		}

--- a/master/internal/api_trials.go
+++ b/master/internal/api_trials.go
@@ -152,6 +152,8 @@ func constructTrialLogsFilters(req *apiv1.TrialLogsRequest) ([]api.Filter, error
 			switch l {
 			case logv1.LogLevel_LOG_LEVEL_UNSPECIFIED:
 				levels = append(levels, "DEBUG")
+			case logv1.LogLevel_LOG_LEVEL_TRACE:
+				levels = append(levels, "TRACE")
 			case logv1.LogLevel_LOG_LEVEL_DEBUG:
 				levels = append(levels, "DEBUG")
 			case logv1.LogLevel_LOG_LEVEL_INFO:

--- a/master/internal/core.go
+++ b/master/internal/core.go
@@ -61,14 +61,14 @@ type Master struct {
 	config   *Config
 	taskSpec *tasks.TaskSpec
 
-	logs          *logger.LogBuffer
-	system        *actor.System
-	echo          *echo.Echo
-	rm            *actor.Ref
-	rwCoordinator *actor.Ref
-	db            *db.PgDB
-	proxy         *actor.Ref
-	trialLogger   *actor.Ref
+	logs            *logger.LogBuffer
+	system          *actor.System
+	echo            *echo.Echo
+	rm              *actor.Ref
+	rwCoordinator   *actor.Ref
+	db              *db.PgDB
+	proxy           *actor.Ref
+	trialLogger     *actor.Ref
 	trialLogBackend TrialLogBackend
 }
 
@@ -367,9 +367,9 @@ func (m *Master) Run(ctx context.Context) error {
 	case m.config.Logging.DefaultLoggingConfig != nil:
 		m.trialLogBackend = m.db
 	case m.config.Logging.ElasticLoggingConfig != nil:
-		es, err := elastic.Setup(*m.config.Logging.ElasticLoggingConfig)
-		if err != nil {
-			return err
+		es, eErr := elastic.Setup(*m.config.Logging.ElasticLoggingConfig)
+		if eErr != nil {
+			return eErr
 		}
 		m.trialLogBackend = es
 	default:

--- a/master/internal/core.go
+++ b/master/internal/core.go
@@ -67,6 +67,7 @@ type Master struct {
 	rm            *actor.Ref
 	rwCoordinator *actor.Ref
 	db            *db.PgDB
+	es            *elastic.Elastic
 	proxy         *actor.Ref
 	trialLogger   *actor.Ref
 }
@@ -367,11 +368,11 @@ func (m *Master) Run(ctx context.Context) error {
 	case m.config.Logging.DefaultLoggingConfig != nil:
 		trialLogPersister = m.db
 	case m.config.Logging.ElasticLoggingConfig != nil:
-		es, sErr := elastic.Setup(*m.config.Logging.ElasticLoggingConfig)
-		if sErr != nil {
-			return sErr
+		m.es, err = elastic.Setup(*m.config.Logging.ElasticLoggingConfig)
+		if err != nil {
+			return err
 		}
-		trialLogPersister = es
+		trialLogPersister = m.es
 	default:
 		panic("unsupported logging backend")
 	}

--- a/master/internal/db/postgres.go
+++ b/master/internal/db/postgres.go
@@ -1933,13 +1933,13 @@ func (db *PgDB) AuthTokenKeypair() (*model.AuthTokenKeypair, error) {
 	}
 }
 
-// TrialStatus returns current state of the given trial.
+// TrialStatus returns the current state of the given trial.
 func (db *PgDB) TrialStatus(trialID int) (model.State, error) {
 	var state model.State
 	err := db.sql.QueryRow(`
-SELECT t.state AS State
-FROM trials t
-WHERE t.id = $1
+SELECT state AS State
+FROM trials
+WHERE id = $1
 `, trialID).Scan(&state)
 	return state, err
 }

--- a/master/internal/db/postgres.go
+++ b/master/internal/db/postgres.go
@@ -1933,6 +1933,17 @@ func (db *PgDB) AuthTokenKeypair() (*model.AuthTokenKeypair, error) {
 	}
 }
 
+// TrialStatus returns current state of the given trial.
+func (db *PgDB) TrialStatus(trialID int) (model.State, error) {
+	var state model.State
+	err := db.sql.QueryRow(`
+SELECT t.state AS State
+FROM trials t
+WHERE t.id = $1
+`, trialID).Scan(&state)
+	return state, err
+}
+
 func (db *PgDB) queryRowsWithParser(
 	query string, p func(*sqlx.Rows, interface{}) error, v interface{}, args ...interface{},
 ) error {

--- a/master/internal/db/postgres.go
+++ b/master/internal/db/postgres.go
@@ -1937,7 +1937,7 @@ func (db *PgDB) AuthTokenKeypair() (*model.AuthTokenKeypair, error) {
 func (db *PgDB) TrialStatus(trialID int) (model.State, error) {
 	var state model.State
 	err := db.sql.QueryRow(`
-SELECT state AS State
+SELECT state
 FROM trials
 WHERE id = $1
 `, trialID).Scan(&state)

--- a/master/internal/db/postgres.go
+++ b/master/internal/db/postgres.go
@@ -1360,45 +1360,6 @@ FROM (
 	return db.rawQuery(fmt.Sprintf(queryTemplate, strings.Join(averageMetrics, ",")), id)
 }
 
-// AddTrialLogs adds a list of *model.TrialLog objects to the database with automatic IDs.
-func (db *PgDB) AddTrialLogs(logs []*model.TrialLog) error {
-	if len(logs) == 0 {
-		return nil
-	}
-
-	var text strings.Builder
-	text.WriteString(`
-INSERT INTO trial_logs
-  (trial_id, message, log, agent_id, container_id, rank_id, timestamp, level, stdtype, source)
- VALUES
-`)
-
-	args := make([]interface{}, 0, len(logs)*10)
-
-	for i, log := range logs {
-		if i > 0 {
-			text.WriteString(",")
-		}
-		fmt.Fprintf(&text, " ($%d, $%d, $%d, $%d, $%d, $%d, $%d, $%d, $%d, $%d)",
-			i*10+1, i*10+2, i*10+3, i*10+4, i*10+5, i*10+6, i*10+7, i*10+8, i*10+9, i*10+10)
-
-		var l *model.RawString
-		if log.Log != nil {
-			r := model.RawString(*log.Log)
-			l = &r
-		}
-
-		args = append(args, log.TrialID, log.Message, l, log.AgentID, log.ContainerID, log.RankID,
-			log.Timestamp, log.Level, log.StdType, log.Source)
-	}
-
-	if _, err := db.sql.Exec(text.String(), args...); err != nil {
-		return errors.Wrapf(err, "error inserting %d trial logs", len(logs))
-	}
-
-	return nil
-}
-
 // TrialLogsRaw returns the logs for a trial as a JSON string.
 func (db *PgDB) TrialLogsRaw(
 	id int,

--- a/master/internal/db/postgres_trial_logs.go
+++ b/master/internal/db/postgres_trial_logs.go
@@ -95,16 +95,15 @@ func (db *PgDB) TrialLogCount(trialID int, fs []api.Filter) (int, error) {
 	fragment, params := filtersToSQL(fs, params)
 	query := fmt.Sprintf(`
 SELECT count(*)
-FROM trial_logs l
-WHERE l.trial_id = $1
+FROM trial_logs
+WHERE trial_id = $1
 %s
 `, fragment)
 	var count int
-	err := db.sql.QueryRow(query, params...).Scan(&count)
-	if err != nil {
+	if err := db.sql.QueryRow(query, params...).Scan(&count); err != nil {
 		return 0, err
 	}
-	return count, err
+	return count, nil
 }
 
 // TrialLogFields returns the unique fields that can be filtered on for the given trial.

--- a/master/internal/db/postgres_trial_logs.go
+++ b/master/internal/db/postgres_trial_logs.go
@@ -2,6 +2,8 @@ package db
 
 import (
 	"fmt"
+	"github.com/pkg/errors"
+	"strings"
 
 	"github.com/determined-ai/determined/master/internal/api"
 
@@ -10,8 +12,8 @@ import (
 
 // TrialLogs takes a trial ID and log offset, limit and filters and returns matching trial logs.
 func (db *PgDB) TrialLogs(
-	trialID, offset, limit int, fs []api.Filter,
-) ([]*model.TrialLog, error) {
+	trialID, offset, limit int, fs []api.Filter, _ interface{},
+) ([]*model.TrialLog, interface{}, error) {
 	params := []interface{}{trialID, offset, limit}
 	fragment, params := filtersToSQL(fs, params)
 	query := fmt.Sprintf(`
@@ -42,5 +44,58 @@ ORDER BY l.id ASC OFFSET $2 LIMIT $3
 `, fragment)
 
 	var b []*model.TrialLog
-	return b, db.queryRows(query, &b, params...)
+	return b, nil, db.queryRows(query, &b, params...)
+}
+
+// AddTrialLogs adds a list of *model.TrialLog objects to the database with automatic IDs.
+func (db *PgDB) AddTrialLogs(logs []*model.TrialLog) error {
+	if len(logs) == 0 {
+		return nil
+	}
+
+	var text strings.Builder
+	text.WriteString(`
+INSERT INTO trial_logs
+  (trial_id, message, log, agent_id, container_id, rank_id, timestamp, level, stdtype, source)
+ VALUES
+`)
+
+	args := make([]interface{}, 0, len(logs)*10)
+
+	for i, log := range logs {
+		if i > 0 {
+			text.WriteString(",")
+		}
+		fmt.Fprintf(&text, " ($%d, $%d, $%d, $%d, $%d, $%d, $%d, $%d, $%d, $%d)",
+			i*10+1, i*10+2, i*10+3, i*10+4, i*10+5, i*10+6, i*10+7, i*10+8, i*10+9, i*10+10)
+
+		var l *model.RawString
+		if log.Log != nil {
+			r := model.RawString(*log.Log)
+			l = &r
+		}
+
+		args = append(args, log.TrialID, log.Message, l, log.AgentID, log.ContainerID, log.RankID,
+			log.Timestamp, log.Level, log.StdType, log.Source)
+	}
+
+	if _, err := db.sql.Exec(text.String(), args...); err != nil {
+		return errors.Wrapf(err, "error inserting %d trial logs", len(logs))
+	}
+
+	return nil
+}
+
+// TrialLogCount returns the number of logs in postgres for the given trial. This shouldn't be called,
+// instead the master's TrialLogBackend should be called which may call this.
+func (db *PgDB) TrialLogCount(trialID int) (int, error) {
+	trialStatus := struct {
+		State   model.State
+		NumLogs int
+	}{}
+	err := db.Query("trial_status", &trialStatus, trialID)
+	if err != nil {
+		return 0, err
+	}
+	return trialStatus.NumLogs, err
 }

--- a/master/internal/db/postgres_trial_logs.go
+++ b/master/internal/db/postgres_trial_logs.go
@@ -2,9 +2,11 @@ package db
 
 import (
 	"fmt"
-	"github.com/determined-ai/determined/proto/pkg/apiv1"
-	"github.com/pkg/errors"
 	"strings"
+
+	"github.com/pkg/errors"
+
+	"github.com/determined-ai/determined/proto/pkg/apiv1"
 
 	"github.com/determined-ai/determined/master/internal/api"
 

--- a/master/internal/db/postgres_trial_logs.go
+++ b/master/internal/db/postgres_trial_logs.go
@@ -108,7 +108,7 @@ WHERE trial_id = $1
 
 // TrialLogFields returns the unique fields that can be filtered on for the given trial.
 func (db *PgDB) TrialLogFields(trialID int) (*apiv1.TrialLogsFieldsResponse, error) {
-	var fields *apiv1.TrialLogsFieldsResponse
-	err := db.QueryProto("get_trial_log_fields", fields, trialID)
-	return fields, err
+	var fields apiv1.TrialLogsFieldsResponse
+	err := db.QueryProto("get_trial_log_fields", &fields, trialID)
+	return &fields, err
 }

--- a/master/internal/db/postgres_trial_logs.go
+++ b/master/internal/db/postgres_trial_logs.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"fmt"
+	"github.com/determined-ai/determined/proto/pkg/apiv1"
 	"github.com/pkg/errors"
 	"strings"
 
@@ -87,8 +88,6 @@ INSERT INTO trial_logs
 }
 
 // TrialLogCount returns the number of logs in postgres for the given trial.
-// This shouldn't be called, instead the master's TrialLogBackend should be
-// called which may call this.
 func (db *PgDB) TrialLogCount(trialID int, fs []api.Filter) (int, error) {
 	params := []interface{}{trialID}
 	fragment, params := filtersToSQL(fs, params)
@@ -104,4 +103,11 @@ WHERE l.trial_id = $1
 		return 0, err
 	}
 	return count, err
+}
+
+// TrialLogFields returns the unique fields that can be filtered on for the given trial.
+func (db *PgDB) TrialLogFields(trialID int) (*apiv1.TrialLogsFieldsResponse, error) {
+	var fields *apiv1.TrialLogsFieldsResponse
+	err := db.QueryProto("get_trial_log_fields", fields, trialID)
+	return fields, err
 }

--- a/master/internal/elastic/elastic.go
+++ b/master/internal/elastic/elastic.go
@@ -4,11 +4,11 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	"github.com/sirupsen/logrus"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"time"
+
+	"github.com/sirupsen/logrus"
 
 	"github.com/elastic/go-elasticsearch/v7"
 	"github.com/pkg/errors"

--- a/master/internal/elastic/elastic_trial_logs.go
+++ b/master/internal/elastic/elastic_trial_logs.go
@@ -84,8 +84,8 @@ func (e *Elastic) TrialLogCount(trialID int) (int, error) {
 // search after over itself.
 // https://www.elastic.co/guide/en/elasticsearch/reference/6.8/search-request-search-after.html
 func (e *Elastic) TrialLogs(
-	trialID, offset, limit int, fs []api.Filter, searchAfter []interface{},
-) ([]*model.TrialLog, []interface{}, error) {
+	trialID, offset, limit int, fs []api.Filter, searchAfter interface{},
+) ([]*model.TrialLog, interface{}, error) {
 	if limit > ElasticMaxQuerySize {
 		limit = ElasticMaxQuerySize
 	}
@@ -192,7 +192,7 @@ func (e *Elastic) TrialLogs(
 		logs = append(logs, h.Source)
 	}
 
-	var sortValues []interface{}
+	var sortValues interface{}
 	if len(resp.Hits.Hits) > 0 {
 		sortValues = resp.Hits.Hits[len(resp.Hits.Hits)-1].Sort
 	} else if searchAfter != nil {

--- a/master/internal/elastic/elastic_trial_logs.go
+++ b/master/internal/elastic/elastic_trial_logs.go
@@ -3,11 +3,24 @@ package elastic
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
+	"reflect"
 	"time"
+
+	log "github.com/sirupsen/logrus"
+
+	"github.com/determined-ai/determined/master/internal/api"
 
 	"github.com/pkg/errors"
 
 	"github.com/determined-ai/determined/master/pkg/model"
+)
+
+// The maximum size of elasticsearch queries on a cluster with default configurations.
+// Can be increased but is limited by Lucene's 2m cap also.
+const (
+	ElasticMaxQuerySize    = 10000
+	ElasticTimeWindowDelay = -10 * time.Second
 )
 
 // AddTrialLogs indexes a batch of trial logs into the index like triallogs-yyyy-MM-dd based
@@ -40,6 +53,205 @@ func (e *Elastic) AddTrialLogs(logs []*model.TrialLog) error {
 		}
 	}
 	return nil
+}
+
+// TrialLogCount returns the number of trial logs for the given trial.
+func (e *Elastic) TrialLogCount(trialID int) (int, error) {
+	res, err := e.client.Count(
+		e.client.Count.WithQuery(fmt.Sprintf("trial_id:%d", trialID)))
+	if err != nil {
+		return 0, fmt.Errorf("failed to retrieve log count: %w", err)
+	}
+	defer func() {
+		if cErr := res.Body.Close(); cErr != nil {
+			log.Errorf("failed to close count response body: %s", cErr)
+		}
+	}()
+
+	resp := struct {
+		Count int `json:"count"`
+	}{}
+	err = json.NewDecoder(res.Body).Decode(&resp)
+	if err != nil {
+		return 0, fmt.Errorf("failed to decode count api response")
+	}
+	return resp.Count, nil
+}
+
+// TrialLogs return a set of trial logs within a specified window.
+// This uses the search after API, since from+size is prohibitively
+// expensive for deep pagination and the scroll api specifically recommends
+// search after over itself.
+// https://www.elastic.co/guide/en/elasticsearch/reference/6.8/search-request-search-after.html
+func (e *Elastic) TrialLogs(
+	trialID, offset, limit int, fs []api.Filter, searchAfter []interface{},
+) ([]*model.TrialLog, []interface{}, error) {
+	if limit > ElasticMaxQuerySize {
+		limit = ElasticMaxQuerySize
+	}
+
+	query := map[string]interface{}{
+		// Use from+size to begin at the requested offset, but move to search after
+		// API after first query to paginate the requests.
+		"size": limit,
+		"from": offset,
+		"query": map[string]interface{}{
+			"bool": map[string]interface{}{
+				"filter": append(filtersToElastic(fs),
+					map[string]interface{}{
+						"term": map[string]interface{}{
+							"trial_id": trialID,
+						},
+					},
+					// Only look at logs posted more than 10 seconds ago. In the event
+					// a fluentbit shipper is backed up, it may post logs with a timestamp
+					// that falls before the current time. If we do a search_after based on
+					// the latest logs, we may miss these backed up unless we do this.
+					map[string]interface{}{
+						"range": map[string]interface{}{
+							"timestamp": map[string]interface{}{
+								"lt": time.Now().UTC().Add(ElasticTimeWindowDelay),
+							},
+						},
+					}),
+			},
+		},
+		"sort": []map[string]interface{}{
+			{"timestamp": "asc"},
+			// If two containers emit logs with the same timestamp down
+			// to the nanosecond, it may be lost in some cases still, but
+			// this should be better than nothing.
+			{"container_id.keyword": "asc"},
+		},
+	}
+
+	if searchAfter != nil {
+		query["search_after"] = searchAfter
+		// If a request comes with searchAfter values, offset is meaningless
+		// so we just remove it.
+		delete(query, "from")
+	}
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(query); err != nil {
+		return nil, nil, fmt.Errorf("failed to encoding query: %w", err)
+	}
+
+	res, err := e.client.Search(e.client.Search.WithBody(&buf))
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to perform search: %w", err)
+	}
+	defer func() {
+		cErr := res.Body.Close()
+		if cErr != nil {
+			log.Errorf("failed to close search resp body: %s", cErr)
+		}
+	}()
+
+	resp := struct {
+		Hits struct {
+			Hits []struct {
+				Source *model.TrialLog `json:"_source"`
+				Sort   []interface{}   `json:"sort"`
+			} `json:"hits"`
+		} `json:"hits"`
+	}{}
+	err = json.NewDecoder(res.Body).Decode(&resp)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to decode search api response")
+	}
+
+	var logs []*model.TrialLog
+	for _, h := range resp.Hits.Hits {
+		var timestamp string
+		if h.Source.Timestamp != nil {
+			timestamp = h.Source.Timestamp.Format(time.RFC3339Nano)
+		} else {
+			timestamp = "UNKNOWN TIME"
+		}
+
+		var containerID string
+		if h.Source.ContainerID != nil {
+			containerID = *h.Source.ContainerID
+		} else {
+			containerID = "UNKNOWN CONTAINER"
+		}
+
+		var rankID string
+		if h.Source.RankID != nil {
+			rankID = fmt.Sprintf("[rank=%d]", *h.Source.RankID)
+		}
+
+		var level string
+		if h.Source.Level != nil {
+			level = *h.Source.Level
+		}
+
+		h.Source.Message = fmt.Sprintf("[%s] [%s] %s || %s %s",
+			timestamp, containerID, rankID, level, *h.Source.Log)
+		logs = append(logs, h.Source)
+	}
+
+	var sortValues []interface{}
+	if len(resp.Hits.Hits) > 0 {
+		sortValues = resp.Hits.Hits[len(resp.Hits.Hits)-1].Sort
+	} else if searchAfter != nil {
+		sortValues = searchAfter
+	}
+
+	return logs, sortValues, nil
+}
+
+func filtersToElastic(fs []api.Filter) []map[string]interface{} {
+	var terms []map[string]interface{}
+	for _, f := range fs {
+		switch f.Operation {
+		case api.FilterOperationIn:
+			switch reflect.TypeOf(f.Values).Kind() {
+			case reflect.Slice:
+				s := reflect.ValueOf(f.Values)
+				var inTerms []map[string]interface{}
+				for i := 0; i < s.Len(); i++ {
+					inTerms = append(inTerms,
+						map[string]interface{}{
+							"term": map[string]interface{}{
+								// filter against the keyword not the analyzed text.
+								f.Field + ".keyword": s.Index(i).Interface(),
+							},
+						})
+				}
+				terms = append(terms,
+					map[string]interface{}{
+						"bool": map[string]interface{}{
+							"should": inTerms,
+						},
+					})
+			default:
+				panic(fmt.Sprintf("unsupported IN filter values %T", f.Values))
+			}
+		case api.FilterOperationLessThan:
+			terms = append(terms,
+				map[string]interface{}{
+					"range": map[string]interface{}{
+						f.Field: map[string]interface{}{
+							"lt": f.Values,
+						},
+					},
+				})
+		case api.FilterOperationGreaterThan:
+			terms = append(terms,
+				map[string]interface{}{
+					"range": map[string]interface{}{
+						f.Field: map[string]interface{}{
+							"gt": f.Values,
+						},
+					},
+				})
+		default:
+			panic(fmt.Sprintf("unsupported filter operation: %d", f.Operation))
+		}
+	}
+	return terms
 }
 
 func logstashIndexFromTimestamp(time *time.Time) string {

--- a/master/internal/elastic/elastic_trial_logs.go
+++ b/master/internal/elastic/elastic_trial_logs.go
@@ -56,7 +56,7 @@ func (e *Elastic) AddTrialLogs(logs []*model.TrialLog) error {
 }
 
 // TrialLogCount returns the number of trial logs for the given trial.
-func (e *Elastic) TrialLogCount(trialID int) (int, error) {
+func (e *Elastic) TrialLogCount(trialID int, fs []api.Filter) (int, error) {
 	res, err := e.client.Count(
 		e.client.Count.WithQuery(fmt.Sprintf("trial_id:%d", trialID)))
 	if err != nil {

--- a/master/internal/trial_logger.go
+++ b/master/internal/trial_logger.go
@@ -25,14 +25,8 @@ type (
 	flushLogs struct{}
 )
 
-// TrialLogPersister is an interface for a storage backend that can persist
-// trial logs.
-type TrialLogPersister interface {
-	AddTrialLogs([]*model.TrialLog) error
-}
-
 type trialLogger struct {
-	backend    TrialLogPersister
+	backend      TrialLogBackend
 	pending      []*model.TrialLog
 	lastLogFlush time.Time
 }
@@ -41,7 +35,7 @@ type trialLogger struct {
 // There should only be one trialLogger shared across the entire system.
 func newTrialLogger(backend TrialLogBackend) actor.Actor {
 	return &trialLogger{
-		backend:    backend,
+		backend:      backend,
 		lastLogFlush: time.Now(),
 		pending:      make([]*model.TrialLog, 0, logBuffer),
 	}

--- a/master/static/srv/trial_status.sql
+++ b/master/static/srv/trial_status.sql
@@ -1,7 +1,7 @@
 SELECT
     t.state AS State,
-    COUNT(*) AS NumLogs
+    (SELECT count(*)
+        FROM trial_logs l
+        WHERE l.trial_id = $1) AS NumLogs
 FROM trials t
-JOIN trial_logs l ON t.id = l.trial_id
 WHERE t.id = $1
-GROUP BY t.state

--- a/master/static/srv/trial_status.sql
+++ b/master/static/srv/trial_status.sql
@@ -1,7 +1,3 @@
-SELECT
-    t.state AS State,
-    (SELECT count(*)
-        FROM trial_logs l
-        WHERE l.trial_id = $1) AS NumLogs
+SELECT t.state AS State
 FROM trials t
 WHERE t.id = $1

--- a/master/static/srv/trial_status.sql
+++ b/master/static/srv/trial_status.sql
@@ -1,3 +1,0 @@
-SELECT t.state AS State
-FROM trials t
-WHERE t.id = $1


### PR DESCRIPTION
## Description
This PR adds an support for reading logs from elasticsearch when it is configured as the log backend for the cluster.
<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan
- [ ] add integration tests in a follow up pr
- [x] add support for `/api/v1/trials/:trial_id/logs/fields` backed by elasticsearch in a followup PR
- [x] fix determining the offset when filters are applied (run count queries with filters in elastic+postgres) in a followup PR
<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)
This supports the same API as trial logs, however in several cases this API is not well suited to elasticsearch. For example, the webui makes queries to the API like `/api/v1/trials/:trial_id/logs?limit=1000&offset=-1000&follow=true` that get converted to a postgres query with `LIMIT 1000 OFFSET count_this_trials_logs - 1000`. Postgres handles grabbing the last page of a large result set fine, however the equivalent query in elasticsearch potentially requires a large from+size that would exceed `index.max_result_window` or worse cause OOMs before it did. Because of this, I suggest we keep this API but move the webui to consuming logs by accessing for successive timestamp ranges instead. If we go with this route, we will need to figure out how to return unique IDs so as the webui manually pages backwards as the user scrolls up, it can order and potentially dedup any logs.
<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234