### PR TITLE
feat: detect MIG instances in agents

### DIFF
--- a/agent/internal/detect.go
+++ b/agent/internal/detect.go
@@ -1,10 +1,12 @@
 package internal
 
 import (
+	"bufio"
 	"encoding/csv"
 	"fmt"
 	"io"
 	"os/exec"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -71,11 +73,69 @@ func detectCPUs() ([]device.Device, error) {
 	}
 }
 
+var detectMIGEnabled = []string{
+							"nvidia-smi", "--query-gpu=mig.mode.current", "--format=csv,noheader"}
+var detectNvidiaDevices = []string{"nvidia-smi", "-L"} // Lists both GPUs and MIG instances
+var detectMIGRegExp = regexp.MustCompile(`(?P<dev>MIG \S+).+\(UUID.+(?P<uuid>MIG.+)\)`)
+
 var detectGPUsArgs = []string{"nvidia-smi", "--query-gpu=index,name,uuid", "--format=csv,noheader"}
 var detectGPUsIDFlagTpl = "--id=%v"
 
+// detect if MIG is enabled and if there are instances configured.
+func detectMigInstances(visibleGPUs string) ([]device.Device, error) {
+	// Fail fast if MIG isn't even enabled
+	// #nosec G204
+	cmd := exec.Command(detectMIGEnabled[0], detectMIGEnabled[1:]...)
+	out, err := cmd.Output()
+	if execError, ok := err.(*exec.Error); ok && execError.Err == exec.ErrNotFound {
+		return nil, nil
+	} else if err != nil {
+		log.WithError(err).WithField("output", string(out)).Warnf(
+			"error while executing nvidia-smi to detect MIG mode")
+		return nil, nil
+	}
+	if !strings.HasPrefix(string(out), "Enabled") {
+		return nil, nil
+	}
+
+	// #nosec G204
+	cmd = exec.Command(detectNvidiaDevices[0], detectNvidiaDevices[1:]...)
+	out, err = cmd.Output()
+	if err != nil {
+		log.WithError(err).WithField("output", string(out)).Warnf(
+			"error while executing nvidia-smi to detect MIG instances")
+		return nil, nil
+	}
+
+	devices := make([]device.Device, 0)
+	deviceIndex := 0
+
+	scanner := bufio.NewScanner(strings.NewReader(string(out)))
+	for scanner.Scan() {
+		line := scanner.Text()
+
+		if detectMIGRegExp.MatchString(line) {
+			matches := detectMIGRegExp.FindStringSubmatch(line)
+			if len(matches) != 3 {
+				continue
+			}
+			brand := matches[1]
+			uuid := matches[2]
+			devices = append(devices,
+				device.Device{ID: deviceIndex, Brand: brand, UUID: uuid, Type: device.GPU})
+			deviceIndex++
+		}
+	}
+	return devices, err
+}
+
 // detectGPUs returns the list of available Nvidia GPUs.
 func detectGPUs(visibleGPUs string) ([]device.Device, error) {
+	devices, err := detectMigInstances(visibleGPUs)
+	if err == nil && devices != nil && len(devices) > 0 {
+		return devices, nil
+	}
+
 	flags := detectGPUsArgs[1:]
 	if visibleGPUs != "" {
 		flags = append(flags, fmt.Sprintf(detectGPUsIDFlagTpl, visibleGPUs))
@@ -88,11 +148,12 @@ func detectGPUs(visibleGPUs string) ([]device.Device, error) {
 	if execError, ok := err.(*exec.Error); ok && execError.Err == exec.ErrNotFound {
 		return nil, nil
 	} else if err != nil {
-		log.WithError(err).WithField("output", string(out)).Warnf("error while executing nvidia-smi")
+		log.WithError(err).WithField("output", string(out)).Warnf(
+			"error while executing nvidia-smi to detect GPUs")
 		return nil, nil
 	}
 
-	devices := make([]device.Device, 0)
+	devices = make([]device.Device, 0)
 
 	r := csv.NewReader(strings.NewReader(string(out)))
 	for {

--- a/agent/internal/detect.go
+++ b/agent/internal/detect.go
@@ -126,7 +126,7 @@ func detectMigInstances(visibleGPUs string) ([]device.Device, error) {
 			deviceIndex++
 		}
 	}
-	return devices, err
+	return devices, nil
 }
 
 // detectGPUs returns the list of available Nvidia GPUs.

--- a/docs/release-notes/3204-experimental-mig-support.txt
+++ b/docs/release-notes/3204-experimental-mig-support.txt
@@ -1,0 +1,7 @@
+:orphan:
+
+**New Features**
+
+-  Experimental MIG support: static agents and kubernetes clusters may be able to use MIG instances
+   for some workloads. Distributed training is not supported, and all MIG instances and nodes within
+   a resource pool must still be homogeneous.


### PR DESCRIPTION
## Description

This is a step toward supporting MIG instances, a feature of CUDA 11 and A100's that allows a GPU to be split into smaller virtual devices that have their own compute / memory resources. For instance, a 40GB A100 can be split into 7 5GB MIG instances. This could be useful for more granular scheduling of smaller, distinct jobs on bigger GPUs. For instance, a single A100 could be shared by 7 distinct JupyterLab instances, or 7 concurrent (smaller) trials.

This support is considered experimental only and applies only to Kubernetes clusters and static agent clusters. Distributed training is not supported.

## Test Plan

See https://docs.nvidia.com/datacenter/tesla/mig-user-guide/index.html for how to do the MIG portion of this. The GPU cards need to have their MIG mode enabled and the MIG instances created before starting the Determined agent (this, and the distinction between how many physical GPUs you request and how many logical devices are then presented, is what's missing from supporting dynamic agents). 

I tested on a cluster with 2 static agents. Each agent had 2 A100 split into 7 MIG instances each (profile 19). I confirmed that the MIG slots were reported and accounted for correctly (although static agents always report -1 for "Slots per node" and I have filed a separate issue to improve this). I confirmed that distributed training is not possible on PyTorch or TensorFlow because of APIs that deal exclusively with physical devices even in the presence of a MIG configuration. I don't believe distributed training is a very useful thing to use MIG instances for anyway. I have run other jobs including simple experiments and hyperparameter search jobs and confirmed the additional slots are scheduled as expected. I have run GPU notebooks and confirmed that you get the number of MIG instances passed through to the JupyterLab that you select as "GPU slots".

I have also run all the upstream GPU tests in Circle CI and done manual testing locally to confirm non-MIG configurations still behave the same. I have previously run similar tests on a GKE cluster with daemonsets to configure MIG, etc. in an identical configuration. NVIDIA's documentation of setting this up is here: https://docs.nvidia.com/datacenter/cloud-native/kubernetes/mig-k8s.html.

## Commentary

Again, this support is experimental. Not every feature is supported, and the workloads for which this is useful need to be better understood and tested. This feature will be activated if MIG is enabled and MIG instances are created, otherwise it will fall back to using physical GPUs only.

The assumption that all nodes and GPUs within a resource pool are homogeneous still applies: you cannot use MIG instances of differing sizes (e.g. the 4/3 configuration), and you cannot use MIG on only a subset of GPUs within a node or on only a subset of nodes within a resource pool.

## Checklist

- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.