### PR TITLE
ci: split CircleCI tests more carefully

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -300,7 +300,13 @@ commands:
           name: Split tests
           working_directory: ~/project/e2e_tests
           command: |
-            circleci tests glob "tests/**/test*.py" | circleci tests split --split-by=timings > /tmp/tests-to-run
+            # If a test mark is specified, preselect only files that contain tests with that mark to
+            # minimize how wrong CircleCI's splitting can get things.
+            if [ -n "<<parameters.mark>>" ]; then
+              find tests -name 'test*.py' -print0 | xargs -0 grep -rl 'pytest\.mark\.<<parameters.mark>>'
+            else
+              circleci tests glob 'tests/**/test*.py'
+            fi | circleci tests split --split-by=timings > /tmp/tests-to-run
             echo "Running tests from these files:"
             sed 's/^/- /' </tmp/tests-to-run
 
@@ -315,7 +321,7 @@ commands:
           command: |
             DET_MASTER_CERT_FILE=<<parameters.master-cert>> DET_MASTER_CERT_NAME=<<parameters.master-cert-name>> \
             pytest -vv -s \
-            -m <<parameters.mark>> \
+            -m '<<parameters.mark>>' \
             --durations=0 \
             --master-scheme="<<parameters.master-scheme>>" \
             --master-host="<<parameters.master-host>>" \


### PR DESCRIPTION
## Description

Recently, nightly tests have been failing because only two files contain
`nightly`-marked tests and CircleCI's test splitting, due to how it
works on files without timing information, tends to put both of those
files in the same one of two parallel runs, causing the other one to
fail with no tests found.

This avoids that issue by explicitly limiting the splitting of E2E tests
to operate on only test files containing the requested mark (or all
files as before if no mark is provided, though that never actually
happens in our config).

## Test Plan

- [x] [run CI](https://app.circleci.com/pipelines/github/determined-ai/determined?branch=fix-nightly-splits) and check that files submitted for splitting in E2E tests look right

## Commentary (optional)

There's potentially some fragility to this (e.g., I first included `@` in the `grep` and that missed some tests that pass the mark to another pytest helper instead of decorating a function directly), but I think it should be pretty fine; happy to hear opinions on that.

We could just turn off parallelism for these tests and avoid the issue entirely. The length of nightly tests doesn't super matter, though I still wouldn't want them to get _too_ long, and I'd say 3 hours is starting to get up in that ballpark. Could go either way.

Or (just thought of this while writing this text) we could run `pytest -m '<mark>' --collect-only --disable-warnings -qq | cut -d: -f1` to list files; I like reusing pytest itself to list things, but I don't like relying on the not-necessarily-stable output. Now that I've thought of that, I think I like it a little better overall, though.