### PR TITLE
refactor: move ee to oss [DET-5937]

### DIFF
--- a/proto/src/determined/api/v1/master.proto
+++ b/proto/src/determined/api/v1/master.proto
@@ -10,6 +10,17 @@ import "protoc-gen-swagger/options/annotations.proto";
 import "determined/log/v1/log.proto";
 import "determined/master/v1/master.proto";
 
+// Describe one SSO provider.
+message SSOProvider {
+  option (grpc.gateway.protoc_gen_swagger.options.openapiv2_schema) = {
+    json_schema: { required: [ "name", "sso_url" ] }
+  };
+  // A descriptive name for this provider.
+  string name = 1;
+  // The URL to use for SSO with this provider.
+  string sso_url = 2;
+}
+
 // Get master information.
 message GetMasterRequest {}
 // Response to GetMasterRequest.
@@ -29,6 +40,8 @@ message GetMasterResponse {
   string cluster_name = 4;
   // Telemetry status.
   bool telemetry_enabled = 5;
+  // SSO providers.
+  repeated SSOProvider sso_providers = 6;
 }
 
 // Get telemetry information.

--- a/webui/react/src/ee/SamlAuth.ts
+++ b/webui/react/src/ee/SamlAuth.ts
@@ -1,0 +1,22 @@
+import queryString from 'query-string';
+
+import history from 'routes/history';
+
+export const samlUrl = (basePath: string, queries?: string): string => {
+  if (!queries) return basePath;
+  return `${basePath}?relayState=${encodeURIComponent(queries)}`;
+};
+
+type WithRelayState<T> = T & {relayState?: string}
+
+// decode relayState into expected query params T
+export const handleRelayState = <T>(queries: WithRelayState<T>): T => {
+  if (!queries.relayState) return queries;
+  queries = {
+    ...queries,
+    ...(queryString.parse(queries.relayState)),
+  };
+  delete queries.relayState;
+  history.push(`${history.location.pathname}?${queryString.stringify(queries)}`);
+  return queries;
+};

--- a/webui/react/src/ioTypes.ts
+++ b/webui/react/src/ioTypes.ts
@@ -27,11 +27,17 @@ const optional = (x: io.Mixed) => io.union([ x, io.null, io.undefined ]);
 
 /* Info */
 
+const ioSsoProvider = io.type({
+  name: io.string,
+  sso_url: io.string,
+});
+
 export const ioDeterminedInfo = io.type({
   cluster_id: io.string,
   cluster_name: io.string,
   isTelemetryEnabled: io.boolean,
   master_id: io.string,
+  sso_providers: optional(io.array(ioSsoProvider)),
   version: io.string,
 });
 

--- a/webui/react/src/services/api-ts-sdk/api.ts
+++ b/webui/react/src/services/api-ts-sdk/api.ts
@@ -1933,6 +1933,12 @@ export interface V1GetMasterResponse {
      * @memberof V1GetMasterResponse
      */
     telemetryEnabled?: boolean;
+    /**
+     * SSO providers.
+     * @type {Array<V1SSOProvider>}
+     * @memberof V1GetMasterResponse
+     */
+    ssoProviders?: Array<V1SSOProvider>;
 }
 
 /**
@@ -4138,6 +4144,26 @@ export enum V1RunnableType {
     UNSPECIFIED = <any> 'RUNNABLE_TYPE_UNSPECIFIED',
     TRAIN = <any> 'RUNNABLE_TYPE_TRAIN',
     VALIDATE = <any> 'RUNNABLE_TYPE_VALIDATE'
+}
+
+/**
+ * Describe one SSO provider.
+ * @export
+ * @interface V1SSOProvider
+ */
+export interface V1SSOProvider {
+    /**
+     * A descriptive name for this provider.
+     * @type {string}
+     * @memberof V1SSOProvider
+     */
+    name: string;
+    /**
+     * The URL to use for SSO with this provider.
+     * @type {string}
+     * @memberof V1SSOProvider
+     */
+    ssoUrl: string;
 }
 
 /**

--- a/webui/react/src/services/apiConfig.ts
+++ b/webui/react/src/services/apiConfig.ts
@@ -119,7 +119,7 @@ export const getUsers: DetApi<EmptyParams, Api.V1GetUsersResponse, DetailedUser[
 
 export const getInfo: DetApi<EmptyParams, Api.V1GetMasterResponse, DeterminedInfo> = {
   name: 'getInfo',
-  postProcess: (response) => decoder.jsonToDeterminedInfo(response),
+  postProcess: (response) => decoder.mapV1MasterInfo(response),
   request: () => detApi.Cluster.determinedGetMaster(),
 };
 

--- a/webui/react/src/services/decoder.ts
+++ b/webui/react/src/services/decoder.ts
@@ -20,16 +20,12 @@ export const mapV1UserList = (data: Sdk.V1GetUsersResponse): types.DetailedUser[
 };
 
 export const mapV1MasterInfo = (data: Sdk.V1GetMasterResponse): types.DeterminedInfo => {
-  const ssoData = data as unknown as { ssoProviders?: types.SsoProvider[] };
-  const ssoProviders = ssoData.ssoProviders
-    ? ssoData.ssoProviders.map(provider => ({ name: provider.name, ssoUrl: provider.ssoUrl }))
-    : undefined;
   return {
     clusterId: data.clusterId,
     clusterName: data.clusterName,
     isTelemetryEnabled: data.telemetryEnabled === true,
     masterId: data.masterId,
-    ssoProviders,
+    ssoProviders: data.ssoProviders,
     version: data.version,
   };
 };

--- a/webui/react/src/services/decoder.ts
+++ b/webui/react/src/services/decoder.ts
@@ -19,12 +19,17 @@ export const mapV1UserList = (data: Sdk.V1GetUsersResponse): types.DetailedUser[
   return (data.users || []).map(user => mapV1User(user));
 };
 
-export const jsonToDeterminedInfo = (data: Sdk.V1GetMasterResponse): types.DeterminedInfo => {
+export const mapV1MasterInfo = (data: Sdk.V1GetMasterResponse): types.DeterminedInfo => {
+  const ssoData = data as unknown as { ssoProviders?: types.SsoProvider[] };
+  const ssoProviders = ssoData.ssoProviders
+    ? ssoData.ssoProviders.map(provider => ({ name: provider.name, ssoUrl: provider.ssoUrl }))
+    : undefined;
   return {
     clusterId: data.clusterId,
     clusterName: data.clusterName,
     isTelemetryEnabled: data.telemetryEnabled === true,
     masterId: data.masterId,
+    ssoProviders,
     version: data.version,
   };
 };

--- a/webui/react/src/types.ts
+++ b/webui/react/src/types.ts
@@ -33,11 +33,17 @@ export interface Auth {
   user?: DetailedUser;
 }
 
+export interface SsoProvider {
+  name: string;
+  ssoUrl: string;
+}
+
 export interface DeterminedInfo {
   clusterId: string;
   clusterName: string;
   isTelemetryEnabled: boolean;
   masterId: string;
+  ssoProviders?: SsoProvider[];
   version: string;
 }
 


### PR DESCRIPTION
## Description

Update OSS to detect if `ssoProviders` property is set on `/api/v1/master` and enable SAML sign in (via Okta).

Previously this code sat in our enterprise only version but we decided to bring all these features and delineations into the OSS repo. The goal is to have the cluster the WebUI is connected to, to determine what capabilities the cluster can support and turning these features on and off based on availability via the API. The basic idea is the following:

1. WebUI loads a generic form
2. WebUI fetches GET `/api/v1/master` to see what type of cluster setup it is talking to
3. Based on the previous API call, the WebUI turns on/off features the cluster is capable of handling.

In our case, we are simply turning on Okta single-sign-on if the `ssoProviders` field is returned from `/api/v1/master` and includes `okta` as one of the sso providers.

TESTED
Was able to point a local build to an ee cluster w/ Okta provider.
<img width="385" alt="Screen Shot 2021-09-15 at 1 31 51 PM" src="https://user-images.githubusercontent.com/220971/133497902-61ebd686-1c06-41d3-89d3-0b04287ec5b7.png">


<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan

- [x] confirm that OSS build can communicate with an EE cluster with SSO providers

<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234