### PR TITLE
fix: generating printable master config does not alter original

### DIFF
--- a/master/internal/config.go
+++ b/master/internal/config.go
@@ -96,7 +96,7 @@ func (c Config) Printable() ([]byte, error) {
 	c.Telemetry.SegmentMasterKey = hiddenValue
 	c.Telemetry.SegmentWebUIKey = hiddenValue
 
-	c.CheckpointStorage.Printable()
+	c.CheckpointStorage = c.CheckpointStorage.Printable()
 
 	optJSON, err := json.Marshal(c)
 	if err != nil {

--- a/master/pkg/schemas/expconf/storage_config.go
+++ b/master/pkg/schemas/expconf/storage_config.go
@@ -49,17 +49,19 @@ func (c *CheckpointStorageConfigV0) UnmarshalJSON(data []byte) error {
 	return errors.Wrap(json.Unmarshal(data, DefaultParser(c)), "failed to parse checkpoint storage")
 }
 
-// Printable modifies the object with secrets hidden.
-func (c *CheckpointStorageConfigV0) Printable() {
+// Printable returns a copy the object with secrets hidden.
+func (c CheckpointStorageConfigV0) Printable() CheckpointStorageConfigV0 {
+	out := schemas.Copy(c).(CheckpointStorageConfigV0)
 	hiddenValue := "********"
-	if c.RawS3Config != nil {
-		if c.RawS3Config.RawAccessKey != nil {
-			c.RawS3Config.RawAccessKey = &hiddenValue
+	if out.RawS3Config != nil {
+		if out.RawS3Config.RawAccessKey != nil {
+			out.RawS3Config.RawAccessKey = &hiddenValue
 		}
-		if c.RawS3Config.RawSecretKey != nil {
-			c.RawS3Config.RawSecretKey = &hiddenValue
+		if out.RawS3Config.RawSecretKey != nil {
+			out.RawS3Config.RawSecretKey = &hiddenValue
 		}
 	}
+	return out
 }
 
 //go:generate ../gen.sh


### PR DESCRIPTION
## Description

Since expconf, any S3 checkpoint storage configured in the master
which included the access key and access secret would be mangled while
generating a printable config, and experiments generated from that
master would no longer work.

## Test Plan

Added a unit test to ensure that generating a printable config does not alter the original.