### PR TITLE
fix: correct crash when changing filter on multi-selected rows [DET-5258]

### DIFF
--- a/docs/release-notes/2226-fix-user-filter-crash.txt
+++ b/docs/release-notes/2226-fix-user-filter-crash.txt
@@ -1,0 +1,6 @@
+:orphan:
+
+**Bug Fixes**
+
+-  WebUI: Fix the issue of the WebUI crashing when user selects a row in
+   experiment list page then changes the user filter.

--- a/webui/react/src/pages/ExperimentList.tsx
+++ b/webui/react/src/pages/ExperimentList.tsx
@@ -349,6 +349,7 @@ const ExperimentList: React.FC = () => {
 
   const handleFilterChange = useCallback((filters: ExperimentFilters): void => {
     storage.set(STORAGE_FILTERS_KEY, filters);
+    setSelectedRowKeys([]);
     setFilters(filters);
     setPagination(prev => ({ ...prev, offset: 0 }));
   }, [ setFilters, storage ]);

--- a/webui/react/src/pages/TaskList.tsx
+++ b/webui/react/src/pages/TaskList.tsx
@@ -205,6 +205,7 @@ const TaskList: React.FC = () => {
 
   const handleFilterChange = useCallback((filters: TaskFilters<CommandType>): void => {
     storage.set(STORAGE_FILTERS_KEY, filters);
+    setSelectedRowKeys([]);
     setFilters(filters);
   }, [ setFilters, storage ]);
 


### PR DESCRIPTION
## Description

Problem: WebUI crashes when user selects a rows in multi-selectable tables and then changing filters on the table.
Solution: Reset the selected rows when filter changes.

<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan

- [ ] on experiment list page, select multiple rows then change any filter (user, label, archived, etc)
- [ ] on task list page, select multiple rows then change any filter (user, label, archived, etc)

<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234