### PR TITLE
fix: make trial log timestamp filters backwards compatible 

### DIFF
--- a/master/internal/db/postgres_filters.go
+++ b/master/internal/db/postgres_filters.go
@@ -40,8 +40,8 @@ func filterToSQL(
 	f api.Filter, values []interface{}, paramID int, fieldMap map[string]string,
 ) string {
 	var field string
-	if m, ok := fieldMap[f.Field]; ok {
-		f.Field = m
+	if fm, ok := fieldMap[f.Field]; ok {
+		field = fm
 	} else {
 		field = f.Field
 	}

--- a/master/internal/db/postgres_filters.go
+++ b/master/internal/db/postgres_filters.go
@@ -19,7 +19,9 @@ var validField = regexp.MustCompile(`^[a-zA-Z0-9_]+$`)
 //
 // The user input to the filters should always be contained in api.Filter.Values and
 // never the field. If the field is taken from user input, SQL injection is possible.
-func filtersToSQL(fs []api.Filter, params []interface{}) (string, []interface{}) {
+func filtersToSQL(
+	fs []api.Filter, params []interface{}, fieldMap map[string]string,
+) (string, []interface{}) {
 	paramID := len(params) + 1
 	var fragments []string
 	for _, f := range fs {
@@ -27,14 +29,22 @@ func filtersToSQL(fs []api.Filter, params []interface{}) (string, []interface{})
 			panic(fmt.Sprintf("field in filter %s contains possible SQL injection", f.Field))
 		}
 		filterParams := filterToParams(f)
-		fragments = append(fragments, filterToSQL(f, filterParams, paramID))
+		fragments = append(fragments, filterToSQL(f, filterParams, paramID, fieldMap))
 		params = append(params, filterParams...)
 		paramID += len(filterParams)
 	}
 	return strings.Join(fragments, "\n"), params
 }
 
-func filterToSQL(f api.Filter, values []interface{}, paramID int) string {
+func filterToSQL(
+	f api.Filter, values []interface{}, paramID int, fieldMap map[string]string,
+) string {
+	var field string
+	if m, ok := fieldMap[f.Field]; ok {
+		f.Field = m
+	} else {
+		field = f.Field
+	}
 	switch f.Operation {
 	case api.FilterOperationIn:
 		var fragment strings.Builder
@@ -45,11 +55,11 @@ func filterToSQL(f api.Filter, values []interface{}, paramID int) string {
 		}
 		_, _ = fragment.WriteString(strings.Join(paramFragments, ","))
 		_, _ = fragment.WriteString(")")
-		return fmt.Sprintf(fragment.String(), f.Field)
+		return fmt.Sprintf(fragment.String(), field)
 	case api.FilterOperationGreaterThan:
-		return fmt.Sprintf("AND %s > $%d", f.Field, paramID)
+		return fmt.Sprintf("AND %s > $%d", field, paramID)
 	case api.FilterOperationLessThanEqual:
-		return fmt.Sprintf("AND %s <= $%d", f.Field, paramID)
+		return fmt.Sprintf("AND %s <= $%d", field, paramID)
 	default:
 		panic(fmt.Sprintf("cannot convert operation %d to SQL", f.Operation))
 	}


### PR DESCRIPTION
## Description
This change makes the query to gather trial logs with timestamp filters backwards compatible with logs created before 0.13.8.
<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan
- [x] built 0.13.6 from scratch, ran an experiment with a ton of logs, checked out my branch and built it from scratch and checked and all the logs, start at the bottom and scroll up, start at top and scroll down, everything works.
<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)
Bit of a hack, but it's necessary
<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->




<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234