### PR TITLE
fix: template merging for bind mounts [DET-4630]

### DIFF
--- a/docs/release-notes/1678-fix-tpl.txt
+++ b/docs/release-notes/1678-fix-tpl.txt
@@ -1,0 +1,6 @@
+:orphan:
+
+**Fixes**
+
+-  Fix merging templates with user-specified configuration for bind
+   mounts.

--- a/master/pkg/model/command_config.go
+++ b/master/pkg/model/command_config.go
@@ -7,12 +7,12 @@ import (
 // CommandConfig holds the necessary configurations to launch a command task in
 // the cluster.
 type CommandConfig struct {
-	Description     string          `json:"description"`
-	BindMounts      []BindMount     `json:"bind_mounts"`
-	Environment     Environment     `json:"environment"`
-	Resources       ResourcesConfig `json:"resources"`
-	Entrypoint      []string        `json:"entrypoint"`
-	TensorBoardArgs []string        `json:"tensorboard_args"`
+	Description     string           `json:"description"`
+	BindMounts      BindMountsConfig `json:"bind_mounts"`
+	Environment     Environment      `json:"environment"`
+	Resources       ResourcesConfig  `json:"resources"`
+	Entrypoint      []string         `json:"entrypoint"`
+	TensorBoardArgs []string         `json:"tensorboard_args"`
 }
 
 // Validate implements the check.Validatable interface.

--- a/master/pkg/model/experiment_config.go
+++ b/master/pkg/model/experiment_config.go
@@ -35,7 +35,7 @@ type ExperimentConfig struct {
 	Optimizations            OptimizationsConfig       `json:"optimizations"`
 	RecordsPerEpoch          int                       `json:"records_per_epoch"`
 	SchedulingUnit           int                       `json:"scheduling_unit"`
-	BindMounts               []BindMount               `json:"bind_mounts,omitempty"`
+	BindMounts               BindMountsConfig          `json:"bind_mounts,omitempty"`
 	Environment              Environment               `json:"environment"`
 	Reproducibility          ReproducibilityConfig     `json:"reproducibility"`
 	MaxRestarts              int                       `json:"max_restarts"`
@@ -248,6 +248,19 @@ func (r OptimizationsConfig) Validate() []error {
 		check.GreaterThanOrEqualTo(r.TensorFusionThreshold, 0, "tensor_fusion_threshold must be >= 0"),
 		check.GreaterThanOrEqualTo(r.TensorFusionCycleTime, 0, "tensor_fusion_cycle_time must be >= 0"),
 	}
+}
+
+// BindMountsConfig is the configuration for bind mounts.
+type BindMountsConfig []BindMount
+
+// UnmarshalJSON implements the json.Unmarshaler interface.
+func (b *BindMountsConfig) UnmarshalJSON(data []byte) error {
+	unmarshaled := make([]BindMount, 0)
+	if err := json.Unmarshal(data, &unmarshaled); err != nil {
+		return errors.Wrapf(err, "failed to parse bind mounts")
+	}
+	*b = append(*b, unmarshaled...)
+	return nil
 }
 
 // BindMount configures trial runner filesystem bind mounts.

--- a/master/pkg/model/experiment_config.go
+++ b/master/pkg/model/experiment_config.go
@@ -257,7 +257,7 @@ type BindMountsConfig []BindMount
 func (b *BindMountsConfig) UnmarshalJSON(data []byte) error {
 	unmarshaled := make([]BindMount, 0)
 	if err := json.Unmarshal(data, &unmarshaled); err != nil {
-		return errors.Wrapf(err, "failed to parse bind mounts")
+		return errors.Wrap(err, "failed to parse bind mounts")
 	}
 	*b = append(*b, unmarshaled...)
 	return nil


### PR DESCRIPTION
## Description

Fix merging template for bind mounts.

## Test Plan

Manually tested it.

## Commentary (optional)

N/A

## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
