### PR TITLE
chore: fix TF version detection and RNG usage in test

### DIFF
--- a/e2e_tests/tests/fixtures/keras_no_op/model_def.py
+++ b/e2e_tests/tests/fixtures/keras_no_op/model_def.py
@@ -36,7 +36,7 @@ class TensorFlowRandomMetric(tf.keras.metrics.Metric):
     def result(self):
         def my_func(x):
             if version.parse(tf.__version__) >= version.parse("2.0.0"):
-                return tf.random.get_global_generator().uniform()
+                return tf.random.get_global_generator().uniform([1], dtype=tf.float64).numpy()[0]
             else:
                 return 0.0
 


### PR DESCRIPTION
## Description

This came up in @azhou-determined 's testing of making TensorFlow 2 the default. Turns out this test was only ever running against the default, and additional logic is required for it to run on the right version in the TF1/TF2 tests. And .uniform() may have changed since I last tested this.

## Test Plan

This is covered by CI