### PR TITLE
fix: avoid passing loginRedirect to routeAll

### DIFF
--- a/webui/react/src/pages/SignIn.tsx
+++ b/webui/react/src/pages/SignIn.tsx
@@ -50,11 +50,10 @@ const SignIn: React.FC = () => {
 
       // Reroute the authenticated user to the app.
       const loginRedirect = getPath<Location>(location, 'state.loginRedirect');
-      const redirect = queries.redirect || locationToPath(loginRedirect);
-      if (!redirect) {
-        routeToReactUrl(defaultRoute.path);
+      if (!queries.redirect) {
+        routeToReactUrl(locationToPath(loginRedirect) || defaultRoute.path);
       } else {
-        routeAll(redirect);
+        routeAll(queries.redirect);
       }
     } else if (auth.checked) {
       storeDispatch({ type: StoreAction.HideUISpinner });


### PR DESCRIPTION
## Description

We know that loginRedirect is always set to internal react routes since it originates from a page in our SPA so we set signIn to always treat it as an internal route instead of trying to figure out whether it's an internal route or not.

<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

Determining whether a string is a path to A) an internal react route vs B) an asset that hosted by react vs C ) a server route quickly and without making async requests is hard
multiple ways to address this: TBD (edited) 

- stop using string routes, use react route objects
- stop using relative paths where possible
- remove the need for routeAll
- if we use routeAll we explicitly tell it if we know it's an internal route which is an equivelant of just using routeToReactUrl
- something else?


<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234