### PR TITLE
docs: fix some monospace treatment.

### DIFF
--- a/docs/reference/api/lightning_adapter.txt
+++ b/docs/reference/api/lightning_adapter.txt
@@ -95,7 +95,7 @@ not supported. Read about those here:
 In addition, we also patched some ``LightningModule`` methods to make
 porting your code easier:
 
--  `log` and `log_dict` are patched to always log ship their values to
+-  ``log`` and ``log_dict`` are patched to always ship their values to
    Tensorboard. In the current version only the first two arguments in
    ``log``: ``key`` and ``value``, and the first argument in
    ``log_dict`` are supported.

--- a/docs/topic-guides/hp-constraints-det.txt
+++ b/docs/topic-guides/hp-constraints-det.txt
@@ -13,8 +13,8 @@ fit a particular deployment environment.
 
 Using Determined's HP Search Constraints requires no changes to the
 configuration files. Rather, users can simply raise a
-`determined.InvalidHP` exception in their model code when the trial is
-first created in the `__init__` or at any subsequent point during
+``determined.InvalidHP`` exception in their model code when the trial is
+first created in the ``__init__`` or at any subsequent point during
 training. This user-raised exception is then handled by Determined's
 system internally – resulting in the graceful stop of the current trial
 being trained, logging the InvalidHP in the trial logs, and propagating
@@ -23,7 +23,7 @@ that information to the search method.
 .. warning::
 
    It is important to note that each search method has different
-   behavior when a `determined.InvalidHP` is raised by the user in
+   behavior when a ``determined.InvalidHP`` is raised by the user in
    accordance with the internal dynamics of each searcher, as detailed
    below.
 
@@ -36,9 +36,10 @@ it follows that the timing/placement of user-raised InvalidHP exceptions
 would be different.
 
 In the case of PyTorch, this exception can be raised in either the trial
-`__init__`, `train_batch`, or `evaluate_batch`. In the case of either TF
-Keras and TF Estimator, it is valid for the user to raise this exception
-in either the `__init__` or in an `on_checkpoint_end` callback.
+``__init__``, ``train_batch``, or ``evaluate_batch``. In the case of
+either TF Keras and TF Estimator, it is valid for the user to raise this
+exception in either the ``__init__`` or in an ``on_checkpoint_end``
+callback.
 
 See this
 https://github.com/determined-ai/determined/tree/master/examples/features/hp_constraints_mnist_pytorch

--- a/docs/topic-guides/users.txt
+++ b/docs/topic-guides/users.txt
@@ -215,7 +215,7 @@ specified user and group.
    agent, tasks created by that user will run as the root user on the
    agent. This behavior may change in the future.
 
-   If the task does not use `bind_mount` option, the effect of running
+   If the task does not use ``bind_mount`` option, the effect of running
    as root will be limited to the task container and not intrude on the
    agent itself.
 


### PR DESCRIPTION
## Description

A community user has recently highlighted a chunk of docs where an italic styling was used instead of monospace: https://determined-community.slack.com/archives/CV3MVAQJU/p1625534932056100
This change fixes it, along with a couple of other occurrences I've found with my rudimentary regexp.

## Test Plan
N/A
<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
