### PR TITLE
fix: rolling back trials when restarting a trial [DET-4994]

### DIFF
--- a/master/internal/trial_workload_sequencer.go
+++ b/master/internal/trial_workload_sequencer.go
@@ -373,7 +373,7 @@ func (s *trialWorkloadSequencer) RollBackSequencer() (int, error) {
 	if err != nil {
 		return 0, errors.Wrap(err, "cannot roll back sequencer")
 	}
-	return wkld.PriorBatchesProcessed, nil
+	return wkld.TotalBatches(), nil
 }
 
 // UpToDate returns if the sequencer has completed all searcher requested operations.


### PR DESCRIPTION
## Description

Fix rolling back trials when restarting a trial. The bug was introduced in [this commit](https://github.com/determined-ai/determined/commit/07be51016588165535e7c1dab58a68746a0ececb), which should use the current active step totalBatches rather than the last completed step.

## Test Plan

Manually tested it

## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
