### PR TITLE
refactor: ban python builtin shadowing.

### DIFF
--- a/e2e_tests/tests/cluster_log_manager.py
+++ b/e2e_tests/tests/cluster_log_manager.py
@@ -12,7 +12,7 @@ class ClusterLogManager:
         self.setup_logs()
         return self
 
-    def __exit__(self, type: type, value: Exception, traceback: TracebackType) -> None:
+    def __exit__(self, exc_type: type, exc_value: Exception, traceback: TracebackType) -> None:
         self.stop_logs()
 
     def setup_logs(self) -> None:

--- a/e2e_tests/tests/command/command.py
+++ b/e2e_tests/tests/command/command.py
@@ -90,17 +90,17 @@ def get_num_running_commands() -> int:
     return len([command for command in r.json()["commands"] if command["state"] == "STATE_RUNNING"])
 
 
-def get_command(id: str) -> Any:
+def get_command(command_id: str) -> Any:
     certs.cli_cert = certs.default_load(conf.make_master_url())
     authentication.cli_auth = authentication.Authentication(conf.make_master_url(), try_reauth=True)
-    r = api.get(conf.make_master_url(), "api/v1/commands/" + id)
+    r = api.get(conf.make_master_url(), "api/v1/commands/" + command_id)
     assert r.status_code == requests.codes.ok, r.text
     return r.json()["command"]
 
 
-def get_command_config(command_type: str, id: str) -> str:
+def get_command_config(command_type: str, task_id: str) -> str:
     assert command_type in ["command", "notebook", "shell"]
-    command = ["det", "-m", conf.make_master_url(), command_type, "config", id]
+    command = ["det", "-m", conf.make_master_url(), command_type, "config", task_id]
     env = os.environ.copy()
     env["DET_DEBUG"] = "true"
     completed_process = subprocess.run(

--- a/e2e_tests/tests/test_users.py
+++ b/e2e_tests/tests/test_users.py
@@ -356,7 +356,7 @@ def kill_notebooks(*notebook_ids: str) -> None:
         output = extract_columns(det_run(["notebook", "list", "-a"]), [0, 3])  # id, state
 
         # Get set of running IDs.
-        running_ids = {id for id, state in output if state == "RUNNING"}
+        running_ids = {task_id for task_id, state in output if state == "RUNNING"}
 
         intersection = running_ids & nids
         if not intersection:
@@ -376,7 +376,7 @@ def kill_tensorboards(*tensorboard_ids: str) -> None:
     while tids:
         output = extract_columns(det_run(["tensorboard", "list", "-a"]), [0, 3])
 
-        running_ids = {id for id, state in output if state == "RUNNING"}
+        running_ids = {task_id for task_id, state in output if state == "RUNNING"}
 
         intersection = running_ids & tids
         if not intersection:

--- a/harness/.flake8
+++ b/harness/.flake8
@@ -25,7 +25,8 @@ per-file-ignores = __init__.py:F401 patch_saver_restore.py:E111,E114,
 # - E203 (no space before colon): not PEP8-compliant; triggered by Black-formatted code
 # - W503 (no line breaks before binary operator): not PEP8-compliant; triggered by Black-formatted code
 # - C812-C816 (missing trailing comma): stylistic choice
-ignore = D1,D200,D202,D203,D205,D212,D4,E203,W503,C812,C813,C814,C815,C816
+# - A003 (class attribute is shadowing a python builtin): not a high risk of causing issues.
+ignore = D1,D200,D202,D203,D205,D212,D4,E203,W503,C812,C813,C814,C815,C816,A003
 
 show_source = true
 

--- a/harness/determined/cli/checkpoint.py
+++ b/harness/determined/cli/checkpoint.py
@@ -60,7 +60,7 @@ def render_checkpoint(checkpoint: experimental.Checkpoint, path: Optional[str] =
 
 
 @authentication.required
-def list(args: Namespace) -> None:
+def list_checkpoints(args: Namespace) -> None:
     params = {}
     if args.best is not None:
         if args.best < 0:

--- a/harness/determined/cli/command.py
+++ b/harness/determined/cli/command.py
@@ -121,7 +121,7 @@ Command = namedtuple(
 
 
 @authentication.required
-def list(args: Namespace) -> None:
+def list_tasks(args: Namespace) -> None:
     api_path = RemoteTaskNewAPIs[args._command]
     api_full_path = "api/v1/{}".format(api_path)
     table_header = RemoteTaskListTableHeaders[args._command]
@@ -146,17 +146,17 @@ def list(args: Namespace) -> None:
 
 @authentication.required
 def kill(args: Namespace) -> None:
-    ids = RemoteTaskGetIDsFunc[args._command](args)  # type: ignore
+    task_ids = RemoteTaskGetIDsFunc[args._command](args)  # type: ignore
     name = RemoteTaskName[args._command]
 
-    for i, id in enumerate(ids):
+    for i, task_id in enumerate(task_ids):
         try:
-            api_full_path = "api/v1/{}/{}/kill".format(RemoteTaskNewAPIs[args._command], id)
+            api_full_path = "api/v1/{}/{}/kill".format(RemoteTaskNewAPIs[args._command], task_id)
             api.post(args.master, api_full_path)
-            print(colored("Killed {} {}".format(name, id), "green"))
+            print(colored("Killed {} {}".format(name, task_id), "green"))
         except api.errors.APIException as e:
             if not args.force:
-                for ignored in ids[i + 1 :]:
+                for ignored in task_ids[i + 1 :]:
                     print("Cowardly not killing {}".format(ignored))
                 raise e
             print(colored("Skipping: {} ({})".format(e, type(e).__name__), "red"))
@@ -164,13 +164,15 @@ def kill(args: Namespace) -> None:
 
 @authentication.required
 def set_priority(args: Namespace) -> None:
-    id = RemoteTaskGetIDsFunc[args._command](args)  # type: ignore
+    task_id = RemoteTaskGetIDsFunc[args._command](args)  # type: ignore
     name = RemoteTaskName[args._command]
 
     try:
-        api_full_path = "api/v1/{}/{}/set_priority".format(RemoteTaskNewAPIs[args._command], id)
+        api_full_path = "api/v1/{}/{}/set_priority".format(
+            RemoteTaskNewAPIs[args._command], task_id
+        )
         api.post(args.master, api_full_path, {"priority": args.priority})
-        print(colored("Set priority of {} {} to {}".format(name, id, args.priority), "green"))
+        print(colored("Set priority of {} {} to {}".format(name, task_id, args.priority), "green"))
     except api.errors.APIException as e:
         print(colored("Skipping: {} ({})".format(e, type(e).__name__), "red"))
 

--- a/harness/determined/cli/experiment.py
+++ b/harness/determined/cli/experiment.py
@@ -649,7 +649,7 @@ def experiment_id_completer(prefix: str, parsed_args: Namespace, **kwargs: Any) 
     return [str(e["id"]) for e in r.json()]
 
 
-def experiment_id_arg(help: str) -> Arg:
+def experiment_id_arg(help: str) -> Arg:  # noqa: A002
     return Arg("experiment_id", type=int, help=help, completer=experiment_id_completer)
 
 
@@ -709,7 +709,7 @@ args_description = Cmd(
         ),
         Cmd(
             "list-checkpoints lc",
-            checkpoint.list,
+            checkpoint.list_checkpoints,
             "list checkpoints of experiment",
             [
                 experiment_id_arg("experiment ID"),

--- a/harness/determined/cli/notebook.py
+++ b/harness/determined/cli/notebook.py
@@ -46,7 +46,7 @@ def start_notebook(args: Namespace) -> None:
     with api.ws(args.master, "notebooks/{}/events".format(obj["id"])) as ws:
         for msg in ws:
             if msg["service_ready_event"] and not args.no_browser:
-                url = api.open(args.master, obj["serviceAddress"])
+                url = api.browser_open(args.master, obj["serviceAddress"])
                 print(colored("Jupyter Notebook is running at: {}".format(url), "green"))
             render_event_stream(msg)
 
@@ -55,14 +55,14 @@ def start_notebook(args: Namespace) -> None:
 def open_notebook(args: Namespace) -> None:
     resp = api.get(args.master, "api/v1/notebooks/{}".format(args.notebook_id)).json()["notebook"]
     check_eq(resp["state"], "STATE_RUNNING", "Notebook must be in a running state")
-    api.open(args.master, resp["serviceAddress"])
+    api.browser_open(args.master, resp["serviceAddress"])
 
 
 # fmt: off
 
 args_description = [
     Cmd("notebook", None, "manage notebooks", [
-        Cmd("list ls", command.list, "list notebooks", [
+        Cmd("list ls", command.list_tasks, "list notebooks", [
             Arg("-q", "--quiet", action="store_true",
                 help="only display the IDs"),
             Arg("--all", "-a", action="store_true",

--- a/harness/determined/cli/remote.py
+++ b/harness/determined/cli/remote.py
@@ -43,7 +43,7 @@ def run_command(args: Namespace) -> None:
 
 args_description = [
     Cmd("command cmd", None, "manage commands", [
-        Cmd("list ls", command.list, "list commands", [
+        Cmd("list ls", command.list_tasks, "list commands", [
             Arg("-q", "--quiet", action="store_true",
                 help="only display the IDs"),
             Arg("--all", "-a", action="store_true",

--- a/harness/determined/cli/shell.py
+++ b/harness/determined/cli/shell.py
@@ -174,7 +174,7 @@ def _open_shell(
 
 args_description = [
     Cmd("shell", None, "manage shells", [
-        Cmd("list", command.list, "list shells", [
+        Cmd("list", command.list_tasks, "list shells", [
             Arg("-q", "--quiet", action="store_true",
                 help="only display the IDs"),
             Arg("--all", "-a", action="store_true",

--- a/harness/determined/cli/sso.py
+++ b/harness/determined/cli/sso.py
@@ -39,7 +39,7 @@ def make_handler(master_url: str, close_cb: Callable[[int], None]) -> Any:
                 print("Error authenticating: {}.".format(e))
                 close_cb(1)
 
-        def log_message(self, format: Any, *args: List[Any]) -> None:
+        def log_message(self, format: Any, *args: List[Any]) -> None:  # noqa: A002
             # Silence server logging.
             return
 

--- a/harness/determined/cli/tensorboard.py
+++ b/harness/determined/cli/tensorboard.py
@@ -49,7 +49,7 @@ def start_tensorboard(args: Namespace) -> None:
                 if args.no_browser:
                     url = api.make_url(args.master, resp["serviceAddress"])
                 else:
-                    url = api.open(args.master, resp["serviceAddress"])
+                    url = api.browser_open(args.master, resp["serviceAddress"])
 
                 print(colored("TensorBoard is running at: {}".format(url), "green"))
                 render_event_stream(msg)
@@ -63,14 +63,14 @@ def open_tensorboard(args: Namespace) -> None:
         "tensorboard"
     ]
     check_eq(resp["state"], "STATE_RUNNING", "TensorBoard must be in a running state")
-    api.open(args.master, resp["serviceAddress"])
+    api.browser_open(args.master, resp["serviceAddress"])
 
 
 # fmt: off
 
 args_description = [
     Cmd("tensorboard", None, "manage TensorBoard instances", [
-        Cmd("list ls", command.list, "list TensorBoard instances", [
+        Cmd("list ls", command.list_tasks, "list TensorBoard instances", [
             Arg("-q", "--quiet", action="store_true",
                 help="only display the IDs"),
             Arg("--all", "-a", action="store_true",

--- a/harness/determined/common/api/__init__.py
+++ b/harness/determined/common/api/__init__.py
@@ -20,7 +20,7 @@ from determined.common.api.request import (
     do_request,
     get,
     make_url,
-    open,
+    browser_open,
     parse_master_address,
     patch,
     post,

--- a/harness/determined/common/api/request.py
+++ b/harness/determined/common/api/request.py
@@ -241,7 +241,7 @@ def put(
     )
 
 
-def open(host: str, path: str) -> str:
+def browser_open(host: str, path: str) -> str:
     url = make_url(host, path)
     webbrowser.open(url)
     return url

--- a/harness/determined/common/experimental/checkpoint/_checkpoint.py
+++ b/harness/determined/common/experimental/checkpoint/_checkpoint.py
@@ -52,7 +52,7 @@ class Checkpoint(object):
         metadata: Dict[str, Any],
         determined_version: Optional[str] = None,
         framework: Optional[str] = None,
-        format: Optional[str] = None,
+        format: Optional[str] = None,  # noqa: A002
         model_version: Optional[int] = None,
         model_name: Optional[str] = None,
     ):

--- a/harness/determined/common/experimental/determined.py
+++ b/harness/determined/common/experimental/determined.py
@@ -18,12 +18,12 @@ class _CreateExperimentResponse:
             raise ValueError(f'CreateExperimentResponse["experiment"] must be a dict; got {exp}')
         if "id" not in exp:
             raise ValueError(f'CreateExperimentResponse["experiment"] must have an id; got {exp}')
-        id = exp["id"]
-        if not isinstance(id, int):
+        exp_id = exp["id"]
+        if not isinstance(exp_id, int):
             raise ValueError(
-                f'CreateExperimentResponse["experiment"]["id"] must be a int; got {id}'
+                f'CreateExperimentResponse["experiment"]["id"] must be a int; got {exp_id}'
             )
-        self.id = id
+        self.id = exp_id
 
 
 class Determined:

--- a/harness/determined/common/storage/base.py
+++ b/harness/determined/common/storage/base.py
@@ -14,7 +14,7 @@ class StorageMetadata:
         storage_id: str,
         resources: Dict[str, int],
         framework: Optional[str] = None,
-        format: Optional[str] = None,
+        format: Optional[str] = None,  # noqa: A002
     ) -> None:
         check_gt(len(storage_id), 0, "Invalid storage ID")
         self.storage_id = storage_id

--- a/harness/determined/deploy/gcp/gcp.py
+++ b/harness/determined/deploy/gcp/gcp.py
@@ -48,9 +48,9 @@ def terraform_read_variables(vars_file_path: str) -> Dict:
         sys.exit(1)
 
     with open(vars_file_path, "r") as f:
-        vars = json.load(f)
-        assert isinstance(vars, dict), "expected a dict of variables"
-        return vars
+        variables = json.load(f)
+        assert isinstance(variables, dict), "expected a dict of variables"
+        return variables
 
 
 def terraform_write_variables(configs: Dict, variables_to_exclude: List) -> str:
@@ -175,11 +175,11 @@ def wait_for_operations(compute: Any, tf_vars: Dict, operations: List) -> bool:
     return False
 
 
-def list_instances(compute: Any, tf_vars: Dict, filter: str) -> Any:
+def list_instances(compute: Any, tf_vars: Dict, filter_expr: str) -> Any:
     """Get list of instances for this deployment matching the given filter."""
     result = (
         compute.instances()
-        .list(project=tf_vars.get("project_id"), zone=tf_vars.get("zone"), filter=filter)
+        .list(project=tf_vars.get("project_id"), zone=tf_vars.get("zone"), filter=filter_expr)
         .execute()
     )
     return result["items"] if "items" in result else []
@@ -230,8 +230,8 @@ def master_name(tf_vars: Dict) -> str:
 
 def stop_master(compute: Any, tf_vars: Dict) -> None:
     """Stop the master, waiting for operation to complete."""
-    filter = f'name="{master_name(tf_vars)}"'
-    instances = list_instances(compute, tf_vars, filter)
+    filter_expr = f'name="{master_name(tf_vars)}"'
+    instances = list_instances(compute, tf_vars, filter_expr)
 
     if len(instances) == 0:
         print(f"WARNING: Unable to locate master: {master_name(tf_vars)}")
@@ -251,8 +251,8 @@ def stop_master(compute: Any, tf_vars: Dict) -> None:
 
 def terminate_running_agents(compute: Any, tf_vars: Dict) -> None:
     """Terminate all dynamic agents, waiting for operation to complete."""
-    filter = f'labels.managed-by="{master_name(tf_vars)}"'
-    agent_instances = list_instances(compute, tf_vars, filter)
+    filter_expr = f'labels.managed-by="{master_name(tf_vars)}"'
+    agent_instances = list_instances(compute, tf_vars, filter_expr)
     delete_instances(compute, tf_vars, agent_instances)
 
 

--- a/harness/determined/errors.py
+++ b/harness/determined/errors.py
@@ -23,8 +23,8 @@ class InvalidDataTypeException(InvalidExperimentException):
     InvalidDataType is used if the data type of an experiment is invalid.
     """
 
-    def __init__(self, type: Type, message: str) -> None:
-        super().__init__(f"Invalid data type ({type.__name__}): {message}.")
+    def __init__(self, typ: Type, message: str) -> None:
+        super().__init__(f"Invalid data type ({typ.__name__}): {message}.")
 
 
 class InvalidConfigurationException(InvalidExperimentException):

--- a/harness/determined/pytorch/_pytorch_context.py
+++ b/harness/determined/pytorch/_pytorch_context.py
@@ -107,7 +107,7 @@ class PyTorchTrialContext(det.TrialContext, pytorch._PyTorchReducerContext):
         warned_types = set()
 
         # Second, eliminate any need for the loss functions to be in that context:
-        def end_fp16(module: torch.nn.Module, input: Any, output: Any) -> Any:
+        def end_fp16(module: torch.nn.Module, input: Any, output: Any) -> Any:  # noqa: A002
 
             if isinstance(output, torch.Tensor):
                 return output.float() if output.dtype == torch.float16 else output

--- a/harness/determined/workload.py
+++ b/harness/determined/workload.py
@@ -47,15 +47,15 @@ class Workload:
         return self.__dict__
 
     @staticmethod
-    def from_json(dict: Dict[str, Any]) -> "Workload":
-        check.check_in(dict["kind"], Workload.Kind.__members__)
+    def from_json(data: Dict[str, Any]) -> "Workload":
+        check.check_in(data["kind"], Workload.Kind.__members__)
         return Workload(
-            Workload.Kind[dict["kind"]],
-            dict["experiment_id"],
-            dict["trial_id"],
-            dict["step_id"],
-            dict["num_batches"],
-            dict["total_batches_processed"],
+            Workload.Kind[data["kind"]],
+            data["experiment_id"],
+            data["trial_id"],
+            data["step_id"],
+            data["num_batches"],
+            data["total_batches_processed"],
         )
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@
 black>=20.8b1
 flake8>=3.8.0
 flake8-bugbear>=19.8.0
+flake8-builtins>=1.5.3
 flake8-colors>=0.1.6
 flake8-commas==2.0.0
 flake8-comprehensions>=2.2.0

--- a/schemas/.flake8
+++ b/schemas/.flake8
@@ -24,7 +24,8 @@ per-file-ignores = __init__.py:F401 patch_saver_restore.py:E111,E114,
 # - E203 (no space before colon): not PEP8-compliant; triggered by Black-formatted code
 # - W503 (no line breaks before binary operator): not PEP8-compliant; triggered by Black-formatted code
 # - C812-C816 (missing trailing comma): stylistic choice
-ignore = D1,D200,D202,D203,D205,D212,D4,E203,W503,C812,C813,C814,C815,C816
+# - A001-A003 (flake8-builtins): disable plugin
+ignore = D1,D200,D202,D203,D205,D212,D4,E203,W503,C812,C813,C814,C815,C816,A001,A002,A003
 
 show_source = true
 

--- a/tools/.flake8
+++ b/tools/.flake8
@@ -24,7 +24,8 @@ per-file-ignores = __init__.py:F401 patch_saver_restore.py:E111,E114,
 # - E203 (no space before colon): not PEP8-compliant; triggered by Black-formatted code
 # - W503 (no line breaks before binary operator): not PEP8-compliant; triggered by Black-formatted code
 # - C812-C816 (missing trailing comma): stylistic choice
-ignore = D1,D200,D202,D203,D205,D212,D4,E203,W503,C812,C813,C814,C815,C816
+# - A001-A003 (flake8-builtins): disable plugin
+ignore = D1,D200,D202,D203,D205,D212,D4,E203,W503,C812,C813,C814,C815,C816,A001,A002,A003
 
 show_source = true
 


### PR DESCRIPTION
## Description

- Add flake8-builtins plugin to ban shadowing python built-ins in harness.
- Fix ~20 places where it has been violated. I didn't touch public APIs and `noqa`ed a few places where it made sense.

## Test Plan

N/A

## Commentary (optional)

I was debugging a bizarre issue in the code. After an hour I discovered that place had shadowed `list`, flipped out, and made this PR.

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
