### PR TITLE
feat: Add python method for listing trials in an experiment [DET-5088]

### DIFF
--- a/docs/release-notes/3270-list-experiment-trials.txt
+++ b/docs/release-notes/3270-list-experiment-trials.txt
@@ -2,5 +2,4 @@
 
 **New Features**
 
-- API: Add a method for listing trials within an experiment.
-
+-  API: Add a method for listing trials within an experiment.

--- a/docs/release-notes/3270-list-experiment-trials.txt
+++ b/docs/release-notes/3270-list-experiment-trials.txt
@@ -1,0 +1,6 @@
+:orphan:
+
+**New Features**
+
+- API: Add a method for listing trials within an experiment.
+

--- a/harness/determined/common/experimental/__init__.py
+++ b/harness/determined/common/experimental/__init__.py
@@ -2,5 +2,5 @@ from determined.common.experimental.checkpoint import Checkpoint
 from determined.common.experimental.determined import Determined
 from determined.common.experimental.experiment import ExperimentReference
 from determined.common.experimental.session import Session
-from determined.common.experimental.trial import TrialReference
+from determined.common.experimental.trial import TrialReference, TrialSortBy, TrialOrderBy
 from determined.common.experimental.model import Model, ModelOrderBy, ModelSortBy, ModelVersion

--- a/harness/determined/common/experimental/experiment.py
+++ b/harness/determined/common/experimental/experiment.py
@@ -113,7 +113,7 @@ class ExperimentReference:
                 :class:`~determined.experimental.TrialOrderBy`.
         """
         r = self._session.get(f"/api/v1/experiments/{self.id}/trials")
-        trials = r.json().get("trials")
+        trials = r.json()["trials"]
         return [trial.TrialReference(t["id"], self._session) for t in trials]
 
     def kill(self) -> None:

--- a/harness/determined/common/experimental/experiment.py
+++ b/harness/determined/common/experimental/experiment.py
@@ -3,7 +3,7 @@ import sys
 import time
 from typing import Any, Dict, List, Optional, cast
 
-from determined.common.experimental import checkpoint, session
+from determined.common.experimental import checkpoint, session, trial
 
 
 class ExperimentState(enum.Enum):
@@ -97,6 +97,24 @@ class ExperimentReference:
 
     def get_config(self) -> Dict[str, Any]:
         return self._get().config
+
+    def get_trials(
+        self,
+        sort_by: trial.TrialSortBy = trial.TrialSortBy.ID,
+        order_by: trial.TrialOrderBy = trial.TrialOrderBy.ASCENDING
+    ) -> List[trial.TrialReference]:
+        """
+        Get the list of :class:`~determined.experimental.TrialReference` instances
+        representing trials for an experiment.
+
+        Arguments:
+            sort_by: Which field to sort by. See :class:`~determined.experimental.TrialSortBy`.
+            order_by: Whether to sort in ascending or descending order. See
+                :class:`~determined.experimental.TrialOrderBy`.
+        """
+        r = self._session.get(f"/api/v1/experiments/{self.id}/trials")
+        trials = r.json().get("trials")
+        return [trial.TrialReference(t["id"], self._session) for t in trials]
 
     def kill(self) -> None:
         self._session.post(f"/api/v1/experiments/{self.id}/kill")

--- a/harness/determined/common/experimental/experiment.py
+++ b/harness/determined/common/experimental/experiment.py
@@ -101,7 +101,7 @@ class ExperimentReference:
     def get_trials(
         self,
         sort_by: trial.TrialSortBy = trial.TrialSortBy.ID,
-        order_by: trial.TrialOrderBy = trial.TrialOrderBy.ASCENDING
+        order_by: trial.TrialOrderBy = trial.TrialOrderBy.ASCENDING,
     ) -> List[trial.TrialReference]:
         """
         Get the list of :class:`~determined.experimental.TrialReference` instances

--- a/harness/determined/common/experimental/trial.py
+++ b/harness/determined/common/experimental/trial.py
@@ -1,3 +1,4 @@
+import enum
 from typing import Any, Callable, Dict, Optional
 
 from determined.common import check
@@ -132,3 +133,48 @@ class TrialReference:
 
     def __repr__(self) -> str:
         return "Trial(id={})".format(self.id)
+
+
+class TrialSortBy(enum.Enum):
+    """
+    Specifies the field to sort a list of trials on.
+
+    Attributes:
+        UNSPECIFIED
+        ID
+        START_TIME
+        END_TIME
+        STATE
+        BEST_VALIDATION_METRIC
+        LATEST_VALIDATION_METRIC
+        BATCHES_PROCESSED
+        DURATION
+    """
+
+    UNSPECIFIED = 0
+    ID = 1
+    START_TIME = 4
+    END_TIME = 5
+    STATE = 6
+    BEST_VALIDATION_METRIC = 7
+    LATEST_VALIDATION_METRIC = 8
+    BATCHES_PROCESSED = 9
+    DURATION = 10
+
+
+class TrialOrderBy(enum.Enum):
+    """
+    Specifies whether a sorted list of trials should be in ascending or
+    descending order.
+
+    Attributes:
+        ASCENDING
+        ASC
+        DESCENDING
+        DESC
+    """
+
+    ASCENDING = 1
+    ASC = 1
+    DESCENDING = 2
+    DESC = 2

--- a/harness/determined/experimental/__init__.py
+++ b/harness/determined/experimental/__init__.py
@@ -7,7 +7,7 @@ from determined.common.experimental import (
     ModelSortBy,
     TrialReference,
     TrialOrderBy,
-    TrialSortBy
+    TrialSortBy,
 )
 from determined.experimental._native import (
     create,

--- a/harness/determined/experimental/__init__.py
+++ b/harness/determined/experimental/__init__.py
@@ -6,6 +6,8 @@ from determined.common.experimental import (
     ModelOrderBy,
     ModelSortBy,
     TrialReference,
+    TrialOrderBy,
+    TrialSortBy
 )
 from determined.experimental._native import (
     create,

--- a/harness/determined/experimental/client.py
+++ b/harness/determined/experimental/client.py
@@ -55,7 +55,11 @@ from determined.common.experimental.experiment import (  # noqa: F401
 )
 from determined.common.experimental.model import Model, ModelOrderBy, ModelSortBy
 from determined.common.experimental.session import Session  # noqa: F401
-from determined.common.experimental.trial import TrialReference, TrialOrderBy, TrialSortBy  # noqa: F401
+from determined.common.experimental.trial import (  # noqa: F401
+    TrialOrderBy,
+    TrialReference,
+    TrialSortBy,
+)
 
 _determined = None  # type: Optional[Determined]
 

--- a/harness/determined/experimental/client.py
+++ b/harness/determined/experimental/client.py
@@ -55,7 +55,7 @@ from determined.common.experimental.experiment import (  # noqa: F401
 )
 from determined.common.experimental.model import Model, ModelOrderBy, ModelSortBy
 from determined.common.experimental.session import Session  # noqa: F401
-from determined.common.experimental.trial import TrialReference
+from determined.common.experimental.trial import TrialReference, TrialOrderBy, TrialSortBy  # noqa: F401
 
 _determined = None  # type: Optional[Determined]
 


### PR DESCRIPTION
## Description
Add method to ExperimentReference to list trials within an experiment [DET-5088].

## Test Plan

Tested manually, locally.

## Commentary (optional)

There is an endpoint in the REST API to get trials within an experiment. It has a rich set of parameters: sorting, pagination, filtering by state. I decided to only expose the sorting parameters. The only similar method, `determined.experimental.client.get_models`, also does not offer pagination, which makes sense if you view serving UIs as one of responsibility of a RESTful API of which the python API is free.
I don't have as strong an argument for not offering filtering by state; it just does not feel very important.

## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.



[DET-5088]: https://determinedai.atlassian.net/browse/DET-5088?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ