### PR TITLE
chore: disable profiling after restart [DET-5424]

### DIFF
--- a/harness/determined/common/api/__init__.py
+++ b/harness/determined/common/api/__init__.py
@@ -29,4 +29,5 @@ from determined.common.api.request import (
 from determined.common.api.profiler import (
     post_trial_profiler_metrics_batches,
     TrialProfilerMetricsBatch,
+    get_trial_profiler_available_series,
 )

--- a/harness/determined/common/api/profiler.py
+++ b/harness/determined/common/api/profiler.py
@@ -1,6 +1,7 @@
 from typing import Any, Dict, List
 
 import backoff
+import requests
 from requests.exceptions import RequestException
 
 from determined.common import api
@@ -46,3 +47,25 @@ def post_trial_profiler_metrics_batches(
         "/api/v1/trials/profiler/metrics",
         body={"batches": [b.__dict__ for b in batches]},
     )
+
+
+@backoff.on_exception(  # type: ignore
+    backoff.constant,
+    RequestException,
+    max_tries=2,
+    giveup=lambda e: e.response is not None and e.response.status_code < 500,
+)
+def get_trial_profiler_available_series(
+    master_url: str,
+    trial_id: str,
+) -> None:
+    """
+    Get available profiler series for a trial. This uses the non-streaming version of the API
+    """
+    follow = False
+    response = api.get(
+        host=master_url,
+        path=f"/api/v1/trials/{trial_id}/profiler/available_series",
+        params={"follow": follow}
+    )
+    print(response)

--- a/harness/determined/profiler.py
+++ b/harness/determined/profiler.py
@@ -118,6 +118,7 @@ class ProfilerAgent:
 
         self.has_started = False
         self.has_finished = False
+        self.disabled_due_to_preexisting_metrics = False
 
         self.shutdown_lock = threading.Lock()
 

--- a/harness/determined/profiler.py
+++ b/harness/determined/profiler.py
@@ -48,6 +48,18 @@ class ShutdownMessage:
     pass
 
 
+def profiling_metrics_exist(master_url: str, trial_id: str) -> bool:
+    """
+    Return True if there are already profiling metrics for the trial.
+    """
+    # TODO: Implement
+    raise NotImplementedError
+
+
+SendBatchFnType = Callable[[str, List[TrialProfilerMetricsBatch]], None]
+CheckDataExistsFnType = Callable[[str, str], bool]
+
+
 class ProfilerAgent:
     """
     Agent that collects metrics and sends them to the master.
@@ -63,7 +75,15 @@ class ProfilerAgent:
     shut down MAX_COLLECTION_SECONDS after starting. When profiling is not active, no system metrics
     are collected and the record_timing function is a no-op.
 
+    Profiling is automatically disabled if profiling metrics already exist in the API. This would
+    indicates that the harness restarted due to job failure or being descheduled. Picking up
+    profiling in that case introduces issues around multiple data points for the same batch_idx,
+    difficult-to-render graphs due to large time gaps, and misleading data due to GPU warmup.
+
     If is_enabled=False, every method in this class should be a no-op.
+
+    send_batch_fn and check_data_exists_fn are the pieces of code that communicate with the
+    master API. They can be replaced with dummy functions to enable testing without a master.
     """
 
     # dev note: We optimize this code by only creating threads if they will be used.
@@ -81,22 +101,33 @@ class ProfilerAgent:
         local_rank: int,
         start_on_batch: int,
         end_after_batch: Optional[int] = None,
+        send_batch_fn: SendBatchFnType = api.post_trial_profiler_metrics_batches,
+        check_data_exists_fn: CheckDataExistsFnType = profiling_metrics_exist,
     ):
         self.current_batch_idx = 0
-        self.agent_id = agent_id
         self.trial_id = trial_id
+        self.agent_id = agent_id
         self.master_url = master_url
+        self.profiling_is_enabled_in_experiment_config = profiling_is_enabled
+        self.global_rank = global_rank
+        self.local_rank = local_rank
         self.start_on_batch = start_on_batch
         self.end_after_batch = end_after_batch
-        self.local_rank = local_rank
-        self.global_rank = global_rank
-
-        self.profiling_is_enabled_in_experiment_config = profiling_is_enabled
+        self.send_batch_fn = send_batch_fn
+        self.check_data_already_exists_fn = check_data_exists_fn
 
         self.has_started = False
         self.has_finished = False
 
         self.shutdown_lock = threading.Lock()
+        self.disabled_due_to_preexisting_metrics = self.check_data_already_exists_fn(
+            self.master_url, self.trial_id
+        )
+        if self.disabled_due_to_preexisting_metrics and self.global_rank == 0:
+            logging.warning(
+                f"{LOG_NAMESPACE}: ProfilerAgent is disabled because profiling data for this "
+                f"trial already exists in the DB. No additional profiling data will be generated."
+            )
 
         # If the ProfilingAgent is disabled, don't waste resources by creating useless threads
         if self.is_enabled:
@@ -125,7 +156,7 @@ class ProfilerAgent:
                 )
 
             self.sender_thread = ProfilerSenderThread(
-                self.send_queue, self.master_url, num_producers
+                self.send_queue, self.master_url, num_producers, self.send_batch_fn
             )
 
     @staticmethod
@@ -182,15 +213,25 @@ class ProfilerAgent:
         """
         if not self.profiling_is_enabled_in_experiment_config:
             return False
+        if self.disabled_due_to_preexisting_metrics:
+            return False
         return self.sysmetrics_is_enabled or self.timings_is_enabled
 
     @property
     def sysmetrics_is_enabled(self) -> bool:
-        return self.profiling_is_enabled_in_experiment_config and self.local_rank == 0
+        if not self.profiling_is_enabled_in_experiment_config:
+            return False
+        if self.disabled_due_to_preexisting_metrics:
+            return False
+        return self.local_rank == 0
 
     @property
     def timings_is_enabled(self) -> bool:
-        return self.profiling_is_enabled_in_experiment_config and self.global_rank == 0
+        if not self.profiling_is_enabled_in_experiment_config:
+            return False
+        if self.disabled_due_to_preexisting_metrics:
+            return False
+        return self.global_rank == 0
 
     @property
     def is_active(self) -> bool:
@@ -589,11 +630,18 @@ class ProfilerSenderThread(threading.Thread):
     upstream producers and exits whenever it receives a ShutdownMessage from each producer.
     """
 
-    def __init__(self, inbound_queue: queue.Queue, master_url: str, num_producers: int) -> None:
+    def __init__(
+        self,
+        inbound_queue: queue.Queue,
+        master_url: str,
+        num_producers: int,
+        send_batch_fn: SendBatchFnType,
+    ) -> None:
         self.master_url = master_url
         self.inbound_queue = inbound_queue
         self.num_producers = num_producers
         self.producers_shutdown = 0
+        self.send_batch_fn = send_batch_fn
         super().__init__(daemon=True)
 
     def run(self) -> None:
@@ -605,7 +653,7 @@ class ProfilerSenderThread(threading.Thread):
                     return
                 else:
                     continue
-            api.post_trial_profiler_metrics_batches(
+            self.send_batch_fn(
                 self.master_url,
                 message,
             )

--- a/harness/determined/profiler.py
+++ b/harness/determined/profiler.py
@@ -52,8 +52,8 @@ def profiling_metrics_exist(master_url: str, trial_id: str) -> bool:
     """
     Return True if there are already profiling metrics for the trial.
     """
-    # TODO: Implement
-    raise NotImplementedError
+    series_labels = api.get_trial_profiler_available_series(master_url, trial_id)
+    return len(series_labels) > 0
 
 
 SendBatchFnType = Callable[[str, List[TrialProfilerMetricsBatch]], None]

--- a/harness/determined/profiler.py
+++ b/harness/determined/profiler.py
@@ -120,17 +120,20 @@ class ProfilerAgent:
         self.has_finished = False
 
         self.shutdown_lock = threading.Lock()
-        self.disabled_due_to_preexisting_metrics = self.check_data_already_exists_fn(
-            self.master_url, self.trial_id
-        )
-        if self.disabled_due_to_preexisting_metrics and self.global_rank == 0:
-            logging.warning(
-                f"{LOG_NAMESPACE}: ProfilerAgent is disabled because profiling data for this "
-                f"trial already exists. No additional profiling data is generated after a restart."
-            )
 
         # If the ProfilingAgent is disabled, don't waste resources by creating useless threads
+        # or making API calls
         if self.is_enabled:
+            self.disabled_due_to_preexisting_metrics = self.check_data_already_exists_fn(
+                self.master_url, self.trial_id
+            )
+            if self.disabled_due_to_preexisting_metrics and self.global_rank == 0:
+                logging.warning(
+                    f"{LOG_NAMESPACE}: ProfilerAgent is disabled because profiling data for "
+                    f"this trial already exists. No additional profiling data is generated "
+                    f"after a restart."
+                )
+
             # Set up timer thread to stop collecting after MAX_COLLECTION_SECONDS
             self.shutdown_timer = PreemptibleTimer(MAX_COLLECTION_SECONDS, self._end_collection)
 

--- a/harness/determined/profiler.py
+++ b/harness/determined/profiler.py
@@ -126,7 +126,7 @@ class ProfilerAgent:
         if self.disabled_due_to_preexisting_metrics and self.global_rank == 0:
             logging.warning(
                 f"{LOG_NAMESPACE}: ProfilerAgent is disabled because profiling data for this "
-                f"trial already exists in the DB. No additional profiling data will be generated."
+                f"trial already exists. No additional profiling data is generated after a restart."
             )
 
         # If the ProfilingAgent is disabled, don't waste resources by creating useless threads

--- a/master/internal/grpcutil/auth.go
+++ b/master/internal/grpcutil/auth.go
@@ -105,7 +105,7 @@ func GetUser(ctx context.Context, d *db.PgDB) (*model.User, *model.UserSession, 
 	}
 }
 
-// Return error if user cannot be authenticated or lacks authorization
+// Return error if user cannot be authenticated or lacks authorization.
 func auth(ctx context.Context, db *db.PgDB, fullMethod string) error {
 	if unauthenticatedMethods[fullMethod] {
 		return nil

--- a/master/internal/grpcutil/auth.go
+++ b/master/internal/grpcutil/auth.go
@@ -40,7 +40,7 @@ var (
 	// ErrInvalidCredentials notifies that the provided credentials are invalid or missing.
 	ErrInvalidCredentials = status.Error(codes.Unauthenticated, "invalid credentials")
 	// ErrTokenMissing notifies that the bearer token could not be found.
-	ErrTokenMissing = status.Error(codes.InvalidArgument, "token missing")
+	ErrTokenMissing = status.Error(codes.Unauthenticated, "token missing")
 	// ErrPermissionDenied notifies that the user does not have permission to access the method.
 	ErrPermissionDenied = status.Error(codes.PermissionDenied, "user does not have permission")
 )
@@ -105,13 +105,33 @@ func GetUser(ctx context.Context, d *db.PgDB) (*model.User, *model.UserSession, 
 	}
 }
 
+// Return error if user cannot be authenticated or lacks authorization
+func auth(ctx context.Context, db *db.PgDB, fullMethod string) error {
+	if unauthenticatedMethods[fullMethod] {
+		return nil
+	}
+	if _, err := GetTaskSession(ctx, db); err == ErrTokenMissing {
+		switch u, _, uErr := GetUser(ctx, db); {
+		case uErr != nil:
+			return uErr
+		case !u.Admin && adminMethods[fullMethod]:
+			return ErrPermissionDenied
+		}
+	} else if err != nil && err != ErrTokenMissing {
+		return err
+	}
+	return nil
+}
+
 func streamAuthInterceptor(db *db.PgDB) grpc.StreamServerInterceptor {
 	return func(
 		srv interface{}, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler,
 	) error {
-		if _, _, err := GetUser(ss.Context(), db); err != nil {
+		err := auth(ss.Context(), db, info.FullMethod)
+		if err != nil {
 			return err
 		}
+
 		return handler(srv, ss)
 	}
 }
@@ -120,17 +140,9 @@ func unaryAuthInterceptor(db *db.PgDB) grpc.UnaryServerInterceptor {
 	return func(
 		ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler,
 	) (resp interface{}, err error) {
-		if !unauthenticatedMethods[info.FullMethod] {
-			if _, err = GetTaskSession(ctx, db); err == ErrTokenMissing {
-				switch u, _, uErr := GetUser(ctx, db); {
-				case uErr != nil:
-					return nil, uErr
-				case !u.Admin && adminMethods[info.FullMethod]:
-					return nil, ErrPermissionDenied
-				}
-			} else if err != nil && err != ErrTokenMissing {
-				return nil, err
-			}
+		err = auth(ctx, db, info.FullMethod)
+		if err != nil {
+			return nil, err
 		}
 		return handler(ctx, req)
 	}

--- a/master/test/integration/api/api_trials_test.go
+++ b/master/test/integration/api/api_trials_test.go
@@ -247,7 +247,7 @@ func trialProfilerMetricsAvailableSeriesTests(
 	ctx, _ := context.WithTimeout(creds, time.Minute)
 	tlCl, err := cl.GetTrialProfilerAvailableSeries(ctx, &apiv1.GetTrialProfilerAvailableSeriesRequest{
 		TrialId: int32(trial.ID),
-		Follow: true,
+		Follow:  true,
 	})
 	assert.NilError(t, err, "failed to initiate trial profiler series stream")
 


### PR DESCRIPTION
## Description

Disable profiling if profiling data already exists in the API. This avoids problems around multiple data points with the same batch index, timeseries graphs with large gaps, and confusing data caused by GPU warmup if the user didn't notice the restart.

Also change the POST API function to be passed in to the ProfilingAgent constructor instead of being hardcoded. Making all functions that communicate with the master API easy to overwrite will make it easier to write unit tests without a running master.

Additionally, fix missing task token authentication logic for streaming APIs and unify auth logic across unary and streaming APIs.


## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
