### PR TITLE
docs: fix typo in `train_batch` description

### DIFF
--- a/docs/tutorials/pytorch-mnist-tutorial.txt
+++ b/docs/tutorials/pytorch-mnist-tutorial.txt
@@ -210,7 +210,7 @@ Defining ``train_batch``
 ========================
 
 The :func:`~determined.pytorch.PyTorchTrial.train_batch` method is
-passed a single batch of data from the validation data set; it should
+passed a single batch of data from the training data set; it should
 run the forward passes on the models, the backward passes on the losses,
 and step the optimizers. This method should return a dictionary with
 user-defined training metrics; Determined will automatically average all


### PR DESCRIPTION
I think you meant `training` not `validation` for `train_batch`