### PR TITLE
ci: print trial logs for timed out e2e_test experiments

### DIFF
--- a/e2e_tests/tests/experiment/experiment.py
+++ b/e2e_tests/tests/experiment/experiment.py
@@ -150,6 +150,9 @@ def wait_for_experiment_state(
         time.sleep(1)
 
     else:
+        if target_state == "COMPLETED":
+            cancel_experiment(experiment_id)
+            report_failed_experiment(experiment_id, "CANCELED")
         pytest.fail(
             "Experiment did not reach target state {} after {} seconds".format(
                 target_state, max_wait_secs
@@ -367,15 +370,16 @@ def report_failed_experiment(experiment_id: int, state: str) -> None:
     trials = experiment_trials(experiment_id)
     active_trials = [t for t in trials if t["state"] == "ACTIVE"]
     error_trials = [t for t in trials if t["state"] == "ERROR"]
+    canceled_trials = [t for t in trials if t["state"] == "CANCELED"]
 
     print(
-        "Experiment {}: {} trials, {} active trials, {} failed trials".format(
-            experiment_id, len(trials), len(active_trials), len(error_trials)
+        "Experiment {}: {} trials, {} active trials, {} failed trials, {} canceled trials".format(
+            experiment_id, len(trials), len(active_trials), len(error_trials), len(canceled_trials)
         ),
         file=sys.stderr,
     )
 
-    for trial in error_trials:
+    for trial in error_trials + canceled_trials:
         print_trial_logs(trial["id"])
 
 


### PR DESCRIPTION
## Description
Download trial logs to artifacts directory for e2e tests.  This will make it easier to debug test failures that do not show up in master or agent logs.  
<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->



<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234