### PR TITLE
ci: increase resource class for packaging steps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -715,6 +715,7 @@ jobs:
       - image: cimg/go:1.15
         environment:
           GO111MODULE: "on"
+    resource_class: medium+
     steps:
       - checkout
       - attach_workspace:
@@ -741,6 +742,7 @@ jobs:
       - image: cimg/go:1.15
         environment:
           GO111MODULE: "on"
+    resource_class: medium+
     steps:
       - checkout
       - attach_workspace:
@@ -759,6 +761,7 @@ jobs:
       - image: cimg/go:1.15
         environment:
           GO111MODULE: "on"
+    resource_class: medium+
     steps:
       - checkout
       - attach_workspace:
@@ -777,6 +780,7 @@ jobs:
       - image: cimg/go:1.15
         environment:
           GO111MODULE: "on"
+    resource_class: medium+
     steps:
       - checkout
       - attach_workspace:


### PR DESCRIPTION
## Description

We've occasionally seen CI failures due to what looks like an OOM kill
of the Go compiler during the GoReleaser packaging step. This bumps up
the memory available to that step from 4 GB to 6 GB [1], hopefully
preventing that failure from continuing to happen.

[1] https://circleci.com/docs/2.0/executor-types/#available-docker-resource-classes

## Test Plan

Well, if the CI on this PR doesn't immediately fail, I'm pretty sure we're in no worse a state than we were before.
