### PR TITLE
fix: accept None-type hyperparameters with --local

### DIFF
--- a/common/determined_common/api/experiment.py
+++ b/common/determined_common/api/experiment.py
@@ -246,7 +246,7 @@ def generate_random_hparam_values(hparam_def: Dict[str, Any]) -> Dict[str, Any]:
                 return math.pow(hparam["base"], random.uniform(hparam["minval"], hparam["maxval"]))
             else:
                 raise Exception("Wrong type of hyperparameter: {}".format(hparam["type"]))
-        elif isinstance(hparam, (int, float, str)):
+        elif isinstance(hparam, (int, float, str, type(None))):
             return hparam
         else:
             raise Exception("Wrong type of hyperparameter: {}".format(type(hparam)))


### PR DESCRIPTION
I hit this trying to use `--local --test` on a model that @katport wrote.