### PR TITLE
feat: Documentation and CI of support for NVIDIA A100's and Google A2 instances

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1430,7 +1430,7 @@ jobs:
         default: 1
       gke-version:
         type: string
-        default: "1.18.12-gke.1200"
+        default: "1.18.12-gke.1205"
       machine-type:
         type: string
         default: "a2-highgpu-1g"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,9 +4,10 @@ version: 2.1
 orbs:
   win: circleci/windows@2.3.0
   slack: circleci/slack@3.4.2
-  gke: circleci/gcp-gke@1.0.4
+  gke: circleci/gcp-gke@1.1.0
   kubernetes: circleci/kubernetes@0.11.0
   helm: circleci/helm@1.1.2
+  gcloud: circleci/gcp-cli@2.1.0
 
 executors:
   python-35:
@@ -478,6 +479,20 @@ commands:
           command: |
             gcloud container clusters delete <<parameters.cluster-id>> --quiet --region=<<parameters.region>>
 
+  terminate-gke-cluster-cuda-11:
+    parameters:
+      cluster-id:
+        type: string
+      zone:
+        type: string
+    steps:
+      # Use a run instead of `gke/delete-cluster` because circle CI orbs do not support `when`.
+      - run:
+          name: Terminate GKE Cluster
+          when: always
+          command: |
+            gcloud container clusters delete <<parameters.cluster-id>> --quiet --zone=<<parameters.zone>>
+
   setup-gke-cluster:
     parameters:
       cluster-id:
@@ -525,6 +540,81 @@ commands:
           values-to-override: |
             detVersion=<<parameters.det-version>>,\
             maxSlotsPerPod=<<parameters.gpus-per-machine>>,\
+            checkpointStorage.type=gcs,\
+            checkpointStorage.bucket=det-ci
+      - set-master-address-gke:
+          release-name: "ci"
+          namespace: "default" 
+
+  setup-gke-cluster-cuda-11:
+    parameters:
+      cluster-id:
+        type: string
+      det-version:
+        type: string
+      gke-version:
+        type: string
+      machine-type:
+        type: string
+      num-machines:
+        type: integer
+      gpu-type:
+        type: string
+      gpus-per-machine:
+        type: integer
+      node-locations:
+        type: string
+      release-channel:
+        type: string
+        default: rapid
+      gcloud-service-key:
+        default: GCLOUD_SERVICE_KEY
+        description: The gcloud service key
+        type: env_var_name
+      google-compute-zone:
+        default: GOOGLE_COMPUTE_ZONE
+        description: The Google compute zone to connect with via the gcloud CLI
+        type: env_var_name
+      google-project-id:
+        default: GOOGLE_PROJECT_ID
+        description: The Google project ID to connect with via the gcloud CLI
+        type: env_var_name
+    steps:
+      - set-cluster-id:
+          cluster-id: <<parameters.cluster-id>>
+      - gcloud/install:
+          version: "319.0.0"
+      - kubernetes/install-kubectl
+      - gcloud/initialize:
+          gcloud-service-key: <<parameters.gcloud-service-key>>
+          google-compute-zone: <<parameters.google-compute-zone>>
+          google-project-id: <<parameters.google-project-id>>
+      - run:
+          command: gcloud beta container clusters create ${CLUSTER_ID} --addons=HorizontalPodAutoscaling,HttpLoadBalancing,Istio,CloudRun,NodeLocalDNS --machine-type=n1-standard-8 --cluster-version=<<parameters.gke-version>> --zone=us-central1-c --release-channel rapid --node-locations=us-central1-c --subnetwork=default --enable-stackdriver-kubernetes --scopes storage-rw,cloud-platform --num-nodes 1
+          name: Create GKE cluster
+      - run:
+          command: gcloud container clusters get-credentials ${CLUSTER_ID} --project determined-ai --zone <<parameters.node-locations>>
+          name: Get Kubeconfig
+      - run:
+          command: gcloud container node-pools create accel --project determined-ai --zone <<parameters.node-locations>> --cluster ${CLUSTER_ID} --num-nodes <<parameters.num-machines>> --accelerator type=<<parameters.gpu-type>>,count=<<parameters.gpus-per-machine>> --machine-type=<<parameters.machine-type>> --enable-autorepair --disk-size=100 --scopes cloud-platform --verbosity error
+          name: Create GPU node pool
+      - run:
+          command: kubectl apply -f https://raw.githubusercontent.com/GoogleCloudPlatform/container-engine-accelerators/master/nvidia-driver-installer/cos/daemonset-preloaded.yaml
+          name: Install NVIDIA drivers
+      - run:
+          command: kubectl create clusterrolebinding cluster-admin-binding --clusterrole cluster-admin --user "$(gcloud config get-value account)"
+          name: Setup cluster role binding
+      - helm/install-helm-chart:
+          chart: helm/charts/determined
+          helm-version: v3.2.4
+          namespace: "default"
+          wait: true
+          release-name: "ci"
+          values-to-override: |
+            detVersion=<<parameters.det-version>>,\
+            maxSlotsPerPod=<<parameters.gpus-per-machine>>,\
+            taskContainerDefaults.cpuImage=determinedai/environments:cuda-11.0-pytorch-1.7-tf-2.4-gpu-0.9.0,\
+            taskContainerDefaults.gpuImage=determinedai/environments:cuda-11.0-pytorch-1.7-tf-2.4-gpu-0.9.0,\
             checkpointStorage.type=gcs,\
             checkpointStorage.bucket=det-ci
       - set-master-address-gke:
@@ -1329,6 +1419,86 @@ jobs:
           mentions: <<parameters.slack-mentions>>
           channel: <<parameters.slack-channel>>
 
+  test-e2e-gke-cuda-11:
+    parameters:
+      cluster-id-prefix:
+        type: string
+      mark:
+        type: string
+      parallelism:
+        type: integer
+        default: 1
+      gke-version:
+        type: string
+        default: "1.18.12-gke.1200"
+      machine-type:
+        type: string
+        default: "a2-highgpu-1g"
+      num-machines:
+        type: integer
+        default: 1
+      gpu-type:
+        type: string
+        default: "nvidia-tesla-a100"
+      gpus-per-machine:
+        type: integer
+        default: 1
+      region:
+        type: string
+        default: "us-central1"
+      node-locations:
+        type: string
+        default: "us-central1-c"
+      slack-mentions:
+        type: string
+        default: ""
+      slack-channel:
+        type: string
+        default: ""
+    docker:
+      - image: determinedai/cimg-base:stable
+    parallelism: <<parameters.parallelism>>
+    environment:
+      # Using the TF2-only image here is a hack to get more test coverage since TF1 is
+      # still the default system-wide. TF1 tests that fail in this configuration should
+      # be skipped when the "CUDA" environment variable is set to 11
+      TF1_CPU_IMAGE: determinedai/environments:cuda-11.0-pytorch-1.7-tf-2.4-gpu-0.9.0
+      TF1_GPU_IMAGE: determinedai/environments:cuda-11.0-pytorch-1.7-tf-2.4-gpu-0.9.0
+      TF2_CPU_IMAGE: determinedai/environments:cuda-11.0-pytorch-1.7-tf-2.4-gpu-0.9.0
+      TF2_GPU_IMAGE: determinedai/environments:cuda-11.0-pytorch-1.7-tf-2.4-gpu-0.9.0
+      CUDA: 11
+    steps:
+      - checkout
+      - set-slack-user-id
+      - setup-python-venv:
+          determined-common: true
+          determined-cli: true
+          determined: true
+          extra-requirements-file: "e2e_tests/tests/requirements.txt"
+          executor: determinedai/cimg-base:stable
+      - setup-gke-cluster-cuda-11:
+          cluster-id: <<parameters.cluster-id-prefix>>-$(git rev-parse --short HEAD)-${CIRCLE_BUILD_NUM}-${CIRCLE_NODE_INDEX}
+          det-version: ${CIRCLE_SHA1}
+          gke-version: <<parameters.gke-version>>
+          machine-type: <<parameters.machine-type>>
+          num-machines: <<parameters.num-machines>>
+          gpu-type: <<parameters.gpu-type>>
+          gpus-per-machine: <<parameters.gpus-per-machine>>
+          node-locations: <<parameters.node-locations>>
+      - set-google-application-credentials
+      - run-e2e-tests:
+          mark: <<parameters.mark>>
+          master-host: ${MASTER_HOST}
+      - terminate-gke-cluster-cuda-11:
+          cluster-id: ${CLUSTER_ID}
+          zone: <<parameters.node-locations>>
+      - slack/status:
+          fail_only: True
+          only_for_branches: master
+          failure_message: ':thisisfine: A \`<<parameters.mark>>\` E2E GKE GPU job on branch \`${CIRCLE_BRANCH}\` has failed! Author Email: \`${AUTHOR_EMAIL}\`'
+          mentions: <<parameters.slack-mentions>>
+          channel: <<parameters.slack-channel>>
+
   test-det-deploy:
     parameters:
       mark:
@@ -1557,7 +1727,7 @@ workflows:
       - request-gpu-tests:
           type: approval
           filters: *upstream-feature-branch
-
+      
       - test-e2e-aws:
           name: test-e2e-gpu-parallel
           context: aws
@@ -1626,6 +1796,10 @@ workflows:
           type: approval
           filters: *upstream-feature-branch
 
+      - request-k8-tests-cuda-11:
+          type: approval
+          filters: *upstream-feature-branch
+
       - test-e2e-gke:
           name: test-e2e-gke-single-gpu
           context: gcp
@@ -1654,6 +1828,37 @@ workflows:
               parallelism: [1]
               slack-mentions: ["${SLACK_USER_ID}"]
               machine-type: ["n1-standard-32"]
+              gpus-per-machine: [4]
+              num-machines: [2]
+
+      - test-e2e-gke-cuda-11:
+          name: test-e2e-gke-single-gpu-cuda-11
+          context: gcp
+          filters: *upstream-feature-branch
+          requires:
+            - request-k8-tests-cuda-11
+            - package-and-push-system-dev
+          matrix:
+            parameters:
+              cluster-id-prefix: ["e2e-gpu"]
+              mark: ["e2e_gpu"]
+              parallelism: [1]
+              slack-mentions: ["${SLACK_USER_ID}"]
+
+      - test-e2e-gke-cuda-11:
+          name: test-e2e-gke-parallel-cuda-11
+          context: gcp
+          filters: *upstream-feature-branch
+          requires:
+            - request-k8-tests-cuda-11
+            - package-and-push-system-dev
+          matrix:
+            parameters:
+              cluster-id-prefix: ["parallel"]
+              mark: ["parallel"]
+              parallelism: [1]
+              slack-mentions: ["${SLACK_USER_ID}"]
+              machine-type: ["a2-highgpu-4g"]
               gpus-per-machine: [4]
               num-machines: [2]
 
@@ -1698,6 +1903,38 @@ workflows:
               max-dynamic-agents: [2]
               slack-mentions: ["channel"]
               slack-channel: ["ml-ag"]
+  
+  weekly-cuda-11:
+    triggers:
+      - schedule:
+          cron: "0 0 * * 1"
+          filters:
+            branches:
+              only:
+                - master
+    jobs:
+      - test-e2e-gke-cuda-11:
+          name: test-e2e-gke-single-gpu-cuda-11
+          context: gcp
+          matrix:
+            parameters:
+              cluster-id-prefix: ["e2e-gpu"]
+              mark: ["e2e_gpu"]
+              parallelism: [1]
+              slack-mentions: ["${SLACK_USER_ID}"]
+
+      - test-e2e-gke-cuda-11:
+          name: test-e2e-gke-parallel-cuda-11
+          context: gcp
+          matrix:
+            parameters:
+              cluster-id-prefix: ["parallel"]
+              mark: ["parallel"]
+              parallelism: [1]
+              slack-mentions: ["${SLACK_USER_ID}"]
+              machine-type: ["a2-highgpu-4g"]
+              gpus-per-machine: [4]
+              num-machines: [2]
 
   release:
     jobs:

--- a/docs/how-to/installation/aws.txt
+++ b/docs/how-to/installation/aws.txt
@@ -544,6 +544,8 @@ Running Determined
 
    -  ``image_id`` should be the latest Determined agent AMI.
    -  ``instance_type`` should be any p2 or p3 EC2 instance type.
+   -  For more information about resource pools, see
+      :ref:`resource-pool`
 
    .. warning::
 
@@ -570,22 +572,25 @@ Running Determined
         port: 5432
         name: determined
 
-      provisioner:
-        iam_instance_profile_arn: ${AgentInstanceProfile.Arn}
-        image_id: ${AgentAmiId}
-        agent_docker_image: determinedai/determined-agent:${Version}
-        instance_name: determined-agent-${UserName}
-        instance_type: ${AgentInstanceType}
-        master_url: http://local-ipv4:8080
-        max_idle_agent_period: ${MaxIdleAgentPeriod}
-        max_instances: ${MaxInstances}
-        network_interface:
-          public_ip: true
-          security_group_id: ${AgentSecurityGroup.GroupId}
-        provider: aws
-        ssh_key_name: ${Keypair}
-        tag_key: determined-${UserName}
-        tag_value: determined-${UserName}-agent
+      resource_pools:
+        - pool_name: default
+          description: The default resource pool
+          provider:
+            iam_instance_profile_arn: ${AgentInstanceProfile.Arn}
+            image_id: ${AgentAmiId}
+            agent_docker_image: determinedai/determined-agent:${Version}
+            instance_name: determined-agent-${UserName}
+            instance_type: ${AgentInstanceType}
+            master_url: http://local-ipv4:8080
+            max_idle_agent_period: ${MaxIdleAgentPeriod}
+            max_instances: ${MaxInstances}
+            network_interface:
+              public_ip: true
+              security_group_id: ${AgentSecurityGroup.GroupId}
+            type: aws
+            ssh_key_name: ${Keypair}
+            tag_key: determined-${UserName}
+            tag_value: determined-${UserName}-agent
 
 #. Start the Determined master.
 

--- a/docs/how-to/installation/dynamic-agents-gcp.txt
+++ b/docs/how-to/installation/dynamic-agents-gcp.txt
@@ -91,6 +91,20 @@ Network Requirements
 
 See :ref:`network-requirements` for details.
 
+.. _gcp-gpu-requirements:
+
+Supported GPU Types
+-------------------
+
+The following GPU types are supported by Determined:
+
+-  ``nvidia-tesla-t4``
+-  ``nvidia-tesla-p100``
+-  ``nvidia-tesla-p4``
+-  ``nvidia-tesla-v100``
+-  ``nvidia-tesla-k80``
+-  ``nvidia-tesla-a100``
+
 .. _gcp-cluster-configuration:
 
 ***********************

--- a/docs/how-to/installation/requirements.txt
+++ b/docs/how-to/installation/requirements.txt
@@ -35,8 +35,8 @@ Hardware
 -  Each Determined agent node should be configured with at least 2 CPUs
    (Intel Broadwell or later), 4GB of RAM, and 50GB of free disk space.
    If using GPUs, Nvidia GPUs with compute capability 3.7 or greater are
-   required (e.g., K80, P100, V100, GTX 1080, GTX 1080 Ti, TITAN, TITAN
-   XP).
+   required (e.g., K80, P100, V100, A100, GTX 1080, GTX 1080 Ti, TITAN,
+   TITAN XP).
 
 .. note::
 

--- a/docs/topic-guides/system-concepts/resource-pool.txt
+++ b/docs/topic-guides/system-concepts/resource-pool.txt
@@ -4,22 +4,188 @@
  Resource Pool
 ###############
 
-Large-scale deep learning requires using different resources, including
-computation resources, memory, network, and storage. Typically, we start
-off prototyping our models with immediately available instance types
-with few accelerators. Once our models are mature enough, we want to
-scale up the training speed with larger instance types that have more
-powerful accelerators and high-performing processors and more instances.
-We also want to use instance types without expensive accelerators to run
-TensorBoard or any bash commands to avoid wasting accelerators.
+To run tasks such as experiments or notebooks, Determined needs to have
+resources (CPUs, GPUs) on which to run the tasks. However, different
+tasks have different resource requirements and, given the cost of GPU
+resources, it's important to choose the right resources for specific
+goals so that you get the most value out of your money. For example, you
+may want to run your training on beefy V100 GPU machines, while you want
+your Tensorboards to run on cheap CPU machines with minimal resources.
 
-Determined provides the abstraction of physical resources for users to
-choose on their tasks. We call this abstraction *resource pools*. We can
-get the most value of our money by choosing different resource pools for
-different goals.
-
-Each resource pool is intended to map resources that are physically
-close to each other. Each resource pool can be set to use one cloud
-provider and one instance type and limited to have one region on AWS or
-zone on GCP. Each resource pool handles scheduling and scaling
+Determined has the concept of *resource pools*, which is a set of
+resources that are identical and located physically close to each other.
+Determined allows you to configure your cluster to have multiple
+resource pools and to assign tasks to a specific resource pool, so that
+you can use different sets of resources for different tasks. Each
+resource pool handles scheduling and instance provisioning
 independently.
+
+Here are some scenarios where it can be valuable to use multiple
+resource pools:
+
+-  *Use GPU for training while using CPUs for TensorBoard.*
+
+   You create one pool, ``aws-v100``, that provisions ``p3dn.24xlarge``
+   instances (large V100 EC2 instances) and another pool, ``aws-cpu``
+   that provisions ``m5.large`` instances (small and cheap CPU
+   instances). You train your experiments using the ``aws-v100`` pool,
+   while you run your Tensorboards in the ``aws-cpu`` pool. When your
+   experiments complete, the ``aws-v100 pool`` can scale down to zero to
+   save money, but you can continue to run your Tensorboard. Without
+   resource pools, you would have needed to keep a ``p3dn.24xlarge``
+   instance running to keep the Tensorboard alive.
+
+-  *Use GPUs in different availability zones on AWS*
+
+   You have one pool ``aws-v100-us-east-1a`` that runs ``p3dn.24xlarge``
+   in the ``us-east-1a`` availability zone and another pool
+   ``aws-v100-us-east-1b`` that runs ``p3dn.24xlarge`` instances in the
+   ``us-east-1b`` availability zone. You can launch an experiment into
+   ``aws-v100-us-east-1a`` and, if AWS does not have sufficient
+   ``p3dn.24xlarge`` capacity in that availability zone, you can launch
+   the experiment in ``aws-v100-us-east-1b`` to check if that
+   availability zone has capacity. Note that currently the "AWS does not
+   have capacity" notification is only visible in the master logs, not
+   on the experiment itself.
+
+-  *Use spot/preemptible instance and fall back to on-demand if needed.*
+
+   You have one pool ``aws-v100-spot`` that you use to try to run
+   training on spot instances and another pool ``aws-v100-on-demand``
+   that you fall back to if AWS does not have enough spot capacity to
+   run your job.
+
+-  *Use cheaper GPUs for prototyping on small datasets and expensive GPU
+   for training on full datasets*
+
+   You have one pool with less expensive GPUs that you use for initial
+   prototyping on small data sets and another pool that you use for
+   training more mature models on large datasets,
+
+*************
+ Limitations
+*************
+
+Currently resource pools are completely independent from each other so
+it is not possible to launch an experiment that tries to use one pool
+and then falls back to another one if a certain condition is met. You
+will need to manually decide to shift an experiment from one pool to
+another.
+
+We do not currently allow a cluster to have resource pools in multiple
+AWS regions/GCP zones or across multiple cloud providers. If the master
+is running in one AWS region/GCP zone, all resource pools must also be
+in that AWS region/GCP zone.
+
+We are constantly working to improve Determined and would love to hear
+your feedback either through GitHub issues or in our community Slack.
+
+***************************
+ Setting Up Resource Pools
+***************************
+
+Resource pools are configured via the the :ref:`master-configuration`.
+For each resource pool, you can configure scheduler and provider
+information.
+
+If you are using static resource pools and launching agents by hand, you
+will need to update the :ref:`agent-configuration` to specify which
+resource pool the agent should join.
+
+*****************************
+ Migrating to Resource Pools
+*****************************
+
+With the introduction of resource pools, the :ref:`master-configuration`
+format has changed to a new format. The old format had the top level
+fields of ``scheduler`` and ``provisioner`` which set the scheduler and
+provisioner settings for the cluster.
+
+The new format has the top level fields ``resource_manager`` and
+``resource_pools``. The ``resource_manager`` section is for cluster
+level setting such as which pools should be used by default and the
+default scheduler settings. The ``scheduler`` information is identical
+to the the ``scheduler`` field in the legacy format. The
+``resource_pools`` section is a list of resource pools each of which has
+a name, description and resource pool level settings. Each resource pool
+can be configured with a ``provider`` field that contains the same
+information as the ``provisioner`` field in the legacy format. Each
+resource pool can also have a ``scheduler`` field that sets resource
+pool specific scheduler settings. If the ``scheduler`` field is not set
+for a specific resource pool, the default settings are used.
+
+Note that defining resource pool-specific ``scheduler`` settings is
+all-or-nothing. If the pool-specific ``scheduler`` field is blank, all
+scheduler settings will be inherited from the settings defined in
+``resource_manager.scheduler``. If any fields are set in the
+pool-specific ``scheduler`` section, no settings will be inherited from
+``resource_manager.scheduler`` - you need to redefine everything.
+
+Here is an example master configuration illustrating the potential
+problem.
+
+.. code:: yaml
+
+   resource_manager:
+     type: agent
+     scheduler:
+       type: round_robin
+       fitting_policy: best
+     default_cpu_resource_pool: pool1
+     default_gpu_resource_pool: pool1
+
+   resource_pools:
+     - pool_name: pool1
+       scheduler:
+         fitting_policy: worst
+
+In this example, we are setting the cluster-wide scheduler defaults to
+use a best-fit, round robin scheduler in ``resource_manager.scheduler``.
+We are then overwriting the scheduler settings at the pool level for
+``pool1``. Because we set ``scheduler.fitting_policy=worst``, no
+settings are inherited from ``resource_manager.scheduler`` so pool1 will
+end up using a worst-fit, fair share scheduler (because when
+``scheduler.type`` is left blank, the default value is ``fair_share``).
+
+If you want to have ``pool1`` use a worst-fit, round robin scheduler,
+you need to make sure you redefine the scheduler type at the
+pool-specific level:
+
+.. code:: yaml
+
+   resource_manager:
+     type: agent
+     scheduler:
+       type: round_robin
+       fitting_policy: best
+     default_cpu_resource_pool: pool1
+     default_gpu_resource_pool: pool1
+
+   resource_pools:
+     - pool_name: pool1
+       scheduler:
+         type: round_robin
+         fitting_policy: worst
+
+*************************************
+ Launching Tasks Into Resource Pools
+*************************************
+
+When creating a task, the configuration file has a section called
+"resources". You can set the resource_pool subfield to specify the
+resource_pool that a task should be launched into.
+
+.. code:: yaml
+
+   resources:
+       resource_pool: pool1
+
+If this field is not set, the task will be launched into one of the two
+default pools defined in the :ref:`master-configuration`. Experiments
+will be launched into the default GPU pool. Tensorboards will be
+launched into the default CPU pool. Commands, Shells, and Notebooks that
+request a slot (which is the default behavior if the 'slots' field is
+not set) will be launched into the default GPU pool. Commands, Shells,
+and Notebooks that explicitly request 0 slots (for example the 'Launch
+CPU-only Notebook' button in the Web UI) will be launched into the CPU
+pool.

--- a/e2e_tests/tests/command/test_run.py
+++ b/e2e_tests/tests/command/test_run.py
@@ -1,4 +1,5 @@
 import copy
+import os
 import re
 import subprocess
 import tempfile
@@ -522,6 +523,8 @@ def test_horovod_optimizer(
     image = conf.TF1_GPU_IMAGE
     if tf2:
         image = conf.TF2_GPU_IMAGE
+    if not tf2 and "CUDA" in os.environ and os.environ["CUDA"] == "11":
+        pytest.skip("CUDA 11 is not supported by TensorFlow 1")
 
     config = {
         "environment": {

--- a/harness/determined/ipc.py
+++ b/harness/determined/ipc.py
@@ -95,7 +95,7 @@ class ZMQBroadcastServer:
     ) -> None:
         self._num_connections = num_connections
 
-        context = zmq.Context()
+        context = zmq.Context()  # type: ignore
 
         self._pub_socket = context.socket(zmq.PUB)
         self._pull_socket = context.socket(zmq.PULL)
@@ -179,7 +179,7 @@ class ZMQBroadcastServer:
 
 class ZMQBroadcastClient:
     def __init__(self, srv_pub_url: str, srv_pull_url: str) -> None:
-        context = zmq.Context()
+        context = zmq.Context()  # type: ignore
 
         self._sub_socket = context.socket(zmq.SUB)
         # Subscriber always listens to ALL messages.
@@ -245,7 +245,7 @@ class ZMQServer:
         ports: Optional[List[int]] = None,
         port_range: Optional[Tuple[int, int]] = None,
     ) -> None:
-        self.context = zmq.Context()
+        self.context = zmq.Context()  # type: ignore
         self.sockets = []  # type: List[zmq.Socket]
         self.ports = []  # type: List[int]
 
@@ -297,11 +297,11 @@ class ZMQServer:
 
     def send(self, py_obj: Any) -> None:
         for socket in self.sockets:
-            socket.send_pyobj(py_obj)
+            socket.send_pyobj(py_obj)  # type: ignore
 
     def receive_blocking(self, send_rank: int) -> Any:
         check.lt(send_rank, len(self.sockets))
-        message = self.sockets[send_rank].recv_pyobj()
+        message = self.sockets[send_rank].recv_pyobj()  # type: ignore
         return message
 
     def receive_non_blocking(
@@ -311,9 +311,9 @@ class ZMQServer:
         timeout = 1000 if not deadline else int(deadline - time.time()) * 1000
         timeout = max(timeout, 100)
 
-        if self.sockets[send_rank].poll(timeout) == 0:
+        if self.sockets[send_rank].poll(timeout) == 0:  # type: ignore
             return False, None
-        message = self.sockets[send_rank].recv_pyobj()
+        message = self.sockets[send_rank].recv_pyobj()  # type: ignore
         return True, message
 
     def barrier(
@@ -341,13 +341,13 @@ class ZMQServer:
 
             check.is_instance(barrier_message, _OneSidedBarrier)
             messages.append(barrier_message.message)
-            self.sockets[0].send_pyobj(_OneSidedBarrier(message=message))
+            self.sockets[0].send_pyobj(_OneSidedBarrier(message=message))  # type: ignore
 
         return messages
 
     def close(self) -> None:
         for socket in self.sockets:
-            socket.close()
+            socket.close()  # type: ignore
 
 
 class ZMQClient:
@@ -358,7 +358,7 @@ class ZMQClient:
     """
 
     def __init__(self, ip_address: str, port: int) -> None:
-        self.context = zmq.Context()
+        self.context = zmq.Context()  # type: ignore
         self.socket = self.context.socket(zmq.REQ)
         self.socket.connect(f"tcp://{ip_address}:{port}")
 

--- a/master/packaging/master.yaml
+++ b/master/packaging/master.yaml
@@ -15,8 +15,9 @@
 #  type: agent
 #  scheduler:
 #    type: fair_share
-#    fit: best
-
+#    fitting_policy: best
+#  default_cpu_resource_pool: default
+#  default_gpu_resource_pool: default
 ## Resource pools configuration.
 #resource_pools:
 #  - pool_name: default

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,3 +21,5 @@ isort==4.3.21
 # pytest 6.0 is based on mypy 0.780
 mypy==0.780
 bump2version>=1.0.0
+# Earlier versions had different type annotations
+pyzmq>=22

--- a/webui/react/src/pages/Cluster.tsx
+++ b/webui/react/src/pages/Cluster.tsx
@@ -174,10 +174,7 @@ const Cluster: React.FC = () => {
       >
         {selectedView === View.Grid &&
           <Grid gap={ShirtSize.medium} minItemWidth={30} mode={GridMode.AutoFill}>
-            {resourcePools.map((_, idx) => {
-              const rp = resourcePools[Math.floor(
-                Math.random() * resourcePools.length,
-              )];
+            {resourcePools.map((rp, idx) => {
               return <ResourcePoolCard
                 containerStates={getSlotContainerStates(agents.data || [], rp.name)}
                 key={idx}

--- a/webui/react/src/services/apiConfig.ts
+++ b/webui/react/src/services/apiConfig.ts
@@ -274,7 +274,7 @@ export const getExpTrials: DetApi<
 GetTrialsParams,
 Api.V1GetExperimentTrialsResponse,
 TrialDetails[]> = {
-  name: 'getExperimentValidationHistory',
+  name: 'getExperimentTrials',
   postProcess: (response) => {
     return response.trials.map(trial => decoder.decodeTrialResponseToTrialDetails({ trial }));
   },


### PR DESCRIPTION
## Description

Adds some CI coverage for the CUDA 11 images that were recently published in connection with the upgrades to PyTorch and TensorFlow.

## Test Plan

Ran the relevant tests here: https://app.circleci.com/pipelines/github/determined-ai/determined/9339/workflows/5afe5b24-3061-4508-88f1-f31037cf1c24.

## Commentary (optional)

A couple of things to note:

I consider it very hacky, but as a cost-effective way to maximize test coverage here, I'm setting a TF2 image as the TF1 default image, since the TF1 image is THE default, and is specified in many places. There's only 1 test that this causes a problem for (test_horovod_optimizer when tf2=false).

Also I'm having to use the "rapid" channel of GKE versions to use the A100 instances, and this means the version string may be a little fragile moving forward. It's always an easy fix at least...

## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.