### PR TITLE
feat: allow retaining CloudWatch log groups of det-deploy clusters

### DIFF
--- a/deploy/determined_deploy/aws/cli.py
+++ b/deploy/determined_deploy/aws/cli.py
@@ -198,6 +198,18 @@ def make_up_subparser(subparsers: argparse._SubParsersAction) -> None:
         type=str,
         help="Docker image for GPU tasks",
     )
+    subparser.add_argument(
+        "--log-group-prefix",
+        type=str,
+        help="prefix for output CloudWatch log group",
+    )
+    subparser.add_argument(
+        "--retain-log-group",
+        action="store_const",
+        const="true",
+        help="whether to retain CloudWatch log group after the stack is deleted"
+        " (only available for the simple template)",
+    )
 
 
 def make_aws_parser(subparsers: argparse._SubParsersAction) -> None:
@@ -314,6 +326,8 @@ def deploy_aws(args: argparse.Namespace) -> None:
         constants.cloudformation.PREEMPTION_ENABLED: args.preemption_enabled,
         constants.cloudformation.CPU_ENV_IMAGE: args.cpu_env_image,
         constants.cloudformation.GPU_ENV_IMAGE: args.gpu_env_image,
+        constants.cloudformation.LOG_GROUP_PREFIX: args.log_group_prefix,
+        constants.cloudformation.RETAIN_LOG_GROUP: args.retain_log_group,
     }
 
     deployment_object = deployment_type_map[args.deployment_type](det_configs)

--- a/deploy/determined_deploy/aws/constants.py
+++ b/deploy/determined_deploy/aws/constants.py
@@ -55,6 +55,8 @@ class cloudformation:
     PREEMPTION_ENABLED = "PreemptionEnabled"
     CPU_ENV_IMAGE = "CpuEnvImage"
     GPU_ENV_IMAGE = "GpuEnvImage"
+    LOG_GROUP_PREFIX = "LogGroupPrefix"
+    RETAIN_LOG_GROUP = "RetainLogGroup"
 
 
 class misc:

--- a/deploy/determined_deploy/aws/deployment_types/secure.py
+++ b/deploy/determined_deploy/aws/deployment_types/secure.py
@@ -41,6 +41,7 @@ class Secure(base.DeterminedDeployment):
         constants.cloudformation.SPOT_MAX_PRICE,
         constants.cloudformation.CPU_ENV_IMAGE,
         constants.cloudformation.GPU_ENV_IMAGE,
+        constants.cloudformation.LOG_GROUP_PREFIX,
     ]
 
     def deploy(self) -> None:

--- a/deploy/determined_deploy/aws/deployment_types/simple.py
+++ b/deploy/determined_deploy/aws/deployment_types/simple.py
@@ -38,6 +38,8 @@ class Simple(base.DeterminedDeployment):
         constants.cloudformation.PREEMPTION_ENABLED,
         constants.cloudformation.CPU_ENV_IMAGE,
         constants.cloudformation.GPU_ENV_IMAGE,
+        constants.cloudformation.LOG_GROUP_PREFIX,
+        constants.cloudformation.RETAIN_LOG_GROUP,
     ]
 
     def deploy(self) -> None:

--- a/deploy/determined_deploy/aws/deployment_types/vpc.py
+++ b/deploy/determined_deploy/aws/deployment_types/vpc.py
@@ -34,6 +34,7 @@ class VPC(base.DeterminedDeployment):
         constants.cloudformation.SPOT_MAX_PRICE,
         constants.cloudformation.CPU_ENV_IMAGE,
         constants.cloudformation.GPU_ENV_IMAGE,
+        constants.cloudformation.LOG_GROUP_PREFIX,
     ]
 
     def deploy(self) -> None:

--- a/deploy/determined_deploy/aws/templates/efs.yaml
+++ b/deploy/determined_deploy/aws/templates/efs.yaml
@@ -150,7 +150,7 @@ Parameters:
     Type: String
     Description: Whether preemption is enabled (only supported for priority scheduler).
     Default: false
-  
+
   CpuEnvImage:
     Type: String
     Description: Docker image for CPU tasks
@@ -160,6 +160,11 @@ Parameters:
     Type: String
     Description: Docker image for GPU tasks
     Default: ""
+
+  LogGroupPrefix:
+    Type: String
+    Description: Prefix for output CloudWatch log group (the full log group will be "/<prefix>/<stack>")
+    Default: determined
 
 Resources:
   VPC:
@@ -459,7 +464,7 @@ Resources:
   LogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
-      LogGroupName: !Sub /determined/${AWS::StackName}
+      LogGroupName: !Sub /${LogGroupPrefix}/${AWS::StackName}
 
   LogPolicy:
     Type: AWS::IAM::Policy

--- a/deploy/determined_deploy/aws/templates/fsx.yaml
+++ b/deploy/determined_deploy/aws/templates/fsx.yaml
@@ -149,7 +149,7 @@ Parameters:
     Type: String
     Description: Whether preemption is enabled (only supported for priority scheduler).
     Default: false
-  
+
   CpuEnvImage:
     Type: String
     Description: Docker image for CPU tasks
@@ -159,6 +159,11 @@ Parameters:
     Type: String
     Description: Docker image for GPU tasks
     Default: ""
+
+  LogGroupPrefix:
+    Type: String
+    Description: Prefix for output CloudWatch log group (the full log group will be "/<prefix>/<stack>")
+    Default: determined
 
 Resources:
   VPC:
@@ -477,7 +482,7 @@ Resources:
   LogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
-      LogGroupName: !Sub /determined/${AWS::StackName}
+      LogGroupName: !Sub /${LogGroupPrefix}/${AWS::StackName}
 
   LogPolicy:
     Type: AWS::IAM::Policy

--- a/deploy/determined_deploy/aws/templates/secure.yaml
+++ b/deploy/determined_deploy/aws/templates/secure.yaml
@@ -181,6 +181,11 @@ Parameters:
     Description: Docker image for GPU tasks
     Default: ""
 
+  LogGroupPrefix:
+    Type: String
+    Description: Prefix for output CloudWatch log group (the full log group will be "/<prefix>/<stack>")
+    Default: determined
+
 Resources:
   VPC:
     Type: AWS::EC2::VPC
@@ -513,7 +518,7 @@ Resources:
   LogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
-      LogGroupName: !Sub /determined/det-${AWS::StackName}
+      LogGroupName: !Sub /${LogGroupPrefix}/${AWS::StackName}
 
   LogPolicy:
     Type: AWS::IAM::Policy

--- a/deploy/determined_deploy/aws/templates/simple.yaml
+++ b/deploy/determined_deploy/aws/templates/simple.yaml
@@ -141,7 +141,7 @@ Parameters:
     Type: String
     Description: Whether preemption is enabled (only supported for priority scheduler).
     Default: false
-  
+
   CpuEnvImage:
     Type: String
     Description: Docker image for CPU tasks
@@ -151,6 +151,20 @@ Parameters:
     Type: String
     Description: Docker image for GPU tasks
     Default: ""
+
+  LogGroupPrefix:
+    Type: String
+    Description: Prefix for output CloudWatch log group (the full log group will be "/<prefix>/<stack>")
+    Default: determined
+
+  RetainLogGroup:
+    Type: String
+    Description: Whether to retain CloudWatch log group after the stack is deleted
+    Default: false
+
+Conditions:
+  RetainLogGroup: !Equals [!Ref RetainLogGroup, true]
+  DeleteLogGroup: !Not [!Equals [!Ref RetainLogGroup, true]]
 
 Resources:
   CheckpointBucket:
@@ -320,10 +334,19 @@ Resources:
         MinCapacity: 2
         MaxCapacity: 8
 
-  LogGroup:
+  RetainedLogGroup:
     Type: AWS::Logs::LogGroup
+    Condition: RetainLogGroup
+    DeletionPolicy: Retain
     Properties:
-      LogGroupName: !Sub /determined/${AWS::StackName}
+      LogGroupName: !Sub /${LogGroupPrefix}/${AWS::StackName}
+
+  DeletedLogGroup:
+    Type: AWS::Logs::LogGroup
+    Condition: DeleteLogGroup
+    DeletionPolicy: Delete
+    Properties:
+      LogGroupName: !Sub /${LogGroupPrefix}/${AWS::StackName}
 
   LogPolicy:
     Type: AWS::IAM::Policy
@@ -341,8 +364,8 @@ Resources:
               - logs:PutLogEvents
               - logs:DescribeLogStreams
             Resource:
-              - !Sub arn:aws:logs:*:*:log-group:${LogGroup},
-              - !Sub arn:aws:logs:*:*:log-group:${LogGroup}:log-stream:*
+              - !Sub arn:aws:logs:*:*:log-group:/${LogGroupPrefix}/${AWS::StackName},
+              - !Sub arn:aws:logs:*:*:log-group:/${LogGroupPrefix}/${AWS::StackName}:log-stream:*
 
   MetricPolicy:
     Type: AWS::IAM::Policy
@@ -534,7 +557,7 @@ Resources:
                   agent_docker_image: determinedai/determined-agent:${Version}
                   instance_name: determined-agent-${AWS::StackName}
                   instance_type: ${CPUAgentInstanceType}
-                  log_group: ${LogGroup}
+                  log_group: /${LogGroupPrefix}/${AWS::StackName}
                   log_stream: determined-agent
                   master_url: $scheme://local-ipv4:$port
                   max_idle_agent_period: ${MaxIdleAgentPeriod}
@@ -562,7 +585,7 @@ Resources:
                   agent_docker_image: determinedai/determined-agent:${Version}
                   instance_name: determined-agent-${AWS::StackName}
                   instance_type: ${GPUAgentInstanceType}
-                  log_group: ${LogGroup}
+                  log_group: /${LogGroupPrefix}/${AWS::StackName}
                   log_stream: determined-agent
                   master_url: $scheme://local-ipv4:$port
                   max_idle_agent_period: ${MaxIdleAgentPeriod}
@@ -638,7 +661,7 @@ Resources:
                 --network determined \
                 --restart unless-stopped \
                 --log-driver=awslogs \
-                --log-opt awslogs-group=${LogGroup} \
+                --log-opt awslogs-group=/${LogGroupPrefix}/${AWS::StackName} \
                 --log-opt awslogs-stream=determined-master \
                 -p "$port":"$port" \
                 -v /usr/local/determined/etc/master.yaml:/etc/determined/master.yaml \
@@ -698,7 +721,7 @@ Outputs:
 
   LogGroup:
     Description: The Log Group for Determined Logs
-    Value: !Ref LogGroup
+    Value: !Sub /${LogGroupPrefix}/${AWS::StackName}
 
   Region:
     Description: The AWS Region the stack is deployed in

--- a/deploy/determined_deploy/aws/templates/vpc.yaml
+++ b/deploy/determined_deploy/aws/templates/vpc.yaml
@@ -161,6 +161,11 @@ Parameters:
     Description: Docker image for GPU tasks
     Default: ""
 
+  LogGroupPrefix:
+    Type: String
+    Description: Prefix for output CloudWatch log group (the full log group will be "/<prefix>/<stack>")
+    Default: determined
+
 Resources:
   VPC:
     Type: AWS::EC2::VPC
@@ -420,7 +425,7 @@ Resources:
   LogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
-      LogGroupName: !Sub /determined/${AWS::StackName}
+      LogGroupName: !Sub /determined/det-${AWS::StackName}
 
   LogPolicy:
     Type: AWS::IAM::Policy


### PR DESCRIPTION
## Description

`det-deploy aws up` now supports two new options: `--retain-log-group`
and `--log-group-prefix`. The former sets the CloudWatch log group that
is created for the stack to not be deleted when the rest of the stack
is, which may be useful in some situations. The latter sets the prefix
that is applied to the stack name to generate the log group name
(default "determined", leading to the same behavior as before).

Because CloudFormation's templating is terrible, the implementation
looks a bit awkward. The `DeletionPolicy` field is required to be a
literal, so it is not possible to use an expression to set it
conditionally. Instead, we have to define two separate resources, one
retained and one not, each of which is created conditionally. As far as
I can tell, those conditions can't be written inline but instead have to
be defined in a separate section and referred to by name, which also
means we need one for each case. Having two separate resources in turn
means that we can't refer to the log group by its logical ID later on
when we need the log group name; instead, we have to insert the
expression used to compute the log group name everywhere we need
it (since it also seems to be impossible to define derived variables in
the template without doing something crazy like going through AWS
Lambda or storing config snippets in S3).

## Test Plan

- [x] start stacks with and without `--retain-log-group`, check that log group is deleted or not
- [x] run with `--log-group-prefix`

## Commentary (optional)

CloudFormation makes this so terrible. I'm honestly not 100% sure this is worth doing, given the hoops that we need to jump through; accordingly, I've only updated the simple template so far so we can evaluate first.

The prefix option doesn't strictly have to go along with the retention one, but I figure it'll be useful to allow a bit more control over where logs go if there are likely to be more of them (for CI-generated logs in particular).
