### PR TITLE
chore: retry for more errors when uploading to GCS

### DIFF
--- a/common/determined_common/storage/gcs.py
+++ b/common/determined_common/storage/gcs.py
@@ -4,6 +4,7 @@ import os
 import tempfile
 from typing import Iterator, Optional
 
+import google.api_core.exceptions
 import requests.exceptions
 import urllib3.exceptions
 from google.api_core import retry
@@ -14,7 +15,10 @@ from determined_common.storage.base import StorageManager, StorageMetadata
 
 retry_network_errors = retry.Retry(
     retry.if_exception_type(
-        ConnectionError, urllib3.exceptions.ProtocolError, requests.exceptions.ConnectionError
+        ConnectionError,
+        google.api_core.exceptions.ServerError,
+        urllib3.exceptions.ProtocolError,
+        requests.exceptions.ConnectionError,
     )
 )
 


### PR DESCRIPTION
## Description

We saw a [CI failure](https://app.circleci.com/pipelines/github/determined-ai/determined/8819/workflows/a6dd8e75-07fd-4300-8bb8-6b3b287c25fb/jobs/242223) recently due to an HTTP 504 (gateway timeout)
received while uploading to GCS; this adds a superclass of the
corresponding exception type to the list of types that will trigger
retrying uploads.

## Test Plan

- [x] run Python and import the package to ensure I didn't typo any syntax or names

Otherwise, this is pretty unlikely to cause any material issues. At worst, it may cause a nonrecoverable failure to take a bit longer to surface.
