### PR TITLE
fix: always deallocate resources if a task actor fail [DET-4973]

### DIFF
--- a/master/internal/agent/slot.go
+++ b/master/internal/agent/slot.go
@@ -65,11 +65,6 @@ func (s *slot) Receive(ctx *actor.Context) error {
 		s.container = &msg.Container
 		if msg.Container.State == container.Terminated {
 			s.container = nil
-			if s.enabled.Enabled() {
-				ctx.Tell(s.resourcePool, sproto.FreeDevice{
-					DeviceID: s.deviceID(ctx), ContainerID: &msg.Container.ID,
-				})
-			}
 		}
 	case *proto.GetSlotRequest:
 		ctx.Respond(&proto.GetSlotResponse{Slot: toProtoSlot(s.summarize(ctx))})

--- a/master/internal/resourcemanagers/agent.go
+++ b/master/internal/resourcemanagers/agent.go
@@ -80,15 +80,13 @@ func (a *agentState) allocateFreeDevices(slots int, id cproto.ID) []device.Devic
 	return devices
 }
 
-func (a *agentState) deallocateDevice(t device.Type, id cproto.ID, d device.Device) {
-	if t == device.ZeroSlot {
-		delete(a.zeroSlotContainers, id)
-		return
+func (a *agentState) deallocateContainer(id cproto.ID) {
+	delete(a.zeroSlotContainers, id)
+	for d, cid := range a.devices {
+		if cid != nil && *cid == id {
+			a.devices[d] = nil
+		}
 	}
-	cid, ok := a.devices[d]
-	check.Panic(check.True(ok, "error freeing device, device not found: %s", d))
-	check.Panic(check.True(cid != nil, "error freeing device, device not assigned: %s", d))
-	a.devices[d] = nil
 }
 
 func (a *agentState) deepCopy() *agentState {

--- a/master/internal/resourcemanagers/priority_test.go
+++ b/master/internal/resourcemanagers/priority_test.go
@@ -7,8 +7,6 @@ import (
 
 	"github.com/determined-ai/determined/master/internal/sproto"
 	"github.com/determined-ai/determined/master/pkg/actor"
-	cproto "github.com/determined-ai/determined/master/pkg/container"
-	"github.com/determined-ai/determined/master/pkg/device"
 )
 
 func TestSortTasksByPriorityAndTimestamps(t *testing.T) {
@@ -886,23 +884,13 @@ func AddUnallocatedTasks(
 	}
 }
 
-func deallocateDevices(a *agentState, slots int, id cproto.ID, devices []device.Device) {
-	if slots == 0 {
-		a.deallocateDevice(device.ZeroSlot, id, device.Device{})
-	}
-
-	for _, d := range devices {
-		a.deallocateDevice(device.CPU, id, d)
-	}
-}
-
 func RemoveTask(slots int, toRelease *actor.Ref, taskList *taskList, delete bool) bool {
 	for _, alloc := range taskList.GetAllocations(toRelease).Allocations {
 		alloc, ok := alloc.(*containerAllocation)
 		if !ok {
 			return false
 		}
-		deallocateDevices(alloc.agent, slots, alloc.container.id, alloc.devices)
+		alloc.agent.deallocateContainer(alloc.container.id)
 	}
 	if delete {
 		taskList.RemoveTaskByHandler(toRelease)

--- a/master/internal/sproto/agent_resource_manager.go
+++ b/master/internal/sproto/agent_resource_manager.go
@@ -28,11 +28,6 @@ type (
 		DeviceID
 		ContainerID *cproto.ID
 	}
-	// FreeDevice notifies the cluster that the device's container is no longer running.
-	FreeDevice struct {
-		DeviceID
-		ContainerID *cproto.ID
-	}
 	// RemoveDevice removes the device from scheduling.
 	RemoveDevice struct {
 		DeviceID


### PR DESCRIPTION
## Description

Previously, the agent resource pool relies on the container state change message to deallocate resources. This PR changes that to always deallocate resources when a task actor fails.

## Test Plan

1. Start the cluster
2. Alter the table using the following SQL to fail the trial actor.

```sql
alter table trials drop column seed;
```

3. submit an adaptive experiment.
4. see if the resources get deallocated.

## Commentary (optional)

This PR doesn't fix that the experiment state should error out if a trial fails to write to the DB.

## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
