### PR TITLE
fix: fail non-restartable tasks on allocation termination [DET-6158]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -140,6 +140,7 @@ commands:
       - run: PATH=$HOME/.local/bin:$PATH make -C proto build
       - run: make -C master get-deps
       - run: make -C agent get-deps
+      - install-devcluster
       - start-devcluster:
           target-stage: elastic
           devcluster-config: elastic.devcluster.yaml
@@ -295,6 +296,9 @@ commands:
       master-cert-name:
         type: string
         default: ""
+      managed-devcluster:
+        type: boolean
+        default: false
     steps:
       - run:
           name: Split tests
@@ -313,10 +317,13 @@ commands:
             echo "Running tests from these files:"
             sed 's/^/- /' </tmp/tests-to-run
 
-      - wait-for-master:
-          scheme: <<parameters.master-scheme>>
-          host: <<parameters.master-host>>
-          port: <<parameters.master-port>>
+      - unless:
+          condition: <<parameters.managed-devcluster>>
+          steps:
+            - wait-for-master:
+                scheme: <<parameters.master-scheme>>
+                host: <<parameters.master-host>>
+                port: <<parameters.master-port>>
 
       - run:
           name: Run e2e tests
@@ -836,6 +843,10 @@ commands:
       - run: make -C master check
       - run: make -C agent check
 
+  install-devcluster:
+    steps:
+      - run: pip install git+https://github.com/determined-ai/devcluster.git@v1.1.0#egg=devcluster
+
   start-devcluster:
     parameters:
       devcluster-config:
@@ -845,7 +856,6 @@ commands:
         type: string
         default: agent1
     steps:
-      - run: pip install git+https://github.com/determined-ai/devcluster.git@1b9749e26271bbfae8a672f1ffe4ba82884bb9f7#egg=devcluster
       - run:
           command: devcluster --oneshot -c .circleci/devcluster/<<parameters.devcluster-config>> --target-stage <<parameters.target-stage>>
           background: true
@@ -1081,6 +1091,7 @@ jobs:
       - run: sudo cp .circleci/packaging/agent.yaml /etc/determined/agent.yaml
       - setup-python-venv:
           executor: ubuntu-2004:202101-01
+      - install-devcluster
       - start-devcluster:
           target-stage: db
       - run: python3 .circleci/scripts/wait_for_server.py localhost 5432
@@ -1105,6 +1116,7 @@ jobs:
           executor: ubuntu-2004:202101-01
 
       - run: make -C master get-deps
+      - install-devcluster
       - start-devcluster
       - run: python3 .circleci/scripts/wait_for_server.py localhost 8080
 
@@ -1406,6 +1418,9 @@ jobs:
       target-stage:
         type: string
         default: agent1
+      managed-devcluster:
+        type: boolean
+        default: false
     machine:
       image: ubuntu-2004:202101-01
     resource_class: large
@@ -1424,9 +1439,13 @@ jobs:
           name: Get master dependencies
           command: make -C master get-deps
 
-      - start-devcluster:
-          devcluster-config: <<parameters.devcluster-config>>
-          target-stage: <<parameters.target-stage>>
+      - install-devcluster
+      - unless:
+          condition: <<parameters.managed-devcluster>>
+          steps:
+            - start-devcluster:
+                devcluster-config: <<parameters.devcluster-config>>
+                target-stage: <<parameters.target-stage>>
 
       - pull-task-images:
           tf1: <<parameters.tf1>>
@@ -1435,6 +1454,7 @@ jobs:
       - run-e2e-tests:
           mark: <<parameters.mark>>
           master-host: localhost
+          managed-devcluster: <<parameters.managed-devcluster>>
 
       - store_test_results:
           path: /tmp/test-results/
@@ -1884,6 +1904,16 @@ workflows:
           tf2: true
           mark: e2e_cpu_2a
           target-stage: agent2
+
+      - test-e2e:
+          name: test-e2e-managed-devcluster
+          requires:
+            - build-go
+          parallelism: 1
+          tf1: false
+          tf2: true
+          mark: managed_devcluster
+          managed-devcluster: true
 
       - test-e2e-webui:
           requires:

--- a/e2e_tests/pytest.ini
+++ b/e2e_tests/pytest.ini
@@ -11,13 +11,13 @@ markers =
     e2e_gpu: end to end GPU tests
     gpu_required: tests with a hard CUDA requirement
     distributed: distributed training tests
-    cloud: cloud tests
     parallel: parallel, multi-gpu tests
     model_hub_transformers: model_hub_transformers tests
     model_hub_transformers_amp: model_hub_transformers_amp tests
     model_hub_mmdetection: model_hub_mmdetection tests
     nightly: nightly tests
     det_deploy_local: test det deploy local
+    managed_devcluster: cluster tests that require a pytest-side managed cluster
 junit_logging = all
 filterwarnings =
 		ignore:::tensorflow.python.framework.tensor_util

--- a/e2e_tests/tests/cluster/test_agent_restart.py
+++ b/e2e_tests/tests/cluster/test_agent_restart.py
@@ -1,0 +1,226 @@
+import json
+import os
+import subprocess
+import time
+from typing import Any, Dict, Iterator, List, Tuple, cast
+
+import pytest
+
+from tests import config as conf
+from tests import experiment as exp
+
+from .utils import get_command_info, run_command, wait_for_command_state
+
+DEVCLUSTER_CONFIG_PATH = conf.PROJECT_ROOT_PATH.joinpath(
+    ".circleci/devcluster/double.devcluster.yaml"
+)
+
+
+def _get_agent_data(master_url: str) -> List[Dict[str, Any]]:
+    command = ["det", "-m", master_url, "agent", "list", "--json"]
+    output = subprocess.check_output(command).decode()
+    agent_data = cast(List[Dict[str, Any]], json.loads(output))
+    return agent_data
+
+
+class ManagedCluster:
+    # This utility wrapper uses double agent yaml configurations,
+    # but provides helpers to run/kill a single agent setup.
+
+    def __init__(self) -> None:
+        # Strategically only import devcluster on demand to avoid having it as a hard dependency.
+        from devcluster import Devcluster
+
+        self.dc = Devcluster(config=str(DEVCLUSTER_CONFIG_PATH))
+        self.master_url = conf.make_master_url()
+
+    def __enter__(self) -> "ManagedCluster":
+        self.old_cd = os.getcwd()
+        os.chdir(str(conf.PROJECT_ROOT_PATH))
+        self.dc.__enter__()
+        return self
+
+    def __exit__(self, *_: Any) -> None:
+        os.chdir(self.old_cd)
+        self.dc.__exit__(*_)
+
+    def initial_startup(self) -> None:
+        self.dc.set_target("agent1", wait=True, timeout=3 * 60)
+
+    def kill_agent(self) -> None:
+        self.dc.kill_stage("agent1")
+
+        WAIT_FOR_KILL = 5
+        for _i in range(WAIT_FOR_KILL):
+            agent_data = _get_agent_data(self.master_url)
+            if len(agent_data) == 0:
+                break
+            if len(agent_data) == 1 and agent_data[0]["draining"] is True:
+                break
+            time.sleep(1)
+        else:
+            pytest.fail(f"Agent is still present after {WAIT_FOR_KILL} seconds")
+
+    def restart_agent(self) -> None:
+        agent_data = _get_agent_data(self.master_url)
+        if len(agent_data) == 1 and agent_data[0]["enabled"]:
+            return
+
+        # Currently, we've got to wait for master to "forget" the agent before reconnecting.
+        WAIT_FOR_AMNESIA = 60
+        for _i in range(WAIT_FOR_AMNESIA):
+            agent_data = _get_agent_data(self.master_url)
+            if len(agent_data) == 0:
+                break
+            time.sleep(1)
+        else:
+            pytest.fail(f"Agent is still not forgotten after {WAIT_FOR_AMNESIA} seconds")
+
+        self.dc.restart_stage("agent1", wait=True, timeout=10)
+
+        WAIT_FOR_STARTUP = 10
+        for _i in range(WAIT_FOR_STARTUP):
+            agent_data = _get_agent_data(self.master_url)
+            if (
+                len(agent_data) == 1
+                and agent_data[0]["enabled"] is True
+                and agent_data[0]["draining"] is False
+            ):
+                break
+            time.sleep(1)
+        else:
+            pytest.fail(f"Agent didn't restart after {WAIT_FOR_STARTUP} seconds")
+
+    def ensure_agent_ok(self) -> None:
+        agent_data = _get_agent_data(self.master_url)
+        assert len(agent_data) == 1
+        assert agent_data[0]["enabled"] is True
+        assert agent_data[0]["draining"] is False
+
+
+@pytest.fixture(scope="session")
+def managed_cluster() -> Iterator[ManagedCluster]:
+    with ManagedCluster() as mc:
+        mc.initial_startup()
+        yield mc
+
+
+@pytest.mark.managed_devcluster
+def test_managed_cluster_working(managed_cluster: ManagedCluster) -> None:
+    try:
+        managed_cluster.ensure_agent_ok()
+        managed_cluster.kill_agent()
+    finally:
+        managed_cluster.restart_agent()
+
+
+def _local_container_ids_with_labels() -> Iterator[Tuple[str, str]]:
+    lines = (
+        subprocess.check_output(["docker", "ps", "--format", "{{.ID}}\t{{.Labels}}"])
+        .decode("utf-8")
+        .strip()
+        .split("\n")
+    )
+    for line in lines:
+        container_id, *labels = line.strip().split("\t")
+        yield container_id, (labels[0] if labels else "")
+
+
+def _local_container_ids_for_experiment(exp_id: int) -> Iterator[str]:
+    for container_id, labels in _local_container_ids_with_labels():
+        if f"/experiments/{exp_id}/" in labels:
+            yield container_id
+
+
+def _local_container_ids_for_command(command_id: str) -> Iterator[str]:
+    for container_id, labels in _local_container_ids_with_labels():
+        if f"/commands/{command_id}/" in labels:
+            yield container_id
+
+
+def _task_list_json(master_url: str) -> Dict[str, Dict[str, Any]]:
+    command = ["det", "-m", master_url, "task", "list", "--json"]
+    tasks_data: Dict[str, Dict[str, Any]] = json.loads(subprocess.check_output(command).decode())
+    return tasks_data
+
+
+@pytest.mark.managed_devcluster
+def test_agent_restart_exp_container_failure(managed_cluster: ManagedCluster) -> None:
+    managed_cluster.ensure_agent_ok()
+    try:
+        exp_id = exp.create_experiment(
+            conf.fixtures_path("no_op/single-medium-train-step.yaml"),
+            conf.fixtures_path("no_op"),
+            None,
+        )
+        exp.wait_for_experiment_workload_progress(exp_id)
+        container_ids = list(_local_container_ids_for_experiment(exp_id))
+        if len(container_ids) != 1:
+            pytest.fail(
+                f"unexpected number of local containers for the experiment: {len(container_ids)}"
+            )
+        # Get task id / allocation id
+        tasks_data = _task_list_json(managed_cluster.master_url)
+        assert len(tasks_data) == 1
+        exp_task_before = list(tasks_data.values())[0]
+
+        managed_cluster.kill_agent()
+        subprocess.check_call(["docker", "kill", container_ids[0]])
+    except Exception:
+        managed_cluster.restart_agent()
+        raise
+    else:
+        managed_cluster.restart_agent()
+        # As soon as the agent is back, the original allocation should be considered dead,
+        # but the new one should be allocated.
+        state = exp.experiment_state(exp_id)
+        assert state == "ACTIVE"
+        tasks_data = _task_list_json(managed_cluster.master_url)
+        assert len(tasks_data) == 1
+        exp_task_after = list(tasks_data.values())[0]
+
+        assert exp_task_before["task_id"] == exp_task_after["task_id"]
+        assert exp_task_before["allocation_id"] != exp_task_after["allocation_id"]
+
+        exp.wait_for_experiment_state(exp_id, "COMPLETED")
+
+
+@pytest.mark.managed_devcluster
+@pytest.mark.parametrize("command_duration", [10, 20, 60])
+def test_agent_restart_cmd_container_failure(
+    managed_cluster: ManagedCluster, command_duration: int
+) -> None:
+    # Launch a cmd, kill agent, wait for reconnect timeout, check it's not marked as success.
+    # Reconnect timeout is ~25 seconds. We'd like to both test tasks that take
+    # longer (60 seconds) and shorter (10 seconds) than that.
+    # I've also added the (20 seconds) run for extra insurance in case of some
+    # flakiness of (10 second) run.
+    managed_cluster.ensure_agent_ok()
+    try:
+        command_id = run_command(command_duration)
+        wait_for_command_state(command_id, "RUNNING", 10)
+
+        for _i in range(10):
+            if len(list(_local_container_ids_for_command(command_id))) > 0:
+                break
+            time.sleep(1)
+        else:
+            pytest.fail(f"Failed to find the command container id after {_i} ticks")
+
+        managed_cluster.kill_agent()
+
+        # Container should still be alive.
+        assert list(_local_container_ids_for_command(command_id))
+        for _i in range(60):
+            if len(list(_local_container_ids_for_command(command_id))) == 0:
+                break
+            time.sleep(1)
+        else:
+            pytest.fail(f"command container didn't terminate after {_i} ticks")
+        wait_for_command_state(command_id, "TERMINATED", 30)
+        assert "success" not in get_command_info(command_id)["exitStatus"]
+    except Exception:
+        managed_cluster.restart_agent()
+        raise
+    else:
+        managed_cluster.restart_agent()

--- a/e2e_tests/tests/config.py
+++ b/e2e_tests/tests/config.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import Path
 from typing import Any, Dict
 
 from determined.common import util
@@ -26,6 +27,8 @@ TF2_CPU_IMAGE = os.environ.get("TF2_CPU_IMAGE") or DEFAULT_TF2_CPU_IMAGE
 TF1_GPU_IMAGE = os.environ.get("TF1_GPU_IMAGE") or DEFAULT_TF1_GPU_IMAGE
 TF2_GPU_IMAGE = os.environ.get("TF2_GPU_IMAGE") or DEFAULT_TF2_GPU_IMAGE
 GPU_ENABLED = os.environ.get("DET_TEST_GPU_ENABLED", "1") not in ("0", "false")
+
+PROJECT_ROOT_PATH = Path(__file__).resolve().parents[2]
 
 
 def fixtures_path(path: str) -> str:

--- a/e2e_tests/tests/conftest.py
+++ b/e2e_tests/tests/conftest.py
@@ -24,12 +24,12 @@ _INTEG_MARKERS = {
     "e2e_gpu",
     "det_deploy_local",
     "distributed",
-    "cloud",
     "parallel",
     "nightly",
     "model_hub_transformers",
     "model_hub_transformers_amp",
     "model_hub_mmdetection",
+    "managed_devcluster",
 }
 
 

--- a/master/internal/task/allocation.go
+++ b/master/internal/task/allocation.go
@@ -609,12 +609,12 @@ func (a *Allocation) terminated(ctx *actor.Context) {
 				exit.Err = err
 				return
 			case aproto.AgentError, aproto.AgentFailed:
-				// Questionable, could be considered failures, but for now we don't.
 				ctx.Log().WithError(err).Warnf("allocation exited due to agent (%s)", err.FailureType)
+				exit.Err = err
 				return
 			case aproto.TaskAborted:
-				// Definitely not a failure.
 				ctx.Log().WithError(err).Debugf("allocation aborted (%s)", err.FailureType)
+				exit.Err = err
 				return
 			default:
 				panic(errors.Wrapf(err, "unexpected allocation failure (%s)", err.Error()))

--- a/master/internal/trial.go
+++ b/master/internal/trial.go
@@ -15,6 +15,7 @@ import (
 	"github.com/determined-ai/determined/master/internal/db"
 	"github.com/determined-ai/determined/master/internal/sproto"
 	"github.com/determined-ai/determined/master/pkg/actor"
+	aproto "github.com/determined-ai/determined/master/pkg/agent"
 	"github.com/determined-ai/determined/master/pkg/model"
 	"github.com/determined-ai/determined/master/pkg/schemas"
 	"github.com/determined-ai/determined/master/pkg/schemas/expconf"
@@ -299,7 +300,7 @@ func (t *trial) allocationExited(ctx *actor.Context, exit *task.AllocationExited
 			return t.transition(ctx, model.ErrorState)
 		}
 		return t.transition(ctx, model.CompletedState)
-	case exit.Err != nil:
+	case exit.Err != nil && !aproto.IsRestartableSystemError(exit.Err):
 		ctx.Log().
 			WithError(exit.Err).
 			Errorf("trial failed (restart %d/%d)", t.restarts, t.config.MaxRestarts())

--- a/master/pkg/agent/exit.go
+++ b/master/pkg/agent/exit.go
@@ -82,3 +82,25 @@ const (
 	// AgentError denotes that the agent failed to launch the container.
 	AgentError = FailureType("agent failed to launch the container")
 )
+
+// IsRestartableSystemError checks if the error is caused by the system and
+// shouldn't count against `max_restarts`.
+func IsRestartableSystemError(err error) bool {
+	switch contErr := err.(type) {
+	case ContainerFailure:
+		switch contErr.FailureType {
+		case ContainerFailed, TaskError:
+			return false
+		// Questionable, could be considered failures, but for now we don't.
+		case AgentError, AgentFailed:
+			return true
+		// Definitely not a failure.
+		case TaskAborted:
+			return true
+		default:
+			return false
+		}
+	default:
+		return false
+	}
+}


### PR DESCRIPTION
## Description

Currently, when an allocation is terminated for agent-related reasons (e.g. agent failing), it's not counted as failure, and as a result the master treats the non-trial tasks (e.g. commands) as if they exited successfully. 

- We should count these as failures.
- _Not counting_ these against trial `max_restarts` is moved to trial.
- Update devcluster to latest version, and add a new test option for a "managed devcluster", where we use devcluster API to spawn and programmatically control it to kill/restart agents as needed for the test purposes.

## Test Plan

Added managed-devcluster tests for
 - making sure commands die without reporting success on agent kill.
 - checking that max_restarts=0 experiments still restart in that setup.

## Commentary (optional)

This managed setup will get used more extensively in the work related to recovering containers after agent restarts. Also we could potentially move the entirety of tests currently using devcluster (i.e. most e2e setups) to this managed setup.

This PR includes a (thin) wrapper `ManagedCluster`. I expect it to include various common behaviors that'd otherwise be helper functions. 

Additionally I'd like to implement an ability to *not use* managed cluster for managed setup, and connect to an externally running devcluster instead via a client. The motivation for that is to allow running a test against a local development cluster you're currently running "in another terminal".

One more thing: this setup has a hard limit of one devcluster per node because of a) devcluster file lock b) binding master to local port, reusing same fluent ports, etc. When that's no longer a limit, we could have this managed devcluster look more like a true pytest fixture, allowing us to get rid of existing manual split between e2e-cpu / e2e-cpu-double / e2e-managed-devcluster, and do them all in one circleci job with parallelism.

## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ