### PR TITLE
fix: always terminate streams for terminated trials [DET-5790]

### DIFF
--- a/master/internal/api_master.go
+++ b/master/internal/api_master.go
@@ -84,6 +84,7 @@ func (a *apiServer) MasterLogs(
 		fetch,
 		onBatch,
 		nil,
+		false,
 		masterLogsBatchWaitTime,
 		masterLogsBatchMissWaitTime,
 	).Run(resp.Context())

--- a/master/internal/api_trials.go
+++ b/master/internal/api_trials.go
@@ -50,7 +50,7 @@ var (
 
 	trialLogsBatchWaitTime     = 100 * time.Millisecond
 	trialLogsBatchMissWaitTime = time.Second
-	trialLogsTerminationDelay  = 20 * time.Second
+	trialLogsTerminationDelay  = 2 * time.Second
 
 	distinctFieldBatchWaitTime = 5 * time.Second
 


### PR DESCRIPTION
## Description
This changes updates streaming code to make the trial logs fields and profiler labels endpoints close when the trial closes. It also shortens the trial stream termination delay because, let's be honest, 20s? That was a little ridiculous of me.
<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan
- [x] run an experiment with trial logs fields, ensure it closes when the trial closes (after 2s delay)
<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234