### PR TITLE
feat: allow kubernetes to use priority from exp config

### DIFF
--- a/docs/topic-guides/system-concepts/scheduling.txt
+++ b/docs/topic-guides/system-concepts/scheduling.txt
@@ -190,18 +190,25 @@ and Determined can only automatically set labels for GPU experiments.
 Determined provides a default priority class, ``determined-medium-priority`` that has a priority of
 ``50`` and is used for all tasks. If users want to set a different priority level for an experiment,
 they may either specify a priority in the ``resources`` field of the experiment config or create a
-priorityclass and specify it in the ``pod_spec`` of the config, as shown below. Also, if using a
-cluster with tainted nodes or labels, users must specify the tolerations or node selectors in the
-``pod_spec``:
+priorityClass and specify it in the ``pod_spec`` of the config. If both are specified, the specified
+priorityClass will take precedence over the priority field.
+
+Additionally, if using a cluster with tainted nodes or labels, users must specify the tolerations or
+node selectors in the ``pod_spec``. We recommend using both tolerations and node selectors to better
+constrain where your experiments can run, especially on clusters that contain multiple GPU types.
+
+Below is an example that illustrates how to set priorities, tolerations, and node selectors.
 
 .. code:: yaml
 
+   resources:
+      priority: 42 # priorityClass, if set, takes precedence over this value
    environment:
       pod_spec:
          apiVersion: v1
          kind: Pod
          spec:
-            priorityClassName: determined-medium-priority
+            priorityClassName: determined-medium-priority # don't set if using priority value
             nodeSelector:
                key: value
             tolerations:
@@ -209,6 +216,3 @@ cluster with tainted nodes or labels, users must specify the tolerations or node
                operator: "Equal"
                value: "value"
                effect: "NoSchedule"
-
-We recommend using both tolerations and node selectors to better constrain where your experiments
-can run, especially on clusters that contain multiple GPU types.

--- a/docs/topic-guides/system-concepts/scheduling.txt
+++ b/docs/topic-guides/system-concepts/scheduling.txt
@@ -187,8 +187,12 @@ This plugin is also in beta and is not enabled by default. Similar to the cosche
 enabled by setting the ``defaultScheduler`` field to ``preemption``. Autoscaling is not supported
 and Determined can only automatically set labels for GPU experiments.
 
-If using a cluster with tainted nodes or labels, users must specify the tolerations or node
-selectors in the experiment config:
+Determined provides a default priority class, ``determined-medium-priority`` that has a priority of
+``50`` and is used for all tasks. If users want to set a different priority level for an experiment,
+they may either specify a priority in the ``resources`` field of the experiment config or create a
+priorityclass and specify it in the ``pod_spec`` of the config, as shown below. Also, if using a
+cluster with tainted nodes or labels, users must specify the tolerations or node selectors in the
+``pod_spec``:
 
 .. code:: yaml
 
@@ -207,7 +211,4 @@ selectors in the experiment config:
                effect: "NoSchedule"
 
 We recommend using both tolerations and node selectors to better constrain where your experiments
-can run, especially on clusters that contain multiple GPU types. Lastly, Determined provides low,
-medium, and high priority classes by default, named ``determined-low-priority``,
-``determined-medium-priority``, and ``determined-high-priority``. Users may make their own priority
-classes for finer grained control if they wish.
+can run, especially on clusters that contain multiple GPU types.

--- a/helm/charts/determined/Chart.yaml
+++ b/helm/charts/determined/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: determined
 description: A Helm chart for Determined
-version: "0.16.4"
+version: "0.16.5"
 icon: https://github.com/determined-ai/determined/blob/master/determined-logo.png?raw=true
 home: https://github.com/determined-ai/determined.git
 

--- a/helm/charts/determined/templates/master-permissions.yaml
+++ b/helm/charts/determined/templates/master-permissions.yaml
@@ -29,7 +29,9 @@ rules:
   - apiGroups: [""]
     resources: ["nodes", "events"]
     verbs: ["list", "watch"]
-
+  - apiGroups: ["scheduling.k8s.io"]
+    resources: ["priorityclasses"]
+    verbs: ["create", "get", "list", "delete"]
 
 
 ---

--- a/helm/charts/determined/templates/priority-classes.yaml
+++ b/helm/charts/determined/templates/priority-classes.yaml
@@ -7,6 +7,15 @@ preemptionPolicy: Never
 globalDefault: false
 description: "This priority class should be used for Determined system pods only."
 ---
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: determined-medium-priority
+value: 50
+preemptionPolicy: Never
+globalDefault: false
+description: "This priority class should be used for medium priority Determined jobs."
+---
 {{- if .Values.defaultScheduler}}
 {{- $schedulerType := .Values.defaultScheduler | trim}}
 {{- if or (eq $schedulerType "coscheduler") (eq $schedulerType "preemption")}}
@@ -18,15 +27,6 @@ value: 100
 preemptionPolicy: Never
 globalDefault: false
 description: "This priority class should be used for high priority Determined jobs."
----
-apiVersion: scheduling.k8s.io/v1
-kind: PriorityClass
-metadata:
-  name: determined-medium-priority
-value: 50
-preemptionPolicy: Never
-globalDefault: false
-description: "This priority class should be used for medium priority Determined jobs."
 ---
 apiVersion: scheduling.k8s.io/v1
 kind: PriorityClass

--- a/helm/charts/determined/templates/priority-classes.yaml
+++ b/helm/charts/determined/templates/priority-classes.yaml
@@ -15,26 +15,3 @@ value: 50
 preemptionPolicy: Never
 globalDefault: false
 description: "This priority class should be used for medium priority Determined jobs."
----
-{{- if .Values.defaultScheduler}}
-{{- $schedulerType := .Values.defaultScheduler | trim}}
-{{- if or (eq $schedulerType "coscheduler") (eq $schedulerType "preemption")}}
-apiVersion: scheduling.k8s.io/v1
-kind: PriorityClass
-metadata:
-  name: determined-high-priority
-value: 100
-preemptionPolicy: Never
-globalDefault: false
-description: "This priority class should be used for high priority Determined jobs."
----
-apiVersion: scheduling.k8s.io/v1
-kind: PriorityClass
-metadata:
-  name: determined-low-priority
-value: 1
-preemptionPolicy: Never
-globalDefault: false
-description: "This priority class should be used for low priority Determined jobs."
-{{- end }}
-{{- end }}

--- a/master/internal/kubernetes/pods.go
+++ b/master/internal/kubernetes/pods.go
@@ -400,6 +400,9 @@ func (p *pods) cleanUpPodHandler(ctx *actor.Context, podHandler *actor.Ref) erro
 		return errors.Errorf("unknown pod handler being deleted %s", podHandler.Address())
 	}
 
+	name := fmt.Sprintf("%s-priorityclass", podInfo.containerID)
+	p.clientSet.SchedulingV1().PriorityClasses().Delete(name, &metaV1.DeleteOptions{})
+
 	ctx.Log().WithField("pod", podInfo.podName).WithField(
 		"handler", podHandler.Address()).Infof("de-registering pod handler")
 	delete(p.podNameToPodHandler, podInfo.podName)

--- a/master/internal/kubernetes/pods.go
+++ b/master/internal/kubernetes/pods.go
@@ -401,10 +401,12 @@ func (p *pods) cleanUpPodHandler(ctx *actor.Context, podHandler *actor.Ref) erro
 	}
 
 	name := fmt.Sprintf("%s-priorityclass", podInfo.containerID)
-	err := p.clientSet.SchedulingV1().PriorityClasses().Delete(name, &metaV1.DeleteOptions{})
-	if err != nil {
-		ctx.Log().Infof("Deletion of PriorityClass %s failed. This is expected if you are using the "+
-			"default determined priorityclass", name)
+	_, exists := p.clientSet.SchedulingV1().PriorityClasses().Get(name, metaV1.GetOptions{})
+	if exists == nil {
+		err := p.clientSet.SchedulingV1().PriorityClasses().Delete(name, &metaV1.DeleteOptions{})
+		if err != nil {
+			ctx.Log().Warnf("Deletion of PriorityClass %s failed.", name)
+		}
 	}
 
 	ctx.Log().WithField("pod", podInfo.podName).WithField(

--- a/master/internal/kubernetes/pods.go
+++ b/master/internal/kubernetes/pods.go
@@ -401,7 +401,11 @@ func (p *pods) cleanUpPodHandler(ctx *actor.Context, podHandler *actor.Ref) erro
 	}
 
 	name := fmt.Sprintf("%s-priorityclass", podInfo.containerID)
-	_ = p.clientSet.SchedulingV1().PriorityClasses().Delete(name, &metaV1.DeleteOptions{})
+	err := p.clientSet.SchedulingV1().PriorityClasses().Delete(name, &metaV1.DeleteOptions{})
+	if err != nil {
+		ctx.Log().Infof("Deletion of PriorityClass %s failed. This is expected if you are using the "+
+			"default determined priorityclass", name)
+	}
 
 	ctx.Log().WithField("pod", podInfo.podName).WithField(
 		"handler", podHandler.Address()).Infof("de-registering pod handler")

--- a/master/internal/kubernetes/pods.go
+++ b/master/internal/kubernetes/pods.go
@@ -401,7 +401,7 @@ func (p *pods) cleanUpPodHandler(ctx *actor.Context, podHandler *actor.Ref) erro
 	}
 
 	name := fmt.Sprintf("%s-priorityclass", podInfo.containerID)
-	p.clientSet.SchedulingV1().PriorityClasses().Delete(name, &metaV1.DeleteOptions{})
+	_ = p.clientSet.SchedulingV1().PriorityClasses().Delete(name, &metaV1.DeleteOptions{})
 
 	ctx.Log().WithField("pod", podInfo.podName).WithField(
 		"handler", podHandler.Address()).Infof("de-registering pod handler")

--- a/master/internal/kubernetes/spec.go
+++ b/master/internal/kubernetes/spec.go
@@ -23,7 +23,7 @@ import (
 	"github.com/determined-ai/determined/master/pkg/tasks"
 
 	k8sV1 "k8s.io/api/core/v1"
-	scheduleV1 "k8s.io/api/scheduling/v1"
+	schedulingV1 "k8s.io/api/scheduling/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -267,7 +267,7 @@ func (p *pod) configureCoscheduler(newPod *k8sV1.Pod, scheduler string) {
 func (p *pod) createPriorityClass(name string, priority int32) error {
 	preemptionPolicy := k8sV1.PreemptNever
 
-	_, err := p.clientSet.SchedulingV1().PriorityClasses().Create(&scheduleV1.PriorityClass{
+	_, err := p.clientSet.SchedulingV1().PriorityClasses().Create(&schedulingV1.PriorityClass{
 		TypeMeta: metaV1.TypeMeta{},
 		ObjectMeta: metaV1.ObjectMeta{
 			Name:      name,


### PR DESCRIPTION
## Description
Previously we relied on static priority classes that we create with helm install. With this change, determined can now dynamically create and destroy priority classes, allowing the user to specify a priority number in the experiment config. Now only two priority classes will be created during installation: a determined system priority for high priority tasks like master and gc, and a medium priority to serve as a default priority level.

NOTE: so far, this has only been tested with 0.16.5 becuase I've had troubles getting 0.17 to build. The mechanisms for priorityclass creation and deletion shouldn't change though.

<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan
spin up a kubernetes cluster, launch an experiment with the priority field populated. (`resources: priority: x`) Check the list of priorityclasses and make sure that the priority class named `<container-id>-priorityclass` has been created. At the end of the experiment check that the priority class has been deleted.

Repeat with an hp search experiment and make sure that it can handle multiple trials.

Repeat again but this time, specify a priority class in the podSpec. It should use the priority class defined in the podSpec instead of generating a new one.  Similarly, not specifying a priority will result in it using the `determined-medium-priority` class. 
<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234