### PR TITLE
fix: cpu only preemption [DET-5763]

### DIFF
--- a/docs/how-to/installation/kubernetes.txt
+++ b/docs/how-to/installation/kubernetes.txt
@@ -150,9 +150,6 @@ reasonable to set ``maxSlotsPerPod: 1`` and ``slotResourceRequests.cpu:
 want to use finer-grained ``slotResourceRequests.cpu: 15``, set
 ``maxSlotsPerPod: 2``.
 
-When using CPU-only training, avoid setting the ``defaultScheduler``
-field. CPU training is not supported for these options yet.
-
 Checkpoint Storage
 ==================
 
@@ -320,10 +317,6 @@ set ``defaultScheduler`` to ``preemption``.
 .. code:: yaml
 
    defaultScheduler: preemption
-
-If you are using CPU-only training with Kubernetes, avoid setting the
-``defaultScheduler`` field. CPU training is not supported for these
-scheduling options yet.
 
 ***********************
  Installing Determined

--- a/helm/charts/determined/templates/db-deployment.yaml
+++ b/helm/charts/determined/templates/db-deployment.yaml
@@ -19,6 +19,7 @@ spec:
         app: determined-db-{{ .Release.Name }}
         determined-system: db
     spec:
+      priorityClassName: determined-system-priority
       containers:
       - name: determined-db-{{ .Release.Name }}
         image: postgres:10.14

--- a/helm/charts/determined/templates/master-deployment.yaml
+++ b/helm/charts/determined/templates/master-deployment.yaml
@@ -21,6 +21,7 @@ spec:
         # changes the master-config.yaml.
         checksum/config: {{ include (print $.Template.BasePath "/master-config.yaml") . | sha256sum }}
     spec:
+      priorityClassName: determined-system-priority
       serviceAccount: determined-master-{{ .Release.Name }}
       containers:
       - name: determined-master-{{ .Release.Name }}

--- a/helm/charts/determined/templates/priority-classes.yaml
+++ b/helm/charts/determined/templates/priority-classes.yaml
@@ -2,7 +2,7 @@ apiVersion: scheduling.k8s.io/v1
 kind: PriorityClass
 metadata:
   name: determined-system-priority
-value: 1000000000
+value: 1000000
 preemptionPolicy: Never
 globalDefault: false
 description: "This priority class should be used for Determined system pods only."

--- a/helm/charts/determined/templates/priority-classes.yaml
+++ b/helm/charts/determined/templates/priority-classes.yaml
@@ -1,15 +1,15 @@
-{{- if .Values.defaultScheduler}}
-{{- $schedulerType := .Values.defaultScheduler | trim}}
-{{- if or (eq $schedulerType "coscheduler") (eq $schedulerType "preemption")}}
 apiVersion: scheduling.k8s.io/v1
 kind: PriorityClass
 metadata:
   name: determined-system-priority
-value: 1000000
+value: 1000000000
 preemptionPolicy: Never
 globalDefault: false
 description: "This priority class should be used for Determined system pods only."
 ---
+{{- if .Values.defaultScheduler}}
+{{- $schedulerType := .Values.defaultScheduler | trim}}
+{{- if or (eq $schedulerType "coscheduler") (eq $schedulerType "preemption")}}
 apiVersion: scheduling.k8s.io/v1
 kind: PriorityClass
 metadata:

--- a/helm/charts/determined/values.yaml
+++ b/helm/charts/determined/values.yaml
@@ -90,7 +90,6 @@ checkpointStorage:
 maxSlotsPerPod:
 
 ## For CPU-only clusters, use `slotType: cpu`, and make sure to set `slotResourceRequest` below.
-## Do NOT specify a defaultScheduler if using CPU-only clusters.
 # slotType: cpu
 # slotResourceRequests:
   ## Number of cpu units requested for compute slots. Note: since kubernetes may schedule some

--- a/master/internal/kubernetes/spec.go
+++ b/master/internal/kubernetes/spec.go
@@ -215,7 +215,7 @@ func (p *pod) configureCoscheduler(newPod *k8sV1.Pod, scheduler string) {
 	}
 
 	resources := p.taskSpec.ResourcesConfig
-	var minAvailable int
+	minAvailable := 0
 
 	if p.taskSpec.Description == gcTask {
 		if newPod.Spec.PriorityClassName != "" {
@@ -226,6 +226,9 @@ func (p *pod) configureCoscheduler(newPod *k8sV1.Pod, scheduler string) {
 			)
 		}
 		newPod.Spec.PriorityClassName = "determined-system-priority"
+	}
+
+	if p.slotType == device.GPU {
 		minAvailable = 0
 	} else {
 		minAvailable = int(math.Ceil(float64(resources.SlotsPerTrial()) / float64(p.slots)))

--- a/master/internal/kubernetes/spec.go
+++ b/master/internal/kubernetes/spec.go
@@ -228,7 +228,7 @@ func (p *pod) configureCoscheduler(newPod *k8sV1.Pod, scheduler string) {
 		newPod.Spec.PriorityClassName = "determined-system-priority"
 	}
 
-	if p.slotType == device.GPU {
+	if p.slotType != device.GPU {
 		minAvailable = 0
 	} else {
 		minAvailable = int(math.Ceil(float64(resources.SlotsPerTrial()) / float64(p.slots)))


### PR DESCRIPTION
## Description
Kubernetes was preempting the master and DB instance because they had a priority of 0. This was occurring as part of the kubernetes preemption protocol, and not as a result of Determined itself. This fix adds a priority value to the master and db instances, as well as reintroduces content from the reverted pull #2631 (prevent CPU-only training from being blocked by the coscheduler).

<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan
Set up a CPU-only kubernetes cluster and submit a job. First, make sure that the master and DB instances don't die and restart after job submission. Then, make sure the job is able to be scheduled and starts running.
<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234