### PR TITLE
chore: deal gracefully with missing values in trials-sample [DET-4771]

### DIFF
--- a/master/internal/db/postgres_experiments.go
+++ b/master/internal/db/postgres_experiments.go
@@ -360,10 +360,10 @@ WHERE t.id=$2
   AND (prior_batches_processed + num_batches) <= $4
   AND s.end_time > $5
 ORDER BY batches;`, metricName, trialID, startBatches, endBatches, startTime)
-	defer rows.Close()
 	if err != nil {
 		return nil, maxEndTime, errors.Wrapf(err, "failed to get metrics to sample for experiment")
 	}
+	defer rows.Close()
 	metricSeries, maxEndTime = scanMetricsSeries(metricSeries, rows)
 	return metricSeries, maxEndTime, nil
 }
@@ -387,10 +387,10 @@ WHERE t.id=$2
   AND (prior_batches_processed + num_batches) <= $4
   AND v.end_time > $5
 ORDER BY batches;`, metricName, trialID, startBatches, endBatches, startTime)
-	defer rows.Close()
 	if err != nil {
 		return nil, maxEndTime, errors.Wrapf(err, "failed to get metrics to sample for experiment")
 	}
+	defer rows.Close()
 	metricSeries, maxEndTime = scanMetricsSeries(metricSeries, rows)
 	return metricSeries, maxEndTime, nil
 }

--- a/master/internal/db/postgres_experiments.go
+++ b/master/internal/db/postgres_experiments.go
@@ -359,6 +359,7 @@ WHERE t.id=$2
   AND (prior_batches_processed + num_batches) >= $3
   AND (prior_batches_processed + num_batches) <= $4
   AND s.end_time > $5
+  AND s.metrics->'avg_metrics'->$1 IS NOT NULL
 ORDER BY batches;`, metricName, trialID, startBatches, endBatches, startTime)
 	if err != nil {
 		return nil, maxEndTime, errors.Wrapf(err, "failed to get metrics to sample for experiment")
@@ -386,6 +387,7 @@ WHERE t.id=$2
   AND (prior_batches_processed + num_batches) >= $3
   AND (prior_batches_processed + num_batches) <= $4
   AND v.end_time > $5
+  AND v.metrics->'validation_metrics'->$1 IS NOT NULL
 ORDER BY batches;`, metricName, trialID, startBatches, endBatches, startTime)
 	if err != nil {
 		return nil, maxEndTime, errors.Wrapf(err, "failed to get metrics to sample for experiment")


### PR DESCRIPTION
## Description

Caleb hit an issue working with the trial-sample endpoint, where if you supply a non-existent metric it breaks. Which isn't terribly surprising, except it breaks in the SQL scan phase because the JSON functions in the query just return empty columns. This is complicated because in the near future we also want to deal gracefully with sparse metrics (i.e. a metric is real but it isn't recorded every step) and maybe later things like nested metrics. One way or another we can't use the default SQL scanner anyway, so here I use my own and deal gracefully with missing values (and if you specify a metric that doesn't exist, you get no results - we can't 100% reliably distinguish between that and a sparse metric.

## Test Plan

Ran through Caleb's initial test with both real and fake metrics, and reran the integration tests for these API