### PR TITLE
fix: force line-break to prevent overlapping in trial logs [DET-5121]

### DIFF
--- a/webui/react/src/components/LogViewer.module.scss
+++ b/webui/react/src/components/LogViewer.module.scss
@@ -64,6 +64,7 @@
   .line > .time::after { content: '\00a0'; }
   .line > .message {
     flex-grow: 1;
+    line-break: anywhere;
     white-space: pre-wrap;
     word-break: break-all;
   }


### PR DESCRIPTION
not an easy find, but noticed that the issue should be related to separators like quotation marks not properly breaked (see red rect here, the quotation should be there, not going to newline).
<img width="959" alt="Schermata 2021-03-12 alle 11 32 28" src="https://user-images.githubusercontent.com/5413702/110928609-5fd9bb00-8327-11eb-84ce-b29364a68e5e.png">

Found this https://github.com/w3c/csswg-drafts/issues/1171#issuecomment-494164252
That lead me to this https://developer.mozilla.org/en-US/docs/Web/CSS/line-break


## Description

<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234