### PR TITLE
chore: remove some unnecessary conversions and error paths

### DIFF
--- a/master/cmd/determined-master/init.go
+++ b/master/cmd/determined-master/init.go
@@ -23,7 +23,7 @@ var v *viper.Viper
 // already broken and fixes some parts of what was broken that people care about.
 const viperKeyDelimiter = ".."
 
-//nolint:gochecknoinit
+//nolint:gochecknoinits
 func init() {
 	// The version of rootCmd is set in init() rather than when `rootCmd` is initialized,
 	// because link-time variable assignments are not applied when package-scoped variables

--- a/master/internal/api.go
+++ b/master/internal/api.go
@@ -152,12 +152,8 @@ func (a *apiServer) filter(values interface{}, check func(int) bool) {
 	rv.Elem().Set(results)
 }
 
-func (a *apiServer) actorRequest(addr string, req actor.Message, v interface{}) error {
-	actorAddr := actor.Address{}
-	if err := actorAddr.UnmarshalText([]byte(addr)); err != nil {
-		return status.Errorf(codes.InvalidArgument, "/api/v1%s is not a valid path", addr)
-	}
-	resp := a.m.system.AskAt(actorAddr, req)
+func (a *apiServer) actorRequest(addr actor.Address, req actor.Message, v interface{}) error {
+	resp := a.m.system.AskAt(addr, req)
 	if err := api.ProcessActorResponseError(&resp); err != nil {
 		return err
 	}

--- a/master/internal/api/actor.go
+++ b/master/internal/api/actor.go
@@ -24,15 +24,13 @@ func codeFromHTTPStatus(code int) codes.Code {
 // ProcessActorResponseError checks actor resposne for errors.
 func ProcessActorResponseError(resp *actor.Response) error {
 	if (*resp).Empty() {
-		src := (*resp).Source()
 		msg := "actor not found"
-		if src != nil {
+		if src := (*resp).Source(); src != nil {
 			msg = fmt.Sprintf("actor not found: /api/v1%s", src.Address().String())
 		}
 		return status.Error(codes.NotFound, msg)
 	}
 	if err := (*resp).Error(); err != nil {
-		fmt.Println(err)
 		switch typedErr := err.(type) {
 		case *echo.HTTPError:
 			return status.Error(codeFromHTTPStatus(typedErr.Code), typedErr.Error())

--- a/master/internal/api_command.go
+++ b/master/internal/api_command.go
@@ -144,7 +144,7 @@ func (a *apiServer) getCommandLaunchParams(ctx context.Context, req *protoComman
 func (a *apiServer) GetCommands(
 	_ context.Context, req *apiv1.GetCommandsRequest,
 ) (resp *apiv1.GetCommandsResponse, err error) {
-	err = a.actorRequest("/commands", req, &resp)
+	err = a.actorRequest(commandsAddr, req, &resp)
 	if err != nil {
 		return nil, err
 	}
@@ -154,18 +154,18 @@ func (a *apiServer) GetCommands(
 
 func (a *apiServer) GetCommand(
 	_ context.Context, req *apiv1.GetCommandRequest) (resp *apiv1.GetCommandResponse, err error) {
-	return resp, a.actorRequest(fmt.Sprintf("/commands/%s", req.CommandId), req, &resp)
+	return resp, a.actorRequest(commandsAddr.Child(req.CommandId), req, &resp)
 }
 
 func (a *apiServer) KillCommand(
 	_ context.Context, req *apiv1.KillCommandRequest) (resp *apiv1.KillCommandResponse, err error) {
-	return resp, a.actorRequest(fmt.Sprintf("/commands/%s", req.CommandId), req, &resp)
+	return resp, a.actorRequest(commandsAddr.Child(req.CommandId), req, &resp)
 }
 
 func (a *apiServer) SetCommandPriority(
 	_ context.Context, req *apiv1.SetCommandPriorityRequest,
 ) (resp *apiv1.SetCommandPriorityResponse, err error) {
-	return resp, a.actorRequest(fmt.Sprintf("/commands/%s", req.CommandId), req, &resp)
+	return resp, a.actorRequest(commandsAddr.Child(req.CommandId), req, &resp)
 }
 
 func (a *apiServer) LaunchCommand(

--- a/master/internal/api_experiment.go
+++ b/master/internal/api_experiment.go
@@ -410,7 +410,7 @@ func (a *apiServer) ActivateExperiment(
 		return nil, err
 	}
 
-	addr := experimentsAddr.Child(req.Id).String()
+	addr := experimentsAddr.Child(req.Id)
 	switch err = a.actorRequest(addr, req, &resp); {
 	case status.Code(err) == codes.NotFound:
 		return nil, status.Error(codes.FailedPrecondition, "experiment in terminal state")
@@ -428,7 +428,7 @@ func (a *apiServer) PauseExperiment(
 		return nil, err
 	}
 
-	addr := experimentsAddr.Child(req.Id).String()
+	addr := experimentsAddr.Child(req.Id)
 	switch err = a.actorRequest(addr, req, &resp); {
 	case status.Code(err) == codes.NotFound:
 		return nil, status.Error(codes.FailedPrecondition, "experiment in terminal state")
@@ -446,7 +446,7 @@ func (a *apiServer) CancelExperiment(
 		return nil, err
 	}
 
-	addr := experimentsAddr.Child(req.Id).String()
+	addr := experimentsAddr.Child(req.Id)
 	err = a.actorRequest(addr, req, &resp)
 	if status.Code(err) == codes.NotFound {
 		return &apiv1.CancelExperimentResponse{}, nil
@@ -462,7 +462,7 @@ func (a *apiServer) KillExperiment(
 		return nil, err
 	}
 
-	addr := experimentsAddr.Child(req.Id).String()
+	addr := experimentsAddr.Child(req.Id)
 	err = a.actorRequest(addr, req, &resp)
 	if status.Code(err) == codes.NotFound {
 		return &apiv1.KillExperimentResponse{}, nil
@@ -692,7 +692,7 @@ func (a *apiServer) CreateExperiment(
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to create experiment: %s", err)
 	}
-	a.m.system.ActorOf(actor.Addr("experiments", e.ID), e)
+	a.m.system.ActorOf(experimentsAddr.Child(e.ID), e)
 
 	protoExp, err := a.getExperiment(e.ID)
 	if err != nil {

--- a/master/internal/api_notebook.go
+++ b/master/internal/api_notebook.go
@@ -45,7 +45,7 @@ var notebooksAddr = actor.Addr("notebooks")
 func (a *apiServer) GetNotebooks(
 	_ context.Context, req *apiv1.GetNotebooksRequest,
 ) (resp *apiv1.GetNotebooksResponse, err error) {
-	err = a.actorRequest("/notebooks", req, &resp)
+	err = a.actorRequest(notebooksAddr, req, &resp)
 	if err != nil {
 		return nil, err
 	}
@@ -55,18 +55,18 @@ func (a *apiServer) GetNotebooks(
 
 func (a *apiServer) GetNotebook(
 	_ context.Context, req *apiv1.GetNotebookRequest) (resp *apiv1.GetNotebookResponse, err error) {
-	return resp, a.actorRequest(fmt.Sprintf("/notebooks/%s", req.NotebookId), req, &resp)
+	return resp, a.actorRequest(notebooksAddr.Child(req.NotebookId), req, &resp)
 }
 
 func (a *apiServer) KillNotebook(
 	_ context.Context, req *apiv1.KillNotebookRequest) (resp *apiv1.KillNotebookResponse, err error) {
-	return resp, a.actorRequest(fmt.Sprintf("/notebooks/%s", req.NotebookId), req, &resp)
+	return resp, a.actorRequest(notebooksAddr.Child(req.NotebookId), req, &resp)
 }
 
 func (a *apiServer) SetNotebookPriority(
 	_ context.Context, req *apiv1.SetNotebookPriorityRequest,
 ) (resp *apiv1.SetNotebookPriorityResponse, err error) {
-	return resp, a.actorRequest(fmt.Sprintf("/notebooks/%s", req.NotebookId), req, &resp)
+	return resp, a.actorRequest(notebooksAddr.Child(req.NotebookId), req, &resp)
 }
 
 func (a *apiServer) NotebookLogs(
@@ -77,7 +77,7 @@ func (a *apiServer) NotebookLogs(
 		return err
 	}
 
-	cmdManagerAddr := actor.Addr("notebooks", req.NotebookId)
+	cmdManagerAddr := notebooksAddr.Child(req.NotebookId)
 	eventManager := a.m.system.Get(cmdManagerAddr.Child("events"))
 
 	logRequest := api.BatchRequest{

--- a/master/internal/api_resourcepool.go
+++ b/master/internal/api_resourcepool.go
@@ -15,9 +15,9 @@ func (a *apiServer) GetResourcePools(
 ) (resp *apiv1.GetResourcePoolsResponse, err error) {
 	switch {
 	case sproto.UseAgentRM(a.m.system):
-		err = a.actorRequest(sproto.AgentRMAddr.String(), req, &resp)
+		err = a.actorRequest(sproto.AgentRMAddr, req, &resp)
 	case sproto.UseK8sRM(a.m.system):
-		err = a.actorRequest(sproto.K8sRMAddr.String(), req, &resp)
+		err = a.actorRequest(sproto.K8sRMAddr, req, &resp)
 
 	default:
 		err = status.Error(codes.NotFound, "cannot find appropriate resource manager")

--- a/master/internal/api_shell.go
+++ b/master/internal/api_shell.go
@@ -39,7 +39,7 @@ var shellsAddr = actor.Addr("shells")
 func (a *apiServer) GetShells(
 	_ context.Context, req *apiv1.GetShellsRequest,
 ) (resp *apiv1.GetShellsResponse, err error) {
-	err = a.actorRequest("/shells", req, &resp)
+	err = a.actorRequest(shellsAddr, req, &resp)
 	if err != nil {
 		return nil, err
 	}
@@ -49,18 +49,18 @@ func (a *apiServer) GetShells(
 
 func (a *apiServer) GetShell(
 	_ context.Context, req *apiv1.GetShellRequest) (resp *apiv1.GetShellResponse, err error) {
-	return resp, a.actorRequest(fmt.Sprintf("/shells/%s", req.ShellId), req, &resp)
+	return resp, a.actorRequest(shellsAddr.Child(req.ShellId), req, &resp)
 }
 
 func (a *apiServer) KillShell(
 	_ context.Context, req *apiv1.KillShellRequest) (resp *apiv1.KillShellResponse, err error) {
-	return resp, a.actorRequest(fmt.Sprintf("/shells/%s", req.ShellId), req, &resp)
+	return resp, a.actorRequest(shellsAddr.Child(req.ShellId), req, &resp)
 }
 
 func (a *apiServer) SetShellPriority(
 	_ context.Context, req *apiv1.SetShellPriorityRequest,
 ) (resp *apiv1.SetShellPriorityResponse, err error) {
-	return resp, a.actorRequest(fmt.Sprintf("/shells/%s", req.ShellId), req, &resp)
+	return resp, a.actorRequest(shellsAddr.Child(req.ShellId), req, &resp)
 }
 
 func (a *apiServer) LaunchShell(

--- a/master/internal/api_tensorboard.go
+++ b/master/internal/api_tensorboard.go
@@ -65,7 +65,7 @@ func filesToArchive(files []*utilv1.File) archive.Archive {
 func (a *apiServer) GetTensorboards(
 	_ context.Context, req *apiv1.GetTensorboardsRequest,
 ) (resp *apiv1.GetTensorboardsResponse, err error) {
-	err = a.actorRequest(tensorboardsAddr.String(), req, &resp)
+	err = a.actorRequest(tensorboardsAddr, req, &resp)
 	if err != nil {
 		return nil, err
 	}
@@ -76,19 +76,19 @@ func (a *apiServer) GetTensorboards(
 func (a *apiServer) GetTensorboard(
 	_ context.Context, req *apiv1.GetTensorboardRequest,
 ) (resp *apiv1.GetTensorboardResponse, err error) {
-	return resp, a.actorRequest(tensorboardsAddr.Child(req.TensorboardId).String(), req, &resp)
+	return resp, a.actorRequest(tensorboardsAddr.Child(req.TensorboardId), req, &resp)
 }
 
 func (a *apiServer) KillTensorboard(
 	_ context.Context, req *apiv1.KillTensorboardRequest,
 ) (resp *apiv1.KillTensorboardResponse, err error) {
-	return resp, a.actorRequest(tensorboardsAddr.Child(req.TensorboardId).String(), req, &resp)
+	return resp, a.actorRequest(tensorboardsAddr.Child(req.TensorboardId), req, &resp)
 }
 
 func (a *apiServer) SetTensorboardPriority(
 	_ context.Context, req *apiv1.SetTensorboardPriorityRequest,
 ) (resp *apiv1.SetTensorboardPriorityResponse, err error) {
-	return resp, a.actorRequest(tensorboardsAddr.Child(req.TensorboardId).String(), req, &resp)
+	return resp, a.actorRequest(tensorboardsAddr.Child(req.TensorboardId), req, &resp)
 }
 
 func (a *apiServer) LaunchTensorboard(

--- a/master/internal/api_trials.go
+++ b/master/internal/api_trials.go
@@ -303,8 +303,7 @@ func (a *apiServer) KillTrial(
 	}
 
 	resp := apiv1.KillTrialResponse{}
-	addr := actor.Addr("trials", req.Id).String()
-	err = a.actorRequest(addr, req, &resp)
+	err = a.actorRequest(actor.Addr("trials", req.Id), req, &resp)
 	if status.Code(err) == codes.NotFound {
 		return &apiv1.KillTrialResponse{}, nil
 	}


### PR DESCRIPTION
## Description

- Remove the unused error return from an internal `toNotebook` function,
  bringing it in line with other similar functions nearby.
- Change an internal `actorRequest` function to take an `actor.Addr`
  instead of a string, since it was almost always passed a stringified
  address anyway.
- Expand usage of some predefined address constants.

## Test Plan

- [x] start and stop all the kinds of tasks to make sure the actor addresses still line up
