### PR TITLE
fix: add download model to visible header buttons [DET-5670]

### DIFF
--- a/webui/react/src/components/PageHeaderFoldable.module.scss
+++ b/webui/react/src/components/PageHeaderFoldable.module.scss
@@ -108,3 +108,15 @@
     display: none !important;
   }
 }
+
+@media only screen and (min-width: $breakpoint-desktop-large) {
+  .optionsMainButton:nth-child(3) {
+    display: inline-block;
+  }
+  .optionsDropdownItem:nth-child(3) {
+    display: none;
+  }
+  .optionsDropdownThreeChild {
+    display: none !important;
+  }
+}

--- a/webui/react/src/components/PageHeaderFoldable.tsx
+++ b/webui/react/src/components/PageHeaderFoldable.tsx
@@ -38,6 +38,7 @@ const PageHeaderFoldable: React.FC<Props> = (
   if (options && options.length > 0) {
     if (options.length === 1) dropdownClasses.push(css.optionsDropdownOneChild);
     if (options.length === 2) dropdownClasses.push(css.optionsDropdownTwoChild);
+    if (options.length === 3) dropdownClasses.push(css.optionsDropdownThreeChild);
     dropdownOptions = (
       <Menu>
         {options.map(opt => (
@@ -67,7 +68,7 @@ const PageHeaderFoldable: React.FC<Props> = (
         )}
 
         <div className={css.options}>
-          {options && options.slice(0, 2).map((opt, i) => (
+          {options && options.slice(0, 3).map((opt, i) => (
             <Button
               className={css.optionsMainButton}
               disabled={!opt.onClick}

--- a/webui/react/src/pages/ExperimentDetails/ExperimentDetailsHeader.tsx
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentDetailsHeader.tsx
@@ -62,6 +62,7 @@ const ExperimentDetailsHeader: React.FC<Props> = (
         },
       },
       {
+        icon: <Icon name="download" size="small" />,
         key: 'download-model',
         label: 'Download Model',
         onClick: (e) => {

--- a/webui/react/src/styles/global.scss
+++ b/webui/react/src/styles/global.scss
@@ -2,3 +2,4 @@ $breakpoint-mobile: 480px;
 $breakpoint-tablet: 768px;
 $breakpoint-desktop-small: 1024px;
 $breakpoint-desktop-medium: 1200px;
+$breakpoint-desktop-large: 1400px;


### PR DESCRIPTION
## Description

That's the 3rd button that will be visible in the header only when width of the page is > 1400px.

Note that with Caleb we decided to keep this simple and use css @media queries to position those buttons.


## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
