### PR TITLE
chore: hack tensorboard support to include custom metrics [DET-4697]

### DIFF
--- a/e2e_tests/tests/fixtures/metric_maker/metric_maker.py
+++ b/e2e_tests/tests/fixtures/metric_maker/metric_maker.py
@@ -94,13 +94,17 @@ class MetricMaker(det.CallbackTrialController):
         # Update the overall base value for the trial..
         self.value += self.gain_per_batch * num_batches
 
-        return {"metrics": {"batch_metrics": batch_metrics, "num_inputs": num_batches}}
+        return {
+            "metrics": det.util.make_metrics(num_batches, batch_metrics),
+            "stop_requested": self.context.get_stop_requested(),
+        }
 
     def compute_validation_metrics(self, step_id: int) -> Dict[str, Any]:
         return {
             "metrics": {
                 "validation_metrics": structure_to_metrics(self.value, self.validation_structure)
-            }
+            },
+            "stop_requested": self.context.get_stop_requested(),
         }
 
     def set_random_seed(self, trial_seed) -> None:

--- a/harness/determined/callback.py
+++ b/harness/determined/callback.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List
+from typing import Any, Dict
 
 
 class Callback(object):
@@ -21,7 +21,7 @@ class Callback(object):
         step_id: int,
         num_batches: int,
         total_batches_processed: int,
-        metrics: List[Dict[str, Any]],
+        metrics: Dict[str, Any],
     ) -> None:
         """
         Executed at the end of a training step.

--- a/harness/determined/layers/_workload_manager.py
+++ b/harness/determined/layers/_workload_manager.py
@@ -152,7 +152,7 @@ class _TrialWorkloadManager(WorkloadManager):
 
             for callback in self.callbacks:
                 callback.on_train_step_end(
-                    wkld.step_id, wkld.num_batches, wkld.total_batches_processed, batch_metrics
+                    wkld.step_id, wkld.num_batches, wkld.total_batches_processed, metrics
                 )
 
             self.tensorboard_mgr.sync()


### PR DESCRIPTION
## Description

chore: hack tensorboard support to include custom metrics [DET-4697]

Our Tensorboard support is still based on the totally outdated Callback
class (BatchMetricWriter is the only remaining implementation of
Callback).

The bug was that PyTorch custom reducers for training metrics did not
show up in Tensorboard at all.  This is because they are only set in
avg_metrics, and the Callback interface never used to pass avg_metrics.

Since there is only one implementation of Callback, we can just change
pass batch_metrics and avg_metrics to allow BatchMetricWriter to detect
these custom reduced metrics.  It would be preferable to break the
Tensorboard logic out of the WorkloadManager, but this hack is easy
enough to land in time for the feature release of PyTorch custom
reducers.

## Test Plan

Tested manually.

[DET-4697]: https://determinedai.atlassian.net/browse/DET-4697