### PR TITLE
feat: json-schema for experiment config validation [DET-4311] [DET-4313]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,16 +41,16 @@ clean: clean-tools clean-proto clean-common clean-harness clean-cli clean-deploy
 check-%:
 	$(MAKE) -C $(subst -,/,$*) check
 .PHONY: check
-check: check-common check-proto check-harness check-cli check-deploy check-e2e_tests check-tools check-master check-agent check-webui check-examples check-docs
+check: check-common check-proto check-harness check-cli check-deploy check-e2e_tests check-tools check-master check-agent check-webui check-examples check-docs check-schemas
 
 .PHONY: fmt-%
 fmt-%:
 	$(MAKE) -C $(subst -,/,$*) fmt
 .PHONY: fmt
-fmt: fmt-common fmt-harness fmt-cli fmt-deploy fmt-e2e_tests fmt-tools fmt-master fmt-agent fmt-webui fmt-examples fmt-docs
+fmt: fmt-common fmt-harness fmt-cli fmt-deploy fmt-e2e_tests fmt-tools fmt-master fmt-agent fmt-webui fmt-examples fmt-docs fmt-schemas
 
 .PHONY: test-%
 test-%:
 	$(MAKE) -C $(subst -,/,$*) test
 .PHONY: test
-test: test-harness test-cli test-master test-agent test-webui
+test: test-harness test-cli test-common test-master test-agent test-webui

--- a/agent/go.sum
+++ b/agent/go.sum
@@ -656,6 +656,7 @@ github.com/ryancurrah/gomodguard v1.1.0/go.mod h1:4O8tr7hBODaGE6VIhfJDHcwzh5GUcc
 github.com/ryanrolds/sqlclosecheck v0.3.0 h1:AZx+Bixh8zdUBxUA1NxbxVAS78vTPq4rCb8OUZI9xFw=
 github.com/ryanrolds/sqlclosecheck v0.3.0/go.mod h1:1gREqxyTGR3lVtpngyFo3hZAgk0KCtEdgEkHwDbigdA=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
+github.com/santhosh-tekuri/jsonschema/v2 v2.2.0/go.mod h1:yzJzKUGV4RbWqWIBBP4wSOBqavX5saE02yirLS0OTyg=
 github.com/sassoftware/go-rpmutils v0.0.0-20190420191620-a8f1baeba37b h1:+gCnWOZV8Z/8jehJ2CdqB47Z3S+SREmQcuXkRFLNsiI=
 github.com/sassoftware/go-rpmutils v0.0.0-20190420191620-a8f1baeba37b/go.mod h1:am+Fp8Bt506lA3Rk3QCmSqmYmLMnPDhdDUcosQCAx+I=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=

--- a/common/.gitignore
+++ b/common/.gitignore
@@ -1,3 +1,6 @@
+# Generated files
+*_gen.py
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/common/Makefile
+++ b/common/Makefile
@@ -1,3 +1,5 @@
+GENERATED := determined_common/schemas/expconf/_v1_gen.py
+
 .PHONY: clean
 clean:
 	rm -rf .pytest_cache/
@@ -7,6 +9,18 @@ clean:
 	rm -rf dist/
 	rm -rf build/
 	find . \( -name __pycache__ -o -name \*.pyc \) -delete
+
+.PHONY: ungen
+ungen:
+	rm -f $(GENERATED)
+
+gen: $(GENERATED)
+
+determined_common/schemas/expconf/_v1_gen.py: ../schemas/gen.py $(shell find ../schemas/expconf -name "*.json")
+	../schemas/gen.py \
+		--output $@ \
+		python \
+		$(shell find ../schemas/expconf/v1 -name "*.json")
 
 .PHONY: build
 build:
@@ -22,8 +36,12 @@ fmt:
 	black .
 
 .PHONY: check
-check:
+check: gen
 	isort --check-only
-	black . --check
-	flake8
+	black .
+	flake8 --exclude '*_gen.py'
 	mypy .
+
+.PHONY: test
+test: gen
+	pytest -v tests

--- a/common/determined_common/schemas/__init__.py
+++ b/common/determined_common/schemas/__init__.py
@@ -1,0 +1,2 @@
+# Avoid automatically importing anything in this module, since these imports are non-trivial and
+# would affect the user experience in the cli.

--- a/common/determined_common/schemas/expconf/__init__.py
+++ b/common/determined_common/schemas/expconf/__init__.py
@@ -1,0 +1,1 @@
+from determined_common.schemas.expconf._validate import validation_errors

--- a/common/determined_common/schemas/expconf/__main__.py
+++ b/common/determined_common/schemas/expconf/__main__.py
@@ -1,0 +1,15 @@
+import json
+import sys
+
+from determined_common.schemas import expconf
+
+if __name__ == "__main__":
+    example = json.load(sys.stdin)
+
+    errors = expconf.validation_errors(example)
+
+    if not errors:
+        sys.exit(0)
+
+    print("\n".join(expconf.validation_errors(example)))
+    sys.exit(1)

--- a/common/determined_common/schemas/expconf/_validate.py
+++ b/common/determined_common/schemas/expconf/_validate.py
@@ -1,0 +1,46 @@
+from typing import Any, Dict, List, Optional
+
+import jsonschema
+
+from determined_common.schemas import extensions, util
+from determined_common.schemas.expconf import _v1_gen
+
+_v1_validators = {}  # type: Dict[str, Any]
+
+
+def v1_validator(url: Optional[str] = None) -> Any:
+    # Use the experiment config schema by default.
+    if url is None:
+        url = "http://determined.ai/schemas/expconf/v1/experiment.json"
+
+    global _v1_validators
+    if url in _v1_validators:
+        return _v1_validators[url]
+
+    schema = _v1_gen.schemas[url]
+
+    resolver = jsonschema.RefResolver(
+        base_uri=url,
+        referrer=schema,
+        handlers={"http": lambda url: _v1_gen.schemas[url]},
+    )
+
+    validator = jsonschema.Draft7Validator(schema=schema, resolver=resolver)
+    ext = {
+        "disallowProperties": extensions.disallowProperties,
+        "union": extensions.union,
+        "checks": extensions.checks,
+        "compareProperties": extensions.compareProperties,
+        "conditional": extensions.conditional,
+        "eventuallyRequired": extensions.eventuallyRequired,
+    }
+    cls = jsonschema.validators.extend(validator, ext)
+    _v1_validators[url] = cls(schema=schema, resolver=resolver)
+
+    return _v1_validators[url]
+
+
+def validation_errors(instance: Any, url: Optional[str] = None) -> List[str]:
+    validator = v1_validator(url)
+    errors = validator.iter_errors(instance)
+    return util.format_validation_errors(errors)

--- a/common/determined_common/schemas/extensions.py
+++ b/common/determined_common/schemas/extensions.py
@@ -1,0 +1,319 @@
+import os
+from typing import Any, Dict, Iterator, List
+
+import jsonschema
+
+
+def disallowProperties(
+    validator: jsonschema.Draft7Validator, disallowed: Dict, instance: Any, schema: Dict
+) -> Iterator[jsonschema.ValidationError]:
+    """
+    disallowProperties is for restricting which properties are allowed in an object with
+    per-property, such as when we allow a k8s pod spec with some fields disallowed.
+
+    Example: The "pod_spec" property of the environment config:
+
+        "pod_spec": {
+            "type": "object",
+            "disallowProperties": {
+                "name": "pod Name is not a configurable option",
+                "name_space": "pod NameSpace is not a configurable option"
+            }
+        }
+    """
+    if not validator.is_type(instance, "object"):
+        return
+
+    for prop in instance:
+        if prop in disallowed:
+            msg = disallowed[prop]
+            yield jsonschema.ValidationError(msg)
+
+
+def union(
+    validator: jsonschema.Draft7Validator, det_one_of: Dict, instance: Any, schema: Dict
+) -> Iterator[jsonschema.ValidationError]:
+    """
+    union is for custom error messages with union types.  The built-in oneOf keyword has the same
+    validation behavior but awful error handling.  If you had the following invalid hyperparameter:
+
+        hyperparameters:
+          - learning_rate:
+              type: double
+              min: 0.001
+              max: 0.005
+
+    would you return an error saying:
+
+        "your double hparam has invalid fields 'min' and 'max' but needs 'minval' and 'maxval'",
+
+    or would you say:
+
+        "your int hparam has type=double but needs type=int and 'minval' and 'maxval'"?
+
+    Obviously you want the first option, because we treat the "type" key as special, and we can
+    uniquely identify which subschema should match against the provided data based on the "type".
+
+    The union extension provides this exact behavior.
+
+    Example: The "additionalProperties" schema for the hyperparameters dict:
+
+        "union": {
+            "items": [
+                {
+                    "unionKey": "const:type=int",
+                    "$ref": ...
+                },
+                {
+                    "unionKey": "const:type=double",
+                    "$ref": ...
+                },
+                ...
+            ]
+        }
+
+    When the oneOf validation logic is not met, the error chosen is based on the first unionKey to
+    evaluate to true.  In this case, the "const:" means a certain key ("type") must match a certain
+    value ("int" or "double") for that subschema's error message to be chosen.
+    """
+    selected_errors = None
+    valid = []
+
+    for idx, item in enumerate(det_one_of["items"]):
+        errors = list(validator.descend(instance, schema=item, schema_path=idx))
+        if errors:
+            key = item["unionKey"]
+            if not selected_errors and _evaluate_unionKey(key, instance):
+                selected_errors = errors
+        else:
+            valid.append(item)
+
+    if len(valid) == 1:
+        # No errors.
+        return
+
+    if len(valid) > 1:
+        yield jsonschema.ValidationError(f"bug in validation! Multiple schemas matched: {valid}")
+        return
+
+    if selected_errors:
+        yield from selected_errors
+        return
+
+    default_message = det_one_of.get("defaultMessage", "union failed to validate")
+    yield jsonschema.ValidationError(default_message)
+
+
+def _evaluate_unionKey(key: str, instance: Any) -> bool:
+    """
+    unionKey is part of the union extension.  It allows for concisely describing when an instance
+    of data "should" match a given portion of a subschema of a union type, even when it doesn't
+    fully match.  unionKey allows us to select the correct error message to show to the user from
+    the union type.
+    """
+    if key is None:
+        return False
+
+    if isinstance(key, str):
+        if key == "always":
+            return True
+
+        if key == "never":
+            return False
+
+        # All other valid keys have arguments.
+        key, arg = key.split(":", 1)
+        if key == "not":
+            return not _evaluate_unionKey(arg, instance)
+
+        if key == "const":
+            # "const:NAME=VALUE" returns True when the instance has NAME and it evalutes to VALUE.
+            name, value = arg.split("=", 1)
+            if not isinstance(instance, dict):
+                return False
+            return instance.get(name) == value
+
+        if key == "singleproperty":
+            # "singleproperty:ATTR" returns True when the instance has ATTR as its only key.
+            if not isinstance(instance, dict):
+                return False
+            if len(instance) != 1:
+                return False
+            return arg in instance
+
+        if key == "type":
+            # "type:TYPE" returns True when the instance's json type is TYPE.
+            assert arg in ["array", "object"]
+            if arg == "array":
+                return isinstance(instance, list)
+            if arg == "object":
+                return isinstance(instance, dict)
+
+        if key == "hasattr":
+            # hasattr:ATTR returns True when the instance has the attribute ATTR.
+            return isinstance(instance, dict) and arg in instance
+
+    raise ValueError(f"invalid unionKey: {key}")
+
+
+def checks(
+    validator: jsonschema.Draft7Validator, checks: Dict, instance: Any, schema: Dict
+) -> Iterator[jsonschema.ValidationError]:
+    """
+    checks is a simple extension that returns a specific error if a subschema fails to match.
+
+    The keys of the "checks" dictionary are the user-facing messages, and the values are the
+    subschemas that must match.
+
+    Example:
+
+        "checks": {
+            "you must specify an entrypoint that references the trial class":{
+                ... (schema which allows Native API or requires that entrypoint is set) ...
+            },
+            "you requested a bayesian search but hyperband is way better": {
+                ... (schema which checks if you try searcher.name=baysian) ...
+            }
+        }
+    """
+    for msg, subschema in schema["checks"].items():
+        errors = list(validator.descend(instance, schema=subschema))
+        if errors:
+            yield jsonschema.ValidationError(msg)
+
+
+def compareProperties(
+    validator: jsonschema.Draft7Validator, compare: Dict, instance: Any, schema: Dict
+) -> Iterator[jsonschema.ValidationError]:
+    """
+    compareProperties allows a schema to compare values in the instance against each other.
+    Amazingly, json-schema does not have a built-in way to do this.
+
+    Example: ensuring that hyperparmeter minval is less than maxval:
+
+        "compareProperties": {
+            "type": "a<b",
+            "a": "minval",
+            "b": "maxval"
+        }
+    """
+    if not validator.is_type(instance, "object"):
+        return
+
+    def get_by_path(path: str) -> Any:
+        obj = instance
+        for key in path.split("."):
+            if not obj:
+                return None
+            obj = obj.get(key)
+        return obj
+
+    a_path = compare["a"]
+    a = get_by_path(a_path)
+
+    b_path = compare["b"]
+    b = get_by_path(b_path)
+
+    if a is None or b is None:
+        return
+
+    typ = compare["type"]
+
+    if typ == "a<b":
+        if a >= b:
+            yield jsonschema.ValidationError(f"{a_path} must be less than {b_path}")
+        return
+
+    if typ == "same_units":
+        # same_units refers to a Length object.
+        if not isinstance(a, dict) or not isinstance(b, dict):
+            return
+        if next(iter(a.keys())) != next(iter(b.keys())):
+            yield jsonschema.ValidationError(
+                f"{a_path} must be defined in the same units as {b_path}"
+            )
+        return
+
+    if typ == "length_a<length_b":
+        # length_a<length_b compares two length objects.
+        if not isinstance(a, dict) or not isinstance(b, dict):
+            return
+        # Assume the same units.
+        length_a = next(iter(a.values()))
+        length_b = next(iter(b.values()))
+        if not isinstance(length_a, int) or not isinstance(length_b, int):
+            return
+        if length_a >= length_b:
+            yield jsonschema.ValidationError(f"{a_path} must be less than {b_path}")
+        return
+
+    if typ == "a_is_subdir_of_b":
+        a_norm = os.path.normpath(a)
+        b_norm = os.path.normpath(b)
+        if os.path.isabs(a_norm):
+            if not a_norm.startswith(b_norm):
+                yield jsonschema.ValidationError(f"{a_path} must be a subdirectory of {b_path}")
+        else:
+            if a_norm.startswith(".."):
+                yield jsonschema.ValidationError(f"{a_path} must be a subdirectory of {b_path}")
+        return
+
+    raise ValueError(f"unrecognized comparison {compare[typ]}")
+
+
+def conditional(
+    validator: jsonschema.Draft7Validator, conditional: Dict, instance: Any, schema: Dict
+) -> Iterator[jsonschema.ValidationError]:
+    """
+    conditional enforces one subschema only when some other schema is satisified.  The other schema
+    can be negated by marking it as "unless" insted of "when".
+
+    Only the error from the "enforce" clause is ever shown.
+
+    Example: when records per epoch not set, forbid epoch lengths:
+
+        "conditional": {
+            "when": {
+                ... (schema that checks if records_per_epoch is unset) ...
+            },
+            "enforce": {
+                ... (schema that checks that epoch lengths are not used) ...
+            }
+        }
+    """
+    when = conditional.get("when")
+    unless = conditional.get("unless")
+    enforce = conditional["enforce"]
+
+    if when is not None:
+        if list(validator.descend(instance, schema=when, schema_path="when")):
+            # "when" clause failed, return early.
+            return
+    else:
+        assert unless is not None, "invalid schema"
+        if not list(validator.descend(instance, schema=unless, schema_path="unless")):
+            # "unless" clause passed, returned early.
+            return
+
+    # Enforce the "enforce" clause.
+    yield from validator.descend(instance, schema=enforce, schema_path="enforce")
+
+
+def eventuallyRequired(
+    validator: jsonschema.Draft7Validator,
+    eventuallyRequired: Any,
+    instance: List,
+    schema: Dict,
+) -> Iterator[jsonschema.ValidationError]:
+    """
+    eventuallyRequred allows for two-step validation.  This is a requirement specific to Determined
+    because there are fields required (checkpoint_storage) but which may not be present in what the
+    user actually submits, since a cluster default may be present.
+
+    eventuallyRequired behaves identically to required, only when building the validator, it is
+    possible to not include the eventuallyRequired extension; making it possible to *not* enforce
+    eventuallyRequired at specific times.
+    """
+    for key in eventuallyRequired:
+        if key not in instance:
+            yield jsonschema.ValidationError(f"{key} is a required property")

--- a/common/determined_common/schemas/util.py
+++ b/common/determined_common/schemas/util.py
@@ -1,0 +1,14 @@
+from typing import Any, List
+
+
+def _path_string(json_path: str) -> str:
+    return "".join([f"[{p}]" if isinstance(p, int) else f".{p}" for p in json_path])
+
+
+def _fmt_msg(e: Any) -> str:
+    path = _path_string(e.absolute_path)
+    return f"<config>{path}: {e.message}"
+
+
+def format_validation_errors(errors: List) -> List[str]:
+    return sorted(_fmt_msg(e) for e in errors)

--- a/common/tests/test_schemas.py
+++ b/common/tests/test_schemas.py
@@ -1,0 +1,65 @@
+import os
+from typing import Any, Dict, Iterator, List, Optional
+
+from determined_common import yaml
+from determined_common.schemas import expconf
+
+test_cases_path = os.path.join(os.path.dirname(__file__), "..", "..", "schemas", "test_cases", "v1")
+
+
+def cases_files() -> Iterator["str"]:
+    for case_file in os.listdir(test_cases_path):
+        if case_file.endswith(".yaml"):
+            yield os.path.join(test_cases_path, case_file)
+
+
+class Case:
+    def __init__(
+        self,
+        name: str,
+        case: Any,
+        matches: Optional[List[str]] = None,
+        errors: Optional[Dict[str, str]] = None,
+    ) -> None:
+        self.name = name
+        self.case = case
+        self.matches = matches
+        self.errors = errors
+
+    def run(self) -> None:
+        self.run_matches()
+        self.run_errors()
+
+    def run_matches(self) -> None:
+        if not self.matches:
+            return
+        for url in self.matches:
+            errors = expconf.validation_errors(self.case, url)
+            if not errors:
+                continue
+            raise ValueError(f"'{self.name}' failed against {url}:\n - " + "\n - ".join(errors))
+
+    def run_errors(self) -> None:
+        if not self.errors:
+            return
+        for url, expected in self.errors.items():
+            errors = expconf.validation_errors(self.case, url)
+            assert errors, f"'{self.name}' matched {url} unexpectedly"
+            for exp in expected:
+                for err in errors:
+                    if exp in err:
+                        break
+                else:
+                    msg = f"while testing '{self.name}', expected to see\n"
+                    msg += f"    {exp}\n"
+                    msg += "but it was not found in any of\n    "
+                    msg += "\n    ".join(errors)
+                    raise ValueError(msg)
+
+
+def test_v1() -> None:
+    for cases_file in cases_files():
+        with open(cases_file) as f:
+            cases = yaml.safe_load(f)
+        for case in cases:
+            Case(**case).run()

--- a/master/.gitignore
+++ b/master/.gitignore
@@ -1,7 +1,7 @@
 # Build directory
 build/
 
-# Generated LICENSE file
+# Generated files
 packaging/LICENSE
 
 # Dist directory

--- a/master/.golangci.yml
+++ b/master/.golangci.yml
@@ -8,6 +8,10 @@ run:
   # The exit code when at least one issue was found.
   issues-exit-code: 1
 
+  # Exclude generated code.
+  skip-files:
+    pkg/schemas/expconf/v1_gen.go
+
 output:
   # Linter output format.
   format: colored-line-number

--- a/master/Makefile
+++ b/master/Makefile
@@ -1,10 +1,30 @@
+GENERATED_COMMITTED := pkg/schemas/expconf/v1_gen.go
+GENERATED := $(GENERATED_COMMITTED) packaging/LICENSE
+
 export VERSION := $(shell cat ../VERSION)
 export GO111MODULE := on
 
 .PHONY: clean
-clean:
+clean: ungen
 	rm -rf dist
 	rm -rf build
+
+.PHONY: ungen
+ungen:
+	rm -f $(GENERATED)
+
+.PHONY: gen
+gen: $(GENERATED)
+
+.PHONY: force-gen
+force-gen:
+	touch ../schemas/gen.py
+
+.PHONY: check-gen
+check-gen: force-gen $(GENERATED_COMMITTED)
+	# Checking that committed, generated code is up-to-date by ensuring that
+	# git reports the files as unchanged after forcibly regenerating the files:
+	test -z "$(shell git status --porcelain $(GENERATED_COMMITTED))"
 
 .PHONY: get-deps
 get-deps:
@@ -14,14 +34,14 @@ get-deps:
 	go install github.com/goreleaser/goreleaser
 
 .PHONY: build
-build:
+build: gen
 	go build \
 		-ldflags "-X github.com/determined-ai/determined/master/version.Version=$(VERSION)" \
 		-o build/determined-master \
 		./cmd/determined-master
 
 .PHONY: check
-check:
+check: check-gen
 	golangci-lint run --timeout 10m
 
 .PHONY: fmt
@@ -52,14 +72,11 @@ pre-package:
 	cp ../cli/dist/*.whl build/wheels/
 	cp ../harness/dist/*.whl build/wheels/
 
-packaging/LICENSE: $(shell find ../tools/scripts/licenses -type f)
-	../tools/scripts/gen-attributions.py agent $@
-
 .PHONY: package
 package: export DET_SEGMENT_MASTER_KEY ?=
 package: export DET_SEGMENT_WEBUI_KEY ?=
 package: export GORELEASER_CURRENT_TAG := $(VERSION)
-package: packaging/LICENSE
+package: gen
 	goreleaser --snapshot --rm-dist
 
 .PHONY: release
@@ -67,7 +84,7 @@ release: export DET_SEGMENT_MASTER_KEY ?=
 release: export DET_SEGMENT_WEBUI_KEY ?=
 release: export GORELEASER_CURRENT_TAG := $(VERSION)
 release: export GORELEASER_PREVIOUS_TAG := $(shell git tag --sort=-creatordate | grep -v "rc\|v" | grep "$(VERSION)" -A1 | sed -n '2 p')
-release: packaging/LICENSE
+release: gen
 	goreleaser --rm-dist
 
 .PHONY: publish
@@ -78,3 +95,13 @@ publish:
 publish-dev:
 	docker push determinedai/determined-master:$(shell git rev-parse HEAD)
 	docker push determinedai/determined-dev:determined-master-$(shell git rev-parse HEAD)
+
+packaging/LICENSE: $(shell find ../tools/scripts/licenses -type f)
+	../tools/scripts/gen-attributions.py master $@
+
+pkg/schemas/expconf/v1_gen.go: ../schemas/gen.py $(shell find ../schemas/expconf -name "*.json")
+	../schemas/gen.py \
+		--output $@ \
+		go \
+		$(shell find ../schemas/expconf/v1 -name "*.json")
+	goimports -l -local github.com/determined-ai -w $@

--- a/master/go.mod
+++ b/master/go.mod
@@ -37,6 +37,7 @@ require (
 	github.com/opencontainers/image-spec v1.0.1 // indirect
 	github.com/opentracing/opentracing-go v1.2.0
 	github.com/pkg/errors v0.9.1
+	github.com/santhosh-tekuri/jsonschema/v2 v2.2.0
 	github.com/segmentio/backo-go v0.0.0-20200129164019-23eae7c10bd3 // indirect
 	github.com/sirupsen/logrus v1.6.0
 	github.com/soheilhy/cmux v0.1.4

--- a/master/go.sum
+++ b/master/go.sum
@@ -698,6 +698,8 @@ github.com/ryancurrah/gomodguard v1.1.0/go.mod h1:4O8tr7hBODaGE6VIhfJDHcwzh5GUcc
 github.com/ryanrolds/sqlclosecheck v0.3.0 h1:AZx+Bixh8zdUBxUA1NxbxVAS78vTPq4rCb8OUZI9xFw=
 github.com/ryanrolds/sqlclosecheck v0.3.0/go.mod h1:1gREqxyTGR3lVtpngyFo3hZAgk0KCtEdgEkHwDbigdA=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
+github.com/santhosh-tekuri/jsonschema/v2 v2.2.0 h1:72xCpK0g27Y1is2lreGNcZhIX3ZCtRpkHvvHrHD+5y4=
+github.com/santhosh-tekuri/jsonschema/v2 v2.2.0/go.mod h1:yzJzKUGV4RbWqWIBBP4wSOBqavX5saE02yirLS0OTyg=
 github.com/sassoftware/go-rpmutils v0.0.0-20190420191620-a8f1baeba37b h1:+gCnWOZV8Z/8jehJ2CdqB47Z3S+SREmQcuXkRFLNsiI=
 github.com/sassoftware/go-rpmutils v0.0.0-20190420191620-a8f1baeba37b/go.mod h1:am+Fp8Bt506lA3Rk3QCmSqmYmLMnPDhdDUcosQCAx+I=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=

--- a/master/internal/core_experiment.go
+++ b/master/internal/core_experiment.go
@@ -22,6 +22,7 @@ import (
 	"github.com/determined-ai/determined/master/pkg/archive"
 	"github.com/determined-ai/determined/master/pkg/check"
 	"github.com/determined-ai/determined/master/pkg/model"
+	"github.com/determined-ai/determined/master/pkg/schemas/expconf"
 )
 
 // ExperimentRequestQuery contains values for the experiments request queries with defaults already
@@ -389,6 +390,11 @@ func (m *Master) parseCreateExperiment(params *CreateExperimentParams) (
 	}
 
 	if cerr := check.Validate(config); cerr != nil {
+		if ok, msgs := expconf.SaneYamlV1([]byte(params.ConfigBytes)); !ok {
+			// Return the errors from json-schema, which will be much clearer.
+			cerr = errors.New("\n" + strings.Join(msgs, "\n"))
+			return nil, false, errors.Wrap(cerr, "invalid experiment configuration")
+		}
 		return nil, false, errors.Wrap(cerr, "invalid experiment configuration")
 	}
 

--- a/master/pkg/model/hyperparameters_config.go
+++ b/master/pkg/model/hyperparameters_config.go
@@ -104,7 +104,7 @@ type IntHyperparameter struct {
 func (i IntHyperparameter) Validate() []error {
 	return []error{
 		check.GreaterThan(i.Maxval, i.Minval, "minval is greater than maxval"),
-		check.GreaterThan(i.Count, 0, "count must be >= 0"),
+		check.GreaterThan(i.Count, 0, "count must be > 0"),
 	}
 }
 
@@ -119,7 +119,7 @@ type DoubleHyperparameter struct {
 func (d DoubleHyperparameter) Validate() []error {
 	return []error{
 		check.GreaterThan(d.Maxval, d.Minval, "minval is greater than maxval"),
-		check.GreaterThan(d.Count, 0, "count must be >= 0"),
+		check.GreaterThan(d.Count, 0, "count must be > 0"),
 	}
 }
 
@@ -137,8 +137,8 @@ type LogHyperparameter struct {
 func (h *LogHyperparameter) Validate() []error {
 	return []error{
 		check.GreaterThan(h.Maxval, h.Minval, "minval is greater than maxval"),
-		check.GreaterThan(h.Base, 0.0, "base must be >= 0"),
-		check.GreaterThan(h.Count, 0, "count must be >= 0"),
+		check.GreaterThan(h.Base, 0.0, "base must be > 0"),
+		check.GreaterThan(h.Count, 0, "count must be > 0"),
 	}
 }
 

--- a/master/pkg/model/searcher_config.go
+++ b/master/pkg/model/searcher_config.go
@@ -3,6 +3,8 @@ package model
 import (
 	"encoding/json"
 
+	"github.com/pkg/errors"
+
 	"github.com/determined-ai/determined/master/pkg/check"
 	"github.com/determined-ai/determined/master/pkg/union"
 )
@@ -42,7 +44,7 @@ func (s *SearcherConfig) UnmarshalJSON(data []byte) error {
 		return err
 	}
 	type DefaultParser *SearcherConfig
-	return json.Unmarshal(data, DefaultParser(s))
+	return errors.Wrap(json.Unmarshal(data, DefaultParser(s)), "failed to parse searcher config")
 }
 
 // Unit implements the model.InUnits interface.

--- a/master/pkg/schemas/expconf/util.go
+++ b/master/pkg/schemas/expconf/util.go
@@ -1,0 +1,101 @@
+package expconf
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/ghodss/yaml"
+
+	"github.com/santhosh-tekuri/jsonschema/v2"
+)
+
+type (
+	// JSON is the type for arbitrary JSON.
+	JSON = interface{}
+	// JSONObject is the type for JSON objects.
+	JSONObject = map[string]interface{}
+	// JSONArray is the type for JSON arrays.
+	JSONArray = []interface{}
+)
+
+// jsonFromYaml takes yaml-formatted bytes and converts them to json-format for the purpose of
+// applying json-schema validation.
+func jsonFromYaml(byts []byte) ([]byte, error) {
+	var blob JSON
+	err := yaml.Unmarshal(byts, &blob)
+	if err != nil {
+		return nil, err
+	}
+
+	return json.Marshal(blob)
+}
+
+// renderJSONPointer renders "#/key/0/key" as ".key[0].key".  Return the raw ptr in case of errors.
+func renderJSONPointer(ptr string, instance JSON) string {
+	out := ""
+	split := strings.Split(ptr, "/")[1:]
+
+	for _, s := range split {
+		switch tInstance := instance.(type) {
+		case JSONArray:
+			i, err := strconv.Atoi(s)
+			if err != nil || i >= len(tInstance) {
+				return ptr
+			}
+			instance = tInstance[i]
+			out += fmt.Sprintf("[%d]", i)
+
+		case JSONObject:
+			var ok bool
+			instance, ok = tInstance[s]
+			if !ok {
+				return ptr
+			}
+			out += fmt.Sprintf(".%s", s)
+
+		default:
+			return ptr
+		}
+	}
+	return out
+}
+
+// getChildErrors takes a nested-tree-style jsonschema error and returns a flat list of leaf errors.
+func getChildErrors(valError *jsonschema.ValidationError, instance JSON) []string {
+	var errors []string
+
+	for _, subError := range valError.Causes {
+		errors = append(errors, getChildErrors(subError, instance)...)
+	}
+
+	if len(errors) > 0 {
+		sort.Strings(errors)
+		return errors
+	}
+
+	msg := valError.Message
+	displayPtr := renderJSONPointer(valError.InstancePtr, instance)
+	errors = append(errors, fmt.Sprintf("% *s<config>%v: %v", 0, "", displayPtr, msg))
+
+	return errors
+}
+
+// getRenderedErrors takes a jsonschema valiation plus the bytes that caused it and returns
+// user-facing errors.
+func getRenderedErrors(err error, byts []byte) []string {
+	// Make sure the input is even valid json, plus we'll need this to render the json pointer.
+	var instance JSON
+	if uErr := json.Unmarshal(byts, &instance); uErr != nil {
+		return []string{fmt.Sprintf("%v", uErr)}
+	}
+
+	tErr, ok := err.(*jsonschema.ValidationError)
+	if !ok {
+		return []string{fmt.Sprintf("%v", err)}
+	}
+
+	return getChildErrors(tErr, instance)
+}

--- a/master/pkg/schemas/expconf/v1.go
+++ b/master/pkg/schemas/expconf/v1.go
@@ -1,0 +1,131 @@
+package expconf
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/santhosh-tekuri/jsonschema/v2"
+
+	"github.com/determined-ai/determined/master/pkg/schemas/extensions"
+)
+
+var sanityValidatorsV1 = map[string]*jsonschema.Schema{}
+var completenessValidatorsV1 = map[string]*jsonschema.Schema{}
+
+// Create a jsonschema.Compiler with all the schemas preloaded.
+func newCompiler() *jsonschema.Compiler {
+	compiler := jsonschema.NewCompiler()
+
+	for url, byts := range schemaBytesMap() {
+		if err := compiler.AddResource(url, bytes.NewReader(byts)); err != nil {
+			panic("invalid schema: " + url)
+		}
+	}
+
+	return compiler
+}
+
+func getSanityValidatorV1(url string) *jsonschema.Schema {
+	if url == "" {
+		// By default, return the validator for the experiment config object.
+		url = parsedExperimentConfigV1().(JSONObject)["$id"].(string)
+	}
+
+	// Check if we have a pre-compiled validator already.
+	if validator, ok := sanityValidatorsV1[url]; ok {
+		return validator
+	}
+
+	compiler := newCompiler()
+
+	// Sanity check means eventuallyRequired isn't required yet.
+	compiler.Extensions["disallowProperties"] = extensions.DisallowPropertiesExtension()
+	compiler.Extensions["union"] = extensions.UnionExtension()
+	compiler.Extensions["checks"] = extensions.ChecksExtension()
+	compiler.Extensions["compareProperties"] = extensions.ComparePropertiesExtension()
+	compiler.Extensions["conditional"] = extensions.ConditionalExtension()
+
+	validator, err := compiler.Compile(url)
+	if err != nil {
+		panic("uncompilable schema: " + url)
+	}
+
+	// Remember this validator for later.
+	sanityValidatorsV1[url] = validator
+
+	return validator
+}
+
+func getCompletenessValidatorV1(url string) *jsonschema.Schema {
+	if url == "" {
+		// By default, return the validator for the experiment config object.
+		url = parsedExperimentConfigV1().(JSONObject)["$id"].(string)
+	}
+
+	if validator, ok := completenessValidatorsV1[url]; ok {
+		return validator
+	}
+
+	compiler := newCompiler()
+
+	// Completeness means eventuallyRequired is now required.
+	compiler.Extensions["disallowProperties"] = extensions.DisallowPropertiesExtension()
+	compiler.Extensions["union"] = extensions.UnionExtension()
+	compiler.Extensions["checks"] = extensions.ChecksExtension()
+	compiler.Extensions["compareProperties"] = extensions.ComparePropertiesExtension()
+	compiler.Extensions["conditional"] = extensions.ConditionalExtension()
+	compiler.Extensions["eventuallyRequired"] = extensions.EventuallyRequiredExtension()
+
+	validator, err := compiler.Compile(url)
+	if err != nil {
+		panic("uncompilable schema: " + url)
+	}
+
+	completenessValidatorsV1[url] = validator
+
+	return validator
+}
+
+// SaneYamlV1 validates yaml-formatted bytes, return if it was valid and a list of errors.
+// "Sane" means it might not satisfied the "eventuallyRequired" keywords but that everything else
+// is valid.
+func SaneYamlV1(byts []byte) (bool, []string) {
+	byts, err := jsonFromYaml(byts)
+	if err != nil {
+		return false, []string{fmt.Sprintf("%v", err)}
+	}
+	return SaneJSONV1(byts)
+}
+
+// SaneJSONV1 validates yaml-formatted bytes, return if it was valid and a list of errors.
+// "Sane" means it might not satisfied the "eventuallyRequired" keywords but that everything else
+// is valid.
+func SaneJSONV1(byts []byte) (bool, []string) {
+	schema := getSanityValidatorV1("")
+	err := schema.Validate(bytes.NewReader(byts))
+	if err == nil {
+		return true, nil
+	}
+
+	return false, getRenderedErrors(err, byts)
+}
+
+// CompleteYamlV1 validates yaml-formatted bytes, return if it was valid and a list of errors.
+func CompleteYamlV1(byts []byte) (bool, []string) {
+	byts, err := jsonFromYaml(byts)
+	if err != nil {
+		return false, []string{fmt.Sprintf("%v", err)}
+	}
+	return CompleteJSONV1(byts)
+}
+
+// CompleteJSONV1 validates json-formatted bytes, return if it was valid and a list of errors.
+func CompleteJSONV1(byts []byte) (bool, []string) {
+	schema := getCompletenessValidatorV1("")
+	err := schema.Validate(bytes.NewReader(byts))
+	if err == nil {
+		return true, nil
+	}
+
+	return false, getRenderedErrors(err, byts)
+}

--- a/master/pkg/schemas/expconf/v1_gen.go
+++ b/master/pkg/schemas/expconf/v1_gen.go
@@ -1,0 +1,2995 @@
+// This is a generated file.  Editing it will make you sad.
+
+package expconf
+
+import "encoding/json"
+
+var (
+	textBindMountV1 = []byte(`{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "http://determined.ai/schemas/expconf/v1/bind-mount.json",
+    "title": "BindMount",
+    "additionalProperties": false,
+    "required": [
+        "host_path",
+        "container_path"
+    ],
+    "type": "object",
+    "properties": {
+        "host_path": {
+            "type": "string",
+            "checks": {
+                "host_path must be an absolute path": {
+                    "pattern": "^/"
+                }
+            }
+        },
+        "container_path": {
+            "type": "string",
+            "checks": {
+                "container_path must not be \".\"": {
+                    "not": {
+                        "const": "."
+                    }
+                }
+            }
+        },
+        "read_only": {
+            "type": [
+                "boolean",
+                "null"
+            ],
+            "default": false
+        },
+        "propagation": {
+            "type": [
+                "string",
+                "null"
+            ],
+            "default": "rprivate"
+        }
+    }
+}
+`)
+	textCheckDataLayerCacheV1 = []byte(`{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "http://determined.ai/schemas/expconf/v1/check-data-layer-cache.json",
+    "title": "CheckDataLayerCache",
+    "checks": {
+        "local_cache_container_path must be specified if local_cache_host_path is set": {
+            "not": {
+                "required": [
+                    "local_cache_host_path"
+                ],
+                "properties": {
+                    "local_cache_container_path": {
+                        "type": "null"
+                    },
+                    "local_cache_host_path": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "local_cache_host_path must be specified if local_cache_container_path is set": {
+            "not": {
+                "required": [
+                    "local_cache_container_path"
+                ],
+                "properties": {
+                    "local_cache_container_path": {
+                        "type": "string"
+                    },
+                    "local_cache_host_path": {
+                        "type": "null"
+                    }
+                }
+            }
+        }
+    }
+}
+`)
+	textCheckEpochNotUsedV1 = []byte(`{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "http://determined.ai/schemas/expconf/v1/check-epoch-not-used.json",
+    "title": "CheckEpochNotUsed",
+    "additionalProperties": {
+        "$ref": "http://determined.ai/schemas/expconf/v1/check-epoch-not-used.json"
+    },
+    "items": {
+        "$ref": "http://determined.ai/schemas/expconf/v1/check-epoch-not-used.json"
+    },
+    "checks": {
+        "must specify the top-level records_per_epoch when this field is in terms of epochs": {
+            "properties": {
+                "epochs": {
+                    "not": {
+                        "type": "number"
+                    }
+                }
+            }
+        }
+    }
+}
+`)
+	textCheckGlobalBatchSizeV1 = []byte(`{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "http://determined.ai/schemas/expconf/v1/check-global-batch-size.json",
+    "title": "CheckGlobalBatchSize",
+    "union": {
+        "defaultMessage": "is neither a positive integer nor an int hyperparameter",
+        "items": [
+            {
+                "unionKey": "const:type=int",
+                "allOf": [
+                    {
+                        "$ref": "http://determined.ai/schemas/expconf/v1/hyperparameter-int.json"
+                    },
+                    {
+                        "properties": {
+                            "minval": {
+                                "type": "number",
+                                "minimum": 1
+                            }
+                        }
+                    }
+                ]
+            },
+            {
+                "unionKey": "const:type=const",
+                "allOf": [
+                    {
+                        "$ref": "http://determined.ai/schemas/expconf/v1/hyperparameter-const.json"
+                    },
+                    {
+                        "properties": {
+                            "val": {
+                                "type": "number",
+                                "minimum": 1
+                            }
+                        }
+                    }
+                ]
+            },
+            {
+                "unionKey": "const:type=categorical",
+                "allOf": [
+                    {
+                        "$ref": "http://determined.ai/schemas/expconf/v1/hyperparameter-categorical.json"
+                    },
+                    {
+                        "properties": {
+                            "vals": {
+                                "type": "array",
+                                "items": {
+                                    "type": "integer",
+                                    "minimum": 1
+                                }
+                            }
+                        }
+                    }
+                ]
+            },
+            {
+                "unionKey": "never",
+                "type": "integer",
+                "minimum": 1
+            }
+        ]
+    }
+}
+`)
+	textCheckGridHyperparameterV1 = []byte(`{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "http://determined.ai/schemas/expconf/v1/check-grid-hyperparameter.json",
+    "title": "CheckGridHyperparameter",
+    "union": {
+        "items": [
+            {
+                "unionKey": "type:array",
+                "type": "array",
+                "items": {
+                    "$ref": "http://determined.ai/schemas/expconf/v1/check-grid-hyperparameter.json"
+                }
+            },
+            {
+                "unionKey": "not:hasattr:type",
+                "type": "object",
+                "properties": {
+                    "type": false
+                },
+                "additionalProperties": {
+                    "$ref": "http://determined.ai/schemas/expconf/v1/check-grid-hyperparameter.json"
+                }
+            },
+            {
+                "unionKey": "never",
+                "not": {
+                    "type": [
+                        "object",
+                        "array"
+                    ]
+                }
+            },
+            {
+                "unionKey": "hasattr:type",
+                "type": "object",
+                "required": [
+                    "type"
+                ],
+                "properties": {
+                    "type": {
+                        "type": "string"
+                    }
+                },
+                "checks": {
+                    "grid search is in use but count was not provided": {
+                        "conditional": {
+                            "$comment": "unless type is not double/log/int, expect non-null count",
+                            "unless": {
+                                "not": {
+                                    "properties": {
+                                        "type": {
+                                            "enum": [
+                                                "double",
+                                                "log",
+                                                "int"
+                                            ]
+                                        }
+                                    }
+                                }
+                            },
+                            "enforce": {
+                                "not": {
+                                    "properties": {
+                                        "count": {
+                                            "type": "null"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        ]
+    }
+}
+`)
+	textCheckPositiveLengthV1 = []byte(`{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "http://determined.ai/schemas/expconf/v1/check-positive-length.json",
+    "title": "CheckPositiveLength",
+    "allOf": [
+        {
+            "$ref": "http://determined.ai/schemas/expconf/v1/length.json"
+        },
+        {
+            "additionalProperties": {
+                "type": "integer",
+                "minimum": 1
+            }
+        }
+    ]
+}
+`)
+	textCheckpointStorageConfigV1 = []byte(`{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "http://determined.ai/schemas/expconf/v1/checkpoint-storage.json",
+    "title": "CheckpointStorageConfig",
+    "union": {
+        "defaultMessage": "is not an object where object[\"type\"] is one of 'shared_fs', 'hdfs', 's3', or 'gcs'",
+        "items": [
+            {
+                "unionKey": "const:type=shared_fs",
+                "$ref": "http://determined.ai/schemas/expconf/v1/shared-fs.json"
+            },
+            {
+                "unionKey": "const:type=hdfs",
+                "$ref": "http://determined.ai/schemas/expconf/v1/hdfs.json"
+            },
+            {
+                "unionKey": "const:type=s3",
+                "$ref": "http://determined.ai/schemas/expconf/v1/s3.json"
+            },
+            {
+                "unionKey": "const:type=gcs",
+                "$ref": "http://determined.ai/schemas/expconf/v1/gcs.json"
+            }
+        ]
+    }
+}
+`)
+	textDataLayerGCSConfigV1 = []byte(`{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "http://determined.ai/schemas/expconf/v1/data-layer-gcs.json",
+    "title": "DataLayerGCSConfig",
+    "type": "object",
+    "additionalProperties": false,
+    "required": [
+        "type",
+        "bucket",
+        "bucket_directory_path"
+    ],
+    "properties": {
+        "type": {
+            "const": "gcs"
+        },
+        "bucket": {
+            "type": "string"
+        },
+        "bucket_directory_path": {
+            "type": "string"
+        },
+        "local_cache_host_path": {
+            "type": [
+                "string",
+                "null"
+            ],
+            "checks": {
+                "local_cache_host_path must be an absolute path": {
+                    "pattern": "^/"
+                }
+            },
+            "default": null
+        },
+        "local_cache_container_path": {
+            "type": [
+                "string",
+                "null"
+            ],
+            "checks": {
+                "local_cache_container_path must be an absolute path": {
+                    "pattern": "^/"
+                }
+            },
+            "default": null
+        }
+    },
+    "allOf": [
+        {
+            "$ref": "http://determined.ai/schemas/expconf/v1/check-data-layer-cache.json"
+        }
+    ]
+}
+`)
+	textDataLayerS3ConfigV1 = []byte(`{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "http://determined.ai/schemas/expconf/v1/data-layer-s3.json",
+    "title": "DataLayerS3Config",
+    "type": "object",
+    "additionalProperties": false,
+    "required": [
+        "type",
+        "bucket",
+        "bucket_directory_path"
+    ],
+    "properties": {
+        "type": {
+            "const": "s3"
+        },
+        "bucket": {
+            "type": "string"
+        },
+        "bucket_directory_path": {
+            "type": "string"
+        },
+        "local_cache_host_path": {
+            "type": [
+                "string",
+                "null"
+            ],
+            "checks": {
+                "local_cache_host_path must be an absolute path": {
+                    "pattern": "^/"
+                }
+            },
+            "default": null
+        },
+        "local_cache_container_path": {
+            "type": [
+                "string",
+                "null"
+            ],
+            "checks": {
+                "local_cache_container_path must be an absolute path": {
+                    "pattern": "^/"
+                }
+            },
+            "default": null
+        },
+        "access_key": {
+            "type": [
+                "string",
+                "null"
+            ],
+            "default": null
+        },
+        "secret_key": {
+            "type": [
+                "string",
+                "null"
+            ],
+            "default": null
+        },
+        "endpoint_url": {
+            "type": [
+                "string",
+                "null"
+            ],
+            "default": null
+        }
+    },
+    "allOf": [
+        {
+            "$ref": "http://determined.ai/schemas/expconf/v1/check-data-layer-cache.json"
+        }
+    ]
+}
+`)
+	textDataLayerSharedFSConfigV1 = []byte(`{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "http://determined.ai/schemas/expconf/v1/data-layer-shared-fs.json",
+    "title": "DataLayerSharedFSConfig",
+    "type": "object",
+    "additionalProperties": false,
+    "required": [
+        "type"
+    ],
+    "properties": {
+        "type": {
+            "const": "shared_fs"
+        },
+        "host_storage_path": {
+            "type": [
+                "string",
+                "null"
+            ],
+            "checks": {
+                "host_storage_path must be an absolute path": {
+                    "pattern": "^/"
+                }
+            },
+            "default": null
+        },
+        "container_storage_path": {
+            "type": [
+                "string",
+                "null"
+            ],
+            "checks": {
+                "container_storage_path must be an absolute path": {
+                    "pattern": "^/"
+                }
+            },
+            "default": null
+        }
+    }
+}
+`)
+	textDataLayerConfigV1 = []byte(`{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "http://determined.ai/schemas/expconf/v1/data-layer.json",
+    "title": "DataLayerConfig",
+    "union": {
+        "defaultMessage": "is not an object where object[\"type\"] is one of 'shared_fs', 's3', or 'gcs'",
+        "items": [
+            {
+                "unionKey": "const:type=shared_fs",
+                "$ref": "http://determined.ai/schemas/expconf/v1/data-layer-shared-fs.json"
+            },
+            {
+                "unionKey": "const:type=gcs",
+                "$ref": "http://determined.ai/schemas/expconf/v1/data-layer-gcs.json"
+            },
+            {
+                "unionKey": "const:type=s3",
+                "$ref": "http://determined.ai/schemas/expconf/v1/data-layer-s3.json"
+            }
+        ]
+    }
+}
+`)
+	textEnvironmentImageV1 = []byte(`{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "http://determined.ai/schemas/expconf/v1/environment-image.json",
+    "title": "EnvironmentImage",
+    "union": {
+        "defaultMessage": "is neither a string nor a map of cpu/gpu to strings",
+        "items": [
+            {
+                "unionKey": "never",
+                "type": "object",
+                "additionalProperties": false,
+                "required": [
+                    "cpu",
+                    "gpu"
+                ],
+                "properties": {
+                    "cpu": {
+                        "type": "string"
+                    },
+                    "gpu": {
+                        "type": "string"
+                    }
+                }
+            },
+            {
+                "unionKey": "never",
+                "type": "string"
+            }
+        ]
+    }
+}
+`)
+	textEnvironmentVariablesV1 = []byte(`{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "http://determined.ai/schemas/expconf/v1/environment-variables.json",
+    "title": "EnvironmentVariables",
+    "union": {
+        "defaultMessage": "is neither a list of strings nor a map of cpu/gpu to lists of strings",
+        "items": [
+            {
+                "unionKey": "never",
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "cpu": {
+                        "type": [
+                            "array",
+                            "null"
+                        ],
+                        "items": {
+                            "type": "string"
+                        },
+                        "default": []
+                    },
+                    "gpu": {
+                        "type": [
+                            "array",
+                            "null"
+                        ],
+                        "items": {
+                            "type": "string"
+                        },
+                        "default": []
+                    }
+                }
+            },
+            {
+                "unionKey": "never",
+                "type": "array",
+                "items": {
+                    "type": "string"
+                }
+            }
+        ]
+    }
+}
+`)
+	textEnvironmentConfigV1 = []byte(`{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "http://determined.ai/schemas/expconf/v1/environment.json",
+    "title": "EnvironmentConfig",
+    "type": "object",
+    "additionalProperties": false,
+    "required": [],
+    "properties": {
+        "image": {
+            "type": [
+                "object",
+                "null"
+            ],
+            "$ref": "http://determined.ai/schemas/expconf/v1/environment-image.json",
+            "default": null
+        },
+        "environment_variables": {
+            "type": [
+                "object",
+                "null"
+            ],
+            "$ref": "http://determined.ai/schemas/expconf/v1/environment-variables.json",
+            "default": []
+        },
+        "ports": {
+            "type": [
+                "object",
+                "null"
+            ],
+            "additionalProperties": {
+                "type": "integer"
+            },
+            "default": {}
+        },
+        "force_pull_image": {
+            "type": [
+                "boolean",
+                "null"
+            ],
+            "default": false
+        },
+        "pod_spec": {
+            "type": [
+                "object",
+                "null"
+            ],
+            "default": null,
+            "disallowProperties": {
+                "name": "pod Name is not a configurable option",
+                "name_space": "pod NameSpace is not a configurable option"
+            },
+            "properties": {
+                "spec": {
+                    "type": [
+                        "object",
+                        "null"
+                    ],
+                    "default": null,
+                    "properties": {
+                        "containers": {
+                            "type": [
+                                "array",
+                                "null"
+                            ],
+                            "default": null,
+                            "items": {
+                                "type": "object",
+                                "disallowProperties": {
+                                    "image": "container Image is not configurable, set it in the experiment config",
+                                    "command": "container Command is not configurable",
+                                    "args": "container Args are not configurable",
+                                    "working_dir": "container WorkingDir is not configurable",
+                                    "ports": "container Ports are not configurable",
+                                    "env_from": "container EnvFrom is not configurable",
+                                    "env": "container Env is not configurable, set it in the experiment config",
+                                    "liveness_probe": "container LivenessProbe is not configurable",
+                                    "readiness_probe": "container ReadinessProbe is not configurable",
+                                    "startup_probe": "container StartupProbe is not configurable",
+                                    "lifecycle": "container Lifecycle is not configurable",
+                                    "termination_message_path": "container TerminationMessagePath is not configurable",
+                                    "termination_message_policy": "container TerminationMessagePolicy is not configurable",
+                                    "image_pull_policy": "container ImagePullPolicy is not configurable, set it in the experiment config",
+                                    "security_context": "container SecurityContext is not configurable, set it in the experiment config"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+`)
+	textExperimentConfigV1 = []byte(`{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "http://determined.ai/schemas/expconf/v1/experiment.json",
+    "title": "ExperimentConfig",
+    "type": "object",
+    "additionalProperties": false,
+    "required": [
+        "hyperparameters",
+        "searcher"
+    ],
+    "eventuallyRequired": [
+        "checkpoint_storage"
+    ],
+    "properties": {
+        "bind_mounts": {
+            "type": [
+                "array",
+                "null"
+            ],
+            "items": {
+                "$ref": "http://determined.ai/schemas/expconf/v1/bind-mount.json"
+            },
+            "default": []
+        },
+        "checkpoint_policy": {
+            "enum": [
+                null,
+                "best",
+                "all",
+                "none"
+            ],
+            "default": "best"
+        },
+        "checkpoint_storage": {
+            "type": [
+                "object",
+                "null"
+            ],
+            "$ref": "http://determined.ai/schemas/expconf/v1/checkpoint-storage.json",
+            "default": "null"
+        },
+        "data": {
+            "type": [
+                "object",
+                "null"
+            ],
+            "default": {}
+        },
+        "data_layer": {
+            "type": [
+                "object",
+                "null"
+            ],
+            "$ref": "http://determined.ai/schemas/expconf/v1/data-layer.json",
+            "default": {
+                "type": "shared_fs"
+            }
+        },
+        "debug": {
+            "type": [
+                "boolean",
+                "null"
+            ],
+            "default": false
+        },
+        "description": {
+            "type": [
+                "string",
+                "null"
+            ],
+            "default": ""
+        },
+        "entrypoint": {
+            "type": [
+                "string",
+                "null"
+            ],
+            "checks": {
+                "entrypoint must be of the form \"module.submodule:ClassName\"": {
+                    "pattern": "^[a-zA-Z0-9_.]+:[a-zA-Z0-9_]+$"
+                }
+            },
+            "default": null
+        },
+        "environment": {
+            "type": [
+                "object",
+                "null"
+            ],
+            "$ref": "http://determined.ai/schemas/expconf/v1/environment.json",
+            "default": null
+        },
+        "hyperparameters": {
+            "type": "object",
+            "required": [
+                "global_batch_size"
+            ],
+            "properties": {
+                "global_batch_size": {
+                    "$ref": "http://determined.ai/schemas/expconf/v1/check-global-batch-size.json"
+                }
+            },
+            "additionalProperties": {
+                "$ref": "http://determined.ai/schemas/expconf/v1/hyperparameter.json"
+            }
+        },
+        "internal": {
+            "type": [
+                "object",
+                "null"
+            ],
+            "default": null
+        },
+        "labels": {
+            "type": [
+                "array",
+                "null"
+            ],
+            "items": {
+                "type": "string"
+            },
+            "default": null
+        },
+        "max_restarts": {
+            "type": [
+                "integer",
+                "null"
+            ],
+            "minimum": 0,
+            "default": 5
+        },
+        "min_checkpoint_period": {
+            "type": [
+                "object",
+                "null"
+            ],
+            "$ref": "http://determined.ai/schemas/expconf/v1/length.json",
+            "default": {
+                "batches": 0
+            }
+        },
+        "min_validation_period": {
+            "type": [
+                "object",
+                "null"
+            ],
+            "$ref": "http://determined.ai/schemas/expconf/v1/length.json",
+            "default": {
+                "batches": 0
+            }
+        },
+        "optimizations": {
+            "type": [
+                "object",
+                "null"
+            ],
+            "$ref": "http://determined.ai/schemas/expconf/v1/optimizations.json",
+            "default": {}
+        },
+        "perform_initial_validation": {
+            "type": [
+                "boolean",
+                "null"
+            ],
+            "default": true
+        },
+        "records_per_epoch": {
+            "type": [
+                "integer",
+                "null"
+            ],
+            "default": 0
+        },
+        "reproducibility": {
+            "type": [
+                "object",
+                "null"
+            ],
+            "additionalProperties": false,
+            "properties": {
+                "experiment_seed": {
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "default": null
+                }
+            },
+            "default": {}
+        },
+        "resources": {
+            "type": [
+                "object",
+                "null"
+            ],
+            "$ref": "http://determined.ai/schemas/expconf/v1/resources.json",
+            "default": {}
+        },
+        "scheduling_unit": {
+            "type": [
+                "integer",
+                "null"
+            ],
+            "minimum": 1,
+            "default": 100
+        },
+        "searcher": {
+            "$ref": "http://determined.ai/schemas/expconf/v1/searcher.json"
+        },
+        "security": {
+            "type": "null",
+            "default": "null"
+        },
+        "tensorboard_storage": {
+            "type": "null",
+            "default": "null"
+        }
+    },
+    "allOf": [
+        {
+            "conditional": {
+                "$comment": "when grid search is in use, expect hp counts",
+                "when": {
+                    "properties": {
+                        "searcher": {
+                            "properties": {
+                                "name": {
+                                    "const": "grid"
+                                }
+                            }
+                        }
+                    }
+                },
+                "enforce": {
+                    "properties": {
+                        "hyperparameters": {
+                            "additionalProperties": {
+                                "$ref": "http://determined.ai/schemas/expconf/v1/check-grid-hyperparameter.json"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        {
+            "conditional": {
+                "$comment": "when records per epoch not set, forbid epoch lengths",
+                "when": {
+                    "properties": {
+                        "records_per_epoch": {
+                            "maximum": 0
+                        }
+                    }
+                },
+                "enforce": {
+                    "properties": {
+                        "min_validation_period": {
+                            "$ref": "http://determined.ai/schemas/expconf/v1/check-epoch-not-used.json"
+                        },
+                        "min_checkpoint_period": {
+                            "$ref": "http://determined.ai/schemas/expconf/v1/check-epoch-not-used.json"
+                        },
+                        "searcher": {
+                            "$ref": "http://determined.ai/schemas/expconf/v1/check-epoch-not-used.json"
+                        }
+                    }
+                }
+            }
+        }
+    ],
+    "checks": {
+        "must specify an entrypoint that references the trial class": {
+            "conditional": {
+                "$comment": "when internal.native is null, expect an entrypoint",
+                "when": {
+                    "properties": {
+                        "internal": {
+                            "properties": {
+                                "native": {
+                                    "type": "null"
+                                }
+                            }
+                        }
+                    }
+                },
+                "enforce": {
+                    "not": {
+                        "properties": {
+                            "entrypoint": {
+                                "type": "null"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+`)
+	textGCSConfigV1 = []byte(`{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "http://determined.ai/schemas/expconf/v1/gcs.json",
+    "title": "GCSConfig",
+    "type": "object",
+    "additionalProperties": false,
+    "required": [
+        "type",
+        "bucket"
+    ],
+    "properties": {
+        "type": {
+            "const": "gcs"
+        },
+        "bucket": {
+            "type": "string"
+        },
+        "save_experiment_best": {
+            "type": [
+                "integer",
+                "null"
+            ],
+            "default": 0,
+            "minimum": 0
+        },
+        "save_trial_best": {
+            "type": [
+                "integer",
+                "null"
+            ],
+            "default": 1,
+            "minimum": 0
+        },
+        "save_trial_latest": {
+            "type": [
+                "integer",
+                "null"
+            ],
+            "default": 1,
+            "minimum": 0
+        }
+    }
+}
+`)
+	textHDFSConfigV1 = []byte(`{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "http://determined.ai/schemas/expconf/v1/hdfs.json",
+    "title": "HDFSConfig",
+    "type": "object",
+    "additionalProperties": false,
+    "required": [
+        "type",
+        "hdfs_url",
+        "hdfs_path"
+    ],
+    "properties": {
+        "type": {
+            "const": "hdfs"
+        },
+        "hdfs_url": {
+            "type": "string"
+        },
+        "hdfs_path": {
+            "type": "string",
+            "checks": {
+                "hdfs_path must be an absolute path": {
+                    "pattern": "^/"
+                }
+            }
+        },
+        "user": {
+            "type": [
+                "string",
+                "null"
+            ],
+            "default": null
+        },
+        "save_experiment_best": {
+            "type": [
+                "integer",
+                "null"
+            ],
+            "default": 0,
+            "minimum": 0
+        },
+        "save_trial_best": {
+            "type": [
+                "integer",
+                "null"
+            ],
+            "default": 1,
+            "minimum": 0
+        },
+        "save_trial_latest": {
+            "type": [
+                "integer",
+                "null"
+            ],
+            "default": 1,
+            "minimum": 0
+        }
+    }
+}
+`)
+	textCategoricalHyperparameterV1 = []byte(`{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "http://determined.ai/schemas/expconf/v1/hyperparameter-categorical.json",
+    "title": "CategoricalHyperparameter",
+    "type": "object",
+    "additionalProperties": false,
+    "required": [
+        "type",
+        "vals"
+    ],
+    "properties": {
+        "type": {
+            "const": "categorical"
+        },
+        "vals": {
+            "type": "array",
+            "minLength": 1
+        }
+    }
+}
+`)
+	textConstHyperparameterV1 = []byte(`{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "http://determined.ai/schemas/expconf/v1/hyperparameter-const.json",
+    "title": "ConstHyperparameter",
+    "type": "object",
+    "additionalProperties": false,
+    "required": [
+        "type",
+        "val"
+    ],
+    "properties": {
+        "type": {
+            "const": "const"
+        },
+        "val": true
+    }
+}
+`)
+	textDoubleHyperparameterV1 = []byte(`{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "http://determined.ai/schemas/expconf/v1/hyperparameter-double.json",
+    "title": "DoubleHyperparameter",
+    "type": "object",
+    "additionalProperties": false,
+    "required": [
+        "type",
+        "minval",
+        "maxval"
+    ],
+    "properties": {
+        "type": {
+            "const": "double"
+        },
+        "minval": {
+            "type": "number"
+        },
+        "maxval": {
+            "type": "number"
+        },
+        "count": {
+            "type": [
+                "integer",
+                "null"
+            ],
+            "default": null,
+            "minimum": 1
+        }
+    },
+    "compareProperties": {
+        "type": "a<b",
+        "a": "minval",
+        "b": "maxval"
+    }
+}
+`)
+	textIntHyperparameterV1 = []byte(`{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "http://determined.ai/schemas/expconf/v1/hyperparameter-int.json",
+    "title": "IntHyperparameter",
+    "type": "object",
+    "additionalProperties": false,
+    "required": [
+        "type",
+        "minval",
+        "maxval"
+    ],
+    "properties": {
+        "type": {
+            "const": "int"
+        },
+        "minval": {
+            "type": "integer"
+        },
+        "maxval": {
+            "type": "integer"
+        },
+        "count": {
+            "type": [
+                "integer",
+                "null"
+            ],
+            "default": null,
+            "minimum": 1
+        }
+    },
+    "compareProperties": {
+        "type": "a<b",
+        "a": "minval",
+        "b": "maxval"
+    }
+}
+`)
+	textLogHyperparameterV1 = []byte(`{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "http://determined.ai/schemas/expconf/v1/hyperparameter-log.json",
+    "title": "LogHyperparameter",
+    "type": "object",
+    "additionalProperties": false,
+    "required": [
+        "type",
+        "minval",
+        "maxval",
+        "base"
+    ],
+    "properties": {
+        "type": {
+            "const": "log"
+        },
+        "minval": {
+            "type": "number"
+        },
+        "maxval": {
+            "type": "number"
+        },
+        "base": {
+            "type": "number",
+            "exclusiveMinimum": 0
+        },
+        "count": {
+            "type": [
+                "integer",
+                "null"
+            ],
+            "default": null,
+            "minimum": 1
+        }
+    },
+    "compareProperties": {
+        "type": "a<b",
+        "a": "minval",
+        "b": "maxval"
+    }
+}
+`)
+	textHyperparameterV1 = []byte(`{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "http://determined.ai/schemas/expconf/v1/hyperparameter.json",
+    "title": "Hyperparameter",
+    "union": {
+        "items": [
+            {
+                "unionKey": "const:type=int",
+                "$ref": "http://determined.ai/schemas/expconf/v1/hyperparameter-int.json"
+            },
+            {
+                "unionKey": "const:type=double",
+                "$ref": "http://determined.ai/schemas/expconf/v1/hyperparameter-double.json"
+            },
+            {
+                "unionKey": "const:type=log",
+                "$ref": "http://determined.ai/schemas/expconf/v1/hyperparameter-log.json"
+            },
+            {
+                "unionKey": "const:type=const",
+                "$ref": "http://determined.ai/schemas/expconf/v1/hyperparameter-const.json"
+            },
+            {
+                "unionKey": "const:type=categorical",
+                "$ref": "http://determined.ai/schemas/expconf/v1/hyperparameter-categorical.json"
+            },
+            {
+                "unionKey": "type:array",
+                "type": "array",
+                "items": {
+                    "$ref": "http://determined.ai/schemas/expconf/v1/hyperparameter.json"
+                }
+            },
+            {
+                "unionKey": "always",
+                "type": "object",
+                "checks": {
+                    "if a hyperparameter object's [\"type\"] is set, it must be one of \"int\", \"double\", \"log\", const\", or \"categorical\"": {
+                        "properties": {
+                            "type": false
+                        }
+                    }
+                },
+                "additionalProperties": {
+                    "$ref": "http://determined.ai/schemas/expconf/v1/hyperparameter.json"
+                }
+            },
+            {
+                "unionKey": "never",
+                "not": {
+                    "type": [
+                        "object",
+                        "array"
+                    ]
+                }
+            }
+        ]
+    }
+}
+`)
+	textInternalConfigV1 = []byte(`{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "http://determined.ai/schemas/expconf/v1/internal.json",
+    "title": "InternalConfig",
+    "type": "object",
+    "additionalProperties": false,
+    "required": [],
+    "properties": {
+        "native": {
+            "type": [
+                "array",
+                "null"
+            ],
+            "items": {
+                "type": "string"
+            },
+            "default": null
+        }
+    }
+}
+`)
+	textLengthV1 = []byte(`{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "http://determined.ai/schemas/expconf/v1/length.json",
+    "title": "Length",
+    "union": {
+        "defaultMessage": "a length object must have one attribute named \"batches\", \"records\", or \"epochs\"",
+        "items": [
+            {
+                "unionKey": "hasattr:batches",
+                "type": "object",
+                "additionalProperties": false,
+                "required": [
+                    "batches"
+                ],
+                "properties": {
+                    "batches": {
+                        "type": "integer",
+                        "minimum": 0
+                    }
+                }
+            },
+            {
+                "unionKey": "hasattr:records",
+                "type": "object",
+                "additionalProperties": false,
+                "required": [
+                    "records"
+                ],
+                "properties": {
+                    "records": {
+                        "type": "integer",
+                        "minimum": 0
+                    }
+                }
+            },
+            {
+                "unionKey": "hasattr:epochs",
+                "type": "object",
+                "additionalProperties": false,
+                "required": [
+                    "epochs"
+                ],
+                "properties": {
+                    "epochs": {
+                        "type": "integer",
+                        "minimum": 0
+                    }
+                }
+            }
+        ]
+    }
+}
+`)
+	textOptimizationsConfigV1 = []byte(`{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "http://determined.ai/schemas/expconf/v1/optimizations.json",
+    "title": "OptimizationsConfig",
+    "type": "object",
+    "additionalProperties": false,
+    "required": [],
+    "properties": {
+        "aggregation_frequency": {
+            "type": [
+                "integer",
+                "null"
+            ],
+            "minimum": 1,
+            "default": 1
+        },
+        "auto_tune_tensor_fusion": {
+            "type": [
+                "boolean",
+                "null"
+            ],
+            "default": false
+        },
+        "average_aggregated_gradients": {
+            "type": [
+                "boolean",
+                "null"
+            ],
+            "default": true
+        },
+        "average_training_metrics": {
+            "type": [
+                "boolean",
+                "null"
+            ],
+            "default": false
+        },
+        "gradient_compression": {
+            "type": [
+                "boolean",
+                "null"
+            ],
+            "default": false
+        },
+        "mixed_precision": {
+            "enum": [
+                null,
+                "O0",
+                "O1",
+                "O2",
+                "O3"
+            ],
+            "default": "O0",
+            "checks": {
+                "mixed_precision should be a string starting with an uppercase letter 'O'": {
+                    "pattern": "^O"
+                }
+            }
+        },
+        "tensor_fusion_cycle_time": {
+            "type": [
+                "integer",
+                "null"
+            ],
+            "minimum": 0,
+            "default": 5
+        },
+        "tensor_fusion_threshold": {
+            "type": [
+                "integer",
+                "null"
+            ],
+            "minimum": 0,
+            "default": 64
+        }
+    }
+}
+`)
+	textResourcesConfigV1 = []byte(`{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "http://determined.ai/schemas/expconf/v1/resources.json",
+    "title": "ResourcesConfig",
+    "type": "object",
+    "additionalProperties": false,
+    "required": [],
+    "properties": {
+        "agent_label": {
+            "type": [
+                "string",
+                "null"
+            ],
+            "default": ""
+        },
+        "max_slots": {
+            "type": [
+                "integer",
+                "null"
+            ],
+            "default": "null"
+        },
+        "native_parallel": {
+            "type": [
+                "boolean",
+                "null"
+            ],
+            "default": false
+        },
+        "priority": {
+            "type": [
+                "integer",
+                "null"
+            ],
+            "minimum": 1,
+            "maximum": 99,
+            "default": null
+        },
+        "resource_pool": {
+            "type": [
+                "string",
+                "null"
+            ],
+            "default": null
+        },
+        "shm_size": {
+            "type": [
+                "integer",
+                "null"
+            ],
+            "default": "null"
+        },
+        "slots_per_trial": {
+            "type": [
+                "integer",
+                "null"
+            ],
+            "minimum": 0,
+            "default": 1
+        },
+        "weight": {
+            "type": [
+                "number",
+                "null"
+            ],
+            "default": 1
+        }
+    }
+}
+`)
+	textS3ConfigV1 = []byte(`{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "http://determined.ai/schemas/expconf/v1/s3.json",
+    "title": "S3Config",
+    "type": "object",
+    "additionalProperties": false,
+    "required": [
+        "type",
+        "access_key",
+        "bucket",
+        "secret_key"
+    ],
+    "properties": {
+        "type": {
+            "const": "s3"
+        },
+        "access_key": {
+            "type": "string"
+        },
+        "bucket": {
+            "type": "string"
+        },
+        "secret_key": {
+            "type": "string"
+        },
+        "endpoint_url": {
+            "type": [
+                "string",
+                "null"
+            ],
+            "default": null
+        },
+        "save_experiment_best": {
+            "type": [
+                "integer",
+                "null"
+            ],
+            "default": 0,
+            "minimum": 0
+        },
+        "save_trial_best": {
+            "type": [
+                "integer",
+                "null"
+            ],
+            "default": 1,
+            "minimum": 0
+        },
+        "save_trial_latest": {
+            "type": [
+                "integer",
+                "null"
+            ],
+            "default": 1,
+            "minimum": 0
+        }
+    }
+}
+`)
+	textAdaptiveASHASearcherConfigV1 = []byte(`{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "http://determined.ai/schemas/expconf/v1/searcher-adaptive-asha.json",
+    "title": "AdaptiveASHASearcherConfig",
+    "type": "object",
+    "additionalProperties": false,
+    "required": [
+        "name",
+        "max_length",
+        "max_trials",
+        "metric"
+    ],
+    "properties": {
+        "name": {
+            "const": "adaptive_asha"
+        },
+        "bracket_rungs": {
+            "type": [
+                "array",
+                "null"
+            ],
+            "default": [],
+            "items": {
+                "type": "integer"
+            }
+        },
+        "max_trials": {
+            "type": "integer",
+            "minimum": 1
+        },
+        "mode": {
+            "enum": [
+                null,
+                "aggressive",
+                "standard",
+                "conservative"
+            ],
+            "default": "standard"
+        },
+        "divisor": {
+            "type": [
+                "number",
+                "null"
+            ],
+            "exclusiveMinimum": 1,
+            "default": 4
+        },
+        "max_rungs": {
+            "type": [
+                "integer",
+                "null"
+            ],
+            "minimum": 1,
+            "default": 5
+        },
+        "max_concurrent_trials": {
+            "type": [
+                "integer",
+                "null"
+            ],
+            "minimum": 0,
+            "default": 0
+        },
+        "max_length": {
+            "$ref": "http://determined.ai/schemas/expconf/v1/check-positive-length.json"
+        },
+        "metric": {
+            "type": "string"
+        },
+        "smaller_is_better": {
+            "type": [
+                "boolean",
+                "null"
+            ],
+            "default": true
+        },
+        "source_trial_id": {
+            "type": [
+                "integer",
+                "null"
+            ],
+            "default": null
+        },
+        "source_checkpoint_uuid": {
+            "type": [
+                "string",
+                "null"
+            ],
+            "default": null
+        }
+    }
+}
+`)
+	textAdaptiveSimpleSearcherConfigV1 = []byte(`{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "http://determined.ai/schemas/expconf/v1/searcher-adaptive-simple.json",
+    "title": "AdaptiveSimpleSearcherConfig",
+    "type": "object",
+    "additionalProperties": false,
+    "required": [
+        "name",
+        "max_trials",
+        "max_length",
+        "metric"
+    ],
+    "properties": {
+        "name": {
+            "const": "adaptive_simple"
+        },
+        "max_trials": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 2000
+        },
+        "mode": {
+            "enum": [
+                null,
+                "aggressive",
+                "standard",
+                "conservative"
+            ],
+            "default": "standard"
+        },
+        "divisor": {
+            "type": [
+                "number",
+                "null"
+            ],
+            "exclusiveMinimum": 1,
+            "default": 4
+        },
+        "max_rungs": {
+            "type": [
+                "integer",
+                "null"
+            ],
+            "minimum": 1,
+            "default": 5
+        },
+        "max_length": {
+            "$ref": "http://determined.ai/schemas/expconf/v1/check-positive-length.json"
+        },
+        "metric": {
+            "type": "string"
+        },
+        "smaller_is_better": {
+            "type": [
+                "boolean",
+                "null"
+            ],
+            "default": true
+        },
+        "source_trial_id": {
+            "type": [
+                "integer",
+                "null"
+            ],
+            "default": null
+        },
+        "source_checkpoint_uuid": {
+            "type": [
+                "string",
+                "null"
+            ],
+            "default": null
+        }
+    }
+}
+`)
+	textAdaptiveSearcherConfigV1 = []byte(`{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "http://determined.ai/schemas/expconf/v1/searcher-adaptive.json",
+    "title": "AdaptiveSearcherConfig",
+    "type": "object",
+    "additionalProperties": false,
+    "required": [
+        "name",
+        "budget",
+        "max_length",
+        "metric"
+    ],
+    "properties": {
+        "name": {
+            "const": "adaptive"
+        },
+        "budget": {
+            "$ref": "http://determined.ai/schemas/expconf/v1/length.json"
+        },
+        "bracket_rungs": {
+            "type": [
+                "array",
+                "null"
+            ],
+            "default": [],
+            "items": {
+                "type": "integer"
+            }
+        },
+        "mode": {
+            "enum": [
+                null,
+                "aggressive",
+                "standard",
+                "conservative"
+            ],
+            "default": "standard"
+        },
+        "divisor": {
+            "type": [
+                "number",
+                "null"
+            ],
+            "exclusiveMinimum": 1,
+            "default": 4
+        },
+        "max_rungs": {
+            "type": [
+                "integer",
+                "null"
+            ],
+            "minimum": 1,
+            "default": 5
+        },
+        "max_length": {
+            "$ref": "http://determined.ai/schemas/expconf/v1/check-positive-length.json"
+        },
+        "train_stragglers": {
+            "type": [
+                "boolean",
+                "null"
+            ],
+            "default": true
+        },
+        "metric": {
+            "type": "string"
+        },
+        "smaller_is_better": {
+            "type": [
+                "boolean",
+                "null"
+            ],
+            "default": true
+        },
+        "source_trial_id": {
+            "type": [
+                "integer",
+                "null"
+            ],
+            "default": null
+        },
+        "source_checkpoint_uuid": {
+            "type": [
+                "string",
+                "null"
+            ],
+            "default": null
+        }
+    },
+    "checks": {
+        "max_length and budget must be specified in terms of the same unit": {
+            "compareProperties": {
+                "type": "same_units",
+                "a": "max_length",
+                "b": "budget"
+            }
+        },
+        "budget must be greater than max_length": {
+            "compareProperties": {
+                "type": "length_a<length_b",
+                "a": "max_length",
+                "b": "budget"
+            }
+        }
+    }
+}
+`)
+	textAsyncHalvingSearcherConfigV1 = []byte(`{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "http://determined.ai/schemas/expconf/v1/searcher-async-halving.json",
+    "title": "AsyncHalvingSearcherConfig",
+    "type": "object",
+    "additionalProperties": false,
+    "required": [
+        "name",
+        "num_rungs",
+        "max_length",
+        "max_trials",
+        "metric"
+    ],
+    "properties": {
+        "name": {
+            "const": "async_halving"
+        },
+        "num_rungs": {
+            "type": "integer",
+            "minimum": 1
+        },
+        "max_length": {
+            "$ref": "http://determined.ai/schemas/expconf/v1/check-positive-length.json"
+        },
+        "max_trials": {
+            "type": "integer",
+            "minimum": 1
+        },
+        "divisor": {
+            "type": [
+                "number",
+                "null"
+            ],
+            "exclusiveMinimum": 1,
+            "default": 4
+        },
+        "max_concurrent_trials": {
+            "type": [
+                "integer",
+                "null"
+            ],
+            "minimum": 0,
+            "default": 0
+        },
+        "metric": {
+            "type": "string"
+        },
+        "smaller_is_better": {
+            "type": [
+                "boolean",
+                "null"
+            ],
+            "default": true
+        },
+        "source_trial_id": {
+            "type": [
+                "integer",
+                "null"
+            ],
+            "default": null
+        },
+        "source_checkpoint_uuid": {
+            "type": [
+                "string",
+                "null"
+            ],
+            "default": null
+        }
+    }
+}
+`)
+	textGridSearcherConfigV1 = []byte(`{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "http://determined.ai/schemas/expconf/v1/searcher-grid.json",
+    "title": "GridSearcherConfig",
+    "type": "object",
+    "additionalProperties": false,
+    "required": [
+        "name",
+        "max_length",
+        "metric"
+    ],
+    "properties": {
+        "name": {
+            "const": "grid"
+        },
+        "max_length": {
+            "$ref": "http://determined.ai/schemas/expconf/v1/check-positive-length.json"
+        },
+        "metric": {
+            "type": "string"
+        },
+        "smaller_is_better": {
+            "type": [
+                "boolean",
+                "null"
+            ],
+            "default": true
+        },
+        "source_trial_id": {
+            "type": [
+                "integer",
+                "null"
+            ],
+            "default": null
+        },
+        "source_checkpoint_uuid": {
+            "type": [
+                "string",
+                "null"
+            ],
+            "default": null
+        }
+    }
+}
+`)
+	textPBTSearcherConfigV1 = []byte(`{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "http://determined.ai/schemas/expconf/v1/searcher-pbt.json",
+    "title": "PBTSearcherConfig",
+    "type": "object",
+    "additionalProperties": false,
+    "required": [
+        "name",
+        "metric",
+        "population_size",
+        "length_per_round",
+        "num_rounds",
+        "replace_function",
+        "explore_function"
+    ],
+    "properties": {
+        "name": {
+            "const": "pbt"
+        },
+        "population_size": {
+            "type": "integer",
+            "minimum": 1
+        },
+        "length_per_round": {
+            "$ref": "http://determined.ai/schemas/expconf/v1/check-positive-length.json"
+        },
+        "num_rounds": {
+            "type": "integer",
+            "minimum": 1
+        },
+        "replace_function": {
+            "unionKey": "singleproperty",
+            "union": {
+                "items": [
+                    {
+                        "unionKey": "always",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "required": [
+                            "truncate_fraction"
+                        ],
+                        "properties": {
+                            "truncate_fraction": {
+                                "type": "number",
+                                "minimum": 0.0,
+                                "maximum": 1.0
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        "explore_function": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+                "resample_probability",
+                "perturb_factor"
+            ],
+            "properties": {
+                "resample_probability": {
+                    "type": "number",
+                    "minimum": 0.0,
+                    "maximum": 1.0
+                },
+                "perturb_factor": {
+                    "type": "number",
+                    "minimum": 0.0,
+                    "maximum": 1.0
+                }
+            }
+        },
+        "metric": {
+            "type": "string"
+        },
+        "smaller_is_better": {
+            "type": [
+                "boolean",
+                "null"
+            ],
+            "default": true
+        },
+        "source_trial_id": {
+            "type": [
+                "integer",
+                "null"
+            ],
+            "default": null
+        },
+        "source_checkpoint_uuid": {
+            "type": [
+                "string",
+                "null"
+            ],
+            "default": null
+        }
+    }
+}
+`)
+	textRandomSearcherConfigV1 = []byte(`{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "http://determined.ai/schemas/expconf/v1/searcher-random.json",
+    "title": "RandomSearcherConfig",
+    "type": "object",
+    "additionalProperties": false,
+    "required": [
+        "name",
+        "max_trials",
+        "max_length",
+        "metric"
+    ],
+    "properties": {
+        "name": {
+            "const": "random"
+        },
+        "max_trials": {
+            "type": "integer",
+            "minimum": 1
+        },
+        "max_length": {
+            "$ref": "http://determined.ai/schemas/expconf/v1/check-positive-length.json"
+        },
+        "metric": {
+            "type": "string"
+        },
+        "smaller_is_better": {
+            "type": [
+                "boolean",
+                "null"
+            ],
+            "default": true
+        },
+        "source_trial_id": {
+            "type": [
+                "integer",
+                "null"
+            ],
+            "default": null
+        },
+        "source_checkpoint_uuid": {
+            "type": [
+                "string",
+                "null"
+            ],
+            "default": null
+        }
+    }
+}
+`)
+	textSingleSearcherConfigV1 = []byte(`{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "http://determined.ai/schemas/expconf/v1/searcher-single.json",
+    "title": "SingleSearcherConfig",
+    "type": "object",
+    "additionalProperties": false,
+    "required": [
+        "name",
+        "max_length",
+        "metric"
+    ],
+    "properties": {
+        "name": {
+            "const": "single"
+        },
+        "max_length": {
+            "$ref": "http://determined.ai/schemas/expconf/v1/check-positive-length.json"
+        },
+        "metric": {
+            "type": "string"
+        },
+        "smaller_is_better": {
+            "type": [
+                "boolean",
+                "null"
+            ],
+            "default": true
+        },
+        "source_trial_id": {
+            "type": [
+                "integer",
+                "null"
+            ],
+            "default": null
+        },
+        "source_checkpoint_uuid": {
+            "type": [
+                "string",
+                "null"
+            ],
+            "default": null
+        }
+    }
+}
+`)
+	textSyncHalvingSearcherConfigV1 = []byte(`{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "http://determined.ai/schemas/expconf/v1/searcher-sync-halving.json",
+    "title": "SyncHalvingSearcherConfig",
+    "type": "object",
+    "additionalProperties": false,
+    "required": [
+        "name",
+        "num_rungs",
+        "max_length",
+        "budget",
+        "metric"
+    ],
+    "properties": {
+        "name": {
+            "const": "sync_halving"
+        },
+        "budget": {
+            "$ref": "http://determined.ai/schemas/expconf/v1/check-positive-length.json"
+        },
+        "num_rungs": {
+            "type": "integer",
+            "minimum": 1
+        },
+        "max_length": {
+            "$ref": "http://determined.ai/schemas/expconf/v1/check-positive-length.json"
+        },
+        "divisor": {
+            "type": [
+                "number",
+                "null"
+            ],
+            "exclusiveMinimum": 1,
+            "default": 4
+        },
+        "train_stragglers": {
+            "type": [
+                "boolean",
+                "null"
+            ],
+            "default": true
+        },
+        "metric": {
+            "type": "string"
+        },
+        "smaller_is_better": {
+            "type": [
+                "boolean",
+                "null"
+            ],
+            "default": true
+        },
+        "source_trial_id": {
+            "type": [
+                "integer",
+                "null"
+            ],
+            "default": null
+        },
+        "source_checkpoint_uuid": {
+            "type": [
+                "string",
+                "null"
+            ],
+            "default": null
+        }
+    }
+}
+`)
+	textSearcherConfigV1 = []byte(`{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "http://determined.ai/schemas/expconf/v1/searcher.json",
+    "title": "SearcherConfig",
+    "union": {
+        "defaultMessage": "is not an object where object[\"name\"] is one of 'single', 'random', 'grid', 'adaptive', 'adaptive_asha', 'adaptive_simple', or 'pbt'",
+        "items": [
+            {
+                "unionKey": "const:name=single",
+                "$ref": "http://determined.ai/schemas/expconf/v1/searcher-single.json"
+            },
+            {
+                "unionKey": "const:name=random",
+                "$ref": "http://determined.ai/schemas/expconf/v1/searcher-random.json"
+            },
+            {
+                "unionKey": "const:name=grid",
+                "$ref": "http://determined.ai/schemas/expconf/v1/searcher-grid.json"
+            },
+            {
+                "unionKey": "const:name=adaptive_asha",
+                "$ref": "http://determined.ai/schemas/expconf/v1/searcher-adaptive-asha.json"
+            },
+            {
+                "unionKey": "const:name=adaptive_simple",
+                "$ref": "http://determined.ai/schemas/expconf/v1/searcher-adaptive-simple.json"
+            },
+            {
+                "unionKey": "const:name=adaptive",
+                "$ref": "http://determined.ai/schemas/expconf/v1/searcher-adaptive.json"
+            },
+            {
+                "unionKey": "const:name=pbt",
+                "$ref": "http://determined.ai/schemas/expconf/v1/searcher-pbt.json"
+            },
+            {
+                "unionKey": "const:name=sync_halving",
+                "$ref": "http://determined.ai/schemas/expconf/v1/searcher-sync-halving.json"
+            },
+            {
+                "unionKey": "const:name=async_halving",
+                "$ref": "http://determined.ai/schemas/expconf/v1/searcher-async-halving.json"
+            }
+        ]
+    }
+}
+`)
+	textSharedFSConfigV1 = []byte(`{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "http://determined.ai/schemas/expconf/v1/shared-fs.json",
+    "title": "SharedFSConfig",
+    "type": "object",
+    "additionalProperties": false,
+    "required": [
+        "type",
+        "host_path"
+    ],
+    "properties": {
+        "type": {
+            "const": "shared_fs"
+        },
+        "host_path": {
+            "type": "string"
+        },
+        "storage_path": {
+            "type": [
+                "string",
+                "null"
+            ],
+            "default": null
+        },
+        "propagation": {
+            "type": [
+                "string",
+                "null"
+            ],
+            "default": "rprivate"
+        },
+        "container_path": {
+            "type": [
+                "string",
+                "null"
+            ],
+            "default": null
+        },
+        "checkpoint_path": {
+            "type": [
+                "string",
+                "null"
+            ],
+            "default": null
+        },
+        "tensorboard_path": {
+            "type": [
+                "string",
+                "null"
+            ],
+            "default": null
+        },
+        "save_experiment_best": {
+            "type": [
+                "integer",
+                "null"
+            ],
+            "default": 0,
+            "minimum": 0
+        },
+        "save_trial_best": {
+            "type": [
+                "integer",
+                "null"
+            ],
+            "default": 1,
+            "minimum": 0
+        },
+        "save_trial_latest": {
+            "type": [
+                "integer",
+                "null"
+            ],
+            "default": 1,
+            "minimum": 0
+        }
+    },
+    "checks": {
+        "storage_path must either be a relative directory or a subdirectory of host_path": {
+            "compareProperties": {
+                "type": "a_is_subdir_of_b",
+                "a": "storage_path",
+                "b": "host_path"
+            }
+        }
+    }
+}
+`)
+	schemaBindMountV1                    interface{}
+	schemaCheckDataLayerCacheV1          interface{}
+	schemaCheckEpochNotUsedV1            interface{}
+	schemaCheckGlobalBatchSizeV1         interface{}
+	schemaCheckGridHyperparameterV1      interface{}
+	schemaCheckPositiveLengthV1          interface{}
+	schemaCheckpointStorageConfigV1      interface{}
+	schemaDataLayerGCSConfigV1           interface{}
+	schemaDataLayerS3ConfigV1            interface{}
+	schemaDataLayerSharedFSConfigV1      interface{}
+	schemaDataLayerConfigV1              interface{}
+	schemaEnvironmentImageV1             interface{}
+	schemaEnvironmentVariablesV1         interface{}
+	schemaEnvironmentConfigV1            interface{}
+	schemaExperimentConfigV1             interface{}
+	schemaGCSConfigV1                    interface{}
+	schemaHDFSConfigV1                   interface{}
+	schemaCategoricalHyperparameterV1    interface{}
+	schemaConstHyperparameterV1          interface{}
+	schemaDoubleHyperparameterV1         interface{}
+	schemaIntHyperparameterV1            interface{}
+	schemaLogHyperparameterV1            interface{}
+	schemaHyperparameterV1               interface{}
+	schemaInternalConfigV1               interface{}
+	schemaLengthV1                       interface{}
+	schemaOptimizationsConfigV1          interface{}
+	schemaResourcesConfigV1              interface{}
+	schemaS3ConfigV1                     interface{}
+	schemaAdaptiveASHASearcherConfigV1   interface{}
+	schemaAdaptiveSimpleSearcherConfigV1 interface{}
+	schemaAdaptiveSearcherConfigV1       interface{}
+	schemaAsyncHalvingSearcherConfigV1   interface{}
+	schemaGridSearcherConfigV1           interface{}
+	schemaPBTSearcherConfigV1            interface{}
+	schemaRandomSearcherConfigV1         interface{}
+	schemaSingleSearcherConfigV1         interface{}
+	schemaSyncHalvingSearcherConfigV1    interface{}
+	schemaSearcherConfigV1               interface{}
+	schemaSharedFSConfigV1               interface{}
+	cachedSchemaMap                      map[string]interface{}
+	cachedSchemaBytesMap                 map[string][]byte
+)
+
+func parsedBindMountV1() interface{} {
+	if schemaBindMountV1 != nil {
+		return schemaBindMountV1
+	}
+	err := json.Unmarshal(textBindMountV1, &schemaBindMountV1)
+	if err != nil {
+		panic("invalid embedded json for BindMountV1")
+	}
+	return schemaBindMountV1
+}
+
+func parsedCheckDataLayerCacheV1() interface{} {
+	if schemaCheckDataLayerCacheV1 != nil {
+		return schemaCheckDataLayerCacheV1
+	}
+	err := json.Unmarshal(textCheckDataLayerCacheV1, &schemaCheckDataLayerCacheV1)
+	if err != nil {
+		panic("invalid embedded json for CheckDataLayerCacheV1")
+	}
+	return schemaCheckDataLayerCacheV1
+}
+
+func parsedCheckEpochNotUsedV1() interface{} {
+	if schemaCheckEpochNotUsedV1 != nil {
+		return schemaCheckEpochNotUsedV1
+	}
+	err := json.Unmarshal(textCheckEpochNotUsedV1, &schemaCheckEpochNotUsedV1)
+	if err != nil {
+		panic("invalid embedded json for CheckEpochNotUsedV1")
+	}
+	return schemaCheckEpochNotUsedV1
+}
+
+func parsedCheckGlobalBatchSizeV1() interface{} {
+	if schemaCheckGlobalBatchSizeV1 != nil {
+		return schemaCheckGlobalBatchSizeV1
+	}
+	err := json.Unmarshal(textCheckGlobalBatchSizeV1, &schemaCheckGlobalBatchSizeV1)
+	if err != nil {
+		panic("invalid embedded json for CheckGlobalBatchSizeV1")
+	}
+	return schemaCheckGlobalBatchSizeV1
+}
+
+func parsedCheckGridHyperparameterV1() interface{} {
+	if schemaCheckGridHyperparameterV1 != nil {
+		return schemaCheckGridHyperparameterV1
+	}
+	err := json.Unmarshal(textCheckGridHyperparameterV1, &schemaCheckGridHyperparameterV1)
+	if err != nil {
+		panic("invalid embedded json for CheckGridHyperparameterV1")
+	}
+	return schemaCheckGridHyperparameterV1
+}
+
+func parsedCheckPositiveLengthV1() interface{} {
+	if schemaCheckPositiveLengthV1 != nil {
+		return schemaCheckPositiveLengthV1
+	}
+	err := json.Unmarshal(textCheckPositiveLengthV1, &schemaCheckPositiveLengthV1)
+	if err != nil {
+		panic("invalid embedded json for CheckPositiveLengthV1")
+	}
+	return schemaCheckPositiveLengthV1
+}
+
+func parsedCheckpointStorageConfigV1() interface{} {
+	if schemaCheckpointStorageConfigV1 != nil {
+		return schemaCheckpointStorageConfigV1
+	}
+	err := json.Unmarshal(textCheckpointStorageConfigV1, &schemaCheckpointStorageConfigV1)
+	if err != nil {
+		panic("invalid embedded json for CheckpointStorageConfigV1")
+	}
+	return schemaCheckpointStorageConfigV1
+}
+
+func parsedDataLayerGCSConfigV1() interface{} {
+	if schemaDataLayerGCSConfigV1 != nil {
+		return schemaDataLayerGCSConfigV1
+	}
+	err := json.Unmarshal(textDataLayerGCSConfigV1, &schemaDataLayerGCSConfigV1)
+	if err != nil {
+		panic("invalid embedded json for DataLayerGCSConfigV1")
+	}
+	return schemaDataLayerGCSConfigV1
+}
+
+func parsedDataLayerS3ConfigV1() interface{} {
+	if schemaDataLayerS3ConfigV1 != nil {
+		return schemaDataLayerS3ConfigV1
+	}
+	err := json.Unmarshal(textDataLayerS3ConfigV1, &schemaDataLayerS3ConfigV1)
+	if err != nil {
+		panic("invalid embedded json for DataLayerS3ConfigV1")
+	}
+	return schemaDataLayerS3ConfigV1
+}
+
+func parsedDataLayerSharedFSConfigV1() interface{} {
+	if schemaDataLayerSharedFSConfigV1 != nil {
+		return schemaDataLayerSharedFSConfigV1
+	}
+	err := json.Unmarshal(textDataLayerSharedFSConfigV1, &schemaDataLayerSharedFSConfigV1)
+	if err != nil {
+		panic("invalid embedded json for DataLayerSharedFSConfigV1")
+	}
+	return schemaDataLayerSharedFSConfigV1
+}
+
+func parsedDataLayerConfigV1() interface{} {
+	if schemaDataLayerConfigV1 != nil {
+		return schemaDataLayerConfigV1
+	}
+	err := json.Unmarshal(textDataLayerConfigV1, &schemaDataLayerConfigV1)
+	if err != nil {
+		panic("invalid embedded json for DataLayerConfigV1")
+	}
+	return schemaDataLayerConfigV1
+}
+
+func parsedEnvironmentImageV1() interface{} {
+	if schemaEnvironmentImageV1 != nil {
+		return schemaEnvironmentImageV1
+	}
+	err := json.Unmarshal(textEnvironmentImageV1, &schemaEnvironmentImageV1)
+	if err != nil {
+		panic("invalid embedded json for EnvironmentImageV1")
+	}
+	return schemaEnvironmentImageV1
+}
+
+func parsedEnvironmentVariablesV1() interface{} {
+	if schemaEnvironmentVariablesV1 != nil {
+		return schemaEnvironmentVariablesV1
+	}
+	err := json.Unmarshal(textEnvironmentVariablesV1, &schemaEnvironmentVariablesV1)
+	if err != nil {
+		panic("invalid embedded json for EnvironmentVariablesV1")
+	}
+	return schemaEnvironmentVariablesV1
+}
+
+func parsedEnvironmentConfigV1() interface{} {
+	if schemaEnvironmentConfigV1 != nil {
+		return schemaEnvironmentConfigV1
+	}
+	err := json.Unmarshal(textEnvironmentConfigV1, &schemaEnvironmentConfigV1)
+	if err != nil {
+		panic("invalid embedded json for EnvironmentConfigV1")
+	}
+	return schemaEnvironmentConfigV1
+}
+
+func parsedExperimentConfigV1() interface{} {
+	if schemaExperimentConfigV1 != nil {
+		return schemaExperimentConfigV1
+	}
+	err := json.Unmarshal(textExperimentConfigV1, &schemaExperimentConfigV1)
+	if err != nil {
+		panic("invalid embedded json for ExperimentConfigV1")
+	}
+	return schemaExperimentConfigV1
+}
+
+func parsedGCSConfigV1() interface{} {
+	if schemaGCSConfigV1 != nil {
+		return schemaGCSConfigV1
+	}
+	err := json.Unmarshal(textGCSConfigV1, &schemaGCSConfigV1)
+	if err != nil {
+		panic("invalid embedded json for GCSConfigV1")
+	}
+	return schemaGCSConfigV1
+}
+
+func parsedHDFSConfigV1() interface{} {
+	if schemaHDFSConfigV1 != nil {
+		return schemaHDFSConfigV1
+	}
+	err := json.Unmarshal(textHDFSConfigV1, &schemaHDFSConfigV1)
+	if err != nil {
+		panic("invalid embedded json for HDFSConfigV1")
+	}
+	return schemaHDFSConfigV1
+}
+
+func parsedCategoricalHyperparameterV1() interface{} {
+	if schemaCategoricalHyperparameterV1 != nil {
+		return schemaCategoricalHyperparameterV1
+	}
+	err := json.Unmarshal(textCategoricalHyperparameterV1, &schemaCategoricalHyperparameterV1)
+	if err != nil {
+		panic("invalid embedded json for CategoricalHyperparameterV1")
+	}
+	return schemaCategoricalHyperparameterV1
+}
+
+func parsedConstHyperparameterV1() interface{} {
+	if schemaConstHyperparameterV1 != nil {
+		return schemaConstHyperparameterV1
+	}
+	err := json.Unmarshal(textConstHyperparameterV1, &schemaConstHyperparameterV1)
+	if err != nil {
+		panic("invalid embedded json for ConstHyperparameterV1")
+	}
+	return schemaConstHyperparameterV1
+}
+
+func parsedDoubleHyperparameterV1() interface{} {
+	if schemaDoubleHyperparameterV1 != nil {
+		return schemaDoubleHyperparameterV1
+	}
+	err := json.Unmarshal(textDoubleHyperparameterV1, &schemaDoubleHyperparameterV1)
+	if err != nil {
+		panic("invalid embedded json for DoubleHyperparameterV1")
+	}
+	return schemaDoubleHyperparameterV1
+}
+
+func parsedIntHyperparameterV1() interface{} {
+	if schemaIntHyperparameterV1 != nil {
+		return schemaIntHyperparameterV1
+	}
+	err := json.Unmarshal(textIntHyperparameterV1, &schemaIntHyperparameterV1)
+	if err != nil {
+		panic("invalid embedded json for IntHyperparameterV1")
+	}
+	return schemaIntHyperparameterV1
+}
+
+func parsedLogHyperparameterV1() interface{} {
+	if schemaLogHyperparameterV1 != nil {
+		return schemaLogHyperparameterV1
+	}
+	err := json.Unmarshal(textLogHyperparameterV1, &schemaLogHyperparameterV1)
+	if err != nil {
+		panic("invalid embedded json for LogHyperparameterV1")
+	}
+	return schemaLogHyperparameterV1
+}
+
+func parsedHyperparameterV1() interface{} {
+	if schemaHyperparameterV1 != nil {
+		return schemaHyperparameterV1
+	}
+	err := json.Unmarshal(textHyperparameterV1, &schemaHyperparameterV1)
+	if err != nil {
+		panic("invalid embedded json for HyperparameterV1")
+	}
+	return schemaHyperparameterV1
+}
+
+func parsedInternalConfigV1() interface{} {
+	if schemaInternalConfigV1 != nil {
+		return schemaInternalConfigV1
+	}
+	err := json.Unmarshal(textInternalConfigV1, &schemaInternalConfigV1)
+	if err != nil {
+		panic("invalid embedded json for InternalConfigV1")
+	}
+	return schemaInternalConfigV1
+}
+
+func parsedLengthV1() interface{} {
+	if schemaLengthV1 != nil {
+		return schemaLengthV1
+	}
+	err := json.Unmarshal(textLengthV1, &schemaLengthV1)
+	if err != nil {
+		panic("invalid embedded json for LengthV1")
+	}
+	return schemaLengthV1
+}
+
+func parsedOptimizationsConfigV1() interface{} {
+	if schemaOptimizationsConfigV1 != nil {
+		return schemaOptimizationsConfigV1
+	}
+	err := json.Unmarshal(textOptimizationsConfigV1, &schemaOptimizationsConfigV1)
+	if err != nil {
+		panic("invalid embedded json for OptimizationsConfigV1")
+	}
+	return schemaOptimizationsConfigV1
+}
+
+func parsedResourcesConfigV1() interface{} {
+	if schemaResourcesConfigV1 != nil {
+		return schemaResourcesConfigV1
+	}
+	err := json.Unmarshal(textResourcesConfigV1, &schemaResourcesConfigV1)
+	if err != nil {
+		panic("invalid embedded json for ResourcesConfigV1")
+	}
+	return schemaResourcesConfigV1
+}
+
+func parsedS3ConfigV1() interface{} {
+	if schemaS3ConfigV1 != nil {
+		return schemaS3ConfigV1
+	}
+	err := json.Unmarshal(textS3ConfigV1, &schemaS3ConfigV1)
+	if err != nil {
+		panic("invalid embedded json for S3ConfigV1")
+	}
+	return schemaS3ConfigV1
+}
+
+func parsedAdaptiveASHASearcherConfigV1() interface{} {
+	if schemaAdaptiveASHASearcherConfigV1 != nil {
+		return schemaAdaptiveASHASearcherConfigV1
+	}
+	err := json.Unmarshal(textAdaptiveASHASearcherConfigV1, &schemaAdaptiveASHASearcherConfigV1)
+	if err != nil {
+		panic("invalid embedded json for AdaptiveASHASearcherConfigV1")
+	}
+	return schemaAdaptiveASHASearcherConfigV1
+}
+
+func parsedAdaptiveSimpleSearcherConfigV1() interface{} {
+	if schemaAdaptiveSimpleSearcherConfigV1 != nil {
+		return schemaAdaptiveSimpleSearcherConfigV1
+	}
+	err := json.Unmarshal(textAdaptiveSimpleSearcherConfigV1, &schemaAdaptiveSimpleSearcherConfigV1)
+	if err != nil {
+		panic("invalid embedded json for AdaptiveSimpleSearcherConfigV1")
+	}
+	return schemaAdaptiveSimpleSearcherConfigV1
+}
+
+func parsedAdaptiveSearcherConfigV1() interface{} {
+	if schemaAdaptiveSearcherConfigV1 != nil {
+		return schemaAdaptiveSearcherConfigV1
+	}
+	err := json.Unmarshal(textAdaptiveSearcherConfigV1, &schemaAdaptiveSearcherConfigV1)
+	if err != nil {
+		panic("invalid embedded json for AdaptiveSearcherConfigV1")
+	}
+	return schemaAdaptiveSearcherConfigV1
+}
+
+func parsedAsyncHalvingSearcherConfigV1() interface{} {
+	if schemaAsyncHalvingSearcherConfigV1 != nil {
+		return schemaAsyncHalvingSearcherConfigV1
+	}
+	err := json.Unmarshal(textAsyncHalvingSearcherConfigV1, &schemaAsyncHalvingSearcherConfigV1)
+	if err != nil {
+		panic("invalid embedded json for AsyncHalvingSearcherConfigV1")
+	}
+	return schemaAsyncHalvingSearcherConfigV1
+}
+
+func parsedGridSearcherConfigV1() interface{} {
+	if schemaGridSearcherConfigV1 != nil {
+		return schemaGridSearcherConfigV1
+	}
+	err := json.Unmarshal(textGridSearcherConfigV1, &schemaGridSearcherConfigV1)
+	if err != nil {
+		panic("invalid embedded json for GridSearcherConfigV1")
+	}
+	return schemaGridSearcherConfigV1
+}
+
+func parsedPBTSearcherConfigV1() interface{} {
+	if schemaPBTSearcherConfigV1 != nil {
+		return schemaPBTSearcherConfigV1
+	}
+	err := json.Unmarshal(textPBTSearcherConfigV1, &schemaPBTSearcherConfigV1)
+	if err != nil {
+		panic("invalid embedded json for PBTSearcherConfigV1")
+	}
+	return schemaPBTSearcherConfigV1
+}
+
+func parsedRandomSearcherConfigV1() interface{} {
+	if schemaRandomSearcherConfigV1 != nil {
+		return schemaRandomSearcherConfigV1
+	}
+	err := json.Unmarshal(textRandomSearcherConfigV1, &schemaRandomSearcherConfigV1)
+	if err != nil {
+		panic("invalid embedded json for RandomSearcherConfigV1")
+	}
+	return schemaRandomSearcherConfigV1
+}
+
+func parsedSingleSearcherConfigV1() interface{} {
+	if schemaSingleSearcherConfigV1 != nil {
+		return schemaSingleSearcherConfigV1
+	}
+	err := json.Unmarshal(textSingleSearcherConfigV1, &schemaSingleSearcherConfigV1)
+	if err != nil {
+		panic("invalid embedded json for SingleSearcherConfigV1")
+	}
+	return schemaSingleSearcherConfigV1
+}
+
+func parsedSyncHalvingSearcherConfigV1() interface{} {
+	if schemaSyncHalvingSearcherConfigV1 != nil {
+		return schemaSyncHalvingSearcherConfigV1
+	}
+	err := json.Unmarshal(textSyncHalvingSearcherConfigV1, &schemaSyncHalvingSearcherConfigV1)
+	if err != nil {
+		panic("invalid embedded json for SyncHalvingSearcherConfigV1")
+	}
+	return schemaSyncHalvingSearcherConfigV1
+}
+
+func parsedSearcherConfigV1() interface{} {
+	if schemaSearcherConfigV1 != nil {
+		return schemaSearcherConfigV1
+	}
+	err := json.Unmarshal(textSearcherConfigV1, &schemaSearcherConfigV1)
+	if err != nil {
+		panic("invalid embedded json for SearcherConfigV1")
+	}
+	return schemaSearcherConfigV1
+}
+
+func parsedSharedFSConfigV1() interface{} {
+	if schemaSharedFSConfigV1 != nil {
+		return schemaSharedFSConfigV1
+	}
+	err := json.Unmarshal(textSharedFSConfigV1, &schemaSharedFSConfigV1)
+	if err != nil {
+		panic("invalid embedded json for SharedFSConfigV1")
+	}
+	return schemaSharedFSConfigV1
+}
+
+func schemaBytesMap() map[string][]byte {
+	if cachedSchemaBytesMap != nil {
+		return cachedSchemaBytesMap
+	}
+	var url string
+	cachedSchemaBytesMap = map[string][]byte{}
+	url = "http://determined.ai/schemas/expconf/v1/bind-mount.json"
+	cachedSchemaBytesMap[url] = textBindMountV1
+	url = "http://determined.ai/schemas/expconf/v1/check-data-layer-cache.json"
+	cachedSchemaBytesMap[url] = textCheckDataLayerCacheV1
+	url = "http://determined.ai/schemas/expconf/v1/check-epoch-not-used.json"
+	cachedSchemaBytesMap[url] = textCheckEpochNotUsedV1
+	url = "http://determined.ai/schemas/expconf/v1/check-global-batch-size.json"
+	cachedSchemaBytesMap[url] = textCheckGlobalBatchSizeV1
+	url = "http://determined.ai/schemas/expconf/v1/check-grid-hyperparameter.json"
+	cachedSchemaBytesMap[url] = textCheckGridHyperparameterV1
+	url = "http://determined.ai/schemas/expconf/v1/check-positive-length.json"
+	cachedSchemaBytesMap[url] = textCheckPositiveLengthV1
+	url = "http://determined.ai/schemas/expconf/v1/checkpoint-storage.json"
+	cachedSchemaBytesMap[url] = textCheckpointStorageConfigV1
+	url = "http://determined.ai/schemas/expconf/v1/data-layer-gcs.json"
+	cachedSchemaBytesMap[url] = textDataLayerGCSConfigV1
+	url = "http://determined.ai/schemas/expconf/v1/data-layer-s3.json"
+	cachedSchemaBytesMap[url] = textDataLayerS3ConfigV1
+	url = "http://determined.ai/schemas/expconf/v1/data-layer-shared-fs.json"
+	cachedSchemaBytesMap[url] = textDataLayerSharedFSConfigV1
+	url = "http://determined.ai/schemas/expconf/v1/data-layer.json"
+	cachedSchemaBytesMap[url] = textDataLayerConfigV1
+	url = "http://determined.ai/schemas/expconf/v1/environment-image.json"
+	cachedSchemaBytesMap[url] = textEnvironmentImageV1
+	url = "http://determined.ai/schemas/expconf/v1/environment-variables.json"
+	cachedSchemaBytesMap[url] = textEnvironmentVariablesV1
+	url = "http://determined.ai/schemas/expconf/v1/environment.json"
+	cachedSchemaBytesMap[url] = textEnvironmentConfigV1
+	url = "http://determined.ai/schemas/expconf/v1/experiment.json"
+	cachedSchemaBytesMap[url] = textExperimentConfigV1
+	url = "http://determined.ai/schemas/expconf/v1/gcs.json"
+	cachedSchemaBytesMap[url] = textGCSConfigV1
+	url = "http://determined.ai/schemas/expconf/v1/hdfs.json"
+	cachedSchemaBytesMap[url] = textHDFSConfigV1
+	url = "http://determined.ai/schemas/expconf/v1/hyperparameter-categorical.json"
+	cachedSchemaBytesMap[url] = textCategoricalHyperparameterV1
+	url = "http://determined.ai/schemas/expconf/v1/hyperparameter-const.json"
+	cachedSchemaBytesMap[url] = textConstHyperparameterV1
+	url = "http://determined.ai/schemas/expconf/v1/hyperparameter-double.json"
+	cachedSchemaBytesMap[url] = textDoubleHyperparameterV1
+	url = "http://determined.ai/schemas/expconf/v1/hyperparameter-int.json"
+	cachedSchemaBytesMap[url] = textIntHyperparameterV1
+	url = "http://determined.ai/schemas/expconf/v1/hyperparameter-log.json"
+	cachedSchemaBytesMap[url] = textLogHyperparameterV1
+	url = "http://determined.ai/schemas/expconf/v1/hyperparameter.json"
+	cachedSchemaBytesMap[url] = textHyperparameterV1
+	url = "http://determined.ai/schemas/expconf/v1/internal.json"
+	cachedSchemaBytesMap[url] = textInternalConfigV1
+	url = "http://determined.ai/schemas/expconf/v1/length.json"
+	cachedSchemaBytesMap[url] = textLengthV1
+	url = "http://determined.ai/schemas/expconf/v1/optimizations.json"
+	cachedSchemaBytesMap[url] = textOptimizationsConfigV1
+	url = "http://determined.ai/schemas/expconf/v1/resources.json"
+	cachedSchemaBytesMap[url] = textResourcesConfigV1
+	url = "http://determined.ai/schemas/expconf/v1/s3.json"
+	cachedSchemaBytesMap[url] = textS3ConfigV1
+	url = "http://determined.ai/schemas/expconf/v1/searcher-adaptive-asha.json"
+	cachedSchemaBytesMap[url] = textAdaptiveASHASearcherConfigV1
+	url = "http://determined.ai/schemas/expconf/v1/searcher-adaptive-simple.json"
+	cachedSchemaBytesMap[url] = textAdaptiveSimpleSearcherConfigV1
+	url = "http://determined.ai/schemas/expconf/v1/searcher-adaptive.json"
+	cachedSchemaBytesMap[url] = textAdaptiveSearcherConfigV1
+	url = "http://determined.ai/schemas/expconf/v1/searcher-async-halving.json"
+	cachedSchemaBytesMap[url] = textAsyncHalvingSearcherConfigV1
+	url = "http://determined.ai/schemas/expconf/v1/searcher-grid.json"
+	cachedSchemaBytesMap[url] = textGridSearcherConfigV1
+	url = "http://determined.ai/schemas/expconf/v1/searcher-pbt.json"
+	cachedSchemaBytesMap[url] = textPBTSearcherConfigV1
+	url = "http://determined.ai/schemas/expconf/v1/searcher-random.json"
+	cachedSchemaBytesMap[url] = textRandomSearcherConfigV1
+	url = "http://determined.ai/schemas/expconf/v1/searcher-single.json"
+	cachedSchemaBytesMap[url] = textSingleSearcherConfigV1
+	url = "http://determined.ai/schemas/expconf/v1/searcher-sync-halving.json"
+	cachedSchemaBytesMap[url] = textSyncHalvingSearcherConfigV1
+	url = "http://determined.ai/schemas/expconf/v1/searcher.json"
+	cachedSchemaBytesMap[url] = textSearcherConfigV1
+	url = "http://determined.ai/schemas/expconf/v1/shared-fs.json"
+	cachedSchemaBytesMap[url] = textSharedFSConfigV1
+	return cachedSchemaBytesMap
+}
+func schemaMap() map[string]interface{} {
+	if cachedSchemaMap != nil {
+		return cachedSchemaMap
+	}
+	var url string
+	cachedSchemaMap = map[string]interface{}{}
+	url = "http://determined.ai/schemas/expconf/v1/bind-mount.json"
+	cachedSchemaMap[url] = parsedBindMountV1()
+	url = "http://determined.ai/schemas/expconf/v1/check-data-layer-cache.json"
+	cachedSchemaMap[url] = parsedCheckDataLayerCacheV1()
+	url = "http://determined.ai/schemas/expconf/v1/check-epoch-not-used.json"
+	cachedSchemaMap[url] = parsedCheckEpochNotUsedV1()
+	url = "http://determined.ai/schemas/expconf/v1/check-global-batch-size.json"
+	cachedSchemaMap[url] = parsedCheckGlobalBatchSizeV1()
+	url = "http://determined.ai/schemas/expconf/v1/check-grid-hyperparameter.json"
+	cachedSchemaMap[url] = parsedCheckGridHyperparameterV1()
+	url = "http://determined.ai/schemas/expconf/v1/check-positive-length.json"
+	cachedSchemaMap[url] = parsedCheckPositiveLengthV1()
+	url = "http://determined.ai/schemas/expconf/v1/checkpoint-storage.json"
+	cachedSchemaMap[url] = parsedCheckpointStorageConfigV1()
+	url = "http://determined.ai/schemas/expconf/v1/data-layer-gcs.json"
+	cachedSchemaMap[url] = parsedDataLayerGCSConfigV1()
+	url = "http://determined.ai/schemas/expconf/v1/data-layer-s3.json"
+	cachedSchemaMap[url] = parsedDataLayerS3ConfigV1()
+	url = "http://determined.ai/schemas/expconf/v1/data-layer-shared-fs.json"
+	cachedSchemaMap[url] = parsedDataLayerSharedFSConfigV1()
+	url = "http://determined.ai/schemas/expconf/v1/data-layer.json"
+	cachedSchemaMap[url] = parsedDataLayerConfigV1()
+	url = "http://determined.ai/schemas/expconf/v1/environment-image.json"
+	cachedSchemaMap[url] = parsedEnvironmentImageV1()
+	url = "http://determined.ai/schemas/expconf/v1/environment-variables.json"
+	cachedSchemaMap[url] = parsedEnvironmentVariablesV1()
+	url = "http://determined.ai/schemas/expconf/v1/environment.json"
+	cachedSchemaMap[url] = parsedEnvironmentConfigV1()
+	url = "http://determined.ai/schemas/expconf/v1/experiment.json"
+	cachedSchemaMap[url] = parsedExperimentConfigV1()
+	url = "http://determined.ai/schemas/expconf/v1/gcs.json"
+	cachedSchemaMap[url] = parsedGCSConfigV1()
+	url = "http://determined.ai/schemas/expconf/v1/hdfs.json"
+	cachedSchemaMap[url] = parsedHDFSConfigV1()
+	url = "http://determined.ai/schemas/expconf/v1/hyperparameter-categorical.json"
+	cachedSchemaMap[url] = parsedCategoricalHyperparameterV1()
+	url = "http://determined.ai/schemas/expconf/v1/hyperparameter-const.json"
+	cachedSchemaMap[url] = parsedConstHyperparameterV1()
+	url = "http://determined.ai/schemas/expconf/v1/hyperparameter-double.json"
+	cachedSchemaMap[url] = parsedDoubleHyperparameterV1()
+	url = "http://determined.ai/schemas/expconf/v1/hyperparameter-int.json"
+	cachedSchemaMap[url] = parsedIntHyperparameterV1()
+	url = "http://determined.ai/schemas/expconf/v1/hyperparameter-log.json"
+	cachedSchemaMap[url] = parsedLogHyperparameterV1()
+	url = "http://determined.ai/schemas/expconf/v1/hyperparameter.json"
+	cachedSchemaMap[url] = parsedHyperparameterV1()
+	url = "http://determined.ai/schemas/expconf/v1/internal.json"
+	cachedSchemaMap[url] = parsedInternalConfigV1()
+	url = "http://determined.ai/schemas/expconf/v1/length.json"
+	cachedSchemaMap[url] = parsedLengthV1()
+	url = "http://determined.ai/schemas/expconf/v1/optimizations.json"
+	cachedSchemaMap[url] = parsedOptimizationsConfigV1()
+	url = "http://determined.ai/schemas/expconf/v1/resources.json"
+	cachedSchemaMap[url] = parsedResourcesConfigV1()
+	url = "http://determined.ai/schemas/expconf/v1/s3.json"
+	cachedSchemaMap[url] = parsedS3ConfigV1()
+	url = "http://determined.ai/schemas/expconf/v1/searcher-adaptive-asha.json"
+	cachedSchemaMap[url] = parsedAdaptiveASHASearcherConfigV1()
+	url = "http://determined.ai/schemas/expconf/v1/searcher-adaptive-simple.json"
+	cachedSchemaMap[url] = parsedAdaptiveSimpleSearcherConfigV1()
+	url = "http://determined.ai/schemas/expconf/v1/searcher-adaptive.json"
+	cachedSchemaMap[url] = parsedAdaptiveSearcherConfigV1()
+	url = "http://determined.ai/schemas/expconf/v1/searcher-async-halving.json"
+	cachedSchemaMap[url] = parsedAsyncHalvingSearcherConfigV1()
+	url = "http://determined.ai/schemas/expconf/v1/searcher-grid.json"
+	cachedSchemaMap[url] = parsedGridSearcherConfigV1()
+	url = "http://determined.ai/schemas/expconf/v1/searcher-pbt.json"
+	cachedSchemaMap[url] = parsedPBTSearcherConfigV1()
+	url = "http://determined.ai/schemas/expconf/v1/searcher-random.json"
+	cachedSchemaMap[url] = parsedRandomSearcherConfigV1()
+	url = "http://determined.ai/schemas/expconf/v1/searcher-single.json"
+	cachedSchemaMap[url] = parsedSingleSearcherConfigV1()
+	url = "http://determined.ai/schemas/expconf/v1/searcher-sync-halving.json"
+	cachedSchemaMap[url] = parsedSyncHalvingSearcherConfigV1()
+	url = "http://determined.ai/schemas/expconf/v1/searcher.json"
+	cachedSchemaMap[url] = parsedSearcherConfigV1()
+	url = "http://determined.ai/schemas/expconf/v1/shared-fs.json"
+	cachedSchemaMap[url] = parsedSharedFSConfigV1()
+	return cachedSchemaMap
+}

--- a/master/pkg/schemas/expconf/v1_test.go
+++ b/master/pkg/schemas/expconf/v1_test.go
@@ -1,0 +1,107 @@
+package expconf
+
+import (
+	"bytes"
+	"encoding/json"
+	"io/ioutil"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"gotest.tools/assert"
+)
+
+type SchemaTestCase struct {
+	Name    string               `json:"name"`
+	Matches *[]string            `json:"matches"`
+	Errors  *map[string][]string `json:"errors"`
+	Case    JSON                 `json:"case"`
+}
+
+func errorIn(expect string, errors []string) bool {
+	for _, msg := range errors {
+		if strings.Contains(msg, expect) {
+			return true
+		}
+	}
+	return false
+}
+
+func (tc SchemaTestCase) CheckMatches(t *testing.T) {
+	if tc.Matches == nil {
+		return
+	}
+	byts, err := json.Marshal(tc.Case)
+	assert.NilError(t, err)
+	for _, url := range *tc.Matches {
+		schema := getCompletenessValidatorV1(url)
+		err := schema.Validate(bytes.NewReader(byts))
+		if err == nil {
+			continue
+		}
+		// Unexpected errors.
+		rendered := getRenderedErrors(err, byts)
+		t.Errorf("errors matching %v:\n%v", url, strings.Join(rendered, "\n"))
+	}
+}
+
+func (tc SchemaTestCase) CheckErrors(t *testing.T) {
+	if tc.Errors == nil {
+		return
+	}
+	byts, err := json.Marshal(tc.Case)
+	assert.NilError(t, err)
+	for url, expectedErrors := range *tc.Errors {
+		schema := getCompletenessValidatorV1(url)
+		err := schema.Validate(bytes.NewReader(byts))
+		if err == nil {
+			t.Errorf("expected error matching %v but got none", url)
+			continue
+		}
+		rendered := getRenderedErrors(err, byts)
+		for _, expect := range expectedErrors {
+			if !errorIn(expect, rendered) {
+				t.Errorf(
+					"while matching %v\ndid not find error:\n    %q\nin:\n    %v",
+					url,
+					expect,
+					strings.Join(rendered, "\n    "),
+				)
+			}
+		}
+	}
+}
+
+func RunCasesFile(t *testing.T, path string) {
+	// Ignore the security error about including files as variables; this is just a test.
+	byts, err := ioutil.ReadFile(path) //nolint: gosec
+	assert.NilError(t, err)
+
+	jbyts, err := jsonFromYaml(byts)
+	assert.NilError(t, err)
+
+	var cases []SchemaTestCase
+	err = json.Unmarshal(jbyts, &cases)
+	assert.NilError(t, err)
+
+	for _, testCase := range cases {
+		tc := testCase
+		t.Run(tc.Name, func(t *testing.T) {
+			tc.CheckMatches(t)
+			tc.CheckErrors(t)
+		})
+	}
+}
+
+func TestExperimentConfig(t *testing.T) {
+	dir := "../../../../schemas/test_cases/v1"
+	files, err := ioutil.ReadDir(dir)
+	assert.NilError(t, err)
+
+	for _, file := range files {
+		path := filepath.Join(dir, file.Name())
+		if strings.HasSuffix(path, ".yaml") {
+			RunCasesFile(t, path)
+		}
+	}
+}

--- a/master/pkg/schemas/extensions/checks.go
+++ b/master/pkg/schemas/extensions/checks.go
@@ -1,0 +1,117 @@
+// See determined_common/schemas/extensions.py for the explanation of this and other extensions.
+
+// This file is a tutorial for implementing extensions for the santhosh-tekuri/jsonschema package.
+//
+// A jsonschema extension consists of three parts:
+//
+//  - A compile function.  Compiling happens once before any validations and takes the schema as
+//    input.  The extension's compile function will be called each time the extension appears in
+//    the schema.  The return value of the compile function will be fed to the validation function.
+//
+//  - A validate function.  Validation happens once for each instance of data that is checked.  The
+//    extension's validate function is called once for each time the compile function was caused,
+//    for each overall validation.  Each call to the validate function receives the output from one
+//    call to the compile function and corresponds to a particular appearance of the extension in
+//    the schema.
+//
+//  - A metaschema which describes how the *schema* that uses the extension is allowed to look.
+
+package extensions
+
+import (
+	"github.com/santhosh-tekuri/jsonschema/v2"
+)
+
+// checksCompile is called for each time the extension appears in the schema.  The input object is
+// the point in the schema which *contains* the extension.  The object returned from the compile
+// function will be passed to the validate function.
+func checksCompile(ctx jsonschema.CompilerContext, m JSONObject) (interface{}, error) {
+	rawChecks, ok := m["checks"]
+	if !ok {
+		return nil, nil
+	}
+
+	// checks is just a map of custom error messages to jsonschema checks.  Example:
+	//
+	//    "checks": {
+	//        "you must specify an entrypoint that references the trial class":{
+	//            ... (schema which allows Native API or requires that entrypoint is set) ...
+	//        },
+	//        "you requested a bayesian search but hyperband is way better": {
+	//            ... (schema which checks if you try searcher.name=baysian) ...
+	//        }
+	//    }
+	checks := rawChecks.(JSONObject)
+
+	// With this package, the way to descend into subschemas during validations is to compile them
+	// here in the compile function, so we can call them later during validation.
+	compiled := map[string]*jsonschema.Schema{}
+	for msg, rawSchema := range checks {
+		schema, err := ctx.Compile(rawSchema)
+		if err != nil {
+			return nil, err
+		}
+		compiled[msg] = schema
+	}
+	return compiled, nil
+}
+
+// checksValidate is called once for each time the extension appears in the schema, during each
+// validation.  Each call to validate during a single validation corresponds to one of the calls
+// to compile, meaning that it corresponds to a particular appearance of the extension in the
+// schema, and meaning that it gets the output of that particular compile call as one of its
+// inputs (the 'compiled' parameter).  The other input is the instance to be validated at this
+// point in the schema.
+func checksValidate(
+	ctx jsonschema.ValidationContext, rawCompiled interface{}, instance JSON,
+) error {
+	// rawCompiled is the interface{}-typed output of our compile function.
+	compiled := rawCompiled.(map[string]*jsonschema.Schema)
+
+	// We will gather up all of the custom error messgages that we need to return in this list.
+	var errors []error
+
+	for msg, schema := range compiled {
+		// Descend into a subschema, using ctx rather than the external API for validation.
+		err := ctx.Validate(schema, instance)
+		if err != nil {
+			// Return the custom error message for this check (which is just the map key).
+			errors = append(errors, ctx.Error("checks", msg))
+		}
+	}
+
+	if len(errors) == 0 {
+		// Woohoo, no errors.  Just return nil.
+		return nil
+	}
+
+	// jsonschema's ValidationError is a nestable error.  We return a single error corresponding to
+	// our extension (a "checks failed" error) with child errors corresponding to the "useful"
+	// errors that we generated from checking subschemas.  Ultimately, only the leaves of this tree
+	// of errors are useful at all.
+	//
+	// Also, jsonschema makes questionable use of object-oriented programming for generating the
+	// errors, hence this odd x variable.
+	var x jsonschema.ValidationError
+	return x.Group(ctx.Error("checks", "checks failed"), errors...)
+}
+
+// ChecksExtension creates the metaschema and returns the full jsonschema.Extension object, gluing
+// together the metaschema, the compile function, and the validate function.
+func ChecksExtension() jsonschema.Extension {
+	meta, err := jsonschema.CompileString("checksExtension.json", `{
+		"properties" : {
+			"checks": {
+				"additionalProperties": { "type": "object" }
+			}
+		}
+	}`)
+	if err != nil {
+		panic(err)
+	}
+	return jsonschema.Extension{
+		Meta:     meta,
+		Compile:  checksCompile,
+		Validate: checksValidate,
+	}
+}

--- a/master/pkg/schemas/extensions/compare_properties.go
+++ b/master/pkg/schemas/extensions/compare_properties.go
@@ -1,0 +1,167 @@
+// See determined_common/schemas/extensions.py for the explanation of this and other extensions.
+// See ./checks.go for notes on implementing extensions for the santhosh-tekuri/jsonschema package.
+
+package extensions
+
+import (
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/santhosh-tekuri/jsonschema/v2"
+)
+
+// getPropertyByPath dereferences a series of nested json objects according to a "."-dilineated
+// name like "a.b.c" and returns the result.  It panics if the name is not present.
+func getPropertyByPath(instance JSON, name string) JSON {
+	for _, key := range strings.Split(name, ".") {
+		instance = instance.(JSONObject)[key]
+	}
+	return instance
+}
+
+// getLengthUnits takes a raw, unmarshaled Length object and returns "records", "epochs", or
+// "batches".  It does not validate the Length; that should be done elsewhere.
+func getLengthUnits(instance JSON) string {
+	// Just return the name of the first key in the object.
+	for key := range instance.(JSONObject) {
+		return key
+	}
+	panic("no unit found")
+}
+
+// getLengthValue takes a raw, unmarshaled Length object and returns the numeric length associated
+// with it.  It does not validate the Length; that should be done elsewhere.
+func getLengthValue(instance JSON) int64 {
+	for _, value := range instance.(JSONObject) {
+		i, err := value.(json.Number).Int64()
+		if err != nil {
+			panic("length is not an integer")
+		}
+		return i
+	}
+	panic("no value found")
+}
+
+// compareProperty is the parsed schema that must be matched against.
+type compareProperty struct {
+	Type string
+	A    string
+	B    string
+}
+
+func comparePropertiesCompile(ctx jsonschema.CompilerContext, m JSONObject) (interface{}, error) {
+	rawCompare, ok := m["compareProperties"]
+	if !ok {
+		return nil, nil
+	}
+	compare := rawCompare.(JSONObject)
+
+	cmp := compareProperty{}
+
+	cmp.Type = compare["type"].(string)
+	cmp.A = compare["a"].(string)
+	cmp.B = compare["b"].(string)
+
+	return cmp, nil
+}
+
+func comparePropertiesValidate(
+	ctx jsonschema.ValidationContext, rawCmp interface{}, instance JSON,
+) error {
+	cmp := rawCmp.(compareProperty)
+
+	// Disregard panics due to wrongly-typed structures; this extensions does not need to
+	// double-check the well-formedness of the instance, just the values.  In fact, duplicate
+	// errors would actually be actively unhelpful.
+	defer func() {
+		_ = recover()
+	}()
+
+	a := getPropertyByPath(instance, cmp.A)
+	b := getPropertyByPath(instance, cmp.B)
+
+	switch cmp.Type {
+	case "a<b":
+		aNum, err := a.(json.Number).Float64()
+		if err != nil {
+			panic("length is not a number")
+		}
+		bNum, err := b.(json.Number).Float64()
+		if err != nil {
+			panic("length is not a number")
+		}
+		if aNum >= bNum {
+			return ctx.Error(
+				"compareProperties",
+				fmt.Sprintf("%v must be less than %v", cmp.A, cmp.B),
+			)
+		}
+
+	case "same_units":
+		aUnit := getLengthUnits(a)
+		bUnit := getLengthUnits(b)
+		if aUnit != bUnit {
+			return ctx.Error(
+				"compareProperties",
+				fmt.Sprintf("%v must use the same units as %v", cmp.A, cmp.B),
+			)
+		}
+
+	case "length_a<length_b":
+		aLength := getLengthValue(a)
+		bLength := getLengthValue(b)
+		if aLength >= bLength {
+			return ctx.Error(
+				"compareProperties",
+				fmt.Sprintf("%v must be less than %v", cmp.A, cmp.B),
+			)
+		}
+
+	case "a_is_subdir_of_b":
+		aPath := filepath.Clean(a.(string))
+		bPath := filepath.Clean(b.(string))
+		if filepath.IsAbs(aPath) {
+			if !strings.HasPrefix(aPath, bPath) {
+				return ctx.Error(
+					"compareProperties",
+					fmt.Sprintf("%v must be a subdirectory of %v", cmp.A, cmp.B),
+				)
+			}
+		} else {
+			if strings.HasPrefix(aPath, "..") {
+				return ctx.Error(
+					"compareProperties",
+					fmt.Sprintf("%v must be a subdirectory of %v", cmp.A, cmp.B),
+				)
+			}
+		}
+	}
+	return nil
+}
+
+// ComparePropertiesExtension instantiates the compareProperties extension.
+func ComparePropertiesExtension() jsonschema.Extension {
+	meta, err := jsonschema.CompileString("compareProperties.json", `{
+		"properties" : {
+			"compareProperties": {
+				"type": "object",
+				"required": ["type", "a", "b"],
+				"properties": {
+					"type": {"type": "string"},
+					"a": {"type": "string"},
+					"b": {"type": "string"}
+				}
+			}
+		}
+	}`)
+	if err != nil {
+		panic(err)
+	}
+	return jsonschema.Extension{
+		Meta:     meta,
+		Compile:  comparePropertiesCompile,
+		Validate: comparePropertiesValidate,
+	}
+}

--- a/master/pkg/schemas/extensions/conditional.go
+++ b/master/pkg/schemas/extensions/conditional.go
@@ -1,0 +1,97 @@
+// See determined_common/schemas/extensions.py for the explanation of this and other extensions.
+// See ./checks.go for notes on implementing extensions for the santhosh-tekuri/jsonschema package.
+
+package extensions
+
+import (
+	"github.com/santhosh-tekuri/jsonschema/v2"
+)
+
+type conditional struct {
+	// Test is either an "unless" or a "when" clause.
+	Test *jsonschema.Schema
+	// EnforceAfterPass will be "true" for "when" clauses or "false" for "unless" clauses.
+	EnforceAfterPass bool
+	// Enforce is the schema whose error will be shown to the user.
+	Enforce *jsonschema.Schema
+}
+
+func conditionalCompile(ctx jsonschema.CompilerContext, m JSONObject) (interface{}, error) {
+	rawConditional, ok := m["conditional"]
+	if !ok {
+		return nil, nil
+	}
+	cond := rawConditional.(JSONObject)
+
+	var err error
+	var test *jsonschema.Schema
+	enforceAfterPass := true
+
+	if rawWhen, ok := cond["when"]; ok {
+		test, err = ctx.Compile(rawWhen)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		test, err = ctx.Compile(cond["unless"])
+		if err != nil {
+			return nil, err
+		}
+		enforceAfterPass = false
+	}
+
+	enforce, err := ctx.Compile(cond["enforce"])
+	if err != nil {
+		return nil, err
+	}
+
+	return conditional{test, enforceAfterPass, enforce}, nil
+}
+
+func conditionalValidate(
+	ctx jsonschema.ValidationContext, rawConditional interface{}, instance JSON,
+) error {
+	cond := rawConditional.(conditional)
+
+	// Evaluate the Test clause.
+	err := ctx.Validate(cond.Test, instance)
+	passed := (err != nil)
+	if cond.EnforceAfterPass == passed {
+		return nil
+	}
+
+	// Evalutate the Enforce clause.
+	err = ctx.Validate(cond.Enforce, instance)
+	if err == nil {
+		return nil
+	}
+
+	var x jsonschema.ValidationError
+	return x.Group(ctx.Error("conditional", "conditional failed"), err)
+}
+
+// ConditionalExtension instantiates the conditional extension.
+func ConditionalExtension() jsonschema.Extension {
+	meta, err := jsonschema.CompileString("conditionalExtension.json", `{
+		"properties" : {
+			"conditional": {
+				"additionalProperties": false,
+				"required": ["enforce"],
+				"properties": {
+					"when": true,
+					"unless": true,
+					"enforce": true,
+					"$comment": {"type": "string"}
+				}
+			}
+		}
+	}`)
+	if err != nil {
+		panic(err)
+	}
+	return jsonschema.Extension{
+		Meta:     meta,
+		Compile:  conditionalCompile,
+		Validate: conditionalValidate,
+	}
+}

--- a/master/pkg/schemas/extensions/disallow_properties.go
+++ b/master/pkg/schemas/extensions/disallow_properties.go
@@ -1,0 +1,69 @@
+// See determined_common/schemas/extensions.py for the explanation of this and other extensions.
+// See ./checks.go for notes on implementing extensions for the santhosh-tekuri/jsonschema package.
+
+package extensions
+
+import (
+	"github.com/santhosh-tekuri/jsonschema/v2"
+)
+
+func disallowPropertiesCompile(ctx jsonschema.CompilerContext, m JSONObject) (interface{}, error) {
+	disallowSchema, ok := m["disallowProperties"]
+	if !ok {
+		return nil, nil
+	}
+
+	// disallowProperties is a map of string property names to error messages.
+	disallowed := map[string]string{}
+
+	for prop, msg := range disallowSchema.(JSONObject) {
+		disallowed[prop] = msg.(string)
+	}
+
+	return disallowed, nil
+}
+
+func disallowPropertiesValidate(
+	ctx jsonschema.ValidationContext, rawDisallowed interface{}, instance JSON,
+) error {
+	object, ok := instance.(JSONObject)
+	if !ok {
+		return nil
+	}
+
+	disallowed := rawDisallowed.(map[string]string)
+
+	var errors []error
+
+	for prop, msg := range disallowed {
+		if _, ok := object[prop]; ok {
+			errors = append(errors, ctx.Error("disallowProperties", msg))
+		}
+	}
+
+	if len(errors) > 0 {
+		var x jsonschema.ValidationError
+		return x.Group(ctx.Error("disallowProperties", "found disallowed properties"), errors...)
+	}
+
+	return nil
+}
+
+// DisallowPropertiesExtension instantiates the disallowProperties extension.
+func DisallowPropertiesExtension() jsonschema.Extension {
+	meta, err := jsonschema.CompileString("disallowProperties.json", `{
+		"properties" : {
+			"disallowProperties": {
+				"additionalProperties": { "type": "string" }
+			}
+		}
+	}`)
+	if err != nil {
+		panic(err)
+	}
+	return jsonschema.Extension{
+		Meta:     meta,
+		Compile:  disallowPropertiesCompile,
+		Validate: disallowPropertiesValidate,
+	}
+}

--- a/master/pkg/schemas/extensions/eventually_required.go
+++ b/master/pkg/schemas/extensions/eventually_required.go
@@ -1,0 +1,73 @@
+// See determined_common/schemas/extensions.py for the explanation of this and other extensions.
+// See ./checks.go for notes on implementing extensions for the santhosh-tekuri/jsonschema package.
+
+package extensions
+
+import (
+	"fmt"
+
+	"github.com/santhosh-tekuri/jsonschema/v2"
+)
+
+func eventuallyRequiredCompile(ctx jsonschema.CompilerContext, m JSONObject) (interface{}, error) {
+	eventuallyRequired, ok := m["eventuallyRequired"]
+	if !ok {
+		return nil, nil
+	}
+
+	// eventuallyRequired is a list of string property names.
+	var required []string
+	for _, prop := range eventuallyRequired.(JSONArray) {
+		required = append(required, prop.(string))
+	}
+	return required, nil
+}
+
+func eventuallyRequiredValidate(
+	ctx jsonschema.ValidationContext, rawRequired interface{}, instance JSON,
+) error {
+	object, ok := instance.(JSONObject)
+	if !ok {
+		return nil
+	}
+
+	required := rawRequired.([]string)
+
+	var errors []error
+
+	// Require every eventuallyRequired property to be present in object.
+	for _, prop := range required {
+		value, ok := object[prop]
+		if ok && value != nil {
+			continue
+		}
+		reason := fmt.Sprintf("%v is a required property", prop)
+		errors = append(errors, ctx.Error("eventuallyRequired", reason))
+	}
+
+	if len(errors) == 0 {
+		return nil
+	}
+
+	var x jsonschema.ValidationError
+	return x.Group(ctx.Error("eventuallyRequired", "missing required properties"), errors...)
+}
+
+// EventuallyRequiredExtension instantiates the eventuallyRequired extension.
+func EventuallyRequiredExtension() jsonschema.Extension {
+	meta, err := jsonschema.CompileString("eventuallyRequired.json", `{
+		"properties" : {
+			"eventuallyRequired": {
+				"items": { "type": "string" }
+			}
+		}
+	}`)
+	if err != nil {
+		panic(err)
+	}
+	return jsonschema.Extension{
+		Meta:     meta,
+		Compile:  eventuallyRequiredCompile,
+		Validate: eventuallyRequiredValidate,
+	}
+}

--- a/master/pkg/schemas/extensions/union.go
+++ b/master/pkg/schemas/extensions/union.go
@@ -1,0 +1,215 @@
+// See determined_common/schemas/extensions.py for the explanation of this and other extensions.
+// See ./checks.go for notes on implementing extensions for the santhosh-tekuri/jsonschema package.
+
+package extensions
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/santhosh-tekuri/jsonschema/v2"
+)
+
+type unionItem struct {
+	Schema    *jsonschema.Schema
+	Key       string
+	RawSchema JSON
+}
+
+type unionSchema struct {
+	Message string
+	Items   []unionItem
+}
+
+func unionCompile(ctx jsonschema.CompilerContext, m JSONObject) (interface{}, error) {
+	rawUnion, ok := m["union"]
+	if !ok {
+		return nil, nil
+	}
+
+	union := rawUnion.(JSONObject)
+
+	// Store the default message.
+	rawDefaultMessage, ok := union["defaultMessage"]
+	defaultMessage := "union failed to validate"
+	if ok {
+		msgString := rawDefaultMessage.(string)
+		defaultMessage = msgString
+	}
+
+	// Compile the child schemas.
+	var items []unionItem
+	rawItems := union["items"].(JSONArray)
+	for _, rawItem := range rawItems {
+		schema, err := ctx.Compile(rawItem)
+		if err != nil {
+			return nil, err
+		}
+
+		item := rawItem.(JSONObject)
+		rawKey := item["unionKey"]
+		key := rawKey.(string)
+		items = append(items, unionItem{schema, key, rawItem})
+	}
+
+	return unionSchema{defaultMessage, items}, nil
+}
+
+func unionValidate(
+	ctx jsonschema.ValidationContext, rawUnion interface{}, instance JSON,
+) error {
+	union := rawUnion.(unionSchema)
+
+	// We will only return one error message, which should be the error where the unionKey
+	// evaluates to true.
+	var selectedError error
+
+	// We should only have one subschema which validates as true.
+	var valid []JSON
+
+	for _, item := range union.Items {
+		err := ctx.Validate(item.Schema, instance)
+		if err != nil {
+			if selectedError == nil {
+				// Is this the error we want to show to users?
+				if evaluateUnionKey(item.Key, instance) {
+					selectedError = err
+				}
+			}
+		} else {
+			valid = append(valid, item.RawSchema)
+		}
+	}
+
+	if len(valid) == 1 {
+		// no errors
+		return nil
+	}
+
+	if len(valid) > 1 {
+		return ctx.Error("union", "bug in validation! Multiple schemas matched: %v", valid)
+	}
+
+	if selectedError != nil {
+		var x jsonschema.ValidationError
+		return x.Group(ctx.Error("union", union.Message), selectedError)
+	}
+
+	return ctx.Error("union", union.Message)
+}
+
+// UnionExtension instantiates the union extension.
+func UnionExtension() jsonschema.Extension {
+	meta, err := jsonschema.CompileString("union.json", `{
+		"properties" : {
+			"defaultMessage": { "type": "string" },
+			"union": {
+				"type": "object",
+				"additionalProperties": false,
+				"required": ["items"],
+				"properties": {
+					"defaultMessage": { "type": "string" },
+					"items": {
+						"type": "array",
+						"items": {
+							"type": "object",
+							"required": ["unionKey"],
+							"properties": {
+								"unionKey": { "type": "string" }
+							}
+						}
+					}
+				}
+			}
+		}
+	}`)
+	if err != nil {
+		panic(err)
+	}
+	return jsonschema.Extension{
+		Meta:     meta,
+		Compile:  unionCompile,
+		Validate: unionValidate,
+	}
+}
+
+func evaluateUnionKey(key JSON, instance JSON) bool {
+	switch tKey := key.(type) {
+	case string:
+		// Parse the string and evaluate.
+		switch {
+		case tKey == "always":
+			return true
+
+		case tKey == "never":
+			return false
+
+		case strings.HasPrefix(tKey, "not:"):
+			return !evaluateUnionKey(tKey[len("not:"):], instance)
+
+		case strings.HasPrefix(tKey, "const:"):
+			split := strings.SplitN(tKey[len("const:"):], "=", 2)
+			if len(split) != 2 {
+				panic("invalid unionKey")
+			}
+			name := split[0]
+			value := split[1]
+
+			tInstance, ok := instance.(JSONObject)
+			if !ok {
+				return false
+			}
+
+			instanceValue, ok := tInstance[name]
+			if !ok {
+				return false
+			}
+
+			tInstanceValue, ok := instanceValue.(string)
+			if !ok {
+				return false
+			}
+
+			return value == tInstanceValue
+
+		case strings.HasPrefix(tKey, "singleproperty:"):
+			name := tKey[len("singleproperty:"):]
+
+			tInstance, ok := instance.(JSONObject)
+			if !ok {
+				return false
+			}
+
+			if len(tInstance) != 1 {
+				return false
+			}
+
+			_, ok = tInstance[name]
+			return ok
+
+		case strings.HasPrefix(tKey, "type:"):
+			typ := tKey[len("type:"):]
+
+			switch typ {
+			case "array":
+				_, ok := instance.(JSONArray)
+				return ok
+			case "object":
+				_, ok := instance.(JSONObject)
+				return ok
+			}
+
+		case strings.HasPrefix(tKey, "hasattr:"):
+			attr := tKey[len("hasattr:"):]
+
+			tInstance, ok := instance.(JSONObject)
+			if !ok {
+				return false
+			}
+
+			_, ok = tInstance[attr]
+			return ok
+		}
+	}
+	panic(fmt.Sprintf("invalid unionKey: %v", key))
+}

--- a/master/pkg/schemas/extensions/util.go
+++ b/master/pkg/schemas/extensions/util.go
@@ -1,0 +1,10 @@
+package extensions
+
+type (
+	// JSON is the type for arbitrary JSON.
+	JSON = interface{}
+	// JSONObject is the type for JSON objects.
+	JSONObject = map[string]interface{}
+	// JSONArray is the type for JSON arrays.
+	JSONArray = []interface{}
+)

--- a/master/pkg/union/marshal.go
+++ b/master/pkg/union/marshal.go
@@ -8,8 +8,8 @@ import (
 	"github.com/pkg/errors"
 )
 
-// Marshal marshals the provided union type into a JSON byte array.
-func Marshal(v interface{}) ([]byte, error) {
+// MarshalEx allows for configurable error handling.
+func MarshalEx(v interface{}, allowEmptyUnion bool) ([]byte, error) {
 	data := make(map[string]interface{})
 	value := reflect.ValueOf(v)
 	valueType := reflect.TypeOf(v)
@@ -50,7 +50,7 @@ func Marshal(v interface{}) ([]byte, error) {
 		}
 
 		// At least one union type must be defined.
-		if !unionDefined {
+		if !unionDefined && !allowEmptyUnion {
 			return nil, errors.Errorf("no union field defined: %s", key)
 		}
 	}
@@ -74,6 +74,11 @@ func Marshal(v interface{}) ([]byte, error) {
 	}
 
 	return json.Marshal(data)
+}
+
+// Marshal marshals the provided union type into a JSON byte array.
+func Marshal(v interface{}) ([]byte, error) {
+	return MarshalEx(v, false)
 }
 
 // marshalToMap returns a map representation of the provided interface.

--- a/schemas/.flake8
+++ b/schemas/.flake8
@@ -1,0 +1,43 @@
+[flake8]
+max-line-length = 100
+exclude =
+    .git,
+    __pycache__,
+    build,
+    dist
+
+# We ignore F401 in __init__.py because it is expected for there to be
+# "unused imports" when defining a "regular" package. (This file is
+# implicitly executed when the package is imported, and the imports would
+# be used by the importer.) We ignore patch_saver_restore.py because it includes
+# a near-verbatim TensorFlow function with a small patch.
+per-file-ignores = __init__.py:F401 patch_saver_restore.py:E111,E114,
+
+# Explanations for ignored error codes:
+# - D1* (no missing docstrings): too much effort to start enforcing
+# - D200 (short docstring must fit in one line with quotes): stylistic choice
+# - D202 (no blank lines after function docstrings): stylistic choice
+# - D203 (blank line before class docstring): stylistic choice
+# - D205 (blank line between summary and description): not enforcing single-line summaries
+# - D212 (docstring should start on first line): stylistic choice (prefer D213, docstrings start on second line)
+# - D4* (docstring content warnings): too much effort to start enforcing
+# - E203 (no space before colon): not PEP8-compliant; triggered by Black-formatted code
+# - W503 (no line breaks before binary operator): not PEP8-compliant; triggered by Black-formatted code
+# - C812-C816 (missing trailing comma): stylistic choice
+ignore = D1,D200,D202,D203,D205,D212,D4,E203,W503,C812,C813,C814,C815,C816
+
+show_source = true
+
+# flake8-colors
+format = ${cyan}%(path)s${reset}:${yellow_bold}%(row)d${reset}:${green_bold}%(col)d${reset}: ${red_bold}%(code)s${reset} %(text)s
+
+# flake8-docstrings
+docstring-convention = google
+
+# flake8-import-order
+application-import-names = determined
+import-order-style = edited
+
+# flake8-quotes
+inline-quotes = "
+multiline-quotes = """

--- a/schemas/Makefile
+++ b/schemas/Makefile
@@ -1,0 +1,15 @@
+all:
+
+.PHONY: fmt
+fmt:
+	./lint.py expconf/v1/*
+	isort -y
+	black .
+
+.PHONY: check
+check:
+	./lint.py --check expconf/v1/*
+	isort --check-only
+	black . --check
+	flake8
+	mypy `find -name '*.py'`

--- a/schemas/README
+++ b/schemas/README
@@ -1,0 +1,44 @@
+JSON-SCHEMA AS THE EXPERIMENT CONFIG DEFINITION
+
+Linting:
+  - There is a linter which enforces various custom checks to ensure that the
+    assumptions we make in our system will be enforced by the schemas
+  - The linter also enforces basic formatting requirements
+
+Validation:
+  - Validation happens in two steps:
+    - Sanity check: make sure everything is parsable
+    - Validation: make sure everything is present
+  - Sanity check is applied to raw user inputs
+  - Validation is applied after cluster defaults have been applied
+  - The implementation difference between sanity check and validation is the
+    inclusion of a single eventuallyRequired schema in the latter.
+
+Null handling:
+  - There is no pythonic or golangic way to represent values which were
+    provided in the configuration as literal nulls, rather than values which
+    were not provided at all.  In theory, you could have singleton
+    "NotProvided" pointers, which you would check for every time that you
+    checked a value in the schema, but in practice that would be a pain in the
+    ass.  Additionally, the golang json-schema library we use treats
+    not-present values a nil values anyway.
+
+    Conclusion: null values shall be treated as if they were not present.
+
+Default values:
+  - "default" refers to "encoded in json-schema" and not "cluster default"
+  - otherwise, there's no way to do client-side defaults, as the master would
+    need to be involved in deciding all default values.
+
+Customization strategy:
+  - Json-schema alone does not provide the behavior we want out of the box
+  - Most json-schema libraries have great support for custom validation logic
+  - We have json-schema extensions for the following keywords:
+    - checks: Custom messages for arbitrary validation logic
+    - compareProperties: Support customizable value comparisons
+    - conditional: Enforce a schema whenever some condition is met.
+    - disallowProperties: Custom messages when disallowing properties
+    - eventuallyRequired: Support two-step validation
+    - union: Excellent error messages when validating union types
+  - The canonical implementations (with thorough comments) may be found in
+    determined_common/schemas/extensions.py

--- a/schemas/expconf/v1/bind-mount.json
+++ b/schemas/expconf/v1/bind-mount.json
@@ -1,0 +1,45 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "http://determined.ai/schemas/expconf/v1/bind-mount.json",
+    "title": "BindMount",
+    "additionalProperties": false,
+    "required": [
+        "host_path",
+        "container_path"
+    ],
+    "type": "object",
+    "properties": {
+        "host_path": {
+            "type": "string",
+            "checks": {
+                "host_path must be an absolute path": {
+                    "pattern": "^/"
+                }
+            }
+        },
+        "container_path": {
+            "type": "string",
+            "checks": {
+                "container_path must not be \".\"": {
+                    "not": {
+                        "const": "."
+                    }
+                }
+            }
+        },
+        "read_only": {
+            "type": [
+                "boolean",
+                "null"
+            ],
+            "default": false
+        },
+        "propagation": {
+            "type": [
+                "string",
+                "null"
+            ],
+            "default": "rprivate"
+        }
+    }
+}

--- a/schemas/expconf/v1/check-data-layer-cache.json
+++ b/schemas/expconf/v1/check-data-layer-cache.json
@@ -1,0 +1,37 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "http://determined.ai/schemas/expconf/v1/check-data-layer-cache.json",
+    "title": "CheckDataLayerCache",
+    "checks": {
+        "local_cache_container_path must be specified if local_cache_host_path is set": {
+            "not": {
+                "required": [
+                    "local_cache_host_path"
+                ],
+                "properties": {
+                    "local_cache_container_path": {
+                        "type": "null"
+                    },
+                    "local_cache_host_path": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "local_cache_host_path must be specified if local_cache_container_path is set": {
+            "not": {
+                "required": [
+                    "local_cache_container_path"
+                ],
+                "properties": {
+                    "local_cache_container_path": {
+                        "type": "string"
+                    },
+                    "local_cache_host_path": {
+                        "type": "null"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/schemas/expconf/v1/check-epoch-not-used.json
+++ b/schemas/expconf/v1/check-epoch-not-used.json
@@ -1,0 +1,22 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "http://determined.ai/schemas/expconf/v1/check-epoch-not-used.json",
+    "title": "CheckEpochNotUsed",
+    "additionalProperties": {
+        "$ref": "http://determined.ai/schemas/expconf/v1/check-epoch-not-used.json"
+    },
+    "items": {
+        "$ref": "http://determined.ai/schemas/expconf/v1/check-epoch-not-used.json"
+    },
+    "checks": {
+        "must specify the top-level records_per_epoch when this field is in terms of epochs": {
+            "properties": {
+                "epochs": {
+                    "not": {
+                        "type": "number"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/schemas/expconf/v1/check-global-batch-size.json
+++ b/schemas/expconf/v1/check-global-batch-size.json
@@ -1,0 +1,66 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "http://determined.ai/schemas/expconf/v1/check-global-batch-size.json",
+    "title": "CheckGlobalBatchSize",
+    "union": {
+        "defaultMessage": "is neither a positive integer nor an int hyperparameter",
+        "items": [
+            {
+                "unionKey": "const:type=int",
+                "allOf": [
+                    {
+                        "$ref": "http://determined.ai/schemas/expconf/v1/hyperparameter-int.json"
+                    },
+                    {
+                        "properties": {
+                            "minval": {
+                                "type": "number",
+                                "minimum": 1
+                            }
+                        }
+                    }
+                ]
+            },
+            {
+                "unionKey": "const:type=const",
+                "allOf": [
+                    {
+                        "$ref": "http://determined.ai/schemas/expconf/v1/hyperparameter-const.json"
+                    },
+                    {
+                        "properties": {
+                            "val": {
+                                "type": "number",
+                                "minimum": 1
+                            }
+                        }
+                    }
+                ]
+            },
+            {
+                "unionKey": "const:type=categorical",
+                "allOf": [
+                    {
+                        "$ref": "http://determined.ai/schemas/expconf/v1/hyperparameter-categorical.json"
+                    },
+                    {
+                        "properties": {
+                            "vals": {
+                                "type": "array",
+                                "items": {
+                                    "type": "integer",
+                                    "minimum": 1
+                                }
+                            }
+                        }
+                    }
+                ]
+            },
+            {
+                "unionKey": "never",
+                "type": "integer",
+                "minimum": 1
+            }
+        ]
+    }
+}

--- a/schemas/expconf/v1/check-grid-hyperparameter.json
+++ b/schemas/expconf/v1/check-grid-hyperparameter.json
@@ -1,0 +1,76 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "http://determined.ai/schemas/expconf/v1/check-grid-hyperparameter.json",
+    "title": "CheckGridHyperparameter",
+    "union": {
+        "items": [
+            {
+                "unionKey": "type:array",
+                "type": "array",
+                "items": {
+                    "$ref": "http://determined.ai/schemas/expconf/v1/check-grid-hyperparameter.json"
+                }
+            },
+            {
+                "unionKey": "not:hasattr:type",
+                "type": "object",
+                "properties": {
+                    "type": false
+                },
+                "additionalProperties": {
+                    "$ref": "http://determined.ai/schemas/expconf/v1/check-grid-hyperparameter.json"
+                }
+            },
+            {
+                "unionKey": "never",
+                "not": {
+                    "type": [
+                        "object",
+                        "array"
+                    ]
+                }
+            },
+            {
+                "unionKey": "hasattr:type",
+                "type": "object",
+                "required": [
+                    "type"
+                ],
+                "properties": {
+                    "type": {
+                        "type": "string"
+                    }
+                },
+                "checks": {
+                    "grid search is in use but count was not provided": {
+                        "conditional": {
+                            "$comment": "unless type is not double/log/int, expect non-null count",
+                            "unless": {
+                                "not": {
+                                    "properties": {
+                                        "type": {
+                                            "enum": [
+                                                "double",
+                                                "log",
+                                                "int"
+                                            ]
+                                        }
+                                    }
+                                }
+                            },
+                            "enforce": {
+                                "not": {
+                                    "properties": {
+                                        "count": {
+                                            "type": "null"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        ]
+    }
+}

--- a/schemas/expconf/v1/check-positive-length.json
+++ b/schemas/expconf/v1/check-positive-length.json
@@ -1,0 +1,16 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "http://determined.ai/schemas/expconf/v1/check-positive-length.json",
+    "title": "CheckPositiveLength",
+    "allOf": [
+        {
+            "$ref": "http://determined.ai/schemas/expconf/v1/length.json"
+        },
+        {
+            "additionalProperties": {
+                "type": "integer",
+                "minimum": 1
+            }
+        }
+    ]
+}

--- a/schemas/expconf/v1/checkpoint-storage.json
+++ b/schemas/expconf/v1/checkpoint-storage.json
@@ -1,0 +1,26 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "http://determined.ai/schemas/expconf/v1/checkpoint-storage.json",
+    "title": "CheckpointStorageConfig",
+    "union": {
+        "defaultMessage": "is not an object where object[\"type\"] is one of 'shared_fs', 'hdfs', 's3', or 'gcs'",
+        "items": [
+            {
+                "unionKey": "const:type=shared_fs",
+                "$ref": "http://determined.ai/schemas/expconf/v1/shared-fs.json"
+            },
+            {
+                "unionKey": "const:type=hdfs",
+                "$ref": "http://determined.ai/schemas/expconf/v1/hdfs.json"
+            },
+            {
+                "unionKey": "const:type=s3",
+                "$ref": "http://determined.ai/schemas/expconf/v1/s3.json"
+            },
+            {
+                "unionKey": "const:type=gcs",
+                "$ref": "http://determined.ai/schemas/expconf/v1/gcs.json"
+            }
+        ]
+    }
+}

--- a/schemas/expconf/v1/data-layer-gcs.json
+++ b/schemas/expconf/v1/data-layer-gcs.json
@@ -1,0 +1,52 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "http://determined.ai/schemas/expconf/v1/data-layer-gcs.json",
+    "title": "DataLayerGCSConfig",
+    "type": "object",
+    "additionalProperties": false,
+    "required": [
+        "type",
+        "bucket",
+        "bucket_directory_path"
+    ],
+    "properties": {
+        "type": {
+            "const": "gcs"
+        },
+        "bucket": {
+            "type": "string"
+        },
+        "bucket_directory_path": {
+            "type": "string"
+        },
+        "local_cache_host_path": {
+            "type": [
+                "string",
+                "null"
+            ],
+            "checks": {
+                "local_cache_host_path must be an absolute path": {
+                    "pattern": "^/"
+                }
+            },
+            "default": null
+        },
+        "local_cache_container_path": {
+            "type": [
+                "string",
+                "null"
+            ],
+            "checks": {
+                "local_cache_container_path must be an absolute path": {
+                    "pattern": "^/"
+                }
+            },
+            "default": null
+        }
+    },
+    "allOf": [
+        {
+            "$ref": "http://determined.ai/schemas/expconf/v1/check-data-layer-cache.json"
+        }
+    ]
+}

--- a/schemas/expconf/v1/data-layer-s3.json
+++ b/schemas/expconf/v1/data-layer-s3.json
@@ -1,0 +1,73 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "http://determined.ai/schemas/expconf/v1/data-layer-s3.json",
+    "title": "DataLayerS3Config",
+    "type": "object",
+    "additionalProperties": false,
+    "required": [
+        "type",
+        "bucket",
+        "bucket_directory_path"
+    ],
+    "properties": {
+        "type": {
+            "const": "s3"
+        },
+        "bucket": {
+            "type": "string"
+        },
+        "bucket_directory_path": {
+            "type": "string"
+        },
+        "local_cache_host_path": {
+            "type": [
+                "string",
+                "null"
+            ],
+            "checks": {
+                "local_cache_host_path must be an absolute path": {
+                    "pattern": "^/"
+                }
+            },
+            "default": null
+        },
+        "local_cache_container_path": {
+            "type": [
+                "string",
+                "null"
+            ],
+            "checks": {
+                "local_cache_container_path must be an absolute path": {
+                    "pattern": "^/"
+                }
+            },
+            "default": null
+        },
+        "access_key": {
+            "type": [
+                "string",
+                "null"
+            ],
+            "default": null
+        },
+        "secret_key": {
+            "type": [
+                "string",
+                "null"
+            ],
+            "default": null
+        },
+        "endpoint_url": {
+            "type": [
+                "string",
+                "null"
+            ],
+            "default": null
+        }
+    },
+    "allOf": [
+        {
+            "$ref": "http://determined.ai/schemas/expconf/v1/check-data-layer-cache.json"
+        }
+    ]
+}

--- a/schemas/expconf/v1/data-layer-shared-fs.json
+++ b/schemas/expconf/v1/data-layer-shared-fs.json
@@ -1,0 +1,39 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "http://determined.ai/schemas/expconf/v1/data-layer-shared-fs.json",
+    "title": "DataLayerSharedFSConfig",
+    "type": "object",
+    "additionalProperties": false,
+    "required": [
+        "type"
+    ],
+    "properties": {
+        "type": {
+            "const": "shared_fs"
+        },
+        "host_storage_path": {
+            "type": [
+                "string",
+                "null"
+            ],
+            "checks": {
+                "host_storage_path must be an absolute path": {
+                    "pattern": "^/"
+                }
+            },
+            "default": null
+        },
+        "container_storage_path": {
+            "type": [
+                "string",
+                "null"
+            ],
+            "checks": {
+                "container_storage_path must be an absolute path": {
+                    "pattern": "^/"
+                }
+            },
+            "default": null
+        }
+    }
+}

--- a/schemas/expconf/v1/data-layer.json
+++ b/schemas/expconf/v1/data-layer.json
@@ -1,0 +1,22 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "http://determined.ai/schemas/expconf/v1/data-layer.json",
+    "title": "DataLayerConfig",
+    "union": {
+        "defaultMessage": "is not an object where object[\"type\"] is one of 'shared_fs', 's3', or 'gcs'",
+        "items": [
+            {
+                "unionKey": "const:type=shared_fs",
+                "$ref": "http://determined.ai/schemas/expconf/v1/data-layer-shared-fs.json"
+            },
+            {
+                "unionKey": "const:type=gcs",
+                "$ref": "http://determined.ai/schemas/expconf/v1/data-layer-gcs.json"
+            },
+            {
+                "unionKey": "const:type=s3",
+                "$ref": "http://determined.ai/schemas/expconf/v1/data-layer-s3.json"
+            }
+        ]
+    }
+}

--- a/schemas/expconf/v1/environment-image.json
+++ b/schemas/expconf/v1/environment-image.json
@@ -1,0 +1,31 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "http://determined.ai/schemas/expconf/v1/environment-image.json",
+    "title": "EnvironmentImage",
+    "union": {
+        "defaultMessage": "is neither a string nor a map of cpu/gpu to strings",
+        "items": [
+            {
+                "unionKey": "never",
+                "type": "object",
+                "additionalProperties": false,
+                "required": [
+                    "cpu",
+                    "gpu"
+                ],
+                "properties": {
+                    "cpu": {
+                        "type": "string"
+                    },
+                    "gpu": {
+                        "type": "string"
+                    }
+                }
+            },
+            {
+                "unionKey": "never",
+                "type": "string"
+            }
+        ]
+    }
+}

--- a/schemas/expconf/v1/environment-variables.json
+++ b/schemas/expconf/v1/environment-variables.json
@@ -1,0 +1,44 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "http://determined.ai/schemas/expconf/v1/environment-variables.json",
+    "title": "EnvironmentVariables",
+    "union": {
+        "defaultMessage": "is neither a list of strings nor a map of cpu/gpu to lists of strings",
+        "items": [
+            {
+                "unionKey": "never",
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "cpu": {
+                        "type": [
+                            "array",
+                            "null"
+                        ],
+                        "items": {
+                            "type": "string"
+                        },
+                        "default": []
+                    },
+                    "gpu": {
+                        "type": [
+                            "array",
+                            "null"
+                        ],
+                        "items": {
+                            "type": "string"
+                        },
+                        "default": []
+                    }
+                }
+            },
+            {
+                "unionKey": "never",
+                "type": "array",
+                "items": {
+                    "type": "string"
+                }
+            }
+        ]
+    }
+}

--- a/schemas/expconf/v1/environment.json
+++ b/schemas/expconf/v1/environment.json
@@ -1,0 +1,92 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "http://determined.ai/schemas/expconf/v1/environment.json",
+    "title": "EnvironmentConfig",
+    "type": "object",
+    "additionalProperties": false,
+    "required": [],
+    "properties": {
+        "image": {
+            "type": [
+                "object",
+                "null"
+            ],
+            "$ref": "http://determined.ai/schemas/expconf/v1/environment-image.json",
+            "default": null
+        },
+        "environment_variables": {
+            "type": [
+                "object",
+                "null"
+            ],
+            "$ref": "http://determined.ai/schemas/expconf/v1/environment-variables.json",
+            "default": []
+        },
+        "ports": {
+            "type": [
+                "object",
+                "null"
+            ],
+            "additionalProperties": {
+                "type": "integer"
+            },
+            "default": {}
+        },
+        "force_pull_image": {
+            "type": [
+                "boolean",
+                "null"
+            ],
+            "default": false
+        },
+        "pod_spec": {
+            "type": [
+                "object",
+                "null"
+            ],
+            "default": null,
+            "disallowProperties": {
+                "name": "pod Name is not a configurable option",
+                "name_space": "pod NameSpace is not a configurable option"
+            },
+            "properties": {
+                "spec": {
+                    "type": [
+                        "object",
+                        "null"
+                    ],
+                    "default": null,
+                    "properties": {
+                        "containers": {
+                            "type": [
+                                "array",
+                                "null"
+                            ],
+                            "default": null,
+                            "items": {
+                                "type": "object",
+                                "disallowProperties": {
+                                    "image": "container Image is not configurable, set it in the experiment config",
+                                    "command": "container Command is not configurable",
+                                    "args": "container Args are not configurable",
+                                    "working_dir": "container WorkingDir is not configurable",
+                                    "ports": "container Ports are not configurable",
+                                    "env_from": "container EnvFrom is not configurable",
+                                    "env": "container Env is not configurable, set it in the experiment config",
+                                    "liveness_probe": "container LivenessProbe is not configurable",
+                                    "readiness_probe": "container ReadinessProbe is not configurable",
+                                    "startup_probe": "container StartupProbe is not configurable",
+                                    "lifecycle": "container Lifecycle is not configurable",
+                                    "termination_message_path": "container TerminationMessagePath is not configurable",
+                                    "termination_message_policy": "container TerminationMessagePolicy is not configurable",
+                                    "image_pull_policy": "container ImagePullPolicy is not configurable, set it in the experiment config",
+                                    "security_context": "container SecurityContext is not configurable, set it in the experiment config"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/schemas/expconf/v1/experiment.json
+++ b/schemas/expconf/v1/experiment.json
@@ -1,0 +1,298 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "http://determined.ai/schemas/expconf/v1/experiment.json",
+    "title": "ExperimentConfig",
+    "type": "object",
+    "additionalProperties": false,
+    "required": [
+        "hyperparameters",
+        "searcher"
+    ],
+    "eventuallyRequired": [
+        "checkpoint_storage"
+    ],
+    "properties": {
+        "bind_mounts": {
+            "type": [
+                "array",
+                "null"
+            ],
+            "items": {
+                "$ref": "http://determined.ai/schemas/expconf/v1/bind-mount.json"
+            },
+            "default": []
+        },
+        "checkpoint_policy": {
+            "enum": [
+                null,
+                "best",
+                "all",
+                "none"
+            ],
+            "default": "best"
+        },
+        "checkpoint_storage": {
+            "type": [
+                "object",
+                "null"
+            ],
+            "$ref": "http://determined.ai/schemas/expconf/v1/checkpoint-storage.json",
+            "default": "null"
+        },
+        "data": {
+            "type": [
+                "object",
+                "null"
+            ],
+            "default": {}
+        },
+        "data_layer": {
+            "type": [
+                "object",
+                "null"
+            ],
+            "$ref": "http://determined.ai/schemas/expconf/v1/data-layer.json",
+            "default": {
+                "type": "shared_fs"
+            }
+        },
+        "debug": {
+            "type": [
+                "boolean",
+                "null"
+            ],
+            "default": false
+        },
+        "description": {
+            "type": [
+                "string",
+                "null"
+            ],
+            "default": ""
+        },
+        "entrypoint": {
+            "type": [
+                "string",
+                "null"
+            ],
+            "checks": {
+                "entrypoint must be of the form \"module.submodule:ClassName\"": {
+                    "pattern": "^[a-zA-Z0-9_.]+:[a-zA-Z0-9_]+$"
+                }
+            },
+            "default": null
+        },
+        "environment": {
+            "type": [
+                "object",
+                "null"
+            ],
+            "$ref": "http://determined.ai/schemas/expconf/v1/environment.json",
+            "default": null
+        },
+        "hyperparameters": {
+            "type": "object",
+            "required": [
+                "global_batch_size"
+            ],
+            "properties": {
+                "global_batch_size": {
+                    "$ref": "http://determined.ai/schemas/expconf/v1/check-global-batch-size.json"
+                }
+            },
+            "additionalProperties": {
+                "$ref": "http://determined.ai/schemas/expconf/v1/hyperparameter.json"
+            }
+        },
+        "internal": {
+            "type": [
+                "object",
+                "null"
+            ],
+            "default": null
+        },
+        "labels": {
+            "type": [
+                "array",
+                "null"
+            ],
+            "items": {
+                "type": "string"
+            },
+            "default": null
+        },
+        "max_restarts": {
+            "type": [
+                "integer",
+                "null"
+            ],
+            "minimum": 0,
+            "default": 5
+        },
+        "min_checkpoint_period": {
+            "type": [
+                "object",
+                "null"
+            ],
+            "$ref": "http://determined.ai/schemas/expconf/v1/length.json",
+            "default": {
+                "batches": 0
+            }
+        },
+        "min_validation_period": {
+            "type": [
+                "object",
+                "null"
+            ],
+            "$ref": "http://determined.ai/schemas/expconf/v1/length.json",
+            "default": {
+                "batches": 0
+            }
+        },
+        "optimizations": {
+            "type": [
+                "object",
+                "null"
+            ],
+            "$ref": "http://determined.ai/schemas/expconf/v1/optimizations.json",
+            "default": {}
+        },
+        "perform_initial_validation": {
+            "type": [
+                "boolean",
+                "null"
+            ],
+            "default": true
+        },
+        "records_per_epoch": {
+            "type": [
+                "integer",
+                "null"
+            ],
+            "default": 0
+        },
+        "reproducibility": {
+            "type": [
+                "object",
+                "null"
+            ],
+            "additionalProperties": false,
+            "properties": {
+                "experiment_seed": {
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "default": null
+                }
+            },
+            "default": {}
+        },
+        "resources": {
+            "type": [
+                "object",
+                "null"
+            ],
+            "$ref": "http://determined.ai/schemas/expconf/v1/resources.json",
+            "default": {}
+        },
+        "scheduling_unit": {
+            "type": [
+                "integer",
+                "null"
+            ],
+            "minimum": 1,
+            "default": 100
+        },
+        "searcher": {
+            "$ref": "http://determined.ai/schemas/expconf/v1/searcher.json"
+        },
+        "security": {
+            "type": "null",
+            "default": "null"
+        },
+        "tensorboard_storage": {
+            "type": "null",
+            "default": "null"
+        }
+    },
+    "allOf": [
+        {
+            "conditional": {
+                "$comment": "when grid search is in use, expect hp counts",
+                "when": {
+                    "properties": {
+                        "searcher": {
+                            "properties": {
+                                "name": {
+                                    "const": "grid"
+                                }
+                            }
+                        }
+                    }
+                },
+                "enforce": {
+                    "properties": {
+                        "hyperparameters": {
+                            "additionalProperties": {
+                                "$ref": "http://determined.ai/schemas/expconf/v1/check-grid-hyperparameter.json"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        {
+            "conditional": {
+                "$comment": "when records per epoch not set, forbid epoch lengths",
+                "when": {
+                    "properties": {
+                        "records_per_epoch": {
+                            "maximum": 0
+                        }
+                    }
+                },
+                "enforce": {
+                    "properties": {
+                        "min_validation_period": {
+                            "$ref": "http://determined.ai/schemas/expconf/v1/check-epoch-not-used.json"
+                        },
+                        "min_checkpoint_period": {
+                            "$ref": "http://determined.ai/schemas/expconf/v1/check-epoch-not-used.json"
+                        },
+                        "searcher": {
+                            "$ref": "http://determined.ai/schemas/expconf/v1/check-epoch-not-used.json"
+                        }
+                    }
+                }
+            }
+        }
+    ],
+    "checks": {
+        "must specify an entrypoint that references the trial class": {
+            "conditional": {
+                "$comment": "when internal.native is null, expect an entrypoint",
+                "when": {
+                    "properties": {
+                        "internal": {
+                            "properties": {
+                                "native": {
+                                    "type": "null"
+                                }
+                            }
+                        }
+                    }
+                },
+                "enforce": {
+                    "not": {
+                        "properties": {
+                            "entrypoint": {
+                                "type": "null"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/schemas/expconf/v1/gcs.json
+++ b/schemas/expconf/v1/gcs.json
@@ -1,0 +1,43 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "http://determined.ai/schemas/expconf/v1/gcs.json",
+    "title": "GCSConfig",
+    "type": "object",
+    "additionalProperties": false,
+    "required": [
+        "type",
+        "bucket"
+    ],
+    "properties": {
+        "type": {
+            "const": "gcs"
+        },
+        "bucket": {
+            "type": "string"
+        },
+        "save_experiment_best": {
+            "type": [
+                "integer",
+                "null"
+            ],
+            "default": 0,
+            "minimum": 0
+        },
+        "save_trial_best": {
+            "type": [
+                "integer",
+                "null"
+            ],
+            "default": 1,
+            "minimum": 0
+        },
+        "save_trial_latest": {
+            "type": [
+                "integer",
+                "null"
+            ],
+            "default": 1,
+            "minimum": 0
+        }
+    }
+}

--- a/schemas/expconf/v1/hdfs.json
+++ b/schemas/expconf/v1/hdfs.json
@@ -1,0 +1,59 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "http://determined.ai/schemas/expconf/v1/hdfs.json",
+    "title": "HDFSConfig",
+    "type": "object",
+    "additionalProperties": false,
+    "required": [
+        "type",
+        "hdfs_url",
+        "hdfs_path"
+    ],
+    "properties": {
+        "type": {
+            "const": "hdfs"
+        },
+        "hdfs_url": {
+            "type": "string"
+        },
+        "hdfs_path": {
+            "type": "string",
+            "checks": {
+                "hdfs_path must be an absolute path": {
+                    "pattern": "^/"
+                }
+            }
+        },
+        "user": {
+            "type": [
+                "string",
+                "null"
+            ],
+            "default": null
+        },
+        "save_experiment_best": {
+            "type": [
+                "integer",
+                "null"
+            ],
+            "default": 0,
+            "minimum": 0
+        },
+        "save_trial_best": {
+            "type": [
+                "integer",
+                "null"
+            ],
+            "default": 1,
+            "minimum": 0
+        },
+        "save_trial_latest": {
+            "type": [
+                "integer",
+                "null"
+            ],
+            "default": 1,
+            "minimum": 0
+        }
+    }
+}

--- a/schemas/expconf/v1/hyperparameter-categorical.json
+++ b/schemas/expconf/v1/hyperparameter-categorical.json
@@ -1,0 +1,20 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "http://determined.ai/schemas/expconf/v1/hyperparameter-categorical.json",
+    "title": "CategoricalHyperparameter",
+    "type": "object",
+    "additionalProperties": false,
+    "required": [
+        "type",
+        "vals"
+    ],
+    "properties": {
+        "type": {
+            "const": "categorical"
+        },
+        "vals": {
+            "type": "array",
+            "minLength": 1
+        }
+    }
+}

--- a/schemas/expconf/v1/hyperparameter-const.json
+++ b/schemas/expconf/v1/hyperparameter-const.json
@@ -1,0 +1,17 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "http://determined.ai/schemas/expconf/v1/hyperparameter-const.json",
+    "title": "ConstHyperparameter",
+    "type": "object",
+    "additionalProperties": false,
+    "required": [
+        "type",
+        "val"
+    ],
+    "properties": {
+        "type": {
+            "const": "const"
+        },
+        "val": true
+    }
+}

--- a/schemas/expconf/v1/hyperparameter-double.json
+++ b/schemas/expconf/v1/hyperparameter-double.json
@@ -1,0 +1,36 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "http://determined.ai/schemas/expconf/v1/hyperparameter-double.json",
+    "title": "DoubleHyperparameter",
+    "type": "object",
+    "additionalProperties": false,
+    "required": [
+        "type",
+        "minval",
+        "maxval"
+    ],
+    "properties": {
+        "type": {
+            "const": "double"
+        },
+        "minval": {
+            "type": "number"
+        },
+        "maxval": {
+            "type": "number"
+        },
+        "count": {
+            "type": [
+                "integer",
+                "null"
+            ],
+            "default": null,
+            "minimum": 1
+        }
+    },
+    "compareProperties": {
+        "type": "a<b",
+        "a": "minval",
+        "b": "maxval"
+    }
+}

--- a/schemas/expconf/v1/hyperparameter-int.json
+++ b/schemas/expconf/v1/hyperparameter-int.json
@@ -1,0 +1,36 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "http://determined.ai/schemas/expconf/v1/hyperparameter-int.json",
+    "title": "IntHyperparameter",
+    "type": "object",
+    "additionalProperties": false,
+    "required": [
+        "type",
+        "minval",
+        "maxval"
+    ],
+    "properties": {
+        "type": {
+            "const": "int"
+        },
+        "minval": {
+            "type": "integer"
+        },
+        "maxval": {
+            "type": "integer"
+        },
+        "count": {
+            "type": [
+                "integer",
+                "null"
+            ],
+            "default": null,
+            "minimum": 1
+        }
+    },
+    "compareProperties": {
+        "type": "a<b",
+        "a": "minval",
+        "b": "maxval"
+    }
+}

--- a/schemas/expconf/v1/hyperparameter-log.json
+++ b/schemas/expconf/v1/hyperparameter-log.json
@@ -1,0 +1,41 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "http://determined.ai/schemas/expconf/v1/hyperparameter-log.json",
+    "title": "LogHyperparameter",
+    "type": "object",
+    "additionalProperties": false,
+    "required": [
+        "type",
+        "minval",
+        "maxval",
+        "base"
+    ],
+    "properties": {
+        "type": {
+            "const": "log"
+        },
+        "minval": {
+            "type": "number"
+        },
+        "maxval": {
+            "type": "number"
+        },
+        "base": {
+            "type": "number",
+            "exclusiveMinimum": 0
+        },
+        "count": {
+            "type": [
+                "integer",
+                "null"
+            ],
+            "default": null,
+            "minimum": 1
+        }
+    },
+    "compareProperties": {
+        "type": "a<b",
+        "a": "minval",
+        "b": "maxval"
+    }
+}

--- a/schemas/expconf/v1/hyperparameter.json
+++ b/schemas/expconf/v1/hyperparameter.json
@@ -1,0 +1,59 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "http://determined.ai/schemas/expconf/v1/hyperparameter.json",
+    "title": "Hyperparameter",
+    "union": {
+        "items": [
+            {
+                "unionKey": "const:type=int",
+                "$ref": "http://determined.ai/schemas/expconf/v1/hyperparameter-int.json"
+            },
+            {
+                "unionKey": "const:type=double",
+                "$ref": "http://determined.ai/schemas/expconf/v1/hyperparameter-double.json"
+            },
+            {
+                "unionKey": "const:type=log",
+                "$ref": "http://determined.ai/schemas/expconf/v1/hyperparameter-log.json"
+            },
+            {
+                "unionKey": "const:type=const",
+                "$ref": "http://determined.ai/schemas/expconf/v1/hyperparameter-const.json"
+            },
+            {
+                "unionKey": "const:type=categorical",
+                "$ref": "http://determined.ai/schemas/expconf/v1/hyperparameter-categorical.json"
+            },
+            {
+                "unionKey": "type:array",
+                "type": "array",
+                "items": {
+                    "$ref": "http://determined.ai/schemas/expconf/v1/hyperparameter.json"
+                }
+            },
+            {
+                "unionKey": "always",
+                "type": "object",
+                "checks": {
+                    "if a hyperparameter object's [\"type\"] is set, it must be one of \"int\", \"double\", \"log\", const\", or \"categorical\"": {
+                        "properties": {
+                            "type": false
+                        }
+                    }
+                },
+                "additionalProperties": {
+                    "$ref": "http://determined.ai/schemas/expconf/v1/hyperparameter.json"
+                }
+            },
+            {
+                "unionKey": "never",
+                "not": {
+                    "type": [
+                        "object",
+                        "array"
+                    ]
+                }
+            }
+        ]
+    }
+}

--- a/schemas/expconf/v1/internal.json
+++ b/schemas/expconf/v1/internal.json
@@ -1,0 +1,20 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "http://determined.ai/schemas/expconf/v1/internal.json",
+    "title": "InternalConfig",
+    "type": "object",
+    "additionalProperties": false,
+    "required": [],
+    "properties": {
+        "native": {
+            "type": [
+                "array",
+                "null"
+            ],
+            "items": {
+                "type": "string"
+            },
+            "default": null
+        }
+    }
+}

--- a/schemas/expconf/v1/length.json
+++ b/schemas/expconf/v1/length.json
@@ -1,0 +1,52 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "http://determined.ai/schemas/expconf/v1/length.json",
+    "title": "Length",
+    "union": {
+        "defaultMessage": "a length object must have one attribute named \"batches\", \"records\", or \"epochs\"",
+        "items": [
+            {
+                "unionKey": "hasattr:batches",
+                "type": "object",
+                "additionalProperties": false,
+                "required": [
+                    "batches"
+                ],
+                "properties": {
+                    "batches": {
+                        "type": "integer",
+                        "minimum": 0
+                    }
+                }
+            },
+            {
+                "unionKey": "hasattr:records",
+                "type": "object",
+                "additionalProperties": false,
+                "required": [
+                    "records"
+                ],
+                "properties": {
+                    "records": {
+                        "type": "integer",
+                        "minimum": 0
+                    }
+                }
+            },
+            {
+                "unionKey": "hasattr:epochs",
+                "type": "object",
+                "additionalProperties": false,
+                "required": [
+                    "epochs"
+                ],
+                "properties": {
+                    "epochs": {
+                        "type": "integer",
+                        "minimum": 0
+                    }
+                }
+            }
+        ]
+    }
+}

--- a/schemas/expconf/v1/optimizations.json
+++ b/schemas/expconf/v1/optimizations.json
@@ -1,0 +1,77 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "http://determined.ai/schemas/expconf/v1/optimizations.json",
+    "title": "OptimizationsConfig",
+    "type": "object",
+    "additionalProperties": false,
+    "required": [],
+    "properties": {
+        "aggregation_frequency": {
+            "type": [
+                "integer",
+                "null"
+            ],
+            "minimum": 1,
+            "default": 1
+        },
+        "auto_tune_tensor_fusion": {
+            "type": [
+                "boolean",
+                "null"
+            ],
+            "default": false
+        },
+        "average_aggregated_gradients": {
+            "type": [
+                "boolean",
+                "null"
+            ],
+            "default": true
+        },
+        "average_training_metrics": {
+            "type": [
+                "boolean",
+                "null"
+            ],
+            "default": false
+        },
+        "gradient_compression": {
+            "type": [
+                "boolean",
+                "null"
+            ],
+            "default": false
+        },
+        "mixed_precision": {
+            "enum": [
+                null,
+                "O0",
+                "O1",
+                "O2",
+                "O3"
+            ],
+            "default": "O0",
+            "checks": {
+                "mixed_precision should be a string starting with an uppercase letter 'O'": {
+                    "pattern": "^O"
+                }
+            }
+        },
+        "tensor_fusion_cycle_time": {
+            "type": [
+                "integer",
+                "null"
+            ],
+            "minimum": 0,
+            "default": 5
+        },
+        "tensor_fusion_threshold": {
+            "type": [
+                "integer",
+                "null"
+            ],
+            "minimum": 0,
+            "default": 64
+        }
+    }
+}

--- a/schemas/expconf/v1/resources.json
+++ b/schemas/expconf/v1/resources.json
@@ -1,0 +1,69 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "http://determined.ai/schemas/expconf/v1/resources.json",
+    "title": "ResourcesConfig",
+    "type": "object",
+    "additionalProperties": false,
+    "required": [],
+    "properties": {
+        "agent_label": {
+            "type": [
+                "string",
+                "null"
+            ],
+            "default": ""
+        },
+        "max_slots": {
+            "type": [
+                "integer",
+                "null"
+            ],
+            "default": "null"
+        },
+        "native_parallel": {
+            "type": [
+                "boolean",
+                "null"
+            ],
+            "default": false
+        },
+        "priority": {
+            "type": [
+                "integer",
+                "null"
+            ],
+            "minimum": 1,
+            "maximum": 99,
+            "default": null
+        },
+        "resource_pool": {
+            "type": [
+                "string",
+                "null"
+            ],
+            "default": null
+        },
+        "shm_size": {
+            "type": [
+                "integer",
+                "null"
+            ],
+            "default": "null"
+        },
+        "slots_per_trial": {
+            "type": [
+                "integer",
+                "null"
+            ],
+            "minimum": 0,
+            "default": 1
+        },
+        "weight": {
+            "type": [
+                "number",
+                "null"
+            ],
+            "default": 1
+        }
+    }
+}

--- a/schemas/expconf/v1/s3.json
+++ b/schemas/expconf/v1/s3.json
@@ -1,0 +1,58 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "http://determined.ai/schemas/expconf/v1/s3.json",
+    "title": "S3Config",
+    "type": "object",
+    "additionalProperties": false,
+    "required": [
+        "type",
+        "access_key",
+        "bucket",
+        "secret_key"
+    ],
+    "properties": {
+        "type": {
+            "const": "s3"
+        },
+        "access_key": {
+            "type": "string"
+        },
+        "bucket": {
+            "type": "string"
+        },
+        "secret_key": {
+            "type": "string"
+        },
+        "endpoint_url": {
+            "type": [
+                "string",
+                "null"
+            ],
+            "default": null
+        },
+        "save_experiment_best": {
+            "type": [
+                "integer",
+                "null"
+            ],
+            "default": 0,
+            "minimum": 0
+        },
+        "save_trial_best": {
+            "type": [
+                "integer",
+                "null"
+            ],
+            "default": 1,
+            "minimum": 0
+        },
+        "save_trial_latest": {
+            "type": [
+                "integer",
+                "null"
+            ],
+            "default": 1,
+            "minimum": 0
+        }
+    }
+}

--- a/schemas/expconf/v1/searcher-adaptive-asha.json
+++ b/schemas/expconf/v1/searcher-adaptive-asha.json
@@ -1,0 +1,92 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "http://determined.ai/schemas/expconf/v1/searcher-adaptive-asha.json",
+    "title": "AdaptiveASHASearcherConfig",
+    "type": "object",
+    "additionalProperties": false,
+    "required": [
+        "name",
+        "max_length",
+        "max_trials",
+        "metric"
+    ],
+    "properties": {
+        "name": {
+            "const": "adaptive_asha"
+        },
+        "bracket_rungs": {
+            "type": [
+                "array",
+                "null"
+            ],
+            "default": [],
+            "items": {
+                "type": "integer"
+            }
+        },
+        "max_trials": {
+            "type": "integer",
+            "minimum": 1
+        },
+        "mode": {
+            "enum": [
+                null,
+                "aggressive",
+                "standard",
+                "conservative"
+            ],
+            "default": "standard"
+        },
+        "divisor": {
+            "type": [
+                "number",
+                "null"
+            ],
+            "exclusiveMinimum": 1,
+            "default": 4
+        },
+        "max_rungs": {
+            "type": [
+                "integer",
+                "null"
+            ],
+            "minimum": 1,
+            "default": 5
+        },
+        "max_concurrent_trials": {
+            "type": [
+                "integer",
+                "null"
+            ],
+            "minimum": 0,
+            "default": 0
+        },
+        "max_length": {
+            "$ref": "http://determined.ai/schemas/expconf/v1/check-positive-length.json"
+        },
+        "metric": {
+            "type": "string"
+        },
+        "smaller_is_better": {
+            "type": [
+                "boolean",
+                "null"
+            ],
+            "default": true
+        },
+        "source_trial_id": {
+            "type": [
+                "integer",
+                "null"
+            ],
+            "default": null
+        },
+        "source_checkpoint_uuid": {
+            "type": [
+                "string",
+                "null"
+            ],
+            "default": null
+        }
+    }
+}

--- a/schemas/expconf/v1/searcher-adaptive-simple.json
+++ b/schemas/expconf/v1/searcher-adaptive-simple.json
@@ -1,0 +1,75 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "http://determined.ai/schemas/expconf/v1/searcher-adaptive-simple.json",
+    "title": "AdaptiveSimpleSearcherConfig",
+    "type": "object",
+    "additionalProperties": false,
+    "required": [
+        "name",
+        "max_trials",
+        "max_length",
+        "metric"
+    ],
+    "properties": {
+        "name": {
+            "const": "adaptive_simple"
+        },
+        "max_trials": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 2000
+        },
+        "mode": {
+            "enum": [
+                null,
+                "aggressive",
+                "standard",
+                "conservative"
+            ],
+            "default": "standard"
+        },
+        "divisor": {
+            "type": [
+                "number",
+                "null"
+            ],
+            "exclusiveMinimum": 1,
+            "default": 4
+        },
+        "max_rungs": {
+            "type": [
+                "integer",
+                "null"
+            ],
+            "minimum": 1,
+            "default": 5
+        },
+        "max_length": {
+            "$ref": "http://determined.ai/schemas/expconf/v1/check-positive-length.json"
+        },
+        "metric": {
+            "type": "string"
+        },
+        "smaller_is_better": {
+            "type": [
+                "boolean",
+                "null"
+            ],
+            "default": true
+        },
+        "source_trial_id": {
+            "type": [
+                "integer",
+                "null"
+            ],
+            "default": null
+        },
+        "source_checkpoint_uuid": {
+            "type": [
+                "string",
+                "null"
+            ],
+            "default": null
+        }
+    }
+}

--- a/schemas/expconf/v1/searcher-adaptive.json
+++ b/schemas/expconf/v1/searcher-adaptive.json
@@ -1,0 +1,106 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "http://determined.ai/schemas/expconf/v1/searcher-adaptive.json",
+    "title": "AdaptiveSearcherConfig",
+    "type": "object",
+    "additionalProperties": false,
+    "required": [
+        "name",
+        "budget",
+        "max_length",
+        "metric"
+    ],
+    "properties": {
+        "name": {
+            "const": "adaptive"
+        },
+        "budget": {
+            "$ref": "http://determined.ai/schemas/expconf/v1/length.json"
+        },
+        "bracket_rungs": {
+            "type": [
+                "array",
+                "null"
+            ],
+            "default": [],
+            "items": {
+                "type": "integer"
+            }
+        },
+        "mode": {
+            "enum": [
+                null,
+                "aggressive",
+                "standard",
+                "conservative"
+            ],
+            "default": "standard"
+        },
+        "divisor": {
+            "type": [
+                "number",
+                "null"
+            ],
+            "exclusiveMinimum": 1,
+            "default": 4
+        },
+        "max_rungs": {
+            "type": [
+                "integer",
+                "null"
+            ],
+            "minimum": 1,
+            "default": 5
+        },
+        "max_length": {
+            "$ref": "http://determined.ai/schemas/expconf/v1/check-positive-length.json"
+        },
+        "train_stragglers": {
+            "type": [
+                "boolean",
+                "null"
+            ],
+            "default": true
+        },
+        "metric": {
+            "type": "string"
+        },
+        "smaller_is_better": {
+            "type": [
+                "boolean",
+                "null"
+            ],
+            "default": true
+        },
+        "source_trial_id": {
+            "type": [
+                "integer",
+                "null"
+            ],
+            "default": null
+        },
+        "source_checkpoint_uuid": {
+            "type": [
+                "string",
+                "null"
+            ],
+            "default": null
+        }
+    },
+    "checks": {
+        "max_length and budget must be specified in terms of the same unit": {
+            "compareProperties": {
+                "type": "same_units",
+                "a": "max_length",
+                "b": "budget"
+            }
+        },
+        "budget must be greater than max_length": {
+            "compareProperties": {
+                "type": "length_a<length_b",
+                "a": "max_length",
+                "b": "budget"
+            }
+        }
+    }
+}

--- a/schemas/expconf/v1/searcher-async-halving.json
+++ b/schemas/expconf/v1/searcher-async-halving.json
@@ -1,0 +1,70 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "http://determined.ai/schemas/expconf/v1/searcher-async-halving.json",
+    "title": "AsyncHalvingSearcherConfig",
+    "type": "object",
+    "additionalProperties": false,
+    "required": [
+        "name",
+        "num_rungs",
+        "max_length",
+        "max_trials",
+        "metric"
+    ],
+    "properties": {
+        "name": {
+            "const": "async_halving"
+        },
+        "num_rungs": {
+            "type": "integer",
+            "minimum": 1
+        },
+        "max_length": {
+            "$ref": "http://determined.ai/schemas/expconf/v1/check-positive-length.json"
+        },
+        "max_trials": {
+            "type": "integer",
+            "minimum": 1
+        },
+        "divisor": {
+            "type": [
+                "number",
+                "null"
+            ],
+            "exclusiveMinimum": 1,
+            "default": 4
+        },
+        "max_concurrent_trials": {
+            "type": [
+                "integer",
+                "null"
+            ],
+            "minimum": 0,
+            "default": 0
+        },
+        "metric": {
+            "type": "string"
+        },
+        "smaller_is_better": {
+            "type": [
+                "boolean",
+                "null"
+            ],
+            "default": true
+        },
+        "source_trial_id": {
+            "type": [
+                "integer",
+                "null"
+            ],
+            "default": null
+        },
+        "source_checkpoint_uuid": {
+            "type": [
+                "string",
+                "null"
+            ],
+            "default": null
+        }
+    }
+}

--- a/schemas/expconf/v1/searcher-grid.json
+++ b/schemas/expconf/v1/searcher-grid.json
@@ -1,0 +1,44 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "http://determined.ai/schemas/expconf/v1/searcher-grid.json",
+    "title": "GridSearcherConfig",
+    "type": "object",
+    "additionalProperties": false,
+    "required": [
+        "name",
+        "max_length",
+        "metric"
+    ],
+    "properties": {
+        "name": {
+            "const": "grid"
+        },
+        "max_length": {
+            "$ref": "http://determined.ai/schemas/expconf/v1/check-positive-length.json"
+        },
+        "metric": {
+            "type": "string"
+        },
+        "smaller_is_better": {
+            "type": [
+                "boolean",
+                "null"
+            ],
+            "default": true
+        },
+        "source_trial_id": {
+            "type": [
+                "integer",
+                "null"
+            ],
+            "default": null
+        },
+        "source_checkpoint_uuid": {
+            "type": [
+                "string",
+                "null"
+            ],
+            "default": null
+        }
+    }
+}

--- a/schemas/expconf/v1/searcher-pbt.json
+++ b/schemas/expconf/v1/searcher-pbt.json
@@ -1,0 +1,98 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "http://determined.ai/schemas/expconf/v1/searcher-pbt.json",
+    "title": "PBTSearcherConfig",
+    "type": "object",
+    "additionalProperties": false,
+    "required": [
+        "name",
+        "metric",
+        "population_size",
+        "length_per_round",
+        "num_rounds",
+        "replace_function",
+        "explore_function"
+    ],
+    "properties": {
+        "name": {
+            "const": "pbt"
+        },
+        "population_size": {
+            "type": "integer",
+            "minimum": 1
+        },
+        "length_per_round": {
+            "$ref": "http://determined.ai/schemas/expconf/v1/check-positive-length.json"
+        },
+        "num_rounds": {
+            "type": "integer",
+            "minimum": 1
+        },
+        "replace_function": {
+            "unionKey": "singleproperty",
+            "union": {
+                "items": [
+                    {
+                        "unionKey": "always",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "required": [
+                            "truncate_fraction"
+                        ],
+                        "properties": {
+                            "truncate_fraction": {
+                                "type": "number",
+                                "minimum": 0.0,
+                                "maximum": 1.0
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        "explore_function": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+                "resample_probability",
+                "perturb_factor"
+            ],
+            "properties": {
+                "resample_probability": {
+                    "type": "number",
+                    "minimum": 0.0,
+                    "maximum": 1.0
+                },
+                "perturb_factor": {
+                    "type": "number",
+                    "minimum": 0.0,
+                    "maximum": 1.0
+                }
+            }
+        },
+        "metric": {
+            "type": "string"
+        },
+        "smaller_is_better": {
+            "type": [
+                "boolean",
+                "null"
+            ],
+            "default": true
+        },
+        "source_trial_id": {
+            "type": [
+                "integer",
+                "null"
+            ],
+            "default": null
+        },
+        "source_checkpoint_uuid": {
+            "type": [
+                "string",
+                "null"
+            ],
+            "default": null
+        }
+    }
+}

--- a/schemas/expconf/v1/searcher-random.json
+++ b/schemas/expconf/v1/searcher-random.json
@@ -1,0 +1,49 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "http://determined.ai/schemas/expconf/v1/searcher-random.json",
+    "title": "RandomSearcherConfig",
+    "type": "object",
+    "additionalProperties": false,
+    "required": [
+        "name",
+        "max_trials",
+        "max_length",
+        "metric"
+    ],
+    "properties": {
+        "name": {
+            "const": "random"
+        },
+        "max_trials": {
+            "type": "integer",
+            "minimum": 1
+        },
+        "max_length": {
+            "$ref": "http://determined.ai/schemas/expconf/v1/check-positive-length.json"
+        },
+        "metric": {
+            "type": "string"
+        },
+        "smaller_is_better": {
+            "type": [
+                "boolean",
+                "null"
+            ],
+            "default": true
+        },
+        "source_trial_id": {
+            "type": [
+                "integer",
+                "null"
+            ],
+            "default": null
+        },
+        "source_checkpoint_uuid": {
+            "type": [
+                "string",
+                "null"
+            ],
+            "default": null
+        }
+    }
+}

--- a/schemas/expconf/v1/searcher-single.json
+++ b/schemas/expconf/v1/searcher-single.json
@@ -1,0 +1,44 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "http://determined.ai/schemas/expconf/v1/searcher-single.json",
+    "title": "SingleSearcherConfig",
+    "type": "object",
+    "additionalProperties": false,
+    "required": [
+        "name",
+        "max_length",
+        "metric"
+    ],
+    "properties": {
+        "name": {
+            "const": "single"
+        },
+        "max_length": {
+            "$ref": "http://determined.ai/schemas/expconf/v1/check-positive-length.json"
+        },
+        "metric": {
+            "type": "string"
+        },
+        "smaller_is_better": {
+            "type": [
+                "boolean",
+                "null"
+            ],
+            "default": true
+        },
+        "source_trial_id": {
+            "type": [
+                "integer",
+                "null"
+            ],
+            "default": null
+        },
+        "source_checkpoint_uuid": {
+            "type": [
+                "string",
+                "null"
+            ],
+            "default": null
+        }
+    }
+}

--- a/schemas/expconf/v1/searcher-sync-halving.json
+++ b/schemas/expconf/v1/searcher-sync-halving.json
@@ -1,0 +1,68 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "http://determined.ai/schemas/expconf/v1/searcher-sync-halving.json",
+    "title": "SyncHalvingSearcherConfig",
+    "type": "object",
+    "additionalProperties": false,
+    "required": [
+        "name",
+        "num_rungs",
+        "max_length",
+        "budget",
+        "metric"
+    ],
+    "properties": {
+        "name": {
+            "const": "sync_halving"
+        },
+        "budget": {
+            "$ref": "http://determined.ai/schemas/expconf/v1/check-positive-length.json"
+        },
+        "num_rungs": {
+            "type": "integer",
+            "minimum": 1
+        },
+        "max_length": {
+            "$ref": "http://determined.ai/schemas/expconf/v1/check-positive-length.json"
+        },
+        "divisor": {
+            "type": [
+                "number",
+                "null"
+            ],
+            "exclusiveMinimum": 1,
+            "default": 4
+        },
+        "train_stragglers": {
+            "type": [
+                "boolean",
+                "null"
+            ],
+            "default": true
+        },
+        "metric": {
+            "type": "string"
+        },
+        "smaller_is_better": {
+            "type": [
+                "boolean",
+                "null"
+            ],
+            "default": true
+        },
+        "source_trial_id": {
+            "type": [
+                "integer",
+                "null"
+            ],
+            "default": null
+        },
+        "source_checkpoint_uuid": {
+            "type": [
+                "string",
+                "null"
+            ],
+            "default": null
+        }
+    }
+}

--- a/schemas/expconf/v1/searcher.json
+++ b/schemas/expconf/v1/searcher.json
@@ -1,0 +1,46 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "http://determined.ai/schemas/expconf/v1/searcher.json",
+    "title": "SearcherConfig",
+    "union": {
+        "defaultMessage": "is not an object where object[\"name\"] is one of 'single', 'random', 'grid', 'adaptive', 'adaptive_asha', 'adaptive_simple', or 'pbt'",
+        "items": [
+            {
+                "unionKey": "const:name=single",
+                "$ref": "http://determined.ai/schemas/expconf/v1/searcher-single.json"
+            },
+            {
+                "unionKey": "const:name=random",
+                "$ref": "http://determined.ai/schemas/expconf/v1/searcher-random.json"
+            },
+            {
+                "unionKey": "const:name=grid",
+                "$ref": "http://determined.ai/schemas/expconf/v1/searcher-grid.json"
+            },
+            {
+                "unionKey": "const:name=adaptive_asha",
+                "$ref": "http://determined.ai/schemas/expconf/v1/searcher-adaptive-asha.json"
+            },
+            {
+                "unionKey": "const:name=adaptive_simple",
+                "$ref": "http://determined.ai/schemas/expconf/v1/searcher-adaptive-simple.json"
+            },
+            {
+                "unionKey": "const:name=adaptive",
+                "$ref": "http://determined.ai/schemas/expconf/v1/searcher-adaptive.json"
+            },
+            {
+                "unionKey": "const:name=pbt",
+                "$ref": "http://determined.ai/schemas/expconf/v1/searcher-pbt.json"
+            },
+            {
+                "unionKey": "const:name=sync_halving",
+                "$ref": "http://determined.ai/schemas/expconf/v1/searcher-sync-halving.json"
+            },
+            {
+                "unionKey": "const:name=async_halving",
+                "$ref": "http://determined.ai/schemas/expconf/v1/searcher-async-halving.json"
+            }
+        ]
+    }
+}

--- a/schemas/expconf/v1/shared-fs.json
+++ b/schemas/expconf/v1/shared-fs.json
@@ -1,0 +1,87 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "http://determined.ai/schemas/expconf/v1/shared-fs.json",
+    "title": "SharedFSConfig",
+    "type": "object",
+    "additionalProperties": false,
+    "required": [
+        "type",
+        "host_path"
+    ],
+    "properties": {
+        "type": {
+            "const": "shared_fs"
+        },
+        "host_path": {
+            "type": "string"
+        },
+        "storage_path": {
+            "type": [
+                "string",
+                "null"
+            ],
+            "default": null
+        },
+        "propagation": {
+            "type": [
+                "string",
+                "null"
+            ],
+            "default": "rprivate"
+        },
+        "container_path": {
+            "type": [
+                "string",
+                "null"
+            ],
+            "default": null
+        },
+        "checkpoint_path": {
+            "type": [
+                "string",
+                "null"
+            ],
+            "default": null
+        },
+        "tensorboard_path": {
+            "type": [
+                "string",
+                "null"
+            ],
+            "default": null
+        },
+        "save_experiment_best": {
+            "type": [
+                "integer",
+                "null"
+            ],
+            "default": 0,
+            "minimum": 0
+        },
+        "save_trial_best": {
+            "type": [
+                "integer",
+                "null"
+            ],
+            "default": 1,
+            "minimum": 0
+        },
+        "save_trial_latest": {
+            "type": [
+                "integer",
+                "null"
+            ],
+            "default": 1,
+            "minimum": 0
+        }
+    },
+    "checks": {
+        "storage_path must either be a relative directory or a subdirectory of host_path": {
+            "compareProperties": {
+                "type": "a_is_subdir_of_b",
+                "a": "storage_path",
+                "b": "host_path"
+            }
+        }
+    }
+}

--- a/schemas/gen.py
+++ b/schemas/gen.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+import os
+import sys
+from typing import List, Optional
+
+
+def camel_to_snake(name: str) -> str:
+    """Convert CamelCase to snake_case, handling acronyms properly."""
+    out = name[0].lower()
+    for c0, c1, c2 in zip(name[:-2], name[1:-1], name[2:]):
+        # Catch lower->upper transitions.
+        if c0.islower() and c1.isupper():
+            out += "_"
+        # Catch acronym endings.
+        if c0.isupper() and c1.isupper() and c2.islower():
+            out += "_"
+        out += c1.lower()
+    out += name[-1].lower()
+    return out
+
+
+class Schema:
+    def __init__(self, url: str, text: str) -> None:
+        self.url = url
+        self.text = text
+        try:
+            self.schema = json.loads(text)
+        except Exception as e:
+            raise ValueError(f"{url} is not a valid json file") from e
+        self.golang_title = self.schema["title"] + "V1"
+        self.python_title = camel_to_snake(self.golang_title)
+
+
+def read_schemas(files: List[str]) -> List[Schema]:
+    schemas = []
+    urlbase = "http://determined.ai/schemas/expconf/v1"
+    for file in files:
+        url = os.path.join(urlbase, os.path.basename(file))
+        with open(file) as f:
+            schema = Schema(url, f.read())
+            schemas.append(schema)
+    # Sort schemas so that the output is deterministic.
+    schemas.sort(key=lambda s: s.url)
+    return schemas
+
+
+def gen_go(schemas: List[Schema]) -> List[str]:
+    lines = []
+    lines.append("// This is a generated file.  Editing it will make you sad.")
+    lines.append("")
+    lines.append("package expconf")
+    lines.append("")
+    lines.append('import "encoding/json"')
+    lines.append("")
+
+    # Global variables (lazily loaded but otherwise constants).
+    lines.append("var (")
+    # Schema texts.
+    lines.extend(
+        [f"\ttext{schema.golang_title} = []byte(`{schema.text}`)" for schema in schemas]
+    )
+    # Cached schema values, initially nil.
+    lines.extend([f"\tschema{schema.golang_title} interface{{}}" for schema in schemas])
+    # Cached map of urls to schema values, initially nil.
+    lines.append("\tcachedSchemaMap map[string]interface{}")
+    lines.append("\tcachedSchemaBytesMap map[string][]byte")
+    lines.append(")")
+    lines.append("")
+
+    # Schema getters.
+    for schema in schemas:
+        lines.extend(
+            [
+                f"func parsed{schema.golang_title}() interface{{}} {{",
+                f"\tif schema{schema.golang_title} != nil {{",
+                f"\t\treturn schema{schema.golang_title}",
+                "\t}",
+                f"\terr := json.Unmarshal(text{schema.golang_title}, &schema{schema.golang_title})",
+                "\tif err != nil {",
+                f'\t\tpanic("invalid embedded json for {schema.golang_title}")',
+                "\t}",
+                f"\treturn schema{schema.golang_title}",
+                "}",
+            ]
+        )
+        lines.append("")
+
+    # SchemaBytesMap.
+    lines.append("func schemaBytesMap() map[string][]byte {")
+    lines.append("\tif cachedSchemaBytesMap != nil {")
+    lines.append("\t\treturn cachedSchemaBytesMap")
+    lines.append("\t}")
+    lines.append("\tvar url string")
+    lines.append("\tcachedSchemaBytesMap = map[string][]byte{}")
+    for schema in schemas:
+        lines.append(f'\turl = "{schema.url}"')
+        lines.append(f"\tcachedSchemaBytesMap[url] = text{schema.golang_title}")
+    lines.append("\treturn cachedSchemaBytesMap")
+    lines.append("}")
+
+    # SchemaMap.
+    lines.append("func schemaMap() map[string]interface{} {")
+    lines.append("\tif cachedSchemaMap != nil {")
+    lines.append("\t\treturn cachedSchemaMap")
+    lines.append("\t}")
+    lines.append("\tvar url string")
+    lines.append("\tcachedSchemaMap = map[string]interface{}{}")
+    for schema in schemas:
+        lines.append(f'\turl = "{schema.url}"')
+        lines.append(f"\tcachedSchemaMap[url] = parsed{schema.golang_title}()")
+    lines.append("\treturn cachedSchemaMap")
+    lines.append("}")
+
+    return lines
+
+
+def gen_python(schemas: List[Schema]) -> List[str]:
+    lines = []
+    lines.append("# This is a generated file.  Editing it will make you sad.")
+    lines.append("")
+    lines.append("import json")
+    lines.append("")
+    lines.append("schemas = {")
+    for schema in schemas:
+        lines.append(f'    "{schema.url}": json.loads(')
+        lines.append(f'        r"""\n{schema.text}\n"""')
+        lines.append("    ),")
+    lines.append("}")
+
+    return lines
+
+
+def main(language: str, files: List[str], output: Optional[str]) -> None:
+    assert language in ["go", "python"], "language must be 'go' or 'python'"
+    assert files, "no input files"
+    assert output is not None, "missing output file"
+
+    schemas = read_schemas(files)
+
+    if language == "go":
+        lines = gen_go(schemas)
+    else:
+        lines = gen_python(schemas)
+
+    text = "\n".join([*lines, "\n"])
+
+    # Write the output file.
+    with open(output, "w") as f:
+        f.write(text)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="generate code with embedded schemas")
+    parser.add_argument("language", help="go or python")
+    parser.add_argument("files", nargs="*", help="input files")
+    parser.add_argument("--output")
+    args = parser.parse_args()
+
+    try:
+        main(args.language, args.files, args.output)
+    except AssertionError as e:
+        print(e, file=sys.stderr)
+        sys.exit(1)

--- a/schemas/lint.py
+++ b/schemas/lint.py
@@ -1,0 +1,483 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+import os
+import sys
+from typing import Callable, List, Optional, Tuple, TypeVar, Union
+
+Schema = Union[dict, bool]
+Errors = List[Tuple[str, str]]
+
+
+linters = []  # type: List[Callable]
+
+
+F = TypeVar("F", bound=Callable)
+
+
+def register_linter(fn: F) -> F:
+    linters.append(fn)
+    return fn
+
+
+# Only compound types supported are the nullable supported types.
+COMPOUND_TYPES = {
+    frozenset(("number", "null")): "number",
+    frozenset(("integer", "null")): "integer",
+    frozenset(("number", "null")): "number",
+    frozenset(("object", "null")): "object",
+    frozenset(("array", "null")): "array",
+    frozenset(("string", "null")): "string",
+    frozenset(("boolean", "null")): "boolean",
+    # This only occurs for implicitly nested hyperparameters.
+    frozenset(("object", "array")): "null",
+}
+
+SUPPORTED_KEYWORDS_BY_TYPE = {
+    "number": {
+        "minimum",
+        "exclusiveMinimum",
+        "maximum",
+        "exclusiveMaximum",
+        "default",
+        "unionKey",
+        "checks",
+    },
+    "integer": {
+        "minimum",
+        "exclusiveMinimum",
+        "maximum",
+        "exclusiveMaximum",
+        "default",
+        "unionKey",
+        "checks",
+    },
+    "object": {
+        "additionalProperties",
+        "required",
+        "properties",
+        "$ref",
+        "default",
+        "unionKey",
+        "disallowProperties",
+        "eventuallyRequired",
+        "checks",
+        "compareProperties",
+        "allOf",
+    },
+    "array": {"items", "default", "unionKey", "minLength", "checks"},
+    "string": {"pattern", "default", "unionKey", "checks"},
+    "boolean": {"default", "unionKey", "checks"},
+    "null": {"default", "unionKey", "checks"},
+}
+
+TOPLEVEL_KEYWORDS = {"$schema", "$id", "title"}
+
+
+class LintContext:
+    def __init__(
+        self, schema: Schema, path: str, toplevel: bool, in_checks: bool
+    ) -> None:
+        self._schema = schema
+        self._path = path
+        self.toplevel = toplevel
+        self.in_checks = in_checks
+
+
+@register_linter
+def check_schema(schema: dict, path: str, ctx: LintContext) -> Errors:
+    if not ctx.toplevel:
+        return []
+
+    if "$schema" not in schema:
+        return [(path, "$schema is missing")]
+
+    exp_schema = "http://json-schema.org/draft-07/schema#"
+
+    if schema["$schema"] != exp_schema:
+        return [(path, f'$schema is not "{exp_schema}"')]
+
+    return []
+
+
+@register_linter
+def check_id(schema: dict, path: str, ctx: LintContext) -> Errors:
+    if not ctx.toplevel:
+        return []
+
+    if "$id" not in schema:
+        return [(path, "$id is missing")]
+
+    errors = []
+    subpath = path + ".$id"
+    id = os.path.split(schema["$id"])
+
+    base, name = id
+
+    exp_base = "http://determined.ai/schemas/expconf/v1"
+
+    if base != exp_base:
+        errors.append((subpath, f'$id ({id}) must start with "{exp_base}"'))
+
+    if path != f"<{name}>":
+        errors.append((subpath, f"$id ({id}) is not correct for filename {path}"))
+
+    return errors
+
+
+def is_required(object_schema: dict, key: str) -> bool:
+    return key in object_schema.get("required", [])
+
+
+def is_nullable(object_schema: dict, key: str) -> bool:
+    sub = object_schema["properties"][key]
+    if isinstance(sub, bool):
+        return sub
+    assert isinstance(sub, dict), f"expected dict but got {sub}"
+    if "const" in sub:
+        return False
+    if "enum" in sub:
+        return None in sub["enum"]
+    if "type" in sub:
+        if isinstance(sub["type"], list):
+            return "null" in sub["type"]
+        return bool(sub["type"] == "null")
+    return False
+
+
+@register_linter
+def check_defaults(schema: dict, path: str, ctx: LintContext) -> Errors:
+    if ctx.in_checks:
+        return []
+    if not isinstance(schema, dict) or "properties" not in schema:
+        return []
+
+    errors = []
+
+    required = schema.get("required", [])
+    for key, sub in schema["properties"].items():
+        subpath = path + f".{key}"
+        if key in required and isinstance(sub, dict) and "default" in sub:
+            errors.append((subpath, "default provided for required value"))
+        if key not in required and isinstance(sub, dict) and "default" not in sub:
+            errors.append((subpath, "default not provided for non-required value"))
+
+    return errors
+
+
+@register_linter
+def check_nullable(schema: dict, path: str, ctx: LintContext) -> Errors:
+    """Non-Required fields must be nullable; required fields must be non-Nullable."""
+    if ctx.in_checks:
+        return []
+    if not isinstance(schema, dict) or "properties" not in schema:
+        return []
+
+    errors = []
+
+    for key, sub in schema["properties"].items():
+        if sub is True:
+            # Don't complain about the universal match (true).
+            continue
+        subpath = path + f".{key}"
+        if is_required(schema, key) and is_nullable(schema, key):
+            errors.append((subpath, "required property is nullable"))
+        if not is_required(schema, key) and not is_nullable(schema, key):
+            errors.append((subpath, "non-required property is not nullable"))
+
+    return errors
+
+
+@register_linter
+def check_types(schema: dict, path: str, ctx: LintContext) -> Errors:
+    if "type" not in schema:
+        return []
+
+    typ = schema["type"]
+    if not isinstance(typ, str):
+        if frozenset(typ) not in COMPOUND_TYPES:
+            return [(path, f"unsupported compound type: {typ}")]
+        typ = COMPOUND_TYPES[frozenset(typ)]
+
+    if typ not in SUPPORTED_KEYWORDS_BY_TYPE:
+        return [(path, f"unsupported type: {typ}")]
+
+    keys = set(schema.keys()).difference(TOPLEVEL_KEYWORDS)
+    keys.remove("type")
+
+    errors = []
+
+    extra_keys = keys.difference(SUPPORTED_KEYWORDS_BY_TYPE[typ])
+    for kw in extra_keys:
+        errors.append((path, f"{kw} not allowed in schema of type {typ}"))
+
+    return errors
+
+
+@register_linter
+def check_union(schema: dict, path: str, ctx: LintContext) -> Errors:
+    if "union" not in schema:
+        return []
+
+    errors = []
+
+    for idx, sub in enumerate(schema["union"]["items"]):
+        subpath = path + f"union.items.[{idx}]"
+        if not isinstance(sub, dict):
+            errors.append((subpath, "is not a json object"))
+            continue
+        if "unionKey" not in sub:
+            errors.append((subpath, "has no unionKey"))
+            continue
+        if not isinstance(sub["unionKey"], str):
+            errors.append((subpath, "unionKey is not a string"))
+            continue
+
+    return errors
+
+
+@register_linter
+def check_conditional(schema: dict, path: str, ctx: LintContext) -> Errors:
+    if "conditional" not in schema:
+        return []
+
+    conditional = schema["conditional"]
+    subpath = path + ".conditional"
+
+    errors = []
+
+    if "when" not in conditional and "unless" not in conditional:
+        errors.append((subpath, "has no when clause or until clause"))
+    if "when" in conditional and "unless" in conditional:
+        errors.append((subpath, "has both a when clause and an until clause"))
+    if "enforce" not in conditional:
+        errors.append((subpath, "has no enforce clause"))
+
+    return errors
+
+
+@register_linter
+def check_compareProperties(schema: dict, path: str, ctx: LintContext) -> Errors:
+    if "compareProperties" not in schema:
+        return []
+
+    compare = schema["compareProperties"]
+    subpath = path + ".compareProperties"
+
+    errors = []  # type: Errors
+
+    if "type" not in compare:
+        errors.append((subpath, "has no type"))
+    if "a" not in compare:
+        errors.append((subpath, "has no a"))
+    if "b" not in compare:
+        errors.append((subpath, "has no b"))
+    if compare["type"] not in {
+        "a<b",
+        "same_units",
+        "length_a<length_b",
+        "a_is_subdir_of_b",
+    }:
+        errors.append((subpath, f'invalid type: {compare["type"]}'))
+
+    return errors
+
+
+def iter_subdict(schema: dict, path: str, key: str, ctx: LintContext) -> Errors:
+    """Helper function to iter_schema()."""
+
+    if key not in schema:
+        return []
+
+    child = schema[key]
+    path += f".{key}"
+
+    if not isinstance(child, dict):
+        return [(path, "expected a dict but got a {type(child).__name__}")]
+
+    errors = []
+
+    for key, sub in child.items():
+        errors += iter_schema(sub, path + f".{key}", ctx)
+
+    return errors
+
+
+def iter_sublist(schema: dict, path: str, key: str, ctx: LintContext) -> Errors:
+    """Helper function to iter_schema()."""
+
+    if key not in schema:
+        return []
+
+    child = schema[key]
+    path += f".{key}"
+
+    if not isinstance(child, list):
+        return [(path, f"expected a list but got a {type(child).__name__}")]
+
+    errors = []
+
+    for idx, sub in enumerate(child):
+        errors += iter_schema(sub, path + f"[{idx}]", ctx)
+
+    return errors
+
+
+def iter_subschema(schema: dict, path: str, key: str, ctx: LintContext) -> Errors:
+    """Helper function to iter_schema()."""
+
+    if key not in schema:
+        return []
+
+    child = schema[key]
+    path += f".{key}"
+
+    return iter_schema(child, path, ctx)
+
+
+def iter_union(schema: dict, path: str, ctx: LintContext) -> Errors:
+    """Helper function to iter_schema()."""
+
+    if "union" not in schema:
+        return []
+
+    child = schema["union"]
+    path += ".union"
+
+    if not isinstance(child, dict):
+        return [(path, f"expected a dict but got a {type(child).__name__}")]
+
+    return iter_sublist(child, path, "items", ctx)
+
+
+def iter_schema(
+    schema: dict, path: str, ctx: Optional[LintContext] = None, in_checks: bool = False
+) -> Errors:
+    """
+    Iterate through structural elements of a schema.  In the following example:
+
+        {
+            "type": "string",
+            "required": ["meh"],
+            "additionalProperties": false,
+            "properties": {
+                "meh": { "const": "some_val" }
+            }
+        }
+
+    ... the root object, the `false`, and the `{ "const": "some_val" }` are each structural.
+
+    Everthing else is content-related and non-structural.
+    """
+
+    if not isinstance(schema, (dict, bool)):
+        return [(path, "schema should be a dictionary or a bool")]
+
+    # True or False are special.
+    if isinstance(schema, bool):
+        return []
+
+    errors = []
+
+    # Apply linters to this structural element.
+    if ctx is None:
+        ctx = LintContext(schema, path, toplevel=True, in_checks=in_checks)
+    else:
+        ctx = LintContext(schema, path, False, ctx.in_checks)
+    for linter in linters:
+        try:
+            errors += linter(schema, path, ctx)
+        except Exception as e:
+            raise ValueError(
+                f"error processing schema:\n{json.dumps(schema, indent=4)}"
+            ) from e
+
+    # Descend into child dicts of structural elements.
+    for kw in ["properties"]:
+        errors += iter_subdict(schema, path, kw, ctx)
+
+    for kw in ["checks"]:
+        ctx.in_checks = True
+        errors += iter_subdict(schema, path, kw, ctx)
+
+    # Descend into child lists of structural elements.
+    for kw in ["oneOf", "anyOf", "allOf"]:
+        errors += iter_sublist(schema, path, kw, ctx)
+
+    # Descend directly into child structural elements.
+    for kw in ["items", "additionalProperties", "not"]:
+        errors += iter_subschema(schema, path, kw, ctx)
+
+    # Descend into custom structural elements.
+    errors += iter_union(schema, path, ctx)
+
+    return errors
+
+
+def fmt(files: List[str], reformat: bool) -> Errors:
+    errors = []
+
+    for file in files:
+        with open(file) as f:
+            text = f.read()
+        jobj = json.loads(text)
+        # Apply the same linting that `python -mjson.tool` would apply.
+        fixed = json.dumps(jobj, sort_keys=False, indent=4) + "\n"
+        if fixed != text:
+            if reformat:
+                with open(file, "w") as f:
+                    f.write(fixed)
+            else:
+                doc = os.path.basename(file)
+                errors.append((f"<{doc}>", "would reformat"))
+
+    return errors
+
+
+def lint(files: List[str], reformat: bool) -> List[str]:
+    assert files, "no files provided"
+
+    invalids = []
+    errors = []
+
+    for file in files:
+        with open(file) as f:
+            try:
+                schema = json.loads(f.read())
+            except json.decoder.JSONDecodeError as e:
+                invalids.append(f"{file} not valid: {e}")
+                continue
+
+        doc = os.path.basename(file)
+
+        try:
+            errors += iter_schema(
+                schema, f"<{doc}>", in_checks=doc.startswith("check-")
+            )
+        except Exception as e:
+            raise ValueError(f"failure processing {file}") from e
+
+    # Exit now if there are invalid errors.
+    if invalids:
+        return invalids
+
+    errors += fmt(files, reformat)
+
+    if errors:
+        pathwidth = max(len(path) for path, error in errors)
+        msgs = ["%-*s  %s" % (pathwidth, path, error) for path, error in errors]
+        return sorted(msgs)
+
+    return []
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="static analysis for json schema")
+    parser.add_argument("files", nargs="*", help="files to check")
+    parser.add_argument("--check", action="store_true", help="no auto-reformatting")
+    args = parser.parse_args()
+    errors = lint(args.files, reformat=not args.check)
+    if errors:
+        print("\n".join(errors), file=sys.stderr)
+        sys.exit(1)

--- a/schemas/mypy.ini
+++ b/schemas/mypy.ini
@@ -1,0 +1,18 @@
+[mypy]
+python_version = 3.6
+follow_imports = silent
+ignore_missing_imports = True
+
+# All strict checks.
+check_untyped_defs = True
+disallow_incomplete_defs = True
+disallow_subclassing_any = True
+disallow_untyped_calls = True
+disallow_untyped_decorators = True
+disallow_untyped_defs = True
+no_implicit_optional = True
+strict_equality = True
+warn_redundant_casts = True
+warn_return_any = True
+warn_unused_configs = True
+warn_unused_ignores = True

--- a/schemas/test_cases/v1/compare_properties.yaml
+++ b/schemas/test_cases/v1/compare_properties.yaml
@@ -1,0 +1,91 @@
+- name: a<b compareProperties (valid)
+  matches:
+    - http://determined.ai/schemas/expconf/v1/hyperparameter-int.json
+  case:
+    type: int
+    minval: 2
+    maxval: 10
+
+- name: a<b compareProperties (invalid)
+  errors:
+    http://determined.ai/schemas/expconf/v1/hyperparameter-int.json:
+      - minval must be less than maxval
+  case:
+    type: int
+    minval: 2
+    maxval: 2
+
+- name: same_units and length_a<length_b compareProperties (valid)
+  matches:
+    - http://determined.ai/schemas/expconf/v1/searcher-adaptive.json
+  case:
+    name: adaptive
+    metric: loss
+    budget:
+      epochs: 2
+    max_length:
+      epochs: 1
+
+- name: same_units and length_a<length_b compareProperties (invalid)
+  errors:
+    http://determined.ai/schemas/expconf/v1/searcher-adaptive.json:
+      - max_length and budget must be specified in terms of the same unit
+      - budget must be greater than max_length
+  case:
+    name: adaptive
+    metric: loss
+    budget:
+      epochs: 2
+    max_length:
+      records: 10
+
+- name: a_is_subdir_of_b (valid, absolute)
+  matches:
+    - http://determined.ai/schemas/expconf/v1/checkpoint-storage.json
+    - http://determined.ai/schemas/expconf/v1/shared-fs.json
+  case:
+    type: shared_fs
+    host_path: /tmp
+    storage_path: /tmp/storage_path
+
+- name: a_is_subdir_of_b (valid, relative)
+  matches:
+    - http://determined.ai/schemas/expconf/v1/checkpoint-storage.json
+    - http://determined.ai/schemas/expconf/v1/shared-fs.json
+  case:
+    type: shared_fs
+    host_path: /tmp
+    storage_path: storage_path
+
+- name: a_is_subdir_of_b (invalid, absolute)
+  errors:
+    http://determined.ai/schemas/expconf/v1/checkpoint-storage.json:
+      - storage_path must either be a relative directory or a subdirectory of host_path
+    http://determined.ai/schemas/expconf/v1/shared-fs.json:
+      - storage_path must either be a relative directory or a subdirectory of host_path
+  case:
+    type: shared_fs
+    host_path: /tmp
+    storage_path: /storage_path
+
+- name: a_is_subdir_of_b (invalid, relative)
+  errors:
+    http://determined.ai/schemas/expconf/v1/checkpoint-storage.json:
+      - storage_path must either be a relative directory or a subdirectory of host_path
+    http://determined.ai/schemas/expconf/v1/shared-fs.json:
+      - storage_path must either be a relative directory or a subdirectory of host_path
+  case:
+    type: shared_fs
+    host_path: /tmp
+    storage_path: ../storage_path
+
+- name: a_is_subdir_of_b (invalid, relative, unnormalized)
+  errors:
+    http://determined.ai/schemas/expconf/v1/checkpoint-storage.json:
+      - storage_path must either be a relative directory or a subdirectory of host_path
+    http://determined.ai/schemas/expconf/v1/shared-fs.json:
+      - storage_path must either be a relative directory or a subdirectory of host_path
+  case:
+    type: shared_fs
+    host_path: /tmp
+    storage_path: anywhere/../../storage_path

--- a/schemas/test_cases/v1/experiment.yaml
+++ b/schemas/test_cases/v1/experiment.yaml
@@ -1,0 +1,282 @@
+- name: full valid experiment
+  matches:
+    - http://determined.ai/schemas/expconf/v1/experiment.json
+  case:
+    bind_mounts:
+      - host_path: /asdf
+        container_path: /asdf
+        read_only: true
+        propagation: "rprivate"
+    checkpoint_policy: best
+    checkpoint_storage:
+      type: shared_fs
+      host_path: /tmp
+      storage_path: determined-cp
+      propagation: rprivate
+      container_path: /asdf
+      checkpoint_path: /qwer
+      tensorboard_path: /zxcv
+      save_experiment_best: 0
+      save_trial_best: 1
+      save_trial_latest: 1
+    data:
+      any: thing
+    data_layer:
+      container_storage_path: null
+      type: shared_fs
+    debug: false
+    description: pytorch-noop
+    entrypoint: long.module.path.model_def:NoopPytorchTrial
+    environment:
+      environment_variables: {}
+      force_pull_image: false
+      image:
+        cpu: determinedai/environments:cuda-10.1-pytorch-1.4-tf-2.2-gpu-0f2001a
+        gpu: determinedai/environments:cuda-10.1-pytorch-1.4-tf-2.2-gpu-0f2001a
+      pod_spec: null
+      ports: null
+    hyperparameters:
+      global_batch_size:
+        type: const
+        val: 32
+      list_hparam:
+        - 10
+        - type: const
+          val: asdf
+        - type: int
+          minval: 1
+          maxval: 2
+      dict_hparam:
+        double_hparam:
+          type: double
+          minval: 1
+          maxval: 10
+        log_hparam:
+          type: log
+          minval: 1
+          maxval: 10
+          base: 1
+      categorical_hparam:
+        type: categorical
+        vals: [1, 2, 3, 4]
+    internal: null
+    max_restarts: 0
+    min_validation_period:
+      batches: 0
+    optimizations:
+      aggregation_frequency: 1
+      auto_tune_tensor_fusion: false
+      average_aggregated_gradients: true
+      average_training_metrics: false
+      gradient_compression: false
+      mixed_precision: O0
+      tensor_fusion_cycle_time: 5
+      tensor_fusion_threshold: 64
+    perform_initial_validation: false
+    records_per_epoch: 0
+    reproducibility:
+      experiment_seed: 1606239866
+    resources:
+      agent_label: ''
+      native_parallel: false
+      slots_per_trial: 1
+      weight: 1
+    scheduling_unit: 100
+    searcher:
+      max_length:
+        batches: 1000
+      metric: loss
+      name: single
+      smaller_is_better: true
+      source_checkpoint_uuid: null
+      source_trial_id: null
+
+- name: minimal valid experiment
+  matches:
+    - http://determined.ai/schemas/expconf/v1/experiment.json
+  case:
+    checkpoint_storage:
+      type: shared_fs
+      host_path: /tmp
+    hyperparameters:
+      global_batch_size: 32
+    searcher:
+      name: single
+      metric: loss
+      max_length:
+        batches: 1000
+    entrypoint: model_def:MyTrial
+
+- name: records_per_epoch conditional (valid)
+  matches:
+    - http://determined.ai/schemas/expconf/v1/experiment.json
+  case:
+    hyperparameters:
+      global_batch_size: 32
+    checkpoint_storage:
+      type: shared_fs
+      host_path: /tmp
+    entrypoint: model_def:MyTrial
+    searcher:
+      name: single
+      metric: loss
+      max_length:
+        epochs: 10
+    min_validation_period:
+      epochs: 10
+    min_checkpoint_period:
+      epochs: 10
+    records_per_epoch: 10
+
+- name: records_per_epoch conditional (invalid, zero)
+  errors:
+    http://determined.ai/schemas/expconf/v1/experiment.json:
+      - "<config>.searcher.max_length: must specify the top-level records_per_epoch"
+      - "<config>.min_validation_period: must specify the top-level records_per_epoch"
+      - "<config>.min_checkpoint_period: must specify the top-level records_per_epoch"
+  case:
+    searcher:
+      name: single
+      metric: loss
+      max_length:
+        epochs: 10
+    min_validation_period:
+      epochs: 10
+    min_checkpoint_period:
+      epochs: 10
+    records_per_epoch: 0
+
+- name: records_per_epoch conditional (invalid, missing)
+  errors:
+    http://determined.ai/schemas/expconf/v1/experiment.json:
+      - "<config>.searcher.max_length: must specify the top-level records_per_epoch"
+      - "<config>.min_validation_period: must specify the top-level records_per_epoch"
+      - "<config>.min_checkpoint_period: must specify the top-level records_per_epoch"
+  case:
+    searcher:
+      name: single
+      metric: loss
+      max_length:
+        epochs: 10
+    min_validation_period:
+      epochs: 10
+    min_checkpoint_period:
+      epochs: 10
+    entrypoint: model_def:MyTrial
+
+- name: check grid conditional (valid)
+  matches:
+    - http://determined.ai/schemas/expconf/v1/experiment.json
+  case:
+    hyperparameters:
+      global_batch_size:
+        type: const
+        val: 32
+      list_hparam:
+        - 10
+        - type: const
+          val: asdf
+        - type: int
+          minval: 1
+          maxval: 2
+          count: 2
+      dict_hparam:
+        double_hparam:
+          type: double
+          minval: 1
+          maxval: 10
+          count: 2
+        log_hparam:
+          type: log
+          minval: 1
+          maxval: 10
+          base: 1
+          count: 2
+      categorical_hparam:
+        type: categorical
+        vals: [1, 2, 3, 4]
+    checkpoint_storage:
+      type: shared_fs
+      host_path: /tmp
+    searcher:
+      name: grid
+      metric: loss
+      max_length:
+        batches: 1000
+    entrypoint: model_def:MyTrial
+
+- name: check grid conditional (invalid)
+  errors:
+    http://determined.ai/schemas/expconf/v1/experiment.json:
+      - "<config>.hyperparameters.dict_hparam.log_hparam: grid search is in use but count was not provided"
+      - "<config>.hyperparameters.list_hparam[2]: grid search is in use but count was not provided"
+  case:
+    hyperparameters:
+      global_batch_size:
+        type: const
+        val: 32
+      list_hparam:
+        - 10
+        - type: const
+          val: asdf
+        - type: int
+          minval: 1
+          maxval: 2
+      dict_hparam:
+        double_hparam:
+          type: double
+          minval: 1
+          maxval: 10
+          count: 2
+        log_hparam:
+          type: log
+          minval: 1
+          maxval: 10
+          base: 1
+      categorical_hparam:
+        type: categorical
+        vals: [1, 2, 3, 4]
+    searcher:
+      name: grid
+      metric: loss
+      max_length:
+        batches: 1000
+
+- name: check entrypoint conditional (valid, native in use)
+  matches:
+    - http://determined.ai/schemas/expconf/v1/experiment.json
+  case:
+    hyperparameters:
+      global_batch_size: 32
+    checkpoint_storage:
+      type: shared_fs
+      host_path: /tmp
+    searcher:
+      name: single
+      metric: loss
+      max_length:
+        batches: 1000
+    internal:
+      native: ["script.py"]
+
+- name: check entrypoint conditional (invalid)
+  errors:
+    http://determined.ai/schemas/expconf/v1/experiment.json:
+      - must specify an entrypoint that references the trial class
+  case:
+    hyperparameters:
+      global_batch_size: 32
+    searcher:
+      name: single
+      metric: loss
+      max_length:
+        batches: 1000
+    internal:
+      native: null
+
+- name: entrypoint check (invalid)
+  errors:
+    http://determined.ai/schemas/expconf/v1/experiment.json:
+      - "entrypoint must be of the form \"module.submodule:ClassName\""
+  case:
+    entrypoint: not-right:NotRightTrial

--- a/schemas/test_cases/v1/global_batch_size.yaml
+++ b/schemas/test_cases/v1/global_batch_size.yaml
@@ -1,0 +1,73 @@
+- name: check global_batch_size (valid, implicit const)
+  matches:
+    - http://determined.ai/schemas/expconf/v1/check-global-batch-size.json
+    - http://determined.ai/schemas/expconf/v1/hyperparameter.json
+  case:
+    32
+
+- name: check global_batch_size (valid, explicit const)
+  matches:
+    - http://determined.ai/schemas/expconf/v1/check-global-batch-size.json
+    - http://determined.ai/schemas/expconf/v1/hyperparameter.json
+  case:
+    type: const
+    val: 32
+
+- name: check global_batch_size (valid, int)
+  matches:
+    - http://determined.ai/schemas/expconf/v1/check-global-batch-size.json
+    - http://determined.ai/schemas/expconf/v1/hyperparameter.json
+  case:
+    type: int
+    minval: 32
+    maxval: 64
+
+- name: check global_batch_size (valid, categorical)
+  matches:
+    - http://determined.ai/schemas/expconf/v1/check-global-batch-size.json
+    - http://determined.ai/schemas/expconf/v1/hyperparameter.json
+  case:
+    type: categorical
+    vals: [32, 64]
+
+- name: check global_batch_size (invalid, implicit const)
+  matches:
+    - http://determined.ai/schemas/expconf/v1/hyperparameter.json
+  errors:
+    http://determined.ai/schemas/expconf/v1/check-global-batch-size.json:
+      - is neither a positive integer nor an int hyperparameter
+  case:
+    0
+
+- name: check global_batch_size (invalid, explicit const)
+  matches:
+    - http://determined.ai/schemas/expconf/v1/hyperparameter.json
+  errors:
+    http://determined.ai/schemas/expconf/v1/check-global-batch-size.json:
+      # json-schema builtin checks have error messages which vary by library.
+      - "<config>.val:"
+  case:
+    type: const
+    val: 0
+
+- name: check global_batch_size (invalid, int)
+  matches:
+    - http://determined.ai/schemas/expconf/v1/hyperparameter.json
+  errors:
+    http://determined.ai/schemas/expconf/v1/check-global-batch-size.json:
+      - "<config>.minval:"
+  case:
+    type: int
+    minval: 0
+    maxval: 32
+
+- name: check global_batch_size (invalid, categorical)
+  matches:
+    - http://determined.ai/schemas/expconf/v1/hyperparameter.json
+  errors:
+    http://determined.ai/schemas/expconf/v1/check-global-batch-size.json:
+      - "<config>.vals[0]:"
+      - "<config>.vals[1]:"
+  case:
+    type: categorical
+    vals: [0, -1]

--- a/schemas/test_cases/v1/hyperparameters.yaml
+++ b/schemas/test_cases/v1/hyperparameters.yaml
@@ -1,0 +1,90 @@
+- name: implicit const hyperparameter (valid, implicit)
+  matches:
+    - http://determined.ai/schemas/expconf/v1/hyperparameter.json
+  case:
+    nest:
+      const_implicit_empty:
+      const_implicit_null: null
+      const_implicit_bool: true
+      const_implicit_int: 1234
+      const_implicit_float: 1234.5678
+      const_implicit_list:
+        - 1
+        - fish
+        - 2
+        - fish
+      const_implicit_dict:
+        red: fish
+        blue: fish
+
+- name: list, const hyperparameter (valid, explicit)
+  matches:
+    - http://determined.ai/schemas/expconf/v1/hyperparameter.json
+  case:
+    - type: const
+      val: asdf
+    - type: const
+      val: [1, "fish", 2, "fish"]
+    - type: const
+      val: {"red": "fish", "blue": "fish"}
+
+- name: int hyperparameter (valid)
+  matches:
+    - http://determined.ai/schemas/expconf/v1/hyperparameter.json
+    - http://determined.ai/schemas/expconf/v1/hyperparameter-int.json
+  case:
+    type: int
+    minval: 1
+    maxval: 2
+
+- name: double hyperparameter (valid)
+  matches:
+    - http://determined.ai/schemas/expconf/v1/hyperparameter.json
+    - http://determined.ai/schemas/expconf/v1/hyperparameter-double.json
+  case:
+    type: double
+    minval: 1
+    maxval: 2
+
+- name: log hyperparameter (valid)
+  matches:
+    - http://determined.ai/schemas/expconf/v1/hyperparameter.json
+    - http://determined.ai/schemas/expconf/v1/hyperparameter-log.json
+  case:
+    type: log
+    minval: 1
+    maxval: 10
+    base: 3.14
+
+- name: categorical hyperparameter (valid)
+  matches:
+    - http://determined.ai/schemas/expconf/v1/hyperparameter.json
+    - http://determined.ai/schemas/expconf/v1/hyperparameter-categorical.json
+  case:
+    type: categorical
+    vals:
+      - null
+      - true
+      - 0
+      - 0.0
+      - asdf
+      - [1, "fish", 2, "fish"]
+      - {"red": "fish", "blue": "fish"}
+
+- name: nested hyperparameters (invalid, to show paths in errors)
+  errors:
+    http://determined.ai/schemas/expconf/v1/hyperparameter.json:
+      - "<config>[0][0]:"
+      - "<config>[0][1]:"
+      - "<config>[1].one.a:"
+      - "<config>[1].one.b[0]:"
+      - "<config>[1].one.b[1]:"
+  case:
+    - - type: categorical
+      - type: categorical
+    - one:
+        a:
+          type: categorical
+        b:
+          - type: categorical
+          - type: categorical

--- a/schemas/test_cases/v1/misc.yaml
+++ b/schemas/test_cases/v1/misc.yaml
@@ -1,0 +1,121 @@
+- name: bind_mount checks (invalid)
+  errors:
+    http://determined.ai/schemas/expconf/v1/bind-mount.json:
+      - container_path must not be "."
+      - host_path must be an absolute path
+  case:
+    host_path: asdf
+    container_path: .
+
+- name: epoch length in use (invalid)
+  errors:
+    http://determined.ai/schemas/expconf/v1/check-epoch-not-used.json:
+      - "<config>.a[0].b.c: must specify the top-level records_per_epoch"
+  case:
+    a:
+      - b:
+          c:
+            epochs:
+              10
+
+- name: check counts for grid (valid)
+  matches:
+    - http://determined.ai/schemas/expconf/v1/check-grid-hyperparameter.json
+  case:
+    global_batch_size:
+      type: const
+      val: 32
+    a: 1
+    list_hparam:
+      - 10
+      - type: const
+        val: asdf
+      - type: int
+        minval: 1
+        maxval: 2
+        count: 2
+    dict_hparam:
+      double_hparam:
+        type: double
+        minval: 1
+        maxval: 10
+        count: 4
+      log_hparam:
+        type: log
+        minval: 1
+        maxval: 10
+        base: 1
+        count: 1
+    categorical_hparam:
+      type: categorical
+      vals: [1, 2, 3, 4]
+
+- name: check counts for grid (invalid)
+  errors:
+    http://determined.ai/schemas/expconf/v1/check-grid-hyperparameter.json:
+      - "<config>.dict_hparam.double_hparam: grid search is in use but count was not provided"
+      - "<config>.dict_hparam.log_hparam: grid search is in use but count was not provided"
+      - "<config>.list_hparam[2]: grid search is in use but count was not provided"
+  case:
+    global_batch_size:
+      type: const
+      val: 32
+    a: 1
+    list_hparam:
+      - 10
+      - type: const
+        val: asdf
+      - type: int
+        minval: 1
+        maxval: 2
+    dict_hparam:
+      double_hparam:
+        type: double
+        minval: 1
+        maxval: 10
+      log_hparam:
+        type: log
+        minval: 1
+        maxval: 10
+        base: 1
+    categorical_hparam:
+      type: categorical
+      vals: [1, 2, 3, 4]
+
+- name: local_cache data layer checks (valid, present)
+  matches:
+    - http://determined.ai/schemas/expconf/v1/data-layer-s3.json
+  case:
+    type: s3
+    bucket: asdf
+    bucket_directory_path: /asdf/asdf
+    local_cache_container_path: /asdf/asdf
+    local_cache_host_path: /asdf/asdf
+
+- name: local_cache data layer checks (valid, empty)
+  matches:
+    - http://determined.ai/schemas/expconf/v1/data-layer-s3.json
+  case:
+    type: s3
+    bucket: asdf
+    bucket_directory_path: /asdf/asdf
+
+- name: local_cache data layer checks (invalid, has host)
+  errors:
+    http://determined.ai/schemas/expconf/v1/data-layer-s3.json:
+      - "local_cache_container_path must be specified if local_cache_host_path is set"
+  case:
+    type: s3
+    bucket: asdf
+    bucket_directory_path: /asdf/asdf
+    local_cache_host_path: /asdf/asdf
+
+- name: local_cache data layer checks (invalid, has container)
+  errors:
+    http://determined.ai/schemas/expconf/v1/data-layer-s3.json:
+      - "local_cache_host_path must be specified if local_cache_container_path is set"
+  case:
+    type: s3
+    bucket: asdf
+    bucket_directory_path: /asdf/asdf
+    local_cache_container_path: /asdf/asdf

--- a/schemas/test_cases/v1/searchers.yaml
+++ b/schemas/test_cases/v1/searchers.yaml
@@ -1,0 +1,149 @@
+- name: single searcher (valid)
+  matches:
+    - http://determined.ai/schemas/expconf/v1/searcher.json
+    - http://determined.ai/schemas/expconf/v1/searcher-single.json
+  case:
+    name: single
+    max_length:
+      batches: 1000
+    metric: loss
+    smaller_is_better: true
+    source_checkpoint_uuid: null
+    source_trial_id: null
+
+- name: random searcher (valid)
+  matches:
+    - http://determined.ai/schemas/expconf/v1/searcher.json
+    - http://determined.ai/schemas/expconf/v1/searcher-random.json
+  case:
+    name: random
+    max_length:
+      batches: 1000
+    max_trials: 1000
+    metric: loss
+    smaller_is_better: true
+    source_checkpoint_uuid: "asdf"
+    source_trial_id: null
+
+- name: grid searcher (valid)
+  matches:
+    - http://determined.ai/schemas/expconf/v1/searcher.json
+    - http://determined.ai/schemas/expconf/v1/searcher-grid.json
+  case:
+    name: grid
+    max_length:
+      batches: 1000
+    metric: loss
+    smaller_is_better: true
+    source_checkpoint_uuid: "asdf"
+    source_trial_id: null
+
+- name: sync_halving searcher (valid)
+  matches:
+    - http://determined.ai/schemas/expconf/v1/searcher.json
+    - http://determined.ai/schemas/expconf/v1/searcher-sync-halving.json
+  case:
+    name: sync_halving
+    max_length:
+      batches: 1000
+    num_rungs: 5
+    budget:
+      epochs: 1
+    divisor: 1.5
+    train_stragglers: true
+    metric: loss
+    smaller_is_better: true
+    source_checkpoint_uuid: null
+    source_trial_id: 15
+
+- name: async_halving searcher (valid)
+  matches:
+    - http://determined.ai/schemas/expconf/v1/searcher.json
+    - http://determined.ai/schemas/expconf/v1/searcher-async-halving.json
+  case:
+    name: async_halving
+    num_rungs: 5
+    max_length:
+      batches: 1000
+    max_trials: 100
+    divisor: 1.5
+    max_concurrent_trials: 2
+    metric: loss
+    smaller_is_better: true
+    source_checkpoint_uuid: null
+    source_trial_id: 15
+
+- name: adaptive searcher (valid)
+  matches:
+    - http://determined.ai/schemas/expconf/v1/searcher.json
+    - http://determined.ai/schemas/expconf/v1/searcher-adaptive.json
+  case:
+    name: adaptive
+    max_length:
+      batches: 1000
+    budget:
+      batches: 10000
+    bracket_rungs: [1, 2, 3, 4, 5]
+    divisor: 1.5
+    train_stragglers: true
+    max_rungs: 5
+    mode: standard
+    metric: loss
+    smaller_is_better: true
+    source_checkpoint_uuid: null
+    source_trial_id: 15
+
+- name: adaptive_simple searcher (valid)
+  matches:
+    - http://determined.ai/schemas/expconf/v1/searcher.json
+    - http://determined.ai/schemas/expconf/v1/searcher-adaptive-simple.json
+  case:
+    name: adaptive_simple
+    max_length:
+      batches: 1000
+    max_trials: 100
+    max_rungs: 5
+    mode: standard
+    metric: loss
+    smaller_is_better: true
+    source_checkpoint_uuid: null
+    source_trial_id: 15
+
+- name: adaptive_asha searcher (valid)
+  matches:
+    - http://determined.ai/schemas/expconf/v1/searcher.json
+    - http://determined.ai/schemas/expconf/v1/searcher-adaptive-asha.json
+  case:
+    name: adaptive_asha
+    max_length:
+      batches: 1000
+    max_trials: 100
+    bracket_rungs: [1, 2, 3, 4, 5]
+    divisor: 5
+    mode: standard
+    max_rungs: 5
+    max_concurrent_trials: 5
+    metric: loss
+    smaller_is_better: true
+    source_checkpoint_uuid: null
+    source_trial_id: 15
+
+- name: pbt searcher (valid)
+  matches:
+    - http://determined.ai/schemas/expconf/v1/searcher.json
+    - http://determined.ai/schemas/expconf/v1/searcher-pbt.json
+  case:
+    name: pbt
+    population_size: 25
+    num_rounds: 25
+    length_per_round:
+      batches: 1000
+    replace_function:
+      truncate_fraction: 0.5
+    explore_function:
+      resample_probability: 0.5
+      perturb_factor: 0.5
+    metric: loss
+    smaller_is_better: true
+    source_checkpoint_uuid: null
+    source_trial_id: 15

--- a/schemas/test_cases/v1/unions.yaml
+++ b/schemas/test_cases/v1/unions.yaml
@@ -1,0 +1,140 @@
+# One instance of each type in all the smaller union types.
+# (Other types like hyperparameters or searchers have their own files)
+
+- name: s3 checkpoint storage (valid)
+  matches:
+    - http://determined.ai/schemas/expconf/v1/s3.json
+    - http://determined.ai/schemas/expconf/v1/checkpoint-storage.json
+  case:
+    type: s3
+    bucket: determined-cp
+    access_key: minio
+    secret_key: "12341234"
+    endpoint_url: "http://192.168.0.4:9000"
+    save_experiment_best: 0
+    save_trial_best: 1
+    save_trial_latest: 1
+
+- name: gcs checkpoint storage (valid)
+  matches:
+    - http://determined.ai/schemas/expconf/v1/gcs.json
+    - http://determined.ai/schemas/expconf/v1/checkpoint-storage.json
+  case:
+    type: gcs
+    bucket: determined-cp
+    save_experiment_best: 0
+    save_trial_best: 1
+    save_trial_latest: 1
+
+- name: shared_fs checkpoint storage (valid)
+  matches:
+    - http://determined.ai/schemas/expconf/v1/shared-fs.json
+    - http://determined.ai/schemas/expconf/v1/checkpoint-storage.json
+  case:
+    type: shared_fs
+    host_path: /tmp
+    storage_path: determined-cp
+    propagation: rprivate
+    container_path: /asdf
+    checkpoint_path: /qwer
+    tensorboard_path: /zxcv
+    save_experiment_best: 0
+    save_trial_best: 1
+    save_trial_latest: 1
+
+- name: hdfs checkpoint storage (valid)
+  matches:
+    - http://determined.ai/schemas/expconf/v1/hdfs.json
+    - http://determined.ai/schemas/expconf/v1/checkpoint-storage.json
+  case:
+    type: hdfs
+    hdfs_url: hfds://hdfs.hdfs
+    hdfs_path: /a/b/c/d
+    user: user
+    save_experiment_best: 0
+    save_trial_best: 1
+    save_trial_latest: 1
+
+
+- name: shared_fs data layer (valid)
+  matches:
+    - http://determined.ai/schemas/expconf/v1/data-layer-shared-fs.json
+    - http://determined.ai/schemas/expconf/v1/data-layer.json
+  case:
+    type: shared_fs
+    host_storage_path: /asdf/asdf
+    container_storage_path: /asdf/asdf
+
+- name: s3 data layer (valid)
+  matches:
+    - http://determined.ai/schemas/expconf/v1/data-layer-s3.json
+    - http://determined.ai/schemas/expconf/v1/data-layer.json
+  case:
+    type: s3
+    bucket: asdf
+    bucket_directory_path: /asdf/asdf
+    local_cache_container_path: /asdf/asdf
+    local_cache_host_path: /asdf/asdf
+    access_key: "samIAM"
+    secret_key: gr33n3ggsNham
+    endpoint_url: "https://asdf.com:9000"
+
+- name: gcs data layer (valid)
+  matches:
+    - http://determined.ai/schemas/expconf/v1/data-layer-gcs.json
+    - http://determined.ai/schemas/expconf/v1/data-layer.json
+  case:
+    type: gcs
+    bucket: asdf
+    bucket_directory_path: /asdf/asdf
+    local_cache_container_path: /asdf/asdf
+    local_cache_host_path: /asdf/asdf
+
+- name: records length (valid)
+  matches:
+    - http://determined.ai/schemas/expconf/v1/length.json
+  case:
+    records:
+      1
+
+- name: batches length (valid)
+  matches:
+    - http://determined.ai/schemas/expconf/v1/length.json
+  case:
+    batches:
+      1
+
+- name: epochs length (valid)
+  matches:
+    - http://determined.ai/schemas/expconf/v1/length.json
+  case:
+    epochs:
+      1
+
+- name: environment image string (valid)
+  matches:
+    - http://determined.ai/schemas/expconf/v1/environment-image.json
+  case:
+    "alpine"
+
+- name: environment image map of string (valid)
+  matches:
+    - http://determined.ai/schemas/expconf/v1/environment-image.json
+  case:
+    cpu: "alpine"
+    gpu: "alpine"
+
+- name: environment variables list of strings (valid)
+  matches:
+    - http://determined.ai/schemas/expconf/v1/environment-variables.json
+  case:
+    - "ABCD=1234"
+
+- name: environment variables map of lists of strings (valid)
+  matches:
+    - http://determined.ai/schemas/expconf/v1/environment-variables.json
+  case:
+    cpu:
+      - "ABCD=1234"
+    gpu:
+      - "ABCD=1234"


### PR DESCRIPTION
## Description

feat: json-schema for experiment config validation

Json-schema defines validation logic for arbitrary schemas with good
cross-language support.  This allows us to migrate our experiment config
validation logic (and defaulting logic) out of Go and into both Python
and JavaScript (this PR only includes the Go and Python validation).

Json-schema is not natively capable of all of the validation logic that
we need, but it is still highly valuable for our usecase because custom
extensions are a first class feature in most json-schema libraries.

We have the following custom extensions:
  - union: Excellent error messages when validating union types
  - checks: Custom messages for arbitrary validation logic
  - disallowProperties: Custom messages when disallowing properties
  - eventuallyRequired: Support two-step validation
  - compareProperties: Support customizable value comparisons

This PR's effect on the current system is purely cosmetic.  The new
json-schema validators are used purely for improving the invalid config
error messages, but all validation and defaulting logic otherwise
remains the same.

The goal of this PR is to have identical logic as before but in a
cross-language format.  The only exceptions are where the old behavior
is completely wrong (additional fields are silently allowed in the
ResourcesConfig).  A non-goal is to modify the experiment config schema
from its current state.  Eventually, supporting automatic shimming of
experiment configs between explicit versions will give us the
flexibility to modify our existing experiment config schema as we wish.


## Testing plan

For now, I plan on conducting tests against existing bodies of experiment configs (ours and our customers') to find if there are experiment configs in the wild which do not properly validate against the new logic.  So far, it seems ResourcesConfig wrongly allows any wildcard properties with the old config, which was definitely an oversight.

I also plan on having an automated test suite with a fully-specified valid configuration and a minimally-specified valid configuration.

Future tests will include an automated test suite with various invalid configurations; those will be blocking the transition from the old golang validation as the source of truth to the json-schema validation as the source of truth, and they will also be key to making sure that the custom extensions are implemented properly in each language.