### PR TITLE
docs: edit YAML topic guide

### DIFF
--- a/docs/topic-guides/yaml.txt
+++ b/docs/topic-guides/yaml.txt
@@ -1,33 +1,45 @@
 .. _topic-guides_yaml:
 
-##################
- YAML Topic Guide
-##################
+######
+ YAML
+######
 
-YAML is a markup language often used for configuration. In Determined,
-we use YAML for configuring tasks such as experiments and notebooks, as
-well as :ref:`configuring the Determined cluster
-<cluster-configuration>`.
+`YAML <https://yaml.org/>`__ is a markup language often used for
+configuration. Determined uses YAML for configuring tasks such as
+:ref:`experiments <experiment-configuration>` and :ref:`notebooks
+<notebook-configuration>`, as well as configuring the Determined
+:ref:`cluster as a whole <cluster-configuration>`. This guide describes
+a subset of YAML that we recommend for use with Determined. This is not
+a full description of YAML; see the `specification
+<https://yaml.org/spec/1.2/spec.html>`__ or other online guides for more
+details.
 
 **********
  Overview
 **********
 
-Key-Value Pairs
-===============
+A value in YAML can be a scalar (``null`` or a number, string, or
+Boolean) or a collection (an array or map). Collections can contain
+other collections nested to any depth (though Determined's YAML files
+generally have a fairly fixed structure).
 
-At its core, YAML is a set of key-value pairs. These pairs are written
-like ``key: value``. We use snake-case for words in Determined. The
-values in a YAML file can be ints, floats, booleans, strings, or more
-complex types like maps and arrays.
+A comment in a YAML file starts with a ``#`` character and extends to
+the end of the line.
+
+If you are familiar with `JSON <https://www.json.org>`__, you can think
+of YAML as an alternative way of expressing JSON objects that is meant
+to be easier for humans to read and write, since it allows comments and
+has fewer markup characters around the content.
 
 Maps
 ====
 
-Maps represent hierarchical relationships of keys and values. Maps in
-YAML are represented by providing additional key-value pairs as the
-value of a particular key. Maps can be nested and combined with other
-YAML structures like arrays. Indents should be two spaces.
+Maps represent unordered mappings from strings to YAML values. A map is
+written as a sequence of key-value pairs. Each key is followed by a
+colon and the corresponding value. The value can be on the same line as
+the key if it is a scalar (in which case it must be preceded by a space)
+or on subsequent lines (in which case it must be indented,
+conventionally by two spaces).
 
 We use a map in the experiment configuration to configure
 hyperparameters:
@@ -41,12 +53,16 @@ hyperparameters:
      n_filters1: 40
      n_filters2: 40
 
+The snippet above describes a map with one key, ``hyperparameters``; the
+corresponding value is itself a map whose keys are
+``base_learning_rate``, ``weight_cost``, etc.
+
 Arrays
 ======
 
-We use arrays to provide multiple values for a given key. In arrays,
-each value is on its own line and is preceded by a ``-`` and a space.
-Arrays can be nested and combined with other YAML structures like maps.
+An array contains multiple other YAML values in some order. An array is
+written as a sequence of values, each one preceded by a hyphen and a
+space. The hyphens for one list must all be indented by the same amount.
 
 We use an array in the experiment configuration to configure environment
 variables:
@@ -59,13 +75,40 @@ variables:
        - B=B
        - C=C
 
+Scalars
+=======
+
+Scalars generally behave naturally: ``null``, ``true``, ``2.718``, and
+``"foo"`` all have the same meanings that they would in JSON (and many
+programming languages). However, YAML allows strings to be unquoted:
+``foo`` is the same as ``"foo"``. This behavior is often convenient, but
+it can lead to unexpected behavior when small edits to a value change
+its type. For example, the following YAML block represents a list
+containing several values whose types are listed in the comments:
+
+.. code:: yaml
+
+   - true          # Boolean
+   - grue          # string
+
+   - 0.0           # number
+   - 0.0.          # string
+
+   - foo: bar      # map
+   - foo:bar       # string
+   - foo bar       # string
+
 *************************
  Putting It All Together
 *************************
 
-Configurations usually use some combination of key-value pairs, maps,
-and arrays. In this example experiment configuration, we use key-value
-pairs, floats, integers, strings, a map, and an array:
+A Determined configuration file consists of a YAML object with a
+particular structure: a map at the top level that is expected to have
+certain keys, with the value for each key expected to have a certain
+structure in turn.
+
+In this example experiment configuration, we use numbers, strings, maps,
+and an array:
 
 .. code:: yaml
 
@@ -107,3 +150,4 @@ pairs, floats, integers, strings, a map, and an array:
 
 -  Read more about YAML: https://learnxinyminutes.com/docs/yaml/
 -  Validate your YAML: http://www.yamllint.com/
+-  Convert YAML to JSON: https://www.json2yaml.com/convert-yaml-to-json


### PR DESCRIPTION
## Description

Edit out the distinction between maps and key-value pairs (which doesn't
seem to actually exist), add a section on scalars, and generally massage
the text to more precisely describe things.

## Test Plan

- [x] render and examine docs
