### PR TITLE
fix: correct trial log scrolling behaviors [DET-5096, DET-5097]

### DIFF
--- a/docs/release-notes/2038-fix-scroll-to-end-trial-logs.txt
+++ b/docs/release-notes/2038-fix-scroll-to-end-trial-logs.txt
@@ -1,0 +1,7 @@
+:orphan:
+
+**Bug Fixes**
+
+-  WebUI: In trial logs, fixed the issue of clicking on `Scroll-to-End`
+   button while already on tailing mode causing the logs to clear and
+   remain cleared.

--- a/webui/react/src/components/LogViewerTimestamp.tsx
+++ b/webui/react/src/components/LogViewerTimestamp.tsx
@@ -239,18 +239,20 @@ const LogViewerTimestamp: React.FC<Props> = ({
   }, [ onDownloadClick ]);
 
   const handleEnableTailing = useCallback(() => {
+    if (direction === DIRECTIONS.TAILING) return;
     clearLogs();
     setDirection(DIRECTIONS.TAILING);
-  }, [ clearLogs ]);
+  }, [ clearLogs, direction ]);
 
   const handleFullScreen = useCallback(() => {
     if (baseRef.current && screenfull.isEnabled) screenfull.toggle();
   }, []);
 
   const handleScrollToTop = useCallback(() => {
+    if (direction === DIRECTIONS.OLDEST) return;
     clearLogs();
     setDirection(DIRECTIONS.OLDEST);
-  }, [ clearLogs ]);
+  }, [ clearLogs, direction ]);
 
   const onItemsRendered =
     useCallback(({ visibleStartIndex, visibleStopIndex }: ListOnItemsRenderedProps) => {


### PR DESCRIPTION
## Description

In trial logs, when clicking on scroll-to-end while already in the tailing mode, the log viewer gets cleared but it does not attempt to load the logs again because the direction is already set to `TAILING`. The `direction` value doesn't change, which in turn does not trigger an API call. The same is true for the `OLDEST` behavior.

<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan

- [ ] Clicking on `Scroll-to-end` button multiple times should work.
- [ ] Clicking on `Scroll-to-oldest` button multiple times should work.

<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234