### PR TITLE
fix: pass get_trials sort parameters to REST

### DIFF
--- a/harness/determined/common/experimental/experiment.py
+++ b/harness/determined/common/experimental/experiment.py
@@ -117,7 +117,7 @@ class ExperimentReference:
             params={
                 "sort_by": sort_by.value,
                 "order_by": order_by.value,
-            }
+            },
         )
         trials = r.json()["trials"]
         return [trial.TrialReference(t["id"], self._session) for t in trials]

--- a/harness/determined/common/experimental/experiment.py
+++ b/harness/determined/common/experimental/experiment.py
@@ -112,7 +112,13 @@ class ExperimentReference:
             order_by: Whether to sort in ascending or descending order. See
                 :class:`~determined.experimental.TrialOrderBy`.
         """
-        r = self._session.get(f"/api/v1/experiments/{self.id}/trials")
+        r = self._session.get(
+            f"/api/v1/experiments/{self.id}/trials",
+            params={
+                "sort_by": sort_by.value,
+                "order_by": order_by.value,
+            }
+        )
         trials = r.json()["trials"]
         return [trial.TrialReference(t["id"], self._session) for t in trials]
 


### PR DESCRIPTION
## Description

get_trials sort parameters were not passed to the underlying REST api.
https://determinedai.atlassian.net/browse/DET-5088

## Testing
![image](https://user-images.githubusercontent.com/17324129/145283267-6bb6dd07-09ae-4f9d-8a79-098fedf73a70.png)


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


