### PR TITLE
chore: update urllib3

### DIFF
--- a/harness/setup.py
+++ b/harness/setup.py
@@ -43,7 +43,7 @@ setup(
         "requests>=2.22.0",
         # botocore>1.19.0 has stricter urllib3 requirements than boto3, and pip will not reliably
         # resolve it until the --use-feature=2020-resolver behavior in pip 20.3, so we list it here.
-        "urllib3>=1.25.4,<1.26",
+        "urllib3>=1.26.5
         # CLI:
         "argcomplete>=1.9.4",
         "gitpython>=3.1.3",

--- a/harness/setup.py
+++ b/harness/setup.py
@@ -37,12 +37,10 @@ setup(
         "pathspec>=0.6.0",
         "simplejson",
         "termcolor>=1.1.0",
-        # boto3 1.14.11+ has consistent urllib3 requirements which we have to manually resolve.
-        "boto3>=1.14.11",
-        # requests<2.22.0 requires urllib3<1.25, which is incompatible with boto3>=1.14.11
+        # previous releases of boto3 (botocore specifically), urllib3 and requests have had
+        # incompatible interactions that required pinning the versions of these libraries.
+        "boto3>=1.17.87",
         "requests>=2.22.0",
-        # botocore>1.19.0 has stricter urllib3 requirements than boto3, and pip will not reliably
-        # resolve it until the --use-feature=2020-resolver behavior in pip 20.3, so we list it here.
         "urllib3>=1.26.5",
         # CLI:
         "argcomplete>=1.9.4",

--- a/harness/setup.py
+++ b/harness/setup.py
@@ -43,7 +43,7 @@ setup(
         "requests>=2.22.0",
         # botocore>1.19.0 has stricter urllib3 requirements than boto3, and pip will not reliably
         # resolve it until the --use-feature=2020-resolver behavior in pip 20.3, so we list it here.
-        "urllib3>=1.26.5
+        "urllib3>=1.26.5",
         # CLI:
         "argcomplete>=1.9.4",
         "gitpython>=3.1.3",

--- a/harness/setup.py
+++ b/harness/setup.py
@@ -37,11 +37,7 @@ setup(
         "pathspec>=0.6.0",
         "simplejson",
         "termcolor>=1.1.0",
-        # previous releases of boto3 (botocore specifically), urllib3 and requests have had
-        # incompatible interactions that required pinning the versions of these libraries.
-        "boto3>=1.17.87",
-        "requests>=2.22.0",
-        "urllib3>=1.26.5",
+        "boto3",
         # CLI:
         "argcomplete>=1.9.4",
         "gitpython>=3.1.3",


### PR DESCRIPTION
This was highlighted by dependabot. After looking into why it was pinned the way it was, the previous incompatibilities requiring a very specific range of some of these dependencies appear to no longer be an issue. As long as we're past certain minimum versions, things should work better.