### PR TITLE
chore: Helm notes should recognize preemption scheduler

### DIFF
--- a/helm/charts/determined/templates/NOTES.txt
+++ b/helm/charts/determined/templates/NOTES.txt
@@ -37,7 +37,8 @@ format X.Y.Z (e.g., 0.13.6).
 {{ end -}}
 
 {{- if .Values.defaultScheduler }}
-      {{- if not (eq (.Values.defaultScheduler | trim) "coscheduler")}}
+      {{- $schedulerType := .Values.defaultScheduler | trim}}
+      {{- if not (or (eq $schedulerType "coscheduler") (eq $schedulerType "preemption"))}}
 WARNING: defaultScheduler has been set to an unsupported value. The cluster default scheduler will be set to the Kubernetes scheduler.
       {{ end }}
 {{ end -}}


### PR DESCRIPTION
## Description

In connection with @eecsliu's recent changes - just a missed clause in the NOTES file.

## Test Plan

Ran Helm locally