### PR TITLE
docs: bumping K8s version to 1.19 for EKS

### DIFF
--- a/docs/how-to/installation/setup-eks-cluster.txt
+++ b/docs/how-to/installation/setup-eks-cluster.txt
@@ -67,7 +67,7 @@ insert the cluster name and S3 bucket name.
    metadata:
      name: <cluster-name> # Specify your cluster name here
      region: us-west-2 # The default region is us-west-2
-     version: "1.17"
+     version: "1.19" # 1.20 is also supported
 
    # Cluster availability zones must be explicitly named in order for single availability zone node groups to work.
    availabilityZones:

--- a/docs/how-to/installation/setup-eks-cluster.txt
+++ b/docs/how-to/installation/setup-eks-cluster.txt
@@ -67,7 +67,7 @@ insert the cluster name and S3 bucket name.
    metadata:
      name: <cluster-name> # Specify your cluster name here
      region: us-west-2 # The default region is us-west-2
-     version: "1.15" # 1.16 and 1.17 are also supported
+     version: "1.17"
 
    # Cluster availability zones must be explicitly named in order for single availability zone node groups to work.
    availabilityZones:


### PR DESCRIPTION
## Description

Bumping K8s version to 1.19 for EKS as 1.15 is not supported anymore.

## Test Plan


## Commentary (optional)


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.
