### PR TITLE
docs: updates to docs

### DIFF
--- a/docs/how-to/installation/setup-eks-cluster.txt
+++ b/docs/how-to/installation/setup-eks-cluster.txt
@@ -67,7 +67,7 @@ insert the cluster name and S3 bucket name.
    metadata:
      name: <cluster-name> # Specify your cluster name here
      region: us-west-2 # The default region is us-west-2
-     version: "1.15" # 1.16 and 1.17 are also supported
+     version: "1.16" # 1.17 is also supported
 
    # Cluster availability zones must be explicitly named in order for single availability zone node groups to work.
    availabilityZones:

--- a/docs/topic-guides/system-concepts/system-architecture.txt
+++ b/docs/topic-guides/system-concepts/system-architecture.txt
@@ -12,7 +12,7 @@ The master is responsible for
 
 -  Storing experiment, trial, and workload metadata.
 -  Scheduling and dispatching work to agents.
--  Advancing the experiment, trial, workload state machines over time.
+-  Advancing the experiment, trial, and workload state machines over time.
 
 Each agent manages a number of **slots**, which represent computing
 devices, typically one slot per CPU or GPU. On startup the agent sends


### PR DESCRIPTION
Lowest supported version for EKS is 1.16. V1.15 is EOS 25 Jul 2021, per:
https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html

## Test Plan
None needed.
