### PR TITLE
ci: store E2E test results to fix automatic test balancing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1416,6 +1416,8 @@ jobs:
           mark: <<parameters.mark>>
           master-host: localhost
 
+      - store_test_results:
+          path: /tmp/test-results/
 
   deploy:
     parameters:


### PR DESCRIPTION
## Description

This step was removed at some point, which didn't totally break
anything, but it did mean that CircleCI's automatic test balancing
broke, causing all PRs to take much longer to run tests.

## Test Plan

- [x]  run E2E tests twice, check that the second time runs faster (17 minutes vs. 27) and doesn't show an error about timing information not being found https://app.circleci.com/pipelines/github/determined-ai/determined?branch=fix-test-balancing

## Commentary

I was looking over recent PR timings, and apparently sometimes CircleCI figures things out and does the proper splitting anyway. Not sure why. But I think this will make it work consistently? Shouldn't hurt, anyway.