### PR TITLE
chore: improve performance of tfevent file filtering

### DIFF
--- a/harness/determined/tensorboard/gcs.py
+++ b/harness/determined/tensorboard/gcs.py
@@ -31,7 +31,6 @@ class GCSTensorboardManager(base.TensorboardManager):
             logging.debug(f"Uploading to GCS: {blob_name}")
 
             blob.upload_from_filename(str(path))
-            self._synced_event_sizes[path] = path.stat().st_size
 
     def delete(self) -> None:
         self.bucket.delete_blobs(blobs=list(self.bucket.list_blobs(prefix=self.sync_path)))

--- a/harness/determined/tensorboard/hdfs.py
+++ b/harness/determined/tensorboard/hdfs.py
@@ -37,7 +37,6 @@ class HDFSTensorboardManager(base.TensorboardManager):
             logging.debug(f"Uploading {path} to {self.hdfs_path}")
 
             self.client.upload(file_name, str(path))
-            self._synced_event_sizes[path] = path.stat().st_size
 
     def delete(self) -> None:
         self.client.delete(self.sync_path, recursive=True)

--- a/harness/determined/tensorboard/s3.py
+++ b/harness/determined/tensorboard/s3.py
@@ -45,7 +45,6 @@ class S3TensorboardManager(base.TensorboardManager):
             logging.debug(f"Uploading {path} to {url}")
 
             self.client.upload_file(str(path), self.bucket, key_name)
-            self._synced_event_sizes[path] = path.stat().st_size
 
     def delete(self) -> None:
         self.resource.Bucket(self.bucket).objects.filter(Prefix=str(self.sync_path)).delete()

--- a/harness/determined/tensorboard/shared.py
+++ b/harness/determined/tensorboard/shared.py
@@ -31,7 +31,5 @@ class SharedFSTensorboardManager(base.TensorboardManager):
             pathlib.Path.mkdir(shared_fs_path.parent, exist_ok=True)
             shutil.copy(path, shared_fs_path)
 
-            self._synced_event_sizes[path] = path.stat().st_size
-
     def delete(self) -> None:
         shutil.rmtree(self.shared_fs_base, False)

--- a/harness/tests/tensorboard/test_base.py
+++ b/harness/tests/tensorboard/test_base.py
@@ -102,7 +102,7 @@ def test_list_directory(tmp_path: pathlib.Path) -> None:
 
     full_event_path = BASE_PATH.joinpath("tensorboard", "events.out.tfevents.example")
 
-    assert set(manager.list_tfevents()) == {full_event_path}
+    assert set(manager.list_tfevents(0)) == {full_event_path}
 
 
 def test_list_nonexistent_directory(tmp_path: pathlib.Path) -> None:
@@ -114,4 +114,4 @@ def test_list_nonexistent_directory(tmp_path: pathlib.Path) -> None:
     manager = tensorboard.SharedFSTensorboardManager(str(tmp_path), base_path, sync_path)
 
     assert not pathlib.Path(base_path).exists()
-    assert manager.list_tfevents() == []
+    assert manager.list_tfevents(0) == []


### PR DESCRIPTION
I observed that as tfevent files build up, just selecting which files to
examine can actually be a bit of a bottleneck.  The current strategy
seems to have a minimum cost of about 1ms per 100 files (calling
stat() on 1500 event files takes my system 0.012s).  The previous
implementation kept a complex index of how large each file had been
before uploading it, which quadrupled the time for choosing files to
around 0.045 seconds.  The new strategy, which just chooses all modified
files since the last sync time, has basically no overhead over the cost
of stat'ing each file.

The only strategy I can think of that would be faster would be to hook
into inotify to have the operating system watch the list of files for
you.