### PR TITLE
feat: change k8s preemption scheduler to backfilling scheduler [DET-5398]

### DIFF
--- a/docs/topic-guides/system-concepts/scheduling.txt
+++ b/docs/topic-guides/system-concepts/scheduling.txt
@@ -163,10 +163,15 @@ You can also use ``schedulerName: default-scheduler`` to use the default Kuberne
 ***************************************************
 
 Determined also makes available a priority scheduler with preemption that extends the Kubernetes
-scheduler to support preemption. This plugin will preempt existing pods if higher priority pods are
-submitted. This plugin is also in beta and is not enabled by default. Similar to the coscheduling
-plugin, it is enabled by setting the ``defaultScheduler`` field to ``preemption``. Autoscaling is
-not supported and Determined can only automatically set labels for GPU experiments.
+scheduler to support preemption with backfilling. This plugin will preempt existing pods if higher
+priority pods are submitted. If there is still space in the cluster, backfilling will attempt to
+fill the nodes by scheduling lower priority jobs. Additionally, if there are leftover slots on
+partially-filled nodes, the scheduler will attempt to assign single-slot tasks until the space is
+filled. This packing behavior only occurs with single-slot tasks.
+
+This plugin is also in beta and is not enabled by default. Similar to the coscheduling plugin, it is
+enabled by setting the ``defaultScheduler`` field to ``preemption``. Autoscaling is not supported
+and Determined can only automatically set labels for GPU experiments.
 
 If using a cluster with tainted nodes or labels, users must specify the tolerations or node
 selectors in the experiment config:

--- a/helm/charts/determined/templates/scheduler-config.yaml
+++ b/helm/charts/determined/templates/scheduler-config.yaml
@@ -31,6 +31,9 @@ data:
         unreserve:
           enabled:
             - name: Coscheduling
+        score:
+          enabled:
+            - name: Coscheduling
     # optional plugin configs
       pluginConfig: 
       - name: Coscheduling

--- a/helm/charts/determined/templates/scheduler-deployment.yaml
+++ b/helm/charts/determined/templates/scheduler-deployment.yaml
@@ -36,7 +36,7 @@ spec:
         - --config=/etc/config/config.yaml
         name: coscheduler
         {{- if eq $schedulerType "preemption"}}
-        image: ecsliu/scheduler-test:latest
+        image: determinedai/kube-scheduler:0.16.0
         {{- else }}
         image: k8s.gcr.io/scheduler-plugins/kube-scheduler:v0.18.9
         {{- end}}

--- a/helm/charts/determined/templates/scheduler-deployment.yaml
+++ b/helm/charts/determined/templates/scheduler-deployment.yaml
@@ -36,7 +36,7 @@ spec:
         - --config=/etc/config/config.yaml
         name: coscheduler
         {{- if eq $schedulerType "preemption"}}
-        image: determinedai/kube-scheduler:latest
+        image: ecsliu/scheduler-test:latest
         {{- else }}
         image: k8s.gcr.io/scheduler-plugins/kube-scheduler:v0.18.9
         {{- end}}


### PR DESCRIPTION
## Description
This change updates the k8s scheduling documentation to describe the new priority scheduler with backfilling. It also updates the helm charts to default to the backfilling version of the preemption scheduler.
<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan
Launch determined on a k8s cluster based on this helm chart. Use `kubectl get pods -n kube-system` to make sure the `preemption-scheduler-...` pod is running and submit a job to check if it successfully schedules. 
<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234