### PR TITLE
chore: enable hyperparameter importance computation by default

### DIFF
--- a/e2e_tests/tests/experiment/test_metrics.py
+++ b/e2e_tests/tests/experiment/test_metrics.py
@@ -62,7 +62,6 @@ def test_streaming_metrics_api() -> None:
 
 @pytest.mark.nightly  # type: ignore
 @pytest.mark.timeout(1200)  # type: ignore
-@pytest.mark.skip(reason="HP importance is currently disabled by default")  # type: ignore
 def test_hp_importance_api() -> None:
     auth.initialize_session(conf.make_master_url(), try_reauth=True)
 

--- a/master/internal/config.go
+++ b/master/internal/config.go
@@ -64,7 +64,7 @@ func DefaultConfig() *Config {
 			DefaultLoggingConfig: &model.DefaultLoggingConfig{},
 		},
 		HPImportance: hpimportance.HPImportanceConfig{
-			WorkersLimit:   0,
+			WorkersLimit:   2,
 			QueueLimit:     16,
 			CoresPerWorker: 1,
 			MaxTrees:       100,

--- a/master/internal/hpimportance/hpimportance_test.go
+++ b/master/internal/hpimportance/hpimportance_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestComputeHPImportance(t *testing.T) {
 	masterConfig := HPImportanceConfig{
-		WorkersLimit:   0,
+		WorkersLimit:   2,
 		QueueLimit:     16,
 		CoresPerWorker: 1,
 		MaxTrees:       100,


### PR DESCRIPTION
## Description

The UI will now attempt to use this feature to sort metrics in a drop-down by their relative importance.

## Test Plan

Tests are already written, but were disabled along with the feature. Will confirm they are run in pre-commits.