### PR TITLE
fix: k8s available GPUs indicator [DET-5808]

### DIFF
--- a/master/internal/kubernetes/pods.go
+++ b/master/internal/kubernetes/pods.go
@@ -479,7 +479,7 @@ func (p *pods) summarize(ctx *actor.Context) map[string]model.AgentSummary {
 				}
 
 				slotsSummary[strconv.Itoa(curSlot)] = model.SlotSummary{
-					ID:        strconv.Itoa(i),
+					ID:        strconv.Itoa(curSlot),
 					Device:    device.Device{Type: deviceType},
 					Enabled:   true,
 					Container: podInfo.container,

--- a/master/internal/kubernetes/pods.go
+++ b/master/internal/kubernetes/pods.go
@@ -479,7 +479,7 @@ func (p *pods) summarize(ctx *actor.Context) map[string]model.AgentSummary {
 				}
 
 				slotsSummary[strconv.Itoa(curSlot)] = model.SlotSummary{
-					ID:        strconv.Itoa(curSlot),
+					ID:        strconv.Itoa(i),
 					Device:    device.Device{Type: deviceType},
 					Enabled:   true,
 					Container: podInfo.container,

--- a/master/pkg/model/agent.go
+++ b/master/pkg/model/agent.go
@@ -23,8 +23,8 @@ type AgentSummary struct {
 // ToProto converts an agent summary to a proto struct.
 func (a AgentSummary) ToProto() *agentv1.Agent {
 	slots := make(map[string]*agentv1.Slot)
-	for _, s := range a.Slots {
-		slots[s.ID] = s.ToProto()
+	for i, s := range a.Slots {
+		slots[i] = s.ToProto()
 	}
 	return &agentv1.Agent{
 		Id:             a.ID,


### PR DESCRIPTION
## Description
The kubernetes GPU number displayed incorrect numbers, seemingly subtracting numbers from the total number of GPUs instead of just from the available number. This was due to kubernetes counting slots differently from IDs, where IDs looped for every pod. Patched by making the ID == slot count. 
<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan
Spin up a kubernetes cluster with autoscaling enabled (https://docs.determined.ai/latest/how-to/installation/setup-gke-cluster.html?highlight=gke). Make sure that the number of slots per node > 1. Start a few experiments and make sure that the number of available GPUs is correct on the dashboard. Also make sure that the number of allocated GPUs on the cluster page also looks correct. 
<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234