### PR TITLE
chore: add non-streaming APIs for trial profiler endpoints

### DIFF
--- a/harness/determined/_swagger/client/api/profiler_api.py
+++ b/harness/determined/_swagger/client/api/profiler_api.py
@@ -43,7 +43,7 @@ class ProfilerApi(object):
 
         :param async_req bool
         :param int trial_id: The requested trial's id. (required)
-        :param bool follow: Continue streaming labels until the trial stops.
+        :param bool follow: Continue streaming labels until the trial stops. Defaults to False.
         :return: StreamResultOfV1GetTrialProfilerAvailableSeriesResponse
                  If the method is called asynchronously,
                  returns the request thread.
@@ -65,7 +65,7 @@ class ProfilerApi(object):
 
         :param async_req bool
         :param int trial_id: The requested trial's id. (required)
-        :param bool follow: Continue streaming labels until the trial stops.
+        :param bool follow: Continue streaming labels until the trial stops. Defaults to False.
         :return: StreamResultOfV1GetTrialProfilerAvailableSeriesResponse
                  If the method is called asynchronously,
                  returns the request thread.
@@ -148,7 +148,7 @@ class ProfilerApi(object):
         :param str labels_agent_id: The agent ID associated with the metric.
         :param str labels_gpu_uuid: The GPU UUID associated with the metric.
         :param str labels_metric_type: The type of the metric.   - PROFILER_METRIC_TYPE_UNSPECIFIED: Zero-value (not allowed).  - PROFILER_METRIC_TYPE_SYSTEM: For systems metrics, like GPU utilization or memory.  - PROFILER_METRIC_TYPE_TIMING: For timing metrics, like how long a backwards pass or getting a batch from the dataloader took.
-        :param bool follow: Continue streaming metrics until the trial stops.
+        :param bool follow: Continue streaming metrics until the trial stops. Defaults to False.
         :return: StreamResultOfV1GetTrialProfilerMetricsResponse
                  If the method is called asynchronously,
                  returns the request thread.
@@ -174,7 +174,7 @@ class ProfilerApi(object):
         :param str labels_agent_id: The agent ID associated with the metric.
         :param str labels_gpu_uuid: The GPU UUID associated with the metric.
         :param str labels_metric_type: The type of the metric.   - PROFILER_METRIC_TYPE_UNSPECIFIED: Zero-value (not allowed).  - PROFILER_METRIC_TYPE_SYSTEM: For systems metrics, like GPU utilization or memory.  - PROFILER_METRIC_TYPE_TIMING: For timing metrics, like how long a backwards pass or getting a batch from the dataloader took.
-        :param bool follow: Continue streaming metrics until the trial stops.
+        :param bool follow: Continue streaming metrics until the trial stops. Defaults to False.
         :return: StreamResultOfV1GetTrialProfilerMetricsResponse
                  If the method is called asynchronously,
                  returns the request thread.

--- a/harness/determined/_swagger/client/api/profiler_api.py
+++ b/harness/determined/_swagger/client/api/profiler_api.py
@@ -43,6 +43,7 @@ class ProfilerApi(object):
 
         :param async_req bool
         :param int trial_id: The requested trial's id. (required)
+        :param bool follow: Continue streaming labels until the trial stops.
         :return: StreamResultOfV1GetTrialProfilerAvailableSeriesResponse
                  If the method is called asynchronously,
                  returns the request thread.
@@ -64,12 +65,13 @@ class ProfilerApi(object):
 
         :param async_req bool
         :param int trial_id: The requested trial's id. (required)
+        :param bool follow: Continue streaming labels until the trial stops.
         :return: StreamResultOfV1GetTrialProfilerAvailableSeriesResponse
                  If the method is called asynchronously,
                  returns the request thread.
         """
 
-        all_params = ['trial_id']  # noqa: E501
+        all_params = ['trial_id', 'follow']  # noqa: E501
         all_params.append('async_req')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
@@ -96,6 +98,8 @@ class ProfilerApi(object):
             path_params['trialId'] = params['trial_id']  # noqa: E501
 
         query_params = []
+        if 'follow' in params:
+            query_params.append(('follow', params['follow']))  # noqa: E501
 
         header_params = {}
 
@@ -144,6 +148,7 @@ class ProfilerApi(object):
         :param str labels_agent_id: The agent ID associated with the metric.
         :param str labels_gpu_uuid: The GPU UUID associated with the metric.
         :param str labels_metric_type: The type of the metric.   - PROFILER_METRIC_TYPE_UNSPECIFIED: Zero-value (not allowed).  - PROFILER_METRIC_TYPE_SYSTEM: For systems metrics, like GPU utilization or memory.  - PROFILER_METRIC_TYPE_TIMING: For timing metrics, like how long a backwards pass or getting a batch from the dataloader took.
+        :param bool follow: Continue streaming metrics until the trial stops.
         :return: StreamResultOfV1GetTrialProfilerMetricsResponse
                  If the method is called asynchronously,
                  returns the request thread.
@@ -169,12 +174,13 @@ class ProfilerApi(object):
         :param str labels_agent_id: The agent ID associated with the metric.
         :param str labels_gpu_uuid: The GPU UUID associated with the metric.
         :param str labels_metric_type: The type of the metric.   - PROFILER_METRIC_TYPE_UNSPECIFIED: Zero-value (not allowed).  - PROFILER_METRIC_TYPE_SYSTEM: For systems metrics, like GPU utilization or memory.  - PROFILER_METRIC_TYPE_TIMING: For timing metrics, like how long a backwards pass or getting a batch from the dataloader took.
+        :param bool follow: Continue streaming metrics until the trial stops.
         :return: StreamResultOfV1GetTrialProfilerMetricsResponse
                  If the method is called asynchronously,
                  returns the request thread.
         """
 
-        all_params = ['labels_trial_id', 'labels_name', 'labels_agent_id', 'labels_gpu_uuid', 'labels_metric_type']  # noqa: E501
+        all_params = ['labels_trial_id', 'labels_name', 'labels_agent_id', 'labels_gpu_uuid', 'labels_metric_type', 'follow']  # noqa: E501
         all_params.append('async_req')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
@@ -209,6 +215,8 @@ class ProfilerApi(object):
             query_params.append(('labels.gpuUuid', params['labels_gpu_uuid']))  # noqa: E501
         if 'labels_metric_type' in params:
             query_params.append(('labels.metricType', params['labels_metric_type']))  # noqa: E501
+        if 'follow' in params:
+            query_params.append(('follow', params['follow']))  # noqa: E501
 
         header_params = {}
 

--- a/master/internal/api_trials.go
+++ b/master/internal/api_trials.go
@@ -482,8 +482,6 @@ func (a *apiServer) GetTrialProfilerAvailableSeries(
 		})
 	}
 
-
-
 	return api.NewBatchStreamProcessor(
 		api.BatchRequest{Follow: req.Follow},
 		fetch,

--- a/master/internal/api_trials.go
+++ b/master/internal/api_trials.go
@@ -449,7 +449,7 @@ func (a *apiServer) GetTrialProfilerMetrics(
 	}
 
 	return api.NewBatchStreamProcessor(
-		api.BatchRequest{Follow: true},
+		api.BatchRequest{Follow: req.Follow},
 		fetch,
 		onBatch,
 		a.isTrialTerminalFunc(int(req.Labels.TrialId), -1),
@@ -482,8 +482,10 @@ func (a *apiServer) GetTrialProfilerAvailableSeries(
 		})
 	}
 
+
+
 	return api.NewBatchStreamProcessor(
-		api.BatchRequest{Follow: true},
+		api.BatchRequest{Follow: req.Follow},
 		fetch,
 		onBatch,
 		a.isTrialTerminalFunc(int(req.TrialId), 10),

--- a/master/test/integration/api/api_trials_test.go
+++ b/master/test/integration/api/api_trials_test.go
@@ -182,6 +182,7 @@ func trialProfilerMetricsTests(
 			AgentId:    "brad's agent",
 			MetricType: trialv1.TrialProfilerMetricLabels_PROFILER_METRIC_TYPE_SYSTEM,
 		},
+		Follow: true,
 	})
 	assert.NilError(t, err, "failed to initiate trial profiler metrics stream")
 
@@ -246,6 +247,7 @@ func trialProfilerMetricsAvailableSeriesTests(
 	ctx, _ := context.WithTimeout(creds, time.Minute)
 	tlCl, err := cl.GetTrialProfilerAvailableSeries(ctx, &apiv1.GetTrialProfilerAvailableSeriesRequest{
 		TrialId: int32(trial.ID),
+		Follow: true,
 	})
 	assert.NilError(t, err, "failed to initiate trial profiler series stream")
 

--- a/proto/src/determined/api/v1/trial.proto
+++ b/proto/src/determined/api/v1/trial.proto
@@ -231,7 +231,7 @@ message GetTrialProfilerMetricsRequest {
   };
   // The labels for the series requested.
   determined.trial.v1.TrialProfilerMetricLabels labels = 1;
-  // Continue streaming metrics until the trial stops.
+  // Continue streaming metrics until the trial stops. Defaults to False.
   bool follow = 2;
 }
 // Response to TrialProfilerMetricsResponse
@@ -250,7 +250,7 @@ message GetTrialProfilerAvailableSeriesRequest {
   };
   // The requested trial's id.
   int32 trial_id = 1;
-  // Continue streaming labels until the trial stops.
+  // Continue streaming labels until the trial stops. Defaults to False.
   bool follow = 2;
 }
 // Response to TrialProfilerAvailableSeriesRequest.

--- a/proto/src/determined/api/v1/trial.proto
+++ b/proto/src/determined/api/v1/trial.proto
@@ -231,6 +231,8 @@ message GetTrialProfilerMetricsRequest {
   };
   // The labels for the series requested.
   determined.trial.v1.TrialProfilerMetricLabels labels = 1;
+  // Continue streaming metrics until the trial stops.
+  bool follow = 2;
 }
 // Response to TrialProfilerMetricsResponse
 message GetTrialProfilerMetricsResponse {
@@ -248,6 +250,8 @@ message GetTrialProfilerAvailableSeriesRequest {
   };
   // The requested trial's id.
   int32 trial_id = 1;
+  // Continue streaming labels until the trial stops.
+  bool follow = 2;
 }
 // Response to TrialProfilerAvailableSeriesRequest.
 message GetTrialProfilerAvailableSeriesResponse {

--- a/webui/react/src/pages/TrialDetails/Profiles/utils.ts
+++ b/webui/react/src/pages/TrialDetails/Profiles/utils.ts
@@ -69,6 +69,7 @@ export const useFetchAvailableSeries = (trialId: number): AvailableSeries => {
     consumeStream(
       detApi.StreamingProfiler.determinedGetTrialProfilerAvailableSeries(
         trialId,
+        true,
         { signal: canceler.signal },
       ),
       (event: V1GetTrialProfilerAvailableSeriesResponse) => {
@@ -148,6 +149,7 @@ export const useFetchMetrics = (
         labelsAgentId,
         labelsGpuUuid,
         labelsMetricType,
+        true,
         { signal: canceler.signal },
       ),
       (event: V1GetTrialProfilerMetricsResponse) => {


### PR DESCRIPTION
## Description

Add the `follow` param to the Profiling APIs to indicate whether the API should stream results until the trial is complete.

## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

The available series changes are required for the ProfilingAgent to know whether profiling results have already been recorded for the trial so it can know to not add more profiling data.

I added the flag to both APIs because some tools don't have good support for streaming (e.g. Swagger) and it is really convenient to have non-streaming versions of the APIs.


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
