### PR TITLE
feat: precision prop and amp support for lightning adapter [DET-5116]

### DIFF
--- a/docs/reference/api/lightning_adapter.txt
+++ b/docs/reference/api/lightning_adapter.txt
@@ -92,8 +92,6 @@ not supported. Read about those here:
    ``on_train_epoch_end``, ``manual_backward``, ``backward``,
    ``optimizer_step``, ``optimizer_zero_grad``
 
--  Support coming soon: `precision`
-
 In addition, we also patched some ``LightningModule`` methods to make
 porting your code easier:
 

--- a/e2e_tests/.flake8
+++ b/e2e_tests/.flake8
@@ -36,3 +36,9 @@ import-order-style = edited
 # flake8-quotes
 inline-quotes = "
 multiline-quotes = """
+
+exclude =
+  ./tests/fixtures/pytorch_lightning_amp/model_def.py,
+  ./tests/fixtures/pytorch_lightning_amp/mnist.py,
+  ./tests/fixtures/pytorch_lightning_amp/data.py
+ 

--- a/e2e_tests/Makefile
+++ b/e2e_tests/Makefile
@@ -4,7 +4,10 @@ fmt:
 	isort \
 		-s ./tests/fixtures/pytorch_amp/model_def.py \
 		-s ./tests/fixtures/pytorch_amp/layers.py \
-		-s ./tests/fixtures/pytorch_amp/data.py
+		-s ./tests/fixtures/pytorch_amp/data.py \
+		-s ./tests/fixtures/pytorch_lightning_amp/model_def.py \
+		-s ./tests/fixtures/pytorch_lightning_amp/mnist.py \
+		-s ./tests/fixtures/pytorch_lightning_amp/data.py
 	# These skipped files are symlinks to another module
 	black .
 
@@ -12,7 +15,10 @@ check:
 	isort --check-only  \
 		-s ./tests/fixtures/pytorch_amp/model_def.py \
 		-s ./tests/fixtures/pytorch_amp/layers.py \
-		-s ./tests/fixtures/pytorch_amp/data.py
+		-s ./tests/fixtures/pytorch_amp/data.py \
+		-s ./tests/fixtures/pytorch_lightning_amp/model_def.py \
+		-s ./tests/fixtures/pytorch_lightning_amp/mnist.py \
+		-s ./tests/fixtures/pytorch_lightning_amp/data.py
 	black . --check
 	flake8
 	mypy tests

--- a/e2e_tests/tests/experiment/test_pytorch_lightning.py
+++ b/e2e_tests/tests/experiment/test_pytorch_lightning.py
@@ -20,3 +20,13 @@ def test_pl_mnist_gan() -> None:
     config = conf.set_max_length(config, {"batches": 200})
 
     exp.run_basic_test_with_temp_config(config, conf.gan_examples_path(exp_dir), 1)
+
+
+@pytest.mark.e2e_gpu  # type: ignore
+@pytest.mark.parametrize("api_style", ["apex", "auto"])  # type: ignore
+def test_pytorch_const_with_amp(api_style: str) -> None:
+    dir_name = "pytorch_lightning_amp"
+    config = conf.load_config(conf.fixtures_path(dir_name + "/" + api_style + "_amp.yaml"))
+    config = conf.set_max_length(config, {"batches": 200})
+
+    exp.run_basic_test_with_temp_config(config, conf.fixtures_path(dir_name), 1)

--- a/e2e_tests/tests/fixtures/pytorch_lightning_amp/apex_amp.yaml
+++ b/e2e_tests/tests/fixtures/pytorch_lightning_amp/apex_amp.yaml
@@ -1,0 +1,18 @@
+description: mnist_pytorch_lightning_const  with PyTorch APEX support configured
+data:
+  url: "https://s3-us-west-2.amazonaws.com/determined-ai-test-data/pytorch_mnist.tar.gz"
+hyperparameters:
+  global_batch_size: 64
+  learning_rate: 0.001
+searcher:
+  name: single
+  metric: val_loss
+  max_length:
+      batches: 937
+  smaller_is_better: true
+entrypoint: apex_amp_model_def:MNistApexAMPTrial
+environment:
+  image:
+    gpu: determinedai/environments:cuda-10.2-pytorch-1.7-lightning-1.2-tf-2.4-gpu-0.10.0
+    cpu: determinedai/environments:py-3.7-pytorch-1.7-lightning-1.2-tf-2.4-cpu-0.10.0
+

--- a/e2e_tests/tests/fixtures/pytorch_lightning_amp/apex_amp_model_def.py
+++ b/e2e_tests/tests/fixtures/pytorch_lightning_amp/apex_amp_model_def.py
@@ -1,6 +1,6 @@
 """
-This example demonstrates how to modify a model to use PyTorch's support for
-NVIDIA APEX in Determined.
+This example demonstrates how to modify a LightningAdapter model to
+use PyTorchTrial support for NVIDIA APEX in Determined.
 """
 
 from model_def import MNISTTrial

--- a/e2e_tests/tests/fixtures/pytorch_lightning_amp/apex_amp_model_def.py
+++ b/e2e_tests/tests/fixtures/pytorch_lightning_amp/apex_amp_model_def.py
@@ -1,0 +1,13 @@
+"""
+This example demonstrates how to modify a model to use PyTorch's support for
+NVIDIA APEX in Determined.
+"""
+
+from model_def import MNISTTrial
+
+from determined.pytorch import PyTorchTrialContext
+
+
+class MNistApexAMPTrial(MNISTTrial):
+    def __init__(self, context: PyTorchTrialContext) -> None:
+        super().__init__(context, precision=16, amp_backend="apex")

--- a/e2e_tests/tests/fixtures/pytorch_lightning_amp/auto_amp.yaml
+++ b/e2e_tests/tests/fixtures/pytorch_lightning_amp/auto_amp.yaml
@@ -1,0 +1,18 @@
+description: mnist_pytorch_lightning_const with PyTorch AMP API automatically enabled
+data:
+  url: "https://s3-us-west-2.amazonaws.com/determined-ai-test-data/pytorch_mnist.tar.gz"
+hyperparameters:
+  global_batch_size: 64
+  learning_rate: 0.001
+searcher:
+  name: single
+  metric: val_loss
+  max_length:
+      batches: 937
+  smaller_is_better: true
+entrypoint: auto_amp_model_def:MNistAutoAMPTrial
+environment:
+  image:
+    gpu: determinedai/environments:cuda-10.2-pytorch-1.7-lightning-1.2-tf-2.4-gpu-0.10.0
+    cpu: determinedai/environments:py-3.7-pytorch-1.7-lightning-1.2-tf-2.4-cpu-0.10.0
+

--- a/e2e_tests/tests/fixtures/pytorch_lightning_amp/auto_amp_model_def.py
+++ b/e2e_tests/tests/fixtures/pytorch_lightning_amp/auto_amp_model_def.py
@@ -1,0 +1,24 @@
+"""
+This example demonstrates how to modify a model to use PyTorch's native AMP
+(automatic mixed precision) support in Determined.
+
+In the `__init__` method, amp_init() is called (and this accepts parameters to
+tune the GradScaler).
+
+The methods `train_batch` and `evaluate_batch` are modified to use an autocast
+context during the forward pass.
+"""
+
+from typing import Dict, Sequence, Union
+
+import torch
+from model_def import MNISTTrial
+
+from determined.pytorch import PyTorchTrialContext
+
+TorchData = Union[Dict[str, torch.Tensor], Sequence[torch.Tensor], torch.Tensor]
+
+
+class MNistAutoAMPTrial(MNISTTrial):
+    def __init__(self, context: PyTorchTrialContext) -> None:
+        super().__init__(context, precision=16)

--- a/e2e_tests/tests/fixtures/pytorch_lightning_amp/auto_amp_model_def.py
+++ b/e2e_tests/tests/fixtures/pytorch_lightning_amp/auto_amp_model_def.py
@@ -1,12 +1,6 @@
 """
-This example demonstrates how to modify a model to use PyTorch's native AMP
-(automatic mixed precision) support in Determined.
-
-In the `__init__` method, amp_init() is called (and this accepts parameters to
-tune the GradScaler).
-
-The methods `train_batch` and `evaluate_batch` are modified to use an autocast
-context during the forward pass.
+This example demonstrates how to modify a LightningAdapter model to
+use PyTorch's native AMP (automatic mixed precision) support in Determined.
 """
 
 from typing import Dict, Sequence, Union

--- a/e2e_tests/tests/fixtures/pytorch_lightning_amp/data.py
+++ b/e2e_tests/tests/fixtures/pytorch_lightning_amp/data.py
@@ -1,0 +1,1 @@
+../../../../examples/computer_vision/mnist_pl/data.py

--- a/e2e_tests/tests/fixtures/pytorch_lightning_amp/mnist.py
+++ b/e2e_tests/tests/fixtures/pytorch_lightning_amp/mnist.py
@@ -1,0 +1,1 @@
+../../../../examples/computer_vision/mnist_pl/mnist.py

--- a/e2e_tests/tests/fixtures/pytorch_lightning_amp/model_def.py
+++ b/e2e_tests/tests/fixtures/pytorch_lightning_amp/model_def.py
@@ -1,0 +1,1 @@
+../../../../examples/computer_vision/mnist_pl/model_def.py

--- a/examples/computer_vision/mnist_pl/model_def.py
+++ b/examples/computer_vision/mnist_pl/model_def.py
@@ -9,13 +9,13 @@ from determined.pytorch.lightning import LightningAdapter
 import mnist
 
 class MNISTTrial(LightningAdapter):
-    def __init__(self, context: PyTorchTrialContext) -> None:
+    def __init__(self, context: PyTorchTrialContext, *args, **kwargs) -> None:
         lm = mnist.LightningMNISTClassifier(lr=context.get_hparam('learning_rate'))
         data_dir = f"/tmp/data-rank{context.distributed.get_rank()}"
         self.dm = mnist.MNISTDataModule(context.get_data_config()["url"],
                                         data_dir)
 
-        super().__init__(context, lightning_module=lm)
+        super().__init__(context, lightning_module=lm, *args, **kwargs)
         self.dm.prepare_data()
 
     def build_training_data_loader(self) -> DataLoader:

--- a/harness/determined/pytorch/lightning/_adapter.py
+++ b/harness/determined/pytorch/lightning/_adapter.py
@@ -151,15 +151,18 @@ class LightningAdapter(PyTorchTrial):
                 super().__init__(context, lightning_module=lm)
 
         Arguments:
-            context (``PyTorchTrialContext``)
+            context (PyTorchTrialContext)
             lightning_module (``LightningModule``):
-                user-defined lightning module.
-            precision (32, 16):
-                precision to use.
-            amp_backend ("native", "apex"):
-                automatic mixed precision backend to use.
-            amp_level ('O0', 'O1', 'O2', 'O3'):
+                User-defined lightning module.
+            precision (int, default=32):
+                Precision to use.
+                Accepted values are 16, and 32.
+            amp_backend (str):
+                Automatic mixed precision backend to use.
+                Accepted values are "native", and "mixed".
+            amp_level (str, optional):
                 Apex amp optimization level.
+                Accepted values are "O0", "O1", "O2", and "O3".
                 https://nvidia.github.io/apex/amp.html#opt-levels-and-properties
 
         """

--- a/harness/determined/pytorch/lightning/_adapter.py
+++ b/harness/determined/pytorch/lightning/_adapter.py
@@ -125,7 +125,7 @@ class LightningAdapter(PyTorchTrial):
         self,
         context: PyTorchTrialContext,
         lightning_module: pl.LightningModule,
-        precision: Union[Literal[32], Literal[16]] = 32,
+        precision: int = 32,
         amp_backend: Union[Literal["native"], Literal["apex"]] = "native",
         amp_level: Optional[str] = None,
     ):
@@ -150,14 +150,17 @@ class LightningAdapter(PyTorchTrial):
                 lm = mnist.LightningMNISTClassifier(lr=context.get_hparam('learning_rate'))
                 super().__init__(context, lightning_module=lm)
 
-
-        :param context: a reference to the associated PyTorchTrialContext.
-        :param lightning_module: user-defined lightning module.
-        :param precision: the type of precision to use.
-        :param amp_backend: automatic mixed precision backend to use.
-        :param amp_level: Apex amp optimization level.
-            https://nvidia.github.io/apex/amp.html#opt-levels-and-properties
-
+        Arguments:
+            context (``PyTorchTrialContext``)
+            lightning_module (``LightningModule``):
+                user-defined lightning module.
+            precision (32, 16):
+                precision to use.
+            amp_backend ("native", "apex"):
+                automatic mixed precision backend to use.
+            amp_level ('O0', 'O1', 'O2', 'O3'):
+                Apex amp optimization level.
+                https://nvidia.github.io/apex/amp.html#opt-levels-and-properties
 
         """
         check_compatibility(lightning_module)

--- a/harness/determined/pytorch/lightning/_adapter.py
+++ b/harness/determined/pytorch/lightning/_adapter.py
@@ -152,13 +152,9 @@ class LightningAdapter(PyTorchTrial):
 
 
         :param context: a reference to the associated PyTorchTrialContext.
-        :type context: PyTorchTrialContext
         :param lightning_module: user-defined lightning module.
-        :type lightning_module: LightningModule
         :param precision: the type of precision to use.
-        :type precision: Union[Literal[32], Literal[16]]
         :param amp_backend: automatic mixed precision backend to use.
-        :type amp_backend: str
         :param amp_level: Apex amp optimization level.
             https://nvidia.github.io/apex/amp.html#opt-levels-and-properties
 

--- a/harness/determined/pytorch/lightning/_adapter.py
+++ b/harness/determined/pytorch/lightning/_adapter.py
@@ -125,7 +125,7 @@ class LightningAdapter(PyTorchTrial):
         self,
         context: PyTorchTrialContext,
         lightning_module: pl.LightningModule,
-        precision: int = 32,
+        precision: Union[Literal[32], Literal[16]] = 32,
         amp_backend: Union[Literal["native"], Literal["apex"]] = "native",
         amp_level: Optional[str] = None,
     ):
@@ -150,17 +150,14 @@ class LightningAdapter(PyTorchTrial):
                 lm = mnist.LightningMNISTClassifier(lr=context.get_hparam('learning_rate'))
                 super().__init__(context, lightning_module=lm)
 
-        Arguments:
-            context (``PyTorchTrialContext``)
-            lightning_module (``LightningModule``):
-                user-defined lightning module.
-            precision (32, 16):
-                precision to use.
-            amp_backend ("native", "apex"):
-                automatic mixed precision backend to use.
-            amp_level ('O0', 'O1', 'O2', 'O3'):
-                Apex amp optimization level.
-                https://nvidia.github.io/apex/amp.html#opt-levels-and-properties
+
+        :param context: a reference to the associated PyTorchTrialContext.
+        :param lightning_module: user-defined lightning module.
+        :param precision: the type of precision to use.
+        :param amp_backend: automatic mixed precision backend to use.
+        :param amp_level: Apex amp optimization level.
+            https://nvidia.github.io/apex/amp.html#opt-levels-and-properties
+
 
         """
         check_compatibility(lightning_module)

--- a/harness/determined/pytorch/lightning/_adapter.py
+++ b/harness/determined/pytorch/lightning/_adapter.py
@@ -152,9 +152,13 @@ class LightningAdapter(PyTorchTrial):
 
 
         :param context: a reference to the associated PyTorchTrialContext.
+        :type context: PyTorchTrialContext
         :param lightning_module: user-defined lightning module.
+        :type lightning_module: LightningModule
         :param precision: the type of precision to use.
+        :type precision: Union[Literal[32], Literal[16]]
         :param amp_backend: automatic mixed precision backend to use.
+        :type amp_backend: str
         :param amp_level: Apex amp optimization level.
             https://nvidia.github.io/apex/amp.html#opt-levels-and-properties
 


### PR DESCRIPTION
## Description

- add parameters `precision`, `amp_level`, and `amp_backend` to LightningAdapter to allow user to set up automatic mixed precision using a similar API to trainer and without calling `auto_amp` or `configure_apex_amp`.
- set precision property

<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan
gpu e2e tests are added and passed here :
https://app.circleci.com/pipelines/github/determined-ai/determined?branch=ptl-amp

<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

users can opt to avoid using the added parameters and set up AMP themselves using PyTorchTrial APIs

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234