### PR TITLE
chore: Add output printing to debug flaky test

### DIFF
--- a/e2e_tests/tests/command/test_run.py
+++ b/e2e_tests/tests/command/test_run.py
@@ -40,7 +40,7 @@ def _run_and_verify_exit_code_zero(args: List[str], **kwargs: Any) -> None:
     """Wraps subprocess.check_output and verifies a successful exit code."""
     # TODO(#2903): remove this once exit status are propagated through cli
     output = subprocess.check_output(args, **kwargs)
-    assert re.search(b"command exited successfully", output) is not None
+    assert re.search(b"command exited successfully", output) is not None, f"Output is: {output.decode("utf-8")}"
 
 
 def _run_and_verify_failure(args: List[str], message: str, **kwargs: Any) -> None:

--- a/e2e_tests/tests/command/test_run.py
+++ b/e2e_tests/tests/command/test_run.py
@@ -40,7 +40,9 @@ def _run_and_verify_exit_code_zero(args: List[str], **kwargs: Any) -> None:
     """Wraps subprocess.check_output and verifies a successful exit code."""
     # TODO(#2903): remove this once exit status are propagated through cli
     output = subprocess.check_output(args, **kwargs)
-    assert re.search(b"command exited successfully", output) is not None, f"Output is: {output.decode("utf-8")}"
+    assert re.search(b"command exited successfully", output) is not None, "Output is: {}".format(
+        output.decode("utf-8")
+    )
 
 
 def _run_and_verify_failure(args: List[str], message: str, **kwargs: Any) -> None:


### PR DESCRIPTION
## Description
Add printing of output in `_run_and_verify_exit_code_zero` to be able to see why `test_relative_bind_mount` flakes.

<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234