### PR TITLE
docs: add docs for preemption in kubernetes

### DIFF
--- a/docs/how-to/installation/kubernetes.txt
+++ b/docs/how-to/installation/kubernetes.txt
@@ -286,6 +286,16 @@ tasks.
 
    defaultScheduler: coscheduler
 
+Determined also includes support for priority based scheduling with
+preemption. This feature allows experiments to be preempted if higher
+priority ones are submitted. This feature is also in beta and is not
+enabled by default. To activate priority-based preemption scheduling,
+set ``defaultScheduler`` to ``preemption``.
+
+.. code:: yaml
+
+   defaultScheduler: preemption
+
 ***********************
  Installing Determined
 ***********************

--- a/docs/reference/helm-config.txt
+++ b/docs/reference/helm-config.txt
@@ -239,8 +239,9 @@ Helm Chart </helm/determined-0.5.0.tgz>`.
       --set-file logging.security.tls.certificate=<path>``.
 
 -  ``defaultScheduler``: Configures the default scheduler that
-   Determined will use. Currently only supports the ``coscheduler``
-   option, which enables the `lightweight coscheduling plugin
-   <https://github.com/kubernetes-sigs/scheduler-plugins/tree/release-1.18/pkg/coscheduling>`__.
-   Unless specified as ``coscheduler``, Determined will use the default
-   Kubernetes scheduler.
+   Determined will use. Currently supports the ``coscheduler`` option,
+   which enables the `lightweight coscheduling plugin
+   <https://github.com/kubernetes-sigs/scheduler-plugins/tree/release-1.18/pkg/coscheduling>`__,
+   and the ``preemption`` option, which enables a priority-based
+   preemption scheduler. Unless specified as ``coscheduler``, Determined
+   will use the default Kubernetes scheduler.

--- a/docs/topic-guides/deployment/determined-on-kubernetes.txt
+++ b/docs/topic-guides/deployment/determined-on-kubernetes.txt
@@ -50,9 +50,11 @@ starts. Determined includes built-in support for the `lightweight
 coscheduling plugin
 <https://github.com/kubernetes-sigs/scheduler-plugins/tree/release-1.18/pkg/coscheduling>`__,
 which extends the default Kubernetes scheduler to support gang
-scheduling. The coscheduling plugin is not enabled by default. For more
-details and instructions on how to enable the coscheduling plugin, refer
-to :ref:`scheduling-on-kubernetes`.
+scheduling. Determined also includes support for priority-based
+preemption scheduling. Neither are enabled by default. For more details
+and instructions on how to enable the coscheduling plugin, refer to
+:ref:`gang-scheduling-on-kubernetes` and
+:ref:`priority-scheduling-on-kubernetes`.
 
 Dynamic Agents
 ==============

--- a/docs/topic-guides/system-concepts/scheduling.txt
+++ b/docs/topic-guides/system-concepts/scheduling.txt
@@ -119,11 +119,11 @@ enabled:
    priority 1 then starts running. Once that experiment is complete,
    distributed training experiment with priority 2 runs.
 
-.. _scheduling-on-kubernetes:
+.. _gang-scheduling-on-kubernetes:
 
-**************************
- Scheduling on Kubernetes
-**************************
+*******************************
+ Gang Scheduling on Kubernetes
+*******************************
 
 By default, the Kubernetes scheduler does not perform gang scheduling or
 support preemption of pods. While it does take pod priority into
@@ -140,8 +140,8 @@ experiment and some GPUs to the other. Because neither experiment will
 receive the resources it needs to begin executing, the system will wait
 indefinitely.
 
-Determined addresses these problems through the use of the `lightweight
-coscheduling plugin
+One way Determined addresses these problems is through the use of the
+`lightweight coscheduling plugin
 <https://github.com/kubernetes-sigs/scheduler-plugins/tree/release-1.18/pkg/coscheduling>`__,
 which extends the Kubernetes scheduler to support priority-based gang
 scheduling. To implement gang scheduling, the coscheduling plugin will
@@ -161,12 +161,10 @@ gang scheduling. Also, while the plugin allocates resources to jobs
 based on their priority, it does not support preemption. For example, if
 the cluster is full of low priority jobs and a new high priority job is
 submitted, the high priority job will not be scheduled until one of the
-low priority jobs finishes. Additionally, there isn't an implementation
-of ``max_slots`` or ``max_concurrent_trials`` that would limit the
-resources of an experiment, i.e. one for hyperparameter search. Lastly,
-Determined's capability to automatically set pod labels is restricted to
-GPU experiments; Determined does not currently set labels for CPU
-experiments or user commands.
+low priority jobs finishes. Lastly, Determined's capability to
+automatically set pod labels is restricted to GPU experiments;
+Determined does not currently set labels for CPU experiments or user
+commands.
 
 To enable gang scheduling with commands or CPU experiments, enable the
 coscheduler in ``values.yaml`` and modify the experiment config to
@@ -185,3 +183,44 @@ contain the following:
 
 You can also use ``schedulerName: default-scheduler`` to use the default
 Kubernetes scheduler.
+
+.. _priority-scheduling-on-kubernetes:
+
+***************************************************
+ Priority Scheduling with Preemption on Kubernetes
+***************************************************
+
+Determined also makes available a priority scheduler with preemption
+that extends the Kubernetes scheduler to support preemption. This plugin
+will preempt existing pods if higher priority pods are submitted. This
+plugin is also in beta and is not enabled by default. Similar to the
+coscheduling plugin, it is enabled by setting the ``defaultScheduler``
+field to ``preemption``. Autoscaling is not supported and Determined can
+only automatically set labels for GPU experiments.
+
+If using a cluster with tainted nodes or labels, users must specify the
+tolerations or node selectors in the experiment config:
+
+.. code:: yaml
+
+   environment:
+      pod_spec:
+         apiVersion: v1
+         kind: Pod
+         spec:
+            priorityClassName: determined-medium-priority
+            nodeSelector:
+               key: value
+            tolerations:
+            -  key: "key1"
+               operator: "Equal"
+               value: "value"
+               effect: "NoSchedule"
+
+We recommend using both tolerations and node selectors to better
+constrain where your experiments can run, especially on clusters that
+contain multiple GPU types. Lastly, Determined provides low, medium, and
+high priority classes by default, named ``determined-low-priority``,
+``determined-medium-priority``, and ``determined-high-priority``. Users
+may make their own priority classes for finer grained control if they
+wish.


### PR DESCRIPTION
## Description

<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234