### PR TITLE
refactor: let shared_fs be "magic"

### DIFF
--- a/harness/determined/_generic/_context.py
+++ b/harness/determined/_generic/_context.py
@@ -4,7 +4,7 @@ import pathlib
 from typing import Iterator
 
 import determined as det
-from determined.common import constants, storage
+from determined.common import storage
 
 
 class Context:
@@ -20,10 +20,7 @@ class Context:
         self._env = env
         self._dist = dist
 
-        self._storage_mgr = storage.build(
-            env.experiment_config["checkpoint_storage"],
-            container_path=None if not env.on_cluster else constants.SHARED_FS_CONTAINER_PATH,
-        )
+        self._storage_mgr = storage.build(env.experiment_config["checkpoint_storage"])
 
     @contextlib.contextmanager
     def _download_initial_checkpoint(self, storage_id: str) -> Iterator[pathlib.Path]:

--- a/harness/determined/common/experimental/checkpoint/_checkpoint.py
+++ b/harness/determined/common/experimental/checkpoint/_checkpoint.py
@@ -4,7 +4,7 @@ import pathlib
 import shutil
 from typing import Any, Dict, List, Optional, cast
 
-from determined.common import constants, storage
+from determined.common import storage
 from determined.common.experimental import session
 from determined.common.storage import shared
 
@@ -81,13 +81,8 @@ class Checkpoint(object):
         host_path = self.experiment_config["checkpoint_storage"]["host_path"]
         storage_path = self.experiment_config["checkpoint_storage"].get("storage_path")
         potential_paths = [
-            pathlib.Path(shared._full_storage_path(host_path, storage_path), self.uuid),
-            pathlib.Path(
-                shared._full_storage_path(
-                    host_path, storage_path, constants.SHARED_FS_CONTAINER_PATH
-                ),
-                self.uuid,
-            ),
+            pathlib.Path(shared._full_storage_path(True, host_path, storage_path), self.uuid),
+            pathlib.Path(shared._full_storage_path(False, host_path, storage_path), self.uuid),
         ]
 
         for path in potential_paths:
@@ -130,10 +125,7 @@ class Checkpoint(object):
                 shutil.copytree(str(src_ckpt_dir), str(local_ckpt_dir))
             else:
                 local_ckpt_dir.mkdir(parents=True, exist_ok=True)
-                manager = storage.build(
-                    self.experiment_config["checkpoint_storage"],
-                    container_path=None,
-                )
+                manager = storage.build(self.experiment_config["checkpoint_storage"])
                 if not isinstance(
                     manager,
                     (

--- a/harness/determined/common/storage/__init__.py
+++ b/harness/determined/common/storage/__init__.py
@@ -10,6 +10,7 @@ from .azure import AzureStorageManager
 from .gcs import GCSStorageManager
 from .hdfs import HDFSStorageManager
 from .s3 import S3StorageManager
+from .file import FileStorageManager
 from .shared import SharedFSStorageManager
 
 __all__ = [
@@ -30,7 +31,7 @@ _STORAGE_MANAGERS = {
 }  # type: Dict[str, Type[StorageManager]]
 
 
-def build(config: Dict[str, Any], container_path: Optional[str]) -> StorageManager:
+def build(config: Dict[str, Any]) -> StorageManager:
     """
     Return a checkpoint manager defined by the value of the `type` key in
     the configuration dictionary. Throws a `TypeError` if no storage manager
@@ -76,7 +77,7 @@ def build(config: Dict[str, Any], container_path: Optional[str]) -> StorageManag
     config.pop("checkpoint_path", None)
 
     try:
-        return subclass.from_config(config, container_path)
+        return subclass.from_config(config)
     except TypeError as e:
         raise TypeError(
             "Failed to instantiate {} checkpoint storage: {}".format(identifier, str(e))
@@ -115,5 +116,5 @@ def validate_manager(manager: StorageManager) -> None:
     manager.delete(storage_id)
 
 
-def validate_config(config: Dict[str, Any], container_path: Optional[str]) -> None:
-    validate_manager(build(config, container_path))
+def validate_config(config: Dict[str, Any]) -> None:
+    validate_manager(build(config))

--- a/harness/determined/common/storage/file.py
+++ b/harness/determined/common/storage/file.py
@@ -1,0 +1,48 @@
+import contextlib
+import os
+from typing import Iterator
+
+from determined import errors
+from determined.common.storage.base import StorageManager
+
+
+class FileStorageManager(StorageManager):
+    """
+    FileStorageManager stores artifacts files.
+
+    This StorageManager is not exposed via the normal checkpoint_storage config mechanism.
+    Presently, the only way to create one is to create one explicitly, or to use the
+    SharedFSStorageManager's .from_config() using a shared_fs checkpoint storage config.
+    """
+
+    def post_store_path(self, storage_id: str, storage_dir: str) -> None:
+        """
+        FileStorageManager has nothing special to do at this point.
+        """
+
+    @contextlib.contextmanager
+    def restore_path(self, storage_id: str) -> Iterator[str]:
+        """
+        FileStorageManager's restore_ath just verifies that the checkoint exists.
+        """
+        storage_dir = os.path.join(self._base_path, storage_id)
+        if not os.path.exists(storage_dir):
+            raise errors.CheckpointNotFound(
+                f"Did not find checkpoint {storage_id} in shared_fs storage"
+            )
+
+        yield storage_dir
+
+    def delete(self, storage_id: str) -> None:
+        """
+        Delete a checkpoint from the filesystem.
+        """
+        storage_dir = os.path.join(self._base_path, storage_id)
+
+        if not os.path.exists(storage_dir):
+            raise ValueError("Storage directory does not exist: {}".format(storage_dir))
+
+        if not os.path.isdir(storage_dir):
+            raise ValueError("Storage path is not a directory: {}".format(storage_dir))
+
+        self._remove_checkpoint_directory(storage_id, ignore_errors=False)

--- a/harness/determined/exec/gc_checkpoints.py
+++ b/harness/determined/exec/gc_checkpoints.py
@@ -10,7 +10,7 @@ from typing import Any, List
 
 import determined as det
 from determined import tensorboard
-from determined.common import constants, storage
+from determined.common import storage
 
 
 def delete_checkpoints(
@@ -97,7 +97,7 @@ def main(argv: List[str]) -> None:
     storage_config = args.storage_config
     logging.info("Using checkpoint storage: {}".format(storage_config))
 
-    manager = storage.build(storage_config, container_path=constants.SHARED_FS_CONTAINER_PATH)
+    manager = storage.build(storage_config)
 
     storage_ids = [c["uuid"] for c in args.delete["checkpoints"]]
 
@@ -109,7 +109,6 @@ def main(argv: List[str]) -> None:
             args.experiment_id,
             None,
             storage_config,
-            container_path=constants.SHARED_FS_CONTAINER_PATH,
         )
         delete_tensorboards(tb_manager, dry_run=args.dry_run)
 

--- a/harness/determined/exec/launch_autohorovod.py
+++ b/harness/determined/exec/launch_autohorovod.py
@@ -16,7 +16,7 @@ import simplejson
 import determined as det
 import determined.common
 from determined import horovod
-from determined.common import api, constants, storage
+from determined.common import api, storage
 from determined.common.api import certs
 from determined.constants import HOROVOD_SSH_PORT
 
@@ -40,10 +40,7 @@ def main() -> int:
     # TODO: this should go in the chief worker, not in the launch layer.  For now, the
     # DistributedContext is not created soon enough for that to work well.
     try:
-        storage.validate_config(
-            experiment_config["checkpoint_storage"],
-            container_path=constants.SHARED_FS_CONTAINER_PATH,
-        )
+        storage.validate_config(experiment_config["checkpoint_storage"])
     except Exception as e:
         logging.error("Checkpoint storage validation failed: {}".format(e))
         return 1

--- a/harness/determined/layers/_workload_sequencer.py
+++ b/harness/determined/layers/_workload_sequencer.py
@@ -5,7 +5,7 @@ from typing import Any, Generator, Optional, Tuple
 
 import determined as det
 from determined import _generic, tensorboard, workload
-from determined.common import check, constants
+from determined.common import check
 from determined.experimental import client
 
 WorkloadStreamElem = Tuple[workload.Workload, workload.ResponseFunc]
@@ -105,7 +105,6 @@ class WorkloadSequencer(workload.Source):
             env.det_experiment_id,
             env.det_trial_id,
             env.experiment_config["checkpoint_storage"],
-            container_path=None if not env.on_cluster else constants.SHARED_FS_CONTAINER_PATH,
         )
         tbd_writer = tensorboard.get_metric_writer()
         self.training = _generic.Training(

--- a/harness/tests/storage/test_gcs.py
+++ b/harness/tests/storage/test_gcs.py
@@ -17,7 +17,8 @@ def prep_gcs_test_creds(tmp_path: Path) -> Iterator[None]:
 
     Note that the gcs credentials in the "storage-unit-tests" context are the keyid=c07eed131 key
     to the storage-unit-tests@determined-ai.iam.gserviceaccount.com service account.  The contents
-    of the key are at github.com/determined-ai/secrets/gcp/service-accounts/storage-unit-tests.json.
+    of the key are at
+    github.com/determined-ai/secrets/tree/master/gcp/service-accounts/storage-unit-tests.json.
 
     The service account should only have permission to view the "storage-unit-tests" bucket.
     """

--- a/harness/tests/storage/test_s3.py
+++ b/harness/tests/storage/test_s3.py
@@ -12,13 +12,13 @@ from tests.storage import util
 def live_manager(tmp_path: Path, require_secrets: bool) -> storage.S3StorageManager:
     """
     Return a working S3StorageManager connected to a real bucket when we detect that we have access
-    to s3.  S3 access may come from the user's normal filesystem authentication of from the
+    to s3.  S3 access may come from the user's normal filesystem authentication or from the
     AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY environment variables.
 
     Note that we pass these variables as part of circleci's "storage-unit-tests" context.
 
     The circleci credentials belong to the "storage-unit-tests" user.  The contest of the key are at
-    github.com/determined-ai/secrets/aws/access-keys/storage-unit-tests.csv.
+    github.com/determined-ai/secrets/tree/master/aws/access-keys/storage-unit-tests.csv.
 
     The user only has premissions to read/write the "storage-unit-tests" bucket.
     """

--- a/harness/tests/storage/test_shared_fs.py
+++ b/harness/tests/storage/test_shared_fs.py
@@ -4,62 +4,64 @@ from pathlib import Path
 
 import pytest
 
-from determined.common import check, storage
+from determined.common import check, constants, storage
 from determined.common.storage import shared
 from tests.storage import util
 
+CONTAINER_PATH = constants.SHARED_FS_CONTAINER_PATH
+
 
 @pytest.fixture()
-def manager(tmp_path: Path) -> storage.SharedFSStorageManager:
-    return storage.SharedFSStorageManager(str(tmp_path))
+def manager(tmp_path: Path) -> storage.StorageManager:
+    return storage.FileStorageManager(str(tmp_path))
 
 
 def test_full_storage_path() -> None:
-    with pytest.raises(check.CheckFailedError, match="`host_path` must be an absolute path"):
-        shared._full_storage_path("host_path")
+    with pytest.raises(check.CheckFailedError, match="must be an absolute path"):
+        shared._full_storage_path(True, "host_path")
 
-    path = shared._full_storage_path("/host_path")
+    path = shared._full_storage_path(False, "/host_path")
     assert path == "/host_path"
 
-    path = shared._full_storage_path("/host_path", container_path="cpath")
-    assert path == "cpath"
+    path = shared._full_storage_path(True, "/host_path")
+    assert path == constants.SHARED_FS_CONTAINER_PATH
 
-    path = shared._full_storage_path("/host_path", "storage_path")
+    path = shared._full_storage_path(False, "/host_path", "storage_path")
     assert path == "/host_path/storage_path"
 
-    path = shared._full_storage_path("/host_path", "storage_path", container_path="cpath")
-    assert path == "cpath/storage_path"
+    path = shared._full_storage_path(True, "/host_path", "storage_path")
+    assert path == f"{constants.SHARED_FS_CONTAINER_PATH}/storage_path"
 
-    path = shared._full_storage_path("/host_path", storage_path="/host_path/storage_path")
+    path = shared._full_storage_path(False, "/host_path", "/host_path/storage_path")
     assert path == "/host_path/storage_path"
 
-    path = shared._full_storage_path("/host_path", "/host_path/storage_path", "cpath")
-    assert path == "cpath/storage_path"
+    path = shared._full_storage_path(True, "/host_path", "/host_path/storage_path")
+    assert path == f"{constants.SHARED_FS_CONTAINER_PATH}/storage_path"
 
     with pytest.raises(check.CheckFailedError, match="must be a subdirectory"):
-        shared._full_storage_path("/host_path", storage_path="/storage_path")
+        shared._full_storage_path(True, "/host_path", "/storage_path")
 
     with pytest.raises(check.CheckFailedError, match="must be a subdirectory"):
-        shared._full_storage_path("/host_path", storage_path="/host_path/../test")
+        shared._full_storage_path(True, "/host_path", "/host_path/../test")
 
     with pytest.raises(check.CheckFailedError, match="must be a subdirectory"):
-        shared._full_storage_path("/host_path", storage_path="../test")
+        shared._full_storage_path(True, "/host_path", "../test")
 
 
-def test_checkpoint_lifecycle(manager: storage.SharedFSStorageManager) -> None:
+def test_checkpoint_lifecycle(manager: storage.StorageManager) -> None:
     def post_delete_cb(storage_id: str) -> None:
         assert storage_id not in os.listdir(manager._base_path)
 
     util.run_storage_lifecycle_test(manager, post_delete_cb)
 
 
-def test_validate(manager: storage.SharedFSStorageManager) -> None:
+def test_validate(manager: storage.StorageManager) -> None:
     assert len(os.listdir(manager._base_path)) == 0
     storage.validate_manager(manager)
     assert len(os.listdir(manager._base_path)) == 0
 
 
-def test_validate_read_only_dir(manager: storage.SharedFSStorageManager) -> None:
+def test_validate_read_only_dir(manager: storage.StorageManager) -> None:
     def permission_error(_1: str, _2: str) -> None:
         raise PermissionError("Permission denied")
 

--- a/harness/tests/storage/test_storage_base.py
+++ b/harness/tests/storage/test_storage_base.py
@@ -10,26 +10,18 @@ from determined.common.storage import StorageManager
 def test_unknown_type() -> None:
     config = {"type": "unknown"}
     with pytest.raises(TypeError, match="Unknown storage type: unknown"):
-        storage.build(config, container_path=None)
+        storage.build(config)
 
 
 def test_missing_type() -> None:
     with pytest.raises(CheckFailedError, match="Missing 'type' parameter"):
-        storage.build({}, container_path=None)
+        storage.build({})
 
 
 def test_illegal_type() -> None:
     config = {"type": 4}
     with pytest.raises(CheckFailedError, match="must be a string"):
-        storage.build(config, container_path=None)
-
-
-def test_build_with_container_path() -> None:
-    config = {"type": "shared_fs", "host_path": "/host_path", "storage_path": "storage_path"}
-    manager = storage.build(config, container_path=None)
-    assert manager._base_path == "/host_path/storage_path"
-    manager = storage.build(config, container_path="/container_path")
-    assert manager._base_path == "/container_path/storage_path"
+        storage.build(config)
 
 
 def test_list_directory() -> None:

--- a/harness/tests/tensorboard/test_base.py
+++ b/harness/tests/tensorboard/test_base.py
@@ -33,24 +33,6 @@ def test_setting_optional_variable(tmp_path: pathlib.Path) -> None:
     assert manager.base_path == pathlib.Path("test_value/tensorboard")
 
 
-def test_build_with_container_path(tmp_path: pathlib.Path) -> None:
-    checkpoint_config = {
-        "type": "shared_fs",
-        "host_path": str(HOST_PATH),
-        "storage_path": str(STORAGE_PATH),
-    }
-    env = test_util.get_dummy_env()
-    manager = tensorboard.build(
-        env.det_cluster_id,
-        env.det_experiment_id,
-        env.det_trial_id,
-        checkpoint_config,
-        container_path=str(tmp_path),
-    )
-    assert isinstance(manager, tensorboard.SharedFSTensorboardManager)
-    assert manager.storage_path == tmp_path.joinpath("test_storage_path")
-
-
 def test_setting_storage_path(tmp_path: pathlib.Path) -> None:
     checkpoint_config = {
         "type": "shared_fs",

--- a/harness/tests/test_gc_harness.py
+++ b/harness/tests/test_gc_harness.py
@@ -11,7 +11,7 @@ from tests.storage import util as storage_util
 
 @pytest.fixture()
 def manager(tmp_path: Path) -> storage.StorageManager:
-    return storage.SharedFSStorageManager(str(tmp_path))
+    return storage.FileStorageManager(str(tmp_path))
 
 
 @pytest.fixture(params=[0, 1, 5])


### PR DESCRIPTION
A while ago, I decided that all forms of "magic" were wrong and that you
should always have to create a storage manager with an explicit
configuration (`container_path: Optional[str]`) that clearly indicated
if you were inside a container or on the host machine.

The idea was to have all the "magic" of detecting where you were
operating in the higher layers of the callstack, and to let the inner
layers of the callstack be as predictable and as explicit as possible.

But you know what?  The resulting API was terrible in all cases.  I
think that correct behavior of `shared_fs` storage manager is magical
by definition.

The result was that there was an overall crappy API, and there was a
missing feature: no super-simple FileStorageManager that took only a
single path as input.  While it's not clear if such a storage manager
would be widely useful to users on the cluster, the unit tests would be
a lot clearer if such a thing existed, and some day local training mode
would be too.

So to solve both of those problems, we let shared_fs be exactly as
magical as it was originally designed (based on the new ClusterInfo API)
and we introduce a FileStorageManager (currently, only accessible in
python).

## Commentary (optional)

I don't think it is obvious what this PR is trying to solve.  That's a bad thing; it's like a sign that maybe nothing was all that wrong to begin with, or maybe I didn't actually fix anything but just shuffled problems around.

Overall, I'm frustrated by a few things:
 - The inability to create the most basic-possible StorageManager with a simple constructor.  Well, technically, the StorageManager itself can be used for this purpose, even though it's explicitly documented to be an abstract base class.
 - The mix of abstract-base-classiness of the StorageManager with some partial and some complete implementations of some things.  The worst of these is the ridiculously simple `StorageManager.__init__()` which decreases the local understandability of the subclasses without offering _any_ useful behavior.  Setting a single attribute, wow, round of applause for the `StorageManager.__init__()`.

So in this PR, I added a clearer API to fix the first problem and also moved us a teeny bit closer to the "abstract base class with non-interacting concrete implementations".  I didn't fully solve the second problem to minimize conflict with https://github.com/determined-ai/determined/pull/2978, but that's the only reason why.  I find OO code with code execution that jumps back and forth between parent class and child class to be some of the most confusing way to write code.

But all things considered, I'm also ok just abandoning this PR and coming back to it with a more full rewrite of the code here (also in Tensorboard, though that code is closer to abstract-base-class-with-concrete-implementations already).