### PR TITLE
chore: report running of migrations

### DIFF
--- a/master/internal/db/postgres.go
+++ b/master/internal/db/postgres.go
@@ -58,6 +58,7 @@ const (
 
 // Migrate runs the migrations from the specified directory URL.
 func (db *PgDB) Migrate(migrationURL string) error {
+	log.Infof("running DB migrations from %s; this might take a while...", migrationURL)
 	driver, err := postgresM.WithInstance(db.sql.DB, &postgresM.Config{})
 	if err != nil {
 		return errors.Wrap(err, "error constructing Postgres migration driver")
@@ -80,7 +81,7 @@ func (db *PgDB) Migrate(migrationURL string) error {
 	if err = m.Up(); err != migrate.ErrNoChange {
 		return errors.Wrap(err, "error applying migrations")
 	}
-
+	log.Info("DB migrations completed")
 	return nil
 }
 

--- a/master/internal/db/setup.go
+++ b/master/internal/db/setup.go
@@ -27,7 +27,6 @@ func Setup(opts *Config) (*PgDB, error) {
 
 	db.sql.SetMaxOpenConns(maxOpenConns)
 
-	log.Infof("running migrations from %v", opts.Migrations)
 	if err = db.Migrate(opts.Migrations); err != nil {
 		return nil, errors.Wrap(err, "running migrations")
 	}


### PR DESCRIPTION
## Description

better communicate that migrations are running.

<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

sample startup logs

```
determined-master  | INFO[2021-05-27T13:19:24-07:00] Determined master 0.15.6.dev0 (built with go1.16.4) 
determined-master  | INFO[2021-05-27T13:19:24-07:00] connecting to database localhost:5432        
determined-master  | INFO[2021-05-27T13:19:24-07:00] running DB migrations from file:///home/hmd/projects/da/determined/tools/build/static/migrations; this might take a while... 
determined-master  | INFO[2021-05-27T13:19:24-07:00] found golang-migrate version 20210513134524  
determined-master  | INFO[2021-05-27T13:19:24-07:00] DB migrations completed                      
determined-master  | INFO[2021-05-27T13:19:24-07:00] deleting all snapshots for terminal state experiments 
determined-master  | INFO[2021-05-27T13:19:24-07:00] creating resource pool: default               id=agentRM system=master type=agentResourceManager
determined-master  | INFO[2021-05-27T13:19:24-07:00] pool default using global scheduling config   id=agentRM system=master type=agentResourceManager
determined-master  | INFO[2021-05-27T13:19:24-07:00] not enabling provisioner for resource pool: default  id=default resource-pool=default system=master type=ResourcePool
determined-master  | INFO[2021-05-27T13:19:24-07:00] scheduling next resource allocation aggregation in 3h41m35s at 2021-05-28 00:01:00 +0000 UTC  id=allocation-aggregator system=master type=allocationAggregator
determined-master  | INFO[2021-05-27T13:19:24-07:00] telemetry reporting is disabled              
determined-master  | INFO[2021-05-27T13:19:24-07:00] accepting incoming connections on port 8080  
```

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234