### PR TITLE
fix: omit internal fields in previewed notebook [DET-5523]

### DIFF
--- a/harness/determined/cli/command.py
+++ b/harness/determined/cli/command.py
@@ -253,6 +253,7 @@ def launch_command(
     template: str,
     context_path: Optional[Path] = None,
     data: Optional[Dict[str, Any]] = None,
+    preview: Optional[bool] = False,
 ) -> Any:
     user_files = []  # type: List[Dict[str, Any]]
     if context_path:
@@ -270,6 +271,9 @@ def launch_command(
         message_bytes = json.dumps(data).encode("utf-8")
         base64_bytes = base64.b64encode(message_bytes)
         body["data"] = base64_bytes
+
+    if preview:
+        body["preview"] = preview
 
     return api.post(
         master,

--- a/master/internal/api_command.go
+++ b/master/internal/api_command.go
@@ -35,7 +35,6 @@ type protoCommandParams struct {
 	Files        []*utilv1.File
 	Data         []byte
 	MustZeroSlot bool
-	Preview      bool
 }
 
 func (a *apiServer) makeFullCommandSpec(

--- a/master/internal/command/command.go
+++ b/master/internal/command/command.go
@@ -53,12 +53,9 @@ func DefaultConfig(taskContainerDefaults *model.TaskContainerDefaultsConfig) mod
 	expConf := model.DefaultExperimentConfig(taskContainerDefaults)
 	return model.CommandConfig{
 		Resources: model.ResourcesConfig{
-			Slots:  1,
-			Weight: 1,
-			// SlotsPerTrial is not used by commands. They prefer Slots instead.
-			// It is only defined here to pass check.Validate.
-			SlotsPerTrial: 1,
-			Devices:       expConf.Resources.Devices,
+			Slots:   1,
+			Weight:  1,
+			Devices: expConf.Resources.Devices,
 		},
 		Environment: expConf.Environment,
 	}

--- a/master/pkg/model/command_config.go
+++ b/master/pkg/model/command_config.go
@@ -12,7 +12,7 @@ type CommandConfig struct {
 	Environment     Environment      `json:"environment"`
 	Resources       ResourcesConfig  `json:"resources"`
 	Entrypoint      []string         `json:"entrypoint"`
-	TensorBoardArgs []string         `json:"tensorboard_args"`
+	TensorBoardArgs []string         `json:"tensorboard_args,omitempty"`
 }
 
 // Validate implements the check.Validatable interface.

--- a/master/pkg/model/command_config_test.go
+++ b/master/pkg/model/command_config_test.go
@@ -21,9 +21,8 @@ func TestConfigValidate(t *testing.T) {
 	}
 	var environment Environment
 	resources := ResourcesConfig{
-		Slots:         1,
-		SlotsPerTrial: 1,
-		Weight:        1,
+		Slots:  1,
+		Weight: 1,
 	}
 
 	tests := []testCase{

--- a/master/pkg/model/compat.go
+++ b/master/pkg/model/compat.go
@@ -29,7 +29,7 @@ func (r ResourcesConfig) ToExpconf() expconf.ResourcesConfig {
 	return schemas.WithDefaults(expconf.ResourcesConfig{
 		RawSlots:          ptrs.IntPtr(r.Slots),
 		RawMaxSlots:       r.MaxSlots,
-		RawSlotsPerTrial:  ptrs.IntPtr(r.SlotsPerTrial),
+		RawSlotsPerTrial:  ptrs.IntPtr(1),
 		RawWeight:         ptrs.Float64Ptr(r.Weight),
 		RawNativeParallel: ptrs.BoolPtr(r.NativeParallel),
 		RawShmSize:        r.ShmSize,

--- a/master/pkg/model/defaults.go
+++ b/master/pkg/model/defaults.go
@@ -75,7 +75,6 @@ func DefaultExperimentConfig(taskContainerDefaults *TaskContainerDefaultsConfig)
 			},
 		},
 		Resources: ResourcesConfig{
-			SlotsPerTrial:  1,
 			Weight:         1,
 			NativeParallel: false,
 		},

--- a/master/pkg/model/experiment_config.go
+++ b/master/pkg/model/experiment_config.go
@@ -216,13 +216,11 @@ func (d *DeviceConfig) UnmarshalJSON(data []byte) error {
 
 // ResourcesConfig configures resource usage for an experiment, command, notebook, or tensorboard.
 type ResourcesConfig struct {
-	// Slots is used by commands while trials use SlotsPerTrial.
 	Slots int `json:"slots,omitempty"`
 
 	MaxSlots       *int    `json:"max_slots,omitempty"`
-	SlotsPerTrial  int     `json:"slots_per_trial"`
 	Weight         float64 `json:"weight"`
-	NativeParallel bool    `json:"native_parallel"`
+	NativeParallel bool    `json:"native_parallel,omitempty"`
 	ShmSize        *int    `json:"shm_size,omitempty"`
 	AgentLabel     string  `json:"agent_label"`
 	ResourcePool   string  `json:"resource_pool"`
@@ -243,8 +241,7 @@ func ParseJustResources(configBytes []byte) ResourcesConfig {
 
 	dummy := DummyConfig{
 		Resources: ResourcesConfig{
-			Slots:         1,
-			SlotsPerTrial: 1,
+			Slots: 1,
 		},
 	}
 
@@ -272,10 +269,8 @@ func ValidatePrioritySetting(priority *int) []error {
 // Validate implements the check.Validatable interface.
 func (r ResourcesConfig) Validate() []error {
 	errs := []error{
-		check.GreaterThan(r.SlotsPerTrial, 0, "slots_per_trial must be > 0"),
+		check.GreaterThanOrEqualTo(r.Slots, 0, "slots must be >= 0"),
 		check.GreaterThan(r.Weight, float64(0), "weight must be > 0"),
-		check.GreaterThanOrEqualTo(
-			r.MaxSlots, r.SlotsPerTrial, "max_slots must be >= slots_per_trial"),
 		check.GreaterThanOrEqualTo(r.ShmSize, 0, "shm_size must be >= 0"),
 	}
 	errs = append(errs, ValidatePrioritySetting(r.Priority)...)

--- a/master/pkg/model/experiment_config_test.go
+++ b/master/pkg/model/experiment_config_test.go
@@ -174,7 +174,6 @@ func validGridSearchConfig() ExperimentConfig {
 
 func validResourcesConfig() ExperimentConfig {
 	config := validGridSearchConfig()
-	config.Resources.SlotsPerTrial = 4
 	return config
 }
 
@@ -367,7 +366,7 @@ func TestExperiment(t *testing.T) {
 			SmallerIsBetter: false,
 			SingleConfig:    &SingleConfig{MaxLength: NewLengthInBatches(1000)},
 		},
-		Resources: ResourcesConfig{SlotsPerTrial: 1, Weight: 1},
+		Resources: ResourcesConfig{Weight: 1},
 		Optimizations: OptimizationsConfig{
 			AggregationFrequency:       1,
 			AverageAggregatedGradients: true,


### PR DESCRIPTION
## Description

The previewed notebook configuration goes down the same path populating the full configuration for the actual creation. However, some fields might be null and they are still populated. They should be removed in the previewed configuration.

Also, `resources.slots_per_trial` is an internal field since the experiment configuration and the command configuration shared the same resource configuration go struct. This PR also removes this field since now the experiment configuration goes down a new path that doesn't use the previous go struct.

I noticed there are tests that still use the old experiment configuration go struct but the production code does not use it. So the experiment workflow should just work.

## Test Plan

- CI
- Manually run `det notebook start --preview`

## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234