### PR TITLE
feat: make `det deploy gcp` clusters log to GCP Cloud Logging

### DIFF
--- a/docs/how-to/installation/gcp.txt
+++ b/docs/how-to/installation/gcp.txt
@@ -40,6 +40,8 @@ The following GCP APIs must be enabled on your GCP project:
    <https://console.developers.google.com/apis/api/iam.googleapis.com/overview>`__
 -  `Service Networking API
    <https://console.cloud.google.com/apis/library/servicenetworking.googleapis.com>`__
+-  `Cloud Logging API
+   <https://console.cloud.google.com/apis/api/logging.googleapis.com/overview>`__
 
 Credentials
 ===========

--- a/harness/determined/deploy/gcp/terraform/modules/compute/main.tf
+++ b/harness/determined/deploy/gcp/terraform/modules/compute/main.tf
@@ -103,6 +103,7 @@ resource "google_compute_instance" "master_instance" {
           operation_timeout_period: ${var.operation_timeout_period}
           base_config:
             minCpuPlatform: ${var.min_cpu_platform_agent}
+          use_cloud_logging: true
 
       - pool_name: compute-pool
         max_aux_containers_per_agent: 0
@@ -149,6 +150,7 @@ resource "google_compute_instance" "master_instance" {
           operation_timeout_period: ${var.operation_timeout_period}
           base_config:
             minCpuPlatform: ${var.min_cpu_platform_agent}
+          use_cloud_logging: true
 
     task_container_defaults:
     EOF
@@ -203,6 +205,7 @@ resource "google_compute_instance" "master_instance" {
         --name determined-master \
         --network ${var.master_docker_network} \
         --restart unless-stopped \
+        --log-driver=gcplogs \
         -p ${var.port}:${var.port} \
         -v /usr/local/determined/etc/master.yaml:/etc/determined/master.yaml \
         -v /usr/local/determined/etc/db_ssl_root_cert.pem:/etc/determined/etc/db_ssl_root_cert.pem \

--- a/harness/determined/deploy/gcp/terraform/modules/service_account/main.tf
+++ b/harness/determined/deploy/gcp/terraform/modules/service_account/main.tf
@@ -1,4 +1,9 @@
 // Create Service Account
+locals {
+  service_account_email = google_service_account.service_account.email
+  resource_member = "serviceAccount:${local.service_account_email}"
+}
+
 resource "google_service_account" "service_account" {
   account_id   = "det-${var.unique_id}"
   display_name = "DET Service Account ${var.unique_id}"
@@ -7,21 +12,23 @@ resource "google_service_account" "service_account" {
 resource "google_project_iam_member" "project_compute" {
   project = var.project_id
   role    = "roles/compute.admin"
-  member  = "serviceAccount:${google_service_account.service_account.email}"
+  member  = local.resource_member
 }
 
 resource "google_project_iam_member" "project_service" {
   project = var.project_id
   role    = "roles/iam.serviceAccountUser"
-  member  = "serviceAccount:${google_service_account.service_account.email}"
+  member  = local.resource_member
 }
 
 resource "google_project_iam_member" "project_iam" {
   project = var.project_id
-  role    = "roles/compute.imageUser" 
-  member  = "serviceAccount:${google_service_account.service_account.email}"
+  role    = "roles/compute.imageUser"
+  member  = local.resource_member
 }
 
-locals {
-  service_account_email = google_service_account.service_account.email
+resource "google_project_iam_member" "project_logging" {
+  project = var.project_id
+  role    = "roles/logging.logWriter"
+  member  = local.resource_member
 }

--- a/master/internal/provisioner/gcp.go
+++ b/master/internal/provisioner/gcp.go
@@ -87,6 +87,7 @@ func newGCPCluster(
 		AgentID: `$(curl "http://metadata.google.internal/computeMetadata/v1/instance/` +
 			`name" -H "Metadata-Flavor: Google")`,
 		ResourcePool: resourcePool,
+		LogOptions:   config.GCP.buildDockerLogString(),
 	}))
 
 	cluster := &gcpCluster{

--- a/master/internal/provisioner/gcp_config.go
+++ b/master/internal/provisioner/gcp_config.go
@@ -44,6 +44,8 @@ type GCPClusterConfig struct {
 
 	OperationTimeoutPeriod Duration `json:"operation_timeout_period"`
 	CPUSlotsAllowed        bool     `json:"cpu_slots_allowed"`
+
+	UseCloudLogging bool `json:"use_cloud_logging"`
 }
 
 // DefaultGCPClusterConfig returns the default configuration of the gcp cluster.
@@ -218,6 +220,13 @@ func (c GCPClusterConfig) SlotType() device.Type {
 		return device.CPU
 	}
 	return device.ZeroSlot
+}
+
+func (c GCPClusterConfig) buildDockerLogString() string {
+	if c.UseCloudLogging {
+		return "--log-driver gcplogs"
+	}
+	return ""
 }
 
 type gceNetworkInterface struct {


### PR DESCRIPTION
## Description

Mimicking `det deploy aws`, GCP clusters are now run with `docker run
--log-driver gcplogs` so that container logs are sent to GCP Cloud
Logging and viewable online. (Unconditionally for the master, and via a
new master config option for agents that has no effect in other
situations.)

## Test Plan

- [x] run `det deploy gcp up` and check that output shows up in GCP Cloud Logging
