### PR TITLE
feat: add `--config` override to `det e create`. [DET-5786]

### DIFF
--- a/docs/release-notes/2769-det-e-config.txt
+++ b/docs/release-notes/2769-det-e-config.txt
@@ -1,0 +1,5 @@
+:orphan:
+
+**New Features**
+
+- Allow command-line config overrides in experiment creation, e.g. ``det e create const.yaml . --config name=test``.

--- a/docs/release-notes/2769-det-e-config.txt
+++ b/docs/release-notes/2769-det-e-config.txt
@@ -2,4 +2,5 @@
 
 **New Features**
 
-- Allow command-line config overrides in experiment creation, e.g. ``det e create const.yaml . --config name=test``.
+-  Allow command-line config overrides in experiment creation, e.g.
+   ``det e create const.yaml . --config name=test``.

--- a/e2e_tests/tests/experiment/__init__.py
+++ b/e2e_tests/tests/experiment/__init__.py
@@ -10,6 +10,7 @@ from .experiment import (
     create_native_experiment,
     experiment_has_active_workload,
     experiment_has_completed_workload,
+    experiment_json,
     experiment_state,
     experiment_trials,
     export_and_load_model,

--- a/e2e_tests/tests/experiment/test_noop.py
+++ b/e2e_tests/tests/experiment/test_noop.py
@@ -363,3 +363,18 @@ def test_pytorch_cpu_rng_restore() -> None:
 @pytest.mark.e2e_gpu  # type: ignore
 def test_pytorch_gpu_rng_restore() -> None:
     _test_rng_restore("pytorch_no_op", ["np_rand", "rand_rand", "torch_rand", "gpu_rand"])
+
+
+@pytest.mark.e2e_cpu  # type: ignore
+def test_noop_experiment_config_override() -> None:
+    config_obj = conf.load_config(conf.fixtures_path("no_op/single-one-short-step.yaml"))
+    with tempfile.NamedTemporaryFile() as tf:
+        with open(tf.name, "w") as f:
+            yaml.dump(config_obj, f)
+        experiment_id = exp.create_experiment(
+            tf.name, conf.fixtures_path("no_op"), [
+                "--config", "reproducibility.experiment_seed=8200"
+            ])
+        exp_config = exp.experiment_json(experiment_id)["config"]
+        assert exp_config["reproducibility"]["experiment_seed"] == 8200
+        exp.cancel_single(experiment_id)

--- a/e2e_tests/tests/experiment/test_noop.py
+++ b/e2e_tests/tests/experiment/test_noop.py
@@ -372,9 +372,10 @@ def test_noop_experiment_config_override() -> None:
         with open(tf.name, "w") as f:
             yaml.dump(config_obj, f)
         experiment_id = exp.create_experiment(
-            tf.name, conf.fixtures_path("no_op"), [
-                "--config", "reproducibility.experiment_seed=8200"
-            ])
+            tf.name,
+            conf.fixtures_path("no_op"),
+            ["--config", "reproducibility.experiment_seed=8200"],
+        )
         exp_config = exp.experiment_json(experiment_id)["config"]
         assert exp_config["reproducibility"]["experiment_seed"] == 8200
         exp.cancel_single(experiment_id)

--- a/harness/determined/cli/command.py
+++ b/harness/determined/cli/command.py
@@ -190,17 +190,7 @@ def _set_nested_config(config: Dict[str, Any], key_path: List[str], value: Any) 
     return config
 
 
-def parse_config(
-    config_file: Optional[IO],
-    entrypoint: Optional[List[str]],
-    overrides: Iterable[str],
-    volumes: Iterable[str],
-) -> Dict[str, Any]:
-    config = {}  # type: Dict[str, Any]
-    if config_file:
-        with config_file:
-            config = util.safe_load_yaml_with_exceptions(config_file)
-
+def parse_config_overrides(config: Dict[str, Any], overrides: Iterable[str]) -> None:
     for config_arg in overrides:
         if "=" not in config_arg:
             raise ValueError(
@@ -225,6 +215,20 @@ def parse_config(
         # TODO(#2703): Consider using full JSONPath spec instead of dot
         # notation.
         config = _set_nested_config(config, key.split("."), value)
+
+
+def parse_config(
+    config_file: Optional[IO],
+    entrypoint: Optional[List[str]],
+    overrides: Iterable[str],
+    volumes: Iterable[str],
+) -> Dict[str, Any]:
+    config = {}  # type: Dict[str, Any]
+    if config_file:
+        with config_file:
+            config = util.safe_load_yaml_with_exceptions(config_file)
+
+    parse_config_overrides(config, overrides)
 
     for volume_arg in volumes:
         if ":" not in volume_arg:

--- a/harness/determined/cli/experiment.py
+++ b/harness/determined/cli/experiment.py
@@ -18,7 +18,7 @@ import determined.load
 from determined import _local_execution_manager
 from determined.cli import checkpoint, render
 from determined.cli.command import CONFIG_DESC, parse_config_overrides
-from determined.common import api, constants, context, util, yaml, set_logger
+from determined.common import api, constants, context, set_logger, util, yaml
 from determined.common.api import authentication
 from determined.common.declarative_argparse import Arg, Cmd, Group
 from determined.common.experimental import Determined

--- a/harness/determined/cli/experiment.py
+++ b/harness/determined/cli/experiment.py
@@ -9,12 +9,15 @@ import time
 from argparse import FileType, Namespace
 from pathlib import Path
 from pprint import pformat
-from typing import Any, Dict, List, Optional, Set, Tuple
+from typing import Any, Dict, Iterable, List, Optional, Set, Tuple
 
 import tabulate
 
-import determined.common
+import determined
+import determined.experimental
+import determined.load
 from determined.cli import checkpoint, render
+from determined.cli.command import CONFIG_DESC, parse_config_overrides
 from determined.common import api, constants, context, util, yaml
 from determined.common.api import authentication
 from determined.common.declarative_argparse import Arg, Cmd, Group
@@ -111,19 +114,22 @@ def read_git_metadata(model_def_path: pathlib.Path) -> Tuple[str, str, str, str]
     return (remote_url, commit_hash, committer, commit_date)
 
 
-def _parse_config_file_or_exit(config_file: io.FileIO) -> Dict:
+def _parse_config_file_or_exit(config_file: io.FileIO, config_overrides: Iterable[str]) -> Dict:
     experiment_config = util.safe_load_yaml_with_exceptions(config_file)
 
     config_file.close()
     if not experiment_config or not isinstance(experiment_config, dict):
         print("Error: invalid experiment config file {}".format(config_file.name))
         sys.exit(1)
+
+    parse_config_overrides(experiment_config, config_overrides)
+
     return experiment_config
 
 
 @authentication.required
 def submit_experiment(args: Namespace) -> None:
-    experiment_config = _parse_config_file_or_exit(args.config_file)
+    experiment_config = _parse_config_file_or_exit(args.config_file, args.config)
     model_context = context.Context.from_local(args.model_def, constants.MAX_CONTEXT_SIZE)
 
     additional_body_fields = {}
@@ -156,13 +162,6 @@ def submit_experiment(args: Namespace) -> None:
 
 
 def local_experiment(args: Namespace) -> None:
-    try:
-        import determined as det
-        from determined import experimental, load
-    except ImportError as e:
-        print("--local requires that the `determined` package is installed.")
-        raise e
-
     if not args.test_mode:
         raise NotImplementedError(
             "Local training mode (--local mode without --test mode) is not yet supported. Please "
@@ -170,13 +169,13 @@ def local_experiment(args: Namespace) -> None:
             "the --local flag."
         )
 
-    experiment_config = _parse_config_file_or_exit(args.config_file)
+    experiment_config = _parse_config_file_or_exit(args.config_file, args.config)
 
     determined.common.set_logger(bool(experiment_config.get("debug", False)))
 
-    with det._local_execution_manager(args.model_def.resolve()):
-        trial_class = load.trial_class_from_entrypoint(experiment_config["entrypoint"])
-        experimental.test_one_batch(trial_class=trial_class, config=experiment_config)
+    with determined._local_execution_manager(args.model_def.resolve()):
+        trial_class = determined.load.trial_class_from_entrypoint(experiment_config["entrypoint"])
+        determined.experimental.test_one_batch(trial_class=trial_class, config=experiment_config)
 
 
 def create(args: Namespace) -> None:
@@ -746,6 +745,7 @@ args_description = Cmd(
                     type=str,
                     help="name of template to apply to the experiment configuration",
                 ),
+                Arg("--config", action="append", default=[], help=CONFIG_DESC),
                 Group(
                     Arg(
                         "-f",

--- a/harness/determined/cli/experiment.py
+++ b/harness/determined/cli/experiment.py
@@ -13,12 +13,12 @@ from typing import Any, Dict, Iterable, List, Optional, Set, Tuple
 
 import tabulate
 
-import determined
 import determined.experimental
 import determined.load
+from determined import _local_execution_manager
 from determined.cli import checkpoint, render
 from determined.cli.command import CONFIG_DESC, parse_config_overrides
-from determined.common import api, constants, context, util, yaml
+from determined.common import api, constants, context, util, yaml, set_logger
 from determined.common.api import authentication
 from determined.common.declarative_argparse import Arg, Cmd, Group
 from determined.common.experimental import Determined
@@ -171,9 +171,9 @@ def local_experiment(args: Namespace) -> None:
 
     experiment_config = _parse_config_file_or_exit(args.config_file, args.config)
 
-    determined.common.set_logger(bool(experiment_config.get("debug", False)))
+    set_logger(bool(experiment_config.get("debug", False)))
 
-    with determined._local_execution_manager(args.model_def.resolve()):
+    with _local_execution_manager(args.model_def.resolve()):
         trial_class = determined.load.trial_class_from_entrypoint(experiment_config["entrypoint"])
         determined.experimental.test_one_batch(trial_class=trial_class, config=experiment_config)
 


### PR DESCRIPTION
## Description

Add `--config` override to `det e create`, similar to `det notebook` or `det shell`. Now you can change experiment config in ad-hoc fashion, e.g. `det e create const.yaml . --config name=test-final-hack-9`

Also, remove a little bit of dead code in local mode that is irrelevant now that we've merged all python packages into one.

## Test Plan

Added an e2e test.

## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

