### PR TITLE
docs: add release note for removing cloudpickle

### DIFF
--- a/docs/release-notes/2204-stop-using-cloudpickle.txt
+++ b/docs/release-notes/2204-stop-using-cloudpickle.txt
@@ -1,0 +1,7 @@
+:orphan:
+
+**Improvements**
+
+-  PyTorch checkpoints are no longer saved using cloudpickle. This should
+   not impact compatibility of existing checkpoints and improves portability
+   across Python versions.


### PR DESCRIPTION
## Description

Adding release note about removing cloudpickle from checkpoints. Confident that it should have no impact because I tested loading an old checkpoint and continuing to train. Also, we weren't using cloudpickle to load checkpoints anyway, and there is no logic in PyTorch to dynamically decide cloudpickle should be used for loading.

## Test Plan

Pre-commits should be sufficient