### PR TITLE
fix: only upload model code as model code [DET-3865]

### DIFF
--- a/docs/release-notes/2077-model-upload.txt
+++ b/docs/release-notes/2077-model-upload.txt
@@ -1,0 +1,9 @@
+:orphan:
+
+**Fixes**
+
+-  Model code uploaded to checkpoints will now match the model code
+   provided during experiment creation. Previously, it may have included
+   additional files that had been bind-mounted in with a
+   ``container_path`` that was either relative or was a subdirectory of
+   ``/run/determined/workdir``.

--- a/harness/determined/_env_context.py
+++ b/harness/determined/_env_context.py
@@ -31,8 +31,9 @@ class EnvContext:
         det_experiment_id: str,
         det_cluster_id: str,
         trial_seed: int,
-        managed_training: bool = True,
-        test_mode: bool = False,
+        managed_training: bool,
+        test_mode: bool,
+        on_cluster: bool,
     ):
         self.master_addr = master_addr
         self.master_port = master_port
@@ -58,6 +59,7 @@ class EnvContext:
         self.trial_seed = trial_seed
         self.managed_training = managed_training
         self.test_mode = test_mode
+        self.on_cluster = on_cluster
 
         self._per_slot_batch_size, self._global_batch_size = self._calculate_batch_sizes()
 

--- a/harness/determined/_execution.py
+++ b/harness/determined/_execution.py
@@ -131,6 +131,7 @@ def _make_local_execution_env(
         trial_seed=config.experiment_seed(),
         managed_training=managed_training,
         test_mode=test_mode,
+        on_cluster=False,
     )
     rendezvous_ports = env.rendezvous_ports()
     rendezvous_info = det.RendezvousInfo(

--- a/harness/determined/constants.py
+++ b/harness/determined/constants.py
@@ -66,3 +66,5 @@ HOROVOD_GLOO_TIMEOUT_SECONDS = 240
 # The well-known locations of the executing container's STDOUT and STDERR.
 CONTAINER_STDOUT = "/run/determined/train/logs/stdout.log"
 CONTAINER_STDERR = "/run/determined/train/logs/stderr.log"
+
+MANAGED_TRAINING_MODEL_COPY = "/run/determined/train/model"

--- a/harness/determined/estimator/_estimator_trial.py
+++ b/harness/determined/estimator/_estimator_trial.py
@@ -207,7 +207,7 @@ class DeterminedControlHook(estimator.RunHook):
         self._copy_latest_checkpoint(checkpoint_path=checkpoint_path)
         self._save_serving_input_receiver_fns(checkpoint_path=str(checkpoint_path))
 
-        det.util.write_user_code(checkpoint_path)
+        det.util.write_user_code(checkpoint_path, self.estimator_trial_controller.env.on_cluster)
 
         for callback in self.estimator_trial_controller.train_hooks:
             if isinstance(callback, estimator.RunHook):

--- a/harness/determined/exec/harness.py
+++ b/harness/determined/exec/harness.py
@@ -207,6 +207,9 @@ def main() -> None:
         det_experiment_id,
         det_cluster_id,
         trial_seed,
+        managed_training=True,
+        test_mode=False,
+        on_cluster=True,
     )
 
     logging.info(

--- a/harness/determined/keras/_tf_keras_trial.py
+++ b/harness/determined/keras/_tf_keras_trial.py
@@ -577,7 +577,7 @@ class TFKerasTrialController(det.LoopTrialController):
             pickle.dump(rng_state, f)
 
         # Save user code.
-        det.util.write_user_code(path)
+        det.util.write_user_code(path, self.env.on_cluster)
 
         # Save callback(s) state.
         callbacks_state = self.multiplexer._get_state()

--- a/harness/determined/pytorch/_pytorch_trial.py
+++ b/harness/determined/pytorch/_pytorch_trial.py
@@ -670,8 +670,7 @@ class PyTorchTrialController(det.LoopTrialController):
 
         path.mkdir(parents=True, exist_ok=True)
 
-        # The model code is the current working directory.
-        util.write_user_code(path)
+        util.write_user_code(path, self.env.on_cluster)
 
         rng_state = {
             "cpu_rng_state": torch.random.get_rng_state(),  # type: ignore

--- a/harness/determined/util.py
+++ b/harness/determined/util.py
@@ -13,6 +13,7 @@ import numpy as np
 import simplejson
 
 import determined as det
+from determined import constants
 from determined_common import check, util
 
 
@@ -161,7 +162,7 @@ def json_encode(obj: Any, indent: Optional[str] = None, sort_keys: bool = False)
     return s
 
 
-def write_user_code(path: pathlib.Path) -> None:
+def write_user_code(path: pathlib.Path, on_cluster: bool) -> None:
     code_path = path.joinpath("code")
 
     # When restarting from checkpoint, it is possible that the code path is already present
@@ -170,8 +171,13 @@ def write_user_code(path: pathlib.Path) -> None:
     if code_path.exists():
         shutil.rmtree(str(code_path))
 
-    # Pytorch and tf.1 keras models can only be restored from a checkpoint if
-    # the original code is present. The model code is the current working
-    # directory. Therefore we save the current directory with the checkpoint.
-    shutil.copytree(os.getcwd(), code_path, ignore=shutil.ignore_patterns("__pycache__"))
+    # Most models can only be restored from a checkpoint if the original code is present. However,
+    # since it is rather common that users mount large, non-model files into their working directory
+    # (like data or their entire HOME directory), when we are training on-cluster we use a
+    # specially-prepared clean copy of the model rather than the working directory.
+    if on_cluster:
+        model_dir = constants.MANAGED_TRAINING_MODEL_COPY
+    else:
+        model_dir = "."
+    shutil.copytree(model_dir, code_path, ignore=shutil.ignore_patterns("__pycache__"))
     os.chmod(code_path, 0o755)

--- a/harness/tests/experiment/utils.py
+++ b/harness/tests/experiment/utils.py
@@ -145,6 +145,9 @@ def make_default_env_context(
         det_experiment_id="1",
         det_cluster_id="uuid-123",
         trial_seed=trial_seed,
+        managed_training=True,
+        test_mode=False,
+        on_cluster=False,
     )
 
 

--- a/harness/tests/tensorboard/test_util.py
+++ b/harness/tests/tensorboard/test_util.py
@@ -37,6 +37,9 @@ def get_dummy_env() -> det.EnvContext:
         det_experiment_id="1",
         det_cluster_id="uuid-123",
         trial_seed=0,
+        managed_training=True,
+        test_mode=False,
+        on_cluster=False,
     )
 
 

--- a/harness/tests/test_horovod.py
+++ b/harness/tests/test_horovod.py
@@ -40,6 +40,9 @@ def create_default_env_context(experiment_config: Dict[str, Any]) -> det.EnvCont
         det_experiment_id="1",
         det_cluster_id="uuid-123",
         trial_seed=0,
+        managed_training=True,
+        test_mode=False,
+        on_cluster=False,
     )
 
 

--- a/master/pkg/tasks/task.go
+++ b/master/pkg/tasks/task.go
@@ -18,6 +18,7 @@ const (
 	userPythonBaseDir = "/run/determined/pythonuserbase"
 	runDir            = "/run/determined"
 	trainDir          = "/run/determined/train"
+	modelCopy         = "/run/determined/train/model"
 	rootDir           = "/"
 	passwdPath        = "/run/determined/etc/passwd"
 	shadowPath        = "/run/determined/etc/shadow"
@@ -31,7 +32,6 @@ func workDirArchive(aug *model.AgentUserGroup) container.RunArchive {
 		archive.Archive{
 			aug.OwnedArchiveItem(runDir, nil, 0700, tar.TypeDir),
 			aug.OwnedArchiveItem(ContainerWorkDir, nil, 0700, tar.TypeDir),
-			aug.OwnedArchiveItem(trainDir, nil, 0700, tar.TypeDir),
 			aug.OwnedArchiveItem(userPythonBaseDir, nil, 0700, tar.TypeDir),
 		},
 		rootDir,

--- a/master/pkg/tasks/task_spec.go
+++ b/master/pkg/tasks/task_spec.go
@@ -280,7 +280,15 @@ type StartTrial struct {
 
 // Archives implements InnerSpec.
 func (s StartTrial) Archives(u *model.AgentUserGroup) []container.RunArchive {
-	return []container.RunArchive{wrapArchive(s.AdditionalFiles, rootDir),
+	return []container.RunArchive{
+		wrapArchive(
+			archive.Archive{
+				u.OwnedArchiveItem(trainDir, nil, 0700, tar.TypeDir),
+				u.OwnedArchiveItem(modelCopy, nil, 0700, tar.TypeDir),
+			},
+			rootDir,
+		),
+		wrapArchive(s.AdditionalFiles, rootDir),
 		wrapArchive(
 			archive.Archive{
 				u.OwnedArchiveItem(
@@ -292,6 +300,7 @@ func (s StartTrial) Archives(u *model.AgentUserGroup) []container.RunArchive {
 			},
 			trainDir,
 		),
+		wrapArchive(u.OwnArchive(s.ModelDefinition), modelCopy),
 		wrapArchive(u.OwnArchive(s.ModelDefinition), ContainerWorkDir),
 	}
 }


### PR DESCRIPTION
Before we always copied the working directory as model code.  Users
often saw apparent hangs waiting for checkpoint upload, which in fact
were caused by things like us silently trying to upload their entire
dataset to S3.

It might not be a good idea to upload auto-discovered model definitions
to checkpoint storage.  But rather than fundamentally alter the
assumptions of our checkpointing system, this PR just adds a clean copy
of the model which was submitted to the master into the training
container, and during managed training, that clean copy gets uploaded
rather than the /run/determined/workdir.
