### PR TITLE
fix: Return last_updated_time on model versions

### DIFF
--- a/master/static/srv/get_model_version.sql
+++ b/master/static/srv/get_model_version.sql
@@ -1,5 +1,5 @@
 WITH mv AS (
-  SELECT version, checkpoint_uuid, model_versions.id, creation_time, name, comment, metadata, labels, notes, username
+  SELECT version, checkpoint_uuid, model_versions.id, creation_time, name, comment, metadata, labels, notes, username, last_updated_time
     FROM model_versions
     LEFT JOIN users ON users.id = model_versions.user_id
     WHERE model_id = $1 AND model_versions.id = $2
@@ -44,5 +44,5 @@ SELECT
     mv.version, mv.id,
     mv.creation_time, mv.notes,
     mv.name, mv.comment, mv.metadata,
-    mv.username
+    mv.username, mv.last_updated_time
     FROM c, m, mv;

--- a/master/static/srv/get_model_versions.sql
+++ b/master/static/srv/get_model_versions.sql
@@ -9,7 +9,8 @@ WITH mv AS (
     metadata,
     labels,
     notes,
-    username
+    username,
+    last_updated_time
   FROM model_versions
   LEFT JOIN users ON users.id = model_versions.user_id
   WHERE model_id = $1
@@ -53,6 +54,6 @@ SELECT
     array_to_json(mv.labels) AS labels,
     mv.version, mv.id,
     mv.creation_time, mv.notes,
-    mv.name, mv.comment, mv.metadata
+    mv.name, mv.comment, mv.metadata, mv.last_updated_time
     FROM c, mv, m
     WHERE c.uuid = mv.checkpoint_uuid::text;


### PR DESCRIPTION
## Description

This fixes a bug where the Model Version API always returns `null` for `last_updated_time`.

Reproducing the bug: if you update the description or other attribute of a model version, you'll see the updated time does not change - it is falling back to the creation time.

## Checklist

- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.