### PR TITLE
fix: `det deploy gcp` support for terraform 0.15 [DET-5449]

### DIFF
--- a/docs/release-notes/2376-fix-gcp-terraform.txt
+++ b/docs/release-notes/2376-fix-gcp-terraform.txt
@@ -1,0 +1,5 @@
+:orphan:
+
+**Bug Fixes**
+
+-  Deploy: Add support for ``terraform`` 0.15 in ``det deploy gcp``.

--- a/harness/determined/deploy/gcp/gcp.py
+++ b/harness/determined/deploy/gcp/gcp.py
@@ -96,42 +96,35 @@ def terraform_init(configs: Dict, env: Dict) -> None:
         terraform_dir(configs),
     )
 
-    command = ["terraform init"]
+    command = ["terraform", "init"]
     command += [
-        "-backend-config='path={}'".format(
+        "-backend-config=path={}".format(
             os.path.join(configs["local_state_path"], "terraform.tfstate")
         )
     ]
 
-    command += [terraform_dir(configs)]
-
-    output = subprocess.Popen(" ".join(command), env=env, shell=True, stdout=sys.stdout)
-    output.wait()
+    run_command(command, env, cwd=terraform_dir(configs))
 
 
 def terraform_plan(configs: Dict, env: Dict, variables_to_exclude: List) -> None:
     vars_file_path = terraform_write_variables(configs, variables_to_exclude)
 
     command = ["terraform", "plan"]
-
     command += ["-input=false"]
     command += [f"-var-file={vars_file_path}"]
-    command += [terraform_dir(configs)]
 
-    run_command(" ".join(command), env)
+    run_command(command, env, cwd=terraform_dir(configs))
 
 
 def terraform_apply(configs: Dict, env: Dict, variables_to_exclude: List) -> None:
     vars_file_path = terraform_write_variables(configs, variables_to_exclude)
 
     command = ["terraform", "apply"]
-
     command += ["-input=false"]
     command += ["-auto-approve"]
     command += [f"-var-file={vars_file_path}"]
-    command += [terraform_dir(configs)]
 
-    run_command(" ".join(command), env)
+    run_command(command, env, cwd=terraform_dir(configs))
 
 
 def terraform_output(configs: Dict, env: Dict, variable_name: str) -> Any:
@@ -286,13 +279,12 @@ def delete(configs: Dict, env: Dict) -> None:
     command += ["-input=false"]
     command += ["-auto-approve"]
     command += [f"-var-file={vars_file_path}"]
-    command += [terraform_dir(configs)]
 
-    run_command(" ".join(command), env)
+    run_command(command, env, cwd=terraform_dir(configs))
 
 
-def run_command(command: str, env: Dict[str, str]) -> None:
-    subprocess.check_call(command, env=env, shell=True, stdout=sys.stdout)
+def run_command(command: List[str], env: Dict[str, str], cwd: Optional[str] = None) -> None:
+    subprocess.check_call(command, env=env, stdout=sys.stdout, cwd=cwd)
 
 
 def validate_gcp_credentials(configs: Dict) -> None:


### PR DESCRIPTION
## Description
Terraform 0.15 [doesn't support](https://www.terraform.io/docs/cli/commands/plan.html#passing-a-different-configuration-directory) passing the config directory as the last argument anymore; they suggest using -chdir instead, but that doesn't work in older terraform (e.g. 0.13). Since we explicitly specify the tfstate path anyway, change the subprocess `cwd` instead.

Also, remove `shell=True`. Now the users will be able to have directory names with spaces in them.

## Test Plan
Tested with Terraform 0.13 and 0.15.

## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
