### PR TITLE
fix: `det deploy aws --retain-log-group`.

### DIFF
--- a/harness/determined/deploy/aws/templates/simple.yaml
+++ b/harness/determined/deploy/aws/templates/simple.yaml
@@ -684,7 +684,7 @@ Resources:
                 --network determined \
                 --restart unless-stopped \
                 --log-driver=awslogs \
-                --log-opt awslogs-group=${LogGroup} \
+                --log-opt awslogs-group=/${LogGroupPrefix}/${AWS::StackName} \
                 --log-opt awslogs-stream=determined-master \
                 -p "$port":"$port" \
                 -v /usr/local/determined/etc/:/etc/determined/ \
@@ -750,7 +750,7 @@ Outputs:
 
   LogGroup:
     Description: The Log Group for Determined Logs
-    Value: !Ref LogGroup
+    Value: !Sub /${LogGroupPrefix}/${AWS::StackName}
 
   Region:
     Description: The AWS Region the stack is deployed in


### PR DESCRIPTION
## Description

A two line "refactoring"/unification in #2766 broke `--retain-log-group` in `--deployment-type simple`. Rolling that back.

## Test Plan

CI is green again.

## Commentary (optional)

## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
