### PR TITLE
feat: add bind mounts to task container defaults [DET-5362]

### DIFF
--- a/docs/reference/cluster-config.txt
+++ b/docs/reference/cluster-config.txt
@@ -308,6 +308,10 @@ The master supports the following configuration settings:
       daemon. Ignored by resource managers of type ``kubernetes``. See
       :ref:`resources.devices <exp-resources-devices>` for more details.
 
+   -  `bind_mounts`: The default bind mounts to pass to the Docker
+      container. Ignored by resource managers of type ``kubernetes``.
+      See :ref:`resources.devices <exp-bind-mounts>` for more details.
+
 -  ``root``: Specifies the root directory of the state files. Defaults
    to ``/usr/share/determined/master``.
 

--- a/docs/reference/experiment-config.txt
+++ b/docs/reference/experiment-config.txt
@@ -829,6 +829,8 @@ allowed to use.
    ``kubernetes``. See :ref:`master configuration
    <master-configuration>` for details about resource managers.
 
+.. _exp-bind-mounts:
+
 *************
  Bind Mounts
 *************

--- a/docs/release-notes/add-bind-mounts.txt
+++ b/docs/release-notes/add-bind-mounts.txt
@@ -1,0 +1,8 @@
+:orphan:
+
+**New Features**
+
+-  Master Configuration: support ``bind_mounts`` in
+   ``task_container_defaults`` in the master configuration. The
+   configured directories will be mounted for experiments, notebooks,
+   commands, shells, and TensorBoards.

--- a/master/internal/command/command.go
+++ b/master/internal/command/command.go
@@ -58,6 +58,7 @@ func DefaultConfig(taskContainerDefaults *model.TaskContainerDefaultsConfig) mod
 			Devices: expConf.Resources.Devices,
 		},
 		Environment: expConf.Environment,
+		BindMounts:  expConf.BindMounts,
 	}
 }
 

--- a/master/pkg/model/defaults.go
+++ b/master/pkg/model/defaults.go
@@ -120,5 +120,7 @@ func DefaultExperimentConfig(taskContainerDefaults *TaskContainerDefaultsConfig)
 	defaultConfig.Environment.AddCapabilities = taskContainerDefaults.AddCapabilities
 	defaultConfig.Environment.DropCapabilities = taskContainerDefaults.DropCapabilities
 
+	defaultConfig.BindMounts = taskContainerDefaults.BindMounts
+
 	return defaultConfig
 }

--- a/master/pkg/model/task_container_defaults.go
+++ b/master/pkg/model/task_container_defaults.go
@@ -34,6 +34,8 @@ type TaskContainerDefaultsConfig struct {
 	AddCapabilities  []string      `json:"add_capabilities"`
 	DropCapabilities []string      `json:"drop_capabilities"`
 	Devices          DevicesConfig `json:"devices"`
+
+	BindMounts BindMountsConfig `json:"bind_mounts"`
 }
 
 func validatePortRange(portRange string) []error {
@@ -144,4 +146,7 @@ func (c *TaskContainerDefaultsConfig) MergeIntoConfig(config *expconf.Experiment
 		RawRegistryAuth:     c.RegistryAuth,
 	}
 	config.RawEnvironment = schemas.Merge(config.RawEnvironment, &env).(*expconf.EnvironmentConfig)
+
+	bindMounts := c.BindMounts.ToExpconf()
+	config.RawBindMounts = schemas.Merge(config.RawBindMounts, bindMounts).(expconf.BindMountsConfig)
 }


### PR DESCRIPTION
## Description

Add bind mounts to task container defaults to support cluster-level defaults.

## Test Plan

Manually test it.

## Commentary (optional)

N/A

## Checklist

- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
