### PR TITLE
feat: det deploy local: remove support for --auto-bind-mount [DET-5948]

### DIFF
--- a/docs/release-notes/2932-auto-bind-mount.txt
+++ b/docs/release-notes/2932-auto-bind-mount.txt
@@ -3,7 +3,7 @@
 **Removed Features**
 
 -  **Breaking Change** Remove ``--auto-bind-mount`` support from ``det deploy local``. The new
-   ``work_dir`` feature should be a strictly better experience. Users who depended on the
+   ``--auto-work-dir`` feature should be a strictly better experience. Users who depended on the
    ``shared_fs`` directory created by ``--auto-bind-mount`` can implement the same behavior by
    calling ``det deploy local cluster_up`` with a ``--master-config-path`` pointing to a
    ``master.yaml`` file containing the following text:
@@ -14,3 +14,12 @@
         bind_mounts:
           container_path: ./shared_fs
           host_path: /path/to/your/HOME/dir
+
+**New Features**
+
+-  Add a new ``--auto-work-dir`` feature to ``det deploy local``. Setting ``--auto-work-dir
+   /some/path`` will have two effects: First, ``/some/path`` will be bind-mounted into the container
+   (still as ``/some/path``). Second, interactive jobs (Notebooks, Shells, and Commands) will run in
+   the provided working directory by default. Note that by default, containers run as root, so you
+   may want to configure your user with ``det user`` such that interactive jobs run as your real
+   user.

--- a/docs/release-notes/2932-auto-bind-mount.txt
+++ b/docs/release-notes/2932-auto-bind-mount.txt
@@ -1,0 +1,16 @@
+:orphan:
+
+**Removed Features**
+
+-  **Breaking Change** Remove ``--auto-bind-mount`` support from ``det deploy local``. The new
+   ``work_dir`` feature should be a strictly better experience. Users who depended on the
+   ``shared_fs`` directory created by ``--auto-bind-mount`` can implement the same behavior by
+   calling ``det deploy local cluster_up`` with a ``--master-config-path`` pointing to a
+   ``master.yaml`` file containing the following text:
+
+   .. code:: yaml
+
+      task_container_defaults:
+        bind_mounts:
+          container_path: ./shared_fs
+          host_path: /path/to/your/HOME/dir

--- a/harness/determined/deploy/local/cli.py
+++ b/harness/determined/deploy/local/cli.py
@@ -29,8 +29,6 @@ def handle_cluster_up(args: argparse.Namespace) -> None:
         delete_db=args.delete_db,
         gpu=args.gpu,
         autorestart=(not args.no_autorestart),
-        auto_bind_mount=args.auto_bind_mount,
-        no_auto_bind_mount=args.no_auto_bind_mount,
     )
 
 
@@ -53,8 +51,6 @@ def handle_master_up(args: argparse.Namespace) -> None:
         db_password=args.db_password,
         delete_db=args.delete_db,
         autorestart=(not args.no_autorestart),
-        auto_bind_mount=args.auto_bind_mount,
-        no_auto_bind_mount=args.no_auto_bind_mount,
         cluster_name=args.cluster_name,
     )
 
@@ -161,17 +157,6 @@ args_description = Cmd(
                     help="disable container auto-restart (recommended for local development)",
                     action="store_true",
                 ),
-                Arg(
-                    "--auto-bind-mount",
-                    type=str,
-                    default=None,
-                    help="directory to mount into task containers (default: user's home directory)",
-                ),
-                Arg(
-                    "--no-auto-bind-mount",
-                    help="disable mounting user's home directory into task containers",
-                    action="store_true",
-                ),
             ],
         ),
         Cmd(
@@ -233,17 +218,6 @@ args_description = Cmd(
                 Arg(
                     "--no-autorestart",
                     help="disable container auto-restart (recommended for local development)",
-                    action="store_true",
-                ),
-                Arg(
-                    "--auto-bind-mount",
-                    type=str,
-                    default=str(Path.home()),
-                    help="directory to mount into task containers (default: user's home directory)",
-                ),
-                Arg(
-                    "--no-auto-bind-mount",
-                    help="disable mounting user's home directory into task containers",
                     action="store_true",
                 ),
                 Arg(

--- a/harness/determined/deploy/local/cli.py
+++ b/harness/determined/deploy/local/cli.py
@@ -3,14 +3,10 @@ import sys
 from pathlib import Path
 from typing import Callable, Dict
 
-import appdirs
-
 from determined.common.declarative_argparse import Arg, BoolOptArg, Cmd, Group
 
 from . import cluster_utils
 from .preflight import check_docker_install
-
-DEFAULT_STORAGE_HOST_PATH = Path(appdirs.user_data_dir("determined"))
 
 
 def handle_cluster_up(args: argparse.Namespace) -> None:
@@ -29,6 +25,7 @@ def handle_cluster_up(args: argparse.Namespace) -> None:
         delete_db=args.delete_db,
         gpu=args.gpu,
         autorestart=(not args.no_autorestart),
+        auto_work_dir=args.auto_work_dir,
     )
 
 
@@ -52,6 +49,7 @@ def handle_master_up(args: argparse.Namespace) -> None:
         delete_db=args.delete_db,
         autorestart=(not args.no_autorestart),
         cluster_name=args.cluster_name,
+        auto_work_dir=args.auto_work_dir,
     )
 
 
@@ -115,7 +113,7 @@ args_description = Cmd(
                     Arg(
                         "--storage-host-path",
                         type=Path,
-                        default=DEFAULT_STORAGE_HOST_PATH,
+                        default=None,
                         help="Storage location for cluster data (e.g. checkpoints)",
                     ),
                 ),
@@ -157,6 +155,12 @@ args_description = Cmd(
                     help="disable container auto-restart (recommended for local development)",
                     action="store_true",
                 ),
+                Arg(
+                    "--auto-work-dir",
+                    type=Path,
+                    default=None,
+                    help="the default work dir, used for interactive jobs",
+                ),
             ],
         ),
         Cmd(
@@ -192,7 +196,7 @@ args_description = Cmd(
                     Arg(
                         "--storage-host-path",
                         type=str,
-                        default=DEFAULT_STORAGE_HOST_PATH,
+                        default=None,
                         help="Storage location for cluster data (e.g. checkpoints)",
                     ),
                 ),
@@ -225,6 +229,12 @@ args_description = Cmd(
                     type=str,
                     default="determined",
                     help="name for the cluster resources",
+                ),
+                Arg(
+                    "--auto-work-dir",
+                    type=Path,
+                    default=None,
+                    help="the default work dir, used for interactive jobs",
                 ),
             ],
         ),

--- a/harness/determined/deploy/local/cluster_utils.py
+++ b/harness/determined/deploy/local/cluster_utils.py
@@ -2,13 +2,16 @@ import os
 import re
 import subprocess
 import sys
+import tempfile
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Sequence
 
+import appdirs
 import docker
 
 import determined
 import determined.deploy
+from determined.common import yaml
 from determined.deploy.errors import MasterTimeoutExpired
 from determined.deploy.healthcheck import wait_for_master
 
@@ -78,7 +81,6 @@ def docker_compose(
     # Start with the user's environment to ensure that Docker and Docker Compose work correctly.
     process_env = dict(os.environ)
     if env is not None:
-        # raise ValueError(str(env))
         process_env.update(env)
     process_env["INTEGRATIONS_PROXY_ADDR"] = get_proxy_addr()
     base_command = ["docker-compose", "-f", str(path), "-p", cluster_name]
@@ -110,9 +112,9 @@ def master_up(
     delete_db: bool,
     autorestart: bool,
     cluster_name: str,
+    auto_work_dir: Optional[Path],
 ) -> None:
     command = ["up", "-d"]
-    extra_files = []
     if image_repo_prefix is None:
         image_repo_prefix = "determinedai"
     if version is None:
@@ -124,30 +126,68 @@ def master_up(
 
     env = {
         "INTEGRATIONS_HOST_PORT": str(port),
-        "DET_MASTER_CONFIG": str(master_config_path),
         "DET_DB_PASSWORD": db_password,
         "IMAGE_REPO_PREFIX": image_repo_prefix,
         "DET_VERSION": version,
         "DET_RESTART_POLICY": restart_policy,
     }
 
-    # When master config yaml is provided, we don't provide our own storage path
-    # as we expect the yaml to specify checkpoint_storage.
-    if master_config_path is not None:
-        master_config_path = Path(master_config_path).resolve()
-        mount_yaml = Path(__file__).parent.joinpath("mount.yaml").resolve()
-        extra_files.append(str(mount_yaml))
-    else:
-        storage_yaml = Path(__file__).parent.joinpath("storage.yaml").resolve()
-        extra_files.append(str(storage_yaml))
+    # Some cli flags for det deploy local will cause us to write a temporary master.yaml.
+    master_conf = {}
+    make_temp_conf = False
 
+    if master_config_path is not None:
+        with master_config_path.open() as f:
+            master_conf = yaml.safe_load(f)
+    else:
+        # These defaults come from master/packaging/master.yaml (except for host_path).
+        master_conf = {
+            "db": {
+                "user": "postgres",
+                "host": "determined-db",
+                "port": 5432,
+                "name": "determined",
+            },
+            "checkpoint_storage": {
+                "type": "shared_fs",
+                "host_path": str(Path(appdirs.user_data_dir("determined"))),
+                "save_experiment_best": 0,
+                "save_trial_best": 1,
+                "save_trial_latest": 1,
+            },
+        }
+        make_temp_conf = True
+
+    if storage_host_path is not None:
         if not storage_host_path.exists():
             storage_host_path.mkdir(parents=True)
+        master_conf["checkpoint_storage"] = {
+            "type": "shared_fs",
+            "host_path": str(storage_host_path.resolve()),
+        }
+        make_temp_conf = True
 
-        env["DET_CHECKPOINT_STORAGE_HOST_PATH"] = str(storage_host_path)
+    if auto_work_dir is not None:
+        work_dir = str(auto_work_dir.resolve())
+        master_conf.setdefault("task_container_defaults", {})["work_dir"] = work_dir
+        master_conf["task_container_defaults"].setdefault("bind_mounts", []).append(
+            {"host_path": work_dir, "container_path": work_dir}
+        )
+        make_temp_conf = True
+
+    if make_temp_conf:
+        fd, temp_path = tempfile.mkstemp(prefix="det-deploy-local-master-config-")
+        with open(fd, "w") as f:
+            yaml.dump(master_conf, f)
+        master_config_path = Path(temp_path)
+
+    # This is always true by now, but mypy needs help.
+    assert master_config_path is not None
+
+    env["DET_MASTER_CONFIG"] = str(master_config_path.resolve())
 
     master_down(master_name, delete_db)
-    docker_compose(command, master_name, env, extra_files=extra_files)
+    docker_compose(command, master_name, env)
     _wait_for_master("localhost", port, cluster_name)
 
 
@@ -170,6 +210,7 @@ def cluster_up(
     delete_db: bool,
     gpu: bool,
     autorestart: bool,
+    auto_work_dir: Optional[Path],
 ) -> None:
     cluster_down(cluster_name, delete_db)
     master_up(
@@ -183,6 +224,7 @@ def cluster_up(
         delete_db=delete_db,
         autorestart=autorestart,
         cluster_name=cluster_name,
+        auto_work_dir=auto_work_dir,
     )
     for agent_number in range(num_agents):
         agent_name = cluster_name + f"-agent-{agent_number}"

--- a/harness/determined/deploy/local/cluster_utils.py
+++ b/harness/determined/deploy/local/cluster_utils.py
@@ -109,8 +109,6 @@ def master_up(
     db_password: str,
     delete_db: bool,
     autorestart: bool,
-    auto_bind_mount: Optional[str],
-    no_auto_bind_mount: bool,
     cluster_name: str,
 ) -> None:
     command = ["up", "-d"]
@@ -123,12 +121,6 @@ def master_up(
         restart_policy = "unless-stopped"
     else:
         restart_policy = "no"
-    if auto_bind_mount:
-        bind_mount = auto_bind_mount
-    else:
-        bind_mount = str(Path.home())
-    if no_auto_bind_mount:
-        bind_mount = ""
 
     env = {
         "INTEGRATIONS_HOST_PORT": str(port),
@@ -137,7 +129,6 @@ def master_up(
         "IMAGE_REPO_PREFIX": image_repo_prefix,
         "DET_VERSION": version,
         "DET_RESTART_POLICY": restart_policy,
-        "DET_AUTO_BIND_MOUNT": bind_mount,
     }
 
     # When master config yaml is provided, we don't provide our own storage path
@@ -179,8 +170,6 @@ def cluster_up(
     delete_db: bool,
     gpu: bool,
     autorestart: bool,
-    auto_bind_mount: Optional[str],
-    no_auto_bind_mount: bool,
 ) -> None:
     cluster_down(cluster_name, delete_db)
     master_up(
@@ -193,8 +182,6 @@ def cluster_up(
         db_password=db_password,
         delete_db=delete_db,
         autorestart=autorestart,
-        auto_bind_mount=auto_bind_mount,
-        no_auto_bind_mount=no_auto_bind_mount,
         cluster_name=cluster_name,
     )
     for agent_number in range(num_agents):

--- a/harness/determined/deploy/local/docker-compose.yaml
+++ b/harness/determined/deploy/local/docker-compose.yaml
@@ -19,6 +19,8 @@ services:
     depends_on:
       - determined-db
     image: ${IMAGE_REPO_PREFIX:-determinedai}/determined-master:${DET_VERSION}
+    volumes:
+      - ${DET_MASTER_CONFIG}:/etc/determined/master.yaml
     ports:
       - "${INTEGRATIONS_HOST_PORT:-8080}:8080"
     environment:

--- a/harness/determined/deploy/local/docker-compose.yaml
+++ b/harness/determined/deploy/local/docker-compose.yaml
@@ -25,7 +25,6 @@ services:
       DET_LOG_LEVEL: ${INTEGRATIONS_LOG_LEVEL:-info}
       DET_MASTER_HTTP_PORT: ${INTEGRATIONS_HOST_PORT:-8080}
       DET_DB_PASSWORD: ${DET_DB_PASSWORD}
-      DET_AUTO_BIND_MOUNT: ${DET_AUTO_BIND_MOUNT}
 
 volumes:
   determined-db-volume: {}

--- a/harness/determined/deploy/local/mount.yaml
+++ b/harness/determined/deploy/local/mount.yaml
@@ -1,6 +1,0 @@
-version: "3.7"
-
-services:
-  determined-master:
-    volumes:
-      -  ${DET_MASTER_CONFIG:-/usr/local/determined/etc/master.yaml}:/etc/determined/master.yaml

--- a/harness/determined/deploy/local/storage.yaml
+++ b/harness/determined/deploy/local/storage.yaml
@@ -1,7 +1,0 @@
-version: "3.7"
-
-services:
-  determined-master:
-    environment:
-      DET_CHECKPOINT_STORAGE_TYPE: shared_fs
-      DET_CHECKPOINT_STORAGE_HOST_PATH: ${DET_CHECKPOINT_STORAGE_HOST_PATH}

--- a/master/cmd/determined-master/init.go
+++ b/master/cmd/determined-master/init.go
@@ -46,10 +46,6 @@ func (c configKey) FlagName() string {
 	return strings.Join(c, "-")
 }
 
-func registerEnv(name configKey) {
-	_ = v.BindEnv(name.AccessPath(), name.EnvName())
-}
-
 func registerString(flags *pflag.FlagSet, name configKey, value string, usage string) {
 	flags.String(name.FlagName(), value, usage)
 	_ = v.BindEnv(name.AccessPath(), name.EnvName())
@@ -133,9 +129,4 @@ func registerConfig() {
 		defaults.Telemetry.SegmentMasterKey, "the Segment write key for the master")
 	registerString(flags, name("telemetry", "segment-webui-key"),
 		defaults.Telemetry.SegmentWebUIKey, "the Segment write key for the WebUI")
-
-	// These env vars are used by `det deploy` to override host_path.
-	// We don't register pflags for these to avoid setting a default.
-	registerEnv(name("checkpoint-storage", "type"))
-	registerEnv(name("checkpoint-storage", "host-path"))
 }

--- a/master/cmd/determined-master/init.go
+++ b/master/cmd/determined-master/init.go
@@ -138,7 +138,4 @@ func registerConfig() {
 	// We don't register pflags for these to avoid setting a default.
 	registerEnv(name("checkpoint-storage", "type"))
 	registerEnv(name("checkpoint-storage", "host-path"))
-
-	// This env var is used by `det deploy` to override bind_mounts.
-	registerEnv(name("auto-bind-mount"))
 }


### PR DESCRIPTION
Support for work_dir will provide a strictly better experience that
--auto-bind-mount could provide, but both features combined would result
in strange directory layouts.  We'd rather just have work_dir.

Users who depended on --auto-bind-mount should instead use the
--master-config-path option to create a relative bind mount directly in
the master.yaml.