### PR TITLE
chore: mark open allocs as closed on restart

### DIFF
--- a/master/internal/core.go
+++ b/master/internal/core.go
@@ -715,7 +715,10 @@ func (m *Master) Run(ctx context.Context) error {
 		go m.tryRestoreExperiment(sema, exp)
 	}
 	if err = m.db.FailDeletingExperiment(); err != nil {
-		return errors.Wrap(err, "couldn't force fail deleting experiments after crash")
+		return err
+	}
+	if err = m.db.CloseOpenAllocations(); err != nil {
+		return err
 	}
 
 	// Docs and WebUI.

--- a/master/internal/db/postgres_tasks.go
+++ b/master/internal/db/postgres_tasks.go
@@ -119,3 +119,16 @@ func (db *PgDB) DeleteAllocationSession(allocationID model.AllocationID) error {
 		"DELETE FROM allocation_sessions WHERE allocation_id=$1", allocationID)
 	return err
 }
+
+// CloseOpenAllocations finds all allocations that were open when the master crashed
+// and adds an end time.
+func (db *PgDB) CloseOpenAllocations() error {
+	if _, err := db.sql.Exec(`
+UPDATE allocations
+SET end_time = current_timestamp AT TIME ZONE 'UTC'
+WHERE end_time IS NULL
+`); err != nil {
+		return errors.Wrap(err, "closing old allocations")
+	}
+	return nil
+}

--- a/master/pkg/tasks/task_gc.go
+++ b/master/pkg/tasks/task_gc.go
@@ -37,7 +37,7 @@ func (g GCCkptSpec) ToTaskSpec(allocationToken string) TaskSpec {
 	envVars := g.LegacyConfig.EnvironmentVariables()
 	env := expconf.EnvironmentConfig{
 		RawEnvironmentVariables: &envVars,
-		RawPodSpec: g.LegacyConfig.PodSpec(),
+		RawPodSpec:              g.LegacyConfig.PodSpec(),
 	}
 	// Fill the rest of the environment with default values.
 	defaultConfig := expconf.ExperimentConfig{}


### PR DESCRIPTION
## Description
This change ensure that, upon master crashes, allocations are marked as ended, so they don't get counted ad infinitum.
<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan
- [x] test the query on a real DB
<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
