### PR TITLE
chore: TF RNG in Estimators test would require a session [DET-4624]

### DIFF
--- a/e2e_tests/tests/experiment/test_noop.py
+++ b/e2e_tests/tests/experiment/test_noop.py
@@ -310,7 +310,7 @@ def test_keras_rng_restore() -> None:
 @pytest.mark.tensorflow1_cpu  # type: ignore
 @pytest.mark.tensorflow2_cpu  # type: ignore
 def test_estimator_rng_restore() -> None:
-    _test_rng_restore("estimator_no_op", ["rand_rand", "np_rand", "tf_rand"])
+    _test_rng_restore("estimator_no_op", ["rand_rand", "np_rand"])
 
 
 @pytest.mark.e2e_cpu  # type: ignore

--- a/e2e_tests/tests/fixtures/estimator_no_op/model_def.py
+++ b/e2e_tests/tests/fixtures/estimator_no_op/model_def.py
@@ -9,7 +9,6 @@ from typing import List
 
 import numpy as np
 import tensorflow as tf
-from packaging import version
 
 from determined import estimator
 
@@ -20,13 +19,6 @@ def rand_rand_reducer(batch_metrics: List):
 
 def np_rand_reducer(batch_metrics: List):
     return np.random.random()
-
-
-def tf_rand_reducer(batch_metrics: List):
-    if version.parse(tf.__version__) >= version.parse("2.0.0"):
-        return tf.random.get_global_generator().uniform
-    else:
-        return 0.0
 
 
 class ChiefPauseOnTerminateRunHook(estimator.RunHook):
@@ -52,7 +44,6 @@ class NoopEstimator(estimator.EstimatorTrial):
                     for name, metric, reducer in [
                         ("rand_rand", tf.constant([[]]), rand_rand_reducer),
                         ("np_rand", tf.constant([[]]), np_rand_reducer),
-                        ("tf_rand", tf.constant([[]]), tf_rand_reducer),
                     ]
                 }
 

--- a/e2e_tests/tests/fixtures/keras_no_op/model_def.py
+++ b/e2e_tests/tests/fixtures/keras_no_op/model_def.py
@@ -36,7 +36,7 @@ class TensorFlowRandomMetric(tf.keras.metrics.Metric):
     def result(self):
         def my_func(x):
             if version.parse(tf.__version__) >= version.parse("2.0.0"):
-                return tf.random.get_global_generator().uniform
+                return tf.random.get_global_generator().uniform()
             else:
                 return 0.0
 


### PR DESCRIPTION
## Description

This wasn't caught until recent CUDA 11 testing enabled a lot more tests on TF 2.x specifically. We weren't calling uniform(), we were returning the function itself. Actually calling it is somewhat pointless because estimators is a graph-mode-only framework and you just can't use the RNG this way easily. As before, we're doing a best-effort attempt to restore RNG state in TensorFlow, but it simply doesn't support this 100% anyway.