### PR TITLE
fix: increase CircleCI resource class for React builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1157,6 +1157,7 @@ jobs:
         default: false
     docker:
       - image: cimg/node:14.16
+    resource_class: large
     steps:
       - checkout
       - react-get-deps


### PR DESCRIPTION
## Description

Already applied on release branches. Craco keeps causing the React build to fail.