### PR TITLE
perf: support max_concurrent_trials for random and grid search [DET-3664]

### DIFF
--- a/docs/reference/experiment-config.txt
+++ b/docs/reference/experiment-config.txt
@@ -532,6 +532,11 @@ validation metrics should be computed more frequently.
    Whether to minimize or maximize the metric defined above. The default
    value is ``true`` (minimize).
 
+``max_concurrent_trials``
+   The maximum number of trials that can be worked on simultaneously.
+   The default value is ``0``, in which case we will try to work on as
+   many trials as possible.
+
 ``source_trial_id``
    If specified, the weights of *every* trial in the search will be
    initialized to the most recent checkpoint of the given trial ID. This
@@ -566,6 +571,11 @@ For more details see the :ref:`topic-guides_hp-tuning-det_grid`.
 ``smaller_is_better``
    Whether to minimize or maximize the metric defined above. The default
    value is ``true`` (minimize).
+
+``max_concurrent_trials``
+   The maximum number of trials that can be worked on simultaneously.
+   The default value is ``0``, in which case we will try to work on as
+   many trials as possible.
 
 ``source_trial_id``
    If specified, the weights of this trial will be initialized to the

--- a/master/pkg/model/defaults.go
+++ b/master/pkg/model/defaults.go
@@ -50,6 +50,12 @@ func DefaultExperimentConfig(taskContainerDefaults *TaskContainerDefaultsConfig)
 		Hyperparameters: make(map[string]Hyperparameter),
 		Searcher: SearcherConfig{
 			SmallerIsBetter: true,
+			RandomConfig: &RandomConfig{
+				MaxConcurrentTrials: 0,
+			},
+			GridConfig: &GridConfig{
+				MaxConcurrentTrials: 0,
+			},
 			SyncHalvingConfig: &SyncHalvingConfig{
 				SmallerIsBetter: true,
 				Divisor:         4,

--- a/master/pkg/model/searcher_config.go
+++ b/master/pkg/model/searcher_config.go
@@ -92,8 +92,9 @@ func (s SingleConfig) Unit() Unit {
 
 // RandomConfig configures a random search.
 type RandomConfig struct {
-	MaxLength Length `json:"max_length"`
-	MaxTrials int    `json:"max_trials"`
+	MaxLength           Length `json:"max_length"`
+	MaxTrials           int    `json:"max_trials"`
+	MaxConcurrentTrials int    `json:"max_concurrent_trials"`
 }
 
 // Unit implements the model.InUnits interface.
@@ -106,12 +107,14 @@ func (r RandomConfig) Validate() (errs []error) {
 	return []error{
 		check.GreaterThan(r.MaxLength.Units, 0, "max_length must be > 0"),
 		check.GreaterThan(r.MaxTrials, 0, "max_trials must be > 0"),
+		check.GreaterThanOrEqualTo(r.MaxConcurrentTrials, 0, "max_concurrent_trials must be >= 0"),
 	}
 }
 
 // GridConfig configures a grid search.
 type GridConfig struct {
-	MaxLength Length `json:"max_length"`
+	MaxLength           Length `json:"max_length"`
+	MaxConcurrentTrials int    `json:"max_concurrent_trials"`
 }
 
 // Unit implements the model.InUnits interface.
@@ -123,6 +126,7 @@ func (g GridConfig) Unit() Unit {
 func (g GridConfig) Validate() (errs []error) {
 	return []error{
 		check.GreaterThan(g.MaxLength.Units, 0, "max_length must be > 0"),
+		check.GreaterThanOrEqualTo(g.MaxConcurrentTrials, 0, "max_concurrent_trials must be >= 0"),
 	}
 }
 

--- a/master/pkg/searcher/grid.go
+++ b/master/pkg/searcher/grid.go
@@ -10,9 +10,14 @@ import (
 )
 
 type (
-	// gridSearchState stores the state for grid. Though grid is stateless, it is useful
-	// on restart to know the type of searcher during restore, in the event it must be shimmed.
+	// gridSearchState stores the state for grid. The state will track the remaining hp settings
+	// that have yet to be created for evaluation.  PendingTrials tracks how many trials have
+	// active workloads and is used to check max_concurrent_trials for the searcher is respected.
+	// Tracking searcher type on restart gives us the ability to differentiate grid searches
+	// in a shim if needed.
 	gridSearchState struct {
+		PendingTrials    int              `json:"pending_trials"`
+		RemainingTrials  []hparamSample   `json:"remaining_trials"`
 		SearchMethodType SearchMethodType `json:"search_method_type"`
 	}
 	// gridSearch corresponds to a grid search method. A grid of hyperparameter configs is built. Then,
@@ -27,35 +32,77 @@ type (
 
 func newGridSearch(config model.GridConfig) SearchMethod {
 	return &gridSearch{
-		GridConfig:      config,
-		gridSearchState: gridSearchState{GridSearch},
+		GridConfig: config,
+		gridSearchState: gridSearchState{
+			SearchMethodType: GridSearch,
+			RemainingTrials:  make([]hparamSample, 0),
+		},
 	}
 }
 
 func (s *gridSearch) initialOperations(ctx context) ([]Operation, error) {
-	var ops []Operation
 	grid := newHyperparameterGrid(ctx.hparams)
 	s.trials = len(grid)
-	for _, params := range grid {
+	s.RemainingTrials = append(s.RemainingTrials, grid...)
+	initialTrials := s.trials
+	if s.MaxConcurrentTrials > 0 {
+		initialTrials = min(s.trials, s.MaxConcurrentTrials)
+	}
+	var ops []Operation
+	for trial := 0; trial < initialTrials; trial++ {
+		params := s.RemainingTrials[len(s.RemainingTrials)-1]
+		s.RemainingTrials = s.RemainingTrials[:len(s.RemainingTrials)-1]
 		create := NewCreate(ctx.rand, params, model.TrialWorkloadSequencerType)
 		ops = append(ops, create)
 		ops = append(ops, NewTrain(create.RequestID, s.MaxLength))
 		ops = append(ops, NewValidate(create.RequestID))
 		ops = append(ops, NewClose(create.RequestID))
+		s.PendingTrials++
 	}
 	return ops, nil
 }
 
 func (s *gridSearch) progress(unitsCompleted float64) float64 {
+	if s.MaxConcurrentTrials > 0 && s.PendingTrials > s.MaxConcurrentTrials {
+		panic("pending trials is greater than max_concurrent_trials")
+	}
 	return unitsCompleted / float64(s.GridConfig.MaxLength.MultInt(s.trials).Units)
 }
 
 // trialExitedEarly does nothing since grid does not take actions based on
 // search status or progress.
 func (s *gridSearch) trialExitedEarly(
-	context, model.RequestID, workload.ExitedReason,
+	ctx context, requestID model.RequestID, exitedReason workload.ExitedReason,
 ) ([]Operation, error) {
-	return nil, nil
+	s.PendingTrials--
+	var ops []Operation
+	if len(s.RemainingTrials) > 0 {
+		params := s.RemainingTrials[len(s.RemainingTrials)-1]
+		s.RemainingTrials = s.RemainingTrials[:len(s.RemainingTrials)-1]
+		create := NewCreate(ctx.rand, params, model.TrialWorkloadSequencerType)
+		ops = append(ops, create)
+		ops = append(ops, NewTrain(create.RequestID, s.MaxLength))
+		ops = append(ops, NewValidate(create.RequestID))
+		ops = append(ops, NewClose(create.RequestID))
+		s.PendingTrials++
+	}
+	return ops, nil
+}
+
+func (s *gridSearch) trialClosed(ctx context, requestID model.RequestID) ([]Operation, error) {
+	s.PendingTrials--
+	var ops []Operation
+	if len(s.RemainingTrials) > 0 {
+		params := s.RemainingTrials[len(s.RemainingTrials)-1]
+		s.RemainingTrials = s.RemainingTrials[:len(s.RemainingTrials)-1]
+		create := NewCreate(ctx.rand, params, model.TrialWorkloadSequencerType)
+		ops = append(ops, create)
+		ops = append(ops, NewTrain(create.RequestID, s.MaxLength))
+		ops = append(ops, NewValidate(create.RequestID))
+		ops = append(ops, NewClose(create.RequestID))
+		s.PendingTrials++
+	}
+	return ops, nil
 }
 
 func newHyperparameterGrid(params model.Hyperparameters) []hparamSample {

--- a/master/pkg/searcher/grid_test.go
+++ b/master/pkg/searcher/grid_test.go
@@ -153,7 +153,10 @@ func TestGridSearchMethod(t *testing.T) {
 				newEarlyExitPredefinedTrial(toOps("300B"), .1),
 			},
 			config: model.SearcherConfig{
-				GridConfig: &model.GridConfig{MaxLength: model.NewLengthInBatches(300)},
+				GridConfig: &model.GridConfig{
+					MaxLength:           model.NewLengthInBatches(300),
+					MaxConcurrentTrials: 2,
+				},
 			},
 			hparams: generateHyperparameters([]int{2, 1, 3}),
 		},

--- a/master/pkg/searcher/random_test.go
+++ b/master/pkg/searcher/random_test.go
@@ -48,8 +48,9 @@ func TestRandomSearchMethod(t *testing.T) {
 			},
 			config: model.SearcherConfig{
 				RandomConfig: &model.RandomConfig{
-					MaxLength: model.NewLengthInBatches(500),
-					MaxTrials: 4,
+					MaxLength:           model.NewLengthInBatches(500),
+					MaxTrials:           4,
+					MaxConcurrentTrials: 2,
 				},
 			},
 		},

--- a/master/pkg/searcher/util_test.go
+++ b/master/pkg/searcher/util_test.go
@@ -2,6 +2,7 @@ package searcher
 
 import (
 	"bytes"
+	"fmt"
 	"strconv"
 	"strings"
 	"testing"
@@ -376,6 +377,10 @@ func saveAndReload(method SearchMethod) error {
 	} else if state2, err := method.Snapshot(); err != nil { // Test restore is correct.
 		return err
 	} else if !bytes.Equal(state, state2) {
+		var unmarshaledState = method.Restore(state)
+		var unmarshaledState2 = method.Restore(state2)
+		fmt.Printf("%+v\n", unmarshaledState)
+		fmt.Printf("%+v\n", unmarshaledState2)
 		return errors.New("successive snapshots were not identical")
 	}
 	return nil


### PR DESCRIPTION
## Description
This PR allows users to limit the maximum number of concurrent trials training at any given time for grid and random search.  While there is some overlap in capability with `max_slots`, `max_concurrent_trials` works for dynamic agents, which is not true for `max_slots`.  We expect to deprecate `max_slots` in a future release.   

## Test Plan
Existing tests for searchers pass and verified that the `max_concurrent_trials` constraint is not violated.

## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.

