### PR TITLE
fix: add support for float16 metrics serialization

### DIFF
--- a/harness/determined/util.py
+++ b/harness/determined/util.py
@@ -138,6 +138,8 @@ def json_encode(obj: Any, indent: Optional[str] = None, sort_keys: bool = False)
             return float(obj)
         if isinstance(obj, np.float32):
             return float(obj)
+        if isinstance(obj, np.float16):
+            return float(obj)
         if isinstance(obj, np.int64):
             return int(obj)
         if isinstance(obj, np.int32):


### PR DESCRIPTION
## Description

<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->
Adds support for float16 metrics serialization


## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->
When running an experiment using keras while having enable mixed precision using `tf.keras.mixed_precision.set_global_policy("mixed_float16")` (TF 2.6), the metrics are serialized before being sent by socket (to the master I guess?).
However, while float64 and float32 are supported, **float16** is not one of them: this patch hopefully fixes it.


## Checklist

- [X] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [X] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234