### PR TITLE
feat: add the ability to set job priorities on the fly [DET-5863]

### DIFF
--- a/docs/release-notes/2834-set-priority.txt
+++ b/docs/release-notes/2834-set-priority.txt
@@ -1,0 +1,6 @@
+:orphan:
+
+**New Features**
+
+-  Support changing task priorities using the ``det experiment/command/notebook/tensorboard/shell
+   set priority`` commands.

--- a/harness/determined/cli/command.py
+++ b/harness/determined/cli/command.py
@@ -163,6 +163,19 @@ def kill(args: Namespace) -> None:
 
 
 @authentication.required
+def set_priority(args: Namespace) -> None:
+    id = RemoteTaskGetIDsFunc[args._command](args)  # type: ignore
+    name = RemoteTaskName[args._command]
+
+    try:
+        api_full_path = "api/v1/{}/{}/set_priority".format(RemoteTaskNewAPIs[args._command], id)
+        api.post(args.master, api_full_path, {"priority": args.priority})
+        print(colored("Set priority of {} {} to {}".format(name, id, args.priority), "green"))
+    except api.errors.APIException as e:
+        print(colored("Skipping: {} ({})".format(e, type(e).__name__), "red"))
+
+
+@authentication.required
 def config(args: Namespace) -> None:
     api_full_path = "api/v1/{}/{}".format(RemoteTaskNewAPIs[args._command], args.id)
     res_json = api.get(args.master, api_full_path).json()

--- a/harness/determined/cli/experiment.py
+++ b/harness/determined/cli/experiment.py
@@ -564,6 +564,12 @@ def set_weight(args: Namespace) -> None:
 
 
 @authentication.required
+def set_priority(args: Namespace) -> None:
+    patch_experiment(args, "change `priority` of", {"resources": {"priority": args.priority}})
+    print("Set `priority` of experiment {} to {}".format(args.experiment_id, args.priority))
+
+
+@authentication.required
 def set_gc_policy(args: Namespace) -> None:
     policy = {
         "save_experiment_best": args.save_experiment_best,
@@ -960,6 +966,15 @@ args_description = Cmd(
                     [
                         experiment_id_arg("experiment ID to modify"),
                         Arg("weight", type=float, help="weight"),
+                    ],
+                ),
+                Cmd(
+                    "priority",
+                    set_priority,
+                    "set `priority` of experiment",
+                    [
+                        experiment_id_arg("experiment ID to modify"),
+                        Arg("priority", type=int, help="priority"),
                     ],
                 ),
             ],

--- a/harness/determined/cli/notebook.py
+++ b/harness/determined/cli/notebook.py
@@ -103,6 +103,12 @@ args_description = [
             Arg("notebook_id", help="notebook ID", nargs=ONE_OR_MORE),
             Arg("-f", "--force", action="store_true", help="ignore errors"),
         ]),
+        Cmd("set", None, "set notebook attributes", [
+            Cmd("priority", command.set_priority, "set notebook priority", [
+                Arg("notebook_id", help="notebook ID"),
+                Arg("priority", type=int, help="priority"),
+            ]),
+        ]),
     ])
 ]  # type: List[Any]
 

--- a/harness/determined/cli/remote.py
+++ b/harness/determined/cli/remote.py
@@ -79,6 +79,12 @@ args_description = [
             Arg("command_id", help="command ID", nargs=ONE_OR_MORE),
             Arg("-f", "--force", action="store_true", help="ignore errors"),
         ]),
+        Cmd("set", None, "set command attributes", [
+            Cmd("priority", command.set_priority, "set command priority", [
+                Arg("command_id", help="command ID"),
+                Arg("priority", type=int, help="priority"),
+            ]),
+        ]),
     ])
 ]  # type: List[Any]
 

--- a/harness/determined/cli/shell.py
+++ b/harness/determined/cli/shell.py
@@ -223,6 +223,12 @@ args_description = [
             Arg("shell_id", help="shell ID", nargs=ONE_OR_MORE),
             Arg("-f", "--force", action="store_true", help="ignore errors"),
         ]),
+        Cmd("set", None, "set shell attributes", [
+            Cmd("priority", command.set_priority, "set shell priority", [
+                Arg("shell_id", help="shell ID"),
+                Arg("priority", type=int, help="priority"),
+            ]),
+        ]),
     ])
 ]  # type: List[Any]
 

--- a/harness/determined/cli/tensorboard.py
+++ b/harness/determined/cli/tensorboard.py
@@ -114,6 +114,12 @@ args_description = [
             Arg("tensorboard_id", help="TensorBoard ID", nargs=ONE_OR_MORE),
             Arg("-f", "--force", action="store_true", help="ignore errors"),
         ]),
+        Cmd("set", None, "set TensorBoard attributes", [
+            Cmd("priority", command.set_priority, "set TensorBoard priority", [
+                Arg("tensorboard_id", help="TensorBoard ID"),
+                Arg("priority", type=int, help="priority"),
+            ]),
+        ]),
     ])
 ]  # type: List[Any]
 

--- a/master/internal/api_command.go
+++ b/master/internal/api_command.go
@@ -162,6 +162,12 @@ func (a *apiServer) KillCommand(
 	return resp, a.actorRequest(fmt.Sprintf("/commands/%s", req.CommandId), req, &resp)
 }
 
+func (a *apiServer) SetCommandPriority(
+	_ context.Context, req *apiv1.SetCommandPriorityRequest,
+) (resp *apiv1.SetCommandPriorityResponse, err error) {
+	return resp, a.actorRequest(fmt.Sprintf("/commands/%s", req.CommandId), req, &resp)
+}
+
 func (a *apiServer) LaunchCommand(
 	ctx context.Context, req *apiv1.LaunchCommandRequest,
 ) (*apiv1.LaunchCommandResponse, error) {

--- a/master/internal/api_notebook.go
+++ b/master/internal/api_notebook.go
@@ -63,6 +63,12 @@ func (a *apiServer) KillNotebook(
 	return resp, a.actorRequest(fmt.Sprintf("/notebooks/%s", req.NotebookId), req, &resp)
 }
 
+func (a *apiServer) SetNotebookPriority(
+	_ context.Context, req *apiv1.SetNotebookPriorityRequest,
+) (resp *apiv1.SetNotebookPriorityResponse, err error) {
+	return resp, a.actorRequest(fmt.Sprintf("/notebooks/%s", req.NotebookId), req, &resp)
+}
+
 func (a *apiServer) NotebookLogs(
 	req *apiv1.NotebookLogsRequest, resp apiv1.Determined_NotebookLogsServer) error {
 	if err := grpcutil.ValidateRequest(

--- a/master/internal/api_shell.go
+++ b/master/internal/api_shell.go
@@ -57,6 +57,12 @@ func (a *apiServer) KillShell(
 	return resp, a.actorRequest(fmt.Sprintf("/shells/%s", req.ShellId), req, &resp)
 }
 
+func (a *apiServer) SetShellPriority(
+	_ context.Context, req *apiv1.SetShellPriorityRequest,
+) (resp *apiv1.SetShellPriorityResponse, err error) {
+	return resp, a.actorRequest(fmt.Sprintf("/shells/%s", req.ShellId), req, &resp)
+}
+
 func (a *apiServer) LaunchShell(
 	ctx context.Context, req *apiv1.LaunchShellRequest,
 ) (*apiv1.LaunchShellResponse, error) {

--- a/master/internal/api_tensorboard.go
+++ b/master/internal/api_tensorboard.go
@@ -85,6 +85,12 @@ func (a *apiServer) KillTensorboard(
 	return resp, a.actorRequest(tensorboardsAddr.Child(req.TensorboardId).String(), req, &resp)
 }
 
+func (a *apiServer) SetTensorboardPriority(
+	_ context.Context, req *apiv1.SetTensorboardPriorityRequest,
+) (resp *apiv1.SetTensorboardPriorityResponse, err error) {
+	return resp, a.actorRequest(tensorboardsAddr.Child(req.TensorboardId).String(), req, &resp)
+}
+
 func (a *apiServer) LaunchTensorboard(
 	ctx context.Context, req *apiv1.LaunchTensorboardRequest,
 ) (*apiv1.LaunchTensorboardResponse, error) {

--- a/master/internal/core_experiment.go
+++ b/master/internal/core_experiment.go
@@ -247,6 +247,7 @@ func (m *Master) patchExperiment(c echo.Context) (interface{}, error) {
 		Resources *struct {
 			MaxSlots api.MaybeInt `json:"max_slots"`
 			Weight   *float64     `json:"weight"`
+			Priority *int         `json:"priority"`
 		} `json:"resources"`
 		CheckpointStorage *struct {
 			SaveExperimentBest int `json:"save_experiment_best"`
@@ -286,6 +287,9 @@ func (m *Master) patchExperiment(c echo.Context) (interface{}, error) {
 		}
 		if patch.Resources.Weight != nil {
 			resources.SetWeight(*patch.Resources.Weight)
+		}
+		if patch.Resources.Priority != nil {
+			resources.SetPriority(patch.Resources.Priority)
 		}
 		dbExp.Config.SetResources(resources)
 	}
@@ -329,6 +333,10 @@ func (m *Master) patchExperiment(c echo.Context) (interface{}, error) {
 		if patch.Resources.Weight != nil {
 			m.system.TellAt(actor.Addr("experiments", args.ExperimentID),
 				sproto.SetGroupWeight{Weight: *patch.Resources.Weight})
+		}
+		if patch.Resources.Priority != nil {
+			m.system.TellAt(actor.Addr("experiments", args.ExperimentID),
+				sproto.SetGroupPriority{Priority: patch.Resources.Priority})
 		}
 	}
 

--- a/master/internal/experiment.go
+++ b/master/internal/experiment.go
@@ -284,6 +284,12 @@ func (e *experiment) Receive(ctx *actor.Context) error {
 		e.Config.SetResources(resources)
 		msg.Handler = ctx.Self()
 		ctx.Tell(e.rm, msg)
+	case sproto.SetGroupPriority:
+		resources := e.Config.Resources()
+		resources.SetPriority(msg.Priority)
+		e.Config.SetResources(resources)
+		msg.Handler = ctx.Self()
+		ctx.Tell(e.rm, msg)
 
 	// Experiment shutdown logic.
 	case actor.PostStop:

--- a/master/internal/resourcemanagers/priority.go
+++ b/master/internal/resourcemanagers/priority.go
@@ -162,12 +162,7 @@ func trySchedulingTaskViaPreemption(
 	log.Debugf("trying to schedule task %s by preempting other tasks", allocationRequest.Name)
 
 	for priority := model.MaxUserSchedulingPriority; priority > allocationPriority; priority-- {
-		if _, ok := priorityToScheduledTaskMap[priority]; !ok {
-			continue
-		}
-
-		preemptionCandidates := priorityToScheduledTaskMap[priority]
-		for _, preemptionCandidate := range preemptionCandidates {
+		for _, preemptionCandidate := range priorityToScheduledTaskMap[priority] {
 			if preemptionCandidate.NonPreemptible || !filter(preemptionCandidate) {
 				continue
 			}

--- a/proto/src/determined/api/v1/api.proto
+++ b/proto/src/determined/api/v1/api.proto
@@ -683,6 +683,17 @@ service Determined {
       tags: "Notebooks"
     };
   }
+  // Set the priority of the requested notebook.
+  rpc SetNotebookPriority(SetNotebookPriorityRequest)
+      returns (SetNotebookPriorityResponse) {
+    option (google.api.http) = {
+      post: "/api/v1/notebooks/{notebook_id}/set_priority"
+      body: "*"
+    };
+    option (grpc.gateway.protoc_gen_swagger.options.openapiv2_operation) = {
+      tags: "Notebooks"
+    };
+  }
   // Stream notebook logs.
   rpc NotebookLogs(NotebookLogsRequest) returns (stream NotebookLogsResponse) {
     option (google.api.http) = {
@@ -730,6 +741,17 @@ service Determined {
       tags: "Shells"
     };
   }
+  // Set the priority of the requested shell.
+  rpc SetShellPriority(SetShellPriorityRequest)
+      returns (SetShellPriorityResponse) {
+    option (google.api.http) = {
+      post: "/api/v1/shells/{shell_id}/set_priority"
+      body: "*"
+    };
+    option (grpc.gateway.protoc_gen_swagger.options.openapiv2_operation) = {
+      tags: "Shells"
+    };
+  }
   // Launch a shell.
   rpc LaunchShell(LaunchShellRequest) returns (LaunchShellResponse) {
     option (google.api.http) = {
@@ -763,6 +785,17 @@ service Determined {
   rpc KillCommand(KillCommandRequest) returns (KillCommandResponse) {
     option (google.api.http) = {
       post: "/api/v1/commands/{command_id}/kill"
+    };
+    option (grpc.gateway.protoc_gen_swagger.options.openapiv2_operation) = {
+      tags: "Commands"
+    };
+  }
+  // Set the priority of the requested command.
+  rpc SetCommandPriority(SetCommandPriorityRequest)
+      returns (SetCommandPriorityResponse) {
+    option (google.api.http) = {
+      post: "/api/v1/commands/{command_id}/set_priority"
+      body: "*"
     };
     option (grpc.gateway.protoc_gen_swagger.options.openapiv2_operation) = {
       tags: "Commands"
@@ -803,6 +836,17 @@ service Determined {
       returns (KillTensorboardResponse) {
     option (google.api.http) = {
       post: "/api/v1/tensorboards/{tensorboard_id}/kill"
+    };
+    option (grpc.gateway.protoc_gen_swagger.options.openapiv2_operation) = {
+      tags: "Tensorboards"
+    };
+  }
+  // Set the priority of the requested TensorBoard.
+  rpc SetTensorboardPriority(SetTensorboardPriorityRequest)
+      returns (SetTensorboardPriorityResponse) {
+    option (google.api.http) = {
+      post: "/api/v1/tensorboards/{tensorboard_id}/set_priority"
+      body: "*"
     };
     option (grpc.gateway.protoc_gen_swagger.options.openapiv2_operation) = {
       tags: "Tensorboards"

--- a/proto/src/determined/api/v1/command.proto
+++ b/proto/src/determined/api/v1/command.proto
@@ -67,6 +67,19 @@ message KillCommandResponse {
   determined.command.v1.Command command = 1;
 }
 
+// Set the priority of the requested command.
+message SetCommandPriorityRequest {
+  // The id of the command.
+  string command_id = 1;
+  // The new priority.
+  int32 priority = 2;
+}
+// Response to SetCommandPriorityRequest.
+message SetCommandPriorityResponse {
+  // The requested command.
+  determined.command.v1.Command command = 1;
+}
+
 // Request to launch a command.
 message LaunchCommandRequest {
   // Command config (JSON).

--- a/proto/src/determined/api/v1/notebook.proto
+++ b/proto/src/determined/api/v1/notebook.proto
@@ -68,6 +68,19 @@ message KillNotebookResponse {
   determined.notebook.v1.Notebook notebook = 1;
 }
 
+// Set the priority of the requested notebook.
+message SetNotebookPriorityRequest {
+  // The id of the notebook.
+  string notebook_id = 1;
+  // The new priority.
+  int32 priority = 2;
+}
+// Response to SetNotebookPriorityRequest.
+message SetNotebookPriorityResponse {
+  // The requested notebook.
+  determined.notebook.v1.Notebook notebook = 1;
+}
+
 // Stream notebook logs.
 message NotebookLogsRequest {
   // Requested Notebook id.

--- a/proto/src/determined/api/v1/shell.proto
+++ b/proto/src/determined/api/v1/shell.proto
@@ -67,6 +67,19 @@ message KillShellResponse {
   determined.shell.v1.Shell shell = 1;
 }
 
+// Set the priority of the requested shell.
+message SetShellPriorityRequest {
+  // The id of the shell.
+  string shell_id = 1;
+  // The new priority.
+  int32 priority = 2;
+}
+// Response to SetShellPriorityRequest.
+message SetShellPriorityResponse {
+  // The requested shell.
+  determined.shell.v1.Shell shell = 1;
+}
+
 // Request to launch a shell.
 message LaunchShellRequest {
   // Shell config (JSON).

--- a/proto/src/determined/api/v1/tensorboard.proto
+++ b/proto/src/determined/api/v1/tensorboard.proto
@@ -68,6 +68,19 @@ message KillTensorboardResponse {
   determined.tensorboard.v1.Tensorboard tensorboard = 1;
 }
 
+// Set the priority of the requested TensorBoard.
+message SetTensorboardPriorityRequest {
+  // The id of the TensorBoard.
+  string tensorboard_id = 1;
+  // The new priority.
+  int32 priority = 2;
+}
+// Response to SetTensorboardPriorityRequest.
+message SetTensorboardPriorityResponse {
+  // The requested Tensorboard.
+  determined.tensorboard.v1.Tensorboard tensorboard = 1;
+}
+
 // Request to launch a tensorboard.
 message LaunchTensorboardRequest {
   // List of source experiment ids.

--- a/webui/react/src/services/api-ts-sdk/api.ts
+++ b/webui/react/src/services/api-ts-sdk/api.ts
@@ -4036,6 +4036,142 @@ export interface V1SearcherOperation {
 }
 
 /**
+ * Set the priority of the requested command.
+ * @export
+ * @interface V1SetCommandPriorityRequest
+ */
+export interface V1SetCommandPriorityRequest {
+    /**
+     * The id of the command.
+     * @type {string}
+     * @memberof V1SetCommandPriorityRequest
+     */
+    commandId?: string;
+    /**
+     * The new priority.
+     * @type {number}
+     * @memberof V1SetCommandPriorityRequest
+     */
+    priority?: number;
+}
+
+/**
+ * Response to SetCommandPriorityRequest.
+ * @export
+ * @interface V1SetCommandPriorityResponse
+ */
+export interface V1SetCommandPriorityResponse {
+    /**
+     * The requested command.
+     * @type {V1Command}
+     * @memberof V1SetCommandPriorityResponse
+     */
+    command?: V1Command;
+}
+
+/**
+ * Set the priority of the requested notebook.
+ * @export
+ * @interface V1SetNotebookPriorityRequest
+ */
+export interface V1SetNotebookPriorityRequest {
+    /**
+     * The id of the notebook.
+     * @type {string}
+     * @memberof V1SetNotebookPriorityRequest
+     */
+    notebookId?: string;
+    /**
+     * The new priority.
+     * @type {number}
+     * @memberof V1SetNotebookPriorityRequest
+     */
+    priority?: number;
+}
+
+/**
+ * Response to SetNotebookPriorityRequest.
+ * @export
+ * @interface V1SetNotebookPriorityResponse
+ */
+export interface V1SetNotebookPriorityResponse {
+    /**
+     * The requested notebook.
+     * @type {V1Notebook}
+     * @memberof V1SetNotebookPriorityResponse
+     */
+    notebook?: V1Notebook;
+}
+
+/**
+ * Set the priority of the requested shell.
+ * @export
+ * @interface V1SetShellPriorityRequest
+ */
+export interface V1SetShellPriorityRequest {
+    /**
+     * The id of the shell.
+     * @type {string}
+     * @memberof V1SetShellPriorityRequest
+     */
+    shellId?: string;
+    /**
+     * The new priority.
+     * @type {number}
+     * @memberof V1SetShellPriorityRequest
+     */
+    priority?: number;
+}
+
+/**
+ * Response to SetShellPriorityRequest.
+ * @export
+ * @interface V1SetShellPriorityResponse
+ */
+export interface V1SetShellPriorityResponse {
+    /**
+     * The requested shell.
+     * @type {V1Shell}
+     * @memberof V1SetShellPriorityResponse
+     */
+    shell?: V1Shell;
+}
+
+/**
+ * Set the priority of the requested TensorBoard.
+ * @export
+ * @interface V1SetTensorboardPriorityRequest
+ */
+export interface V1SetTensorboardPriorityRequest {
+    /**
+     * The id of the TensorBoard.
+     * @type {string}
+     * @memberof V1SetTensorboardPriorityRequest
+     */
+    tensorboardId?: string;
+    /**
+     * The new priority.
+     * @type {number}
+     * @memberof V1SetTensorboardPriorityRequest
+     */
+    priority?: number;
+}
+
+/**
+ * Response to SetTensorboardPriorityRequest.
+ * @export
+ * @interface V1SetTensorboardPriorityResponse
+ */
+export interface V1SetTensorboardPriorityResponse {
+    /**
+     * The requested Tensorboard.
+     * @type {V1Tensorboard}
+     * @memberof V1SetTensorboardPriorityResponse
+     */
+    tensorboard?: V1Tensorboard;
+}
+
+/**
  * Response to SetUserPasswordRequest.
  * @export
  * @interface V1SetUserPasswordResponse
@@ -6686,6 +6822,52 @@ export const CommandsApiFetchParamCreator = function (configuration?: Configurat
                 options: localVarRequestOptions,
             };
         },
+        /**
+         * 
+         * @summary Set the priority of the requested command.
+         * @param {string} commandId The id of the command.
+         * @param {V1SetCommandPriorityRequest} body 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        determinedSetCommandPriority(commandId: string, body: V1SetCommandPriorityRequest, options: any = {}): FetchArgs {
+            // verify required parameter 'commandId' is not null or undefined
+            if (commandId === null || commandId === undefined) {
+                throw new RequiredError('commandId','Required parameter commandId was null or undefined when calling determinedSetCommandPriority.');
+            }
+            // verify required parameter 'body' is not null or undefined
+            if (body === null || body === undefined) {
+                throw new RequiredError('body','Required parameter body was null or undefined when calling determinedSetCommandPriority.');
+            }
+            const localVarPath = `/api/v1/commands/{commandId}/set_priority`
+                .replace(`{${"commandId"}}`, encodeURIComponent(String(commandId)));
+            const localVarUrlObj = url.parse(localVarPath, true);
+            const localVarRequestOptions = Object.assign({ method: 'POST' }, options);
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            // authentication BearerToken required
+            if (configuration && configuration.apiKey) {
+                const localVarApiKeyValue = typeof configuration.apiKey === 'function'
+					? configuration.apiKey("Authorization")
+					: configuration.apiKey;
+                localVarHeaderParameter["Authorization"] = localVarApiKeyValue;
+            }
+
+            localVarHeaderParameter['Content-Type'] = 'application/json';
+
+            localVarUrlObj.query = Object.assign({}, localVarUrlObj.query, localVarQueryParameter, options.query);
+            // fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
+            delete localVarUrlObj.search;
+            localVarRequestOptions.headers = Object.assign({}, localVarHeaderParameter, options.headers);
+            const needsSerialization = (<any>"V1SetCommandPriorityRequest" !== "string") || localVarRequestOptions.headers['Content-Type'] === 'application/json';
+            localVarRequestOptions.body =  needsSerialization ? JSON.stringify(body || {}) : (body || "");
+
+            return {
+                url: url.format(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
     }
 };
 
@@ -6775,6 +6957,26 @@ export const CommandsApiFp = function(configuration?: Configuration) {
                 });
             };
         },
+        /**
+         * 
+         * @summary Set the priority of the requested command.
+         * @param {string} commandId The id of the command.
+         * @param {V1SetCommandPriorityRequest} body 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        determinedSetCommandPriority(commandId: string, body: V1SetCommandPriorityRequest, options?: any): (fetch?: FetchAPI, basePath?: string) => Promise<V1SetCommandPriorityResponse> {
+            const localVarFetchArgs = CommandsApiFetchParamCreator(configuration).determinedSetCommandPriority(commandId, body, options);
+            return (fetch: FetchAPI = portableFetch, basePath: string = BASE_PATH) => {
+                return fetch(basePath + localVarFetchArgs.url, localVarFetchArgs.options).then((response) => {
+                    if (response.status >= 200 && response.status < 300) {
+                        return response.json();
+                    } else {
+                        throw response;
+                    }
+                });
+            };
+        },
     }
 };
 
@@ -6827,6 +7029,17 @@ export const CommandsApiFactory = function (configuration?: Configuration, fetch
          */
         determinedLaunchCommand(body: V1LaunchCommandRequest, options?: any) {
             return CommandsApiFp(configuration).determinedLaunchCommand(body, options)(fetch, basePath);
+        },
+        /**
+         * 
+         * @summary Set the priority of the requested command.
+         * @param {string} commandId The id of the command.
+         * @param {V1SetCommandPriorityRequest} body 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        determinedSetCommandPriority(commandId: string, body: V1SetCommandPriorityRequest, options?: any) {
+            return CommandsApiFp(configuration).determinedSetCommandPriority(commandId, body, options)(fetch, basePath);
         },
     };
 };
@@ -6888,6 +7101,19 @@ export class CommandsApi extends BaseAPI {
      */
     public determinedLaunchCommand(body: V1LaunchCommandRequest, options?: any) {
         return CommandsApiFp(this.configuration).determinedLaunchCommand(body, options)(this.fetch, this.basePath);
+    }
+
+    /**
+     * 
+     * @summary Set the priority of the requested command.
+     * @param {string} commandId The id of the command.
+     * @param {V1SetCommandPriorityRequest} body 
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof CommandsApi
+     */
+    public determinedSetCommandPriority(commandId: string, body: V1SetCommandPriorityRequest, options?: any) {
+        return CommandsApiFp(this.configuration).determinedSetCommandPriority(commandId, body, options)(this.fetch, this.basePath);
     }
 
 }
@@ -11638,6 +11864,52 @@ export const NotebooksApiFetchParamCreator = function (configuration?: Configura
                 options: localVarRequestOptions,
             };
         },
+        /**
+         * 
+         * @summary Set the priority of the requested notebook.
+         * @param {string} notebookId The id of the notebook.
+         * @param {V1SetNotebookPriorityRequest} body 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        determinedSetNotebookPriority(notebookId: string, body: V1SetNotebookPriorityRequest, options: any = {}): FetchArgs {
+            // verify required parameter 'notebookId' is not null or undefined
+            if (notebookId === null || notebookId === undefined) {
+                throw new RequiredError('notebookId','Required parameter notebookId was null or undefined when calling determinedSetNotebookPriority.');
+            }
+            // verify required parameter 'body' is not null or undefined
+            if (body === null || body === undefined) {
+                throw new RequiredError('body','Required parameter body was null or undefined when calling determinedSetNotebookPriority.');
+            }
+            const localVarPath = `/api/v1/notebooks/{notebookId}/set_priority`
+                .replace(`{${"notebookId"}}`, encodeURIComponent(String(notebookId)));
+            const localVarUrlObj = url.parse(localVarPath, true);
+            const localVarRequestOptions = Object.assign({ method: 'POST' }, options);
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            // authentication BearerToken required
+            if (configuration && configuration.apiKey) {
+                const localVarApiKeyValue = typeof configuration.apiKey === 'function'
+					? configuration.apiKey("Authorization")
+					: configuration.apiKey;
+                localVarHeaderParameter["Authorization"] = localVarApiKeyValue;
+            }
+
+            localVarHeaderParameter['Content-Type'] = 'application/json';
+
+            localVarUrlObj.query = Object.assign({}, localVarUrlObj.query, localVarQueryParameter, options.query);
+            // fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
+            delete localVarUrlObj.search;
+            localVarRequestOptions.headers = Object.assign({}, localVarHeaderParameter, options.headers);
+            const needsSerialization = (<any>"V1SetNotebookPriorityRequest" !== "string") || localVarRequestOptions.headers['Content-Type'] === 'application/json';
+            localVarRequestOptions.body =  needsSerialization ? JSON.stringify(body || {}) : (body || "");
+
+            return {
+                url: url.format(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
     }
 };
 
@@ -11749,6 +12021,26 @@ export const NotebooksApiFp = function(configuration?: Configuration) {
                 });
             };
         },
+        /**
+         * 
+         * @summary Set the priority of the requested notebook.
+         * @param {string} notebookId The id of the notebook.
+         * @param {V1SetNotebookPriorityRequest} body 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        determinedSetNotebookPriority(notebookId: string, body: V1SetNotebookPriorityRequest, options?: any): (fetch?: FetchAPI, basePath?: string) => Promise<V1SetNotebookPriorityResponse> {
+            const localVarFetchArgs = NotebooksApiFetchParamCreator(configuration).determinedSetNotebookPriority(notebookId, body, options);
+            return (fetch: FetchAPI = portableFetch, basePath: string = BASE_PATH) => {
+                return fetch(basePath + localVarFetchArgs.url, localVarFetchArgs.options).then((response) => {
+                    if (response.status >= 200 && response.status < 300) {
+                        return response.json();
+                    } else {
+                        throw response;
+                    }
+                });
+            };
+        },
     }
 };
 
@@ -11814,6 +12106,17 @@ export const NotebooksApiFactory = function (configuration?: Configuration, fetc
          */
         determinedNotebookLogs(notebookId: string, offset?: number, limit?: number, follow?: boolean, options?: any) {
             return NotebooksApiFp(configuration).determinedNotebookLogs(notebookId, offset, limit, follow, options)(fetch, basePath);
+        },
+        /**
+         * 
+         * @summary Set the priority of the requested notebook.
+         * @param {string} notebookId The id of the notebook.
+         * @param {V1SetNotebookPriorityRequest} body 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        determinedSetNotebookPriority(notebookId: string, body: V1SetNotebookPriorityRequest, options?: any) {
+            return NotebooksApiFp(configuration).determinedSetNotebookPriority(notebookId, body, options)(fetch, basePath);
         },
     };
 };
@@ -11890,6 +12193,19 @@ export class NotebooksApi extends BaseAPI {
      */
     public determinedNotebookLogs(notebookId: string, offset?: number, limit?: number, follow?: boolean, options?: any) {
         return NotebooksApiFp(this.configuration).determinedNotebookLogs(notebookId, offset, limit, follow, options)(this.fetch, this.basePath);
+    }
+
+    /**
+     * 
+     * @summary Set the priority of the requested notebook.
+     * @param {string} notebookId The id of the notebook.
+     * @param {V1SetNotebookPriorityRequest} body 
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof NotebooksApi
+     */
+    public determinedSetNotebookPriority(notebookId: string, body: V1SetNotebookPriorityRequest, options?: any) {
+        return NotebooksApiFp(this.configuration).determinedSetNotebookPriority(notebookId, body, options)(this.fetch, this.basePath);
     }
 
 }
@@ -12310,6 +12626,52 @@ export const ShellsApiFetchParamCreator = function (configuration?: Configuratio
                 options: localVarRequestOptions,
             };
         },
+        /**
+         * 
+         * @summary Set the priority of the requested shell.
+         * @param {string} shellId The id of the shell.
+         * @param {V1SetShellPriorityRequest} body 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        determinedSetShellPriority(shellId: string, body: V1SetShellPriorityRequest, options: any = {}): FetchArgs {
+            // verify required parameter 'shellId' is not null or undefined
+            if (shellId === null || shellId === undefined) {
+                throw new RequiredError('shellId','Required parameter shellId was null or undefined when calling determinedSetShellPriority.');
+            }
+            // verify required parameter 'body' is not null or undefined
+            if (body === null || body === undefined) {
+                throw new RequiredError('body','Required parameter body was null or undefined when calling determinedSetShellPriority.');
+            }
+            const localVarPath = `/api/v1/shells/{shellId}/set_priority`
+                .replace(`{${"shellId"}}`, encodeURIComponent(String(shellId)));
+            const localVarUrlObj = url.parse(localVarPath, true);
+            const localVarRequestOptions = Object.assign({ method: 'POST' }, options);
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            // authentication BearerToken required
+            if (configuration && configuration.apiKey) {
+                const localVarApiKeyValue = typeof configuration.apiKey === 'function'
+					? configuration.apiKey("Authorization")
+					: configuration.apiKey;
+                localVarHeaderParameter["Authorization"] = localVarApiKeyValue;
+            }
+
+            localVarHeaderParameter['Content-Type'] = 'application/json';
+
+            localVarUrlObj.query = Object.assign({}, localVarUrlObj.query, localVarQueryParameter, options.query);
+            // fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
+            delete localVarUrlObj.search;
+            localVarRequestOptions.headers = Object.assign({}, localVarHeaderParameter, options.headers);
+            const needsSerialization = (<any>"V1SetShellPriorityRequest" !== "string") || localVarRequestOptions.headers['Content-Type'] === 'application/json';
+            localVarRequestOptions.body =  needsSerialization ? JSON.stringify(body || {}) : (body || "");
+
+            return {
+                url: url.format(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
     }
 };
 
@@ -12399,6 +12761,26 @@ export const ShellsApiFp = function(configuration?: Configuration) {
                 });
             };
         },
+        /**
+         * 
+         * @summary Set the priority of the requested shell.
+         * @param {string} shellId The id of the shell.
+         * @param {V1SetShellPriorityRequest} body 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        determinedSetShellPriority(shellId: string, body: V1SetShellPriorityRequest, options?: any): (fetch?: FetchAPI, basePath?: string) => Promise<V1SetShellPriorityResponse> {
+            const localVarFetchArgs = ShellsApiFetchParamCreator(configuration).determinedSetShellPriority(shellId, body, options);
+            return (fetch: FetchAPI = portableFetch, basePath: string = BASE_PATH) => {
+                return fetch(basePath + localVarFetchArgs.url, localVarFetchArgs.options).then((response) => {
+                    if (response.status >= 200 && response.status < 300) {
+                        return response.json();
+                    } else {
+                        throw response;
+                    }
+                });
+            };
+        },
     }
 };
 
@@ -12451,6 +12833,17 @@ export const ShellsApiFactory = function (configuration?: Configuration, fetch?:
          */
         determinedLaunchShell(body: V1LaunchShellRequest, options?: any) {
             return ShellsApiFp(configuration).determinedLaunchShell(body, options)(fetch, basePath);
+        },
+        /**
+         * 
+         * @summary Set the priority of the requested shell.
+         * @param {string} shellId The id of the shell.
+         * @param {V1SetShellPriorityRequest} body 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        determinedSetShellPriority(shellId: string, body: V1SetShellPriorityRequest, options?: any) {
+            return ShellsApiFp(configuration).determinedSetShellPriority(shellId, body, options)(fetch, basePath);
         },
     };
 };
@@ -12512,6 +12905,19 @@ export class ShellsApi extends BaseAPI {
      */
     public determinedLaunchShell(body: V1LaunchShellRequest, options?: any) {
         return ShellsApiFp(this.configuration).determinedLaunchShell(body, options)(this.fetch, this.basePath);
+    }
+
+    /**
+     * 
+     * @summary Set the priority of the requested shell.
+     * @param {string} shellId The id of the shell.
+     * @param {V1SetShellPriorityRequest} body 
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof ShellsApi
+     */
+    public determinedSetShellPriority(shellId: string, body: V1SetShellPriorityRequest, options?: any) {
+        return ShellsApiFp(this.configuration).determinedSetShellPriority(shellId, body, options)(this.fetch, this.basePath);
     }
 
 }
@@ -13083,6 +13489,52 @@ export const TensorboardsApiFetchParamCreator = function (configuration?: Config
                 options: localVarRequestOptions,
             };
         },
+        /**
+         * 
+         * @summary Set the priority of the requested TensorBoard.
+         * @param {string} tensorboardId The id of the TensorBoard.
+         * @param {V1SetTensorboardPriorityRequest} body 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        determinedSetTensorboardPriority(tensorboardId: string, body: V1SetTensorboardPriorityRequest, options: any = {}): FetchArgs {
+            // verify required parameter 'tensorboardId' is not null or undefined
+            if (tensorboardId === null || tensorboardId === undefined) {
+                throw new RequiredError('tensorboardId','Required parameter tensorboardId was null or undefined when calling determinedSetTensorboardPriority.');
+            }
+            // verify required parameter 'body' is not null or undefined
+            if (body === null || body === undefined) {
+                throw new RequiredError('body','Required parameter body was null or undefined when calling determinedSetTensorboardPriority.');
+            }
+            const localVarPath = `/api/v1/tensorboards/{tensorboardId}/set_priority`
+                .replace(`{${"tensorboardId"}}`, encodeURIComponent(String(tensorboardId)));
+            const localVarUrlObj = url.parse(localVarPath, true);
+            const localVarRequestOptions = Object.assign({ method: 'POST' }, options);
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            // authentication BearerToken required
+            if (configuration && configuration.apiKey) {
+                const localVarApiKeyValue = typeof configuration.apiKey === 'function'
+					? configuration.apiKey("Authorization")
+					: configuration.apiKey;
+                localVarHeaderParameter["Authorization"] = localVarApiKeyValue;
+            }
+
+            localVarHeaderParameter['Content-Type'] = 'application/json';
+
+            localVarUrlObj.query = Object.assign({}, localVarUrlObj.query, localVarQueryParameter, options.query);
+            // fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
+            delete localVarUrlObj.search;
+            localVarRequestOptions.headers = Object.assign({}, localVarHeaderParameter, options.headers);
+            const needsSerialization = (<any>"V1SetTensorboardPriorityRequest" !== "string") || localVarRequestOptions.headers['Content-Type'] === 'application/json';
+            localVarRequestOptions.body =  needsSerialization ? JSON.stringify(body || {}) : (body || "");
+
+            return {
+                url: url.format(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
     }
 };
 
@@ -13172,6 +13624,26 @@ export const TensorboardsApiFp = function(configuration?: Configuration) {
                 });
             };
         },
+        /**
+         * 
+         * @summary Set the priority of the requested TensorBoard.
+         * @param {string} tensorboardId The id of the TensorBoard.
+         * @param {V1SetTensorboardPriorityRequest} body 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        determinedSetTensorboardPriority(tensorboardId: string, body: V1SetTensorboardPriorityRequest, options?: any): (fetch?: FetchAPI, basePath?: string) => Promise<V1SetTensorboardPriorityResponse> {
+            const localVarFetchArgs = TensorboardsApiFetchParamCreator(configuration).determinedSetTensorboardPriority(tensorboardId, body, options);
+            return (fetch: FetchAPI = portableFetch, basePath: string = BASE_PATH) => {
+                return fetch(basePath + localVarFetchArgs.url, localVarFetchArgs.options).then((response) => {
+                    if (response.status >= 200 && response.status < 300) {
+                        return response.json();
+                    } else {
+                        throw response;
+                    }
+                });
+            };
+        },
     }
 };
 
@@ -13224,6 +13696,17 @@ export const TensorboardsApiFactory = function (configuration?: Configuration, f
          */
         determinedLaunchTensorboard(body: V1LaunchTensorboardRequest, options?: any) {
             return TensorboardsApiFp(configuration).determinedLaunchTensorboard(body, options)(fetch, basePath);
+        },
+        /**
+         * 
+         * @summary Set the priority of the requested TensorBoard.
+         * @param {string} tensorboardId The id of the TensorBoard.
+         * @param {V1SetTensorboardPriorityRequest} body 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        determinedSetTensorboardPriority(tensorboardId: string, body: V1SetTensorboardPriorityRequest, options?: any) {
+            return TensorboardsApiFp(configuration).determinedSetTensorboardPriority(tensorboardId, body, options)(fetch, basePath);
         },
     };
 };
@@ -13285,6 +13768,19 @@ export class TensorboardsApi extends BaseAPI {
      */
     public determinedLaunchTensorboard(body: V1LaunchTensorboardRequest, options?: any) {
         return TensorboardsApiFp(this.configuration).determinedLaunchTensorboard(body, options)(this.fetch, this.basePath);
+    }
+
+    /**
+     * 
+     * @summary Set the priority of the requested TensorBoard.
+     * @param {string} tensorboardId The id of the TensorBoard.
+     * @param {V1SetTensorboardPriorityRequest} body 
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof TensorboardsApi
+     */
+    public determinedSetTensorboardPriority(tensorboardId: string, body: V1SetTensorboardPriorityRequest, options?: any) {
+        return TensorboardsApiFp(this.configuration).determinedSetTensorboardPriority(tensorboardId, body, options)(this.fetch, this.basePath);
     }
 
 }


### PR DESCRIPTION
## Description

Add `det ... set priority` CLI commands and API support for changing
priorities.

The scheduling algorithm itself already adapted perfectly fine to
changing priorities; all we have to do here is wire up the CLI and API
to let changes be requested from outside.

## Test Plan

- [x] run a cluster with preemption on, start several experiments and play with their priorities, check that the scheduler responds by preempting and scheduling the right things
- [x] check that all the other `det * set priority` commands set the priority

## Commentary

I feel like it's a problem how much repetition it takes to handle all the non-experiment task types...