### PR TITLE
fix: pull model definitions into containers [DET-5788]

### DIFF
--- a/docs/release-notes/2753-model-dup.txt
+++ b/docs/release-notes/2753-model-dup.txt
@@ -1,0 +1,7 @@
+:orphan:
+
+**Fixes**
+
+-  Fix a bug where experiments with model definitions of exceeding 50%
+   of the maximum allowable size size would actually cause trials to
+   never start.

--- a/e2e_tests/tests/experiment/test_noop.py
+++ b/e2e_tests/tests/experiment/test_noop.py
@@ -1,4 +1,6 @@
 import copy
+import os
+import shutil
 import tempfile
 import time
 from typing import Union
@@ -251,6 +253,17 @@ def test_startup_hook() -> None:
         conf.fixtures_path("no_op"),
         1,
     )
+
+
+@pytest.mark.e2e_cpu  # type: ignore
+def test_large_model_def_experiment() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        shutil.copy(conf.fixtures_path("no_op/model_def.py"), td)
+        # Write a 94MB file into the directory.
+        with open(os.path.join(td, "junk.txt"), "w") as f:
+            f.write("x" * 94 * 1024 * 1024)
+
+        exp.run_basic_test(conf.fixtures_path("no_op/single-one-short-step.yaml"), td, 1)
 
 
 def _test_rng_restore(fixture: str, metrics: list, tf2: Union[None, bool] = None) -> None:

--- a/harness/determined/common/context.py
+++ b/harness/determined/common/context.py
@@ -28,7 +28,8 @@ class ContextItem:
     @property
     def size(self) -> int:
         if self.content:
-            return len(self.content)
+            # The content is already base64-encoded, and we want the real length.
+            return len(self.content) // 4 * 3
         return 0
 
     def dict(self) -> Dict[str, Any]:

--- a/harness/determined/exec/fetch_context.py
+++ b/harness/determined/exec/fetch_context.py
@@ -1,0 +1,30 @@
+import base64
+import distutils.util
+import io
+import os
+import tarfile
+
+from determined import constants
+from determined.common.api import certs, request
+
+if __name__ == "__main__":
+    exp_id = os.environ["DET_EXPERIMENT_ID"]
+    master_addr = os.environ["DET_MASTER_ADDR"]
+    master_port = os.environ["DET_MASTER_PORT"]
+    use_tls = distutils.util.strtobool(os.environ.get("DET_USE_TLS", "false"))
+
+    master_url = f"http{'s' if use_tls else ''}://{master_addr}:{master_port}"
+    certs.cli_cert = certs.default_load(master_url=master_url)
+
+    resp = request.get(master_url, f"api/v1/experiments/{exp_id}/model_def")
+    resp.raise_for_status()
+
+    tgz = base64.b64decode(resp.json()["b64Tgz"])
+
+    with tarfile.open(fileobj=io.BytesIO(tgz), mode="r:gz") as model_def:
+        # Ensure all members of the tarball resolve to subdirectories.
+        for path in model_def.getnames():
+            if os.path.relpath(path).startswith("../"):
+                raise ValueError(f"'{path}' in tarball would expand to a parent directory")
+        model_def.extractall(path=constants.MANAGED_TRAINING_MODEL_COPY)
+        model_def.extractall(path=".")

--- a/master/internal/api_experiment.go
+++ b/master/internal/api_experiment.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"math"
@@ -1240,4 +1241,18 @@ func (a *apiServer) GetBestSearcherValidationMetric(
 	return &apiv1.GetBestSearcherValidationMetricResponse{
 		Metric: metric,
 	}, nil
+}
+
+func (a *apiServer) GetModelDef(
+	_ context.Context, req *apiv1.GetModelDefRequest,
+) (*apiv1.GetModelDefResponse, error) {
+	tgz, err := a.m.db.ExperimentModelDefinitionRaw(int(req.ExperimentId))
+	if err != nil {
+		return nil, errors.Wrapf(err,
+			"error fetching model definition from database: %d", req.ExperimentId)
+	}
+
+	b64Tgz := base64.StdEncoding.EncodeToString(tgz)
+
+	return &apiv1.GetModelDefResponse{B64Tgz: b64Tgz}, nil
 }

--- a/master/pkg/tasks/task_trial.go
+++ b/master/pkg/tasks/task_trial.go
@@ -92,8 +92,6 @@ func (s TrialSpec) ToTaskSpec(keys *ssh.PrivateAndPublicKeys, taskToken string) 
 			},
 			trainDir,
 		),
-		wrapArchive(s.Base.AgentUserGroup.OwnArchive(s.ModelDefinition), modelCopy),
-		wrapArchive(s.Base.AgentUserGroup.OwnArchive(s.ModelDefinition), ContainerWorkDir),
 	}
 
 	res.Description = fmt.Sprintf(

--- a/master/static/srv/entrypoint.sh
+++ b/master/static/srv/entrypoint.sh
@@ -52,5 +52,7 @@ fi
 
 "$DET_PYTHON_EXECUTABLE" -m pip install -q --user /opt/determined/wheels/determined*.whl
 
+"$DET_PYTHON_EXECUTABLE" -m determined.exec.fetch_context
+
 cd ${WORKING_DIR} && test -f "${STARTUP_HOOK}" && source "${STARTUP_HOOK}"
 exec "$DET_PYTHON_EXECUTABLE" -m determined.exec.harness "$@"

--- a/proto/src/determined/api/v1/api.proto
+++ b/proto/src/determined/api/v1/api.proto
@@ -281,6 +281,15 @@ service Determined {
       tags: "Experiments"
     };
   }
+  // Get the model definition of an experiment.
+  rpc GetModelDef(GetModelDefRequest) returns (GetModelDefResponse) {
+    option (google.api.http) = {
+      get: "/api/v1/experiments/{experiment_id}/model_def"
+    };
+    option (grpc.gateway.protoc_gen_swagger.options.openapiv2_operation) = {
+      tags: "Experiments"
+    };
+  }
   // Get a list of unique experiment labels (sorted by popularity).
   rpc GetExperimentLabels(GetExperimentLabelsRequest)
       returns (GetExperimentLabelsResponse) {

--- a/proto/src/determined/api/v1/experiment.proto
+++ b/proto/src/determined/api/v1/experiment.proto
@@ -527,3 +527,18 @@ message GetHPImportanceResponse {
   // A map of validation metric names to their respective entries.
   map<string, MetricHPImportance> validation_metrics = 2;
 }
+
+// Request for an experiment model definition.
+message GetModelDefRequest {
+  // The id of the experiment.
+  int32 experiment_id = 1;
+}
+
+// Response to GetModelDefRequest.
+message GetModelDefResponse {
+  option (grpc.gateway.protoc_gen_swagger.options.openapiv2_schema) = {
+    json_schema: { required: [ "b64_tgz" ] }
+  };
+  // The base64-encoded, gzipped, tarball.
+  string b64_tgz = 1;
+}

--- a/webui/react/src/services/api-ts-sdk/api.ts
+++ b/webui/react/src/services/api-ts-sdk/api.ts
@@ -1852,6 +1852,20 @@ export interface V1GetMasterResponse {
 }
 
 /**
+ * Response to GetModelDefRequest.
+ * @export
+ * @interface V1GetModelDefResponse
+ */
+export interface V1GetModelDefResponse {
+    /**
+     * The base64-encoded, gzipped, tarball.
+     * @type {string}
+     * @memberof V1GetModelDefResponse
+     */
+    b64Tgz: string;
+}
+
+/**
  * Response to GetModelRequest.
  * @export
  * @interface V1GetModelResponse
@@ -7347,6 +7361,43 @@ export const ExperimentsApiFetchParamCreator = function (configuration?: Configu
         },
         /**
          * 
+         * @summary Get the model definition of an experiment.
+         * @param {number} experimentId The id of the experiment.
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        determinedGetModelDef(experimentId: number, options: any = {}): FetchArgs {
+            // verify required parameter 'experimentId' is not null or undefined
+            if (experimentId === null || experimentId === undefined) {
+                throw new RequiredError('experimentId','Required parameter experimentId was null or undefined when calling determinedGetModelDef.');
+            }
+            const localVarPath = `/api/v1/experiments/{experimentId}/model_def`
+                .replace(`{${"experimentId"}}`, encodeURIComponent(String(experimentId)));
+            const localVarUrlObj = url.parse(localVarPath, true);
+            const localVarRequestOptions = Object.assign({ method: 'GET' }, options);
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            // authentication BearerToken required
+            if (configuration && configuration.apiKey) {
+                const localVarApiKeyValue = typeof configuration.apiKey === 'function'
+					? configuration.apiKey("Authorization")
+					: configuration.apiKey;
+                localVarHeaderParameter["Authorization"] = localVarApiKeyValue;
+            }
+
+            localVarUrlObj.query = Object.assign({}, localVarUrlObj.query, localVarQueryParameter, options.query);
+            // fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
+            delete localVarUrlObj.search;
+            localVarRequestOptions.headers = Object.assign({}, localVarHeaderParameter, options.headers);
+
+            return {
+                url: url.format(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         * 
          * @summary Get a single trial.
          * @param {number} trialId The requested trial&#39;s id.
          * @param {*} [options] Override http request option.
@@ -8037,6 +8088,25 @@ export const ExperimentsApiFp = function(configuration?: Configuration) {
         },
         /**
          * 
+         * @summary Get the model definition of an experiment.
+         * @param {number} experimentId The id of the experiment.
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        determinedGetModelDef(experimentId: number, options?: any): (fetch?: FetchAPI, basePath?: string) => Promise<V1GetModelDefResponse> {
+            const localVarFetchArgs = ExperimentsApiFetchParamCreator(configuration).determinedGetModelDef(experimentId, options);
+            return (fetch: FetchAPI = portableFetch, basePath: string = BASE_PATH) => {
+                return fetch(basePath + localVarFetchArgs.url, localVarFetchArgs.options).then((response) => {
+                    if (response.status >= 200 && response.status < 300) {
+                        return response.json();
+                    } else {
+                        throw response;
+                    }
+                });
+            };
+        },
+        /**
+         * 
          * @summary Get a single trial.
          * @param {number} trialId The requested trial&#39;s id.
          * @param {*} [options] Override http request option.
@@ -8374,6 +8444,16 @@ export const ExperimentsApiFactory = function (configuration?: Configuration, fe
         },
         /**
          * 
+         * @summary Get the model definition of an experiment.
+         * @param {number} experimentId The id of the experiment.
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        determinedGetModelDef(experimentId: number, options?: any) {
+            return ExperimentsApiFp(configuration).determinedGetModelDef(experimentId, options)(fetch, basePath);
+        },
+        /**
+         * 
          * @summary Get a single trial.
          * @param {number} trialId The requested trial&#39;s id.
          * @param {*} [options] Override http request option.
@@ -8638,6 +8718,18 @@ export class ExperimentsApi extends BaseAPI {
      */
     public determinedGetExperiments(sortBy?: 'SORT_BY_UNSPECIFIED' | 'SORT_BY_ID' | 'SORT_BY_DESCRIPTION' | 'SORT_BY_START_TIME' | 'SORT_BY_END_TIME' | 'SORT_BY_STATE' | 'SORT_BY_NUM_TRIALS' | 'SORT_BY_PROGRESS' | 'SORT_BY_USER' | 'SORT_BY_NAME', orderBy?: 'ORDER_BY_UNSPECIFIED' | 'ORDER_BY_ASC' | 'ORDER_BY_DESC', offset?: number, limit?: number, description?: string, name?: string, labels?: Array<string>, archived?: boolean, states?: Array<'STATE_UNSPECIFIED' | 'STATE_ACTIVE' | 'STATE_PAUSED' | 'STATE_STOPPING_COMPLETED' | 'STATE_STOPPING_CANCELED' | 'STATE_STOPPING_ERROR' | 'STATE_COMPLETED' | 'STATE_CANCELED' | 'STATE_ERROR' | 'STATE_DELETED'>, users?: Array<string>, options?: any) {
         return ExperimentsApiFp(this.configuration).determinedGetExperiments(sortBy, orderBy, offset, limit, description, name, labels, archived, states, users, options)(this.fetch, this.basePath);
+    }
+
+    /**
+     * 
+     * @summary Get the model definition of an experiment.
+     * @param {number} experimentId The id of the experiment.
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof ExperimentsApi
+     */
+    public determinedGetModelDef(experimentId: number, options?: any) {
+        return ExperimentsApiFp(this.configuration).determinedGetModelDef(experimentId, options)(this.fetch, this.basePath);
     }
 
     /**


### PR DESCRIPTION
## Description

This fixes the model definition duplication problem, which would cause
experiments with model definitions greater than roughly 64MB to never
start.

This also fixes the model-def-too-big-for-config-maps problem when
running on kubernetes.

## Test Plan

Added an e2e test for a large upload, and I plan to run k8s tests to make sure this solution works on non-agents as well.