### PR TITLE
fix: loosen check on context.wrap_optimizer()

### DIFF
--- a/harness/determined/keras/_tf_keras_context.py
+++ b/harness/determined/keras/_tf_keras_context.py
@@ -334,10 +334,10 @@ class TFKerasContext:
             self._compiled_optimizer = optimizer
             return optimizer
 
-        if optimizer in self._wrapped_optimizers:
+        if len(self._wrapped_optimizers) > 0:
             logging.debug(
                 "Skipping wrapping optimizer that is part of the compile "
-                "call as it was already wrapped explicitly via wrap_optimizer()."
+                "call as the user has already used the wrap_optimizer() API."
             )
             wrapped_optimizer = optimizer
         else:


### PR DESCRIPTION
Previously, TFKerasTrial would automatically call wrap_optimizer()
on the optimizer argument to a user's `model.compile()` call, unless
that optimizer had already been wrapped with a context.wrap_optimizer()
explicitly by the user.

This was originally designed to allow subclassed keras.models.Model
classes with multiple optimizers in a way which was backwards-compatible
with models that worked before context.wrap_optimizer() was introduced.

However, there are actually 'meta' optimizers in tensorflow_addons which
don't really need to be wrapped by horovod at all, though typically the
meta optimizers wrap a "real" optimizer that does need to be wrapped by
horovod.

The original backwards compatible behavior was too overbearing; it
assumed that all optimizers needed to be wrapped by horovod.  This PR
changes that assumption to say "if the user calls
context.wrap_optimizer() at all then assume they know what they're doing".

## Test Plan

I will ensure that this fix works for the customer.