### PR TITLE
chore: Work around possible bug when PyTorch opens checkpoint files [DET-4614]

### DIFF
--- a/common/determined_common/experimental/checkpoint/_torch.py
+++ b/common/determined_common/experimental/checkpoint/_torch.py
@@ -10,7 +10,7 @@ from determined.pytorch import PyTorchTrial, PyTorchTrialContext
 def load_model(
     ckpt_dir: pathlib.Path, metadata: Dict[str, Any], **kwargs: Any
 ) -> Union[PyTorchTrial, torch.nn.Module]:
-    checkpoint = torch.load(ckpt_dir.joinpath("state_dict.pth"), **kwargs)  # type: ignore
+    checkpoint = torch.load(str(ckpt_dir.joinpath("state_dict.pth")), **kwargs)  # type: ignore
 
     trial_cls, trial_context = experimental._load_trial_on_local(
         ckpt_dir.joinpath("code"),

--- a/harness/determined/pytorch/_pytorch_trial.py
+++ b/harness/determined/pytorch/_pytorch_trial.py
@@ -631,7 +631,7 @@ class PyTorchTrialController(det.LoopTrialController):
         for ckpt_path in potential_paths:
             maybe_ckpt = self.load_path.joinpath(*ckpt_path)
             if maybe_ckpt.exists():
-                checkpoint = torch.load(maybe_ckpt, map_location="cpu")  # type: ignore
+                checkpoint = torch.load(str(maybe_ckpt), map_location="cpu")  # type: ignore
                 break
 
         if "model_state_dict" in checkpoint:


### PR DESCRIPTION
Still working on a minimal reproduction of this, but it seems there's a possible bug involving the ByteBuffer class in Torch's C++ code. It calls .tell(), assuming the object passed in is an already opened file. We're supposed to be able to pass in a path and have it be opened, but that appears to be skipped in the case of some of our tests running against the latest PyTorch.