### PR TITLE
fix: erroneous warning with PyTorchCallback

### DIFF
--- a/harness/determined/pytorch/_pytorch_trial.py
+++ b/harness/determined/pytorch/_pytorch_trial.py
@@ -395,10 +395,11 @@ class PyTorchTrialController(det.LoopTrialController):
             model.eval()
 
         for callback in self.callbacks.values():
-            logging.warning(
-                "on_validation_step_start is now deprecated, please use on_validation_start instead"
-            )
-            callback.on_validation_step_start()
+            if util.is_overridden(callback.on_validation_step_start, pytorch.PyTorchCallback):
+                logging.warning(
+                    "on_validation_step_start is now deprecated, please use on_validation_start instead"
+                )
+                callback.on_validation_step_start()
 
         for callback in self.callbacks.values():
             callback.on_validation_start()
@@ -486,10 +487,11 @@ class PyTorchTrialController(det.LoopTrialController):
             metrics = hvd.broadcast_object(metrics, root_rank=0)
 
         for callback in self.callbacks.values():
-            logging.warning(
-                "on_validation_step_end is now deprecated, please use on_validation_end instead"
-            )
-            callback.on_validation_step_end(metrics)
+            if util.is_overridden(callback.on_validation_step_end, pytorch.PyTorchCallback):
+                logging.warning(
+                    "on_validation_step_end is now deprecated, please use on_validation_end instead"
+                )
+                callback.on_validation_step_end(metrics)
 
         for callback in self.callbacks.values():
             callback.on_validation_end(metrics)

--- a/harness/determined/pytorch/_pytorch_trial.py
+++ b/harness/determined/pytorch/_pytorch_trial.py
@@ -397,7 +397,8 @@ class PyTorchTrialController(det.LoopTrialController):
         for callback in self.callbacks.values():
             if util.is_overridden(callback.on_validation_step_start, pytorch.PyTorchCallback):
                 logging.warning(
-                    "on_validation_step_start is now deprecated, please use on_validation_start instead"
+                    "on_validation_step_start is now deprecated, "
+                    "please use on_validation_start instead"
                 )
                 callback.on_validation_step_start()
 


### PR DESCRIPTION
Previously, PyTorchTrial would issue warnings about
on_validation_step_start and on_validation_step_end anytime you provided
any PyTorchCallback, regardless of whether or not you used the
deprecated methods.