### PR TITLE
chore:  exclude useless GPU type in resource pool API [DET-5079]

### DIFF
--- a/master/internal/resourcemanagers/agent_resource_manager.go
+++ b/master/internal/resourcemanagers/agent_resource_manager.go
@@ -225,11 +225,17 @@ func (a *agentResourceManager) createResourcePoolSummary(
 			location = pool.Provider.GCP.Zone
 			imageID = pool.Provider.GCP.BootDiskSourceImage
 
-			instanceType = fmt.Sprintf("%s, %dx%s",
-				pool.Provider.GCP.InstanceType.MachineType,
-				pool.Provider.GCP.InstanceType.GPUNum,
-				pool.Provider.GCP.InstanceType.GPUType,
-			)
+
+			if pool.Provider.GCP.InstanceType.GPUNum == 0 {
+				instanceType = pool.Provider.GCP.InstanceType.MachineType
+			} else {
+				instanceType = fmt.Sprintf("%s, %d x %s",
+					pool.Provider.GCP.InstanceType.MachineType,
+					pool.Provider.GCP.InstanceType.GPUNum,
+					pool.Provider.GCP.InstanceType.GPUType,
+				)
+			}
+
 		}
 	}
 

--- a/master/internal/resourcemanagers/agent_resource_manager.go
+++ b/master/internal/resourcemanagers/agent_resource_manager.go
@@ -225,7 +225,6 @@ func (a *agentResourceManager) createResourcePoolSummary(
 			location = pool.Provider.GCP.Zone
 			imageID = pool.Provider.GCP.BootDiskSourceImage
 
-
 			if pool.Provider.GCP.InstanceType.GPUNum == 0 {
 				instanceType = pool.Provider.GCP.InstanceType.MachineType
 			} else {

--- a/master/internal/resourcemanagers/agent_resource_manager.go
+++ b/master/internal/resourcemanagers/agent_resource_manager.go
@@ -234,7 +234,6 @@ func (a *agentResourceManager) createResourcePoolSummary(
 					pool.Provider.GCP.InstanceType.GPUType,
 				)
 			}
-
 		}
 	}
 


### PR DESCRIPTION
## Description

In GCP, when the number of GPUs is zero, do not include the GPU type as part of the instance type string. This avoids confusing strings such as "n1-standard-4, 0xnvidia-tesla-k80".

Also adds a space between the number of GPUs and the type so that it is easier to read.


## Test Plan


## Commentary (optional)

This PR seems too trivial to deserve release notes. LMK if you disagree.


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.

