### PR TITLE
fix: support Docker images with EXPOSE in notebooks/shells/tensorboard [DET-5648]

### DIFF
--- a/docs/release-notes/2596-fix-expose.txt
+++ b/docs/release-notes/2596-fix-expose.txt
@@ -1,0 +1,7 @@
+:orphan:
+
+**Fixes**
+
+-  Support using Docker images with ``EXPOSE`` commands as images for
+   Notebooks/Shells/Tensorboards. Previously, the ``EXPOSE`` command
+   could break the proxy through the Determined master.

--- a/master/internal/command/command.go
+++ b/master/internal/command/command.go
@@ -74,6 +74,7 @@ type command struct {
 	readinessMessageSent bool
 	metadata             map[string]interface{}
 	serviceAddress       *string
+	assignedPort         int
 
 	registeredTime time.Time
 	task           *sproto.AllocateRequest
@@ -206,8 +207,16 @@ func (c *command) Receive(ctx *actor.Context) error {
 		case msg.Container.State == container.Running:
 			c.addresses = msg.ContainerStarted.Addresses
 
-			names := make([]string, 0, len(c.addresses))
+			var names []string
 			for _, address := range c.addresses {
+				// Only proxy the port we expect to proxy.  If a dockerfile uses an EXPOSE command,
+				// additional addresses will appear her, but currently we only proxy one uuid to one
+				// port, so it doesn't make sense to send multiple proxy.Register messages for a
+				// single ServiceID (only the last one would work).
+				if c.assignedPort == 0 || address.ContainerPort != c.assignedPort {
+					continue
+				}
+
 				// We are keying on task ID instead of container ID. Revisit this when we need to
 				// proxy multi-container tasks or when containers are created prior to being
 				// assigned to an agent.
@@ -220,6 +229,13 @@ func (c *command) Receive(ctx *actor.Context) error {
 					ProxyTCP: c.proxyTCP,
 				})
 				names = append(names, string(c.taskID))
+			}
+			if c.assignedPort == 0 && len(names) > 0 {
+				ctx.Log().Error("Expected to not proxy any ports but proxied one anyway")
+			} else if len(names) != 1 {
+				ctx.Log().Errorf(
+					"Expected to proxy exactly 1 port but proxied %v instead", len(names),
+				)
 			}
 			c.proxyNames = names
 			ctx.Tell(c.eventStream, event{

--- a/master/internal/command/notebook_manager.go
+++ b/master/internal/command/notebook_manager.go
@@ -182,7 +182,7 @@ func (n *notebookManager) newNotebook(params *CommandParams) (*command, error) {
 			},
 		},
 		serviceAddress: &serviceAddress,
-		assignedPort:   port,
+		assignedPort:   &port,
 
 		owner: commandOwner{
 			ID:       params.User.ID,

--- a/master/internal/command/notebook_manager.go
+++ b/master/internal/command/notebook_manager.go
@@ -182,6 +182,7 @@ func (n *notebookManager) newNotebook(params *CommandParams) (*command, error) {
 			},
 		},
 		serviceAddress: &serviceAddress,
+		assignedPort:   port,
 
 		owner: commandOwner{
 			ID:       params.User.ID,

--- a/master/internal/command/shell_manager.go
+++ b/master/internal/command/shell_manager.go
@@ -178,6 +178,7 @@ func (s *shellManager) newShell(
 		},
 
 		serviceAddress: &serviceAddress,
+		assignedPort:   port,
 		owner: commandOwner{
 			ID:       params.User.ID,
 			Username: params.User.Username,

--- a/master/internal/command/shell_manager.go
+++ b/master/internal/command/shell_manager.go
@@ -178,7 +178,7 @@ func (s *shellManager) newShell(
 		},
 
 		serviceAddress: &serviceAddress,
-		assignedPort:   port,
+		assignedPort:   &port,
 		owner: commandOwner{
 			ID:       params.User.ID,
 			Username: params.User.Username,

--- a/master/internal/command/tensorboard_manager.go
+++ b/master/internal/command/tensorboard_manager.go
@@ -346,7 +346,7 @@ func (t *tensorboardManager) newTensorBoard(
 			},
 		},
 		serviceAddress: &serviceAddress,
-		assignedPort:   port,
+		assignedPort:   &port,
 		owner: commandOwner{
 			ID:       params.User.ID,
 			Username: params.User.Username,

--- a/master/internal/command/tensorboard_manager.go
+++ b/master/internal/command/tensorboard_manager.go
@@ -346,6 +346,7 @@ func (t *tensorboardManager) newTensorBoard(
 			},
 		},
 		serviceAddress: &serviceAddress,
+		assignedPort:   port,
 		owner: commandOwner{
 			ID:       params.User.ID,
 			Username: params.User.Username,


### PR DESCRIPTION
## Test Plan

Tested manually.  Note that for the old code to fail, `docker inspect CONTAINER_ID | jq '.[].NetworkSettings'` should show the _wrong_ port last.  The ports seem to be sorted alphanumerically, and we typically pick ports in the 3000 range, so any port that starts with a 4 or higher is a good test port.

Example dockerfile:

```dockerfile
FROM docker.io/determinedai/environments:py-3.7-pytorch-1.7-lightning-1.2-tf-2.4-cpu-3a452bc
EXPOSE 8888
```

```bash
docker build . -t junk && det notebook start --config=environment.image=junk
```