### PR TITLE
feat: confirm before modifying an existing AWS stack in `det deploy` [DET-6128]

### DIFF
--- a/docs/release-notes/3117-confirm-cloudformation-updates.txt
+++ b/docs/release-notes/3117-confirm-cloudformation-updates.txt
@@ -1,0 +1,5 @@
+:orphan:
+
+**Improvements**
+
+-  Deploy: Will now confirm potentially destructive updates on AWS unless --no-prompt is specified.

--- a/harness/determined/deploy/aws/aws.py
+++ b/harness/determined/deploy/aws/aws.py
@@ -308,6 +308,7 @@ def deploy_stack(
     template_body: str,
     keypair: str,
     boto3_session: boto3.session.Session,
+    no_prompt: bool,
     parameters: Optional[List] = None,
 ) -> None:
     cfn = boto3_session.client("cloudformation")
@@ -316,6 +317,15 @@ def deploy_stack(
     check_keypair(keypair, boto3_session)
     if stack_exists(stack_name, boto3_session):
         print("True - Updating Stack")
+
+        if not no_prompt:
+            val = input(
+                "If --deployment-type has changed, updating the stack may reset the database. "
+                "Are you sure you want to proceed? [y/n]"
+            )
+            if val.lower() != "y":
+                print("Update cancelled.")
+                sys.exit(1)
 
         update_stack(stack_name, template_body, boto3_session, parameters)
     else:

--- a/harness/determined/deploy/aws/aws.py
+++ b/harness/determined/deploy/aws/aws.py
@@ -356,7 +356,7 @@ def deploy_stack(
         if not no_prompt:
             tags = get_tags(stack_name, boto3_session)
             prompt_needed = False
-            if not constants.deployment_types.TYPE_TAG_KEY in tags:
+            if constants.deployment_types.TYPE_TAG_KEY not in tags:
                 print("Previous value of --deployment-type is not known.")
                 prompt_needed = True
             elif tags[constants.deployment_types.TYPE_TAG_KEY] != deployment_type:

--- a/harness/determined/deploy/aws/aws.py
+++ b/harness/determined/deploy/aws/aws.py
@@ -113,7 +113,7 @@ def delete(stack_name: str, boto3_session: boto3.session.Session) -> None:
     delete_stack(stack_name, boto3_session)
 
 
-def get_tags(stack_name: str, boto3_session: boto3.session.Session) -> bool:
+def get_tags(stack_name: str, boto3_session: boto3.session.Session) -> Dict[Any, Any]:
     cfn = boto3_session.client("cloudformation")
 
     print(f"Retrieving tags for CloudFormation Stack ({stack_name})")

--- a/harness/determined/deploy/aws/aws.py
+++ b/harness/determined/deploy/aws/aws.py
@@ -372,7 +372,7 @@ def deploy_stack(
 
             if prompt_needed:
                 val = input(
-                    "If --deployment-type has changed, updating the stack may erase the database. "
+                    "If --deployment-type has changed, updating the stack may erase the database.\n"
                     "Are you sure you want to proceed? [y/N]"
                 )
                 if val.lower() != "y":

--- a/harness/determined/deploy/aws/aws.py
+++ b/harness/determined/deploy/aws/aws.py
@@ -119,8 +119,8 @@ def get_tags(stack_name: str, boto3_session: boto3.session.Session) -> bool:
     print(f"Retrieving tags for CloudFormation Stack ({stack_name})")
 
     description = cfn.describe_stacks(StackName=stack_name)
-    stack = description['Stacks'][0]
-    return {x['Key']: x['Value'] for x in stack['Tags']}
+    stack = description["Stacks"][0]
+    return {x["Key"]: x["Value"] for x in stack["Tags"]}
 
 
 # Cloudformation
@@ -195,7 +195,9 @@ def update_stack(
             )
         else:
             cfn.update_stack(
-                StackName=stack_name, TemplateBody=template_body, Capabilities=["CAPABILITY_IAM"],
+                StackName=stack_name,
+                TemplateBody=template_body,
+                Capabilities=["CAPABILITY_IAM"],
                 Tags=[
                     {
                         "Key": constants.deployment_types.TYPE_TAG_KEY,

--- a/harness/determined/deploy/aws/aws.py
+++ b/harness/determined/deploy/aws/aws.py
@@ -358,13 +358,13 @@ def deploy_stack(
             prompt_needed = False
             if constants.deployment_types.TYPE_TAG_KEY not in tags:
                 print()
-                print("Previous value of --deployment-type is not known. Versions of Determined as late")
-                print("as 0.17.2 did not annotate deployed clusters, and it was the responsibility of")
-                print("the user to make updates with the same --deployment-type. Note that if you are")
-                print("sure you did not set --deployment-type before, your cluster would have deployed")
-                print("as --deployment-type simple (the default).")
+                print("Previous value of --deployment-type is unknown. Versions of `det` prior to")
+                print("0.17.3 did not annotate deployed clusters, and it was the responsibility of")
+                print("the user to make updates with the same --deployment-type. Note that if you")
+                print("are sure --deployment-type was not set before, your cluster would have")
+                print("deployed as --deployment-type simple (the default).")
                 print()
-                
+
                 prompt_needed = True
             elif tags[constants.deployment_types.TYPE_TAG_KEY] != deployment_type:
                 print("Value of --deployment-type has changed!")

--- a/harness/determined/deploy/aws/aws.py
+++ b/harness/determined/deploy/aws/aws.py
@@ -357,7 +357,14 @@ def deploy_stack(
             tags = get_tags(stack_name, boto3_session)
             prompt_needed = False
             if constants.deployment_types.TYPE_TAG_KEY not in tags:
-                print("Previous value of --deployment-type is not known.")
+                print()
+                print("Previous value of --deployment-type is not known. Versions of Determined as late")
+                print("as 0.17.2 did not annotate deployed clusters, and it was the responsibility of")
+                print("the user to make updates with the same --deployment-type. Note that if you are")
+                print("sure you did not set --deployment-type before, your cluster would have deployed")
+                print("as --deployment-type simple (the default).")
+                print()
+                
                 prompt_needed = True
             elif tags[constants.deployment_types.TYPE_TAG_KEY] != deployment_type:
                 print("Value of --deployment-type has changed!")
@@ -369,7 +376,7 @@ def deploy_stack(
                     "Are you sure you want to proceed? [y/N]"
                 )
                 if val.lower() != "y":
-                    print("Update cancelled.")
+                    print("Update canceled.")
                     sys.exit(1)
 
         update_stack(stack_name, template_body, boto3_session, deployment_type, parameters)

--- a/harness/determined/deploy/aws/cli.py
+++ b/harness/determined/deploy/aws/cli.py
@@ -491,7 +491,7 @@ args_description = Cmd(
                 Arg(
                     "--no-prompt",
                     action="store_true",
-                    help="no prompt when deleting existing resources",
+                    help="no prompt when deployment would delete existing database",
                 ),
             ],
         ),

--- a/harness/determined/deploy/aws/cli.py
+++ b/harness/determined/deploy/aws/cli.py
@@ -109,7 +109,7 @@ def deploy_aws(command: str, args: argparse.Namespace) -> None:
             val = input(
                 "Deleting an AWS stack will lose all your data, including the created network "
                 "file system. Please back up the file system before deleting it. Do you still "
-                "want to delete the stack? [y/n]"
+                "want to delete the stack? [y/N]"
             )
             if val.lower() != "y":
                 print("Delete cancelled.")

--- a/harness/determined/deploy/aws/cli.py
+++ b/harness/determined/deploy/aws/cli.py
@@ -207,7 +207,7 @@ def deploy_aws(command: str, args: argparse.Namespace) -> None:
 
     print("Starting Determined Deployment")
     try:
-        deployment_object.deploy()
+        deployment_object.deploy(args.no_prompt)
     except NoCredentialsError:
         error_no_credentials()
     except Exception as e:
@@ -487,6 +487,11 @@ args_description = Cmd(
                     help="preexisting FSx that will be mounted into the task containers; "
                     "if not provided, a new FSx instance will be created.  Note that you need"
                     "to ensure that the agents can connect to the FSx instance.",
+                ),
+                Arg(
+                    "--no-prompt",
+                    action="store_true",
+                    help="no prompt when deleting existing resources",
                 ),
             ],
         ),

--- a/harness/determined/deploy/aws/constants.py
+++ b/harness/determined/deploy/aws/constants.py
@@ -6,6 +6,7 @@ class deployment_types:
     FSX = "fsx"
     GOVCLOUD = "govcloud"
     DEPLOYMENT_TYPES = [SIMPLE, SECURE, VPC, EFS, FSX, GOVCLOUD]
+    TYPE_TAG_KEY = "deployment-type"
 
 
 class defaults:

--- a/harness/determined/deploy/aws/deployment_types/base.py
+++ b/harness/determined/deploy/aws/deployment_types/base.py
@@ -36,7 +36,7 @@ class DeterminedDeployment(metaclass=abc.ABCMeta):
         self.parameters = parameters
 
     @abc.abstractmethod
-    def deploy(self) -> None:
+    def deploy(self, no_prompt: bool) -> None:
         pass
 
     def print(self) -> None:

--- a/harness/determined/deploy/aws/deployment_types/govcloud.py
+++ b/harness/determined/deploy/aws/deployment_types/govcloud.py
@@ -56,6 +56,6 @@ class Govcloud(base.DeterminedDeployment):
             boto3_session=self.parameters[constants.cloudformation.BOTO3_SESSION],
             parameters=cfn_parameters,
             no_prompt=no_prompt,
-            deployment_type = self.deployment_type,
+            deployment_type=self.deployment_type,
         )
         self.print_results()

--- a/harness/determined/deploy/aws/deployment_types/govcloud.py
+++ b/harness/determined/deploy/aws/deployment_types/govcloud.py
@@ -12,6 +12,7 @@ class Govcloud(base.DeterminedDeployment):
     )
 
     template = "govcloud.yaml"
+    deployment_type = constants.deployment_types.GOVCLOUD
 
     template_parameter_keys = [
         constants.cloudformation.ENABLE_CORS,
@@ -55,5 +56,6 @@ class Govcloud(base.DeterminedDeployment):
             boto3_session=self.parameters[constants.cloudformation.BOTO3_SESSION],
             parameters=cfn_parameters,
             no_prompt=no_prompt,
+            deployment_type = self.deployment_type,
         )
         self.print_results()

--- a/harness/determined/deploy/aws/deployment_types/govcloud.py
+++ b/harness/determined/deploy/aws/deployment_types/govcloud.py
@@ -42,7 +42,7 @@ class Govcloud(base.DeterminedDeployment):
         constants.cloudformation.MASTER_CONFIG_TEMPLATE,
     ]
 
-    def deploy(self) -> None:
+    def deploy(self, no_prompt: bool) -> None:
         cfn_parameters = self.consolidate_parameters()
         self.before_deploy_print()
         with open(self.template_path) as f:
@@ -54,5 +54,6 @@ class Govcloud(base.DeterminedDeployment):
             keypair=self.parameters[constants.cloudformation.KEYPAIR],
             boto3_session=self.parameters[constants.cloudformation.BOTO3_SESSION],
             parameters=cfn_parameters,
+            no_prompt=no_prompt,
         )
         self.print_results()

--- a/harness/determined/deploy/aws/deployment_types/secure.py
+++ b/harness/determined/deploy/aws/deployment_types/secure.py
@@ -24,6 +24,7 @@ class Secure(base.DeterminedDeployment):
         "yellow",
     )
     template = "secure.yaml"
+    deployment_type = constants.deployment_types.SECURE
 
     template_parameter_keys = [
         constants.cloudformation.ENABLE_CORS,
@@ -64,6 +65,7 @@ class Secure(base.DeterminedDeployment):
             boto3_session=self.parameters[constants.cloudformation.BOTO3_SESSION],
             parameters=cfn_parameters,
             no_prompt=no_prompt,
+            deployment_type=self.deployment_type,
         )
         self.print_results()
 

--- a/harness/determined/deploy/aws/deployment_types/secure.py
+++ b/harness/determined/deploy/aws/deployment_types/secure.py
@@ -51,7 +51,7 @@ class Secure(base.DeterminedDeployment):
         constants.cloudformation.MASTER_CONFIG_TEMPLATE,
     ]
 
-    def deploy(self) -> None:
+    def deploy(self, no_prompt: bool) -> None:
         self.before_deploy_print()
         cfn_parameters = self.consolidate_parameters()
         with open(self.template_path) as f:
@@ -63,6 +63,7 @@ class Secure(base.DeterminedDeployment):
             keypair=self.parameters[constants.cloudformation.KEYPAIR],
             boto3_session=self.parameters[constants.cloudformation.BOTO3_SESSION],
             parameters=cfn_parameters,
+            no_prompt=no_prompt,
         )
         self.print_results()
 

--- a/harness/determined/deploy/aws/deployment_types/simple.py
+++ b/harness/determined/deploy/aws/deployment_types/simple.py
@@ -34,7 +34,7 @@ class Simple(base.DeterminedDeployment):
         constants.cloudformation.MASTER_CONFIG_TEMPLATE,
     ]
 
-    def deploy(self) -> None:
+    def deploy(self, no_prompt: bool) -> None:
         cfn_parameters = self.consolidate_parameters()
         self.before_deploy_print()
         with open(self.template_path) as f:
@@ -46,5 +46,6 @@ class Simple(base.DeterminedDeployment):
             keypair=self.parameters[constants.cloudformation.KEYPAIR],
             boto3_session=self.parameters[constants.cloudformation.BOTO3_SESSION],
             parameters=cfn_parameters,
+            no_prompt=no_prompt,
         )
         self.print_results()

--- a/harness/determined/deploy/aws/deployment_types/simple.py
+++ b/harness/determined/deploy/aws/deployment_types/simple.py
@@ -4,6 +4,7 @@ from determined.deploy.aws.deployment_types import base
 
 class Simple(base.DeterminedDeployment):
     template = "simple.yaml"
+    deployment_type = constants.deployment_types.SIMPLE
 
     template_parameter_keys = [
         constants.cloudformation.ENABLE_CORS,
@@ -47,5 +48,6 @@ class Simple(base.DeterminedDeployment):
             boto3_session=self.parameters[constants.cloudformation.BOTO3_SESSION],
             parameters=cfn_parameters,
             no_prompt=no_prompt,
+            deployment_type=self.deployment_type,
         )
         self.print_results()

--- a/harness/determined/deploy/aws/deployment_types/vpc.py
+++ b/harness/determined/deploy/aws/deployment_types/vpc.py
@@ -32,7 +32,7 @@ class VPC(base.DeterminedDeployment):
         constants.cloudformation.MOUNT_FSX_ID,
     ]
 
-    def deploy(self) -> None:
+    def deploy(self, no_prompt: bool) -> None:
         self.before_deploy_print()
         cfn_parameters = self.consolidate_parameters()
         with open(self.template_path) as f:
@@ -44,6 +44,7 @@ class VPC(base.DeterminedDeployment):
             keypair=self.parameters[constants.cloudformation.KEYPAIR],
             boto3_session=self.parameters[constants.cloudformation.BOTO3_SESSION],
             parameters=cfn_parameters,
+            no_prompt=no_prompt,
         )
         self.print_results()
 

--- a/harness/determined/deploy/aws/deployment_types/vpc.py
+++ b/harness/determined/deploy/aws/deployment_types/vpc.py
@@ -4,6 +4,7 @@ from determined.deploy.aws.deployment_types import base
 
 class VPC(base.DeterminedDeployment):
     template = "vpc.yaml"
+    deployment_type = constants.deployment_types.VPC
 
     template_parameter_keys = [
         constants.cloudformation.ENABLE_CORS,
@@ -45,13 +46,16 @@ class VPC(base.DeterminedDeployment):
             boto3_session=self.parameters[constants.cloudformation.BOTO3_SESSION],
             parameters=cfn_parameters,
             no_prompt=no_prompt,
+            deployment_type=self.deployment_type,
         )
         self.print_results()
 
 
 class FSx(VPC):
     template = "fsx.yaml"
+    deployment_type = constants.deployment_types.FSX
 
 
 class EFS(VPC):
     template = "efs.yaml"
+    deployment_type = constants.deployment_types.EFS


### PR DESCRIPTION
## Description

Changing from a simple deployment an EFS deployment for example, will cause the database to be recreated because of the change to put everything inside a VPC. CloudFormation doesn't provide a good mechanism to check for this dynamically, so on any update we'll just confirm before proceeding.

## Test Plan

I tested new deployments, updated deployments, both approved and un-approved, and the use of the --no-prompt flag, etc.