### PR TITLE
feat: Adding Openshift route support in Helm chart

### DIFF
--- a/helm/charts/determined/templates/master-route.yaml
+++ b/helm/charts/determined/templates/master-route.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.route.enabled }}
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: determined-master-{{ .Release.Name }}
+    release: {{ .Release.Name }}
+  name: determined-master-route-{{ .Release.Name }}
+spec:
+  tls:
+    termination: {{ .Values.route.termination }}
+  to:
+    kind: Service
+    name: determined-master-service-{{ .Release.Name }}
+    weight: 100
+  wildcardPolicy: None
+{{- end }}

--- a/helm/charts/determined/values.yaml
+++ b/helm/charts/determined/values.yaml
@@ -19,6 +19,11 @@ masterPort: 8080
 # load-balancer.
 useNodePortForMaster: false
 
+# Enable route support for Openshift by setting enabled to true. Configure tls termination (i.e edge) if needed.
+# route:
+  # enabled: 
+  # termination: 
+
 # tlsSecret enables TLS encryption for all communication made to the Determined master (TLS
 # termination is performed in the Determined master). This includes communication between the
 # Determined master and the task containers it launches, but does not include communication between


### PR DESCRIPTION
## Description

Adding Openshift 4.X route setup for Helm chart.


## Test Plan

- Change `determined/helm/charts/determined/values.yaml` to create route:

```
route:
 enabled: true
 termination: edge
```
- Validate route was created:
```
oc get routes -n $your_namespace
```
- Verify Determined master is accessible from the route.


## Commentary 

More variables can be added if needed.

## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.
