### PR TITLE
fix: add in 'just a snapshot' msg to not lose progress on restart

### DIFF
--- a/docs/release-notes/2380-fix-fault-tolerance-bug.txt
+++ b/docs/release-notes/2380-fix-fault-tolerance-bug.txt
@@ -1,0 +1,5 @@
+:orphan:
+
+**Bug Fixes**
+
+-  Cluster: Fix a breakage in trial fault tolerance caused by not sending enough state snapshots.

--- a/examples/tutorials/mnist_pytorch/const.yaml
+++ b/examples/tutorials/mnist_pytorch/const.yaml
@@ -8,6 +8,8 @@ hyperparameters:
   n_filters2: 64
   dropout1: 0.25
   dropout2: 0.5
+min_checkpoint_period:
+  batches: 100
 searcher:
   name: single
   metric: validation_loss

--- a/examples/tutorials/mnist_pytorch/const.yaml
+++ b/examples/tutorials/mnist_pytorch/const.yaml
@@ -8,8 +8,6 @@ hyperparameters:
   n_filters2: 64
   dropout1: 0.25
   dropout2: 0.5
-min_checkpoint_period:
-  batches: 100
 searcher:
   name: single
   metric: validation_loss

--- a/master/internal/experiment.go
+++ b/master/internal/experiment.go
@@ -223,6 +223,8 @@ func (e *experiment) Receive(ctx *actor.Context) error {
 		}
 		ops, err := e.searcher.ValidationCompleted(msg.trialID, msg.metric, msg.op)
 		e.processOperations(ctx, ops, err)
+	case trialSnapshot:
+		// Handled by the defered call at the top.
 	case trialReportEarlyExit:
 		ops, err := e.searcher.TrialExitedEarly(msg.trialID, msg.reason)
 		if err != nil && ctx.ExpectingResponse() {

--- a/master/internal/trial.go
+++ b/master/internal/trial.go
@@ -709,6 +709,11 @@ func (t *trial) processCompletedWorkload(ctx *actor.Context, msg workload.Comple
 		ctx.Tell(ctx.Self().Parent(), sendNextWorkload{runID: t.RunID})
 		return nil
 	default:
+		if err := t.tellWithSnapshot(ctx, ctx.Self().Parent(), func(s trialSnapshot) interface{} {
+			return s
+		}); err != nil {
+			return errors.Wrap(err, "failed to report snapshot")
+		}
 		return t.sendNextWorkload(ctx)
 	}
 }

--- a/master/internal/trial.go
+++ b/master/internal/trial.go
@@ -709,10 +709,12 @@ func (t *trial) processCompletedWorkload(ctx *actor.Context, msg workload.Comple
 		ctx.Tell(ctx.Self().Parent(), sendNextWorkload{runID: t.RunID})
 		return nil
 	default:
-		if err := t.tellWithSnapshot(ctx, ctx.Self().Parent(), func(s trialSnapshot) interface{} {
-			return s
-		}); err != nil {
-			return errors.Wrap(err, "failed to report snapshot")
+		if msg.CheckpointMetrics != nil {
+			if err := t.tellWithSnapshot(ctx, ctx.Self().Parent(), func(s trialSnapshot) interface{} {
+				return s
+			}); err != nil {
+				return errors.Wrap(err, "failed to report snapshot")
+			}
 		}
 		return t.sendNextWorkload(ctx)
 	}


### PR DESCRIPTION
## Description
This fixes a bug where we only took trial snapshots on searcher related events. This sounds right from the searcher point of view.. but the snapshots are also how we restore the workload sequencer state, so this caused us to lose all kinds of state on failures.
<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan
- [x] test with a live cluster by running mnist with checkpoint_period = 100, kill after N 100 batches or so and blip the master. the job should resume about where it left off, not from the beginning.
<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)
Oops. I removed a message but I forgot it had a snapshot attached..
<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234