### PR TITLE
chore: upgrade the version of Terraform used to deploy docs

### DIFF
--- a/docs/deploy/main.tf
+++ b/docs/deploy/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 0.12"
+  required_version = "~> 1.0"
 
   backend "s3" {
     bucket = "determined-ai-docs-terraform"


### PR DESCRIPTION
## Description

With the release of Terraform 1.0.0, the old version constraint was no
longer satisfied by the latest Terraform image.

## Test Plan

- [x] Publish docs... it seems to have completed successfully, so it's good, right?
