### PR TITLE
chore: Improvements to metrics streaming endpoints [DET-4532]

### DIFF
--- a/e2e_tests/tests/experiment/test_metrics.py
+++ b/e2e_tests/tests/experiment/test_metrics.py
@@ -121,7 +121,11 @@ def request_valid_metric_batches(experiment_id):  # type: ignore
     response = api.get(
         conf.make_master_url(),
         "api/v1/experiments/{}/metrics-stream/batches".format(experiment_id),
-        params={"metric_name": "accuracy", "metric_type": "METRIC_TYPE_VALIDATION", "period_seconds": 1},
+        params={
+            "metric_name": "accuracy",
+            "metric_type": "METRIC_TYPE_VALIDATION",
+            "period_seconds": 1,
+        },
     )
     results = [message["result"] for message in map(json.loads, response.text.splitlines())]
 

--- a/e2e_tests/tests/experiment/test_metrics.py
+++ b/e2e_tests/tests/experiment/test_metrics.py
@@ -61,6 +61,7 @@ def request_metric_names(experiment_id):  # type: ignore
     response = api.get(
         conf.make_master_url(),
         "api/v1/experiments/{}/metrics-stream/metric-names".format(experiment_id),
+        params={"period_seconds": 1},
     )
     results = [message["result"] for message in map(json.loads, response.text.splitlines())]
 
@@ -96,7 +97,7 @@ def request_train_metric_batches(experiment_id):  # type: ignore
     response = api.get(
         conf.make_master_url(),
         "api/v1/experiments/{}/metrics-stream/batches".format(experiment_id),
-        params={"metric_name": "loss", "metric_type": "METRIC_TYPE_TRAINING"},
+        params={"metric_name": "loss", "metric_type": "METRIC_TYPE_TRAINING", "period_seconds": 1},
     )
     results = [message["result"] for message in map(json.loads, response.text.splitlines())]
 
@@ -120,7 +121,7 @@ def request_valid_metric_batches(experiment_id):  # type: ignore
     response = api.get(
         conf.make_master_url(),
         "api/v1/experiments/{}/metrics-stream/batches".format(experiment_id),
-        params={"metric_name": "accuracy", "metric_type": "METRIC_TYPE_VALIDATION"},
+        params={"metric_name": "accuracy", "metric_type": "METRIC_TYPE_VALIDATION", "period_seconds": 1},
     )
     results = [message["result"] for message in map(json.loads, response.text.splitlines())]
 
@@ -158,6 +159,7 @@ def request_train_trials_snapshot(experiment_id):  # type: ignore
             "metric_name": "loss",
             "metric_type": "METRIC_TYPE_TRAINING",
             "batches_processed": 100,
+            "period_seconds": 1,
         },
     )
     results = [message["result"] for message in map(json.loads, response.text.splitlines())]
@@ -187,6 +189,7 @@ def request_valid_trials_snapshot(experiment_id):  # type: ignore
             "metric_name": "accuracy",
             "metric_type": "METRIC_TYPE_VALIDATION",
             "batches_processed": 200,
+            "period_seconds": 1,
         },
     )
     results = [message["result"] for message in map(json.loads, response.text.splitlines())]
@@ -252,6 +255,7 @@ def request_train_trials_sample(experiment_id):  # type: ignore
         params={
             "metric_name": "loss",
             "metric_type": "METRIC_TYPE_TRAINING",
+            "period_seconds": 1,
         },
     )
     results = [message["result"] for message in map(json.loads, response.text.splitlines())]
@@ -265,6 +269,7 @@ def request_valid_trials_sample(experiment_id):  # type: ignore
         params={
             "metric_name": "accuracy",
             "metric_type": "METRIC_TYPE_VALIDATION",
+            "period_seconds": 1,
         },
     )
     results = [message["result"] for message in map(json.loads, response.text.splitlines())]

--- a/master/internal/api_experiment.go
+++ b/master/internal/api_experiment.go
@@ -586,7 +586,7 @@ func (a *apiServer) MetricNames(req *apiv1.MetricNamesRequest,
 			}
 		}
 
-		if err := resp.Send(&response); err != nil {
+		if err = resp.Send(&response); err != nil {
 			return err
 		}
 
@@ -594,7 +594,7 @@ func (a *apiServer) MetricNames(req *apiv1.MetricNamesRequest,
 		if err != nil {
 			return errors.Wrap(err, "error looking up experiment state")
 		}
-		if model.TerminalStates[model.State(state)] {
+		if model.TerminalStates[state] {
 			return nil
 		}
 
@@ -655,7 +655,7 @@ func (a *apiServer) MetricBatches(req *apiv1.MetricBatchesRequest,
 			}
 		}
 
-		if err := resp.Send(&response); err != nil {
+		if err = resp.Send(&response); err != nil {
 			return errors.Wrapf(err, "error sending batches recorded for metric")
 		}
 
@@ -663,7 +663,7 @@ func (a *apiServer) MetricBatches(req *apiv1.MetricBatchesRequest,
 		if err != nil {
 			return errors.Wrap(err, "error looking up experiment state")
 		}
-		if model.TerminalStates[model.State(state)] {
+		if model.TerminalStates[state] {
 			return nil
 		}
 
@@ -721,7 +721,7 @@ func (a *apiServer) TrialsSnapshot(req *apiv1.TrialsSnapshotRequest,
 
 		response.Trials = newTrials
 
-		if err := resp.Send(&response); err != nil {
+		if err = resp.Send(&response); err != nil {
 			return errors.Wrapf(err, "error sending batches recorded for metrics")
 		}
 
@@ -729,7 +729,7 @@ func (a *apiServer) TrialsSnapshot(req *apiv1.TrialsSnapshotRequest,
 		if err != nil {
 			return errors.Wrap(err, "error looking up experiment state")
 		}
-		if model.TerminalStates[model.State(state)] {
+		if model.TerminalStates[state] {
 			return nil
 		}
 
@@ -890,7 +890,8 @@ func (a *apiServer) TrialsSample(req *apiv1.TrialsSampleRequest,
 			return errors.Wrapf(err, "error determining top trials")
 		}
 		for _, trialID := range trialIDs {
-			trial, err := a.fetchTrialSample(trialID, metricName, metricType, maxDatapoints,
+			var trial *apiv1.TrialsSampleResponse_Trial
+			trial, err = a.fetchTrialSample(trialID, metricName, metricType, maxDatapoints,
 				startBatches, endBatches, currentTrials, trialCursors)
 			if err != nil {
 				return err
@@ -919,7 +920,7 @@ func (a *apiServer) TrialsSample(req *apiv1.TrialsSampleRequest,
 		response.PromotedTrials = promotedTrials
 		response.DemotedTrials = demotedTrials
 
-		if err := resp.Send(&response); err != nil {
+		if err = resp.Send(&response); err != nil {
 			return errors.Wrap(err, "error sending sample of trial metric streams")
 		}
 
@@ -927,7 +928,7 @@ func (a *apiServer) TrialsSample(req *apiv1.TrialsSampleRequest,
 		if err != nil {
 			return errors.Wrap(err, "error looking up experiment state")
 		}
-		if model.TerminalStates[model.State(state)] {
+		if model.TerminalStates[state] {
 			return nil
 		}
 

--- a/master/internal/api_experiment.go
+++ b/master/internal/api_experiment.go
@@ -536,11 +536,18 @@ func (a *apiServer) CreateExperiment(
 	}, nil
 }
 
-var metricsStreamPeriod = 30 * time.Second
+var defaultMetricsStreamPeriod = 30 * time.Second
 
 func (a *apiServer) MetricNames(req *apiv1.MetricNamesRequest,
 	resp apiv1.Determined_MetricNamesServer) error {
 	experimentID := int(req.ExperimentId)
+	if err := a.checkExperimentExists(experimentID); err != nil {
+		return err
+	}
+	period := time.Duration(req.PeriodSeconds) * time.Second
+	if period == 0 {
+		period = defaultMetricsStreamPeriod
+	}
 
 	config, err := a.m.db.ExperimentConfig(experimentID)
 	if err != nil {
@@ -583,12 +590,15 @@ func (a *apiServer) MetricNames(req *apiv1.MetricNamesRequest,
 			return err
 		}
 
-		experiment, _ := a.getExperiment(experimentID)
-		if experiment.State == experimentv1.State_STATE_COMPLETED {
+		state, err := a.m.db.GetExperimentState(experimentID)
+		if err != nil {
+			return errors.Wrap(err, "error looking up experiment state")
+		}
+		if model.TerminalStates[model.State(state)] {
 			return nil
 		}
 
-		time.Sleep(metricsStreamPeriod)
+		time.Sleep(period)
 		if err := resp.Context().Err(); err != nil {
 			// connection is closed
 			return nil
@@ -599,13 +609,20 @@ func (a *apiServer) MetricNames(req *apiv1.MetricNamesRequest,
 func (a *apiServer) MetricBatches(req *apiv1.MetricBatchesRequest,
 	resp apiv1.Determined_MetricBatchesServer) error {
 	experimentID := int(req.ExperimentId)
+	if err := a.checkExperimentExists(experimentID); err != nil {
+		return err
+	}
 	metricName := req.MetricName
+	if metricName == "" {
+		return status.Error(codes.InvalidArgument, "must specify a metric name")
+	}
 	metricType := req.MetricType
 	if metricType == apiv1.MetricType_METRIC_TYPE_UNSPECIFIED {
-		return errors.New("must specify a metric type")
+		return status.Error(codes.InvalidArgument, "must specify a metric type")
 	}
-	if metricName == "" {
-		return errors.New("must provide metric name")
+	period := time.Duration(req.PeriodSeconds) * time.Second
+	if period == 0 {
+		period = defaultMetricsStreamPeriod
 	}
 
 	seenBatches := make(map[int32]bool)
@@ -642,12 +659,15 @@ func (a *apiServer) MetricBatches(req *apiv1.MetricBatchesRequest,
 			return errors.Wrapf(err, "error sending batches recorded for metric")
 		}
 
-		experiment, _ := a.getExperiment(experimentID)
-		if experiment.State == experimentv1.State_STATE_COMPLETED {
+		state, err := a.m.db.GetExperimentState(experimentID)
+		if err != nil {
+			return errors.Wrap(err, "error looking up experiment state")
+		}
+		if model.TerminalStates[model.State(state)] {
 			return nil
 		}
 
-		time.Sleep(metricsStreamPeriod)
+		time.Sleep(period)
 		if err := resp.Context().Err(); err != nil {
 			// connection is closed
 			return nil
@@ -658,14 +678,21 @@ func (a *apiServer) MetricBatches(req *apiv1.MetricBatchesRequest,
 func (a *apiServer) TrialsSnapshot(req *apiv1.TrialsSnapshotRequest,
 	resp apiv1.Determined_TrialsSnapshotServer) error {
 	experimentID := int(req.ExperimentId)
+	if err := a.checkExperimentExists(experimentID); err != nil {
+		return err
+	}
 	batchesProcessed := int(req.BatchesProcessed)
 	metricName := req.MetricName
+	if metricName == "" {
+		return status.Error(codes.InvalidArgument, "must specify a metric name")
+	}
 	metricType := req.MetricType
 	if metricType == apiv1.MetricType_METRIC_TYPE_UNSPECIFIED {
-		return errors.New("must specify a metric type")
+		return status.Error(codes.InvalidArgument, "must specify a metric type")
 	}
-	if metricName == "" {
-		return errors.New("must provide metric name")
+	period := time.Duration(req.PeriodSeconds) * time.Second
+	if period == 0 {
+		period = defaultMetricsStreamPeriod
 	}
 
 	var startTime time.Time
@@ -698,12 +725,15 @@ func (a *apiServer) TrialsSnapshot(req *apiv1.TrialsSnapshotRequest,
 			return errors.Wrapf(err, "error sending batches recorded for metrics")
 		}
 
-		experiment, _ := a.getExperiment(experimentID)
-		if experiment.State == experimentv1.State_STATE_COMPLETED {
+		state, err := a.m.db.GetExperimentState(experimentID)
+		if err != nil {
+			return errors.Wrap(err, "error looking up experiment state")
+		}
+		if model.TerminalStates[model.State(state)] {
 			return nil
 		}
 
-		time.Sleep(metricsStreamPeriod)
+		time.Sleep(period)
 		if err := resp.Context().Err(); err != nil {
 			// connection is closed
 			return nil
@@ -809,6 +839,9 @@ func (a *apiServer) fetchTrialSample(trialID int32, metricName string, metricTyp
 func (a *apiServer) TrialsSample(req *apiv1.TrialsSampleRequest,
 	resp apiv1.Determined_TrialsSampleServer) error {
 	experimentID := int(req.ExperimentId)
+	if err := a.checkExperimentExists(experimentID); err != nil {
+		return err
+	}
 	maxTrials := int(req.MaxTrials)
 	if maxTrials == 0 {
 		maxTrials = 25
@@ -822,14 +855,18 @@ func (a *apiServer) TrialsSample(req *apiv1.TrialsSampleRequest,
 	if endBatches <= 0 {
 		endBatches = math.MaxInt32
 	}
+	period := time.Duration(req.PeriodSeconds) * time.Second
+	if period == 0 {
+		period = defaultMetricsStreamPeriod
+	}
 
 	metricName := req.MetricName
 	metricType := req.MetricType
 	if metricType == apiv1.MetricType_METRIC_TYPE_UNSPECIFIED {
-		return errors.New("must specify a metric type")
+		return status.Error(codes.InvalidArgument, "must specify a metric type")
 	}
 	if metricName == "" {
-		return errors.New("must provide metric name")
+		return status.Error(codes.InvalidArgument, "must specify a metric name")
 	}
 
 	config, err := a.m.db.ExperimentConfig(experimentID)
@@ -886,12 +923,15 @@ func (a *apiServer) TrialsSample(req *apiv1.TrialsSampleRequest,
 			return errors.Wrap(err, "error sending sample of trial metric streams")
 		}
 
-		experiment, _ := a.getExperiment(experimentID)
-		if experiment.State == experimentv1.State_STATE_COMPLETED {
+		state, err := a.m.db.GetExperimentState(experimentID)
+		if err != nil {
+			return errors.Wrap(err, "error looking up experiment state")
+		}
+		if model.TerminalStates[model.State(state)] {
 			return nil
 		}
 
-		time.Sleep(metricsStreamPeriod)
+		time.Sleep(period)
 		if err := resp.Context().Err(); err != nil {
 			// connection is closed
 			return nil

--- a/master/internal/db/postgres_experiments.go
+++ b/master/internal/db/postgres_experiments.go
@@ -8,6 +8,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/determined-ai/determined/master/internal/lttb"
+	"github.com/determined-ai/determined/master/pkg/model"
 	"github.com/determined-ai/determined/master/pkg/protoutils"
 	"github.com/determined-ai/determined/proto/pkg/apiv1"
 )
@@ -50,7 +51,8 @@ func (db *PgDB) ExperimentLabelUsage() (labelUsage map[string]int, err error) {
 	return labelUsage, nil
 }
 
-func (db *PgDB) GetExperimentState(experimentID int) (state string, err error) {
+// GetExperimentState returns the current state of the experiment.
+func (db *PgDB) GetExperimentState(experimentID int) (state model.State, err error) {
 	err = db.sql.Get(&state, "SELECT state FROM experiments WHERE id=$1", experimentID)
 	return state, err
 }

--- a/master/internal/db/postgres_experiments.go
+++ b/master/internal/db/postgres_experiments.go
@@ -50,6 +50,11 @@ func (db *PgDB) ExperimentLabelUsage() (labelUsage map[string]int, err error) {
 	return labelUsage, nil
 }
 
+func (db *PgDB) GetExperimentState(experimentID int) (state string, err error) {
+	err = db.sql.Get(&state, "SELECT state FROM experiments WHERE id=$1", experimentID)
+	return state, err
+}
+
 // MetricNames returns the set of training and validation metric names that have been recorded for
 // an experiment.
 func (db *PgDB) MetricNames(experimentID int, sStartTime time.Time, vStartTime time.Time) (

--- a/proto/src/determined/api/v1/experiment.proto
+++ b/proto/src/determined/api/v1/experiment.proto
@@ -253,8 +253,13 @@ message CreateExperimentResponse {
 
 // Request for the set of metrics recorded by an experiment.
 message MetricNamesRequest {
+  option (grpc.gateway.protoc_gen_swagger.options.openapiv2_schema) = {
+    json_schema: { required: [ "experiment_id" ] }
+  };
   // The id of the experiment.
   int32 experiment_id = 1;
+  // Seconds to wait when polling for updates.
+  int32 period_seconds = 2;
 }
 
 // Response to MetricNamesRequest.
@@ -280,12 +285,17 @@ enum MetricType {
 // Request the milestones (in batches processed) at which a metric is recorded
 // by an experiment.
 message MetricBatchesRequest {
+  option (grpc.gateway.protoc_gen_swagger.options.openapiv2_schema) = {
+    json_schema: { required: [ "experiment_id", "metric_name", "metric_type" ] }
+  };
   // The id of the experiment.
   int32 experiment_id = 1;
   // A metric name.
   string metric_name = 2;
   // The type of metric.
   MetricType metric_type = 3;
+  // Seconds to wait when polling for updates.
+  int32 period_seconds = 4;
 }
 
 // Response to MetricBatchesRequest.
@@ -297,6 +307,9 @@ message MetricBatchesResponse {
 
 // Request metrics from all trials at a progress point of progress.
 message TrialsSnapshotRequest {
+  option (grpc.gateway.protoc_gen_swagger.options.openapiv2_schema) = {
+    json_schema: { required: [ "experiment_id", "batches_processed", "metric_name", "metric_type" ] }
+  };
   // The id of the experiment.
   int32 experiment_id = 1;
   // The point of progress at which to query metrics.
@@ -305,6 +318,8 @@ message TrialsSnapshotRequest {
   string metric_name = 3;
   // The type of metric.
   MetricType metric_type = 4;
+  // Seconds to wait when polling for updates.
+  int32 period_seconds = 5;
 }
 
 // Response to TrialSnapshotResponse
@@ -324,6 +339,9 @@ message TrialsSnapshotResponse {
 
 // Request a sample of metrics over time for a sample of trials.
 message TrialsSampleRequest {
+  option (grpc.gateway.protoc_gen_swagger.options.openapiv2_schema) = {
+    json_schema: { required: [ "experiment_id", "metric_name", "metric_type" ] }
+  };
   // The id of the experiment.
   int32 experiment_id = 1;
   // A metric name.
@@ -338,6 +356,8 @@ message TrialsSampleRequest {
   int32 start_batches = 6;
   // Ending of window (inclusive) to fetch data for.
   int32 end_batches = 7;
+  // Seconds to wait when polling for updates.
+  int32 period_seconds = 8;
 }
 
 // Response to TrialsSampleRequest

--- a/proto/src/determined/api/v1/experiment.proto
+++ b/proto/src/determined/api/v1/experiment.proto
@@ -253,11 +253,8 @@ message CreateExperimentResponse {
 
 // Request for the set of metrics recorded by an experiment.
 message MetricNamesRequest {
-  option (grpc.gateway.protoc_gen_swagger.options.openapiv2_schema) = {
-    json_schema: { required: [ "experiment_id" ] }
-  };
   // The id of the experiment.
-  int32 experiment_id = 1;
+  int32 experiment_id = 1 [(grpc.gateway.protoc_gen_swagger.options.openapiv2_field) = { required: ["experiment_id"]; }];
   // Seconds to wait when polling for updates.
   int32 period_seconds = 2;
 }
@@ -285,15 +282,12 @@ enum MetricType {
 // Request the milestones (in batches processed) at which a metric is recorded
 // by an experiment.
 message MetricBatchesRequest {
-  option (grpc.gateway.protoc_gen_swagger.options.openapiv2_schema) = {
-    json_schema: { required: [ "experiment_id", "metric_name", "metric_type" ] }
-  };
   // The id of the experiment.
-  int32 experiment_id = 1;
+  int32 experiment_id = 1 [(grpc.gateway.protoc_gen_swagger.options.openapiv2_field) = { required: ["experiment_id"]; }];
   // A metric name.
-  string metric_name = 2;
+  string metric_name = 2 [(grpc.gateway.protoc_gen_swagger.options.openapiv2_field) = { required: ["metric_name"]; }];
   // The type of metric.
-  MetricType metric_type = 3;
+  MetricType metric_type = 3 [(grpc.gateway.protoc_gen_swagger.options.openapiv2_field) = { required: ["metric_type"]; }];
   // Seconds to wait when polling for updates.
   int32 period_seconds = 4;
 }
@@ -307,17 +301,14 @@ message MetricBatchesResponse {
 
 // Request metrics from all trials at a progress point of progress.
 message TrialsSnapshotRequest {
-  option (grpc.gateway.protoc_gen_swagger.options.openapiv2_schema) = {
-    json_schema: { required: [ "experiment_id", "batches_processed", "metric_name", "metric_type" ] }
-  };
   // The id of the experiment.
-  int32 experiment_id = 1;
+  int32 experiment_id = 1 [(grpc.gateway.protoc_gen_swagger.options.openapiv2_field) = { required: ["experiment_id"]; }];
   // The point of progress at which to query metrics.
-  int32 batches_processed = 2;
+  int32 batches_processed = 2 [(grpc.gateway.protoc_gen_swagger.options.openapiv2_field) = { required: ["batches_processed"]; }];
   // A metric name.
-  string metric_name = 3;
+  string metric_name = 3 [(grpc.gateway.protoc_gen_swagger.options.openapiv2_field) = { required: ["metric_name"]; }];
   // The type of metric.
-  MetricType metric_type = 4;
+  MetricType metric_type = 4 [(grpc.gateway.protoc_gen_swagger.options.openapiv2_field) = { required: ["metric_type"]; }];
   // Seconds to wait when polling for updates.
   int32 period_seconds = 5;
 }
@@ -339,15 +330,12 @@ message TrialsSnapshotResponse {
 
 // Request a sample of metrics over time for a sample of trials.
 message TrialsSampleRequest {
-  option (grpc.gateway.protoc_gen_swagger.options.openapiv2_schema) = {
-    json_schema: { required: [ "experiment_id", "metric_name", "metric_type" ] }
-  };
   // The id of the experiment.
-  int32 experiment_id = 1;
+  int32 experiment_id = 1 [(grpc.gateway.protoc_gen_swagger.options.openapiv2_field) = { required: ["experiment_id"]; }];
   // A metric name.
-  string metric_name = 2;
+  string metric_name = 2 [(grpc.gateway.protoc_gen_swagger.options.openapiv2_field) = { required: ["metric_name"]; }];
   // The type of metric.
-  MetricType metric_type = 3;
+  MetricType metric_type = 3 [(grpc.gateway.protoc_gen_swagger.options.openapiv2_field) = { required: ["metric_type"]; }];
   // Maximum number of trials to fetch data for.
   int32 max_trials = 4;
   // Maximum number of initial / historical data points.


### PR DESCRIPTION
## Description

Implementing a bunch of feedback that I got shortly after committing these calls. I'm wondering if our CI is going to flag this as incompatible, but anything disallowed by these changes was simply broken / wouldn't work / nonsensical before anyway. Furthermore, we tagged this API as "Internal" prior to release because a bigger change than this was being discussed (which we have decided against doing). These APIs are being implemented for a very specify use case, and as that use case progresses we might decide on other changes being necessary. The changes now are:

* Required parameters are now documented in the JSON schema
* Correct HTTP status code (400) are now returned for invalid input
* Correct HTTP status code (404) are now return for a non-existent experiment code
* The polling period is now an optional parameter in the query
* More efficient and comprehensive checking for experiment completion while polling

## Test Plan

Re-ran the integration tests, which should avoid an extra ~30 seconds of waiting on each request now! Also did some manual testing of negative cases checking HTTP codes, and various other sanity things.