### PR TITLE
fix: remove proteins_pytorch_geometric from nightlies.

### DIFF
--- a/e2e_tests/tests/nightly/test_capability.py
+++ b/e2e_tests/tests/nightly/test_capability.py
@@ -82,13 +82,3 @@ def test_word_language_lstm_const() -> None:
     config["hyperparameters"]["tied"] = False
 
     exp.run_basic_test_with_temp_config(config, conf.nlp_examples_path("word_language_model"), 1)
-
-
-@pytest.mark.nightly  # type: ignore
-def test_protein_pytorch_geometric() -> None:
-    config = conf.load_config(conf.graphs_examples_path("proteins_pytorch_geometric/const.yaml"))
-    config = conf.set_max_length(config, {"epochs": 50})
-
-    exp.run_basic_test_with_temp_config(
-        config, conf.graphs_examples_path("proteins_pytorch_geometric"), 1
-    )

--- a/examples/graphs/proteins_pytorch_geometric/README.md
+++ b/examples/graphs/proteins_pytorch_geometric/README.md
@@ -44,3 +44,5 @@ configuration file in place of `const.yaml`.
 ## Results
 The trial will achieve ~75% accuracy after training for 50 epochs, and will approach ~80% accuracy
 by epoch 300 in a few minutes of runtime on NVIDIA K80.
+
+NOTE: this example may have convergence issues with the default hyperparameters.

--- a/examples/graphs/proteins_pytorch_geometric/const.yaml
+++ b/examples/graphs/proteins_pytorch_geometric/const.yaml
@@ -1,6 +1,6 @@
 name: proteins_pytorch_geometric
 hyperparameters:
-  global_batch_size: 64
+  global_batch_size: 20
   dataset: PROTEINS
   lr: 5.e-4
   weight_decay: 1.e-4


### PR DESCRIPTION
## Description

Seems like `proteins_pytorch_geometric` example sometimes has convergence issues which breaks nightlies. Remove it for the nightlies for now, pending an investigation. Also set batch_size to 20 to align with the original repo example.

## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
