### PR TITLE
docs: fix incorrect field name in docker registry creds docs

### DIFF
--- a/docs/reference/cluster-config.txt
+++ b/docs/reference/cluster-config.txt
@@ -365,7 +365,7 @@ The master supports the following configuration settings:
 
       -  ``username`` (required)
       -  ``password`` (required)
-      -  ``server`` (optional)
+      -  ``serveraddress`` (optional)
       -  ``email`` (optional)
 
 -  ``root``: Specifies the root directory of the state files. Defaults


### PR DESCRIPTION
This came up in the oss-community slack a while back, had a note to fix it hanging around.