### PR TITLE
chore: remove petname dependency

### DIFF
--- a/common/determined_common/schemas/expconf/_v0.py
+++ b/common/determined_common/schemas/expconf/_v0.py
@@ -2,8 +2,6 @@ import enum
 import time
 from typing import Any, Dict, List, Optional, TypeVar, Union
 
-import petname
-
 from determined_common import schemas
 
 
@@ -833,7 +831,7 @@ class ExperimentConfigV0(schemas.SchemaBase):
 
     def runtime_defaults(self) -> None:
         if self.description is None:
-            self.description = f"Experiment ({petname.Generate(3)})"
+            self.description = "Experiment (really-bad-petname)"
 
 
 # Test Structs Below:

--- a/common/setup.py
+++ b/common/setup.py
@@ -20,7 +20,6 @@ setup(
         "hdfs>=2.2.2",
         "lomond>=0.3.3",
         "pathspec>=0.6.0",
-        "petname",
         "ruamel.yaml>=0.15.78",
         "simplejson",
         "termcolor>=1.1.0",


### PR DESCRIPTION
Avoid image complications by using dummy values where petname would be
used.

This is ok since the values in question won't be user-facing until the
python SDK lands.