### PR TITLE
chore: only return the port binding appropriate for the proxy [DET-5495]

### DIFF
--- a/master/internal/trial.go
+++ b/master/internal/trial.go
@@ -925,15 +925,10 @@ func (t *trial) pushRendezvous(ctx *actor.Context) error {
 		var addresses []*rendezvousAddress
 
 		var addrs []cproto.Address
-		// Track container ports and only add uniques to addrs.
-		// Sometime around Docker 20.10.6, Docker started, seemingly randomly,
-		// binding multiple host ports to a container port very rarely.
-		containerPorts := map[int]bool{}
 		for _, addr := range caddr.Addresses {
 			if MinLocalRendezvousPort <= addr.ContainerPort &&
-				addr.ContainerPort <= MaxLocalRendezvousPort && !containerPorts[addr.ContainerPort] {
+				addr.ContainerPort <= MaxLocalRendezvousPort {
 				addrs = append(addrs, addr)
-				containerPorts[addr.ContainerPort] = true
 			}
 
 			addresses = append(addresses, &rendezvousAddress{

--- a/master/pkg/agent/master_message.go
+++ b/master/pkg/agent/master_message.go
@@ -62,12 +62,7 @@ type ContainerStarted struct {
 // started information.
 func (c ContainerStarted) Addresses() []container.Address {
 	proxy := c.ProxyAddress
-
-	proxyIP, _, err := net.ParseCIDR(proxy)
-	if err != nil {
-		panic(errors.Wrapf(err, "failed to parse ip %s", proxy))
-	}
-	proxyIsIPv4 := len(proxyIP) == net.IPv4len
+	proxyIsIPv4 := len(net.ParseIP(proxy)) == net.IPv4len
 
 	info := c.ContainerInfo
 

--- a/master/pkg/agent/master_message.go
+++ b/master/pkg/agent/master_message.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"net"
 	"strconv"
 	"time"
 
@@ -61,6 +62,13 @@ type ContainerStarted struct {
 // started information.
 func (c ContainerStarted) Addresses() []container.Address {
 	proxy := c.ProxyAddress
+
+	proxyIP, _, err := net.ParseCIDR(proxy)
+	if err != nil {
+		panic(errors.Wrapf(err, "failed to parse ip %s", proxy))
+	}
+	proxyIsIPv4 := len(proxyIP) == net.IPv4len
+
 	info := c.ContainerInfo
 
 	var addresses []container.Address
@@ -83,31 +91,39 @@ func (c ContainerStarted) Addresses() []container.Address {
 		for _, network := range networks {
 			ipAddresses = append(ipAddresses, network.IPAddress)
 		}
-		// uniqueBindings is used to filter out bindings to 0.0.0.0 and ::
-		// that are coalesced to the same container.Address.
-		uniqueBindings := map[string]bool{}
+
 		for port, bindings := range info.NetworkSettings.Ports {
 			for _, binding := range bindings {
 				for _, ip := range ipAddresses {
 					hostIP := binding.HostIP
-					if hostIP == "" || hostIP == "0.0.0.0" || hostIP == "::" {
+					switch {
+					case hostIP == "0.0.0.0":
+						// Just don't return the ipv4 binding for an ipv6 proxy
+						if !proxyIsIPv4 {
+							continue
+						}
+						hostIP = proxy
+					case hostIP == "::":
+						// And vice versa.
+						if proxyIsIPv4 {
+							continue
+						}
+						hostIP = proxy
+					case hostIP == "":
 						hostIP = proxy
 					}
+
 					hostPort, err := strconv.Atoi(binding.HostPort)
 					if err != nil {
 						panic(errors.Wrapf(err, "unexpected host port: %s", binding.HostPort))
 					}
 
-					cAddress := container.Address{
+					addresses = append(addresses, container.Address{
 						ContainerIP:   ip,
 						ContainerPort: port.Int(),
 						HostIP:        hostIP,
 						HostPort:      hostPort,
-					}
-					if !uniqueBindings[cAddress.String()] {
-						addresses = append(addresses, cAddress)
-						uniqueBindings[cAddress.String()] = true
-					}
+					})
 				}
 			}
 		}

--- a/master/pkg/agent/master_message.go
+++ b/master/pkg/agent/master_message.go
@@ -62,7 +62,7 @@ type ContainerStarted struct {
 // started information.
 func (c ContainerStarted) Addresses() []container.Address {
 	proxy := c.ProxyAddress
-	proxyIsIPv4 := len(net.ParseIP(proxy)) == net.IPv4len
+	proxyIsIPv4 := net.ParseIP(proxy).To4() != nil
 
 	info := c.ContainerInfo
 


### PR DESCRIPTION
## Description
This change alters how we derive container addresses. When docker changed to make ipv6 show up by default again it threw us for a loop. My hasty fix wasn't quite correct but also introduced with it a bug that also seemed to be docker port related. This lead me to hackily fix the bug of the bug fix rather than realize the root cause, since a revert of the original fix of bug caused the docker ipv6 change to not allow any containers to run. This change fixes both issues by always just returning a single container address when the container is bound to 0.0.0.0 or :: based on whether the proxy is ipv4 or ipv6.
<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan
- [x] test on an affected machine
<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234