### PR TITLE
feat: add frequency support for lr_scheduler [DET-5021]

### DIFF
--- a/docs/release-notes/2079-lr-scheduler-frequency.txt
+++ b/docs/release-notes/2079-lr-scheduler-frequency.txt
@@ -1,0 +1,6 @@
+:orphan:
+
+**New Features**
+
+-  PyTorchTrial: Add an option to LRScheduler to accept a frequency
+   option alongside batch and epoch step modes.

--- a/harness/determined/pytorch/_lr_scheduler.py
+++ b/harness/determined/pytorch/_lr_scheduler.py
@@ -52,6 +52,8 @@ class LRScheduler:
                 3. ``MANUAL_STEP``: Determined will not call scheduler.step() at all.
                    It is up to the user to decide when to call scheduler.step(),
                    and whether to pass any arguments.
+            frequency:
+                Sets the frequency with witch the batch and epoch step modes get triggered.
         """
         check.check_not_none(scheduler)
         check.check_isinstance(step_mode, LRScheduler.StepMode)

--- a/harness/determined/pytorch/_lr_scheduler.py
+++ b/harness/determined/pytorch/_lr_scheduler.py
@@ -33,6 +33,7 @@ class LRScheduler:
         self,
         scheduler: torch.optim.lr_scheduler._LRScheduler,
         step_mode: StepMode,
+        frequency: int = 1,
     ):
         """LRScheduler constructor
 
@@ -43,10 +44,10 @@ class LRScheduler:
                 The strategy Determined will use to call (or not call) scheduler.step().
 
                 1. ``STEP_EVERY_EPOCH``: Determined will call scheduler.step() after
-                   every training epoch. No arguments will be passed to step().
+                   every ``frequency`` training epoch(s). No arguments will be passed to step().
 
                 2. ``STEP_EVERY_BATCH``: Determined will call scheduler.step() after every
-                   training batch. No arguments will be passed to step().
+                   ``frequency`` training batch(es). No arguments will be passed to step().
 
                 3. ``MANUAL_STEP``: Determined will not call scheduler.step() at all.
                    It is up to the user to decide when to call scheduler.step(),
@@ -57,6 +58,7 @@ class LRScheduler:
 
         self._scheduler = scheduler
         self._step_mode = step_mode
+        self._frequency = frequency
 
     def step(self, *args: Any, **kwargs: Any) -> None:
         self._scheduler.step(*args, **kwargs)

--- a/harness/determined/pytorch/_pytorch_trial.py
+++ b/harness/determined/pytorch/_pytorch_trial.py
@@ -253,9 +253,10 @@ class PyTorchTrialController(det.LoopTrialController):
         This function aims at automatically step a LR scheduler. It should be called per batch.
         """
         if lr_scheduler._step_mode == pytorch.LRScheduler.StepMode.STEP_EVERY_BATCH:
-            lr_scheduler.step()
+            if (batch_idx + 1) % lr_scheduler._frequency == 0:
+                lr_scheduler.step()
         elif lr_scheduler._step_mode == pytorch.LRScheduler.StepMode.STEP_EVERY_EPOCH:
-            mod = (batch_idx + 1) % len(self.training_loader)
+            mod = (batch_idx + 1) % (len(self.training_loader) * lr_scheduler._frequency)
             if mod == 0 or mod < self.hvd_config.aggregation_frequency:
                 lr_scheduler.step()
 


### PR DESCRIPTION
## Description

<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234