### PR TITLE
fix: lr_scheduler step when using gradient_aggregation [DET-5289]

### DIFF
--- a/docs/release-notes/2271-fix-lr-scheduler.txt
+++ b/docs/release-notes/2271-fix-lr-scheduler.txt
@@ -1,0 +1,6 @@
+:orphan:
+
+**Bug Fixes**
+
+-  PyTorchTrial: Fix learning rate scheduler behavior when used with
+   gradient aggregation.


### PR DESCRIPTION
## Description
Fix a bug in how we step the `lr_scheduler` in pytorch when gradient aggregation frequency > 1.


## Test Plan
Tested locally.

<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
