### PR TITLE
fix: stop parsing notebook config on every edit [DET-5605]

### DIFF
--- a/webui/react/src/components/NotebookModal.tsx
+++ b/webui/react/src/components/NotebookModal.tsx
@@ -210,6 +210,8 @@ const NotebookFullConfig:React.FC<FullConfigProps> = (
               minimap: { enabled: false },
               scrollBeyondLastLine: false,
               selectOnLineNumbers: true,
+              wordWrap: 'on',
+              wrappingIndent: 'indent',
             }}
           />
         </Item>

--- a/webui/react/src/components/NotebookModal.tsx
+++ b/webui/react/src/components/NotebookModal.tsx
@@ -71,9 +71,9 @@ interface FormProps {
 }
 
 interface FullConfigProps {
-  config?: RawJson;
+  config?: string;
   configError?: string;
-  onChange: (config: RawJson) => void;
+  onChange: (config: string) => void;
   setButtonDisabled: (buttonDisabled: boolean) => void;
 }
 
@@ -89,7 +89,7 @@ const NotebookModal: React.FC<NotebookModalProps> = (
 
   const [ showFullConfig, setShowFullConfig ] = useState(false);
   const [ fields, dispatch ] = useNotebookForm();
-  const [ config, setConfig ] = useState<RawJson | undefined>();
+  const [ config, setConfig ] = useState<string | undefined>();
   const [ buttonDisabled, setButtonDisabled ] = useState(false);
 
   const fetchConfig = useCallback(async () => {
@@ -100,7 +100,7 @@ const NotebookModal: React.FC<NotebookModalProps> = (
         fields.name,
         fields.pool,
       );
-      setConfig(newConfig);
+      setConfig(yaml.dump(newConfig));
     } catch (e) {
       setConfig(undefined);
     }
@@ -119,7 +119,7 @@ const NotebookModal: React.FC<NotebookModalProps> = (
 
   const handleCreateEnvironment = useCallback(() => {
     if (showFullConfig) {
-      launchNotebook(config);
+      launchNotebook(yaml.load(config || '') as RawJson);
     } else {
       launchNotebook(
         undefined,
@@ -132,7 +132,7 @@ const NotebookModal: React.FC<NotebookModalProps> = (
     if (onLaunch) onLaunch();
   }, [ config, fields, onLaunch, showFullConfig ]);
 
-  const handleConfigChange = useCallback((config: RawJson) => setConfig(config), []);
+  const handleConfigChange = useCallback((config: string) => setConfig(config), []);
 
   return (
     <Modal
@@ -165,15 +165,14 @@ const NotebookFullConfig:React.FC<FullConfigProps> = (
   const [ field, setField ] = useState([ { name: 'config', value: '' } ]);
 
   useEffect(() => {
-    setField([ { name: 'config', value: yaml.dump(config) } ]);
+    setField([ { name: 'config', value: config || '' } ]);
   }, [ config ]);
 
   const handleConfigChange = useCallback((_, allFields) => {
     if (!Array.isArray(allFields) || allFields.length === 0) return;
     try {
       const configString = allFields[0].value;
-      const config = yaml.load(configString) as RawJson;
-      onChange(config);
+      onChange(configString);
     } catch (e) {}
   }, [ onChange ]);
 


### PR DESCRIPTION
## Description
The full notebook config was being parsed as yaml after every edit, leading to unwanted results such as deleting the number of slots and having null automatically filled in it's place. This fixes that problem by only parsing the config when launching a new notebook and treating it as text beforehand. This PR also adds word wrapping to the editor.
<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234