### PR TITLE
chore: Bump images and versions to Tensorflow 2.4.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,11 +100,11 @@ commands:
       - when:
           condition: <<parameters.tf1>>
           steps:
-            - run: docker pull determinedai/environments:py-3.6.9-pytorch-1.7-tf-1.15-cpu-5f6f6e1
+            - run: docker pull determinedai/environments:py-3.6.9-pytorch-1.7-tf-1.15-cpu-4a93d25
       - when:
           condition: <<parameters.tf2>>
           steps:
-            - run: docker pull determinedai/environments:py-3.6.9-pytorch-1.7-tf-2.4-cpu-5f6f6e1
+            - run: docker pull determinedai/environments:py-3.6.9-pytorch-1.7-tf-2.4-cpu-4a93d25
 
   login-docker:
     steps:
@@ -1129,7 +1129,7 @@ jobs:
       - setup-python-venv:
           determined-common: true
           determined: true
-          extras-requires: "tensorflow==2.4.0 torch==1.7.0 torchvision==0.8.1"
+          extras-requires: "tensorflow==2.4.1 torch==1.7.0 torchvision==0.8.1"
           extra-requirements-file: "harness/tests/requirements.txt"
           executor: determinedai/cimg-base:stable
       - run: make -C harness test
@@ -1142,7 +1142,7 @@ jobs:
       - setup-python-venv:
           determined-common: true
           determined: true
-          extras-requires: "tensorflow==2.2.0"
+          extras-requires: "tensorflow==2.4.1"
           extra-requirements-file: "harness/tests/requirements.txt"
           executor: determinedai/cimg-base:stable
       - run: make -C harness test-tf2

--- a/deploy/determined_deploy/aws/templates/efs.yaml
+++ b/deploy/determined_deploy/aws/templates/efs.yaml
@@ -4,35 +4,35 @@ Mappings:
   RegionMap:
     ap-northeast-1:
       Master: ami-03ec47ea54612a98d
-      Agent: ami-0881b60d3da7bd055
+      Agent: ami-055e84fd91eebace4
     # TODO(DET-4258) Uncomment these when we fully support all P3 regions.
     # ap-northeast-2:
     #   Master: ami-00813ad98dc81f443
-    #   Agent: ami-045eb8957d930ee48
+    #   Agent: ami-098f3d295106b7e70
     # ap-southeast-1:
     #   Master: ami-0acac505592775345
-    #   Agent: ami-0b5cca90cd338e59d
+    #   Agent: ami-00de94d5b3e68b0da
     # ap-southeast-2:
     #   Master: ami-07c5b4ba4c9dd25a3
-    #   Agent: ami-0725e68bb3b036074
+    #   Agent: ami-0af10fa7e8454d943
     eu-central-1:
       Master: ami-01c74b7d55cbb6e31
-      Agent: ami-0a7e28c7ffceaaca3
+      Agent: ami-0171d0a466f6d4ac3
     eu-west-1:
       Master: ami-06f91a2970093cb47
-      Agent: ami-01ff907f77946e9c0
+      Agent: ami-09925722b0ba31d90
     # eu-west-2:
     #   Master: ami-0be58974fa441cb39
-    #   Agent: ami-08b697d6313df6508
+    #   Agent: ami-0aa3396d882c02376
     us-east-1:
       Master: ami-0f593aebffc0070e1
-      Agent: ami-0abefee50ebdc21f4
+      Agent: ami-0281f5b6b2ae2df84
     us-east-2:
       Master: ami-096cdd827d38ca4d8
-      Agent: ami-0d074fb7abacd5219
+      Agent: ami-02a26ef27a997c7de
     us-west-2:
       Master: ami-04e9aec1ab665f323
-      Agent: ami-0685e5e3534f24db8
+      Agent: ami-0fc52ebf88f40652b
 
 Parameters:
   VpcCIDR:

--- a/deploy/determined_deploy/aws/templates/fsx.yaml
+++ b/deploy/determined_deploy/aws/templates/fsx.yaml
@@ -3,35 +3,35 @@ Mappings:
   RegionMap:
     ap-northeast-1:
       Master: ami-03ec47ea54612a98d
-      Agent: ami-0881b60d3da7bd055
+      Agent: ami-055e84fd91eebace4
     # TODO(DET-4258) Uncomment these when we fully support all P3 regions.
     # ap-northeast-2:
     #   Master: ami-00813ad98dc81f443
-    #   Agent: ami-045eb8957d930ee48
+    #   Agent: ami-098f3d295106b7e70
     # ap-southeast-1:
     #   Master: ami-0acac505592775345
-    #   Agent: ami-0b5cca90cd338e59d
+    #   Agent: ami-00de94d5b3e68b0da
     # ap-southeast-2:
     #   Master: ami-07c5b4ba4c9dd25a3
-    #   Agent: ami-0725e68bb3b036074
+    #   Agent: ami-0af10fa7e8454d943
     eu-central-1:
       Master: ami-01c74b7d55cbb6e31
-      Agent: ami-0a7e28c7ffceaaca3
+      Agent: ami-0171d0a466f6d4ac3
     eu-west-1:
       Master: ami-06f91a2970093cb47
-      Agent: ami-01ff907f77946e9c0
+      Agent: ami-09925722b0ba31d90
     # eu-west-2:
     #   Master: ami-0be58974fa441cb39
-    #   Agent: ami-08b697d6313df6508
+    #   Agent: ami-0aa3396d882c02376
     us-east-1:
       Master: ami-0f593aebffc0070e1
-      Agent: ami-0abefee50ebdc21f4
+      Agent: ami-0281f5b6b2ae2df84
     us-east-2:
       Master: ami-096cdd827d38ca4d8
-      Agent: ami-0d074fb7abacd5219
+      Agent: ami-02a26ef27a997c7de
     us-west-2:
       Master: ami-04e9aec1ab665f323
-      Agent: ami-0685e5e3534f24db8
+      Agent: ami-0fc52ebf88f40652b
 
 Parameters:
   VpcCIDR:

--- a/deploy/determined_deploy/aws/templates/secure.yaml
+++ b/deploy/determined_deploy/aws/templates/secure.yaml
@@ -4,45 +4,45 @@ Mappings:
   RegionMap:
     ap-northeast-1:
       Master: ami-03ec47ea54612a98d
-      Agent: ami-0881b60d3da7bd055
-      Bastion: ami-07faf6b16c502e9e1
+      Agent: ami-055e84fd91eebace4
+      Bastion: ami-09dac16017637391f
     # TODO(DET-4258) Uncomment these when we fully support all P3 regions.
     # ap-northeast-2:
     #   Master: ami-00813ad98dc81f443
-    #   Agent: ami-045eb8957d930ee48
-    #   Bastion: ami-0ee428c63274f56c1
+    #   Agent: ami-098f3d295106b7e70
+    #   Bastion: ami-0b50511490117e709
     # ap-southeast-1:
     #   Master: ami-0acac505592775345
-    #   Agent: ami-0b5cca90cd338e59d
-    #   Bastion: ami-06bcc4026e190b380
+    #   Agent: ami-00de94d5b3e68b0da
+    #   Bastion: ami-0ae3e6717dc99c62b
     # ap-southeast-2:
     #   Master: ami-07c5b4ba4c9dd25a3
-    #   Agent: ami-0725e68bb3b036074
-    #   Bastion: ami-0b079c5b689b2d44e
+    #   Agent: ami-0af10fa7e8454d943
+    #   Bastion: ami-080b87fdc6d5ca853
     eu-central-1:
       Master: ami-01c74b7d55cbb6e31
-      Agent: ami-0a7e28c7ffceaaca3
-      Bastion: ami-0a4938aa802d3fc05
+      Agent: ami-0171d0a466f6d4ac3
+      Bastion: ami-0093cac2bf998a669
     eu-west-1:
       Master: ami-06f91a2970093cb47
-      Agent: ami-01ff907f77946e9c0
-      Bastion: ami-0074515a838fb8787
+      Agent: ami-09925722b0ba31d90
+      Bastion: ami-0e5657f6d3c3ea350
     # eu-west-2:
     #   Master: ami-0be58974fa441cb39
-    #   Agent: ami-08b697d6313df6508
-    #   Bastion: ami-0789c35b922fefc1e
+    #   Agent: ami-0aa3396d882c02376
+    #   Bastion: ami-09b984029e6b0326b
     us-east-1:
       Master: ami-0f593aebffc0070e1
-      Agent: ami-0abefee50ebdc21f4
-      Bastion: ami-007e8beb808004fdc
+      Agent: ami-0281f5b6b2ae2df84
+      Bastion: ami-02fe94dee086c0c37
     us-east-2:
       Master: ami-096cdd827d38ca4d8
-      Agent: ami-0d074fb7abacd5219
-      Bastion: ami-05c386ebc03ca06da
+      Agent: ami-02a26ef27a997c7de
+      Bastion: ami-02aa7f3de34db391a
     us-west-2:
       Master: ami-04e9aec1ab665f323
-      Agent: ami-0685e5e3534f24db8
-      Bastion: ami-0b5f687730c825c7d
+      Agent: ami-0fc52ebf88f40652b
+      Bastion: ami-025102f49d03bec05
 
 Parameters:
   VpcCIDR:

--- a/deploy/determined_deploy/aws/templates/simple.yaml
+++ b/deploy/determined_deploy/aws/templates/simple.yaml
@@ -5,35 +5,35 @@ Mappings:
   RegionMap:
     ap-northeast-1:
       Master: ami-03ec47ea54612a98d
-      Agent: ami-0881b60d3da7bd055
+      Agent: ami-055e84fd91eebace4
     # TODO(DET-4258) Uncomment these when we fully support all P3 regions.
     # ap-northeast-2:
     #   Master: ami-00813ad98dc81f443
-    #   Agent: ami-045eb8957d930ee48
+    #   Agent: ami-098f3d295106b7e70
     # ap-southeast-1:
     #   Master: ami-0acac505592775345
-    #   Agent: ami-0b5cca90cd338e59d
+    #   Agent: ami-00de94d5b3e68b0da
     # ap-southeast-2:
     #   Master: ami-07c5b4ba4c9dd25a3
-    #   Agent: ami-0725e68bb3b036074
+    #   Agent: ami-0af10fa7e8454d943
     eu-central-1:
       Master: ami-01c74b7d55cbb6e31
-      Agent: ami-0a7e28c7ffceaaca3
+      Agent: ami-0171d0a466f6d4ac3
     eu-west-1:
       Master: ami-06f91a2970093cb47
-      Agent: ami-01ff907f77946e9c0
+      Agent: ami-09925722b0ba31d90
     # eu-west-2:
     #   Master: ami-0be58974fa441cb39
-    #   Agent: ami-08b697d6313df6508
+    #   Agent: ami-0aa3396d882c02376
     us-east-1:
       Master: ami-0f593aebffc0070e1
-      Agent: ami-0abefee50ebdc21f4
+      Agent: ami-0281f5b6b2ae2df84
     us-east-2:
       Master: ami-096cdd827d38ca4d8
-      Agent: ami-0d074fb7abacd5219
+      Agent: ami-02a26ef27a997c7de
     us-west-2:
       Master: ami-04e9aec1ab665f323
-      Agent: ami-0685e5e3534f24db8
+      Agent: ami-0fc52ebf88f40652b
 
 Parameters:
   Keypair:

--- a/deploy/determined_deploy/aws/templates/vpc.yaml
+++ b/deploy/determined_deploy/aws/templates/vpc.yaml
@@ -4,35 +4,35 @@ Mappings:
   RegionMap:
     ap-northeast-1:
       Master: ami-03ec47ea54612a98d
-      Agent: ami-0881b60d3da7bd055
+      Agent: ami-055e84fd91eebace4
     # TODO(DET-4258) Uncomment these when we fully support all P3 regions.
     # ap-northeast-2:
     #   Master: ami-00813ad98dc81f443
-    #   Agent: ami-045eb8957d930ee48
+    #   Agent: ami-098f3d295106b7e70
     # ap-southeast-1:
     #   Master: ami-0acac505592775345
-    #   Agent: ami-0b5cca90cd338e59d
+    #   Agent: ami-00de94d5b3e68b0da
     # ap-southeast-2:
     #   Master: ami-07c5b4ba4c9dd25a3
-    #   Agent: ami-0725e68bb3b036074
+    #   Agent: ami-0af10fa7e8454d943
     eu-central-1:
       Master: ami-01c74b7d55cbb6e31
-      Agent: ami-0a7e28c7ffceaaca3
+      Agent: ami-0171d0a466f6d4ac3
     eu-west-1:
       Master: ami-06f91a2970093cb47
-      Agent: ami-01ff907f77946e9c0
+      Agent: ami-09925722b0ba31d90
     # eu-west-2:
     #   Master: ami-0be58974fa441cb39
-    #   Agent: ami-08b697d6313df6508
+    #   Agent: ami-0aa3396d882c02376
     us-east-1:
       Master: ami-0f593aebffc0070e1
-      Agent: ami-0abefee50ebdc21f4
+      Agent: ami-0281f5b6b2ae2df84
     us-east-2:
       Master: ami-096cdd827d38ca4d8
-      Agent: ami-0d074fb7abacd5219
+      Agent: ami-02a26ef27a997c7de
     us-west-2:
       Master: ami-04e9aec1ab665f323
-      Agent: ami-0685e5e3534f24db8
+      Agent: ami-0fc52ebf88f40652b
 
 Parameters:
   VpcCIDR:

--- a/deploy/determined_deploy/gcp/constants.py
+++ b/deploy/determined_deploy/gcp/constants.py
@@ -3,7 +3,7 @@ class defaults:
     CPU_AGENT_INSTANCE_TYPE = "n1-standard-4"
     GPU_AGENT_INSTANCE_TYPE = "n1-standard-32"
     DB_PASSWORD = "postgres"
-    ENVIRONMENT_IMAGE = "det-environments-5f6f6e1"
+    ENVIRONMENT_IMAGE = "det-environments-4a93d25"
     GPU_NUM = 8
     GPU_TYPE = "nvidia-tesla-k80"
     MASTER_INSTANCE_TYPE = "n1-standard-2"

--- a/docs/release-notes/1851-framework-upgrades.txt
+++ b/docs/release-notes/1851-framework-upgrades.txt
@@ -3,5 +3,5 @@
 **Improvements**
 
 -  Upgrade the default PyTorch version to 1.7.0 and the default
-   TensorFlow version to 1.15.5 (or TensorFlow 2.4.0 in -tf2 task
+   TensorFlow version to 1.15.5 (or TensorFlow 2.4.1 in -tf2 task
    environments).

--- a/e2e_tests/tests/config.py
+++ b/e2e_tests/tests/config.py
@@ -12,10 +12,10 @@ MAX_TASK_SCHEDULED_SECS = 30
 MAX_TRIAL_BUILD_SECS = 90
 
 
-DEFAULT_TF1_CPU_IMAGE = "determinedai/environments:py-3.6.9-pytorch-1.7-tf-1.15-cpu-5f6f6e1"
-DEFAULT_TF2_CPU_IMAGE = "determinedai/environments:py-3.6.9-pytorch-1.7-tf-2.4-cpu-5f6f6e1"
-DEFAULT_TF1_GPU_IMAGE = "determinedai/environments:cuda-10.1-pytorch-1.7-tf-1.15-gpu-5f6f6e1"
-DEFAULT_TF2_GPU_IMAGE = "determinedai/environments:cuda-10.1-pytorch-1.7-tf-2.4-gpu-5f6f6e1"
+DEFAULT_TF1_CPU_IMAGE = "determinedai/environments:py-3.6.9-pytorch-1.7-tf-1.15-cpu-4a93d25"
+DEFAULT_TF2_CPU_IMAGE = "determinedai/environments:py-3.6.9-pytorch-1.7-tf-2.4-cpu-4a93d25"
+DEFAULT_TF1_GPU_IMAGE = "determinedai/environments:cuda-10.1-pytorch-1.7-tf-1.15-gpu-4a93d25"
+DEFAULT_TF2_GPU_IMAGE = "determinedai/environments:cuda-10.1-pytorch-1.7-tf-2.4-gpu-4a93d25"
 
 TF1_CPU_IMAGE = os.environ.get("TF1_CPU_IMAGE") or DEFAULT_TF1_CPU_IMAGE
 TF2_CPU_IMAGE = os.environ.get("TF2_CPU_IMAGE") or DEFAULT_TF2_CPU_IMAGE

--- a/e2e_tests/tests/requirements.txt
+++ b/e2e_tests/tests/requirements.txt
@@ -5,7 +5,7 @@ pytest-timeout
 pexpect
 torch==1.7
 torchvision==0.8.1
-tensorflow==2.4.0
+tensorflow==2.4.1
 numpy
 pandas
 pyyaml

--- a/examples/gan/dcgan_tf_keras/const.yaml
+++ b/examples/gan/dcgan_tf_keras/const.yaml
@@ -15,5 +15,5 @@ entrypoint: model_def:DCGanTrial
 environment:
   # This model only works with Tensorflow 2.2+.
   image:
-     cpu: "determinedai/environments:py-3.6.9-pytorch-1.7-tf-2.4-cpu-5f6f6e1"
-     gpu: "determinedai/environments:cuda-10.1-pytorch-1.7-tf-2.4-gpu-5f6f6e1"
+     cpu: "determinedai/environments:py-3.6.9-pytorch-1.7-tf-2.4-cpu-4a93d25"
+     gpu: "determinedai/environments:cuda-10.1-pytorch-1.7-tf-2.4-gpu-4a93d25"

--- a/examples/gan/dcgan_tf_keras/distributed.yaml
+++ b/examples/gan/dcgan_tf_keras/distributed.yaml
@@ -17,5 +17,5 @@ resources:
 environment:
   # This model only works with Tensorflow 2.2+.
   image:
-     cpu: "determinedai/environments:py-3.6.9-pytorch-1.7-tf-2.4-cpu-5f6f6e1"
-     gpu: "determinedai/environments:cuda-10.1-pytorch-1.7-tf-2.4-gpu-5f6f6e1"
+     cpu: "determinedai/environments:py-3.6.9-pytorch-1.7-tf-2.4-cpu-4a93d25"
+     gpu: "determinedai/environments:cuda-10.1-pytorch-1.7-tf-2.4-gpu-4a93d25"

--- a/harness/setup.py
+++ b/harness/setup.py
@@ -29,9 +29,9 @@ setup(
     extras_require={
         "tf-115-cuda101": ["tensorflow-gpu==1.15.5"],
         "tf-1115-cpu": ["tensorflow==1.15.5"],
-        "tf-240-cuda101": ["tensorflow-gpu==2.4.0"],
-        "tf-240-cpu": ["tensorflow==2.4.0"],
-        "tf-240-cuda110": ["tensorflow-gpu==2.4.0"],
+        "tf-240-cuda101": ["tensorflow-gpu==2.4.1"],
+        "tf-240-cpu": ["tensorflow==2.4.1"],
+        "tf-240-cuda110": ["tensorflow-gpu==2.4.1"],
         "pytorch-17-cuda101": ["torch==1.7.1+cu101", "torchvision==0.8.2+cu101"],
         "pytorch-17-cuda110": ["torch==1.7.1+cu110", "torchvision==0.8.2+cu110"],
         "pytorch-17-cpu": ["torch==1.7.0", "torchvision==0.8.2"],

--- a/master/internal/provisioner/aws_config.go
+++ b/master/internal/provisioner/aws_config.go
@@ -41,16 +41,16 @@ type AWSClusterConfig struct {
 }
 
 var defaultAWSImageID = map[string]string{
-	"ap-northeast-1": "ami-0881b60d3da7bd055",
-	"ap-northeast-2": "ami-045eb8957d930ee48",
-	"ap-southeast-1": "ami-0b5cca90cd338e59d",
-	"ap-southeast-2": "ami-0725e68bb3b036074",
-	"us-east-2":      "ami-0d074fb7abacd5219",
-	"us-east-1":      "ami-0abefee50ebdc21f4",
-	"us-west-2":      "ami-0685e5e3534f24db8",
-	"eu-central-1":   "ami-0a7e28c7ffceaaca3",
-	"eu-west-2":      "ami-08b697d6313df6508",
-	"eu-west-1":      "ami-01ff907f77946e9c0",
+	"ap-northeast-1": "ami-055e84fd91eebace4",
+	"ap-northeast-2": "ami-098f3d295106b7e70",
+	"ap-southeast-1": "ami-00de94d5b3e68b0da",
+	"ap-southeast-2": "ami-0af10fa7e8454d943",
+	"us-east-2":      "ami-02a26ef27a997c7de",
+	"us-east-1":      "ami-0281f5b6b2ae2df84",
+	"us-west-2":      "ami-0fc52ebf88f40652b",
+	"eu-central-1":   "ami-0171d0a466f6d4ac3",
+	"eu-west-2":      "ami-0aa3396d882c02376",
+	"eu-west-1":      "ami-09925722b0ba31d90",
 }
 
 var defaultAWSClusterConfig = AWSClusterConfig{

--- a/master/internal/provisioner/gcp_config.go
+++ b/master/internal/provisioner/gcp_config.go
@@ -48,7 +48,7 @@ type GCPClusterConfig struct {
 func DefaultGCPClusterConfig() *GCPClusterConfig {
 	return &GCPClusterConfig{
 		BootDiskSize:        200,
-		BootDiskSourceImage: "projects/determined-ai/global/images/det-environments-5f6f6e1",
+		BootDiskSourceImage: "projects/determined-ai/global/images/det-environments-4a93d25",
 		LabelKey:            "managed-by",
 		InstanceType: gceInstanceType{
 			MachineType: "n1-standard-32",

--- a/master/pkg/model/defaults.go
+++ b/master/pkg/model/defaults.go
@@ -25,8 +25,8 @@ const (
 
 // Default task environment docker image names.
 const (
-	defaultCPUImage = "determinedai/environments:py-3.6.9-pytorch-1.7-tf-1.15-cpu-5f6f6e1"
-	defaultGPUImage = "determinedai/environments:cuda-10.1-pytorch-1.7-tf-1.15-gpu-5f6f6e1"
+	defaultCPUImage = "determinedai/environments:py-3.6.9-pytorch-1.7-tf-1.15-cpu-4a93d25"
+	defaultGPUImage = "determinedai/environments:cuda-10.1-pytorch-1.7-tf-1.15-gpu-4a93d25"
 )
 
 // DefaultExperimentConfig returns a new default experiment config.

--- a/tools/scripts/bumpenvs.yaml
+++ b/tools/scripts/bumpenvs.yaml
@@ -1,121 +1,122 @@
 ap_northeast_1_agent_ami:
-  new: ami-0881b60d3da7bd055
-  old: ami-0a01b67743d465a6e
+  new: ami-055e84fd91eebace4
+  old: ami-0881b60d3da7bd055
 ap_northeast_1_bastion_ami:
-  new: ami-07faf6b16c502e9e1
-  old: ami-05855b7c54f91a1ae
+  new: ami-09dac16017637391f
+  old: ami-07faf6b16c502e9e1
 ap_northeast_1_master_ami:
   new: ami-03ec47ea54612a98d
   old: ami-0af17d43b1f4ff4ea
 ap_northeast_2_agent_ami:
-  new: ami-045eb8957d930ee48
-  old: ami-0c74312df78509701
+  new: ami-098f3d295106b7e70
+  old: ami-045eb8957d930ee48
 ap_northeast_2_bastion_ami:
-  new: ami-0ee428c63274f56c1
-  old: ami-063acefae626a1e95
+  new: ami-0b50511490117e709
+  old: ami-0ee428c63274f56c1
 ap_northeast_2_master_ami:
   new: ami-00813ad98dc81f443
   old: ami-04e6fcf8cfe3b09ea
 ap_southeast_1_agent_ami:
-  new: ami-0b5cca90cd338e59d
-  old: ami-0eddf3f941d216f11
+  new: ami-00de94d5b3e68b0da
+  old: ami-0b5cca90cd338e59d
 ap_southeast_1_bastion_ami:
-  new: ami-06bcc4026e190b380
-  old: ami-0311dbbdd981577d5
+  new: ami-0ae3e6717dc99c62b
+  old: ami-06bcc4026e190b380
 ap_southeast_1_master_ami:
   new: ami-0acac505592775345
   old: ami-0ba45f1ec3dff60f9
 ap_southeast_2_agent_ami:
-  new: ami-0725e68bb3b036074
-  old: ami-0c54777eb400a9e68
+  new: ami-0af10fa7e8454d943
+  old: ami-0725e68bb3b036074
 ap_southeast_2_bastion_ami:
-  new: ami-0b079c5b689b2d44e
-  old: ami-0dea9aeaa95b9751b
+  new: ami-080b87fdc6d5ca853
+  old: ami-0b079c5b689b2d44e
 ap_southeast_2_master_ami:
   new: ami-07c5b4ba4c9dd25a3
   old: ami-004d0fb87d10716c6
 cuda_11_hashed:
-  new: determinedai/environments:cuda-11.0-pytorch-1.7-tf-2.4-gpu-5f6f6e1
+  new: determinedai/environments:cuda-11.0-pytorch-1.7-tf-2.4-gpu-4a93d25
+  old: determinedai/environments:cuda-11.0-pytorch-1.7-tf-2.4-gpu-5f6f6e1
 cuda_11_versioned:
   new: determinedai/environments:cuda-11.0-pytorch-1.7-tf-2.4-gpu-0.9.0
 eu_central_1_agent_ami:
-  new: ami-0a7e28c7ffceaaca3
-  old: ami-0474e45bb1a45bbfe
+  new: ami-0171d0a466f6d4ac3
+  old: ami-0a7e28c7ffceaaca3
 eu_central_1_bastion_ami:
-  new: ami-0a4938aa802d3fc05
-  old: ami-08a099fcfc36dff3f
+  new: ami-0093cac2bf998a669
+  old: ami-0a4938aa802d3fc05
 eu_central_1_master_ami:
   new: ami-01c74b7d55cbb6e31
   old: ami-08a1a61694dd1c82f
 eu_west_1_agent_ami:
-  new: ami-01ff907f77946e9c0
-  old: ami-0036879b70fee3339
+  new: ami-09925722b0ba31d90
+  old: ami-01ff907f77946e9c0
 eu_west_1_bastion_ami:
-  new: ami-0074515a838fb8787
-  old: ami-00c25f7948e360133
+  new: ami-0e5657f6d3c3ea350
+  old: ami-0074515a838fb8787
 eu_west_1_master_ami:
   new: ami-06f91a2970093cb47
   old: ami-0d67111dcacb4a14a
 eu_west_2_agent_ami:
-  new: ami-08b697d6313df6508
-  old: ami-05d9b28afa79dbda3
+  new: ami-0aa3396d882c02376
+  old: ami-08b697d6313df6508
 eu_west_2_bastion_ami:
-  new: ami-0789c35b922fefc1e
-  old: ami-076071bbe3485317c
+  new: ami-09b984029e6b0326b
+  old: ami-0789c35b922fefc1e
 eu_west_2_master_ami:
   new: ami-0be58974fa441cb39
   old: ami-03441ec6f2faa7ddc
 gcp_env:
-  new: det-environments-5f6f6e1
-  old: det-environments-067db2b
+  new: det-environments-4a93d25
+  old: det-environments-5f6f6e1
 tf1_cpu_hashed:
-  new: determinedai/environments:py-3.6.9-pytorch-1.7-tf-1.15-cpu-5f6f6e1
-  old: determinedai/environments:py-3.6.9-pytorch-1.4-tf-1.15-cpu-067db2b
+  new: determinedai/environments:py-3.6.9-pytorch-1.7-tf-1.15-cpu-4a93d25
+  old: determinedai/environments:py-3.6.9-pytorch-1.7-tf-1.15-cpu-5f6f6e1
 tf1_cpu_versioned:
   new: determinedai/environments:py-3.6.9-pytorch-1.7-tf-1.15-cpu-0.9.0
   old: determinedai/environments:py-3.6.9-pytorch-1.4-tf-1.15-cpu-0.8.0
 tf1_gpu_hashed:
-  new: determinedai/environments:cuda-10.1-pytorch-1.7-tf-1.15-gpu-5f6f6e1
-  old: determinedai/environments:cuda-10.0-pytorch-1.4-tf-1.15-gpu-067db2b
+  new: determinedai/environments:cuda-10.1-pytorch-1.7-tf-1.15-gpu-4a93d25
+  old: determinedai/environments:cuda-10.1-pytorch-1.7-tf-1.15-gpu-5f6f6e1
 tf1_gpu_versioned:
   new: determinedai/environments:cuda-10.1-pytorch-1.7-tf-1.15-gpu-0.9.0
   old: determinedai/environments:cuda-10.0-pytorch-1.4-tf-1.15-gpu-0.8.0
 tf2_cpu_hashed:
-  new: determinedai/environments:py-3.6.9-pytorch-1.7-tf-2.4-cpu-5f6f6e1
-  old: determinedai/environments:py-3.6.9-pytorch-1.4-tf-2.2-cpu-067db2b
+  new: determinedai/environments:py-3.6.9-pytorch-1.7-tf-2.4-cpu-4a93d25
+  old: determinedai/environments:py-3.6.9-pytorch-1.7-tf-2.4-cpu-5f6f6e1
 tf2_cpu_versioned:
   new: determinedai/environments:py-3.6.9-pytorch-1.7-tf-2.4-cpu-0.9.0
   old: determinedai/environments:py-3.6.9-pytorch-1.4-tf-2.2-cpu-0.8.0
 tf2_gpu_hashed:
-  new: determinedai/environments:cuda-10.1-pytorch-1.7-tf-2.4-gpu-5f6f6e1
-  old: determinedai/environments:cuda-10.1-pytorch-1.4-tf-2.2-gpu-067db2b
+  new: determinedai/environments:cuda-10.1-pytorch-1.7-tf-2.4-gpu-4a93d25
+  old: determinedai/environments:cuda-10.1-pytorch-1.7-tf-2.4-gpu-5f6f6e1
 tf2_gpu_versioned:
   new: determinedai/environments:cuda-10.1-pytorch-1.7-tf-2.4-gpu-0.9.0
   old: determinedai/environments:cuda-10.1-pytorch-1.4-tf-2.2-gpu-0.8.0
 us_east_1_agent_ami:
-  new: ami-0abefee50ebdc21f4
-  old: ami-0080b638f1339ccd5
+  new: ami-0281f5b6b2ae2df84
+  old: ami-0abefee50ebdc21f4
 us_east_1_bastion_ami:
-  new: ami-007e8beb808004fdc
-  old: ami-053adf54573f777cf
+  new: ami-02fe94dee086c0c37
+  old: ami-007e8beb808004fdc
 us_east_1_master_ami:
   new: ami-0f593aebffc0070e1
   old: ami-099e921e69356cf89
 us_east_2_agent_ami:
-  new: ami-0d074fb7abacd5219
-  old: ami-07318f0e0b3a02b8e
+  new: ami-02a26ef27a997c7de
+  old: ami-0d074fb7abacd5219
 us_east_2_bastion_ami:
-  new: ami-05c386ebc03ca06da
-  old: ami-0b9487791bf873774
+  new: ami-02aa7f3de34db391a
+  old: ami-05c386ebc03ca06da
 us_east_2_master_ami:
   new: ami-096cdd827d38ca4d8
   old: ami-05edbb8e25e281608
 us_west_2_agent_ami:
-  new: ami-0685e5e3534f24db8
-  old: ami-0211fc4b3b0eb5c64
+  new: ami-0fc52ebf88f40652b
+  old: ami-0685e5e3534f24db8
 us_west_2_bastion_ami:
-  new: ami-0b5f687730c825c7d
-  old: ami-0cc158853935719b7
+  new: ami-025102f49d03bec05
+  old: ami-0b5f687730c825c7d
 us_west_2_master_ami:
   new: ami-04e9aec1ab665f323
   old: ami-00f1e37d20049f858

--- a/webui/react/src/fixtures/responses/experiment-details/non-scalar-metrics-4078.json
+++ b/webui/react/src/fixtures/responses/experiment-details/non-scalar-metrics-4078.json
@@ -31,8 +31,8 @@
     "description": "Fork of Fork of mnist_tp_to_estimator_const",
     "environment": {
       "image": {
-        "cpu": "determinedai/environments:py-3.6.9-pytorch-1.7-tf-1.15-cpu-5f6f6e1",
-        "gpu": "determinedai/environments:cuda-10.1-pytorch-1.7-tf-1.15-gpu-5f6f6e1"
+        "cpu": "determinedai/environments:py-3.6.9-pytorch-1.7-tf-1.15-cpu-4a93d25",
+        "gpu": "determinedai/environments:cuda-10.1-pytorch-1.7-tf-1.15-gpu-4a93d25"
       },
       "ports": null,
       "pod_spec": null,

--- a/webui/react/src/fixtures/responses/experiment-details/set-a.json
+++ b/webui/react/src/fixtures/responses/experiment-details/set-a.json
@@ -694,8 +694,8 @@
         "environment_variables": {},
         "force_pull_image": false,
         "image": {
-          "cpu": "determinedai/environments:py-3.6.9-pytorch-1.7-tf-1.15-cpu-5f6f6e1",
-          "gpu": "determinedai/environments:cuda-10.1-pytorch-1.7-tf-1.15-gpu-5f6f6e1"
+          "cpu": "determinedai/environments:py-3.6.9-pytorch-1.7-tf-1.15-cpu-4a93d25",
+          "gpu": "determinedai/environments:cuda-10.1-pytorch-1.7-tf-1.15-gpu-4a93d25"
         },
         "pod_spec": null,
         "ports": null
@@ -838,8 +838,8 @@
         "environment_variables": {},
         "force_pull_image": false,
         "image": {
-          "cpu": "determinedai/environments:py-3.6.9-pytorch-1.7-tf-1.15-cpu-5f6f6e1",
-          "gpu": "determinedai/environments:cuda-10.1-pytorch-1.7-tf-1.15-gpu-5f6f6e1"
+          "cpu": "determinedai/environments:py-3.6.9-pytorch-1.7-tf-1.15-cpu-4a93d25",
+          "gpu": "determinedai/environments:cuda-10.1-pytorch-1.7-tf-1.15-gpu-4a93d25"
         },
         "pod_spec": {
           "metadata": {
@@ -2596,8 +2596,8 @@
       "description": "noop_adaptive",
       "environment": {
         "image": {
-          "cpu": "determinedai/environments:py-3.6.9-pytorch-1.7-tf-1.15-cpu-5f6f6e1",
-          "gpu": "determinedai/environments:cuda-10.1-pytorch-1.7-tf-1.15-gpu-5f6f6e1"
+          "cpu": "determinedai/environments:py-3.6.9-pytorch-1.7-tf-1.15-cpu-4a93d25",
+          "gpu": "determinedai/environments:cuda-10.1-pytorch-1.7-tf-1.15-gpu-4a93d25"
         },
         "ports": null,
         "pod_spec": null,

--- a/webui/react/src/fixtures/responses/trial-details/old-trial-config-noop-adaptive.json
+++ b/webui/react/src/fixtures/responses/trial-details/old-trial-config-noop-adaptive.json
@@ -29,8 +29,8 @@
   "description": "noop_adaptive",
   "environment": {
     "image": {
-      "cpu": "determinedai/environments:py-3.6.9-pytorch-1.7-tf-1.15-cpu-5f6f6e1",
-      "gpu": "determinedai/environments:cuda-10.1-pytorch-1.7-tf-1.15-gpu-5f6f6e1"
+      "cpu": "determinedai/environments:py-3.6.9-pytorch-1.7-tf-1.15-cpu-4a93d25",
+      "gpu": "determinedai/environments:cuda-10.1-pytorch-1.7-tf-1.15-gpu-4a93d25"
     },
     "ports": null,
     "force_pull_image": false,


### PR DESCRIPTION
## Description

Bumping to the recent TF 2.4.1 release to eliminate a requirement for AVX2.

## Test Plan

GPU tests are running on an upstream branch.
