### PR TITLE
fix: typos in model debugging doc

### DIFF
--- a/docs/how-to/model-debug.txt
+++ b/docs/how-to/model-debug.txt
@@ -161,7 +161,7 @@ Once you are on the cluster, testing is identical to Step 1.
       128MB. If you need files larger than that as part of your model
       definition, consider setting up a bind mount via the
       ``bind_mounts`` field of :ref:`command-notebook-configuration`.
-      The tutorial on `ref:`data-access` lists some additional
+      The tutorial on :ref:`data-access` lists some additional
       strategies for accessing files inside a containerized environment
       which may also be relevant.
 
@@ -358,7 +358,7 @@ library APIs correctly, then theoretically distributed training should
 
    -  If your experiment is not being scheduled on the cluster, ensure
       that your ``slots_per_trial`` setting is valid for your cluster.
-      E.g. if you have 4 Detrmined Agents running with 4 GPUs each, your
+      E.g. if you have 4 Determined Agents running with 4 GPUs each, your
       ``slots_per_trial`` could be ``1``, ``2,``, ``3``, ``4`` (which
       would all fit on a single machine), or it could be ``8`` or ``12``
       or ``16`` (which would take up some number of complete Agent
@@ -366,7 +366,7 @@ library APIs correctly, then theoretically distributed training should
       multiple of Agent size) and it couldn't be ``32`` (too big for the
       cluster). Also ensure that there are no other notebooks, shells,
       or experiments on the cluster which may be consuming too many
-      resources and preventing from starting.
+      resources and preventing the experiment from starting.
 
    -  Determined normally controls the details of distributed training
       for you. Attempting to also control those details yourself, such

--- a/docs/how-to/model-debug.txt
+++ b/docs/how-to/model-debug.txt
@@ -358,15 +358,15 @@ library APIs correctly, then theoretically distributed training should
 
    -  If your experiment is not being scheduled on the cluster, ensure
       that your ``slots_per_trial`` setting is valid for your cluster.
-      E.g. if you have 4 Determined Agents running with 4 GPUs each, your
-      ``slots_per_trial`` could be ``1``, ``2,``, ``3``, ``4`` (which
-      would all fit on a single machine), or it could be ``8`` or ``12``
-      or ``16`` (which would take up some number of complete Agent
-      machines), but it couldn't be ``5`` (more than one Agent but not a
-      multiple of Agent size) and it couldn't be ``32`` (too big for the
-      cluster). Also ensure that there are no other notebooks, shells,
-      or experiments on the cluster which may be consuming too many
-      resources and preventing the experiment from starting.
+      E.g. if you have 4 Determined Agents running with 4 GPUs each,
+      your ``slots_per_trial`` could be ``1``, ``2,``, ``3``, ``4``
+      (which would all fit on a single machine), or it could be ``8`` or
+      ``12`` or ``16`` (which would take up some number of complete
+      Agent machines), but it couldn't be ``5`` (more than one Agent but
+      not a multiple of Agent size) and it couldn't be ``32`` (too big
+      for the cluster). Also ensure that there are no other notebooks,
+      shells, or experiments on the cluster which may be consuming too
+      many resources and preventing the experiment from starting.
 
    -  Determined normally controls the details of distributed training
       for you. Attempting to also control those details yourself, such


### PR DESCRIPTION
## Description

Fix typos in documentation on debugging models


## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
