### PR TITLE
feat: support resource pools in det-deploy local agent-up [DET-4938]

### DIFF
--- a/deploy/determined_deploy/local/cli.py
+++ b/deploy/determined_deploy/local/cli.py
@@ -133,6 +133,7 @@ def add_agent_up_subparser(subparsers: argparse._SubParsersAction) -> None:
     parser.add_argument("--det-version", type=str, default=None, help="version or commit to use")
     parser.add_argument("--agent-name", type=str, default="det-agent", help="agent name")
     parser.add_argument("--agent-label", type=str, default=None, help="agent label")
+    parser.add_argument("--agent-resource-pool", type=str, default=None, help="agent resource pool")
     parser.add_argument("--no-gpu", help="disable GPU support", action="store_true")
     parser.add_argument(
         "--no-autorestart",
@@ -218,6 +219,7 @@ def handle_agent_up(args: argparse.Namespace) -> None:
         no_gpu=args.no_gpu,
         agent_name=args.agent_name,
         agent_label=args.agent_label,
+        agent_resource_pool=args.agent_resource_pool,
         version=args.det_version,
         labels=None,
         autorestart=(not args.no_autorestart),

--- a/deploy/determined_deploy/local/cluster_utils.py
+++ b/deploy/determined_deploy/local/cluster_utils.py
@@ -180,6 +180,7 @@ def cluster_up(
             master_port=port,
             agent_name=agent_name,
             agent_label=None,
+            agent_resource_pool=None,
             version=version,
             labels=labels,
             no_gpu=no_gpu,
@@ -202,6 +203,7 @@ def agent_up(
     master_port: int,
     agent_name: str,
     agent_label: Optional[str],
+    agent_resource_pool: Optional[str],
     version: Optional[str],
     no_gpu: bool,
     autorestart: bool,
@@ -221,6 +223,7 @@ def agent_up(
         "DET_MASTER_PORT": master_port,
         "DET_AGENT_ID": agent_name,
         "DET_LABEL": agent_label,
+        "DET_RESOURCE_POOL": agent_resource_pool,
     }
     init = True
     volumes = ["/var/run/docker.sock:/var/run/docker.sock"]

--- a/docs/how-to/installation/deploy.txt
+++ b/docs/how-to/installation/deploy.txt
@@ -137,7 +137,8 @@ This will create an agent on that machine. To verify whether it has
 successfully connected to the master, navigate to the WebUI and check
 whether slots have appeared on the ``Cluster`` page.
 
-To launch the agent into a specific resource pool, use the ``--agent-resource-pool`` flag:
+To launch the agent into a specific resource pool, use the
+``--agent-resource-pool`` flag:
 
 .. code::
 

--- a/docs/how-to/installation/deploy.txt
+++ b/docs/how-to/installation/deploy.txt
@@ -137,6 +137,14 @@ This will create an agent on that machine. To verify whether it has
 successfully connected to the master, navigate to the WebUI and check
 whether slots have appeared on the ``Cluster`` page.
 
+To launch the agent into a specific resource pool, use the ``--agent-resource-pool`` flag:
+
+.. code::
+
+   det-deploy local agent-up --agent-resource-pool= <resource_pool> <master_hostname>
+
+For more information about resource pools, see :ref:`resource-pool`.
+
 To stop a running agent, run:
 
 .. code::


### PR DESCRIPTION
## Description

Add ability to specify which resource pool an agent should join in det-deploy local


## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.


