### PR TITLE
fix: trial hangs when it fails to write to the DB [DET-4905]

### DIFF
--- a/docs/release-notes/1877-fix-trial-hanging.txt
+++ b/docs/release-notes/1877-fix-trial-hanging.txt
@@ -1,0 +1,6 @@
+:orphan:
+
+**Bug Fixes**
+
+-  Trial: fix the trial not deallocating resources when it fails at
+   writing to the DB.

--- a/master/internal/trial.go
+++ b/master/internal/trial.go
@@ -546,7 +546,7 @@ func (t *trial) processAllocated(
 		if err := t.db.AddTrial(modelTrial); err != nil {
 			ctx.Log().WithError(err).Error("failed to save trial to database")
 			t.terminate(ctx, true)
-			return nil
+			return err
 		}
 		t.processID(modelTrial.ID)
 		ctx.AddLabel("trial-id", t.id)
@@ -554,7 +554,7 @@ func (t *trial) processAllocated(
 			if err := t.db.AddNoOpStep(model.NewNoOpStep(t.id, 0)); err != nil {
 				ctx.Log().WithError(err).Error("failed to save zeroth step for initial validation")
 				t.terminate(ctx, true)
-				return nil
+				return err
 			}
 		}
 		ctx.Tell(t.rm, resourcemanagers.SetTaskName{


### PR DESCRIPTION
## Description

It has been noticed that the trial doesn't deallocate resources when it fails at writing to the DB. The killing logic starts when failing at writing to the DB but then the trial waits for the container terminated message, which will never come. This PR fails the trial directly rather than handling restarting when the failure is caused by the DB.

## Test Plan

N/A

## Commentary (optional)

N/A

## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
