### PR TITLE
chore: Revert "Testing gang-scheduling [DET-5134]"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -567,8 +567,7 @@ commands:
             detVersion=<<parameters.det-version>>,\
             maxSlotsPerPod=<<parameters.gpus-per-machine>>,\
             checkpointStorage.type=gcs,\
-            checkpointStorage.bucket=det-ci,\
-            defaultScheduler=coscheduler
+            checkpointStorage.bucket=det-ci
       - set-master-address-gke:
           release-name: "ci"
           namespace: "default"
@@ -643,8 +642,7 @@ commands:
             taskContainerDefaults.cpuImage=determinedai/environments:cuda-11.1-pytorch-1.8-lightning-1.2-tf-2.4-gpu-0.9.0,\
             taskContainerDefaults.gpuImage=determinedai/environments:cuda-11.1-pytorch-1.8-lightning-1.2-tf-2.4-gpu-0.9.0,\
             checkpointStorage.type=gcs,\
-            checkpointStorage.bucket=det-ci,\
-            defaultScheduler=coscheduler
+            checkpointStorage.bucket=det-ci
       - set-master-address-gke:
           release-name: "ci"
           namespace: "default"
@@ -1486,11 +1484,6 @@ jobs:
           region: <<parameters.region>>
           node-locations: <<parameters.node-locations>>
       - set-google-application-credentials
-      - run:
-          name: Set environment variables 
-          command: |
-            echo "export TOTAL_SLOTS="$((<<parameters.num-machines>> * <<parameters.gpus-per-machine>>))"" >> $BASH_ENV
-            source $BASH_ENV
       - run-e2e-tests:
           mark: <<parameters.mark>>
           master-host: ${MASTER_HOST}

--- a/e2e_tests/tests/test_system.py
+++ b/e2e_tests/tests/test_system.py
@@ -1,9 +1,7 @@
 import json
 import operator
-import os
 import subprocess
 import tempfile
-import threading
 import time
 from typing import Dict, Set
 
@@ -572,27 +570,3 @@ def test_disable_and_enable_slots() -> None:
         slots[0]["slot_id"],
     ]
     subprocess.check_call(command)
-
-
-@pytest.mark.parallel  # type: ignore
-@pytest.mark.timeout(300)  # type: ignore
-def test_gang_scheduling() -> None:
-    config = conf.load_config(conf.tutorials_path("mnist_pytorch/distributed.yaml"))
-    total_slots = os.getenv("TOTAL_SLOTS")
-    if total_slots is None:
-        pytest.fail("test requires TOTAL_SLOTS be set in the environment")
-    config = conf.set_slots_per_trial(config, int(total_slots))
-
-    model = conf.tutorials_path("mnist_pytorch")
-
-    def submit_job() -> None:
-        ret_value = exp.run_basic_test_with_temp_config(config, model, 1)
-        print(ret_value)
-
-    t = []
-    for _i in range(2):
-        t.append(threading.Thread(target=submit_job))
-    for i in range(2):
-        t[i].start()
-    for i in range(2):
-        t[i].join()


### PR DESCRIPTION
This reverts commit 2c5beaadafc0b50d38de1ec481b263e95e47f208.

## Description

This failed a GKE run and needs investigation. It also failed the normal GPU tests because it's missing the TOTAL_SLOTS setting.

## Test Plan

I'll fix the TOTAL_SLOTS problem on the GPU tests, and repush this to an upstream branch to troubleshoot the other failure. Reverting now to unblock tests.
