### PR TITLE
ci: switch release ordering of Docker and PyPi publishing [DET-5195]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2491,13 +2491,6 @@ workflows:
             - build-helm
             - build-proto
 
-      - publish-python-package:
-          matrix:
-            parameters:
-              path: ["harness", "common", "cli", "deploy", "model_hub"]
-          context: determined-production
-          filters: *release-and-rc-filters
-
       - package-and-push-system-rc:
           requires:
             - build-react
@@ -2505,12 +2498,32 @@ workflows:
           context: determined-production
           filters: *rc-filters
 
+      - publish-python-package:
+          name: publish-python-package-rc
+          matrix:
+            parameters:
+              path: ["harness", "common", "cli", "deploy", "model_hub"]
+          context: determined-production
+          filters: *rc-filters
+          requires:
+            - package-and-push-system-rc
+
       - package-and-push-system-release:
           requires:
             - build-react
             - build-docs
           context: determined-production
           filters: *release-filters
+
+      - publish-python-package:
+          name: publish-python-package-release
+          matrix:
+            parameters:
+              path: ["harness", "common", "cli", "deploy", "model_hub"]
+          context: determined-production
+          filters: *release-filters
+          requires:
+            - package-and-push-system-release
 
       - publish-docs:
           requires:


### PR DESCRIPTION
## Description

This is a reincarnation of https://github.com/determined-ai/determined/pull/2656 with a different (hopefully working) solution: explicitly specifying dependencies instead of just changing the order in the definition. As there are 2 possible dependencies depending on the branch, and I don't see a way to express that alone, there are now 2 jobs, 1 with each dependency, and they are filtered by branch like the corresponding dependencies.

## Test Plan

As before! I already ensured the CircleCI config at least gets parsed successfully.