### PR TITLE
ci: update gke version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1567,7 +1567,7 @@ jobs:
         default: 1
       gke-version:
         type: string
-        default: "1.20.10-gke.301"
+        default: "1.21.3-gke.2001"
       machine-type:
         type: string
         default: "n1-standard-8"
@@ -1650,7 +1650,7 @@ jobs:
         default: 1
       gke-version:
         type: string
-        default: "1.20.10-gke.301"
+        default: "1.21.3-gke.2001"
       machine-type:
         type: string
         default: "n1-standard-8"


### PR DESCRIPTION
1.18.* is no longer available.  Rather than doing the minimum possible
update, switch to what gke says is the default version of the "Regular
Channel".

https://cloud.google.com/kubernetes-engine/docs/release-notes