### PR TITLE
refactor: improve experiment terminal state [DET-5202]

### DIFF
--- a/webui/react/src/hooks/usePolling.ts
+++ b/webui/react/src/hooks/usePolling.ts
@@ -13,6 +13,12 @@ interface PollingOptions {
   runImmediately?: boolean;
 }
 
+/*
+ * When calling `stopPolling` with `terminateGracefully` set to true,
+ * the polling will be marked as stopped but we avoid killing the timer.
+ * This means that the polling function will allowed to run one last time
+ * before terminating.
+ */
 interface StopOptions {
   terminateGracefully?: boolean;
 }

--- a/webui/react/src/hooks/usePolling.ts
+++ b/webui/react/src/hooks/usePolling.ts
@@ -5,12 +5,16 @@ type PollingFn = (() => Promise<void>) | (() => void);
 interface PollingHooks {
   isPolling: boolean;
   startPolling: () => void;
-  stopPolling: () => void;
+  stopPolling: (options?: StopOptions) => void;
 }
 
 interface PollingOptions {
   interval?: number;
   runImmediately?: boolean;
+}
+
+interface StopOptions {
+  terminateGracefully?: boolean;
 }
 
 const DEFAULT_OPTIONS: PollingOptions = {
@@ -47,9 +51,9 @@ const usePolling = (pollingFn: PollingFn, options: PollingOptions = {}): Polling
     poll();
   }, [ poll ]);
 
-  const stopPolling = useCallback(() => {
+  const stopPolling = useCallback((options: StopOptions = {}) => {
     isPolling.current = false;
-    clearTimer();
+    if (!options.terminateGracefully) clearTimer();
   }, [ clearTimer ]);
 
   // Update polling function if a new one is passed in.

--- a/webui/react/src/pages/ExperimentDetails/ExperimentOverview.tsx
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentOverview.tsx
@@ -181,7 +181,7 @@ const ExperimentOverview: React.FC<Props> = ({
   }, [ fetchExperimentTrials ]);
 
   useEffect(() => {
-    if (terminalRunStates.has(experiment.state)) stopPolling();
+    if (terminalRunStates.has(experiment.state)) stopPolling({ terminateGracefully: true });
   }, [ experiment.state, stopPolling ]);
 
   useEffect(() => {


### PR DESCRIPTION
## Description

While the experiment is active, the experiment detail page polls to keep the page updated with fresh data. When the experiment reaches a terminal state, the detail page stops polling. This can cause the rest of the page to be out of sync.

Solution is to allow the secondary polling to run one final time before it is terminated. A soft polling stoppage enables this behavior. The polling mechanism will mark the polling to be stopped but the timer for polling is allowed to still run its course to resolve the polling function one final time.

<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan

- [ ] run a multi-trial experiment (`/e2e-tests/tests/fixtures/no_op/adaptive.yaml` is a good one) and view the experiment detail page. Change the trial table `# / page` option to `100 / page`. Leave the page open and when the experiment completes, all of the trials state should show `completed`.

<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234