### PR TITLE
fix: prevents k8s priority scheduler from blocking cpu only training

### DIFF
--- a/master/internal/kubernetes/spec.go
+++ b/master/internal/kubernetes/spec.go
@@ -227,6 +227,8 @@ func (p *pod) configureCoscheduler(newPod *k8sV1.Pod, scheduler string) {
 		}
 		newPod.Spec.PriorityClassName = "determined-system-priority"
 		minAvailable = 0
+	} else if p.slotType != device.GPU {
+		minAvailable = 0
 	} else {
 		minAvailable = int(math.Ceil(float64(resources.SlotsPerTrial()) / float64(p.slots)))
 	}

--- a/master/internal/kubernetes/spec.go
+++ b/master/internal/kubernetes/spec.go
@@ -215,7 +215,7 @@ func (p *pod) configureCoscheduler(newPod *k8sV1.Pod, scheduler string) {
 	}
 
 	resources := p.taskSpec.ResourcesConfig()
-	var minAvailable int
+	minAvailable := 0
 
 	if p.taskSpec.Description() == gcTask {
 		if newPod.Spec.PriorityClassName != "" {
@@ -226,10 +226,9 @@ func (p *pod) configureCoscheduler(newPod *k8sV1.Pod, scheduler string) {
 			)
 		}
 		newPod.Spec.PriorityClassName = "determined-system-priority"
-		minAvailable = 0
-	} else if p.slotType != device.GPU {
-		minAvailable = 0
-	} else {
+	}
+
+	if p.slotType == device.GPU {
 		minAvailable = int(math.Ceil(float64(resources.SlotsPerTrial()) / float64(p.slots)))
 	}
 


### PR DESCRIPTION
## Description
The k8s coscheduler and priority scheduler implementations rely on a `minAvailable` metric that is calculated by dividing `slots` by `maxSlotsPerPod`. This is different from the implementation of CPU only training, and could cause issues if attempting to schedule them. By setting `minAvailable` to zero, we bypass the coscheduler and let the vanilla kubernetes scheduler schedule the pod. Gpu pod scheduling will remain unaffected.

<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234