### PR TITLE
fix: fix deprecation warning on using ABCs from 'collections'

### DIFF
--- a/common/determined_common/api/experiment.py
+++ b/common/determined_common/api/experiment.py
@@ -38,7 +38,7 @@ def trial_logs(
     level_above: Optional[str] = None,
     timestamp_before: Optional[str] = None,
     timestamp_after: Optional[str] = None,
-) -> collections.Iterable:
+) -> collections.abc.Iterable:
     def to_levels_above(level: str) -> List[str]:
         # We should just be using the generated client instead and this is why.
         levels = [

--- a/common/determined_common/context.py
+++ b/common/determined_common/context.py
@@ -85,7 +85,7 @@ class Context:
         return self._size
 
     @property
-    def entries(self) -> collections.ValuesView:
+    def entries(self) -> collections.abc.ValuesView:
         return self._items.values()
 
     def add_item(self, entry: ContextItem) -> None:


### PR DESCRIPTION
## Description

<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->

There are 2 deprecated warnings in determined-common:
```
DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc'
is deprecated since Python 3.3, and in 3.9 it will stop working
```
Solution: Need use `collections.abc.` instead of `collections.`

## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.
-->
` make -C common test` without any deprecated warnings on `collections.abc`

## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234