### PR TITLE
chore: update trials-sample endpoint to support a single trial experiments [DET-4688]

### DIFF
--- a/master/internal/api_experiment.go
+++ b/master/internal/api_experiment.go
@@ -797,7 +797,7 @@ func (a *apiServer) fetchTrialSample(trialID int, metricName string, metricType 
 
 	if _, current := currentTrials[trialID]; !current {
 		var trialConfig *model.Trial
-		trialConfig, err = a.m.db.TrialByID(int(trialID))
+		trialConfig, err = a.m.db.TrialByID(trialID)
 		if err != nil {
 			return nil, errors.Wrapf(err, "error fetching trial metadata")
 		}

--- a/master/internal/api_experiment.go
+++ b/master/internal/api_experiment.go
@@ -742,11 +742,12 @@ func (a *apiServer) TrialsSnapshot(req *apiv1.TrialsSnapshotRequest,
 }
 
 func (a *apiServer) topTrials(experimentID int, maxTrials int, s model.SearcherConfig) (
-	trials []int32, err error) {
+	trials []int, err error) {
 	type Ranking int
 	const (
-		ByMetricOfInterest Ranking = 1
-		ByTrainingLength   Ranking = 2
+		ByMetricOfInterest Ranking = iota
+		ByTrainingLength   Ranking = iota
+		NoFilter           Ranking = iota
 	)
 	var ranking Ranking
 
@@ -766,7 +767,7 @@ func (a *apiServer) topTrials(experimentID int, maxTrials int, s model.SearcherC
 	case s.AdaptiveASHAConfig != nil:
 		ranking = ByTrainingLength
 	case s.SingleConfig != nil:
-		return nil, errors.New("single-trial experiments are not supported for trial sampling")
+		ranking = NoFilter
 	case s.PBTConfig != nil:
 		return nil, errors.New("population-based training not supported for trial sampling")
 	default:
@@ -777,20 +778,22 @@ func (a *apiServer) topTrials(experimentID int, maxTrials int, s model.SearcherC
 		return a.m.db.TopTrialsByMetric(experimentID, maxTrials, s.Metric, s.SmallerIsBetter)
 	case ByTrainingLength:
 		return a.m.db.TopTrialsByTrainingLength(experimentID, maxTrials, s.Metric, s.SmallerIsBetter)
+	case NoFilter:
+		return a.m.db.TrialIDsByExperiment(experimentID)
 	default:
 		panic("Invalid state in trial sampling")
 	}
 }
 
-func (a *apiServer) fetchTrialSample(trialID int32, metricName string, metricType apiv1.MetricType,
-	maxDatapoints int, startBatches int, endBatches int, currentTrials map[int32]bool,
-	trialCursors map[int32]time.Time) (*apiv1.TrialsSampleResponse_Trial, error) {
+func (a *apiServer) fetchTrialSample(trialID int, metricName string, metricType apiv1.MetricType,
+	maxDatapoints int, startBatches int, endBatches int, currentTrials map[int]bool,
+	trialCursors map[int]time.Time) (*apiv1.TrialsSampleResponse_Trial, error) {
 	var metricSeries []lttb.Point
 	var endTime time.Time
 	var zeroTime time.Time
 	var err error
 	var trial apiv1.TrialsSampleResponse_Trial
-	trial.TrialId = trialID
+	trial.TrialId = int32(trialID)
 
 	if _, current := currentTrials[trialID]; !current {
 		var trialConfig *model.Trial
@@ -875,15 +878,15 @@ func (a *apiServer) TrialsSample(req *apiv1.TrialsSampleRequest,
 	}
 	searcherConfig := config.Searcher
 
-	trialCursors := make(map[int32]time.Time)
-	currentTrials := make(map[int32]bool)
+	trialCursors := make(map[int]time.Time)
+	currentTrials := make(map[int]bool)
 	for {
 		var response apiv1.TrialsSampleResponse
 		var promotedTrials []int32
 		var demotedTrials []int32
 		var trials []*apiv1.TrialsSampleResponse_Trial
 
-		seenThisRound := make(map[int32]bool)
+		seenThisRound := make(map[int]bool)
 
 		trialIDs, err := a.topTrials(experimentID, maxTrials, searcherConfig)
 		if err != nil {
@@ -898,7 +901,7 @@ func (a *apiServer) TrialsSample(req *apiv1.TrialsSampleRequest,
 			}
 
 			if _, current := currentTrials[trialID]; !current {
-				promotedTrials = append(promotedTrials, trialID)
+				promotedTrials = append(promotedTrials, int32(trialID))
 				currentTrials[trialID] = true
 			}
 			seenThisRound[trialID] = true
@@ -907,13 +910,13 @@ func (a *apiServer) TrialsSample(req *apiv1.TrialsSampleRequest,
 		}
 		for oldTrial := range currentTrials {
 			if !seenThisRound[oldTrial] {
-				demotedTrials = append(demotedTrials, oldTrial)
+				demotedTrials = append(demotedTrials, int32(oldTrial))
 				delete(trialCursors, oldTrial)
 			}
 		}
 		// Deletes from currentTrials have to happen when not looping over currentTrials
 		for _, oldTrial := range demotedTrials {
-			delete(currentTrials, oldTrial)
+			delete(currentTrials, int(oldTrial))
 		}
 
 		response.Trials = trials

--- a/master/internal/db/postgres.go
+++ b/master/internal/db/postgres.go
@@ -1174,12 +1174,12 @@ RETURNING id`, trial)
 }
 
 // TrialIDsByExperiment returns the trial IDs from a given experiment.
-func (db *PgDB) TrialIDsByExperiment(experimentId int) (trial_ids []int, err error) {
-	err = db.sql.Select(&trial_ids, `SELECT id FROM trials WHERE experiment_id=$1`, experimentId)
+func (db *PgDB) TrialIDsByExperiment(experimentID int) (trialIDs []int, err error) {
+	err = db.sql.Select(&trialIDs, `SELECT id FROM trials WHERE experiment_id=$1`, experimentID)
 	if err != nil {
 		err = errors.Wrapf(err, "error querying trial ids for experiment")
 	}
-	return trial_ids, err
+	return trialIDs, err
 }
 
 // TrialByID looks up a trial by ID, returning an error if none exists.

--- a/master/internal/db/postgres.go
+++ b/master/internal/db/postgres.go
@@ -1173,6 +1173,7 @@ RETURNING id`, trial)
 	return nil
 }
 
+// TrialIDsByExperiment returns the trial IDs from a given experiment.
 func (db *PgDB) TrialIDsByExperiment(experiment_id int) (trial_ids []int, err error) {
 	err = db.sql.Select(&trial_ids, `SELECT id FROM trials WHERE experiment_id=$1`, experiment_id)
 	if err != nil {

--- a/master/internal/db/postgres.go
+++ b/master/internal/db/postgres.go
@@ -1174,8 +1174,8 @@ RETURNING id`, trial)
 }
 
 // TrialIDsByExperiment returns the trial IDs from a given experiment.
-func (db *PgDB) TrialIDsByExperiment(experiment_id int) (trial_ids []int, err error) {
-	err = db.sql.Select(&trial_ids, `SELECT id FROM trials WHERE experiment_id=$1`, experiment_id)
+func (db *PgDB) TrialIDsByExperiment(experimentId int) (trial_ids []int, err error) {
+	err = db.sql.Select(&trial_ids, `SELECT id FROM trials WHERE experiment_id=$1`, experimentId)
 	if err != nil {
 		err = errors.Wrapf(err, "error querying trial ids for experiment")
 	}

--- a/master/internal/db/postgres.go
+++ b/master/internal/db/postgres.go
@@ -1173,6 +1173,14 @@ RETURNING id`, trial)
 	return nil
 }
 
+func (db *PgDB) TrialIDsByExperiment(experiment_id int) (trial_ids []int, err error) {
+	err = db.sql.Select(&trial_ids, `SELECT id FROM trials WHERE experiment_id=$1`, experiment_id)
+	if err != nil {
+		err = errors.Wrapf(err, "error querying trial ids for experiment")
+	}
+	return trial_ids, err
+}
+
 // TrialByID looks up a trial by ID, returning an error if none exists.
 func (db *PgDB) TrialByID(id int) (*model.Trial, error) {
 	trial := model.Trial{}

--- a/master/internal/db/postgres_experiments.go
+++ b/master/internal/db/postgres_experiments.go
@@ -272,7 +272,7 @@ ORDER BY v.end_time;`, &rows, metricName, experimentID, batchesProcessed, startT
 // TopTrialsByMetric chooses the subset of trials from an experiment that recorded the best values
 // for the specified metric at any point during the trial.
 func (db *PgDB) TopTrialsByMetric(experimentID int, maxTrials int, metric string,
-	smallerIsBetter bool) (trials []int32, err error) {
+	smallerIsBetter bool) (trials []int, err error) {
 	order := desc
 	aggregate := max
 	if smallerIsBetter {
@@ -298,7 +298,7 @@ SELECT t.id FROM (
 // TopTrialsByTrainingLength chooses the subset of trials that has been training for the highest
 // number of batches, using the specified metric as a tie breaker.
 func (db *PgDB) TopTrialsByTrainingLength(experimentID int, maxTrials int, metric string,
-	smallerIsBetter bool) (trials []int32, err error) {
+	smallerIsBetter bool) (trials []int, err error) {
 	order := desc
 	aggregate := max
 	if smallerIsBetter {
@@ -344,7 +344,7 @@ func scanMetricsSeries(metricSeries []lttb.Point, rows *sql.Rows) ([]lttb.Point,
 
 // TrainingMetricsSeries returns a time-series of the specified training metric in the specified
 // trial.
-func (db *PgDB) TrainingMetricsSeries(trialID int32, startTime time.Time, metricName string,
+func (db *PgDB) TrainingMetricsSeries(trialID int, startTime time.Time, metricName string,
 	startBatches int, endBatches int) (metricSeries []lttb.Point, maxEndTime time.Time,
 	err error) {
 	rows, err := db.sql.Query(`
@@ -371,7 +371,7 @@ ORDER BY batches;`, metricName, trialID, startBatches, endBatches, startTime)
 
 // ValidationMetricsSeries returns a time-series of the specified validation metric in the specified
 // trial.
-func (db *PgDB) ValidationMetricsSeries(trialID int32, startTime time.Time, metricName string,
+func (db *PgDB) ValidationMetricsSeries(trialID int, startTime time.Time, metricName string,
 	startBatches int, endBatches int) (metricSeries []lttb.Point, maxEndTime time.Time,
 	err error) {
 	rows, err := db.sql.Query(`


### PR DESCRIPTION
## Description

We originally discussed not support single-trial experiments in the sampling function that chooses the top-N trials. But it turns out it's still useful visualization (learning curve, etc.) to just pick the one trial and return its data.

The integer conversions here are because I was adding a function near other similar functions in postgres.go and saw we use int's internally all over the place for these IDs. So I'm just using int32 where it's needed for protobuf stuff.

## Test Plan

Ran manually against a single-trial experiment.
