### PR TITLE
chore: Moving back to Python 3.7 and PyTorch 1.7.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,11 +97,11 @@ commands:
       - when:
           condition: <<parameters.tf1>>
           steps:
-            - run: docker pull determinedai/environments:py-3.7-pytorch-1.8-tf-1.15-cpu-145c0d8
+            - run: docker pull determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-1c4ea10
       - when:
           condition: <<parameters.tf2>>
           steps:
-            - run: docker pull determinedai/environments:py-3.7-pytorch-1.8-lightning-1.2-tf-2.4-cpu-145c0d8
+            - run: docker pull determinedai/environments:py-3.7-pytorch-1.7-lightning-1.2-tf-2.4-cpu-1c4ea10
 
   login-docker:
     parameters:
@@ -612,8 +612,8 @@ commands:
           values-to-override: |
             detVersion=<<parameters.det-version>>,\
             maxSlotsPerPod=<<parameters.gpus-per-machine>>,\
-            taskContainerDefaults.cpuImage=determinedai/environments:cuda-11.1-pytorch-1.8-lightning-1.2-tf-2.4-gpu-0.9.0,\
-            taskContainerDefaults.gpuImage=determinedai/environments:cuda-11.1-pytorch-1.8-lightning-1.2-tf-2.4-gpu-0.9.0,\
+            taskContainerDefaults.cpuImage=determinedai/environments:cuda-11.0-pytorch-1.7-lightning-1.2-tf-2.4-gpu-0.10.0,\
+            taskContainerDefaults.gpuImage=determinedai/environments:cuda-11.0-pytorch-1.7-lightning-1.2-tf-2.4-gpu-0.10.0,\
             checkpointStorage.type=gcs,\
             checkpointStorage.bucket=det-ci
       - set-master-address-gke:
@@ -1503,8 +1503,8 @@ jobs:
       # "CUDA" environment variable is set to 11.
       # TODO: (DET-4918): we should ensure a consistent way to have tests that can run against
       # both major TensorFlow versions do so regularly (but not others).
-      TF1_GPU_IMAGE: determinedai/environments:cuda-11.1-pytorch-1.8-lightning-1.2-tf-2.4-gpu-0.9.0
-      TF2_GPU_IMAGE: determinedai/environments:cuda-11.1-pytorch-1.8-lightning-1.2-tf-2.4-gpu-0.9.0
+      TF1_GPU_IMAGE: determinedai/environments:cuda-11.0-pytorch-1.7-lightning-1.2-tf-2.4-gpu-0.10.0
+      TF2_GPU_IMAGE: determinedai/environments:cuda-11.0-pytorch-1.7-lightning-1.2-tf-2.4-gpu-0.10.0
       CUDA: 11
     steps:
       - checkout

--- a/docs/faq.txt
+++ b/docs/faq.txt
@@ -203,9 +203,9 @@ container image that has been configured for that experiment. Determined
 provides prebuilt Docker images that include TensorFlow 1.15, 2.2, and
 2.4, respectively:
 
--  ``determinedai/environments:cuda-10.2-pytorch-1.8-tf-1.15-gpu-0.9.0``
+-  ``determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-0.10.0``
    (default)
--  ``determinedai/environments:cuda-10.2-pytorch-1.8-lightning-1.2-tf-2.4-gpu-0.9.0``
+-  ``determinedai/environments:cuda-10.2-pytorch-1.7-lightning-1.2-tf-2.4-gpu-0.10.0``
 
 To change the container image used for an experiment, specify
 :ref:`environment.image <exp-environment-image>` in the experiment

--- a/docs/how-to/custom-env.txt
+++ b/docs/how-to/custom-env.txt
@@ -95,7 +95,7 @@ executed in containers with the following:
 -  CUDA 10.2
 -  Python 3.7
 -  TensorFlow 1.15.5
--  PyTorch 1.8.0
+-  PyTorch 1.7.1
 
 Determined will automatically select GPU-specific versions of each
 library when running on agents with GPUs.
@@ -109,9 +109,9 @@ and values of the hyperparameters for the current trial.
 .. note::
 
    The default images are
-   ``determinedai/environments:cuda-10.2-pytorch-1.8-tf-1.15-gpu-0.9.0``
+   ``determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-0.10.0``
    and
-   ``determinedai/environments:py-3.7-pytorch-1.8-tf-1.15-cpu-0.9.0``
+   ``determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-0.10.0``
    for GPU and CPU respectively.
 
 CUDA 11 Images
@@ -125,14 +125,15 @@ commands containing the following:
 -  CUDA 11.0
 -  Python 3.6.9
 -  TensorFlow 2.4.1
--  PyTorch 1.7.0
+-  PyTorch 1.7.1
+-  PyTorch Lightning 1.2
 
 This can be configured in your experiment configuration like below:
 
 .. code:: yaml
 
    environment:
-     image: "determinedai/environments:cuda-11.0-pytorch-1.7-tf-2.4-gpu-0.9.0"
+     image: "determinedai/environments:cuda-11.0-pytorch-1.7-lightning-1.2-tf-2.4-gpu-0.10.0"
 
 Older Images
 ============
@@ -172,7 +173,7 @@ Here is an example of a ``Dockerfile`` that installs both ``conda``- and
 
 .. code::
 
-   FROM determinedai/environments:cuda-10.2-pytorch-1.8-tf-1.15-gpu-0.9.0
+   FROM determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-0.10.0
    RUN apt-get update && apt-get install -y unzip python-opencv graphviz
    COPY environment.yml /tmp/environment.yml
    COPY pip_requirements.txt /tmp/pip_requirements.txt

--- a/docs/how-to/tensorboard.txt
+++ b/docs/how-to/tensorboard.txt
@@ -68,7 +68,7 @@ data with a bind-mount.
 .. code:: yaml
 
    environment:
-     image: determinedai/environments:cuda-10.0-pytorch-1.4-tf-1.15-cpu-0.5.0
+     image: determinedai/environments:cuda-10.2-pytorch-1.7-lightning-1.2-tf-2.4-gpu-0.10.0
    bind_mounts:
      - host_path: /my/agent/path
        container_path: /my/container/path

--- a/docs/reference/cluster-config.txt
+++ b/docs/reference/cluster-config.txt
@@ -267,9 +267,9 @@ The master supports the following configuration settings:
       specifying a dict with two keys, ``cpu`` and ``gpu``. Default
       values:
 
-      -  ``determinedai/environments:py-3.7-pytorch-1.8-tf-1.15-cpu-0.9.0``
+      -  ``determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-0.10.0``
          for CPU agents
-      -  ``determinedai/environments:cuda-10.2-pytorch-1.8-tf-1.15-gpu-0.9.0``
+      -  ``determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-0.10.0``
          for GPU agents.
 
    -  ``force_pull_image``: Defines the default policy for forcibly

--- a/docs/reference/command-notebook-config.txt
+++ b/docs/reference/command-notebook-config.txt
@@ -49,9 +49,9 @@ The following configuration settings are supported:
       Determined agent machine in the cluster. Users can customize the
       image used for GPU vs. CPU agents by specifying a dict with two
       keys, ``cpu`` and ``gpu``. Defaults to
-      ``determinedai/environments:py-3.7-pytorch-1.8-tf-1.15-cpu-0.9.0``
+      ``determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-0.10.0``
       for CPU agents and
-      ``determinedai/environments:cuda-10.2-pytorch-1.8-tf-1.15-gpu-0.9.0``
+      ``determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-0.10.0``
       for GPU agents.
 
    -  ``force_pull_image``: Forcibly pull the image from the Docker

--- a/docs/reference/experiment-config.txt
+++ b/docs/reference/experiment-config.txt
@@ -1023,9 +1023,9 @@ more information on customizing the trial environment, refer to
    GPU vs. CPU agents by specifying a dict with two keys, ``cpu`` and
    ``gpu``. Default values:
 
-   -  ``determinedai/environments:cuda-10.2-pytorch-1.8-tf-1.15-gpu-0.9.0``
+   -  ``determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-0.10.0``
       for agents with GPUs.
-   -  ``determinedai/environments:py-3.7-pytorch-1.8-tf-1.15-cpu-0.9.0``
+   -  ``determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-0.10.0``
       for agents with only CPUs.
 
 ``force_pull_image``

--- a/docs/reference/helm-config.txt
+++ b/docs/reference/helm-config.txt
@@ -204,12 +204,12 @@ Helm Chart </helm/determined-0.5.0.tgz>`.
    -  ``cpuImage``: Sets the default docker image for all non-gpu tasks.
       If a docker image is specified in the :ref:`experiment config
       <exp-environment-image>` this default is overriden. Defaults to:
-      ``determinedai/environments:py-3.7-pytorch-1.8-tf-1.15-cpu-0.9.0``.
+      ``determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-0.10.0``.
 
    -  ``gpuImage``: Sets the default docker image for all gpu tasks. If
       a docker image is specified in the :ref:`experiment config
       <exp-environment-image>` this default is overriden. Defaults to:
-      ``determinedai/environments:cuda-10.2-pytorch-1.8-tf-1.15-gpu-0.9.0``.
+      ``determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-0.10.0``.
 
 -  ``enterpriseEdition``: Specifies whether to use Determined enterprise
    edition.

--- a/docs/tutorials/quick-start.txt
+++ b/docs/tutorials/quick-start.txt
@@ -43,10 +43,10 @@ cluster without writing a model, see :ref:`commands-and-shells`.
 .. code::
 
    # For CPU computations
-   docker pull determinedai/environments:py-3.7-pytorch-1.8-tf-1.15-cpu-0.9.0
+   docker pull determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-0.10.0
 
    # For GPU computations
-   docker pull determinedai/environments:cuda-10.2-pytorch-1.8-tf-1.15-gpu-0.9.0
+   docker pull determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-0.10.0
 
 .. _quick-start-first-job:
 

--- a/e2e_tests/tests/config.py
+++ b/e2e_tests/tests/config.py
@@ -12,13 +12,13 @@ MAX_TASK_SCHEDULED_SECS = 30
 MAX_TRIAL_BUILD_SECS = 90
 
 
-DEFAULT_TF1_CPU_IMAGE = "determinedai/environments:py-3.7-pytorch-1.8-tf-1.15-cpu-145c0d8"
+DEFAULT_TF1_CPU_IMAGE = "determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-1c4ea10"
 DEFAULT_TF2_CPU_IMAGE = (
-    "determinedai/environments:py-3.7-pytorch-1.8-lightning-1.2-tf-2.4-cpu-145c0d8"
+    "determinedai/environments:py-3.7-pytorch-1.7-lightning-1.2-tf-2.4-cpu-1c4ea10"
 )
-DEFAULT_TF1_GPU_IMAGE = "determinedai/environments:cuda-10.2-pytorch-1.8-tf-1.15-gpu-145c0d8"
+DEFAULT_TF1_GPU_IMAGE = "determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-1c4ea10"
 DEFAULT_TF2_GPU_IMAGE = (
-    "determinedai/environments:cuda-10.2-pytorch-1.8-lightning-1.2-tf-2.4-gpu-145c0d8"
+    "determinedai/environments:cuda-10.2-pytorch-1.7-lightning-1.2-tf-2.4-gpu-1c4ea10"
 )
 
 TF1_CPU_IMAGE = os.environ.get("TF1_CPU_IMAGE") or DEFAULT_TF1_CPU_IMAGE

--- a/examples/computer_vision/mnist_pl/adaptive.yaml
+++ b/examples/computer_vision/mnist_pl/adaptive.yaml
@@ -19,5 +19,5 @@ searcher:
 entrypoint: model_def:MNISTTrial
 environment:
   image:
-    gpu: determinedai/environments:cuda-10.1-pytorch-1.7-lightning-1.2-tf-2.4-gpu-0.9.0
-    cpu: determinedai/environments:py-3.6.9-pytorch-1.7-lightning-1.2-tf-2.4-cpu-0.9.0
+    gpu: determinedai/environments:cuda-10.2-pytorch-1.7-lightning-1.2-tf-2.4-gpu-0.10.0
+    cpu: determinedai/environments:py-3.7-pytorch-1.7-lightning-1.2-tf-2.4-cpu-0.10.0

--- a/examples/computer_vision/mnist_pl/const.yaml
+++ b/examples/computer_vision/mnist_pl/const.yaml
@@ -13,5 +13,5 @@ searcher:
 entrypoint: model_def:MNISTTrial
 environment:
   image:
-    gpu: determinedai/environments:cuda-10.1-pytorch-1.7-lightning-1.2-tf-2.4-gpu-0.9.0
-    cpu: determinedai/environments:py-3.6.9-pytorch-1.7-lightning-1.2-tf-2.4-cpu-0.9.0
+    gpu: determinedai/environments:cuda-10.2-pytorch-1.7-lightning-1.2-tf-2.4-gpu-0.10.0
+    cpu: determinedai/environments:py-3.7-pytorch-1.7-lightning-1.2-tf-2.4-cpu-0.10.0

--- a/examples/computer_vision/unets_tf_keras/const.yaml
+++ b/examples/computer_vision/unets_tf_keras/const.yaml
@@ -22,4 +22,4 @@ min_validation_period:
 entrypoint: model_def:UNetsTrial
 scheduling_unit: 57
 environment:
-    image: determinedai/environments:cuda-10.1-pytorch-1.4-tf-2.2-gpu-23863bb
+    image: determinedai/environments:cuda-10.2-pytorch-1.7-lightning-1.2-tf-2.4-gpu-0.10.0

--- a/examples/computer_vision/unets_tf_keras/distributed.yaml
+++ b/examples/computer_vision/unets_tf_keras/distributed.yaml
@@ -25,4 +25,4 @@ min_validation_period:
 scheduling_unit: 8
 entrypoint: model_def:UNetsTrial
 environment:
-    image: determinedai/environments:cuda-10.1-pytorch-1.4-tf-2.2-gpu-23863bb
+    image: determinedai/environments:cuda-10.2-pytorch-1.7-lightning-1.2-tf-2.4-gpu-0.10.0

--- a/examples/decision_trees/gbt_titanic_estimator/adaptive.yaml
+++ b/examples/decision_trees/gbt_titanic_estimator/adaptive.yaml
@@ -42,4 +42,4 @@ searcher:
 entrypoint: model_def:BoostedTreesTrial
 scheduling_unit: 1
 environment:
-  image: "determinedai/environments:py-3.7-pytorch-1.8-tf-1.15-cpu-0.9.0"
+  image: "determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-0.10.0"

--- a/examples/decision_trees/gbt_titanic_estimator/const.yaml
+++ b/examples/decision_trees/gbt_titanic_estimator/const.yaml
@@ -20,4 +20,4 @@ searcher:
 entrypoint: model_def:BoostedTreesTrial
 scheduling_unit: 1
 environment:
-  image: "determinedai/environments:py-3.7-pytorch-1.8-tf-1.15-cpu-0.9.0" 
+  image: "determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-0.10.0" 

--- a/examples/gan/dcgan_tf_keras/const.yaml
+++ b/examples/gan/dcgan_tf_keras/const.yaml
@@ -15,5 +15,5 @@ entrypoint: model_def:DCGanTrial
 environment:
   # This model only works with Tensorflow 2.2+.
   image:
-     cpu: "determinedai/environments:py-3.7-pytorch-1.8-lightning-1.2-tf-2.4-cpu-145c0d8"
-     gpu: "determinedai/environments:cuda-10.2-pytorch-1.8-lightning-1.2-tf-2.4-gpu-145c0d8"
+     cpu: "determinedai/environments:py-3.7-pytorch-1.7-lightning-1.2-tf-2.4-cpu-1c4ea10"
+     gpu: "determinedai/environments:cuda-10.2-pytorch-1.7-lightning-1.2-tf-2.4-gpu-1c4ea10"

--- a/examples/gan/dcgan_tf_keras/distributed.yaml
+++ b/examples/gan/dcgan_tf_keras/distributed.yaml
@@ -17,5 +17,5 @@ resources:
 environment:
   # This model only works with Tensorflow 2.2+.
   image:
-     cpu: "determinedai/environments:py-3.7-pytorch-1.8-lightning-1.2-tf-2.4-cpu-145c0d8"
-     gpu: "determinedai/environments:cuda-10.2-pytorch-1.8-lightning-1.2-tf-2.4-gpu-145c0d8"
+     cpu: "determinedai/environments:py-3.7-pytorch-1.7-lightning-1.2-tf-2.4-cpu-1c4ea10"
+     gpu: "determinedai/environments:cuda-10.2-pytorch-1.7-lightning-1.2-tf-2.4-gpu-1c4ea10"

--- a/examples/gan/gan_mnist_pl/adaptive.yaml
+++ b/examples/gan/gan_mnist_pl/adaptive.yaml
@@ -25,5 +25,5 @@ resources:
 entrypoint: model_def:GANTrial
 environment:
   image:
-    gpu: determinedai/environments:cuda-10.1-pytorch-1.7-lightning-1.2-tf-2.4-gpu-0.9.0
-    cpu: determinedai/environments:py-3.6.9-pytorch-1.7-lightning-1.2-tf-2.4-cpu-0.9.0
+    gpu: determinedai/environments:cuda-10.2-pytorch-1.7-lightning-1.2-tf-2.4-gpu-0.10.0
+    cpu: determinedai/environments:py-3.7-pytorch-1.7-lightning-1.2-tf-2.4-cpu-0.10.0

--- a/examples/gan/gan_mnist_pl/const.yaml
+++ b/examples/gan/gan_mnist_pl/const.yaml
@@ -16,5 +16,5 @@ searcher:
 entrypoint: model_def:GANTrial
 environment:
   image:
-    gpu: determinedai/environments:cuda-10.1-pytorch-1.7-lightning-1.2-tf-2.4-gpu-0.9.0
-    cpu: determinedai/environments:py-3.6.9-pytorch-1.7-lightning-1.2-tf-2.4-cpu-0.9.0
+    gpu: determinedai/environments:cuda-10.2-pytorch-1.7-lightning-1.2-tf-2.4-gpu-0.10.0
+    cpu: determinedai/environments:py-3.7-pytorch-1.7-lightning-1.2-tf-2.4-cpu-0.10.0

--- a/examples/gan/gan_mnist_pl/distributed.yaml
+++ b/examples/gan/gan_mnist_pl/distributed.yaml
@@ -25,5 +25,5 @@ resources:
 entrypoint: model_def:GANTrial
 environment:
   image:
-    gpu: determinedai/environments:cuda-10.1-pytorch-1.7-lightning-1.2-tf-2.4-gpu-0.9.0
-    cpu: determinedai/environments:py-3.6.9-pytorch-1.7-lightning-1.2-tf-2.4-cpu-0.9.0
+    gpu: determinedai/environments:cuda-10.2-pytorch-1.7-lightning-1.2-tf-2.4-gpu-0.10.0
+    cpu: determinedai/environments:py-3.7-pytorch-1.7-lightning-1.2-tf-2.4-cpu-0.10.0

--- a/harness/determined/common/schemas/expconf/_v0.py
+++ b/harness/determined/common/schemas/expconf/_v0.py
@@ -207,9 +207,9 @@ class EnvironmentImageV0(schemas.SchemaBase):
 
     def runtime_defaults(self) -> None:
         if self.cpu is None:
-            self.cpu = "determinedai/environments:py-3.7-pytorch-1.8-tf-1.15-cpu-145c0d8"
+            self.cpu = "determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-1c4ea10"
         if self.gpu is None:
-            self.gpu = "determinedai/environments:cuda-10.2-pytorch-1.8-tf-1.15-gpu-145c0d8"
+            self.gpu = "determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-1c4ea10"
 
 
 class EnvironmentVariablesV0(schemas.SchemaBase):

--- a/harness/determined/deploy/aws/templates/efs.yaml
+++ b/harness/determined/deploy/aws/templates/efs.yaml
@@ -3,36 +3,36 @@ Description:  This template deploys a VPC, with a public and private subnet. It 
 Mappings:
   RegionMap:
     ap-northeast-1:
-      Master: ami-093c296276d61b583
-      Agent: ami-09e14aa0aa0dcb32d
+      Master: ami-005021e678ab162ea
+      Agent: ami-039e09c6582ec61c5
     # TODO(DET-4258) Uncomment these when we fully support all P3 regions.
     # ap-northeast-2:
-    #   Master: ami-0632cfe5256e6b811
-    #   Agent: ami-0be5ff6df8b8d1a40
+    #   Master: ami-090b3f1f06a12d28d
+    #   Agent: ami-063ee28bcaee0c2b1
     # ap-southeast-1:
-    #   Master: ami-010e14b2b7ac1b58f
-    #   Agent: ami-01db1862ab8c2920b
+    #   Master: ami-01e1605d140c6b5e6
+    #   Agent: ami-0cc963cd1e2f1b045
     # ap-southeast-2:
-    #   Master: ami-04fad20d313cc0947
-    #   Agent: ami-00174d24de08746a5
+    #   Master: ami-00d02a4b2cf1df2f4
+    #   Agent: ami-0612c09a99b545d53
     eu-central-1:
-      Master: ami-0ce70c4057dc39200
-      Agent: ami-00b4f432a0da11788
+      Master: ami-08c1695e3dcdd191e
+      Agent: ami-0e706905d18bcf024
     eu-west-1:
-      Master: ami-0d94cb8577ea0e2fd
-      Agent: ami-07713577ece651903
+      Master: ami-08fabf5d4fa6fcc12
+      Agent: ami-020a8186dcd6e0222
     # eu-west-2:
-    #   Master: ami-009725fa4dfe4acb0
-    #   Agent: ami-0ae7e172e79ecb809
+    #   Master: ami-0b3e07036579e1b57
+    #   Agent: ami-01163cd376120c8c8
     us-east-1:
-      Master: ami-09943f9da1f1b7899
-      Agent: ami-0f9b07080cf36d8fa
+      Master: ami-056db1277deef2218
+      Agent: ami-0e8bcb2511e8ecd6e
     us-east-2:
-      Master: ami-0bcacfac640850227
-      Agent: ami-0db1a4eb8743660dc
+      Master: ami-0a4b51dd47f678ba3
+      Agent: ami-0c8afd5575ba72550
     us-west-2:
-      Master: ami-076cbb27c223df09a
-      Agent: ami-0a1f00f048dc70fd5
+      Master: ami-0ee876776acf64c80
+      Agent: ami-06380c60a2b768f2d
 
 Parameters:
   VpcCIDR:

--- a/harness/determined/deploy/aws/templates/fsx.yaml
+++ b/harness/determined/deploy/aws/templates/fsx.yaml
@@ -2,36 +2,36 @@ Description:  This template deploys a VPC, with a public and private subnet, and
 Mappings:
   RegionMap:
     ap-northeast-1:
-      Master: ami-093c296276d61b583
-      Agent: ami-09e14aa0aa0dcb32d
+      Master: ami-005021e678ab162ea
+      Agent: ami-039e09c6582ec61c5
     # TODO(DET-4258) Uncomment these when we fully support all P3 regions.
     # ap-northeast-2:
-    #   Master: ami-0632cfe5256e6b811
-    #   Agent: ami-0be5ff6df8b8d1a40
+    #   Master: ami-090b3f1f06a12d28d
+    #   Agent: ami-063ee28bcaee0c2b1
     # ap-southeast-1:
-    #   Master: ami-010e14b2b7ac1b58f
-    #   Agent: ami-01db1862ab8c2920b
+    #   Master: ami-01e1605d140c6b5e6
+    #   Agent: ami-0cc963cd1e2f1b045
     # ap-southeast-2:
-    #   Master: ami-04fad20d313cc0947
-    #   Agent: ami-00174d24de08746a5
+    #   Master: ami-00d02a4b2cf1df2f4
+    #   Agent: ami-0612c09a99b545d53
     eu-central-1:
-      Master: ami-0ce70c4057dc39200
-      Agent: ami-00b4f432a0da11788
+      Master: ami-08c1695e3dcdd191e
+      Agent: ami-0e706905d18bcf024
     eu-west-1:
-      Master: ami-0d94cb8577ea0e2fd
-      Agent: ami-07713577ece651903
+      Master: ami-08fabf5d4fa6fcc12
+      Agent: ami-020a8186dcd6e0222
     # eu-west-2:
-    #   Master: ami-009725fa4dfe4acb0
-    #   Agent: ami-0ae7e172e79ecb809
+    #   Master: ami-0b3e07036579e1b57
+    #   Agent: ami-01163cd376120c8c8
     us-east-1:
-      Master: ami-09943f9da1f1b7899
-      Agent: ami-0f9b07080cf36d8fa
+      Master: ami-056db1277deef2218
+      Agent: ami-0e8bcb2511e8ecd6e
     us-east-2:
-      Master: ami-0bcacfac640850227
-      Agent: ami-0db1a4eb8743660dc
+      Master: ami-0a4b51dd47f678ba3
+      Agent: ami-0c8afd5575ba72550
     us-west-2:
-      Master: ami-076cbb27c223df09a
-      Agent: ami-0a1f00f048dc70fd5
+      Master: ami-0ee876776acf64c80
+      Agent: ami-06380c60a2b768f2d
 
 Parameters:
   VpcCIDR:

--- a/harness/determined/deploy/aws/templates/secure.yaml
+++ b/harness/determined/deploy/aws/templates/secure.yaml
@@ -3,46 +3,46 @@ Description:  This template deploys a VPC, with a public and private subnet. It 
 Mappings:
   RegionMap:
     ap-northeast-1:
-      Master: ami-093c296276d61b583
-      Agent: ami-09e14aa0aa0dcb32d
-      Bastion: ami-0ef85cf6e604e5650
+      Master: ami-005021e678ab162ea
+      Agent: ami-039e09c6582ec61c5
+      Bastion: ami-04fe60822d08387bb
     # TODO(DET-4258) Uncomment these when we fully support all P3 regions.
     # ap-northeast-2:
-    #   Master: ami-0632cfe5256e6b811
-    #   Agent: ami-0be5ff6df8b8d1a40
-    #   Bastion: ami-0078a04747667d409
+    #   Master: ami-090b3f1f06a12d28d
+    #   Agent: ami-063ee28bcaee0c2b1
+    #   Bastion: ami-05f375b54be4ab849
     # ap-southeast-1:
-    #   Master: ami-010e14b2b7ac1b58f
-    #   Agent: ami-01db1862ab8c2920b
-    #   Bastion: ami-05b891753d41ff88f
+    #   Master: ami-01e1605d140c6b5e6
+    #   Agent: ami-0cc963cd1e2f1b045
+    #   Bastion: ami-0ead23393ac084a1e
     # ap-southeast-2:
-    #   Master: ami-04fad20d313cc0947
-    #   Agent: ami-00174d24de08746a5
-    #   Bastion: ami-076a5bf4a712000ed
+    #   Master: ami-00d02a4b2cf1df2f4
+    #   Agent: ami-0612c09a99b545d53
+    #   Bastion: ami-05b921f2a1a419c07
     eu-central-1:
-      Master: ami-0ce70c4057dc39200
-      Agent: ami-00b4f432a0da11788
-      Bastion: ami-0e0102e3ff768559b
+      Master: ami-08c1695e3dcdd191e
+      Agent: ami-0e706905d18bcf024
+      Bastion: ami-07a0e33d3c1c5fb82
     eu-west-1:
-      Master: ami-0d94cb8577ea0e2fd
-      Agent: ami-07713577ece651903
-      Bastion: ami-06fd78dc2f0b69910
+      Master: ami-08fabf5d4fa6fcc12
+      Agent: ami-020a8186dcd6e0222
+      Bastion: ami-03c4a26550b802f69
     # eu-west-2:
-    #   Master: ami-009725fa4dfe4acb0
-    #   Agent: ami-0ae7e172e79ecb809
-    #   Bastion: ami-0244a5621d426859b
+    #   Master: ami-0b3e07036579e1b57
+    #   Agent: ami-01163cd376120c8c8
+    #   Bastion: ami-066213f162acbccdc
     us-east-1:
-      Master: ami-09943f9da1f1b7899
-      Agent: ami-0f9b07080cf36d8fa
-      Bastion: ami-013f17f36f8b1fefb
+      Master: ami-056db1277deef2218
+      Agent: ami-0e8bcb2511e8ecd6e
+      Bastion: ami-03eaf3b9c3367e75c
     us-east-2:
-      Master: ami-0bcacfac640850227
-      Agent: ami-0db1a4eb8743660dc
-      Bastion: ami-01e7ca2ef94a0ae86
+      Master: ami-0a4b51dd47f678ba3
+      Agent: ami-0c8afd5575ba72550
+      Bastion: ami-09135e71dc2619458
     us-west-2:
-      Master: ami-076cbb27c223df09a
-      Agent: ami-0a1f00f048dc70fd5
-      Bastion: ami-02701bcdc5509e57b
+      Master: ami-0ee876776acf64c80
+      Agent: ami-06380c60a2b768f2d
+      Bastion: ami-007e276c37b5ff2d7
 
 Parameters:
   VpcCIDR:

--- a/harness/determined/deploy/aws/templates/simple.yaml
+++ b/harness/determined/deploy/aws/templates/simple.yaml
@@ -4,36 +4,36 @@ Description: Determined Template
 Mappings:
   RegionMap:
     ap-northeast-1:
-      Master: ami-093c296276d61b583
-      Agent: ami-09e14aa0aa0dcb32d
+      Master: ami-005021e678ab162ea
+      Agent: ami-039e09c6582ec61c5
     # TODO(DET-4258) Uncomment these when we fully support all P3 regions.
     # ap-northeast-2:
-    #   Master: ami-0632cfe5256e6b811
-    #   Agent: ami-0be5ff6df8b8d1a40
+    #   Master: ami-090b3f1f06a12d28d
+    #   Agent: ami-063ee28bcaee0c2b1
     # ap-southeast-1:
-    #   Master: ami-010e14b2b7ac1b58f
-    #   Agent: ami-01db1862ab8c2920b
+    #   Master: ami-01e1605d140c6b5e6
+    #   Agent: ami-0cc963cd1e2f1b045
     # ap-southeast-2:
-    #   Master: ami-04fad20d313cc0947
-    #   Agent: ami-00174d24de08746a5
+    #   Master: ami-00d02a4b2cf1df2f4
+    #   Agent: ami-0612c09a99b545d53
     eu-central-1:
-      Master: ami-0ce70c4057dc39200
-      Agent: ami-00b4f432a0da11788
+      Master: ami-08c1695e3dcdd191e
+      Agent: ami-0e706905d18bcf024
     eu-west-1:
-      Master: ami-0d94cb8577ea0e2fd
-      Agent: ami-07713577ece651903
+      Master: ami-08fabf5d4fa6fcc12
+      Agent: ami-020a8186dcd6e0222
     # eu-west-2:
-    #   Master: ami-009725fa4dfe4acb0
-    #   Agent: ami-0ae7e172e79ecb809
+    #   Master: ami-0b3e07036579e1b57
+    #   Agent: ami-01163cd376120c8c8
     us-east-1:
-      Master: ami-09943f9da1f1b7899
-      Agent: ami-0f9b07080cf36d8fa
+      Master: ami-056db1277deef2218
+      Agent: ami-0e8bcb2511e8ecd6e
     us-east-2:
-      Master: ami-0bcacfac640850227
-      Agent: ami-0db1a4eb8743660dc
+      Master: ami-0a4b51dd47f678ba3
+      Agent: ami-0c8afd5575ba72550
     us-west-2:
-      Master: ami-076cbb27c223df09a
-      Agent: ami-0a1f00f048dc70fd5
+      Master: ami-0ee876776acf64c80
+      Agent: ami-06380c60a2b768f2d
 
 Parameters:
   Keypair:

--- a/harness/determined/deploy/aws/templates/vpc.yaml
+++ b/harness/determined/deploy/aws/templates/vpc.yaml
@@ -3,36 +3,36 @@ Description:  This template deploys a VPC, with a public and private subnet. It 
 Mappings:
   RegionMap:
     ap-northeast-1:
-      Master: ami-093c296276d61b583
-      Agent: ami-09e14aa0aa0dcb32d
+      Master: ami-005021e678ab162ea
+      Agent: ami-039e09c6582ec61c5
     # TODO(DET-4258) Uncomment these when we fully support all P3 regions.
     # ap-northeast-2:
-    #   Master: ami-0632cfe5256e6b811
-    #   Agent: ami-0be5ff6df8b8d1a40
+    #   Master: ami-090b3f1f06a12d28d
+    #   Agent: ami-063ee28bcaee0c2b1
     # ap-southeast-1:
-    #   Master: ami-010e14b2b7ac1b58f
-    #   Agent: ami-01db1862ab8c2920b
+    #   Master: ami-01e1605d140c6b5e6
+    #   Agent: ami-0cc963cd1e2f1b045
     # ap-southeast-2:
-    #   Master: ami-04fad20d313cc0947
-    #   Agent: ami-00174d24de08746a5
+    #   Master: ami-00d02a4b2cf1df2f4
+    #   Agent: ami-0612c09a99b545d53
     eu-central-1:
-      Master: ami-0ce70c4057dc39200
-      Agent: ami-00b4f432a0da11788
+      Master: ami-08c1695e3dcdd191e
+      Agent: ami-0e706905d18bcf024
     eu-west-1:
-      Master: ami-0d94cb8577ea0e2fd
-      Agent: ami-07713577ece651903
+      Master: ami-08fabf5d4fa6fcc12
+      Agent: ami-020a8186dcd6e0222
     # eu-west-2:
-    #   Master: ami-009725fa4dfe4acb0
-    #   Agent: ami-0ae7e172e79ecb809
+    #   Master: ami-0b3e07036579e1b57
+    #   Agent: ami-01163cd376120c8c8
     us-east-1:
-      Master: ami-09943f9da1f1b7899
-      Agent: ami-0f9b07080cf36d8fa
+      Master: ami-056db1277deef2218
+      Agent: ami-0e8bcb2511e8ecd6e
     us-east-2:
-      Master: ami-0bcacfac640850227
-      Agent: ami-0db1a4eb8743660dc
+      Master: ami-0a4b51dd47f678ba3
+      Agent: ami-0c8afd5575ba72550
     us-west-2:
-      Master: ami-076cbb27c223df09a
-      Agent: ami-0a1f00f048dc70fd5
+      Master: ami-0ee876776acf64c80
+      Agent: ami-06380c60a2b768f2d
 
 Parameters:
   VpcCIDR:

--- a/harness/determined/deploy/gcp/constants.py
+++ b/harness/determined/deploy/gcp/constants.py
@@ -3,7 +3,7 @@ class defaults:
     CPU_AGENT_INSTANCE_TYPE = "n1-standard-4"
     GPU_AGENT_INSTANCE_TYPE = "n1-standard-32"
     DB_PASSWORD = "postgres"
-    ENVIRONMENT_IMAGE = "det-environments-145c0d8"
+    ENVIRONMENT_IMAGE = "det-environments-1c4ea10"
     GPU_NUM = 8
     GPU_TYPE = "nvidia-tesla-k80"
     MASTER_INSTANCE_TYPE = "n1-standard-2"

--- a/harness/determined/estimator/_estimator_trial.py
+++ b/harness/determined/estimator/_estimator_trial.py
@@ -820,7 +820,7 @@ class EstimatorTrial(det.Trial):
     """
     By default, experiments run with TensorFlow 1.x. To configure your trial to
     use TensorFlow 2.x, set a TF 2.x image in the experiment configuration
-    (e.g. ``determinedai/environments:cuda-10.2-pytorch-1.8-lightning-1.2-tf-2.4-gpu-0.9.0``).
+    (e.g. ``determinedai/environments:cuda-10.2-pytorch-1.7-lightning-1.2-tf-2.4-gpu-0.10.0``).
 
     ``EstimatorTrial`` supports TF 2.x; however it uses TensorFlow V1
     behavior. We have disabled TensorFlow V2 behavior for ``EstimatorTrial``,

--- a/harness/determined/keras/_tf_keras_trial.py
+++ b/harness/determined/keras/_tf_keras_trial.py
@@ -969,7 +969,7 @@ class TFKerasTrial(det.Trial):
     TensorFlow 2.x, specify a TensorFlow 2.x image in the
     :ref:`environment.image <exp-environment-image>` field of the experiment
     configuration (e.g.,
-    ``determinedai/environments:cuda-10.2-pytorch-1.8-lightning-1.2-tf-2.4-gpu-0.9.0``).
+    ``determinedai/environments:cuda-10.2-pytorch-1.7-lightning-1.2-tf-2.4-gpu-0.10.0``).
 
     Trials default to using eager execution with TensorFlow 2.x but not with
     TensorFlow 1.x. To override the default behavior, call the appropriate

--- a/master/internal/provisioner/aws_config.go
+++ b/master/internal/provisioner/aws_config.go
@@ -41,16 +41,16 @@ type AWSClusterConfig struct {
 }
 
 var defaultAWSImageID = map[string]string{
-	"ap-northeast-1": "ami-09e14aa0aa0dcb32d",
-	"ap-northeast-2": "ami-0be5ff6df8b8d1a40",
-	"ap-southeast-1": "ami-01db1862ab8c2920b",
-	"ap-southeast-2": "ami-00174d24de08746a5",
-	"us-east-2":      "ami-0db1a4eb8743660dc",
-	"us-east-1":      "ami-0f9b07080cf36d8fa",
-	"us-west-2":      "ami-0a1f00f048dc70fd5",
-	"eu-central-1":   "ami-00b4f432a0da11788",
-	"eu-west-2":      "ami-0ae7e172e79ecb809",
-	"eu-west-1":      "ami-07713577ece651903",
+	"ap-northeast-1": "ami-039e09c6582ec61c5",
+	"ap-northeast-2": "ami-063ee28bcaee0c2b1",
+	"ap-southeast-1": "ami-0cc963cd1e2f1b045",
+	"ap-southeast-2": "ami-0612c09a99b545d53",
+	"us-east-2":      "ami-0c8afd5575ba72550",
+	"us-east-1":      "ami-0e8bcb2511e8ecd6e",
+	"us-west-2":      "ami-06380c60a2b768f2d",
+	"eu-central-1":   "ami-0e706905d18bcf024",
+	"eu-west-2":      "ami-01163cd376120c8c8",
+	"eu-west-1":      "ami-020a8186dcd6e0222",
 }
 
 var defaultAWSClusterConfig = AWSClusterConfig{

--- a/master/internal/provisioner/gcp_config.go
+++ b/master/internal/provisioner/gcp_config.go
@@ -48,7 +48,7 @@ type GCPClusterConfig struct {
 func DefaultGCPClusterConfig() *GCPClusterConfig {
 	return &GCPClusterConfig{
 		BootDiskSize:        200,
-		BootDiskSourceImage: "projects/determined-ai/global/images/det-environments-145c0d8",
+		BootDiskSourceImage: "projects/determined-ai/global/images/det-environments-1c4ea10",
 		LabelKey:            "managed-by",
 		InstanceType: gceInstanceType{
 			MachineType: "n1-standard-32",

--- a/master/pkg/model/defaults.go
+++ b/master/pkg/model/defaults.go
@@ -25,8 +25,8 @@ const (
 
 // Default task environment docker image names.
 const (
-	defaultCPUImage = "determinedai/environments:py-3.7-pytorch-1.8-tf-1.15-cpu-145c0d8"
-	defaultGPUImage = "determinedai/environments:cuda-10.2-pytorch-1.8-tf-1.15-gpu-145c0d8"
+	defaultCPUImage = "determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-1c4ea10"
+	defaultGPUImage = "determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-1c4ea10"
 )
 
 // DefaultExperimentConfig returns a new default experiment config.

--- a/master/pkg/schemas/expconf/const.go
+++ b/master/pkg/schemas/expconf/const.go
@@ -8,6 +8,6 @@ const (
 
 // Default task environment docker image names.
 const (
-	DefaultCPUImage = "determinedai/environments:py-3.6.9-pytorch-1.4-tf-1.15-cpu-067db2b"
-	DefaultGPUImage = "determinedai/environments:cuda-10.0-pytorch-1.4-tf-1.15-gpu-067db2b"
+	DefaultCPUImage = "determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-1c4ea10"
+	DefaultGPUImage = "determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-1c4ea10"
 )

--- a/schemas/test_cases/v0/experiment.yaml
+++ b/schemas/test_cases/v0/experiment.yaml
@@ -31,8 +31,8 @@
       environment_variables: {}
       force_pull_image: false
       image:
-        cpu: determinedai/environments:cuda-10.1-pytorch-1.4-tf-2.2-gpu-0f2001a
-        gpu: determinedai/environments:cuda-10.1-pytorch-1.4-tf-2.2-gpu-0f2001a
+        cpu: determinedai/environments:py-3.7-pytorch-1.7-lightning-1.2-tf-2.4-cpu-1c4ea10
+        gpu: determinedai/environments:cuda-10.2-pytorch-1.7-lightning-1.2-tf-2.4-gpu-1c4ea10
       pod_spec: null
       ports: null
     hyperparameters:

--- a/tools/scripts/bumpenvs.yaml
+++ b/tools/scripts/bumpenvs.yaml
@@ -1,125 +1,129 @@
 ap_northeast_1_agent_ami:
-  new: ami-09e14aa0aa0dcb32d
-  old: ami-0a01b67743d465a6e
+  new: ami-039e09c6582ec61c5
+  old: ami-09e14aa0aa0dcb32d
 ap_northeast_1_bastion_ami:
-  new: ami-0ef85cf6e604e5650
-  old: ami-05855b7c54f91a1ae
+  new: ami-04fe60822d08387bb
+  old: ami-0ef85cf6e604e5650
 ap_northeast_1_master_ami:
-  new: ami-093c296276d61b583
-  old: ami-0af17d43b1f4ff4ea
+  new: ami-005021e678ab162ea
+  old: ami-093c296276d61b583
 ap_northeast_2_agent_ami:
-  new: ami-0be5ff6df8b8d1a40
-  old: ami-0c74312df78509701
+  new: ami-063ee28bcaee0c2b1
+  old: ami-0be5ff6df8b8d1a40
 ap_northeast_2_bastion_ami:
-  new: ami-0078a04747667d409
-  old: ami-063acefae626a1e95
+  new: ami-05f375b54be4ab849
+  old: ami-0078a04747667d409
 ap_northeast_2_master_ami:
-  new: ami-0632cfe5256e6b811
-  old: ami-04e6fcf8cfe3b09ea
+  new: ami-090b3f1f06a12d28d
+  old: ami-0632cfe5256e6b811
 ap_southeast_1_agent_ami:
-  new: ami-01db1862ab8c2920b
-  old: ami-0eddf3f941d216f11
+  new: ami-0cc963cd1e2f1b045
+  old: ami-01db1862ab8c2920b
 ap_southeast_1_bastion_ami:
-  new: ami-05b891753d41ff88f
-  old: ami-0311dbbdd981577d5
+  new: ami-0ead23393ac084a1e
+  old: ami-05b891753d41ff88f
 ap_southeast_1_master_ami:
-  new: ami-010e14b2b7ac1b58f
-  old: ami-0ba45f1ec3dff60f9
+  new: ami-01e1605d140c6b5e6
+  old: ami-010e14b2b7ac1b58f
 ap_southeast_2_agent_ami:
-  new: ami-00174d24de08746a5
-  old: ami-0c54777eb400a9e68
+  new: ami-0612c09a99b545d53
+  old: ami-00174d24de08746a5
 ap_southeast_2_bastion_ami:
-  new: ami-076a5bf4a712000ed
-  old: ami-0dea9aeaa95b9751b
+  new: ami-05b921f2a1a419c07
+  old: ami-076a5bf4a712000ed
 ap_southeast_2_master_ami:
-  new: ami-04fad20d313cc0947
-  old: ami-004d0fb87d10716c6
+  new: ami-00d02a4b2cf1df2f4
+  old: ami-04fad20d313cc0947
 cuda_11_hashed:
-  new: determinedai/environments:cuda-11.1-pytorch-1.8-lightning-1.2-tf-2.4-gpu-145c0d8
+  new: determinedai/environments:cuda-11.0-pytorch-1.7-lightning-1.2-tf-2.4-gpu-1c4ea10
+  old: determinedai/environments:cuda-11.1-pytorch-1.8-lightning-1.2-tf-2.4-gpu-145c0d8
 cuda_11_versioned:
-  new: determinedai/environments:cuda-11.1-pytorch-1.8-lightning-1.2-tf-2.4-gpu-0.9.0
+  new: determinedai/environments:cuda-11.0-pytorch-1.7-lightning-1.2-tf-2.4-gpu-0.10.0
+  old: determinedai/environments:cuda-11.1-pytorch-1.8-lightning-1.2-tf-2.4-gpu-0.9.0
 eu_central_1_agent_ami:
-  new: ami-00b4f432a0da11788
-  old: ami-0474e45bb1a45bbfe
+  new: ami-0e706905d18bcf024
+  old: ami-00b4f432a0da11788
 eu_central_1_bastion_ami:
-  new: ami-0e0102e3ff768559b
-  old: ami-08a099fcfc36dff3f
+  new: ami-07a0e33d3c1c5fb82
+  old: ami-0e0102e3ff768559b
 eu_central_1_master_ami:
-  new: ami-0ce70c4057dc39200
-  old: ami-08a1a61694dd1c82f
+  new: ami-08c1695e3dcdd191e
+  old: ami-0ce70c4057dc39200
 eu_west_1_agent_ami:
-  new: ami-07713577ece651903
-  old: ami-0036879b70fee3339
+  new: ami-020a8186dcd6e0222
+  old: ami-07713577ece651903
 eu_west_1_bastion_ami:
-  new: ami-06fd78dc2f0b69910
-  old: ami-00c25f7948e360133
+  new: ami-03c4a26550b802f69
+  old: ami-06fd78dc2f0b69910
 eu_west_1_master_ami:
-  new: ami-0d94cb8577ea0e2fd
-  old: ami-0d67111dcacb4a14a
+  new: ami-08fabf5d4fa6fcc12
+  old: ami-0d94cb8577ea0e2fd
 eu_west_2_agent_ami:
-  new: ami-0ae7e172e79ecb809
-  old: ami-05d9b28afa79dbda3
+  new: ami-01163cd376120c8c8
+  old: ami-0ae7e172e79ecb809
 eu_west_2_bastion_ami:
-  new: ami-0244a5621d426859b
-  old: ami-076071bbe3485317c
+  new: ami-066213f162acbccdc
+  old: ami-0244a5621d426859b
 eu_west_2_master_ami:
-  new: ami-009725fa4dfe4acb0
-  old: ami-03441ec6f2faa7ddc
+  new: ami-0b3e07036579e1b57
+  old: ami-009725fa4dfe4acb0
 gcp_env:
-  new: det-environments-145c0d8
-  old: det-environments-067db2b
+  new: det-environments-1c4ea10
+  old: det-environments-145c0d8
 tf1_cpu_hashed:
-  new: determinedai/environments:py-3.7-pytorch-1.8-tf-1.15-cpu-145c0d8
-  old: determinedai/environments:py-3.6.9-pytorch-1.4-tf-1.15-cpu-067db2b
+  new: determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-1c4ea10
+  old: determinedai/environments:py-3.7-pytorch-1.8-tf-1.15-cpu-145c0d8
 tf1_cpu_versioned:
-  new: determinedai/environments:py-3.7-pytorch-1.8-tf-1.15-cpu-0.9.0
-  old: determinedai/environments:py-3.6.9-pytorch-1.4-tf-1.15-cpu-0.8.0
+  new: determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-0.10.0
+  old: determinedai/environments:py-3.7-pytorch-1.8-tf-1.15-cpu-0.9.0
 tf1_gpu_hashed:
-  new: determinedai/environments:cuda-10.2-pytorch-1.8-tf-1.15-gpu-145c0d8
-  old: determinedai/environments:cuda-10.0-pytorch-1.4-tf-1.15-gpu-067db2b
+  new: determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-1c4ea10
+  old: determinedai/environments:cuda-10.2-pytorch-1.8-tf-1.15-gpu-145c0d8
 tf1_gpu_versioned:
-  new: determinedai/environments:cuda-10.2-pytorch-1.8-tf-1.15-gpu-0.9.0
-  old: determinedai/environments:cuda-10.0-pytorch-1.4-tf-1.15-gpu-0.8.0
+  new: determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-0.10.0
+  old: determinedai/environments:cuda-10.2-pytorch-1.8-tf-1.15-gpu-0.9.0
 tf2_cpu_hashed:
-  new: determinedai/environments:py-3.7-pytorch-1.8-lightning-1.2-tf-2.4-cpu-145c0d8
-  old: determinedai/environments:py-3.6.9-pytorch-1.4-tf-2.2-cpu-067db2b
+  new: determinedai/environments:py-3.7-pytorch-1.7-lightning-1.2-tf-2.4-cpu-1c4ea10
+  old: determinedai/environments:py-3.7-pytorch-1.8-lightning-1.2-tf-2.4-cpu-145c0d8
 tf2_cpu_versioned:
-  new: determinedai/environments:py-3.7-pytorch-1.8-lightning-1.2-tf-2.4-cpu-0.9.0
-  old: determinedai/environments:py-3.6.9-pytorch-1.4-tf-2.2-cpu-0.8.0
+  new: determinedai/environments:py-3.7-pytorch-1.7-lightning-1.2-tf-2.4-cpu-0.10.0
+  old: determinedai/environments:py-3.7-pytorch-1.8-lightning-1.2-tf-2.4-cpu-0.9.0
 tf2_gpu_hashed:
-  new: determinedai/environments:cuda-10.2-pytorch-1.8-lightning-1.2-tf-2.4-gpu-145c0d8
-  old: determinedai/environments:cuda-10.1-pytorch-1.4-tf-2.2-gpu-067db2b
+  new: determinedai/environments:cuda-10.2-pytorch-1.7-lightning-1.2-tf-2.4-gpu-1c4ea10
+  old: determinedai/environments:cuda-10.2-pytorch-1.8-lightning-1.2-tf-2.4-gpu-145c0d8
 tf2_gpu_versioned:
-  new: determinedai/environments:cuda-10.2-pytorch-1.8-lightning-1.2-tf-2.4-gpu-0.9.0
-  old: determinedai/environments:cuda-10.1-pytorch-1.4-tf-2.2-gpu-0.8.0
+  new: determinedai/environments:cuda-10.2-pytorch-1.7-lightning-1.2-tf-2.4-gpu-0.10.0
+  old: determinedai/environments:cuda-10.2-pytorch-1.8-lightning-1.2-tf-2.4-gpu-0.9.0
 us_east_1_agent_ami:
-  new: ami-0f9b07080cf36d8fa
-  old: ami-0080b638f1339ccd5
+  new: ami-0e8bcb2511e8ecd6e
+  old: ami-0f9b07080cf36d8fa
 us_east_1_bastion_ami:
-  new: ami-013f17f36f8b1fefb
-  old: ami-053adf54573f777cf
+  new: ami-03eaf3b9c3367e75c
+  old: ami-013f17f36f8b1fefb
 us_east_1_master_ami:
-  new: ami-09943f9da1f1b7899
-  old: ami-099e921e69356cf89
+  new: ami-056db1277deef2218
+  old: ami-09943f9da1f1b7899
 us_east_2_agent_ami:
-  new: ami-0db1a4eb8743660dc
-  old: ami-07318f0e0b3a02b8e
+  new: ami-0c8afd5575ba72550
+  old: ami-0db1a4eb8743660dc
 us_east_2_bastion_ami:
-  new: ami-01e7ca2ef94a0ae86
-  old: ami-0b9487791bf873774
+  new: ami-09135e71dc2619458
+  old: ami-01e7ca2ef94a0ae86
 us_east_2_master_ami:
-  new: ami-0bcacfac640850227
-  old: ami-05edbb8e25e281608
+  new: ami-0a4b51dd47f678ba3
+  old: ami-0bcacfac640850227
 us_gov_east_1_agent_ami:
-  new: ami-04eced5bbe48fd193
+  new: ami-0056a5171326d2770
+  old: ami-04eced5bbe48fd193
 us_gov_west_1_agent_ami:
-  new: ami-039e218ea111c6b28
+  new: ami-08d3d4fe2387a844c
+  old: ami-039e218ea111c6b28
 us_west_2_agent_ami:
-  new: ami-0a1f00f048dc70fd5
-  old: ami-0211fc4b3b0eb5c64
+  new: ami-06380c60a2b768f2d
+  old: ami-0a1f00f048dc70fd5
 us_west_2_bastion_ami:
-  new: ami-02701bcdc5509e57b
-  old: ami-0cc158853935719b7
+  new: ami-007e276c37b5ff2d7
+  old: ami-02701bcdc5509e57b
 us_west_2_master_ami:
-  new: ami-076cbb27c223df09a
-  old: ami-00f1e37d20049f858
+  new: ami-0ee876776acf64c80
+  old: ami-076cbb27c223df09a

--- a/webui/react/src/fixtures/responses/experiment-details/non-scalar-metrics-4078.json
+++ b/webui/react/src/fixtures/responses/experiment-details/non-scalar-metrics-4078.json
@@ -31,8 +31,8 @@
     "description": "Fork of Fork of mnist_tp_to_estimator_const",
     "environment": {
       "image": {
-        "cpu": "determinedai/environments:py-3.7-pytorch-1.8-tf-1.15-cpu-145c0d8",
-        "gpu": "determinedai/environments:cuda-10.2-pytorch-1.8-tf-1.15-gpu-145c0d8"
+        "cpu": "determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-1c4ea10",
+        "gpu": "determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-1c4ea10"
       },
       "ports": null,
       "pod_spec": null,

--- a/webui/react/src/fixtures/responses/experiment-details/set-a.json
+++ b/webui/react/src/fixtures/responses/experiment-details/set-a.json
@@ -694,8 +694,8 @@
         "environment_variables": {},
         "force_pull_image": false,
         "image": {
-          "cpu": "determinedai/environments:py-3.7-pytorch-1.8-tf-1.15-cpu-145c0d8",
-          "gpu": "determinedai/environments:cuda-10.2-pytorch-1.8-tf-1.15-gpu-145c0d8"
+          "cpu": "determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-1c4ea10",
+          "gpu": "determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-1c4ea10"
         },
         "pod_spec": null,
         "ports": null
@@ -838,8 +838,8 @@
         "environment_variables": {},
         "force_pull_image": false,
         "image": {
-          "cpu": "determinedai/environments:py-3.7-pytorch-1.8-tf-1.15-cpu-145c0d8",
-          "gpu": "determinedai/environments:cuda-10.2-pytorch-1.8-tf-1.15-gpu-145c0d8"
+          "cpu": "determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-1c4ea10",
+          "gpu": "determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-1c4ea10"
         },
         "pod_spec": {
           "metadata": {
@@ -2596,8 +2596,8 @@
       "description": "noop_adaptive",
       "environment": {
         "image": {
-          "cpu": "determinedai/environments:py-3.7-pytorch-1.8-tf-1.15-cpu-145c0d8",
-          "gpu": "determinedai/environments:cuda-10.2-pytorch-1.8-tf-1.15-gpu-145c0d8"
+          "cpu": "determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-1c4ea10",
+          "gpu": "determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-1c4ea10"
         },
         "ports": null,
         "pod_spec": null,

--- a/webui/react/src/fixtures/responses/trial-details/old-trial-config-noop-adaptive.json
+++ b/webui/react/src/fixtures/responses/trial-details/old-trial-config-noop-adaptive.json
@@ -29,8 +29,8 @@
   "description": "noop_adaptive",
   "environment": {
     "image": {
-      "cpu": "determinedai/environments:py-3.7-pytorch-1.8-tf-1.15-cpu-145c0d8",
-      "gpu": "determinedai/environments:cuda-10.2-pytorch-1.8-tf-1.15-gpu-145c0d8"
+      "cpu": "determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-1c4ea10",
+      "gpu": "determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-1c4ea10"
     },
     "ports": null,
     "force_pull_image": false,


### PR DESCRIPTION
## Description

Discovered some problems involving Python 3.8 (cloudpickle compatibility concerns that need to be addressed) and PyTorch 1.8 (needs some fixes from upstream Horovod, which has not fully tested it yet).

This includes the usual bumpenvs process, but also manually updating a few docs and the PyTorch lightning examples that referenced other out of date images.

## Test Plan

I will run post-commits here before merging (that said, I thought I did this last time and obviously missed some glaring problems): https://app.circleci.com/pipelines/github/determined-ai/determined?branch=mackrory.

## Commentary (optional)

Our docs are also lacking a section about the TF2 images, but I will add that separately.