### PR TITLE
feat: cross-compile for powerpc64

### DIFF
--- a/agent/.goreleaser.yml
+++ b/agent/.goreleaser.yml
@@ -10,6 +10,7 @@ builds:
       - darwin
     goarch:
       - amd64
+      - ppc64
 
 archives:
   - wrap_in_directory: true

--- a/master/.goreleaser.yml
+++ b/master/.goreleaser.yml
@@ -18,8 +18,7 @@ builds:
       - darwin
     goarch:
       - amd64
-      # Before supporting more architectures than amd64, the inclusion of the
-      # growforest binary would need to be refactored to support the new arch.
+      - ppc64
   - main: ./cmd/determined-gotmpl
     id: determined-gotmpl
     binary: determined-gotmpl
@@ -28,6 +27,7 @@ builds:
       - darwin
     goarch:
       - amd64
+      - ppc64
 
 archives:
   - wrap_in_directory: true

--- a/master/packaging/fetch-cloud-forest.sh
+++ b/master/packaging/fetch-cloud-forest.sh
@@ -1,14 +1,15 @@
 #!/usr/bin/env bash
 
-# Install native version to ensure it's on PATH
+# Ensure growforest is present.
 go install github.com/ryanbressler/CloudForest/growforest
 
-# Ensure the Linux binary is installed regardless of OS
-GOOS=linux go install github.com/ryanbressler/CloudForest/growforest
+# Load the whole go env.
+source <(go env)
 
-# Find the Linux binary for packaging and output the path
-if [ "$(go env GOOS)" == "linux" ]; then
-  echo $(which growforest)
+# Find the appropriate binary for packaging and output the path.
+if [ "$GOOS" == "$GOHOSTOS" ] && [ "$GOARCH" == "$GOHOSTARCH" ]; then
+    # Package is installed for local use.
+    echo "$GOPATH/bin/growforest"
 else
-  echo $(dirname $(which growforest))/linux_amd64/growforest
+    echo "$GOPATH/bin/${GOOS}_${GOARCH}/growforest"
 fi


### PR DESCRIPTION
## Description

For fetch-cloud-forest.sh, assume that GOOS and GOHOST have been set already, and only detect the special case where `growforest` is put directly in the GOPATH/bin.

## Test Plan

First, the user will confirm if it runs at all.  Then we can talk about potentially some sort of powerpc automated testing.

## Commentary (optional)

An OSS user has been trying to get the `determined-master` and `determined-agent` to build for powerpc64 but has not been successful.  I think that actually supporting powerpc64 is basically free for us.