### PR TITLE
fix: CLI keeps activate_experiment for backward compatibility [DET-6315]

### DIFF
--- a/harness/determined/common/api/experiment.py
+++ b/harness/determined/common/api/experiment.py
@@ -216,7 +216,7 @@ def create_experiment(
     additional_body_fields: Optional[Dict[str, Any]] = None,
 ) -> int:
     body = {
-        "activate": activate,
+        "activate": False,
         "experiment_config": yaml.safe_dump(config),
         "model_definition": [e.dict() for e in model_context.entries],
         "validate_only": validate_only,
@@ -237,6 +237,9 @@ def create_experiment(
 
     new_resource = r.headers["Location"]
     experiment_id = int(new_resource.split("/")[-1])
+
+    if activate:
+        activate_experiment(master_url, experiment_id)
 
     return experiment_id
 


### PR DESCRIPTION
## Description

#3236 changed how the CLI initializes experiments. This caused the new CLI to create only paused/inactive experiments in an old master server. This restores the previous CLI code which creates the experiment and activates it as two separate requests.

## Checklist

- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.