### PR TITLE
chore: allow non-singleton Authentication

### DIFF
--- a/.circleci/scripts/wait_for_master.py
+++ b/.circleci/scripts/wait_for_master.py
@@ -4,11 +4,12 @@ import time
 import requests
 
 from determined.common import api
+from determined.common.api import certs
 
 
 def _wait_for_master(address: str) -> None:
     print("Checking for master at", address)
-    cert = api.request.Cert(noverify=True)
+    cert = certs.Cert(noverify=True)
     for _ in range(150):
         try:
             r = api.get(address, "info", authenticated=False, cert=cert)

--- a/.circleci/scripts/wait_for_master.py
+++ b/.circleci/scripts/wait_for_master.py
@@ -8,10 +8,10 @@ from determined.common import api
 
 def _wait_for_master(address: str) -> None:
     print("Checking for master at", address)
-    api.request.set_master_cert_bundle(False)
+    cert = api.Request.Cert(noverify=True)
     for _ in range(150):
         try:
-            r = api.get(address, "info", authenticated=False)
+            r = api.get(address, "info", authenticated=False, cert=cert)
             if r.status_code == requests.codes.ok:
                 return
         except api.errors.MasterNotFoundException:

--- a/.circleci/scripts/wait_for_master.py
+++ b/.circleci/scripts/wait_for_master.py
@@ -8,7 +8,7 @@ from determined.common import api
 
 def _wait_for_master(address: str) -> None:
     print("Checking for master at", address)
-    cert = api.Request.Cert(noverify=True)
+    cert = api.request.Cert(noverify=True)
     for _ in range(150):
         try:
             r = api.get(address, "info", authenticated=False, cert=cert)

--- a/e2e_tests/tests/cluster/cluster.py
+++ b/e2e_tests/tests/cluster/cluster.py
@@ -4,8 +4,8 @@ from typing import Any, Dict, List
 
 import requests
 
-import determined.common.api.authentication as auth
 from determined.common import api
+from determined.common.api import authentication
 from tests import config as conf
 
 
@@ -19,7 +19,7 @@ def cluster_slots() -> Dict[str, Any]:
     cluster_slots returns a dict of slots that each agent has.
     :return:  Dict[AgentID, List[Slot]]
     """
-    auth.initialize_session(conf.make_master_url(), try_reauth=True)
+    authentication.cli_auth = authentication.Authentication(conf.make_master_url(), try_reauth=True)
     r = api.get(conf.make_master_url(), "agents")
     assert r.status_code == requests.codes.ok, r.text
     json = r.json()  # type: Dict[str, Any]
@@ -67,7 +67,7 @@ def wait_for_agents(min_agent_count: int) -> None:
 
 
 def num_agents() -> int:
-    auth.initialize_session(conf.make_master_url(), try_reauth=True)
+    authentication.cli_auth = authentication.Authentication(conf.make_master_url(), try_reauth=True)
     r = api.get(conf.make_master_url(), "agents")
     assert r.status_code == requests.codes.ok, r.text
 

--- a/e2e_tests/tests/command/command.py
+++ b/e2e_tests/tests/command/command.py
@@ -6,8 +6,8 @@ from typing import IO, Any, Generator, Optional
 
 import requests
 
-import determined.common.api.authentication as auth
 from determined.common import api
+from determined.common.api import authentication
 from tests import config as conf
 
 
@@ -81,7 +81,7 @@ def interactive_command(*args: str) -> Generator:
 
 
 def get_num_running_commands() -> int:
-    auth.initialize_session(conf.make_master_url(), try_reauth=True)
+    authentication.cli_auth = authentication.Authentication(conf.make_master_url(), try_reauth=True)
     r = api.get(conf.make_master_url(), "api/v1/commands")
     assert r.status_code == requests.codes.ok, r.text
 
@@ -89,7 +89,7 @@ def get_num_running_commands() -> int:
 
 
 def get_command(id: str) -> Any:
-    auth.initialize_session(conf.make_master_url(), try_reauth=True)
+    authentication.cli_auth = authentication.Authentication(conf.make_master_url(), try_reauth=True)
     r = api.get(conf.make_master_url(), "api/v1/commands/" + id)
     assert r.status_code == requests.codes.ok, r.text
     return r.json()["command"]

--- a/e2e_tests/tests/experiment/experiment.py
+++ b/e2e_tests/tests/experiment/experiment.py
@@ -13,9 +13,9 @@ import dateutil.parser
 import pytest
 import requests
 
-import determined.common.api.authentication as auth
 from determined import experimental
 from determined.common import api, yaml
+from determined.common.api import authentication
 from tests import cluster
 from tests import config as conf
 
@@ -91,7 +91,7 @@ def activate_experiment(experiment_id: int) -> None:
 
 
 def change_experiment_state(experiment_id: int, new_state: str) -> None:
-    auth.initialize_session(conf.make_master_url(), try_reauth=True)
+    authentication.cli_auth = authentication.Authentication(conf.make_master_url(), try_reauth=True)
     r = api.patch(
         conf.make_master_url(),
         "experiments/{}".format(experiment_id),
@@ -170,7 +170,7 @@ def experiment_has_active_workload(experiment_id: int) -> bool:
 
 
 def experiment_json(experiment_id: int) -> Dict[str, Any]:
-    auth.initialize_session(conf.make_master_url(), try_reauth=True)
+    authentication.cli_auth = authentication.Authentication(conf.make_master_url(), try_reauth=True)
     r = api.get(conf.make_master_url(), "experiments/{}".format(experiment_id))
     assert r.status_code == requests.codes.ok, r.text
     json = r.json()  # type: Dict[str, Any]
@@ -188,7 +188,7 @@ def experiment_trials(experiment_id: int) -> List[Dict[str, Any]]:
 
 
 def num_experiments() -> int:
-    auth.initialize_session(conf.make_master_url(), try_reauth=True)
+    authentication.cli_auth = authentication.Authentication(conf.make_master_url(), try_reauth=True)
     r = api.get(conf.make_master_url(), "experiments")
     assert r.status_code == requests.codes.ok, r.text
     return len(r.json())
@@ -210,7 +210,7 @@ def is_terminal_state(state: str) -> bool:
 
 
 def trial_metrics(trial_id: int) -> Dict[str, Any]:
-    auth.initialize_session(conf.make_master_url(), try_reauth=True)
+    authentication.cli_auth = authentication.Authentication(conf.make_master_url(), try_reauth=True)
     r = api.get(conf.make_master_url(), "trials/{}/metrics".format(trial_id))
     assert r.status_code == requests.codes.ok, r.text
     json = r.json()  # type: Dict[str, Any]
@@ -240,7 +240,7 @@ def num_error_trials(experiment_id: int) -> int:
 
 
 def trial_logs(trial_id: int) -> List[str]:
-    auth.initialize_session(conf.make_master_url(), try_reauth=True)
+    authentication.cli_auth = authentication.Authentication(conf.make_master_url(), try_reauth=True)
     return [tl["message"] for tl in api.trial_logs(conf.make_master_url(), trial_id)]
 
 

--- a/e2e_tests/tests/experiment/test_metrics.py
+++ b/e2e_tests/tests/experiment/test_metrics.py
@@ -4,8 +4,8 @@ from typing import Set, Union
 
 import pytest
 
-import determined.common.api.authentication as auth
 from determined.common import api
+from determined.common.api import authentication
 from tests import config as conf
 from tests import experiment as exp
 
@@ -13,7 +13,7 @@ from tests import experiment as exp
 @pytest.mark.e2e_cpu  # type: ignore
 @pytest.mark.timeout(600)  # type: ignore
 def test_streaming_metrics_api() -> None:
-    auth.initialize_session(conf.make_master_url(), try_reauth=True)
+    authentication.cli_auth = authentication.Authentication(conf.make_master_url(), try_reauth=True)
 
     pool = mp.pool.ThreadPool(processes=7)
 
@@ -63,7 +63,7 @@ def test_streaming_metrics_api() -> None:
 @pytest.mark.distributed  # type: ignore
 @pytest.mark.timeout(1800)  # type: ignore
 def test_hp_importance_api() -> None:
-    auth.initialize_session(conf.make_master_url(), try_reauth=True)
+    authentication.cli_auth = authentication.Authentication(conf.make_master_url(), try_reauth=True)
 
     pool = mp.pool.ThreadPool(processes=1)
 

--- a/e2e_tests/tests/experiment/test_profiling.py
+++ b/e2e_tests/tests/experiment/test_profiling.py
@@ -6,8 +6,8 @@ import pytest
 import simplejson
 import yaml
 
-import determined.common.api.authentication as auth
 from determined.common import api
+from determined.common.api import authentication
 from tests import config as conf
 from tests import experiment as exp
 
@@ -25,7 +25,8 @@ from tests import experiment as exp
 def test_streaming_observability_metrics_apis(
     framework_base_experiment: str, framework_timings_enabled: bool
 ) -> None:
-    auth.initialize_session(conf.make_master_url(), try_reauth=True)
+    # TODO: refactor profiling to not use cli singleton auth.
+    authentication.cli_auth = authentication.Authentication(conf.make_master_url(), try_reauth=True)
 
     config_path = conf.tutorials_path(f"../{framework_base_experiment}/const.yaml")
     model_def_path = conf.tutorials_path(f"../{framework_base_experiment}")

--- a/e2e_tests/tests/test_users.py
+++ b/e2e_tests/tests/test_users.py
@@ -12,26 +12,26 @@ import pytest
 from pexpect import spawn
 
 from determined.common import constants, yaml
-from determined.common.api.authentication import Authentication, Credentials, TokenStore
+from determined.common.api import authentication
 from tests import command
 from tests import config as conf
 from tests import experiment as exp
 from tests.filetree import FileTree
 
 EXPECT_TIMEOUT = 5
-ADMIN_CREDENTIALS = Credentials("admin", "")
+ADMIN_CREDENTIALS = authentication.Credentials("admin", "")
 
 
 @pytest.fixture(scope="session")  # type: ignore
-def auth() -> Authentication:
-    a = Authentication.instance()
-    a.reset_session()
-    yield a
-    TokenStore.delete_token_cache()
+def auth() -> authentication.Authentication:
+    authentication.cli_auth = None
+    yield authentication.cli_auth
+    authentication.cli_auth = None
+    authentication.TokenStore.delete_token_cache()
 
 
 @contextlib.contextmanager
-def logged_in_user(credentials: Credentials) -> Generator:
+def logged_in_user(credentials: authentication.Credentials) -> Generator:
     assert log_in_user(credentials) == 0
     yield
     assert log_out_user() == 0
@@ -52,7 +52,7 @@ def det_run(args: List[str]) -> str:
     )
 
 
-def log_in_user(credentials: Credentials) -> int:
+def log_in_user(credentials: authentication.Credentials) -> int:
     username, password = credentials
     child = det_spawn(["user", "login", username])
     child.setecho(True)
@@ -64,7 +64,7 @@ def log_in_user(credentials: Credentials) -> int:
     return cast(int, child.exitstatus)
 
 
-def create_user(n_username: str, admin_credentials: Credentials) -> None:
+def create_user(n_username: str, admin_credentials: authentication.Credentials) -> None:
     a_username, a_password = admin_credentials
 
     child = det_spawn(["-u", a_username, "user", "create", n_username])
@@ -88,7 +88,7 @@ def create_user(n_username: str, admin_credentials: Credentials) -> None:
 
 
 def change_user_password(
-    target_username: str, target_password: str, admin_credentials: Credentials
+    target_username: str, target_password: str, admin_credentials: authentication.Credentials
 ) -> int:
     a_username, a_password = admin_credentials
 
@@ -112,7 +112,9 @@ def change_user_password(
     return cast(int, child.exitstatus)
 
 
-def create_test_user(admin_credentials: Credentials, add_password: bool = False) -> Credentials:
+def create_test_user(
+    admin_credentials: authentication.Credentials, add_password: bool = False
+) -> authentication.Credentials:
     username = get_random_string()
     create_user(username, admin_credentials)
 
@@ -121,7 +123,7 @@ def create_test_user(admin_credentials: Credentials, add_password: bool = False)
         password = get_random_string()
         assert change_user_password(username, password, admin_credentials) == 0
 
-    return Credentials(username, password)
+    return authentication.Credentials(username, password)
 
 
 def log_out_user(username: Optional[str] = None) -> int:
@@ -175,7 +177,7 @@ def extract_id_and_owner_from_exp_list(output: str) -> List[Tuple[int, str]]:
 
 
 @pytest.mark.e2e_cpu  # type: ignore
-def test_logout(auth: Authentication) -> None:
+def test_logout(auth: authentication.Authentication) -> None:
     creds = create_test_user(ADMIN_CREDENTIALS, True)
 
     # Set Determined passwordto something in order to disable auto-login.
@@ -201,7 +203,7 @@ def test_logout(auth: Authentication) -> None:
     assert child.exitstatus != 0
 
     # Log in as determined.
-    log_in_user(Credentials(constants.DEFAULT_DETERMINED_USER, password))
+    log_in_user(authentication.Credentials(constants.DEFAULT_DETERMINED_USER, password))
 
     # Log back in as new user.
     log_in_user(creds)
@@ -222,7 +224,7 @@ def test_logout(auth: Authentication) -> None:
 
 
 @pytest.mark.e2e_cpu  # type: ignore
-def test_activate_deactivate(auth: Authentication) -> None:
+def test_activate_deactivate(auth: authentication.Authentication) -> None:
     creds = create_test_user(ADMIN_CREDENTIALS, True)
 
     # Make sure we can log in as the user.
@@ -245,7 +247,7 @@ def test_activate_deactivate(auth: Authentication) -> None:
 
 
 @pytest.mark.e2e_cpu  # type: ignore
-def test_change_password(auth: Authentication) -> None:
+def test_change_password(auth: authentication.Authentication) -> None:
     # Create a user without a password.
     creds = create_test_user(ADMIN_CREDENTIALS, False)
 
@@ -258,11 +260,11 @@ def test_change_password(auth: Authentication) -> None:
     newPassword = get_random_string()
     assert change_user_password(creds.username, newPassword, ADMIN_CREDENTIALS) == 0
 
-    assert log_in_user(Credentials(creds.username, newPassword)) == 0
+    assert log_in_user(authentication.Credentials(creds.username, newPassword)) == 0
 
 
 @pytest.mark.e2e_cpu  # type: ignore
-def test_experiment_creation_and_listing(auth: Authentication) -> None:
+def test_experiment_creation_and_listing(auth: authentication.Authentication) -> None:
     # Create 2 users.
     creds1 = create_test_user(ADMIN_CREDENTIALS, True)
 
@@ -387,7 +389,7 @@ def kill_tensorboards(*tensorboard_ids: str) -> None:
 
 
 @pytest.mark.e2e_cpu  # type: ignore
-def test_notebook_creation_and_listing(auth: Authentication) -> None:
+def test_notebook_creation_and_listing(auth: authentication.Authentication) -> None:
     creds1 = create_test_user(ADMIN_CREDENTIALS, True)
     creds2 = create_test_user(ADMIN_CREDENTIALS, True)
 
@@ -415,7 +417,7 @@ def test_notebook_creation_and_listing(auth: Authentication) -> None:
 
 
 @pytest.mark.e2e_cpu  # type: ignore
-def test_tensorboard_creation_and_listing(auth: Authentication) -> None:
+def test_tensorboard_creation_and_listing(auth: authentication.Authentication) -> None:
     creds1 = create_test_user(ADMIN_CREDENTIALS, True)
     creds2 = create_test_user(ADMIN_CREDENTIALS, True)
 
@@ -452,7 +454,7 @@ def test_tensorboard_creation_and_listing(auth: Authentication) -> None:
 
 
 @pytest.mark.e2e_cpu  # type: ignore
-def test_command_creation_and_listing(auth: Authentication) -> None:
+def test_command_creation_and_listing(auth: authentication.Authentication) -> None:
     creds1 = create_test_user(ADMIN_CREDENTIALS, True)
     creds2 = create_test_user(ADMIN_CREDENTIALS, True)
 
@@ -472,7 +474,7 @@ def test_command_creation_and_listing(auth: Authentication) -> None:
         assert (command_id2, creds2.username) in output
 
 
-def create_linked_user(uid: int, user: str, gid: int, group: str) -> Credentials:
+def create_linked_user(uid: int, user: str, gid: int, group: str) -> authentication.Credentials:
     admin_username, *_rest = ADMIN_CREDENTIALS
 
     user_creds = create_test_user(ADMIN_CREDENTIALS, False)
@@ -503,7 +505,7 @@ def create_linked_user(uid: int, user: str, gid: int, group: str) -> Credentials
 
 
 @pytest.mark.e2e_cpu  # type: ignore
-def test_link_with_agent_user(auth: Authentication) -> None:
+def test_link_with_agent_user(auth: authentication.Authentication) -> None:
     user = create_linked_user(200, "someuser", 300, "somegroup")
 
     expected_output = "someuser:200:somegroup:300"
@@ -518,7 +520,7 @@ def test_link_with_agent_user(auth: Authentication) -> None:
 
 
 @pytest.mark.e2e_cpu  # type: ignore
-def test_link_with_large_uid(auth: Authentication) -> None:
+def test_link_with_large_uid(auth: authentication.Authentication) -> None:
     user = create_linked_user(2000000000, "someuser", 2000000000, "somegroup")
 
     expected_output = "someuser:2000000000:somegroup:2000000000"
@@ -533,7 +535,7 @@ def test_link_with_large_uid(auth: Authentication) -> None:
 
 
 @pytest.mark.e2e_cpu  # type: ignore
-def test_link_with_existing_agent_user(auth: Authentication) -> None:
+def test_link_with_existing_agent_user(auth: authentication.Authentication) -> None:
     user = create_linked_user(65534, "nobody", 65534, "nogroup")
 
     expected_output = "nobody:65534:nogroup:65534"
@@ -575,7 +577,7 @@ def non_tmp_shared_fs_path() -> Generator:
 
 
 @pytest.mark.e2e_cpu  # type: ignore
-def test_non_root_experiment(auth: Authentication, tmp_path: pathlib.Path) -> None:
+def test_non_root_experiment(auth: authentication.Authentication, tmp_path: pathlib.Path) -> None:
     user = create_linked_user(65534, "nobody", 65534, "nogroup")
 
     with logged_in_user(user):
@@ -605,22 +607,25 @@ def test_non_root_experiment(auth: Authentication, tmp_path: pathlib.Path) -> No
 
 
 @pytest.mark.e2e_cpu  # type: ignore
-def test_link_without_agent_user(auth: Authentication) -> None:
+def test_link_without_agent_user(auth: authentication.Authentication) -> None:
     user = create_test_user(ADMIN_CREDENTIALS, False)
 
     expected_output = "root:0:root:0"
     with logged_in_user(user), command.interactive_command(
         "cmd", "run", "bash", "-c", "echo $(id -u -n):$(id -u):$(id -g -n):$(id -g)"
     ) as cmd:
+        recvd = []
         for line in cmd.stdout:
             if expected_output in line:
                 break
+            recvd.append(line)
         else:
-            raise AssertionError(f"Did not find {expected_output} in output")
+            output = "".join(recvd)
+            raise AssertionError(f"Did not find {expected_output} in output:\n{output}")
 
 
 @pytest.mark.e2e_cpu  # type: ignore
-def test_non_root_shell(auth: Authentication, tmp_path: pathlib.Path) -> None:
+def test_non_root_shell(auth: authentication.Authentication, tmp_path: pathlib.Path) -> None:
     user = create_linked_user(1234, "someuser", 1234, "somegroup")
 
     expected_output = "someuser:1234:somegroup:1234"

--- a/harness/determined/cli/agent.py
+++ b/harness/determined/cli/agent.py
@@ -7,7 +7,7 @@ from typing import Any, Callable, List
 
 from determined.cli import render
 from determined.common import api
-from determined.common.api.authentication import authentication_required
+from determined.common.api import authentication
 from determined.common.check import check_false
 from determined.common.declarative_argparse import Arg, Cmd, Group
 
@@ -16,7 +16,7 @@ def local_id(address: str) -> str:
     return os.path.basename(address)
 
 
-@authentication_required
+@authentication.required
 def list_agents(args: argparse.Namespace) -> None:
     r = api.get(args.master, "agents")
 
@@ -45,7 +45,7 @@ def list_agents(args: argparse.Namespace) -> None:
     render.tabulate_or_csv(headers, values, args.csv)
 
 
-@authentication_required
+@authentication.required
 def list_slots(args: argparse.Namespace) -> None:
     task_res = api.get(args.master, "tasks")
     agent_res = api.get(args.master, "agents")
@@ -101,7 +101,7 @@ def list_slots(args: argparse.Namespace) -> None:
 
 
 def patch_agent(enabled: bool) -> Callable[[argparse.Namespace], None]:
-    @authentication_required
+    @authentication.required
     def patch(args: argparse.Namespace) -> None:
         check_false(args.all and args.agent_id)
 
@@ -128,7 +128,7 @@ def patch_agent(enabled: bool) -> Callable[[argparse.Namespace], None]:
 
 
 def patch_slot(enabled: bool) -> Callable[[argparse.Namespace], None]:
-    @authentication_required
+    @authentication.required
     def patch(args: argparse.Namespace) -> None:
         path = "agents/{}/slots/{}".format(args.agent_id, args.slot_id)
         headers = {"Content-Type": "application/merge-patch+json"}

--- a/harness/determined/cli/checkpoint.py
+++ b/harness/determined/cli/checkpoint.py
@@ -3,7 +3,7 @@ from argparse import Namespace
 from typing import Any, Dict, List, Optional
 
 from determined.common import api, constants, experimental
-from determined.common.api.authentication import authentication_required
+from determined.common.api import authentication
 from determined.common.declarative_argparse import Arg, Cmd
 from determined.common.experimental import Determined
 
@@ -59,7 +59,7 @@ def render_checkpoint(checkpoint: experimental.Checkpoint, path: Optional[str] =
     render.tabulate_or_csv(headers, [values], False)
 
 
-@authentication_required
+@authentication.required
 def list(args: Namespace) -> None:
     params = {}
     if args.best is not None:

--- a/harness/determined/cli/cli.py
+++ b/harness/determined/cli/cli.py
@@ -1,5 +1,4 @@
 import hashlib
-import os
 import socket
 import ssl
 import sys
@@ -32,7 +31,7 @@ from determined.cli.user import args_description as user_args_description
 from determined.cli.version import args_description as version_args_description
 from determined.cli.version import check_version
 from determined.common import api, yaml
-from determined.common.api import authentication
+from determined.common.api import authentication, certs
 from determined.common.check import check_not_none
 from determined.common.declarative_argparse import Arg, Cmd, add_args
 from determined.common.util import (
@@ -223,9 +222,8 @@ def main(args: List[str] = sys.argv[1:]) -> None:
             parser.print_usage()
             parser.exit(2, "{}: no subcommand specified\n".format(parser.prog))
 
-        cert_fn = str(authentication.get_config_path().joinpath("master.crt"))
-        if os.path.exists(cert_fn):
-            api.request.set_master_cert_bundle(cert_fn)
+        # Configure the CLI's Cert singleton.
+        certs.cli_cert = certs.default_load(parsed_args.master)
 
         try:
             # For `det deploy`, skip interaction with master.
@@ -270,9 +268,9 @@ def main(args: List[str] = sys.argv[1:]) -> None:
                 ):
                     die("Unable to verify master certificate")
 
-                with open(cert_fn, "w") as out:
-                    out.write(cert_pem_data)
-                api.request.set_master_cert_bundle(cert_fn)
+                certs.set_cert(certs.default_store(), parsed_args.master, cert_pem_data)
+                # Reconfigure the CLI's Cert singleton.
+                certs.cli_cert = certs.Cert(cert_pem=cert_pem_data)
 
                 check_version(parsed_args)
 

--- a/harness/determined/cli/cli.py
+++ b/harness/determined/cli/cli.py
@@ -15,7 +15,6 @@ from termcolor import colored
 
 import determined
 import determined.cli
-import determined.common.api.authentication as auth
 from determined.cli import checkpoint, experiment, render
 from determined.cli.agent import args_description as agent_args_description
 from determined.cli.master import args_description as master_args_description
@@ -33,7 +32,7 @@ from determined.cli.user import args_description as user_args_description
 from determined.cli.version import args_description as version_args_description
 from determined.cli.version import check_version
 from determined.common import api, yaml
-from determined.common.api.authentication import authentication_required
+from determined.common.api import authentication
 from determined.common.check import check_not_none
 from determined.common.declarative_argparse import Arg, Cmd, add_args
 from determined.common.util import (
@@ -48,7 +47,7 @@ from determined.deploy.cli import args_description as deploy_args_description
 from .errors import EnterpriseOnlyError
 
 
-@authentication_required
+@authentication.required
 def list_tasks(args: Namespace) -> None:
     r = api.get(args.master, "tasks")
 
@@ -90,7 +89,7 @@ def list_tasks(args: Namespace) -> None:
     render.tabulate_or_csv(headers, values, args.csv)
 
 
-@authentication_required
+@authentication.required
 def preview_search(args: Namespace) -> None:
     experiment_config = safe_load_yaml_with_exceptions(args.config_file)
     args.config_file.close()
@@ -224,7 +223,7 @@ def main(args: List[str] = sys.argv[1:]) -> None:
             parser.print_usage()
             parser.exit(2, "{}: no subcommand specified\n".format(parser.prog))
 
-        cert_fn = str(auth.get_config_path().joinpath("master.crt"))
+        cert_fn = str(authentication.get_config_path().joinpath("master.crt"))
         if os.path.exists(cert_fn):
             api.request.set_master_cert_bundle(cert_fn)
 

--- a/harness/determined/cli/cli.py
+++ b/harness/determined/cli/cli.py
@@ -268,7 +268,7 @@ def main(args: List[str] = sys.argv[1:]) -> None:
                 ):
                     die("Unable to verify master certificate")
 
-                certs.set_cert(certs.default_store(), parsed_args.master, cert_pem_data)
+                certs.CertStore(certs.default_store()).set_cert(parsed_args.master, cert_pem_data)
                 # Reconfigure the CLI's Cert singleton.
                 certs.cli_cert = certs.Cert(cert_pem=cert_pem_data)
 

--- a/harness/determined/cli/command.py
+++ b/harness/determined/cli/command.py
@@ -9,7 +9,7 @@ from termcolor import colored
 
 from determined.cli import render
 from determined.common import api, context, util, yaml
-from determined.common.api.authentication import authentication_required
+from determined.common.api import authentication
 
 CONFIG_DESC = """
 Additional configuration arguments for setting up a command.
@@ -120,7 +120,7 @@ Command = namedtuple(
 )
 
 
-@authentication_required
+@authentication.required
 def list(args: Namespace) -> None:
     api_path = RemoteTaskNewAPIs[args._command]
     api_full_path = "api/v1/{}".format(api_path)
@@ -129,7 +129,7 @@ def list(args: Namespace) -> None:
     if args.all:
         params = {}  # type: Dict[str, Any]
     else:
-        params = {"users": [api.Authentication.instance().get_session_user()]}
+        params = {"users": [authentication.must_cli_auth().get_session_user()]}
 
     res = api.get(args.master, api_full_path, params=params).json()[api_path]
 
@@ -144,7 +144,7 @@ def list(args: Namespace) -> None:
     render.render_table(res, table_header)
 
 
-@authentication_required
+@authentication.required
 def kill(args: Namespace) -> None:
     ids = RemoteTaskGetIDsFunc[args._command](args)  # type: ignore
     name = RemoteTaskName[args._command]
@@ -162,7 +162,7 @@ def kill(args: Namespace) -> None:
             print(colored("Skipping: {} ({})".format(e, type(e).__name__), "red"))
 
 
-@authentication_required
+@authentication.required
 def config(args: Namespace) -> None:
     name = RemoteTaskName[args._command]
     api_full_path = "api/v1/{}/{}".format(RemoteTaskNewAPIs[args._command], args.id)
@@ -170,7 +170,7 @@ def config(args: Namespace) -> None:
     print(render.format_object_as_yaml(res_json["config"]))
 
 
-@authentication_required
+@authentication.required
 def tail_logs(args: Namespace) -> None:
     api_full_path = "{}/{}/events?follow={}&tail={}".format(
         RemoteTaskOldAPIs[args._command],

--- a/harness/determined/cli/experiment.py
+++ b/harness/determined/cli/experiment.py
@@ -16,7 +16,7 @@ import tabulate
 import determined.common
 from determined.cli import checkpoint, render
 from determined.common import api, constants, context, util, yaml
-from determined.common.api.authentication import authentication_required
+from determined.common.api import authentication
 from determined.common.declarative_argparse import Arg, Cmd, Group
 from determined.common.experimental import Determined
 
@@ -31,19 +31,19 @@ def patch_experiment(args: Namespace, verb: str, patch_doc: Dict[str, Any]) -> N
     api.patch_experiment(args.master, args.experiment_id, patch_doc)
 
 
-@authentication_required
+@authentication.required
 def activate(args: Namespace) -> None:
     api.activate_experiment(args.master, args.experiment_id)
     print("Activated experiment {}".format(args.experiment_id))
 
 
-@authentication_required
+@authentication.required
 def archive(args: Namespace) -> None:
     patch_experiment(args, "archive", {"archived": True})
     print("Archived experiment {}".format(args.experiment_id))
 
 
-@authentication_required
+@authentication.required
 def cancel(args: Namespace) -> None:
     patch_experiment(args, "cancel", {"state": "STOPPING_CANCELED"})
     print("Canceled experiment {}".format(args.experiment_id))
@@ -121,7 +121,7 @@ def _parse_config_file_or_exit(config_file: io.FileIO) -> Dict:
     return experiment_config
 
 
-@authentication_required
+@authentication.required
 def submit_experiment(args: Namespace) -> None:
     experiment_config = _parse_config_file_or_exit(args.config_file)
     model_context = context.Context.from_local(args.model_def, constants.MAX_CONTEXT_SIZE)
@@ -186,7 +186,7 @@ def create(args: Namespace) -> None:
         submit_experiment(args)
 
 
-@authentication_required
+@authentication.required
 def delete_experiment(args: Namespace) -> None:
     if args.yes or render.yes_or_no(
         "Deleting an experiment will result in the unrecoverable \n"
@@ -201,7 +201,7 @@ def delete_experiment(args: Namespace) -> None:
         print("Aborting experiment deletion.")
 
 
-@authentication_required
+@authentication.required
 def describe(args: Namespace) -> None:
     docs = []
     for experiment_id in args.experiment_ids.split(","):
@@ -367,13 +367,13 @@ def describe(args: Namespace) -> None:
     render.tabulate_or_csv(headers, values, args.csv, outfile)
 
 
-@authentication_required
+@authentication.required
 def config(args: Namespace) -> None:
     result = api.get(args.master, "experiments/{}/config".format(args.experiment_id))
     yaml.safe_dump(result.json(), stream=sys.stdout, default_flow_style=False)
 
 
-@authentication_required
+@authentication.required
 def download_model_def(args: Namespace) -> None:
     resp = api.get(args.master, "experiments/{}/model_def".format(args.experiment_id))
     value, params = cgi.parse_header(resp.headers["Content-Disposition"])
@@ -403,13 +403,13 @@ def download(args: Namespace) -> None:
             print()
 
 
-@authentication_required
+@authentication.required
 def kill_experiment(args: Namespace) -> None:
     api.post(args.master, "experiments/{}/kill".format(args.experiment_id))
     print("Killed experiment {}".format(args.experiment_id))
 
 
-@authentication_required
+@authentication.required
 def wait(args: Namespace) -> None:
     while True:
         r = api.get(args.master, "experiments/{}".format(args.experiment_id)).json()
@@ -424,13 +424,13 @@ def wait(args: Namespace) -> None:
         time.sleep(args.polling_interval)
 
 
-@authentication_required
+@authentication.required
 def list_experiments(args: Namespace) -> None:
     params = {}
     if args.all:
         params["filter"] = "all"
     else:
-        params["user"] = api.Authentication.instance().get_session_user()
+        params["user"] = authentication.must_cli_auth().get_session_user()
 
     r = api.get(args.master, "experiments", params=params)
 
@@ -501,7 +501,7 @@ def scalar_validation_metrics_names(exp: Dict[str, Any]) -> Set[str]:
     return set()
 
 
-@authentication_required
+@authentication.required
 def list_trials(args: Namespace) -> None:
     r = api.get(args.master, "experiments/{}/summary".format(args.experiment_id))
     experiment = r.json()
@@ -522,49 +522,49 @@ def list_trials(args: Namespace) -> None:
     render.tabulate_or_csv(headers, values, args.csv)
 
 
-@authentication_required
+@authentication.required
 def pause(args: Namespace) -> None:
     patch_experiment(args, "pause", {"state": "PAUSED"})
     print("Paused experiment {}".format(args.experiment_id))
 
 
-@authentication_required
+@authentication.required
 def set_description(args: Namespace) -> None:
     api.patch_experiment_v1(args.master, args.experiment_id, {"description": args.description})
     print("Set description of experiment {} to '{}'".format(args.experiment_id, args.description))
 
 
-@authentication_required
+@authentication.required
 def set_name(args: Namespace) -> None:
     api.patch_experiment_v1(args.master, args.experiment_id, {"name": args.name})
     print("Set name of experiment {} to '{}'".format(args.experiment_id, args.name))
 
 
-@authentication_required
+@authentication.required
 def add_label(args: Namespace) -> None:
     patch_experiment(args, "add label to", {"labels": {args.label: True}})
     print("Added label '{}' to experiment {}".format(args.label, args.experiment_id))
 
 
-@authentication_required
+@authentication.required
 def remove_label(args: Namespace) -> None:
     patch_experiment(args, "remove label from", {"labels": {args.label: None}})
     print("Removed label '{}' from experiment {}".format(args.label, args.experiment_id))
 
 
-@authentication_required
+@authentication.required
 def set_max_slots(args: Namespace) -> None:
     patch_experiment(args, "change `max_slots` of", {"resources": {"max_slots": args.max_slots}})
     print("Set `max_slots` of experiment {} to {}".format(args.experiment_id, args.max_slots))
 
 
-@authentication_required
+@authentication.required
 def set_weight(args: Namespace) -> None:
     patch_experiment(args, "change `weight` of", {"resources": {"weight": args.weight}})
     print("Set `weight` of experiment {} to {}".format(args.experiment_id, args.weight))
 
 
-@authentication_required
+@authentication.required
 def set_gc_policy(args: Namespace) -> None:
     policy = {
         "save_experiment_best": args.save_experiment_best,
@@ -626,7 +626,7 @@ def set_gc_policy(args: Namespace) -> None:
         print("Aborting operations.")
 
 
-@authentication_required
+@authentication.required
 def unarchive(args: Namespace) -> None:
     patch_experiment(args, "archive", {"archived": False})
     print("Unarchived experiment {}".format(args.experiment_id))

--- a/harness/determined/cli/master.py
+++ b/harness/determined/cli/master.py
@@ -6,18 +6,18 @@ from typing import Any, List
 from requests import Response
 
 from determined.common import api
-from determined.common.api.authentication import authentication_required
+from determined.common.api import authentication
 from determined.common.check import check_gt
 from determined.common.declarative_argparse import Arg, Cmd
 
 
-@authentication_required
+@authentication.required
 def config(args: Namespace) -> None:
     response = api.get(args.master, "config")
     print(json.dumps(response.json(), indent=4))
 
 
-@authentication_required
+@authentication.required
 def logs(args: Namespace) -> None:
     def process_response(response: Response, latest_log_id: int) -> int:
         for log in response.json():

--- a/harness/determined/cli/model.py
+++ b/harness/determined/cli/model.py
@@ -3,7 +3,7 @@ from argparse import Namespace
 from typing import Any, List
 
 from determined.common import api
-from determined.common.api.authentication import authentication_required
+from determined.common.api import authentication
 from determined.common.declarative_argparse import Arg, Cmd
 from determined.common.experimental import Checkpoint, Determined, Model, ModelOrderBy, ModelSortBy
 
@@ -65,7 +65,7 @@ def list_models(args: Namespace) -> None:
         render.tabulate_or_csv(headers, values, False)
 
 
-@authentication_required
+@authentication.required
 def list_versions(args: Namespace) -> None:
     if args.json:
         r = api.get(args.master, "models/{}/versions".format(args.name))
@@ -123,7 +123,7 @@ def describe(args: Namespace) -> None:
             render_model_version(checkpoint)
 
 
-@authentication_required
+@authentication.required
 def register_version(args: Namespace) -> None:
     if args.json:
         resp = api.post(

--- a/harness/determined/cli/notebook.py
+++ b/harness/determined/cli/notebook.py
@@ -6,7 +6,7 @@ from termcolor import colored
 
 from determined.cli import command, render
 from determined.common import api
-from determined.common.api.authentication import authentication_required
+from determined.common.api import authentication
 from determined.common.check import check_eq
 from determined.common.declarative_argparse import Arg, Cmd
 
@@ -20,7 +20,7 @@ from .command import (
 )
 
 
-@authentication_required
+@authentication.required
 def start_notebook(args: Namespace) -> None:
     config = parse_config(args.config_file, None, args.config, args.volume)
 
@@ -51,7 +51,7 @@ def start_notebook(args: Namespace) -> None:
             render_event_stream(msg)
 
 
-@authentication_required
+@authentication.required
 def open_notebook(args: Namespace) -> None:
     resp = api.get(args.master, "api/v1/notebooks/{}".format(args.notebook_id)).json()["notebook"]
     check_eq(resp["state"], "STATE_RUNNING", "Notebook must be in a running state")

--- a/harness/determined/cli/remote.py
+++ b/harness/determined/cli/remote.py
@@ -4,7 +4,7 @@ from typing import Any, List
 
 from determined.cli import command
 from determined.common import api
-from determined.common.api.authentication import authentication_required
+from determined.common.api import authentication
 from determined.common.declarative_argparse import Arg, Cmd
 
 from .command import (
@@ -17,7 +17,7 @@ from .command import (
 )
 
 
-@authentication_required
+@authentication.required
 def run_command(args: Namespace) -> None:
     config = parse_config(args.config_file, args.entrypoint, args.config, args.volume)
     resp = launch_command(

--- a/harness/determined/cli/resources.py
+++ b/harness/determined/cli/resources.py
@@ -5,7 +5,7 @@ from typing import Any, List
 import requests
 
 from determined.common import api
-from determined.common.api.authentication import authentication_required
+from determined.common.api import authentication
 from determined.common.declarative_argparse import Arg, Cmd
 
 
@@ -15,14 +15,14 @@ def print_response(r: requests.Response) -> None:
         sys.stdout.buffer.write(chunk)
 
 
-@authentication_required
+@authentication.required
 def raw(args: Namespace) -> None:
     params = {"timestamp_after": args.timestamp_after, "timestamp_before": args.timestamp_before}
     path = "api/v1/resources/allocation/raw" if args.json else "resources/allocation/raw"
     print_response(api.get(args.master, path, params=params))
 
 
-@authentication_required
+@authentication.required
 def aggregated(args: Namespace) -> None:
     params = {
         "start_date": args.start_date,

--- a/harness/determined/cli/shell.py
+++ b/harness/determined/cli/shell.py
@@ -12,8 +12,7 @@ from termcolor import colored
 
 from determined.cli import command
 from determined.common import api
-from determined.common.api import request
-from determined.common.api.authentication import authentication_required
+from determined.common.api import authentication, request
 from determined.common.check import check_eq, check_len
 from determined.common.declarative_argparse import Arg, Cmd
 
@@ -27,7 +26,7 @@ from .command import (
 )
 
 
-@authentication_required
+@authentication.required
 def start_shell(args: Namespace) -> None:
     data = {}
     if args.passphrase:
@@ -65,7 +64,7 @@ def start_shell(args: Namespace) -> None:
         )
 
 
-@authentication_required
+@authentication.required
 def open_shell(args: Namespace) -> None:
     shell = api.get(args.master, "api/v1/shells/{}".format(args.shell_id)).json()["shell"]
     check_eq(shell["state"], "STATE_RUNNING", "Shell must be in a running state")
@@ -78,7 +77,7 @@ def open_shell(args: Namespace) -> None:
     )
 
 
-@authentication_required
+@authentication.required
 def show_ssh_command(args: Namespace) -> None:
     shell = api.get(args.master, "api/v1/shells/{}".format(args.shell_id)).json()["shell"]
     check_eq(shell["state"], "STATE_RUNNING", "Shell must be in a running state")

--- a/harness/determined/cli/sso.py
+++ b/harness/determined/cli/sso.py
@@ -6,6 +6,7 @@ from typing import Any, Callable, List
 from urllib.parse import parse_qs, urlparse
 
 from determined.common import api
+from determined.common.api import authentication
 from determined.common.declarative_argparse import Arg, Cmd
 
 from .errors import EnterpriseOnlyError
@@ -23,7 +24,7 @@ def make_handler(master_url: str, close_cb: Callable[[int], None]) -> Any:
                 tmp_auth = {"Cookie": "auth={token}".format(token=token)}
                 me = api.get(master_url, "/users/me", headers=tmp_auth, authenticated=False).json()
 
-                token_store = api.Authentication.instance().token_store
+                token_store = authentication.TokenStore()
                 token_store.set_token(me["username"], token)
                 token_store.set_active(me["username"], True)
 

--- a/harness/determined/cli/template.py
+++ b/harness/determined/cli/template.py
@@ -6,7 +6,7 @@ from typing import Any, List
 from termcolor import colored
 
 from determined.common import api, util, yaml
-from determined.common.api.authentication import authentication_required
+from determined.common.api import authentication
 from determined.common.declarative_argparse import Arg, Cmd
 
 from . import render
@@ -20,7 +20,7 @@ def _parse_config(field: Any) -> Any:
     return yaml.safe_dump(yaml.safe_load(base64.b64decode(field)), default_flow_style=False)
 
 
-@authentication_required
+@authentication.required
 def list_template(args: Namespace) -> None:
     templates = [
         render.unmarshal(TemplateAll, t, {"config": _parse_config})
@@ -32,14 +32,14 @@ def list_template(args: Namespace) -> None:
         render.render_objects(TemplateClean, templates)
 
 
-@authentication_required
+@authentication.required
 def describe_template(args: Namespace) -> None:
     resp = api.get(args.master, path="templates/{}".format(args.template_name)).json()
     template = render.unmarshal(TemplateAll, resp, {"config": _parse_config})
     print(template.config)
 
 
-@authentication_required
+@authentication.required
 def set_template(args: Namespace) -> None:
     with args.template_file:
         body = util.safe_load_yaml_with_exceptions(args.template_file)
@@ -47,7 +47,7 @@ def set_template(args: Namespace) -> None:
         print(colored("Set template {}".format(args.template_name), "green"))
 
 
-@authentication_required
+@authentication.required
 def remove_templates(args: Namespace) -> None:
     api.delete(args.master, path="templates/" + args.template_name)
     print(colored("Removed template {}".format(args.template_name), "green"))

--- a/harness/determined/cli/tensorboard.py
+++ b/harness/determined/cli/tensorboard.py
@@ -7,14 +7,14 @@ from termcolor import colored
 
 from determined.cli import command
 from determined.common import api, constants, context
-from determined.common.api.authentication import authentication_required
+from determined.common.api import authentication
 from determined.common.check import check_eq
 from determined.common.declarative_argparse import Arg, Cmd
 
 from .command import CONTEXT_DESC, parse_config, render_event_stream
 
 
-@authentication_required
+@authentication.required
 def start_tensorboard(args: Namespace) -> None:
     if args.trial_ids is None and args.experiment_ids is None:
         print("Either experiment_ids or trial_ids must be specified.")
@@ -57,7 +57,7 @@ def start_tensorboard(args: Namespace) -> None:
             render_event_stream(msg)
 
 
-@authentication_required
+@authentication.required
 def open_tensorboard(args: Namespace) -> None:
     resp = api.get(args.master, "api/v1/tensorboards/{}".format(args.tensorboard_id)).json()[
         "tensorboard"

--- a/harness/determined/cli/trial.py
+++ b/harness/determined/cli/trial.py
@@ -5,14 +5,14 @@ from typing import Any, List
 
 from determined.cli import render
 from determined.common import api
-from determined.common.api.authentication import authentication_required
+from determined.common.api import authentication
 from determined.common.declarative_argparse import Arg, Cmd, Group
 from determined.common.experimental import Determined
 
 from .checkpoint import format_checkpoint, format_validation, render_checkpoint
 
 
-@authentication_required
+@authentication.required
 def describe_trial(args: Namespace) -> None:
     if args.metrics:
         r = api.get(args.master, "trials/{}/metrics".format(args.trial_id))
@@ -98,13 +98,13 @@ def download(args: Namespace) -> None:
         render_checkpoint(checkpoint, path)
 
 
-@authentication_required
+@authentication.required
 def kill_trial(args: Namespace) -> None:
     api.post(args.master, "trials/{}/kill".format(args.trial_id))
     print("Killed trial {}".format(args.trial_id))
 
 
-@authentication_required
+@authentication.required
 def trial_logs(args: Namespace) -> None:
     api.experiment.print_trial_logs(
         args.master,

--- a/harness/determined/cli/user.py
+++ b/harness/determined/cli/user.py
@@ -1,15 +1,13 @@
 import getpass
 from argparse import Namespace
 from collections import namedtuple
-from functools import wraps
-from typing import Any, Callable, Dict, List, Optional
+from typing import Any, Dict, List, Optional
 
 from requests import Response
 from termcolor import colored
 
-import determined.common.api.authentication as auth
 from determined.common import api
-from determined.common.api.authentication import authentication_required
+from determined.common.api import authentication
 from determined.common.declarative_argparse import Arg, Cmd
 
 from . import render
@@ -18,20 +16,6 @@ FullUser = namedtuple(
     "FullUser",
     ["username", "admin", "active", "agent_uid", "agent_gid", "agent_user", "agent_group"],
 )
-
-
-def authentication_optional(func: Callable[[Namespace], Any]) -> Callable[[Namespace], Any]:
-    @wraps(func)
-    def f(namespace: Namespace) -> Any:
-        v = vars(namespace)
-        try:
-            auth.initialize_session(namespace.master, v.get("user"), try_reauth=False)
-        except api.errors.UnauthenticatedException:
-            pass
-
-        return func(namespace)
-
-    return f
 
 
 def update_user(
@@ -62,19 +46,19 @@ def update_username(current_username: str, master_address: str, new_username: st
     return api.patch(master_address, "users/{}/username".format(current_username), body=request)
 
 
-@authentication_required
+@authentication.required
 def list_users(args: Namespace) -> None:
     render.render_objects(
         FullUser, [render.unmarshal(FullUser, u) for u in api.get(args.master, path="users").json()]
     )
 
 
-@authentication_required
+@authentication.required
 def activate_user(parsed_args: Namespace) -> None:
     update_user(parsed_args.username, parsed_args.master, active=True)
 
 
-@authentication_required
+@authentication.required
 def deactivate_user(parsed_args: Namespace) -> None:
     update_user(parsed_args.username, parsed_args.master, active=False)
 
@@ -90,56 +74,52 @@ def log_in_user(parsed_args: Namespace) -> None:
     # In order to not send clear-text passwords, we hash the password.
     password = api.salt_and_hash(getpass.getpass(message))
 
-    auth_inst = api.Authentication.instance()
+    token_store = authentication.TokenStore()
 
-    auth.do_login(parsed_args.master, auth_inst, username=username, password=password)
-    auth_inst.token_store.set_active(username, True)
+    token = authentication.do_login(parsed_args.master, username, password)
+    token_store.set_token(username, token)
+    token_store.set_active(username, True)
 
 
-@authentication_optional
+@authentication.optional
 def log_out_user(parsed_args: Namespace) -> None:
-    auth_inst = api.Authentication.instance()
-    if auth_inst.session is None:
+    auth = authentication.cli_auth
+    if auth is None:
         return
 
     try:
         api.post(
             parsed_args.master,
             "logout",
-            headers={"Authorization": "Bearer {}".format(auth_inst.get_session_token())},
+            headers={"Authorization": "Bearer {}".format(auth.get_session_token())},
             authenticated=False,
         )
     except api.errors.APIException as e:
         if e.status_code != 401:
             raise e
 
-    auth_inst.token_store.drop_user(auth_inst.get_session_user())
+    token_store = authentication.TokenStore()
+    token_store.drop_user(auth.get_session_user())
 
 
-@authentication_required
+@authentication.required
 def rename(parsed_args: Namespace) -> None:
     update_username(parsed_args.target_user, parsed_args.master, parsed_args.new_username)
 
 
-@authentication_required
+@authentication.required
 def change_password(parsed_args: Namespace) -> None:
-    auth_inst = api.Authentication.instance()
-
     if parsed_args.target_user:
         username = parsed_args.target_user
     elif parsed_args.user:
         username = parsed_args.user
     else:
-        username = auth_inst.get_session_user()
+        username = authentication.must_cli_auth().get_session_user()
 
     if not username:
         # The default user should have been set by now by autologin.
         print(colored("Please log in as an admin or user to change passwords", "red"))
         return
-
-    # If the target user's password isn't being changed by another user, reauthenticate after
-    # password change so that the user doesn't have to do so manually.
-    reauthenticate = parsed_args.target_user is None
 
     password = getpass.getpass("New password for user '{}': ".format(username))
     check_password = getpass.getpass("Confirm password: ")
@@ -153,15 +133,16 @@ def change_password(parsed_args: Namespace) -> None:
 
     update_user(username, parsed_args.master, password=password)
 
-    if reauthenticate:
-        set_active = auth_inst.is_user_active(username)
-        auth_inst = api.Authentication.instance()
+    # If the target user's password isn't being changed by another user, reauthenticate after
+    # password change so that the user doesn't have to do so manually.
+    if parsed_args.target_user is None:
+        token_store = authentication.TokenStore()
+        token = authentication.do_login(parsed_args.master, username, password)
+        token_store.set_token(username, token)
+        token_store.set_active(username, True)
 
-        auth.do_login(parsed_args.master, auth_inst, username, password)
-        auth_inst.token_store.set_active(username, set_active)
 
-
-@authentication_required
+@authentication.required
 def link_with_agent_user(parsed_args: Namespace) -> None:
     if parsed_args.agent_uid is None:
         raise api.errors.BadRequestException("agent-uid argument required")
@@ -182,7 +163,7 @@ def link_with_agent_user(parsed_args: Namespace) -> None:
     update_user(parsed_args.det_username, parsed_args.master, agent_user_group=agent_user_group)
 
 
-@authentication_required
+@authentication.required
 def create_user(parsed_args: Namespace) -> None:
     username = parsed_args.username
     admin = bool(parsed_args.admin)
@@ -191,7 +172,7 @@ def create_user(parsed_args: Namespace) -> None:
     api.post(parsed_args.master, "users", body=request)
 
 
-@authentication_required
+@authentication.required
 def whoami(parsed_args: Namespace) -> None:
     response = api.get(parsed_args.master, "users/me")
     user = response.json()

--- a/harness/determined/common/api/certs.py
+++ b/harness/determined/common/api/certs.py
@@ -10,7 +10,7 @@ from typing import Dict, Iterator, Optional, Union, cast
 import certifi
 import filelock
 
-from determined.common.api import authentication
+from determined.common import util
 
 
 class Cert:
@@ -166,7 +166,7 @@ def maybe_shim_old_cert_store(
 
 
 def default_store() -> pathlib.Path:
-    return authentication.get_config_path().joinpath("certs.json")
+    return util.get_config_path().joinpath("certs.json")
 
 
 def default_load(
@@ -209,7 +209,7 @@ def default_load(
     else:
         # Otherwise, look in the default location for cert_pem.
         store_path = default_store()
-        old_path = authentication.get_config_path().joinpath("master.crt")
+        old_path = util.get_config_path().joinpath("master.crt")
         maybe_shim_old_cert_store(old_path, store_path, master_url)
         cert_pem = get_cert(store_path, master_url)
 

--- a/harness/determined/common/api/certs.py
+++ b/harness/determined/common/api/certs.py
@@ -147,6 +147,10 @@ def delete_cert(path: pathlib.Path, url: str) -> None:
 def maybe_shim_old_cert_store(
     old_path: pathlib.Path, new_path: pathlib.Path, master_url: str
 ) -> None:
+    """
+    maybe_shim_old_cert_store will detect when an old v0 cert store is present and will shim it to
+    a v1 cert store.
+    """
     if not old_path.exists():
         return None
 

--- a/harness/determined/common/api/certs.py
+++ b/harness/determined/common/api/certs.py
@@ -209,7 +209,7 @@ def default_load(
     else:
         # Otherwise, look in the default location for cert_pem.
         store_path = default_store()
-        old_path = authentication.get_config_path().joinpath("master.cert")
+        old_path = authentication.get_config_path().joinpath("master.crt")
         maybe_shim_old_cert_store(old_path, store_path, master_url)
         cert_pem = get_cert(store_path, master_url)
 

--- a/harness/determined/common/api/certs.py
+++ b/harness/determined/common/api/certs.py
@@ -1,0 +1,220 @@
+import atexit
+import contextlib
+import json
+import logging
+import os
+import pathlib
+import tempfile
+from typing import Dict, Iterator, Optional, Union, cast
+
+import certifi
+import filelock
+
+from determined.common.api import authentication
+
+
+class Cert:
+    def __init__(
+        self,
+        cert_pem: Optional[str] = None,
+        noverify: bool = False,
+        name: Optional[str] = None,
+    ) -> None:
+        if cert_pem is not None and noverify:
+            raise AssertionError("you cannot set cert_pem with noverify=True")
+
+        if name == "":
+            name = None
+        self._name = name
+
+        if noverify:
+            self._bundle = False  # type: Union[None, str, bool]
+        elif cert_pem is None:
+            self._bundle = None
+        else:
+            # Don't use NamedTemporaryFile, since it would make the file inaccessible by path on
+            # Windows after this.
+            # (see https://docs.python.org/3/library/tempfile.html#tempfile.NamedTemporaryFile)
+            fd, combined_path = tempfile.mkstemp(prefix="det-master-cert-")
+            atexit.register(os.unlink, combined_path)
+
+            with open(fd, "wb") as out:
+                with open(certifi.where(), "rb") as base_certs:
+                    out.write(base_certs.read())
+                out.write(b"\n")
+                out.write(cert_pem.encode("utf8"))
+
+            self._bundle = combined_path
+
+    @property
+    def bundle(self) -> Union[None, str, bool]:
+        """
+        The path to a file containing an SSL certificate to trust specifically for the master, if
+        any, or False to disable cert verification entirely. If set to a path, it should always be a
+        temporary file that we own and can delete.
+        """
+        return self._bundle
+
+    @property
+    def name(self) -> Optional[str]:
+        """
+        The name we use to verify the master certificate.
+        """
+        return self._name
+
+
+cli_cert = None  # type: Optional[Cert]
+
+
+class _BrokenCertStore(Exception):
+    pass
+
+
+def _load_cert_store(path: pathlib.Path) -> Dict[str, str]:
+    if not path.exists():
+        return {}
+    try:
+
+        with path.open() as f:
+            content = f.read()
+
+        try:
+            store = json.loads(content)
+        except json.JSONDecodeError:
+            raise _BrokenCertStore()
+
+            if not isinstance(store, dict):
+                raise _BrokenCertStore()
+
+        # Store must be a dictionary.
+        if not isinstance(store, dict):
+            raise _BrokenCertStore()
+
+        # All keys are url's, all values are pem-encoded certs.
+        for k, v in store.items():
+            if not isinstance(k, str):
+                raise _BrokenCertStore()
+            if not isinstance(v, str):
+                raise _BrokenCertStore()
+
+    except _BrokenCertStore:
+        path.unlink()
+        return {}
+
+    return cast(Dict[str, str], store)
+
+
+@contextlib.contextmanager
+def _modifiable_store(path: pathlib.Path) -> Iterator[Dict["str", "str"]]:
+    """
+    Yields the appropriate store that can be modified, and the modified result will be written
+    back to file.
+
+    The modified store is also saved to the local object.
+    """
+    path = path
+    path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+    # Decide on paths for a lock file and a temp files (during writing).
+    temp = pathlib.Path(str(path) + ".temp")
+    lock = pathlib.Path(str(path) + ".lock")
+
+    with filelock.FileLock(lock):
+        store = _load_cert_store(path)
+
+        # No need for try/finally, because we don't update the file after failures.
+        yield store
+
+        with temp.open("w") as f:
+            json.dump(store, f, indent=4, sort_keys=True)
+        temp.rename(path)
+
+
+def get_cert(path: pathlib.Path, url: str) -> Optional[str]:
+    if not path.exists():
+        return None
+    # Technically this doesn't have to be modfiable, but it is unlikely to matter.
+    with _modifiable_store(path) as store:
+        return store.get(url)
+
+
+def set_cert(path: pathlib.Path, url: str, cert_pem: str) -> None:
+    with _modifiable_store(path) as store:
+        store[url] = cert_pem
+
+
+def delete_cert(path: pathlib.Path, url: str) -> None:
+    with _modifiable_store(path) as store:
+        if url in store:
+            del store[url]
+
+
+def maybe_shim_old_cert_store(
+    old_path: pathlib.Path, new_path: pathlib.Path, master_url: str
+) -> None:
+    if not old_path.exists():
+        return None
+
+    # Only try to shim when ONLY the old path exists.
+    if not new_path.exists():
+        with old_path.open("r") as f:
+            pem_content = f.read()
+        store = {master_url: pem_content}
+        with new_path.open("w") as f:
+            json.dump(store, f, indent=4, sort_keys=True)
+
+    old_path.unlink()
+
+
+def default_store() -> pathlib.Path:
+    return authentication.get_config_path().joinpath("certs.json")
+
+
+def default_load(
+    master_url: str,
+    explicit_path: Optional[str] = None,
+    explicit_cert_name: Optional[str] = None,
+    explicit_noverify: bool = False,
+) -> Cert:
+    """
+    default_load takes as input the user-specified certificate-related configurations, reads
+    environment variable configs, reads configs from the default store on the filesystem, and
+    returns the resulting Cert object.
+
+    Having all of the default loading logic in one function makes it easy to invoke the same logic
+    in both the cli and the python sdk.
+    """
+    # Any explicit args causes us to ignore environment variables and defaults.
+    if explicit_path or explicit_cert_name or explicit_noverify:
+        if explicit_path:
+            with open(explicit_path, "r") as f:
+                cert_pem = f.read()  # type: Optional[str]
+        else:
+            cert_pem = None
+        return Cert(cert_pem=cert_pem, noverify=explicit_noverify, name=explicit_cert_name)
+
+    # Let any environment variable for CERT_FILE override the default store.
+    env_path = os.environ.get("DET_MASTER_CERT_FILE")
+    noverify = False
+    cert_pem = None
+    if env_path:
+        if env_path.lower() == "noverify":
+            noverify = True
+        elif os.path.exists(env_path):
+            with open(env_path, "r") as f:
+                cert_pem = f.read()
+        else:
+            logging.warning(
+                f"DET_MASTER_CERT_FILE={env_path} path not found; continuing without cert"
+            )
+    else:
+        # Otherwise, look in the default location for cert_pem.
+        store_path = default_store()
+        old_path = authentication.get_config_path().joinpath("master.cert")
+        maybe_shim_old_cert_store(old_path, store_path, master_url)
+        cert_pem = get_cert(store_path, master_url)
+
+    env_name = os.environ.get("DET_MASTER_CERT_NAME")
+    if env_name == "":
+        env_name = None
+
+    return Cert(cert_pem=cert_pem, noverify=noverify, name=env_name)

--- a/harness/determined/common/api/errors.py
+++ b/harness/determined/common/api/errors.py
@@ -57,3 +57,11 @@ class CorruptTokenCacheException(Exception):
             "Attempted to read a corrupted token cache.  The store has been deleted; "
             "please try again.\n"
         )
+
+
+class CorruptCertificateCacheException(Exception):
+    def __init__(self) -> None:
+        super().__init__(
+            "Attempted to read a corrupted certificate cache.  The store has been deleted; "
+            "please try again.\n"
+        )

--- a/harness/determined/common/api/request.py
+++ b/harness/determined/common/api/request.py
@@ -1,80 +1,14 @@
-import atexit
-import builtins
-import os
-import tempfile
 import webbrowser
 from types import TracebackType
-from typing import Any, Dict, Iterator, Optional, Union
+from typing import Any, Dict, Iterator, Optional
 from urllib import parse
 
-import certifi
 import lomond
 import requests
 import simplejson
 
 import determined.common.requests
-from determined.common.api import authentication, errors
-
-# The path to a file containing an SSL certificate to trust specifically for the master, if any, or
-# False to disable cert verification entirely. If set to a path, it should always be a temporary
-# file that we own and can delete.
-_master_cert_bundle = None  # type: Optional[Union[str, bool]]
-
-# The name we use to verify the master.
-_master_cert_name = None
-
-
-def set_master_cert_bundle(path: Optional[Union[str, bool]]) -> None:
-    global _master_cert_bundle
-
-    if path == "":
-        path = None
-    if path is None or isinstance(path, bool):
-        _master_cert_bundle = path
-        return
-
-    # Don't use NamedTemporaryFile, since it would make the file inaccessible by path on Windows
-    # after this (see https://docs.python.org/3/library/tempfile.html#tempfile.NamedTemporaryFile).
-    fd, combined_path = tempfile.mkstemp(prefix="det-master-cert-")
-    atexit.register(os.unlink, combined_path)
-
-    with builtins.open(fd, "wb") as out:
-        with builtins.open(certifi.where(), "rb") as base_certs:
-            out.write(base_certs.read())
-        out.write(b"\n")
-        with builtins.open(path, "rb") as custom_certs:
-            out.write(custom_certs.read())
-
-    _master_cert_bundle = combined_path
-
-
-def set_master_cert_name(name: Optional[str]) -> None:
-    if name == "":
-        name = None
-    global _master_cert_name
-    _master_cert_name = name
-
-
-# Set the bundle if one is specified by the environment. This is done on import since we can't
-# always count on having an entry point we control (e.g., if someone is importing this code in a
-# notebook).
-f = os.environ.get("DET_MASTER_CERT_FILE")
-if f and f.lower() == "noverify":
-    set_master_cert_bundle(False)
-else:
-    set_master_cert_bundle(f)
-del f
-
-# Set the master servername from the environment.
-set_master_cert_name(os.environ.get("DET_MASTER_CERT_NAME"))
-
-
-def get_master_cert_bundle() -> Optional[Union[str, bool]]:
-    return _master_cert_bundle
-
-
-def get_master_cert_name() -> Optional[str]:
-    return _master_cert_name
+from determined.common.api import authentication, certs, errors
 
 
 def parse_master_address(master_address: str) -> parse.ParseResult:
@@ -106,12 +40,15 @@ def maybe_upgrade_ws_scheme(master_address: str) -> str:
         return master_address
 
 
-def add_token_to_headers(headers: Dict[str, str]) -> Dict[str, str]:
+def add_token_to_headers(
+    headers: Dict[str, str],
+    auth: Optional[authentication.Authentication],
+) -> Dict[str, str]:
     # Try to get user token first since it will include the user token that is used
     # for queries in some restful APIs.
     user_token = ""
-    if authentication.cli_auth is not None:
-        user_token = authentication.cli_auth.get_session_token()
+    if auth is not None:
+        user_token = auth.get_session_token()
     if user_token:
         return {**headers, "Authorization": "Bearer {}".format(user_token)}
 
@@ -130,8 +67,16 @@ def do_request(
     body: Optional[Dict[str, Any]] = None,
     headers: Optional[Dict[str, str]] = None,
     authenticated: bool = True,
+    auth: Optional[authentication.Authentication] = None,
+    cert: Optional[certs.Cert] = None,
     stream: bool = False,
 ) -> requests.Response:
+    # If no explicit Authentication object was provided, use the cli's singleton Authentication.
+    if auth is None:
+        auth = authentication.cli_auth
+    if cert is None:
+        cert = certs.cli_cert
+
     if headers is None:
         h = {}  # type: Dict[str, str]
     else:
@@ -141,7 +86,7 @@ def do_request(
         params = {}
 
     if authenticated:
-        h = add_token_to_headers(h)
+        h = add_token_to_headers(h, auth)
 
     try:
         r = determined.common.requests.request(
@@ -150,9 +95,9 @@ def do_request(
             params=params,
             json=body,
             headers=h,
-            verify=_master_cert_bundle,
+            verify=cert.bundle if cert else None,
             stream=stream,
-            server_hostname=_master_cert_name,
+            server_hostname=cert.name if cert else None,
         )
     except requests.exceptions.SSLError:
         raise
@@ -163,8 +108,8 @@ def do_request(
 
     if r.status_code == 403:
         username = ""
-        if authentication.cli_auth is not None:
-            username = authentication.cli_auth.get_session_user()
+        if auth is not None:
+            username = auth.get_session_user()
         raise errors.UnauthenticatedException(username=username)
     elif r.status_code == 404:
         raise errors.NotFoundException(r)
@@ -180,6 +125,8 @@ def get(
     params: Optional[Dict[str, Any]] = None,
     headers: Optional[Dict[str, str]] = None,
     authenticated: bool = True,
+    auth: Optional[authentication.Authentication] = None,
+    cert: Optional[certs.Cert] = None,
     stream: bool = False,
 ) -> requests.Response:
     """
@@ -192,6 +139,8 @@ def get(
         params=params,
         headers=headers,
         authenticated=authenticated,
+        auth=auth,
+        cert=cert,
         stream=stream,
     )
 
@@ -202,12 +151,21 @@ def delete(
     params: Optional[Dict[str, Any]] = None,
     headers: Optional[Dict[str, str]] = None,
     authenticated: bool = True,
+    auth: Optional[authentication.Authentication] = None,
+    cert: Optional[certs.Cert] = None,
 ) -> requests.Response:
     """
     Send a DELETE request to the remote API.
     """
     return do_request(
-        "DELETE", host, path, params=params, headers=headers, authenticated=authenticated
+        "DELETE",
+        host,
+        path,
+        params=params,
+        headers=headers,
+        authenticated=authenticated,
+        auth=auth,
+        cert=cert,
     )
 
 
@@ -217,11 +175,22 @@ def post(
     body: Optional[Dict[str, Any]] = None,
     headers: Optional[Dict[str, str]] = None,
     authenticated: bool = True,
+    auth: Optional[authentication.Authentication] = None,
+    cert: Optional[certs.Cert] = None,
 ) -> requests.Response:
     """
     Send a POST request to the remote API.
     """
-    return do_request("POST", host, path, body=body, headers=headers, authenticated=authenticated)
+    return do_request(
+        "POST",
+        host,
+        path,
+        body=body,
+        headers=headers,
+        authenticated=authenticated,
+        auth=auth,
+        cert=cert,
+    )
 
 
 def patch(
@@ -230,11 +199,22 @@ def patch(
     body: Dict[str, Any],
     headers: Optional[Dict[str, str]] = None,
     authenticated: bool = True,
+    auth: Optional[authentication.Authentication] = None,
+    cert: Optional[certs.Cert] = None,
 ) -> requests.Response:
     """
     Send a PATCH request to the remote API.
     """
-    return do_request("PATCH", host, path, body=body, headers=headers, authenticated=authenticated)
+    return do_request(
+        "PATCH",
+        host,
+        path,
+        body=body,
+        headers=headers,
+        authenticated=authenticated,
+        auth=auth,
+        cert=cert,
+    )
 
 
 def put(
@@ -243,11 +223,22 @@ def put(
     body: Optional[Dict[str, Any]] = None,
     headers: Optional[Dict[str, str]] = None,
     authenticated: bool = True,
+    auth: Optional[authentication.Authentication] = None,
+    cert: Optional[certs.Cert] = None,
 ) -> requests.Response:
     """
     Send a PUT request to the remote API.
     """
-    return do_request("PUT", host, path, body=body, headers=headers, authenticated=authenticated)
+    return do_request(
+        "PUT",
+        host,
+        path,
+        body=body,
+        headers=headers,
+        authenticated=authenticated,
+        auth=auth,
+        cert=cert,
+    )
 
 
 def open(host: str, path: str) -> str:

--- a/harness/determined/common/experimental/determined.py
+++ b/harness/determined/common/experimental/determined.py
@@ -53,17 +53,17 @@ class Determined:
     ):
         master = master or util.get_default_master_address()
 
-        # TODO: This should probably be try_reauth=False, but it appears that would break the case
-        # where the default credentials are in place and could be discovered by checking against
-        # the master.
-        auth = authentication.Authentication(master, user, try_reauth=True)
-
         cert = certs.default_load(
             master_url=master,
             explicit_path=cert_path,
             explicit_cert_name=cert_name,
             explicit_noverify=noverify,
         )
+
+        # TODO: This should probably be try_reauth=False, but it appears that would break the case
+        # where the default credentials are available from the master and could be discovered by
+        # a REST API call against the master.
+        auth = authentication.Authentication(master, user, try_reauth=True, cert=cert)
 
         self._session = session.Session(master, user, auth, cert)
 

--- a/harness/determined/common/experimental/determined.py
+++ b/harness/determined/common/experimental/determined.py
@@ -9,6 +9,7 @@ from determined._swagger.client.configuration import Configuration
 from determined._swagger.client.models.v1_create_experiment_request import V1CreateExperimentRequest
 from determined._swagger.client.models.v1_file import V1File
 from determined.common import api, check, context, util, yaml
+from determined.common.api import authentication
 from determined.common.experimental import checkpoint, experiment, model, session, trial
 
 
@@ -49,7 +50,7 @@ class Determined:
     ):
         self._session = session.Session(master, user)
 
-        userauth = api.authentication.Authentication.instance()
+        userauth = authentication.must_cli_auth()
 
         configuration = Configuration()
         configuration.host = self._session._master.rstrip("/")

--- a/harness/determined/common/experimental/model.py
+++ b/harness/determined/common/experimental/model.py
@@ -3,8 +3,7 @@ import enum
 import json
 from typing import Any, Dict, List, Optional
 
-from determined.common import api
-from determined.common.experimental.checkpoint import Checkpoint
+from determined.common.experimental import checkpoint, session
 
 
 class ModelSortBy(enum.Enum):
@@ -60,21 +59,21 @@ class Model:
 
     def __init__(
         self,
+        session: session.Session,
         name: str,
         description: str = "",
         creation_time: Optional[datetime.datetime] = None,
         last_updated_time: Optional[datetime.datetime] = None,
         metadata: Optional[Dict[str, Any]] = None,
-        master: str = "",
     ):
-        self._master = master
+        self._session = session
         self.name = name
         self.description = description
         self.creation_time = creation_time
         self.last_updated_time = last_updated_time
         self.metadata = metadata or {}
 
-    def get_version(self, version: int = 0) -> Optional[Checkpoint]:
+    def get_version(self, version: int = 0) -> Optional[checkpoint.Checkpoint]:
         """
         Retrieve the checkpoint corresponding to the specified version of the
         model. If the specified version of the model does not exist, an exception
@@ -88,8 +87,7 @@ class Model:
             version (int, optional): The model version number requested.
         """
         if version == 0:
-            resp = api.get(
-                self._master,
+            resp = self._session.get(
                 "/api/v1/models/{}/versions/".format(self.name),
                 {"limit": 1, "order_by": 2},
             )
@@ -99,20 +97,23 @@ class Model:
                 return None
 
             latest_version = data["modelVersions"][0]
-            return Checkpoint.from_json(
+            return checkpoint.Checkpoint.from_json(
                 {
                     **latest_version["checkpoint"],
                     "model_version": latest_version["version"],
                     "model_name": data["model"]["name"],
-                }
+                },
+                self._session,
             )
         else:
-            resp = api.get(self._master, "/api/v1/models/{}/versions/{}".format(self.name, version))
+            resp = self._session.get("/api/v1/models/{}/versions/{}".format(self.name, version))
 
         data = resp.json()
-        return Checkpoint.from_json(data["modelVersion"]["checkpoint"], self._master)
+        return checkpoint.Checkpoint.from_json(data["modelVersion"]["checkpoint"], self._session)
 
-    def get_versions(self, order_by: ModelOrderBy = ModelOrderBy.DESC) -> List[Checkpoint]:
+    def get_versions(
+        self, order_by: ModelOrderBy = ModelOrderBy.DESC
+    ) -> List[checkpoint.Checkpoint]:
         """
         Get a list of checkpoints corresponding to versions of this model. The
         models are sorted by version number and are returned in descending
@@ -121,49 +122,47 @@ class Model:
         Arguments:
             order_by (enum): A member of the :class:`ModelOrderBy` enum.
         """
-        resp = api.get(
-            self._master,
+        resp = self._session.get(
             "/api/v1/models/{}/versions/".format(self.name),
             params={"order_by": order_by.value},
         )
         data = resp.json()
 
         return [
-            Checkpoint.from_json(
+            checkpoint.Checkpoint.from_json(
                 {
                     **version["checkpoint"],
                     "model_version": version["version"],
                     "model_name": data["model"]["name"],
                 },
-                self._master,
+                self._session,
             )
             for version in data["modelVersions"]
         ]
 
-    def register_version(self, checkpoint_uuid: str) -> Checkpoint:
+    def register_version(self, checkpoint_uuid: str) -> checkpoint.Checkpoint:
         """
         Creates a new model version and returns the
-        :class:`~determined.experimental.Checkpoint` corresponding to the
+        :class:`~determined.experimental.checkpoint.Checkpoint` corresponding to the
         version.
 
         Arguments:
             checkpoint_uuid: The UUID of the checkpoint to register.
         """
-        resp = api.post(
-            self._master,
+        resp = self._session.post(
             "/api/v1/models/{}/versions".format(self.name),
             body={"checkpoint_uuid": checkpoint_uuid},
         )
 
         data = resp.json()
 
-        return Checkpoint.from_json(
+        return checkpoint.Checkpoint.from_json(
             {
                 **data["modelVersion"]["checkpoint"],
                 "model_version": data["modelVersion"]["version"],
                 "model_name": data["modelVersion"]["model"]["name"],
             },
-            self._master,
+            self._session,
         )
 
     def add_metadata(self, metadata: Dict[str, Any]) -> None:
@@ -178,8 +177,7 @@ class Model:
         for key, val in metadata.items():
             self.metadata[key] = val
 
-        api.patch(
-            self._master,
+        self._session.patch(
             "/api/v1/models/{}".format(self.name),
             body={"model": {"metadata": self.metadata, "description": self.description}},
         )
@@ -196,8 +194,7 @@ class Model:
             if key in self.metadata:
                 del self.metadata[key]
 
-        api.patch(
-            self._master,
+        self._session.patch(
             "/api/v1/models/{}".format(self.name),
             body={"model": {"metadata": self.metadata, "description": self.description}},
         )
@@ -215,12 +212,12 @@ class Model:
         return "Model(name={}, metadata={})".format(self.name, json.dumps(self.metadata))
 
     @staticmethod
-    def from_json(data: Dict[str, Any], master: str) -> "Model":
+    def from_json(data: Dict[str, Any], session: session.Session) -> "Model":
         return Model(
+            session,
             data["name"],
             data.get("description", ""),
             data.get("creationTime"),
             data.get("lastUpdatedTime"),
             data.get("metadata", {}),
-            master,
         )

--- a/harness/determined/common/experimental/session.py
+++ b/harness/determined/common/experimental/session.py
@@ -1,11 +1,15 @@
 from typing import Optional
 
 from determined.common import util
-from determined.common.api import authentication as auth
+from determined.common.api import authentication
 
 
 class Session:
     def __init__(self, master: Optional[str], user: Optional[str]):
         self._master = master or util.get_default_master_address()
         self._user = user
-        auth.initialize_session(self._master, self._user, try_reauth=True)
+
+        # TODO: use a local Authentication rather than the cli's singleton.
+        authentication.cli_auth = authentication.Authentication(
+            self._master, self._user, try_reauth=True
+        )

--- a/harness/determined/common/experimental/session.py
+++ b/harness/determined/common/experimental/session.py
@@ -1,15 +1,77 @@
-from typing import Optional
+from typing import Any, Dict, Optional
+
+import requests
 
 from determined.common import util
-from determined.common.api import authentication
+from determined.common.api import authentication, certs, request
 
 
 class Session:
-    def __init__(self, master: Optional[str], user: Optional[str]):
+    def __init__(
+        self,
+        master: Optional[str],
+        user: Optional[str],
+        auth: authentication.Authentication,
+        cert: certs.Cert,
+    ) -> None:
         self._master = master or util.get_default_master_address()
         self._user = user
+        self._auth = auth
+        self._cert = cert
 
-        # TODO: use a local Authentication rather than the cli's singleton.
-        authentication.cli_auth = authentication.Authentication(
-            self._master, self._user, try_reauth=True
+    def _do_request(
+        self,
+        method: str,
+        path: str,
+        params: Optional[Dict[str, Any]],
+        body: Optional[Dict[str, Any]],
+    ) -> requests.Response:
+        return request.do_request(
+            method,
+            self._master,
+            path,
+            params=params,
+            body=body,
+            auth=self._auth,
+            cert=self._cert,
         )
+
+    def get(
+        self,
+        path: str,
+        params: Optional[Dict[str, Any]] = None,
+        body: Optional[Dict[str, Any]] = None,
+    ) -> requests.Response:
+        return self._do_request("GET", path, params, body)
+
+    def delete(
+        self,
+        path: str,
+        params: Optional[Dict[str, Any]] = None,
+        body: Optional[Dict[str, Any]] = None,
+    ) -> requests.Response:
+        return self._do_request("DELETE", path, params, body)
+
+    def post(
+        self,
+        path: str,
+        params: Optional[Dict[str, Any]] = None,
+        body: Optional[Dict[str, Any]] = None,
+    ) -> requests.Response:
+        return self._do_request("POST", path, params, body)
+
+    def patch(
+        self,
+        path: str,
+        params: Optional[Dict[str, Any]] = None,
+        body: Optional[Dict[str, Any]] = None,
+    ) -> requests.Response:
+        return self._do_request("PATCH", path, params, body)
+
+    def put(
+        self,
+        path: str,
+        params: Optional[Dict[str, Any]] = None,
+        body: Optional[Dict[str, Any]] = None,
+    ) -> requests.Response:
+        return self._do_request("PUT", path, params, body)

--- a/harness/determined/common/util.py
+++ b/harness/determined/common/util.py
@@ -1,9 +1,11 @@
 import functools
 import io
 import os
+import pathlib
+import platform
 import random
 import sys
-from typing import IO, Any, Callable, Iterator, Sequence, TypeVar, Union, overload
+from typing import IO, Any, Callable, Iterator, Optional, Sequence, TypeVar, Union, overload
 
 from determined.common import yaml
 
@@ -108,3 +110,17 @@ def safe_load_yaml_with_exceptions(yaml_file: Union[io.FileIO, IO[Any]]) -> Any:
         print(err_msg)
         sys.exit(1)
     return config
+
+
+def get_config_path() -> pathlib.Path:
+    system = platform.system()
+    if "Linux" in system and "XDG_CONFIG_HOME" in os.environ:
+        config_path = pathlib.Path(os.environ["XDG_CONFIG_HOME"])
+    elif "Darwin" in system:
+        config_path = pathlib.Path.home().joinpath("Library").joinpath("Application Support")
+    elif "Windows" in system and "LOCALAPPDATA" in os.environ:
+        config_path = pathlib.Path(os.environ["LOCALAPPDATA"])
+    else:
+        config_path = pathlib.Path.home().joinpath(".config")
+
+    return config_path.joinpath("determined")

--- a/harness/determined/common/util.py
+++ b/harness/determined/common/util.py
@@ -5,7 +5,7 @@ import pathlib
 import platform
 import random
 import sys
-from typing import IO, Any, Callable, Iterator, Optional, Sequence, TypeVar, Union, overload
+from typing import IO, Any, Callable, Iterator, Sequence, TypeVar, Union, overload
 
 from determined.common import yaml
 

--- a/harness/determined/deploy/aws/deployment_types/base.py
+++ b/harness/determined/deploy/aws/deployment_types/base.py
@@ -6,7 +6,7 @@ from termcolor import colored
 
 import determined
 import determined.deploy
-from determined.common import api
+from determined.common.api import certs
 from determined.deploy.aws import aws, constants
 from determined.deploy.healthcheck import wait_for_master_url
 
@@ -44,10 +44,11 @@ class DeterminedDeployment(metaclass=abc.ABCMeta):
             print(f.read())
 
     def wait_for_master(self, timeout: int = 5 * 60) -> None:
+        cert = None
         if self.parameters[constants.cloudformation.MASTER_TLS_CERT]:
-            api.request.set_master_cert_bundle(False)
+            cert = certs.Cert(noverify=True)
         master_url = self._get_master_url()
-        return wait_for_master_url(master_url, timeout=timeout)
+        return wait_for_master_url(master_url, timeout=timeout, cert=cert)
 
     def consolidate_parameters(self) -> List[Dict[str, Any]]:
         return [

--- a/harness/determined/deploy/healthcheck.py
+++ b/harness/determined/deploy/healthcheck.py
@@ -1,8 +1,10 @@
 import time
+from typing import Optional
 
 import requests
 
 from determined.common import api
+from determined.common.api import certs
 
 from .errors import MasterTimeoutExpired
 
@@ -14,14 +16,21 @@ def _make_master_url(master_host: str, master_port: int, suffix: str = "") -> st
 
 
 def wait_for_master(
-    master_host: str, master_port: int = 8080, timeout: int = DEFAULT_TIMEOUT
+    master_host: str,
+    master_port: int = 8080,
+    timeout: int = DEFAULT_TIMEOUT,
+    cert: Optional[certs.Cert] = None,
 ) -> None:
     master_url = _make_master_url(master_host, master_port)
 
-    return wait_for_master_url(master_url, timeout)
+    return wait_for_master_url(master_url, timeout, cert)
 
 
-def wait_for_master_url(master_url: str, timeout: int = DEFAULT_TIMEOUT) -> None:
+def wait_for_master_url(
+    master_url: str,
+    timeout: int = DEFAULT_TIMEOUT,
+    cert: Optional[certs.Cert] = None,
+) -> None:
     POLL_INTERVAL = 2
     polling = False
     start_time = time.time()
@@ -29,7 +38,7 @@ def wait_for_master_url(master_url: str, timeout: int = DEFAULT_TIMEOUT) -> None
     try:
         while time.time() - start_time < timeout:
             try:
-                r = api.get(master_url, "info", authenticated=False)
+                r = api.get(master_url, "info", authenticated=False, cert=cert)
                 if r.status_code == requests.codes.ok:
                     return
             except api.errors.MasterNotFoundException:

--- a/harness/determined/exec/harness.py
+++ b/harness/determined/exec/harness.py
@@ -39,6 +39,7 @@ import determined as det
 import determined.common
 from determined import gpu, horovod, layers, load, workload
 from determined.common import constants, storage
+from determined.common.api import certs
 
 ENVIRONMENT_VARIABLE_KEYS = {
     "DET_MASTER_ADDR",
@@ -168,6 +169,11 @@ def main() -> None:
     container_id = os.environ["DET_CONTAINER_ID"]
     hparams = simplejson.loads(os.environ["DET_HPARAMS"])
     initial_work = workload.Workload.from_json(simplejson.loads(os.environ["DET_INITIAL_WORKLOAD"]))
+
+    # TODO: refactor websocket, data_layer, and profiling to to not use the cli_cert.
+    certs.cli_cert = certs.default_load(
+        master_url="http{'s' if use_tls else ''}://{master_addr}:{master_port}"
+    )
 
     with open(os.environ["DET_LATEST_CHECKPOINT"], "r") as f:
         latest_checkpoint = json.load(f)

--- a/harness/determined/experimental/_native.py
+++ b/harness/determined/experimental/_native.py
@@ -7,9 +7,9 @@ from typing import Any, Dict, List, Optional, Tuple, Type
 
 import determined as det
 import determined.common
-import determined.common.api.authentication as auth
 from determined import constants, errors, load, workload
 from determined.common import api, check, context, util
+from determined.common.api import authentication
 
 
 def _in_ipython() -> bool:
@@ -78,7 +78,10 @@ def _submit_experiment(
     # authentication module will attempt to use the token store to grab the
     # current logged-in user. If there is no logged in user found, it will
     # default to constants.DEFAULT_DETERMINED_USER.
-    auth.initialize_session(master_url, requested_user=None, try_reauth=True)
+    # TODO: refactor this to use the python sdk rather than using the cli_auth singleton.
+    authentication.cli_auth = authentication.Authentication(
+        master_url, requested_user=None, try_reauth=True
+    )
 
     if test:
         return api.create_test_experiment_and_follow_logs(master_url, config, exp_context)

--- a/harness/tests/common/test_tls.py
+++ b/harness/tests/common/test_tls.py
@@ -4,7 +4,7 @@ import os
 import pytest
 import requests
 
-from determined.common.api import request
+from determined.common.api import certs, request
 
 TRUSTED_DOMAIN = "https://example.com"
 UNTRUSTED_DOMAIN = "https://untrusted-root.badssl.com"
@@ -12,16 +12,22 @@ UNTRUSTED_CERT_FILE = os.path.join(os.path.dirname(__file__), "untrusted-root.ba
 
 
 def test_custom_tls_certs() -> None:
-    for bundle, raises in [
-        (False, False),
-        (True, True),
-        (UNTRUSTED_CERT_FILE, False),
-        (None, True),
-    ]:
-        request.set_master_cert_bundle(bundle)  # type: ignore
+    with open(UNTRUSTED_CERT_FILE) as f:
+        untrusted_pem = f.read()
 
-        request.get(TRUSTED_DOMAIN, "", authenticated=False)
+    for kwargs, raises in [
+        ({"noverify": True}, False),
+        ({"noverify": False}, True),
+        ({"cert_pem": untrusted_pem}, False),
+        ({}, True),
+    ]:
+        assert isinstance(kwargs, dict)
+        cert = certs.Cert(**kwargs)
+
+        # Trusted domains should always work.
+        request.get(TRUSTED_DOMAIN, "", authenticated=False, cert=cert)
+
         with contextlib.ExitStack() as ctx:
             if raises:
                 ctx.enter_context(pytest.raises(requests.exceptions.SSLError))
-            request.get(UNTRUSTED_DOMAIN, "", authenticated=False)
+            request.get(UNTRUSTED_DOMAIN, "", authenticated=False, cert=cert)


### PR DESCRIPTION
## Description

The authentication.Authentication object was written as a singleton
object for the CLI.  Since the CLI never talked to multiple masters or
wrote to multiple masters, that pattern worked great.

However, the upcoming Python SDK will need more flexibility than that.
Rather than duplicate the existing authentication logic, we can refactor
what exists now to be a bit more flexible so that the Python SDK can
reuse what is already written.

Additionally, this PR introduces an explicit Cert object, and configures all
Python SDK API calls to pass explicit Authentication and Cert objects.

## Test Plan

I am new to the cli authentication logic.  I ran all the following tests manually:

- authentication bootstrapping is automatic
- broken tokens in auth.json get cleaned up automatically
- make sure the fallback to "regular determined user" still works.
- change password for yourself -> token update in file
- change password for other user -> no token update in file
- login works
- logout works
- logout unsets active user
- logout removes token