### PR TITLE
chore: dont close trial on socket close

### DIFF
--- a/master/internal/trial.go
+++ b/master/internal/trial.go
@@ -439,9 +439,8 @@ func (t *trial) runningReceive(ctx *actor.Context) error {
 			return err
 		}
 
-	case actor.ChildFailed:
-		ctx.Log().Info("found child actor failed, terminating forcibly")
-		t.terminate(ctx, true)
+	case actor.ChildStopped, actor.ChildFailed:
+		ctx.Log().Info("trial socket exited")
 
 	case killTrial:
 		ctx.Log().Info("received killing request")
@@ -465,8 +464,6 @@ func (t *trial) runningReceive(ctx *actor.Context) error {
 			ctx.Log().Info("forcibly terminating unresponsive trial after timeout expired")
 			t.terminate(ctx, true)
 		}
-
-	case actor.ChildStopped:
 
 	default:
 		return actor.ErrUnexpectedMessage(ctx)


### PR DESCRIPTION
## Description
This change updates the master code to _not_ forcibly close trials on socket disconnects. In the event of a socket from the harness disconnecting, the harness code should exit. Forcibly killing hung code should be left to the use of `det t kill` or similar, since hung code could also not be hung, but just awaiting some important cleanup.
<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan
- [x] run stuff and make sure trials end up in ok states still
<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234