### PR TITLE
fix: write cluster_info.json in all non-cmd task types

### DIFF
--- a/master/static/srv/gc-checkpoints-entrypoint.sh
+++ b/master/static/srv/gc-checkpoints-entrypoint.sh
@@ -15,4 +15,6 @@ fi
 
 "$DET_PYTHON_EXECUTABLE" -m pip install -q --user /opt/determined/wheels/determined*.whl
 
+"$DET_PYTHON_EXECUTABLE" -m determined.exec.prep_container
+
 exec "$DET_PYTHON_EXECUTABLE" -m determined.exec.gc_checkpoints "$@"

--- a/master/static/srv/notebook-entrypoint.sh
+++ b/master/static/srv/notebook-entrypoint.sh
@@ -30,6 +30,8 @@ export SHELL
 
 "$DET_PYTHON_EXECUTABLE" -m pip install -q --user /opt/determined/wheels/determined*.whl
 
+"$DET_PYTHON_EXECUTABLE" -m determined.exec.prep_container --resources
+
 test -f "${STARTUP_HOOK}" && source "${STARTUP_HOOK}"
 
 exec "$DET_PYTHON_EXECUTABLE" /run/determined/jupyter/check_idle.py &

--- a/master/static/srv/shell-entrypoint.sh
+++ b/master/static/srv/shell-entrypoint.sh
@@ -19,6 +19,8 @@ fi
 
 "$DET_PYTHON_EXECUTABLE" -m pip install -q --user /opt/determined/wheels/determined*.whl
 
+"$DET_PYTHON_EXECUTABLE" -m determined.exec.prep_container --resources
+
 test -f "${STARTUP_HOOK}" && source "${STARTUP_HOOK}"
 
 # Prepend each key in authorized_keys with a set of environment="KEY=VALUE"

--- a/master/static/srv/tensorboard-entrypoint.sh
+++ b/master/static/srv/tensorboard-entrypoint.sh
@@ -16,6 +16,8 @@ fi
 
 "$DET_PYTHON_EXECUTABLE" -m pip install -q --user /opt/determined/wheels/determined*.whl
 
+"$DET_PYTHON_EXECUTABLE" -m determined.exec.prep_container
+
 # Install tensorboard if not already installed (for custom Pytorch images)
 "$DET_PYTHON_EXECUTABLE" -m pip install tensorboard
 "$DET_PYTHON_EXECUTABLE" -m pip install tensorboard-plugin-profile


### PR DESCRIPTION
## Commentary

The python cli `det e list` still fails inside of notebook containers if you've disabled the `determined` user, but it turns out that has been true forever (see DET-6123).