### PR TITLE
chore: add zmq-based IPC to the DistributedContext [DET-5484]

### DIFF
--- a/harness/determined/_trial_controller.py
+++ b/harness/determined/_trial_controller.py
@@ -4,7 +4,7 @@ import pathlib
 from typing import Any, Dict, List, Optional, cast
 
 import determined as det
-from determined import constants, horovod, ipc, workload
+from determined import horovod, workload
 from determined._rendezvous_info import RendezvousInfo
 from determined.common import check
 from determined.common.types import StepID
@@ -237,10 +237,10 @@ class LoopTrialController(TrialController):
 
         if self.hvd_config.use:
             self.is_chief = hvd.rank() == 0
-            training_process_rank = hvd.local_rank()
+            rank = hvd.rank()
         else:
             self.is_chief = True
-            training_process_rank = 0
+            rank = 0
 
         if self.hvd_config.use and not self.is_chief:
             log_level = (
@@ -249,82 +249,5 @@ class LoopTrialController(TrialController):
             logging.getLogger().setLevel(log_level)
 
         logging.debug(
-            f"Training coordination initialized on local rank {training_process_rank}, "
-            f"using hvd: {self.hvd_config.use}."
+            f"TrialController initialized on rank {rank}, using hvd: {self.hvd_config.use}."
         )
-
-        # Initialize communication directly between training processes.
-        self.train_process_comm_chief = None  # type: Optional[ipc.ZMQBroadcastServer]
-        self.train_process_comm_worker = None  # type: Optional[ipc.ZMQBroadcastClient]
-        if self.hvd_config.use:
-            self._initialize_train_process_comm()
-
-    def _initialize_train_process_comm(self) -> None:
-        check.true(self.hvd_config.use)
-
-        srv_pub_port = (
-            constants.INTER_TRAIN_PROCESS_COMM_PORT_1 + self.env.det_trial_unique_port_offset
-        )
-        srv_pull_port = (
-            constants.INTER_TRAIN_PROCESS_COMM_PORT_2 + self.env.det_trial_unique_port_offset
-        )
-
-        if self.is_chief:
-            logging.debug(f"Chief setting up server with ports {srv_pub_port}/{srv_pull_port}.")
-            self.train_process_comm_chief = ipc.ZMQBroadcastServer(
-                num_connections=self.env.experiment_config.slots_per_trial() - 1,
-                pub_port=srv_pub_port,
-                pull_port=srv_pull_port,
-            )
-        else:
-            chief_ip_address = self.rendezvous_info.get_ip_addresses()[0]
-            logging.debug(
-                f"Non-Chief {hvd.rank()} setting up comm to "
-                f"{chief_ip_address} w/ ports "
-                f"{srv_pub_port}/{srv_pull_port}."
-            )
-            self.train_process_comm_worker = ipc.ZMQBroadcastClient(
-                srv_pub_url=f"tcp://{chief_ip_address}:{srv_pub_port}",
-                srv_pull_url=f"tcp://{chief_ip_address}:{srv_pull_port}",
-            )
-
-    def _global_barrier(self) -> None:
-        # Executes a barrier by communicating directly between worker processes via ZMQ.
-        logging.debug(f"Worker {self.context.distributed.get_rank()} entering global barrier.")
-        if self.is_chief:
-            self.train_process_comm_chief = cast(
-                ipc.ZMQBroadcastServer, self.train_process_comm_chief
-            )
-            self.train_process_comm_chief.gather_with_polling(lambda: None)
-            self.train_process_comm_chief.broadcast(None)
-        else:
-            self.train_process_comm_worker = cast(
-                ipc.ZMQBroadcastClient, self.train_process_comm_worker
-            )
-            self.train_process_comm_worker.send([None])
-            # Synchronize with the chief so that there is no risk of accidentally calling send()
-            # for a future gather before all workers have called send() on this gather.
-            _ = self.train_process_comm_worker.recv()
-        logging.debug(f"Worker {self.context.distributed.get_rank()} exiting global barrier.")
-
-    def allgather_metrics(self, metrics: Any) -> List:
-        if not self.hvd_config.use:
-            return [metrics]
-
-        if self.is_chief:
-            self.train_process_comm_chief = cast(
-                ipc.ZMQBroadcastServer, self.train_process_comm_chief
-            )
-            logging.debug(f"Chief {hvd.rank()} beginning allgathering metrics.")
-            worker_stuff, _ = self.train_process_comm_chief.gather_with_polling(lambda: None)
-            logging.debug(f"Chief {hvd.rank()} done allgathering metrics.")
-            all_metrics = [metrics, *worker_stuff]
-            self.train_process_comm_chief.broadcast(all_metrics)
-            return all_metrics
-        else:
-            self.train_process_comm_worker = cast(
-                ipc.ZMQBroadcastClient, self.train_process_comm_worker
-            )
-            logging.debug(f"Worker {hvd.rank()} allgathering metrics.")
-            self.train_process_comm_worker.send(metrics)
-            return self.train_process_comm_worker.recv()  # type: ignore

--- a/harness/determined/cli/experiment.py
+++ b/harness/determined/cli/experiment.py
@@ -174,7 +174,7 @@ def local_experiment(args: Namespace) -> None:
     determined.common.set_logger(bool(experiment_config.get("debug", False)))
 
     with det._local_execution_manager(args.model_def.resolve()):
-        trial_class = load.load_trial_implementation(experiment_config["entrypoint"])
+        trial_class = load.trial_class_from_entrypoint(experiment_config["entrypoint"])
         experimental.test_one_batch(trial_class=trial_class, config=experiment_config)
 
 

--- a/harness/determined/estimator/_reducer.py
+++ b/harness/determined/estimator/_reducer.py
@@ -117,20 +117,13 @@ class _SimpleMetricReducer(MetricReducer):
         return self.reduce_fn(flat_metrics)
 
 
-def default_allgather_fn(metrics: Any) -> List:
-    """
-    A noop allgather implementation to ensure that custom reducers work outside of Determined.
-    """
-    return [metrics]
-
-
 class _EstimatorReducerContext:
     """
     Context class that contains only the reducer-related information.
     """
 
-    def __init__(self) -> None:
-        self._allgather_fn = default_allgather_fn  # type: Callable[[Any], List]
+    def __init__(self, allgather_fn: Callable[[Any], List[Any]]) -> None:
+        self._allgather_fn = allgather_fn
         # allgather is not parallelizable, so we have to strictly order how they are placed in the
         # graph via tf.control_dependencies().
         self._allgather_ops = []  # type: List[tf.Operation]

--- a/harness/determined/ipc.py
+++ b/harness/determined/ipc.py
@@ -1,5 +1,5 @@
 import time
-from typing import Any, Callable, Dict, List, Optional, Tuple, cast
+from typing import Any, Callable, List, Optional, Tuple, cast
 
 import zmq
 from zmq.error import ZMQBindError, ZMQError
@@ -17,17 +17,6 @@ class _OneSidedBarrier:
 
     def __init__(self, message: Any) -> None:
         self.message = message
-
-
-class MetricsInfo:
-    """
-    MetricsInfo contains validation metrics and the number of batches used to generate those
-    metrics. Used to communicate metrics between training processes.
-    """
-
-    def __init__(self, metrics: Dict[str, Any], num_batches: int):
-        self.metrics = metrics
-        self.num_batches = num_batches
 
 
 class ConnectedMessage:

--- a/harness/determined/keras/_tf_keras_context.py
+++ b/harness/determined/keras/_tf_keras_context.py
@@ -380,8 +380,13 @@ class TFKerasContext:
 
 
 class TFKerasTrialContext(det.TrialContext, TFKerasContext):
-    def __init__(self, env: det.EnvContext, hvd_config: horovod.HorovodContext) -> None:
-        det.TrialContext.__init__(self, env, hvd_config)
+    def __init__(
+        self,
+        env: det.EnvContext,
+        hvd_config: horovod.HorovodContext,
+        rendezvous_info: det.RendezvousInfo,
+    ) -> None:
+        det.TrialContext.__init__(self, env, hvd_config, rendezvous_info)
         TFKerasContext.__init__(self, env, hvd_config)
 
     def wrap_model(self, model: Any) -> Any:
@@ -401,8 +406,13 @@ class TFKerasTrialContext(det.TrialContext, TFKerasContext):
 
 
 class TFKerasNativeContext(det.NativeContext, TFKerasContext):
-    def __init__(self, env: det.EnvContext, hvd_config: horovod.HorovodContext):
-        det.NativeContext.__init__(self, env, hvd_config)
+    def __init__(
+        self,
+        env: det.EnvContext,
+        hvd_config: horovod.HorovodContext,
+        rendezvous_info: det.RendezvousInfo,
+    ) -> None:
+        det.NativeContext.__init__(self, env, hvd_config, rendezvous_info)
         TFKerasContext.__init__(self, env, hvd_config)
 
     def wrap_model(self, model: Any) -> Any:

--- a/harness/determined/keras/_tf_keras_trial.py
+++ b/harness/determined/keras/_tf_keras_trial.py
@@ -931,7 +931,7 @@ class TFKerasTrialController(det.LoopTrialController):
             # Use a global ZMQ barrier here because we have observed cases where hvd.allreduce
             # may hang when called minutes apart by different workers which may happen if
             # workers complete evaluation at different speeds.
-            self._global_barrier()
+            _ = self.context.distributed._zmq_gather(None)
 
             num_inputs = hvd.allreduce(num_inputs, average=False, name="validation_num_inputs")
             if isinstance(num_inputs, EagerTensor):

--- a/harness/determined/load/__init__.py
+++ b/harness/determined/load/__init__.py
@@ -1,7 +1,7 @@
 from determined.load._load_implementation import (
     RunpyGlobals,
     load_native_implementation,
-    load_trial_implementation,
+    trial_class_from_entrypoint,
 )
 from determined.load._load_trial_controller import (
     load_native_implementation_controller,

--- a/harness/determined/load/_load_trial_controller.py
+++ b/harness/determined/load/_load_trial_controller.py
@@ -32,7 +32,7 @@ def load_controller_from_trial(
 
     # Step 2: Initialize framework-specific details (horovod, random seeds, etc).
     controller_class.pre_execute_hook(env, hvd_config)
-    trial_context = trial_class.trial_context_class(env, hvd_config)
+    trial_context = trial_class.trial_context_class(env, hvd_config, rendezvous_info)
 
     # Step 3: Instantiate the user's Trial.
     trial_inst = trial_class(trial_context)
@@ -57,7 +57,7 @@ def load_trial_implementation_controller(
     rendezvous_info: det.RendezvousInfo,
     hvd_config: horovod.HorovodContext,
 ) -> det.TrialController:
-    trial_class = load.load_trial_implementation(env.experiment_config["entrypoint"])
+    trial_class = load.trial_class_from_entrypoint(env.experiment_config["entrypoint"])
     return load_controller_from_trial(
         trial_class=trial_class,
         env=env,
@@ -81,7 +81,9 @@ def load_native_implementation_controller(
         f"configuration: {env.experiment_config}",
     )
 
-    context, trial_class, controller_class = load.load_native_implementation(env, hvd_config)
+    context, trial_class, controller_class = load.load_native_implementation(
+        env, hvd_config, rendezvous_info
+    )
 
     if trial_class is not None:
         return load_controller_from_trial(

--- a/harness/determined/pytorch/_pytorch_context.py
+++ b/harness/determined/pytorch/_pytorch_context.py
@@ -48,7 +48,7 @@ class PyTorchTrialContext(det.TrialContext, pytorch._PyTorchReducerContext):
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         det.TrialContext.__init__(self, *args, **kwargs)
-        pytorch._PyTorchReducerContext.__init__(self)
+        pytorch._PyTorchReducerContext.__init__(self, self.distributed._zmq_allgather)
 
         self._init_device()
 

--- a/harness/determined/pytorch/_reducer.py
+++ b/harness/determined/pytorch/_reducer.py
@@ -256,12 +256,9 @@ class _PyTorchReducerContext:
     case we would rename it with a public name first.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, allgather_fn: Callable[[Any], List[Any]] = default_allgather_fn) -> None:
         self._wrapped_reducers = []  # type: List[_WrappedReducer]
-        self._allgather_fn = default_allgather_fn
-
-    def _set_allgather_fn(self, fn: Callable) -> None:
-        self._allgather_fn = fn
+        self._allgather_fn = allgather_fn
 
     def reset_reducers(self) -> None:
         for wrapped in self._wrapped_reducers:


### PR DESCRIPTION
This is part of a multi-step process to refactor the harness code in
favor of push architecture:

Goal:

*    Introduce Python WorkloadSequencer that uses Push Architecture.

That can't happen until:

*    The WorkloadManager is broken into simple function calls for
    mutating workload responses.  These simple functions (one after each
    of training, validation, and checkpointing) can be called right
    before making calls to the push API, rather than after responding
    with a workload.Response on a stream of workloads.

That can't happen until:

*    The StorageManager is no longer a part of the WorkloadManager.  The
    StorageManager is the only part of the WorkloadManager that doesn't
    fit neatly into the aforementioned three function calls, since
    storage_mgr.store_path() is a contextmanager.  However, if the
    TrialController were responsible for the StorageManager rather than
    the WorkloadManager, the extra `args: List[Any]` parameter in the
    workload stream would disappear.

Now, it would be nice to package all of that functionality on a
GenericContext of some sort, in preparation for the eventual Generic
API.  It makes sense that the GenericContext would be the place that all
metrics and checkpoint reporting would go through, so that would be the
place where after_training(), after_validation(), and
after_checkpointing() would each be called.  It also makes sense that
the GenericContext would expose the StorageManager to user code.

But nothing can be packaged into the GenericContext until the
GenericContext has ZMQ communications.  For example, a
GenericContext.maybe_load_checkpoint() can't function without
cross-worker synchronization; only the local_rank=0 worker each compute
node should actually load the checkpoint, and the other workers must
wait.

We have all of the tools for ZMQ communication in the harness, and we
even have the ports allocated for it.  But they have always been
attached to the TrialController, rather than the DistributedContext.
That is because right after the refactor, I believed/enforced that the
Context objects were purely for light-weight API call exposures and
didn't have any beefy logic in them.  However, PyTorchContext has proven
that putting logic in the Context object is actually a great strategy,
and the upcoming Generic API is really just the logical conclusion of
that realization.

So as a first step, the ownership of the ZMQ sockets is passing to the
DistributedContext (which will eventually be a member of the
GenericContext).