### PR TITLE
chore: Fix scientific notation in example yamls

### DIFF
--- a/e2e_tests/tests/fixtures/mnist_estimator/single-multi-slot.yaml
+++ b/e2e_tests/tests/fixtures/mnist_estimator/single-multi-slot.yaml
@@ -1,6 +1,6 @@
 description: mnist-estimator-single
 hyperparameters:
-  learning_rate: 1e-3
+  learning_rate: 1.0e-3
   global_batch_size: 64
   hidden_layer_1: 2500
   hidden_layer_2: 1000

--- a/e2e_tests/tests/fixtures/mnist_estimator/single.yaml
+++ b/e2e_tests/tests/fixtures/mnist_estimator/single.yaml
@@ -1,6 +1,6 @@
 description: mnist-estimator-single
 hyperparameters:
-  learning_rate: 1e-3
+  learning_rate: 1.0e-3
   global_batch_size: 64
   hidden_layer_1: 2500
   hidden_layer_2: 1000

--- a/examples/computer_vision/cifar10_pytorch/adaptive.yaml
+++ b/examples/computer_vision/cifar10_pytorch/adaptive.yaml
@@ -5,7 +5,7 @@ hyperparameters:
     minval: -5.0
     maxval: 1.0
     base: 10.0
-  learning_rate_decay: 1e-6
+  learning_rate_decay: 1.0e-6
   layer1_dropout:
     type: double
     minval: 0.2

--- a/examples/computer_vision/cifar10_pytorch/const.yaml
+++ b/examples/computer_vision/cifar10_pytorch/const.yaml
@@ -1,7 +1,7 @@
 name: cifar10_pytorch_const
 hyperparameters:
-  learning_rate: 1e-4
-  learning_rate_decay: 1e-6
+  learning_rate: 1.0e-4
+  learning_rate_decay: 1.0e-6
   layer1_dropout: 0.25
   layer2_dropout: 0.25
   layer3_dropout: 0.5

--- a/examples/computer_vision/cifar10_pytorch/distributed.yaml
+++ b/examples/computer_vision/cifar10_pytorch/distributed.yaml
@@ -1,7 +1,7 @@
 name: cifar10_pytorch_distributed
 hyperparameters:
-  learning_rate: 1e-4
-  learning_rate_decay: 1e-6
+  learning_rate: 1.0e-4
+  learning_rate_decay: 1.0e-6
   layer1_dropout: 0.25
   layer2_dropout: 0.25
   layer3_dropout: 0.5

--- a/examples/computer_vision/cifar10_tf_keras/adaptive.yaml
+++ b/examples/computer_vision/cifar10_tf_keras/adaptive.yaml
@@ -7,7 +7,7 @@ hyperparameters:
     minval: -5.0
     maxval: 1.0
     base: 10.0
-  learning_rate_decay: 1e-6
+  learning_rate_decay: 1.0e-6
   layer1_dropout:
     type: double
     minval: 0.2

--- a/examples/computer_vision/cifar10_tf_keras/const.yaml
+++ b/examples/computer_vision/cifar10_tf_keras/const.yaml
@@ -2,8 +2,8 @@ name: cifar10_tf_keras_const
 data:
   url: https://s3-us-west-2.amazonaws.com/determined-ai-datasets/cifar10/cifar-10-python.tar.gz
 hyperparameters:
-  learning_rate: 1e-4
-  learning_rate_decay: 1e-6
+  learning_rate: 1.0e-4
+  learning_rate_decay: 1.0e-6
   layer1_dropout: 0.25
   layer2_dropout: 0.25
   layer3_dropout: 0.5

--- a/examples/computer_vision/cifar10_tf_keras/distributed.yaml
+++ b/examples/computer_vision/cifar10_tf_keras/distributed.yaml
@@ -2,8 +2,8 @@ name: cifar10_tf_keras_distributed
 data:
   url: https://s3-us-west-2.amazonaws.com/determined-ai-datasets/cifar10/cifar-10-python.tar.gz
 hyperparameters:
-  learning_rate: 1e-4
-  learning_rate_decay: 1e-6
+  learning_rate: 1.0e-4
+  learning_rate_decay: 1.0e-6
   layer1_dropout: 0.25
   layer2_dropout: 0.25
   layer3_dropout: 0.5

--- a/examples/computer_vision/deformabledetr_coco_pytorch/const_fake.yaml
+++ b/examples/computer_vision/deformabledetr_coco_pytorch/const_fake.yaml
@@ -1,15 +1,15 @@
 name: deformabledetr_coco_fake_data
 hyperparameters:
-    lr: 2e-4
+    lr: 2.0e-4
     lr_backbone_names:
         - backbone.0 
-    lr_backbone: 2e-5
+    lr_backbone: 2.0e-5
     lr_linear_proj_names:
         - reference_points
         - sampling_offsets
     lr_linear_proj_mult: 0.1
     global_batch_size: 1
-    weight_decay: 1e-4
+    weight_decay: 1.0e-4
     lr_drop: 40
     clip_max_norm: 0.1
 

--- a/examples/computer_vision/deformabledetr_coco_pytorch/distributed.yaml
+++ b/examples/computer_vision/deformabledetr_coco_pytorch/distributed.yaml
@@ -2,16 +2,16 @@ name: deformabledetr_coco_distributed
 hyperparameters:
     # These settings match those used in this experiment from the original repo:
     #   https://github.com/fundamentalvision/Deformable-DETR/blob/main/configs/r50_deformable_detr.sh
-    lr: 2e-4
+    lr: 2.0e-4
     lr_backbone_names:
         - backbone.0
-    lr_backbone: 2e-5
+    lr_backbone: 2.0e-5
     lr_linear_proj_names:
         - reference_points
         - sampling_offsets
     lr_linear_proj_mult: 0.1
     global_batch_size: 32
-    weight_decay: 1e-4
+    weight_decay: 1.0e-4
     lr_drop: 40
     clip_max_norm: 0.1
 

--- a/examples/computer_vision/deformabledetr_coco_pytorch/finetune.yaml
+++ b/examples/computer_vision/deformabledetr_coco_pytorch/finetune.yaml
@@ -1,6 +1,6 @@
 name: deformabledetr_coco_finetune
 hyperparameters:
-    lr: 1e-4
+    lr: 1.0e-4
     lr_backbone_names:
         - backbone.0
     lr_backbone: 0
@@ -9,7 +9,7 @@ hyperparameters:
         - sampling_offsets
     lr_linear_proj_mult: 0.1
     global_batch_size: 2
-    weight_decay: 1e-4
+    weight_decay: 1.0e-4
     lr_drop: 4
     clip_max_norm: 0.1
 

--- a/examples/computer_vision/deformabledetr_coco_pytorch/finetune_adaptive.yaml
+++ b/examples/computer_vision/deformabledetr_coco_pytorch/finetune_adaptive.yaml
@@ -2,8 +2,8 @@ name: deformabledetr_coco_adaptive
 hyperparameters:
     lr: 
         type: double
-        minval: 1e-5
-        maxval: 1e-4
+        minval: 1.0e-5
+        maxval: 1.0e-4
     lr_backbone_names:
         - backbone.0
     lr_backbone: 0
@@ -12,7 +12,7 @@ hyperparameters:
         - sampling_offsets
     lr_linear_proj_mult: 0.1
     global_batch_size: 4
-    weight_decay: 1e-4
+    weight_decay: 1.0e-4
     lr_drop: 4
     clip_max_norm: 
         type: double

--- a/examples/computer_vision/detr_coco_pytorch/const_fake.yaml
+++ b/examples/computer_vision/detr_coco_pytorch/const_fake.yaml
@@ -1,9 +1,9 @@
 name: detr_coco_fake_data
 hyperparameters:
-    lr: 1e-4
-    lr_backbone: 1e-5
+    lr: 1.0e-4
+    lr_backbone: 1.0e-5
     global_batch_size: 2
-    weight_decay: 1e-4
+    weight_decay: 1.0e-4
     lr_drop: 100
     clip_max_norm: 0.1
 

--- a/examples/computer_vision/detr_coco_pytorch/distributed.yaml
+++ b/examples/computer_vision/detr_coco_pytorch/distributed.yaml
@@ -2,10 +2,10 @@ name: detr_coco_distributed
 hyperparameters:
     # These settings match that for the 150 epoch run provided in the original repo:
     #   https://github.com/facebookresearch/detr
-    lr: 1e-4
-    lr_backbone: 1e-5
+    lr: 1.0e-4
+    lr_backbone: 1.0e-5
     global_batch_size: 16
-    weight_decay: 1e-4
+    weight_decay: 1.0e-4
     lr_drop: 100
     clip_max_norm: 0.1
 

--- a/examples/computer_vision/detr_coco_pytorch/finetune.yaml
+++ b/examples/computer_vision/detr_coco_pytorch/finetune.yaml
@@ -1,9 +1,9 @@
 name: detr_coco_finetune
 hyperparameters:
-    lr: 1e-4
+    lr: 1.0e-4
     lr_backbone: 0
     global_batch_size: 4
-    weight_decay: 1e-4
+    weight_decay: 1.0e-4
     lr_drop: 4
     clip_max_norm: 0.1
 

--- a/examples/computer_vision/detr_coco_pytorch/finetune_adaptive.yaml
+++ b/examples/computer_vision/detr_coco_pytorch/finetune_adaptive.yaml
@@ -3,11 +3,11 @@ hyperparameters:
     # We will tune learning rate and gradient clipping.
     lr: 
         type: double
-        minval: 1e-5
-        maxval: 1e-4
+        minval: 1.0e-5
+        maxval: 1.0e-4
     lr_backbone: 0
     global_batch_size: 4
-    weight_decay: 1e-4
+    weight_decay: 1.0e-4
     lr_drop: 4
     clip_max_norm: 
         type: double

--- a/examples/computer_vision/efficientdet_pytorch/adaptive.yaml
+++ b/examples/computer_vision/efficientdet_pytorch/adaptive.yaml
@@ -55,7 +55,7 @@ hyperparameters:
   lr_cycle_mul: 1.0
   lr_cycle_limit: 1
   warmup_lr: 0.0001
-  min_lr: 1e-5
+  min_lr: 1.0e-5
   start_epoch: None
   decay_epochs: 30
   warmup_epochs: 5

--- a/examples/computer_vision/efficientdet_pytorch/const.yaml
+++ b/examples/computer_vision/efficientdet_pytorch/const.yaml
@@ -26,7 +26,7 @@ hyperparameters:
   opt: fusedmomentum
   opt_eps: 0.001
   momentum: 0.9
-  weight_decay: 4e-05
+  weight_decay: 4.0e-05
   sched: cosine
   lr: .03
   lr_noise: 0.4 0.9
@@ -35,7 +35,7 @@ hyperparameters:
   lr_cycle_mul: 1.0
   lr_cycle_limit: 1
   warmup_lr: 0.0001
-  min_lr: 1e-5
+  min_lr: 1.0e-5
   start_epoch: None
   decay_epochs: 30
   warmup_epochs: 5

--- a/examples/computer_vision/efficientdet_pytorch/const_fake.yaml
+++ b/examples/computer_vision/efficientdet_pytorch/const_fake.yaml
@@ -26,7 +26,7 @@ hyperparameters:
   opt: fusedmomentum
   opt_eps: 0.001
   momentum: 0.9
-  weight_decay: 4e-05
+  weight_decay: 4.0e-05
   sched: cosine
   lr: .03
   lr_noise: 0.4 0.9
@@ -35,7 +35,7 @@ hyperparameters:
   lr_cycle_mul: 1.0
   lr_cycle_limit: 1
   warmup_lr: 0.0001
-  min_lr: 1e-5
+  min_lr: 1.0e-5
   start_epoch: None
   decay_epochs: 30
   warmup_epochs: 5

--- a/examples/computer_vision/efficientdet_pytorch/distributed.yaml
+++ b/examples/computer_vision/efficientdet_pytorch/distributed.yaml
@@ -28,7 +28,7 @@ hyperparameters:
   opt: fusedmomentum
   opt_eps: 0.001
   momentum: 0.9
-  weight_decay: 4e-05
+  weight_decay: 4.0e-05
   sched: cosine
   lr: 0.06
   lr_noise: 0.4 0.9
@@ -37,7 +37,7 @@ hyperparameters:
   lr_cycle_mul: 1.0
   lr_cycle_limit: 1
   warmup_lr: 0.0001
-  min_lr: 1e-5
+  min_lr: 1.0e-5
   start_epoch: None
   decay_epochs: 30
   warmup_epochs: 5

--- a/examples/computer_vision/iris_tf_keras/adaptive.yaml
+++ b/examples/computer_vision/iris_tf_keras/adaptive.yaml
@@ -8,7 +8,7 @@ hyperparameters:
     minval: -5.0
     maxval: 1.0
     base: 10.0
-  learning_rate_decay: 1e-6
+  learning_rate_decay: 1.0e-6
   layer1_dense_size:
     type: int
     minval: 4

--- a/examples/computer_vision/iris_tf_keras/const.yaml
+++ b/examples/computer_vision/iris_tf_keras/const.yaml
@@ -3,8 +3,8 @@ data:
   train_url: http://download.tensorflow.org/data/iris_training.csv
   test_url: http://download.tensorflow.org/data/iris_test.csv
 hyperparameters:
-  learning_rate: 1e-4
-  learning_rate_decay: 1e-6
+  learning_rate: 1.0e-4
+  learning_rate_decay: 1.0e-6
   layer1_dense_size: 16
   global_batch_size: 30
 searcher:

--- a/examples/computer_vision/iris_tf_keras/distributed.yaml
+++ b/examples/computer_vision/iris_tf_keras/distributed.yaml
@@ -3,8 +3,8 @@ data:
   train_url: http://download.tensorflow.org/data/iris_training.csv
   test_url: http://download.tensorflow.org/data/iris_test.csv
 hyperparameters:
-  learning_rate: 1e-4
-  learning_rate_decay: 1e-6
+  learning_rate: 1.0e-4
+  learning_rate_decay: 1.0e-6
   layer1_dense_size: 16
   global_batch_size: 30
 resources:

--- a/examples/computer_vision/mnist_estimator/const.yaml
+++ b/examples/computer_vision/mnist_estimator/const.yaml
@@ -1,6 +1,6 @@
 name: mnist_estimator_const
 hyperparameters:
-  learning_rate: 1e-3
+  learning_rate: 1.0e-3
   global_batch_size: 64
   hidden_layer_1: 2500
   hidden_layer_2: 1000

--- a/examples/computer_vision/mnist_estimator/distributed.yaml
+++ b/examples/computer_vision/mnist_estimator/distributed.yaml
@@ -1,6 +1,6 @@
 name: mnist_estimator_distributed
 hyperparameters:
-  learning_rate: 1e-3
+  learning_rate: 1.0e-3
   global_batch_size: 1024 # per GPU batch size of 64
   hidden_layer_1: 2500
   hidden_layer_2: 1000

--- a/examples/computer_vision/mnist_tf_layers/const.yaml
+++ b/examples/computer_vision/mnist_tf_layers/const.yaml
@@ -1,6 +1,6 @@
 name: mnist_tf_core_to_estimator
 hyperparameters:
-  learning_rate: 1e-3
+  learning_rate: 1.0e-3
   global_batch_size: 64
   n_filters_1: 10
   n_filters_2: 40

--- a/examples/computer_vision/unets_tf_keras/const.yaml
+++ b/examples/computer_vision/unets_tf_keras/const.yaml
@@ -4,8 +4,8 @@ data:
   data_file: mobilenet_v2_weights_tf_dim_ordering_tf_kernels_1.0_128_no_top.h5
 
 hyperparameters:
-  learning_rate: 1e-4
-  learning_rate_decay: 1e-6
+  learning_rate: 1.0e-4
+  learning_rate_decay: 1.0e-6
   layer1_dense_size: 16
   global_batch_size: 64
   OUTPUT_CHANNELS: 3

--- a/examples/computer_vision/unets_tf_keras/distributed.yaml
+++ b/examples/computer_vision/unets_tf_keras/distributed.yaml
@@ -4,8 +4,8 @@ data:
   data_file: mobilenet_v2_weights_tf_dim_ordering_tf_kernels_1.0_128_no_top.h5
 
 hyperparameters:
-  learning_rate: 1e-4
-  learning_rate_decay: 1e-6
+  learning_rate: 1.0e-4
+  learning_rate_decay: 1.0e-6
   layer1_dense_size: 16
   global_batch_size: 512 # per slot batch size = 64 
   OUTPUT_CHANNELS: 3

--- a/examples/features/data_layer_mnist_estimator/const.yaml
+++ b/examples/features/data_layer_mnist_estimator/const.yaml
@@ -2,7 +2,7 @@ name: data_layer_mnist_estimator_const
 data:
   skip_checkpointing_input: true
 hyperparameters:
-  learning_rate: 1e-3
+  learning_rate: 1.0e-3
   global_batch_size: 16
   hidden_layer_1: 2500
   hidden_layer_2: 1000

--- a/examples/features/data_layer_mnist_estimator/distributed.yaml
+++ b/examples/features/data_layer_mnist_estimator/distributed.yaml
@@ -2,7 +2,7 @@ name: data_layer_mnist_estimator_const
 data:
   skip_checkpointing_input: true
 hyperparameters:
-  learning_rate: 1e-3
+  learning_rate: 1.0e-3
   global_batch_size: 128
   hidden_layer_1: 2500
   hidden_layer_2: 1000

--- a/examples/features/data_layer_mnist_tf_keras/const.yaml
+++ b/examples/features/data_layer_mnist_tf_keras/const.yaml
@@ -2,8 +2,8 @@ name: data_layer_mnist_tf_keras_const
 data:
   url: https://s3-us-west-2.amazonaws.com/determined-ai-datasets/cifar10/cifar-10-python.tar.gz
 hyperparameters:
-  learning_rate: 1e-4
-  learning_rate_decay: 1e-6
+  learning_rate: 1.0e-4
+  learning_rate_decay: 1.0e-6
   layer1_dropout: 0.25
   layer2_dropout: 0.25
   layer3_dropout: 0.5

--- a/examples/hp_search_benchmarks/darts_cifar10_pytorch/adaptive.yaml
+++ b/examples/hp_search_benchmarks/darts_cifar10_pytorch/adaptive.yaml
@@ -9,7 +9,7 @@ min_validation_period:
 hyperparameters:
   learning_rate: 0.025
   momentum: 0.9
-  weight_decay: 3e-4
+  weight_decay: 3.0e-4
   train_epochs: 300
   global_batch_size: 96
   init_channels: 36

--- a/examples/hp_search_benchmarks/darts_cifar10_pytorch/constrained_adaptive.yaml
+++ b/examples/hp_search_benchmarks/darts_cifar10_pytorch/constrained_adaptive.yaml
@@ -10,7 +10,7 @@ hyperparameters:
   use_constraints: true
   learning_rate: 0.025
   momentum: 0.9
-  weight_decay: 3e-4
+  weight_decay: 3.0e-4
   train_epochs: 300
   global_batch_size: 96
   init_channels: 36

--- a/examples/hp_search_benchmarks/darts_cifar10_pytorch/constrained_random.yaml
+++ b/examples/hp_search_benchmarks/darts_cifar10_pytorch/constrained_random.yaml
@@ -10,7 +10,7 @@ hyperparameters:
   use_constraints: true
   learning_rate: 0.025
   momentum: 0.9
-  weight_decay: 3e-4
+  weight_decay: 3.0e-4
   train_epochs: 300
   global_batch_size: 96
   init_channels: 36

--- a/examples/hp_search_benchmarks/darts_penntreebank_pytorch/adaptive.yaml
+++ b/examples/hp_search_benchmarks/darts_penntreebank_pytorch/adaptive.yaml
@@ -21,8 +21,8 @@ hyperparameters:
   dropoute: 0.1
   nonmono: 5
   alpha: 0
-  beta: 1e-3
-  weight_decay: 8e-7
+  beta: 1.0e-3
+  weight_decay: 8.0e-7
   max_seq_length_delta: 20
   clip_gradients_l2_norm: 0.25
 

--- a/examples/hp_search_benchmarks/darts_penntreebank_pytorch/const.yaml
+++ b/examples/hp_search_benchmarks/darts_penntreebank_pytorch/const.yaml
@@ -26,8 +26,8 @@ hyperparameters:
   dropoute: 0.1
   nonmono: 5
   alpha: 0
-  beta: 1e-3
-  weight_decay: 8e-7
+  beta: 1.0e-3
+  weight_decay: 8.0e-7
   max_seq_length_delta: 20
   clip_gradients_l2_norm: 0.25
 

--- a/examples/meta_learning/protonet_omniglot_pytorch/20way1shot.yaml
+++ b/examples/meta_learning/protonet_omniglot_pytorch/20way1shot.yaml
@@ -8,7 +8,7 @@ data:
     val_workers: 4
 
 hyperparameters:
-  learning_rate: 1e-3
+  learning_rate: 1.0e-3
   weight_decay: 0
   reduce_every: 200
   lr_gamma: 0.5

--- a/examples/meta_learning/protonet_omniglot_pytorch/20way5shot.yaml
+++ b/examples/meta_learning/protonet_omniglot_pytorch/20way5shot.yaml
@@ -8,7 +8,7 @@ data:
     val_workers: 4
 
 hyperparameters:
-  learning_rate: 1e-3
+  learning_rate: 1.0e-3
   weight_decay: 0
   reduce_every: 200
   lr_gamma: 0.5

--- a/examples/nas/gaea_pytorch/eval/const.yaml
+++ b/examples/nas/gaea_pytorch/eval/const.yaml
@@ -46,7 +46,7 @@ hyperparameters:
   clip_gradients_l2_norm: 5
   learning_rate: 0.5
   momentum: 0.9
-  weight_decay: 3e-5
+  weight_decay: 3.0e-5
   # Choices include linear, efficientnet, and cosine
   lr_scheduler: linear
   lr_epochs: 300

--- a/examples/nas/gaea_pytorch/eval/distributed.yaml
+++ b/examples/nas/gaea_pytorch/eval/distributed.yaml
@@ -43,7 +43,7 @@ hyperparameters:
   num_classes: 1000
   learning_rate: 0.5
   momentum: 0.9
-  weight_decay: 3e-5
+  weight_decay: 3.0e-5
   drop_path_prob: 0.0
   drop_prob: 0.0
   label_smoothing_rate: 0.1

--- a/examples/nas/gaea_pytorch/eval/distributed_no_data_download.yaml
+++ b/examples/nas/gaea_pytorch/eval/distributed_no_data_download.yaml
@@ -46,7 +46,7 @@ hyperparameters:
   clip_gradients_l2_norm: 5
   learning_rate: 0.5
   momentum: 0.9
-  weight_decay: 3e-5
+  weight_decay: 3.0e-5
   # Choices include linear, efficientnet, and cosine
   lr_scheduler: linear
   lr_epochs: 300

--- a/examples/nas/gaea_pytorch/search/const.yaml
+++ b/examples/nas/gaea_pytorch/search/const.yaml
@@ -18,7 +18,7 @@ hyperparameters:
     momentum: 0.9
     min_learning_rate: 0
     scheduler_epochs: 50
-    weight_decay: 3e-4
+    weight_decay: 3.0e-4
     arch_learning_rate: 0.1
     init_channels: 16
     layers: 8

--- a/examples/nlp/albert_squad_pytorch/const.yaml
+++ b/examples/nlp/albert_squad_pytorch/const.yaml
@@ -2,9 +2,9 @@
 name: ALBert_SQuAD_PyTorch_1gpu
 hyperparameters:
     global_batch_size: 2
-    learning_rate: 5e-5
+    learning_rate: 5.0e-5
     model_type: 'albert'
-    adam_epsilon: 1e-8
+    adam_epsilon: 1.0e-8
     weight_decay: 0
     num_warmup_steps: 13220  # 10% of total training
     max_seq_length: 384

--- a/examples/nlp/albert_squad_pytorch/distributed_64gpu.yaml
+++ b/examples/nlp/albert_squad_pytorch/distributed_64gpu.yaml
@@ -5,7 +5,7 @@ hyperparameters:
     learning_rate: 0.0002
     model_type: 'albert'
     do_lower_case: true
-    adam_epsilon: 1e-8
+    adam_epsilon: 1.0e-8
     weight_decay: 0
     num_warmup_steps: 206
     max_seq_length: 384

--- a/examples/nlp/albert_squad_pytorch/distributed_8gpu.yaml
+++ b/examples/nlp/albert_squad_pytorch/distributed_8gpu.yaml
@@ -2,10 +2,10 @@
 name: ALBert_SQuAD_PyTorch_8gpu
 hyperparameters:
     global_batch_size: 16
-    learning_rate: 5e-5
+    learning_rate: 5.0e-5
     model_type: 'albert'
     do_lower_case: true
-    adam_epsilon: 1e-8
+    adam_epsilon: 1.0e-8
     weight_decay: 0
     num_warmup_steps: 1620
     max_seq_length: 384

--- a/examples/nlp/bert_glue_pytorch/const.yaml
+++ b/examples/nlp/bert_glue_pytorch/const.yaml
@@ -1,10 +1,10 @@
 name: bert_glue_pytorch_const
 hyperparameters:
   global_batch_size: 24
-  learning_rate: 2e-5
+  learning_rate: 2.0e-5
   lr_scheduler_epoch_freq: 1
   model_type: 'bert'
-  adam_epsilon: 1e-8
+  adam_epsilon: 1.0e-8
   weight_decay: 0
   num_warmup_steps: 0
   num_training_steps: 459

--- a/examples/nlp/bert_glue_pytorch/distributed.yaml
+++ b/examples/nlp/bert_glue_pytorch/distributed.yaml
@@ -1,10 +1,10 @@
 name: bert_glue_pytorch_distributed 
 hyperparameters:
   global_batch_size: 192 # per gpu batch size of 24
-  learning_rate: 2e-5
+  learning_rate: 2.0e-5
   lr_scheduler_epoch_freq: 1
   model_type: 'bert'
-  adam_epsilon: 1e-8
+  adam_epsilon: 1.0e-8
   weight_decay: 0
   num_warmup_steps: 0
   num_training_steps: 459

--- a/examples/nlp/bert_squad_pytorch/const.yaml
+++ b/examples/nlp/bert_squad_pytorch/const.yaml
@@ -2,10 +2,10 @@
 name: Bert_SQuAD_PyTorch
 hyperparameters:
     global_batch_size: 12
-    learning_rate: 3e-5
+    learning_rate: 3.0e-5
     lr_scheduler_epoch_freq: 1
     model_type: 'bert'
-    adam_epsilon: 1e-8
+    adam_epsilon: 1.0e-8
     weight_decay: 0
     num_warmup_steps: 0
     max_seq_length: 384

--- a/examples/nlp/bert_squad_pytorch/distributed.yaml
+++ b/examples/nlp/bert_squad_pytorch/distributed.yaml
@@ -2,10 +2,10 @@
 name: Bert_SQuAD_PyTorch_distributed
 hyperparameters:
     global_batch_size: 96  # per slot batch size = 12
-    learning_rate: 3e-5
+    learning_rate: 3.0e-5
     lr_scheduler_epoch_freq: 1
     model_type: 'bert'
-    adam_epsilon: 1e-8
+    adam_epsilon: 1.0e-8
     weight_decay: 0
     num_warmup_steps: 0
     max_seq_length: 384

--- a/model_hub/examples/huggingface/language-modeling/clm_config.yaml
+++ b/model_hub/examples/huggingface/language-modeling/clm_config.yaml
@@ -7,8 +7,8 @@ hyperparameters:
   cache_dir: null
   # Training Args
   global_batch_size: 8
-  learning_rate: 5e-5
-  adam_epsilon: 1e-8
+  learning_rate: 5.0e-5
+  adam_epsilon: 1.0e-8
   weight_decay: 0
   lr_scheduler_type: linear
   num_warmup_steps: 0

--- a/model_hub/examples/huggingface/language-modeling/mlm_config.yaml
+++ b/model_hub/examples/huggingface/language-modeling/mlm_config.yaml
@@ -7,8 +7,8 @@ hyperparameters:
   cache_dir: null
   # Training Args
   global_batch_size: 8
-  learning_rate: 5e-5
-  adam_epsilon: 1e-8
+  learning_rate: 5.0e-5
+  adam_epsilon: 1.0e-8
   weight_decay: 0
   lr_scheduler_type: linear
   num_warmup_steps: 0

--- a/model_hub/examples/huggingface/language-modeling/plm_config.yaml
+++ b/model_hub/examples/huggingface/language-modeling/plm_config.yaml
@@ -7,8 +7,8 @@ hyperparameters:
   cache_dir: null
   # Training Args
   global_batch_size: 2
-  learning_rate: 2e-5
-  adam_epsilon: 1e-8
+  learning_rate: 2.0e-5
+  adam_epsilon: 1.0e-8
   weight_decay: 0
   lr_scheduler_type: linear
   num_warmup_steps: 0

--- a/model_hub/examples/huggingface/multiple-choice/swag_config.yaml
+++ b/model_hub/examples/huggingface/multiple-choice/swag_config.yaml
@@ -7,8 +7,8 @@ hyperparameters:
   cache_dir: null
   # Training Args
   global_batch_size: 64
-  learning_rate: 5e-5
-  adam_epsilon: 1e-8
+  learning_rate: 5.0e-5
+  adam_epsilon: 1.0e-8
   weight_decay: 0
   lr_scheduler_type: linear
   num_warmup_steps: 0

--- a/model_hub/examples/huggingface/question-answering/squad.yaml
+++ b/model_hub/examples/huggingface/question-answering/squad.yaml
@@ -7,8 +7,8 @@ hyperparameters:
   cache_dir: null
   # Training Args
   global_batch_size: 12
-  learning_rate: 3e-5
-  adam_epsilon: 1e-8
+  learning_rate: 3.0e-5
+  adam_epsilon: 1.0e-8
   weight_decay: 0
   lr_scheduler_type: linear
   num_warmup_steps: 0

--- a/model_hub/examples/huggingface/question-answering/squad_beam_search.yaml
+++ b/model_hub/examples/huggingface/question-answering/squad_beam_search.yaml
@@ -7,8 +7,8 @@ hyperparameters:
   cache_dir: null
   # Training Args
   global_batch_size: 4
-  learning_rate: 3e-5
-  adam_epsilon: 1e-8
+  learning_rate: 3.0e-5
+  adam_epsilon: 1.0e-8
   weight_decay: 0
   lr_scheduler_type: linear
   num_warmup_steps: 0

--- a/model_hub/examples/huggingface/question-answering/squad_v2.yaml
+++ b/model_hub/examples/huggingface/question-answering/squad_v2.yaml
@@ -7,8 +7,8 @@ hyperparameters:
   cache_dir: null
   # Training Args
   global_batch_size: 12
-  learning_rate: 3e-5
-  adam_epsilon: 1e-8
+  learning_rate: 3.0e-5
+  adam_epsilon: 1.0e-8
   weight_decay: 0
   lr_scheduler_type: linear
   num_warmup_steps: 0

--- a/model_hub/examples/huggingface/question-answering/squad_v2_beam_search.yaml
+++ b/model_hub/examples/huggingface/question-answering/squad_v2_beam_search.yaml
@@ -7,8 +7,8 @@ hyperparameters:
   cache_dir: null
   # Training Args
   global_batch_size: 4
-  learning_rate: 3e-5
-  adam_epsilon: 1e-8
+  learning_rate: 3.0e-5
+  adam_epsilon: 1.0e-8
   weight_decay: 0
   lr_scheduler_type: linear
   num_warmup_steps: 0

--- a/model_hub/examples/huggingface/text-classification/glue_config.yaml
+++ b/model_hub/examples/huggingface/text-classification/glue_config.yaml
@@ -18,8 +18,8 @@ hyperparameters:
   use_apex_amp: true
   # Training Args
   global_batch_size: 32
-  learning_rate: 3e-5
-  adam_epsilon: 1e-8
+  learning_rate: 3.0e-5
+  adam_epsilon: 1.0e-8
   weight_decay: 0
   lr_scheduler_type: linear
   num_warmup_steps: 0

--- a/model_hub/examples/huggingface/text-classification/xnli_config.yaml
+++ b/model_hub/examples/huggingface/text-classification/xnli_config.yaml
@@ -8,8 +8,8 @@ hyperparameters:
   do_lower_case: false
   # Training Args
   global_batch_size: 32
-  learning_rate: 5e-5
-  adam_epsilon: 1e-8
+  learning_rate: 5.0e-5
+  adam_epsilon: 1.0e-8
   weight_decay: 0
   lr_scheduler_type: linear
   num_warmup_steps: 0

--- a/model_hub/examples/huggingface/token-classification/ner_config.yaml
+++ b/model_hub/examples/huggingface/token-classification/ner_config.yaml
@@ -7,8 +7,8 @@ hyperparameters:
   use_apex_amp: false
   # Training Args
   global_batch_size: 8
-  learning_rate: 5e-5
-  adam_epsilon: 1e-8
+  learning_rate: 5.0e-5
+  adam_epsilon: 1.0e-8
   weight_decay: 0
   lr_scheduler_type: linear
   num_warmup_steps: 0


### PR DESCRIPTION
## Description

Example yamls use scientific notation like `1e-5` which yamls parses as `str` instead of `float`. Determined is smart enough to convert this to float when submitting experiments to the server but not so when running in local mode. This leads to numerous errors when trying to operate on strings as if they were floats.


## Test Plan
Tested running experiments with and without this change locally and on the server/cluster.


## Commentary (optional)
Another option would have been to upgrade the `_make_local_execution_exp_config` method to be smarter about parsing configs for local execution. The change here is simpler and conforms better to intended yaml syntax.

## Checklist

- [x ] User-facing API changes need the "User-facing API Change" label. - not necessary
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [x ] Licenses should be included for new code which was copied and/or modified from any external code. - not necessary


