### PR TITLE
feat: add sync timing toggle for profiling [DET-5891]

### DIFF
--- a/docs/reference/api/experiment-config.txt
+++ b/docs/reference/api/experiment-config.txt
@@ -922,6 +922,11 @@ The ``profiling`` section specifies configuration options related to profiling e
    ``end_after_batch``
       Specifies the batch after which profiling should end.
 
+   ``sync_timings``
+      Specifies whether Determined should wait for all GPU kernel streams before considering a
+      timing as ended. Defaults to 'true'. Applies only for frameworks that collect timing metrics
+      (currently just PyTorch).
+
 .. _data-layer_exp_config:
 
 ************

--- a/harness/determined/_experiment_config.py
+++ b/harness/determined/_experiment_config.py
@@ -35,6 +35,9 @@ class ExperimentConfig(dict):
 
         return self["profiling"]["begin_on_batch"], self["profiling"].get("end_after_batch", None)
 
+    def profiling_sync_timings(self) -> bool:
+        return bool(self.get("profiling", {}).get("sync_timings", True))
+
     def get_data_layer_type(self) -> str:
         return cast(str, self["data_layer"]["type"])
 

--- a/harness/determined/common/schemas/expconf/_gen.py
+++ b/harness/determined/common/schemas/expconf/_gen.py
@@ -1973,6 +1973,13 @@ schemas = {
             ],
             "default": null,
             "minimum": 0
+        },
+        "sync_timings": {
+            "type": [
+                "boolean",
+                "null"
+            ],
+            "default": true
         }
     },
     "compareProperties": {

--- a/harness/determined/common/schemas/expconf/_v0.py
+++ b/harness/determined/common/schemas/expconf/_v0.py
@@ -116,6 +116,7 @@ class ProfilingConfigV0(schemas.SchemaBase):
     enabled: Optional[bool] = None
     begin_on_batch: Optional[int] = None
     end_after_batch: Optional[int] = None
+    sync_timings: Optional[bool] = None
 
     @schemas.auto_init
     def __init__(
@@ -123,6 +124,7 @@ class ProfilingConfigV0(schemas.SchemaBase):
         enabled: Optional[bool] = None,
         begin_on_batch: Optional[int] = None,
         end_after_batch: Optional[int] = None,
+        sync_timings: Optional[bool] = None,
     ) -> None:
         pass
 

--- a/harness/determined/pytorch/_pytorch_trial.py
+++ b/harness/determined/pytorch/_pytorch_trial.py
@@ -31,6 +31,8 @@ class PyTorchTrialController(det.TrialController):
         self.trial = cast(PyTorchTrial, trial_inst)
         self.context = cast(pytorch.PyTorchTrialContext, self.context)
         self.context._set_determined_profiler(self.prof)
+        if torch.cuda.is_available():
+            self.prof._set_sync_device(self._sync_device)
         self.callbacks = self.trial.build_callbacks()
 
         check.gt_eq(
@@ -803,6 +805,9 @@ class PyTorchTrialController(det.TrialController):
         if self.wlsq is not None:
             with path.joinpath("workload_sequencer.pkl").open("wb") as f:
                 pickle.dump(self.wlsq.get_state(), f)
+
+    def _sync_device(self) -> None:
+        torch.cuda.synchronize(self.context.device)
 
 
 class PyTorchTrial(det.Trial):

--- a/master/pkg/schemas/expconf/profiling.go
+++ b/master/pkg/schemas/expconf/profiling.go
@@ -6,4 +6,5 @@ type ProfilingConfigV0 struct {
 	RawEnabled       *bool `json:"enabled"`
 	RawBeginOnBatch  *int  `json:"begin_on_batch"`
 	RawEndAfterBatch *int  `json:"end_after_batch"`
+	RawSyncTimings   *bool `json:"sync_timings"`
 }

--- a/master/pkg/schemas/expconf/zgen_profiling_config_v0.go
+++ b/master/pkg/schemas/expconf/zgen_profiling_config_v0.go
@@ -38,6 +38,17 @@ func (p *ProfilingConfigV0) SetEndAfterBatch(val *int) {
 	p.RawEndAfterBatch = val
 }
 
+func (p ProfilingConfigV0) SyncTimings() bool {
+	if p.RawSyncTimings == nil {
+		panic("You must call WithDefaults on ProfilingConfigV0 before .SyncTimings")
+	}
+	return *p.RawSyncTimings
+}
+
+func (p *ProfilingConfigV0) SetSyncTimings(val bool) {
+	p.RawSyncTimings = &val
+}
+
 func (p ProfilingConfigV0) ParsedSchema() interface{} {
 	return schemas.ParsedProfilingConfigV0()
 }

--- a/master/pkg/schemas/zgen_schemas.go
+++ b/master/pkg/schemas/zgen_schemas.go
@@ -1835,6 +1835,13 @@ var (
             ],
             "default": null,
             "minimum": 0
+        },
+        "sync_timings": {
+            "type": [
+                "boolean",
+                "null"
+            ],
+            "default": true
         }
     },
     "compareProperties": {

--- a/schemas/expconf/v0/profiling.json
+++ b/schemas/expconf/v0/profiling.json
@@ -28,6 +28,13 @@
             ],
             "default": null,
             "minimum": 0
+        },
+        "sync_timings": {
+            "type": [
+                "boolean",
+                "null"
+            ],
+            "default": true
         }
     },
     "compareProperties": {

--- a/schemas/test_cases/v0/experiment.yaml
+++ b/schemas/test_cases/v0/experiment.yaml
@@ -93,6 +93,7 @@
       enabled: true
       begin_on_batch: 0
       end_after_batch: 1
+      sync_timings: false
     records_per_epoch: 0
     reproducibility:
       experiment_seed: 1606239866
@@ -193,6 +194,7 @@
       enabled: false
       begin_on_batch: 0
       end_after_batch: null
+      sync_timings: true
     records_per_epoch: 0
     reproducibility:
       experiment_seed: "*"


### PR DESCRIPTION
## Description
This change adds the toggle `profiling.sync_timings` which defaults to `true` and forces Determined to call `torch.cuda.synchronize` appropriately so that timing metrics are more accurate. Since this comes as a trade off, the toggle is available, which disables synchronize and instead of collecting many granular metrics, the profiler instead collects a single "overview" metric.
<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan
- [x] test an experiment with the toggle on and off, ensure all is well and that certain timing metrics appear more accurate (looking at device transfer time mainly)
<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)
Currently this collects no timings when sync is disabled, since `samples_per_second` will likely be the best "overview" we can still get and any subset of timings that can be trusted are piecemeal and not as useful together, I think.
<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234