### PR TITLE
feat: local clusters to store checkpoint data in home [DET-5154]

### DIFF
--- a/docs/release-notes/2170-checkpoint-storage-defaults.txt
+++ b/docs/release-notes/2170-checkpoint-storage-defaults.txt
@@ -1,0 +1,13 @@
+:orphan:
+
+**Improvements**
+
+-  Default storage location for checkpoint data in local clusters
+   deployed via `det deploy local` has been changed to OS-specific user
+   data dir (e.g. `$XDG_DATA_HOME/determined` or
+   `~/.local/share/determined` on Linux, and `~/Library/Application
+   Support/determined` on macOS). Previously, `/tmp` was used. This
+   location can be changed using `--storage-host-path` command line flag
+   of `det deploy local`. If users provide their own custom
+   `master.yaml` via `--master-config-path`, `checkpoint_storage`
+   configuration in yaml will continue to take precedence.

--- a/harness/determined/deploy/local/cli.py
+++ b/harness/determined/deploy/local/cli.py
@@ -1,11 +1,16 @@
 import argparse
 import sys
+from pathlib import Path
 from typing import Callable, Dict
 
-from determined.common.declarative_argparse import Arg, BoolOptArg, Cmd
+import appdirs
+
+from determined.common.declarative_argparse import Arg, BoolOptArg, Cmd, Group
 
 from . import cluster_utils
 from .preflight import check_docker_install
+
+DEFAULT_STORAGE_HOST_PATH = Path(appdirs.user_data_dir("determined"))
 
 
 def handle_cluster_up(args: argparse.Namespace) -> None:
@@ -16,6 +21,7 @@ def handle_cluster_up(args: argparse.Namespace) -> None:
         num_agents=args.agents,
         port=args.master_port,
         master_config_path=args.master_config_path,
+        storage_host_path=args.storage_host_path,
         cluster_name=args.cluster_name,
         version=args.det_version,
         db_password=args.db_password,
@@ -37,6 +43,7 @@ def handle_master_up(args: argparse.Namespace) -> None:
     cluster_utils.master_up(
         port=args.master_port,
         master_config_path=args.master_config_path,
+        storage_host_path=args.storage_host_path,
         master_name=args.master_name,
         version=args.det_version,
         db_password=args.db_password,
@@ -95,11 +102,19 @@ args_description = Cmd(
             handle_cluster_up,
             "Create a Determined cluster",
             [
-                Arg(
-                    "--master-config-path",
-                    type=str,
-                    default=None,
-                    help="path to master configuration",
+                Group(
+                    Arg(
+                        "--master-config-path",
+                        type=Path,
+                        default=None,
+                        help="path to master configuration",
+                    ),
+                    Arg(
+                        "--storage-host-path",
+                        type=Path,
+                        default=DEFAULT_STORAGE_HOST_PATH,
+                        help="Storage location for cluster data (e.g. checkpoints)",
+                    ),
                 ),
                 Arg(
                     "--agents",
@@ -164,11 +179,19 @@ args_description = Cmd(
             handle_master_up,
             "Start a Determined master",
             [
-                Arg(
-                    "--master-config-path",
-                    type=str,
-                    default=None,
-                    help="path to master configuration",
+                Group(
+                    Arg(
+                        "--master-config-path",
+                        type=str,
+                        default=None,
+                        help="path to master configuration",
+                    ),
+                    Arg(
+                        "--storage-host-path",
+                        type=str,
+                        default=DEFAULT_STORAGE_HOST_PATH,
+                        help="Storage location for cluster data (e.g. checkpoints)",
+                    ),
                 ),
                 Arg("--master-port", type=int, default=8080, help="port to expose master on"),
                 Arg(

--- a/harness/determined/deploy/local/storage.yaml
+++ b/harness/determined/deploy/local/storage.yaml
@@ -1,0 +1,7 @@
+version: "3.7"
+
+services:
+  determined-master:
+    environment:
+      DET_CHECKPOINT_STORAGE_TYPE: shared_fs
+      DET_CHECKPOINT_STORAGE_HOST_PATH: ${DET_CHECKPOINT_STORAGE_HOST_PATH}

--- a/harness/setup.py
+++ b/harness/setup.py
@@ -55,6 +55,7 @@ setup(
         "paramiko>=2.4.2",  # explicitly pull in paramiko to prevent DistributionNotFound error
         "docker-compose>=1.13.0",
         "tqdm",
+        "appdirs",
     ],
     extras_require={
         "tf-115-cuda102": ["tensorflow-gpu==1.15.5"],

--- a/master/cmd/determined-master/init.go
+++ b/master/cmd/determined-master/init.go
@@ -7,7 +7,6 @@ import (
 	"github.com/spf13/viper"
 
 	"github.com/determined-ai/determined/master/internal"
-	"github.com/determined-ai/determined/master/pkg/model"
 	"github.com/determined-ai/determined/master/version"
 )
 
@@ -45,6 +44,10 @@ func (c configKey) AccessPath() string {
 
 func (c configKey) FlagName() string {
 	return strings.Join(c, "-")
+}
+
+func registerEnv(name configKey) {
+	v.BindEnv(name.AccessPath(), name.EnvName())
 }
 
 func registerString(flags *pflag.FlagSet, name configKey, value string, usage string) {
@@ -131,8 +134,8 @@ func registerConfig() {
 	registerString(flags, name("telemetry", "segment-webui-key"),
 		defaults.Telemetry.SegmentWebUIKey, "the Segment write key for the WebUI")
 
-	registerString(flags, name("checkpoint-storage", "type"),
-		model.DefaultCheckpointStorageType, "checkpoint storage type")
-	registerString(flags, name("checkpoint-storage", "host-path"),
-		model.DefaultSharedFSHostPath, "checkpoint storage host path")
+	// These env vars are used by `det deploy` to override host_path.
+	// We don't register pflags for these to avoid setting a default.
+	registerEnv(name("checkpoint-storage", "type"))
+	registerEnv(name("checkpoint-storage", "host-path"))
 }

--- a/master/cmd/determined-master/init.go
+++ b/master/cmd/determined-master/init.go
@@ -7,6 +7,7 @@ import (
 	"github.com/spf13/viper"
 
 	"github.com/determined-ai/determined/master/internal"
+	"github.com/determined-ai/determined/master/pkg/model"
 	"github.com/determined-ai/determined/master/version"
 )
 
@@ -129,4 +130,9 @@ func registerConfig() {
 		defaults.Telemetry.SegmentMasterKey, "the Segment write key for the master")
 	registerString(flags, name("telemetry", "segment-webui-key"),
 		defaults.Telemetry.SegmentWebUIKey, "the Segment write key for the WebUI")
+
+	registerString(flags, name("checkpoint-storage", "type"),
+		model.DefaultCheckpointStorageType, "checkpoint storage type")
+	registerString(flags, name("checkpoint-storage", "host-path"),
+		model.DefaultSharedFSHostPath, "checkpoint storage host path")
 }

--- a/master/cmd/determined-master/init.go
+++ b/master/cmd/determined-master/init.go
@@ -47,7 +47,7 @@ func (c configKey) FlagName() string {
 }
 
 func registerEnv(name configKey) {
-	v.BindEnv(name.AccessPath(), name.EnvName())
+	_ = v.BindEnv(name.AccessPath(), name.EnvName())
 }
 
 func registerString(flags *pflag.FlagSet, name configKey, value string, usage string) {

--- a/master/pkg/model/defaults.go
+++ b/master/pkg/model/defaults.go
@@ -29,6 +29,13 @@ const (
 	defaultGPUImage = "determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-1c4ea10"
 )
 
+const (
+	// DefaultCheckpointStorageType is SharedFS.
+	DefaultCheckpointStorageType = "shared_fs"
+	// DefaultSharedFSHostPath is the default path on hosts for SharedFS storage mounts.
+	DefaultSharedFSHostPath = "/tmp"
+)
+
 // DefaultExperimentConfig returns a new default experiment config.
 func DefaultExperimentConfig(taskContainerDefaults *TaskContainerDefaultsConfig) ExperimentConfig {
 	defaultDescription := fmt.Sprintf(
@@ -41,7 +48,9 @@ func DefaultExperimentConfig(taskContainerDefaults *TaskContainerDefaultsConfig)
 			SaveExperimentBest: 0,
 			SaveTrialBest:      1,
 			SaveTrialLatest:    1,
-			SharedFSConfig:     &SharedFSConfig{},
+			SharedFSConfig: &SharedFSConfig{
+				HostPath: DefaultSharedFSHostPath,
+			},
 		},
 		CheckpointPolicy: BestCheckpointPolicy,
 		DataLayer: DataLayerConfig{

--- a/master/pkg/model/defaults.go
+++ b/master/pkg/model/defaults.go
@@ -29,13 +29,6 @@ const (
 	defaultGPUImage = "determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-1c4ea10"
 )
 
-const (
-	// DefaultCheckpointStorageType is SharedFS.
-	DefaultCheckpointStorageType = "shared_fs"
-	// DefaultSharedFSHostPath is the default path on hosts for SharedFS storage mounts.
-	DefaultSharedFSHostPath = "/tmp"
-)
-
 // DefaultExperimentConfig returns a new default experiment config.
 func DefaultExperimentConfig(taskContainerDefaults *TaskContainerDefaultsConfig) ExperimentConfig {
 	defaultDescription := fmt.Sprintf(
@@ -48,9 +41,7 @@ func DefaultExperimentConfig(taskContainerDefaults *TaskContainerDefaultsConfig)
 			SaveExperimentBest: 0,
 			SaveTrialBest:      1,
 			SaveTrialLatest:    1,
-			SharedFSConfig: &SharedFSConfig{
-				HostPath: DefaultSharedFSHostPath,
-			},
+			SharedFSConfig:     &SharedFSConfig{},
 		},
 		CheckpointPolicy: BestCheckpointPolicy,
 		DataLayer: DataLayerConfig{


### PR DESCRIPTION
## Description

- Default storage location for checkpoint data in local clusters deployed via `det deploy local` has been changed to OS-specific user data dir (e.g. `$XDG_DATA_HOME/determined` or `~/.local/share/determined` on Linux, and `~/Library/Application Support/determined` on macOS). Previously, `/tmp` was used.
- This location can be changed using `--storage-host-path` command line flag of `det deploy local`.
- If users provide their own custom `master.yaml` via `--master-config-path`, `checkpoint_storage` configuration in yaml will continue to take precedence.

## Test Plan
- Check that the old experiment data in /tmp is not lost after upgrade.
- Check the new default directory works ok, --storage-host-path, and --master-config-path.
 
## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234