### PR TITLE
fix: gallery modal [DET-5257]

### DIFF
--- a/webui/react/src/components/ScatterPlot.tsx
+++ b/webui/react/src/components/ScatterPlot.tsx
@@ -144,15 +144,19 @@ const ScatterPlot: React.FC<Props> = ({
   // Redraw the chart when we detect changes in the data or a resize event.
   useEffect(() => {
     const throttleResize = throttle(DEFAULT_RESIZE_THROTTLE_TIME, () => {
-      if (!chartRef.current || resize.width === 0 || resize.height === 0) return;
+      if (!chartRef.current) return;
+
       const rect = chartRef.current.getBoundingClientRect();
+      if (rect.width === 0 || rect.height === 0) return;
+
       const layout = { ...chartLayout, width: rect.width };
       if (xIsString) layout.xaxis = { ...layout.xaxis, tickangle: 90 };
-      Plotly.react(chartRef.current, [ chartData ], layout, plotlyConfig);
+
+      Plotly.react(id, [ chartData ], layout, plotlyConfig);
     });
 
     throttleResize();
-  }, [ chartData, chartLayout, resize, xIsString, yIsString ]);
+  }, [ chartData, chartLayout, id, resize, xIsString, yIsString ]);
 
   return <div id={id} ref={chartRef} />;
 };


### PR DESCRIPTION
## Description

Problem: Navigation (previous chart / next chart) for gallery modal view on HP Scatter Plots and HP Heatmap do not work on the very first load.
Technical issue: The problem is that the very initial size of the chart is 0 in width and height and the re-render ignores when the width and height of the resize event are 0. It's actually not 0 so change to dynamically getting the width and height to determine if the size of the chart is actually 0.

<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234