### PR TITLE
fix: restore trials with operations intact to avoid unintended behavior [DET-4994]

### DIFF
--- a/master/internal/restore.go
+++ b/master/internal/restore.go
@@ -84,7 +84,7 @@ func (m *Master) restoreExperiment(expModel *model.Experiment) error {
 // restoreTrial takes the a searcher.Create and attempts to restore the trial that would be
 // associated with it. On failure, the trial is just reset to the start and errors are logged.
 func (e *experiment) restoreTrial(
-	ctx *actor.Context, op searcher.Create, ckpt *model.Checkpoint,
+	ctx *actor.Context, op searcher.Create, ckpt *model.Checkpoint, ops []searcher.Operation,
 ) (terminal bool) {
 	l := ctx.Log().WithField("request-id", op.RequestID)
 	l.Info("restoring trial")
@@ -130,6 +130,7 @@ func (e *experiment) restoreTrial(
 		}
 	}
 	t.replayCreate = trialID != nil && snapshot == nil
+	t.processOperations(ops)
 	ctx.ActorOf(op.RequestID, t)
 	l.Infof("restored trial to the beginning of step %d", t.sequencer.CurStepID)
 	return false

--- a/master/internal/trial_workload_sequencer.go
+++ b/master/internal/trial_workload_sequencer.go
@@ -112,14 +112,8 @@ func (s *trialWorkloadSequencer) WorkloadManagerType() model.WorkloadManagerType
 }
 
 // OperationRequested records an operation requested by the searcher.
-func (s *trialWorkloadSequencer) OperationRequested(op searcher.Runnable) error {
-	switch op := op.(type) {
-	case searcher.Runnable:
-		s.ops = append(s.ops, op)
-	default:
-		return errors.Errorf("illegal workload for trialWorkloadSequencer: %v", op)
-	}
-	return nil
+func (s *trialWorkloadSequencer) OperationRequested(op searcher.Runnable) {
+	s.ops = append(s.ops, op)
 }
 
 // CompleteCachedCheckpoints attempts to complete cached checkpoints that we received previously
@@ -369,11 +363,7 @@ func (s *trialWorkloadSequencer) snapshotState() {
 func (s *trialWorkloadSequencer) RollBackSequencer() (int, error) {
 	s.trialWorkloadSequencerState = *s.LatestSnapshot
 	s.LatestSnapshot = s.trialWorkloadSequencerState.deepCopy()
-	wkld, err := s.Workload()
-	if err != nil {
-		return 0, errors.Wrap(err, "cannot roll back sequencer")
-	}
-	return wkld.PriorBatchesProcessed, nil
+	return s.TotalBatchesProcessed, nil
 }
 
 // UpToDate returns if the sequencer has completed all searcher requested operations.

--- a/master/internal/trial_workload_sequencer_test.go
+++ b/master/internal/trial_workload_sequencer_test.go
@@ -148,10 +148,10 @@ checkpoint_policy: none
 	assert.Assert(t, s.UpToDate())
 
 	// Request a few operations so the sequencer builds its internal desired state.
-	assert.NilError(t, s.OperationRequested(train))
+	s.OperationRequested(train)
 	assert.Assert(t, !s.UpToDate())
-	assert.NilError(t, s.OperationRequested(validate))
-	assert.NilError(t, s.OperationRequested(checkpoint))
+	s.OperationRequested(validate)
+	s.OperationRequested(checkpoint)
 
 	// Check that workload() returns an error before setTrialID is set
 	_, err := s.Workload()
@@ -299,9 +299,9 @@ func TestTrialWorkloadSequencerFailedWorkloads(t *testing.T) {
 	s := newTrialWorkloadSequencer(experiment, create, nil)
 	s.SetTrialID(1)
 
-	assert.NilError(t, s.OperationRequested(
+	s.OperationRequested(
 		searcher.NewTrain(create.RequestID, model.NewLength(model.Batches, 500)),
-	))
+	)
 
 	op, _, err := s.WorkloadCompleted(workload.CompletedMessage{
 		Workload: workload.Workload{
@@ -348,9 +348,9 @@ func TestTrialWorkloadSequencerOperationLessThanBatchSize(t *testing.T) {
 	s.SetTrialID(1)
 
 	train := searcher.NewTrain(create.RequestID, model.NewLength(model.Records, 24))
-	assert.NilError(t, s.OperationRequested(
+	s.OperationRequested(
 		train,
-	))
+	)
 
 	op, _, err := s.WorkloadCompleted(workload.CompletedMessage{
 		Workload: workload.Workload{


### PR DESCRIPTION
This commit changes how trial operations snapshotted in the experiment state are given to trials during a restore. Previous, the experiment would sent all these operations to trials after starting, now they are added to the trial before it is restored.

## Description

<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan
- [x] run adaptive chaos and restore it,
<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)
The only part really necessary for this fix is the bit that changes how we were calling `s.Workload()` in `t.reset()`. The other bits are because, the way restart was written, we were starting a trial in an invalid state (without its operations) which I realized later (now) is totally wrong.
<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234