### PR TITLE
ci: set a CI-specific prefix for and retain CloudWatch log groups

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -379,6 +379,12 @@ commands:
       max-dynamic-agents:
         type: integer
         default: 1
+      retain-log-group:
+        type: boolean
+        default: false
+      log-group-prefix:
+        type: string
+        default: ""
     steps:
       - run:
           name: Initialize extra arguments
@@ -398,6 +404,11 @@ commands:
             if [ -n "<<parameters.master-tls-cert>>" ]; then echo "--master-tls-cert <<parameters.master-tls-cert>>" >> /tmp/det-deploy-extra-args; fi
             if [ -n "<<parameters.master-tls-key>>" ]; then echo "--master-tls-key <<parameters.master-tls-key>>" >> /tmp/det-deploy-extra-args; fi
             if [ -n "<<parameters.master-cert-name>>" ]; then echo "--master-cert-name <<parameters.master-cert-name>>" >> /tmp/det-deploy-extra-args; fi
+      - run:
+          name: Configure log group arguments
+          command: |
+            if [ <<parameters.retain-log-group>> ]; then echo "--retain-log-group" >> /tmp/det-deploy-extra-args; fi
+            if [ -n "<<parameters.log-group-prefix>>" ]; then echo "--log-group-prefix <<parameters.log-group-prefix>>" >> /tmp/det-deploy-extra-args; fi
       - run:
           name: Deploy AWS cluster
           command: |
@@ -457,6 +468,8 @@ commands:
           master-tls-cert: <<parameters.master-tls-cert>>
           master-tls-key: <<parameters.master-tls-key>>
           master-cert-name: <<parameters.master-cert-name>>
+          log-group-prefix: determined-ci
+          retain-log-group: true
       - set-master-address-aws:
           cluster-id: ${CLUSTER_ID}
           master-tls-cert: <<parameters.master-tls-cert>>

--- a/deploy/determined_deploy/aws/templates/simple.yaml
+++ b/deploy/determined_deploy/aws/templates/simple.yaml
@@ -341,7 +341,7 @@ Resources:
     Properties:
       LogGroupName: !Sub /${LogGroupPrefix}/${AWS::StackName}
 
-  DeletedLogGroup:
+  LogGroup:
     Type: AWS::Logs::LogGroup
     Condition: DeleteLogGroup
     DeletionPolicy: Delete


### PR DESCRIPTION
(duplicate of #1952 because that merged into the wrong branch)

## Description

In order to avoid the (somehow) error-prone step of exporting CI logs
from CloudWatch to S3, we now set logs from CI-spawned det-deploy AWS
test clusters to be retained after the CloudFormation stacks are
deleted. Those log groups also now have a new "determined-ci" prefix to
separate them from other log groups, now that they're going to stick
around.

This also includes a fix for an issue in updating a stack after the
recent det-deploy change introducing log retention: the logical name of
a deleted log group is now set to the same as it was before, which
should avoid a conflict in CloudFormation.
