### PR TITLE
refactor: add internal restful APIs for checkpoints and metrics [DET-4896]

### DIFF
--- a/harness/determined/__init__.py
+++ b/harness/determined/__init__.py
@@ -1,4 +1,5 @@
 from determined.__version__ import __version__
+from determined import errors, workload
 from determined._env_context import EnvContext
 from determined._rendezvous_info import RendezvousInfo
 from determined._execution import (
@@ -17,5 +18,4 @@ from determined._trial_controller import (
     LoopTrialController,
     TrialController,
 )
-from determined import errors
 from determined import util

--- a/harness/determined/_execution.py
+++ b/harness/determined/_execution.py
@@ -131,6 +131,7 @@ def _make_local_execution_env(
         trial_seed=config.experiment_seed(),
         managed_training=managed_training,
         test_mode=test_mode,
+        local_mode=True,
     )
     rendezvous_ports = env.rendezvous_ports()
     rendezvous_info = det.RendezvousInfo(

--- a/harness/determined/util.py
+++ b/harness/determined/util.py
@@ -129,34 +129,50 @@ def wrap_metrics(
         return {"metrics": metrics, "stop_requested": stop_requested, "invalid_hp": invalid_hp}
 
 
-def json_encode(obj: Any, indent: Optional[str] = None, sort_keys: bool = False) -> str:
-    def json_serializer(obj: Any) -> Any:
-        if isinstance(obj, datetime.datetime):
-            return obj.isoformat()
-        if isinstance(obj, enum.Enum):
-            return obj.name
-        if isinstance(obj, np.float64):
-            return float(obj)
-        if isinstance(obj, np.float32):
-            return float(obj)
-        if isinstance(obj, np.int64):
-            return int(obj)
-        if isinstance(obj, np.int32):
-            return int(obj)
-        if isinstance(obj, uuid.UUID):
-            return str(obj)
-        if isinstance(obj, np.ndarray):
-            return obj.tolist()
-        # Objects that provide their own custom JSON serialization.
-        if hasattr(obj, "__json__"):
-            return obj.__json__()
-
-        raise TypeError("Unserializable object {} of type {}".format(obj, type(obj)))
-
+def make_serializable(obj: Any, raise_type_error: bool = False) -> Any:
     # NB: We serialize NaN, Infinity, and -Infinity as `null`, because
     # those are not allowed by the JSON spec.
+    if isinstance(obj, dict):
+        for k in obj:
+            obj[k] = make_serializable(obj[k])
+        return obj
+    if isinstance(obj, list):
+        return [make_serializable(item) for item in obj]
+    if isinstance(obj, tuple):
+        return (make_serializable(item) for item in obj)
+    if isinstance(obj, datetime.datetime):
+        return obj.isoformat()
+    if isinstance(obj, enum.Enum):
+        return obj.name
+    if isinstance(obj, np.float64):
+        return float(obj)
+    if isinstance(obj, np.float32):
+        return float(obj)
+    if isinstance(obj, np.int64):
+        return int(obj)
+    if isinstance(obj, np.int32):
+        return int(obj)
+    if isinstance(obj, uuid.UUID):
+        return str(obj)
+    if isinstance(obj, np.ndarray):
+        return obj.tolist()
+    # Objects that provide their own custom JSON serialization.
+    if hasattr(obj, "__json__"):
+        return obj.__json__()
+
+    if raise_type_error:
+        raise TypeError(f"Unserializable object {obj} of type {type(obj)}")
+
+    return obj
+
+
+def json_encode(obj: Any, indent: Optional[str] = None, sort_keys: bool = False) -> str:
     s = simplejson.dumps(
-        obj, default=json_serializer, ignore_nan=True, indent=indent, sort_keys=sort_keys
+        obj,
+        default=lambda x: make_serializable(x, True),
+        ignore_nan=True,
+        indent=indent,
+        sort_keys=sort_keys,
     )  # type: str
     return s
 

--- a/harness/determined/workload.py
+++ b/harness/determined/workload.py
@@ -58,6 +58,9 @@ class Workload:
             dict["total_batches_processed"],
         )
 
+    def target_batch(self) -> int:
+        return self.num_batches + self.total_batches_processed
+
 
 """Metrics is the general structure of metrics used in response messages throughout the harness."""
 Metrics = Dict[str, Any]

--- a/harness/tests/experiment/utils.py
+++ b/harness/tests/experiment/utils.py
@@ -145,6 +145,7 @@ def make_default_env_context(
         det_experiment_id="1",
         det_cluster_id="uuid-123",
         trial_seed=trial_seed,
+        local_mode=True,
     )
 
 

--- a/harness/tests/tensorboard/test_util.py
+++ b/harness/tests/tensorboard/test_util.py
@@ -37,6 +37,7 @@ def get_dummy_env() -> det.EnvContext:
         det_experiment_id="1",
         det_cluster_id="uuid-123",
         trial_seed=0,
+        local_mode=True,
     )
 
 

--- a/master/internal/api_model_metrics.go
+++ b/master/internal/api_model_metrics.go
@@ -1,0 +1,104 @@
+package internal
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+
+	"github.com/determined-ai/determined/master/pkg/model"
+	"github.com/determined-ai/determined/proto/pkg/apiv1"
+)
+
+func (a *apiServer) CreateTrainingMetrics(
+	_ context.Context, req *apiv1.CreateTrainingMetricsRequest,
+) (*apiv1.CreateTrainingMetricsResponse, error) {
+	log.Infof("adding training metrics %s (trial %d, batch %d to %d)",
+		req.TrainingMetrics.Uuid, req.TrainingMetrics.TrialId,
+		req.TrainingMetrics.StartBatch, req.TrainingMetrics.EndBatch)
+	modelT, err := model.TrainingMetricsFromProto(req.TrainingMetrics)
+	if err != nil {
+		return nil, errors.Wrapf(
+			err, "error adding training metrics %s (trial %d, batch %d to %d) in database",
+			req.TrainingMetrics.Uuid, req.TrainingMetrics.TrialId,
+			req.TrainingMetrics.StartBatch, req.TrainingMetrics.EndBatch)
+	}
+	err = a.m.db.AddStep(modelT)
+	if err != nil {
+		return nil, errors.Wrapf(err,
+			"error adding training metrics %s (trial %d, batch %d to %d) in database",
+			req.TrainingMetrics.Uuid, req.TrainingMetrics.TrialId,
+			req.TrainingMetrics.StartBatch, req.TrainingMetrics.EndBatch)
+	}
+	return &apiv1.CreateTrainingMetricsResponse{TrainingMetrics: req.TrainingMetrics}, nil
+}
+
+func (a *apiServer) PatchTrainingMetrics(
+	_ context.Context, req *apiv1.PatchTrainingMetricsRequest,
+) (*apiv1.PatchTrainingMetricsResponse, error) {
+	log.Infof("patching training metrics %s (trial %d, batch %d to %d) state %s",
+		req.TrainingMetrics.Uuid, req.TrainingMetrics.TrialId,
+		req.TrainingMetrics.StartBatch, req.TrainingMetrics.EndBatch, req.TrainingMetrics.State)
+	modelS, err := model.TrainingMetricsFromProto(req.TrainingMetrics)
+	if err != nil {
+		return nil, errors.Wrapf(
+			err, "error patching training metrics %s (trial %d, batch %d to %d) in database",
+			req.TrainingMetrics.Uuid, req.TrainingMetrics.TrialId,
+			req.TrainingMetrics.StartBatch, req.TrainingMetrics.EndBatch)
+	}
+	err = a.m.db.UpdateStep(
+		int(req.TrainingMetrics.TrialId), int(req.TrainingMetrics.EndBatch), *modelS)
+	if err != nil {
+		return nil, errors.Wrapf(err,
+			"error patching training metrics %s (trial %d, batch %d to %d) in database",
+			req.TrainingMetrics.Uuid, req.TrainingMetrics.TrialId,
+			req.TrainingMetrics.StartBatch, req.TrainingMetrics.EndBatch)
+	}
+	return &apiv1.PatchTrainingMetricsResponse{TrainingMetrics: req.TrainingMetrics}, nil
+}
+
+func (a *apiServer) CreateValidationMetrics(
+	_ context.Context, req *apiv1.CreateValidationMetricsRequest,
+) (*apiv1.CreateValidationMetricsResponse, error) {
+	log.Infof("adding validation metrics %s (trial %d, batch %d)",
+		req.ValidationMetrics.Uuid, req.ValidationMetrics.TrialId, req.ValidationMetrics.TotalBatches)
+	modelV, err := model.ValidationMetricsFromProto(req.ValidationMetrics)
+	if err != nil {
+		return nil, errors.Wrapf(
+			err, "error adding validation metrics %s (trial %d, batch %d) in database",
+			req.ValidationMetrics.Uuid, req.ValidationMetrics.TrialId,
+			req.ValidationMetrics.TotalBatches)
+	}
+	err = a.m.db.AddValidation(modelV)
+	if err != nil {
+		return nil, errors.Wrapf(
+			err, "error adding validation metrics %s (trial %d, batch %d) in database",
+			req.ValidationMetrics.Uuid, req.ValidationMetrics.TrialId,
+			req.ValidationMetrics.TotalBatches)
+	}
+	return &apiv1.CreateValidationMetricsResponse{ValidationMetrics: req.ValidationMetrics}, nil
+}
+
+func (a *apiServer) PatchValidationMetrics(
+	_ context.Context, req *apiv1.PatchValidationMetricsRequest,
+) (*apiv1.PatchValidationMetricsResponse, error) {
+	log.Infof("patching validation metrics %s (trial %d, batch %d) state %s",
+		req.ValidationMetrics.Uuid, req.ValidationMetrics.TrialId,
+		req.ValidationMetrics.TotalBatches, req.ValidationMetrics.State)
+	modelV, err := model.ValidationMetricsFromProto(req.ValidationMetrics)
+	if err != nil {
+		return nil, errors.Wrapf(
+			err, "error patching validation metrics %s (trial %d, batch %d) in database",
+			req.ValidationMetrics.Uuid, req.ValidationMetrics.TrialId,
+			req.ValidationMetrics.TotalBatches)
+	}
+	err = a.m.db.UpdateValidation(
+		int(req.ValidationMetrics.TrialId), int(req.ValidationMetrics.TotalBatches), *modelV)
+	if err != nil {
+		return nil, errors.Wrapf(err,
+			"error patching validation metrics %s (trial %d, batch %d) in database",
+			req.ValidationMetrics.Uuid, req.ValidationMetrics.TrialId,
+			req.ValidationMetrics.TotalBatches)
+	}
+	return &apiv1.PatchValidationMetricsResponse{ValidationMetrics: req.ValidationMetrics}, nil
+}

--- a/master/internal/db/postgres.go
+++ b/master/internal/db/postgres.go
@@ -1324,24 +1324,14 @@ FROM (
 
 // AddStep adds the step to the database.
 func (db *PgDB) AddStep(step *model.Step) error {
-	if !step.IsNew() {
-		return errors.Errorf("unexpected state for new step: %v", step)
-	}
-	trial, err := db.TrialByID(step.TrialID)
-	if err != nil {
-		return errors.Wrapf(err, "error finding trial %v for new step", step.TrialID)
-	}
-	if trial.State != model.ActiveState {
-		return errors.Errorf("can't add step to trial %v with state %v", trial.ID, trial.State)
-	}
-	err = db.namedExecOne(`
+	if err := db.namedExecOne(`
 INSERT INTO steps
-(trial_id, id, total_batches, state, start_time, end_time, num_batches, prior_batches_processed)
+	(id, trial_id, total_batches, num_batches, prior_batches_processed, 
+	state, start_time, end_time, metrics)
 VALUES (
-	:trial_id, :id, :total_batches, :state, :start_time, :end_time, 
-	:num_batches, :prior_batches_processed
-)`, step)
-	if err != nil {
+	:id, :trial_id, :total_batches, :num_batches, :prior_batches_processed, 
+	:state, :start_time, :end_time, :metrics
+)`, step); err != nil {
 		return errors.Wrapf(err, "error inserting step %v", *step)
 	}
 	return nil
@@ -1360,73 +1350,62 @@ func (db *PgDB) AddNoOpStep(step *model.Step) error {
 	if trial.State != model.ActiveState {
 		return errors.Errorf("can't add step to trial %v with state %v", trial.ID, trial.State)
 	}
-	err = db.namedExecOne(`
+	if err = db.namedExecOne(`
 INSERT INTO steps
-(trial_id, id, total_batches, state, start_time, end_time, num_batches, prior_batches_processed)
+	(id, trial_id, total_batches, num_batches, prior_batches_processed, 
+	state, start_time, end_time)
 VALUES (
-	:trial_id, :id, :total_batches, :state, :start_time, :end_time, 
-	:num_batches, :prior_batches_processed
+	:id, :trial_id, :total_batches, :num_batches, :prior_batches_processed, 
+	:state, :start_time, :end_time
 )`,
-		step)
-	if err != nil {
+		step); err != nil {
 		return errors.Wrapf(err, "error inserting step %v", *step)
 	}
 	return nil
 }
 
-// StepByTotalBatches looks up a step by (TrialID, TotalBatches) pair,
-// returning an error if none exists.
-func (db *PgDB) StepByTotalBatches(trialID, totalBatches int) (*model.Step, error) {
+// UpdateStep updates an existing step. Fields that are nil or zero are not
+// updated.  end_time is set if the step moves to a terminal state.
+func (db *PgDB) UpdateStep(trialID, totalBatches int, newStep model.Step) error {
 	var step model.Step
 	if err := db.query(`
 SELECT 
-	trial_id, id, total_batches, state, start_time, end_time, metrics, 
-	num_batches, prior_batches_processed
+	id, trial_id, total_batches, num_batches, prior_batches_processed, 
+	state, start_time, end_time, metrics
 FROM steps
-WHERE trial_id = $1 AND total_batches = $2`, &step, trialID, totalBatches); err != nil {
-		return nil, errors.Wrapf(err, "error querying for step %v, %v", trialID, totalBatches)
-	}
-	return &step, nil
-}
-
-// UpdateStep updates an existing step. Fields that are nil or zero are not
-// updated.  end_time is set if the step moves to a terminal state.
-func (db *PgDB) UpdateStep(
-	trialID, totalBatches int, newState model.State, metrics model.JSONObj) error {
-	if len(newState) == 0 && len(metrics) == 0 {
-		return nil
-	}
-	step, err := db.StepByTotalBatches(trialID, totalBatches)
-	if err != nil {
+WHERE trial_id = $1 AND total_batches = $2
+`, &step, trialID, totalBatches); errors.Cause(err) == ErrNotFound {
 		return errors.Wrapf(err, "error finding step (%v, %v) to update", trialID, totalBatches)
+	} else if err != nil {
+		return errors.Errorf("cannot update missing step (%v, %v)", trialID, totalBatches)
 	}
+
 	toUpdate := []string{}
-	if len(newState) != 0 {
-		if !model.StepTransitions[step.State][newState] {
+	if len(newStep.State) != 0 {
+		if !model.StepTransitions[step.State][newStep.State] {
 			return errors.Errorf("illegal transition %v -> %v for step (%v, %v)",
-				step.State, newState, step.TrialID, step.TotalBatches)
+				step.State, newStep.State, step.TrialID, step.TotalBatches)
 		}
-		step.State = newState
+		step.State = newStep.State
 		toUpdate = append(toUpdate, "state")
-		if model.TerminalStates[newState] {
+		if model.TerminalStates[newStep.State] {
 			now := time.Now().UTC()
 			step.EndTime = &now
 			toUpdate = append(toUpdate, "end_time")
 		}
 	}
-	if len(metrics) != 0 {
+	if len(newStep.Metrics) != 0 {
 		if len(step.Metrics) != 0 {
 			return errors.Errorf("step (%v, %v) already has metrics", trialID, totalBatches)
 		}
-		step.Metrics = metrics
+		step.Metrics = newStep.Metrics
 		toUpdate = append(toUpdate, "metrics")
 	}
-	err = db.namedExecOne(fmt.Sprintf(`
+	if err := db.namedExecOne(fmt.Sprintf(`
 UPDATE steps
 %v
-WHERE trial_id = :trial_id
-AND id = :id`, setClause(toUpdate)), step)
-	if err != nil {
+WHERE trial_id = :trial_id AND total_batches = :total_batches
+`, setClause(toUpdate)), step); err != nil {
 		return errors.Wrapf(err, "error updating (%v) in step (%v, %v)",
 			strings.Join(toUpdate, ", "), step.TrialID, step.TotalBatches)
 	}
@@ -1435,102 +1414,73 @@ AND id = :id`, setClause(toUpdate)), step)
 
 // AddValidation adds the validation to the database and sets its ID.
 func (db *PgDB) AddValidation(validation *model.Validation) error {
-	if !validation.IsNew() {
-		return errors.Errorf("unexpected state for new validation: %v", validation)
-	}
-	trial, err := db.TrialByID(validation.TrialID)
-	if err != nil {
-		return errors.Wrapf(err, "error finding trial %v for new validation", validation.TrialID)
-	}
-	if trial.State != model.ActiveState {
-		return errors.Errorf("can't add validation to trial %v with state %v", trial.ID, trial.State)
-	}
-	var count int
-	err = db.namedGet(&count, `
-SELECT COUNT(*)
-FROM validations
-WHERE trial_id = :trial_id
-AND total_batches = :total_batches`, validation)
-	if err != nil {
-		return errors.Wrapf(err, "error checking at-most-one validation %v", *validation)
-	}
-	if count > 0 {
-		return errors.Errorf("duplicate validation for trial %v total batch %v",
-			validation.TrialID, validation.TotalBatches)
-	}
-	err = db.namedGet(&validation.ID, `
+	err := db.namedGet(&validation.ID, `
 INSERT INTO validations
-(trial_id, total_batches, state, start_time, end_time)
-VALUES (:trial_id, :total_batches, :state, :start_time, :end_time)
-RETURNING id`, validation)
+	(trial_id, total_batches, state, start_time, end_time, metrics)
+VALUES 
+	(:trial_id, :total_batches, :state, :start_time, :end_time, :metrics)
+RETURNING id
+`, validation)
 	if err != nil {
 		return errors.Wrapf(err, "error inserting validation %v", *validation)
 	}
 	return nil
 }
 
-// ValidationByTotalBatches looks up a validation by trial and step ID,
-// returning nil if none exists.
-func (db *PgDB) ValidationByTotalBatches(trialID, totalBatches int) (*model.Validation, error) {
+// UpdateValidation updates an existing validation. Fields that are nil or zero
+// are not updated. end_time is set if the validation moves to a terminal
+// state.
+func (db *PgDB) UpdateValidation(trialID, totalBatches int, newValidation model.Validation) error {
 	var validation model.Validation
 	if err := db.query(`
 SELECT id, trial_id, total_batches, state, start_time, end_time, metrics
 FROM validations
-WHERE trial_id = $1
-AND total_batches = $2`, &validation, trialID, totalBatches); errors.Cause(err) == ErrNotFound {
-		return nil, nil
-	} else if err != nil {
-		return nil, errors.Wrapf(err, "error querying for validation (%v, %v)",
+WHERE trial_id = $1 AND total_batches = $2
+`, &validation, trialID, totalBatches); errors.Cause(err) == ErrNotFound {
+		return errors.Wrapf(err, "can't update missing validation (%v, %v)",
 			trialID, totalBatches)
-	}
-	return &validation, nil
-}
-
-// UpdateValidation updates an existing validation. Fields that are nil or zero
-// are not updated. end_time is set if the validation moves to a terminal
-// state.
-func (db *PgDB) UpdateValidation(
-	trialID, totalBatches int, newState model.State, metrics model.JSONObj,
-) error {
-	if len(newState) == 0 && len(metrics) == 0 {
-		return nil
-	}
-	validation, err := db.ValidationByTotalBatches(trialID, totalBatches)
-	if err != nil {
+	} else if err != nil {
 		return errors.Wrapf(err, "error querying for validation (%v, %v) to update",
 			trialID, totalBatches)
 	}
-	if validation == nil {
-		return errors.Wrapf(err, "can't update missing validation (%v, %v)",
-			trialID, totalBatches)
-	}
+
 	toUpdate := []string{}
-	if len(newState) != 0 {
-		if !model.StepTransitions[validation.State][newState] {
+	if len(newValidation.State) != 0 {
+		if !model.StepTransitions[validation.State][newValidation.State] {
 			return errors.Errorf("illegal transition %v -> %v for validation %v",
-				validation.State, newState, validation.ID)
+				validation.State, newValidation.State, validation.ID)
 		}
-		validation.State = newState
+		validation.State = newValidation.State
 		toUpdate = append(toUpdate, "state")
-		if model.TerminalStates[newState] {
+		if model.TerminalStates[newValidation.State] {
 			now := time.Now().UTC()
 			validation.EndTime = &now
 			toUpdate = append(toUpdate, "end_time")
 		}
 	}
-	if len(metrics) != 0 {
+	if len(newValidation.Metrics) != 0 {
+		if _, ok := newValidation.Metrics["validation_metrics"]; !ok {
+			return errors.Errorf("validation metrics must have key validation_metrics: %v",
+				newValidation.Metrics)
+		}
+		if _, ok := newValidation.Metrics["num_inputs"]; !ok {
+			return errors.Errorf("validation metrics must have key num_inputs: %v",
+				newValidation.Metrics)
+		}
+
 		if len(validation.Metrics) != 0 {
 			return errors.Errorf("validation (%v, %v) already has metrics",
 				trialID, totalBatches)
 		}
-		validation.Metrics = metrics
+		validation.Metrics = newValidation.Metrics
 		toUpdate = append(toUpdate, "metrics")
 	}
-	err = db.namedExecOne(fmt.Sprintf(`
+
+	if err := db.namedExecOne(fmt.Sprintf(`
 UPDATE validations
 %v
-WHERE id = :id`, setClause(toUpdate)), validation)
-	if err != nil {
+WHERE trial_id = :trial_id AND total_batches = :total_batches
+`, setClause(toUpdate)), validation); err != nil {
 		return errors.Wrapf(err, "error updating (%v) in validation (%v, %v)",
 			strings.Join(toUpdate, ", "), trialID, totalBatches)
 	}
@@ -1544,48 +1494,19 @@ WHERE id = :id`, setClause(toUpdate)), validation)
 
 // AddCheckpoint adds the checkpoint to the database and sets its ID.
 func (db *PgDB) AddCheckpoint(checkpoint *model.Checkpoint) error {
-	if !checkpoint.IsNew() {
-		return errors.Errorf("unexpected state for new checkpoint: %v", checkpoint)
-	}
-	var count int
-	err := db.namedGet(&count, `
-SELECT COUNT(*)
-FROM checkpoints
-WHERE trial_id = :trial_id
-AND total_batches = :total_batches`, checkpoint)
-	if err != nil {
-		return errors.Wrapf(err, "error checking at-most-one checkpoint %v", *checkpoint)
-	}
-	if count > 0 {
-		return errors.Errorf("duplicate checkpoint for trial %v total batch %v",
-			checkpoint.TrialID, checkpoint.TotalBatches)
-	}
-	err = db.namedGet(&checkpoint.ID, `
+	err := db.namedGet(&checkpoint.ID, `
 INSERT INTO checkpoints
-(trial_id, total_batches, state, start_time, metadata, determined_version)
-VALUES (:trial_id, :total_batches, :state, :start_time, :metadata, :determined_version)
-RETURNING id`, checkpoint)
+	(trial_id, total_batches, state, start_time, end_time, uuid, resources, metadata, 
+	framework, format, determined_version)
+VALUES 
+	(:trial_id, :total_batches, :state, :start_time, :end_time, :uuid, :resources, :metadata, 
+	:framework, :format, :determined_version)
+RETURNING id
+`, checkpoint)
 	if err != nil {
 		return errors.Wrapf(err, "error inserting checkpoint %v", *checkpoint)
 	}
 	return nil
-}
-
-// CheckpointByTotalBatches looks up a checkpoint by trial and total batch,
-// returning nil if none exists.
-func (db *PgDB) CheckpointByTotalBatches(trialID, totalBatches int) (*model.Checkpoint, error) {
-	var checkpoint model.Checkpoint
-	if err := db.query(`
-SELECT id, trial_id, total_batches, state, start_time, end_time, uuid, resources, metadata
-FROM checkpoints
-WHERE trial_id = $1
-AND total_batches = $2`, &checkpoint, trialID, totalBatches); errors.Cause(err) == ErrNotFound {
-		return nil, nil
-	} else if err != nil {
-		return nil, errors.Wrapf(err, "error querying for checkpoint (%v, %v)",
-			trialID, totalBatches)
-	}
-	return &checkpoint, nil
 }
 
 // CheckpointByUUID looks up a checkpoint by UUID, returning nil if none exists.
@@ -1622,30 +1543,27 @@ LIMIT 1`, &checkpoint, trialID); errors.Cause(err) == ErrNotFound {
 // UpdateCheckpoint updates an existing checkpoint. Fields that are nil or zero
 // are not updated. end_time is set if the checkpoint moves to a terminal
 // state.
-func (db *PgDB) UpdateCheckpoint(
-	trialID, totalBatches int,
-	newCheckpoint model.Checkpoint,
-) error {
-	if len(newCheckpoint.State) == 0 && len(*newCheckpoint.UUID) == 0 &&
-		len(newCheckpoint.Resources) == 0 && len(newCheckpoint.Metadata) == 0 {
-		return nil
-	}
-
-	checkpoint, err := db.CheckpointByTotalBatches(trialID, totalBatches)
-	if err != nil {
-		return errors.Wrapf(err, "error querying for checkpoint (%v, %v) to update",
+func (db *PgDB) UpdateCheckpoint(trialID, totalBatches int, newCheckpoint model.Checkpoint) error {
+	var checkpoint model.Checkpoint
+	if err := db.query(`
+SELECT 
+	id, trial_id, total_batches, state, start_time, end_time, uuid, resources, metadata, 
+	framework, format, determined_version 
+FROM checkpoints
+WHERE trial_id = $1 AND total_batches = $2
+`, &checkpoint, trialID, totalBatches); errors.Cause(err) == ErrNotFound {
+		return errors.Errorf("cannot update missing checkpoint (%v, %v)",
 			trialID, totalBatches)
-	}
-	if checkpoint == nil {
-		return errors.Wrapf(err, "can't update missing checkpoint (%v, %v)",
+	} else if err != nil {
+		return errors.Wrapf(err, "error querying for checkpoint (%v, %v) to update",
 			trialID, totalBatches)
 	}
 
 	toUpdate := []string{}
 	if len(newCheckpoint.State) != 0 {
 		if !model.CheckpointTransitions[checkpoint.State][newCheckpoint.State] {
-			return errors.Errorf("illegal transition %v -> %v for checkpoint %v",
-				checkpoint.State, newCheckpoint.State, checkpoint.ID)
+			return errors.Errorf("illegal transition %v -> %v for checkpoint (%v, %v)",
+				checkpoint.State, newCheckpoint.State, checkpoint.TrialID, checkpoint.TotalBatches)
 		}
 		checkpoint.State = newCheckpoint.State
 		toUpdate = append(toUpdate, "state")
@@ -1682,7 +1600,6 @@ func (db *PgDB) UpdateCheckpoint(
 
 		toUpdate = append(toUpdate, "metadata")
 	}
-
 	if len(newCheckpoint.Framework) != 0 {
 		if len(checkpoint.Framework) != 0 {
 			return errors.Errorf("checkpoint (%v, %v) already has a framework", trialID, totalBatches)
@@ -1691,7 +1608,6 @@ func (db *PgDB) UpdateCheckpoint(
 		checkpoint.Framework = newCheckpoint.Framework
 		toUpdate = append(toUpdate, "framework")
 	}
-
 	if len(newCheckpoint.Format) != 0 {
 		if len(checkpoint.Format) != 0 {
 			return errors.Errorf("checkpoint (%v, %v) already has a format", trialID, totalBatches)
@@ -1701,10 +1617,11 @@ func (db *PgDB) UpdateCheckpoint(
 		toUpdate = append(toUpdate, "format")
 	}
 
-	err = db.namedExecOne(fmt.Sprintf(`
+	err := db.namedExecOne(fmt.Sprintf(`
 UPDATE checkpoints
 %v
-WHERE id = :id`, setClause(toUpdate)), checkpoint)
+WHERE id = :id
+`, setClause(toUpdate)), checkpoint)
 	if err != nil {
 		return errors.Wrapf(err, "error updating (%v) in checkpoint (%v, %v)",
 			strings.Join(toUpdate, ", "), trialID, totalBatches)

--- a/master/internal/db/postgres_proto.go
+++ b/master/internal/db/postgres_proto.go
@@ -57,5 +57,5 @@ func protoParser(rows *sqlx.Rows, val interface{}) error {
 		return errors.Wrapf(err, "error converting row to json bytes: %s", dest)
 	}
 	return errors.Wrapf(protojson.Unmarshal(bytes, message),
-		"error converting row to Protobuf struct")
+		"error converting row to Protobuf struct: %s", bytes)
 }

--- a/master/pkg/model/types.go
+++ b/master/pkg/model/types.go
@@ -4,11 +4,32 @@ import (
 	"database/sql/driver"
 	"encoding/json"
 
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
+
 	"github.com/pkg/errors"
 )
 
 // JSONObj is a JSON object that converts to a []byte in SQL queries.
 type JSONObj map[string]interface{}
+
+// ProtoToJSONObj returns a JSONObj from a protobuf map-like message.
+func ProtoToJSONObj(m proto.Message) (JSONObj, error) {
+	if m == nil {
+		return nil, nil
+	}
+
+	bytes, err := protojson.Marshal(m)
+	if err != nil {
+		return nil, errors.Wrapf(err, "cannot marshal proto to JSONObj")
+	}
+	res := JSONObj{}
+	err = json.Unmarshal(bytes, &res)
+	if err != nil {
+		return nil, errors.Wrapf(err, "cannot unmarshal to JSONObj: %s", bytes)
+	}
+	return res, nil
+}
 
 // Value marshals a []byte.
 func (j JSONObj) Value() (driver.Value, error) {

--- a/master/test/integration/api/api_trials_test.go
+++ b/master/test/integration/api/api_trials_test.go
@@ -113,10 +113,11 @@ func trialDetailAPITests(
 			err = db.AddStep(step)
 			assert.NilError(t, err, "failed to insert step")
 
-			metrics := map[string]interface{}{
+			step.State = model.CompletedState
+			step.Metrics = map[string]interface{}{
 				"avg_metrics": tc.metrics,
 			}
-			err = db.UpdateStep(trial.ID, step.TotalBatches, model.CompletedState, metrics)
+			err = db.UpdateStep(trial.ID, step.TotalBatches, *step)
 			assert.NilError(t, err, "failed to update step")
 
 			ctx, _ := context.WithTimeout(creds, 10*time.Second)

--- a/proto/src/determined/api/v1/api.proto
+++ b/proto/src/determined/api/v1/api.proto
@@ -16,10 +16,12 @@ import "determined/api/v1/model.proto";
 import "determined/api/v1/notebook.proto";
 import "determined/api/v1/template.proto";
 import "determined/api/v1/tensorboard.proto";
+import "determined/api/v1/trainingmetrics.proto";
 import "determined/api/v1/trial.proto";
 import "determined/api/v1/shell.proto";
 import "determined/api/v1/user.proto";
 import "determined/api/v1/resourcepool.proto";
+import "determined/api/v1/validationmetrics.proto";
 
 option (grpc.gateway.protoc_gen_swagger.options.openapiv2_swagger) = {
   info: {
@@ -726,6 +728,54 @@ service Determined {
     };
   }
 
+  // Create training metrics.
+  rpc CreateTrainingMetrics(CreateTrainingMetricsRequest)
+      returns (CreateTrainingMetricsResponse) {
+    option (google.api.http) = {
+      post: "/api/v1/training_metrics"
+      body: "*"
+    };
+    option (grpc.gateway.protoc_gen_swagger.options.openapiv2_operation) = {
+      tags: "Internal"
+    };
+  }
+
+  // Patch training metrics.
+  rpc PatchTrainingMetrics(PatchTrainingMetricsRequest)
+      returns (PatchTrainingMetricsResponse) {
+    option (google.api.http) = {
+      put: "/api/v1/training_metrics"
+      body: "*"
+    };
+    option (grpc.gateway.protoc_gen_swagger.options.openapiv2_operation) = {
+      tags: "Internal"
+    };
+  }
+
+  // Create validation metrics.
+  rpc CreateValidationMetrics(CreateValidationMetricsRequest)
+      returns (CreateValidationMetricsResponse) {
+    option (google.api.http) = {
+      post: "/api/v1/validation_metrics"
+      body: "*"
+    };
+    option (grpc.gateway.protoc_gen_swagger.options.openapiv2_operation) = {
+      tags: "Internal"
+    };
+  }
+
+  // Patch validation metrics.
+  rpc PatchValidationMetrics(PatchValidationMetricsRequest)
+      returns (PatchValidationMetricsResponse) {
+    option (google.api.http) = {
+      put: "/api/v1/validation_metrics"
+      body: "*"
+    };
+    option (grpc.gateway.protoc_gen_swagger.options.openapiv2_operation) = {
+      tags: "Internal"
+    };
+  }
+
   // Get the requested checkpoint.
   rpc GetCheckpoint(GetCheckpointRequest) returns (GetCheckpointResponse) {
     option (google.api.http) = {
@@ -733,6 +783,30 @@ service Determined {
     };
     option (grpc.gateway.protoc_gen_swagger.options.openapiv2_operation) = {
       tags: "Checkpoints"
+    };
+  }
+
+  // Create a checkpoint.
+  rpc CreateCheckpoint(CreateCheckpointRequest)
+      returns (CreateCheckpointResponse) {
+    option (google.api.http) = {
+      post: "/api/v1/checkpoints"
+      body: "*"
+    };
+    option (grpc.gateway.protoc_gen_swagger.options.openapiv2_operation) = {
+      tags: "Internal"
+    };
+  }
+
+  // Patch a checkpoint.
+  rpc PatchCheckpoint(PatchCheckpointRequest)
+      returns (PatchCheckpointResponse) {
+    option (google.api.http) = {
+      put: "/api/v1/checkpoints"
+      body: "*"
+    };
+    option (grpc.gateway.protoc_gen_swagger.options.openapiv2_operation) = {
+      tags: "Internal"
     };
   }
 

--- a/proto/src/determined/api/v1/checkpoint.proto
+++ b/proto/src/determined/api/v1/checkpoint.proto
@@ -17,6 +17,30 @@ message GetCheckpointResponse {
   determined.checkpoint.v1.Checkpoint checkpoint = 1;
 }
 
+// Request for create a checkpoint.
+message CreateCheckpointRequest {
+  // The desired checkpoint fields and values.
+  determined.checkpoint.v1.Checkpoint checkpoint = 1;
+}
+
+// Response to CreateCheckpointRequest.
+message CreateCheckpointResponse {
+  // The updated checkpoint.
+  determined.checkpoint.v1.Checkpoint checkpoint = 1;
+}
+
+// Request for update a checkpoint.
+message PatchCheckpointRequest {
+  // The desired checkpoint fields and values.
+  determined.checkpoint.v1.Checkpoint checkpoint = 1;
+}
+
+// Response to PatchCheckpointRequest.
+message PatchCheckpointResponse {
+  // The patched checkpoint.
+  determined.checkpoint.v1.Checkpoint checkpoint = 1;
+}
+
 // Request for updating a checkpoints metadata.
 message PostCheckpointMetadataRequest {
   // The desired checkpoint fields and values.

--- a/proto/src/determined/api/v1/trainingmetrics.proto
+++ b/proto/src/determined/api/v1/trainingmetrics.proto
@@ -1,0 +1,30 @@
+syntax = "proto3";
+
+package determined.api.v1;
+option go_package = "github.com/determined-ai/determined/proto/pkg/apiv1";
+
+import "determined/modelmetrics/v1/modelmetrics.proto";
+
+// Request for create a training metrics.
+message CreateTrainingMetricsRequest {
+  // The desired training metrics fields and values.
+  determined.modelmetrics.v1.TrainingMetrics training_metrics = 1;
+}
+
+// Response to CreateTrainingMetricsRequest.
+message CreateTrainingMetricsResponse {
+  // The updated training metrics.
+  determined.modelmetrics.v1.TrainingMetrics training_metrics = 1;
+}
+
+// Request for patch a training metrics.
+message PatchTrainingMetricsRequest {
+  // The desired training metrics fields and values.
+  determined.modelmetrics.v1.TrainingMetrics training_metrics = 1;
+}
+
+// Response to PatchTrainingMetricsRequest.
+message PatchTrainingMetricsResponse {
+  // The patched training metrics.
+  determined.modelmetrics.v1.TrainingMetrics training_metrics = 1;
+}

--- a/proto/src/determined/api/v1/validationmetrics.proto
+++ b/proto/src/determined/api/v1/validationmetrics.proto
@@ -1,0 +1,30 @@
+syntax = "proto3";
+
+package determined.api.v1;
+option go_package = "github.com/determined-ai/determined/proto/pkg/apiv1";
+
+import "determined/modelmetrics/v1/modelmetrics.proto";
+
+// Request for create a validation metrics.
+message CreateValidationMetricsRequest {
+  // The desired validation metrics fields and values.
+  determined.modelmetrics.v1.ValidationMetrics validation_metrics = 1;
+}
+
+// Response to CreateValidationMetricsRequest.
+message CreateValidationMetricsResponse {
+  // The updated validation metrics.
+  determined.modelmetrics.v1.ValidationMetrics validation_metrics = 1;
+}
+
+// Request for patch a validation metrics.
+message PatchValidationMetricsRequest {
+  // The desired validation metrics fields and values.
+  determined.modelmetrics.v1.ValidationMetrics validation_metrics = 1;
+}
+
+// Response to PatchValidationMetricsRequest.
+message PatchValidationMetricsResponse {
+  // The patched validation metrics.
+  determined.modelmetrics.v1.ValidationMetrics validation_metrics = 1;
+}

--- a/proto/src/determined/modelmetrics/v1/modelmetrics.proto
+++ b/proto/src/determined/modelmetrics/v1/modelmetrics.proto
@@ -1,0 +1,85 @@
+syntax = "proto3";
+
+package determined.modelmetrics.v1;
+option go_package = "github.com/determined-ai/determined/proto/pkg/modelmetricsv1";
+
+import "google/protobuf/struct.proto";
+import "google/protobuf/timestamp.proto";
+import "protoc-gen-swagger/options/annotations.proto";
+
+// The current state of the metrics.
+enum State {
+  // The state of the metrics is unknown.
+  STATE_UNSPECIFIED = 0;
+  // The metrics is in an active state.
+  STATE_ACTIVE = 1;
+  // The metrics is persisted to checkpoint storage.
+  STATE_COMPLETED = 2;
+  // The metrics errored.
+  STATE_ERROR = 3;
+  // The metrics has been deleted.
+  STATE_DELETED = 4;
+}
+
+// TrainingMetrics represents model training metrics.
+message TrainingMetrics {
+  option (grpc.gateway.protoc_gen_swagger.options.openapiv2_schema) = {
+    json_schema: {
+      required: [
+        "experiment_id",
+        "trial_id",
+        "step_id",
+        "start_batch",
+        "end_batch",
+        "state"
+      ]
+    }
+  };
+  // The UUID.
+  string uuid = 1;
+  // The ID of the experiment that created this.
+  int32 experiment_id = 2;
+  // The ID of the trial that created this.
+  int32 trial_id = 3;
+  // The ID of the step in the trial.
+  int32 step_id = 4;
+  // The state.
+  State state = 5;
+  // Start batch number of training metrics, equivalent to prior processed
+  // batches for checkpoints and validations.
+  int32 start_batch = 6;
+  // End batch number of training metrics, equivalent to total batches
+  // for checkpoints and validations.
+  int32 end_batch = 7;
+  // Timestamp when this began being saved to persistent storage.
+  google.protobuf.Timestamp start_time = 8;
+  // Timestamp when this completed being saved to persistent storage.
+  google.protobuf.Timestamp end_time = 9;
+  // Metrics calculated on the training set.
+  google.protobuf.Struct metrics = 10;
+}
+
+// ValidationMetrics represents model validation metrics.
+message ValidationMetrics {
+  option (grpc.gateway.protoc_gen_swagger.options.openapiv2_schema) = {
+    json_schema: {
+      required: [ "experiment_id", "trial_id", "total_batches", "state" ]
+    }
+  };
+  // The UUID.
+  string uuid = 1;
+  // The ID of the experiment that created this.
+  int32 experiment_id = 2;
+  // The ID of the trial that created this.
+  int32 trial_id = 3;
+  // The state.
+  State state = 4;
+  // batch number of validation metrics.
+  int32 total_batches = 5;
+  // Timestamp when this began being saved to persistent storage.
+  google.protobuf.Timestamp start_time = 6;
+  // Timestamp when this completed being saved to persistent storage.
+  google.protobuf.Timestamp end_time = 7;
+  // Metrics calculated on the validation set.
+  google.protobuf.Struct metrics = 8;
+}


### PR DESCRIPTION
## Description

Add internal restful APIs in the master. Those APIs are used for registering saved checkpoints and both training and validation metrics.

## Test Plan

Tested it manually by launch new experiments, pausing them, checking if the WebUI and CLI display the experiments correctly.

## Commentary (optional)

N/A

## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
