### PR TITLE
fix: increase trial log timestamp resolution to support milliseconds [DET-4861]

### DIFF
--- a/proto/src/determined/api/v1/trial.proto
+++ b/proto/src/determined/api/v1/trial.proto
@@ -49,7 +49,7 @@ message TrialLogsRequest {
 // Response to TrialLogsRequest.
 message TrialLogsResponse {
   option (grpc.gateway.protoc_gen_swagger.options.openapiv2_schema) = {
-    json_schema: { required: [ "id", "message" ] }
+    json_schema: { required: [ "id", "level", "message", "timestamp" ] }
   };
   // The ID of the trial log.
   string id = 1;

--- a/webui/react/src/components/LogViewer.module.scss
+++ b/webui/react/src/components/LogViewer.module.scss
@@ -52,8 +52,10 @@
     padding: 0.1rem;
   }
   .line > .level > .levelLabel { font-size: 0; }
+  .line > .critical { color: var(--theme-colors-states-failed); }
   .line > .debug { color: var(--theme-colors-states-active); }
   .line > .error { color: var(--theme-colors-states-failed); }
+  .line > .trace { color: var(--theme-colors-states-active); }
   .line > .warning { color: var(--theme-colors-states-suspended); }
   .line > .time {
     color: var(--theme-colors-base-0);

--- a/webui/react/src/components/LogViewerTimestamp.tsx
+++ b/webui/react/src/components/LogViewerTimestamp.tsx
@@ -27,8 +27,8 @@ import Page, { Props as PageProps } from './Page';
 
 export interface LogViewerTimestampFilter {
   limit?: number,
-  timestampAfter?: Dayjs,
-  timestampBefore?: Dayjs,
+  timestampAfter?: Dayjs,   // exclusive of the specified date time
+  timestampBefore?: Dayjs,  // inclusive of the specified date time
 }
 
 interface Props {
@@ -418,9 +418,9 @@ const LogViewerTimestamp: React.FC<Props> = ({
       if (!max || log.time > max) max = log.time;
       if (!min || log.time < min) min = log.time;
     });
-    setLogTimestampRange(prevRange => ({
-      max: (prevRange.max && max && prevRange.max > max) ? prevRange.max : max,
-      min: (prevRange.min && min && prevRange.min < min) ? prevRange.min : min,
+    setLogTimestampRange(prev => ({
+      max: (prev.max && max && dayjs(prev.max).isAfter(dayjs(max))) ? prev.max : max,
+      min: (prev.min && min && dayjs(prev.min).isBefore(dayjs(min))) ? prev.min : min,
     }));
   }, [ container ]);
 
@@ -503,7 +503,7 @@ const LogViewerTimestamp: React.FC<Props> = ({
 
       fetchArgs = onFetchLogBefore({
         ...filter,
-        timestampBefore: dayjs(logTimestampRange.min).add(1, 'second'),
+        timestampBefore: dayjs(logTimestampRange.min),
       }, canceler);
       isPrepend = true;
     }
@@ -515,7 +515,7 @@ const LogViewerTimestamp: React.FC<Props> = ({
 
       fetchArgs = onFetchLogAfter({
         ...filter,
-        timestampAfter: dayjs(logTimestampRange.max).subtract(1, 'second'),
+        timestampAfter: dayjs(logTimestampRange.max),
       }, canceler);
       isPrepend = false;
     }

--- a/webui/react/src/components/LogViewerTimestamp.tsx
+++ b/webui/react/src/components/LogViewerTimestamp.tsx
@@ -63,7 +63,7 @@ interface MessageSize {
   top: number;
 }
 
-export const TAIL_SIZE = 100;
+export const TAIL_SIZE = 500;
 
 // What factor to multiply against the displayable lines in the visible view.
 const BUFFER_FACTOR = 1;

--- a/webui/react/src/ioTypes.ts
+++ b/webui/react/src/ioTypes.ts
@@ -329,7 +329,7 @@ export const ioTrialLog = io.type({
   id: io.string,
   level: optional(ioLogLevelType2),
   message: io.string,
-  time: optional(io.string),
+  timestamp: io.string,
 });
 
 export const ioLogs = io.array(ioLog);

--- a/webui/react/src/ioTypes.ts
+++ b/webui/react/src/ioTypes.ts
@@ -327,7 +327,7 @@ const ioLogLevels2: Record<string, null> = Object.values(LogLevel2)
 const ioLogLevelType2 = io.keyof(ioLogLevels2);
 export const ioTrialLog = io.type({
   id: io.string,
-  level: optional(ioLogLevelType2),
+  level: ioLogLevelType2,
   message: io.string,
   timestamp: io.string,
 });

--- a/webui/react/src/ioTypes.ts
+++ b/webui/react/src/ioTypes.ts
@@ -3,7 +3,7 @@ import * as io from 'io-ts';
 
 import { ErrorLevel, ErrorType } from 'ErrorHandler';
 import {
-  CheckpointState, CheckpointStorageType, CommandState, LogLevel, LogLevel2, RunState,
+  CheckpointState, CheckpointStorageType, CommandState, LogLevel, RunState,
 } from 'types';
 
 /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
@@ -322,23 +322,10 @@ export const ioLog = io.type({
   time: optional(io.string),
 });
 
-const ioLogLevels2: Record<string, null> = Object.values(LogLevel2)
-  .reduce((acc, val) => ({ ...acc, [val]: null }), {});
-const ioLogLevelType2 = io.keyof(ioLogLevels2);
-export const ioTrialLog = io.type({
-  id: io.string,
-  level: ioLogLevelType2,
-  message: io.string,
-  timestamp: io.string,
-});
-
 export const ioLogs = io.array(ioLog);
-export const ioTrialLogs = io.array(ioTrialLog);
 
 export type ioTypeLog = io.TypeOf<typeof ioLog>;
 export type ioTypeLogs = io.TypeOf<typeof ioLogs>;
-export type ioTypeTrialLog = io.TypeOf<typeof ioTrialLog>;
-export type ioTypeTrialLogs = io.TypeOf<typeof ioTrialLogs>;
 
 const ioTaskLog = io.type({
   assigned_event: io.unknown,

--- a/webui/react/src/pages/TrialLogs.tsx
+++ b/webui/react/src/pages/TrialLogs.tsx
@@ -154,7 +154,6 @@ const TrialLogs: React.FC = () => {
 
   return (
     <LogViewerTimestamp
-      disableLevel
       fetchToLogConverter={jsonToTrialLog}
       FilterComponent={TrialLogFilters}
       noWrap

--- a/webui/react/src/services/api.ts
+++ b/webui/react/src/services/api.ts
@@ -5,13 +5,13 @@ import {
   ApiSorter, CommandIdParams, CreateExperimentParams, CreateNotebookParams, CreateTensorboardParams,
   EmptyParams, ExperimentDetailsParams, ExperimentIdParams, GetExperimentsParams, GetTrialsParams,
   LoginResponse, LogsParams, PatchExperimentParams, SingleEntityParams, TaskLogsParams,
-  TrialDetailsParams, TrialLogsParams,
+  TrialDetailsParams,
 } from 'services/types';
 import { generateApi, generateDetApi, processApiError } from 'services/utils';
 import {
   Agent, ALL_VALUE, Command, CommandTask, CommandType, Credentials, DetailedUser, DeterminedInfo,
   ExperimentBase, ExperimentFilters, ExperimentItem, Log, Pagination, RunState,
-  Telemetry, TrialDetails, TrialLog, ValidationHistory,
+  Telemetry, TrialDetails, ValidationHistory,
 } from 'types';
 import { terminalCommandStates, tsbMatchesSource } from 'utils/types';
 
@@ -205,5 +205,3 @@ export const killTask = async (task: CommandTask): Promise<void> => {
 export const getMasterLogs = generateApi<LogsParams, Log[]>(Config.getMasterLogs);
 
 export const getTaskLogs = generateApi<TaskLogsParams, Log[]>(Config.getTaskLogs);
-
-export const getTrialLogs = generateApi<TrialLogsParams, TrialLog[]>(Config.getTrialLogs);

--- a/webui/react/src/services/apiConfig.ts
+++ b/webui/react/src/services/apiConfig.ts
@@ -7,19 +7,19 @@ import * as Api from 'services/api-ts-sdk';
 import {
   jsonToAgents, jsonToCommands, jsonToDeterminedInfo,
   jsonToLogin, jsonToLogs, jsonToNotebook, jsonToNotebooks, jsonToShells, jsonToTaskLogs,
-  jsonToTensorboard, jsonToTensorboards, jsonToTrialLogs, jsonToUsers,
+  jsonToTensorboard, jsonToTensorboards, jsonToUsers,
 } from 'services/decoder';
 import * as decoder from 'services/decoder';
 import {
   CommandIdParams, CreateExperimentParams, CreateNotebookParams, CreateTensorboardParams, DetApi,
   EmptyParams, ExperimentDetailsParams, ExperimentIdParams, GetExperimentsParams, GetTrialsParams,
   LoginResponse, LogsParams, PatchExperimentParams, SingleEntityParams, TaskLogsParams,
-  TrialDetailsParams, TrialLogsParams,
+  TrialDetailsParams,
 } from 'services/types';
 import { HttpApi } from 'services/types';
 import {
   Agent, Command, CommandType, Credentials, DetailedUser, DeterminedInfo, ExperimentBase,
-  Log, TBSourceType, Telemetry, TrialDetails, TrialLog, ValidationHistory,
+  Log, TBSourceType, Telemetry, TrialDetails, ValidationHistory,
 } from 'types';
 
 import { noOp } from './utils';
@@ -405,15 +405,4 @@ export const getTaskLogs: HttpApi<TaskLogsParams, Log[]> = {
   }),
   name: 'getTaskLogs',
   postProcess: response => jsonToTaskLogs(response.data),
-};
-
-export const getTrialLogs: HttpApi<TrialLogsParams, TrialLog[]> = {
-  httpOptions: (params: TrialLogsParams) => ({
-    url: [
-      `/experiments/${params.experimentId}/trials/${params.trialId}/logs`,
-      buildQuery(params),
-    ].join('?'),
-  }),
-  name: 'getTrialLogs',
-  postProcess: response => jsonToTrialLogs(response.data as Api.V1TrialLogsResponse[]),
 };

--- a/webui/react/src/services/apiConfig.ts
+++ b/webui/react/src/services/apiConfig.ts
@@ -415,5 +415,5 @@ export const getTrialLogs: HttpApi<TrialLogsParams, TrialLog[]> = {
     ].join('?'),
   }),
   name: 'getTrialLogs',
-  postProcess: response => jsonToTrialLogs(response.data),
+  postProcess: response => jsonToTrialLogs(response.data as Api.V1TrialLogsResponse[]),
 };

--- a/webui/react/src/services/decoder.ts
+++ b/webui/react/src/services/decoder.ts
@@ -382,10 +382,6 @@ export const jsonToTrialLog = (data: unknown): types.TrialLog => {
   return log;
 };
 
-export const jsonToTrialLogs = (data: unknown): types.TrialLog[] => {
-  return (data as Sdk.V1TrialLogsResponse[]).map(d => jsonToTrialLog(d));
-};
-
 const ioTaskEventToMessage = (event: string): string => {
   if (defaultRegex.test(event)) {
     const matches = event.match(defaultRegex) || [];

--- a/webui/react/src/services/decoder.ts
+++ b/webui/react/src/services/decoder.ts
@@ -350,18 +350,17 @@ const defaultRegex = /^\[([^\]]+)\]\s([\s\S]*)(\r|\n)$/im;
 const kubernetesRegex = /^\s*([0-9a-f]+)\s+(\[[^\]]+\])\s\|\|\s(\S+)\s([\s\S]*)(\r|\n)$/im;
 
 const ioToTrialLog = (io: ioTypes.ioTypeTrialLog): types.TrialLog => {
+  const log = { id: io.id, level: io.level, message: io.message, time: io.timestamp };
   if (defaultRegex.test(io.message)) {
     const matches = io.message.match(defaultRegex) || [];
-    const time = matches[1];
     const message = matches[2] || '';
-    return { id: io.id, message, time };
+    log.message = message;
   } else if (kubernetesRegex.test(io.message)) {
     const matches = io.message.match(kubernetesRegex) || [];
-    const time = matches[3];
     const message = [ matches[1], matches[2], matches[4] ].join(' ');
-    return { id: io.id, message, time };
+    log.message = message;
   }
-  return { id: io.id, message: io.message };
+  return log;
 };
 
 export const jsonToTrialLog = (data: unknown): types.TrialLog => {

--- a/webui/react/src/services/decoder.ts
+++ b/webui/react/src/services/decoder.ts
@@ -348,24 +348,42 @@ export const jsonToLogs = (data: unknown): types.Log[] => {
 
 const defaultRegex = /^\[([^\]]+)\]\s([\s\S]*)(\r|\n)$/im;
 const kubernetesRegex = /^\s*([0-9a-f]+)\s+(\[[^\]]+\])\s\|\|\s(\S+)\s([\s\S]*)(\r|\n)$/im;
+const logLevelMap: Record<Sdk.V1LogLevel, types.LogLevel | undefined> = {
+  [Sdk.V1LogLevel.UNSPECIFIED]: undefined,
+  [Sdk.V1LogLevel.CRITICAL]: types.LogLevel.Critical,
+  [Sdk.V1LogLevel.DEBUG]: types.LogLevel.Debug,
+  [Sdk.V1LogLevel.ERROR]: types.LogLevel.Error,
+  [Sdk.V1LogLevel.INFO]: types.LogLevel.Info,
+  [Sdk.V1LogLevel.TRACE]: types.LogLevel.Trace,
+  [Sdk.V1LogLevel.WARNING]: types.LogLevel.Warning,
+};
 
-const ioToTrialLog = (io: ioTypes.ioTypeTrialLog): types.TrialLog => {
-  const log = { id: io.id, level: io.level, message: io.message, time: io.timestamp };
-  if (defaultRegex.test(io.message)) {
-    const matches = io.message.match(defaultRegex) || [];
+const decodeV1LogLevelToLogLevel = (level: Sdk.V1LogLevel): types.LogLevel | undefined => {
+  return logLevelMap[level];
+};
+
+export const jsonToTrialLog = (data: unknown): types.TrialLog => {
+  const logData = data as Sdk.V1TrialLogsResponse;
+  const log = {
+    id: logData.id,
+    level: decodeV1LogLevelToLogLevel(logData.level),
+    message: logData.message,
+    time: logData.timestamp as unknown as string,
+  };
+  if (defaultRegex.test(logData.message)) {
+    const matches = logData.message.match(defaultRegex) || [];
     const message = matches[2] || '';
     log.message = message;
-  } else if (kubernetesRegex.test(io.message)) {
-    const matches = io.message.match(kubernetesRegex) || [];
+  } else if (kubernetesRegex.test(logData.message)) {
+    const matches = logData.message.match(kubernetesRegex) || [];
     const message = [ matches[1], matches[2], matches[4] ].join(' ');
     log.message = message;
   }
   return log;
 };
 
-export const jsonToTrialLog = (data: unknown): types.TrialLog => {
-  const io = ioTypes.decode<ioTypes.ioTypeTrialLog>(ioTypes.ioTrialLog, data);
-  return ioToTrialLog(io);
+export const jsonToTrialLogs = (data: unknown): types.TrialLog[] => {
+  return (data as Sdk.V1TrialLogsResponse[]).map(d => jsonToTrialLog(d));
 };
 
 const ioTaskEventToMessage = (event: string): string => {
@@ -402,9 +420,4 @@ export const jsonToTaskLogs = (data: unknown): types.Log[] => {
         time: log.time,
       };
     });
-};
-
-export const jsonToTrialLogs = (data: unknown): types.TrialLog[] => {
-  const io = ioTypes.decode<ioTypes.ioTypeTrialLogs>(ioTypes.ioTrialLogs, data);
-  return io.map(ioToTrialLog);
 };

--- a/webui/react/src/services/decoder.ts
+++ b/webui/react/src/services/decoder.ts
@@ -346,21 +346,21 @@ export const jsonToLogs = (data: unknown): types.Log[] => {
   }));
 };
 
-const defaultRegex = /^\[([^\]]+)\]\s([\s\S]*)(\r|\n)$/im;
-const kubernetesRegex = /^\s*([0-9a-f]+)\s+(\[[^\]]+\])\s\|\|\s(\S+)\s([\s\S]*)(\r|\n)$/im;
-const logLevelMap: Record<Sdk.V1LogLevel, types.LogLevel | undefined> = {
-  [Sdk.V1LogLevel.UNSPECIFIED]: undefined,
-  [Sdk.V1LogLevel.CRITICAL]: types.LogLevel.Critical,
-  [Sdk.V1LogLevel.DEBUG]: types.LogLevel.Debug,
-  [Sdk.V1LogLevel.ERROR]: types.LogLevel.Error,
-  [Sdk.V1LogLevel.INFO]: types.LogLevel.Info,
-  [Sdk.V1LogLevel.TRACE]: types.LogLevel.Trace,
-  [Sdk.V1LogLevel.WARNING]: types.LogLevel.Warning,
-};
-
 const decodeV1LogLevelToLogLevel = (level: Sdk.V1LogLevel): types.LogLevel | undefined => {
+  const logLevelMap: Record<Sdk.V1LogLevel, types.LogLevel | undefined> = {
+    [Sdk.V1LogLevel.UNSPECIFIED]: undefined,
+    [Sdk.V1LogLevel.CRITICAL]: types.LogLevel.Critical,
+    [Sdk.V1LogLevel.DEBUG]: types.LogLevel.Debug,
+    [Sdk.V1LogLevel.ERROR]: types.LogLevel.Error,
+    [Sdk.V1LogLevel.INFO]: types.LogLevel.Info,
+    [Sdk.V1LogLevel.TRACE]: types.LogLevel.Trace,
+    [Sdk.V1LogLevel.WARNING]: types.LogLevel.Warning,
+  };
   return logLevelMap[level];
 };
+
+const defaultRegex = /^\[([^\]]+)\]\s([\s\S]*)(\r|\n)$/im;
+const kubernetesRegex = /^\s*([0-9a-f]+)\s+(\[[^\]]+\])\s\|\|\s(\S+)\s([\s\S]*)(\r|\n)$/im;
 
 export const jsonToTrialLog = (data: unknown): types.TrialLog => {
   const logData = data as Sdk.V1TrialLogsResponse;

--- a/webui/react/src/services/types.ts
+++ b/webui/react/src/services/types.ts
@@ -120,10 +120,5 @@ export interface TaskLogsParams extends LogsParams {
   taskType: CommandType;
 }
 
-export interface TrialLogsParams extends LogsParams {
-  experimentId: number;
-  trialId: number;
-}
-
 /* eslint-disable-next-line @typescript-eslint/ban-types */
 export type EmptyParams = {}

--- a/webui/react/src/styles/icons.scss
+++ b/webui/react/src/styles/icons.scss
@@ -40,6 +40,7 @@
 .icon-cluster::before { content: '\e913'; }
 .icon-collapse::before { content: '\e90d'; }
 .icon-command::before { content: '\e914'; }
+.icon-critical::before { content: '\e902'; }
 .icon-debug::before { content: '\e901'; }
 .icon-docs::before { content: '\e922'; }
 .icon-error::before { content: '\e902'; }
@@ -67,6 +68,7 @@
 .icon-tasks::before { content: '\e920'; }
 .icon-tensorboard::before { content: '\e90c'; }
 .icon-tensorflow::before { content: '\e90b'; }
+.icon-trace::before { content: '\e901'; }
 .icon-user::before { content: '\e916'; }
 .icon-user-small::before { content: '\e912'; }
 .icon-warning::before { content: '\e91c'; }

--- a/webui/react/src/types.ts
+++ b/webui/react/src/types.ts
@@ -432,20 +432,12 @@ export type CommonProps = {
 };
 
 export enum LogLevel {
+  Critical = 'critical',
   Debug = 'debug',
   Error = 'error',
   Info = 'info',
+  Trace = 'trace',
   Warning = 'warning',
-}
-
-export enum LogLevel2 {
-  Critical = 'LOG_LEVEL_CRITICAL',
-  Debug = 'LOG_LEVEL_DEBUG',
-  Error = 'LOG_LEVEL_ERROR',
-  Info = 'LOG_LEVEL_INFO',
-  Trace = 'LOG_LEVEL_TRACE',
-  Unspecified = 'LOG_LEVEL_UNSPECIFIED',
-  Warning = 'LOG_LEVEL_WARNING',
 }
 
 export interface Log {
@@ -460,5 +452,5 @@ export interface TrialLog {
   id: string;
   level?: LogLevel;
   message: string;
-  time?: string;
+  time: string;
 }


### PR DESCRIPTION
## Description

When there are a lot of trial logs happening with a short time of 1 second, the log viewer can potentially stop rendering older logs. The issue is that the requests are based on timestamps and with only resolution of whole seconds, the request for older trial logs remain the same, making it seem like the trial logs has terminated at that timestamp.

Update the trial log requests to use timestamps with milliseconds resolution.

<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234