### PR TITLE
fix: gracefully handle prestart agent failures

### DIFF
--- a/master/internal/agent/agent.go
+++ b/master/internal/agent/agent.go
@@ -212,7 +212,7 @@ func (a *agent) receive(ctx *actor.Context, msg interface{}) error {
 	case actor.ChildFailed:
 		if !a.started {
 			// If we happen to fail before the agent has started and been registered with
-			// the resource manager, then nothing can be running no it. In this case we
+			// the resource manager, then nothing can be running on it. In this case we
 			// just fail outright and make it restart.
 			telemetry.ReportAgentDisconnected(ctx.Self().System(), a.uuid)
 			return errors.Wrapf(msg.Error, "child failed: %s", msg.Child.Address())

--- a/master/internal/agent/agent.go
+++ b/master/internal/agent/agent.go
@@ -34,6 +34,8 @@ type (
 		containers       map[container.ID]*actor.Ref
 		resourcePoolName string
 		label            string
+		// started tracks if we have received the AgentStarted message.
+		started bool
 		// enabled and draining are duplicated in resourcepool agentState.
 		// TODO(ilia): refactor/dedupe it.
 		enabled  bool
@@ -208,6 +210,14 @@ func (a *agent) receive(ctx *actor.Context, msg interface{}) error {
 	case echo.Context:
 		a.handleAPIRequest(ctx, msg)
 	case actor.ChildFailed:
+		if !a.started {
+			// If we happen to fail before the agent has started and been registered with
+			// the resource manager, then nothing can be running no it. In this case we
+			// just fail outright and make it restart.
+			telemetry.ReportAgentDisconnected(ctx.Self().System(), a.uuid)
+			return errors.Wrapf(msg.Error, "child failed: %s", msg.Child.Address())
+		}
+
 		ctx.Log().WithError(msg.Error).Errorf("child failed, awaiting reconnect: %s", msg.Child.Address())
 		a.socket = nil
 		a.awaitingReconnect = true
@@ -273,6 +283,7 @@ func (a *agent) handleIncomingWSMessage(ctx *actor.Context, msg aproto.MasterMes
 
 		ctx.Tell(a.resourcePool, sproto.AddAgent{Agent: ctx.Self(), Label: msg.AgentStarted.Label})
 		ctx.Tell(a.slots, *msg.AgentStarted)
+		a.started = true
 		a.label = msg.AgentStarted.Label
 	case msg.ContainerStateChanged != nil:
 		a.containerStateChanged(ctx, *msg.ContainerStateChanged)


### PR DESCRIPTION
## Description
Fix a bug that could crash the resource manager when an agent disconnects before it sent the master it's `AgentStarted` message. In this case, the failure caused the master to move the agent to the draining state but, since it wasn't registered with the resource manager, this made the RM panic.
<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan
- [x] retest these reconnect features
- [x] test the exact bug with a 5s sleep
<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)
oops
<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ