### PR TITLE
feat: make `determined-agent [ARGS]` behave as `determined-agent run [ARGS]`.

### DIFF
--- a/agent/cmd/determined-agent/main.go
+++ b/agent/cmd/determined-agent/main.go
@@ -1,10 +1,39 @@
 package main
 
 import (
+	"os"
+
 	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
 )
 
+func maybeInjectRootAlias(rootCmd *cobra.Command, inject string) {
+	nonRootAliases := nonRootSubCmds(rootCmd)
+
+	if len(os.Args) > 1 {
+		for _, v := range nonRootAliases {
+			if os.Args[1] == v {
+				return
+			}
+		}
+	}
+	os.Args = append([]string{os.Args[0], inject}, os.Args[1:]...)
+}
+
+func nonRootSubCmds(rootCmd *cobra.Command) []string {
+	res := []string{"help"}
+	for _, c := range rootCmd.Commands() {
+		res = append(res, c.Name())
+		res = append(res, c.Aliases...)
+	}
+
+	return res
+}
+
 func main() {
+	rootCmd := newRootCmd()
+	maybeInjectRootAlias(rootCmd, "run")
+
 	if err := newRootCmd().Execute(); err != nil {
 		log.WithError(err).Fatal("fatal error running Determined agent")
 	}


### PR DESCRIPTION
## Description

One can run master as `determined-master`, but `determined-agent` just prints help, and you need `determined-agent run`. This is odd. 

This PR makes it work either way for the sake of backwards compatibility and convenience.

Cobra doesn't really support that, and they simply recommend users to inject `os.Args[1]`: https://github.com/spf13/cobra/issues/725

## Test Plan

- `determined-agent [RUN SUBCOMMAND ARGS]` should work the same as `determined-agent run [RUN SUBCOMMAND ARGS]`.
- other subcommands should still work fine.

## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
