### PR TITLE
docs: deprecate old master configuration fields

### DIFF
--- a/docs/reference/cluster-config.txt
+++ b/docs/reference/cluster-config.txt
@@ -40,8 +40,8 @@ configure the behavior of the master or agent using environment
 variables, specify an environment variable starting with ``DET_``
 followed by the name of the configuration variable. Underscores (``_``)
 should be used to indicate nested options: for example, the
-``scheduler.fit`` master configuration option can be specified via an
-environment variable named ``DET_SCHEDULER_FIT``.
+``logging.type`` master configuration option can be specified via an
+environment variable named ``DET_LOGGING_TYPE``.
 
 The equivalent of the agent configuration file shown above can be
 specified by setting two environment variables, ``DET_MASTER_HOST`` and

--- a/docs/release-notes/deprecate-old-master-config.txt
+++ b/docs/release-notes/deprecate-old-master-config.txt
@@ -1,0 +1,8 @@
+:orphan:
+
+**Deprecation**
+
+-  Master Configuration: deprecate ``scheduler`` and ``provisioner``
+   fields in the master configuration in favor of ``resource_manager``
+   and ``resource pools``. They will be remove in the future version
+   0.16.0. For more information see :ref:`resource-pools`.


### PR DESCRIPTION
## Description

<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234