### PR TITLE
ci: upgrade version of CircleCI Helm orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
   slack: circleci/slack@3.4.2
   gke: circleci/gcp-gke@1.0.4
   kubernetes: circleci/kubernetes@0.11.0
-  helm: circleci/helm@1.0.0
+  helm: circleci/helm@1.1.2
 
 executors:
   python-35:


### PR DESCRIPTION
## Description

The old version used an old Helm-related URL that is no longer correct,
leading to CI failures. The new version is the current latest version.

## Test Plan

- [run Kubernetes CI tests](https://app.circleci.com/pipelines/github/determined-ai/determined?branch=helm-orb-upgrade) and see that they get past the installation step where they were failing before
