### PR TITLE
chore: fixes eslint error

### DIFF
--- a/webui/react/.eslintrc.js
+++ b/webui/react/.eslintrc.js
@@ -105,6 +105,7 @@ module.exports = {
   },
   settings: {
     'import/resolver': { typescript: {} }, // This loads <rootdir>/tsconfig.json to eslint
+    'jest': { version: 'detect' },
     'react': { version: 'detect' },
   },
 };


### PR DESCRIPTION
## Description
While setting up eslint, I received the following error:
```
ESLint: Error while loading rule 'jest/no-deprecated-functions': Unable to detect Jest version - please ensure jest package is installed, or otherwise set version explicitly
```
Making this change to eslintrc.js fixes this error and allows eslint to function correctly.
<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->

[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234