### PR TITLE
fix: don't validate entire config on preview-search

### DIFF
--- a/master/internal/core_searcher.go
+++ b/master/internal/core_searcher.go
@@ -13,32 +13,43 @@ import (
 )
 
 func (m *Master) getSearcherPreview(c echo.Context) (interface{}, error) {
-	body, err := ioutil.ReadAll(c.Request().Body)
+	bytes, err := ioutil.ReadAll(c.Request().Body)
 	if err != nil {
 		return nil, err
 	}
 
 	// Parse the provided experiment config.
-	config, err := expconf.ParseAnyExperimentConfigYAML(body)
+	config, err := expconf.ParseAnyExperimentConfigYAML(bytes)
 	if err != nil {
-		return nil, errors.Wrap(err, "invalid experiment configuration")
+		return nil, errors.Wrapf(err, "invalid experiment configuration")
 	}
 
-	// Apply any json-schema-defined defaults.
-	config = schemas.WithDefaults(config).(expconf.ExperimentConfig)
+	// Get the useful subconfigs for preview search.
+	if config.RawSearcher == nil {
+		return nil, errors.New("invalid experiment configuration; missing searcher")
+	}
+	sc := *config.RawSearcher
+	hc := config.RawHyperparameters
 
-	// Make sure the experiment config has all eventuallyRequired fields.
-	if err = schemas.IsComplete(config); err != nil {
-		return nil, errors.Wrap(err, "invalid experiment configuration")
+	// Apply any json-schema-defined defaults.
+	sc = schemas.WithDefaults(sc).(expconf.SearcherConfig)
+	hc = schemas.WithDefaults(hc).(expconf.Hyperparameters)
+
+	// Make sure the searcher config has all eventuallyRequired fields.
+	if err = schemas.IsComplete(sc); err != nil {
+		return nil, errors.Wrapf(err, "invalid searcher configuration")
+	}
+	if err = schemas.IsComplete(hc); err != nil {
+		return nil, errors.Wrapf(err, "invalid hyperparameters configuration")
 	}
 
 	// Disallow EOL searchers.
-	if err = config.Searcher().AssertCurrent(); err != nil {
+	if err = sc.AssertCurrent(); err != nil {
 		return nil, errors.Wrap(err, "invalid experiment configuration")
 	}
 
-	sm := searcher.NewSearchMethod(config.Searcher())
-	s := searcher.NewSearcher(0, sm, config.Hyperparameters())
+	sm := searcher.NewSearchMethod(sc)
+	s := searcher.NewSearcher(0, sm, hc)
 	return searcher.Simulate(s, nil, searcher.RandomValidation, true, config.Searcher().Metric())
 }
 


### PR DESCRIPTION
## Description

<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234