### PR TITLE
ci: bump gke version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1433,7 +1433,7 @@ jobs:
         default: 1
       gke-version:
         type: string
-        default: "1.17.14-gke.1600"
+        default: "1.17.15-gke.800"
       machine-type:
         type: string
         default: "n1-standard-8"


### PR DESCRIPTION
cloud.google.com/kubernetes-engine/docs/release-notes#february_17_2021_2021-r6