### PR TITLE
docs: add model debug doc

### DIFF
--- a/docs/faq.txt
+++ b/docs/faq.txt
@@ -219,9 +219,19 @@ To change the container image used for an experiment, specify
 configuration file. Please see :ref:`container-images` for more details
 about configuring training environments.
 
+How do I debug a TensorFlow model inside Determined?
+====================================================
+
+Please see :ref:`model-debug`.
+
 *****************
  PyTorch Support
 *****************
+
+How do I debug a PyTorch model inside Determined?
+=================================================
+
+Please see :ref:`model-debug`.
 
 Why am I seeing significantly different metrics for trials which are paused and later continued than trials which aren't paused?
 ================================================================================================================================

--- a/docs/how-to/custom-env.txt
+++ b/docs/how-to/custom-env.txt
@@ -91,11 +91,11 @@ Default Images
 In the current version of Determined, the experiments and commands are
 executed in containers with the following:
 
--  Ubuntu 18.04
--  CUDA 10.0
+-  Ubuntu 20.04
+-  CUDA 10.1
 -  Python 3.6.9
--  TensorFlow 1.15.0
--  PyTorch 1.4.0
+-  TensorFlow 1.15.4
+-  PyTorch 1.7.0
 
 Determined will automatically select GPU-specific versions of each
 library when running on agents with GPUs.
@@ -120,11 +120,11 @@ TensorFlow 2 Images
 Determined also supports TensorFlow 2.2 and has a Docker image you can
 use for experiments and commands containing the following:
 
--  Ubuntu 18.04
+-  Ubuntu 20.04
 -  CUDA 10.1
 -  Python 3.6.9
--  TensorFlow 2.2.0
--  PyTorch 1.4.0
+-  TensorFlow 2.4.1
+-  PyTorch 1.7.0
 
 This can be configured in your experiment configuration like below:
 

--- a/docs/how-to/index.txt
+++ b/docs/how-to/index.txt
@@ -24,6 +24,10 @@ starting guides.
 
 -  :ref:`multi-gpu-training`
 
+**Model Debugging**
+
+-  :ref:`model-debug`
+
 The full list of our how-to guides can be found below:
 
 .. toctree::

--- a/docs/how-to/model-debug.txt
+++ b/docs/how-to/model-debug.txt
@@ -7,37 +7,50 @@
 This document aims to provide useful guidelines for debugging models
 with Determined. Hopefully, it will help you become a power user of
 Determined, but if you get stuck please don't hesitate to contact us on
-TODO:ref-support-channels!
+`Slack <https://determined-community.slack.com>`_! (`signup link
+<https://join.slack.com/t/determined-community/shared_invite/zt-cnj7802v-KcVbaUrIzQOwmkmY7gP0Ew>`_)
 
 This document focuses on model debugging, not cluster debugging, so it
 is assumed that you have already successfully :ref:`installed Determined
 <install-cluster>`.
 
+Successfully running code on a Determined cluster differs from normal
+training scripts in the following ways:
+
+   -  Your code will be organized into a Trial API.
+   -  The code will run in a docker container on another machine.
+   -  Your model may be ran many times in a hyperparameter search,
+      and/or it may be distributed across multiple GPUs or machines.
+
+This guide will introduce each change incrementally as we work towards
+achieving a fully-function model in Determined.
+
 The basic steps for debugging are:
 
-   -  Model-related issues:
+**Model-related issues:**
 
-        1. Does the original code run locally?
-        2. Does each method of your Trial class work locally?
-        3. Does local test mode work?
+   1. Does the original code run locally?
+   2. Does each method of your Trial class work locally?
+   3. Does local test mode work?
 
-   -  Docker- or Cluster-related issues
+**Docker- or Cluster-related issues**
 
-        4. Does the original code run in a Notebook or Shell?
-        5. Does each method of your Trial class work in a Notebook or Shell?
-        6. Does local test mode work in a Notebook or Shell?
+   4. Does the original code run in a Notebook or Shell?
+   5. Does each method of your Trial class work in a Notebook or Shell?
+   6. Does local test mode work in a Notebook or Shell?
 
-   -  Higher-level issues
+**Higher-level issues**
 
-        7. Does cluster test mode work with ``slots_per_trial=1``?
-        8. Does a single-GPU experiment work?
-        9. Does a multi-GPU experiment work?
+   7. Does cluster test mode work with ``slots_per_trial=1``?
+   8. Does a single-GPU experiment work?
+   9. Does a multi-GPU experiment work?
 
-Model-related issues
-====================
+**********************
+ Model-related issues
+**********************
 
 1. Does the original code run locally?
---------------------------------------
+======================================
 
 This step assumes you have have ported your model from some code outside
 of Determined. If your Trial code is not based on any such code, skip to
@@ -47,19 +60,23 @@ Probably you already know your code works, but this is a reminder to
 double-check before proceeding.
 
 2. Does each method of your Trial class work locally?
------------------------------------------------------
+=====================================================
 
 This step assumes you have a working local environment for training. If
-you normally run your code in a docker environment of some instead, skip
-to Step 4.
+you normally run your code in a docker environment instead, skip to Step
+4.
+
+The goal of this step is to ensure that your Trial API is behaving the
+way you think it should by calling its methods yourself and verifying
+the output.
 
 **How to test:** You should create some simple tests to verify that each
 method of your Trial is doing what you think it ought to be doing. There
 are some simple and practical examples of what these tests might look
 like for ``PyTorchTrial`` and ``TFKerasTrial`` in the
-:meth:`determined.TrainContext.from_config` documentation, but
-ultimately only you know what a reasonable test for your Trial needs to
-look like.
+:meth:`determined.TrialContext.from_config`
+documentation, but ultimately only you know what a reasonable test for
+your Trial needs to look like.
 
 **How to diagnose failures:** If you hit any issues running the methods
 of your Trial code locally, there are most likely errors in your Trial
@@ -68,10 +85,15 @@ file. Ideally, breaking it down method-by-method like this makes finding
 and solving issues much faster.
 
 3. Does local test mode work?
------------------------------
+=============================
 
 This step assumes you have a working local environment for training. If
 you do not, skip to Step 4.
+
+In Step 2, you validated that your Trial API calls are behaving the way
+you want them to. Now we will run the real Determined training loop
+(with abbreviated workloads) with your Trial to make sure that it is
+meeting the Determined requirements.
 
 **How to test:** Simply create an experiment, passing ``--local --test``
 on the command line:
@@ -80,20 +102,29 @@ on the command line:
 
    det experiment create myconfig.yaml my_model_dir --local --test
 
+``--local`` mean the training happens right where you launch it, rather
+than submitting the code to a cluster.
+
+``--test`` means that we are going to run abbreviated workloads to try
+to hit bugs sooner, and then exit right afterwards.
+
+If the command exits successfully, the test passed.
+
 **How to diagnose failures:** Local test mode does very few things; it
 builds a model, runs a single batch of training data, evaluates the
 model, and saves a checkpoint (to a dummy location). If your per-method
 checks in Step 2 were all successful but local test mode does not work,
 you may not be implementing your framework's Trial class correctly
 (double-check the documentation) or you may have found a bug in an
-invalid assumption in Determined (please file a github issue or contact
-us on TODO:ref:slack).
+invalid assumption in Determined (please file a Github issue or contact
+us on `slack <https://determined-community.slack.com>`_).
 
-Docker- or Cluster-related issues
-=================================
+***********************************
+ Docker- or Cluster-related issues
+***********************************
 
 4. Does the original code run in a Notebook or Shell?
------------------------------------------------------
+=====================================================
 
 This step is basically identical to Step 1, except we are going to run
 the original code on the Determined cluster rather than locally.
@@ -104,7 +135,8 @@ a ``--context`` option on the command line.
 
 Note that changes made to the ``--context`` directory while inside the
 Notebook or Shell will not affect the original files outside of the
-Notebook or Shell; see TODO for more details.
+Notebook or Shell; see :ref:`this description <notebook-state>` for more
+details.
 
 If you prefer to interact with your model via a Jupyter Notebook, try:
 
@@ -127,22 +159,24 @@ Once you are on the cluster, testing is identical to Step 1.
       context directory exceeding the maximum allowed size, it is
       because the ``--context`` directory has an upper limit of around
       128MB. If you need files larger than that as part of your model
-      definition, have a look at TODO:how-to-get-files-into-a-container.
+      definition, consider setting up a bind mount via the
+      ``bind_mounts`` field of :ref:`command-notebook-configuration`.
 
    -  You may be referencing files which exist locally but outside of
       the ``--context`` directory. If they are small, you may be able to
-      just copy them into the ``--context`` directory, see
-      TODO:how-to-get-files-into-a-container
+      just copy them into the ``--context`` directory.  Otherwise bind
+      mounting the files may be an option.
 
    -  If you hit dependency errors, you may have dependencies installed
       locally that are not installed in the Docker environment used on
-      the cluster. See TODO:customizing-commands
+      the cluster. See :ref:`custom-env` and :ref:`custom-docker-images`
+      for some options.
 
    -  If you have environment variables that you need set for your model
-      to work, see TODO:customizing-commands
+      to work, see :ref:`command-notebook-configuration`.
 
 5. Does each method of your Trial class work in a Notebook or Shell?
---------------------------------------------------------------------
+====================================================================
 
 This step is basically identical to Step 2, except we are going to run
 the original code on the Determined cluster rather than locally.
@@ -156,7 +190,7 @@ identical to Step 2.
 failure diagnosis for Step 2 and for Step 4.
 
 6. Does local test mode work in a Notebook or Shell?
-----------------------------------------------------
+====================================================
 
 This step is basically identical to Step 3, except we are going to run
 the original code on the Determined cluster rather than locally.
@@ -177,11 +211,12 @@ experiment create`` would.
 **How to diagnose failures:** Failure diagnosis is a combination of the
 failure diagnosis for both Step 3 and Step 4.
 
-Higher-level issues
-===================
+*********************
+ Higher-level issues
+*********************
 
 7. Does cluster test mode work with ``slots_per_trial=1``?
---------------------------------------------------------
+==========================================================
 
 This step is conceptually similar to Step 6, except instead of launching
 the command from an interactive environment, we will submit it to the
@@ -215,20 +250,16 @@ replicated in your experiment config:
       experiment config.
 
    -  Any ``pip``-install or ``apt``-install commands needed in the
-      interactive environment must either be built into a custom
-      docker image or they can be written into file called
-      ``startup-hook.sh`` in the root of the model definition
-      directory.  The commands in ``startup-hook.sh`` will be executed
-      automatically before training begins.
-
-      The startup-hook.sh option is quiker to try but will be slower at
-      runtime since it runs at the beginning of every trial.
+      interactive environment must either be built into a custom docker
+      image or they can be written into file called ``startup-hook.sh``
+      in the root of the model definition directory.  See
+      :ref:`startup-hooks` for more details.
 
    -  Any custom bind mounts to run in the interactive environment are
       also specified in the experiment config.
 
-   -  Environment variables are set properly in the experiment config
-      TODO:ref
+   -  Environment variables are set properly in the
+      :ref:`experiment-configuration`
 
 If no missing customizations are to blame, there are still several new
 layers introduced with a cluster-managed experiment that would not cause
@@ -240,32 +271,32 @@ issues with local training mode:
       message during experiment config validation, before any experiment
       or trials are created. To correct it, simply provide a
       ``checkpoint_storage`` configuration in one of those locations
-      (TODO:ref:master.yaml or TODO:ref:experiment_config).
+      (:ref:`master-configuration` or :ref:`experiment-configuration`).
 
    -  The configured ``checkpoint_storage`` settings are validated
-      before training starts for an experiment on the cluster. If you get
-      a message saying ``Checkpoint storage validation failed``, please
-      review the correctness of the values in your
+      before training starts for an experiment on the cluster. If you
+      get a message saying ``Checkpoint storage validation failed``,
+      please review the correctness of the values in your
       ``checkpoint_storage`` settings.
 
    -  The experiment config is fully validated for cluster-managed
       experiments, more strictly than it is for ``--local --test`` mode.
       If you get errors related to ``unmarshaling JSON`` when trying to
       submit the experiment to the cluster, that is an indication that
-      the experiment config has errors. Please review the TODO:
-      experiment-config-reference
+      the experiment config has errors. Please review the
+      :ref:`experiment-configuration`
 
-Again, if you are unable to identify the root cause of the issue yourself,
-please do not hesitate to contact Determined through our community
-support channels! TODO: link to support
+Again, if you are unable to identify the root cause of the issue
+yourself, please do not hesitate to contact Determined through our
+`community support <https://determined-community.slack.com>`_!
 
 8. Does a single-GPU experiment work?
--------------------------------------
+=====================================
 
 This step is just like to Step 7, except it introduces hyperparameter
 search and will execute full training for each trial.
 
-**How to test:** Configuration should be identical to Step 7.  Again,
+**How to test:** Configuration should be identical to Step 7. Again,
 confirm that your experiment config either does not specify
 ``resources.slots_per_trial`` at all, or that it is set to 1, like:
 
@@ -286,19 +317,19 @@ helpful):
 there are a few high-level categories of issues to check for:
 
    -  Does the error happen when the experiment has a
-      ``searcher.source_trial_id`` set?  One thing that can occur in a
+      ``searcher.source_trial_id`` set? One thing that can occur in a
       real experiment that does not occur in a ``--test`` experiment is
-      the loading of a of a previous checkpoint.  Errors when loading
+      the loading of a of a previous checkpoint. Errors when loading
       from a checkpoint can be caused by architecture change, where the
       new model code is not architecture-compatible with the old trial
       code.
 
-   - Generally, issues at this step are caused by doing training and
-     evaluation continuously, so focus on how that change may cause
-     issues with your code.
+   -  Generally, issues at this step are caused by doing training and
+      evaluation continuously, so focus on how that change may cause
+      issues with your code.
 
 9. Does a multi-GPU experiment work?
--------------------------------------
+====================================
 
 This step is like Step 8, but introduces distributed training.
 Naturally, this step is only relevant if you have multiple GPUs and you
@@ -318,20 +349,34 @@ Then create your experiment:
 
    det experiment create myconfig.yaml my_model_dir -f
 
-**How to diagnose failures:**  If you are using the ``determined``
+**How to diagnose failures:** If you are using the ``determined``
 library APIs correctly, then theoretically distributed training should
-"just work".  However, you should be aware of some common pitfalls:
+"just work". However, you should be aware of some common pitfalls:
 
-   - Determined normally controls the details of distributed training
-     for you.  If you are also trying to control those details, such as
-     calling ``tf.config.set_visible_devices()`` in a KerasTrial or
-     EstimatorTrial will very likely cause issues.
+   -  If your experiment is not being scheduled on the cluster, ensure
+      that your ``slots_per_trial`` setting is valid for your cluster.
+      E.g. if you have 4 Detrmined Agents running with 4 GPUs each, your
+      ``slots_per_trial`` could be ``1``, ``2,``, ``3``, ``4`` (which
+      would all fit on a single machine), or it could be ``8`` or ``12``
+      or ``16`` (which would take up some number of complete Agent
+      machines), but it couldn't be ``5`` (more than one Agent but not a
+      multiple of Agent size) and it couldn't be ``32`` (too big for the
+      cluster). Also ensure that there are no other notebooks, shells,
+      or experiments on the cluster which may be consuming too many
+      resources and preventing from starting.
 
-   - Some classes of metrics must be calculated specially during
-     distributed training.  Most metrics, like loss or accuracy, can be
-     calculated piecemeal on each worker in a distributed training job
-     and averaged afterwards.  Those metrics are handled automatically
-     by Determined and need no special handling.  Other metrics, like
-     F1 score, cannot be averaged from individual workers' F1 scores.
-     Determined has tooling for handling these metrics, see
-     TODO:ref:pytorch-reducers and TODO:ref:estimators-reducers.
+   -  Determined normally controls the details of distributed training
+      for you. Attempting to also control those details yourself, such
+      as calling ``tf.config.set_visible_devices()`` in a KerasTrial or
+      EstimatorTrial will very likely cause issues.
+
+   -  Some classes of metrics must be calculated specially during
+      distributed training. Most metrics, like loss or accuracy, can be
+      calculated piecemeal on each worker in a distributed training job
+      and averaged afterwards. Those metrics are handled automatically
+      by Determined and need no special handling. Other metrics, like F1
+      score, cannot be averaged from individual workers' F1 scores.
+      Determined has tooling for handling these metrics; see the docs
+      for using custom metric reducers with
+      :ref:`PyTorchTrial <pytorch-custom-reducers>` and
+      :ref:`EstimatorTrial <estimators-custom-reducers>`.

--- a/docs/how-to/model-debug.txt
+++ b/docs/how-to/model-debug.txt
@@ -1,0 +1,337 @@
+.. _model-debug:
+
+###############################
+ Model Debugging in Determined
+###############################
+
+This document aims to provide useful guidelines for debugging models
+with Determined. Hopefully, it will help you become a power user of
+Determined, but if you get stuck please don't hesitate to contact us on
+TODO:ref-support-channels!
+
+This document focuses on model debugging, not cluster debugging, so it
+is assumed that you have already successfully :ref:`installed Determined
+<install-cluster>`.
+
+The basic steps for debugging are:
+
+   -  Model-related issues:
+
+        1. Does the original code run locally?
+        2. Does each method of your Trial class work locally?
+        3. Does local test mode work?
+
+   -  Docker- or Cluster-related issues
+
+        4. Does the original code run in a Notebook or Shell?
+        5. Does each method of your Trial class work in a Notebook or Shell?
+        6. Does local test mode work in a Notebook or Shell?
+
+   -  Higher-level issues
+
+        7. Does cluster test mode work with ``slots_per_trial=1``?
+        8. Does a single-GPU experiment work?
+        9. Does a multi-GPU experiment work?
+
+Model-related issues
+====================
+
+1. Does the original code run locally?
+--------------------------------------
+
+This step assumes you have have ported your model from some code outside
+of Determined. If your Trial code is not based on any such code, skip to
+Step 2.
+
+Probably you already know your code works, but this is a reminder to
+double-check before proceeding.
+
+2. Does each method of your Trial class work locally?
+-----------------------------------------------------
+
+This step assumes you have a working local environment for training. If
+you normally run your code in a docker environment of some instead, skip
+to Step 4.
+
+**How to test:** You should create some simple tests to verify that each
+method of your Trial is doing what you think it ought to be doing. There
+are some simple and practical examples of what these tests might look
+like for ``PyTorchTrial`` and ``TFKerasTrial`` in the
+:meth:`determined.TrainContext.from_config` documentation, but
+ultimately only you know what a reasonable test for your Trial needs to
+look like.
+
+**How to diagnose failures:** If you hit any issues running the methods
+of your Trial code locally, there are most likely errors in your Trial
+class, or possibly in the ``hyperparameters`` section of your config
+file. Ideally, breaking it down method-by-method like this makes finding
+and solving issues much faster.
+
+3. Does local test mode work?
+-----------------------------
+
+This step assumes you have a working local environment for training. If
+you do not, skip to Step 4.
+
+**How to test:** Simply create an experiment, passing ``--local --test``
+on the command line:
+
+.. code:: bash
+
+   det experiment create myconfig.yaml my_model_dir --local --test
+
+**How to diagnose failures:** Local test mode does very few things; it
+builds a model, runs a single batch of training data, evaluates the
+model, and saves a checkpoint (to a dummy location). If your per-method
+checks in Step 2 were all successful but local test mode does not work,
+you may not be implementing your framework's Trial class correctly
+(double-check the documentation) or you may have found a bug in an
+invalid assumption in Determined (please file a github issue or contact
+us on TODO:ref:slack).
+
+Docker- or Cluster-related issues
+=================================
+
+4. Does the original code run in a Notebook or Shell?
+-----------------------------------------------------
+
+This step is basically identical to Step 1, except we are going to run
+the original code on the Determined cluster rather than locally.
+
+**How to test:** First launch a Notebook or Shell on the cluster,
+passing the root directory containing your model and training scripts as
+a ``--context`` option on the command line.
+
+Note that changes made to the ``--context`` directory while inside the
+Notebook or Shell will not affect the original files outside of the
+Notebook or Shell; see TODO for more details.
+
+If you prefer to interact with your model via a Jupyter Notebook, try:
+
+.. code:: bash
+
+   det notebook start --context my_model_dir
+   # Your browser should automatically open the notebook.
+
+If you prefer to interact with your model via ssh, try:
+
+.. code:: bash
+
+   det shell start --context my_model_dir
+   # Your terminal should automatically connect to the shell.
+
+Once you are on the cluster, testing is identical to Step 1.
+
+**How to diagnose failures:**
+   -  If you are unable to start the container with a message about the
+      context directory exceeding the maximum allowed size, it is
+      because the ``--context`` directory has an upper limit of around
+      128MB. If you need files larger than that as part of your model
+      definition, have a look at TODO:how-to-get-files-into-a-container.
+
+   -  You may be referencing files which exist locally but outside of
+      the ``--context`` directory. If they are small, you may be able to
+      just copy them into the ``--context`` directory, see
+      TODO:how-to-get-files-into-a-container
+
+   -  If you hit dependency errors, you may have dependencies installed
+      locally that are not installed in the Docker environment used on
+      the cluster. See TODO:customizing-commands
+
+   -  If you have environment variables that you need set for your model
+      to work, see TODO:customizing-commands
+
+5. Does each method of your Trial class work in a Notebook or Shell?
+--------------------------------------------------------------------
+
+This step is basically identical to Step 2, except we are going to run
+the original code on the Determined cluster rather than locally.
+
+**How to test:** Launch a Notebook or Shell as in Step 4.
+
+Once you are interacting with the shell or notebook, testing is
+identical to Step 2.
+
+**How to diagnose failures:** Failure diagnosis is a combination of the
+failure diagnosis for Step 2 and for Step 4.
+
+6. Does local test mode work in a Notebook or Shell?
+----------------------------------------------------
+
+This step is basically identical to Step 3, except we are going to run
+the original code on the Determined cluster rather than locally.
+
+**How to test:** Launch a Notebook or Shell as in Step 4.
+
+Once you are on the cluster, testing is identical to Step 3, with the
+important caveat that the model definition argument to ``det experiment
+create`` (the second positional argument) should always be
+``/run/determined/workdir`` (or ``.`` if you have not changed the
+working directory from when you first connected to the cluster).
+
+This is because the ``--context`` you passed when creating the Shell or
+Notebook will be copied to ``/run/determined/workdir`` inside the
+container, exactly the same as the model definition argument to ``det
+experiment create`` would.
+
+**How to diagnose failures:** Failure diagnosis is a combination of the
+failure diagnosis for both Step 3 and Step 4.
+
+Higher-level issues
+===================
+
+7. Does cluster test mode work with ``slots_per_trial=1``?
+--------------------------------------------------------
+
+This step is conceptually similar to Step 6, except instead of launching
+the command from an interactive environment, we will submit it to the
+cluster and let Determined manage everything.
+
+**How to test:** If you had to make any customizations to your command
+environment while testing Steps 3, 4, or 5, make sure that you have made
+the same customizations in your experiment config. Then also confirm
+that your experiment config either does not specify
+``resources.slots_per_trial`` at all, or that it is set to 1, like:
+
+.. code:: yaml
+
+   resources:
+     slots_per_trial: 1
+
+Then create an experiment with the ``--test`` flag (but not the
+``--local`` flag):
+
+.. code:: bash
+
+   det experiment create myconfig.yaml my_model_dir --test
+
+**How to diagnose failures:** If you were able to run local test mode
+inside a Notebook or Shell, but you are unable to successfully submit an
+experiment, you should focus on making sure that any customizations you
+made to get it to work in the Notebook or Shell have been properly
+replicated in your experiment config:
+
+   -  If you need a custom docker image, that can be set in the
+      experiment config.
+
+   -  Any ``pip``-install or ``apt``-install commands needed in the
+      interactive environment must either be built into a custom
+      docker image or they can be written into file called
+      ``startup-hook.sh`` in the root of the model definition
+      directory.  The commands in ``startup-hook.sh`` will be executed
+      automatically before training begins.
+
+      The startup-hook.sh option is quiker to try but will be slower at
+      runtime since it runs at the beginning of every trial.
+
+   -  Any custom bind mounts to run in the interactive environment are
+      also specified in the experiment config.
+
+   -  Environment variables are set properly in the experiment config
+      TODO:ref
+
+If no missing customizations are to blame, there are still several new
+layers introduced with a cluster-managed experiment that would not cause
+issues with local training mode:
+
+   -  The ``checkpoint_storage`` settings are used for cluster-managed
+      trainings. If ``checkpoint_storage`` was neither configured in the
+      experiment config nor in the master config, you will see an error
+      message during experiment config validation, before any experiment
+      or trials are created. To correct it, simply provide a
+      ``checkpoint_storage`` configuration in one of those locations
+      (TODO:ref:master.yaml or TODO:ref:experiment_config).
+
+   -  The configured ``checkpoint_storage`` settings are validated
+      before training starts for an experiment on the cluster. If you get
+      a message saying ``Checkpoint storage validation failed``, please
+      review the correctness of the values in your
+      ``checkpoint_storage`` settings.
+
+   -  The experiment config is fully validated for cluster-managed
+      experiments, more strictly than it is for ``--local --test`` mode.
+      If you get errors related to ``unmarshaling JSON`` when trying to
+      submit the experiment to the cluster, that is an indication that
+      the experiment config has errors. Please review the TODO:
+      experiment-config-reference
+
+Again, if you are unable to identify the root cause of the issue yourself,
+please do not hesitate to contact Determined through our community
+support channels! TODO: link to support
+
+8. Does a single-GPU experiment work?
+-------------------------------------
+
+This step is just like to Step 7, except it introduces hyperparameter
+search and will execute full training for each trial.
+
+**How to test:** Configuration should be identical to Step 7.  Again,
+confirm that your experiment config either does not specify
+``resources.slots_per_trial`` at all, or that it is set to 1, like:
+
+.. code:: yaml
+
+   resources:
+     slots_per_trial: 1
+
+Then create an experiment without either of ``--test`` or ``--local``
+flags (probably you will find the ``--follow`` or ``-f`` flag to be
+helpful):
+
+.. code:: bash
+
+   det experiment create myconfig.yaml my_model_dir -f
+
+**How to diagnose failures:** If Step 7 worked but Step 8 does not,
+there are a few high-level categories of issues to check for:
+
+   -  Does the error happen when the experiment has a
+      ``searcher.source_trial_id`` set?  One thing that can occur in a
+      real experiment that does not occur in a ``--test`` experiment is
+      the loading of a of a previous checkpoint.  Errors when loading
+      from a checkpoint can be caused by architecture change, where the
+      new model code is not architecture-compatible with the old trial
+      code.
+
+   - Generally, issues at this step are caused by doing training and
+     evaluation continuously, so focus on how that change may cause
+     issues with your code.
+
+9. Does a multi-GPU experiment work?
+-------------------------------------
+
+This step is like Step 8, but introduces distributed training.
+Naturally, this step is only relevant if you have multiple GPUs and you
+wish to use distributed training.
+
+**How to test:** Configuration should be like Step 7, except you will
+now set ``resources.slots_per_trial`` to some number greater than 1:
+
+.. code:: yaml
+
+   resources:
+     slots_per_trial: 2
+
+Then create your experiment:
+
+.. code:: bash
+
+   det experiment create myconfig.yaml my_model_dir -f
+
+**How to diagnose failures:**  If you are using the ``determined``
+library APIs correctly, then theoretically distributed training should
+"just work".  However, you should be aware of some common pitfalls:
+
+   - Determined normally controls the details of distributed training
+     for you.  If you are also trying to control those details, such as
+     calling ``tf.config.set_visible_devices()`` in a KerasTrial or
+     EstimatorTrial will very likely cause issues.
+
+   - Some classes of metrics must be calculated specially during
+     distributed training.  Most metrics, like loss or accuracy, can be
+     calculated piecemeal on each worker in a distributed training job
+     and averaged afterwards.  Those metrics are handled automatically
+     by Determined and need no special handling.  Other metrics, like
+     F1 score, cannot be averaged from individual workers' F1 scores.
+     Determined has tooling for handling these metrics, see
+     TODO:ref:pytorch-reducers and TODO:ref:estimators-reducers.

--- a/docs/how-to/model-debug.txt
+++ b/docs/how-to/model-debug.txt
@@ -29,21 +29,21 @@ The basic steps for debugging are:
 
 **Model-related issues:**
 
-   1. Does the original code run locally?
-   2. Does each method of your Trial class work locally?
-   3. Does local test mode work?
+   #. Does the original code run locally?
+   #. Does each method of your Trial class work locally?
+   #. Does local test mode work?
 
 **Docker- or Cluster-related issues**
 
    4. Does the original code run in a Notebook or Shell?
-   5. Does each method of your Trial class work in a Notebook or Shell?
-   6. Does local test mode work in a Notebook or Shell?
+   #. Does each method of your Trial class work in a Notebook or Shell?
+   #. Does local test mode work in a Notebook or Shell?
 
 **Higher-level issues**
 
    7. Does cluster test mode work with ``slots_per_trial=1``?
-   8. Does a single-GPU experiment work?
-   9. Does a multi-GPU experiment work?
+   #. Does a single-GPU experiment work?
+   #. Does a multi-GPU experiment work?
 
 **********************
  Model-related issues
@@ -74,9 +74,9 @@ the output.
 method of your Trial is doing what you think it ought to be doing. There
 are some simple and practical examples of what these tests might look
 like for ``PyTorchTrial`` and ``TFKerasTrial`` in the
-:meth:`determined.TrialContext.from_config`
-documentation, but ultimately only you know what a reasonable test for
-your Trial needs to look like.
+:meth:`determined.TrialContext.from_config` documentation, but
+ultimately only you know what a reasonable test for your Trial needs to
+look like.
 
 **How to diagnose failures:** If you hit any issues running the methods
 of your Trial code locally, there are most likely errors in your Trial
@@ -161,10 +161,13 @@ Once you are on the cluster, testing is identical to Step 1.
       128MB. If you need files larger than that as part of your model
       definition, consider setting up a bind mount via the
       ``bind_mounts`` field of :ref:`command-notebook-configuration`.
+      The tutorial on `ref:`data-access` lists some additional
+      strategies for accessing files inside a containerized environment
+      which may also be relevant.
 
    -  You may be referencing files which exist locally but outside of
       the ``--context`` directory. If they are small, you may be able to
-      just copy them into the ``--context`` directory.  Otherwise bind
+      just copy them into the ``--context`` directory. Otherwise bind
       mounting the files may be an option.
 
    -  If you hit dependency errors, you may have dependencies installed
@@ -252,7 +255,7 @@ replicated in your experiment config:
    -  Any ``pip``-install or ``apt``-install commands needed in the
       interactive environment must either be built into a custom docker
       image or they can be written into file called ``startup-hook.sh``
-      in the root of the model definition directory.  See
+      in the root of the model definition directory. See
       :ref:`startup-hooks` for more details.
 
    -  Any custom bind mounts to run in the interactive environment are
@@ -377,6 +380,6 @@ library APIs correctly, then theoretically distributed training should
       by Determined and need no special handling. Other metrics, like F1
       score, cannot be averaged from individual workers' F1 scores.
       Determined has tooling for handling these metrics; see the docs
-      for using custom metric reducers with
-      :ref:`PyTorchTrial <pytorch-custom-reducers>` and
-      :ref:`EstimatorTrial <estimators-custom-reducers>`.
+      for using custom metric reducers with :ref:`PyTorchTrial
+      <pytorch-custom-reducers>` and :ref:`EstimatorTrial
+      <estimators-custom-reducers>`.

--- a/docs/reference/api/estimator.txt
+++ b/docs/reference/api/estimator.txt
@@ -53,6 +53,8 @@ context object where these functions will be found will be in
    :members: cache_train_dataset, cache_validation_dataset, make_metric
    :member-order: bysource
 
+.. _estimators-custom-reducers:
+
 Reducing Metrics
 ================
 

--- a/docs/reference/api/estimator.txt
+++ b/docs/reference/api/estimator.txt
@@ -110,6 +110,12 @@ metadata checkpoints:
                hooks=[MyHook(self.context, "my_metadata")],
            )
 
+***********
+ Debugging
+***********
+
+Please see :ref:`model-debug`.
+
 **********
  Examples
 **********

--- a/docs/reference/api/keras.txt
+++ b/docs/reference/api/keras.txt
@@ -114,6 +114,12 @@ the ``tf.keras.callbacks.Callbacks`` interface) and supply them to the
 
 .. autoclass:: determined.keras.callbacks.TensorBoard
 
+***********
+ Debugging
+***********
+
+Please see :ref:`model-debug`.
+
 **********
  Examples
 **********

--- a/docs/reference/api/pytorch.txt
+++ b/docs/reference/api/pytorch.txt
@@ -132,6 +132,12 @@ To execute arbitrary Python code during the lifecycle of a
 .. autoclass:: determined.pytorch.PyTorchCallback
    :members:
 
+***********
+ Debugging
+***********
+
+Please see :ref:`model-debug`.
+
 **********
  Examples
 **********

--- a/docs/reference/api/pytorch.txt
+++ b/docs/reference/api/pytorch.txt
@@ -103,7 +103,7 @@ Gradient Clipping
 Users need to pass a gradient clipping function to
 :meth:`determined.pytorch.PyTorchTrialContext.step_optimizer`.
 
-.. _pytorch-callbacks:
+.. _pytorch-custom-reducers:
 
 Reducing Metrics
 ================
@@ -120,6 +120,8 @@ for more details.
 .. autoclass:: determined.pytorch.MetricReducer
    :members: reset, per_slot_reduce, cross_slot_reduce
    :member-order: bysource
+
+.. _pytorch-callbacks:
 
 Callbacks
 =========

--- a/docs/release-notes/1895-model-debug-doc.txt
+++ b/docs/release-notes/1895-model-debug-doc.txt
@@ -1,0 +1,9 @@
+:orphan:
+
+**Improvements**
+
+-  Documentation: Add a guide for :ref:`model-debug`. The new guide will
+   walk you step-by-step through solving problems with a model in
+   Determined, with a focus on testing features incrementally until the
+   model is fully working. It may also be useful when porting new models
+   to Determined.

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -5,5 +5,5 @@ sphinx-argparse>=0.2.5
 git+https://github.com/determined-ai/determined_sphinx_theme.git@9edfa7c6ce6926def9fc69b8ddd7666f3419a907
 sphinx-sitemap>=2.2.0
 pillow
-rstfmt==0.0.6
+rstfmt==0.0.7
 sphinx-copybutton

--- a/docs/topic-guides/model-definitions/best-practices.txt
+++ b/docs/topic-guides/model-definitions/best-practices.txt
@@ -102,6 +102,9 @@ Do not:
 
 Do:
 
+-  Use the :ref:`model-debug` guide if you run into issues with your
+   Trial class.
+
 -  Use framework abstractions to implement learning rate scheduling
    instead of directly changing the learning rate. See
    `tf.keras.optimizers.schedules.LearningRateSchedule

--- a/docs/topic-guides/model-definitions/trial-api.txt
+++ b/docs/topic-guides/model-definitions/trial-api.txt
@@ -21,6 +21,11 @@ application frameworks it supports:
 -  :ref:`tf-keras-trial`
 -  :ref:`estimator-trial`
 
+If you hit any issues creating your Trial API model definition, you can
+visit :ref:`model-debug`. It may also be useful for writing your first
+trial, as it has a framework for incrementally testing each of the
+features you will need in a successful Trial definition.
+
 .. _model-definitions_trial-api-create:
 
 ********************************************************


### PR DESCRIPTION
## Description

It is looking like the observability project is going to solve what I was trying to solve in https://github.com/determined-ai/determined/pull/1625, only much better.  As a result, I'm pulling out just the debug documentation as a separate PR to land now.