### PR TITLE
fix: squelch "response already committed" master log message

### DIFF
--- a/master/internal/core_experiment.go
+++ b/master/internal/core_experiment.go
@@ -434,7 +434,6 @@ func (m *Master) postExperiment(c echo.Context) (interface{}, error) {
 	}
 
 	dbExp, validateOnly, taskSpec, err := m.parseCreateExperiment(&params)
-
 	if err != nil {
 		return nil, echo.NewHTTPError(
 			http.StatusBadRequest,
@@ -442,7 +441,7 @@ func (m *Master) postExperiment(c echo.Context) (interface{}, error) {
 	}
 
 	if validateOnly {
-		return nil, c.NoContent(http.StatusNoContent)
+		return nil, nil
 	}
 
 	dbExp.OwnerID = &user.ID
@@ -459,7 +458,7 @@ func (m *Master) postExperiment(c echo.Context) (interface{}, error) {
 		Config:   e.Config,
 		Labels:   make([]string, 0),
 	}
-	return c.JSON(http.StatusCreated, response), nil
+	return response, nil
 }
 
 func (m *Master) postExperimentKill(c echo.Context) (interface{}, error) {


### PR DESCRIPTION
This was emitted when creating new experiments. The cause is that
postExperiment() calls echo.Context#JSON(http.StatusCreated, ...), but it is
wrapped by api.Route(), which calls echo.Context#JSON() itself, with a different
status code. The second call is ignored but results in printing the ugly log
message.

To fix this, we can either

  (a) change the HTTP status code for POST'ing an experiment to
      be http.StatusOK, instead of http.StatusCreated, or
  (b) change postExperiment() to not use api.Route(), or
  (c) make api.Route() smart enough to support different HTTP response codes.

This commit takes option A, which results in a change to the REST API. However,
switching from status 201 to 200 is probably not a change that will upset many
API clients.


## Description

<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->

[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234