### PR TITLE
feat: support back-filling in the priority scheduler [DET-5397]

### DIFF
--- a/docs/release-notes/backfill.txt
+++ b/docs/release-notes/backfill.txt
@@ -1,0 +1,8 @@
+:orphan:
+
+**Improvements**
+
+-  Scheduling: support back-filling in the priority scheduler. If there
+   are no high priority tasks can be scheduled or preempted, low
+   priority tasks will be back-filled on the idle slots. This needs
+   preemption to be enabled.

--- a/docs/topic-guides/system-concepts/scheduling.txt
+++ b/docs/topic-guides/system-concepts/scheduling.txt
@@ -60,23 +60,24 @@ will be assigned four slots.
 **********
 
 The master allocates cluster resources (*slots*) to active tasks based
-on their *priority*. While tasks of higher priority (lower priority
-number) are pending, no lower priority tasks will be scheduled. For
-instance, if tasks with priorities of five and forty-two are pending,
-the latter will not be scheduled until the former has been. Tasks of
-equal priority are scheduled in the order in which they were created.
+on their *priority*. High-priority tasks are preferred to low-priority
+tasks. Low-priority tasks will be preempted to make space for pending
+high-priority tasks if possible. Tasks of equal priority are scheduled
+in the order in which they were created.
 
 By default, the priority scheduler does not use preemption. If
 preemption is enabled (:ref:`master-configuration`), when a higher
 priority task is pending and cannot be scheduled because no idle
 resources are available, the scheduler will attempt to schedule it by
 preempting lower priority tasks, starting with the task with the lowest
-priority. When a trial is preempted, its state is checkpointed so that
-the progress of the trial is not lost. Enabling preemption ensures that
-cluster resources can be reallocated to high priority tasks more
-promptly; however, preemption can also result in additional overhead due
-to checkpointing low priority tasks, which might be expensive for some
-models.
+priority. If there are no tasks to preempt, lower priority tasks might
+be backfilled on the idle resources. When a trial is preempted, its
+state is checkpointed so that the progress of the trial is not lost.
+Enabling preemption ensures that cluster resources can be reallocated to
+high priority tasks more promptly and backfilled to make the most use of
+the idle resources; however, preemption can also result in additional
+overhead due to checkpointing low priority tasks, which might be
+expensive for some models.
 
 .. note::
 
@@ -112,12 +113,13 @@ enabled:
    are available.
 
 #. User submits a priority 2 distributed training experiment with
-   slots_per_trial 4. It will not be scheduled even though 7 slots are
-   available, because it is behind a higher priority pending task.
+   slots_per_trial 4. One trial will be scheduled to make use of the
+   idle 7 slots.
 
-#. The notebook is killed. The distributed training job that has
-   priority 1 then starts running. Once that experiment is complete,
-   distributed training experiment with priority 2 runs.
+#. The notebook is killed. The priority 2 distributed training
+   experiment is preempted. And then the priority 1 distributed training
+   experiment starts running. Once that experiment is complete,
+   distributed training experiment with priority 2 restarts.
 
 .. _gang-scheduling-on-kubernetes:
 

--- a/master/internal/resourcemanagers/scheduler.go
+++ b/master/internal/resourcemanagers/scheduler.go
@@ -7,8 +7,12 @@ import (
 	"github.com/determined-ai/determined/master/pkg/actor"
 )
 
-// Scheduler assigns pending tasks to agents (depending on cluster availability) or requests
-// running tasks to terminate.
+// Scheduler schedules tasks on agents.  Its only function Schedule is called
+// to determine which pending requests can be fulfilled and which scheduled tasks
+// can be terminated.  Schedule is expected to ba called every time there is a change
+// to the cluster status, for example, new agents being connected, devices being disabled,
+// and etc,.   Schedule should avoid unnecessary shuffling tasks on agents to avoid
+// the overhead of restarting a preempted task.
 type Scheduler interface {
 	Schedule(rp *ResourcePool) ([]*sproto.AllocateRequest, []*actor.Ref)
 }


### PR DESCRIPTION
## Description

Support back-filling in the priority scheduler. When there are no high-priority tasks to schedule or release, back-fill preemptible low-priority tasks. This behavior needs the preemption to be enabled.

## Test Plan

- Add unit tests.
- Run the current test suite.

## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234