### PR TITLE
fix: add support for dynamic section content via css [DET-5299]

### DIFF
--- a/docs/release-notes/2277-fix-safari-trial-logs.txt
+++ b/docs/release-notes/2277-fix-safari-trial-logs.txt
@@ -1,0 +1,6 @@
+:orphan:
+
+**Bug Fixes**
+
+-  WebUI: Fix the issue of trial logs not rendering properly on Safari
+   14.

--- a/webui/react/src/components/LogViewerTimestamp.tsx
+++ b/webui/react/src/components/LogViewerTimestamp.tsx
@@ -448,6 +448,7 @@ const LogViewerTimestamp: React.FC<Props> = ({
     <Page {...props.pageProps} options={logOptions}>
       <Section
         bodyBorder
+        bodyDynamic
         bodyNoPadding
         filters={FilterComponent && <FilterComponent
           filter={filter}

--- a/webui/react/src/components/Section.module.scss
+++ b/webui/react/src/components/Section.module.scss
@@ -76,6 +76,13 @@
     border-radius: 0 0 var(--theme-sizes-border-radius) var(--theme-sizes-border-radius);
   }
 }
+.base.bodyDynamic {
+  .body > :global(.ant-spin-nested-loading) {
+    height: 100%;
+    position: absolute;
+    width: 100%;
+  }
+}
 .base.bodyNoPadding {
   .body { padding: 0; }
 }

--- a/webui/react/src/components/Section.tsx
+++ b/webui/react/src/components/Section.tsx
@@ -8,6 +8,7 @@ import Spinner from './Spinner';
 
 interface Props {
   bodyBorder?: boolean;
+  bodyDynamic?: boolean;
   bodyNoPadding?: boolean;
   bodyScroll?: boolean;
   divider?: boolean;
@@ -28,6 +29,7 @@ const Section: React.FC<Props> = (props: PropsWithChildren<Props>) => {
   const classes = [ css.base ];
 
   if (props.bodyBorder) classes.push(css.bodyBorder);
+  if (props.bodyDynamic) classes.push(css.bodyDynamic);
   if (props.bodyNoPadding) classes.push(css.bodyNoPadding);
   if (props.bodyScroll) classes.push(css.bodyScroll);
   if (props.divider) classes.push(css.divider);


### PR DESCRIPTION
## Description

Trial logs does not render properly on `Safari 14.0.3` (`13.1.1` works fine)
<img width="1616" alt="Screen Shot 2021-04-26 at 10 20 30 AM" src="https://user-images.githubusercontent.com/220971/116117176-2fe93b80-a679-11eb-8d80-3dd1a9929914.png">

The problem is due to `Safari 14.0.3` not respecting the CSS height of `100%`. `LogViewerTimestamp` attempts to dynamically fetch the height of the space available to set height of the visible log viewer, but on `Safari 14.0.3` it was returning `0` due to CSS issues.

The solution is to adjust the CSS to work on Safari (and the other browsers) so that the height can correctly and dynamically be fetched.

Fixed:
<img width="1616" alt="Screen Shot 2021-04-26 at 10 20 18 AM" src="https://user-images.githubusercontent.com/220971/116117214-38da0d00-a679-11eb-8d9e-84428bc4f5d7.png">

<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan

- [ ] Check that the Trial logs render properly in Safari `14.0.3`
- [ ] Check that the Trial logs render properly in Safari `13.1.1` or older
- [ ] Check that the Trial logs render properly in Chrome
- [ ] Check that the Trial logs render properly in Firefox

<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234