### PR TITLE
fix: prevent spot resource pool contention [DET-5349]

### DIFF
--- a/master/internal/provisioner/aws.go
+++ b/master/internal/provisioner/aws.go
@@ -171,6 +171,7 @@ func (c *awsCluster) stateFromEC2State(state *ec2.InstanceState) InstanceState {
 func (c *awsCluster) prestart(ctx *actor.Context) {
 	if c.SpotEnabled {
 		c.attemptToApproximateClockSkew(ctx)
+		c.cleanupLegacySpotInstances(ctx)
 	}
 }
 

--- a/master/internal/provisioner/aws_spot.go
+++ b/master/internal/provisioner/aws_spot.go
@@ -108,6 +108,9 @@ type spotState struct {
 // fulfilled an actual EC2 instance will be returned as an Instance. If the request has not
 // been fulfilled, a fake Instance will be returned where the InstanceID is the SpotRequestID
 // and the state is SpotRequestPendingAWS.
+//
+// This function does more than just list spot instances. Because this function is called every
+// provisioner tick, we have it also handle several aspects of the spot provisioner lifecycle.
 func (c *awsCluster) listSpot(ctx *actor.Context) ([]*Instance, error) {
 	activeReqsInAPI, err := c.listActiveSpotInstanceRequests(ctx, false)
 	if err != nil {
@@ -317,6 +320,10 @@ func (c *awsCluster) setTagsOnInstances(ctx *actor.Context, activeReqs *setOfSpo
 			{
 				Key:   aws.String("Name"),
 				Value: aws.String(c.InstanceName),
+			},
+			{
+				Key:   aws.String("determined-resource-pool"),
+				Value: aws.String(c.resourcePool),
 			},
 			{
 				Key:   aws.String(c.TagKey),
@@ -533,6 +540,10 @@ func (c *awsCluster) createSpotInstanceRequest(
 						Value: aws.String(c.InstanceName),
 					},
 					{
+						Key:   aws.String("determined-resource-pool"),
+						Value: aws.String(c.resourcePool),
+					},
+					{
 						Key:   aws.String("determined-master-address"),
 						Value: aws.String(c.masterURL.String()),
 					},
@@ -592,6 +603,10 @@ func (c *awsCluster) listCanceledButInstanceRunningSpotRequests(
 				},
 			},
 			{
+				Name:   aws.String(fmt.Sprintf("tag:%s", "determined-resource-pool")),
+				Values: []*string{aws.String(c.resourcePool)},
+			},
+			{
 				Name: aws.String("status-code"),
 				Values: []*string{
 					aws.String("request-canceled-and-instance-running"),
@@ -636,6 +651,10 @@ func (c *awsCluster) listActiveSpotInstanceRequests(
 				Values: []*string{
 					aws.String(c.TagValue),
 				},
+			},
+			{
+				Name:   aws.String(fmt.Sprintf("tag:%s", "determined-resource-pool")),
+				Values: []*string{aws.String(c.resourcePool)},
 			},
 			{
 				Name: aws.String("state"),
@@ -693,6 +712,10 @@ func (c *awsCluster) listSpotRequestsByID(
 				Values: []*string{
 					aws.String(c.TagValue),
 				},
+			},
+			{
+				Name:   aws.String(fmt.Sprintf("tag:%s", "determined-resource-pool")),
+				Values: []*string{aws.String(c.resourcePool)},
 			},
 			{
 				Name:   aws.String("spot-instance-request-id"),

--- a/master/internal/provisioner/aws_spot.go
+++ b/master/internal/provisioner/aws_spot.go
@@ -668,7 +668,7 @@ func (c *awsCluster) listActiveSpotInstanceRequests(
 
 	response, err := c.client.DescribeSpotInstanceRequests(input)
 	if err != nil {
-		return
+		return nil, err
 	}
 
 	ret := newSetOfSpotRequests()

--- a/master/internal/provisioner/aws_spot_legacy.go
+++ b/master/internal/provisioner/aws_spot_legacy.go
@@ -1,0 +1,204 @@
+package provisioner
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+
+	"github.com/determined-ai/determined/master/pkg/actor"
+)
+
+// There was a bug where spot requests and instances were not being tagged with
+// the resource pool, leading to multiple resource pools trying to manage the
+// same instances. The code now uses a resource pool tag, but that means that
+// instances with the old tag format are ignored. To make sure we aren't leaving
+// orphaned instances after a version upgrade, we identify instances with the old
+// format and clean them up. Because the spot API is eventually consistent, we
+// repeat the cleanup after 5 minutes. This function can be removed once all users
+// are on versions newer than 0.15.5
+func (c *awsCluster) cleanupLegacySpotInstances(ctx *actor.Context) {
+
+	cleanup := func(ctx *actor.Context) {
+		ctx.Log().
+			WithField("codepath", "spotLegacy").
+			Infof("Starting Legacy Spot cleanup operation")
+		// List spot requests with the old format
+		activeSpotReqs, err := c.legacyListActiveSpotInstanceRequests(ctx)
+		if err != nil {
+			ctx.Log().
+				WithField("codepath", "spotLegacy").
+				WithError(err).
+				Debugf("cannot list active spot requests")
+		} else {
+			ctx.Log().
+				WithField("codepath", "spotLegacy").
+				Infof("Terminating %d active spot instance requests", activeSpotReqs.numReqs())
+			// Delete spot requests with old format
+			_, err2 := c.terminateSpotInstanceRequests(ctx, activeSpotReqs.idsAsListOfPointers(), false)
+			if err2 != nil {
+				ctx.Log().
+					WithField("codepath", "spotLegacy").
+					WithError(err).
+					Debugf("unable to terminate legacy spot instance requests")
+			}
+
+			// Delete any instance associated with the active requests
+			instancesToTerminate := newSetOfStrings()
+			for _, req := range activeSpotReqs.iter() {
+				if req.InstanceID != nil {
+					instancesToTerminate.add(*req.InstanceID)
+				}
+			}
+			ctx.Log().
+				WithField("codepath", "spotLegacy").
+				Infof("Terminating %d active spot instances", instancesToTerminate.length())
+			_, err3 := c.terminateInstances(instancesToTerminate.asListOfPointers())
+			if err3 != nil {
+				ctx.Log().
+					WithField("codepath", "spotLegacy").
+					WithError(err).
+					Debugf("unable to terminate instances associated with legacy spot instance requests")
+			}
+		}
+
+		ctx.Log().
+			WithField("codepath", "spotLegacy").
+			Infof("Listing CanceledButInstanceRunning requests")
+		canceledButInstanceRunningSpotReqs, err := c.legacyListCanceledButInstanceRunningSpotRequests(ctx)
+		if err != nil {
+			ctx.Log().
+				WithField("codepath", "spotLegacy").
+				WithError(err).
+				Debugf("unable to list canceled but instance running legacy spot instance requests")
+			return
+		}
+		// Delete any instances associated with canceledButInstanceRunning spot requests
+		if canceledButInstanceRunningSpotReqs.numReqs() > 0 {
+			ctx.Log().
+				WithField("codepath", "spotLegacy").
+				Infof("Terminating %d spot instances where requests are canceled but instance is running", canceledButInstanceRunningSpotReqs.numReqs())
+
+			ctx.Log().
+				WithField("codepath", "spotLegacy").
+				Debugf(
+					"terminating EC2 instances associated with canceled spot requests: %s",
+					strings.Join(canceledButInstanceRunningSpotReqs.idsAsList(), ","),
+				)
+			_, err = c.terminateInstances(canceledButInstanceRunningSpotReqs.instanceIds())
+			if err != nil {
+				ctx.Log().
+					WithField("codepath", "spotLegacy").
+					WithError(err).
+					Debugf("cannot terminate EC2 instances associated with canceled spot requests")
+			}
+		}
+		ctx.Log().
+			WithField("codepath", "spotLegacy").
+			Infof("Completed Legacy Spot cleanup")
+	}
+
+	// Repeat after 5 minutes
+	go func() {
+		cleanup(ctx)
+		time.Sleep(5 * time.Minute)
+		cleanup(ctx)
+	}()
+
+}
+
+func isLegacy(request *ec2.SpotInstanceRequest) bool {
+	for _, tag := range request.Tags {
+		if *tag.Key == "determined-resource-pool" {
+			return false
+		}
+	}
+	return true
+}
+
+func (c *awsCluster) legacyListCanceledButInstanceRunningSpotRequests(
+	ctx *actor.Context,
+) (reqs *setOfSpotRequests, err error) {
+	input := &ec2.DescribeSpotInstanceRequestsInput{
+		Filters: []*ec2.Filter{
+			{
+				Name: aws.String(fmt.Sprintf("tag:%s", c.TagKey)),
+				Values: []*string{
+					aws.String(c.TagValue),
+				},
+			},
+			{
+				Name: aws.String("status-code"),
+				Values: []*string{
+					aws.String("request-canceled-and-instance-running"),
+				},
+			},
+		},
+	}
+
+	response, err := c.client.DescribeSpotInstanceRequests(input)
+	if err != nil {
+		return
+	}
+
+	ret := newSetOfSpotRequests()
+	for _, req := range response.SpotInstanceRequests {
+		if isLegacy(req) {
+			ret.add(&spotRequest{
+				SpotRequestID: *req.SpotInstanceRequestId,
+				State:         *req.State,
+				StatusCode:    req.Status.Code,
+				StatusMessage: req.Status.Message,
+				InstanceID:    req.InstanceId,
+				CreationTime:  *req.CreateTime,
+			})
+		}
+	}
+
+	return &ret, nil
+}
+
+func (c *awsCluster) legacyListActiveSpotInstanceRequests(
+	ctx *actor.Context,
+) (reqs *setOfSpotRequests, err error) {
+
+	input := &ec2.DescribeSpotInstanceRequestsInput{
+		Filters: []*ec2.Filter{
+			{
+				Name: aws.String(fmt.Sprintf("tag:%s", c.TagKey)),
+				Values: []*string{
+					aws.String(c.TagValue),
+				},
+			},
+			{
+				Name: aws.String("state"),
+				Values: []*string{
+					aws.String("open"),
+					aws.String("active"),
+				},
+			},
+		},
+	}
+
+	response, err := c.client.DescribeSpotInstanceRequests(input)
+	if err != nil {
+		return
+	}
+
+	ret := newSetOfSpotRequests()
+	for _, req := range response.SpotInstanceRequests {
+		if isLegacy(req) {
+			ret.add(&spotRequest{
+				SpotRequestID: *req.SpotInstanceRequestId,
+				State:         *req.State,
+				StatusCode:    req.Status.Code,
+				StatusMessage: req.Status.Message,
+				InstanceID:    req.InstanceId,
+				CreationTime:  *req.CreateTime,
+			})
+		}
+	}
+	return &ret, nil
+}

--- a/master/internal/provisioner/aws_spot_legacy.go
+++ b/master/internal/provisioner/aws_spot_legacy.go
@@ -18,9 +18,8 @@ import (
 // orphaned instances after a version upgrade, we identify instances with the old
 // format and clean them up. Because the spot API is eventually consistent, we
 // repeat the cleanup after 5 minutes. This function can be removed once all users
-// are on versions newer than 0.15.5
+// are on versions newer than 0.15.5.
 func (c *awsCluster) cleanupLegacySpotInstances(ctx *actor.Context) {
-
 	cleanup := func(ctx *actor.Context) {
 		ctx.Log().
 			WithField("codepath", "spotLegacy").
@@ -79,7 +78,11 @@ func (c *awsCluster) cleanupLegacySpotInstances(ctx *actor.Context) {
 		if canceledButInstanceRunningSpotReqs.numReqs() > 0 {
 			ctx.Log().
 				WithField("codepath", "spotLegacy").
-				Infof("Terminating %d spot instances where requests are canceled but instance is running", canceledButInstanceRunningSpotReqs.numReqs())
+				Infof(
+					"Terminating %d spot instances where requests are "+
+						"canceled but instance is running",
+					canceledButInstanceRunningSpotReqs.numReqs(),
+				)
 
 			ctx.Log().
 				WithField("codepath", "spotLegacy").
@@ -106,7 +109,6 @@ func (c *awsCluster) cleanupLegacySpotInstances(ctx *actor.Context) {
 		time.Sleep(5 * time.Minute)
 		cleanup(ctx)
 	}()
-
 }
 
 func isLegacy(request *ec2.SpotInstanceRequest) bool {
@@ -163,7 +165,6 @@ func (c *awsCluster) legacyListCanceledButInstanceRunningSpotRequests(
 func (c *awsCluster) legacyListActiveSpotInstanceRequests(
 	ctx *actor.Context,
 ) (reqs *setOfSpotRequests, err error) {
-
 	input := &ec2.DescribeSpotInstanceRequestsInput{
 		Filters: []*ec2.Filter{
 			{

--- a/master/internal/provisioner/aws_spot_legacy.go
+++ b/master/internal/provisioner/aws_spot_legacy.go
@@ -73,9 +73,9 @@ func (c *awsCluster) legacyCleanupActiveSpotRequestsAndInstances(ctx *actor.Cont
 	}
 
 	var instanceListToLog strings.Builder
-	for _, instanceId := range instancesToTerminate {
+	for _, instanceID := range instancesToTerminate {
 		instanceListToLog.WriteString(", ")
-		instanceListToLog.WriteString(*instanceId)
+		instanceListToLog.WriteString(*instanceID)
 	}
 	loggerSpotLegacy.Infof(
 		"terminating %d legacy spot instances associated with active legacy spot requests: %s",

--- a/master/internal/provisioner/aws_spot_legacy.go
+++ b/master/internal/provisioner/aws_spot_legacy.go
@@ -73,8 +73,10 @@ func (c *awsCluster) legacyCleanupActiveSpotRequestsAndInstances(ctx *actor.Cont
 	}
 
 	var instanceListToLog strings.Builder
-	for _, instanceID := range instancesToTerminate {
-		instanceListToLog.WriteString(", ")
+	for idx, instanceID := range instancesToTerminate {
+		if idx > 0 {
+			instanceListToLog.WriteString(", ")
+		}
 		instanceListToLog.WriteString(*instanceID)
 	}
 	loggerSpotLegacy.Infof(


### PR DESCRIPTION
## Description

There is a bug where spot requests and spot instances in AWS do not include the resource pool as part of the tags. This leads to issues where one spot resource pool creates instances, but all of the spot resource pools think they are responsible for managing the instance. This causes spot instances to get shut down because some resource pools think they are idle. This PR ensures that we include the resource pool as one of the tags to prevent this contention. 

This PR also ensures that this change doesn't lead to orphaned spot instances by deleting all spot requests and instances that do not include the `determined-resource-pool` tag when the provisioner starts up.

## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
