### PR TITLE
chore: recover agent websocket flakes [DET-5935]

### DIFF
--- a/agent/go.mod
+++ b/agent/go.mod
@@ -18,7 +18,6 @@ require (
 	github.com/goreleaser/goreleaser v0.140.0
 	github.com/gorilla/mux v1.8.0 // indirect
 	github.com/gorilla/websocket v1.4.2
-	github.com/hashicorp/go-multierror v1.1.1
 	github.com/labstack/echo/v4 v4.3.0
 	github.com/pkg/errors v0.9.1
 	github.com/shirou/gopsutil v2.19.9+incompatible

--- a/agent/go.mod
+++ b/agent/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/goreleaser/goreleaser v0.140.0
 	github.com/gorilla/mux v1.8.0 // indirect
 	github.com/gorilla/websocket v1.4.2
+	github.com/hashicorp/go-multierror v1.1.1
 	github.com/labstack/echo/v4 v4.3.0
 	github.com/pkg/errors v0.9.1
 	github.com/shirou/gopsutil v2.19.9+incompatible

--- a/agent/internal/agent.go
+++ b/agent/internal/agent.go
@@ -325,8 +325,8 @@ func (a *agent) makeMasterWebsocket(ctx *actor.Context) error {
 		}
 
 		b, rErr := ioutil.ReadAll(resp.Body)
-		if rErr == nil && strings.Contains(string(b), proto.AgentMustReconnect.Error()) {
-			return proto.AgentMustReconnect
+		if rErr == nil && strings.Contains(string(b), proto.ErrAgentMustReconnect.Error()) {
+			return proto.ErrAgentMustReconnect
 		}
 
 		return errors.Wrapf(err, "error dialing master: %s", b)
@@ -348,7 +348,7 @@ func (a *agent) attemptReconnect(ctx *actor.Context) bool {
 		switch err := a.connect(ctx); {
 		case err == nil:
 			return true
-		case errors.Is(err, proto.AgentMustReconnect):
+		case errors.Is(err, proto.ErrAgentMustReconnect):
 			return false
 		default:
 			ctx.Log().WithError(err).Error("error to reconnecting to master")

--- a/master/internal/agent/agent.go
+++ b/master/internal/agent/agent.go
@@ -56,7 +56,7 @@ type (
 		reconnectBacklog  []interface{}
 		// On disconnect, we stash the state here and become "draining + disabled". Upon reconnect, we
 		// pop back to our previous state.
-		preDisconnectEnabled bool
+		preDisconnectEnabled  bool
 		preDisconnectDraining bool
 
 		// uuid is an anonymous ID that is used when reporting telemetry

--- a/master/internal/agent/agent.go
+++ b/master/internal/agent/agent.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 	"syscall"
 
+	"github.com/determined-ai/determined/master/pkg/actor/actors"
+
 	"github.com/google/uuid"
 	"github.com/labstack/echo/v4"
 	"github.com/pkg/errors"
@@ -23,30 +25,56 @@ import (
 	proto "github.com/determined-ai/determined/proto/pkg/apiv1"
 )
 
-type agent struct {
-	address          string
-	resourcePool     *actor.Ref
-	socket           *actor.Ref
-	slots            *actor.Ref
-	containers       map[container.ID]*actor.Ref
-	resourcePoolName string
-	label            string
-	// enabled and draining are duplicated in resourcepool agentState.
-	// TODO(ilia): refactor/dedupe it.
-	enabled  bool
-	draining bool
+type (
+	agent struct {
+		address          string
+		resourcePool     *actor.Ref
+		socket           *actor.Ref
+		slots            *actor.Ref
+		containers       map[container.ID]*actor.Ref
+		resourcePoolName string
+		label            string
+		// enabled and draining are duplicated in resourcepool agentState.
+		// TODO(ilia): refactor/dedupe it.
+		enabled  bool
+		draining bool
 
-	// uuid is an anonymous ID that is used when reporting telemetry
-	// information to allow agent connection and disconnection events
-	// to be correlated.
-	uuid uuid.UUID
+		// awaitingReconnect et al contain reconnect related state. The pattern for
+		// reconnecting agents is
+		//  * They have a small window to reconnect.
+		//  * In the meantime, we store up the messages it still can receive. We buffer and replay
+		//    such that things go out in the order they always would have. This is critical since
+		//    Start/Kill messages don't commute.
+		//  * We deny state changes while in recovery for simplicity. Within a bounded time, it will
+		//    recover or die.
+		//  * If the agent reconnects within the deadline, great. We replay the messages and move on.
+		//  * If it doesn't we stop with an error. If it comes back to reconnect later (only by some
+		//    monumental clock skew), the agent manager shoos it away, telling it to restart.
+		// Because of all this, for future developers: messages must be replay-able and writes must
+		// get buffered while down.
+		awaitingReconnect bool
+		reconnectBacklog  []interface{}
 
-	// opts are additional agent options the master sends to the agent.
-	opts *aproto.MasterSetAgentOptions
-}
+		// uuid is an anonymous ID that is used when reporting telemetry
+		// information to allow agent connection and disconnection events
+		// to be correlated.
+		uuid uuid.UUID
+
+		// opts are additional agent options the master sends to the agent.
+		opts *aproto.MasterSetAgentOptions
+	}
+
+	reconnectTimeout struct{}
+)
+
+var errRecovering = errors.New("agent disconnected, wait for recovery")
 
 func (a *agent) Receive(ctx *actor.Context) error {
-	switch msg := ctx.Message().(type) {
+	return a.receive(ctx, ctx.Message())
+}
+
+func (a *agent) receive(ctx *actor.Context, msg interface{}) error {
+	switch msg := msg.(type) {
 	case actor.PreStart:
 		a.uuid = uuid.New()
 		a.slots, _ = ctx.ActorOf("slots", &slots{resourcePool: a.resourcePool})
@@ -68,7 +96,22 @@ func (a *agent) Receive(ctx *actor.Context) error {
 		if err := ctx.Ask(a.socket, wsm).Error(); err != nil {
 			ctx.Log().WithError(err).Error("failed to write master set agent options")
 		}
+		if a.awaitingReconnect {
+			ctx.Log().Info("agent reconnected")
+			a.awaitingReconnect = false
+			for msg := range a.reconnectBacklog {
+				if err := a.receive(ctx, msg); err != nil {
+					return errors.Wrapf(err, "replaying backlog")
+				}
+			}
+			a.reconnectBacklog = nil
+		}
 	case sproto.KillTaskContainer:
+		if a.awaitingReconnect {
+			a.bufferForRecovery(ctx, msg)
+			return nil
+		}
+
 		ctx.Log().Infof("killing container id: %s", msg.ContainerID)
 		killMsg := aproto.SignalContainer{
 			ContainerID: msg.ContainerID, Signal: syscall.SIGKILL,
@@ -78,11 +121,21 @@ func (a *agent) Receive(ctx *actor.Context) error {
 			ctx.Log().WithError(err).Error("failed to write kill task message")
 		}
 	case aproto.SignalContainer:
+		if a.awaitingReconnect {
+			a.bufferForRecovery(ctx, msg)
+			return nil
+		}
+
 		wsm := ws.WriteMessage{Message: aproto.AgentMessage{SignalContainer: &msg}}
 		if err := ctx.Ask(a.socket, wsm).Error(); err != nil {
 			ctx.Log().WithError(err).Error("failed to write signal container message")
 		}
 	case sproto.StartTaskContainer:
+		if a.awaitingReconnect {
+			a.bufferForRecovery(ctx, msg)
+			return nil
+		}
+
 		ctx.Log().Infof("starting container id: %s slots: %d task handler: %s",
 			msg.StartContainer.Container.ID, len(msg.StartContainer.Container.Devices),
 			msg.TaskActor.Address())
@@ -106,16 +159,19 @@ func (a *agent) Receive(ctx *actor.Context) error {
 		sort.Slice(slots, func(i, j int) bool { return slots[i].Id < slots[j].Id })
 		ctx.Respond(&proto.GetSlotsResponse{Slots: slots})
 	case *proto.EnableAgentRequest:
-		a.enabled = true
-		a.draining = false
+		if a.awaitingReconnect {
+			ctx.Respond(errRecovering)
+			return nil
+		}
 
 		ctx.Tell(a.slots, patchSlot{Enabled: true})
 		ctx.Tell(a.resourcePool, sproto.EnableAgent{Agent: ctx.Self()})
 		ctx.Respond(&proto.EnableAgentResponse{Agent: a.summarize(ctx).ToProto()})
 	case *proto.DisableAgentRequest:
-		// Update our state.
-		a.enabled = false
-		a.draining = msg.Drain
+		if a.awaitingReconnect {
+			ctx.Respond(errRecovering)
+			return nil
+		}
 
 		// Mark current agent as disabled with RP.
 		ctx.Tell(a.resourcePool, sproto.DisableAgent{Agent: ctx.Self(), Drain: msg.Drain})
@@ -132,8 +188,16 @@ func (a *agent) Receive(ctx *actor.Context) error {
 	case echo.Context:
 		a.handleAPIRequest(ctx, msg)
 	case actor.ChildFailed:
-		telemetry.ReportAgentDisconnected(ctx.Self().System(), a.uuid)
-		return errors.Wrapf(msg.Error, "child failed: %s", msg.Child.Address())
+		ctx.Log().WithError(msg.Error).Errorf("child failed, awaiting reconnect: %s", msg.Child.Address())
+		a.socket = nil
+		a.awaitingReconnect = true
+		actors.NotifyAfter(ctx, aproto.AgentReconnectWait, reconnectTimeout{})
+	case reconnectTimeout:
+		// Re-enter from actor.ChildFailed.
+		if a.awaitingReconnect {
+			telemetry.ReportAgentDisconnected(ctx.Self().System(), a.uuid)
+			return errors.New("agent failed to reconnect by deadline")
+		}
 	case actor.ChildStopped:
 		telemetry.ReportAgentDisconnected(ctx.Self().System(), a.uuid)
 		ctx.Self().Stop()
@@ -155,6 +219,11 @@ func (a *agent) Receive(ctx *actor.Context) error {
 		return actor.ErrUnexpectedMessage(ctx)
 	}
 	return nil
+}
+
+func (a *agent) bufferForRecovery(ctx *actor.Context, msg interface{}) {
+	ctx.Log().WithField("msg", msg).Debugf("buffering message until agent reconnects")
+	a.reconnectBacklog = append(a.reconnectBacklog, msg)
 }
 
 func (a *agent) handleAPIRequest(ctx *actor.Context, apiCtx echo.Context) {

--- a/master/internal/agent/agents.go
+++ b/master/internal/agent/agents.go
@@ -52,7 +52,7 @@ func (a *agents) Receive(ctx *actor.Context) error {
 				// In the event it has closed and the agent is trying to reconnect,
 				// continue to deny it. This case is nearly impossible (master waits
 				// longer than agent tries, to avoid it).
-				ctx.Respond(errors.New("agent is past reconnect period, it must restart"))
+				ctx.Respond(aproto.AgentMustReconnect)
 			}
 			return nil
 		}

--- a/master/internal/agent/agents.go
+++ b/master/internal/agent/agents.go
@@ -52,7 +52,7 @@ func (a *agents) Receive(ctx *actor.Context) error {
 				// In the event it has closed and the agent is trying to reconnect,
 				// continue to deny it. This case is nearly impossible (master waits
 				// longer than agent tries, to avoid it).
-				ctx.Respond(aproto.AgentMustReconnect)
+				ctx.Respond(aproto.ErrAgentMustReconnect)
 			}
 			return nil
 		}

--- a/master/pkg/actor/api/ws.go
+++ b/master/pkg/actor/api/ws.go
@@ -171,8 +171,7 @@ func (s *websocketActor) processWriteMessage(
 }
 
 func isClosingError(err error) bool {
-	return err == websocket.ErrCloseSent ||
-		websocket.IsCloseError(err, websocket.CloseNormalClosure, websocket.CloseAbnormalClosure)
+	return err == websocket.ErrCloseSent || websocket.IsCloseError(err, websocket.CloseNormalClosure)
 }
 
 func (s *websocketActor) setupPingLoop(ctx *actor.Context) {

--- a/master/pkg/agent/agent_message.go
+++ b/master/pkg/agent/agent_message.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"syscall"
+	"time"
 
 	"github.com/determined-ai/determined/master/pkg/model"
 
@@ -35,3 +36,14 @@ type SignalContainer struct {
 	ContainerID container.ID
 	Signal      syscall.Signal
 }
+
+const (
+	// AgentReconnectAttempts is the max attempts an agent has to reconnect.
+	AgentReconnectAttempts = 5
+	// AgentReconnectBackoff is the time between attempts, with the exception of the first.
+	AgentReconnectBackoff = 5 * time.Second
+	// AgentReconnectWait is the max time the master should wait for an agent before considering
+	// it dead. The agent waits (AgentReconnectWait - AgentReconnectBackoff) before stopping
+	// attempts and AgentReconnectWait before crashing.
+	AgentReconnectWait = AgentReconnectAttempts * AgentReconnectBackoff
+)

--- a/master/pkg/agent/agent_message.go
+++ b/master/pkg/agent/agent_message.go
@@ -1,9 +1,10 @@
 package agent
 
 import (
-	"github.com/pkg/errors"
 	"syscall"
 	"time"
+
+	"github.com/pkg/errors"
 
 	"github.com/determined-ai/determined/master/pkg/model"
 
@@ -49,5 +50,5 @@ const (
 	AgentReconnectWait = AgentReconnectAttempts * AgentReconnectBackoff
 )
 
-// AgentMustReconnect is the error returned by the master when the agent must exit and reconnect.
-var AgentMustReconnect = errors.New("agent is past reconnect period, it must restart")
+// ErrAgentMustReconnect is the error returned by the master when the agent must exit and reconnect.
+var ErrAgentMustReconnect = errors.New("agent is past reconnect period, it must restart")

--- a/master/pkg/agent/agent_message.go
+++ b/master/pkg/agent/agent_message.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"github.com/pkg/errors"
 	"syscall"
 	"time"
 
@@ -47,3 +48,6 @@ const (
 	// attempts and AgentReconnectWait before crashing.
 	AgentReconnectWait = AgentReconnectAttempts * AgentReconnectBackoff
 )
+
+// AgentMustReconnect is the error returned by the master when the agent must exit and reconnect.
+var AgentMustReconnect = errors.New("agent is past reconnect period, it must restart")


### PR DESCRIPTION
## Description
This change adds functionality to recover agent websocket flakes.
<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan
Writing tests right now, going to add a "chaos test" target I think. For manual testing
* add `actors.NotifyAfter(ctx, 10*time.Second, errors.New("connection reset"))` to the websocket prestart
* modify `isClosingError` to treat abnormal closures as socket errors
* submit an experiment and watch it complete, with the agent websocket crashing on both sides every 10 seconds
* or just use socat/nc 🤷 (i also tested this way with `socat TCP-LISTEN:8081,fork,reuseaddr TCP4:localhost:8080` between the master and agent, blipping the tunnel)
<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)
For now, I didn't set the agent to draining. There are some edge cases that are tempting to not handle when we're draining because they're _almost_ not possible (E.G. getting a task scheduled, technically we could get scheduled as we tell the scheduler we're draining, right?); so for the sake of correctness, I handled it this way first. Setting ourselves to drain can be added on top as an improvement.
<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234