### PR TITLE
feat: add SlotsPerAgent in resource pool API

### DIFF
--- a/docs/release-notes/2383-slots-per-agent.txt
+++ b/docs/release-notes/2383-slots-per-agent.txt
@@ -1,0 +1,7 @@
+:orphan:
+
+**Improvements**
+
+-  API: return a SlotsPerAgent field in the resource pool API. This
+   returns the slot number on each dynamic agent on AWS, GCP, or K8s. If
+   no dynamic agent is configured, return -1.

--- a/master/internal/provisioner/aws.go
+++ b/master/internal/provisioner/aws.go
@@ -122,7 +122,7 @@ func newAWSCluster(
 			StartupScriptBase64:          startupScriptBase64,
 			ContainerStartupScriptBase64: containerScriptBase64,
 			MasterCertBase64:             masterCertBase64,
-			AgentUseGPUs:                 config.AWS.InstanceType.slots() > 0,
+			AgentUseGPUs:                 config.AWS.InstanceType.Slots() > 0,
 			AgentDockerRuntime:           config.AgentDockerRuntime,
 			AgentNetwork:                 config.AgentDockerNetwork,
 			AgentDockerImage:             config.AgentDockerImage,

--- a/master/internal/provisioner/aws_config.go
+++ b/master/internal/provisioner/aws_config.go
@@ -196,7 +196,7 @@ func (t ec2InstanceType) name() string {
 	return string(t)
 }
 
-func (t ec2InstanceType) slots() int {
+func (t ec2InstanceType) Slots() int {
 	if s, ok := ec2InstanceSlots[t]; ok {
 		return s
 	}

--- a/master/internal/provisioner/gcp.go
+++ b/master/internal/provisioner/gcp.go
@@ -76,7 +76,7 @@ func newGCPCluster(
 		MasterHost:                   masterURL.Hostname(),
 		MasterPort:                   masterURL.Port(),
 		MasterCertName:               config.MasterCertName,
-		AgentUseGPUs:                 config.GCP.InstanceType.slots() > 0,
+		AgentUseGPUs:                 config.GCP.InstanceType.Slots() > 0,
 		AgentNetwork:                 config.AgentDockerNetwork,
 		AgentDockerRuntime:           config.AgentDockerRuntime,
 		AgentDockerImage:             config.AgentDockerImage,

--- a/master/internal/provisioner/gcp_config.go
+++ b/master/internal/provisioner/gcp_config.go
@@ -258,7 +258,7 @@ func (t gceInstanceType) name() string {
 	return fmt.Sprintf("%s-%s-%d", t.MachineType, t.GPUType, t.GPUNum)
 }
 
-func (t gceInstanceType) slots() int {
+func (t gceInstanceType) Slots() int {
 	return t.GPUNum
 }
 

--- a/master/internal/provisioner/instance.go
+++ b/master/internal/provisioner/instance.go
@@ -9,7 +9,7 @@ import (
 // instanceType describes an instance type.
 type instanceType interface {
 	name() string
-	slots() int
+	Slots() int
 }
 
 // InstanceState is an enum type that describes an instance state.

--- a/master/internal/provisioner/provisioner.go
+++ b/master/internal/provisioner/provisioner.go
@@ -95,9 +95,9 @@ func (p *Provisioner) Receive(ctx *actor.Context) error {
 	return nil
 }
 
-// SlotsPerInstance returns the number of slots per instance the provisioner launches.
+// SlotsPerInstance returns the number of Slots per instance the provisioner launches.
 func (p *Provisioner) SlotsPerInstance() int {
-	return p.provider.instanceType().slots()
+	return p.provider.instanceType().Slots()
 }
 
 func (p *Provisioner) provision(ctx *actor.Context) {

--- a/master/internal/provisioner/provisioner_test.go
+++ b/master/internal/provisioner/provisioner_test.go
@@ -12,15 +12,15 @@ import (
 )
 
 type TestInstanceType struct {
-	Name  string
-	Slots int
+	Name     string
+	NumSlots int
 }
 
 func (t TestInstanceType) name() string {
 	return t.Name
 }
-func (t TestInstanceType) slots() int {
-	return t.Slots
+func (t TestInstanceType) Slots() int {
+	return t.NumSlots
 }
 
 func newInstanceIDSet(instanceIDs []string) map[string]bool {
@@ -144,8 +144,8 @@ func TestProvisionerScaleUp(t *testing.T) {
 	setup := &mockConfig{
 		maxDisconnectPeriod: 5 * time.Minute,
 		instanceType: TestInstanceType{
-			Name:  "test.instanceType",
-			Slots: 4,
+			Name:     "test.instanceType",
+			NumSlots: 4,
 		},
 		Config: &Config{
 			MaxInstances: 100,
@@ -159,8 +159,8 @@ func TestProvisionerScaleUp(t *testing.T) {
 	assert.DeepEqual(t, mock.cluster.history, []mockFuncCall{
 		newMockFuncCall("list"),
 		newMockFuncCall("launch", TestInstanceType{
-			Name:  "test.instanceType",
-			Slots: 4,
+			Name:     "test.instanceType",
+			NumSlots: 4,
 		}, 4),
 	})
 }
@@ -169,8 +169,8 @@ func TestProvisionerScaleUpNotPastMax(t *testing.T) {
 	setup := &mockConfig{
 		maxDisconnectPeriod: 5 * time.Minute,
 		instanceType: TestInstanceType{
-			Name:  "test.instanceType",
-			Slots: 4,
+			Name:     "test.instanceType",
+			NumSlots: 4,
 		},
 		Config: &Config{
 			MaxInstances: 1,
@@ -184,8 +184,8 @@ func TestProvisionerScaleUpNotPastMax(t *testing.T) {
 	assert.DeepEqual(t, mock.cluster.history, []mockFuncCall{
 		newMockFuncCall("list"),
 		newMockFuncCall("launch", TestInstanceType{
-			Name:  "test.instanceType",
-			Slots: 4,
+			Name:     "test.instanceType",
+			NumSlots: 4,
 		}, 1),
 	})
 }
@@ -194,8 +194,8 @@ func TestProvisionerScaleDown(t *testing.T) {
 	setup := &mockConfig{
 		maxDisconnectPeriod: 5 * time.Minute,
 		instanceType: TestInstanceType{
-			Name:  "test.instanceType",
-			Slots: 4,
+			Name:     "test.instanceType",
+			NumSlots: 4,
 		},
 		Config: &Config{
 			MaxIdleAgentPeriod: Duration(50 * time.Millisecond),
@@ -244,8 +244,8 @@ func TestProvisionerNotProvisionExtraInstances(t *testing.T) {
 	setup := &mockConfig{
 		maxDisconnectPeriod: 5 * time.Minute,
 		instanceType: TestInstanceType{
-			Name:  "test.instanceType",
-			Slots: 4,
+			Name:     "test.instanceType",
+			NumSlots: 4,
 		},
 		Config: &Config{
 			MaxAgentStartingPeriod: Duration(100 * time.Millisecond),
@@ -302,8 +302,8 @@ func TestProvisionerTerminateDisconnectedInstances(t *testing.T) {
 	setup := &mockConfig{
 		maxDisconnectPeriod: 50 * time.Millisecond,
 		instanceType: TestInstanceType{
-			Name:  "test.instanceType",
-			Slots: 4,
+			Name:     "test.instanceType",
+			NumSlots: 4,
 		},
 		Config: &Config{
 			MaxAgentStartingPeriod: Duration(3 * time.Minute),

--- a/master/internal/resourcemanagers/agent_resource_manager.go
+++ b/master/internal/resourcemanagers/agent_resource_manager.go
@@ -210,6 +210,7 @@ func (a *agentResourceManager) createResourcePoolSummary(
 	location := "on-prem"
 	imageID := ""
 	instanceType := ""
+	slotsPerAgent := -1
 
 	if pool.Provider != nil {
 		if pool.Provider.AWS != nil {
@@ -218,13 +219,14 @@ func (a *agentResourceManager) createResourcePoolSummary(
 			location = pool.Provider.AWS.Region
 			imageID = pool.Provider.AWS.ImageID
 			instanceType = string(pool.Provider.AWS.InstanceType)
+			slotsPerAgent = pool.Provider.AWS.InstanceType.Slots()
 		}
 		if pool.Provider.GCP != nil {
 			poolType = resourcepoolv1.ResourcePoolType_RESOURCE_POOL_TYPE_GCP
 			preemptible = pool.Provider.GCP.InstanceType.Preemptible
 			location = pool.Provider.GCP.Zone
 			imageID = pool.Provider.GCP.BootDiskSourceImage
-
+			slotsPerAgent = pool.Provider.GCP.InstanceType.GPUNum
 			if pool.Provider.GCP.InstanceType.GPUNum == 0 {
 				instanceType = pool.Provider.GCP.InstanceType.MachineType
 			} else {
@@ -264,6 +266,7 @@ func (a *agentResourceManager) createResourcePoolSummary(
 		DefaultCpuPool:               a.config.DefaultCPUResourcePool == poolName,
 		DefaultGpuPool:               a.config.DefaultGPUResourcePool == poolName,
 		Preemptible:                  preemptible,
+		SlotsPerAgent:                int32(slotsPerAgent),
 		CpuContainerCapacityPerAgent: int32(pool.MaxCPUContainersPerAgent),
 		SchedulerType:                schedulerType,
 		Location:                     location,

--- a/master/internal/resourcemanagers/kubernetes_resource_manager.go
+++ b/master/internal/resourcemanagers/kubernetes_resource_manager.go
@@ -134,6 +134,7 @@ func (k *kubernetesResourceManager) summarizeDummyResourcePool(
 		Preemptible:                  false,
 		MinAgents:                    0,
 		MaxAgents:                    0,
+		SlotsPerAgent:                int32(k.config.MaxSlotsPerPod),
 		CpuContainerCapacityPerAgent: 0,
 		SchedulerType:                resourcepoolv1.SchedulerType_SCHEDULER_TYPE_KUBERNETES,
 		SchedulerFittingPolicy:       resourcepoolv1.FittingPolicy_FITTING_POLICY_KUBERNETES,

--- a/proto/src/determined/resourcepool/v1/resourcepool.proto
+++ b/proto/src/determined/resourcepool/v1/resourcepool.proto
@@ -117,6 +117,8 @@ message ResourcePool {
   // When using dynamic agents, the maximum number of agents that can exist in
   // the resource pool.
   int32 max_agents = 13;
+  // The number of slots that exists on an dynamic agent.
+  int32 slots_per_agent = 14;
   // The maximum number of CPU containers that can run on an individual agent
   int32 cpu_container_capacity_per_agent = 15;
   // The type of the scheduler. Either 'FAIR_SHARE', 'PRIORITY', or


### PR DESCRIPTION
## Description

Add a SlotsPerAgent field in the resource pool API. This returns the slot number on each dynamic agent. If there is no dynamic agents configured, return -1.

## Test Plan

- CI
- Manually check the resource pool field.

## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
