### PR TITLE
feat: support multiple backward call per train_batch in pytorch [DET-4667]

### DIFF
--- a/docs/release-notes/1732-feat-more-flexible-local-gradient-agg.txt
+++ b/docs/release-notes/1732-feat-more-flexible-local-gradient-agg.txt
@@ -1,0 +1,5 @@
+:orphan:
+
+**IMPROVEMENTS**
+
+-  PyTorchTrial: support more flexible local gradient aggregation 

--- a/docs/release-notes/1732-feat-more-flexible-local-gradient-agg.txt
+++ b/docs/release-notes/1732-feat-more-flexible-local-gradient-agg.txt
@@ -2,4 +2,5 @@
 
 **IMPROVEMENTS**
 
--  PyTorchTrial: support more flexible local gradient aggregation 
+-  PyTorchTrial: Support more than 1 backward passes per optimizer step
+   for distributed training.

--- a/harness/determined/pytorch/_pytorch_context.py
+++ b/harness/determined/pytorch/_pytorch_context.py
@@ -175,7 +175,7 @@ class PyTorchTrialContext(det.TrialContext):
                 loss2 = output['loss2']
                 self.context.backward(loss1)
                 self.context.backward(loss2)
-                self.context.step_optimizer(self.optimizer)
+                self.context.step_optimizer(self.optimizer, backward_passes_per_step=2)
                 return {"loss1": loss1, "loss2": loss2}
 
         """


### PR DESCRIPTION
## Description
hvd checks to make sure that backward calls before communicating is equal to backward passes per step.  we pass in the aggregation frequency, for backward passes per step, which is fine when backward is called once before an optimizer step.  however, in some train_batch calls, we need to do multiple backward passes before an optimizer step (this is pretty common in nas).  this pr supports this type of train step of which an example is shown below
```
def train_batch(
    self, batch: TorchData, epoch_idx: int, batch_idx: int
) -> Dict[str, torch.Tensor]:
    data, labels = batch
    output = self.model(data)
    loss1 = output['loss1']
    loss2 = output['loss2']
    self.context.backward(loss1)
    self.context.backward(loss2)
    self.context.step_optimizer(self.optimizer)
    return {"loss1": loss1, "loss2": loss2}
```
[DET-4667]

## Test Plan

- [x] Default behavior does not impact any existing calls of wrap_optimizer.  
- [x] Test the case where `backward_steps_per_batch > 1` on an in place distillation example for NAS.

## Checklist

- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.


[DET-4667]: https://determinedai.atlassian.net/browse/DET-4667