### PR TITLE
feat: add API to query best searcher validation [DET-5212]

### DIFF
--- a/master/internal/api_experiment.go
+++ b/master/internal/api_experiment.go
@@ -1209,3 +1209,20 @@ func (a *apiServer) GetHPImportance(req *apiv1.GetHPImportanceRequest,
 		}
 	}
 }
+
+func (a *apiServer) GetBestSearcherValidationMetric(
+	_ context.Context, req *apiv1.GetBestSearcherValidationMetricRequest,
+) (*apiv1.GetBestSearcherValidationMetricResponse, error) {
+	if err := a.checkExperimentExists(int(req.ExperimentId)); err != nil {
+		return nil, err
+	}
+
+	metric, err := a.m.db.ExperimentBestSearcherValidation(int(req.ExperimentId))
+	if err != nil {
+		return nil, err
+	}
+
+	return &apiv1.GetBestSearcherValidationMetricResponse{
+		Metric: metric,
+	}, nil
+}

--- a/master/internal/db/postgres_filters.go
+++ b/master/internal/db/postgres_filters.go
@@ -85,17 +85,13 @@ func filterToParams(f api.Filter) []interface{} {
 }
 
 func orderByToSQL(order apiv1.OrderBy) string {
-	const (
-		ascKeyword  = "ASC"
-		descKeyword = "DESC"
-	)
 	switch order {
 	case apiv1.OrderBy_ORDER_BY_UNSPECIFIED:
-		return ascKeyword
+		return asc
 	case apiv1.OrderBy_ORDER_BY_ASC:
-		return ascKeyword
+		return asc
 	case apiv1.OrderBy_ORDER_BY_DESC:
-		return descKeyword
+		return desc
 	default:
 		panic(fmt.Sprintf("unexpected order by: %s", order))
 	}

--- a/proto/src/determined/api/v1/api.proto
+++ b/proto/src/determined/api/v1/api.proto
@@ -381,6 +381,16 @@ service Determined {
       tags: "Experiments"
     };
   }
+  // Get the best searcher validation for an experiment by the given metric.
+  rpc GetBestSearcherValidationMetric(GetBestSearcherValidationMetricRequest)
+      returns (GetBestSearcherValidationMetricResponse) {
+    option (google.api.http) = {
+      get: "/api/v1/experiments/{experiment_id}/searcher/best_searcher_validation_metric"
+    };
+    option (grpc.gateway.protoc_gen_swagger.options.openapiv2_operation) = {
+      tags: "Internal"
+    };
+  }
 
   // Get a list of checkpoints for an experiment.
   rpc GetExperimentCheckpoints(GetExperimentCheckpointsRequest)

--- a/proto/src/determined/api/v1/experiment.proto
+++ b/proto/src/determined/api/v1/experiment.proto
@@ -108,6 +108,17 @@ message DeleteExperimentRequest {
 // Response to DeleteExperimentRequest.
 message DeleteExperimentResponse {}
 
+// Get the best searcher validation.
+message GetBestSearcherValidationMetricRequest {
+  // The ID of the experiment.
+  int32 experiment_id = 1;
+}
+// Response to GetBestSearcherValidationMetricRequest.
+message GetBestSearcherValidationMetricResponse {
+  // The value of the metric.
+  float metric = 1;
+}
+
 // Preview hyperparameter search.
 message PreviewHPSearchRequest {
   // The experiment config to simulate.


### PR DESCRIPTION
## Description
This change adds an API to query an experiment's best validation. That is pretty much it. This is necessary to implement the `checkpoint_policy: best` behavior in the confines of push architecture.
<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan
- [x] call the API
<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234