### PR TITLE
fix: add backwards compatability for logs before 0.13.8

### DIFF
--- a/docs/release-notes/1942-fix-pre-0-13-8-logs.txt
+++ b/docs/release-notes/1942-fix-pre-0-13-8-logs.txt
@@ -1,0 +1,6 @@
+:orphan:
+
+**Bug Fixes**
+
+-  Trial: Fix a bug that prevented trial logs created before 0.13.8 from
+   loading correctly.

--- a/master/internal/db/postgres_trial_logs.go
+++ b/master/internal/db/postgres_trial_logs.go
@@ -36,7 +36,7 @@ SELECT
     END AS message,
     l.agent_id,
     l.container_id,
-	CASE
+    CASE
       WHEN l.timestamp is NOT NULL THEN l.timestamp
       ELSE to_timestamp(
         substring(convert_from(message, 'UTF-8') from '\[([0-9]{4}-[0-9]{2}-[0-9]{2}T.*)\]'),

--- a/master/internal/db/postgres_trial_logs.go
+++ b/master/internal/db/postgres_trial_logs.go
@@ -36,14 +36,20 @@ SELECT
     END AS message,
     l.agent_id,
     l.container_id,
-    l.timestamp,
+	CASE
+      WHEN l.timestamp is NOT NULL THEN l.timestamp
+      ELSE to_timestamp(
+        substring(convert_from(message, 'UTF-8') from '\[([0-9]{4}-[0-9]{2}-[0-9]{2}T.*)\]'),
+        'YYYY-MM-DD hh24:mi:ss'
+      )
+    END as timestamp,
     l.level,
     l.stdtype,
     l.source
 FROM trial_logs l
 WHERE l.trial_id = $1
 %s
-ORDER BY l.timestamp %s OFFSET $2 LIMIT $3
+ORDER BY timestamp %s OFFSET $2 LIMIT $3
 `, fragment, orderByToSQL(order))
 
 	var b []*model.TrialLog

--- a/master/internal/db/postgres_trial_logs.go
+++ b/master/internal/db/postgres_trial_logs.go
@@ -39,7 +39,8 @@ SELECT
     CASE
       WHEN l.timestamp is NOT NULL THEN l.timestamp
       ELSE to_timestamp(
-        substring(convert_from(message, 'UTF-8') from '\[([0-9]{4}-[0-9]{2}-[0-9]{2}T.*)\]'),
+        substring(convert_from(message, 'UTF-8') from
+          '\[([0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z)\]'),
         'YYYY-MM-DD hh24:mi:ss'
       )
     END as timestamp,

--- a/master/internal/db/postgres_trial_logs.go
+++ b/master/internal/db/postgres_trial_logs.go
@@ -36,14 +36,13 @@ SELECT
     END AS message,
     l.agent_id,
     l.container_id,
-    CASE
-      WHEN l.timestamp is NOT NULL THEN l.timestamp
-      ELSE to_timestamp(
+    coalesce(l.timestamp,
+      to_timestamp(
         substring(convert_from(message, 'UTF-8') from
           '\[([0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z)\]'),
         'YYYY-MM-DD hh24:mi:ss'
       )
-    END as timestamp,
+    ) AS timestamp,
     l.level,
     l.stdtype,
     l.source


### PR DESCRIPTION
## Description
This change tweaks the query used to retrieve trial logs to select the timestamp from the old field `public.trial_logs.message` where it doesn't exist for old logs.
<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan
- [x] checkout 0.13.5, run an experiment and peek that `public.trial_logs` is missing the new fields
- [x] checkout this branch, load those logs in the correct order, scroll up/down work as expected
- [x] explain analyze the query, make sure we don't take a huge hit.
- [x] run `select to_timestamp(substring(convert_from(message, 'UTF-8') from '\[([0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z)\]'), 'YYYY-MM-DD hh24:mi:ss') from trial_logs where timestamp is NULL order by trial_id desc;` to test this for every log on latest master.
<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234