### PR TITLE
chore: update images for release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,11 +97,11 @@ commands:
       - when:
           condition: <<parameters.tf1>>
           steps:
-            - run: docker pull determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-0af9954
+            - run: docker pull determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-2409e48
       - when:
           condition: <<parameters.tf2>>
           steps:
-            - run: docker pull determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0af9954
+            - run: docker pull determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-2409e48
 
   login-docker:
     parameters:

--- a/e2e_tests/tests/config.py
+++ b/e2e_tests/tests/config.py
@@ -12,13 +12,13 @@ MAX_TASK_SCHEDULED_SECS = 30
 MAX_TRIAL_BUILD_SECS = 90
 
 
-DEFAULT_TF1_CPU_IMAGE = "determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-0af9954"
+DEFAULT_TF1_CPU_IMAGE = "determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-2409e48"
 DEFAULT_TF2_CPU_IMAGE = (
-    "determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0af9954"
+    "determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-2409e48"
 )
-DEFAULT_TF1_GPU_IMAGE = "determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-0af9954"
+DEFAULT_TF1_GPU_IMAGE = "determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-2409e48"
 DEFAULT_TF2_GPU_IMAGE = (
-    "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0af9954"
+    "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-2409e48"
 )
 
 TF1_CPU_IMAGE = os.environ.get("TF1_CPU_IMAGE") or DEFAULT_TF1_CPU_IMAGE

--- a/examples/computer_vision/mmdetection_pytorch/docker/Dockerfile
+++ b/examples/computer_vision/mmdetection_pytorch/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0af9954
+FROM determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-2409e48
 
 ENV TORCH_CUDA_ARCH_LIST="6.0 6.1 7.0+PTX"
 ENV TORCH_NVCC_FLAGS="-Xfatbin -compress-all"

--- a/examples/computer_vision/unets_tf_keras/const.yaml
+++ b/examples/computer_vision/unets_tf_keras/const.yaml
@@ -22,4 +22,4 @@ min_validation_period:
 entrypoint: model_def:UNetsTrial
 scheduling_unit: 57
 environment:
-    image: determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0af9954
+    image: determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-2409e48

--- a/examples/computer_vision/unets_tf_keras/distributed.yaml
+++ b/examples/computer_vision/unets_tf_keras/distributed.yaml
@@ -25,4 +25,4 @@ min_validation_period:
 scheduling_unit: 8
 entrypoint: model_def:UNetsTrial
 environment:
-    image: determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0af9954
+    image: determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-2409e48

--- a/examples/gan/dcgan_tf_keras/const.yaml
+++ b/examples/gan/dcgan_tf_keras/const.yaml
@@ -15,5 +15,5 @@ entrypoint: model_def:DCGanTrial
 environment:
   # This model only works with Tensorflow 2.2+.
   image:
-     cpu: "determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0af9954"
-     gpu: "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0af9954"
+     cpu: "determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-2409e48"
+     gpu: "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-2409e48"

--- a/examples/gan/dcgan_tf_keras/distributed.yaml
+++ b/examples/gan/dcgan_tf_keras/distributed.yaml
@@ -17,5 +17,5 @@ resources:
 environment:
   # This model only works with Tensorflow 2.2+.
   image:
-     cpu: "determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0af9954"
-     gpu: "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0af9954"
+     cpu: "determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-2409e48"
+     gpu: "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-2409e48"

--- a/harness/determined/common/schemas/expconf/_v0.py
+++ b/harness/determined/common/schemas/expconf/_v0.py
@@ -242,11 +242,11 @@ class EnvironmentImageV0(schemas.SchemaBase):
     def runtime_defaults(self) -> None:
         if self.cpu is None:
             self.cpu = (
-                "determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0af9954"
+                "determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-2409e48"
             )
         if self.gpu is None:
             self.gpu = (
-                "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0af9954"
+                "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-2409e48"
             )
 
 

--- a/harness/determined/deploy/aws/templates/efs.yaml
+++ b/harness/determined/deploy/aws/templates/efs.yaml
@@ -4,35 +4,35 @@ Mappings:
   RegionMap:
     ap-northeast-1:
       Master: ami-0827d8ed0295e3feb
-      Agent: ami-01212f05a2ea3aaa5
+      Agent: ami-0a5666e5badd0077f
     # TODO(DET-4258) Uncomment these when we fully support all P3 regions.
     # ap-northeast-2:
     #   Master: ami-00bbba67d13faed04
-    #   Agent: ami-0a50e1e19a56278ca
+    #   Agent: ami-036d136ef074d733c
     # ap-southeast-1:
     #   Master: ami-0f6565c3d5328c913
-    #   Agent: ami-043f0a9aabdf7a02e
+    #   Agent: ami-027eca300b800ddd4
     # ap-southeast-2:
     #   Master: ami-0a1002150df471b2b
-    #   Agent: ami-080db061a1ad68909
+    #   Agent: ami-0fa75036939155792
     eu-central-1:
       Master: ami-0bdbe51a2e8070ff2
-      Agent: ami-01f74c7da98d01339
+      Agent: ami-007c306facb6bf4f4
     eu-west-1:
       Master: ami-03caf24deed650e2c
-      Agent: ami-0a410de0d54939163
+      Agent: ami-03d9920ed19325433
     # eu-west-2:
     #   Master: ami-093d303510c432519
-    #   Agent: ami-04c0cb46ffe701eae
+    #   Agent: ami-005b149621ce3dbe9
     us-east-1:
       Master: ami-0dd76f917833aac4b
-      Agent: ami-0c75d547b1d6abb5d
+      Agent: ami-0e07a509dbfbd738f
     us-east-2:
       Master: ami-0b29b6e62f2343b46
-      Agent: ami-043dee27437994e4b
+      Agent: ami-0f0683c726e626465
     us-west-2:
       Master: ami-01773ce53581acf22
-      Agent: ami-073be88e92129640d
+      Agent: ami-00118c4b9f4d3c23d
 
 Parameters:
   VpcCIDR:

--- a/harness/determined/deploy/aws/templates/fsx.yaml
+++ b/harness/determined/deploy/aws/templates/fsx.yaml
@@ -3,35 +3,35 @@ Mappings:
   RegionMap:
     ap-northeast-1:
       Master: ami-0827d8ed0295e3feb
-      Agent: ami-01212f05a2ea3aaa5
+      Agent: ami-0a5666e5badd0077f
     # TODO(DET-4258) Uncomment these when we fully support all P3 regions.
     # ap-northeast-2:
     #   Master: ami-00bbba67d13faed04
-    #   Agent: ami-0a50e1e19a56278ca
+    #   Agent: ami-036d136ef074d733c
     # ap-southeast-1:
     #   Master: ami-0f6565c3d5328c913
-    #   Agent: ami-043f0a9aabdf7a02e
+    #   Agent: ami-027eca300b800ddd4
     # ap-southeast-2:
     #   Master: ami-0a1002150df471b2b
-    #   Agent: ami-080db061a1ad68909
+    #   Agent: ami-0fa75036939155792
     eu-central-1:
       Master: ami-0bdbe51a2e8070ff2
-      Agent: ami-01f74c7da98d01339
+      Agent: ami-007c306facb6bf4f4
     eu-west-1:
       Master: ami-03caf24deed650e2c
-      Agent: ami-0a410de0d54939163
+      Agent: ami-03d9920ed19325433
     # eu-west-2:
     #   Master: ami-093d303510c432519
-    #   Agent: ami-04c0cb46ffe701eae
+    #   Agent: ami-005b149621ce3dbe9
     us-east-1:
       Master: ami-0dd76f917833aac4b
-      Agent: ami-0c75d547b1d6abb5d
+      Agent: ami-0e07a509dbfbd738f
     us-east-2:
       Master: ami-0b29b6e62f2343b46
-      Agent: ami-043dee27437994e4b
+      Agent: ami-0f0683c726e626465
     us-west-2:
       Master: ami-01773ce53581acf22
-      Agent: ami-073be88e92129640d
+      Agent: ami-00118c4b9f4d3c23d
 
 Parameters:
   VpcCIDR:

--- a/harness/determined/deploy/aws/templates/secure.yaml
+++ b/harness/determined/deploy/aws/templates/secure.yaml
@@ -4,44 +4,44 @@ Mappings:
   RegionMap:
     ap-northeast-1:
       Master: ami-0827d8ed0295e3feb
-      Agent: ami-01212f05a2ea3aaa5
+      Agent: ami-0a5666e5badd0077f
       Bastion: ami-0827d8ed0295e3feb
     # TODO(DET-4258) Uncomment these when we fully support all P3 regions.
     # ap-northeast-2:
     #   Master: ami-00bbba67d13faed04
-    #   Agent: ami-0a50e1e19a56278ca
+    #   Agent: ami-036d136ef074d733c
     #   Bastion: ami-00bbba67d13faed04
     # ap-southeast-1:
     #   Master: ami-0f6565c3d5328c913
-    #   Agent: ami-043f0a9aabdf7a02e
+    #   Agent: ami-027eca300b800ddd4
     #   Bastion: ami-0f6565c3d5328c913
     # ap-southeast-2:
     #   Master: ami-0a1002150df471b2b
-    #   Agent: ami-080db061a1ad68909
+    #   Agent: ami-0fa75036939155792
     #   Bastion: ami-0a1002150df471b2b
     eu-central-1:
       Master: ami-0bdbe51a2e8070ff2
-      Agent: ami-01f74c7da98d01339
+      Agent: ami-007c306facb6bf4f4
       Bastion: ami-0bdbe51a2e8070ff2
     eu-west-1:
       Master: ami-03caf24deed650e2c
-      Agent: ami-0a410de0d54939163
+      Agent: ami-03d9920ed19325433
       Bastion: ami-03caf24deed650e2c
     # eu-west-2:
     #   Master: ami-093d303510c432519
-    #   Agent: ami-04c0cb46ffe701eae
+    #   Agent: ami-005b149621ce3dbe9
     #   Bastion: ami-093d303510c432519
     us-east-1:
       Master: ami-0dd76f917833aac4b
-      Agent: ami-0c75d547b1d6abb5d
+      Agent: ami-0e07a509dbfbd738f
       Bastion: ami-0dd76f917833aac4b
     us-east-2:
       Master: ami-0b29b6e62f2343b46
-      Agent: ami-043dee27437994e4b
+      Agent: ami-0f0683c726e626465
       Bastion: ami-0b29b6e62f2343b46
     us-west-2:
       Master: ami-01773ce53581acf22
-      Agent: ami-073be88e92129640d
+      Agent: ami-00118c4b9f4d3c23d
       Bastion: ami-01773ce53581acf22
 
 Parameters:

--- a/harness/determined/deploy/aws/templates/simple.yaml
+++ b/harness/determined/deploy/aws/templates/simple.yaml
@@ -5,35 +5,35 @@ Mappings:
   RegionMap:
     ap-northeast-1:
       Master: ami-0827d8ed0295e3feb
-      Agent: ami-01212f05a2ea3aaa5
+      Agent: ami-0a5666e5badd0077f
     # TODO(DET-4258) Uncomment these when we fully support all P3 regions.
     # ap-northeast-2:
     #   Master: ami-00bbba67d13faed04
-    #   Agent: ami-0a50e1e19a56278ca
+    #   Agent: ami-036d136ef074d733c
     # ap-southeast-1:
     #   Master: ami-0f6565c3d5328c913
-    #   Agent: ami-043f0a9aabdf7a02e
+    #   Agent: ami-027eca300b800ddd4
     # ap-southeast-2:
     #   Master: ami-0a1002150df471b2b
-    #   Agent: ami-080db061a1ad68909
+    #   Agent: ami-0fa75036939155792
     eu-central-1:
       Master: ami-0bdbe51a2e8070ff2
-      Agent: ami-01f74c7da98d01339
+      Agent: ami-007c306facb6bf4f4
     eu-west-1:
       Master: ami-03caf24deed650e2c
-      Agent: ami-0a410de0d54939163
+      Agent: ami-03d9920ed19325433
     # eu-west-2:
     #   Master: ami-093d303510c432519
-    #   Agent: ami-04c0cb46ffe701eae
+    #   Agent: ami-005b149621ce3dbe9
     us-east-1:
       Master: ami-0dd76f917833aac4b
-      Agent: ami-0c75d547b1d6abb5d
+      Agent: ami-0e07a509dbfbd738f
     us-east-2:
       Master: ami-0b29b6e62f2343b46
-      Agent: ami-043dee27437994e4b
+      Agent: ami-0f0683c726e626465
     us-west-2:
       Master: ami-01773ce53581acf22
-      Agent: ami-073be88e92129640d
+      Agent: ami-00118c4b9f4d3c23d
 
 Parameters:
   Keypair:

--- a/harness/determined/deploy/aws/templates/vpc.yaml
+++ b/harness/determined/deploy/aws/templates/vpc.yaml
@@ -4,35 +4,35 @@ Mappings:
   RegionMap:
     ap-northeast-1:
       Master: ami-0827d8ed0295e3feb
-      Agent: ami-01212f05a2ea3aaa5
+      Agent: ami-0a5666e5badd0077f
     # TODO(DET-4258) Uncomment these when we fully support all P3 regions.
     # ap-northeast-2:
     #   Master: ami-00bbba67d13faed04
-    #   Agent: ami-0a50e1e19a56278ca
+    #   Agent: ami-036d136ef074d733c
     # ap-southeast-1:
     #   Master: ami-0f6565c3d5328c913
-    #   Agent: ami-043f0a9aabdf7a02e
+    #   Agent: ami-027eca300b800ddd4
     # ap-southeast-2:
     #   Master: ami-0a1002150df471b2b
-    #   Agent: ami-080db061a1ad68909
+    #   Agent: ami-0fa75036939155792
     eu-central-1:
       Master: ami-0bdbe51a2e8070ff2
-      Agent: ami-01f74c7da98d01339
+      Agent: ami-007c306facb6bf4f4
     eu-west-1:
       Master: ami-03caf24deed650e2c
-      Agent: ami-0a410de0d54939163
+      Agent: ami-03d9920ed19325433
     # eu-west-2:
     #   Master: ami-093d303510c432519
-    #   Agent: ami-04c0cb46ffe701eae
+    #   Agent: ami-005b149621ce3dbe9
     us-east-1:
       Master: ami-0dd76f917833aac4b
-      Agent: ami-0c75d547b1d6abb5d
+      Agent: ami-0e07a509dbfbd738f
     us-east-2:
       Master: ami-0b29b6e62f2343b46
-      Agent: ami-043dee27437994e4b
+      Agent: ami-0f0683c726e626465
     us-west-2:
       Master: ami-01773ce53581acf22
-      Agent: ami-073be88e92129640d
+      Agent: ami-00118c4b9f4d3c23d
 
 Parameters:
   VpcCIDR:

--- a/harness/determined/deploy/gcp/constants.py
+++ b/harness/determined/deploy/gcp/constants.py
@@ -3,7 +3,7 @@ class defaults:
     AUX_AGENT_INSTANCE_TYPE = "n1-standard-4"
     COMPUTE_AGENT_INSTANCE_TYPE = "n1-standard-32"
     DB_PASSWORD = "postgres"
-    ENVIRONMENT_IMAGE = "det-environments-0af9954"
+    ENVIRONMENT_IMAGE = "det-environments-2409e48"
     GPU_NUM = 8
     GPU_TYPE = "nvidia-tesla-k80"
     MASTER_INSTANCE_TYPE = "n1-standard-2"

--- a/helm/charts/determined/templates/master-config.yaml
+++ b/helm/charts/determined/templates/master-config.yaml
@@ -60,8 +60,8 @@ data:
         cpu: {{ .Values.slotResourceRequests.cpu }}
       {{- end }}
 
-    {{$cpuImage := (split "/" "determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0af9954")._1}}
-    {{- $gpuImage := (split "/" "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0af9954")._1 -}}
+    {{$cpuImage := (split "/" "determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-2409e48")._1}}
+    {{- $gpuImage := (split "/" "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-2409e48")._1 -}}
     {{ if .Values.taskContainerDefaults -}}
     task_container_defaults:
       {{- if .Values.taskContainerDefaults.networkMode }}

--- a/master/internal/provisioner/aws_config.go
+++ b/master/internal/provisioner/aws_config.go
@@ -44,16 +44,16 @@ type AWSClusterConfig struct {
 }
 
 var defaultAWSImageID = map[string]string{
-	"ap-northeast-1": "ami-01212f05a2ea3aaa5",
-	"ap-northeast-2": "ami-0a50e1e19a56278ca",
-	"ap-southeast-1": "ami-043f0a9aabdf7a02e",
-	"ap-southeast-2": "ami-080db061a1ad68909",
-	"us-east-2":      "ami-043dee27437994e4b",
-	"us-east-1":      "ami-0c75d547b1d6abb5d",
-	"us-west-2":      "ami-073be88e92129640d",
-	"eu-central-1":   "ami-01f74c7da98d01339",
-	"eu-west-2":      "ami-04c0cb46ffe701eae",
-	"eu-west-1":      "ami-0a410de0d54939163",
+	"ap-northeast-1": "ami-0a5666e5badd0077f",
+	"ap-northeast-2": "ami-036d136ef074d733c",
+	"ap-southeast-1": "ami-027eca300b800ddd4",
+	"ap-southeast-2": "ami-0fa75036939155792",
+	"us-east-2":      "ami-0f0683c726e626465",
+	"us-east-1":      "ami-0e07a509dbfbd738f",
+	"us-west-2":      "ami-00118c4b9f4d3c23d",
+	"eu-central-1":   "ami-007c306facb6bf4f4",
+	"eu-west-2":      "ami-005b149621ce3dbe9",
+	"eu-west-1":      "ami-03d9920ed19325433",
 }
 
 var defaultAWSClusterConfig = AWSClusterConfig{

--- a/master/internal/provisioner/gcp_config.go
+++ b/master/internal/provisioner/gcp_config.go
@@ -52,7 +52,7 @@ type GCPClusterConfig struct {
 func DefaultGCPClusterConfig() *GCPClusterConfig {
 	return &GCPClusterConfig{
 		BootDiskSize:        200,
-		BootDiskSourceImage: "projects/determined-ai/global/images/det-environments-0af9954",
+		BootDiskSourceImage: "projects/determined-ai/global/images/det-environments-2409e48",
 		LabelKey:            "managed-by",
 		InstanceType: gceInstanceType{
 			MachineType: "n1-standard-32",

--- a/master/pkg/model/defaults.go
+++ b/master/pkg/model/defaults.go
@@ -25,8 +25,8 @@ const (
 
 // Default task environment docker image names.
 const (
-	CPUImage = "determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0af9954"
-	GPUImage = "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0af9954"
+	CPUImage = "determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-2409e48"
+	GPUImage = "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-2409e48"
 )
 
 // DefaultResourcesConfig returns the default resources configuration.

--- a/master/pkg/schemas/expconf/const.go
+++ b/master/pkg/schemas/expconf/const.go
@@ -8,6 +8,6 @@ const (
 
 // Default task environment docker image names.
 const (
-	CPUImage = "determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0af9954"
-	GPUImage = "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0af9954"
+	CPUImage = "determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-2409e48"
+	GPUImage = "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-2409e48"
 )

--- a/master/pkg/schemas/expconf/legacy_test.go
+++ b/master/pkg/schemas/expconf/legacy_test.go
@@ -233,8 +233,8 @@ func TestLegacyConfig(t *testing.T) {
                     gpu: []
                   force_pull_image: false
                   image:
-                    cpu: determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-0af9954
-                    gpu: determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-0af9954
+                    cpu: determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-2409e48
+                    gpu: determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-2409e48
                   pod_spec: null
                   ports: {}
                   registry_auth: null

--- a/schemas/test_cases/v0/experiment.yaml
+++ b/schemas/test_cases/v0/experiment.yaml
@@ -31,8 +31,8 @@
       environment_variables: {}
       force_pull_image: false
       image:
-        cpu: determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0af9954
-        gpu: determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0af9954
+        cpu: determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-2409e48
+        gpu: determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-2409e48
       pod_spec: null
       ports:
         qwer: 1234

--- a/tools/scripts/bumpenvs.yaml
+++ b/tools/scripts/bumpenvs.yaml
@@ -1,6 +1,6 @@
 ap_northeast_1_agent_ami:
-  new: ami-01212f05a2ea3aaa5
-  old: ami-026b87a4b928f2119
+  new: ami-0a5666e5badd0077f
+  old: ami-01212f05a2ea3aaa5
 ap_northeast_1_bastion_ami:
   new: ami-0827d8ed0295e3feb
   old: ami-09ff2b6ef00accc2e
@@ -8,8 +8,8 @@ ap_northeast_1_master_ami:
   new: ami-0827d8ed0295e3feb
   old: ami-09ff2b6ef00accc2e
 ap_northeast_2_agent_ami:
-  new: ami-0a50e1e19a56278ca
-  old: ami-0e2cb5ed320bf7757
+  new: ami-036d136ef074d733c
+  old: ami-0a50e1e19a56278ca
 ap_northeast_2_bastion_ami:
   new: ami-00bbba67d13faed04
   old: ami-0b329fb1f17558744
@@ -17,8 +17,8 @@ ap_northeast_2_master_ami:
   new: ami-00bbba67d13faed04
   old: ami-0b329fb1f17558744
 ap_southeast_1_agent_ami:
-  new: ami-043f0a9aabdf7a02e
-  old: ami-0d5f2a28b3223f391
+  new: ami-027eca300b800ddd4
+  old: ami-043f0a9aabdf7a02e
 ap_southeast_1_bastion_ami:
   new: ami-0f6565c3d5328c913
   old: ami-048b4b1ddefe6759f
@@ -26,8 +26,8 @@ ap_southeast_1_master_ami:
   new: ami-0f6565c3d5328c913
   old: ami-048b4b1ddefe6759f
 ap_southeast_2_agent_ami:
-  new: ami-080db061a1ad68909
-  old: ami-0fa2374d33a4f8112
+  new: ami-0fa75036939155792
+  old: ami-080db061a1ad68909
 ap_southeast_2_bastion_ami:
   new: ami-0a1002150df471b2b
   old: ami-052a251c7ca533c26
@@ -35,8 +35,8 @@ ap_southeast_2_master_ami:
   new: ami-0a1002150df471b2b
   old: ami-052a251c7ca533c26
 eu_central_1_agent_ami:
-  new: ami-01f74c7da98d01339
-  old: ami-0f0c6481b2232217e
+  new: ami-007c306facb6bf4f4
+  old: ami-01f74c7da98d01339
 eu_central_1_bastion_ami:
   new: ami-0bdbe51a2e8070ff2
   old: ami-0d3905203a039e3b0
@@ -44,8 +44,8 @@ eu_central_1_master_ami:
   new: ami-0bdbe51a2e8070ff2
   old: ami-0d3905203a039e3b0
 eu_west_1_agent_ami:
-  new: ami-0a410de0d54939163
-  old: ami-099e60b9442fb31ce
+  new: ami-03d9920ed19325433
+  old: ami-0a410de0d54939163
 eu_west_1_bastion_ami:
   new: ami-03caf24deed650e2c
   old: ami-0b7fd7bc9c6fb1c78
@@ -53,8 +53,8 @@ eu_west_1_master_ami:
   new: ami-03caf24deed650e2c
   old: ami-0b7fd7bc9c6fb1c78
 eu_west_2_agent_ami:
-  new: ami-04c0cb46ffe701eae
-  old: ami-0d7562b7c9d19e898
+  new: ami-005b149621ce3dbe9
+  old: ami-04c0cb46ffe701eae
 eu_west_2_bastion_ami:
   new: ami-093d303510c432519
   old: ami-02ead6ecbd926d792
@@ -62,41 +62,41 @@ eu_west_2_master_ami:
   new: ami-093d303510c432519
   old: ami-02ead6ecbd926d792
 gcp_env:
-  new: det-environments-0af9954
-  old: det-environments-b06dafb
+  new: det-environments-2409e48
+  old: det-environments-0af9954
 tf1_cpu_hashed:
-  new: determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-0af9954
-  old: determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-b06dafb
+  new: determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-2409e48
+  old: determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-0af9954
 tf1_cpu_versioned:
   new: determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-0.16.2
   old: determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-0.16.1
 tf1_gpu_hashed:
-  new: determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-0af9954
-  old: determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-b06dafb
+  new: determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-2409e48
+  old: determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-0af9954
 tf1_gpu_versioned:
   new: determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-0.16.2
   old: determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-0.16.1
 tf25_gpu_hashed:
-  new: determinedai/environments:cuda-11.2-pytorch-1.7-lightning-1.2-tf-2.5-gpu-0af9954
-  old: determinedai/environments:cuda-11.2-pytorch-1.7-lightning-1.2-tf-2.5-gpu-b06dafb
+  new: determinedai/environments:cuda-11.2-pytorch-1.7-lightning-1.2-tf-2.5-gpu-2409e48
+  old: determinedai/environments:cuda-11.2-pytorch-1.7-lightning-1.2-tf-2.5-gpu-0af9954
 tf25_gpu_versioned:
   new: determinedai/environments:cuda-11.2-pytorch-1.7-lightning-1.2-tf-2.5-gpu-0.16.2
   old: determinedai/environments:cuda-11.2-pytorch-1.7-lightning-1.2-tf-2.5-gpu-0.16.1
 tf2_cpu_hashed:
-  new: determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0af9954
-  old: determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-b06dafb
+  new: determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-2409e48
+  old: determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0af9954
 tf2_cpu_versioned:
   new: determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0.16.2
   old: determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0.16.1
 tf2_gpu_hashed:
-  new: determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0af9954
-  old: determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-b06dafb
+  new: determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-2409e48
+  old: determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0af9954
 tf2_gpu_versioned:
   new: determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0.16.2
   old: determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0.16.1
 us_east_1_agent_ami:
-  new: ami-0c75d547b1d6abb5d
-  old: ami-091765ae08c55bf83
+  new: ami-0e07a509dbfbd738f
+  old: ami-0c75d547b1d6abb5d
 us_east_1_bastion_ami:
   new: ami-0dd76f917833aac4b
   old: ami-04cc2b0ad9e30a9c8
@@ -104,8 +104,8 @@ us_east_1_master_ami:
   new: ami-0dd76f917833aac4b
   old: ami-04cc2b0ad9e30a9c8
 us_east_2_agent_ami:
-  new: ami-043dee27437994e4b
-  old: ami-03cc872d44e8d4b52
+  new: ami-0f0683c726e626465
+  old: ami-043dee27437994e4b
 us_east_2_bastion_ami:
   new: ami-0b29b6e62f2343b46
   old: ami-02fc6052104add5ae
@@ -113,20 +113,20 @@ us_east_2_master_ami:
   new: ami-0b29b6e62f2343b46
   old: ami-02fc6052104add5ae
 us_gov_east_1_agent_ami:
-  new: ami-042ef4e5e2810fe2d
-  old: ami-0930dbc24c979b616
+  new: ami-0524cce6632188c57
+  old: ami-042ef4e5e2810fe2d
 us_gov_east_1_master_ami:
   new: ami-0ce79d6fa9e9a242e
   old: ami-af9379de
 us_gov_west_1_agent_ami:
-  new: ami-0876d9f53274830e3
-  old: ami-08f68439d7c838247
+  new: ami-092a6c287497ed9df
+  old: ami-0876d9f53274830e3
 us_gov_west_1_master_ami:
   new: ami-04a2f96ef9b12b2b1
   old: ami-84556de5
 us_west_2_agent_ami:
-  new: ami-073be88e92129640d
-  old: ami-0ac1704f8d67d1845
+  new: ami-00118c4b9f4d3c23d
+  old: ami-073be88e92129640d
 us_west_2_bastion_ami:
   new: ami-01773ce53581acf22
   old: ami-0a62a78cfedc09d76

--- a/webui/react/src/fixtures/responses/experiment-details/non-scalar-metrics-4078.json
+++ b/webui/react/src/fixtures/responses/experiment-details/non-scalar-metrics-4078.json
@@ -32,8 +32,8 @@
     "name": "Fork of Fork of mnist_tp_to_estimator_const",
     "environment": {
       "image": {
-        "cpu": "determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0af9954",
-        "gpu": "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0af9954"
+        "cpu": "determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-2409e48",
+        "gpu": "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-2409e48"
       },
       "ports": null,
       "pod_spec": null,

--- a/webui/react/src/fixtures/responses/experiment-details/set-a.json
+++ b/webui/react/src/fixtures/responses/experiment-details/set-a.json
@@ -694,8 +694,8 @@
         "environment_variables": {},
         "force_pull_image": false,
         "image": {
-          "cpu": "determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0af9954",
-          "gpu": "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0af9954"
+          "cpu": "determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-2409e48",
+          "gpu": "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-2409e48"
         },
         "pod_spec": null,
         "ports": null
@@ -838,8 +838,8 @@
         "environment_variables": {},
         "force_pull_image": false,
         "image": {
-          "cpu": "determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0af9954",
-          "gpu": "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0af9954"
+          "cpu": "determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-2409e48",
+          "gpu": "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-2409e48"
         },
         "pod_spec": {
           "metadata": {
@@ -2596,8 +2596,8 @@
       "name": "noop_adaptive",
       "environment": {
         "image": {
-          "cpu": "determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0af9954",
-          "gpu": "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0af9954"
+          "cpu": "determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-2409e48",
+          "gpu": "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-2409e48"
         },
         "ports": null,
         "pod_spec": null,

--- a/webui/react/src/fixtures/responses/trial-details/old-trial-config-noop-adaptive.json
+++ b/webui/react/src/fixtures/responses/trial-details/old-trial-config-noop-adaptive.json
@@ -30,8 +30,8 @@
   "name": "noop_adaptive",
   "environment": {
     "image": {
-      "cpu": "determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0af9954",
-      "gpu": "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0af9954"
+      "cpu": "determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-2409e48",
+      "gpu": "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-2409e48"
     },
     "ports": null,
     "force_pull_image": false,


### PR DESCRIPTION
## Description

The combination of PyTorch 1.9 and the HOROVOD_GPU_ALLREDUCE=NCCL option (which means to use NCCL specifically for the All-Reduce algorithm only) has been resulting in extra processes on the GPUs and consequent memory errors. Configuring NCCL to be used for all operations appears to eliminate this problem and we probably should have been doing that anyway. Also, working around a recent regression in Pillow by just pinning to an older release (https://github.com/python-pillow/Pillow/issues/5571).

See also: https://github.com/determined-ai/environments/pull/110

## Test Plan

https://app.circleci.com/pipelines/github/determined-ai/determined?branch=all_operations_nccl

At the time of this writing, one job is still running but the rest have passed.