### PR TITLE
fix: detr and deformabledetr e2e tests

### DIFF
--- a/e2e_tests/tests/config.py
+++ b/e2e_tests/tests/config.py
@@ -69,6 +69,12 @@ def make_master_url(suffix: str = "") -> str:
     return "{}://{}:{}/{}".format(MASTER_SCHEME, MASTER_IP, MASTER_PORT, suffix)
 
 
+def set_global_batch_size(config: Dict[Any, Any], batch_size: int) -> Dict[Any, Any]:
+    config = config.copy()
+    config["hyperparameters"]["global_batch_size"] = batch_size
+    return config
+
+
 def set_slots_per_trial(config: Dict[Any, Any], slots: int) -> Dict[Any, Any]:
     config = config.copy()
     config.setdefault("resources", {})

--- a/e2e_tests/tests/nightly/test_distributed.py
+++ b/e2e_tests/tests/nightly/test_distributed.py
@@ -109,6 +109,7 @@ def test_detr_coco_pytorch_distributed() -> None:
 def test_deformabledetr_coco_pytorch_distributed() -> None:
     config = conf.load_config(conf.cv_examples_path("deformabledetr_coco_pytorch/const_fake.yaml"))
     config = conf.set_max_length(config, {"batches": 200})
+    config = conf.set_global_batch_size(config, 2)
     config = conf.set_slots_per_trial(config, 2)
 
     exp.run_basic_test_with_temp_config(

--- a/examples/computer_vision/deformabledetr_coco_pytorch/model_def.py
+++ b/examples/computer_vision/deformabledetr_coco_pytorch/model_def.py
@@ -4,6 +4,7 @@ from attrdict import AttrDict
 import numpy as np
 import sys
 import os
+import copy
 import time
 
 sys.path.append("./ddetr")
@@ -71,9 +72,9 @@ class COCOReducer(MetricReducer):
             coco_evaluator.eval_imgs[iou_type] = np.concatenate(
                 coco_evaluator.eval_imgs[iou_type], 2
             )
-            create_common_coco_eval(
-                coco_eval, coco_evaluator.img_ids, coco_evaluator.eval_imgs[iou_type]
-            )
+            coco_eval.evalImgs = list(coco_evaluator.eval_imgs[iou_type].flatten())
+            coco_eval.params.imgIds = list(coco_evaluator.img_ids)
+            coco_eval._paramsEval = copy.deepcopy(coco_eval.params)
         coco_evaluator.accumulate()
         coco_evaluator.summarize()
 

--- a/examples/computer_vision/detr_coco_pytorch/model_def.py
+++ b/examples/computer_vision/detr_coco_pytorch/model_def.py
@@ -5,6 +5,7 @@ from typing import Any, Dict, Sequence, Union
 from attrdict import AttrDict
 import numpy as np
 import sys
+import copy
 import os
 import time
 
@@ -64,9 +65,9 @@ class COCOReducer(MetricReducer):
             coco_evaluator.eval_imgs[iou_type] = np.concatenate(
                 coco_evaluator.eval_imgs[iou_type], 2
             )
-            create_common_coco_eval(
-                coco_eval, coco_evaluator.img_ids, coco_evaluator.eval_imgs[iou_type]
-            )
+            coco_eval.evalImgs = list(coco_evaluator.eval_imgs[iou_type].flatten())
+            coco_eval.params.imgIds = list(coco_evaluator.img_ids)
+            coco_eval._paramsEval = copy.deepcopy(coco_eval.params)
         coco_evaluator.accumulate()
         coco_evaluator.summarize()
 


### PR DESCRIPTION
## Description
Test for single gpu was broken due to a bug in the custom metric reducer that only affected single gpu eval.  Also changed batch size for distributed deformabledetr test to 2 instead of 1 to allow 1 datapoint per gpu.  

<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan
- [x] Test both single and multi-gpu eval for detr and deformable detr
<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.
-->



<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234