### PR TITLE
fix: add reload route to allow remounting of same pages [DET-5818]

### DIFF
--- a/docs/release-notes/2761-fix-fork-stale-experiment.txt
+++ b/docs/release-notes/2761-fix-fork-stale-experiment.txt
@@ -1,0 +1,6 @@
+:orphan:
+
+**Bug Fixes**
+
+-  WebUI: fix the issue of new experiments from fork and continue trial
+   showing outdated data.

--- a/webui/react/src/components/ContinueTrial.tsx
+++ b/webui/react/src/components/ContinueTrial.tsx
@@ -70,7 +70,10 @@ const ContinueTrial: React.FC<Props> = forwardRef(function ContinueTrial(
         parentId: trial.experimentId,
       });
       setIsVisible(false);
-      routeToReactUrl(paths.experimentDetails(newExperimentId));
+
+      // Route to reload path to forcibly remount experiment page.
+      const newPath = paths.experimentDetails(newExperimentId);
+      routeToReactUrl(paths.reload(newPath));
     } catch (e) {
       let errorMessage = 'Unable to continue trial with the provided config.';
       if (e.name === 'YAMLException') {

--- a/webui/react/src/pages/ExperimentDetails.tsx
+++ b/webui/react/src/pages/ExperimentDetails.tsx
@@ -62,7 +62,7 @@ const ExperimentDetails: React.FC = () => {
     valHistory,
   ]);
 
-  const { startPolling, stopPolling } = usePolling(fetchExperimentDetails);
+  const { stopPolling } = usePolling(fetchExperimentDetails);
 
   const showForkModal = useCallback((): void => {
     if (experiment?.configRaw) {
@@ -89,16 +89,11 @@ const ExperimentDetails: React.FC = () => {
         parentId: id,
       });
 
-      // Reset experiment state and start polling for newly forked experiment.
       setIsForkModalVisible(false);
-      setExperiment(undefined);
 
       // Route to reload path to forcibly remount experiment page.
       const newPath = paths.experimentDetails(configId);
       routeToReactUrl(paths.reload(newPath));
-
-      // Add a slight delay to allow polling function to update.
-      setTimeout(() => startPolling(), 100);
     } catch (e) {
       let errorMessage = 'Unable to fork experiment with the provided config.';
       if (e.name === 'YAMLException') {
@@ -111,7 +106,7 @@ const ExperimentDetails: React.FC = () => {
       }
       setForkModalError(errorMessage);
     }
-  }, [ id, startPolling ]);
+  }, [ id ]);
 
   useEffect(() => {
     if (experiment && terminalRunStates.has(experiment.state)) {

--- a/webui/react/src/pages/ExperimentDetails.tsx
+++ b/webui/react/src/pages/ExperimentDetails.tsx
@@ -93,8 +93,9 @@ const ExperimentDetails: React.FC = () => {
       setIsForkModalVisible(false);
       setExperiment(undefined);
 
-      // Route to newly forked experiment.
-      routeToReactUrl(paths.experimentDetails(configId));
+      // Route to reload path to forcibly remount experiment page.
+      const newPath = paths.experimentDetails(configId);
+      routeToReactUrl(paths.reload(newPath));
 
       // Add a slight delay to allow polling function to update.
       setTimeout(() => startPolling(), 100);

--- a/webui/react/src/pages/Reload.tsx
+++ b/webui/react/src/pages/Reload.tsx
@@ -1,0 +1,28 @@
+/*
+ * The purpose of this page is to allow React to navigate from
+ * an existing route to the same base route with different params.
+ * For example, going from `/experiments/1` to `/experiments/2`.
+ * Without the `Reload` redirection, `/experiments/2` will not
+ * unmount and remount the page, causing stale data from experiment 1
+ * to show up on experiment 2 page.
+ */
+
+import queryString from 'query-string';
+import { useEffect } from 'react';
+import { useHistory, useLocation } from 'react-router-dom';
+
+const Reload: React.FC = () => {
+  const history = useHistory();
+  const location = useLocation();
+
+  useEffect(() => {
+    const queryParams = queryString.parse(location.search);
+    if (queryParams.path) {
+      history.replace(queryParams.path as string);
+    }
+  }, [ history, location.search ]);
+
+  return null;
+};
+
+export default Reload;

--- a/webui/react/src/routes/index.ts
+++ b/webui/react/src/routes/index.ts
@@ -5,6 +5,7 @@ import Dashboard from 'pages/Dashboard';
 import ExperimentDetails from 'pages/ExperimentDetails';
 import ExperimentList from 'pages/ExperimentList';
 import MasterLogs from 'pages/MasterLogs';
+import Reload from 'pages/Reload';
 import SignIn from 'pages/SignIn';
 import SignOut from 'pages/SignOut';
 import TaskList from 'pages/TaskList';
@@ -21,6 +22,7 @@ const routeComponentMap: Record<string, FC> = {
   experimentDetails: ExperimentDetails,
   experimentList: ExperimentList,
   masterLogs: MasterLogs,
+  reload: Reload,
   signIn: SignIn,
   signOut: SignOut,
   taskList: TaskList,

--- a/webui/react/src/routes/routes.ts
+++ b/webui/react/src/routes/routes.ts
@@ -90,6 +90,12 @@ const routes: RouteConfig[] = [
     path: '/logout',
     title: 'Logout',
   },
+  {
+    id: 'reload',
+    needAuth: false,
+    path: '/reload',
+    title: 'Reload',
+  },
 ];
 
 export default routes;

--- a/webui/react/src/routes/utils.ts
+++ b/webui/react/src/routes/utils.ts
@@ -1,4 +1,5 @@
 import { pathToRegexp } from 'path-to-regexp';
+import queryString from 'query-string';
 import React from 'react';
 
 import { globalStorage } from 'globalStorage';
@@ -203,6 +204,9 @@ export const paths = {
   },
   masterLogs: (): string => {
     return '/logs';
+  },
+  reload: (path: string): string => {
+    return `/reload?${queryString.stringify({ path })}`;
   },
   taskList: (): string => {
     return '/tasks';


### PR DESCRIPTION
## Description

PROBLEM:
During a reroute that mounts to the same page component, the page component does not unmount. For example, when going from `/experiments/1` to `/experiments/2`, both of these pages mount to `ExperimentDetail` page component and so upon a successful fork, when rerouting to the newly forked experiment, the new page will show the stale data from the previous experiment until the new experiment data loads (if at all). 

SOLUTION:
Create a `/reload` route that takes a `path` query param that we can route to to force an unmount of the component. This essentially "refreshes" the page. This is the preferred approach over a `window.location` reload for a few reasons:
- we don't lose or mess with history we accumulate on our end
- using `window.location` in conjunction with our internal history causes our internal history to diverge from the native history
- we avoid attempting to reload the entire page again 

<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan

- [ ] check that an experiment fork loads a new experiment page without stale data (such as metrics)
- [ ] check that continuing a trial loads a new experiment page without stale data

<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234