### PR TITLE
ci: push `latest` tag for master and agent Docker images

### DIFF
--- a/agent/.goreleaser.yml
+++ b/agent/.goreleaser.yml
@@ -46,6 +46,7 @@ dockers:
   - goos: linux
     goarch: amd64
     image_templates:
+      - "determinedai/{{.ProjectName}}:latest"
       - "determinedai/{{.ProjectName}}:{{.Env.VERSION}}"
       - "determinedai/{{.ProjectName}}:{{.ShortCommit}}"
       - "determinedai/{{.ProjectName}}:{{.FullCommit}}"

--- a/master/.goreleaser.yml
+++ b/master/.goreleaser.yml
@@ -58,6 +58,7 @@ dockers:
   - goos: linux
     goarch: amd64
     image_templates:
+      - "determinedai/{{.ProjectName}}:latest"
       - "determinedai/{{.ProjectName}}:{{.Env.VERSION}}"
       - "determinedai/{{.ProjectName}}:{{.ShortCommit}}"
       - "determinedai/{{.ProjectName}}:{{.FullCommit}}"


### PR DESCRIPTION
Closes #2630.

## Description

## Test Plan

Eh, wait and see what happens during the release? Seems unlikely to go wrong.