### PR TITLE
docs: improvements to spot instance and resource pool docs

### DIFF
--- a/docs/examples.txt
+++ b/docs/examples.txt
@@ -68,7 +68,7 @@ MNIST <pytorch-mnist-tutorial>` and :ref:`tf.keras MNIST
 
    -  -  PyTorch (Lightning Adapter)
       -  MNIST
-      -  :download:`mnist_pl.tgz </examples/_mnist_pl.tgz>`
+      -  :download:`mnist_pl.tgz </examples/mnist_pl.tgz>`
 
    -  -  TensorFlow (Estimator API)
       -  MNIST

--- a/docs/how-to/installation/deploy.txt
+++ b/docs/how-to/installation/deploy.txt
@@ -7,6 +7,9 @@
 This document shows how to deploy Determined locally or in a production
 cluster using the ``det deploy`` command-line tool, which automates the
 process of starting Determined as a collection of Docker containers.
+``det deploy`` can also be used to install Determined on the cloud; for
+more information, see the :ref:`AWS <install-aws>` and :ref:`GCP
+<install-gcp>` installation guides, respectively.
 
 In a typical production setup, the master and agents will run on
 separate machines. They can also run on a single machine, which is

--- a/docs/reference/cluster-config.txt
+++ b/docs/reference/cluster-config.txt
@@ -312,55 +312,52 @@ The master supports the following configuration settings:
       dynamic agents.
 
       -  ``scheduler``: Specifies how Determined schedules tasks to
-            agents on resource pools. If a resource pool is specified
-            with an individual scheduler configuration, that will
-            override the default scheduling behavior specified here. For
-            more on scheduling behavior in Determined, see
-            :ref:`scheduling`.
+         agents on resource pools. If a resource pool is specified with
+         an individual scheduler configuration, that will override the
+         default scheduling behavior specified here. For more on
+         scheduling behavior in Determined, see :ref:`scheduling`.
 
-            -  ``type``: The scheduling policy to use when allocating
-               resources between different tasks (experiments,
-               notebooks, etc.). Defaults to ``fair_share``.
+         -  ``type``: The scheduling policy to use when allocating
+            resources between different tasks (experiments, notebooks,
+            etc.). Defaults to ``fair_share``.
 
-               -  ``fair_share``: Tasks receive a proportional amount of
-                  the available resources depending on the resource they
-                  require and their weight.
+            -  ``fair_share``: Tasks receive a proportional amount of
+               the available resources depending on the resource they
+               require and their weight.
 
-               -  ``round_robin``: Tasks are scheduled in the order
-                  which they arrive at the cluster.
+            -  ``round_robin``: Tasks are scheduled in the order which
+               they arrive at the cluster.
 
-               -  ``priority``: Tasks are scheduled based on their
-                  priority, which can range from the values 1 to 99
-                  inclusive. Lower priority numbers indicate higher
-                  priority tasks. A lower priority task will never be
-                  scheduled while a higher priority task is pending.
-                  Zero-slot tasks (e.g., CPU-only notebooks,
-                  tensorboards) are prioritized separately from tasks
-                  requiring slots (e.g., experiments running on GPUs).
-                  Task priority can be assigned using the the
-                  ``resources.priority`` field. If a task does not
-                  specify a priority it is assigned the
-                  ``default_priority``.
+            -  ``priority``: Tasks are scheduled based on their
+               priority, which can range from the values 1 to 99
+               inclusive. Lower priority numbers indicate higher
+               priority tasks. A lower priority task will never be
+               scheduled while a higher priority task is pending.
+               Zero-slot tasks (e.g., CPU-only notebooks, tensorboards)
+               are prioritized separately from tasks requiring slots
+               (e.g., experiments running on GPUs). Task priority can be
+               assigned using the the ``resources.priority`` field. If a
+               task does not specify a priority it is assigned the
+               ``default_priority``.
 
-                  -  ``preemption``: Specifies whether lower priority
-                     tasks should be preempted to schedule higher
-                     priority tasks. Tasks are preempted in order of
-                     lowest priority first.
+               -  ``preemption``: Specifies whether lower priority tasks
+                  should be preempted to schedule higher priority tasks.
+                  Tasks are preempted in order of lowest priority first.
 
-                  -  ``default_priority``: The priority that is assigned
-                     to tasks that do not specify a priority. Can be
-                     configured to 1 to 99 inclusively. Defaults to 42.
+               -  ``default_priority``: The priority that is assigned to
+                  tasks that do not specify a priority. Can be
+                  configured to 1 to 99 inclusively. Defaults to 42.
 
-            -  ``fitting_policy``: The scheduling policy to use when
-               assigning tasks to agents in the cluster. Defaults to
-               ``best``.
+         -  ``fitting_policy``: The scheduling policy to use when
+            assigning tasks to agents in the cluster. Defaults to
+            ``best``.
 
-               -  ``best``: The best-fit policy ensures that tasks will
-                  be preferentially "packed" together on the smallest
-                  number of agents.
+            -  ``best``: The best-fit policy ensures that tasks will be
+               preferentially "packed" together on the smallest number
+               of agents.
 
-               -  ``worst``: The worst-fit policy ensures that tasks
-                  will be placed on under-utilized agents.
+            -  ``worst``: The worst-fit policy ensures that tasks will
+               be placed on under-utilized agents.
 
       -  ``default_cpu_resource_pool``: The default resource pool to use
          for tasks that do not need GPUs. Defaults to ``default`` if no
@@ -396,15 +393,19 @@ The master supports the following configuration settings:
       -  ``master_service_name``: The service account Determined uses to
          interact with the Kubernetes API.
 
--  ``resource_pools``: The resource pools to use to acquire resources.
-   Defaults to a resource pool with a name ``default``.
+-  ``resource_pools``: A list of resource pools. A resource pool is a
+   collection of identical computational resources. Users can specify
+   which resource pool a job should be assigned to when the job is
+   submitted. Refer to the documentation on :ref:`resource-pools` for
+   more information. Defaults to a resource pool with a name
+   ``default``.
 
    -  ``pool_name``: The name of the resource pool.
 
    -  ``description``: The description of the resource pool.
 
-   -  ``max_cpu_containers_per_agent``: The maximum number of containers
-      that do not take any GPUs on each agent.
+   -  ``max_cpu_containers_per_agent``: The maximum number of CPU-only
+      containers that can be scheduled on each agent in this pool.
 
    -  ``scheduler``: Specifies how Determined schedules tasks to agents.
       The scheduler configuration on each resource pool will override
@@ -433,13 +434,13 @@ The master supports the following configuration settings:
             ``resources.priority`` field. If a task does not specify a
             priority it is assigned the ``default_priority``.
 
-               -  ``preemption``: Specifies whether lower priority tasks
-                  should be preempted to schedule higher priority tasks.
-                  Tasks are preempted in order of lowest priority first.
+            -  ``preemption``: Specifies whether lower priority tasks
+               should be preempted to schedule higher priority tasks.
+               Tasks are preempted in order of lowest priority first.
 
-               -  ``default_priority``: The priority that is assigned to
-                  tasks that do not specify a priority. Can be
-                  configured to 1 to 99 inclusively. Defaults to 42.
+            -  ``default_priority``: The priority that is assigned to
+               tasks that do not specify a priority. Can be configured
+               to 1 to 99 inclusively. Defaults to 42.
 
       -  ``fitting_policy``: The scheduling policy to use when assigning
          tasks to agents in the cluster. Defaults to ``best``.

--- a/docs/reference/command-notebook-config.txt
+++ b/docs/reference/command-notebook-config.txt
@@ -6,9 +6,12 @@
 
 The behavior of Determined tasks, such as TensorBoards, notebooks,
 :ref:`commands, and shells <commands-and-shells>`, can be influenced by
-setting a variety of configuration variables. Configuration settings can
-be specified by passing a YAML configuration file when launching the
-workload via the Determined CLI:
+setting a variety of configuration variables. These configuration
+variables are similar but not identical to the configuration options
+supported by :ref:`experiments <experiment-configuration>`.
+
+Configuration settings can be specified by passing a YAML configuration
+file when launching the workload via the Determined CLI:
 
 .. code::
 
@@ -36,13 +39,12 @@ Determined task unless otherwise specified.
 
 The following configuration settings are supported:
 
--  ``description``: A human-readable description of the
-   command/notebook. This does not need to be unique. The default
-   description consists of a timestamp and the entrypoint of the
-   command.
+-  ``description``: A human-readable description of the task. This does
+   not need to be unique. The default description consists of a
+   timestamp and the entrypoint of the command.
 
 -  ``environment``: Specifies the environment of the container that is
-   used to execute the command/notebook.
+   used to execute the task.
 
    -  ``image``: Specifies a Docker image to use when executing the
       workload. The image must be available via ``docker pull`` to every
@@ -77,32 +79,37 @@ The following configuration settings are supported:
       -  ``server`` (optional)
       -  ``email`` (optional)
 
--  ``resources``: The resources Determined allows a command/notebook to
-   use.
+-  ``resources``: The resources Determined allows a task to use.
 
-   -  ``slots``: Specifies the number of slots to use for the
-      command/notebook. The default value is ``1``. The maximum value is
-      the number of slots on the agent in the cluster with the most
-      slots. For example, Determined will be unable to schedule a
-      command that requests 4 slots if the Determined cluster is
-      composed of agents with 2 slots each. The number of slots for
-      TensorBoard is fixed at ``0`` and may not be changed.
+   -  ``slots``: Specifies the number of slots to use for the task. The
+      default value is ``1``. The maximum value is the number of slots
+      on the agent in the cluster with the most slots. For example,
+      Determined will be unable to schedule a task that requests 4 slots
+      if the Determined cluster is composed of agents with 2 slots each.
+      The number of slots for TensorBoard is fixed at ``0`` and may not
+      be changed.
 
-   -  ``agent_label``: If set, the command/notebook will *only* be
-      scheduled on agents that have the given label set. If this is not
-      set (the default behavior), the command/notebook will only be
-      scheduled on unlabeled agents. An agent's label can be configured
-      via the ``label`` field in the :ref:`agent configuration
-      <agent-configuration>`.
+   -  ``agent_label``: If set, the task will *only* be scheduled on
+      agents that have the given label set. If this is not set (the
+      default behavior), the task will only be scheduled on unlabeled
+      agents. An agent's label can be configured via the ``label`` field
+      in the :ref:`agent configuration <agent-configuration>`.
 
-   -  ``shm_size``: The size in bytes of ``/dev/shm`` for trial
+   -  ``shm_size``: The size in bytes of ``/dev/shm`` for task
       containers. Defaults to ``4294967296`` (4GiB). If set, this value
       overrides the value specified in the :ref:`master configuration
       <master-configuration>`.
 
-   -  ``priority``: The priority assigned to this experiment. Smaller
-      priority assignment indicates higher priority. Only applicable
-      when using the ``priority`` scheduler.
+   -  ``priority``: The priority assigned to this task. Tasks with
+      smaller priority values are scheduled before tasks with higher
+      priority values. Only applicable when using the ``priority``
+      scheduler. Refer to :ref:`scheduling` for more information.
+
+   -  ``resource_pool``: The resource pool where this task will be
+      scheduled. If no resource pool is specified, CPU-only tasks will
+      be scheduled in the default CPU pool, while GPU-using tasks will
+      be scheduled in the default GPU tool. Refer to
+      :ref:`resource-pools` for more information.
 
 -  ``bind_mounts``: Specifies a collection of directories that are
    bind-mounted into the Docker containers for execution. This can be

--- a/docs/reference/experiment-config.txt
+++ b/docs/reference/experiment-config.txt
@@ -958,9 +958,15 @@ allowed to use.
    specified in the :ref:`master configuration <master-configuration>`.
 
 ``priority``
-   The priority assigned to this experiment. Smaller priority assignment
-   indicates higher priority. Only applicable when using the
-   ``priority`` scheduler.
+   The priority assigned to this experiment. Experiments with smaller
+   priority values are scheduled before experiments with higher priority
+   values. Only applicable when using the ``priority`` scheduler. Refer
+   to :ref:`scheduling` for more information.
+
+``resource_pool``
+   The resource pool where this experiment will be scheduled. If no
+   resource pool is specified, experiments will run in the default GPU
+   pool. Refer to :ref:`resource-pools` for more information.
 
 *************
  Bind Mounts

--- a/docs/reference/index.txt
+++ b/docs/reference/index.txt
@@ -14,8 +14,9 @@ concepts of the product.
 
 **Configurations**
 
--  :ref:`config-template`
 -  :ref:`experiment-configuration`
+-  :ref:`command-notebook-configuration`
+-  :ref:`cluster-configuration`
 
 The full list of reference guides can be found below:
 

--- a/docs/topic-guides/deployment/aws-spot.txt
+++ b/docs/topic-guides/deployment/aws-spot.txt
@@ -46,19 +46,42 @@ instance type. GPU instances, particularly those with the most modern
 GPUs, are often in high demand and they may sometimes be difficult to
 get as spot instances.
 
-********************
- Spot On Determined
-********************
+**************************************
+ Using Spot Instances with Determined
+**************************************
 
 Because they can be reclaimed, using spot instances requires you to have
 good fault tolerance built into your software. Determined was built with
 fault-tolerance as a core feature, so using spot instances is usually as
-easy as setting ``spot: true`` in the master configuration.
+easy as configuring a :ref:`resource pool <resource-pools>` with ``spot:
+true`` in the master configuration. Here is a fragment of a master
+configuration file that defines a resource pool with up to 10 p2.8xlarge
+spot instances:
+
+.. code:: yaml
+
+   resource_pools:
+     - pool_name: aws-spot-p2-8xlarge
+       provider:
+         type: aws
+         max_instances: 10
+         instance_type: p2.8xlarge
+         spot: true
+         # ...
+
+When using ``det deploy`` to install Determined on AWS, you can also
+specify ``--spot`` when running ``det deploy aws up`` to cause the
+default CPU and GPU resource pools to use spot instances.
 
 AWS might not always have the capacity to fulfill spot requests. When
 AWS is out of capacity, the Determined cluster will wait until AWS has
 capacity and can fulfill the requests. This will be visible in the
-master logs.
+master logs. A useful approach is to configure the master with two
+resource pools, one that uses spot instances and another that uses
+on-demand instances. This allows users to easily select whether to use
+spot or on-demand instances for a given job by setting
+``resources.resource_pool`` appropriately in their experiment
+configuration file.
 
 **************
  Spot Pricing

--- a/docs/topic-guides/system-concepts/resource-pool.txt
+++ b/docs/topic-guides/system-concepts/resource-pool.txt
@@ -12,8 +12,8 @@ goals so that you get the most value out of your money. For example, you
 may want to run your training on beefy V100 GPU machines, while you want
 your Tensorboards to run on cheap CPU machines with minimal resources.
 
-Determined has the concept of *resource pools*, which is a set of
-resources that are identical and located physically close to each other.
+Determined has the concept of a *resource pool*, which is a collection
+of identical resources that are located physically close to each other.
 Determined allows you to configure your cluster to have multiple
 resource pools and to assign tasks to a specific resource pool, so that
 you can use different sets of resources for different tasks. Each
@@ -24,12 +24,12 @@ When you configure a cluster, you set which pool is the default for CPU
 tasks and which pool is the default for GPU tasks. CPU-only tasks such a
 Tensorboards will run on the default CPU pool unless you specify that it
 should run in a different pool when launching the task. Tasks which
-require a slot such as Experiments or GPU-notebooks will launch on to
-the default GPU pool unless otherwise specified. For this reason we
+require a slot, such as experiments or GPU-notebooks, will use the
+default GPU pool unless otherwise specified. For this reason we
 recommend that you always create a cluster with at least two pools, one
 with low-cost CPU instances for CPU-only tasks and one with GPU
 instances for GPU tasks. This is the default setup when launching a
-cluster via ``det deploy``.
+cluster on AWS or GCP via ``det deploy``.
 
 Here are some scenarios where it can be valuable to use multiple
 resource pools:
@@ -42,12 +42,12 @@ resource pools:
    instances). You train your experiments using the ``aws-v100`` pool,
    while you run your Tensorboards in the ``aws-cpu`` pool. When your
    experiments complete, the ``aws-v100 pool`` can scale down to zero to
-   save money, but you can continue to run your Tensorboard. Without
+   save money, but you can continue to run your TensorBoard. Without
    resource pools, you would have needed to keep a ``p3dn.24xlarge``
-   instance running to keep the Tensorboard alive. By default
+   instance running to keep the TensorBoard alive. By default
    Tensorboard will always run on the default CPU pool.
 
--  *Use GPUs in different availability zones on AWS*
+-  *Use GPUs in different availability zones on AWS.*
 
    You have one pool ``aws-v100-us-east-1a`` that runs ``p3dn.24xlarge``
    in the ``us-east-1a`` availability zone and another pool
@@ -60,15 +60,21 @@ resource pools:
    have capacity" notification is only visible in the master logs, not
    on the experiment itself.
 
--  *Use spot/preemptible instance and fall back to on-demand if needed.*
+-  *Use spot/preemptible instances and fall back to on-demand if
+   needed.*
 
    You have one pool ``aws-v100-spot`` that you use to try to run
    training on spot instances and another pool ``aws-v100-on-demand``
    that you fall back to if AWS does not have enough spot capacity to
-   run your job.
+   run your job. Determined will not switch from spot to on-demand
+   instances automatically, but by configuring resource pools
+   appropriately, it should be easy for users to select the appropriate
+   pool depending on the job they want to run and the current
+   availability of spot instances in the AWS region they are using. For
+   more information on using spot instances, refer to :ref:`aws-spot`.
 
 -  *Use cheaper GPUs for prototyping on small datasets and expensive GPU
-   for training on full datasets*
+   for training on full datasets.*
 
    You have one pool with less expensive GPUs that you use for initial
    prototyping on small data sets and another pool that you use for
@@ -196,7 +202,7 @@ pool-specific level:
  Launching Tasks Into Resource Pools
 *************************************
 
-When creating a task, the configuration file has a section called
+When creating a task, the job configuration file has a section called
 "resources". You can set the ``resource_pool`` subfield to specify the
 ``resource_pool`` that a task should be launched into.
 
@@ -209,8 +215,7 @@ If this field is not set, the task will be launched into one of the two
 default pools defined in the :ref:`master-configuration`. Experiments
 will be launched into the default GPU pool. Tensorboards will be
 launched into the default CPU pool. Commands, Shells, and Notebooks that
-request a slot (which is the default behavior if the 'slots' field is
-not set) will be launched into the default GPU pool. Commands, Shells,
-and Notebooks that explicitly request 0 slots (for example the 'Launch
-CPU-only Notebook' button in the Web UI) will be launched into the CPU
-pool.
+request a slot (which is the default behavior if the ``resources.slots``
+field is not set) will be launched into the default GPU pool. Commands,
+Shells, and Notebooks that explicitly request 0 slots (for example the
+"Launch CPU-only Notebook" button in the Web UI) will use the CPU pool.

--- a/master/pkg/model/experiment_config.go
+++ b/master/pkg/model/experiment_config.go
@@ -182,7 +182,7 @@ func (l *Labels) UnmarshalJSON(data []byte) error {
 	return err
 }
 
-// ResourcesConfig configures experiment resource usage.
+// ResourcesConfig configures resource usage for an experiment, command, notebook, or tensorboard.
 type ResourcesConfig struct {
 	// Slots is used by commands while trials use SlotsPerTrial.
 	Slots int `json:"slots,omitempty"`


### PR DESCRIPTION
Also fix a syntax error in the cluster config reference that resulted in
a bunch of list elements being rendered incorrectly.


## Description

<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->

[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234