### PR TITLE
chore: unrevert and fix "actually use expconf in the master"

### DIFF
--- a/agent/go.sum
+++ b/agent/go.sum
@@ -730,6 +730,7 @@ github.com/ryancurrah/gomodguard v1.1.0/go.mod h1:4O8tr7hBODaGE6VIhfJDHcwzh5GUcc
 github.com/ryanrolds/sqlclosecheck v0.3.0 h1:AZx+Bixh8zdUBxUA1NxbxVAS78vTPq4rCb8OUZI9xFw=
 github.com/ryanrolds/sqlclosecheck v0.3.0/go.mod h1:1gREqxyTGR3lVtpngyFo3hZAgk0KCtEdgEkHwDbigdA=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
+github.com/santhosh-tekuri/jsonschema/v2 v2.2.0 h1:72xCpK0g27Y1is2lreGNcZhIX3ZCtRpkHvvHrHD+5y4=
 github.com/santhosh-tekuri/jsonschema/v2 v2.2.0/go.mod h1:yzJzKUGV4RbWqWIBBP4wSOBqavX5saE02yirLS0OTyg=
 github.com/sassoftware/go-rpmutils v0.0.0-20190420191620-a8f1baeba37b h1:+gCnWOZV8Z/8jehJ2CdqB47Z3S+SREmQcuXkRFLNsiI=
 github.com/sassoftware/go-rpmutils v0.0.0-20190420191620-a8f1baeba37b/go.mod h1:am+Fp8Bt506lA3Rk3QCmSqmYmLMnPDhdDUcosQCAx+I=

--- a/harness/determined/common/schemas/expconf/_v0.py
+++ b/harness/determined/common/schemas/expconf/_v0.py
@@ -292,6 +292,10 @@ class RegistryAuthConfigV0(schemas.SchemaBase):
     ) -> None:
         pass
 
+    def to_dict(self, explicit_nones: bool = False) -> Any:
+        # Match go's docker library's omitempty behavior.
+        return super().to_dict(explicit_nones=False)
+
 
 class EnvironmentConfigV0(schemas.SchemaBase):
     _id = "http://determined.ai/schemas/expconf/v0/environment.json"

--- a/master/cmd/determined-master/root_test.go
+++ b/master/cmd/determined-master/root_test.go
@@ -13,6 +13,8 @@ import (
 	"github.com/determined-ai/determined/master/internal/provisioner"
 	"github.com/determined-ai/determined/master/internal/resourcemanagers"
 	"github.com/determined-ai/determined/master/pkg/model"
+	"github.com/determined-ai/determined/master/pkg/schemas"
+	"github.com/determined-ai/determined/master/pkg/schemas/expconf"
 )
 
 func TestUnmarshalMasterConfigurationViaViper(t *testing.T) {
@@ -99,12 +101,9 @@ func TestUnmarshalMasterConfiguration(t *testing.T) {
 	config, err := getConfig(v.AllSettings())
 	assert.NilError(t, err)
 
-	c, err := config.CheckpointStorage.ToModel()
-	if err != nil {
-		t.Fatal(err)
-	}
+	c := schemas.WithDefaults(config.CheckpointStorage).(expconf.CheckpointStorageConfig)
 
-	if f := c.SaveTrialBest; f <= 0 {
+	if f := c.SaveTrialBest(); f <= 0 {
 		t.Errorf("SaveTrialBest %d <= 0", f)
 	}
 }

--- a/master/internal/api_experiment.go
+++ b/master/internal/api_experiment.go
@@ -24,9 +24,10 @@ import (
 	"github.com/determined-ai/determined/master/internal/hpimportance"
 	"github.com/determined-ai/determined/master/internal/lttb"
 	"github.com/determined-ai/determined/master/pkg/actor"
-	"github.com/determined-ai/determined/master/pkg/check"
 	"github.com/determined-ai/determined/master/pkg/model"
 	"github.com/determined-ai/determined/master/pkg/protoutils"
+	"github.com/determined-ai/determined/master/pkg/schemas"
+	"github.com/determined-ai/determined/master/pkg/schemas/expconf"
 	"github.com/determined-ai/determined/master/pkg/searcher"
 	"github.com/determined-ai/determined/proto/pkg/apiv1"
 	"github.com/determined-ai/determined/proto/pkg/checkpointv1"
@@ -112,9 +113,12 @@ func (a *apiServer) DeleteExperiment(
 		agentUserGroup = &a.m.config.Security.DefaultTask
 	}
 
-	exp.Config.CheckpointStorage.SaveExperimentBest = 0
-	exp.Config.CheckpointStorage.SaveTrialBest = 0
-	exp.Config.CheckpointStorage.SaveTrialLatest = 0
+	storage := exp.Config.CheckpointStorage()
+	storage.SetSaveExperimentBest(0)
+	storage.SetSaveTrialBest(0)
+	storage.SetSaveTrialLatest(0)
+	exp.Config.SetCheckpointStorage(storage)
+
 	if sErr := a.m.db.SaveExperimentConfig(exp); sErr != nil {
 		return nil, errors.Wrapf(sErr, "failed to patch experiment checkpoint storage")
 	}
@@ -254,17 +258,41 @@ func (a *apiServer) PreviewHPSearch(
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "error parsing experiment config: %s", err)
 	}
-	config := model.DefaultExperimentConfig(&a.m.config.TaskContainerDefaults)
-	if err = json.Unmarshal(bytes, &config); err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, "error parsing experiment config: %s", err)
-	}
-	if err = check.Validate(config.Searcher); err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, "invalid experiment config: %s", err)
+
+	// Parse the provided experiment config.
+	config, err := expconf.ParseAnyExperimentConfigYAML(bytes)
+	if err != nil {
+		return nil, status.Errorf(
+			codes.InvalidArgument, "invalid experiment configuration: %s", err,
+		)
 	}
 
-	sm := searcher.NewSearchMethod(config.Searcher)
-	s := searcher.NewSearcher(req.Seed, sm, config.Hyperparameters)
-	sim, err := searcher.Simulate(s, nil, searcher.RandomValidation, true, config.Searcher.Metric)
+	// Get the useful subconfigs for preview search.
+	if config.RawSearcher == nil {
+		return nil, status.Errorf(
+			codes.InvalidArgument, "invalid experiment configuration; missing searcher",
+		)
+	}
+	sc := *config.RawSearcher
+	hc := config.RawHyperparameters
+
+	// Apply any json-schema-defined defaults.
+	sc = schemas.WithDefaults(sc).(expconf.SearcherConfig)
+	hc = schemas.WithDefaults(hc).(expconf.Hyperparameters)
+
+	// Make sure the searcher config has all eventuallyRequired fields.
+	if err = schemas.IsComplete(sc); err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid searcher configuration: %s", err)
+	}
+	if err = schemas.IsComplete(hc); err != nil {
+		return nil, status.Errorf(
+			codes.InvalidArgument, "invalid hyperparameters configuration: %s", err,
+		)
+	}
+
+	sm := searcher.NewSearchMethod(sc)
+	s := searcher.NewSearcher(req.Seed, sm, hc)
+	sim, err := searcher.Simulate(s, nil, searcher.RandomValidation, true, sc.Metric())
 	if err != nil {
 		return nil, err
 	}
@@ -272,7 +300,7 @@ func (a *apiServer) PreviewHPSearch(
 	indexes := make(map[string]int)
 	toProto := func(op searcher.ValidateAfter) ([]*experimentv1.RunnableOperation, error) {
 		switch op.Length.Unit {
-		case model.Records:
+		case expconf.Records:
 			return []*experimentv1.RunnableOperation{
 				{
 					Type: experimentv1.RunnableType_RUNNABLE_TYPE_VALIDATE,
@@ -285,7 +313,7 @@ func (a *apiServer) PreviewHPSearch(
 					Type: experimentv1.RunnableType_RUNNABLE_TYPE_VALIDATE,
 				},
 			}, nil
-		case model.Batches:
+		case expconf.Batches:
 			return []*experimentv1.RunnableOperation{
 				{
 					Type: experimentv1.RunnableType_RUNNABLE_TYPE_TRAIN,
@@ -298,7 +326,7 @@ func (a *apiServer) PreviewHPSearch(
 					Type: experimentv1.RunnableType_RUNNABLE_TYPE_VALIDATE,
 				},
 			}, nil
-		case model.Epochs:
+		case expconf.Epochs:
 			return []*experimentv1.RunnableOperation{
 				{
 					Type: experimentv1.RunnableType_RUNNABLE_TYPE_TRAIN,
@@ -624,7 +652,7 @@ func (a *apiServer) MetricNames(req *apiv1.MetricNamesRequest,
 		return errors.Wrapf(err,
 			"error fetching experiment config from database: %d", experimentID)
 	}
-	searcherMetric := config.Searcher.Metric
+	searcherMetric := config.Searcher().Metric()
 
 	seenTrain := make(map[string]bool)
 	seenValid := make(map[string]bool)
@@ -830,7 +858,7 @@ func (a *apiServer) TrialsSnapshot(req *apiv1.TrialsSnapshotRequest,
 	}
 }
 
-func (a *apiServer) topTrials(experimentID int, maxTrials int, s model.SearcherConfig) (
+func (a *apiServer) topTrials(experimentID int, maxTrials int, s expconf.SearcherConfig) (
 	trials []int32, err error) {
 	type Ranking int
 	const (
@@ -839,27 +867,27 @@ func (a *apiServer) topTrials(experimentID int, maxTrials int, s model.SearcherC
 	)
 	var ranking Ranking
 
-	switch {
-	case s.RandomConfig != nil:
+	switch s.GetUnionMember().(type) {
+	case expconf.RandomConfig:
 		ranking = ByMetricOfInterest
-	case s.GridConfig != nil:
+	case expconf.GridConfig:
 		ranking = ByMetricOfInterest
-	case s.AsyncHalvingConfig != nil:
+	case expconf.AsyncHalvingConfig:
 		ranking = ByTrainingLength
-	case s.AdaptiveASHAConfig != nil:
+	case expconf.AdaptiveASHAConfig:
 		ranking = ByTrainingLength
-	case s.SingleConfig != nil:
+	case expconf.SingleConfig:
 		return nil, errors.New("single-trial experiments are not supported for trial sampling")
-	case s.PBTConfig != nil:
+	case expconf.PBTConfig:
 		return nil, errors.New("population-based training not supported for trial sampling")
 	default:
 		return nil, errors.New("unable to detect a searcher algorithm for trial sampling")
 	}
 	switch ranking {
 	case ByMetricOfInterest:
-		return a.m.db.TopTrialsByMetric(experimentID, maxTrials, s.Metric, s.SmallerIsBetter)
+		return a.m.db.TopTrialsByMetric(experimentID, maxTrials, s.Metric(), s.SmallerIsBetter())
 	case ByTrainingLength:
-		return a.m.db.TopTrialsByTrainingLength(experimentID, maxTrials, s.Metric, s.SmallerIsBetter)
+		return a.m.db.TopTrialsByTrainingLength(experimentID, maxTrials, s.Metric(), s.SmallerIsBetter())
 	default:
 		panic("Invalid state in trial sampling")
 	}
@@ -956,7 +984,7 @@ func (a *apiServer) TrialsSample(req *apiv1.TrialsSampleRequest,
 	if err != nil {
 		return errors.Wrapf(err, "error fetching experiment config from database")
 	}
-	searcherConfig := config.Searcher
+	searcherConfig := config.Searcher()
 
 	trialCursors := make(map[int32]time.Time)
 	currentTrials := make(map[int32]bool)

--- a/master/internal/checkpoint_gc.go
+++ b/master/internal/checkpoint_gc.go
@@ -10,6 +10,7 @@ import (
 	"github.com/determined-ai/determined/master/pkg/actor"
 	"github.com/determined-ai/determined/master/pkg/container"
 	"github.com/determined-ai/determined/master/pkg/model"
+	"github.com/determined-ai/determined/master/pkg/ptrs"
 	"github.com/determined-ai/determined/master/pkg/tasks"
 )
 
@@ -47,10 +48,15 @@ func (t *checkpointGCTask) Receive(ctx *actor.Context) error {
 			return errors.Wrap(err, "cannot start a new task session for a GC task")
 		}
 
-		config := t.experiment.Config.CheckpointStorage
+		config := t.experiment.Config.CheckpointStorage()
 
-		checkpoints, err := t.db.ExperimentCheckpointsToGCRaw(t.experiment.ID,
-			&config.SaveExperimentBest, &config.SaveTrialBest, &config.SaveTrialLatest, true)
+		checkpoints, err := t.db.ExperimentCheckpointsToGCRaw(
+			t.experiment.ID,
+			ptrs.IntPtr(config.SaveExperimentBest()),
+			ptrs.IntPtr(config.SaveTrialBest()),
+			ptrs.IntPtr(config.SaveTrialLatest()),
+			true,
+		)
 		if err != nil {
 			return err
 		}

--- a/master/internal/config.go
+++ b/master/internal/config.go
@@ -1,7 +1,6 @@
 package internal
 
 import (
-	"bytes"
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
@@ -12,9 +11,9 @@ import (
 	"github.com/determined-ai/determined/master/internal/db"
 	"github.com/determined-ai/determined/master/internal/hpimportance"
 	"github.com/determined-ai/determined/master/internal/resourcemanagers"
-	"github.com/determined-ai/determined/master/pkg/check"
 	"github.com/determined-ai/determined/master/pkg/logger"
 	"github.com/determined-ai/determined/master/pkg/model"
+	"github.com/determined-ai/determined/master/pkg/schemas/expconf"
 )
 
 // These are package-level variables so that they can be set at link time.
@@ -25,12 +24,6 @@ var (
 
 // DefaultConfig returns the default configuration of the master.
 func DefaultConfig() *Config {
-	defaultExp := model.DefaultExperimentConfig(nil)
-	var c CheckpointStorageConfig
-	if err := c.FromModel(&defaultExp.CheckpointStorage); err != nil {
-		panic(err)
-	}
-
 	return &Config{
 		ConfigFile: "",
 		Log:        *logger.DefaultConfig(),
@@ -49,10 +42,9 @@ func DefaultConfig() *Config {
 			},
 		},
 		// If left unspecified, the port is later filled in with 8080 (no TLS) or 8443 (TLS).
-		Port:              0,
-		CheckpointStorage: c,
-		HarnessPath:       "/opt/determined",
-		Root:              "/usr/share/determined/master",
+		Port:        0,
+		HarnessPath: "/opt/determined",
+		Root:        "/usr/share/determined/master",
 		Telemetry: TelemetryConfig{
 			Enabled:          true,
 			SegmentMasterKey: DefaultSegmentMasterKey,
@@ -83,7 +75,7 @@ type Config struct {
 	DB                    db.Config                         `json:"db"`
 	TensorBoardTimeout    int                               `json:"tensorboard_timeout"`
 	Security              SecurityConfig                    `json:"security"`
-	CheckpointStorage     CheckpointStorageConfig           `json:"checkpoint_storage"`
+	CheckpointStorage     expconf.CheckpointStorageConfig   `json:"checkpoint_storage"`
 	TaskContainerDefaults model.TaskContainerDefaultsConfig `json:"task_container_defaults"`
 	Port                  int                               `json:"port"`
 	HarnessPath           string                            `json:"harness_path"`
@@ -104,11 +96,7 @@ func (c Config) Printable() ([]byte, error) {
 	c.Telemetry.SegmentMasterKey = hiddenValue
 	c.Telemetry.SegmentWebUIKey = hiddenValue
 
-	cs, err := c.CheckpointStorage.printable()
-	if err != nil {
-		return nil, errors.Wrap(err, "unable to convert checkpoint storage config to printable")
-	}
-	c.CheckpointStorage = cs
+	c.CheckpointStorage.Printable()
 
 	optJSON, err := json.Marshal(c)
 	if err != nil {
@@ -148,107 +136,6 @@ func (c *Config) Resolve() error {
 	}
 
 	return nil
-}
-
-// CheckpointStorageConfig defers the parsing of a
-// model.CheckpointStorageConfig. The global (master) CheckpointStorageConfig is
-// merged with the per-experiment config, so in general, validation cannot be
-// performed until the per-experiment config is known.
-type CheckpointStorageConfig []byte
-
-// Validate implements the check.Validatable interface.
-//
-// The actual CheckpointStorageConfig is not known until the global (master)
-// config is merged with the per-experiment config. Validate attempts to check
-// as many fields as possible without depending on the per-experiment config.
-func (c CheckpointStorageConfig) Validate() []error {
-	m, err := c.ToModel()
-
-	if err != nil {
-		return []error{
-			err,
-		}
-	}
-
-	// We cannot validate a SharedFSConfig until users have a chance to set
-	// host_path.
-	m.SharedFSConfig = nil
-
-	if err := check.Validate(m); err != nil {
-		return []error{
-			err,
-		}
-	}
-
-	return nil
-}
-
-func (c *CheckpointStorageConfig) printable() ([]byte, error) {
-	var hiddenValue = "********"
-	switch csm, err := c.ToModel(); {
-	case err != nil:
-		return nil, err
-	case csm.S3Config != nil:
-		csm.S3Config.AccessKey = &hiddenValue
-		csm.S3Config.SecretKey = &hiddenValue
-		return csm.MarshalJSON()
-	default:
-		return csm.MarshalJSON()
-	}
-}
-
-// FromModel initializes a CheckpointStorageConfig from the corresponding model.
-func (c *CheckpointStorageConfig) FromModel(m *model.CheckpointStorageConfig) error {
-	bs, err := json.Marshal(m)
-	if err != nil {
-		return err
-	}
-
-	*c = bs
-
-	return nil
-}
-
-// ToModel returns the model.CheckpointStorageConfig for the current config.
-func (c CheckpointStorageConfig) ToModel() (*model.CheckpointStorageConfig, error) {
-	var m model.CheckpointStorageConfig
-
-	if len(c) == 0 {
-		return &m, nil
-	}
-
-	dec := json.NewDecoder(bytes.NewReader(c))
-	dec.DisallowUnknownFields()
-
-	if err := dec.Decode(&m); err != nil {
-		return nil, errors.WithStack(err)
-	}
-
-	return &m, nil
-}
-
-// MarshalJSON implements the json.Marshaler interface.
-func (c CheckpointStorageConfig) MarshalJSON() ([]byte, error) {
-	return c, nil
-}
-
-// UnmarshalJSON implements the json.Unmarshaler interface.
-func (c *CheckpointStorageConfig) UnmarshalJSON(data []byte) error {
-	// Roundtrip through json.Unmarshal so that fields are updated elementwise,
-	// which would be the behavior if CheckpointStorageConfig were a pure
-	// struct. If we simply set *c = data, we would not preserve fields not
-	// mentioned by data.
-
-	m, err := c.ToModel()
-	if err != nil {
-		return errors.WithStack(err)
-	}
-
-	if err := json.Unmarshal(data, &m); err != nil {
-		return errors.WithStack(err)
-	}
-
-	return c.FromModel(m)
 }
 
 // SecurityConfig is the security configuration for the master.

--- a/master/internal/config_test.go
+++ b/master/internal/config_test.go
@@ -2,10 +2,8 @@ package internal
 
 import (
 	"fmt"
-	"strings"
 	"testing"
 	"time"
-	"unicode"
 
 	"github.com/ghodss/yaml"
 	"gotest.tools/assert"
@@ -15,6 +13,8 @@ import (
 	"github.com/determined-ai/determined/master/internal/resourcemanagers"
 	"github.com/determined-ai/determined/master/pkg/logger"
 	"github.com/determined-ai/determined/master/pkg/model"
+	"github.com/determined-ai/determined/master/pkg/ptrs"
+	"github.com/determined-ai/determined/master/pkg/schemas/expconf"
 	"github.com/determined-ai/determined/master/version"
 )
 
@@ -123,18 +123,6 @@ db:
 	assert.DeepEqual(t, unmarshaled, expected)
 }
 
-func removeAllWhitespace(s string) string {
-	var b strings.Builder
-	b.Grow(len(s))
-	for _, r := range s {
-		if unicode.IsSpace(r) {
-			continue
-		}
-		b.WriteRune(r)
-	}
-	return b.String()
-}
-
 func TestUnmarshalConfigWithExperiment(t *testing.T) {
 	raw := `
 log:
@@ -163,16 +151,13 @@ checkpoint_storage:
 			Host:     "hostname",
 			Port:     "3000",
 		},
-		CheckpointStorage: CheckpointStorageConfig(removeAllWhitespace(`
-{
-  "access_key": "my_key",
-  "bucket": "my_bucket",
-  "save_experiment_best": 0,
-  "save_trial_best": 0,
-  "save_trial_latest": 0,
-  "secret_key": "my_secret",
-  "type":"s3"
-}`)),
+		CheckpointStorage: expconf.CheckpointStorageConfig{
+			RawS3Config: &expconf.S3Config{
+				RawAccessKey: ptrs.StringPtr("my_key"),
+				RawBucket:    ptrs.StringPtr("my_bucket"),
+				RawSecretKey: ptrs.StringPtr("my_secret"),
+			},
+		},
 	}
 
 	var unmarshaled Config

--- a/master/internal/core.go
+++ b/master/internal/core.go
@@ -13,7 +13,6 @@ import (
 	"net/http/pprof"
 	"os"
 	"path/filepath"
-	"reflect"
 	"runtime"
 	"strconv"
 	"strings"
@@ -443,17 +442,11 @@ func closeWithErrCheck(name string, closer io.Closer) {
 func (m *Master) tryRestoreExperiment(sema chan struct{}, e *model.Experiment) {
 	sema <- struct{}{}
 	defer func() { <-sema }()
-	// Check if the returned config is the zero value, i.e. the config could not be parsed
-	// correctly. If the config could not be parsed, mark the experiment as errored.
-	if !reflect.DeepEqual(e.Config, model.ExperimentConfig{}) {
-		err := m.restoreExperiment(e)
-		if err == nil {
-			return
-		}
-		log.WithError(err).Errorf("failed to restore experiment: %d", e.ID)
-	} else {
-		log.Errorf("failed to parse experiment config: %d", e.ID)
+	err := m.restoreExperiment(e)
+	if err == nil {
+		return
 	}
+	log.WithError(err).Errorf("failed to restore experiment: %d", e.ID)
 	e.State = model.ErrorState
 	if err := m.db.TerminateExperimentInRestart(e.ID, e.State); err != nil {
 		log.WithError(err).Error("failed to mark experiment as errored")

--- a/master/internal/core_experiment.go
+++ b/master/internal/core_experiment.go
@@ -205,7 +205,7 @@ func (m *Master) getExperimentModelDefinition(c echo.Context) error {
 
 	// Make a Regex to remove everything but a whitelist of characters.
 	reg := regexp.MustCompile(`[^A-Za-z0-9_ \-()[\].{}]+`)
-	cleanDescription := reg.ReplaceAllString(expConfig.Description(), "")
+	cleanDescription := reg.ReplaceAllString(expConfig.Description().String(), "")
 
 	// Truncate description to a smaller size to both accommodate file name and path size
 	// limits on different platforms as well as get users more accustom to picking shorter
@@ -290,7 +290,9 @@ func (m *Master) patchExperiment(c echo.Context) (interface{}, error) {
 		dbExp.Config.SetResources(resources)
 	}
 	if patch.Description != nil {
-		dbExp.Config.SetDescription(*patch.Description)
+		description := dbExp.Config.Description()
+		description.SetString(*patch.Description)
+		dbExp.Config.SetDescription(description)
 	}
 	labels := dbExp.Config.Labels()
 	for label, keep := range patch.Labels {

--- a/master/internal/core_searcher.go
+++ b/master/internal/core_searcher.go
@@ -3,12 +3,12 @@ package internal
 import (
 	"io/ioutil"
 
-	"github.com/ghodss/yaml"
 	"github.com/labstack/echo/v4"
+	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 
-	"github.com/determined-ai/determined/master/pkg/check"
-	"github.com/determined-ai/determined/master/pkg/model"
+	"github.com/determined-ai/determined/master/pkg/schemas"
+	"github.com/determined-ai/determined/master/pkg/schemas/expconf"
 	"github.com/determined-ai/determined/master/pkg/searcher"
 )
 
@@ -17,17 +17,25 @@ func (m *Master) getSearcherPreview(c echo.Context) (interface{}, error) {
 	if err != nil {
 		return nil, err
 	}
-	config := model.DefaultExperimentConfig(&m.config.TaskContainerDefaults)
-	if uerr := yaml.Unmarshal(body, &config); uerr != nil {
-		return nil, uerr
-	}
-	if verr := check.Validate(config.Searcher); verr != nil {
-		return nil, verr
+
+	// Parse the provided experiment config.
+	config, err := expconf.ParseAnyExperimentConfigYAML(body)
+	if err != nil {
+		return nil, errors.Wrap(err, "invalid experiment configuration")
 	}
 
-	sm := searcher.NewSearchMethod(config.Searcher)
-	s := searcher.NewSearcher(0, sm, config.Hyperparameters)
-	return searcher.Simulate(s, nil, searcher.RandomValidation, true, config.Searcher.Metric)
+	// Apply any json-schema-defined defaults.
+	config = schemas.WithDefaults(config).(expconf.ExperimentConfig)
+
+	// Make sure the experiment config has all eventuallyRequired fields.
+	err = schemas.IsComplete(config)
+	if err != nil {
+		return nil, errors.Wrap(err, "invalid experiment configuration")
+	}
+
+	sm := searcher.NewSearchMethod(config.Searcher())
+	s := searcher.NewSearcher(0, sm, config.Hyperparameters())
+	return searcher.Simulate(s, nil, searcher.RandomValidation, true, config.Searcher().Metric())
 }
 
 // cleanUpExperimentSnapshots deletes all snapshots for terminal state experiments from

--- a/master/internal/experiment.go
+++ b/master/internal/experiment.go
@@ -113,20 +113,26 @@ func newExperiment(master *Master, expModel *model.Experiment, taskSpec *tasks.T
 	// Validate the ResourcePool setting.  The reason to do it now and not in postExperiment like
 	// all the other validations is that the resource pool should be revalidated every time the
 	// master restarts.
-	if err := sproto.ValidateRP(master.system, conf.Resources.ResourcePool); err != nil {
+	resources := conf.Resources()
+	poolName := resources.ResourcePool()
+	if err := sproto.ValidateRP(master.system, poolName); err != nil {
 		return nil, err
 	}
 	// If the resource pool isn't set, fill in the default.
-	if expModel.Config.Resources.ResourcePool == "" {
-		if expModel.Config.Resources.SlotsPerTrial == 0 {
-			expModel.Config.Resources.ResourcePool = sproto.GetDefaultCPUResourcePool(master.system)
+	if poolName == "" {
+		if resources.SlotsPerTrial() == 0 {
+			poolName = sproto.GetDefaultCPUResourcePool(master.system)
 		} else {
-			expModel.Config.Resources.ResourcePool = sproto.GetDefaultGPUResourcePool(master.system)
+			poolName = sproto.GetDefaultGPUResourcePool(master.system)
 		}
+		resources.SetResourcePool(poolName)
+		conf.SetResources(resources)
 	}
 
-	method := searcher.NewSearchMethod(conf.Searcher)
-	search := searcher.NewSearcher(conf.Reproducibility.ExperimentSeed, method, conf.Hyperparameters)
+	method := searcher.NewSearchMethod(conf.Searcher())
+	search := searcher.NewSearcher(
+		conf.Reproducibility().ExperimentSeed(), method, conf.Hyperparameters(),
+	)
 
 	// Call InitialOperations which adds operations to the record in the Searcher. These
 	// will be sent back to their respective trials in experiment prestart. This allows them to
@@ -138,7 +144,7 @@ func newExperiment(master *Master, expModel *model.Experiment, taskSpec *tasks.T
 
 	// Retrieve the warm start checkpoint, if provided.
 	checkpoint, err := checkpointFromTrialIDOrUUID(
-		master.db, conf.Searcher.SourceTrialID, conf.Searcher.SourceCheckpointUUID)
+		master.db, conf.Searcher().SourceTrialID(), conf.Searcher().SourceCheckpointUUID())
 	if err != nil {
 		return nil, err
 	}
@@ -193,12 +199,12 @@ func (e *experiment) Receive(ctx *actor.Context) error {
 		telemetry.ReportExperimentCreated(ctx.Self().System(), *e.Experiment)
 
 		ctx.Tell(e.rm, sproto.SetGroupMaxSlots{
-			MaxSlots: e.Config.Resources.MaxSlots,
+			MaxSlots: e.Config.Resources().MaxSlots(),
 			Handler:  ctx.Self(),
 		})
-		ctx.Tell(e.rm, sproto.SetGroupWeight{Weight: e.Config.Resources.Weight, Handler: ctx.Self()})
+		ctx.Tell(e.rm, sproto.SetGroupWeight{Weight: e.Config.Resources().Weight(), Handler: ctx.Self()})
 		ctx.Tell(e.rm, sproto.SetGroupPriority{
-			Priority: e.Config.Resources.Priority,
+			Priority: e.Config.Resources().Priority(),
 			Handler:  ctx.Self(),
 		})
 
@@ -275,11 +281,15 @@ func (e *experiment) Receive(ctx *actor.Context) error {
 	case model.State:
 		e.updateState(ctx, msg)
 	case sproto.SetGroupMaxSlots:
-		e.Config.Resources.MaxSlots = msg.MaxSlots
+		resources := e.Config.Resources()
+		resources.SetMaxSlots(msg.MaxSlots)
+		e.Config.SetResources(resources)
 		msg.Handler = ctx.Self()
 		ctx.Tell(e.rm, msg)
 	case sproto.SetGroupWeight:
-		e.Config.Resources.Weight = msg.Weight
+		resources := e.Config.Resources()
+		resources.SetWeight(msg.Weight)
+		e.Config.SetResources(resources)
 		msg.Handler = ctx.Self()
 		ctx.Tell(e.rm, msg)
 
@@ -500,13 +510,13 @@ func (e *experiment) checkpointForCreate(op searcher.Create) (*model.Checkpoint,
 }
 
 func (e *experiment) isBestValidation(metrics workload.ValidationMetrics) bool {
-	metricName := e.Config.Searcher.Metric
+	metricName := e.Config.Searcher().Metric()
 	validation, err := metrics.Metric(metricName)
 	if err != nil {
 		// TODO: Better error handling here.
 		return false
 	}
-	smallerIsBetter := e.Config.Searcher.SmallerIsBetter
+	smallerIsBetter := e.Config.Searcher().SmallerIsBetter()
 	isBest := (e.BestValidation == nil) ||
 		(smallerIsBetter && validation <= *e.BestValidation) ||
 		(!smallerIsBetter && validation >= *e.BestValidation)

--- a/master/internal/experiment_test.go
+++ b/master/internal/experiment_test.go
@@ -8,6 +8,8 @@ import (
 	"gotest.tools/assert"
 
 	"github.com/determined-ai/determined/master/pkg/model"
+	"github.com/determined-ai/determined/master/pkg/ptrs"
+	"github.com/determined-ai/determined/master/pkg/schemas/expconf"
 )
 
 type metricCase struct {
@@ -18,10 +20,10 @@ type metricCase struct {
 func testBestValidationCase(t *testing.T, smallerIsBetter bool, metrics []metricCase) {
 	exp := &experiment{
 		Experiment: &model.Experiment{
-			Config: model.ExperimentConfig{
-				Searcher: model.SearcherConfig{
-					Metric:          "metric",
-					SmallerIsBetter: smallerIsBetter,
+			Config: expconf.ExperimentConfig{
+				RawSearcher: &expconf.SearcherConfig{
+					RawMetric:          ptrs.StringPtr("metric"),
+					RawSmallerIsBetter: &smallerIsBetter,
 				},
 			},
 		},

--- a/master/internal/hpimportance/hpimportance_test.go
+++ b/master/internal/hpimportance/hpimportance_test.go
@@ -7,6 +7,8 @@ import (
 	"gotest.tools/assert"
 
 	"github.com/determined-ai/determined/master/pkg/model"
+	"github.com/determined-ai/determined/master/pkg/schemas"
+	"github.com/determined-ai/determined/master/pkg/schemas/expconf"
 )
 
 func TestComputeHPImportance(t *testing.T) {
@@ -16,50 +18,51 @@ func TestComputeHPImportance(t *testing.T) {
 		CoresPerWorker: 1,
 		MaxTrees:       100,
 	}
-	expConfig := &model.ExperimentConfig{
-		Hyperparameters: model.Hyperparameters{
-			"dropout1": model.Hyperparameter{
-				DoubleHyperparameter: &model.DoubleHyperparameter{
-					Minval: 0.2,
-					Maxval: 0.8,
+	expConfig := expconf.ExperimentConfig{
+		RawHyperparameters: expconf.Hyperparameters{
+			"dropout1": expconf.Hyperparameter{
+				RawDoubleHyperparameter: &expconf.DoubleHyperparameter{
+					RawMinval: 0.2,
+					RawMaxval: 0.8,
 				},
 			},
 			"dropout2": {
-				DoubleHyperparameter: &model.DoubleHyperparameter{
-					Minval: 0.2,
-					Maxval: 0.8,
+				RawDoubleHyperparameter: &expconf.DoubleHyperparameter{
+					RawMinval: 0.2,
+					RawMaxval: 0.8,
 				},
 			},
 			"global_batch_size": {
-				ConstHyperparameter: &model.ConstHyperparameter{
-					Val: 64,
+				RawConstHyperparameter: &expconf.ConstHyperparameter{
+					RawVal: 64,
 				},
 			},
 			"learning_rate": {
-				DoubleHyperparameter: &model.DoubleHyperparameter{
-					Minval: .0001,
-					Maxval: 1.0,
+				RawDoubleHyperparameter: &expconf.DoubleHyperparameter{
+					RawMinval: .0001,
+					RawMaxval: 1.0,
 				},
 			},
 			"n_filters1": {
-				IntHyperparameter: &model.IntHyperparameter{
-					Minval: 8,
-					Maxval: 64,
+				RawIntHyperparameter: &expconf.IntHyperparameter{
+					RawMinval: 8,
+					RawMaxval: 64,
 				},
 			},
 			"n_filters2": {
-				IntHyperparameter: &model.IntHyperparameter{
-					Minval: 8,
-					Maxval: 72,
+				RawIntHyperparameter: &expconf.IntHyperparameter{
+					RawMinval: 8,
+					RawMaxval: 72,
 				},
 			},
 			"n_filters3": {
-				CategoricalHyperparameter: &model.CategoricalHyperparameter{
-					Vals: []interface{}{"val1", "val2"},
+				RawCategoricalHyperparameter: &expconf.CategoricalHyperparameter{
+					RawVals: []interface{}{"val1", "val2"},
 				},
 			},
 		},
 	}
+	expConfig = schemas.WithDefaults(expConfig).(expconf.ExperimentConfig)
 
 	data := map[int][]model.HPImportanceTrialData{
 		10: {

--- a/master/internal/hpimportance/manager.go
+++ b/master/internal/hpimportance/manager.go
@@ -322,7 +322,7 @@ func (m *manager) triggerDefaultWork(ctx *actor.Context, experimentID int) {
 		hpi.SetMetricHPImportance(lossHpi, loss, model.TrainingMetric)
 	}
 
-	searcherMetric := config.Searcher.Metric
+	searcherMetric := config.Searcher().Metric()
 	triggerForSearcherMetric := false
 	searcherMetricHpi := hpi.GetMetricHPImportance(searcherMetric, model.ValidationMetric)
 	if !searcherMetricHpi.Pending {

--- a/master/internal/kubernetes/spec.go
+++ b/master/internal/kubernetes/spec.go
@@ -19,6 +19,7 @@ import (
 	"github.com/determined-ai/determined/master/pkg/etc"
 	"github.com/determined-ai/determined/master/pkg/fluent"
 	"github.com/determined-ai/determined/master/pkg/model"
+	"github.com/determined-ai/determined/master/pkg/schemas/expconf"
 	"github.com/determined-ai/determined/master/pkg/tasks"
 
 	k8sV1 "k8s.io/api/core/v1"
@@ -47,10 +48,10 @@ func (p *pod) configureResourcesRequirements() k8sV1.ResourceRequirements {
 
 func (p *pod) configureEnvVars(
 	envVarsMap map[string]string,
-	environment model.Environment,
+	environment expconf.EnvironmentConfig,
 	deviceType device.Type,
 ) ([]k8sV1.EnvVar, error) {
-	for _, envVar := range environment.EnvironmentVariables.For(deviceType) {
+	for _, envVar := range environment.EnvironmentVariables().For(deviceType) {
 		envVarSplit := strings.Split(envVar, "=")
 		if len(envVarSplit) != 2 {
 			return nil, errors.Errorf("unable to split envVar %s", envVar)
@@ -212,7 +213,7 @@ func (p *pod) configureCoscheduler(newPod *k8sV1.Pod, scheduler string) {
 		newPod.Spec.PriorityClassName = "determined-system-priority"
 		minAvailable = 0
 	} else {
-		minAvailable = int(math.Ceil(float64(resources.SlotsPerTrial) / float64(p.gpus)))
+		minAvailable = int(math.Ceil(float64(resources.SlotsPerTrial()) / float64(p.gpus)))
 	}
 
 	if newPod.Spec.PriorityClassName == "" {
@@ -313,7 +314,7 @@ func (p *pod) createPodSpec(ctx *actor.Context, scheduler string) error {
 
 	env := spec.Environment()
 
-	for _, port := range env.Ports {
+	for _, port := range env.Ports() {
 		p.ports = append(p.ports, port)
 	}
 
@@ -325,7 +326,7 @@ func (p *pod) createPodSpec(ctx *actor.Context, scheduler string) error {
 	initContainer := configureInitContainer(
 		len(runArchives),
 		initContainerVolumeMounts,
-		env.Image.For(deviceType),
+		env.Image().For(deviceType),
 		configureImagePullPolicy(env),
 	)
 
@@ -409,7 +410,7 @@ func (p *pod) createPodSpec(ctx *actor.Context, scheduler string) error {
 		Name:            model.DeterminedK8ContainerName,
 		Command:         spec.Entrypoint(),
 		Env:             envVars,
-		Image:           env.Image.For(deviceType),
+		Image:           env.Image().For(deviceType),
 		ImagePullPolicy: configureImagePullPolicy(env),
 		SecurityContext: configureSecurityContext(spec.AgentUserGroup),
 		Resources:       p.configureResourcesRequirements(),
@@ -418,7 +419,7 @@ func (p *pod) createPodSpec(ctx *actor.Context, scheduler string) error {
 	}
 
 	p.pod = p.configurePodSpec(
-		ctx, volumes, initContainer, container, sidecars, env.PodSpec, scheduler)
+		ctx, volumes, initContainer, container, sidecars, env.PodSpec(), scheduler)
 
 	p.configMap, err = p.configureConfigMapSpec(runArchives, fluentFiles)
 	if err != nil {
@@ -458,9 +459,9 @@ func configureSecurityContext(agentUserGroup *model.AgentUserGroup) *k8sV1.Secur
 	return nil
 }
 
-func configureImagePullPolicy(environment model.Environment) k8sV1.PullPolicy {
+func configureImagePullPolicy(environment expconf.EnvironmentConfig) k8sV1.PullPolicy {
 	pullPolicy := k8sV1.PullAlways
-	if !environment.ForcePullImage {
+	if !environment.ForcePullImage() {
 		pullPolicy = k8sV1.PullIfNotPresent
 	}
 	return pullPolicy

--- a/master/internal/kubernetes/spec.go
+++ b/master/internal/kubernetes/spec.go
@@ -419,7 +419,7 @@ func (p *pod) createPodSpec(ctx *actor.Context, scheduler string) error {
 	}
 
 	p.pod = p.configurePodSpec(
-		ctx, volumes, initContainer, container, sidecars, env.PodSpec(), scheduler)
+		ctx, volumes, initContainer, container, sidecars, (*k8sV1.Pod)(env.PodSpec()), scheduler)
 
 	p.configMap, err = p.configureConfigMapSpec(runArchives, fluentFiles)
 	if err != nil {

--- a/master/internal/restore.go
+++ b/master/internal/restore.go
@@ -65,8 +65,8 @@ func (m *Master) restoreExperiment(expModel *model.Experiment) error {
 
 	// Get the TaskSpec for this experiment.
 	taskSpec := m.makeTaskSpec(
-		expModel.Config.Resources.ResourcePool,
-		expModel.Config.Resources.SlotsPerTrial,
+		expModel.Config.Resources().ResourcePool(),
+		expModel.Config.Resources().SlotsPerTrial(),
 	)
 
 	log.WithField("experiment", expModel.ID).Info("restoring experiment")

--- a/master/internal/telemetry/reports.go
+++ b/master/internal/telemetry/reports.go
@@ -37,11 +37,11 @@ func ReportAgentDisconnected(system *actor.System, uuid uuid.UUID) {
 func ReportExperimentCreated(system *actor.System, e model.Experiment) {
 	report(system, "experiment_created", map[string]interface{}{
 		"id":               e.ID,
-		"searcher":         e.Config.Searcher,
-		"resources":        e.Config.Resources,
-		"image":            e.Config.Environment.Image,
-		"num_hparams":      len(e.Config.Hyperparameters),
-		"batches_per_step": e.Config.SchedulingUnit,
+		"searcher":         e.Config.Searcher(),
+		"resources":        e.Config.Resources(),
+		"image":            e.Config.Environment().Image(),
+		"num_hparams":      len(e.Config.Hyperparameters()),
+		"batches_per_step": e.Config.SchedulingUnit(),
 	})
 }
 

--- a/master/internal/trial.go
+++ b/master/internal/trial.go
@@ -328,7 +328,7 @@ func (t *trial) Receive(ctx *actor.Context) error {
 		if !t.idSet {
 			return nil
 		}
-		if t.Restarts > t.experiment.Config.MaxRestarts {
+		if t.Restarts > t.experiment.Config.MaxRestarts() {
 			if err := t.db.UpdateTrial(t.id, model.ErrorState); err != nil {
 				ctx.Log().Error(err)
 			}
@@ -356,9 +356,9 @@ func (t *trial) Receive(ctx *actor.Context) error {
 		if t.trialClosing() {
 			ctx.Self().Stop()
 		} else if !t.sequencer.UpToDate() && t.experimentState == model.ActiveState {
-			slotsNeeded := t.experiment.Config.Resources.SlotsPerTrial
-			label := t.experiment.Config.Resources.AgentLabel
-			resourcePool := t.experiment.Config.Resources.ResourcePool
+			slotsNeeded := t.experiment.Config.Resources().SlotsPerTrial()
+			label := t.experiment.Config.Resources().AgentLabel()
+			resourcePool := t.experiment.Config.Resources().ResourcePool()
 			var name string
 			if t.idSet {
 				name = fmt.Sprintf("Trial %d (Experiment %d)", t.id, t.experiment.ID)
@@ -579,7 +579,7 @@ func (t *trial) processAllocated(
 		}
 		t.processID(modelTrial.ID)
 		ctx.AddLabel("trial-id", t.id)
-		if t.experiment.Config.PerformInitialValidation {
+		if t.experiment.Config.PerformInitialValidation() {
 			if err := t.db.AddNoOpStep(model.NewNoOpStep(t.id, 0)); err != nil {
 				ctx.Log().WithError(err).Error("failed to save zeroth step for initial validation")
 				t.terminate(ctx, true)
@@ -716,7 +716,7 @@ func (t *trial) processCompletedWorkload(ctx *actor.Context, msg workload.Comple
 	case err != nil:
 		return errors.Wrap(err, "failed to pass completed message to sequencer")
 	case op != nil:
-		m, err := msg.ValidationMetrics.Metric(t.experiment.Config.Searcher.Metric)
+		m, err := msg.ValidationMetrics.Metric(t.experiment.Config.Searcher().Metric())
 		if err != nil {
 			return err
 		}
@@ -1075,7 +1075,7 @@ func (t *trial) reset() error {
 }
 
 func (t *trial) trialClosing() bool {
-	return t.sequencer.ExitingEarly || t.Killed || t.Restarts > t.experiment.Config.MaxRestarts ||
+	return t.sequencer.ExitingEarly || t.Killed || t.Restarts > t.experiment.Config.MaxRestarts() ||
 		(t.close != nil && t.sequencer.UpToDate()) ||
 		model.StoppingStates[t.experimentState]
 }
@@ -1166,9 +1166,9 @@ func (t *trial) terminated(ctx *actor.Context) {
 	}
 
 	ctx.Log().Errorf("unexpected failure of trial after restart %d/%d: %v",
-		t.Restarts, t.experiment.Config.MaxRestarts, status)
+		t.Restarts, t.experiment.Config.MaxRestarts(), status)
 	t.Restarts++
-	if t.Restarts <= t.experiment.Config.MaxRestarts {
+	if t.Restarts <= t.experiment.Config.MaxRestarts() {
 		ctx.Log().Infof("resetting trial %d", t.id)
 		if err := t.reset(); err != nil {
 			ctx.Log().Warn("failed to reset trial", err)

--- a/master/pkg/model/compat.go
+++ b/master/pkg/model/compat.go
@@ -96,6 +96,6 @@ func (e Environment) ToExpconf() expconf.EnvironmentConfig {
 		RawPorts:                e.Ports,
 		RawRegistryAuth:         e.RegistryAuth,
 		RawForcePullImage:       ptrs.BoolPtr(e.ForcePullImage),
-		RawPodSpec:              e.PodSpec,
+		RawPodSpec:              (*expconf.PodSpec)(e.PodSpec),
 	}).(expconf.EnvironmentConfig)
 }

--- a/master/pkg/model/compat.go
+++ b/master/pkg/model/compat.go
@@ -1,0 +1,101 @@
+package model
+
+import (
+	"github.com/determined-ai/determined/master/pkg/ptrs"
+	"github.com/determined-ai/determined/master/pkg/schemas"
+	"github.com/determined-ai/determined/master/pkg/schemas/expconf"
+)
+
+// ToExpconf translates old model objects into an expconf object.
+func (d DeviceConfig) ToExpconf() expconf.Device {
+	return schemas.WithDefaults(expconf.Device{
+		RawHostPath:      d.HostPath,
+		RawContainerPath: d.ContainerPath,
+		RawMode:          ptrs.StringPtr(d.Mode),
+	}).(expconf.Device)
+}
+
+// ToExpconf translates old model objects into an expconf object.
+func (d DevicesConfig) ToExpconf() expconf.DevicesConfig {
+	var out expconf.DevicesConfig
+	for _, d := range d {
+		out = append(out, d.ToExpconf())
+	}
+	return schemas.WithDefaults(out).(expconf.DevicesConfig)
+}
+
+// ToExpconf translates old model objects into an expconf object.
+func (r ResourcesConfig) ToExpconf() expconf.ResourcesConfig {
+	return schemas.WithDefaults(expconf.ResourcesConfig{
+		RawSlots:          ptrs.IntPtr(r.Slots),
+		RawMaxSlots:       r.MaxSlots,
+		RawSlotsPerTrial:  ptrs.IntPtr(r.SlotsPerTrial),
+		RawWeight:         ptrs.Float64Ptr(r.Weight),
+		RawNativeParallel: ptrs.BoolPtr(r.NativeParallel),
+		RawShmSize:        r.ShmSize,
+		RawAgentLabel:     ptrs.StringPtr(r.AgentLabel),
+		RawResourcePool:   ptrs.StringPtr(r.ResourcePool),
+		RawPriority:       r.Priority,
+		RawDevices:        r.Devices.ToExpconf(),
+	}).(expconf.ResourcesConfig)
+}
+
+// ToExpconf translates old model objects into an expconf object.
+func (b BindMount) ToExpconf() expconf.BindMount {
+	return schemas.WithDefaults(expconf.BindMount{
+		RawHostPath:      b.HostPath,
+		RawContainerPath: b.ContainerPath,
+		RawReadOnly:      ptrs.BoolPtr(b.ReadOnly),
+		RawPropagation:   ptrs.StringPtr(b.Propagation),
+	}).(expconf.BindMount)
+}
+
+// ToExpconf translates old model objects into an expconf object.
+func (b BindMountsConfig) ToExpconf() expconf.BindMountsConfig {
+	var out expconf.BindMountsConfig
+	for _, m := range b {
+		out = append(out, m.ToExpconf())
+	}
+	return schemas.WithDefaults(out).(expconf.BindMountsConfig)
+}
+
+// ToModelBindMount converts new expconf bind mounts into old modl bind mounts.
+func ToModelBindMount(b expconf.BindMount) BindMount {
+	return BindMount{
+		HostPath:      b.HostPath(),
+		ContainerPath: b.ContainerPath(),
+		ReadOnly:      b.ReadOnly(),
+		Propagation:   b.Propagation(),
+	}
+}
+
+// ToExpconf translates old model objects into an expconf object.
+func (r RuntimeItems) ToExpconf() expconf.EnvironmentVariablesMap {
+	return schemas.WithDefaults(expconf.EnvironmentVariablesMap{
+		RawCPU: r.CPU,
+		RawGPU: r.GPU,
+	}).(expconf.EnvironmentVariablesMap)
+}
+
+// ToExpconf translates old model objects into an expconf object.
+func (r RuntimeItem) ToExpconf() expconf.EnvironmentImageMap {
+	return schemas.WithDefaults(expconf.EnvironmentImageMap{
+		RawCPU: ptrs.StringPtr(r.CPU),
+		RawGPU: ptrs.StringPtr(r.GPU),
+	}).(expconf.EnvironmentImageMap)
+}
+
+// ToExpconf translates old model objects into an expconf object.
+func (e Environment) ToExpconf() expconf.EnvironmentConfig {
+	image := e.Image.ToExpconf()
+	vars := e.EnvironmentVariables.ToExpconf()
+
+	return schemas.WithDefaults(expconf.EnvironmentConfig{
+		RawImage:                &image,
+		RawEnvironmentVariables: &vars,
+		RawPorts:                e.Ports,
+		RawRegistryAuth:         e.RegistryAuth,
+		RawForcePullImage:       ptrs.BoolPtr(e.ForcePullImage),
+		RawPodSpec:              e.PodSpec,
+	}).(expconf.EnvironmentConfig)
+}

--- a/master/pkg/model/experiment.go
+++ b/master/pkg/model/experiment.go
@@ -10,6 +10,7 @@ import (
 	"github.com/pkg/errors"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
+	"github.com/determined-ai/determined/master/pkg/schemas/expconf"
 	"github.com/determined-ai/determined/master/version"
 	"github.com/determined-ai/determined/proto/pkg/apiv1"
 	"github.com/determined-ai/determined/proto/pkg/logv1"
@@ -186,10 +187,10 @@ var CheckpointReverseTransitions = reverseTransitions(CheckpointTransitions)
 
 // Experiment represents a row from the `experiments` table.
 type Experiment struct {
-	ID             int              `db:"id"`
-	State          State            `db:"state"`
-	Config         ExperimentConfig `db:"config"`
-	OriginalConfig string           `db:"original_config"`
+	ID             int                      `db:"id"`
+	State          State                    `db:"state"`
+	Config         expconf.ExperimentConfig `db:"config"`
+	OriginalConfig string                   `db:"original_config"`
 	// The model definition is stored as a .tar.gz file (raw bytes).
 	ModelDefinitionBytes []byte     `db:"model_definition"`
 	StartTime            time.Time  `db:"start_time"`
@@ -205,16 +206,16 @@ type Experiment struct {
 
 // ExperimentDescriptor is a minimal description of an experiment.
 type ExperimentDescriptor struct {
-	ID       int              `json:"id"`
-	Archived bool             `json:"archived"`
-	Config   ExperimentConfig `json:"config"`
-	Labels   []string         `json:"labels"`
+	ID       int                      `json:"id"`
+	Archived bool                     `json:"archived"`
+	Config   expconf.ExperimentConfig `json:"config"`
+	Labels   []string                 `json:"labels"`
 }
 
 // NewExperiment creates a new experiment struct in the paused state.  Note
 // that the experiment ID will not be set.
 func NewExperiment(
-	config ExperimentConfig,
+	config expconf.ExperimentConfig,
 	originalConfig string,
 	modelDefinitionBytes []byte,
 	parentID *int,

--- a/master/pkg/model/task_container_defaults.go
+++ b/master/pkg/model/task_container_defaults.go
@@ -140,7 +140,7 @@ func (c *TaskContainerDefaultsConfig) MergeIntoConfig(config *expconf.Experiment
 		RawDropCapabilities: c.DropCapabilities,
 		RawForcePullImage:   ptrs.BoolPtr(c.ForcePullImage),
 		RawImage:            image,
-		RawPodSpec:          podSpec,
+		RawPodSpec:          (*expconf.PodSpec)(podSpec),
 		RawRegistryAuth:     c.RegistryAuth,
 	}
 	config.RawEnvironment = schemas.Merge(config.RawEnvironment, &env).(*expconf.EnvironmentConfig)

--- a/master/pkg/schemas/copy_test.go
+++ b/master/pkg/schemas/copy_test.go
@@ -80,3 +80,33 @@ func TestCopyNested(t *testing.T) {
 	obj := Copy(src).(A)
 	assert.DeepEqual(t, obj, src)
 }
+
+type E struct {
+	// C is a reflect-friendly public member.
+	C C
+	// d is a reflect-unfriendly private member.
+	d D
+}
+
+// Copy implements the Copyable interface.
+func (e E) Copy() interface{} {
+	return E{
+		C: Copy(e.C).(C),
+		d: Copy(e.d).(D),
+	}
+}
+
+// assertDeepEqual is needed since DeepEqual fails on E for the same reason as Copy.
+func (e E) assertDeepEqual(t *testing.T, other E) {
+	assert.DeepEqual(t, e.C, other.C)
+	assert.DeepEqual(t, e.d, other.d)
+}
+
+func TestCopyable(t *testing.T) {
+	src := E{
+		C: C{I: 6, D: map[string]D{"help": {I: 1, S: "im"}, "trapped": {I: 2, S: "in a"}}},
+		d: D{I: 1, S: "unittest factory"},
+	}
+	obj := Copy(src).(E)
+	obj.assertDeepEqual(t, src)
+}

--- a/master/pkg/schemas/expconf/experiment_config.go
+++ b/master/pkg/schemas/expconf/experiment_config.go
@@ -22,7 +22,7 @@ type ExperimentConfigV0 struct {
 	RawDataLayer                *DataLayerConfigV0          `json:"data_layer"`
 	RawData                     map[string]interface{}      `json:"data"`
 	RawDebug                    *bool                       `json:"debug"`
-	RawDescription              *string                     `json:"description"`
+	RawDescription              Description                 `json:"description"`
 	RawEntrypoint               *string                     `json:"entrypoint"`
 	RawEnvironment              *EnvironmentConfigV0        `json:"environment"`
 	RawHyperparameters          HyperparametersV0           `json:"hyperparameters"`
@@ -41,23 +41,6 @@ type ExperimentConfigV0 struct {
 	RawSearcher                 *SearcherConfigV0           `json:"searcher"`
 	RawSecurity                 *SecurityConfigV0           `json:"security,omitempty"`
 	RawTensorboardStorage       *TensorboardStorageConfigV0 `json:"tensorboard_storage,omitempty"`
-}
-
-func runtimeDefaultDescription() *string {
-	s := fmt.Sprintf(
-		"Experiment (%s)",
-		petname.Generate(TaskNameGeneratorWords, TaskNameGeneratorSep),
-	)
-	return &s
-}
-
-// RuntimeDefaults implements the RuntimeDefaultable interface.
-func (e ExperimentConfigV0) RuntimeDefaults() interface{} {
-	// Description has runtime defaults.
-	if e.RawDescription == nil {
-		e.RawDescription = runtimeDefaultDescription()
-	}
-	return e
 }
 
 // Unit implements the model.InUnits interface.
@@ -96,6 +79,50 @@ func (e *ExperimentConfigV0) Scan(src interface{}) error {
 	// inside the system, we call WithDefaults here.
 	*e = schemas.WithDefaults(config).(ExperimentConfigV0)
 	return nil
+}
+
+// Description is a container struct for handling runtime defaults. It has to be a container so that
+// it can be responsible for allocating the nil pointer if one is not provided.  It would be nice if
+// you could use `type Description *string` but go won't let you create methods on such a type.
+type Description struct {
+	RawString *string
+}
+
+// WithDefaults implements the Defaultable interface.
+func (d Description) WithDefaults() interface{} {
+	var s string
+	if d.RawString != nil {
+		s = *d.RawString
+	} else {
+		s = fmt.Sprintf(
+			"Experiment (%s)",
+			petname.Generate(TaskNameGeneratorWords, TaskNameGeneratorSep),
+		)
+	}
+	return Description{&s}
+}
+
+// String is part of the Getter/Setter API.
+func (d Description) String() string {
+	if d.RawString == nil {
+		panic("You must call WithDefaults on Description before .String")
+	}
+	return *d.RawString
+}
+
+// SetString is part of the Getter/Setter API.
+func (d *Description) SetString(s string) {
+	d.RawString = &s
+}
+
+// MarshalJSON marshals makes the Description container transparent to marshaling.
+func (d Description) MarshalJSON() ([]byte, error) {
+	return json.Marshal(d.RawString)
+}
+
+// UnmarshalJSON marshals makes the Description container transparent to unmarshaling.
+func (d *Description) UnmarshalJSON(bytes []byte) error {
+	return json.Unmarshal(bytes, &d.RawString)
 }
 
 // InUnits is describes a type that is in terms of a specific unit.
@@ -225,13 +252,15 @@ type ReproducibilityConfigV0 struct {
 	RawExperimentSeed *uint32 `json:"experiment_seed"`
 }
 
-// RuntimeDefaults implements the RuntimeDefaultable interface.
-func (r ReproducibilityConfigV0) RuntimeDefaults() interface{} {
-	if r.RawExperimentSeed == nil {
-		t := uint32(time.Now().Unix())
-		r.RawExperimentSeed = &t
+// WithDefaults implements the Defaultable interface.
+func (r ReproducibilityConfigV0) WithDefaults() interface{} {
+	var seed uint32
+	if r.RawExperimentSeed != nil {
+		seed = *r.RawExperimentSeed
+	} else {
+		seed = uint32(time.Now().Unix())
 	}
-	return r
+	return ReproducibilityConfigV0{&seed}
 }
 
 //go:generate ../gen.sh

--- a/master/pkg/schemas/expconf/experiment_config_test.go
+++ b/master/pkg/schemas/expconf/experiment_config_test.go
@@ -1,10 +1,12 @@
 package expconf
 
 import (
+	"encoding/json"
 	"testing"
 
 	"gotest.tools/assert"
 
+	"github.com/determined-ai/determined/master/pkg/ptrs"
 	"github.com/determined-ai/determined/master/pkg/schemas"
 )
 
@@ -29,4 +31,30 @@ func TestBindMountsMerge(t *testing.T) {
 	assert.Assert(t, len(out.RawBindMounts) == 2)
 	assert.Assert(t, out.RawBindMounts[0].RawHostPath == "/host/e1")
 	assert.Assert(t, out.RawBindMounts[1].RawHostPath == "/host/e2")
+}
+
+func TestDescription(t *testing.T) {
+	config := ExperimentConfig{
+		RawDescription: Description{
+			RawString: ptrs.StringPtr("my_description"),
+		},
+	}
+
+	// Test marshaling.
+	bytes, err := json.Marshal(config)
+	assert.NilError(t, err)
+
+	rawObj := map[string]interface{}{}
+	err = json.Unmarshal(bytes, &rawObj)
+	assert.NilError(t, err)
+
+	var expect interface{} = "my_description"
+	assert.DeepEqual(t, rawObj["description"], expect)
+
+	// Test unmarshaling.
+	newConfig := ExperimentConfig{}
+	err = json.Unmarshal(bytes, &newConfig)
+	assert.NilError(t, err)
+
+	assert.DeepEqual(t, newConfig.Description().String(), "my_description")
 }

--- a/master/pkg/schemas/expconf/schema_test.go
+++ b/master/pkg/schemas/expconf/schema_test.go
@@ -100,6 +100,8 @@ func objectForURL(url string) interface{} {
 		return &BindMountsConfigV0{}
 	case "http://determined.ai/schemas/expconf/v0/devices.json":
 		return &DevicesConfigV0{}
+	case "http://determined.ai/schemas/expconf/v0/environment.json":
+		return &EnvironmentConfigV0{}
 	// For union member schemas, just return the union type.
 	case "http://determined.ai/schemas/expconf/v0/searcher.json",
 		"http://determined.ai/schemas/expconf/v0/searcher-adaptive-asha.json",

--- a/master/pkg/schemas/expconf/test_types.go
+++ b/master/pkg/schemas/expconf/test_types.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/determined-ai/determined/master/pkg/ptrs"
 	"github.com/determined-ai/determined/master/pkg/union"
 )
 
@@ -64,17 +63,37 @@ type TestRootV0 struct {
 	RawValX int `json:"val_x"`
 
 	// defaultable; pointer.
-	RawSubObj             *TestSubV0   `json:"sub_obj"`
-	RawSubUnion           *TestUnionV0 `json:"sub_union"`
-	RawRuntimeDefaultable *int         `json:"runtime_defaultable"`
-	RawDefaultedArray     []string     `json:"defaulted_array"`
-	RawNodefaultArray     []string     `json:"nodefault_array"`
+	RawSubObj         *TestSubV0   `json:"sub_obj"`
+	RawSubUnion       *TestUnionV0 `json:"sub_union"`
+	RawDefaultedArray []string     `json:"defaulted_array"`
+	RawNodefaultArray []string     `json:"nodefault_array"`
+
+	// runtime-defaultable container; non-pointer struct containing a pointer.
+	RawRuntimeDefaultable TestRuntimeDefaultable `json:"runtime_defaultable"`
 }
 
-// RuntimeDefaults implements the RuntimeDefaultable interface.
-func (t TestRootV0) RuntimeDefaults() interface{} {
-	if t.RawRuntimeDefaultable == nil {
-		t.RawRuntimeDefaultable = ptrs.IntPtr(10)
+// TestRuntimeDefaultable is container for implementing runtime defaults.
+type TestRuntimeDefaultable struct {
+	RawInt *int
+}
+
+// WithDefaults implements the Defaultable interface.
+func (t TestRuntimeDefaultable) WithDefaults() interface{} {
+	var i int
+	if t.RawInt != nil {
+		i = *t.RawInt
+	} else {
+		i = 10
 	}
-	return t
+	return TestRuntimeDefaultable{&i}
+}
+
+// MarshalJSON makes the container transparent for marshaling.
+func (t *TestRuntimeDefaultable) MarshalJSON() ([]byte, error) {
+	return json.Marshal(t.RawInt)
+}
+
+// UnmarshalJSON makes the container transparent for unmarshaling.
+func (t *TestRuntimeDefaultable) UnmarshalJSON(bytes []byte) error {
+	return json.Unmarshal(bytes, &t.RawInt)
 }

--- a/master/pkg/schemas/expconf/zgen_environment_config_v0.go
+++ b/master/pkg/schemas/expconf/zgen_environment_config_v0.go
@@ -5,7 +5,6 @@ package expconf
 import (
 	"github.com/docker/docker/api/types"
 	"github.com/santhosh-tekuri/jsonschema/v2"
-	k8sV1 "k8s.io/api/core/v1"
 
 	"github.com/determined-ai/determined/master/pkg/schemas"
 )
@@ -59,11 +58,11 @@ func (e *EnvironmentConfigV0) SetForcePullImage(val bool) {
 	e.RawForcePullImage = &val
 }
 
-func (e EnvironmentConfigV0) PodSpec() *k8sV1.Pod {
+func (e EnvironmentConfigV0) PodSpec() *PodSpec {
 	return e.RawPodSpec
 }
 
-func (e *EnvironmentConfigV0) SetPodSpec(val *k8sV1.Pod) {
+func (e *EnvironmentConfigV0) SetPodSpec(val *PodSpec) {
 	e.RawPodSpec = val
 }
 

--- a/master/pkg/schemas/expconf/zgen_experiment_config_v0.go
+++ b/master/pkg/schemas/expconf/zgen_experiment_config_v0.go
@@ -68,15 +68,12 @@ func (e *ExperimentConfigV0) SetDebug(val bool) {
 	e.RawDebug = &val
 }
 
-func (e ExperimentConfigV0) Description() string {
-	if e.RawDescription == nil {
-		panic("You must call WithDefaults on ExperimentConfigV0 before .Description")
-	}
-	return *e.RawDescription
+func (e ExperimentConfigV0) Description() Description {
+	return e.RawDescription
 }
 
-func (e *ExperimentConfigV0) SetDescription(val string) {
-	e.RawDescription = &val
+func (e *ExperimentConfigV0) SetDescription(val Description) {
+	e.RawDescription = val
 }
 
 func (e ExperimentConfigV0) Entrypoint() *string {

--- a/master/pkg/schemas/expconf/zgen_test_root_v0.go
+++ b/master/pkg/schemas/expconf/zgen_test_root_v0.go
@@ -35,14 +35,6 @@ func (t *TestRootV0) SetSubUnion(val *TestUnionV0) {
 	t.RawSubUnion = val
 }
 
-func (t TestRootV0) RuntimeDefaultable() *int {
-	return t.RawRuntimeDefaultable
-}
-
-func (t *TestRootV0) SetRuntimeDefaultable(val *int) {
-	t.RawRuntimeDefaultable = val
-}
-
 func (t TestRootV0) DefaultedArray() []string {
 	return t.RawDefaultedArray
 }
@@ -57,6 +49,14 @@ func (t TestRootV0) NodefaultArray() []string {
 
 func (t *TestRootV0) SetNodefaultArray(val []string) {
 	t.RawNodefaultArray = val
+}
+
+func (t TestRootV0) RuntimeDefaultable() TestRuntimeDefaultable {
+	return t.RawRuntimeDefaultable
+}
+
+func (t *TestRootV0) SetRuntimeDefaultable(val TestRuntimeDefaultable) {
+	t.RawRuntimeDefaultable = val
 }
 
 func (t TestRootV0) ParsedSchema() interface{} {

--- a/master/pkg/searcher/adaptive_asha.go
+++ b/master/pkg/searcher/adaptive_asha.go
@@ -6,7 +6,13 @@ import (
 	"sort"
 
 	"github.com/determined-ai/determined/master/pkg/model"
+	"github.com/determined-ai/determined/master/pkg/ptrs"
+	"github.com/determined-ai/determined/master/pkg/schemas/expconf"
 )
+
+func lengthPtr(val expconf.Length) *expconf.Length {
+	return &val
+}
 
 func getBracketMaxTrials(
 	maxTrials int, divisor float64, brackets []int) []int {
@@ -64,42 +70,41 @@ func getBracketMaxConcurrentTrials(
 	return bracketMaxConcurrentTrials
 }
 
-func newAdaptiveASHASearch(config model.AdaptiveASHAConfig) SearchMethod {
-	modeFunc := parseAdaptiveMode(config.Mode)
+func newAdaptiveASHASearch(config expconf.AdaptiveASHAConfig, smallerIsBetter bool) SearchMethod {
+	modeFunc := parseAdaptiveMode(config.Mode())
 
-	brackets := config.BracketRungs
+	brackets := config.BracketRungs()
 	if len(brackets) == 0 {
-		config.MaxRungs = min(
-			config.MaxRungs,
-			int(math.Log(float64(config.MaxLength.Units))/math.Log(config.Divisor))+1)
-		config.MaxRungs = min(
-			config.MaxRungs,
-			int(math.Log(float64(config.MaxTrials))/math.Log(config.Divisor))+1)
-		brackets = modeFunc(config.MaxRungs)
+		maxRungs := config.MaxRungs()
+		maxRungs = min(
+			maxRungs,
+			int(math.Log(float64(config.MaxLength().Units))/math.Log(config.Divisor()))+1)
+		maxRungs = min(
+			maxRungs,
+			int(math.Log(float64(config.MaxTrials()))/math.Log(config.Divisor()))+1)
+		brackets = modeFunc(maxRungs)
 	}
 	// We prioritize brackets that perform more early stopping to try to max speedups early on.
 	sort.Sort(sort.Reverse(sort.IntSlice(brackets)))
 	bracketMaxTrials := getBracketMaxTrials(
-		config.MaxTrials, config.Divisor, brackets)
+		config.MaxTrials(), config.Divisor(), brackets)
 	bracketMaxConcurrentTrials := getBracketMaxConcurrentTrials(
-		config.MaxConcurrentTrials, config.Divisor, bracketMaxTrials)
+		config.MaxConcurrentTrials(), config.Divisor(), bracketMaxTrials)
 
 	methods := make([]SearchMethod, 0, len(brackets))
 	for i, numRungs := range brackets {
-		c := model.AsyncHalvingConfig{
-			Metric:              config.Metric,
-			SmallerIsBetter:     config.SmallerIsBetter,
-			NumRungs:            numRungs,
-			MaxLength:           config.MaxLength,
-			MaxTrials:           bracketMaxTrials[i],
-			Divisor:             config.Divisor,
-			MaxConcurrentTrials: bracketMaxConcurrentTrials[i],
-			StopOnce:            config.StopOnce,
+		c := expconf.AsyncHalvingConfig{
+			RawNumRungs:            ptrs.IntPtr(numRungs),
+			RawMaxLength:           lengthPtr(config.MaxLength()),
+			RawMaxTrials:           &bracketMaxTrials[i],
+			RawDivisor:             ptrs.Float64Ptr(config.Divisor()),
+			RawMaxConcurrentTrials: ptrs.IntPtr(bracketMaxConcurrentTrials[i]),
+			RawStopOnce:            ptrs.BoolPtr(config.StopOnce()),
 		}
-		if config.StopOnce {
-			methods = append(methods, newAsyncHalvingStoppingSearch(c))
+		if config.StopOnce() {
+			methods = append(methods, newAsyncHalvingStoppingSearch(c, smallerIsBetter))
 		} else {
-			methods = append(methods, newAsyncHalvingSearch(c))
+			methods = append(methods, newAsyncHalvingSearch(c, smallerIsBetter))
 		}
 	}
 
@@ -128,7 +133,7 @@ func aggressiveMode(maxRungs int) []int {
 	return []int{maxRungs}
 }
 
-func parseAdaptiveMode(rawMode model.AdaptiveMode) adaptiveMode {
+func parseAdaptiveMode(rawMode expconf.AdaptiveMode) adaptiveMode {
 	switch rawMode {
 	case model.ConservativeMode:
 		return conservativeMode

--- a/master/pkg/searcher/adaptive_asha_test.go
+++ b/master/pkg/searcher/adaptive_asha_test.go
@@ -5,7 +5,9 @@ import (
 
 	"gotest.tools/assert"
 
-	"github.com/determined-ai/determined/master/pkg/model"
+	"github.com/determined-ai/determined/master/pkg/ptrs"
+	"github.com/determined-ai/determined/master/pkg/schemas"
+	"github.com/determined-ai/determined/master/pkg/schemas/expconf"
 )
 
 func TestBracketMaxTrials(t *testing.T) {
@@ -22,18 +24,21 @@ func TestBracketMaxConcurrentTrials(t *testing.T) {
 	assert.DeepEqual(t, getBracketMaxConcurrentTrials(0, 4., []int{40, 10}), []int{10, 10})
 }
 
+func modePtr(x expconf.AdaptiveMode) *expconf.AdaptiveMode {
+	return &x
+}
+
 func TestAdaptiveASHASearcherReproducibility(t *testing.T) {
-	conf := model.AdaptiveASHAConfig{
-		Metric: defaultMetric, SmallerIsBetter: true,
-		MaxLength: model.NewLengthInBatches(6400), MaxTrials: 128, Divisor: 4,
-		Mode: model.AggressiveMode, MaxRungs: 3,
+	conf := expconf.AdaptiveASHAConfig{
+		RawMaxLength: lengthPtr(expconf.NewLengthInBatches(6400)),
+		RawMaxTrials: ptrs.IntPtr(128),
 	}
-	gen := func() SearchMethod { return newAdaptiveASHASearch(conf) }
+	conf = schemas.WithDefaults(conf).(expconf.AdaptiveASHAConfig)
+	gen := func() SearchMethod { return newAdaptiveASHASearch(conf, true) }
 	checkReproducibility(t, gen, nil, defaultMetric)
 }
 
 func TestAdaptiveASHASearchMethod(t *testing.T) {
-	maxConcurrentTrials := 5
 	testCases := []valueSimulationTestCase{
 		{
 			name: "smaller is better",
@@ -44,16 +49,14 @@ func TestAdaptiveASHASearchMethod(t *testing.T) {
 				newConstantPredefinedTrial(toOps("900B"), 0.4),
 				newConstantPredefinedTrial(toOps("900B"), 0.5),
 			},
-			config: model.SearcherConfig{
-				AdaptiveASHAConfig: &model.AdaptiveASHAConfig{
-					Metric:              "error",
-					SmallerIsBetter:     true,
-					MaxLength:           model.NewLengthInBatches(900),
-					MaxTrials:           5,
-					Mode:                model.StandardMode,
-					MaxRungs:            2,
-					Divisor:             3,
-					MaxConcurrentTrials: maxConcurrentTrials,
+			config: expconf.SearcherConfig{
+				RawSmallerIsBetter: ptrs.BoolPtr(true),
+				RawAdaptiveASHAConfig: &expconf.AdaptiveASHAConfig{
+					RawMaxLength: lengthPtr(expconf.NewLengthInBatches(900)),
+					RawMaxTrials: ptrs.IntPtr(5),
+					RawMode:      modePtr(expconf.StandardMode),
+					RawMaxRungs:  ptrs.IntPtr(2),
+					RawDivisor:   ptrs.Float64Ptr(3),
 				},
 			},
 		},
@@ -66,16 +69,14 @@ func TestAdaptiveASHASearchMethod(t *testing.T) {
 				newConstantPredefinedTrial(toOps("900B"), 0.4),
 				newConstantPredefinedTrial(toOps("900B"), 0.5),
 			},
-			config: model.SearcherConfig{
-				AdaptiveASHAConfig: &model.AdaptiveASHAConfig{
-					Metric:              "error",
-					SmallerIsBetter:     true,
-					MaxLength:           model.NewLengthInBatches(900),
-					MaxTrials:           5,
-					Mode:                model.StandardMode,
-					MaxRungs:            2,
-					Divisor:             3,
-					MaxConcurrentTrials: maxConcurrentTrials,
+			config: expconf.SearcherConfig{
+				RawSmallerIsBetter: ptrs.BoolPtr(true),
+				RawAdaptiveASHAConfig: &expconf.AdaptiveASHAConfig{
+					RawMaxLength: lengthPtr(expconf.NewLengthInBatches(900)),
+					RawMaxTrials: ptrs.IntPtr(5),
+					RawMode:      modePtr(expconf.StandardMode),
+					RawMaxRungs:  ptrs.IntPtr(2),
+					RawDivisor:   ptrs.Float64Ptr(3),
 				},
 			},
 		},
@@ -88,16 +89,14 @@ func TestAdaptiveASHASearchMethod(t *testing.T) {
 				newConstantPredefinedTrial(toOps("900B"), 0.2),
 				newConstantPredefinedTrial(toOps("900B"), 0.1),
 			},
-			config: model.SearcherConfig{
-				AdaptiveASHAConfig: &model.AdaptiveASHAConfig{
-					Metric:              "error",
-					SmallerIsBetter:     false,
-					MaxLength:           model.NewLengthInBatches(900),
-					MaxTrials:           5,
-					Mode:                model.StandardMode,
-					MaxRungs:            2,
-					Divisor:             3,
-					MaxConcurrentTrials: maxConcurrentTrials,
+			config: expconf.SearcherConfig{
+				RawSmallerIsBetter: ptrs.BoolPtr(false),
+				RawAdaptiveASHAConfig: &expconf.AdaptiveASHAConfig{
+					RawMaxLength: lengthPtr(expconf.NewLengthInBatches(900)),
+					RawMaxTrials: ptrs.IntPtr(5),
+					RawMode:      modePtr(expconf.StandardMode),
+					RawMaxRungs:  ptrs.IntPtr(2),
+					RawDivisor:   ptrs.Float64Ptr(3),
 				},
 			},
 		},
@@ -110,16 +109,14 @@ func TestAdaptiveASHASearchMethod(t *testing.T) {
 				newConstantPredefinedTrial(toOps("900B"), 0.2),
 				newConstantPredefinedTrial(toOps("900B"), 0.1),
 			},
-			config: model.SearcherConfig{
-				AdaptiveASHAConfig: &model.AdaptiveASHAConfig{
-					Metric:              "error",
-					SmallerIsBetter:     false,
-					MaxLength:           model.NewLengthInBatches(900),
-					MaxTrials:           5,
-					Mode:                model.StandardMode,
-					MaxRungs:            2,
-					Divisor:             3,
-					MaxConcurrentTrials: maxConcurrentTrials,
+			config: expconf.SearcherConfig{
+				RawSmallerIsBetter: ptrs.BoolPtr(false),
+				RawAdaptiveASHAConfig: &expconf.AdaptiveASHAConfig{
+					RawMaxLength: lengthPtr(expconf.NewLengthInBatches(900)),
+					RawMaxTrials: ptrs.IntPtr(5),
+					RawMode:      modePtr(expconf.StandardMode),
+					RawMaxRungs:  ptrs.IntPtr(2),
+					RawDivisor:   ptrs.Float64Ptr(3),
 				},
 			},
 		},
@@ -129,7 +126,6 @@ func TestAdaptiveASHASearchMethod(t *testing.T) {
 }
 
 func TestAdaptiveASHAStoppingSearchMethod(t *testing.T) {
-	maxConcurrentTrials := 5
 	testCases := []valueSimulationTestCase{
 		{
 			name: "smaller is better",
@@ -140,17 +136,15 @@ func TestAdaptiveASHAStoppingSearchMethod(t *testing.T) {
 				newConstantPredefinedTrial(toOps("900B"), 0.4),
 				newConstantPredefinedTrial(toOps("900B"), 0.5),
 			},
-			config: model.SearcherConfig{
-				AdaptiveASHAConfig: &model.AdaptiveASHAConfig{
-					Metric:              "error",
-					SmallerIsBetter:     true,
-					MaxLength:           model.NewLengthInBatches(900),
-					MaxTrials:           5,
-					Mode:                model.StandardMode,
-					MaxRungs:            2,
-					Divisor:             3,
-					MaxConcurrentTrials: maxConcurrentTrials,
-					StopOnce:            true,
+			config: expconf.SearcherConfig{
+				RawSmallerIsBetter: ptrs.BoolPtr(true),
+				RawAdaptiveASHAConfig: &expconf.AdaptiveASHAConfig{
+					RawMaxLength: lengthPtr(expconf.NewLengthInBatches(900)),
+					RawMaxTrials: ptrs.IntPtr(5),
+					RawMode:      modePtr(expconf.StandardMode),
+					RawMaxRungs:  ptrs.IntPtr(2),
+					RawDivisor:   ptrs.Float64Ptr(3),
+					RawStopOnce:  ptrs.BoolPtr(true),
 				},
 			},
 		},
@@ -163,17 +157,15 @@ func TestAdaptiveASHAStoppingSearchMethod(t *testing.T) {
 				newConstantPredefinedTrial(toOps("900B"), 0.4),
 				newConstantPredefinedTrial(toOps("900B"), 0.5),
 			},
-			config: model.SearcherConfig{
-				AdaptiveASHAConfig: &model.AdaptiveASHAConfig{
-					Metric:              "error",
-					SmallerIsBetter:     true,
-					MaxLength:           model.NewLengthInBatches(900),
-					MaxTrials:           5,
-					Mode:                model.StandardMode,
-					MaxRungs:            2,
-					Divisor:             3,
-					MaxConcurrentTrials: maxConcurrentTrials,
-					StopOnce:            true,
+			config: expconf.SearcherConfig{
+				RawSmallerIsBetter: ptrs.BoolPtr(true),
+				RawAdaptiveASHAConfig: &expconf.AdaptiveASHAConfig{
+					RawMaxLength: lengthPtr(expconf.NewLengthInBatches(900)),
+					RawMaxTrials: ptrs.IntPtr(5),
+					RawMode:      modePtr(expconf.StandardMode),
+					RawMaxRungs:  ptrs.IntPtr(2),
+					RawDivisor:   ptrs.Float64Ptr(3),
+					RawStopOnce:  ptrs.BoolPtr(true),
 				},
 			},
 		},
@@ -186,17 +178,15 @@ func TestAdaptiveASHAStoppingSearchMethod(t *testing.T) {
 				newConstantPredefinedTrial(toOps("900B"), 0.4),
 				newConstantPredefinedTrial(toOps("900B"), 0.5),
 			},
-			config: model.SearcherConfig{
-				AdaptiveASHAConfig: &model.AdaptiveASHAConfig{
-					Metric:              "error",
-					SmallerIsBetter:     false,
-					MaxLength:           model.NewLengthInBatches(900),
-					MaxTrials:           5,
-					Mode:                model.StandardMode,
-					MaxRungs:            2,
-					Divisor:             3,
-					MaxConcurrentTrials: maxConcurrentTrials,
-					StopOnce:            true,
+			config: expconf.SearcherConfig{
+				RawSmallerIsBetter: ptrs.BoolPtr(false),
+				RawAdaptiveASHAConfig: &expconf.AdaptiveASHAConfig{
+					RawMaxLength: lengthPtr(expconf.NewLengthInBatches(900)),
+					RawMaxTrials: ptrs.IntPtr(5),
+					RawMode:      modePtr(expconf.StandardMode),
+					RawMaxRungs:  ptrs.IntPtr(2),
+					RawDivisor:   ptrs.Float64Ptr(3),
+					RawStopOnce:  ptrs.BoolPtr(true),
 				},
 			},
 		},
@@ -209,17 +199,15 @@ func TestAdaptiveASHAStoppingSearchMethod(t *testing.T) {
 				newConstantPredefinedTrial(toOps("900B"), 0.4),
 				newConstantPredefinedTrial(toOps("900B"), 0.5),
 			},
-			config: model.SearcherConfig{
-				AdaptiveASHAConfig: &model.AdaptiveASHAConfig{
-					Metric:              "error",
-					SmallerIsBetter:     false,
-					MaxLength:           model.NewLengthInBatches(900),
-					MaxTrials:           5,
-					Mode:                model.StandardMode,
-					MaxRungs:            2,
-					Divisor:             3,
-					MaxConcurrentTrials: maxConcurrentTrials,
-					StopOnce:            true,
+			config: expconf.SearcherConfig{
+				RawSmallerIsBetter: ptrs.BoolPtr(false),
+				RawAdaptiveASHAConfig: &expconf.AdaptiveASHAConfig{
+					RawMaxLength: lengthPtr(expconf.NewLengthInBatches(900)),
+					RawMaxTrials: ptrs.IntPtr(5),
+					RawMode:      modePtr(expconf.StandardMode),
+					RawMaxRungs:  ptrs.IntPtr(2),
+					RawDivisor:   ptrs.Float64Ptr(3),
+					RawStopOnce:  ptrs.BoolPtr(true),
 				},
 			},
 		},

--- a/master/pkg/searcher/asha.go
+++ b/master/pkg/searcher/asha.go
@@ -5,9 +5,9 @@ import (
 	"math"
 	"sort"
 
-	"github.com/determined-ai/determined/master/pkg/workload"
-
 	"github.com/determined-ai/determined/master/pkg/model"
+	"github.com/determined-ai/determined/master/pkg/schemas/expconf"
+	"github.com/determined-ai/determined/master/pkg/workload"
 )
 
 // AsyncHalvingSearch implements a search using the asynchronous successive halving algorithm
@@ -27,7 +27,8 @@ type (
 	}
 
 	asyncHalvingSearch struct {
-		model.AsyncHalvingConfig
+		expconf.AsyncHalvingConfig
+		SmallerIsBetter bool
 		asyncHalvingSearchState
 	}
 
@@ -40,10 +41,10 @@ type (
 
 	// rung describes a set of trials that are to be trained for the same number of units.
 	rung struct {
-		UnitsNeeded   model.Length  `json:"units_needed"`
-		Metrics       []trialMetric `json:"metrics"`
-		StartTrials   int           `json:"start_trials"`
-		PromoteTrials int           `json:"promote_trials"`
+		UnitsNeeded   expconf.Length `json:"units_needed"`
+		Metrics       []trialMetric  `json:"metrics"`
+		StartTrials   int            `json:"start_trials"`
+		PromoteTrials int            `json:"promote_trials"`
 		// field below used by asha.go.
 		OutstandingTrials int `json:"outstanding_trials"`
 	}
@@ -51,19 +52,20 @@ type (
 
 const ashaExitedMetricValue = math.MaxFloat64
 
-func newAsyncHalvingSearch(config model.AsyncHalvingConfig) SearchMethod {
-	rungs := make([]*rung, 0, config.NumRungs)
+func newAsyncHalvingSearch(config expconf.AsyncHalvingConfig, smallerIsBetter bool) SearchMethod {
+	rungs := make([]*rung, 0, config.NumRungs())
 	unitsNeeded := 0
-	for id := 0; id < config.NumRungs; id++ {
+	for id := 0; id < config.NumRungs(); id++ {
 		// We divide the MaxLength by downsampling rate to get the target units
 		// for a rung.
-		downsamplingRate := math.Pow(config.Divisor, float64(config.NumRungs-id-1))
-		unitsNeeded += max(int(float64(config.MaxLength.Units)/downsamplingRate), 1)
-		rungs = append(rungs, &rung{UnitsNeeded: model.NewLength(config.Unit(), unitsNeeded)})
+		downsamplingRate := math.Pow(config.Divisor(), float64(config.NumRungs()-id-1))
+		unitsNeeded += max(int(float64(config.MaxLength().Units)/downsamplingRate), 1)
+		rungs = append(rungs, &rung{UnitsNeeded: expconf.NewLength(config.Unit(), unitsNeeded)})
 	}
 
 	return &asyncHalvingSearch{
 		AsyncHalvingConfig: config,
+		SmallerIsBetter:    smallerIsBetter,
 		asyncHalvingSearchState: asyncHalvingSearchState{
 			Rungs:            rungs,
 			TrialRungs:       make(map[model.RequestID]int),
@@ -134,11 +136,11 @@ func (s *asyncHalvingSearch) initialOperations(ctx context) ([]Operation, error)
 	var ops []Operation
 	var maxConcurrentTrials int
 
-	if s.MaxConcurrentTrials > 0 {
-		maxConcurrentTrials = min(s.MaxConcurrentTrials, s.MaxTrials)
+	if s.MaxConcurrentTrials() > 0 {
+		maxConcurrentTrials = min(s.MaxConcurrentTrials(), s.MaxTrials())
 	} else {
 		maxConcurrentTrials = max(
-			min(int(math.Pow(s.Divisor, float64(s.NumRungs-1))), s.MaxTrials),
+			min(int(math.Pow(s.Divisor(), float64(s.NumRungs()-1))), s.MaxTrials()),
 			1)
 	}
 
@@ -191,7 +193,7 @@ func (s *asyncHalvingSearch) promoteAsync(
 
 	var ops []Operation
 	// If the trial has completed the top rung's validation, close the trial.
-	if rungIndex == s.NumRungs-1 {
+	if rungIndex == s.NumRungs()-1 {
 		rung.Metrics = append(rung.Metrics,
 			trialMetric{
 				RequestID: requestID,
@@ -209,13 +211,13 @@ func (s *asyncHalvingSearch) promoteAsync(
 		for _, promotionID := range rung.promotionsAsync(
 			requestID,
 			metric,
-			s.Divisor,
+			s.Divisor(),
 		) {
 			s.TrialRungs[promotionID] = rungIndex + 1
 			nextRung.OutstandingTrials++
 			if !s.EarlyExitTrials[promotionID] {
 				unitsNeeded := max(nextRung.UnitsNeeded.Units-rung.UnitsNeeded.Units, 1)
-				ops = append(ops, NewValidateAfter(promotionID, model.NewLength(s.Unit(), unitsNeeded)))
+				ops = append(ops, NewValidateAfter(promotionID, expconf.NewLength(s.Unit(), unitsNeeded)))
 				addedTrainWorkload = true
 				s.PendingTrials++
 			} else {
@@ -228,7 +230,7 @@ func (s *asyncHalvingSearch) promoteAsync(
 	}
 
 	allTrials := len(s.TrialRungs) - s.InvalidTrials
-	if !addedTrainWorkload && allTrials < s.MaxTrials {
+	if !addedTrainWorkload && allTrials < s.MaxTrials() {
 		s.PendingTrials++
 		create := NewCreate(
 			ctx.rand, sampleAll(ctx.hparams, ctx.rand), model.TrialWorkloadSequencerType)
@@ -238,7 +240,7 @@ func (s *asyncHalvingSearch) promoteAsync(
 	}
 
 	// Only close out trials once we have reached the MaxTrials for the searcher.
-	if len(s.Rungs[0].Metrics) == s.MaxTrials {
+	if len(s.Rungs[0].Metrics) == s.MaxTrials() {
 		ops = append(ops, s.closeOutRungs()...)
 	}
 	return ops
@@ -265,15 +267,15 @@ func (s *asyncHalvingSearch) closeOutRungs() []Operation {
 }
 
 func (s *asyncHalvingSearch) progress(map[model.RequestID]model.PartialUnits) float64 {
-	if s.MaxConcurrentTrials > 0 && s.PendingTrials > s.MaxConcurrentTrials {
+	if s.MaxConcurrentTrials() > 0 && s.PendingTrials > s.MaxConcurrentTrials() {
 		panic("pending trials is greater than max_concurrent_trials")
 	}
 	allTrials := len(s.Rungs[0].Metrics)
 	// Give ourselves an overhead of 20% of MaxTrials when calculating progress.
-	progress := float64(allTrials) / (1.2 * float64(s.MaxTrials))
-	if allTrials == s.MaxTrials {
+	progress := float64(allTrials) / (1.2 * float64(s.MaxTrials()))
+	if allTrials == s.MaxTrials() {
 		numValidTrials := float64(s.TrialsCompleted) - float64(s.InvalidTrials)
-		progressNoOverhead := numValidTrials / float64(s.MaxTrials)
+		progressNoOverhead := numValidTrials / float64(s.MaxTrials())
 		progress = math.Max(progressNoOverhead, progress)
 	}
 	return progress

--- a/master/pkg/searcher/asha_stopping_test.go
+++ b/master/pkg/searcher/asha_stopping_test.go
@@ -3,19 +3,21 @@ package searcher
 import (
 	"testing"
 
-	"github.com/determined-ai/determined/master/pkg/model"
+	"github.com/determined-ai/determined/master/pkg/ptrs"
+	"github.com/determined-ai/determined/master/pkg/schemas"
+	"github.com/determined-ai/determined/master/pkg/schemas/expconf"
 )
 
 func TestASHAStoppingSearcherRecords(t *testing.T) {
-	actual := model.AsyncHalvingConfig{
-		Metric: defaultMetric, NumRungs: 3,
-		MaxLength:           model.NewLengthInRecords(576000),
-		SmallerIsBetter:     true,
-		Divisor:             3,
-		MaxTrials:           12,
-		StopOnce:            true,
-		MaxConcurrentTrials: 2,
+	actual := expconf.AsyncHalvingConfig{
+		RawNumRungs:            ptrs.IntPtr(3),
+		RawMaxLength:           lengthPtr(expconf.NewLengthInRecords(576000)),
+		RawDivisor:             ptrs.Float64Ptr(3),
+		RawMaxTrials:           ptrs.IntPtr(12),
+		RawStopOnce:            ptrs.BoolPtr(true),
+		RawMaxConcurrentTrials: ptrs.IntPtr(2),
 	}
+	actual = schemas.WithDefaults(actual).(expconf.AsyncHalvingConfig)
 	// Stopping-based ASHA will only promote if a trial is in top 1/3 of trials in the rung or if
 	// there have been no promotions so far.  Since trials cannot be restarted and metrics increase
 	// for later trials, only the first trial will be promoted and all others will be stopped on
@@ -27,19 +29,19 @@ func TestASHAStoppingSearcherRecords(t *testing.T) {
 		toOps("64000R"), toOps("64000R"), toOps("64000R"),
 		toOps("64000R"), toOps("64000R"),
 	}
-	checkSimulation(t, newAsyncHalvingStoppingSearch(actual), nil, TrialIDMetric, expected)
+	checkSimulation(t, newAsyncHalvingStoppingSearch(actual, true), nil, TrialIDMetric, expected)
 }
 
 func TestASHAStoppingSearcherBatches(t *testing.T) {
-	actual := model.AsyncHalvingConfig{
-		Metric: defaultMetric, NumRungs: 3,
-		MaxLength:           model.NewLengthInBatches(9000),
-		SmallerIsBetter:     true,
-		Divisor:             3,
-		MaxTrials:           12,
-		StopOnce:            true,
-		MaxConcurrentTrials: 2,
+	actual := expconf.AsyncHalvingConfig{
+		RawNumRungs:            ptrs.IntPtr(3),
+		RawMaxLength:           lengthPtr(expconf.NewLengthInBatches(9000)),
+		RawDivisor:             ptrs.Float64Ptr(3),
+		RawMaxTrials:           ptrs.IntPtr(12),
+		RawStopOnce:            ptrs.BoolPtr(true),
+		RawMaxConcurrentTrials: ptrs.IntPtr(2),
 	}
+	actual = schemas.WithDefaults(actual).(expconf.AsyncHalvingConfig)
 	expected := [][]ValidateAfter{
 		toOps("1000B 3000B 9000B"),
 		toOps("1000B"), toOps("1000B"), toOps("1000B"),
@@ -47,19 +49,19 @@ func TestASHAStoppingSearcherBatches(t *testing.T) {
 		toOps("1000B"), toOps("1000B"), toOps("1000B"),
 		toOps("1000B"), toOps("1000B"),
 	}
-	checkSimulation(t, newAsyncHalvingStoppingSearch(actual), nil, TrialIDMetric, expected)
+	checkSimulation(t, newAsyncHalvingStoppingSearch(actual, true), nil, TrialIDMetric, expected)
 }
 
 func TestASHAStoppingSearcherEpochs(t *testing.T) {
-	actual := model.AsyncHalvingConfig{
-		Metric: defaultMetric, NumRungs: 3,
-		MaxLength:           model.NewLengthInEpochs(12),
-		SmallerIsBetter:     true,
-		Divisor:             3,
-		MaxTrials:           12,
-		StopOnce:            true,
-		MaxConcurrentTrials: 2,
+	actual := expconf.AsyncHalvingConfig{
+		RawNumRungs:            ptrs.IntPtr(3),
+		RawMaxLength:           lengthPtr(expconf.NewLengthInEpochs(12)),
+		RawDivisor:             ptrs.Float64Ptr(3),
+		RawMaxTrials:           ptrs.IntPtr(12),
+		RawStopOnce:            ptrs.BoolPtr(true),
+		RawMaxConcurrentTrials: ptrs.IntPtr(2),
 	}
+	actual = schemas.WithDefaults(actual).(expconf.AsyncHalvingConfig)
 	expected := [][]ValidateAfter{
 		toOps("1E 4E 12E"),
 		toOps("1E"), toOps("1E"), toOps("1E"),
@@ -67,11 +69,10 @@ func TestASHAStoppingSearcherEpochs(t *testing.T) {
 		toOps("1E"), toOps("1E"), toOps("1E"),
 		toOps("1E"), toOps("1E"),
 	}
-	checkSimulation(t, newAsyncHalvingStoppingSearch(actual), nil, TrialIDMetric, expected)
+	checkSimulation(t, newAsyncHalvingStoppingSearch(actual, true), nil, TrialIDMetric, expected)
 }
 
 func TestASHAStoppingSearchMethod(t *testing.T) {
-	maxConcurrentTrials := 3
 	testCases := []valueSimulationTestCase{
 		{
 			name: "smaller is better",
@@ -89,16 +90,14 @@ func TestASHAStoppingSearchMethod(t *testing.T) {
 				newConstantPredefinedTrial(toOps("1000B"), 0.11),
 				newConstantPredefinedTrial(toOps("1000B"), 0.12),
 			},
-			config: model.SearcherConfig{
-				AsyncHalvingConfig: &model.AsyncHalvingConfig{
-					Metric:              "error",
-					NumRungs:            3,
-					SmallerIsBetter:     true,
-					MaxLength:           model.NewLengthInBatches(9000),
-					MaxTrials:           12,
-					Divisor:             3,
-					MaxConcurrentTrials: maxConcurrentTrials,
-					StopOnce:            true,
+			config: expconf.SearcherConfig{
+				RawSmallerIsBetter: ptrs.BoolPtr(true),
+				RawAsyncHalvingConfig: &expconf.AsyncHalvingConfig{
+					RawNumRungs:  ptrs.IntPtr(3),
+					RawMaxLength: lengthPtr(expconf.NewLengthInBatches(9000)),
+					RawMaxTrials: ptrs.IntPtr(12),
+					RawDivisor:   ptrs.Float64Ptr(3),
+					RawStopOnce:  ptrs.BoolPtr(true),
 				},
 			},
 		},
@@ -118,16 +117,14 @@ func TestASHAStoppingSearchMethod(t *testing.T) {
 				newConstantPredefinedTrial(toOps("1000B"), 0.03),
 				newConstantPredefinedTrial(toOps("1000B"), 0.04),
 			},
-			config: model.SearcherConfig{
-				AsyncHalvingConfig: &model.AsyncHalvingConfig{
-					Metric:              "error",
-					NumRungs:            3,
-					SmallerIsBetter:     true,
-					MaxLength:           model.NewLengthInBatches(9000),
-					MaxTrials:           12,
-					Divisor:             3,
-					MaxConcurrentTrials: maxConcurrentTrials,
-					StopOnce:            true,
+			config: expconf.SearcherConfig{
+				RawSmallerIsBetter: ptrs.BoolPtr(true),
+				RawAsyncHalvingConfig: &expconf.AsyncHalvingConfig{
+					RawNumRungs:  ptrs.IntPtr(3),
+					RawMaxLength: lengthPtr(expconf.NewLengthInBatches(9000)),
+					RawMaxTrials: ptrs.IntPtr(12),
+					RawDivisor:   ptrs.Float64Ptr(3),
+					RawStopOnce:  ptrs.BoolPtr(true),
 				},
 			},
 		},
@@ -147,16 +144,14 @@ func TestASHAStoppingSearchMethod(t *testing.T) {
 				newConstantPredefinedTrial(toOps("1000B 3000B 9000B"), 0.11),
 				newConstantPredefinedTrial(toOps("1000B 3000B 9000B"), 0.12),
 			},
-			config: model.SearcherConfig{
-				AsyncHalvingConfig: &model.AsyncHalvingConfig{
-					Metric:              "error",
-					NumRungs:            3,
-					SmallerIsBetter:     false,
-					MaxLength:           model.NewLengthInBatches(9000),
-					MaxTrials:           12,
-					Divisor:             3,
-					MaxConcurrentTrials: maxConcurrentTrials,
-					StopOnce:            true,
+			config: expconf.SearcherConfig{
+				RawSmallerIsBetter: ptrs.BoolPtr(false),
+				RawAsyncHalvingConfig: &expconf.AsyncHalvingConfig{
+					RawNumRungs:  ptrs.IntPtr(3),
+					RawMaxLength: lengthPtr(expconf.NewLengthInBatches(9000)),
+					RawMaxTrials: ptrs.IntPtr(12),
+					RawDivisor:   ptrs.Float64Ptr(3),
+					RawStopOnce:  ptrs.BoolPtr(true),
 				},
 			},
 		},
@@ -176,16 +171,14 @@ func TestASHAStoppingSearchMethod(t *testing.T) {
 				newConstantPredefinedTrial(toOps("1000B 3000B"), 0.03),
 				newConstantPredefinedTrial(toOps("1000B 3000B 9000B"), 0.04),
 			},
-			config: model.SearcherConfig{
-				AsyncHalvingConfig: &model.AsyncHalvingConfig{
-					Metric:              "error",
-					NumRungs:            3,
-					SmallerIsBetter:     false,
-					MaxLength:           model.NewLengthInBatches(9000),
-					MaxTrials:           12,
-					Divisor:             3,
-					MaxConcurrentTrials: maxConcurrentTrials,
-					StopOnce:            true,
+			config: expconf.SearcherConfig{
+				RawSmallerIsBetter: ptrs.BoolPtr(false),
+				RawAsyncHalvingConfig: &expconf.AsyncHalvingConfig{
+					RawNumRungs:  ptrs.IntPtr(3),
+					RawMaxLength: lengthPtr(expconf.NewLengthInBatches(9000)),
+					RawMaxTrials: ptrs.IntPtr(12),
+					RawDivisor:   ptrs.Float64Ptr(3),
+					RawStopOnce:  ptrs.BoolPtr(true),
 				},
 			},
 		},
@@ -205,16 +198,14 @@ func TestASHAStoppingSearchMethod(t *testing.T) {
 				newConstantPredefinedTrial(toOps("1000B"), 0.03),
 				newConstantPredefinedTrial(toOps("1000B"), 0.04),
 			},
-			config: model.SearcherConfig{
-				AsyncHalvingConfig: &model.AsyncHalvingConfig{
-					Metric:              "error",
-					NumRungs:            3,
-					SmallerIsBetter:     true,
-					MaxLength:           model.NewLengthInBatches(9000),
-					MaxTrials:           12,
-					Divisor:             3,
-					MaxConcurrentTrials: maxConcurrentTrials,
-					StopOnce:            true,
+			config: expconf.SearcherConfig{
+				RawSmallerIsBetter: ptrs.BoolPtr(true),
+				RawAsyncHalvingConfig: &expconf.AsyncHalvingConfig{
+					RawNumRungs:  ptrs.IntPtr(3),
+					RawMaxLength: lengthPtr(expconf.NewLengthInBatches(9000)),
+					RawMaxTrials: ptrs.IntPtr(12),
+					RawDivisor:   ptrs.Float64Ptr(3),
+					RawStopOnce:  ptrs.BoolPtr(true),
 				},
 			},
 		},
@@ -234,16 +225,14 @@ func TestASHAStoppingSearchMethod(t *testing.T) {
 				newConstantPredefinedTrial(toOps("1000B 3000B 9000B"), 0.03),
 				newConstantPredefinedTrial(toOps("1000B 3000B 9000B"), 0.04),
 			},
-			config: model.SearcherConfig{
-				AsyncHalvingConfig: &model.AsyncHalvingConfig{
-					Metric:              "error",
-					NumRungs:            3,
-					SmallerIsBetter:     false,
-					MaxLength:           model.NewLengthInBatches(9000),
-					MaxTrials:           12,
-					Divisor:             3,
-					MaxConcurrentTrials: maxConcurrentTrials,
-					StopOnce:            true,
+			config: expconf.SearcherConfig{
+				RawSmallerIsBetter: ptrs.BoolPtr(false),
+				RawAsyncHalvingConfig: &expconf.AsyncHalvingConfig{
+					RawNumRungs:  ptrs.IntPtr(3),
+					RawMaxLength: lengthPtr(expconf.NewLengthInBatches(9000)),
+					RawMaxTrials: ptrs.IntPtr(12),
+					RawDivisor:   ptrs.Float64Ptr(3),
+					RawStopOnce:  ptrs.BoolPtr(true),
 				},
 			},
 		},
@@ -258,16 +247,14 @@ func TestASHAStoppingSearchMethod(t *testing.T) {
 				newConstantPredefinedTrial(toOps("9000B"), 0.07),
 				newConstantPredefinedTrial(toOps("9000B"), 0.08),
 			},
-			config: model.SearcherConfig{
-				AsyncHalvingConfig: &model.AsyncHalvingConfig{
-					Metric:              "error",
-					NumRungs:            1,
-					SmallerIsBetter:     true,
-					MaxLength:           model.NewLengthInBatches(9000),
-					MaxTrials:           4,
-					Divisor:             3,
-					MaxConcurrentTrials: maxConcurrentTrials,
-					StopOnce:            true,
+			config: expconf.SearcherConfig{
+				RawSmallerIsBetter: ptrs.BoolPtr(true),
+				RawAsyncHalvingConfig: &expconf.AsyncHalvingConfig{
+					RawNumRungs:  ptrs.IntPtr(1),
+					RawMaxLength: lengthPtr(expconf.NewLengthInBatches(9000)),
+					RawMaxTrials: ptrs.IntPtr(4),
+					RawDivisor:   ptrs.Float64Ptr(3),
+					RawStopOnce:  ptrs.BoolPtr(true),
 				},
 			},
 		},

--- a/master/pkg/searcher/asha_test.go
+++ b/master/pkg/searcher/asha_test.go
@@ -3,16 +3,19 @@ package searcher
 import (
 	"testing"
 
-	"github.com/determined-ai/determined/master/pkg/model"
+	"github.com/determined-ai/determined/master/pkg/ptrs"
+	"github.com/determined-ai/determined/master/pkg/schemas"
+	"github.com/determined-ai/determined/master/pkg/schemas/expconf"
 )
 
 func TestASHASearcherRecords(t *testing.T) {
-	actual := model.AsyncHalvingConfig{
-		Metric: defaultMetric, NumRungs: 3,
-		MaxLength: model.NewLengthInRecords(576000),
-		Divisor:   3,
-		MaxTrials: 12,
+	actual := expconf.AsyncHalvingConfig{
+		RawNumRungs:  ptrs.IntPtr(3),
+		RawMaxLength: lengthPtr(expconf.NewLengthInRecords(576000)),
+		RawDivisor:   ptrs.Float64Ptr(3),
+		RawMaxTrials: ptrs.IntPtr(12),
 	}
+	actual = schemas.WithDefaults(actual).(expconf.AsyncHalvingConfig)
 	expected := [][]ValidateAfter{
 		toOps("64000R"), toOps("64000R"), toOps("64000R"),
 		toOps("64000R"), toOps("64000R"), toOps("64000R"),
@@ -22,16 +25,17 @@ func TestASHASearcherRecords(t *testing.T) {
 		toOps("64000R 192000R"),
 		toOps("64000R 192000R 576000R"),
 	}
-	checkSimulation(t, newAsyncHalvingSearch(actual), nil, ConstantValidation, expected)
+	checkSimulation(t, newAsyncHalvingSearch(actual, true), nil, ConstantValidation, expected)
 }
 
 func TestASHASearcherBatches(t *testing.T) {
-	actual := model.AsyncHalvingConfig{
-		Metric: defaultMetric, NumRungs: 3,
-		MaxLength: model.NewLengthInBatches(9000),
-		Divisor:   3,
-		MaxTrials: 12,
+	actual := expconf.AsyncHalvingConfig{
+		RawNumRungs:  ptrs.IntPtr(3),
+		RawMaxLength: lengthPtr(expconf.NewLengthInBatches(9000)),
+		RawDivisor:   ptrs.Float64Ptr(3),
+		RawMaxTrials: ptrs.IntPtr(12),
 	}
+	actual = schemas.WithDefaults(actual).(expconf.AsyncHalvingConfig)
 	expected := [][]ValidateAfter{
 		toOps("1000B"), toOps("1000B"), toOps("1000B"),
 		toOps("1000B"), toOps("1000B"), toOps("1000B"),
@@ -41,16 +45,17 @@ func TestASHASearcherBatches(t *testing.T) {
 		toOps("1000B 3000B"),
 		toOps("1000B 3000B 9000B"),
 	}
-	checkSimulation(t, newAsyncHalvingSearch(actual), nil, ConstantValidation, expected)
+	checkSimulation(t, newAsyncHalvingSearch(actual, true), nil, ConstantValidation, expected)
 }
 
 func TestASHASearcherEpochs(t *testing.T) {
-	actual := model.AsyncHalvingConfig{
-		Metric: defaultMetric, NumRungs: 3,
-		MaxLength: model.NewLengthInEpochs(12),
-		Divisor:   3,
-		MaxTrials: 12,
+	actual := expconf.AsyncHalvingConfig{
+		RawNumRungs:  ptrs.IntPtr(3),
+		RawMaxLength: lengthPtr(expconf.NewLengthInEpochs(12)),
+		RawDivisor:   ptrs.Float64Ptr(3),
+		RawMaxTrials: ptrs.IntPtr(12),
 	}
+	actual = schemas.WithDefaults(actual).(expconf.AsyncHalvingConfig)
 	expected := [][]ValidateAfter{
 		toOps("1E"), toOps("1E"), toOps("1E"),
 		toOps("1E"), toOps("1E"), toOps("1E"),
@@ -60,11 +65,10 @@ func TestASHASearcherEpochs(t *testing.T) {
 		toOps("1E 4E"),
 		toOps("1E 4E 12E"),
 	}
-	checkSimulation(t, newAsyncHalvingSearch(actual), nil, ConstantValidation, expected)
+	checkSimulation(t, newAsyncHalvingSearch(actual, true), nil, ConstantValidation, expected)
 }
 
 func TestASHASearchMethod(t *testing.T) {
-	maxConcurrentTrials := 3
 	testCases := []valueSimulationTestCase{
 		{
 			name: "smaller is better",
@@ -82,15 +86,13 @@ func TestASHASearchMethod(t *testing.T) {
 				newConstantPredefinedTrial(toOps("1000B"), 0.11),
 				newConstantPredefinedTrial(toOps("1000B"), 0.12),
 			},
-			config: model.SearcherConfig{
-				AsyncHalvingConfig: &model.AsyncHalvingConfig{
-					Metric:              "error",
-					NumRungs:            3,
-					SmallerIsBetter:     true,
-					MaxLength:           model.NewLengthInBatches(9000),
-					MaxTrials:           12,
-					Divisor:             3,
-					MaxConcurrentTrials: maxConcurrentTrials,
+			config: expconf.SearcherConfig{
+				RawSmallerIsBetter: ptrs.BoolPtr(true),
+				RawAsyncHalvingConfig: &expconf.AsyncHalvingConfig{
+					RawNumRungs:  ptrs.IntPtr(3),
+					RawMaxLength: lengthPtr(expconf.NewLengthInBatches(9000)),
+					RawMaxTrials: ptrs.IntPtr(12),
+					RawDivisor:   ptrs.Float64Ptr(3),
 				},
 			},
 		},
@@ -110,15 +112,13 @@ func TestASHASearchMethod(t *testing.T) {
 				newConstantPredefinedTrial(toOps("1000B"), 0.11),
 				newConstantPredefinedTrial(toOps("1000B"), 0.12),
 			},
-			config: model.SearcherConfig{
-				AsyncHalvingConfig: &model.AsyncHalvingConfig{
-					Metric:              "error",
-					NumRungs:            3,
-					SmallerIsBetter:     true,
-					MaxLength:           model.NewLengthInBatches(9000),
-					MaxTrials:           12,
-					Divisor:             3,
-					MaxConcurrentTrials: maxConcurrentTrials,
+			config: expconf.SearcherConfig{
+				RawSmallerIsBetter: ptrs.BoolPtr(true),
+				RawAsyncHalvingConfig: &expconf.AsyncHalvingConfig{
+					RawNumRungs:  ptrs.IntPtr(3),
+					RawMaxLength: lengthPtr(expconf.NewLengthInBatches(9000)),
+					RawMaxTrials: ptrs.IntPtr(12),
+					RawDivisor:   ptrs.Float64Ptr(3),
 				},
 			},
 		},
@@ -138,15 +138,13 @@ func TestASHASearchMethod(t *testing.T) {
 				newConstantPredefinedTrial(toOps("1000B"), 0.02),
 				newConstantPredefinedTrial(toOps("1000B"), 0.01),
 			},
-			config: model.SearcherConfig{
-				AsyncHalvingConfig: &model.AsyncHalvingConfig{
-					Metric:              "error",
-					NumRungs:            3,
-					SmallerIsBetter:     false,
-					MaxLength:           model.NewLengthInBatches(9000),
-					MaxTrials:           12,
-					Divisor:             3,
-					MaxConcurrentTrials: maxConcurrentTrials,
+			config: expconf.SearcherConfig{
+				RawSmallerIsBetter: ptrs.BoolPtr(false),
+				RawAsyncHalvingConfig: &expconf.AsyncHalvingConfig{
+					RawNumRungs:  ptrs.IntPtr(3),
+					RawMaxLength: lengthPtr(expconf.NewLengthInBatches(9000)),
+					RawMaxTrials: ptrs.IntPtr(12),
+					RawDivisor:   ptrs.Float64Ptr(3),
 				},
 			},
 		},
@@ -166,15 +164,13 @@ func TestASHASearchMethod(t *testing.T) {
 				newConstantPredefinedTrial(toOps("1000B"), 0.02),
 				newConstantPredefinedTrial(toOps("1000B"), 0.01),
 			},
-			config: model.SearcherConfig{
-				AsyncHalvingConfig: &model.AsyncHalvingConfig{
-					Metric:              "error",
-					NumRungs:            3,
-					SmallerIsBetter:     false,
-					MaxLength:           model.NewLengthInBatches(9000),
-					MaxTrials:           12,
-					Divisor:             3,
-					MaxConcurrentTrials: maxConcurrentTrials,
+			config: expconf.SearcherConfig{
+				RawSmallerIsBetter: ptrs.BoolPtr(false),
+				RawAsyncHalvingConfig: &expconf.AsyncHalvingConfig{
+					RawNumRungs:  ptrs.IntPtr(3),
+					RawMaxLength: lengthPtr(expconf.NewLengthInBatches(9000)),
+					RawMaxTrials: ptrs.IntPtr(12),
+					RawDivisor:   ptrs.Float64Ptr(3),
 				},
 			},
 		},
@@ -197,15 +193,13 @@ func TestASHASearchMethod(t *testing.T) {
 				newConstantPredefinedTrial(toOps("1000B"), 0.08),
 				newConstantPredefinedTrial(toOps("1000B"), 0.09),
 			},
-			config: model.SearcherConfig{
-				AsyncHalvingConfig: &model.AsyncHalvingConfig{
-					Metric:              "error",
-					NumRungs:            3,
-					SmallerIsBetter:     true,
-					MaxLength:           model.NewLengthInBatches(9000),
-					MaxTrials:           12,
-					Divisor:             3,
-					MaxConcurrentTrials: maxConcurrentTrials,
+			config: expconf.SearcherConfig{
+				RawSmallerIsBetter: ptrs.BoolPtr(true),
+				RawAsyncHalvingConfig: &expconf.AsyncHalvingConfig{
+					RawNumRungs:  ptrs.IntPtr(3),
+					RawMaxLength: lengthPtr(expconf.NewLengthInBatches(9000)),
+					RawMaxTrials: ptrs.IntPtr(12),
+					RawDivisor:   ptrs.Float64Ptr(3),
 				},
 			},
 		},
@@ -220,15 +214,13 @@ func TestASHASearchMethod(t *testing.T) {
 				newConstantPredefinedTrial(toOps("9000B"), 0.07),
 				newConstantPredefinedTrial(toOps("9000B"), 0.08),
 			},
-			config: model.SearcherConfig{
-				AsyncHalvingConfig: &model.AsyncHalvingConfig{
-					Metric:              "error",
-					NumRungs:            1,
-					SmallerIsBetter:     true,
-					MaxLength:           model.NewLengthInBatches(9000),
-					MaxTrials:           4,
-					Divisor:             3,
-					MaxConcurrentTrials: maxConcurrentTrials,
+			config: expconf.SearcherConfig{
+				RawSmallerIsBetter: ptrs.BoolPtr(true),
+				RawAsyncHalvingConfig: &expconf.AsyncHalvingConfig{
+					RawNumRungs:  ptrs.IntPtr(1),
+					RawMaxLength: lengthPtr(expconf.NewLengthInBatches(9000)),
+					RawMaxTrials: ptrs.IntPtr(4),
+					RawDivisor:   ptrs.Float64Ptr(3),
 				},
 			},
 		},

--- a/master/pkg/searcher/grid.go
+++ b/master/pkg/searcher/grid.go
@@ -6,6 +6,7 @@ import (
 	"math"
 
 	"github.com/determined-ai/determined/master/pkg/model"
+	"github.com/determined-ai/determined/master/pkg/schemas/expconf"
 	"github.com/determined-ai/determined/master/pkg/workload"
 )
 
@@ -24,13 +25,13 @@ type (
 	// one trial is generated per point on the grid and trained for the specified number of steps.
 	gridSearch struct {
 		defaultSearchMethod
-		model.GridConfig
+		expconf.GridConfig
 		gridSearchState
 		trials int
 	}
 )
 
-func newGridSearch(config model.GridConfig) SearchMethod {
+func newGridSearch(config expconf.GridConfig) SearchMethod {
 	return &gridSearch{
 		GridConfig: config,
 		gridSearchState: gridSearchState{
@@ -45,8 +46,8 @@ func (s *gridSearch) initialOperations(ctx context) ([]Operation, error) {
 	s.trials = len(grid)
 	s.RemainingTrials = append(s.RemainingTrials, grid...)
 	initialTrials := s.trials
-	if s.MaxConcurrentTrials > 0 {
-		initialTrials = min(s.trials, s.MaxConcurrentTrials)
+	if s.MaxConcurrentTrials() > 0 {
+		initialTrials = min(s.trials, s.MaxConcurrentTrials())
 	}
 	var ops []Operation
 	for trial := 0; trial < initialTrials; trial++ {
@@ -54,7 +55,7 @@ func (s *gridSearch) initialOperations(ctx context) ([]Operation, error) {
 		s.RemainingTrials = s.RemainingTrials[:len(s.RemainingTrials)-1]
 		create := NewCreate(ctx.rand, params, model.TrialWorkloadSequencerType)
 		ops = append(ops, create)
-		ops = append(ops, NewValidateAfter(create.RequestID, s.MaxLength))
+		ops = append(ops, NewValidateAfter(create.RequestID, s.MaxLength()))
 		ops = append(ops, NewClose(create.RequestID))
 		s.PendingTrials++
 	}
@@ -62,11 +63,11 @@ func (s *gridSearch) initialOperations(ctx context) ([]Operation, error) {
 }
 
 func (s *gridSearch) progress(trialProgress map[model.RequestID]model.PartialUnits) float64 {
-	if s.MaxConcurrentTrials > 0 && s.PendingTrials > s.MaxConcurrentTrials {
+	if s.MaxConcurrentTrials() > 0 && s.PendingTrials > s.MaxConcurrentTrials() {
 		panic("pending trials is greater than max_concurrent_trials")
 	}
 	unitsCompleted := sumTrialLengths(trialProgress)
-	unitsExpected := s.MaxLength.Units * s.trials
+	unitsExpected := s.MaxLength().Units * s.trials
 	return float64(unitsCompleted) / float64(unitsExpected)
 }
 
@@ -82,7 +83,7 @@ func (s *gridSearch) trialExitedEarly(
 		s.RemainingTrials = s.RemainingTrials[:len(s.RemainingTrials)-1]
 		create := NewCreate(ctx.rand, params, model.TrialWorkloadSequencerType)
 		ops = append(ops, create)
-		ops = append(ops, NewValidateAfter(create.RequestID, s.MaxLength))
+		ops = append(ops, NewValidateAfter(create.RequestID, s.MaxLength()))
 		ops = append(ops, NewClose(create.RequestID))
 		s.PendingTrials++
 	}
@@ -97,17 +98,17 @@ func (s *gridSearch) trialClosed(ctx context, _ model.RequestID) ([]Operation, e
 		s.RemainingTrials = s.RemainingTrials[:len(s.RemainingTrials)-1]
 		create := NewCreate(ctx.rand, params, model.TrialWorkloadSequencerType)
 		ops = append(ops, create)
-		ops = append(ops, NewValidateAfter(create.RequestID, s.MaxLength))
+		ops = append(ops, NewValidateAfter(create.RequestID, s.MaxLength()))
 		ops = append(ops, NewClose(create.RequestID))
 		s.PendingTrials++
 	}
 	return ops, nil
 }
 
-func newHyperparameterGrid(params model.Hyperparameters) []hparamSample {
+func newHyperparameterGrid(params expconf.Hyperparameters) []hparamSample {
 	var names []string
 	var values [][]interface{}
-	params.Each(func(name string, param model.Hyperparameter) {
+	params.Each(func(name string, param expconf.Hyperparameter) {
 		names = append(names, name)
 		values = append(values, grid(param))
 	})
@@ -142,60 +143,66 @@ func cartesianProduct(names []string, valueSets [][]interface{}) []hparamSample 
 	}
 }
 
-func grid(h model.Hyperparameter) []interface{} {
+func grid(h expconf.Hyperparameter) []interface{} {
 	switch {
-	case h.ConstHyperparameter != nil:
-		p := *h.ConstHyperparameter
-		return []interface{}{p.Val}
-	case h.IntHyperparameter != nil:
-		p := *h.IntHyperparameter
+	case h.RawConstHyperparameter != nil:
+		p := *h.RawConstHyperparameter
+		return []interface{}{p.Val()}
+	case h.RawIntHyperparameter != nil:
+		p := *h.RawIntHyperparameter
 		// Dereferencing is okay because initialization of GridSearch has checked p.Count is non-nil.
-		count := *p.Count
+		count := *p.Count()
 
 		// Clamp to the maximum number of integers in the range.
-		count = min(count, p.Maxval-p.Minval+1)
+		count = min(count, p.Maxval()-p.Minval()+1)
 
 		vals := make([]interface{}, count)
 		// Includes temporary validation, for invalid count
 		if count == 1 {
-			vals[0] = int(math.Round(float64(p.Minval+p.Maxval) / 2.0))
+			vals[0] = int(math.Round(float64(p.Minval()+p.Maxval()) / 2.0))
 		} else {
 			for i := 0; i < count; i++ {
-				vals[i] = int(math.Round(float64(p.Minval) + float64(i*(p.Maxval-p.Minval))/float64(count-1)))
+				vals[i] = int(
+					math.Round(
+						float64(p.Minval()) + float64(i*(p.Maxval()-p.Minval()))/float64(count-1),
+					),
+				)
 			}
 		}
 		return vals
-	case h.DoubleHyperparameter != nil:
-		p := *h.DoubleHyperparameter
+	case h.RawDoubleHyperparameter != nil:
+		p := *h.RawDoubleHyperparameter
 		// Dereferencing is okay because initialization of GridSearch has checked p.Count is non-nil.
-		count := *p.Count
+		count := *p.Count()
 		vals := make([]interface{}, count)
 
 		if count == 1 {
-			vals[0] = (p.Minval + p.Maxval) / 2.0
+			vals[0] = (p.Minval() + p.Maxval()) / 2.0
 		} else {
 			for i := 0; i < count; i++ {
-				vals[i] = p.Minval + float64(i)*(p.Maxval-p.Minval)/float64(count-1)
+				vals[i] = p.Minval() + float64(i)*(p.Maxval()-p.Minval())/float64(count-1)
 			}
 		}
 		return vals
-	case h.LogHyperparameter != nil:
-		p := *h.LogHyperparameter
-		count := *p.Count
+	case h.RawLogHyperparameter != nil:
+		p := *h.RawLogHyperparameter
+		count := *p.Count()
 		vals := make([]interface{}, count)
 
 		// Includes temporary validation, for invalid count.
 		if count == 1 {
-			vals[0] = math.Pow(p.Base, (p.Minval+p.Maxval)/2.0)
+			vals[0] = math.Pow(p.Base(), (p.Minval()+p.Maxval())/2.0)
 		} else {
 			for i := 0; i < count; i++ {
-				vals[i] = math.Pow(p.Base, p.Minval+float64(i)*(p.Maxval-p.Minval)/float64(count-1))
+				vals[i] = math.Pow(
+					p.Base(), p.Minval()+float64(i)*(p.Maxval()-p.Minval())/float64(count-1),
+				)
 			}
 		}
 		return vals
-	case h.CategoricalHyperparameter != nil:
-		p := *h.CategoricalHyperparameter
-		return p.Vals
+	case h.RawCategoricalHyperparameter != nil:
+		p := *h.RawCategoricalHyperparameter
+		return p.Vals()
 	default:
 		panic(fmt.Sprintf("unexpected hyperparameter type %+v", h))
 	}

--- a/master/pkg/searcher/grid_test.go
+++ b/master/pkg/searcher/grid_test.go
@@ -6,19 +6,19 @@ import (
 
 	"gotest.tools/assert"
 
-	"github.com/determined-ai/determined/master/pkg/model"
+	"github.com/determined-ai/determined/master/pkg/ptrs"
+	"github.com/determined-ai/determined/master/pkg/schemas"
+	"github.com/determined-ai/determined/master/pkg/schemas/expconf"
 )
 
-func intP(x int) *int {
-	return &x
-}
-
-func generateHyperparameters(counts []int) model.Hyperparameters {
-	params := make(model.Hyperparameters, len(counts))
+func generateHyperparameters(counts []int) expconf.Hyperparameters {
+	params := make(expconf.Hyperparameters, len(counts))
 	for i, count := range counts {
 		c := count
-		params[strconv.Itoa(i)] = model.Hyperparameter{
-			DoubleHyperparameter: &model.DoubleHyperparameter{Minval: -1.0, Maxval: 1.0, Count: &c},
+		params[strconv.Itoa(i)] = expconf.Hyperparameter{
+			RawDoubleHyperparameter: &expconf.DoubleHyperparameter{
+				RawMinval: -1.0, RawMaxval: 1.0, RawCount: &c,
+			},
 		}
 	}
 	return params
@@ -43,24 +43,26 @@ func TestGridFunctionality(t *testing.T) {
 }
 
 func TestHyperparameterGridMethod(t *testing.T) {
-	dParam := model.DoubleHyperparameter{Maxval: 2.0, Count: intP(5)}
-	assert.Equal(t, len(grid(model.Hyperparameter{DoubleHyperparameter: &dParam})), 5)
-	iParam := model.IntHyperparameter{Maxval: 20, Count: intP(7)}
-	assert.Equal(t, len(grid(model.Hyperparameter{IntHyperparameter: &iParam})), 7)
-	lParam := model.LogHyperparameter{Minval: -3.0, Maxval: -2.0, Base: 10, Count: intP(2)}
-	assert.Equal(t, len(grid(model.Hyperparameter{LogHyperparameter: &lParam})), 2)
-	catParam := model.CategoricalHyperparameter{Vals: []interface{}{1, 2, 3}}
-	assert.Equal(t, len(grid(model.Hyperparameter{CategoricalHyperparameter: &catParam})), 3)
-	constParam := model.ConstHyperparameter{Val: 3}
-	assert.Equal(t, len(grid(model.Hyperparameter{ConstHyperparameter: &constParam})), 1)
+	dParam := expconf.DoubleHyperparameter{RawMaxval: 2.0, RawCount: ptrs.IntPtr(5)}
+	assert.Equal(t, len(grid(expconf.Hyperparameter{RawDoubleHyperparameter: &dParam})), 5)
+	iParam := expconf.IntHyperparameter{RawMaxval: 20, RawCount: ptrs.IntPtr(7)}
+	assert.Equal(t, len(grid(expconf.Hyperparameter{RawIntHyperparameter: &iParam})), 7)
+	lParam := expconf.LogHyperparameter{
+		RawMinval: -3.0, RawMaxval: -2.0, RawBase: 10, RawCount: ptrs.IntPtr(2),
+	}
+	assert.Equal(t, len(grid(expconf.Hyperparameter{RawLogHyperparameter: &lParam})), 2)
+	catParam := expconf.CategoricalHyperparameter{RawVals: []interface{}{1, 2, 3}}
+	assert.Equal(t, len(grid(expconf.Hyperparameter{RawCategoricalHyperparameter: &catParam})), 3)
+	constParam := expconf.ConstHyperparameter{RawVal: 3}
+	assert.Equal(t, len(grid(expconf.Hyperparameter{RawConstHyperparameter: &constParam})), 1)
 }
 
 func TestGrid(t *testing.T) {
-	iParam1 := &model.IntHyperparameter{Maxval: 20, Count: intP(3)}
-	iParam2 := &model.IntHyperparameter{Maxval: 10, Count: intP(3)}
-	hparams := model.Hyperparameters{
-		"1": model.Hyperparameter{IntHyperparameter: iParam1},
-		"2": model.Hyperparameter{IntHyperparameter: iParam2},
+	iParam1 := &expconf.IntHyperparameter{RawMaxval: 20, RawCount: ptrs.IntPtr(3)}
+	iParam2 := &expconf.IntHyperparameter{RawMaxval: 10, RawCount: ptrs.IntPtr(3)}
+	hparams := expconf.Hyperparameters{
+		"1": expconf.Hyperparameter{RawIntHyperparameter: iParam1},
+		"2": expconf.Hyperparameter{RawIntHyperparameter: iParam2},
 	}
 	actual := newHyperparameterGrid(hparams)
 	expected := []hparamSample{
@@ -78,9 +80,12 @@ func TestGrid(t *testing.T) {
 }
 
 func TestGridIntCount(t *testing.T) {
-	hparams := model.Hyperparameters{
-		"1": model.Hyperparameter{
-			IntHyperparameter: &model.IntHyperparameter{Minval: 0, Maxval: 4, Count: intP(5)}},
+	hparams := expconf.Hyperparameters{
+		"1": expconf.Hyperparameter{
+			RawIntHyperparameter: &expconf.IntHyperparameter{
+				RawMinval: 0, RawMaxval: 4, RawCount: ptrs.IntPtr(5),
+			},
+		},
 	}
 	actual := newHyperparameterGrid(hparams)
 	expected := []hparamSample{
@@ -94,9 +99,12 @@ func TestGridIntCount(t *testing.T) {
 }
 
 func TestGridIntCountNegative(t *testing.T) {
-	hparams := model.Hyperparameters{
-		"1": model.Hyperparameter{
-			IntHyperparameter: &model.IntHyperparameter{Minval: -4, Maxval: -2, Count: intP(3)}},
+	hparams := expconf.Hyperparameters{
+		"1": expconf.Hyperparameter{
+			RawIntHyperparameter: &expconf.IntHyperparameter{
+				RawMinval: -4, RawMaxval: -2, RawCount: ptrs.IntPtr(3),
+			},
+		},
 	}
 	actual := newHyperparameterGrid(hparams)
 	expected := []hparamSample{
@@ -108,7 +116,8 @@ func TestGridIntCountNegative(t *testing.T) {
 }
 
 func TestGridSearcherRecords(t *testing.T) {
-	actual := model.GridConfig{MaxLength: model.NewLengthInRecords(19200)}
+	actual := expconf.GridConfig{RawMaxLength: lengthPtr(expconf.NewLengthInRecords(19200))}
+	actual = schemas.WithDefaults(actual).(expconf.GridConfig)
 	params := generateHyperparameters([]int{2, 1, 3})
 	expected := [][]ValidateAfter{
 		toOps("19200R"), toOps("19200R"), toOps("19200R"),
@@ -119,7 +128,8 @@ func TestGridSearcherRecords(t *testing.T) {
 }
 
 func TestGridSearcherBatches(t *testing.T) {
-	actual := model.GridConfig{MaxLength: model.NewLengthInBatches(300)}
+	actual := expconf.GridConfig{RawMaxLength: lengthPtr(expconf.NewLengthInBatches(300))}
+	actual = schemas.WithDefaults(actual).(expconf.GridConfig)
 	params := generateHyperparameters([]int{2, 1, 3})
 	expected := [][]ValidateAfter{
 		toOps("300B"), toOps("300B"), toOps("300B"),
@@ -130,7 +140,8 @@ func TestGridSearcherBatches(t *testing.T) {
 }
 
 func TestGridSearcherEpochs(t *testing.T) {
-	actual := model.GridConfig{MaxLength: model.NewLengthInEpochs(3)}
+	actual := expconf.GridConfig{RawMaxLength: lengthPtr(expconf.NewLengthInEpochs(3))}
+	actual = schemas.WithDefaults(actual).(expconf.GridConfig)
 	params := generateHyperparameters([]int{2, 1, 3})
 	expected := [][]ValidateAfter{
 		toOps("3E"), toOps("3E"), toOps("3E"),
@@ -152,10 +163,10 @@ func TestGridSearchMethod(t *testing.T) {
 				newConstantPredefinedTrial(toOps("300B"), 0.1),
 				newEarlyExitPredefinedTrial(toOps("300B"), .1),
 			},
-			config: model.SearcherConfig{
-				GridConfig: &model.GridConfig{
-					MaxLength:           model.NewLengthInBatches(300),
-					MaxConcurrentTrials: 2,
+			config: expconf.SearcherConfig{
+				RawGridConfig: &expconf.GridConfig{
+					RawMaxLength:           lengthPtr(expconf.NewLengthInBatches(300)),
+					RawMaxConcurrentTrials: ptrs.IntPtr(2),
 				},
 			},
 			hparams: generateHyperparameters([]int{2, 1, 3}),

--- a/master/pkg/searcher/hyperparameters_test.go
+++ b/master/pkg/searcher/hyperparameters_test.go
@@ -5,18 +5,20 @@ import (
 
 	"gotest.tools/assert"
 
-	"github.com/determined-ai/determined/master/pkg/model"
 	"github.com/determined-ai/determined/master/pkg/nprand"
+	"github.com/determined-ai/determined/master/pkg/schemas/expconf"
 )
 
 func TestSamplingReproducibility(t *testing.T) {
-	spec := model.Hyperparameters{
-		"cat": {CategoricalHyperparameter: &model.CategoricalHyperparameter{
-			Vals: []interface{}{0, 1, 2, 3, 4, 5, 6}}},
-		"const":  {ConstHyperparameter: &model.ConstHyperparameter{Val: "val"}},
-		"double": {DoubleHyperparameter: &model.DoubleHyperparameter{Minval: 0, Maxval: 100}},
-		"int":    {IntHyperparameter: &model.IntHyperparameter{Minval: 0, Maxval: 100}},
-		"log":    {LogHyperparameter: &model.LogHyperparameter{Base: 10, Minval: -2, Maxval: 2}},
+	spec := expconf.Hyperparameters{
+		"cat": {RawCategoricalHyperparameter: &expconf.CategoricalHyperparameter{
+			RawVals: []interface{}{0, 1, 2, 3, 4, 5, 6}}},
+		"const":  {RawConstHyperparameter: &expconf.ConstHyperparameter{RawVal: "val"}},
+		"double": {RawDoubleHyperparameter: &expconf.DoubleHyperparameter{RawMinval: 0, RawMaxval: 100}},
+		"int":    {RawIntHyperparameter: &expconf.IntHyperparameter{RawMinval: 0, RawMaxval: 100}},
+		"log": {
+			RawLogHyperparameter: &expconf.LogHyperparameter{RawBase: 10, RawMinval: -2, RawMaxval: 2},
+		},
 	}
 
 	// Run the checks multiple times; map iteration order, if it has an effect on the result, is an

--- a/master/pkg/searcher/operations.go
+++ b/master/pkg/searcher/operations.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/determined-ai/determined/master/pkg/model"
 	"github.com/determined-ai/determined/master/pkg/nprand"
+	"github.com/determined-ai/determined/master/pkg/schemas/expconf"
 )
 
 // Operation represents the base interface for possible operations that a search method can return.
@@ -160,11 +161,11 @@ func (c Checkpoint) String() string {
 // its total batches trained equals the specified length.
 type ValidateAfter struct {
 	RequestID model.RequestID
-	Length    model.Length
+	Length    expconf.Length
 }
 
 // NewValidateAfter returns a new train operation.
-func NewValidateAfter(requestID model.RequestID, length model.Length) ValidateAfter {
+func NewValidateAfter(requestID model.RequestID, length expconf.Length) ValidateAfter {
 	return ValidateAfter{requestID, length}
 }
 
@@ -174,7 +175,7 @@ func ValidateAfterFromProto(
 ) ValidateAfter {
 	return ValidateAfter{
 		RequestID: rID,
-		Length:    model.LengthFromProto(op.Length),
+		Length:    expconf.LengthFromProto(op.Length),
 	}
 }
 

--- a/master/pkg/searcher/pbt.go
+++ b/master/pkg/searcher/pbt.go
@@ -5,9 +5,9 @@ import (
 	"math"
 	"sort"
 
-	"github.com/determined-ai/determined/master/pkg/workload"
-
 	"github.com/determined-ai/determined/master/pkg/model"
+	"github.com/determined-ai/determined/master/pkg/schemas/expconf"
+	"github.com/determined-ai/determined/master/pkg/workload"
 )
 
 // PBTSearch implements population-based training (PBT). See https://arxiv.org/abs/1711.09846 for
@@ -27,14 +27,15 @@ type (
 
 	pbtSearch struct {
 		defaultSearchMethod
-		model.PBTConfig
+		expconf.PBTConfig
 		pbtSearchState
+		SmallerIsBetter bool
 	}
 )
 
 const pbtExitedMetricValue = math.MaxFloat64
 
-func newPBTSearch(config model.PBTConfig) SearchMethod {
+func newPBTSearch(config expconf.PBTConfig, smallerIsBetter bool) SearchMethod {
 	return &pbtSearch{
 		PBTConfig: config,
 		pbtSearchState: pbtSearchState{
@@ -44,6 +45,7 @@ func newPBTSearch(config model.PBTConfig) SearchMethod {
 			EarlyExitTrials:      make(map[model.RequestID]bool),
 			SearchMethodType:     PBTSearch,
 		},
+		SmallerIsBetter: smallerIsBetter,
 	}
 }
 
@@ -60,12 +62,12 @@ func (s *pbtSearch) Restore(state json.RawMessage) error {
 
 func (s *pbtSearch) initialOperations(ctx context) ([]Operation, error) {
 	var ops []Operation
-	for trial := 0; trial < s.PopulationSize; trial++ {
+	for trial := 0; trial < s.PopulationSize(); trial++ {
 		create := NewCreate(
 			ctx.rand, sampleAll(ctx.hparams, ctx.rand), model.TrialWorkloadSequencerType)
 		s.TrialParams[create.RequestID] = create.Hparams
 		ops = append(ops, create)
-		ops = append(ops, NewValidateAfter(create.RequestID, s.LengthPerRound))
+		ops = append(ops, NewValidateAfter(create.RequestID, s.LengthPerRound()))
 	}
 	return ops, nil
 }
@@ -87,13 +89,13 @@ func (s *pbtSearch) runNewTrials(ctx context, requestID model.RequestID) ([]Oper
 	var ops []Operation
 
 	s.TrialRoundsCompleted[requestID]++
-	if len(s.Metrics) < s.PopulationSize {
+	if len(s.Metrics) < s.PopulationSize() {
 		return ops, nil
 	}
 
 	// We've finished all the rounds, so close everything.
 	s.RoundsCompleted++
-	if s.RoundsCompleted >= s.NumRounds {
+	if s.RoundsCompleted >= s.NumRounds() {
 		for requestID := range s.Metrics {
 			if !s.EarlyExitTrials[requestID] {
 				ops = append(ops, NewClose(requestID))
@@ -104,7 +106,7 @@ func (s *pbtSearch) runNewTrials(ctx context, requestID model.RequestID) ([]Oper
 
 	// We have all the results and another round to run; now apply truncation to select which trials
 	// to close and which to copy.
-	numTruncate := int(s.TruncateFraction * float64(s.PopulationSize))
+	numTruncate := int(s.ReplaceFunction().TruncateFraction * float64(s.PopulationSize()))
 
 	// Sort trials by metric value.
 	trialIDs := make([]model.RequestID, 0, len(s.Metrics))
@@ -143,7 +145,7 @@ func (s *pbtSearch) runNewTrials(ctx context, requestID model.RequestID) ([]Oper
 
 			ops = append(ops,
 				create,
-				NewValidateAfter(create.RequestID, s.LengthPerRound))
+				NewValidateAfter(create.RequestID, s.LengthPerRound()))
 		}
 	}
 
@@ -151,7 +153,7 @@ func (s *pbtSearch) runNewTrials(ctx context, requestID model.RequestID) ([]Oper
 	for _, requestID := range trialIDs[:len(trialIDs)-numTruncate] {
 		if !s.EarlyExitTrials[requestID] {
 			ops = append(ops, NewValidateAfter(
-				requestID, s.LengthPerRound.MultInt(s.TrialRoundsCompleted[requestID]+1)))
+				requestID, s.LengthPerRound().MultInt(s.TrialRoundsCompleted[requestID]+1)))
 		} else {
 			s.Metrics[requestID] = pbtExitedMetricValue
 		}
@@ -165,33 +167,33 @@ func (s *pbtSearch) runNewTrials(ctx context, requestID model.RequestID) ([]Oper
 // multiplicative factor.
 func (s *pbtSearch) exploreParams(ctx context, old hparamSample) hparamSample {
 	params := make(hparamSample)
-	ctx.hparams.Each(func(name string, sampler model.Hyperparameter) {
-		if ctx.rand.UnitInterval() < s.ResampleProbability {
+	ctx.hparams.Each(func(name string, sampler expconf.Hyperparameter) {
+		if ctx.rand.UnitInterval() < s.ExploreFunction().ResampleProbability {
 			params[name] = sampleOne(sampler, ctx.rand)
 		} else {
 			val := old[name]
 			decrease := ctx.rand.UnitInterval() < .5
 			var multiplier float64
 			if decrease {
-				multiplier = 1 - s.PerturbFactor
+				multiplier = 1 - s.ExploreFunction().PerturbFactor
 			} else {
-				multiplier = 1 + s.PerturbFactor
+				multiplier = 1 + s.ExploreFunction().PerturbFactor
 			}
 			switch {
-			case sampler.IntHyperparameter != nil:
-				h := sampler.IntHyperparameter
+			case sampler.RawIntHyperparameter != nil:
+				h := sampler.RawIntHyperparameter
 				if decrease {
-					val = intClamp(int(math.Floor(float64(val.(int))*multiplier)), h.Minval, h.Maxval)
+					val = intClamp(int(math.Floor(float64(val.(int))*multiplier)), h.Minval(), h.Maxval())
 				} else {
-					val = intClamp(int(math.Ceil(float64(val.(int))*multiplier)), h.Minval, h.Maxval)
+					val = intClamp(int(math.Ceil(float64(val.(int))*multiplier)), h.Minval(), h.Maxval())
 				}
-			case sampler.DoubleHyperparameter != nil:
-				h := sampler.DoubleHyperparameter
-				val = doubleClamp(val.(float64)*multiplier, h.Minval, h.Maxval)
-			case sampler.LogHyperparameter != nil:
-				h := sampler.LogHyperparameter
-				minval := math.Pow(h.Base, h.Minval)
-				maxval := math.Pow(h.Base, h.Maxval)
+			case sampler.RawDoubleHyperparameter != nil:
+				h := sampler.RawDoubleHyperparameter
+				val = doubleClamp(val.(float64)*multiplier, h.Minval(), h.Maxval())
+			case sampler.RawLogHyperparameter != nil:
+				h := sampler.RawLogHyperparameter
+				minval := math.Pow(h.Base(), h.Minval())
+				maxval := math.Pow(h.Base(), h.Maxval())
 				val = doubleClamp(val.(float64)*multiplier, minval, maxval)
 			}
 			params[name] = val
@@ -202,7 +204,7 @@ func (s *pbtSearch) exploreParams(ctx context, old hparamSample) hparamSample {
 
 func (s *pbtSearch) progress(trialProgress map[model.RequestID]model.PartialUnits) float64 {
 	unitsCompleted := sumTrialLengths(trialProgress)
-	unitsExpected := s.LengthPerRound.MultInt(s.PopulationSize).MultInt(s.NumRounds).Units
+	unitsExpected := s.LengthPerRound().MultInt(s.PopulationSize()).MultInt(s.NumRounds()).Units
 	return float64(unitsCompleted) / float64(unitsExpected)
 }
 

--- a/master/pkg/searcher/pbt_test.go
+++ b/master/pkg/searcher/pbt_test.go
@@ -6,25 +6,31 @@ import (
 
 	"gotest.tools/assert"
 
-	"github.com/determined-ai/determined/master/pkg/check"
-	"github.com/determined-ai/determined/master/pkg/model"
 	"github.com/determined-ai/determined/master/pkg/nprand"
+	"github.com/determined-ai/determined/master/pkg/ptrs"
+	"github.com/determined-ai/determined/master/pkg/schemas/expconf"
 )
+
+func replaceConfigPtr(val expconf.PBTReplaceConfig) *expconf.PBTReplaceConfig {
+	return &val
+}
+
+func exploreConfigPtr(val expconf.PBTExploreConfig) *expconf.PBTExploreConfig {
+	return &val
+}
 
 func TestPBTSearcherWorkloads(t *testing.T) {
 	t.Run("simple", func(t *testing.T) {
 		// After the first round, trial 1 beats trial 2, spawning trial 3. Trial 1 lasts for two rounds
 		// and the others last one round each.
-		config := model.PBTConfig{
-			Metric:          defaultMetric,
-			SmallerIsBetter: false,
-			PopulationSize:  2,
-			NumRounds:       2,
-			LengthPerRound:  model.NewLengthInBatches(200),
-			PBTReplaceConfig: model.PBTReplaceConfig{
+		config := expconf.PBTConfig{
+			RawPopulationSize: ptrs.IntPtr(2),
+			RawNumRounds:      ptrs.IntPtr(2),
+			RawLengthPerRound: lengthPtr(expconf.NewLengthInBatches(200)),
+			RawReplaceFunction: replaceConfigPtr(expconf.PBTReplaceConfig{
 				TruncateFraction: .5,
-			},
-			PBTExploreConfig: model.PBTExploreConfig{},
+			}),
+			RawExploreFunction: exploreConfigPtr(expconf.PBTExploreConfig{}),
 		}
 
 		val := func(random *rand.Rand, trialID, _ int) float64 {
@@ -36,21 +42,19 @@ func TestPBTSearcherWorkloads(t *testing.T) {
 			toOps("200B"),
 			toOps("200B"),
 		}
-		checkSimulation(t, newPBTSearch(config), nil, val, expected)
+		checkSimulation(t, newPBTSearch(config, false), nil, val, expected)
 	})
 
 	t.Run("no_truncation", func(t *testing.T) {
 		// There is no truncation, so the initial population just survives forever.
-		config := model.PBTConfig{
-			Metric:          defaultMetric,
-			SmallerIsBetter: false,
-			PopulationSize:  3,
-			NumRounds:       4,
-			LengthPerRound:  model.NewLengthInBatches(400),
-			PBTReplaceConfig: model.PBTReplaceConfig{
+		config := expconf.PBTConfig{
+			RawPopulationSize: ptrs.IntPtr(3),
+			RawNumRounds:      ptrs.IntPtr(4),
+			RawLengthPerRound: lengthPtr(expconf.NewLengthInBatches(400)),
+			RawReplaceFunction: replaceConfigPtr(expconf.PBTReplaceConfig{
 				TruncateFraction: 0.,
-			},
-			PBTExploreConfig: model.PBTExploreConfig{},
+			}),
+			RawExploreFunction: exploreConfigPtr(expconf.PBTExploreConfig{}),
 		}
 
 		val := func(random *rand.Rand, trialID, _ int) float64 {
@@ -62,23 +66,21 @@ func TestPBTSearcherWorkloads(t *testing.T) {
 			toOps("400B 800B 1200B 1600B"),
 			toOps("400B 800B 1200B 1600B"),
 		}
-		checkSimulation(t, newPBTSearch(config), nil, val, expected)
+		checkSimulation(t, newPBTSearch(config, false), nil, val, expected)
 	})
 
 	t.Run("even_odd", func(t *testing.T) {
 		// After the first round, trial 1 beats trial 2, spawning trial 3. After the second round, trial 3
 		// beats trial 1, spawning trial 4. Thus we have two trials that run for two rounds (1, 3) and two
 		// that run for one round (2, 4).
-		config := model.PBTConfig{
-			Metric:          defaultMetric,
-			SmallerIsBetter: false,
-			PopulationSize:  2,
-			NumRounds:       3,
-			LengthPerRound:  model.NewLengthInBatches(1700),
-			PBTReplaceConfig: model.PBTReplaceConfig{
+		config := expconf.PBTConfig{
+			RawPopulationSize: ptrs.IntPtr(2),
+			RawNumRounds:      ptrs.IntPtr(3),
+			RawLengthPerRound: lengthPtr(expconf.NewLengthInBatches(1700)),
+			RawReplaceFunction: replaceConfigPtr(expconf.PBTReplaceConfig{
 				TruncateFraction: .5,
-			},
-			PBTExploreConfig: model.PBTExploreConfig{},
+			}),
+			RawExploreFunction: exploreConfigPtr(expconf.PBTExploreConfig{}),
 		}
 
 		val := func(random *rand.Rand, trialID, _ int) float64 {
@@ -94,23 +96,21 @@ func TestPBTSearcherWorkloads(t *testing.T) {
 			toOps("1700B"),
 			toOps("1700B"),
 		}
-		checkSimulation(t, newPBTSearch(config), nil, val, expected)
+		checkSimulation(t, newPBTSearch(config, false), nil, val, expected)
 	})
 
 	t.Run("new_is_better", func(t *testing.T) {
 		// After each round, the two lowest-numbered trials are replaced by two new trials. Each trial
 		// therefore lasts for two rounds, except for two of the initial population and the two created
 		// right before the last round.
-		config := model.PBTConfig{
-			Metric:          defaultMetric,
-			SmallerIsBetter: false,
-			PopulationSize:  4,
-			NumRounds:       8,
-			LengthPerRound:  model.NewLengthInBatches(500),
-			PBTReplaceConfig: model.PBTReplaceConfig{
+		config := expconf.PBTConfig{
+			RawPopulationSize: ptrs.IntPtr(4),
+			RawNumRounds:      ptrs.IntPtr(8),
+			RawLengthPerRound: lengthPtr(expconf.NewLengthInBatches(500)),
+			RawReplaceFunction: replaceConfigPtr(expconf.PBTReplaceConfig{
 				TruncateFraction: .5,
-			},
-			PBTExploreConfig: model.PBTExploreConfig{},
+			}),
+			RawExploreFunction: exploreConfigPtr(expconf.PBTExploreConfig{}),
 		}
 
 		val := func(random *rand.Rand, trialID, _ int) float64 {
@@ -137,22 +137,20 @@ func TestPBTSearcherWorkloads(t *testing.T) {
 			toOps("500B"),
 			toOps("500B"),
 		}
-		checkSimulation(t, newPBTSearch(config), nil, val, expected)
+		checkSimulation(t, newPBTSearch(config, false), nil, val, expected)
 	})
 
 	t.Run("old_is_better", func(t *testing.T) {
 		// Same as the above case, except that smaller is now better; thus, the two lowest-numbered trials
 		// are always the best and survive forever, but all other trials last only one round.
-		config := model.PBTConfig{
-			Metric:          defaultMetric,
-			SmallerIsBetter: true,
-			PopulationSize:  4,
-			NumRounds:       8,
-			LengthPerRound:  model.NewLengthInBatches(500),
-			PBTReplaceConfig: model.PBTReplaceConfig{
+		config := expconf.PBTConfig{
+			RawPopulationSize: ptrs.IntPtr(4),
+			RawNumRounds:      ptrs.IntPtr(8),
+			RawLengthPerRound: lengthPtr(expconf.NewLengthInBatches(500)),
+			RawReplaceFunction: replaceConfigPtr(expconf.PBTReplaceConfig{
 				TruncateFraction: .5,
-			},
-			PBTExploreConfig: model.PBTExploreConfig{},
+			}),
+			RawExploreFunction: exploreConfigPtr(expconf.PBTExploreConfig{}),
 		}
 
 		val := func(random *rand.Rand, trialID, _ int) float64 {
@@ -179,56 +177,59 @@ func TestPBTSearcherWorkloads(t *testing.T) {
 			toOps("500B"),
 			toOps("500B"),
 		}
-		checkSimulation(t, newPBTSearch(config), nil, val, expected)
+		checkSimulation(t, newPBTSearch(config, true), nil, val, expected)
 	})
 }
 
 func TestPBTSearcherReproducibility(t *testing.T) {
-	conf := model.PBTConfig{
-		Metric: defaultMetric, SmallerIsBetter: true,
-		PopulationSize: 10, NumRounds: 10, LengthPerRound: model.NewLengthInBatches(1000),
-		PBTReplaceConfig: model.PBTReplaceConfig{TruncateFraction: 0.5},
-		PBTExploreConfig: model.PBTExploreConfig{ResampleProbability: 0.5, PerturbFactor: 0.5},
+	conf := expconf.PBTConfig{
+		RawPopulationSize:  ptrs.IntPtr(10),
+		RawNumRounds:       ptrs.IntPtr(10),
+		RawLengthPerRound:  lengthPtr(expconf.NewLengthInBatches(1000)),
+		RawReplaceFunction: replaceConfigPtr(expconf.PBTReplaceConfig{TruncateFraction: 0.5}),
+		RawExploreFunction: exploreConfigPtr(
+			expconf.PBTExploreConfig{ResampleProbability: 0.5, PerturbFactor: 0.5},
+		),
 	}
-	searchMethod := func() SearchMethod { return newPBTSearch(conf) }
+	searchMethod := func() SearchMethod { return newPBTSearch(conf, true) }
 	checkReproducibility(t, searchMethod, nil, defaultMetric)
 }
 
 func testPBTExploreWithSeed(t *testing.T, seed uint32) {
-	nullConfig := model.PBTConfig{
-		Metric:           defaultMetric,
-		SmallerIsBetter:  true,
-		PopulationSize:   10,
-		NumRounds:        10,
-		LengthPerRound:   model.NewLengthInBatches(1000),
-		PBTReplaceConfig: model.PBTReplaceConfig{},
-		PBTExploreConfig: model.PBTExploreConfig{},
+	nullConfig := func() expconf.PBTConfig {
+		return expconf.PBTConfig{
+			RawPopulationSize:  ptrs.IntPtr(10),
+			RawNumRounds:       ptrs.IntPtr(10),
+			RawLengthPerRound:  lengthPtr(expconf.NewLengthInBatches(1000)),
+			RawReplaceFunction: replaceConfigPtr(expconf.PBTReplaceConfig{}),
+			RawExploreFunction: exploreConfigPtr(expconf.PBTExploreConfig{}),
+		}
 	}
 
-	spec := model.Hyperparameters{
-		"cat": model.Hyperparameter{
-			CategoricalHyperparameter: &model.CategoricalHyperparameter{
-				Vals: []interface{}{0, 1, 2, 3, 4, 5, 6},
+	spec := expconf.Hyperparameters{
+		"cat": expconf.Hyperparameter{
+			RawCategoricalHyperparameter: &expconf.CategoricalHyperparameter{
+				RawVals: []interface{}{0, 1, 2, 3, 4, 5, 6},
 			},
 		},
-		"const": model.Hyperparameter{
-			ConstHyperparameter: &model.ConstHyperparameter{
-				Val: "val",
+		"const": expconf.Hyperparameter{
+			RawConstHyperparameter: &expconf.ConstHyperparameter{
+				RawVal: "val",
 			},
 		},
-		"double": model.Hyperparameter{
-			DoubleHyperparameter: &model.DoubleHyperparameter{
-				Minval: 0, Maxval: 100,
+		"double": expconf.Hyperparameter{
+			RawDoubleHyperparameter: &expconf.DoubleHyperparameter{
+				RawMinval: 0, RawMaxval: 100,
 			},
 		},
-		"int": model.Hyperparameter{
-			IntHyperparameter: &model.IntHyperparameter{
-				Minval: 0, Maxval: 100,
+		"int": expconf.Hyperparameter{
+			RawIntHyperparameter: &expconf.IntHyperparameter{
+				RawMinval: 0, RawMaxval: 100,
 			},
 		},
-		"log": model.Hyperparameter{
-			LogHyperparameter: &model.LogHyperparameter{
-				Base: 10, Minval: -4, Maxval: -2,
+		"log": expconf.Hyperparameter{
+			RawLogHyperparameter: &expconf.LogHyperparameter{
+				RawBase: 10, RawMinval: -4, RawMaxval: -2,
 			},
 		},
 	}
@@ -244,22 +245,22 @@ func testPBTExploreWithSeed(t *testing.T, seed uint32) {
 
 	// Test that exploring with no resampling and no perturbing does not change the hyperparameters.
 	{
-		pbt := newPBTSearch(nullConfig).(*pbtSearch)
+		pbt := newPBTSearch(nullConfig(), true).(*pbtSearch)
 		newSample := pbt.exploreParams(ctx, sample)
 		assert.DeepEqual(t, sample, newSample)
 	}
 
 	// Test that exploring with guaranteed resampling changes all of the hyperparameters.
 	{
-		resamplingConfig := nullConfig
-		resamplingConfig.ResampleProbability = 1
+		resamplingConfig := nullConfig()
+		resamplingConfig.RawExploreFunction.ResampleProbability = 1
 
 		// Create a hyperparameter sample where none of the values are actually valid, then resample it.
 		invalidSample := make(hparamSample)
-		spec.Each(func(name string, _ model.Hyperparameter) {
+		spec.Each(func(name string, _ expconf.Hyperparameter) {
 			invalidSample[name] = nil
 		})
-		pbt := newPBTSearch(nullConfig).(*pbtSearch)
+		pbt := newPBTSearch(nullConfig(), true).(*pbtSearch)
 		newSample := pbt.exploreParams(ctx, sample)
 
 		assert.Equal(t, len(invalidSample), len(newSample))
@@ -272,9 +273,9 @@ func testPBTExploreWithSeed(t *testing.T, seed uint32) {
 
 	// Test that guaranteed perturbing produces reasonable values.
 	{
-		perturbingConfig := nullConfig
-		perturbingConfig.PerturbFactor = .5
-		pbt := newPBTSearch(perturbingConfig).(*pbtSearch)
+		perturbingConfig := nullConfig()
+		perturbingConfig.RawExploreFunction.PerturbFactor = .5
+		pbt := newPBTSearch(perturbingConfig, true).(*pbtSearch)
 
 		newSample := pbt.exploreParams(ctx, sample)
 
@@ -298,69 +299,8 @@ func testPBTExploreWithSeed(t *testing.T, seed uint32) {
 }
 
 func TestPBTExplore(t *testing.T) {
-	for i := uint32(0); i < 100; i++ {
+	for i := uint32(0); i < 1; i++ {
 		testPBTExploreWithSeed(t, i)
-	}
-}
-
-func TestPBTValidation(t *testing.T) {
-	goodConfig := model.PBTConfig{
-		Metric:           defaultMetric,
-		SmallerIsBetter:  true,
-		PopulationSize:   10,
-		NumRounds:        10,
-		LengthPerRound:   model.NewLengthInBatches(1000),
-		PBTReplaceConfig: model.PBTReplaceConfig{},
-		PBTExploreConfig: model.PBTExploreConfig{},
-	}
-	assert.NilError(t, check.Validate(goodConfig))
-
-	{
-		badConfig := goodConfig
-		badConfig.PopulationSize = 0
-		assert.ErrorContains(t, check.Validate(badConfig), "population_size")
-		badConfig.PopulationSize = -1
-		assert.ErrorContains(t, check.Validate(badConfig), "population_size")
-	}
-
-	{
-		badConfig := goodConfig
-		badConfig.NumRounds = 0
-		assert.ErrorContains(t, check.Validate(badConfig), "num_rounds")
-		badConfig.NumRounds = -1
-		assert.ErrorContains(t, check.Validate(badConfig), "num_rounds")
-	}
-
-	{
-		badConfig := goodConfig
-		badConfig.LengthPerRound = model.NewLengthInBatches(0)
-		assert.ErrorContains(t, check.Validate(badConfig), "length_per_round")
-		badConfig.LengthPerRound = model.NewLengthInBatches(-1)
-		assert.ErrorContains(t, check.Validate(badConfig), "length_per_round")
-	}
-
-	{
-		badConfig := goodConfig
-		badConfig.PerturbFactor = -.1
-		assert.ErrorContains(t, check.Validate(badConfig), "perturb_factor")
-		badConfig.PerturbFactor = 1.1
-		assert.ErrorContains(t, check.Validate(badConfig), "perturb_factor")
-	}
-
-	{
-		badConfig := goodConfig
-		badConfig.TruncateFraction = -.1
-		assert.ErrorContains(t, check.Validate(badConfig), "truncate_fraction")
-		badConfig.TruncateFraction = .6
-		assert.ErrorContains(t, check.Validate(badConfig), "truncate_fraction")
-	}
-
-	{
-		badConfig := goodConfig
-		badConfig.ResampleProbability = -.1
-		assert.ErrorContains(t, check.Validate(badConfig), "resample_probability")
-		badConfig.ResampleProbability = 1.1
-		assert.ErrorContains(t, check.Validate(badConfig), "resample_probability")
 	}
 }
 
@@ -379,17 +319,16 @@ func TestPBTSearchMethod(t *testing.T) {
 				// Fourth generation loses to second generation also.
 				newConstantPredefinedTrial(toOps("200B"), 0.3),
 			},
-			config: model.SearcherConfig{
-				PBTConfig: &model.PBTConfig{
-					Metric:          "error",
-					SmallerIsBetter: true,
-					PopulationSize:  2,
-					NumRounds:       4,
-					LengthPerRound:  model.NewLengthInBatches(200),
-					PBTReplaceConfig: model.PBTReplaceConfig{
+			config: expconf.SearcherConfig{
+				RawSmallerIsBetter: ptrs.BoolPtr(true),
+				RawPBTConfig: &expconf.PBTConfig{
+					RawPopulationSize: ptrs.IntPtr(2),
+					RawNumRounds:      ptrs.IntPtr(4),
+					RawLengthPerRound: lengthPtr(expconf.NewLengthInBatches(200)),
+					RawReplaceFunction: replaceConfigPtr(expconf.PBTReplaceConfig{
 						TruncateFraction: .5,
-					},
-					PBTExploreConfig: model.PBTExploreConfig{},
+					}),
+					RawExploreFunction: exploreConfigPtr(expconf.PBTExploreConfig{}),
 				},
 			},
 		},
@@ -406,17 +345,16 @@ func TestPBTSearchMethod(t *testing.T) {
 				// Fourth generation loses to second generation also.
 				newConstantPredefinedTrial(toOps("200B"), 0.3),
 			},
-			config: model.SearcherConfig{
-				PBTConfig: &model.PBTConfig{
-					Metric:          "error",
-					SmallerIsBetter: true,
-					PopulationSize:  2,
-					NumRounds:       4,
-					LengthPerRound:  model.NewLengthInBatches(200),
-					PBTReplaceConfig: model.PBTReplaceConfig{
+			config: expconf.SearcherConfig{
+				RawSmallerIsBetter: ptrs.BoolPtr(true),
+				RawPBTConfig: &expconf.PBTConfig{
+					RawPopulationSize: ptrs.IntPtr(2),
+					RawNumRounds:      ptrs.IntPtr(4),
+					RawLengthPerRound: lengthPtr(expconf.NewLengthInBatches(200)),
+					RawReplaceFunction: replaceConfigPtr(expconf.PBTReplaceConfig{
 						TruncateFraction: .5,
-					},
-					PBTExploreConfig: model.PBTExploreConfig{},
+					}),
+					RawExploreFunction: exploreConfigPtr(expconf.PBTExploreConfig{}),
 				},
 			},
 		},
@@ -433,17 +371,16 @@ func TestPBTSearchMethod(t *testing.T) {
 				// Fourth generation loses to second generation also.
 				newConstantPredefinedTrial(toOps("200B"), 0.7),
 			},
-			config: model.SearcherConfig{
-				PBTConfig: &model.PBTConfig{
-					Metric:          "error",
-					SmallerIsBetter: false,
-					PopulationSize:  2,
-					NumRounds:       4,
-					LengthPerRound:  model.NewLengthInBatches(200),
-					PBTReplaceConfig: model.PBTReplaceConfig{
+			config: expconf.SearcherConfig{
+				RawSmallerIsBetter: ptrs.BoolPtr(false),
+				RawPBTConfig: &expconf.PBTConfig{
+					RawPopulationSize: ptrs.IntPtr(2),
+					RawNumRounds:      ptrs.IntPtr(4),
+					RawLengthPerRound: lengthPtr(expconf.NewLengthInBatches(200)),
+					RawReplaceFunction: replaceConfigPtr(expconf.PBTReplaceConfig{
 						TruncateFraction: .5,
-					},
-					PBTExploreConfig: model.PBTExploreConfig{},
+					}),
+					RawExploreFunction: exploreConfigPtr(expconf.PBTExploreConfig{}),
 				},
 			},
 		},
@@ -460,17 +397,16 @@ func TestPBTSearchMethod(t *testing.T) {
 				// Fourth generation loses to second generation also.
 				newConstantPredefinedTrial(toOps("200B"), 0.7),
 			},
-			config: model.SearcherConfig{
-				PBTConfig: &model.PBTConfig{
-					Metric:          "error",
-					SmallerIsBetter: false,
-					PopulationSize:  2,
-					NumRounds:       4,
-					LengthPerRound:  model.NewLengthInBatches(200),
-					PBTReplaceConfig: model.PBTReplaceConfig{
+			config: expconf.SearcherConfig{
+				RawSmallerIsBetter: ptrs.BoolPtr(false),
+				RawPBTConfig: &expconf.PBTConfig{
+					RawPopulationSize: ptrs.IntPtr(2),
+					RawNumRounds:      ptrs.IntPtr(4),
+					RawLengthPerRound: lengthPtr(expconf.NewLengthInBatches(200)),
+					RawReplaceFunction: replaceConfigPtr(expconf.PBTReplaceConfig{
 						TruncateFraction: .5,
-					},
-					PBTExploreConfig: model.PBTExploreConfig{},
+					}),
+					RawExploreFunction: exploreConfigPtr(expconf.PBTExploreConfig{}),
 				},
 			},
 		},

--- a/master/pkg/searcher/random.go
+++ b/master/pkg/searcher/random.go
@@ -4,6 +4,9 @@ import (
 	"encoding/json"
 
 	"github.com/determined-ai/determined/master/pkg/model"
+	"github.com/determined-ai/determined/master/pkg/ptrs"
+	"github.com/determined-ai/determined/master/pkg/schemas"
+	"github.com/determined-ai/determined/master/pkg/schemas/expconf"
 	"github.com/determined-ai/determined/master/pkg/workload"
 )
 
@@ -23,12 +26,12 @@ type (
 	// is trained for the specified number of steps, and then validation metrics are computed.
 	randomSearch struct {
 		defaultSearchMethod
-		model.RandomConfig
+		expconf.RandomConfig
 		randomSearchState
 	}
 )
 
-func newRandomSearch(config model.RandomConfig) SearchMethod {
+func newRandomSearch(config expconf.RandomConfig) SearchMethod {
 	return &randomSearch{
 		RandomConfig: config,
 		randomSearchState: randomSearchState{
@@ -37,9 +40,12 @@ func newRandomSearch(config model.RandomConfig) SearchMethod {
 	}
 }
 
-func newSingleSearch(config model.SingleConfig) SearchMethod {
+func newSingleSearch(config expconf.SingleConfig) SearchMethod {
 	return &randomSearch{
-		RandomConfig: model.RandomConfig{MaxTrials: 1, MaxLength: config.MaxLength},
+		RandomConfig: schemas.WithDefaults(expconf.RandomConfig{
+			RawMaxTrials: ptrs.IntPtr(1),
+			RawMaxLength: lengthPtr(config.MaxLength()),
+		}).(expconf.RandomConfig),
 		randomSearchState: randomSearchState{
 			SearchMethodType: SingleSearch,
 		},
@@ -48,14 +54,14 @@ func newSingleSearch(config model.SingleConfig) SearchMethod {
 
 func (s *randomSearch) initialOperations(ctx context) ([]Operation, error) {
 	var ops []Operation
-	initialTrials := s.MaxTrials
-	if s.MaxConcurrentTrials > 0 {
-		initialTrials = min(s.MaxTrials, s.MaxConcurrentTrials)
+	initialTrials := s.MaxTrials()
+	if s.MaxConcurrentTrials() > 0 {
+		initialTrials = min(s.MaxTrials(), s.MaxConcurrentTrials())
 	}
 	for trial := 0; trial < initialTrials; trial++ {
 		create := NewCreate(ctx.rand, sampleAll(ctx.hparams, ctx.rand), model.TrialWorkloadSequencerType)
 		ops = append(ops, create)
-		ops = append(ops, NewValidateAfter(create.RequestID, s.MaxLength))
+		ops = append(ops, NewValidateAfter(create.RequestID, s.MaxLength()))
 		ops = append(ops, NewClose(create.RequestID))
 		s.CreatedTrials++
 		s.PendingTrials++
@@ -64,11 +70,11 @@ func (s *randomSearch) initialOperations(ctx context) ([]Operation, error) {
 }
 
 func (s *randomSearch) progress(trialProgress map[model.RequestID]model.PartialUnits) float64 {
-	if s.MaxConcurrentTrials > 0 && s.PendingTrials > s.MaxConcurrentTrials {
+	if s.MaxConcurrentTrials() > 0 && s.PendingTrials > s.MaxConcurrentTrials() {
 		panic("pending trials is greater than max_concurrent_trials")
 	}
 	unitsCompleted := sumTrialLengths(trialProgress)
-	unitsExpected := s.MaxLength.Units * s.MaxTrials
+	unitsExpected := s.MaxLength().Units * s.MaxTrials()
 	return float64(unitsCompleted) / float64(unitsExpected)
 }
 
@@ -82,7 +88,7 @@ func (s *randomSearch) trialExitedEarly(
 		var ops []Operation
 		create := NewCreate(ctx.rand, sampleAll(ctx.hparams, ctx.rand), model.TrialWorkloadSequencerType)
 		ops = append(ops, create)
-		ops = append(ops, NewValidateAfter(create.RequestID, s.MaxLength))
+		ops = append(ops, NewValidateAfter(create.RequestID, s.MaxLength()))
 		ops = append(ops, NewClose(create.RequestID))
 		// We don't increment CreatedTrials here because this trial is replacing the invalid trial.
 		s.PendingTrials++
@@ -94,10 +100,10 @@ func (s *randomSearch) trialExitedEarly(
 func (s *randomSearch) trialClosed(ctx context, requestID model.RequestID) ([]Operation, error) {
 	s.PendingTrials--
 	var ops []Operation
-	if s.CreatedTrials < s.MaxTrials {
+	if s.CreatedTrials < s.MaxTrials() {
 		create := NewCreate(ctx.rand, sampleAll(ctx.hparams, ctx.rand), model.TrialWorkloadSequencerType)
 		ops = append(ops, create)
-		ops = append(ops, NewValidateAfter(create.RequestID, s.MaxLength))
+		ops = append(ops, NewValidateAfter(create.RequestID, s.MaxLength()))
 		ops = append(ops, NewClose(create.RequestID))
 		s.CreatedTrials++
 		s.PendingTrials++

--- a/master/pkg/searcher/random_test.go
+++ b/master/pkg/searcher/random_test.go
@@ -3,11 +3,16 @@ package searcher
 import (
 	"testing"
 
-	"github.com/determined-ai/determined/master/pkg/model"
+	"github.com/determined-ai/determined/master/pkg/ptrs"
+	"github.com/determined-ai/determined/master/pkg/schemas"
+	"github.com/determined-ai/determined/master/pkg/schemas/expconf"
 )
 
 func TestRandomSearcherRecords(t *testing.T) {
-	actual := model.RandomConfig{MaxTrials: 4, MaxLength: model.NewLengthInRecords(19200)}
+	actual := expconf.RandomConfig{
+		RawMaxTrials: ptrs.IntPtr(4), RawMaxLength: lengthPtr(expconf.NewLengthInRecords(19200)),
+	}
+	actual = schemas.WithDefaults(actual).(expconf.RandomConfig)
 	expected := [][]ValidateAfter{
 		toOps("19200R"),
 		toOps("19200R"),
@@ -19,7 +24,10 @@ func TestRandomSearcherRecords(t *testing.T) {
 }
 
 func TestRandomSearcherBatches(t *testing.T) {
-	actual := model.RandomConfig{MaxTrials: 4, MaxLength: model.NewLengthInBatches(300)}
+	actual := expconf.RandomConfig{
+		RawMaxTrials: ptrs.IntPtr(4), RawMaxLength: lengthPtr(expconf.NewLengthInBatches(300)),
+	}
+	actual = schemas.WithDefaults(actual).(expconf.RandomConfig)
 	expected := [][]ValidateAfter{
 		toOps("300B"),
 		toOps("300B"),
@@ -31,7 +39,10 @@ func TestRandomSearcherBatches(t *testing.T) {
 }
 
 func TestRandomSearcherReproducibility(t *testing.T) {
-	conf := model.RandomConfig{MaxTrials: 4, MaxLength: model.NewLengthInBatches(300)}
+	conf := expconf.RandomConfig{
+		RawMaxTrials: ptrs.IntPtr(4), RawMaxLength: lengthPtr(expconf.NewLengthInBatches(300)),
+	}
+	conf = schemas.WithDefaults(conf).(expconf.RandomConfig)
 	gen := func() SearchMethod { return newRandomSearch(conf) }
 	checkReproducibility(t, gen, nil, defaultMetric)
 }
@@ -46,11 +57,11 @@ func TestRandomSearchMethod(t *testing.T) {
 				newConstantPredefinedTrial(toOps("500B"), .1),
 				newEarlyExitPredefinedTrial(toOps("500B"), .1),
 			},
-			config: model.SearcherConfig{
-				RandomConfig: &model.RandomConfig{
-					MaxLength:           model.NewLengthInBatches(500),
-					MaxTrials:           4,
-					MaxConcurrentTrials: 2,
+			config: expconf.SearcherConfig{
+				RawRandomConfig: &expconf.RandomConfig{
+					RawMaxLength:           lengthPtr(expconf.NewLengthInBatches(500)),
+					RawMaxTrials:           ptrs.IntPtr(4),
+					RawMaxConcurrentTrials: ptrs.IntPtr(2),
 				},
 			},
 		},
@@ -62,10 +73,10 @@ func TestRandomSearchMethod(t *testing.T) {
 				newConstantPredefinedTrial(toOps("32017R"), .1),
 				newConstantPredefinedTrial(toOps("32017R"), .1),
 			},
-			config: model.SearcherConfig{
-				RandomConfig: &model.RandomConfig{
-					MaxLength: model.NewLengthInRecords(32017),
-					MaxTrials: 4,
+			config: expconf.SearcherConfig{
+				RawRandomConfig: &expconf.RandomConfig{
+					RawMaxLength: lengthPtr(expconf.NewLengthInRecords(32017)),
+					RawMaxTrials: ptrs.IntPtr(4),
 				},
 			},
 		},
@@ -81,9 +92,9 @@ func TestSingleSearchMethod(t *testing.T) {
 			expectedTrials: []predefinedTrial{
 				newConstantPredefinedTrial(toOps("500B"), .1),
 			},
-			config: model.SearcherConfig{
-				SingleConfig: &model.SingleConfig{
-					MaxLength: model.NewLengthInBatches(500),
+			config: expconf.SearcherConfig{
+				RawSingleConfig: &expconf.SingleConfig{
+					RawMaxLength: lengthPtr(expconf.NewLengthInBatches(500)),
 				},
 			},
 		},

--- a/master/pkg/searcher/searcher.go
+++ b/master/pkg/searcher/searcher.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/determined-ai/determined/master/pkg/model"
 	"github.com/determined-ai/determined/master/pkg/nprand"
+	"github.com/determined-ai/determined/master/pkg/schemas/expconf"
 )
 
 type (
@@ -36,14 +37,14 @@ type (
 
 	// Searcher encompasses the state as the searcher progresses using the provided search method.
 	Searcher struct {
-		hparams model.Hyperparameters
+		hparams expconf.Hyperparameters
 		method  SearchMethod
 		SearcherState
 	}
 )
 
 // NewSearcher creates a new Searcher configured with the provided searcher config.
-func NewSearcher(seed uint32, method SearchMethod, hparams model.Hyperparameters) *Searcher {
+func NewSearcher(seed uint32, method SearchMethod, hparams expconf.Hyperparameters) *Searcher {
 	return &Searcher{
 		hparams: hparams,
 		method:  method,

--- a/master/pkg/searcher/simulate.go
+++ b/master/pkg/searcher/simulate.go
@@ -11,6 +11,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/determined-ai/determined/master/pkg/model"
+	"github.com/determined-ai/determined/master/pkg/schemas/expconf"
 )
 
 // ValidationFunction calculates the validation metric for the validation step.
@@ -39,11 +40,11 @@ func (s SimulationResults) MarshalJSON() ([]byte, error) {
 		var keyParts []string
 		for _, op := range ops {
 			switch op.Length.Unit {
-			case model.Records:
+			case expconf.Records:
 				keyParts = append(keyParts, fmt.Sprintf("%dR", op.Length.Units))
-			case model.Batches:
+			case expconf.Batches:
 				keyParts = append(keyParts, fmt.Sprintf("%dB", op.Length.Units))
-			case model.Epochs:
+			case expconf.Epochs:
 				keyParts = append(keyParts, fmt.Sprintf("%dE", op.Length.Units))
 			}
 		}

--- a/master/pkg/searcher/tournament.go
+++ b/master/pkg/searcher/tournament.go
@@ -6,6 +6,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/determined-ai/determined/master/pkg/model"
+	"github.com/determined-ai/determined/master/pkg/schemas/expconf"
 	"github.com/determined-ai/determined/master/pkg/workload"
 )
 
@@ -125,7 +126,7 @@ func (s *tournamentSearch) progress(trialProgress map[model.RequestID]model.Part
 	return sum / float64(len(s.subSearches))
 }
 
-func (s *tournamentSearch) Unit() model.Unit {
+func (s *tournamentSearch) Unit() expconf.Unit {
 	return s.subSearches[0].Unit()
 }
 

--- a/master/pkg/searcher/tournament_test.go
+++ b/master/pkg/searcher/tournament_test.go
@@ -5,7 +5,9 @@ import (
 
 	"gotest.tools/assert"
 
-	"github.com/determined-ai/determined/master/pkg/model"
+	"github.com/determined-ai/determined/master/pkg/ptrs"
+	"github.com/determined-ai/determined/master/pkg/schemas"
+	"github.com/determined-ai/determined/master/pkg/schemas/expconf"
 )
 
 const RandomTournamentSearch SearchMethodType = "random_tournament"
@@ -13,14 +15,14 @@ const RandomTournamentSearch SearchMethodType = "random_tournament"
 func TestRandomTournamentSearcher(t *testing.T) {
 	actual := newTournamentSearch(
 		RandomTournamentSearch,
-		newRandomSearch(model.RandomConfig{
-			MaxTrials: 2,
-			MaxLength: model.NewLengthInBatches(300),
-		}),
-		newRandomSearch(model.RandomConfig{
-			MaxTrials: 3,
-			MaxLength: model.NewLengthInBatches(200),
-		}),
+		newRandomSearch(schemas.WithDefaults(expconf.RandomConfig{
+			RawMaxTrials: ptrs.IntPtr(2),
+			RawMaxLength: lengthPtr(expconf.NewLengthInBatches(300)),
+		}).(expconf.RandomConfig)),
+		newRandomSearch(schemas.WithDefaults(expconf.RandomConfig{
+			RawMaxTrials: ptrs.IntPtr(3),
+			RawMaxLength: lengthPtr(expconf.NewLengthInBatches(200)),
+		}).(expconf.RandomConfig)),
 	)
 	expected := [][]ValidateAfter{
 		toOps("300B"),
@@ -33,7 +35,10 @@ func TestRandomTournamentSearcher(t *testing.T) {
 }
 
 func TestRandomTournamentSearcherReproducibility(t *testing.T) {
-	conf := model.RandomConfig{MaxTrials: 5, MaxLength: model.NewLengthInBatches(800)}
+	conf := expconf.RandomConfig{
+		RawMaxTrials: ptrs.IntPtr(5), RawMaxLength: lengthPtr(expconf.NewLengthInBatches(800)),
+	}
+	conf = schemas.WithDefaults(conf).(expconf.RandomConfig)
 	gen := func() SearchMethod {
 		return newTournamentSearch(
 			RandomTournamentSearch,
@@ -55,31 +60,29 @@ func TestTournamentSearchMethod(t *testing.T) {
 		newConstantPredefinedTrial(toOps("1000B 3000B"), 0.1),
 	}
 
-	adaptiveConfig1 := model.SearcherConfig{
-		AsyncHalvingConfig: &model.AsyncHalvingConfig{
-			Metric:          "error",
-			NumRungs:        3,
-			SmallerIsBetter: true,
-			MaxLength:       model.NewLengthInBatches(9000),
-			MaxTrials:       3,
-			Divisor:         3,
+	adaptiveConfig1 := expconf.SearcherConfig{
+		RawAsyncHalvingConfig: &expconf.AsyncHalvingConfig{
+			RawNumRungs:  ptrs.IntPtr(3),
+			RawMaxLength: lengthPtr(expconf.NewLengthInBatches(9000)),
+			RawMaxTrials: ptrs.IntPtr(3),
+			RawDivisor:   ptrs.Float64Ptr(3),
 		},
 	}
+	adaptiveConfig1 = schemas.WithDefaults(adaptiveConfig1).(expconf.SearcherConfig)
 	adaptiveMethod1 := NewSearchMethod(adaptiveConfig1)
 
-	adaptiveConfig2 := model.SearcherConfig{
-		AsyncHalvingConfig: &model.AsyncHalvingConfig{
-			Metric:          "error",
-			NumRungs:        3,
-			SmallerIsBetter: true,
-			MaxLength:       model.NewLengthInBatches(9000),
-			MaxTrials:       3,
-			Divisor:         3,
+	adaptiveConfig2 := expconf.SearcherConfig{
+		RawAsyncHalvingConfig: &expconf.AsyncHalvingConfig{
+			RawNumRungs:  ptrs.IntPtr(3),
+			RawMaxLength: lengthPtr(expconf.NewLengthInBatches(9000)),
+			RawMaxTrials: ptrs.IntPtr(3),
+			RawDivisor:   ptrs.Float64Ptr(3),
 		},
 	}
+	adaptiveConfig2 = schemas.WithDefaults(adaptiveConfig2).(expconf.SearcherConfig)
 	adaptiveMethod2 := NewSearchMethod(adaptiveConfig2)
 
-	params := model.Hyperparameters{}
+	params := expconf.Hyperparameters{}
 
 	method := newTournamentSearch(AdaptiveSearch, adaptiveMethod1, adaptiveMethod2)
 

--- a/master/pkg/searcher/util_test.go
+++ b/master/pkg/searcher/util_test.go
@@ -15,6 +15,8 @@ import (
 	"github.com/determined-ai/determined/master/pkg/check"
 	"github.com/determined-ai/determined/master/pkg/model"
 	"github.com/determined-ai/determined/master/pkg/nprand"
+	"github.com/determined-ai/determined/master/pkg/schemas"
+	"github.com/determined-ai/determined/master/pkg/schemas/expconf"
 )
 
 const defaultMetric = "metric"
@@ -34,7 +36,7 @@ func isExpected(actual, expected []ValidateAfter) bool {
 func checkSimulation(
 	t *testing.T,
 	method SearchMethod,
-	params model.Hyperparameters,
+	params expconf.Hyperparameters,
 	validation ValidationFunction,
 	expected [][]ValidateAfter,
 ) {
@@ -62,8 +64,9 @@ func checkSimulation(
 // them, and checks that they produce the same trials and the same sequence of workloads for each
 // trial.
 func checkReproducibility(
-	t assert.TestingT, methodGen func() SearchMethod, hparams model.Hyperparameters, metric string,
+	t assert.TestingT, methodGen func() SearchMethod, hparams expconf.Hyperparameters, metric string,
 ) {
+	hparams = schemas.WithDefaults(hparams).(expconf.Hyperparameters)
 	seed := int64(17)
 	searcher1 := NewSearcher(uint32(seed), methodGen(), hparams)
 	searcher2 := NewSearcher(uint32(seed), methodGen(), hparams)
@@ -95,11 +98,11 @@ func toOps(types string) (ops []ValidateAfter) {
 		}
 		switch unit := string(unparsed[len(unparsed)-1]); unit {
 		case "R":
-			ops = append(ops, ValidateAfter{Length: model.NewLengthInRecords(count)})
+			ops = append(ops, ValidateAfter{Length: expconf.NewLengthInRecords(count)})
 		case "B":
-			ops = append(ops, ValidateAfter{Length: model.NewLengthInBatches(count)})
+			ops = append(ops, ValidateAfter{Length: expconf.NewLengthInBatches(count)})
 		case "E":
-			ops = append(ops, ValidateAfter{Length: model.NewLengthInEpochs(count)})
+			ops = append(ops, ValidateAfter{Length: expconf.NewLengthInEpochs(count)})
 		}
 	}
 	return ops
@@ -136,7 +139,7 @@ func newConstantPredefinedTrial(ops []ValidateAfter, valMetric float64) predefin
 	return newPredefinedTrial(ops, nil, valMetrics)
 }
 
-func (t *predefinedTrial) Train(length model.Length, opIndex int) error {
+func (t *predefinedTrial) Train(length expconf.Length, opIndex int) error {
 	if opIndex >= len(t.Ops) {
 		return errors.Errorf("ran out of expected ops trying to train")
 	}
@@ -155,7 +158,7 @@ func (t *predefinedTrial) CheckComplete(opIndex int) error {
 func checkValueSimulation(
 	t *testing.T,
 	method SearchMethod,
-	params model.Hyperparameters,
+	params expconf.Hyperparameters,
 	expectedTrials []predefinedTrial,
 ) error {
 	// Create requests are assigned a predefinedTrial in order.
@@ -252,8 +255,11 @@ func runValueSimulationTestCases(t *testing.T, testCases []valueSimulationTestCa
 	for _, testCase := range testCases {
 		tc := testCase
 		t.Run(tc.name, func(t *testing.T) {
-			method := NewSearchMethod(tc.config)
-			err := checkValueSimulation(t, method, tc.hparams, tc.expectedTrials)
+			// Apply WithDefaults in one place to make tests easyto write.
+			config := schemas.WithDefaults(tc.config).(expconf.SearcherConfig)
+			hparams := schemas.WithDefaults(tc.hparams).(expconf.Hyperparameters)
+			method := NewSearchMethod(config)
+			err := checkValueSimulation(t, method, hparams, tc.expectedTrials)
 			assert.NilError(t, err)
 		})
 	}
@@ -262,8 +268,8 @@ func runValueSimulationTestCases(t *testing.T, testCases []valueSimulationTestCa
 type valueSimulationTestCase struct {
 	name           string
 	expectedTrials []predefinedTrial
-	hparams        model.Hyperparameters
-	config         model.SearcherConfig
+	hparams        expconf.Hyperparameters
+	config         expconf.SearcherConfig
 }
 
 func simulateOperationComplete(

--- a/master/pkg/tasks/mounts.go
+++ b/master/pkg/tasks/mounts.go
@@ -5,24 +5,24 @@ import (
 
 	"github.com/docker/docker/api/types/mount"
 
-	"github.com/determined-ai/determined/master/pkg/model"
+	"github.com/determined-ai/determined/master/pkg/schemas/expconf"
 )
 
-// ToDockerMounts converts model bind mounts to container mounts.
-func ToDockerMounts(bindMounts []model.BindMount) []mount.Mount {
+// ToDockerMounts converts expconf bind mounts to container mounts.
+func ToDockerMounts(bindMounts []expconf.BindMount) []mount.Mount {
 	dockerMounts := make([]mount.Mount, 0, len(bindMounts))
 	for _, m := range bindMounts {
-		target := m.ContainerPath
+		target := m.ContainerPath()
 		if !filepath.IsAbs(target) {
 			target = filepath.Join(ContainerWorkDir, target)
 		}
 		dockerMounts = append(dockerMounts, mount.Mount{
 			Type:     mount.TypeBind,
-			Source:   m.HostPath,
+			Source:   m.HostPath(),
 			Target:   target,
-			ReadOnly: m.ReadOnly,
+			ReadOnly: m.ReadOnly(),
 			BindOptions: &mount.BindOptions{
-				Propagation: mount.Propagation(m.Propagation),
+				Propagation: mount.Propagation(m.Propagation()),
 			},
 		})
 	}

--- a/master/pkg/tasks/task.go
+++ b/master/pkg/tasks/task.go
@@ -71,7 +71,7 @@ func ToContainerSpec(t TaskSpec) container.Spec {
 	if len(t.Devices) > 0 {
 		deviceType = t.Devices[0].Type
 	}
-	envVars = append(envVars, env.EnvironmentVariables.For(deviceType)...)
+	envVars = append(envVars, env.EnvironmentVariables().For(deviceType)...)
 
 	network := t.TaskContainerDefaults.NetworkMode
 	if t.UseHostMode() {
@@ -85,26 +85,26 @@ func ToContainerSpec(t TaskSpec) container.Spec {
 
 	resources := t.ResourcesConfig()
 	var devices []docker.DeviceMapping
-	for _, device := range resources.Devices {
+	for _, device := range resources.Devices() {
 		devices = append(devices, docker.DeviceMapping{
-			PathOnHost:        device.HostPath,
-			PathInContainer:   device.ContainerPath,
-			CgroupPermissions: device.Mode,
+			PathOnHost:        device.HostPath(),
+			PathInContainer:   device.ContainerPath(),
+			CgroupPermissions: device.Mode(),
 		})
 	}
 
 	spec := container.Spec{
 		PullSpec: container.PullSpec{
-			Registry:  env.RegistryAuth,
-			ForcePull: env.ForcePullImage,
+			Registry:  env.RegistryAuth(),
+			ForcePull: env.ForcePullImage(),
 		},
 		RunSpec: container.RunSpec{
 			ContainerConfig: docker.Config{
 				User:         getUser(t.AgentUserGroup),
-				ExposedPorts: toPortSet(env.Ports),
+				ExposedPorts: toPortSet(env.Ports()),
 				Env:          envVars,
 				Cmd:          t.Entrypoint(),
-				Image:        env.Image.For(deviceType),
+				Image:        env.Image().For(deviceType),
 				WorkingDir:   ContainerWorkDir,
 			},
 			HostConfig: docker.HostConfig{
@@ -112,8 +112,8 @@ func ToContainerSpec(t TaskSpec) container.Spec {
 				Mounts:          t.Mounts(),
 				PublishAllPorts: true,
 				ShmSize:         shmSize,
-				CapAdd:          env.AddCapabilities,
-				CapDrop:         env.DropCapabilities,
+				CapAdd:          env.AddCapabilities(),
+				CapDrop:         env.DropCapabilities(),
 
 				Resources: docker.Resources{
 					Devices: devices,

--- a/master/pkg/tasks/task_spec.go
+++ b/master/pkg/tasks/task_spec.go
@@ -18,6 +18,8 @@ import (
 	"github.com/determined-ai/determined/master/pkg/archive"
 	"github.com/determined-ai/determined/master/pkg/device"
 	"github.com/determined-ai/determined/master/pkg/model"
+	"github.com/determined-ai/determined/master/pkg/schemas"
+	"github.com/determined-ai/determined/master/pkg/schemas/expconf"
 )
 
 // MakeTaskSpecFn is a workaround for the delayed initialization that we have around how tasks are
@@ -36,7 +38,7 @@ type InnerSpec interface {
 	// Entrypoint returns the command and arguments to run in the container for this task.
 	Entrypoint() []string
 	// Environment returns the container environment for this task.
-	Environment(TaskSpec) model.Environment
+	Environment(TaskSpec) expconf.EnvironmentConfig
 	// EnvVars returns the environment variables to set for this task (apart from the base ones set for
 	// all containers).
 	EnvVars(TaskSpec) map[string]string
@@ -52,7 +54,7 @@ type InnerSpec interface {
 	// UseHostMode indicates whether host mode networking would be desirable for this task.
 	UseHostMode() bool
 	//ResourcesConfig returns the resources config of the model
-	ResourcesConfig() model.ResourcesConfig
+	ResourcesConfig() expconf.ResourcesConfig
 }
 
 // This alias allows TaskSpec to privately embed the public InnerSpec so that it can reuse (some of)
@@ -124,7 +126,7 @@ func (t *TaskSpec) Archives() []container.RunArchive {
 }
 
 // Environment returns the container environment for this task.
-func (t *TaskSpec) Environment() model.Environment { return t.inner.Environment(*t) }
+func (t *TaskSpec) Environment() expconf.EnvironmentConfig { return t.inner.Environment(*t) }
 
 // EnvVars returns the environment variables that should be set in the container for this task.
 func (t *TaskSpec) EnvVars() map[string]string {
@@ -157,7 +159,9 @@ func (s StartCommand) Description() string { return "cmd" }
 func (s StartCommand) Entrypoint() []string { return s.Config.Entrypoint }
 
 // Environment implements InnerSpec.
-func (s StartCommand) Environment(TaskSpec) model.Environment { return s.Config.Environment }
+func (s StartCommand) Environment(TaskSpec) expconf.EnvironmentConfig {
+	return s.Config.Environment.ToExpconf()
+}
 
 // EnvVars implements InnerSpec.
 func (s StartCommand) EnvVars(TaskSpec) map[string]string { return nil }
@@ -166,7 +170,9 @@ func (s StartCommand) EnvVars(TaskSpec) map[string]string { return nil }
 func (s StartCommand) LoggingFields() map[string]string { return nil }
 
 // Mounts implements InnerSpec.
-func (s StartCommand) Mounts() []mount.Mount { return ToDockerMounts(s.Config.BindMounts) }
+func (s StartCommand) Mounts() []mount.Mount {
+	return ToDockerMounts(s.Config.BindMounts.ToExpconf())
+}
 
 // ShmSize implements InnerSpec.
 func (s StartCommand) ShmSize() int64 {
@@ -183,12 +189,14 @@ func (s StartCommand) UseFluentLogging() bool { return false }
 func (s StartCommand) UseHostMode() bool { return false }
 
 // ResourcesConfig implements InnerSpec.
-func (s StartCommand) ResourcesConfig() model.ResourcesConfig { return s.Config.Resources }
+func (s StartCommand) ResourcesConfig() expconf.ResourcesConfig {
+	return s.Config.Resources.ToExpconf()
+}
 
 // GCCheckpoints is a description of a task for running checkpoint GC.
 type GCCheckpoints struct {
 	ExperimentID       int
-	ExperimentConfig   model.ExperimentConfig
+	ExperimentConfig   expconf.ExperimentConfig
 	ToDelete           json.RawMessage
 	DeleteTensorboards bool
 }
@@ -243,10 +251,20 @@ func (g GCCheckpoints) Entrypoint() []string {
 }
 
 // Environment implements InnerSpec.
-func (g GCCheckpoints) Environment(t TaskSpec) model.Environment {
-	env := model.DefaultExperimentConfig(&t.TaskContainerDefaults).Environment
-	env.EnvironmentVariables = g.ExperimentConfig.Environment.EnvironmentVariables
-	return env
+func (g GCCheckpoints) Environment(t TaskSpec) expconf.EnvironmentConfig {
+	// Keep only the EnvironmentVariables provided by the experiment's config.
+	env := expconf.EnvironmentConfig{
+		RawEnvironmentVariables: g.ExperimentConfig.Environment().RawEnvironmentVariables,
+	}
+
+	// Fill the rest of the environment with default values.
+	defaultConfig := expconf.ExperimentConfig{}
+	t.TaskContainerDefaults.MergeIntoConfig(&defaultConfig)
+
+	if defaultConfig.RawEnvironment != nil {
+		env = schemas.Merge(env, *defaultConfig.RawEnvironment).(expconf.EnvironmentConfig)
+	}
+	return schemas.WithDefaults(env).(expconf.EnvironmentConfig)
 }
 
 // EnvVars implements InnerSpec.
@@ -257,11 +275,11 @@ func (g GCCheckpoints) LoggingFields() map[string]string { return nil }
 
 // Mounts implements InnerSpec.
 func (g GCCheckpoints) Mounts() []mount.Mount {
-	mounts := ToDockerMounts(g.ExperimentConfig.BindMounts)
-	if fs := g.ExperimentConfig.CheckpointStorage.SharedFSConfig; fs != nil {
+	mounts := ToDockerMounts(g.ExperimentConfig.BindMounts())
+	if fs := g.ExperimentConfig.CheckpointStorage().RawSharedFSConfig; fs != nil {
 		mounts = append(mounts, mount.Mount{
 			Type:   mount.TypeBind,
-			Source: fs.HostPath,
+			Source: fs.HostPath(),
 			Target: model.DefaultSharedFSContainerPath,
 			BindOptions: &mount.BindOptions{
 				Propagation: model.DefaultSharedFSPropagation,
@@ -281,13 +299,13 @@ func (g GCCheckpoints) UseFluentLogging() bool { return false }
 func (g GCCheckpoints) UseHostMode() bool { return false }
 
 // ResourcesConfig implements InnerSpec.
-func (g GCCheckpoints) ResourcesConfig() model.ResourcesConfig {
-	return g.ExperimentConfig.Resources
+func (g GCCheckpoints) ResourcesConfig() expconf.ResourcesConfig {
+	return g.ExperimentConfig.Resources()
 }
 
 // StartTrial is a description of a task for running a trial container.
 type StartTrial struct {
-	ExperimentConfig    model.ExperimentConfig
+	ExperimentConfig    expconf.ExperimentConfig
 	ModelDefinition     archive.Archive
 	HParams             map[string]interface{}
 	TrialSeed           uint32
@@ -346,14 +364,13 @@ func (s StartTrial) Entrypoint() []string {
 }
 
 // Environment implements InnerSpec.
-func (s StartTrial) Environment(t TaskSpec) model.Environment {
-	env := s.ExperimentConfig.Environment
-	if env.Ports == nil {
-		env.Ports = make(map[string]int)
-	}
+func (s StartTrial) Environment(t TaskSpec) expconf.EnvironmentConfig {
+	env := s.ExperimentConfig.Environment()
+	ports := env.Ports()
 	for i, port := range rendezvousPorts(trialUniquePortOffset(t.Devices)) {
-		env.Ports[fmt.Sprintf("trial-%d", i)] = port
+		ports[fmt.Sprintf("trial-%d", i)] = port
 	}
+	env.SetPorts(ports)
 	return env
 }
 
@@ -387,34 +404,34 @@ func (s StartTrial) LoggingFields() map[string]string {
 
 // Mounts implements InnerSpec.
 func (s StartTrial) Mounts() []mount.Mount {
-	mounts := ToDockerMounts(s.ExperimentConfig.BindMounts)
+	mounts := ToDockerMounts(s.ExperimentConfig.BindMounts())
 	addMount := func(source, target string, bindOpts *mount.BindOptions) {
 		mounts = append(mounts, mount.Mount{
 			Type: mount.TypeBind, Source: source, Target: target, BindOptions: bindOpts,
 		})
 	}
 
-	if c := s.ExperimentConfig.CheckpointStorage.SharedFSConfig; c != nil {
+	if c := s.ExperimentConfig.CheckpointStorage().RawSharedFSConfig; c != nil {
 		addMount(
-			c.HostPath,
+			c.HostPath(),
 			model.DefaultSharedFSContainerPath,
 			&mount.BindOptions{Propagation: model.DefaultSharedFSPropagation},
 		)
 	}
 
-	if c := s.ExperimentConfig.DataLayer.SharedFSConfig; c != nil {
-		if c.HostStoragePath != nil && c.ContainerStoragePath != nil {
-			addMount(*c.HostStoragePath, *c.ContainerStoragePath, nil)
+	if c := s.ExperimentConfig.DataLayer().RawSharedFSConfig; c != nil {
+		if c.HostStoragePath() != nil && c.ContainerStoragePath() != nil {
+			addMount(*c.HostStoragePath(), *c.ContainerStoragePath(), nil)
 		}
 	}
-	if c := s.ExperimentConfig.DataLayer.S3Config; c != nil {
-		if c.LocalCacheHostPath != nil && c.LocalCacheContainerPath != nil {
-			addMount(*c.LocalCacheHostPath, *c.LocalCacheContainerPath, nil)
+	if c := s.ExperimentConfig.DataLayer().RawS3Config; c != nil {
+		if c.LocalCacheHostPath() != nil && c.LocalCacheContainerPath() != nil {
+			addMount(*c.LocalCacheHostPath(), *c.LocalCacheContainerPath(), nil)
 		}
 	}
-	if c := s.ExperimentConfig.DataLayer.GCSConfig; c != nil {
-		if c.LocalCacheHostPath != nil && c.LocalCacheContainerPath != nil {
-			addMount(*c.LocalCacheHostPath, *c.LocalCacheContainerPath, nil)
+	if c := s.ExperimentConfig.DataLayer().RawGCSConfig; c != nil {
+		if c.LocalCacheHostPath() != nil && c.LocalCacheContainerPath() != nil {
+			addMount(*c.LocalCacheHostPath(), *c.LocalCacheContainerPath(), nil)
 		}
 	}
 
@@ -429,11 +446,13 @@ func (s StartTrial) UseHostMode() bool { return s.IsMultiAgent }
 
 // ShmSize implements InnerSpec.
 func (s StartTrial) ShmSize() int64 {
-	if shm := s.ExperimentConfig.Resources.ShmSize; shm != nil {
+	if shm := s.ExperimentConfig.Resources().ShmSize(); shm != nil {
 		return int64(*shm)
 	}
 	return 0
 }
 
 // ResourcesConfig implements InnerSpec.
-func (s StartTrial) ResourcesConfig() model.ResourcesConfig { return s.ExperimentConfig.Resources }
+func (s StartTrial) ResourcesConfig() expconf.ResourcesConfig {
+	return s.ExperimentConfig.Resources()
+}

--- a/master/test/integration/api/api_trials_test.go
+++ b/master/test/integration/api/api_trials_test.go
@@ -135,7 +135,7 @@ func trialDetailAPITests(
 
 			step := testutils.StepModel(trial.ID)
 			step.ID = id
-			step.TotalBatches = id * experiment.Config.SchedulingUnit
+			step.TotalBatches = id * experiment.Config.SchedulingUnit()
 			err = db.AddStep(step)
 			assert.NilError(t, err, "failed to insert step")
 

--- a/schemas/gen.py
+++ b/schemas/gen.py
@@ -255,6 +255,10 @@ def get_defaulted_type(schema: Schema, tag: str, type: str) -> Tuple[str, str, b
         "DevicesConfigV0",
         "HyperparametersV0",
         "LabelsV0",
+        # Technically Description is a struct containing a string pointer, which exists only to
+        # handle the semantics of runtime defaultables.  But it has the same mechanics as a map or
+        # slice alias, so we include it here.
+        "Description",
     ]
 
     # Disallow pointers for required fields in all cases.

--- a/schemas/test_cases/v0/defaults.yaml
+++ b/schemas/test_cases/v0/defaults.yaml
@@ -12,6 +12,45 @@
     propagation: rprivate
     read_only: false
 
+- name: environment defaults with k8sV1.Pod present
+  matches:
+    - http://determined.ai/schemas/expconf/v0/environment.json
+  case:
+    environment_variables:
+      - ASDF=asdf
+    # Any non-null pod_spec is fine
+    pod_spec: {}
+    ports:
+      asdf: 1
+    registry_auth:
+      username: samiam
+      password: eggsnham
+    add_capabilities:
+      - CAP_STRING
+    drop_capabilities:
+      - OTHER_CAP_STRING
+  defaulted:
+    environment_variables:
+      cpu:
+        - ASDF=asdf
+      gpu:
+        - ASDF=asdf
+    force_pull_image: false
+    image:
+      cpu: '*'
+      gpu: '*'
+    # go will generate some non-empty struct here, but python will not
+    pod_spec: '*'
+    ports:
+      asdf: 1
+    registry_auth:
+      username: samiam
+      password: eggsnham
+    add_capabilities:
+      - CAP_STRING
+    drop_capabilities:
+      - OTHER_CAP_STRING
+
 - name: single searcher defaults
   matches:
     - http://determined.ai/schemas/expconf/v0/searcher.json


### PR DESCRIPTION
## Description

fix add schemas.Defaultable and schemas.Copyable

The reflect-based behavior of schemas.WithDefaults and schemas.Merge
works great on plain-old-data types which have no private fields, but it
pukes on private fields.

There already was a schemas.Mergable interface for customizing the
merging behaviors of objects.  This change introduces the
schemas.Defaultable and schemas.Copyable interfaces, which have
analagous effects on schemas.WithDefaults and schemas.cpy (unexported).

schemas.Copyable is very easy to understand.  For example, the new
expconf.Pod (which is type-defined to k8sV1.Pod) simply calls
k8sV1.Pod.DeepCopy().

schemas.RuntimeDefaultable has been removed in favor of
schemas.Defaultable.  Defaultable makes the reflect code a little
easier and is more like the Mergable and Copyable
interfaces than RuntimeDefaultable was.  The flipside is that the
runtime default behavior of the ExperimentConfig.Description is slightly
more complex.  Overall the tradeoff seems appropriate; the general code
(schemas.WithDefaults()) got more general and clearer, and the specific
challenges of the calling code are handled in the calling code.

Overall, the motivation for this change was to protect against panics
when interfacing with the k8sV1.Pod object.  The only other external
object in the expconf project, `AuthConfig`, is reflect-friendly and
does not require modification.

## Test Plan

I will run GKE tests before thinking this works.
