### PR TITLE
chore: remove simplejson

### DIFF
--- a/e2e_tests/tests/experiment/record_profiling.py
+++ b/e2e_tests/tests/experiment/record_profiling.py
@@ -1,8 +1,7 @@
+import json
 from statistics import mean
 from typing import Callable, Dict, List, Optional, Tuple
 from urllib.parse import urlencode
-
-import simplejson
 
 from determined.common import api
 from determined.profiler import SysMetricName
@@ -77,7 +76,7 @@ def get_profiling_metrics(trial_id: int, metric_type: str) -> List[float]:
         return [
             batch
             for batches in [
-                simplejson.loads(line)["result"]["batch"]["values"] for line in r.iter_lines()
+                json.loads(line)["result"]["batch"]["values"] for line in r.iter_lines()
             ]
             for batch in batches
         ]

--- a/e2e_tests/tests/experiment/test_core.py
+++ b/e2e_tests/tests/experiment/test_core.py
@@ -94,6 +94,7 @@ def test_nan_metrics() -> None:
     training_structure = config["hyperparameters"]["training_structure"]["val"]
     training_structure["inf"] = "Infinity"
     training_structure["nan"] = "NaN"
+    training_structure["nanarray"] = ["NaN", "NaN"]
     validation_structure = config["hyperparameters"]["validation_structure"]["val"]
     validation_structure["neg_inf"] = "-Infinity"
 

--- a/e2e_tests/tests/experiment/test_profiling.py
+++ b/e2e_tests/tests/experiment/test_profiling.py
@@ -1,9 +1,9 @@
+import json
 import tempfile
 from typing import Any, Dict, Optional, Sequence
 from urllib.parse import urlencode
 
 import pytest
-import simplejson
 import yaml
 
 from determined.common import api
@@ -102,7 +102,7 @@ def request_profiling_metric_labels(trial_id: int, timing_enabled: bool, gpu_ena
         stream=True,
     ) as r:
         for line in r.iter_lines():
-            labels = simplejson.loads(line)["result"]["labels"]
+            labels = json.loads(line)["result"]["labels"]
             validate_labels(labels)
             # Just check 1 iter.
             return
@@ -131,7 +131,7 @@ def request_profiling_system_metrics(trial_id: int, metric_name: str) -> None:
     ) as r:
         have_batch = False
         for line in r.iter_lines():
-            batch = simplejson.loads(line)["result"]["batch"]
+            batch = json.loads(line)["result"]["batch"]
             validate_gpu_metric_batch(batch)
             have_batch = True
         if not have_batch:
@@ -183,7 +183,7 @@ def request_profiling_pytorch_timing_metrics(
         batch_idx = 0
         have_batch = False
         for line in r.iter_lines():
-            batch = simplejson.loads(line)["result"]["batch"]
+            batch = json.loads(line)["result"]["batch"]
             batch_idx = validate_timing_batch(batch, batch_idx)
             have_batch = True
         if not have_batch:

--- a/e2e_tests/tests/fixtures/metric_maker/metric_maker.py
+++ b/e2e_tests/tests/fixtures/metric_maker/metric_maker.py
@@ -195,6 +195,7 @@ class NANMetricMaker(MetricMaker):
         self.training_structure = self.env.hparams["training_structure"]
         self.training_structure["inf"] = math.inf
         self.training_structure["nan"] = math.nan
+        self.training_structure["nanarray"] = np.array([math.nan, math.nan])
         self.validation_structure = self.env.hparams["validation_structure"]
         self.validation_structure["neg_inf"] = -1 * math.inf
         self.gain_per_batch = 0

--- a/harness/determined/_generic/_searcher.py
+++ b/harness/determined/_generic/_searcher.py
@@ -76,17 +76,15 @@ class SearcherOp:
         if math.isnan(searcher_metric):
             raise RuntimeError("searcher_metric may not be NaN")
         self._completed = True
-        body = det.util.clearinf(
-            {
-                "op": {
-                    "length": {
-                        "length": self._length,
-                        "unit": self._unit.value,
-                    }
-                },
-                "searcherMetric": searcher_metric,
-            }
-        )
+        body = {
+            "op": {
+                "length": {
+                    "length": self._length,
+                    "unit": self._unit.value,
+                }
+            },
+            "searcherMetric": searcher_metric,
+        }
         logger.debug(f"op.complete({searcher_metric})")
         self._session.post(
             f"/api/v1/trials/{self._trial_id}/searcher/completed_operation",

--- a/harness/determined/_generic/_training.py
+++ b/harness/determined/_generic/_training.py
@@ -59,10 +59,10 @@ class Training:
         body = {
             "trial_run_id": self._run_id,
             "latest_batch": latest_batch,
-            "metrics": det.util.clearinf(metrics),
+            "metrics": metrics,
         }
         if batch_metrics is not None:
-            body["batch_metrics"] = det.util.clearinf(batch_metrics)
+            body["batch_metrics"] = batch_metrics
         logger.info(f"report_training_metrics(latest_batch={latest_batch}, metrics={metrics})")
         self._session.post(
             f"/api/v1/trials/{self._trial_id}/training_metrics",
@@ -119,7 +119,7 @@ class Training:
         body = {
             "trial_run_id": self._run_id,
             "latest_batch": latest_batch,
-            "metrics": det.util.clearinf(reportable_metrics),
+            "metrics": reportable_metrics,
         }
         logger.info(f"report_validation_metrics(latest_batch={latest_batch}, metrics={metrics})")
         self._session.post(

--- a/harness/determined/common/api/experiment.py
+++ b/harness/determined/common/api/experiment.py
@@ -1,4 +1,5 @@
 import collections
+import json
 import math
 import random
 import sys
@@ -7,7 +8,6 @@ import uuid
 from typing import Any, Dict, List, Optional
 from urllib.parse import urlencode
 
-import simplejson
 from termcolor import colored
 
 from determined.common import api, constants, context, yaml
@@ -92,7 +92,7 @@ def trial_logs(
         if reverse:
             line_iter = reversed(list(line_iter))
         for line in line_iter:
-            yield simplejson.loads(line)["result"]
+            yield json.loads(line)["result"]
 
 
 def print_trial_logs(master_url: str, trial_id: int, **kwargs: Any) -> None:

--- a/harness/determined/common/api/request.py
+++ b/harness/determined/common/api/request.py
@@ -1,3 +1,4 @@
+import json as _json
 import webbrowser
 from types import TracebackType
 from typing import Any, Dict, Iterator, Optional, Tuple, Union
@@ -5,8 +6,8 @@ from urllib import parse
 
 import lomond
 import requests
-import simplejson
 
+import determined as det
 import determined.common.requests
 from determined.common.api import authentication, certs, errors
 
@@ -94,12 +95,14 @@ def do_request(
     if json is not None and data is not None:
         raise ValueError("json and data must not be provided together")
 
+    if json:
+        data = det.util.json_encode(json)
+
     try:
         r = determined.common.requests.request(
             method,
             make_url(host, path),
             params=params,
-            json=json,
             data=data,
             headers=h,
             verify=cert.bundle if cert else None,
@@ -116,7 +119,7 @@ def do_request(
 
     def _get_message(r: requests.models.Response) -> str:
         try:
-            return str(simplejson.loads(r.text).get("message"))
+            return str(_json.loads(r.text).get("message"))
         except Exception:
             return ""
 
@@ -294,7 +297,7 @@ class WebSocket:
             elif isinstance(event, lomond.events.Text):
                 # All web socket connections are expected to be in a JSON
                 # format.
-                yield simplejson.loads(event.text)
+                yield _json.loads(event.text)
 
     def __exit__(
         self,

--- a/harness/determined/exec/launch_autohorovod.py
+++ b/harness/determined/exec/launch_autohorovod.py
@@ -6,14 +6,13 @@ subprocess otherwise.
 """
 
 import copy
+import json
 import logging
 import socket
 import subprocess
 import sys
 import time
 from typing import Dict
-
-import simplejson
 
 import determined as det
 import determined.common
@@ -52,7 +51,7 @@ def main() -> int:
 
     logging.info(
         f"New trial runner in (container {info.container_id}) on agent {info.agent_id}: "
-        + simplejson.dumps(mask_config_dict(experiment_config))
+        + json.dumps(mask_config_dict(experiment_config))
     )
 
     # TODO: this should go in the chief worker, not in the launch layer.  For now, the

--- a/harness/determined/util.py
+++ b/harness/determined/util.py
@@ -2,7 +2,9 @@ import collections
 import datetime
 import enum
 import inspect
+import json
 import math
+import numbers
 import os
 import pathlib
 import random
@@ -10,9 +12,7 @@ import shutil
 import time
 import uuid
 import warnings
-from typing import Any, Callable, Dict, List, Optional, Set, TypeVar, cast
-
-import simplejson
+from typing import Any, Callable, Dict, List, Optional, Set, SupportsFloat, TypeVar, cast
 
 from determined import constants
 from determined.common import check, util
@@ -129,48 +129,54 @@ def make_metrics(num_inputs: Optional[int], batch_metrics: List[Dict[str, Any]])
     return metrics
 
 
-def clearinf(obj: Any) -> Any:
-    if isinstance(obj, float) and math.isnan(obj):
-        return "NaN"
-    if obj == math.inf:
-        return "Infinity"
-    if obj == -1 * math.inf:
-        return "-Infinity"
-    if isinstance(obj, List):
-        return list(map(clearinf, obj))
-    if isinstance(obj, dict):
-        return {k: clearinf(v) for k, v in obj.items()}
-    return obj
-
-
 def json_encode(obj: Any, indent: Optional[str] = None, sort_keys: bool = False) -> str:
+    """
+    Encode things as json, with an extra preprocessing step to handle some non-standard types.
+
+    Note: json has a "default" argument that accepts something like our preprocessing step,
+    except it is only invoked for non-native types (i.e. no catching nan or inf floats).
+    """
     import numpy as np
 
-    def json_serializer(obj: Any) -> Any:
+    def jsonable(obj: Any) -> Any:
+        if isinstance(obj, (str, bool, type(None))):
+            # Needs no fancy encoding.
+            return obj
+        if isinstance(obj, numbers.Integral):
+            # int, np.int64, etc.
+            return int(obj)
+        if isinstance(obj, numbers.Number):
+            obj = cast(SupportsFloat, obj)
+            # float, np.float64, etc.  Serialize nan/±infinity as strings.
+            if math.isnan(obj):
+                return "NaN"
+            if math.isinf(obj):
+                return "Infinity" if obj > 0 else "-Infinity"
+            return float(obj)
+        if isinstance(obj, bytes):
+            # Assume bytes are utf8 (json can't encode arbitrary binary data).
+            return obj.decode("utf8")
+        if isinstance(obj, (list, tuple)):
+            # Recurse into lists.
+            return [jsonable(v) for v in obj]
+        if isinstance(obj, dict):
+            # Recurse into dicts.
+            return {k: jsonable(v) for k, v in obj.items()}
+        if isinstance(obj, np.ndarray):
+            # Expand arrays into lists, then recurse.
+            return jsonable(obj.tolist())
         if isinstance(obj, datetime.datetime):
             return obj.isoformat()
         if isinstance(obj, enum.Enum):
             return obj.name
-        if isinstance(obj, (np.float64, np.float32, np.float16)):
-            return clearinf(float(obj))
-        if isinstance(obj, (np.int64, np.int32)):
-            return int(obj)
         if isinstance(obj, uuid.UUID):
             return str(obj)
-        if isinstance(obj, np.ndarray):
-            return clearinf(obj.tolist())
         # Objects that provide their own custom JSON serialization.
         if hasattr(obj, "__json__"):
             return obj.__json__()
-
         raise TypeError("Unserializable object {} of type {}".format(obj, type(obj)))
 
-    # NB: We serialize NaN, Infinity, and -Infinity as `null`, because
-    # those are not allowed by the JSON spec.
-    s = simplejson.dumps(
-        obj, default=json_serializer, ignore_nan=False, indent=indent, sort_keys=sort_keys
-    )  # type: str
-    return s
+    return json.dumps(jsonable(obj), indent=indent, sort_keys=sort_keys)
 
 
 def write_user_code(path: pathlib.Path, on_cluster: bool) -> None:

--- a/harness/setup.py
+++ b/harness/setup.py
@@ -32,7 +32,6 @@ setup(
         "hdfs>=2.2.2",
         "lomond>=0.3.3",
         "pathspec>=0.6.0",
-        "simplejson",
         "azure-storage-blob",
         "termcolor>=1.1.0",
         "boto3",


### PR DESCRIPTION
simplejson is just externally-maintained json.  We don't have any
particular need to bring in an external dependency over what's packaged
in python's standard library, so just use the built-in json module.

Additionally, stop using json's "default" argument for encoding custom
types.  The function passed to "default" argument is not consulted when
encoding default types (especially "float") so it is impossible to catch
NaNs.  As a result, when using "default", we had to pre-and-post-process
the object during encoding.  Now, we do our own pre-processing step,
where we explicitly visit every object so we can eliminate the
post-processing step.