### PR TITLE
feat: add stopping-based variant of adaptive search [DET-3669]

### DIFF
--- a/docs/release-notes/2061-asha-stopping.txt
+++ b/docs/release-notes/2061-asha-stopping.txt
@@ -1,0 +1,10 @@
+:orphan:
+
+**New Features**
+
+-  Stopping-based Adaptive Search: This release introduces a
+   stopping-based variant of `adaptive` hyperparameter search that will
+   continue training trials by default unless stopped by the algorithm.
+   Compared to the default promotions-based algorithm, the stopping
+   variant will promote to higher rungs faster and does not require
+   fault tolerance since it will not resume stopped trials.

--- a/master/pkg/model/defaults.go
+++ b/master/pkg/model/defaults.go
@@ -72,6 +72,7 @@ func DefaultExperimentConfig(taskContainerDefaults *TaskContainerDefaultsConfig)
 				SmallerIsBetter:     true,
 				Divisor:             4,
 				MaxConcurrentTrials: 0,
+				StopOnce:            false,
 			},
 			AdaptiveASHAConfig: &AdaptiveASHAConfig{
 				SmallerIsBetter:     true,
@@ -79,6 +80,7 @@ func DefaultExperimentConfig(taskContainerDefaults *TaskContainerDefaultsConfig)
 				Mode:                StandardMode,
 				MaxRungs:            5,
 				MaxConcurrentTrials: 0,
+				StopOnce:            false,
 			},
 			PBTConfig: &PBTConfig{
 				SmallerIsBetter: true,

--- a/master/pkg/model/searcher_config.go
+++ b/master/pkg/model/searcher_config.go
@@ -151,6 +151,7 @@ type AsyncHalvingConfig struct {
 	MaxTrials           int     `json:"max_trials"`
 	Divisor             float64 `json:"divisor"`
 	MaxConcurrentTrials int     `json:"max_concurrent_trials"`
+	StopOnce            bool    `json:"stop_once"`
 }
 
 // Validate implements the check.Validatable interface.
@@ -258,6 +259,7 @@ type AdaptiveASHAConfig struct {
 	Mode                AdaptiveMode `json:"mode"`
 	MaxRungs            int          `json:"max_rungs"`
 	MaxConcurrentTrials int          `json:"max_concurrent_trials"`
+	StopOnce            bool         `json:"stop_once"`
 }
 
 // Validate implements the check.Validatable interface.

--- a/master/pkg/searcher/adaptive_asha.go
+++ b/master/pkg/searcher/adaptive_asha.go
@@ -93,8 +93,13 @@ func newAdaptiveASHASearch(config model.AdaptiveASHAConfig) SearchMethod {
 			MaxTrials:           bracketMaxTrials[i],
 			Divisor:             config.Divisor,
 			MaxConcurrentTrials: bracketMaxConcurrentTrials[i],
+			StopOnce:            config.StopOnce,
 		}
-		methods = append(methods, newAsyncHalvingSearch(c))
+		if config.StopOnce {
+			methods = append(methods, newAsyncHalvingStoppingSearch(c))
+		} else {
+			methods = append(methods, newAsyncHalvingSearch(c))
+		}
 	}
 
 	return newTournamentSearch(AdaptiveASHASearch, methods...)

--- a/master/pkg/searcher/adaptive_asha_test.go
+++ b/master/pkg/searcher/adaptive_asha_test.go
@@ -127,3 +127,103 @@ func TestAdaptiveASHASearchMethod(t *testing.T) {
 
 	runValueSimulationTestCases(t, testCases)
 }
+
+func TestAdaptiveASHAStoppingSearchMethod(t *testing.T) {
+	maxConcurrentTrials := 5
+	testCases := []valueSimulationTestCase{
+		{
+			name: "smaller is better",
+			expectedTrials: []predefinedTrial{
+				newConstantPredefinedTrial(toOps("300B V 600B V"), 0.1),
+				newConstantPredefinedTrial(toOps("300B V"), 0.2),
+				newConstantPredefinedTrial(toOps("300B V"), 0.3),
+				newConstantPredefinedTrial(toOps("900B V"), 0.4),
+				newConstantPredefinedTrial(toOps("900B V"), 0.5),
+			},
+			config: model.SearcherConfig{
+				AdaptiveASHAConfig: &model.AdaptiveASHAConfig{
+					Metric:              "error",
+					SmallerIsBetter:     true,
+					MaxLength:           model.NewLengthInBatches(900),
+					MaxTrials:           5,
+					Mode:                model.StandardMode,
+					MaxRungs:            2,
+					Divisor:             3,
+					MaxConcurrentTrials: maxConcurrentTrials,
+					StopOnce:            true,
+				},
+			},
+		},
+		{
+			name: "early exit -- smaller is better",
+			expectedTrials: []predefinedTrial{
+				newConstantPredefinedTrial(toOps("300B V 600B V"), 0.1),
+				newEarlyExitPredefinedTrial(toOps("300B"), 0.2),
+				newConstantPredefinedTrial(toOps("300B V"), 0.3),
+				newConstantPredefinedTrial(toOps("900B V"), 0.4),
+				newConstantPredefinedTrial(toOps("900B V"), 0.5),
+			},
+			config: model.SearcherConfig{
+				AdaptiveASHAConfig: &model.AdaptiveASHAConfig{
+					Metric:              "error",
+					SmallerIsBetter:     true,
+					MaxLength:           model.NewLengthInBatches(900),
+					MaxTrials:           5,
+					Mode:                model.StandardMode,
+					MaxRungs:            2,
+					Divisor:             3,
+					MaxConcurrentTrials: maxConcurrentTrials,
+					StopOnce:            true,
+				},
+			},
+		},
+		{
+			name: "smaller is not better",
+			expectedTrials: []predefinedTrial{
+				newConstantPredefinedTrial(toOps("300B V 600B V"), 0.1),
+				newConstantPredefinedTrial(toOps("300B V 600B V"), 0.2),
+				newConstantPredefinedTrial(toOps("300B V 600B V"), 0.3),
+				newConstantPredefinedTrial(toOps("900B V"), 0.4),
+				newConstantPredefinedTrial(toOps("900B V"), 0.5),
+			},
+			config: model.SearcherConfig{
+				AdaptiveASHAConfig: &model.AdaptiveASHAConfig{
+					Metric:              "error",
+					SmallerIsBetter:     false,
+					MaxLength:           model.NewLengthInBatches(900),
+					MaxTrials:           5,
+					Mode:                model.StandardMode,
+					MaxRungs:            2,
+					Divisor:             3,
+					MaxConcurrentTrials: maxConcurrentTrials,
+					StopOnce:            true,
+				},
+			},
+		},
+		{
+			name: "early exit -- smaller is not better",
+			expectedTrials: []predefinedTrial{
+				newConstantPredefinedTrial(toOps("300B V 600B V"), 0.1),
+				newEarlyExitPredefinedTrial(toOps("300B"), 0.2),
+				newConstantPredefinedTrial(toOps("300B V 600B V"), 0.3),
+				newConstantPredefinedTrial(toOps("900B V"), 0.4),
+				newConstantPredefinedTrial(toOps("900B V"), 0.5),
+			},
+			config: model.SearcherConfig{
+				AdaptiveASHAConfig: &model.AdaptiveASHAConfig{
+					Metric:              "error",
+					SmallerIsBetter:     false,
+					MaxLength:           model.NewLengthInBatches(900),
+					MaxTrials:           5,
+					Mode:                model.StandardMode,
+					MaxRungs:            2,
+					Divisor:             3,
+					MaxConcurrentTrials: maxConcurrentTrials,
+					StopOnce:            true,
+				},
+			},
+		},
+	}
+
+	runValueSimulationTestCases(t, testCases)
+}

--- a/master/pkg/searcher/asha.go
+++ b/master/pkg/searcher/asha.go
@@ -281,8 +281,8 @@ func (s *asyncHalvingSearch) trialExitedEarly(
 			for i, trialMetric := range rung.Metrics {
 				if trialMetric.RequestID == requestID {
 					rung.Metrics = append(rung.Metrics[:i], rung.Metrics[i+1:]...)
+					break
 				}
-				break
 			}
 		}
 		// Add new trial to searcher queue

--- a/master/pkg/searcher/asha_stopping.go
+++ b/master/pkg/searcher/asha_stopping.go
@@ -1,0 +1,259 @@
+package searcher
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+	"sort"
+
+	"github.com/determined-ai/determined/master/pkg/workload"
+
+	"github.com/determined-ai/determined/master/pkg/model"
+)
+
+// AsyncHalvingStoppingSearch implements a modified version of the asynchronous successive
+// halving algorithm (ASHA) that does not require fault tolerance to perform early-stopping.
+// For each trial, after a train and validation workload, the algorithm will decide whether
+// to stop or continue training the trial based on the ranking of the validation metric
+// compared to other trials in a particular rung.  Once a trial has been stopped, it will not
+// be resumed later; this is why the algorithm does not require fault tolerance.
+// The searcher state and config match that of AsyncHalvingSearch but we will only run
+// the stopping based version if StopOnce is true.
+type asyncHalvingStoppingSearch struct {
+	defaultSearchMethod
+	model.AsyncHalvingConfig
+	asyncHalvingSearchState
+}
+
+func newAsyncHalvingStoppingSearch(config model.AsyncHalvingConfig) SearchMethod {
+	rungs := make([]*rung, 0, config.NumRungs)
+	if !config.StopOnce {
+		panic(fmt.Sprintf("stop_once is %t, should not be running stopping-based ASHA", config.StopOnce))
+	}
+	for id := 0; id < config.NumRungs; id++ {
+		// We divide the MaxLength by downsampling rate to get the target units
+		// for a rung.
+		downsamplingRate := math.Pow(config.Divisor, float64(config.NumRungs-id-1))
+		unitsNeeded := max(int(float64(config.MaxLength.Units)/downsamplingRate), 1)
+		rungs = append(rungs,
+			&rung{
+				UnitsNeeded:       model.NewLength(config.Unit(), unitsNeeded),
+				OutstandingTrials: 0,
+			})
+	}
+
+	return &asyncHalvingStoppingSearch{
+		AsyncHalvingConfig: config,
+		asyncHalvingSearchState: asyncHalvingSearchState{
+			Rungs:            rungs,
+			TrialRungs:       make(map[model.RequestID]int),
+			EarlyExitTrials:  make(map[model.RequestID]bool),
+			ClosedTrials:     make(map[model.RequestID]bool),
+			SearchMethodType: ASHASearch,
+		},
+	}
+}
+
+func (s *asyncHalvingStoppingSearch) Snapshot() (json.RawMessage, error) {
+	return json.Marshal(s.asyncHalvingSearchState)
+}
+
+func (s *asyncHalvingStoppingSearch) Restore(state json.RawMessage) error {
+	return json.Unmarshal(state, &s.asyncHalvingSearchState)
+}
+
+// promotions handles bookkeeping of validation metrics and decides whether to continue
+// training the current trial.
+func (r *rung) continueTraining(requestID model.RequestID, metric float64, divisor float64) bool {
+	// Compute cutoff for promotion to next rung to continue training.
+	numPromote := max(int(float64(len(r.Metrics)+1)/divisor), 1)
+
+	// Insert the new trial result in the appropriate place in the sorted list.
+	insertIndex := sort.Search(
+		len(r.Metrics),
+		func(i int) bool { return r.Metrics[i].Metric >= metric },
+	)
+	// We will continue training if trial ranked in top 1/divisor for the rung or
+	// if there are fewere than divisor trials in the rung.
+	promoteNow := insertIndex < numPromote
+
+	r.Metrics = append(r.Metrics, trialMetric{})
+	copy(r.Metrics[insertIndex+1:], r.Metrics[insertIndex:])
+	r.Metrics[insertIndex] = trialMetric{
+		RequestID: requestID,
+		Metric:    metric,
+		Promoted:  promoteNow,
+	}
+
+	return promoteNow
+}
+
+func (s *asyncHalvingStoppingSearch) initialOperations(ctx context) ([]Operation, error) {
+	// The number of initialOperations will control the degree of parallelism
+	// of the search experiment since we guarantee that each validationComplete
+	// call will return a new train workload until we reach MaxTrials.
+
+	// We will use searcher config field if available.
+	// Otherwise we will default to a number of trials that will
+	// guarantee at least one trial at the top rung.
+	var ops []Operation
+	var maxConcurrentTrials int
+
+	if s.MaxConcurrentTrials > 0 {
+		maxConcurrentTrials = min(s.MaxConcurrentTrials, s.MaxTrials)
+	} else {
+		maxConcurrentTrials = max(
+			min(int(math.Pow(s.Divisor, float64(s.NumRungs-1))), s.MaxTrials),
+			1)
+	}
+
+	for trial := 0; trial < maxConcurrentTrials; trial++ {
+		create := NewCreate(
+			ctx.rand, sampleAll(ctx.hparams, ctx.rand), model.TrialWorkloadSequencerType)
+		s.TrialRungs[create.RequestID] = 0
+		ops = append(ops, create)
+		ops = append(ops, NewTrain(create.RequestID, s.Rungs[0].UnitsNeeded))
+		ops = append(ops, NewValidate(create.RequestID))
+	}
+	return ops, nil
+}
+
+func (s *asyncHalvingStoppingSearch) trialCreated(
+	ctx context, requestID model.RequestID) ([]Operation, error) {
+	s.Rungs[0].OutstandingTrials++
+	s.TrialRungs[requestID] = 0
+	return nil, nil
+}
+
+func (s *asyncHalvingStoppingSearch) trialClosed(
+	ctx context, requestID model.RequestID) ([]Operation, error) {
+	s.TrialsCompleted++
+	s.ClosedTrials[requestID] = true
+	return nil, nil
+}
+
+func (s *asyncHalvingStoppingSearch) validationCompleted(
+	ctx context, requestID model.RequestID, validate Validate, metrics workload.ValidationMetrics,
+) ([]Operation, error) {
+	// Extract the relevant metric as a float.
+	metric, err := metrics.Metric(s.Metric)
+	if err != nil {
+		return nil, err
+	}
+	if !s.SmallerIsBetter {
+		metric *= -1
+	}
+
+	return s.promoteAsync(ctx, requestID, metric), nil
+}
+
+func (s *asyncHalvingStoppingSearch) promoteAsync(
+	ctx context, requestID model.RequestID, metric float64,
+) []Operation {
+	// Upon a validation complete, we should return at least one more train&val workload
+	// unless the bracket of successive halving is finished.
+	rungIndex := s.TrialRungs[requestID]
+	rung := s.Rungs[rungIndex]
+	rung.OutstandingTrials--
+	addedTrainWorkload := false
+
+	var ops []Operation
+	// If the trial has completed the top rung's validation, close the trial.
+	if rungIndex == s.NumRungs-1 {
+		rung.Metrics = append(rung.Metrics,
+			trialMetric{
+				RequestID: requestID,
+				Metric:    metric,
+			},
+		)
+
+		if !s.EarlyExitTrials[requestID] {
+			ops = append(ops, NewClose(requestID))
+			s.ClosedTrials[requestID] = true
+		}
+	} else {
+		// This is not the top rung, so do promotions to the next rung.
+		nextRung := s.Rungs[rungIndex+1]
+		promoteTrial := rung.continueTraining(
+			requestID,
+			metric,
+			s.Divisor,
+		)
+		if promoteTrial {
+			s.TrialRungs[requestID] = rungIndex + 1
+			nextRung.OutstandingTrials++
+			if !s.EarlyExitTrials[requestID] {
+				unitsNeeded := max(nextRung.UnitsNeeded.Units-rung.UnitsNeeded.Units, 1)
+				ops = append(ops, NewTrain(requestID, model.NewLength(s.Unit(), unitsNeeded)))
+				ops = append(ops, NewValidate(requestID))
+				addedTrainWorkload = true
+			} else {
+				// We make a recursive call that will behave the same
+				// as if we'd actually run the promoted job and received
+				// the worse possible result in return.
+				return s.promoteAsync(ctx, requestID, ashaExitedMetricValue)
+			}
+		} else {
+			ops = append(ops, NewClose(requestID))
+			s.ClosedTrials[requestID] = true
+		}
+	}
+
+	allTrials := len(s.TrialRungs) - s.InvalidTrials
+	if !addedTrainWorkload && allTrials < s.MaxTrials {
+		create := NewCreate(
+			ctx.rand, sampleAll(ctx.hparams, ctx.rand), model.TrialWorkloadSequencerType)
+		s.TrialRungs[create.RequestID] = 0
+		ops = append(ops, create)
+		ops = append(ops, NewTrain(create.RequestID, s.Rungs[0].UnitsNeeded))
+		ops = append(ops, NewValidate(create.RequestID))
+	}
+
+	return ops
+}
+
+func (s *asyncHalvingStoppingSearch) progress(float64) float64 {
+	allTrials := len(s.Rungs[0].Metrics)
+	// Give ourselves an overhead of 20% of maxTrials when calculating progress.
+	progress := float64(allTrials) / (1.2 * float64(s.MaxTrials))
+	if allTrials == s.MaxTrials {
+		numValidTrials := float64(s.TrialsCompleted) - float64(s.InvalidTrials)
+		progressNoOverhead := numValidTrials / float64(s.MaxTrials)
+		progress = math.Max(progressNoOverhead, progress)
+	}
+	return progress
+}
+
+func (s *asyncHalvingStoppingSearch) trialExitedEarly(
+	ctx context, requestID model.RequestID, exitedReason workload.ExitedReason,
+) ([]Operation, error) {
+	if exitedReason == workload.InvalidHP {
+		var ops []Operation
+		s.EarlyExitTrials[requestID] = true
+		ops = append(ops, NewClose(requestID))
+		s.ClosedTrials[requestID] = true
+		s.InvalidTrials++
+		// Remove metrics associated with InvalidHP trial across all rungs
+		highestRungIndex := s.TrialRungs[requestID]
+		for rungIndex := 0; rungIndex <= highestRungIndex; rungIndex++ {
+			rung := s.Rungs[rungIndex]
+			for i, trialMetric := range rung.Metrics {
+				if trialMetric.RequestID == requestID {
+					rung.Metrics = append(rung.Metrics[:i], rung.Metrics[i+1:]...)
+				}
+				break
+			}
+		}
+		// Add new trial to searcher queue
+		create := NewCreate(
+			ctx.rand, sampleAll(ctx.hparams, ctx.rand), model.TrialWorkloadSequencerType)
+		s.TrialRungs[create.RequestID] = 0
+		ops = append(ops, create)
+		ops = append(ops, NewTrain(create.RequestID, s.Rungs[0].UnitsNeeded))
+		ops = append(ops, NewValidate(create.RequestID))
+		return ops, nil
+	}
+	s.EarlyExitTrials[requestID] = true
+	s.ClosedTrials[requestID] = true
+	return s.promoteAsync(ctx, requestID, ashaExitedMetricValue), nil
+}

--- a/master/pkg/searcher/asha_stopping_test.go
+++ b/master/pkg/searcher/asha_stopping_test.go
@@ -1,0 +1,277 @@
+package searcher
+
+import (
+	"testing"
+
+	"github.com/determined-ai/determined/master/pkg/model"
+)
+
+func TestASHAStoppingSearcherRecords(t *testing.T) {
+	actual := model.AsyncHalvingConfig{
+		Metric: defaultMetric, NumRungs: 3,
+		MaxLength:           model.NewLengthInRecords(576000),
+		SmallerIsBetter:     true,
+		Divisor:             3,
+		MaxTrials:           12,
+		StopOnce:            true,
+		MaxConcurrentTrials: 2,
+	}
+	// Stopping-based ASHA will only promote if a trial is in top 1/3 of trials in the rung or if
+	// there have been no promotions so far.  Since trials cannot be restarted and metrics increase
+	// for later trials, only the first trial will be promoted and all others will be stopped on
+	// the first rung.  See continueTraining method in asha_stopping.go for the logic.
+	expected := [][]Runnable{
+		toOps("64000R V 128000R V 384000R V"),
+		toOps("64000R V"), toOps("64000R V"), toOps("64000R V"),
+		toOps("64000R V"), toOps("64000R V"), toOps("64000R V"),
+		toOps("64000R V"), toOps("64000R V"), toOps("64000R V"),
+		toOps("64000R V"), toOps("64000R V"),
+	}
+	checkSimulation(t, newAsyncHalvingStoppingSearch(actual), nil, TrialIDMetric, expected)
+}
+
+func TestASHAStoppingSearcherBatches(t *testing.T) {
+	actual := model.AsyncHalvingConfig{
+		Metric: defaultMetric, NumRungs: 3,
+		MaxLength:           model.NewLengthInBatches(9000),
+		SmallerIsBetter:     true,
+		Divisor:             3,
+		MaxTrials:           12,
+		StopOnce:            true,
+		MaxConcurrentTrials: 2,
+	}
+	expected := [][]Runnable{
+		toOps("1000B V 2000B V 6000B V"),
+		toOps("1000B V"), toOps("1000B V"), toOps("1000B V"),
+		toOps("1000B V"), toOps("1000B V"), toOps("1000B V"),
+		toOps("1000B V"), toOps("1000B V"), toOps("1000B V"),
+		toOps("1000B V"), toOps("1000B V"),
+	}
+	checkSimulation(t, newAsyncHalvingStoppingSearch(actual), nil, TrialIDMetric, expected)
+}
+
+func TestASHAStoppingSearcherEpochs(t *testing.T) {
+	actual := model.AsyncHalvingConfig{
+		Metric: defaultMetric, NumRungs: 3,
+		MaxLength:           model.NewLengthInEpochs(12),
+		SmallerIsBetter:     true,
+		Divisor:             3,
+		MaxTrials:           12,
+		StopOnce:            true,
+		MaxConcurrentTrials: 2,
+	}
+	expected := [][]Runnable{
+		toOps("1E V 3E V 8E V"),
+		toOps("1E V"), toOps("1E V"), toOps("1E V"),
+		toOps("1E V"), toOps("1E V"), toOps("1E V"),
+		toOps("1E V"), toOps("1E V"), toOps("1E V"),
+		toOps("1E V"), toOps("1E V"),
+	}
+	checkSimulation(t, newAsyncHalvingStoppingSearch(actual), nil, TrialIDMetric, expected)
+}
+
+func TestASHAStoppingSearchMethod(t *testing.T) {
+	maxConcurrentTrials := 3
+	testCases := []valueSimulationTestCase{
+		{
+			name: "smaller is better",
+			expectedTrials: []predefinedTrial{
+				newConstantPredefinedTrial(toOps("1000B V 2000B V 6000B V"), 0.01),
+				newConstantPredefinedTrial(toOps("1000B V"), 0.02),
+				newConstantPredefinedTrial(toOps("1000B V"), 0.03),
+				newConstantPredefinedTrial(toOps("1000B V"), 0.04),
+				newConstantPredefinedTrial(toOps("1000B V"), 0.05),
+				newConstantPredefinedTrial(toOps("1000B V"), 0.06),
+				newConstantPredefinedTrial(toOps("1000B V"), 0.07),
+				newConstantPredefinedTrial(toOps("1000B V"), 0.08),
+				newConstantPredefinedTrial(toOps("1000B V"), 0.09),
+				newConstantPredefinedTrial(toOps("1000B V"), 0.10),
+				newConstantPredefinedTrial(toOps("1000B V"), 0.11),
+				newConstantPredefinedTrial(toOps("1000B V"), 0.12),
+			},
+			config: model.SearcherConfig{
+				AsyncHalvingConfig: &model.AsyncHalvingConfig{
+					Metric:              "error",
+					NumRungs:            3,
+					SmallerIsBetter:     true,
+					MaxLength:           model.NewLengthInBatches(9000),
+					MaxTrials:           12,
+					Divisor:             3,
+					MaxConcurrentTrials: maxConcurrentTrials,
+					StopOnce:            true,
+				},
+			},
+		},
+		{
+			name: "smaller is better (round robin)",
+			expectedTrials: []predefinedTrial{
+				newConstantPredefinedTrial(toOps("1000B V 2000B V 6000B V"), 0.01),
+				newConstantPredefinedTrial(toOps("1000B V"), 0.02),
+				newConstantPredefinedTrial(toOps("1000B V"), 0.03),
+				newConstantPredefinedTrial(toOps("1000B V"), 0.04),
+				newConstantPredefinedTrial(toOps("1000B V 2000B V 6000B V"), 0.01),
+				newConstantPredefinedTrial(toOps("1000B V"), 0.02),
+				newConstantPredefinedTrial(toOps("1000B V"), 0.03),
+				newConstantPredefinedTrial(toOps("1000B V"), 0.04),
+				newConstantPredefinedTrial(toOps("1000B V 2000B V 6000B V"), 0.01),
+				newConstantPredefinedTrial(toOps("1000B V"), 0.02),
+				newConstantPredefinedTrial(toOps("1000B V"), 0.03),
+				newConstantPredefinedTrial(toOps("1000B V"), 0.04),
+			},
+			config: model.SearcherConfig{
+				AsyncHalvingConfig: &model.AsyncHalvingConfig{
+					Metric:              "error",
+					NumRungs:            3,
+					SmallerIsBetter:     true,
+					MaxLength:           model.NewLengthInBatches(9000),
+					MaxTrials:           12,
+					Divisor:             3,
+					MaxConcurrentTrials: maxConcurrentTrials,
+					StopOnce:            true,
+				},
+			},
+		},
+		{
+			name: "smaller is not better",
+			expectedTrials: []predefinedTrial{
+				newConstantPredefinedTrial(toOps("1000B V 2000B V 6000B V"), 0.01),
+				newConstantPredefinedTrial(toOps("1000B V 2000B V 6000B V"), 0.02),
+				newConstantPredefinedTrial(toOps("1000B V 2000B V 6000B V"), 0.03),
+				newConstantPredefinedTrial(toOps("1000B V 2000B V 6000B V"), 0.04),
+				newConstantPredefinedTrial(toOps("1000B V 2000B V 6000B V"), 0.05),
+				newConstantPredefinedTrial(toOps("1000B V 2000B V 6000B V"), 0.06),
+				newConstantPredefinedTrial(toOps("1000B V 2000B V 6000B V"), 0.07),
+				newConstantPredefinedTrial(toOps("1000B V 2000B V 6000B V"), 0.08),
+				newConstantPredefinedTrial(toOps("1000B V 2000B V 6000B V"), 0.09),
+				newConstantPredefinedTrial(toOps("1000B V 2000B V 6000B V"), 0.10),
+				newConstantPredefinedTrial(toOps("1000B V 2000B V 6000B V"), 0.11),
+				newConstantPredefinedTrial(toOps("1000B V 2000B V 6000B V"), 0.12),
+			},
+			config: model.SearcherConfig{
+				AsyncHalvingConfig: &model.AsyncHalvingConfig{
+					Metric:              "error",
+					NumRungs:            3,
+					SmallerIsBetter:     false,
+					MaxLength:           model.NewLengthInBatches(9000),
+					MaxTrials:           12,
+					Divisor:             3,
+					MaxConcurrentTrials: maxConcurrentTrials,
+					StopOnce:            true,
+				},
+			},
+		},
+		{
+			name: "smaller is not better (round robin)",
+			expectedTrials: []predefinedTrial{
+				newConstantPredefinedTrial(toOps("1000B V 2000B V 6000B V"), 0.01),
+				newConstantPredefinedTrial(toOps("1000B V 2000B V 6000B V"), 0.02),
+				newConstantPredefinedTrial(toOps("1000B V 2000B V 6000B V"), 0.03),
+				newConstantPredefinedTrial(toOps("1000B V 2000B V 6000B V"), 0.04),
+				newConstantPredefinedTrial(toOps("1000B V"), 0.01),
+				newConstantPredefinedTrial(toOps("1000B V"), 0.02),
+				newConstantPredefinedTrial(toOps("1000B V 2000B V"), 0.03),
+				newConstantPredefinedTrial(toOps("1000B V 2000B V 6000B V"), 0.04),
+				newConstantPredefinedTrial(toOps("1000B V"), 0.01),
+				newConstantPredefinedTrial(toOps("1000B V"), 0.02),
+				newConstantPredefinedTrial(toOps("1000B V 2000B V"), 0.03),
+				newConstantPredefinedTrial(toOps("1000B V 2000B V 6000B V"), 0.04),
+			},
+			config: model.SearcherConfig{
+				AsyncHalvingConfig: &model.AsyncHalvingConfig{
+					Metric:              "error",
+					NumRungs:            3,
+					SmallerIsBetter:     false,
+					MaxLength:           model.NewLengthInBatches(9000),
+					MaxTrials:           12,
+					Divisor:             3,
+					MaxConcurrentTrials: maxConcurrentTrials,
+					StopOnce:            true,
+				},
+			},
+		},
+		{
+			name: "early exit -- smaller is better (round robin)",
+			expectedTrials: []predefinedTrial{
+				newConstantPredefinedTrial(toOps("1000B V 2000B V 6000B V"), 0.01),
+				newConstantPredefinedTrial(toOps("1000B V"), 0.02),
+				newConstantPredefinedTrial(toOps("1000B V"), 0.03),
+				newConstantPredefinedTrial(toOps("1000B V"), 0.04),
+				newEarlyExitPredefinedTrial(toOps("1000B V 2000B"), 0.01),
+				newConstantPredefinedTrial(toOps("1000B V"), 0.02),
+				newConstantPredefinedTrial(toOps("1000B V"), 0.03),
+				newConstantPredefinedTrial(toOps("1000B V"), 0.04),
+				newConstantPredefinedTrial(toOps("1000B V 2000B V 6000B V"), 0.01),
+				newConstantPredefinedTrial(toOps("1000B V"), 0.02),
+				newConstantPredefinedTrial(toOps("1000B V"), 0.03),
+				newConstantPredefinedTrial(toOps("1000B V"), 0.04),
+			},
+			config: model.SearcherConfig{
+				AsyncHalvingConfig: &model.AsyncHalvingConfig{
+					Metric:              "error",
+					NumRungs:            3,
+					SmallerIsBetter:     true,
+					MaxLength:           model.NewLengthInBatches(9000),
+					MaxTrials:           12,
+					Divisor:             3,
+					MaxConcurrentTrials: maxConcurrentTrials,
+					StopOnce:            true,
+				},
+			},
+		},
+		{
+			name: "early exit -- smaller is not better (round robin)",
+			expectedTrials: []predefinedTrial{
+				newConstantPredefinedTrial(toOps("1000B V 2000B V 6000B V"), 0.01),
+				newConstantPredefinedTrial(toOps("1000B V 2000B V 6000B V"), 0.02),
+				newConstantPredefinedTrial(toOps("1000B V 2000B V 6000B V"), 0.03),
+				newEarlyExitPredefinedTrial(toOps("1000B V 2000B"), 0.04),
+				newConstantPredefinedTrial(toOps("1000B V"), 0.01),
+				newConstantPredefinedTrial(toOps("1000B V"), 0.02),
+				newConstantPredefinedTrial(toOps("1000B V 2000B V 6000B V"), 0.03),
+				newConstantPredefinedTrial(toOps("1000B V 2000B V 6000B V"), 0.04),
+				newConstantPredefinedTrial(toOps("1000B V"), 0.01),
+				newConstantPredefinedTrial(toOps("1000B V"), 0.02),
+				newConstantPredefinedTrial(toOps("1000B V 2000B V 6000B V"), 0.03),
+				newConstantPredefinedTrial(toOps("1000B V 2000B V 6000B V"), 0.04),
+			},
+			config: model.SearcherConfig{
+				AsyncHalvingConfig: &model.AsyncHalvingConfig{
+					Metric:              "error",
+					NumRungs:            3,
+					SmallerIsBetter:     false,
+					MaxLength:           model.NewLengthInBatches(9000),
+					MaxTrials:           12,
+					Divisor:             3,
+					MaxConcurrentTrials: maxConcurrentTrials,
+					StopOnce:            true,
+				},
+			},
+		},
+		{
+			name: "single rung bracket",
+			expectedTrials: []predefinedTrial{
+				// The first trial is promoted due to asynchronous
+				// promotions despite being below top 1/3 of trials in
+				// base rung.
+				newConstantPredefinedTrial(toOps("9000B V"), 0.05),
+				newConstantPredefinedTrial(toOps("9000B V"), 0.06),
+				newConstantPredefinedTrial(toOps("9000B V"), 0.07),
+				newConstantPredefinedTrial(toOps("9000B V"), 0.08),
+			},
+			config: model.SearcherConfig{
+				AsyncHalvingConfig: &model.AsyncHalvingConfig{
+					Metric:              "error",
+					NumRungs:            1,
+					SmallerIsBetter:     true,
+					MaxLength:           model.NewLengthInBatches(9000),
+					MaxTrials:           4,
+					Divisor:             3,
+					MaxConcurrentTrials: maxConcurrentTrials,
+					StopOnce:            true,
+				},
+			},
+		},
+	}
+
+	runValueSimulationTestCases(t, testCases)
+}

--- a/master/pkg/searcher/search_method.go
+++ b/master/pkg/searcher/search_method.go
@@ -86,6 +86,9 @@ func NewSearchMethod(c model.SearcherConfig) SearchMethod {
 	case c.AdaptiveSimpleConfig != nil:
 		return newAdaptiveSimpleSearch(*c.AdaptiveSimpleConfig)
 	case c.AsyncHalvingConfig != nil:
+		if c.AsyncHalvingConfig.StopOnce {
+			return newAsyncHalvingStoppingSearch(*c.AsyncHalvingConfig)
+		}
 		return newAsyncHalvingSearch(*c.AsyncHalvingConfig)
 	case c.AdaptiveASHAConfig != nil:
 		return newAdaptiveASHASearch(*c.AdaptiveASHAConfig)

--- a/master/pkg/searcher/simulate.go
+++ b/master/pkg/searcher/simulate.go
@@ -24,6 +24,12 @@ func ConstantValidation(_ *rand.Rand, _, _ int) float64 { return 1 }
 // RandomValidation returns a random validation metric for each validation step.
 func RandomValidation(rand *rand.Rand, _, _ int) float64 { return rand.Float64() }
 
+// TrialIDMetric returns the trialID as the metric for all validation steps.
+func TrialIDMetric(_ *rand.Rand, trialID, _ int) float64 {
+	fmt.Println(trialID)
+	return float64(trialID)
+}
+
 // SimulationResults holds all created trials and all executed workloads for each trial.
 type SimulationResults map[model.RequestID][]Runnable
 


### PR DESCRIPTION
## Description
Add a stopping-based variant of adaptive search that does not require fault-tolerance for early-stopping.  This variant is based on  the implementation of ASHA in Ray Tune: https://docs.ray.io/en/master/tune/api_docs/schedulers.html#tune-scheduler-hyperband.  


## Test Plan
- [x] Add simulated tests
- [x] Run local HP search experiment

## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label. **I'm not sure if this counts as user-facing api change.**
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234