### PR TITLE
perf: move experiment filtering to database [DET-4770]

### DIFF
--- a/docs/release-notes/1803-improve-api-perf.txt
+++ b/docs/release-notes/1803-improve-api-perf.txt
@@ -1,0 +1,5 @@
+:orphan:
+
+**Improvements**
+
+-  REST API: Improve the performance of the experiments API.

--- a/master/internal/db/postgres.go
+++ b/master/internal/db/postgres.go
@@ -1878,16 +1878,28 @@ func (db *PgDB) queryRowsWithParser(
 }
 
 // Query returns the result of the query. Any placeholder parameters are replaced
-// with supplied args.
-func (db *PgDB) Query(queryName string, v interface{}, args ...interface{}) error {
+// with supplied params.
+func (db *PgDB) Query(queryName string, v interface{}, params ...interface{}) error {
 	parser := func(rows *sqlx.Rows, val interface{}) error { return rows.StructScan(val) }
-	return db.queryRowsWithParser(db.queries.getOrLoad(queryName), parser, v, args...)
+	return db.queryRowsWithParser(db.queries.getOrLoad(queryName), parser, v, params...)
+}
+
+// QueryF returns the result of the formated query. Any placeholder parameters are replaced
+// with supplied params.
+func (db *PgDB) QueryF(
+	queryName string, args []interface{}, v interface{}, params ...interface{}) error {
+	parser := func(rows *sqlx.Rows, val interface{}) error { return rows.StructScan(val) }
+	query := db.queries.getOrLoad(queryName)
+	if len(args) > 0 {
+		query = fmt.Sprintf(query, args...)
+	}
+	return db.queryRowsWithParser(query, parser, v, params...)
 }
 
 // RawQuery returns the result of the query as a raw byte string. Any placeholder parameters are
-// replaced with supplied args.
-func (db *PgDB) RawQuery(queryName string, args ...interface{}) ([]byte, error) {
-	return db.rawQuery(db.queries.getOrLoad(queryName), args...)
+// replaced with supplied params.
+func (db *PgDB) RawQuery(queryName string, params ...interface{}) ([]byte, error) {
+	return db.rawQuery(db.queries.getOrLoad(queryName), params...)
 }
 
 // withTransaction executes a function with a transaction.

--- a/master/static/srv/get_experiments.sql
+++ b/master/static/srv/get_experiments.sql
@@ -1,15 +1,33 @@
+WITH filtered_exps AS (
+    SELECT
+        e.id AS id,
+        e.config->>'description' AS description,
+        e.config->'labels' AS labels,
+        e.config->'resources'->>'resource_pool' AS resource_pool,
+        e.start_time AS start_time,
+        e.end_time AS end_time,
+        'STATE_' || e.state AS state,
+        (SELECT COUNT(*) FROM trials t WHERE e.id = t.experiment_id) AS num_trials,
+        e.archived AS archived,
+        COALESCE(e.progress, 0) AS progress,
+        u.username AS username
+    FROM experiments e
+    JOIN users u ON e.owner_id = u.id
+    WHERE
+        ($1 = '' OR e.state IN (SELECT unnest(string_to_array($1, ','))::experiment_state))
+        AND ($2 = '' OR e.archived = $2::BOOL)
+        AND ($3 = '' OR (u.username IN (SELECT unnest(string_to_array($3, ',')))))
+        AND (
+                $4 = ''
+                OR string_to_array($4, ',') <@ ARRAY(SELECT jsonb_array_elements_text(e.config->'labels'))
+            )
+        AND ($5 = '' OR POSITION($5 IN (e.config->>'description')) > 0)
+    )
 SELECT
-    e.id AS id,
-    e.config->>'description' AS description,
-    e.config->'labels' AS labels,
-    e.config->'resources'->>'resource_pool' AS resource_pool,
-    e.start_time AS start_time,
-    e.end_time AS end_time,
-    'STATE_' || e.state AS state,
-    (SELECT COUNT(*) FROM trials t WHERE e.id = t.experiment_id) AS num_trials,
-    e.archived AS archived,
-    COALESCE(e.progress, 0) AS progress,
-    u.username AS username
-FROM
-    experiments e
-JOIN users u ON e.owner_id = u.id
+    (SELECT COUNT(*) FROM filtered_exps) as count,
+    (SELECT json_agg(paginated_exps) FROM (
+        SELECT * FROM filtered_exps
+        ORDER BY %s
+        OFFSET $6
+        LIMIT $7
+    ) AS paginated_exps) AS experiments


### PR DESCRIPTION
## Description

Move filtering to the database when querying the experiments. Since the WebUI queries the experiments API every 5 seconds and the CPU usage is mostly spent on unmarshalling during querying when there are many users the master would undertake huge pressure on the CPU. This PR moves experiment filtering to the database so the database would return fewer experiments.

## Test Plan

Manually tested it by using filtering in the WebUI.

## Commentary (optional)

This PR doesn't choose to move pagination to the database because the WebUI needs the number of all the filtered experiments to display the number of pages.

## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
