### PR TITLE
feat: add support for preemption in Kubernetes [DET-5135]

### DIFF
--- a/master/internal/kubernetes/pod.go
+++ b/master/internal/kubernetes/pod.go
@@ -139,6 +139,10 @@ func (p *pod) Receive(ctx *actor.Context) error {
 	case podEventUpdate:
 		p.receivePodEventUpdate(ctx, msg)
 
+	case podPreemption:
+		ctx.Log().Info("received preemption command")
+		p.taskActor.System().Tell(p.taskActor, sproto.ReleaseResources{})
+
 	case sproto.ContainerLog:
 		p.receiveContainerLog(ctx, msg)
 

--- a/master/internal/kubernetes/pods.go
+++ b/master/internal/kubernetes/pods.go
@@ -60,6 +60,7 @@ type pods struct {
 	informer                *actor.Ref
 	nodeInformer            *actor.Ref
 	eventListener           *actor.Ref
+	preemptionListener		*actor.Ref
 	resourceRequestQueue    *actor.Ref
 	podNameToPodHandler     map[string]*actor.Ref
 	containerIDToPodHandler map[string]*actor.Ref
@@ -125,6 +126,7 @@ func (p *pods) Receive(ctx *actor.Context) error {
 		p.startPodInformer(ctx)
 		p.startNodeInformer(ctx)
 		p.startEventListener(ctx)
+		p.startPreemptionListener(ctx)
 		ctx.Tell(p.cluster, sproto.SetPods{Pods: ctx.Self()})
 
 	case sproto.StartTaskPod:
@@ -140,6 +142,9 @@ func (p *pods) Receive(ctx *actor.Context) error {
 
 	case podEventUpdate:
 		p.receivePodEventUpdate(ctx, msg)
+
+	case podPreemption:
+		p.receivePodPreemption(ctx, msg)
 
 	case sproto.KillTaskPod:
 		p.receiveKillPod(ctx, msg)
@@ -162,6 +167,8 @@ func (p *pods) Receive(ctx *actor.Context) error {
 			return errors.Errorf("node informer failed")
 		case p.eventListener:
 			return errors.Errorf("event listener failed")
+		case p.preemptionListener:
+			return errors.Errorf("preemption listener failed")
 		case p.resourceRequestQueue:
 			return errors.Errorf("resource request actor failed")
 		}
@@ -259,6 +266,11 @@ func (p *pods) startEventListener(ctx *actor.Context) {
 		"event-listener", newEventListener(p.clientSet, p.namespace, ctx.Self()))
 }
 
+func (p *pods) startPreemptionListener(ctx *actor.Context) {
+	p.preemptionListener, _ = ctx.ActorOf(
+		"preemption-listener", newPreemptionListener(p.clientSet, p.namespace, ctx.Self()))
+}
+
 func (p *pods) startResourceRequestQueue(ctx *actor.Context) {
 	p.resourceRequestQueue, _ = ctx.ActorOf(
 		"kubernetes-resource-request-queue",
@@ -326,6 +338,16 @@ func (p *pods) receivePodEventUpdate(ctx *actor.Context, msg podEventUpdate) {
 		return
 	}
 
+	ctx.Tell(ref, msg)
+}
+
+func (p *pods) receivePodPreemption(ctx *actor.Context, msg podPreemption) {
+	ref, ok := p.podNameToPodHandler[msg.podName]
+	if !ok {
+		ctx.Log().WithField("pod-name", msg.podName).Debug(
+			"received preemption command for unregistered container id")
+		return
+	}
 	ctx.Tell(ref, msg)
 }
 

--- a/master/internal/kubernetes/pods.go
+++ b/master/internal/kubernetes/pods.go
@@ -60,7 +60,7 @@ type pods struct {
 	informer                *actor.Ref
 	nodeInformer            *actor.Ref
 	eventListener           *actor.Ref
-	preemptionListener		*actor.Ref
+	preemptionListener      *actor.Ref
 	resourceRequestQueue    *actor.Ref
 	podNameToPodHandler     map[string]*actor.Ref
 	containerIDToPodHandler map[string]*actor.Ref

--- a/master/internal/kubernetes/preemptions.go
+++ b/master/internal/kubernetes/preemptions.go
@@ -1,8 +1,9 @@
 package kubernetes
 
 import (
-	"github.com/determined-ai/determined/master/pkg/actor"
 	"github.com/pkg/errors"
+
+	"github.com/determined-ai/determined/master/pkg/actor"
 
 	k8sV1 "k8s.io/api/core/v1"
 	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/master/internal/kubernetes/preemptions.go
+++ b/master/internal/kubernetes/preemptions.go
@@ -1,0 +1,79 @@
+package kubernetes
+
+import (
+	"github.com/determined-ai/determined/master/pkg/actor"
+	"github.com/pkg/errors"
+
+	k8sV1 "k8s.io/api/core/v1"
+	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sClient "k8s.io/client-go/kubernetes"
+)
+
+// Messages that are sent to the preemption listener.
+type startPreemptionListener struct{}
+
+// Messages that are sent by the preemption listener.
+type podPreemption struct {
+	podName string
+}
+
+type preemptionListener struct {
+	clientSet   *k8sClient.Clientset
+	namespace   string
+	podsHandler *actor.Ref
+}
+
+func newPreemptionListener(
+	clientSet *k8sClient.Clientset,
+	namespace string,
+	podsHandler *actor.Ref,
+) *preemptionListener {
+	return &preemptionListener{
+		clientSet:   clientSet,
+		namespace:   namespace,
+		podsHandler: podsHandler,
+	}
+}
+
+func (p *preemptionListener) Receive(ctx *actor.Context) error {
+	switch msg := ctx.Message().(type) {
+	case actor.PreStart:
+		ctx.Tell(ctx.Self(), startPreemptionListener{})
+
+	case startPreemptionListener:
+		if err := p.startPreemptionListener(ctx); err != nil {
+			return err
+		}
+
+	case actor.PostStop:
+
+	default:
+		ctx.Log().Errorf("unexpected message %T", msg)
+		return actor.ErrUnexpectedMessage(ctx)
+	}
+
+	return nil
+}
+
+func (p *preemptionListener) startPreemptionListener(ctx *actor.Context) error {
+	watch, err := p.clientSet.CoreV1().Pods(p.namespace).Watch(
+		metaV1.ListOptions{LabelSelector: "determined-preemption"})
+	if err != nil {
+		return errors.Wrap(err, "error initializing preemption watch")
+	}
+
+	ctx.Log().Info("preemption listener is starting")
+	for pod := range watch.ResultChan() {
+		newPod, ok := pod.Object.(*k8sV1.Pod)
+		if !ok {
+			ctx.Log().Warnf("error converting object type %T to *k8sV1.Pod: %+v", pod, pod)
+			continue
+		}
+		ctx.Tell(p.podsHandler, podPreemption{podName: newPod.Name})
+	}
+
+	ctx.Log().Warn("preemption listener stopped unexpectedly")
+	ctx.Tell(ctx.Self(), startPreemptionListener{})
+
+	return nil
+}


### PR DESCRIPTION
## Description
In conjunction with the kubernetes coscheduler plugin, this change facilitates preemption in kubernetes by allowing experiments to be paused. Experiments are paused when their pods are tagged with the "determined-preemption" label. 
<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan
Tested manually on kubernetes with the coscheduler running alongside determined.
<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234