### PR TITLE
fix: Continue using model names on the CLI [DET-6152]

### DIFF
--- a/docs/release-notes/3152-model-registry-cli.txt
+++ b/docs/release-notes/3152-model-registry-cli.txt
@@ -4,3 +4,7 @@
 
 -  Revert changes to Model Registry CLI format so models can be referred to by a unique name, and
    not only ID
+
+**Potential for Breaking Change**
+
+-  If multiple models were created with the same name in the registry, the names will change.

--- a/docs/release-notes/3152-model-registry-cli.txt
+++ b/docs/release-notes/3152-model-registry-cli.txt
@@ -1,0 +1,6 @@
+:orphan:
+
+**Improvement**
+
+-  Revert changes to Model Registry CLI format so models can be referred to by a unique name, and
+   not only ID

--- a/harness/determined/cli/model.py
+++ b/harness/determined/cli/model.py
@@ -213,7 +213,7 @@ args_description = [
                     Arg(
                         "--version",
                         type=int,
-                        default=0,
+                        default=-1,
                         help="model version information to include in output",
                     ),
                 ],

--- a/harness/determined/cli/model.py
+++ b/harness/determined/cli/model.py
@@ -78,16 +78,23 @@ def list_models(args: Namespace) -> None:
 
         render.tabulate_or_csv(headers, values, False)
 
+def model_by_name(args: Namespace) -> Model:
+    models = Determined(args.master, None).get_models(name=args.name)
+    if len(models) == 0:
+        raise Error("No model was found with the given name.")
+    if len(models) > 1:
+        raise Error("Multiple models were found with the given name.")
+    return models[0]
 
 @authentication.required
 def list_versions(args: Namespace) -> None:
+    model = model_by_name(args)
     if args.json:
-        r = api.get(args.master, "models/{}/versions".format(args.id))
+        r = api.get(args.master, "models/{}/versions".format(model.model_id))
         data = r.json()
         print(json.dumps(data, indent=2))
 
     else:
-        model = Determined(args.master).get_model(args.id)
         render_model(model)
         print("\n")
 
@@ -125,7 +132,7 @@ def create(args: Namespace) -> None:
 
 
 def describe(args: Namespace) -> None:
-    model = Determined(args.master, None).get_model(args.id)
+    model = model_by_name(args)
     model_version = model.get_version(args.version)
 
     if args.json:
@@ -139,16 +146,16 @@ def describe(args: Namespace) -> None:
 
 @authentication.required
 def register_version(args: Namespace) -> None:
+    model = model_by_name(args)
     if args.json:
         resp = api.post(
             args.master,
-            "/api/v1/models/{}/versions".format(args.id),
+            "/api/v1/models/{}/versions".format(model.model_id),
             json={"checkpointUuid": args.uuid},
         )
 
         print(json.dumps(resp.json(), indent=2))
     else:
-        model = Determined(args.master, None).get_model(args.id)
         model_version = model.register_version(args.uuid)
         render_model(model)
         print("\n")
@@ -189,7 +196,7 @@ args_description = [
                 register_version,
                 "register a new version of a model",
                 [
-                    Arg("id", type=int, help="id of the model"),
+                    Arg("name", type=str, help="name of the model"),
                     Arg("uuid", type=str, help="uuid to register as the next version of the model"),
                     Arg("--json", action="store_true", help="print as JSON"),
                 ],
@@ -199,7 +206,7 @@ args_description = [
                 describe,
                 "describe model",
                 [
-                    Arg("id", type=int, help="model to describe"),
+                    Arg("name", type=str, help="name of model to describe"),
                     Arg("--json", action="store_true", help="print as JSON"),
                     Arg(
                         "--version",
@@ -214,7 +221,7 @@ args_description = [
                 list_versions,
                 "list the versions of a model",
                 [
-                    Arg("id", type=int, help="unique ID of the model"),
+                    Arg("name", type=str, help="unique name of the model"),
                     Arg("--json", action="store_true", help="print as JSON"),
                 ],
             ),
@@ -223,7 +230,7 @@ args_description = [
                 create,
                 "create model",
                 [
-                    Arg("name", type=str, help="name for the model"),
+                    Arg("name", type=str, help="unique name of the model"),
                     Arg("--description", type=str, help="description of the model"),
                     Arg("--json", action="store_true", help="print as JSON"),
                 ],

--- a/harness/determined/cli/model.py
+++ b/harness/determined/cli/model.py
@@ -78,13 +78,15 @@ def list_models(args: Namespace) -> None:
 
         render.tabulate_or_csv(headers, values, False)
 
+
 def model_by_name(args: Namespace) -> Model:
     models = Determined(args.master, None).get_models(name=args.name)
     if len(models) == 0:
-        raise Error("No model was found with the given name.")
+        raise Exception("No model was found with the given name.")
     if len(models) > 1:
-        raise Error("Multiple models were found with the given name.")
+        raise Exception("Multiple models were found with the given name.")
     return models[0]
+
 
 @authentication.required
 def list_versions(args: Namespace) -> None:

--- a/master/static/migrations/20211102110152_make_model_registry_names_unique.down.sql
+++ b/master/static/migrations/20211102110152_make_model_registry_names_unique.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE public.models DROP CONSTRAINT uni_name;

--- a/master/static/migrations/20211102110152_make_model_registry_names_unique.down.sql
+++ b/master/static/migrations/20211102110152_make_model_registry_names_unique.down.sql
@@ -1,1 +1,1 @@
-ALTER TABLE public.models DROP CONSTRAINT uni_name;
+ALTER TABLE public.models DROP CONSTRAINT models_name_unique;

--- a/master/static/migrations/20211102110152_make_model_registry_names_unique.up.sql
+++ b/master/static/migrations/20211102110152_make_model_registry_names_unique.up.sql
@@ -7,4 +7,4 @@ names AS (
 UPDATE models SET name = CONCAT(name, id::text)
 WHERE name IN (SELECT name FROM names);
 
-ALTER TABLE public.models ADD CONSTRAINT uni_name UNIQUE (name);
+ALTER TABLE public.models ADD CONSTRAINT models_name_unique UNIQUE (name);

--- a/master/static/migrations/20211102110152_make_model_registry_names_unique.up.sql
+++ b/master/static/migrations/20211102110152_make_model_registry_names_unique.up.sql
@@ -1,1 +1,10 @@
+WITH m AS (
+  SELECT name, COUNT(*) AS count FROM models GROUP BY name
+),
+names AS (
+  SELECT name FROM m WHERE count > 1
+)
+UPDATE models SET name = CONCAT(name, id::text)
+WHERE name IN (SELECT name FROM names);
+
 ALTER TABLE public.models ADD CONSTRAINT uni_name UNIQUE (name);

--- a/master/static/migrations/20211102110152_make_model_registry_names_unique.up.sql
+++ b/master/static/migrations/20211102110152_make_model_registry_names_unique.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE public.models ADD CONSTRAINT uni_name UNIQUE (name);


### PR DESCRIPTION
## Description

Restores references to model names from the command line to be compatible with our shift to models.id on the backend. This un-does our quick fix of #3134 . Restores a unique constraint so an instance will not have models with duplicate names.

DET-6152 ticket should stay active, as I understand it to mean we would add more model registry actions to the CLI.

## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.