### PR TITLE
fix: fix set up cluster cmd [DET-5399]

### DIFF
--- a/webui/tests/bin/e2e-tests.py
+++ b/webui/tests/bin/e2e-tests.py
@@ -36,7 +36,8 @@ def run(cmd: List[str], config) -> None:
 
 
 def run_forget(cmd: List[str], logfile, config) -> subprocess.Popen:
-    return subprocess.Popen(cmd, stdout=logfile)
+    out_target = logfile if logfile is not None else sys.stdout
+    return subprocess.Popen(cmd, stdout=out_target)
 
 
 def run_ignore_failure(cmd: List[str], config):
@@ -70,7 +71,7 @@ def wait_until(condition, timeout=1, *args):
     return False
 
 
-def setup_cluster(logfile, config):
+def setup_cluster(config, logfile=None):
     logger.info("setting up the cluster..")
     run(CLUSTER_CMD_PREFIX + ["start-db"], config)
     cluster_process = run_forget(CLUSTER_CMD_PREFIX + ["run"], logfile, config)
@@ -94,7 +95,7 @@ def det_cluster(config):
     try:
         log_path = str(test_cluster_dir.joinpath("cluster.stdout.log"))
         with open(log_path, "w") as f:
-            yield setup_cluster(f, config)
+            yield setup_cluster(config, f)
 
     finally:
         teardown_cluster(config)


### PR DESCRIPTION
## Description

`python bin/e2e-tests.py setup-test-cluster` fails complaining that the `config` argument is missing since it had been displaced by the logfile argument.

<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234