### PR TITLE
fix: allow telemetry to be disabled under Helm [DET-5224]

### DIFF
--- a/helm/charts/determined/templates/master-config.yaml
+++ b/helm/charts/determined/templates/master-config.yaml
@@ -90,10 +90,8 @@ data:
     {{ end }}
 
     {{- if .Values.telemetry }}
-    {{- if .Values.telemetry.enabled }}
     telemetry:
       enabled: {{ .Values.telemetry.enabled }}
-    {{- end }}
     {{- end }}
 
     {{- if .Values.clusterName }}


### PR DESCRIPTION
## Description

The telemetry setting defaults to true, so it can't use the same pattern
as things that default to false.

Closes: #2175

## Test Plan

- [x] run the master locally on Kubernetes with `values.yaml` specifying telemetry on or off and check that the master responds
