### PR TITLE
fix: destroy hp-viz tabs when navigating away [DET-5794]

### DIFF
--- a/docs/release-notes/2730-fix-too-many-streaming.txt
+++ b/docs/release-notes/2730-fix-too-many-streaming.txt
@@ -1,0 +1,6 @@
+:orphan:
+
+**Bug Fixes**
+
+-  WebUI: Fix the issue of hp-viz getting stuck showing an infinite
+   spinner after clicking through all the different tabs.

--- a/webui/react/src/pages/ExperimentDetails/ExperimentVisualization.tsx
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentVisualization.tsx
@@ -315,7 +315,12 @@ const ExperimentVisualization: React.FC<Props> = ({
 
   return (
     <div className={css.base}>
-      <Tabs activeKey={typeKey} className={css.base} type="card" onChange={handleTabChange}>
+      <Tabs
+        activeKey={typeKey}
+        className={css.base}
+        destroyInactiveTabPane
+        type="card"
+        onChange={handleTabChange}>
         <Tabs.TabPane
           key={ExperimentVisualizationType.LearningCurve}
           tab="Learning Curve">


### PR DESCRIPTION
## Description

Thanks to @hamidzr's [investigative work](https://github.com/hamidzr/determined/commit/a277be0ebd2a8018a33009627bf9be99feb7e1da), it became clear that the abortion of streaming endpoints via the `AbortController` was not the issue. After further investigation, it is due to having too many open streaming endpoints. This is much more obvious in HP Visualization section.

PROBLEM:
Under HP Visualization, currently, as users navigate to each tab, each visualization tab mounts and creates new streaming connections. They start to add up quite a bit, very quickly.

SOLUTION:
Took a look at a couple of options. One option is to extract all the shared streaming endpoints and make those call at a higher order component (`ExperimentVisualization.ts`) so you don't make as many calls. The downside to this approach is that you may be making extra calls you don't need. One can provide more fine grain control to make the necessary streams when necessary but this seems brittle and can quickly get out of control. Instead, the 2nd option of just unmounting the tab that's navigated away from seems to be a better overall solution. This ensures only the needed streams are open and kept alive and each respective tab doesn't have to worry about each other's streams and the HOC doesn't have to manage any complicated logic.

<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan

- [ ] Open an actively running multi-trial experiment such as `cifar10_pytorch_adaptive_search` and once there are data points to plot, click between the HP Visualization tabs to try to get to an infinite spinner.

<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234