### PR TITLE
fix: resource pool not saved in the DB [DET-5485]

### DIFF
--- a/master/internal/experiment.go
+++ b/master/internal/experiment.go
@@ -108,11 +108,8 @@ type (
 func newExperiment(master *Master, expModel *model.Experiment, taskSpec *tasks.TaskSpec) (
 	*experiment, error,
 ) {
-	conf := expModel.Config
+	conf := &expModel.Config
 
-	// Validate the ResourcePool setting.  The reason to do it now and not in postExperiment like
-	// all the other validations is that the resource pool should be revalidated every time the
-	// master restarts.
 	resources := conf.Resources()
 	poolName := resources.ResourcePool()
 	if err := sproto.ValidateRP(master.system, poolName); err != nil {


### PR DESCRIPTION
## Description

This bug is introduced in [here](https://github.com/determined-ai/determined/commit/afdb74955b5ec498095767b1d81d81756b6da510#diff-d92b0050d5549a1efe86c524037f8a2709d6ebf8ce2c63a777f63744bc8a0b00R103). When we filled in the resource pool value, we did that on a copied go struct. This is fixed by changing it to use a pointer.

## Test Plan

Manually create one experiment and check the WebUI

## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234