### PR TITLE
fix: preserve subroutes for experiment detail page

### DIFF
--- a/webui/react/src/pages/ExperimentDetails/ExperimentMultiTrialTabs.tsx
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentMultiTrialTabs.tsx
@@ -46,14 +46,15 @@ const ExperimentMultiTrialTabs: React.FC<Props> = (
 
   const handleTabChange = useCallback(key => {
     setTabKey(key);
-    history.replace(key === DEFAULT_TAB_KEY ? basePath : `${basePath}/${key}`);
+    history.replace(`${basePath}/${key}`);
   }, [ basePath, history ]);
 
+  // Sets the default sub route.
   useEffect(() => {
-    if (tab && (!TAB_KEYS.includes(tab) || tab === DEFAULT_TAB_KEY)) {
-      history.replace(basePath);
+    if (!tab || (tab && !TAB_KEYS.includes(tab))) {
+      history.replace(`${basePath}/${tabKey}`);
     }
-  }, [ basePath, history, tab ]);
+  }, [ basePath, history, tab, tabKey ]);
 
   return (
     <Tabs defaultActiveKey={tabKey} onChange={handleTabChange}>

--- a/webui/react/src/pages/ExperimentDetails/ExperimentSingleTrialTabs.tsx
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentSingleTrialTabs.tsx
@@ -57,14 +57,15 @@ const ExperimentSingleTrialTabs: React.FC<Props> = (
 
   const handleTabChange = useCallback(key => {
     setTabKey(key);
-    history.replace(key === DEFAULT_TAB_KEY ? basePath : `${basePath}/${key}`);
+    history.replace(`${basePath}/${key}`);
   }, [ basePath, history ]);
 
+  // Sets the default sub route.
   useEffect(() => {
-    if (tab && (!TAB_KEYS.includes(tab) || tab === DEFAULT_TAB_KEY)) {
-      history.replace(basePath);
+    if (!tab || (tab && !TAB_KEYS.includes(tab))) {
+      history.replace(`${basePath}/${tabKey}`);
     }
-  }, [ basePath, history, tab ]);
+  }, [ basePath, history, tab, tabKey ]);
 
   const fetchTrialDetails = useCallback(async () => {
     if (!trialId) return;

--- a/webui/react/src/pages/ExperimentDetails/ExperimentVisualization.tsx
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentVisualization.tsx
@@ -1,6 +1,6 @@
 import { Alert, Tabs } from 'antd';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { useHistory } from 'react-router-dom';
+import { useHistory, useLocation } from 'react-router-dom';
 
 import Link from 'components/Link';
 import Message, { MessageType } from 'components/Message';
@@ -74,6 +74,7 @@ const ExperimentVisualization: React.FC<Props> = ({
   type,
 }: Props) => {
   const history = useHistory();
+  const location = useLocation();
   const storage = useStorage(`${STORAGE_PATH}/${experiment.id}`);
   const searcherMetric = useRef<MetricName>({
     name: experiment.config.searcher.metric,
@@ -140,15 +141,17 @@ const ExperimentVisualization: React.FC<Props> = ({
 
   const handleTabChange = useCallback((type: string) => {
     setTypeKey(type as ExperimentVisualizationType);
-    history.replace(type === DEFAULT_TYPE_KEY ? basePath : `${basePath}/${type}`);
+    history.replace(`${basePath}/${type}`);
   }, [ basePath, history ]);
 
   // Sets the default sub route.
   useEffect(() => {
-    if (type && (!TYPE_KEYS.includes(type) || type === DEFAULT_TYPE_KEY)) {
-      history.replace(basePath);
+    const isVisualizationRoute = location.pathname.includes(basePath);
+    const isInvalidType = type && !TYPE_KEYS.includes(type);
+    if (isVisualizationRoute && (!type || isInvalidType)) {
+      history.replace(`${basePath}/${typeKey}`);
     }
-  }, [ basePath, history, type ]);
+  }, [ basePath, history, location, type, typeKey ]);
 
   // Stream available metrics.
   useEffect(() => {


### PR DESCRIPTION
## Description

2 route improvements:
- The hp visualization routes for multi-trial experiments are getting redirected to a base route. For example, `/experiments/123/visualization/hp-parallel-coordinates` get redirected to `/experiments/123`. 
- Multi-trial and single-trial experiment pages reroute to a simpler route if the default tab is selected. Update the route to accurately reflect exactly what tab state the page is in. For example, currently if user is viewing Visualizations for the Multi-trial experiment page, it will change the route (if applicable) to `/experiments/123`. Instead we want `/experiments/123/visualization` for a couple of reasons: 1) we are starting to  sync up and preserve page state in the URL so they can be shareable. 2) avoid complex logic to maintain default routes (the default routes will still work but will redirect to the accurate routes)

<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234