### PR TITLE
chore: mount Filestore in the task container [DET-5694]

### DIFF
--- a/docs/release-notes/2660-mount-filestore.txt
+++ b/docs/release-notes/2660-mount-filestore.txt
@@ -1,0 +1,8 @@
+:orphan:
+
+**Improvements**
+
+- Support ``startup_script`` field in the environment configuration and task
+  container defaults configuration. This script will run inside each task container.
+- ``det deploy gcp`` now mounts the Filestore inside the task container and no longer
+  mounts it on dynamic agents.

--- a/harness/determined/cli/command.py
+++ b/harness/determined/cli/command.py
@@ -164,9 +164,8 @@ def kill(args: Namespace) -> None:
 
 @authentication.required
 def config(args: Namespace) -> None:
-    name = RemoteTaskName[args._command]
     api_full_path = "api/v1/{}/{}".format(RemoteTaskNewAPIs[args._command], args.id)
-    res_json = api.get(args.master, api_full_path).json()[name]
+    res_json = api.get(args.master, api_full_path).json()
     print(render.format_object_as_yaml(res_json["config"]))
 
 

--- a/harness/determined/common/schemas/expconf/_gen.py
+++ b/harness/determined/common/schemas/expconf/_gen.py
@@ -976,6 +976,9 @@ schemas = {
                 "type": "string"
             }
         },
+        "startup_script": {
+            "type": "string"
+        },
         "pod_spec": {
             "type": [
                 "object",

--- a/harness/determined/common/schemas/expconf/_v0.py
+++ b/harness/determined/common/schemas/expconf/_v0.py
@@ -311,6 +311,7 @@ class EnvironmentConfigV0(schemas.SchemaBase):
     pod_spec: Optional[Dict[str, Any]] = None
     ports: Optional[Dict[str, int]] = None
     registry_auth: Optional[RegistryAuthConfigV0] = None
+    startup_script: Optional[str] = None
 
     @schemas.auto_init
     def __init__(
@@ -323,6 +324,7 @@ class EnvironmentConfigV0(schemas.SchemaBase):
         pod_spec: Optional[Dict[str, Any]] = None,
         ports: Optional[Dict[str, int]] = None,
         registry_auth: Optional[RegistryAuthConfigV0] = None,
+        startup_script: Optional[str] = None,
     ) -> None:
         pass
 

--- a/harness/determined/deploy/gcp/terraform/modules/compute/main.tf
+++ b/harness/determined/deploy/gcp/terraform/modules/compute/main.tf
@@ -151,6 +151,8 @@ resource "google_compute_instance" "master_instance" {
                       mkdir -p /run/determined/shared_fs
                       mount ${var.filestore_address} /run/determined/shared_fs
                       df -h --type=nfs
+      add_capabilities:
+        - SYS_ADMIN
     EOF
     fi
 

--- a/harness/determined/deploy/gcp/terraform/modules/compute/main.tf
+++ b/harness/determined/deploy/gcp/terraform/modules/compute/main.tf
@@ -62,19 +62,6 @@ resource "google_compute_instance" "master_instance" {
       - pool_name: aux-pool
         max_aux_containers_per_agent: ${var.max_aux_containers_per_agent}
         provider:
-    EOF
-
-    if [ -n "${var.filestore_address}" ]; then
-      cat << EOF >> /usr/local/determined/etc/master.yaml
-          startup_script: |
-                          apt-get -y update && apt-get -y install nfs-common
-                          mkdir -p /mnt/shared_fs
-                          mount ${var.filestore_address} /mnt/shared_fs
-                          df -h --type=nfs
-    EOF
-    fi
-
-    cat << EOF >> /usr/local/determined/etc/master.yaml
           boot_disk_source_image: projects/determined-ai/global/images/${var.environment_image}
           agent_docker_image: ${var.image_repo_prefix}/determined-agent:${var.det_version}
           master_url: ${var.scheme}://internal-ip:${var.port}
@@ -108,19 +95,6 @@ resource "google_compute_instance" "master_instance" {
       - pool_name: compute-pool
         max_aux_containers_per_agent: 0
         provider:
-    EOF
-
-    if [ -n "${var.filestore_address}" ]; then
-      cat << EOF >> /usr/local/determined/etc/master.yaml
-          startup_script: |
-                          apt-get -y update && apt-get -y install nfs-common
-                          mkdir -p /mnt/shared_fs
-                          mount ${var.filestore_address} /mnt/shared_fs
-                          df -h --type=nfs
-    EOF
-    fi
-
-    cat << EOF >> /usr/local/determined/etc/master.yaml
           boot_disk_source_image: projects/determined-ai/global/images/${var.environment_image}
           agent_docker_image: ${var.image_repo_prefix}/determined-agent:${var.det_version}
           master_url: ${var.scheme}://internal-ip:${var.port}
@@ -173,9 +147,10 @@ resource "google_compute_instance" "master_instance" {
 
     if [ -n "${var.filestore_address}" ]; then
       cat << EOF >> /usr/local/determined/etc/master.yaml
-      bind_mounts:
-        - host_path: /mnt/shared_fs
-          container_path: /run/determined/shared_fs
+      startup_script: |
+                      mkdir -p /run/determined/shared_fs
+                      mount ${var.filestore_address} /run/determined/shared_fs
+                      df -h --type=nfs
     EOF
     fi
 

--- a/master/pkg/model/compat.go
+++ b/master/pkg/model/compat.go
@@ -97,5 +97,6 @@ func (e Environment) ToExpconf() expconf.EnvironmentConfig {
 		RawRegistryAuth:         e.RegistryAuth,
 		RawForcePullImage:       ptrs.BoolPtr(e.ForcePullImage),
 		RawPodSpec:              (*expconf.PodSpec)(e.PodSpec),
+		RawStartupScript:        e.StartupScript,
 	}).(expconf.EnvironmentConfig)
 }

--- a/master/pkg/model/environment_config.go
+++ b/master/pkg/model/environment_config.go
@@ -34,6 +34,8 @@ type Environment struct {
 
 	AddCapabilities  []string `json:"add_capabilities"`
 	DropCapabilities []string `json:"drop_capabilities"`
+
+	StartupScript *string `json:"startup_script"`
 }
 
 // RuntimeItem configures the runtime image.

--- a/master/pkg/model/task_container_defaults.go
+++ b/master/pkg/model/task_container_defaults.go
@@ -35,7 +35,8 @@ type TaskContainerDefaultsConfig struct {
 	DropCapabilities []string      `json:"drop_capabilities"`
 	Devices          DevicesConfig `json:"devices"`
 
-	BindMounts BindMountsConfig `json:"bind_mounts"`
+	BindMounts    BindMountsConfig `json:"bind_mounts"`
+	StartupScript *string          `json:"startup_script"`
 }
 
 func validatePortRange(portRange string) []error {
@@ -144,6 +145,7 @@ func (c *TaskContainerDefaultsConfig) MergeIntoConfig(config *expconf.Experiment
 		RawImage:            image,
 		RawPodSpec:          (*expconf.PodSpec)(podSpec),
 		RawRegistryAuth:     c.RegistryAuth,
+		RawStartupScript:    c.StartupScript,
 	}
 	config.RawEnvironment = schemas.Merge(config.RawEnvironment, &env).(*expconf.EnvironmentConfig)
 

--- a/master/pkg/schemas/expconf/environment_config.go
+++ b/master/pkg/schemas/expconf/environment_config.go
@@ -53,6 +53,8 @@ type EnvironmentConfigV0 struct {
 
 	RawAddCapabilities  []string `json:"add_capabilities"`
 	RawDropCapabilities []string `json:"drop_capabilities"`
+
+	RawStartupScript *string `json:"startup_script"`
 }
 
 //go:generate ../gen.sh

--- a/master/pkg/schemas/expconf/zgen_environment_config_v0.go
+++ b/master/pkg/schemas/expconf/zgen_environment_config_v0.go
@@ -82,6 +82,14 @@ func (e *EnvironmentConfigV0) SetDropCapabilities(val []string) {
 	e.RawDropCapabilities = val
 }
 
+func (e EnvironmentConfigV0) StartupScript() *string {
+	return e.RawStartupScript
+}
+
+func (e *EnvironmentConfigV0) SetStartupScript(val *string) {
+	e.RawStartupScript = val
+}
+
 func (e EnvironmentConfigV0) ParsedSchema() interface{} {
 	return schemas.ParsedEnvironmentConfigV0()
 }

--- a/master/pkg/schemas/zgen_schemas.go
+++ b/master/pkg/schemas/zgen_schemas.go
@@ -902,6 +902,13 @@ var (
                 "type": "string"
             }
         },
+        "startup_script": {
+            "type": [
+                "string",
+                "null"
+            ],
+            "default": null
+        },
         "pod_spec": {
             "type": [
                 "object",

--- a/master/static/srv/entrypoint.sh
+++ b/master/static/srv/entrypoint.sh
@@ -53,4 +53,8 @@ fi
 "$DET_PYTHON_EXECUTABLE" -m pip install -q --user /opt/determined/wheels/determined*.whl
 
 cd ${WORKING_DIR} && test -f "${STARTUP_HOOK}" && source "${STARTUP_HOOK}"
+
+echo $DET_STARTUP_SCRIPT | base64 --decode > /run/determined/startup_script
+cd ${WORKING_DIR} && test -f /run/determined/startup_script && source /run/determined/startup_script
+
 exec "$DET_PYTHON_EXECUTABLE" -m determined.exec.harness "$@"

--- a/master/static/srv/gc-checkpoints-entrypoint.sh
+++ b/master/static/srv/gc-checkpoints-entrypoint.sh
@@ -15,4 +15,7 @@ fi
 
 "$DET_PYTHON_EXECUTABLE" -m pip install -q --user /opt/determined/wheels/determined*.whl
 
+echo $DET_STARTUP_SCRIPT | base64 --decode > /run/determined/startup_script
+cd ${WORKING_DIR} && test -f /run/determined/startup_script && source /run/determined/startup_script
+
 exec "$DET_PYTHON_EXECUTABLE" -m determined.exec.gc_checkpoints "$@"

--- a/master/static/srv/notebook-entrypoint.sh
+++ b/master/static/srv/notebook-entrypoint.sh
@@ -28,6 +28,10 @@ fi
 "$DET_PYTHON_EXECUTABLE" -m pip install -q --user /opt/determined/wheels/determined*.whl
 
 pushd ${WORKING_DIR} && test -f "${STARTUP_HOOK}" && source "${STARTUP_HOOK}" && popd
+
+echo $DET_STARTUP_SCRIPT | base64 --decode > /run/determined/startup_script
+pushd ${WORKING_DIR} && test -f /run/determined/startup_script && source /run/determined/startup_script && popd
+
 exec jupyter lab --ServerApp.port=${NOTEBOOK_PORT} \
                  --ServerApp.allow_origin="*" \
                  --ServerApp.base_url="/proxy/${DET_TASK_ID}/" \

--- a/master/static/srv/shell-entrypoint.sh
+++ b/master/static/srv/shell-entrypoint.sh
@@ -22,6 +22,9 @@ fi
 
 pushd ${WORKING_DIR} && test -f "${STARTUP_HOOK}" && source "${STARTUP_HOOK}" && popd
 
+echo $DET_STARTUP_SCRIPT | base64 --decode > /run/determined/startup_script
+pushd ${WORKING_DIR} && test -f /run/determined/startup_script && source /run/determined/startup_script && popd
+
 # Prepend each key in authorized_keys with a set of environment="KEY=VALUE"
 # options to inject the entire docker environment into the eventual ssh
 # session via an options in the authorized keys file.  See syntax described in

--- a/master/static/srv/tensorboard-entrypoint.sh
+++ b/master/static/srv/tensorboard-entrypoint.sh
@@ -21,5 +21,8 @@ TENSORBOARD_VERSION=$(pip show tensorboard | grep Version | sed "s/[^:]*: *//")
 
 cd ${WORKING_DIR} && test -f "${STARTUP_HOOK}" && source "${STARTUP_HOOK}"
 
+echo $DET_STARTUP_SCRIPT | base64 --decode > /run/determined/startup_script
+cd ${WORKING_DIR} && test -f /run/determined/startup_script && source /run/determined/startup_script
+
 "$DET_PYTHON_EXECUTABLE" -m pip install tensorboard-plugin-profile
 exec "$DET_PYTHON_EXECUTABLE" -m determined.exec.tensorboard "$TENSORBOARD_VERSION" "$@"

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -3,7 +3,12 @@
 - We use [JSON Schema](https://json-schema.org/) to define the schema of 
   the experiment configuration. This helps apply cross-language policies 
   for validation, null handling, default values, and some custom rules.
-  See `schemas/expconf/v0` for the V0 definitions.
+  
+- To make changes to the configuration schema, change the according files below: 
+    - See `schemas/expconf` for logics that are shared across languages.
+    - See `schemas/test_cases` for test cases that are shared across languages.
+    - See `master/pkg/schemas/expconf` for go struct definitions.
+    - See `harness/determined/common/schemas/expconf` for python class definitions.
 
 - We generate code that contains the definitions and utility functions of 
   structs.  See `schemas/gen.py`.

--- a/schemas/expconf/v0/environment.json
+++ b/schemas/expconf/v0/environment.json
@@ -72,6 +72,13 @@
                 "type": "string"
             }
         },
+        "startup_script": {
+            "type": [
+                "string",
+                "null"
+            ],
+            "default": null
+        },
         "pod_spec": {
             "type": [
                 "object",

--- a/schemas/test_cases/v0/defaults.yaml
+++ b/schemas/test_cases/v0/defaults.yaml
@@ -54,6 +54,7 @@
       - CAP_STRING
     drop_capabilities:
       - OTHER_CAP_STRING
+    startup_script: null
 
 - name: single searcher defaults
   sane_as:

--- a/schemas/test_cases/v0/experiment.yaml
+++ b/schemas/test_cases/v0/experiment.yaml
@@ -167,6 +167,7 @@
       registry_auth: null
       add_capabilities: []
       drop_capabilities: []
+      startup_script: null
     hyperparameters:
       global_batch_size:
         type: const


### PR DESCRIPTION
## Description

The Filestore used to be installed on the fly for tasks. This PR removes the installation and mounts the Filestore using startup_script in the environment configuration.


## Test Plan

1. Use `det deploy gcp up` to test automatic mounting Filestore.
2. Use `det deploy local up` to test mounting with startup_script.

## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
