### PR TITLE
fix: detr & deformable_detr e2e-test timeout

### DIFF
--- a/examples/computer_vision/deformabledetr_coco_pytorch/const_fake.yaml
+++ b/examples/computer_vision/deformabledetr_coco_pytorch/const_fake.yaml
@@ -70,15 +70,13 @@ bind_mounts:
       container_path: /data
       read_only: false
 
-min_validation_period:
-    batches: 10
 records_per_epoch: 117264
 searcher:
   name: single
   metric: mAP
   smaller_is_better: false
   max_length:
-      batches: 20
+      batches: 100
 resources:
     shm_size: 2000000000
 

--- a/examples/computer_vision/deformabledetr_coco_pytorch/finetune.yaml
+++ b/examples/computer_vision/deformabledetr_coco_pytorch/finetune.yaml
@@ -74,7 +74,7 @@ bind_mounts:
       read_only: false
 
 min_validation_period:
-    batches: 100
+    epochs: 1
 records_per_epoch: 1968
 searcher:
   name: single

--- a/examples/computer_vision/deformabledetr_coco_pytorch/model_def.py
+++ b/examples/computer_vision/deformabledetr_coco_pytorch/model_def.py
@@ -22,7 +22,7 @@ from determined.experimental import Determined
 
 # Deformable DETR imports
 import ddetr.util.misc as utils
-from ddetr.datasets.coco_eval import CocoEvaluator, create_common_coco_eval
+from ddetr.datasets.coco_eval import CocoEvaluator
 from model import build_model
 
 # Experiment dir imports
@@ -74,6 +74,9 @@ class COCOReducer(MetricReducer):
             )
             coco_eval.evalImgs = list(coco_evaluator.eval_imgs[iou_type].flatten())
             coco_eval.params.imgIds = list(coco_evaluator.img_ids)
+            # We need to perform a deepcopy here since this dictionary can be modified in a
+            # custom accumulate call and we don't want that to change coco_eval.params.
+            # See https://github.com/cocodataset/cocoapi/blob/master/PythonAPI/pycocotools/cocoeval.py#L315.
             coco_eval._paramsEval = copy.deepcopy(coco_eval.params)
         coco_evaluator.accumulate()
         coco_evaluator.summarize()

--- a/examples/computer_vision/detr_coco_pytorch/const_fake.yaml
+++ b/examples/computer_vision/detr_coco_pytorch/const_fake.yaml
@@ -54,8 +54,6 @@ bind_mounts:
       container_path: /data
       read_only: false
 
-min_validation_period:
-    batches: 100
 records_per_epoch: 117264
 searcher:
     name: single

--- a/examples/computer_vision/detr_coco_pytorch/model_def.py
+++ b/examples/computer_vision/detr_coco_pytorch/model_def.py
@@ -24,7 +24,7 @@ from determined.pytorch import (
 # DETR imports
 import detr.util.misc as utils
 from detr.datasets import get_coco_api_from_dataset
-from detr.datasets.coco_eval import CocoEvaluator, create_common_coco_eval
+from detr.datasets.coco_eval import CocoEvaluator
 from model import build_model
 
 # Experiment dir imports
@@ -67,6 +67,9 @@ class COCOReducer(MetricReducer):
             )
             coco_eval.evalImgs = list(coco_evaluator.eval_imgs[iou_type].flatten())
             coco_eval.params.imgIds = list(coco_evaluator.img_ids)
+            # We need to perform a deepcopy here since this dictionary can be modified in a
+            # custom accumulate call and we don't want that to change coco_eval.params.
+            # See https://github.com/cocodataset/cocoapi/blob/master/PythonAPI/pycocotools/cocoeval.py#L315.
             coco_eval._paramsEval = copy.deepcopy(coco_eval.params)
         coco_evaluator.accumulate()
         coco_evaluator.summarize()


### PR DESCRIPTION
## Description
Fix e2e tests for detr and deformable_detr by modifying config to run just 1 validation workload instead of the 2 indicated by min_validation_period=100 batches and max_length:200 batches which was causing the time out.  

Also, removed an unused import and clarified a usage of deepcopy.

<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan
- [x] Confirmed test would complete in e2e cluster spun up by circleci.

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234