### PR TITLE
fix: make Helm deployment work with no OpenShift config present

### DIFF
--- a/helm/charts/determined/templates/master-route.yaml
+++ b/helm/charts/determined/templates/master-route.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.openshiftRoute }}
 {{- if .Values.openshiftRoute.enabled }}
 apiVersion: route.openshift.io/v1
 kind: Route
@@ -15,4 +16,5 @@ spec:
     name: determined-master-service-{{ .Release.Name }}
     weight: 100
   wildcardPolicy: None
+{{- end }}
 {{- end }}

--- a/helm/charts/determined/values.yaml
+++ b/helm/charts/determined/values.yaml
@@ -21,8 +21,8 @@ useNodePortForMaster: false
 
 # Enable route support for Openshift by setting enabled to true. Configure tls termination (i.e edge) if needed.
 # openshiftRoute:
-  # enabled: 
-  # termination: 
+  # enabled:
+  # termination:
 
 # tlsSecret enables TLS encryption for all communication made to the Determined master (TLS
 # termination is performed in the Determined master). This includes communication between the


### PR DESCRIPTION
## Description

We need to account for the case where the `openshift` key is not present
at all; Helm fails to run in that case without this change.

## Test Plan

- [x] deploy a cluster on Helm
