### PR TITLE
chore: disable eslint for storybook

### DIFF
--- a/webui/react/package.json
+++ b/webui/react/package.json
@@ -12,7 +12,7 @@
     "test": "react-app-rewired test",
     "eject": "react-scripts eject",
     "analyze": "source-map-explorer 'build/static/js/*.js'",
-    "storybook": "NODE_PATH=src start-storybook -p 9009 -s public",
+    "storybook": "DISABLE_ESLINT_PLUGIN=true NODE_PATH=src start-storybook -p 9009 -s public",
     "build-storybook": "NODE_PATH=src build-storybook -s public -o build-storybook"
   },
   "dependencies": {


### PR DESCRIPTION
## Description
Our configuration of eslint and storybook's disagree on formatting. This disables storybook's version in order to resolve that disagreement.
<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->

[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234