### PR TITLE
fix: Send activate param from WebUI to API

### DIFF
--- a/webui/react/src/services/apiConfig.ts
+++ b/webui/react/src/services/apiConfig.ts
@@ -222,6 +222,7 @@ export const createExperiment: Service.DetApi<
   request: (params: Service.CreateExperimentParams, options) => {
     return detApi.Internal.createExperiment(
       {
+        activate: params.activate,
         config: params.experimentConfig,
         parentId: params.parentId,
       },


### PR DESCRIPTION
## Description

Quick fix to make sure the CreateExperimentParams includes the activate param