### PR TITLE
fix: don't request GPUs for Fluent Bit container

### DIFF
--- a/master/internal/kubernetes/spec.go
+++ b/master/internal/kubernetes/spec.go
@@ -332,7 +332,6 @@ func (p *pod) createPodSpecForTrial(ctx *actor.Context) error {
 		Image:           "fluent/fluent-bit:1.6",
 		ImagePullPolicy: configureImagePullPolicy(exp.ExperimentConfig.Environment),
 		SecurityContext: configureSecurityContext(exp.AgentUserGroup),
-		Resources:       p.configureResourcesRequirements(),
 		VolumeMounts:    loggingMounts,
 		WorkingDir:      fluentBaseDir,
 	}


### PR DESCRIPTION
## Description

The Fluent Bit Kubernetes container config was largely copied from the
main container one, and so I accidentally included a duplicate request
for GPUs, meaning that trial pods could never be scheduled.

## Test Plan

- [x] [run GKE tests](https://app.circleci.com/pipelines/github/determined-ai/determined?branch=fluent-resources) (still in progress, but experiments are running successfully when they were just hanging before)
