### PR TITLE
fix: fluentbit should be able to run as nonroot [DET-5949]

### DIFF
--- a/agent/internal/fluent.go
+++ b/agent/internal/fluent.go
@@ -160,6 +160,8 @@ func startLoggingContainer(
 		},
 		masterSetOpts.LoggingOptions,
 		tlsConfig,
+		// TODO(DET-6188): Run fluentbit as non-root on Determined agents.
+		false,
 	)
 
 	createResponse, err := docker.ContainerCreate(

--- a/agent/internal/fluent.go
+++ b/agent/internal/fluent.go
@@ -160,7 +160,7 @@ func startLoggingContainer(
 		},
 		masterSetOpts.LoggingOptions,
 		tlsConfig,
-		// TODO(DET-6188): Run fluentbit as non-root on Determined agents.
+		// TODO(DET-6188): Run Fluent Bit as non-root on Determined agents.
 		false,
 	)
 

--- a/docs/release-notes/3160-nonroot-fluentbit.txt
+++ b/docs/release-notes/3160-nonroot-fluentbit.txt
@@ -2,5 +2,5 @@
 
 **Improvements**
 
--  Security and Logging: if a non-root user is used to run jobs on Kubernetes, the Fluentbit sidecar
+-  Security and Logging: if a non-root user is used to run jobs on Kubernetes, the Fluent Bit sidecar
    will also run as non-root.

--- a/docs/release-notes/3160-nonroot-fluentbit.txt
+++ b/docs/release-notes/3160-nonroot-fluentbit.txt
@@ -1,0 +1,6 @@
+:orphan:
+
+**Improvements**
+
+-  Security and Logging: if a non-root user is used to run jobs on Kubernetes, the Fluentbit sidecar
+   will also run as non-root.

--- a/docs/release-notes/3160-nonroot-fluentbit.txt
+++ b/docs/release-notes/3160-nonroot-fluentbit.txt
@@ -2,5 +2,5 @@
 
 **Improvements**
 
--  Security and Logging: if a non-root user is used to run jobs on Kubernetes, the Fluent Bit sidecar
-   will also run as non-root.
+-  Security and Logging: if a non-root user is used to run jobs on Kubernetes, the Fluent Bit
+   sidecar will also run as non-root.

--- a/master/pkg/fluent/fluent.go
+++ b/master/pkg/fluent/fluent.go
@@ -11,7 +11,7 @@ const (
 	localhost    = "localhost"
 	ipv4Loopback = "127.0.0.1"
 
-	nonRootbitUserName = "nonroot"
+	nonRootUserName = "nonroot"
 	nonRootUID         = 65532
 	nonRootGroupName   = "nonroot"
 	nonRootGID         = 65532
@@ -19,7 +19,7 @@ const (
 )
 
 // NonRootAgentUserGroup is a non-root agent user group that should exist by default
-// for fluentbit container images that has a writable homedir for on-disk buffers.
+// for Fluent Bit container images that has a writable homedir for on-disk buffers.
 var NonRootAgentUserGroup = model.AgentUserGroup{
 	User:  nonRootbitUserName,
 	UID:   nonRootUID,
@@ -188,7 +188,7 @@ end
 
 	bufferDir := "/var/log/flb-buffers"
 	if asNonRoot {
-		bufferDir = nonRootHome + "flb-buffers"
+		bufferDir = filepath.Join(nonRootHome, "flb-buffers")
 	}
 
 	fmt.Fprintf(&config, `

--- a/master/pkg/fluent/fluent.go
+++ b/master/pkg/fluent/fluent.go
@@ -2,6 +2,7 @@ package fluent
 
 import (
 	"fmt"
+	"path/filepath"
 	"strings"
 
 	"github.com/determined-ai/determined/master/pkg/model"
@@ -11,17 +12,17 @@ const (
 	localhost    = "localhost"
 	ipv4Loopback = "127.0.0.1"
 
-	nonRootUserName = "nonroot"
-	nonRootUID         = 65532
-	nonRootGroupName   = "nonroot"
-	nonRootGID         = 65532
-	nonRootHome        = "/home/nonroot/"
+	nonRootUserName  = "nonroot"
+	nonRootUID       = 65532
+	nonRootGroupName = "nonroot"
+	nonRootGID       = 65532
+	nonRootHome      = "/home/nonroot/"
 )
 
 // NonRootAgentUserGroup is a non-root agent user group that should exist by default
 // for Fluent Bit container images that has a writable homedir for on-disk buffers.
 var NonRootAgentUserGroup = model.AgentUserGroup{
-	User:  nonRootbitUserName,
+	User:  nonRootUserName,
 	UID:   nonRootUID,
 	Group: nonRootGroupName,
 	GID:   nonRootGID,

--- a/master/static/srv/entrypoint.sh
+++ b/master/static/srv/entrypoint.sh
@@ -19,8 +19,14 @@ if [ -n "$DET_K8S_LOG_TO_FILE" ]; then
     # stdin to rotated log files; the following line pipes stdout and stderr of
     # this process to separate multilog invocations. "n2" means to only store
     # one old log file -- the logs are being streamed out by Fluent Bit, so we
-    # don't need to keep any more old ones around.
-    exec > >(multilog n2 "$STDOUT_FILE-rotate")  2> >(multilog n2 "$STDERR_FILE-rotate")
+    # don't need to keep any more old ones around. Create the dirs ahead of time
+    # so they are 0755 (when they don't exist, multilog makes them 0700) and
+    # fluentbit can't access them with the nonroot user.
+    STDOUT_ROTATE_DIR="$STDOUT_FILE-rotate"
+    STDERR_ROTATE_DIR="$STDERR_FILE-rotate"
+    mkdir -p -m 755 $STDOUT_ROTATE_DIR
+    mkdir -p -m 755 $STDERR_ROTATE_DIR
+    exec > >(multilog n2 "$STDOUT_ROTATE_DIR")  2> >(multilog n2 "$STDERR_ROTATE_DIR")
 fi
 
 set -e

--- a/master/static/srv/entrypoint.sh
+++ b/master/static/srv/entrypoint.sh
@@ -20,8 +20,8 @@ if [ -n "$DET_K8S_LOG_TO_FILE" ]; then
     # this process to separate multilog invocations. "n2" means to only store
     # one old log file -- the logs are being streamed out by Fluent Bit, so we
     # don't need to keep any more old ones around. Create the dirs ahead of time
-    # so they are 0755 (when they don't exist, multilog makes them 0700) and
-    # fluentbit can't access them with the nonroot user.
+    # so they are 0755 (when they don't exist, multilog makes them 0700 and
+    # Fluent Bit can't access them with the non-root user).
     STDOUT_ROTATE_DIR="$STDOUT_FILE-rotate"
     STDERR_ROTATE_DIR="$STDERR_FILE-rotate"
     mkdir -p -m 755 $STDOUT_ROTATE_DIR

--- a/master/static/srv/k8_init_container_entrypoint.sh
+++ b/master/static/srv/k8_init_container_entrypoint.sh
@@ -13,5 +13,6 @@ do
     SRC=$2/$IDX.tar.gz
     DST=$3/$IDX
     mkdir $DST
+    # TODO(Brad): init container runs as root to use --same-owner, could be a problem.
     tar --same-owner -xvf $SRC -C $DST
 done


### PR DESCRIPTION
## Description
This change updates the kubernetes resource manager so that experiments launched from non-root users will also launch fluentbit as the `nonroot` user included in the fluentbit container.
<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan
- [x] test that launching a non root experiment works on k8s
- [ ] try to come up with a satisfactory explanation for why other seemingly reasonable solutions do not seem to work (may be due to a bug, looking that way)
<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)
Note: the init container still runs as root because `tar --same-owner` requires root. Changing that will require more work.
<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ