### PR TITLE
chore: fix TF version detection and RNG usage in test

### DIFF
--- a/harness/determined/deploy/gcp/terraform/main.tf
+++ b/harness/determined/deploy/gcp/terraform/main.tf
@@ -1,4 +1,13 @@
 // Configure GCP provider
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/google"
+      version = "~> 3.44.0"
+    }
+  }
+}
+
 provider "google" {
   credentials = var.keypath != null ? file(var.keypath) : null
   project = var.project_id
@@ -16,8 +25,8 @@ provider "google-beta" {
 }
 
 locals {
-  unique_id = "${var.cluster_id}"
-  det_version_key = "${var.det_version_key}"
+  unique_id = var.cluster_id
+  det_version_key = var.det_version_key
 }
 
 terraform {

--- a/harness/determined/deploy/gcp/terraform/main.tf
+++ b/harness/determined/deploy/gcp/terraform/main.tf
@@ -1,13 +1,4 @@
 // Configure GCP provider
-terraform {
-  required_providers {
-    gcp = {
-      source  = "hashicorp/google"
-      version = "~> 3.44.0"
-    }
-  }
-}
-
 provider "google" {
   credentials = var.keypath != null ? file(var.keypath) : null
   project = var.project_id

--- a/harness/determined/deploy/gcp/terraform/main.tf
+++ b/harness/determined/deploy/gcp/terraform/main.tf
@@ -1,7 +1,7 @@
 // Configure GCP provider
 terraform {
   required_providers {
-    aws = {
+    gcp = {
       source  = "hashicorp/google"
       version = "~> 3.44.0"
     }

--- a/harness/determined/deploy/gcp/terraform/modules/compute/main.tf
+++ b/harness/determined/deploy/gcp/terraform/modules/compute/main.tf
@@ -12,7 +12,7 @@ resource "google_compute_instance" "master_instance" {
 
   boot_disk {
     initialize_params {
-      image = "ubuntu-os-cloud/ubuntu-1604-lts"
+      image = "ubuntu-os-cloud/ubuntu-2004-lts"
     }
   }
 

--- a/harness/determined/deploy/gcp/terraform/outputs.tf
+++ b/harness/determined/deploy/gcp/terraform/outputs.tf
@@ -51,5 +51,5 @@ output "SSH-to-Master" {
 }
 
 output "Web-UI" {
-  value = "${module.compute.web_ui}"
+  value = module.compute.web_ui
 }


### PR DESCRIPTION
## Description

This came up in @azhou-determined 's testing of making TensorFlow 2 the default. Turns out this test was only ever running against the default, and additional logic is required for it to run on the right version in the TF1/TF2 tests. And .uniform() may have changed since I last tested this.