### PR TITLE
chore: Support changing default images in det-deploy on cloud [DET-4689]

### DIFF
--- a/deploy/determined_deploy/aws/cli.py
+++ b/deploy/determined_deploy/aws/cli.py
@@ -167,6 +167,16 @@ def make_up_subparser(subparsers: argparse._SubParsersAction) -> None:
         action="store_true",
         help="print deployment template",
     )
+    subparser.add_argument(
+        "--cpu-env-image",
+        type=str,
+        help="Docker image for CPU tasks",
+    )
+    subparser.add_argument(
+        "--gpu-env-image",
+        type=str,
+        help="Docker image for GPU tasks",
+    )
 
 
 def make_aws_parser(subparsers: argparse._SubParsersAction) -> None:
@@ -215,6 +225,12 @@ def deploy_aws(args: argparse.Namespace) -> None:
         print("Delete Successful")
         return
 
+    if (args.cpu_env_image and not args.gpu_env_image) or (
+        args.gpu_env_image and not args.cpu_env_image
+    ):
+        print("If a CPU or GPU environment image is specified, both should be.")
+        sys.exit(1)
+
     deployment_type_map = {
         constants.deployment_types.SIMPLE: simple.Simple,
         constants.deployment_types.SECURE: secure.Secure,
@@ -261,6 +277,8 @@ def deploy_aws(args: argparse.Namespace) -> None:
         constants.cloudformation.SUBNET_ID_KEY: args.agent_subnet_id,
         constants.cloudformation.SCHEDULER_TYPE: args.scheduler_type,
         constants.cloudformation.PREEMPTION_ENABLED: args.preemption_enabled,
+        constants.cloudformation.CPU_ENV_IMAGE: args.cpu_env_image,
+        constants.cloudformation.GPU_ENV_IMAGE: args.gpu_env_image,
     }
 
     deployment_object = deployment_type_map[args.deployment_type](det_configs)

--- a/deploy/determined_deploy/aws/constants.py
+++ b/deploy/determined_deploy/aws/constants.py
@@ -49,6 +49,8 @@ class cloudformation:
     SPOT_MAX_PRICE = "SpotMaxPrice"
     SCHEDULER_TYPE = "SchedulerType"
     PREEMPTION_ENABLED = "PreemptionEnabled"
+    CPU_ENV_IMAGE = "CpuEnvImage"
+    GPU_ENV_IMAGE = "GpuEnvImage"
 
 
 class misc:

--- a/deploy/determined_deploy/aws/deployment_types/secure.py
+++ b/deploy/determined_deploy/aws/deployment_types/secure.py
@@ -37,6 +37,8 @@ class Secure(base.DeterminedDeployment):
         constants.cloudformation.MAX_DYNAMIC_AGENTS,
         constants.cloudformation.SPOT_ENABLED,
         constants.cloudformation.SPOT_MAX_PRICE,
+        constants.cloudformation.CPU_ENV_IMAGE,
+        constants.cloudformation.GPU_ENV_IMAGE,
     ]
 
     def deploy(self) -> None:

--- a/deploy/determined_deploy/aws/deployment_types/simple.py
+++ b/deploy/determined_deploy/aws/deployment_types/simple.py
@@ -34,6 +34,8 @@ class Simple(base.DeterminedDeployment):
         constants.cloudformation.SUBNET_ID_KEY,
         constants.cloudformation.SCHEDULER_TYPE,
         constants.cloudformation.PREEMPTION_ENABLED,
+        constants.cloudformation.CPU_ENV_IMAGE,
+        constants.cloudformation.GPU_ENV_IMAGE,
     ]
 
     def deploy(self) -> None:

--- a/deploy/determined_deploy/aws/deployment_types/vpc.py
+++ b/deploy/determined_deploy/aws/deployment_types/vpc.py
@@ -30,6 +30,8 @@ class VPC(base.DeterminedDeployment):
         constants.cloudformation.MAX_DYNAMIC_AGENTS,
         constants.cloudformation.SPOT_ENABLED,
         constants.cloudformation.SPOT_MAX_PRICE,
+        constants.cloudformation.CPU_ENV_IMAGE,
+        constants.cloudformation.GPU_ENV_IMAGE,
     ]
 
     def deploy(self) -> None:

--- a/deploy/determined_deploy/aws/templates/efs.yaml
+++ b/deploy/determined_deploy/aws/templates/efs.yaml
@@ -140,6 +140,16 @@ Parameters:
     Type: String
     Description: Whether preemption is enabled (only supported for priority scheduler).
     Default: false
+  
+  CpuEnvImage:
+    Type: String
+    Description: Docker image for CPU tasks
+    Default: ""
+
+  GpuEnvImage:
+    Type: String
+    Description: Docker image for GPU tasks
+    Default: ""
 
 Resources:
   VPC:
@@ -705,6 +715,23 @@ Resources:
                 cert: /etc/determined/master.crt
                 key: /etc/determined/master.key
             EOF
+            fi
+
+            if [ -n "${CpuEnvImage}" ] || [ -n "${GpuEnvImage}" ]; then
+              cat << EOF >> /usr/local/determined/etc/master.yaml
+            task_container_defaults:
+              image:
+            EOF
+              if [ -n "${CpuEnvImage}" ]; then
+                cat << EOF >> /usr/local/determined/etc/master.yaml
+                cpu: ${CpuEnvImage}
+            EOF
+              fi
+              if [ -n "${GpuEnvImage}" ]; then
+                cat << EOF >> /usr/local/determined/etc/master.yaml
+                gpu: ${GpuEnvImage}
+            EOF
+              fi
             fi
 
             apt-get remove docker docker-engine docker.io containerd runc

--- a/deploy/determined_deploy/aws/templates/fsx.yaml
+++ b/deploy/determined_deploy/aws/templates/fsx.yaml
@@ -139,6 +139,16 @@ Parameters:
     Type: String
     Description: Whether preemption is enabled (only supported for priority scheduler).
     Default: false
+  
+  CpuEnvImage:
+    Type: String
+    Description: Docker image for CPU tasks
+    Default: ""
+
+  GpuEnvImage:
+    Type: String
+    Description: Docker image for GPU tasks
+    Default: ""
 
 Resources:
   VPC:
@@ -720,6 +730,23 @@ Resources:
                 cert: /etc/determined/master.crt
                 key: /etc/determined/master.key
             EOF
+            fi
+
+            if [ -n "${CpuEnvImage}" ] || [ -n "${GpuEnvImage}" ]; then
+              cat << EOF >> /usr/local/determined/etc/master.yaml
+            task_container_defaults:
+              image:
+            EOF
+              if [ -n "${CpuEnvImage}" ]; then
+                cat << EOF >> /usr/local/determined/etc/master.yaml
+                cpu: ${CpuEnvImage}
+            EOF
+              fi
+              if [ -n "${GpuEnvImage}" ]; then
+                cat << EOF >> /usr/local/determined/etc/master.yaml
+                gpu: ${GpuEnvImage}
+            EOF
+              fi
             fi
 
             apt-get remove docker docker-engine docker.io containerd runc

--- a/deploy/determined_deploy/aws/templates/secure.yaml
+++ b/deploy/determined_deploy/aws/templates/secure.yaml
@@ -161,6 +161,16 @@ Parameters:
     Description: Whether preemption is enabled (only supported for priority scheduler).
     Default: false
 
+  CpuEnvImage:
+    Type: String
+    Description: Docker image for CPU tasks
+    Default: ""
+
+  GpuEnvImage:
+    Type: String
+    Description: Docker image for GPU tasks
+    Default: ""
+
 Resources:
   VPC:
     Type: AWS::EC2::VPC
@@ -746,6 +756,23 @@ Resources:
                 cert: /etc/determined/master.crt
                 key: /etc/determined/master.key
             EOF
+            fi
+
+            if [ -n "${CpuEnvImage}" ] || [ -n "${GpuEnvImage}" ]; then
+              cat << EOF >> /usr/local/determined/etc/master.yaml
+            task_container_defaults:
+              image:
+            EOF
+              if [ -n "${CpuEnvImage}" ]; then
+                cat << EOF >> /usr/local/determined/etc/master.yaml
+                cpu: ${CpuEnvImage}
+            EOF
+              fi
+              if [ -n "${GpuEnvImage}" ]; then
+                cat << EOF >> /usr/local/determined/etc/master.yaml
+                gpu: ${GpuEnvImage}
+            EOF
+              fi
             fi
 
             apt-get remove docker docker-engine docker.io containerd runc

--- a/deploy/determined_deploy/aws/templates/simple.yaml
+++ b/deploy/determined_deploy/aws/templates/simple.yaml
@@ -131,6 +131,16 @@ Parameters:
     Type: String
     Description: Whether preemption is enabled (only supported for priority scheduler).
     Default: false
+  
+  CpuEnvImage:
+    Type: String
+    Description: Docker image for CPU tasks
+    Default: ""
+
+  GpuEnvImage:
+    Type: String
+    Description: Docker image for GPU tasks
+    Default: ""
 
 Resources:
   CheckpointBucket:
@@ -539,6 +549,23 @@ Resources:
                 cert: /etc/determined/master.crt
                 key: /etc/determined/master.key
             EOF
+            fi
+
+            if [ -n "${CpuEnvImage}" ] || [ -n "${GpuEnvImage}" ]; then
+              cat << EOF >> /usr/local/determined/etc/master.yaml
+            task_container_defaults:
+              image:
+            EOF
+              if [ -n "${CpuEnvImage}" ]; then
+                cat << EOF >> /usr/local/determined/etc/master.yaml
+                cpu: ${CpuEnvImage}
+            EOF
+              fi
+              if [ -n "${GpuEnvImage}" ]; then
+                cat << EOF >> /usr/local/determined/etc/master.yaml
+                gpu: ${GpuEnvImage}
+            EOF
+              fi
             fi
 
             apt-get remove docker docker-engine docker.io containerd runc

--- a/deploy/determined_deploy/aws/templates/vpc.yaml
+++ b/deploy/determined_deploy/aws/templates/vpc.yaml
@@ -141,6 +141,16 @@ Parameters:
     Description: Whether preemption is enabled (only supported for priority scheduler).
     Default: false
 
+  CpuEnvImage:
+    Type: String
+    Description: Docker image for CPU tasks
+    Default: ""
+
+  GpuEnvImage:
+    Type: String
+    Description: Docker image for GPU tasks
+    Default: ""
+
 Resources:
   VPC:
     Type: AWS::EC2::VPC
@@ -657,6 +667,23 @@ Resources:
                 cert: /etc/determined/master.crt
                 key: /etc/determined/master.key
             EOF
+            fi
+
+            if [ -n "${CpuEnvImage}" ] || [ -n "${GpuEnvImage}" ]; then
+              cat << EOF >> /usr/local/determined/etc/master.yaml
+            task_container_defaults:
+              image:
+            EOF
+              if [ -n "${CpuEnvImage}" ]; then
+                cat << EOF >> /usr/local/determined/etc/master.yaml
+                cpu: ${CpuEnvImage}
+            EOF
+              fi
+              if [ -n "${GpuEnvImage}" ]; then
+                cat << EOF >> /usr/local/determined/etc/master.yaml
+                gpu: ${GpuEnvImage}
+            EOF
+              fi
             fi
 
             apt-get remove docker docker-engine docker.io containerd runc

--- a/deploy/determined_deploy/gcp/cli.py
+++ b/deploy/determined_deploy/gcp/cli.py
@@ -1,5 +1,6 @@
 import argparse
 import os
+import sys
 from typing import Callable
 
 import determined_deploy
@@ -209,6 +210,18 @@ def make_up_subparser(subparsers: argparse._SubParsersAction) -> None:
         help="whether task preemption is supported in the scheduler "
         "(only configurable for priority scheduler).",
     )
+    optional_named.add_argument(
+        "--cpu-env-image",
+        type=str,
+        default="",
+        help="Docker image for CPU tasks",
+    )
+    optional_named.add_argument(
+        "--gpu-env-image",
+        type=str,
+        default="",
+        help="Docker image for GPU tasks",
+    )
 
 
 def make_gcp_parser(subparsers: argparse._SubParsersAction) -> None:
@@ -257,6 +270,12 @@ def deploy_gcp(args: argparse.Namespace) -> None:
         gcp.delete(det_configs, env)
         print("Delete Successful")
         return
+
+    if (args.cpu_env_image and not args.gpu_env_image) or (
+        args.gpu_env_image and not args.cpu_env_image
+    ):
+        print("If a CPU or GPU image is specified, both should be.")
+        sys.exit(1)
 
     # Dry-run flag
     if args.dry_run:

--- a/deploy/determined_deploy/gcp/terraform/main.tf
+++ b/deploy/determined_deploy/gcp/terraform/main.tf
@@ -141,6 +141,8 @@ module "compute" {
   db_password = var.db_password
   scheduler_type = var.scheduler_type
   preemption_enabled = var.preemption_enabled
+  cpu_env_image = var.cpu_env_image
+  gpu_env_image = var.gpu_env_image
 
   network_name = module.network.network_name
   subnetwork_name = module.network.subnetwork_name

--- a/deploy/determined_deploy/gcp/terraform/modules/compute/main.tf
+++ b/deploy/determined_deploy/gcp/terraform/modules/compute/main.tf
@@ -89,6 +89,23 @@ resource "google_compute_instance" "master_instance" {
         minCpuPlatform: ${var.min_cpu_platform_agent}
     EOF
 
+    if [ -n "${var.cpu_env_image}" ] || [ -n "${var.gpu_env_image}" ]; then
+      cat << EOF >> /usr/local/determined/etc/master.yaml
+    task_container_defaults:
+      image:
+    EOF
+      if [ -n "${var.cpu_env_image}" ]; then
+        cat << EOF >> /usr/local/determined/etc/master.yaml
+        cpu: ${var.cpu_env_image}
+    EOF
+      fi
+      if [ -n "${var.gpu_env_image}" ]; then
+        cat << EOF >> /usr/local/determined/etc/master.yaml
+        gpu: ${var.gpu_env_image}
+    EOF
+      fi
+    fi
+
     apt-get remove docker docker-engine docker.io containerd runc
     apt-get update
     apt-get install -y \

--- a/deploy/determined_deploy/gcp/terraform/modules/compute/variables.tf
+++ b/deploy/determined_deploy/gcp/terraform/modules/compute/variables.tf
@@ -117,3 +117,9 @@ variable "scheduler_type" {
 
 variable "preemption_enabled" {
 }
+
+variable "cpu_env_image" {
+}
+
+variable "gpu_env_image" {
+}

--- a/deploy/determined_deploy/gcp/terraform/variables.tf
+++ b/deploy/determined_deploy/gcp/terraform/variables.tf
@@ -149,6 +149,16 @@ variable "det_version_key" {
   type = string
 }
 
+variable "cpu_env_image" {
+  type = string
+  default = ""
+}
+
+variable "gpu_env_image" {
+  type = string
+  default = ""
+}
+
 // MASTER
 
 variable "scheme" {

--- a/e2e_tests/tests/config.py
+++ b/e2e_tests/tests/config.py
@@ -12,10 +12,15 @@ MAX_TASK_SCHEDULED_SECS = 30
 MAX_TRIAL_BUILD_SECS = 90
 
 
-TF1_CPU_IMAGE = "determinedai/environments:py-3.6.9-pytorch-1.4-tf-1.15-cpu-067db2b"
-TF2_CPU_IMAGE = "determinedai/environments:py-3.6.9-pytorch-1.4-tf-2.2-cpu-067db2b"
-TF1_GPU_IMAGE = "determinedai/environments:cuda-10.0-pytorch-1.4-tf-1.15-gpu-067db2b"
-TF2_GPU_IMAGE = "determinedai/environments:cuda-10.1-pytorch-1.4-tf-2.2-gpu-067db2b"
+DEFAULT_TF1_CPU_IMAGE = "determinedai/environments:py-3.6.9-pytorch-1.4-tf-1.15-cpu-067db2b"
+DEFAULT_TF2_CPU_IMAGE = "determinedai/environments:py-3.6.9-pytorch-1.4-tf-2.2-cpu-067db2b"
+DEFAULT_TF1_GPU_IMAGE = "determinedai/environments:cuda-10.0-pytorch-1.4-tf-1.15-gpu-067db2b"
+DEFAULT_TF2_GPU_IMAGE = "determinedai/environments:cuda-10.1-pytorch-1.4-tf-2.2-gpu-067db2b"
+
+TF1_CPU_IMAGE = os.environ.get("TF1_CPU_IMAGE") or DEFAULT_TF1_CPU_IMAGE
+TF2_CPU_IMAGE = os.environ.get("TF2_CPU_IMAGE") or DEFAULT_TF2_CPU_IMAGE
+TF1_GPU_IMAGE = os.environ.get("TF1_GPU_IMAGE") or DEFAULT_TF1_GPU_IMAGE
+TF2_GPU_IMAGE = os.environ.get("TF2_GPU_IMAGE") or DEFAULT_TF2_GPU_IMAGE
 
 
 def fixtures_path(path: str) -> str:


### PR DESCRIPTION
## Description

I wanted this for CI, so we could easily test with non-default images (like when we're transitioning to new framework versions, etc.) Specifically wanting it for CUDA 11.

## Test Plan

Spun up clusters on AWS and GCP and confirmed the images were set. Testing the default case now to make sure the defaults still get applied with no failures.

## Commentary (optional)

I believe this would fail if you specified one but not both. I'm thinking about either requiring both options or neither, or fixing it so that if you only set one in the YAML we just use the default for the other. (update: I changed it so if one is specified, the other is required).