### PR TITLE
fix: command priority not respected [DET-4674]

### DIFF
--- a/docs/release-notes/1735-fix-command-priority.txt
+++ b/docs/release-notes/1735-fix-command-priority.txt
@@ -1,0 +1,6 @@
+:orphan:
+
+**BUG FIXES**
+
+-  Priority Scheduler: Fix a bug where command priority was not
+   respected.

--- a/master/internal/command/command.go
+++ b/master/internal/command/command.go
@@ -118,6 +118,10 @@ func (c *command) Receive(ctx *actor.Context) error {
 		if err := ctx.Ask(sproto.GetRM(ctx.Self().System()), *c.task).Error(); err != nil {
 			return err
 		}
+		ctx.Tell(sproto.GetRM(ctx.Self().System()), sproto.SetGroupPriority{
+			Priority: c.config.Resources.Priority,
+			Handler:  ctx.Self(),
+		})
 		ctx.Tell(c.eventStream, event{Snapshot: newSummary(c), ScheduledEvent: &c.taskID})
 
 	case actor.PostStop:


### PR DESCRIPTION
## Description
Priority scheduler did not respect user set priorities in determined commands; this was due to priorities not being updated from their default set values. This fix allows determined commands to take on user defined priority levels.

<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan
Launch some commands with different priority levels and use det task list to check priorities are properly set.
<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234