### PR TITLE
ci: correct order of artifact release [DET-5195]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2220,13 +2220,6 @@ workflows:
             - build-helm
             - build-proto
 
-      - publish-python-package:
-          matrix:
-            parameters:
-              path: ["harness", "common", "cli", "deploy", "model_hub"]
-          context: determined-production
-          filters: *release-and-rc-filters
-
       - package-and-push-system-rc:
           requires:
             - build-react
@@ -2240,6 +2233,13 @@ workflows:
             - build-docs
           context: determined-production
           filters: *release-filters
+
+      - publish-python-package:
+          matrix:
+            parameters:
+              path: ["harness", "common", "cli", "deploy", "model_hub"]
+          context: determined-production
+          filters: *release-and-rc-filters
 
       - publish-docs:
           requires:


### PR DESCRIPTION
## Description

This should be straighforward because I do not see how any of the Python packages could be pulled into the things packaged by goreleaser. The problem is that people are able to install the latest CLI and try deploying a cluster before the rest of the system is available.

## Test Plan

Can't really test this well until we do a release, so I'll plan to be actively involved in case anything goes wrong with the next release. Unfortunately CircleCI also doesn't make it easy to find workflows run on a tag, and these jobs are run specifically only on a tag, so I think the only way to see the logs is to run them anew.