### PR TITLE
feat: support configurable port and container name for Fluent Bit [DET-5272, DET-5273]

### DIFF
--- a/agent/cmd/determined-agent/run.go
+++ b/agent/cmd/determined-agent/run.go
@@ -147,6 +147,8 @@ func newRunCmd() *cobra.Command {
 		"Docker image to use for the managed Fluent Bit daemon")
 	cmd.Flags().IntVar(&opts.Fluent.Port, "fluent-port", 24224,
 		"TCP port for the Fluent Bit daemon to listen on")
+	cmd.Flags().StringVar(&opts.Fluent.ContainerName, "fluent-container-name", "determined-fluent",
+		"Name for the Fluent Bit container")
 
 	return cmd
 }

--- a/agent/internal/agent_test.go
+++ b/agent/internal/agent_test.go
@@ -103,8 +103,9 @@ func defaultAgentConfig() Options {
 		BindIP:              "0.0.0.0",
 		BindPort:            9090,
 		Fluent: FluentOptions{
-			Image: "fluent/fluent-bit:1.6",
-			Port:  24224,
+			Image:         "fluent/fluent-bit:1.6",
+			Port:          24224,
+			ContainerName: "determined-fluent-test",
 		},
 	}
 }

--- a/agent/internal/options.go
+++ b/agent/internal/options.go
@@ -98,6 +98,7 @@ func (t TLSOptions) Validate() []error {
 
 // FluentOptions stores configurable Fluent Bit-related options.
 type FluentOptions struct {
-	Image string `json:"image"`
-	Port  int    `json:"port"`
+	Image         string `json:"image"`
+	Port          int    `json:"port"`
+	ContainerName string `json:"container_name"`
 }

--- a/docs/release-notes/2251-fluent-config.txt
+++ b/docs/release-notes/2251-fluent-config.txt
@@ -1,0 +1,10 @@
+:orphan:
+
+**New Features**
+
+-  Agent: Support configuring the name of the Fluent Bit logging
+   container via the ``--fluent-container-name`` option.
+
+**Bug Fixes**
+
+-  Agent: Take the ``--fluent-port`` option into account.


### PR DESCRIPTION
## Description

The `--fluent-port` option was present and affected log messages, but it
didn't actually change the port. That is fixed.

Also support changing the name of the Fluent Bit container (mostly for
testing purposes).

## Test Plan

- [x] run the agent with both options set, check that they have the right effect on the container and that trial logs still come through
