### PR TITLE
ci: stop using coscheduler for CI testing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -543,8 +543,7 @@ commands:
             detVersion=<<parameters.det-version>>,\
             maxSlotsPerPod=<<parameters.gpus-per-machine>>,\
             checkpointStorage.type=gcs,\
-            checkpointStorage.bucket=det-ci,\
-            defaultScheduler=coscheduler
+            checkpointStorage.bucket=det-ci
       - set-master-address-gke:
           release-name: "ci"
           namespace: "default"
@@ -616,8 +615,7 @@ commands:
             taskContainerDefaults.cpuImage=determinedai/environments:cuda-11.0-pytorch-1.7-lightning-1.2-tf-2.4-gpu-0.11.0,\
             taskContainerDefaults.gpuImage=determinedai/environments:cuda-11.0-pytorch-1.7-lightning-1.2-tf-2.4-gpu-0.11.0,\
             checkpointStorage.type=gcs,\
-            checkpointStorage.bucket=det-ci,\
-            defaultScheduler=coscheduler
+            checkpointStorage.bucket=det-ci
       - set-master-address-gke:
           release-name: "ci"
           namespace: "default"
@@ -1446,11 +1444,6 @@ jobs:
           region: <<parameters.region>>
           node-locations: <<parameters.node-locations>>
       - set-google-application-credentials
-      - run:
-          name: Set environment variables
-          command: |
-            echo "export TOTAL_SLOTS="$((<<parameters.num-machines>> * <<parameters.gpus-per-machine>>))"" >> $BASH_ENV
-            source $BASH_ENV
       - run-e2e-tests:
           mark: <<parameters.mark>>
           master-host: ${MASTER_HOST}
@@ -1529,11 +1522,6 @@ jobs:
           gpus-per-machine: <<parameters.gpus-per-machine>>
           node-locations: <<parameters.node-locations>>
       - set-google-application-credentials
-      - run:
-          name: Set environment variables
-          command: |
-            echo "export TOTAL_SLOTS="$((<<parameters.num-machines>> * <<parameters.gpus-per-machine>>))"" >> $BASH_ENV
-            source $BASH_ENV
       - run-e2e-tests:
           mark: <<parameters.mark>>
           master-host: ${MASTER_HOST}


### PR DESCRIPTION
## Description

There is a known issue with the coscheduler that an experiment will sometimes hang when you repeatedly allocate 100% of the cluster's resources to a single experiment. This will be worked on, but in the mean time it's causing overall CI runs to fails about half the time on GKE, so the test is doing more harm than good.

## Test Plan

Confirmed this didn't further break the GKE jobs here: https://app.circleci.com/pipelines/github/determined-ai/determined?branch=mackrory. The gang-scheduling test will gracefully skip itself when this TOTAL_SLOTS variable is not set (it already did that since it wasn't supposed to run on anything but static clusters).