### PR TITLE
refactor: classmethods instead of staticmethods in trial controllers.

### DIFF
--- a/harness/determined/_trial_controller.py
+++ b/harness/determined/_trial_controller.py
@@ -1,6 +1,6 @@
 import abc
 import logging
-from typing import Any, Optional
+from typing import Any, Optional, Type
 
 import determined as det
 from determined import horovod, profiler, workload
@@ -49,18 +49,21 @@ class TrialController(metaclass=abc.ABCMeta):
             )
             logging.getLogger().setLevel(log_level)
 
-    @staticmethod
+    @classmethod
     @abc.abstractmethod
-    def pre_execute_hook(env: det.EnvContext, hvd_config: horovod.HorovodContext) -> Any:
+    def pre_execute_hook(
+        cls: Type["TrialController"], env: det.EnvContext, hvd_config: horovod.HorovodContext
+    ) -> Any:
         """
         Certain things must be initialized before either running user code (in the Native API case)
         or intializing user code (in the Trial API case).
         """
         pass
 
-    @staticmethod
+    @classmethod
     @abc.abstractmethod
     def from_trial(
+        cls: Type["TrialController"],
         trial_inst: "det.Trial",
         context: det.TrialContext,
         env: det.EnvContext,
@@ -79,12 +82,12 @@ class TrialController(metaclass=abc.ABCMeta):
         """
         pass
 
-    @staticmethod
-    def supports_mixed_precision() -> bool:
+    @classmethod
+    def supports_mixed_precision(cls: Type["TrialController"]) -> bool:
         return False
 
-    @staticmethod
-    def supports_averaging_training_metrics() -> bool:
+    @classmethod
+    def supports_averaging_training_metrics(cls: Type["TrialController"]) -> bool:
         return False
 
     def initialize_wrapper(self) -> None:

--- a/harness/determined/pytorch/_pytorch_trial.py
+++ b/harness/determined/pytorch/_pytorch_trial.py
@@ -4,7 +4,7 @@ import pickle
 import random
 import time
 from abc import abstractmethod
-from typing import Any, Dict, List, Optional, Tuple, Union, cast
+from typing import Any, Dict, List, Optional, Tuple, Type, Union, cast
 
 import numpy as np
 import torch
@@ -63,17 +63,19 @@ class PyTorchTrialController(det.TrialController):
 
         self.latest_batch = self.env.latest_batch
 
-    @staticmethod
-    def pre_execute_hook(env: det.EnvContext, hvd_config: horovod.HorovodContext) -> None:
+    @classmethod
+    def pre_execute_hook(
+        cls: Type["PyTorchTrialController"], env: det.EnvContext, hvd_config: horovod.HorovodContext
+    ) -> None:
         # Initialize the correct horovod.
         if hvd_config.use:
             hvd.require_horovod_type("torch", "PyTorchTrial is in use.")
             hvd.init()
 
-        PyTorchTrialController._set_random_seeds(env.trial_seed)
+        cls._set_random_seeds(env.trial_seed)
 
-    @staticmethod
-    def _set_random_seeds(seed: int) -> None:
+    @classmethod
+    def _set_random_seeds(cls: Type["PyTorchTrialController"], seed: int) -> None:
         # Set identical random seeds on all training processes.
         # When using horovod, each worker will start at a unique
         # offset in the dataset, ensuring it's processing a unique
@@ -85,16 +87,18 @@ class PyTorchTrialController(det.TrialController):
         # torch.backends.cudnn.deterministic = True
         # torch.backends.cudnn.benchmark = False
 
-    @staticmethod
-    def from_trial(*args: Any, **kwargs: Any) -> det.TrialController:
-        return PyTorchTrialController(*args, **kwargs)
+    @classmethod
+    def from_trial(
+        cls: Type["PyTorchTrialController"], *args: Any, **kwargs: Any
+    ) -> det.TrialController:
+        return cls(*args, **kwargs)
 
-    @staticmethod
-    def supports_mixed_precision() -> bool:
+    @classmethod
+    def supports_mixed_precision(cls: Type["PyTorchTrialController"]) -> bool:
         return True
 
-    @staticmethod
-    def supports_averaging_training_metrics() -> bool:
+    @classmethod
+    def supports_averaging_training_metrics(cls: Type["PyTorchTrialController"]) -> bool:
         return True
 
     def _check_evaluate_implementation(self) -> None:
@@ -451,8 +455,10 @@ class PyTorchTrialController(det.TrialController):
 
         return metrics
 
-    @staticmethod
-    def _convert_metrics_to_numpy(metrics: Dict[str, Any]) -> Dict[str, Any]:
+    @classmethod
+    def _convert_metrics_to_numpy(
+        cls: Type["PyTorchTrialController"], metrics: Dict[str, Any]
+    ) -> Dict[str, Any]:
         for metric_name, metric_val in metrics.items():
             if isinstance(metric_val, torch.Tensor):
                 metrics[metric_name] = metric_val.cpu().numpy()


### PR DESCRIPTION
## Description

Use classmethods for some trial controller internals to allow users inherit from our TrialControllers and override these w/o issues with inheritance.

Motivated by a question https://determined-community.slack.com/archives/CV3MTNZ6U/p1636077811035500 , where they wanted to setup tf logical devices in order to debug some OOM issue. That requires overriding `TFKerasTrialController#_configure_session`, but staticmethod style forces you to also override `from_trial`. 

Existing overrides using `staticmethod` shouldn't be affected and should continue working.

## Test Plan

Everything works as before.

## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
