### PR TITLE
chore: Revert DET-4688, do not support single-trial experiments in trials-sample endpoint [DET-4840]

### DIFF
--- a/master/internal/db/postgres.go
+++ b/master/internal/db/postgres.go
@@ -1173,15 +1173,6 @@ RETURNING id`, trial)
 	return nil
 }
 
-// TrialIDsByExperiment returns the trial IDs from a given experiment.
-func (db *PgDB) TrialIDsByExperiment(experimentID int) (trialIDs []int, err error) {
-	err = db.sql.Select(&trialIDs, `SELECT id FROM trials WHERE experiment_id=$1`, experimentID)
-	if err != nil {
-		err = errors.Wrapf(err, "error querying trial ids for experiment")
-	}
-	return trialIDs, err
-}
-
 // TrialByID looks up a trial by ID, returning an error if none exists.
 func (db *PgDB) TrialByID(id int) (*model.Trial, error) {
 	trial := model.Trial{}

--- a/master/internal/db/postgres_experiments.go
+++ b/master/internal/db/postgres_experiments.go
@@ -272,7 +272,7 @@ ORDER BY v.end_time;`, &rows, metricName, experimentID, batchesProcessed, startT
 // TopTrialsByMetric chooses the subset of trials from an experiment that recorded the best values
 // for the specified metric at any point during the trial.
 func (db *PgDB) TopTrialsByMetric(experimentID int, maxTrials int, metric string,
-	smallerIsBetter bool) (trials []int, err error) {
+	smallerIsBetter bool) (trials []int32, err error) {
 	order := desc
 	aggregate := max
 	if smallerIsBetter {
@@ -298,7 +298,7 @@ SELECT t.id FROM (
 // TopTrialsByTrainingLength chooses the subset of trials that has been training for the highest
 // number of batches, using the specified metric as a tie breaker.
 func (db *PgDB) TopTrialsByTrainingLength(experimentID int, maxTrials int, metric string,
-	smallerIsBetter bool) (trials []int, err error) {
+	smallerIsBetter bool) (trials []int32, err error) {
 	order := desc
 	aggregate := max
 	if smallerIsBetter {
@@ -344,7 +344,7 @@ func scanMetricsSeries(metricSeries []lttb.Point, rows *sql.Rows) ([]lttb.Point,
 
 // TrainingMetricsSeries returns a time-series of the specified training metric in the specified
 // trial.
-func (db *PgDB) TrainingMetricsSeries(trialID int, startTime time.Time, metricName string,
+func (db *PgDB) TrainingMetricsSeries(trialID int32, startTime time.Time, metricName string,
 	startBatches int, endBatches int) (metricSeries []lttb.Point, maxEndTime time.Time,
 	err error) {
 	rows, err := db.sql.Query(`
@@ -371,7 +371,7 @@ ORDER BY batches;`, metricName, trialID, startBatches, endBatches, startTime)
 
 // ValidationMetricsSeries returns a time-series of the specified validation metric in the specified
 // trial.
-func (db *PgDB) ValidationMetricsSeries(trialID int, startTime time.Time, metricName string,
+func (db *PgDB) ValidationMetricsSeries(trialID int32, startTime time.Time, metricName string,
 	startBatches int, endBatches int) (metricSeries []lttb.Point, maxEndTime time.Time,
 	err error) {
 	rows, err := db.sql.Query(`


### PR DESCRIPTION
This reverts commit 1e2dc7872af8f0991232722f0ce6996c062e49de.

## Description

This is a clean revert. There were just conflicting discussions: we've decided that displaying the learning curve plot for single-trial experiments is wholly redundant with the trial view, so the web UI currently uses the error thrown by the backend to display a more helpful recommendation to the user.