### PR TITLE
fix: don't create filestore with no_filestore flag

### DIFF
--- a/docs/release-notes/3223-gcp-no-filestore.txt
+++ b/docs/release-notes/3223-gcp-no-filestore.txt
@@ -1,0 +1,6 @@
+:orphan:
+
+**Bug Fixes**
+
+-  Fix a bug GCP clusters created with ``det deploy gcp up --no-filestore`` still had unused
+   filestores created.

--- a/harness/determined/deploy/gcp/cli.py
+++ b/harness/determined/deploy/gcp/cli.py
@@ -74,9 +74,6 @@ def deploy_gcp(command: str, args: argparse.Namespace) -> None:
         print("If a CPU or GPU image is specified, both should be.")
         sys.exit(1)
 
-    if args.no_filestore:
-        args.filestore_address = ""
-
     if args.master_config_template_path:
         if not args.master_config_template_path.exists():
             raise ValueError(
@@ -98,7 +95,6 @@ def deploy_gcp(command: str, args: argparse.Namespace) -> None:
         "no_preflight_checks",
         "no_wait_for_master",
         "no_prompt",
-        "no_filestore",
         "master_config_template_path",
         "func",
         "_command",

--- a/harness/determined/deploy/gcp/terraform/main.tf
+++ b/harness/determined/deploy/gcp/terraform/main.tf
@@ -68,7 +68,7 @@ module "ip" {
  *****************************************/
 
 module "filestore" {
-  count = var.filestore_address == "" ? 1 : 0
+  count = (!var.no_filestore && var.filestore_address == "") ? 1 : 0
 
   source = "./modules/filestore"
 
@@ -80,7 +80,13 @@ module "filestore" {
 }
 
 locals {
-  filestore_address = "${var.filestore_address=="" ? module.filestore[0].address : var.filestore_address}"
+  filestore_address = (
+    var.no_filestore ?
+    "" :
+    var.filestore_address==""
+      ? module.filestore[0].address
+      : var.filestore_address
+  )
 }
 
 

--- a/harness/determined/deploy/gcp/terraform/variables.tf
+++ b/harness/determined/deploy/gcp/terraform/variables.tf
@@ -37,6 +37,11 @@ variable "subnetwork" {
   default = null
 }
 
+variable "no_filestore" {
+  type = bool
+  default = false
+}
+
 variable "filestore_address" {
   type = string
   default = ""


### PR DESCRIPTION
## Description
This change fixes a logic within terraform such that when creating a GCP cluster with `det deploy` and `--no-filestore` a filestore is not created.
<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan
- [x] deploy a cluster, verify no filestore is created with `--no-filestore`
<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ