### PR TITLE
docs: normalize case of language names in code blocks

### DIFF
--- a/docs/post-training/model-registry.txt
+++ b/docs/post-training/model-registry.txt
@@ -61,15 +61,15 @@ The following example demonstrates how to add a new model to the registry;
 :class:`~determined.experimental.Model` class. The new model will not have any versions (model
 checkpoints) associated with it; adding versions to a model is described below.
 
-.. code:: Python
+.. code:: python
 
    from determined.experimental import Determined
 
    model = Determined().create_model(
-             "model_name",
-             description="optional description",
-             metadata={"optional": "JSON serializable dictionary"}
-           )
+       "model_name",
+       description="optional description",
+       metadata={"optional": "JSON serializable dictionary"},
+   )
 
 Similarly, you can create a model from the CLI using the following command.
 

--- a/docs/sysadmin-deploy-on-k8s/install-on-kubernetes.txt
+++ b/docs/sysadmin-deploy-on-k8s/install-on-kubernetes.txt
@@ -314,7 +314,7 @@ Tolerations
 
 To specify a toleration, use the ``toleration`` field in the PodSpec.
 
-.. code:: YAML
+.. code:: yaml
 
    tolerations:
       - key: "${TAINT_TYPE}"
@@ -325,7 +325,7 @@ To specify a toleration, use the ``toleration`` field in the PodSpec.
 The following example is a toleration for when a node has the ``accelerator`` taint type equal to
 the ``gpu`` taint value.
 
-.. code:: YAML
+.. code:: yaml
 
    tolerations:
       - key: "accelerator"
@@ -335,7 +335,7 @@ the ``gpu`` taint value.
 
 The next example is a toleration for when a node has the ``gpu`` taint type.
 
-.. code:: YAML
+.. code:: yaml
 
    tolerations:
       - key: "gpu"

--- a/docs/sysadmin-deploy-on-k8s/setup-eks-cluster.txt
+++ b/docs/sysadmin-deploy-on-k8s/setup-eks-cluster.txt
@@ -52,7 +52,7 @@ cluster creation with either command line arguments or a cluster config file. Be
 config that deploys a managed node group for Determined's master instance, as well as an autoscaling
 GPU node group for workers. To fill in the template, insert the cluster name and S3 bucket name.
 
-.. code:: YAML
+.. code:: yaml
 
    apiVersion: eksctl.io/v1alpha5
    kind: ClusterConfig
@@ -220,7 +220,7 @@ After finding the particular release you want, click on the release and scroll t
 a list of image URLs. Example:
 https://github.com/kubernetes/autoscaler/releases/tag/cluster-autoscaler-1.20.0
 
-.. code:: YAML
+.. code:: yaml
 
    apiVersion: apps/v1
    kind: Deployment
@@ -300,7 +300,7 @@ account must be specified in order to allow Determined to save checkpoints to S3
 there are tainted nodes, must be listed for the experiment to be scheduled. An example of the
 necessary changes is shown here:
 
-.. code:: YAML
+.. code:: yaml
 
    environment:
      pod_spec:


### PR DESCRIPTION
## Description

The usage should be internally consistent, since the case can matter in
some circumstances. The text formatting change is because rstfmt is
using case-sensitive matching to determine how to format code
blocks (which should and will be changed to match Pygments, but fixing
the case here is better regardless).

## Test Plan

- [x] render and examine docs
