### PR TITLE
fix: fix an issue with wrapping lr_scheduler

### DIFF
--- a/examples/gan/gan_mnist_pl/model_def.py
+++ b/examples/gan/gan_mnist_pl/model_def.py
@@ -12,10 +12,10 @@ class GANTrial(LightningAdapter):
     def __init__(self, context: PyTorchTrialContext) -> None:
         data_dir = f'/tmp/data-rank{context.distributed.get_rank()}'
         self.dm = gan.MNISTDataModule(context.get_data_config()['url'], data_dir,
-                                      batch_size=context.get_global_batch_size())
+                                      batch_size=context.get_per_slot_batch_size())
         channels, width, height = self.dm.size()
         lm = gan.GAN(channels, width, height,
-                    batch_size=context.get_global_batch_size(),
+                    batch_size=context.get_per_slot_batch_size(),
                     lr=context.get_hparam('lr'),
                     b1=context.get_hparam('b1'),
                     b2=context.get_hparam('b2'),

--- a/harness/determined/pytorch/lightning/_adapter.py
+++ b/harness/determined/pytorch/lightning/_adapter.py
@@ -293,10 +293,12 @@ class LightningAdapter(PyTorchTrial):
                     "- Tuple of dictionaries as described, with an optional ‘frequency’ key.\n"
                 )
 
-            check.check_isinstance(lrs["scheduler"].optimizer, _LRScheduler,
-                                   "A returned LRScheduler from `configure_optimizers` is "
-                                   "missing the optimizer attribute."
-                                  )
+            check.check_isinstance(
+                lrs["scheduler"].optimizer,
+                Optimizer,
+                "A returned LRScheduler from `configure_optimizers` is "
+                "missing the optimizer attribute.",
+            )
 
             # switch the user's unwrapped optimizer with the wrapped version.
             lrs["scheduler"].optimizer = wrapped_opt

--- a/harness/determined/pytorch/lightning/_adapter.py
+++ b/harness/determined/pytorch/lightning/_adapter.py
@@ -280,9 +280,20 @@ class LightningAdapter(PyTorchTrial):
 
             wrapped_opt = optimizers_dict[getattr(lrs["scheduler"], "optimizer", None)]
             if wrapped_opt is None:
-                raise InvalidModelException("missing optimizer for lr_scheduler")
+                raise InvalidModelException(
+                    "An LRScheduler is returned in `configure_optimizers` without having "
+                    "returned the optimizer itself. Please follow PyTorchLightning's documenation"
+                    "to make sure you're returning one of the expected values."
+                    "- Single optimizer.\n"
+                    "- List or Tuple - List of optimizers.\n"
+                    "- Two lists - The first list has multiple optimizers, the second a list of"
+                    "LRSchedulers (or lr_dict).\n"
+                    "- Dictionary, with an ‘optimizer’ key, and (optionally) a ‘lr_scheduler’ key"
+                    "whose value is a single LR scheduler or lr_dict.\n"
+                    "- Tuple of dictionaries as described, with an optional ‘frequency’ key.\n"
+                )
 
-            # switch the users unwrapped optimizer with wrapped optimizer.
+            # switch the user's unwrapped optimizer with the wrapped version.
             lrs["scheduler"].optimizer = wrapped_opt
             return self._pls.context.wrap_lr_scheduler(
                 lrs["scheduler"], step_mode, frequency=lrs["frequency"]

--- a/harness/determined/pytorch/lightning/_adapter.py
+++ b/harness/determined/pytorch/lightning/_adapter.py
@@ -128,7 +128,7 @@ class LightningAdapter(PyTorchTrial):
         lightning_module: pl.LightningModule,
         precision: Union[Literal[32], Literal[16]] = 32,
         amp_backend: Union[Literal["native"], Literal["apex"]] = "native",
-        amp_level: Union[Literal["O0", "O1", "O2", "O3"]] = "O2",
+        amp_level: Union[Literal["O0", "O1", "O2", "O3"]] = "O1",
     ):
         """
         This performs the necessary initialization steps to:
@@ -161,7 +161,7 @@ class LightningAdapter(PyTorchTrial):
             amp_backend (str):
                 Automatic mixed precision backend to use.
                 Accepted values are "native", and "mixed".
-            amp_level (str, optional, default="O2"):
+            amp_level (str, optional, default="O1"):
                 Apex amp optimization level.
                 Accepted values are "O0", "O1", "O2", and "O3".
                 https://nvidia.github.io/apex/amp.html#opt-levels-and-properties

--- a/harness/determined/pytorch/lightning/_adapter.py
+++ b/harness/determined/pytorch/lightning/_adapter.py
@@ -128,7 +128,7 @@ class LightningAdapter(PyTorchTrial):
         lightning_module: pl.LightningModule,
         precision: Union[Literal[32], Literal[16]] = 32,
         amp_backend: Union[Literal["native"], Literal["apex"]] = "native",
-        amp_level: Union[Literal["O0", "O1", "O2", "O3"]] = "O1",
+        amp_level: Union[Literal["O0", "O1", "O2", "O3"]] = "O2",
     ):
         """
         This performs the necessary initialization steps to:
@@ -161,7 +161,7 @@ class LightningAdapter(PyTorchTrial):
             amp_backend (str):
                 Automatic mixed precision backend to use.
                 Accepted values are "native", and "mixed".
-            amp_level (str, optional, default="O1"):
+            amp_level (str, optional, default="O2"):
                 Apex amp optimization level.
                 Accepted values are "O0", "O1", "O2", and "O3".
                 https://nvidia.github.io/apex/amp.html#opt-levels-and-properties

--- a/harness/determined/pytorch/lightning/_adapter.py
+++ b/harness/determined/pytorch/lightning/_adapter.py
@@ -293,6 +293,11 @@ class LightningAdapter(PyTorchTrial):
                     "- Tuple of dictionaries as described, with an optional ‘frequency’ key.\n"
                 )
 
+            check.check_isinstance(lrs["scheduler"].optimizer, _LRScheduler,
+                                   "A returned LRScheduler from `configure_optimizers` is "
+                                   "missing the optimizer attribute."
+                                  )
+
             # switch the user's unwrapped optimizer with the wrapped version.
             lrs["scheduler"].optimizer = wrapped_opt
             return self._pls.context.wrap_lr_scheduler(

--- a/harness/tests/experiment/fixtures/lightning_adapter_onevar_model.py
+++ b/harness/tests/experiment/fixtures/lightning_adapter_onevar_model.py
@@ -32,7 +32,8 @@ class OneVarLM(pl.LightningModule):
 
     def configure_optimizers(self):
         opt = torch.optim.SGD(self.model.parameters(), self.lr)
-        return opt
+        sched = torch.optim.lr_scheduler.StepLR(opt, step_size=1e-4)
+        return [opt], [sched]
 
     def training_step(self, batch, batch_idx, *args, **kwargs):
         data, label = batch


### PR DESCRIPTION
## Description

<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234