### PR TITLE
chore: Ensuring examples always call .contiguous() before .view() [DET-4613]

### DIFF
--- a/examples/computer_vision/cifar10_pytorch/model_def.py
+++ b/examples/computer_vision/cifar10_pytorch/model_def.py
@@ -36,7 +36,7 @@ class Flatten(nn.Module):
         assert len(args) == 1
         x = args[0]
         assert isinstance(x, torch.Tensor)
-        return x.view(x.size(0), -1)
+        return x.contiguous().view(x.size(0), -1)
 
 
 class CIFARTrial(PyTorchTrial):

--- a/examples/gan/gan_mnist_pytorch/model_def.py
+++ b/examples/gan/gan_mnist_pytorch/model_def.py
@@ -47,7 +47,7 @@ class Generator(nn.Module):
 
     def forward(self, z):
         img = self.model(z)
-        img = img.view(img.size(0), *self.img_shape)
+        img = img.contiguous().view(img.size(0), *self.img_shape)
         return img
 
 
@@ -65,7 +65,7 @@ class Discriminator(nn.Module):
         )
 
     def forward(self, img):
-        img_flat = img.view(img.size(0), -1)
+        img_flat = img.contiguous().view(img.size(0), -1)
         validity = self.model(img_flat)
 
         return validity

--- a/examples/hp_search_benchmarks/darts_cifar10_pytorch/model.py
+++ b/examples/hp_search_benchmarks/darts_cifar10_pytorch/model.py
@@ -80,7 +80,7 @@ class AuxiliaryHeadCIFAR(nn.Module):
 
     def forward(self, x):
         x = self.features(x)
-        x = self.classifier(x.view(x.size(0), -1))
+        x = self.classifier(x.contiguous().view(x.size(0), -1))
         return x
 
 
@@ -104,7 +104,7 @@ class AuxiliaryHeadImageNet(nn.Module):
 
     def forward(self, x):
         x = self.features(x)
-        x = self.classifier(x.view(x.size(0), -1))
+        x = self.classifier(x.contiguous().view(x.size(0), -1))
         return x
 
 
@@ -153,7 +153,7 @@ class NetworkCIFAR(nn.Module):
                 if self._auxiliary and self.training:
                     logits_aux = self.auxiliary_head(s1)
         out = self.global_pooling(s1)
-        logits = self.classifier(out.view(out.size(0), -1))
+        logits = self.classifier(out.contiguous().view(out.size(0), -1))
         return logits, logits_aux
 
 
@@ -211,5 +211,5 @@ class NetworkImageNet(nn.Module):
                 if self._auxiliary and self.training:
                     logits_aux = self.auxiliary_head(s1)
         out = self.global_pooling(s1)
-        logits = self.classifier(out.view(out.size(0), -1))
+        logits = self.classifier(out.contiguous().view(out.size(0), -1))
         return logits, logits_aux

--- a/examples/hp_search_benchmarks/darts_cifar10_pytorch/utils.py
+++ b/examples/hp_search_benchmarks/darts_cifar10_pytorch/utils.py
@@ -29,11 +29,11 @@ def accuracy(output, target, topk=(1,)):
 
     _, pred = output.topk(maxk, 1, True, True)
     pred = pred.t()
-    correct = pred.eq(target.view(1, -1).expand_as(pred))
+    correct = pred.eq(target.contiguous().view(1, -1).expand_as(pred))
 
     res = []
     for k in topk:
-        correct_k = correct[:k].view(-1).float().sum(0)
+        correct_k = correct[:k].contiguous().view(-1).float().sum(0)
         res.append(correct_k.mul_(100.0 / batch_size))
     return res
 

--- a/examples/hp_search_benchmarks/darts_penntreebank_pytorch/data.py
+++ b/examples/hp_search_benchmarks/darts_penntreebank_pytorch/data.py
@@ -67,7 +67,7 @@ class PTBData(Dataset):
     def batchify(self, data):
         nbatch = data.size(0) // self.batch_size
         data = data.narrow(0, 0, nbatch * self.batch_size)
-        data = data.view(self.batch_size, -1).t().contiguous()  # returns [29049, 32]
+        data = data.contiguous().view(self.batch_size, -1).t().contiguous()  # returns [29049, 32]
         return data
 
     def __len__(self):

--- a/examples/hp_search_benchmarks/darts_penntreebank_pytorch/model_def.py
+++ b/examples/hp_search_benchmarks/darts_penntreebank_pytorch/model_def.py
@@ -205,7 +205,7 @@ class DARTSRNNTrial(PyTorchTrial):
         )
 
         raw_loss = nn.functional.nll_loss(
-            log_prob.view(-1, log_prob.size(2)), labels.contiguous().view(-1)
+            log_prob.contiguous().view(-1, log_prob.size(2)), labels.contiguous().contiguous().view(-1)
         )
 
         loss = raw_loss
@@ -260,7 +260,7 @@ class DARTSRNNTrial(PyTorchTrial):
 
             log_prob, hidden = model(features, hidden)
             loss = nn.functional.nll_loss(
-                log_prob.view(-1, log_prob.size(2)), targets
+                log_prob.contiguous().view(-1, log_prob.size(2)), targets
             ).data
             total_loss += loss * len(features)
 

--- a/examples/hp_search_benchmarks/darts_penntreebank_pytorch/randomNAS_files/model.py
+++ b/examples/hp_search_benchmarks/darts_penntreebank_pytorch/randomNAS_files/model.py
@@ -168,10 +168,10 @@ class RNNModel(nn.Module):
         output = self.lockdrop(raw_output, self.dropout)
         outputs.append(output)
 
-        logit = self.decoder(output.view(-1, self.ninp))
+        logit = self.decoder(output.contiguous().view(-1, self.ninp))
         log_prob = nn.functional.log_softmax(logit, dim=-1)
         model_output = log_prob
-        model_output = model_output.view(-1, batch_size, self.ntoken)
+        model_output = model_output.contiguous().view(-1, batch_size, self.ntoken)
 
         if return_h:
             return model_output, hidden, raw_outputs, outputs

--- a/examples/hp_search_benchmarks/darts_penntreebank_pytorch/randomNAS_files/utils.py
+++ b/examples/hp_search_benchmarks/darts_penntreebank_pytorch/randomNAS_files/utils.py
@@ -16,7 +16,7 @@ def repackage_hidden(h):
 def batchify(data, bsz, args):
     nbatch = data.size(0) // bsz
     data = data.narrow(0, 0, nbatch * bsz)
-    data = data.view(bsz, -1).t().contiguous()
+    data = data.contiguous().view(bsz, -1).t().contiguous()
     if args.cuda:
         data = data.cuda()
     return data

--- a/examples/meta_learning/protonet_omniglot_pytorch/model_def.py
+++ b/examples/meta_learning/protonet_omniglot_pytorch/model_def.py
@@ -16,7 +16,7 @@ class Flatten(nn.Module):
         super(Flatten, self).__init__()
 
     def forward(self, x):
-        return x.view(x.size(0), -1)
+        return x.contiguous().view(x.size(0), -1)
 
 
 def SquaredDistance(x, y):
@@ -159,7 +159,7 @@ class OmniglotProtoNetTrial(PyTorchTrial):
         # Prototype size: (num_classes, embedding_dim)
         prototypes = (
             embedding[0 : num_classes * num_support]
-            .view(num_classes, num_support, embedding_dim)
+            .contiguous().view(num_classes, num_support, embedding_dim)
             .mean(1)
         )
 
@@ -172,13 +172,13 @@ class OmniglotProtoNetTrial(PyTorchTrial):
 
         # Class log probabilities by treating -distances as logits
         # Log_prob_query size: (num_classes, num_query, num_classes)
-        log_prob_query = F.log_softmax(-euclidean_dist, dim=1).view(
+        log_prob_query = F.log_softmax(-euclidean_dist, dim=1).contiguous().view(
             num_classes, num_query, -1
         )
 
         # Match query examples with classes
-        y_query_expand = y_query.view(num_classes, num_query, 1)
-        loss = -log_prob_query.gather(2, y_query_expand).squeeze().view(-1).mean()
+        y_query_expand = y_query.contiguous().view(num_classes, num_query, 1)
+        loss = -log_prob_query.gather(2, y_query_expand).squeeze().contiguous().view(-1).mean()
 
         _, pred_query = log_prob_query.max(2)
 

--- a/examples/nas/gaea_pytorch/eval/model.py
+++ b/examples/nas/gaea_pytorch/eval/model.py
@@ -101,7 +101,7 @@ class AuxiliaryHeadImageNet(nn.Module):
 
     def forward(self, x):
         x = self.features(x)
-        x = self.classifier(x.view(x.size(0), -1))
+        x = self.classifier(x.contiguous().view(x.size(0), -1))
         return x
 
 
@@ -205,5 +205,5 @@ class NetworkImageNet(nn.Module):
                 if self._auxiliary and self.training:
                     logits_aux = self.auxiliary_head(s1)
         out = self.global_pooling(s1)
-        logits = self.classifier(out.view(out.size(0), -1))
+        logits = self.classifier(out.contiguous().view(out.size(0), -1))
         return logits, logits_aux

--- a/examples/nas/gaea_pytorch/eval/utils.py
+++ b/examples/nas/gaea_pytorch/eval/utils.py
@@ -82,11 +82,11 @@ def accuracy(output, target, topk=(1,)):
 
     _, pred = output.topk(maxk, 1, True, True)
     pred = pred.t()
-    correct = pred.eq(target.view(1, -1).expand_as(pred))
+    correct = pred.eq(target.contiguous().view(1, -1).expand_as(pred))
 
     res = []
     for k in topk:
-        correct_k = correct[:k].view(-1).float().sum(0)
+        correct_k = correct[:k].contiguous().view(-1).float().sum(0)
         res.append(correct_k.mul_(100.0 / batch_size))
     return res
 

--- a/examples/nas/gaea_pytorch/search/model_search.py
+++ b/examples/nas/gaea_pytorch/search/model_search.py
@@ -14,12 +14,12 @@ def channel_shuffle(x, groups):
     channels_per_group = num_channels // groups
 
     # reshape
-    x = x.view(batchsize, groups, channels_per_group, height, width)
+    x = x.contiguous().view(batchsize, groups, channels_per_group, height, width)
 
     x = torch.transpose(x, 1, 2).contiguous()
 
     # flatten
-    return x.view(batchsize, -1, height, width)
+    return x.contiguous().view(batchsize, -1, height, width)
 
 
 class MixedOp(nn.Module):
@@ -173,7 +173,7 @@ class Network(nn.Module):
                     weights2 = torch.cat([weights2, tw2], dim=0)
             s0, s1 = s1, cell(s0, s1, weights, weights2)
         out = self.global_pooling(s1)
-        logits = self.classifier(out.view(out.size(0), -1))
+        logits = self.classifier(out.contiguous().view(out.size(0), -1))
         return logits
 
     def _loss(self, input, target):

--- a/examples/nas/gaea_pytorch/search/utils.py
+++ b/examples/nas/gaea_pytorch/search/utils.py
@@ -64,10 +64,10 @@ def accuracy(output, target, topk=(1,)):
 
     _, pred = output.topk(maxk, 1, True, True)
     pred = pred.t()
-    correct = pred.eq(target.view(1, -1).expand_as(pred))
+    correct = pred.eq(target.contiguous().view(1, -1).expand_as(pred))
 
     res = []
     for k in topk:
-        correct_k = correct[:k].view(-1).float().sum(0)
+        correct_k = correct[:k].contiguous().view(-1).float().sum(0)
         res.append(correct_k.mul_(100.0 / batch_size))
     return res

--- a/examples/tutorials/mnist_pytorch/layers.py
+++ b/examples/tutorials/mnist_pytorch/layers.py
@@ -11,7 +11,7 @@ class Flatten(nn.Module):
         assert len(args) == 1
         x = args[0]
         assert isinstance(x, torch.Tensor)
-        return x.view(x.size(0), -1)
+        return x.contiguous().view(x.size(0), -1)
 
 
 class Squeeze(nn.Module):

--- a/harness/tests/experiment/fixtures/pytorch_xor_model.py
+++ b/harness/tests/experiment/fixtures/pytorch_xor_model.py
@@ -115,7 +115,7 @@ class BaseXORTrial(pytorch.PyTorchTrial):
     ) -> Dict[str, torch.Tensor]:
         data, labels = batch
         output = self.model(data)
-        loss = torch.nn.functional.binary_cross_entropy(output, labels.view(-1, 1))
+        loss = torch.nn.functional.binary_cross_entropy(output, labels.contiguous().view(-1, 1))
 
         self.context.backward(loss)
         self.context.step_optimizer(self.optimizer)
@@ -151,7 +151,7 @@ class XORTrialMulti(XORTrial):
     ) -> Dict[str, torch.Tensor]:
         data, labels = batch
         output = self.model(data)
-        loss = nn.functional.binary_cross_entropy(output["output"], labels.view(-1, 1))
+        loss = nn.functional.binary_cross_entropy(output["output"], labels.contiguous().view(-1, 1))
 
         self.context.backward(loss)
         self.context.step_optimizer(self.optimizer)
@@ -172,7 +172,7 @@ class XORTrialWithTrainingMetrics(XORTrialMulti):
         data, labels = batch
         output = self.model(data)
         labels = cast(torch.Tensor, labels)
-        loss = nn.functional.binary_cross_entropy(output["output"], labels.view(-1, 1))
+        loss = nn.functional.binary_cross_entropy(output["output"], labels.contiguous().view(-1, 1))
         accuracy = error_rate(output["output"], labels)
 
         self.context.backward(loss)
@@ -210,7 +210,7 @@ class XORTrialWithNonScalarValidation(pytorch.PyTorchTrial):
     ) -> Dict[str, torch.Tensor]:
         data, labels = batch
         output = self.model(data)
-        loss = nn.functional.binary_cross_entropy(output["output"], labels.view(-1, 1))
+        loss = nn.functional.binary_cross_entropy(output["output"], labels.contiguous().view(-1, 1))
 
         self.context.backward(loss)
         self.context.step_optimizer(self.optimizer)
@@ -347,7 +347,7 @@ class XORTrialAccessContext(BaseXORTrial):
 
         data, labels = batch
         output = self.model_a(data)
-        loss = torch.nn.functional.binary_cross_entropy(output, labels.view(-1, 1))
+        loss = torch.nn.functional.binary_cross_entropy(output, labels.contiguous().view(-1, 1))
 
         self.context.backward(loss)
         self.context.step_optimizer(self.opt_a)
@@ -372,7 +372,7 @@ class XORTrialGradClipping(XORTrial):
     ) -> Dict[str, torch.Tensor]:
         data, labels = batch
         output = self.model(data)
-        loss = torch.nn.functional.binary_cross_entropy(output, labels.view(-1, 1))
+        loss = torch.nn.functional.binary_cross_entropy(output, labels.contiguous().view(-1, 1))
 
         self.context.backward(loss)
 


### PR DESCRIPTION
A bunch of these fail when run on Tesla A100's. It's possibly also caused by changes in new framework versions, but I suspect the different GPU sizes may be a factor here too. So to be safe, and to keep the examples especially running robustly (even if some of them wouldn't always need it in practice), I think it's wise to just always preface the view() calls with contiguous() calls.