### PR TITLE
feat: model registry API can update name, has Notes field

### DIFF
--- a/e2e_tests/tests/cluster/test_model_registry.py
+++ b/e2e_tests/tests/cluster/test_model_registry.py
@@ -116,16 +116,11 @@ def test_model_registry() -> None:
         assert len(all_versions) == 1
 
         # Create some more models and validate listing models.
-        tform = d.create_model("transformer", "all you need is attention __test__")
+        tform = d.create_model("transformer", "all you need is attention")
         objectdetect = d.create_model("object-detection", "a bounding box model")
 
         models = d.get_models(sort_by=ModelSortBy.NAME)
         assert [m.name for m in models] == ["mnist", "object-detection", "transformer"]
-
-        # Search model descriptions
-        results = d.get_models(description="__test__")
-        assert len(results) == 1
-        assert results[0].name == "transformer"
 
         # Test model labels combined
         mnist.set_labels(["hello", "world"])

--- a/e2e_tests/tests/cluster/test_model_registry.py
+++ b/e2e_tests/tests/cluster/test_model_registry.py
@@ -14,121 +14,132 @@ def test_model_registry() -> None:
     )
 
     d = Determined(conf.make_master_url())
+    mnist = None
+    objectdetect = None
+    tform = None
 
-    # Create a model and validate twiddling the metadata.
-    mnist = d.create_model("mnist", "simple computer vision model", labels=["a", "b"])
-    assert mnist.metadata == {}
+    try:
+        # Create a model and validate twiddling the metadata.
+        mnist = d.create_model("mnist", "simple computer vision model", labels=["a", "b"])
+        assert mnist.metadata == {}
 
-    mnist.add_metadata({"testing": "metadata"})
-    db_model = d.get_model(mnist.model_id)
-    # Make sure the model metadata is correct and correctly saved to the db.
-    assert mnist.metadata == db_model.metadata
-    assert mnist.metadata == {"testing": "metadata"}
+        mnist.add_metadata({"testing": "metadata"})
+        db_model = d.get_model(mnist.model_id)
+        # Make sure the model metadata is correct and correctly saved to the db.
+        assert mnist.metadata == db_model.metadata
+        assert mnist.metadata == {"testing": "metadata"}
 
-    # Confirm DB assigned username
-    assert db_model.username == "determined"
+        # Confirm DB assigned username
+        assert db_model.username == "determined"
 
-    mnist.add_metadata({"some_key": "some_value"})
-    db_model = d.get_model(mnist.model_id)
-    assert mnist.metadata == db_model.metadata
-    assert mnist.metadata == {"testing": "metadata", "some_key": "some_value"}
+        mnist.add_metadata({"some_key": "some_value"})
+        db_model = d.get_model(mnist.model_id)
+        assert mnist.metadata == db_model.metadata
+        assert mnist.metadata == {"testing": "metadata", "some_key": "some_value"}
 
-    mnist.add_metadata({"testing": "override"})
-    db_model = d.get_model(mnist.model_id)
-    assert mnist.metadata == db_model.metadata
-    assert mnist.metadata == {"testing": "override", "some_key": "some_value"}
+        mnist.add_metadata({"testing": "override"})
+        db_model = d.get_model(mnist.model_id)
+        assert mnist.metadata == db_model.metadata
+        assert mnist.metadata == {"testing": "override", "some_key": "some_value"}
 
-    mnist.remove_metadata(["some_key"])
-    db_model = d.get_model(mnist.model_id)
-    assert mnist.metadata == db_model.metadata
-    assert mnist.metadata == {"testing": "override"}
+        mnist.remove_metadata(["some_key"])
+        db_model = d.get_model(mnist.model_id)
+        assert mnist.metadata == db_model.metadata
+        assert mnist.metadata == {"testing": "override"}
 
-    mnist.set_labels(["hello", "world"])
-    db_model = d.get_model(mnist.model_id)
-    assert mnist.labels == db_model.labels
-    assert db_model.labels == ["hello", "world"]
+        mnist.set_labels(["hello", "world"])
+        db_model = d.get_model(mnist.model_id)
+        assert mnist.labels == db_model.labels
+        assert db_model.labels == ["hello", "world"]
 
-    # confirm patch does not overwrite other fields
-    mnist.set_description("abcde")
-    db_model = d.get_model(mnist.model_id)
-    assert db_model.metadata == {"testing": "override"}
-    assert db_model.labels == ["hello", "world"]
+        # confirm patch does not overwrite other fields
+        mnist.set_description("abcde")
+        db_model = d.get_model(mnist.model_id)
+        assert db_model.metadata == {"testing": "override"}
+        assert db_model.labels == ["hello", "world"]
 
-    # overwrite labels to empty list
-    mnist.set_labels([])
-    db_model = d.get_model(mnist.model_id)
-    assert db_model.labels == []
+        # overwrite labels to empty list
+        mnist.set_labels([])
+        db_model = d.get_model(mnist.model_id)
+        assert db_model.labels == []
 
-    # archive and unarchive
-    assert mnist.archived is False
-    mnist.archive()
-    db_model = d.get_model(mnist.model_id)
-    assert db_model.archived is True
-    mnist.unarchive()
-    db_model = d.get_model(mnist.model_id)
-    assert db_model.archived is False
+        # archive and unarchive
+        assert mnist.archived is False
+        mnist.archive()
+        db_model = d.get_model(mnist.model_id)
+        assert db_model.archived is True
+        mnist.unarchive()
+        db_model = d.get_model(mnist.model_id)
+        assert db_model.archived is False
 
-    # Register a version for the model and validate the latest.
-    checkpoint = d.get_experiment(exp_id).top_checkpoint()
-    model_version = mnist.register_version(checkpoint.uuid)
-    assert model_version.model_version == 1
+        # Register a version for the model and validate the latest.
+        checkpoint = d.get_experiment(exp_id).top_checkpoint()
+        model_version = mnist.register_version(checkpoint.uuid)
+        assert model_version.model_version == 1
 
-    latest_version = mnist.get_version()
-    assert latest_version is not None
-    assert latest_version.checkpoint.uuid == checkpoint.uuid
+        latest_version = mnist.get_version()
+        assert latest_version is not None
+        assert latest_version.checkpoint.uuid == checkpoint.uuid
 
-    latest_version.set_name("Test 2021")
-    db_version = mnist.get_version()
-    assert db_version is not None
-    assert db_version.name == "Test 2021"
+        latest_version.set_name("Test 2021")
+        db_version = mnist.get_version()
+        assert db_version is not None
+        assert db_version.name == "Test 2021"
 
-    latest_version.set_notes("# Hello Markdown")
-    db_version = mnist.get_version()
-    assert db_version is not None
-    assert db_version.notes == "# Hello Markdown"
+        latest_version.set_notes("# Hello Markdown")
+        db_version = mnist.get_version()
+        assert db_version is not None
+        assert db_version.notes == "# Hello Markdown"
 
-    # Run another basic test and register its checkpoint as a version as well.
-    # Validate the latest has been updated.
-    exp_id = exp.run_basic_test(
-        conf.fixtures_path("mnist_pytorch/const-pytorch11.yaml"),
-        conf.tutorials_path("mnist_pytorch"),
-        None,
-    )
-    checkpoint = d.get_experiment(exp_id).top_checkpoint()
-    model_version = mnist.register_version(checkpoint.uuid)
-    assert model_version.model_version == 2
+        # Run another basic test and register its checkpoint as a version as well.
+        # Validate the latest has been updated.
+        exp_id = exp.run_basic_test(
+            conf.fixtures_path("mnist_pytorch/const-pytorch11.yaml"),
+            conf.tutorials_path("mnist_pytorch"),
+            None,
+        )
+        checkpoint = d.get_experiment(exp_id).top_checkpoint()
+        model_version = mnist.register_version(checkpoint.uuid)
+        assert model_version.model_version == 2
 
-    latest_version = mnist.get_version()
-    assert latest_version is not None
-    assert latest_version.checkpoint.uuid == checkpoint.uuid
+        latest_version = mnist.get_version()
+        assert latest_version is not None
+        assert latest_version.checkpoint.uuid == checkpoint.uuid
 
-    # Ensure the correct number of versions are present.
-    all_versions = mnist.get_versions()
-    assert len(all_versions) == 2
+        # Ensure the correct number of versions are present.
+        all_versions = mnist.get_versions()
+        assert len(all_versions) == 2
 
-    # Test deletion of model version
-    latest_version.delete()
-    all_versions = mnist.get_versions()
-    assert len(all_versions) == 1
+        # Test deletion of model version
+        latest_version.delete()
+        all_versions = mnist.get_versions()
+        assert len(all_versions) == 1
 
-    # Create some more models and validate listing models.
-    tform = d.create_model("transformer", "all you need is attention")
-    objectdetect = d.create_model("object-detection", "a bounding box model")
+        # Create some more models and validate listing models.
+        tform = d.create_model("transformer", "all you need is attention __test__")
+        objectdetect = d.create_model("object-detection", "a bounding box model")
 
-    models = d.get_models(sort_by=ModelSortBy.NAME)
-    assert [m.name for m in models] == ["mnist", "object-detection", "transformer"]
+        models = d.get_models(sort_by=ModelSortBy.NAME)
+        assert [m.name for m in models] == ["mnist", "object-detection", "transformer"]
 
-    # Test model labels combined
-    mnist.set_labels(["hello", "world"])
-    tform.set_labels(["world", "test", "zebra"])
-    labels = d.get_model_labels()
-    assert labels == ["world", "hello", "test", "zebra"]
+        # Search model descriptions
+        results = d.get_models(description="__test__")
+        assert len(results) == 1
+        assert results[0].name == "transformer"
 
-    # Test deletion of model
-    tform.delete()
-    models = d.get_models(sort_by=ModelSortBy.NAME)
-    assert [m.name for m in models] == ["mnist", "object-detection"]
+        # Test model labels combined
+        mnist.set_labels(["hello", "world"])
+        tform.set_labels(["world", "test", "zebra"])
+        labels = d.get_model_labels()
+        assert labels == ["world", "hello", "test", "zebra"]
 
-    # Continue cleaning model registry of test data
-    mnist.delete()
-    objectdetect.delete()
+        # Test deletion of model
+        tform.delete()
+        tform = None
+        models = d.get_models(sort_by=ModelSortBy.NAME)
+        assert [m.name for m in models] == ["mnist", "object-detection"]
+    finally:
+        # Clean model registry of test models
+        for model in [mnist, objectdetect, tform]:
+            if model is not None:
+                model.delete()

--- a/master/internal/api_model.go
+++ b/master/internal/api_model.go
@@ -37,8 +37,8 @@ func (a *apiServer) GetModel(
 func (a *apiServer) GetModels(
 	_ context.Context, req *apiv1.GetModelsRequest) (*apiv1.GetModelsResponse, error) {
 	resp := &apiv1.GetModelsResponse{}
-	nameFilterExpr := strings.ToLower(req.Name)
-	descFilterExpr := strings.ToLower(req.Description)
+	nameFilterExpr := req.Name
+	descFilterExpr := req.Description
 	archFilterExpr := ""
 	if req.Archived != nil {
 		archFilterExpr = strconv.FormatBool(req.Archived.Value)
@@ -80,7 +80,6 @@ func (a *apiServer) GetModels(
 		labelFilterExpr,
 		nameFilterExpr,
 		descFilterExpr,
-		"%",
 	)
 	if err != nil {
 		return nil, err
@@ -131,6 +130,13 @@ func (a *apiServer) PatchModel(
 
 	currModel := getResp.Model
 	madeChanges := false
+
+	if req.Model.Name != nil && req.Model.Name.Value != currModel.Name {
+		log.Infof("model (%d) name changing from \"%s\" to \"%s\"",
+			req.ModelId, currModel.Name, req.Model.Name.Value)
+		madeChanges = true
+		currModel.Name = req.Model.Name.Value
+	}
 
 	if req.Model.Description != nil && req.Model.Description.Value != currModel.Description {
 		log.Infof("model (%d) description changing from \"%s\" to \"%s\"",
@@ -187,8 +193,8 @@ func (a *apiServer) PatchModel(
 
 	finalModel := &modelv1.Model{}
 	err = a.m.db.QueryProto(
-		"update_model", finalModel, req.ModelId, currModel.Description, currModel.Notes,
-		currMeta, currLabels)
+		"update_model", finalModel, req.ModelId, currModel.Name, currModel.Description,
+		currModel.Notes, currMeta, currLabels)
 
 	return &apiv1.PatchModelResponse{Model: finalModel},
 		errors.Wrapf(err, "error updating model %d in database", req.ModelId)

--- a/master/internal/api_model.go
+++ b/master/internal/api_model.go
@@ -80,6 +80,7 @@ func (a *apiServer) GetModels(
 		labelFilterExpr,
 		nameFilterExpr,
 		descFilterExpr,
+		"%",
 	)
 	if err != nil {
 		return nil, err

--- a/master/static/migrations/20211118104412_model_add_notes.down.sql
+++ b/master/static/migrations/20211118104412_model_add_notes.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE public.models DROP COLUMN notes;

--- a/master/static/migrations/20211118104412_model_add_notes.up.sql
+++ b/master/static/migrations/20211118104412_model_add_notes.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE public.models ADD COLUMN notes text;

--- a/master/static/srv/get_model.sql
+++ b/master/static/srv/get_model.sql
@@ -1,4 +1,4 @@
-SELECT m.id, m.name, m.description, m.metadata, m.creation_time, m.last_updated_time, array_to_json(m.labels) AS labels, u.username, m.archived, COUNT(mv.version) as num_versions
+SELECT m.id, m.name, m.description, m.notes, m.metadata, m.creation_time, m.last_updated_time, array_to_json(m.labels) AS labels, u.username, m.archived, COUNT(mv.version) as num_versions
 FROM models as m
   LEFT JOIN model_versions as mv
     ON mv.model_id = m.id

--- a/master/static/srv/get_model_version.sql
+++ b/master/static/srv/get_model_version.sql
@@ -5,7 +5,7 @@ WITH mv AS (
     WHERE model_id = $1 AND model_versions.id = $2
 ),
 m AS (
-  SELECT m.id, m.name, m.description, m.metadata, m.creation_time, m.last_updated_time, array_to_json(m.labels) AS labels, u.username, m.archived, COUNT(mv.version) as num_versions
+  SELECT m.id, m.name, m.description, m.notes, m.metadata, m.creation_time, m.last_updated_time, array_to_json(m.labels) AS labels, u.username, m.archived, COUNT(mv.version) as num_versions
   FROM models as m
   JOIN users as u ON u.id = m.user_id
   LEFT JOIN model_versions as mv

--- a/master/static/srv/get_model_versions.sql
+++ b/master/static/srv/get_model_versions.sql
@@ -15,7 +15,7 @@ WITH mv AS (
   WHERE model_id = $1
 ),
 m AS (
-  SELECT m.id, m.name, m.description, m.metadata, m.creation_time, m.last_updated_time, array_to_json(m.labels) AS labels, u.username, m.archived, COUNT(mv.version) as num_versions
+  SELECT m.id, m.name, m.description, m.notes, m.metadata, m.creation_time, m.last_updated_time, array_to_json(m.labels) AS labels, u.username, m.archived, COUNT(mv.version) as num_versions
   FROM models as m
   JOIN users as u ON u.id = m.user_id
   LEFT JOIN model_versions as mv

--- a/master/static/srv/get_models.sql
+++ b/master/static/srv/get_models.sql
@@ -4,7 +4,7 @@ LEFT JOIN users as u ON u.id = m.user_id
 WHERE ($1 = '' OR m.archived = $1::BOOL)
 AND ($2 = '' OR (u.username IN (SELECT unnest(string_to_array($2, ',')))))
 AND ($3 = '' OR (m.labels <@ string_to_array($3, ',')))
-AND ($4 = '' OR LOWER(m.name) LIKE $4)
-AND ($5 = '' OR LOWER(m.description) LIKE $5)
+AND ($4 = '' OR LOWER(m.name) = $4)
+AND ($5 = '' OR (LOWER(m.description) LIKE CONCAT($6::text, $5, $6::text)))
 GROUP BY m.id, u.id
 ORDER BY %s;

--- a/master/static/srv/get_models.sql
+++ b/master/static/srv/get_models.sql
@@ -1,4 +1,4 @@
-SELECT m.id, m.name, m.description, m.metadata, m.creation_time, m.last_updated_time, array_to_json(m.labels) AS labels, u.username, m.archived, COUNT(mv.version) as num_versions FROM models as m
+SELECT m.id, m.name, m.description, m.notes, m.metadata, m.creation_time, m.last_updated_time, array_to_json(m.labels) AS labels, u.username, m.archived, COUNT(mv.version) as num_versions FROM models as m
 LEFT JOIN model_versions as mv ON mv.model_id = m.id
 LEFT JOIN users as u ON u.id = m.user_id
 WHERE ($1 = '' OR m.archived = $1::BOOL)

--- a/master/static/srv/get_models.sql
+++ b/master/static/srv/get_models.sql
@@ -4,7 +4,7 @@ LEFT JOIN users as u ON u.id = m.user_id
 WHERE ($1 = '' OR m.archived = $1::BOOL)
 AND ($2 = '' OR (u.username IN (SELECT unnest(string_to_array($2, ',')))))
 AND ($3 = '' OR (m.labels <@ string_to_array($3, ',')))
-AND ($4 = '' OR LOWER(m.name) = $4)
-AND ($5 = '' OR (LOWER(m.description) LIKE CONCAT($6::text, $5, $6::text)))
+AND ($4 = '' OR m.name ILIKE $4)
+AND ($5 = '' OR m.description ILIKE $5)
 GROUP BY m.id, u.id
 ORDER BY %s;

--- a/master/static/srv/insert_model.sql
+++ b/master/static/srv/insert_model.sql
@@ -1,8 +1,8 @@
 WITH m AS (
-  INSERT INTO models (name, description, metadata, labels, user_id, creation_time, last_updated_time)
-  VALUES ($1, $2, $3, string_to_array($4, ','), $5, current_timestamp, current_timestamp)
-  RETURNING name, description, metadata, labels, user_id, creation_time, last_updated_time, id
+  INSERT INTO models (name, description, metadata, labels, notes, user_id, creation_time, last_updated_time)
+  VALUES ($1, $2, $3, string_to_array($4, ','), $5, $6, current_timestamp, current_timestamp)
+  RETURNING name, description, notes, metadata, labels, user_id, creation_time, last_updated_time, id
 )
-SELECT m.name, m.description, m.metadata, array_to_json(m.labels) AS labels, u.username, m.creation_time, m.last_updated_time, m.id
+SELECT m.name, m.description, m.notes, m.metadata, array_to_json(m.labels) AS labels, u.username, m.creation_time, m.last_updated_time, m.id
 FROM m
 JOIN users u on u.id = m.user_id;

--- a/master/static/srv/insert_model_version.sql
+++ b/master/static/srv/insert_model_version.sql
@@ -28,7 +28,7 @@ u AS (
 	SELECT username FROM users WHERE id = $6
 ),
 m AS (
-  SELECT m.id, m.name, m.description, m.metadata, m.creation_time, m.last_updated_time, array_to_json(m.labels) AS labels, u.username, m.archived, COUNT(mv.version) as num_versions
+  SELECT m.id, m.name, m.description, m.notes, m.metadata, m.creation_time, m.last_updated_time, array_to_json(m.labels) AS labels, u.username, m.archived, COUNT(mv.version) as num_versions
   FROM models as m
   JOIN users as u ON u.id = m.user_id
   LEFT JOIN model_versions as mv

--- a/master/static/srv/update_model.sql
+++ b/master/static/srv/update_model.sql
@@ -1,3 +1,3 @@
-UPDATE models SET description = $2, notes= $3, metadata = $4, labels = string_to_array($5, ','), last_updated_time = current_timestamp
+UPDATE models SET name = $2, description = $3, notes= $4, metadata = $5, labels = string_to_array($6, ','), last_updated_time = current_timestamp
 WHERE id = $1
 RETURNING name, description, notes, metadata, array_to_json(labels) as labels, creation_time, last_updated_time

--- a/master/static/srv/update_model.sql
+++ b/master/static/srv/update_model.sql
@@ -1,3 +1,3 @@
-UPDATE models SET name = $2, description = $3, notes= $4, metadata = $5, labels = string_to_array($6, ','), last_updated_time = current_timestamp
+UPDATE models SET name = $2, description = $3, notes = $4, metadata = $5, labels = string_to_array($6, ','), last_updated_time = current_timestamp
 WHERE id = $1
 RETURNING name, description, notes, metadata, array_to_json(labels) as labels, creation_time, last_updated_time

--- a/master/static/srv/update_model.sql
+++ b/master/static/srv/update_model.sql
@@ -1,3 +1,3 @@
-UPDATE models SET description = $2, metadata = $3, labels = string_to_array($4, ','), last_updated_time = current_timestamp
+UPDATE models SET description = $2, notes= $3, metadata = $4, labels = string_to_array($5, ','), last_updated_time = current_timestamp
 WHERE id = $1
-RETURNING name, description, metadata, array_to_json(labels) as labels, creation_time, last_updated_time
+RETURNING name, description, notes, metadata, array_to_json(labels) as labels, creation_time, last_updated_time

--- a/master/static/srv/update_model_version.sql
+++ b/master/static/srv/update_model_version.sql
@@ -6,7 +6,7 @@ WITH mv AS (
   RETURNING id, version, checkpoint_uuid, model_id, last_updated_time, creation_time, name, comment, notes, labels, metadata
 ),
 m AS (
-  SELECT m.id, m.name, m.description, m.metadata, m.creation_time, m.last_updated_time, array_to_json(m.labels) AS labels, u.username, m.archived, COUNT(mv.version) as num_versions
+  SELECT m.id, m.name, m.description, m.notes, m.metadata, m.creation_time, m.last_updated_time, array_to_json(m.labels) AS labels, u.username, m.archived, COUNT(mv.version) as num_versions
   FROM models as m
   JOIN users as u ON u.id = m.user_id
   LEFT JOIN model_versions as mv

--- a/proto/src/determined/api/v1/model.proto
+++ b/proto/src/determined/api/v1/model.proto
@@ -100,6 +100,8 @@ message PostModelRequest {
   repeated string labels = 4;
   // User who is creating this model.
   string username = 5;
+  // Notes associated with this model.
+  string notes = 6;
 }
 
 // Response to PostModelRequest.

--- a/proto/src/determined/model/v1/model.proto
+++ b/proto/src/determined/model/v1/model.proto
@@ -47,6 +47,8 @@ message Model {
   string username = 10;
   // Whether this model is archived or not.
   bool archived = 11;
+  // Notes associated with this model.
+  string notes = 12;
 }
 
 // PatchModel is a partial update to a model with only id required
@@ -62,6 +64,8 @@ message PatchModel {
   google.protobuf.Struct metadata = 4;
   // An updated label list for the model.
   google.protobuf.ListValue labels = 5;
+  // Updated notes associated with this model.
+  google.protobuf.StringValue notes = 6;
 }
 
 // A version of a model containing a checkpoint. Users can label checkpoints as

--- a/webui/react/src/services/api-ts-sdk/api.ts
+++ b/webui/react/src/services/api-ts-sdk/api.ts
@@ -3123,6 +3123,12 @@ export interface V1Model {
      * @memberof V1Model
      */
     archived?: boolean;
+    /**
+     * Notes associated with this model.
+     * @type {string}
+     * @memberof V1Model
+     */
+    notes?: string;
 }
 
 /**
@@ -3380,6 +3386,12 @@ export interface V1PatchModel {
      * @memberof V1PatchModel
      */
     labels?: Array<any>;
+    /**
+     * Updated notes associated with this model.
+     * @type {string}
+     * @memberof V1PatchModel
+     */
+    notes?: string;
 }
 
 /**
@@ -3572,6 +3584,12 @@ export interface V1PostModelRequest {
      * @memberof V1PostModelRequest
      */
     username?: string;
+    /**
+     * Notes associated with this model.
+     * @type {string}
+     * @memberof V1PostModelRequest
+     */
+    notes?: string;
 }
 
 /**


### PR DESCRIPTION
## Description

In this updated PR, we make it possible to edit the Name field in PATCH /models/:id.  Re-add the Notes column to Models.

## Checklist

- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.
