### PR TITLE
fix: roll GKE in CircleCI back to 1.18 series.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1447,7 +1447,7 @@ jobs:
         default: 1
       gke-version:
         type: string
-        default: "1.19.9-gke.1900"
+        default: "1.18.17-gke.1901"
       machine-type:
         type: string
         default: "n1-standard-8"
@@ -1517,7 +1517,7 @@ jobs:
         default: 1
       gke-version:
         type: string
-        default: "1.19.9-gke.1900"
+        default: "1.18.17-gke.1901"
       machine-type:
         type: string
         default: "n1-standard-8"


### PR DESCRIPTION
## Description

#2572 cause the gke-parallel job to time out quite often. This PR switches the GKE version to the latest 1.18 instead, and it seems to be working better: https://app.circleci.com/pipelines/github/determined-ai/determined/13464/workflows/9d9db5e6-bfca-4b8e-93ce-592d0ab1a4c7

## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
