### PR TITLE
fix: generate SSH keys for restored trials

### DIFF
--- a/master/internal/api_command.go
+++ b/master/internal/api_command.go
@@ -92,7 +92,6 @@ func (a *apiServer) getCommandLaunchParams(ctx context.Context, req *protoComman
 	taskSpec.TaskContainerDefaults = taskContainerDefaults
 	taskSpec.AgentUserGroup = agentUserGroup
 	taskSpec.Owner = user
-	taskSpec.SSHRsaSize = a.m.config.Security.SSH.RsaKeySize
 
 	// Get the full configuration.
 	config := model.DefaultConfig(&taskSpec.TaskContainerDefaults)

--- a/master/internal/core.go
+++ b/master/internal/core.go
@@ -572,6 +572,7 @@ func (m *Master) Run(ctx context.Context) error {
 		HarnessPath:           filepath.Join(m.config.Root, "wheels"),
 		TaskContainerDefaults: m.config.TaskContainerDefaults,
 		MasterCert:            cert,
+		SSHRsaSize:            m.config.Security.SSH.RsaKeySize,
 		SegmentEnabled:        m.config.Telemetry.Enabled && m.config.Telemetry.SegmentMasterKey != "",
 		SegmentAPIKey:         m.config.Telemetry.SegmentMasterKey,
 	}

--- a/master/internal/core_experiment.go
+++ b/master/internal/core_experiment.go
@@ -425,8 +425,6 @@ func (m *Master) parseCreateExperiment(params *CreateExperimentParams) (
 	taskSpec.TaskContainerDefaults = taskContainerDefaults
 	taskSpec.TaskContainerDefaults.MergeIntoExpConfig(&config)
 
-	taskSpec.SSHRsaSize = m.config.Security.SSH.RsaKeySize
-
 	// Merge in the master's checkpoint storage into the config.
 	config.RawCheckpointStorage = schemas.Merge(
 		config.RawCheckpointStorage, &m.config.CheckpointStorage,


### PR DESCRIPTION
## Description

Previously, the SSH RSA key size for trials was set on a code path that
was only run for newly created experiments. A trial restored after a
master restart would therefore attempt to generate keys with a size of 0
and crash. Instead, we now set the key size in the master's base task
spec so that it applies to all tasks automatically.

## Test Plan

- [x] check that restoring a trial after a master restart fails without the fix and succeeds with it
- [x] check that shells and trials generate a key of the configured size

## Commentary

The error in key generation and, more generally, the reason an allocation was killed don't seem to be surfaced anywhere at all, as far as I can tell.
