### PR TITLE
fix: flush searcher events more often [DET-4644]

### DIFF
--- a/master/internal/experiment.go
+++ b/master/internal/experiment.go
@@ -75,7 +75,7 @@ const (
 	// writing to the database.  In reality, it is much more likely flushing the buffer happens
 	// due to the contents of the SearcherEvents than the number of them; see the comment in
 	// convertSearcherEvent()
-	searcherEventBuffer = 1000
+	searcherEventBuffer = 20
 )
 
 type experiment struct {


### PR DESCRIPTION
## Description
This change shrinks the searcher event buffer so that in the event of infrequent checkpoints and validations we don't end up with a large buffer (previously up to 1k entries) of large events sitting in memory for a long time.
<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->

## Test Plan
- [x] run the code, see in certain cases memory usage is much lower.
<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)
In high scale situations, chances are steps are _very_ long and the metrics in them are also large. Because of this, it may be more performant to just flush events immediately instead of holding them in memory at all. I'm open to that.
<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234