### PR TITLE
docs: stopping-based variant of adaptive search

### DIFF
--- a/docs/reference/experiment-config.txt
+++ b/docs/reference/experiment-config.txt
@@ -629,6 +629,14 @@ large-scale experiments with hundreds or thousands of trials.
    not explore as many configurations given the same budget. We
    recommend using either ``aggressive`` or ``standard`` mode.
 
+``stop_once``
+   If ``stop_once`` is set to ``true``, we will use a variant of ASHA
+   that will not resume trials once stopped. This variant defaults to
+   continuing training and will only stop trials if there is enough
+   evidence to terminate training. We recommend using this version of
+   ASHA when training a trial for the max length as fast as possible is
+   important or when fault tolerance is too expensive.
+
 ``divisor``
    The fraction of trials to keep at each rung, and also determines the
    training length for each rung. The default setting is ``4``; only


### PR DESCRIPTION
## Description
Document usage for stopping-based variant of `adaptive_asha`.



<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
