### PR TITLE
feat: Documentation and CI of support for NVIDIA A100's and Google A2 instances

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1430,7 +1430,7 @@ jobs:
         default: 1
       gke-version:
         type: string
-        default: "1.18.12-gke.1200"
+        default: "1.18.12-gke.1205"
       machine-type:
         type: string
         default: "a2-highgpu-1g"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,9 +4,10 @@ version: 2.1
 orbs:
   win: circleci/windows@2.3.0
   slack: circleci/slack@3.4.2
-  gke: circleci/gcp-gke@1.0.4
+  gke: circleci/gcp-gke@1.1.0
   kubernetes: circleci/kubernetes@0.11.0
   helm: circleci/helm@1.1.2
+  gcloud: circleci/gcp-cli@2.1.0
 
 executors:
   python-35:
@@ -478,6 +479,20 @@ commands:
           command: |
             gcloud container clusters delete <<parameters.cluster-id>> --quiet --region=<<parameters.region>>
 
+  terminate-gke-cluster-cuda-11:
+    parameters:
+      cluster-id:
+        type: string
+      zone:
+        type: string
+    steps:
+      # Use a run instead of `gke/delete-cluster` because circle CI orbs do not support `when`.
+      - run:
+          name: Terminate GKE Cluster
+          when: always
+          command: |
+            gcloud container clusters delete <<parameters.cluster-id>> --quiet --zone=<<parameters.zone>>
+
   setup-gke-cluster:
     parameters:
       cluster-id:
@@ -525,6 +540,81 @@ commands:
           values-to-override: |
             detVersion=<<parameters.det-version>>,\
             maxSlotsPerPod=<<parameters.gpus-per-machine>>,\
+            checkpointStorage.type=gcs,\
+            checkpointStorage.bucket=det-ci
+      - set-master-address-gke:
+          release-name: "ci"
+          namespace: "default" 
+
+  setup-gke-cluster-cuda-11:
+    parameters:
+      cluster-id:
+        type: string
+      det-version:
+        type: string
+      gke-version:
+        type: string
+      machine-type:
+        type: string
+      num-machines:
+        type: integer
+      gpu-type:
+        type: string
+      gpus-per-machine:
+        type: integer
+      node-locations:
+        type: string
+      release-channel:
+        type: string
+        default: rapid
+      gcloud-service-key:
+        default: GCLOUD_SERVICE_KEY
+        description: The gcloud service key
+        type: env_var_name
+      google-compute-zone:
+        default: GOOGLE_COMPUTE_ZONE
+        description: The Google compute zone to connect with via the gcloud CLI
+        type: env_var_name
+      google-project-id:
+        default: GOOGLE_PROJECT_ID
+        description: The Google project ID to connect with via the gcloud CLI
+        type: env_var_name
+    steps:
+      - set-cluster-id:
+          cluster-id: <<parameters.cluster-id>>
+      - gcloud/install:
+          version: "319.0.0"
+      - kubernetes/install-kubectl
+      - gcloud/initialize:
+          gcloud-service-key: <<parameters.gcloud-service-key>>
+          google-compute-zone: <<parameters.google-compute-zone>>
+          google-project-id: <<parameters.google-project-id>>
+      - run:
+          command: gcloud beta container clusters create ${CLUSTER_ID} --addons=HorizontalPodAutoscaling,HttpLoadBalancing,Istio,CloudRun,NodeLocalDNS --machine-type=n1-standard-8 --cluster-version=<<parameters.gke-version>> --zone=us-central1-c --release-channel rapid --node-locations=us-central1-c --subnetwork=default --enable-stackdriver-kubernetes --scopes storage-rw,cloud-platform --num-nodes 1
+          name: Create GKE cluster
+      - run:
+          command: gcloud container clusters get-credentials ${CLUSTER_ID} --project determined-ai --zone <<parameters.node-locations>>
+          name: Get Kubeconfig
+      - run:
+          command: gcloud container node-pools create accel --project determined-ai --zone <<parameters.node-locations>> --cluster ${CLUSTER_ID} --num-nodes <<parameters.num-machines>> --accelerator type=<<parameters.gpu-type>>,count=<<parameters.gpus-per-machine>> --machine-type=<<parameters.machine-type>> --enable-autorepair --disk-size=100 --scopes cloud-platform --verbosity error
+          name: Create GPU node pool
+      - run:
+          command: kubectl apply -f https://raw.githubusercontent.com/GoogleCloudPlatform/container-engine-accelerators/master/nvidia-driver-installer/cos/daemonset-preloaded.yaml
+          name: Install NVIDIA drivers
+      - run:
+          command: kubectl create clusterrolebinding cluster-admin-binding --clusterrole cluster-admin --user "$(gcloud config get-value account)"
+          name: Setup cluster role binding
+      - helm/install-helm-chart:
+          chart: helm/charts/determined
+          helm-version: v3.2.4
+          namespace: "default"
+          wait: true
+          release-name: "ci"
+          values-to-override: |
+            detVersion=<<parameters.det-version>>,\
+            maxSlotsPerPod=<<parameters.gpus-per-machine>>,\
+            taskContainerDefaults.cpuImage=determinedai/environments:cuda-11.0-pytorch-1.7-tf-2.4-gpu-0.9.0,\
+            taskContainerDefaults.gpuImage=determinedai/environments:cuda-11.0-pytorch-1.7-tf-2.4-gpu-0.9.0,\
             checkpointStorage.type=gcs,\
             checkpointStorage.bucket=det-ci
       - set-master-address-gke:
@@ -1329,6 +1419,86 @@ jobs:
           mentions: <<parameters.slack-mentions>>
           channel: <<parameters.slack-channel>>
 
+  test-e2e-gke-cuda-11:
+    parameters:
+      cluster-id-prefix:
+        type: string
+      mark:
+        type: string
+      parallelism:
+        type: integer
+        default: 1
+      gke-version:
+        type: string
+        default: "1.18.12-gke.1200"
+      machine-type:
+        type: string
+        default: "a2-highgpu-1g"
+      num-machines:
+        type: integer
+        default: 1
+      gpu-type:
+        type: string
+        default: "nvidia-tesla-a100"
+      gpus-per-machine:
+        type: integer
+        default: 1
+      region:
+        type: string
+        default: "us-central1"
+      node-locations:
+        type: string
+        default: "us-central1-c"
+      slack-mentions:
+        type: string
+        default: ""
+      slack-channel:
+        type: string
+        default: ""
+    docker:
+      - image: determinedai/cimg-base:stable
+    parallelism: <<parameters.parallelism>>
+    environment:
+      # Using the TF2-only image here is a hack to get more test coverage since TF1 is
+      # still the default system-wide. TF1 tests that fail in this configuration should
+      # be skipped when the "CUDA" environment variable is set to 11
+      TF1_CPU_IMAGE: determinedai/environments:cuda-11.0-pytorch-1.7-tf-2.4-gpu-0.9.0
+      TF1_GPU_IMAGE: determinedai/environments:cuda-11.0-pytorch-1.7-tf-2.4-gpu-0.9.0
+      TF2_CPU_IMAGE: determinedai/environments:cuda-11.0-pytorch-1.7-tf-2.4-gpu-0.9.0
+      TF2_GPU_IMAGE: determinedai/environments:cuda-11.0-pytorch-1.7-tf-2.4-gpu-0.9.0
+      CUDA: 11
+    steps:
+      - checkout
+      - set-slack-user-id
+      - setup-python-venv:
+          determined-common: true
+          determined-cli: true
+          determined: true
+          extra-requirements-file: "e2e_tests/tests/requirements.txt"
+          executor: determinedai/cimg-base:stable
+      - setup-gke-cluster-cuda-11:
+          cluster-id: <<parameters.cluster-id-prefix>>-$(git rev-parse --short HEAD)-${CIRCLE_BUILD_NUM}-${CIRCLE_NODE_INDEX}
+          det-version: ${CIRCLE_SHA1}
+          gke-version: <<parameters.gke-version>>
+          machine-type: <<parameters.machine-type>>
+          num-machines: <<parameters.num-machines>>
+          gpu-type: <<parameters.gpu-type>>
+          gpus-per-machine: <<parameters.gpus-per-machine>>
+          node-locations: <<parameters.node-locations>>
+      - set-google-application-credentials
+      - run-e2e-tests:
+          mark: <<parameters.mark>>
+          master-host: ${MASTER_HOST}
+      - terminate-gke-cluster-cuda-11:
+          cluster-id: ${CLUSTER_ID}
+          zone: <<parameters.node-locations>>
+      - slack/status:
+          fail_only: True
+          only_for_branches: master
+          failure_message: ':thisisfine: A \`<<parameters.mark>>\` E2E GKE GPU job on branch \`${CIRCLE_BRANCH}\` has failed! Author Email: \`${AUTHOR_EMAIL}\`'
+          mentions: <<parameters.slack-mentions>>
+          channel: <<parameters.slack-channel>>
+
   test-det-deploy:
     parameters:
       mark:
@@ -1557,7 +1727,7 @@ workflows:
       - request-gpu-tests:
           type: approval
           filters: *upstream-feature-branch
-
+      
       - test-e2e-aws:
           name: test-e2e-gpu-parallel
           context: aws
@@ -1626,6 +1796,10 @@ workflows:
           type: approval
           filters: *upstream-feature-branch
 
+      - request-k8-tests-cuda-11:
+          type: approval
+          filters: *upstream-feature-branch
+
       - test-e2e-gke:
           name: test-e2e-gke-single-gpu
           context: gcp
@@ -1654,6 +1828,37 @@ workflows:
               parallelism: [1]
               slack-mentions: ["${SLACK_USER_ID}"]
               machine-type: ["n1-standard-32"]
+              gpus-per-machine: [4]
+              num-machines: [2]
+
+      - test-e2e-gke-cuda-11:
+          name: test-e2e-gke-single-gpu-cuda-11
+          context: gcp
+          filters: *upstream-feature-branch
+          requires:
+            - request-k8-tests-cuda-11
+            - package-and-push-system-dev
+          matrix:
+            parameters:
+              cluster-id-prefix: ["e2e-gpu"]
+              mark: ["e2e_gpu"]
+              parallelism: [1]
+              slack-mentions: ["${SLACK_USER_ID}"]
+
+      - test-e2e-gke-cuda-11:
+          name: test-e2e-gke-parallel-cuda-11
+          context: gcp
+          filters: *upstream-feature-branch
+          requires:
+            - request-k8-tests-cuda-11
+            - package-and-push-system-dev
+          matrix:
+            parameters:
+              cluster-id-prefix: ["parallel"]
+              mark: ["parallel"]
+              parallelism: [1]
+              slack-mentions: ["${SLACK_USER_ID}"]
+              machine-type: ["a2-highgpu-4g"]
               gpus-per-machine: [4]
               num-machines: [2]
 
@@ -1698,6 +1903,38 @@ workflows:
               max-dynamic-agents: [2]
               slack-mentions: ["channel"]
               slack-channel: ["ml-ag"]
+  
+  weekly-cuda-11:
+    triggers:
+      - schedule:
+          cron: "0 0 * * 1"
+          filters:
+            branches:
+              only:
+                - master
+    jobs:
+      - test-e2e-gke-cuda-11:
+          name: test-e2e-gke-single-gpu-cuda-11
+          context: gcp
+          matrix:
+            parameters:
+              cluster-id-prefix: ["e2e-gpu"]
+              mark: ["e2e_gpu"]
+              parallelism: [1]
+              slack-mentions: ["${SLACK_USER_ID}"]
+
+      - test-e2e-gke-cuda-11:
+          name: test-e2e-gke-parallel-cuda-11
+          context: gcp
+          matrix:
+            parameters:
+              cluster-id-prefix: ["parallel"]
+              mark: ["parallel"]
+              parallelism: [1]
+              slack-mentions: ["${SLACK_USER_ID}"]
+              machine-type: ["a2-highgpu-4g"]
+              gpus-per-machine: [4]
+              num-machines: [2]
 
   release:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1459,12 +1459,12 @@ jobs:
       - image: determinedai/cimg-base:stable
     parallelism: <<parameters.parallelism>>
     environment:
-      # Using the TF2-only image here is a hack to get more test coverage since TF1 is
-      # still the default system-wide. TF1 tests that fail in this configuration should
-      # be skipped when the "CUDA" environment variable is set to 11
-      TF1_CPU_IMAGE: determinedai/environments:cuda-11.0-pytorch-1.7-tf-2.4-gpu-0.9.0
+      # Using the TF2-only image here is a hack to get more test coverage since TF1 is still the
+      # default system-wide. TF1 tests that fail in this configuration should be skipped when the
+      # "CUDA" environment variable is set to 11.
+      # TODO: (DET-4918): we should ensure a consistent way to have tests that can run against
+      # both major TensorFlow versions do so regularly (but not others).
       TF1_GPU_IMAGE: determinedai/environments:cuda-11.0-pytorch-1.7-tf-2.4-gpu-0.9.0
-      TF2_CPU_IMAGE: determinedai/environments:cuda-11.0-pytorch-1.7-tf-2.4-gpu-0.9.0
       TF2_GPU_IMAGE: determinedai/environments:cuda-11.0-pytorch-1.7-tf-2.4-gpu-0.9.0
       CUDA: 11
     steps:

--- a/docs/how-to/installation/dynamic-agents-gcp.txt
+++ b/docs/how-to/installation/dynamic-agents-gcp.txt
@@ -91,6 +91,20 @@ Network Requirements
 
 See :ref:`network-requirements` for details.
 
+.. _gcp-gpu-requirements:
+
+Supported GPU Types
+-------------------
+
+The following GPU types are supported by Determined:
+
+-  ``nvidia-tesla-t4``
+-  ``nvidia-tesla-p100``
+-  ``nvidia-tesla-p4``
+-  ``nvidia-tesla-v100``
+-  ``nvidia-tesla-k80``
+-  ``nvidia-tesla-a100``
+
 .. _gcp-cluster-configuration:
 
 ***********************

--- a/docs/how-to/installation/requirements.txt
+++ b/docs/how-to/installation/requirements.txt
@@ -35,8 +35,8 @@ Hardware
 -  Each Determined agent node should be configured with at least 2 CPUs
    (Intel Broadwell or later), 4GB of RAM, and 50GB of free disk space.
    If using GPUs, Nvidia GPUs with compute capability 3.7 or greater are
-   required (e.g., K80, P100, V100, GTX 1080, GTX 1080 Ti, TITAN, TITAN
-   XP).
+   required (e.g., K80, P100, V100, A100, GTX 1080, GTX 1080 Ti, TITAN,
+   TITAN XP).
 
 .. note::
 

--- a/e2e_tests/tests/command/test_run.py
+++ b/e2e_tests/tests/command/test_run.py
@@ -526,8 +526,10 @@ def test_horovod_optimizer(
     if not tf2 and "CUDA" in os.environ and os.environ["CUDA"] == "11":
         # TODO: (DET-4918): we should ensure a consistent way to have tests that can run against
         # both major TensorFlow versions do so regularly (but not others).
-        pytest.skip("CUDA 11 is not supported by TensorFlow 1.x, and this test will fail if it is "
-            "run against TensorFlow 2.x without expecting it.")
+        pytest.skip(
+            "CUDA 11 is not supported by TensorFlow 1.x, and this test will fail if it is "
+            "run against TensorFlow 2.x without expecting it."
+        )
 
     config = {
         "environment": {

--- a/e2e_tests/tests/command/test_run.py
+++ b/e2e_tests/tests/command/test_run.py
@@ -1,4 +1,5 @@
 import copy
+import os
 import re
 import subprocess
 import tempfile
@@ -522,6 +523,8 @@ def test_horovod_optimizer(
     image = conf.TF1_GPU_IMAGE
     if tf2:
         image = conf.TF2_GPU_IMAGE
+    if not tf2 and "CUDA" in os.environ and os.environ["CUDA"] == "11":
+        pytest.skip("CUDA 11 is not supported by TensorFlow 1")
 
     config = {
         "environment": {

--- a/e2e_tests/tests/command/test_run.py
+++ b/e2e_tests/tests/command/test_run.py
@@ -524,7 +524,10 @@ def test_horovod_optimizer(
     if tf2:
         image = conf.TF2_GPU_IMAGE
     if not tf2 and "CUDA" in os.environ and os.environ["CUDA"] == "11":
-        pytest.skip("CUDA 11 is not supported by TensorFlow 1")
+        # TODO: (DET-4918): we should ensure a consistent way to have tests that can run against
+        # both major TensorFlow versions do so regularly (but not others).
+        pytest.skip("CUDA 11 is not supported by TensorFlow 1.x, and this test will fail if it is "
+            "run against TensorFlow 2.x without expecting it.")
 
     config = {
         "environment": {


### PR DESCRIPTION
## Description

Adds some CI coverage for the CUDA 11 images that were recently published in connection with the upgrades to PyTorch and TensorFlow.

## Test Plan

Ran the relevant tests here: https://app.circleci.com/pipelines/github/determined-ai/determined/9339/workflows/5afe5b24-3061-4508-88f1-f31037cf1c24.

## Commentary (optional)

A couple of things to note:

I consider it very hacky, but as a cost-effective way to maximize test coverage here, I'm setting a TF2 image as the TF1 default image, since the TF1 image is THE default, and is specified in many places. There's only 1 test that this causes a problem for (test_horovod_optimizer when tf2=false).

Also I'm having to use the "rapid" channel of GKE versions to use the A100 instances, and this means the version string may be a little fragile moving forward. It's always an easy fix at least...

## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.