### PR TITLE
feat: det-deploy aws list [DET-4607]

### DIFF
--- a/deploy/determined_deploy/aws/constants.py
+++ b/deploy/determined_deploy/aws/constants.py
@@ -11,6 +11,8 @@ class defaults:
     DEPLOYMENT_TYPE = deployment_types.SIMPLE
     DB_PASSWORD = "postgres"
     REGION = "us-west-2"
+    STACK_TAG_KEY = "managed-by"
+    STACK_TAG_VALUE = "determined"
 
 
 class cloudformation:

--- a/docs/release-notes/1790-det-deploy-aws-list.txt
+++ b/docs/release-notes/1790-det-deploy-aws-list.txt
@@ -1,0 +1,9 @@
+:orphan:
+
+**Improvements**
+
+-  deployment: support the deployment tool command ```det-deploy aws
+   list``. It lists all the cloudFormation stacks that are managed by
+   det-deploy aws. It recognizes the Determined stacks by finding if
+   there exists a tag pair ``managed-by:determined``. It does not list
+   out the stacks that are spun up by previous versions of det-deploy.


### PR DESCRIPTION
## Description

Support det-deploy aws list. It will list all the cloudFormation stacks that are managed by det-deploy aws. It is based on using the tags of cloudFormation stack. It uses constant tag pair `managed-by:determined` for identifying which stacks are spun up by det-deploy. It won't list the stacks that are spun up by previous versions of det-deploy.


## Test Plan

Manually test it.


## Commentary (optional)

N/A


## Checklist

- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
