### PR TITLE
fix: going back in the browser doesn't update the settings of the experiment list view [DET-5625]

### DIFF
--- a/webui/react/src/pages/ExperimentList.tsx
+++ b/webui/react/src/pages/ExperimentList.tsx
@@ -139,7 +139,7 @@ const ExperimentList: React.FC = () => {
       searchParams.append('user', URL_ALL);
     }
 
-    window.history.pushState(
+    window.history.replaceState(
       {},
       '',
       url.origin + url.pathname + '?' + searchParams.toString(),

--- a/webui/react/src/pages/TrialDetails/Profiles/ProfilesFiltersProvider.tsx
+++ b/webui/react/src/pages/TrialDetails/Profiles/ProfilesFiltersProvider.tsx
@@ -94,7 +94,7 @@ const ProfilesFiltersProvider: React.FC<Props> = ({ children, trial }: Props) =>
       searchParams.append('gpuUuid', filters.gpuUuid);
     }
 
-    window.history.pushState(
+    window.history.replaceState(
       {},
       '',
       url.origin + url.pathname + '?' + searchParams.toString(),


### PR DESCRIPTION
## Description

I spend some time trying to support "reloading" the previous state of the table when going back in the browser history.

That's not easy due to having state partially "synced" between ant-table and the page component (the cleanest solution would have been to update the state by parsing the url when it changes, by avoiding to change the state directly from the component and changing it only by parsing the url).

But this simple fix is probably the best one (avoiding to push a new state in the browser history any time the URL changes but you're still in the experiment list page).


## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
