### PR TITLE
fix: invalidhp handling for single trial experiments [DET-6259]

### DIFF
--- a/master/pkg/searcher/random.go
+++ b/master/pkg/searcher/random.go
@@ -83,15 +83,17 @@ func (s *randomSearch) trialExitedEarly(
 	ctx context, requestID model.RequestID, exitedReason model.ExitedReason,
 ) ([]Operation, error) {
 	s.PendingTrials--
-	if exitedReason == model.InvalidHP || exitedReason == model.InitInvalidHP {
-		var ops []Operation
-		create := NewCreate(ctx.rand, sampleAll(ctx.hparams, ctx.rand), model.TrialWorkloadSequencerType)
-		ops = append(ops, create)
-		ops = append(ops, NewValidateAfter(create.RequestID, s.MaxLength()))
-		ops = append(ops, NewClose(create.RequestID))
-		// We don't increment CreatedTrials here because this trial is replacing the invalid trial.
-		s.PendingTrials++
-		return ops, nil
+	if s.SearchMethodType == RandomSearch {
+		if exitedReason == model.InvalidHP || exitedReason == model.InitInvalidHP {
+			var ops []Operation
+			create := NewCreate(ctx.rand, sampleAll(ctx.hparams, ctx.rand), model.TrialWorkloadSequencerType)
+			ops = append(ops, create)
+			ops = append(ops, NewValidateAfter(create.RequestID, s.MaxLength()))
+			ops = append(ops, NewClose(create.RequestID))
+			// We don't increment CreatedTrials here because this trial is replacing the invalid trial.
+			s.PendingTrials++
+			return ops, nil
+		}
 	}
 	return nil, nil
 }


### PR DESCRIPTION
## Description
If we catch an InvalidHP exception for a single trial experiment, we will continue creating new trials with the same constant experiment config.  This PR fixes that.

## Test Plan
Tested manually.

