### PR TITLE
chore: enable some more Go linters

### DIFF
--- a/agent/.golangci.yml
+++ b/agent/.golangci.yml
@@ -64,13 +64,10 @@ linters:
   enable-all: true
   disable:
     - exhaustive
-    - exportloopref
     - funlen
     - gochecknoglobals
-    - gochecknoinits
     - gocognit
     - gocyclo
-    - godot
     - godox
     - goerr113
     - gofumpt

--- a/master/.golangci.yml
+++ b/master/.golangci.yml
@@ -70,13 +70,10 @@ linters:
   enable-all: true
   disable:
     - exhaustive
-    - exportloopref
     - funlen
     - gochecknoglobals
-    - gochecknoinits
     - gocognit
     - gocyclo
-    - godot
     - godox
     - goerr113
     - gofumpt

--- a/master/cmd/determined-master/init.go
+++ b/master/cmd/determined-master/init.go
@@ -23,6 +23,7 @@ var v *viper.Viper
 // already broken and fixes some parts of what was broken that people care about.
 const viperKeyDelimiter = ".."
 
+//nolint:gochecknoinit
 func init() {
 	// The version of rootCmd is set in init() rather than when `rootCmd` is initialized,
 	// because link-time variable assignments are not applied when package-scoped variables

--- a/master/cmd/determined-master/main.go
+++ b/master/cmd/determined-master/main.go
@@ -1,12 +1,16 @@
 package main
 
 import (
+	"math/rand"
+	"time"
+
 	log "github.com/sirupsen/logrus"
 
 	"github.com/determined-ai/determined/master/pkg/logger"
 )
 
 func main() {
+	rand.Seed(time.Now().UnixNano())
 	logger.SetLogrus(*logger.DefaultConfig())
 
 	if err := rootCmd.Execute(); err != nil {

--- a/master/go.mod
+++ b/master/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/docker/docker v1.13.1
 	github.com/docker/go-connections v0.4.0
 	github.com/docker/go-units v0.4.0 // indirect
-	github.com/dustinkirkland/golang-petname v0.0.0-20170921220637-d3c2ba80e75e
+	github.com/dustinkirkland/golang-petname v0.0.0-20191129215211-8e5a1ed0cff0
 	github.com/elastic/go-elasticsearch/v7 v7.9.0
 	github.com/emirpasic/gods v1.12.0
 	github.com/ghodss/yaml v1.0.1-0.20190212211648-25d852aebe32

--- a/master/go.sum
+++ b/master/go.sum
@@ -218,6 +218,8 @@ github.com/docker/go-units v0.4.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDD
 github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96/go.mod h1:Qh8CwZgvJUkLughtfhJv5dyTYa91l1fOUCrgjqmcifM=
 github.com/dustinkirkland/golang-petname v0.0.0-20170921220637-d3c2ba80e75e h1:bRcq7ruHMqCVB/ugLbBylx+LrccNACFDEaqAD/aZ80Q=
 github.com/dustinkirkland/golang-petname v0.0.0-20170921220637-d3c2ba80e75e/go.mod h1:V+Qd57rJe8gd4eiGzZyg4h54VLHmYVVw54iMnlAMrF8=
+github.com/dustinkirkland/golang-petname v0.0.0-20191129215211-8e5a1ed0cff0 h1:90Ly+6UfUypEF6vvvW5rQIv9opIL8CbmW9FT20LDQoY=
+github.com/dustinkirkland/golang-petname v0.0.0-20191129215211-8e5a1ed0cff0/go.mod h1:V+Qd57rJe8gd4eiGzZyg4h54VLHmYVVw54iMnlAMrF8=
 github.com/elastic/go-elasticsearch/v7 v7.9.0 h1:UEau+a1MiiE/F+UrDj60kqIHFWdzU1M2y/YtBU2NC2M=
 github.com/elastic/go-elasticsearch/v7 v7.9.0/go.mod h1:OJ4wdbtDNk5g503kvlHLyErCgQwwzmDtaFC4XyOxXA4=
 github.com/elazarl/goproxy v0.0.0-20170405201442-c4fc26588b6e/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=

--- a/master/internal/api/params.go
+++ b/master/internal/api/params.go
@@ -6,7 +6,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-// Pagination contains resolved pagination indecies.
+// Pagination contains resolved pagination indices.
 type Pagination struct {
 	StartIndex int // Inclusive
 	EndIndex   int // Exclusive
@@ -49,7 +49,7 @@ func EffectiveOffset(reqOffset int, total int) (offset int) {
 
 // EffectiveLimit computes a hard limit based on the offset and total available items if there is a
 // limit set.
-// Input: non-negative offset
+// Input: non-negative offset.
 func EffectiveLimit(limit int, offset int, total int) int {
 	if offset < 0 {
 		panic("input offset has to be non-negative")

--- a/master/internal/api_experiment.go
+++ b/master/internal/api_experiment.go
@@ -973,7 +973,7 @@ func (a *apiServer) ComputeHPImportance(ctx context.Context,
 	return &resp, nil
 }
 
-// Translates MetricHPImportance to the protobuf form
+// Translates MetricHPImportance to the protobuf form.
 func protoMetricHPI(metricHpi model.MetricHPImportance,
 ) *apiv1.GetHPImportanceResponse_MetricHPImportance {
 	return &apiv1.GetHPImportanceResponse_MetricHPImportance{

--- a/master/internal/command/command.go
+++ b/master/internal/command/command.go
@@ -416,10 +416,6 @@ func (c *command) toTensorboard(ctx *actor.Context) *tensorboardv1.Tensorboard {
 }
 
 func getPort(min, max int) int {
-	// Set the seed here or else the compiler will generate a random number at
-	// compile time and each invocation of this function will return the same
-	// number.
-	rand.Seed(time.Now().Unix())
 	return rand.Intn(max-min) + min
 }
 

--- a/master/internal/provisioner/aws_spot_collections.go
+++ b/master/internal/provisioner/aws_spot_collections.go
@@ -12,19 +12,19 @@ type setOfSpotRequests struct {
 	keyMap map[string]*spotRequest
 }
 
-// add spotRequest to the set
+// add spotRequest to the set.
 func (c *setOfSpotRequests) add(s *spotRequest) *setOfSpotRequests {
 	c.keyMap[s.SpotRequestID] = s
 	return c
 }
 
-// delete spotRequest from the set
+// delete spotRequest from the set.
 func (c *setOfSpotRequests) delete(s *spotRequest) *setOfSpotRequests {
 	delete(c.keyMap, s.SpotRequestID)
 	return c
 }
 
-// deleteByID deletes spotRequest with the given id from the set
+// deleteByID deletes spotRequest with the given ID from the set.
 func (c *setOfSpotRequests) deleteByID(s string) *setOfSpotRequests {
 	delete(c.keyMap, s)
 	return c
@@ -38,7 +38,7 @@ func (c *setOfSpotRequests) deleteIntersection(set2 setOfSpotRequests) *setOfSpo
 	return c
 }
 
-// copy creates a shallow copy of the set
+// copy creates a shallow copy of the set.
 func (c *setOfSpotRequests) copy() setOfSpotRequests {
 	set := newSetOfSpotRequests()
 	for _, req := range c.iter() {
@@ -47,7 +47,7 @@ func (c *setOfSpotRequests) copy() setOfSpotRequests {
 	return set
 }
 
-// asList return the spotRequests in the set as a slice
+// asList return the spotRequests in the set as a slice.
 func (c *setOfSpotRequests) asList() []*spotRequest {
 	list := make([]*spotRequest, 0, len(c.keyMap))
 	for _, sr := range c.keyMap {
@@ -57,7 +57,7 @@ func (c *setOfSpotRequests) asList() []*spotRequest {
 }
 
 // asListInChronologicalOrder returns the spotRequests in the set as a slice,
-// sorted in chronological order
+// sorted in chronological order.
 func (c *setOfSpotRequests) asListInChronologicalOrder() []*spotRequest {
 	l := c.asList()
 	sort.SliceStable(l, func(i, j int) bool {
@@ -66,7 +66,7 @@ func (c *setOfSpotRequests) asListInChronologicalOrder() []*spotRequest {
 	return l
 }
 
-// instanceIds goes through the spotRequests and returns all instanceIds that are not nil
+// instanceIds goes through the spotRequests and returns all instanceIds that are not nil.
 func (c *setOfSpotRequests) instanceIds() []*string {
 	instanceIDs := make([]*string, 0)
 	for _, req := range c.keyMap {
@@ -80,7 +80,7 @@ func (c *setOfSpotRequests) instanceIds() []*string {
 	return instanceIDs
 }
 
-// idsAsList returns the spotRequest ids as a slice of strings
+// idsAsList returns the spotRequest ids as a slice of strings.
 func (c *setOfSpotRequests) idsAsList() []string {
 	list := make([]string, 0, len(c.keyMap))
 	for reqID := range c.keyMap {
@@ -89,7 +89,7 @@ func (c *setOfSpotRequests) idsAsList() []string {
 	return list
 }
 
-// idsAsListOfPointers returns the spotRequest ids as a slice of string pointers
+// idsAsListOfPointers returns the spotRequest ids as a slice of string pointers.
 func (c *setOfSpotRequests) idsAsListOfPointers() []*string {
 	list := make([]*string, 0, len(c.keyMap))
 	for reqID := range c.keyMap {
@@ -102,18 +102,17 @@ func (c *setOfSpotRequests) idsAsListOfPointers() []*string {
 }
 
 // iter returns the underlying map to make iterating over setOfSpotRequests as clean as
-// iterating over a map. e.g.:
-// for reqId, req := range set.iter() { ... }
+// iterating over a map: `for reqId, req := range set.iter() { ... }`.
 func (c *setOfSpotRequests) iter() map[string]*spotRequest {
 	return c.keyMap
 }
 
-// numReqs returns the number of spotRequests in the set
+// numReqs returns the number of spotRequests in the set.
 func (c *setOfSpotRequests) numReqs() int {
 	return len(c.keyMap)
 }
 
-// newSetOfSpotRequests creates a new, empty setOfSpotRequests
+// newSetOfSpotRequests creates a new, empty setOfSpotRequests.
 func newSetOfSpotRequests() setOfSpotRequests {
 	return setOfSpotRequests{
 		keyMap: make(map[string]*spotRequest),
@@ -127,17 +126,17 @@ type setOfStrings struct {
 	keyMap map[string]bool
 }
 
-// add a string to the set
+// add a string to the set.
 func (c *setOfStrings) add(s string) {
 	c.keyMap[s] = true
 }
 
-// length returns the number of items in the set
+// length returns the number of items in the set.
 func (c *setOfStrings) length() int {
 	return len(c.keyMap)
 }
 
-// asList returns the strings in the set as a slice of strings
+// asList returns the strings in the set as a slice of strings.
 func (c *setOfStrings) asList() []string {
 	list := make([]string, 0, len(c.keyMap))
 	for key := range c.keyMap {
@@ -146,7 +145,7 @@ func (c *setOfStrings) asList() []string {
 	return list
 }
 
-// asListOfPointers returns the strings in the set as a slice of string pointers
+// asListOfPointers returns the strings in the set as a slice of string pointers.
 func (c *setOfStrings) asListOfPointers() []*string {
 	list := make([]*string, 0, len(c.keyMap))
 	for key := range c.keyMap {
@@ -159,13 +158,13 @@ func (c *setOfStrings) asListOfPointers() []*string {
 }
 
 // string returns a string representation of the set, which is the list of strings
-// separated by commas
+// separated by commas.
 func (c *setOfStrings) string() string {
 	l := c.asList()
 	return strings.Join(l, ",")
 }
 
-// newSetOfStrings creates a new, empty setOfStrings
+// newSetOfStrings creates a new, empty setOfStrings.
 func newSetOfStrings() setOfStrings {
 	return setOfStrings{
 		keyMap: make(map[string]bool),

--- a/master/internal/provisioner/gcp.go
+++ b/master/internal/provisioner/gcp.go
@@ -5,7 +5,6 @@ import (
 	"encoding/base64"
 	"encoding/pem"
 	"fmt"
-	"math/rand"
 	"net/url"
 	"strings"
 	"time"
@@ -18,11 +17,6 @@ import (
 
 	"github.com/determined-ai/determined/master/pkg/actor"
 )
-
-func init() {
-	// set the seed of the random package for pet name generator
-	rand.Seed(time.Now().UTC().UnixNano())
-}
 
 // gcpCluster wraps a GCE client. Determined recognizes agent GCE instances by:
 // 1. A specific key/value pair label.
@@ -155,7 +149,9 @@ func (c *gcpCluster) generateInstanceName() string {
 	return c.NamePrefix + petname.Generate(2, "-")
 }
 
-func (c *gcpCluster) prestart(ctx *actor.Context) {}
+func (c *gcpCluster) prestart(ctx *actor.Context) {
+	petname.NonDeterministicMode()
+}
 
 func (c *gcpCluster) list(ctx *actor.Context) ([]*Instance, error) {
 	clientCtx := context.Background()

--- a/master/internal/provisioner/gcp_config.go
+++ b/master/internal/provisioner/gcp_config.go
@@ -241,7 +241,7 @@ func getCPUPlatform(machineType string) string {
 	return "Intel Broadwell"
 }
 
-// First prefix match found is applied
+// First prefix match found is applied.
 var gceCPUPlatforms = map[string]string{
 	"a2-highgpu": "Intel Cascade Lake",
 	"a2-megagpu": "Intel Cascade Lake",

--- a/master/internal/resourcemanagers/resource_pool.go
+++ b/master/internal/resourcemanagers/resource_pool.go
@@ -41,7 +41,7 @@ type ResourcePool struct {
 }
 
 // GetResourceSummary is a message to request a summary of the resources used by the
-// resource pool (agents, slots, cpu containers)
+// resource pool (agents, slots, cpu containers).
 type GetResourceSummary struct{}
 
 // NewResourcePool initializes a new empty default resource provider.

--- a/master/internal/resourcemanagers/resource_pool_config.go
+++ b/master/internal/resourcemanagers/resource_pool_config.go
@@ -28,7 +28,7 @@ func DefaultRPConfig() *ResourcePoolConfig {
 	}
 }
 
-// ResourcePoolConfig hosts the configuration for a resource pool
+// ResourcePoolConfig hosts the configuration for a resource pool.
 type ResourcePoolConfig struct {
 	PoolName                 string              `json:"pool_name"`
 	Description              string              `json:"description"`
@@ -54,7 +54,7 @@ func (r *ResourcePoolConfig) UnmarshalJSON(data []byte) error {
 	return errors.Wrap(json.Unmarshal(data, DefaultRPConfig()), "failed to parse resource pool")
 }
 
-// ResourcePoolsConfig hosts the configuration for resource pools
+// ResourcePoolsConfig hosts the configuration for resource pools.
 type ResourcePoolsConfig struct {
 	ResourcePools []ResourcePoolConfig `json:"resource_pools"`
 }

--- a/master/internal/sproto/globals.go
+++ b/master/internal/sproto/globals.go
@@ -63,7 +63,7 @@ func GetRP(system *actor.System, name string) *actor.Ref {
 }
 
 // GetCurrentRM returns either the k8s resource manager or the agents
-// resource manager, depending on which exists
+// resource manager, depending on which exists.
 func GetCurrentRM(system *actor.System) *actor.Ref {
 	if UseK8sRM(system) {
 		return system.Get(K8sRMAddr)
@@ -74,13 +74,13 @@ func GetCurrentRM(system *actor.System) *actor.Ref {
 	panic("There should either be a k8s resource manager or an agent resource manager")
 }
 
-// GetDefaultGPUResourcePool returns the default GPU resource pool
+// GetDefaultGPUResourcePool returns the default GPU resource pool.
 func GetDefaultGPUResourcePool(system *actor.System) string {
 	resp := system.Ask(GetCurrentRM(system), GetDefaultGPUResourcePoolRequest{}).Get()
 	return resp.(GetDefaultGPUResourcePoolResponse).PoolName
 }
 
-// GetDefaultCPUResourcePool returns the default CPU resource pool
+// GetDefaultCPUResourcePool returns the default CPU resource pool.
 func GetDefaultCPUResourcePool(system *actor.System) string {
 	resp := system.Ask(GetCurrentRM(system), GetDefaultCPUResourcePoolRequest{}).Get()
 	return resp.(GetDefaultCPUResourcePoolResponse).PoolName

--- a/master/pkg/actor/pool/pool.go
+++ b/master/pkg/actor/pool/pool.go
@@ -65,7 +65,7 @@ func (p *ActorPool) SubmitTask(task interface{}) error {
 	return nil
 }
 
-// Internal message types
+// Internal message types.
 type (
 	// For giving a new task to the manager.
 	sendTask struct {

--- a/master/pkg/archive/archive.go
+++ b/master/pkg/archive/archive.go
@@ -20,18 +20,13 @@ type (
 	Archive []Item
 )
 
-var defaultModifiedTime UnixTime
-
-func init() {
+var defaultModifiedTime UnixTime = func() UnixTime {
 	t, err := time.Parse(time.RFC3339, pkg.DeterminedBirthday)
 	if err != nil {
 		panic(err)
 	}
-
-	defaultModifiedTime = UnixTime{
-		Time: t,
-	}
-}
+	return UnixTime{Time: t}
+}()
 
 // Item is an in-memory representation of a file.  It contains the content and additional metadata
 // of a file.


### PR DESCRIPTION
## Description

This change enables the following golangci-lint linters:

- exportloopref: prevent the bug that was fixed by #1834
- gochecknoinits: reduce the side effects of imports
- godot: help comment formatting conform with standard Go conventions

The calls to `rand.Seed` and `petname.NonDeterministicMode` are
technically unnecessary, since `github.com/labstack/gommon` internally
seeds the global random `math/rand` generator on import and they all go
to the same place. But that should be treated as an implementation
detail and the multiple seeding is harmless, though pointless.

## Test Plan

- [x] check that ports and pet names are still generated nondeterministically across master runs
- [x] check that reverting #1834 triggers the loop ref check
