### PR TITLE
fix: preserve zoom levels between uPlot remounts [DET-5636, DET-5751]

### DIFF
--- a/docs/release-notes/2797-preserve-uplot-zoom-between-remounts.txt
+++ b/docs/release-notes/2797-preserve-uplot-zoom-between-remounts.txt
@@ -1,0 +1,6 @@
+:orphan:
+
+**Bug Fixes**
+
+-  WebUI: Prevent zoom from reseting when chart data series gets added.
+-  WebUI: Fix issue of learning curve not resizing properly.

--- a/webui/react/src/components/LearningCurveChart.tsx
+++ b/webui/react/src/components/LearningCurveChart.tsx
@@ -1,5 +1,5 @@
-import React, { useEffect, useMemo, useRef } from 'react';
-import uPlot, { AlignedData } from 'uplot';
+import React, { useEffect, useMemo, useState } from 'react';
+import { AlignedData } from 'uplot';
 
 import UPlotChart, { Options } from 'components/UPlotChart';
 import { closestPointPlugin } from 'components/UPlotChart/closestPointPlugin';
@@ -30,7 +30,7 @@ const LearningCurveChart: React.FC<Props> = ({
   trialIds,
   xValues,
 }: Props) => {
-  const chart = useRef<uPlot>();
+  const [ focusIndex, setFocusIndex ] = useState<number>();
 
   const chartData: AlignedData = useMemo(() => {
     return [ xValues, ...data ];
@@ -87,21 +87,14 @@ const LearningCurveChart: React.FC<Props> = ({
    * Focus on a trial series if provided.
    */
   useEffect(() => {
-    if (!chart.current) return;
-
     let seriesIdx = -1;
     if (focusedTrialId && trialIds.includes(focusedTrialId)) {
       seriesIdx = trialIds.findIndex(id => id === focusedTrialId);
     }
-
-    if (seriesIdx === -1) {
-      chart.current.setSeries(null as unknown as number, { focus: false });
-    } else {
-      chart.current.setSeries(seriesIdx + 1, { focus: true });
-    }
+    setFocusIndex(seriesIdx !== -1 ? seriesIdx : undefined);
   }, [ focusedTrialId, trialIds ]);
 
-  return <UPlotChart data={chartData} options={chartOptions} ref={chart} />;
+  return <UPlotChart data={chartData} focusIndex={focusIndex} options={chartOptions} />;
 };
 
 export default LearningCurveChart;

--- a/webui/react/src/components/UPlotChart.tsx
+++ b/webui/react/src/components/UPlotChart.tsx
@@ -1,11 +1,12 @@
 import React, {
-  forwardRef, useEffect, useImperativeHandle, useMemo, useRef, useState,
+  forwardRef, useEffect, useImperativeHandle, useMemo, useRef,
 } from 'react';
 import { throttle } from 'throttle-debounce';
 import uPlot, { AlignedData } from 'uplot';
 
 import Message, { MessageType } from 'components/Message';
 import useResize from 'hooks/useResize';
+import { RecordKey } from 'types';
 
 export interface Options extends Omit<uPlot.Options, 'width'> {
   width?: number;
@@ -29,85 +30,101 @@ const UPlotChart: React.FC<Props> = forwardRef((
   { data, options }: Props,
   ref?: React.Ref<uPlot|undefined>,
 ) => {
-  const [ chart, setChart ] = useState<uPlot>();
+  const chartRef = useRef<uPlot>();
   const chartDivRef = useRef<HTMLDivElement>(null);
+  const scalesRef = useRef<Record<RecordKey, uPlot.Scale>>();
   const scalesZoomData = useRef<Record<string, ScaleZoomData>>({});
 
-  const hasData: boolean = useMemo(() => {
-    // no x values
-    if (!data || !data[0] || data[0].length === 0) return false;
+  const [ hasData, normalizedData ] = useMemo(() => {
+    const chartData: unknown[][] = data || [];
 
-    // series values length not matching x values length
-    for (let i = 1; i < data.length; i++) {
-      if (data[i].length !== data[0].length) return false;
-    }
+    // Figure out the lowest sized series data.
+    const minDataLength = chartData.reduce((acc: number, series: unknown[]) => {
+      return Math.min(acc, series.length);
+    }, Number.MAX_SAFE_INTEGER);
 
-    return true;
+    // Making sure the X series and all the other series data are the same length;
+    const trimmedData = chartData.map(series => series.slice(0, minDataLength));
+
+    // Checking to make sure the X series has some data.
+    const hasXValues = trimmedData && trimmedData[0] && trimmedData[0].length !== 0;
+
+    return [ hasXValues, trimmedData as unknown as AlignedData ];
   }, [ data ]);
 
   /*
-   * Chart setup.
+   * Chart mount and dismount.
    */
   useEffect(() => {
     if (!chartDivRef.current || !hasData || !options) return;
-
-    scalesZoomData.current = {};
 
     const optionsExtended = uPlot.assign(
       {
         cursor: { drag: { dist: 5, uni: 10, x: true, y: true } },
         hooks: {
-          ready: [ (chart: uPlot) => setChart(chart) ],
+          ready: [ (chart: uPlot) => {
+            chartRef.current = chart;
+          } ],
           setScale: [ (uPlot: uPlot, scaleKey: string) => {
-            if (![ 'x', 'y' ].includes(scaleKey)) return;
-
-            const currentMax: number|undefined =
-              uPlot.posToVal(scaleKey === 'x' ? uPlot.bbox.width : 0, scaleKey);
-            const currentMin: number|undefined =
-              uPlot.posToVal(scaleKey === 'x' ? 0 : uPlot.bbox.height, scaleKey);
-            let max: number|undefined = scalesZoomData.current[scaleKey]?.max;
-            let min: number|undefined = scalesZoomData.current[scaleKey]?.min;
+            const currentMax = uPlot.posToVal(scaleKey === 'x' ? uPlot.bbox.width : 0, scaleKey);
+            const currentMin = uPlot.posToVal(scaleKey === 'x' ? 0 : uPlot.bbox.height, scaleKey);
+            let max = scalesZoomData.current[scaleKey]?.max;
+            let min = scalesZoomData.current[scaleKey]?.min;
 
             if (max == null || currentMax > max) max = currentMax;
             if (min == null || currentMin < min) min = currentMin;
 
-            scalesZoomData.current[scaleKey] = {
-              isZoomed: currentMax < max || currentMin > min,
-              max,
-              min,
-            };
+            const isZoomed = currentMax < max || currentMin > min;
+            scalesZoomData.current[scaleKey] = { isZoomed, max, min };
+
+            /*
+             * Save the scale info if zoomed in and clear it otherwise.
+             * This info will be used to restore the zoom when remounting
+             * the chart, which can be caused by new series data, chart option
+             * changes, etc.
+             */
+            if (!scalesRef.current) scalesRef.current = {};
+            if (isZoomed) {
+              scalesRef.current[scaleKey] = uPlot.scales[scaleKey];
+            } else {
+              delete scalesRef.current[scaleKey];
+            }
+            if (Object.keys(scalesRef.current).length === 0) scalesRef.current = undefined;
           } ],
         },
+        scales: scalesRef.current,
         width: chartDivRef.current.offsetWidth,
       },
       options,
-    );
+    ) as uPlot.Options;
 
-    const plotChart = new uPlot(optionsExtended as uPlot.Options, [ [] ], chartDivRef.current);
+    const plotChart = new uPlot(optionsExtended, normalizedData, chartDivRef.current);
 
     return () => {
-      setChart(undefined);
       plotChart.destroy();
+      chartRef.current = undefined;
     };
-  }, [ chartDivRef, hasData, options ]);
+  }, [ chartDivRef, hasData, normalizedData, options ]);
 
   /*
-   * Chart data.
+   * Chart data when data changes.
    */
   useEffect(() => {
-    if (!chart || !data) return;
+    if (!chartRef.current || !normalizedData) return;
     const isZoomed = !!Object.values(scalesZoomData.current).find(i => i.isZoomed === true);
-    chart.setData(data, !isZoomed);
-  }, [ chart, data ]);
+    chartRef.current.setData(normalizedData, isZoomed);
+  }, [ normalizedData ]);
 
   /*
    * Resize the chart when resize events happen.
    */
   const resize = useResize(chartDivRef);
   useEffect(() => {
-    if (!chart || !options?.height || !resize.width) return;
-    chart.setSize({ height: options.height, width: resize.width });
-  }, [ chart, options?.height, resize ]);
+    if (!chartRef.current) return;
+    const [ width, height ] = [ resize.width, options?.height || chartRef.current.height ];
+    if (chartRef.current.width === width && chartRef.current.height === height) return;
+    chartRef.current.setSize({ height, width });
+  }, [ options?.height, resize ]);
 
   /*
    * Resync the chart when scroll events happen to correct the cursor position upon
@@ -115,7 +132,7 @@ const UPlotChart: React.FC<Props> = forwardRef((
    */
   useEffect(() => {
     const throttleFunc = throttle(SCROLL_THROTTLE_TIME, () => {
-      if (chart) chart.syncRect();
+      if (chartRef.current) chartRef.current.syncRect();
     });
     const handleScroll = () => throttleFunc();
 
@@ -130,9 +147,9 @@ const UPlotChart: React.FC<Props> = forwardRef((
       document.removeEventListener('scroll', handleScroll);
       throttleFunc.cancel();
     };
-  }, [ chart ]);
+  }, []);
 
-  useImperativeHandle(ref, () => chart, [ chart ]);
+  useImperativeHandle(ref, () => chartRef.current, []);
 
   return hasData
     ? <div ref={chartDivRef} />

--- a/webui/react/src/components/UPlotChart.tsx
+++ b/webui/react/src/components/UPlotChart.tsx
@@ -153,9 +153,11 @@ const UPlotChart: React.FC<Props> = ({ data, focusIndex, options }: Props) => {
     };
   }, []);
 
-  return hasData
-    ? <div ref={chartDivRef} />
-    : <Message title="No data to plot." type={MessageType.Empty} />;
+  return (
+    <div ref={chartDivRef}>
+      {!hasData && <Message title="No data to plot." type={MessageType.Empty} />}
+    </div>
+  );
 };
 
 export default UPlotChart;

--- a/webui/react/src/components/UPlotChart.tsx
+++ b/webui/react/src/components/UPlotChart.tsx
@@ -1,6 +1,4 @@
-import React, {
-  forwardRef, useEffect, useImperativeHandle, useMemo, useRef,
-} from 'react';
+import React, { useEffect, useMemo, useRef } from 'react';
 import { throttle } from 'throttle-debounce';
 import uPlot, { AlignedData } from 'uplot';
 
@@ -20,16 +18,13 @@ interface ScaleZoomData {
 
 interface Props {
   data?: AlignedData;
+  focusIndex?: number;
   options?: Options;
-  ref?: React.Ref<uPlot|undefined>;
 }
 
 const SCROLL_THROTTLE_TIME = 500;
 
-const UPlotChart: React.FC<Props> = forwardRef((
-  { data, options }: Props,
-  ref?: React.Ref<uPlot|undefined>,
-) => {
+const UPlotChart: React.FC<Props> = ({ data, focusIndex, options }: Props) => {
   const chartRef = useRef<uPlot>();
   const chartDivRef = useRef<HTMLDivElement>(null);
   const scalesRef = useRef<Record<RecordKey, uPlot.Scale>>();
@@ -116,6 +111,15 @@ const UPlotChart: React.FC<Props> = forwardRef((
   }, [ normalizedData ]);
 
   /*
+   * When a focus index is provided, highlight applicable series.
+   */
+  useEffect(() => {
+    if (!chartRef.current) return;
+    const hasFocus = focusIndex !== undefined;
+    chartRef.current.setSeries(hasFocus ? focusIndex as number + 1 : null, { focus: hasFocus });
+  }, [ focusIndex ]);
+
+  /*
    * Resize the chart when resize events happen.
    */
   const resize = useResize(chartDivRef);
@@ -149,11 +153,9 @@ const UPlotChart: React.FC<Props> = forwardRef((
     };
   }, []);
 
-  useImperativeHandle(ref, () => chartRef.current, []);
-
   return hasData
     ? <div ref={chartDivRef} />
     : <Message title="No data to plot." type={MessageType.Empty} />;
-});
+};
 
 export default UPlotChart;


### PR DESCRIPTION
## Description

PROBLEM:
Zoom on the chart does not get preserved on the Learning Curve chart. The Learning Curve chart differs slightly in that new series (new trials) can get added to the chart, which cause the chart options to change, which requires the chart to be remounted (teared down and rebuilt). The zoom gets lost during this remount process.

SOLUTION:
Preserve the zoom (scales) if a zoom is detected, and upon remounting, apply the scales appropriately.

ADDITIONS:
- refactor to save chart as a reference instead of a state.
- refactor to remove the need for a forward reference (generally an anti-pattern)
- fix issue of learning curve not resizing properly.

<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan

- [ ] test the HP-viz learning curve during a live experiment, by zooming in and make sure the zoom doesn't get reset upon a new trial.
- [ ] test the Cluster Historical charts. Zoom in and wait for the data to change and check to make sure the zoom does not change upon new data.
- [ ] test the Profiler charts (same test as above).
- [ ] check to make sure learning curve resizes when you make the browser wider.

<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234