### PR TITLE
docs: fix version of CUDA 11 image

### DIFF
--- a/docs/how-to/custom-env.txt
+++ b/docs/how-to/custom-env.txt
@@ -132,7 +132,7 @@ This can be configured in your experiment configuration like below:
 .. code:: yaml
 
    environment:
-     image: "determinedai/environments:cuda-11.0-pytorch-1.7-tf-2.4-gpu-0.8.0"
+     image: "determinedai/environments:cuda-11.0-pytorch-1.7-tf-2.4-gpu-0.9.0"
 
 Other Images
 ============


### PR DESCRIPTION
We never released an 0.8.0 version of the CUDA 11 image. Double-checked the new string is correct by grepping against some recently-run tests.