### PR TITLE
fix: transformers links in example READMEs

### DIFF
--- a/model_hub/examples/huggingface/multiple-choice/README.md
+++ b/model_hub/examples/huggingface/multiple-choice/README.md
@@ -1,5 +1,5 @@
 # Multiple Choice
-This example mirrors the [multiple choice example](https://github.com/huggingface/transformers/tree/master/examples/multiple-choice) from the original huggingface transformers repo for finetuning on the SWAG dataset.
+This example mirrors the [multiple choice example](https://github.com/huggingface/transformers/tree/master/examples/pytorch/multiple-choice) from the original huggingface transformers repo for finetuning on the SWAG dataset.
 
 ## Files
 * **swag_trial.py**: The [PyTorchTrial definition](https://docs.determined.ai/latest/reference/api/pytorch.html#pytorch-trial) for this example. A few class methods are overwritten and specialized for named-entity recognition but otherwise the behavior is the same as the [BaseTransformerTrial class](../model_hub/transformers/_trial.py).

--- a/model_hub/examples/huggingface/text-classification/README.md
+++ b/model_hub/examples/huggingface/text-classification/README.md
@@ -1,5 +1,5 @@
 # Text Classification
-The two examples here mirror the [text-classification examples](https://github.com/huggingface/transformers/tree/master/examples/text-classification) from the original huggingface transformers repo.
+The two examples here mirror the [text-classification examples](https://github.com/huggingface/transformers/tree/master/examples/pytorch/text-classification) from the original huggingface transformers repo.
 
 ## GLUE Benchmark
 

--- a/model_hub/examples/huggingface/token-classification/README.md
+++ b/model_hub/examples/huggingface/token-classification/README.md
@@ -1,9 +1,9 @@
 # Token Classification
-This example mirrors the [token-classification example](https://github.com/huggingface/transformers/tree/master/examples/token-classification) from the original huggingface transformers repo for named-entity recognition.
+This example mirrors the [token-classification example](https://github.com/huggingface/transformers/tree/master/examples/pytorch/token-classification) from the original huggingface transformers repo for named-entity recognition.
 
 ## Files
 * **ner_trial.py**: The [PyTorchTrial definition](https://docs.determined.ai/latest/reference/api/pytorch.html#pytorch-trial) for this example. A few class methods are overwritten and specialized for named-entity recognition but otherwise the behavior is the same as the [BaseTransformerTrial class](../model_hub/transformers/_trial.py).
-* **ner_utils.py**: Utility functions for NER largely extracted from [run_ner.py](https://github.com/huggingface/transformers/tree/master/examples/token-classification/run_ner.py) to separate example code from Determined code.
+* **ner_utils.py**: Utility functions for NER largely extracted from [run_ner.py](https://github.com/huggingface/transformers/tree/master/examples/pytorch/token-classification/run_ner.py) to separate example code from Determined code.
 
 ### Configuration Files
 * **ner_config.yaml**: Experiment configuration file for finetuning on the CoNLL-2003 dataset with BERT.  These values match the [default values](https://github.com/huggingface/transformers/blob/master/src/transformers/training_args.py) used for transformer's Trainer.


### PR DESCRIPTION


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
