### PR TITLE
chore: move run increment to allocation not termination [DET-5559, DET-5450]

### DIFF
--- a/master/internal/trial.go
+++ b/master/internal/trial.go
@@ -625,6 +625,7 @@ func (t *trial) processAllocated(
 	if err = t.db.AddTrialRun(t.id, t.RunID); err != nil {
 		ctx.Log().WithError(err).Error("failed to save trial run")
 	}
+	t.RunID++
 
 	ctx.Log().Infof("starting trial container: %v", w)
 
@@ -1138,8 +1139,6 @@ func (t *trial) terminated(ctx *actor.Context) {
 	if err := t.db.CompleteTrialRun(t.id, t.RunID); err != nil {
 		ctx.Log().WithError(err).Error("failed to mark trial run completed")
 	}
-
-	t.RunID++
 
 	if t.task != nil {
 		if err := t.db.DeleteTaskSessionByTaskID(string(t.task.ID)); err != nil {


### PR DESCRIPTION
## Description
This change just moves "starting a new run" to when resource are allocated from when we were terminated. It really should've happened in trial reset previously, but this change makes more semantic sense to me: a run isn't started until it is.. started?
<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan
- [ ] run tests, also make sure resets dont print error messages
<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234