### PR TITLE
feat: rebase onto horovod 0.21.0 [DET-4668]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,11 +99,11 @@ commands:
       - when:
           condition: <<parameters.tf1>>
           steps:
-            - run: docker pull determinedai/environments:py-3.6.9-pytorch-1.4-tf-1.15-cpu-0f2001a
+            - run: docker pull determinedai/environments:py-3.6.9-pytorch-1.4-tf-1.15-cpu-600cf86
       - when:
           condition: <<parameters.tf2>>
           steps:
-            - run: docker pull determinedai/environments:py-3.6.9-pytorch-1.4-tf-2.2-cpu-0f2001a
+            - run: docker pull determinedai/environments:py-3.6.9-pytorch-1.4-tf-2.2-cpu-600cf86
 
   login-docker:
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,11 +99,11 @@ commands:
       - when:
           condition: <<parameters.tf1>>
           steps:
-            - run: docker pull determinedai/environments:py-3.6.9-pytorch-1.4-tf-1.15-cpu-600cf86
+            - run: docker pull determinedai/environments:py-3.6.9-pytorch-1.4-tf-1.15-cpu-067db2b
       - when:
           condition: <<parameters.tf2>>
           steps:
-            - run: docker pull determinedai/environments:py-3.6.9-pytorch-1.4-tf-2.2-cpu-600cf86
+            - run: docker pull determinedai/environments:py-3.6.9-pytorch-1.4-tf-2.2-cpu-067db2b
 
   login-docker:
     steps:

--- a/deploy/determined_deploy/aws/templates/efs.yaml
+++ b/deploy/determined_deploy/aws/templates/efs.yaml
@@ -3,36 +3,36 @@ Description:  This template deploys a VPC, with a public and private subnet. It 
 Mappings:
   RegionMap:
     ap-northeast-1:
-      Master: ami-0b8cd500f483d09ee
-      Agent: ami-01094af1846f7e057
+      Master: ami-0af17d43b1f4ff4ea
+      Agent: ami-07dc1e0617119df61
     # TODO(DET-4258) Uncomment these when we fully support all P3 regions.
     # ap-northeast-2:
-    #   Master: ami-07b7be0099924913e
-    #   Agent: ami-068b19daf956a4ca5
+    #   Master: ami-04e6fcf8cfe3b09ea
+    #   Agent: ami-0a0061c1a3f27fe51
     # ap-southeast-1:
-    #   Master: ami-028a5cff2f5a0f6c3
-    #   Agent: ami-01b7af9433b415dac
+    #   Master: ami-0ba45f1ec3dff60f9
+    #   Agent: ami-0994ac61987afed77
     # ap-southeast-2:
-    #   Master: ami-041e1cc8f4c429789
-    #   Agent: ami-07fc663f38164369e
+    #   Master: ami-004d0fb87d10716c6
+    #   Agent: ami-0183cafc9f2a57aa6
     eu-central-1:
-      Master: ami-0d971d62e4d019dcc
-      Agent: ami-00c716e5005603cb0
+      Master: ami-08a1a61694dd1c82f
+      Agent: ami-0c39ce440c27b5b97
     eu-west-1:
-      Master: ami-09b9e380df60300c8
-      Agent: ami-0da48b82961b59fba
+      Master: ami-0d67111dcacb4a14a
+      Agent: ami-085e4c3de4782b626
     # eu-west-2:
-    #   Master: ami-071884cefc7e770ba
-    #   Agent: ami-0d49b45685428fda1
+    #   Master: ami-03441ec6f2faa7ddc
+    #   Agent: ami-080b10920a3f55fd4
     us-east-1:
-      Master: ami-0739f8cdb239fe9ae
-      Agent: ami-0fa3c95101db75a3c
+      Master: ami-099e921e69356cf89
+      Agent: ami-06130d042431bcc18
     us-east-2:
-      Master: ami-0ebc8f6f580a04647
-      Agent: ami-0d7b699aa2315ee2d
+      Master: ami-05edbb8e25e281608
+      Agent: ami-044bdeb2ce74f4549
     us-west-2:
-      Master: ami-008b09448b998a562
-      Agent: ami-0888d917ee7cc9be9
+      Master: ami-00f1e37d20049f858
+      Agent: ami-07b649652a40e4208
 
 Parameters:
   VpcCIDR:

--- a/deploy/determined_deploy/aws/templates/efs.yaml
+++ b/deploy/determined_deploy/aws/templates/efs.yaml
@@ -4,35 +4,35 @@ Mappings:
   RegionMap:
     ap-northeast-1:
       Master: ami-0af17d43b1f4ff4ea
-      Agent: ami-07dc1e0617119df61
+      Agent: ami-0a01b67743d465a6e
     # TODO(DET-4258) Uncomment these when we fully support all P3 regions.
     # ap-northeast-2:
     #   Master: ami-04e6fcf8cfe3b09ea
-    #   Agent: ami-0a0061c1a3f27fe51
+    #   Agent: ami-0c74312df78509701
     # ap-southeast-1:
     #   Master: ami-0ba45f1ec3dff60f9
-    #   Agent: ami-0994ac61987afed77
+    #   Agent: ami-0eddf3f941d216f11
     # ap-southeast-2:
     #   Master: ami-004d0fb87d10716c6
-    #   Agent: ami-0183cafc9f2a57aa6
+    #   Agent: ami-0c54777eb400a9e68
     eu-central-1:
       Master: ami-08a1a61694dd1c82f
-      Agent: ami-0c39ce440c27b5b97
+      Agent: ami-0474e45bb1a45bbfe
     eu-west-1:
       Master: ami-0d67111dcacb4a14a
-      Agent: ami-085e4c3de4782b626
+      Agent: ami-0036879b70fee3339
     # eu-west-2:
     #   Master: ami-03441ec6f2faa7ddc
-    #   Agent: ami-080b10920a3f55fd4
+    #   Agent: ami-05d9b28afa79dbda3
     us-east-1:
       Master: ami-099e921e69356cf89
-      Agent: ami-06130d042431bcc18
+      Agent: ami-0080b638f1339ccd5
     us-east-2:
       Master: ami-05edbb8e25e281608
-      Agent: ami-044bdeb2ce74f4549
+      Agent: ami-07318f0e0b3a02b8e
     us-west-2:
       Master: ami-00f1e37d20049f858
-      Agent: ami-07b649652a40e4208
+      Agent: ami-0211fc4b3b0eb5c64
 
 Parameters:
   VpcCIDR:

--- a/deploy/determined_deploy/aws/templates/fsx.yaml
+++ b/deploy/determined_deploy/aws/templates/fsx.yaml
@@ -2,36 +2,36 @@ Description:  This template deploys a VPC, with a public and private subnet, and
 Mappings:
   RegionMap:
     ap-northeast-1:
-      Master: ami-0b8cd500f483d09ee
-      Agent: ami-01094af1846f7e057
+      Master: ami-0af17d43b1f4ff4ea
+      Agent: ami-07dc1e0617119df61
     # TODO(DET-4258) Uncomment these when we fully support all P3 regions.
     # ap-northeast-2:
-    #   Master: ami-07b7be0099924913e
-    #   Agent: ami-068b19daf956a4ca5
+    #   Master: ami-04e6fcf8cfe3b09ea
+    #   Agent: ami-0a0061c1a3f27fe51
     # ap-southeast-1:
-    #   Master: ami-028a5cff2f5a0f6c3
-    #   Agent: ami-01b7af9433b415dac
+    #   Master: ami-0ba45f1ec3dff60f9
+    #   Agent: ami-0994ac61987afed77
     # ap-southeast-2:
-    #   Master: ami-041e1cc8f4c429789
-    #   Agent: ami-07fc663f38164369e
+    #   Master: ami-004d0fb87d10716c6
+    #   Agent: ami-0183cafc9f2a57aa6
     eu-central-1:
-      Master: ami-0d971d62e4d019dcc
-      Agent: ami-00c716e5005603cb0
+      Master: ami-08a1a61694dd1c82f
+      Agent: ami-0c39ce440c27b5b97
     eu-west-1:
-      Master: ami-09b9e380df60300c8
-      Agent: ami-0da48b82961b59fba
+      Master: ami-0d67111dcacb4a14a
+      Agent: ami-085e4c3de4782b626
     # eu-west-2:
-    #   Master: ami-071884cefc7e770ba
-    #   Agent: ami-0d49b45685428fda1
+    #   Master: ami-03441ec6f2faa7ddc
+    #   Agent: ami-080b10920a3f55fd4
     us-east-1:
-      Master: ami-0739f8cdb239fe9ae
-      Agent: ami-0fa3c95101db75a3c
+      Master: ami-099e921e69356cf89
+      Agent: ami-06130d042431bcc18
     us-east-2:
-      Master: ami-0ebc8f6f580a04647
-      Agent: ami-0d7b699aa2315ee2d
+      Master: ami-05edbb8e25e281608
+      Agent: ami-044bdeb2ce74f4549
     us-west-2:
-      Master: ami-008b09448b998a562
-      Agent: ami-0888d917ee7cc9be9
+      Master: ami-00f1e37d20049f858
+      Agent: ami-07b649652a40e4208
 
 Parameters:
   VpcCIDR:

--- a/deploy/determined_deploy/aws/templates/fsx.yaml
+++ b/deploy/determined_deploy/aws/templates/fsx.yaml
@@ -3,35 +3,35 @@ Mappings:
   RegionMap:
     ap-northeast-1:
       Master: ami-0af17d43b1f4ff4ea
-      Agent: ami-07dc1e0617119df61
+      Agent: ami-0a01b67743d465a6e
     # TODO(DET-4258) Uncomment these when we fully support all P3 regions.
     # ap-northeast-2:
     #   Master: ami-04e6fcf8cfe3b09ea
-    #   Agent: ami-0a0061c1a3f27fe51
+    #   Agent: ami-0c74312df78509701
     # ap-southeast-1:
     #   Master: ami-0ba45f1ec3dff60f9
-    #   Agent: ami-0994ac61987afed77
+    #   Agent: ami-0eddf3f941d216f11
     # ap-southeast-2:
     #   Master: ami-004d0fb87d10716c6
-    #   Agent: ami-0183cafc9f2a57aa6
+    #   Agent: ami-0c54777eb400a9e68
     eu-central-1:
       Master: ami-08a1a61694dd1c82f
-      Agent: ami-0c39ce440c27b5b97
+      Agent: ami-0474e45bb1a45bbfe
     eu-west-1:
       Master: ami-0d67111dcacb4a14a
-      Agent: ami-085e4c3de4782b626
+      Agent: ami-0036879b70fee3339
     # eu-west-2:
     #   Master: ami-03441ec6f2faa7ddc
-    #   Agent: ami-080b10920a3f55fd4
+    #   Agent: ami-05d9b28afa79dbda3
     us-east-1:
       Master: ami-099e921e69356cf89
-      Agent: ami-06130d042431bcc18
+      Agent: ami-0080b638f1339ccd5
     us-east-2:
       Master: ami-05edbb8e25e281608
-      Agent: ami-044bdeb2ce74f4549
+      Agent: ami-07318f0e0b3a02b8e
     us-west-2:
       Master: ami-00f1e37d20049f858
-      Agent: ami-07b649652a40e4208
+      Agent: ami-0211fc4b3b0eb5c64
 
 Parameters:
   VpcCIDR:

--- a/deploy/determined_deploy/aws/templates/secure.yaml
+++ b/deploy/determined_deploy/aws/templates/secure.yaml
@@ -3,46 +3,46 @@ Description:  This template deploys a VPC, with a public and private subnet. It 
 Mappings:
   RegionMap:
     ap-northeast-1:
-      Master: ami-0b8cd500f483d09ee
-      Agent: ami-01094af1846f7e057
-      Bastion: ami-0f475b2993ac825b7
+      Master: ami-0af17d43b1f4ff4ea
+      Agent: ami-07dc1e0617119df61
+      Bastion: ami-05855b7c54f91a1ae
     # TODO(DET-4258) Uncomment these when we fully support all P3 regions.
     # ap-northeast-2:
-    #   Master: ami-07b7be0099924913e
-    #   Agent: ami-068b19daf956a4ca5
-    #   Bastion: ami-0eebe903cd90a3ddd
+    #   Master: ami-04e6fcf8cfe3b09ea
+    #   Agent: ami-0a0061c1a3f27fe51
+    #   Bastion: ami-063acefae626a1e95
     # ap-southeast-1:
-    #   Master: ami-028a5cff2f5a0f6c3
-    #   Agent: ami-01b7af9433b415dac
-    #   Bastion: ami-03060465516794b47
+    #   Master: ami-0ba45f1ec3dff60f9
+    #   Agent: ami-0994ac61987afed77
+    #   Bastion: ami-0311dbbdd981577d5
     # ap-southeast-2:
-    #   Master: ami-041e1cc8f4c429789
-    #   Agent: ami-07fc663f38164369e
-    #   Bastion: ami-001dbdb48850e6f54
+    #   Master: ami-004d0fb87d10716c6
+    #   Agent: ami-0183cafc9f2a57aa6
+    #   Bastion: ami-0dea9aeaa95b9751b
     eu-central-1:
-      Master: ami-0d971d62e4d019dcc
-      Agent: ami-00c716e5005603cb0
-      Bastion: ami-01d4d9d5d6b52b25e
+      Master: ami-08a1a61694dd1c82f
+      Agent: ami-0c39ce440c27b5b97
+      Bastion: ami-08a099fcfc36dff3f
     eu-west-1:
-      Master: ami-09b9e380df60300c8
-      Agent: ami-0da48b82961b59fba
-      Bastion: ami-0b85dae948397feb4
+      Master: ami-0d67111dcacb4a14a
+      Agent: ami-085e4c3de4782b626
+      Bastion: ami-00c25f7948e360133
     # eu-west-2:
-    #   Master: ami-071884cefc7e770ba
-    #   Agent: ami-0d49b45685428fda1
-    #   Bastion: ami-05e1a611b1e866695
+    #   Master: ami-03441ec6f2faa7ddc
+    #   Agent: ami-080b10920a3f55fd4
+    #   Bastion: ami-076071bbe3485317c
     us-east-1:
-      Master: ami-0739f8cdb239fe9ae
-      Agent: ami-0fa3c95101db75a3c
-      Bastion: ami-08b277333b9511393
+      Master: ami-099e921e69356cf89
+      Agent: ami-06130d042431bcc18
+      Bastion: ami-053adf54573f777cf
     us-east-2:
-      Master: ami-0ebc8f6f580a04647
-      Agent: ami-0d7b699aa2315ee2d
-      Bastion: ami-0b9e40918b9df07e4
+      Master: ami-05edbb8e25e281608
+      Agent: ami-044bdeb2ce74f4549
+      Bastion: ami-0b9487791bf873774
     us-west-2:
-      Master: ami-008b09448b998a562
-      Agent: ami-0888d917ee7cc9be9
-      Bastion: ami-08f6a7b1c02ad4ece
+      Master: ami-00f1e37d20049f858
+      Agent: ami-07b649652a40e4208
+      Bastion: ami-0cc158853935719b7
 
 Parameters:
   VpcCIDR:

--- a/deploy/determined_deploy/aws/templates/secure.yaml
+++ b/deploy/determined_deploy/aws/templates/secure.yaml
@@ -4,44 +4,44 @@ Mappings:
   RegionMap:
     ap-northeast-1:
       Master: ami-0af17d43b1f4ff4ea
-      Agent: ami-07dc1e0617119df61
+      Agent: ami-0a01b67743d465a6e
       Bastion: ami-05855b7c54f91a1ae
     # TODO(DET-4258) Uncomment these when we fully support all P3 regions.
     # ap-northeast-2:
     #   Master: ami-04e6fcf8cfe3b09ea
-    #   Agent: ami-0a0061c1a3f27fe51
+    #   Agent: ami-0c74312df78509701
     #   Bastion: ami-063acefae626a1e95
     # ap-southeast-1:
     #   Master: ami-0ba45f1ec3dff60f9
-    #   Agent: ami-0994ac61987afed77
+    #   Agent: ami-0eddf3f941d216f11
     #   Bastion: ami-0311dbbdd981577d5
     # ap-southeast-2:
     #   Master: ami-004d0fb87d10716c6
-    #   Agent: ami-0183cafc9f2a57aa6
+    #   Agent: ami-0c54777eb400a9e68
     #   Bastion: ami-0dea9aeaa95b9751b
     eu-central-1:
       Master: ami-08a1a61694dd1c82f
-      Agent: ami-0c39ce440c27b5b97
+      Agent: ami-0474e45bb1a45bbfe
       Bastion: ami-08a099fcfc36dff3f
     eu-west-1:
       Master: ami-0d67111dcacb4a14a
-      Agent: ami-085e4c3de4782b626
+      Agent: ami-0036879b70fee3339
       Bastion: ami-00c25f7948e360133
     # eu-west-2:
     #   Master: ami-03441ec6f2faa7ddc
-    #   Agent: ami-080b10920a3f55fd4
+    #   Agent: ami-05d9b28afa79dbda3
     #   Bastion: ami-076071bbe3485317c
     us-east-1:
       Master: ami-099e921e69356cf89
-      Agent: ami-06130d042431bcc18
+      Agent: ami-0080b638f1339ccd5
       Bastion: ami-053adf54573f777cf
     us-east-2:
       Master: ami-05edbb8e25e281608
-      Agent: ami-044bdeb2ce74f4549
+      Agent: ami-07318f0e0b3a02b8e
       Bastion: ami-0b9487791bf873774
     us-west-2:
       Master: ami-00f1e37d20049f858
-      Agent: ami-07b649652a40e4208
+      Agent: ami-0211fc4b3b0eb5c64
       Bastion: ami-0cc158853935719b7
 
 Parameters:

--- a/deploy/determined_deploy/aws/templates/simple.yaml
+++ b/deploy/determined_deploy/aws/templates/simple.yaml
@@ -4,36 +4,36 @@ Description: Determined Template
 Mappings:
   RegionMap:
     ap-northeast-1:
-      Master: ami-0b8cd500f483d09ee
-      Agent: ami-01094af1846f7e057
+      Master: ami-0af17d43b1f4ff4ea
+      Agent: ami-07dc1e0617119df61
     # TODO(DET-4258) Uncomment these when we fully support all P3 regions.
     # ap-northeast-2:
-    #   Master: ami-07b7be0099924913e
-    #   Agent: ami-068b19daf956a4ca5
+    #   Master: ami-04e6fcf8cfe3b09ea
+    #   Agent: ami-0a0061c1a3f27fe51
     # ap-southeast-1:
-    #   Master: ami-028a5cff2f5a0f6c3
-    #   Agent: ami-01b7af9433b415dac
+    #   Master: ami-0ba45f1ec3dff60f9
+    #   Agent: ami-0994ac61987afed77
     # ap-southeast-2:
-    #   Master: ami-041e1cc8f4c429789
-    #   Agent: ami-07fc663f38164369e
+    #   Master: ami-004d0fb87d10716c6
+    #   Agent: ami-0183cafc9f2a57aa6
     eu-central-1:
-      Master: ami-0d971d62e4d019dcc
-      Agent: ami-00c716e5005603cb0
+      Master: ami-08a1a61694dd1c82f
+      Agent: ami-0c39ce440c27b5b97
     eu-west-1:
-      Master: ami-09b9e380df60300c8
-      Agent: ami-0da48b82961b59fba
+      Master: ami-0d67111dcacb4a14a
+      Agent: ami-085e4c3de4782b626
     # eu-west-2:
-    #   Master: ami-071884cefc7e770ba
-    #   Agent: ami-0d49b45685428fda1
+    #   Master: ami-03441ec6f2faa7ddc
+    #   Agent: ami-080b10920a3f55fd4
     us-east-1:
-      Master: ami-0739f8cdb239fe9ae
-      Agent: ami-0fa3c95101db75a3c
+      Master: ami-099e921e69356cf89
+      Agent: ami-06130d042431bcc18
     us-east-2:
-      Master: ami-0ebc8f6f580a04647
-      Agent: ami-0d7b699aa2315ee2d
+      Master: ami-05edbb8e25e281608
+      Agent: ami-044bdeb2ce74f4549
     us-west-2:
-      Master: ami-008b09448b998a562
-      Agent: ami-0888d917ee7cc9be9
+      Master: ami-00f1e37d20049f858
+      Agent: ami-07b649652a40e4208
 
 Parameters:
   Keypair:

--- a/deploy/determined_deploy/aws/templates/simple.yaml
+++ b/deploy/determined_deploy/aws/templates/simple.yaml
@@ -5,35 +5,35 @@ Mappings:
   RegionMap:
     ap-northeast-1:
       Master: ami-0af17d43b1f4ff4ea
-      Agent: ami-07dc1e0617119df61
+      Agent: ami-0a01b67743d465a6e
     # TODO(DET-4258) Uncomment these when we fully support all P3 regions.
     # ap-northeast-2:
     #   Master: ami-04e6fcf8cfe3b09ea
-    #   Agent: ami-0a0061c1a3f27fe51
+    #   Agent: ami-0c74312df78509701
     # ap-southeast-1:
     #   Master: ami-0ba45f1ec3dff60f9
-    #   Agent: ami-0994ac61987afed77
+    #   Agent: ami-0eddf3f941d216f11
     # ap-southeast-2:
     #   Master: ami-004d0fb87d10716c6
-    #   Agent: ami-0183cafc9f2a57aa6
+    #   Agent: ami-0c54777eb400a9e68
     eu-central-1:
       Master: ami-08a1a61694dd1c82f
-      Agent: ami-0c39ce440c27b5b97
+      Agent: ami-0474e45bb1a45bbfe
     eu-west-1:
       Master: ami-0d67111dcacb4a14a
-      Agent: ami-085e4c3de4782b626
+      Agent: ami-0036879b70fee3339
     # eu-west-2:
     #   Master: ami-03441ec6f2faa7ddc
-    #   Agent: ami-080b10920a3f55fd4
+    #   Agent: ami-05d9b28afa79dbda3
     us-east-1:
       Master: ami-099e921e69356cf89
-      Agent: ami-06130d042431bcc18
+      Agent: ami-0080b638f1339ccd5
     us-east-2:
       Master: ami-05edbb8e25e281608
-      Agent: ami-044bdeb2ce74f4549
+      Agent: ami-07318f0e0b3a02b8e
     us-west-2:
       Master: ami-00f1e37d20049f858
-      Agent: ami-07b649652a40e4208
+      Agent: ami-0211fc4b3b0eb5c64
 
 Parameters:
   Keypair:

--- a/deploy/determined_deploy/aws/templates/vpc.yaml
+++ b/deploy/determined_deploy/aws/templates/vpc.yaml
@@ -3,36 +3,36 @@ Description:  This template deploys a VPC, with a public and private subnet. It 
 Mappings:
   RegionMap:
     ap-northeast-1:
-      Master: ami-0b8cd500f483d09ee
-      Agent: ami-01094af1846f7e057
+      Master: ami-0af17d43b1f4ff4ea
+      Agent: ami-07dc1e0617119df61
     # TODO(DET-4258) Uncomment these when we fully support all P3 regions.
     # ap-northeast-2:
-    #   Master: ami-07b7be0099924913e
-    #   Agent: ami-068b19daf956a4ca5
+    #   Master: ami-04e6fcf8cfe3b09ea
+    #   Agent: ami-0a0061c1a3f27fe51
     # ap-southeast-1:
-    #   Master: ami-028a5cff2f5a0f6c3
-    #   Agent: ami-01b7af9433b415dac
+    #   Master: ami-0ba45f1ec3dff60f9
+    #   Agent: ami-0994ac61987afed77
     # ap-southeast-2:
-    #   Master: ami-041e1cc8f4c429789
-    #   Agent: ami-07fc663f38164369e
+    #   Master: ami-004d0fb87d10716c6
+    #   Agent: ami-0183cafc9f2a57aa6
     eu-central-1:
-      Master: ami-0d971d62e4d019dcc
-      Agent: ami-00c716e5005603cb0
+      Master: ami-08a1a61694dd1c82f
+      Agent: ami-0c39ce440c27b5b97
     eu-west-1:
-      Master: ami-09b9e380df60300c8
-      Agent: ami-0da48b82961b59fba
+      Master: ami-0d67111dcacb4a14a
+      Agent: ami-085e4c3de4782b626
     # eu-west-2:
-    #   Master: ami-071884cefc7e770ba
-    #   Agent: ami-0d49b45685428fda1
+    #   Master: ami-03441ec6f2faa7ddc
+    #   Agent: ami-080b10920a3f55fd4
     us-east-1:
-      Master: ami-0739f8cdb239fe9ae
-      Agent: ami-0fa3c95101db75a3c
+      Master: ami-099e921e69356cf89
+      Agent: ami-06130d042431bcc18
     us-east-2:
-      Master: ami-0ebc8f6f580a04647
-      Agent: ami-0d7b699aa2315ee2d
+      Master: ami-05edbb8e25e281608
+      Agent: ami-044bdeb2ce74f4549
     us-west-2:
-      Master: ami-008b09448b998a562
-      Agent: ami-0888d917ee7cc9be9
+      Master: ami-00f1e37d20049f858
+      Agent: ami-07b649652a40e4208
 
 Parameters:
   VpcCIDR:

--- a/deploy/determined_deploy/aws/templates/vpc.yaml
+++ b/deploy/determined_deploy/aws/templates/vpc.yaml
@@ -4,35 +4,35 @@ Mappings:
   RegionMap:
     ap-northeast-1:
       Master: ami-0af17d43b1f4ff4ea
-      Agent: ami-07dc1e0617119df61
+      Agent: ami-0a01b67743d465a6e
     # TODO(DET-4258) Uncomment these when we fully support all P3 regions.
     # ap-northeast-2:
     #   Master: ami-04e6fcf8cfe3b09ea
-    #   Agent: ami-0a0061c1a3f27fe51
+    #   Agent: ami-0c74312df78509701
     # ap-southeast-1:
     #   Master: ami-0ba45f1ec3dff60f9
-    #   Agent: ami-0994ac61987afed77
+    #   Agent: ami-0eddf3f941d216f11
     # ap-southeast-2:
     #   Master: ami-004d0fb87d10716c6
-    #   Agent: ami-0183cafc9f2a57aa6
+    #   Agent: ami-0c54777eb400a9e68
     eu-central-1:
       Master: ami-08a1a61694dd1c82f
-      Agent: ami-0c39ce440c27b5b97
+      Agent: ami-0474e45bb1a45bbfe
     eu-west-1:
       Master: ami-0d67111dcacb4a14a
-      Agent: ami-085e4c3de4782b626
+      Agent: ami-0036879b70fee3339
     # eu-west-2:
     #   Master: ami-03441ec6f2faa7ddc
-    #   Agent: ami-080b10920a3f55fd4
+    #   Agent: ami-05d9b28afa79dbda3
     us-east-1:
       Master: ami-099e921e69356cf89
-      Agent: ami-06130d042431bcc18
+      Agent: ami-0080b638f1339ccd5
     us-east-2:
       Master: ami-05edbb8e25e281608
-      Agent: ami-044bdeb2ce74f4549
+      Agent: ami-07318f0e0b3a02b8e
     us-west-2:
       Master: ami-00f1e37d20049f858
-      Agent: ami-07b649652a40e4208
+      Agent: ami-0211fc4b3b0eb5c64
 
 Parameters:
   VpcCIDR:

--- a/deploy/determined_deploy/gcp/constants.py
+++ b/deploy/determined_deploy/gcp/constants.py
@@ -2,7 +2,7 @@ class defaults:
 
     AGENT_INSTANCE_TYPE = "n1-standard-32"
     DB_PASSWORD = "postgres"
-    ENVIRONMENT_IMAGE = "det-environments-600cf86"
+    ENVIRONMENT_IMAGE = "det-environments-067db2b"
     GPU_NUM = 8
     GPU_TYPE = "nvidia-tesla-k80"
     MASTER_INSTANCE_TYPE = "n1-standard-2"

--- a/deploy/determined_deploy/gcp/constants.py
+++ b/deploy/determined_deploy/gcp/constants.py
@@ -2,7 +2,7 @@ class defaults:
 
     AGENT_INSTANCE_TYPE = "n1-standard-32"
     DB_PASSWORD = "postgres"
-    ENVIRONMENT_IMAGE = "det-environments-0f2001a"
+    ENVIRONMENT_IMAGE = "det-environments-600cf86"
     GPU_NUM = 8
     GPU_TYPE = "nvidia-tesla-k80"
     MASTER_INSTANCE_TYPE = "n1-standard-2"

--- a/e2e_tests/tests/config.py
+++ b/e2e_tests/tests/config.py
@@ -12,10 +12,10 @@ MAX_TASK_SCHEDULED_SECS = 30
 MAX_TRIAL_BUILD_SECS = 90
 
 
-TF1_CPU_IMAGE = "determinedai/environments:py-3.6.9-pytorch-1.4-tf-1.15-cpu-600cf86"
-TF2_CPU_IMAGE = "determinedai/environments:py-3.6.9-pytorch-1.4-tf-2.2-cpu-600cf86"
-TF1_GPU_IMAGE = "determinedai/environments:cuda-10.0-pytorch-1.4-tf-1.15-gpu-600cf86"
-TF2_GPU_IMAGE = "determinedai/environments:cuda-10.1-pytorch-1.4-tf-2.2-gpu-600cf86"
+TF1_CPU_IMAGE = "determinedai/environments:py-3.6.9-pytorch-1.4-tf-1.15-cpu-067db2b"
+TF2_CPU_IMAGE = "determinedai/environments:py-3.6.9-pytorch-1.4-tf-2.2-cpu-067db2b"
+TF1_GPU_IMAGE = "determinedai/environments:cuda-10.0-pytorch-1.4-tf-1.15-gpu-067db2b"
+TF2_GPU_IMAGE = "determinedai/environments:cuda-10.1-pytorch-1.4-tf-2.2-gpu-067db2b"
 
 
 def fixtures_path(path: str) -> str:

--- a/e2e_tests/tests/config.py
+++ b/e2e_tests/tests/config.py
@@ -12,10 +12,10 @@ MAX_TASK_SCHEDULED_SECS = 30
 MAX_TRIAL_BUILD_SECS = 90
 
 
-TF1_CPU_IMAGE = "determinedai/environments:py-3.6.9-pytorch-1.4-tf-1.15-cpu-0f2001a"
-TF2_CPU_IMAGE = "determinedai/environments:py-3.6.9-pytorch-1.4-tf-2.2-cpu-0f2001a"
-TF1_GPU_IMAGE = "determinedai/environments:cuda-10.0-pytorch-1.4-tf-1.15-gpu-0f2001a"
-TF2_GPU_IMAGE = "determinedai/environments:cuda-10.1-pytorch-1.4-tf-2.2-gpu-0f2001a"
+TF1_CPU_IMAGE = "determinedai/environments:py-3.6.9-pytorch-1.4-tf-1.15-cpu-600cf86"
+TF2_CPU_IMAGE = "determinedai/environments:py-3.6.9-pytorch-1.4-tf-2.2-cpu-600cf86"
+TF1_GPU_IMAGE = "determinedai/environments:cuda-10.0-pytorch-1.4-tf-1.15-gpu-600cf86"
+TF2_GPU_IMAGE = "determinedai/environments:cuda-10.1-pytorch-1.4-tf-2.2-gpu-600cf86"
 
 
 def fixtures_path(path: str) -> str:

--- a/e2e_tests/tests/fixtures/tf_keras_grad_aggregation/grad_aggregation_test.py
+++ b/e2e_tests/tests/fixtures/tf_keras_grad_aggregation/grad_aggregation_test.py
@@ -38,7 +38,7 @@ def check_tf_1(aggregation_frequency: int, average_aggregated_gradients: bool) -
 
     hvd_optimizer = hvd.DistributedOptimizer(
         optimizer=CustomOptimizer("mine"),
-        aggregation_frequency=aggregation_frequency,
+        backward_passes_per_step=aggregation_frequency,
         average_aggregated_gradients=average_aggregated_gradients,
     )
     iterations = hvd_optimizer.iterations
@@ -72,7 +72,7 @@ def check_tf_2(aggregation_frequency: int, average_aggregated_gradients: bool) -
 
     hvd_optimizer = hvd.DistributedOptimizer(
         optimizer=CustomOptimizer("mine"),
-        aggregation_frequency=aggregation_frequency,
+        backward_passes_per_step=aggregation_frequency,
         average_aggregated_gradients=average_aggregated_gradients,
     )
     _ = hvd_optimizer.iterations

--- a/examples/gan/dcgan_tf_keras/const.yaml
+++ b/examples/gan/dcgan_tf_keras/const.yaml
@@ -15,5 +15,5 @@ entrypoint: model_def:DCGanTrial
 environment:
   # This model only works with Tensorflow 2.2+.
   image:
-     cpu: "determinedai/environments:py-3.6.9-pytorch-1.4-tf-2.2-cpu-600cf86"
-     gpu: "determinedai/environments:cuda-10.1-pytorch-1.4-tf-2.2-gpu-600cf86"
+     cpu: "determinedai/environments:py-3.6.9-pytorch-1.4-tf-2.2-cpu-067db2b"
+     gpu: "determinedai/environments:cuda-10.1-pytorch-1.4-tf-2.2-gpu-067db2b"

--- a/examples/gan/dcgan_tf_keras/const.yaml
+++ b/examples/gan/dcgan_tf_keras/const.yaml
@@ -15,5 +15,5 @@ entrypoint: model_def:DCGanTrial
 environment:
   # This model only works with Tensorflow 2.2+.
   image:
-     cpu: "determinedai/environments:py-3.6.9-pytorch-1.4-tf-2.2-cpu-0f2001a"
-     gpu: "determinedai/environments:cuda-10.1-pytorch-1.4-tf-2.2-gpu-0f2001a"
+     cpu: "determinedai/environments:py-3.6.9-pytorch-1.4-tf-2.2-cpu-600cf86"
+     gpu: "determinedai/environments:cuda-10.1-pytorch-1.4-tf-2.2-gpu-600cf86"

--- a/examples/gan/dcgan_tf_keras/distributed.yaml
+++ b/examples/gan/dcgan_tf_keras/distributed.yaml
@@ -17,5 +17,5 @@ resources:
 environment:
   # This model only works with Tensorflow 2.2+.
   image:
-     cpu: "determinedai/environments:py-3.6.9-pytorch-1.4-tf-2.2-cpu-0f2001a"
-     gpu: "determinedai/environments:cuda-10.1-pytorch-1.4-tf-2.2-gpu-0f2001a"
+     cpu: "determinedai/environments:py-3.6.9-pytorch-1.4-tf-2.2-cpu-600cf86"
+     gpu: "determinedai/environments:cuda-10.1-pytorch-1.4-tf-2.2-gpu-600cf86"

--- a/examples/gan/dcgan_tf_keras/distributed.yaml
+++ b/examples/gan/dcgan_tf_keras/distributed.yaml
@@ -17,5 +17,5 @@ resources:
 environment:
   # This model only works with Tensorflow 2.2+.
   image:
-     cpu: "determinedai/environments:py-3.6.9-pytorch-1.4-tf-2.2-cpu-600cf86"
-     gpu: "determinedai/environments:cuda-10.1-pytorch-1.4-tf-2.2-gpu-600cf86"
+     cpu: "determinedai/environments:py-3.6.9-pytorch-1.4-tf-2.2-cpu-067db2b"
+     gpu: "determinedai/environments:cuda-10.1-pytorch-1.4-tf-2.2-gpu-067db2b"

--- a/harness/determined/estimator/_estimator_context.py
+++ b/harness/determined/estimator/_estimator_context.py
@@ -68,14 +68,14 @@ class EstimatorContext:
         use_compression = self.hvd_config.fp16_compression
 
         # The signature of our horovod optimizer changed after we rebased onto 0.21.
-        hvd_args = inspect.signature(hvd.DistributedOptimizer)
+        hvd_sig = inspect.signature(hvd.DistributedOptimizer)
         horovod_kwargs = {
             "compression": hvd.compression.Compression.fp16
             if use_compression
             else hvd.compression.Compression.none,
             "average_aggregated_gradients": self.hvd_config.average_aggregated_gradients,
         }
-        if "aggregation_frequency" in hvd_args.parameters:
+        if "aggregation_frequency" in hvd_sig.parameters:
             horovod_kwargs["aggregation_frequency"] = self.hvd_config.aggregation_frequency
         else:
             horovod_kwargs["backward_passes_per_step"] = self.hvd_config.aggregation_frequency

--- a/harness/determined/keras/_tf_keras_context.py
+++ b/harness/determined/keras/_tf_keras_context.py
@@ -281,11 +281,11 @@ class TFKerasContext:
             raise det.errors.InvalidExperimentException("string optimizers are not supported")
 
         # The signature of our horovod optimizer changed after we rebased onto 0.21.
-        hvd_args = inspect.signature(hvd.DistributedOptimizer)
+        hvd_sig = inspect.signature(hvd.DistributedOptimizer)
         horovod_kwargs = {
             "average_aggregated_gradients": self.hvd_config.average_aggregated_gradients,
         }  # type: Dict[str, Any]
-        if "aggregation_frequency" in hvd_args.parameters:
+        if "aggregation_frequency" in hvd_sig.parameters:
             horovod_kwargs["aggregation_frequency"] = self.hvd_config.aggregation_frequency
         else:
             horovod_kwargs["backward_passes_per_step"] = self.hvd_config.aggregation_frequency

--- a/harness/determined/keras/_tf_keras_trial.py
+++ b/harness/determined/keras/_tf_keras_trial.py
@@ -821,6 +821,8 @@ class TFKerasTrialController(det.LoopTrialController):
         else:
             horovod_kwargs["average"] = average
 
+        return hvd.allreduce(**horovod_kwargs)
+
     def _convert_possible_tensor(self, possible_tensor: Any) -> Any:
         if isinstance(possible_tensor, EagerTensor):
             # Horovod and / or TensorFlow may promote scalars to tensors in eager mode.

--- a/harness/determined/keras/_tf_keras_trial.py
+++ b/harness/determined/keras/_tf_keras_trial.py
@@ -818,6 +818,12 @@ class TFKerasTrialController(det.LoopTrialController):
 
         if "op" in hvd_sig.parameters:
             horovod_kwargs["op"] = hvd.Average if average else hvd.Sum
+
+            # average has not yet been removed but it's deprecated. It defaults
+            # to true and horovod does not support specifying an op while having
+            # average be not None.
+            if "average" in hvd_sig.parameters:
+                horovod_kwargs["average"] = None
         else:
             horovod_kwargs["average"] = average
 

--- a/harness/determined/keras/_tf_keras_trial.py
+++ b/harness/determined/keras/_tf_keras_trial.py
@@ -804,7 +804,22 @@ class TFKerasTrialController(det.LoopTrialController):
         # Reduce logs in key-sorted to be deterministic across workers.
         keys = sorted(logs)
         logging.debug(f"all-reducing logs on worker {hvd.rank()} for {len(keys)} keys {keys}.")
-        return {key: np.array(hvd.allreduce(logs[key], name=key)) for key in keys}
+        return {
+            key: np.array(self._hvd_allreduce(logs[key], average=True, name=key)) for key in keys
+        }
+
+    def _hvd_allreduce(self, value: Any, average: bool, name: str) -> Any:
+        # The signature of our horovod allreduce changed after we rebased onto 0.21.
+        hvd_sig = inspect.signature(hvd.allreduce)
+        horovod_kwargs = {
+            "value": value,
+            "name": name,
+        }  # type: Dict[str, Any]
+
+        if "op" in hvd_sig.parameters:
+            horovod_kwargs["op"] = hvd.Average if average else hvd.Sum
+        else:
+            horovod_kwargs["average"] = average
 
     def _convert_possible_tensor(self, possible_tensor: Any) -> Any:
         if isinstance(possible_tensor, EagerTensor):
@@ -833,7 +848,7 @@ class TFKerasTrialController(det.LoopTrialController):
             )
 
         if self.hvd_config.use:
-            num_inputs = hvd.allreduce(num_inputs, average=False, name="train_num_inputs")
+            num_inputs = self._hvd_allreduce(num_inputs, average=False, name="train_num_inputs")
             num_inputs = self._convert_possible_tensor(num_inputs)
 
         # Return only the latest metrics, which is the running average for all trained batches in

--- a/master/internal/provisioner/aws_config.go
+++ b/master/internal/provisioner/aws_config.go
@@ -41,16 +41,16 @@ type AWSClusterConfig struct {
 }
 
 var defaultAWSImageID = map[string]string{
-	"ap-northeast-1": "ami-01094af1846f7e057",
-	"ap-northeast-2": "ami-068b19daf956a4ca5",
-	"ap-southeast-1": "ami-01b7af9433b415dac",
-	"ap-southeast-2": "ami-07fc663f38164369e",
-	"us-east-2":      "ami-0d7b699aa2315ee2d",
-	"us-east-1":      "ami-0fa3c95101db75a3c",
-	"us-west-2":      "ami-0888d917ee7cc9be9",
-	"eu-central-1":   "ami-00c716e5005603cb0",
-	"eu-west-2":      "ami-0d49b45685428fda1",
-	"eu-west-1":      "ami-0da48b82961b59fba",
+	"ap-northeast-1": "ami-07dc1e0617119df61",
+	"ap-northeast-2": "ami-0a0061c1a3f27fe51",
+	"ap-southeast-1": "ami-0994ac61987afed77",
+	"ap-southeast-2": "ami-0183cafc9f2a57aa6",
+	"us-east-2":      "ami-044bdeb2ce74f4549",
+	"us-east-1":      "ami-06130d042431bcc18",
+	"us-west-2":      "ami-07b649652a40e4208",
+	"eu-central-1":   "ami-0c39ce440c27b5b97",
+	"eu-west-2":      "ami-080b10920a3f55fd4",
+	"eu-west-1":      "ami-085e4c3de4782b626",
 }
 
 var defaultAWSClusterConfig = AWSClusterConfig{

--- a/master/internal/provisioner/aws_config.go
+++ b/master/internal/provisioner/aws_config.go
@@ -41,16 +41,16 @@ type AWSClusterConfig struct {
 }
 
 var defaultAWSImageID = map[string]string{
-	"ap-northeast-1": "ami-07dc1e0617119df61",
-	"ap-northeast-2": "ami-0a0061c1a3f27fe51",
-	"ap-southeast-1": "ami-0994ac61987afed77",
-	"ap-southeast-2": "ami-0183cafc9f2a57aa6",
-	"us-east-2":      "ami-044bdeb2ce74f4549",
-	"us-east-1":      "ami-06130d042431bcc18",
-	"us-west-2":      "ami-07b649652a40e4208",
-	"eu-central-1":   "ami-0c39ce440c27b5b97",
-	"eu-west-2":      "ami-080b10920a3f55fd4",
-	"eu-west-1":      "ami-085e4c3de4782b626",
+	"ap-northeast-1": "ami-0a01b67743d465a6e",
+	"ap-northeast-2": "ami-0c74312df78509701",
+	"ap-southeast-1": "ami-0eddf3f941d216f11",
+	"ap-southeast-2": "ami-0c54777eb400a9e68",
+	"us-east-2":      "ami-07318f0e0b3a02b8e",
+	"us-east-1":      "ami-0080b638f1339ccd5",
+	"us-west-2":      "ami-0211fc4b3b0eb5c64",
+	"eu-central-1":   "ami-0474e45bb1a45bbfe",
+	"eu-west-2":      "ami-05d9b28afa79dbda3",
+	"eu-west-1":      "ami-0036879b70fee3339",
 }
 
 var defaultAWSClusterConfig = AWSClusterConfig{

--- a/master/internal/provisioner/gcp_config.go
+++ b/master/internal/provisioner/gcp_config.go
@@ -48,7 +48,7 @@ type GCPClusterConfig struct {
 func DefaultGCPClusterConfig() *GCPClusterConfig {
 	return &GCPClusterConfig{
 		BootDiskSize:        200,
-		BootDiskSourceImage: "projects/determined-ai/global/images/det-environments-0f2001a",
+		BootDiskSourceImage: "projects/determined-ai/global/images/det-environments-600cf86",
 		LabelKey:            "managed-by",
 		InstanceType: gceInstanceType{
 			MachineType: "n1-standard-32",

--- a/master/internal/provisioner/gcp_config.go
+++ b/master/internal/provisioner/gcp_config.go
@@ -48,7 +48,7 @@ type GCPClusterConfig struct {
 func DefaultGCPClusterConfig() *GCPClusterConfig {
 	return &GCPClusterConfig{
 		BootDiskSize:        200,
-		BootDiskSourceImage: "projects/determined-ai/global/images/det-environments-600cf86",
+		BootDiskSourceImage: "projects/determined-ai/global/images/det-environments-067db2b",
 		LabelKey:            "managed-by",
 		InstanceType: gceInstanceType{
 			MachineType: "n1-standard-32",

--- a/master/pkg/model/defaults.go
+++ b/master/pkg/model/defaults.go
@@ -25,8 +25,8 @@ const (
 
 // Default task environment docker image names.
 const (
-	defaultCPUImage = "determinedai/environments:py-3.6.9-pytorch-1.4-tf-1.15-cpu-0f2001a"
-	defaultGPUImage = "determinedai/environments:cuda-10.0-pytorch-1.4-tf-1.15-gpu-0f2001a"
+	defaultCPUImage = "determinedai/environments:py-3.6.9-pytorch-1.4-tf-1.15-cpu-600cf86"
+	defaultGPUImage = "determinedai/environments:cuda-10.0-pytorch-1.4-tf-1.15-gpu-600cf86"
 )
 
 // DefaultExperimentConfig returns a new default experiment config.

--- a/master/pkg/model/defaults.go
+++ b/master/pkg/model/defaults.go
@@ -25,8 +25,8 @@ const (
 
 // Default task environment docker image names.
 const (
-	defaultCPUImage = "determinedai/environments:py-3.6.9-pytorch-1.4-tf-1.15-cpu-600cf86"
-	defaultGPUImage = "determinedai/environments:cuda-10.0-pytorch-1.4-tf-1.15-gpu-600cf86"
+	defaultCPUImage = "determinedai/environments:py-3.6.9-pytorch-1.4-tf-1.15-cpu-067db2b"
+	defaultGPUImage = "determinedai/environments:cuda-10.0-pytorch-1.4-tf-1.15-gpu-067db2b"
 )
 
 // DefaultExperimentConfig returns a new default experiment config.

--- a/tools/scripts/bumpenvs.yaml
+++ b/tools/scripts/bumpenvs.yaml
@@ -1,117 +1,117 @@
 ap_northeast_1_agent_ami:
-  new: ami-01094af1846f7e057
-  old: ami-0cd426d06531436fa
+  new: ami-07dc1e0617119df61
+  old: ami-01094af1846f7e057
 ap_northeast_1_bastion_ami:
-  new: ami-0f475b2993ac825b7
-  old: ami-002f145bfc0915873
+  new: ami-05855b7c54f91a1ae
+  old: ami-0f475b2993ac825b7
 ap_northeast_1_master_ami:
-  new: ami-0b8cd500f483d09ee
-  old: ami-0349224eed420a3b5
+  new: ami-0af17d43b1f4ff4ea
+  old: ami-0b8cd500f483d09ee
 ap_northeast_2_agent_ami:
-  new: ami-068b19daf956a4ca5
-  old: ami-03221845e307ee9f7
+  new: ami-0a0061c1a3f27fe51
+  old: ami-068b19daf956a4ca5
 ap_northeast_2_bastion_ami:
-  new: ami-0eebe903cd90a3ddd
-  old: ami-0e95717ef0e92866b
+  new: ami-063acefae626a1e95
+  old: ami-0eebe903cd90a3ddd
 ap_northeast_2_master_ami:
-  new: ami-07b7be0099924913e
-  old: ami-0cd876b15dcf9249d
+  new: ami-04e6fcf8cfe3b09ea
+  old: ami-07b7be0099924913e
 ap_southeast_1_agent_ami:
-  new: ami-01b7af9433b415dac
-  old: ami-04333832c3c743b77
+  new: ami-0994ac61987afed77
+  old: ami-01b7af9433b415dac
 ap_southeast_1_bastion_ami:
-  new: ami-03060465516794b47
-  old: ami-0173e2856f6e1048d
+  new: ami-0311dbbdd981577d5
+  old: ami-03060465516794b47
 ap_southeast_1_master_ami:
-  new: ami-028a5cff2f5a0f6c3
-  old: ami-0e841276b0f027389
+  new: ami-0ba45f1ec3dff60f9
+  old: ami-028a5cff2f5a0f6c3
 ap_southeast_2_agent_ami:
-  new: ami-07fc663f38164369e
-  old: ami-0a94f9b79cafa721e
+  new: ami-0183cafc9f2a57aa6
+  old: ami-07fc663f38164369e
 ap_southeast_2_bastion_ami:
-  new: ami-001dbdb48850e6f54
-  old: ami-03646f515d078ec29
+  new: ami-0dea9aeaa95b9751b
+  old: ami-001dbdb48850e6f54
 ap_southeast_2_master_ami:
-  new: ami-041e1cc8f4c429789
-  old: ami-0257304d38f0c6e7d
+  new: ami-004d0fb87d10716c6
+  old: ami-041e1cc8f4c429789
 eu_central_1_agent_ami:
-  new: ami-00c716e5005603cb0
-  old: ami-0b494b9ed6078a5aa
+  new: ami-0c39ce440c27b5b97
+  old: ami-00c716e5005603cb0
 eu_central_1_bastion_ami:
-  new: ami-01d4d9d5d6b52b25e
-  old: ami-05ef33ae54898e90c
+  new: ami-08a099fcfc36dff3f
+  old: ami-01d4d9d5d6b52b25e
 eu_central_1_master_ami:
-  new: ami-0d971d62e4d019dcc
-  old: ami-0db63f4dee2d55b7a
+  new: ami-08a1a61694dd1c82f
+  old: ami-0d971d62e4d019dcc
 eu_west_1_agent_ami:
-  new: ami-0da48b82961b59fba
-  old: ami-09060c47e59d7e1b1
+  new: ami-085e4c3de4782b626
+  old: ami-0da48b82961b59fba
 eu_west_1_bastion_ami:
-  new: ami-0b85dae948397feb4
-  old: ami-06868ad5a3642e4d7
+  new: ami-00c25f7948e360133
+  old: ami-0b85dae948397feb4
 eu_west_1_master_ami:
-  new: ami-09b9e380df60300c8
-  old: ami-08f3064d8481f3782
+  new: ami-0d67111dcacb4a14a
+  old: ami-09b9e380df60300c8
 eu_west_2_agent_ami:
-  new: ami-0d49b45685428fda1
-  old: ami-022f3e0fca4b0cca6
+  new: ami-080b10920a3f55fd4
+  old: ami-0d49b45685428fda1
 eu_west_2_bastion_ami:
-  new: ami-05e1a611b1e866695
-  old: ami-0584b3a74f9c23f6a
+  new: ami-076071bbe3485317c
+  old: ami-05e1a611b1e866695
 eu_west_2_master_ami:
-  new: ami-071884cefc7e770ba
-  old: ami-0b48089553c9d7962
+  new: ami-03441ec6f2faa7ddc
+  old: ami-071884cefc7e770ba
 gcp_env:
-  new: det-environments-0f2001a
-  old: det-environments-0e2ce4d
+  new: det-environments-600cf86
+  old: det-environments-0f2001a
 tf1_cpu_hashed:
-  new: determinedai/environments:py-3.6.9-pytorch-1.4-tf-1.15-cpu-0f2001a
-  old: determinedai/environments:py-3.6.9-pytorch-1.4-tf-1.15-cpu-0e2ce4d
+  new: determinedai/environments:py-3.6.9-pytorch-1.4-tf-1.15-cpu-600cf86
+  old: determinedai/environments:py-3.6.9-pytorch-1.4-tf-1.15-cpu-0f2001a
 tf1_cpu_versioned:
   new: determinedai/environments:py-3.6.9-pytorch-1.4-tf-1.15-cpu-0.8.0
   old: determinedai/environments:py-3.6.9-pytorch-1.4-tf-1.15-cpu-0.7.0
 tf1_gpu_hashed:
-  new: determinedai/environments:cuda-10.0-pytorch-1.4-tf-1.15-gpu-0f2001a
-  old: determinedai/environments:cuda-10.0-pytorch-1.4-tf-1.15-gpu-0e2ce4d
+  new: determinedai/environments:cuda-10.0-pytorch-1.4-tf-1.15-gpu-600cf86
+  old: determinedai/environments:cuda-10.0-pytorch-1.4-tf-1.15-gpu-0f2001a
 tf1_gpu_versioned:
   new: determinedai/environments:cuda-10.0-pytorch-1.4-tf-1.15-gpu-0.8.0
   old: determinedai/environments:cuda-10.0-pytorch-1.4-tf-1.15-gpu-0.7.0
 tf2_cpu_hashed:
-  new: determinedai/environments:py-3.6.9-pytorch-1.4-tf-2.2-cpu-0f2001a
-  old: determinedai/environments:py-3.6.9-pytorch-1.4-tf-2.2-cpu-0e2ce4d
+  new: determinedai/environments:py-3.6.9-pytorch-1.4-tf-2.2-cpu-600cf86
+  old: determinedai/environments:py-3.6.9-pytorch-1.4-tf-2.2-cpu-0f2001a
 tf2_cpu_versioned:
   new: determinedai/environments:py-3.6.9-pytorch-1.4-tf-2.2-cpu-0.8.0
   old: determinedai/environments:py-3.6.9-pytorch-1.4-tf-2.2-cpu-0.7.0
 tf2_gpu_hashed:
-  new: determinedai/environments:cuda-10.1-pytorch-1.4-tf-2.2-gpu-0f2001a
-  old: determinedai/environments:cuda-10.1-pytorch-1.4-tf-2.2-gpu-0e2ce4d
+  new: determinedai/environments:cuda-10.1-pytorch-1.4-tf-2.2-gpu-600cf86
+  old: determinedai/environments:cuda-10.1-pytorch-1.4-tf-2.2-gpu-0f2001a
 tf2_gpu_versioned:
   new: determinedai/environments:cuda-10.1-pytorch-1.4-tf-2.2-gpu-0.8.0
   old: determinedai/environments:cuda-10.1-pytorch-1.4-tf-2.2-gpu-0.7.0
 us_east_1_agent_ami:
-  new: ami-0fa3c95101db75a3c
-  old: ami-0e2d708bd1dce3cfc
+  new: ami-06130d042431bcc18
+  old: ami-0fa3c95101db75a3c
 us_east_1_bastion_ami:
-  new: ami-08b277333b9511393
-  old: ami-013da1cc4ae87618c
+  new: ami-053adf54573f777cf
+  old: ami-08b277333b9511393
 us_east_1_master_ami:
-  new: ami-0739f8cdb239fe9ae
-  old: ami-0f40c8f97004632f9
+  new: ami-099e921e69356cf89
+  old: ami-0739f8cdb239fe9ae
 us_east_2_agent_ami:
-  new: ami-0d7b699aa2315ee2d
-  old: ami-0341766ad8eaf6c56
+  new: ami-044bdeb2ce74f4549
+  old: ami-0d7b699aa2315ee2d
 us_east_2_bastion_ami:
-  new: ami-0b9e40918b9df07e4
-  old: ami-0fa9de1596e76fb6c
+  new: ami-0b9487791bf873774
+  old: ami-0b9e40918b9df07e4
 us_east_2_master_ami:
-  new: ami-0ebc8f6f580a04647
-  old: ami-05692172625678b4e
+  new: ami-05edbb8e25e281608
+  old: ami-0ebc8f6f580a04647
 us_west_2_agent_ami:
-  new: ami-0888d917ee7cc9be9
-  old: ami-0ca9b5a188aa4be86
+  new: ami-07b649652a40e4208
+  old: ami-0888d917ee7cc9be9
 us_west_2_bastion_ami:
-  new: ami-08f6a7b1c02ad4ece
-  old: ami-0c1ab2d66f996cd4b
+  new: ami-0cc158853935719b7
+  old: ami-08f6a7b1c02ad4ece
 us_west_2_master_ami:
-  new: ami-008b09448b998a562
-  old: ami-09456e8683eb4d259
+  new: ami-00f1e37d20049f858
+  old: ami-008b09448b998a562

--- a/tools/scripts/bumpenvs.yaml
+++ b/tools/scripts/bumpenvs.yaml
@@ -1,6 +1,6 @@
 ap_northeast_1_agent_ami:
-  new: ami-07dc1e0617119df61
-  old: ami-01094af1846f7e057
+  new: ami-0a01b67743d465a6e
+  old: ami-07dc1e0617119df61
 ap_northeast_1_bastion_ami:
   new: ami-05855b7c54f91a1ae
   old: ami-0f475b2993ac825b7
@@ -8,8 +8,8 @@ ap_northeast_1_master_ami:
   new: ami-0af17d43b1f4ff4ea
   old: ami-0b8cd500f483d09ee
 ap_northeast_2_agent_ami:
-  new: ami-0a0061c1a3f27fe51
-  old: ami-068b19daf956a4ca5
+  new: ami-0c74312df78509701
+  old: ami-0a0061c1a3f27fe51
 ap_northeast_2_bastion_ami:
   new: ami-063acefae626a1e95
   old: ami-0eebe903cd90a3ddd
@@ -17,8 +17,8 @@ ap_northeast_2_master_ami:
   new: ami-04e6fcf8cfe3b09ea
   old: ami-07b7be0099924913e
 ap_southeast_1_agent_ami:
-  new: ami-0994ac61987afed77
-  old: ami-01b7af9433b415dac
+  new: ami-0eddf3f941d216f11
+  old: ami-0994ac61987afed77
 ap_southeast_1_bastion_ami:
   new: ami-0311dbbdd981577d5
   old: ami-03060465516794b47
@@ -26,8 +26,8 @@ ap_southeast_1_master_ami:
   new: ami-0ba45f1ec3dff60f9
   old: ami-028a5cff2f5a0f6c3
 ap_southeast_2_agent_ami:
-  new: ami-0183cafc9f2a57aa6
-  old: ami-07fc663f38164369e
+  new: ami-0c54777eb400a9e68
+  old: ami-0183cafc9f2a57aa6
 ap_southeast_2_bastion_ami:
   new: ami-0dea9aeaa95b9751b
   old: ami-001dbdb48850e6f54
@@ -35,8 +35,8 @@ ap_southeast_2_master_ami:
   new: ami-004d0fb87d10716c6
   old: ami-041e1cc8f4c429789
 eu_central_1_agent_ami:
-  new: ami-0c39ce440c27b5b97
-  old: ami-00c716e5005603cb0
+  new: ami-0474e45bb1a45bbfe
+  old: ami-0c39ce440c27b5b97
 eu_central_1_bastion_ami:
   new: ami-08a099fcfc36dff3f
   old: ami-01d4d9d5d6b52b25e
@@ -44,8 +44,8 @@ eu_central_1_master_ami:
   new: ami-08a1a61694dd1c82f
   old: ami-0d971d62e4d019dcc
 eu_west_1_agent_ami:
-  new: ami-085e4c3de4782b626
-  old: ami-0da48b82961b59fba
+  new: ami-0036879b70fee3339
+  old: ami-085e4c3de4782b626
 eu_west_1_bastion_ami:
   new: ami-00c25f7948e360133
   old: ami-0b85dae948397feb4
@@ -53,8 +53,8 @@ eu_west_1_master_ami:
   new: ami-0d67111dcacb4a14a
   old: ami-09b9e380df60300c8
 eu_west_2_agent_ami:
-  new: ami-080b10920a3f55fd4
-  old: ami-0d49b45685428fda1
+  new: ami-05d9b28afa79dbda3
+  old: ami-080b10920a3f55fd4
 eu_west_2_bastion_ami:
   new: ami-076071bbe3485317c
   old: ami-05e1a611b1e866695
@@ -62,35 +62,35 @@ eu_west_2_master_ami:
   new: ami-03441ec6f2faa7ddc
   old: ami-071884cefc7e770ba
 gcp_env:
-  new: det-environments-600cf86
-  old: det-environments-0f2001a
+  new: det-environments-067db2b
+  old: det-environments-600cf86
 tf1_cpu_hashed:
-  new: determinedai/environments:py-3.6.9-pytorch-1.4-tf-1.15-cpu-600cf86
-  old: determinedai/environments:py-3.6.9-pytorch-1.4-tf-1.15-cpu-0f2001a
+  new: determinedai/environments:py-3.6.9-pytorch-1.4-tf-1.15-cpu-067db2b
+  old: determinedai/environments:py-3.6.9-pytorch-1.4-tf-1.15-cpu-600cf86
 tf1_cpu_versioned:
   new: determinedai/environments:py-3.6.9-pytorch-1.4-tf-1.15-cpu-0.8.0
   old: determinedai/environments:py-3.6.9-pytorch-1.4-tf-1.15-cpu-0.7.0
 tf1_gpu_hashed:
-  new: determinedai/environments:cuda-10.0-pytorch-1.4-tf-1.15-gpu-600cf86
-  old: determinedai/environments:cuda-10.0-pytorch-1.4-tf-1.15-gpu-0f2001a
+  new: determinedai/environments:cuda-10.0-pytorch-1.4-tf-1.15-gpu-067db2b
+  old: determinedai/environments:cuda-10.0-pytorch-1.4-tf-1.15-gpu-600cf86
 tf1_gpu_versioned:
   new: determinedai/environments:cuda-10.0-pytorch-1.4-tf-1.15-gpu-0.8.0
   old: determinedai/environments:cuda-10.0-pytorch-1.4-tf-1.15-gpu-0.7.0
 tf2_cpu_hashed:
-  new: determinedai/environments:py-3.6.9-pytorch-1.4-tf-2.2-cpu-600cf86
-  old: determinedai/environments:py-3.6.9-pytorch-1.4-tf-2.2-cpu-0f2001a
+  new: determinedai/environments:py-3.6.9-pytorch-1.4-tf-2.2-cpu-067db2b
+  old: determinedai/environments:py-3.6.9-pytorch-1.4-tf-2.2-cpu-600cf86
 tf2_cpu_versioned:
   new: determinedai/environments:py-3.6.9-pytorch-1.4-tf-2.2-cpu-0.8.0
   old: determinedai/environments:py-3.6.9-pytorch-1.4-tf-2.2-cpu-0.7.0
 tf2_gpu_hashed:
-  new: determinedai/environments:cuda-10.1-pytorch-1.4-tf-2.2-gpu-600cf86
-  old: determinedai/environments:cuda-10.1-pytorch-1.4-tf-2.2-gpu-0f2001a
+  new: determinedai/environments:cuda-10.1-pytorch-1.4-tf-2.2-gpu-067db2b
+  old: determinedai/environments:cuda-10.1-pytorch-1.4-tf-2.2-gpu-600cf86
 tf2_gpu_versioned:
   new: determinedai/environments:cuda-10.1-pytorch-1.4-tf-2.2-gpu-0.8.0
   old: determinedai/environments:cuda-10.1-pytorch-1.4-tf-2.2-gpu-0.7.0
 us_east_1_agent_ami:
-  new: ami-06130d042431bcc18
-  old: ami-0fa3c95101db75a3c
+  new: ami-0080b638f1339ccd5
+  old: ami-06130d042431bcc18
 us_east_1_bastion_ami:
   new: ami-053adf54573f777cf
   old: ami-08b277333b9511393
@@ -98,8 +98,8 @@ us_east_1_master_ami:
   new: ami-099e921e69356cf89
   old: ami-0739f8cdb239fe9ae
 us_east_2_agent_ami:
-  new: ami-044bdeb2ce74f4549
-  old: ami-0d7b699aa2315ee2d
+  new: ami-07318f0e0b3a02b8e
+  old: ami-044bdeb2ce74f4549
 us_east_2_bastion_ami:
   new: ami-0b9487791bf873774
   old: ami-0b9e40918b9df07e4
@@ -107,8 +107,8 @@ us_east_2_master_ami:
   new: ami-05edbb8e25e281608
   old: ami-0ebc8f6f580a04647
 us_west_2_agent_ami:
-  new: ami-07b649652a40e4208
-  old: ami-0888d917ee7cc9be9
+  new: ami-0211fc4b3b0eb5c64
+  old: ami-07b649652a40e4208
 us_west_2_bastion_ami:
   new: ami-0cc158853935719b7
   old: ami-08f6a7b1c02ad4ece

--- a/webui/react/src/fixtures/responses/experiment-details/non-scalar-metrics-4078.json
+++ b/webui/react/src/fixtures/responses/experiment-details/non-scalar-metrics-4078.json
@@ -31,8 +31,8 @@
     "description": "Fork of Fork of mnist_tp_to_estimator_const",
     "environment": {
       "image": {
-        "cpu": "determinedai/environments:py-3.6.9-pytorch-1.4-tf-1.15-cpu-0f2001a",
-        "gpu": "determinedai/environments:cuda-10.0-pytorch-1.4-tf-1.15-gpu-0f2001a"
+        "cpu": "determinedai/environments:py-3.6.9-pytorch-1.4-tf-1.15-cpu-600cf86",
+        "gpu": "determinedai/environments:cuda-10.0-pytorch-1.4-tf-1.15-gpu-600cf86"
       },
       "ports": null,
       "pod_spec": null,

--- a/webui/react/src/fixtures/responses/experiment-details/non-scalar-metrics-4078.json
+++ b/webui/react/src/fixtures/responses/experiment-details/non-scalar-metrics-4078.json
@@ -31,8 +31,8 @@
     "description": "Fork of Fork of mnist_tp_to_estimator_const",
     "environment": {
       "image": {
-        "cpu": "determinedai/environments:py-3.6.9-pytorch-1.4-tf-1.15-cpu-600cf86",
-        "gpu": "determinedai/environments:cuda-10.0-pytorch-1.4-tf-1.15-gpu-600cf86"
+        "cpu": "determinedai/environments:py-3.6.9-pytorch-1.4-tf-1.15-cpu-067db2b",
+        "gpu": "determinedai/environments:cuda-10.0-pytorch-1.4-tf-1.15-gpu-067db2b"
       },
       "ports": null,
       "pod_spec": null,

--- a/webui/react/src/fixtures/responses/trial-details/old-trial-config-noop-adaptive.json
+++ b/webui/react/src/fixtures/responses/trial-details/old-trial-config-noop-adaptive.json
@@ -29,8 +29,8 @@
   "description": "noop_adaptive",
   "environment": {
     "image": {
-      "cpu": "determinedai/environments:py-3.6.9-pytorch-1.4-tf-1.15-cpu-600cf86",
-      "gpu": "determinedai/environments:cuda-10.0-pytorch-1.4-tf-1.15-gpu-600cf86"
+      "cpu": "determinedai/environments:py-3.6.9-pytorch-1.4-tf-1.15-cpu-067db2b",
+      "gpu": "determinedai/environments:cuda-10.0-pytorch-1.4-tf-1.15-gpu-067db2b"
     },
     "ports": null,
     "force_pull_image": false,

--- a/webui/react/src/fixtures/responses/trial-details/old-trial-config-noop-adaptive.json
+++ b/webui/react/src/fixtures/responses/trial-details/old-trial-config-noop-adaptive.json
@@ -29,8 +29,8 @@
   "description": "noop_adaptive",
   "environment": {
     "image": {
-      "cpu": "determinedai/environments:py-3.6.9-pytorch-1.4-tf-1.15-cpu-0f2001a",
-      "gpu": "determinedai/environments:cuda-10.0-pytorch-1.4-tf-1.15-gpu-0f2001a"
+      "cpu": "determinedai/environments:py-3.6.9-pytorch-1.4-tf-1.15-cpu-600cf86",
+      "gpu": "determinedai/environments:cuda-10.0-pytorch-1.4-tf-1.15-gpu-600cf86"
     },
     "ports": null,
     "force_pull_image": false,


### PR DESCRIPTION
## Description
Rebased onto horovod 0.21.0. The API of the horovod optimizer changed for Estimators + Keras.
We handle this in a backwards compatible way.


## Test Plan
Ran full suite of tests: https://app.circleci.com/pipelines/github/determined-ai/determined/8336/workflows/ef7e0193-f8c7-49a0-99aa-6f89811f7e7c