### PR TITLE
docs: add topic guide for resource pools [DET-4348]

### DIFF
--- a/docs/topic-guides/index.txt
+++ b/docs/topic-guides/index.txt
@@ -10,6 +10,7 @@ explanation. Below you will find some suggested starting guides.
 
 -  :ref:`det-system-architecture`
 -  :ref:`terminology-concepts`
+-  :ref:`resource-pool`
 -  :ref:`scheduling`
 -  :ref:`elastic-infrastructure`
 

--- a/docs/topic-guides/system-concepts/resource-pool.txt
+++ b/docs/topic-guides/system-concepts/resource-pool.txt
@@ -1,0 +1,25 @@
+.. _resource-pool:
+
+###############
+ Resource Pool
+###############
+
+Large-scale deep learning requires using different resources, including
+computation resources, memory, network, and storage. Typically, we start
+off prototyping our models with immediately available instance types
+with few accelerators. Once our models are mature enough, we want to
+scale up the training speed with larger instance types that have more
+powerful accelerators and high-performing processors and more instances.
+We also want to use instance types without expensive accelerators to run
+TensorBoard or any bash commands to avoid wasting accelerators.
+
+Determined provides the abstraction of physical resources for users to
+choose on their tasks. We call this abstraction *resource pools*. We can
+get the most value of our money by choosing different resource pools for
+different goals.
+
+Each resource pool is intended to map resources that are physically
+close to each other. Each resource pool can be set to use one cloud
+provider and one instance type and limited to have one region on AWS or
+zone on GCP. Each resource pool handles scheduling and scaling
+independently.


### PR DESCRIPTION
## Description

Add a topic guide for resource pools.

## Test Plan

N/A

## Commentary (optional)

N/A

## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
