### PR TITLE
fix: switch container runtime on slot type

### DIFF
--- a/master/pkg/tasks/task.go
+++ b/master/pkg/tasks/task.go
@@ -136,6 +136,8 @@ func (t *TaskSpec) ToDockerSpec() container.Spec {
 		containerRuntime = runc
 	case device.GPU:
 		containerRuntime = nvidiaContainerRuntime
+	default:
+		panic(fmt.Sprintf("bad device type: %s", deviceType))
 	}
 
 	network := t.TaskContainerDefaults.NetworkMode


### PR DESCRIPTION
## Description
Previous we set the default container runtime to `nvidia` regardless of slot type for the agent. This change moves us to selecting `runc` or `nvidia` based on the slot type, since nvidia-based GPU images won't launch on CPU agents with the `nvidia` runtime when drivers/etc are already baked in (it tries to run an container start hook and fails).
<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan
- [x] run mnist const on a GPU cluster, launch a tensorboard. it should run fine without any finagling.
- [x] e2e tests
<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)
Seems like just an oversight we weren't doing this before.
<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234