### PR TITLE
refactor: reduce code duplication across task types

### DIFF
--- a/master/internal/checkpoint_gc.go
+++ b/master/internal/checkpoint_gc.go
@@ -48,12 +48,12 @@ func (t *checkpointGCTask) Receive(ctx *actor.Context) error {
 
 		for _, a := range msg.Allocations {
 			taskSpec := *t.taskSpec
-			taskSpec.GCCheckpoints = &tasks.GCCheckpoints{
-				AgentUserGroup:   t.agentUserGroup,
+			taskSpec.AgentUserGroup = t.agentUserGroup
+			taskSpec.SetInner(&tasks.GCCheckpoints{
 				ExperimentID:     t.experiment.ID,
 				ExperimentConfig: t.experiment.Config,
 				ToDelete:         checkpoints,
-			}
+			})
 			a.Start(ctx, taskSpec)
 		}
 	case sproto.ReleaseResources:

--- a/master/internal/command/command.go
+++ b/master/internal/command/command.go
@@ -289,12 +289,12 @@ func (c *command) receiveSchedulerMsg(ctx *actor.Context) error {
 		c.allocation = msg.Allocations[0]
 
 		taskSpec := *c.taskSpec
-		taskSpec.StartCommand = &tasks.StartCommand{
-			AgentUserGroup:  c.agentUserGroup,
+		taskSpec.AgentUserGroup = c.agentUserGroup
+		taskSpec.SetInner(&tasks.StartCommand{
 			Config:          c.config,
 			UserFiles:       c.userFiles,
 			AdditionalFiles: c.additionalFiles,
-		}
+		})
 		msg.Allocations[0].Start(ctx, taskSpec)
 
 		ctx.Tell(c.eventStream, event{Snapshot: newSummary(c), AssignedEvent: &msg})

--- a/master/internal/kubernetes/pod.go
+++ b/master/internal/kubernetes/pod.go
@@ -173,19 +173,7 @@ func (p *pod) Receive(ctx *actor.Context) error {
 }
 
 func (p *pod) createPodSpecAndSubmit(ctx *actor.Context) error {
-	var err error
-	switch {
-	case p.taskSpec.StartCommand != nil:
-		err = p.createPodSpecForCommand(ctx)
-	case p.taskSpec.StartContainer != nil:
-		err = p.createPodSpecForTrial(ctx)
-	case p.taskSpec.GCCheckpoints != nil:
-		err = p.createPodSpecForGC(ctx)
-	default:
-		return errors.Errorf("unexpected task spec received")
-	}
-
-	if err != nil {
+	if err := p.createPodSpec(ctx); err != nil {
 		return err
 	}
 

--- a/master/internal/kubernetes/pod_test.go
+++ b/master/internal/kubernetes/pod_test.go
@@ -129,15 +129,15 @@ func createPodWithMockQueue() (
 	map[string]*actor.Ref,
 ) {
 	startCmd := tasks.StartCommand{
-		AgentUserGroup: createAgentUserGroup(),
-		Config:         model.CommandConfig{Description: "test-config"},
+		Config: model.CommandConfig{Description: "test-config"},
 	}
 	task := tasks.TaskSpec{
-		TaskID:       "task",
-		ContainerID:  "container",
-		ClusterID:    "cluster",
-		StartCommand: &startCmd,
+		TaskID:         "task",
+		ContainerID:    "container",
+		ClusterID:      "cluster",
+		AgentUserGroup: createAgentUserGroup(),
 	}
+	task.SetInner(&startCmd)
 	system := actor.NewSystem("test-sys")
 	podMap, actorMap := createReceivers(system)
 

--- a/master/internal/trial.go
+++ b/master/internal/trial.go
@@ -630,7 +630,8 @@ func (t *trial) processAllocated(
 	for rank, a := range msg.Allocations {
 		t.containerRanks[a.Summary().ID] = rank
 		taskSpec := *t.taskSpec
-		taskSpec.StartContainer = &tasks.StartContainer{
+		taskSpec.AgentUserGroup = t.agentUserGroup
+		taskSpec.SetInner(&tasks.StartTrial{
 			ExperimentConfig:    t.experiment.Config,
 			ModelDefinition:     t.modelDefinition,
 			HParams:             t.create.Hparams,
@@ -639,10 +640,9 @@ func (t *trial) processAllocated(
 			InitialWorkload:     w,
 			WorkloadManagerType: t.sequencer.WorkloadManagerType(),
 			AdditionalFiles:     additionalFiles,
-			AgentUserGroup:      t.agentUserGroup,
 			IsMultiAgent:        len(t.allocations) > 1,
 			Rank:                rank,
-		}
+		})
 		a.Start(ctx, taskSpec)
 	}
 

--- a/master/pkg/model/environment_config.go
+++ b/master/pkg/model/environment_config.go
@@ -58,7 +58,7 @@ func (r *RuntimeItem) UnmarshalJSON(data []byte) error {
 }
 
 // For returns the value for the provided device type.
-func (r *RuntimeItem) For(deviceType device.Type) string {
+func (r RuntimeItem) For(deviceType device.Type) string {
 	switch deviceType {
 	case device.CPU:
 		return r.CPU

--- a/master/pkg/tasks/ports.go
+++ b/master/pkg/tasks/ports.go
@@ -20,16 +20,17 @@ const (
 	hostMode container.NetworkMode = "host"
 )
 
-func rendezvousPorts(offset int) []nat.Port {
-	return []nat.Port{
-		nat.Port(fmt.Sprintf("%d/tcp", LocalRendezvousPort+offset)),
-		nat.Port(fmt.Sprintf("%d/tcp", LocalRendezvousPort+offset+LocalRendezvousPortOffset)),
-	}
+func rendezvousPorts(offset int) []int {
+	base := LocalRendezvousPort + offset
+	return []int{base, base + LocalRendezvousPortOffset}
 }
 
 // trialUniquePortOffset determines a deterministic, unique offset for ports that would otherwise
 // collide when using host networking.
 func trialUniquePortOffset(devices []device.Device) int {
+	if len(devices) == 0 {
+		return 0
+	}
 	min := devices[0].ID
 	for _, d := range devices {
 		if d.ID < min {

--- a/master/pkg/tasks/task.go
+++ b/master/pkg/tasks/task.go
@@ -3,17 +3,12 @@ package tasks
 import (
 	"archive/tar"
 	"fmt"
-	"path/filepath"
-	"strings"
 
 	docker "github.com/docker/docker/api/types/container"
-	"github.com/docker/docker/api/types/mount"
-	"github.com/docker/go-connections/nat"
 
 	"github.com/determined-ai/determined/master/pkg/archive"
 	"github.com/determined-ai/determined/master/pkg/container"
 	"github.com/determined-ai/determined/master/pkg/device"
-	"github.com/determined-ai/determined/master/pkg/etc"
 	"github.com/determined-ai/determined/master/pkg/model"
 )
 
@@ -29,20 +24,6 @@ const (
 	groupPath         = "/run/determined/etc/group"
 	certPath          = "/run/determined/etc/ssl/master.crt"
 )
-
-func defaultEnvVars() map[string]string {
-	// PYTHONUSERBASE allows us to `pip install --user` into a location guaranteed to be owned by
-	// the user inside the container.
-	envVars := map[string]string{"PYTHONUSERBASE": userPythonBaseDir}
-	return envVars
-}
-
-func addTLSVars(t TaskSpec, env map[string]string) {
-	if t.MasterCert != nil {
-		env["DET_USE_TLS"] = "true"
-		env["DET_MASTER_CERT_FILE"] = certPath
-	}
-}
 
 // workDirArchive ensures that the workdir is created and owned by the user.
 func workDirArchive(aug *model.AgentUserGroup) container.RunArchive {
@@ -78,368 +59,61 @@ func injectUserArchive(aug *model.AgentUserGroup) container.RunArchive {
 	)
 }
 
-// ToContainerSpec returns the container spec for associated task spec. This is a bridge method
-// for the agent refactor project.
+// ToContainerSpec translates a task spec into a generic container spec.
 func ToContainerSpec(t TaskSpec) container.Spec {
-	switch {
-	case t.StartCommand != nil:
-		return startCommand(t)
-	case t.StartContainer != nil:
-		return startContainer(t)
-	case t.GCCheckpoints != nil:
-		return gcCheckpoint(t)
-	default:
-		panic("unexpected task spec received")
+	var envVars []string
+	for k, v := range t.EnvVars() {
+		envVars = append(envVars, fmt.Sprintf("%s=%s", k, v))
 	}
-}
 
-func getUser(agentUserGroup *model.AgentUserGroup) string {
-	user := ""
-	if agentUserGroup != nil {
-		user = fmt.Sprintf("%d:%d", agentUserGroup.UID, agentUserGroup.GID)
-	}
-	return user
-}
-
-// CommandEnvVars configures environment variables for cmd tasks.
-func CommandEnvVars(t TaskSpec) map[string]string {
-	envVarsMap := defaultEnvVars()
-	envVarsMap["DET_TASK_ID"] = t.TaskID
-	addTLSVars(t, envVarsMap)
-
-	return envVarsMap
-}
-
-// CommandArchives returns the additional files for a command as an archive.
-func CommandArchives(t TaskSpec) []container.RunArchive {
-	cmd := *t.StartCommand
-
-	return []container.RunArchive{
-		workDirArchive(cmd.AgentUserGroup),
-		injectUserArchive(cmd.AgentUserGroup),
-		wrapArchive(cmd.AgentUserGroup.OwnArchive(cmd.UserFiles), ContainerWorkDir),
-		wrapArchive(cmd.AdditionalFiles, rootDir),
-		harnessArchive(t.HarnessPath, cmd.AgentUserGroup),
-		masterCertArchive(t.MasterCert),
-	}
-}
-
-func startCommand(t TaskSpec) container.Spec {
-	cmd := *t.StartCommand
-	user := getUser(cmd.AgentUserGroup)
+	env := t.Environment()
 	deviceType := device.CPU
 	if len(t.Devices) > 0 {
 		deviceType = t.Devices[0].Type
 	}
-	envVarsMap := CommandEnvVars(t)
-	envVars := make([]string, 0, len(envVarsMap))
-	for envVarKey, envVarValue := range envVarsMap {
-		envVars = append(envVars, fmt.Sprintf("%s=%s", envVarKey, envVarValue))
-	}
-	envVars = append(envVars, cmd.Config.Environment.EnvironmentVariables.For(deviceType)...)
+	envVars = append(envVars, env.EnvironmentVariables.For(deviceType)...)
 
-	shmSize := t.TaskContainerDefaults.ShmSizeBytes
-	if cmd.Config.Resources.ShmSize != nil {
-		shmSize = int64(*cmd.Config.Resources.ShmSize)
+	network := t.TaskContainerDefaults.NetworkMode
+	if t.UseHostMode() {
+		network = hostMode
 	}
 
-	return container.Spec{
-		PullSpec: container.PullSpec{
-			Registry:  cmd.Config.Environment.RegistryAuth,
-			ForcePull: cmd.Config.Environment.ForcePullImage,
-		},
-		RunSpec: container.RunSpec{
-			ContainerConfig: docker.Config{
-				User:         user,
-				ExposedPorts: toPortSet(cmd.Config.Environment.Ports),
-				Env:          envVars,
-				Cmd:          cmd.Config.Entrypoint,
-				Image:        cmd.Config.Environment.Image.For(deviceType),
-				WorkingDir:   ContainerWorkDir,
-			},
-			HostConfig: docker.HostConfig{
-				NetworkMode:     t.TaskContainerDefaults.NetworkMode,
-				Mounts:          ToDockerMounts(cmd.Config.BindMounts),
-				PublishAllPorts: true,
-				ShmSize:         shmSize,
-			},
-			Archives: CommandArchives(t),
-		},
+	shmSize := t.ShmSize()
+	if shmSize == 0 {
+		shmSize = t.TaskContainerDefaults.ShmSizeBytes
 	}
-}
-
-// TrialDockerMounts returns the host mounts for a trial container.
-func TrialDockerMounts(exp StartContainer) []mount.Mount {
-	mounts := ToDockerMounts(exp.ExperimentConfig.BindMounts)
-	if exp.ExperimentConfig.CheckpointStorage.SharedFSConfig != nil {
-		sharedFS := exp.ExperimentConfig.CheckpointStorage.SharedFSConfig
-		mounts = append(mounts, mount.Mount{
-			Type:   mount.TypeBind,
-			Source: sharedFS.HostPath,
-			Target: model.DefaultSharedFSContainerPath,
-			BindOptions: &mount.BindOptions{
-				Propagation: model.DefaultSharedFSPropagation,
-			},
-		})
-	}
-
-	if exp.ExperimentConfig.DataLayer.SharedFSConfig != nil {
-		SharedFSConfig := exp.ExperimentConfig.DataLayer.SharedFSConfig
-		if SharedFSConfig.HostStoragePath != nil {
-			mounts = append(mounts, mount.Mount{
-				Type:   mount.TypeBind,
-				Source: *SharedFSConfig.HostStoragePath,
-				Target: *SharedFSConfig.ContainerStoragePath,
-			})
-		}
-	}
-	if exp.ExperimentConfig.DataLayer.S3Config != nil {
-		S3Config := exp.ExperimentConfig.DataLayer.S3Config
-		if S3Config.LocalCacheHostPath != nil {
-			mounts = append(mounts, mount.Mount{
-				Type:   mount.TypeBind,
-				Source: *S3Config.LocalCacheHostPath,
-				Target: *S3Config.LocalCacheContainerPath,
-			})
-		}
-	}
-	if exp.ExperimentConfig.DataLayer.GCSConfig != nil {
-		GCSConfig := exp.ExperimentConfig.DataLayer.GCSConfig
-		if GCSConfig.LocalCacheHostPath != nil {
-			mounts = append(mounts, mount.Mount{
-				Type:   mount.TypeBind,
-				Source: *GCSConfig.LocalCacheHostPath,
-				Target: *GCSConfig.LocalCacheContainerPath,
-			})
-		}
-	}
-
-	return mounts
-}
-
-// TrialEnvVars returns environment variables for a trial.
-func TrialEnvVars(t TaskSpec, rendezvousPorts []string, tPortOffset int) map[string]string {
-	exp := *t.StartContainer
-
-	networkInterface := t.TaskContainerDefaults.DtrainNetworkInterface
-	if networkInterface == "" {
-		networkInterface = "DET_AUTO_DETECT_NETWORK_INTERFACE"
-	}
-
-	envVars := defaultEnvVars()
-	envVars["DET_EXPERIMENT_ID"] = fmt.Sprintf("%d", exp.InitialWorkload.ExperimentID)
-	envVars["DET_TRIAL_ID"] = fmt.Sprintf("%d", exp.InitialWorkload.TrialID)
-	envVars["DET_TRIAL_SEED"] = fmt.Sprintf("%d", exp.TrialSeed)
-	envVars["DET_EXPERIMENT_CONFIG"] = jsonify(exp.ExperimentConfig)
-	envVars["DET_HPARAMS"] = jsonify(exp.HParams)
-	envVars["DET_INITIAL_WORKLOAD"] = jsonify(exp.InitialWorkload)
-	envVars["DET_LATEST_CHECKPOINT"] = "/run/determined/train/checkpoint.json"
-	envVars["DET_WORKLOAD_MANAGER_TYPE"] = string(exp.WorkloadManagerType)
-	envVars["DET_RENDEZVOUS_PORTS"] = strings.Join(rendezvousPorts, ",")
-	envVars["DET_TRIAL_UNIQUE_PORT_OFFSET"] = fmt.Sprintf("%d", tPortOffset)
-	envVars["DET_TRIAL_RUNNER_NETWORK_INTERFACE"] = networkInterface
-	addTLSVars(t, envVars)
-
-	if t.TaskContainerDefaults.NCCLPortRange != "" {
-		envVars["NCCL_PORT_RANGE"] = t.TaskContainerDefaults.NCCLPortRange
-	}
-	if t.TaskContainerDefaults.NCCLPortRange != "" {
-		envVars["GLOO_PORT_RANGE"] = t.TaskContainerDefaults.NCCLPortRange
-	}
-
-	return envVars
-}
-
-// TrialArchives returns the additional files for a trial as an archive.
-func TrialArchives(t TaskSpec) []container.RunArchive {
-	exp := *t.StartContainer
-
-	return []container.RunArchive{
-		workDirArchive(exp.AgentUserGroup),
-		injectUserArchive(exp.AgentUserGroup),
-		wrapArchive(exp.AdditionalFiles, rootDir),
-		wrapArchive(
-			archive.Archive{
-				exp.AgentUserGroup.OwnedArchiveItem(
-					"checkpoint.json",
-					[]byte(jsonify(exp.LatestCheckpoint)),
-					0600,
-					tar.TypeReg,
-				),
-			},
-			trainDir,
-		),
-		wrapArchive(exp.AgentUserGroup.OwnArchive(exp.ModelDefinition), ContainerWorkDir),
-		harnessArchive(t.HarnessPath, exp.AgentUserGroup),
-		masterCertArchive(t.MasterCert),
-	}
-}
-
-func startContainer(t TaskSpec) container.Spec {
-	exp := *t.StartContainer
-	user := getUser(exp.AgentUserGroup)
-	deviceType := device.CPU
-	if len(t.Devices) > 0 {
-		deviceType = t.Devices[0].Type
-	}
-	mounts := TrialDockerMounts(exp)
-	networkMode := t.TaskContainerDefaults.NetworkMode
-	if exp.IsMultiAgent {
-		networkMode = hostMode
-	}
-	tPortOffset := trialUniquePortOffset(t.Devices)
-	rPorts := rendezvousPorts(tPortOffset)
-	ports := make(nat.PortSet)
-	var rPortsEnvVars []string
-	for _, port := range rPorts {
-		rPortsEnvVars = append(rPortsEnvVars, port.Port())
-		ports[port] = struct{}{}
-	}
-
-	envVarsMap := TrialEnvVars(t, rPortsEnvVars, tPortOffset)
-	envVars := make([]string, 0, len(envVarsMap))
-	for envVarKey, envVarValue := range envVarsMap {
-		envVars = append(envVars, fmt.Sprintf("%s=%s", envVarKey, envVarValue))
-	}
-	envVars = append(envVars, exp.ExperimentConfig.Environment.EnvironmentVariables.For(deviceType)...)
 
 	spec := container.Spec{
 		PullSpec: container.PullSpec{
-			ForcePull: exp.ExperimentConfig.Environment.ForcePullImage,
-			Registry:  exp.ExperimentConfig.Environment.RegistryAuth,
+			Registry:  env.RegistryAuth,
+			ForcePull: env.ForcePullImage,
 		},
 		RunSpec: container.RunSpec{
 			ContainerConfig: docker.Config{
-				Cmd:          []string{"/run/determined/train/entrypoint.sh"},
-				User:         user,
-				Image:        exp.ExperimentConfig.Environment.Image.For(deviceType),
-				ExposedPorts: ports,
+				User:         getUser(t.AgentUserGroup),
+				ExposedPorts: toPortSet(env.Ports),
 				Env:          envVars,
+				Cmd:          t.Entrypoint(),
+				Image:        env.Image.For(deviceType),
 				WorkingDir:   ContainerWorkDir,
 			},
 			HostConfig: docker.HostConfig{
-				NetworkMode:     networkMode,
-				Mounts:          mounts,
+				NetworkMode:     network,
+				Mounts:          t.Mounts(),
 				PublishAllPorts: true,
+				ShmSize:         shmSize,
 			},
-			Archives:         TrialArchives(t),
-			UseFluentLogging: true,
+			Archives:         t.Archives(),
+			UseFluentLogging: t.UseFluentLogging(),
 		},
 	}
-	spec.RunSpec.HostConfig.ShmSize = t.TaskContainerDefaults.ShmSizeBytes
-	if exp.ExperimentConfig.Resources.ShmSize != nil {
-		spec.RunSpec.HostConfig.ShmSize = int64(*exp.ExperimentConfig.Resources.ShmSize)
-	}
+
 	return spec
 }
 
-// GCEnvVars returns environment variables for checkpoint gc.
-func GCEnvVars() map[string]string {
-	return defaultEnvVars()
-}
-
-// GCDockerMounts returns the host mounts for a gc container.
-func GCDockerMounts(gcc GCCheckpoints) []mount.Mount {
-	mounts := ToDockerMounts(gcc.ExperimentConfig.BindMounts)
-	if gcc.ExperimentConfig.CheckpointStorage.SharedFSConfig != nil {
-		sharedFS := gcc.ExperimentConfig.CheckpointStorage.SharedFSConfig
-		mounts = append(mounts, mount.Mount{
-			Type:   mount.TypeBind,
-			Source: sharedFS.HostPath,
-			Target: model.DefaultSharedFSContainerPath,
-			BindOptions: &mount.BindOptions{
-				Propagation: model.DefaultSharedFSPropagation,
-			},
-		})
+func getUser(agentUserGroup *model.AgentUserGroup) string {
+	if agentUserGroup == nil {
+		return ""
 	}
-
-	return mounts
-}
-
-// GCArchives returns the additional files for gc as an archive.
-func GCArchives(t TaskSpec) []container.RunArchive {
-	gcc := *t.GCCheckpoints
-
-	return []container.RunArchive{
-		workDirArchive(gcc.AgentUserGroup),
-		injectUserArchive(gcc.AgentUserGroup),
-		wrapArchive(
-			archive.Archive{
-				gcc.AgentUserGroup.OwnedArchiveItem(
-					"experiment_config.json",
-					[]byte(jsonify(gcc.ExperimentConfig)),
-					0600,
-					tar.TypeReg,
-				),
-				gcc.AgentUserGroup.OwnedArchiveItem(
-					"checkpoints_to_delete.json",
-					[]byte(jsonify(gcc.ToDelete)),
-					0600,
-					tar.TypeReg,
-				),
-				gcc.AgentUserGroup.OwnedArchiveItem(
-					etc.GCCheckpointsEntrypointResource,
-					etc.MustStaticFile(etc.GCCheckpointsEntrypointResource),
-					0700,
-					tar.TypeReg,
-				),
-			},
-			ContainerWorkDir,
-		),
-		harnessArchive(t.HarnessPath, gcc.AgentUserGroup),
-	}
-}
-
-// GCCmd configures the entrypoint for GC tasks.
-func GCCmd() []string {
-	return []string{
-		filepath.Join(ContainerWorkDir, etc.GCCheckpointsEntrypointResource),
-		"--experiment-config",
-		"experiment_config.json",
-		"--delete",
-		"checkpoints_to_delete.json",
-	}
-}
-
-func gcCheckpoint(t TaskSpec) container.Spec {
-	gcc := *t.GCCheckpoints
-	user := getUser(gcc.AgentUserGroup)
-	deviceType := device.CPU
-	if len(t.Devices) > 0 {
-		deviceType = t.Devices[0].Type
-	}
-	envVarsMap := GCEnvVars()
-	envVars := make([]string, 0, len(envVarsMap))
-	for envVarKey, envVarValue := range envVarsMap {
-		envVars = append(envVars, fmt.Sprintf("%s=%s", envVarKey, envVarValue))
-	}
-	envVars = append(envVars, gcc.ExperimentConfig.Environment.EnvironmentVariables.For(deviceType)...)
-
-	return container.Spec{
-		PullSpec: container.PullSpec{
-			ForcePull: gcc.ExperimentConfig.Environment.ForcePullImage,
-			Registry:  gcc.ExperimentConfig.Environment.RegistryAuth,
-		},
-		RunSpec: container.RunSpec{
-			ContainerConfig: docker.Config{
-				Cmd: []string{
-					filepath.Join(ContainerWorkDir, etc.GCCheckpointsEntrypointResource),
-					"--experiment-config",
-					"experiment_config.json",
-					"--delete",
-					"checkpoints_to_delete.json",
-				},
-				User:       user,
-				Image:      gcc.ExperimentConfig.Environment.Image.For(deviceType),
-				Env:        envVars,
-				WorkingDir: ContainerWorkDir,
-			},
-			HostConfig: docker.HostConfig{
-				NetworkMode:     t.TaskContainerDefaults.NetworkMode,
-				Mounts:          GCDockerMounts(gcc),
-				PublishAllPorts: true,
-			},
-			Archives: GCArchives(t),
-		},
-	}
+	return fmt.Sprintf("%d:%d", agentUserGroup.UID, agentUserGroup.GID)
 }

--- a/master/pkg/tasks/task_spec.go
+++ b/master/pkg/tasks/task_spec.go
@@ -1,9 +1,18 @@
 package tasks
 
 import (
+	"archive/tar"
 	"crypto/tls"
 	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"strconv"
+	"strings"
 
+	"github.com/docker/docker/api/types/mount"
+
+	"github.com/determined-ai/determined/master/pkg/container"
+	"github.com/determined-ai/determined/master/pkg/etc"
 	"github.com/determined-ai/determined/master/pkg/workload"
 
 	"github.com/determined-ai/determined/master/pkg/archive"
@@ -11,47 +20,246 @@ import (
 	"github.com/determined-ai/determined/master/pkg/model"
 )
 
-// TaskSpec provides the necessary information for an agent to start a task.
+// InnerSpec defines the interface for a particular kind of task container.
+type InnerSpec interface {
+	// Archives returns the files to include in the container for this task (apart from the base files
+	// put into in all containers).
+	Archives(*model.AgentUserGroup) []container.RunArchive
+	// Description returns a brief description of this task.
+	Description() string
+	// Entrypoint returns the command and arguments to run in the container for this task.
+	Entrypoint() []string
+	// Environment returns the container environment for this task.
+	Environment(TaskSpec) model.Environment
+	// EnvVars returns the environment variables to set for this task (apart from the base ones set for
+	// all containers).
+	EnvVars(TaskSpec) map[string]string
+	// LoggingFields returns fields to include in each record of structured (i.e., Fluent Bit) logging.
+	LoggingFields() map[string]string
+	// Mounts returns the list of Docker mounts to use for this task.
+	Mounts() []mount.Mount
+	// ShmSize specifies the shared memory size to allocate to this task's container in bytes (0 for
+	// default behavior).
+	ShmSize() int64
+	// UseFluentLogging specifies whether to use Fluent Bit logging (as opposed to native logging).
+	UseFluentLogging() bool
+	// UseHostMode indicates whether host mode networking would be desirable for this task.
+	UseHostMode() bool
+}
+
+// This alias allows TaskSpec to privately embed the public InnerSpec so that it can reuse (some of)
+// its methods without directly providing access to the field to other packages.
+type inner = InnerSpec
+
+// TaskSpec provides the necessary information for a task to be run.
 type TaskSpec struct {
-	TaskID      string
-	ContainerID string
-	Devices     []device.Device
+	inner
+
+	TaskID         string
+	ContainerID    string
+	Devices        []device.Device
+	AgentUserGroup *model.AgentUserGroup
 
 	ClusterID             string
 	HarnessPath           string
 	TaskContainerDefaults model.TaskContainerDefaultsConfig
 	MasterCert            *tls.Certificate
-
-	StartCommand   *StartCommand
-	StartContainer *StartContainer
-	GCCheckpoints  *GCCheckpoints
 }
 
-// StartCommand is the information sent to an agent to start a command.
-type StartCommand struct {
-	// AgentUserGroup is the user and group to run this task as.
-	AgentUserGroup *model.AgentUserGroup
+// SetInner sets the concrete task represented by this spec.
+func (t *TaskSpec) SetInner(inner InnerSpec) {
+	t.inner = inner
+}
 
+func (t *TaskSpec) baseArchives() []container.RunArchive {
+	return []container.RunArchive{
+		workDirArchive(t.AgentUserGroup),
+		injectUserArchive(t.AgentUserGroup),
+		harnessArchive(t.HarnessPath, t.AgentUserGroup),
+		masterCertArchive(t.MasterCert),
+	}
+}
+
+func (t *TaskSpec) baseEnvVars() map[string]string {
+	e := map[string]string{
+		// PYTHONUSERBASE allows us to `pip install --user` into a location guaranteed to be owned by
+		// the user inside the container.
+		"PYTHONUSERBASE": userPythonBaseDir,
+		"DET_TASK_ID":    t.TaskID,
+	}
+	if t.TaskContainerDefaults.NCCLPortRange != "" {
+		e["NCCL_PORT_RANGE"] = t.TaskContainerDefaults.NCCLPortRange
+	}
+	if t.TaskContainerDefaults.NCCLPortRange != "" {
+		e["GLOO_PORT_RANGE"] = t.TaskContainerDefaults.NCCLPortRange
+	}
+
+	networkInterface := t.TaskContainerDefaults.DtrainNetworkInterface
+	if networkInterface == "" {
+		networkInterface = "DET_AUTO_DETECT_NETWORK_INTERFACE"
+	}
+	e["DET_TRIAL_RUNNER_NETWORK_INTERFACE"] = networkInterface
+
+	if t.MasterCert != nil {
+		e["DET_USE_TLS"] = "true"
+		e["DET_MASTER_CERT_FILE"] = certPath
+	}
+
+	return e
+}
+
+// Archives returns the archives that should be included in the container for this task.
+func (t *TaskSpec) Archives() []container.RunArchive {
+	return append(t.baseArchives(), t.inner.Archives(t.AgentUserGroup)...)
+}
+
+// Environment returns the container environment for this task.
+func (t *TaskSpec) Environment() model.Environment { return t.inner.Environment(*t) }
+
+// EnvVars returns the environment variables that should be set in the container for this task.
+func (t *TaskSpec) EnvVars() map[string]string {
+	e := t.baseEnvVars()
+	for k, v := range t.inner.EnvVars(*t) {
+		e[k] = v
+	}
+	return e
+}
+
+// StartCommand is a description of a task for running a command.
+type StartCommand struct {
 	Config          model.CommandConfig
 	UserFiles       archive.Archive
 	AdditionalFiles archive.Archive
 }
 
-// GCCheckpoints is the information sent to an agent to garbage collect a checkpoint.
-type GCCheckpoints struct {
-	// AgentUserGroup is the user and group to run this task as.
-	AgentUserGroup *model.AgentUserGroup
+// Archives implements InnerSpec.
+func (s StartCommand) Archives(u *model.AgentUserGroup) []container.RunArchive {
+	return []container.RunArchive{
+		wrapArchive(u.OwnArchive(s.UserFiles), ContainerWorkDir),
+		wrapArchive(s.AdditionalFiles, rootDir),
+	}
+}
 
+// Description implements InnerSpec.
+func (s StartCommand) Description() string { return "cmd" }
+
+// Entrypoint implements InnerSpec.
+func (s StartCommand) Entrypoint() []string { return s.Config.Entrypoint }
+
+// Environment implements InnerSpec.
+func (s StartCommand) Environment(TaskSpec) model.Environment { return s.Config.Environment }
+
+// EnvVars implements InnerSpec.
+func (s StartCommand) EnvVars(TaskSpec) map[string]string { return nil }
+
+// LoggingFields implements InnerSpec.
+func (s StartCommand) LoggingFields() map[string]string { return nil }
+
+// Mounts implements InnerSpec.
+func (s StartCommand) Mounts() []mount.Mount { return ToDockerMounts(s.Config.BindMounts) }
+
+// ShmSize implements InnerSpec.
+func (s StartCommand) ShmSize() int64 {
+	if shm := s.Config.Resources.ShmSize; shm != nil {
+		return int64(*shm)
+	}
+	return 0
+}
+
+// UseFluentLogging implements InnerSpec.
+func (s StartCommand) UseFluentLogging() bool { return false }
+
+// UseHostMode implements InnerSpec.
+func (s StartCommand) UseHostMode() bool { return false }
+
+// GCCheckpoints is a description of a task for running checkpoint GC.
+type GCCheckpoints struct {
 	ExperimentID     int
 	ExperimentConfig model.ExperimentConfig
 	ToDelete         json.RawMessage
 }
 
-// StartContainer is the information sent to an agent to start a container (trial).
-type StartContainer struct {
-	// AgentUserGroup is the user and group to run this task as.
-	AgentUserGroup *model.AgentUserGroup
+// Archives implements InnerSpec.
+func (g GCCheckpoints) Archives(u *model.AgentUserGroup) []container.RunArchive {
+	return []container.RunArchive{
+		wrapArchive(
+			archive.Archive{
+				u.OwnedArchiveItem(
+					"experiment_config.json",
+					[]byte(jsonify(g.ExperimentConfig)),
+					0600,
+					tar.TypeReg,
+				),
+				u.OwnedArchiveItem(
+					"checkpoints_to_delete.json",
+					[]byte(jsonify(g.ToDelete)),
+					0600,
+					tar.TypeReg,
+				),
+				u.OwnedArchiveItem(
+					etc.GCCheckpointsEntrypointResource,
+					etc.MustStaticFile(etc.GCCheckpointsEntrypointResource),
+					0700,
+					tar.TypeReg,
+				),
+			},
+			ContainerWorkDir,
+		),
+	}
+}
 
+// Description implements InnerSpec.
+func (g GCCheckpoints) Description() string { return "gc" }
+
+// Entrypoint implements InnerSpec.
+func (g GCCheckpoints) Entrypoint() []string {
+	return []string{
+		filepath.Join(ContainerWorkDir, etc.GCCheckpointsEntrypointResource),
+		"--experiment-config",
+		"experiment_config.json",
+		"--delete",
+		"checkpoints_to_delete.json",
+	}
+}
+
+// Environment implements InnerSpec.
+func (g GCCheckpoints) Environment(TaskSpec) model.Environment {
+	return g.ExperimentConfig.Environment
+}
+
+// EnvVars implements InnerSpec.
+func (g GCCheckpoints) EnvVars(TaskSpec) map[string]string { return nil }
+
+// LoggingFields implements InnerSpec.
+func (g GCCheckpoints) LoggingFields() map[string]string { return nil }
+
+// Mounts implements InnerSpec.
+func (g GCCheckpoints) Mounts() []mount.Mount {
+	mounts := ToDockerMounts(g.ExperimentConfig.BindMounts)
+	if fs := g.ExperimentConfig.CheckpointStorage.SharedFSConfig; fs != nil {
+		mounts = append(mounts, mount.Mount{
+			Type:   mount.TypeBind,
+			Source: fs.HostPath,
+			Target: model.DefaultSharedFSContainerPath,
+			BindOptions: &mount.BindOptions{
+				Propagation: model.DefaultSharedFSPropagation,
+			},
+		})
+	}
+	return mounts
+}
+
+// ShmSize implements InnerSpec.
+func (g GCCheckpoints) ShmSize() int64 { return 0 }
+
+// UseFluentLogging implements InnerSpec.
+func (g GCCheckpoints) UseFluentLogging() bool { return false }
+
+// UseHostMode implements InnerSpec.
+func (g GCCheckpoints) UseHostMode() bool { return false }
+
+// StartTrial is a description of a task for running a trial container.
+type StartTrial struct {
 	ExperimentConfig    model.ExperimentConfig
 	ModelDefinition     archive.Archive
 	HParams             map[string]interface{}
@@ -66,4 +274,127 @@ type StartContainer struct {
 	IsMultiAgent bool
 
 	Rank int
+}
+
+// Archives implements InnerSpec.
+func (s StartTrial) Archives(u *model.AgentUserGroup) []container.RunArchive {
+	return []container.RunArchive{wrapArchive(s.AdditionalFiles, rootDir),
+		wrapArchive(
+			archive.Archive{
+				u.OwnedArchiveItem(
+					"checkpoint.json",
+					[]byte(jsonify(s.LatestCheckpoint)),
+					0600,
+					tar.TypeReg,
+				),
+			},
+			trainDir,
+		),
+		wrapArchive(u.OwnArchive(s.ModelDefinition), ContainerWorkDir),
+	}
+}
+
+// Description implements InnerSpec.
+func (s StartTrial) Description() string {
+	return fmt.Sprintf(
+		"exp-%d-trial-%d-rank-%d",
+		s.InitialWorkload.ExperimentID,
+		s.InitialWorkload.TrialID,
+		s.Rank,
+	)
+}
+
+// Entrypoint implements InnerSpec.
+func (s StartTrial) Entrypoint() []string {
+	return []string{"/run/determined/train/entrypoint.sh"}
+}
+
+// Environment implements InnerSpec.
+func (s StartTrial) Environment(t TaskSpec) model.Environment {
+	env := s.ExperimentConfig.Environment
+	if env.Ports == nil {
+		env.Ports = make(map[string]int)
+	}
+	for i, port := range rendezvousPorts(trialUniquePortOffset(t.Devices)) {
+		env.Ports[fmt.Sprintf("trial-%d", i)] = port
+	}
+	return env
+}
+
+// EnvVars implements InnerSpec.
+func (s StartTrial) EnvVars(t TaskSpec) map[string]string {
+	portOffset := trialUniquePortOffset(t.Devices)
+	var portStrs []string
+	for _, port := range rendezvousPorts(portOffset) {
+		portStrs = append(portStrs, strconv.Itoa(port))
+	}
+	return map[string]string{
+		"DET_EXPERIMENT_ID":            fmt.Sprintf("%d", s.InitialWorkload.ExperimentID),
+		"DET_TRIAL_ID":                 fmt.Sprintf("%d", s.InitialWorkload.TrialID),
+		"DET_TRIAL_SEED":               fmt.Sprintf("%d", s.TrialSeed),
+		"DET_EXPERIMENT_CONFIG":        jsonify(s.ExperimentConfig),
+		"DET_HPARAMS":                  jsonify(s.HParams),
+		"DET_INITIAL_WORKLOAD":         jsonify(s.InitialWorkload),
+		"DET_LATEST_CHECKPOINT":        "/run/determined/train/checkpoint.json",
+		"DET_WORKLOAD_MANAGER_TYPE":    string(s.WorkloadManagerType),
+		"DET_RENDEZVOUS_PORTS":         strings.Join(portStrs, ","),
+		"DET_TRIAL_UNIQUE_PORT_OFFSET": strconv.Itoa(portOffset),
+	}
+}
+
+// LoggingFields implements InnerSpec.
+func (s StartTrial) LoggingFields() map[string]string {
+	return map[string]string{
+		"trial_id": strconv.Itoa(s.InitialWorkload.TrialID),
+	}
+}
+
+// Mounts implements InnerSpec.
+func (s StartTrial) Mounts() []mount.Mount {
+	mounts := ToDockerMounts(s.ExperimentConfig.BindMounts)
+	addMount := func(source, target string, bindOpts *mount.BindOptions) {
+		mounts = append(mounts, mount.Mount{
+			Type: mount.TypeBind, Source: source, Target: target, BindOptions: bindOpts,
+		})
+	}
+
+	if c := s.ExperimentConfig.CheckpointStorage.SharedFSConfig; c != nil {
+		addMount(
+			c.HostPath,
+			model.DefaultSharedFSContainerPath,
+			&mount.BindOptions{Propagation: model.DefaultSharedFSPropagation},
+		)
+	}
+
+	if c := s.ExperimentConfig.DataLayer.SharedFSConfig; c != nil {
+		if c.HostStoragePath != nil && c.ContainerStoragePath != nil {
+			addMount(*c.HostStoragePath, *c.ContainerStoragePath, nil)
+		}
+	}
+	if c := s.ExperimentConfig.DataLayer.S3Config; c != nil {
+		if c.LocalCacheHostPath != nil && c.LocalCacheContainerPath != nil {
+			addMount(*c.LocalCacheHostPath, *c.LocalCacheContainerPath, nil)
+		}
+	}
+	if c := s.ExperimentConfig.DataLayer.GCSConfig; c != nil {
+		if c.LocalCacheHostPath != nil && c.LocalCacheContainerPath != nil {
+			addMount(*c.LocalCacheHostPath, *c.LocalCacheContainerPath, nil)
+		}
+	}
+
+	return mounts
+}
+
+// UseFluentLogging implements InnerSpec.
+func (s StartTrial) UseFluentLogging() bool { return true }
+
+// UseHostMode implements InnerSpec.
+func (s StartTrial) UseHostMode() bool { return s.IsMultiAgent }
+
+// ShmSize implements InnerSpec.
+func (s StartTrial) ShmSize() int64 {
+	if shm := s.ExperimentConfig.Resources.ShmSize; shm != nil {
+		return int64(*shm)
+	}
+	return 0
 }


### PR DESCRIPTION
## Description

For a long time, we've had largely separate code paths with a bunch of
duplication to handle each of the three top-level task types (trials,
checkpoint GC, and commands). That started with the agent code and
transferred over into Kubernetes as well. This change unifies the code
paths to operate on a generic task spec type that has methods providing
the parameters that differ between tasks; everything only operates on
that type generically.

`TaskSpec`, rather than containing a pseudo-union (three pointers,
exactly one of which is expected to be non-nil), now holds one instance
of a new interface that is implemented by a concrete struct type for
each of the task types.

## Test Plan

- run various tasks with both agents and Kubernetes and check that ports are forwarded, logs come through, etc.

## Commentary (optional)

It's not 100% thoroughly tested as I write this, but it's pretty much working and I figure the overall idea is enough to start on for reviewing.

I called the interface type `InnerSpec`, but I'm sure there's a better name I can't think of.
