### PR TITLE
fix: hide expected network errors when nodes are terminated [DET-4822]

### DIFF
--- a/master/pkg/actor/api/ws.go
+++ b/master/pkg/actor/api/ws.go
@@ -171,7 +171,8 @@ func (s *websocketActor) processWriteMessage(
 }
 
 func isClosingError(err error) bool {
-	return err == websocket.ErrCloseSent || websocket.IsCloseError(err, websocket.CloseNormalClosure)
+	return err == websocket.ErrCloseSent ||
+		websocket.IsCloseError(err, websocket.CloseNormalClosure, websocket.CloseAbnormalClosure)
 }
 
 func (s *websocketActor) setupPingLoop(ctx *actor.Context) {


### PR DESCRIPTION
## Description

An "abnormal" closure is actually exactly what the websockets library returns in the case where an idle node is being scaled down. Simply including this closure in IsClosureError() prevents this very routine case from spamming multiple lines into the error logging.

## Test Plan

Tested scale-down on a cluster - logs are much cleaner but do indicate the time at which a node is scaled down (so we can differentiate this case from any actual abnormal failures that would happen).