### PR TITLE
feat: add CPU images for TF 2.5 and 2.6 [DET-5877]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,11 +100,11 @@ commands:
       - when:
           condition: <<parameters.tf1>>
           steps:
-            - run: docker pull determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-7a48718
+            - run: docker pull determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-0ca3d22
       - when:
           condition: <<parameters.tf2>>
           steps:
-            - run: docker pull determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-7a48718
+            - run: docker pull determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0ca3d22
 
   login-docker:
     parameters:
@@ -2162,7 +2162,7 @@ workflows:
               slack-mentions: ["${SLACK_USER_ID}"]
               environment-image:
                 - determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0.17.0
-                - determinedai/environments:cuda-11.2-pytorch-1.7-lightning-1.2-tf-2.5-gpu-0.17.0
+                - determinedai/environments:cuda-11.2-tf-2.5-gpu-0.17.0
 
       - test-e2e-gke-cuda-11:
           name: test-e2e-gke-parallel-cuda-11
@@ -2182,7 +2182,7 @@ workflows:
               num-machines: [2]
               environment-image:
                 - determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0.17.0
-                - determinedai/environments:cuda-11.2-pytorch-1.7-lightning-1.2-tf-2.5-gpu-0.17.0
+                - determinedai/environments:cuda-11.2-tf-2.5-gpu-0.17.0
 
       - test-e2e-gke:
           name: test-e2e-gke-single-cpu
@@ -2350,7 +2350,7 @@ workflows:
               slack-mentions: ["${SLACK_USER_ID}"]
               environment-image:
                 - determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0.17.0
-                - determinedai/environments:cuda-11.2-pytorch-1.7-lightning-1.2-tf-2.5-gpu-0.17.0
+                - determinedai/environments:cuda-11.2-tf-2.5-gpu-0.17.0
 
       - test-e2e-gke-cuda-11:
           name: test-e2e-gke-parallel-cuda-11
@@ -2366,7 +2366,7 @@ workflows:
               num-machines: [2]
               environment-image:
                 - determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0.17.0
-                - determinedai/environments:cuda-11.2-pytorch-1.7-lightning-1.2-tf-2.5-gpu-0.17.0
+                - determinedai/environments:cuda-11.2-tf-2.5-gpu-0.17.0
 
   release:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2162,7 +2162,6 @@ workflows:
               slack-mentions: ["${SLACK_USER_ID}"]
               environment-image:
                 - determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0.17.0
-                - determinedai/environments:cuda-11.2-tf-2.5-gpu-0.17.0
 
       - test-e2e-gke-cuda-11:
           name: test-e2e-gke-parallel-cuda-11
@@ -2182,7 +2181,43 @@ workflows:
               num-machines: [2]
               environment-image:
                 - determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0.17.0
+
+      - test-e2e-gke-cuda-11:
+          name: test-e2e-gke-single-gpu-tfonly
+          context: gcp
+          filters: *upstream-feature-branch
+          requires:
+            - request-k8-tests-cuda-11
+            - package-and-push-system-dev
+          matrix:
+            parameters:
+              cluster-id-prefix: ["e2e-gpu"]
+              mark: ["e2e_gpu and tensorflow2"]
+              parallelism: [1]
+              slack-mentions: ["${SLACK_USER_ID}"]
+              environment-image:
                 - determinedai/environments:cuda-11.2-tf-2.5-gpu-0.17.0
+                - determinedai/environments:cuda-11.2-tf-2.6-gpu-0.17.0
+
+      - test-e2e-gke-cuda-11:
+          name: test-e2e-gke-parallel-tfonly
+          context: gcp
+          filters: *upstream-feature-branch
+          requires:
+            - request-k8-tests-cuda-11
+            - package-and-push-system-dev
+          matrix:
+            parameters:
+              cluster-id-prefix: ["parallel"]
+              mark: ["parallel and tensorflow2"]
+              parallelism: [1]
+              slack-mentions: ["${SLACK_USER_ID}"]
+              machine-type: ["n1-standard-32"]
+              gpus-per-machine: [4]
+              num-machines: [2]
+              environment-image:
+                - determinedai/environments:cuda-11.2-tf-2.5-gpu-0.17.0
+                - determinedai/environments:cuda-11.2-tf-2.6-gpu-0.17.0
 
       - test-e2e-gke:
           name: test-e2e-gke-single-cpu
@@ -2350,7 +2385,6 @@ workflows:
               slack-mentions: ["${SLACK_USER_ID}"]
               environment-image:
                 - determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0.17.0
-                - determinedai/environments:cuda-11.2-tf-2.5-gpu-0.17.0
 
       - test-e2e-gke-cuda-11:
           name: test-e2e-gke-parallel-cuda-11
@@ -2366,7 +2400,35 @@ workflows:
               num-machines: [2]
               environment-image:
                 - determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0.17.0
+
+      - test-e2e-gke-cuda-11:
+          name: test-e2e-gke-single-gpu-tfonly
+          context: gcp
+          matrix:
+            parameters:
+              cluster-id-prefix: ["e2e-gpu"]
+              mark: ["e2e_gpu and tensorflow2"]
+              parallelism: [1]
+              slack-mentions: ["${SLACK_USER_ID}"]
+              environment-image:
                 - determinedai/environments:cuda-11.2-tf-2.5-gpu-0.17.0
+                - determinedai/environments:cuda-11.2-tf-2.6-gpu-0.17.0
+
+      - test-e2e-gke-cuda-11:
+          name: test-e2e-gke-parallel-tfonly
+          context: gcp
+          matrix:
+            parameters:
+              cluster-id-prefix: ["parallel"]
+              mark: ["parallel and tensorflow2"]
+              parallelism: [1]
+              slack-mentions: ["${SLACK_USER_ID}"]
+              machine-type: ["n1-standard-32"]
+              gpus-per-machine: [4]
+              num-machines: [2]
+              environment-image:
+                - determinedai/environments:cuda-11.2-tf-2.5-gpu-0.17.0
+                - determinedai/environments:cuda-11.2-tf-2.6-gpu-0.17.0
 
   release:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,11 +100,11 @@ commands:
       - when:
           condition: <<parameters.tf1>>
           steps:
-            - run: docker pull determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-a173dcd
+            - run: docker pull determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-7a48718
       - when:
           condition: <<parameters.tf2>>
           steps:
-            - run: docker pull determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-a173dcd
+            - run: docker pull determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-7a48718
 
   login-docker:
     parameters:
@@ -632,7 +632,7 @@ commands:
         description: The Google project ID to connect with via the gcloud CLI
         type: env_var_name
       environment-image:
-        default: determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0.16.4
+        default: determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0.17.0
         type: string
     steps:
       - set-cluster-id:
@@ -1664,7 +1664,7 @@ jobs:
         type: string
         default: ""
       environment-image:
-        default: determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0.16.4
+        default: determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0.17.0
         type: string
     docker:
       - image: determinedai/cimg-base:stable
@@ -2161,8 +2161,8 @@ workflows:
               parallelism: [1]
               slack-mentions: ["${SLACK_USER_ID}"]
               environment-image:
-                - determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0.16.4
-                - determinedai/environments:cuda-11.2-pytorch-1.7-lightning-1.2-tf-2.5-gpu-0.16.4
+                - determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0.17.0
+                - determinedai/environments:cuda-11.2-pytorch-1.7-lightning-1.2-tf-2.5-gpu-0.17.0
 
       - test-e2e-gke-cuda-11:
           name: test-e2e-gke-parallel-cuda-11
@@ -2181,8 +2181,8 @@ workflows:
               gpus-per-machine: [4]
               num-machines: [2]
               environment-image:
-                - determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0.16.4
-                - determinedai/environments:cuda-11.2-pytorch-1.7-lightning-1.2-tf-2.5-gpu-0.16.4
+                - determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0.17.0
+                - determinedai/environments:cuda-11.2-pytorch-1.7-lightning-1.2-tf-2.5-gpu-0.17.0
 
       - test-e2e-gke:
           name: test-e2e-gke-single-cpu
@@ -2349,8 +2349,8 @@ workflows:
               parallelism: [1]
               slack-mentions: ["${SLACK_USER_ID}"]
               environment-image:
-                - determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0.16.4
-                - determinedai/environments:cuda-11.2-pytorch-1.7-lightning-1.2-tf-2.5-gpu-0.16.4
+                - determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0.17.0
+                - determinedai/environments:cuda-11.2-pytorch-1.7-lightning-1.2-tf-2.5-gpu-0.17.0
 
       - test-e2e-gke-cuda-11:
           name: test-e2e-gke-parallel-cuda-11
@@ -2365,8 +2365,8 @@ workflows:
               gpus-per-machine: [4]
               num-machines: [2]
               environment-image:
-                - determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0.16.4
-                - determinedai/environments:cuda-11.2-pytorch-1.7-lightning-1.2-tf-2.5-gpu-0.16.4
+                - determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0.17.0
+                - determinedai/environments:cuda-11.2-pytorch-1.7-lightning-1.2-tf-2.5-gpu-0.17.0
 
   release:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,11 +100,11 @@ commands:
       - when:
           condition: <<parameters.tf1>>
           steps:
-            - run: docker pull determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-0ca3d22
+            - run: docker pull determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-e8af732
       - when:
           condition: <<parameters.tf2>>
           steps:
-            - run: docker pull determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0ca3d22
+            - run: docker pull determinedai/environments:py-3.8-pytorch-1.9-lightning-1.3-tf-2.4-cpu-e8af732
 
   login-docker:
     parameters:

--- a/docs/faq.txt
+++ b/docs/faq.txt
@@ -193,10 +193,17 @@ particular experiment is controlled by the container image that has been configu
 experiment. Determined provides prebuilt Docker images that include TensorFlow 2.4, 1.15, 2.5, and
 2.6, respectively:
 
--  ``determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0.16.4`` (default)
--  ``determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-0.16.4``
--  ``determinedai/environments:cuda-11.2-pytorch-1.7-lightning-1.2-tf-2.5-gpu-0.16.4``
--  ``determinedai/environments:cuda-11.2-pytorch-1.7-lightning-1.2-tf-2.6-gpu-0.16.4``
+-  ``determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0.17.0`` (default)
+-  ``determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-0.17.0``
+-  ``determinedai/environments:cuda-11.2-pytorch-1.7-lightning-1.2-tf-2.5-gpu-0.17.0``
+-  ``determinedai/environments:cuda-11.2-pytorch-1.7-lightning-1.2-tf-2.6-gpu-0.17.0``
+
+We also provide lightweight CPU-only counterparts:
+
+-  ``determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0.17.0``
+-  ``determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-0.17.0``
+-  ``determinedai/environments:py-3.7-pytorch-1.7-lightning-1.2-tf-2.5-cpu-0.17.0``
+-  ``determinedai/environments:py-3.7-pytorch-1.7-lightning-1.2-tf-2.6-cpu-0.17.0``
 
 To change the container image used for an experiment, specify :ref:`environment.image
 <exp-environment-image>` in the experiment configuration file. Please see :ref:`container-images`

--- a/docs/faq.txt
+++ b/docs/faq.txt
@@ -195,15 +195,15 @@ experiment. Determined provides prebuilt Docker images that include TensorFlow 2
 
 -  ``determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0.17.0`` (default)
 -  ``determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-0.17.0``
--  ``determinedai/environments:cuda-11.2-pytorch-1.7-lightning-1.2-tf-2.5-gpu-0.17.0``
--  ``determinedai/environments:cuda-11.2-pytorch-1.7-lightning-1.2-tf-2.6-gpu-0.17.0``
+-  ``determinedai/environments:cuda-11.2-tf-2.5-gpu-0.17.0``
+-  ``determinedai/environments:cuda-11.2-tf-2.6-gpu-0.17.0``
 
 We also provide lightweight CPU-only counterparts:
 
 -  ``determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0.17.0``
 -  ``determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-0.17.0``
--  ``determinedai/environments:py-3.7-pytorch-1.7-lightning-1.2-tf-2.5-cpu-0.17.0``
--  ``determinedai/environments:py-3.7-pytorch-1.7-lightning-1.2-tf-2.6-cpu-0.17.0``
+-  ``determinedai/environments:py-3.7-tf-2.5-cpu-0.17.0``
+-  ``determinedai/environments:py-3.7-tf-2.6-cpu-0.17.0``
 
 To change the container image used for an experiment, specify :ref:`environment.image
 <exp-environment-image>` in the experiment configuration file. Please see :ref:`container-images`

--- a/docs/faq.txt
+++ b/docs/faq.txt
@@ -200,10 +200,10 @@ experiment. Determined provides prebuilt Docker images that include TensorFlow 2
 
 We also provide lightweight CPU-only counterparts:
 
--  ``determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0.17.0``
+-  ``determinedai/environments:py-3.8-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0.17.0``
 -  ``determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-0.17.0``
--  ``determinedai/environments:py-3.7-tf-2.5-cpu-0.17.0``
--  ``determinedai/environments:py-3.7-tf-2.6-cpu-0.17.0``
+-  ``determinedai/environments:py-3.8-tf-2.5-cpu-0.17.0``
+-  ``determinedai/environments:py-3.8-tf-2.6-cpu-0.17.0``
 
 To change the container image used for an experiment, specify :ref:`environment.image
 <exp-environment-image>` in the experiment configuration file. Please see :ref:`container-images`

--- a/docs/how-to/custom-env.txt
+++ b/docs/how-to/custom-env.txt
@@ -101,8 +101,8 @@ hyperparameters for the current trial.
 .. note::
 
    The default images are
-   ``determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0.16.4`` and
-   ``determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0.16.4`` for GPU and CPU
+   ``determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0.17.0`` and
+   ``determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0.17.0`` for GPU and CPU
    respectively.
 
 Older Images
@@ -139,7 +139,7 @@ and ``apt``-based dependencies.
 .. code:: bash
 
    # Determined Image
-   FROM determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0.16.4
+   FROM determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0.17.0
 
    # Custom Configuration
    RUN apt-get update && \
@@ -205,7 +205,7 @@ below:
 .. code:: bash
 
    # Determined Image
-   FROM determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0.16.4
+   FROM determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0.17.0
 
    # Create a virtual environment
    RUN conda create -n myenv python=3.6

--- a/docs/how-to/custom-env.txt
+++ b/docs/how-to/custom-env.txt
@@ -102,7 +102,7 @@ hyperparameters for the current trial.
 
    The default images are
    ``determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0.17.0`` and
-   ``determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0.17.0`` for GPU and CPU
+   ``determinedai/environments:py-3.8-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0.17.0`` for GPU and CPU
    respectively.
 
 Older Images
@@ -205,7 +205,7 @@ below:
 .. code:: bash
 
    # Determined Image
-   FROM determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0.17.0
+   FROM determinedai/environments:py-3.8-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0.17.0
 
    # Create a virtual environment
    RUN conda create -n myenv python=3.6

--- a/docs/how-to/installation/gcp.txt
+++ b/docs/how-to/installation/gcp.txt
@@ -409,8 +409,8 @@ This command line will spin up a cluster of up to 2 A100s in the ``us-central1-c
       --compute-agent-instance-type a2-highgpu-1g --gpu-num 1 \
       --gpu-type nvidia-tesla-a100 \
       --region us-central1 --zone us-central1-c \
-      --gpu-env-image determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0.16.4 \
-      --cpu-env-image determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0.16.4
+      --gpu-env-image determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0.17.0 \
+      --cpu-env-image determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0.17.0
 
 ************
  Next Steps

--- a/docs/how-to/installation/gcp.txt
+++ b/docs/how-to/installation/gcp.txt
@@ -410,7 +410,7 @@ This command line will spin up a cluster of up to 2 A100s in the ``us-central1-c
       --gpu-type nvidia-tesla-a100 \
       --region us-central1 --zone us-central1-c \
       --gpu-env-image determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0.17.0 \
-      --cpu-env-image determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0.17.0
+      --cpu-env-image determinedai/environments:py-3.8-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0.17.0
 
 ************
  Next Steps

--- a/docs/how-to/tensorboard.txt
+++ b/docs/how-to/tensorboard.txt
@@ -61,7 +61,7 @@ to additional data with a bind-mount.
 .. code:: yaml
 
    environment:
-     image: determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0.16.4
+     image: determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0.17.0
    bind_mounts:
      - host_path: /my/agent/path
        container_path: /my/container/path

--- a/docs/reference/api/command-notebook-config.txt
+++ b/docs/reference/api/command-notebook-config.txt
@@ -46,8 +46,8 @@ The following configuration settings are supported:
       available via ``docker pull`` to every Determined agent machine in the cluster. Users can
       customize the image used for GPU vs. CPU agents by specifying a dict with two keys, ``cpu``
       and ``gpu``. Defaults to
-      ``determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0.16.4`` for CPU
-      agents and ``determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0.16.4``
+      ``determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0.17.0`` for CPU
+      agents and ``determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0.17.0``
       for GPU agents.
 
    -  ``force_pull_image``: Forcibly pull the image from the Docker registry and bypass the Docker

--- a/docs/reference/api/command-notebook-config.txt
+++ b/docs/reference/api/command-notebook-config.txt
@@ -46,7 +46,7 @@ The following configuration settings are supported:
       available via ``docker pull`` to every Determined agent machine in the cluster. Users can
       customize the image used for GPU vs. CPU agents by specifying a dict with two keys, ``cpu``
       and ``gpu``. Defaults to
-      ``determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0.17.0`` for CPU
+      ``determinedai/environments:py-3.8-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0.17.0`` for CPU
       agents and ``determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0.17.0``
       for GPU agents.
 

--- a/docs/reference/api/experiment-config.txt
+++ b/docs/reference/api/experiment-config.txt
@@ -792,9 +792,9 @@ workloads for this experiment. For more information on customizing the trial env
    images for GPU vs. CPU agents by specifying a dict with two keys, ``cpu`` and ``gpu``. Default
    values:
 
-   -  ``determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0.16.4`` for agents
+   -  ``determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0.17.0`` for agents
       with GPUs.
-   -  ``determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0.16.4`` for agents
+   -  ``determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0.17.0`` for agents
       with only CPUs.
 
 ``force_pull_image``

--- a/docs/reference/api/experiment-config.txt
+++ b/docs/reference/api/experiment-config.txt
@@ -794,7 +794,7 @@ workloads for this experiment. For more information on customizing the trial env
 
    -  ``determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0.17.0`` for agents
       with GPUs.
-   -  ``determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0.17.0`` for agents
+   -  ``determinedai/environments:py-3.8-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0.17.0`` for agents
       with only CPUs.
 
 ``force_pull_image``

--- a/docs/reference/cluster/cluster-config.txt
+++ b/docs/reference/cluster/cluster-config.txt
@@ -232,7 +232,7 @@ The master supports the following configuration settings:
       in the cluster. Users can use different container images for GPU vs. CPU agents differently by
       specifying a dict with two keys, ``cpu`` and ``gpu``. Default values:
 
-      -  ``determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0.17.0`` for CPU
+      -  ``determinedai/environments:py-3.8-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0.17.0`` for CPU
          agents
       -  ``determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0.17.0`` for GPU
          agents.

--- a/docs/reference/cluster/cluster-config.txt
+++ b/docs/reference/cluster/cluster-config.txt
@@ -232,9 +232,9 @@ The master supports the following configuration settings:
       in the cluster. Users can use different container images for GPU vs. CPU agents differently by
       specifying a dict with two keys, ``cpu`` and ``gpu``. Default values:
 
-      -  ``determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0.16.4`` for CPU
+      -  ``determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0.17.0`` for CPU
          agents
-      -  ``determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0.16.4`` for GPU
+      -  ``determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0.17.0`` for GPU
          agents.
 
    -  ``force_pull_image``: Defines the default policy for forcibly pulling images from the docker

--- a/docs/reference/cluster/helm-config.txt
+++ b/docs/reference/cluster/helm-config.txt
@@ -176,11 +176,11 @@ should be configured by editing the ``values.yaml`` and ``Chart.yaml`` files in 
 
    -  ``cpuImage``: Sets the default docker image for all non-gpu tasks. If a docker image is
       specified in the :ref:`experiment config <exp-environment-image>` this default is overriden.
-      Defaults to: ``determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0.16.4``.
+      Defaults to: ``determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0.17.0``.
 
    -  ``gpuImage``: Sets the default docker image for all gpu tasks. If a docker image is specified
       in the :ref:`experiment config <exp-environment-image>` this default is overriden. Defaults
-      to: ``determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0.16.4``.
+      to: ``determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0.17.0``.
 
 -  ``enterpriseEdition``: Specifies whether to use Determined enterprise edition.
 

--- a/docs/reference/cluster/helm-config.txt
+++ b/docs/reference/cluster/helm-config.txt
@@ -176,7 +176,7 @@ should be configured by editing the ``values.yaml`` and ``Chart.yaml`` files in 
 
    -  ``cpuImage``: Sets the default docker image for all non-gpu tasks. If a docker image is
       specified in the :ref:`experiment config <exp-environment-image>` this default is overriden.
-      Defaults to: ``determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0.17.0``.
+      Defaults to: ``determinedai/environments:py-3.8-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0.17.0``.
 
    -  ``gpuImage``: Sets the default docker image for all gpu tasks. If a docker image is specified
       in the :ref:`experiment config <exp-environment-image>` this default is overriden. Defaults

--- a/docs/release-notes/2981-env-images.txt
+++ b/docs/release-notes/2981-env-images.txt
@@ -1,0 +1,7 @@
+:orphan:
+
+**Improvements**
+
+- Images: Added CPU-only images for TF version 2.5 and 2.6.
+- Images: TF 2.5 and 2.6 images will no longer include PyTorch builds. For PyTorch 1.9, please use the combined TF 2.4 & PyTorch 1.9 image.
+- Images: TF 2.4, 2.5, 2.6, and PyTorch 1.9 images will now use Python 3.8. Legacy TF 1.15 & PyTorch 1.7 image will continue to use Python 3.7.

--- a/docs/release-notes/2981-env-images.txt
+++ b/docs/release-notes/2981-env-images.txt
@@ -2,6 +2,8 @@
 
 **Improvements**
 
-- Images: Added CPU-only images for TF version 2.5 and 2.6.
-- Images: TF 2.5 and 2.6 images will no longer include PyTorch builds. For PyTorch 1.9, please use the combined TF 2.4 & PyTorch 1.9 image.
-- Images: TF 2.4, 2.5, 2.6, and PyTorch 1.9 images will now use Python 3.8. Legacy TF 1.15 & PyTorch 1.7 image will continue to use Python 3.7.
+-  Images: Added CPU-only images for TF version 2.5 and 2.6.
+-  Images: TF 2.5 and 2.6 images will no longer include PyTorch builds. For PyTorch 1.9, please use
+   the combined TF 2.4 & PyTorch 1.9 image.
+-  Images: TF 2.4, 2.5, 2.6, and PyTorch 1.9 images will now use Python 3.8. Legacy TF 1.15 &
+   PyTorch 1.7 image will continue to use Python 3.7.

--- a/docs/release-notes/2981-tf-cpu-25-26.txt
+++ b/docs/release-notes/2981-tf-cpu-25-26.txt
@@ -1,0 +1,5 @@
+:orphan:
+
+**New Features**
+
+-  Images: Add an environment image for CPU-only TensorFlow 2.5 and 2.6.

--- a/docs/tutorials/quick-start.txt
+++ b/docs/tutorials/quick-start.txt
@@ -37,10 +37,10 @@ faster (but less structured) way to start using a Determined cluster without wri
 .. code::
 
    # For CPU computations
-   docker pull determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0.16.4
+   docker pull determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0.17.0
 
    # For GPU computations
-   docker pull determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0.16.4
+   docker pull determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0.17.0
 
 .. _quick-start-first-job:
 

--- a/docs/tutorials/quick-start.txt
+++ b/docs/tutorials/quick-start.txt
@@ -37,7 +37,7 @@ faster (but less structured) way to start using a Determined cluster without wri
 .. code::
 
    # For CPU computations
-   docker pull determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0.17.0
+   docker pull determinedai/environments:py-3.8-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0.17.0
 
    # For GPU computations
    docker pull determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0.17.0

--- a/e2e_tests/pytest.ini
+++ b/e2e_tests/pytest.ini
@@ -3,8 +3,9 @@ xfail_strict=true
 addopts = -rfsx --strict-markers
 markers =
     slow: mark tests as slow
-    tensorflow1_cpu: CPU TensorFlow tests
-    tensorflow2_cpu: CPU TensorFlow tests
+    tensorflow1_cpu: CPU TensorFlow 1 tests
+    tensorflow2_cpu: CPU TensorFlow 2 tests
+    tensorflow2: Tensorflow 2 tests
     e2e_cpu: end to end CPU tests
     e2e_cpu_2a: end to end CPU tests with two agents
     e2e_gpu: end to end GPU tests

--- a/e2e_tests/tests/command/test_tensorboard.py
+++ b/e2e_tests/tests/command/test_tensorboard.py
@@ -80,6 +80,7 @@ def test_start_tensorboard_for_shared_fs_experiment(tmp_path: Path) -> None:
 
 @pytest.mark.slow  # type: ignore
 @pytest.mark.e2e_gpu  # type: ignore
+@pytest.mark.tensorflow2  # type: ignore
 def test_start_tensorboard_for_s3_experiment(tmp_path: Path, secrets: Dict[str, str]) -> None:
     """
     Start a random experiment configured with the s3 backend, start a

--- a/e2e_tests/tests/config.py
+++ b/e2e_tests/tests/config.py
@@ -12,13 +12,13 @@ MAX_TASK_SCHEDULED_SECS = 30
 MAX_TRIAL_BUILD_SECS = 90
 
 
-DEFAULT_TF1_CPU_IMAGE = "determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-7a48718"
+DEFAULT_TF1_CPU_IMAGE = "determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-0ca3d22"
 DEFAULT_TF2_CPU_IMAGE = (
-    "determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-7a48718"
+    "determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0ca3d22"
 )
-DEFAULT_TF1_GPU_IMAGE = "determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-7a48718"
+DEFAULT_TF1_GPU_IMAGE = "determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-0ca3d22"
 DEFAULT_TF2_GPU_IMAGE = (
-    "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-7a48718"
+    "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0ca3d22"
 )
 
 TF1_CPU_IMAGE = os.environ.get("TF1_CPU_IMAGE") or DEFAULT_TF1_CPU_IMAGE

--- a/e2e_tests/tests/config.py
+++ b/e2e_tests/tests/config.py
@@ -12,13 +12,13 @@ MAX_TASK_SCHEDULED_SECS = 30
 MAX_TRIAL_BUILD_SECS = 90
 
 
-DEFAULT_TF1_CPU_IMAGE = "determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-a173dcd"
+DEFAULT_TF1_CPU_IMAGE = "determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-7a48718"
 DEFAULT_TF2_CPU_IMAGE = (
-    "determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-a173dcd"
+    "determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-7a48718"
 )
-DEFAULT_TF1_GPU_IMAGE = "determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-a173dcd"
+DEFAULT_TF1_GPU_IMAGE = "determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-7a48718"
 DEFAULT_TF2_GPU_IMAGE = (
-    "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-a173dcd"
+    "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-7a48718"
 )
 
 TF1_CPU_IMAGE = os.environ.get("TF1_CPU_IMAGE") or DEFAULT_TF1_CPU_IMAGE

--- a/e2e_tests/tests/config.py
+++ b/e2e_tests/tests/config.py
@@ -12,13 +12,13 @@ MAX_TASK_SCHEDULED_SECS = 30
 MAX_TRIAL_BUILD_SECS = 90
 
 
-DEFAULT_TF1_CPU_IMAGE = "determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-0ca3d22"
+DEFAULT_TF1_CPU_IMAGE = "determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-e8af732"
 DEFAULT_TF2_CPU_IMAGE = (
-    "determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0ca3d22"
+    "determinedai/environments:py-3.8-pytorch-1.9-lightning-1.3-tf-2.4-cpu-e8af732"
 )
-DEFAULT_TF1_GPU_IMAGE = "determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-0ca3d22"
+DEFAULT_TF1_GPU_IMAGE = "determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-e8af732"
 DEFAULT_TF2_GPU_IMAGE = (
-    "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0ca3d22"
+    "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-e8af732"
 )
 
 TF1_CPU_IMAGE = os.environ.get("TF1_CPU_IMAGE") or DEFAULT_TF1_CPU_IMAGE

--- a/e2e_tests/tests/conftest.py
+++ b/e2e_tests/tests/conftest.py
@@ -18,6 +18,7 @@ from .cluster_log_manager import ClusterLogManager
 _INTEG_MARKERS = {
     "tensorflow1_cpu",
     "tensorflow2_cpu",
+    "tensorflow2",
     "e2e_cpu",
     "e2e_cpu_2a",
     "e2e_gpu",

--- a/e2e_tests/tests/experiment/test_tf_estimator.py
+++ b/e2e_tests/tests/experiment/test_tf_estimator.py
@@ -9,6 +9,7 @@ from tests import experiment as exp
 
 
 @pytest.mark.e2e_gpu  # type: ignore
+@pytest.mark.tensorflow2  # type: ignore
 def test_mnist_estimator_load() -> None:
     config = conf.load_config(conf.fixtures_path("mnist_estimator/single.yaml"))
     config = conf.set_tf1_image(config)
@@ -22,6 +23,7 @@ def test_mnist_estimator_load() -> None:
 
 
 @pytest.mark.parallel  # type: ignore
+@pytest.mark.tensorflow2  # type: ignore
 @pytest.mark.parametrize("tf2", [False, True])  # type: ignore
 def test_mnist_estimator_const_parallel(tf2: bool) -> None:
     config = conf.load_config(conf.fixtures_path("mnist_estimator/single-multi-slot.yaml"))
@@ -36,6 +38,7 @@ def test_mnist_estimator_const_parallel(tf2: bool) -> None:
     exp.assert_performed_initial_validation(exp_id)
 
 
+@pytest.mark.tensorflow2  # type: ignore
 @pytest.mark.parametrize(  # type: ignore
     "tf2",
     [
@@ -73,6 +76,7 @@ def test_mnist_estimator_warm_start(tf2: bool) -> None:
     assert trials[0]["warm_start_checkpoint_id"] == first_checkpoint_id
 
 
+@pytest.mark.tensorflow2  # type: ignore
 @pytest.mark.parametrize(  # type: ignore
     "tf2",
     [
@@ -85,6 +89,7 @@ def test_mnist_estimator_data_layer_lfs(tf2: bool) -> None:
 
 
 @pytest.mark.parallel  # type: ignore
+@pytest.mark.tensorflow2  # type: ignore
 @pytest.mark.parametrize("tf2", [True, False])  # type: ignore
 def test_custom_reducer_distributed(secrets: Dict[str, str], tf2: bool) -> None:
     config = conf.load_config(conf.fixtures_path("estimator_dataset/distributed.yaml"))
@@ -106,6 +111,7 @@ def test_custom_reducer_distributed(secrets: Dict[str, str], tf2: bool) -> None:
 
 
 @pytest.mark.e2e_gpu  # type: ignore
+@pytest.mark.tensorflow2  # type: ignore
 @pytest.mark.parametrize("tf2", [True, False])  # type: ignore
 @pytest.mark.parametrize("storage_type", ["s3"])  # type: ignore
 def test_mnist_estimator_data_layer_s3(
@@ -129,6 +135,7 @@ def run_mnist_estimator_data_layer_test(tf2: bool, storage_type: str) -> None:
 
 
 @pytest.mark.parallel  # type: ignore
+@pytest.mark.tensorflow2  # type: ignore
 @pytest.mark.parametrize("storage_type", ["lfs", "s3"])  # type: ignore
 def test_mnist_estimator_data_layer_parallel(storage_type: str, secrets: Dict[str, str]) -> None:
     config = conf.load_config(conf.features_examples_path("data_layer_mnist_estimator/const.yaml"))
@@ -146,6 +153,7 @@ def test_mnist_estimator_data_layer_parallel(storage_type: str, secrets: Dict[st
 
 
 @pytest.mark.e2e_gpu  # type: ignore
+@pytest.mark.tensorflow2  # type: ignore
 def test_mnist_estimator_adaptive_with_data_layer() -> None:
     config = conf.load_config(conf.fixtures_path("mnist_estimator/adaptive.yaml"))
     config = conf.set_tf2_image(config)
@@ -157,6 +165,7 @@ def test_mnist_estimator_adaptive_with_data_layer() -> None:
 
 
 @pytest.mark.parallel  # type: ignore
+@pytest.mark.tensorflow2  # type: ignore
 def test_on_trial_close_callback() -> None:
     config = conf.load_config(conf.fixtures_path("estimator_no_op/const.yaml"))
     config = conf.set_slots_per_trial(config, 8)

--- a/e2e_tests/tests/experiment/test_tf_keras.py
+++ b/e2e_tests/tests/experiment/test_tf_keras.py
@@ -6,6 +6,7 @@ from tests import config as conf
 from tests import experiment as exp
 
 
+@pytest.mark.tensorflow2  # type: ignore
 @pytest.mark.parametrize(  # type: ignore
     "tf2",
     [
@@ -51,6 +52,7 @@ def test_tf_keras_const_warm_start(
 
 
 @pytest.mark.parallel  # type: ignore
+@pytest.mark.tensorflow2  # type: ignore
 @pytest.mark.parametrize("aggregation_frequency", [1, 4])  # type: ignore
 @pytest.mark.parametrize("tf2", [False, True])  # type: ignore
 def test_tf_keras_parallel(
@@ -75,6 +77,7 @@ def test_tf_keras_parallel(
 
 
 @pytest.mark.e2e_gpu  # type: ignore
+@pytest.mark.tensorflow2  # type: ignore
 @pytest.mark.parametrize("tf2", [True, False])  # type: ignore
 def test_tf_keras_single_gpu(tf2: bool, collect_trial_profiles: Callable[[int], None]) -> None:
     config = conf.load_config(conf.cv_examples_path("cifar10_tf_keras/const.yaml"))
@@ -95,6 +98,7 @@ def test_tf_keras_single_gpu(tf2: bool, collect_trial_profiles: Callable[[int], 
 
 
 @pytest.mark.parallel  # type: ignore
+@pytest.mark.tensorflow2  # type: ignore
 def test_tf_keras_mnist_parallel(collect_trial_profiles: Callable[[int], None]) -> None:
     config = conf.load_config(conf.tutorials_path("fashion_mnist_tf_keras/const.yaml"))
     config = conf.set_slots_per_trial(config, 8)
@@ -110,6 +114,7 @@ def test_tf_keras_mnist_parallel(collect_trial_profiles: Callable[[int], None]) 
 
 
 @pytest.mark.tensorflow2_cpu  # type: ignore
+@pytest.mark.tensorflow2  # type: ignore
 def test_tf_keras_tf2_disabled(collect_trial_profiles: Callable[[int], None]) -> None:
     """Keras on tf2 with tf2 and eager execution disabled."""
     config = conf.load_config(conf.fixtures_path("keras_tf2_disabled_no_op/const.yaml"))
@@ -126,6 +131,7 @@ def test_tf_keras_tf2_disabled(collect_trial_profiles: Callable[[int], None]) ->
     collect_trial_profiles(trials[0]["id"])
 
 
+@pytest.mark.tensorflow2  # type: ignore
 @pytest.mark.parametrize(  # type: ignore
     "tf2",
     [pytest.param(False, marks=pytest.mark.tensorflow1_cpu)],
@@ -139,6 +145,7 @@ def test_tf_keras_mnist_data_layer_lfs(
 
 
 @pytest.mark.e2e_gpu  # type: ignore
+@pytest.mark.tensorflow2  # type: ignore
 @pytest.mark.parametrize("tf2", [False])  # type: ignore
 @pytest.mark.parametrize("storage_type", ["s3"])  # type: ignore
 def test_tf_keras_mnist_data_layer_s3(
@@ -170,6 +177,7 @@ def run_tf_keras_mnist_data_layer_test(tf2: bool, storage_type: str) -> int:
 
 
 @pytest.mark.parallel  # type: ignore
+@pytest.mark.tensorflow2  # type: ignore
 @pytest.mark.parametrize("tf2", [False])  # type: ignore
 @pytest.mark.parametrize("storage_type", ["lfs", "s3"])  # type: ignore
 def test_tf_keras_mnist_data_layer_parallel(
@@ -198,6 +206,7 @@ def test_tf_keras_mnist_data_layer_parallel(
 
 
 @pytest.mark.parallel  # type: ignore
+@pytest.mark.tensorflow2  # type: ignore
 def run_tf_keras_dcgan_example(collect_trial_profiles: Callable[[int], None]) -> None:
     config = conf.load_config(conf.gan_examples_path("dcgan_tf_keras/const.yaml"))
     config = conf.set_max_length(config, {"batches": 200})

--- a/e2e_tests/tests/fixtures/pytorch_lightning_amp/apex_amp.yaml
+++ b/e2e_tests/tests/fixtures/pytorch_lightning_amp/apex_amp.yaml
@@ -14,6 +14,6 @@ searcher:
 entrypoint: apex_amp_model_def:MNistApexAMPTrial
 environment:
   image:
-    gpu: determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0.16.4
-    cpu: determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0.16.4
+    gpu: determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0.17.0
+    cpu: determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0.17.0
 

--- a/e2e_tests/tests/fixtures/pytorch_lightning_amp/apex_amp.yaml
+++ b/e2e_tests/tests/fixtures/pytorch_lightning_amp/apex_amp.yaml
@@ -15,5 +15,5 @@ entrypoint: apex_amp_model_def:MNistApexAMPTrial
 environment:
   image:
     gpu: determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0.17.0
-    cpu: determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0.17.0
+    cpu: determinedai/environments:py-3.8-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0.17.0
 

--- a/e2e_tests/tests/fixtures/pytorch_lightning_amp/auto_amp.yaml
+++ b/e2e_tests/tests/fixtures/pytorch_lightning_amp/auto_amp.yaml
@@ -15,5 +15,5 @@ entrypoint: auto_amp_model_def:MNistAutoAMPTrial
 environment:
   image:
     gpu: determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0.17.0
-    cpu: determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0.17.0
+    cpu: determinedai/environments:py-3.8-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0.17.0
 

--- a/e2e_tests/tests/fixtures/pytorch_lightning_amp/auto_amp.yaml
+++ b/e2e_tests/tests/fixtures/pytorch_lightning_amp/auto_amp.yaml
@@ -14,6 +14,6 @@ searcher:
 entrypoint: auto_amp_model_def:MNistAutoAMPTrial
 environment:
   image:
-    gpu: determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0.16.4
-    cpu: determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0.16.4
+    gpu: determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0.17.0
+    cpu: determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0.17.0
 

--- a/examples/computer_vision/efficientdet_pytorch/const.yaml
+++ b/examples/computer_vision/efficientdet_pytorch/const.yaml
@@ -1,6 +1,6 @@
 description: efficientdet_const
 environment:
-  image: determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-0.16.4
+  image: determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-0.17.0
 hyperparameters:
   global_batch_size: 16
   min_loss_scale: 16.0

--- a/examples/computer_vision/efficientdet_pytorch/const_fake.yaml
+++ b/examples/computer_vision/efficientdet_pytorch/const_fake.yaml
@@ -1,6 +1,6 @@
 description: efficientdet_const
 environment:
-  image: determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-0.16.4
+  image: determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-0.17.0
 hyperparameters:
   global_batch_size: 16
   min_loss_scale: 16.0

--- a/examples/computer_vision/mnist_pl/adaptive.yaml
+++ b/examples/computer_vision/mnist_pl/adaptive.yaml
@@ -18,5 +18,5 @@ searcher:
 entrypoint: model_def:MNISTTrial
 environment:
   image:
-    gpu: determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0.16.4
-    cpu: determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0.16.4
+    gpu: determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0.17.0
+    cpu: determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0.17.0

--- a/examples/computer_vision/mnist_pl/adaptive.yaml
+++ b/examples/computer_vision/mnist_pl/adaptive.yaml
@@ -19,4 +19,4 @@ entrypoint: model_def:MNISTTrial
 environment:
   image:
     gpu: determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0.17.0
-    cpu: determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0.17.0
+    cpu: determinedai/environments:py-3.8-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0.17.0

--- a/examples/computer_vision/mnist_pl/const.yaml
+++ b/examples/computer_vision/mnist_pl/const.yaml
@@ -15,4 +15,4 @@ entrypoint: model_def:MNISTTrial
 environment:
   image:
     gpu: determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0.17.0
-    cpu: determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0.17.0
+    cpu: determinedai/environments:py-3.8-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0.17.0

--- a/examples/computer_vision/mnist_pl/const.yaml
+++ b/examples/computer_vision/mnist_pl/const.yaml
@@ -14,5 +14,5 @@ searcher:
 entrypoint: model_def:MNISTTrial
 environment:
   image:
-    gpu: determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0.16.4
-    cpu: determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0.16.4
+    gpu: determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0.17.0
+    cpu: determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0.17.0

--- a/examples/computer_vision/unets_tf_keras/const.yaml
+++ b/examples/computer_vision/unets_tf_keras/const.yaml
@@ -22,4 +22,4 @@ min_validation_period:
 entrypoint: model_def:UNetsTrial
 scheduling_unit: 57
 environment:
-    image: determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-7a48718
+    image: determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0ca3d22

--- a/examples/computer_vision/unets_tf_keras/const.yaml
+++ b/examples/computer_vision/unets_tf_keras/const.yaml
@@ -22,4 +22,4 @@ min_validation_period:
 entrypoint: model_def:UNetsTrial
 scheduling_unit: 57
 environment:
-    image: determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-a173dcd
+    image: determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-7a48718

--- a/examples/computer_vision/unets_tf_keras/const.yaml
+++ b/examples/computer_vision/unets_tf_keras/const.yaml
@@ -22,4 +22,4 @@ min_validation_period:
 entrypoint: model_def:UNetsTrial
 scheduling_unit: 57
 environment:
-    image: determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0ca3d22
+    image: determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-e8af732

--- a/examples/computer_vision/unets_tf_keras/distributed.yaml
+++ b/examples/computer_vision/unets_tf_keras/distributed.yaml
@@ -25,4 +25,4 @@ min_validation_period:
 scheduling_unit: 8
 entrypoint: model_def:UNetsTrial
 environment:
-    image: determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0ca3d22
+    image: determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-e8af732

--- a/examples/computer_vision/unets_tf_keras/distributed.yaml
+++ b/examples/computer_vision/unets_tf_keras/distributed.yaml
@@ -25,4 +25,4 @@ min_validation_period:
 scheduling_unit: 8
 entrypoint: model_def:UNetsTrial
 environment:
-    image: determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-7a48718
+    image: determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0ca3d22

--- a/examples/computer_vision/unets_tf_keras/distributed.yaml
+++ b/examples/computer_vision/unets_tf_keras/distributed.yaml
@@ -25,4 +25,4 @@ min_validation_period:
 scheduling_unit: 8
 entrypoint: model_def:UNetsTrial
 environment:
-    image: determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-a173dcd
+    image: determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-7a48718

--- a/examples/decision_trees/gbt_titanic_estimator/adaptive.yaml
+++ b/examples/decision_trees/gbt_titanic_estimator/adaptive.yaml
@@ -42,4 +42,4 @@ searcher:
 entrypoint: model_def:BoostedTreesTrial
 scheduling_unit: 1
 environment:
-  image: "determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0.16.4"
+  image: "determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0.17.0"

--- a/examples/decision_trees/gbt_titanic_estimator/adaptive.yaml
+++ b/examples/decision_trees/gbt_titanic_estimator/adaptive.yaml
@@ -42,4 +42,4 @@ searcher:
 entrypoint: model_def:BoostedTreesTrial
 scheduling_unit: 1
 environment:
-  image: "determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0.17.0"
+  image: "determinedai/environments:py-3.8-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0.17.0"

--- a/examples/decision_trees/gbt_titanic_estimator/const.yaml
+++ b/examples/decision_trees/gbt_titanic_estimator/const.yaml
@@ -20,4 +20,4 @@ searcher:
 entrypoint: model_def:BoostedTreesTrial
 scheduling_unit: 1
 environment:
-  image: "determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0.17.0"
+  image: "determinedai/environments:py-3.8-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0.17.0"

--- a/examples/decision_trees/gbt_titanic_estimator/const.yaml
+++ b/examples/decision_trees/gbt_titanic_estimator/const.yaml
@@ -20,4 +20,4 @@ searcher:
 entrypoint: model_def:BoostedTreesTrial
 scheduling_unit: 1
 environment:
-  image: "determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0.16.4"
+  image: "determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0.17.0"

--- a/examples/gan/dcgan_tf_keras/const.yaml
+++ b/examples/gan/dcgan_tf_keras/const.yaml
@@ -15,5 +15,5 @@ entrypoint: model_def:DCGanTrial
 environment:
   # This model only works with Tensorflow 2.2+.
   image:
-     cpu: "determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-a173dcd"
-     gpu: "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-a173dcd"
+     cpu: "determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-7a48718"
+     gpu: "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-7a48718"

--- a/examples/gan/dcgan_tf_keras/const.yaml
+++ b/examples/gan/dcgan_tf_keras/const.yaml
@@ -15,5 +15,5 @@ entrypoint: model_def:DCGanTrial
 environment:
   # This model only works with Tensorflow 2.2+.
   image:
-     cpu: "determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-7a48718"
-     gpu: "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-7a48718"
+     cpu: "determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0ca3d22"
+     gpu: "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0ca3d22"

--- a/examples/gan/dcgan_tf_keras/const.yaml
+++ b/examples/gan/dcgan_tf_keras/const.yaml
@@ -15,5 +15,5 @@ entrypoint: model_def:DCGanTrial
 environment:
   # This model only works with Tensorflow 2.2+.
   image:
-     cpu: "determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0ca3d22"
-     gpu: "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0ca3d22"
+     cpu: "determinedai/environments:py-3.8-pytorch-1.9-lightning-1.3-tf-2.4-cpu-e8af732"
+     gpu: "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-e8af732"

--- a/examples/gan/dcgan_tf_keras/distributed.yaml
+++ b/examples/gan/dcgan_tf_keras/distributed.yaml
@@ -17,5 +17,5 @@ resources:
 environment:
   # This model only works with Tensorflow 2.2+.
   image:
-     cpu: "determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-a173dcd"
-     gpu: "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-a173dcd"
+     cpu: "determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-7a48718"
+     gpu: "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-7a48718"

--- a/examples/gan/dcgan_tf_keras/distributed.yaml
+++ b/examples/gan/dcgan_tf_keras/distributed.yaml
@@ -17,5 +17,5 @@ resources:
 environment:
   # This model only works with Tensorflow 2.2+.
   image:
-     cpu: "determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0ca3d22"
-     gpu: "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0ca3d22"
+     cpu: "determinedai/environments:py-3.8-pytorch-1.9-lightning-1.3-tf-2.4-cpu-e8af732"
+     gpu: "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-e8af732"

--- a/examples/gan/dcgan_tf_keras/distributed.yaml
+++ b/examples/gan/dcgan_tf_keras/distributed.yaml
@@ -17,5 +17,5 @@ resources:
 environment:
   # This model only works with Tensorflow 2.2+.
   image:
-     cpu: "determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-7a48718"
-     gpu: "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-7a48718"
+     cpu: "determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0ca3d22"
+     gpu: "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0ca3d22"

--- a/examples/gan/gan_mnist_pl/adaptive.yaml
+++ b/examples/gan/gan_mnist_pl/adaptive.yaml
@@ -25,5 +25,5 @@ resources:
 entrypoint: model_def:GANTrial
 environment:
   image:
-    gpu: determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0.16.4
-    cpu: determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0.16.4
+    gpu: determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0.17.0
+    cpu: determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0.17.0

--- a/examples/gan/gan_mnist_pl/adaptive.yaml
+++ b/examples/gan/gan_mnist_pl/adaptive.yaml
@@ -26,4 +26,4 @@ entrypoint: model_def:GANTrial
 environment:
   image:
     gpu: determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0.17.0
-    cpu: determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0.17.0
+    cpu: determinedai/environments:py-3.8-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0.17.0

--- a/examples/gan/gan_mnist_pl/const.yaml
+++ b/examples/gan/gan_mnist_pl/const.yaml
@@ -17,4 +17,4 @@ entrypoint: model_def:GANTrial
 environment:
   image:
     gpu: determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0.17.0
-    cpu: determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0.17.0
+    cpu: determinedai/environments:py-3.8-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0.17.0

--- a/examples/gan/gan_mnist_pl/const.yaml
+++ b/examples/gan/gan_mnist_pl/const.yaml
@@ -16,5 +16,5 @@ searcher:
 entrypoint: model_def:GANTrial
 environment:
   image:
-    gpu: determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0.16.4
-    cpu: determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0.16.4
+    gpu: determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0.17.0
+    cpu: determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0.17.0

--- a/examples/gan/gan_mnist_pl/distributed.yaml
+++ b/examples/gan/gan_mnist_pl/distributed.yaml
@@ -25,5 +25,5 @@ resources:
 entrypoint: model_def:GANTrial
 environment:
   image:
-    gpu: determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0.16.4
-    cpu: determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0.16.4
+    gpu: determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0.17.0
+    cpu: determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0.17.0

--- a/examples/gan/gan_mnist_pl/distributed.yaml
+++ b/examples/gan/gan_mnist_pl/distributed.yaml
@@ -26,4 +26,4 @@ entrypoint: model_def:GANTrial
 environment:
   image:
     gpu: determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0.17.0
-    cpu: determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0.17.0
+    cpu: determinedai/environments:py-3.8-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0.17.0

--- a/examples/tests/requirements.txt
+++ b/examples/tests/requirements.txt
@@ -1,6 +1,6 @@
 # pytest 6.0 has linter-breaking changes
 pytest>=6.0.1
-tensorflow==2.4.1
+tensorflow==2.4.3
 torch==1.7.1
 torchvision==0.8.2
 pandas==1.0.3

--- a/harness/determined/common/schemas/expconf/_v0.py
+++ b/harness/determined/common/schemas/expconf/_v0.py
@@ -244,11 +244,11 @@ class EnvironmentImageV0(schemas.SchemaBase):
     def runtime_defaults(self) -> None:
         if self.cpu is None:
             self.cpu = (
-                "determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0ca3d22"
+                "determinedai/environments:py-3.8-pytorch-1.9-lightning-1.3-tf-2.4-cpu-e8af732"
             )
         if self.gpu is None:
             self.gpu = (
-                "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0ca3d22"
+                "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-e8af732"
             )
 
 

--- a/harness/determined/common/schemas/expconf/_v0.py
+++ b/harness/determined/common/schemas/expconf/_v0.py
@@ -244,11 +244,11 @@ class EnvironmentImageV0(schemas.SchemaBase):
     def runtime_defaults(self) -> None:
         if self.cpu is None:
             self.cpu = (
-                "determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-a173dcd"
+                "determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-7a48718"
             )
         if self.gpu is None:
             self.gpu = (
-                "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-a173dcd"
+                "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-7a48718"
             )
 
 

--- a/harness/determined/common/schemas/expconf/_v0.py
+++ b/harness/determined/common/schemas/expconf/_v0.py
@@ -244,11 +244,11 @@ class EnvironmentImageV0(schemas.SchemaBase):
     def runtime_defaults(self) -> None:
         if self.cpu is None:
             self.cpu = (
-                "determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-7a48718"
+                "determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0ca3d22"
             )
         if self.gpu is None:
             self.gpu = (
-                "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-7a48718"
+                "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0ca3d22"
             )
 
 

--- a/harness/determined/deploy/aws/templates/efs.yaml
+++ b/harness/determined/deploy/aws/templates/efs.yaml
@@ -4,35 +4,35 @@ Mappings:
   RegionMap:
     ap-northeast-1:
       Master: ami-0827d8ed0295e3feb
-      Agent: ami-0385dc3dcdc1ac287
+      Agent: ami-0a506b88f4e1268a0
     # TODO(DET-4258) Uncomment these when we fully support all P3 regions.
     # ap-northeast-2:
     #   Master: ami-00bbba67d13faed04
-    #   Agent: ami-090bacb4f1f0540dd
+    #   Agent: ami-05d4c07cb56ed3777
     # ap-southeast-1:
     #   Master: ami-0f6565c3d5328c913
-    #   Agent: ami-0b2c2ed32f574ae3b
+    #   Agent: ami-0b39e143721568921
     # ap-southeast-2:
     #   Master: ami-0a1002150df471b2b
-    #   Agent: ami-09174a303f24171ca
+    #   Agent: ami-0885426f5ce6aada4
     eu-central-1:
       Master: ami-0bdbe51a2e8070ff2
-      Agent: ami-0fd3496afbcaf9e49
+      Agent: ami-0d4478a40cb8bb10e
     eu-west-1:
       Master: ami-03caf24deed650e2c
-      Agent: ami-0139d1106b0258a70
+      Agent: ami-0a15ab370f2846c16
     # eu-west-2:
     #   Master: ami-093d303510c432519
-    #   Agent: ami-0a687fcb2de71ca86
+    #   Agent: ami-0f25f5f71d2b50df3
     us-east-1:
       Master: ami-0dd76f917833aac4b
-      Agent: ami-00e877e7d94b191aa
+      Agent: ami-0bdd6f68db44422a4
     us-east-2:
       Master: ami-0b29b6e62f2343b46
-      Agent: ami-069a72699aafc6f10
+      Agent: ami-09ec9c251aca453c0
     us-west-2:
       Master: ami-01773ce53581acf22
-      Agent: ami-0e321f94fec3fabb9
+      Agent: ami-0f7c8ce0ef2b5a220
 
 Parameters:
   VpcCIDR:

--- a/harness/determined/deploy/aws/templates/efs.yaml
+++ b/harness/determined/deploy/aws/templates/efs.yaml
@@ -4,35 +4,35 @@ Mappings:
   RegionMap:
     ap-northeast-1:
       Master: ami-0827d8ed0295e3feb
-      Agent: ami-0a506b88f4e1268a0
+      Agent: ami-078d9406b4fde0567
     # TODO(DET-4258) Uncomment these when we fully support all P3 regions.
     # ap-northeast-2:
     #   Master: ami-00bbba67d13faed04
-    #   Agent: ami-05d4c07cb56ed3777
+    #   Agent: ami-0fc41a015bd08f558
     # ap-southeast-1:
     #   Master: ami-0f6565c3d5328c913
-    #   Agent: ami-0b39e143721568921
+    #   Agent: ami-0abf18a93839d896a
     # ap-southeast-2:
     #   Master: ami-0a1002150df471b2b
-    #   Agent: ami-0885426f5ce6aada4
+    #   Agent: ami-0b49f4913ed2aeaa3
     eu-central-1:
       Master: ami-0bdbe51a2e8070ff2
-      Agent: ami-0d4478a40cb8bb10e
+      Agent: ami-09dfe0e75110703c8
     eu-west-1:
       Master: ami-03caf24deed650e2c
-      Agent: ami-0a15ab370f2846c16
+      Agent: ami-0b5e7b7b24bfc0afc
     # eu-west-2:
     #   Master: ami-093d303510c432519
-    #   Agent: ami-0f25f5f71d2b50df3
+    #   Agent: ami-0f7eefeb4ae74b526
     us-east-1:
       Master: ami-0dd76f917833aac4b
-      Agent: ami-0bdd6f68db44422a4
+      Agent: ami-08b34534a48df44cd
     us-east-2:
       Master: ami-0b29b6e62f2343b46
-      Agent: ami-09ec9c251aca453c0
+      Agent: ami-0f35ee97c172a6131
     us-west-2:
       Master: ami-01773ce53581acf22
-      Agent: ami-0f7c8ce0ef2b5a220
+      Agent: ami-0a00e428be59ef0ce
 
 Parameters:
   VpcCIDR:

--- a/harness/determined/deploy/aws/templates/efs.yaml
+++ b/harness/determined/deploy/aws/templates/efs.yaml
@@ -4,35 +4,35 @@ Mappings:
   RegionMap:
     ap-northeast-1:
       Master: ami-0827d8ed0295e3feb
-      Agent: ami-0a4d9306d8342befd
+      Agent: ami-0385dc3dcdc1ac287
     # TODO(DET-4258) Uncomment these when we fully support all P3 regions.
     # ap-northeast-2:
     #   Master: ami-00bbba67d13faed04
-    #   Agent: ami-0f7cdbccb4d8a4aac
+    #   Agent: ami-090bacb4f1f0540dd
     # ap-southeast-1:
     #   Master: ami-0f6565c3d5328c913
-    #   Agent: ami-047236f26873c1795
+    #   Agent: ami-0b2c2ed32f574ae3b
     # ap-southeast-2:
     #   Master: ami-0a1002150df471b2b
-    #   Agent: ami-0014377c9081bfad6
+    #   Agent: ami-09174a303f24171ca
     eu-central-1:
       Master: ami-0bdbe51a2e8070ff2
-      Agent: ami-04eea7b023e69d314
+      Agent: ami-0fd3496afbcaf9e49
     eu-west-1:
       Master: ami-03caf24deed650e2c
-      Agent: ami-086307142a8ca8d70
+      Agent: ami-0139d1106b0258a70
     # eu-west-2:
     #   Master: ami-093d303510c432519
-    #   Agent: ami-061988c5080fad3a6
+    #   Agent: ami-0a687fcb2de71ca86
     us-east-1:
       Master: ami-0dd76f917833aac4b
-      Agent: ami-0b94af65779bb341a
+      Agent: ami-00e877e7d94b191aa
     us-east-2:
       Master: ami-0b29b6e62f2343b46
-      Agent: ami-0c7095d79f2379886
+      Agent: ami-069a72699aafc6f10
     us-west-2:
       Master: ami-01773ce53581acf22
-      Agent: ami-0cbe0eb4ce6b8a7f3
+      Agent: ami-0e321f94fec3fabb9
 
 Parameters:
   VpcCIDR:

--- a/harness/determined/deploy/aws/templates/fsx.yaml
+++ b/harness/determined/deploy/aws/templates/fsx.yaml
@@ -3,35 +3,35 @@ Mappings:
   RegionMap:
     ap-northeast-1:
       Master: ami-0827d8ed0295e3feb
-      Agent: ami-0a4d9306d8342befd
+      Agent: ami-0385dc3dcdc1ac287
     # TODO(DET-4258) Uncomment these when we fully support all P3 regions.
     # ap-northeast-2:
     #   Master: ami-00bbba67d13faed04
-    #   Agent: ami-0f7cdbccb4d8a4aac
+    #   Agent: ami-090bacb4f1f0540dd
     # ap-southeast-1:
     #   Master: ami-0f6565c3d5328c913
-    #   Agent: ami-047236f26873c1795
+    #   Agent: ami-0b2c2ed32f574ae3b
     # ap-southeast-2:
     #   Master: ami-0a1002150df471b2b
-    #   Agent: ami-0014377c9081bfad6
+    #   Agent: ami-09174a303f24171ca
     eu-central-1:
       Master: ami-0bdbe51a2e8070ff2
-      Agent: ami-04eea7b023e69d314
+      Agent: ami-0fd3496afbcaf9e49
     eu-west-1:
       Master: ami-03caf24deed650e2c
-      Agent: ami-086307142a8ca8d70
+      Agent: ami-0139d1106b0258a70
     # eu-west-2:
     #   Master: ami-093d303510c432519
-    #   Agent: ami-061988c5080fad3a6
+    #   Agent: ami-0a687fcb2de71ca86
     us-east-1:
       Master: ami-0dd76f917833aac4b
-      Agent: ami-0b94af65779bb341a
+      Agent: ami-00e877e7d94b191aa
     us-east-2:
       Master: ami-0b29b6e62f2343b46
-      Agent: ami-0c7095d79f2379886
+      Agent: ami-069a72699aafc6f10
     us-west-2:
       Master: ami-01773ce53581acf22
-      Agent: ami-0cbe0eb4ce6b8a7f3
+      Agent: ami-0e321f94fec3fabb9
 
 Parameters:
   VpcCIDR:

--- a/harness/determined/deploy/aws/templates/fsx.yaml
+++ b/harness/determined/deploy/aws/templates/fsx.yaml
@@ -3,35 +3,35 @@ Mappings:
   RegionMap:
     ap-northeast-1:
       Master: ami-0827d8ed0295e3feb
-      Agent: ami-0385dc3dcdc1ac287
+      Agent: ami-0a506b88f4e1268a0
     # TODO(DET-4258) Uncomment these when we fully support all P3 regions.
     # ap-northeast-2:
     #   Master: ami-00bbba67d13faed04
-    #   Agent: ami-090bacb4f1f0540dd
+    #   Agent: ami-05d4c07cb56ed3777
     # ap-southeast-1:
     #   Master: ami-0f6565c3d5328c913
-    #   Agent: ami-0b2c2ed32f574ae3b
+    #   Agent: ami-0b39e143721568921
     # ap-southeast-2:
     #   Master: ami-0a1002150df471b2b
-    #   Agent: ami-09174a303f24171ca
+    #   Agent: ami-0885426f5ce6aada4
     eu-central-1:
       Master: ami-0bdbe51a2e8070ff2
-      Agent: ami-0fd3496afbcaf9e49
+      Agent: ami-0d4478a40cb8bb10e
     eu-west-1:
       Master: ami-03caf24deed650e2c
-      Agent: ami-0139d1106b0258a70
+      Agent: ami-0a15ab370f2846c16
     # eu-west-2:
     #   Master: ami-093d303510c432519
-    #   Agent: ami-0a687fcb2de71ca86
+    #   Agent: ami-0f25f5f71d2b50df3
     us-east-1:
       Master: ami-0dd76f917833aac4b
-      Agent: ami-00e877e7d94b191aa
+      Agent: ami-0bdd6f68db44422a4
     us-east-2:
       Master: ami-0b29b6e62f2343b46
-      Agent: ami-069a72699aafc6f10
+      Agent: ami-09ec9c251aca453c0
     us-west-2:
       Master: ami-01773ce53581acf22
-      Agent: ami-0e321f94fec3fabb9
+      Agent: ami-0f7c8ce0ef2b5a220
 
 Parameters:
   VpcCIDR:

--- a/harness/determined/deploy/aws/templates/fsx.yaml
+++ b/harness/determined/deploy/aws/templates/fsx.yaml
@@ -3,35 +3,35 @@ Mappings:
   RegionMap:
     ap-northeast-1:
       Master: ami-0827d8ed0295e3feb
-      Agent: ami-0a506b88f4e1268a0
+      Agent: ami-078d9406b4fde0567
     # TODO(DET-4258) Uncomment these when we fully support all P3 regions.
     # ap-northeast-2:
     #   Master: ami-00bbba67d13faed04
-    #   Agent: ami-05d4c07cb56ed3777
+    #   Agent: ami-0fc41a015bd08f558
     # ap-southeast-1:
     #   Master: ami-0f6565c3d5328c913
-    #   Agent: ami-0b39e143721568921
+    #   Agent: ami-0abf18a93839d896a
     # ap-southeast-2:
     #   Master: ami-0a1002150df471b2b
-    #   Agent: ami-0885426f5ce6aada4
+    #   Agent: ami-0b49f4913ed2aeaa3
     eu-central-1:
       Master: ami-0bdbe51a2e8070ff2
-      Agent: ami-0d4478a40cb8bb10e
+      Agent: ami-09dfe0e75110703c8
     eu-west-1:
       Master: ami-03caf24deed650e2c
-      Agent: ami-0a15ab370f2846c16
+      Agent: ami-0b5e7b7b24bfc0afc
     # eu-west-2:
     #   Master: ami-093d303510c432519
-    #   Agent: ami-0f25f5f71d2b50df3
+    #   Agent: ami-0f7eefeb4ae74b526
     us-east-1:
       Master: ami-0dd76f917833aac4b
-      Agent: ami-0bdd6f68db44422a4
+      Agent: ami-08b34534a48df44cd
     us-east-2:
       Master: ami-0b29b6e62f2343b46
-      Agent: ami-09ec9c251aca453c0
+      Agent: ami-0f35ee97c172a6131
     us-west-2:
       Master: ami-01773ce53581acf22
-      Agent: ami-0f7c8ce0ef2b5a220
+      Agent: ami-0a00e428be59ef0ce
 
 Parameters:
   VpcCIDR:

--- a/harness/determined/deploy/aws/templates/secure.yaml
+++ b/harness/determined/deploy/aws/templates/secure.yaml
@@ -4,44 +4,44 @@ Mappings:
   RegionMap:
     ap-northeast-1:
       Master: ami-0827d8ed0295e3feb
-      Agent: ami-0385dc3dcdc1ac287
+      Agent: ami-0a506b88f4e1268a0
       Bastion: ami-0827d8ed0295e3feb
     # TODO(DET-4258) Uncomment these when we fully support all P3 regions.
     # ap-northeast-2:
     #   Master: ami-00bbba67d13faed04
-    #   Agent: ami-090bacb4f1f0540dd
+    #   Agent: ami-05d4c07cb56ed3777
     #   Bastion: ami-00bbba67d13faed04
     # ap-southeast-1:
     #   Master: ami-0f6565c3d5328c913
-    #   Agent: ami-0b2c2ed32f574ae3b
+    #   Agent: ami-0b39e143721568921
     #   Bastion: ami-0f6565c3d5328c913
     # ap-southeast-2:
     #   Master: ami-0a1002150df471b2b
-    #   Agent: ami-09174a303f24171ca
+    #   Agent: ami-0885426f5ce6aada4
     #   Bastion: ami-0a1002150df471b2b
     eu-central-1:
       Master: ami-0bdbe51a2e8070ff2
-      Agent: ami-0fd3496afbcaf9e49
+      Agent: ami-0d4478a40cb8bb10e
       Bastion: ami-0bdbe51a2e8070ff2
     eu-west-1:
       Master: ami-03caf24deed650e2c
-      Agent: ami-0139d1106b0258a70
+      Agent: ami-0a15ab370f2846c16
       Bastion: ami-03caf24deed650e2c
     # eu-west-2:
     #   Master: ami-093d303510c432519
-    #   Agent: ami-0a687fcb2de71ca86
+    #   Agent: ami-0f25f5f71d2b50df3
     #   Bastion: ami-093d303510c432519
     us-east-1:
       Master: ami-0dd76f917833aac4b
-      Agent: ami-00e877e7d94b191aa
+      Agent: ami-0bdd6f68db44422a4
       Bastion: ami-0dd76f917833aac4b
     us-east-2:
       Master: ami-0b29b6e62f2343b46
-      Agent: ami-069a72699aafc6f10
+      Agent: ami-09ec9c251aca453c0
       Bastion: ami-0b29b6e62f2343b46
     us-west-2:
       Master: ami-01773ce53581acf22
-      Agent: ami-0e321f94fec3fabb9
+      Agent: ami-0f7c8ce0ef2b5a220
       Bastion: ami-01773ce53581acf22
 
 Parameters:

--- a/harness/determined/deploy/aws/templates/secure.yaml
+++ b/harness/determined/deploy/aws/templates/secure.yaml
@@ -4,44 +4,44 @@ Mappings:
   RegionMap:
     ap-northeast-1:
       Master: ami-0827d8ed0295e3feb
-      Agent: ami-0a506b88f4e1268a0
+      Agent: ami-078d9406b4fde0567
       Bastion: ami-0827d8ed0295e3feb
     # TODO(DET-4258) Uncomment these when we fully support all P3 regions.
     # ap-northeast-2:
     #   Master: ami-00bbba67d13faed04
-    #   Agent: ami-05d4c07cb56ed3777
+    #   Agent: ami-0fc41a015bd08f558
     #   Bastion: ami-00bbba67d13faed04
     # ap-southeast-1:
     #   Master: ami-0f6565c3d5328c913
-    #   Agent: ami-0b39e143721568921
+    #   Agent: ami-0abf18a93839d896a
     #   Bastion: ami-0f6565c3d5328c913
     # ap-southeast-2:
     #   Master: ami-0a1002150df471b2b
-    #   Agent: ami-0885426f5ce6aada4
+    #   Agent: ami-0b49f4913ed2aeaa3
     #   Bastion: ami-0a1002150df471b2b
     eu-central-1:
       Master: ami-0bdbe51a2e8070ff2
-      Agent: ami-0d4478a40cb8bb10e
+      Agent: ami-09dfe0e75110703c8
       Bastion: ami-0bdbe51a2e8070ff2
     eu-west-1:
       Master: ami-03caf24deed650e2c
-      Agent: ami-0a15ab370f2846c16
+      Agent: ami-0b5e7b7b24bfc0afc
       Bastion: ami-03caf24deed650e2c
     # eu-west-2:
     #   Master: ami-093d303510c432519
-    #   Agent: ami-0f25f5f71d2b50df3
+    #   Agent: ami-0f7eefeb4ae74b526
     #   Bastion: ami-093d303510c432519
     us-east-1:
       Master: ami-0dd76f917833aac4b
-      Agent: ami-0bdd6f68db44422a4
+      Agent: ami-08b34534a48df44cd
       Bastion: ami-0dd76f917833aac4b
     us-east-2:
       Master: ami-0b29b6e62f2343b46
-      Agent: ami-09ec9c251aca453c0
+      Agent: ami-0f35ee97c172a6131
       Bastion: ami-0b29b6e62f2343b46
     us-west-2:
       Master: ami-01773ce53581acf22
-      Agent: ami-0f7c8ce0ef2b5a220
+      Agent: ami-0a00e428be59ef0ce
       Bastion: ami-01773ce53581acf22
 
 Parameters:

--- a/harness/determined/deploy/aws/templates/secure.yaml
+++ b/harness/determined/deploy/aws/templates/secure.yaml
@@ -4,44 +4,44 @@ Mappings:
   RegionMap:
     ap-northeast-1:
       Master: ami-0827d8ed0295e3feb
-      Agent: ami-0a4d9306d8342befd
+      Agent: ami-0385dc3dcdc1ac287
       Bastion: ami-0827d8ed0295e3feb
     # TODO(DET-4258) Uncomment these when we fully support all P3 regions.
     # ap-northeast-2:
     #   Master: ami-00bbba67d13faed04
-    #   Agent: ami-0f7cdbccb4d8a4aac
+    #   Agent: ami-090bacb4f1f0540dd
     #   Bastion: ami-00bbba67d13faed04
     # ap-southeast-1:
     #   Master: ami-0f6565c3d5328c913
-    #   Agent: ami-047236f26873c1795
+    #   Agent: ami-0b2c2ed32f574ae3b
     #   Bastion: ami-0f6565c3d5328c913
     # ap-southeast-2:
     #   Master: ami-0a1002150df471b2b
-    #   Agent: ami-0014377c9081bfad6
+    #   Agent: ami-09174a303f24171ca
     #   Bastion: ami-0a1002150df471b2b
     eu-central-1:
       Master: ami-0bdbe51a2e8070ff2
-      Agent: ami-04eea7b023e69d314
+      Agent: ami-0fd3496afbcaf9e49
       Bastion: ami-0bdbe51a2e8070ff2
     eu-west-1:
       Master: ami-03caf24deed650e2c
-      Agent: ami-086307142a8ca8d70
+      Agent: ami-0139d1106b0258a70
       Bastion: ami-03caf24deed650e2c
     # eu-west-2:
     #   Master: ami-093d303510c432519
-    #   Agent: ami-061988c5080fad3a6
+    #   Agent: ami-0a687fcb2de71ca86
     #   Bastion: ami-093d303510c432519
     us-east-1:
       Master: ami-0dd76f917833aac4b
-      Agent: ami-0b94af65779bb341a
+      Agent: ami-00e877e7d94b191aa
       Bastion: ami-0dd76f917833aac4b
     us-east-2:
       Master: ami-0b29b6e62f2343b46
-      Agent: ami-0c7095d79f2379886
+      Agent: ami-069a72699aafc6f10
       Bastion: ami-0b29b6e62f2343b46
     us-west-2:
       Master: ami-01773ce53581acf22
-      Agent: ami-0cbe0eb4ce6b8a7f3
+      Agent: ami-0e321f94fec3fabb9
       Bastion: ami-01773ce53581acf22
 
 Parameters:

--- a/harness/determined/deploy/aws/templates/simple.yaml
+++ b/harness/determined/deploy/aws/templates/simple.yaml
@@ -5,35 +5,35 @@ Mappings:
   RegionMap:
     ap-northeast-1:
       Master: ami-0827d8ed0295e3feb
-      Agent: ami-0a506b88f4e1268a0
+      Agent: ami-078d9406b4fde0567
     # TODO(DET-4258) Uncomment these when we fully support all P3 regions.
     # ap-northeast-2:
     #   Master: ami-00bbba67d13faed04
-    #   Agent: ami-05d4c07cb56ed3777
+    #   Agent: ami-0fc41a015bd08f558
     # ap-southeast-1:
     #   Master: ami-0f6565c3d5328c913
-    #   Agent: ami-0b39e143721568921
+    #   Agent: ami-0abf18a93839d896a
     # ap-southeast-2:
     #   Master: ami-0a1002150df471b2b
-    #   Agent: ami-0885426f5ce6aada4
+    #   Agent: ami-0b49f4913ed2aeaa3
     eu-central-1:
       Master: ami-0bdbe51a2e8070ff2
-      Agent: ami-0d4478a40cb8bb10e
+      Agent: ami-09dfe0e75110703c8
     eu-west-1:
       Master: ami-03caf24deed650e2c
-      Agent: ami-0a15ab370f2846c16
+      Agent: ami-0b5e7b7b24bfc0afc
     # eu-west-2:
     #   Master: ami-093d303510c432519
-    #   Agent: ami-0f25f5f71d2b50df3
+    #   Agent: ami-0f7eefeb4ae74b526
     us-east-1:
       Master: ami-0dd76f917833aac4b
-      Agent: ami-0bdd6f68db44422a4
+      Agent: ami-08b34534a48df44cd
     us-east-2:
       Master: ami-0b29b6e62f2343b46
-      Agent: ami-09ec9c251aca453c0
+      Agent: ami-0f35ee97c172a6131
     us-west-2:
       Master: ami-01773ce53581acf22
-      Agent: ami-0f7c8ce0ef2b5a220
+      Agent: ami-0a00e428be59ef0ce
 
 Parameters:
   Keypair:

--- a/harness/determined/deploy/aws/templates/simple.yaml
+++ b/harness/determined/deploy/aws/templates/simple.yaml
@@ -5,35 +5,35 @@ Mappings:
   RegionMap:
     ap-northeast-1:
       Master: ami-0827d8ed0295e3feb
-      Agent: ami-0a4d9306d8342befd
+      Agent: ami-0385dc3dcdc1ac287
     # TODO(DET-4258) Uncomment these when we fully support all P3 regions.
     # ap-northeast-2:
     #   Master: ami-00bbba67d13faed04
-    #   Agent: ami-0f7cdbccb4d8a4aac
+    #   Agent: ami-090bacb4f1f0540dd
     # ap-southeast-1:
     #   Master: ami-0f6565c3d5328c913
-    #   Agent: ami-047236f26873c1795
+    #   Agent: ami-0b2c2ed32f574ae3b
     # ap-southeast-2:
     #   Master: ami-0a1002150df471b2b
-    #   Agent: ami-0014377c9081bfad6
+    #   Agent: ami-09174a303f24171ca
     eu-central-1:
       Master: ami-0bdbe51a2e8070ff2
-      Agent: ami-04eea7b023e69d314
+      Agent: ami-0fd3496afbcaf9e49
     eu-west-1:
       Master: ami-03caf24deed650e2c
-      Agent: ami-086307142a8ca8d70
+      Agent: ami-0139d1106b0258a70
     # eu-west-2:
     #   Master: ami-093d303510c432519
-    #   Agent: ami-061988c5080fad3a6
+    #   Agent: ami-0a687fcb2de71ca86
     us-east-1:
       Master: ami-0dd76f917833aac4b
-      Agent: ami-0b94af65779bb341a
+      Agent: ami-00e877e7d94b191aa
     us-east-2:
       Master: ami-0b29b6e62f2343b46
-      Agent: ami-0c7095d79f2379886
+      Agent: ami-069a72699aafc6f10
     us-west-2:
       Master: ami-01773ce53581acf22
-      Agent: ami-0cbe0eb4ce6b8a7f3
+      Agent: ami-0e321f94fec3fabb9
 
 Parameters:
   Keypair:

--- a/harness/determined/deploy/aws/templates/simple.yaml
+++ b/harness/determined/deploy/aws/templates/simple.yaml
@@ -5,35 +5,35 @@ Mappings:
   RegionMap:
     ap-northeast-1:
       Master: ami-0827d8ed0295e3feb
-      Agent: ami-0385dc3dcdc1ac287
+      Agent: ami-0a506b88f4e1268a0
     # TODO(DET-4258) Uncomment these when we fully support all P3 regions.
     # ap-northeast-2:
     #   Master: ami-00bbba67d13faed04
-    #   Agent: ami-090bacb4f1f0540dd
+    #   Agent: ami-05d4c07cb56ed3777
     # ap-southeast-1:
     #   Master: ami-0f6565c3d5328c913
-    #   Agent: ami-0b2c2ed32f574ae3b
+    #   Agent: ami-0b39e143721568921
     # ap-southeast-2:
     #   Master: ami-0a1002150df471b2b
-    #   Agent: ami-09174a303f24171ca
+    #   Agent: ami-0885426f5ce6aada4
     eu-central-1:
       Master: ami-0bdbe51a2e8070ff2
-      Agent: ami-0fd3496afbcaf9e49
+      Agent: ami-0d4478a40cb8bb10e
     eu-west-1:
       Master: ami-03caf24deed650e2c
-      Agent: ami-0139d1106b0258a70
+      Agent: ami-0a15ab370f2846c16
     # eu-west-2:
     #   Master: ami-093d303510c432519
-    #   Agent: ami-0a687fcb2de71ca86
+    #   Agent: ami-0f25f5f71d2b50df3
     us-east-1:
       Master: ami-0dd76f917833aac4b
-      Agent: ami-00e877e7d94b191aa
+      Agent: ami-0bdd6f68db44422a4
     us-east-2:
       Master: ami-0b29b6e62f2343b46
-      Agent: ami-069a72699aafc6f10
+      Agent: ami-09ec9c251aca453c0
     us-west-2:
       Master: ami-01773ce53581acf22
-      Agent: ami-0e321f94fec3fabb9
+      Agent: ami-0f7c8ce0ef2b5a220
 
 Parameters:
   Keypair:

--- a/harness/determined/deploy/aws/templates/vpc.yaml
+++ b/harness/determined/deploy/aws/templates/vpc.yaml
@@ -4,35 +4,35 @@ Mappings:
   RegionMap:
     ap-northeast-1:
       Master: ami-0827d8ed0295e3feb
-      Agent: ami-0385dc3dcdc1ac287
+      Agent: ami-0a506b88f4e1268a0
     # TODO(DET-4258) Uncomment these when we fully support all P3 regions.
     # ap-northeast-2:
     #   Master: ami-00bbba67d13faed04
-    #   Agent: ami-090bacb4f1f0540dd
+    #   Agent: ami-05d4c07cb56ed3777
     # ap-southeast-1:
     #   Master: ami-0f6565c3d5328c913
-    #   Agent: ami-0b2c2ed32f574ae3b
+    #   Agent: ami-0b39e143721568921
     # ap-southeast-2:
     #   Master: ami-0a1002150df471b2b
-    #   Agent: ami-09174a303f24171ca
+    #   Agent: ami-0885426f5ce6aada4
     eu-central-1:
       Master: ami-0bdbe51a2e8070ff2
-      Agent: ami-0fd3496afbcaf9e49
+      Agent: ami-0d4478a40cb8bb10e
     eu-west-1:
       Master: ami-03caf24deed650e2c
-      Agent: ami-0139d1106b0258a70
+      Agent: ami-0a15ab370f2846c16
     # eu-west-2:
     #   Master: ami-093d303510c432519
-    #   Agent: ami-0a687fcb2de71ca86
+    #   Agent: ami-0f25f5f71d2b50df3
     us-east-1:
       Master: ami-0dd76f917833aac4b
-      Agent: ami-00e877e7d94b191aa
+      Agent: ami-0bdd6f68db44422a4
     us-east-2:
       Master: ami-0b29b6e62f2343b46
-      Agent: ami-069a72699aafc6f10
+      Agent: ami-09ec9c251aca453c0
     us-west-2:
       Master: ami-01773ce53581acf22
-      Agent: ami-0e321f94fec3fabb9
+      Agent: ami-0f7c8ce0ef2b5a220
 
 Parameters:
   VpcCIDR:

--- a/harness/determined/deploy/aws/templates/vpc.yaml
+++ b/harness/determined/deploy/aws/templates/vpc.yaml
@@ -4,35 +4,35 @@ Mappings:
   RegionMap:
     ap-northeast-1:
       Master: ami-0827d8ed0295e3feb
-      Agent: ami-0a506b88f4e1268a0
+      Agent: ami-078d9406b4fde0567
     # TODO(DET-4258) Uncomment these when we fully support all P3 regions.
     # ap-northeast-2:
     #   Master: ami-00bbba67d13faed04
-    #   Agent: ami-05d4c07cb56ed3777
+    #   Agent: ami-0fc41a015bd08f558
     # ap-southeast-1:
     #   Master: ami-0f6565c3d5328c913
-    #   Agent: ami-0b39e143721568921
+    #   Agent: ami-0abf18a93839d896a
     # ap-southeast-2:
     #   Master: ami-0a1002150df471b2b
-    #   Agent: ami-0885426f5ce6aada4
+    #   Agent: ami-0b49f4913ed2aeaa3
     eu-central-1:
       Master: ami-0bdbe51a2e8070ff2
-      Agent: ami-0d4478a40cb8bb10e
+      Agent: ami-09dfe0e75110703c8
     eu-west-1:
       Master: ami-03caf24deed650e2c
-      Agent: ami-0a15ab370f2846c16
+      Agent: ami-0b5e7b7b24bfc0afc
     # eu-west-2:
     #   Master: ami-093d303510c432519
-    #   Agent: ami-0f25f5f71d2b50df3
+    #   Agent: ami-0f7eefeb4ae74b526
     us-east-1:
       Master: ami-0dd76f917833aac4b
-      Agent: ami-0bdd6f68db44422a4
+      Agent: ami-08b34534a48df44cd
     us-east-2:
       Master: ami-0b29b6e62f2343b46
-      Agent: ami-09ec9c251aca453c0
+      Agent: ami-0f35ee97c172a6131
     us-west-2:
       Master: ami-01773ce53581acf22
-      Agent: ami-0f7c8ce0ef2b5a220
+      Agent: ami-0a00e428be59ef0ce
 
 Parameters:
   VpcCIDR:

--- a/harness/determined/deploy/aws/templates/vpc.yaml
+++ b/harness/determined/deploy/aws/templates/vpc.yaml
@@ -4,35 +4,35 @@ Mappings:
   RegionMap:
     ap-northeast-1:
       Master: ami-0827d8ed0295e3feb
-      Agent: ami-0a4d9306d8342befd
+      Agent: ami-0385dc3dcdc1ac287
     # TODO(DET-4258) Uncomment these when we fully support all P3 regions.
     # ap-northeast-2:
     #   Master: ami-00bbba67d13faed04
-    #   Agent: ami-0f7cdbccb4d8a4aac
+    #   Agent: ami-090bacb4f1f0540dd
     # ap-southeast-1:
     #   Master: ami-0f6565c3d5328c913
-    #   Agent: ami-047236f26873c1795
+    #   Agent: ami-0b2c2ed32f574ae3b
     # ap-southeast-2:
     #   Master: ami-0a1002150df471b2b
-    #   Agent: ami-0014377c9081bfad6
+    #   Agent: ami-09174a303f24171ca
     eu-central-1:
       Master: ami-0bdbe51a2e8070ff2
-      Agent: ami-04eea7b023e69d314
+      Agent: ami-0fd3496afbcaf9e49
     eu-west-1:
       Master: ami-03caf24deed650e2c
-      Agent: ami-086307142a8ca8d70
+      Agent: ami-0139d1106b0258a70
     # eu-west-2:
     #   Master: ami-093d303510c432519
-    #   Agent: ami-061988c5080fad3a6
+    #   Agent: ami-0a687fcb2de71ca86
     us-east-1:
       Master: ami-0dd76f917833aac4b
-      Agent: ami-0b94af65779bb341a
+      Agent: ami-00e877e7d94b191aa
     us-east-2:
       Master: ami-0b29b6e62f2343b46
-      Agent: ami-0c7095d79f2379886
+      Agent: ami-069a72699aafc6f10
     us-west-2:
       Master: ami-01773ce53581acf22
-      Agent: ami-0cbe0eb4ce6b8a7f3
+      Agent: ami-0e321f94fec3fabb9
 
 Parameters:
   VpcCIDR:

--- a/harness/determined/deploy/gcp/constants.py
+++ b/harness/determined/deploy/gcp/constants.py
@@ -3,7 +3,7 @@ class defaults:
     AUX_AGENT_INSTANCE_TYPE = "n1-standard-4"
     COMPUTE_AGENT_INSTANCE_TYPE = "n1-standard-32"
     DB_PASSWORD = "postgres"
-    ENVIRONMENT_IMAGE = "det-environments-7a48718"
+    ENVIRONMENT_IMAGE = "det-environments-0ca3d22"
     GPU_NUM = 8
     GPU_TYPE = "nvidia-tesla-k80"
     MASTER_INSTANCE_TYPE = "n1-standard-2"

--- a/harness/determined/deploy/gcp/constants.py
+++ b/harness/determined/deploy/gcp/constants.py
@@ -3,7 +3,7 @@ class defaults:
     AUX_AGENT_INSTANCE_TYPE = "n1-standard-4"
     COMPUTE_AGENT_INSTANCE_TYPE = "n1-standard-32"
     DB_PASSWORD = "postgres"
-    ENVIRONMENT_IMAGE = "det-environments-a173dcd"
+    ENVIRONMENT_IMAGE = "det-environments-7a48718"
     GPU_NUM = 8
     GPU_TYPE = "nvidia-tesla-k80"
     MASTER_INSTANCE_TYPE = "n1-standard-2"

--- a/harness/determined/deploy/gcp/constants.py
+++ b/harness/determined/deploy/gcp/constants.py
@@ -3,7 +3,7 @@ class defaults:
     AUX_AGENT_INSTANCE_TYPE = "n1-standard-4"
     COMPUTE_AGENT_INSTANCE_TYPE = "n1-standard-32"
     DB_PASSWORD = "postgres"
-    ENVIRONMENT_IMAGE = "det-environments-0ca3d22"
+    ENVIRONMENT_IMAGE = "det-environments-e8af732"
     GPU_NUM = 8
     GPU_TYPE = "nvidia-tesla-k80"
     MASTER_INSTANCE_TYPE = "n1-standard-2"

--- a/harness/determined/estimator/_estimator_trial.py
+++ b/harness/determined/estimator/_estimator_trial.py
@@ -778,7 +778,7 @@ class EstimatorTrial(det.Trial):
     """
     By default, experiments run with TensorFlow 1.x. To configure your trial to
     use TensorFlow 2.x, set a TF 2.x image in the experiment configuration
-    (e.g. ``determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0.16.4``).
+    (e.g. ``determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0.17.0``).
 
     ``EstimatorTrial`` supports TF 2.x; however it uses TensorFlow V1
     behavior. We have disabled TensorFlow V2 behavior for ``EstimatorTrial``,

--- a/harness/determined/keras/_tf_keras_trial.py
+++ b/harness/determined/keras/_tf_keras_trial.py
@@ -952,7 +952,7 @@ class TFKerasTrial(det.Trial):
     TensorFlow 2.x, specify a TensorFlow 2.x image in the
     :ref:`environment.image <exp-environment-image>` field of the experiment
     configuration (e.g.,
-    ``determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0.16.4``).
+    ``determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0.17.0``).
 
     Trials default to using eager execution with TensorFlow 2.x but not with
     TensorFlow 1.x. To override the default behavior, call the appropriate

--- a/helm/charts/determined/templates/master-config.yaml
+++ b/helm/charts/determined/templates/master-config.yaml
@@ -71,8 +71,8 @@ data:
         cpu: {{ .Values.slotResourceRequests.cpu }}
       {{- end }}
 
-    {{$cpuImage := (split "/" "determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-a173dcd")._1}}
-    {{- $gpuImage := (split "/" "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-a173dcd")._1 -}}
+    {{$cpuImage := (split "/" "determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-7a48718")._1}}
+    {{- $gpuImage := (split "/" "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-7a48718")._1 -}}
     {{ if .Values.taskContainerDefaults -}}
     task_container_defaults:
       {{- if .Values.taskContainerDefaults.networkMode }}

--- a/helm/charts/determined/templates/master-config.yaml
+++ b/helm/charts/determined/templates/master-config.yaml
@@ -71,8 +71,8 @@ data:
         cpu: {{ .Values.slotResourceRequests.cpu }}
       {{- end }}
 
-    {{$cpuImage := (split "/" "determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0ca3d22")._1}}
-    {{- $gpuImage := (split "/" "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0ca3d22")._1 -}}
+    {{$cpuImage := (split "/" "determinedai/environments:py-3.8-pytorch-1.9-lightning-1.3-tf-2.4-cpu-e8af732")._1}}
+    {{- $gpuImage := (split "/" "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-e8af732")._1 -}}
     {{ if .Values.taskContainerDefaults -}}
     task_container_defaults:
       {{- if .Values.taskContainerDefaults.networkMode }}

--- a/helm/charts/determined/templates/master-config.yaml
+++ b/helm/charts/determined/templates/master-config.yaml
@@ -71,8 +71,8 @@ data:
         cpu: {{ .Values.slotResourceRequests.cpu }}
       {{- end }}
 
-    {{$cpuImage := (split "/" "determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-7a48718")._1}}
-    {{- $gpuImage := (split "/" "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-7a48718")._1 -}}
+    {{$cpuImage := (split "/" "determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0ca3d22")._1}}
+    {{- $gpuImage := (split "/" "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0ca3d22")._1 -}}
     {{ if .Values.taskContainerDefaults -}}
     task_container_defaults:
       {{- if .Values.taskContainerDefaults.networkMode }}

--- a/master/internal/provisioner/aws_config.go
+++ b/master/internal/provisioner/aws_config.go
@@ -44,16 +44,16 @@ type AWSClusterConfig struct {
 }
 
 var defaultAWSImageID = map[string]string{
-	"ap-northeast-1": "ami-0a4d9306d8342befd",
-	"ap-northeast-2": "ami-0f7cdbccb4d8a4aac",
-	"ap-southeast-1": "ami-047236f26873c1795",
-	"ap-southeast-2": "ami-0014377c9081bfad6",
-	"us-east-2":      "ami-0c7095d79f2379886",
-	"us-east-1":      "ami-0b94af65779bb341a",
-	"us-west-2":      "ami-0cbe0eb4ce6b8a7f3",
-	"eu-central-1":   "ami-04eea7b023e69d314",
-	"eu-west-2":      "ami-061988c5080fad3a6",
-	"eu-west-1":      "ami-086307142a8ca8d70",
+	"ap-northeast-1": "ami-0385dc3dcdc1ac287",
+	"ap-northeast-2": "ami-090bacb4f1f0540dd",
+	"ap-southeast-1": "ami-0b2c2ed32f574ae3b",
+	"ap-southeast-2": "ami-09174a303f24171ca",
+	"us-east-2":      "ami-069a72699aafc6f10",
+	"us-east-1":      "ami-00e877e7d94b191aa",
+	"us-west-2":      "ami-0e321f94fec3fabb9",
+	"eu-central-1":   "ami-0fd3496afbcaf9e49",
+	"eu-west-2":      "ami-0a687fcb2de71ca86",
+	"eu-west-1":      "ami-0139d1106b0258a70",
 }
 
 var defaultAWSClusterConfig = AWSClusterConfig{

--- a/master/internal/provisioner/aws_config.go
+++ b/master/internal/provisioner/aws_config.go
@@ -44,16 +44,16 @@ type AWSClusterConfig struct {
 }
 
 var defaultAWSImageID = map[string]string{
-	"ap-northeast-1": "ami-0a506b88f4e1268a0",
-	"ap-northeast-2": "ami-05d4c07cb56ed3777",
-	"ap-southeast-1": "ami-0b39e143721568921",
-	"ap-southeast-2": "ami-0885426f5ce6aada4",
-	"us-east-2":      "ami-09ec9c251aca453c0",
-	"us-east-1":      "ami-0bdd6f68db44422a4",
-	"us-west-2":      "ami-0f7c8ce0ef2b5a220",
-	"eu-central-1":   "ami-0d4478a40cb8bb10e",
-	"eu-west-2":      "ami-0f25f5f71d2b50df3",
-	"eu-west-1":      "ami-0a15ab370f2846c16",
+	"ap-northeast-1": "ami-078d9406b4fde0567",
+	"ap-northeast-2": "ami-0fc41a015bd08f558",
+	"ap-southeast-1": "ami-0abf18a93839d896a",
+	"ap-southeast-2": "ami-0b49f4913ed2aeaa3",
+	"us-east-2":      "ami-0f35ee97c172a6131",
+	"us-east-1":      "ami-08b34534a48df44cd",
+	"us-west-2":      "ami-0a00e428be59ef0ce",
+	"eu-central-1":   "ami-09dfe0e75110703c8",
+	"eu-west-2":      "ami-0f7eefeb4ae74b526",
+	"eu-west-1":      "ami-0b5e7b7b24bfc0afc",
 }
 
 var defaultAWSClusterConfig = AWSClusterConfig{

--- a/master/internal/provisioner/aws_config.go
+++ b/master/internal/provisioner/aws_config.go
@@ -44,16 +44,16 @@ type AWSClusterConfig struct {
 }
 
 var defaultAWSImageID = map[string]string{
-	"ap-northeast-1": "ami-0385dc3dcdc1ac287",
-	"ap-northeast-2": "ami-090bacb4f1f0540dd",
-	"ap-southeast-1": "ami-0b2c2ed32f574ae3b",
-	"ap-southeast-2": "ami-09174a303f24171ca",
-	"us-east-2":      "ami-069a72699aafc6f10",
-	"us-east-1":      "ami-00e877e7d94b191aa",
-	"us-west-2":      "ami-0e321f94fec3fabb9",
-	"eu-central-1":   "ami-0fd3496afbcaf9e49",
-	"eu-west-2":      "ami-0a687fcb2de71ca86",
-	"eu-west-1":      "ami-0139d1106b0258a70",
+	"ap-northeast-1": "ami-0a506b88f4e1268a0",
+	"ap-northeast-2": "ami-05d4c07cb56ed3777",
+	"ap-southeast-1": "ami-0b39e143721568921",
+	"ap-southeast-2": "ami-0885426f5ce6aada4",
+	"us-east-2":      "ami-09ec9c251aca453c0",
+	"us-east-1":      "ami-0bdd6f68db44422a4",
+	"us-west-2":      "ami-0f7c8ce0ef2b5a220",
+	"eu-central-1":   "ami-0d4478a40cb8bb10e",
+	"eu-west-2":      "ami-0f25f5f71d2b50df3",
+	"eu-west-1":      "ami-0a15ab370f2846c16",
 }
 
 var defaultAWSClusterConfig = AWSClusterConfig{

--- a/master/internal/provisioner/gcp_config.go
+++ b/master/internal/provisioner/gcp_config.go
@@ -53,7 +53,7 @@ type GCPClusterConfig struct {
 func DefaultGCPClusterConfig() *GCPClusterConfig {
 	return &GCPClusterConfig{
 		BootDiskSize:        200,
-		BootDiskSourceImage: "projects/determined-ai/global/images/det-environments-0ca3d22",
+		BootDiskSourceImage: "projects/determined-ai/global/images/det-environments-e8af732",
 		LabelKey:            "managed-by",
 		InstanceType: gceInstanceType{
 			MachineType: "n1-standard-32",

--- a/master/internal/provisioner/gcp_config.go
+++ b/master/internal/provisioner/gcp_config.go
@@ -53,7 +53,7 @@ type GCPClusterConfig struct {
 func DefaultGCPClusterConfig() *GCPClusterConfig {
 	return &GCPClusterConfig{
 		BootDiskSize:        200,
-		BootDiskSourceImage: "projects/determined-ai/global/images/det-environments-7a48718",
+		BootDiskSourceImage: "projects/determined-ai/global/images/det-environments-0ca3d22",
 		LabelKey:            "managed-by",
 		InstanceType: gceInstanceType{
 			MachineType: "n1-standard-32",

--- a/master/internal/provisioner/gcp_config.go
+++ b/master/internal/provisioner/gcp_config.go
@@ -53,7 +53,7 @@ type GCPClusterConfig struct {
 func DefaultGCPClusterConfig() *GCPClusterConfig {
 	return &GCPClusterConfig{
 		BootDiskSize:        200,
-		BootDiskSourceImage: "projects/determined-ai/global/images/det-environments-a173dcd",
+		BootDiskSourceImage: "projects/determined-ai/global/images/det-environments-7a48718",
 		LabelKey:            "managed-by",
 		InstanceType: gceInstanceType{
 			MachineType: "n1-standard-32",

--- a/master/pkg/model/defaults.go
+++ b/master/pkg/model/defaults.go
@@ -25,8 +25,8 @@ const (
 
 // Default task environment docker image names.
 const (
-	CPUImage = "determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0ca3d22"
-	GPUImage = "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0ca3d22"
+	CPUImage = "determinedai/environments:py-3.8-pytorch-1.9-lightning-1.3-tf-2.4-cpu-e8af732"
+	GPUImage = "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-e8af732"
 )
 
 // DefaultResourcesConfig returns the default resources configuration.

--- a/master/pkg/model/defaults.go
+++ b/master/pkg/model/defaults.go
@@ -25,8 +25,8 @@ const (
 
 // Default task environment docker image names.
 const (
-	CPUImage = "determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-7a48718"
-	GPUImage = "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-7a48718"
+	CPUImage = "determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0ca3d22"
+	GPUImage = "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0ca3d22"
 )
 
 // DefaultResourcesConfig returns the default resources configuration.

--- a/master/pkg/model/defaults.go
+++ b/master/pkg/model/defaults.go
@@ -25,8 +25,8 @@ const (
 
 // Default task environment docker image names.
 const (
-	CPUImage = "determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-a173dcd"
-	GPUImage = "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-a173dcd"
+	CPUImage = "determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-7a48718"
+	GPUImage = "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-7a48718"
 )
 
 // DefaultResourcesConfig returns the default resources configuration.

--- a/master/pkg/schemas/expconf/const.go
+++ b/master/pkg/schemas/expconf/const.go
@@ -8,6 +8,6 @@ const (
 
 // Default task environment docker image names.
 const (
-	CPUImage = "determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0ca3d22"
-	GPUImage = "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0ca3d22"
+	CPUImage = "determinedai/environments:py-3.8-pytorch-1.9-lightning-1.3-tf-2.4-cpu-e8af732"
+	GPUImage = "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-e8af732"
 )

--- a/master/pkg/schemas/expconf/const.go
+++ b/master/pkg/schemas/expconf/const.go
@@ -8,6 +8,6 @@ const (
 
 // Default task environment docker image names.
 const (
-	CPUImage = "determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-7a48718"
-	GPUImage = "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-7a48718"
+	CPUImage = "determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0ca3d22"
+	GPUImage = "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0ca3d22"
 )

--- a/master/pkg/schemas/expconf/const.go
+++ b/master/pkg/schemas/expconf/const.go
@@ -8,6 +8,6 @@ const (
 
 // Default task environment docker image names.
 const (
-	CPUImage = "determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-a173dcd"
-	GPUImage = "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-a173dcd"
+	CPUImage = "determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-7a48718"
+	GPUImage = "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-7a48718"
 )

--- a/master/pkg/schemas/expconf/legacy_test.go
+++ b/master/pkg/schemas/expconf/legacy_test.go
@@ -233,8 +233,8 @@ func TestLegacyConfig(t *testing.T) {
                     gpu: []
                   force_pull_image: false
                   image:
-                    cpu: determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-7a48718
-                    gpu: determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-7a48718
+                    cpu: determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-0ca3d22
+                    gpu: determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-0ca3d22
                   pod_spec: null
                   ports: {}
                   registry_auth: null

--- a/master/pkg/schemas/expconf/legacy_test.go
+++ b/master/pkg/schemas/expconf/legacy_test.go
@@ -233,8 +233,8 @@ func TestLegacyConfig(t *testing.T) {
                     gpu: []
                   force_pull_image: false
                   image:
-                    cpu: determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-0ca3d22
-                    gpu: determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-0ca3d22
+                    cpu: determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-e8af732
+                    gpu: determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-e8af732
                   pod_spec: null
                   ports: {}
                   registry_auth: null

--- a/master/pkg/schemas/expconf/legacy_test.go
+++ b/master/pkg/schemas/expconf/legacy_test.go
@@ -233,8 +233,8 @@ func TestLegacyConfig(t *testing.T) {
                     gpu: []
                   force_pull_image: false
                   image:
-                    cpu: determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-a173dcd
-                    gpu: determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-a173dcd
+                    cpu: determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-7a48718
+                    gpu: determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-7a48718
                   pod_spec: null
                   ports: {}
                   registry_auth: null

--- a/model_hub/Makefile
+++ b/model_hub/Makefile
@@ -5,7 +5,7 @@ SHORT_GIT_HASH := $(shell git rev-parse --short HEAD)
 ARTIFACTS_DIR := /tmp/artifacts
 
 # Model-hub library environments will be built on top of the default GPU and CPU images in master/pkg/model/defaults.go
-DEFAULT_GPU_IMAGE := determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-7a48718
+DEFAULT_GPU_IMAGE := determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0ca3d22
 
 ############REMINDER############
 # When bumping third-party library versions, remember to bump versions in 

--- a/model_hub/Makefile
+++ b/model_hub/Makefile
@@ -5,7 +5,7 @@ SHORT_GIT_HASH := $(shell git rev-parse --short HEAD)
 ARTIFACTS_DIR := /tmp/artifacts
 
 # Model-hub library environments will be built on top of the default GPU and CPU images in master/pkg/model/defaults.go
-DEFAULT_GPU_IMAGE := determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-a173dcd
+DEFAULT_GPU_IMAGE := determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-7a48718
 
 ############REMINDER############
 # When bumping third-party library versions, remember to bump versions in 

--- a/model_hub/Makefile
+++ b/model_hub/Makefile
@@ -5,7 +5,7 @@ SHORT_GIT_HASH := $(shell git rev-parse --short HEAD)
 ARTIFACTS_DIR := /tmp/artifacts
 
 # Model-hub library environments will be built on top of the default GPU and CPU images in master/pkg/model/defaults.go
-DEFAULT_GPU_IMAGE := determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0ca3d22
+DEFAULT_GPU_IMAGE := determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-e8af732
 
 ############REMINDER############
 # When bumping third-party library versions, remember to bump versions in 

--- a/schemas/test_cases/v0/experiment.yaml
+++ b/schemas/test_cases/v0/experiment.yaml
@@ -31,8 +31,8 @@
       environment_variables: {}
       force_pull_image: false
       image:
-        cpu: determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0ca3d22
-        gpu: determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0ca3d22
+        cpu: determinedai/environments:py-3.8-pytorch-1.9-lightning-1.3-tf-2.4-cpu-e8af732
+        gpu: determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-e8af732
       pod_spec: null
       ports:
         qwer: 1234

--- a/schemas/test_cases/v0/experiment.yaml
+++ b/schemas/test_cases/v0/experiment.yaml
@@ -31,8 +31,8 @@
       environment_variables: {}
       force_pull_image: false
       image:
-        cpu: determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-a173dcd
-        gpu: determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-a173dcd
+        cpu: determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-7a48718
+        gpu: determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-7a48718
       pod_spec: null
       ports:
         qwer: 1234

--- a/schemas/test_cases/v0/experiment.yaml
+++ b/schemas/test_cases/v0/experiment.yaml
@@ -31,8 +31,8 @@
       environment_variables: {}
       force_pull_image: false
       image:
-        cpu: determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-7a48718
-        gpu: determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-7a48718
+        cpu: determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0ca3d22
+        gpu: determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0ca3d22
       pod_spec: null
       ports:
         qwer: 1234

--- a/tools/scripts/bumpenvs.yaml
+++ b/tools/scripts/bumpenvs.yaml
@@ -1,6 +1,6 @@
 ap_northeast_1_agent_ami:
-  new: ami-0a4d9306d8342befd
-  old: ami-0a5666e5badd0077f
+  new: ami-0385dc3dcdc1ac287
+  old: ami-0a4d9306d8342befd
 ap_northeast_1_bastion_ami:
   new: ami-0827d8ed0295e3feb
   old: ami-09ff2b6ef00accc2e
@@ -8,8 +8,8 @@ ap_northeast_1_master_ami:
   new: ami-0827d8ed0295e3feb
   old: ami-09ff2b6ef00accc2e
 ap_northeast_2_agent_ami:
-  new: ami-0f7cdbccb4d8a4aac
-  old: ami-036d136ef074d733c
+  new: ami-090bacb4f1f0540dd
+  old: ami-0f7cdbccb4d8a4aac
 ap_northeast_2_bastion_ami:
   new: ami-00bbba67d13faed04
   old: ami-0b329fb1f17558744
@@ -17,8 +17,8 @@ ap_northeast_2_master_ami:
   new: ami-00bbba67d13faed04
   old: ami-0b329fb1f17558744
 ap_southeast_1_agent_ami:
-  new: ami-047236f26873c1795
-  old: ami-027eca300b800ddd4
+  new: ami-0b2c2ed32f574ae3b
+  old: ami-047236f26873c1795
 ap_southeast_1_bastion_ami:
   new: ami-0f6565c3d5328c913
   old: ami-048b4b1ddefe6759f
@@ -26,8 +26,8 @@ ap_southeast_1_master_ami:
   new: ami-0f6565c3d5328c913
   old: ami-048b4b1ddefe6759f
 ap_southeast_2_agent_ami:
-  new: ami-0014377c9081bfad6
-  old: ami-0fa75036939155792
+  new: ami-09174a303f24171ca
+  old: ami-0014377c9081bfad6
 ap_southeast_2_bastion_ami:
   new: ami-0a1002150df471b2b
   old: ami-052a251c7ca533c26
@@ -35,8 +35,8 @@ ap_southeast_2_master_ami:
   new: ami-0a1002150df471b2b
   old: ami-052a251c7ca533c26
 eu_central_1_agent_ami:
-  new: ami-04eea7b023e69d314
-  old: ami-007c306facb6bf4f4
+  new: ami-0fd3496afbcaf9e49
+  old: ami-04eea7b023e69d314
 eu_central_1_bastion_ami:
   new: ami-0bdbe51a2e8070ff2
   old: ami-0d3905203a039e3b0
@@ -44,8 +44,8 @@ eu_central_1_master_ami:
   new: ami-0bdbe51a2e8070ff2
   old: ami-0d3905203a039e3b0
 eu_west_1_agent_ami:
-  new: ami-086307142a8ca8d70
-  old: ami-03d9920ed19325433
+  new: ami-0139d1106b0258a70
+  old: ami-086307142a8ca8d70
 eu_west_1_bastion_ami:
   new: ami-03caf24deed650e2c
   old: ami-0b7fd7bc9c6fb1c78
@@ -53,8 +53,8 @@ eu_west_1_master_ami:
   new: ami-03caf24deed650e2c
   old: ami-0b7fd7bc9c6fb1c78
 eu_west_2_agent_ami:
-  new: ami-061988c5080fad3a6
-  old: ami-005b149621ce3dbe9
+  new: ami-0a687fcb2de71ca86
+  old: ami-061988c5080fad3a6
 eu_west_2_bastion_ami:
   new: ami-093d303510c432519
   old: ami-02ead6ecbd926d792
@@ -62,45 +62,55 @@ eu_west_2_master_ami:
   new: ami-093d303510c432519
   old: ami-02ead6ecbd926d792
 gcp_env:
-  new: det-environments-a173dcd
-  old: det-environments-2409e48
+  new: det-environments-7a48718
+  old: det-environments-a173dcd
 tf1_cpu_hashed:
-  new: determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-a173dcd
-  old: determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-2409e48
+  new: determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-7a48718
+  old: determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-a173dcd
 tf1_cpu_versioned:
-  new: determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-0.16.4
-  old: determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-0.16.2
+  new: determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-0.17.0
+  old: determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-0.16.4
 tf1_gpu_hashed:
-  new: determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-a173dcd
-  old: determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-2409e48
+  new: determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-7a48718
+  old: determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-a173dcd
 tf1_gpu_versioned:
-  new: determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-0.16.4
-  old: determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-0.16.2
+  new: determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-0.17.0
+  old: determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-0.16.4
+tf25_cpu_hashed:
+  new: determinedai/environments:py-3.7-pytorch-1.7-lightning-1.2-tf-2.5-cpu-7a48718
+tf25_cpu_versioned:
+  new: determinedai/environments:py-3.7-pytorch-1.7-lightning-1.2-tf-2.5-cpu-0.17.0
 tf25_gpu_hashed:
-  new: determinedai/environments:cuda-11.2-pytorch-1.7-lightning-1.2-tf-2.5-gpu-a173dcd
-  old: determinedai/environments:cuda-11.2-pytorch-1.7-lightning-1.2-tf-2.5-gpu-2409e48
+  new: determinedai/environments:cuda-11.2-pytorch-1.7-lightning-1.2-tf-2.5-gpu-7a48718
+  old: determinedai/environments:cuda-11.2-pytorch-1.7-lightning-1.2-tf-2.5-gpu-a173dcd
 tf25_gpu_versioned:
-  new: determinedai/environments:cuda-11.2-pytorch-1.7-lightning-1.2-tf-2.5-gpu-0.16.4
-  old: determinedai/environments:cuda-11.2-pytorch-1.7-lightning-1.2-tf-2.5-gpu-0.16.2
+  new: determinedai/environments:cuda-11.2-pytorch-1.7-lightning-1.2-tf-2.5-gpu-0.17.0
+  old: determinedai/environments:cuda-11.2-pytorch-1.7-lightning-1.2-tf-2.5-gpu-0.16.4
+tf26_cpu_hashed:
+  new: determinedai/environments:py-3.7-pytorch-1.7-lightning-1.2-tf-2.6-cpu-7a48718
+tf26_cpu_versioned:
+  new: determinedai/environments:py-3.7-pytorch-1.7-lightning-1.2-tf-2.6-cpu-0.17.0
 tf26_gpu_hashed:
-  new: determinedai/environments:cuda-11.2-pytorch-1.7-lightning-1.2-tf-2.6-gpu-a173dcd
+  new: determinedai/environments:cuda-11.2-pytorch-1.7-lightning-1.2-tf-2.6-gpu-7a48718
+  old: determinedai/environments:cuda-11.2-pytorch-1.7-lightning-1.2-tf-2.6-gpu-a173dcd
 tf26_gpu_versioned:
-  new: determinedai/environments:cuda-11.2-pytorch-1.7-lightning-1.2-tf-2.6-gpu-0.16.4
+  new: determinedai/environments:cuda-11.2-pytorch-1.7-lightning-1.2-tf-2.6-gpu-0.17.0
+  old: determinedai/environments:cuda-11.2-pytorch-1.7-lightning-1.2-tf-2.6-gpu-0.16.4
 tf2_cpu_hashed:
-  new: determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-a173dcd
-  old: determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-2409e48
+  new: determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-7a48718
+  old: determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-a173dcd
 tf2_cpu_versioned:
-  new: determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0.16.4
-  old: determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0.16.2
+  new: determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0.17.0
+  old: determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0.16.4
 tf2_gpu_hashed:
-  new: determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-a173dcd
-  old: determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-2409e48
+  new: determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-7a48718
+  old: determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-a173dcd
 tf2_gpu_versioned:
-  new: determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0.16.4
-  old: determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0.16.2
+  new: determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0.17.0
+  old: determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0.16.4
 us_east_1_agent_ami:
-  new: ami-0b94af65779bb341a
-  old: ami-0e07a509dbfbd738f
+  new: ami-00e877e7d94b191aa
+  old: ami-0b94af65779bb341a
 us_east_1_bastion_ami:
   new: ami-0dd76f917833aac4b
   old: ami-04cc2b0ad9e30a9c8
@@ -108,8 +118,8 @@ us_east_1_master_ami:
   new: ami-0dd76f917833aac4b
   old: ami-04cc2b0ad9e30a9c8
 us_east_2_agent_ami:
-  new: ami-0c7095d79f2379886
-  old: ami-0f0683c726e626465
+  new: ami-069a72699aafc6f10
+  old: ami-0c7095d79f2379886
 us_east_2_bastion_ami:
   new: ami-0b29b6e62f2343b46
   old: ami-02fc6052104add5ae
@@ -117,20 +127,20 @@ us_east_2_master_ami:
   new: ami-0b29b6e62f2343b46
   old: ami-02fc6052104add5ae
 us_gov_east_1_agent_ami:
-  new: ami-036db831230da5b8d
-  old: ami-0524cce6632188c57
+  new: ami-03327733645599fef
+  old: ami-036db831230da5b8d
 us_gov_east_1_master_ami:
   new: ami-0ce79d6fa9e9a242e
   old: ami-af9379de
 us_gov_west_1_agent_ami:
-  new: ami-01ef73e651b19c33b
-  old: ami-092a6c287497ed9df
+  new: ami-0afc880beeed6e97f
+  old: ami-01ef73e651b19c33b
 us_gov_west_1_master_ami:
   new: ami-04a2f96ef9b12b2b1
   old: ami-84556de5
 us_west_2_agent_ami:
-  new: ami-0cbe0eb4ce6b8a7f3
-  old: ami-00118c4b9f4d3c23d
+  new: ami-0e321f94fec3fabb9
+  old: ami-0cbe0eb4ce6b8a7f3
 us_west_2_bastion_ami:
   new: ami-01773ce53581acf22
   old: ami-0a62a78cfedc09d76

--- a/tools/scripts/bumpenvs.yaml
+++ b/tools/scripts/bumpenvs.yaml
@@ -1,6 +1,6 @@
 ap_northeast_1_agent_ami:
-  new: ami-0a506b88f4e1268a0
-  old: ami-0385dc3dcdc1ac287
+  new: ami-078d9406b4fde0567
+  old: ami-0a506b88f4e1268a0
 ap_northeast_1_bastion_ami:
   new: ami-0827d8ed0295e3feb
   old: ami-09ff2b6ef00accc2e
@@ -8,8 +8,8 @@ ap_northeast_1_master_ami:
   new: ami-0827d8ed0295e3feb
   old: ami-09ff2b6ef00accc2e
 ap_northeast_2_agent_ami:
-  new: ami-05d4c07cb56ed3777
-  old: ami-090bacb4f1f0540dd
+  new: ami-0fc41a015bd08f558
+  old: ami-05d4c07cb56ed3777
 ap_northeast_2_bastion_ami:
   new: ami-00bbba67d13faed04
   old: ami-0b329fb1f17558744
@@ -17,8 +17,8 @@ ap_northeast_2_master_ami:
   new: ami-00bbba67d13faed04
   old: ami-0b329fb1f17558744
 ap_southeast_1_agent_ami:
-  new: ami-0b39e143721568921
-  old: ami-0b2c2ed32f574ae3b
+  new: ami-0abf18a93839d896a
+  old: ami-0b39e143721568921
 ap_southeast_1_bastion_ami:
   new: ami-0f6565c3d5328c913
   old: ami-048b4b1ddefe6759f
@@ -26,8 +26,8 @@ ap_southeast_1_master_ami:
   new: ami-0f6565c3d5328c913
   old: ami-048b4b1ddefe6759f
 ap_southeast_2_agent_ami:
-  new: ami-0885426f5ce6aada4
-  old: ami-09174a303f24171ca
+  new: ami-0b49f4913ed2aeaa3
+  old: ami-0885426f5ce6aada4
 ap_southeast_2_bastion_ami:
   new: ami-0a1002150df471b2b
   old: ami-052a251c7ca533c26
@@ -35,8 +35,8 @@ ap_southeast_2_master_ami:
   new: ami-0a1002150df471b2b
   old: ami-052a251c7ca533c26
 eu_central_1_agent_ami:
-  new: ami-0d4478a40cb8bb10e
-  old: ami-0fd3496afbcaf9e49
+  new: ami-09dfe0e75110703c8
+  old: ami-0d4478a40cb8bb10e
 eu_central_1_bastion_ami:
   new: ami-0bdbe51a2e8070ff2
   old: ami-0d3905203a039e3b0
@@ -44,8 +44,8 @@ eu_central_1_master_ami:
   new: ami-0bdbe51a2e8070ff2
   old: ami-0d3905203a039e3b0
 eu_west_1_agent_ami:
-  new: ami-0a15ab370f2846c16
-  old: ami-0139d1106b0258a70
+  new: ami-0b5e7b7b24bfc0afc
+  old: ami-0a15ab370f2846c16
 eu_west_1_bastion_ami:
   new: ami-03caf24deed650e2c
   old: ami-0b7fd7bc9c6fb1c78
@@ -53,8 +53,8 @@ eu_west_1_master_ami:
   new: ami-03caf24deed650e2c
   old: ami-0b7fd7bc9c6fb1c78
 eu_west_2_agent_ami:
-  new: ami-0f25f5f71d2b50df3
-  old: ami-0a687fcb2de71ca86
+  new: ami-0f7eefeb4ae74b526
+  old: ami-0f25f5f71d2b50df3
 eu_west_2_bastion_ami:
   new: ami-093d303510c432519
   old: ami-02ead6ecbd926d792
@@ -62,59 +62,59 @@ eu_west_2_master_ami:
   new: ami-093d303510c432519
   old: ami-02ead6ecbd926d792
 gcp_env:
-  new: det-environments-0ca3d22
-  old: det-environments-7a48718
+  new: det-environments-e8af732
+  old: det-environments-0ca3d22
 tf1_cpu_hashed:
-  new: determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-0ca3d22
-  old: determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-7a48718
+  new: determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-e8af732
+  old: determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-0ca3d22
 tf1_cpu_versioned:
   new: determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-0.17.0
   old: determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-0.16.4
 tf1_gpu_hashed:
-  new: determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-0ca3d22
-  old: determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-7a48718
+  new: determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-e8af732
+  old: determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-0ca3d22
 tf1_gpu_versioned:
   new: determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-0.17.0
   old: determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-0.16.4
 tf25_cpu_hashed:
-  new: determinedai/environments:py-3.7-tf-2.5-cpu-0ca3d22
-  old: determinedai/environments:py-3.7-pytorch-1.7-lightning-1.2-tf-2.5-cpu-7a48718
+  new: determinedai/environments:py-3.8-tf-2.5-cpu-e8af732
+  old: determinedai/environments:py-3.7-tf-2.5-cpu-0ca3d22
 tf25_cpu_versioned:
-  new: determinedai/environments:py-3.7-tf-2.5-cpu-0.17.0
-  old: determinedai/environments:py-3.7-pytorch-1.7-lightning-1.2-tf-2.5-cpu-0.17.0
+  new: determinedai/environments:py-3.8-tf-2.5-cpu-0.17.0
+  old: determinedai/environments:py-3.7-tf-2.5-cpu-0.17.0
 tf25_gpu_hashed:
-  new: determinedai/environments:cuda-11.2-tf-2.5-gpu-0ca3d22
-  old: determinedai/environments:cuda-11.2-pytorch-1.7-lightning-1.2-tf-2.5-gpu-7a48718
+  new: determinedai/environments:cuda-11.2-tf-2.5-gpu-e8af732
+  old: determinedai/environments:cuda-11.2-tf-2.5-gpu-0ca3d22
 tf25_gpu_versioned:
   new: determinedai/environments:cuda-11.2-tf-2.5-gpu-0.17.0
   old: determinedai/environments:cuda-11.2-pytorch-1.7-lightning-1.2-tf-2.5-gpu-0.17.0
 tf26_cpu_hashed:
-  new: determinedai/environments:py-3.7-tf-2.6-cpu-0ca3d22
-  old: determinedai/environments:py-3.7-pytorch-1.7-lightning-1.2-tf-2.6-cpu-7a48718
+  new: determinedai/environments:py-3.8-tf-2.6-cpu-e8af732
+  old: determinedai/environments:py-3.7-tf-2.6-cpu-0ca3d22
 tf26_cpu_versioned:
-  new: determinedai/environments:py-3.7-tf-2.6-cpu-0.17.0
-  old: determinedai/environments:py-3.7-pytorch-1.7-lightning-1.2-tf-2.6-cpu-0.17.0
+  new: determinedai/environments:py-3.8-tf-2.6-cpu-0.17.0
+  old: determinedai/environments:py-3.7-tf-2.6-cpu-0.17.0
 tf26_gpu_hashed:
-  new: determinedai/environments:cuda-11.2-tf-2.6-gpu-0ca3d22
-  old: determinedai/environments:cuda-11.2-pytorch-1.7-lightning-1.2-tf-2.6-gpu-7a48718
+  new: determinedai/environments:cuda-11.2-tf-2.6-gpu-e8af732
+  old: determinedai/environments:cuda-11.2-tf-2.6-gpu-0ca3d22
 tf26_gpu_versioned:
   new: determinedai/environments:cuda-11.2-tf-2.6-gpu-0.17.0
   old: determinedai/environments:cuda-11.2-pytorch-1.7-lightning-1.2-tf-2.6-gpu-0.17.0
 tf2_cpu_hashed:
-  new: determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0ca3d22
-  old: determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-7a48718
+  new: determinedai/environments:py-3.8-pytorch-1.9-lightning-1.3-tf-2.4-cpu-e8af732
+  old: determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0ca3d22
 tf2_cpu_versioned:
-  new: determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0.17.0
-  old: determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0.16.4
+  new: determinedai/environments:py-3.8-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0.17.0
+  old: determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0.17.0
 tf2_gpu_hashed:
-  new: determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0ca3d22
-  old: determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-7a48718
+  new: determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-e8af732
+  old: determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0ca3d22
 tf2_gpu_versioned:
   new: determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0.17.0
   old: determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0.16.4
 us_east_1_agent_ami:
-  new: ami-0bdd6f68db44422a4
-  old: ami-00e877e7d94b191aa
+  new: ami-08b34534a48df44cd
+  old: ami-0bdd6f68db44422a4
 us_east_1_bastion_ami:
   new: ami-0dd76f917833aac4b
   old: ami-04cc2b0ad9e30a9c8
@@ -122,8 +122,8 @@ us_east_1_master_ami:
   new: ami-0dd76f917833aac4b
   old: ami-04cc2b0ad9e30a9c8
 us_east_2_agent_ami:
-  new: ami-09ec9c251aca453c0
-  old: ami-069a72699aafc6f10
+  new: ami-0f35ee97c172a6131
+  old: ami-09ec9c251aca453c0
 us_east_2_bastion_ami:
   new: ami-0b29b6e62f2343b46
   old: ami-02fc6052104add5ae
@@ -131,20 +131,20 @@ us_east_2_master_ami:
   new: ami-0b29b6e62f2343b46
   old: ami-02fc6052104add5ae
 us_gov_east_1_agent_ami:
-  new: ami-0e23c9332f34ab7d4
-  old: ami-03327733645599fef
+  new: ami-0229a1a96fb0ee333
+  old: ami-0e23c9332f34ab7d4
 us_gov_east_1_master_ami:
   new: ami-0ce79d6fa9e9a242e
   old: ami-af9379de
 us_gov_west_1_agent_ami:
-  new: ami-0355ed885e374d374
-  old: ami-0afc880beeed6e97f
+  new: ami-035ce6a54c02187a5
+  old: ami-0355ed885e374d374
 us_gov_west_1_master_ami:
   new: ami-04a2f96ef9b12b2b1
   old: ami-84556de5
 us_west_2_agent_ami:
-  new: ami-0f7c8ce0ef2b5a220
-  old: ami-0e321f94fec3fabb9
+  new: ami-0a00e428be59ef0ce
+  old: ami-0f7c8ce0ef2b5a220
 us_west_2_bastion_ami:
   new: ami-01773ce53581acf22
   old: ami-0a62a78cfedc09d76

--- a/tools/scripts/bumpenvs.yaml
+++ b/tools/scripts/bumpenvs.yaml
@@ -1,6 +1,6 @@
 ap_northeast_1_agent_ami:
-  new: ami-0385dc3dcdc1ac287
-  old: ami-0a4d9306d8342befd
+  new: ami-0a506b88f4e1268a0
+  old: ami-0385dc3dcdc1ac287
 ap_northeast_1_bastion_ami:
   new: ami-0827d8ed0295e3feb
   old: ami-09ff2b6ef00accc2e
@@ -8,8 +8,8 @@ ap_northeast_1_master_ami:
   new: ami-0827d8ed0295e3feb
   old: ami-09ff2b6ef00accc2e
 ap_northeast_2_agent_ami:
-  new: ami-090bacb4f1f0540dd
-  old: ami-0f7cdbccb4d8a4aac
+  new: ami-05d4c07cb56ed3777
+  old: ami-090bacb4f1f0540dd
 ap_northeast_2_bastion_ami:
   new: ami-00bbba67d13faed04
   old: ami-0b329fb1f17558744
@@ -17,8 +17,8 @@ ap_northeast_2_master_ami:
   new: ami-00bbba67d13faed04
   old: ami-0b329fb1f17558744
 ap_southeast_1_agent_ami:
-  new: ami-0b2c2ed32f574ae3b
-  old: ami-047236f26873c1795
+  new: ami-0b39e143721568921
+  old: ami-0b2c2ed32f574ae3b
 ap_southeast_1_bastion_ami:
   new: ami-0f6565c3d5328c913
   old: ami-048b4b1ddefe6759f
@@ -26,8 +26,8 @@ ap_southeast_1_master_ami:
   new: ami-0f6565c3d5328c913
   old: ami-048b4b1ddefe6759f
 ap_southeast_2_agent_ami:
-  new: ami-09174a303f24171ca
-  old: ami-0014377c9081bfad6
+  new: ami-0885426f5ce6aada4
+  old: ami-09174a303f24171ca
 ap_southeast_2_bastion_ami:
   new: ami-0a1002150df471b2b
   old: ami-052a251c7ca533c26
@@ -35,8 +35,8 @@ ap_southeast_2_master_ami:
   new: ami-0a1002150df471b2b
   old: ami-052a251c7ca533c26
 eu_central_1_agent_ami:
-  new: ami-0fd3496afbcaf9e49
-  old: ami-04eea7b023e69d314
+  new: ami-0d4478a40cb8bb10e
+  old: ami-0fd3496afbcaf9e49
 eu_central_1_bastion_ami:
   new: ami-0bdbe51a2e8070ff2
   old: ami-0d3905203a039e3b0
@@ -44,8 +44,8 @@ eu_central_1_master_ami:
   new: ami-0bdbe51a2e8070ff2
   old: ami-0d3905203a039e3b0
 eu_west_1_agent_ami:
-  new: ami-0139d1106b0258a70
-  old: ami-086307142a8ca8d70
+  new: ami-0a15ab370f2846c16
+  old: ami-0139d1106b0258a70
 eu_west_1_bastion_ami:
   new: ami-03caf24deed650e2c
   old: ami-0b7fd7bc9c6fb1c78
@@ -53,8 +53,8 @@ eu_west_1_master_ami:
   new: ami-03caf24deed650e2c
   old: ami-0b7fd7bc9c6fb1c78
 eu_west_2_agent_ami:
-  new: ami-0a687fcb2de71ca86
-  old: ami-061988c5080fad3a6
+  new: ami-0f25f5f71d2b50df3
+  old: ami-0a687fcb2de71ca86
 eu_west_2_bastion_ami:
   new: ami-093d303510c432519
   old: ami-02ead6ecbd926d792
@@ -62,55 +62,59 @@ eu_west_2_master_ami:
   new: ami-093d303510c432519
   old: ami-02ead6ecbd926d792
 gcp_env:
-  new: det-environments-7a48718
-  old: det-environments-a173dcd
+  new: det-environments-0ca3d22
+  old: det-environments-7a48718
 tf1_cpu_hashed:
-  new: determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-7a48718
-  old: determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-a173dcd
+  new: determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-0ca3d22
+  old: determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-7a48718
 tf1_cpu_versioned:
   new: determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-0.17.0
   old: determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-0.16.4
 tf1_gpu_hashed:
-  new: determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-7a48718
-  old: determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-a173dcd
+  new: determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-0ca3d22
+  old: determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-7a48718
 tf1_gpu_versioned:
   new: determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-0.17.0
   old: determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-0.16.4
 tf25_cpu_hashed:
-  new: determinedai/environments:py-3.7-pytorch-1.7-lightning-1.2-tf-2.5-cpu-7a48718
+  new: determinedai/environments:py-3.7-tf-2.5-cpu-0ca3d22
+  old: determinedai/environments:py-3.7-pytorch-1.7-lightning-1.2-tf-2.5-cpu-7a48718
 tf25_cpu_versioned:
-  new: determinedai/environments:py-3.7-pytorch-1.7-lightning-1.2-tf-2.5-cpu-0.17.0
+  new: determinedai/environments:py-3.7-tf-2.5-cpu-0.17.0
+  old: determinedai/environments:py-3.7-pytorch-1.7-lightning-1.2-tf-2.5-cpu-0.17.0
 tf25_gpu_hashed:
-  new: determinedai/environments:cuda-11.2-pytorch-1.7-lightning-1.2-tf-2.5-gpu-7a48718
-  old: determinedai/environments:cuda-11.2-pytorch-1.7-lightning-1.2-tf-2.5-gpu-a173dcd
+  new: determinedai/environments:cuda-11.2-tf-2.5-gpu-0ca3d22
+  old: determinedai/environments:cuda-11.2-pytorch-1.7-lightning-1.2-tf-2.5-gpu-7a48718
 tf25_gpu_versioned:
-  new: determinedai/environments:cuda-11.2-pytorch-1.7-lightning-1.2-tf-2.5-gpu-0.17.0
-  old: determinedai/environments:cuda-11.2-pytorch-1.7-lightning-1.2-tf-2.5-gpu-0.16.4
+  new: determinedai/environments:cuda-11.2-tf-2.5-gpu-0.17.0
+  old: determinedai/environments:cuda-11.2-pytorch-1.7-lightning-1.2-tf-2.5-gpu-0.17.0
 tf26_cpu_hashed:
-  new: determinedai/environments:py-3.7-pytorch-1.7-lightning-1.2-tf-2.6-cpu-7a48718
+  new: determinedai/environments:py-3.7-tf-2.6-cpu-0ca3d22
+  old: determinedai/environments:py-3.7-pytorch-1.7-lightning-1.2-tf-2.6-cpu-7a48718
 tf26_cpu_versioned:
-  new: determinedai/environments:py-3.7-pytorch-1.7-lightning-1.2-tf-2.6-cpu-0.17.0
+  new: determinedai/environments:py-3.7-tf-2.6-cpu-0.17.0
+  old: determinedai/environments:py-3.7-pytorch-1.7-lightning-1.2-tf-2.6-cpu-0.17.0
 tf26_gpu_hashed:
-  new: determinedai/environments:cuda-11.2-pytorch-1.7-lightning-1.2-tf-2.6-gpu-7a48718
-  old: determinedai/environments:cuda-11.2-pytorch-1.7-lightning-1.2-tf-2.6-gpu-a173dcd
+  new: determinedai/environments:cuda-11.2-tf-2.6-gpu-0ca3d22
+  old: determinedai/environments:cuda-11.2-pytorch-1.7-lightning-1.2-tf-2.6-gpu-7a48718
 tf26_gpu_versioned:
-  new: determinedai/environments:cuda-11.2-pytorch-1.7-lightning-1.2-tf-2.6-gpu-0.17.0
-  old: determinedai/environments:cuda-11.2-pytorch-1.7-lightning-1.2-tf-2.6-gpu-0.16.4
+  new: determinedai/environments:cuda-11.2-tf-2.6-gpu-0.17.0
+  old: determinedai/environments:cuda-11.2-pytorch-1.7-lightning-1.2-tf-2.6-gpu-0.17.0
 tf2_cpu_hashed:
-  new: determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-7a48718
-  old: determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-a173dcd
+  new: determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0ca3d22
+  old: determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-7a48718
 tf2_cpu_versioned:
   new: determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0.17.0
   old: determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0.16.4
 tf2_gpu_hashed:
-  new: determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-7a48718
-  old: determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-a173dcd
+  new: determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0ca3d22
+  old: determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-7a48718
 tf2_gpu_versioned:
   new: determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0.17.0
   old: determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0.16.4
 us_east_1_agent_ami:
-  new: ami-00e877e7d94b191aa
-  old: ami-0b94af65779bb341a
+  new: ami-0bdd6f68db44422a4
+  old: ami-00e877e7d94b191aa
 us_east_1_bastion_ami:
   new: ami-0dd76f917833aac4b
   old: ami-04cc2b0ad9e30a9c8
@@ -118,8 +122,8 @@ us_east_1_master_ami:
   new: ami-0dd76f917833aac4b
   old: ami-04cc2b0ad9e30a9c8
 us_east_2_agent_ami:
-  new: ami-069a72699aafc6f10
-  old: ami-0c7095d79f2379886
+  new: ami-09ec9c251aca453c0
+  old: ami-069a72699aafc6f10
 us_east_2_bastion_ami:
   new: ami-0b29b6e62f2343b46
   old: ami-02fc6052104add5ae
@@ -127,20 +131,20 @@ us_east_2_master_ami:
   new: ami-0b29b6e62f2343b46
   old: ami-02fc6052104add5ae
 us_gov_east_1_agent_ami:
-  new: ami-03327733645599fef
-  old: ami-036db831230da5b8d
+  new: ami-0e23c9332f34ab7d4
+  old: ami-03327733645599fef
 us_gov_east_1_master_ami:
   new: ami-0ce79d6fa9e9a242e
   old: ami-af9379de
 us_gov_west_1_agent_ami:
-  new: ami-0afc880beeed6e97f
-  old: ami-01ef73e651b19c33b
+  new: ami-0355ed885e374d374
+  old: ami-0afc880beeed6e97f
 us_gov_west_1_master_ami:
   new: ami-04a2f96ef9b12b2b1
   old: ami-84556de5
 us_west_2_agent_ami:
-  new: ami-0e321f94fec3fabb9
-  old: ami-0cbe0eb4ce6b8a7f3
+  new: ami-0f7c8ce0ef2b5a220
+  old: ami-0e321f94fec3fabb9
 us_west_2_bastion_ami:
   new: ami-01773ce53581acf22
   old: ami-0a62a78cfedc09d76

--- a/tools/scripts/update-bumpenvs-yaml.py
+++ b/tools/scripts/update-bumpenvs-yaml.py
@@ -124,7 +124,6 @@ def parse_packer_log(packer_log: str) -> Dict[str, str]:
     """Parse the output of packer's -machine-readable format, strange though it may be."""
     out = {}
 
-    print(packer_log)
     lines = packer_log.strip().split("\n")
     fields = [line.split(",") for line in lines]
     # We only care about artifact lines with exactly six fields.

--- a/tools/scripts/update-bumpenvs-yaml.py
+++ b/tools/scripts/update-bumpenvs-yaml.py
@@ -46,7 +46,7 @@ JOB_SUFFIXES = [
 
 EXPECT_JOBS = {
     "publish-cloud-images",
-    *[f"build-and-publish-docker-{suffix}" for suffix in JOB_SUFFIXES],
+    *(f"build-and-publish-docker-{suffix}" for suffix in JOB_SUFFIXES),
 }
 
 PACKER_ARTIFACTS = {
@@ -205,10 +205,12 @@ if __name__ == "__main__":
     artifacts = get_all_artifacts(builds)
 
     tag_list = [
-        parse_packer_log(artifacts[artifact]) for artifact in PACKER_ARTIFACTS
-    ] + [yaml.safe_load(artifacts[artifact]) for artifact in DOCKER_ARTIFACTS]
+        *(parse_packer_log(artifacts[artifact]) for artifact in PACKER_ARTIFACTS),
+        *(yaml.safe_load(artifacts[artifact]) for artifact in DOCKER_ARTIFACTS),
+    ]
 
-    new_tags = {k: d[k] for d in tag_list for k in d}
+    # Flatten tag_list dicts into one dict.
+    new_tags = {k: v for d in tag_list for (k, v) in d.items()}
 
     saw_change = False
     for image_type, new_tag in new_tags.items():

--- a/tools/scripts/update-bumpenvs-yaml.py
+++ b/tools/scripts/update-bumpenvs-yaml.py
@@ -33,25 +33,29 @@ USER = "determined-ai"
 PROJECT = "environments"
 BASE_URL = f"https://circleci.com/api/v1.1/project/github/{USER}/{PROJECT}"
 
+JOB_SUFFIXES = [
+    "tf1-cpu",
+    "tf2-cpu",
+    "tf25-cpu",
+    "tf26-cpu",
+    "tf1-gpu",
+    "tf2-gpu",
+    "tf25-gpu",
+    "tf26-gpu",
+]
+
 EXPECT_JOBS = {
     "publish-cloud-images",
-    "build-and-publish-docker-tf1-cpu",
-    "build-and-publish-docker-tf2-cpu",
-    "build-and-publish-docker-tf1-gpu",
-    "build-and-publish-docker-tf2-gpu",
-    "build-and-publish-docker-tf25-gpu",
-    "build-and-publish-docker-tf26-gpu",
+    *[f"build-and-publish-docker-{suffix}" for suffix in JOB_SUFFIXES],
 }
 
-EXPECT_ARTIFACTS = {
+PACKER_ARTIFACTS = {
     "packer-log",
-    "publish-tf1-cpu",
-    "publish-tf2-cpu",
-    "publish-tf1-gpu",
-    "publish-tf2-gpu",
-    "publish-tf25-gpu",
-    "publish-tf26-gpu",
 }
+
+DOCKER_ARTIFACTS = {f"publish-{suffix}" for suffix in JOB_SUFFIXES}
+
+EXPECT_ARTIFACTS = PACKER_ARTIFACTS | DOCKER_ARTIFACTS
 
 
 class Build:
@@ -120,6 +124,7 @@ def parse_packer_log(packer_log: str) -> Dict[str, str]:
     """Parse the output of packer's -machine-readable format, strange though it may be."""
     out = {}
 
+    print(packer_log)
     lines = packer_log.strip().split("\n")
     fields = [line.split(",") for line in lines]
     # We only care about artifact lines with exactly six fields.
@@ -200,15 +205,11 @@ if __name__ == "__main__":
     builds = get_all_builds(commit)
     artifacts = get_all_artifacts(builds)
 
-    new_tags = {
-        **yaml.safe_load(artifacts["publish-tf1-cpu"]),
-        **yaml.safe_load(artifacts["publish-tf2-cpu"]),
-        **yaml.safe_load(artifacts["publish-tf1-gpu"]),
-        **yaml.safe_load(artifacts["publish-tf2-gpu"]),
-        **yaml.safe_load(artifacts["publish-tf25-gpu"]),
-        **yaml.safe_load(artifacts["publish-tf26-gpu"]),
-        **parse_packer_log(artifacts["packer-log"]),
-    }
+    tag_list = [
+        parse_packer_log(artifacts[artifact]) for artifact in PACKER_ARTIFACTS
+    ] + [yaml.safe_load(artifacts[artifact]) for artifact in DOCKER_ARTIFACTS]
+
+    new_tags = {k: d[k] for d in tag_list for k in d}
 
     saw_change = False
     for image_type, new_tag in new_tags.items():

--- a/webui/react/src/fixtures/responses/experiment-details/non-scalar-metrics-4078.json
+++ b/webui/react/src/fixtures/responses/experiment-details/non-scalar-metrics-4078.json
@@ -32,8 +32,8 @@
     "name": "Fork of Fork of mnist_tp_to_estimator_const",
     "environment": {
       "image": {
-        "cpu": "determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0ca3d22",
-        "gpu": "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0ca3d22"
+        "cpu": "determinedai/environments:py-3.8-pytorch-1.9-lightning-1.3-tf-2.4-cpu-e8af732",
+        "gpu": "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-e8af732"
       },
       "ports": null,
       "pod_spec": null,

--- a/webui/react/src/fixtures/responses/experiment-details/non-scalar-metrics-4078.json
+++ b/webui/react/src/fixtures/responses/experiment-details/non-scalar-metrics-4078.json
@@ -32,8 +32,8 @@
     "name": "Fork of Fork of mnist_tp_to_estimator_const",
     "environment": {
       "image": {
-        "cpu": "determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-7a48718",
-        "gpu": "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-7a48718"
+        "cpu": "determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0ca3d22",
+        "gpu": "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0ca3d22"
       },
       "ports": null,
       "pod_spec": null,

--- a/webui/react/src/fixtures/responses/experiment-details/non-scalar-metrics-4078.json
+++ b/webui/react/src/fixtures/responses/experiment-details/non-scalar-metrics-4078.json
@@ -32,8 +32,8 @@
     "name": "Fork of Fork of mnist_tp_to_estimator_const",
     "environment": {
       "image": {
-        "cpu": "determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-a173dcd",
-        "gpu": "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-a173dcd"
+        "cpu": "determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-7a48718",
+        "gpu": "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-7a48718"
       },
       "ports": null,
       "pod_spec": null,

--- a/webui/react/src/fixtures/responses/experiment-details/set-a.json
+++ b/webui/react/src/fixtures/responses/experiment-details/set-a.json
@@ -694,8 +694,8 @@
         "environment_variables": {},
         "force_pull_image": false,
         "image": {
-          "cpu": "determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-7a48718",
-          "gpu": "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-7a48718"
+          "cpu": "determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0ca3d22",
+          "gpu": "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0ca3d22"
         },
         "pod_spec": null,
         "ports": null
@@ -838,8 +838,8 @@
         "environment_variables": {},
         "force_pull_image": false,
         "image": {
-          "cpu": "determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-7a48718",
-          "gpu": "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-7a48718"
+          "cpu": "determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0ca3d22",
+          "gpu": "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0ca3d22"
         },
         "pod_spec": {
           "metadata": {
@@ -2596,8 +2596,8 @@
       "name": "noop_adaptive",
       "environment": {
         "image": {
-          "cpu": "determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-7a48718",
-          "gpu": "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-7a48718"
+          "cpu": "determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0ca3d22",
+          "gpu": "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0ca3d22"
         },
         "ports": null,
         "pod_spec": null,

--- a/webui/react/src/fixtures/responses/experiment-details/set-a.json
+++ b/webui/react/src/fixtures/responses/experiment-details/set-a.json
@@ -694,8 +694,8 @@
         "environment_variables": {},
         "force_pull_image": false,
         "image": {
-          "cpu": "determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0ca3d22",
-          "gpu": "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0ca3d22"
+          "cpu": "determinedai/environments:py-3.8-pytorch-1.9-lightning-1.3-tf-2.4-cpu-e8af732",
+          "gpu": "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-e8af732"
         },
         "pod_spec": null,
         "ports": null
@@ -838,8 +838,8 @@
         "environment_variables": {},
         "force_pull_image": false,
         "image": {
-          "cpu": "determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0ca3d22",
-          "gpu": "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0ca3d22"
+          "cpu": "determinedai/environments:py-3.8-pytorch-1.9-lightning-1.3-tf-2.4-cpu-e8af732",
+          "gpu": "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-e8af732"
         },
         "pod_spec": {
           "metadata": {
@@ -2596,8 +2596,8 @@
       "name": "noop_adaptive",
       "environment": {
         "image": {
-          "cpu": "determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0ca3d22",
-          "gpu": "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0ca3d22"
+          "cpu": "determinedai/environments:py-3.8-pytorch-1.9-lightning-1.3-tf-2.4-cpu-e8af732",
+          "gpu": "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-e8af732"
         },
         "ports": null,
         "pod_spec": null,

--- a/webui/react/src/fixtures/responses/experiment-details/set-a.json
+++ b/webui/react/src/fixtures/responses/experiment-details/set-a.json
@@ -694,8 +694,8 @@
         "environment_variables": {},
         "force_pull_image": false,
         "image": {
-          "cpu": "determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-a173dcd",
-          "gpu": "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-a173dcd"
+          "cpu": "determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-7a48718",
+          "gpu": "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-7a48718"
         },
         "pod_spec": null,
         "ports": null
@@ -838,8 +838,8 @@
         "environment_variables": {},
         "force_pull_image": false,
         "image": {
-          "cpu": "determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-a173dcd",
-          "gpu": "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-a173dcd"
+          "cpu": "determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-7a48718",
+          "gpu": "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-7a48718"
         },
         "pod_spec": {
           "metadata": {
@@ -2596,8 +2596,8 @@
       "name": "noop_adaptive",
       "environment": {
         "image": {
-          "cpu": "determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-a173dcd",
-          "gpu": "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-a173dcd"
+          "cpu": "determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-7a48718",
+          "gpu": "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-7a48718"
         },
         "ports": null,
         "pod_spec": null,

--- a/webui/react/src/fixtures/responses/trial-details/old-trial-config-noop-adaptive.json
+++ b/webui/react/src/fixtures/responses/trial-details/old-trial-config-noop-adaptive.json
@@ -30,8 +30,8 @@
   "name": "noop_adaptive",
   "environment": {
     "image": {
-      "cpu": "determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-7a48718",
-      "gpu": "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-7a48718"
+      "cpu": "determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0ca3d22",
+      "gpu": "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0ca3d22"
     },
     "ports": null,
     "force_pull_image": false,

--- a/webui/react/src/fixtures/responses/trial-details/old-trial-config-noop-adaptive.json
+++ b/webui/react/src/fixtures/responses/trial-details/old-trial-config-noop-adaptive.json
@@ -30,8 +30,8 @@
   "name": "noop_adaptive",
   "environment": {
     "image": {
-      "cpu": "determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-a173dcd",
-      "gpu": "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-a173dcd"
+      "cpu": "determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-7a48718",
+      "gpu": "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-7a48718"
     },
     "ports": null,
     "force_pull_image": false,

--- a/webui/react/src/fixtures/responses/trial-details/old-trial-config-noop-adaptive.json
+++ b/webui/react/src/fixtures/responses/trial-details/old-trial-config-noop-adaptive.json
@@ -30,8 +30,8 @@
   "name": "noop_adaptive",
   "environment": {
     "image": {
-      "cpu": "determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0ca3d22",
-      "gpu": "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0ca3d22"
+      "cpu": "determinedai/environments:py-3.8-pytorch-1.9-lightning-1.3-tf-2.4-cpu-e8af732",
+      "gpu": "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-e8af732"
     },
     "ports": null,
     "force_pull_image": false,


### PR DESCRIPTION
## Description

- Add CPU-only images for TF 2.5 and TF 2.6 as these were frequently asked for by Community users.
- Security upgrades.
- Rework `update-bumpenvs-yaml` to make it easier to add new images.

## Test Plan

- Run some tensorflow experiments on the new images.

## Commentary (optional)

## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.