### PR TITLE
chore: fix some minor bugs in expconf reflect code

### DIFF
--- a/master/pkg/schemas/copy.go
+++ b/master/pkg/schemas/copy.go
@@ -21,7 +21,7 @@ func cpy(v reflect.Value) reflect.Value {
 
 	case reflect.Interface:
 		if v.IsZero() {
-			return v.Elem()
+			return v
 		}
 		out = cpy(v.Elem())
 
@@ -72,5 +72,5 @@ func cpy(v reflect.Value) reflect.Value {
 		return v
 	}
 
-	return out
+	return out.Convert(v.Type())
 }

--- a/master/pkg/schemas/defaults.go
+++ b/master/pkg/schemas/defaults.go
@@ -152,7 +152,8 @@ func withDefaults(obj reflect.Value, defaultBytes []byte, name string) reflect.V
 
 	// fmt.Printf("withDefaults on %v (%T) returning %T\n", name, obj.Interface(), out.Interface())
 
-	return out
+	// Always return the matching type.
+	return out.Convert(obj.Type())
 }
 
 // jsonNameFromJSONTag is based on encoding/json's parseTag().

--- a/master/pkg/schemas/merge.go
+++ b/master/pkg/schemas/merge.go
@@ -134,11 +134,13 @@ func merge(obj reflect.Value, src reflect.Value, name string) reflect.Value {
 				out.SetMapIndex(key, cpy(srcVal))
 			}
 		}
-		return out
+		return out.Convert(obj.Type())
 
 	case reflect.Slice:
-		// Slices get copied only if the original was a nil pointer, which should always pass
-		// through the cpy() codepath and never through here.
+		// Slices are not merged by default.  If obj is nil we copy the src.
+		if obj.IsZero() {
+			return cpy(src)
+		}
 		return cpy(obj)
 
 	// Assert that none of the "complex" kinds are present.


### PR DESCRIPTION
## Description

The object duplication was breaking down for types like:

    type BindMountsConfigV0 map[string]BindMountV0

because it would create the `map[string]BindMountV0` and never 
convert it to a `BindMountsConfigV0`.