### PR TITLE
fix: nightly mnist_pytorch slots failed to free [DET-5239]

### DIFF
--- a/e2e_tests/tests/experiment/experiment.py
+++ b/e2e_tests/tests/experiment/experiment.py
@@ -460,7 +460,7 @@ def verify_completed_experiment_metadata(
     # When the experiment completes, all slots should now be free. This
     # requires terminating the experiment's last container, which might
     # take some time.
-    max_secs_to_free_slots = 30
+    max_secs_to_free_slots = 900
     for _ in range(max_secs_to_free_slots):
         if cluster.num_free_slots() == cluster.num_slots():
             break


### PR DESCRIPTION
## Description

The `mnist_pytorch` example has been failing on nightly tests due to the checkpoint GC CPU-only tasks taking longer to terminate than the default time period. To resolve this issue, I bumped the `max_secs_to_free_slots` to a 15 min time period. If the slots free before that time period is up, the loop will break so this should not affect the overall time spent running nightly examples. I want to ensure this fixes the problem in nightly examples, after which I can always reduce the time period to free slots if needed.

<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234