### PR TITLE
chore: make MetricsBatcherThread safer

### DIFF
--- a/harness/determined/profiler.py
+++ b/harness/determined/profiler.py
@@ -763,7 +763,6 @@ class MetricsBatcherThread(threading.Thread):
                     for msr in self.accumulating_measurements.values():
                         self.metrics_batch.append(msr.metric_type, msr.metric_name, msr)
                     self.accumulating_measurements = {}
-                    break
                 else:
                     logging.fatal(
                         f"ProfilerAgent.MetricsBatcherThread received a message "
@@ -772,7 +771,7 @@ class MetricsBatcherThread(threading.Thread):
                         f"be a bug in the code."
                     )
 
-            # Timeout met, or an explicit flush.
+            # Timeout met.
             if not self.metrics_batch.isempty():
                 self.send_queue.put(self.metrics_batch.consume())
             deadline = time.time() + self.FLUSH_INTERVAL


### PR DESCRIPTION
## Description
chore: make MetricsBatcherThread safer:

 - Avoid hanging when exceptions are raised
 - Avoid accidentally calling queue.get() with timeout <= 0
 - Avoid crashing on empty metrics
 - Avoid publishing empty metrics altogether