### PR TITLE
fix: fix asha max concurrent trials

### DIFF
--- a/docs/reference/experiment-config.txt
+++ b/docs/reference/experiment-config.txt
@@ -643,7 +643,9 @@ large-scale experiments with hundreds or thousands of trials.
    The maximum number of trials that can be worked on simultaneously.
    The default value is ``0``, and we set reasonable values depending on
    max_trials and the number of rungs in the brackets. This is akin to
-   controlling the degree of parallelism of the experiment.
+   controlling the degree of parallelism of the experiment. If this
+   value is less than the number of brackets produced by the adaptive
+   algorithm, it will be rounded up.
 
 ``source_trial_id``
    If specified, the weights of *every* trial in the search will be

--- a/docs/release-notes/1719-fix-asha-max-concurrent-trials.txt
+++ b/docs/release-notes/1719-fix-asha-max-concurrent-trials.txt
@@ -1,0 +1,6 @@
+:orphan:
+
+**BUG FIXES**
+
+-  HP Search: Fix a bug where ``adaptive_asha`` could run higher max
+   concurrent trials than intended.

--- a/docs/release-notes/1719-fix-asha-max-concurrent-trials.txt
+++ b/docs/release-notes/1719-fix-asha-max-concurrent-trials.txt
@@ -2,5 +2,5 @@
 
 **BUG FIXES**
 
--  HP Search: Fix a bug where ``adaptive_asha`` could run higher max
+-  HP Search: Fix a bug where ``adaptive_asha`` could run with more max
    concurrent trials than intended.

--- a/docs/topic-guides/hp-tuning-det/hp-adaptive-asha.txt
+++ b/docs/topic-guides/hp-tuning-det/hp-adaptive-asha.txt
@@ -44,7 +44,8 @@ Resource budget:
    this many trials training simultaneously at any one time. The
    ``adaptive_asha`` searcher scales nearly perfectly with additional
    compute, so you should set this field based on compute environment
-   constraints.
+   constraints. If this value is less than the number of brackets
+   produced by the adaptive algorithm, it will be rounded up.
 
 *********
  Details

--- a/master/pkg/searcher/adaptive_asha.go
+++ b/master/pkg/searcher/adaptive_asha.go
@@ -44,12 +44,12 @@ func getBracketMaxConcurrentTrials(
 	remainder := 0
 	numBrackets := len(maxTrials)
 	bracketMaxConcurrentTrials := make([]int, 0, numBrackets)
-	// Without this, the remainder will be less than numBrackets and later brackets will,
-	// not receive a constraint on bracketMaxConcurrentTrials.
-	maxConcurrentTrials = min(maxConcurrentTrials, numBrackets)
 	if maxConcurrentTrials == 0 {
 		minTrials = max(maxTrials[numBrackets-1], int(divisor))
 	} else {
+		// Without this, the remainder will be less than numBrackets and later brackets willgit pu
+		// not receive a constraint on bracketMaxConcurrentTrials.
+		maxConcurrentTrials = max(maxConcurrentTrials, numBrackets)
 		minTrials = maxConcurrentTrials / numBrackets
 		remainder = maxConcurrentTrials % numBrackets
 	}

--- a/master/pkg/searcher/adaptive_asha.go
+++ b/master/pkg/searcher/adaptive_asha.go
@@ -44,6 +44,9 @@ func getBracketMaxConcurrentTrials(
 	remainder := 0
 	numBrackets := len(maxTrials)
 	bracketMaxConcurrentTrials := make([]int, 0, numBrackets)
+	// Without this, the remainder will be less than numBrackets and later brackets will,
+	// not receive a constraint on bracketMaxConcurrentTrials.
+	maxConcurrentTrials = min(maxConcurrentTrials, numBrackets)
 	if maxConcurrentTrials == 0 {
 		minTrials = max(maxTrials[numBrackets-1], int(divisor))
 	} else {


### PR DESCRIPTION
## Description
This change fix and bug and makes a shortcoming of the current `max_concurrent_trials` implementation  explicit in the documenation.
<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)
The long term fix is much more complicated and probably involves redesigning the searchers a bit.
<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [x] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234