### PR TITLE
ci: add no-prompt to ignore safety checks in automation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -434,7 +434,9 @@ commands:
               --aux-agent-instance-type <<parameters.aux-agent-instance-type>> \
               --compute-agent-instance-type <<parameters.compute-agent-instance-type>> \
               --max-dynamic-agents <<parameters.max-dynamic-agents>> \
-              --keypair <<parameters.keypair>>
+              --keypair <<parameters.keypair>> \
+              --no-prompt
+
   terminate-aws-cluster:
     parameters:
       cluster-id:


### PR DESCRIPTION
## Description

Automation is tripping up on this, but in this case it's safe: https://github.com/determined-ai/determined/pull/3117

## Test Plan

Will rely on the normal CI pipeline to verify