### PR TITLE
chore: basic python 3.9 support.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,6 +19,9 @@ executors:
   python-38:
     docker:
       - image: python:3.8-slim-buster
+  python-39:
+    docker:
+      - image: python:3.9-slim-buster
 
 parameters:
   det-version:
@@ -1754,6 +1757,7 @@ workflows:
                   "python-36",
                   "python-37",
                   "python-38",
+                  "python-39",
                   "win/default",
                 ]
 

--- a/harness/setup.py
+++ b/harness/setup.py
@@ -15,9 +15,6 @@ setup(
     package_data={"determined": ["py.typed"]},
     include_package_data=True,
     install_requires=[
-        "dill>=0.2.9",
-        # TF 2.2 has strict h5py requirements, which we expose here.
-        "h5py>=2.10.0,<2.11.0",
         "matplotlib",
         "packaging",
         "numpy>=1.16.2",


### PR DESCRIPTION
## Description

- We currently have a restrictive `h5py` requirement in `setup.py` which is not compatible with python 3.9. It's due to TF 2.2 issue long time ago. We aren't dealing with 2.2 anymore so it can be relaxed. But also our use of `h5py` is strictly limited to `_tf_keras_trial.py`, and we end up doing most of the work using tensorflow h5 utilities. Let's treat it as a transient dependency and not explicitly require it in `setup.py` similarly to tensorflow itself; tensorflow install can pull in whatever version it needs, therefore avoiding any potential conflicts and extra version management burden.
- Add python3.9 to `test-cli`.
- Partially addresses #2626 
- Remove neighboring `dill` dependency because it seems it hasn't been used since PEDL.

## Test Plan

- determined CLI now works with python 3.9 (unit tested)
- Manually tried building a custom environment with python 3.9 and tensorflow 2.5; works okay; we should have little issues switching the envs to 3.9 when we decide to.

## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234