### PR TITLE
fix: commands honor per-resource-pool settings

### DIFF
--- a/master/internal/command/api.go
+++ b/master/internal/command/api.go
@@ -20,34 +20,34 @@ func RegisterAPIHandler(
 	proxyRef *actor.Ref,
 	timeout int,
 	defaultAgentUserGroup model.AgentUserGroup,
-	taskSpec *tasks.TaskSpec,
+	makeTaskSpec tasks.MakeTaskSpecFn,
 	middleware ...echo.MiddlewareFunc,
 ) {
 	system.ActorOf(actor.Addr("commands"), &commandManager{
 		defaultAgentUserGroup: defaultAgentUserGroup,
 		db:                    db,
-		taskSpec:              taskSpec,
+		makeTaskSpec:          makeTaskSpec,
 	})
 	echo.Any("/commands*", api.Route(system, nil), middleware...)
 
 	system.ActorOf(actor.Addr("notebooks"), &notebookManager{
 		defaultAgentUserGroup: defaultAgentUserGroup,
 		db:                    db,
-		taskSpec:              taskSpec,
+		makeTaskSpec:          makeTaskSpec,
 	})
 	echo.Any("/notebooks*", api.Route(system, nil), middleware...)
 
 	system.ActorOf(actor.Addr("shells"), &shellManager{
 		defaultAgentUserGroup: defaultAgentUserGroup,
 		db:                    db,
-		taskSpec:              taskSpec,
+		makeTaskSpec:          makeTaskSpec,
 	})
 	echo.Any("/shells*", api.Route(system, nil), middleware...)
 
 	system.ActorOf(actor.Addr("tensorboard"), &tensorboardManager{
 		defaultAgentUserGroup: defaultAgentUserGroup,
 		db:                    db,
-		taskSpec:              taskSpec,
+		makeTaskSpec:          makeTaskSpec,
 		proxyRef:              proxyRef,
 		timeout:               time.Duration(timeout) * time.Second,
 	})

--- a/master/internal/command/command.go
+++ b/master/internal/command/command.go
@@ -50,7 +50,7 @@ type commandOwner struct {
 // commands (e.g., commands, notebooks, shells) if a request
 // does not specify any configuration options.
 func DefaultConfig(taskContainerDefaults *model.TaskContainerDefaultsConfig) model.CommandConfig {
-	environment := model.DefaultExperimentConfig(taskContainerDefaults).Environment
+	expConf := model.DefaultExperimentConfig(taskContainerDefaults)
 	return model.CommandConfig{
 		Resources: model.ResourcesConfig{
 			Slots:  1,
@@ -58,8 +58,9 @@ func DefaultConfig(taskContainerDefaults *model.TaskContainerDefaultsConfig) mod
 			// SlotsPerTrial is not used by commands. They prefer Slots instead.
 			// It is only defined here to pass check.Validate.
 			SlotsPerTrial: 1,
+			Devices:       expConf.Resources.Devices,
 		},
-		Environment: environment,
+		Environment: expConf.Environment,
 	}
 }
 

--- a/master/internal/command/notebook_manager.go
+++ b/master/internal/command/notebook_manager.go
@@ -106,7 +106,7 @@ type notebookManager struct {
 	db *db.PgDB
 
 	defaultAgentUserGroup model.AgentUserGroup
-	taskSpec              *tasks.TaskSpec
+	makeTaskSpec          tasks.MakeTaskSpecFn
 }
 
 // NotebookLaunchRequest describes a request to launch a new notebook.
@@ -120,7 +120,7 @@ func (n *notebookManager) processLaunchRequest(
 	req NotebookLaunchRequest,
 ) (*summary, int, error) {
 	commandReq, err := parseCommandRequest(
-		ctx.Self().System(), n.db, *req.User, req.CommandParams, &n.taskSpec.TaskContainerDefaults, false,
+		ctx.Self().System(), n.db, *req.User, req.CommandParams, n.makeTaskSpec, false,
 	)
 	if err != nil {
 		return nil, http.StatusBadRequest, err
@@ -226,7 +226,7 @@ func (n *notebookManager) newNotebook(req *commandRequest) (*command, error) {
 
 	config.Entrypoint = notebookEntrypoint
 
-	setPodSpec(&config, n.taskSpec.TaskContainerDefaults)
+	setPodSpec(&config, req.TaskSpec.TaskContainerDefaults)
 
 	if config.Description == "" {
 		var err error
@@ -281,7 +281,7 @@ func (n *notebookManager) newNotebook(req *commandRequest) (*command, error) {
 
 		owner:          req.Owner,
 		agentUserGroup: req.AgentUserGroup,
-		taskSpec:       n.taskSpec,
+		taskSpec:       &req.TaskSpec,
 
 		db: n.db,
 	}, nil

--- a/master/internal/core.go
+++ b/master/internal/core.go
@@ -95,6 +95,39 @@ func (m *Master) getConfig(echo.Context) (interface{}, error) {
 	return m.config.Printable()
 }
 
+// makeTaskSpec is the master method that we will pass around as a tasks.MakeTaskSpecFn.  It's
+// behavior is deterministic for the lifetime of the master process.
+func (m *Master) makeTaskSpec(poolName string, numSlots int) tasks.TaskSpec {
+	// Always fall back to the top-level TaskContainerDefaults
+	taskContainerDefaults := m.config.TaskContainerDefaults
+
+	// Only look for pool settings with Agent resource managers.
+	if m.config.ResourceManager.AgentRM != nil {
+		if poolName == "" {
+			if numSlots == 0 {
+				poolName = m.config.ResourceManager.AgentRM.DefaultCPUResourcePool
+			} else {
+				poolName = m.config.ResourceManager.AgentRM.DefaultGPUResourcePool
+			}
+		}
+		// Iterate through configured pools looking for a TaskContainerDefaults setting.
+		for _, pool := range m.config.ResourcePools {
+			if poolName == pool.PoolName {
+				if pool.TaskContainerDefaults == nil {
+					break
+				}
+				taskContainerDefaults = *pool.TaskContainerDefaults
+			}
+		}
+	}
+
+	// Not a deep copy, but deep enough not to overwrite the master's TaskContainerDefaults.
+	taskSpec := *m.taskSpec
+	taskSpec.TaskContainerDefaults = taskContainerDefaults
+
+	return taskSpec
+}
+
 // Info returns this master's information.
 func (m *Master) Info() aproto.MasterInfo {
 	telemetryInfo := aproto.TelemetryInfo{}
@@ -767,7 +800,7 @@ func (m *Master) Run(ctx context.Context) error {
 		m.proxy,
 		m.config.TensorBoardTimeout,
 		m.config.Security.DefaultTask,
-		m.taskSpec,
+		m.makeTaskSpec,
 		authFuncs...,
 	)
 	template.RegisterAPIHandler(m.echo, m.db, authFuncs...)

--- a/master/internal/restore.go
+++ b/master/internal/restore.go
@@ -64,13 +64,10 @@ func (m *Master) restoreExperiment(expModel *model.Experiment) error {
 	}
 
 	// Get the TaskSpec for this experiment.
-	taskContainerDefaults := getResourcePoolTaskContainerDefaultsByName(
+	taskSpec := m.makeTaskSpec(
 		expModel.Config.Resources.ResourcePool,
 		expModel.Config.Resources.SlotsPerTrial,
-		*m.config,
 	)
-	taskSpec := *m.taskSpec
-	taskSpec.TaskContainerDefaults = taskContainerDefaults
 
 	log.WithField("experiment", expModel.ID).Info("restoring experiment")
 	snapshot, err := m.retrieveExperimentSnapshot(expModel)

--- a/master/pkg/model/experiment_config.go
+++ b/master/pkg/model/experiment_config.go
@@ -8,6 +8,8 @@ import (
 
 	"github.com/pkg/errors"
 
+	"github.com/ghodss/yaml"
+
 	"github.com/determined-ai/determined/master/pkg/check"
 )
 
@@ -225,6 +227,29 @@ type ResourcesConfig struct {
 
 	// omitempty since is not an officially announced feature yet
 	Devices *DevicesConfig `json:"devices,omitempty"`
+}
+
+// ParseJustResources is a helper function for breaking the circular dependency where we need the
+// TaskContainerDefaults to unmarshal an ExperimentConfig, but we need the Resources.ResourcePool
+// setting to know which TaskContainerDefaults to use.  It does not throw errors; if unmarshalling
+// fails that can just get caught later.
+func ParseJustResources(configBytes []byte) ResourcesConfig {
+	// Make this function usable on experiment or command configs.
+	type DummyConfig struct {
+		Resources ResourcesConfig `json:"resources"`
+	}
+
+	dummy := DummyConfig{
+		Resources: ResourcesConfig{
+			Slots:         1,
+			SlotsPerTrial: 1,
+		},
+	}
+
+	// Don't throw errors; validation should happen elsewhere.
+	_ = yaml.Unmarshal(configBytes, &dummy)
+
+	return dummy.Resources
 }
 
 // ValidatePrioritySetting checks that priority if set is within a valid range.

--- a/master/pkg/tasks/task_spec.go
+++ b/master/pkg/tasks/task_spec.go
@@ -20,6 +20,12 @@ import (
 	"github.com/determined-ai/determined/master/pkg/model"
 )
 
+// MakeTaskSpecFn is a workaround for the delayed initialization that we have around how tasks are
+// run.  The master knows which task spec and task container defaults belong to which pool, but the
+// actual parsing of configs might be delegated to e.g. a CommandManager which does not have access
+// to the same information.  This lets us avoid extra Asks or passing the Master object around.
+type MakeTaskSpecFn func(poolName string, numSlots int) TaskSpec
+
 // InnerSpec defines the interface for a particular kind of task container.
 type InnerSpec interface {
 	// Archives returns the files to include in the container for this task (apart from the base files


### PR DESCRIPTION
## Description

Fix the known bug in the per-resource-pool configurations with commands/notebooks/shells. 

## Test Plan

Tested manually and will test on customer hardware.

## Commentary (optional)

This refactors how the master's TaskSpec is handled throughout the codebase.
