### PR TITLE
fix: support trial filtering based on categorical hps [DET-5107]

### DIFF
--- a/webui/react/src/components/ParallelCoordinates.tsx
+++ b/webui/react/src/components/ParallelCoordinates.tsx
@@ -90,6 +90,7 @@ const ParallelCoordinates: React.FC<Props> = ({
         const label = truncate(key, MAX_LABEL_LENGTH);
         const hpDimension: Record<string, unknown> = {
           label,
+          multiselect: false,
           range: dimension.range,
           values: data[key],
         };

--- a/webui/react/src/components/ParallelCoordinates.tsx
+++ b/webui/react/src/components/ParallelCoordinates.tsx
@@ -174,12 +174,10 @@ const ParallelCoordinates: React.FC<Props> = ({
 
         // Translate constraints back to categorical values.
         if (dim.categories && range && isNumber(range[0]) && isNumber(range[1])) {
+          // Create a list of acceptable categorical values.
           const minIndex = Math.round((Math.ceil(range[0]) - 1) / 2);
           const maxIndex = Math.round((Math.floor(range[1]) - 1) / 2);
-          const values = [];
-
-          // Create a list of acceptable categorical values.
-          for (let i = minIndex; i <= maxIndex; i++) values.push(dim.categories[i]);
+          const values = dim.categories.slice(minIndex, maxIndex + 1);
           constraint.values = values;
         }
 

--- a/webui/react/src/components/ParallelCoordinates.tsx
+++ b/webui/react/src/components/ParallelCoordinates.tsx
@@ -38,7 +38,7 @@ export interface Dimension {
 
 export interface Constraint {
   range: Range;
-  valueRange: Range<number>;
+  values?: Primitive[];
 }
 
 export const dimensionTypeMap: Record<ExperimentHyperParamType, DimensionType> = {
@@ -169,15 +169,17 @@ const ParallelCoordinates: React.FC<Props> = ({
         const dimIndex = parseInt(matches[1]);
         const dim = dimensions[dimIndex];
         const dimKey = dim.label;
-        const constraint = { range, valueRange: range };
+        const constraint: Constraint = { range };
 
         // Translate constraints back to categorical values.
         if (dim.categories && range && isNumber(range[0]) && isNumber(range[1])) {
           const minIndex = Math.round((Math.ceil(range[0]) - 1) / 2);
           const maxIndex = Math.round((Math.floor(range[1]) - 1) / 2);
-          const minValue = dim.categories[minIndex];
-          const maxValue = dim.categories[maxIndex];
-          constraint.valueRange = [ minValue, maxValue ];
+          const values = [];
+
+          // Create a list of acceptable categorical values.
+          for (let i = minIndex; i <= maxIndex; i++) values.push(dim.categories[i]);
+          constraint.values = values;
         }
 
         setConstraints(prev => {

--- a/webui/react/src/components/ParallelCoordinates.tsx
+++ b/webui/react/src/components/ParallelCoordinates.tsx
@@ -26,7 +26,7 @@ interface Props {
   data: Record<string, Primitive[]>;
   dimensions: Dimension[];
   id?: string;
-  onFilter?: (constraints: Record<string, Range>) => void;
+  onFilter?: (constraints: Record<string, Constraint>) => void;
 }
 
 export interface Dimension {
@@ -34,6 +34,11 @@ export interface Dimension {
   label: string;
   range?: Range;
   type: DimensionType,
+}
+
+export interface Constraint {
+  range: Range;
+  valueRange: Range<number>;
 }
 
 export const dimensionTypeMap: Record<ExperimentHyperParamType, DimensionType> = {
@@ -68,7 +73,7 @@ const ParallelCoordinates: React.FC<Props> = ({
   const chartRef = useRef<HTMLDivElement>(null);
   const resize = useResize(chartRef);
   const [ id ] = useState(props.id ? props.id : generateAlphaNumeric());
-  const [ constraints, setConstraints ] = useState<Record<string, Range>>({});
+  const [ constraints, setConstraints ] = useState<Record<string, Constraint>>({});
 
   const colorValues = useMemo(() => {
     if (!colorScaleKey || !Array.isArray(data[colorScaleKey])) return undefined;
@@ -110,7 +115,7 @@ const ParallelCoordinates: React.FC<Props> = ({
         }
 
         if (constraints[dimension.label] != null) {
-          hpDimension.constraintrange = clone(constraints[dimension.label]);
+          hpDimension.constraintrange = clone(constraints[dimension.label].range);
         }
 
         return hpDimension;
@@ -160,20 +165,31 @@ const ParallelCoordinates: React.FC<Props> = ({
       const regex = /^dimensions\[(\d+)\]\.constraintrange/i;
       const matches = keys[0].match(regex);
       if (Array.isArray(matches) && matches.length === 2) {
-        const constraint: Range = data[0][keys[0]] ? data[0][keys[0]][0] : undefined;
-        const hpIndex = parseInt(matches[1]);
-        const hpKey = dimensions[hpIndex].label;
+        const range: Range = data[0][keys[0]] ? data[0][keys[0]][0] : undefined;
+        const dimIndex = parseInt(matches[1]);
+        const dim = dimensions[dimIndex];
+        const dimKey = dim.label;
+        const constraint = { range, valueRange: range };
+
+        // Translate constraints back to categorical values.
+        if (dim.categories && range && isNumber(range[0]) && isNumber(range[1])) {
+          const minIndex = Math.round((Math.ceil(range[0]) - 1) / 2);
+          const maxIndex = Math.round((Math.floor(range[1]) - 1) / 2);
+          const minValue = dim.categories[minIndex];
+          const maxValue = dim.categories[maxIndex];
+          constraint.valueRange = [ minValue, maxValue ];
+        }
 
         setConstraints(prev => {
           const newConstraints = clone(prev);
 
-          if (constraint == null) {
-            delete newConstraints[hpKey];
-          } else if (isNumber(constraint[0]) && isNumber(constraint[1]) &&
-              Math.abs(constraint[0] - constraint[1]) > CONSTRAINT_REMOVE_THRESHOLD) {
-            newConstraints[hpKey] = constraint;
-          } else if (constraint[0] !== constraint[1]) {
-            newConstraints[hpKey] = constraint;
+          if (range == null) {
+            delete newConstraints[dimKey];
+          } else if (isNumber(range[0]) && isNumber(range[1]) &&
+              Math.abs(range[0] - range[1]) > CONSTRAINT_REMOVE_THRESHOLD) {
+            newConstraints[dimKey] = constraint;
+          } else if (range[0] !== range[1]) {
+            newConstraints[dimKey] = constraint;
           }
 
           return newConstraints;

--- a/webui/react/src/pages/ExperimentDetails/ExperimentVisualization/HpParallelCoordinates.tsx
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentVisualization/HpParallelCoordinates.tsx
@@ -6,6 +6,7 @@ import Message, { MessageType } from 'components/Message';
 import MetricSelectFilter from 'components/MetricSelectFilter';
 import MultiSelect from 'components/MultiSelect';
 import ParallelCoordinates, {
+  Constraint,
   Dimension, DimensionType, dimensionTypeMap,
 } from 'components/ParallelCoordinates';
 import ResponsiveFilters from 'components/ResponsiveFilters';
@@ -149,7 +150,7 @@ const HpParallelCoordinates: React.FC<Props> = ({
     onMetricChange(metric);
   }, [ onMetricChange, resetData ]);
 
-  const handleChartFilter = useCallback((constraints: Record<string, Range>) => {
+  const handleChartFilter = useCallback((constraints: Record<string, Constraint>) => {
     if (!chartData) return;
 
     // Figure out which trials fit within the user provided constraints.
@@ -158,7 +159,9 @@ const HpParallelCoordinates: React.FC<Props> = ({
       return acc;
     }, {} as Record<number, boolean>);
 
-    Object.entries(constraints).forEach(([ key, range ]) => {
+    Object.entries(constraints).forEach(([ key, constraint ]) => {
+      const range = constraint.valueRange;
+      if (!range) return;
       if (!isNumber(range[0]) || !isNumber(range[1])) return;
       if (!chartData.data[key]) return;
 

--- a/webui/react/src/pages/ExperimentDetails/ExperimentVisualization/HpParallelCoordinates.tsx
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentVisualization/HpParallelCoordinates.tsx
@@ -6,8 +6,7 @@ import Message, { MessageType } from 'components/Message';
 import MetricSelectFilter from 'components/MetricSelectFilter';
 import MultiSelect from 'components/MultiSelect';
 import ParallelCoordinates, {
-  Constraint,
-  Dimension, DimensionType, dimensionTypeMap,
+  Constraint, Dimension, DimensionType, dimensionTypeMap,
 } from 'components/ParallelCoordinates';
 import ResponsiveFilters from 'components/ResponsiveFilters';
 import Section from 'components/Section';

--- a/webui/react/src/pages/ExperimentDetails/ExperimentVisualization/HpParallelCoordinates.tsx
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentVisualization/HpParallelCoordinates.tsx
@@ -21,7 +21,7 @@ import {
   metricTypeParamMap, Primitive, Range,
 } from 'types';
 import { defaultNumericRange, getColorScale, getNumericRange, updateRange } from 'utils/chart';
-import { clone, isNumber } from 'utils/data';
+import { clone } from 'utils/data';
 import { numericSorter } from 'utils/sort';
 import { metricNameToStr } from 'utils/string';
 import { terminalRunStates } from 'utils/types';
@@ -160,14 +160,14 @@ const HpParallelCoordinates: React.FC<Props> = ({
     }, {} as Record<number, boolean>);
 
     Object.entries(constraints).forEach(([ key, constraint ]) => {
-      const range = constraint.valueRange;
-      if (!range) return;
-      if (!isNumber(range[0]) || !isNumber(range[1])) return;
+      if (!constraint) return;
       if (!chartData.data[key]) return;
 
+      const range = constraint.range;
       const values = chartData.data[key];
       values.forEach((value, index) => {
-        if (value >= range[0] && value <= range[1]) return;
+        if (constraint.values && constraint.values.includes(value)) return;
+        if (!constraint.values && value >= range[0] && value <= range[1]) return;
         const trialId = chartData.trialIds[index];
         newFilteredTrialIdMap[trialId] = false;
       });


### PR DESCRIPTION
## Description

Fix issue of categorical hp filtering was not working, so the trial table would remain empty whenever a filter is applied for categorical hps.

The core issue is that categorical hp values are converted to a numerical value to space them out nicely in the parallel coordinates. For example, [ 8, 16, 32 ] categorical values will be converted into [ 2, 4, 6 ] with a range of 1 through 7. 1, 3, 5, 7 are used as spacers to keep each categorical value visually separate. When the user applies a filter to this, the filter constraint comes back as something like [ 1.5, 2.5 ] for filtering on categorical value of 8. Simply need to translate it back to the category.

<img width="1611" alt="Screen Shot 2021-03-04 at 1 54 29 PM" src="https://user-images.githubusercontent.com/220971/110028974-297db980-7cf1-11eb-9819-f095df95dfc4.png">

<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan

- [ ] check to make sure filtering on categorical hps work in HP viz parallel coordinates plot.

<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234