### PR TITLE
refactor: code split libraries [DET-5342]

### DIFF
--- a/webui/react/src/components/CreateExperimentModal.module.scss
+++ b/webui/react/src/components/CreateExperimentModal.module.scss
@@ -1,3 +1,6 @@
 .error {
   margin: var(--theme-sizes-layout-large);
 }
+.loading {
+  padding: var(--theme-sizes-layout-mega);
+}

--- a/webui/react/src/components/CreateExperimentModal.tsx
+++ b/webui/react/src/components/CreateExperimentModal.tsx
@@ -2,7 +2,6 @@ import { Alert, Button, Form, Input, Modal } from 'antd';
 import { ModalFuncProps } from 'antd/es/modal/Modal';
 import yaml from 'js-yaml';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import MonacoEditor from 'react-monaco-editor';
 
 import { RawJson } from 'types';
 import { clone } from 'utils/data';
@@ -34,6 +33,8 @@ const getMaxLengthValue = (config: RawJson) => {
   const value = (Object.keys(config.searcher?.max_length || {}) || [])[1];
   return value ? parseInt(value) : undefined;
 };
+
+const MonacoEditor = React.lazy(() => import('react-monaco-editor'));
 
 const CreateExperimentModal: React.FC<Props> = ({
   config = {},

--- a/webui/react/src/components/CreateExperimentModal.tsx
+++ b/webui/react/src/components/CreateExperimentModal.tsx
@@ -7,6 +7,7 @@ import { RawJson } from 'types';
 import { clone } from 'utils/data';
 
 import css from './CreateExperimentModal.module.scss';
+import Spinner from './Spinner';
 
 export enum CreateExperimentType {
   Fork = 'Fork',
@@ -136,18 +137,20 @@ const CreateExperimentModal: React.FC<Props> = ({
       title={props.title}
       visible={props.visible}
       onCancel={handleCancel}>
-      <MonacoEditor
-        height="40vh"
-        language="yaml"
-        options={{
-          minimap: { enabled: false },
-          scrollBeyondLastLine: false,
-          selectOnLineNumbers: true,
-        }}
-        theme="vs-light"
-        value={localConfig}
-        onChange={handleEditorChange}
-      />
+      <React.Suspense fallback={<div className={css.loading}><Spinner /></div>}>
+        <MonacoEditor
+          height="40vh"
+          language="yaml"
+          options={{
+            minimap: { enabled: false },
+            scrollBeyondLastLine: false,
+            selectOnLineNumbers: true,
+          }}
+          theme="vs-light"
+          value={localConfig}
+          onChange={handleEditorChange}
+        />
+      </React.Suspense>
       {configError && <Alert className={css.error} message={configError} type="error" />}
       {error && <Alert className={css.error} message={error} type="error" />}
     </Modal>

--- a/webui/react/src/pages/ExperimentDetails.tsx
+++ b/webui/react/src/pages/ExperimentDetails.tsx
@@ -18,7 +18,6 @@ import { clone, isEqual } from 'utils/data';
 import { terminalRunStates, upgradeConfig } from 'utils/types';
 
 import ExperimentOverview from './ExperimentDetails/ExperimentOverview';
-import ExperimentVisualization from './ExperimentDetails/ExperimentVisualization';
 
 const { TabPane } = Tabs;
 
@@ -35,6 +34,10 @@ interface Params {
 
 const TAB_KEYS = Object.values(TabType);
 const DEFAULT_TAB_KEY = TabType.Overview;
+
+const ExperimentVisualization = React.lazy(() => {
+  return import('./ExperimentDetails/ExperimentVisualization');
+});
 
 const ExperimentDetails: React.FC = () => {
   const { experimentId, tab, viz } = useParams<Params>();
@@ -175,10 +178,12 @@ const ExperimentDetails: React.FC = () => {
             onTagsChange={fetchExperimentDetails} />
         </TabPane>
         <TabPane key="visualization" tab="Visualization">
-          <ExperimentVisualization
-            basePath={`${basePath}/${TabType.Visualization}`}
-            experiment={experiment}
-            type={viz} />
+          <React.Suspense fallback={<Spinner />}>
+            <ExperimentVisualization
+              basePath={`${basePath}/${TabType.Visualization}`}
+              experiment={experiment}
+              type={viz} />
+          </React.Suspense>
         </TabPane>
       </Tabs>
       <CreateExperimentModal

--- a/webui/react/src/pages/ExperimentDetails/ExperimentInfoBox.module.scss
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentInfoBox.module.scss
@@ -1,3 +1,6 @@
 .base {
   height: 100%;
 }
+.loading {
+  padding: var(--theme-sizes-layout-mega);
+}

--- a/webui/react/src/pages/ExperimentDetails/ExperimentInfoBox.tsx
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentInfoBox.tsx
@@ -2,7 +2,6 @@ import { Button, Tooltip } from 'antd';
 import Modal from 'antd/es/modal/Modal';
 import yaml from 'js-yaml';
 import React, { useCallback, useState } from 'react';
-import MonacoEditor from 'react-monaco-editor';
 import TimeAgo from 'timeago-react';
 
 import CheckpointModal from 'components/CheckpointModal';
@@ -29,6 +28,8 @@ export interface TopWorkloads {
   bestCheckpoint?: CheckpointDetail;
   bestValidation?: number;
 }
+
+const MonacoEditor = React.lazy(() => import('react-monaco-editor'));
 
 const ExperimentInfoBox: React.FC<Props> = (
   { experiment, bestValidation, bestCheckpoint, onTagsChange }: Props,

--- a/webui/react/src/pages/ExperimentDetails/ExperimentInfoBox.tsx
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentInfoBox.tsx
@@ -10,6 +10,7 @@ import InfoBox, { InfoRow } from 'components/InfoBox';
 import Link from 'components/Link';
 import ProgressBar from 'components/ProgressBar';
 import Section from 'components/Section';
+import Spinner from 'components/Spinner';
 import TagList from 'components/TagList';
 import tagListCss from 'components/TagList.module.scss';
 import useExperimentTags from 'hooks/useExperimentTags';
@@ -116,18 +117,21 @@ const ExperimentInfoBox: React.FC<Props> = (
         visible={showConfig}
         width={768}
         onCancel={handleHideConfig}>
-        <MonacoEditor
-          height="60vh"
-          language="yaml"
-          options={{
-            minimap: { enabled: false },
-            occurrencesHighlight: false,
-            readOnly: true,
-            scrollBeyondLastLine: false,
-            selectOnLineNumbers: true,
-          }}
-          theme="vs-light"
-          value={yaml.safeDump(experiment.configRaw)} />
+        <React.Suspense
+          fallback={<div className={css.loading}><Spinner className="minHeight" /></div>}>
+          <MonacoEditor
+            height="60vh"
+            language="yaml"
+            options={{
+              minimap: { enabled: false },
+              occurrencesHighlight: false,
+              readOnly: true,
+              scrollBeyondLastLine: false,
+              selectOnLineNumbers: true,
+            }}
+            theme="vs-light"
+            value={yaml.safeDump(experiment.configRaw)} />
+        </React.Suspense>
       </Modal>
     </Section>
   );


### PR DESCRIPTION
## Description

Introduce code splitting to break up expensive libraries. Focus primarily on the two largest libraries that are not immediately needed. The basic idea is to split up the overall bundle into multiple smaller sized packets, where most of them are not needed up front. Then when they are actually needed based on a user flow, they get dynamically loaded. The upfront cost is lowered so the initial time to paint on the web app load is much faster.

1. monaco-editor 41.9% of bundle size based on `npm run analyze` on built distribution.
2. plotly.js 15.0% of bundle size.

Before code splitting:
```
File sizes after gzip:

  1.17 MB    build/static/js/2.f62b3a3f.chunk.js     <= breaking up this big boi
  87.73 KB   build/static/js/main.926a7bd1.chunk.js
  52.37 KB   build/static/css/2.31f03978.chunk.css
  39.15 KB   build/editor.worker.js
  13.01 KB   build/static/css/main.6a081639.chunk.css
  1.28 KB    build/static/js/3.5d242f47.chunk.js
  1.18 KB    build/static/js/runtime-main.d997349c.js
```

After code splitting:
```
File sizes after gzip:

  483.02 KB  build/static/js/0.7165bb6a.chunk.js      <= monaco-editor
  373.87 KB  build/static/js/3.3a8c0957.chunk.js      <= smaller load upfront
  331.63 KB  build/static/js/4.9d85526b.chunk.js      <= ExperimentVisualization (plotly)
  81.31 KB   build/static/js/main.0e359e17.chunk.js
  42.36 KB   build/static/css/3.0dba620b.chunk.css
  39.15 KB   build/editor.worker.js
  12.43 KB   build/static/js/5.e3fa0da9.chunk.js
  12.16 KB   build/static/css/main.72295266.chunk.css
  10.4 KB    build/static/css/0.603bb820.chunk.css    <= webpack splits css also (ignoring this for now since they are small)
  1.63 KB    build/static/css/5.d36c5a35.chunk.css    <= webpack splits css also (ignoring this for now since they are small)
  1.53 KB    build/static/js/runtime-main.722c24ae.js
  1.28 KB    build/static/js/6.e4ecc591.chunk.js
```

Bundle analysis before:
![2021-04-28 at 1 57 PM](https://user-images.githubusercontent.com/220971/116465221-2c48e680-a82a-11eb-8a47-21d4185c6231.png)

Bundle analysis after:
![2021-04-28 at 2 09 PM](https://user-images.githubusercontent.com/220971/116466396-a62d9f80-a82b-11eb-9267-1b6994ecf1a1.png)

<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234