### PR TITLE
ci: deploy NGC images as part of release [DET-4910]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
   slack: circleci/slack@3.4.2
   gke: circleci/gcp-gke@1.1.0
   kubernetes: circleci/kubernetes@0.11.0
-  helm: circleci/helm@1.1.2
+  helm: circleci/helm@1.2.0
   gcloud: circleci/gcp-cli@2.1.0
   queue: eddiewebb/queue@volatile
 
@@ -108,8 +108,20 @@ commands:
             - run: docker pull determinedai/environments:py-3.6.9-pytorch-1.4-tf-2.2-cpu-067db2b
 
   login-docker:
+    parameters:
+      repository:
+        type: string
+        default: ""
+      username:
+        type: string
+      password:
+        type: string
     steps:
-      - run: echo "${DOCKER_PASS}" | docker login --username ${DOCKER_USER} --password-stdin
+      - run: echo "<<parameters.password>>" | docker login <<parameters.repository>> -u "<<parameters.username>>" --password-stdin
+
+  login-helm:
+    steps:
+      - run: helm repo add determined https://helm.ngc.nvidia.com/isv-ngc-partner/determined --username=$NGC_API_USERNAME --password=$NGC_API_KEY
 
   install-protoc:
     steps:
@@ -761,11 +773,28 @@ commands:
 
 
 jobs:
+  build-helm:
+    docker:
+      - image: determinedai/cimg-base:stable
+    steps:
+      - checkout
+      - helm/install-helm-client
+      - attach_workspace:
+          at: .
+      - run: make -C helm build
+      - persist_to_workspace:
+          root: .
+          paths:
+            - helm/build
+      - store_artifacts:
+          path: helm/build
+
   build-docs:
     docker:
       - image: determinedai/cimg-base:stable
     steps:
       - checkout
+      - helm/install-helm-client
       - setup-python-venv:
           determined-common: true
           determined-cli: true
@@ -782,7 +811,6 @@ jobs:
           root: .
           paths:
             - examples/build
-            - helm/build
             - cli/dist
             - common/dist
             - harness/dist
@@ -838,12 +866,14 @@ jobs:
       - checkout
       - attach_workspace:
           at: .
-      - go-get-deps
       - setup_remote_docker:
           version: 19.03.12
+      - login-docker:
+          username: ${DOCKER_USER}
+          password: ${DOCKER_PASS}
+      - go-get-deps
       - run: make -C proto build
       - run: make package
-      - login-docker
       - run: make -C master publish-dev
       - run: make -C agent publish-dev
 
@@ -857,12 +887,18 @@ jobs:
       - checkout
       - attach_workspace:
           at: .
-      - go-get-deps
       - setup_remote_docker:
           version: 19.03.12
+      - login-docker:
+          username: ${DOCKER_USER}
+          password: ${DOCKER_PASS}
+      - login-docker:
+          repository: nvcr.io
+          username: ${NGC_API_USERNAME}
+          password: ${NGC_API_KEY}
+      - go-get-deps
       - run: make -C proto build
       - run: make package
-      - login-docker
       - run: make -C master publish
       - run: make -C agent publish
 
@@ -876,13 +912,31 @@ jobs:
       - checkout
       - attach_workspace:
           at: .
-      - go-get-deps
       - setup_remote_docker:
           version: 19.03.12
-      - login-docker
+      - login-docker:
+          username: ${DOCKER_USER}
+          password: ${DOCKER_PASS}
+      - login-docker:
+          repository: nvcr.io
+          username: ${NGC_API_USERNAME}
+          password: ${NGC_API_KEY}
+      - go-get-deps
       - run: make -C proto build
       - run: make -C master release
       - run: make -C agent release
+
+  publish-helm:
+    docker:
+      - image: determinedai/cimg-base:stable
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - helm/install-helm-client
+      - run: helm plugin install https://github.com/chartmuseum/helm-push.git
+      - login-helm
+      - run: make -C helm release
 
   publish-python-package:
     parameters:
@@ -1606,6 +1660,7 @@ workflows:
   test-e2e:
     jobs:
       - build-proto
+      - build-helm
       - build-and-package-ts-sdk:
           requires:
             - build-proto
@@ -1621,6 +1676,7 @@ workflows:
             - build-and-package-ts-sdk
       - build-docs:
           requires:
+            - build-helm
             - build-proto
       - build-go
       - package-and-push-system-local:
@@ -1959,6 +2015,8 @@ workflows:
 
   release:
     jobs:
+      - build-helm:
+          filters: *release-and-rc-filters
       - build-proto:
           filters: *release-and-rc-filters
       - build-and-package-ts-sdk:
@@ -1974,6 +2032,7 @@ workflows:
           context: determined-production
           filters: *release-and-rc-filters
           requires:
+            - build-helm
             - build-proto
 
       - publish-python-package:
@@ -2002,6 +2061,12 @@ workflows:
             - build-docs
           context: determined-production
           filters: *release-filters
+
+      - publish-helm:
+          requires:
+            - build-helm
+          context: determined-production
+          filters: *release-and-rc-filters
 
       - upload-try-now-template:
           context: determined-production

--- a/agent/.goreleaser.yml
+++ b/agent/.goreleaser.yml
@@ -51,6 +51,9 @@ dockers:
       - "determinedai/{{.ProjectName}}:{{.FullCommit}}"
       - "determinedai/determined-dev:{{.ProjectName}}-{{.ShortCommit}}"
       - "determinedai/determined-dev:{{.ProjectName}}-{{.FullCommit}}"
+      - "nvcr.io/isv-ngc-partner/determined/{{.ProjectName}}:{{.Env.VERSION}}"
+      - "nvcr.io/isv-ngc-partner/determined/{{.ProjectName}}:{{.ShortCommit}}"
+      - "nvcr.io/isv-ngc-partner/determined/{{.ProjectName}}:{{.FullCommit}}"
     extra_files:
       - packaging/entrypoint.sh
       - packaging/LICENSE

--- a/docs/faq.txt
+++ b/docs/faq.txt
@@ -70,10 +70,10 @@ Please see :ref:`useful-kubectl-commands` for more debugging tips.
 When installing Determined on Kubernetes, I get an ``ImagePullBackOff`` error
 =============================================================================
 
-You are trying to install a non-released version of Determined. Please
-see the documentation on how to configure which :ref:`version of
-Determined <configure-determined-kubernetes-version>` to install on
-Kubernetes.
+You may be trying to install a non-released version of Determined or a
+version in a private registry without the right secret. Please see the
+documentation on how to configure which :ref:`version of Determined
+<configure-determined-kubernetes-version>` to install on Kubernetes.
 
 *************************
  Packages and Containers

--- a/docs/how-to/installation/kubernetes.txt
+++ b/docs/how-to/installation/kubernetes.txt
@@ -19,9 +19,16 @@ the following prerequisites are satisfied:
 
 -  The Kubernetes cluster should be running Kubernetes >= 1.15, with GPU
    support enabled.
+
 -  You should have access to the cluster via `kubectl
    <https://kubernetes.io/docs/tasks/tools/install-kubectl/>`_.
+
 -  `Helm 3 <https://helm.sh/docs/intro/install/>`_ should be installed.
+
+-  If you are using a private image registry or the enterprise edition,
+   you should add a secret using `kubectl create secret
+   <https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/>`_.
+
 -  The nodes in the cluster already have or can pull the
    ``fluent/fluent-bit:1.6`` Docker image from Docker Hub.
 
@@ -71,6 +78,23 @@ be created:
 When installing Determined using Helm, you should first configure some
 aspects of the Determined deployment by editing the ``values.yaml`` and
 ``Chart.yaml`` files in the Helm chart.
+
+Image Registry Configuration
+============================
+
+To configure which image registry of Determined will be installed by the
+Helm chart, users should modify ``imageRegistry`` in ``values.yaml``.
+Users can specify our DockerHub public registry ``determinedai`` or
+specify any private registry that hosts the Determined master image.
+
+Image Pull Secret Configuration
+===============================
+
+To configure which image pull secret will be used by the Helm chart,
+users should modify ``imagePullSecretName`` in ``values.yaml``. Users
+can set it to empty for our DockerHub public registry or specify any
+secret that is configured using `kubectl create secret
+<https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/>`_.
 
 .. _configure-determined-kubernetes-version:
 

--- a/helm/Makefile
+++ b/helm/Makefile
@@ -4,10 +4,16 @@ fmt:
 .PHONY: build
 build: clean
 	mkdir -p build/
-	cp -r charts/determined build/determined-helm-chart
-	tar -C build -czf build/determined-helm-chart.tgz determined-helm-chart
-	rm -rf build/determined-helm-chart
+	helm package --destination build charts/determined
 
 .PHONY: clean
 clean:
 	rm -rf build/
+
+.PHONY: release
+release: export NGC_REPO := https://helm.ngc.nvidia.com/isv-ngc-partner/determined
+release: export NGC_API_USERNAME ?=
+release: export NGC_API_KEY ?=
+release:
+	helm repo add determined $$NGC_REPO --username $$NGC_API_USERNAME --password $$NGC_API_KEY
+	helm push -f build/determined-0.4.0.tgz determined

--- a/helm/charts/determined/Chart.yaml
+++ b/helm/charts/determined/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: determined
 description: A Helm chart for Determined
-version: 0.4.0
+version: "0.4.0"
 icon: https://github.com/determined-ai/determined/blob/master/determined-logo.png?raw=true
 home: https://github.com/determined-ai/determined.git
 
@@ -9,4 +9,4 @@ home: https://github.com/determined-ai/determined.git
 # a non-release version (e.g., X.Y.Z.dev0) you will have to specify an
 # existing official release version (e.g., X.Y.Z) or specify a commit has
 # that has been publicly published (all commits from master).
-appVersion: 0.14.2.dev0
+appVersion: "0.14.2.dev0"

--- a/helm/charts/determined/templates/change-password.yaml
+++ b/helm/charts/determined/templates/change-password.yaml
@@ -22,7 +22,7 @@ spec:
       restartPolicy: OnFailure
       containers:
       - name: change-password
-        image: "determinedai/utility:py-3.7-pw-changer"
+        image: "{{ .Values.imageRegistry }}/utility:py-3.7-pw-changer"
         imagePullPolicy: "Always"
         command: ["python3"]
         args:

--- a/helm/charts/determined/templates/master-deployment.yaml
+++ b/helm/charts/determined/templates/master-deployment.yaml
@@ -23,16 +23,16 @@ spec:
       serviceAccount: determined-master-{{ .Release.Name }}
       containers:
       - name: determined-master-{{ .Release.Name }}
-        {{ $image := "determinedai/determined-master" }}
+        {{ $image := "determined-master" }}
         {{- if .Values.enterpriseEdition -}}
-          {{ $image = "determinedai/determined-ee-master" }}
+          {{- $image = "determined-ee-master" -}}
         {{- end -}}
         {{ $tag := (required "A valid Chart.AppVersion entry required!" .Chart.AppVersion) }}
         {{- /* detVersion is used for CI to override the appVersion. */ -}}
         {{- if .Values.detVersion -}}
           {{ $tag = .Values.detVersion }}
         {{- end -}}
-        image: {{ $image }}:{{ $tag }}
+        image: {{ .Values.imageRegistry }}/{{ $image }}:{{ $tag }}
         imagePullPolicy: "Always"
         volumeMounts:
           - name: master-config
@@ -51,10 +51,10 @@ spec:
             {{- if .Values.masterMemRequest }}
             memory: {{ .Values.masterMemRequest  | quote }}
             {{- end}}
-      {{- if .Values.enterpriseEdition }}
+      {{- if .Values.imagePullSecretName}}
       imagePullSecrets:
-      - name: {{ required "A valid Values.imagePullSecretName entry is required!" .Values.imagePullSecretName | quote}}
-      {{- end }}
+        - name: {{ .Values.imagePullSecretName }}
+      {{- end}}
       volumes:
         - name: master-config
           configMap:

--- a/helm/charts/determined/values.yaml
+++ b/helm/charts/determined/values.yaml
@@ -1,3 +1,13 @@
+# The image registry to use. Defaults to the determinedai repository in DockerHub.
+imageRegistry: determinedai
+
+# Install Determined enterprise edition.
+enterpriseEdition: false
+
+# Should be configured if using the master image in the Determined enterprise edition
+# or private registry.
+imagePullSecretName:
+
 # masterPort configures the port at which the Determined master listens for connections on.
 masterPort: 8080
 
@@ -109,13 +119,6 @@ taskContainerDefaults:
   # If specifying a default image, both GPU and CPU default images must be defined.
   # cpuImage:
   # gpuImage:
-
-# Install Determined enterprise edition.
-enterpriseEdition: false
-
-# Should be configured if using the Determined enterprise edition master. Used to access
-# the master image.
-# imagePullSecretName:
 
 ## Configure whether we collect anonymous information about the usage of Determined.
 telemetry:

--- a/master/.goreleaser.yml
+++ b/master/.goreleaser.yml
@@ -61,6 +61,9 @@ dockers:
       - "determinedai/{{.ProjectName}}:{{.FullCommit}}"
       - "determinedai/determined-dev:{{.ProjectName}}-{{.ShortCommit}}"
       - "determinedai/determined-dev:{{.ProjectName}}-{{.FullCommit}}"
+      - "nvcr.io/isv-ngc-partner/determined/{{.ProjectName}}:{{.Env.VERSION}}"
+      - "nvcr.io/isv-ngc-partner/determined/{{.ProjectName}}:{{.ShortCommit}}"
+      - "nvcr.io/isv-ngc-partner/determined/{{.ProjectName}}:{{.FullCommit}}"
     extra_files:
       - "packaging/master.yaml"
       - "packaging/LICENSE"


### PR DESCRIPTION
## Description

Push docker images to the NGC repo and also push the helm charts.

1. Build the helm charts for all the branches and all the PRs.
2. Push the release docker images to `nvcr.io/isv-ngc-partner/determined`.
3. Push the release and release candidates helm charts to `helm/ngc.nvidia.com/isv-ngc-partner/determined`.

## Test Plan

1. manually run a test release candidate in the CI.
2. check if the NGC repo has the docker image.
3. check if the NGC helm repo has the charts.
4. install the helm chart from the NGC repo into a k8s cluster.

The steps are:
1. Create a k8s cluster and node pool.
2. Create a secret using [kubectl create secret](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/).
3. Modify the ``imageRegistry`` field to ``nvcr.io/isv-ngc-partner/determined`` in ``values.yaml``.
4. Modify the ``imagePullSecretName`` field to your secret name in ``values.yaml``.
5. Install the helm chart using ``helm install <name> helm/charts/determined``.

## Commentary (optional)

N/A

## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
