### PR TITLE
ci: clean up persistent volumes on GKE

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -473,6 +473,9 @@ commands:
       region:
         type: string
     steps:
+      - helm/delete-helm-release:
+          helm-version: v3.2.4
+          release-name: ci
       # Use a run instead of `gke/delete-cluster` because circle CI orbs do not support `when`.
       - run:
           name: Terminate GKE Cluster


### PR DESCRIPTION
## Description

The retain policy is already set to "Delete" for the PVs, but if you don't actually remove the pods and claims before destroying the cluster, they don't actually get freed up.

## Test Plan

Ran the K8s tests in an upstream branch - appears the disks got cleaned up.