### PR TITLE
fix: prevent concurrent updates to a single expconf object [DET-5543]

### DIFF
--- a/master/internal/experiment.go
+++ b/master/internal/experiment.go
@@ -17,6 +17,8 @@ import (
 	"github.com/determined-ai/determined/master/pkg/actor"
 	"github.com/determined-ai/determined/master/pkg/archive"
 	"github.com/determined-ai/determined/master/pkg/model"
+	"github.com/determined-ai/determined/master/pkg/schemas"
+	"github.com/determined-ai/determined/master/pkg/schemas/expconf"
 	"github.com/determined-ai/determined/master/pkg/searcher"
 	"github.com/determined-ai/determined/master/pkg/tasks"
 	"github.com/determined-ai/determined/master/pkg/workload"
@@ -471,7 +473,8 @@ func (e *experiment) processOperations(
 				ctx.Log().Error(err)
 				return
 			}
-			ctx.ActorOf(op.RequestID, newTrial(e, op, checkpoint))
+			config := schemas.Copy(e.Config).(expconf.ExperimentConfig)
+			ctx.ActorOf(op.RequestID, newTrial(e, config, op, checkpoint))
 		case searcher.ValidateAfter:
 			trialOperations[op.GetRequestID()] = append(trialOperations[op.GetRequestID()], op)
 			e.TrialCurrentOperation[op.GetRequestID()] = op

--- a/master/internal/restore.go
+++ b/master/internal/restore.go
@@ -11,6 +11,8 @@ import (
 	"github.com/determined-ai/determined/master/internal/telemetry"
 	"github.com/determined-ai/determined/master/pkg/actor"
 	"github.com/determined-ai/determined/master/pkg/model"
+	"github.com/determined-ai/determined/master/pkg/schemas"
+	"github.com/determined-ai/determined/master/pkg/schemas/expconf"
 	"github.com/determined-ai/determined/master/pkg/searcher"
 )
 
@@ -128,7 +130,8 @@ func (e *experiment) restoreTrial(
 		}
 	}
 
-	t := newTrial(e, op, ckpt)
+	config := schemas.Copy(e.Config).(expconf.ExperimentConfig)
+	t := newTrial(e, config, op, ckpt)
 	if trialID != nil {
 		t.processID(*trialID)
 	}
@@ -137,7 +140,7 @@ func (e *experiment) restoreTrial(
 		if err := t.Restore(snapshot); err != nil {
 			l.WithError(err).Warn("failed to restore trial, restarting fresh")
 			// Just new up the trial again in case restore half-worked.
-			t = newTrial(e, op, ckpt)
+			t = newTrial(e, config, op, ckpt)
 			if trialID != nil {
 				t.processID(*trialID)
 			}

--- a/master/internal/trial_workload_sequencer_test.go
+++ b/master/internal/trial_workload_sequencer_test.go
@@ -49,8 +49,6 @@ func TestTrialWorkloadSequencer(t *testing.T) {
 	expConfig, err := defaultExperimentConfig()
 	assert.NilError(t, err)
 
-	experiment := &model.Experiment{ID: 1, State: model.ActiveState, Config: expConfig}
-
 	rand := nprand.New(0)
 	create := searcher.NewCreate(rand, map[string]interface{}{
 		model.GlobalBatchSize: 64,
@@ -149,7 +147,7 @@ func TestTrialWorkloadSequencer(t *testing.T) {
 		PriorBatchesProcessed: schedulingUnit * 5,
 	}
 
-	s := newTrialWorkloadSequencer(experiment, create, nil)
+	s := newTrialWorkloadSequencer(1, expConfig, create, nil)
 
 	// Check that upToDate() returns true as soon as sequencer is created.
 	assert.Assert(t, s.UpToDate())
@@ -308,14 +306,13 @@ func TestTrialWorkloadSequencerFailedWorkloads(t *testing.T) {
 	expConfig, err := defaultExperimentConfig()
 	assert.NilError(t, err)
 	expConfig.SetMinCheckpointPeriod(expconf.NewLengthInBatches(100))
-	experiment := &model.Experiment{ID: 1, State: model.ActiveState, Config: expConfig}
 
 	rand := nprand.New(0)
 	create := searcher.NewCreate(rand, map[string]interface{}{
 		model.GlobalBatchSize: 64,
 	}, model.TrialWorkloadSequencerType)
 
-	s := newTrialWorkloadSequencer(experiment, create, nil)
+	s := newTrialWorkloadSequencer(1, expConfig, create, nil)
 	s.SetTrialID(1)
 
 	train := searcher.NewValidateAfter(create.RequestID, expconf.NewLength(expconf.Batches, 500))
@@ -345,14 +342,13 @@ func TestTrialWorkloadSequencerFailedWorkloads(t *testing.T) {
 func TestTrialWorkloadSequencerOperationLessThanBatchSize(t *testing.T) {
 	expConfig, err := defaultExperimentConfig()
 	assert.NilError(t, err)
-	experiment := &model.Experiment{ID: 1, State: model.ActiveState, Config: expConfig}
 
 	rand := nprand.New(0)
 	create := searcher.NewCreate(rand, map[string]interface{}{
 		model.GlobalBatchSize: 64,
 	}, model.TrialWorkloadSequencerType)
 
-	s := newTrialWorkloadSequencer(experiment, create, nil)
+	s := newTrialWorkloadSequencer(1, expConfig, create, nil)
 	s.SetTrialID(1)
 
 	train := searcher.NewValidateAfter(create.RequestID, expconf.NewLength(expconf.Records, 24))

--- a/master/pkg/schemas/copy.go
+++ b/master/pkg/schemas/copy.go
@@ -13,6 +13,11 @@ type Copyable interface {
 	Copy() interface{}
 }
 
+// Copy is a reflect-based deep copy.  It's only generally safe to use on schema objects.
+func Copy(src interface{}) interface{} {
+	return cpy(reflect.ValueOf(src)).Interface()
+}
+
 // cpy is for deep copying, but it will only work on "nice" objects, which should include our
 // schema objects.  Useful to other reflect code.
 func cpy(v reflect.Value) reflect.Value {

--- a/master/pkg/schemas/copy_test.go
+++ b/master/pkg/schemas/copy_test.go
@@ -1,17 +1,10 @@
 package schemas
 
 import (
-	"reflect"
 	"testing"
 
 	"gotest.tools/assert"
 )
-
-// Copy is the non-reflect version of copy, but mostly the reflect version is called from other
-// reflect code, so it's defined here in test code.
-func Copy(src interface{}) interface{} {
-	return cpy(reflect.ValueOf(src)).Interface()
-}
 
 func TestCopyAllocatedSlice(t *testing.T) {
 	src := []string{}

--- a/master/pkg/schemas/expconf/experiment_config.go
+++ b/master/pkg/schemas/expconf/experiment_config.go
@@ -84,9 +84,11 @@ func (e *ExperimentConfigV0) Scan(src interface{}) error {
 // AsLegacy converts a current ExperimentConfig to a (limited capacity) LegacyConfig.
 func (e ExperimentConfig) AsLegacy() LegacyConfig {
 	return LegacyConfig{
-		checkpointStorage: e.CheckpointStorage(),
-		bindMounts:        e.BindMounts(),
-		envvars:           e.Environment().EnvironmentVariables(),
+		checkpointStorage: schemas.Copy(e.CheckpointStorage()).(CheckpointStorageConfig),
+		bindMounts:        schemas.Copy(e.BindMounts()).(BindMountsConfig),
+		envvars: schemas.Copy(
+			e.Environment().EnvironmentVariables(),
+		).(EnvironmentVariablesMap),
 	}
 }
 


### PR DESCRIPTION
Use a deep copy when passing an experiment config from one actor to
another.