### PR TITLE
ci: adding coscheduler to static k8s test clusters, and test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -543,7 +543,8 @@ commands:
             detVersion=<<parameters.det-version>>,\
             maxSlotsPerPod=<<parameters.gpus-per-machine>>,\
             checkpointStorage.type=gcs,\
-            checkpointStorage.bucket=det-ci
+            checkpointStorage.bucket=det-ci,\
+            defaultScheduler=coscheduler
       - set-master-address-gke:
           release-name: "ci"
           namespace: "default"
@@ -615,7 +616,8 @@ commands:
             taskContainerDefaults.cpuImage=determinedai/environments:cuda-11.0-pytorch-1.7-lightning-1.2-tf-2.4-gpu-0.10.0,\
             taskContainerDefaults.gpuImage=determinedai/environments:cuda-11.0-pytorch-1.7-lightning-1.2-tf-2.4-gpu-0.10.0,\
             checkpointStorage.type=gcs,\
-            checkpointStorage.bucket=det-ci
+            checkpointStorage.bucket=det-ci,\
+            defaultScheduler=coscheduler
       - set-master-address-gke:
           release-name: "ci"
           namespace: "default"
@@ -1445,6 +1447,11 @@ jobs:
           region: <<parameters.region>>
           node-locations: <<parameters.node-locations>>
       - set-google-application-credentials
+      - run:
+          name: Set environment variables 
+          command: |
+            echo "export TOTAL_SLOTS="$((<<parameters.num-machines>> * <<parameters.gpus-per-machine>>))"" >> $BASH_ENV
+            source $BASH_ENV
       - run-e2e-tests:
           mark: <<parameters.mark>>
           master-host: ${MASTER_HOST}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1530,6 +1530,11 @@ jobs:
           gpus-per-machine: <<parameters.gpus-per-machine>>
           node-locations: <<parameters.node-locations>>
       - set-google-application-credentials
+      - run:
+          name: Set environment variables 
+          command: |
+            echo "export TOTAL_SLOTS="$((<<parameters.num-machines>> * <<parameters.gpus-per-machine>>))"" >> $BASH_ENV
+            source $BASH_ENV
       - run-e2e-tests:
           mark: <<parameters.mark>>
           master-host: ${MASTER_HOST}

--- a/e2e_tests/tests/test_system.py
+++ b/e2e_tests/tests/test_system.py
@@ -577,12 +577,12 @@ def test_disable_and_enable_slots() -> None:
 @pytest.mark.parallel  # type: ignore
 @pytest.mark.timeout(300)  # type: ignore
 def test_gang_scheduling() -> None:
-    config = conf.load_config(conf.tutorials_path("mnist_pytorch/distributed.yaml"))
     total_slots = os.getenv("TOTAL_SLOTS")
     if total_slots is None:
-        pytest.fail("test requires TOTAL_SLOTS be set in the environment")
-    config = conf.set_slots_per_trial(config, int(total_slots))
+        pytest.skip("test requires a static cluster and TOTAL_SLOTS set in the environment")
 
+    config = conf.load_config(conf.tutorials_path("mnist_pytorch/distributed.yaml"))
+    config = conf.set_slots_per_trial(config, int(total_slots))
     model = conf.tutorials_path("mnist_pytorch")
 
     def submit_job() -> None:

--- a/helm/charts/determined/templates/NOTES.txt
+++ b/helm/charts/determined/templates/NOTES.txt
@@ -37,7 +37,7 @@ format X.Y.Z (e.g., 0.13.6).
 {{ end -}}
 
 {{- if .Values.defaultScheduler }}
-      {{- if not (eq .Values.defaultScheduler "coscheduler")}}
+      {{- if not (eq (.Values.defaultScheduler | trim) "coscheduler")}}
 WARNING: defaultScheduler has been set to an unsupported value. The cluster default scheduler will be set to the Kubernetes scheduler.
       {{ end }}
 {{ end -}}

--- a/helm/charts/determined/templates/master-config.yaml
+++ b/helm/charts/determined/templates/master-config.yaml
@@ -49,7 +49,7 @@ data:
       max_slots_per_pod: {{ required "A valid Values.maxSlotsPerPod entry is required!" .Values.maxSlotsPerPod }}
       master_service_name: determined-master-service-{{ .Release.Name }}
       {{- if .Values.defaultScheduler}}
-      {{- if eq .Values.defaultScheduler "coscheduler"}}
+      {{- if eq (.Values.defaultScheduler | trim ) "coscheduler"}}
       default_scheduler: "coscheduler"
       {{- end }}
       {{- end }}

--- a/helm/charts/determined/templates/priority-classes.yaml
+++ b/helm/charts/determined/templates/priority-classes.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.defaultScheduler}}
-{{- if eq .Values.defaultScheduler "coscheduler"}}
+{{- if eq (.Values.defaultScheduler | trim ) "coscheduler"}}
 apiVersion: scheduling.k8s.io/v1
 kind: PriorityClass
 metadata:

--- a/helm/charts/determined/templates/scheduler-config.yaml
+++ b/helm/charts/determined/templates/scheduler-config.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.defaultScheduler}}
-{{- if eq .Values.defaultScheduler "coscheduler"}}
+{{- if eq (.Values.defaultScheduler | trim ) "coscheduler"}}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/helm/charts/determined/templates/scheduler-deployment.yaml
+++ b/helm/charts/determined/templates/scheduler-deployment.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.defaultScheduler}}
-{{- if eq .Values.defaultScheduler "coscheduler"}}
+{{- if eq (.Values.defaultScheduler | trim ) "coscheduler"}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/helm/charts/determined/templates/scheduler-permissions.yaml
+++ b/helm/charts/determined/templates/scheduler-permissions.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.defaultScheduler}}
-{{- if eq .Values.defaultScheduler "coscheduler"}}
+{{- if eq (.Values.defaultScheduler | trim ) "coscheduler"}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:


### PR DESCRIPTION
## Description

This is a second attempt at this patch. The last time the tests passed by coincidence (they succeed 50% of the time even without the fix they are validating). The root cause of this is that Helm seems to have some flawed indentation logic for the values overridden via the CLI, and coscheduler was specific with additional newlines and whitespace. If we change the order of the values, it's the GCS bucket that ends up being indented - though it seems to cause no problem. Simply trimming whitespace from the coscheduler value.

## Test Plan

Verified on an upstream branch.