### PR TITLE
chore: tune Fluent Bit logging performance [DET-4714]

### DIFF
--- a/agent/internal/containers.go
+++ b/agent/internal/containers.go
@@ -177,6 +177,8 @@ func overwriteSpec(
 			Config: map[string]string{
 				"fluentd-address":              "localhost:" + strconv.Itoa(fluentPort),
 				"fluentd-sub-second-precision": "true",
+				"mode":                         "non-blocking",
+				"max-buffer-size":              "10m",
 				"env":                          strings.Join(fluentEnvVarNames, ","),
 				"labels":                       dockerContainerParentLabel,
 			},

--- a/agent/internal/fluent.go
+++ b/agent/internal/fluent.go
@@ -130,6 +130,15 @@ func startLoggingContainer(
 		[]fluent.ConfigSection{
 			{
 				{"Name", "forward"},
+				// mem_buf_limit in combination with storage.type filesystem allows
+				// fluentbit to store full buffers in the filesystem if the rest of the
+				// pipeline is backed up. These both in combination with allowing the
+				// docker log driver to run in non-blocking mode allows us to ship
+				// without impacting application performance in bursts.
+				// This scheme is described in more detail at:
+				// https://docs.fluentbit.io/manual/administration/buffering-and-storage
+				{"mem_buf_limit", "10M"},
+				{"storage.type", "filesystem"},
 			},
 		},
 		[]fluent.ConfigSection{

--- a/agent/internal/fluent.go
+++ b/agent/internal/fluent.go
@@ -130,11 +130,11 @@ func startLoggingContainer(
 		[]fluent.ConfigSection{
 			{
 				{"Name", "forward"},
-				// mem_buf_limit in combination with storage.type filesystem allows
-				// fluentbit to store full buffers in the filesystem if the rest of the
-				// pipeline is backed up. These both in combination with allowing the
-				// docker log driver to run in non-blocking mode allows us to ship
-				// without impacting application performance in bursts.
+				// Setting mem_buf_limit and storage.type=filesystem allows Fluent Bit to buffer log data to
+				// disk if the rest of the pipeline is backed up. In combination with setting the Docker log
+				// driver to run in non-blocking mode, that lets us avoid impacting application performance when
+				// there are bursts in log output.
+				//
 				// This scheme is described in more detail at:
 				// https://docs.fluentbit.io/manual/administration/buffering-and-storage
 				{"mem_buf_limit", "10M"},

--- a/master/internal/api/logs.go
+++ b/master/internal/api/logs.go
@@ -100,6 +100,10 @@ func (l *LogStoreProcessor) Receive(ctx *actor.Context) error {
 		ctx.Tell(ctx.Self(), tick{})
 
 	case tick:
+		if l.ctx.Err() != nil {
+			ctx.Self().Stop()
+			return nil
+		}
 		switch batch, err := l.fetcher(l.req); {
 		case err != nil:
 			return errors.Wrapf(err, "failed to fetch logs")
@@ -125,6 +129,8 @@ func (l *LogStoreProcessor) Receive(ctx *actor.Context) error {
 			}
 			actors.NotifyAfter(ctx, 500*time.Millisecond, tick{})
 		default:
+			// Check the ctx again before we process, since fetch takes most of the time and
+			// a send on a closed ctx will print errors in the master log that can be misleading.
 			if l.ctx.Err() != nil {
 				ctx.Self().Stop()
 				return nil

--- a/master/pkg/fluent/fluent.go
+++ b/master/pkg/fluent/fluent.go
@@ -53,10 +53,6 @@ func makeOutputConfig(
 
 		fmt.Fprintf(config, `
 [OUTPUT]
-  Name stdout
-  Match *
-
-[OUTPUT]
   Name http
   Match *
   Host %s
@@ -66,6 +62,7 @@ func makeOutputConfig(
   Format json
   Json_date_key timestamp
   Json_date_format iso8601
+  storage.total_limit_size 1G
 `, masterHost, masterPort)
 
 	case loggingConfig.ElasticLoggingConfig != nil:
@@ -87,6 +84,7 @@ func makeOutputConfig(
   Logstash_Prefix triallogs
   Time_Key timestamp
   Time_Key_Nanos On
+  storage.total_limit_size 1G
 `, fluentElasticHost, elasticOpts.Port)
 
 		elasticSecOpts := elasticOpts.Security
@@ -177,6 +175,7 @@ end
   # Flush every .05 seconds to reduce latency for users.
   Flush .05
   Parsers_File %s
+  storage.path /var/log/flb-buffers/
 `, parserConfigPath)
 
 	for _, input := range inputs {

--- a/tools/docker-compose.yaml
+++ b/tools/docker-compose.yaml
@@ -21,3 +21,4 @@ services:
     environment:
       discovery.type: 'single-node'
       cluster.routing.allocation.disk.threshold_enabled: 'false'
+      logger.level: 'WARN'


### PR DESCRIPTION
## Description
This change makes some tweaks to the fluent config to make it a little more reliable in the face of large log bursts and master or elastic backpressure.
<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan
- [x] run with heavy logging experiments, monitor memory, cpu usage and watch fluent health 
<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)
(Old comment, retro below) This probably will matter more when we perf test elastic, but these are the things we're going to need to be tuning, probably. We probably should've been using `non-blocking` mode for the log driver all along, too, but using `non-blocking` without turning on the mmap buffers to the filesystem escape hatch means where we might've crashed the job before we would just lose logs --- with the escape hatch we should be able to recover unless we get too many logs for too long.

As remarked in https://determinedai.atlassian.net/browse/DET-4714, not running in non-blocking mode lead to very strange and unavoidable crashes within fluentbit when trying to grab logs from the daemon. To fix this, this PR moves to non-blocking mode and tweaks some others stuff that increased throughput in benchmarking.
<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234