### PR TITLE
fix: prevent impossible slot requests for notebooks [DET-5690]

### DIFF
--- a/master/internal/api/error.go
+++ b/master/internal/api/error.go
@@ -5,6 +5,8 @@ import (
 	"net/http"
 
 	"github.com/pkg/errors"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/labstack/echo/v4"
 )
@@ -61,4 +63,22 @@ func AsErrNotFound(msg string, args ...interface{}) error {
 		msg,
 		args...,
 	)
+}
+
+// APIErr2GRPC converts internal api error categories into grpc status.Errors.
+func APIErr2GRPC(err error) error {
+	switch {
+	case errors.Is(err, ErrBadRequest):
+		return status.Errorf(
+			codes.InvalidArgument,
+			err.Error(),
+		)
+	case errors.Is(err, ErrNotFound):
+		return status.Errorf(
+			codes.NotFound,
+			err.Error(),
+		)
+	default:
+		return nil
+	}
 }

--- a/master/internal/api/error.go
+++ b/master/internal/api/error.go
@@ -79,6 +79,6 @@ func APIErr2GRPC(err error) error {
 			err.Error(),
 		)
 	default:
-		return nil
+		return err
 	}
 }

--- a/master/internal/api_command.go
+++ b/master/internal/api_command.go
@@ -199,10 +199,7 @@ func (a *apiServer) LaunchCommand(
 		Data:         req.Data,
 	})
 	if err != nil {
-		if grpcErr := api.APIErr2GRPC(err); grpcErr != nil {
-			return nil, grpcErr
-		}
-		return nil, err
+		return nil, api.APIErr2GRPC(err)
 	}
 
 	commandLaunchReq := command.CommandLaunchRequest{CommandParams: params}

--- a/master/internal/api_command.go
+++ b/master/internal/api_command.go
@@ -94,9 +94,13 @@ func (a *apiServer) makeFullCommandSpec(
 	}
 
 	if config.Resources.Slots > 0 {
-		fillable := sproto.ValidateRPResources(
+		fillable, err := sproto.ValidateRPResources(
 			a.m.system, config.Resources.ResourcePool, config.Resources.Slots)
-		if fillable != nil && !*fillable {
+		if err != nil {
+			return nil, nil, errors.Wrapf(
+				err, "failed to check resource pool resources: ")
+		}
+		if !fillable {
 			return nil, nil, errCommandUnfulfillable
 		}
 	}

--- a/master/internal/api_command.go
+++ b/master/internal/api_command.go
@@ -28,6 +28,7 @@ import (
 )
 
 var commandsAddr = actor.Addr("commands")
+var errCommandUnfulfillable = errors.New("resource request unfulfillable")
 
 type protoCommandParams struct {
 	TemplateName string
@@ -92,6 +93,14 @@ func (a *apiServer) makeFullCommandSpec(
 		}
 	}
 
+	if config.Resources.Slots > 0 {
+		fillable := sproto.ValidateRPResources(
+			a.m.system, config.Resources.ResourcePool, config.Resources.Slots)
+		if fillable != nil && !*fillable {
+			return nil, nil, errCommandUnfulfillable
+		}
+	}
+
 	return &config, &taskSpec, nil
 }
 
@@ -133,6 +142,10 @@ func (a *apiServer) prepareLaunchParams(ctx context.Context, req *protoCommandPa
 	params.FullConfig, params.TaskSpec, err = a.makeFullCommandSpec(
 		configBytes, &req.TemplateName, req.MustZeroSlot)
 	if err != nil {
+		if err == errCommandUnfulfillable {
+			return nil, api.AsErrBadRequest(
+				"resource request unfulfillable, please try requesting less slots")
+		}
 		return nil, status.Errorf(codes.Internal, "failed to make command spec: %s", err)
 	}
 
@@ -182,6 +195,9 @@ func (a *apiServer) LaunchCommand(
 		Data:         req.Data,
 	})
 	if err != nil {
+		if grpcErr := api.APIErr2GRPC(err); grpcErr != nil {
+			return nil, grpcErr
+		}
 		return nil, err
 	}
 

--- a/master/internal/api_notebook.go
+++ b/master/internal/api_notebook.go
@@ -88,10 +88,7 @@ func (a *apiServer) LaunchNotebook(
 		Files:        req.Files,
 	})
 	if err != nil {
-		if grpcErr := api.APIErr2GRPC(err); grpcErr != nil {
-			return nil, grpcErr
-		}
-		return nil, errors.Wrapf(err, "failed to prepare launch params")
+		return nil, api.APIErr2GRPC(errors.Wrapf(err, "failed to prepare launch params"))
 	}
 
 	if req.Preview {

--- a/master/internal/api_notebook.go
+++ b/master/internal/api_notebook.go
@@ -88,6 +88,9 @@ func (a *apiServer) LaunchNotebook(
 		Files:        req.Files,
 	})
 	if err != nil {
+		if grpcErr := api.APIErr2GRPC(err); grpcErr != nil {
+			return nil, grpcErr
+		}
 		return nil, errors.Wrapf(err, "failed to prepare launch params")
 	}
 

--- a/master/internal/api_shell.go
+++ b/master/internal/api_shell.go
@@ -46,6 +46,9 @@ func (a *apiServer) LaunchShell(
 		Data:         req.Data,
 	})
 	if err != nil {
+		if grpcErr := api.APIErr2GRPC(err); grpcErr != nil {
+			return nil, grpcErr
+		}
 		return nil, err
 	}
 

--- a/master/internal/api_shell.go
+++ b/master/internal/api_shell.go
@@ -46,10 +46,7 @@ func (a *apiServer) LaunchShell(
 		Data:         req.Data,
 	})
 	if err != nil {
-		if grpcErr := api.APIErr2GRPC(err); grpcErr != nil {
-			return nil, grpcErr
-		}
-		return nil, err
+		return nil, api.APIErr2GRPC(err)
 	}
 
 	shellLaunchReq := command.ShellLaunchRequest{CommandParams: params}

--- a/master/internal/api_tensorboard.go
+++ b/master/internal/api_tensorboard.go
@@ -77,6 +77,9 @@ func (a *apiServer) LaunchTensorboard(
 		MustZeroSlot: true,
 	})
 	if err != nil {
+		if grpcErr := api.APIErr2GRPC(err); grpcErr != nil {
+			return nil, grpcErr
+		}
 		return nil, err
 	}
 

--- a/master/internal/api_tensorboard.go
+++ b/master/internal/api_tensorboard.go
@@ -77,10 +77,7 @@ func (a *apiServer) LaunchTensorboard(
 		MustZeroSlot: true,
 	})
 	if err != nil {
-		if grpcErr := api.APIErr2GRPC(err); grpcErr != nil {
-			return nil, grpcErr
-		}
-		return nil, err
+		return nil, api.APIErr2GRPC(err)
 	}
 
 	tensorboardLaunchReq := command.TensorboardRequest{

--- a/master/internal/resourcemanagers/kubernetes_resource_manager.go
+++ b/master/internal/resourcemanagers/kubernetes_resource_manager.go
@@ -120,6 +120,10 @@ func (k *kubernetesResourceManager) Receive(ctx *actor.Context) error {
 	case sproto.GetDefaultAuxResourcePoolRequest:
 		ctx.Respond(sproto.GetDefaultAuxResourcePoolResponse{PoolName: ""})
 
+	case sproto.ValidateCommandResourcesRequest:
+		fulfillable := k.config.MaxSlotsPerPod >= msg.Slots
+		ctx.Respond(sproto.ValidateCommandResourcesResponse{Fulfillable: &fulfillable})
+
 	case schedulerTick:
 		if k.reschedule {
 			k.schedulePendingTasks(ctx)

--- a/master/internal/resourcemanagers/kubernetes_resource_manager.go
+++ b/master/internal/resourcemanagers/kubernetes_resource_manager.go
@@ -122,7 +122,7 @@ func (k *kubernetesResourceManager) Receive(ctx *actor.Context) error {
 
 	case sproto.ValidateCommandResourcesRequest:
 		fulfillable := k.config.MaxSlotsPerPod >= msg.Slots
-		ctx.Respond(sproto.ValidateCommandResourcesResponse{Fulfillable: &fulfillable})
+		ctx.Respond(sproto.ValidateCommandResourcesResponse{Fulfillable: fulfillable})
 
 	case schedulerTick:
 		if k.reschedule {

--- a/master/internal/resourcemanagers/resource_managers_test.go
+++ b/master/internal/resourcemanagers/resource_managers_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/labstack/echo/v4"
 
 	"gotest.tools/assert"
-	is "gotest.tools/assert/cmp"
 
 	"github.com/determined-ai/determined/master/internal/sproto"
 	"github.com/determined-ai/determined/master/pkg/actor"
@@ -60,6 +59,7 @@ func TestResourceManagerValidateRPResourcesUnknown(t *testing.T) {
 	}
 
 	Setup(system, echo.New(), conf, nil, nil)
-	value := sproto.ValidateRPResources(system, defaultResourcePoolName, 1)
-	assert.Assert(t, is.Nil(value))
+	value, err := sproto.ValidateRPResources(system, defaultResourcePoolName, 1)
+	assert.Assert(t, err == nil)
+	assert.Assert(t, value)
 }

--- a/master/internal/resourcemanagers/resource_managers_test.go
+++ b/master/internal/resourcemanagers/resource_managers_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/labstack/echo/v4"
 
 	"gotest.tools/assert"
+	is "gotest.tools/assert/cmp"
 
 	"github.com/determined-ai/determined/master/internal/sproto"
 	"github.com/determined-ai/determined/master/pkg/actor"
@@ -34,4 +35,31 @@ func TestResourceManagerForwardMessage(t *testing.T) {
 	taskSummary := system.Ask(rpActor, sproto.GetTaskSummaries{}).Get()
 	assert.DeepEqual(t, taskSummary, make(map[sproto.TaskID]TaskSummary))
 	assert.NilError(t, rpActor.StopAndAwaitTermination())
+}
+
+func TestResourceManagerValidateRPResourcesUnknown(t *testing.T) {
+	// We can reliably run this check only for AWS, GCP, or Kube resource pools,
+	// but initializing either of these in the test is not viable. So let's at least
+	// check if we properly return "unknown" for on-prem-like setups.
+	system := actor.NewSystem(t.Name())
+	conf := &ResourceConfig{
+		ResourceManager: &ResourceManagerConfig{
+			AgentRM: &AgentResourceManagerConfig{
+				Scheduler: &SchedulerConfig{
+					FairShare:     &FairShareSchedulerConfig{},
+					FittingPolicy: best,
+				},
+			},
+		},
+		ResourcePools: []ResourcePoolConfig{
+			{
+				PoolName:                 defaultResourcePoolName,
+				MaxAuxContainersPerAgent: 100,
+			},
+		},
+	}
+
+	Setup(system, echo.New(), conf, nil, nil)
+	value := sproto.ValidateRPResources(system, defaultResourcePoolName, 1)
+	assert.Assert(t, is.Nil(value))
 }

--- a/master/internal/resourcemanagers/resource_pool.go
+++ b/master/internal/resourcemanagers/resource_pool.go
@@ -269,6 +269,14 @@ func (rp *ResourcePool) Receive(ctx *actor.Context) error {
 		reschedule = false
 		actors.NotifyAfter(ctx, actionCoolDown, schedulerTick{})
 
+	case sproto.ValidateCommandResourcesRequest:
+		if rp.slotsPerInstance > 0 {
+			fulfillable := rp.slotsPerInstance >= msg.Slots
+			ctx.Respond(sproto.ValidateCommandResourcesResponse{Fulfillable: &fulfillable})
+		} else {
+			ctx.Respond(sproto.ValidateCommandResourcesResponse{Fulfillable: nil})
+		}
+
 	default:
 		reschedule = false
 		return actor.ErrUnexpectedMessage(ctx)

--- a/master/internal/resourcemanagers/resource_pool.go
+++ b/master/internal/resourcemanagers/resource_pool.go
@@ -270,12 +270,11 @@ func (rp *ResourcePool) Receive(ctx *actor.Context) error {
 		actors.NotifyAfter(ctx, actionCoolDown, schedulerTick{})
 
 	case sproto.ValidateCommandResourcesRequest:
+		fulfillable := true // Default to "true" when unknown.
 		if rp.slotsPerInstance > 0 {
-			fulfillable := rp.slotsPerInstance >= msg.Slots
-			ctx.Respond(sproto.ValidateCommandResourcesResponse{Fulfillable: &fulfillable})
-		} else {
-			ctx.Respond(sproto.ValidateCommandResourcesResponse{Fulfillable: nil})
+			fulfillable = rp.slotsPerInstance >= msg.Slots
 		}
+		ctx.Respond(sproto.ValidateCommandResourcesResponse{Fulfillable: fulfillable})
 
 	default:
 		reschedule = false

--- a/master/internal/sproto/task.go
+++ b/master/internal/sproto/task.go
@@ -34,7 +34,37 @@ type (
 		Name        string
 		TaskHandler *actor.Ref
 	}
+
+	// ValidateCommandResourcesRequest is a message asking resource manager whether the given
+	// resource pool can (or, rather, if it's not impossible to) fulfill the command request
+	// for the given amount of slots.
+	ValidateCommandResourcesRequest struct {
+		ResourcePool string
+		Slots        int
+	}
+
+	// ValidateCommandResourcesResponse is the response to ValidateCommandResourcesRequest.
+	ValidateCommandResourcesResponse struct {
+		// Fulfillable values:
+		// - false: impossible to fulfill
+		// - true: ok or unknown
+		Fulfillable bool
+	}
 )
+
+// ValidateRPResources checks if the resource pool can fulfill resource request for single-node
+// notebook/command/shell etc. Returns &true if yes, &false if not, and nil if unknown.
+func ValidateRPResources(system *actor.System, resourcePoolName string, slots int) (bool, error) {
+	resp := system.Ask(
+		GetCurrentRM(system), ValidateCommandResourcesRequest{
+			ResourcePool: resourcePoolName,
+			Slots:        slots,
+		})
+	if resp.Error() != nil {
+		return false, resp.Error()
+	}
+	return resp.Get().(ValidateCommandResourcesResponse).Fulfillable, nil
+}
 
 // Incoming task actor messages; task actors must accept these messages.
 type (
@@ -64,34 +94,4 @@ type Allocation interface {
 	Summary() ContainerSummary
 	Start(ctx *actor.Context, spec tasks.TaskSpec)
 	Kill(ctx *actor.Context)
-}
-
-type (
-	// ValidateCommandResourcesRequest is a message asking resource manager whether the given
-	// resource pool can (or, rather, if it's not impossible to) fulfill the command request
-	// for the given amount of slots.
-	ValidateCommandResourcesRequest struct {
-		ResourcePool string
-		Slots        int
-	}
-
-	// ValidateCommandResourcesResponse is the response to ValidateCommandResourcesRequest.
-	ValidateCommandResourcesResponse struct {
-		// Fulfillable values:
-		// - nil: unknown
-		// - false: impossible to fulfill
-		// - true: ok
-		Fulfillable *bool
-	}
-)
-
-// ValidateRPResources checks if the resource pool can fulfill resource request for single-node
-// notebook/command/shell etc. Returns &true if yes, &false if not, and nil if unknown.
-func ValidateRPResources(system *actor.System, resourcePoolName string, slots int) *bool {
-	resp := system.Ask(
-		GetCurrentRM(system), ValidateCommandResourcesRequest{
-			ResourcePool: resourcePoolName,
-			Slots:        slots,
-		}).Get()
-	return resp.(ValidateCommandResourcesResponse).Fulfillable
 }

--- a/webui/react/src/components/NotebookModal.tsx
+++ b/webui/react/src/components/NotebookModal.tsx
@@ -79,6 +79,7 @@ interface FullConfigProps {
 interface ResourceInfo {
   hasAux: boolean;
   hasCompute: boolean;
+  maxSlots: number;
   showResourceType: boolean;
 }
 
@@ -239,17 +240,20 @@ const NotebookForm:React.FC<FormProps> = (
   const [ templates, setTemplates ] = useState<Template[]>([]);
   const [ resourcePools, setResourcePools ] = useState<ResourcePool[]>([]);
   const [ resourceInfo, setResourceInfo ] = useState<ResourceInfo>(
-    { hasAux: false, hasCompute: true, showResourceType: true },
+    { hasAux: false, hasCompute: true, maxSlots: 1, showResourceType: true },
   );
 
   const calculateResourceInfo = useCallback((selectedPoolName: string | undefined) => {
     const selectedPool = resourcePools.find(pool => pool.name === selectedPoolName);
     if (!selectedPool) {
-      return { hasAux: false, hasCompute: false, showResourceType: true };
+      return { hasAux: false, hasCompute: false, maxSlots: 0, showResourceType: true };
     }
     const hasAuxCapacity = selectedPool.auxContainerCapacityPerAgent > 0;
     const hasComputeCapacity = selectedPool.slotsAvailable > 0
       || (!!selectedPool.slotsPerAgent && selectedPool.slotsPerAgent > 0);
+    const maxSlots = hasComputeCapacity ?
+      (selectedPool.slotsPerAgent && selectedPool.slotsPerAgent > 0 ?
+        selectedPool.slotsPerAgent : 2**16) : 0;
     if (hasAuxCapacity && !hasComputeCapacity) {
       onChange({ key: 'type', value: ResourceType.UNSPECIFIED });
       onChange({ key: 'slots', value: 0 });
@@ -259,6 +263,7 @@ const NotebookForm:React.FC<FormProps> = (
     return {
       hasAux: hasAuxCapacity,
       hasCompute: hasComputeCapacity,
+      maxSlots: maxSlots,
       showResourceType: hasAuxCapacity && hasComputeCapacity,
     };
   }, [ onChange, resourcePools ]);
@@ -323,6 +328,7 @@ const NotebookForm:React.FC<FormProps> = (
           content = {
             <InputNumber
               defaultValue={fields.slots || 1}
+              max={resourceInfo.maxSlots}
               min={resourceInfo.hasAux ? 0 : 1}
               value={fields.slots}
               onChange={(value) => onChange({ key: 'slots', value: value })} />}

--- a/webui/react/src/components/NotebookModal.tsx
+++ b/webui/react/src/components/NotebookModal.tsx
@@ -79,7 +79,7 @@ interface FullConfigProps {
 interface ResourceInfo {
   hasAux: boolean;
   hasCompute: boolean;
-  maxSlots: number;
+  maxSlots: number | undefined;
   showResourceType: boolean;
 }
 
@@ -253,7 +253,7 @@ const NotebookForm:React.FC<FormProps> = (
       || (!!selectedPool.slotsPerAgent && selectedPool.slotsPerAgent > 0);
     const maxSlots = hasComputeCapacity ?
       (selectedPool.slotsPerAgent && selectedPool.slotsPerAgent > 0 ?
-        selectedPool.slotsPerAgent : 2**16) : 0;
+        selectedPool.slotsPerAgent : undefined) : 0;
     if (hasAuxCapacity && !hasComputeCapacity) {
       onChange({ key: 'type', value: ResourceType.UNSPECIFIED });
       onChange({ key: 'slots', value: 0 });


### PR DESCRIPTION
## Description
- Return API error for "impossible" slot requests.
- Limit max number of slots in the UI.

## Test Plan
Given a GCP, AWS, or Kube cluster with say 4 MaxSlotsPerPod or 4 gpu-nodes:
- In "Launch notebook" UI model, the number of slots for compute will be limited to the max possible number of slots (i.e. 4).
- "Bad" commands such as `det notebook start --config resources.slots=10`, `det shell start --config resources.slots=10` etc. should fail with a comprehensible error about an incorrect # of slots.
- "Good" commands such as `det shell start --config resources.slots=4` should succeed.
On-prem resource pools, e.g. `det deploy local` or local devclusters, will always allow all requests as the max slots are not known. As such, any request should continue working on these clusters.

<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
