### PR TITLE
chore: no pointers to maps or slices in expconf

### DIFF
--- a/harness/determined/common/schemas/expconf/_gen.py
+++ b/harness/determined/common/schemas/expconf/_gen.py
@@ -2675,6 +2675,26 @@ schemas = {
                 "null"
             ],
             "default": null
+        },
+        "defaulted_array": {
+            "type": [
+                "array",
+                "null"
+            ],
+            "default": [],
+            "items": {
+                "type": "string"
+            }
+        },
+        "nodefault_array": {
+            "type": [
+                "array",
+                "null"
+            ],
+            "default": null,
+            "items": {
+                "type": "string"
+            }
         }
     }
 }

--- a/harness/determined/common/schemas/expconf/_v0.py
+++ b/harness/determined/common/schemas/expconf/_v0.py
@@ -875,6 +875,8 @@ class TestRootV0(schemas.SchemaBase):
     _id = "http://determined.ai/schemas/expconf/v0/test-root.json"
 
     val_x: int
+    defaulted_array: Optional[List[str]] = None
+    nodefault_array: Optional[List[str]] = None
     sub_obj: Optional[TestSubV0] = None
     sub_union: Optional[TestUnionV0_Type] = None
     runtime_defaultable: Optional[int] = None
@@ -883,6 +885,8 @@ class TestRootV0(schemas.SchemaBase):
     def __init__(
         self,
         val_x: int,
+        defaulted_array: Optional[List[str]] = None,
+        nodefault_array: Optional[List[str]] = None,
         sub_obj: Optional[TestSubV0] = None,
         sub_union: Optional[TestUnionV0_Type] = None,
         runtime_defaultable: Optional[int] = None,

--- a/master/pkg/schemas/expconf/environment_config.go
+++ b/master/pkg/schemas/expconf/environment_config.go
@@ -18,13 +18,13 @@ type EnvironmentConfigV0 struct {
 	Image                *EnvironmentImageMapV0     `json:"image"`
 	EnvironmentVariables *EnvironmentVariablesMapV0 `json:"environment_variables"`
 
-	Ports          *map[string]int   `json:"ports"`
+	Ports          map[string]int    `json:"ports"`
 	RegistryAuth   *types.AuthConfig `json:"registry_auth"`
 	ForcePullImage *bool             `json:"force_pull_image"`
 	PodSpec        *k8sV1.Pod        `json:"pod_spec"`
 
-	AddCapabilities  *[]string `json:"add_capabilities"`
-	DropCapabilities *[]string `json:"drop_capabilities"`
+	AddCapabilities  []string `json:"add_capabilities"`
+	DropCapabilities []string `json:"drop_capabilities"`
 }
 
 //go:generate ../gen.sh
@@ -80,18 +80,18 @@ func (e *EnvironmentImageMapV0) For(deviceType device.Type) string {
 //go:generate ../gen.sh
 // EnvironmentVariablesMapV0 configures the runtime environment variables.
 type EnvironmentVariablesMapV0 struct {
-	CPU *[]string `json:"cpu"`
-	GPU *[]string `json:"gpu"`
+	CPU []string `json:"cpu"`
+	GPU []string `json:"gpu"`
 }
 
 // UnmarshalJSON implements the json.Unmarshaler interface.
 func (e *EnvironmentVariablesMapV0) UnmarshalJSON(data []byte) error {
 	var plain []string
 	if err := json.Unmarshal(data, &plain); err == nil {
-		e.CPU = &[]string{}
-		e.GPU = &[]string{}
-		*e.CPU = append(*e.CPU, plain...)
-		*e.GPU = append(*e.GPU, plain...)
+		e.CPU = []string{}
+		e.GPU = []string{}
+		e.CPU = append(e.CPU, plain...)
+		e.GPU = append(e.GPU, plain...)
 		return nil
 	}
 	type DefaultParser EnvironmentVariablesMapV0
@@ -99,13 +99,13 @@ func (e *EnvironmentVariablesMapV0) UnmarshalJSON(data []byte) error {
 	if err := json.Unmarshal(data, &jsonItems); err != nil {
 		return errors.Wrapf(err, "failed to parse runtime items")
 	}
-	e.CPU = &[]string{}
-	e.GPU = &[]string{}
+	e.CPU = []string{}
+	e.GPU = []string{}
 	if jsonItems.CPU != nil {
-		*e.CPU = append(*e.CPU, *jsonItems.CPU...)
+		e.CPU = append(e.CPU, jsonItems.CPU...)
 	}
 	if jsonItems.GPU != nil {
-		*e.GPU = append(*e.GPU, *jsonItems.GPU...)
+		e.GPU = append(e.GPU, jsonItems.GPU...)
 	}
 	return nil
 }
@@ -114,9 +114,9 @@ func (e *EnvironmentVariablesMapV0) UnmarshalJSON(data []byte) error {
 func (e *EnvironmentVariablesMapV0) For(deviceType device.Type) []string {
 	switch deviceType {
 	case device.CPU:
-		return *e.CPU
+		return e.CPU
 	case device.GPU:
-		return *e.GPU
+		return e.GPU
 	default:
 		panic(fmt.Sprintf("unexpected device type: %s", deviceType))
 	}

--- a/master/pkg/schemas/expconf/experiment_config.go
+++ b/master/pkg/schemas/expconf/experiment_config.go
@@ -1,6 +1,7 @@
 package expconf
 
 import (
+	"bytes"
 	"database/sql/driver"
 	"encoding/json"
 	"fmt"
@@ -16,17 +17,17 @@ import (
 // ExperimentConfigV0 is a versioned experiment config.
 type ExperimentConfigV0 struct {
 	// Fields which can be omitted or defined at the cluster level.
-	BindMounts               *BindMountsConfigV0         `json:"bind_mounts"`
+	BindMounts               BindMountsConfigV0          `json:"bind_mounts"`
 	CheckpointPolicy         *string                     `json:"checkpoint_policy"`
 	CheckpointStorage        *CheckpointStorageConfigV0  `json:"checkpoint_storage"`
 	DataLayer                *DataLayerConfigV0          `json:"data_layer"`
-	Data                     *map[string]interface{}     `json:"data"`
+	Data                     map[string]interface{}      `json:"data"`
 	Debug                    *bool                       `json:"debug"`
 	Description              *string                     `json:"description"`
 	Entrypoint               *string                     `json:"entrypoint"`
 	Environment              *EnvironmentConfigV0        `json:"environment"`
 	Internal                 *InternalConfigV0           `json:"internal,omitempty"`
-	Labels                   *LabelsV0                   `json:"labels"`
+	Labels                   LabelsV0                    `json:"labels"`
 	MaxRestarts              *int                        `json:"max_restarts"`
 	MinCheckpointPeriod      *LengthV0                   `json:"min_checkpoint_period"`
 	MinValidationPeriod      *LengthV0                   `json:"min_validation_period"`
@@ -107,6 +108,9 @@ type LabelsV0 map[string]bool
 
 // MarshalJSON implements the json.Marshaler interface.
 func (l LabelsV0) MarshalJSON() ([]byte, error) {
+	if l == nil {
+		return []byte("null"), nil
+	}
 	labels := make([]string, 0, len(l))
 	// var labels []string
 	for label := range l {
@@ -117,6 +121,9 @@ func (l LabelsV0) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON implements the json.Unmarshaler interface.
 func (l *LabelsV0) UnmarshalJSON(data []byte) error {
+	if data == nil || bytes.Equal(data, []byte("null")) {
+		return nil
+	}
 	if *l == nil {
 		*l = make(map[string]bool)
 	}
@@ -150,7 +157,7 @@ type ResourcesConfigV0 struct {
 	ResourcePool   *string  `json:"resource_pool"`
 	Priority       *int     `json:"priority"`
 
-	Devices *DevicesConfigV0 `json:"devices"`
+	Devices DevicesConfigV0 `json:"devices"`
 }
 
 //go:generate ../gen.sh
@@ -246,5 +253,5 @@ type InternalConfigV0 struct {
 //go:generate ../gen.sh
 // NativeConfigV0 is a legacy config.
 type NativeConfigV0 struct {
-	Command *[]string `json:"command"`
+	Command []string `json:"command"`
 }

--- a/master/pkg/schemas/expconf/experiment_config_test.go
+++ b/master/pkg/schemas/expconf/experiment_config_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestBindMountsMerge(t *testing.T) {
 	e1 := ExperimentConfig{
-		BindMounts: &BindMountsConfig{
+		BindMounts: BindMountsConfig{
 			BindMount{
 				HostPath:      "/host/e1",
 				ContainerPath: "/container/e1",
@@ -18,7 +18,7 @@ func TestBindMountsMerge(t *testing.T) {
 		},
 	}
 	e2 := ExperimentConfig{
-		BindMounts: &BindMountsConfig{
+		BindMounts: BindMountsConfig{
 			BindMount{
 				HostPath:      "/host/e2",
 				ContainerPath: "/container/e2",
@@ -26,7 +26,7 @@ func TestBindMountsMerge(t *testing.T) {
 		},
 	}
 	out := schemas.Merge(e1, e2).(ExperimentConfig)
-	assert.Assert(t, len(*out.BindMounts) == 2)
-	assert.Assert(t, (*out.BindMounts)[0].HostPath == "/host/e1")
-	assert.Assert(t, (*out.BindMounts)[1].HostPath == "/host/e2")
+	assert.Assert(t, len(out.BindMounts) == 2)
+	assert.Assert(t, out.BindMounts[0].HostPath == "/host/e1")
+	assert.Assert(t, out.BindMounts[1].HostPath == "/host/e2")
 }

--- a/master/pkg/schemas/expconf/searcher_config.go
+++ b/master/pkg/schemas/expconf/searcher_config.go
@@ -155,7 +155,7 @@ type AdaptiveASHAConfigV0 struct {
 
 	MaxLength           LengthV0      `json:"max_length"`
 	MaxTrials           int           `json:"max_trials"`
-	BracketRungs        *[]int        `json:"bracket_rungs"`
+	BracketRungs        []int         `json:"bracket_rungs"`
 	Divisor             *float64      `json:"divisor"`
 	Mode                *AdaptiveMode `json:"mode"`
 	MaxRungs            *int          `json:"max_rungs"`

--- a/master/pkg/schemas/expconf/test_types.go
+++ b/master/pkg/schemas/expconf/test_types.go
@@ -67,6 +67,8 @@ type TestRootV0 struct {
 	SubObj             *TestSubV0   `json:"sub_obj"`
 	SubUnion           *TestUnionV0 `json:"sub_union"`
 	RuntimeDefaultable *int         `json:"runtime_defaultable"`
+	DefaultedArray     []string     `json:"defaulted_array"`
+	NodefaultArray     []string     `json:"nodefault_array"`
 }
 
 // RuntimeDefaults implements the RuntimeDefaultable interface.

--- a/master/pkg/schemas/expconf/zgen_adaptive_asha_config_v0.go
+++ b/master/pkg/schemas/expconf/zgen_adaptive_asha_config_v0.go
@@ -36,10 +36,7 @@ func (a AdaptiveASHAConfigV0) GetMaxTrials() int {
 }
 
 func (a AdaptiveASHAConfigV0) GetBracketRungs() []int {
-	if a.BracketRungs == nil {
-		panic("You must call WithDefaults on AdaptiveASHAConfigV0 before .GetBracketRungs")
-	}
-	return *a.BracketRungs
+	return a.BracketRungs
 }
 
 func (a AdaptiveASHAConfigV0) GetDivisor() float64 {

--- a/master/pkg/schemas/expconf/zgen_environment_config_v0.go
+++ b/master/pkg/schemas/expconf/zgen_environment_config_v0.go
@@ -25,10 +25,7 @@ func (e EnvironmentConfigV0) GetEnvironmentVariables() EnvironmentVariablesMapV0
 }
 
 func (e EnvironmentConfigV0) GetPorts() map[string]int {
-	if e.Ports == nil {
-		panic("You must call WithDefaults on EnvironmentConfigV0 before .GetPorts")
-	}
-	return *e.Ports
+	return e.Ports
 }
 
 func (e EnvironmentConfigV0) GetRegistryAuth() *types.AuthConfig {
@@ -47,17 +44,11 @@ func (e EnvironmentConfigV0) GetPodSpec() *k8sV1.Pod {
 }
 
 func (e EnvironmentConfigV0) GetAddCapabilities() []string {
-	if e.AddCapabilities == nil {
-		panic("You must call WithDefaults on EnvironmentConfigV0 before .GetAddCapabilities")
-	}
-	return *e.AddCapabilities
+	return e.AddCapabilities
 }
 
 func (e EnvironmentConfigV0) GetDropCapabilities() []string {
-	if e.DropCapabilities == nil {
-		panic("You must call WithDefaults on EnvironmentConfigV0 before .GetDropCapabilities")
-	}
-	return *e.DropCapabilities
+	return e.DropCapabilities
 }
 
 func (e EnvironmentConfigV0) WithDefaults() EnvironmentConfigV0 {

--- a/master/pkg/schemas/expconf/zgen_environment_variables_map_v0.go
+++ b/master/pkg/schemas/expconf/zgen_environment_variables_map_v0.go
@@ -9,17 +9,11 @@ import (
 )
 
 func (e EnvironmentVariablesMapV0) GetCPU() []string {
-	if e.CPU == nil {
-		panic("You must call WithDefaults on EnvironmentVariablesMapV0 before .GetCPU")
-	}
-	return *e.CPU
+	return e.CPU
 }
 
 func (e EnvironmentVariablesMapV0) GetGPU() []string {
-	if e.GPU == nil {
-		panic("You must call WithDefaults on EnvironmentVariablesMapV0 before .GetGPU")
-	}
-	return *e.GPU
+	return e.GPU
 }
 
 func (e EnvironmentVariablesMapV0) WithDefaults() EnvironmentVariablesMapV0 {

--- a/master/pkg/schemas/expconf/zgen_experiment_config_v0.go
+++ b/master/pkg/schemas/expconf/zgen_experiment_config_v0.go
@@ -9,10 +9,7 @@ import (
 )
 
 func (e ExperimentConfigV0) GetBindMounts() BindMountsConfigV0 {
-	if e.BindMounts == nil {
-		panic("You must call WithDefaults on ExperimentConfigV0 before .GetBindMounts")
-	}
-	return *e.BindMounts
+	return e.BindMounts
 }
 
 func (e ExperimentConfigV0) GetCheckpointPolicy() string {
@@ -34,10 +31,7 @@ func (e ExperimentConfigV0) GetDataLayer() DataLayerConfigV0 {
 }
 
 func (e ExperimentConfigV0) GetData() map[string]interface{} {
-	if e.Data == nil {
-		panic("You must call WithDefaults on ExperimentConfigV0 before .GetData")
-	}
-	return *e.Data
+	return e.Data
 }
 
 func (e ExperimentConfigV0) GetDebug() bool {
@@ -67,10 +61,7 @@ func (e ExperimentConfigV0) GetInternal() *InternalConfigV0 {
 }
 
 func (e ExperimentConfigV0) GetLabels() LabelsV0 {
-	if e.Labels == nil {
-		panic("You must call WithDefaults on ExperimentConfigV0 before .GetLabels")
-	}
-	return *e.Labels
+	return e.Labels
 }
 
 func (e ExperimentConfigV0) GetMaxRestarts() int {

--- a/master/pkg/schemas/expconf/zgen_native_config_v0.go
+++ b/master/pkg/schemas/expconf/zgen_native_config_v0.go
@@ -8,7 +8,7 @@ import (
 	"github.com/determined-ai/determined/master/pkg/schemas"
 )
 
-func (n NativeConfigV0) GetCommand() *[]string {
+func (n NativeConfigV0) GetCommand() []string {
 	return n.Command
 }
 

--- a/master/pkg/schemas/expconf/zgen_resources_config_v0.go
+++ b/master/pkg/schemas/expconf/zgen_resources_config_v0.go
@@ -57,10 +57,7 @@ func (r ResourcesConfigV0) GetPriority() *int {
 }
 
 func (r ResourcesConfigV0) GetDevices() DevicesConfigV0 {
-	if r.Devices == nil {
-		panic("You must call WithDefaults on ResourcesConfigV0 before .GetDevices")
-	}
-	return *r.Devices
+	return r.Devices
 }
 
 func (r ResourcesConfigV0) WithDefaults() ResourcesConfigV0 {

--- a/master/pkg/schemas/expconf/zgen_test_root_v0.go
+++ b/master/pkg/schemas/expconf/zgen_test_root_v0.go
@@ -27,6 +27,14 @@ func (t TestRootV0) GetRuntimeDefaultable() *int {
 	return t.RuntimeDefaultable
 }
 
+func (t TestRootV0) GetDefaultedArray() []string {
+	return t.DefaultedArray
+}
+
+func (t TestRootV0) GetNodefaultArray() []string {
+	return t.NodefaultArray
+}
+
 func (t TestRootV0) WithDefaults() TestRootV0 {
 	return schemas.WithDefaults(t).(TestRootV0)
 }

--- a/master/pkg/schemas/zgen_schemas.go
+++ b/master/pkg/schemas/zgen_schemas.go
@@ -2489,6 +2489,26 @@ var (
                 "null"
             ],
             "default": null
+        },
+        "defaulted_array": {
+            "type": [
+                "array",
+                "null"
+            ],
+            "default": [],
+            "items": {
+                "type": "string"
+            }
+        },
+        "nodefault_array": {
+            "type": [
+                "array",
+                "null"
+            ],
+            "default": null,
+            "items": {
+                "type": "string"
+            }
         }
     }
 }

--- a/schemas/expconf/v0/test-root.json
+++ b/schemas/expconf/v0/test-root.json
@@ -33,6 +33,26 @@
                 "null"
             ],
             "default": null
+        },
+        "defaulted_array": {
+            "type": [
+                "array",
+                "null"
+            ],
+            "default": [],
+            "items": {
+                "type": "string"
+            }
+        },
+        "nodefault_array": {
+            "type": [
+                "array",
+                "null"
+            ],
+            "default": null,
+            "items": {
+                "type": "string"
+            }
         }
     }
 }

--- a/schemas/test_cases/v0/test-structs.yaml
+++ b/schemas/test_cases/v0/test-structs.yaml
@@ -9,6 +9,8 @@
       val_y: default_y
     sub_union: null
     runtime_defaultable: "*"
+    defaulted_array: []
+    nodefault_array: null
 
 - name: root full (valid)
   matches:
@@ -22,6 +24,11 @@
       val_a: 1
       common_val: common_val
     runtime_defaultable: 777
+    defaulted_array:
+      - hello
+      - world
+    nodefault_array:
+      - shall we play a game?
   defaulted:
     val_x: 1
     sub_obj:
@@ -31,6 +38,11 @@
       val_a: 1
       common_val: common_val
     runtime_defaultable: 777
+    defaulted_array:
+      - hello
+      - world
+    nodefault_array:
+      - shall we play a game?
 
 - name: union unmarshal (valid, type=a)
   matches:


### PR DESCRIPTION
## Description

When I first designed the golang framework for expconf, I didn't actually realize that maps and arrays could be `nil`, so I was using redundant pointers to those objects.  This PR removes that.

## Test Plan

Added relevant objects to the test structs and tests still pass.

## Commentary

The only part of this change that I think is a bit opaque is the hardcoded whitelist of type aliases in gen.py.  To help improve the discoverability of the whitelist, I wrote very clear error messages when the dev might need to add an element to it.