### PR TITLE
fix: avoid showing no-data message for a split second in hp-viz [DET-5099]

### DIFF
--- a/docs/release-notes/2144-fix-no-data-message-flash.txt
+++ b/docs/release-notes/2144-fix-no-data-message-flash.txt
@@ -1,0 +1,6 @@
+:orphan:
+
+**Bug Fixes**
+
+-  WebUI: Avoid flashing `No data to plot` when loading HP visualizaton
+   tab on experiment detail page.

--- a/webui/react/src/pages/ExperimentDetails/ExperimentVisualization.tsx
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentVisualization.tsx
@@ -275,6 +275,8 @@ const ExperimentVisualization: React.FC<Props> = ({
       type="warning" />;
   } else if (pageError) {
     return <Message title={PAGE_ERROR_MESSAGES[pageError]} type={MessageType.Alert} />;
+  } else if (!hasLoaded) {
+    return <Spinner />;
   } else if (!hasData) {
     return isExperimentTerminal ? (
       <Message title="No data to plot." type={MessageType.Empty} />
@@ -286,8 +288,6 @@ const ExperimentVisualization: React.FC<Props> = ({
         <Spinner />
       </div>
     );
-  } else if (!hasLoaded) {
-    return <Spinner />;
   }
 
   const visualizationFilters = (


### PR DESCRIPTION
## Description

There is a split second where hp-viz shows `No data to plot` message when loading the data to populate the chart. The logic just needs a slight tweaking to avoid this.

<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan

- [ ] when loading hp-viz, `No data to plot` should not show up before loading the learning curve chart.

<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
