### PR TITLE
chore: fix mismatched required api attribute names [DET-4648]

### DIFF
--- a/proto/scripts/swagger.py
+++ b/proto/scripts/swagger.py
@@ -31,6 +31,10 @@ def capitalize(s: str) -> str:
         return s.title()
     return s[0].upper() + s[1:]
 
+def to_lower_camel_case(snake_str):
+    components = snake_str.split('_')
+    return components[0] + ''.join(x.title() for x in components[1:])
+
 
 def clean(path: str, patch: str) -> None:
     with open(path, "r") as f:
@@ -46,6 +50,9 @@ def clean(path: str, patch: str) -> None:
         # Clean up titles.
         if "title" not in value:
             value["title"] = "".join(capitalize(k) for k in key.split(sep="v1"))
+
+        if "required" in value:
+            value["required"] = [to_lower_camel_case(attr) for attr in value["required"]]
 
     with open(patch, "r") as f:
         merge_dict(spec, json.load(f))


### PR DESCRIPTION
## Description

<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan

before after diff on swagger.json

```
3639,3640c3639,3640
<         "experiment_id",
<         "start_time",
---
>         "experimentId",
>         "startTime",
3643c3643
<         "total_batches_processed"
---
>         "totalBatchesProcessed"
3801,3804c3801,3804
<         "start_time",
<         "experiment_id",
<         "trial_id",
<         "batch_number"
---
>         "startTime",
>         "experimentId",
>         "trialId",
>         "batchNumber"
3850c3850
<         "start_time",
---
>         "startTime",
4100,4101c4100,4101
<         "start_time",
<         "end_time",
---
>         "startTime",
>         "endTime",
4104c4104
<         "num_trials",
---
>         "numTrials",
4459,4461c4459,4461
<         "master_id",
<         "cluster_id",
<         "cluster_name"
---
>         "masterId",
>         "clusterId",
>         "clusterName"
5236c5236
<         "start_time",
---
>         "startTime",
5272,5273c5272,5273
<         "creation_time",
<         "last_updated_time"
---
>         "creationTime",
>         "lastUpdatedTime"
5966,5968c5966,5968
<         "trial_id",
<         "end_time",
<         "searcher_metric"
---
>         "trialId",
>         "endTime",
>         "searcherMetric"

```

<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

I haven't been able to find an option from `grpc.gateway.protoc_gen_swagger` that configures this behavior so for now I have our post hook update it..

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234