### PR TITLE
fix: allow larger gRPC response bodies

### DIFF
--- a/master/internal/grpc/api.go
+++ b/master/internal/grpc/api.go
@@ -68,7 +68,9 @@ func newGRPCGatewayMux() *runtime.ServeMux {
 // RegisterHTTPProxy registers grpc-gateway with the master echo server.
 func RegisterHTTPProxy(ctx context.Context, e *echo.Echo, port int, cert *tls.Certificate) error {
 	addr := fmt.Sprintf(":%d", port)
-	var opts []grpc.DialOption
+	opts := []grpc.DialOption{
+		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(1 << 26)),
+	}
 	if cert == nil {
 		opts = append(opts, grpc.WithInsecure())
 	} else {


### PR DESCRIPTION
## Description

For large experiments, some API endpoints can result in response bodies
larger than 4 MiB, which is the default maximum size that the gRPC-HTTP
proxy allows. This bumps the limit to 64 MiB to push the problem farther
away.

## Test Plan

- [x] make a request that fails with `grpc: received message larger than max...`, apply change, check that request now succeeds

## Commentary (optional)

Pagination for our clients is on the way, which is the real solution.
