### PR TITLE
ci: unpin pip version, improve py venv cache key.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -266,7 +266,7 @@ commands:
             - "/tmp/venv"
       - run: python --version
       - run: pip --version
-      - run: pip freeze
+      - run: pip freeze --all
       # Allow this to fail, but it is useful for debugging.
       - run: sh -c "pip check || true"
 
@@ -1357,14 +1357,14 @@ jobs:
       # LMDB also has special requirements that only apply to windows (patch-ng).
       - run: sh -c "if which conda ; then conda install cryptography patch-ng --yes ; fi"
       - run: pip install --find-links build determined==<< pipeline.parameters.det-version >>
-      - run: pip freeze
+      - run: pip freeze --all
       # Allow this to fail, but it is useful for debugging.
       - run: sh -c "pip check || true"
       # Ensure Determined cli can run without installing cli test requirements
       - run: det --help
       - run: pip install setuptools_scm
       - run: pip install -r harness/tests/requirements.txt
-      - run: pip freeze
+      - run: pip freeze --all
       - run: sh -c "pip check || true"
       - run: pytest harness/tests/cli
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -218,6 +218,7 @@ commands:
           name: Write cache key
           command: |
             echo <<parameters.executor>> > /tmp/cachefile
+            pip freeze --all >> /tmp/cachefile
             if [ "<<parameters.determined>>" = "true" ]; then
               cat harness/setup.py >> /tmp/cachefile
             fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -212,7 +212,7 @@ commands:
             sudo apt-get install -y python3-venv
             /usr/bin/python3 -m venv /tmp/venv
             echo "export PATH=/tmp/venv/bin:\"${PATH}\"" >> $BASH_ENV
-            /tmp/venv/bin/python -m pip install --upgrade pip\<20 wheel setuptools\<58
+            /tmp/venv/bin/python -m pip install --upgrade pip wheel setuptools
 
       - run:
           name: Write cache key
@@ -231,7 +231,7 @@ commands:
 
       - restore_cache:
           keys:
-            - det-python-deps-v1dev2-{{ checksum "/tmp/cachefile" }}
+            - det-python-deps-v1dev3-{{ checksum "/tmp/cachefile" }}
       - when:
           condition: <<parameters.determined>>
           steps:
@@ -260,7 +260,7 @@ commands:
               pip install -r <<parameters.extra-requirements-file>>
             fi
       - save_cache:
-          key: det-python-deps-v1dev2-{{ checksum "/tmp/cachefile" }}
+          key: det-python-deps-v1dev3-{{ checksum "/tmp/cachefile" }}
           paths:
             - "/tmp/venv"
       - run: python --version


### PR DESCRIPTION
## Description

- Continuing #2920, I've found that the problem wasn't caused by setuptools 58 itself, but a conflict between it and the old circleci cache.
- To fix that, we bump the "major version" of the cache and add `pip freeze --all` to it, because it includes the versions of pip, wheel, and setuptools themselves (in contrast with the plain `pip freeze`).
- `pip<20` restriction comes from a while ago, and it seems we can modernize it.
- `setuptools<58` is no longer necessary.


## Test Plan

CI is green, and also runs fresh pip & setuptools.

## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234