### PR TITLE
chore: fix TF version detection and RNG usage in test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,11 +97,11 @@ commands:
       - when:
           condition: <<parameters.tf1>>
           steps:
-            - run: docker pull determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-606fd02
+            - run: docker pull andazhou/environments:py-3.7-pytorch-1.8.1-lightning-1.2-tf-2.4-cpu-254d511
       - when:
           condition: <<parameters.tf2>>
           steps:
-            - run: docker pull determinedai/environments:py-3.7-pytorch-1.7-lightning-1.2-tf-2.4-cpu-606fd02
+            - run: docker pull andazhou/environments:py-3.7-pytorch-1.8.1-lightning-1.2-tf-2.4-cpu-254d511
 
   login-docker:
     parameters:
@@ -615,8 +615,8 @@ commands:
           values-to-override: |
             detVersion=<<parameters.det-version>>,\
             maxSlotsPerPod=<<parameters.gpus-per-machine>>,\
-            taskContainerDefaults.cpuImage=determinedai/environments:cuda-11.0-pytorch-1.7-lightning-1.2-tf-2.4-gpu-0.14.0,\
-            taskContainerDefaults.gpuImage=determinedai/environments:cuda-11.0-pytorch-1.7-lightning-1.2-tf-2.4-gpu-0.14.0,\
+            taskContainerDefaults.cpuImage=andazhou/environments:cuda-11.1-pytorch-1.8.1-lightning-1.2-tf.2.4-gpu-254d511,\
+            taskContainerDefaults.gpuImage=andazhou/environments:cuda-11.1-pytorch-1.8.1-lightning-1.2-tf.2.4-gpu-254d511,\
             checkpointStorage.type=gcs,\
             checkpointStorage.bucket=det-ci
       - set-master-address-gke:
@@ -1550,8 +1550,8 @@ jobs:
       # "CUDA" environment variable is set to 11.
       # TODO: (DET-4918): we should ensure a consistent way to have tests that can run against
       # both major TensorFlow versions do so regularly (but not others).
-      TF1_GPU_IMAGE: determinedai/environments:cuda-11.0-pytorch-1.7-lightning-1.2-tf-2.4-gpu-0.14.0
-      TF2_GPU_IMAGE: determinedai/environments:cuda-11.0-pytorch-1.7-lightning-1.2-tf-2.4-gpu-0.14.0
+      TF1_GPU_IMAGE: andazhou/environments:cuda-11.1-pytorch-1.8.1-lightning-1.2-tf.2.4-gpu-254d511
+      TF2_GPU_IMAGE: andazhou/environments:cuda-11.1-pytorch-1.8.1-lightning-1.2-tf.2.4-gpu-254d511
       CUDA: 11
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,7 +97,7 @@ commands:
       - when:
           condition: <<parameters.tf1>>
           steps:
-            - run: docker pull andazhou/environments:py-3.7-pytorch-1.8.1-lightning-1.2-tf-2.4-cpu-254d511
+            - run: docker pull determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-606fd02
       - when:
           condition: <<parameters.tf2>>
           steps:

--- a/e2e_tests/tests/config.py
+++ b/e2e_tests/tests/config.py
@@ -14,11 +14,11 @@ MAX_TRIAL_BUILD_SECS = 90
 
 DEFAULT_TF1_CPU_IMAGE = "determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-606fd02"
 DEFAULT_TF2_CPU_IMAGE = (
-    "determinedai/environments:py-3.7-pytorch-1.7-lightning-1.2-tf-2.4-cpu-606fd02"
+    "andazhou/environments:py-3.7-pytorch-1.8.1-lightning-1.2-tf-2.4-cpu-254d511"
 )
 DEFAULT_TF1_GPU_IMAGE = "determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-606fd02"
 DEFAULT_TF2_GPU_IMAGE = (
-    "determinedai/environments:cuda-11.0-pytorch-1.7-lightning-1.2-tf-2.4-gpu-606fd02"
+    "andazhou/environments:cuda-11.1-pytorch-1.8.1-lightning-1.2-tf.2.4-gpu-254d511"
 )
 
 TF1_CPU_IMAGE = os.environ.get("TF1_CPU_IMAGE") or DEFAULT_TF1_CPU_IMAGE

--- a/e2e_tests/tests/experiment/test_noop.py
+++ b/e2e_tests/tests/experiment/test_noop.py
@@ -1,6 +1,7 @@
 import copy
 import tempfile
 import time
+from typing import Union
 
 import pytest
 
@@ -252,7 +253,7 @@ def test_startup_hook() -> None:
     )
 
 
-def _test_rng_restore(fixture: str, metrics: list) -> None:
+def _test_rng_restore(fixture: str, metrics: list, tf2: Union[None, bool] = None) -> None:
     """
     This test confirms that an experiment can be restarted from a checkpoint
     with the same RNG state. It requires a test fixture that will emit
@@ -262,8 +263,13 @@ def _test_rng_restore(fixture: str, metrics: list) -> None:
     metrics get worse over time, or by configuring the experiment to keep all
     checkpoints).
     """
-    experiment = exp.run_basic_test(
-        conf.fixtures_path(fixture + "/const.yaml"),
+    config_base = conf.load_config(conf.fixtures_path(fixture + "/const.yaml"))
+    config = copy.deepcopy(config_base)
+    if tf2 is not None:
+        config = conf.set_tf2_image(config) if tf2 else conf.set_tf1_image(config)
+
+    experiment = exp.run_basic_test_with_temp_config(
+        config,
         conf.fixtures_path(fixture),
         1,
     )
@@ -275,11 +281,10 @@ def _test_rng_restore(fixture: str, metrics: list) -> None:
     first_step = first_trial["steps"][0]
     first_checkpoint_id = first_step["checkpoint"]["id"]
 
-    config_base = conf.load_config(conf.fixtures_path(fixture + "/const.yaml"))
-    config_obj = copy.deepcopy(config_base)
-    config_obj["searcher"]["source_checkpoint_uuid"] = first_step["checkpoint"]["uuid"]
+    config = copy.deepcopy(config_base)
+    config["searcher"]["source_checkpoint_uuid"] = first_step["checkpoint"]["uuid"]
 
-    experiment2 = exp.run_basic_test_with_temp_config(config_obj, conf.fixtures_path(fixture), 1)
+    experiment2 = exp.run_basic_test_with_temp_config(config, conf.fixtures_path(fixture), 1)
 
     second_trial = exp.experiment_trials(experiment2)[0]
 
@@ -300,10 +305,15 @@ def _test_rng_restore(fixture: str, metrics: list) -> None:
 
 
 @pytest.mark.e2e_cpu  # type: ignore
-@pytest.mark.tensorflow1_cpu  # type: ignore
-@pytest.mark.tensorflow2_cpu  # type: ignore
-def test_keras_rng_restore() -> None:
-    _test_rng_restore("keras_no_op", ["val_rand_rand", "val_np_rand", "val_tf_rand"])
+@pytest.mark.parametrize(  # type: ignore
+    "tf2",
+    [
+        pytest.param(True, marks=pytest.mark.tensorflow2_cpu),
+        pytest.param(False, marks=pytest.mark.tensorflow1_cpu),
+    ],
+)
+def test_keras_rng_restore(tf2: bool) -> None:
+    _test_rng_restore("keras_no_op", ["val_rand_rand", "val_np_rand", "val_tf_rand"], tf2=tf2)
 
 
 @pytest.mark.e2e_cpu  # type: ignore

--- a/e2e_tests/tests/experiment/test_noop.py
+++ b/e2e_tests/tests/experiment/test_noop.py
@@ -282,6 +282,8 @@ def _test_rng_restore(fixture: str, metrics: list, tf2: Union[None, bool] = None
     first_checkpoint_id = first_step["checkpoint"]["id"]
 
     config = copy.deepcopy(config_base)
+    if tf2 is not None:
+        config = conf.set_tf2_image(config) if tf2 else conf.set_tf1_image(config)
     config["searcher"]["source_checkpoint_uuid"] = first_step["checkpoint"]["uuid"]
 
     experiment2 = exp.run_basic_test_with_temp_config(config, conf.fixtures_path(fixture), 1)

--- a/e2e_tests/tests/fixtures/keras_no_op/model_def.py
+++ b/e2e_tests/tests/fixtures/keras_no_op/model_def.py
@@ -36,7 +36,7 @@ class TensorFlowRandomMetric(tf.keras.metrics.Metric):
     def result(self):
         def my_func(x):
             if version.parse(tf.__version__) >= version.parse("2.0.0"):
-                return tf.random.get_global_generator().uniform()
+                return tf.random.get_global_generator().uniform([1]).numpy()[0]
             else:
                 return 0.0
 

--- a/e2e_tests/tests/fixtures/keras_no_op/model_def.py
+++ b/e2e_tests/tests/fixtures/keras_no_op/model_def.py
@@ -40,7 +40,7 @@ class TensorFlowRandomMetric(tf.keras.metrics.Metric):
             else:
                 return 0.0
 
-        return tf.compat.v1.py_func(my_func, [tf.ones([1], dtype=tf.float64)], tf.float64)
+        return tf.compat.v1.py_func(my_func, [tf.ones([1], dtype=tf.float32)], tf.float32)
 
 
 class NoopKerasTrial(TFKerasTrial):

--- a/e2e_tests/tests/fixtures/keras_no_op/model_def.py
+++ b/e2e_tests/tests/fixtures/keras_no_op/model_def.py
@@ -36,11 +36,11 @@ class TensorFlowRandomMetric(tf.keras.metrics.Metric):
     def result(self):
         def my_func(x):
             if version.parse(tf.__version__) >= version.parse("2.0.0"):
-                return tf.random.get_global_generator().uniform([1]).numpy()[0]
+                return tf.random.get_global_generator().uniform([1], dtype=tf.float64).numpy()[0]
             else:
                 return 0.0
 
-        return tf.compat.v1.py_func(my_func, [tf.ones([1], dtype=tf.float32)], tf.float32)
+        return tf.compat.v1.py_func(my_func, [tf.ones([1], dtype=tf.float64)], tf.float64)
 
 
 class NoopKerasTrial(TFKerasTrial):

--- a/examples/computer_vision/unets_tf_keras/const.yaml
+++ b/examples/computer_vision/unets_tf_keras/const.yaml
@@ -22,4 +22,4 @@ min_validation_period:
 entrypoint: model_def:UNetsTrial
 scheduling_unit: 57
 environment:
-    image: determinedai/environments:cuda-11.0-pytorch-1.7-lightning-1.2-tf-2.4-gpu-606fd02
+    image: andazhou/environments:cuda-11.1-pytorch-1.8.1-lightning-1.2-tf.2.4-gpu-254d511

--- a/examples/decision_trees/gbt_titanic_estimator/adaptive.yaml
+++ b/examples/decision_trees/gbt_titanic_estimator/adaptive.yaml
@@ -42,4 +42,4 @@ searcher:
 entrypoint: model_def:BoostedTreesTrial
 scheduling_unit: 1
 environment:
-  image: "determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-0.14.0"
+  image: "andazhou/environments:py-3.7-pytorch-1.8.1-lightning-1.2-tf-2.4-cpu-254d511"

--- a/examples/decision_trees/gbt_titanic_estimator/const.yaml
+++ b/examples/decision_trees/gbt_titanic_estimator/const.yaml
@@ -20,4 +20,4 @@ searcher:
 entrypoint: model_def:BoostedTreesTrial
 scheduling_unit: 1
 environment:
-  image: "determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-0.14.0"
+  image: "andazhou/environments:py-3.7-pytorch-1.8.1-lightning-1.2-tf-2.4-cpu-254d511"

--- a/examples/gan/dcgan_tf_keras/const.yaml
+++ b/examples/gan/dcgan_tf_keras/const.yaml
@@ -15,5 +15,5 @@ entrypoint: model_def:DCGanTrial
 environment:
   # This model only works with Tensorflow 2.2+.
   image:
-     cpu: "determinedai/environments:py-3.7-pytorch-1.7-lightning-1.2-tf-2.4-cpu-606fd02"
-     gpu: "determinedai/environments:cuda-11.0-pytorch-1.7-lightning-1.2-tf-2.4-gpu-606fd02"
+     cpu: "andazhou/environments:py-3.7-pytorch-1.8.1-lightning-1.2-tf-2.4-cpu-254d511"
+     gpu: "andazhou/environments:cuda-11.1-pytorch-1.8.1-lightning-1.2-tf.2.4-gpu-254d511"

--- a/examples/gan/dcgan_tf_keras/distributed.yaml
+++ b/examples/gan/dcgan_tf_keras/distributed.yaml
@@ -17,5 +17,5 @@ resources:
 environment:
   # This model only works with Tensorflow 2.2+.
   image:
-     cpu: "determinedai/environments:py-3.7-pytorch-1.7-lightning-1.2-tf-2.4-cpu-606fd02"
-     gpu: "determinedai/environments:cuda-11.0-pytorch-1.7-lightning-1.2-tf-2.4-gpu-606fd02"
+     cpu: "andazhou/environments:py-3.7-pytorch-1.8.1-lightning-1.2-tf-2.4-cpu-254d511"
+     gpu: "andazhou/environments:cuda-11.1-pytorch-1.8.1-lightning-1.2-tf.2.4-gpu-254d511"

--- a/examples/gan/gan_mnist_pl/adaptive.yaml
+++ b/examples/gan/gan_mnist_pl/adaptive.yaml
@@ -25,5 +25,5 @@ resources:
 entrypoint: model_def:GANTrial
 environment:
   image:
-    gpu: determinedai/environments:cuda-11.0-pytorch-1.7-lightning-1.2-tf-2.4-gpu-0.14.0
-    cpu: determinedai/environments:py-3.7-pytorch-1.7-lightning-1.2-tf-2.4-cpu-0.14.0
+    gpu: andazhou/environments:cuda-11.1-pytorch-1.8.1-lightning-1.2-tf.2.4-gpu-254d511
+    cpu: andazhou/environments:py-3.7-pytorch-1.8.1-lightning-1.2-tf-2.4-cpu-254d511

--- a/examples/gan/gan_mnist_pl/const.yaml
+++ b/examples/gan/gan_mnist_pl/const.yaml
@@ -16,5 +16,5 @@ searcher:
 entrypoint: model_def:GANTrial
 environment:
   image:
-    gpu: determinedai/environments:cuda-11.0-pytorch-1.7-lightning-1.2-tf-2.4-gpu-0.14.0
-    cpu: determinedai/environments:py-3.7-pytorch-1.7-lightning-1.2-tf-2.4-cpu-0.14.0
+    gpu: andazhou/environments:cuda-11.1-pytorch-1.8.1-lightning-1.2-tf.2.4-gpu-254d511
+    cpu: andazhou/environments:py-3.7-pytorch-1.8.1-lightning-1.2-tf-2.4-cpu-254d511

--- a/examples/gan/gan_mnist_pl/distributed.yaml
+++ b/examples/gan/gan_mnist_pl/distributed.yaml
@@ -25,5 +25,5 @@ resources:
 entrypoint: model_def:GANTrial
 environment:
   image:
-    gpu: determinedai/environments:cuda-11.0-pytorch-1.7-lightning-1.2-tf-2.4-gpu-0.14.0
-    cpu: determinedai/environments:py-3.7-pytorch-1.7-lightning-1.2-tf-2.4-cpu-0.14.0
+    gpu: andazhou/environments:cuda-11.1-pytorch-1.8.1-lightning-1.2-tf.2.4-gpu-254d511
+    cpu: andazhou/environments:py-3.7-pytorch-1.8.1-lightning-1.2-tf-2.4-cpu-254d511

--- a/master/pkg/model/defaults.go
+++ b/master/pkg/model/defaults.go
@@ -25,8 +25,8 @@ const (
 
 // Default task environment docker image names.
 const (
-	defaultCPUImage = "determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-606fd02"
-	defaultGPUImage = "determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-606fd02"
+	defaultCPUImage = "andazhou/environments:py-3.7-pytorch-1.8.1-lightning-1.2-tf-2.4-cpu-254d511"
+	defaultGPUImage = "andazhou/environments:cuda-11.1-pytorch-1.8.1-lightning-1.2-tf.2.4-gpu-254d511"
 )
 
 // DefaultExperimentConfig returns a new default experiment config.

--- a/master/pkg/schemas/expconf/const.go
+++ b/master/pkg/schemas/expconf/const.go
@@ -8,6 +8,6 @@ const (
 
 // Default task environment docker image names.
 const (
-	DefaultCPUImage = "determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-606fd02"
-	DefaultGPUImage = "determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-606fd02"
+	DefaultCPUImage = "andazhou/environments:py-3.7-pytorch-1.8.1-lightning-1.2-tf-2.4-cpu-254d511"
+	DefaultGPUImage = "andazhou/environments:cuda-11.1-pytorch-1.8.1-lightning-1.2-tf.2.4-gpu-254d511"
 )


### PR DESCRIPTION
# Description

This came up in @azhou-determined 's testing of making TensorFlow 2 the default. Turns out this test was only ever running against the default, and additional logic is required for it to run on the right version in the TF1/TF2 tests. And .uniform() may have changed since I last tested this.