### PR TITLE
ci: move test_hp_importance_api to distributed tests

### DIFF
--- a/e2e_tests/tests/experiment/test_metrics.py
+++ b/e2e_tests/tests/experiment/test_metrics.py
@@ -60,7 +60,7 @@ def test_streaming_metrics_api() -> None:
         pytest.fail("trials-sample (validation): %s. Results: %s" % valid_trials_sample_results)
 
 
-@pytest.mark.nightly  # type: ignore
+@pytest.mark.distributed  # type: ignore
 @pytest.mark.timeout(1800)  # type: ignore
 def test_hp_importance_api() -> None:
     auth.initialize_session(conf.make_master_url(), try_reauth=True)


### PR DESCRIPTION
## Description

This test has been failing because it requires a 50-trial experiment. Even if you only do 1 MNIST batch, the startup-time of each trial is 20 seconds and on the single-GPU nightly cluster it exceeds the 10 minutes no-output timeout. It's not trivial to introduce a "debug" mode to run HP importance on smaller experiments, and we want to check the sanity of real results which isn't feasible with fewer trials.

Moving to the distributed test suite, we can get the 50-trial experiment done in about 4 minutes.

## Test Plan

Pushed to an upstream branch where I had the "distributed" tests run on-demand. It's still running, but as of this writing test_hp_importance_api has already passed.