### PR TITLE
fix: update name and description in exp/trial headers [DET-5668][DET-5669]

### DIFF
--- a/webui/react/src/pages/ExperimentDetails/ExperimentDetailsHeader.tsx
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentDetailsHeader.tsx
@@ -121,8 +121,8 @@ const ExperimentDetailsHeader: React.FC<Props> = (
       <PageHeaderFoldable
         foldableContent={<>
           <div className={css.foldableItem}>
-            <span>Name:</span>
-            {experiment.name}
+            <span>Description:</span>
+            {experiment.description}
           </div>
           <div className={css.foldableItem}>
             <span>Start Time:</span>
@@ -136,10 +136,6 @@ const ExperimentDetailsHeader: React.FC<Props> = (
               {shortEnglishHumannizer(getDuration(experiment))}
             </div>
           )}
-          <div className={css.foldableItem}>
-            <span>Description:</span>
-            {experiment.description}
-          </div>
           <TagList
             ghost={true}
             tags={experiment.config.labels || []}
@@ -149,7 +145,7 @@ const ExperimentDetailsHeader: React.FC<Props> = (
         leftContent={<>
           <ExperimentState experiment={experiment} />
           <div className={css.experimentTitle}>
-            Experiment {experiment.id} <span>({experiment.name})</span>
+            Experiment {experiment.id} | <span>{experiment.name}</span>
           </div>
         </>}
         options={headerOptions}

--- a/webui/react/src/pages/TrialDetails.tsx
+++ b/webui/react/src/pages/TrialDetails.tsx
@@ -259,6 +259,7 @@ const TrialDetailsComp: React.FC = () => {
         },
       ]}
       headerComponent={isShowNewHeader && <TrialDetailsHeader
+        experiment={experiment}
         fetchTrialDetails={fetchTrialDetails}
         handleActionClick={handleActionClick}
         trial={trial}

--- a/webui/react/src/pages/TrialDetails/Header/TrialHeaderLeft.module.scss
+++ b/webui/react/src/pages/TrialDetails/Header/TrialHeaderLeft.module.scss
@@ -1,7 +1,19 @@
 .experiment {
+  align-items: center;
   color: var(--theme-colors-monochrome-17);
+  display: flex;
+  overflow: hidden;
+  text-overflow: ellipsis;
   transition: opacity 0.3s;
+  width: 100%;
 
+  span {
+    display: inline-block;
+    margin-left: 4px;
+    opacity: 0.75;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
   i {
     margin-left: var(--theme-sizes-layout-medium);
   }
@@ -26,6 +38,7 @@
 @media only screen and (min-width: $breakpoint-tablet) {
   .experiment {
     margin-right: var(--theme-sizes-layout-medium);
+    width: auto;
   }
   .trial {
     margin-top: 0;

--- a/webui/react/src/pages/TrialDetails/Header/TrialHeaderLeft.tsx
+++ b/webui/react/src/pages/TrialDetails/Header/TrialHeaderLeft.tsx
@@ -4,19 +4,20 @@ import { Link } from 'react-router-dom';
 import Icon from 'components/Icon';
 import { paths } from 'routes/utils';
 import { getStateColorCssVar } from 'themes';
-import { TrialDetails } from 'types';
+import { ExperimentBase, TrialDetails } from 'types';
 
 import css from './TrialHeaderLeft.module.scss';
 
 interface Props {
+  experiment: ExperimentBase;
   trial: TrialDetails;
 }
 
-const TrialHeaderLeft: React.FC<Props> = ({ trial }: Props) => {
+const TrialHeaderLeft: React.FC<Props> = ({ experiment, trial }: Props) => {
   return (
     <>
       <Link className={css.experiment} to={paths.experimentDetails(trial.experimentId)}>
-        Experiment {trial.experimentId}
+        Experiment {trial.experimentId} | <span>{experiment.name}</span>
         <Icon name="arrow-right" size="tiny" />
       </Link>
       <div className={css.trial}>

--- a/webui/react/src/pages/TrialDetails/TrialDetailsHeader.tsx
+++ b/webui/react/src/pages/TrialDetails/TrialDetailsHeader.tsx
@@ -6,17 +6,18 @@ import TrialHeaderLeft from 'pages/TrialDetails/Header/TrialHeaderLeft';
 import { Action, trialWillNeverHaveData } from 'pages/TrialDetails/TrialActions';
 import { openOrCreateTensorboard } from 'services/api';
 import { getStateColorCssVar } from 'themes';
-import { TrialDetails } from 'types';
+import { ExperimentBase, TrialDetails } from 'types';
 import { openCommand } from 'wait';
 
 interface Props {
+  experiment: ExperimentBase;
   fetchTrialDetails: () => void;
   handleActionClick: (action: Action) => void;
   trial: TrialDetails;
 }
 
 const TrialDetailsHeader: React.FC<Props> = (
-  { fetchTrialDetails, handleActionClick, trial }: Props,
+  { experiment, fetchTrialDetails, handleActionClick, trial }: Props,
 ) => {
   const [ isRunningTensorboard, setIsRunningTensorboard ] = useState<boolean>(false);
 
@@ -65,7 +66,7 @@ const TrialDetailsHeader: React.FC<Props> = (
 
   return (
     <PageHeaderFoldable
-      leftContent={<TrialHeaderLeft trial={trial} />}
+      leftContent={<TrialHeaderLeft experiment={experiment} trial={trial} />}
       options={headerOptions}
       style={{ backgroundColor: getStateColorCssVar(trial.state) }}
     />


### PR DESCRIPTION

## Description

BEFORE:

![Schermata 2021-06-17 alle 11 12 49](https://user-images.githubusercontent.com/5413702/122367783-094ecf00-cf5d-11eb-9131-dafb0e85990d.png)

AFTER:

![Schermata 2021-06-17 alle 11 12 26](https://user-images.githubusercontent.com/5413702/122367796-0c49bf80-cf5d-11eb-9b33-a79baf083643.png)



## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
