### PR TITLE
chore: only select a single host port per container rendezvous port

### DIFF
--- a/master/internal/trial.go
+++ b/master/internal/trial.go
@@ -904,9 +904,15 @@ func (t *trial) pushRendezvous(ctx *actor.Context) error {
 		var addresses []*rendezvousAddress
 
 		var addrs []cproto.Address
+		// Track container ports and only add uniques to addrs.
+		// Sometime around Docker 20.10.6, Docker started, seemingly randomly,
+		// binding multiple host ports to a container port very rarely.
+		containerPorts := map[int]bool{}
 		for _, addr := range caddr.Addresses {
-			if MinLocalRendezvousPort <= addr.ContainerPort && addr.ContainerPort <= MaxLocalRendezvousPort {
+			if MinLocalRendezvousPort <= addr.ContainerPort &&
+				addr.ContainerPort <= MaxLocalRendezvousPort && !containerPorts[addr.ContainerPort] {
 				addrs = append(addrs, addr)
+				containerPorts[addr.ContainerPort] = true
 			}
 
 			addresses = append(addresses, &rendezvousAddress{


### PR DESCRIPTION
## Description
This change updates the code that picks rendezvous ports out of the container addresses to only pick and deliver a single mapping to a container port even if multiple were given. For example, there was a user reported bug where the port bindings looked like the snippet below, even though each port was requested to be bound only a single time.
```
{'container_ip': '172.17.0.2', 'container_port': 1734, 'host_ip': '223.193.1.182', 'host_port': 49457}
{'container_ip': '172.17.0.2', 'container_port': 1734, 'host_ip': '223.193.1.182', 'host_port': 49454}
{'container_ip': '172.17.0.2', 'container_port': 1750, 'host_ip': '223.193.1.182', 'host_port': 49456}
{'container_ip': '172.17.0.2', 'container_port': 1750, 'host_ip': '223.193.1.182', 'host_port': 49453}
```

<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan
- [ ] test on a repro
<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)
This is a weird one, I'm not satisfied but I know this work around will work based on the errors reported by CI, internally, and by OSS users.
<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234