### PR TITLE
feat: expose primitives for pytorch dataloaders

### DIFF
--- a/docs/reference/api/api-pytorch-samplers.txt
+++ b/docs/reference/api/api-pytorch-samplers.txt
@@ -1,0 +1,8 @@
+#############################
+ determined.pytorch.samplers
+#############################
+
+.. _pytorch-samplers:
+
+.. automodule:: determined.pytorch.samplers
+   :members:

--- a/docs/reference/api/api-pytorch.txt
+++ b/docs/reference/api/api-pytorch.txt
@@ -33,7 +33,7 @@ Loading data into ``PyTorchTrial`` models is done by defining two functions,
 :meth:`~determined.pytorch.PyTorchTrial.build_training_data_loader` and
 :meth:`~determined.pytorch.PyTorchTrial.build_validation_data_loader`. These functions should each
 return an instance of :class:`determined.pytorch.DataLoader`. ``determined.pytorch.DataLoader``
-behaves the same as ``torch.utils.data.DataLoader`` and is a drop-in replacement.
+behaves the same as ``torch.utils.data.DataLoader`` and is a drop-in replacement in most cases.
 
 Each ``DataLoader`` is allowed to return batches with arbitrary structures of the following types,
 which will be fed directly to the :meth:`~determined.pytorch.PyTorchTrial.train_batch` and

--- a/docs/release-notes/1937-iterable-datasets.txt
+++ b/docs/release-notes/1937-iterable-datasets.txt
@@ -1,0 +1,14 @@
+:orphan:
+
+**New Features**
+
+-  Support Custom PyTorch DataLoaders with PyTorchTrial
+
+   You may call :meth:`context.experimental.disable_dataset_reproducibility_checks()
+   <determined.pytorch._experimental.PyTorchExperimentalContext.disable_dataset_reproducibility_checks>`
+   in your ``PyTorchTrial.__init__()`` method, which will allow you to return arbitrary
+   ``DataLoader`` objects from ``build_training_data_loader`` and ``build_validation_data_loader``.
+   This is desirable when your data loader is not compatible with Determined's
+   ``det.pytorch.DataLoader``. The usual dataset reproducibility that ``det.pytorch.DataLoader`` is
+   still possible, but will be your responsibility. If desired, you may find the ``Sampler`` classes
+   in :mod:`determined.pytorch.samplers` to be helpful.

--- a/harness/determined/_train_context.py
+++ b/harness/determined/_train_context.py
@@ -176,6 +176,9 @@ class _TrainContext(metaclass=abc.ABCMeta):
         )
         self._stop_requested = stop_requested
 
+    def get_initial_batch(self) -> int:
+        return self.env.initial_workload.total_batches_processed
+
 
 class TrialContext(_TrainContext):
     """

--- a/harness/determined/pytorch/__init__.py
+++ b/harness/determined/pytorch/__init__.py
@@ -1,8 +1,6 @@
+from determined.pytorch import samplers
 from determined.pytorch._data import (
     DataLoader,
-    DistributedBatchSampler,
-    RepeatBatchSampler,
-    SkipBatchSampler,
     TorchData,
     _Data,
     adapt_batch_sampler,

--- a/harness/determined/pytorch/_data.py
+++ b/harness/determined/pytorch/_data.py
@@ -3,7 +3,6 @@ from typing import (
     Any,
     Callable,
     Dict,
-    Generator,
     Iterator,
     List,
     Optional,
@@ -17,12 +16,7 @@ from typing import (
 
 import numpy as np
 import torch
-
-# from torch.utils.data.dataloader import _InfiniteConstantSampler
-from determined.common.check import check_gt, check_lt
-
-# TODO(DET-1524): Uncomment inports.
-from torch.utils.data import (  # _DatasetKind,; IterableDataset,
+from torch.utils.data import (
     BatchSampler,
     Dataset,
     RandomSampler,
@@ -31,6 +25,7 @@ from torch.utils.data import (  # _DatasetKind,; IterableDataset,
     _utils,
 )
 
+from determined.pytorch import samplers
 
 _Array = Union[np.ndarray, torch.Tensor]
 _Data = Union[Dict[str, _Array], Sequence[_Array], _Array]
@@ -101,6 +96,26 @@ class DataLoader:
         timeout: float = 0,
         worker_init_fn: _worker_init_fn_t = None,
     ):
+        # Don't allow IterableDatasets in our DataLoader.
+        if isinstance(dataset, torch.utils.data.IterableDataset):
+            raise ValueError(
+                "IterableDatasets are not supported through det.pytorch.DataLoader().  Read about "
+                "the difference between IterableDatasets and MapDatasets at: "
+                "pytorch.org/docs/stable/data. "
+                "You can use an IterableDataset in Determined, but you will be responsible for "
+                "shuffling, sharding, repeating, and skipping to ensure reproducibility and "
+                "correctness of training.  See the in-depth guide at: "
+                "docs.determined.ai/latest/reference/api/pytorch-samplers.html"
+            )
+
+        # Don't allow this rare combination of inputs that we would puke on later.
+        if batch_sampler is None and batch_size is None:
+            raise ValueError(
+                "The case of batch_sampler=None and batch_size=None is not supported through "
+                "det.pytorch.DataLoader(). For customizing your data loader beyond what is "
+                "supported by det.pytorch.DataLoader, see the in-depth guide at: "
+                "docs.determined.ai/latest/reference/api/pytorch-samplers.html"
+            )
 
         # BEGIN VENDORED CODE FROM PYTORCH
         # https://github.com/pytorch/pytorch/blob/v1.3.1/torch/utils/data/dataloader.py#L120
@@ -118,12 +133,6 @@ class DataLoader:
         self.pin_memory = pin_memory
         self.timeout = timeout
         self.worker_init_fn = worker_init_fn
-
-        # TODO(DET-1524): uncomment this as we do not currently support IterableDataset
-        # if isinstance(dataset, IterableDataset):
-        #     raise AssertionError("`IterableDataset`s are not currently supported.")
-        # else:
-        #     self._dataset_kind = _DatasetKind.Map
 
         if sampler is not None and shuffle:
             raise ValueError("sampler option is mutually exclusive with " "shuffle")
@@ -148,15 +157,6 @@ class DataLoader:
                 )
 
         if sampler is None:  # give default samplers
-            # TODO(DET-1524): uncomment this logic and delete the one after it.
-            # if self._dataset_kind == _DatasetKind.Iterable:
-            #    # See NOTE [ Custom Samplers and IterableDataset ]
-            #    sampler = _InfiniteConstantSampler()
-            # else:  # map-style
-            #    if shuffle:
-            #        sampler = RandomSampler(dataset)
-            #    else:
-            #        sampler = SequentialSampler(dataset)
             if shuffle:
                 sampler = RandomSampler(dataset)  # type: ignore
             else:
@@ -211,9 +211,6 @@ class DataLoader:
 
     def __len__(self) -> int:
         """Compatibiliy with the real DataLoader when using a PyTorchTrial outside of Determined."""
-        # TODO(DET-1524): uncomment this as we do not currently support IterableDataset
-        # if isinstance(dataset, IterableDataset):
-        #     return len(self.dataset)
         batch_sampler = cast(BatchSampler, self.batch_sampler)
         return len(batch_sampler)
 
@@ -231,116 +228,19 @@ def adapt_batch_sampler(
     sharding for distributed training.
     """
     if repeat:
-        batch_sampler = RepeatBatchSampler(batch_sampler)
+        batch_sampler = samplers.RepeatBatchSampler(batch_sampler)
 
     if num_replicas > 1:
-        batch_sampler = DistributedBatchSampler(batch_sampler, num_replicas, rank)
+        batch_sampler = samplers.DistributedBatchSampler(batch_sampler, num_replicas, rank)
 
     # SkipBatchSampler is used when we are continuing training. SkipBatchSampler must be applied
     # after DistributedBatchSampler, since the number of batches to skip is based on how many
     # global batches should be skipped, which corresponds with how many batches are emitted by the
     # DistributedBatchSampler, not the initial BatchSampler.
     if skip > 0:
-        batch_sampler = SkipBatchSampler(batch_sampler, skip, same_length=repeat)
+        batch_sampler = samplers.SkipBatchSampler(batch_sampler, skip)
 
     return batch_sampler
-
-
-class RepeatBatchSampler(torch.utils.data.BatchSampler):
-    """
-    RepeatBatchSampler yields infinite batches indices by repeatedly iterating
-    through the batches of another BatchSampler. __len__ is just the length of
-    the underlying BatchSampler.
-    """
-
-    def __init__(self, batch_sampler: torch.utils.data.BatchSampler) -> None:
-        self.batch_sampler = batch_sampler
-
-    def __len__(self) -> int:
-        return len(self.batch_sampler)
-
-    def __iter__(self) -> Generator:
-        while True:
-            yield from self.batch_sampler
-
-
-class DistributedBatchSampler(torch.utils.data.BatchSampler):
-    """
-    DistributedBatchSampler is meant to wrap any BatchSampler to pass every nth
-    batch to a worker, using the worker's rank as the initial offset.
-
-    DistributedBatchSampler is different than the PyTorch built-in
-    torch.utils.data.distributed.DistributedSampler, because that
-    DistributedSampler expects to bbe called before the BatchSampler, and
-    additionally the DistributedSampler is meant to be a stand-alone sampler.
-
-    DistributedBatchSampler has the potential gotcha that when wrapping a
-    non-repeating BatchSampler, if the length of the BatchSampler is not
-    divisible by the number of replicas the length of the resulting
-    DistributedBatchSampler will differ based on the rank. In that case, the
-    divergent paths of multiple workers could cause problems during training.
-    PyTorchTrial always uses RepeatBatchSampler during training, PyTorchTrial
-    does not require that the workers stay in-step during validation, so this
-    potential gotcha is not a problem in Determined.
-    """
-
-    def __init__(
-        self, batch_sampler: torch.utils.data.BatchSampler, num_replicas: int, rank: int
-    ) -> None:
-        check_gt(rank, -1, "rank must be non-negative")
-        check_gt(num_replicas, 0, "num_replicas must be positive")
-        check_lt(rank, num_replicas, "rank must be less than num_replicas")
-
-        self.batch_sampler = batch_sampler
-        self.num_replicas = num_replicas
-        self.rank = rank
-
-    def __len__(self) -> int:
-        full_global_batches = len(self.batch_sampler) // self.num_replicas
-        worker_gets_partial_batch = int(len(self.batch_sampler) % self.num_replicas > self.rank)
-        return full_global_batches + worker_gets_partial_batch
-
-    def __iter__(self) -> Generator:
-        if self.num_replicas == 1:
-            yield from self.batch_sampler
-        else:
-            for i, batch in enumerate(self.batch_sampler):
-                if i % self.num_replicas == self.rank:
-                    yield batch
-
-
-class SkipBatchSampler(torch.utils.data.BatchSampler):
-    """
-    SkipBatchSampler skips some batches from an underlying BatchSampler, and
-    yield the rest. By default, the length of the new BatchSampler is reported
-    to be the length of the base BatchSampler minus the amount skipped.
-
-    In some cases, such as if the base BatchSampler is known to contain a
-    RepeatBatchSampler, it makes more sense to report the full length of the
-    base BatchSampler. This behavior is controlled using the same_length
-    parameter.
-    """
-
-    def __init__(
-        self, batch_sampler: torch.utils.data.BatchSampler, skip: int, same_length: bool = False
-    ) -> None:
-        self.batch_sampler = batch_sampler
-        self.skip = skip
-        self.length = len(batch_sampler)
-        if not same_length:
-            self.length -= self.skip
-
-    def __len__(self) -> int:
-        return self.length
-
-    def __iter__(self) -> Generator:
-        iterator = iter(self.batch_sampler)
-        for _ in range(self.skip):
-            try:
-                next(iterator)
-            except StopIteration:
-                return
-        yield from iterator
 
 
 def data_length(data: _Data) -> int:

--- a/harness/determined/pytorch/samplers.py
+++ b/harness/determined/pytorch/samplers.py
@@ -1,0 +1,368 @@
+"""
+Guidelines for Reproducible Datasets
+====================================
+
+.. note::
+
+   Normally, using ``det.pytorch.DataLoader`` is required and handles all of the below details
+   without any special effort on your part (see :ref:`pytorch-data-loading`).  When
+   ``det.pytorch.DataLoader()`` is not suitable (especially in the case of ``IterableDatasets``),
+   you may disable this requirement by calling
+   :meth:`context.experimental.disable_dataset_reproducibility_checks()
+   <determined.pytorch.PyTorchExperimentalContext.disable_dataset_reproducibility_checks>`
+   in your Trial's ``__init__()`` method.  Then you may choose to follow the below guidelines for
+   ensuring dataset reproducibility on your own.
+
+Achieving a reproducible dataset that is able to pause and continue (sometimes called "incremental
+training") is easy if you follow a few rules.
+
+- Even if you are going to ultimately return an IterableDataset, it is best to use PyTorch's Sampler
+  class as the basis for choosing the order of records.  Operations on Samplers are quick and cheap,
+  while operations on data afterwards are expensive.  For more details, see the discussion of random
+  vs sequential access `here <https://yogadl.readthedocs.io>`_.  If you don't have a custom sampler,
+  start with a simple one:
+
+  .. code::python
+
+     sampler = torch.utils.data.SequentialSampler(my_dataset)
+
+- **Shuffle first**: Always use a reproducible shuffle when you shuffle.  Determined provides two
+  shuffling samplers for this purpose; the ``ReproducibleShuffleSampler`` for operating on records
+  and the ``ReproducibleShuffleBatchSampler`` for operating on batches.  You should prefer to
+  shuffle on records (use the ``ReproducibleShuffleSampler``) whenever possible, to achieve the
+  highest-quality shuffle.
+
+- **Repeat when training**: In Determined, you always repeat your training dataset and you
+  never repeat your validation datasets.  Determined provides a RepeatSampler and a
+  RepeatBatchSampler to wrap your sampler or batch_sampler.  For your training dataset, make sure
+  that you always repeat AFTER you shuffle, otherwise your shuffle will hang.
+
+- **Always shard, and not before a repeat**: Use Determined's DistributedSampler or
+  DistributedBatchSampler to provide a unique shard of data to each worker based on your sampler or
+  batch_sampler.  It is best to always shard your data, and even when you are not doing distributed
+  training, because in non-distributed-training settings, the sharding is nearly zero-cost, and it
+  makes distributed training seamless if you ever want to use it in the future.
+
+  It is generally important to shard after you repeat, unless you can guarantee that each shard
+  of the dataset will have the same length.  Otherwise, differences between the epoch boundaries for
+  each worker can grow over time, especially on small datasets.  If you shard after you repeat, you
+  can change the number of workers arbitrarily without issue.
+
+- **Skip when training, and always last**: In Determined, training datasets should always be able to
+  start from an arbitrary point in the dataset.  This allows for advanced hyperparameter searches
+  and responsive preemption for training on spot instances in the cloud.  The easiest way to do
+  this, which is also very efficient, is to apply a skip to the sampler.
+
+  Determined provides a SkipBatchSampler that you can apply to your batch_sampler for this purpose.
+  There is also a SkipSampler that you can apply to your sampler, but you should prefer to skip on
+  batches unless you are confident that your dataset always yields identical size batches, where the
+  number of records to skip can be reliably calculatd from the number of batches already trained.
+
+  Always skip AFTER your repeat, so that the skip only happens once, and not on every epoch.
+
+  Always skip AFTER your shuffle, to preserve the reproducibility of the shuffle.
+
+Here is some example code that follows each of these rules that you can use as a starting point if
+you find that the built-in context.DataLoader() does not support your use case.
+
+  .. code::python
+
+    def make_batch_sampler(
+        sampler_or_dataset,
+        mode,  # mode="training" or mode="validation"
+        shuffle_seed,
+        num_workers,
+        rank,
+        batch_size,
+        skip,
+    ):
+        if isinstance(sampler_or_dataset, torch.utils.data.Sampler):
+            sampler = sampler_or_dataset
+        else:
+            # Create a SequentialSampler if we started with a Dataset.
+            sampler = torch.utils.data.SequentialSampler(sampler_or_dataset)
+
+        if mode == "training":
+            # Shuffle first.
+            sampler = samplers.ReproducibleShuffleSampler(sampler, shuffle_seed)
+
+            # Repeat when training.
+            sampler = samplers.RepeatSampler(sampler)
+
+        # Always shard, and not before a repeat.
+        sampler = samplers.DistributedSampler(sampler, num_workers=num_workers, rank=rank)
+
+        # Batch before skip, because Determined counts batches, not records.
+        batch_sampler = torch.utils.data.BatchSampler(sampler, batch_size, drop_last=False)
+
+        if mode == "training":
+            # Skip when training, and always last.
+            batch_sampler = samplers.SkipBatchSampler(batch_sampler, skip)
+
+        return batch_sampler
+
+
+    class MyPyTorchTrial(det.pytorch.PyTorchTrial):
+        def __init__(self, context):
+            context.experimental.disable_dataset_reproducibility_checks()
+
+        def build_training_data_loader(self):
+            my_dataset = ...
+
+            batch_sampler = make_batch_sampler(
+                dataset=my_dataset,
+                mode="training",
+                seed=self.context.get_trial_seed(),
+                num_workers=self.context.distributed.get_size(),
+                rank=self.distributed.get_rank(),
+                batch_size=self.context.get_per_slot_batch_size(),
+                skip=self.context.get_initial_batch(),
+            )
+
+            return torch.utils.data.DataLoader(my_dataset, batch_sampler=batch_sampler)
+"""
+from typing import Iterator
+
+import numpy as np
+import torch
+
+from determined.common import check
+
+
+class RepeatSampler(torch.utils.data.Sampler):
+    """
+    RepeatSampler yields infinite batches indices by repeatedly iterating
+    through the batches of another Sampler. __len__ is just the length of
+    the underlying Sampler.
+    """
+
+    def __init__(self, sampler: torch.utils.data.Sampler) -> None:
+        self._sampler = sampler
+
+    def __len__(self) -> int:
+        return len(self._sampler)  # type: ignore
+
+    def __iter__(self) -> Iterator:
+        while True:
+            yield from self._sampler
+
+
+class RepeatBatchSampler(torch.utils.data.BatchSampler):
+    """
+    RepeatBatchSampler yields infinite batches indices by repeatedly iterating
+    through the batches of another BatchSampler. __len__ is just the length of
+    the underlying BatchSampler.
+    """
+
+    def __init__(self, batch_sampler: torch.utils.data.BatchSampler) -> None:
+        self.batch_sampler = batch_sampler
+
+    def __len__(self) -> int:
+        return len(self.batch_sampler)
+
+    def __iter__(self) -> Iterator:
+        while True:
+            yield from self.batch_sampler
+
+
+class DistributedSampler(torch.utils.data.Sampler):
+    """
+    DistributedSampler will iterate through an underlying sampler and return samples which
+    belong to this shard.
+
+    DistributedSampler is different than the PyTorch built-in torch.utils.data.DistributedSampler
+    because theirs is meant to be a standalone sampler.  Theirs does shuffling and assumes a
+    constant size dataset as an input.  Ours is meant to be used a building block in a chain of
+    samplers, so it accepts a sampler as input that may or may not be constant-size.
+    """
+
+    def __init__(self, sampler: torch.utils.data.Sampler, num_workers: int, rank: int) -> None:
+        self._sampler = sampler
+        self._num_workers = num_workers
+        self._rank = rank
+
+    def __len__(self) -> int:
+        sampler_len = len(self._sampler)  # type: ignore
+        all_workers_get_samples = sampler_len // self._num_workers
+        worker_gets_extra_sample = int(sampler_len % self._num_workers > self._rank)
+        return all_workers_get_samples + worker_gets_extra_sample
+
+    def __iter__(self) -> Iterator:
+        if self._num_workers == 1:
+            yield from self._sampler
+        else:
+            for i, batch in enumerate(self._sampler):
+                if i % self._num_workers == self._rank:
+                    yield batch
+
+
+class DistributedBatchSampler(torch.utils.data.BatchSampler):
+    """
+    DistributedBatchSampler will iterate through an underlying batch sampler and return batches
+    which belong to this shard.
+
+    DistributedBatchSampler is different than the PyTorch built-in
+    torch.utils.data.distributed.DistributedSampler, because that
+    DistributedSampler expects to bbe called before the BatchSampler, and
+    additionally the DistributedSampler is meant to be a stand-alone sampler.
+
+    DistributedBatchSampler has the potential gotcha that when wrapping a
+    non-repeating BatchSampler, if the length of the BatchSampler is not
+    divisible by the number of replicas the length of the resulting
+    DistributedBatchSampler will differ based on the rank. In that case, the
+    divergent paths of multiple workers could cause problems during training.
+    PyTorchTrial always uses RepeatBatchSampler during training, PyTorchTrial
+    does not require that the workers stay in-step during validation, so this
+    potential gotcha is not a problem in Determined.
+    """
+
+    def __init__(
+        self, batch_sampler: torch.utils.data.BatchSampler, num_workers: int, rank: int
+    ) -> None:
+        check.gt(rank, -1, "rank must be non-negative")
+        check.gt(num_workers, 0, "num_workers must be positive")
+        check.lt(rank, num_workers, "rank must be less than num_workers")
+
+        self.batch_sampler = batch_sampler
+        self.num_workers = num_workers
+        self.rank = rank
+
+    def __len__(self) -> int:
+        full_global_batches = len(self.batch_sampler) // self.num_workers
+        worker_gets_partial_batch = int(len(self.batch_sampler) % self.num_workers > self.rank)
+        return full_global_batches + worker_gets_partial_batch
+
+    def __iter__(self) -> Iterator:
+        if self.num_workers == 1:
+            yield from self.batch_sampler
+        else:
+            for i, batch in enumerate(self.batch_sampler):
+                if i % self.num_workers == self.rank:
+                    yield batch
+
+
+class SkipSampler(torch.utils.data.BatchSampler):
+    """
+    SkipSampler skips some records from an underlying Sampler, and yields the rest.
+
+    Always skip before you repeat when you are continuing training, or you will apply the skip on
+    every epoch.
+
+    .. warning::
+
+       When trying to achieve reproducibility after pausing and restarting, you should never prefer
+       this SkipSampler over the SkipBatchSampler, unless you are sure that your dataset will always
+       yield identically sized batches.  This is due to how Determined counts batches trained but
+       does not count records trained.  Reproducibility when skipping records is only possible if
+       the records to skip can be reliably calculated based on batch size and batches trained.
+
+    Because the SkipSampler is only meant to be used on a training dataset (we never checkpoint
+    during evaluation), and because the training dataset should always be repeated before applying
+    the skip (so you only skip once rather than many times), the length reported is always the
+    length of the underlying sampler, regardless of the size of the skip.
+    """
+
+    def __init__(self, sampler: torch.utils.data.BatchSampler, skip: int) -> None:
+        self._sampler = sampler
+        self._skip = skip
+
+    def __len__(self) -> int:
+        return len(self._sampler)
+
+    def __iter__(self) -> Iterator:
+        iterator = iter(self._sampler)
+        for _ in range(self._skip):
+            try:
+                next(iterator)
+            except StopIteration:
+                return
+        yield from iterator
+
+
+class SkipBatchSampler(torch.utils.data.BatchSampler):
+    """
+    SkipBatchSampler skips some batches from an underlying BatchSampler, and yield the rest.
+
+    Always skip before you repeat when you are continuing training, or you will apply the skip on
+    every epoch.
+
+    Because the SkipBatchSampler is only meant to be used on a training dataset (we never
+    checkpoint during evaluation), and because the training dataset should always be repeated
+    before applying the skip (so you only skip once rather than many times), the length reported
+    is always the length of the underlying sampler, regardless of the size of the skip.
+    """
+
+    def __init__(self, batch_sampler: torch.utils.data.BatchSampler, skip: int) -> None:
+        self.batch_sampler = batch_sampler
+        self.skip = skip
+        self.length = len(batch_sampler)
+
+    def __len__(self) -> int:
+        return len(self.batch_sampler)
+
+    def __iter__(self) -> Iterator:
+        iterator = iter(self.batch_sampler)
+        for _ in range(self.skip):
+            try:
+                next(iterator)
+            except StopIteration:
+                return
+        yield from iterator
+
+
+class ReproducibleShuffleSampler(torch.utils.data.Sampler):
+    """
+    ReproducibleShuffleSampler will apply a deterministic shuffle based on a seed.
+
+    .. warning::
+
+       Always shuffle before skipping and before repeating.  Skip-before-shuffle would break
+       the reproducibility of the shuffle, and repeat-before-shuffle would cause the shuffle
+       to hang as it iterates through an infinite sampler.
+    """
+
+    def __init__(self, sampler: torch.utils.data.Sampler, seed: int) -> None:
+        self._sampler = sampler
+        self._rng = np.random.RandomState(seed)
+
+    def __iter__(self) -> Iterator:
+        indices = list(self._sampler)
+        self._rng.shuffle(indices)
+        return iter(indices)
+
+    def __len__(self) -> int:
+        # Check the original sampler in case its length changes every epoch.
+        # TODO: that would likely cause reproducibility issues.
+        return len(self._sampler)  # type: ignore
+
+
+class ReproducibleShuffleBatchSampler(torch.utils.data.Sampler):
+    """
+    ReproducibleShuffleBatchSampler will apply a deterministic shuffle based on a seed.
+
+    .. warning::
+
+       Always shuffle before skipping and before repeating.  Skip-before-shuffle would break
+       the reproducibility of the shuffle, and repeat-before-shuffle would cause the shuffle
+       to hang as it iterates through an infinite sampler.
+
+    .. warning::
+
+       Always prefer ReproducibleShuffleSampler over this class when possible.  The reason is that
+       shuffling at the batch level results in a superior shuffle, where the contents of each
+       batch are varied between epochs, rather than just the order of batches.
+    """
+
+    def __init__(self, batch_sampler: torch.utils.data.BatchSampler, seed: int) -> None:
+        self._batch_sampler = batch_sampler
+        self._rng = np.random.RandomState(seed)
+
+    def __iter__(self) -> Iterator:
+        indices = list(self._batch_sampler)
+        self._rng.shuffle(indices)
+        return iter(indices)
+
+    def __len__(self) -> int:
+        # Check the original batch_sampler in case its length changes every epoch.
+        # TODO: that would likely cause reproducibility issues.
+        return len(self._batch_sampler)

--- a/harness/tests/experiment/fixtures/pytorch_onevar_model.py
+++ b/harness/tests/experiment/fixtures/pytorch_onevar_model.py
@@ -40,6 +40,7 @@ import torch
 import yaml
 
 from determined import experimental, pytorch
+from determined.pytorch import samplers
 
 
 class OnesDataset(torch.utils.data.Dataset):
@@ -110,6 +111,10 @@ class OneVarTrial(pytorch.PyTorchTrial):
         self.cls_reducer = context.wrap_reducer(TriangleLabelSum(), name="cls_reducer")
         self.fn_reducer = context.wrap_reducer(triangle_label_sum, name="fn_reducer")
 
+        self.hparams = self.context.get_hparams()
+        if self.hparams.get("disable_dataset_reproducibility_checks"):
+            self.context.experimental.disable_dataset_reproducibility_checks()
+
     def train_batch(
         self, batch: pytorch.TorchData, epoch_idx: int, batch_idx: int
     ) -> Dict[str, torch.Tensor]:
@@ -167,11 +172,50 @@ class OneVarTrial(pytorch.PyTorchTrial):
         loss = self.loss_fn(self.model(data), label)
         return {"val_loss": loss}
 
-    def build_training_data_loader(self) -> pytorch.DataLoader:
-        return pytorch.DataLoader(OnesDataset(), batch_size=self.context.get_per_slot_batch_size())
+    def build_training_data_loader(self) -> torch.utils.data.DataLoader:
+        if self.hparams["dataloader_type"] == "determined":
+            return pytorch.DataLoader(
+                OnesDataset(), batch_size=self.context.get_per_slot_batch_size()
+            )
+        elif self.hparams["dataloader_type"] == "torch":
+            dataset = OnesDataset()
 
-    def build_validation_data_loader(self) -> pytorch.DataLoader:
-        return pytorch.DataLoader(OnesDataset(), batch_size=self.context.get_per_slot_batch_size())
+            seed = self.context.get_trial_seed()
+            num_workers = self.context.distributed.get_size()
+            rank = self.context.distributed.get_rank()
+            batch_size = self.context.get_per_slot_batch_size()
+            skip_batches = self.context.get_initial_batch()
+
+            sampler = torch.utils.data.SequentialSampler(dataset)
+            sampler = samplers.ReproducibleShuffleSampler(sampler, seed)
+            sampler = samplers.RepeatSampler(sampler)
+            sampler = samplers.DistributedSampler(sampler, num_workers=num_workers, rank=rank)
+            batch_sampler = torch.utils.data.BatchSampler(sampler, batch_size, drop_last=False)
+            batch_sampler = samplers.SkipBatchSampler(batch_sampler, skip_batches)
+
+            return torch.utils.data.DataLoader(dataset, batch_sampler=batch_sampler)
+        else:
+            raise ValueError(f"unknown dataloader_type: {self.hparams['dataloader_type']}")
+
+    def build_validation_data_loader(self) -> torch.utils.data.DataLoader:
+        if self.hparams["dataloader_type"] == "determined":
+            return pytorch.DataLoader(
+                OnesDataset(), batch_size=self.context.get_per_slot_batch_size()
+            )
+        elif self.hparams["dataloader_type"] == "torch":
+            dataset = OnesDataset()
+
+            num_workers = self.context.distributed.get_size()
+            rank = self.context.distributed.get_rank()
+            batch_size = self.context.get_per_slot_batch_size()
+
+            sampler = torch.utils.data.SequentialSampler(dataset)
+            sampler = samplers.DistributedSampler(sampler, num_workers=num_workers, rank=rank)
+            batch_sampler = torch.utils.data.BatchSampler(sampler, batch_size, drop_last=False)
+
+            return torch.utils.data.DataLoader(dataset, batch_sampler=batch_sampler)
+        else:
+            raise ValueError(f"unknown dataloader_type: {self.hparams['dataloader_type']}")
 
 
 if __name__ == "__main__":

--- a/harness/tests/experiment/fixtures/pytorch_onevar_model.py
+++ b/harness/tests/experiment/fixtures/pytorch_onevar_model.py
@@ -224,6 +224,7 @@ if __name__ == "__main__":
     description: test-native-api-local-test-mode
     hyperparameters:
       global_batch_size: 32
+      dataloader_type: determined
     scheduling_unit: 1
     searcher:
       name: single

--- a/harness/tests/experiment/pytorch/test_pytorch_data.py
+++ b/harness/tests/experiment/pytorch/test_pytorch_data.py
@@ -23,36 +23,78 @@ def make_data_loader() -> torch.utils.data.DataLoader:
     return torch.utils.data.DataLoader(make_dataset(), batch_size=1)
 
 
+def test_skip_sampler():
+    skip = 2
+    sampler = torch.utils.data.SequentialSampler(range(15))
+    skip_sampler = samplers.SkipSampler(sampler, skip)
+
+    assert len(skip_sampler) == 15
+
+    for samp, skip_samp in zip(range(skip, 15), iter(skip_sampler)):
+        assert samp == skip_samp
+
+
 def test_skip_batch_sampler():
     skip = 2
-    sampler = torch.utils.data.BatchSampler(
-        torch.utils.data.SequentialSampler(range(15)), batch_size=2, drop_last=False
-    )
-    skip_sampler = samplers.SkipBatchSampler(sampler, skip)
+    sampler = torch.utils.data.SequentialSampler(range(15))
+    batch_sampler = torch.utils.data.BatchSampler(sampler, batch_size=2, drop_last=False)
+    skip_batch_sampler = samplers.SkipBatchSampler(batch_sampler, skip)
 
-    assert len(skip_sampler) == 8
+    assert len(skip_batch_sampler) == 8
 
-    iterator = iter(sampler)
+    iterator = iter(batch_sampler)
 
     # Advance the iterator by skip batches.
     for _ in range(skip):
         next(iterator)
 
-    for samp, skip_samp in zip(iterator, iter(skip_sampler)):
+    for samp, skip_samp in zip(iterator, iter(skip_batch_sampler)):
         assert samp == skip_samp
 
 
-def test_repeat_batch_sampler():
-    sampler = torch.utils.data.BatchSampler(torch.utils.data.SequentialSampler(range(10)), 3, False)
-    repeat_sampler = samplers.RepeatBatchSampler(sampler)
+def test_repeat_sampler():
+    sampler = torch.utils.data.SequentialSampler(range(10))
+    repeat_sampler = samplers.RepeatSampler(sampler)
 
-    assert len(repeat_sampler) == 4
+    assert len(repeat_sampler) == 10
 
     one_pass = list(sampler)
 
     iterator = iter(repeat_sampler)
     for _ in range(3):
         assert one_pass == [next(iterator) for _ in range(len(one_pass))]
+
+
+def test_repeat_batch_sampler():
+    sampler = torch.utils.data.SequentialSampler(range(10))
+    batch_sampler = torch.utils.data.BatchSampler(sampler, 3, False)
+    repeat_batch_sampler = samplers.RepeatBatchSampler(batch_sampler)
+
+    assert len(repeat_batch_sampler) == 4
+
+    one_pass = list(batch_sampler)
+
+    iterator = iter(repeat_batch_sampler)
+    for _ in range(3):
+        assert one_pass == [next(iterator) for _ in range(len(one_pass))]
+
+
+def test_distributed_sampler():
+    sampler = torch.utils.data.SequentialSampler(range(19))
+
+    num_replicas = 4
+
+    expected_samples = []
+    expected_samples.append([0, 4, 8, 12, 16])
+    expected_samples.append([1, 5, 9, 13, 17])
+    expected_samples.append([2, 6, 10, 14, 18])
+    expected_samples.append([3, 7, 11, 15])
+
+    for rank in range(num_replicas):
+        dist_sampler = samplers.DistributedSampler(sampler, 4, rank)
+        samples = list(dist_sampler)
+        assert len(dist_sampler) == len(samples)
+        assert samples == expected_samples[rank]
 
 
 def test_distributed_batch_sampler():
@@ -73,6 +115,23 @@ def test_distributed_batch_sampler():
         samples = list(dist_sampler)
         assert len(dist_sampler) == len(samples)
         assert samples == expected_samples[rank]
+
+
+def test_reproducible_shuffle_sampler():
+    sampler = torch.utils.data.SequentialSampler(range(5))
+    sampler = samplers.ReproducibleShuffleSampler(sampler, 777)
+
+    assert list(sampler) == [0, 4, 1, 2, 3]
+    assert list(sampler) == [2, 0, 1, 3, 4]
+
+
+def test_reproducible_shuffle_batch_sampler():
+    sampler = torch.utils.data.SequentialSampler(range(10))
+    batch_sampler = torch.utils.data.BatchSampler(sampler, batch_size=2, drop_last=False)
+    shuffle_batch_sampler = samplers.ReproducibleShuffleSampler(batch_sampler, 777)
+
+    assert list(shuffle_batch_sampler) == [[0, 1], [8, 9], [2, 3], [4, 5], [6, 7]]
+    assert list(shuffle_batch_sampler) == [[4, 5], [0, 1], [2, 3], [6, 7], [8, 9]]
 
 
 def test_pytorch_adapt_batch_sampler():

--- a/harness/tests/experiment/test_local.py
+++ b/harness/tests/experiment/test_local.py
@@ -24,7 +24,7 @@ def test_test_one_batch() -> None:
 
 
 def test_pytorch_from_config() -> None:
-    config = {"hyperparameters": {"global_batch_size": 4}}
+    config = {"hyperparameters": {"global_batch_size": 4, "dataloader_type": "determined"}}
     context = pytorch.PyTorchTrialContext.from_config(config)
     trial = pytorch_onevar_model.OneVarTrial(context)
 


### PR DESCRIPTION
## Description

My first idea for handling iterable datasets was  #1928, but I think that PR offered tooling to the user at the wrong layer; lower-layer than what the happy-path users wanted, and higher-layer than what the advanced users needed.

This PR is another idea, which offers high-level tooling for the happy-path users, and clearly documented primitives for building data loaders that are "determined-compliant" in other cases.

Here are some meeting notes from the #ml-ag meeting on 2 Nov 2020 (abriged):

> Aaron: Accept arbitrary Pytorch DataLoaders to reduce initial porting overhead. Could also upstream some of this.
> - AH: We wanted to do it for at least IterableDatasets, but we should do this for all data loaders (while explaining caveats). Doesn’t require YogaDL necessarily (but may have caveats to behaviors). 1. It’s up to users to make sure that each GPU gets a unique data sample. 2. Pause/restart for HP search.
> - KP: question: they’ll need to do some work to get the GPU sampling to work? What does this look like from a user perspective?
>   - RB: maybe the context should offer a special sampler… (editor's note: #1928 was a failed attempt at this)
>   - AH: the other problem is the start/restart logic. We shouldn’t even try to fix that if they’re using a PT data loader
>   - RB: you’d fix that in the sampler anyway
>   - AH: our easy 1-line config change is for a DDL. if you don’t want to use it, there are these disclaimers, will take more on your side. Kind of what we do for TF dataset right now, restart logic is just not correct unless you use YogaDL but we don’t force that
> - VM: devil’s in the details, what do we do if we get a custom data loader that doesn’t work w/ Determined?
>   - AH: no, we don’t fail for TF datasets right now etc.
>   - RB: the answer is some people want it to fail, some people don’t. Like compiler warnings. We kind of need a feature like this. Document correct errors, which conditions, and allow users to request strictness depending on their use case
>   - AH: i think this is useful, but i also don’t think we should block on this
>   - VM: we need to let people know what they’re buying into; 1. If a user hasn’t read the docs and say BYODL, there’s no warning that there’s a science-compromising issue

As may be clear from the above discourse, the issue here has less to do with difficulty of implementation and more to do with correctness and being able to give assurance to the user about correctness.  That gets harder as we move away from plugin-api paradigms and into sprinkle api paradigms.  However, no users have ever complained about the pytorch-flexible-primitives API, where we made a similar transition from rigid, guaranteed-correct APIs to a "remember to make these calls" style of API.

**The conclusion that this PR takes is: "make the happy-path easy and clearly document how to make the advanced path correct"**

This "clear documentation" is at the top of `harness/determined/pytorch/samplers.py` right now. 

## Example usage:

This example uses the sampler primitives directly, as an academic exercise.

```python
class MNistTrial(PyTorchTrial):
    def build_training_data_loader(self) -> torch.utils.data.DataLoader:
        train_data = data.get_dataset(self.download_directory, train=True)

        mode = "I like pain"

        if mode == "I like easy":
            return det.pytorch.DataLoader(train_data)

        if mode == "I like pain":

            from determined.pytorch import samplers

            seed = self.context.get_trial_seed()
            rank = self.context.distributed.get_rank()
            size = self.context.distributed.get_size()
            skip = self.context.get_initial_batch()
            batch_size = self.context.get_per_slot_batch_size()

            # Shuffle-repeat-shard-batch-skip, just like Determined told me to.
            sampler = torch.utils.data.SequentialSampler(train_data)
            sampler = samplers.ReproducibleShuffleSampler(sampler, seed)
            sampler = samplers.RepeatSampler(sampler)
            sampler = samplers.DistributedSampler(sampler, num_workers=size, rank=rank)
            batch_sampler = torch.utils.data.BatchSampler(sampler, batch_size, drop_last=False)
            batch_sampler = samplers.SkipBatchSampler(batch_sampler, skip)

            return torch.utils.data.DataLoader(train_data, batch_sampler=batch_sampler)
```

## A more realistic advanced use case:

This is how @katport could have ported the detectron2 model dataloaders, with their fancy IterableDataset-based speedups.

See the original function [here](https://github.com/katport/determined/blob/DET-3158/examples/experimental/trial/detectron2/detectron2_files/data.py#L407)

```python
def build_detection_train_loader(cfg, batch_size, mapper=None):
    """
    A data loader is created by the following steps:
    1. Use the dataset names in config to query :class:`DatasetCatalog`, and obtain a list of dicts.
    2. Coordinate a random shuffle order shared among all processes (all GPUs)
    3. Each process spawn another few workers to process the dicts. Each worker will:
       * Map each metadata dict into another format to be consumed by the model.
       * Batch them by simply putting dicts into a list.
    The batched ``list[mapped_dict]`` is what this dataloader will yield.
    Args:
        cfg (CfgNode): the config
        mapper (callable): a callable which takes a sample (dict) from dataset and
            returns the format to be consumed by the model.
            By default it will be `DatasetMapper(cfg, True)`.
    Returns:
        an infinite iterator of training data
    """
    dataset_dicts = get_detection_dataset_dicts(
        cfg.DATASETS.TRAIN,
        filter_empty=cfg.DATALOADER.FILTER_EMPTY_ANNOTATIONS,
        min_keypoints=cfg.MODEL.ROI_KEYPOINT_HEAD.MIN_KEYPOINTS_PER_IMAGE
        if cfg.MODEL.KEYPOINT_ON
        else 0,
        proposal_files=cfg.DATASETS.PROPOSAL_FILES_TRAIN if cfg.MODEL.LOAD_PROPOSALS else None,
    )
    dataset = DatasetFromList(dataset_dicts, copy=False)

    if mapper is None:
        mapper = DatasetMapper(cfg, True)
    dataset = MapDataset(dataset, mapper)

    sampler_name = cfg.DATALOADER.SAMPLER_TRAIN
    print ('sampler_name: ', sampler_name)
    logger = logging.getLogger(__name__)
    logger.info("Using training sampler {}".format(sampler_name))
    # TODO avoid if-else?
    if sampler_name == "TrainingSampler":
        sampler = TrainingSampler(len(dataset))
    elif sampler_name == "RepeatFactorTrainingSampler":
        repeat_factors = RepeatFactorTrainingSampler.repeat_factors_from_category_frequency(
            dataset_dicts, cfg.DATALOADER.REPEAT_THRESHOLD
        )
        sampler = RepeatFactorTrainingSampler(repeat_factors)
    else:
        raise ValueError("Unknown training sampler: {}".format(sampler_name))

################################
# Use the new sampler primitives

    # We know:
    #  - the shuffle is handled by TrainingSampler
    #  - the repeat is handled by TrainingSampler
    #  - we still need sharding (detectron2 only shards for torch-native dtrain)
    #  - we still need skipping to support for continuing training
    #
    # We assume:
    #  - reproducibility is not required; it is enough to train on fresh data
    #    when we continue from a checkpoint.  It would be nearly impossible
    #    to repopulate the buckets of the AspectRatioGroupedDataset in a
    #    reproducible way.
    from determined.pytorch import samplers

    context = ... # You need to get this object here somehow

    # Shard before skip:
    rank = context.distributed.get_rank()
    size = context.distributed.get_size()
    sampler = samplers.DistributedSampler(sampler, num_workers=size, rank=rank)

    # Skip at the record level, since all batches are the same size in training
    batch_size = context.get_per_slot_batch_size()
    initial_batch = context.get_initial_batch()
    skip_records = batch_size * initial_batch
    sampler = det.pytorch.samplers.SkipSampler(sampler, skip=skip_records)

##############################

    return build_batch_data_loader(
        dataset,
        sampler,
        cfg.SOLVER.IMS_PER_BATCH,
        aspect_ratio_grouping=cfg.DATALOADER.ASPECT_RATIO_GROUPING,
        num_workers=cfg.DATALOADER.NUM_WORKERS,
        batch_size=batch_size
    )
```