### PR TITLE
chore: update to Go 1.15

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -697,7 +697,7 @@ jobs:
 
   package-and-push-system-local:
     docker:
-      - image: cimg/go:1.13
+      - image: cimg/go:1.15
         environment:
           GO111MODULE: "on"
     steps:
@@ -723,7 +723,7 @@ jobs:
 
   package-and-push-system-dev:
     docker:
-      - image: cimg/go:1.13
+      - image: cimg/go:1.15
         environment:
           GO111MODULE: "on"
     steps:
@@ -741,7 +741,7 @@ jobs:
 
   package-and-push-system-rc:
     docker:
-      - image: cimg/go:1.13
+      - image: cimg/go:1.15
         environment:
           GO111MODULE: "on"
     steps:
@@ -759,7 +759,7 @@ jobs:
 
   package-and-push-system-release:
     docker:
-      - image: cimg/go:1.13
+      - image: cimg/go:1.15
         environment:
           GO111MODULE: "on"
     steps:
@@ -940,7 +940,7 @@ jobs:
 
   lint-go:
     docker:
-      - image: cimg/go:1.13
+      - image: cimg/go:1.15
         environment:
           GO111MODULE: "on"
     steps:
@@ -953,7 +953,7 @@ jobs:
 
   build-go:
     docker:
-      - image: cimg/go:1.13
+      - image: cimg/go:1.15
         environment:
           GO111MODULE: "on"
     steps:
@@ -970,7 +970,7 @@ jobs:
 
   build-proto:
     docker:
-      - image: cimg/go:1.13
+      - image: cimg/go:1.15
         environment:
           GO111MODULE: "on"
     steps:
@@ -984,7 +984,7 @@ jobs:
 
   test-unit-go:
     docker:
-      - image: cimg/go:1.13
+      - image: cimg/go:1.15
         environment:
           GO111MODULE: "on"
     steps:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,7 +48,7 @@ git clone git@github.com:determined-ai/determined.git
 
 #### Prerequisites
 
-- Go (>= 1.13)
+- Go (>= 1.15)
 - Python (>= 3.6, < 3.8)
 - Node (>= 12)
 - NPM (>= 6.12)

--- a/agent/go.mod
+++ b/agent/go.mod
@@ -1,6 +1,6 @@
 module github.com/determined-ai/determined/agent
 
-go 1.12
+go 1.15
 
 require (
 	github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d // indirect

--- a/master/go.mod
+++ b/master/go.mod
@@ -1,5 +1,7 @@
 module github.com/determined-ai/determined/master
 
+go 1.15
+
 require (
 	cloud.google.com/go v0.58.0
 	github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78 // indirect
@@ -65,5 +67,3 @@ require (
 replace github.com/determined-ai/determined/proto => ../proto
 
 replace github.com/docker/docker v1.13.1 => github.com/docker/engine v1.4.2-0.20191113042239-ea84732a7725
-
-go 1.13

--- a/proto/go.mod
+++ b/proto/go.mod
@@ -1,6 +1,6 @@
 module github.com/determined-ai/determined/proto
 
-go 1.13
+go 1.15
 
 require (
 	github.com/bufbuild/buf v0.12.1


### PR DESCRIPTION
## Description

Go 1.13 went out of support when 1.15 came out a few months ago, so
let's get everything bumped up.

## Test Plan

- [x] use 1.15 locally for the past several months
- [x] [run tests with upgraded images in CI](https://app.circleci.com/pipelines/github/determined-ai/determined?branch=go-1.15)
