### PR TITLE
docs: update procedure for latest NVIDIA drivers on GKE

### DIFF
--- a/docs/how-to/installation/setup-gke-cluster.txt
+++ b/docs/how-to/installation/setup-gke-cluster.txt
@@ -53,7 +53,6 @@ their local machine.
        --region us-west1 \
        --node-locations us-west1-b\
        --num-nodes=1 \
-       --image-type=UBUNTU \
        --machine-type=n1-standard-16
 
    # Create a node pool. This will not launch any nodes immediately but will
@@ -67,12 +66,11 @@ their local machine.
      --enable-autoscaling \
      --min-nodes=0 \
      --max-nodes=4 \
-     --image-type=UBUNTU \
      --machine-type=n1-standard-32 \
-     --scopes=storage-full
+     --scopes=storage-full,cloud-platform
 
    # Deploy a DaemonSet that enables the GPUs.
-   kubectl apply -f https://raw.githubusercontent.com/GoogleCloudPlatform/container-engine-accelerators/master/nvidia-driver-installer/ubuntu/daemonset-preloaded.yaml
+   kubectl apply -f https://raw.githubusercontent.com/GoogleCloudPlatform/container-engine-accelerators/master/nvidia-driver-installer/cos/daemonset-preloaded.yaml
 
    # Create a GCS bucket to store checkpoints.
    gsutil mb gs://${GCS_BUCKET_NAME}


### PR DESCRIPTION
## Description

There are some caveats on GKE that aren't very well documented that are required to get the latest NVIDIA docs:
* Keeping GPUs in a non-default node-pool (we already do this, since the master is in the default pool)
* A different DaemonSet for the driver installer
* Adding the cloud-platform scope
So we'll keep these in our documentation.

## Test Plan

Follow the original procedure, and ensured I had problems with CUDA 11. Made the attached modifications manually and verified I got a CUDA 11-compatible version (https://docs.nvidia.com/datacenter/tesla/tesla-release-notes-450-51-06/index.html).