### PR TITLE
chore: fix some semi-broken unit tests

### DIFF
--- a/harness/tests/fixtures/fake_subprocess_receiver.py
+++ b/harness/tests/fixtures/fake_subprocess_receiver.py
@@ -34,11 +34,11 @@ def main() -> None:
 
         # Compare the workloads received against the expected stream of workloads.
         expected = fake_workload_gen()
-        for i, (wkld, _, resp_fn) in enumerate(iter(subrec)):
-            assert wkld == next(expected)
+        actual = iter(subrec)
+        for i, wkld in enumerate(expected):
+            actual_wkld, _, resp_fn = next(actual)
+            assert wkld == actual_wkld
             resp_fn({"count": i})
-
-        assert i == NUM_FAKE_WORKLOADS
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fix test_ipc: the child process never exited.

Fix test_to_device_warnings: there is no longer any need for
multiprocessing.Queue().