### PR TITLE
docs: warn users not to use cpu training with a custom scheduler

### DIFF
--- a/docs/how-to/installation/kubernetes.txt
+++ b/docs/how-to/installation/kubernetes.txt
@@ -151,8 +151,7 @@ want to use finer-grained ``slotResourceRequests.cpu: 15``, set
 ``maxSlotsPerPod: 2``.
 
 When using CPU-only training, avoid setting the ``defaultScheduler``
-field. CPU training has not been validated with these scheduler options
-and may cause instability the deployment.
+field. CPU training is not supported for these options yet.
 
 Checkpoint Storage
 ==================
@@ -322,9 +321,9 @@ set ``defaultScheduler`` to ``preemption``.
 
    defaultScheduler: preemption
 
-If you are using cpu training with Kubernetes, avoid setting the
-``defaultScheduler`` field. Cpu training has not yet been validated for
-these scheduling options.
+If you are using CPU-only training with Kubernetes, avoid setting the
+``defaultScheduler`` field. CPU training is not supported for these
+scheduling options yet.
 
 ***********************
  Installing Determined

--- a/docs/how-to/installation/kubernetes.txt
+++ b/docs/how-to/installation/kubernetes.txt
@@ -150,6 +150,10 @@ reasonable to set ``maxSlotsPerPod: 1`` and ``slotResourceRequests.cpu:
 want to use finer-grained ``slotResourceRequests.cpu: 15``, set
 ``maxSlotsPerPod: 2``.
 
+When using CPU-only training, avoid setting the ``defaultScheduler``
+field. CPU training has not been validated with these scheduler options
+and may cause instability the deployment.
+
 Checkpoint Storage
 ==================
 
@@ -317,6 +321,10 @@ set ``defaultScheduler`` to ``preemption``.
 .. code:: yaml
 
    defaultScheduler: preemption
+
+If you are using cpu training with Kubernetes, avoid setting the
+``defaultScheduler`` field. Cpu training has not yet been validated for
+these scheduling options.
 
 ***********************
  Installing Determined

--- a/helm/charts/determined/values.yaml
+++ b/helm/charts/determined/values.yaml
@@ -90,6 +90,7 @@ checkpointStorage:
 maxSlotsPerPod:
 
 ## For CPU-only clusters, use `slotType: cpu`, and make sure to set `slotResourceRequest` below.
+## Do NOT specify a defaultScheduler if using CPU-only clusters.
 # slotType: cpu
 # slotResourceRequests:
   ## Number of cpu units requested for compute slots. Note: since kubernetes may schedule some


### PR DESCRIPTION
## Description

<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234