### PR TITLE
fix: kube RPs should allow aux tasks [DET-5710]

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,6 +57,7 @@ git clone git@github.com:determined-ai/determined.git
 - Protoc (>= 3.0)
 - Java (>= 7)
 - cURL (>= 7)
+- jq (>= 1.6)
 
 ### Building Determined
 

--- a/master/internal/resourcemanagers/kubernetes_resource_manager.go
+++ b/master/internal/resourcemanagers/kubernetes_resource_manager.go
@@ -85,6 +85,9 @@ func (k *kubernetesResourceManager) Receive(ctx *actor.Context) error {
 			handler:            podsActor,
 			devices:            make(map[device.Device]*cproto.ID),
 			zeroSlotContainers: make(map[cproto.ID]bool),
+			// Expose a fake number here just to signal to the UI
+			// that this RP does support the aux containers.
+			maxZeroSlotContainers: 1,
 		}
 
 	case
@@ -165,7 +168,7 @@ func (k *kubernetesResourceManager) summarizeDummyResourcePool(
 		MinAgents:                    0,
 		MaxAgents:                    0,
 		SlotsPerAgent:                int32(k.config.MaxSlotsPerPod),
-		AuxContainerCapacityPerAgent: 0,
+		AuxContainerCapacityPerAgent: int32(k.agent.maxZeroSlotContainers),
 		SchedulerType:                resourcepoolv1.SchedulerType_SCHEDULER_TYPE_KUBERNETES,
 		SchedulerFittingPolicy:       resourcepoolv1.FittingPolicy_FITTING_POLICY_KUBERNETES,
 		Location:                     "kubernetes",


### PR DESCRIPTION
## Description

WebUI uses `auxContainersPerAgent` to check if zero-slot tasks are allowed; Kubernetes does allow these, so its dummy resource pool should advertise itself as such.
Also, we now have `jq` as a requirement so I'm updating the `CONTRIBUTING` docs for good measure.

## Test Plan

Deploy a kube cluster and try to launch a zero-slot notebook via "Launch Notebook" UI.

## Commentary (optional)

## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
