### PR TITLE
chore: rework tensorboard and checkpoint gc paths

### DIFF
--- a/harness/determined/exec/tensorboard.py
+++ b/harness/determined/exec/tensorboard.py
@@ -1,4 +1,3 @@
-import json
 import os
 import subprocess
 import sys
@@ -9,9 +8,12 @@ import boto3
 import requests
 
 
-def set_s3_region(bucket: str) -> None:
-    endpoint_url = os.environ.get("DET_S3_ENDPOINT", None)
+def set_s3_region() -> None:
+    bucket = os.environ.get("AWS_BUCKET")
+    if bucket is None:
+        return
 
+    endpoint_url = os.environ.get("DET_S3_ENDPOINT_URL", None)
     client = boto3.client("s3", endpoint_url=endpoint_url)
     bucketLocation = client.get_bucket_location(Bucket=bucket)
 
@@ -60,31 +62,6 @@ def wait_for_tensorboard(max_seconds: float, url: str, still_alive_fn: Callable[
             if len(val):
                 print("TensorBoard contains metrics")
                 return True
-
-
-def main(args: List[str]) -> int:
-    with open("/run/determined/workdir/experiment_config.json") as f:
-        exp_conf = json.load(f)
-
-    if exp_conf["checkpoint_storage"]["type"] == "s3":
-        set_s3_region(exp_conf["checkpoint_storage"]["bucket"])
-
-    task_id = os.environ["DET_TASK_ID"]
-    port = os.environ["TENSORBOARD_PORT"]
-    tensorboard_addr = f"http://localhost:{port}/proxy/{task_id}"
-    url = f"{tensorboard_addr}/data/plugin/scalars/tags"
-    tensorboard_args = get_tensorboard_args(args)
-
-    print(f"Running: {tensorboard_args}")
-    p = subprocess.Popen(tensorboard_args)
-
-    def still_alive() -> bool:
-        return p.poll() is None
-
-    if not wait_for_tensorboard(600, url, still_alive):
-        p.kill()
-
-    return p.wait()
 
 
 def get_tensorboard_version(version: str) -> Tuple[str, str]:
@@ -142,6 +119,27 @@ def get_tensorboard_args(args: List[str]) -> List[str]:
 
     tensorboard_args.append(f"--logdir={logdir}")
     return tensorboard_args
+
+
+def main(args: List[str]) -> int:
+    set_s3_region()
+
+    task_id = os.environ["DET_TASK_ID"]
+    port = os.environ["TENSORBOARD_PORT"]
+    tensorboard_addr = f"http://localhost:{port}/proxy/{task_id}"
+    url = f"{tensorboard_addr}/data/plugin/scalars/tags"
+    tensorboard_args = get_tensorboard_args(args)
+
+    print(f"Running: {tensorboard_args}")
+    p = subprocess.Popen(tensorboard_args)
+
+    def still_alive() -> bool:
+        return p.poll() is None
+
+    if not wait_for_tensorboard(600, url, still_alive):
+        p.kill()
+
+    return p.wait()
 
 
 if __name__ == "__main__":

--- a/master/internal/api_tensorboard.go
+++ b/master/internal/api_tensorboard.go
@@ -35,11 +35,10 @@ import (
 )
 
 const (
-	expConfPath = "/run/determined/workdir/experiment_config.json"
 	// Agent ports 2600 - 3500 are split between TensorBoards, Notebooks, and Shells.
 	minTensorBoardPort        = 2600
 	maxTensorBoardPort        = minTensorBoardPort + 299
-	tensorboardEntrypointFile = "/run/determined/workdir/tensorboard-entrypoint.sh"
+	tensorboardEntrypointFile = "/run/determined/tensorboard/tensorboard-entrypoint.sh"
 )
 
 var tensorboardsAddr = actor.Addr("tensorboard")
@@ -187,7 +186,7 @@ func (a *apiServer) LaunchTensorboard(
 
 				// The TensorBoard container needs access to the original URL
 				// and the URL in "host:port" form.
-				uniqEnvVars["DET_S3_ENDPOINT"] = *c.EndpointURL()
+				uniqEnvVars["DET_S3_ENDPOINT_URL"] = *c.EndpointURL()
 				uniqEnvVars["S3_ENDPOINT"] = endpoint.Host
 
 				uniqEnvVars["S3_USE_HTTPS"] = "0"
@@ -278,7 +277,6 @@ func (a *apiServer) LaunchTensorboard(
 			etc.MustStaticFile(etc.TensorboardEntryScriptResource), 0700,
 			tar.TypeReg,
 		),
-		spec.Base.AgentUserGroup.OwnedArchiveItem(expConfPath, confBytes, 0700, tar.TypeReg),
 	}
 
 	if err = check.Validate(req.Config); err != nil {


### PR DESCRIPTION
Make the tensorboard and checkpoint gc applications to not rely on
the working directory whatsoever.

Let tensorboard use /run/determined/tensorboard, and let checkpoint gc
use /run/determined/checkpoint_gc, the way trials use
/run/determined/trial.