### PR TITLE
fix: limit concurrent restores to avoid resource exhaustion [DET-4556]

### DIFF
--- a/docs/release-notes/1666-fix-db-pool-deadlock.txt
+++ b/docs/release-notes/1666-fix-db-pool-deadlock.txt
@@ -1,0 +1,7 @@
+:orphan:
+
+**Fixes**
+
+-  Fix a bug where restoring a large number of experiments after a
+   failure would lead to deadlock from contention on the database
+   connection pool.


### PR DESCRIPTION
## Description
Limit the number of concurrent restores at any time within the system to maxConcurrentRestores.
This avoids an issue where the connection pool can be exhausted and the system deadlock. For
example if there are N connections in the pool and N experiments restoring, since a connection
is pinned per restore streaming events, if during any restore blocks for a connection before
completing, we are deadlocked.
<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan
- [x] make sure experiments restore at most 10 at a time
<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)
There may be a better solution but this is pretty simple at least.
<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234