### PR TITLE
fix: include maxval in int hparam range

### DIFF
--- a/docs/release-notes/2884-int-maxval.txt
+++ b/docs/release-notes/2884-int-maxval.txt
@@ -1,0 +1,12 @@
+:orphan:
+
+**Fixes**
+
+-  Include ``maxval`` in ``int``-type hyperparameter ranges. Previously, the docs said that the
+   endpoints of the hyperparameter were both inclusive, but in reality the upper limit ``maxval``
+   was never actually selected for any trials.
+
+-  **Breaking Change** The reproducibility of hyperparameter selection may differ between Determined
+   v0.16.5 and v0.17.0 for hyperparameter searches containing ``int``-type hyperparameters, due to
+   the above-mentioned fix. However, the reproducibility of model training for any given set of
+   pre-chosen hyperparameters should be unaffected.

--- a/master/pkg/searcher/hyperparameters.go
+++ b/master/pkg/searcher/hyperparameters.go
@@ -36,7 +36,7 @@ func sampleOne(h expconf.Hyperparameter, rand *nprand.State) interface{} {
 		return p.Val()
 	case h.RawIntHyperparameter != nil:
 		p := h.RawIntHyperparameter
-		return p.Minval() + rand.Intn(p.Maxval()-p.Minval())
+		return p.Minval() + rand.Intn(p.Maxval()-p.Minval()+1)
 	case h.RawDoubleHyperparameter != nil:
 		p := h.RawDoubleHyperparameter
 		return rand.Uniform(p.Minval(), p.Maxval())


### PR DESCRIPTION
Do what the docs have always said we do.

## Commentary

This has been broken since the python master was replaced with the go master.

Changing it includes breaking reproducibility of hparam sampling across determined versions, so we will land this in 0.17.0.