### PR TITLE
fix: requested stops shouldn't be treated as errored [DET-4725]

### DIFF
--- a/master/pkg/searcher/searcher.go
+++ b/master/pkg/searcher/searcher.go
@@ -126,7 +126,7 @@ func (s *Searcher) TrialClosed(requestID RequestID) ([]Operation, error) {
 	}
 	s.eventLog.OperationsCreated(operations...)
 	if s.eventLog.TrialsRequested == s.eventLog.TrialsClosed {
-		shutdown := Shutdown{Failure: len(s.eventLog.earlyExits) >= s.eventLog.TrialsRequested}
+		shutdown := Shutdown{Failure: len(s.eventLog.failures) >= s.eventLog.TrialsRequested}
 		s.eventLog.OperationsCreated(shutdown)
 		operations = append(operations, shutdown)
 	}


### PR DESCRIPTION
## Description
This change updates the searcher code to only consider `workload.Errored` exits as errored. Previously all exits (true failures, user requested stops and soon invalid HPs) were counted as `earlyExits`. Since `earlyExits` are use to determine if an experiment has failed, this meant that if all trials of an experiment were requested to be stopped by the user, the experiment would be `ERRORED`. This is confusing, especially since the state of all the trials is `COMPLETED`.
<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan
- [x] run an experiment to double check this works
<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.
-->


<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234