### PR TITLE
chore: Update environments to have a minimal base layer

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,11 +97,11 @@ commands:
       - when:
           condition: <<parameters.tf1>>
           steps:
-            - run: docker pull determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-b06dafb
+            - run: docker pull determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-0af9954
       - when:
           condition: <<parameters.tf2>>
           steps:
-            - run: docker pull determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-b06dafb
+            - run: docker pull determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0af9954
 
   login-docker:
     parameters:
@@ -621,7 +621,7 @@ commands:
         description: The Google project ID to connect with via the gcloud CLI
         type: env_var_name
       environment-image:
-        default: determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0.16.1
+        default: determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0.16.2
         type: string
     steps:
       - set-cluster-id:
@@ -1596,7 +1596,7 @@ jobs:
         type: string
         default: ""
       environment-image:
-        default: determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0.16.1
+        default: determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0.16.2
         type: string
     docker:
       - image: determinedai/cimg-base:stable
@@ -2052,8 +2052,8 @@ workflows:
               parallelism: [1]
               slack-mentions: ["${SLACK_USER_ID}"]
               environment-image:
-                - determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0.16.1
-                - determinedai/environments:cuda-11.2-pytorch-1.7-lightning-1.2-tf-2.5-gpu-0.16.1
+                - determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0.16.2
+                - determinedai/environments:cuda-11.2-pytorch-1.7-lightning-1.2-tf-2.5-gpu-0.16.2
 
       - test-e2e-gke-cuda-11:
           name: test-e2e-gke-parallel-cuda-11
@@ -2072,8 +2072,8 @@ workflows:
               gpus-per-machine: [4]
               num-machines: [2]
               environment-image:
-                - determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0.16.1
-                - determinedai/environments:cuda-11.2-pytorch-1.7-lightning-1.2-tf-2.5-gpu-0.16.1
+                - determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0.16.2
+                - determinedai/environments:cuda-11.2-pytorch-1.7-lightning-1.2-tf-2.5-gpu-0.16.2
 
       - test-e2e-gke:
           name: test-e2e-gke-single-cpu
@@ -2180,8 +2180,8 @@ workflows:
               parallelism: [1]
               slack-mentions: ["${SLACK_USER_ID}"]
               environment-image:
-                - determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0.16.1
-                - determinedai/environments:cuda-11.2-pytorch-1.7-lightning-1.2-tf-2.5-gpu-0.16.1
+                - determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0.16.2
+                - determinedai/environments:cuda-11.2-pytorch-1.7-lightning-1.2-tf-2.5-gpu-0.16.2
 
       - test-e2e-gke-cuda-11:
           name: test-e2e-gke-parallel-cuda-11
@@ -2196,8 +2196,8 @@ workflows:
               gpus-per-machine: [4]
               num-machines: [2]
               environment-image:
-                - determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0.16.1
-                - determinedai/environments:cuda-11.2-pytorch-1.7-lightning-1.2-tf-2.5-gpu-0.16.1
+                - determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0.16.2
+                - determinedai/environments:cuda-11.2-pytorch-1.7-lightning-1.2-tf-2.5-gpu-0.16.2
 
   release:
     jobs:

--- a/docs/faq.txt
+++ b/docs/faq.txt
@@ -214,10 +214,10 @@ container image that has been configured for that experiment. Determined
 provides prebuilt Docker images that include TensorFlow 2.4, 1.15, and
 2.5, respectively:
 
--  ``determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0.16.1``
+-  ``determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0.16.2``
    (default)
--  ``determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-0.16.1``
--  ``determinedai/environments:cuda-11.2-pytorch-1.7-lightning-1.2-tf-2.5-gpu-0.16.1``
+-  ``determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-0.16.2``
+-  ``determinedai/environments:cuda-11.2-pytorch-1.7-lightning-1.2-tf-2.5-gpu-0.16.2``
 
 To change the container image used for an experiment, specify
 :ref:`environment.image <exp-environment-image>` in the experiment

--- a/docs/how-to/custom-env.txt
+++ b/docs/how-to/custom-env.txt
@@ -110,9 +110,9 @@ and values of the hyperparameters for the current trial.
 .. note::
 
    The default images are
-   ``determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0.16.1``
+   ``determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0.16.2``
    and
-   ``determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0.16.1``
+   ``determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0.16.2``
    for GPU and CPU respectively.
 
 Older Images
@@ -154,7 +154,7 @@ example of a Dockerfile that installs custom ``conda``-, ``pip``- and
 .. code:: bash
 
    # Determined Image
-   FROM determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0.16.1
+   FROM determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0.16.2
 
    # Custom Configuration
    RUN apt-get update && \

--- a/docs/how-to/installation/gcp.txt
+++ b/docs/how-to/installation/gcp.txt
@@ -374,8 +374,8 @@ This command line will spin up a cluster of up to 2 A100s in the
       --compute-agent-instance-type a2-highgpu-1g --gpu-num 1 \
       --gpu-type nvidia-tesla-a100 \
       --region us-central1 --zone us-central1-c \
-      --gpu-env-image determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0.16.1 \
-      --cpu-env-image determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0.16.1
+      --gpu-env-image determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0.16.2 \
+      --cpu-env-image determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0.16.2
 
 ************
  Next Steps

--- a/docs/how-to/tensorboard.txt
+++ b/docs/how-to/tensorboard.txt
@@ -68,7 +68,7 @@ data with a bind-mount.
 .. code:: yaml
 
    environment:
-     image: determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0.16.1
+     image: determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0.16.2
    bind_mounts:
      - host_path: /my/agent/path
        container_path: /my/container/path

--- a/docs/reference/cluster-config.txt
+++ b/docs/reference/cluster-config.txt
@@ -269,9 +269,9 @@ The master supports the following configuration settings:
       specifying a dict with two keys, ``cpu`` and ``gpu``. Default
       values:
 
-      -  ``determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0.16.1``
+      -  ``determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0.16.2``
          for CPU agents
-      -  ``determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0.16.1``
+      -  ``determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0.16.2``
          for GPU agents.
 
    -  ``force_pull_image``: Defines the default policy for forcibly

--- a/docs/reference/command-notebook-config.txt
+++ b/docs/reference/command-notebook-config.txt
@@ -52,9 +52,9 @@ The following configuration settings are supported:
       Determined agent machine in the cluster. Users can customize the
       image used for GPU vs. CPU agents by specifying a dict with two
       keys, ``cpu`` and ``gpu``. Defaults to
-      ``determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0.16.1``
+      ``determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0.16.2``
       for CPU agents and
-      ``determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0.16.1``
+      ``determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0.16.2``
       for GPU agents.
 
    -  ``force_pull_image``: Forcibly pull the image from the Docker

--- a/docs/reference/experiment-config.txt
+++ b/docs/reference/experiment-config.txt
@@ -896,9 +896,9 @@ more information on customizing the trial environment, refer to
    GPU vs. CPU agents by specifying a dict with two keys, ``cpu`` and
    ``gpu``. Default values:
 
-   -  ``determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0.16.1``
+   -  ``determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0.16.2``
       for agents with GPUs.
-   -  ``determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0.16.1``
+   -  ``determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0.16.2``
       for agents with only CPUs.
 
 ``force_pull_image``

--- a/docs/reference/helm-config.txt
+++ b/docs/reference/helm-config.txt
@@ -204,12 +204,12 @@ Helm Chart </helm/determined-0.5.0.tgz>`.
    -  ``cpuImage``: Sets the default docker image for all non-gpu tasks.
       If a docker image is specified in the :ref:`experiment config
       <exp-environment-image>` this default is overriden. Defaults to:
-      ``determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0.16.1``.
+      ``determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0.16.2``.
 
    -  ``gpuImage``: Sets the default docker image for all gpu tasks. If
       a docker image is specified in the :ref:`experiment config
       <exp-environment-image>` this default is overriden. Defaults to:
-      ``determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0.16.1``.
+      ``determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0.16.2``.
 
 -  ``enterpriseEdition``: Specifies whether to use Determined enterprise
    edition.

--- a/docs/tutorials/quick-start.txt
+++ b/docs/tutorials/quick-start.txt
@@ -43,10 +43,10 @@ cluster without writing a model, see :ref:`commands-and-shells`.
 .. code::
 
    # For CPU computations
-   docker pull determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0.16.1
+   docker pull determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0.16.2
 
    # For GPU computations
-   docker pull determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0.16.1
+   docker pull determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0.16.2
 
 .. _quick-start-first-job:
 

--- a/e2e_tests/tests/config.py
+++ b/e2e_tests/tests/config.py
@@ -12,13 +12,13 @@ MAX_TASK_SCHEDULED_SECS = 30
 MAX_TRIAL_BUILD_SECS = 90
 
 
-DEFAULT_TF1_CPU_IMAGE = "determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-b06dafb"
+DEFAULT_TF1_CPU_IMAGE = "determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-0af9954"
 DEFAULT_TF2_CPU_IMAGE = (
-    "determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-b06dafb"
+    "determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0af9954"
 )
-DEFAULT_TF1_GPU_IMAGE = "determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-b06dafb"
+DEFAULT_TF1_GPU_IMAGE = "determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-0af9954"
 DEFAULT_TF2_GPU_IMAGE = (
-    "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-b06dafb"
+    "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0af9954"
 )
 
 TF1_CPU_IMAGE = os.environ.get("TF1_CPU_IMAGE") or DEFAULT_TF1_CPU_IMAGE

--- a/e2e_tests/tests/fixtures/pytorch_lightning_amp/apex_amp.yaml
+++ b/e2e_tests/tests/fixtures/pytorch_lightning_amp/apex_amp.yaml
@@ -14,6 +14,6 @@ searcher:
 entrypoint: apex_amp_model_def:MNistApexAMPTrial
 environment:
   image:
-    gpu: determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0.16.1
-    cpu: determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0.16.1
+    gpu: determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0.16.2
+    cpu: determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0.16.2
 

--- a/e2e_tests/tests/fixtures/pytorch_lightning_amp/auto_amp.yaml
+++ b/e2e_tests/tests/fixtures/pytorch_lightning_amp/auto_amp.yaml
@@ -14,6 +14,6 @@ searcher:
 entrypoint: auto_amp_model_def:MNistAutoAMPTrial
 environment:
   image:
-    gpu: determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0.16.1
-    cpu: determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0.16.1
+    gpu: determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0.16.2
+    cpu: determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0.16.2
 

--- a/examples/computer_vision/mmdetection_pytorch/docker/Dockerfile
+++ b/examples/computer_vision/mmdetection_pytorch/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-b06dafb
+FROM determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0af9954
 
 ENV TORCH_CUDA_ARCH_LIST="6.0 6.1 7.0+PTX"
 ENV TORCH_NVCC_FLAGS="-Xfatbin -compress-all"

--- a/examples/computer_vision/mnist_pl/adaptive.yaml
+++ b/examples/computer_vision/mnist_pl/adaptive.yaml
@@ -18,5 +18,5 @@ searcher:
 entrypoint: model_def:MNISTTrial
 environment:
   image:
-    gpu: determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0.16.1
-    cpu: determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0.16.1
+    gpu: determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0.16.2
+    cpu: determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0.16.2

--- a/examples/computer_vision/mnist_pl/const.yaml
+++ b/examples/computer_vision/mnist_pl/const.yaml
@@ -14,5 +14,5 @@ searcher:
 entrypoint: model_def:MNISTTrial
 environment:
   image:
-    gpu: determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0.16.1
-    cpu: determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0.16.1
+    gpu: determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0.16.2
+    cpu: determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0.16.2

--- a/examples/computer_vision/unets_tf_keras/const.yaml
+++ b/examples/computer_vision/unets_tf_keras/const.yaml
@@ -22,4 +22,4 @@ min_validation_period:
 entrypoint: model_def:UNetsTrial
 scheduling_unit: 57
 environment:
-    image: determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-b06dafb
+    image: determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0af9954

--- a/examples/computer_vision/unets_tf_keras/distributed.yaml
+++ b/examples/computer_vision/unets_tf_keras/distributed.yaml
@@ -25,4 +25,4 @@ min_validation_period:
 scheduling_unit: 8
 entrypoint: model_def:UNetsTrial
 environment:
-    image: determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-b06dafb
+    image: determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0af9954

--- a/examples/decision_trees/gbt_titanic_estimator/adaptive.yaml
+++ b/examples/decision_trees/gbt_titanic_estimator/adaptive.yaml
@@ -42,4 +42,4 @@ searcher:
 entrypoint: model_def:BoostedTreesTrial
 scheduling_unit: 1
 environment:
-  image: "determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0.16.1"
+  image: "determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0.16.2"

--- a/examples/decision_trees/gbt_titanic_estimator/const.yaml
+++ b/examples/decision_trees/gbt_titanic_estimator/const.yaml
@@ -20,4 +20,4 @@ searcher:
 entrypoint: model_def:BoostedTreesTrial
 scheduling_unit: 1
 environment:
-  image: "determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0.16.1"
+  image: "determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0.16.2"

--- a/examples/gan/dcgan_tf_keras/const.yaml
+++ b/examples/gan/dcgan_tf_keras/const.yaml
@@ -15,5 +15,5 @@ entrypoint: model_def:DCGanTrial
 environment:
   # This model only works with Tensorflow 2.2+.
   image:
-     cpu: "determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-b06dafb"
-     gpu: "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-b06dafb"
+     cpu: "determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0af9954"
+     gpu: "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0af9954"

--- a/examples/gan/dcgan_tf_keras/distributed.yaml
+++ b/examples/gan/dcgan_tf_keras/distributed.yaml
@@ -17,5 +17,5 @@ resources:
 environment:
   # This model only works with Tensorflow 2.2+.
   image:
-     cpu: "determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-b06dafb"
-     gpu: "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-b06dafb"
+     cpu: "determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0af9954"
+     gpu: "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0af9954"

--- a/examples/gan/gan_mnist_pl/adaptive.yaml
+++ b/examples/gan/gan_mnist_pl/adaptive.yaml
@@ -25,5 +25,5 @@ resources:
 entrypoint: model_def:GANTrial
 environment:
   image:
-    gpu: determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0.16.1
-    cpu: determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0.16.1
+    gpu: determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0.16.2
+    cpu: determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0.16.2

--- a/examples/gan/gan_mnist_pl/const.yaml
+++ b/examples/gan/gan_mnist_pl/const.yaml
@@ -16,5 +16,5 @@ searcher:
 entrypoint: model_def:GANTrial
 environment:
   image:
-    gpu: determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0.16.1
-    cpu: determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0.16.1
+    gpu: determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0.16.2
+    cpu: determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0.16.2

--- a/examples/gan/gan_mnist_pl/distributed.yaml
+++ b/examples/gan/gan_mnist_pl/distributed.yaml
@@ -25,5 +25,5 @@ resources:
 entrypoint: model_def:GANTrial
 environment:
   image:
-    gpu: determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0.16.1
-    cpu: determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0.16.1
+    gpu: determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0.16.2
+    cpu: determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0.16.2

--- a/harness/determined/common/schemas/expconf/_v0.py
+++ b/harness/determined/common/schemas/expconf/_v0.py
@@ -242,11 +242,11 @@ class EnvironmentImageV0(schemas.SchemaBase):
     def runtime_defaults(self) -> None:
         if self.cpu is None:
             self.cpu = (
-                "determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-b06dafb"
+                "determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0af9954"
             )
         if self.gpu is None:
             self.gpu = (
-                "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-b06dafb"
+                "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0af9954"
             )
 
 

--- a/harness/determined/deploy/aws/templates/efs.yaml
+++ b/harness/determined/deploy/aws/templates/efs.yaml
@@ -4,35 +4,35 @@ Mappings:
   RegionMap:
     ap-northeast-1:
       Master: ami-0827d8ed0295e3feb
-      Agent: ami-026b87a4b928f2119
+      Agent: ami-01212f05a2ea3aaa5
     # TODO(DET-4258) Uncomment these when we fully support all P3 regions.
     # ap-northeast-2:
     #   Master: ami-00bbba67d13faed04
-    #   Agent: ami-0e2cb5ed320bf7757
+    #   Agent: ami-0a50e1e19a56278ca
     # ap-southeast-1:
     #   Master: ami-0f6565c3d5328c913
-    #   Agent: ami-0d5f2a28b3223f391
+    #   Agent: ami-043f0a9aabdf7a02e
     # ap-southeast-2:
     #   Master: ami-0a1002150df471b2b
-    #   Agent: ami-0fa2374d33a4f8112
+    #   Agent: ami-080db061a1ad68909
     eu-central-1:
       Master: ami-0bdbe51a2e8070ff2
-      Agent: ami-0f0c6481b2232217e
+      Agent: ami-01f74c7da98d01339
     eu-west-1:
       Master: ami-03caf24deed650e2c
-      Agent: ami-099e60b9442fb31ce
+      Agent: ami-0a410de0d54939163
     # eu-west-2:
     #   Master: ami-093d303510c432519
-    #   Agent: ami-0d7562b7c9d19e898
+    #   Agent: ami-04c0cb46ffe701eae
     us-east-1:
       Master: ami-0dd76f917833aac4b
-      Agent: ami-091765ae08c55bf83
+      Agent: ami-0c75d547b1d6abb5d
     us-east-2:
       Master: ami-0b29b6e62f2343b46
-      Agent: ami-03cc872d44e8d4b52
+      Agent: ami-043dee27437994e4b
     us-west-2:
       Master: ami-01773ce53581acf22
-      Agent: ami-0ac1704f8d67d1845
+      Agent: ami-073be88e92129640d
 
 Parameters:
   VpcCIDR:

--- a/harness/determined/deploy/aws/templates/fsx.yaml
+++ b/harness/determined/deploy/aws/templates/fsx.yaml
@@ -3,35 +3,35 @@ Mappings:
   RegionMap:
     ap-northeast-1:
       Master: ami-0827d8ed0295e3feb
-      Agent: ami-026b87a4b928f2119
+      Agent: ami-01212f05a2ea3aaa5
     # TODO(DET-4258) Uncomment these when we fully support all P3 regions.
     # ap-northeast-2:
     #   Master: ami-00bbba67d13faed04
-    #   Agent: ami-0e2cb5ed320bf7757
+    #   Agent: ami-0a50e1e19a56278ca
     # ap-southeast-1:
     #   Master: ami-0f6565c3d5328c913
-    #   Agent: ami-0d5f2a28b3223f391
+    #   Agent: ami-043f0a9aabdf7a02e
     # ap-southeast-2:
     #   Master: ami-0a1002150df471b2b
-    #   Agent: ami-0fa2374d33a4f8112
+    #   Agent: ami-080db061a1ad68909
     eu-central-1:
       Master: ami-0bdbe51a2e8070ff2
-      Agent: ami-0f0c6481b2232217e
+      Agent: ami-01f74c7da98d01339
     eu-west-1:
       Master: ami-03caf24deed650e2c
-      Agent: ami-099e60b9442fb31ce
+      Agent: ami-0a410de0d54939163
     # eu-west-2:
     #   Master: ami-093d303510c432519
-    #   Agent: ami-0d7562b7c9d19e898
+    #   Agent: ami-04c0cb46ffe701eae
     us-east-1:
       Master: ami-0dd76f917833aac4b
-      Agent: ami-091765ae08c55bf83
+      Agent: ami-0c75d547b1d6abb5d
     us-east-2:
       Master: ami-0b29b6e62f2343b46
-      Agent: ami-03cc872d44e8d4b52
+      Agent: ami-043dee27437994e4b
     us-west-2:
       Master: ami-01773ce53581acf22
-      Agent: ami-0ac1704f8d67d1845
+      Agent: ami-073be88e92129640d
 
 Parameters:
   VpcCIDR:

--- a/harness/determined/deploy/aws/templates/secure.yaml
+++ b/harness/determined/deploy/aws/templates/secure.yaml
@@ -4,44 +4,44 @@ Mappings:
   RegionMap:
     ap-northeast-1:
       Master: ami-0827d8ed0295e3feb
-      Agent: ami-026b87a4b928f2119
+      Agent: ami-01212f05a2ea3aaa5
       Bastion: ami-0827d8ed0295e3feb
     # TODO(DET-4258) Uncomment these when we fully support all P3 regions.
     # ap-northeast-2:
     #   Master: ami-00bbba67d13faed04
-    #   Agent: ami-0e2cb5ed320bf7757
+    #   Agent: ami-0a50e1e19a56278ca
     #   Bastion: ami-00bbba67d13faed04
     # ap-southeast-1:
     #   Master: ami-0f6565c3d5328c913
-    #   Agent: ami-0d5f2a28b3223f391
+    #   Agent: ami-043f0a9aabdf7a02e
     #   Bastion: ami-0f6565c3d5328c913
     # ap-southeast-2:
     #   Master: ami-0a1002150df471b2b
-    #   Agent: ami-0fa2374d33a4f8112
+    #   Agent: ami-080db061a1ad68909
     #   Bastion: ami-0a1002150df471b2b
     eu-central-1:
       Master: ami-0bdbe51a2e8070ff2
-      Agent: ami-0f0c6481b2232217e
+      Agent: ami-01f74c7da98d01339
       Bastion: ami-0bdbe51a2e8070ff2
     eu-west-1:
       Master: ami-03caf24deed650e2c
-      Agent: ami-099e60b9442fb31ce
+      Agent: ami-0a410de0d54939163
       Bastion: ami-03caf24deed650e2c
     # eu-west-2:
     #   Master: ami-093d303510c432519
-    #   Agent: ami-0d7562b7c9d19e898
+    #   Agent: ami-04c0cb46ffe701eae
     #   Bastion: ami-093d303510c432519
     us-east-1:
       Master: ami-0dd76f917833aac4b
-      Agent: ami-091765ae08c55bf83
+      Agent: ami-0c75d547b1d6abb5d
       Bastion: ami-0dd76f917833aac4b
     us-east-2:
       Master: ami-0b29b6e62f2343b46
-      Agent: ami-03cc872d44e8d4b52
+      Agent: ami-043dee27437994e4b
       Bastion: ami-0b29b6e62f2343b46
     us-west-2:
       Master: ami-01773ce53581acf22
-      Agent: ami-0ac1704f8d67d1845
+      Agent: ami-073be88e92129640d
       Bastion: ami-01773ce53581acf22
 
 Parameters:

--- a/harness/determined/deploy/aws/templates/simple.yaml
+++ b/harness/determined/deploy/aws/templates/simple.yaml
@@ -5,35 +5,35 @@ Mappings:
   RegionMap:
     ap-northeast-1:
       Master: ami-0827d8ed0295e3feb
-      Agent: ami-026b87a4b928f2119
+      Agent: ami-01212f05a2ea3aaa5
     # TODO(DET-4258) Uncomment these when we fully support all P3 regions.
     # ap-northeast-2:
     #   Master: ami-00bbba67d13faed04
-    #   Agent: ami-0e2cb5ed320bf7757
+    #   Agent: ami-0a50e1e19a56278ca
     # ap-southeast-1:
     #   Master: ami-0f6565c3d5328c913
-    #   Agent: ami-0d5f2a28b3223f391
+    #   Agent: ami-043f0a9aabdf7a02e
     # ap-southeast-2:
     #   Master: ami-0a1002150df471b2b
-    #   Agent: ami-0fa2374d33a4f8112
+    #   Agent: ami-080db061a1ad68909
     eu-central-1:
       Master: ami-0bdbe51a2e8070ff2
-      Agent: ami-0f0c6481b2232217e
+      Agent: ami-01f74c7da98d01339
     eu-west-1:
       Master: ami-03caf24deed650e2c
-      Agent: ami-099e60b9442fb31ce
+      Agent: ami-0a410de0d54939163
     # eu-west-2:
     #   Master: ami-093d303510c432519
-    #   Agent: ami-0d7562b7c9d19e898
+    #   Agent: ami-04c0cb46ffe701eae
     us-east-1:
       Master: ami-0dd76f917833aac4b
-      Agent: ami-091765ae08c55bf83
+      Agent: ami-0c75d547b1d6abb5d
     us-east-2:
       Master: ami-0b29b6e62f2343b46
-      Agent: ami-03cc872d44e8d4b52
+      Agent: ami-043dee27437994e4b
     us-west-2:
       Master: ami-01773ce53581acf22
-      Agent: ami-0ac1704f8d67d1845
+      Agent: ami-073be88e92129640d
 
 Parameters:
   Keypair:

--- a/harness/determined/deploy/aws/templates/vpc.yaml
+++ b/harness/determined/deploy/aws/templates/vpc.yaml
@@ -4,35 +4,35 @@ Mappings:
   RegionMap:
     ap-northeast-1:
       Master: ami-0827d8ed0295e3feb
-      Agent: ami-026b87a4b928f2119
+      Agent: ami-01212f05a2ea3aaa5
     # TODO(DET-4258) Uncomment these when we fully support all P3 regions.
     # ap-northeast-2:
     #   Master: ami-00bbba67d13faed04
-    #   Agent: ami-0e2cb5ed320bf7757
+    #   Agent: ami-0a50e1e19a56278ca
     # ap-southeast-1:
     #   Master: ami-0f6565c3d5328c913
-    #   Agent: ami-0d5f2a28b3223f391
+    #   Agent: ami-043f0a9aabdf7a02e
     # ap-southeast-2:
     #   Master: ami-0a1002150df471b2b
-    #   Agent: ami-0fa2374d33a4f8112
+    #   Agent: ami-080db061a1ad68909
     eu-central-1:
       Master: ami-0bdbe51a2e8070ff2
-      Agent: ami-0f0c6481b2232217e
+      Agent: ami-01f74c7da98d01339
     eu-west-1:
       Master: ami-03caf24deed650e2c
-      Agent: ami-099e60b9442fb31ce
+      Agent: ami-0a410de0d54939163
     # eu-west-2:
     #   Master: ami-093d303510c432519
-    #   Agent: ami-0d7562b7c9d19e898
+    #   Agent: ami-04c0cb46ffe701eae
     us-east-1:
       Master: ami-0dd76f917833aac4b
-      Agent: ami-091765ae08c55bf83
+      Agent: ami-0c75d547b1d6abb5d
     us-east-2:
       Master: ami-0b29b6e62f2343b46
-      Agent: ami-03cc872d44e8d4b52
+      Agent: ami-043dee27437994e4b
     us-west-2:
       Master: ami-01773ce53581acf22
-      Agent: ami-0ac1704f8d67d1845
+      Agent: ami-073be88e92129640d
 
 Parameters:
   VpcCIDR:

--- a/harness/determined/deploy/gcp/constants.py
+++ b/harness/determined/deploy/gcp/constants.py
@@ -3,7 +3,7 @@ class defaults:
     AUX_AGENT_INSTANCE_TYPE = "n1-standard-4"
     COMPUTE_AGENT_INSTANCE_TYPE = "n1-standard-32"
     DB_PASSWORD = "postgres"
-    ENVIRONMENT_IMAGE = "det-environments-b06dafb"
+    ENVIRONMENT_IMAGE = "det-environments-0af9954"
     GPU_NUM = 8
     GPU_TYPE = "nvidia-tesla-k80"
     MASTER_INSTANCE_TYPE = "n1-standard-2"

--- a/harness/determined/estimator/_estimator_trial.py
+++ b/harness/determined/estimator/_estimator_trial.py
@@ -767,7 +767,7 @@ class EstimatorTrial(det.Trial):
     """
     By default, experiments run with TensorFlow 1.x. To configure your trial to
     use TensorFlow 2.x, set a TF 2.x image in the experiment configuration
-    (e.g. ``determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0.16.1``).
+    (e.g. ``determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0.16.2``).
 
     ``EstimatorTrial`` supports TF 2.x; however it uses TensorFlow V1
     behavior. We have disabled TensorFlow V2 behavior for ``EstimatorTrial``,

--- a/harness/determined/keras/_tf_keras_trial.py
+++ b/harness/determined/keras/_tf_keras_trial.py
@@ -935,7 +935,7 @@ class TFKerasTrial(det.Trial):
     TensorFlow 2.x, specify a TensorFlow 2.x image in the
     :ref:`environment.image <exp-environment-image>` field of the experiment
     configuration (e.g.,
-    ``determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0.16.1``).
+    ``determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0.16.2``).
 
     Trials default to using eager execution with TensorFlow 2.x but not with
     TensorFlow 1.x. To override the default behavior, call the appropriate

--- a/helm/charts/determined/templates/master-config.yaml
+++ b/helm/charts/determined/templates/master-config.yaml
@@ -60,8 +60,8 @@ data:
         cpu: {{ .Values.slotResourceRequests.cpu }}
       {{- end }}
 
-    {{$cpuImage := (split "/" "determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-b06dafb")._1}}
-    {{- $gpuImage := (split "/" "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-b06dafb")._1 -}}
+    {{$cpuImage := (split "/" "determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0af9954")._1}}
+    {{- $gpuImage := (split "/" "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0af9954")._1 -}}
     {{ if .Values.taskContainerDefaults -}}
     task_container_defaults:
       {{- if .Values.taskContainerDefaults.networkMode }}

--- a/master/internal/provisioner/aws_config.go
+++ b/master/internal/provisioner/aws_config.go
@@ -44,16 +44,16 @@ type AWSClusterConfig struct {
 }
 
 var defaultAWSImageID = map[string]string{
-	"ap-northeast-1": "ami-026b87a4b928f2119",
-	"ap-northeast-2": "ami-0e2cb5ed320bf7757",
-	"ap-southeast-1": "ami-0d5f2a28b3223f391",
-	"ap-southeast-2": "ami-0fa2374d33a4f8112",
-	"us-east-2":      "ami-03cc872d44e8d4b52",
-	"us-east-1":      "ami-091765ae08c55bf83",
-	"us-west-2":      "ami-0ac1704f8d67d1845",
-	"eu-central-1":   "ami-0f0c6481b2232217e",
-	"eu-west-2":      "ami-0d7562b7c9d19e898",
-	"eu-west-1":      "ami-099e60b9442fb31ce",
+	"ap-northeast-1": "ami-01212f05a2ea3aaa5",
+	"ap-northeast-2": "ami-0a50e1e19a56278ca",
+	"ap-southeast-1": "ami-043f0a9aabdf7a02e",
+	"ap-southeast-2": "ami-080db061a1ad68909",
+	"us-east-2":      "ami-043dee27437994e4b",
+	"us-east-1":      "ami-0c75d547b1d6abb5d",
+	"us-west-2":      "ami-073be88e92129640d",
+	"eu-central-1":   "ami-01f74c7da98d01339",
+	"eu-west-2":      "ami-04c0cb46ffe701eae",
+	"eu-west-1":      "ami-0a410de0d54939163",
 }
 
 var defaultAWSClusterConfig = AWSClusterConfig{

--- a/master/internal/provisioner/gcp_config.go
+++ b/master/internal/provisioner/gcp_config.go
@@ -50,7 +50,7 @@ type GCPClusterConfig struct {
 func DefaultGCPClusterConfig() *GCPClusterConfig {
 	return &GCPClusterConfig{
 		BootDiskSize:        200,
-		BootDiskSourceImage: "projects/determined-ai/global/images/det-environments-b06dafb",
+		BootDiskSourceImage: "projects/determined-ai/global/images/det-environments-0af9954",
 		LabelKey:            "managed-by",
 		InstanceType: gceInstanceType{
 			MachineType: "n1-standard-32",

--- a/master/pkg/model/defaults.go
+++ b/master/pkg/model/defaults.go
@@ -25,8 +25,8 @@ const (
 
 // Default task environment docker image names.
 const (
-	CPUImage = "determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-b06dafb"
-	GPUImage = "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-b06dafb"
+	CPUImage = "determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0af9954"
+	GPUImage = "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0af9954"
 )
 
 // DefaultResourcesConfig returns the default resources configuration.

--- a/master/pkg/schemas/expconf/const.go
+++ b/master/pkg/schemas/expconf/const.go
@@ -8,6 +8,6 @@ const (
 
 // Default task environment docker image names.
 const (
-	CPUImage = "determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-b06dafb"
-	GPUImage = "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-b06dafb"
+	CPUImage = "determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0af9954"
+	GPUImage = "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0af9954"
 )

--- a/master/pkg/schemas/expconf/legacy_test.go
+++ b/master/pkg/schemas/expconf/legacy_test.go
@@ -233,8 +233,8 @@ func TestLegacyConfig(t *testing.T) {
                     gpu: []
                   force_pull_image: false
                   image:
-                    cpu: determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-b06dafb
-                    gpu: determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-b06dafb
+                    cpu: determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-0af9954
+                    gpu: determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-0af9954
                   pod_spec: null
                   ports: {}
                   registry_auth: null

--- a/schemas/test_cases/v0/experiment.yaml
+++ b/schemas/test_cases/v0/experiment.yaml
@@ -31,8 +31,8 @@
       environment_variables: {}
       force_pull_image: false
       image:
-        cpu: determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-b06dafb
-        gpu: determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-b06dafb
+        cpu: determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0af9954
+        gpu: determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0af9954
       pod_spec: null
       ports:
         qwer: 1234

--- a/tools/scripts/bumpenvs.yaml
+++ b/tools/scripts/bumpenvs.yaml
@@ -1,6 +1,6 @@
 ap_northeast_1_agent_ami:
-  new: ami-026b87a4b928f2119
-  old: ami-014f80311fc835d7e
+  new: ami-01212f05a2ea3aaa5
+  old: ami-026b87a4b928f2119
 ap_northeast_1_bastion_ami:
   new: ami-0827d8ed0295e3feb
   old: ami-09ff2b6ef00accc2e
@@ -8,8 +8,8 @@ ap_northeast_1_master_ami:
   new: ami-0827d8ed0295e3feb
   old: ami-09ff2b6ef00accc2e
 ap_northeast_2_agent_ami:
-  new: ami-0e2cb5ed320bf7757
-  old: ami-0a7fcf5741217cfbf
+  new: ami-0a50e1e19a56278ca
+  old: ami-0e2cb5ed320bf7757
 ap_northeast_2_bastion_ami:
   new: ami-00bbba67d13faed04
   old: ami-0b329fb1f17558744
@@ -17,8 +17,8 @@ ap_northeast_2_master_ami:
   new: ami-00bbba67d13faed04
   old: ami-0b329fb1f17558744
 ap_southeast_1_agent_ami:
-  new: ami-0d5f2a28b3223f391
-  old: ami-06c7eb3d8641cb988
+  new: ami-043f0a9aabdf7a02e
+  old: ami-0d5f2a28b3223f391
 ap_southeast_1_bastion_ami:
   new: ami-0f6565c3d5328c913
   old: ami-048b4b1ddefe6759f
@@ -26,23 +26,17 @@ ap_southeast_1_master_ami:
   new: ami-0f6565c3d5328c913
   old: ami-048b4b1ddefe6759f
 ap_southeast_2_agent_ami:
-  new: ami-0fa2374d33a4f8112
-  old: ami-02677d06227bdeff4
+  new: ami-080db061a1ad68909
+  old: ami-0fa2374d33a4f8112
 ap_southeast_2_bastion_ami:
   new: ami-0a1002150df471b2b
   old: ami-052a251c7ca533c26
 ap_southeast_2_master_ami:
   new: ami-0a1002150df471b2b
   old: ami-052a251c7ca533c26
-cuda_11_hashed:
-  new: determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-b06dafb
-  old: determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-744337d
-cuda_11_versioned:
-  new: determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0.16.1
-  old: determinedai/environments:cuda-11.0-pytorch-1.7-lightning-1.2-tf-2.4-gpu-0.16.0
 eu_central_1_agent_ami:
-  new: ami-0f0c6481b2232217e
-  old: ami-092d26413029b7921
+  new: ami-01f74c7da98d01339
+  old: ami-0f0c6481b2232217e
 eu_central_1_bastion_ami:
   new: ami-0bdbe51a2e8070ff2
   old: ami-0d3905203a039e3b0
@@ -50,8 +44,8 @@ eu_central_1_master_ami:
   new: ami-0bdbe51a2e8070ff2
   old: ami-0d3905203a039e3b0
 eu_west_1_agent_ami:
-  new: ami-099e60b9442fb31ce
-  old: ami-046fc4c6f27d086de
+  new: ami-0a410de0d54939163
+  old: ami-099e60b9442fb31ce
 eu_west_1_bastion_ami:
   new: ami-03caf24deed650e2c
   old: ami-0b7fd7bc9c6fb1c78
@@ -59,8 +53,8 @@ eu_west_1_master_ami:
   new: ami-03caf24deed650e2c
   old: ami-0b7fd7bc9c6fb1c78
 eu_west_2_agent_ami:
-  new: ami-0d7562b7c9d19e898
-  old: ami-025713f438d46db32
+  new: ami-04c0cb46ffe701eae
+  old: ami-0d7562b7c9d19e898
 eu_west_2_bastion_ami:
   new: ami-093d303510c432519
   old: ami-02ead6ecbd926d792
@@ -68,35 +62,41 @@ eu_west_2_master_ami:
   new: ami-093d303510c432519
   old: ami-02ead6ecbd926d792
 gcp_env:
-  new: det-environments-b06dafb
-  old: det-environments-744337d
+  new: det-environments-0af9954
+  old: det-environments-b06dafb
 tf1_cpu_hashed:
-  new: determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-b06dafb
-  old: determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-744337d
+  new: determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-0af9954
+  old: determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-b06dafb
 tf1_cpu_versioned:
-  new: determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-0.16.1
-  old: determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-0.16.0
+  new: determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-0.16.2
+  old: determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-0.16.1
 tf1_gpu_hashed:
-  new: determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-b06dafb
-  old: determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-744337d
+  new: determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-0af9954
+  old: determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-b06dafb
 tf1_gpu_versioned:
-  new: determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-0.16.1
-  old: determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-0.16.0
+  new: determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-0.16.2
+  old: determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-0.16.1
 tf25_gpu_hashed:
-  new: determinedai/environments:cuda-11.2-pytorch-1.7-lightning-1.2-tf-2.5-gpu-b06dafb
-  old: determinedai/environments:cuda-11.2-pytorch-1.7-lightning-1.2-tf-2.5-gpu-744337d
+  new: determinedai/environments:cuda-11.2-pytorch-1.7-lightning-1.2-tf-2.5-gpu-0af9954
+  old: determinedai/environments:cuda-11.2-pytorch-1.7-lightning-1.2-tf-2.5-gpu-b06dafb
 tf25_gpu_versioned:
-  new: determinedai/environments:cuda-11.2-pytorch-1.7-lightning-1.2-tf-2.5-gpu-0.16.1
-  old: determinedai/environments:cuda-11.2-pytorch-1.7-lightning-1.2-tf-2.5-gpu-0.16.0
+  new: determinedai/environments:cuda-11.2-pytorch-1.7-lightning-1.2-tf-2.5-gpu-0.16.2
+  old: determinedai/environments:cuda-11.2-pytorch-1.7-lightning-1.2-tf-2.5-gpu-0.16.1
 tf2_cpu_hashed:
-  new: determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-b06dafb
-  old: determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-744337d
+  new: determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0af9954
+  old: determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-b06dafb
 tf2_cpu_versioned:
-  new: determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0.16.1
-  old: determinedai/environments:py-3.7-pytorch-1.7-lightning-1.2-tf-2.4-cpu-0.16.0
+  new: determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0.16.2
+  old: determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0.16.1
+tf2_gpu_hashed:
+  new: determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0af9954
+  old: determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-b06dafb
+tf2_gpu_versioned:
+  new: determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0.16.2
+  old: determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0.16.1
 us_east_1_agent_ami:
-  new: ami-091765ae08c55bf83
-  old: ami-0a6d182544caded1a
+  new: ami-0c75d547b1d6abb5d
+  old: ami-091765ae08c55bf83
 us_east_1_bastion_ami:
   new: ami-0dd76f917833aac4b
   old: ami-04cc2b0ad9e30a9c8
@@ -104,8 +104,8 @@ us_east_1_master_ami:
   new: ami-0dd76f917833aac4b
   old: ami-04cc2b0ad9e30a9c8
 us_east_2_agent_ami:
-  new: ami-03cc872d44e8d4b52
-  old: ami-0608f914a86bab144
+  new: ami-043dee27437994e4b
+  old: ami-03cc872d44e8d4b52
 us_east_2_bastion_ami:
   new: ami-0b29b6e62f2343b46
   old: ami-02fc6052104add5ae
@@ -113,20 +113,20 @@ us_east_2_master_ami:
   new: ami-0b29b6e62f2343b46
   old: ami-02fc6052104add5ae
 us_gov_east_1_agent_ami:
-  new: ami-0930dbc24c979b616
-  old: ami-09c4be806bc42dd0f
+  new: ami-042ef4e5e2810fe2d
+  old: ami-0930dbc24c979b616
 us_gov_east_1_master_ami:
   new: ami-0ce79d6fa9e9a242e
   old: ami-af9379de
 us_gov_west_1_agent_ami:
-  new: ami-08f68439d7c838247
-  old: ami-0478e0c973a52d962
+  new: ami-0876d9f53274830e3
+  old: ami-08f68439d7c838247
 us_gov_west_1_master_ami:
   new: ami-04a2f96ef9b12b2b1
   old: ami-84556de5
 us_west_2_agent_ami:
-  new: ami-0ac1704f8d67d1845
-  old: ami-0f3f8ce0b9877021c
+  new: ami-073be88e92129640d
+  old: ami-0ac1704f8d67d1845
 us_west_2_bastion_ami:
   new: ami-01773ce53581acf22
   old: ami-0a62a78cfedc09d76

--- a/tools/scripts/update-bumpenvs-yaml.py
+++ b/tools/scripts/update-bumpenvs-yaml.py
@@ -35,20 +35,20 @@ BASE_URL = f"https://circleci.com/api/v1.1/project/github/{USER}/{PROJECT}"
 
 EXPECT_JOBS = {
     "publish-cloud-images",
-    "build-and-publish-docker-tf2-cpu",
     "build-and-publish-docker-tf1-cpu",
+    "build-and-publish-docker-tf2-cpu",
     "build-and-publish-docker-tf1-gpu",
-    "build-and-publish-docker-cuda-11",
+    "build-and-publish-docker-tf2-gpu",
     "build-and-publish-docker-tf25-gpu",
 }
 
 EXPECT_ARTIFACTS = {
     "packer-log",
-    "publish-tf2-cpu",
     "publish-tf1-cpu",
+    "publish-tf2-cpu",
     "publish-tf1-gpu",
+    "publish-tf2-gpu",
     "publish-tf25-gpu",
-    "publish-cuda-11",
 }
 
 
@@ -200,10 +200,10 @@ if __name__ == "__main__":
 
     new_tags = {
         **yaml.safe_load(artifacts["publish-tf1-cpu"]),
-        **yaml.safe_load(artifacts["publish-tf1-gpu"]),
         **yaml.safe_load(artifacts["publish-tf2-cpu"]),
+        **yaml.safe_load(artifacts["publish-tf1-gpu"]),
+        **yaml.safe_load(artifacts["publish-tf2-gpu"]),
         **yaml.safe_load(artifacts["publish-tf25-gpu"]),
-        **yaml.safe_load(artifacts["publish-cuda-11"]),
         **parse_packer_log(artifacts["packer-log"]),
     }
 

--- a/webui/react/src/fixtures/responses/experiment-details/non-scalar-metrics-4078.json
+++ b/webui/react/src/fixtures/responses/experiment-details/non-scalar-metrics-4078.json
@@ -32,8 +32,8 @@
     "name": "Fork of Fork of mnist_tp_to_estimator_const",
     "environment": {
       "image": {
-        "cpu": "determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-b06dafb",
-        "gpu": "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-b06dafb"
+        "cpu": "determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0af9954",
+        "gpu": "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0af9954"
       },
       "ports": null,
       "pod_spec": null,

--- a/webui/react/src/fixtures/responses/experiment-details/set-a.json
+++ b/webui/react/src/fixtures/responses/experiment-details/set-a.json
@@ -694,8 +694,8 @@
         "environment_variables": {},
         "force_pull_image": false,
         "image": {
-          "cpu": "determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-b06dafb",
-          "gpu": "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-b06dafb"
+          "cpu": "determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0af9954",
+          "gpu": "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0af9954"
         },
         "pod_spec": null,
         "ports": null
@@ -838,8 +838,8 @@
         "environment_variables": {},
         "force_pull_image": false,
         "image": {
-          "cpu": "determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-b06dafb",
-          "gpu": "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-b06dafb"
+          "cpu": "determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0af9954",
+          "gpu": "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0af9954"
         },
         "pod_spec": {
           "metadata": {
@@ -2596,8 +2596,8 @@
       "name": "noop_adaptive",
       "environment": {
         "image": {
-          "cpu": "determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-b06dafb",
-          "gpu": "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-b06dafb"
+          "cpu": "determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0af9954",
+          "gpu": "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0af9954"
         },
         "ports": null,
         "pod_spec": null,

--- a/webui/react/src/fixtures/responses/trial-details/old-trial-config-noop-adaptive.json
+++ b/webui/react/src/fixtures/responses/trial-details/old-trial-config-noop-adaptive.json
@@ -30,8 +30,8 @@
   "name": "noop_adaptive",
   "environment": {
     "image": {
-      "cpu": "determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-b06dafb",
-      "gpu": "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-b06dafb"
+      "cpu": "determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0af9954",
+      "gpu": "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0af9954"
     },
     "ports": null,
     "force_pull_image": false,


### PR DESCRIPTION
## Description

This corresponds to this commit: https://github.com/determined-ai/environments/pull/96. In addition to the normal bumpenvs process, it includes a rename of the CUDA 11 image to being our standard TF2/GPU image.

## Test Plan

Tests were run with these images as linked in the other PR.