### PR TITLE
docs: notify users of coscheduler behavior [DET-5150]

### DIFF
--- a/docs/topic-guides/system-concepts/scheduling.txt
+++ b/docs/topic-guides/system-concepts/scheduling.txt
@@ -155,16 +155,26 @@ The coscheduling plugin is in beta and is therefore not enabled by
 default. To enable it, edit ``values.yaml`` in the Determined Helm chart
 to set the ``defaultScheduler`` field to ``coscheduler``.
 
-Importantly, the coscheduling plugin does not work with Kubernetes'
-cluster autoscaling feature: static node pools must be used to achieve
-gang scheduling. Also, while the plugin allocates resources to jobs
-based on their priority, it does not support preemption. For example, if
-the cluster is full of low priority jobs and a new high priority job is
-submitted, the high priority job will not be scheduled until one of the
-low priority jobs finishes. Lastly, Determined's capability to
-automatically set pod labels is restricted to GPU experiments;
-Determined does not currently set labels for CPU experiments or user
-commands.
+There are several limitations to the coscheduling plugin to be aware of:
+
+#. The coscheduling plugin does not work with Kubernetes' cluster
+   autoscaling feature. Static node pools must be used to achieve gang
+   scheduling
+
+#. The plugin does not support preemption. For example, if the cluster
+   is full of low priority jobs and a new high priority job is
+   submitted, the high priority job will not be scheduled until one of
+   the low priority jobs finishes.
+
+#. Determined is able to automatically set pod labels, but only for GPU
+   experiments. Determined does not currently set labels for CPU
+   experiments or user commands.
+
+#. When scheduling experiments that utilize the entire cluster, the
+   plugin may take several minutes to schedule the next job. Because the
+   coscheduler only approves of jobs when all of its pods are available,
+   it may repeatedly reject partially-ready jobs, causing them to wait
+   further.
 
 To enable gang scheduling with commands or CPU experiments, enable the
 coscheduler in ``values.yaml`` and modify the experiment config to

--- a/docs/topic-guides/system-concepts/scheduling.txt
+++ b/docs/topic-guides/system-concepts/scheduling.txt
@@ -166,8 +166,8 @@ There are several limitations to the coscheduling plugin to be aware of:
    submitted, the high priority job will not be scheduled until one of
    the low priority jobs finishes.
 
-#. Determined is able to automatically set pod labels, but only for GPU
-   experiments. Determined does not currently set labels for CPU
+#. Determined's capability to automatically set pod labels is restricted
+   to GPU experiments. Determined does not currently set labels for CPU
    experiments or user commands.
 
 #. When scheduling experiments that utilize the entire cluster, the


### PR DESCRIPTION
## Description
Updates the docs to reflect that the coscheduler has long waiting time if attempting to schedule jobs requiring the full cluster.

<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234