### PR TITLE
chore: reset error field on hp importance success

### DIFF
--- a/master/internal/hpimportance/manager.go
+++ b/master/internal/hpimportance/manager.go
@@ -256,6 +256,7 @@ func (m *manager) workCompleted(ctx *actor.Context, msg workCompleted) {
 		return
 	}
 	metricData := hpi.GetMetricHPImportance(msg.metricName, msg.metricType)
+	metricData.Error = ""
 	metricData.ExperimentProgress = msg.progress
 	metricData.HpImportance = msg.results
 	metricData.InProgress = false


### PR DESCRIPTION
## Description

The error field may often include temporary and expected conditions, like not having > 50 trials when the experiment is 10% complete. We need to reset that when it completes.

## Test Plan

Found and tested this while investigating a larger issue with HP importance.