### PR TITLE
chore: add experiment name to breadcrumb on trial detail page [DET-5284]

### DIFF
--- a/webui/react/src/components/Page.tsx
+++ b/webui/react/src/components/Page.tsx
@@ -11,6 +11,7 @@ import Spinner from './Spinner';
 export interface BreadCrumbRoute {
   breadcrumbName: string;
   path: string;
+  breadcrumbTooltip?: string;
 }
 
 export interface Props extends CommonProps {

--- a/webui/react/src/components/Page.tsx
+++ b/webui/react/src/components/Page.tsx
@@ -10,8 +10,8 @@ import Spinner from './Spinner';
 
 export interface BreadCrumbRoute {
   breadcrumbName: string;
-  path: string;
   breadcrumbTooltip?: string;
+  path: string;
 }
 
 export interface Props extends CommonProps {

--- a/webui/react/src/components/PageHeader.tsx
+++ b/webui/react/src/components/PageHeader.tsx
@@ -1,5 +1,4 @@
 import { Breadcrumb, Tooltip } from 'antd';
-import { Route } from 'antd/es/breadcrumb/Breadcrumb';
 import React from 'react';
 
 import { CommonProps } from 'types';
@@ -17,49 +16,17 @@ export interface Props extends CommonProps {
   title?: string;
 }
 
-export type BreadcrumbRoute = Route
-
-const tooLongExperimentDescription = 40;
-
-const isExperimentIdWithDescCrumb = (breadcrumbName: string) => {
-  const crumbElements = breadcrumbName.split(' ');
-  // The experiment description may have spaces in it, so there should be at least 3 elements
-  if (crumbElements.length < 3
-      || crumbElements[0] !== 'Experiment'
-      || isNaN(parseInt(crumbElements[1]))) {
-    return false;
-  }
-
-  const expDescWithParens = crumbElements.slice(2).join(' ');
-  return (expDescWithParens.startsWith('(') && expDescWithParens.endsWith(')'));
-};
-
-const buildExperimentInfoCrumbElement = (breadcrumbName: string) => {
-  const breadcrumbParts = breadcrumbName.split(' ');
-  const experimentId = breadcrumbParts[1];
-  // Reconstitute the breadcrumbName minus 'Experiment $ID', then remove the parentheses
-  const experimentDesc = breadcrumbParts.slice(2).join(' ').slice(1).slice(0, -1);
-
-  if (experimentDesc.length > tooLongExperimentDescription) {
-    const truncatedDesc = experimentDesc.slice(0, tooLongExperimentDescription);
-    return <Tooltip title={experimentDesc}>
-      <span>{`Experiment ${experimentId} (${truncatedDesc}...)`}</span>
-    </Tooltip>;
-  } else {
-    return <>{breadcrumbName}</>;
-  }
-};
-
-const breadCrumbRender = (route: Route, params: unknown, routes: Route[]) => {
+const breadCrumbRender = (route: BreadCrumbRoute, params: unknown, routes: BreadCrumbRoute[]) => {
 
   const last = routes.indexOf(route) === routes.length - 1;
-
   return last ? (
     <span>{route.breadcrumbName}</span>
   ) : (
     <Link path={route.path}>{
-      isExperimentIdWithDescCrumb(route.breadcrumbName)
-        ? buildExperimentInfoCrumbElement(route.breadcrumbName)
+      route.breadcrumbTooltip
+        ? <Tooltip title={route.breadcrumbTooltip}>
+          <span>{route.breadcrumbName}</span>
+        </Tooltip>
         : route.breadcrumbName}
     </Link>
   );

--- a/webui/react/src/components/PageHeader.tsx
+++ b/webui/react/src/components/PageHeader.tsx
@@ -1,4 +1,4 @@
-import { Breadcrumb } from 'antd';
+import { Breadcrumb, Tooltip } from 'antd';
 import { Route } from 'antd/es/breadcrumb/Breadcrumb';
 import React from 'react';
 
@@ -17,12 +17,49 @@ export interface Props extends CommonProps {
   title?: string;
 }
 
+const tooLongExperimentDescription = 40;
+
+const isExperimentIdWithDescCrumb = (breadcrumbName: string) => {
+  const crumbElements = breadcrumbName.split(' ');
+  // The experiment description may have spaces in it, so there should be at least 3 elements
+  if (crumbElements.length < 3
+      || crumbElements[0] !== 'Experiment'
+      || isNaN(parseInt(crumbElements[1]))) {
+    return false;
+  }
+
+  const expDescWithParens = crumbElements.slice(2).join(' ');
+  return (expDescWithParens.startsWith('(') && expDescWithParens.endsWith(')'));
+};
+
+const buildExperimentInfoCrumbElement = (breadcrumbName: string) => {
+  const breadcrumbParts = breadcrumbName.split(' ');
+  const experimentId = breadcrumbParts[1];
+  // Reconstitute the breadcrumbName minus 'Experiment $ID', then remove the parentheses
+  const experimentDesc = breadcrumbParts.slice(2).join(' ').slice(1).slice(0, -1);
+
+  if (experimentDesc.length > tooLongExperimentDescription) {
+    const truncatedDesc = experimentDesc.slice(0, tooLongExperimentDescription);
+    return <Tooltip title={experimentDesc}>
+      <span>{`Experiment ${experimentId} (${truncatedDesc}...)`}</span>
+    </Tooltip>;
+  } else {
+    return <>{breadcrumbName}</>;
+  }
+};
+
 const breadCrumbRender = (route: Route, params: unknown, routes: Route[]) => {
+
   const last = routes.indexOf(route) === routes.length - 1;
+
   return last ? (
     <span>{route.breadcrumbName}</span>
   ) : (
-    <Link path={route.path}>{route.breadcrumbName}</Link>
+    <Link path={route.path}>{
+      isExperimentIdWithDescCrumb(route.breadcrumbName)
+        ? buildExperimentInfoCrumbElement(route.breadcrumbName)
+        : route.breadcrumbName}
+    </Link>
   );
 };
 

--- a/webui/react/src/components/PageHeader.tsx
+++ b/webui/react/src/components/PageHeader.tsx
@@ -17,6 +17,8 @@ export interface Props extends CommonProps {
   title?: string;
 }
 
+export type BreadcrumbRoute = Route
+
 const tooLongExperimentDescription = 40;
 
 const isExperimentIdWithDescCrumb = (breadcrumbName: string) => {

--- a/webui/react/src/pages/ExperimentDetails.tsx
+++ b/webui/react/src/pages/ExperimentDetails.tsx
@@ -152,13 +152,6 @@ const ExperimentDetails: React.FC = () => {
 
   return (
     <Page
-      breadcrumb={[
-        { breadcrumbName: 'Experiments', path: paths.experimentList() },
-        {
-          breadcrumbName: `Experiment ${experimentId}`,
-          path: paths.experimentDetails(experimentId),
-        },
-      ]}
       options={<ExperimentActions
         experiment={experiment}
         onClick={{ Fork: showForkModal }}

--- a/webui/react/src/pages/TrialDetails.tsx
+++ b/webui/react/src/pages/TrialDetails.tsx
@@ -6,7 +6,7 @@ import { useHistory, useParams } from 'react-router';
 import Badge, { BadgeType } from 'components/Badge';
 import CreateExperimentModal, { CreateExperimentType } from 'components/CreateExperimentModal';
 import Message, { MessageType } from 'components/Message';
-import Page from 'components/Page';
+import Page, { BreadCrumbRoute } from 'components/Page';
 import Spinner from 'components/Spinner';
 import handleError, { ErrorType } from 'ErrorHandler';
 import usePolling from 'hooks/usePolling';
@@ -23,6 +23,8 @@ import { isAborted } from 'services/utils';
 import { ExperimentBase, RawJson, TrialDetails, TrialHyperParameters } from 'types';
 import { clone } from 'utils/data';
 import { terminalRunStates, trialHParamsToExperimentHParams, upgradeConfig } from 'utils/types';
+
+const maxBreadcrumbDescLength = 40;
 
 const { TabPane } = Tabs;
 
@@ -218,17 +220,28 @@ const TrialDetailsComp: React.FC = () => {
     return <Spinner />;
   }
 
-  const experimentDescForBreadcrumb = experiment.config.description
-    ? ` (${experiment.config.description})`
-    : '';
+  let desc = `Experiment ${experiment.id}`;
+  if (experiment.config.description) {
+    if (experiment.config.description.length > maxBreadcrumbDescLength) {
+      const truncatedDesc = experiment.config.description.slice(0, maxBreadcrumbDescLength);
+      desc = desc.concat(` (${truncatedDesc}...)`);
+    } else {
+      desc = desc.concat(` (${experiment.config.description})`);
+    }
+  }
+
+  const expBreadcrumbRoute : BreadCrumbRoute = {
+    breadcrumbName: ` ${desc}`,
+    path: paths.experimentDetails(experiment.id),
+  };
+  if (experiment.config.description.length > maxBreadcrumbDescLength) {
+    expBreadcrumbRoute.breadcrumbTooltip = experiment.config.description;
+  }
 
   return (
     <Page
       breadcrumb={[
-        {
-          breadcrumbName: `Experiment ${experiment.id}${experimentDescForBreadcrumb}`,
-          path: paths.experimentDetails(experiment.id),
-        },
+        expBreadcrumbRoute,
         {
           breadcrumbName: `Trial ${trialId}`,
           path: paths.trialDetails(trialId, experiment.id),

--- a/webui/react/src/pages/TrialDetails.tsx
+++ b/webui/react/src/pages/TrialDetails.tsx
@@ -218,15 +218,15 @@ const TrialDetailsComp: React.FC = () => {
     return <Spinner />;
   }
 
+  const experimentDescForBreadcrumb = experiment.config.description
+    ? ` (${experiment.config.description})`
+    : '';
+
   return (
     <Page
       breadcrumb={[
         {
-          breadcrumbName: 'Experiments',
-          path: paths.experimentList(),
-        },
-        {
-          breadcrumbName: `Experiment ${experiment.id}`,
+          breadcrumbName: `Experiment ${experiment.id}${experimentDescForBreadcrumb}`,
           path: paths.experimentDetails(experiment.id),
         },
         {

--- a/webui/react/src/pages/TrialDetails.tsx
+++ b/webui/react/src/pages/TrialDetails.tsx
@@ -24,7 +24,7 @@ import { ExperimentBase, RawJson, TrialDetails, TrialHyperParameters } from 'typ
 import { clone } from 'utils/data';
 import { terminalRunStates, trialHParamsToExperimentHParams, upgradeConfig } from 'utils/types';
 
-const maxBreadcrumbDescLength = 40;
+const maxBreadcrumbDescLength = 30;
 
 const { TabPane } = Tabs;
 
@@ -220,18 +220,23 @@ const TrialDetailsComp: React.FC = () => {
     return <Spinner />;
   }
 
-  let desc = `Experiment ${experiment.id}`;
+  let expBreadcrumbName = `Experiment ${experiment.id}`;
   if (experiment.config.description) {
     if (experiment.config.description.length > maxBreadcrumbDescLength) {
-      const truncatedDesc = experiment.config.description.slice(0, maxBreadcrumbDescLength);
-      desc = desc.concat(` (${truncatedDesc}...)`);
+      let truncatedDesc = experiment.config.description.slice(0, maxBreadcrumbDescLength);
+
+      // Don't add ellipsis after underscore, it looks wrong
+      while (truncatedDesc.endsWith('_')){
+        truncatedDesc = truncatedDesc.slice(0, -1);
+      }
+      expBreadcrumbName = expBreadcrumbName.concat(` (${truncatedDesc}…)`);
     } else {
-      desc = desc.concat(` (${experiment.config.description})`);
+      expBreadcrumbName = expBreadcrumbName.concat(` (${experiment.config.description})`);
     }
   }
 
   const expBreadcrumbRoute : BreadCrumbRoute = {
-    breadcrumbName: ` ${desc}`,
+    breadcrumbName: expBreadcrumbName,
     path: paths.experimentDetails(experiment.id),
   };
   if (experiment.config.description.length > maxBreadcrumbDescLength) {


### PR DESCRIPTION
## Description

Include the experiment description in the WebUI breadcrumbs.

Removed the breadcrumbs from the Experiment Detail page.

<img width="1789" alt="Screen Shot 2021-06-02 at 12 01 07 PM" src="https://user-images.githubusercontent.com/13806811/120515418-497a5300-c39c-11eb-834d-236df00a377e.png">



Added the experiment description to the Trial Detail page breadcrumbs that is truncated when it exceeds ~40~ 30 characters.


<img width="1792" alt="Screen Shot 2021-06-02 at 12 01 27 PM" src="https://user-images.githubusercontent.com/13806811/120515465-51d28e00-c39c-11eb-8138-3be9d570031a.png">


Added a tooltip to the breadcrumb when the description is truncated.

<img width="1792" alt="Screen Shot 2021-06-02 at 12 01 40 PM" src="https://user-images.githubusercontent.com/13806811/120515513-5eef7d00-c39c-11eb-99f9-4fc4e8b2d140.png">








## Commentary (optional)

I played with mobile a bit. This implementation doesn't look very good. 

<img width="277" alt="Screen Shot 2021-06-02 at 12 01 50 PM" src="https://user-images.githubusercontent.com/13806811/120515582-6dd62f80-c39c-11eb-94b6-6365738c8bd4.png">

Max length of 40 looks better than 30 on desktop IMO, but it really breaks the mobile view. The implementation looks better on mobile if we set the max description length of 15, but that isn't a good value for desktop. If the react code can differentiate between mobile and desktop, we could improve this, but I'm not sure how to do that/if that's a good practice.

However, there seems to be other problems with the header on mobile, so I don't think this PR makes anything worse

<img width="229" alt="Screen Shot 2021-06-02 at 12 05 44 PM" src="https://user-images.githubusercontent.com/13806811/120515731-9827ed00-c39c-11eb-9489-d7874a14a39d.png">
<img width="233" alt="Screen Shot 2021-06-02 at 12 05 52 PM" src="https://user-images.githubusercontent.com/13806811/120515735-9a8a4700-c39c-11eb-97c6-d17d3a8a765c.png">

We could rethink how we do breadcrumbs as the breadcrumbs are currently very redundant on the Trial Detail page.

<img width="444" alt="Screen Shot 2021-06-02 at 12 07 46 PM" src="https://user-images.githubusercontent.com/13806811/120515914-d02f3000-c39c-11eb-92bb-f6caa28b3138.png">

Mobile looks much better if we just don't render the `/ Trial 71` part of the breadcrumb (forgot to take a screenshot of the better mobile look).

However, the breadcrumbs are also used by the Task Logs page where the info is possibly not redundant.

<img width="538" alt="Screen Shot 2021-06-02 at 12 19 25 PM" src="https://user-images.githubusercontent.com/13806811/120516076-f81e9380-c39c-11eb-9066-79ac96d84cae.png">

If we don't think `/ Command 76b6` is important information, we can change the breadcrumb rendering to not render the last entry. All we would need to do is play with CSS since the black text color is currently based on `.ant-breadcrumb > span:last-child`.



### TODO

- Add release notes

## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.
