### PR TITLE
fix: `det t describe --metrics` API and rendering [DET-6025]

### DIFF
--- a/harness/determined/cli/checkpoint.py
+++ b/harness/determined/cli/checkpoint.py
@@ -25,7 +25,7 @@ def format_validation(validation: Dict[str, Any]) -> List[Any]:
 # TODO(neilc): Report more info about checkpoints and validations.
 def format_checkpoint(checkpoint: Dict[str, Any]) -> List[Any]:
     if not checkpoint:
-        return [None, None]
+        return [None, None, None]
 
     if checkpoint["state"] in (constants.COMPLETED, constants.DELETED):
         return [

--- a/master/static/srv/get_trial_metrics.sql
+++ b/master/static/srv/get_trial_metrics.sql
@@ -3,6 +3,7 @@ FROM
   (SELECT t.id,
           t.experiment_id,
           t.state,
+          t.start_time,
           t.end_time,
           t.hparams,
           t.seed,


### PR DESCRIPTION
## Description
This fixes a mistaken removal in the API backing `det t describe --metrics` and a long-standing rendering bug with `det t describe`, where `format_checkpoint` didn't return enough rows if there was no checkpoint.
<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan
- [x] ensure `det t describe --metrics` works
<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)
I was unaware `det t describe --metrics` called an entirely separate API with an entirely separate SQL query, so I missed this yesterday when I checked `det t describe`.
<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234