### PR TITLE
fix: master_config_path not being treated as Path

### DIFF
--- a/harness/determined/deploy/local/cli.py
+++ b/harness/determined/deploy/local/cli.py
@@ -43,7 +43,7 @@ def handle_logs(args: argparse.Namespace) -> None:
 def handle_master_up(args: argparse.Namespace) -> None:
     cluster_utils.master_up(
         port=args.master_port,
-        master_config_path=Path(args.master_config_path),
+        master_config_path=args.master_config_path,
         storage_host_path=args.storage_host_path,
         master_name=args.master_name,
         image_repo_prefix=args.image_repo_prefix,
@@ -202,13 +202,13 @@ args_description = Cmd(
                 Group(
                     Arg(
                         "--master-config-path",
-                        type=str,
+                        type=Path,
                         default=None,
                         help="path to master configuration",
                     ),
                     Arg(
                         "--storage-host-path",
-                        type=str,
+                        type=Path,
                         default=None,
                         help="Storage location for cluster data (e.g. checkpoints)",
                     ),


### PR DESCRIPTION
## Description

*Affects local deployment.*

When calling `handle_master_up()` in `deploy/local/cli.py`, `args.master_config_path` was sent as a `str` instead of `Path`, which is the required argument type of `cluster_utils.master_up()`.

## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
