### PR TITLE
ci: always clean up Taiko Gauge images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -559,7 +559,10 @@ commands:
             -w /webui/tests \
             --env DET_MASTER=determined-master:8080 \
             determinedai/gauge-taiko-ts
-          rm -f webui/tests/reports/videos/*.jpeg
+      - run:
+          name: Clean up images
+          when: always
+          command: rm -f webui/tests/reports/videos/*.jpeg
 
   generate-tls-cert:
     steps:


### PR DESCRIPTION
## Description

Previously, a failed Taiko Gauge run would cause the testing command to
abort and skip the command that cleaned up frames, leading to a very
long and unnecessary subsequent artifact upload step. This moves that
command into a separate step that always runs, avoiding that situation.

## Test Plan

- [x] watch CI on this PR ([this run](https://app.circleci.com/pipelines/github/determined-ai/determined/9050/workflows/c0aba049-b0af-41ab-904d-a1292fd196a2/jobs/249876) included a temporary command included to force failure, and the images still got cleaned up)
