### PR TITLE
chore: update model-hub transformers base image [DET-5701]

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -30,16 +30,4 @@ values =
 
 [bumpversion:file:helm/charts/determined/Chart.yaml]
 
-[bumpversion:file:model_hub/examples/huggingface/token-classification/ner_config.yaml]
-
-[bumpversion:file:model_hub/examples/huggingface/language-modeling/clm_config.yaml]
-
-[bumpversion:file:model_hub/examples/huggingface/language-modeling/mlm_config.yaml]
-
-[bumpversion:file:model_hub/examples/huggingface/language-modeling/plm_config.yaml]
-
-[bumpversion:file:model_hub/examples/huggingface/multiple-choice/swag_config.yaml]
-
-[bumpversion:file:model_hub/examples/huggingface/text-classification/glue_config.yaml]
-
-[bumpversion:file:model_hub/examples/huggingface/text-classification/xnli_config.yaml]
+[bumpversion:glob:model_hub/examples/huggingface/*/*.yaml]

--- a/model_hub/Makefile
+++ b/model_hub/Makefile
@@ -4,9 +4,9 @@ SHORT_GIT_HASH := $(shell git rev-parse --short HEAD)
 ARTIFACTS_DIR := /tmp/artifacts
 
 # Model-hub library environments will be built on top of the default GPU and CPU images in master/pkg/model/defaults.go
-DEFAULT_GPU_IMAGE := determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-606fd02
-TRANSFORMERS_VERSION := 4.6.1
-DATASETS_VERSION := 1.7.0
+DEFAULT_GPU_IMAGE := determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-2409e48
+TRANSFORMERS_VERSION := 4.8.2
+DATASETS_VERSION := 1.9.0
 TRANSFORMERS_ENVIRONMENT_ROOT := determinedai/model-hub-transformers
 
 # Example dirs

--- a/model_hub/Makefile
+++ b/model_hub/Makefile
@@ -4,7 +4,7 @@ SHORT_GIT_HASH := $(shell git rev-parse --short HEAD)
 ARTIFACTS_DIR := /tmp/artifacts
 
 # Model-hub library environments will be built on top of the default GPU and CPU images in master/pkg/model/defaults.go
-DEFAULT_GPU_IMAGE := determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-2409e48
+DEFAULT_GPU_IMAGE := determinedai/environments:cuda-11.0-pytorch-1.7-lightning-1.2-tf-2.4-gpu-3a452bc
 TRANSFORMERS_VERSION := 4.8.2
 DATASETS_VERSION := 1.9.0
 TRANSFORMERS_ENVIRONMENT_ROOT := determinedai/model-hub-transformers

--- a/model_hub/examples/huggingface/language-modeling/clm_config.yaml
+++ b/model_hub/examples/huggingface/language-modeling/clm_config.yaml
@@ -32,7 +32,8 @@ searcher:
     epochs: 3
   smaller_is_better: true
 environment:
-  image: determinedai/model-hub-transformers:0.16.3.dev0
+  image: 
+    gpu: determinedai/model-hub-transformers:0.16.3.dev0
 resources:
   slots_per_trial: 4
 # We add a bind_mount here so that cached data, tokenized data, and models will be saved to the

--- a/model_hub/examples/huggingface/language-modeling/mlm_config.yaml
+++ b/model_hub/examples/huggingface/language-modeling/mlm_config.yaml
@@ -35,7 +35,8 @@ searcher:
     epochs: 3
   smaller_is_better: true
 environment:
-  image: determinedai/model-hub-transformers:0.16.3.dev0
+  image: 
+    gpu: determinedai/model-hub-transformers:0.16.3.dev0
 resources:
   slots_per_trial: 1
 # We add a bind_mount here so that cached data, tokenized data, and models will be saved to the

--- a/model_hub/examples/huggingface/language-modeling/plm_config.yaml
+++ b/model_hub/examples/huggingface/language-modeling/plm_config.yaml
@@ -36,7 +36,8 @@ searcher:
     epochs: 3
   smaller_is_better: true
 environment:
-  image: determinedai/model-hub-transformers:0.16.3.dev0
+  image: 
+    gpu: determinedai/model-hub-transformers:0.16.3.dev0
 resources:
   slots_per_trial: 2
 # We add a bind_mount here so that cached data, tokenized data, and models will be saved to the

--- a/model_hub/examples/huggingface/multiple-choice/swag_config.yaml
+++ b/model_hub/examples/huggingface/multiple-choice/swag_config.yaml
@@ -32,7 +32,8 @@ searcher:
     epochs: 3
   smaller_is_better: false
 environment:
-  image: determinedai/model-hub-transformers:0.16.3.dev0
+  image: 
+   gpu: determinedai/model-hub-transformers:0.16.3.dev0
 resources:
   slots_per_trial: 2
 # We add a bind_mount here so that cached data, tokenized data, and models will be saved to the

--- a/model_hub/examples/huggingface/question-answering/squad.yaml
+++ b/model_hub/examples/huggingface/question-answering/squad.yaml
@@ -37,7 +37,8 @@ searcher:
     epochs: 2
   smaller_is_better: false
 environment:
-  image: determinedai/model-hub-transformers:0.15.3.dev0
+  image: 
+    gpu: determinedai/model-hub-transformers:0.16.3.dev0
 resources:
   slots_per_trial: 1
 # We add a bind_mount here so that cached data, tokenized data, and models will be saved to the

--- a/model_hub/examples/huggingface/question-answering/squad_beam_search.yaml
+++ b/model_hub/examples/huggingface/question-answering/squad_beam_search.yaml
@@ -36,7 +36,8 @@ searcher:
     epochs: 2
   smaller_is_better: false
 environment:
-  image: determinedai/model-hub-transformers:0.15.3.dev0
+  image: 
+    gpu: determinedai/model-hub-transformers:0.16.3.dev0
 resources:
   slots_per_trial: 1
 # We add a bind_mount here so that cached data, tokenized data, and models will be saved to the

--- a/model_hub/examples/huggingface/question-answering/squad_v2.yaml
+++ b/model_hub/examples/huggingface/question-answering/squad_v2.yaml
@@ -37,7 +37,8 @@ searcher:
     epochs: 4
   smaller_is_better: false
 environment:
-  image: determinedai/model-hub-transformers:0.15.3.dev0
+  image: 
+    gpu: determinedai/model-hub-transformers:0.16.3.dev0
 resources:
   slots_per_trial: 1
 # We add a bind_mount here so that cached data, tokenized data, and models will be saved to the

--- a/model_hub/examples/huggingface/question-answering/squad_v2_beam_search.yaml
+++ b/model_hub/examples/huggingface/question-answering/squad_v2_beam_search.yaml
@@ -37,7 +37,8 @@ searcher:
     epochs: 4
   smaller_is_better: false
 environment:
-  image: determinedai/model-hub-transformers:0.15.3.dev0
+  image: 
+    gpu: determinedai/model-hub-transformers:0.16.3.dev0
 resources:
   slots_per_trial: 1
 # We add a bind_mount here so that cached data, tokenized data, and models will be saved to the

--- a/model_hub/examples/huggingface/text-classification/glue_config.yaml
+++ b/model_hub/examples/huggingface/text-classification/glue_config.yaml
@@ -44,7 +44,8 @@ searcher:
     epochs: 3
   smaller_is_better: false
 environment:
-  image: determinedai/model-hub-transformers:0.16.3.dev0
+  image: 
+    gpu: determinedai/model-hub-transformers:0.16.3.dev0
 resources:
   slots_per_trial: 1
 # We add a bind_mount here so that cached data, tokenized data, and models will be saved to the

--- a/model_hub/examples/huggingface/text-classification/xnli_config.yaml
+++ b/model_hub/examples/huggingface/text-classification/xnli_config.yaml
@@ -35,7 +35,8 @@ searcher:
     epochs: 2
   smaller_is_better: false
 environment:
-  image: determinedai/model-hub-transformers:0.16.3.dev0
+  image: 
+    gpu: determinedai/model-hub-transformers:0.16.3.dev0
 resources:
   slots_per_trial: 2
 # We add a bind_mount here so that cached data, tokenized data, and models will be saved to the

--- a/model_hub/examples/huggingface/token-classification/ner_config.yaml
+++ b/model_hub/examples/huggingface/token-classification/ner_config.yaml
@@ -33,7 +33,8 @@ searcher:
     epochs: 3
   smaller_is_better: false
 environment:
-  image: determinedai/model-hub-transformers:0.16.3.dev0
+  image: 
+    gpu: determinedai/model-hub-transformers:0.16.3.dev0
 resources:
   slots_per_trial: 1
 # We add a bind_mount here so that cached data, tokenized data, and models will be saved to the


### PR DESCRIPTION
## Description
* bumped base image for model-hub transformers to the latest default gpu image with torch 1.9
* modified experiment configs to use a separate cpu image so tensorboard will work
* bumped up versions of transformers and datasets

## Test Plan
- [x] Run model-hub e2e tests


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234