### PR TITLE
fix: make profiling schema more lenient [DET-5497]

### DIFF
--- a/harness/determined/common/schemas/expconf/_gen.py
+++ b/harness/determined/common/schemas/expconf/_gen.py
@@ -1837,7 +1837,7 @@ schemas = {
                 "integer",
                 "null"
             ],
-            "default": null,
+            "default": 0,
             "minimum": 0
         },
         "end_after_batch": {
@@ -1849,37 +1849,10 @@ schemas = {
             "minimum": 0
         }
     },
-    "conditional": {
-        "$comment": "when enabled=true, assert begin <= end",
-        "when": {
-            "required": [
-                "enabled"
-            ],
-            "properties": {
-                "enabled": {
-                    "const": true
-                }
-            }
-        },
-        "enforce": {
-            "required": [
-                "begin_on_batch",
-                "end_after_batch"
-            ],
-            "propeties": {
-                "begin_on_batch": {
-                    "type": "integer"
-                },
-                "end_after_batch": {
-                    "type": "integer"
-                }
-            },
-            "compareProperties": {
-                "type": "a<=b",
-                "a": "begin_on_batch",
-                "b": "end_after_batch"
-            }
-        }
+    "compareProperties": {
+        "type": "a<=b",
+        "a": "begin_on_batch",
+        "b": "end_after_batch"
     }
 }
 

--- a/master/pkg/schemas/expconf/zgen_profiling_config_v0.go
+++ b/master/pkg/schemas/expconf/zgen_profiling_config_v0.go
@@ -19,12 +19,15 @@ func (p *ProfilingConfigV0) SetEnabled(val bool) {
 	p.RawEnabled = &val
 }
 
-func (p ProfilingConfigV0) BeginOnBatch() *int {
-	return p.RawBeginOnBatch
+func (p ProfilingConfigV0) BeginOnBatch() int {
+	if p.RawBeginOnBatch == nil {
+		panic("You must call WithDefaults on ProfilingConfigV0 before .BeginOnBatch")
+	}
+	return *p.RawBeginOnBatch
 }
 
-func (p *ProfilingConfigV0) SetBeginOnBatch(val *int) {
-	p.RawBeginOnBatch = val
+func (p *ProfilingConfigV0) SetBeginOnBatch(val int) {
+	p.RawBeginOnBatch = &val
 }
 
 func (p ProfilingConfigV0) EndAfterBatch() *int {

--- a/master/pkg/schemas/zgen_schemas.go
+++ b/master/pkg/schemas/zgen_schemas.go
@@ -1703,7 +1703,7 @@ var (
                 "integer",
                 "null"
             ],
-            "default": null,
+            "default": 0,
             "minimum": 0
         },
         "end_after_batch": {
@@ -1715,37 +1715,10 @@ var (
             "minimum": 0
         }
     },
-    "conditional": {
-        "$comment": "when enabled=true, assert begin <= end",
-        "when": {
-            "required": [
-                "enabled"
-            ],
-            "properties": {
-                "enabled": {
-                    "const": true
-                }
-            }
-        },
-        "enforce": {
-            "required": [
-                "begin_on_batch",
-                "end_after_batch"
-            ],
-            "propeties": {
-                "begin_on_batch": {
-                    "type": "integer"
-                },
-                "end_after_batch": {
-                    "type": "integer"
-                }
-            },
-            "compareProperties": {
-                "type": "a<=b",
-                "a": "begin_on_batch",
-                "b": "end_after_batch"
-            }
-        }
+    "compareProperties": {
+        "type": "a<=b",
+        "a": "begin_on_batch",
+        "b": "end_after_batch"
     }
 }
 `)

--- a/schemas/expconf/v0/profiling.json
+++ b/schemas/expconf/v0/profiling.json
@@ -18,7 +18,7 @@
                 "integer",
                 "null"
             ],
-            "default": null,
+            "default": 0,
             "minimum": 0
         },
         "end_after_batch": {
@@ -31,10 +31,12 @@
         }
     },
     "conditional": {
-        "$comment": "when enabled=true, assert begin <= end",
+        "$comment": "when enabled=true and both begin and end are present, assert begin <= end",
         "when": {
             "required": [
-                "enabled"
+                "enabled",
+                "begin_on_batch",
+                "end_after_batch"
             ],
             "properties": {
                 "enabled": {

--- a/schemas/expconf/v0/profiling.json
+++ b/schemas/expconf/v0/profiling.json
@@ -30,38 +30,9 @@
             "minimum": 0
         }
     },
-    "conditional": {
-        "$comment": "when enabled=true and both begin and end are present, assert begin <= end",
-        "when": {
-            "required": [
-                "enabled",
-                "begin_on_batch",
-                "end_after_batch"
-            ],
-            "properties": {
-                "enabled": {
-                    "const": true
-                }
-            }
-        },
-        "enforce": {
-            "required": [
-                "begin_on_batch",
-                "end_after_batch"
-            ],
-            "propeties": {
-                "begin_on_batch": {
-                    "type": "integer"
-                },
-                "end_after_batch": {
-                    "type": "integer"
-                }
-            },
-            "compareProperties": {
-                "type": "a<=b",
-                "a": "begin_on_batch",
-                "b": "end_after_batch"
-            }
-        }
+    "compareProperties": {
+        "type": "a<=b",
+        "a": "begin_on_batch",
+        "b": "end_after_batch"
     }
 }

--- a/schemas/test_cases/v0/experiment.yaml
+++ b/schemas/test_cases/v0/experiment.yaml
@@ -187,7 +187,7 @@
     perform_initial_validation: false
     profiling:
       enabled: false
-      begin_on_batch: null
+      begin_on_batch: 0
       end_after_batch: null
     records_per_epoch: 0
     reproducibility:

--- a/schemas/test_cases/v0/misc.yaml
+++ b/schemas/test_cases/v0/misc.yaml
@@ -130,8 +130,7 @@
 - name: profiling is valid when empty
   matches:
     - http://determined.ai/schemas/expconf/v0/profiling.json
-  case:
-#    enabled: false
+  case: {}
 
 - name: profiling is valid when only enabled is set
   matches:

--- a/schemas/test_cases/v0/misc.yaml
+++ b/schemas/test_cases/v0/misc.yaml
@@ -132,7 +132,15 @@
     - http://determined.ai/schemas/expconf/v0/profiling.json
   case:
     enabled: false
-    begin_on_batch: null
+    begin_on_batch: 0
+    end_after_batch: null
+
+- name: profiling is valid when only enabled is set
+  matches:
+    - http://determined.ai/schemas/expconf/v0/profiling.json
+  case:
+    enabled: true
+    begin_on_batch: 0
     end_after_batch: null
 
 - name: profiling is valid when full

--- a/schemas/test_cases/v0/misc.yaml
+++ b/schemas/test_cases/v0/misc.yaml
@@ -140,8 +140,6 @@
     - http://determined.ai/schemas/expconf/v0/profiling.json
   case:
     enabled: true
-    begin_on_batch: 0
-    end_after_batch: null
 
 - name: profiling is valid when full
   matches:

--- a/schemas/test_cases/v0/misc.yaml
+++ b/schemas/test_cases/v0/misc.yaml
@@ -131,9 +131,7 @@
   matches:
     - http://determined.ai/schemas/expconf/v0/profiling.json
   case:
-    enabled: false
-    begin_on_batch: 0
-    end_after_batch: null
+#    enabled: false
 
 - name: profiling is valid when only enabled is set
   matches:


### PR DESCRIPTION
## Description

Users should be able to set `profiling.enabled: true` in the experiment config and fall back to intelligent defaults on starting batch and duration of profiling. The current experiment config doesn't allow only `enabled: true` because it wants to validate that `begin_on_batch <= end_after_batch`. This PR changes the experiment config schema to allow one of both of the fields to be unset when `enabled: true`

This is fine because:
- if both are unset, the default behavior of starting at batch 0 and running for 5 minutes is good
- if start is unset but the end is set, it will default to 0 (previously this was handled by logic in the experiment config, but this PR moves that logic into the schema itself). Then the end doesn't matter because it should always be >= 0 (do we need to add a check to enforce this? it's pretty common sense)
- if the end is unset, but the start is set, the behavior is to profile for 5 minutes which is good behavior.


## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

I don't understand at all how the 'conditional' extension works (e.g. what is `properties.enabled.const: true` doing), so I'm sure this code isn't right. Let me know the right way to fix it.


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
