### PR TITLE
chore: close agents on websocket closures

### DIFF
--- a/master/internal/agent/agent.go
+++ b/master/internal/agent/agent.go
@@ -109,8 +109,10 @@ func (a *agent) Receive(ctx *actor.Context) error {
 		a.handleAPIRequest(ctx, msg)
 	case actor.ChildFailed:
 		telemetry.ReportAgentDisconnected(ctx.Self().System(), a.uuid)
-
 		return errors.Wrapf(msg.Error, "child failed: %s", msg.Child.Address())
+	case actor.ChildStopped:
+		telemetry.ReportAgentDisconnected(ctx.Self().System(), a.uuid)
+		ctx.Self().Stop()
 	case actor.PostStop:
 		ctx.Log().Infof("agent disconnected")
 		for cid := range a.containers {


### PR DESCRIPTION
## Description
This change updates the agent tracking code in the master to terminate when the websocket actor closes.
<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan
- [x] make sure agent exits disconnect agents
- [x] check other websockets to make sure they do not depend on this pattern
<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)
Prior to https://github.com/determined-ai/determined/pull/2351 it seems the agent actor in the master relied on the websocket actor propogating `actor.ChildFailed` up to it to detect exits and mark agents as terminated. #2351 changed this to swallow abnormal websocket closures.

This fix is still subpar, any _real_ agent abnormal websocket closures are now swallowed, not logged and essentially invisible (though _i've_ never seen one that matter, but that could be because of the noise). I think just a revert of #2351 may be more correct than this (and the _most_ correct thing is probably a heck of a lot of work).
<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234