### PR TITLE
feat: add workload status to trial infobox [DET-4289]

### DIFF
--- a/webui/react/src/pages/TrialDetails/TrialInfoBox.tsx
+++ b/webui/react/src/pages/TrialDetails/TrialInfoBox.tsx
@@ -72,6 +72,8 @@ const TrialInfoBox: React.FC<Props> = ({ trial, experiment }: Props) => {
   const handleShowHParams = useCallback(() => setShowHParams(true), []);
   const handleHideHParams = useCallback(() => setShowHParams(false), []);
 
+  const workloadStatus: string = Object.entries(trial.workloads.last()).find(e => !!e[1])?.first();
+
   const infoRows = [
     {
       content: formatDatetime(trial.startTime),
@@ -91,8 +93,8 @@ const TrialInfoBox: React.FC<Props> = ({ trial, experiment }: Props) => {
     },
     {
       content: trial.state === 'ACTIVE' &&
-      `${Object.entries(trial.workloads.last())
-        .find(entry => !!entry[1])?.first()} on batch ${trial.totalBatchesProcessed}`,
+      `${workloadStatus[0].toUpperCase() + workloadStatus.slice(1)}
+      on batch ${trial.totalBatchesProcessed}`,
       label: 'Workload Status',
     },
     {

--- a/webui/react/src/pages/TrialDetails/TrialInfoBox.tsx
+++ b/webui/react/src/pages/TrialDetails/TrialInfoBox.tsx
@@ -96,7 +96,7 @@ const TrialInfoBox: React.FC<Props> = ({ trial, experiment }: Props) => {
       content: trial.state === 'ACTIVE' &&
       `${capitalize(workloadStatus)}
       on batch ${trial.totalBatchesProcessed}`,
-      label: 'Workload Status',
+      label: 'Current Workload',
     },
     {
       content: bestValidation &&

--- a/webui/react/src/pages/TrialDetails/TrialInfoBox.tsx
+++ b/webui/react/src/pages/TrialDetails/TrialInfoBox.tsx
@@ -72,8 +72,8 @@ const TrialInfoBox: React.FC<Props> = ({ trial, experiment }: Props) => {
   const handleShowHParams = useCallback(() => setShowHParams(true), []);
   const handleHideHParams = useCallback(() => setShowHParams(false), []);
 
-  const workloadStatus: string = Object.entries(trial.workloads.last())
-    .find(e => !!e[1])?.first() || '';
+  const workloadStatus: string | undefined =
+    Object.entries(trial.workloads.last()).find(e => !!e[1])?.first();
 
   const infoRows = [
     {
@@ -93,9 +93,8 @@ const TrialInfoBox: React.FC<Props> = ({ trial, experiment }: Props) => {
       label: 'Durations',
     },
     {
-      content: trial.state === 'ACTIVE' &&
-      `${capitalize(workloadStatus)}
-      on batch ${trial.totalBatchesProcessed}`,
+      content: (trial.state === 'ACTIVE' && workloadStatus !== undefined) &&
+      `${capitalize(workloadStatus)} on batch ${trial.totalBatchesProcessed}`,
       label: 'Current Workload',
     },
     {

--- a/webui/react/src/pages/TrialDetails/TrialInfoBox.tsx
+++ b/webui/react/src/pages/TrialDetails/TrialInfoBox.tsx
@@ -11,7 +11,7 @@ import {
 } from 'types';
 import { isObject } from 'utils/data';
 import { formatDatetime } from 'utils/date';
-import { humanReadableBytes } from 'utils/string';
+import { humanReadableBytes, capitalize } from 'utils/string';
 import { shortEnglishHumannizer } from 'utils/time';
 import { trialDurations } from 'utils/trial';
 import { checkpointSize } from 'utils/types';
@@ -93,7 +93,7 @@ const TrialInfoBox: React.FC<Props> = ({ trial, experiment }: Props) => {
     },
     {
       content: trial.state === 'ACTIVE' &&
-      `${workloadStatus[0].toUpperCase() + workloadStatus.slice(1)}
+      `${capitalize(workloadStatus)}
       on batch ${trial.totalBatchesProcessed}`,
       label: 'Workload Status',
     },

--- a/webui/react/src/pages/TrialDetails/TrialInfoBox.tsx
+++ b/webui/react/src/pages/TrialDetails/TrialInfoBox.tsx
@@ -90,6 +90,12 @@ const TrialInfoBox: React.FC<Props> = ({ trial, experiment }: Props) => {
       label: 'Durations',
     },
     {
+      content: trial.state === 'ACTIVE' &&
+      `${Object.entries(trial.workloads.last())
+        .find(entry => !!entry[1])?.first()} on batch ${trial.totalBatchesProcessed}`,
+      label: 'Workload Status',
+    },
+    {
       content: bestValidation &&
         <>
           <HumanReadableFloat num={bestValidation} /> {`(${experiment.config.searcher.metric})`}

--- a/webui/react/src/pages/TrialDetails/TrialInfoBox.tsx
+++ b/webui/react/src/pages/TrialDetails/TrialInfoBox.tsx
@@ -11,7 +11,7 @@ import {
 } from 'types';
 import { isObject } from 'utils/data';
 import { formatDatetime } from 'utils/date';
-import { humanReadableBytes, capitalize } from 'utils/string';
+import { capitalize, humanReadableBytes } from 'utils/string';
 import { shortEnglishHumannizer } from 'utils/time';
 import { trialDurations } from 'utils/trial';
 import { checkpointSize } from 'utils/types';
@@ -72,7 +72,8 @@ const TrialInfoBox: React.FC<Props> = ({ trial, experiment }: Props) => {
   const handleShowHParams = useCallback(() => setShowHParams(true), []);
   const handleHideHParams = useCallback(() => setShowHParams(false), []);
 
-  const workloadStatus: string = Object.entries(trial.workloads.last()).find(e => !!e[1])?.first() || '';
+  const workloadStatus: string = Object.entries(trial.workloads.last())
+    .find(e => !!e[1])?.first() || '';
 
   const infoRows = [
     {

--- a/webui/react/src/pages/TrialDetails/TrialInfoBox.tsx
+++ b/webui/react/src/pages/TrialDetails/TrialInfoBox.tsx
@@ -72,7 +72,7 @@ const TrialInfoBox: React.FC<Props> = ({ trial, experiment }: Props) => {
   const handleShowHParams = useCallback(() => setShowHParams(true), []);
   const handleHideHParams = useCallback(() => setShowHParams(false), []);
 
-  const workloadStatus: string = Object.entries(trial.workloads.last()).find(e => !!e[1])?.first();
+  const workloadStatus: string = Object.entries(trial.workloads.last()).find(e => !!e[1])?.first() || '';
 
   const infoRows = [
     {


### PR DESCRIPTION
## Description
Add an entry to the Trial Summary telling the user the current workload status
<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan
Tested manually while running experiment.

<img src="https://user-images.githubusercontent.com/15078396/117844630-74fa9980-b245-11eb-9b78-50b255c9fae0.png" width="300" />
<img src="https://user-images.githubusercontent.com/15078396/117844641-775cf380-b245-11eb-9053-b76f98517b39.png" width="300" />

<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.
-->

[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234