### PR TITLE
fix: buffer the trial log in the correct order [DET-4931]

### DIFF
--- a/docs/release-notes/1912-fix-trial-log-order.txt
+++ b/docs/release-notes/1912-fix-trial-log-order.txt
@@ -1,0 +1,6 @@
+:orphan:
+
+**Bug Fixes**
+
+-  WebUI: fix issue of incorrect trial log order when viewing oldest
+   logs first.

--- a/webui/react/src/components/LogViewerTimestamp.tsx
+++ b/webui/react/src/components/LogViewerTimestamp.tsx
@@ -604,7 +604,7 @@ const LogViewerTimestamp: React.FC<Props> = ({
           <div className={css.measure} ref={measure} />
         </div>
         <div className={css.scrollTo}>
-          <Tooltip placement="topRight" title="Scroll to Top">
+          <Tooltip placement="left" title="Scroll to Top">
             <Button
               aria-label="Scroll to Top"
               className={scrollToTopClasses.join(' ')}
@@ -612,7 +612,7 @@ const LogViewerTimestamp: React.FC<Props> = ({
               onClick={handleScrollToTop} />
           </Tooltip>
           <Tooltip
-            placement="topRight"
+            placement="left"
             title={direction === DIRECTIONS.TAILING ? 'Tailing Enabled' : 'Enable Tailing'}
           >
             <Button

--- a/webui/react/src/components/LogViewerTimestamp.tsx
+++ b/webui/react/src/components/LogViewerTimestamp.tsx
@@ -491,7 +491,8 @@ const LogViewerTimestamp: React.FC<Props> = ({
       consumeStream(
         fetchArgs,
         event => {
-          buffer.push(fetchToLogConverter(event));
+          const logEntry = fetchToLogConverter(event);
+          direction === DIRECTIONS.OLDEST ? buffer.unshift(logEntry) : buffer.push(logEntry);
         },
       ).then(() => {
         if (buffer.length < TAIL_SIZE) setIsLastReached(true);


### PR DESCRIPTION
## Description

The trial log buffer is currently added in reverse order when the stream is in ascending order, causing logs within the same second to be in the reverse order.

<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan

- check that the log entry order is the same regardless of tailing behavior vs scroll to oldest behavior.

<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234