### PR TITLE
chore: Update to Ubuntu 20.04 for agent, master and bastion images [DET-5238]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,11 +97,11 @@ commands:
       - when:
           condition: <<parameters.tf1>>
           steps:
-            - run: docker pull determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-1c4ea10
+            - run: docker pull determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-da9ba40
       - when:
           condition: <<parameters.tf2>>
           steps:
-            - run: docker pull determinedai/environments:py-3.7-pytorch-1.7-lightning-1.2-tf-2.4-cpu-1c4ea10
+            - run: docker pull determinedai/environments:py-3.7-pytorch-1.7-lightning-1.2-tf-2.4-cpu-da9ba40
 
   login-docker:
     parameters:
@@ -637,8 +637,8 @@ commands:
           values-to-override: |
             detVersion=<<parameters.det-version>>,\
             maxSlotsPerPod=<<parameters.gpus-per-machine>>,\
-            taskContainerDefaults.cpuImage=determinedai/environments:cuda-11.0-pytorch-1.7-lightning-1.2-tf-2.4-gpu-0.10.0,\
-            taskContainerDefaults.gpuImage=determinedai/environments:cuda-11.0-pytorch-1.7-lightning-1.2-tf-2.4-gpu-0.10.0,\
+            taskContainerDefaults.cpuImage=determinedai/environments:cuda-11.0-pytorch-1.7-lightning-1.2-tf-2.4-gpu-0.11.0,\
+            taskContainerDefaults.gpuImage=determinedai/environments:cuda-11.0-pytorch-1.7-lightning-1.2-tf-2.4-gpu-0.11.0,\
             checkpointStorage.type=gcs,\
             checkpointStorage.bucket=det-ci,\
             defaultScheduler=coscheduler
@@ -1547,8 +1547,8 @@ jobs:
       # "CUDA" environment variable is set to 11.
       # TODO: (DET-4918): we should ensure a consistent way to have tests that can run against
       # both major TensorFlow versions do so regularly (but not others).
-      TF1_GPU_IMAGE: determinedai/environments:cuda-11.0-pytorch-1.7-lightning-1.2-tf-2.4-gpu-0.10.0
-      TF2_GPU_IMAGE: determinedai/environments:cuda-11.0-pytorch-1.7-lightning-1.2-tf-2.4-gpu-0.10.0
+      TF1_GPU_IMAGE: determinedai/environments:cuda-11.0-pytorch-1.7-lightning-1.2-tf-2.4-gpu-0.11.0
+      TF2_GPU_IMAGE: determinedai/environments:cuda-11.0-pytorch-1.7-lightning-1.2-tf-2.4-gpu-0.11.0
       CUDA: 11
     steps:
       - checkout

--- a/docs/faq.txt
+++ b/docs/faq.txt
@@ -203,9 +203,9 @@ container image that has been configured for that experiment. Determined
 provides prebuilt Docker images that include TensorFlow 1.15, 2.2, and
 2.4, respectively:
 
--  ``determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-0.10.0``
+-  ``determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-0.11.0``
    (default)
--  ``determinedai/environments:cuda-10.2-pytorch-1.7-lightning-1.2-tf-2.4-gpu-0.10.0``
+-  ``determinedai/environments:cuda-10.2-pytorch-1.7-lightning-1.2-tf-2.4-gpu-0.11.0``
 
 To change the container image used for an experiment, specify
 :ref:`environment.image <exp-environment-image>` in the experiment

--- a/docs/how-to/custom-env.txt
+++ b/docs/how-to/custom-env.txt
@@ -109,9 +109,9 @@ and values of the hyperparameters for the current trial.
 .. note::
 
    The default images are
-   ``determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-0.10.0``
+   ``determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-0.11.0``
    and
-   ``determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-0.10.0``
+   ``determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-0.11.0``
    for GPU and CPU respectively.
 
 CUDA 11 Images
@@ -133,7 +133,7 @@ This can be configured in your experiment configuration like below:
 .. code:: yaml
 
    environment:
-     image: "determinedai/environments:cuda-11.0-pytorch-1.7-lightning-1.2-tf-2.4-gpu-0.10.0"
+     image: "determinedai/environments:cuda-11.0-pytorch-1.7-lightning-1.2-tf-2.4-gpu-0.11.0"
 
 Older Images
 ============
@@ -173,7 +173,7 @@ Here is an example of a ``Dockerfile`` that installs both ``conda``- and
 
 .. code::
 
-   FROM determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-0.10.0
+   FROM determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-0.11.0
    RUN apt-get update && apt-get install -y unzip python-opencv graphviz
    COPY environment.yml /tmp/environment.yml
    COPY pip_requirements.txt /tmp/pip_requirements.txt

--- a/docs/how-to/tensorboard.txt
+++ b/docs/how-to/tensorboard.txt
@@ -68,7 +68,7 @@ data with a bind-mount.
 .. code:: yaml
 
    environment:
-     image: determinedai/environments:cuda-10.2-pytorch-1.7-lightning-1.2-tf-2.4-gpu-0.10.0
+     image: determinedai/environments:cuda-10.2-pytorch-1.7-lightning-1.2-tf-2.4-gpu-0.11.0
    bind_mounts:
      - host_path: /my/agent/path
        container_path: /my/container/path

--- a/docs/reference/cluster-config.txt
+++ b/docs/reference/cluster-config.txt
@@ -267,9 +267,9 @@ The master supports the following configuration settings:
       specifying a dict with two keys, ``cpu`` and ``gpu``. Default
       values:
 
-      -  ``determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-0.10.0``
+      -  ``determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-0.11.0``
          for CPU agents
-      -  ``determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-0.10.0``
+      -  ``determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-0.11.0``
          for GPU agents.
 
    -  ``force_pull_image``: Defines the default policy for forcibly

--- a/docs/reference/command-notebook-config.txt
+++ b/docs/reference/command-notebook-config.txt
@@ -51,9 +51,9 @@ The following configuration settings are supported:
       Determined agent machine in the cluster. Users can customize the
       image used for GPU vs. CPU agents by specifying a dict with two
       keys, ``cpu`` and ``gpu``. Defaults to
-      ``determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-0.10.0``
+      ``determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-0.11.0``
       for CPU agents and
-      ``determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-0.10.0``
+      ``determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-0.11.0``
       for GPU agents.
 
    -  ``force_pull_image``: Forcibly pull the image from the Docker

--- a/docs/reference/experiment-config.txt
+++ b/docs/reference/experiment-config.txt
@@ -880,9 +880,9 @@ more information on customizing the trial environment, refer to
    GPU vs. CPU agents by specifying a dict with two keys, ``cpu`` and
    ``gpu``. Default values:
 
-   -  ``determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-0.10.0``
+   -  ``determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-0.11.0``
       for agents with GPUs.
-   -  ``determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-0.10.0``
+   -  ``determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-0.11.0``
       for agents with only CPUs.
 
 ``force_pull_image``

--- a/docs/reference/helm-config.txt
+++ b/docs/reference/helm-config.txt
@@ -204,12 +204,12 @@ Helm Chart </helm/determined-0.5.0.tgz>`.
    -  ``cpuImage``: Sets the default docker image for all non-gpu tasks.
       If a docker image is specified in the :ref:`experiment config
       <exp-environment-image>` this default is overriden. Defaults to:
-      ``determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-0.10.0``.
+      ``determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-0.11.0``.
 
    -  ``gpuImage``: Sets the default docker image for all gpu tasks. If
       a docker image is specified in the :ref:`experiment config
       <exp-environment-image>` this default is overriden. Defaults to:
-      ``determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-0.10.0``.
+      ``determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-0.11.0``.
 
 -  ``enterpriseEdition``: Specifies whether to use Determined enterprise
    edition.

--- a/docs/tutorials/quick-start.txt
+++ b/docs/tutorials/quick-start.txt
@@ -43,10 +43,10 @@ cluster without writing a model, see :ref:`commands-and-shells`.
 .. code::
 
    # For CPU computations
-   docker pull determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-0.10.0
+   docker pull determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-0.11.0
 
    # For GPU computations
-   docker pull determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-0.10.0
+   docker pull determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-0.11.0
 
 .. _quick-start-first-job:
 

--- a/e2e_tests/tests/config.py
+++ b/e2e_tests/tests/config.py
@@ -12,13 +12,13 @@ MAX_TASK_SCHEDULED_SECS = 30
 MAX_TRIAL_BUILD_SECS = 90
 
 
-DEFAULT_TF1_CPU_IMAGE = "determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-1c4ea10"
+DEFAULT_TF1_CPU_IMAGE = "determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-da9ba40"
 DEFAULT_TF2_CPU_IMAGE = (
-    "determinedai/environments:py-3.7-pytorch-1.7-lightning-1.2-tf-2.4-cpu-1c4ea10"
+    "determinedai/environments:py-3.7-pytorch-1.7-lightning-1.2-tf-2.4-cpu-da9ba40"
 )
-DEFAULT_TF1_GPU_IMAGE = "determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-1c4ea10"
+DEFAULT_TF1_GPU_IMAGE = "determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-da9ba40"
 DEFAULT_TF2_GPU_IMAGE = (
-    "determinedai/environments:cuda-10.2-pytorch-1.7-lightning-1.2-tf-2.4-gpu-1c4ea10"
+    "determinedai/environments:cuda-10.2-pytorch-1.7-lightning-1.2-tf-2.4-gpu-da9ba40"
 )
 
 TF1_CPU_IMAGE = os.environ.get("TF1_CPU_IMAGE") or DEFAULT_TF1_CPU_IMAGE

--- a/e2e_tests/tests/fixtures/pytorch_lightning_amp/apex_amp.yaml
+++ b/e2e_tests/tests/fixtures/pytorch_lightning_amp/apex_amp.yaml
@@ -14,6 +14,6 @@ searcher:
 entrypoint: apex_amp_model_def:MNistApexAMPTrial
 environment:
   image:
-    gpu: determinedai/environments:cuda-10.2-pytorch-1.7-lightning-1.2-tf-2.4-gpu-0.10.0
-    cpu: determinedai/environments:py-3.7-pytorch-1.7-lightning-1.2-tf-2.4-cpu-0.10.0
+    gpu: determinedai/environments:cuda-10.2-pytorch-1.7-lightning-1.2-tf-2.4-gpu-0.11.0
+    cpu: determinedai/environments:py-3.7-pytorch-1.7-lightning-1.2-tf-2.4-cpu-0.11.0
 

--- a/e2e_tests/tests/fixtures/pytorch_lightning_amp/auto_amp.yaml
+++ b/e2e_tests/tests/fixtures/pytorch_lightning_amp/auto_amp.yaml
@@ -14,6 +14,6 @@ searcher:
 entrypoint: auto_amp_model_def:MNistAutoAMPTrial
 environment:
   image:
-    gpu: determinedai/environments:cuda-10.2-pytorch-1.7-lightning-1.2-tf-2.4-gpu-0.10.0
-    cpu: determinedai/environments:py-3.7-pytorch-1.7-lightning-1.2-tf-2.4-cpu-0.10.0
+    gpu: determinedai/environments:cuda-10.2-pytorch-1.7-lightning-1.2-tf-2.4-gpu-0.11.0
+    cpu: determinedai/environments:py-3.7-pytorch-1.7-lightning-1.2-tf-2.4-cpu-0.11.0
 

--- a/examples/computer_vision/mmdetection_pytorch/docker/Dockerfile
+++ b/examples/computer_vision/mmdetection_pytorch/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-1c4ea10
+FROM determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-da9ba40
 
 ENV TORCH_CUDA_ARCH_LIST="6.0 6.1 7.0+PTX"
 ENV TORCH_NVCC_FLAGS="-Xfatbin -compress-all"

--- a/examples/computer_vision/mnist_pl/adaptive.yaml
+++ b/examples/computer_vision/mnist_pl/adaptive.yaml
@@ -18,5 +18,5 @@ searcher:
 entrypoint: model_def:MNISTTrial
 environment:
   image:
-    gpu: determinedai/environments:cuda-10.2-pytorch-1.7-lightning-1.2-tf-2.4-gpu-0.10.0
-    cpu: determinedai/environments:py-3.7-pytorch-1.7-lightning-1.2-tf-2.4-cpu-0.10.0
+    gpu: determinedai/environments:cuda-10.2-pytorch-1.7-lightning-1.2-tf-2.4-gpu-0.11.0
+    cpu: determinedai/environments:py-3.7-pytorch-1.7-lightning-1.2-tf-2.4-cpu-0.11.0

--- a/examples/computer_vision/mnist_pl/const.yaml
+++ b/examples/computer_vision/mnist_pl/const.yaml
@@ -14,5 +14,5 @@ searcher:
 entrypoint: model_def:MNISTTrial
 environment:
   image:
-    gpu: determinedai/environments:cuda-10.2-pytorch-1.7-lightning-1.2-tf-2.4-gpu-0.10.0
-    cpu: determinedai/environments:py-3.7-pytorch-1.7-lightning-1.2-tf-2.4-cpu-0.10.0
+    gpu: determinedai/environments:cuda-10.2-pytorch-1.7-lightning-1.2-tf-2.4-gpu-0.11.0
+    cpu: determinedai/environments:py-3.7-pytorch-1.7-lightning-1.2-tf-2.4-cpu-0.11.0

--- a/examples/decision_trees/gbt_titanic_estimator/adaptive.yaml
+++ b/examples/decision_trees/gbt_titanic_estimator/adaptive.yaml
@@ -42,4 +42,4 @@ searcher:
 entrypoint: model_def:BoostedTreesTrial
 scheduling_unit: 1
 environment:
-  image: "determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-0.10.0"
+  image: "determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-0.11.0"

--- a/examples/decision_trees/gbt_titanic_estimator/const.yaml
+++ b/examples/decision_trees/gbt_titanic_estimator/const.yaml
@@ -20,4 +20,4 @@ searcher:
 entrypoint: model_def:BoostedTreesTrial
 scheduling_unit: 1
 environment:
-  image: "determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-0.10.0" 
+  image: "determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-0.11.0" 

--- a/examples/gan/dcgan_tf_keras/const.yaml
+++ b/examples/gan/dcgan_tf_keras/const.yaml
@@ -15,5 +15,5 @@ entrypoint: model_def:DCGanTrial
 environment:
   # This model only works with Tensorflow 2.2+.
   image:
-     cpu: "determinedai/environments:py-3.7-pytorch-1.7-lightning-1.2-tf-2.4-cpu-1c4ea10"
-     gpu: "determinedai/environments:cuda-10.2-pytorch-1.7-lightning-1.2-tf-2.4-gpu-1c4ea10"
+     cpu: "determinedai/environments:py-3.7-pytorch-1.7-lightning-1.2-tf-2.4-cpu-da9ba40"
+     gpu: "determinedai/environments:cuda-10.2-pytorch-1.7-lightning-1.2-tf-2.4-gpu-da9ba40"

--- a/examples/gan/dcgan_tf_keras/distributed.yaml
+++ b/examples/gan/dcgan_tf_keras/distributed.yaml
@@ -17,5 +17,5 @@ resources:
 environment:
   # This model only works with Tensorflow 2.2+.
   image:
-     cpu: "determinedai/environments:py-3.7-pytorch-1.7-lightning-1.2-tf-2.4-cpu-1c4ea10"
-     gpu: "determinedai/environments:cuda-10.2-pytorch-1.7-lightning-1.2-tf-2.4-gpu-1c4ea10"
+     cpu: "determinedai/environments:py-3.7-pytorch-1.7-lightning-1.2-tf-2.4-cpu-da9ba40"
+     gpu: "determinedai/environments:cuda-10.2-pytorch-1.7-lightning-1.2-tf-2.4-gpu-da9ba40"

--- a/examples/gan/gan_mnist_pl/adaptive.yaml
+++ b/examples/gan/gan_mnist_pl/adaptive.yaml
@@ -25,5 +25,5 @@ resources:
 entrypoint: model_def:GANTrial
 environment:
   image:
-    gpu: determinedai/environments:cuda-10.2-pytorch-1.7-lightning-1.2-tf-2.4-gpu-0.10.0
-    cpu: determinedai/environments:py-3.7-pytorch-1.7-lightning-1.2-tf-2.4-cpu-0.10.0
+    gpu: determinedai/environments:cuda-10.2-pytorch-1.7-lightning-1.2-tf-2.4-gpu-0.11.0
+    cpu: determinedai/environments:py-3.7-pytorch-1.7-lightning-1.2-tf-2.4-cpu-0.11.0

--- a/examples/gan/gan_mnist_pl/const.yaml
+++ b/examples/gan/gan_mnist_pl/const.yaml
@@ -16,5 +16,5 @@ searcher:
 entrypoint: model_def:GANTrial
 environment:
   image:
-    gpu: determinedai/environments:cuda-10.2-pytorch-1.7-lightning-1.2-tf-2.4-gpu-0.10.0
-    cpu: determinedai/environments:py-3.7-pytorch-1.7-lightning-1.2-tf-2.4-cpu-0.10.0
+    gpu: determinedai/environments:cuda-10.2-pytorch-1.7-lightning-1.2-tf-2.4-gpu-0.11.0
+    cpu: determinedai/environments:py-3.7-pytorch-1.7-lightning-1.2-tf-2.4-cpu-0.11.0

--- a/examples/gan/gan_mnist_pl/distributed.yaml
+++ b/examples/gan/gan_mnist_pl/distributed.yaml
@@ -25,5 +25,5 @@ resources:
 entrypoint: model_def:GANTrial
 environment:
   image:
-    gpu: determinedai/environments:cuda-10.2-pytorch-1.7-lightning-1.2-tf-2.4-gpu-0.10.0
-    cpu: determinedai/environments:py-3.7-pytorch-1.7-lightning-1.2-tf-2.4-cpu-0.10.0
+    gpu: determinedai/environments:cuda-10.2-pytorch-1.7-lightning-1.2-tf-2.4-gpu-0.11.0
+    cpu: determinedai/environments:py-3.7-pytorch-1.7-lightning-1.2-tf-2.4-cpu-0.11.0

--- a/harness/determined/common/schemas/expconf/_v0.py
+++ b/harness/determined/common/schemas/expconf/_v0.py
@@ -207,9 +207,9 @@ class EnvironmentImageV0(schemas.SchemaBase):
 
     def runtime_defaults(self) -> None:
         if self.cpu is None:
-            self.cpu = "determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-1c4ea10"
+            self.cpu = "determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-da9ba40"
         if self.gpu is None:
-            self.gpu = "determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-1c4ea10"
+            self.gpu = "determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-da9ba40"
 
 
 class EnvironmentVariablesV0(schemas.SchemaBase):

--- a/harness/determined/deploy/aws/templates/efs.yaml
+++ b/harness/determined/deploy/aws/templates/efs.yaml
@@ -3,36 +3,36 @@ Description:  This template deploys a VPC, with a public and private subnet. It 
 Mappings:
   RegionMap:
     ap-northeast-1:
-      Master: ami-005021e678ab162ea
-      Agent: ami-039e09c6582ec61c5
+      Master: ami-09ff2b6ef00accc2e
+      Agent: ami-0aa0009aef18b0bf6
     # TODO(DET-4258) Uncomment these when we fully support all P3 regions.
     # ap-northeast-2:
-    #   Master: ami-090b3f1f06a12d28d
-    #   Agent: ami-063ee28bcaee0c2b1
+    #   Master: ami-0b329fb1f17558744
+    #   Agent: ami-0467839b0f89571f3
     # ap-southeast-1:
-    #   Master: ami-01e1605d140c6b5e6
-    #   Agent: ami-0cc963cd1e2f1b045
+    #   Master: ami-048b4b1ddefe6759f
+    #   Agent: ami-0b62986f9f7eb81a8
     # ap-southeast-2:
-    #   Master: ami-00d02a4b2cf1df2f4
-    #   Agent: ami-0612c09a99b545d53
+    #   Master: ami-052a251c7ca533c26
+    #   Agent: ami-0ff94af30d0c3de3d
     eu-central-1:
-      Master: ami-08c1695e3dcdd191e
-      Agent: ami-0e706905d18bcf024
+      Master: ami-0d3905203a039e3b0
+      Agent: ami-04b224a3d8a60c33c
     eu-west-1:
-      Master: ami-08fabf5d4fa6fcc12
-      Agent: ami-020a8186dcd6e0222
+      Master: ami-0b7fd7bc9c6fb1c78
+      Agent: ami-09c3ee9c7fa7ca807
     # eu-west-2:
-    #   Master: ami-0b3e07036579e1b57
-    #   Agent: ami-01163cd376120c8c8
+    #   Master: ami-02ead6ecbd926d792
+    #   Agent: ami-0656062915959b484
     us-east-1:
-      Master: ami-056db1277deef2218
-      Agent: ami-0e8bcb2511e8ecd6e
+      Master: ami-04cc2b0ad9e30a9c8
+      Agent: ami-053a634ff2eb53ab2
     us-east-2:
-      Master: ami-0a4b51dd47f678ba3
-      Agent: ami-0c8afd5575ba72550
+      Master: ami-02fc6052104add5ae
+      Agent: ami-0b7819c38bd6e76f3
     us-west-2:
-      Master: ami-0ee876776acf64c80
-      Agent: ami-06380c60a2b768f2d
+      Master: ami-0a62a78cfedc09d76
+      Agent: ami-0e0b3b379de73ae4e
 
 Parameters:
   VpcCIDR:

--- a/harness/determined/deploy/aws/templates/fsx.yaml
+++ b/harness/determined/deploy/aws/templates/fsx.yaml
@@ -2,36 +2,36 @@ Description:  This template deploys a VPC, with a public and private subnet, and
 Mappings:
   RegionMap:
     ap-northeast-1:
-      Master: ami-005021e678ab162ea
-      Agent: ami-039e09c6582ec61c5
+      Master: ami-09ff2b6ef00accc2e
+      Agent: ami-0aa0009aef18b0bf6
     # TODO(DET-4258) Uncomment these when we fully support all P3 regions.
     # ap-northeast-2:
-    #   Master: ami-090b3f1f06a12d28d
-    #   Agent: ami-063ee28bcaee0c2b1
+    #   Master: ami-0b329fb1f17558744
+    #   Agent: ami-0467839b0f89571f3
     # ap-southeast-1:
-    #   Master: ami-01e1605d140c6b5e6
-    #   Agent: ami-0cc963cd1e2f1b045
+    #   Master: ami-048b4b1ddefe6759f
+    #   Agent: ami-0b62986f9f7eb81a8
     # ap-southeast-2:
-    #   Master: ami-00d02a4b2cf1df2f4
-    #   Agent: ami-0612c09a99b545d53
+    #   Master: ami-052a251c7ca533c26
+    #   Agent: ami-0ff94af30d0c3de3d
     eu-central-1:
-      Master: ami-08c1695e3dcdd191e
-      Agent: ami-0e706905d18bcf024
+      Master: ami-0d3905203a039e3b0
+      Agent: ami-04b224a3d8a60c33c
     eu-west-1:
-      Master: ami-08fabf5d4fa6fcc12
-      Agent: ami-020a8186dcd6e0222
+      Master: ami-0b7fd7bc9c6fb1c78
+      Agent: ami-09c3ee9c7fa7ca807
     # eu-west-2:
-    #   Master: ami-0b3e07036579e1b57
-    #   Agent: ami-01163cd376120c8c8
+    #   Master: ami-02ead6ecbd926d792
+    #   Agent: ami-0656062915959b484
     us-east-1:
-      Master: ami-056db1277deef2218
-      Agent: ami-0e8bcb2511e8ecd6e
+      Master: ami-04cc2b0ad9e30a9c8
+      Agent: ami-053a634ff2eb53ab2
     us-east-2:
-      Master: ami-0a4b51dd47f678ba3
-      Agent: ami-0c8afd5575ba72550
+      Master: ami-02fc6052104add5ae
+      Agent: ami-0b7819c38bd6e76f3
     us-west-2:
-      Master: ami-0ee876776acf64c80
-      Agent: ami-06380c60a2b768f2d
+      Master: ami-0a62a78cfedc09d76
+      Agent: ami-0e0b3b379de73ae4e
 
 Parameters:
   VpcCIDR:

--- a/harness/determined/deploy/aws/templates/govcloud.yaml
+++ b/harness/determined/deploy/aws/templates/govcloud.yaml
@@ -7,7 +7,7 @@ Mappings:
       Master: ami-af9379de
       Agent: ami-0b71e56244b8ac1cb
     us-gov-west-1:
-      Master: ami-a6e8d2c7
+      Master: ami-84556de5
       Agent: ami-0d26002529bfac823
 Parameters:
   Keypair:

--- a/harness/determined/deploy/aws/templates/secure.yaml
+++ b/harness/determined/deploy/aws/templates/secure.yaml
@@ -3,46 +3,46 @@ Description:  This template deploys a VPC, with a public and private subnet. It 
 Mappings:
   RegionMap:
     ap-northeast-1:
-      Master: ami-005021e678ab162ea
-      Agent: ami-039e09c6582ec61c5
-      Bastion: ami-04fe60822d08387bb
+      Master: ami-09ff2b6ef00accc2e
+      Agent: ami-0aa0009aef18b0bf6
+      Bastion: ami-09ff2b6ef00accc2e
     # TODO(DET-4258) Uncomment these when we fully support all P3 regions.
     # ap-northeast-2:
-    #   Master: ami-090b3f1f06a12d28d
-    #   Agent: ami-063ee28bcaee0c2b1
-    #   Bastion: ami-05f375b54be4ab849
+    #   Master: ami-0b329fb1f17558744
+    #   Agent: ami-0467839b0f89571f3
+    #   Bastion: ami-0b329fb1f17558744
     # ap-southeast-1:
-    #   Master: ami-01e1605d140c6b5e6
-    #   Agent: ami-0cc963cd1e2f1b045
-    #   Bastion: ami-0ead23393ac084a1e
+    #   Master: ami-048b4b1ddefe6759f
+    #   Agent: ami-0b62986f9f7eb81a8
+    #   Bastion: ami-048b4b1ddefe6759f
     # ap-southeast-2:
-    #   Master: ami-00d02a4b2cf1df2f4
-    #   Agent: ami-0612c09a99b545d53
-    #   Bastion: ami-05b921f2a1a419c07
+    #   Master: ami-052a251c7ca533c26
+    #   Agent: ami-0ff94af30d0c3de3d
+    #   Bastion: ami-052a251c7ca533c26
     eu-central-1:
-      Master: ami-08c1695e3dcdd191e
-      Agent: ami-0e706905d18bcf024
-      Bastion: ami-07a0e33d3c1c5fb82
+      Master: ami-0d3905203a039e3b0
+      Agent: ami-04b224a3d8a60c33c
+      Bastion: ami-0d3905203a039e3b0
     eu-west-1:
-      Master: ami-08fabf5d4fa6fcc12
-      Agent: ami-020a8186dcd6e0222
-      Bastion: ami-03c4a26550b802f69
+      Master: ami-0b7fd7bc9c6fb1c78
+      Agent: ami-09c3ee9c7fa7ca807
+      Bastion: ami-0b7fd7bc9c6fb1c78
     # eu-west-2:
-    #   Master: ami-0b3e07036579e1b57
-    #   Agent: ami-01163cd376120c8c8
-    #   Bastion: ami-066213f162acbccdc
+    #   Master: ami-02ead6ecbd926d792
+    #   Agent: ami-0656062915959b484
+    #   Bastion: ami-02ead6ecbd926d792
     us-east-1:
-      Master: ami-056db1277deef2218
-      Agent: ami-0e8bcb2511e8ecd6e
-      Bastion: ami-03eaf3b9c3367e75c
+      Master: ami-04cc2b0ad9e30a9c8
+      Agent: ami-053a634ff2eb53ab2
+      Bastion: ami-04cc2b0ad9e30a9c8
     us-east-2:
-      Master: ami-0a4b51dd47f678ba3
-      Agent: ami-0c8afd5575ba72550
-      Bastion: ami-09135e71dc2619458
+      Master: ami-02fc6052104add5ae
+      Agent: ami-0b7819c38bd6e76f3
+      Bastion: ami-02fc6052104add5ae
     us-west-2:
-      Master: ami-0ee876776acf64c80
-      Agent: ami-06380c60a2b768f2d
-      Bastion: ami-007e276c37b5ff2d7
+      Master: ami-0a62a78cfedc09d76
+      Agent: ami-0e0b3b379de73ae4e
+      Bastion: ami-0a62a78cfedc09d76
 
 Parameters:
   VpcCIDR:

--- a/harness/determined/deploy/aws/templates/simple.yaml
+++ b/harness/determined/deploy/aws/templates/simple.yaml
@@ -4,36 +4,36 @@ Description: Determined Template
 Mappings:
   RegionMap:
     ap-northeast-1:
-      Master: ami-005021e678ab162ea
-      Agent: ami-039e09c6582ec61c5
+      Master: ami-09ff2b6ef00accc2e
+      Agent: ami-0aa0009aef18b0bf6
     # TODO(DET-4258) Uncomment these when we fully support all P3 regions.
     # ap-northeast-2:
-    #   Master: ami-090b3f1f06a12d28d
-    #   Agent: ami-063ee28bcaee0c2b1
+    #   Master: ami-0b329fb1f17558744
+    #   Agent: ami-0467839b0f89571f3
     # ap-southeast-1:
-    #   Master: ami-01e1605d140c6b5e6
-    #   Agent: ami-0cc963cd1e2f1b045
+    #   Master: ami-048b4b1ddefe6759f
+    #   Agent: ami-0b62986f9f7eb81a8
     # ap-southeast-2:
-    #   Master: ami-00d02a4b2cf1df2f4
-    #   Agent: ami-0612c09a99b545d53
+    #   Master: ami-052a251c7ca533c26
+    #   Agent: ami-0ff94af30d0c3de3d
     eu-central-1:
-      Master: ami-08c1695e3dcdd191e
-      Agent: ami-0e706905d18bcf024
+      Master: ami-0d3905203a039e3b0
+      Agent: ami-04b224a3d8a60c33c
     eu-west-1:
-      Master: ami-08fabf5d4fa6fcc12
-      Agent: ami-020a8186dcd6e0222
+      Master: ami-0b7fd7bc9c6fb1c78
+      Agent: ami-09c3ee9c7fa7ca807
     # eu-west-2:
-    #   Master: ami-0b3e07036579e1b57
-    #   Agent: ami-01163cd376120c8c8
+    #   Master: ami-02ead6ecbd926d792
+    #   Agent: ami-0656062915959b484
     us-east-1:
-      Master: ami-056db1277deef2218
-      Agent: ami-0e8bcb2511e8ecd6e
+      Master: ami-04cc2b0ad9e30a9c8
+      Agent: ami-053a634ff2eb53ab2
     us-east-2:
-      Master: ami-0a4b51dd47f678ba3
-      Agent: ami-0c8afd5575ba72550
+      Master: ami-02fc6052104add5ae
+      Agent: ami-0b7819c38bd6e76f3
     us-west-2:
-      Master: ami-0ee876776acf64c80
-      Agent: ami-06380c60a2b768f2d
+      Master: ami-0a62a78cfedc09d76
+      Agent: ami-0e0b3b379de73ae4e
 
 Parameters:
   Keypair:

--- a/harness/determined/deploy/aws/templates/vpc.yaml
+++ b/harness/determined/deploy/aws/templates/vpc.yaml
@@ -3,36 +3,36 @@ Description:  This template deploys a VPC, with a public and private subnet. It 
 Mappings:
   RegionMap:
     ap-northeast-1:
-      Master: ami-005021e678ab162ea
-      Agent: ami-039e09c6582ec61c5
+      Master: ami-09ff2b6ef00accc2e
+      Agent: ami-0aa0009aef18b0bf6
     # TODO(DET-4258) Uncomment these when we fully support all P3 regions.
     # ap-northeast-2:
-    #   Master: ami-090b3f1f06a12d28d
-    #   Agent: ami-063ee28bcaee0c2b1
+    #   Master: ami-0b329fb1f17558744
+    #   Agent: ami-0467839b0f89571f3
     # ap-southeast-1:
-    #   Master: ami-01e1605d140c6b5e6
-    #   Agent: ami-0cc963cd1e2f1b045
+    #   Master: ami-048b4b1ddefe6759f
+    #   Agent: ami-0b62986f9f7eb81a8
     # ap-southeast-2:
-    #   Master: ami-00d02a4b2cf1df2f4
-    #   Agent: ami-0612c09a99b545d53
+    #   Master: ami-052a251c7ca533c26
+    #   Agent: ami-0ff94af30d0c3de3d
     eu-central-1:
-      Master: ami-08c1695e3dcdd191e
-      Agent: ami-0e706905d18bcf024
+      Master: ami-0d3905203a039e3b0
+      Agent: ami-04b224a3d8a60c33c
     eu-west-1:
-      Master: ami-08fabf5d4fa6fcc12
-      Agent: ami-020a8186dcd6e0222
+      Master: ami-0b7fd7bc9c6fb1c78
+      Agent: ami-09c3ee9c7fa7ca807
     # eu-west-2:
-    #   Master: ami-0b3e07036579e1b57
-    #   Agent: ami-01163cd376120c8c8
+    #   Master: ami-02ead6ecbd926d792
+    #   Agent: ami-0656062915959b484
     us-east-1:
-      Master: ami-056db1277deef2218
-      Agent: ami-0e8bcb2511e8ecd6e
+      Master: ami-04cc2b0ad9e30a9c8
+      Agent: ami-053a634ff2eb53ab2
     us-east-2:
-      Master: ami-0a4b51dd47f678ba3
-      Agent: ami-0c8afd5575ba72550
+      Master: ami-02fc6052104add5ae
+      Agent: ami-0b7819c38bd6e76f3
     us-west-2:
-      Master: ami-0ee876776acf64c80
-      Agent: ami-06380c60a2b768f2d
+      Master: ami-0a62a78cfedc09d76
+      Agent: ami-0e0b3b379de73ae4e
 
 Parameters:
   VpcCIDR:

--- a/harness/determined/deploy/gcp/constants.py
+++ b/harness/determined/deploy/gcp/constants.py
@@ -3,7 +3,7 @@ class defaults:
     CPU_AGENT_INSTANCE_TYPE = "n1-standard-4"
     GPU_AGENT_INSTANCE_TYPE = "n1-standard-32"
     DB_PASSWORD = "postgres"
-    ENVIRONMENT_IMAGE = "det-environments-1c4ea10"
+    ENVIRONMENT_IMAGE = "det-environments-da9ba40"
     GPU_NUM = 8
     GPU_TYPE = "nvidia-tesla-k80"
     MASTER_INSTANCE_TYPE = "n1-standard-2"

--- a/harness/determined/estimator/_estimator_trial.py
+++ b/harness/determined/estimator/_estimator_trial.py
@@ -820,7 +820,7 @@ class EstimatorTrial(det.Trial):
     """
     By default, experiments run with TensorFlow 1.x. To configure your trial to
     use TensorFlow 2.x, set a TF 2.x image in the experiment configuration
-    (e.g. ``determinedai/environments:cuda-10.2-pytorch-1.7-lightning-1.2-tf-2.4-gpu-0.10.0``).
+    (e.g. ``determinedai/environments:cuda-10.2-pytorch-1.7-lightning-1.2-tf-2.4-gpu-0.11.0``).
 
     ``EstimatorTrial`` supports TF 2.x; however it uses TensorFlow V1
     behavior. We have disabled TensorFlow V2 behavior for ``EstimatorTrial``,

--- a/harness/determined/keras/_tf_keras_trial.py
+++ b/harness/determined/keras/_tf_keras_trial.py
@@ -969,7 +969,7 @@ class TFKerasTrial(det.Trial):
     TensorFlow 2.x, specify a TensorFlow 2.x image in the
     :ref:`environment.image <exp-environment-image>` field of the experiment
     configuration (e.g.,
-    ``determinedai/environments:cuda-10.2-pytorch-1.7-lightning-1.2-tf-2.4-gpu-0.10.0``).
+    ``determinedai/environments:cuda-10.2-pytorch-1.7-lightning-1.2-tf-2.4-gpu-0.11.0``).
 
     Trials default to using eager execution with TensorFlow 2.x but not with
     TensorFlow 1.x. To override the default behavior, call the appropriate

--- a/master/internal/provisioner/aws_config.go
+++ b/master/internal/provisioner/aws_config.go
@@ -41,16 +41,16 @@ type AWSClusterConfig struct {
 }
 
 var defaultAWSImageID = map[string]string{
-	"ap-northeast-1": "ami-039e09c6582ec61c5",
-	"ap-northeast-2": "ami-063ee28bcaee0c2b1",
-	"ap-southeast-1": "ami-0cc963cd1e2f1b045",
-	"ap-southeast-2": "ami-0612c09a99b545d53",
-	"us-east-2":      "ami-0c8afd5575ba72550",
-	"us-east-1":      "ami-0e8bcb2511e8ecd6e",
-	"us-west-2":      "ami-06380c60a2b768f2d",
-	"eu-central-1":   "ami-0e706905d18bcf024",
-	"eu-west-2":      "ami-01163cd376120c8c8",
-	"eu-west-1":      "ami-020a8186dcd6e0222",
+	"ap-northeast-1": "ami-0aa0009aef18b0bf6",
+	"ap-northeast-2": "ami-0467839b0f89571f3",
+	"ap-southeast-1": "ami-0b62986f9f7eb81a8",
+	"ap-southeast-2": "ami-0ff94af30d0c3de3d",
+	"us-east-2":      "ami-0b7819c38bd6e76f3",
+	"us-east-1":      "ami-053a634ff2eb53ab2",
+	"us-west-2":      "ami-0e0b3b379de73ae4e",
+	"eu-central-1":   "ami-04b224a3d8a60c33c",
+	"eu-west-2":      "ami-0656062915959b484",
+	"eu-west-1":      "ami-09c3ee9c7fa7ca807",
 }
 
 var defaultAWSClusterConfig = AWSClusterConfig{

--- a/master/internal/provisioner/gcp_config.go
+++ b/master/internal/provisioner/gcp_config.go
@@ -48,7 +48,7 @@ type GCPClusterConfig struct {
 func DefaultGCPClusterConfig() *GCPClusterConfig {
 	return &GCPClusterConfig{
 		BootDiskSize:        200,
-		BootDiskSourceImage: "projects/determined-ai/global/images/det-environments-1c4ea10",
+		BootDiskSourceImage: "projects/determined-ai/global/images/det-environments-da9ba40",
 		LabelKey:            "managed-by",
 		InstanceType: gceInstanceType{
 			MachineType: "n1-standard-32",

--- a/master/pkg/model/defaults.go
+++ b/master/pkg/model/defaults.go
@@ -25,8 +25,8 @@ const (
 
 // Default task environment docker image names.
 const (
-	defaultCPUImage = "determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-1c4ea10"
-	defaultGPUImage = "determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-1c4ea10"
+	defaultCPUImage = "determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-da9ba40"
+	defaultGPUImage = "determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-da9ba40"
 )
 
 // DefaultExperimentConfig returns a new default experiment config.

--- a/master/pkg/schemas/expconf/const.go
+++ b/master/pkg/schemas/expconf/const.go
@@ -8,6 +8,6 @@ const (
 
 // Default task environment docker image names.
 const (
-	DefaultCPUImage = "determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-1c4ea10"
-	DefaultGPUImage = "determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-1c4ea10"
+	DefaultCPUImage = "determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-da9ba40"
+	DefaultGPUImage = "determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-da9ba40"
 )

--- a/schemas/test_cases/v0/experiment.yaml
+++ b/schemas/test_cases/v0/experiment.yaml
@@ -31,8 +31,8 @@
       environment_variables: {}
       force_pull_image: false
       image:
-        cpu: determinedai/environments:py-3.7-pytorch-1.7-lightning-1.2-tf-2.4-cpu-1c4ea10
-        gpu: determinedai/environments:cuda-10.2-pytorch-1.7-lightning-1.2-tf-2.4-gpu-1c4ea10
+        cpu: determinedai/environments:py-3.7-pytorch-1.7-lightning-1.2-tf-2.4-cpu-da9ba40
+        gpu: determinedai/environments:cuda-10.2-pytorch-1.7-lightning-1.2-tf-2.4-gpu-da9ba40
       pod_spec: null
       ports: null
     hyperparameters:

--- a/tools/scripts/README.md
+++ b/tools/scripts/README.md
@@ -36,7 +36,9 @@ be registered in the determined repo. Here is the process:
    and `*_bastion_ami` image tags in bumpenvs.yaml.  This isn't strictly
    necessary; we just need to run it periodically, and now is a fine time. The
    base images in environments/cloud/environments-packer.json also need to be
-   manually updated periodically.
+   manually updated periodically. AWS GovCloud images need to be updated
+   manually as they are (at the time of this writing) missing or not current
+   in Ubuntu's AMI locator.
 
 6. Run `./bumpenvs.py bumpenvs.yaml`.  This will do a simple string replacement
    in the repository, replacing the `old` values with the `new` values for

--- a/tools/scripts/bumpenvs.yaml
+++ b/tools/scripts/bumpenvs.yaml
@@ -1,129 +1,135 @@
 ap_northeast_1_agent_ami:
-  new: ami-039e09c6582ec61c5
-  old: ami-09e14aa0aa0dcb32d
+  new: ami-0aa0009aef18b0bf6
+  old: ami-039e09c6582ec61c5
 ap_northeast_1_bastion_ami:
-  new: ami-04fe60822d08387bb
-  old: ami-0ef85cf6e604e5650
+  new: ami-09ff2b6ef00accc2e
+  old: ami-04fe60822d08387bb
 ap_northeast_1_master_ami:
-  new: ami-005021e678ab162ea
-  old: ami-093c296276d61b583
+  new: ami-09ff2b6ef00accc2e
+  old: ami-005021e678ab162ea
 ap_northeast_2_agent_ami:
-  new: ami-063ee28bcaee0c2b1
-  old: ami-0be5ff6df8b8d1a40
+  new: ami-0467839b0f89571f3
+  old: ami-063ee28bcaee0c2b1
 ap_northeast_2_bastion_ami:
-  new: ami-05f375b54be4ab849
-  old: ami-0078a04747667d409
+  new: ami-0b329fb1f17558744
+  old: ami-05f375b54be4ab849
 ap_northeast_2_master_ami:
-  new: ami-090b3f1f06a12d28d
-  old: ami-0632cfe5256e6b811
+  new: ami-0b329fb1f17558744
+  old: ami-090b3f1f06a12d28d
 ap_southeast_1_agent_ami:
-  new: ami-0cc963cd1e2f1b045
-  old: ami-01db1862ab8c2920b
+  new: ami-0b62986f9f7eb81a8
+  old: ami-0cc963cd1e2f1b045
 ap_southeast_1_bastion_ami:
-  new: ami-0ead23393ac084a1e
-  old: ami-05b891753d41ff88f
+  new: ami-048b4b1ddefe6759f
+  old: ami-0ead23393ac084a1e
 ap_southeast_1_master_ami:
-  new: ami-01e1605d140c6b5e6
-  old: ami-010e14b2b7ac1b58f
+  new: ami-048b4b1ddefe6759f
+  old: ami-01e1605d140c6b5e6
 ap_southeast_2_agent_ami:
-  new: ami-0612c09a99b545d53
-  old: ami-00174d24de08746a5
+  new: ami-0ff94af30d0c3de3d
+  old: ami-0612c09a99b545d53
 ap_southeast_2_bastion_ami:
-  new: ami-05b921f2a1a419c07
-  old: ami-076a5bf4a712000ed
+  new: ami-052a251c7ca533c26
+  old: ami-05b921f2a1a419c07
 ap_southeast_2_master_ami:
-  new: ami-00d02a4b2cf1df2f4
-  old: ami-04fad20d313cc0947
+  new: ami-052a251c7ca533c26
+  old: ami-00d02a4b2cf1df2f4
 cuda_11_hashed:
-  new: determinedai/environments:cuda-11.0-pytorch-1.7-lightning-1.2-tf-2.4-gpu-1c4ea10
-  old: determinedai/environments:cuda-11.1-pytorch-1.8-lightning-1.2-tf-2.4-gpu-145c0d8
+  new: determinedai/environments:cuda-11.0-pytorch-1.7-lightning-1.2-tf-2.4-gpu-da9ba40
+  old: determinedai/environments:cuda-11.0-pytorch-1.7-lightning-1.2-tf-2.4-gpu-1c4ea10
 cuda_11_versioned:
-  new: determinedai/environments:cuda-11.0-pytorch-1.7-lightning-1.2-tf-2.4-gpu-0.10.0
-  old: determinedai/environments:cuda-11.1-pytorch-1.8-lightning-1.2-tf-2.4-gpu-0.9.0
+  new: determinedai/environments:cuda-11.0-pytorch-1.7-lightning-1.2-tf-2.4-gpu-0.11.0
+  old: determinedai/environments:cuda-11.0-pytorch-1.7-lightning-1.2-tf-2.4-gpu-0.10.0
 eu_central_1_agent_ami:
-  new: ami-0e706905d18bcf024
-  old: ami-00b4f432a0da11788
+  new: ami-04b224a3d8a60c33c
+  old: ami-0e706905d18bcf024
 eu_central_1_bastion_ami:
-  new: ami-07a0e33d3c1c5fb82
-  old: ami-0e0102e3ff768559b
+  new: ami-0d3905203a039e3b0
+  old: ami-07a0e33d3c1c5fb82
 eu_central_1_master_ami:
-  new: ami-08c1695e3dcdd191e
-  old: ami-0ce70c4057dc39200
+  new: ami-0d3905203a039e3b0
+  old: ami-08c1695e3dcdd191e
 eu_west_1_agent_ami:
-  new: ami-020a8186dcd6e0222
-  old: ami-07713577ece651903
+  new: ami-09c3ee9c7fa7ca807
+  old: ami-020a8186dcd6e0222
 eu_west_1_bastion_ami:
-  new: ami-03c4a26550b802f69
-  old: ami-06fd78dc2f0b69910
+  new: ami-0b7fd7bc9c6fb1c78
+  old: ami-03c4a26550b802f69
 eu_west_1_master_ami:
-  new: ami-08fabf5d4fa6fcc12
-  old: ami-0d94cb8577ea0e2fd
+  new: ami-0b7fd7bc9c6fb1c78
+  old: ami-08fabf5d4fa6fcc12
 eu_west_2_agent_ami:
-  new: ami-01163cd376120c8c8
-  old: ami-0ae7e172e79ecb809
+  new: ami-0656062915959b484
+  old: ami-01163cd376120c8c8
 eu_west_2_bastion_ami:
-  new: ami-066213f162acbccdc
-  old: ami-0244a5621d426859b
+  new: ami-02ead6ecbd926d792
+  old: ami-066213f162acbccdc
 eu_west_2_master_ami:
-  new: ami-0b3e07036579e1b57
-  old: ami-009725fa4dfe4acb0
+  new: ami-02ead6ecbd926d792
+  old: ami-0b3e07036579e1b57
 gcp_env:
-  new: det-environments-1c4ea10
-  old: det-environments-145c0d8
+  new: det-environments-da9ba40
+  old: det-environments-1c4ea10
 tf1_cpu_hashed:
-  new: determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-1c4ea10
-  old: determinedai/environments:py-3.7-pytorch-1.8-tf-1.15-cpu-145c0d8
+  new: determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-da9ba40
+  old: determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-1c4ea10
 tf1_cpu_versioned:
-  new: determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-0.10.0
-  old: determinedai/environments:py-3.7-pytorch-1.8-tf-1.15-cpu-0.9.0
+  new: determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-0.11.0
+  old: determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-0.10.0
 tf1_gpu_hashed:
-  new: determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-1c4ea10
-  old: determinedai/environments:cuda-10.2-pytorch-1.8-tf-1.15-gpu-145c0d8
+  new: determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-da9ba40
+  old: determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-1c4ea10
 tf1_gpu_versioned:
-  new: determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-0.10.0
-  old: determinedai/environments:cuda-10.2-pytorch-1.8-tf-1.15-gpu-0.9.0
+  new: determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-0.11.0
+  old: determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-0.10.0
 tf2_cpu_hashed:
-  new: determinedai/environments:py-3.7-pytorch-1.7-lightning-1.2-tf-2.4-cpu-1c4ea10
-  old: determinedai/environments:py-3.7-pytorch-1.8-lightning-1.2-tf-2.4-cpu-145c0d8
+  new: determinedai/environments:py-3.7-pytorch-1.7-lightning-1.2-tf-2.4-cpu-da9ba40
+  old: determinedai/environments:py-3.7-pytorch-1.7-lightning-1.2-tf-2.4-cpu-1c4ea10
 tf2_cpu_versioned:
-  new: determinedai/environments:py-3.7-pytorch-1.7-lightning-1.2-tf-2.4-cpu-0.10.0
-  old: determinedai/environments:py-3.7-pytorch-1.8-lightning-1.2-tf-2.4-cpu-0.9.0
+  new: determinedai/environments:py-3.7-pytorch-1.7-lightning-1.2-tf-2.4-cpu-0.11.0
+  old: determinedai/environments:py-3.7-pytorch-1.7-lightning-1.2-tf-2.4-cpu-0.10.0
 tf2_gpu_hashed:
-  new: determinedai/environments:cuda-10.2-pytorch-1.7-lightning-1.2-tf-2.4-gpu-1c4ea10
-  old: determinedai/environments:cuda-10.2-pytorch-1.8-lightning-1.2-tf-2.4-gpu-145c0d8
+  new: determinedai/environments:cuda-10.2-pytorch-1.7-lightning-1.2-tf-2.4-gpu-da9ba40
+  old: determinedai/environments:cuda-10.2-pytorch-1.7-lightning-1.2-tf-2.4-gpu-1c4ea10
 tf2_gpu_versioned:
-  new: determinedai/environments:cuda-10.2-pytorch-1.7-lightning-1.2-tf-2.4-gpu-0.10.0
-  old: determinedai/environments:cuda-10.2-pytorch-1.8-lightning-1.2-tf-2.4-gpu-0.9.0
+  new: determinedai/environments:cuda-10.2-pytorch-1.7-lightning-1.2-tf-2.4-gpu-0.11.0
+  old: determinedai/environments:cuda-10.2-pytorch-1.7-lightning-1.2-tf-2.4-gpu-0.10.0
 us_east_1_agent_ami:
-  new: ami-0e8bcb2511e8ecd6e
-  old: ami-0f9b07080cf36d8fa
+  new: ami-053a634ff2eb53ab2
+  old: ami-0e8bcb2511e8ecd6e
 us_east_1_bastion_ami:
-  new: ami-03eaf3b9c3367e75c
-  old: ami-013f17f36f8b1fefb
+  new: ami-04cc2b0ad9e30a9c8
+  old: ami-03eaf3b9c3367e75c
 us_east_1_master_ami:
-  new: ami-056db1277deef2218
-  old: ami-09943f9da1f1b7899
+  new: ami-04cc2b0ad9e30a9c8
+  old: ami-056db1277deef2218
 us_east_2_agent_ami:
-  new: ami-0c8afd5575ba72550
-  old: ami-0db1a4eb8743660dc
+  new: ami-0b7819c38bd6e76f3
+  old: ami-0c8afd5575ba72550
 us_east_2_bastion_ami:
-  new: ami-09135e71dc2619458
-  old: ami-01e7ca2ef94a0ae86
+  new: ami-02fc6052104add5ae
+  old: ami-09135e71dc2619458
 us_east_2_master_ami:
-  new: ami-0a4b51dd47f678ba3
-  old: ami-0bcacfac640850227
+  new: ami-02fc6052104add5ae
+  old: ami-0a4b51dd47f678ba3
 us_gov_east_1_agent_ami:
-  new: ami-0056a5171326d2770
-  old: ami-04eced5bbe48fd193
+  new: ami-039cd3596f2a845fb
+  old: ami-0056a5171326d2770
+us_gov_east_1_master_ami:
+  new: ami-af9379de
+  old: ami-469c7637
 us_gov_west_1_agent_ami:
-  new: ami-08d3d4fe2387a844c
-  old: ami-039e218ea111c6b28
+  new: ami-02fcfa7d90e18dde4
+  old: ami-08d3d4fe2387a844c
+us_gov_west_1_master_ami:
+  new: ami-84556de5
+  old: ami-a6e8d2c7
 us_west_2_agent_ami:
-  new: ami-06380c60a2b768f2d
-  old: ami-0a1f00f048dc70fd5
+  new: ami-0e0b3b379de73ae4e
+  old: ami-06380c60a2b768f2d
 us_west_2_bastion_ami:
-  new: ami-007e276c37b5ff2d7
-  old: ami-02701bcdc5509e57b
+  new: ami-0a62a78cfedc09d76
+  old: ami-007e276c37b5ff2d7
 us_west_2_master_ami:
-  new: ami-0ee876776acf64c80
-  old: ami-076cbb27c223df09a
+  new: ami-0a62a78cfedc09d76
+  old: ami-0ee876776acf64c80

--- a/tools/scripts/refresh-ubuntu-amis.py
+++ b/tools/scripts/refresh-ubuntu-amis.py
@@ -76,14 +76,14 @@ if __name__ == "__main__":
     for image_type, subconf in conf.items():
         if image_type.endswith("_master_ami"):
             region = image_type.rstrip("_master_ami").replace("_", "-")
-            # Master AMIs are based on Xenial.
-            new_ami = get_ubuntu_ami("xenial", region)
+            # Master AMIs are based on Focal.
+            new_ami = get_ubuntu_ami("focal", region)
             update_tag_for_image_type(subconf, new_ami)
 
         if image_type.endswith("_bastion_ami"):
             region = image_type.rstrip("_bastion_ami").replace("_", "-")
-            # Bastion AMIs are based on Bionic.
-            new_ami = get_ubuntu_ami("bionic", region)
+            # Bastion AMIs are based on Focal.
+            new_ami = get_ubuntu_ami("focal", region)
             update_tag_for_image_type(subconf, new_ami)
 
     with open(path, "w") as f:

--- a/webui/react/src/fixtures/responses/experiment-details/non-scalar-metrics-4078.json
+++ b/webui/react/src/fixtures/responses/experiment-details/non-scalar-metrics-4078.json
@@ -31,8 +31,8 @@
     "description": "Fork of Fork of mnist_tp_to_estimator_const",
     "environment": {
       "image": {
-        "cpu": "determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-1c4ea10",
-        "gpu": "determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-1c4ea10"
+        "cpu": "determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-da9ba40",
+        "gpu": "determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-da9ba40"
       },
       "ports": null,
       "pod_spec": null,

--- a/webui/react/src/fixtures/responses/experiment-details/set-a.json
+++ b/webui/react/src/fixtures/responses/experiment-details/set-a.json
@@ -694,8 +694,8 @@
         "environment_variables": {},
         "force_pull_image": false,
         "image": {
-          "cpu": "determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-1c4ea10",
-          "gpu": "determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-1c4ea10"
+          "cpu": "determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-da9ba40",
+          "gpu": "determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-da9ba40"
         },
         "pod_spec": null,
         "ports": null
@@ -838,8 +838,8 @@
         "environment_variables": {},
         "force_pull_image": false,
         "image": {
-          "cpu": "determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-1c4ea10",
-          "gpu": "determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-1c4ea10"
+          "cpu": "determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-da9ba40",
+          "gpu": "determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-da9ba40"
         },
         "pod_spec": {
           "metadata": {
@@ -2596,8 +2596,8 @@
       "description": "noop_adaptive",
       "environment": {
         "image": {
-          "cpu": "determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-1c4ea10",
-          "gpu": "determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-1c4ea10"
+          "cpu": "determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-da9ba40",
+          "gpu": "determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-da9ba40"
         },
         "ports": null,
         "pod_spec": null,

--- a/webui/react/src/fixtures/responses/trial-details/old-trial-config-noop-adaptive.json
+++ b/webui/react/src/fixtures/responses/trial-details/old-trial-config-noop-adaptive.json
@@ -29,8 +29,8 @@
   "description": "noop_adaptive",
   "environment": {
     "image": {
-      "cpu": "determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-1c4ea10",
-      "gpu": "determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-1c4ea10"
+      "cpu": "determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-da9ba40",
+      "gpu": "determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-da9ba40"
     },
     "ports": null,
     "force_pull_image": false,


### PR DESCRIPTION
## Description

Ubuntu 16.04 is about to be EOL so we need to upgrade now. Moving all the way to Ubuntu 20.04 to support Ubuntu 20.04 Docker images safely and because there's no compelling reason to not update further than 18.04...

## Test Plan

Ran all GPU and nightly tests. Only failure was unrelated and exists on master (test_hp_importance has no output for 10 minutes - which is expected and needs to be worked around). Doing `det deploy` to AWS with the secure deployment type fails - there's still a need to see why, likely the Bastion host.