### PR TITLE
docs: update idle timeout [DET-5906]

### DIFF
--- a/docs/how-to/notebooks.txt
+++ b/docs/how-to/notebooks.txt
@@ -124,6 +124,7 @@ In addition to the ``--config`` flag, configuration may also be supplied via a Y
    bind_mounts:
      - host_path: /data/notebook_scratch
        container_path: /scratch
+   idle_timeout: 30m
    EOL
    $ det notebook start --config-file config.yaml
 

--- a/docs/reference/api/command-notebook-config.txt
+++ b/docs/reference/api/command-notebook-config.txt
@@ -134,7 +134,7 @@ The following configuration settings are supported:
 -  ``tensorboard_args``: Lists optional arguments for launching TensorBoard. Each element of the
    list should be a string of the form ``NAME=VALUE``.
 
--  ``idle_timeout``: Specifies the duration in seconds before idle instances are
+-  ``idle_timeout``: Specifies the duration before idle instances are
       automatically terminated. This string is a sequence of decimal numbers, each with optional
       fraction and a unit suffix, such as "30s", "1h", or "1m30s". Valid time units are "s", "m",
       "h". The default value is ``20m``. This is only used by TensorBoard and Notebook instances. A


### PR DESCRIPTION
## Description

Update idle timeout docs.

<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234