### PR TITLE
refactor: replace step IDs with total batch in the DB

### DIFF
--- a/common/determined_common/experimental/experiment.py
+++ b/common/determined_common/experimental/experiment.py
@@ -93,7 +93,8 @@ class ExperimentReference:
             smaller_is_better = checkpoints[0]["experimentConfig"]["searcher"]["smaller_is_better"]
 
         checkpoints.sort(
-            reverse=not smaller_is_better, key=lambda x: x["metrics"]["validationMetrics"][sort_by]
+            reverse=not smaller_is_better,
+            key=lambda x: (x["metrics"]["validationMetrics"][sort_by], x["trialId"]),
         )
 
         # Ensure returned checkpoints are from distinct trials.

--- a/e2e_tests/tests/test_system.py
+++ b/e2e_tests/tests/test_system.py
@@ -97,11 +97,11 @@ def run_gc_checkpoints_test(checkpoint_storage: Dict[str, str]) -> None:
     fixtures = [
         (
             conf.fixtures_path("no_op/gc_checkpoints_decreasing.yaml"),
-            {"COMPLETED": {8, 9, 10}, "DELETED": {1, 2, 3, 4, 5, 6, 7}},
+            {"COMPLETED": {800, 900, 1000}, "DELETED": {100, 200, 300, 400, 500, 600, 700}},
         ),
         (
             conf.fixtures_path("no_op/gc_checkpoints_increasing.yaml"),
-            {"COMPLETED": {1, 2, 3, 9, 10}, "DELETED": {4, 5, 6, 7, 8}},
+            {"COMPLETED": {100, 200, 300, 900, 1000}, "DELETED": {400, 500, 600, 700, 800}},
         ),
     ]
 
@@ -126,12 +126,12 @@ def run_gc_checkpoints_test(checkpoint_storage: Dict[str, str]) -> None:
 
             checkpoints = sorted(
                 (step["checkpoint"] for step in trials[0]["steps"]),
-                key=operator.itemgetter("step_id"),
+                key=operator.itemgetter("total_batches"),
             )
             assert len(checkpoints) == 10
             by_state = {}  # type: Dict[str, Set[int]]
             for checkpoint in checkpoints:
-                by_state.setdefault(checkpoint["state"], set()).add(checkpoint["step_id"])
+                by_state.setdefault(checkpoint["state"], set()).add(checkpoint["total_batches"])
 
             if by_state == result:
                 all_checkpoints.append((config, checkpoints))

--- a/master/internal/db/postgres_proto.go
+++ b/master/internal/db/postgres_proto.go
@@ -13,7 +13,10 @@ import (
 // QueryProto returns the result of the query. Any placeholder parameters are replaced
 // with supplied args. Enum values must be the full name of the enum.
 func (db *PgDB) QueryProto(queryName string, v interface{}, args ...interface{}) error {
-	return db.queryRowsWithParser(db.queries.getOrLoad(queryName), protoParser, v, args...)
+	return errors.Wrapf(
+		db.queryRowsWithParser(db.queries.getOrLoad(queryName), protoParser, v, args...),
+		"error running query: %v", queryName,
+	)
 }
 
 // QueryProtof returns the result of the formated query. Any placeholder parameters are replaced
@@ -24,7 +27,10 @@ func (db *PgDB) QueryProtof(
 	if len(args) > 0 {
 		query = fmt.Sprintf(query, args...)
 	}
-	return db.queryRowsWithParser(query, protoParser, v, params...)
+	return errors.Wrapf(
+		db.queryRowsWithParser(query, protoParser, v, params...),
+		"error running query: %v", queryName,
+	)
 }
 
 func protoParser(rows *sqlx.Rows, val interface{}) error {

--- a/master/internal/trial.go
+++ b/master/internal/trial.go
@@ -1030,8 +1030,12 @@ func classifyStatus(state terminatedContainerWithState) aproto.ContainerStopped 
 }
 
 func (t *trial) reset() error {
-	step := t.sequencer.RollBackSequencer()
-	if err := t.db.RollBackTrial(t.id, step); err != nil {
+	totalBatches, err := t.sequencer.RollBackSequencer()
+	if err != nil {
+		return errors.Wrap(err, "failed to rollback trial sequencer in reset")
+	}
+	err = t.db.RollBackTrial(t.id, totalBatches)
+	if err != nil {
 		return errors.Wrap(err, "failed to rollback trial in reset")
 	}
 	return nil

--- a/master/internal/trial_workload_sequencer.go
+++ b/master/internal/trial_workload_sequencer.go
@@ -366,10 +366,14 @@ func (s *trialWorkloadSequencer) snapshotState() {
 
 // RollBackSequencer rolls back the sequencer to the latest checkpoint and sets the latest
 // checkpoint back to the one we just rolled back to.
-func (s *trialWorkloadSequencer) RollBackSequencer() int {
+func (s *trialWorkloadSequencer) RollBackSequencer() (int, error) {
 	s.trialWorkloadSequencerState = *s.LatestSnapshot
 	s.LatestSnapshot = s.trialWorkloadSequencerState.deepCopy()
-	return s.CurStepID
+	wkld, err := s.Workload()
+	if err != nil {
+		return 0, errors.Wrap(err, "cannot roll back sequencer")
+	}
+	return wkld.PriorBatchesProcessed, nil
 }
 
 // UpToDate returns if the sequencer has completed all searcher requested operations.
@@ -387,7 +391,7 @@ func (s trialWorkloadSequencer) train(numBatches int) workload.Workload {
 		TrialID:               s.trialID,
 		StepID:                s.CurStepID + 1,
 		NumBatches:            numBatches,
-		TotalBatchesProcessed: s.TotalBatchesProcessed,
+		PriorBatchesProcessed: s.TotalBatchesProcessed,
 	}
 }
 
@@ -397,7 +401,7 @@ func (s trialWorkloadSequencer) validate() workload.Workload {
 		ExperimentID:          s.experiment.ID,
 		TrialID:               s.trialID,
 		StepID:                s.CurStepID,
-		TotalBatchesProcessed: s.TotalBatchesProcessed,
+		PriorBatchesProcessed: s.TotalBatchesProcessed,
 	}
 }
 
@@ -407,7 +411,7 @@ func (s trialWorkloadSequencer) checkpoint() workload.Workload {
 		ExperimentID:          s.experiment.ID,
 		TrialID:               s.trialID,
 		StepID:                s.CurStepID,
-		TotalBatchesProcessed: s.TotalBatchesProcessed,
+		PriorBatchesProcessed: s.TotalBatchesProcessed,
 	}
 }
 

--- a/master/internal/trial_workload_sequencer_test.go
+++ b/master/internal/trial_workload_sequencer_test.go
@@ -58,7 +58,7 @@ checkpoint_policy: none
 		TrialID:               1,
 		StepID:                1,
 		NumBatches:            schedulingUnit,
-		TotalBatchesProcessed: 0,
+		PriorBatchesProcessed: 0,
 	}
 	trainWorkload2 := workload.Workload{
 		Kind:                  workload.RunStep,
@@ -66,7 +66,7 @@ checkpoint_policy: none
 		TrialID:               1,
 		StepID:                2,
 		NumBatches:            schedulingUnit,
-		TotalBatchesProcessed: schedulingUnit,
+		PriorBatchesProcessed: schedulingUnit,
 	}
 	trainWorkload3 := workload.Workload{
 		Kind:                  workload.RunStep,
@@ -74,7 +74,7 @@ checkpoint_policy: none
 		TrialID:               1,
 		StepID:                3,
 		NumBatches:            schedulingUnit,
-		TotalBatchesProcessed: 2 * schedulingUnit,
+		PriorBatchesProcessed: 2 * schedulingUnit,
 	}
 	trainWorkload4 := workload.Workload{
 		Kind:                  workload.RunStep,
@@ -82,7 +82,7 @@ checkpoint_policy: none
 		TrialID:               1,
 		StepID:                4,
 		NumBatches:            schedulingUnit,
-		TotalBatchesProcessed: 3 * schedulingUnit,
+		PriorBatchesProcessed: 3 * schedulingUnit,
 	}
 	trainWorkload5 := workload.Workload{
 		Kind:                  workload.RunStep,
@@ -90,56 +90,56 @@ checkpoint_policy: none
 		TrialID:               1,
 		StepID:                5,
 		NumBatches:            schedulingUnit,
-		TotalBatchesProcessed: 4 * schedulingUnit,
+		PriorBatchesProcessed: 4 * schedulingUnit,
 	}
 	checkpointWorkload1 := workload.Workload{
 		Kind:                  workload.CheckpointModel,
 		ExperimentID:          1,
 		TrialID:               1,
 		StepID:                1,
-		TotalBatchesProcessed: schedulingUnit,
+		PriorBatchesProcessed: schedulingUnit,
 	}
 	checkpointWorkload2 := workload.Workload{
 		Kind:                  workload.CheckpointModel,
 		ExperimentID:          1,
 		TrialID:               1,
 		StepID:                2,
-		TotalBatchesProcessed: schedulingUnit * 2,
+		PriorBatchesProcessed: schedulingUnit * 2,
 	}
 	checkpointWorkload4 := workload.Workload{
 		Kind:                  workload.CheckpointModel,
 		ExperimentID:          1,
 		TrialID:               1,
 		StepID:                4,
-		TotalBatchesProcessed: schedulingUnit * 4,
+		PriorBatchesProcessed: schedulingUnit * 4,
 	}
 	checkpointWorkload5 := workload.Workload{
 		Kind:                  workload.CheckpointModel,
 		ExperimentID:          1,
 		TrialID:               1,
 		StepID:                5,
-		TotalBatchesProcessed: schedulingUnit * 5,
+		PriorBatchesProcessed: schedulingUnit * 5,
 	}
 	validationWorkload2 := workload.Workload{
 		Kind:                  workload.ComputeValidationMetrics,
 		ExperimentID:          1,
 		TrialID:               1,
 		StepID:                2,
-		TotalBatchesProcessed: schedulingUnit * 2,
+		PriorBatchesProcessed: schedulingUnit * 2,
 	}
 	validationWorkload4 := workload.Workload{
 		Kind:                  workload.ComputeValidationMetrics,
 		ExperimentID:          1,
 		TrialID:               1,
 		StepID:                4,
-		TotalBatchesProcessed: schedulingUnit * 4,
+		PriorBatchesProcessed: schedulingUnit * 4,
 	}
 	validationWorkload5 := workload.Workload{
 		Kind:                  workload.ComputeValidationMetrics,
 		ExperimentID:          1,
 		TrialID:               1,
 		StepID:                5,
-		TotalBatchesProcessed: schedulingUnit * 5,
+		PriorBatchesProcessed: schedulingUnit * 5,
 	}
 
 	s := newTrialWorkloadSequencer(experiment, create, nil)
@@ -237,7 +237,9 @@ checkpoint_policy: none
 	assert.Equal(t, w, checkpointWorkload5)
 
 	// Check that rollBackSequencer() affects nothing before a completed checkpoint.
-	assert.Equal(t, s.RollBackSequencer(), 4)
+	totalBatches, err := s.RollBackSequencer()
+	assert.NilError(t, err)
+	assert.Equal(t, totalBatches, 400)
 	w, err = s.Workload()
 	assert.NilError(t, err)
 	assert.Equal(t, w, trainWorkload5)
@@ -308,7 +310,7 @@ func TestTrialWorkloadSequencerFailedWorkloads(t *testing.T) {
 			TrialID:               1,
 			StepID:                1,
 			NumBatches:            expConfig.SchedulingUnit,
-			TotalBatchesProcessed: 0,
+			PriorBatchesProcessed: 0,
 		},
 	}, nil)
 	assert.NilError(t, err)
@@ -323,7 +325,7 @@ func TestTrialWorkloadSequencerFailedWorkloads(t *testing.T) {
 			ExperimentID:          1,
 			TrialID:               1,
 			StepID:                1,
-			TotalBatchesProcessed: expConfig.SchedulingUnit,
+			PriorBatchesProcessed: expConfig.SchedulingUnit,
 		},
 		CheckpointMetrics: nil,
 		ExitedReason:      &exitedReason,
@@ -357,7 +359,7 @@ func TestTrialWorkloadSequencerOperationLessThanBatchSize(t *testing.T) {
 			TrialID:               1,
 			StepID:                1,
 			NumBatches:            1,
-			TotalBatchesProcessed: 0,
+			PriorBatchesProcessed: 0,
 		},
 	}, nil)
 	assert.NilError(t, err)

--- a/master/pkg/workload/workload.go
+++ b/master/pkg/workload/workload.go
@@ -27,7 +27,12 @@ type Workload struct {
 	TrialID               int  `json:"trial_id"`
 	StepID                int  `json:"step_id"`
 	NumBatches            int  `json:"num_batches"`
-	TotalBatchesProcessed int  `json:"total_batches_processed"`
+	PriorBatchesProcessed int  `json:"total_batches_processed"`
+}
+
+// TotalBatches returns the total batch number after the workload is processed.
+func (w Workload) TotalBatches() int {
+	return w.NumBatches + w.PriorBatchesProcessed
 }
 
 func (w Workload) String() string {
@@ -35,6 +40,6 @@ func (w Workload) String() string {
 	if w.Kind == RunStep {
 		extra += fmt.Sprintf(" (%d Batches)", w.NumBatches)
 	}
-	extra += fmt.Sprintf(" (%d Prior Batches)", w.TotalBatchesProcessed)
+	extra += fmt.Sprintf(" (%d Prior Batches)", w.PriorBatchesProcessed)
 	return fmt.Sprintf("<%s%s: (%d,%d,%d)>", w.Kind, extra, w.ExperimentID, w.TrialID, w.StepID)
 }

--- a/master/pkg/workload/workload_test.go
+++ b/master/pkg/workload/workload_test.go
@@ -14,7 +14,7 @@ func TestWorkloadMarshaling(t *testing.T) {
 		TrialID:               2,
 		StepID:                3,
 		NumBatches:            10,
-		TotalBatchesProcessed: 0,
+		PriorBatchesProcessed: 0,
 	}
 	blob, marshalErr := json.Marshal(marshaled)
 	assert.NilError(t, marshalErr)

--- a/master/static/migrations/20210208000000_add-total-batch.down.sql
+++ b/master/static/migrations/20210208000000_add-total-batch.down.sql
@@ -1,0 +1,32 @@
+-- Replace total_batches with step_id in the checkpoints table.
+ALTER TABLE checkpoints ADD COLUMN step_id integer NOT NULL DEFAULT 0;
+
+UPDATE checkpoints AS c
+SET step_id = COALESCE(
+    (SELECT
+            s.id AS step_id
+    FROM steps s
+    WHERE c.total_batches = s.total_batches AND c.trial_id = s.trial_id), 0);
+
+ALTER TABLE checkpoints
+    ADD CONSTRAINT checkpoints_trial_step_unique UNIQUE (trial_id, step_id);
+
+ALTER TABLE checkpoints DROP COLUMN total_batches;
+
+-- Replace total_batches with step_id in the validations table.
+ALTER TABLE validations ADD COLUMN step_id integer NOT NULL DEFAULT 0;
+
+UPDATE validations AS v
+SET step_id = COALESCE(
+    (SELECT
+            s.id AS step_id
+    FROM steps s
+    WHERE v.total_batches = s.total_batches AND v.trial_id = s.trial_id), 0);
+
+ALTER TABLE validations
+    ADD CONSTRAINT validations_trial_step_unique UNIQUE (trial_id, step_id);
+
+ALTER TABLE validations DROP COLUMN total_batches;
+
+-- Remove total_batches in the steps table.
+ALTER TABLE steps DROP COLUMN total_batches;

--- a/master/static/migrations/20210208000000_add-total_batch.up.sql
+++ b/master/static/migrations/20210208000000_add-total_batch.up.sql
@@ -1,0 +1,38 @@
+-- Replace step_id with total_batches in the checkpoints table.
+ALTER TABLE checkpoints ADD COLUMN total_batches integer NOT NULL DEFAULT 0;
+
+UPDATE checkpoints AS c
+SET total_batches = COALESCE(
+    (SELECT
+           s.prior_batches_processed + s.num_batches AS total_batches
+    FROM steps s
+    WHERE c.step_id = s.id AND c.trial_id = s.trial_id), 0);
+
+ALTER TABLE checkpoints
+    ADD CONSTRAINT checkpoints_trial_total_batches_unique UNIQUE (trial_id, total_batches);
+
+ALTER TABLE checkpoints DROP COLUMN step_id;
+
+-- Replace step_id with total_batches in the validations table.
+ALTER TABLE validations ADD COLUMN total_batches integer NOT NULL DEFAULT 0;
+
+UPDATE validations AS v
+SET total_batches = COALESCE(
+    (SELECT
+            s.prior_batches_processed + s.num_batches AS total_batches
+    FROM steps s
+    WHERE v.step_id = s.id AND v.trial_id = s.trial_id), 0);
+
+ALTER TABLE validations
+    ADD CONSTRAINT validations_trial_total_batches_unique UNIQUE (trial_id, total_batches);
+
+ALTER TABLE validations DROP COLUMN step_id;
+
+-- Add total_batches in the steps table.
+ALTER TABLE steps ADD COLUMN total_batches integer NOT NULL DEFAULT 0;
+
+UPDATE steps AS s
+SET total_batches = COALESCE(s.prior_batches_processed + s.num_batches, 0);
+
+ALTER TABLE steps
+    ADD CONSTRAINT steps_trial_total_batches_unique UNIQUE (trial_id, total_batches);

--- a/master/static/srv/get_checkpoint.sql
+++ b/master/static/srv/get_checkpoint.sql
@@ -4,9 +4,9 @@ SELECT
     e.id AS  experiment_id,
     t.id AS trial_id,
     t.hparams as hparams,
-    s.prior_batches_processed + s.num_batches AS batch_number,
-    s.start_time AS start_time,
-    s.end_time AS end_time,
+    c.total_batches AS batch_number,
+    c.start_time AS start_time,
+    c.end_time AS end_time,
     c.resources AS resources,
     COALESCE(c.metadata, '{}') AS metadata,
     COALESCE(c.framework, '') as framework,
@@ -17,8 +17,7 @@ SELECT
     'STATE_' || v.state AS validation_state,
     'STATE_' || c.state AS state
 FROM checkpoints c
-JOIN steps s ON c.step_id = s.id AND c.trial_id = s.trial_id
-LEFT JOIN validations v ON v.step_id = s.id AND v.trial_id = s.trial_id
-JOIN trials t ON s.trial_id = t.id
+LEFT JOIN validations v ON v.total_batches = c.total_batches AND v.trial_id = c.trial_id
+JOIN trials t ON c.trial_id = t.id
 JOIN experiments e ON t.experiment_id = e.id
 WHERE c.uuid = $1

--- a/master/static/srv/get_checkpoints_for_experiment.sql
+++ b/master/static/srv/get_checkpoints_for_experiment.sql
@@ -7,9 +7,9 @@ SELECT
     e.id AS  experiment_id,
     t.id AS trial_id,
     t.hparams as hparams,
-    s.prior_batches_processed + s.num_batches AS batch_number,
-    s.start_time AS start_time,
-    s.end_time AS end_time,
+    c.total_batches AS batch_number,
+    c.start_time AS start_time,
+    c.end_time AS end_time,
     c.resources AS resources,
     COALESCE(c.metadata, '{}') AS metadata,
     COALESCE(c.framework, '') as framework,
@@ -19,9 +19,8 @@ SELECT
     'STATE_' || v.state AS validation_state,
     (v.metrics->'validation_metrics'->>(e.config->'searcher'->>'metric'))::float8 AS searcher_metric
 FROM checkpoints c
-JOIN steps s ON c.step_id = s.id AND c.trial_id = s.trial_id
-LEFT JOIN validations v ON v.step_id = s.id AND v.trial_id = s.trial_id
-JOIN trials t ON s.trial_id = t.id
+LEFT JOIN validations v ON v.total_batches = c.total_batches AND v.trial_id = c.trial_id
+JOIN trials t ON c.trial_id = t.id
 JOIN experiments e ON t.experiment_id = e.id
 WHERE e.id = $1
 ORDER BY start_time DESC

--- a/master/static/srv/get_checkpoints_for_trial.sql
+++ b/master/static/srv/get_checkpoints_for_trial.sql
@@ -5,9 +5,9 @@ SELECT
     e.id AS  experiment_id,
     t.id AS trial_id,
     t.hparams as hparams,
-    s.prior_batches_processed + s.num_batches AS batch_number,
-    s.start_time AS start_time,
-    s.end_time AS end_time,
+    c.total_batches AS batch_number,
+    c.start_time AS start_time,
+    c.end_time AS end_time,
     c.resources AS resources,
     COALESCE(c.metadata, '{}') AS metadata,
     COALESCE(c.framework, '') as framework,
@@ -17,9 +17,8 @@ SELECT
     'STATE_' || v.state AS validation_state,
     (v.metrics->'validation_metrics'->>(e.config->'searcher'->>'metric'))::float8 AS searcher_metric
 FROM checkpoints c
-JOIN steps s ON c.step_id = s.id AND c.trial_id = s.trial_id
-LEFT JOIN validations v ON v.step_id = s.id AND v.trial_id = s.trial_id
-JOIN trials t ON s.trial_id = t.id
+LEFT JOIN validations v ON v.total_batches = c.total_batches AND v.trial_id = c.trial_id
+JOIN trials t ON c.trial_id = t.id
 JOIN experiments e ON t.experiment_id = e.id
 WHERE t.id = $1
 ORDER BY start_time DESC

--- a/master/static/srv/get_model_version.sql
+++ b/master/static/srv/get_model_version.sql
@@ -13,7 +13,7 @@ c AS (
     e.id AS  experiment_id,
     t.id AS trial_id,
     t.hparams as hparams,
-    s.prior_batches_processed + s.num_batches AS batch_number,
+    s.total_batches AS batch_number,
     s.start_time AS start_time,
     s.end_time AS end_time,
     c.resources AS resources,
@@ -25,8 +25,8 @@ c AS (
     'STATE_' || v.state AS validation_state,
     'STATE_' || c.state AS state
   FROM checkpoints c
-  JOIN steps s ON c.step_id = s.id AND c.trial_id = s.trial_id
-  LEFT JOIN validations v ON v.step_id = s.id AND v.trial_id = s.trial_id
+  JOIN steps s ON c.total_batches = s.total_batches AND c.trial_id = s.trial_id
+  LEFT JOIN validations v ON v.total_batches = s.total_batches AND v.trial_id = s.trial_id
   JOIN trials t ON s.trial_id = t.id
   JOIN experiments e ON t.experiment_id = e.id
   WHERE c.uuid = (SELECT checkpoint_uuid FROM mv)

--- a/master/static/srv/get_model_versions.sql
+++ b/master/static/srv/get_model_versions.sql
@@ -13,7 +13,7 @@ c AS (
     e.id AS  experiment_id,
     t.id AS trial_id,
     t.hparams as hparams,
-    s.prior_batches_processed + s.num_batches AS batch_number,
+    s.total_batches AS batch_number,
     s.start_time AS start_time,
     s.end_time AS end_time,
     c.resources AS resources,
@@ -25,8 +25,8 @@ c AS (
     'STATE_' || v.state AS validation_state,
     'STATE_' || c.state AS state
   FROM checkpoints c
-  JOIN steps s ON c.step_id = s.id AND c.trial_id = s.trial_id
-  LEFT JOIN validations v ON v.step_id = s.id AND v.trial_id = s.trial_id
+  JOIN steps s ON c.total_batches = s.total_batches AND c.trial_id = s.trial_id
+  LEFT JOIN validations v ON v.total_batches = s.total_batches AND v.trial_id = s.trial_id
   JOIN trials t ON s.trial_id = t.id
   JOIN experiments e ON t.experiment_id = e.id
   WHERE c.uuid IN (SELECT checkpoint_uuid FROM mv)

--- a/master/static/srv/get_trial.sql
+++ b/master/static/srv/get_trial.sql
@@ -24,7 +24,7 @@ FROM
             FROM
               (SELECT c.id,
                       c.trial_id,
-                      c.step_id,
+                      c.total_batches,
                       c.state,
                       c.start_time,
                       c.end_time,
@@ -33,20 +33,20 @@ FROM
                       c.metadata
                FROM checkpoints c
                WHERE c.trial_id = t.id
-                 AND c.step_id = s.id ) r3) AS CHECKPOINT,
+                 AND c.total_batches = s.total_batches ) r3) AS CHECKPOINT,
 
            (SELECT row_to_json(r4)
             FROM
               (SELECT v.id,
                       v.trial_id,
-                      v.step_id,
+                      v.total_batches,
                       v.state,
                       v.start_time,
                       v.end_time,
                       v.metrics
                FROM validations v
                WHERE v.trial_id = t.id
-                 AND v.step_id = s.id ) r4) AS validation
+                 AND v.total_batches = s.total_batches ) r4) AS validation
          FROM steps s
          WHERE s.trial_id = t.id ) r2) AS steps
    FROM trials t

--- a/master/static/srv/get_trial_metrics.sql
+++ b/master/static/srv/get_trial_metrics.sql
@@ -13,6 +13,7 @@ FROM
                                 ORDER BY r2.id ASC), '[]'::JSONB)
       FROM
         (SELECT s.id,
+                s.total_batches,
                 s.trial_id,
                 s.state,
                 s.start_time,
@@ -25,7 +26,7 @@ FROM
             FROM
               (SELECT c.id,
                       c.trial_id,
-                      c.step_id,
+                      c.total_batches,
                       c.state,
                       c.start_time,
                       c.end_time,
@@ -34,20 +35,20 @@ FROM
                       c.metadata
                FROM checkpoints c
                WHERE c.trial_id = t.id
-                 AND c.step_id = s.id ) r3) AS CHECKPOINT,
+                 AND c.total_batches = s.total_batches ) r3) AS CHECKPOINT,
 
            (SELECT row_to_json(r4)
             FROM
               (SELECT v.id,
                       v.trial_id,
-                      v.step_id,
+                      v.total_batches,
                       v.state,
                       v.start_time,
                       v.end_time,
                       v.metrics
                FROM validations v
                WHERE v.trial_id = t.id
-                 AND v.step_id = s.id ) r4) AS validation
+                 AND v.total_batches = s.total_batches ) r4) AS validation
          FROM steps s
          WHERE s.trial_id = t.id ) r2) AS steps
    FROM trials t

--- a/master/static/srv/proto_get_trial_ids_for_experiment.sql
+++ b/master/static/srv/proto_get_trial_ids_for_experiment.sql
@@ -21,7 +21,7 @@ WITH searcher_info AS (
         t.end_time,
         coalesce(t.end_time, now()) - t.start_time AS duration,
         (
-            SELECT s.prior_batches_processed + s.num_batches
+            SELECT s.total_batches
             FROM steps s
             WHERE s.trial_id = t.id
                 AND s.state = 'COMPLETED'

--- a/master/static/srv/proto_get_trial_workloads.sql
+++ b/master/static/srv/proto_get_trial_workloads.sql
@@ -1,31 +1,29 @@
 WITH validations_vt AS (
-  SELECT row_to_json(r1) AS validation,
-    step_id
+  SELECT row_to_json(r1) AS validation, total_batches
   FROM (
       SELECT 'STATE_' || v.state as state,
         v.start_time,
         v.end_time,
         s.num_batches,
         s.prior_batches_processed,
-        v.step_id,
+        v.total_batches,
         v.metrics->'num_inputs' as num_inputs,
         v.metrics->'validation_metrics' as metrics
       FROM validations v
         INNER JOIN steps s ON v.trial_id = s.trial_id
-        AND v.step_id = s.id
+        AND v.total_batches = s.total_batches
       WHERE v.trial_id = $1
     ) AS r1
 ),
 trainings_vt AS (
-  SELECT row_to_json(r1) AS training,
-    step_id
+  SELECT row_to_json(r1) AS training, total_batches
   FROM (
       SELECT s.start_time,
         s.end_time,
         'STATE_' || s.state as state,
         s.num_batches,
         s.prior_batches_processed,
-        s.id as step_id,
+        s.total_batches,
         s.metrics->'avg_metrics' as metrics,
         s.metrics->'num_inputs' as num_inputs
       FROM steps s
@@ -33,30 +31,30 @@ trainings_vt AS (
     ) AS r1
 ),
 checkpoints_vt AS (
-  SELECT row_to_json(r1) AS checkpoint,
-    step_id
+  SELECT row_to_json(r1) AS checkpoint, total_batches
   FROM (
       SELECT 'STATE_' || c.state as state,
         c.start_time,
         c.end_time,
         c.uuid,
-        c.step_id,
+        c.total_batches,
         s.num_batches,
         s.prior_batches_processed,
         c.resources
       FROM checkpoints c
         INNER JOIN steps s ON c.trial_id = s.trial_id
-        AND c.step_id = s.id
+        AND c.total_batches = s.total_batches
       WHERE c.trial_id = $1
     ) AS r1
 )
-SELECT v.validation::jsonb - 'step_id' AS validation,
-  t.training::jsonb - 'step_id' AS training,
-  c.checkpoint::jsonb - 'step_id' AS checkpoint
+SELECT v.validation::jsonb - 'total_batches' AS validation,
+  t.training::jsonb - 'total_batches' AS training,
+  c.checkpoint::jsonb - 'total_batches' AS checkpoint
 FROM trainings_vt t
   FULL JOIN checkpoints_vt c ON false
   FULL JOIN validations_vt v ON false
 ORDER BY coalesce(
-    t.step_id,
-    coalesce(v.step_id, c.step_id)
+    t.total_batches,
+    v.total_batches,
+    c.total_batches
   ) ASC

--- a/master/test/integration/api/api_trials_test.go
+++ b/master/test/integration/api/api_trials_test.go
@@ -107,13 +107,16 @@ func trialDetailAPITests(
 
 			step := testutils.StepModel(trial.ID)
 			step.ID = id
+			step.NumBatches = experiment.Config.SchedulingUnit
+			step.PriorBatchesProcessed = (id - 1) * experiment.Config.SchedulingUnit
+			step.TotalBatches = id * experiment.Config.SchedulingUnit
 			err = db.AddStep(step)
 			assert.NilError(t, err, "failed to insert step")
 
 			metrics := map[string]interface{}{
 				"avg_metrics": tc.metrics,
 			}
-			err = db.UpdateStep(trial.ID, step.ID, model.CompletedState, metrics)
+			err = db.UpdateStep(trial.ID, step.TotalBatches, model.CompletedState, metrics)
 			assert.NilError(t, err, "failed to update step")
 
 			ctx, _ := context.WithTimeout(creds, 10*time.Second)


### PR DESCRIPTION
## Description

Replace the use of step id with the total batch in the DB. Any checkpoint, training metric, validation can be located with a trial id and a total batch number. They used to depend on the concept of steps. In order to hand over the control on checkpointing and validating to the user code, all the internal use of steps should be abandoned.

In the meantime, remove the constraint that all checkpoints and validations need to be associated with a step. We will change the restful APIs later to return the checkpoints and validations of all total_batches rather than just those of steps.

## Test Plan

1. Use the CI for testing.
2. Manually test running experiments of constant hp params and adaptive hp search on 
training metrics, validations, checkpoints, and fault tolerance.

## Commentary (optional)

N/A

## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234