### PR TITLE
fix: force checkpoint GC to use the master's default environment [DET-5260]

### DIFF
--- a/master/pkg/tasks/task_spec.go
+++ b/master/pkg/tasks/task_spec.go
@@ -237,8 +237,10 @@ func (g GCCheckpoints) Entrypoint() []string {
 }
 
 // Environment implements InnerSpec.
-func (g GCCheckpoints) Environment(TaskSpec) model.Environment {
-	return g.ExperimentConfig.Environment
+func (g GCCheckpoints) Environment(t TaskSpec) model.Environment {
+	env := model.DefaultExperimentConfig(&t.TaskContainerDefaults).Environment
+	env.EnvironmentVariables = g.ExperimentConfig.Environment.EnvironmentVariables
+	return env
 }
 
 // EnvVars implements InnerSpec.


### PR DESCRIPTION
## Description
This change updates the checkpoint GC task to use either the default `environment.image` or the defaults from task container defaults if they were defined.
<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan
- [x] submit exp with custom image, make sure it doesn't use it.
<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)
This uses the task spec from the experiment, which is the task spec from master, which contains the master's task container defaults, not the task container defaults for the resource pool this got scheduled on. Maybe that is a shortcoming, but it probably will work fine.
<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234