### PR TITLE
chore: remove the deprecated PyTorch API [DET-3262]

### DIFF
--- a/docs/reference/api/pytorch.txt
+++ b/docs/reference/api/pytorch.txt
@@ -10,7 +10,7 @@
 
 .. autoclass:: determined.pytorch.PyTorchTrial
    :members:
-   :exclude-members: trial_controller_class, trial_context_class, build_model, optimizer, create_lr_scheduler
+   :exclude-members: trial_controller_class, trial_context_class
    :inherited-members:
    :member-order: bysource
    :special-members: __init__
@@ -92,7 +92,6 @@ Trial Context
 
 .. autoclass:: determined.pytorch.PyTorchTrialContext
    :members:
-   :exclude-members: get_model, get_optimizer, get_lr_scheduler
 
 .. autoclass:: determined.pytorch.PyTorchExperimentalContext
    :members:
@@ -130,44 +129,6 @@ To execute arbitrary Python code during the lifecycle of a
 
 .. autoclass:: determined.pytorch.PyTorchCallback
    :members:
-
-.. _migration-guide-flexible-primitives:
-
-*************************************
- Migration from deprecated interface
-*************************************
-
-The current PyTorch interface is designed to be flexible and to support
-multiple models, optimizers, and LR schedulers. The ability to run
-forward and backward passes in an arbitrary order affords users much
-greater flexibility compared to the `deprecated approach
-<https://docs.determined.ai/0.12.12/reference/api/pytorch.html>`__ used
-in Determined 0.12.12 and earlier.
-
-To migrate from the previous PyTorch API, please change the following
-places in your code:
-
-#. Wrap models, optimizers, and LR schedulers in the :meth:`__init__`
-   method with the ``wrap_model``, ``wrap_optimizer``, and
-   ``wrap_lr_scheduler`` methods that are provided by
-   :class:`PyTorchTrialContext
-   <determined.pytorch.PyTorchTrialContext>`. At the same time, remove
-   the implementation of :meth:`build_model`, :meth:`optimizer`,
-   :meth:`create_lr_scheduler`.
-
-#. If using automatic mixed precision (AMP), configure Apex AMP in the
-   ``__init__`` method with the :meth:`context.configure_apex_amp
-   <determined.pytorch.PyTorchTrialContext>` method. At the same time,
-   remove the experiment configuration field
-   ``optimizations.mixed_precision``.
-
-#. Run backward passes on losses and step optimizers in the
-   :meth:`train_batch` method with the ``backward`` and
-   ``step_optimizer`` methods provided by :class:`PyTorchTrialContext
-   <determined.pytorch.PyTorchTrialContext>`. Clip gradients by passing
-   a function to the ``clip_grads`` argument of ``step_optimizer`` while
-   removing the ``PyTorchCallback`` counterpart in the
-   :meth:`build_callbacks` method.
 
 **********
  Examples

--- a/docs/release-notes.txt
+++ b/docs/release-notes.txt
@@ -43,9 +43,9 @@ Version 0.13.13
 **Deprecated Features**
 
 -  The old PyTorch API was deprecated in 0.12.13 and will be removed in
-   the next release. See the :ref:`migration guide
-   <migration-guide-flexible-primitives>` for details on updating your
-   PyTorch model code to use the new API.
+   the next release. See the `migration guide
+   <https://docs.determined.ai/0.13.13/reference/api/pytorch.html#migration-from-deprecated-interface>`_
+   for details on updating your PyTorch model code to use the new API.
 
 Version 0.13.12
 ===============
@@ -993,10 +993,10 @@ Version 0.12.13
    more flexible and supports deep learning experiments that use
    multiple models, optimizers, and LR schedulers. The old API is still
    supported but is now deprecated and will be removed in a future
-   release. See the :ref:`migration guide
-   <migration-guide-flexible-primitives>` for details on updating your
-   PyTorch model code. *Deprecated methods will be supported until at
-   least the next minor release.*
+   release. See the `Pytorch migration guide
+   <https://docs.determined.ai/0.12.13/reference/api/pytorch.html#migration-from-deprecated-interface>`_
+   for details on updating your PyTorch model code. *Deprecated methods
+   will be supported until at least the next minor release.*
 
    -  The new API supports PyTorch code that uses multiple models,
       optimizers, and LR schedulers. In your trial class, you should

--- a/docs/release-notes/1784-remove-deprecated-pytorch-api.txt
+++ b/docs/release-notes/1784-remove-deprecated-pytorch-api.txt
@@ -1,0 +1,21 @@
+:orphan:
+
+**Removed Features**
+
+-  Trial API: The old Pytorch APIs are removed, including:
+
+   -  the method ``build_model``, ``optimizer``, and
+      ``create_lr_scheduler`` in
+      :class:`~determined.pytorch.PyTorchTrial`;
+
+   -  the callback ``on_before_optimizer_step``,
+      ``optimizations.mixed_precision`` in the experiment configuration;
+
+   -  the ``model`` arguments to
+      :meth:`~determined.pytorch.PyTorchTrial.train_batch`,
+      :meth:`~determined.pytorch.PyTorchTrial.evaluate_batch`, and
+      :meth:`~determined.pytorch.PyTorchTrial.evaluate_full_dataset`.
+
+   The experiments that are forked from those which use the old Pytorch
+   APIs cannot run. However, the checkpoints from the old experiments
+   will still be supported.

--- a/harness/determined/_experiment_config.py
+++ b/harness/determined/_experiment_config.py
@@ -17,10 +17,6 @@ class ExperimentConfig(dict):
     def native_parallel_enabled(self) -> bool:
         return bool(self["resources"]["native_parallel"])
 
-    # TODO(DET-3262): remove this backward compatibility.
-    def mixed_precision_enabled(self) -> bool:
-        return bool(self["optimizations"]["mixed_precision"] != "O0")
-
     def averaging_training_metrics_enabled(self) -> bool:
         return bool(self["optimizations"]["average_training_metrics"])
 

--- a/harness/determined/_trial_controller.py
+++ b/harness/determined/_trial_controller.py
@@ -111,13 +111,6 @@ class TrialController(metaclass=abc.ABCMeta):
         pass
 
     def _check_if_trial_supports_configurations(self, env: det.EnvContext) -> None:
-        if self.env.experiment_config.mixed_precision_enabled():
-            check.true(
-                self.supports_mixed_precision(),
-                "Mixed precision training is not supported for this framework interface. "
-                'Please set `mixed_precision = "O0"`.',
-            )
-
         if env.experiment_config.averaging_training_metrics_enabled():
             check.true(self.supports_averaging_training_metrics())
 

--- a/harness/determined/errors.py
+++ b/harness/determined/errors.py
@@ -36,6 +36,15 @@ class InvalidConfigurationException(InvalidExperimentException):
         super().__init__(f"Invalid configuration ({config}): {message}.")
 
 
+class InvalidCheckpointException(Exception):
+    """
+    InvalidCheckpointException is used if a checkpoint is invalid.
+    """
+
+    def __init__(self) -> None:
+        super().__init__("Invalid checkpoint.")
+
+
 class StopLoadingImplementation(Exception):
     """
     Exception that intercepts loading the user code.

--- a/harness/determined/pytorch/__init__.py
+++ b/harness/determined/pytorch/__init__.py
@@ -9,7 +9,7 @@ from determined.pytorch._data import (
     data_length,
     to_device,
 )
-from determined.pytorch._callback import PyTorchCallback, ClipGradsL2Norm, ClipGradsL2Value
+from determined.pytorch._callback import PyTorchCallback
 from determined.pytorch._lr_scheduler import LRScheduler
 from determined.pytorch._reducer import MetricReducer, _SimpleReducer, Reducer, _reduce_metrics
 from determined.pytorch._experimental import PyTorchExperimentalContext

--- a/harness/determined/pytorch/_callback.py
+++ b/harness/determined/pytorch/_callback.py
@@ -1,7 +1,4 @@
-import logging
-from typing import Any, Dict, Iterator
-
-import torch
+from typing import Any, Dict
 
 
 class PyTorchCallback:
@@ -21,19 +18,6 @@ class PyTorchCallback:
         :meth:`on_checkpoint_end`). To configure a callback implementation to execute on a subset of
         GPUs, please condition your implementation on ``trial.context.distributed.get_rank()``.
     """
-
-    # TODO(DET-3262): remove this backward compatibility of old interface.
-    def on_before_optimizer_step(self, parameters: Iterator) -> None:
-        """
-        Run before every ``optimizer.step()``.  For multi-GPU training, executes
-        after gradient updates have been communicated. Typically used to perform
-        gradient clipping.
-
-        .. warning::
-            This is deprecated. Please pass a function into
-            ``context.optimizer.step(clip_gradients=...)`` if you want to clip gradients.
-        """
-        pass
 
     def on_validation_start(self) -> None:
         """
@@ -88,50 +72,3 @@ class PyTorchCallback:
         Load the state of this using the deserialized ``state_dict``.
         """
         pass
-
-
-# TODO(DET-3262): remove this backward compatibility of old interface.
-class ClipGradsL2Norm(PyTorchCallback):
-    """Callback that performs gradient clipping using
-    `L2 Norm <https://pytorch.org/docs/stable/nn.html#clip-grad-norm>`_.
-
-    .. warning::
-
-        This is deprecated. Please use clip_grads argument in
-        ``PytorchTrialContext.step_optimizer(optimizer, clip_grads=...)``
-        for clipping the gradients.
-    """
-
-    def __init__(self, clip_value: float) -> None:
-        logging.warning(
-            "The ClipGradsL2Norm callback is deprecated. Please use clip_grads "
-            "argument in PytorchTrialContext.step_optimizer(optimizer, clip_grads=...) "
-            "for clipping the gradients."
-        )
-        self._clip_value = clip_value
-
-    def on_before_optimizer_step(self, parameters: Iterator) -> None:
-        torch.nn.utils.clip_grad_norm_(parameters, self._clip_value)  # type: ignore
-
-
-# TODO(DET-3262): remove this backward compatibility of old interface.
-class ClipGradsL2Value(PyTorchCallback):
-    """Callback that performs gradient clipping using
-    `L2 Value <https://pytorch.org/docs/stable/nn.html#clip-grad-value>`_.
-
-    .. warning::
-        This is deprecated. Please use clip_grads argument in
-        ``PytorchTrialContext.step_optimizer(optimizer, clip_grads=...)``
-        for clipping the gradients.
-    """
-
-    def __init__(self, clip_value: float) -> None:
-        logging.warning(
-            "The ClipGradsL2Value callback is deprecated. Please use clip_grads "
-            "argument in PytorchTrialContext.step_optimizer(optimizer, clip_grads=...) "
-            "for clipping the gradients."
-        )
-        self._clip_value = clip_value
-
-    def on_before_optimizer_step(self, parameters: Iterator) -> None:
-        torch.nn.utils.clip_grad_value_(parameters, self._clip_value)  # type: ignore

--- a/harness/determined/pytorch/_pytorch_context.py
+++ b/harness/determined/pytorch/_pytorch_context.py
@@ -64,69 +64,6 @@ class PyTorchTrialContext(det.TrialContext):
 
         self.experimental = pytorch.PyTorchExperimentalContext()
 
-    def get_model(self) -> torch.nn.Module:
-        """
-        Get the model associated with the trial. This function should not be
-        called from:
-
-            * ``__init__``
-            * ``build_model()``
-
-        .. warning::
-            This is deprecated.
-        """
-        # TODO(DET-3262): remove this backward compatibility of old interface.
-        logging.warning(
-            "PyTorchTrialContext.get_model is deprecated. "
-            "Please directly use the model wrapped by context.wrap_model()."
-        )
-        check.len_eq(self.models, 1)
-        return self.models[0]
-
-    def get_optimizer(self) -> torch.optim.Optimizer:  # type: ignore
-        """
-        Get the optimizer associated with the trial. This function should not be
-        called from:
-
-            * ``__init__``
-            * ``build_model()``
-            * ``optimizer()``
-
-
-        .. warning::
-            This is deprecated.
-        """
-        # TODO(DET-3262): remove this backward compatibility of old interface.
-        logging.warning(
-            "PyTorchTrialContext.get_optimizer is deprecated. "
-            "Please directly use the model wrapped by context.wrap_optimizer()."
-        )
-        check.len_eq(self.optimizers, 1)
-        return self.optimizers[0]
-
-    def get_lr_scheduler(self) -> Optional[pytorch.LRScheduler]:
-        """
-        Get the scheduler associated with the trial, if one is defined. This
-        function should not be called from:
-
-            * ``__init__``
-            * ``build_model()``
-            * ``optimizer()``
-            * ``create_lr_scheduler()``
-
-        .. warning::
-            This is deprecated.
-        """
-        # TODO(DET-3262): remove this backward compatibility of old interface.
-        logging.warning(
-            "PyTorchTrialContext.get_lr_scheduler is deprecated. "
-            "Please directly use the model wrapped by context.wrap_lr_scheduler()."
-        )
-        check.lt_eq(len(self.lr_schedulers), 1)
-        if len(self.lr_schedulers) == 1:
-            return self.lr_schedulers[0]
-        return None
-
     def wrap_model(self, model: torch.nn.Module) -> torch.nn.Module:
         """Returns a wrapped model."""
 

--- a/harness/determined/util.py
+++ b/harness/determined/util.py
@@ -37,6 +37,13 @@ def is_overridden(full_method: Any, parent_class: Any) -> bool:
     return False
 
 
+def get_member_func(obj: Any, func_name: str) -> Any:
+    member = getattr(obj, func_name, None)
+    if callable(member):
+        return member
+    return None
+
+
 def _list_to_dict(list_of_dicts: List[Dict[str, Any]]) -> Dict[str, List[Any]]:
     """Transpose list of dicts to dict of lists."""
     dict_of_lists = collections.defaultdict(list)  # type: Dict[str, List[Any]]


### PR DESCRIPTION
## Description

BREAKING CHANGE: remove the deprecated Pytorch API.

## Test Plan

N/A


## Commentary (optional)

N/A

## Checklist

- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
