### PR TITLE
fix: only warn for non-numeric np.dtypes [DET-5288]

### DIFF
--- a/docs/release-notes/2287-non-numeric-numpy.txt
+++ b/docs/release-notes/2287-non-numeric-numpy.txt
@@ -1,0 +1,11 @@
+:orphan:
+
+**Fixes**
+
+-  ``PyTorchTrial``'s
+   :meth:`~determined.pytorch.PyTorchTrialContext.to_device` no longer
+   throws errors on non-numeric Numpy-like data. As PyTorch is still
+   unable to move such data to the GPU, non-numeric arrays will simply
+   remain on the CPU. This is especially useful to NLP practitioners who
+   wish to make use of Numpy's string manipulations anywhere in their
+   data pipelines.

--- a/harness/determined/pytorch/_data.py
+++ b/harness/determined/pytorch/_data.py
@@ -394,13 +394,17 @@ def to_device(
 
     if isinstance(data, dict):
         return {k: to_device(v, device, warned_types) for k, v in data.items()}  # type: ignore
-    if isinstance(data, list):
+    elif isinstance(data, list):
         return [to_device(d, device, warned_types) for d in data]  # type: ignore
-    if isinstance(data, tuple):
+    elif isinstance(data, tuple):
         return tuple(to_device(d, device, warned_types) for d in data)  # type: ignore
-    if isinstance(data, np.ndarray):
-        return torch.from_numpy(data).to(device)
-    if hasattr(data, "to") and callable(data.to):  # type: ignore
+    elif isinstance(data, np.ndarray):
+        # Torch supports floats, complex floats, ints, uints, and bools as tensors.
+        # Those correspond to numpy dtype kinds: "f", "c", "i", "u", and "b", respectively.
+        # Do not attempt to convert any other kinds to tensors.
+        if data.dtype.kind in "fciub":
+            return torch.from_numpy(data).to(device)
+    elif hasattr(data, "to") and callable(data.to):  # type: ignore
         return data.to(device)  # type: ignore
 
     if type(data) not in warned_types:
@@ -409,4 +413,4 @@ def to_device(
             f"Was not able to move data item of type '{type(data).__name__}' to device."
         )
 
-    return data
+    return data  # type:ignore


### PR DESCRIPTION
Numerous users have run into mysterious error messages due to having
numpy arrays of python objects or strings.

It turns out numpy has support for string arrays that is useful to NLP
users, so there's not necessarily good reason to enforce that users use
python lists instead of numpy arrays for non-numeric data.

We can just handle it better.

The allowable dtypes for pytorch come from:

    pytorch/torch/csrc/utils/tensor_numpy.cpp

The corresponding kinds are derived from:

    numpy/numpy/core/numerictypes.py