### PR TITLE
chore: Add back Continue Trial button to single-trial experiment page [DET-5749]

### DIFF
--- a/webui/react/src/components/ContinueTrial.tsx
+++ b/webui/react/src/components/ContinueTrial.tsx
@@ -1,0 +1,100 @@
+import React, { forwardRef, useCallback, useImperativeHandle, useState } from 'react';
+
+import CreateExperimentModal, { CreateExperimentType } from 'components/CreateExperimentModal';
+import handleError, { ErrorType } from 'ErrorHandler';
+import { paths, routeToReactUrl } from 'routes/utils';
+import { createExperiment } from 'services/api';
+import { ExperimentBase, RawJson, TrialDetails, TrialHyperParameters } from 'types';
+import { clone } from 'utils/data';
+import { trialHParamsToExperimentHParams, upgradeConfig } from 'utils/types';
+
+export interface ContinueTrialHandles {
+  show: () => void;
+}
+
+interface Props {
+  experiment: ExperimentBase;
+  ref?: React.Ref<ContinueTrialHandles>;
+  trial: TrialDetails;
+}
+
+const trialContinueConfig = (
+  experimentConfig: RawJson,
+  trialHparams: TrialHyperParameters,
+  trialId: number,
+): RawJson => {
+  return {
+    ...experimentConfig,
+    hyperparameters: trialHParamsToExperimentHParams(trialHparams),
+    searcher: {
+      max_length: experimentConfig.searcher.max_length,
+      metric: experimentConfig.searcher.metric,
+      name: 'single',
+      smaller_is_better: experimentConfig.searcher.smaller_is_better,
+      source_trial_id: trialId,
+    },
+  };
+};
+
+const ContinueTrial: React.FC<Props> = forwardRef(function ContinueTrial(
+  { experiment, trial }: Props,
+  ref?: React.Ref<ContinueTrialHandles>,
+) {
+  const [ contModalConfig, setContModalConfig ] = useState<RawJson>();
+  const [ contModalError, setContModalError ] = useState<string>();
+  const [ isVisible, setIsVisible ] = useState(false);
+
+  const show = useCallback(() => {
+    const rawConfig = trialContinueConfig(clone(experiment.configRaw), trial.hparams, trial.id);
+    let newDescription = `Continuation of trial ${trial.id}, experiment ${trial.experimentId}`;
+    if (rawConfig.description) newDescription += ` (${rawConfig.description})`;
+    rawConfig.description = newDescription;
+    upgradeConfig(rawConfig);
+    setContModalConfig(rawConfig);
+    setIsVisible(true);
+  }, [ experiment.configRaw, trial ]);
+
+  useImperativeHandle(ref, () => ({ show }));
+
+  const handleContModalCancel = useCallback(() => {
+    setIsVisible(false);
+  }, []);
+
+  const handleContModalSubmit = useCallback(async (newConfig: string) => {
+    try {
+      const { id: newExperimentId } = await createExperiment({
+        experimentConfig: newConfig,
+        parentId: trial.experimentId,
+      });
+      setIsVisible(false);
+      routeToReactUrl(paths.experimentDetails(newExperimentId));
+    } catch (e) {
+      handleError({
+        error: e,
+        message: 'Failed to continue trial',
+        publicMessage: [
+          'Check the experiment config.',
+          'If the problem persists please contact support.',
+        ].join(' '),
+        publicSubject: 'Failed to continue trial',
+        silent: false,
+        type: ErrorType.Api,
+      });
+      setContModalError(e.response?.data?.message || e.message);
+    }
+  }, [ trial ]);
+
+  return (
+    <CreateExperimentModal
+      config={contModalConfig}
+      error={contModalError}
+      title={`Continue Trial ${trial.id}`}
+      type={CreateExperimentType.ContinueTrial}
+      visible={isVisible}
+      onCancel={handleContModalCancel}
+      onOk={handleContModalSubmit}
+    />
+  );
+});
+
+export default ContinueTrial;

--- a/webui/react/src/pages/ExperimentDetails.tsx
+++ b/webui/react/src/pages/ExperimentDetails.tsx
@@ -95,6 +95,10 @@ const ExperimentDetails: React.FC = () => {
     setIsForkModalVisible(true);
   }, [ experiment?.configRaw ]);
 
+  const showContinueTrial = useCallback((): void => {
+    continueTrialRef.current?.show();
+  }, [ continueTrialRef ]);
+
   const handleForkModalCancel = useCallback(() => {
     setIsForkModalVisible(false);
   }, []);
@@ -156,10 +160,10 @@ const ExperimentDetails: React.FC = () => {
   return (
     <Page
       headerComponent={<ExperimentDetailsHeader
-        continueTrialRef={continueTrialRef}
         experiment={experiment}
         fetchExperimentDetails={fetchExperimentDetails}
         isSingleTrial={isSingleTrial}
+        showContinueTrial={showContinueTrial}
         showForkModal={showForkModal}
       />}
       stickyHeader

--- a/webui/react/src/pages/ExperimentDetails.tsx
+++ b/webui/react/src/pages/ExperimentDetails.tsx
@@ -1,6 +1,7 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useParams } from 'react-router';
 
+import { ContinueTrialHandles } from 'components/ContinueTrial';
 import CreateExperimentModal, { CreateExperimentType } from 'components/CreateExperimentModal';
 import Message, { MessageType } from 'components/Message';
 import Page from 'components/Page';
@@ -37,6 +38,7 @@ const ExperimentDetails: React.FC = () => {
   const [ forkModalError, setForkModalError ] = useState<string>();
   const [ isForkModalVisible, setIsForkModalVisible ] = useState(false);
   const [ isSingleTrial, setIsSingleTrial ] = useState(false);
+  const continueTrialRef = useRef<ContinueTrialHandles>(null);
 
   const id = parseInt(experimentId);
 
@@ -154,14 +156,20 @@ const ExperimentDetails: React.FC = () => {
   return (
     <Page
       headerComponent={<ExperimentDetailsHeader
+        continueTrialRef={continueTrialRef}
         experiment={experiment}
         fetchExperimentDetails={fetchExperimentDetails}
+        isSingleTrial={isSingleTrial}
         showForkModal={showForkModal}
       />}
       stickyHeader
       title={`Experiment ${experimentId}`}>
       {isSingleTrial ? (
-        <ExperimentSingleTrialTabs experiment={experiment} trialId={firstTrialId} />
+        <ExperimentSingleTrialTabs
+          continueTrialRef={continueTrialRef}
+          experiment={experiment}
+          trialId={firstTrialId}
+        />
       ) : (
         <ExperimentMultiTrialTabs experiment={experiment} />
       )}

--- a/webui/react/src/pages/ExperimentDetails/ExperimentDetailsHeader.tsx
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentDetailsHeader.tsx
@@ -2,7 +2,6 @@ import { Tooltip } from 'antd';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import TimeAgo from 'timeago-react';
 
-import { ContinueTrialHandles } from 'components/ContinueTrial';
 import Icon from 'components/Icon';
 import InlineTextEdit from 'components/InlineTextEdit';
 import PageHeaderFoldable, { Option } from 'components/PageHeaderFoldable';
@@ -24,15 +23,15 @@ import { openCommand } from 'wait';
 import css from './ExperimentDetailsHeader.module.scss';
 
 interface Props {
-  continueTrialRef: React.RefObject<ContinueTrialHandles>;
   experiment: ExperimentBase;
   fetchExperimentDetails: () => void;
   isSingleTrial: boolean;
+  showContinueTrial: () => void;
   showForkModal: () => void;
 }
 
 const ExperimentDetailsHeader: React.FC<Props> = ({
-  continueTrialRef,
+  showContinueTrial,
   experiment,
   fetchExperimentDetails,
   isSingleTrial,
@@ -69,7 +68,7 @@ const ExperimentDetailsHeader: React.FC<Props> = ({
     const continueTrial: Option = {
       key: 'continue-trial',
       label: 'Continue Trial',
-      onClick: () => continueTrialRef.current?.show(),
+      onClick: showContinueTrial,
     };
     const downloadModel: Option = {
       icon: <Icon name="download" size="small" />,
@@ -149,7 +148,6 @@ const ExperimentDetailsHeader: React.FC<Props> = ({
 
     return options;
   }, [
-    continueTrialRef,
     experiment.archived,
     experiment.id,
     experiment.state,
@@ -158,6 +156,7 @@ const ExperimentDetailsHeader: React.FC<Props> = ({
     isRunningTensorboard,
     isRunningUnarchive,
     isSingleTrial,
+    showContinueTrial,
     showForkModal,
   ]);
 

--- a/webui/react/src/pages/ExperimentDetails/ExperimentSingleTrialTabs.tsx
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentSingleTrialTabs.tsx
@@ -2,6 +2,7 @@ import { Alert, Tabs } from 'antd';
 import React, { useCallback, useEffect, useState } from 'react';
 import { useHistory, useParams } from 'react-router';
 
+import ContinueTrial, { ContinueTrialHandles } from 'components/ContinueTrial';
 import Spinner from 'components/Spinner';
 import handleError, { ErrorLevel, ErrorType } from 'ErrorHandler';
 import usePolling from 'hooks/usePolling';
@@ -40,6 +41,7 @@ const ExperimentConfiguration = React.lazy(() => {
 });
 
 export interface Props {
+  continueTrialRef: React.Ref<ContinueTrialHandles>;
   experiment: ExperimentBase;
   trialId?: number;
 }
@@ -47,7 +49,7 @@ export interface Props {
 const NoDataAlert = <Alert message="No data available." type="warning" />;
 
 const ExperimentSingleTrialTabs: React.FC<Props> = (
-  { experiment, trialId }: Props,
+  { continueTrialRef, experiment, trialId }: Props,
 ) => {
   const history = useHistory();
   const prevTrialId = usePrevious(trialId, undefined);
@@ -123,38 +125,43 @@ const ExperimentSingleTrialTabs: React.FC<Props> = (
   if (!hasLoaded) return <Spinner tip={`Fetching trial ${trialId} details...`} />;
 
   return (
-    <Tabs defaultActiveKey={tabKey} onChange={handleTabChange}>
-      <TabPane key="overview" tab="Overview">
-        {trialDetails
-          ? <TrialDetailsOverview experiment={experiment} trial={trialDetails} />
-          : NoDataAlert}
-      </TabPane>
-      <TabPane key="hyperparameters" tab="Hyperparameters">
-        {trialDetails
-          ? <TrialDetailsHyperparameters experiment={experiment} trial={trialDetails} />
-          : NoDataAlert}
-      </TabPane>
-      <TabPane key="workloads" tab="Workloads">
-        {trialDetails
-          ? <TrialDetailsWorkloads experiment={experiment} trial={trialDetails} />
-          : NoDataAlert}
-      </TabPane>
-      <TabPane key="configuration" tab="Configuration">
-        <React.Suspense fallback={<Spinner tip="Loading experiment configuration editor..." />}>
-          <ExperimentConfiguration experiment={experiment} />
-        </React.Suspense>
-      </TabPane>
-      <TabPane key="profiler" tab="Profiler">
-        {trialDetails
-          ? <TrialDetailsProfiles experiment={experiment} trial={trialDetails} />
-          : NoDataAlert}
-      </TabPane>
-      <TabPane key="logs" tab="Logs">
-        {trialDetails
-          ? <TrialDetailsLogs experiment={experiment} trial={trialDetails} />
-          : NoDataAlert}
-      </TabPane>
-    </Tabs>
+    <>
+      <Tabs defaultActiveKey={tabKey} onChange={handleTabChange}>
+        <TabPane key="overview" tab="Overview">
+          {trialDetails
+            ? <TrialDetailsOverview experiment={experiment} trial={trialDetails} />
+            : NoDataAlert}
+        </TabPane>
+        <TabPane key="hyperparameters" tab="Hyperparameters">
+          {trialDetails
+            ? <TrialDetailsHyperparameters experiment={experiment} trial={trialDetails} />
+            : NoDataAlert}
+        </TabPane>
+        <TabPane key="workloads" tab="Workloads">
+          {trialDetails
+            ? <TrialDetailsWorkloads experiment={experiment} trial={trialDetails} />
+            : NoDataAlert}
+        </TabPane>
+        <TabPane key="configuration" tab="Configuration">
+          <React.Suspense fallback={<Spinner tip="Loading experiment configuration editor..." />}>
+            <ExperimentConfiguration experiment={experiment} />
+          </React.Suspense>
+        </TabPane>
+        <TabPane key="profiler" tab="Profiler">
+          {trialDetails
+            ? <TrialDetailsProfiles experiment={experiment} trial={trialDetails} />
+            : NoDataAlert}
+        </TabPane>
+        <TabPane key="logs" tab="Logs">
+          {trialDetails
+            ? <TrialDetailsLogs experiment={experiment} trial={trialDetails} />
+            : NoDataAlert}
+        </TabPane>
+      </Tabs>
+      {trialDetails && (
+        <ContinueTrial experiment={experiment} ref={continueTrialRef} trial={trialDetails} />
+      )}
+    </>
   );
 };
 

--- a/webui/react/src/pages/TrialDetails.tsx
+++ b/webui/react/src/pages/TrialDetails.tsx
@@ -1,9 +1,9 @@
 import { Tabs } from 'antd';
 import axios from 'axios';
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useHistory, useParams } from 'react-router';
 
-import CreateExperimentModal, { CreateExperimentType } from 'components/CreateExperimentModal';
+import ContinueTrial, { ContinueTrialHandles } from 'components/ContinueTrial';
 import Message, { MessageType } from 'components/Message';
 import Page from 'components/Page';
 import Spinner from 'components/Spinner';
@@ -16,14 +16,13 @@ import TrialDetailsOverview from 'pages/TrialDetails/TrialDetailsOverview';
 import TrialDetailsProfiles from 'pages/TrialDetails/TrialDetailsProfiles';
 import TrialDetailsWorkloads from 'pages/TrialDetails/TrialDetailsWorkloads';
 import TrialRangeHyperparameters from 'pages/TrialDetails/TrialRangeHyperparameters';
-import { paths, routeToReactUrl } from 'routes/utils';
-import { createExperiment, getExperimentDetails, getTrialDetails, isNotFound } from 'services/api';
+import { paths } from 'routes/utils';
+import { getExperimentDetails, getTrialDetails, isNotFound } from 'services/api';
 import { ApiState } from 'services/types';
 import { isAborted } from 'services/utils';
-import { ExperimentBase, RawJson, TrialDetails, TrialHyperParameters } from 'types';
-import { clone } from 'utils/data';
+import { ExperimentBase, TrialDetails } from 'types';
 import { isSingleTrialExperiment } from 'utils/experiment';
-import { terminalRunStates, trialHParamsToExperimentHParams, upgradeConfig } from 'utils/types';
+import { terminalRunStates } from 'utils/types';
 
 const { TabPane } = Tabs;
 
@@ -43,31 +42,11 @@ interface Params {
 
 const DEFAULT_TAB_KEY = TabType.Overview;
 
-const trialContinueConfig = (
-  experimentConfig: RawJson,
-  trialHparams: TrialHyperParameters,
-  trialId: number,
-): RawJson => {
-  return {
-    ...experimentConfig,
-    hyperparameters: trialHParamsToExperimentHParams(trialHparams),
-    searcher: {
-      max_length: experimentConfig.searcher.max_length,
-      metric: experimentConfig.searcher.metric,
-      name: 'single',
-      smaller_is_better: experimentConfig.searcher.smaller_is_better,
-      source_trial_id: trialId,
-    },
-  };
-};
-
 const TrialDetailsComp: React.FC = () => {
   const [ canceler ] = useState(new AbortController());
-  const [ contModalConfig, setContModalConfig ] = useState<RawJson>();
-  const [ contModalError, setContModalError ] = useState<string>();
   const [ experiment, setExperiment ] = useState<ExperimentBase>();
-  const [ isContModalVisible, setIsContModalVisible ] = useState(false);
   const [ source ] = useState(axios.CancelToken.source());
+  const continueTrialRef = useRef<ContinueTrialHandles>(null);
   const history = useHistory();
   const routeParams = useParams<Params>();
 
@@ -126,55 +105,13 @@ const TrialDetailsComp: React.FC = () => {
     }
   }, [ canceler, trialDetails.error, trialId ]);
 
-  const showContModal = useCallback(() => {
-    if (experiment?.configRaw && trial) {
-      const rawConfig = trialContinueConfig(clone(experiment.configRaw), trial.hparams, trial.id);
-      let newDescription = `Continuation of trial ${trial.id}, experiment ${trial.experimentId}`;
-      if (rawConfig.description) newDescription += ` (${rawConfig.description})`;
-      rawConfig.description = newDescription;
-      upgradeConfig(rawConfig);
-      setContModalConfig(rawConfig);
-    }
-    setIsContModalVisible(true);
-  }, [ experiment?.configRaw, trial ]);
-
   const handleActionClick = useCallback((action: TrialAction) => {
     switch (action) {
       case TrialAction.Continue:
-        showContModal();
+        continueTrialRef.current?.show();
         break;
     }
-  }, [ showContModal ]);
-
-  const handleContModalCancel = useCallback(() => {
-    setIsContModalVisible(false);
-  }, []);
-
-  const handleContModalSubmit = useCallback(async (newConfig: string) => {
-    if (!trial) return;
-
-    try {
-      const { id: newExperimentId } = await createExperiment({
-        experimentConfig: newConfig,
-        parentId: trial.experimentId,
-      });
-      setIsContModalVisible(false);
-      routeToReactUrl(paths.experimentDetails(newExperimentId));
-    } catch (e) {
-      handleError({
-        error: e,
-        message: 'Failed to continue trial',
-        publicMessage: [
-          'Check the experiment config.',
-          'If the problem persists please contact support.',
-        ].join(' '),
-        publicSubject: 'Failed to continue trial',
-        silent: false,
-        type: ErrorType.Api,
-      });
-      setContModalError(e.response?.data?.message || e.message);
-    }
-  }, [ trial ]);
+  }, [ continueTrialRef ]);
 
   const handleTabChange = useCallback(key => {
     setTabKey(key);
@@ -250,15 +187,7 @@ const TrialDetailsComp: React.FC = () => {
           <TrialDetailsLogs experiment={experiment} trial={trial} />
         </TabPane>
       </Tabs>
-      <CreateExperimentModal
-        config={contModalConfig}
-        error={contModalError}
-        title={`Continue Trial ${trialId}`}
-        type={CreateExperimentType.ContinueTrial}
-        visible={isContModalVisible}
-        onCancel={handleContModalCancel}
-        onOk={handleContModalSubmit}
-      />
+      <ContinueTrial experiment={experiment} ref={continueTrialRef} trial={trial} />
     </Page>
   );
 };

--- a/webui/react/src/pages/TrialDetails/TrialDetailsHeader.tsx
+++ b/webui/react/src/pages/TrialDetails/TrialDetailsHeader.tsx
@@ -39,22 +39,6 @@ const TrialDetailsHeader: React.FC<Props> = (
   const headerOptions = useMemo<Option[]>(() => {
     const options: Option[] = [];
 
-    if (trial.bestAvailableCheckpoint !== undefined) {
-      options.push({
-        icon: <Icon name="fork" size="small" />,
-        key: Action.Continue,
-        label: 'Continue Trial',
-        onClick: () => handleActionClick(Action.Continue),
-      });
-    } else {
-      options.push({
-        icon: <Icon name="fork" size="small" />,
-        key: Action.Continue,
-        label: 'Continue Trial',
-        tooltip: 'No checkpoints found. Cannot continue trial',
-      });
-    }
-
     if (!trialWillNeverHaveData(trial)) {
       options.push({
         icon: <Icon name="tensorboard" size="small" />,
@@ -68,6 +52,22 @@ const TrialDetailsHeader: React.FC<Props> = (
           await fetchTrialDetails();
           setIsRunningTensorboard(false);
         },
+      });
+    }
+
+    if (trial.bestAvailableCheckpoint !== undefined) {
+      options.push({
+        icon: <Icon name="fork" size="small" />,
+        key: Action.Continue,
+        label: 'Continue Trial',
+        onClick: () => handleActionClick(Action.Continue),
+      });
+    } else {
+      options.push({
+        icon: <Icon name="fork" size="small" />,
+        key: Action.Continue,
+        label: 'Continue Trial',
+        tooltip: 'No checkpoints found. Cannot continue trial',
       });
     }
 


### PR DESCRIPTION


## Description

This should take care of:
- On the Trial page of single-trial experiments, let's add an action to "Continue Trial" to the header
- On the Trial page of single-trial experiments, let's reorder the header buttons to be 1. TensorBoard 2. Download Model 3. Fork 4. Continue Trial
- On the Trial page of a multi-trial experiment, let's reorder the header buttons to be 1. TensorBoard 2. Continue Trial



## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
