### PR TITLE
chore: prevent NaNs from polluting HP importance [DET-6119]

### DIFF
--- a/master/internal/hpimportance/hpimportance.go
+++ b/master/internal/hpimportance/hpimportance.go
@@ -13,6 +13,7 @@ import (
 	"encoding/csv"
 	"fmt"
 	"io"
+	"math"
 	"os"
 	"os/exec"
 	"path"
@@ -170,9 +171,12 @@ func parseImportanceOutput(filename string) (map[string]float64, error) {
 		if record[1] == "metric" || record[1] == "numBatches" {
 			continue
 		}
-		hpi[record[1]], err = strconv.ParseFloat(record[2], 64)
+		value, err := strconv.ParseFloat(record[2], 64)
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse HP importance value: %w", err)
+		}
+		if !math.IsNaN(value) && !math.IsInf(value, 0) {
+			hpi[record[1]] = value
 		}
 	}
 	return hpi, nil


### PR DESCRIPTION
## Description

We have apparently been getting NaNs in this data. CloudForest will sometimes do that even with > 50 trials. We should just not record data if CloudForest couldn't generate a figure. Also enhancing the error messages to allow us to do better should this come up again - they were previously identical and didn't tell you which experiment was at which point.

## Test Plan

Ran through existing tests of this feature to ensure no regressions. Reproducing these NaNs is non-deterministic and I haven't been able to do it very well. That's one reason for the added detail in error messages should this happen again.