### PR TITLE
fix: always `helm push` latest version

### DIFF
--- a/helm/Makefile
+++ b/helm/Makefile
@@ -17,4 +17,4 @@ release: export NGC_API_USERNAME ?=
 release: export NGC_API_KEY ?=
 release:
 	helm repo add determined $$NGC_REPO --username $$NGC_API_USERNAME --password $$NGC_API_KEY
-	helm push -f build/determined-0.16.1.tgz determined
+	helm push -f build/determined-latest.tgz determined


### PR DESCRIPTION
## Description

The version needed to be kept in sync with the chart before, which was
annoying. It turns out `helm push` works fine with the `latest` symlink.

## Test Plan

- [x] run `helm push build/determined-latest.tgz determined` and see that it correctly picks up the versioned file name
