### PR TITLE
🩹 new global option -chdir from Terraform v0.15.0.

### DIFF
--- a/harness/determined/deploy/gcp/gcp.py
+++ b/harness/determined/deploy/gcp/gcp.py
@@ -96,14 +96,14 @@ def terraform_init(configs: Dict, env: Dict) -> None:
         terraform_dir(configs),
     )
 
-    command = ["terraform init"]
+    command = ["terraform"]
+    command += ["-chdir={}".format(terraform_dir(configs))]
+    command += ["init"]
     command += [
         "-backend-config='path={}'".format(
             os.path.join(configs["local_state_path"], "terraform.tfstate")
         )
     ]
-
-    command += [terraform_dir(configs)]
 
     output = subprocess.Popen(" ".join(command), env=env, shell=True, stdout=sys.stdout)
     output.wait()
@@ -112,11 +112,12 @@ def terraform_init(configs: Dict, env: Dict) -> None:
 def terraform_plan(configs: Dict, env: Dict, variables_to_exclude: List) -> None:
     vars_file_path = terraform_write_variables(configs, variables_to_exclude)
 
-    command = ["terraform", "plan"]
+    command = ["terraform"]
+    command += ["-chdir={}".format(terraform_dir(configs))]
+    command += ["plan"]
 
     command += ["-input=false"]
     command += [f"-var-file={vars_file_path}"]
-    command += [terraform_dir(configs)]
 
     run_command(" ".join(command), env)
 
@@ -124,12 +125,13 @@ def terraform_plan(configs: Dict, env: Dict, variables_to_exclude: List) -> None
 def terraform_apply(configs: Dict, env: Dict, variables_to_exclude: List) -> None:
     vars_file_path = terraform_write_variables(configs, variables_to_exclude)
 
-    command = ["terraform", "apply"]
+    command = ["terraform"]
+    command += ["-chdir={}".format(terraform_dir(configs))]
+    command = ["apply"]
 
     command += ["-input=false"]
     command += ["-auto-approve"]
     command += [f"-var-file={vars_file_path}"]
-    command += [terraform_dir(configs)]
 
     run_command(" ".join(command), env)
 
@@ -281,12 +283,13 @@ def delete(configs: Dict, env: Dict) -> None:
     stop_master(compute, tf_vars)
     terminate_running_agents(compute, tf_vars)
 
-    command = ["terraform", "destroy"]
+    command = ["terraform"]
+    command += ["-chdir={}".format(terraform_dir(configs))]
+    command += ["destroy"]
 
     command += ["-input=false"]
     command += ["-auto-approve"]
     command += [f"-var-file={vars_file_path}"]
-    command += [terraform_dir(configs)]
 
     run_command(" ".join(command), env)
 


### PR DESCRIPTION
## Description

The trailing [DIR] argument in Terraform cli to specify the working directory for various commands is no longer supported from 0.15.0 (April 14, 2021). Use the global `-chdir` option instead. 




## Test Plan

On mac os with python 3.7.10
- pip install determined==0.15.1
- brew install terraform@0.15


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
