### PR TITLE
chore: update OS and other language in Terraform modules [DET-4276]

### DIFF
--- a/harness/determined/deploy/gcp/terraform/main.tf
+++ b/harness/determined/deploy/gcp/terraform/main.tf
@@ -1,4 +1,13 @@
 // Configure GCP provider
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/google"
+      version = "~> 3.44.0"
+    }
+  }
+}
+
 provider "google" {
   credentials = var.keypath != null ? file(var.keypath) : null
   project = var.project_id
@@ -16,8 +25,8 @@ provider "google-beta" {
 }
 
 locals {
-  unique_id = "${var.cluster_id}"
-  det_version_key = "${var.det_version_key}"
+  unique_id = var.cluster_id
+  det_version_key = var.det_version_key
 }
 
 terraform {

--- a/harness/determined/deploy/gcp/terraform/main.tf
+++ b/harness/determined/deploy/gcp/terraform/main.tf
@@ -1,13 +1,4 @@
 // Configure GCP provider
-terraform {
-  required_providers {
-    gcp = {
-      source  = "hashicorp/google"
-      version = "~> 3.44.0"
-    }
-  }
-}
-
 provider "google" {
   credentials = var.keypath != null ? file(var.keypath) : null
   project = var.project_id

--- a/harness/determined/deploy/gcp/terraform/main.tf
+++ b/harness/determined/deploy/gcp/terraform/main.tf
@@ -1,7 +1,7 @@
 // Configure GCP provider
 terraform {
   required_providers {
-    aws = {
+    gcp = {
       source  = "hashicorp/google"
       version = "~> 3.44.0"
     }

--- a/harness/determined/deploy/gcp/terraform/modules/compute/main.tf
+++ b/harness/determined/deploy/gcp/terraform/modules/compute/main.tf
@@ -12,7 +12,7 @@ resource "google_compute_instance" "master_instance" {
 
   boot_disk {
     initialize_params {
-      image = "ubuntu-os-cloud/ubuntu-1604-lts"
+      image = "ubuntu-os-cloud/ubuntu-2004-lts"
     }
   }
 

--- a/harness/determined/deploy/gcp/terraform/outputs.tf
+++ b/harness/determined/deploy/gcp/terraform/outputs.tf
@@ -51,5 +51,5 @@ output "SSH-to-Master" {
 }
 
 output "Web-UI" {
-  value = "${module.compute.web_ui}"
+  value = module.compute.web_ui
 }


### PR DESCRIPTION
## Description

This updates a lingering reference to Ubuntu 16.04 (which has EOL'd and has been replaced by Ubuntu 20.04 elsewhere in our stack). It also eliminates warnings related to interpolation syntax that has been deprecated for quite a few Terraform versions now, and adds a source for the Google provider (idiomatic in more recent versions).

## Test Plan

Put a cluster up and down, confirmed the OS version, and did some basic functionality tests (scaling up and down, running an experiment). Confirmed the warnings are gone. This was done on Terraform 0.13.5 - which is also a little bit behind. We don't document a required Terraform version, but this confirms we're not introducing any unreasonable requirement for the newness of the version.