### PR TITLE
fix: profiler metrics without follow should return metrics [DET-5911]

### DIFF
--- a/e2e_tests/tests/experiment/test_profiling.py
+++ b/e2e_tests/tests/experiment/test_profiling.py
@@ -164,7 +164,8 @@ def request_profiling_pytorch_timing_metrics(
         if not all(x + 1 == y for x, y in zip(batches, batches[1:])):
             pytest.fail(f"skips in batches sampled: {batch}")
 
-        if accumulated and all(x < y for x, y in zip(values, values[1:])):
+        # 10 is just a threshold at which it would be really strange for a batch to be monotonic.
+        if accumulated and len(values) > 10 and all(x < y for x, y in zip(values, values[1:])):
             pytest.fail(
                 f"per batch accumulated metric was monotonic, which is really fishy: {batch}"
             )

--- a/e2e_tests/tests/experiment/test_profiling.py
+++ b/e2e_tests/tests/experiment/test_profiling.py
@@ -164,7 +164,7 @@ def request_profiling_pytorch_timing_metrics(
         if not all(x + 1 == y for x, y in zip(batches, batches[1:])):
             pytest.fail(f"skips in batches sampled: {batch}")
 
-        if accumulated and all(x < y for x, y in zip(batches, batches[1:])):
+        if accumulated and all(x < y for x, y in zip(values, values[1:])):
             pytest.fail(
                 f"per batch accumulated metric was monotonic, which is really fishy: {batch}"
             )

--- a/e2e_tests/tests/experiment/test_profiling.py
+++ b/e2e_tests/tests/experiment/test_profiling.py
@@ -129,9 +129,13 @@ def request_profiling_system_metrics(trial_id: int, metric_name: str) -> None:
         ),
         stream=True,
     ) as r:
+        have_batch = False
         for line in r.iter_lines():
             batch = simplejson.loads(line)["result"]["batch"]
             validate_gpu_metric_batch(batch)
+            have_batch = True
+        if not have_batch:
+            pytest.fail("no batch metrics at all")
 
 
 def request_profiling_pytorch_timing_metrics(
@@ -176,9 +180,13 @@ def request_profiling_pytorch_timing_metrics(
         stream=True,
     ) as r:
         batch_idx = 0
+        have_batch = False
         for line in r.iter_lines():
             batch = simplejson.loads(line)["result"]["batch"]
             batch_idx = validate_timing_batch(batch, batch_idx)
+            have_batch = True
+        if not have_batch:
+            pytest.fail("no batch metrics at all")
 
 
 PROFILER_METRIC_TYPE_SYSTEM = "PROFILER_METRIC_TYPE_SYSTEM"

--- a/harness/determined/profiler.py
+++ b/harness/determined/profiler.py
@@ -283,6 +283,7 @@ class ProfilerAgent:
         self.has_started = False
         self.has_finished = False
         self.disabled_due_to_preexisting_metrics = False
+        self.training = False
 
         self.shutdown_lock = threading.Lock()
 
@@ -400,6 +401,8 @@ class ProfilerAgent:
             return False
         if self.disabled_due_to_preexisting_metrics:
             return False
+        if not self.training:
+            return False
         return self.global_rank == 0
 
     @property
@@ -410,6 +413,14 @@ class ProfilerAgent:
         if not self.is_enabled:
             return False
         return self.has_started and not self.has_finished
+
+    def set_training(self, training: bool) -> None:
+        if not self.is_enabled:
+            return
+
+        self.training = training
+        if not training:
+            self.metrics_batcher_queue.put(FinalizeBatchMessage())
 
     def update_batch_idx(self, new_batch_idx: int) -> None:
         if not self.is_enabled:

--- a/harness/determined/pytorch/_pytorch_trial.py
+++ b/harness/determined/pytorch/_pytorch_trial.py
@@ -294,6 +294,7 @@ class PyTorchTrialController(det.LoopTrialController):
     def _train_for_step(
         self, step_id: int, num_batches: int, total_batches_processed: int
     ) -> workload.Response:
+        self.prof.set_training(True)
         check.gt(step_id, 0)
         self.context.reset_reducers()
 
@@ -393,6 +394,7 @@ class PyTorchTrialController(det.LoopTrialController):
             return workload.Skipped()
 
         logging.debug(f"Done training step: {num_inputs} records in {num_batches} batches.")
+        self.prof.set_training(False)
 
         return metrics
 

--- a/master/internal/api_trials.go
+++ b/master/internal/api_trials.go
@@ -3,6 +3,7 @@ package internal
 import (
 	"context"
 	"fmt"
+	"math"
 	"strconv"
 	"strings"
 	"time"
@@ -457,7 +458,7 @@ func (a *apiServer) GetTrialProfilerMetrics(
 	}
 
 	return api.NewBatchStreamProcessor(
-		api.BatchRequest{Follow: req.Follow},
+		api.BatchRequest{Limit: math.MaxInt32, Follow: req.Follow},
 		fetch,
 		onBatch,
 		a.isTrialTerminalFunc(int(req.Labels.TrialId), -1),


### PR DESCRIPTION
## Description
Calls to the profiler metrics API without follow should return some metrics. Additionally, this fixes some bad code in tests that did not catch this issue.
<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan
- [x] call the metrics endpoint without `follow=true`
<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)
For simplicity, i omitted a limit from the API but also omitted this critical detail.
<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234