### PR TITLE
fix: k8s resource pool API response should not have nil field [DET-4989]

### DIFF
--- a/docs/release-notes/1979-k8s-cluster-page.txt
+++ b/docs/release-notes/1979-k8s-cluster-page.txt
@@ -1,0 +1,5 @@
+:orphan:
+
+**Bug Fixes**
+
+-  Kubernetes: Fix a bug that caused the Cluster page to not render when using a Kubernetes cluster.

--- a/docs/release-notes/1979-k8s-cluster-page.txt
+++ b/docs/release-notes/1979-k8s-cluster-page.txt
@@ -2,4 +2,5 @@
 
 **Bug Fixes**
 
--  Kubernetes: Fix a bug that caused the Cluster page to not render when using a Kubernetes cluster.
+-  Kubernetes: Fix a bug that caused the Cluster page to not render when
+   using a Kubernetes cluster.

--- a/master/internal/resourcemanagers/kubernetes_resource_manager.go
+++ b/master/internal/resourcemanagers/kubernetes_resource_manager.go
@@ -140,7 +140,7 @@ func (k *kubernetesResourceManager) summarizeDummyResourcePool(
 		Location:                     "kubernetes",
 		ImageId:                      "",
 		InstanceType:                 "kubernetes",
-		Details:                      nil,
+		Details:                      &resourcepoolv1.ResourcePoolDetail{},
 	}
 }
 


### PR DESCRIPTION
## Description

Change the "details" field in the Resource Pool GET API to be an empty struct instead of nil to be consistent with the non-kubernetes behavior. This fixes a bug where the Cluster page in the WebUI would crash because it expects that field to exist in the response.


## Test Plan

Manually tested on a k8s cluster.

## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
