### PR TITLE
fix: default tooltip prefix to be an empty string

### DIFF
--- a/docs/release-notes/2165-fix-tooltip.txt
+++ b/docs/release-notes/2165-fix-tooltip.txt
@@ -1,0 +1,6 @@
+:orphan:
+
+**Bug Fixes**
+
+-  WebUI: Fix human readable number tooltip of showing `undefined`
+   prefix.

--- a/webui/react/src/components/HumanReadableFloat.tsx
+++ b/webui/react/src/components/HumanReadableFloat.tsx
@@ -14,7 +14,7 @@ const defaultProps: Props = {
   precision: 6,
 };
 
-const HumanReadableFloat: React.FC<Props> = ({ num, precision, tooltipPrefix }: Props) => {
+const HumanReadableFloat: React.FC<Props> = ({ num, precision, tooltipPrefix = '' }: Props) => {
   const isInteger = Number.isInteger(num);
   const absoluteNum = Math.abs(num);
   const stringNum = num.toString();


### PR DESCRIPTION
## Description

Fix the issue of showing `undefined` as prefix for human readable tooltips.

<img width="378" alt="Screen Shot 2021-04-02 at 4 12 06 PM" src="https://user-images.githubusercontent.com/220971/113457890-411e8f80-93ce-11eb-83ba-01ab58fc6152.png">

<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234