### PR TITLE
fix: hp search progress to account for early-stopped trials [DET-6231]

### DIFF
--- a/master/pkg/searcher/asha.go
+++ b/master/pkg/searcher/asha.go
@@ -265,7 +265,8 @@ func (s *asyncHalvingSearch) closeOutRungs() []Operation {
 	return ops
 }
 
-func (s *asyncHalvingSearch) progress(map[model.RequestID]model.PartialUnits) float64 {
+func (s *asyncHalvingSearch) progress(
+	map[model.RequestID]model.PartialUnits, map[model.RequestID]bool) float64 {
 	if s.MaxConcurrentTrials() > 0 && s.PendingTrials > s.MaxConcurrentTrials() {
 		panic("pending trials is greater than max_concurrent_trials")
 	}

--- a/master/pkg/searcher/asha_stopping.go
+++ b/master/pkg/searcher/asha_stopping.go
@@ -202,7 +202,8 @@ func (s *asyncHalvingStoppingSearch) promoteAsync(
 	return ops
 }
 
-func (s *asyncHalvingStoppingSearch) progress(map[model.RequestID]model.PartialUnits) float64 {
+func (s *asyncHalvingStoppingSearch) progress(
+	map[model.RequestID]model.PartialUnits, map[model.RequestID]bool) float64 {
 	allTrials := len(s.Rungs[0].Metrics)
 	// Give ourselves an overhead of 20% of maxTrials when calculating progress.
 	progress := float64(allTrials) / (1.2 * float64(s.MaxTrials()))

--- a/master/pkg/searcher/grid.go
+++ b/master/pkg/searcher/grid.go
@@ -61,13 +61,31 @@ func (s *gridSearch) initialOperations(ctx context) ([]Operation, error) {
 	return ops, nil
 }
 
-func (s *gridSearch) progress(trialProgress map[model.RequestID]model.PartialUnits) float64 {
+func (s *gridSearch) progress(
+	trialProgress map[model.RequestID]model.PartialUnits,
+	trialsClosed map[model.RequestID]bool) float64 {
 	if s.MaxConcurrentTrials() > 0 && s.PendingTrials > s.MaxConcurrentTrials() {
 		panic("pending trials is greater than max_concurrent_trials")
 	}
-	unitsCompleted := sumTrialLengths(trialProgress)
+	unitsCompleted := 0.
+	for k, v := range trialsClosed {
+		if _, ok := trialProgress[k]; !ok {
+			if v {
+				unitsCompleted += float64(s.MaxLength().Units)
+			}
+		}
+	}
+	for k, v := range trialProgress {
+		if closed, ok := trialsClosed[k]; ok {
+			if closed {
+				unitsCompleted += float64(s.MaxLength().Units)
+			}
+		} else {
+			unitsCompleted += float64(v)
+		}
+	}
 	unitsExpected := s.MaxLength().Units * s.trials
-	return float64(unitsCompleted) / float64(unitsExpected)
+	return unitsCompleted / float64(unitsExpected)
 }
 
 // trialExitedEarly does nothing since grid does not take actions based on

--- a/master/pkg/searcher/grid.go
+++ b/master/pkg/searcher/grid.go
@@ -67,20 +67,20 @@ func (s *gridSearch) progress(
 	if s.MaxConcurrentTrials() > 0 && s.PendingTrials > s.MaxConcurrentTrials() {
 		panic("pending trials is greater than max_concurrent_trials")
 	}
+	// Progress is calculated as follows:
+	//   - InvalidHP trials contribute max_length units since they represent one config within the grid
+	//     and are not replaced with a new config as with random search
+	//   - Other early-exit trials contribute max_length units
+	//   - In progress trials contribute units trained
 	unitsCompleted := 0.
-	for k, v := range trialsClosed {
-		if _, ok := trialProgress[k]; !ok {
-			if v {
-				unitsCompleted += float64(s.MaxLength().Units)
-			}
-		}
+	// trialsClosed includes InvalidHP trials and other exited trials
+	for range trialsClosed {
+		unitsCompleted += float64(s.MaxLength().Units)
 	}
+	// trialProgress records units trained for all trials except for InvalidHP trials.
+	// This can overlap with trialsClosed so we need to be sure to not double count.
 	for k, v := range trialProgress {
-		if closed, ok := trialsClosed[k]; ok {
-			if closed {
-				unitsCompleted += float64(s.MaxLength().Units)
-			}
-		} else {
+		if !trialsClosed[k] {
 			unitsCompleted += float64(v)
 		}
 	}

--- a/master/pkg/searcher/pbt.go
+++ b/master/pkg/searcher/pbt.go
@@ -201,7 +201,9 @@ func (s *pbtSearch) exploreParams(ctx context, old HParamSample) HParamSample {
 	return params
 }
 
-func (s *pbtSearch) progress(trialProgress map[model.RequestID]model.PartialUnits) float64 {
+func (s *pbtSearch) progress(
+	trialProgress map[model.RequestID]model.PartialUnits,
+	trialsClosed map[model.RequestID]bool) float64 {
 	unitsCompleted := sumTrialLengths(trialProgress)
 	unitsExpected := s.LengthPerRound().MultInt(s.PopulationSize()).MultInt(s.NumRounds()).Units
 	return float64(unitsCompleted) / float64(unitsExpected)

--- a/master/pkg/searcher/random.go
+++ b/master/pkg/searcher/random.go
@@ -74,12 +74,16 @@ func (s *randomSearch) progress(
 	if s.MaxConcurrentTrials() > 0 && s.PendingTrials > s.MaxConcurrentTrials() {
 		panic("pending trials is greater than max_concurrent_trials")
 	}
+	// Progress is calculated as follows:
+	//   - InvalidHP trials contribute 0 since we do not count them against max_trials budget and are
+	//     replaced with another randomly sampled config
+	//   - Other early-exit trials contribute max_length units
+	//   - In progress trials contribute units trained
 	unitsCompleted := 0.
+	// trialProgress records units trained for all trials except for InvalidHP trials.
 	for k, v := range trialProgress {
-		if closed, ok := trialsClosed[k]; ok {
-			if closed {
-				unitsCompleted += float64(s.MaxLength().Units)
-			}
+		if trialsClosed[k] {
+			unitsCompleted += float64(s.MaxLength().Units)
 		} else {
 			unitsCompleted += float64(v)
 		}

--- a/master/pkg/searcher/search_method.go
+++ b/master/pkg/searcher/search_method.go
@@ -29,7 +29,7 @@ type SearchMethod interface {
 	// operation.
 	trialClosed(ctx context, requestID model.RequestID) ([]Operation, error)
 	// progress returns experiment progress as a float between 0.0 and 1.0.
-	progress(map[model.RequestID]model.PartialUnits) float64
+	progress(map[model.RequestID]model.PartialUnits, map[model.RequestID]bool) float64
 	// trialExitedEarly informs the searcher that the trial has exited earlier than expected.
 	trialExitedEarly(
 		ctx context, requestID model.RequestID, exitedReason model.ExitedReason,

--- a/master/pkg/searcher/searcher.go
+++ b/master/pkg/searcher/searcher.go
@@ -149,7 +149,7 @@ func (s *Searcher) TrialClosed(requestID model.RequestID) ([]Operation, error) {
 
 // Progress returns experiment progress as a float between 0.0 and 1.0.
 func (s *Searcher) Progress() float64 {
-	progress := s.method.progress(s.TrialProgress)
+	progress := s.method.progress(s.TrialProgress, s.TrialsCreated)
 	if math.IsNaN(progress) || math.IsInf(progress, 0) {
 		return 0.0
 	}

--- a/master/pkg/searcher/searcher.go
+++ b/master/pkg/searcher/searcher.go
@@ -149,7 +149,7 @@ func (s *Searcher) TrialClosed(requestID model.RequestID) ([]Operation, error) {
 
 // Progress returns experiment progress as a float between 0.0 and 1.0.
 func (s *Searcher) Progress() float64 {
-	progress := s.method.progress(s.TrialProgress, s.TrialsCreated)
+	progress := s.method.progress(s.TrialProgress, s.TrialsClosed)
 	if math.IsNaN(progress) || math.IsInf(progress, 0) {
 		return 0.0
 	}

--- a/master/pkg/searcher/tournament.go
+++ b/master/pkg/searcher/tournament.go
@@ -111,7 +111,9 @@ func (s *tournamentSearch) trialExitedEarly(
 }
 
 // progress returns experiment progress as a float between 0.0 and 1.0.
-func (s *tournamentSearch) progress(trialProgress map[model.RequestID]model.PartialUnits) float64 {
+func (s *tournamentSearch) progress(
+	trialProgress map[model.RequestID]model.PartialUnits,
+	trialsClosed map[model.RequestID]bool) float64 {
 	sum := 0.0
 	for id, subSearch := range s.subSearches {
 		subSearchTrialProgress := map[model.RequestID]model.PartialUnits{}
@@ -120,7 +122,13 @@ func (s *tournamentSearch) progress(trialProgress map[model.RequestID]model.Part
 				subSearchTrialProgress[rID] = p
 			}
 		}
-		sum += subSearch.progress(subSearchTrialProgress)
+		subSearchTrialsClosed := map[model.RequestID]bool{}
+		for rID, closed := range trialsClosed {
+			if id == s.TrialTable[rID] {
+				subSearchTrialsClosed[rID] = closed
+			}
+		}
+		sum += subSearch.progress(subSearchTrialProgress, subSearchTrialsClosed)
 	}
 	return sum / float64(len(s.subSearches))
 }

--- a/master/pkg/searcher/tournament.go
+++ b/master/pkg/searcher/tournament.go
@@ -115,16 +115,16 @@ func (s *tournamentSearch) progress(
 	trialProgress map[model.RequestID]model.PartialUnits,
 	trialsClosed map[model.RequestID]bool) float64 {
 	sum := 0.0
-	for id, subSearch := range s.subSearches {
+	for subSearchID, subSearch := range s.subSearches {
 		subSearchTrialProgress := map[model.RequestID]model.PartialUnits{}
 		for rID, p := range trialProgress {
-			if id == s.TrialTable[rID] {
+			if subSearchID == s.TrialTable[rID] {
 				subSearchTrialProgress[rID] = p
 			}
 		}
 		subSearchTrialsClosed := map[model.RequestID]bool{}
 		for rID, closed := range trialsClosed {
-			if id == s.TrialTable[rID] {
+			if subSearchID == s.TrialTable[rID] {
 				subSearchTrialsClosed[rID] = closed
 			}
 		}


### PR DESCRIPTION
## Description
We are not counting progress for early exit trials correctly for random and grid search.  The desired behavior is as follows:
- Random: trials with exit reason InvalidHPs should not count towards trial progress at all. All other early exit trials should count as completing the max_length when accounted for progress.
- Grid: all early exit trials including InvalidHP trials should count as completing the max_length when accounted for progress.

This PR changes progress calculations to reflect the above.