### PR TITLE
hack: "support" iterable datasets

### DIFF
--- a/harness/determined/pytorch/__init__.py
+++ b/harness/determined/pytorch/__init__.py
@@ -6,6 +6,10 @@ from determined.pytorch._data import (
     TorchData,
     _Data,
     adapt_batch_sampler,
+    ReproducibleShuffleSampler,
+    DistributedSampler,
+    RepeatSampler,
+    reproducible_distributable_batch_sampler,
     data_length,
     to_device,
 )


### PR DESCRIPTION
## Description

This is a proposed idea for how we could support Iterable Datasets.  It is in line with what I proposed in #ml-ag during the 2 Nov 2020 meeting (abridged):

> Aaron: Accept arbitrary Pytorch DataLoaders to reduce initial porting overhead. Could also upstream some of this.
> - AH: We wanted to do it for at least IterableDatasets, but we should do this for all data loaders (while explaining caveats). Doesn’t require YogaDL necessarily (but may have caveats to behaviors). 1. It’s up to users to make sure that each GPU gets a unique data sample. 2. Pause/restart for HP search.
> - KP: question: they’ll need to do some work to get the GPU sampling to work? What does this look like from a user perspective?
>   - RB: **maybe the context should offer a special sampler**…
>   - AH: the other problem is the start/restart logic. We shouldn’t even try to fix that if they’re using a PT data loader
>   - RB: you’d fix that in the sampler anyway
>   - AH: our easy 1-line config change is for a DDL. if you don’t want to use it, there are these disclaimers, will take more on your side. Kind of what we do for TF dataset right now, restart logic is just not correct unless you use YogaDL but we don’t force that
> - VM: devil’s in the details, what do we do if we get a custom data loader that doesn’t work w/ Determined?
>   - AH: no, we don’t fail for TF datasets right now etc.
>   - RB: the answer is some people want it to fail, some people don’t. Like compiler warnings. We kind of need a feature like this. Document correct errors, which conditions, and allow users to request strictness depending on their use case
>   - AH: i think this is useful, but i also don’t think we should block on this
>   - VM: we need to let people know what they’re buying into; 1. If a user hasn’t read the docs and say BYODL, there’s no warning that there’s a science-compromising issue

As may be clear from the above discourse, the issue here has less to do with difficulty of implementation and more to do with correctness and being able to give assurance to the user about correctness.  That gets harder as we move away from plugin-api paradigms and into sprinkle api paradigms.  However, no users have ever complained about the pytorch-flexible-primitives API, where we made a similar transition from rigid, guaranteed-correct APIs to a "remember to make these calls" style of API.

The way you would apply this new API to your code is demonstrated in this PR on the `mnist_pytorch` tutorial example:
```diff
         validation_data = data.get_dataset(self.download_directory, train=False)
-        return DataLoader(validation_data, batch_size=self.context.get_per_slot_batch_size())
+
+        batch_sampler = self.context.make_validation_batch_sampler(
+            validation_data, batch_size=self.context.get_per_slot_batch_size()
+        )
+
+        return torch.utils.data.DataLoader(validation_data, batch_sampler=batch_sampler)
```

But a more realistic application would be somewhere like @katport's detectron2 port, where [on this line](https://github.com/katport/determined/blob/DET-3158/examples/experimental/trial/detectron2/detectron2_files/data.py#L380) she had to bail out and return the wrong value, because the normal codepath would result in an Iterable dataset that Determined would have puked on.

That said, the `make_validation_batch_sampler()` API proposed here would still require significant edits to detectron2's `AspectRatioGroupedDataset` class before that class would behave itself.  A user would probably have to go read the internals of `pytorch.reproducible_distributable_batch_sampler` and do each step on their own.  But hey, at least it would be possible now.

Actually, I think I've already convinced myself that the `make_validation_batch_sampler()` API is not worth having, but maybe some of the lower-layer primitives in this PR could still be useful, and a few code examples would allow the users with the really advanced use cases to set up their use cases correctly. 