### PR TITLE
chore: make tensorboard and checkpoint gc expconf reads backwards compatible

### DIFF
--- a/master/internal/api_experiment.go
+++ b/master/internal/api_experiment.go
@@ -86,7 +86,7 @@ func (a *apiServer) DeleteExperiment(
 	_ context.Context, req *apiv1.DeleteExperimentRequest,
 ) (*apiv1.DeleteExperimentResponse, error) {
 	expID := int(req.ExperimentId)
-	exp, err := a.m.db.ExperimentByID(expID)
+	exp, err := a.m.db.ExperimentByIDWithUnparsableFieldsDummied(expID)
 	switch {
 	case errors.Cause(err) == db.ErrNotFound:
 		return nil, status.Errorf(codes.NotFound, "experiment not found")
@@ -119,6 +119,7 @@ func (a *apiServer) DeleteExperiment(
 	storage.SetSaveTrialLatest(0)
 	exp.Config.SetCheckpointStorage(storage)
 
+	// TODO(now): This is bad.
 	if sErr := a.m.db.SaveExperimentConfig(exp); sErr != nil {
 		return nil, errors.Wrapf(sErr, "failed to patch experiment checkpoint storage")
 	}

--- a/master/internal/checkpoint_gc.go
+++ b/master/internal/checkpoint_gc.go
@@ -10,7 +10,6 @@ import (
 	"github.com/determined-ai/determined/master/pkg/actor"
 	"github.com/determined-ai/determined/master/pkg/container"
 	"github.com/determined-ai/determined/master/pkg/model"
-	"github.com/determined-ai/determined/master/pkg/ptrs"
 	"github.com/determined-ai/determined/master/pkg/tasks"
 )
 
@@ -19,6 +18,10 @@ type checkpointGCTask struct {
 	db             *db.PgDB
 	experiment     *model.Experiment
 	gcTensorboards bool
+
+	keepExperimentBest int
+	keepTrialBest      int
+	keepTrialLatest    int
 
 	agentUserGroup *model.AgentUserGroup
 	taskSpec       *tasks.TaskSpec
@@ -48,13 +51,11 @@ func (t *checkpointGCTask) Receive(ctx *actor.Context) error {
 			return errors.Wrap(err, "cannot start a new task session for a GC task")
 		}
 
-		config := t.experiment.Config.CheckpointStorage()
-
 		checkpoints, err := t.db.ExperimentCheckpointsToGCRaw(
 			t.experiment.ID,
-			ptrs.IntPtr(config.SaveExperimentBest()),
-			ptrs.IntPtr(config.SaveTrialBest()),
-			ptrs.IntPtr(config.SaveTrialLatest()),
+			t.keepExperimentBest,
+			t.keepTrialBest,
+			t.keepTrialLatest,
 			true,
 		)
 		if err != nil {

--- a/master/internal/command/tensorboard_manager.go
+++ b/master/internal/command/tensorboard_manager.go
@@ -359,7 +359,7 @@ func (t *tensorboardManager) getTensorBoardConfigs(req TensorboardRequest) (
 			return nil, err
 		}
 
-		exp, err = t.db.ExperimentByID(expID)
+		exp, err = t.db.ExperimentByIDWithUnparsableFieldsDummied(expID)
 		if err != nil {
 			return nil, err
 		}

--- a/master/internal/core_experiment.go
+++ b/master/internal/core_experiment.go
@@ -173,10 +173,10 @@ func (m *Master) getExperimentSummaryMetrics(c echo.Context) (interface{}, error
 
 func (m *Master) getExperimentCheckpointsToGC(c echo.Context) (interface{}, error) {
 	args := struct {
-		ExperimentID   int  `path:"experiment_id"`
-		ExperimentBest *int `query:"save_experiment_best"`
-		TrialBest      *int `query:"save_trial_best"`
-		TrialLatest    *int `query:"save_trial_latest"`
+		ExperimentID   int `path:"experiment_id"`
+		ExperimentBest int `query:"save_experiment_best"`
+		TrialBest      int `query:"save_trial_best"`
+		TrialLatest    int `query:"save_trial_latest"`
 	}{}
 	if err := api.BindArgs(&args, c); err != nil {
 		return nil, err

--- a/master/internal/experiment.go
+++ b/master/internal/experiment.go
@@ -322,11 +322,14 @@ func (e *experiment) Receive(ctx *actor.Context) error {
 		ctx.Log().Infof("experiment state changed to %s", e.State)
 		addr := actor.Addr(fmt.Sprintf("experiment-%d-checkpoint-gc", e.ID))
 		ctx.Self().System().ActorOf(addr, &checkpointGCTask{
-			agentUserGroup: e.agentUserGroup,
-			taskSpec:       e.taskSpec,
-			rm:             e.rm,
-			db:             e.db,
-			experiment:     e.Experiment,
+			agentUserGroup:     e.agentUserGroup,
+			taskSpec:           e.taskSpec,
+			rm:                 e.rm,
+			db:                 e.db,
+			experiment:         e.Experiment,
+			keepExperimentBest: e.Config.CheckpointStorage().SaveExperimentBest(),
+			keepTrialBest:      e.Config.CheckpointStorage().SaveTrialBest(),
+			keepTrialLatest:    e.Config.CheckpointStorage().SaveTrialLatest(),
 		})
 
 		if e.State == model.CompletedState {


### PR DESCRIPTION
## Description
This change has two parts: first, it re-adds the atrocity `ExperimentByIDWithUnparsableFieldsDummied` that attempts to parse and expconf from the database and falls back to parsing an incomplete version of it. It also changes checkpoint GC to never try to save the maybe invalid expconf.
<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan
- [ ] run tbs and delete for old, old experiments
<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)
Yep.
<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234