### PR TITLE
chore: Endpoint and infrastructure for hyperparameter importance computation [DET-4464]

### DIFF
--- a/e2e_tests/tests/experiment/test_metrics.py
+++ b/e2e_tests/tests/experiment/test_metrics.py
@@ -35,7 +35,7 @@ def test_streaming_metrics_api() -> None:
     valid_trials_snapshot_thread = pool.apply_async(request_valid_trials_snapshot, (experiment_id,))
     train_trials_sample_thread = pool.apply_async(request_train_trials_sample, (experiment_id,))
     valid_trials_sample_thread = pool.apply_async(request_valid_trials_sample, (experiment_id,))
-    #hp_importance_thread = pool.apply_async(request_hp_importance, (experiment_id,))
+    # hp_importance_thread = pool.apply_async(request_hp_importance, (experiment_id,))
 
     metric_names_results = metric_names_thread.get()
     train_metric_batches_results = train_metric_batches_thread.get()
@@ -44,7 +44,7 @@ def test_streaming_metrics_api() -> None:
     valid_trials_snapshot_results = valid_trials_snapshot_thread.get()
     train_trials_sample_results = train_trials_sample_thread.get()
     valid_trials_sample_results = valid_trials_sample_thread.get()
-    #hp_importance_results = hp_importance_thread.get()
+    # hp_importance_results = hp_importance_thread.get()
 
     if metric_names_results is not None:
         pytest.fail("metric-names: %s. Results: %s" % metric_names_results)
@@ -60,7 +60,7 @@ def test_streaming_metrics_api() -> None:
         pytest.fail("trials-sample (training): %s. Results: %s" % train_trials_sample_results)
     if valid_trials_sample_results is not None:
         pytest.fail("trials-sample (validation): %s. Results: %s" % valid_trials_sample_results)
-    #if hp_importance_results is not None:
+    # if hp_importance_results is not None:
     #    pytest.fail("hyperparameter-importance: %s. Results: %s" % hp_importance_results)
 
 

--- a/e2e_tests/tests/experiment/test_metrics.py
+++ b/e2e_tests/tests/experiment/test_metrics.py
@@ -315,8 +315,8 @@ def request_hp_importance(experiment_id):  # type: ignore
                 return ("Unexpected importance for hparam %s" % hparam, lastResult)
         if not metric["experimentProgress"] == 1:
             return ("HP importance from unfinished experiment included!", lastResult)
-        if not metric["status"] == "complete":
-            return ("Unexpected non-complete status in HP importance", lastResult)
+        if metric["pending"] or metric["inProgress"]:
+            return ("Unexpected incomplete status in HP importance", lastResult)
         if not metric["error"] == "":
             return ("Unexpected error in HP importance", lastResult)
     return None

--- a/e2e_tests/tests/experiment/test_metrics.py
+++ b/e2e_tests/tests/experiment/test_metrics.py
@@ -15,7 +15,7 @@ from tests import experiment as exp
 def test_streaming_metrics_api() -> None:
     auth.initialize_session(conf.make_master_url(), try_reauth=True)
 
-    pool = mp.pool.ThreadPool(processes=7)
+    pool = mp.pool.ThreadPool(processes=8)
 
     experiment_id = exp.create_experiment(
         conf.fixtures_path("mnist_pytorch/adaptive_short.yaml"),
@@ -32,6 +32,7 @@ def test_streaming_metrics_api() -> None:
     valid_trials_snapshot_thread = pool.apply_async(request_valid_trials_snapshot, (experiment_id,))
     train_trials_sample_thread = pool.apply_async(request_train_trials_sample, (experiment_id,))
     valid_trials_sample_thread = pool.apply_async(request_valid_trials_sample, (experiment_id,))
+    hp_importance_thread = pool.apply_async(request_hp_importance, (experiment_id,))
 
     metric_names_results = metric_names_thread.get()
     train_metric_batches_results = train_metric_batches_thread.get()
@@ -40,6 +41,7 @@ def test_streaming_metrics_api() -> None:
     valid_trials_snapshot_results = valid_trials_snapshot_thread.get()
     train_trials_sample_results = train_trials_sample_thread.get()
     valid_trials_sample_results = valid_trials_sample_thread.get()
+    hp_importance_results = hp_importance_thread.get()
 
     if metric_names_results is not None:
         pytest.fail("metric-names: %s. Results: %s" % metric_names_results)
@@ -55,6 +57,8 @@ def test_streaming_metrics_api() -> None:
         pytest.fail("trials-sample (training): %s. Results: %s" % train_trials_sample_results)
     if valid_trials_sample_results is not None:
         pytest.fail("trials-sample (validation): %s. Results: %s" % valid_trials_sample_results)
+    if hp_importance_results is not None:
+        pytest.fail("hyperparameter-importance: %s. Results: %s" % hp_importance_results)
 
 
 def request_metric_names(experiment_id):  # type: ignore
@@ -278,3 +282,41 @@ def request_valid_trials_sample(experiment_id):  # type: ignore
     )
     results = [message["result"] for message in map(json.loads, response.text.splitlines())]
     return check_trials_sample_result(results)
+
+
+def request_hp_importance(experiment_id):  # type: ignore
+    response = api.get(
+        conf.make_master_url(),
+        "api/v1/experiments/{}/hyperparameter-importance".format(experiment_id),
+        params={"period_seconds": 1},
+    )
+    results = [message["result"] for message in map(json.loads, response.text.splitlines())]
+
+    lastResult = results[-1]
+    if len(lastResult["trainingMetrics"]) != 1 or len(lastResult["validationMetrics"]) != 1:
+        return ("Unexpected number of metrics", lastResult)
+
+    def valid_importance(x: float) -> bool:
+        return x >= 0 and x <= 1
+
+    loss = lastResult["trainingMetrics"]["loss"]
+    searcherMetric = lastResult["validationMetrics"]["validation_loss"]
+
+    for metric in [loss, searcherMetric]:
+        for hparam in [
+            "dropout1",
+            "dropout2",
+            "global_batch_size",
+            "learning_rate",
+            "n_filters1",
+            "n_filters2",
+        ]:
+            if not valid_importance(loss["hpImportance"][hparam]):
+                return ("Unexpected importance for hparam %s" % hparam, lastResult)
+        if not metric["experimentProgress"] == 1:
+            return ("HP importance from unfinished experiment included!", lastResult)
+        if not metric["status"] == "complete":
+            return ("Unexpected non-complete status in HP importance", lastResult)
+        if not metric["error"] == "":
+            return ("Unexpected error in HP importance", lastResult)
+    return None

--- a/e2e_tests/tests/experiment/test_metrics.py
+++ b/e2e_tests/tests/experiment/test_metrics.py
@@ -25,6 +25,9 @@ def test_streaming_metrics_api() -> None:
     # experiment, and then stay open until the experiment is complete. To accomplish this with all
     # of the API calls on a single experiment, we spawn them all in threads.
 
+    # The HP importance portion of this test is commented out until the feature is enabled by
+    # default
+
     metric_names_thread = pool.apply_async(request_metric_names, (experiment_id,))
     train_metric_batches_thread = pool.apply_async(request_train_metric_batches, (experiment_id,))
     valid_metric_batches_thread = pool.apply_async(request_valid_metric_batches, (experiment_id,))
@@ -32,7 +35,7 @@ def test_streaming_metrics_api() -> None:
     valid_trials_snapshot_thread = pool.apply_async(request_valid_trials_snapshot, (experiment_id,))
     train_trials_sample_thread = pool.apply_async(request_train_trials_sample, (experiment_id,))
     valid_trials_sample_thread = pool.apply_async(request_valid_trials_sample, (experiment_id,))
-    hp_importance_thread = pool.apply_async(request_hp_importance, (experiment_id,))
+    #hp_importance_thread = pool.apply_async(request_hp_importance, (experiment_id,))
 
     metric_names_results = metric_names_thread.get()
     train_metric_batches_results = train_metric_batches_thread.get()
@@ -41,7 +44,7 @@ def test_streaming_metrics_api() -> None:
     valid_trials_snapshot_results = valid_trials_snapshot_thread.get()
     train_trials_sample_results = train_trials_sample_thread.get()
     valid_trials_sample_results = valid_trials_sample_thread.get()
-    hp_importance_results = hp_importance_thread.get()
+    #hp_importance_results = hp_importance_thread.get()
 
     if metric_names_results is not None:
         pytest.fail("metric-names: %s. Results: %s" % metric_names_results)
@@ -57,8 +60,8 @@ def test_streaming_metrics_api() -> None:
         pytest.fail("trials-sample (training): %s. Results: %s" % train_trials_sample_results)
     if valid_trials_sample_results is not None:
         pytest.fail("trials-sample (validation): %s. Results: %s" % valid_trials_sample_results)
-    if hp_importance_results is not None:
-        pytest.fail("hyperparameter-importance: %s. Results: %s" % hp_importance_results)
+    #if hp_importance_results is not None:
+    #    pytest.fail("hyperparameter-importance: %s. Results: %s" % hp_importance_results)
 
 
 def request_metric_names(experiment_id):  # type: ignore

--- a/master/internal/api_experiment.go
+++ b/master/internal/api_experiment.go
@@ -944,7 +944,8 @@ func (a *apiServer) TrialsSample(req *apiv1.TrialsSampleRequest,
 	}
 }
 
-func (a *apiServer) ComputeHPImportance(ctx context.Context, req *apiv1.ComputeHPImportanceRequest) (*apiv1.ComputeHPImportanceResponse, error) {
+func (a *apiServer) ComputeHPImportance(ctx context.Context,
+	req *apiv1.ComputeHPImportanceRequest) (*apiv1.ComputeHPImportanceResponse, error) {
 	experimentID := int(req.ExperimentId)
 	if err := a.checkExperimentExists(experimentID); err != nil {
 		return nil, err

--- a/master/internal/api_experiment.go
+++ b/master/internal/api_experiment.go
@@ -976,6 +976,17 @@ func (a *apiServer) ComputeHPImportance(ctx context.Context,
 	return &resp, nil
 }
 
+// Translates MetricHPImportance to the protobuf form
+func protoMetricHPI(metricHpi model.MetricHPImportance) *apiv1.GetHPImportanceResponse_MetricHPImportance {
+	return &apiv1.GetHPImportanceResponse_MetricHPImportance{
+		Error:              metricHpi.Error,
+		Pending:            metricHpi.Pending,
+		InProgress:         metricHpi.InProgress,
+		ExperimentProgress: metricHpi.ExperimentProgress,
+		HpImportance:       metricHpi.HpImportance,
+	}
+}
+
 func (a *apiServer) GetHPImportance(req *apiv1.GetHPImportanceRequest,
 	resp apiv1.Determined_GetHPImportanceServer) error {
 	experimentID := int(req.ExperimentId)
@@ -998,22 +1009,10 @@ func (a *apiServer) GetHPImportance(req *apiv1.GetHPImportanceRequest,
 		response.TrainingMetrics = make(map[string]*apiv1.GetHPImportanceResponse_MetricHPImportance)
 		response.ValidationMetrics = make(map[string]*apiv1.GetHPImportanceResponse_MetricHPImportance)
 		for metric, metricHpi := range result.TrainingMetrics {
-			response.TrainingMetrics[metric] = &apiv1.GetHPImportanceResponse_MetricHPImportance{
-				Error:              metricHpi.Error,
-				Pending:            metricHpi.Pending,
-				InProgress:         metricHpi.InProgress,
-				ExperimentProgress: metricHpi.ExperimentProgress,
-				HpImportance:       metricHpi.HpImportance,
-			}
+			response.TrainingMetrics[metric] = protoMetricHPI(metricHpi)
 		}
 		for metric, metricHpi := range result.ValidationMetrics {
-			response.ValidationMetrics[metric] = &apiv1.GetHPImportanceResponse_MetricHPImportance{
-				Error:              metricHpi.Error,
-				Pending:            metricHpi.Pending,
-				InProgress:         metricHpi.InProgress,
-				ExperimentProgress: metricHpi.ExperimentProgress,
-				HpImportance:       metricHpi.HpImportance,
-			}
+			response.ValidationMetrics[metric] = protoMetricHPI(metricHpi)
 		}
 
 		if err := resp.Send(&response); err != nil {

--- a/master/internal/api_experiment.go
+++ b/master/internal/api_experiment.go
@@ -977,7 +977,8 @@ func (a *apiServer) ComputeHPImportance(ctx context.Context,
 }
 
 // Translates MetricHPImportance to the protobuf form
-func protoMetricHPI(metricHpi model.MetricHPImportance) *apiv1.GetHPImportanceResponse_MetricHPImportance {
+func protoMetricHPI(metricHpi model.MetricHPImportance,
+) *apiv1.GetHPImportanceResponse_MetricHPImportance {
 	return &apiv1.GetHPImportanceResponse_MetricHPImportance{
 		Error:              metricHpi.Error,
 		Pending:            metricHpi.Pending,

--- a/master/internal/config.go
+++ b/master/internal/config.go
@@ -10,6 +10,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/determined-ai/determined/master/internal/db"
+	"github.com/determined-ai/determined/master/internal/hpimportance"
 	"github.com/determined-ai/determined/master/internal/provisioner"
 	"github.com/determined-ai/determined/master/internal/resourcemanagers"
 	"github.com/determined-ai/determined/master/pkg/check"
@@ -63,6 +64,10 @@ func DefaultConfig() *Config {
 		Logging: model.LoggingConfig{
 			DefaultLoggingConfig: &model.DefaultLoggingConfig{},
 		},
+		HPImportance: hpimportance.HPImportanceConfig{
+			WorkersLimit: 4,
+			QueueLimit:   64,
+		},
 	}
 }
 
@@ -85,6 +90,7 @@ type Config struct {
 	EnableCors            bool                              `json:"enable_cors"`
 	ClusterName           string                            `json:"cluster_name"`
 	Logging               model.LoggingConfig               `json:"logging"`
+	HPImportance          hpimportance.HPImportanceConfig   `json:"hyperparameter_importance"`
 
 	Scheduler   *resourcemanagers.Config `json:"scheduler"`
 	Provisioner *provisioner.Config      `json:"provisioner"`

--- a/master/internal/config.go
+++ b/master/internal/config.go
@@ -65,8 +65,8 @@ func DefaultConfig() *Config {
 			DefaultLoggingConfig: &model.DefaultLoggingConfig{},
 		},
 		HPImportance: hpimportance.HPImportanceConfig{
-			WorkersLimit: 4,
-			QueueLimit:   64,
+			WorkersLimit: 0,
+			QueueLimit:   1,
 		},
 	}
 }

--- a/master/internal/core.go
+++ b/master/internal/core.go
@@ -71,7 +71,7 @@ type Master struct {
 	proxy           *actor.Ref
 	trialLogger     *actor.Ref
 	trialLogBackend TrialLogBackend
-	hpImportance  *actor.Ref
+	hpImportance    *actor.Ref
 }
 
 // New creates an instance of the Determined master.

--- a/master/internal/core.go
+++ b/master/internal/core.go
@@ -32,6 +32,7 @@ import (
 	detContext "github.com/determined-ai/determined/master/internal/context"
 	"github.com/determined-ai/determined/master/internal/db"
 	"github.com/determined-ai/determined/master/internal/grpc"
+	"github.com/determined-ai/determined/master/internal/hpimportance"
 	"github.com/determined-ai/determined/master/internal/proxy"
 	"github.com/determined-ai/determined/master/internal/resourcemanagers"
 	"github.com/determined-ai/determined/master/internal/telemetry"
@@ -70,6 +71,7 @@ type Master struct {
 	proxy           *actor.Ref
 	trialLogger     *actor.Ref
 	trialLogBackend TrialLogBackend
+	hpImportance  *actor.Ref
 }
 
 // New creates an instance of the Determined master.
@@ -601,6 +603,9 @@ func (m *Master) Run(ctx context.Context) error {
 	} else {
 		log.Info("telemetry reporting is disabled")
 	}
+
+	hpi := hpimportance.NewManager(m.db)
+	m.hpImportance, _ = m.system.ActorOf(actor.Addr(hpimportance.RootAddr), hpi)
 
 	return m.startServers(ctx, cert)
 }

--- a/master/internal/core.go
+++ b/master/internal/core.go
@@ -604,7 +604,7 @@ func (m *Master) Run(ctx context.Context) error {
 		log.Info("telemetry reporting is disabled")
 	}
 
-	hpi := hpimportance.NewManager(m.db, m.system)
+	hpi := hpimportance.NewManager(m.db, m.system, m.config.HPImportance)
 	m.hpImportance, _ = m.system.ActorOf(actor.Addr(hpimportance.RootAddr), hpi)
 
 	return m.startServers(ctx, cert)

--- a/master/internal/core.go
+++ b/master/internal/core.go
@@ -604,7 +604,7 @@ func (m *Master) Run(ctx context.Context) error {
 		log.Info("telemetry reporting is disabled")
 	}
 
-	hpi := hpimportance.NewManager(m.db)
+	hpi := hpimportance.NewManager(m.db, m.system)
 	m.hpImportance, _ = m.system.ActorOf(actor.Addr(hpimportance.RootAddr), hpi)
 
 	return m.startServers(ctx, cert)

--- a/master/internal/db/postgres_experiments.go
+++ b/master/internal/db/postgres_experiments.go
@@ -414,12 +414,7 @@ func unmarshalHPImportanceHParams(r hpImportanceDataWrapper) (model.HPImportance
 		Batches: r.Batches,
 		Metric:  r.Metric,
 	}
-
-	err := json.Unmarshal(r.Hparams, &entry.Hparams)
-	if err != nil {
-		return entry, err
-	}
-	return entry, nil
+	return entry, json.Unmarshal(r.Hparams, &entry.Hparams)
 }
 
 // FetchHPImportanceTrainingData retrieves all the data needed by the hyperparameter importance

--- a/master/internal/db/postgres_experiments.go
+++ b/master/internal/db/postgres_experiments.go
@@ -408,25 +408,25 @@ type hpImportanceDataWrapper struct {
 	Metric  float64 `db:"metric"`
 }
 
-func unmarshalHPImportanceHParams(r hpImportanceDataWrapper) (*model.HPImportanceTrialData, error) {
+func unmarshalHPImportanceHParams(r hpImportanceDataWrapper) (model.HPImportanceTrialData, error) {
 	entry := model.HPImportanceTrialData{
 		TrialID: r.TrialID,
 		Batches: r.Batches,
 		Metric:  r.Metric,
 	}
 
-	err := json.Unmarshal(r.Hparams, &entry.Hparams) // FIXME this seems backwards?
+	err := json.Unmarshal(r.Hparams, &entry.Hparams)
 	if err != nil {
-		return nil, err
+		return entry, err
 	}
-	return &entry, nil
+	return entry, nil
 }
 
 // FetchHPImportanceTrainingData retrieves all the data needed by the hyperparameter importance
 // algorithm to measure the relative importance of various hyperparameters for one specific training
 // metric across all the trials in an experiment.
 func (db *PgDB) FetchHPImportanceTrainingData(experimentID int, metric string) (
-	*[]model.HPImportanceTrialData, error) {
+	[]model.HPImportanceTrialData, error) {
 	var rows []hpImportanceDataWrapper
 	var results []model.HPImportanceTrialData
 	// TODO: aren't we ignoring overtraining by taking the last?
@@ -458,18 +458,18 @@ FROM trials t
 		result, err := unmarshalHPImportanceHParams(row)
 		if err != nil {
 			return nil, errors.Wrap(err,
-				"Failed to process training metrics for hyperparameter importance")
+				"failed to process training metrics for hyperparameter importance")
 		}
-		results = append(results, *result)
+		results = append(results, result)
 	}
-	return &results, nil
+	return results, nil
 }
 
 // FetchHPImportanceValidationData retrieves all the data needed by the hyperparameter importance
 // algorithm to measure the relative importance of various hyperparameters for one specific
 // validation metric across all the trials in an experiment.
 func (db *PgDB) FetchHPImportanceValidationData(experimentID int, metric string) (
-	*[]model.HPImportanceTrialData, error) {
+	[]model.HPImportanceTrialData, error) {
 	var rows []hpImportanceDataWrapper
 	var results []model.HPImportanceTrialData
 	err := db.queryRows(`
@@ -505,9 +505,9 @@ FROM trials t
 			return nil, errors.Wrap(err,
 				"Failed to process validation metrics for hyperparameter importance")
 		}
-		results = append(results, *result)
+		results = append(results, result)
 	}
-	return &results, nil
+	return results, nil
 }
 
 // GetHPImportance returns the hyperparameter importance data and status for an experiment.

--- a/master/internal/experiment.go
+++ b/master/internal/experiment.go
@@ -457,7 +457,6 @@ func (e *experiment) Receive(ctx *actor.Context) error {
 	case *apiv1.PauseExperimentRequest:
 		switch ok := e.updateState(ctx, model.PausedState); ok {
 		case true:
-			ctx.Tell(e.hpImportance, hpimportance.ExperimentPaused{ID: e.ID})
 			ctx.Respond(&apiv1.PauseExperimentResponse{})
 		default:
 			ctx.Respond(status.Errorf(codes.FailedPrecondition,

--- a/master/internal/experiment.go
+++ b/master/internal/experiment.go
@@ -10,6 +10,7 @@ import (
 	"google.golang.org/grpc/status"
 
 	"github.com/determined-ai/determined/master/internal/db"
+	"github.com/determined-ai/determined/master/internal/hpimportance"
 	"github.com/determined-ai/determined/master/internal/sproto"
 	"github.com/determined-ai/determined/master/internal/telemetry"
 	"github.com/determined-ai/determined/master/pkg/actor"
@@ -83,6 +84,7 @@ type experiment struct {
 	modelDefinition     archive.Archive
 	rm                  *actor.Ref
 	trialLogger         *actor.Ref
+	hpImportance        *actor.Ref
 	db                  *db.PgDB
 	searcher            *searcher.Searcher
 	warmStartCheckpoint *model.Checkpoint
@@ -141,6 +143,7 @@ func newExperiment(master *Master, expModel *model.Experiment) (*experiment, err
 		modelDefinition:     modelDefinition,
 		rm:                  master.rm,
 		trialLogger:         master.trialLogger,
+		hpImportance:        master.hpImportance,
 		db:                  master.db,
 		searcher:            search,
 		warmStartCheckpoint: checkpoint,
@@ -310,6 +313,7 @@ func (e *experiment) Receive(ctx *actor.Context) error {
 		})
 		ops, err := e.searcher.InitialOperations()
 		e.processOperations(ctx, ops, err)
+		ctx.Tell(e.hpImportance, hpimportance.ExperimentCreated{ID: e.ID})
 	case trialCreated:
 		ops, err := e.searcher.TrialCreated(msg.create, msg.trialID)
 		e.processOperations(ctx, ops, err)
@@ -328,6 +332,7 @@ func (e *experiment) Receive(ctx *actor.Context) error {
 		if err := e.db.SaveExperimentProgress(e.ID, &progress); err != nil {
 			ctx.Log().WithError(err).Error("failed to save experiment progress")
 		}
+		ctx.Tell(e.hpImportance, hpimportance.ExperimentProgress{ID: e.ID, Progress: progress})
 	case trialExitedEarly:
 		ops, err := e.searcher.TrialExitedEarly(msg.trialID, msg.exitedReason)
 		e.processOperations(ctx, ops, err)
@@ -428,6 +433,8 @@ func (e *experiment) Receive(ctx *actor.Context) error {
 			experiment:     e.Experiment,
 		})
 
+		ctx.Tell(e.hpImportance, hpimportance.ExperimentCompleted{ID: e.ID})
+
 		// Discard searcher events for all terminal experiments (even failed ones).
 		// This is safe because we never try to restore the state of the searcher for
 		// terminated experiments.
@@ -450,6 +457,7 @@ func (e *experiment) Receive(ctx *actor.Context) error {
 	case *apiv1.PauseExperimentRequest:
 		switch ok := e.updateState(ctx, model.PausedState); ok {
 		case true:
+			ctx.Tell(e.hpImportance, hpimportance.ExperimentPaused{ID: e.ID})
 			ctx.Respond(&apiv1.PauseExperimentResponse{})
 		default:
 			ctx.Respond(status.Errorf(codes.FailedPrecondition,

--- a/master/internal/hpimportance/hpimportance.go
+++ b/master/internal/hpimportance/hpimportance.go
@@ -4,11 +4,11 @@ import (
 	"github.com/determined-ai/determined/master/pkg/model"
 )
 
-func computeHPImportance(data *[]model.HPImportanceTrialData) map[string]float64 {
+func computeHPImportance(data []model.HPImportanceTrialData) map[string]float64 {
 	// This is a place-holder for a future Random Forest implementation to actually compute the
 	// importance of each hyperparameter.
 	output := make(map[string]float64)
-	for key := range (*data)[0].Hparams {
+	for key := range data[0].Hparams {
 		output[key] = 0.0
 	}
 	return output

--- a/master/internal/hpimportance/hpimportance.go
+++ b/master/internal/hpimportance/hpimportance.go
@@ -1,0 +1,15 @@
+package hpimportance
+
+import (
+	"github.com/determined-ai/determined/master/pkg/model"
+)
+
+func computeHPImportance(data *[]model.HPImportanceTrialData) map[string]float64 {
+	// This is a place-holder for a future Random Forest implementation to actually compute the
+	// importance of each hyperparameter.
+	output := make(map[string]float64)
+	for key := range (*data)[0].Hparams {
+		output[key] = 0.0
+	}
+	return output
+}

--- a/master/internal/hpimportance/manager.go
+++ b/master/internal/hpimportance/manager.go
@@ -179,11 +179,8 @@ func (m *manager) getChild(ctx *actor.Context, experimentID int) *actor.Ref {
 		may return a task to sleep for a time), and the manager decides when to spawn or scale down
 		workers. Or each authenticated user can have their own actor, for improved multi-tenancy.
 	*/
-	result = ctx.Child(experimentID)
-	if result == nil {
-		w := newWorker(m.db, ctx.Self())
-		result, _ = ctx.ActorOf(experimentID, w)
-	}
+	factory := func() actor.Actor { return newWorker(m.db, ctx.Self()) }
+	result, _ = ctx.ActorOfFromFactory(experimentID, factory)
 	return result
 }
 

--- a/master/internal/hpimportance/manager.go
+++ b/master/internal/hpimportance/manager.go
@@ -287,7 +287,6 @@ func getMetricHPImportance(hpi model.ExperimentHPImportance, metricName string,
 		metricHpi, ok := hpi.TrainingMetrics[metricName]
 		if !ok {
 			var newMetricHpi model.MetricHPImportance
-			hpi.TrainingMetrics[metricName] = newMetricHpi
 			metricHpi = newMetricHpi
 		}
 		return metricHpi
@@ -295,7 +294,6 @@ func getMetricHPImportance(hpi model.ExperimentHPImportance, metricName string,
 		metricHpi, ok := hpi.ValidationMetrics[metricName]
 		if !ok {
 			var newMetricHpi model.MetricHPImportance
-			hpi.ValidationMetrics[metricName] = newMetricHpi
 			metricHpi = newMetricHpi
 		}
 		return metricHpi

--- a/master/internal/hpimportance/manager.go
+++ b/master/internal/hpimportance/manager.go
@@ -69,7 +69,7 @@ type manager struct {
 func NewManager(db *db.PgDB, system *actor.System, config HPImportanceConfig) actor.Actor {
 	return &manager{
 		db:       db,
-		disabled: config.WorkersLimit > 0,
+		disabled: config.WorkersLimit == 0,
 		state:    make(map[int]stateRecord),
 		pool: pool.NewActorPool(
 			system, config.QueueLimit, config.WorkersLimit, "hp-importance-pool",

--- a/master/internal/hpimportance/manager.go
+++ b/master/internal/hpimportance/manager.go
@@ -74,7 +74,7 @@ func (m *manager) Receive(ctx *actor.Context) error {
 	case ExperimentCompleted:
 		m.experimentCompleted(ctx, msg)
 	case ExperimentCreated:
-		m.experimentCreated(ctx, msg) // TODO: should we just start the clock at the first sign of progress?
+		m.experimentCreated(ctx, msg)
 	case ExperimentProgress:
 		m.experimentProgress(ctx, msg)
 	case WorkRequest:

--- a/master/internal/hpimportance/manager.go
+++ b/master/internal/hpimportance/manager.go
@@ -1,0 +1,284 @@
+package hpimportance
+
+import (
+	"time"
+
+	"github.com/determined-ai/determined/master/internal/db"
+	"github.com/determined-ai/determined/master/pkg/actor"
+	"github.com/determined-ai/determined/master/pkg/model"
+)
+
+type metricType int
+
+// Training designates metrics from training steps.
+const Training metricType = 0
+
+// Validation designates metrics from validation steps.
+const Validation metricType = 1
+
+// Pending indicates that a computation request is queued.
+const Pending string = "pending"
+
+// InProgress indicates that a computation request is in-progress.
+const InProgress string = "in_progress"
+
+// Complete indicates that one request was completed and no further requests have been received.
+const Complete string = "complete"
+
+// Failed indicates that there was an error during computation.
+const Failed string = "failed"
+
+const (
+	// RootAddr is the path to use for looking up the manager actor.
+	RootAddr = "hpimportance"
+
+	// Evaluate after every 10%, but no more than every 10 minutes
+	minPause   = 10 * time.Minute
+	minPercent = 0.1
+)
+
+// TerminalStates indicate final states, as opposed to tasks that imply imminent changes.
+var TerminalStates = map[string]bool{
+	Complete: true,
+	Failed:   true,
+}
+
+// ExperimentCreated is the message an experiment sends when created.
+type ExperimentCreated struct {
+	ID int
+}
+
+// ExperimentCompleted is the message an experiment sends upon completion.
+type ExperimentCompleted struct {
+	ID int
+}
+
+// ExperimentPaused is the message an experiment sends on pausing.
+type ExperimentPaused struct {
+	ID int
+}
+
+// ExperimentProgress is the message an experiment sends after trial completion.
+type ExperimentProgress struct {
+	ID       int
+	Progress float64
+}
+
+// The zero-values of these types happen to be sensible defaults too. If we add fields for which
+// that is not true, add a newStateRecord(). This is for state that doesn't need to be persisted,
+// especially if it is access very frequently.
+type stateRecord struct {
+	lastResult   time.Time
+	lastProgress float64
+}
+
+type manager struct {
+	db    *db.PgDB
+	state map[int]stateRecord
+}
+
+// NewManager initializes the master actor (of which there should only be one instance running).
+func NewManager(db *db.PgDB) actor.Actor {
+	return &manager{db, make(map[int]stateRecord)}
+}
+
+func (m *manager) Receive(ctx *actor.Context) error {
+	switch msg := ctx.Message().(type) {
+	case actor.PreStart:
+		// TODO: fetch any pending or in_progress tasks from the DB and trigger them
+	case actor.PostStop:
+		// Do nothing
+	case actor.ChildFailed:
+		ctx.Log().Warnf("hyperparameter importance worker failed: %+v", msg)
+	case actor.ChildStopped:
+		// Do nothing - it'll respawn next time a request is received
+	case ExperimentCompleted:
+		m.triggerDefaultWork(ctx, msg.ID)
+	case ExperimentCreated:
+		m.state[msg.ID] = stateRecord{
+			lastResult: time.Now(),
+		}
+	case ExperimentPaused:
+		m.triggerDefaultWork(ctx, msg.ID)
+	case ExperimentProgress:
+		var state stateRecord
+		var ok bool
+		if state, ok = m.state[msg.ID]; !ok {
+			state = stateRecord{}
+		}
+		if msg.Progress-state.lastProgress > minPercent &&
+			time.Since(state.lastResult) > minPause {
+			m.triggerDefaultWork(ctx, msg.ID)
+		}
+	case workStarted:
+		hpi, err := m.db.GetHPImportance(msg.experimentID)
+		if err != nil {
+			ctx.Log().Errorf("error retrieving hyperparameter importance state: %s", err.Error())
+			return nil
+		}
+		metricData := getMetricHPImportance(hpi, msg.metricName, msg.metricType)
+		metricData.Status = InProgress
+		setMetricHPImportance(&hpi, metricData, msg.metricName, msg.metricType)
+		err = m.db.SetHPImportance(msg.experimentID, hpi)
+		if err != nil {
+			ctx.Log().Errorf("error writing hyperparameter importance state: %s", err.Error())
+			return nil
+		}
+	case workFailed:
+		hpi, err := m.db.GetHPImportance(msg.experimentID)
+		if err != nil {
+			ctx.Log().Errorf("error retrieving hyperparameter importance state: %s", err.Error())
+			return nil
+		}
+		metricData := getMetricHPImportance(hpi, msg.metricName, msg.metricType)
+		metricData.Status = Failed
+		metricData.Error = msg.err
+		setMetricHPImportance(&hpi, metricData, msg.metricName, msg.metricType)
+		err = m.db.SetHPImportance(msg.experimentID, hpi)
+		if err != nil {
+			ctx.Log().Errorf("error writing hyperparameter importance state: %s", err.Error())
+			return nil
+		}
+	case workCompleted:
+		m.state[msg.experimentID] = stateRecord{
+			lastResult:   time.Now(),
+			lastProgress: m.state[msg.experimentID].lastProgress,
+		}
+		hpi, err := m.db.GetHPImportance(msg.experimentID)
+		if err != nil {
+			ctx.Log().Errorf("error retrieving hyperparameter importance state: %s", err.Error())
+			return nil
+		}
+		metricData := getMetricHPImportance(hpi, msg.metricName, msg.metricType)
+		metricData.ExperimentProgress = msg.progress
+		metricData.HpImportance = msg.results
+		switch metricData.Status {
+		case Pending:
+			// Do nothing - this means another startWork message was already sent
+		case InProgress:
+			metricData.Status = Complete
+		default:
+			ctx.Log().Warnf("work was completed for a metric with an unexpected state")
+		}
+		setMetricHPImportance(&hpi, metricData, msg.metricName, msg.metricType)
+		err = m.db.SetHPImportance(msg.experimentID, hpi)
+		if err != nil {
+			ctx.Log().Errorf("error writing hyperparameter importance state: %s", err.Error())
+			return nil
+		}
+	default:
+		ctx.Log().Errorf("unknown message received by hyperparameter importance manager: %v!",
+			ctx.Message())
+	}
+	return nil
+}
+
+func (m *manager) getChild(ctx *actor.Context, experimentID int) *actor.Ref {
+	var result *actor.Ref
+	/*
+		Currently each experiment gets their own actor, that will persist even after the work
+		for an experiment may be complete. But the child actor's don't need to maintain any state
+		between tasks, so if this becomes a problem in practice we could use a threadpool model
+		where the manager maintains a queue of tasks, workers .Ask() the manager for a task (and it
+		may return a task to sleep for a time), and the manager decides when to spawn or scale down
+		workers. Or each authenticated user can have their own actor, for improved multi-tenancy.
+	*/
+	result = ctx.Child(experimentID)
+	if result == nil {
+		w := newWorker(m.db, ctx.Self())
+		result, _ = ctx.ActorOf(experimentID, w)
+	}
+	return result
+}
+
+func (m *manager) triggerDefaultWork(ctx *actor.Context, experimentID int) {
+	child := m.getChild(ctx, experimentID)
+
+	hpi, err := m.db.GetHPImportance(experimentID)
+	if err != nil {
+		ctx.Log().Errorf("error retrieving hyperparameter importance state: %s", err.Error())
+		return
+	}
+
+	config, err := m.db.ExperimentConfig(experimentID)
+	if err != nil {
+		ctx.Log().Errorf("error retrieving experiment config: %s", err.Error())
+		return
+	}
+
+	loss := "loss"
+	triggerForLoss := false
+	lossHpi := getMetricHPImportance(hpi, loss, Training)
+	if lossHpi.Status != Pending {
+		triggerForLoss = true
+	}
+	lossHpi.Status = Pending
+	setMetricHPImportance(&hpi, lossHpi, loss, Training)
+
+	searcherMetric := config.Searcher.Metric
+	triggerForSearcherMetric := false
+	searcherMetricHpi := getMetricHPImportance(hpi, searcherMetric, Validation)
+	if searcherMetricHpi.Status != Pending {
+		triggerForSearcherMetric = true
+	}
+	searcherMetricHpi.Status = Pending
+	setMetricHPImportance(&hpi, searcherMetricHpi, searcherMetric, Validation)
+
+	err = m.db.SetHPImportance(experimentID, hpi)
+	if err != nil {
+		ctx.Log().Errorf("error writing hyperparameter importance state: %s", err.Error())
+		return
+	}
+
+	if triggerForLoss {
+		ctx.Tell(child, startWork{
+			experimentID: experimentID,
+			metricName:   loss,
+			metricType:   Training,
+		})
+	}
+	if triggerForSearcherMetric {
+		ctx.Tell(child, startWork{
+			experimentID: experimentID,
+			metricName:   searcherMetric,
+			metricType:   Validation,
+		})
+	}
+}
+
+func setMetricHPImportance(hpi *model.ExperimentHPImportance, metricHpi model.MetricHPImportance,
+	metricName string, metricType metricType) *model.ExperimentHPImportance {
+	switch metricType {
+	case Training:
+		hpi.TrainingMetrics[metricName] = metricHpi
+	case Validation:
+		hpi.ValidationMetrics[metricName] = metricHpi
+	default:
+		panic("Invalid metric type!")
+	}
+	return hpi
+}
+
+func getMetricHPImportance(hpi model.ExperimentHPImportance, metricName string,
+	metricType metricType) model.MetricHPImportance {
+	switch metricType {
+	case Training:
+		metricHpi, ok := hpi.TrainingMetrics[metricName]
+		if !ok {
+			var newMetricHpi model.MetricHPImportance
+			hpi.TrainingMetrics[metricName] = newMetricHpi
+			metricHpi = newMetricHpi
+		}
+		return metricHpi
+	case Validation:
+		metricHpi, ok := hpi.ValidationMetrics[metricName]
+		if !ok {
+			var newMetricHpi model.MetricHPImportance
+			hpi.ValidationMetrics[metricName] = newMetricHpi
+			metricHpi = newMetricHpi
+		}
+		return metricHpi
+	default:
+		panic("Invalid metric type!")
+	}
+}

--- a/master/internal/hpimportance/worker.go
+++ b/master/internal/hpimportance/worker.go
@@ -79,6 +79,7 @@ func (w *worker) Receive(ctx *actor.Context) (err error) {
 		state, progress, err := w.db.GetExperimentStatus(msg.experimentID)
 		if err != nil {
 			w.sendWorkFailed(ctx, msg, err.Error())
+			return nil
 		}
 		if state == model.CompletedState {
 			progress = 1

--- a/master/internal/hpimportance/worker.go
+++ b/master/internal/hpimportance/worker.go
@@ -37,7 +37,6 @@ type (
 )
 
 func taskHandlerFactory(db *db.PgDB, system *actor.System) func(interface{}) interface{} {
-
 	getManager := func() *actor.Ref {
 		return system.Get(actor.Addr(RootAddr))
 	}

--- a/master/internal/hpimportance/worker.go
+++ b/master/internal/hpimportance/worker.go
@@ -1,0 +1,110 @@
+package hpimportance
+
+import (
+	"github.com/determined-ai/determined/master/internal/db"
+	"github.com/determined-ai/determined/master/pkg/actor"
+	"github.com/determined-ai/determined/master/pkg/model"
+)
+
+type startWork struct {
+	experimentID int
+	metricName   string
+	metricType   metricType
+}
+
+type workStarted struct {
+	experimentID int
+	metricName   string
+	metricType   metricType
+}
+
+type workCompleted struct {
+	experimentID int
+	metricName   string
+	metricType   metricType
+	progress     float64
+	results      map[string]float64
+}
+
+type workFailed struct {
+	experimentID int
+	metricName   string
+	metricType   metricType
+	err          string
+}
+
+type worker struct {
+	db      *db.PgDB
+	manager *actor.Ref
+}
+
+func newWorker(db *db.PgDB, manager *actor.Ref) actor.Actor {
+	return &worker{db: db, manager: manager}
+}
+
+func (w *worker) sendWorkStarted(ctx *actor.Context, msg startWork) {
+	ctx.Tell(w.manager, workStarted(msg))
+}
+
+func (w *worker) sendWorkFailed(ctx *actor.Context, msg startWork, err string) {
+	ctx.Tell(w.manager, workFailed{
+		experimentID: msg.experimentID,
+		metricType:   msg.metricType,
+		metricName:   msg.metricName,
+		err:          err,
+	})
+}
+
+func (w *worker) sendWorkCompleted(ctx *actor.Context, msg startWork, progress float64,
+	results map[string]float64) {
+	ctx.Tell(w.manager, workCompleted{
+		experimentID: msg.experimentID,
+		metricType:   msg.metricType,
+		metricName:   msg.metricName,
+		progress:     progress,
+		results:      results,
+	})
+}
+
+func (w *worker) Receive(ctx *actor.Context) (err error) {
+	switch msg := ctx.Message().(type) {
+	case actor.PreStart:
+		// Do nothing
+	case actor.PostStop:
+		// Do nothing
+	case startWork:
+		w.sendWorkStarted(ctx, msg)
+
+		state, progress, err := w.db.GetExperimentStatus(msg.experimentID)
+		if err != nil {
+			w.sendWorkFailed(ctx, msg, err.Error())
+		}
+		if state == model.CompletedState {
+			progress = 1
+		}
+
+		var trials *[]model.HPImportanceTrialData
+		switch msg.metricType {
+		case Training:
+			trials, err = w.db.FetchHPImportanceTrainingData(msg.experimentID, msg.metricName)
+			if err != nil {
+				w.sendWorkFailed(ctx, msg, err.Error())
+				return nil
+			}
+		case Validation:
+			trials, err = w.db.FetchHPImportanceValidationData(msg.experimentID, msg.metricName)
+			if err != nil {
+				w.sendWorkFailed(ctx, msg, err.Error())
+				return nil
+			}
+		default:
+			w.sendWorkFailed(ctx, msg, "invalid metric type received in hyperparameter importance worker")
+			return nil
+		}
+		results := computeHPImportance(trials)
+		w.sendWorkCompleted(ctx, msg, progress, results)
+	default:
+		ctx.Log().Errorf("Unknown message sent to HP Importance worker: %v!", ctx.Message())
+	}
+	return nil
+}

--- a/master/pkg/actor/context.go
+++ b/master/pkg/actor/context.go
@@ -65,6 +65,13 @@ func (c *Context) ActorOf(id interface{}, actor Actor) (*Ref, bool) {
 	return c.recipient.createChild(c.recipient.address.Child(id), actor)
 }
 
+// ActorOfFromFactory behaves the same as ActorOf but will only create the actor instance if it's
+// needed. It is intended for cases where an actor needs to be looked up many times safely but
+// usually exists.
+func (c *Context) ActorOfFromFactory(id interface{}, factory func() Actor) (*Ref, bool) {
+	return c.recipient.createChildFromFactory(c.recipient.address.Child(id), factory)
+}
+
 // Sender returns the reference to the actor that sent the message.
 func (c *Context) Sender() *Ref {
 	return c.sender

--- a/master/pkg/actor/pool/pool.go
+++ b/master/pkg/actor/pool/pool.go
@@ -148,13 +148,14 @@ func (w worker) Receive(ctx *actor.Context) error {
 	case actor.PreStart, actor.PostStop:
 		// Expected life-cycle messages; do nothing
 	case workerUp:
+	workLoop:
 		for {
 			task := ctx.Ask(ctx.Sender(), receiveTask{}).Get()
 
 			switch realTask := task.(type) {
 			case workerDown:
 				ctx.Self().Stop()
-				break
+				break workLoop
 			default:
 				result := w.pool.taskHandler(realTask)
 				ctx.Tell(ctx.Sender(), returnTask{result})

--- a/master/pkg/actor/pool/pool.go
+++ b/master/pkg/actor/pool/pool.go
@@ -1,0 +1,158 @@
+package pool
+
+import (
+	"errors"
+
+	"github.com/determined-ai/determined/master/pkg/actor"
+)
+
+type ActorPool struct {
+	name string
+
+	taskHandler func(task interface{}) interface{}
+	callback    func(result interface{})
+
+	queueLimit   uint
+	workersLimit uint
+	workers      uint
+	counter      uint64
+
+	manager *actor.Ref
+	system  *actor.System
+
+	queue chan interface{}
+}
+
+func NewActorPool(
+	system *actor.System,
+	queueLimit uint,
+	workersLimit uint,
+	name string,
+	taskHandler func(task interface{}) interface{},
+	callback func(result interface{})) ActorPool {
+
+	pool := ActorPool{
+		name: name,
+
+		taskHandler: taskHandler, // May be called many times in parallel
+		callback:    callback,    // Will only be called by the manager actor
+
+		queueLimit:   queueLimit,
+		workersLimit: workersLimit,
+
+		system: system,
+
+		queue: make(chan interface{}, queueLimit),
+	}
+	ref, _ := system.ActorOf(actor.Addr(name), &pool)
+	pool.manager = ref
+	return pool
+}
+
+func (p *ActorPool) SubmitTask(task interface{}) error {
+	result := p.system.Ask(p.manager, sendTask{task}).Get()
+	if result != nil {
+		return result.(error)
+	}
+	return nil
+}
+
+// Internal message types
+type (
+	// For giving a new task to the manager.
+	sendTask struct {
+		task interface{}
+	}
+
+	// For workers to request their next task.
+	receiveTask struct{}
+
+	// To return the result of a task to the manager.
+	returnTask struct {
+		result interface{}
+	}
+
+	// Instructs a worker to start it's main loop.
+	workerUp struct{}
+
+	// Instructs a worker to stop. Not used as a "message" in Receive, but a response to a worker's
+	// Ask().
+	workerDown struct{}
+)
+
+// Manager
+
+func (p *ActorPool) Receive(ctx *actor.Context) error {
+	switch msg := ctx.Message().(type) {
+	case actor.PreStart, actor.PostStop, actor.ChildStopped:
+		// Expected life-cycle messages; do nothing
+	case actor.ChildFailed:
+		ctx.Log().Warnf("worker failed in actor pool %s: %+v", p.name, msg)
+	case sendTask:
+		if uint(len(p.queue)) == p.queueLimit {
+			ctx.Respond(errors.New("actor pool queue is full!"))
+			return nil
+		}
+		p.queue <- msg.task
+		if p.workers < p.workersLimit {
+			newWorker := worker{pool: p}
+			ref, _ := ctx.ActorOf(p.counter, newWorker)
+			p.counter = p.counter + 1
+			p.workers = p.workers + 1
+			ctx.Tell(ref, workerUp{})
+		}
+	case receiveTask:
+		var response interface{}
+		select {
+		case realTask := <-p.queue:
+			response = realTask
+		default:
+			response = workerDown{}
+			p.workers = p.workers - 1
+		}
+		ctx.Respond(response)
+	case returnTask:
+		if p.callback != nil {
+			p.callback(msg.result)
+		}
+	default:
+		ctx.Log().Errorf("unknown message received by actor pool %s: %+v!",
+			p.name, ctx.Message())
+	}
+	return nil
+}
+
+// Worker
+
+type worker struct {
+	pool *ActorPool
+}
+
+func (w worker) Receive(ctx *actor.Context) error {
+	// Other than minimal life-cycle messages, a worker receives a workerUp message and is then
+	// stuck in an infinite loop, polling for tasks from the master until it receives a workerDown
+	// response and stops itself.
+	switch ctx.Message().(type) {
+	case actor.PreStart, actor.PostStop:
+		// Expected life-cycle messages; do nothing
+	case workerUp:
+		for {
+			task := ctx.Ask(ctx.Sender(), receiveTask{}).Get()
+
+			switch realTask := task.(type) {
+			case workerDown:
+				err := ctx.Self().StopAndAwaitTermination()
+				if err != nil {
+					return nil
+					// TODO log error, because now there's gonna be a zombie actor
+				}
+			default:
+				result := w.pool.taskHandler(realTask)
+				ctx.Tell(ctx.Sender(), returnTask{result})
+			}
+		}
+	default:
+		ctx.Log().Errorf("unknown message received by actor pool worker: %v!", ctx.Message())
+	}
+	return nil
+}

--- a/master/pkg/actor/ref.go
+++ b/master/pkg/actor/ref.go
@@ -173,6 +173,22 @@ func (r *Ref) createChild(address Address, actor Actor) (*Ref, bool) {
 	return ref, true
 }
 
+func (r *Ref) createChildFromFactory(address Address, factory func() Actor) (*Ref, bool) {
+	if existingRef, ok := r.children[address]; ok {
+		return existingRef, false
+	}
+
+	ref := newRef(r.system, r, address, factory())
+	r.children[address] = ref
+
+	r.system.refsLock.Lock()
+	defer r.system.refsLock.Unlock()
+
+	r.system.refs[address] = ref
+
+	return ref, true
+}
+
 func (r *Ref) deleteChild(address Address) {
 	delete(r.children, address)
 

--- a/master/pkg/model/experiment.go
+++ b/master/pkg/model/experiment.go
@@ -487,12 +487,13 @@ type SearcherEvent struct {
 	Content      JSONObj `db:"content"`
 }
 
+// MetricType denotes what type of step (training / validation) a metric is from.
 type MetricType int
 
 const (
-	// Training designates metrics from training steps.
+	// TrainingMetric designates metrics from training steps.
 	TrainingMetric MetricType = iota
-	// Validation designates metrics from validation steps.
+	// ValidationMetric designates metrics from validation steps.
 	ValidationMetric MetricType = iota
 )
 

--- a/master/pkg/model/experiment.go
+++ b/master/pkg/model/experiment.go
@@ -487,6 +487,34 @@ type SearcherEvent struct {
 	Content      JSONObj `db:"content"`
 }
 
+type MetricType int
+
+const (
+	// Training designates metrics from training steps.
+	TrainingMetric MetricType = iota
+	// Validation designates metrics from validation steps.
+	ValidationMetric MetricType = iota
+)
+
+type HPImportanceStatus string
+
+const (
+	// Pending indicates that a computation request is queued.
+	Pending HPImportanceStatus = "pending"
+	// InProgress indicates that a computation request is in-progress.
+	InProgress HPImportanceStatus = "in_progress"
+	// Complete indicates that one request was completed and no further requests have been received.
+	Complete HPImportanceStatus = "complete"
+	// Failed indicates that there was an error during computation.
+	Failed HPImportanceStatus = "failed"
+)
+
+// TerminalStates indicate final states, as opposed to tasks that imply imminent changes.
+var HPImportanceTerminalStates = map[HPImportanceStatus]bool{
+	Complete: true,
+	Failed:   true,
+}
+
 // HPImportanceTrialData is the input to the hyperparameter importance algorithm.
 type HPImportanceTrialData struct {
 	TrialID int                    `db:"trial_id"`
@@ -505,7 +533,7 @@ type ExperimentHPImportance struct {
 // MetricHPImportance is hyperparameter importance with respect to a specific metric.
 type MetricHPImportance struct {
 	Error              string             `json:"error"`
-	Status             string             `json:"state"`
+	Status             HPImportanceStatus `json:"state"`
 	ExperimentProgress float64            `json:"experiment_progress"`
 	HpImportance       map[string]float64 `json:"hp_importance"`
 }

--- a/master/pkg/model/experiment.go
+++ b/master/pkg/model/experiment.go
@@ -486,3 +486,26 @@ type SearcherEvent struct {
 	EventType    string  `db:"event_type"`
 	Content      JSONObj `db:"content"`
 }
+
+// HPImportanceTrialData is the input to the hyperparameter importance algorithm.
+type HPImportanceTrialData struct {
+	TrialID int                    `db:"trial_id"`
+	Hparams map[string]interface{} `db:"hparams"`
+	Batches int                    `db:"batches"`
+	Metric  float64                `db:"metric"`
+}
+
+// ExperimentHPImportance is hyperparameter importance for an experiment, and consists of
+// independent measurements of importance for any of the metrics recorded by the experiment.
+type ExperimentHPImportance struct {
+	TrainingMetrics   map[string]MetricHPImportance `json:"training_metrics"`
+	ValidationMetrics map[string]MetricHPImportance `json:"validation_metrics"`
+}
+
+// MetricHPImportance is hyperparameter importance with respect to a specific metric.
+type MetricHPImportance struct {
+	Error              string             `json:"error"`
+	Status             string             `json:"state"`
+	ExperimentProgress float64            `json:"experiment_progress"`
+	HpImportance       map[string]float64 `json:"hp_importance"`
+}

--- a/master/pkg/model/experiment.go
+++ b/master/pkg/model/experiment.go
@@ -496,25 +496,6 @@ const (
 	ValidationMetric MetricType = iota
 )
 
-type HPImportanceStatus string
-
-const (
-	// Pending indicates that a computation request is queued.
-	Pending HPImportanceStatus = "pending"
-	// InProgress indicates that a computation request is in-progress.
-	InProgress HPImportanceStatus = "in_progress"
-	// Complete indicates that one request was completed and no further requests have been received.
-	Complete HPImportanceStatus = "complete"
-	// Failed indicates that there was an error during computation.
-	Failed HPImportanceStatus = "failed"
-)
-
-// TerminalStates indicate final states, as opposed to tasks that imply imminent changes.
-var HPImportanceTerminalStates = map[HPImportanceStatus]bool{
-	Complete: true,
-	Failed:   true,
-}
-
 // HPImportanceTrialData is the input to the hyperparameter importance algorithm.
 type HPImportanceTrialData struct {
 	TrialID int                    `db:"trial_id"`
@@ -533,7 +514,8 @@ type ExperimentHPImportance struct {
 // MetricHPImportance is hyperparameter importance with respect to a specific metric.
 type MetricHPImportance struct {
 	Error              string             `json:"error"`
-	Status             HPImportanceStatus `json:"state"`
+	Pending            bool               `json:"pending"`
+	InProgress         bool               `json:"in_progress"`
 	ExperimentProgress float64            `json:"experiment_progress"`
 	HpImportance       map[string]float64 `json:"hp_importance"`
 }

--- a/master/pkg/model/experiment.go
+++ b/master/pkg/model/experiment.go
@@ -520,3 +520,40 @@ type MetricHPImportance struct {
 	ExperimentProgress float64            `json:"experiment_progress"`
 	HpImportance       map[string]float64 `json:"hp_importance"`
 }
+
+// SetMetricHPImportance is a convenience function when modifying results for a specific metric.
+func (hpi *ExperimentHPImportance) SetMetricHPImportance(metricHpi MetricHPImportance,
+	metricName string, metricType MetricType) *ExperimentHPImportance {
+	switch metricType {
+	case TrainingMetric:
+		hpi.TrainingMetrics[metricName] = metricHpi
+	case ValidationMetric:
+		hpi.ValidationMetrics[metricName] = metricHpi
+	default:
+		panic("Invalid metric type!")
+	}
+	return hpi
+}
+
+// GetMetricHPImportance is a convenience function when working with results for a specific metric.
+func (hpi *ExperimentHPImportance) GetMetricHPImportance(metricName string, metricType MetricType,
+) MetricHPImportance {
+	switch metricType {
+	case TrainingMetric:
+		metricHpi, ok := hpi.TrainingMetrics[metricName]
+		if !ok {
+			var newMetricHpi MetricHPImportance
+			metricHpi = newMetricHpi
+		}
+		return metricHpi
+	case ValidationMetric:
+		metricHpi, ok := hpi.ValidationMetrics[metricName]
+		if !ok {
+			var newMetricHpi MetricHPImportance
+			metricHpi = newMetricHpi
+		}
+		return metricHpi
+	default:
+		panic("Invalid metric type!")
+	}
+}

--- a/master/pkg/model/experiment.go
+++ b/master/pkg/model/experiment.go
@@ -540,19 +540,15 @@ func (hpi *ExperimentHPImportance) GetMetricHPImportance(metricName string, metr
 ) MetricHPImportance {
 	switch metricType {
 	case TrainingMetric:
-		metricHpi, ok := hpi.TrainingMetrics[metricName]
-		if !ok {
-			var newMetricHpi MetricHPImportance
-			metricHpi = newMetricHpi
+		if metricHpi, ok := hpi.TrainingMetrics[metricName]; ok {
+			return metricHpi
 		}
-		return metricHpi
+		return MetricHPImportance{}
 	case ValidationMetric:
-		metricHpi, ok := hpi.ValidationMetrics[metricName]
-		if !ok {
-			var newMetricHpi MetricHPImportance
-			metricHpi = newMetricHpi
+		if metricHpi, ok := hpi.ValidationMetrics[metricName]; ok {
+			return metricHpi
 		}
-		return metricHpi
+		return MetricHPImportance{}
 	default:
 		panic("Invalid metric type!")
 	}

--- a/master/static/migrations/20201211160817_add-hpimportance-fields.down.sql
+++ b/master/static/migrations/20201211160817_add-hpimportance-fields.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE public.experiments DROP COLUMN hpimportance;

--- a/master/static/migrations/20201211160817_add-hpimportance-fields.up.sql
+++ b/master/static/migrations/20201211160817_add-hpimportance-fields.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE public.experiments ADD COLUMN hpimportance jsonb;

--- a/proto/src/determined/api/v1/api.proto
+++ b/proto/src/determined/api/v1/api.proto
@@ -803,6 +803,15 @@ service Determined {
     };
   }
 
+  rpc ComputeHPImportance(ComputeHPImportanceRequest) returns (ComputeHPImportanceResponse) {
+    option (google.api.http) = {
+      post: "/api/v1/experiments/{experiment_id}/hyperparameter-importance"
+    };
+    option (grpc.gateway.protoc_gen_swagger.options.openapiv2_operation) = {
+      tags: "Internal"
+    };
+  }
+
   // Retrieve the latest computation of hyperparameter importance. Currently this is triggered for
   // training loss (if emitted) and the searcher metric after 10% increments in an experiment's
   // progress, but no more than every 10 minutes.

--- a/proto/src/determined/api/v1/api.proto
+++ b/proto/src/determined/api/v1/api.proto
@@ -803,9 +803,11 @@ service Determined {
     };
   }
 
-  // Trigger the computation of hyperparameter importance on-demand for a specific metric on a
-  // specific experiment. The status and results can be retrieved with GetHPImportance.
-  rpc ComputeHPImportance(ComputeHPImportanceRequest) returns (ComputeHPImportanceResponse) {
+  // Trigger the computation of hyperparameter importance on-demand for a
+  // specific metric on a specific experiment. The status and results can be
+  // retrieved with GetHPImportance.
+  rpc ComputeHPImportance(ComputeHPImportanceRequest)
+      returns (ComputeHPImportanceResponse) {
     option (google.api.http) = {
       post: "/api/v1/experiments/{experiment_id}/hyperparameter-importance"
     };
@@ -814,10 +816,12 @@ service Determined {
     };
   }
 
-  // Retrieve the latest computation of hyperparameter importance. Currently this is triggered for
-  // training loss (if emitted) and the searcher metric after 10% increments in an experiment's
-  // progress, but no more than every 10 minutes.
-  rpc GetHPImportance(GetHPImportanceRequest) returns (stream GetHPImportanceResponse) {
+  // Retrieve the latest computation of hyperparameter importance. Currently
+  // this is triggered for training loss (if emitted) and the searcher metric
+  // after 10% increments in an experiment's progress, but no more than every 10
+  // minutes.
+  rpc GetHPImportance(GetHPImportanceRequest)
+      returns (stream GetHPImportanceResponse) {
     option (google.api.http) = {
       get: "/api/v1/experiments/{experiment_id}/hyperparameter-importance"
     };

--- a/proto/src/determined/api/v1/api.proto
+++ b/proto/src/determined/api/v1/api.proto
@@ -803,6 +803,8 @@ service Determined {
     };
   }
 
+  // Trigger the computation of hyperparameter importance on-demand for a specific metric on a
+  // specific experiment. The status and results can be retrieved with GetHPImportance.
   rpc ComputeHPImportance(ComputeHPImportanceRequest) returns (ComputeHPImportanceResponse) {
     option (google.api.http) = {
       post: "/api/v1/experiments/{experiment_id}/hyperparameter-importance"

--- a/proto/src/determined/api/v1/api.proto
+++ b/proto/src/determined/api/v1/api.proto
@@ -802,4 +802,16 @@ service Determined {
       tags: "Internal"
     };
   }
+
+  // Retrieve the latest computation of hyperparameter importance. Currently this is triggered for
+  // training loss (if emitted) and the searcher metric after 10% increments in an experiment's
+  // progress, but no more than every 10 minutes.
+  rpc GetHPImportance(GetHPImportanceRequest) returns (stream GetHPImportanceResponse) {
+    option (google.api.http) = {
+      get: "/api/v1/experiments/{experiment_id}/hyperparameter-importance"
+    };
+    option (grpc.gateway.protoc_gen_swagger.options.openapiv2_operation) = {
+      tags: "Internal"
+    };
+  }
 }

--- a/proto/src/determined/api/v1/experiment.proto
+++ b/proto/src/determined/api/v1/experiment.proto
@@ -431,20 +431,27 @@ message TrialsSampleResponse {
   repeated int32 demoted_trials = 3;
 }
 
-// Trigger the computation of hyperparameter importance on-demand for a specific metric on a
-// specific experiment.
+// Trigger the computation of hyperparameter importance on-demand for a specific
+// metric on a specific experiment.
 message ComputeHPImportanceRequest {
   // The id of the experiment.
   int32 experiment_id = 1;
   // A metric name.
-  string metric_name = 2 [(grpc.gateway.protoc_gen_swagger.options.openapiv2_field) = { required: ["metric_name"]; }];
+  string metric_name = 2
+      [(grpc.gateway.protoc_gen_swagger.options.openapiv2_field) = {
+        required:
+          ["metric_name"];
+      }];
   // The type of metric.
-  MetricType metric_type = 3 [(grpc.gateway.protoc_gen_swagger.options.openapiv2_field) = { required: ["metric_type"]; }];
+  MetricType metric_type = 3
+      [(grpc.gateway.protoc_gen_swagger.options.openapiv2_field) = {
+        required:
+          ["metric_type"];
+      }];
 }
 
 // Response to ComputeHPImportanceRequest
-message ComputeHPImportanceResponse {
-}
+message ComputeHPImportanceResponse {}
 
 // Retrieve the status and results of hyperparameter importance computation.
 message GetHPImportanceRequest {
@@ -459,10 +466,12 @@ message GetHPImportanceResponse {
   // Hyperparameter importance as computed with respect for one specific metric.
   message MetricHPImportance {
     // A map between hyperparameter names and their relative importance.
-    map<string,double> hp_importance = 1;
-    // The approximate portion of the experiment that was complete when the data was read.
+    map<string, double> hp_importance = 1;
+    // The approximate portion of the experiment that was complete when the data
+    // was read.
     double experiment_progress = 2;
-    // A description of why computation failed. Empty unless the state is (or was) 'failed'.
+    // A description of why computation failed. Empty unless the state is (or
+    // was) 'failed'.
     string error = 3;
     // Whether or not a request to compute results for this metric is queued.
     bool pending = 4;
@@ -470,7 +479,7 @@ message GetHPImportanceResponse {
     bool in_progress = 5;
   }
   // A map of training metric names to their respective entries.
-  map<string,MetricHPImportance> training_metrics = 1;
+  map<string, MetricHPImportance> training_metrics = 1;
   // A map of validation metric names to their respective entries.
-  map<string,MetricHPImportance> validation_metrics = 2;
+  map<string, MetricHPImportance> validation_metrics = 2;
 }

--- a/proto/src/determined/api/v1/experiment.proto
+++ b/proto/src/determined/api/v1/experiment.proto
@@ -456,24 +456,16 @@ message GetHPImportanceRequest {
 message GetHPImportanceResponse {
   // Hyperparameter importance as computed with respect for one specific metric.
   message MetricHPImportance {
-    // Possible statuses for hyperparameter importance computation
-    enum Status {
-      // A request is queued.
-      STATUS_PENDING = 0;
-      // A request is in progress.
-      STATUS_IN_PROGRESS = 1;
-      // A request is complete.
-      STATUS_COMPLETE = 2;
-    }
-
     // A map between hyperparameter names and their relative importance.
     map<string,double> hp_importance = 1;
     // The approximate portion of the experiment that was complete when the data was read.
     double experiment_progress = 2;
-    // The current status of any on-going computation.
-    Status status = 3;
     // A description of why computation failed. Empty unless the state is (or was) 'failed'.
-    string error = 4;
+    string error = 3;
+    // Whether or not a request to compute results for this metric is queued.
+    bool pending = 4;
+    // Whether or not results for this metric are currently being computed.
+    bool in_progress = 5;
   }
   // A map of training metric names to their respective entries.
   map<string,MetricHPImportance> training_metrics = 1;

--- a/proto/src/determined/api/v1/experiment.proto
+++ b/proto/src/determined/api/v1/experiment.proto
@@ -432,6 +432,19 @@ message TrialsSampleResponse {
 }
 
 // Retrieve
+message ComputeHPImportanceRequest {
+  // The id of the experiment.
+  int32 experiment_id = 1;
+  // A metric name.
+  string metric_name = 2 [(grpc.gateway.protoc_gen_swagger.options.openapiv2_field) = { required: ["metric_name"]; }];
+  // The type of metric.
+  MetricType metric_type = 3 [(grpc.gateway.protoc_gen_swagger.options.openapiv2_field) = { required: ["metric_type"]; }];
+}
+
+message ComputeHPImportanceResponse {
+}
+
+// Retrieve
 message GetHPImportanceRequest {
   // The id of the experiment.
   int32 experiment_id = 1;

--- a/proto/src/determined/api/v1/experiment.proto
+++ b/proto/src/determined/api/v1/experiment.proto
@@ -431,7 +431,8 @@ message TrialsSampleResponse {
   repeated int32 demoted_trials = 3;
 }
 
-// Retrieve
+// Trigger the computation of hyperparameter importance on-demand for a specific metric on a
+// specific experiment.
 message ComputeHPImportanceRequest {
   // The id of the experiment.
   int32 experiment_id = 1;
@@ -441,10 +442,11 @@ message ComputeHPImportanceRequest {
   MetricType metric_type = 3 [(grpc.gateway.protoc_gen_swagger.options.openapiv2_field) = { required: ["metric_type"]; }];
 }
 
+// Response to ComputeHPImportanceRequest
 message ComputeHPImportanceResponse {
 }
 
-// Retrieve
+// Retrieve the status and results of hyperparameter importance computation.
 message GetHPImportanceRequest {
   // The id of the experiment.
   int32 experiment_id = 1;

--- a/proto/src/determined/api/v1/experiment.proto
+++ b/proto/src/determined/api/v1/experiment.proto
@@ -443,16 +443,22 @@ message GetHPImportanceRequest {
 message GetHPImportanceResponse {
   // Hyperparameter importance as computed with respect for one specific metric.
   message MetricHPImportance {
+    // Possible statuses for hyperparameter importance computation
+    enum Status {
+      // A request is queued.
+      STATUS_PENDING = 0;
+      // A request is in progress.
+      STATUS_IN_PROGRESS = 1;
+      // A request is complete.
+      STATUS_COMPLETE = 2;
+    }
+
     // A map between hyperparameter names and their relative importance.
     map<string,double> hp_importance = 1;
     // The approximate portion of the experiment that was complete when the data was read.
     double experiment_progress = 2;
-    // The current status of any on-going computation. 'pending' means a request is queued, even if
-    // complete results from a previous computation are included. 'in_progress' means a new
-    // computation is ongoing (again, even if previous results are included). 'complete' means
-    // the current results are the latest available and no further action has been triggered.
-    // 'failed' means there was some error during computation (see 'error').
-    string status = 3;
+    // The current status of any on-going computation.
+    Status status = 3;
     // A description of why computation failed. Empty unless the state is (or was) 'failed'.
     string error = 4;
   }

--- a/proto/src/determined/api/v1/experiment.proto
+++ b/proto/src/determined/api/v1/experiment.proto
@@ -430,3 +430,34 @@ message TrialsSampleResponse {
   // IDs of trials that are no loger included in the top N trials.
   repeated int32 demoted_trials = 3;
 }
+
+// Retrieve
+message GetHPImportanceRequest {
+  // The id of the experiment.
+  int32 experiment_id = 1;
+  // Seconds to wait when polling for updates.
+  int32 period_seconds = 2;
+}
+
+// Response to GetHPImportanceRequest
+message GetHPImportanceResponse {
+  // Hyperparameter importance as computed with respect for one specific metric.
+  message MetricHPImportance {
+    // A map between hyperparameter names and their relative importance.
+    map<string,double> hp_importance = 1;
+    // The approximate portion of the experiment that was complete when the data was read.
+    double experiment_progress = 2;
+    // The current status of any on-going computation. 'pending' means a request is queued, even if
+    // complete results from a previous computation are included. 'in_progress' means a new
+    // computation is ongoing (again, even if previous results are included). 'complete' means
+    // the current results are the latest available and no further action has been triggered.
+    // 'failed' means there was some error during computation (see 'error').
+    string status = 3;
+    // A description of why computation failed. Empty unless the state is (or was) 'failed'.
+    string error = 4;
+  }
+  // A map of training metric names to their respective entries.
+  map<string,MetricHPImportance> training_metrics = 1;
+  // A map of validation metric names to their respective entries.
+  map<string,MetricHPImportance> validation_metrics = 2;
+}


### PR DESCRIPTION
## Description

This is the initial infrastructure required for hyperparameter importance: automatically triggering computation after every 10% milestone in the experiment, or every 10 minutes, whichever is slower, doing so for training loss (if it exists) and the searcher metric, and a streaming API to retrieve the results.

It has been designed to allow the results to be computed with respect to arbitrary metrics on-demand, although that API does not exist today.

## Test Plan

Added the same type of integration test I've been giving all of the streaming metrics APIs, and did some manual poking via curl.

## Commentary (optional)

One possible redesign to consider in the future is how we allocate workers for this. It's unlikely to be constantly working, but when it is working each task is computationally expensive (may be a couple of minutes on larger experiments). Right now it's 1 worker per experiment, and the actor just hangs around once it's done. We might consider 1 worker per active user for better multitenancy in the future, or we might consider a threadpool-like model where workers .Ask() the manager for tasks. If idle, the manager returns a no op telling them to sleep, and will decide as the work queue shrinks or grows whether or not to spawn more workers. For now, I consider that all premature optimization.