### PR TITLE
docs: clarification instructions for TF 1.15 eager mode

### DIFF
--- a/harness/determined/keras/_tf_keras_trial.py
+++ b/harness/determined/keras/_tf_keras_trial.py
@@ -945,9 +945,11 @@ class TFKerasTrial(det.Trial):
 
     Trials default to using eager execution with TensorFlow 2.x but not with
     TensorFlow 1.x. To override the default behavior, call the appropriate
-    function in your ``__init__`` method. For example, if you want to disable
+    function at the top of your code. For example, if you want to disable
     eager execution while using TensorFlow 2.x, call
-    ``tf.compat.v1.disable_eager_execution`` at the top of your ``__init__`` method.
+    ``tf.compat.v1.disable_eager_execution`` after your import statements.
+    If you are using TensorFlow 1.x in eager mode, please add
+    ``experimental_run_tf_function=False`` to your model compile function.
 
     For more information on writing ``tf.keras`` trial classes, refer to the
     :ref:`tutorial <tf-mnist-tutorial>`.


### PR DESCRIPTION
## Description
Added docs that clarify the need for additional configuration when using TF 1.15 in eager mode with Determined.
<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234