### PR TITLE
fix: allow dots in map config keys [DET-4542]

### DIFF
--- a/docs/release-notes/1665-fix-dots-in-config.txt
+++ b/docs/release-notes/1665-fix-dots-in-config.txt
@@ -1,0 +1,7 @@
+:orphan:
+
+**Fixes**
+
+-  Allow configurations with ``.`` in the keys for fields that are maps
+   in the master.yaml (e.g.
+   ``task_container_defaults.cpu_pod_spec.metadata.labels``).

--- a/master/cmd/determined-master/root.go
+++ b/master/cmd/determined-master/root.go
@@ -11,7 +11,6 @@ import (
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 
 	"github.com/determined-ai/determined/master/internal"
 	"github.com/determined-ai/determined/master/pkg/check"
@@ -58,7 +57,7 @@ func runRoot() error {
 // global logging state based on those options.
 func initializeConfig() (*internal.Config, error) {
 	// Fetch an initial config to get the config file path and read its settings into Viper.
-	initialConfig, err := getConfig(viper.AllSettings())
+	initialConfig, err := getConfig(v.AllSettings())
 	if err != nil {
 		return nil, err
 	}
@@ -73,7 +72,7 @@ func initializeConfig() (*internal.Config, error) {
 
 	// Now call viper.AllSettings() again to get the full config, containing all values from CLI flags,
 	// environment variables, and the configuration file.
-	config, err := getConfig(viper.AllSettings())
+	config, err := getConfig(v.AllSettings())
 	if err != nil {
 		return nil, err
 	}
@@ -111,7 +110,7 @@ func mergeConfigBytesIntoViper(bs []byte) error {
 	if err := yaml.Unmarshal(bs, &configMap); err != nil {
 		return errors.Wrap(err, "error unmarshal yaml configuration file")
 	}
-	if err := viper.MergeConfigMap(configMap); err != nil {
+	if err := v.MergeConfigMap(configMap); err != nil {
 		return errors.Wrap(err, "error merge configuration to viper")
 	}
 	return nil


### PR DESCRIPTION
## Description
This change allow keys in map sections of the `master.yaml` to be specified with a `.` in them. This was previously not possible because, while we marshal the configuration successfully into a `map[string]interface{}`, when we merge this configuration into viper, viper loses its ability to disambiguate keys with `.`'s and nested objects because it uses `.` as the object delimiter by default (explained in more detail in comment in code).
<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan
- [x] add a test case for failing code
- [x] run a cluster with the configuration that was previously unhandled
<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)
Feels a bit a hack to make the problem just happen less, but `..` should be a much less common occurrence and the only real alternative is to pin to the viper commit where they let you ignore key delimiters in some cases but it ended up being a breaking change in viper, was reverted in favor of setting the key delimiter and that feels more a hack/risky.
<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234