### PR TITLE
fix: issue with tensorboard install version fetch order

### DIFF
--- a/master/static/srv/tensorboard-entrypoint.sh
+++ b/master/static/srv/tensorboard-entrypoint.sh
@@ -15,14 +15,14 @@ if ! /bin/which "$DET_PYTHON_EXECUTABLE" >/dev/null 2>&1 ; then
     exit 1
 fi
 
-TENSORBOARD_VERSION=$(pip show tensorboard | grep Version | sed "s/[^:]*: *//")
-
 "$DET_PYTHON_EXECUTABLE" -m pip install -q --user /opt/determined/wheels/determined*.whl
 
 cd ${WORKING_DIR} && test -f "${STARTUP_HOOK}" && source "${STARTUP_HOOK}"
 
 # Install tensorboard if not already installed (for custom Pytorch images)
 "$DET_PYTHON_EXECUTABLE" -m pip install tensorboard
+
+TENSORBOARD_VERSION=$(pip show tensorboard | grep Version | sed "s/[^:]*: *//")
 
 "$DET_PYTHON_EXECUTABLE" -m pip install tensorboard-plugin-profile
 exec "$DET_PYTHON_EXECUTABLE" -m determined.exec.tensorboard "$TENSORBOARD_VERSION" "$@"


### PR DESCRIPTION
## Description

It is possible that a newer version of tensorboard could be installed after we determine what the version of tensorboard we should pass into Python.

## Test Plan

No test required.
