### PR TITLE
fix: update harness to handle telemetry being off

### DIFF
--- a/harness/determined/common/api/analytics.py
+++ b/harness/determined/common/api/analytics.py
@@ -2,8 +2,20 @@ import os
 
 import analytics
 
+analytics.write_key = os.environ.get("DET_SEGMENT_API_KEY")
+_cluster_id = os.environ.get("DET_CLUSTER_ID")
 
-def send_analytics(tracking_key: str) -> None:
-    analytics.write_key = os.environ.get("DET_SEGMENT_API_KEY")
-    if os.environ.get("DET_SEGMENT_ENABLED"):
-        analytics.track(os.environ.get("DET_CLUSTER_ID"), tracking_key)
+if (
+    os.environ.get("DET_SEGMENT_ENABLED") == "true"
+    and _cluster_id is not None
+    and analytics.write_key is not None
+):
+
+    def send_analytics(tracking_key: str) -> None:
+        analytics.track(_cluster_id, tracking_key)
+
+
+else:
+
+    def send_analytics(tracking_key: str) -> None:
+        pass

--- a/master/internal/core.go
+++ b/master/internal/core.go
@@ -571,7 +571,7 @@ func (m *Master) Run(ctx context.Context) error {
 		HarnessPath:           filepath.Join(m.config.Root, "wheels"),
 		TaskContainerDefaults: m.config.TaskContainerDefaults,
 		MasterCert:            cert,
-		SegmentEnabled:        m.config.Telemetry.Enabled,
+		SegmentEnabled:        m.config.Telemetry.Enabled && m.config.Telemetry.SegmentMasterKey != "",
 		SegmentAPIKey:         m.config.Telemetry.SegmentMasterKey,
 	}
 


### PR DESCRIPTION
## Description

Since the string "false" is truthy in Python, the harness would
previously attempt to run the analytics code even when telemetry was
disabled and no key was available, causing an exception.

Also update the master to avoid telling tasks that telemetry is on if no
key is actually configured.

## Test Plan

- [x] run master with telemetry off, check that experiments fail without the fix and run with it
