### PR TITLE
chore: revert default images and framework versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,11 +100,11 @@ commands:
       - when:
           condition: <<parameters.tf1>>
           steps:
-            - run: docker pull determinedai/environments:py-3.6.9-pytorch-1.7-tf-1.15-cpu-4a93d25
+            - run: docker pull determinedai/environments:py-3.6.9-pytorch-1.7-tf-1.15-cpu-5f6f6e1
       - when:
           condition: <<parameters.tf2>>
           steps:
-            - run: docker pull determinedai/environments:py-3.6.9-pytorch-1.7-tf-2.4-cpu-4a93d25
+            - run: docker pull determinedai/environments:py-3.6.9-pytorch-1.7-tf-2.4-cpu-5f6f6e1
 
   login-docker:
     steps:
@@ -1129,7 +1129,7 @@ jobs:
       - setup-python-venv:
           determined-common: true
           determined: true
-          extras-requires: "tensorflow==2.4.1 torch==1.7.0 torchvision==0.8.1"
+          extras-requires: "tensorflow==2.4.0 torch==1.7.0 torchvision==0.8.1"
           extra-requirements-file: "harness/tests/requirements.txt"
           executor: determinedai/cimg-base:stable
       - run: make -C harness test
@@ -1142,7 +1142,7 @@ jobs:
       - setup-python-venv:
           determined-common: true
           determined: true
-          extras-requires: "tensorflow==2.4.1"
+          extras-requires: "tensorflow==2.2.0"
           extra-requirements-file: "harness/tests/requirements.txt"
           executor: determinedai/cimg-base:stable
       - run: make -C harness test-tf2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,11 +100,11 @@ commands:
       - when:
           condition: <<parameters.tf1>>
           steps:
-            - run: docker pull determinedai/environments:py-3.6.9-pytorch-1.7-tf-1.15-cpu-5f6f6e1
+            - run: docker pull determinedai/environments:py-3.6.9-pytorch-1.4-tf-1.15-cpu-067db2b
       - when:
           condition: <<parameters.tf2>>
           steps:
-            - run: docker pull determinedai/environments:py-3.6.9-pytorch-1.7-tf-2.4-cpu-5f6f6e1
+            - run: docker pull determinedai/environments:py-3.6.9-pytorch-1.4-tf-2.2-cpu-067db2b
 
   login-docker:
     steps:
@@ -199,7 +199,7 @@ commands:
       - run:
           name: Setup venv
           command: |
-            python3 -m venv /tmp/venv
+            python3.6 -m venv /tmp/venv
             echo "export PATH=/tmp/venv/bin:\"${PATH}\"" >> $BASH_ENV
             /tmp/venv/bin/python -m pip install --upgrade pip\<20 wheel setuptools
 
@@ -752,7 +752,7 @@ jobs:
           determined-common: true
           determined-cli: true
           determined: true
-          extras-requires: "tensorflow==2.4 torch==1.7"
+          extras-requires: "tensorflow==1.14 torch==1.4"
           extra-requirements-file: "docs/requirements.txt"
           executor: determinedai/cimg-base:stable
       - run: make -C examples build
@@ -1110,7 +1110,7 @@ jobs:
           determined-cli: true
           determined: true
           determined-deploy: true
-          extras-requires: "torch==1.7.0"
+          extras-requires: "torch==1.4.0"
           extra-requirements-file: "requirements.txt"
           executor: determinedai/cimg-base:stable
       - run: make -C cli check
@@ -1129,7 +1129,7 @@ jobs:
       - setup-python-venv:
           determined-common: true
           determined: true
-          extras-requires: "tensorflow==2.4.0 torch==1.7.0 torchvision==0.8.1"
+          extras-requires: "tensorflow==1.14.0 torch==1.4.0 torchvision==0.5.0"
           extra-requirements-file: "harness/tests/requirements.txt"
           executor: determinedai/cimg-base:stable
       - run: make -C harness test
@@ -1207,9 +1207,6 @@ jobs:
       - attach_workspace:
           at: .
 
-      - run: pyenv uninstall -f 3.6.10
-      - run: sudo apt install -y liblzma-dev lzma
-      - run: PYTHON_BUILD_MIRROR_URL=https://detpyenv.s3.amazonaws.com pyenv install 3.6.10
       - run: pyenv global 3.6.10
       - setup-python-venv:
           determined-common: true

--- a/deploy/determined_deploy/aws/templates/efs.yaml
+++ b/deploy/determined_deploy/aws/templates/efs.yaml
@@ -3,36 +3,36 @@ Description:  This template deploys a VPC, with a public and private subnet. It 
 Mappings:
   RegionMap:
     ap-northeast-1:
-      Master: ami-03ec47ea54612a98d
-      Agent: ami-0881b60d3da7bd055
+      Master: ami-0af17d43b1f4ff4ea
+      Agent: ami-0a01b67743d465a6e
     # TODO(DET-4258) Uncomment these when we fully support all P3 regions.
     # ap-northeast-2:
-    #   Master: ami-00813ad98dc81f443
-    #   Agent: ami-045eb8957d930ee48
+    #   Master: ami-04e6fcf8cfe3b09ea
+    #   Agent: ami-0c74312df78509701
     # ap-southeast-1:
-    #   Master: ami-0acac505592775345
-    #   Agent: ami-0b5cca90cd338e59d
+    #   Master: ami-0ba45f1ec3dff60f9
+    #   Agent: ami-0eddf3f941d216f11
     # ap-southeast-2:
-    #   Master: ami-07c5b4ba4c9dd25a3
-    #   Agent: ami-0725e68bb3b036074
+    #   Master: ami-004d0fb87d10716c6
+    #   Agent: ami-0c54777eb400a9e68
     eu-central-1:
-      Master: ami-01c74b7d55cbb6e31
-      Agent: ami-0a7e28c7ffceaaca3
+      Master: ami-08a1a61694dd1c82f
+      Agent: ami-0474e45bb1a45bbfe
     eu-west-1:
-      Master: ami-06f91a2970093cb47
-      Agent: ami-01ff907f77946e9c0
+      Master: ami-0d67111dcacb4a14a
+      Agent: ami-0036879b70fee3339
     # eu-west-2:
-    #   Master: ami-0be58974fa441cb39
-    #   Agent: ami-08b697d6313df6508
+    #   Master: ami-03441ec6f2faa7ddc
+    #   Agent: ami-05d9b28afa79dbda3
     us-east-1:
-      Master: ami-0f593aebffc0070e1
-      Agent: ami-0abefee50ebdc21f4
+      Master: ami-099e921e69356cf89
+      Agent: ami-0080b638f1339ccd5
     us-east-2:
-      Master: ami-096cdd827d38ca4d8
-      Agent: ami-0d074fb7abacd5219
+      Master: ami-05edbb8e25e281608
+      Agent: ami-07318f0e0b3a02b8e
     us-west-2:
-      Master: ami-04e9aec1ab665f323
-      Agent: ami-0685e5e3534f24db8
+      Master: ami-00f1e37d20049f858
+      Agent: ami-0211fc4b3b0eb5c64
 
 Parameters:
   VpcCIDR:

--- a/deploy/determined_deploy/aws/templates/efs.yaml
+++ b/deploy/determined_deploy/aws/templates/efs.yaml
@@ -4,35 +4,35 @@ Mappings:
   RegionMap:
     ap-northeast-1:
       Master: ami-03ec47ea54612a98d
-      Agent: ami-055e84fd91eebace4
+      Agent: ami-0881b60d3da7bd055
     # TODO(DET-4258) Uncomment these when we fully support all P3 regions.
     # ap-northeast-2:
     #   Master: ami-00813ad98dc81f443
-    #   Agent: ami-098f3d295106b7e70
+    #   Agent: ami-045eb8957d930ee48
     # ap-southeast-1:
     #   Master: ami-0acac505592775345
-    #   Agent: ami-00de94d5b3e68b0da
+    #   Agent: ami-0b5cca90cd338e59d
     # ap-southeast-2:
     #   Master: ami-07c5b4ba4c9dd25a3
-    #   Agent: ami-0af10fa7e8454d943
+    #   Agent: ami-0725e68bb3b036074
     eu-central-1:
       Master: ami-01c74b7d55cbb6e31
-      Agent: ami-0171d0a466f6d4ac3
+      Agent: ami-0a7e28c7ffceaaca3
     eu-west-1:
       Master: ami-06f91a2970093cb47
-      Agent: ami-09925722b0ba31d90
+      Agent: ami-01ff907f77946e9c0
     # eu-west-2:
     #   Master: ami-0be58974fa441cb39
-    #   Agent: ami-0aa3396d882c02376
+    #   Agent: ami-08b697d6313df6508
     us-east-1:
       Master: ami-0f593aebffc0070e1
-      Agent: ami-0281f5b6b2ae2df84
+      Agent: ami-0abefee50ebdc21f4
     us-east-2:
       Master: ami-096cdd827d38ca4d8
-      Agent: ami-02a26ef27a997c7de
+      Agent: ami-0d074fb7abacd5219
     us-west-2:
       Master: ami-04e9aec1ab665f323
-      Agent: ami-0fc52ebf88f40652b
+      Agent: ami-0685e5e3534f24db8
 
 Parameters:
   VpcCIDR:

--- a/deploy/determined_deploy/aws/templates/fsx.yaml
+++ b/deploy/determined_deploy/aws/templates/fsx.yaml
@@ -2,36 +2,36 @@ Description:  This template deploys a VPC, with a public and private subnet, and
 Mappings:
   RegionMap:
     ap-northeast-1:
-      Master: ami-03ec47ea54612a98d
-      Agent: ami-0881b60d3da7bd055
+      Master: ami-0af17d43b1f4ff4ea
+      Agent: ami-0a01b67743d465a6e
     # TODO(DET-4258) Uncomment these when we fully support all P3 regions.
     # ap-northeast-2:
-    #   Master: ami-00813ad98dc81f443
-    #   Agent: ami-045eb8957d930ee48
+    #   Master: ami-04e6fcf8cfe3b09ea
+    #   Agent: ami-0c74312df78509701
     # ap-southeast-1:
-    #   Master: ami-0acac505592775345
-    #   Agent: ami-0b5cca90cd338e59d
+    #   Master: ami-0ba45f1ec3dff60f9
+    #   Agent: ami-0eddf3f941d216f11
     # ap-southeast-2:
-    #   Master: ami-07c5b4ba4c9dd25a3
-    #   Agent: ami-0725e68bb3b036074
+    #   Master: ami-004d0fb87d10716c6
+    #   Agent: ami-0c54777eb400a9e68
     eu-central-1:
-      Master: ami-01c74b7d55cbb6e31
-      Agent: ami-0a7e28c7ffceaaca3
+      Master: ami-08a1a61694dd1c82f
+      Agent: ami-0474e45bb1a45bbfe
     eu-west-1:
-      Master: ami-06f91a2970093cb47
-      Agent: ami-01ff907f77946e9c0
+      Master: ami-0d67111dcacb4a14a
+      Agent: ami-0036879b70fee3339
     # eu-west-2:
-    #   Master: ami-0be58974fa441cb39
-    #   Agent: ami-08b697d6313df6508
+    #   Master: ami-03441ec6f2faa7ddc
+    #   Agent: ami-05d9b28afa79dbda3
     us-east-1:
-      Master: ami-0f593aebffc0070e1
-      Agent: ami-0abefee50ebdc21f4
+      Master: ami-099e921e69356cf89
+      Agent: ami-0080b638f1339ccd5
     us-east-2:
-      Master: ami-096cdd827d38ca4d8
-      Agent: ami-0d074fb7abacd5219
+      Master: ami-05edbb8e25e281608
+      Agent: ami-07318f0e0b3a02b8e
     us-west-2:
-      Master: ami-04e9aec1ab665f323
-      Agent: ami-0685e5e3534f24db8
+      Master: ami-00f1e37d20049f858
+      Agent: ami-0211fc4b3b0eb5c64
 
 Parameters:
   VpcCIDR:

--- a/deploy/determined_deploy/aws/templates/fsx.yaml
+++ b/deploy/determined_deploy/aws/templates/fsx.yaml
@@ -3,35 +3,35 @@ Mappings:
   RegionMap:
     ap-northeast-1:
       Master: ami-03ec47ea54612a98d
-      Agent: ami-055e84fd91eebace4
+      Agent: ami-0881b60d3da7bd055
     # TODO(DET-4258) Uncomment these when we fully support all P3 regions.
     # ap-northeast-2:
     #   Master: ami-00813ad98dc81f443
-    #   Agent: ami-098f3d295106b7e70
+    #   Agent: ami-045eb8957d930ee48
     # ap-southeast-1:
     #   Master: ami-0acac505592775345
-    #   Agent: ami-00de94d5b3e68b0da
+    #   Agent: ami-0b5cca90cd338e59d
     # ap-southeast-2:
     #   Master: ami-07c5b4ba4c9dd25a3
-    #   Agent: ami-0af10fa7e8454d943
+    #   Agent: ami-0725e68bb3b036074
     eu-central-1:
       Master: ami-01c74b7d55cbb6e31
-      Agent: ami-0171d0a466f6d4ac3
+      Agent: ami-0a7e28c7ffceaaca3
     eu-west-1:
       Master: ami-06f91a2970093cb47
-      Agent: ami-09925722b0ba31d90
+      Agent: ami-01ff907f77946e9c0
     # eu-west-2:
     #   Master: ami-0be58974fa441cb39
-    #   Agent: ami-0aa3396d882c02376
+    #   Agent: ami-08b697d6313df6508
     us-east-1:
       Master: ami-0f593aebffc0070e1
-      Agent: ami-0281f5b6b2ae2df84
+      Agent: ami-0abefee50ebdc21f4
     us-east-2:
       Master: ami-096cdd827d38ca4d8
-      Agent: ami-02a26ef27a997c7de
+      Agent: ami-0d074fb7abacd5219
     us-west-2:
       Master: ami-04e9aec1ab665f323
-      Agent: ami-0fc52ebf88f40652b
+      Agent: ami-0685e5e3534f24db8
 
 Parameters:
   VpcCIDR:

--- a/deploy/determined_deploy/aws/templates/secure.yaml
+++ b/deploy/determined_deploy/aws/templates/secure.yaml
@@ -3,46 +3,46 @@ Description:  This template deploys a VPC, with a public and private subnet. It 
 Mappings:
   RegionMap:
     ap-northeast-1:
-      Master: ami-03ec47ea54612a98d
-      Agent: ami-0881b60d3da7bd055
-      Bastion: ami-07faf6b16c502e9e1
+      Master: ami-0af17d43b1f4ff4ea
+      Agent: ami-0a01b67743d465a6e
+      Bastion: ami-05855b7c54f91a1ae
     # TODO(DET-4258) Uncomment these when we fully support all P3 regions.
     # ap-northeast-2:
-    #   Master: ami-00813ad98dc81f443
-    #   Agent: ami-045eb8957d930ee48
-    #   Bastion: ami-0ee428c63274f56c1
+    #   Master: ami-04e6fcf8cfe3b09ea
+    #   Agent: ami-0c74312df78509701
+    #   Bastion: ami-063acefae626a1e95
     # ap-southeast-1:
-    #   Master: ami-0acac505592775345
-    #   Agent: ami-0b5cca90cd338e59d
-    #   Bastion: ami-06bcc4026e190b380
+    #   Master: ami-0ba45f1ec3dff60f9
+    #   Agent: ami-0eddf3f941d216f11
+    #   Bastion: ami-0311dbbdd981577d5
     # ap-southeast-2:
-    #   Master: ami-07c5b4ba4c9dd25a3
-    #   Agent: ami-0725e68bb3b036074
-    #   Bastion: ami-0b079c5b689b2d44e
+    #   Master: ami-004d0fb87d10716c6
+    #   Agent: ami-0c54777eb400a9e68
+    #   Bastion: ami-0dea9aeaa95b9751b
     eu-central-1:
-      Master: ami-01c74b7d55cbb6e31
-      Agent: ami-0a7e28c7ffceaaca3
-      Bastion: ami-0a4938aa802d3fc05
+      Master: ami-08a1a61694dd1c82f
+      Agent: ami-0474e45bb1a45bbfe
+      Bastion: ami-08a099fcfc36dff3f
     eu-west-1:
-      Master: ami-06f91a2970093cb47
-      Agent: ami-01ff907f77946e9c0
-      Bastion: ami-0074515a838fb8787
+      Master: ami-0d67111dcacb4a14a
+      Agent: ami-0036879b70fee3339
+      Bastion: ami-00c25f7948e360133
     # eu-west-2:
-    #   Master: ami-0be58974fa441cb39
-    #   Agent: ami-08b697d6313df6508
-    #   Bastion: ami-0789c35b922fefc1e
+    #   Master: ami-03441ec6f2faa7ddc
+    #   Agent: ami-05d9b28afa79dbda3
+    #   Bastion: ami-076071bbe3485317c
     us-east-1:
-      Master: ami-0f593aebffc0070e1
-      Agent: ami-0abefee50ebdc21f4
-      Bastion: ami-007e8beb808004fdc
+      Master: ami-099e921e69356cf89
+      Agent: ami-0080b638f1339ccd5
+      Bastion: ami-053adf54573f777cf
     us-east-2:
-      Master: ami-096cdd827d38ca4d8
-      Agent: ami-0d074fb7abacd5219
-      Bastion: ami-05c386ebc03ca06da
+      Master: ami-05edbb8e25e281608
+      Agent: ami-07318f0e0b3a02b8e
+      Bastion: ami-0b9487791bf873774
     us-west-2:
-      Master: ami-04e9aec1ab665f323
-      Agent: ami-0685e5e3534f24db8
-      Bastion: ami-0b5f687730c825c7d
+      Master: ami-00f1e37d20049f858
+      Agent: ami-0211fc4b3b0eb5c64
+      Bastion: ami-0cc158853935719b7
 
 Parameters:
   VpcCIDR:

--- a/deploy/determined_deploy/aws/templates/secure.yaml
+++ b/deploy/determined_deploy/aws/templates/secure.yaml
@@ -4,45 +4,45 @@ Mappings:
   RegionMap:
     ap-northeast-1:
       Master: ami-03ec47ea54612a98d
-      Agent: ami-055e84fd91eebace4
-      Bastion: ami-09dac16017637391f
+      Agent: ami-0881b60d3da7bd055
+      Bastion: ami-07faf6b16c502e9e1
     # TODO(DET-4258) Uncomment these when we fully support all P3 regions.
     # ap-northeast-2:
     #   Master: ami-00813ad98dc81f443
-    #   Agent: ami-098f3d295106b7e70
-    #   Bastion: ami-0b50511490117e709
+    #   Agent: ami-045eb8957d930ee48
+    #   Bastion: ami-0ee428c63274f56c1
     # ap-southeast-1:
     #   Master: ami-0acac505592775345
-    #   Agent: ami-00de94d5b3e68b0da
-    #   Bastion: ami-0ae3e6717dc99c62b
+    #   Agent: ami-0b5cca90cd338e59d
+    #   Bastion: ami-06bcc4026e190b380
     # ap-southeast-2:
     #   Master: ami-07c5b4ba4c9dd25a3
-    #   Agent: ami-0af10fa7e8454d943
-    #   Bastion: ami-080b87fdc6d5ca853
+    #   Agent: ami-0725e68bb3b036074
+    #   Bastion: ami-0b079c5b689b2d44e
     eu-central-1:
       Master: ami-01c74b7d55cbb6e31
-      Agent: ami-0171d0a466f6d4ac3
-      Bastion: ami-0093cac2bf998a669
+      Agent: ami-0a7e28c7ffceaaca3
+      Bastion: ami-0a4938aa802d3fc05
     eu-west-1:
       Master: ami-06f91a2970093cb47
-      Agent: ami-09925722b0ba31d90
-      Bastion: ami-0e5657f6d3c3ea350
+      Agent: ami-01ff907f77946e9c0
+      Bastion: ami-0074515a838fb8787
     # eu-west-2:
     #   Master: ami-0be58974fa441cb39
-    #   Agent: ami-0aa3396d882c02376
-    #   Bastion: ami-09b984029e6b0326b
+    #   Agent: ami-08b697d6313df6508
+    #   Bastion: ami-0789c35b922fefc1e
     us-east-1:
       Master: ami-0f593aebffc0070e1
-      Agent: ami-0281f5b6b2ae2df84
-      Bastion: ami-02fe94dee086c0c37
+      Agent: ami-0abefee50ebdc21f4
+      Bastion: ami-007e8beb808004fdc
     us-east-2:
       Master: ami-096cdd827d38ca4d8
-      Agent: ami-02a26ef27a997c7de
-      Bastion: ami-02aa7f3de34db391a
+      Agent: ami-0d074fb7abacd5219
+      Bastion: ami-05c386ebc03ca06da
     us-west-2:
       Master: ami-04e9aec1ab665f323
-      Agent: ami-0fc52ebf88f40652b
-      Bastion: ami-025102f49d03bec05
+      Agent: ami-0685e5e3534f24db8
+      Bastion: ami-0b5f687730c825c7d
 
 Parameters:
   VpcCIDR:

--- a/deploy/determined_deploy/aws/templates/simple.yaml
+++ b/deploy/determined_deploy/aws/templates/simple.yaml
@@ -5,35 +5,35 @@ Mappings:
   RegionMap:
     ap-northeast-1:
       Master: ami-03ec47ea54612a98d
-      Agent: ami-055e84fd91eebace4
+      Agent: ami-0881b60d3da7bd055
     # TODO(DET-4258) Uncomment these when we fully support all P3 regions.
     # ap-northeast-2:
     #   Master: ami-00813ad98dc81f443
-    #   Agent: ami-098f3d295106b7e70
+    #   Agent: ami-045eb8957d930ee48
     # ap-southeast-1:
     #   Master: ami-0acac505592775345
-    #   Agent: ami-00de94d5b3e68b0da
+    #   Agent: ami-0b5cca90cd338e59d
     # ap-southeast-2:
     #   Master: ami-07c5b4ba4c9dd25a3
-    #   Agent: ami-0af10fa7e8454d943
+    #   Agent: ami-0725e68bb3b036074
     eu-central-1:
       Master: ami-01c74b7d55cbb6e31
-      Agent: ami-0171d0a466f6d4ac3
+      Agent: ami-0a7e28c7ffceaaca3
     eu-west-1:
       Master: ami-06f91a2970093cb47
-      Agent: ami-09925722b0ba31d90
+      Agent: ami-01ff907f77946e9c0
     # eu-west-2:
     #   Master: ami-0be58974fa441cb39
-    #   Agent: ami-0aa3396d882c02376
+    #   Agent: ami-08b697d6313df6508
     us-east-1:
       Master: ami-0f593aebffc0070e1
-      Agent: ami-0281f5b6b2ae2df84
+      Agent: ami-0abefee50ebdc21f4
     us-east-2:
       Master: ami-096cdd827d38ca4d8
-      Agent: ami-02a26ef27a997c7de
+      Agent: ami-0d074fb7abacd5219
     us-west-2:
       Master: ami-04e9aec1ab665f323
-      Agent: ami-0fc52ebf88f40652b
+      Agent: ami-0685e5e3534f24db8
 
 Parameters:
   Keypair:

--- a/deploy/determined_deploy/aws/templates/simple.yaml
+++ b/deploy/determined_deploy/aws/templates/simple.yaml
@@ -4,36 +4,36 @@ Description: Determined Template
 Mappings:
   RegionMap:
     ap-northeast-1:
-      Master: ami-03ec47ea54612a98d
-      Agent: ami-0881b60d3da7bd055
+      Master: ami-0af17d43b1f4ff4ea
+      Agent: ami-0a01b67743d465a6e
     # TODO(DET-4258) Uncomment these when we fully support all P3 regions.
     # ap-northeast-2:
-    #   Master: ami-00813ad98dc81f443
-    #   Agent: ami-045eb8957d930ee48
+    #   Master: ami-04e6fcf8cfe3b09ea
+    #   Agent: ami-0c74312df78509701
     # ap-southeast-1:
-    #   Master: ami-0acac505592775345
-    #   Agent: ami-0b5cca90cd338e59d
+    #   Master: ami-0ba45f1ec3dff60f9
+    #   Agent: ami-0eddf3f941d216f11
     # ap-southeast-2:
-    #   Master: ami-07c5b4ba4c9dd25a3
-    #   Agent: ami-0725e68bb3b036074
+    #   Master: ami-004d0fb87d10716c6
+    #   Agent: ami-0c54777eb400a9e68
     eu-central-1:
-      Master: ami-01c74b7d55cbb6e31
-      Agent: ami-0a7e28c7ffceaaca3
+      Master: ami-08a1a61694dd1c82f
+      Agent: ami-0474e45bb1a45bbfe
     eu-west-1:
-      Master: ami-06f91a2970093cb47
-      Agent: ami-01ff907f77946e9c0
+      Master: ami-0d67111dcacb4a14a
+      Agent: ami-0036879b70fee3339
     # eu-west-2:
-    #   Master: ami-0be58974fa441cb39
-    #   Agent: ami-08b697d6313df6508
+    #   Master: ami-03441ec6f2faa7ddc
+    #   Agent: ami-05d9b28afa79dbda3
     us-east-1:
-      Master: ami-0f593aebffc0070e1
-      Agent: ami-0abefee50ebdc21f4
+      Master: ami-099e921e69356cf89
+      Agent: ami-0080b638f1339ccd5
     us-east-2:
-      Master: ami-096cdd827d38ca4d8
-      Agent: ami-0d074fb7abacd5219
+      Master: ami-05edbb8e25e281608
+      Agent: ami-07318f0e0b3a02b8e
     us-west-2:
-      Master: ami-04e9aec1ab665f323
-      Agent: ami-0685e5e3534f24db8
+      Master: ami-00f1e37d20049f858
+      Agent: ami-0211fc4b3b0eb5c64
 
 Parameters:
   Keypair:

--- a/deploy/determined_deploy/aws/templates/vpc.yaml
+++ b/deploy/determined_deploy/aws/templates/vpc.yaml
@@ -3,36 +3,36 @@ Description:  This template deploys a VPC, with a public and private subnet. It 
 Mappings:
   RegionMap:
     ap-northeast-1:
-      Master: ami-03ec47ea54612a98d
-      Agent: ami-0881b60d3da7bd055
+      Master: ami-0af17d43b1f4ff4ea
+      Agent: ami-0a01b67743d465a6e
     # TODO(DET-4258) Uncomment these when we fully support all P3 regions.
     # ap-northeast-2:
-    #   Master: ami-00813ad98dc81f443
-    #   Agent: ami-045eb8957d930ee48
+    #   Master: ami-04e6fcf8cfe3b09ea
+    #   Agent: ami-0c74312df78509701
     # ap-southeast-1:
-    #   Master: ami-0acac505592775345
-    #   Agent: ami-0b5cca90cd338e59d
+    #   Master: ami-0ba45f1ec3dff60f9
+    #   Agent: ami-0eddf3f941d216f11
     # ap-southeast-2:
-    #   Master: ami-07c5b4ba4c9dd25a3
-    #   Agent: ami-0725e68bb3b036074
+    #   Master: ami-004d0fb87d10716c6
+    #   Agent: ami-0c54777eb400a9e68
     eu-central-1:
-      Master: ami-01c74b7d55cbb6e31
-      Agent: ami-0a7e28c7ffceaaca3
+      Master: ami-08a1a61694dd1c82f
+      Agent: ami-0474e45bb1a45bbfe
     eu-west-1:
-      Master: ami-06f91a2970093cb47
-      Agent: ami-01ff907f77946e9c0
+      Master: ami-0d67111dcacb4a14a
+      Agent: ami-0036879b70fee3339
     # eu-west-2:
-    #   Master: ami-0be58974fa441cb39
-    #   Agent: ami-08b697d6313df6508
+    #   Master: ami-03441ec6f2faa7ddc
+    #   Agent: ami-05d9b28afa79dbda3
     us-east-1:
-      Master: ami-0f593aebffc0070e1
-      Agent: ami-0abefee50ebdc21f4
+      Master: ami-099e921e69356cf89
+      Agent: ami-0080b638f1339ccd5
     us-east-2:
-      Master: ami-096cdd827d38ca4d8
-      Agent: ami-0d074fb7abacd5219
+      Master: ami-05edbb8e25e281608
+      Agent: ami-07318f0e0b3a02b8e
     us-west-2:
-      Master: ami-04e9aec1ab665f323
-      Agent: ami-0685e5e3534f24db8
+      Master: ami-00f1e37d20049f858
+      Agent: ami-0211fc4b3b0eb5c64
 
 Parameters:
   VpcCIDR:

--- a/deploy/determined_deploy/aws/templates/vpc.yaml
+++ b/deploy/determined_deploy/aws/templates/vpc.yaml
@@ -4,35 +4,35 @@ Mappings:
   RegionMap:
     ap-northeast-1:
       Master: ami-03ec47ea54612a98d
-      Agent: ami-055e84fd91eebace4
+      Agent: ami-0881b60d3da7bd055
     # TODO(DET-4258) Uncomment these when we fully support all P3 regions.
     # ap-northeast-2:
     #   Master: ami-00813ad98dc81f443
-    #   Agent: ami-098f3d295106b7e70
+    #   Agent: ami-045eb8957d930ee48
     # ap-southeast-1:
     #   Master: ami-0acac505592775345
-    #   Agent: ami-00de94d5b3e68b0da
+    #   Agent: ami-0b5cca90cd338e59d
     # ap-southeast-2:
     #   Master: ami-07c5b4ba4c9dd25a3
-    #   Agent: ami-0af10fa7e8454d943
+    #   Agent: ami-0725e68bb3b036074
     eu-central-1:
       Master: ami-01c74b7d55cbb6e31
-      Agent: ami-0171d0a466f6d4ac3
+      Agent: ami-0a7e28c7ffceaaca3
     eu-west-1:
       Master: ami-06f91a2970093cb47
-      Agent: ami-09925722b0ba31d90
+      Agent: ami-01ff907f77946e9c0
     # eu-west-2:
     #   Master: ami-0be58974fa441cb39
-    #   Agent: ami-0aa3396d882c02376
+    #   Agent: ami-08b697d6313df6508
     us-east-1:
       Master: ami-0f593aebffc0070e1
-      Agent: ami-0281f5b6b2ae2df84
+      Agent: ami-0abefee50ebdc21f4
     us-east-2:
       Master: ami-096cdd827d38ca4d8
-      Agent: ami-02a26ef27a997c7de
+      Agent: ami-0d074fb7abacd5219
     us-west-2:
       Master: ami-04e9aec1ab665f323
-      Agent: ami-0fc52ebf88f40652b
+      Agent: ami-0685e5e3534f24db8
 
 Parameters:
   VpcCIDR:

--- a/deploy/determined_deploy/gcp/constants.py
+++ b/deploy/determined_deploy/gcp/constants.py
@@ -3,7 +3,7 @@ class defaults:
     CPU_AGENT_INSTANCE_TYPE = "n1-standard-4"
     GPU_AGENT_INSTANCE_TYPE = "n1-standard-32"
     DB_PASSWORD = "postgres"
-    ENVIRONMENT_IMAGE = "det-environments-4a93d25"
+    ENVIRONMENT_IMAGE = "det-environments-5f6f6e1"
     GPU_NUM = 8
     GPU_TYPE = "nvidia-tesla-k80"
     MASTER_INSTANCE_TYPE = "n1-standard-2"

--- a/deploy/determined_deploy/gcp/constants.py
+++ b/deploy/determined_deploy/gcp/constants.py
@@ -3,7 +3,7 @@ class defaults:
     CPU_AGENT_INSTANCE_TYPE = "n1-standard-4"
     GPU_AGENT_INSTANCE_TYPE = "n1-standard-32"
     DB_PASSWORD = "postgres"
-    ENVIRONMENT_IMAGE = "det-environments-5f6f6e1"
+    ENVIRONMENT_IMAGE = "det-environments-067db2b"
     GPU_NUM = 8
     GPU_TYPE = "nvidia-tesla-k80"
     MASTER_INSTANCE_TYPE = "n1-standard-2"

--- a/docs/faq.txt
+++ b/docs/faq.txt
@@ -203,9 +203,9 @@ container image that has been configured for that experiment. Determined
 provides prebuilt Docker images that include TensorFlow 1 and 2,
 respectively:
 
--  ``determinedai/environments:cuda-10.1-pytorch-1.7-tf-1.15-gpu-0.9.0``
+-  ``determinedai/environments:cuda-10.0-pytorch-1.4-tf-1.15-gpu-0.8.0``
    (default)
--  ``determinedai/environments:cuda-10.1-pytorch-1.7-tf-2.4-gpu-0.9.0``
+-  ``determinedai/environments:cuda-10.1-pytorch-1.4-tf-2.2-gpu-0.8.0``
 
 To change the container image used for an experiment, specify
 :ref:`environment.image <exp-environment-image>` in the experiment

--- a/docs/how-to/custom-env.txt
+++ b/docs/how-to/custom-env.txt
@@ -109,9 +109,9 @@ and values of the hyperparameters for the current trial.
 .. note::
 
    The default images are
-   ``determinedai/environments:cuda-10.1-pytorch-1.7-tf-1.15-gpu-0.9.0``
+   ``determinedai/environments:cuda-10.0-pytorch-1.4-tf-1.15-gpu-0.8.0``
    and
-   ``determinedai/environments:py-3.6.9-pytorch-1.7-tf-1.15-cpu-0.9.0``
+   ``determinedai/environments:py-3.6.9-pytorch-1.4-tf-1.15-cpu-0.8.0``
    for GPU and CPU respectively.
 
 TensorFlow 2 Images
@@ -132,8 +132,8 @@ This can be configured in your experiment configuration like below:
 
    environment:
      image:
-       gpu: "determinedai/environments:cuda-10.1-pytorch-1.7-tf-2.4-gpu-0.9.0"
-       cpu: "determinedai/environments:py-3.6.9-pytorch-1.7-tf-2.4-cpu-0.9.0"
+       gpu: "determinedai/environments:cuda-10.1-pytorch-1.4-tf-2.2-gpu-0.8.0"
+       cpu: "determinedai/environments:py-3.6.9-pytorch-1.4-tf-2.2-cpu-0.8.0"
 
 .. _custom-docker-images:
 
@@ -161,7 +161,7 @@ Here is an example of a ``Dockerfile`` that installs both ``conda``- and
 
 .. code::
 
-   FROM determinedai/environments:cuda-10.1-pytorch-1.7-tf-1.15-gpu-0.9.0
+   FROM determinedai/environments:cuda-10.0-pytorch-1.4-tf-1.15-gpu-0.8.0
    RUN apt-get update && apt-get install -y unzip python-opencv graphviz
    COPY environment.yml /tmp/environment.yml
    COPY pip_requirements.txt /tmp/pip_requirements.txt

--- a/docs/reference/cluster-config.txt
+++ b/docs/reference/cluster-config.txt
@@ -267,9 +267,9 @@ The master supports the following configuration settings:
       specifying a dict with two keys, ``cpu`` and ``gpu``. Default
       values:
 
-      -  ``determinedai/environments:py-3.6.9-pytorch-1.7-tf-1.15-cpu-0.9.0``
+      -  ``determinedai/environments:py-3.6.9-pytorch-1.4-tf-1.15-cpu-0.8.0``
          for CPU agents
-      -  ``determinedai/environments:cuda-10.1-pytorch-1.7-tf-1.15-gpu-0.9.0``
+      -  ``determinedai/environments:cuda-10.0-pytorch-1.4-tf-1.15-gpu-0.8.0``
          for GPU agents.
 
    -  ``force_pull_image``: Defines the default policy for forcibly

--- a/docs/reference/command-notebook-config.txt
+++ b/docs/reference/command-notebook-config.txt
@@ -49,9 +49,9 @@ The following configuration settings are supported:
       Determined agent machine in the cluster. Users can customize the
       image used for GPU vs. CPU agents by specifying a dict with two
       keys, ``cpu`` and ``gpu``. Defaults to
-      ``determinedai/environments:py-3.6.9-pytorch-1.7-tf-1.15-cpu-0.9.0``
+      ``determinedai/environments:py-3.6.9-pytorch-1.4-tf-1.15-cpu-0.8.0``
       for CPU agents and
-      ``determinedai/environments:cuda-10.1-pytorch-1.7-tf-1.15-gpu-0.9.0``
+      ``determinedai/environments:cuda-10.0-pytorch-1.4-tf-1.15-gpu-0.8.0``
       for GPU agents.
 
    -  ``force_pull_image``: Forcibly pull the image from the Docker

--- a/docs/reference/experiment-config.txt
+++ b/docs/reference/experiment-config.txt
@@ -1015,9 +1015,9 @@ more information on customizing the trial environment, refer to
    GPU vs. CPU agents by specifying a dict with two keys, ``cpu`` and
    ``gpu``. Default values:
 
-   -  ``determinedai/environments:cuda-10.1-pytorch-1.7-tf-1.15-gpu-0.9.0``
+   -  ``determinedai/environments:cuda-10.0-pytorch-1.4-tf-1.15-gpu-0.8.0``
       for agents with GPUs.
-   -  ``determinedai/environments:py-3.6.9-pytorch-1.7-tf-1.15-cpu-0.9.0``
+   -  ``determinedai/environments:py-3.6.9-pytorch-1.4-tf-1.15-cpu-0.8.0``
       for agents with only CPUs.
 
 ``force_pull_image``

--- a/docs/reference/helm-config.txt
+++ b/docs/reference/helm-config.txt
@@ -204,12 +204,12 @@ Helm Chart </helm/determined-helm-chart.tgz>`.
    -  ``cpuImage``: Sets the default docker image for all non-gpu tasks.
       If a docker image is specified in the :ref:`experiment config
       <exp-environment-image>` this default is overriden. Defaults to:
-      ``determinedai/environments:py-3.6.9-pytorch-1.7-tf-1.15-cpu-0.9.0``.
+      ``determinedai/environments:py-3.6.9-pytorch-1.4-tf-1.15-cpu-0.8.0``.
 
    -  ``gpuImage``: Sets the default docker image for all gpu tasks. If
       a docker image is specified in the :ref:`experiment config
       <exp-environment-image>` this default is overriden. Defaults to:
-      ``determinedai/environments:cuda-10.1-pytorch-1.7-tf-1.15-gpu-0.9.0``.
+      ``determinedai/environments:cuda-10.0-pytorch-1.4-tf-1.15-gpu-0.8.0``.
 
 -  ``enterpriseEdition``: Specifies whether to use Determined enterprise
    edition.

--- a/docs/release-notes/1851-framework-upgrades.txt
+++ b/docs/release-notes/1851-framework-upgrades.txt
@@ -3,5 +3,5 @@
 **Improvements**
 
 -  Upgrade the default PyTorch version to 1.7.0 and the default
-   TensorFlow version to 1.15.5 (or TensorFlow 2.4.1 in -tf2 task
+   TensorFlow version to 1.15.5 (or TensorFlow 2.4.0 in -tf2 task
    environments).

--- a/docs/release-notes/1851-framework-upgrades.txt
+++ b/docs/release-notes/1851-framework-upgrades.txt
@@ -1,7 +1,0 @@
-:orphan:
-
-**Improvements**
-
--  Upgrade the default PyTorch version to 1.7.0 and the default
-   TensorFlow version to 1.15.5 (or TensorFlow 2.4.0 in -tf2 task
-   environments).

--- a/docs/tutorials/quick-start.txt
+++ b/docs/tutorials/quick-start.txt
@@ -43,10 +43,10 @@ cluster without writing a model, see :ref:`commands-and-shells`.
 .. code::
 
    # For CPU computations
-   docker pull determinedai/environments:py-3.6.9-pytorch-1.7-tf-1.15-cpu-0.9.0
+   docker pull determinedai/environments:py-3.6.9-pytorch-1.4-tf-1.15-cpu-0.8.0
 
    # For GPU computations
-   docker pull determinedai/environments:cuda-10.1-pytorch-1.7-tf-1.15-gpu-0.9.0
+   docker pull determinedai/environments:cuda-10.0-pytorch-1.4-tf-1.15-gpu-0.8.0
 
 .. _quick-start-first-job:
 

--- a/e2e_tests/tests/config.py
+++ b/e2e_tests/tests/config.py
@@ -12,10 +12,10 @@ MAX_TASK_SCHEDULED_SECS = 30
 MAX_TRIAL_BUILD_SECS = 90
 
 
-DEFAULT_TF1_CPU_IMAGE = "determinedai/environments:py-3.6.9-pytorch-1.7-tf-1.15-cpu-5f6f6e1"
-DEFAULT_TF2_CPU_IMAGE = "determinedai/environments:py-3.6.9-pytorch-1.7-tf-2.4-cpu-5f6f6e1"
-DEFAULT_TF1_GPU_IMAGE = "determinedai/environments:cuda-10.1-pytorch-1.7-tf-1.15-gpu-5f6f6e1"
-DEFAULT_TF2_GPU_IMAGE = "determinedai/environments:cuda-10.1-pytorch-1.7-tf-2.4-gpu-5f6f6e1"
+DEFAULT_TF1_CPU_IMAGE = "determinedai/environments:py-3.6.9-pytorch-1.4-tf-1.15-cpu-067db2b"
+DEFAULT_TF2_CPU_IMAGE = "determinedai/environments:py-3.6.9-pytorch-1.4-tf-2.2-cpu-067db2b"
+DEFAULT_TF1_GPU_IMAGE = "determinedai/environments:cuda-10.0-pytorch-1.4-tf-1.15-gpu-067db2b"
+DEFAULT_TF2_GPU_IMAGE = "determinedai/environments:cuda-10.1-pytorch-1.4-tf-2.2-gpu-067db2b"
 
 TF1_CPU_IMAGE = os.environ.get("TF1_CPU_IMAGE") or DEFAULT_TF1_CPU_IMAGE
 TF2_CPU_IMAGE = os.environ.get("TF2_CPU_IMAGE") or DEFAULT_TF2_CPU_IMAGE

--- a/e2e_tests/tests/config.py
+++ b/e2e_tests/tests/config.py
@@ -12,10 +12,10 @@ MAX_TASK_SCHEDULED_SECS = 30
 MAX_TRIAL_BUILD_SECS = 90
 
 
-DEFAULT_TF1_CPU_IMAGE = "determinedai/environments:py-3.6.9-pytorch-1.7-tf-1.15-cpu-4a93d25"
-DEFAULT_TF2_CPU_IMAGE = "determinedai/environments:py-3.6.9-pytorch-1.7-tf-2.4-cpu-4a93d25"
-DEFAULT_TF1_GPU_IMAGE = "determinedai/environments:cuda-10.1-pytorch-1.7-tf-1.15-gpu-4a93d25"
-DEFAULT_TF2_GPU_IMAGE = "determinedai/environments:cuda-10.1-pytorch-1.7-tf-2.4-gpu-4a93d25"
+DEFAULT_TF1_CPU_IMAGE = "determinedai/environments:py-3.6.9-pytorch-1.7-tf-1.15-cpu-5f6f6e1"
+DEFAULT_TF2_CPU_IMAGE = "determinedai/environments:py-3.6.9-pytorch-1.7-tf-2.4-cpu-5f6f6e1"
+DEFAULT_TF1_GPU_IMAGE = "determinedai/environments:cuda-10.1-pytorch-1.7-tf-1.15-gpu-5f6f6e1"
+DEFAULT_TF2_GPU_IMAGE = "determinedai/environments:cuda-10.1-pytorch-1.7-tf-2.4-gpu-5f6f6e1"
 
 TF1_CPU_IMAGE = os.environ.get("TF1_CPU_IMAGE") or DEFAULT_TF1_CPU_IMAGE
 TF2_CPU_IMAGE = os.environ.get("TF2_CPU_IMAGE") or DEFAULT_TF2_CPU_IMAGE

--- a/e2e_tests/tests/requirements.txt
+++ b/e2e_tests/tests/requirements.txt
@@ -5,7 +5,7 @@ pytest-timeout
 pexpect
 torch==1.7
 torchvision==0.8.1
-tensorflow==2.4.1
+tensorflow==2.4.0
 numpy
 pandas
 pyyaml

--- a/e2e_tests/tests/requirements.txt
+++ b/e2e_tests/tests/requirements.txt
@@ -3,10 +3,12 @@ appdirs
 pytest>=6.0.1
 pytest-timeout
 pexpect
-torch==1.7
-torchvision==0.8.1
-tensorflow==2.4.0
-numpy
+torch==1.4
+torchvision==0.5.0
+tensorflow==1.15.4
+# TF 1.15.4 has requirement numpy<1.19.0,>=1.16.0
+# and numpy==1.19.2 throws numpy.ufunc has the wrong size error
+numpy==1.18.5
 pandas
 pyyaml
 docker

--- a/examples/decision_trees/gbt_titanic_estimator/adaptive.yaml
+++ b/examples/decision_trees/gbt_titanic_estimator/adaptive.yaml
@@ -42,4 +42,4 @@ searcher:
 entrypoint: model_def:BoostedTreesTrial
 scheduling_unit: 1
 environment:
-  image: "determinedai/environments:py-3.6.9-pytorch-1.7-tf-1.15-cpu-0.9.0"
+  image: "determinedai/environments:py-3.6.9-pytorch-1.4-tf-1.15-cpu-0.8.0"

--- a/examples/decision_trees/gbt_titanic_estimator/const.yaml
+++ b/examples/decision_trees/gbt_titanic_estimator/const.yaml
@@ -20,4 +20,4 @@ searcher:
 entrypoint: model_def:BoostedTreesTrial
 scheduling_unit: 1
 environment:
-  image: "determinedai/environments:py-3.6.9-pytorch-1.7-tf-1.15-cpu-0.9.0" 
+  image: "determinedai/environments:py-3.6.9-pytorch-1.4-tf-1.15-cpu-0.8.0" 

--- a/examples/gan/dcgan_tf_keras/const.yaml
+++ b/examples/gan/dcgan_tf_keras/const.yaml
@@ -15,5 +15,5 @@ entrypoint: model_def:DCGanTrial
 environment:
   # This model only works with Tensorflow 2.2+.
   image:
-     cpu: "determinedai/environments:py-3.6.9-pytorch-1.7-tf-2.4-cpu-5f6f6e1"
-     gpu: "determinedai/environments:cuda-10.1-pytorch-1.7-tf-2.4-gpu-5f6f6e1"
+     cpu: "determinedai/environments:py-3.6.9-pytorch-1.4-tf-2.2-cpu-067db2b"
+     gpu: "determinedai/environments:cuda-10.1-pytorch-1.4-tf-2.2-gpu-067db2b"

--- a/examples/gan/dcgan_tf_keras/const.yaml
+++ b/examples/gan/dcgan_tf_keras/const.yaml
@@ -15,5 +15,5 @@ entrypoint: model_def:DCGanTrial
 environment:
   # This model only works with Tensorflow 2.2+.
   image:
-     cpu: "determinedai/environments:py-3.6.9-pytorch-1.7-tf-2.4-cpu-4a93d25"
-     gpu: "determinedai/environments:cuda-10.1-pytorch-1.7-tf-2.4-gpu-4a93d25"
+     cpu: "determinedai/environments:py-3.6.9-pytorch-1.7-tf-2.4-cpu-5f6f6e1"
+     gpu: "determinedai/environments:cuda-10.1-pytorch-1.7-tf-2.4-gpu-5f6f6e1"

--- a/examples/gan/dcgan_tf_keras/distributed.yaml
+++ b/examples/gan/dcgan_tf_keras/distributed.yaml
@@ -17,5 +17,5 @@ resources:
 environment:
   # This model only works with Tensorflow 2.2+.
   image:
-     cpu: "determinedai/environments:py-3.6.9-pytorch-1.7-tf-2.4-cpu-5f6f6e1"
-     gpu: "determinedai/environments:cuda-10.1-pytorch-1.7-tf-2.4-gpu-5f6f6e1"
+     cpu: "determinedai/environments:py-3.6.9-pytorch-1.4-tf-2.2-cpu-067db2b"
+     gpu: "determinedai/environments:cuda-10.1-pytorch-1.4-tf-2.2-gpu-067db2b"

--- a/examples/gan/dcgan_tf_keras/distributed.yaml
+++ b/examples/gan/dcgan_tf_keras/distributed.yaml
@@ -17,5 +17,5 @@ resources:
 environment:
   # This model only works with Tensorflow 2.2+.
   image:
-     cpu: "determinedai/environments:py-3.6.9-pytorch-1.7-tf-2.4-cpu-4a93d25"
-     gpu: "determinedai/environments:cuda-10.1-pytorch-1.7-tf-2.4-gpu-4a93d25"
+     cpu: "determinedai/environments:py-3.6.9-pytorch-1.7-tf-2.4-cpu-5f6f6e1"
+     gpu: "determinedai/environments:cuda-10.1-pytorch-1.7-tf-2.4-gpu-5f6f6e1"

--- a/examples/tests/requirements.txt
+++ b/examples/tests/requirements.txt
@@ -1,8 +1,8 @@
 # pytest 6.0 has linter-breaking changes
 pytest>=6.0.1
 tensorflow==2.2.1
-torch==1.7.0
-torchvision==0.8.1
+torch==1.4.0
+torchvision==0.5.0
 pandas==1.0.3
 tensorflow_datasets
 scipy

--- a/harness/Makefile
+++ b/harness/Makefile
@@ -30,7 +30,7 @@ check:
 
 .PHONY: test
 test:
-	pytest -v -s --runslow --durations=0 tests
+	pytest -v --runslow --durations=0 tests
 
 .PHONY: test-tf2
 test-tf2:

--- a/harness/determined/estimator/_estimator_trial.py
+++ b/harness/determined/estimator/_estimator_trial.py
@@ -805,7 +805,7 @@ class EstimatorTrial(det.Trial):
     """
     By default, experiments run with TensorFlow 1.x. To configure your trial to
     use TensorFlow 2.x, set a TF 2.x image in the experiment configuration
-    (e.g. ``determinedai/environments:cuda-10.1-pytorch-1.7-tf-2.4-gpu-0.9.0``).
+    (e.g. ``determinedai/environments:cuda-10.1-pytorch-1.4-tf-2.2-gpu-0.8.0``).
 
     ``EstimatorTrial`` supports TF 2.x; however it uses TensorFlow V1
     behavior. We have disabled TensorFlow V2 behavior for ``EstimatorTrial``,

--- a/harness/determined/keras/_tf_keras_trial.py
+++ b/harness/determined/keras/_tf_keras_trial.py
@@ -941,7 +941,7 @@ class TFKerasTrial(det.Trial):
     TensorFlow 2.x, specify a TensorFlow 2.x image in the
     :ref:`environment.image <exp-environment-image>` field of the experiment
     configuration (e.g.,
-    ``determinedai/environments:cuda-10.1-pytorch-1.7-tf-2.4-gpu-0.9.0``).
+    ``determinedai/environments:cuda-10.1-pytorch-1.4-tf-2.2-gpu-0.8.0``).
 
     Trials default to using eager execution with TensorFlow 2.x but not with
     TensorFlow 1.x. To override the default behavior, call the appropriate

--- a/harness/determined/pytorch/_data.py
+++ b/harness/determined/pytorch/_data.py
@@ -158,9 +158,9 @@ class DataLoader:
             #    else:
             #        sampler = SequentialSampler(dataset)
             if shuffle:
-                sampler = RandomSampler(dataset)  # type: ignore
+                sampler = RandomSampler(dataset)
             else:
-                sampler = SequentialSampler(dataset)  # type: ignore
+                sampler = SequentialSampler(dataset)
 
         if batch_size is not None and batch_sampler is None:
             # auto_collation without custom batch_sampler

--- a/harness/determined/pytorch/_lr_scheduler.py
+++ b/harness/determined/pytorch/_lr_scheduler.py
@@ -62,7 +62,7 @@ class LRScheduler:
         self._scheduler.step(*args, **kwargs)
 
     def get_last_lr(self) -> List:
-        return self._scheduler.get_last_lr()
+        return self._scheduler.get_last_lr()  # type: ignore
 
     def load_state_dict(self, state_dict: Dict[Any, Any]) -> None:
         self._scheduler.load_state_dict(state_dict)

--- a/harness/determined/pytorch/_pytorch_context.py
+++ b/harness/determined/pytorch/_pytorch_context.py
@@ -46,7 +46,7 @@ class PyTorchTrialContext(det.TrialContext):
         # The following attributes are initialized during the lifetime of
         # a PyTorchTrialContext.
         self.models = []  # type: List[nn.Module]
-        self.optimizers = []  # type: List[torch.optim.Optimizer]
+        self.optimizers = []  # type: List[torch.optim.Optimizer] #  type: ignore
         self.lr_schedulers = []  # type: List[pytorch.LRScheduler]
         self._epoch_len = None  # type: Optional[int]
 
@@ -56,7 +56,7 @@ class PyTorchTrialContext(det.TrialContext):
         # different names using __setattr__ and use the state_dict of the main model
         # for broadcasting. Note that broadcast_parameters only accepts state_dict()
         # although its doc says it also accepts named_parameters()
-        self._main_model = nn.Module()  # type: ignore
+        self._main_model = nn.Module()  # type: nn.Module
         self._use_amp = False
         self._loss_ids = {}  # type: Dict[torch.Tensor, int]
         self._last_backward_batch_idx = None  # type: Optional[int]
@@ -90,9 +90,9 @@ class PyTorchTrialContext(det.TrialContext):
 
     def wrap_optimizer(
         self,
-        optimizer: torch.optim.Optimizer,
+        optimizer: torch.optim.Optimizer,  # type: ignore
         backward_passes_per_step: int = 1,
-    ) -> torch.optim.Optimizer:
+    ) -> torch.optim.Optimizer:  # type: ignore
         """Returns a wrapped optimizer.
 
         The optimizer must use the models wrapped by :meth:`wrap_model`. This function
@@ -186,7 +186,7 @@ class PyTorchTrialContext(det.TrialContext):
         # don't care about.
         return lr_scheduler
 
-    def _filter_named_parameters(self, optimizer: torch.optim.Optimizer) -> List:
+    def _filter_named_parameters(self, optimizer: torch.optim.Optimizer) -> List:  # type: ignore
         """_filter_named_parameters filters the named parameters of a specified optimizer out
         of all the named parameters from a specified model. We need this function because
         a ``torch.optim.Optimizer`` doesn't store parameter names and we need the names of
@@ -221,7 +221,7 @@ class PyTorchTrialContext(det.TrialContext):
     def configure_apex_amp(
         self,
         models: Union[torch.nn.Module, List[torch.nn.Module]],
-        optimizers: Union[torch.optim.Optimizer, List[torch.optim.Optimizer]],
+        optimizers: Union[torch.optim.Optimizer, List[torch.optim.Optimizer]],  # type: ignore
         enabled: Optional[bool] = True,
         opt_level: Optional[str] = "O1",
         cast_model_type: Optional[torch.dtype] = None,
@@ -418,7 +418,7 @@ class PyTorchTrialContext(det.TrialContext):
                     # to integrate torch native AMP (https://pytorch.org/docs/stable/amp.html),
                     # which will come out soon.
                     for optimizer in self.optimizers:
-                        optimizer.synchronize()  # type: ignore
+                        optimizer.synchronize()
         else:
             loss.backward(  # type: ignore
                 gradient=gradient,
@@ -437,7 +437,7 @@ class PyTorchTrialContext(det.TrialContext):
 
     def step_optimizer(
         self,
-        optimizer: torch.optim.Optimizer,
+        optimizer: torch.optim.Optimizer,  # type: ignore
         clip_grads: Optional[Callable[[Iterator], None]] = None,
         auto_zero_grads: bool = True,
     ) -> None:
@@ -478,7 +478,7 @@ class PyTorchTrialContext(det.TrialContext):
             # Communication needs to be synchronized so that is completed
             # before we apply gradient clipping and `step()`.
             if self.hvd_config.use and not self._use_amp:
-                optimizer.synchronize()  # type: ignore
+                optimizer.synchronize()
 
             parameters = (
                 [p for group in optimizer.param_groups for p in group.get("params", [])]
@@ -495,7 +495,7 @@ class PyTorchTrialContext(det.TrialContext):
                 clip_grads(parameters)
 
             if self.hvd_config.use:
-                with optimizer.skip_synchronize():  # type: ignore
+                with optimizer.skip_synchronize():
                     optimizer.step()
             else:
                 optimizer.step()

--- a/harness/setup.py
+++ b/harness/setup.py
@@ -29,9 +29,9 @@ setup(
     extras_require={
         "tf-115-cuda101": ["tensorflow-gpu==1.15.5"],
         "tf-1115-cpu": ["tensorflow==1.15.5"],
-        "tf-240-cuda101": ["tensorflow-gpu==2.4.1"],
-        "tf-240-cpu": ["tensorflow==2.4.1"],
-        "tf-240-cuda110": ["tensorflow-gpu==2.4.1"],
+        "tf-240-cuda101": ["tensorflow-gpu==2.4.0"],
+        "tf-240-cpu": ["tensorflow==2.4.0"],
+        "tf-240-cuda110": ["tensorflow-gpu==2.4.0"],
         "pytorch-17-cuda101": ["torch==1.7.1+cu101", "torchvision==0.8.2+cu101"],
         "pytorch-17-cuda110": ["torch==1.7.1+cu110", "torchvision==0.8.2+cu110"],
         "pytorch-17-cpu": ["torch==1.7.0", "torchvision==0.8.2"],

--- a/harness/setup.py
+++ b/harness/setup.py
@@ -27,14 +27,10 @@ setup(
         "yogadl==0.1.3",
     ],
     extras_require={
-        "tf-115-cuda101": ["tensorflow-gpu==1.15.5"],
-        "tf-1115-cpu": ["tensorflow==1.15.5"],
-        "tf-240-cuda101": ["tensorflow-gpu==2.4.0"],
-        "tf-240-cpu": ["tensorflow==2.4.0"],
-        "tf-240-cuda110": ["tensorflow-gpu==2.4.0"],
-        "pytorch-17-cuda101": ["torch==1.7.1+cu101", "torchvision==0.8.2+cu101"],
-        "pytorch-17-cuda110": ["torch==1.7.1+cu110", "torchvision==0.8.2+cu110"],
-        "pytorch-17-cpu": ["torch==1.7.0", "torchvision==0.8.2"],
+        "tf-114-cuda100": ["tensorflow-gpu==1.14.0"],
+        "tf-114-cpu": ["tensorflow==1.14.0"],
+        "pytorch-14-cuda100": ["torch==1.4.0+cu100", "torchvision==0.5.0+cu100"],
+        "pytorch-14-cpu": ["torch==1.4.0", "torchvision==0.5.0"],
     },
     zip_safe=False,
 )

--- a/harness/tests/experiment/keras/test_tf_keras_trial.py
+++ b/harness/tests/experiment/keras/test_tf_keras_trial.py
@@ -341,8 +341,6 @@ def test_surface_native_error():
                 b"ValueError: Shapes (None, 10) and (None, 1) are incompatible" in err
                 or b"ValueError: Input 0 of layer sequential is incompatible with the "
                 b"layer: : expected min_ndim=2, found ndim=1. Full shape received: [1]" in err
-                or b"ValueError: Input 0 of layer sequential is incompatible with the "
-                b"layer: : expected min_ndim=2, found ndim=1. Full shape received: (1,)" in err
             )
         else:
             assert b"ValueError: Input 0 of layer sequential is incompatible with the layer" in err

--- a/master/internal/provisioner/aws_config.go
+++ b/master/internal/provisioner/aws_config.go
@@ -41,16 +41,16 @@ type AWSClusterConfig struct {
 }
 
 var defaultAWSImageID = map[string]string{
-	"ap-northeast-1": "ami-055e84fd91eebace4",
-	"ap-northeast-2": "ami-098f3d295106b7e70",
-	"ap-southeast-1": "ami-00de94d5b3e68b0da",
-	"ap-southeast-2": "ami-0af10fa7e8454d943",
-	"us-east-2":      "ami-02a26ef27a997c7de",
-	"us-east-1":      "ami-0281f5b6b2ae2df84",
-	"us-west-2":      "ami-0fc52ebf88f40652b",
-	"eu-central-1":   "ami-0171d0a466f6d4ac3",
-	"eu-west-2":      "ami-0aa3396d882c02376",
-	"eu-west-1":      "ami-09925722b0ba31d90",
+	"ap-northeast-1": "ami-0881b60d3da7bd055",
+	"ap-northeast-2": "ami-045eb8957d930ee48",
+	"ap-southeast-1": "ami-0b5cca90cd338e59d",
+	"ap-southeast-2": "ami-0725e68bb3b036074",
+	"us-east-2":      "ami-0d074fb7abacd5219",
+	"us-east-1":      "ami-0abefee50ebdc21f4",
+	"us-west-2":      "ami-0685e5e3534f24db8",
+	"eu-central-1":   "ami-0a7e28c7ffceaaca3",
+	"eu-west-2":      "ami-08b697d6313df6508",
+	"eu-west-1":      "ami-01ff907f77946e9c0",
 }
 
 var defaultAWSClusterConfig = AWSClusterConfig{

--- a/master/internal/provisioner/aws_config.go
+++ b/master/internal/provisioner/aws_config.go
@@ -41,16 +41,16 @@ type AWSClusterConfig struct {
 }
 
 var defaultAWSImageID = map[string]string{
-	"ap-northeast-1": "ami-0881b60d3da7bd055",
-	"ap-northeast-2": "ami-045eb8957d930ee48",
-	"ap-southeast-1": "ami-0b5cca90cd338e59d",
-	"ap-southeast-2": "ami-0725e68bb3b036074",
-	"us-east-2":      "ami-0d074fb7abacd5219",
-	"us-east-1":      "ami-0abefee50ebdc21f4",
-	"us-west-2":      "ami-0685e5e3534f24db8",
-	"eu-central-1":   "ami-0a7e28c7ffceaaca3",
-	"eu-west-2":      "ami-08b697d6313df6508",
-	"eu-west-1":      "ami-01ff907f77946e9c0",
+	"ap-northeast-1": "ami-0a01b67743d465a6e",
+	"ap-northeast-2": "ami-0c74312df78509701",
+	"ap-southeast-1": "ami-0eddf3f941d216f11",
+	"ap-southeast-2": "ami-0c54777eb400a9e68",
+	"us-east-2":      "ami-07318f0e0b3a02b8e",
+	"us-east-1":      "ami-0080b638f1339ccd5",
+	"us-west-2":      "ami-0211fc4b3b0eb5c64",
+	"eu-central-1":   "ami-0474e45bb1a45bbfe",
+	"eu-west-2":      "ami-05d9b28afa79dbda3",
+	"eu-west-1":      "ami-0036879b70fee3339",
 }
 
 var defaultAWSClusterConfig = AWSClusterConfig{

--- a/master/internal/provisioner/gcp_config.go
+++ b/master/internal/provisioner/gcp_config.go
@@ -48,7 +48,7 @@ type GCPClusterConfig struct {
 func DefaultGCPClusterConfig() *GCPClusterConfig {
 	return &GCPClusterConfig{
 		BootDiskSize:        200,
-		BootDiskSourceImage: "projects/determined-ai/global/images/det-environments-4a93d25",
+		BootDiskSourceImage: "projects/determined-ai/global/images/det-environments-5f6f6e1",
 		LabelKey:            "managed-by",
 		InstanceType: gceInstanceType{
 			MachineType: "n1-standard-32",

--- a/master/internal/provisioner/gcp_config.go
+++ b/master/internal/provisioner/gcp_config.go
@@ -48,7 +48,7 @@ type GCPClusterConfig struct {
 func DefaultGCPClusterConfig() *GCPClusterConfig {
 	return &GCPClusterConfig{
 		BootDiskSize:        200,
-		BootDiskSourceImage: "projects/determined-ai/global/images/det-environments-5f6f6e1",
+		BootDiskSourceImage: "projects/determined-ai/global/images/det-environments-067db2b",
 		LabelKey:            "managed-by",
 		InstanceType: gceInstanceType{
 			MachineType: "n1-standard-32",

--- a/master/pkg/model/defaults.go
+++ b/master/pkg/model/defaults.go
@@ -25,8 +25,8 @@ const (
 
 // Default task environment docker image names.
 const (
-	defaultCPUImage = "determinedai/environments:py-3.6.9-pytorch-1.7-tf-1.15-cpu-4a93d25"
-	defaultGPUImage = "determinedai/environments:cuda-10.1-pytorch-1.7-tf-1.15-gpu-4a93d25"
+	defaultCPUImage = "determinedai/environments:py-3.6.9-pytorch-1.7-tf-1.15-cpu-5f6f6e1"
+	defaultGPUImage = "determinedai/environments:cuda-10.1-pytorch-1.7-tf-1.15-gpu-5f6f6e1"
 )
 
 // DefaultExperimentConfig returns a new default experiment config.

--- a/master/pkg/model/defaults.go
+++ b/master/pkg/model/defaults.go
@@ -25,8 +25,8 @@ const (
 
 // Default task environment docker image names.
 const (
-	defaultCPUImage = "determinedai/environments:py-3.6.9-pytorch-1.7-tf-1.15-cpu-5f6f6e1"
-	defaultGPUImage = "determinedai/environments:cuda-10.1-pytorch-1.7-tf-1.15-gpu-5f6f6e1"
+	defaultCPUImage = "determinedai/environments:py-3.6.9-pytorch-1.4-tf-1.15-cpu-067db2b"
+	defaultGPUImage = "determinedai/environments:cuda-10.0-pytorch-1.4-tf-1.15-gpu-067db2b"
 )
 
 // DefaultExperimentConfig returns a new default experiment config.

--- a/tools/scripts/bumpenvs.yaml
+++ b/tools/scripts/bumpenvs.yaml
@@ -1,121 +1,117 @@
 ap_northeast_1_agent_ami:
-  new: ami-0881b60d3da7bd055
-  old: ami-0a01b67743d465a6e
+  new: ami-0a01b67743d465a6e
+  old: ami-07dc1e0617119df61
 ap_northeast_1_bastion_ami:
-  new: ami-07faf6b16c502e9e1
-  old: ami-05855b7c54f91a1ae
+  new: ami-05855b7c54f91a1ae
+  old: ami-0f475b2993ac825b7
 ap_northeast_1_master_ami:
-  new: ami-03ec47ea54612a98d
-  old: ami-0af17d43b1f4ff4ea
+  new: ami-0af17d43b1f4ff4ea
+  old: ami-0b8cd500f483d09ee
 ap_northeast_2_agent_ami:
-  new: ami-045eb8957d930ee48
-  old: ami-0c74312df78509701
+  new: ami-0c74312df78509701
+  old: ami-0a0061c1a3f27fe51
 ap_northeast_2_bastion_ami:
-  new: ami-0ee428c63274f56c1
-  old: ami-063acefae626a1e95
+  new: ami-063acefae626a1e95
+  old: ami-0eebe903cd90a3ddd
 ap_northeast_2_master_ami:
-  new: ami-00813ad98dc81f443
-  old: ami-04e6fcf8cfe3b09ea
+  new: ami-04e6fcf8cfe3b09ea
+  old: ami-07b7be0099924913e
 ap_southeast_1_agent_ami:
-  new: ami-0b5cca90cd338e59d
-  old: ami-0eddf3f941d216f11
+  new: ami-0eddf3f941d216f11
+  old: ami-0994ac61987afed77
 ap_southeast_1_bastion_ami:
-  new: ami-06bcc4026e190b380
-  old: ami-0311dbbdd981577d5
+  new: ami-0311dbbdd981577d5
+  old: ami-03060465516794b47
 ap_southeast_1_master_ami:
-  new: ami-0acac505592775345
-  old: ami-0ba45f1ec3dff60f9
+  new: ami-0ba45f1ec3dff60f9
+  old: ami-028a5cff2f5a0f6c3
 ap_southeast_2_agent_ami:
-  new: ami-0725e68bb3b036074
-  old: ami-0c54777eb400a9e68
+  new: ami-0c54777eb400a9e68
+  old: ami-0183cafc9f2a57aa6
 ap_southeast_2_bastion_ami:
-  new: ami-0b079c5b689b2d44e
-  old: ami-0dea9aeaa95b9751b
+  new: ami-0dea9aeaa95b9751b
+  old: ami-001dbdb48850e6f54
 ap_southeast_2_master_ami:
-  new: ami-07c5b4ba4c9dd25a3
-  old: ami-004d0fb87d10716c6
-cuda_11_hashed:
-  new: determinedai/environments:cuda-11.0-pytorch-1.7-tf-2.4-gpu-5f6f6e1
-cuda_11_versioned:
-  new: determinedai/environments:cuda-11.0-pytorch-1.7-tf-2.4-gpu-0.9.0
+  new: ami-004d0fb87d10716c6
+  old: ami-041e1cc8f4c429789
 eu_central_1_agent_ami:
-  new: ami-0a7e28c7ffceaaca3
-  old: ami-0474e45bb1a45bbfe
+  new: ami-0474e45bb1a45bbfe
+  old: ami-0c39ce440c27b5b97
 eu_central_1_bastion_ami:
-  new: ami-0a4938aa802d3fc05
-  old: ami-08a099fcfc36dff3f
+  new: ami-08a099fcfc36dff3f
+  old: ami-01d4d9d5d6b52b25e
 eu_central_1_master_ami:
-  new: ami-01c74b7d55cbb6e31
-  old: ami-08a1a61694dd1c82f
+  new: ami-08a1a61694dd1c82f
+  old: ami-0d971d62e4d019dcc
 eu_west_1_agent_ami:
-  new: ami-01ff907f77946e9c0
-  old: ami-0036879b70fee3339
+  new: ami-0036879b70fee3339
+  old: ami-085e4c3de4782b626
 eu_west_1_bastion_ami:
-  new: ami-0074515a838fb8787
-  old: ami-00c25f7948e360133
+  new: ami-00c25f7948e360133
+  old: ami-0b85dae948397feb4
 eu_west_1_master_ami:
-  new: ami-06f91a2970093cb47
-  old: ami-0d67111dcacb4a14a
+  new: ami-0d67111dcacb4a14a
+  old: ami-09b9e380df60300c8
 eu_west_2_agent_ami:
-  new: ami-08b697d6313df6508
-  old: ami-05d9b28afa79dbda3
+  new: ami-05d9b28afa79dbda3
+  old: ami-080b10920a3f55fd4
 eu_west_2_bastion_ami:
-  new: ami-0789c35b922fefc1e
-  old: ami-076071bbe3485317c
+  new: ami-076071bbe3485317c
+  old: ami-05e1a611b1e866695
 eu_west_2_master_ami:
-  new: ami-0be58974fa441cb39
-  old: ami-03441ec6f2faa7ddc
+  new: ami-03441ec6f2faa7ddc
+  old: ami-071884cefc7e770ba
 gcp_env:
-  new: det-environments-5f6f6e1
-  old: det-environments-067db2b
+  new: det-environments-067db2b
+  old: det-environments-600cf86
 tf1_cpu_hashed:
-  new: determinedai/environments:py-3.6.9-pytorch-1.7-tf-1.15-cpu-5f6f6e1
-  old: determinedai/environments:py-3.6.9-pytorch-1.4-tf-1.15-cpu-067db2b
+  new: determinedai/environments:py-3.6.9-pytorch-1.4-tf-1.15-cpu-067db2b
+  old: determinedai/environments:py-3.6.9-pytorch-1.4-tf-1.15-cpu-600cf86
 tf1_cpu_versioned:
-  new: determinedai/environments:py-3.6.9-pytorch-1.7-tf-1.15-cpu-0.9.0
-  old: determinedai/environments:py-3.6.9-pytorch-1.4-tf-1.15-cpu-0.8.0
+  new: determinedai/environments:py-3.6.9-pytorch-1.4-tf-1.15-cpu-0.8.0
+  old: determinedai/environments:py-3.6.9-pytorch-1.4-tf-1.15-cpu-0.7.0
 tf1_gpu_hashed:
-  new: determinedai/environments:cuda-10.1-pytorch-1.7-tf-1.15-gpu-5f6f6e1
-  old: determinedai/environments:cuda-10.0-pytorch-1.4-tf-1.15-gpu-067db2b
+  new: determinedai/environments:cuda-10.0-pytorch-1.4-tf-1.15-gpu-067db2b
+  old: determinedai/environments:cuda-10.0-pytorch-1.4-tf-1.15-gpu-600cf86
 tf1_gpu_versioned:
-  new: determinedai/environments:cuda-10.1-pytorch-1.7-tf-1.15-gpu-0.9.0
-  old: determinedai/environments:cuda-10.0-pytorch-1.4-tf-1.15-gpu-0.8.0
+  new: determinedai/environments:cuda-10.0-pytorch-1.4-tf-1.15-gpu-0.8.0
+  old: determinedai/environments:cuda-10.0-pytorch-1.4-tf-1.15-gpu-0.7.0
 tf2_cpu_hashed:
-  new: determinedai/environments:py-3.6.9-pytorch-1.7-tf-2.4-cpu-5f6f6e1
-  old: determinedai/environments:py-3.6.9-pytorch-1.4-tf-2.2-cpu-067db2b
+  new: determinedai/environments:py-3.6.9-pytorch-1.4-tf-2.2-cpu-067db2b
+  old: determinedai/environments:py-3.6.9-pytorch-1.4-tf-2.2-cpu-600cf86
 tf2_cpu_versioned:
-  new: determinedai/environments:py-3.6.9-pytorch-1.7-tf-2.4-cpu-0.9.0
-  old: determinedai/environments:py-3.6.9-pytorch-1.4-tf-2.2-cpu-0.8.0
+  new: determinedai/environments:py-3.6.9-pytorch-1.4-tf-2.2-cpu-0.8.0
+  old: determinedai/environments:py-3.6.9-pytorch-1.4-tf-2.2-cpu-0.7.0
 tf2_gpu_hashed:
-  new: determinedai/environments:cuda-10.1-pytorch-1.7-tf-2.4-gpu-5f6f6e1
-  old: determinedai/environments:cuda-10.1-pytorch-1.4-tf-2.2-gpu-067db2b
+  new: determinedai/environments:cuda-10.1-pytorch-1.4-tf-2.2-gpu-067db2b
+  old: determinedai/environments:cuda-10.1-pytorch-1.4-tf-2.2-gpu-600cf86
 tf2_gpu_versioned:
-  new: determinedai/environments:cuda-10.1-pytorch-1.7-tf-2.4-gpu-0.9.0
-  old: determinedai/environments:cuda-10.1-pytorch-1.4-tf-2.2-gpu-0.8.0
+  new: determinedai/environments:cuda-10.1-pytorch-1.4-tf-2.2-gpu-0.8.0
+  old: determinedai/environments:cuda-10.1-pytorch-1.4-tf-2.2-gpu-0.7.0
 us_east_1_agent_ami:
-  new: ami-0abefee50ebdc21f4
-  old: ami-0080b638f1339ccd5
+  new: ami-0080b638f1339ccd5
+  old: ami-06130d042431bcc18
 us_east_1_bastion_ami:
-  new: ami-007e8beb808004fdc
-  old: ami-053adf54573f777cf
+  new: ami-053adf54573f777cf
+  old: ami-08b277333b9511393
 us_east_1_master_ami:
-  new: ami-0f593aebffc0070e1
-  old: ami-099e921e69356cf89
+  new: ami-099e921e69356cf89
+  old: ami-0739f8cdb239fe9ae
 us_east_2_agent_ami:
-  new: ami-0d074fb7abacd5219
-  old: ami-07318f0e0b3a02b8e
+  new: ami-07318f0e0b3a02b8e
+  old: ami-044bdeb2ce74f4549
 us_east_2_bastion_ami:
-  new: ami-05c386ebc03ca06da
-  old: ami-0b9487791bf873774
+  new: ami-0b9487791bf873774
+  old: ami-0b9e40918b9df07e4
 us_east_2_master_ami:
-  new: ami-096cdd827d38ca4d8
-  old: ami-05edbb8e25e281608
+  new: ami-05edbb8e25e281608
+  old: ami-0ebc8f6f580a04647
 us_west_2_agent_ami:
-  new: ami-0685e5e3534f24db8
-  old: ami-0211fc4b3b0eb5c64
+  new: ami-0211fc4b3b0eb5c64
+  old: ami-07b649652a40e4208
 us_west_2_bastion_ami:
-  new: ami-0b5f687730c825c7d
-  old: ami-0cc158853935719b7
+  new: ami-0cc158853935719b7
+  old: ami-08f6a7b1c02ad4ece
 us_west_2_master_ami:
-  new: ami-04e9aec1ab665f323
-  old: ami-00f1e37d20049f858
+  new: ami-00f1e37d20049f858
+  old: ami-008b09448b998a562

--- a/tools/scripts/bumpenvs.yaml
+++ b/tools/scripts/bumpenvs.yaml
@@ -1,122 +1,121 @@
 ap_northeast_1_agent_ami:
-  new: ami-055e84fd91eebace4
-  old: ami-0881b60d3da7bd055
+  new: ami-0881b60d3da7bd055
+  old: ami-0a01b67743d465a6e
 ap_northeast_1_bastion_ami:
-  new: ami-09dac16017637391f
-  old: ami-07faf6b16c502e9e1
+  new: ami-07faf6b16c502e9e1
+  old: ami-05855b7c54f91a1ae
 ap_northeast_1_master_ami:
   new: ami-03ec47ea54612a98d
   old: ami-0af17d43b1f4ff4ea
 ap_northeast_2_agent_ami:
-  new: ami-098f3d295106b7e70
-  old: ami-045eb8957d930ee48
+  new: ami-045eb8957d930ee48
+  old: ami-0c74312df78509701
 ap_northeast_2_bastion_ami:
-  new: ami-0b50511490117e709
-  old: ami-0ee428c63274f56c1
+  new: ami-0ee428c63274f56c1
+  old: ami-063acefae626a1e95
 ap_northeast_2_master_ami:
   new: ami-00813ad98dc81f443
   old: ami-04e6fcf8cfe3b09ea
 ap_southeast_1_agent_ami:
-  new: ami-00de94d5b3e68b0da
-  old: ami-0b5cca90cd338e59d
+  new: ami-0b5cca90cd338e59d
+  old: ami-0eddf3f941d216f11
 ap_southeast_1_bastion_ami:
-  new: ami-0ae3e6717dc99c62b
-  old: ami-06bcc4026e190b380
+  new: ami-06bcc4026e190b380
+  old: ami-0311dbbdd981577d5
 ap_southeast_1_master_ami:
   new: ami-0acac505592775345
   old: ami-0ba45f1ec3dff60f9
 ap_southeast_2_agent_ami:
-  new: ami-0af10fa7e8454d943
-  old: ami-0725e68bb3b036074
+  new: ami-0725e68bb3b036074
+  old: ami-0c54777eb400a9e68
 ap_southeast_2_bastion_ami:
-  new: ami-080b87fdc6d5ca853
-  old: ami-0b079c5b689b2d44e
+  new: ami-0b079c5b689b2d44e
+  old: ami-0dea9aeaa95b9751b
 ap_southeast_2_master_ami:
   new: ami-07c5b4ba4c9dd25a3
   old: ami-004d0fb87d10716c6
 cuda_11_hashed:
-  new: determinedai/environments:cuda-11.0-pytorch-1.7-tf-2.4-gpu-4a93d25
-  old: determinedai/environments:cuda-11.0-pytorch-1.7-tf-2.4-gpu-5f6f6e1
+  new: determinedai/environments:cuda-11.0-pytorch-1.7-tf-2.4-gpu-5f6f6e1
 cuda_11_versioned:
   new: determinedai/environments:cuda-11.0-pytorch-1.7-tf-2.4-gpu-0.9.0
 eu_central_1_agent_ami:
-  new: ami-0171d0a466f6d4ac3
-  old: ami-0a7e28c7ffceaaca3
+  new: ami-0a7e28c7ffceaaca3
+  old: ami-0474e45bb1a45bbfe
 eu_central_1_bastion_ami:
-  new: ami-0093cac2bf998a669
-  old: ami-0a4938aa802d3fc05
+  new: ami-0a4938aa802d3fc05
+  old: ami-08a099fcfc36dff3f
 eu_central_1_master_ami:
   new: ami-01c74b7d55cbb6e31
   old: ami-08a1a61694dd1c82f
 eu_west_1_agent_ami:
-  new: ami-09925722b0ba31d90
-  old: ami-01ff907f77946e9c0
+  new: ami-01ff907f77946e9c0
+  old: ami-0036879b70fee3339
 eu_west_1_bastion_ami:
-  new: ami-0e5657f6d3c3ea350
-  old: ami-0074515a838fb8787
+  new: ami-0074515a838fb8787
+  old: ami-00c25f7948e360133
 eu_west_1_master_ami:
   new: ami-06f91a2970093cb47
   old: ami-0d67111dcacb4a14a
 eu_west_2_agent_ami:
-  new: ami-0aa3396d882c02376
-  old: ami-08b697d6313df6508
+  new: ami-08b697d6313df6508
+  old: ami-05d9b28afa79dbda3
 eu_west_2_bastion_ami:
-  new: ami-09b984029e6b0326b
-  old: ami-0789c35b922fefc1e
+  new: ami-0789c35b922fefc1e
+  old: ami-076071bbe3485317c
 eu_west_2_master_ami:
   new: ami-0be58974fa441cb39
   old: ami-03441ec6f2faa7ddc
 gcp_env:
-  new: det-environments-4a93d25
-  old: det-environments-5f6f6e1
+  new: det-environments-5f6f6e1
+  old: det-environments-067db2b
 tf1_cpu_hashed:
-  new: determinedai/environments:py-3.6.9-pytorch-1.7-tf-1.15-cpu-4a93d25
-  old: determinedai/environments:py-3.6.9-pytorch-1.7-tf-1.15-cpu-5f6f6e1
+  new: determinedai/environments:py-3.6.9-pytorch-1.7-tf-1.15-cpu-5f6f6e1
+  old: determinedai/environments:py-3.6.9-pytorch-1.4-tf-1.15-cpu-067db2b
 tf1_cpu_versioned:
   new: determinedai/environments:py-3.6.9-pytorch-1.7-tf-1.15-cpu-0.9.0
   old: determinedai/environments:py-3.6.9-pytorch-1.4-tf-1.15-cpu-0.8.0
 tf1_gpu_hashed:
-  new: determinedai/environments:cuda-10.1-pytorch-1.7-tf-1.15-gpu-4a93d25
-  old: determinedai/environments:cuda-10.1-pytorch-1.7-tf-1.15-gpu-5f6f6e1
+  new: determinedai/environments:cuda-10.1-pytorch-1.7-tf-1.15-gpu-5f6f6e1
+  old: determinedai/environments:cuda-10.0-pytorch-1.4-tf-1.15-gpu-067db2b
 tf1_gpu_versioned:
   new: determinedai/environments:cuda-10.1-pytorch-1.7-tf-1.15-gpu-0.9.0
   old: determinedai/environments:cuda-10.0-pytorch-1.4-tf-1.15-gpu-0.8.0
 tf2_cpu_hashed:
-  new: determinedai/environments:py-3.6.9-pytorch-1.7-tf-2.4-cpu-4a93d25
-  old: determinedai/environments:py-3.6.9-pytorch-1.7-tf-2.4-cpu-5f6f6e1
+  new: determinedai/environments:py-3.6.9-pytorch-1.7-tf-2.4-cpu-5f6f6e1
+  old: determinedai/environments:py-3.6.9-pytorch-1.4-tf-2.2-cpu-067db2b
 tf2_cpu_versioned:
   new: determinedai/environments:py-3.6.9-pytorch-1.7-tf-2.4-cpu-0.9.0
   old: determinedai/environments:py-3.6.9-pytorch-1.4-tf-2.2-cpu-0.8.0
 tf2_gpu_hashed:
-  new: determinedai/environments:cuda-10.1-pytorch-1.7-tf-2.4-gpu-4a93d25
-  old: determinedai/environments:cuda-10.1-pytorch-1.7-tf-2.4-gpu-5f6f6e1
+  new: determinedai/environments:cuda-10.1-pytorch-1.7-tf-2.4-gpu-5f6f6e1
+  old: determinedai/environments:cuda-10.1-pytorch-1.4-tf-2.2-gpu-067db2b
 tf2_gpu_versioned:
   new: determinedai/environments:cuda-10.1-pytorch-1.7-tf-2.4-gpu-0.9.0
   old: determinedai/environments:cuda-10.1-pytorch-1.4-tf-2.2-gpu-0.8.0
 us_east_1_agent_ami:
-  new: ami-0281f5b6b2ae2df84
-  old: ami-0abefee50ebdc21f4
+  new: ami-0abefee50ebdc21f4
+  old: ami-0080b638f1339ccd5
 us_east_1_bastion_ami:
-  new: ami-02fe94dee086c0c37
-  old: ami-007e8beb808004fdc
+  new: ami-007e8beb808004fdc
+  old: ami-053adf54573f777cf
 us_east_1_master_ami:
   new: ami-0f593aebffc0070e1
   old: ami-099e921e69356cf89
 us_east_2_agent_ami:
-  new: ami-02a26ef27a997c7de
-  old: ami-0d074fb7abacd5219
+  new: ami-0d074fb7abacd5219
+  old: ami-07318f0e0b3a02b8e
 us_east_2_bastion_ami:
-  new: ami-02aa7f3de34db391a
-  old: ami-05c386ebc03ca06da
+  new: ami-05c386ebc03ca06da
+  old: ami-0b9487791bf873774
 us_east_2_master_ami:
   new: ami-096cdd827d38ca4d8
   old: ami-05edbb8e25e281608
 us_west_2_agent_ami:
-  new: ami-0fc52ebf88f40652b
-  old: ami-0685e5e3534f24db8
+  new: ami-0685e5e3534f24db8
+  old: ami-0211fc4b3b0eb5c64
 us_west_2_bastion_ami:
-  new: ami-025102f49d03bec05
-  old: ami-0b5f687730c825c7d
+  new: ami-0b5f687730c825c7d
+  old: ami-0cc158853935719b7
 us_west_2_master_ami:
   new: ami-04e9aec1ab665f323
   old: ami-00f1e37d20049f858

--- a/tools/scripts/update-bumpenvs-yaml.py
+++ b/tools/scripts/update-bumpenvs-yaml.py
@@ -39,7 +39,6 @@ EXPECT_JOBS = {
     "build-and-publish-docker-tf1-cpu",
     "build-and-publish-docker-tf1-gpu",
     "build-and-publish-docker-tf2-gpu",
-    "build-and-publish-docker-cuda-11",
 }
 
 EXPECT_ARTIFACTS = {
@@ -48,7 +47,6 @@ EXPECT_ARTIFACTS = {
     "publish-tf1-cpu",
     "publish-tf1-gpu",
     "publish-tf2-gpu",
-    "publish-cuda-11",
 }
 
 
@@ -199,17 +197,12 @@ if __name__ == "__main__":
         **yaml.safe_load(artifacts["publish-tf1-gpu"]),
         **yaml.safe_load(artifacts["publish-tf2-cpu"]),
         **yaml.safe_load(artifacts["publish-tf2-gpu"]),
-        **yaml.safe_load(artifacts["publish-cuda-11"]),
         **parse_packer_log(artifacts["packer-log"]),
     }
 
     saw_change = False
     for image_type, new_tag in new_tags.items():
-        if image_type not in conf:
-            conf[image_type] = {"new": new_tag}
-            saw_change = True
-        else:
-            saw_change |= update_tag_for_image_type(conf[image_type], new_tag)
+        saw_change |= update_tag_for_image_type(conf[image_type], new_tag)
 
     if not saw_change:
         print(

--- a/webui/react/src/fixtures/responses/experiment-details/non-scalar-metrics-4078.json
+++ b/webui/react/src/fixtures/responses/experiment-details/non-scalar-metrics-4078.json
@@ -31,8 +31,8 @@
     "description": "Fork of Fork of mnist_tp_to_estimator_const",
     "environment": {
       "image": {
-        "cpu": "determinedai/environments:py-3.6.9-pytorch-1.7-tf-1.15-cpu-5f6f6e1",
-        "gpu": "determinedai/environments:cuda-10.1-pytorch-1.7-tf-1.15-gpu-5f6f6e1"
+        "cpu": "determinedai/environments:py-3.6.9-pytorch-1.4-tf-1.15-cpu-067db2b",
+        "gpu": "determinedai/environments:cuda-10.0-pytorch-1.4-tf-1.15-gpu-067db2b"
       },
       "ports": null,
       "pod_spec": null,

--- a/webui/react/src/fixtures/responses/experiment-details/non-scalar-metrics-4078.json
+++ b/webui/react/src/fixtures/responses/experiment-details/non-scalar-metrics-4078.json
@@ -31,8 +31,8 @@
     "description": "Fork of Fork of mnist_tp_to_estimator_const",
     "environment": {
       "image": {
-        "cpu": "determinedai/environments:py-3.6.9-pytorch-1.7-tf-1.15-cpu-4a93d25",
-        "gpu": "determinedai/environments:cuda-10.1-pytorch-1.7-tf-1.15-gpu-4a93d25"
+        "cpu": "determinedai/environments:py-3.6.9-pytorch-1.7-tf-1.15-cpu-5f6f6e1",
+        "gpu": "determinedai/environments:cuda-10.1-pytorch-1.7-tf-1.15-gpu-5f6f6e1"
       },
       "ports": null,
       "pod_spec": null,

--- a/webui/react/src/fixtures/responses/experiment-details/set-a.json
+++ b/webui/react/src/fixtures/responses/experiment-details/set-a.json
@@ -694,8 +694,8 @@
         "environment_variables": {},
         "force_pull_image": false,
         "image": {
-          "cpu": "determinedai/environments:py-3.6.9-pytorch-1.7-tf-1.15-cpu-5f6f6e1",
-          "gpu": "determinedai/environments:cuda-10.1-pytorch-1.7-tf-1.15-gpu-5f6f6e1"
+          "cpu": "determinedai/environments:py-3.6.9-pytorch-1.4-tf-1.15-cpu-067db2b",
+          "gpu": "determinedai/environments:cuda-10.0-pytorch-1.4-tf-1.15-gpu-067db2b"
         },
         "pod_spec": null,
         "ports": null
@@ -838,8 +838,8 @@
         "environment_variables": {},
         "force_pull_image": false,
         "image": {
-          "cpu": "determinedai/environments:py-3.6.9-pytorch-1.7-tf-1.15-cpu-5f6f6e1",
-          "gpu": "determinedai/environments:cuda-10.1-pytorch-1.7-tf-1.15-gpu-5f6f6e1"
+          "cpu": "determinedai/environments:py-3.6.9-pytorch-1.4-tf-1.15-cpu-067db2b",
+          "gpu": "determinedai/environments:cuda-10.0-pytorch-1.4-tf-1.15-gpu-067db2b"
         },
         "pod_spec": {
           "metadata": {
@@ -2596,8 +2596,8 @@
       "description": "noop_adaptive",
       "environment": {
         "image": {
-          "cpu": "determinedai/environments:py-3.6.9-pytorch-1.7-tf-1.15-cpu-5f6f6e1",
-          "gpu": "determinedai/environments:cuda-10.1-pytorch-1.7-tf-1.15-gpu-5f6f6e1"
+          "cpu": "determinedai/environments:py-3.6.9-pytorch-1.4-tf-1.15-cpu-067db2b",
+          "gpu": "determinedai/environments:cuda-10.0-pytorch-1.4-tf-1.15-gpu-067db2b"
         },
         "ports": null,
         "pod_spec": null,

--- a/webui/react/src/fixtures/responses/experiment-details/set-a.json
+++ b/webui/react/src/fixtures/responses/experiment-details/set-a.json
@@ -694,8 +694,8 @@
         "environment_variables": {},
         "force_pull_image": false,
         "image": {
-          "cpu": "determinedai/environments:py-3.6.9-pytorch-1.7-tf-1.15-cpu-4a93d25",
-          "gpu": "determinedai/environments:cuda-10.1-pytorch-1.7-tf-1.15-gpu-4a93d25"
+          "cpu": "determinedai/environments:py-3.6.9-pytorch-1.7-tf-1.15-cpu-5f6f6e1",
+          "gpu": "determinedai/environments:cuda-10.1-pytorch-1.7-tf-1.15-gpu-5f6f6e1"
         },
         "pod_spec": null,
         "ports": null
@@ -838,8 +838,8 @@
         "environment_variables": {},
         "force_pull_image": false,
         "image": {
-          "cpu": "determinedai/environments:py-3.6.9-pytorch-1.7-tf-1.15-cpu-4a93d25",
-          "gpu": "determinedai/environments:cuda-10.1-pytorch-1.7-tf-1.15-gpu-4a93d25"
+          "cpu": "determinedai/environments:py-3.6.9-pytorch-1.7-tf-1.15-cpu-5f6f6e1",
+          "gpu": "determinedai/environments:cuda-10.1-pytorch-1.7-tf-1.15-gpu-5f6f6e1"
         },
         "pod_spec": {
           "metadata": {
@@ -2596,8 +2596,8 @@
       "description": "noop_adaptive",
       "environment": {
         "image": {
-          "cpu": "determinedai/environments:py-3.6.9-pytorch-1.7-tf-1.15-cpu-4a93d25",
-          "gpu": "determinedai/environments:cuda-10.1-pytorch-1.7-tf-1.15-gpu-4a93d25"
+          "cpu": "determinedai/environments:py-3.6.9-pytorch-1.7-tf-1.15-cpu-5f6f6e1",
+          "gpu": "determinedai/environments:cuda-10.1-pytorch-1.7-tf-1.15-gpu-5f6f6e1"
         },
         "ports": null,
         "pod_spec": null,

--- a/webui/react/src/fixtures/responses/trial-details/old-trial-config-noop-adaptive.json
+++ b/webui/react/src/fixtures/responses/trial-details/old-trial-config-noop-adaptive.json
@@ -29,8 +29,8 @@
   "description": "noop_adaptive",
   "environment": {
     "image": {
-      "cpu": "determinedai/environments:py-3.6.9-pytorch-1.7-tf-1.15-cpu-4a93d25",
-      "gpu": "determinedai/environments:cuda-10.1-pytorch-1.7-tf-1.15-gpu-4a93d25"
+      "cpu": "determinedai/environments:py-3.6.9-pytorch-1.7-tf-1.15-cpu-5f6f6e1",
+      "gpu": "determinedai/environments:cuda-10.1-pytorch-1.7-tf-1.15-gpu-5f6f6e1"
     },
     "ports": null,
     "force_pull_image": false,

--- a/webui/react/src/fixtures/responses/trial-details/old-trial-config-noop-adaptive.json
+++ b/webui/react/src/fixtures/responses/trial-details/old-trial-config-noop-adaptive.json
@@ -29,8 +29,8 @@
   "description": "noop_adaptive",
   "environment": {
     "image": {
-      "cpu": "determinedai/environments:py-3.6.9-pytorch-1.7-tf-1.15-cpu-5f6f6e1",
-      "gpu": "determinedai/environments:cuda-10.1-pytorch-1.7-tf-1.15-gpu-5f6f6e1"
+      "cpu": "determinedai/environments:py-3.6.9-pytorch-1.4-tf-1.15-cpu-067db2b",
+      "gpu": "determinedai/environments:cuda-10.0-pytorch-1.4-tf-1.15-gpu-067db2b"
     },
     "ports": null,
     "force_pull_image": false,


### PR DESCRIPTION
## Description

Seeing some performance regressions in automated tests that need more investigation before making this versions the default.

## Test Plan

Ran the nightly tests and confirmed all of the significant (reliably >10%) performance regressions that started a week ago get reversed by this change.
