### PR TITLE
feat: health check master after cluster creation [DET-5183]

### DIFF
--- a/harness/determined/deploy/aws/cli.py
+++ b/harness/determined/deploy/aws/cli.py
@@ -201,11 +201,11 @@ def deploy_aws(command: str, args: argparse.Namespace) -> None:
         except MasterTimeoutExpired:
             print(
                 colored(
-                    "Determined cluster has been deployed, but Master health check has failed.",
+                    "Determined cluster has been deployed, but master health check has failed.",
                     "red",
                 )
             )
-            print("For details, SSH to Master instance and check /var/log/cloud-init-output.log")
+            print("For details, SSH to master instance and check /var/log/cloud-init-output.log.")
             sys.exit(1)
 
     print("Determined Deployment Successful")

--- a/harness/determined/deploy/aws/deployment_types/govcloud.py
+++ b/harness/determined/deploy/aws/deployment_types/govcloud.py
@@ -1,4 +1,3 @@
-import boto3
 from termcolor import colored
 
 from determined.deploy.aws import aws, constants
@@ -54,15 +53,4 @@ class Govcloud(base.DeterminedDeployment):
             boto3_session=self.parameters[constants.cloudformation.BOTO3_SESSION],
             parameters=cfn_parameters,
         )
-        self.print_results(
-            self.parameters[constants.cloudformation.CLUSTER_ID],
-            self.parameters[constants.cloudformation.BOTO3_SESSION],
-        )
-
-    def print_results(self, stack_name: str, boto3_session: boto3.session.Session) -> None:
-        output = aws.get_output(stack_name, boto3_session)
-        master_ip = output[constants.cloudformation.DET_ADDRESS]
-        region = output[constants.cloudformation.REGION]
-        log_group = output[constants.cloudformation.LOG_GROUP]
-
-        self.print_output_info(master_ip=master_ip, region=region, log_group=log_group)
+        self.print_results()

--- a/harness/determined/deploy/aws/deployment_types/secure.py
+++ b/harness/determined/deploy/aws/deployment_types/secure.py
@@ -94,5 +94,5 @@ class Secure(base.DeterminedDeployment):
         )
 
     def wait_for_master(self, timeout: int = 0) -> None:
-        print("Skipping automated master healthcheck due to bastion host usage.")
+        print("Skipping automated master health check due to bastion host usage.")
         return

--- a/harness/determined/deploy/aws/deployment_types/secure.py
+++ b/harness/determined/deploy/aws/deployment_types/secure.py
@@ -1,6 +1,5 @@
 from typing import Iterable
 
-import boto3
 from termcolor import colored
 
 from determined.deploy.aws import aws, constants
@@ -63,12 +62,12 @@ class Secure(base.DeterminedDeployment):
             boto3_session=self.parameters[constants.cloudformation.BOTO3_SESSION],
             parameters=cfn_parameters,
         )
-        self.print_results(
-            self.parameters[constants.cloudformation.CLUSTER_ID],
-            self.parameters[constants.cloudformation.BOTO3_SESSION],
-        )
+        self.print_results()
 
-    def print_results(self, stack_name: str, boto3_session: boto3.session.Session) -> None:
+    def print_results(self) -> None:
+        stack_name = self.parameters[constants.cloudformation.CLUSTER_ID]
+        boto3_session = self.parameters[constants.cloudformation.BOTO3_SESSION]
+
         output = aws.get_output(stack_name, boto3_session)
 
         bastion_ip = aws.get_ec2_info(output["BastionId"], boto3_session)[
@@ -93,3 +92,7 @@ class Secure(base.DeterminedDeployment):
             self.logs_info,
             self.ssh_info,
         )
+
+    def wait_for_master(self, timeout: int = 0) -> None:
+        print("Skipping automated master healthcheck due to bastion host usage.")
+        return

--- a/harness/determined/deploy/aws/deployment_types/simple.py
+++ b/harness/determined/deploy/aws/deployment_types/simple.py
@@ -1,5 +1,3 @@
-import boto3
-
 from determined.deploy.aws import aws, constants
 from determined.deploy.aws.deployment_types import base
 
@@ -47,15 +45,4 @@ class Simple(base.DeterminedDeployment):
             boto3_session=self.parameters[constants.cloudformation.BOTO3_SESSION],
             parameters=cfn_parameters,
         )
-        self.print_results(
-            self.parameters[constants.cloudformation.CLUSTER_ID],
-            self.parameters[constants.cloudformation.BOTO3_SESSION],
-        )
-
-    def print_results(self, stack_name: str, boto3_session: boto3.session.Session) -> None:
-        output = aws.get_output(stack_name, boto3_session)
-        master_ip = output[constants.cloudformation.DET_ADDRESS]
-        region = output[constants.cloudformation.REGION]
-        log_group = output[constants.cloudformation.LOG_GROUP]
-
-        self.print_output_info(master_ip=master_ip, region=region, log_group=log_group)
+        self.print_results()

--- a/harness/determined/deploy/aws/deployment_types/vpc.py
+++ b/harness/determined/deploy/aws/deployment_types/vpc.py
@@ -1,5 +1,3 @@
-import boto3
-
 from determined.deploy.aws import aws, constants
 from determined.deploy.aws.deployment_types import base
 
@@ -43,18 +41,7 @@ class VPC(base.DeterminedDeployment):
             boto3_session=self.parameters[constants.cloudformation.BOTO3_SESSION],
             parameters=cfn_parameters,
         )
-        self.print_results(
-            self.parameters[constants.cloudformation.CLUSTER_ID],
-            self.parameters[constants.cloudformation.BOTO3_SESSION],
-        )
-
-    def print_results(self, stack_name: str, boto3_session: boto3.session.Session) -> None:
-        output = aws.get_output(stack_name, boto3_session)
-        master_ip = output[constants.cloudformation.DET_ADDRESS]
-        region = output[constants.cloudformation.REGION]
-        log_group = output[constants.cloudformation.LOG_GROUP]
-
-        self.print_output_info(master_ip=master_ip, region=region, log_group=log_group)
+        self.print_results()
 
 
 class FSx(VPC):

--- a/harness/determined/deploy/cli.py
+++ b/harness/determined/deploy/cli.py
@@ -13,6 +13,11 @@ args_subs: List[Union[Arg, Cmd]] = [
     # TODO(DET-5171): Remove --version flag when det-deploy is deprecated.
     Arg("--version", action="version", version="%(prog)s {}".format(__version__)),
     Arg("--no-preflight-checks", action="store_true", help="Disable preflight checks"),
+    Arg(
+        "--no-wait-for-master",
+        action="store_true",
+        help="Do not wait for master to come up after AWS or GCP clusters are deployed",
+    ),
     local_args_description,
     aws_args_description,
     gcp_args_description,

--- a/harness/determined/deploy/errors.py
+++ b/harness/determined/deploy/errors.py
@@ -1,2 +1,6 @@
 class PreflightFailure(Exception):
     pass
+
+
+class MasterTimeoutExpired(Exception):
+    pass

--- a/harness/determined/deploy/gcp/cli.py
+++ b/harness/determined/deploy/gcp/cli.py
@@ -103,11 +103,11 @@ def deploy_gcp(command: str, args: argparse.Namespace) -> None:
         except MasterTimeoutExpired:
             print(
                 colored(
-                    "Determined cluster has been deployed, but Master health check has failed.",
+                    "Determined cluster has been deployed, but master health check has failed.",
                     "red",
                 )
             )
-            print("For details, SSH to Master instance and check /var/log/cloud-init-output.log")
+            print("For details, SSH to master instance and check /var/log/cloud-init-output.log.")
             sys.exit(1)
 
     print("Determined Deployment Successful")

--- a/harness/determined/deploy/gcp/terraform/outputs.tf
+++ b/harness/determined/deploy/gcp/terraform/outputs.tf
@@ -47,7 +47,7 @@ output "NOTE" {
 }
 
 output "SSH-to-Master" {
-  value = "> To SSH to Determined master instance, run:\n\n  gcloud compute ssh ${module.compute.master_instance_name}\n"
+  value = "> To SSH to the Determined master instance, run:\n\n  gcloud compute ssh ${module.compute.master_instance_name}\n"
 }
 
 output "Web-UI" {

--- a/harness/determined/deploy/gcp/terraform/outputs.tf
+++ b/harness/determined/deploy/gcp/terraform/outputs.tf
@@ -47,7 +47,7 @@ output "NOTE" {
 }
 
 output "SSH-to-Master" {
-  value = "> To ssh to Determined Master instance, run:\n\n  gcloud compute ssh ${module.compute.master_instance_name}\n"
+  value = "> To SSH to Determined master instance, run:\n\n  gcloud compute ssh ${module.compute.master_instance_name}\n"
 }
 
 output "Web-UI" {

--- a/harness/determined/deploy/gcp/terraform/outputs.tf
+++ b/harness/determined/deploy/gcp/terraform/outputs.tf
@@ -46,6 +46,10 @@ output "NOTE" {
   value = "> To use the Determined CLI without needing to specify the master in each command, run:\n\n  export DET_MASTER=${module.compute.web_ui}\n"
 }
 
+output "SSH-to-Master" {
+  value = "> To ssh to Determined Master instance, run:\n\n  gcloud compute ssh ${module.compute.master_instance_name}\n"
+}
+
 output "Web-UI" {
   value = "${module.compute.web_ui}"
 }

--- a/harness/determined/deploy/healthcheck.py
+++ b/harness/determined/deploy/healthcheck.py
@@ -1,0 +1,41 @@
+import time
+
+import requests
+
+from determined.common import api
+
+from .errors import MasterTimeoutExpired
+
+
+def _make_master_url(master_host: str, master_port: int, suffix: str = "") -> str:
+    return "http://{}:{}/{}".format(master_host, master_port, suffix)
+
+
+def wait_for_master(master_host: str, master_port: int = 8080, timeout: int = 100) -> None:
+    master_url = _make_master_url(master_host, master_port)
+
+    return wait_for_master_url(master_url, timeout)
+
+
+def wait_for_master_url(master_url: str, timeout: int = 100) -> None:
+    POLL_INTERVAL = 2
+    polling = False
+    try:
+
+        for _ in range(int(timeout / POLL_INTERVAL)):
+            try:
+                r = api.get(master_url, "info", authenticated=False)
+                if r.status_code == requests.codes.ok:
+                    return
+            except api.errors.MasterNotFoundException:
+                pass
+            if not polling:
+                polling = True
+                print("Waiting for Master instance to be available..", end="", flush=True)
+            time.sleep(POLL_INTERVAL)
+            print(".", end="", flush=True)
+
+        raise MasterTimeoutExpired
+    finally:
+        if polling:
+            print()

--- a/harness/determined/deploy/healthcheck.py
+++ b/harness/determined/deploy/healthcheck.py
@@ -6,23 +6,28 @@ from determined.common import api
 
 from .errors import MasterTimeoutExpired
 
+DEFAULT_TIMEOUT = 100
+
 
 def _make_master_url(master_host: str, master_port: int, suffix: str = "") -> str:
     return "http://{}:{}/{}".format(master_host, master_port, suffix)
 
 
-def wait_for_master(master_host: str, master_port: int = 8080, timeout: int = 100) -> None:
+def wait_for_master(
+    master_host: str, master_port: int = 8080, timeout: int = DEFAULT_TIMEOUT
+) -> None:
     master_url = _make_master_url(master_host, master_port)
 
     return wait_for_master_url(master_url, timeout)
 
 
-def wait_for_master_url(master_url: str, timeout: int = 100) -> None:
+def wait_for_master_url(master_url: str, timeout: int = DEFAULT_TIMEOUT) -> None:
     POLL_INTERVAL = 2
     polling = False
-    try:
+    start_time = time.time()
 
-        for _ in range(int(timeout / POLL_INTERVAL)):
+    try:
+        while time.time() - start_time < timeout:
             try:
                 r = api.get(master_url, "info", authenticated=False)
                 if r.status_code == requests.codes.ok:
@@ -31,7 +36,8 @@ def wait_for_master_url(master_url: str, timeout: int = 100) -> None:
                 pass
             if not polling:
                 polling = True
-                print("Waiting for Master instance to be available..", end="", flush=True)
+                # Third dot will be added two lines later.
+                print("Waiting for master instance to be available..", end="", flush=True)
             time.sleep(POLL_INTERVAL)
             print(".", end="", flush=True)
 

--- a/harness/determined/deploy/healthcheck.py
+++ b/harness/determined/deploy/healthcheck.py
@@ -36,8 +36,7 @@ def wait_for_master_url(master_url: str, timeout: int = DEFAULT_TIMEOUT) -> None
                 pass
             if not polling:
                 polling = True
-                # Third dot will be added two lines later.
-                print("Waiting for master instance to be available..", end="", flush=True)
+                print("Waiting for master instance to be available...", end="", flush=True)
             time.sleep(POLL_INTERVAL)
             print(".", end="", flush=True)
 


### PR DESCRIPTION
## Description
- `det deploy {aws,gcp} up` will now poll the master after the deployment until it's up.
- "successful" deployment will take "longer", but as soon as command exists successfully, the cluster should be already good to go (as you don't need to wait extra few minutes for master to come up).
- this behavior can be skipped using `det deploy --no-wait-for-master`.

## Test Plan
You can simulate a failing deployment by specifying a bad/unavailable container versions, e.g. doing `--det-version 0.15.0`.

## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
