### PR TITLE
chore: update ZMQ logic in DistributedContext

### DIFF
--- a/harness/determined/__init__.py
+++ b/harness/determined/__init__.py
@@ -8,7 +8,7 @@ from determined._execution import (
     _local_execution_manager,
     InvalidHP,
 )
-from determined._train_context import NativeContext, TrialContext
+from determined._train_context import NativeContext, TrialContext, DistributedContext, RankInfo
 from determined._trial import Trial
 from determined._experiment_config import ExperimentConfig
 from determined._hparam import Categorical, Constant, Double, Integer, Log

--- a/harness/determined/_rendezvous_info.py
+++ b/harness/determined/_rendezvous_info.py
@@ -2,6 +2,13 @@ from typing import List
 
 
 class RendezvousInfo:
+    """
+    RendezvousInfo was machine identity information that is:
+     - configured as an environment variable in the rendezvous layer
+     - independent of the launch layer
+     - consumed by the launch layer
+    """
+
     def __init__(self, addrs: List[str], rank: int):
         self.addrs = addrs
         self.rank = rank

--- a/harness/determined/_train_context.py
+++ b/harness/determined/_train_context.py
@@ -289,14 +289,6 @@ class DistributedContext:
             # No broadcasting necessary.
             return
 
-        # Why does this work?  Why don't multiple agents in training decide on different ports,
-        # causing them to be unable to communicate?
-        #
-        # Answer: unique port offsets are set on by the determined-master on a per-container basis.
-        # Multi-agent dtrain only allows for one-container-per-node, in which case
-        # unique_port_offset is always 0, and every container in training will agree on the same
-        # port.  Single-agent dtrain always within a single container, so the unique_port_offset
-        # may not be zero but all workers (in that same container) will still agree.
         srv_pub_port = constants.INTER_TRAIN_PROCESS_COMM_PORT_1 + self._unique_port_offset
         srv_pull_port = constants.INTER_TRAIN_PROCESS_COMM_PORT_2 + self._unique_port_offset
 

--- a/harness/determined/_train_context.py
+++ b/harness/determined/_train_context.py
@@ -225,6 +225,7 @@ class DistributedContext:
                     pub_port=srv_pub_port,
                     pull_port=srv_pull_port,
                 )
+                self._chief_zmq.safe_start(lambda: None)
 
             else:
                 chief_ip_address = self._rendezvous_info.get_ip_addresses()[0]
@@ -237,6 +238,7 @@ class DistributedContext:
                     srv_pub_url=f"tcp://{chief_ip_address}:{srv_pub_port}",
                     srv_pull_url=f"tcp://{chief_ip_address}:{srv_pull_port}",
                 )
+                self._worker_zmq.safe_start()
 
     def get_rank(self) -> int:
         """

--- a/harness/determined/_train_context.py
+++ b/harness/determined/_train_context.py
@@ -222,8 +222,8 @@ class DistributedContext:
                 logging.debug(f"Chief setting up server with ports {srv_pub_port}/{srv_pull_port}.")
                 self._chief_zmq = ipc.ZMQBroadcastServer(
                     num_connections=self._env.experiment_config.slots_per_trial() - 1,
-                    pub_port=srv_pub_port,
-                    pull_port=srv_pull_port,
+                    pub_url=f"tcp://*:{srv_pub_port}",
+                    pull_url=f"tcp://*:{srv_pull_port}",
                 )
                 self._chief_zmq.safe_start(lambda: None)
 
@@ -238,7 +238,7 @@ class DistributedContext:
                     srv_pub_url=f"tcp://{chief_ip_address}:{srv_pub_port}",
                     srv_pull_url=f"tcp://{chief_ip_address}:{srv_pull_port}",
                 )
-                self._worker_zmq.safe_start()
+                self._worker_zmq.safe_start(lambda: None)
 
     def get_rank(self) -> int:
         """

--- a/harness/determined/_train_context.py
+++ b/harness/determined/_train_context.py
@@ -213,6 +213,12 @@ class NativeContext(_TrainContext):
 
 
 class RankInfo:
+    """
+    RankInfo was worker identity information that is:
+     - dependent on the launch layer
+     - created/used in the worker process
+    """
+
     def __init__(
         self,
         *,

--- a/harness/determined/_trial_controller.py
+++ b/harness/determined/_trial_controller.py
@@ -104,6 +104,9 @@ class TrialController(metaclass=abc.ABCMeta):
         if env.experiment_config.averaging_training_metrics_enabled():
             check.true(self.supports_averaging_training_metrics())
 
+    def close(self) -> None:
+        self.context.close()
+
 
 class CallbackTrialController(TrialController):
     """

--- a/harness/determined/horovod.py
+++ b/harness/determined/horovod.py
@@ -66,6 +66,26 @@ class _PolyHorovod:
         check.is_not_none(self._poly_hvd_module, "Horovod could not be imported in this process.")
         return getattr(self._poly_hvd_module, attr)
 
+    def cross_rank(self) -> Any:
+        """
+        Horovod versions <= v0.21.3 accidentally did not expose cross_rank or cross_size for keras.
+
+        See https://github.com/horovod/horovod/pull/3008.
+        """
+        if self._poly_hvd_type == "tensorflow.keras":
+            # The horovod.tensorflow module ultimately provides size/local_size/cross_size.
+            import horovod.tensorflow
+
+            return horovod.tensorflow.cross_rank()
+        return self._poly_hvd_module.cross_rank()
+
+    def cross_size(self) -> Any:
+        if self._poly_hvd_type == "tensorflow.keras":
+            import horovod.tensorflow
+
+            return horovod.tensorflow.cross_size()
+        return self._poly_hvd_module.cross_size()
+
 
 hvd = _PolyHorovod()
 

--- a/harness/determined/ipc.py
+++ b/harness/determined/ipc.py
@@ -118,7 +118,7 @@ class ZMQBroadcastServer:
         """
         Broadcast Hello messages over and over until all clients response with a Hello message.
 
-        The reason for this is that the only way to be 100% confidient that a subscriber has
+        The reason for this is that the only way to be 100% confident that a subscriber has
         connected is for it to actually receive a message over the pub/sub connection.
 
         After each client sees its first Hello, it will send a single Hello message to the


### PR DESCRIPTION
## Description

This PR introduce a series of small refactors to support push architecture.

* It fixes a rare hang in the ZMQBroadcastServer/Client.  The hang
  has always been possible but seemingly was not often hit due to the
  ordering of how we ran things.
* It introduces a node-local ZMQBroadcastServer/Client in the
  DistributedContext.  This will be used in push architecture for things
  like coordinating checkpoint downloads.
* It introduces Unix-socket-based ZMQ communication for the node-local
  sever/client, which is slightly faster and less likely to be affected
  by networking issues.
* It adds a test for the DistributedContext, for each of local/global
  broadcast/gather/allgather functions.


## Test Plan

Test added!