### PR TITLE
feat: display task priorities in CLI [DET-4515, DET-4516]

### DIFF
--- a/cli/determined_cli/cli.py
+++ b/cli/determined_cli/cli.py
@@ -50,7 +50,7 @@ def list_tasks(args: Namespace) -> None:
         return [c["agent"] for c in containers]
 
     tasks = r.json()
-    headers = ["ID", "Name", "Slots Needed", "Registered Time", "Agent"]
+    headers = ["ID", "Name", "Slots Needed", "Registered Time", "Agent", "Priority"]
     values = [
         [
             task["id"],
@@ -58,6 +58,7 @@ def list_tasks(args: Namespace) -> None:
             task["slots_needed"],
             render.format_time(task["registered_time"]),
             agent_info(task),
+            task["priority"] if task["scheduler_type"] == "priority" else "N/A",
         ]
         for task_id, task in sorted(
             tasks.items(),

--- a/master/internal/resourcemanagers/kubernetes_resource_manager.go
+++ b/master/internal/resourcemanagers/kubernetes_resource_manager.go
@@ -12,6 +12,9 @@ import (
 	image "github.com/determined-ai/determined/master/pkg/tasks"
 )
 
+
+const KUBERNETES = "kubernetes"
+
 // kubernetesResourceProvider manages the lifecycle of k8s resources.
 type kubernetesResourceManager struct {
 	config *KubernetesResourceManagerConfig
@@ -69,14 +72,14 @@ func (k *kubernetesResourceManager) Receive(ctx *actor.Context) error {
 		return k.receiveRequestMsg(ctx)
 
 	case GetTaskSummary:
-		if resp := getTaskSummary(k.reqList, *msg.ID, k.groups, "kubernetes"); resp != nil {
+		if resp := getTaskSummary(k.reqList, *msg.ID, k.groups, KUBERNETES); resp != nil {
 			ctx.Respond(*resp)
 		}
 		reschedule = false
 
 	case GetTaskSummaries:
 		reschedule = false
-		ctx.Respond(getTaskSummaries(k.reqList, k.groups, "kubernetes"))
+		ctx.Respond(getTaskSummaries(k.reqList, k.groups, KUBERNETES))
 
 	case schedulerTick:
 		if k.reschedule {

--- a/master/internal/resourcemanagers/kubernetes_resource_manager.go
+++ b/master/internal/resourcemanagers/kubernetes_resource_manager.go
@@ -69,14 +69,14 @@ func (k *kubernetesResourceManager) Receive(ctx *actor.Context) error {
 		return k.receiveRequestMsg(ctx)
 
 	case GetTaskSummary:
-		if resp := getTaskSummary(k.reqList, *msg.ID); resp != nil {
+		if resp := getTaskSummary(k.reqList, *msg.ID, k.groups, "kubernetes"); resp != nil {
 			ctx.Respond(*resp)
 		}
 		reschedule = false
 
 	case GetTaskSummaries:
 		reschedule = false
-		ctx.Respond(getTaskSummaries(k.reqList))
+		ctx.Respond(getTaskSummaries(k.reqList, k.groups, "kubernetes"))
 
 	case schedulerTick:
 		if k.reschedule {

--- a/master/internal/resourcemanagers/kubernetes_resource_manager.go
+++ b/master/internal/resourcemanagers/kubernetes_resource_manager.go
@@ -12,8 +12,7 @@ import (
 	image "github.com/determined-ai/determined/master/pkg/tasks"
 )
 
-
-const KUBERNETES = "kubernetes"
+const kubernetesScheduler = "kubernetes"
 
 // kubernetesResourceProvider manages the lifecycle of k8s resources.
 type kubernetesResourceManager struct {
@@ -72,14 +71,14 @@ func (k *kubernetesResourceManager) Receive(ctx *actor.Context) error {
 		return k.receiveRequestMsg(ctx)
 
 	case GetTaskSummary:
-		if resp := getTaskSummary(k.reqList, *msg.ID, k.groups, KUBERNETES); resp != nil {
+		if resp := getTaskSummary(k.reqList, *msg.ID, k.groups, kubernetesScheduler); resp != nil {
 			ctx.Respond(*resp)
 		}
 		reschedule = false
 
 	case GetTaskSummaries:
 		reschedule = false
-		ctx.Respond(getTaskSummaries(k.reqList, k.groups, KUBERNETES))
+		ctx.Respond(getTaskSummaries(k.reqList, k.groups, kubernetesScheduler))
 
 	case schedulerTick:
 		if k.reschedule {

--- a/master/internal/resourcemanagers/resource_pool.go
+++ b/master/internal/resourcemanagers/resource_pool.go
@@ -232,13 +232,14 @@ func (rp *ResourcePool) Receive(ctx *actor.Context) error {
 
 	case GetTaskSummary:
 		reschedule = false
-		if resp := getTaskSummary(rp.taskList, *msg.ID); resp != nil {
+		if resp := getTaskSummary(
+			rp.taskList, *msg.ID, rp.groups, rp.config.Scheduler.GetType()); resp != nil {
 			ctx.Respond(*resp)
 		}
 
 	case GetTaskSummaries:
 		reschedule = false
-		ctx.Respond(getTaskSummaries(rp.taskList))
+		ctx.Respond(getTaskSummaries(rp.taskList, rp.groups, rp.config.Scheduler.GetType()))
 
 	case schedulerTick:
 		if rp.reschedule {


### PR DESCRIPTION
## Description
This PR improves observability into the priority scheduler by displaying task priority 
as part of the output of `det task list`. Additionally task summaries now include task
priorities so we will be able to display them via other mediums (e.g., WebUI) in the 
future.

## Test Plan
Tested manually.

This PR is blocked on #1634. 