### PR TITLE
fix: make the gRPC gateway never use a proxy [DET-5689]

### DIFF
--- a/master/internal/grpcutil/api.go
+++ b/master/internal/grpcutil/api.go
@@ -88,6 +88,7 @@ func RegisterHTTPProxy(ctx context.Context, e *echo.Echo, port int, cert *tls.Ce
 	addr := fmt.Sprintf(":%d", port)
 	opts := []grpc.DialOption{
 		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(1 << 26)),
+		grpc.WithNoProxy(),
 	}
 	if cert == nil {
 		opts = append(opts, grpc.WithInsecure())


### PR DESCRIPTION
## Description

Without this, if a proxy is set using the `https_proxy` environment
variable, the gRPC gateway attempts to use it to connect back to the
master's own listener, which typically breaks things. A proxy should
never be used for such connections.

## Test Plan

- [x] set `https_proxy` to something, check that gRPC gateway endpoints fail without the fix and work with it

## Commentary (optional)

Thanks to Ryan for actually figuring out the issue before I got assigned to it.
