### PR TITLE
fix: don't replay duplicates in master restart [DET-4525, DET-4599]

### DIFF
--- a/docs/release-notes/1655-restart-with-failures.txt
+++ b/docs/release-notes/1655-restart-with-failures.txt
@@ -1,0 +1,6 @@
+:orphan:
+
+**Fixes**
+
+-  Fix a bug that caused ACTIVE trials with ``max_restarts > 0`` and
+   failures to not be restored properly on a master restart.


### PR DESCRIPTION
## Description
Duplicates can arise in master restart when a trial has failed prior to the master restart. A bug was introduced in 0.13.0 during a refactor and the logic for dedup'ing events was removed. This adds the logic back in, where it makes sense in the current structure.

<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan
- [x] run a repro with and without patch to make sure it fixes
- [x] this is a great thing to _not_ need an e2e test so i plan on using it to add an experiment/trial test in my tech debt
<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)
oops, this is a remove steps bug. I put the logic it back into the restore as opposed to the event log so the old events are at least there in the searcher events instead of just throwing them away (the old way just didn't add them to the uncommitted list that gets flushed).
<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234