### PR TITLE
fix: improve CPU core count parsing on agents with CPU slots.

### DIFF
--- a/docs/release-notes/3304-fix-cpu-core-count.txt
+++ b/docs/release-notes/3304-fix-cpu-core-count.txt
@@ -1,0 +1,5 @@
+:orphan:
+
+**Bug Fixes**
+
+-  Agent: fix displayed CPU core count for CPU slots.


### PR DESCRIPTION
## Description

Agent CPU slot detection was incorrectly parsing `cpuinfo` on linux. As a result, `det slot list` will display CPU-based slot device brand as if it only uses a single core, e.g. `Intel(R) Xeon(R) CPU E5-2686 v4 @ 2.30GHz x 1 physical cores`, even though in reality it uses all 32 cores.

This PR fixes that, and also tries to handle multi-socket systems with different CPU models, if that ever happens.

## Test Plan

Run a CPU-slotted agent on linux and confirm it reports a correct number of cores.

## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
