### PR TITLE
fix: non-scalar nan handling

### DIFF
--- a/harness/determined/_generic/_searcher.py
+++ b/harness/determined/_generic/_searcher.py
@@ -5,7 +5,6 @@ from typing import Iterator, Optional
 
 import determined as det
 from determined.common.experimental.session import Session
-from determined.common.util import clearinf
 
 logger = logging.getLogger("determined.generic")
 
@@ -77,15 +76,13 @@ class SearcherOp:
         if math.isnan(searcher_metric):
             raise RuntimeError("searcher_metric may not be NaN")
         self._completed = True
-        body = clearinf(
+        body = det.util.clearinf(
             {
                 "op": {
-                    "length": clearinf(
-                        {
-                            "length": self._length,
-                            "unit": self._unit.value,
-                        }
-                    )
+                    "length": {
+                        "length": self._length,
+                        "unit": self._unit.value,
+                    }
                 },
                 "searcherMetric": searcher_metric,
             }

--- a/harness/determined/_generic/_training.py
+++ b/harness/determined/_generic/_training.py
@@ -7,7 +7,6 @@ import determined as det
 from determined import tensorboard
 from determined.common.api import errors
 from determined.common.experimental.session import Session
-from determined.common.util import clearinf
 
 logger = logging.getLogger("determined.generic")
 
@@ -60,10 +59,10 @@ class Training:
         body = {
             "trial_run_id": self._run_id,
             "latest_batch": latest_batch,
-            "metrics": clearinf(metrics),
+            "metrics": det.util.clearinf(metrics),
         }
         if batch_metrics is not None:
-            body["batch_metrics"] = list(map(clearinf, batch_metrics))
+            body["batch_metrics"] = det.util.clearinf(batch_metrics)
         logger.info(f"report_training_metrics(latest_batch={latest_batch}, metrics={metrics})")
         self._session.post(
             f"/api/v1/trials/{self._trial_id}/training_metrics",
@@ -120,7 +119,7 @@ class Training:
         body = {
             "trial_run_id": self._run_id,
             "latest_batch": latest_batch,
-            "metrics": clearinf(reportable_metrics),
+            "metrics": det.util.clearinf(reportable_metrics),
         }
         logger.info(f"report_validation_metrics(latest_batch={latest_batch}, metrics={metrics})")
         self._session.post(

--- a/harness/determined/common/util.py
+++ b/harness/determined/common/util.py
@@ -1,6 +1,5 @@
 import functools
 import io
-import math
 import os
 import pathlib
 import platform
@@ -128,15 +127,3 @@ def get_config_path() -> pathlib.Path:
         config_path = pathlib.Path.home().joinpath(".config")
 
     return config_path.joinpath("determined")
-
-
-# serialize single result or batch which may have inf/nan
-def clearinf(okv: dict) -> dict:
-    for k in okv.keys():
-        if okv[k] == math.inf:
-            okv[k] = "Infinity"
-        elif okv[k] == -1 * math.inf:
-            okv[k] = "-Infinity"
-        elif isinstance(okv[k], float) and math.isnan(okv[k]):
-            okv[k] = "NaN"
-    return okv


### PR DESCRIPTION
As a quick release-party fix, add a post-processing step to catch NaN's in arrays.

This means we do a pre-processing step and a post-processing step.  This is less code (better for a release party fix) but the long-term fix will involve replacing simplejson.dumps, which doesn't allow us to customize handling of python-native types.