### PR TITLE
fix: make clear unauthorized vs. unauthenticated [DET-5869]

### DIFF
--- a/e2e_tests/tests/test_users.py
+++ b/e2e_tests/tests/test_users.py
@@ -181,9 +181,10 @@ def extract_id_and_owner_from_exp_list(output: str) -> List[Tuple[int, str]]:
 
 @pytest.mark.e2e_cpu  # type: ignore
 def test_logout(clean_auth: None) -> None:
+    # Tests fallback to default determined user
     creds = create_test_user(ADMIN_CREDENTIALS, True)
 
-    # Set Determined passwordto something in order to disable auto-login.
+    # Set Determined password to something in order to disable auto-login.
     password = get_random_string()
     assert change_user_password(constants.DEFAULT_DETERMINED_USER, password, ADMIN_CREDENTIALS) == 0
 
@@ -299,6 +300,98 @@ def test_experiment_creation_and_listing(clean_auth: None) -> None:
     with logged_in_user(ADMIN_CREDENTIALS):
         # Clean up.
         delete_experiments(experiment_id1, experiment_id2)
+
+
+@pytest.mark.e2e_cpu  # type: ignore
+def test_login_wrong_password(clean_auth: None) -> None:
+    creds = create_test_user(ADMIN_CREDENTIALS, True)
+
+    passwd_prompt = f"Password for user '{creds.username}':"
+    unauth_error = r".*Forbidden\(invalid credentials\).*"
+
+    child = det_spawn(["user", "login", creds.username])
+    child.setecho(True)
+    child.expect(passwd_prompt, timeout=EXPECT_TIMEOUT)
+    child.sendline("this is the wrong password")
+
+    child.expect(unauth_error, timeout=EXPECT_TIMEOUT)
+    child.read()
+    child.wait()
+    child.close()
+
+    assert child.exitstatus != 0
+
+
+@pytest.mark.e2e_cpu  # type: ignore
+def test_login_as_non_existent_user(clean_auth: None) -> None:
+    username = "doesNotExist"
+
+    passwd_prompt = f"Password for user '{username}':"
+    unauth_error = r".*Forbidden\(user not found\).*"
+
+    child = det_spawn(["user", "login", username])
+    child.setecho(True)
+    child.expect(passwd_prompt, timeout=EXPECT_TIMEOUT)
+    child.sendline("secret")
+
+    child.expect(unauth_error, timeout=EXPECT_TIMEOUT)
+    child.read()
+    child.wait()
+    child.close()
+
+    assert child.exitstatus != 0
+
+
+@pytest.mark.e2e_cpu  # type: ignore
+def test_login_as_non_active_user(clean_auth: None) -> None:
+    creds = create_test_user(ADMIN_CREDENTIALS, True)
+
+    passwd_prompt = f"Password for user '{creds.username}':"
+    unauth_error = r".*Forbidden\(user not active\)"
+
+    with logged_in_user(ADMIN_CREDENTIALS):
+        child = det_spawn(["user", "deactivate", creds.username])
+
+    child = det_spawn(["user", "login", creds.username])
+    child.setecho(True)
+    child.expect(passwd_prompt, timeout=EXPECT_TIMEOUT)
+    child.sendline(creds.password)
+
+    child.expect(unauth_error, timeout=EXPECT_TIMEOUT)
+    child.read()
+    child.wait()
+    child.close()
+
+    assert child.exitstatus != 0
+
+
+@pytest.mark.e2e_cpu  # type: ignore
+def test_non_admin_user_link_with_agent_user(clean_auth: None) -> None:
+    creds = create_test_user(ADMIN_CREDENTIALS, True)
+    unauth_error = r".*Forbidden\(user not authorized\)"
+
+    with logged_in_user(creds):
+        child = det_spawn(
+            [
+                "user",
+                "link-with-agent-user",
+                creds.username,
+                "--agent-uid",
+                str(1),
+                "--agent-gid",
+                str(1),
+                "--agent-user",
+                creds.username,
+                "--agent-group",
+                creds.username,
+            ]
+        )
+        child.expect(unauth_error, timeout=EXPECT_TIMEOUT)
+        child.read()
+        child.wait()
+        child.close()
+
+        assert child.exitstatus != 0
 
 
 def run_command() -> str:

--- a/harness/determined/common/api/errors.py
+++ b/harness/determined/common/api/errors.py
@@ -41,6 +41,15 @@ class NotFoundException(APIException):
     pass
 
 
+class ForbiddenException(BadRequestException):
+    def __init__(self, username: str, message: str = ""):
+        super().__init__(
+            message=f"Forbidden({message}): Please contact your administrator "
+            "in order to access this resource."
+        )
+        self.username = username
+
+
 class UnauthenticatedException(BadRequestException):
     def __init__(self, username: str):
         super().__init__(

--- a/harness/determined/common/api/request.py
+++ b/harness/determined/common/api/request.py
@@ -114,11 +114,17 @@ def do_request(
     except requests.exceptions.RequestException as e:
         raise errors.BadRequestException(str(e))
 
+    def _get_message(r: requests.models.Response) -> str:
+        try:
+            return str(simplejson.loads(r.text).get("message"))
+        except Exception:
+            return ""
+
     if r.status_code == 403:
         username = ""
         if auth is not None:
             username = auth.get_session_user()
-        raise errors.UnauthenticatedException(username=username)
+        raise errors.ForbiddenException(username=username, message=_get_message(r))
     elif r.status_code == 404:
         raise errors.NotFoundException(r)
     elif r.status_code >= 300:


### PR DESCRIPTION
DET-5869

## Description

[DET-5869]


## Test Plan

e2e tests added. Manual testing was also done.


## Commentary (optional)

In, harness/determined/common/api/authentication.py, the `catch Unauthorized -> throw Unauthenticated` is needed because of our automatic fallback to the default determined user. It doesn't make sense to say, "Unauthorized" unless the user actually attempted to login as a specific user.



[DET-5869]: https://determinedai.atlassian.net/browse/DET-5869