### PR TITLE
chore: remove NativeContext and simplify Context inheritance

### DIFF
--- a/docs/reference/api/api-estimator.txt
+++ b/docs/reference/api/api-estimator.txt
@@ -17,16 +17,16 @@
 
 .. _estimator-context:
 
-*******************************************
- ``determined.estimator.EstimatorContext``
-*******************************************
+************************************************
+ ``determined.estimator.EstimatorTrialContext``
+************************************************
 
 To use ``tf.estimator`` models with Determined, users need to wrap their optimizer and datasets
-using the following functions inherited from :class:`determined.estimator.EstimatorContext`. Note
-that the concrete context object where these functions will be found will be in
+using the following functions inherited from :class:`determined.estimator.EstimatorTrialContext`.
+Note that the concrete context object where these functions will be found will be in
 :class:`determined.estimator.EstimatorTrialContext`.
 
-.. autoclass:: determined.estimator.EstimatorContext
+.. autoclass:: determined.estimator.EstimatorTrialContext
    :members:
    :inherited-members:
    :member-order: bysource
@@ -50,7 +50,7 @@ Determined supports proper reduction of arbitrary validation metrics during dist
 allowing users to define custom reducers for their metrics. Custom reducers can be either a function
 or an implementation of the :class:`determined.estimator.MetricReducer` interface.
 
-See :func:`context.make_metric() <determined.estimator.EstimatorContext.make_metric>` for more
+See :func:`context.make_metric() <determined.estimator.EstimatorTrialContext.make_metric>` for more
 details.
 
 .. autoclass:: determined.estimator.MetricReducer

--- a/harness/determined/__init__.py
+++ b/harness/determined/__init__.py
@@ -8,7 +8,7 @@ from determined._execution import (
     _local_execution_manager,
     InvalidHP,
 )
-from determined._train_context import NativeContext, TrialContext, DistributedContext, RankInfo
+from determined._train_context import TrialContext, DistributedContext, RankInfo
 from determined import _generic
 from determined._trial import Trial
 from determined._hparam import Categorical, Constant, Double, Integer, Log

--- a/harness/determined/_train_context.py
+++ b/harness/determined/_train_context.py
@@ -11,10 +11,9 @@ import determined as det
 from determined import constants, horovod, ipc
 
 
-class _TrainContext(metaclass=abc.ABCMeta):
+class TrialContext(metaclass=abc.ABCMeta):
     """
-    _TrainContext is the API to query the system about the trial as it's running.
-    These methods should be made available to both Native and Trial APIs.
+    TrialContext is the system-provided API to a Trial class.
     """
 
     def __init__(
@@ -54,7 +53,7 @@ class _TrainContext(metaclass=abc.ABCMeta):
         self._stop_requested = False
 
     @classmethod
-    def from_config(cls, config: Dict[str, Any]) -> "_TrainContext":
+    def from_config(cls, config: Dict[str, Any]) -> "TrialContext":
         """
         Create an context object suitable for debugging outside of Determined.
 
@@ -185,41 +184,6 @@ class _TrainContext(metaclass=abc.ABCMeta):
         return self.env.latest_batch
 
 
-class TrialContext(_TrainContext):
-    """
-    A base class that all TrialContexts will inherit from.
-    The context passed to the User's ``Trial.__init__()`` will inherit from this class.
-    """
-
-    def __init__(
-        self,
-        env: det.EnvContext,
-        hvd_config: horovod.HorovodContext,
-        rendezvous_info: det.RendezvousInfo,
-    ) -> None:
-        super().__init__(env, hvd_config, rendezvous_info)
-
-
-class NativeContext(_TrainContext):
-    """
-    A base class that all NativeContexts will inherit when using the Native API.
-
-    The context returned by the ``init()`` function will inherit from this class.
-    """
-
-    def __init__(
-        self,
-        env: det.EnvContext,
-        hvd_config: horovod.HorovodContext,
-        rendezvous_info: det.RendezvousInfo,
-    ) -> None:
-        super().__init__(env, hvd_config, rendezvous_info)
-        self._train_fn = None  # type: Optional[Callable[[], None]]
-
-    def _set_train_fn(self, train_fn: Callable[[], None]) -> None:
-        self._train_fn = train_fn
-
-
 class RankInfo:
     """
     RankInfo was worker identity information that is:
@@ -271,9 +235,7 @@ class RankInfo:
 
 class DistributedContext:
     """
-    DistributedContext extends all TrialContexts and NativeContexts under
-    the ``context.distributed`` namespace. It provides useful methods for
-    effective distributed training.
+    DistributedContext  provides useful methods for effective distributed training.
     """
 
     def __init__(

--- a/harness/determined/estimator/__init__.py
+++ b/harness/determined/estimator/__init__.py
@@ -6,8 +6,6 @@ from determined.estimator._reducer import (
     _EstimatorReducerContext,
 )
 from determined.estimator._estimator_context import (
-    EstimatorNativeContext,
-    EstimatorContext,
     EstimatorExperimentalContext,
     EstimatorTrialContext,
     ServingInputReceiverFn,

--- a/harness/determined/estimator/_estimator_trial.py
+++ b/harness/determined/estimator/_estimator_trial.py
@@ -358,7 +358,7 @@ class EstimatorTrialController(det.TrialController):
         user_train_spec: tf.estimator.TrainSpec,
         val_spec: tf.estimator.EvalSpec,
         serving_input_receiver_fns: Dict[str, estimator.ServingInputReceiverFn],
-        context: estimator.EstimatorContext,
+        context: estimator.EstimatorTrialContext,
         *args: Any,
         **kwargs: Any,
     ) -> None:

--- a/harness/determined/estimator/_reducer.py
+++ b/harness/determined/estimator/_reducer.py
@@ -53,7 +53,8 @@ class MetricReducer:
                     eval_metric_ops={"my_avg_prediction": my_avg_prediction},
                 )
 
-    See also: :func:`context.make_metric() <determined.estimator.EstimatorContext.make_metric>`.
+    See also: :func:`context.make_metric()
+    <determined.estimator.EstimatorTrialContext.make_metric>`.
     """
 
     @abc.abstractmethod

--- a/harness/determined/keras/__init__.py
+++ b/harness/determined/keras/__init__.py
@@ -10,8 +10,6 @@ from determined.keras._data import (
 from determined.keras._enqueuer import _Enqueuer, _Sampler, _build_enqueuer
 from determined.keras._tensorboard_callback import TFKerasTensorBoard
 from determined.keras._tf_keras_context import (
-    TFKerasNativeContext,
-    TFKerasContext,
     TFKerasExperimentalContext,
     TFKerasTrainConfig,
     TFKerasTrialContext,

--- a/harness/determined/keras/_tf_keras_trial.py
+++ b/harness/determined/keras/_tf_keras_trial.py
@@ -218,7 +218,7 @@ class TFKerasTrialController(det.TrialController):
 
     @staticmethod
     def compile_model(
-        context: keras.TFKerasContext,
+        context: keras.TFKerasTrialContext,
         compile_args: inspect.BoundArguments,
         env: det.EnvContext,
         hvd_config: horovod.HorovodContext,

--- a/harness/tests/experiment/fixtures/estimator_xor_model.py
+++ b/harness/tests/experiment/fixtures/estimator_xor_model.py
@@ -1,5 +1,5 @@
 import os
-from typing import Any, Callable, Dict, Tuple, Union
+from typing import Any, Callable, Dict, Tuple
 
 import tensorflow as tf
 
@@ -8,7 +8,7 @@ from tests.experiment.utils import xor_data
 
 
 def xor_input_fn(
-    context: Union[estimator.EstimatorNativeContext, estimator.EstimatorTrialContext],
+    context: estimator.EstimatorTrialContext,
     batch_size: int,
     shuffle: bool = False,
 ) -> Callable[[], Tuple[tf.Tensor, tf.Tensor]]:
@@ -31,7 +31,7 @@ def xor_input_fn(
 
 
 def xor_input_fn_data_layer(
-    context: Union[estimator.EstimatorNativeContext, estimator.EstimatorTrialContext],
+    context: estimator.EstimatorTrialContext,
     training: bool,
     batch_size: int,
     shuffle: bool = False,


### PR DESCRIPTION
These classes have been unused since the removal of
`det.experimental.keras.init()` and `det.experimental.estimator.init()`
in 0.16.0.