### PR TITLE
fix: pin version of `torchmetrics`

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,7 @@
 # pin docutils at 0.15.2 to avoid transitive dependency conflict with botocore (requires < 0.16)
 docutils==0.15.2
+# 0.5.1 raises an error in import during docs bulids.
+torchmetrics==0.5.0
 
 pillow
 pytorch-lightning==1.3.5


### PR DESCRIPTION
## Description

The just-released 0.5.1 appears to raise an error on import, at least in
the context of docs builds, so pin it for now.

## Test Plan

- observe [broken docs build first](https://app.circleci.com/pipelines/github/determined-ai/determined/15122/workflows/6230fcb2-484f-4b1b-b26e-b1e5cf25a026/jobs/455506), observe [successful docs build](https://app.circleci.com/pipelines/github/determined-ai/determined/15128/workflows/64cd79dd-5927-47c4-93b7-5e7eaf29db8d/jobs/455711) with the change
