### PR TITLE
test: fix race condition in test-intg-agent

### DIFF
--- a/agent/internal/fluent_intg_test.go
+++ b/agent/internal/fluent_intg_test.go
@@ -11,6 +11,7 @@ import (
 	"math"
 	"math/rand"
 	"net"
+	"sort"
 	"testing"
 	"time"
 
@@ -55,17 +56,24 @@ func TestFluentPostgresLogging(t *testing.T) {
 
 	// THEN fluent should parse all fields as expected and ship them to the mock master.
 	i := 0
+	var logs []model.TrialLog
 	for {
 		select {
 		case l := <-logBuffer:
-			assertLogEquals(t, l, expected[i])
+			logs = append(logs, l)
 			i++
-			if i == len(expected) {
-				return
-			}
 		case <-time.After(time.Minute):
 			assert.Equal(t, i, len(expected), "not enough logs received after one minute")
 		}
+		if i == len(expected) {
+			break
+		}
+	}
+	sort.Slice(logs, func(i, j int) bool {
+		return logs[i].Timestamp.Before(*logs[j].Timestamp)
+	})
+	for i := range logs {
+		assertLogEquals(t, logs[i], expected[i])
 	}
 }
 
@@ -91,7 +99,7 @@ func TestFluentLoggingElastic(t *testing.T) {
 
 	// This is really unfortunate, but we don't query for logs until they're more than 10 seconds old
 	// to _try_ to avoid the trickiness involved with elastic's consistency model.
-	time.Sleep(10 * time.Second)
+	time.Sleep(11 * time.Second)
 
 	assert.NilError(t, elastic.WaitForIngest(testutils.CurrentLogstashElasticIndex()))
 
@@ -239,6 +247,18 @@ func runContainerWithLogs(t *testing.T, fakeLogs string, trialID, fluentPort int
 	assert.NilError(t, err, "failed to copy files to container")
 	err = docker.ContainerStart(context.Background(), cc.ID, types.ContainerStartOptions{})
 	assert.NilError(t, err, "error starting container")
+
+	exit, cErr := docker.ContainerWait(context.Background(), cc.ID, container.WaitConditionNextExit)
+	select {
+	case err = <-cErr:
+		assert.NilError(t, err, "container wait failed")
+	case exit := <-exit:
+		if exit.Error != nil {
+			t.Fatalf("container exited with error: %s", exit.Error)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("container did not exit after 10 seconds")
+	}
 }
 
 func assertLogEquals(t *testing.T, l, expected model.TrialLog) {

--- a/master/internal/elastic/elastic.go
+++ b/master/internal/elastic/elastic.go
@@ -63,8 +63,8 @@ func Setup(conf model.ElasticLoggingConfig) (*Elastic, error) {
 			return &Elastic{es}, nil
 		}
 		numTries++
-		// Elastic can take a really long time to come up.
-		if numTries >= 60 {
+		// Elastic can take a really long time to come up and we'd rather not fail integrations on this.
+		if numTries >= 300 {
 			return nil, errors.Wrapf(err, "could not connect to elastic after %v tries", numTries)
 		}
 		time.Sleep(time.Second)


### PR DESCRIPTION
## Description
This change fixes two race conditions with the agent integration tests. One involved us not waiting for the container to exit before checking the logs. The other involved logs showing up out of order and from different fluent flushes. This is fixed by awaiting the logging container exit and just waiting for all the logs and resorting them when checking if they were received.
<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234