### PR TITLE
chore: stop using cloudpickle to write PyTorch checkpoints [DET-5175]

### DIFF
--- a/harness/determined/pytorch/_pytorch_trial.py
+++ b/harness/determined/pytorch/_pytorch_trial.py
@@ -4,7 +4,6 @@ import random
 from abc import abstractmethod
 from typing import Any, Dict, List, Optional, Tuple, Union, cast
 
-import cloudpickle
 import numpy as np
 import torch
 
@@ -728,7 +727,7 @@ class PyTorchTrialController(det.LoopTrialController):
         for callback in self.callbacks.values():
             callback.on_checkpoint_save_start(checkpoint)
 
-        torch.save(checkpoint, str(path.joinpath("state_dict.pth")), pickle_module=cloudpickle)
+        torch.save(checkpoint, str(path.joinpath("state_dict.pth")))
 
         for callback in self.callbacks.values():
             callback.on_checkpoint_end(str(path))
@@ -737,7 +736,7 @@ class PyTorchTrialController(det.LoopTrialController):
             workload.Response,
             {
                 "framework": f"torch-{torch.__version__}",
-                "format": "cloudpickle",
+                "format": "pickle",
             },
         )
 

--- a/harness/setup.py
+++ b/harness/setup.py
@@ -15,7 +15,6 @@ setup(
     package_data={"determined": ["py.typed"]},
     include_package_data=True,
     install_requires=[
-        "cloudpickle",
         "dill>=0.2.9",
         # TF 2.2 has strict h5py requirements, which we expose here.
         "h5py>=2.10.0,<2.11.0",


### PR DESCRIPTION
## Description

cloudpickle explicitly says not to use it for long-term storage and we know it has problems across Python versions (like 3.6/7->3.8). It was initially added in connection with MLFlow stuff and is not believed to be needed now (as opposed to standard pickle).

## Test Plan

I already ran our GPU post-commit tests against this: https://app.circleci.com/pipelines/github/determined-ai/determined?branch=mackrory

I also ran the cifar10 model in Pytorch, then modified the Docker image to remove cloudpickle, patched the experiment to apply this change to harness, used the previous trial as the searcher.source_trial_id, and confirmed that training was able to pick up where it left off.