### PR TITLE
fix: merge logic for union-type configs [DET-5486]

### DIFF
--- a/master/pkg/schemas/expconf/data_layer_config.go
+++ b/master/pkg/schemas/expconf/data_layer_config.go
@@ -17,33 +17,9 @@ type DataLayerConfigV0 struct {
 	RawGCSConfig      *GCSDataLayerConfigV0      `union:"type,gcs" json:"-"`
 }
 
-// Merge implements schemas.Mergeable.  This Merge enforces that we can't ever merge two union
-// members into one output.
+// Merge implements schemas.Mergeable.
 func (d DataLayerConfigV0) Merge(other interface{}) interface{} {
-	tOther := other.(DataLayerConfigV0)
-
-	// There are no common members to merge.
-	out := DataLayerConfigV0{}
-
-	// Only merge union members based on d, not based on other... unless d has no member at all.
-	// The only reason it is valid to have no members is due to common fields on union types.
-	useOther := all(
-		d.RawSharedFSConfig == nil,
-		d.RawS3Config == nil,
-		d.RawGCSConfig == nil,
-	)
-	if useOther || d.RawSharedFSConfig != nil {
-		out.RawSharedFSConfig = schemas.Merge(
-			d.RawSharedFSConfig, tOther.RawSharedFSConfig,
-		).(*SharedFSDataLayerConfigV0)
-	}
-	if useOther || d.RawS3Config != nil {
-		out.RawS3Config = schemas.Merge(d.RawS3Config, tOther.RawS3Config).(*S3DataLayerConfigV0)
-	}
-	if useOther || d.RawGCSConfig != nil {
-		out.RawGCSConfig = schemas.Merge(d.RawGCSConfig, tOther.RawGCSConfig).(*GCSDataLayerConfigV0)
-	}
-	return out
+	return schemas.UnionMerge(d, other)
 }
 
 // MarshalJSON implements the json.Marshaler interface.

--- a/master/pkg/schemas/expconf/data_layer_config.go
+++ b/master/pkg/schemas/expconf/data_layer_config.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/pkg/errors"
 
+	"github.com/determined-ai/determined/master/pkg/schemas"
 	"github.com/determined-ai/determined/master/pkg/union"
 )
 
@@ -14,6 +15,35 @@ type DataLayerConfigV0 struct {
 	RawSharedFSConfig *SharedFSDataLayerConfigV0 `union:"type,shared_fs" json:"-"`
 	RawS3Config       *S3DataLayerConfigV0       `union:"type,s3" json:"-"`
 	RawGCSConfig      *GCSDataLayerConfigV0      `union:"type,gcs" json:"-"`
+}
+
+// Merge implements schemas.Mergeable.  This Merge enforces that we can't ever merge two union
+// members into one output.
+func (d DataLayerConfigV0) Merge(other interface{}) interface{} {
+	tOther := other.(DataLayerConfigV0)
+
+	// There are no common members to merge.
+	out := DataLayerConfigV0{}
+
+	// Only merge union members based on d, not based on other... unless d has no member at all.
+	// The only reason it is valid to have no members is due to common fields on union types.
+	useOther := all(
+		d.RawSharedFSConfig == nil,
+		d.RawS3Config == nil,
+		d.RawGCSConfig == nil,
+	)
+	if useOther || d.RawSharedFSConfig != nil {
+		out.RawSharedFSConfig = schemas.Merge(
+			d.RawSharedFSConfig, tOther.RawSharedFSConfig,
+		).(*SharedFSDataLayerConfigV0)
+	}
+	if useOther || d.RawS3Config != nil {
+		out.RawS3Config = schemas.Merge(d.RawS3Config, tOther.RawS3Config).(*S3DataLayerConfigV0)
+	}
+	if useOther || d.RawGCSConfig != nil {
+		out.RawGCSConfig = schemas.Merge(d.RawGCSConfig, tOther.RawGCSConfig).(*GCSDataLayerConfigV0)
+	}
+	return out
 }
 
 // MarshalJSON implements the json.Marshaler interface.

--- a/master/pkg/schemas/expconf/schema_test.go
+++ b/master/pkg/schemas/expconf/schema_test.go
@@ -102,6 +102,8 @@ func objectForURL(url string) interface{} {
 		return &DevicesConfigV0{}
 	case "http://determined.ai/schemas/expconf/v0/environment.json":
 		return &EnvironmentConfigV0{}
+	case "http://determined.ai/schemas/expconf/v0/data-layer.json":
+		return &DataLayerConfigV0{}
 	// For union member schemas, just return the union type.
 	case "http://determined.ai/schemas/expconf/v0/searcher.json",
 		"http://determined.ai/schemas/expconf/v0/searcher-adaptive-asha.json",

--- a/master/pkg/schemas/expconf/searcher_config.go
+++ b/master/pkg/schemas/expconf/searcher_config.go
@@ -25,59 +25,9 @@ type SearcherConfigV0 struct {
 	RawSourceCheckpointUUID *string `json:"source_checkpoint_uuid"`
 }
 
-// Merge implements schemas.Mergeable.  This Merge enforces that we can't ever merge two union
-// members into one output.
+// Merge implements schemas.Mergeable.
 func (s SearcherConfigV0) Merge(other interface{}) interface{} {
-	tOther := other.(SearcherConfigV0)
-
-	// Merge common members.
-	out := SearcherConfigV0{
-		RawMetric:          schemas.Merge(s.RawMetric, tOther.RawMetric).(*string),
-		RawSmallerIsBetter: schemas.Merge(s.RawSmallerIsBetter, tOther.RawSmallerIsBetter).(*bool),
-		RawSourceTrialID:   schemas.Merge(s.RawSourceTrialID, tOther.RawSourceTrialID).(*int),
-		RawSourceCheckpointUUID: schemas.Merge(
-			s.RawSourceCheckpointUUID, tOther.RawSourceCheckpointUUID,
-		).(*string),
-	}
-
-	// Only merge union members based on s, not based on other... unless s has no member at all.
-	// The only reason it is valid to have no members is due to common fields on union types.
-	useOther := all(
-		s.RawSingleConfig == nil,
-		s.RawRandomConfig == nil,
-		s.RawGridConfig == nil,
-		s.RawAsyncHalvingConfig == nil,
-		s.RawAdaptiveASHAConfig == nil,
-		s.RawPBTConfig == nil,
-	)
-	if useOther || s.RawSingleConfig != nil {
-		out.RawSingleConfig = schemas.Merge(
-			s.RawSingleConfig, tOther.RawSingleConfig,
-		).(*SingleConfigV0)
-	}
-	if useOther || s.RawRandomConfig != nil {
-		out.RawRandomConfig = schemas.Merge(
-			s.RawRandomConfig, tOther.RawRandomConfig,
-		).(*RandomConfigV0)
-	}
-	if useOther || s.RawGridConfig != nil {
-		out.RawGridConfig = schemas.Merge(s.RawGridConfig, tOther.RawGridConfig).(*GridConfigV0)
-	}
-	if useOther || s.RawAsyncHalvingConfig != nil {
-		out.RawAsyncHalvingConfig = schemas.Merge(
-			s.RawAsyncHalvingConfig, tOther.RawAsyncHalvingConfig,
-		).(*AsyncHalvingConfigV0)
-	}
-	if useOther || s.RawAdaptiveASHAConfig != nil {
-		out.RawAdaptiveASHAConfig = schemas.Merge(
-			s.RawAdaptiveASHAConfig, tOther.RawAdaptiveASHAConfig,
-		).(*AdaptiveASHAConfigV0)
-	}
-	if useOther || s.RawPBTConfig != nil {
-		out.RawPBTConfig = schemas.Merge(s.RawPBTConfig, tOther.RawPBTConfig).(*PBTConfigV0)
-	}
-
-	return out
+	return schemas.UnionMerge(s, other)
 }
 
 // MarshalJSON implements the json.Marshaler interface.

--- a/master/pkg/schemas/expconf/searcher_config.go
+++ b/master/pkg/schemas/expconf/searcher_config.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/pkg/errors"
 
+	"github.com/determined-ai/determined/master/pkg/schemas"
 	"github.com/determined-ai/determined/master/pkg/union"
 )
 
@@ -22,6 +23,61 @@ type SearcherConfigV0 struct {
 	RawSmallerIsBetter      *bool   `json:"smaller_is_better"`
 	RawSourceTrialID        *int    `json:"source_trial_id"`
 	RawSourceCheckpointUUID *string `json:"source_checkpoint_uuid"`
+}
+
+// Merge implements schemas.Mergeable.  This Merge enforces that we can't ever merge two union
+// members into one output.
+func (s SearcherConfigV0) Merge(other interface{}) interface{} {
+	tOther := other.(SearcherConfigV0)
+
+	// Merge common members.
+	out := SearcherConfigV0{
+		RawMetric:          schemas.Merge(s.RawMetric, tOther.RawMetric).(*string),
+		RawSmallerIsBetter: schemas.Merge(s.RawSmallerIsBetter, tOther.RawSmallerIsBetter).(*bool),
+		RawSourceTrialID:   schemas.Merge(s.RawSourceTrialID, tOther.RawSourceTrialID).(*int),
+		RawSourceCheckpointUUID: schemas.Merge(
+			s.RawSourceCheckpointUUID, tOther.RawSourceCheckpointUUID,
+		).(*string),
+	}
+
+	// Only merge union members based on s, not based on other... unless s has no member at all.
+	// The only reason it is valid to have no members is due to common fields on union types.
+	useOther := all(
+		s.RawSingleConfig == nil,
+		s.RawRandomConfig == nil,
+		s.RawGridConfig == nil,
+		s.RawAsyncHalvingConfig == nil,
+		s.RawAdaptiveASHAConfig == nil,
+		s.RawPBTConfig == nil,
+	)
+	if useOther || s.RawSingleConfig != nil {
+		out.RawSingleConfig = schemas.Merge(
+			s.RawSingleConfig, tOther.RawSingleConfig,
+		).(*SingleConfigV0)
+	}
+	if useOther || s.RawRandomConfig != nil {
+		out.RawRandomConfig = schemas.Merge(
+			s.RawRandomConfig, tOther.RawRandomConfig,
+		).(*RandomConfigV0)
+	}
+	if useOther || s.RawGridConfig != nil {
+		out.RawGridConfig = schemas.Merge(s.RawGridConfig, tOther.RawGridConfig).(*GridConfigV0)
+	}
+	if useOther || s.RawAsyncHalvingConfig != nil {
+		out.RawAsyncHalvingConfig = schemas.Merge(
+			s.RawAsyncHalvingConfig, tOther.RawAsyncHalvingConfig,
+		).(*AsyncHalvingConfigV0)
+	}
+	if useOther || s.RawAdaptiveASHAConfig != nil {
+		out.RawAdaptiveASHAConfig = schemas.Merge(
+			s.RawAdaptiveASHAConfig, tOther.RawAdaptiveASHAConfig,
+		).(*AdaptiveASHAConfigV0)
+	}
+	if useOther || s.RawPBTConfig != nil {
+		out.RawPBTConfig = schemas.Merge(s.RawPBTConfig, tOther.RawPBTConfig).(*PBTConfigV0)
+	}
+
+	return out
 }
 
 // MarshalJSON implements the json.Marshaler interface.

--- a/master/pkg/schemas/expconf/storage_config.go
+++ b/master/pkg/schemas/expconf/storage_config.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/pkg/errors"
 
+	"github.com/determined-ai/determined/master/pkg/schemas"
 	"github.com/determined-ai/determined/master/pkg/union"
 )
 
@@ -15,6 +16,15 @@ const (
 	// DefaultSharedFSPropagation is the propagation setting for SharedFS storage.
 	DefaultSharedFSPropagation = "rprivate"
 )
+
+func all(in ...bool) bool {
+	for _, i := range in {
+		if !i {
+			return false
+		}
+	}
+	return true
+}
 
 //go:generate ../gen.sh
 // CheckpointStorageConfigV0 has the common checkpoint config params.
@@ -27,6 +37,50 @@ type CheckpointStorageConfigV0 struct {
 	RawSaveExperimentBest *int `json:"save_experiment_best"`
 	RawSaveTrialBest      *int `json:"save_trial_best"`
 	RawSaveTrialLatest    *int `json:"save_trial_latest"`
+}
+
+// Merge implements schemas.Mergeable.  This Merge enforces that we can't ever merge two union
+// members into one output.
+func (c CheckpointStorageConfigV0) Merge(other interface{}) interface{} {
+	tOther := other.(CheckpointStorageConfigV0)
+
+	// Merge common members.
+	out := CheckpointStorageConfigV0{
+		RawSaveExperimentBest: schemas.Merge(
+			c.RawSaveExperimentBest, tOther.RawSaveExperimentBest,
+		).(*int),
+		RawSaveTrialBest:   schemas.Merge(c.RawSaveTrialBest, tOther.RawSaveTrialBest).(*int),
+		RawSaveTrialLatest: schemas.Merge(c.RawSaveTrialLatest, tOther.RawSaveTrialLatest).(*int),
+	}
+
+	// Only merge union members based on c, not based on other... unless c has no member at all.
+	// The only reason it is valid to have no members is due to common fields on union types.
+	useOther := all(
+		c.RawSharedFSConfig == nil,
+		c.RawHDFSConfig == nil,
+		c.RawS3Config == nil,
+		c.RawGCSConfig == nil,
+	)
+	if useOther || c.RawSharedFSConfig != nil {
+		out.RawSharedFSConfig = schemas.Merge(
+			c.RawSharedFSConfig, tOther.RawSharedFSConfig,
+		).(*SharedFSConfigV0)
+	}
+	if useOther || c.RawHDFSConfig != nil {
+		out.RawHDFSConfig = schemas.Merge(
+			c.RawHDFSConfig, tOther.RawHDFSConfig,
+		).(*HDFSConfigV0)
+	}
+	if useOther || c.RawS3Config != nil {
+		out.RawS3Config = schemas.Merge(c.RawS3Config, tOther.RawS3Config).(*S3ConfigV0)
+	}
+	if useOther || c.RawGCSConfig != nil {
+		out.RawGCSConfig = schemas.Merge(
+			c.RawGCSConfig, tOther.RawGCSConfig,
+		).(*GCSConfigV0)
+	}
+
+	return out
 }
 
 // MarshalJSON implements the json.Marshaler interface.
@@ -63,6 +117,12 @@ type TensorboardStorageConfigV0 struct {
 	RawHDFSConfig       *HDFSConfigV0     `union:"type,hdfs" json:"-"`
 	RawS3Config         *S3ConfigV0       `union:"type,s3" json:"-"`
 	RawGCSConfig        *GCSConfigV0      `union:"type,gcs" json:"-"`
+}
+
+// Merge implements schemas.Mergeable.  Avoid merging TensorboardStorageConfigs at all, because it's
+// a totally useless config, but it could still break the union marshaling.
+func (t TensorboardStorageConfigV0) Merge(other interface{}) interface{} {
+	return t
 }
 
 // MarshalJSON implements the json.Marshaler interface.

--- a/schemas/test_cases/v0/merging.yaml
+++ b/schemas/test_cases/v0/merging.yaml
@@ -89,3 +89,77 @@
     minval: 10
     maxval: 100
     # count is an omitempty field
+
+- name: checkpoint storage merges only allow one union type
+  merge_as: http://determined.ai/schemas/expconf/v0/checkpoint-storage.json
+  case:
+    type: shared_fs
+    host_path: /tmp
+    storage_path: determined-cp
+    propagation: rprivate
+    save_experiment_best: 0
+    save_trial_best: 1
+  merge_src:
+    type: s3
+    bucket: determined-cp
+    save_experiment_best: 10
+    save_trial_best: 10
+    save_trial_latest: 10
+  merged:
+    type: shared_fs
+    host_path: /tmp
+    storage_path: determined-cp
+    propagation: rprivate
+    save_experiment_best: 0
+    save_trial_best: 1
+    save_trial_latest: 10
+
+- name: searcher merges only allow one union type
+  merge_as: http://determined.ai/schemas/expconf/v0/searcher.json
+  case:
+    name: single
+    max_length:
+      batches: 1000
+    metric: loss
+    smaller_is_better: true
+  merge_src:
+    name: random
+    max_concurrent_trials: 2
+    max_length:
+      batches: 10000
+    max_trials: 10000
+    metric: loss
+    smaller_is_better: false
+    source_checkpoint_uuid: "asdf"
+  merged:
+    name: single
+    max_length:
+      batches: 1000
+    metric: loss
+    smaller_is_better: true
+    source_trial_id: null
+    source_checkpoint_uuid: "asdf"
+
+- name: data layer merges only allow one union type
+  merge_as: http://determined.ai/schemas/expconf/v0/data-layer.json
+  case:
+    type: s3
+    bucket: asdf
+    bucket_directory_path: /asdf/asdf
+    local_cache_container_path: /asdf/asdf
+    local_cache_host_path: /asdf/asdf
+    endpoint_url: s3://s3.com
+    access_key: s3
+    secret_key: s3s3s3
+  merge_src:
+    type: gcs
+    bucket: zxcv
+  merged:
+    type: s3
+    bucket: asdf
+    bucket_directory_path: /asdf/asdf
+    local_cache_container_path: /asdf/asdf
+    local_cache_host_path: /asdf/asdf
+    endpoint_url: s3://s3.com
+    access_key: s3
+    secret_key: s3s3s3


### PR DESCRIPTION
Previously, schemas.Merge() would happily merge a shared_fs checkpoint
storage and an s3 checkpoint storage into one, totally invalid,
frankenstorage.

The problem was also present on other union types.

## Test Plan

New tests were added.
