### PR TITLE
chore: fix bumpversion config not properly bumping setup.py files

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -32,8 +32,6 @@ values =
 
 [bumpversion:file:model_hub/model_hub/__version__.py]
 
-[bumpversion:file:model_hub/setup.py]
-
 [bumpversion:file:model_hub/examples/huggingface/token-classification/ner_config.yaml]
 
 [bumpversion:file:model_hub/examples/huggingface/language-modeling/clm_config.yaml]


### PR DESCRIPTION
## Description

<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan

I tested using `bumpversion patch` and confirmed that `setup.py`s were properly bumped.

## Commentary (optional)

This line is redundant b/c a few lines above already bumps all `*/setup.py` files.

## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234