### PR TITLE
chore: reuse ordering logic between k8 and priority schedulers

### DIFF
--- a/master/internal/resourcemanagers/priority_test.go
+++ b/master/internal/resourcemanagers/priority_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/determined-ai/determined/master/internal/sproto"
 	"github.com/determined-ai/determined/master/pkg/actor"
+	"github.com/determined-ai/determined/master/pkg/model"
 )
 
 func TestSortTasksByPriorityAndTimestamps(t *testing.T) {
@@ -649,9 +650,11 @@ func AddUnallocatedTasks(
 		ref, created := system.ActorOf(actor.Addr(mockTask.id), mockTask)
 		assert.Assert(t, created)
 
+		jobID := model.JobID(mockTask.jobID)
 		req := &sproto.AllocateRequest{
 			AllocationID: mockTask.id,
 			SlotsNeeded:  mockTask.slotsNeeded,
+			JobID:        &jobID,
 			Label:        mockTask.label,
 			TaskActor:    ref,
 			Preemptible:  !mockTask.nonPreemptible,

--- a/master/internal/resourcemanagers/resource_managers.go
+++ b/master/internal/resourcemanagers/resource_managers.go
@@ -1,7 +1,6 @@
 package resourcemanagers
 
 import (
-	"sort"
 	"time"
 
 	"github.com/determined-ai/determined/master/internal/sproto"
@@ -60,20 +59,4 @@ func GetResourceManagerType(rmConfig *ResourceManagerConfig) string {
 	default:
 		panic("no expected resource manager config is defined")
 	}
-}
-
-type orderedTaskMap = map[int]AllocReqs
-
-func orderTaskMapToSlice(taskMap orderedTaskMap) AllocReqs {
-	out := make(AllocReqs, 0)
-	keys := make([]int, 0, len(taskMap))
-	for k := range taskMap {
-		keys = append(keys, k)
-	}
-	sort.Ints(keys)
-
-	for _, k := range keys {
-		out = append(out, taskMap[k]...)
-	}
-	return out
 }


### PR DESCRIPTION
## Description

fix a job order inconsistency between k8 and priority scheduler. 
improve code reuse.

<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

![2021-12-09_17-31-00](https://user-images.githubusercontent.com/12127420/145502148-e17f25e9-abb0-4f4f-b21f-602c2397fdbf.png)

![2021-12-09_17-33-03](https://user-images.githubusercontent.com/12127420/145502222-4b53aeec-cf00-453b-baff-0e66c4e65c8d.png)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ