### PR TITLE
feat: support auto bind mount as part of det deploy local [DET-5432]

### DIFF
--- a/docs/reference/cluster-config.txt
+++ b/docs/reference/cluster-config.txt
@@ -308,7 +308,7 @@ The master supports the following configuration settings:
       daemon. Ignored by resource managers of type ``kubernetes``. See
       :ref:`resources.devices <exp-resources-devices>` for more details.
 
-   -  `bind_mounts`: The default bind mounts to pass to the Docker
+   -  ``bind_mounts``: The default bind mounts to pass to the Docker
       container. Ignored by resource managers of type ``kubernetes``.
       See :ref:`resources.devices <exp-bind-mounts>` for more details.
 

--- a/docs/release-notes/5432-local-bind-mount.txt
+++ b/docs/release-notes/5432-local-bind-mount.txt
@@ -2,6 +2,6 @@
 
 **Improvements**
 
--  Automatically bind-mount the user's home directory into task containers
-   for for clusters spun up using `det deploy local` and add a flag to
-   disable this feature.
+-  Automatically bind-mount the user's home directory into task
+   containers for for clusters spun up using `det deploy local` and add
+   a flag to disable this feature.

--- a/docs/release-notes/5432-local-bind-mount.txt
+++ b/docs/release-notes/5432-local-bind-mount.txt
@@ -1,0 +1,7 @@
+:orphan:
+
+**Improvements**
+
+-  Automatically bind-mount the user's home directory into task containers
+   for for clusters spun up using `det deploy local` and add a flag to
+   disable this feature.

--- a/harness/determined/deploy/local/cli.py
+++ b/harness/determined/deploy/local/cli.py
@@ -29,7 +29,7 @@ def handle_cluster_up(args: argparse.Namespace) -> None:
         delete_db=args.delete_db,
         gpu=args.gpu,
         autorestart=(not args.no_autorestart),
-        auto_bind_mount=(not args.no_auto_bind_mount),
+        auto_bind_mount=args.auto_bind_mount,
     )
 
 
@@ -52,7 +52,7 @@ def handle_master_up(args: argparse.Namespace) -> None:
         db_password=args.db_password,
         delete_db=args.delete_db,
         autorestart=(not args.no_autorestart),
-        auto_bind_mount=(not args.no_auto_bind_mount),
+        auto_bind_mount=args.auto_bind_mount,
         cluster_name=args.cluster_name,
     )
 
@@ -159,10 +159,13 @@ args_description = Cmd(
                     help="disable container auto-restart (recommended for local development)",
                     action="store_true",
                 ),
-                Arg(
+                BoolOptArg(
+                    "--auto-bind-mount",
                     "--no-auto-bind-mount",
-                    help="disable bind mounting the user's home directory into task containers",
-                    action="store_true",
+                    dest="auto_bind_mount",
+                    default=True,
+                    true_help="bind mount the user's home directory into task containers",
+                    false_help="disable mounting the user's home directory into task containers",
                 ),
             ],
         ),
@@ -227,10 +230,13 @@ args_description = Cmd(
                     help="disable container auto-restart (recommended for local development)",
                     action="store_true",
                 ),
-                Arg(
+                BoolOptArg(
+                    "--auto-bind-mount",
                     "--no-auto-bind-mount",
-                    help="disable bind mounting the user's home directory into task containers",
-                    action="store_true",
+                    dest="auto_bind_mount",
+                    default=True,
+                    true_help="bind mount the user's home directory into task containers",
+                    false_help="disable mounting the user's home directory into task containers",
                 ),
                 Arg(
                     "--cluster-name",

--- a/harness/determined/deploy/local/cli.py
+++ b/harness/determined/deploy/local/cli.py
@@ -29,6 +29,7 @@ def handle_cluster_up(args: argparse.Namespace) -> None:
         delete_db=args.delete_db,
         gpu=args.gpu,
         autorestart=(not args.no_autorestart),
+        auto_bind_mount=(not args.no_auto_bind_mount),
     )
 
 
@@ -51,6 +52,7 @@ def handle_master_up(args: argparse.Namespace) -> None:
         db_password=args.db_password,
         delete_db=args.delete_db,
         autorestart=(not args.no_autorestart),
+        auto_bind_mount=(not args.no_auto_bind_mount),
         cluster_name=args.cluster_name,
     )
 
@@ -157,6 +159,11 @@ args_description = Cmd(
                     help="disable container auto-restart (recommended for local development)",
                     action="store_true",
                 ),
+                Arg(
+                    "--no-auto-bind-mount",
+                    help="disable bind mounting the user's home directory into task containers",
+                    action="store_true",
+                ),
             ],
         ),
         Cmd(
@@ -218,6 +225,11 @@ args_description = Cmd(
                 Arg(
                     "--no-autorestart",
                     help="disable container auto-restart (recommended for local development)",
+                    action="store_true",
+                ),
+                Arg(
+                    "--no-auto-bind-mount",
+                    help="disable bind mounting the user's home directory into task containers",
                     action="store_true",
                 ),
                 Arg(

--- a/harness/determined/deploy/local/cluster_utils.py
+++ b/harness/determined/deploy/local/cluster_utils.py
@@ -123,7 +123,7 @@ def master_up(
     else:
         restart_policy = "no"
     if auto_bind_mount:
-        bind_mount = "/home"
+        bind_mount = str(Path.home())
     else:
         bind_mount = "no"
 

--- a/harness/determined/deploy/local/cluster_utils.py
+++ b/harness/determined/deploy/local/cluster_utils.py
@@ -125,7 +125,7 @@ def master_up(
     if auto_bind_mount:
         bind_mount = str(Path.home())
     else:
-        bind_mount = "no"
+        bind_mount = ""
 
     env = {
         "INTEGRATIONS_HOST_PORT": str(port),

--- a/harness/determined/deploy/local/cluster_utils.py
+++ b/harness/determined/deploy/local/cluster_utils.py
@@ -109,6 +109,7 @@ def master_up(
     db_password: str,
     delete_db: bool,
     autorestart: bool,
+    auto_bind_mount: bool,
     cluster_name: str,
 ) -> None:
     command = ["up", "-d"]
@@ -121,6 +122,10 @@ def master_up(
         restart_policy = "unless-stopped"
     else:
         restart_policy = "no"
+    if auto_bind_mount:
+        bind_mount = "/home"
+    else:
+        bind_mount = "no"
 
     env = {
         "INTEGRATIONS_HOST_PORT": str(port),
@@ -129,6 +134,7 @@ def master_up(
         "IMAGE_REPO_PREFIX": image_repo_prefix,
         "DET_VERSION": version,
         "DET_RESTART_POLICY": restart_policy,
+        "DET_AUTO_BIND_MOUNT": bind_mount,
     }
 
     # When master config yaml is provided, we don't provide our own storage path
@@ -170,6 +176,7 @@ def cluster_up(
     delete_db: bool,
     gpu: bool,
     autorestart: bool,
+    auto_bind_mount: bool,
 ) -> None:
     cluster_down(cluster_name, delete_db)
     master_up(
@@ -182,6 +189,7 @@ def cluster_up(
         db_password=db_password,
         delete_db=delete_db,
         autorestart=autorestart,
+        auto_bind_mount=auto_bind_mount,
         cluster_name=cluster_name,
     )
     for agent_number in range(num_agents):

--- a/harness/determined/deploy/local/docker-compose.yaml
+++ b/harness/determined/deploy/local/docker-compose.yaml
@@ -25,6 +25,7 @@ services:
       DET_LOG_LEVEL: ${INTEGRATIONS_LOG_LEVEL:-info}
       DET_MASTER_HTTP_PORT: ${INTEGRATIONS_HOST_PORT:-8080}
       DET_DB_PASSWORD: ${DET_DB_PASSWORD}
+      DET_AUTO_BIND_MOUNT: ${DET_AUTO_BIND_MOUNT}
 
 volumes:
   determined-db-volume: {}

--- a/master/cmd/determined-master/init.go
+++ b/master/cmd/determined-master/init.go
@@ -138,4 +138,8 @@ func registerConfig() {
 	// We don't register pflags for these to avoid setting a default.
 	registerEnv(name("checkpoint-storage", "type"))
 	registerEnv(name("checkpoint-storage", "host-path"))
+
+
+    // This env var is used by `det deploy` to override bind_mounts.
+    registerEnv(name("task-container-defaults", "bind-mounts"))
 }

--- a/master/cmd/determined-master/init.go
+++ b/master/cmd/determined-master/init.go
@@ -139,7 +139,6 @@ func registerConfig() {
 	registerEnv(name("checkpoint-storage", "type"))
 	registerEnv(name("checkpoint-storage", "host-path"))
 
-
-    // This env var is used by `det deploy` to override bind_mounts.
-    registerEnv(name("task-container-defaults", "bind-mounts"))
+	// This env var is used by `det deploy` to override bind_mounts.
+	registerEnv(name("auto-bind-mount"))
 }

--- a/master/cmd/determined-master/root.go
+++ b/master/cmd/determined-master/root.go
@@ -123,13 +123,13 @@ func getConfig(configMap map[string]interface{}) (*internal.Config, error) {
 		return nil, errors.Wrap(err, "cannot apply backwards compatibility")
 	}
 
-	configMapv2, err := applyBindMount(configMap)
+	configMap, err = applyBindMount(configMap)
 	if err != nil {
 		return nil, errors.Wrap(err, "invalid bind mount location")
 	}
 
 	config := internal.DefaultConfig()
-	bs, err := json.Marshal(configMapv2)
+	bs, err := json.Marshal(configMap)
 	if err != nil {
 		return nil, errors.Wrap(err, "cannot marshal configuration map into json bytes")
 	}
@@ -153,7 +153,7 @@ func applyBindMount(configMap map[string]interface{}) (map[string]interface{}, e
 		return nil, errors.New("wrong type for bind mount field")
 	}
 
-	if vBindMount != "no" {
+	if vBindMount != "" {
 		_, tcdExisted := configMap["task_container_defaults"]
 		if !tcdExisted {
 			newTCD := make(map[string]interface{})

--- a/master/cmd/determined-master/root.go
+++ b/master/cmd/determined-master/root.go
@@ -154,7 +154,7 @@ func applyBindMount(configMap map[string]interface{}) (map[string]interface{}, e
 	}
 
 	if vBindMount != "" {
-		_, tcdExisted := configMap["task_container_defaults"]
+		tcd, tcdExisted := configMap["task_container_defaults"]
 		if !tcdExisted {
 			newTCD := make(map[string]interface{})
 			bindMounts := []model.BindMount{
@@ -166,7 +166,18 @@ func applyBindMount(configMap map[string]interface{}) (map[string]interface{}, e
 			newTCD["bind_mounts"] = bindMounts
 			configMap["task_container_defaults"] = newTCD
 		} else {
-			return nil, errors.New("have to add code for task container defaults existing")
+			vTCD, ok := tcd.(map[string]interface{})
+			if !ok {
+				return nil, errors.New("wrong type for task_container_defaults field")
+			}
+
+			vTCD["bind_mounts"] = append(
+				vTCD["bind_mounts"].([]model.BindMount),
+				model.BindMount{
+					HostPath:      vBindMount,
+					ContainerPath: "/run/determined/shared_fs",
+				},
+			)
 		}
 	}
 	delete(configMap, "auto_bind_mount")

--- a/master/cmd/determined-master/root.go
+++ b/master/cmd/determined-master/root.go
@@ -158,7 +158,7 @@ func applyBindMount(configMap map[string]interface{}) (map[string]interface{}, e
 		if !tcdExisted {
 			newTCD := make(map[string]interface{})
 			bindMounts := []model.BindMount{
-			    model.BindMount{
+				{
 					HostPath:      vBindMount,
 					ContainerPath: "/run/determined/shared_fs",
 				},

--- a/master/cmd/determined-master/root.go
+++ b/master/cmd/determined-master/root.go
@@ -157,13 +157,14 @@ func applyBindMount(configMap map[string]interface{}) (map[string]interface{}, e
 		_, tcdExisted := configMap["task_container_defaults"]
 		if !tcdExisted {
 			newTCD := make(map[string]interface{})
-			bindMounts := make([]model.BindMount, 1)
-			bindMounts[0] = model.BindMount{
-				HostPath:      vBindMount,
-				ContainerPath: "/run/determined/shared_fs",
+			bindMounts := []model.BindMount{
+			    model.BindMount{
+					HostPath:      vBindMount,
+					ContainerPath: "/run/determined/shared_fs",
+				},
 			}
 			newTCD["bind_mounts"] = bindMounts
-			configMap["task_container_defaults"] = []map[string]interface{}{newTCD}
+			configMap["task_container_defaults"] = newTCD
 		} else {
 			return nil, errors.New("have to add code for task container defaults existing")
 		}


### PR DESCRIPTION
## Description

Add support for automatically bind mounting the user's home directory onto task agents for `det deploy local` and a flag for disabling it.

<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan

Test by running: 
1. `det deploy local cluster-up`, open two files in the base directory and ensure any changes to one happen to the other.
2. `det deploy local cluster-up --no-auto-bind-mount` to ensure normal behavior.

<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234