### PR TITLE
chore: extend timeout on HP importance test

### DIFF
--- a/e2e_tests/tests/experiment/test_metrics.py
+++ b/e2e_tests/tests/experiment/test_metrics.py
@@ -61,7 +61,7 @@ def test_streaming_metrics_api() -> None:
 
 
 @pytest.mark.nightly  # type: ignore
-@pytest.mark.timeout(1200)  # type: ignore
+@pytest.mark.timeout(1800)  # type: ignore
 def test_hp_importance_api() -> None:
     auth.initialize_session(conf.make_master_url(), try_reauth=True)
 


### PR DESCRIPTION
## Description

This test timed out last night for what appears to be an unrelated failure. However in my investigation I noticed that we could be cutting it very close sometimes. Nightly tests run with a single GPU, so even though this is close to being a no-op model (10 batches on mnist_pytorch), it's 50 trials sequentially, dominated by the startup time of the harness. Just extending the timeout to prevent flakiness.