### PR TITLE
fix: detect parcoords filter removal properly

### DIFF
--- a/docs/release-notes/2022-fix-parcoords-filters.txt
+++ b/docs/release-notes/2022-fix-parcoords-filters.txt
@@ -1,0 +1,6 @@
+:orphan:
+
+**Bug Fixes**
+
+-  WebUI: Fix the issue of removed parallel coordinates filters from
+   coming back during a re-render.

--- a/webui/react/src/components/ParallelCoordinates.tsx
+++ b/webui/react/src/components/ParallelCoordinates.tsx
@@ -164,20 +164,20 @@ const ParallelCoordinates: React.FC<Props> = ({
         const hpIndex = parseInt(matches[1]);
         const hpKey = dimensions[hpIndex].label;
 
-        if (constraint) {
-          setConstraints(prev => {
-            const newConstraints = clone(prev);
+        setConstraints(prev => {
+          const newConstraints = clone(prev);
 
-            if (isNumber(constraint[0]) && isNumber(constraint[1]) &&
-                Math.abs(constraint[0] - constraint[1]) > CONSTRAINT_REMOVE_THRESHOLD) {
-              newConstraints[hpKey] = constraint;
-            } else if (constraint[0] !== constraint[1]) {
-              newConstraints[hpKey] = constraint;
-            }
+          if (constraint == null) {
+            delete newConstraints[hpKey];
+          } else if (isNumber(constraint[0]) && isNumber(constraint[1]) &&
+              Math.abs(constraint[0] - constraint[1]) > CONSTRAINT_REMOVE_THRESHOLD) {
+            newConstraints[hpKey] = constraint;
+          } else if (constraint[0] !== constraint[1]) {
+            newConstraints[hpKey] = constraint;
+          }
 
-            return newConstraints;
-          });
-        }
+          return newConstraints;
+        });
       }
     });
 


### PR DESCRIPTION
## Description

HP Parallel Coordinates filters that are previously removed come back during a re-render. Update the chart to detect filter removal and properly save the removal state.

<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan

- [ ] Create some HP parcoords filters and click on them to remove them. Wait about 10 sec+ to ensure they don't come back on a re-render.

<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234