### PR TITLE
fix: immediately fetch single trial data when able to [DET-5758]

### DIFF
--- a/docs/release-notes/2708-reduce-single-trial-exp-page-loading.txt
+++ b/docs/release-notes/2708-reduce-single-trial-exp-page-loading.txt
@@ -1,0 +1,6 @@
+:orphan:
+
+**BUG FIXES**
+
+-  WebUI: Avoid waiting for an extra polling cycle to load trial data
+   when loading single trial experiments.


### PR DESCRIPTION
## Description

PROBLEM:
The single-trial component is initially created with an `undefined` trial Id until the first trial id is fetched by experiment page. Upon sending the newly fetched trial id to `ExperimentSingleTrialTabs` it doesn't immediately fetch trial detail as it's tied to a polling mechanism, hence waiting for one polling cycle to pass through before making the fetch.

SOLUTION:
Upon detecting a change of trial id in `ExperimentSingleTrialTabs`, immediately make the call to fetch trial detail.

<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234