### PR TITLE
fix: synchronize pods actor startup in k8s resource manager [DET-5536]

### DIFF
--- a/docs/release-notes/2453-fix-k8s-resource-manager.txt
+++ b/docs/release-notes/2453-fix-k8s-resource-manager.txt
@@ -1,0 +1,6 @@
+:orphan:
+
+**Bug Fixes**
+
+-  K8s: Fix one nil pointer dereference issue that might cause the
+   master to crash when using kubernetes.

--- a/master/internal/kubernetes/pods.go
+++ b/master/internal/kubernetes/pods.go
@@ -104,6 +104,7 @@ func Initialize(
 		currentNodes:             make(map[string]*k8sV1.Node),
 	})
 	check.Panic(check.True(ok, "pods address already taken"))
+	s.Ask(podsActor, actor.Ping{}).Get()
 
 	// We re-use the agents endpoint for the default resource manager.
 	e.Any("/agents", api.Route(s, podsActor))
@@ -127,7 +128,6 @@ func (p *pods) Receive(ctx *actor.Context) error {
 		p.startNodeInformer(ctx)
 		p.startEventListener(ctx)
 		p.startPreemptionListener(ctx)
-		ctx.Tell(p.cluster, sproto.SetPods{Pods: ctx.Self()})
 
 	case sproto.StartTaskPod:
 		if err := p.receiveStartTaskPod(ctx, msg); err != nil {

--- a/master/internal/resourcemanagers/resource_managers.go
+++ b/master/internal/resourcemanagers/resource_managers.go
@@ -1,7 +1,6 @@
 package resourcemanagers
 
 import (
-	"crypto/tls"
 	"time"
 
 	"github.com/determined-ai/determined/master/internal/sproto"
@@ -19,31 +18,6 @@ type schedulerTick struct{}
 // Currently support only one resource manager at a time.
 type ResourceManagers struct {
 	ref *actor.Ref
-}
-
-// NewResourceManagers creates an instance of ResourceManagers.
-func NewResourceManagers(
-	system *actor.System, config *ResourceConfig, cert *tls.Certificate,
-) *ResourceManagers {
-	var ref *actor.Ref
-	switch {
-	case config.ResourceManager.AgentRM != nil:
-		ref, _ = system.ActorOf(
-			actor.Addr("agentRM"),
-			newAgentResourceManager(config, cert),
-		)
-
-	case config.ResourceManager.KubernetesRM != nil:
-		ref, _ = system.ActorOf(
-			actor.Addr("kubernetesRM"),
-			newKubernetesResourceManager(config.ResourceManager.KubernetesRM),
-		)
-
-	default:
-		panic("no expected resource manager config is defined")
-	}
-
-	return &ResourceManagers{ref: ref}
 }
 
 // Receive implements the actor.Actor interface.

--- a/master/internal/resourcemanagers/resource_managers_test.go
+++ b/master/internal/resourcemanagers/resource_managers_test.go
@@ -3,6 +3,8 @@ package resourcemanagers
 import (
 	"testing"
 
+	"github.com/labstack/echo/v4"
+
 	"gotest.tools/assert"
 
 	"github.com/determined-ai/determined/master/internal/sproto"
@@ -27,9 +29,7 @@ func TestResourceManagerForwardMessage(t *testing.T) {
 			},
 		},
 	}
-	rpActor, created := system.ActorOf(actor.Addr("resourceManagers"),
-		NewResourceManagers(system, conf, nil))
-	assert.Assert(t, created)
+	rpActor := Setup(system, echo.New(), conf, nil, nil)
 
 	taskSummary := system.Ask(rpActor, sproto.GetTaskSummaries{}).Get()
 	assert.DeepEqual(t, taskSummary, make(map[sproto.TaskID]TaskSummary))

--- a/master/internal/resourcemanagers/setup.go
+++ b/master/internal/resourcemanagers/setup.go
@@ -10,7 +10,6 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/determined-ai/determined/master/internal/agent"
-	"github.com/determined-ai/determined/master/internal/kubernetes"
 	"github.com/determined-ai/determined/master/pkg/actor"
 	aproto "github.com/determined-ai/determined/master/pkg/agent"
 	"github.com/determined-ai/determined/master/pkg/model"
@@ -105,13 +104,8 @@ func setupKubernetesResourceManager(
 ) *actor.Ref {
 	ref, _ := system.ActorOf(
 		actor.Addr("kubernetesRM"),
-		newKubernetesResourceManager(config),
+		newKubernetesResourceManager(config, echo, masterTLSConfig, loggingConfig),
 	)
 	system.Ask(ref, actor.Ping{}).Get()
-
-	kubernetes.Initialize(
-		system, echo, ref, config.Namespace, config.MasterServiceName, masterTLSConfig, loggingConfig,
-		config.LeaveKubernetesResources, config.DefaultScheduler,
-	)
 	return ref
 }

--- a/master/internal/sproto/kubernetes_resource_manager.go
+++ b/master/internal/sproto/kubernetes_resource_manager.go
@@ -19,8 +19,3 @@ type (
 		PodID container.ID
 	}
 )
-
-// SetPods sets the pods for the kubernetes resource manager.
-type SetPods struct {
-	Pods *actor.Ref
-}


### PR DESCRIPTION
## Description

Previously, when the k8s pods actor starts up, it sends a message to the k8s resource manager actor, which then creates a mock agent. Before the mock agent is created, no allocation requests should be handled in the k8s resource manager actor. However, there is no synchronization to ensure the k8s resource manager actor receives `SetPods` message first.

This PR moves creating the k8s pods actor into the `PreStart` of the k8s resource manager actor so the order is enforced.


## Test Plan

CI

## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
