### PR TITLE
fix: gracefully handle Docker binding published ports to ipv4 and ipv6 [DET-5295]

### DIFF
--- a/master/pkg/container/address.go
+++ b/master/pkg/container/address.go
@@ -1,5 +1,7 @@
 package container
 
+import "fmt"
+
 // Address represents an exposed port on a container.
 type Address struct {
 	// ContainerIP is the IP address from inside the container.
@@ -14,4 +16,8 @@ type Address struct {
 	// HostPort is the IP port from outside the container. This can be different
 	// than the ContainerPort because of network forwarding on the host machine.
 	HostPort int `json:"host_port"`
+}
+
+func (a Address) String() string {
+	return fmt.Sprintf("%s:%d:%s:%d", a.HostIP, a.HostPort, a.ContainerIP, a.ContainerPort)
 }


### PR DESCRIPTION
## Description
This change updates how we determine the Addresses for a container to gracefully handle when Docker publishes ports for ipv4 and ipv6 (e.g. looks like `0.0.0.0:8080->8080/tcp, :::8080->8080/tcp`) by coalescing either to `agent-ip:host-port:...` and de-duplicating the Addresses returned to consumers when ipv4 and ipv6 are coalesced to the same address.
<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan
- [ ] run this on plain ubuntu 20.04 w/o nvidia docker or host mode and make sure it works.
<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)
There are several ways to "fix" this - this feels the most correct. `Addresses()` still returns all addresses associated with the container in the event we need to rely on others in the future (and making this return exactly what rendezvous wants feels weird, it's in the wrong place) and it works when the container only has ipv6 bound too. The way we determine rendezvous ports - just assuming it's all the addresses associated with a container - still feels a little brittle, but it's fine for now. Alternative, if we ever expose ports other than rendezvous for a trial would just be knowing the container ports used for rendezvous and then finding how those got exposed on container created by grabbing the port binding's corresponding container port's host ports.
<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234