### PR TITLE
fix: make k8s watchers more resilient [DET-5910]

### DIFF
--- a/agent/go.sum
+++ b/agent/go.sum
@@ -257,6 +257,7 @@ github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1m
 github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
 github.com/envoyproxy/go-control-plane v0.9.9-0.20210217033140-668b12f5399d/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
+github.com/evanphx/json-patch v4.2.0+incompatible h1:fUDGZCv/7iAN7u0puUVhvKCcsR6vRfwrJatElLBEf0I=
 github.com/evanphx/json-patch v4.2.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/color v1.9.0 h1:8xPHl4/q1VyqGIPif1F+1V3Y3lSmrq01EabUW3CoW5s=
@@ -1482,6 +1483,7 @@ k8s.io/klog v0.0.0-20181102134211-b9b56d5dfc92/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUc
 k8s.io/klog v0.3.0/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUcqjScdoY3a9IHpCEIOOfk=
 k8s.io/klog v0.4.0 h1:lCJCxf/LIowc2IGS9TPjWDyXY4nOmdGdfcwwDQCOURQ=
 k8s.io/klog v0.4.0/go.mod h1:4Bi6QPql/J/LkTDqv7R/cd3hPo4k2DG6Ptcz060Ez5I=
+k8s.io/kube-openapi v0.0.0-20190816220812-743ec37842bf h1:EYm5AW/UUDbnmnI+gK0TJDVK9qPLhM+sRHYanNKw0EQ=
 k8s.io/kube-openapi v0.0.0-20190816220812-743ec37842bf/go.mod h1:1TqjTSzOxsLGIKfj0lK8EeCP7K1iUG65v09OM0/WG5E=
 k8s.io/utils v0.0.0-20190801114015-581e00157fb1 h1:+ySTxfHnfzZb9ys375PXNlLhkJPLKgHajBU0N62BDvE=
 k8s.io/utils v0.0.0-20190801114015-581e00157fb1/go.mod h1:sZAwmy6armz5eXlNoLmJcl4F1QuKu7sr+mFQ0byX7Ew=

--- a/master/go.sum
+++ b/master/go.sum
@@ -259,6 +259,7 @@ github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1m
 github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
 github.com/envoyproxy/go-control-plane v0.9.9-0.20210217033140-668b12f5399d/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
+github.com/evanphx/json-patch v4.2.0+incompatible h1:fUDGZCv/7iAN7u0puUVhvKCcsR6vRfwrJatElLBEf0I=
 github.com/evanphx/json-patch v4.2.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/color v1.9.0 h1:8xPHl4/q1VyqGIPif1F+1V3Y3lSmrq01EabUW3CoW5s=
@@ -1496,6 +1497,7 @@ k8s.io/klog v0.0.0-20181102134211-b9b56d5dfc92/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUc
 k8s.io/klog v0.3.0/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUcqjScdoY3a9IHpCEIOOfk=
 k8s.io/klog v0.4.0 h1:lCJCxf/LIowc2IGS9TPjWDyXY4nOmdGdfcwwDQCOURQ=
 k8s.io/klog v0.4.0/go.mod h1:4Bi6QPql/J/LkTDqv7R/cd3hPo4k2DG6Ptcz060Ez5I=
+k8s.io/kube-openapi v0.0.0-20190816220812-743ec37842bf h1:EYm5AW/UUDbnmnI+gK0TJDVK9qPLhM+sRHYanNKw0EQ=
 k8s.io/kube-openapi v0.0.0-20190816220812-743ec37842bf/go.mod h1:1TqjTSzOxsLGIKfj0lK8EeCP7K1iUG65v09OM0/WG5E=
 k8s.io/utils v0.0.0-20190801114015-581e00157fb1 h1:+ySTxfHnfzZb9ys375PXNlLhkJPLKgHajBU0N62BDvE=
 k8s.io/utils v0.0.0-20190801114015-581e00157fb1/go.mod h1:sZAwmy6armz5eXlNoLmJcl4F1QuKu7sr+mFQ0byX7Ew=

--- a/master/internal/kubernetes/events.go
+++ b/master/internal/kubernetes/events.go
@@ -1,7 +1,11 @@
 package kubernetes
 
 import (
-	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/tools/cache"
+	watchtools "k8s.io/client-go/tools/watch"
+
+	"github.com/determined-ai/determined/master/pkg/actor/actors"
 
 	k8sV1 "k8s.io/api/core/v1"
 	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -46,9 +50,7 @@ func (e *eventListener) Receive(ctx *actor.Context) error {
 		ctx.Tell(ctx.Self(), startEventListener{})
 
 	case startEventListener:
-		if err := e.startEventListener(ctx); err != nil {
-			return err
-		}
+		e.startEventListener(ctx)
 
 	case actor.PostStop:
 
@@ -60,14 +62,32 @@ func (e *eventListener) Receive(ctx *actor.Context) error {
 	return nil
 }
 
-func (e *eventListener) startEventListener(ctx *actor.Context) error {
-	watch, err := e.clientSet.CoreV1().Events(e.namespace).Watch(metaV1.ListOptions{})
+func (e *eventListener) startEventListener(ctx *actor.Context) {
+	events, err := e.clientSet.CoreV1().Events(e.namespace).List(metaV1.ListOptions{})
 	if err != nil {
-		return errors.Wrap(err, "error initializing event watch")
+		ctx.Log().WithError(err).Error("error retrieving internal resource version")
+		actors.NotifyAfter(ctx, defaultInformerBackoff, startEventListener{})
+		return
+	}
+
+	rw, err := watchtools.NewRetryWatcher(events.ResourceVersion, &cache.ListWatch{
+		WatchFunc: func(options metaV1.ListOptions) (watch.Interface, error) {
+			return e.clientSet.CoreV1().Events(e.namespace).Watch(metaV1.ListOptions{})
+		},
+	})
+	if err != nil {
+		ctx.Log().WithError(err).Error("error initializing event retry watcher")
+		actors.NotifyAfter(ctx, defaultInformerBackoff, startEventListener{})
+		return
 	}
 
 	ctx.Log().Info("event listener is starting")
-	for event := range watch.ResultChan() {
+	for event := range rw.ResultChan() {
+		if event.Type == watch.Error {
+			ctx.Log().WithField("error", event.Object).Warnf("event listener encountered error")
+			continue
+		}
+
 		newEvent, ok := event.Object.(*k8sV1.Event)
 		if !ok {
 			ctx.Log().Warnf("error converting object type %T to *k8sV1.Event: %+v", event, event)
@@ -78,6 +98,4 @@ func (e *eventListener) startEventListener(ctx *actor.Context) error {
 
 	ctx.Log().Warn("event listener stopped unexpectedly")
 	ctx.Tell(ctx.Self(), startEventListener{})
-
-	return nil
 }

--- a/master/internal/kubernetes/events.go
+++ b/master/internal/kubernetes/events.go
@@ -65,7 +65,7 @@ func (e *eventListener) Receive(ctx *actor.Context) error {
 func (e *eventListener) startEventListener(ctx *actor.Context) {
 	events, err := e.clientSet.CoreV1().Events(e.namespace).List(metaV1.ListOptions{})
 	if err != nil {
-		ctx.Log().WithError(err).Error("error retrieving internal resource version")
+		ctx.Log().WithError(err).Warnf("error retrieving internal resource version")
 		actors.NotifyAfter(ctx, defaultInformerBackoff, startEventListener{})
 		return
 	}
@@ -76,7 +76,7 @@ func (e *eventListener) startEventListener(ctx *actor.Context) {
 		},
 	})
 	if err != nil {
-		ctx.Log().WithError(err).Error("error initializing event retry watcher")
+		ctx.Log().WithError(err).Warnf("error initializing event retry watcher")
 		actors.NotifyAfter(ctx, defaultInformerBackoff, startEventListener{})
 		return
 	}

--- a/master/internal/kubernetes/informer.go
+++ b/master/internal/kubernetes/informer.go
@@ -70,7 +70,7 @@ func (i *informer) Receive(ctx *actor.Context) error {
 func (i *informer) startInformer(ctx *actor.Context) {
 	pods, err := i.podInterface.List(metaV1.ListOptions{LabelSelector: determinedLabel})
 	if err != nil {
-		ctx.Log().WithError(err).Error("error retrieving internal resource version")
+		ctx.Log().WithError(err).Warnf("error retrieving internal resource version")
 		actors.NotifyAfter(ctx, defaultInformerBackoff, startInformer{})
 		return
 	}
@@ -81,7 +81,7 @@ func (i *informer) startInformer(ctx *actor.Context) {
 		},
 	})
 	if err != nil {
-		ctx.Log().WithError(err).Error("error initializing pod retry watcher")
+		ctx.Log().WithError(err).Warnf("error initializing pod retry watcher")
 		actors.NotifyAfter(ctx, defaultInformerBackoff, startInformer{})
 		return
 	}
@@ -89,13 +89,13 @@ func (i *informer) startInformer(ctx *actor.Context) {
 	ctx.Log().Info("pod informer is starting")
 	for event := range rw.ResultChan() {
 		if event.Type == watch.Error {
-			ctx.Log().Errorf("pod informer emitted error %+v", event)
+			ctx.Log().Warnf("pod informer emitted error %+v", event)
 			continue
 		}
 
 		pod, ok := event.Object.(*k8sV1.Pod)
 		if !ok {
-			ctx.Log().Errorf("error converting event of type %T to *k8sV1.Pod: %+v", event, event)
+			ctx.Log().Warnf("error converting event of type %T to *k8sV1.Pod: %+v", event, event)
 			continue
 		}
 

--- a/master/internal/kubernetes/informer.go
+++ b/master/internal/kubernetes/informer.go
@@ -1,7 +1,13 @@
 package kubernetes
 
 import (
-	"github.com/pkg/errors"
+	"time"
+
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/tools/cache"
+	watchtools "k8s.io/client-go/tools/watch"
+
+	"github.com/determined-ai/determined/master/pkg/actor/actors"
 
 	k8sV1 "k8s.io/api/core/v1"
 	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -9,6 +15,8 @@ import (
 
 	"github.com/determined-ai/determined/master/pkg/actor"
 )
+
+const defaultInformerBackoff = 5 * time.Second
 
 // messages that are sent to the informer.
 type (
@@ -47,9 +55,7 @@ func (i *informer) Receive(ctx *actor.Context) error {
 		ctx.Tell(ctx.Self(), startInformer{})
 
 	case startInformer:
-		if err := i.startInformer(ctx); err != nil {
-			return err
-		}
+		i.startInformer(ctx)
 
 	case actor.PostStop:
 
@@ -61,14 +67,32 @@ func (i *informer) Receive(ctx *actor.Context) error {
 	return nil
 }
 
-func (i *informer) startInformer(ctx *actor.Context) error {
-	watch, err := i.podInterface.Watch(metaV1.ListOptions{LabelSelector: determinedLabel})
+func (i *informer) startInformer(ctx *actor.Context) {
+	pods, err := i.podInterface.List(metaV1.ListOptions{LabelSelector: determinedLabel})
 	if err != nil {
-		return errors.Wrap(err, "error initializing pod watch")
+		ctx.Log().WithError(err).Error("error retrieving internal resource version")
+		actors.NotifyAfter(ctx, defaultInformerBackoff, startInformer{})
+		return
+	}
+
+	rw, err := watchtools.NewRetryWatcher(pods.ResourceVersion, &cache.ListWatch{
+		WatchFunc: func(options metaV1.ListOptions) (watch.Interface, error) {
+			return i.podInterface.Watch(metaV1.ListOptions{LabelSelector: determinedLabel})
+		},
+	})
+	if err != nil {
+		ctx.Log().WithError(err).Error("error initializing pod retry watcher")
+		actors.NotifyAfter(ctx, defaultInformerBackoff, startInformer{})
+		return
 	}
 
 	ctx.Log().Info("pod informer is starting")
-	for event := range watch.ResultChan() {
+	for event := range rw.ResultChan() {
+		if event.Type == watch.Error {
+			ctx.Log().Errorf("pod informer emitted error %+v", event)
+			continue
+		}
+
 		pod, ok := event.Object.(*k8sV1.Pod)
 		if !ok {
 			ctx.Log().Errorf("error converting event of type %T to *k8sV1.Pod: %+v", event, event)
@@ -85,6 +109,4 @@ func (i *informer) startInformer(ctx *actor.Context) error {
 
 	ctx.Log().Warn("pod informer stopped unexpectedly")
 	ctx.Tell(ctx.Self(), startInformer{})
-
-	return nil
 }

--- a/master/internal/kubernetes/pod.go
+++ b/master/internal/kubernetes/pod.go
@@ -22,11 +22,12 @@ import (
 )
 
 const (
-	initContainerTarSrcPath = "/run/determined/temp/tar/src"
-	initContainerTarDstPath = "/run/determined/temp/tar/dst"
-	initContainerWorkDir    = "/run/determined/temp/"
-	determinedLabel         = "determined"
-	determinedSystemLabel   = "determined-system"
+	initContainerTarSrcPath   = "/run/determined/temp/tar/src"
+	initContainerTarDstPath   = "/run/determined/temp/tar/dst"
+	initContainerWorkDir      = "/run/determined/temp/"
+	determinedLabel           = "determined"
+	determinedPreemptionLabel = "determined-preemption"
+	determinedSystemLabel     = "determined-system"
 )
 
 // pod manages the lifecycle of a Kubernetes pod that executes a

--- a/master/internal/kubernetes/pods.go
+++ b/master/internal/kubernetes/pods.go
@@ -139,6 +139,8 @@ func (p *pods) Receive(ctx *actor.Context) error {
 		p.startEventListener(ctx)
 		p.startPreemptionListener(ctx)
 
+	case actor.PostStop:
+
 	case sproto.StartTaskPod:
 		if err := p.receiveStartTaskPod(ctx, msg); err != nil {
 			return err

--- a/master/internal/kubernetes/preemptions.go
+++ b/master/internal/kubernetes/preemptions.go
@@ -62,7 +62,7 @@ func (p *preemptionListener) startPreemptionListener(ctx *actor.Context) {
 	pods, err := p.clientSet.CoreV1().Pods(p.namespace).List(
 		metaV1.ListOptions{LabelSelector: determinedPreemptionLabel})
 	if err != nil {
-		ctx.Log().WithError(err).Error(
+		ctx.Log().WithError(err).Warnf(
 			"error in initializing preemption listener: checking for pods to preempt",
 		)
 		actors.NotifyAfter(ctx, defaultInformerBackoff, startPreemptionListener{})
@@ -80,7 +80,7 @@ func (p *preemptionListener) startPreemptionListener(ctx *actor.Context) {
 		},
 	})
 	if err != nil {
-		ctx.Log().WithError(err).Error("error initializing preemption watch")
+		ctx.Log().WithError(err).Warnf("error initializing preemption watch")
 		actors.NotifyAfter(ctx, defaultInformerBackoff, startPreemptionListener{})
 		return
 	}

--- a/master/internal/kubernetes/preemptions.go
+++ b/master/internal/kubernetes/preemptions.go
@@ -1,9 +1,12 @@
 package kubernetes
 
 import (
-	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/tools/cache"
+	watchtools "k8s.io/client-go/tools/watch"
 
 	"github.com/determined-ai/determined/master/pkg/actor"
+	"github.com/determined-ai/determined/master/pkg/actor/actors"
 
 	k8sV1 "k8s.io/api/core/v1"
 	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -42,9 +45,7 @@ func (p *preemptionListener) Receive(ctx *actor.Context) error {
 		ctx.Tell(ctx.Self(), startPreemptionListener{})
 
 	case startPreemptionListener:
-		if err := p.startPreemptionListener(ctx); err != nil {
-			return err
-		}
+		p.startPreemptionListener(ctx)
 
 	case actor.PostStop:
 
@@ -56,36 +57,49 @@ func (p *preemptionListener) Receive(ctx *actor.Context) error {
 	return nil
 }
 
-func (p *preemptionListener) startPreemptionListener(ctx *actor.Context) error {
+func (p *preemptionListener) startPreemptionListener(ctx *actor.Context) {
 	// check if there are pods to preempt on startup
 	pods, err := p.clientSet.CoreV1().Pods(p.namespace).List(
-		metaV1.ListOptions{LabelSelector: "determined-preemption"})
+		metaV1.ListOptions{LabelSelector: determinedPreemptionLabel})
 	if err != nil {
-		return errors.Wrap(err,
-			"error in initializing preemption listener: checking for pods to preempt")
+		ctx.Log().WithError(err).Error(
+			"error in initializing preemption listener: checking for pods to preempt",
+		)
+		actors.NotifyAfter(ctx, defaultInformerBackoff, startPreemptionListener{})
+		return
 	}
+
 	for _, pod := range pods.Items {
 		ctx.Tell(p.podsHandler, podPreemption{podName: pod.Name})
 	}
 
-	watch, err := p.clientSet.CoreV1().Pods(p.namespace).Watch(
-		metaV1.ListOptions{LabelSelector: "determined-preemption"})
+	rw, err := watchtools.NewRetryWatcher(pods.ResourceVersion, &cache.ListWatch{
+		WatchFunc: func(options metaV1.ListOptions) (watch.Interface, error) {
+			return p.clientSet.CoreV1().Pods(p.namespace).Watch(
+				metaV1.ListOptions{LabelSelector: determinedPreemptionLabel})
+		},
+	})
 	if err != nil {
-		return errors.Wrap(err, "error initializing preemption watch")
+		ctx.Log().WithError(err).Error("error initializing preemption watch")
+		actors.NotifyAfter(ctx, defaultInformerBackoff, startPreemptionListener{})
+		return
 	}
 
 	ctx.Log().Info("preemption listener is starting")
-	for pod := range watch.ResultChan() {
-		newPod, ok := pod.Object.(*k8sV1.Pod)
-		if !ok {
-			ctx.Log().Warnf("error converting object type %T to *k8sV1.Pod: %+v", pod, pod)
+	for e := range rw.ResultChan() {
+		if e.Type == watch.Error {
+			ctx.Log().WithField("error", e.Object).Warnf("preemption listener encountered error")
 			continue
 		}
-		ctx.Tell(p.podsHandler, podPreemption{podName: newPod.Name})
+
+		pod, ok := e.Object.(*k8sV1.Pod)
+		if !ok {
+			ctx.Log().Warnf("error converting object type %T to *k8sV1.Pod: %+v", e, e)
+			continue
+		}
+		ctx.Tell(p.podsHandler, podPreemption{podName: pod.Name})
 	}
 
 	ctx.Log().Warn("preemption listener stopped unexpectedly")
 	ctx.Tell(ctx.Self(), startPreemptionListener{})
-
-	return nil
 }

--- a/master/internal/resourcemanagers/setup.go
+++ b/master/internal/resourcemanagers/setup.go
@@ -6,6 +6,8 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 
+	"github.com/determined-ai/determined/master/internal/sproto"
+
 	"github.com/labstack/echo/v4"
 	"github.com/pkg/errors"
 
@@ -103,7 +105,7 @@ func setupKubernetesResourceManager(
 	loggingConfig model.LoggingConfig,
 ) *actor.Ref {
 	ref, _ := system.ActorOf(
-		actor.Addr("kubernetesRM"),
+		actor.Addr(sproto.K8sRMAddr),
 		newKubernetesResourceManager(config, echo, masterTLSConfig, loggingConfig),
 	)
 	system.Ask(ref, actor.Ping{}).Get()

--- a/master/internal/resourcemanagers/setup.go
+++ b/master/internal/resourcemanagers/setup.go
@@ -105,7 +105,7 @@ func setupKubernetesResourceManager(
 	loggingConfig model.LoggingConfig,
 ) *actor.Ref {
 	ref, _ := system.ActorOf(
-		actor.Addr(sproto.K8sRMAddr),
+		sproto.K8sRMAddr,
 		newKubernetesResourceManager(config, echo, masterTLSConfig, loggingConfig),
 	)
 	system.Ask(ref, actor.Ping{}).Get()


### PR DESCRIPTION
## Description
This change updates the k8s code to use the `watchtools.RetryWatcher` helper to recover from bad watches. Additionally it makes the watcher restart correctly from errors before it is instantiated.
<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan
- [x] run k8s tests
- [ ] deploy a cluster and blip the apiserver
<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)
I'll have a follow up to restructure the k8s actors so that the RM can actually handle pods actor failures (or at least notice them and print a really scary message).
<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234