### PR TITLE
fix: improve rendering for uPlot chart with empty data [DET-5330]

### DIFF
--- a/webui/react/src/components/UPlotChart.tsx
+++ b/webui/react/src/components/UPlotChart.tsx
@@ -1,7 +1,8 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { throttle } from 'throttle-debounce';
 import uPlot, { AlignedData } from 'uplot';
 
+import Message, { MessageType } from 'components/Message';
 import useResize from 'hooks/useResize';
 
 export interface Options extends Omit<uPlot.Options, 'width'> {
@@ -81,6 +82,17 @@ const UPlotChart: React.FC<Props> = ({ data, options }: Props) => {
       throttleFunc.cancel();
     };
   }, [ chart ]);
+
+  /*
+   * Don't plot the chart if there are no X values.
+   */
+  const hasData: boolean = useMemo(() => {
+    return !!(data && data[0].length > 0);
+  }, [ data ]);
+
+  if (!hasData) {
+    return <Message title="No data to plot." type={MessageType.Empty} />;
+  }
 
   return <div ref={chartDivRef} />;
 };

--- a/webui/react/src/pages/Cluster/ClusterHistoricalUsageChart.tsx
+++ b/webui/react/src/pages/Cluster/ClusterHistoricalUsageChart.tsx
@@ -2,6 +2,7 @@ import dayjs from 'dayjs';
 import React, { useMemo } from 'react';
 import uPlot, { AlignedData, Series } from 'uplot';
 
+import Message, { MessageType } from 'components/Message';
 import UPlotChart, { Options } from 'components/UPlotChart';
 import { glasbeyColor } from 'utils/color';
 
@@ -96,7 +97,7 @@ const ClusterHistoricalUsageChart: React.FC<ClusterHistoricalUsageChartProps> = 
   }, [ hoursByLabel ]);
 
   if (!hasData) {
-    return (<div>No data to plot.</div>);
+    return <Message title="No data to plot." type={MessageType.Empty} />;
   }
 
   return (


### PR DESCRIPTION
## Description

This is just preventing renderings when chart data has no X values (that's where the main layout imperfection are happening).

If there are X values but no Y values, the chart will still be rendered, but chart layout is ok.
Cases like this, where possible, needs to be handled on a per-chart basis, because the issue of having no Y data can have 2 sources:
- no series or empty series
- series with data but hidden

A good example is the "GPU Hours by Label" chart in [the 2nd point of this page](http://localhost:3000/det/cluster/historical-usage?after=2021-01-01&before=2021-01-31&group-by=day) and the relative code fix in this MR.

## Test Plan

Those 2 URLs will cause 2 different types of empty chart to be rendered:
- [ ] [chart with no X values](http://localhost:3000/det/experiments/1455)
- [ ] [cluster chart that has X values but no visible Y values](http://localhost:3000/det/cluster/historical-usage?after=2021-01-01&before=2021-01-31&group-by=day)


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234