### PR TITLE
chore: update environment images before release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,11 +97,11 @@ commands:
       - when:
           condition: <<parameters.tf1>>
           steps:
-            - run: docker pull determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-744337d
+            - run: docker pull determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-b06dafb
       - when:
           condition: <<parameters.tf2>>
           steps:
-            - run: docker pull determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-744337d
+            - run: docker pull determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-b06dafb
 
   login-docker:
     parameters:

--- a/e2e_tests/tests/config.py
+++ b/e2e_tests/tests/config.py
@@ -12,13 +12,13 @@ MAX_TASK_SCHEDULED_SECS = 30
 MAX_TRIAL_BUILD_SECS = 90
 
 
-DEFAULT_TF1_CPU_IMAGE = "determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-744337d"
+DEFAULT_TF1_CPU_IMAGE = "determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-b06dafb"
 DEFAULT_TF2_CPU_IMAGE = (
-    "determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-744337d"
+    "determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-b06dafb"
 )
-DEFAULT_TF1_GPU_IMAGE = "determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-744337d"
+DEFAULT_TF1_GPU_IMAGE = "determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-b06dafb"
 DEFAULT_TF2_GPU_IMAGE = (
-    "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-744337d"
+    "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-b06dafb"
 )
 
 TF1_CPU_IMAGE = os.environ.get("TF1_CPU_IMAGE") or DEFAULT_TF1_CPU_IMAGE

--- a/examples/computer_vision/mmdetection_pytorch/docker/Dockerfile
+++ b/examples/computer_vision/mmdetection_pytorch/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-744337d
+FROM determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-b06dafb
 
 ENV TORCH_CUDA_ARCH_LIST="6.0 6.1 7.0+PTX"
 ENV TORCH_NVCC_FLAGS="-Xfatbin -compress-all"

--- a/examples/computer_vision/unets_tf_keras/const.yaml
+++ b/examples/computer_vision/unets_tf_keras/const.yaml
@@ -22,4 +22,4 @@ min_validation_period:
 entrypoint: model_def:UNetsTrial
 scheduling_unit: 57
 environment:
-    image: determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-744337d
+    image: determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-b06dafb

--- a/examples/computer_vision/unets_tf_keras/distributed.yaml
+++ b/examples/computer_vision/unets_tf_keras/distributed.yaml
@@ -25,4 +25,4 @@ min_validation_period:
 scheduling_unit: 8
 entrypoint: model_def:UNetsTrial
 environment:
-    image: determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-744337d
+    image: determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-b06dafb

--- a/examples/gan/dcgan_tf_keras/const.yaml
+++ b/examples/gan/dcgan_tf_keras/const.yaml
@@ -15,5 +15,5 @@ entrypoint: model_def:DCGanTrial
 environment:
   # This model only works with Tensorflow 2.2+.
   image:
-     cpu: "determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-744337d"
-     gpu: "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-744337d"
+     cpu: "determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-b06dafb"
+     gpu: "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-b06dafb"

--- a/examples/gan/dcgan_tf_keras/distributed.yaml
+++ b/examples/gan/dcgan_tf_keras/distributed.yaml
@@ -17,5 +17,5 @@ resources:
 environment:
   # This model only works with Tensorflow 2.2+.
   image:
-     cpu: "determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-744337d"
-     gpu: "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-744337d"
+     cpu: "determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-b06dafb"
+     gpu: "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-b06dafb"

--- a/harness/determined/common/schemas/expconf/_v0.py
+++ b/harness/determined/common/schemas/expconf/_v0.py
@@ -242,11 +242,11 @@ class EnvironmentImageV0(schemas.SchemaBase):
     def runtime_defaults(self) -> None:
         if self.cpu is None:
             self.cpu = (
-                "determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-744337d"
+                "determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-b06dafb"
             )
         if self.gpu is None:
             self.gpu = (
-                "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-744337d"
+                "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-b06dafb"
             )
 
 

--- a/harness/determined/deploy/aws/templates/efs.yaml
+++ b/harness/determined/deploy/aws/templates/efs.yaml
@@ -3,36 +3,36 @@ Description:  This template deploys a VPC, with a public and private subnet. It 
 Mappings:
   RegionMap:
     ap-northeast-1:
-      Master: ami-09ff2b6ef00accc2e
-      Agent: ami-014f80311fc835d7e
+      Master: ami-0827d8ed0295e3feb
+      Agent: ami-026b87a4b928f2119
     # TODO(DET-4258) Uncomment these when we fully support all P3 regions.
     # ap-northeast-2:
-    #   Master: ami-0b329fb1f17558744
-    #   Agent: ami-0a7fcf5741217cfbf
+    #   Master: ami-00bbba67d13faed04
+    #   Agent: ami-0e2cb5ed320bf7757
     # ap-southeast-1:
-    #   Master: ami-048b4b1ddefe6759f
-    #   Agent: ami-06c7eb3d8641cb988
+    #   Master: ami-0f6565c3d5328c913
+    #   Agent: ami-0d5f2a28b3223f391
     # ap-southeast-2:
-    #   Master: ami-052a251c7ca533c26
-    #   Agent: ami-02677d06227bdeff4
+    #   Master: ami-0a1002150df471b2b
+    #   Agent: ami-0fa2374d33a4f8112
     eu-central-1:
-      Master: ami-0d3905203a039e3b0
-      Agent: ami-092d26413029b7921
+      Master: ami-0bdbe51a2e8070ff2
+      Agent: ami-0f0c6481b2232217e
     eu-west-1:
-      Master: ami-0b7fd7bc9c6fb1c78
-      Agent: ami-046fc4c6f27d086de
+      Master: ami-03caf24deed650e2c
+      Agent: ami-099e60b9442fb31ce
     # eu-west-2:
-    #   Master: ami-02ead6ecbd926d792
-    #   Agent: ami-025713f438d46db32
+    #   Master: ami-093d303510c432519
+    #   Agent: ami-0d7562b7c9d19e898
     us-east-1:
-      Master: ami-04cc2b0ad9e30a9c8
-      Agent: ami-0a6d182544caded1a
+      Master: ami-0dd76f917833aac4b
+      Agent: ami-091765ae08c55bf83
     us-east-2:
-      Master: ami-02fc6052104add5ae
-      Agent: ami-0608f914a86bab144
+      Master: ami-0b29b6e62f2343b46
+      Agent: ami-03cc872d44e8d4b52
     us-west-2:
-      Master: ami-0a62a78cfedc09d76
-      Agent: ami-0f3f8ce0b9877021c
+      Master: ami-01773ce53581acf22
+      Agent: ami-0ac1704f8d67d1845
 
 Parameters:
   VpcCIDR:

--- a/harness/determined/deploy/aws/templates/fsx.yaml
+++ b/harness/determined/deploy/aws/templates/fsx.yaml
@@ -2,36 +2,36 @@ Description:  This template deploys a VPC, with a public and private subnet, and
 Mappings:
   RegionMap:
     ap-northeast-1:
-      Master: ami-09ff2b6ef00accc2e
-      Agent: ami-014f80311fc835d7e
+      Master: ami-0827d8ed0295e3feb
+      Agent: ami-026b87a4b928f2119
     # TODO(DET-4258) Uncomment these when we fully support all P3 regions.
     # ap-northeast-2:
-    #   Master: ami-0b329fb1f17558744
-    #   Agent: ami-0a7fcf5741217cfbf
+    #   Master: ami-00bbba67d13faed04
+    #   Agent: ami-0e2cb5ed320bf7757
     # ap-southeast-1:
-    #   Master: ami-048b4b1ddefe6759f
-    #   Agent: ami-06c7eb3d8641cb988
+    #   Master: ami-0f6565c3d5328c913
+    #   Agent: ami-0d5f2a28b3223f391
     # ap-southeast-2:
-    #   Master: ami-052a251c7ca533c26
-    #   Agent: ami-02677d06227bdeff4
+    #   Master: ami-0a1002150df471b2b
+    #   Agent: ami-0fa2374d33a4f8112
     eu-central-1:
-      Master: ami-0d3905203a039e3b0
-      Agent: ami-092d26413029b7921
+      Master: ami-0bdbe51a2e8070ff2
+      Agent: ami-0f0c6481b2232217e
     eu-west-1:
-      Master: ami-0b7fd7bc9c6fb1c78
-      Agent: ami-046fc4c6f27d086de
+      Master: ami-03caf24deed650e2c
+      Agent: ami-099e60b9442fb31ce
     # eu-west-2:
-    #   Master: ami-02ead6ecbd926d792
-    #   Agent: ami-025713f438d46db32
+    #   Master: ami-093d303510c432519
+    #   Agent: ami-0d7562b7c9d19e898
     us-east-1:
-      Master: ami-04cc2b0ad9e30a9c8
-      Agent: ami-0a6d182544caded1a
+      Master: ami-0dd76f917833aac4b
+      Agent: ami-091765ae08c55bf83
     us-east-2:
-      Master: ami-02fc6052104add5ae
-      Agent: ami-0608f914a86bab144
+      Master: ami-0b29b6e62f2343b46
+      Agent: ami-03cc872d44e8d4b52
     us-west-2:
-      Master: ami-0a62a78cfedc09d76
-      Agent: ami-0f3f8ce0b9877021c
+      Master: ami-01773ce53581acf22
+      Agent: ami-0ac1704f8d67d1845
 
 Parameters:
   VpcCIDR:

--- a/harness/determined/deploy/aws/templates/govcloud.yaml
+++ b/harness/determined/deploy/aws/templates/govcloud.yaml
@@ -4,10 +4,10 @@ Description: Determined Template
 Mappings:
   RegionMap:
     us-gov-east-1:
-      Master: ami-af9379de
+      Master: ami-0ce79d6fa9e9a242e
       Agent: ami-0b71e56244b8ac1cb
     us-gov-west-1:
-      Master: ami-84556de5
+      Master: ami-04a2f96ef9b12b2b1
       Agent: ami-0d26002529bfac823
 Parameters:
   Keypair:

--- a/harness/determined/deploy/aws/templates/secure.yaml
+++ b/harness/determined/deploy/aws/templates/secure.yaml
@@ -3,46 +3,46 @@ Description:  This template deploys a VPC, with a public and private subnet. It 
 Mappings:
   RegionMap:
     ap-northeast-1:
-      Master: ami-09ff2b6ef00accc2e
-      Agent: ami-014f80311fc835d7e
-      Bastion: ami-09ff2b6ef00accc2e
+      Master: ami-0827d8ed0295e3feb
+      Agent: ami-026b87a4b928f2119
+      Bastion: ami-0827d8ed0295e3feb
     # TODO(DET-4258) Uncomment these when we fully support all P3 regions.
     # ap-northeast-2:
-    #   Master: ami-0b329fb1f17558744
-    #   Agent: ami-0a7fcf5741217cfbf
-    #   Bastion: ami-0b329fb1f17558744
+    #   Master: ami-00bbba67d13faed04
+    #   Agent: ami-0e2cb5ed320bf7757
+    #   Bastion: ami-00bbba67d13faed04
     # ap-southeast-1:
-    #   Master: ami-048b4b1ddefe6759f
-    #   Agent: ami-06c7eb3d8641cb988
-    #   Bastion: ami-048b4b1ddefe6759f
+    #   Master: ami-0f6565c3d5328c913
+    #   Agent: ami-0d5f2a28b3223f391
+    #   Bastion: ami-0f6565c3d5328c913
     # ap-southeast-2:
-    #   Master: ami-052a251c7ca533c26
-    #   Agent: ami-02677d06227bdeff4
-    #   Bastion: ami-052a251c7ca533c26
+    #   Master: ami-0a1002150df471b2b
+    #   Agent: ami-0fa2374d33a4f8112
+    #   Bastion: ami-0a1002150df471b2b
     eu-central-1:
-      Master: ami-0d3905203a039e3b0
-      Agent: ami-092d26413029b7921
-      Bastion: ami-0d3905203a039e3b0
+      Master: ami-0bdbe51a2e8070ff2
+      Agent: ami-0f0c6481b2232217e
+      Bastion: ami-0bdbe51a2e8070ff2
     eu-west-1:
-      Master: ami-0b7fd7bc9c6fb1c78
-      Agent: ami-046fc4c6f27d086de
-      Bastion: ami-0b7fd7bc9c6fb1c78
+      Master: ami-03caf24deed650e2c
+      Agent: ami-099e60b9442fb31ce
+      Bastion: ami-03caf24deed650e2c
     # eu-west-2:
-    #   Master: ami-02ead6ecbd926d792
-    #   Agent: ami-025713f438d46db32
-    #   Bastion: ami-02ead6ecbd926d792
+    #   Master: ami-093d303510c432519
+    #   Agent: ami-0d7562b7c9d19e898
+    #   Bastion: ami-093d303510c432519
     us-east-1:
-      Master: ami-04cc2b0ad9e30a9c8
-      Agent: ami-0a6d182544caded1a
-      Bastion: ami-04cc2b0ad9e30a9c8
+      Master: ami-0dd76f917833aac4b
+      Agent: ami-091765ae08c55bf83
+      Bastion: ami-0dd76f917833aac4b
     us-east-2:
-      Master: ami-02fc6052104add5ae
-      Agent: ami-0608f914a86bab144
-      Bastion: ami-02fc6052104add5ae
+      Master: ami-0b29b6e62f2343b46
+      Agent: ami-03cc872d44e8d4b52
+      Bastion: ami-0b29b6e62f2343b46
     us-west-2:
-      Master: ami-0a62a78cfedc09d76
-      Agent: ami-0f3f8ce0b9877021c
-      Bastion: ami-0a62a78cfedc09d76
+      Master: ami-01773ce53581acf22
+      Agent: ami-0ac1704f8d67d1845
+      Bastion: ami-01773ce53581acf22
 
 Parameters:
   VpcCIDR:

--- a/harness/determined/deploy/aws/templates/simple.yaml
+++ b/harness/determined/deploy/aws/templates/simple.yaml
@@ -4,36 +4,36 @@ Description: Determined Template
 Mappings:
   RegionMap:
     ap-northeast-1:
-      Master: ami-09ff2b6ef00accc2e
-      Agent: ami-014f80311fc835d7e
+      Master: ami-0827d8ed0295e3feb
+      Agent: ami-026b87a4b928f2119
     # TODO(DET-4258) Uncomment these when we fully support all P3 regions.
     # ap-northeast-2:
-    #   Master: ami-0b329fb1f17558744
-    #   Agent: ami-0a7fcf5741217cfbf
+    #   Master: ami-00bbba67d13faed04
+    #   Agent: ami-0e2cb5ed320bf7757
     # ap-southeast-1:
-    #   Master: ami-048b4b1ddefe6759f
-    #   Agent: ami-06c7eb3d8641cb988
+    #   Master: ami-0f6565c3d5328c913
+    #   Agent: ami-0d5f2a28b3223f391
     # ap-southeast-2:
-    #   Master: ami-052a251c7ca533c26
-    #   Agent: ami-02677d06227bdeff4
+    #   Master: ami-0a1002150df471b2b
+    #   Agent: ami-0fa2374d33a4f8112
     eu-central-1:
-      Master: ami-0d3905203a039e3b0
-      Agent: ami-092d26413029b7921
+      Master: ami-0bdbe51a2e8070ff2
+      Agent: ami-0f0c6481b2232217e
     eu-west-1:
-      Master: ami-0b7fd7bc9c6fb1c78
-      Agent: ami-046fc4c6f27d086de
+      Master: ami-03caf24deed650e2c
+      Agent: ami-099e60b9442fb31ce
     # eu-west-2:
-    #   Master: ami-02ead6ecbd926d792
-    #   Agent: ami-025713f438d46db32
+    #   Master: ami-093d303510c432519
+    #   Agent: ami-0d7562b7c9d19e898
     us-east-1:
-      Master: ami-04cc2b0ad9e30a9c8
-      Agent: ami-0a6d182544caded1a
+      Master: ami-0dd76f917833aac4b
+      Agent: ami-091765ae08c55bf83
     us-east-2:
-      Master: ami-02fc6052104add5ae
-      Agent: ami-0608f914a86bab144
+      Master: ami-0b29b6e62f2343b46
+      Agent: ami-03cc872d44e8d4b52
     us-west-2:
-      Master: ami-0a62a78cfedc09d76
-      Agent: ami-0f3f8ce0b9877021c
+      Master: ami-01773ce53581acf22
+      Agent: ami-0ac1704f8d67d1845
 
 Parameters:
   Keypair:

--- a/harness/determined/deploy/aws/templates/vpc.yaml
+++ b/harness/determined/deploy/aws/templates/vpc.yaml
@@ -3,36 +3,36 @@ Description:  This template deploys a VPC, with a public and private subnet. It 
 Mappings:
   RegionMap:
     ap-northeast-1:
-      Master: ami-09ff2b6ef00accc2e
-      Agent: ami-014f80311fc835d7e
+      Master: ami-0827d8ed0295e3feb
+      Agent: ami-026b87a4b928f2119
     # TODO(DET-4258) Uncomment these when we fully support all P3 regions.
     # ap-northeast-2:
-    #   Master: ami-0b329fb1f17558744
-    #   Agent: ami-0a7fcf5741217cfbf
+    #   Master: ami-00bbba67d13faed04
+    #   Agent: ami-0e2cb5ed320bf7757
     # ap-southeast-1:
-    #   Master: ami-048b4b1ddefe6759f
-    #   Agent: ami-06c7eb3d8641cb988
+    #   Master: ami-0f6565c3d5328c913
+    #   Agent: ami-0d5f2a28b3223f391
     # ap-southeast-2:
-    #   Master: ami-052a251c7ca533c26
-    #   Agent: ami-02677d06227bdeff4
+    #   Master: ami-0a1002150df471b2b
+    #   Agent: ami-0fa2374d33a4f8112
     eu-central-1:
-      Master: ami-0d3905203a039e3b0
-      Agent: ami-092d26413029b7921
+      Master: ami-0bdbe51a2e8070ff2
+      Agent: ami-0f0c6481b2232217e
     eu-west-1:
-      Master: ami-0b7fd7bc9c6fb1c78
-      Agent: ami-046fc4c6f27d086de
+      Master: ami-03caf24deed650e2c
+      Agent: ami-099e60b9442fb31ce
     # eu-west-2:
-    #   Master: ami-02ead6ecbd926d792
-    #   Agent: ami-025713f438d46db32
+    #   Master: ami-093d303510c432519
+    #   Agent: ami-0d7562b7c9d19e898
     us-east-1:
-      Master: ami-04cc2b0ad9e30a9c8
-      Agent: ami-0a6d182544caded1a
+      Master: ami-0dd76f917833aac4b
+      Agent: ami-091765ae08c55bf83
     us-east-2:
-      Master: ami-02fc6052104add5ae
-      Agent: ami-0608f914a86bab144
+      Master: ami-0b29b6e62f2343b46
+      Agent: ami-03cc872d44e8d4b52
     us-west-2:
-      Master: ami-0a62a78cfedc09d76
-      Agent: ami-0f3f8ce0b9877021c
+      Master: ami-01773ce53581acf22
+      Agent: ami-0ac1704f8d67d1845
 
 Parameters:
   VpcCIDR:

--- a/harness/determined/deploy/gcp/constants.py
+++ b/harness/determined/deploy/gcp/constants.py
@@ -3,7 +3,7 @@ class defaults:
     AUX_AGENT_INSTANCE_TYPE = "n1-standard-4"
     COMPUTE_AGENT_INSTANCE_TYPE = "n1-standard-32"
     DB_PASSWORD = "postgres"
-    ENVIRONMENT_IMAGE = "det-environments-744337d"
+    ENVIRONMENT_IMAGE = "det-environments-b06dafb"
     GPU_NUM = 8
     GPU_TYPE = "nvidia-tesla-k80"
     MASTER_INSTANCE_TYPE = "n1-standard-2"

--- a/helm/charts/determined/templates/master-config.yaml
+++ b/helm/charts/determined/templates/master-config.yaml
@@ -60,8 +60,8 @@ data:
         cpu: {{ .Values.slotResourceRequests.cpu }}
       {{- end }}
 
-    {{$cpuImage := (split "/" "determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-744337d")._1}}
-    {{- $gpuImage := (split "/" "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-744337d")._1 -}}
+    {{$cpuImage := (split "/" "determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-b06dafb")._1}}
+    {{- $gpuImage := (split "/" "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-b06dafb")._1 -}}
     {{ if .Values.taskContainerDefaults -}}
     task_container_defaults:
       {{- if .Values.taskContainerDefaults.networkMode }}

--- a/master/internal/provisioner/aws_config.go
+++ b/master/internal/provisioner/aws_config.go
@@ -44,16 +44,16 @@ type AWSClusterConfig struct {
 }
 
 var defaultAWSImageID = map[string]string{
-	"ap-northeast-1": "ami-014f80311fc835d7e",
-	"ap-northeast-2": "ami-0a7fcf5741217cfbf",
-	"ap-southeast-1": "ami-06c7eb3d8641cb988",
-	"ap-southeast-2": "ami-02677d06227bdeff4",
-	"us-east-2":      "ami-0608f914a86bab144",
-	"us-east-1":      "ami-0a6d182544caded1a",
-	"us-west-2":      "ami-0f3f8ce0b9877021c",
-	"eu-central-1":   "ami-092d26413029b7921",
-	"eu-west-2":      "ami-025713f438d46db32",
-	"eu-west-1":      "ami-046fc4c6f27d086de",
+	"ap-northeast-1": "ami-026b87a4b928f2119",
+	"ap-northeast-2": "ami-0e2cb5ed320bf7757",
+	"ap-southeast-1": "ami-0d5f2a28b3223f391",
+	"ap-southeast-2": "ami-0fa2374d33a4f8112",
+	"us-east-2":      "ami-03cc872d44e8d4b52",
+	"us-east-1":      "ami-091765ae08c55bf83",
+	"us-west-2":      "ami-0ac1704f8d67d1845",
+	"eu-central-1":   "ami-0f0c6481b2232217e",
+	"eu-west-2":      "ami-0d7562b7c9d19e898",
+	"eu-west-1":      "ami-099e60b9442fb31ce",
 }
 
 var defaultAWSClusterConfig = AWSClusterConfig{

--- a/master/internal/provisioner/gcp_config.go
+++ b/master/internal/provisioner/gcp_config.go
@@ -50,7 +50,7 @@ type GCPClusterConfig struct {
 func DefaultGCPClusterConfig() *GCPClusterConfig {
 	return &GCPClusterConfig{
 		BootDiskSize:        200,
-		BootDiskSourceImage: "projects/determined-ai/global/images/det-environments-744337d",
+		BootDiskSourceImage: "projects/determined-ai/global/images/det-environments-b06dafb",
 		LabelKey:            "managed-by",
 		InstanceType: gceInstanceType{
 			MachineType: "n1-standard-32",

--- a/master/pkg/model/defaults.go
+++ b/master/pkg/model/defaults.go
@@ -25,8 +25,8 @@ const (
 
 // Default task environment docker image names.
 const (
-	CPUImage = "determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-744337d"
-	GPUImage = "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-744337d"
+	CPUImage = "determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-b06dafb"
+	GPUImage = "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-b06dafb"
 )
 
 // DefaultResourcesConfig returns the default resources configuration.

--- a/master/pkg/schemas/expconf/const.go
+++ b/master/pkg/schemas/expconf/const.go
@@ -8,6 +8,6 @@ const (
 
 // Default task environment docker image names.
 const (
-	CPUImage = "determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-744337d"
-	GPUImage = "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-744337d"
+	CPUImage = "determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-b06dafb"
+	GPUImage = "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-b06dafb"
 )

--- a/master/pkg/schemas/expconf/legacy_test.go
+++ b/master/pkg/schemas/expconf/legacy_test.go
@@ -233,8 +233,8 @@ func TestLegacyConfig(t *testing.T) {
                     gpu: []
                   force_pull_image: false
                   image:
-                    cpu: determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-744337d
-                    gpu: determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-744337d
+                    cpu: determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-b06dafb
+                    gpu: determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-b06dafb
                   pod_spec: null
                   ports: {}
                   registry_auth: null

--- a/schemas/test_cases/v0/experiment.yaml
+++ b/schemas/test_cases/v0/experiment.yaml
@@ -31,8 +31,8 @@
       environment_variables: {}
       force_pull_image: false
       image:
-        cpu: determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-744337d
-        gpu: determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-744337d
+        cpu: determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-b06dafb
+        gpu: determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-b06dafb
       pod_spec: null
       ports:
         qwer: 1234

--- a/tools/scripts/bumpenvs.yaml
+++ b/tools/scripts/bumpenvs.yaml
@@ -1,6 +1,6 @@
 ap_northeast_1_agent_ami:
-  new: ami-014f80311fc835d7e
-  old: ami-0e3a70a34fa5e5ecd
+  new: ami-026b87a4b928f2119
+  old: ami-014f80311fc835d7e
 ap_northeast_1_bastion_ami:
   new: ami-09ff2b6ef00accc2e
   old: ami-04fe60822d08387bb
@@ -8,8 +8,8 @@ ap_northeast_1_master_ami:
   new: ami-09ff2b6ef00accc2e
   old: ami-005021e678ab162ea
 ap_northeast_2_agent_ami:
-  new: ami-0a7fcf5741217cfbf
-  old: ami-05eebec073bc0cc96
+  new: ami-0e2cb5ed320bf7757
+  old: ami-0a7fcf5741217cfbf
 ap_northeast_2_bastion_ami:
   new: ami-0b329fb1f17558744
   old: ami-05f375b54be4ab849
@@ -17,8 +17,8 @@ ap_northeast_2_master_ami:
   new: ami-0b329fb1f17558744
   old: ami-090b3f1f06a12d28d
 ap_southeast_1_agent_ami:
-  new: ami-06c7eb3d8641cb988
-  old: ami-016959945bce80d61
+  new: ami-0d5f2a28b3223f391
+  old: ami-06c7eb3d8641cb988
 ap_southeast_1_bastion_ami:
   new: ami-048b4b1ddefe6759f
   old: ami-0ead23393ac084a1e
@@ -26,8 +26,8 @@ ap_southeast_1_master_ami:
   new: ami-048b4b1ddefe6759f
   old: ami-01e1605d140c6b5e6
 ap_southeast_2_agent_ami:
-  new: ami-02677d06227bdeff4
-  old: ami-09de3e1a4ea012c41
+  new: ami-0fa2374d33a4f8112
+  old: ami-02677d06227bdeff4
 ap_southeast_2_bastion_ami:
   new: ami-052a251c7ca533c26
   old: ami-05b921f2a1a419c07
@@ -35,14 +35,14 @@ ap_southeast_2_master_ami:
   new: ami-052a251c7ca533c26
   old: ami-00d02a4b2cf1df2f4
 cuda_11_hashed:
-  new: determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-744337d
-  old: determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-df5f9aa
+  new: determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-b06dafb
+  old: determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-744337d
 cuda_11_versioned:
   new: determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0.16.1
   old: determinedai/environments:cuda-11.0-pytorch-1.7-lightning-1.2-tf-2.4-gpu-0.16.0
 eu_central_1_agent_ami:
-  new: ami-092d26413029b7921
-  old: ami-09dcd93a0cf322c31
+  new: ami-0f0c6481b2232217e
+  old: ami-092d26413029b7921
 eu_central_1_bastion_ami:
   new: ami-0d3905203a039e3b0
   old: ami-07a0e33d3c1c5fb82
@@ -50,8 +50,8 @@ eu_central_1_master_ami:
   new: ami-0d3905203a039e3b0
   old: ami-08c1695e3dcdd191e
 eu_west_1_agent_ami:
-  new: ami-046fc4c6f27d086de
-  old: ami-06134ecdb05b84361
+  new: ami-099e60b9442fb31ce
+  old: ami-046fc4c6f27d086de
 eu_west_1_bastion_ami:
   new: ami-0b7fd7bc9c6fb1c78
   old: ami-03c4a26550b802f69
@@ -59,8 +59,8 @@ eu_west_1_master_ami:
   new: ami-0b7fd7bc9c6fb1c78
   old: ami-08fabf5d4fa6fcc12
 eu_west_2_agent_ami:
-  new: ami-025713f438d46db32
-  old: ami-09fc70c9ad77d32d2
+  new: ami-0d7562b7c9d19e898
+  old: ami-025713f438d46db32
 eu_west_2_bastion_ami:
   new: ami-02ead6ecbd926d792
   old: ami-066213f162acbccdc
@@ -68,35 +68,35 @@ eu_west_2_master_ami:
   new: ami-02ead6ecbd926d792
   old: ami-0b3e07036579e1b57
 gcp_env:
-  new: det-environments-744337d
-  old: det-environments-df5f9aa
+  new: det-environments-b06dafb
+  old: det-environments-744337d
 tf1_cpu_hashed:
-  new: determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-744337d
-  old: determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-df5f9aa
+  new: determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-b06dafb
+  old: determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-744337d
 tf1_cpu_versioned:
   new: determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-0.16.1
   old: determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-0.16.0
 tf1_gpu_hashed:
-  new: determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-744337d
-  old: determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-df5f9aa
+  new: determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-b06dafb
+  old: determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-744337d
 tf1_gpu_versioned:
   new: determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-0.16.1
   old: determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-0.16.0
 tf25_gpu_hashed:
-  new: determinedai/environments:cuda-11.2-pytorch-1.7-lightning-1.2-tf-2.5-gpu-744337d
-  old: determinedai/environments:cuda-11.2-pytorch-1.7-lightning-1.2-tf-2.5-gpu-df5f9aa
+  new: determinedai/environments:cuda-11.2-pytorch-1.7-lightning-1.2-tf-2.5-gpu-b06dafb
+  old: determinedai/environments:cuda-11.2-pytorch-1.7-lightning-1.2-tf-2.5-gpu-744337d
 tf25_gpu_versioned:
   new: determinedai/environments:cuda-11.2-pytorch-1.7-lightning-1.2-tf-2.5-gpu-0.16.1
   old: determinedai/environments:cuda-11.2-pytorch-1.7-lightning-1.2-tf-2.5-gpu-0.16.0
 tf2_cpu_hashed:
-  new: determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-744337d
-  old: determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-df5f9aa
+  new: determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-b06dafb
+  old: determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-744337d
 tf2_cpu_versioned:
   new: determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0.16.1
   old: determinedai/environments:py-3.7-pytorch-1.7-lightning-1.2-tf-2.4-cpu-0.16.0
 us_east_1_agent_ami:
-  new: ami-0a6d182544caded1a
-  old: ami-0e791d1cf4f2951f9
+  new: ami-091765ae08c55bf83
+  old: ami-0a6d182544caded1a
 us_east_1_bastion_ami:
   new: ami-04cc2b0ad9e30a9c8
   old: ami-03eaf3b9c3367e75c
@@ -104,8 +104,8 @@ us_east_1_master_ami:
   new: ami-04cc2b0ad9e30a9c8
   old: ami-056db1277deef2218
 us_east_2_agent_ami:
-  new: ami-0608f914a86bab144
-  old: ami-054d6ef9236263c05
+  new: ami-03cc872d44e8d4b52
+  old: ami-0608f914a86bab144
 us_east_2_bastion_ami:
   new: ami-02fc6052104add5ae
   old: ami-09135e71dc2619458
@@ -113,20 +113,20 @@ us_east_2_master_ami:
   new: ami-02fc6052104add5ae
   old: ami-0a4b51dd47f678ba3
 us_gov_east_1_agent_ami:
-  new: ami-09c4be806bc42dd0f
-  old: ami-03bfb85673a2b9a47
+  new: ami-0930dbc24c979b616
+  old: ami-09c4be806bc42dd0f
 us_gov_east_1_master_ami:
   new: ami-af9379de
   old: ami-469c7637
 us_gov_west_1_agent_ami:
-  new: ami-0478e0c973a52d962
-  old: ami-0620db8301870fe15
+  new: ami-08f68439d7c838247
+  old: ami-0478e0c973a52d962
 us_gov_west_1_master_ami:
   new: ami-84556de5
   old: ami-a6e8d2c7
 us_west_2_agent_ami:
-  new: ami-0f3f8ce0b9877021c
-  old: ami-0168122c7dfef8aab
+  new: ami-0ac1704f8d67d1845
+  old: ami-0f3f8ce0b9877021c
 us_west_2_bastion_ami:
   new: ami-0a62a78cfedc09d76
   old: ami-007e276c37b5ff2d7

--- a/tools/scripts/bumpenvs.yaml
+++ b/tools/scripts/bumpenvs.yaml
@@ -2,38 +2,38 @@ ap_northeast_1_agent_ami:
   new: ami-026b87a4b928f2119
   old: ami-014f80311fc835d7e
 ap_northeast_1_bastion_ami:
-  new: ami-09ff2b6ef00accc2e
-  old: ami-04fe60822d08387bb
+  new: ami-0827d8ed0295e3feb
+  old: ami-09ff2b6ef00accc2e
 ap_northeast_1_master_ami:
-  new: ami-09ff2b6ef00accc2e
-  old: ami-005021e678ab162ea
+  new: ami-0827d8ed0295e3feb
+  old: ami-09ff2b6ef00accc2e
 ap_northeast_2_agent_ami:
   new: ami-0e2cb5ed320bf7757
   old: ami-0a7fcf5741217cfbf
 ap_northeast_2_bastion_ami:
-  new: ami-0b329fb1f17558744
-  old: ami-05f375b54be4ab849
+  new: ami-00bbba67d13faed04
+  old: ami-0b329fb1f17558744
 ap_northeast_2_master_ami:
-  new: ami-0b329fb1f17558744
-  old: ami-090b3f1f06a12d28d
+  new: ami-00bbba67d13faed04
+  old: ami-0b329fb1f17558744
 ap_southeast_1_agent_ami:
   new: ami-0d5f2a28b3223f391
   old: ami-06c7eb3d8641cb988
 ap_southeast_1_bastion_ami:
-  new: ami-048b4b1ddefe6759f
-  old: ami-0ead23393ac084a1e
+  new: ami-0f6565c3d5328c913
+  old: ami-048b4b1ddefe6759f
 ap_southeast_1_master_ami:
-  new: ami-048b4b1ddefe6759f
-  old: ami-01e1605d140c6b5e6
+  new: ami-0f6565c3d5328c913
+  old: ami-048b4b1ddefe6759f
 ap_southeast_2_agent_ami:
   new: ami-0fa2374d33a4f8112
   old: ami-02677d06227bdeff4
 ap_southeast_2_bastion_ami:
-  new: ami-052a251c7ca533c26
-  old: ami-05b921f2a1a419c07
+  new: ami-0a1002150df471b2b
+  old: ami-052a251c7ca533c26
 ap_southeast_2_master_ami:
-  new: ami-052a251c7ca533c26
-  old: ami-00d02a4b2cf1df2f4
+  new: ami-0a1002150df471b2b
+  old: ami-052a251c7ca533c26
 cuda_11_hashed:
   new: determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-b06dafb
   old: determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-744337d
@@ -44,29 +44,29 @@ eu_central_1_agent_ami:
   new: ami-0f0c6481b2232217e
   old: ami-092d26413029b7921
 eu_central_1_bastion_ami:
-  new: ami-0d3905203a039e3b0
-  old: ami-07a0e33d3c1c5fb82
+  new: ami-0bdbe51a2e8070ff2
+  old: ami-0d3905203a039e3b0
 eu_central_1_master_ami:
-  new: ami-0d3905203a039e3b0
-  old: ami-08c1695e3dcdd191e
+  new: ami-0bdbe51a2e8070ff2
+  old: ami-0d3905203a039e3b0
 eu_west_1_agent_ami:
   new: ami-099e60b9442fb31ce
   old: ami-046fc4c6f27d086de
 eu_west_1_bastion_ami:
-  new: ami-0b7fd7bc9c6fb1c78
-  old: ami-03c4a26550b802f69
+  new: ami-03caf24deed650e2c
+  old: ami-0b7fd7bc9c6fb1c78
 eu_west_1_master_ami:
-  new: ami-0b7fd7bc9c6fb1c78
-  old: ami-08fabf5d4fa6fcc12
+  new: ami-03caf24deed650e2c
+  old: ami-0b7fd7bc9c6fb1c78
 eu_west_2_agent_ami:
   new: ami-0d7562b7c9d19e898
   old: ami-025713f438d46db32
 eu_west_2_bastion_ami:
-  new: ami-02ead6ecbd926d792
-  old: ami-066213f162acbccdc
+  new: ami-093d303510c432519
+  old: ami-02ead6ecbd926d792
 eu_west_2_master_ami:
-  new: ami-02ead6ecbd926d792
-  old: ami-0b3e07036579e1b57
+  new: ami-093d303510c432519
+  old: ami-02ead6ecbd926d792
 gcp_env:
   new: det-environments-b06dafb
   old: det-environments-744337d
@@ -98,38 +98,38 @@ us_east_1_agent_ami:
   new: ami-091765ae08c55bf83
   old: ami-0a6d182544caded1a
 us_east_1_bastion_ami:
-  new: ami-04cc2b0ad9e30a9c8
-  old: ami-03eaf3b9c3367e75c
+  new: ami-0dd76f917833aac4b
+  old: ami-04cc2b0ad9e30a9c8
 us_east_1_master_ami:
-  new: ami-04cc2b0ad9e30a9c8
-  old: ami-056db1277deef2218
+  new: ami-0dd76f917833aac4b
+  old: ami-04cc2b0ad9e30a9c8
 us_east_2_agent_ami:
   new: ami-03cc872d44e8d4b52
   old: ami-0608f914a86bab144
 us_east_2_bastion_ami:
-  new: ami-02fc6052104add5ae
-  old: ami-09135e71dc2619458
+  new: ami-0b29b6e62f2343b46
+  old: ami-02fc6052104add5ae
 us_east_2_master_ami:
-  new: ami-02fc6052104add5ae
-  old: ami-0a4b51dd47f678ba3
+  new: ami-0b29b6e62f2343b46
+  old: ami-02fc6052104add5ae
 us_gov_east_1_agent_ami:
   new: ami-0930dbc24c979b616
   old: ami-09c4be806bc42dd0f
 us_gov_east_1_master_ami:
-  new: ami-af9379de
-  old: ami-469c7637
+  new: ami-0ce79d6fa9e9a242e
+  old: ami-af9379de
 us_gov_west_1_agent_ami:
   new: ami-08f68439d7c838247
   old: ami-0478e0c973a52d962
 us_gov_west_1_master_ami:
-  new: ami-84556de5
-  old: ami-a6e8d2c7
+  new: ami-04a2f96ef9b12b2b1
+  old: ami-84556de5
 us_west_2_agent_ami:
   new: ami-0ac1704f8d67d1845
   old: ami-0f3f8ce0b9877021c
 us_west_2_bastion_ami:
-  new: ami-0a62a78cfedc09d76
-  old: ami-007e276c37b5ff2d7
+  new: ami-01773ce53581acf22
+  old: ami-0a62a78cfedc09d76
 us_west_2_master_ami:
-  new: ami-0a62a78cfedc09d76
-  old: ami-0ee876776acf64c80
+  new: ami-01773ce53581acf22
+  old: ami-0a62a78cfedc09d76

--- a/tools/scripts/refresh-ubuntu-amis.py
+++ b/tools/scripts/refresh-ubuntu-amis.py
@@ -9,7 +9,7 @@ Usage: refresh-ubuntu-amis.py path/to/bumpenvs.yaml
 """
 
 import sys
-from typing import Dict, List
+from typing import Dict, List, Union
 
 import requests
 import yaml
@@ -26,7 +26,7 @@ def cacheable_get(url: str) -> str:
     return get_cache[url]
 
 
-def get_ubuntu_ami(release: str, region: str) -> str:
+def get_ubuntu_ami(release: str, region: str) -> Union[None, str]:
     resp = cacheable_get(
         f"https://cloud-images.ubuntu.com/query/{release}/server/released.current.txt"
     )

--- a/tools/scripts/refresh-ubuntu-amis.py
+++ b/tools/scripts/refresh-ubuntu-amis.py
@@ -48,10 +48,10 @@ def get_ubuntu_ami(release: str, region: str) -> str:
     results = [line for line in ami_lines if filters(line)]
 
     if len(results) > 1:
-      print(f"Found multiple AMIs for {region}!", file=sys.stderr)
+        print(f"Found multiple AMIs for {region}!", file=sys.stderr)
     if len(results) == 0:
-      print(f"Failed to find AMI for {region}!", file=sys.stderr)
-      return None
+        print(f"Failed to find AMI for {region}!", file=sys.stderr)
+        return None
 
     return results[0][7]
 

--- a/tools/scripts/refresh-ubuntu-amis.py
+++ b/tools/scripts/refresh-ubuntu-amis.py
@@ -47,9 +47,11 @@ def get_ubuntu_ami(release: str, region: str) -> str:
 
     results = [line for line in ami_lines if filters(line)]
 
-    assert (
-        len(results) == 1
-    ), f"expected one match to {release}/{region} but got {results}"
+    if len(results) > 1:
+      print(f"Found multiple AMIs for {region}!", file=sys.stderr)
+    if len(results) == 0:
+      print(f"Failed to find AMI for {region}!", file=sys.stderr)
+      return None
 
     return results[0][7]
 
@@ -78,13 +80,15 @@ if __name__ == "__main__":
             region = image_type.rstrip("_master_ami").replace("_", "-")
             # Master AMIs are based on Focal.
             new_ami = get_ubuntu_ami("focal", region)
-            update_tag_for_image_type(subconf, new_ami)
+            if new_ami is not None:
+                update_tag_for_image_type(subconf, new_ami)
 
         if image_type.endswith("_bastion_ami"):
             region = image_type.rstrip("_bastion_ami").replace("_", "-")
             # Bastion AMIs are based on Focal.
             new_ami = get_ubuntu_ami("focal", region)
-            update_tag_for_image_type(subconf, new_ami)
+            if new_ami is not None:
+                update_tag_for_image_type(subconf, new_ami)
 
     with open(path, "w") as f:
         yaml.dump(conf, f, sort_keys=True)

--- a/webui/react/src/fixtures/responses/experiment-details/non-scalar-metrics-4078.json
+++ b/webui/react/src/fixtures/responses/experiment-details/non-scalar-metrics-4078.json
@@ -32,8 +32,8 @@
     "name": "Fork of Fork of mnist_tp_to_estimator_const",
     "environment": {
       "image": {
-        "cpu": "determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-744337d",
-        "gpu": "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-744337d"
+        "cpu": "determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-b06dafb",
+        "gpu": "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-b06dafb"
       },
       "ports": null,
       "pod_spec": null,

--- a/webui/react/src/fixtures/responses/experiment-details/set-a.json
+++ b/webui/react/src/fixtures/responses/experiment-details/set-a.json
@@ -694,8 +694,8 @@
         "environment_variables": {},
         "force_pull_image": false,
         "image": {
-          "cpu": "determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-744337d",
-          "gpu": "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-744337d"
+          "cpu": "determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-b06dafb",
+          "gpu": "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-b06dafb"
         },
         "pod_spec": null,
         "ports": null
@@ -838,8 +838,8 @@
         "environment_variables": {},
         "force_pull_image": false,
         "image": {
-          "cpu": "determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-744337d",
-          "gpu": "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-744337d"
+          "cpu": "determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-b06dafb",
+          "gpu": "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-b06dafb"
         },
         "pod_spec": {
           "metadata": {
@@ -2596,8 +2596,8 @@
       "name": "noop_adaptive",
       "environment": {
         "image": {
-          "cpu": "determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-744337d",
-          "gpu": "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-744337d"
+          "cpu": "determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-b06dafb",
+          "gpu": "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-b06dafb"
         },
         "ports": null,
         "pod_spec": null,

--- a/webui/react/src/fixtures/responses/trial-details/old-trial-config-noop-adaptive.json
+++ b/webui/react/src/fixtures/responses/trial-details/old-trial-config-noop-adaptive.json
@@ -30,8 +30,8 @@
   "name": "noop_adaptive",
   "environment": {
     "image": {
-      "cpu": "determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-744337d",
-      "gpu": "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-744337d"
+      "cpu": "determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-b06dafb",
+      "gpu": "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-b06dafb"
     },
     "ports": null,
     "force_pull_image": false,


### PR DESCRIPTION
Updating images. Also, since Ubuntu images for GovCloud need to be added manually, the previous entries caused this run to fail because equivalents couldn't be looked up the same way. We now just gracefully log a warning, reminding the user that this needs to happen (as said in the README).

I'm running all the opt-in tests here: https://app.circleci.com/pipelines/github/determined-ai/determined/13602/workflows/d7bcc6c7-85ee-42c9-816a-3aa1e131f8a5