### PR TITLE
fix: update `helm push` command to `helm cm-push`

### DIFF
--- a/helm/Makefile
+++ b/helm/Makefile
@@ -17,4 +17,4 @@ release: export NGC_API_USERNAME ?=
 release: export NGC_API_KEY ?=
 release:
 	helm repo add determined $$NGC_REPO --username $$NGC_API_USERNAME --password $$NGC_API_KEY
-	helm push -f build/determined-latest.tgz determined
+	helm cm-push -f build/determined-latest.tgz determined


### PR DESCRIPTION
## Description

The name of the command was changed by the upstream package [1].

[1] https://github.com/chartmuseum/helm-push/commit/d7cc009a34f06eea26f87a03566a2c3f246d4394

## Test Plan

- [x] rerun failed push job in CI
