### PR TITLE
ci: fix retention of CloudWatch logs for deploy clusters

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -407,7 +407,7 @@ commands:
       - run:
           name: Configure log group arguments
           command: |
-            if [ <<parameters.retain-log-group>> ]; then echo "--retain-log-group" >> /tmp/det-deploy-extra-args; fi
+            if <<parameters.retain-log-group>>; then echo "--retain-log-group" >> /tmp/det-deploy-extra-args; fi
             if [ -n "<<parameters.log-group-prefix>>" ]; then echo "--log-group-prefix <<parameters.log-group-prefix>>" >> /tmp/det-deploy-extra-args; fi
       - run:
           name: Deploy AWS cluster


### PR DESCRIPTION
## Description

Due to an incorrect shell script, `--retain-log-group` was being set for
all AWS clusters, even when it shouldn't've been.

## Test Plan

Watch the deploy on master!
