### PR TITLE
feat: switch to bash in jupyterlab shells. [DET-5791]

### DIFF
--- a/master/static/srv/notebook-entrypoint.sh
+++ b/master/static/srv/notebook-entrypoint.sh
@@ -25,6 +25,10 @@ if [ "$HOME" = "/" ] ; then
     export HOME
 fi
 
+# Use user's preferred SHELL in JupyterLab terminals.
+SHELL="$(set -o pipefail; getent passwd "$(whoami)" | cut -d: -f7)" || SHELL="/bin/bash"
+export SHELL
+
 "$DET_PYTHON_EXECUTABLE" -m pip install -q --user /opt/determined/wheels/determined*.whl
 
 pushd ${WORKING_DIR} && test -f "${STARTUP_HOOK}" && source "${STARTUP_HOOK}" && popd


### PR DESCRIPTION
## Description

JupyterLab defaults to `/bin/sh` in terminals which is annoying for users. Let's grab the shell from passwd and set `SHELL` to make JupyterLab use the user's preferred shell (in practice, `/bin/bash`).

## Test Plan
Launch a terminal inside JupyterLab.

## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
