### PR TITLE
chore: minor edits to cli behaviors

### DIFF
--- a/harness/determined/cli/cli.py
+++ b/harness/determined/cli/cli.py
@@ -215,7 +215,7 @@ def main(args: List[str] = sys.argv[1:]) -> None:
             if always_print_traceback or debug_mode():
                 import traceback
 
-                traceback.print_exc()
+                traceback.print_exc(file=sys.stderr)
 
             parser.exit(1, colored(message + "\n", "red"))
 
@@ -292,4 +292,11 @@ def main(args: List[str] = sys.argv[1:]) -> None:
         except Exception:
             die("Failed to {}".format(parsed_args.func.__name__), always_print_traceback=True)
     except KeyboardInterrupt:
-        parser.exit(3, colored("Interrupting...\n", "red"))
+        # die() may not be defined yet.
+        if debug_mode():
+            import traceback
+
+            traceback.print_exc(file=sys.stderr)
+
+        print(colored("Interrupting...\n", "red"), file=sys.stderr)
+        exit(3)

--- a/harness/determined/cli/version.py
+++ b/harness/determined/cli/version.py
@@ -1,4 +1,5 @@
 import argparse
+import sys
 from typing import Any, Dict, List
 
 import requests
@@ -45,7 +46,8 @@ def check_version(parsed_args: argparse.Namespace) -> None:
                     parsed_args.master
                 ),
                 "yellow",
-            )
+            ),
+            file=sys.stderr,
         )
     elif version.Version(client_version) < version.Version(master_version):
         print(
@@ -53,7 +55,8 @@ def check_version(parsed_args: argparse.Namespace) -> None:
                 "CLI version {} is less than master version {}. "
                 "Consider upgrading the CLI.".format(client_version, master_version),
                 "yellow",
-            )
+            ),
+            file=sys.stderr,
         )
     elif version.Version(client_version) > version.Version(master_version):
         print(
@@ -61,7 +64,8 @@ def check_version(parsed_args: argparse.Namespace) -> None:
                 "Master version {} is less than CLI version {}. "
                 "Consider upgrading the master.".format(master_version, client_version),
                 "yellow",
-            )
+            ),
+            file=sys.stderr,
         )
 
 


### PR DESCRIPTION
## Description

This fixes issues where e.g. `det master config | yq .` would fail if
the master version didn't match the cli version exactly, since the
warnings were printed to stdout rather than stderr.