### PR TITLE
fix: e2e test for deformable detr with fake backend

### DIFF
--- a/examples/computer_vision/deformabledetr_coco_pytorch/data.py
+++ b/examples/computer_vision/deformabledetr_coco_pytorch/data.py
@@ -143,6 +143,12 @@ class CocoDetection(torchvision.datasets.CocoDetection):
             )
         return img, target
 
+    def __len__(self):
+        # If using fake data, we'll limit the dataset to 1000 examples.
+        if isinstance(self.backend, FakeBackend):
+            return 1000
+        return len(self.ids)
+
 
 def build_dataset(image_set, args):
     root = args.data_dir

--- a/examples/computer_vision/detr_coco_pytorch/data.py
+++ b/examples/computer_vision/detr_coco_pytorch/data.py
@@ -145,6 +145,12 @@ class CocoDetection(torchvision.datasets.CocoDetection):
 
         return img, target
 
+    def __len__(self):
+        # If using fake data, we'll limit the dataset to 1000 examples.
+        if isinstance(self.backend, FakeBackend):
+            return 1000
+        return len(self.ids)
+
 
 def build_dataset(image_set, args):
     root = args.data_dir


### PR DESCRIPTION
## Description
Reduces the dataset set when using the FakeBackend for DETR and Deformable DETR so that we will not timeout for e2e capabilities tests.  
<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan
- [ ] Tested locally to time validation step (~3 mins).  

<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234