### PR TITLE
chore: make pip happy again

### DIFF
--- a/harness/setup.py
+++ b/harness/setup.py
@@ -25,6 +25,7 @@ setup(
         "pyzmq>=18.1.0",
         "yogadl==0.1.4",
         # Common:
+        "backoff",
         "google-cloud-storage>=1.20.0",
         # google-cloud-core 1.4.2 breaks our windows cli tests for python 3.5.
         "google-cloud-core<1.4.2",
@@ -55,7 +56,9 @@ setup(
         "docker-compose>=1.13.0",
         "tqdm",
         "appdirs",
-        "backoff",
+        # docker-compose has a requirement not properly propagated with semi-old pip installations;
+        # so we expose that requirement here.
+        "websocket-client<1",
     ],
     extras_require={
         "tf-115-cuda102": ["tensorflow-gpu==1.15.5"],


### PR DESCRIPTION
## Description

websocket-client just released 1.0, which conflicts with docker-compose,
which breaks the determined install with older version of pip.

See https://app.circleci.com/pipelines/github/determined-ai/determined/12416/workflows/4d41102c-4e72-46e9-842f-6226121f2429/jobs/360714 for an example.