### PR TITLE
fix: another place scheduler config for resource pool not being inherited

### DIFF
--- a/master/internal/resourcemanagers/resource_manager_config.go
+++ b/master/internal/resourcemanagers/resource_manager_config.go
@@ -30,7 +30,6 @@ func ResolveConfig(
 					PoolName:                 defaultResourcePoolName,
 					Provider:                 provisionerConf,
 					MaxCPUContainersPerAgent: 100,
-					Scheduler:                defaultSchedulerConfig(),
 				},
 			},
 		}


### PR DESCRIPTION
## Description

Fix bug where scheduler settings for a resource pool are filled in by default. Correct behavior should allows the scheduler config to be empty, which indicates that the resource pool should inherit the settings from the ResourceManager's settings.

This PR is a follow on to #1847, which missed one location where the scheduler is being configured with defaults where it should actually be left unconfigured. This PR fixes that mistake.


## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
