### PR TITLE
fix: track best validation metric for darts_cnn hp search benchmark

### DIFF
--- a/examples/hp_search_benchmarks/darts_cifar10_pytorch/README.md
+++ b/examples/hp_search_benchmarks/darts_cifar10_pytorch/README.md
@@ -29,7 +29,6 @@ adaptive.yaml .`. The other configurations can be run by specifying the appropri
 configuration file in place of `adaptive.yaml`.
 
 ## Expected Performance
-With 16 V100 GPUs, the best architecture after 1 day should achieve around to 96.8\% 
-to 97.0\% accuracy on CIFAR-10.  For a fair comparison to the NAS results for this search space, 
+With 16 V100 GPUs, the best architecture after 1 day should achieve around 97\% accuracy on CIFAR-10.  For a fair comparison to the NAS results for this search space, 
 you will have to train the best architecture for a total of 600 epochs instead of the 300 epochs 
 used for the HP search experiment.

--- a/examples/hp_search_benchmarks/darts_cifar10_pytorch/adaptive.yaml
+++ b/examples/hp_search_benchmarks/darts_cifar10_pytorch/adaptive.yaml
@@ -142,6 +142,10 @@ searcher:
     batches: 156200
   max_trials: 10000
   mode: aggressive
+  # A maximum of 4 rungs corresponds to a minimum training length of 1/divisor^(max_rungs - 1) = 1/64 * max_length 
+  # per trial.  Trials with higher validation accuracy will be trained for longer than this minimum will poor
+  # trials will be stopped early.
+  max_rungs: 4
   max_concurrent_trials: 16
 
 entrypoint: model_def:DARTSCNNTrial

--- a/examples/hp_search_benchmarks/darts_cifar10_pytorch/utils.py
+++ b/examples/hp_search_benchmarks/darts_cifar10_pytorch/utils.py
@@ -76,7 +76,10 @@ def _data_transforms_cifar10(args):
         train_transform.transforms.append(Cutout(args.cutout_length))
 
     valid_transform = transforms.Compose(
-        [transforms.ToTensor(), transforms.Normalize(CIFAR_MEAN, CIFAR_STD),]
+        [
+            transforms.ToTensor(),
+            transforms.Normalize(CIFAR_MEAN, CIFAR_STD),
+        ]
     )
     return train_transform, valid_transform
 


### PR DESCRIPTION
## Description
The validation accuracy is quiet noisy and fluctuates a lot for this benchmark.  This negatively impacts the performance of hp search, which uses the latest validation accuracy to make early-stopping decisions.  Hence, we change the validation accuracy to return the best accuracy so far instead of latest so that the searcher has a higher quality signal for early-stopping.  


## Test Plan
Verified with experiments that adaptive search does indeed find architectures with better final accuracy when using best accuracy so far as the searcher metric.  
