### PR TITLE
docs: add an example for `bind_mounts` usage.

### DIFF
--- a/docs/training-apis/experiment-config.txt
+++ b/docs/training-apis/experiment-config.txt
@@ -776,6 +776,25 @@ For each bind mount, the following optional fields may also be specified:
    <https://docs.docker.com/storage/bind-mounts/#configure-bind-propagation>`__ for replicas of the
    bind-mount. Defaults to ``rprivate``.
 
+For example, to mount ``/data`` on the host to the same path in the container, use:
+
+.. code:: yaml
+
+   bind_mounts:
+     - host_path: /data
+       container_path: /data
+
+It is also possible to mount multiple paths:
+
+.. code:: yaml
+
+   bind_mounts:
+     - host_path: /data
+       container_path: /data
+     - host_path: /shared/read-only-data
+       container_path: /shared/read-only-data
+       read_only: true
+
 .. _exp-environment:
 
 *************


### PR DESCRIPTION
## Description

An OSS user had a confusion about proper use of `bind_mounts`. It is indeed hard to find an example of `bind_mounts` use in our docs. They tend to link to this section in `experiment-config.html`, so I've just added a couple examples here.

https://determined-community.slack.com/archives/CV3MTNZ6U/p1638369591151400

## Test Plan

N/A

## Commentary (optional)

## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
