### PR TITLE
ci: add label for GKE clusters in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -538,7 +538,7 @@ commands:
           google-compute-zone: <<parameters.google-compute-zone>>
           google-project-id: <<parameters.google-project-id>>
       - run:
-          command: gcloud container clusters create ${CLUSTER_ID} --machine-type=n1-standard-8 --cluster-version=<<parameters.gke-version>> --region=<<parameters.region>> --node-locations=<<parameters.node-locations>> --scopes storage-rw,cloud-platform --num-nodes 1
+          command: gcloud container clusters create ${CLUSTER_ID} --machine-type=n1-standard-8 --cluster-version=<<parameters.gke-version>> --region=<<parameters.region>> --node-locations=<<parameters.node-locations>> --scopes storage-rw,cloud-platform --num-nodes 1 --labels environment=ci
           name: Create GKE cluster
       - run:
           command: gcloud container clusters get-credentials ${CLUSTER_ID} --project determined-ai --region <<parameters.region>>


### PR DESCRIPTION
## Description

To help with tracking cloud spend from different sources, this adds a
label to mark GCE instances spun up as part of GKE clusters in CI.

## Test Plan

- [x] push branch to main repo, approve GKE tests, go to GCP console and check that the new instance has the `environment:ci` label
