### PR TITLE
chore: bump default environment CPU and GPU images to tf-2.4

### DIFF
--- a/docs/faq.txt
+++ b/docs/faq.txt
@@ -214,7 +214,7 @@ container image that has been configured for that experiment. Determined
 provides prebuilt Docker images that include TensorFlow 1.15, and 2.4,
 respectively:
 
--  ``determinedai/environments:cuda-11.0-pytorch-1.7-lightning-1.2-tf-2.4-gpu-0.14.0``
+-  ``determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-0.14.0``
    (default)
 -  ``determinedai/environments:cuda-11.0-pytorch-1.7-lightning-1.2-tf-2.4-gpu-0.14.0``
 

--- a/docs/faq.txt
+++ b/docs/faq.txt
@@ -214,7 +214,7 @@ container image that has been configured for that experiment. Determined
 provides prebuilt Docker images that include TensorFlow 1.15, and 2.4,
 respectively:
 
--  ``determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-0.14.0``
+-  ``determinedai/environments:cuda-11.0-pytorch-1.7-lightning-1.2-tf-2.4-gpu-0.14.0``
    (default)
 -  ``determinedai/environments:cuda-11.0-pytorch-1.7-lightning-1.2-tf-2.4-gpu-0.14.0``
 

--- a/docs/how-to/custom-env.txt
+++ b/docs/how-to/custom-env.txt
@@ -110,9 +110,9 @@ and values of the hyperparameters for the current trial.
 .. note::
 
    The default images are
-   ``determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-0.14.0``
+   ``determinedai/environments:cuda-11.0-pytorch-1.7-lightning-1.2-tf-2.4-gpu-0.14.0``
    and
-   ``determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-0.14.0``
+   ``determinedai/environments:py-3.7-pytorch-1.7-lightning-1.2-tf-2.4-cpu-0.14.0``
    for GPU and CPU respectively.
 
 .. _cuda-11-images:
@@ -177,7 +177,7 @@ example of a Dockerfile that installs custom ``conda``-, ``pip``- and
 .. code:: bash
 
    # Determined Image
-   FROM determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-0.14.0
+   FROM determinedai/environments:cuda-11.0-pytorch-1.7-lightning-1.2-tf-2.4-gpu-0.14.0
 
    # Custom Configuration
    RUN apt-get update && \

--- a/docs/reference/cluster-config.txt
+++ b/docs/reference/cluster-config.txt
@@ -269,9 +269,9 @@ The master supports the following configuration settings:
       specifying a dict with two keys, ``cpu`` and ``gpu``. Default
       values:
 
-      -  ``determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-0.14.0``
+      -  ``determinedai/environments:py-3.7-pytorch-1.7-lightning-1.2-tf-2.4-cpu-0.14.0``
          for CPU agents
-      -  ``determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-0.14.0``
+      -  ``determinedai/environments:cuda-11.0-pytorch-1.7-lightning-1.2-tf-2.4-gpu-0.14.0``
          for GPU agents.
 
    -  ``force_pull_image``: Defines the default policy for forcibly

--- a/docs/reference/command-notebook-config.txt
+++ b/docs/reference/command-notebook-config.txt
@@ -52,9 +52,9 @@ The following configuration settings are supported:
       Determined agent machine in the cluster. Users can customize the
       image used for GPU vs. CPU agents by specifying a dict with two
       keys, ``cpu`` and ``gpu``. Defaults to
-      ``determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-0.14.0``
+      ``determinedai/environments:py-3.7-pytorch-1.7-lightning-1.2-tf-2.4-cpu-0.14.0``
       for CPU agents and
-      ``determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-0.14.0``
+      ``determinedai/environments:cuda-11.0-pytorch-1.7-lightning-1.2-tf-2.4-gpu-0.14.0``
       for GPU agents.
 
    -  ``force_pull_image``: Forcibly pull the image from the Docker

--- a/docs/reference/experiment-config.txt
+++ b/docs/reference/experiment-config.txt
@@ -890,9 +890,9 @@ more information on customizing the trial environment, refer to
    GPU vs. CPU agents by specifying a dict with two keys, ``cpu`` and
    ``gpu``. Default values:
 
-   -  ``determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-0.14.0``
+   -  ``determinedai/environments:cuda-11.0-pytorch-1.7-lightning-1.2-tf-2.4-gpu-0.14.0``
       for agents with GPUs.
-   -  ``determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-0.14.0``
+   -  ``determinedai/environments:py-3.7-pytorch-1.7-lightning-1.2-tf-2.4-cpu-0.14.0``
       for agents with only CPUs.
 
 ``force_pull_image``

--- a/docs/reference/helm-config.txt
+++ b/docs/reference/helm-config.txt
@@ -204,12 +204,12 @@ Helm Chart </helm/determined-0.5.0.tgz>`.
    -  ``cpuImage``: Sets the default docker image for all non-gpu tasks.
       If a docker image is specified in the :ref:`experiment config
       <exp-environment-image>` this default is overriden. Defaults to:
-      ``determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-0.14.0``.
+      ``determinedai/environments:py-3.7-pytorch-1.7-lightning-1.2-tf-2.4-cpu-0.14.0``.
 
    -  ``gpuImage``: Sets the default docker image for all gpu tasks. If
       a docker image is specified in the :ref:`experiment config
       <exp-environment-image>` this default is overriden. Defaults to:
-      ``determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-0.14.0``.
+      ``determinedai/environments:cuda-11.0-pytorch-1.7-lightning-1.2-tf-2.4-gpu-0.14.0``.
 
 -  ``enterpriseEdition``: Specifies whether to use Determined enterprise
    edition.

--- a/docs/tutorials/quick-start.txt
+++ b/docs/tutorials/quick-start.txt
@@ -43,10 +43,10 @@ cluster without writing a model, see :ref:`commands-and-shells`.
 .. code::
 
    # For CPU computations
-   docker pull determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-0.14.0
+   docker pull determinedai/environments:py-3.7-pytorch-1.7-lightning-1.2-tf-2.4-cpu-0.14.0
 
    # For GPU computations
-   docker pull determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-0.14.0
+   docker pull determinedai/environments:cuda-11.0-pytorch-1.7-lightning-1.2-tf-2.4-gpu-0.14.0
 
 .. _quick-start-first-job:
 

--- a/examples/computer_vision/mmdetection_pytorch/docker/Dockerfile
+++ b/examples/computer_vision/mmdetection_pytorch/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-606fd02
+FROM determinedai/environments:cuda-11.0-pytorch-1.7-lightning-1.2-tf-2.4-gpu-606fd02
 
 ENV TORCH_CUDA_ARCH_LIST="6.0 6.1 7.0+PTX"
 ENV TORCH_NVCC_FLAGS="-Xfatbin -compress-all"

--- a/examples/decision_trees/gbt_titanic_estimator/adaptive.yaml
+++ b/examples/decision_trees/gbt_titanic_estimator/adaptive.yaml
@@ -42,4 +42,4 @@ searcher:
 entrypoint: model_def:BoostedTreesTrial
 scheduling_unit: 1
 environment:
-  image: "determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-0.14.0"
+  image: "determinedai/environments:py-3.7-pytorch-1.7-lightning-1.2-tf-2.4-cpu-0.14.0"

--- a/examples/decision_trees/gbt_titanic_estimator/const.yaml
+++ b/examples/decision_trees/gbt_titanic_estimator/const.yaml
@@ -20,4 +20,4 @@ searcher:
 entrypoint: model_def:BoostedTreesTrial
 scheduling_unit: 1
 environment:
-  image: "determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-0.14.0"
+  image: "determinedai/environments:py-3.7-pytorch-1.7-lightning-1.2-tf-2.4-cpu-0.14.0"

--- a/master/pkg/model/defaults.go
+++ b/master/pkg/model/defaults.go
@@ -25,8 +25,8 @@ const (
 
 // Default task environment docker image names.
 const (
-	defaultCPUImage = "determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-606fd02"
-	defaultGPUImage = "determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-606fd02"
+	defaultCPUImage = "determinedai/environments:py-3.7-pytorch-1.7-lightning-1.2-tf-2.4-cpu-606fd02"
+	defaultGPUImage = "determinedai/environments:cuda-11.0-pytorch-1.7-lightning-1.2-tf-2.4-gpu-606fd02"
 )
 
 // DefaultExperimentConfig returns a new default experiment config.

--- a/master/pkg/schemas/expconf/const.go
+++ b/master/pkg/schemas/expconf/const.go
@@ -8,6 +8,6 @@ const (
 
 // Default task environment docker image names.
 const (
-	DefaultCPUImage = "determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-606fd02"
-	DefaultGPUImage = "determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-606fd02"
+	DefaultCPUImage = "determinedai/environments:py-3.7-pytorch-1.7-lightning-1.2-tf-2.4-cpu-606fd02"
+	DefaultGPUImage = "determinedai/environments:cuda-11.0-pytorch-1.7-lightning-1.2-tf-2.4-gpu-606fd02"
 )

--- a/webui/react/src/fixtures/responses/experiment-details/non-scalar-metrics-4078.json
+++ b/webui/react/src/fixtures/responses/experiment-details/non-scalar-metrics-4078.json
@@ -31,8 +31,8 @@
     "description": "Fork of Fork of mnist_tp_to_estimator_const",
     "environment": {
       "image": {
-        "cpu": "determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-606fd02",
-        "gpu": "determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-606fd02"
+        "cpu": "determinedai/environments:py-3.7-pytorch-1.7-lightning-1.2-tf-2.4-cpu-606fd02",
+        "gpu": "determinedai/environments:cuda-11.0-pytorch-1.7-lightning-1.2-tf-2.4-gpu-606fd02"
       },
       "ports": null,
       "pod_spec": null,

--- a/webui/react/src/fixtures/responses/experiment-details/set-a.json
+++ b/webui/react/src/fixtures/responses/experiment-details/set-a.json
@@ -694,8 +694,8 @@
         "environment_variables": {},
         "force_pull_image": false,
         "image": {
-          "cpu": "determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-606fd02",
-          "gpu": "determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-606fd02"
+          "cpu": "determinedai/environments:py-3.7-pytorch-1.7-lightning-1.2-tf-2.4-cpu-606fd02",
+          "gpu": "determinedai/environments:cuda-11.0-pytorch-1.7-lightning-1.2-tf-2.4-gpu-606fd02"
         },
         "pod_spec": null,
         "ports": null
@@ -838,8 +838,8 @@
         "environment_variables": {},
         "force_pull_image": false,
         "image": {
-          "cpu": "determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-606fd02",
-          "gpu": "determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-606fd02"
+          "cpu": "determinedai/environments:py-3.7-pytorch-1.7-lightning-1.2-tf-2.4-cpu-606fd02",
+          "gpu": "determinedai/environments:cuda-11.0-pytorch-1.7-lightning-1.2-tf-2.4-gpu-606fd02"
         },
         "pod_spec": {
           "metadata": {
@@ -2596,8 +2596,8 @@
       "description": "noop_adaptive",
       "environment": {
         "image": {
-          "cpu": "determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-606fd02",
-          "gpu": "determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-606fd02"
+          "cpu": "determinedai/environments:py-3.7-pytorch-1.7-lightning-1.2-tf-2.4-cpu-606fd02",
+          "gpu": "determinedai/environments:cuda-11.0-pytorch-1.7-lightning-1.2-tf-2.4-gpu-606fd02"
         },
         "ports": null,
         "pod_spec": null,

--- a/webui/react/src/fixtures/responses/trial-details/old-trial-config-noop-adaptive.json
+++ b/webui/react/src/fixtures/responses/trial-details/old-trial-config-noop-adaptive.json
@@ -29,8 +29,8 @@
   "description": "noop_adaptive",
   "environment": {
     "image": {
-      "cpu": "determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-606fd02",
-      "gpu": "determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-606fd02"
+      "cpu": "determinedai/environments:py-3.7-pytorch-1.7-lightning-1.2-tf-2.4-cpu-606fd02",
+      "gpu": "determinedai/environments:cuda-11.0-pytorch-1.7-lightning-1.2-tf-2.4-gpu-606fd02"
     },
     "ports": null,
     "force_pull_image": false,


### PR DESCRIPTION
tf-2.4 builds have been stable for a while now, updating default model builds as a prerequisite for integration with Tensorflow's profiler plugin for tensorboard 2.2+.

