### PR TITLE
chore: support task tokens in harness for authentication [DET-4897]

### DIFF
--- a/common/determined_common/api/authentication.py
+++ b/common/determined_common/api/authentication.py
@@ -16,6 +16,8 @@ Credentials = NamedTuple("Credentials", [("username", str), ("password", str)])
 
 PASSWORD_SALT = "GubPEmmotfiK9TMD6Zdw"
 
+cur_task_token = os.environ.get("DET_TASK_TOKEN", "")
+
 
 def authentication_required(func: Callable[[Namespace], Any]) -> Callable[..., Any]:
     @wraps(func)
@@ -77,6 +79,9 @@ class Authentication:
 
     def reset_session(self) -> None:
         self.session = None
+
+    def get_task_token(self) -> str:
+        return cur_task_token
 
 
 class TokenStore:

--- a/common/determined_common/api/request.py
+++ b/common/determined_common/api/request.py
@@ -107,8 +107,10 @@ def maybe_upgrade_ws_scheme(master_address: str) -> str:
 
 
 def add_token_to_headers(headers: Dict[str, str]) -> Dict[str, str]:
+    task_token = authentication.Authentication.instance().get_task_token()
+    if task_token:
+        return {**headers, "Grpc-Metadata-x-task-token": "Bearer {}".format(task_token)}
     token = authentication.Authentication.instance().get_session_token()
-
     return {**headers, "Authorization": "Bearer {}".format(token)}
 
 

--- a/master/internal/api_auth.go
+++ b/master/internal/api_auth.go
@@ -67,6 +67,6 @@ func (a *apiServer) Logout(
 	if err != nil {
 		return nil, err
 	}
-	err = a.m.db.DeleteSessionByID(userSession.ID)
+	err = a.m.db.DeleteUserSessionByID(userSession.ID)
 	return &apiv1.LogoutResponse{}, err
 }

--- a/master/internal/command/command_manager.go
+++ b/master/internal/command/command_manager.go
@@ -150,5 +150,7 @@ func (c *commandManager) newCommand(req *commandRequest) *command {
 		owner:          req.Owner,
 		agentUserGroup: req.AgentUserGroup,
 		taskSpec:       c.taskSpec,
+
+		db: c.db,
 	}
 }

--- a/master/internal/command/notebook_manager.go
+++ b/master/internal/command/notebook_manager.go
@@ -282,5 +282,7 @@ func (n *notebookManager) newNotebook(req *commandRequest) (*command, error) {
 		owner:          req.Owner,
 		agentUserGroup: req.AgentUserGroup,
 		taskSpec:       n.taskSpec,
+
+		db: n.db,
 	}, nil
 }

--- a/master/internal/command/shell_manager.go
+++ b/master/internal/command/shell_manager.go
@@ -222,5 +222,7 @@ func (s *shellManager) newShell(
 		taskSpec:       s.taskSpec,
 
 		proxyTCP: true,
+
+		db: s.db,
 	}
 }

--- a/master/internal/command/tensorboard_manager.go
+++ b/master/internal/command/tensorboard_manager.go
@@ -377,6 +377,8 @@ func (t *tensorboardManager) newTensorBoard(
 		owner:          commandReq.Owner,
 		agentUserGroup: commandReq.AgentUserGroup,
 		taskSpec:       t.taskSpec,
+
+		db: t.db,
 	}, nil
 }
 

--- a/master/internal/db/postgres_tasks.go
+++ b/master/internal/db/postgres_tasks.go
@@ -1,0 +1,59 @@
+package db
+
+import (
+	"github.com/o1egl/paseto"
+	"github.com/pkg/errors"
+
+	"github.com/determined-ai/determined/master/pkg/model"
+)
+
+// initTaskSessions creates a row in the task_sessions table.
+func (db *PgDB) initTaskSessions() error {
+	_, err := db.sql.Exec("DELETE FROM task_sessions")
+	return err
+}
+
+// StartTaskSession creates a row in the task_sessions table.
+func (db *PgDB) StartTaskSession(taskID string) (string, error) {
+	taskSession := &model.TaskSession{
+		TaskID: taskID,
+	}
+
+	query := "INSERT INTO task_sessions (task_id) VALUES (:task_id) RETURNING id"
+	if err := db.namedGet(&taskSession.ID, query, *taskSession); err != nil {
+		return "", err
+	}
+
+	v2 := paseto.NewV2()
+	token, err := v2.Sign(db.tokenKeys.PrivateKey, taskSession, nil)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to generate task authentication token")
+	}
+	return token, nil
+}
+
+// TaskSessionByToken returns a task session given an authentication token.
+func (db *PgDB) TaskSessionByToken(token string) (*model.TaskSession, error) {
+	v2 := paseto.NewV2()
+
+	var session model.TaskSession
+	err := v2.Verify(token, db.tokenKeys.PublicKey, &session, nil)
+	if err != nil {
+		return nil, ErrNotFound
+	}
+
+	query := `SELECT * FROM task_sessions WHERE id=$1`
+	if err := db.query(query, &session, session.ID); errors.Cause(err) == ErrNotFound {
+		return nil, ErrNotFound
+	} else if err != nil {
+		return nil, err
+	}
+
+	return &session, nil
+}
+
+// DeleteTaskSessionByTaskID deletes the task session with the given ID.
+func (db *PgDB) DeleteTaskSessionByTaskID(taskID string) error {
+	_, err := db.sql.Exec("DELETE FROM task_sessions WHERE task_id=$1", taskID)
+	return err
+}

--- a/master/internal/db/postgres_users.go
+++ b/master/internal/db/postgres_users.go
@@ -33,7 +33,7 @@ func (db *PgDB) StartUserSession(user *model.User) (string, error) {
 	v2 := paseto.NewV2()
 	token, err := v2.Sign(db.tokenKeys.PrivateKey, userSession, nil)
 	if err != nil {
-		return "", errors.Wrap(err, "failed to generate authentication token")
+		return "", errors.Wrap(err, "failed to generate user authentication token")
 	}
 	return token, nil
 }
@@ -72,8 +72,8 @@ WHERE user_sessions.id=$1`, &user, session.ID); errors.Cause(err) == ErrNotFound
 	return &user, &session, nil
 }
 
-// DeleteSessionByID deletes the session with the given ID.
-func (db *PgDB) DeleteSessionByID(sessionID model.SessionID) error {
+// DeleteUserSessionByID deletes the user session with the given ID.
+func (db *PgDB) DeleteUserSessionByID(sessionID model.SessionID) error {
 	_, err := db.sql.Exec("DELETE FROM user_sessions WHERE id=$1", sessionID)
 	return err
 }

--- a/master/internal/db/setup.go
+++ b/master/internal/db/setup.go
@@ -31,5 +31,11 @@ func Setup(opts *Config) (*PgDB, error) {
 	if err = db.Migrate(opts.Migrations); err != nil {
 		return nil, errors.Wrap(err, "running migrations")
 	}
-	return db, db.initAuthKeys()
+	if err = db.initAuthKeys(); err != nil {
+		return nil, err
+	}
+	if err = db.initTaskSessions(); err != nil {
+		return nil, err
+	}
+	return db, nil
 }

--- a/master/internal/trial.go
+++ b/master/internal/trial.go
@@ -628,11 +628,15 @@ func (t *trial) processAllocated(
 			tar.TypeReg,
 		),
 	}
-
+	taskToken, err := t.db.StartTaskSession(string(t.task.ID))
+	if err != nil {
+		return errors.Wrap(err, "cannot start a new task session for a trial")
+	}
 	for rank, a := range msg.Allocations {
 		t.containerRanks[a.Summary().ID] = rank
 		taskSpec := *t.taskSpec
 		taskSpec.AgentUserGroup = t.agentUserGroup
+		taskSpec.TaskToken = taskToken
 		taskSpec.SetInner(&tasks.StartTrial{
 			ExperimentConfig:    t.experiment.Config,
 			ModelDefinition:     t.modelDefinition,
@@ -1093,6 +1097,11 @@ func (t *trial) terminated(ctx *actor.Context) {
 
 	t.RunID++
 
+	if t.task != nil {
+		if err := t.db.DeleteTaskSessionByTaskID(string(t.task.ID)); err != nil {
+			ctx.Log().WithError(err).Error("error delete task session for a trial")
+		}
+	}
 	t.task = nil
 	t.allocations = nil
 	t.containerRanks = make(map[cproto.ID]int)

--- a/master/internal/user/service.go
+++ b/master/internal/user/service.go
@@ -111,7 +111,7 @@ func (s *Service) postLogout(c echo.Context) (interface{}, error) {
 	// Delete the user session information from the database.
 	sess := c.(*context.DetContext).MustGetUserSession()
 
-	if err := s.db.DeleteSessionByID(sess.ID); err != nil {
+	if err := s.db.DeleteUserSessionByID(sess.ID); err != nil {
 		return nil, err
 	}
 

--- a/master/pkg/model/task_session.go
+++ b/master/pkg/model/task_session.go
@@ -1,0 +1,7 @@
+package model
+
+// TaskSession corresponds to a row in the "task_sessions" DB table.
+type TaskSession struct {
+	ID     SessionID `db:"id" json:"id"`
+	TaskID string    `db:"task_id" json:"task_id"`
+}

--- a/master/pkg/tasks/task_spec.go
+++ b/master/pkg/tasks/task_spec.go
@@ -56,6 +56,7 @@ type TaskSpec struct {
 	inner
 
 	TaskID         string
+	TaskToken      string
 	ContainerID    string
 	Devices        []device.Device
 	AgentUserGroup *model.AgentUserGroup
@@ -86,6 +87,7 @@ func (t *TaskSpec) baseEnvVars() map[string]string {
 		// the user inside the container.
 		"PYTHONUSERBASE": userPythonBaseDir,
 		"DET_TASK_ID":    t.TaskID,
+		"DET_TASK_TOKEN": t.TaskToken,
 	}
 	if t.TaskContainerDefaults.NCCLPortRange != "" {
 		e["NCCL_PORT_RANGE"] = t.TaskContainerDefaults.NCCLPortRange

--- a/master/static/migrations/20210211000000_add-task-session.down.sql
+++ b/master/static/migrations/20210211000000_add-task-session.down.sql
@@ -1,0 +1,3 @@
+DROP TABLE public.task_sessions;
+
+DROP SEQUENCE public.task_sessions_id_seq;

--- a/master/static/migrations/20210211000000_add-task-session.up.sql
+++ b/master/static/migrations/20210211000000_add-task-session.up.sql
@@ -1,0 +1,12 @@
+CREATE SEQUENCE public.task_sessions_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+CREATE TABLE public.task_sessions (
+      id integer NOT NULL PRIMARY KEY DEFAULT nextval('public.task_sessions_id_seq'::regclass),
+      task_id uuid NOT NULL UNIQUE
+);


### PR DESCRIPTION
## Description

All the harness internal APIs will access the restful APIs with authentication. It uses a task token that is passed into the container. All task tokens' lifecycles are tied with the tasks' lifecycles.

Specifically, all the requests can have an HTTP header key-value pair with the key `Grpc-Metadata-x-task-token`. The gRPC server on the master will truncate the prefix `Grpc-` in the HTTP header and look it up in the task session list that exists in the database.

## Test Plan

Use it only internally. So tested it manually by the following command:

```
det command run --config 'resources.slots=0' 'curl -H "Grpc-Metadata-x-task-token: Bearer $DET_TASK_TOKEN" GET "$DET_MASTER/api/v1/experiments"'
```


## Commentary (optional)

N/A

## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
