### PR TITLE
fix: dedup BindMounts and Devices on merge

### DIFF
--- a/master/pkg/schemas/expconf/experiment_config.go
+++ b/master/pkg/schemas/expconf/experiment_config.go
@@ -223,7 +223,17 @@ func (b BindMountsConfigV0) Merge(other interface{}) interface{} {
 	// Merge by appending.
 	out := BindMountsConfigV0{}
 	out = append(out, b...)
-	out = append(out, tOther...)
+
+	// Prevent duplicate container paths as a result of the merge.
+	paths := map[string]bool{}
+	for _, mount := range b {
+		paths[mount.ContainerPath()] = true
+	}
+	for _, mount := range tOther {
+		if _, ok := paths[mount.ContainerPath()]; !ok {
+			out = append(out, mount)
+		}
+	}
 	return out
 }
 
@@ -241,12 +251,22 @@ type BindMountV0 struct {
 type DevicesConfigV0 []DeviceV0
 
 // Merge implements the Mergable interface.
-func (b DevicesConfigV0) Merge(other interface{}) interface{} {
+func (d DevicesConfigV0) Merge(other interface{}) interface{} {
 	tOther := other.(DevicesConfigV0)
 	// Merge by appending.
 	out := DevicesConfigV0{}
-	out = append(out, b...)
-	out = append(out, tOther...)
+	out = append(out, d...)
+
+	// Prevent duplicate container paths as a result of the merge.
+	paths := map[string]bool{}
+	for _, mount := range d {
+		paths[mount.ContainerPath()] = true
+	}
+	for _, mount := range tOther {
+		if _, ok := paths[mount.ContainerPath()]; !ok {
+			out = append(out, mount)
+		}
+	}
 	return out
 }
 

--- a/master/pkg/schemas/expconf/experiment_config_test.go
+++ b/master/pkg/schemas/expconf/experiment_config_test.go
@@ -7,31 +7,7 @@ import (
 	"gotest.tools/assert"
 
 	"github.com/determined-ai/determined/master/pkg/ptrs"
-	"github.com/determined-ai/determined/master/pkg/schemas"
 )
-
-func TestBindMountsMerge(t *testing.T) {
-	e1 := ExperimentConfig{
-		RawBindMounts: BindMountsConfig{
-			BindMount{
-				RawHostPath:      "/host/e1",
-				RawContainerPath: "/container/e1",
-			},
-		},
-	}
-	e2 := ExperimentConfig{
-		RawBindMounts: BindMountsConfig{
-			BindMount{
-				RawHostPath:      "/host/e2",
-				RawContainerPath: "/container/e2",
-			},
-		},
-	}
-	out := schemas.Merge(e1, e2).(ExperimentConfig)
-	assert.Assert(t, len(out.RawBindMounts) == 2)
-	assert.Assert(t, out.RawBindMounts[0].RawHostPath == "/host/e1")
-	assert.Assert(t, out.RawBindMounts[1].RawHostPath == "/host/e2")
-}
 
 func TestName(t *testing.T) {
 	config := ExperimentConfig{

--- a/schemas/test_cases/v0/merging.yaml
+++ b/schemas/test_cases/v0/merging.yaml
@@ -1,4 +1,4 @@
-- name: bind mounts append when merged
+- name: unique bind mounts append when merged
   merge_as: http://determined.ai/schemas/expconf/v0/bind-mounts.json
   case:
     - host_path: /asdf
@@ -6,6 +6,8 @@
   merge_src:
     - host_path: /zxcv
       container_path: /zxcv
+    - host_path: /not_asdf
+      container_path: /asdf
   merged:
     - host_path: /asdf
       container_path: /asdf
@@ -16,7 +18,7 @@
       propagation:
       read_only:
 
-- name: devices append when merged
+- name: unique devices append when merged
   merge_as: http://determined.ai/schemas/expconf/v0/devices.json
   case:
     - host_path: /asdf
@@ -24,6 +26,8 @@
   merge_src:
     - host_path: /zxcv
       container_path: /zxcv
+    - host_path: /not_asdf
+      container_path: /asdf
   merged:
     - host_path: /asdf
       container_path: /asdf


### PR DESCRIPTION
Previously, forking an experiment with either devices or bind_mounts set
in the task_container_defaults at the master level would add duplicate
entries to the devices or bind_mounts (since the master injected them
into the original experiment, and injected them again after forking the
original experiment).

This does not dedup duplicates which already existed in the config,
since a schemas.Merge() operation should not actually fix an
already-broken user-provided config.  Instead, it should just never
break a user-provided config.

## Test Plan

Added merge tests for these two objects.