### PR TITLE
feat: enable configuring trial logs backend on Kubernetes

### DIFF
--- a/docs/reference/helm-config.txt
+++ b/docs/reference/helm-config.txt
@@ -225,3 +225,15 @@ Helm Chart </helm/determined-helm-chart.tgz>`.
 
 -  ``defaultPassword``: Specifies a string containing the default
    password for the admin and determined user accounts.
+
+-  ``logging``: Configures where trial logs are stored. This section
+   takes the same shape as the logging configuration in the
+   :ref:`cluster configuration <cluster-configuration>`, except that
+   names are changed to camel case to match Helm conventions (e.g.,
+   ``skip_verify`` would be ``skipVerify`` here).
+
+   -  ``logging.security.tls.certificate``: Contains the contents of an
+      expected TLS certificate for the Elasticsearch cluster, rather
+      than a path as it does in the cluster configuration. This can be
+      conveniently set at the command line using ``helm install
+      --set-file logging.security.tls.certificate=<path>``.

--- a/docs/release-notes/1737-elastic-kubernetes.txt
+++ b/docs/release-notes/1737-elastic-kubernetes.txt
@@ -1,0 +1,6 @@
+:orphan:
+
+**IMPROVEMENTS**
+
+-  Allow the trial logging backend to be configured in Kubernetes
+   deployments of Determined.

--- a/helm/charts/determined/Chart.yaml
+++ b/helm/charts/determined/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: determined
 description: A Helm chart for Determined
-version: 0.3.1
+version: 0.4.0
 icon: https://github.com/determined-ai/determined/blob/master/determined-logo.png?raw=true
 home: https://github.com/determined-ai/determined.git
 

--- a/helm/charts/determined/templates/master-config.yaml
+++ b/helm/charts/determined/templates/master-config.yaml
@@ -13,9 +13,9 @@ data:
       {{- if eq .Values.checkpointStorage.type "shared_fs" }}
       host_path: {{ required "A valid Values.checkpointStorage.hostPath entry is required!" .Values.checkpointStorage.hostPath | quote }}
       {{- else if eq .Values.checkpointStorage.type "gcs" }}
-      bucket: {{ required "A valid Values.checkpointStorage.bucket entry is required!" .Values.checkpointStorage.bucket }} 
+      bucket: {{ required "A valid Values.checkpointStorage.bucket entry is required!" .Values.checkpointStorage.bucket }}
       {{- else if eq .Values.checkpointStorage.type "s3" }}
-      bucket: {{ required "A valid Values.checkpointStorage.bucket entry is required!" .Values.checkpointStorage.bucket }} 
+      bucket: {{ required "A valid Values.checkpointStorage.bucket entry is required!" .Values.checkpointStorage.bucket }}
       access_key: {{ .Values.checkpointStorage.accessKey | quote }}
       secret_key: {{ .Values.checkpointStorage.secretKey | quote }}
       endpoint_url: {{ .Values.checkpointStorage.endpointUrl | quote }}
@@ -95,3 +95,41 @@ data:
     {{- if .Values.clusterName }}
     cluster_name: {{ .Values.clusterName }}
     {{- end }}
+
+    logging:
+      {{- if .Values.logging.backend }}
+      backend: {{ .Values.logging.backend }}
+      {{- end }}
+      {{- if .Values.logging.host }}
+      host: {{ .Values.logging.host }}
+      {{- end }}
+      {{- if .Values.logging.port }}
+      port: {{ .Values.logging.port }}
+      {{- end }}
+      {{- if .Values.logging.security }}
+      security:
+        {{- if .Values.logging.security.username }}
+        username: {{ .Values.logging.security.username }}
+        {{- end }}
+        {{- if .Values.logging.security.password }}
+        password: {{ .Values.logging.security.password }}
+        {{- end }}
+        {{- if .Values.logging.security.tls }}
+        tls:
+          {{- if .Values.logging.security.tls.enabled }}
+          enabled: {{ .Values.logging.security.tls.enabled }}
+          {{- end }}
+          {{- if .Values.logging.security.tls.skipVerify }}
+          skip_verify: {{ .Values.logging.security.tls.skipVerify }}
+          {{- end }}
+          {{- if .Values.logging.security.tls.certificate }}
+          certificate: /etc/determined/elastic.crt
+          {{- end }}
+          {{- if .Values.logging.security.tls.certificateName }}
+          certificate_name: {{ .Values.logging.security.tls.certificateName }}
+          {{- end }}
+        {{- end}}
+      {{- end }}
+  {{- if .Values.logging.security.tls.certificate }}
+  elastic.crt: |{{ nindent 4 .Values.logging.security.tls.certificate }}
+  {{- end}}

--- a/helm/charts/determined/templates/master-config.yaml
+++ b/helm/charts/determined/templates/master-config.yaml
@@ -96,16 +96,15 @@ data:
     cluster_name: {{ .Values.clusterName }}
     {{- end }}
 
+    {{- if .Values.logging }}
     logging:
       {{- if .Values.logging.backend }}
       backend: {{ .Values.logging.backend }}
       {{- end }}
-      {{- if .Values.logging.host }}
-      host: {{ .Values.logging.host }}
-      {{- end }}
-      {{- if .Values.logging.port }}
-      port: {{ .Values.logging.port }}
-      {{- end }}
+
+      {{- if (eq (default "" .Values.logging.backend) "elastic") }}
+      host: {{ required "A valid host must be provided if logging to Elasticsearch!" .Values.logging.host }}
+      port: {{ required "A valid port must be provided if logging to Elasticsearch!" .Values.logging.port }}
       {{- if .Values.logging.security }}
       security:
         {{- if .Values.logging.security.username }}
@@ -130,6 +129,14 @@ data:
           {{- end }}
         {{- end}}
       {{- end }}
+      {{- end }}
+    {{- end}}
+  {{- if .Values.logging }}
+  {{- if .Values.logging.security }}
+  {{- if .Values.logging.security.tls }}
   {{- if .Values.logging.security.tls.certificate }}
   elastic.crt: |{{ nindent 4 .Values.logging.security.tls.certificate }}
-  {{- end}}
+  {{- end }}
+  {{- end }}
+  {{- end }}
+  {{- end }}

--- a/helm/charts/determined/values.yaml
+++ b/helm/charts/determined/values.yaml
@@ -140,7 +140,7 @@ telemetry:
   # host: <host>
   # port: <port>
 
-  ## Authentication and TLS options for making the connection.
+  ## Authentication and TLS options for making the connection to Elasticsearch.
   # security:
     # username: <username>
     # password: <password>

--- a/helm/charts/determined/values.yaml
+++ b/helm/charts/determined/values.yaml
@@ -126,3 +126,31 @@ telemetry:
 
 # defaultPassword sets the password for the admin and determined user accounts.
 # defaultPassword:
+
+## Configure how trial logs are stored.
+# logging:
+  ## The backend to use. Can be `default` to send logs to the master to store in the PostgreSQL
+  ## database or `elastic` to store logs in an Elasticsearch cluster (without going through the
+  ## master).
+  # backend: default
+
+  ## The remaining options should be provided only for the `elastic` backend.
+
+  ## The host and port to use to connect to the Elasticsearch cluster.
+  # host: <host>
+  # port: <port>
+
+  ## Authentication and TLS options for making the connection.
+  # security:
+    # username: <username>
+    # password: <password>
+    # tls:
+      # enabled: true
+      # skipVerify: false
+
+      ## The name to use when verifying the certificate, if different from the name used to connect.
+      # certificateName: <name>
+
+      ## This value must contain the contents of the certificate file, not a path. It may be set
+      ## directly or using `helm install --set-file logging.security.tls.certificate=<path>`.
+      # certificate: <certificate contents>


### PR DESCRIPTION
## Description

This mostly involves passing a bunch of values through the config
template from the Helm values file into the final master config.
Documentation is also provided.

## Test Plan

- [x] provide some logging values in `values.yaml` and see that they show up in the master config
- [x] check that trial logging works with the master connected to an Elasticsearch cluster over TLS

## Commentary

Should we also manage an Elasticsearch service ourselves at some point? That sounds like a whole other thing and I'm not really clear if that was supposed to be in scope.