### PR TITLE
chore: fix docstring syntax and remove extra whitespace

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -243,7 +243,7 @@ commands:
           steps:
             - run:
                 name: Install mmdetection dependencies
-                command: sudo apt-get install -y ffmpeg libsm6 libxext6 
+                command: sudo apt-get install -y ffmpeg libsm6 libxext6
             - install-wheel:
                 package-name: model-hub
                 package-location: ~/project/model_hub

--- a/e2e_tests/tests/fixtures/mmdetection/fake_data.yaml
+++ b/e2e_tests/tests/fixtures/mmdetection/fake_data.yaml
@@ -18,7 +18,7 @@ searcher:
     batches: 200
   smaller_is_better: false
 environment:
-  image: 
+  image:
     gpu: determinedai/model-hub-mmdetection
 bind_mounts:
     - host_path: /tmp

--- a/e2e_tests/tests/fixtures/mmdetection/startup-hook.sh
+++ b/e2e_tests/tests/fixtures/mmdetection/startup-hook.sh
@@ -1,4 +1,4 @@
 wget http://images.cocodataset.org/annotations/annotations_trainval2017.zip
-unzip annotations_trainval2017.zip 
+unzip annotations_trainval2017.zip
 mv annotations/instances_train2017.json /tmp
 mv annotations/instances_val2017.json /tmp

--- a/harness/determined/pytorch/_experimental.py
+++ b/harness/determined/pytorch/_experimental.py
@@ -66,6 +66,7 @@ class PyTorchExperimentalContext:
         as in the example below.
 
         .. code-block:: python
+
             # PyTorchTrial methods.
             def __init__(context): # PyTorchTrial init
                 self.context.experimental.disable_auto_to_device()

--- a/model_hub/Makefile
+++ b/model_hub/Makefile
@@ -75,7 +75,7 @@ build-transformers-dev:
 		--build-arg DATASETS_VERSION=$(DATASETS_VERSION) \
 		--build-arg MODEL_HUB_VERSION=$(VERSION) \
 		-t $(TRANSFORMERS_ENVIRONMENT_ROOT):$(SHORT_GIT_HASH) \
-		. 
+		.
 
 .PHONY: publish-transformers-dev
 publish-transformers-dev:
@@ -160,5 +160,3 @@ build-docker: build-transformers build-mmdetection
 
 .PHONY: publish-docker
 publish-docker: publish-transformers publish-mmdetection
-
-

--- a/model_hub/docker/Dockerfile.mmdetection
+++ b/model_hub/docker/Dockerfile.mmdetection
@@ -22,7 +22,7 @@ ARG MMDETECTION_VERSION
 RUN git checkout tags/v${MMDETECTION_VERSION}
 ENV FORCE_CUDA="1"
 RUN pip install -r requirements/build.txt
-RUN pip install --no-cache-dir -e . 
+RUN pip install --no-cache-dir -e .
 ENV MMDETECTION_CONFIG_DIR=/mmdetection/configs
 
 # Wheel must be built before building the docker image

--- a/model_hub/examples/mmdetection/hydra/README.md
+++ b/model_hub/examples/mmdetection/hydra/README.md
@@ -1,5 +1,5 @@
 # Using model-hub mmdetection with [Hydra](https://hydra.cc/)
-Hydra is a framework for configuring applications that works very well with machine learning experiments.  
+Hydra is a framework for configuring applications that works very well with machine learning experiments.
 You can use Determined's python API with Hydra to:
 * Easily submit experiments with different configurations
 * Perform parameter sweeps
@@ -29,12 +29,9 @@ python mmdet_experiment.py --multirun \
     hyperparameters.config_file=faster_rcnn/faster_rcnn_r50_fpn_1x_coco.py,detr/detr_r50_8x2_150e_coco.py
 ```
 
-Configuration with Hydra is also highly flexible and extensible.  
+Configuration with Hydra is also highly flexible and extensible.
 For example, you can run hyperparameter search on the optimizer learning rate by
 ```
 python mmdet_experiment.py searcher=adaptive +hyperparameters=tune_optimizer hyperparameters.config_file=mask_rcnn/mask_rcnn_r50_fpn_1x_coco.py
 ```
 You can look the [config directory](configs) to see how we use some of this functionality.  Feel free to add your own configs as needed to further customize the behavior.
-
-
-

--- a/model_hub/examples/mmdetection/hydra/configs/config.yaml
+++ b/model_hub/examples/mmdetection/hydra/configs/config.yaml
@@ -1,6 +1,6 @@
 name: model_hub_mmdet_experiment
 defaults:
-    - data: disk 
+    - data: disk
     - profiling: disabled
     - searcher: single
     - hyperparameters:
@@ -13,7 +13,7 @@ min_validation_period:
   batches: 7320
 
 environment:
-  image: 
+  image:
     gpu: determinedai/model-hub-mmdetection
   environment_variables:
       - OMP_NUM_THREADS=1 # Following pytorch dtrain, this environment variable is set to 1 to avoid overloading the system.

--- a/model_hub/examples/mmdetection/maskrcnn.yaml
+++ b/model_hub/examples/mmdetection/maskrcnn.yaml
@@ -40,7 +40,7 @@ searcher:
   smaller_is_better: false
 max_restarts: 0
 environment:
-  image: 
+  image:
     gpu: determinedai/model-hub-mmdetection
   environment_variables:
       - OMP_NUM_THREADS=1 # Following pytorch dtrain, this environment variable is set to 1 to avoid overloading the system.


### PR DESCRIPTION
## Description

There needs to be a blank line after a `.. code-block::` directive.

## Test Plan

- [x] build docs
