### PR TITLE
feat: support .tgz model definitions

### DIFF
--- a/master/internal/api_experiment.go
+++ b/master/internal/api_experiment.go
@@ -24,6 +24,7 @@ import (
 	"github.com/determined-ai/determined/master/internal/hpimportance"
 	"github.com/determined-ai/determined/master/internal/lttb"
 	"github.com/determined-ai/determined/master/pkg/actor"
+	"github.com/determined-ai/determined/master/pkg/archive"
 	"github.com/determined-ai/determined/master/pkg/model"
 	"github.com/determined-ai/determined/master/pkg/protoutils"
 	"github.com/determined-ai/determined/master/pkg/schemas"
@@ -602,7 +603,8 @@ func (a *apiServer) CreateExperiment(
 ) (*apiv1.CreateExperimentResponse, error) {
 	detParams := CreateExperimentParams{
 		ConfigBytes:  req.Config,
-		ModelDef:     filesToArchive(req.ModelDefinition),
+		ModelDef:     archive.ProtoFilesToArchive(req.ModelDefinition),
+		ModelDefTgz:  req.ModelDefinitionTgz,
 		ValidateOnly: req.ValidateOnly,
 	}
 	if req.ParentId != 0 {

--- a/master/internal/api_notebook.go
+++ b/master/internal/api_notebook.go
@@ -12,6 +12,7 @@ import (
 	"github.com/determined-ai/determined/master/internal/grpcutil"
 	"github.com/determined-ai/determined/master/internal/sproto"
 	"github.com/determined-ai/determined/master/pkg/actor"
+	"github.com/determined-ai/determined/master/pkg/archive"
 	"github.com/determined-ai/determined/master/pkg/logger"
 	"github.com/determined-ai/determined/master/pkg/protoutils"
 	"github.com/determined-ai/determined/proto/pkg/apiv1"
@@ -82,10 +83,15 @@ func (a *apiServer) NotebookLogs(
 func (a *apiServer) LaunchNotebook(
 	ctx context.Context, req *apiv1.LaunchNotebookRequest,
 ) (*apiv1.LaunchNotebookResponse, error) {
+	arx, err := archive.FilesOrTgzToArchive(req.Files, req.FilesTgz)
+	if err != nil {
+		return nil, err
+	}
+
 	params, err := a.prepareLaunchParams(ctx, &protoCommandParams{
 		TemplateName: req.TemplateName,
 		Config:       req.Config,
-		Files:        req.Files,
+		Files:        arx,
 	})
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to prepare launch params")

--- a/master/internal/api_shell.go
+++ b/master/internal/api_shell.go
@@ -8,6 +8,7 @@ import (
 	"github.com/determined-ai/determined/master/internal/command"
 	"github.com/determined-ai/determined/master/internal/sproto"
 	"github.com/determined-ai/determined/master/pkg/actor"
+	"github.com/determined-ai/determined/master/pkg/archive"
 	"github.com/determined-ai/determined/master/pkg/protoutils"
 	"github.com/determined-ai/determined/proto/pkg/apiv1"
 	"github.com/determined-ai/determined/proto/pkg/shellv1"
@@ -39,10 +40,15 @@ func (a *apiServer) KillShell(
 func (a *apiServer) LaunchShell(
 	ctx context.Context, req *apiv1.LaunchShellRequest,
 ) (*apiv1.LaunchShellResponse, error) {
+	arx, err := archive.FilesOrTgzToArchive(req.Files, req.FilesTgz)
+	if err != nil {
+		return nil, err
+	}
+
 	params, err := a.prepareLaunchParams(ctx, &protoCommandParams{
 		TemplateName: req.TemplateName,
 		Config:       req.Config,
-		Files:        req.Files,
+		Files:        arx,
 		Data:         req.Data,
 	})
 	if err != nil {

--- a/proto/src/determined/api/v1/command.proto
+++ b/proto/src/determined/api/v1/command.proto
@@ -73,10 +73,12 @@ message LaunchCommandRequest {
   google.protobuf.Struct config = 1;
   // Template name.
   string template_name = 2;
-  // The files to run with the command.
+  // The files to run with the command (deprecated).
   repeated determined.util.v1.File files = 3;
   // Additional data.
   bytes data = 4;
+  // The files to run with the command.
+  optional bytes files_tgz = 5;
 }
 // Response to LaunchCommandRequest.
 message LaunchCommandResponse {

--- a/proto/src/determined/api/v1/experiment.proto
+++ b/proto/src/determined/api/v1/experiment.proto
@@ -248,7 +248,7 @@ message GetExperimentValidationHistoryResponse {
 
 // Request to create a new experiment.
 message CreateExperimentRequest {
-  // Experiment context.
+  // Experiment context (deprecated format).
   repeated determined.util.v1.File model_definition = 1;
   // Experiment config (YAML).
   string config = 2;
@@ -256,6 +256,8 @@ message CreateExperimentRequest {
   bool validate_only = 3;
   // Parent experiment id.
   int32 parent_id = 4;
+  // Experiment context.
+  optional bytes model_definition_tgz = 5;
 }
 // Response to CreateExperimentRequest.
 message CreateExperimentResponse {

--- a/proto/src/determined/api/v1/notebook.proto
+++ b/proto/src/determined/api/v1/notebook.proto
@@ -93,10 +93,12 @@ message LaunchNotebookRequest {
   google.protobuf.Struct config = 1;
   // Template name.
   string template_name = 2;
-  // The files to run with the command.
+  // The files to run with the command (deprecated).
   repeated determined.util.v1.File files = 3;
   // Preview a launching request without actually creating a Notebook.
   bool preview = 4;
+  // The files to run with the command.
+  optional bytes files_tgz = 5;
 }
 // Response to LaunchNotebookRequest.
 message LaunchNotebookResponse {

--- a/proto/src/determined/api/v1/shell.proto
+++ b/proto/src/determined/api/v1/shell.proto
@@ -73,10 +73,12 @@ message LaunchShellRequest {
   google.protobuf.Struct config = 1;
   // Template name.
   string template_name = 2;
-  // The files to run with the command.
+  // The files to run with the command (deprecated).
   repeated determined.util.v1.File files = 3;
   // Additional data.
   bytes data = 4;
+  // The files to run with the command.
+  optional bytes files_tgz = 5;
 }
 // Response to LaunchShellRequest.
 message LaunchShellResponse {

--- a/proto/src/determined/api/v1/tensorboard.proto
+++ b/proto/src/determined/api/v1/tensorboard.proto
@@ -78,8 +78,10 @@ message LaunchTensorboardRequest {
   google.protobuf.Struct config = 3;
   // Tensorboard template name.
   string template_name = 4;
-  // The files to run with the command.
+  // The files to run with the command( (deprecated).
   repeated determined.util.v1.File files = 5;
+  // The files to run with the command.
+  optional bytes files_tgz = 6;
 }
 // Response to LaunchTensorboardRequest.
 message LaunchTensorboardResponse {


### PR DESCRIPTION
The determined-master has always taken an unorthodox
tarball-over-json-like file format for specifying context directories
(notably for POST experiment, but also for all varieties of commands).

The new format is to post the contents of a gzipped tarball directly.

In all cases, the master supports both the old and the new formats via
different arguments.  This is important because it is fairly common for
users to run old cli's against new masters, and it is only a small
amount of shimming code to give those users an excellent experience.