### PR TITLE
feat: basic support for container recovery on agent restarts [DET-6061]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -848,6 +848,11 @@ commands:
   install-devcluster:
     steps:
       - run: pip install git+https://github.com/determined-ai/devcluster.git@v1.1.0#egg=devcluster
+      - run:
+          command: |
+            if ! [ -x "$(command -v socat)" ]; then
+              apt update && apt install -y socat
+            fi
 
   start-devcluster:
     parameters:

--- a/.circleci/devcluster/double-reattach.devcluster.yaml
+++ b/.circleci/devcluster/double-reattach.devcluster.yaml
@@ -19,6 +19,21 @@ stages:
         log:
           level: debug
         root: tools/build
+        resource_manager:
+          default_aux_resource_pool: default
+          default_compute_resource_pool: default
+          scheduler:
+            fitting_policy: best
+          type: fair_share
+          type: agent
+        resource_pools:
+          - agent_reattach_enabled: true
+            agent_reconnect_wait: 25s
+            description: ''
+            max_aux_containers_per_agent: 100
+            pool_name: default
+            provider: null
+            task_container_defaults: null
 
   - custom:
       name: proxy

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,6 +60,7 @@ git clone git@github.com:determined-ai/determined.git
 - Java (>= 7)
 - cURL (>= 7)
 - jq (>= 1.6)
+- socat (>= 1.7)
 
 ### Building Determined
 

--- a/agent/internal/agent.go
+++ b/agent/internal/agent.go
@@ -417,12 +417,16 @@ func (a *agent) setup(ctx *actor.Context) error {
 		return errors.Wrap(err, "error initializing container manager")
 	}
 	a.cm, _ = ctx.ActorOf("containers", cm)
+	res := ctx.Ask(a.cm, requestReattachContainers{
+		a.MasterSetAgentOptions.ContainersToReattach,
+	}).Get().(responseReattachContainers)
 
 	ctx.Ask(a.socket, api.WriteMessage{Message: aproto.MasterMessage{
 		AgentStarted: &aproto.AgentStarted{
-			Version: a.Version,
-			Devices: a.Devices,
-			Label:   a.Label,
+			Version:              a.Version,
+			Devices:              a.Devices,
+			Label:                a.Label,
+			ContainersReattached: res.ContainersReattached,
 		},
 	}})
 	return nil

--- a/agent/internal/container.go
+++ b/agent/internal/container.go
@@ -34,6 +34,7 @@ type containerActor struct {
 	containerInfo *types.ContainerJSON
 
 	baseTrialLog model.TrialLog
+	reattached   bool
 }
 
 type (
@@ -43,6 +44,10 @@ type (
 
 func newContainerActor(msg aproto.StartContainer, client *client.Client) actor.Actor {
 	return &containerActor{Container: msg.Container, spec: &msg.Spec, client: client}
+}
+
+func reattachContainerActor(container cproto.Container, client *client.Client) actor.Actor {
+	return &containerActor{Container: container, client: client, reattached: true}
 }
 
 // getExtraFluentValues computes the container-specific extra fields to be injected into each Fluent
@@ -73,18 +78,21 @@ func getBaseTrialLog(spec *cproto.Spec) model.TrialLog {
 func (c *containerActor) Receive(ctx *actor.Context) error {
 	switch msg := ctx.Message().(type) {
 	case actor.PreStart:
-		c.docker, _ = ctx.ActorOf("docker", &dockerActor{Client: c.client, spec: c.spec})
-		c.transition(ctx, cproto.Pulling)
-		pull := pullImage{PullSpec: c.spec.PullSpec, Name: c.spec.RunSpec.ContainerConfig.Image}
-		ctx.Tell(c.docker, pull)
-		c.baseTrialLog = getBaseTrialLog(c.spec)
-
+		c.docker, _ = ctx.ActorOf("docker", &dockerActor{Client: c.client})
+		if !c.reattached {
+			c.transition(ctx, cproto.Pulling)
+			pull := pullImage{PullSpec: c.spec.PullSpec, Name: c.spec.RunSpec.ContainerConfig.Image}
+			ctx.Tell(c.docker, pull)
+			c.baseTrialLog = getBaseTrialLog(c.spec)
+		} else {
+			ctx.Tell(c.docker, reattachContainer{ID: c.Container.ID})
+		}
 	case getContainerSummary:
 		ctx.Respond(c.Container)
 
 	case imagePulled:
 		c.transition(ctx, cproto.Starting)
-		ctx.Tell(c.docker, c.spec.RunSpec)
+		ctx.Tell(c.docker, runContainer{c.spec.RunSpec})
 
 	case containerStarted:
 		c.containerInfo = &msg.containerInfo
@@ -107,7 +115,7 @@ func (c *containerActor) Receive(ctx *actor.Context) error {
 		c.containerStarted(ctx, aproto.ContainerStarted{ContainerInfo: *c.containerInfo})
 
 	case containerTerminated:
-		c.containerStopped(ctx, aproto.ContainerExited(aproto.ExitCode(msg.ExitCode)))
+		c.containerStopped(ctx, aproto.ContainerExited(msg.ExitCode))
 		ctx.Self().Stop()
 
 	case aproto.SignalContainer:
@@ -219,20 +227,22 @@ func (c *containerActor) transition(ctx *actor.Context, newState cproto.State) {
 }
 
 func (c *containerActor) containerStarted(ctx *actor.Context, started aproto.ContainerStarted) {
-	ctx.Log().Infof("transitioning state from %s to %s", c.State, cproto.Running)
-	c.Container = c.Transition(cproto.Running)
+	newState := cproto.Running
+	ctx.Log().Infof("transitioning state from %s to %s", c.State, newState)
+	c.Container = c.Transition(newState)
 	ctx.Tell(ctx.Self().Parent(), aproto.ContainerStateChanged{
 		Container: c.Container, ContainerStarted: &started})
 }
 
 func (c *containerActor) containerStopped(ctx *actor.Context, stopped aproto.ContainerStopped) {
-	if c.State == cproto.Terminated {
-		ctx.Log().Infof(
-			"attempted transition of state from %s to %s", cproto.Terminated, cproto.Terminated)
-	} else {
-		ctx.Log().Infof("transitioning state from %s to %s", c.State, cproto.Terminated)
-		c.Container = c.Transition(cproto.Terminated)
-		ctx.Tell(ctx.Self().Parent(), aproto.ContainerStateChanged{
-			Container: c.Container, ContainerStopped: &stopped})
+	newState := cproto.Terminated
+	if c.State == newState {
+		ctx.Log().Infof("attempted transition of state from %s to %s", newState, newState)
+		return
 	}
+
+	ctx.Log().Infof("transitioning state from %s to %s", c.State, newState)
+	c.Container = c.Transition(newState)
+	ctx.Tell(ctx.Self().Parent(), aproto.ContainerStateChanged{
+		Container: c.Container, ContainerStopped: &stopped})
 }

--- a/agent/internal/containers.go
+++ b/agent/internal/containers.go
@@ -1,15 +1,19 @@
 package internal
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"strconv"
 	"strings"
 
+	"github.com/docker/docker/api/types"
 	dcontainer "github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/client"
 	"github.com/labstack/echo/v4"
 	"github.com/pkg/errors"
+	"golang.org/x/sys/unix"
 
 	"github.com/determined-ai/determined/master/pkg/actor"
 	"github.com/determined-ai/determined/master/pkg/aproto"
@@ -27,6 +31,8 @@ const (
 	dockerAgentLabel            = "ai.determined.container.agent"
 	dockerClusterLabel          = "ai.determined.container.cluster"
 	dockerMasterLabel           = "ai.determined.container.master"
+	dockerContainerVersionLabel = "ai.determined.container.version"
+	dockerContainerVersionValue = "0"
 )
 
 type containerManager struct {
@@ -39,6 +45,15 @@ type containerManager struct {
 	fluentPort int
 	docker     *client.Client
 }
+
+type (
+	requestReattachContainers struct {
+		ContainersToReattach []aproto.ContainerReattach
+	}
+	responseReattachContainers struct {
+		ContainersReattached []aproto.ContainerReattachAck
+	}
+)
 
 func newContainerManager(a *agent, fluentPort int) (*containerManager, error) {
 	return &containerManager{
@@ -92,6 +107,14 @@ func (c *containerManager) Receive(ctx *actor.Context) error {
 			dockerAgentLabel:         c.Options.AgentID,
 			dockerClusterLabel:       c.MasterInfo.ClusterID,
 			dockerMasterLabel:        c.MasterInfo.MasterID,
+		}
+	case requestReattachContainers:
+		reattachedContainers, err := c.reattachContainers(ctx, msg.ContainersToReattach)
+		if err != nil {
+			ctx.Log().WithError(err).Warn("failed to reattach containers")
+			ctx.Respond(responseReattachContainers{})
+		} else {
+			ctx.Respond(responseReattachContainers{ContainersReattached: reattachedContainers})
 		}
 
 	case aproto.ContainerLog, aproto.ContainerStateChanged, model.TrialLog:
@@ -160,13 +183,10 @@ func overwriteSpec(
 	for key, value := range labels {
 		spec.RunSpec.ContainerConfig.Labels[key] = value
 	}
-	spec.RunSpec.ContainerConfig.Labels[dockerContainerIDLabel] = cont.ID.String()
-	spec.RunSpec.ContainerConfig.Labels[dockerContainerParentLabel] = cont.Parent.String()
-	var slotIds []string
-	for _, d := range cont.Devices {
-		slotIds = append(slotIds, strconv.Itoa(d.ID))
+
+	for k, v := range makeContainerDockerLabels(cont) {
+		spec.RunSpec.ContainerConfig.Labels[k] = v
 	}
-	spec.RunSpec.ContainerConfig.Labels[dockerContainerDevicesLabel] = strings.Join(slotIds, ",")
 
 	spec.RunSpec.HostConfig.DeviceRequests = append(
 		spec.RunSpec.HostConfig.DeviceRequests, gpuDeviceRequests(cont)...)
@@ -211,4 +231,169 @@ func containerEnvVars(cont cproto.Container) []string {
 		fmt.Sprintf("DET_CONTAINER_ID=%s", cont.ID),
 		fmt.Sprintf("DET_SLOT_IDS=[%s]", strings.Join(slotIds, ",")),
 	}
+}
+
+func (c *containerManager) reattachContainers(
+	ctx *actor.Context, expectedSurvivors []aproto.ContainerReattach) (
+	[]aproto.ContainerReattachAck, error) {
+	result := make([]aproto.ContainerReattachAck, 0, len(expectedSurvivors))
+
+	runningContainers, err := c.listRunningContainers(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, expectedSurvivor := range expectedSurvivors {
+		var ack aproto.ContainerReattachAck
+
+		containerInfo, ok := runningContainers[expectedSurvivor.Container.ID]
+		if !ok {
+			ack = aproto.ContainerReattachAck{
+				Container: cproto.Container{ID: expectedSurvivor.Container.ID},
+				Failure: &aproto.ContainerFailure{
+					FailureType: aproto.AgentFailed,
+					ErrMsg:      "container is gone on reattachment",
+				},
+			}
+		} else {
+			ctx.Log().Infof("will reattach container %s", expectedSurvivor.Container.ID)
+			cpc, err := c.reattachContainer(ctx, expectedSurvivor.Container, containerInfo)
+			if err != nil {
+				ack = aproto.ContainerReattachAck{
+					Container: *cpc,
+					Failure: &aproto.ContainerFailure{
+						FailureType: aproto.AgentFailed,
+						ErrMsg:      "failed to restore info from container labels",
+					},
+				}
+			} else {
+				ack = aproto.ContainerReattachAck{
+					Container: cproto.Container{ID: expectedSurvivor.Container.ID},
+				}
+			}
+		}
+
+		result = append(result, ack)
+		delete(runningContainers, expectedSurvivor.Container.ID)
+	}
+
+	// SIGKILL the rest.
+	for cid, containerInfo := range runningContainers {
+		ctx.Log().Infof("will kill container %s", cid)
+		err := c.docker.ContainerKill(
+			context.Background(), containerInfo.ID, unix.SignalName(unix.SIGKILL))
+		if err != nil {
+			ctx.Log().WithError(err).Warnf("failed to kill container %s", cid)
+		}
+	}
+
+	return result, nil
+}
+
+func (c *containerManager) reattachContainer(
+	ctx *actor.Context, containerPrevState cproto.Container, containerInfo types.Container) (
+	*cproto.Container, error) {
+	containerCurrState, err := c.unmakeContainerDockerLabels(ctx, containerInfo)
+	if err != nil {
+		return nil, err
+	}
+	// TODO(ilia): Support reattaching containers that have changed state:
+	// - starting -> running,
+	// - running -> terminated.
+	if containerCurrState.State != containerPrevState.State {
+		return nil, errors.New("container has changed state while offline")
+	}
+
+	cid := containerPrevState.ID
+	_, ok := ctx.ActorOf(cid, reattachContainerActor(*containerCurrState, c.docker))
+	if !ok {
+		errorMsg := fmt.Sprintf("failed to reattach container %s: actor already exists", cid)
+		ctx.Log().Warnf(errorMsg)
+		if killed := ctx.Kill(cid); killed {
+			ctx.Log().Warnf("possible invalid state, killed container actor %s", cid)
+		} else {
+			ctx.Log().Warnf("possible invalid state, failed to kill container actor %s", cid)
+		}
+		return nil, errors.New(errorMsg)
+	}
+
+	return containerCurrState, nil
+}
+
+func (c *containerManager) listRunningContainers(ctx *actor.Context) (
+	map[cproto.ID]types.Container, error) {
+	// List "our" running containers, based on `dockerAgentLabel`.
+	// This doesn't affect fluentbit, or containers spawned by other agents.
+	containers, err := c.docker.ContainerList(context.Background(), types.ContainerListOptions{
+		All: false,
+		Filters: filters.NewArgs(
+			filters.Arg("label", dockerAgentLabel+"="+c.Options.AgentID),
+		),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	result := make(map[cproto.ID]types.Container, len(containers))
+
+	for _, cont := range containers {
+		containerID, ok := cont.Labels[dockerContainerIDLabel]
+		if ok {
+			result[cproto.ID(containerID)] = cont
+		} else {
+			ctx.Log().Warnf("container %v has agent label but no container id", cont.ID)
+		}
+	}
+
+	return result, nil
+}
+
+func makeContainerDockerLabels(cont cproto.Container) map[string]string {
+	labels := map[string]string{}
+	labels[dockerContainerVersionLabel] = dockerContainerVersionValue
+	labels[dockerContainerIDLabel] = cont.ID.String()
+	labels[dockerContainerParentLabel] = cont.Parent.String()
+	var slotIds []string
+	for _, d := range cont.Devices {
+		slotIds = append(slotIds, strconv.Itoa(d.ID))
+	}
+	labels[dockerContainerDevicesLabel] = strings.Join(slotIds, ",")
+
+	return labels
+}
+
+func (c *containerManager) unmakeContainerDockerLabels(ctx *actor.Context, cont types.Container) (
+	*cproto.Container, error) {
+	// TODO(ilia): Shim old versions whenever possible, when we'll have them.
+	if cont.Labels[dockerContainerVersionLabel] != dockerContainerVersionValue {
+		return nil, errors.New(fmt.Sprintf(
+			"can't parse container labels version %s", cont.Labels[dockerContainerVersionLabel]))
+	}
+
+	devicesLabel := cont.Labels[dockerContainerDevicesLabel]
+	devices := []device.Device{}
+
+	// devicesLabel is empty for zero-slot tasks.
+	if len(devicesLabel) > 0 {
+		slotIDs := strings.Split(devicesLabel, ",")
+		for _, slotID := range slotIDs {
+			number, err := strconv.ParseInt(slotID, 10, 64)
+			if err != nil {
+				return nil, err
+			}
+			devices = append(devices, c.Devices[number])
+		}
+	}
+
+	state, err := cproto.ParseStateFromDocker(cont)
+	if err != nil {
+		return nil, err
+	}
+
+	return &cproto.Container{
+		ID:      cproto.ID(cont.Labels[dockerContainerIDLabel]),
+		Parent:  actor.AddrFromString(cont.Labels[dockerContainerParentLabel]),
+		Devices: devices,
+		State:   state,
+	}, nil
 }

--- a/docs/release-notes/3155-rolling.txt
+++ b/docs/release-notes/3155-rolling.txt
@@ -1,0 +1,5 @@
+:orphan:
+
+**Improvements**
+
+-  Agent: improve handling of master connection failures.

--- a/master/cmd/determined-master/root_test.go
+++ b/master/cmd/determined-master/root_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/determined-ai/determined/master/internal/config"
 	"github.com/determined-ai/determined/master/internal/resourcemanagers"
 	"github.com/determined-ai/determined/master/internal/resourcemanagers/provisioner"
+	"github.com/determined-ai/determined/master/pkg/aproto"
 	"github.com/determined-ai/determined/master/pkg/model"
 	"github.com/determined-ai/determined/master/pkg/schemas"
 	"github.com/determined-ai/determined/master/pkg/schemas/expconf"
@@ -68,6 +69,7 @@ task_container_defaults:
 			PoolName:                 "default",
 			Provider:                 providerConf,
 			MaxAuxContainersPerAgent: 100,
+			AgentReconnectWait:       model.Duration(aproto.AgentReconnectWait),
 		},
 	}
 	expected.TaskContainerDefaults.CPUPodSpec = &k8sV1.Pod{

--- a/master/internal/config/config_test.go
+++ b/master/internal/config/config_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/determined-ai/determined/master/internal/db"
 	"github.com/determined-ai/determined/master/internal/resourcemanagers"
 	"github.com/determined-ai/determined/master/internal/resourcemanagers/provisioner"
+	"github.com/determined-ai/determined/master/pkg/aproto"
 	"github.com/determined-ai/determined/master/pkg/logger"
 	"github.com/determined-ai/determined/master/pkg/model"
 	"github.com/determined-ai/determined/master/pkg/ptrs"
@@ -83,6 +84,7 @@ resource_pools:
 						NetworkMode:            "bridge",
 						DtrainNetworkInterface: "if0",
 					},
+					AgentReconnectWait: model.Duration(aproto.AgentReconnectWait),
 				},
 			},
 		},
@@ -140,6 +142,7 @@ resource_pools:
 					},
 					MaxAuxContainersPerAgent: 10,
 					MaxCPUContainersPerAgent: 0,
+					AgentReconnectWait:       model.Duration(aproto.AgentReconnectWait),
 				},
 				{
 					PoolName: "gpu-pool",
@@ -154,6 +157,7 @@ resource_pools:
 					},
 					MaxAuxContainersPerAgent: 0,
 					MaxCPUContainersPerAgent: 0,
+					AgentReconnectWait:       model.Duration(aproto.AgentReconnectWait),
 				},
 			},
 		},

--- a/master/internal/resourcemanagers/resource_pool.go
+++ b/master/internal/resourcemanagers/resource_pool.go
@@ -262,6 +262,13 @@ func (rp *ResourcePool) Receive(ctx *actor.Context) error {
 		reschedule = false
 		ctx.Respond(getResourceSummary(rp.agents))
 
+	case aproto.GetRPConfig:
+		reschedule = false
+		ctx.Respond(aproto.GetRPResponse{
+			AgentReconnectWait:   rp.config.AgentReconnectWait,
+			AgentReattachEnabled: rp.config.AgentReattachEnabled,
+		})
+
 	case schedulerTick:
 		if rp.reschedule {
 			toAllocate, toRelease := rp.scheduler.Schedule(rp)

--- a/master/internal/resourcemanagers/resource_pool_config.go
+++ b/master/internal/resourcemanagers/resource_pool_config.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 
 	"github.com/determined-ai/determined/master/internal/resourcemanagers/provisioner"
+	"github.com/determined-ai/determined/master/pkg/aproto"
 	"github.com/determined-ai/determined/master/pkg/check"
 	"github.com/determined-ai/determined/master/pkg/model"
 )
@@ -13,6 +14,8 @@ func defaultRPConfig() ResourcePoolConfig {
 	return ResourcePoolConfig{
 		MaxAuxContainersPerAgent: 100,
 		MaxCPUContainersPerAgent: -1,
+		AgentReconnectWait:       model.Duration(aproto.AgentReconnectWait),
+		AgentReattachEnabled:     false,
 	}
 }
 
@@ -24,6 +27,13 @@ type ResourcePoolConfig struct {
 	Scheduler                *SchedulerConfig                   `json:"scheduler,omitempty"`
 	MaxAuxContainersPerAgent int                                `json:"max_aux_containers_per_agent"`
 	TaskContainerDefaults    *model.TaskContainerDefaultsConfig `json:"task_container_defaults"`
+	// AgentReattachEnabled defines if master & agent try to recover
+	// running containers after a clean restart.
+	AgentReattachEnabled bool `json:"agent_reattach_enabled"`
+	// AgentReconnectWait define the time master will wait for agent
+	// before abandoning it.
+	AgentReconnectWait model.Duration `json:"agent_reconnect_wait"`
+
 	// Deprecated: Use MaxAuxContainersPerAgent instead.
 	MaxCPUContainersPerAgent int `json:"max_cpu_containers_per_agent,omitempty"`
 }

--- a/master/internal/sproto/task_actor.go
+++ b/master/internal/sproto/task_actor.go
@@ -45,6 +45,11 @@ type (
 		ContainerStopped *TaskContainerStopped
 	}
 
+	// GetTaskContainerState requests cproto.Container state.
+	GetTaskContainerState struct {
+		ContainerID cproto.ID
+	}
+
 	// SetGroupMaxSlots sets the maximum number of slots that a group can consume in the cluster.
 	SetGroupMaxSlots struct {
 		MaxSlots     *int

--- a/master/internal/task/allocation.go
+++ b/master/internal/task/allocation.go
@@ -167,6 +167,12 @@ func (a *Allocation) Receive(ctx *actor.Context) error {
 		}
 	case sproto.TaskContainerStateChanged:
 		a.TaskContainerStateChanged(ctx, msg)
+	case sproto.GetTaskContainerState:
+		if v, ok := a.reservations[msg.ContainerID]; ok {
+			ctx.Respond(*v.container)
+		} else {
+			ctx.Respond(errors.New(fmt.Sprintf("unknown container %s", msg.ContainerID)))
+		}
 	case sproto.ReleaseResources:
 		a.Terminate(ctx)
 	case actor.PostStop:

--- a/master/pkg/actor/actors/timer.go
+++ b/master/pkg/actor/actors/timer.go
@@ -20,6 +20,8 @@ func (t *timer) Receive(ctx *actor.Context) error {
 	switch ctx.Message().(type) {
 	case actor.PreStart:
 		go t.awaitTimer(ctx)
+	case actor.PostStop:
+		t.Stop()
 	}
 	return nil
 }
@@ -32,8 +34,8 @@ func (t *timer) awaitTimer(ctx *actor.Context) {
 
 // NotifyAfter asynchronously notifies the context's recipient with the provided message when
 // after the provided duration.
-func NotifyAfter(ctx *actor.Context, d time.Duration, msg actor.Message) {
+func NotifyAfter(ctx *actor.Context, d time.Duration, msg actor.Message) (*actor.Ref, bool) {
 	addr := actor.Addr("notify-timer-" + uuid.New().String())
-	ctx.Self().System().ActorOf(addr,
+	return ctx.Self().System().ActorOf(addr,
 		&timer{Timer: time.NewTimer(d), recipient: ctx.Self(), msg: msg})
 }

--- a/master/pkg/actor/address.go
+++ b/master/pkg/actor/address.go
@@ -36,6 +36,11 @@ func Addr(rawPath ...interface{}) Address {
 	return Address{path: parsed.String()}
 }
 
+// AddrFromString is the inverse of `Address.String()`.
+func AddrFromString(fullPath string) Address {
+	return Address{path: fullPath}
+}
+
 func (a Address) String() string {
 	return a.path
 }

--- a/master/pkg/actor/api/ws.go
+++ b/master/pkg/actor/api/ws.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net"
 	"reflect"
+	"strconv"
 	"sync"
 	"time"
 
@@ -50,6 +51,11 @@ func (w WebSocketConnected) Accept(
 	a, _ := ctx.ActorOf("websocket-"+uuid.New().String(), WrapSocket(conn, msgType, usePing))
 	ctx.Respond(a)
 	return a, true
+}
+
+// IsReconnect checks if agent is reconnecting after a network failure.
+func (w *WebSocketConnected) IsReconnect() (bool, error) {
+	return strconv.ParseBool(w.Ctx.QueryParam("reconnect"))
 }
 
 // WriteMessage is a message to a websocketActor asking it to write out the

--- a/master/pkg/aproto/agent_message.go
+++ b/master/pkg/aproto/agent_message.go
@@ -2,7 +2,6 @@ package aproto
 
 import (
 	"syscall"
-	"time"
 
 	"github.com/pkg/errors"
 
@@ -23,8 +22,9 @@ type AgentMessage struct {
 // This is generally useful for configurations that are not _agent_ specific but
 // cluster-wide.
 type MasterSetAgentOptions struct {
-	MasterInfo     MasterInfo
-	LoggingOptions model.LoggingConfig
+	MasterInfo           MasterInfo
+	LoggingOptions       model.LoggingConfig
+	ContainersToReattach []ContainerReattach
 }
 
 // StartContainer notifies the agent to start a container with the provided spec.
@@ -38,17 +38,6 @@ type SignalContainer struct {
 	ContainerID cproto.ID
 	Signal      syscall.Signal
 }
-
-const (
-	// AgentReconnectAttempts is the max attempts an agent has to reconnect.
-	AgentReconnectAttempts = 5
-	// AgentReconnectBackoff is the time between attempts, with the exception of the first.
-	AgentReconnectBackoff = 5 * time.Second
-	// AgentReconnectWait is the max time the master should wait for an agent before considering
-	// it dead. The agent waits (AgentReconnectWait - AgentReconnectBackoff) before stopping
-	// attempts and AgentReconnectWait before crashing.
-	AgentReconnectWait = AgentReconnectAttempts * AgentReconnectBackoff
-)
 
 // ErrAgentMustReconnect is the error returned by the master when the agent must exit and reconnect.
 var ErrAgentMustReconnect = errors.New("agent is past reconnect period, it must restart")

--- a/master/pkg/aproto/master_message.go
+++ b/master/pkg/aproto/master_message.go
@@ -37,11 +37,23 @@ type MasterMessage struct {
 	ContainerLog          *ContainerLog
 }
 
+// ContainerReattach is a struct describing containers that can be reattached.
+type ContainerReattach struct {
+	Container cproto.Container
+}
+
+// ContainerReattachAck is a struct describing containers reattachment success.
+type ContainerReattachAck struct {
+	Container cproto.Container
+	Failure   *ContainerFailure
+}
+
 // AgentStarted notifies the master that the agent has started up.
 type AgentStarted struct {
-	Version string
-	Label   string
-	Devices []device.Device
+	Version              string
+	Label                string
+	Devices              []device.Device
+	ContainersReattached []ContainerReattachAck
 }
 
 // ContainerStateChanged notifies the master that the agent transitioned the container state.

--- a/master/pkg/aproto/net.go
+++ b/master/pkg/aproto/net.go
@@ -1,0 +1,27 @@
+package aproto
+
+import (
+	"time"
+
+	"github.com/determined-ai/determined/master/pkg/model"
+)
+
+const (
+	// AgentReconnectAttempts is the max attempts an agent has to reconnect.
+	AgentReconnectAttempts = 5
+	// AgentReconnectBackoff is the time between attempts, with the exception of the first.
+	AgentReconnectBackoff = 5 * time.Second
+	// AgentReconnectWait is the max time the master should wait for an agent before considering
+	// it dead. The agent waits (AgentReconnectWait - AgentReconnectBackoff) before stopping
+	// attempts and AgentReconnectWait before crashing.
+	AgentReconnectWait = AgentReconnectAttempts * AgentReconnectBackoff
+)
+
+// GetRPConfig is a request from agent to RP actor for some config options.
+type GetRPConfig struct{}
+
+// GetRPResponse is a response to the previous request.
+type GetRPResponse struct {
+	AgentReconnectWait   model.Duration
+	AgentReattachEnabled bool
+}


### PR DESCRIPTION
## Description

Basic support for "reattaching" running containers on agent restart (or crash). 
- The full feature is somewhat dependent on #3070 (task logs); otherwise the task logs are lost. So, this PR hides the reattachment behind a feature flag: `resource_pool` configuration ffield `agent_reattach_enabled`.
- Since #2991 when an agent tried to cleanly reconnect under the disconnect timeout, it'd be rejected. With this change, they'll be "accepted" once again; same agent actor is reused. When reattachment if off, old container state is cleaned up as if they exited to an error.
- When reattachment is on, the master will send the agent a list of container it expects it to have; the agent will try to reattach these. It'll send a list of successfully reattached ones back to the master. Master will treat the containers not-successfully-reattached as if they exited to an error.
- Agent will now list and kill the containers with the same "agent_id", if they aren't supposed to be running (under reattachment).
- Allow users to configure `agent_reconnect_wait` on per-resource pool basis.

## Test Plan

`ManagedCluster` fixture is extended to account for the feature flag. A handful of tests added to check for successful recovery.

Manual test:
- Run `det cmd run sleep 120`.
- Kill agent; restart agent.
- The task will continue running and will finish successfully. (although logs are lost at the moment)

## Commentary (optional)

Future work: add tests for task logs working properly once #3070 lands.

## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ