### PR TITLE
fix: bug in random search leading to incorrect total trials

### DIFF
--- a/master/pkg/searcher/random.go
+++ b/master/pkg/searcher/random.go
@@ -86,7 +86,7 @@ func (s *randomSearch) trialExitedEarly(
 		ops = append(ops, NewTrain(create.RequestID, s.MaxLength))
 		ops = append(ops, NewValidate(create.RequestID))
 		ops = append(ops, NewClose(create.RequestID))
-		s.CreatedTrials++
+		// We don't increment CreatedTrials here because this trial is replacing the invalid trial.
 		s.PendingTrials++
 		return ops, nil
 	}


### PR DESCRIPTION
## Description
Fixing bug where we incorrectly incremented `CreatedTrials` for an invalid HP trial.
