### PR TITLE
feat: Add /labels to Model Registry API [DET-6178]

### DIFF
--- a/e2e_tests/tests/cluster/test_model_registry.py
+++ b/e2e_tests/tests/cluster/test_model_registry.py
@@ -110,6 +110,11 @@ def test_model_registry() -> None:
     models = d.get_models(sort_by=ModelSortBy.NAME)
     assert [m.name for m in models] == ["mnist", "object-detection", "transformer"]
 
+    # Test model labels combined
+    tform.set_labels(["world", "test", "zebra"])
+    labels = d.get_model_labels()
+    assert labels == ["world", "hello", "test", "zebra"]
+
     # Test deletion of model
     tform.delete()
     models = d.get_models(sort_by=ModelSortBy.NAME)

--- a/harness/determined/common/experimental/determined.py
+++ b/harness/determined/common/experimental/determined.py
@@ -195,3 +195,11 @@ class Determined:
 
         models = r.json().get("models")
         return [model.Model.from_json(m, self._session) for m in models]
+
+    def get_model_labels(self) -> List[str]:
+        """
+        Get a list of labels used on any models, sorted from most-popular to least-popular.
+        """
+        r = self._session.get("/api/v1/model/labels")
+
+        return r.json().get("labels")

--- a/harness/determined/common/experimental/determined.py
+++ b/harness/determined/common/experimental/determined.py
@@ -202,4 +202,5 @@ class Determined:
         """
         r = self._session.get("/api/v1/model/labels")
 
-        return r.json().get("labels")
+        labels = r.json().get("labels")
+        return [str(label) for label in labels]

--- a/harness/determined/common/experimental/determined.py
+++ b/harness/determined/common/experimental/determined.py
@@ -1,5 +1,5 @@
 import pathlib
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Union, cast
 
 from determined.common import check, context, util, yaml
 from determined.common.api import authentication, certs
@@ -203,4 +203,4 @@ class Determined:
         r = self._session.get("/api/v1/model/labels")
 
         labels = r.json().get("labels")
-        return [str(label) for label in labels]
+        return cast(List[str], labels)

--- a/harness/determined/experimental/client.py
+++ b/harness/determined/experimental/client.py
@@ -247,4 +247,4 @@ def get_model_labels() -> List[str]:
     Get a list of labels used on any models, sorted from most-popular to least-popular.
     """
     assert _determined is not None
-    return _determined.get_labels()
+    return _determined.get_model_labels()

--- a/harness/determined/experimental/client.py
+++ b/harness/determined/experimental/client.py
@@ -239,3 +239,12 @@ def get_models(
     """
     assert _determined is not None
     return _determined.get_models(sort_by, order_by, name, description)
+
+
+@_require_singleton
+def get_model_labels() -> List[str]:
+    """
+    Get a list of labels used on any models, sorted from most-popular to least-popular.
+    """
+    assert _determined is not None
+    return _determined.get_labels()

--- a/master/internal/api_model.go
+++ b/master/internal/api_model.go
@@ -85,6 +85,17 @@ func (a *apiServer) GetModels(
 	return resp, a.paginate(&resp.Pagination, &resp.Models, req.Offset, req.Limit)
 }
 
+func (a *apiServer) GetModelLabels(
+	_ context.Context, req *apiv1.GetModelLabelsRequest) (*apiv1.GetModelLabelsResponse, error) {
+	resp := &apiv1.GetModelLabelsResponse{}
+	err := a.m.db.QueryProto("get_model_labels", resp)
+	if err != nil {
+		return nil, err
+	}
+
+	return resp, errors.Wrapf(err, "error getting model labels")
+}
+
 func (a *apiServer) PostModel(
 	ctx context.Context, req *apiv1.PostModelRequest) (*apiv1.PostModelResponse, error) {
 	b, err := protojson.Marshal(req.Metadata)

--- a/master/static/srv/get_model_labels.sql
+++ b/master/static/srv/get_model_labels.sql
@@ -1,0 +1,11 @@
+WITH sorted_labels AS (
+  SELECT label
+  FROM (
+    SELECT id, UNNEST(labels) AS label
+    FROM models
+  ) all_labels
+  GROUP BY label
+  ORDER BY COUNT(DISTINCT(id)) DESC, label ASC
+)
+SELECT array_to_json(ARRAY_AGG(label)) AS labels
+FROM sorted_labels;

--- a/proto/src/determined/api/v1/api.proto
+++ b/proto/src/determined/api/v1/api.proto
@@ -982,6 +982,15 @@ service Determined {
       tags: "Models"
     };
   }
+  // Get a list of unique model labels (sorted by popularity).
+  rpc GetModelLabels(GetModelLabelsRequest) returns (GetModelLabelsResponse) {
+    option (google.api.http) = {
+      get: "/api/v1/model/labels"
+    };
+    option (grpc.gateway.protoc_gen_swagger.options.openapiv2_operation) = {
+      tags: "Models"
+    };
+  }
   // Get the requested model version.
   rpc GetModelVersion(GetModelVersionRequest)
       returns (GetModelVersionResponse) {

--- a/proto/src/determined/api/v1/model.proto
+++ b/proto/src/determined/api/v1/model.proto
@@ -76,6 +76,15 @@ message GetModelsResponse {
   Pagination pagination = 2;
 }
 
+// Get a list of model labels.
+message GetModelLabelsRequest {}
+
+// Response to GetModelLabelsRequest.
+message GetModelLabelsResponse {
+  // List of labels used across all models.
+  repeated string labels = 1;
+}
+
 // Request for creating a model in the registry.
 message PostModelRequest {
   option (grpc.gateway.protoc_gen_swagger.options.openapiv2_schema) = {

--- a/webui/react/src/services/api-ts-sdk/api.ts
+++ b/webui/react/src/services/api-ts-sdk/api.ts
@@ -1988,6 +1988,20 @@ export interface V1GetModelDefResponse {
 }
 
 /**
+ * Response to GetModelLabelsRequest.
+ * @export
+ * @interface V1GetModelLabelsResponse
+ */
+export interface V1GetModelLabelsResponse {
+    /**
+     * List of labels used across all models.
+     * @type {Array<string>}
+     * @memberof V1GetModelLabelsResponse
+     */
+    labels?: Array<string>;
+}
+
+/**
  * Response to GetModelRequest.
  * @export
  * @interface V1GetModelResponse
@@ -11912,6 +11926,37 @@ export const ModelsApiFetchParamCreator = function (configuration?: Configuratio
         },
         /**
          * 
+         * @summary Get a list of unique model labels (sorted by popularity).
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        determinedGetModelLabels(options: any = {}): FetchArgs {
+            const localVarPath = `/api/v1/model/labels`;
+            const localVarUrlObj = url.parse(localVarPath, true);
+            const localVarRequestOptions = Object.assign({ method: 'GET' }, options);
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            // authentication BearerToken required
+            if (configuration && configuration.apiKey) {
+                const localVarApiKeyValue = typeof configuration.apiKey === 'function'
+					? configuration.apiKey("Authorization")
+					: configuration.apiKey;
+                localVarHeaderParameter["Authorization"] = localVarApiKeyValue;
+            }
+
+            localVarUrlObj.query = Object.assign({}, localVarUrlObj.query, localVarQueryParameter, options.query);
+            // fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
+            delete localVarUrlObj.search;
+            localVarRequestOptions.headers = Object.assign({}, localVarHeaderParameter, options.headers);
+
+            return {
+                url: url.format(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         * 
          * @summary Get the requested model version.
          * @param {number} modelId The id of the model.
          * @param {number} modelVersion The version number.
@@ -12395,6 +12440,24 @@ export const ModelsApiFp = function(configuration?: Configuration) {
         },
         /**
          * 
+         * @summary Get a list of unique model labels (sorted by popularity).
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        determinedGetModelLabels(options?: any): (fetch?: FetchAPI, basePath?: string) => Promise<V1GetModelLabelsResponse> {
+            const localVarFetchArgs = ModelsApiFetchParamCreator(configuration).determinedGetModelLabels(options);
+            return (fetch: FetchAPI = portableFetch, basePath: string = BASE_PATH) => {
+                return fetch(basePath + localVarFetchArgs.url, localVarFetchArgs.options).then((response) => {
+                    if (response.status >= 200 && response.status < 300) {
+                        return response.json();
+                    } else {
+                        throw response;
+                    }
+                });
+            };
+        },
+        /**
+         * 
          * @summary Get the requested model version.
          * @param {number} modelId The id of the model.
          * @param {number} modelVersion The version number.
@@ -12614,6 +12677,15 @@ export const ModelsApiFactory = function (configuration?: Configuration, fetch?:
         },
         /**
          * 
+         * @summary Get a list of unique model labels (sorted by popularity).
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        determinedGetModelLabels(options?: any) {
+            return ModelsApiFp(configuration).determinedGetModelLabels(options)(fetch, basePath);
+        },
+        /**
+         * 
          * @summary Get the requested model version.
          * @param {number} modelId The id of the model.
          * @param {number} modelVersion The version number.
@@ -12766,6 +12838,17 @@ export class ModelsApi extends BaseAPI {
      */
     public determinedGetModel(modelId: number, options?: any) {
         return ModelsApiFp(this.configuration).determinedGetModel(modelId, options)(this.fetch, this.basePath);
+    }
+
+    /**
+     * 
+     * @summary Get a list of unique model labels (sorted by popularity).
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof ModelsApi
+     */
+    public determinedGetModelLabels(options?: any) {
+        return ModelsApiFp(this.configuration).determinedGetModelLabels(options)(this.fetch, this.basePath);
     }
 
     /**


### PR DESCRIPTION
## Description

Adds a new endpoint `/model/labels` to the Model Registry, listing all labels used in any model, in order of popularity.

We SELECT the model id and order by COUNT(DISTINCT(id)) to prevent duplicate labels on a model counting more than once. Labels with the same number of model occurrences are secondarily ordered alphabetically. 

Adds a call to the model registry's e2e test

## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.