### PR TITLE
feat: generic_context.searcher.epochs() [DET-6083]

### DIFF
--- a/harness/determined/_generic/__init__.py
+++ b/harness/determined/_generic/__init__.py
@@ -1,6 +1,6 @@
 from determined._generic._distributed import DistributedContext, DummyDistributed
 from determined._generic._checkpointing import Checkpointing, DummyCheckpointing
 from determined._generic._training import Training, DummyTraining, EarlyExitReason
-from determined._generic._searcher import AdvancedSearcher, DummyAdvancedSearcher, SearcherOp, Unit
+from determined._generic._searcher import Searcher, DummySearcher, SearcherOp, Unit
 from determined._generic._preemption import Preemption, DummyPreemption, _PreemptionWatcher
 from determined._generic._context import Context, init, _dummy_init

--- a/harness/determined/_generic/_context.py
+++ b/harness/determined/_generic/_context.py
@@ -23,15 +23,13 @@ class Context:
         distributed: Optional[_generic.DistributedContext] = None,
         preemption: Optional[_generic.Preemption] = None,
         training: Optional[_generic.Training] = None,
-        searcher: Optional[_generic.AdvancedSearcher] = None,
+        searcher: Optional[_generic.Searcher] = None,
     ) -> None:
         self.checkpointing = checkpointing
         self.distributed = distributed or _generic.DummyDistributed()
         self.preemption = preemption or _generic.DummyPreemption()
         self.training = training or _generic.DummyTraining()
-        # TODO(DET-6083): Finalize BasicSearcher.  Figure out if calling this .searcher is going to
-        # create a name conflict between AdvancedSearcher and BasicSearcher
-        self.searcher = searcher or _generic.DummyAdvancedSearcher()
+        self.searcher = searcher or _generic.DummySearcher()
 
     def __enter__(self) -> "Context":
         self.preemption.start()
@@ -68,7 +66,7 @@ def _dummy_init(
     checkpointing = _generic.DummyCheckpointing(distributed, storage_manager)
 
     training = _generic.DummyTraining()
-    searcher = _generic.DummyAdvancedSearcher()
+    searcher = _generic.DummySearcher()
 
     return Context(
         distributed=distributed,
@@ -131,7 +129,7 @@ def init(
             tbd_mgr,
             tbd_writer,
         )
-        searcher = _generic.AdvancedSearcher(
+        searcher = _generic.Searcher(
             session, info.trial.trial_id, info.trial._trial_run_id, info.allocation_id
         )
 

--- a/harness/determined/_generic/_searcher.py
+++ b/harness/determined/_generic/_searcher.py
@@ -92,14 +92,109 @@ class SearcherOp:
         )
 
 
-class AdvancedSearcher:
-    """A namespaced API to make it clear which searcher-related things go to which API"""
+class SearcherEpoch:
+    def __init__(self, epoch_idx: int, op: SearcherOp) -> None:
+        self.epoch_idx = epoch_idx
+        self._op = op
+        self._completed = False
+
+    def complete(self, searcher_metric: float) -> None:
+        if self._completed:
+            raise RuntimeError("you may only call op.complete() once")
+        self._completed = True
+        epochs_completed = self.epoch_idx + 1
+        if epochs_completed < self._op.epochs:
+            self._op.report_progress(epochs_completed)
+        else:
+            self._op.complete(searcher_metric)
+
+
+class Searcher:
+    """
+    There are two ways to use the Searcher API: the basic epoch-based approached, and the more
+    advanced operation-based approach.
+
+    The basic epoch-based approach requires that you configure your searcher in terms of epochs.
+    You iterate through ``SearcherEpoch`` objects one at a time, reporting your searcher metric
+    after each epoch is complete:
+
+    .. code:: python
+
+       # You'll have to load initial_epoch from a checkpoint if you
+       # want to support pausing/continuing training:
+       epochs_trained = 0
+
+       # Iterate through epoch objects during training:
+       for epoch in generic_context.searcher.epochs(epochs_trained):
+           val_metrics = my_train_and_validate(epoch_idx = epoch.epoch_idx)
+
+           # pass your searcher metric to epoch.complete() after each epoch:
+           epoch.complete(val_metrics["my_searcher_metric"])
+
+    The more advanced operation-based approach supports searchers configured in epochs, batches, or
+    records.  It requires you to introduce a second layer of for-loop into the structure of your
+    training loop, but gives you more control over the frequency of training interruptions.  You can
+    report training progress as frequently as you like, or if validation of your model is expensive,
+    you can validate as infrequently as the searcher algorithm will allow, for optimal performance.
+
+    In the operation-based approach, you iterate through ``SearcherOp`` objects.  When you report
+    progress, it will be reflected in the WebUI, and when you have finished the training necessary
+    for the SearcherOp, you pass it to ``op.complete``:
+
+    .. code:: python
+
+       # You'll have to load your starting point from a checkpoint
+       # if you want to support pausing/continuing training:
+       length_trained = 0
+
+       for op in generic_context.searcher.ops():
+
+           # Train differently based on op.unit.  Note that op.unit
+           # reflects how you configured your searcher, so you are
+           # free to only support units you care about using.
+           if op.unit == det.generic.Unit.EPOCHS:
+               # Train for however long the op requires you to.
+               # Note that op.length is an absolute length, not an
+               # incremental length; i.e. you need to subtract any
+               # length of training you've already completed:
+               for i in range(length_trained, op.length):
+                   my_train_epoch()
+                   # Report progress in the same units as the op:
+                   op.report_progress(i+1)
+
+           elif op.unit == det.generic.Unit.BATCHES:
+               # Same thing but in batches:
+               for i in range(length_trained, op.length):
+                   my_train_batch()
+                   # Reporting progress every batch would be expensive:
+                   if i % 1000:
+                       op.report_progress(i+1)
+
+           elif op.unit == det.generic.Unit.RECORDS:
+               # Same thing but in records.
+               ...
+
+           else:
+               # Future-proofing is always encouraged.
+               raise ValueError("unrecognized op type:", type(op))
+
+           length_trained = op.length
+
+           # After training the required amount, pass your searcher
+           # metric to op.complete():
+
+           # Pass your searcher metric to op.complete():
+           val_metrics = my_validate()
+           op.complete(va_metrics["my_searcher_metric"])
+    """
 
     def __init__(self, session: Session, trial_id: int, run_id: int, allocation_id: str) -> None:
         self._session = session
         self._trial_id = trial_id
         self._run_id = run_id
         self._allocation_id = allocation_id
+
+        self._iterated = None  # type: Optional[str]
 
     def _get_searcher_op(self) -> Optional[SearcherOp]:
         logger.debug("_get_searcher_op()")
@@ -113,12 +208,61 @@ class AdvancedSearcher:
             self._session, self._trial_id, unit=Unit(length["unit"]), length=length["length"]
         )
 
+    def epochs(self, initial_epoch: int = 0, auto_ack: bool = True) -> Iterator[SearcherEpoch]:
+        """
+        Iterate through all the epochs requested by this searcher.
+
+        The caller must call epoch.complete() after completing each epoch of training, with the
+        validation metric computed after the training.
+
+        Searcher.epochs() is simple, but has the following limitations:
+          - It will raise an exception if the searcher is configured in units other than epochs.
+          - It requires you to validate every epoch, in order to call epoch.complete().
+          - It does not support reporting progress on except on epoch boundaries.
+        """
+        if self._iterated is not None:
+            raise RuntimeError(
+                f"illegal second iteration through the searcher: searcher.{self._iterated}() has "
+                "already been called previously"
+            )
+
+        self._iterated = "epochs"
+
+        epochs_completed = initial_epoch
+        while True:
+            op = self._get_searcher_op()
+            if op is None:
+                if auto_ack:
+                    self.acknowledge_out_of_ops()
+                break
+            if op.unit != Unit.EPOCHS:
+                raise RuntimeError(
+                    f"illegal call to searcher.epochs() with a searcher configured in {op.unit}"
+                )
+            for epoch_idx in range(epochs_completed, op.epochs):
+                epoch = SearcherEpoch(epoch_idx, op)
+                yield epoch
+                if not epoch._completed:
+                    raise RuntimeError("you must call epoch.complete() on each epoch")
+            epochs_completed = op.epochs
+
     def ops(self, auto_ack: bool = True) -> Iterator[SearcherOp]:
         """
         Iterate through all the ops this searcher has to offer.
 
-        The caller must call op.complete() on each operation.
+        The caller must call op.complete() after completing the training requested by each
+        operation, with the validation metric calculated after the training.
+
+        Searcher.ops() supports the full capabilities of hyperparameter search in the Determined
+        platform, but is more complex than using Searcher.epochs().
         """
+        if self._iterated is not None:
+            raise RuntimeError(
+                f"illegal second iteration through the searcher: searcher.{self._iterated}() has "
+                "already been called previously"
+            )
+
+        self._iterated = "ops"
 
         while True:
             op = self._get_searcher_op()
@@ -138,8 +282,9 @@ class AdvancedSearcher:
         This is important for the Determined master to know that it is safe to restart this process
         should new operations be assigned to this trial.
 
-        acknowledge_out_of_ops() is normally called automatically just before ops() raises a
-        StopIteration, unless ops() is called with auto_ack=False.
+        acknowledge_out_of_ops() is normally called automatically just before searcher.ops() or
+        searcher.epochs() raises a StopIteration exception, unless ops()/epochs() is called with
+        auto_ack=False.
         """
         logger.debug(f"acknowledge_out_of_ops(allocation_id:{self._allocation_id})")
         self._session.post(f"/api/v1/allocations/{self._allocation_id}/signals/ack_preemption")
@@ -165,7 +310,7 @@ class DummySearcherOp(SearcherOp):
         logger.info(f"SearcherOp Complete: searcher_metric={det.util.json_encode(searcher_metric)}")
 
 
-class DummyAdvancedSearcher(AdvancedSearcher):
+class DummySearcher(Searcher):
     """Yield a singe search op.  We need a way for this to be configurable."""
 
     def __init__(self, unit: Unit = Unit.EPOCHS, length: int = 1) -> None:
@@ -177,6 +322,15 @@ class DummyAdvancedSearcher(AdvancedSearcher):
         yield op
         if not op._completed:
             raise RuntimeError("you must call op.complete() on each operation")
+
+    def epochs(self, initial_epoch: int = 0, auto_ack: bool = True) -> Iterator[SearcherEpoch]:
+        target = initial_epoch + self._length
+        op = DummySearcherOp(Unit.EPOCHS, target)
+        for epoch_idx in range(initial_epoch, op.epochs):
+            epoch = SearcherEpoch(epoch_idx, op)
+            yield epoch
+            if not epoch._completed:
+                raise RuntimeError("you must call epoch.complete() on each epoch")
 
     def acknowledge_out_of_ops(self) -> None:
         pass


### PR DESCRIPTION
If generic_context.searcher.ops() is the advanced way to use the
searcher, generic_context.searcher.epochs() is the basic way.

## Commentary

This is basically exactly what @stoksc proposed before we started implementing push architecture.  Thanks, Bradley!