### PR TITLE
chore: testing gang-scheduling [DET-5134]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -565,7 +565,8 @@ commands:
             detVersion=<<parameters.det-version>>,\
             maxSlotsPerPod=<<parameters.gpus-per-machine>>,\
             checkpointStorage.type=gcs,\
-            checkpointStorage.bucket=det-ci
+            checkpointStorage.bucket=det-ci,\
+            defaultScheduler=coscheduler
       - set-master-address-gke:
           release-name: "ci"
           namespace: "default"
@@ -640,7 +641,8 @@ commands:
             taskContainerDefaults.cpuImage=determinedai/environments:cuda-11.0-pytorch-1.7-tf-2.4-gpu-0.9.0,\
             taskContainerDefaults.gpuImage=determinedai/environments:cuda-11.0-pytorch-1.7-tf-2.4-gpu-0.9.0,\
             checkpointStorage.type=gcs,\
-            checkpointStorage.bucket=det-ci
+            checkpointStorage.bucket=det-ci,\
+            defaultScheduler=coscheduler
       - set-master-address-gke:
           release-name: "ci"
           namespace: "default"
@@ -1482,6 +1484,11 @@ jobs:
           region: <<parameters.region>>
           node-locations: <<parameters.node-locations>>
       - set-google-application-credentials
+      - run:
+          name: Set environment variables 
+          command: |
+            echo "export TOTAL_SLOTS="$((<<parameters.num-machines>> * <<parameters.gpus-per-machine>>))"" >> $BASH_ENV
+            source $BASH_ENV
       - run-e2e-tests:
           mark: <<parameters.mark>>
           master-host: ${MASTER_HOST}

--- a/e2e_tests/tests/test_system.py
+++ b/e2e_tests/tests/test_system.py
@@ -1,7 +1,9 @@
 import json
 import operator
+import os
 import subprocess
 import tempfile
+import threading
 import time
 from typing import Dict, Set
 
@@ -568,3 +570,27 @@ def test_disable_and_enable_slots() -> None:
         slots[0]["slot_id"],
     ]
     subprocess.check_call(command)
+
+
+@pytest.mark.parallel  # type: ignore
+@pytest.mark.timeout(300)  # type: ignore
+def test_gang_scheduling() -> None:
+    config = conf.load_config(conf.tutorials_path("mnist_pytorch/distributed.yaml"))
+    total_slots = os.getenv("TOTAL_SLOTS")
+    if total_slots is None:
+        pytest.fail("test requires TOTAL_SLOTS be set in the environment")
+    config = conf.set_slots_per_trial(config, int(total_slots))
+
+    model = conf.tutorials_path("mnist_pytorch")
+
+    def submit_job() -> None:
+        ret_value = exp.run_basic_test_with_temp_config(config, model, 1)
+        print(ret_value)
+
+    t = []
+    for _i in range(2):
+        t.append(threading.Thread(target=submit_job))
+    for i in range(2):
+        t[i].start()
+    for i in range(2):
+        t[i].join()


### PR DESCRIPTION
## Description

Adding automated tests of the coscheduler / gang scheduling feature.

## Test Plan

This *is* the test plan! The test fails (times out) about 50% of the time when the coscheduler isn't enabled, but reliably passes when it is. This test also has the benefit of exercising the coscheduler more, since our other test clusters usually have auto-scaling, with which the coscheduler isn't supported.

I'm concerned this may be a little flaky because the coscheduler is known to sometimes have timeouts when an experiment requires the entire cluster, which is the case with this test. Since a multi-node job must consume 100% of the GPUs on a certain number of nodes, one alternative would be for the tests to use a 3-node-cluster and 2 (or more) 2-node tests. But let's see if that necessary before making that change.

Ran this on an upstream branch: https://app.circleci.com/pipelines/github/determined-ai/determined/10669/workflows/368ab9ad-e7e8-41ac-bfa1-ebfc21da41f0/jobs/302416