### PR TITLE
feat: per-resource-pool configs [DET-5173]

### DIFF
--- a/docs/reference/cluster-config.txt
+++ b/docs/reference/cluster-config.txt
@@ -296,8 +296,8 @@ The master supports the following configuration settings:
       -  ``serveraddress`` (optional)
       -  ``email`` (optional)
 
-   -  ``add_capabilities``: The default list of capability strings to
-      pass to the Docker daemon. Ignored by resource managers of type
+   -  ``add_capabilities``: The default list of Linux capabilities to
+      grant to task containers. Ignored by resource managers of type
       ``kubernetes``. See :ref:`environment.add_capabilities
       <exp-environment-add-capapbilities>` for more details.
 

--- a/docs/reference/cluster-config.txt
+++ b/docs/reference/cluster-config.txt
@@ -407,8 +407,6 @@ The master supports the following configuration settings:
       -  ``master_service_name``: The service account Determined uses to
          interact with the Kubernetes API.
 
-.. _resource-pool-config:
-
 -  ``resource_pools``: A list of resource pools. A resource pool is a
    collection of identical computational resources. Users can specify
    which resource pool a job should be assigned to when the job is

--- a/docs/reference/cluster-config.txt
+++ b/docs/reference/cluster-config.txt
@@ -213,6 +213,8 @@ The master supports the following configuration settings:
 -  ``port``: The TCP port on which the master accepts all incoming
    connections. Defaults to ``8080``.
 
+.. _master-task-container-defaults:
+
 -  ``task_container_defaults``: Specifies Docker defaults for all task
    containers. A task represents a single schedulable unit, such as a
    trial, command, or tensorboard.
@@ -293,6 +295,18 @@ The master supports the following configuration settings:
       -  ``password`` (required)
       -  ``serveraddress`` (optional)
       -  ``email`` (optional)
+
+   -  ``add_capabilities``: The default list of capability strings to
+      pass to the Docker daemon. Ignored by resource managers of type
+      ``kubernetes``. See :ref:`environment.add_capabilities
+      <exp-environment-add-capapbilities>` for more details.
+
+   -  ``drop_capabilities``: Just like ``add_capabilities`` but for
+      dropping capabilities.
+
+   -  ``devices``: The default list of devices to pass to the Docker
+      daemon. Ignored by resource managers of type ``kubernetes``. See
+      :ref:`resources.devices <exp-resources-devices>` for more details.
 
 -  ``root``: Specifies the root directory of the state files. Defaults
    to ``/usr/share/determined/master``.
@@ -393,6 +407,8 @@ The master supports the following configuration settings:
       -  ``master_service_name``: The service account Determined uses to
          interact with the Kubernetes API.
 
+.. _resource-pool-config:
+
 -  ``resource_pools``: A list of resource pools. A resource pool is a
    collection of identical computational resources. Users can specify
    which resource pool a job should be assigned to when the job is
@@ -406,6 +422,13 @@ The master supports the following configuration settings:
 
    -  ``max_cpu_containers_per_agent``: The maximum number of CPU-only
       containers that can be scheduled on each agent in this pool.
+
+   -  ``task_container_defaults``: Each resource pool may specify a
+      ``task_container_defaults`` that overrides the :ref:`top-level
+      setting <master-task-container-defaults>` for all tasks launched
+      in that resource pool. There is no merging behavior; when a
+      resource pool's ``task_container_defaults`` is set, tasks launched
+      in that pool will completely ignore the top-level setting.
 
    -  ``scheduler``: Specifies how Determined schedules tasks to agents.
       The scheduler configuration on each resource pool will override

--- a/docs/reference/command-notebook-config.txt
+++ b/docs/reference/command-notebook-config.txt
@@ -80,8 +80,8 @@ The following configuration settings are supported:
       -  ``server`` (optional)
       -  ``email`` (optional)
 
-   -  ``add_capabilities``: A list of capability strings to pass to the
-      Docker daemon. Each entry in the list is equivalent to a
+   -  ``add_capabilities``: A list of Linux capabilities to grant to
+      task containers. Each entry in the list is equivalent to a
       ``--cap-add CAP`` command line argument to ``docker run``.
       ``add_capabilities`` is honored by resource managers of type
       ``agent`` but is ignored by resource managers of type

--- a/docs/reference/command-notebook-config.txt
+++ b/docs/reference/command-notebook-config.txt
@@ -80,6 +80,18 @@ The following configuration settings are supported:
       -  ``server`` (optional)
       -  ``email`` (optional)
 
+   -  ``add_capabilities``: A list of capability strings to pass to the
+      Docker daemon. Each entry in the list is equivalent to a
+      ``--cap-add CAP`` command line argument to ``docker run``.
+      ``add_capabilities`` is honored by resource managers of type
+      ``agent`` but is ignored by resource managers of type
+      ``kubernetes``. See :ref:`master configuration
+      <master-configuration>` for details about resource managers.
+
+   -  ``drop_capabilities``: Just like ``add_capabilities`` but
+      corresponding to the ``--cap-drop`` argument of ``docker run``
+      rather than ``--cap-add``.
+
 -  ``resources``: The resources Determined allows a task to use.
 
    -  ``slots``: Specifies the number of slots to use for the task. The
@@ -111,6 +123,27 @@ The following configuration settings are supported:
       be scheduled in the default CPU pool, while GPU-using tasks will
       be scheduled in the default GPU tool. Refer to
       :ref:`resource-pools` for more information.
+
+   -  ``devices``: A list of device strings to pass to the Docker
+      daemon. Each entry in the list is equivalent to a ``--device
+      DEVICE`` command line argument to ``docker run``. ``devices`` is
+      honored by resource managers of type ``agent`` but is ignored by
+      resource managers of type ``kubernetes``. See :ref:`master
+      configuration <master-configuration>` for details about resource
+      managers.
+
+``resource_pool``
+   The resource pool where this experiment will be scheduled. If no
+   resource pool is specified, experiments will run in the default GPU
+   pool. Refer to :ref:`resource-pools` for more information.
+
+``devices``
+   A list of device strings to pass to the Docker daemon. Each entry in
+   the list is equivalent to a ``--device DEVICE`` command line argument
+   to ``docker run``. ``devices`` is honored by resource managers of
+   type ``agent`` but is ignored by resource managers of type
+   ``kubernetes``. See :ref:`master configuration
+   <master-configuration>` for details about resource managers.
 
 -  ``bind_mounts``: Specifies a collection of directories that are
    bind-mounted into the Docker containers for execution. This can be

--- a/docs/reference/experiment-config.txt
+++ b/docs/reference/experiment-config.txt
@@ -927,7 +927,7 @@ more information on customizing the trial environment, refer to
 .. _exp-environment-add-capapbilities:
 
 ``add_capabilities``
-   A list of capability strings to pass to the Docker daemon. Each entry
+   A list of Linux capabilities to grant to task containers. Each entry
    in the list is equivalent to a ``--cap-add CAP`` command line
    argument to ``docker run``. ``add_capabilities`` is honored by
    resource managers of type ``agent`` but is ignored by resource

--- a/docs/reference/experiment-config.txt
+++ b/docs/reference/experiment-config.txt
@@ -819,6 +819,16 @@ allowed to use.
    resource pool is specified, experiments will run in the default GPU
    pool. Refer to :ref:`resource-pools` for more information.
 
+.. _exp-resources-devices:
+
+``devices``
+   A list of device strings to pass to the Docker daemon. Each entry in
+   the list is equivalent to a ``--device DEVICE`` command line argument
+   to ``docker run``. ``devices`` is honored by resource managers of
+   type ``agent`` but is ignored by resource managers of type
+   ``kubernetes``. See :ref:`master configuration
+   <master-configuration>` for details about resource managers.
+
 *************
  Bind Mounts
 *************
@@ -913,6 +923,20 @@ more information on customizing the trial environment, refer to
    Only applicable when running Determined on Kubernetes. Applies a pod
    spec to the pods that are launched by Determined for this task. See
    :ref:`custom-pod-specs` for details.
+
+.. _exp-environment-add-capapbilities:
+
+``add_capabilities``
+   A list of capability strings to pass to the Docker daemon. Each entry
+   in the list is equivalent to a ``--cap-add CAP`` command line
+   argument to ``docker run``. ``add_capabilities`` is honored by
+   resource managers of type ``agent`` but is ignored by resource
+   managers of type ``kubernetes``. See :ref:`master configuration
+   <master-configuration>` for details about resource managers.
+
+``drop_capabilities``
+   Just like ``add_capabilities`` but corresponding to the
+   ``--cap-drop`` argument of ``docker run`` rather than ``--cap-add``.
 
 ***************
  Optimizations

--- a/docs/release-notes/2214-resource-pool-configs.txt
+++ b/docs/release-notes/2214-resource-pool-configs.txt
@@ -3,7 +3,7 @@
 **New Features**
 
 -  Add support for the ``--devices``, ``--cap-add``, and ``--cap-drop``
-   arugments to the ``docker run`` command. These are configured in an
+   arguments to the ``docker run`` command. These are configured in an
    experiment or command/notebook config via ``resources.devices``,
    ``environment.add_capabilities``, and
    ``environment.drop_capabilities``. These settings can combine to
@@ -20,5 +20,6 @@
    configure tasks in each pool with the correct settings. When a
    resource pool has a ``task_container_defaults`` field set, the
    top-level ``task_container_defaults`` will be ignored for tasks
-   launched in that pool (there is no merging behavior. See
-   :ref:`resource-pool-config` for more information.
+   launched in that pool (there is no merging behavior. See Resource
+   Pool configuration under :ref:`cluster-configuration` for more
+   information.

--- a/docs/release-notes/2214-resource-pool-configs.txt
+++ b/docs/release-notes/2214-resource-pool-configs.txt
@@ -1,0 +1,24 @@
+:orphan:
+
+**New Features**
+
+-  Add support for the ``--devices``, ``--cap-add``, and ``--cap-drop``
+   arugments to the ``docker run`` command. These are configured in an
+   experiment or command/notebook config via ``resources.devices``,
+   ``environment.add_capabilities``, and
+   ``environment.drop_capabilities``. These settings can combine to
+   allow an experiment to take advantage of cluster hardware not
+   previously available to training or notebook task. See
+   :ref:`experiment-configuration` for more details. These
+   configurations are only honored by resource managers of type
+   ``agent``, and are ignored by resource managers of type
+   ``kubernetes``.
+
+-  Add support for configuring distinct ``task_container_defaults`` for
+   each resource pool configured on the cluster. This can allow
+   different resource pools which may have very different hardware to
+   configure tasks in each pool with the correct settings. When a
+   resource pool has a ``task_container_defaults`` field set, the
+   top-level ``task_container_defaults`` will be ignored for tasks
+   launched in that pool (there is no merging behavior. See
+   :ref:`resource-pool-config` for more information.

--- a/master/cmd/determined-master/root_test.go
+++ b/master/cmd/determined-master/root_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/determined-ai/determined/master/internal"
 	"github.com/determined-ai/determined/master/internal/provisioner"
 	"github.com/determined-ai/determined/master/internal/resourcemanagers"
+	"github.com/determined-ai/determined/master/pkg/model"
 )
 
 func TestUnmarshalMasterConfigurationViaViper(t *testing.T) {
@@ -61,6 +62,10 @@ task_container_defaults:
 			PoolName:                 "default",
 			Provider:                 providerConf,
 			MaxCPUContainersPerAgent: 100,
+			TaskContainerDefaults: model.TaskContainerDefaultsConfig{
+				ShmSizeBytes: 4294967296,
+				NetworkMode:  "bridge",
+			},
 		},
 	}
 	expected.TaskContainerDefaults.CPUPodSpec = &k8sV1.Pod{

--- a/master/cmd/determined-master/root_test.go
+++ b/master/cmd/determined-master/root_test.go
@@ -19,7 +19,7 @@ func TestUnmarshalMasterConfigurationViaViper(t *testing.T) {
 	raw := `
 resource_pools:
   - pool_name: default
-    provider: 
+    provider:
       type: gcp
       base_config:
         disks:
@@ -57,15 +57,15 @@ task_container_defaults:
 			},
 		},
 	}
+	expected.TaskContainerDefaults = model.TaskContainerDefaultsConfig{
+		ShmSizeBytes: 4294967296,
+		NetworkMode:  "bridge",
+	}
 	expected.ResourcePools = []resourcemanagers.ResourcePoolConfig{
 		{
 			PoolName:                 "default",
 			Provider:                 providerConf,
 			MaxCPUContainersPerAgent: 100,
-			TaskContainerDefaults: model.TaskContainerDefaultsConfig{
-				ShmSizeBytes: 4294967296,
-				NetworkMode:  "bridge",
-			},
 		},
 	}
 	expected.TaskContainerDefaults.CPUPodSpec = &k8sV1.Pod{

--- a/master/internal/api_experiment.go
+++ b/master/internal/api_experiment.go
@@ -570,7 +570,7 @@ func (a *apiServer) CreateExperiment(
 		detParams.ParentID = &parentID
 	}
 
-	dbExp, validateOnly, err := a.m.parseCreateExperiment(&detParams)
+	dbExp, validateOnly, taskSpec, err := a.m.parseCreateExperiment(&detParams)
 
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "invalid experiment: %s", err)
@@ -586,7 +586,7 @@ func (a *apiServer) CreateExperiment(
 	}
 
 	dbExp.OwnerID = &user.ID
-	e, err := newExperiment(a.m, dbExp)
+	e, err := newExperiment(a.m, dbExp, taskSpec)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to create experiment: %s", err)
 	}

--- a/master/internal/command/api.go
+++ b/master/internal/command/api.go
@@ -20,34 +20,34 @@ func RegisterAPIHandler(
 	proxyRef *actor.Ref,
 	timeout int,
 	defaultAgentUserGroup model.AgentUserGroup,
-	taskSpec *tasks.TaskSpec,
+	makeTaskSpec tasks.MakeTaskSpecFn,
 	middleware ...echo.MiddlewareFunc,
 ) {
 	system.ActorOf(actor.Addr("commands"), &commandManager{
 		defaultAgentUserGroup: defaultAgentUserGroup,
 		db:                    db,
-		taskSpec:              taskSpec,
+		makeTaskSpec:          makeTaskSpec,
 	})
 	echo.Any("/commands*", api.Route(system, nil), middleware...)
 
 	system.ActorOf(actor.Addr("notebooks"), &notebookManager{
 		defaultAgentUserGroup: defaultAgentUserGroup,
 		db:                    db,
-		taskSpec:              taskSpec,
+		makeTaskSpec:          makeTaskSpec,
 	})
 	echo.Any("/notebooks*", api.Route(system, nil), middleware...)
 
 	system.ActorOf(actor.Addr("shells"), &shellManager{
 		defaultAgentUserGroup: defaultAgentUserGroup,
 		db:                    db,
-		taskSpec:              taskSpec,
+		makeTaskSpec:          makeTaskSpec,
 	})
 	echo.Any("/shells*", api.Route(system, nil), middleware...)
 
 	system.ActorOf(actor.Addr("tensorboard"), &tensorboardManager{
 		defaultAgentUserGroup: defaultAgentUserGroup,
 		db:                    db,
-		taskSpec:              taskSpec,
+		makeTaskSpec:          makeTaskSpec,
 		proxyRef:              proxyRef,
 		timeout:               time.Duration(timeout) * time.Second,
 	})

--- a/master/internal/command/command.go
+++ b/master/internal/command/command.go
@@ -50,7 +50,7 @@ type commandOwner struct {
 // commands (e.g., commands, notebooks, shells) if a request
 // does not specify any configuration options.
 func DefaultConfig(taskContainerDefaults *model.TaskContainerDefaultsConfig) model.CommandConfig {
-	environment := model.DefaultExperimentConfig(taskContainerDefaults).Environment
+	expConf := model.DefaultExperimentConfig(taskContainerDefaults)
 	return model.CommandConfig{
 		Resources: model.ResourcesConfig{
 			Slots:  1,
@@ -58,8 +58,9 @@ func DefaultConfig(taskContainerDefaults *model.TaskContainerDefaultsConfig) mod
 			// SlotsPerTrial is not used by commands. They prefer Slots instead.
 			// It is only defined here to pass check.Validate.
 			SlotsPerTrial: 1,
+			Devices:       expConf.Resources.Devices,
 		},
-		Environment: environment,
+		Environment: expConf.Environment,
 	}
 }
 

--- a/master/internal/command/notebook_manager.go
+++ b/master/internal/command/notebook_manager.go
@@ -106,7 +106,7 @@ type notebookManager struct {
 	db *db.PgDB
 
 	defaultAgentUserGroup model.AgentUserGroup
-	taskSpec              *tasks.TaskSpec
+	makeTaskSpec          tasks.MakeTaskSpecFn
 }
 
 // NotebookLaunchRequest describes a request to launch a new notebook.
@@ -120,7 +120,7 @@ func (n *notebookManager) processLaunchRequest(
 	req NotebookLaunchRequest,
 ) (*summary, int, error) {
 	commandReq, err := parseCommandRequest(
-		ctx.Self().System(), n.db, *req.User, req.CommandParams, &n.taskSpec.TaskContainerDefaults, false,
+		ctx.Self().System(), n.db, *req.User, req.CommandParams, n.makeTaskSpec, false,
 	)
 	if err != nil {
 		return nil, http.StatusBadRequest, err
@@ -226,7 +226,7 @@ func (n *notebookManager) newNotebook(req *commandRequest) (*command, error) {
 
 	config.Entrypoint = notebookEntrypoint
 
-	setPodSpec(&config, n.taskSpec.TaskContainerDefaults)
+	setPodSpec(&config, req.TaskSpec.TaskContainerDefaults)
 
 	if config.Description == "" {
 		var err error
@@ -281,7 +281,7 @@ func (n *notebookManager) newNotebook(req *commandRequest) (*command, error) {
 
 		owner:          req.Owner,
 		agentUserGroup: req.AgentUserGroup,
-		taskSpec:       n.taskSpec,
+		taskSpec:       &req.TaskSpec,
 
 		db: n.db,
 	}, nil

--- a/master/internal/config_test.go
+++ b/master/internal/config_test.go
@@ -39,6 +39,8 @@ resource_pools:
     provider:
       max_idle_agent_period: 30s
       max_agent_starting_period: 30s
+    task_container_defaults:
+      dtrain_network_interface: if0
 `
 	expected := Config{
 		Log: logger.Config{
@@ -75,9 +77,10 @@ resource_pools:
 						MaxInstances:           5,
 					},
 					MaxCPUContainersPerAgent: 100,
-					TaskContainerDefaults: model.TaskContainerDefaultsConfig{
-						ShmSizeBytes: 4294967296,
-						NetworkMode:  "bridge",
+					TaskContainerDefaults: &model.TaskContainerDefaultsConfig{
+						ShmSizeBytes:           4294967296,
+						NetworkMode:            "bridge",
+						DtrainNetworkInterface: "if0",
 					},
 				},
 			},
@@ -145,7 +148,7 @@ db:
 
 checkpoint_storage:
   type: s3
-  access_key: my_key 
+  access_key: my_key
   secret_key: my_secret
   bucket: my_bucket
 `

--- a/master/internal/config_test.go
+++ b/master/internal/config_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/determined-ai/determined/master/internal/provisioner"
 	"github.com/determined-ai/determined/master/internal/resourcemanagers"
 	"github.com/determined-ai/determined/master/pkg/logger"
+	"github.com/determined-ai/determined/master/pkg/model"
 	"github.com/determined-ai/determined/master/version"
 )
 
@@ -74,6 +75,10 @@ resource_pools:
 						MaxInstances:           5,
 					},
 					MaxCPUContainersPerAgent: 100,
+					TaskContainerDefaults: model.TaskContainerDefaultsConfig{
+						ShmSizeBytes: 4294967296,
+						NetworkMode:  "bridge",
+					},
 				},
 			},
 		},

--- a/master/internal/core.go
+++ b/master/internal/core.go
@@ -95,6 +95,39 @@ func (m *Master) getConfig(echo.Context) (interface{}, error) {
 	return m.config.Printable()
 }
 
+// makeTaskSpec is the master method that we will pass around as a tasks.MakeTaskSpecFn.  It's
+// behavior is deterministic for the lifetime of the master process.
+func (m *Master) makeTaskSpec(poolName string, numSlots int) tasks.TaskSpec {
+	// Always fall back to the top-level TaskContainerDefaults
+	taskContainerDefaults := m.config.TaskContainerDefaults
+
+	// Only look for pool settings with Agent resource managers.
+	if m.config.ResourceManager.AgentRM != nil {
+		if poolName == "" {
+			if numSlots == 0 {
+				poolName = m.config.ResourceManager.AgentRM.DefaultCPUResourcePool
+			} else {
+				poolName = m.config.ResourceManager.AgentRM.DefaultGPUResourcePool
+			}
+		}
+		// Iterate through configured pools looking for a TaskContainerDefaults setting.
+		for _, pool := range m.config.ResourcePools {
+			if poolName == pool.PoolName {
+				if pool.TaskContainerDefaults == nil {
+					break
+				}
+				taskContainerDefaults = *pool.TaskContainerDefaults
+			}
+		}
+	}
+
+	// Not a deep copy, but deep enough not to overwrite the master's TaskContainerDefaults.
+	taskSpec := *m.taskSpec
+	taskSpec.TaskContainerDefaults = taskContainerDefaults
+
+	return taskSpec
+}
+
 // Info returns this master's information.
 func (m *Master) Info() aproto.MasterInfo {
 	telemetryInfo := aproto.TelemetryInfo{}
@@ -773,7 +806,7 @@ func (m *Master) Run(ctx context.Context) error {
 		m.proxy,
 		m.config.TensorBoardTimeout,
 		m.config.Security.DefaultTask,
-		m.taskSpec,
+		m.makeTaskSpec,
 		authFuncs...,
 	)
 	template.RegisterAPIHandler(m.echo, m.db, authFuncs...)

--- a/master/internal/resourcemanagers/config.go
+++ b/master/internal/resourcemanagers/config.go
@@ -26,7 +26,7 @@ func (r *ResourceConfig) ResolveResource() error {
 		r.ResourceManager.AgentRM = &AgentResourceManagerConfig{}
 	}
 	if r.ResourceManager.AgentRM != nil && r.ResourcePools == nil {
-		defaultPool := *defaultRPConfig()
+		defaultPool := defaultRPConfig()
 		defaultPool.PoolName = defaultResourcePoolName
 		r.ResourcePools = []ResourcePoolConfig{defaultPool}
 	}

--- a/master/internal/resourcemanagers/config.go
+++ b/master/internal/resourcemanagers/config.go
@@ -26,12 +26,9 @@ func (r *ResourceConfig) ResolveResource() error {
 		r.ResourceManager.AgentRM = &AgentResourceManagerConfig{}
 	}
 	if r.ResourceManager.AgentRM != nil && r.ResourcePools == nil {
-		r.ResourcePools = []ResourcePoolConfig{
-			{
-				PoolName:                 defaultResourcePoolName,
-				MaxCPUContainersPerAgent: 100,
-			},
-		}
+		defaultPool := *defaultRPConfig()
+		defaultPool.PoolName = defaultResourcePoolName
+		r.ResourcePools = []ResourcePoolConfig{defaultPool}
 	}
 	return nil
 }

--- a/master/internal/resourcemanagers/resource_pool_config.go
+++ b/master/internal/resourcemanagers/resource_pool_config.go
@@ -5,22 +5,28 @@ import (
 
 	"github.com/determined-ai/determined/master/internal/provisioner"
 	"github.com/determined-ai/determined/master/pkg/check"
+	"github.com/determined-ai/determined/master/pkg/model"
 )
 
 // DefaultRPConfig returns the default resources pool configuration.
 func defaultRPConfig() *ResourcePoolConfig {
 	return &ResourcePoolConfig{
 		MaxCPUContainersPerAgent: 100,
+		TaskContainerDefaults: model.TaskContainerDefaultsConfig{
+			ShmSizeBytes: 4294967296,
+			NetworkMode:  "bridge",
+		},
 	}
 }
 
 // ResourcePoolConfig hosts the configuration for a resource pool.
 type ResourcePoolConfig struct {
-	PoolName                 string              `json:"pool_name"`
-	Description              string              `json:"description"`
-	Provider                 *provisioner.Config `json:"provider"`
-	Scheduler                *SchedulerConfig    `json:"scheduler,omitempty"`
-	MaxCPUContainersPerAgent int                 `json:"max_cpu_containers_per_agent"`
+	PoolName                 string                            `json:"pool_name"`
+	Description              string                            `json:"description"`
+	Provider                 *provisioner.Config               `json:"provider"`
+	Scheduler                *SchedulerConfig                  `json:"scheduler,omitempty"`
+	MaxCPUContainersPerAgent int                               `json:"max_cpu_containers_per_agent"`
+	TaskContainerDefaults    model.TaskContainerDefaultsConfig `json:"task_container_defaults"`
 }
 
 // UnmarshalJSON implements the json.Unmarshaler interface.

--- a/master/internal/resourcemanagers/resource_pool_config.go
+++ b/master/internal/resourcemanagers/resource_pool_config.go
@@ -12,21 +12,17 @@ import (
 func defaultRPConfig() *ResourcePoolConfig {
 	return &ResourcePoolConfig{
 		MaxCPUContainersPerAgent: 100,
-		TaskContainerDefaults: model.TaskContainerDefaultsConfig{
-			ShmSizeBytes: 4294967296,
-			NetworkMode:  "bridge",
-		},
 	}
 }
 
 // ResourcePoolConfig hosts the configuration for a resource pool.
 type ResourcePoolConfig struct {
-	PoolName                 string                            `json:"pool_name"`
-	Description              string                            `json:"description"`
-	Provider                 *provisioner.Config               `json:"provider"`
-	Scheduler                *SchedulerConfig                  `json:"scheduler,omitempty"`
-	MaxCPUContainersPerAgent int                               `json:"max_cpu_containers_per_agent"`
-	TaskContainerDefaults    model.TaskContainerDefaultsConfig `json:"task_container_defaults"`
+	PoolName                 string                             `json:"pool_name"`
+	Description              string                             `json:"description"`
+	Provider                 *provisioner.Config                `json:"provider"`
+	Scheduler                *SchedulerConfig                   `json:"scheduler,omitempty"`
+	MaxCPUContainersPerAgent int                                `json:"max_cpu_containers_per_agent"`
+	TaskContainerDefaults    *model.TaskContainerDefaultsConfig `json:"task_container_defaults"`
 }
 
 // UnmarshalJSON implements the json.Unmarshaler interface.

--- a/master/internal/resourcemanagers/resource_pool_config.go
+++ b/master/internal/resourcemanagers/resource_pool_config.go
@@ -9,8 +9,8 @@ import (
 )
 
 // DefaultRPConfig returns the default resources pool configuration.
-func defaultRPConfig() *ResourcePoolConfig {
-	return &ResourcePoolConfig{
+func defaultRPConfig() ResourcePoolConfig {
+	return ResourcePoolConfig{
 		MaxCPUContainersPerAgent: 100,
 	}
 }
@@ -27,7 +27,7 @@ type ResourcePoolConfig struct {
 
 // UnmarshalJSON implements the json.Unmarshaler interface.
 func (r *ResourcePoolConfig) UnmarshalJSON(data []byte) error {
-	*r = *defaultRPConfig()
+	*r = defaultRPConfig()
 	type DefaultParser *ResourcePoolConfig
 	return json.Unmarshal(data, DefaultParser(r))
 }

--- a/master/internal/restore.go
+++ b/master/internal/restore.go
@@ -63,12 +63,21 @@ func (m *Master) restoreExperiment(expModel *model.Experiment) error {
 		)
 	}
 
+	// Get the TaskSpec for this experiment.
+	taskContainerDefaults := getResourcePoolTaskContainerDefaultsByName(
+		expModel.Config.Resources.ResourcePool,
+		expModel.Config.Resources.SlotsPerTrial,
+		*m.config,
+	)
+	taskSpec := *m.taskSpec
+	taskSpec.TaskContainerDefaults = taskContainerDefaults
+
 	log.WithField("experiment", expModel.ID).Info("restoring experiment")
 	snapshot, err := m.retrieveExperimentSnapshot(expModel)
 	if err != nil {
 		return errors.Wrapf(err, "failed to restore experiment %d", expModel.ID)
 	}
-	e, err := newExperiment(m, expModel)
+	e, err := newExperiment(m, expModel, &taskSpec)
 	if err != nil {
 		return errors.Wrapf(err, "failed to create experiment %d from model", expModel.ID)
 	}

--- a/master/internal/restore.go
+++ b/master/internal/restore.go
@@ -64,13 +64,10 @@ func (m *Master) restoreExperiment(expModel *model.Experiment) error {
 	}
 
 	// Get the TaskSpec for this experiment.
-	taskContainerDefaults := getResourcePoolTaskContainerDefaultsByName(
+	taskSpec := m.makeTaskSpec(
 		expModel.Config.Resources.ResourcePool,
 		expModel.Config.Resources.SlotsPerTrial,
-		*m.config,
 	)
-	taskSpec := *m.taskSpec
-	taskSpec.TaskContainerDefaults = taskContainerDefaults
 
 	log.WithField("experiment", expModel.ID).Info("restoring experiment")
 	snapshot, err := m.retrieveExperimentSnapshot(expModel)

--- a/master/pkg/model/defaults.go
+++ b/master/pkg/model/defaults.go
@@ -117,5 +117,9 @@ func DefaultExperimentConfig(taskContainerDefaults *TaskContainerDefaultsConfig)
 		defaultConfig.Environment.Image = *taskContainerDefaults.Image
 	}
 
+	defaultConfig.Resources.Devices = taskContainerDefaults.Devices
+	defaultConfig.Environment.AddCapabilities = taskContainerDefaults.AddCapabilities
+	defaultConfig.Environment.DropCapabilities = taskContainerDefaults.DropCapabilities
+
 	return defaultConfig
 }

--- a/master/pkg/model/environment_config.go
+++ b/master/pkg/model/environment_config.go
@@ -31,6 +31,10 @@ type Environment struct {
 	RegistryAuth   *types.AuthConfig `json:"registry_auth,omitempty"`
 	ForcePullImage bool              `json:"force_pull_image"`
 	PodSpec        *k8sV1.Pod        `json:"pod_spec"`
+
+	// omitempty since they are not officially announced features yet
+	AddCapabilities  *[]string `json:"add_capabilities,omitempty"`
+	DropCapabilities *[]string `json:"drop_capabilities,omitempty"`
 }
 
 // RuntimeItem configures the runtime image.

--- a/master/pkg/model/environment_config.go
+++ b/master/pkg/model/environment_config.go
@@ -32,9 +32,8 @@ type Environment struct {
 	ForcePullImage bool              `json:"force_pull_image"`
 	PodSpec        *k8sV1.Pod        `json:"pod_spec"`
 
-	// omitempty since they are not officially announced features yet
-	AddCapabilities  *[]string `json:"add_capabilities,omitempty"`
-	DropCapabilities *[]string `json:"drop_capabilities,omitempty"`
+	AddCapabilities  []string `json:"add_capabilities"`
+	DropCapabilities []string `json:"drop_capabilities"`
 }
 
 // RuntimeItem configures the runtime image.

--- a/master/pkg/model/experiment_config.go
+++ b/master/pkg/model/experiment_config.go
@@ -186,7 +186,8 @@ func (l *Labels) UnmarshalJSON(data []byte) error {
 	return err
 }
 
-// DevicesConfig is the configuration for bind mounts.
+// DevicesConfig is the configuration for devices.  It is a named type because it needs custom
+// merging behavior (via UnmarshalJSON).
 type DevicesConfig []DeviceConfig
 
 // UnmarshalJSON implements the json.Unmarshaler interface so that DeviceConfigs are additive.
@@ -227,8 +228,7 @@ type ResourcesConfig struct {
 	ResourcePool   string  `json:"resource_pool"`
 	Priority       *int    `json:"priority,omitempty"`
 
-	// omitempty since is not an officially announced feature yet
-	Devices *DevicesConfig `json:"devices,omitempty"`
+	Devices DevicesConfig `json:"devices"`
 }
 
 // ParseJustResources is a helper function for breaking the circular dependency where we need the

--- a/master/pkg/model/experiment_config.go
+++ b/master/pkg/model/experiment_config.go
@@ -184,6 +184,33 @@ func (l *Labels) UnmarshalJSON(data []byte) error {
 	return err
 }
 
+// DevicesConfig is the configuration for bind mounts.
+type DevicesConfig []DeviceConfig
+
+// UnmarshalJSON implements the json.Unmarshaler interface so that DeviceConfigs are additive.
+func (d *DevicesConfig) UnmarshalJSON(data []byte) error {
+	unmarshaled := make([]DeviceConfig, 0)
+	if err := json.Unmarshal(data, &unmarshaled); err != nil {
+		return errors.Wrap(err, "failed to parse devices")
+	}
+	*d = append(*d, unmarshaled...)
+	return nil
+}
+
+// DeviceConfig configures trial runner filesystem bind mounts.
+type DeviceConfig struct {
+	HostPath      string `json:"host_path"`
+	ContainerPath string `json:"container_path"`
+	Mode          string `json:"mode"`
+}
+
+// UnmarshalJSON implements the json.Unmarshaler interface.
+func (d *DeviceConfig) UnmarshalJSON(data []byte) error {
+	d.Mode = "mrw"
+	type DefaultParser *DeviceConfig
+	return errors.Wrap(json.Unmarshal(data, DefaultParser(d)), "failed to parse device")
+}
+
 // ResourcesConfig configures resource usage for an experiment, command, notebook, or tensorboard.
 type ResourcesConfig struct {
 	// Slots is used by commands while trials use SlotsPerTrial.
@@ -197,6 +224,9 @@ type ResourcesConfig struct {
 	AgentLabel     string  `json:"agent_label"`
 	ResourcePool   string  `json:"resource_pool"`
 	Priority       *int    `json:"priority,omitempty"`
+
+	// omitempty since is not an officially announced feature yet
+	Devices *DevicesConfig `json:"devices,omitempty"`
 }
 
 // ValidatePrioritySetting checks that priority if set is within a valid range.

--- a/master/pkg/model/task_container_defaults.go
+++ b/master/pkg/model/task_container_defaults.go
@@ -26,6 +26,11 @@ type TaskContainerDefaultsConfig struct {
 	Image                  *RuntimeItem          `json:"image,omitempty"`
 	RegistryAuth           *types.AuthConfig     `json:"registry_auth,omitempty"`
 	ForcePullImage         bool                  `json:"force_pull_image,omitempty"`
+
+	// omitempty since they are not officially announced features yet
+	AddCapabilities  *[]string      `json:"add_capabilities,omitempty"`
+	DropCapabilities *[]string      `json:"drop_capabilities,omitempty"`
+	Devices          *DevicesConfig `json:"devices,omitempty"`
 }
 
 func validatePortRange(portRange string) []error {

--- a/master/pkg/model/task_container_defaults.go
+++ b/master/pkg/model/task_container_defaults.go
@@ -28,10 +28,9 @@ type TaskContainerDefaultsConfig struct {
 	RegistryAuth           *types.AuthConfig     `json:"registry_auth,omitempty"`
 	ForcePullImage         bool                  `json:"force_pull_image,omitempty"`
 
-	// omitempty since they are not officially announced features yet
-	AddCapabilities  *[]string      `json:"add_capabilities,omitempty"`
-	DropCapabilities *[]string      `json:"drop_capabilities,omitempty"`
-	Devices          *DevicesConfig `json:"devices,omitempty"`
+	AddCapabilities  []string      `json:"add_capabilities"`
+	DropCapabilities []string      `json:"drop_capabilities"`
+	Devices          DevicesConfig `json:"devices"`
 }
 
 func validatePortRange(portRange string) []error {

--- a/master/pkg/tasks/task.go
+++ b/master/pkg/tasks/task.go
@@ -83,9 +83,6 @@ func ToContainerSpec(t TaskSpec) container.Spec {
 		shmSize = t.TaskContainerDefaults.ShmSizeBytes
 	}
 
-	capAdd := env.AddCapabilities
-	capDrop := env.DropCapabilities
-
 	resources := t.ResourcesConfig()
 	var devices []docker.DeviceMapping
 	for _, device := range resources.Devices {
@@ -115,8 +112,8 @@ func ToContainerSpec(t TaskSpec) container.Spec {
 				Mounts:          t.Mounts(),
 				PublishAllPorts: true,
 				ShmSize:         shmSize,
-				CapAdd:          capAdd,
-				CapDrop:         capDrop,
+				CapAdd:          env.AddCapabilities,
+				CapDrop:         env.DropCapabilities,
 
 				Resources: docker.Resources{
 					Devices: devices,

--- a/master/pkg/tasks/task.go
+++ b/master/pkg/tasks/task.go
@@ -83,26 +83,17 @@ func ToContainerSpec(t TaskSpec) container.Spec {
 		shmSize = t.TaskContainerDefaults.ShmSizeBytes
 	}
 
-	var capAdd []string
-	if env.AddCapabilities != nil {
-		capAdd = *env.AddCapabilities
-	}
-
-	var capDrop []string
-	if env.DropCapabilities != nil {
-		capDrop = *env.DropCapabilities
-	}
+	capAdd := env.AddCapabilities
+	capDrop := env.DropCapabilities
 
 	resources := t.ResourcesConfig()
 	var devices []docker.DeviceMapping
-	if resources.Devices != nil {
-		for _, device := range *resources.Devices {
-			devices = append(devices, docker.DeviceMapping{
-				PathOnHost:        device.HostPath,
-				PathInContainer:   device.ContainerPath,
-				CgroupPermissions: device.Mode,
-			})
-		}
+	for _, device := range resources.Devices {
+		devices = append(devices, docker.DeviceMapping{
+			PathOnHost:        device.HostPath,
+			PathInContainer:   device.ContainerPath,
+			CgroupPermissions: device.Mode,
+		})
 	}
 
 	spec := container.Spec{

--- a/master/pkg/tasks/task_spec.go
+++ b/master/pkg/tasks/task_spec.go
@@ -20,6 +20,12 @@ import (
 	"github.com/determined-ai/determined/master/pkg/model"
 )
 
+// MakeTaskSpecFn is a workaround for the delayed initialization that we have around how tasks are
+// run.  The master knows which task spec and task container defaults belong to which pool, but the
+// actual parsing of configs might be delegated to e.g. a CommandManager which does not have access
+// to the same information.  This lets us avoid extra Asks or passing the Master object around.
+type MakeTaskSpecFn func(poolName string, numSlots int) TaskSpec
+
 // InnerSpec defines the interface for a particular kind of task container.
 type InnerSpec interface {
 	// Archives returns the files to include in the container for this task (apart from the base files


### PR DESCRIPTION
## Description

Add new configuration options in the experiment config and master
config.

Experiment Config:

* Add resources.devices, a list of --device settings for docker run
  (ignored by kubernetes resource manager).
* Add environment.add_capabilities, a list of --cap-add settings for
  docker run (ignored by kubernetes resource manager).
* Add environment.drop_capabilities, a list of --cap-drop settings for
  docker run (ignored by kubernetes resource manager).

Master Config:

* Add task_container_defaults.add_capabilities
* Add task_container_defaults.drop_capabilities
* Add task_container_defaults.devices
* Support a new task_container_defaults field each of the entries of
  resource_pools.  The task_container_defaults applied to a
  experiment/notebook/shell/command is matching resource_pool's
  task_container_defaults, or the top-level task_container_defaults if
  the per-resource_pool setting is not defined.

## Test Plan

Tested manually.

## Commentary

This PR includes a refactor of how the `master.taskSpec` is handled throughout the master.  Previously it was passed around to different API endpoint handlers, which would derive their own TaskSpec from the master's TaskSpec.  Now, it is necessary to construct the TaskSpec on the fly (due to having multiple task_container_defaults) and so the master passes around a function which takes as input a resource pool name and a number of slots and returns an appropriate TaskSpec.