### PR TITLE
feat: add endpoint for raw resource allocation information [DET-5043]

### DIFF
--- a/master/static/srv/allocation_raw.sql
+++ b/master/static/srv/allocation_raw.sql
@@ -1,0 +1,79 @@
+WITH const AS (
+    SELECT
+        $1 :: timestamp AS day_start,
+        $2 :: timestamp AS day_end
+),
+-- Workloads that had any overlap with the target interval, with their start and end times bounded
+-- to the interval.
+workloads AS (
+    SELECT
+        all_workloads.trial_id,
+        all_workloads.kind,
+        all_workloads.start_time,
+        all_workloads.end_time,
+        extract(
+            epoch
+            FROM
+                CASE
+                    WHEN all_workloads.end_time IS NULL THEN const.day_end
+                    WHEN all_workloads.end_time > const.day_end THEN const.day_end
+                    ELSE all_workloads.end_time
+                END - CASE
+                    WHEN all_workloads.start_time < const.day_start THEN const.day_start
+                    ELSE all_workloads.start_time
+                END
+        ) AS seconds
+    FROM
+        (
+            -- Summarize the common relevant fields from all workload types. We might want this to
+            -- be a CTE, but I think that would cause PostgreSQL <12 to insert an optimization fence
+            -- and have to fully scan all three tables, which could be bad.
+            SELECT
+                'step' AS kind,
+                trial_id,
+                start_time,
+                end_time
+            FROM
+                steps
+            UNION ALL
+            SELECT
+                'validation' AS kind,
+                trial_id,
+                start_time,
+                end_time
+            FROM
+                validations
+            UNION ALL
+            SELECT
+                'checkpoint' AS kind,
+                trial_id,
+                start_time,
+                end_time
+            FROM
+                checkpoints
+        ) AS all_workloads,
+        const
+    WHERE
+        all_workloads.start_time <= const.day_end
+        AND coalesce(all_workloads.end_time, const.day_end) >= const.day_start
+)
+SELECT
+    trials.experiment_id,
+    workloads.kind,
+    users.username,
+    experiments.config -> 'resources' ->> 'slots_per_trial' AS slots,
+    experiments.config -> 'labels' AS labels,
+    workloads.start_time,
+    workloads.end_time,
+    workloads.seconds
+FROM
+    workloads,
+    trials,
+    experiments,
+    users
+WHERE
+    workloads.trial_id = trials.id
+    AND trials.experiment_id = experiments.id
+    AND experiments.owner_id = users.id
+ORDER BY
+    start_time

--- a/proto/src/determined/api/v1/api.proto
+++ b/proto/src/determined/api/v1/api.proto
@@ -829,4 +829,12 @@ service Determined {
       tags: "Internal"
     };
   }
+
+  // Get a detailed view of resource allocation during the given time period.
+  rpc ResourceAllocationRaw(ResourceAllocationRawRequest)
+      returns (ResourceAllocationRawResponse) {
+    option (google.api.http) = {
+      get: "/api/v1/resources/allocation/raw"
+    };
+  }
 }

--- a/proto/src/determined/api/v1/master.proto
+++ b/proto/src/determined/api/v1/master.proto
@@ -4,9 +4,11 @@ package determined.api.v1;
 option go_package = "github.com/determined-ai/determined/proto/pkg/apiv1";
 
 import "google/protobuf/struct.proto";
+import "google/protobuf/timestamp.proto";
 import "protoc-gen-swagger/options/annotations.proto";
 
 import "determined/log/v1/log.proto";
+import "determined/master/v1/master.proto";
 
 // Get master information.
 message GetMasterRequest {}
@@ -67,4 +69,17 @@ message MasterLogsRequest {
 message MasterLogsResponse {
   // The log entry.
   determined.log.v1.LogEntry log_entry = 1;
+}
+
+// Get a detailed view of resource allocation during the given time period.
+message ResourceAllocationRawRequest {
+  // The start of the period to consider.
+  google.protobuf.Timestamp start_date = 1;
+  // The end of the period to consider.
+  google.protobuf.Timestamp end_date = 2;
+}
+// Response to ResourceAllocationRawRequest.
+message ResourceAllocationRawResponse {
+  // An entry summarizing one workload.
+  repeated determined.master.v1.ResourceAllocationRawEntry resource_entry = 1;
 }

--- a/proto/src/determined/master/v1/master.proto
+++ b/proto/src/determined/master/v1/master.proto
@@ -1,0 +1,27 @@
+syntax = "proto3";
+
+package determined.master.v1;
+option go_package = "github.com/determined-ai/determined/proto/pkg/masterv1";
+
+import "google/protobuf/timestamp.proto";
+
+// One instance of slots in the cluster being allocated.
+message ResourceAllocationRawEntry {
+  // The kind of workload being run during this allocation (step, checkpoint, or
+  // validation).
+  string kind = 1;
+  // The time at which the allocation began.
+  google.protobuf.Timestamp start_time = 2;
+  // The time at which the allocation ended.
+  google.protobuf.Timestamp end_time = 3;
+  // The ID of the experiment the allocation is a part of.
+  int32 experiment_id = 4;
+  // The username of the user who ran the experiment.
+  string username = 5;
+  // The labels assigned to the experiment.
+  repeated string labels = 6;
+  // The length in time of the allocation.
+  float seconds = 7;
+  // The number of slots used by the allocation.
+  int32 slots = 8;
+}


### PR DESCRIPTION
## Description

The new endpoint groups up all steps, checkpoints, and validations to
give information about slot time used in a given time period.

## Test Plan

- [x] have some workloads in the database, play around with various queries

## Commentary (optional)

The CSV endpoint needs to do something to deal with multiple labels. Right now it separates them with `|` and adds some escaping. Not sure if there's a standard thing to do here. Quoting?