### PR TITLE
removed obsolete targets test-cli and test-common

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,7 @@ fmt: fmt-common fmt-harness fmt-cli fmt-deploy fmt-model_hub fmt-e2e_tests fmt-t
 test-%:
 	$(MAKE) -C $(subst -,/,$*) test
 .PHONY: test
-test: test-harness test-cli test-common test-model_hub test-master test-agent test-webui 
+test: test-harness test-model_hub test-master test-agent test-webui 
 
 .PHONY: devcluster
 devcluster:


### PR DESCRIPTION
## Description
Removed obsolete targets
`test-cli`
`test-common`

### Background
`make test`, when run from the root of the repository, would fail attempting to build `test-cli`, an obsolete target, because the cli tests have moved.

## Test Plan
Testing consists in running
`make all`
`make test`

## Commentary (optional)

- initial error: /cli/tests does not exist


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
