### PR TITLE
docs: fix image formatting in 0.17.5 release notes

### DIFF
--- a/docs/release-notes.txt
+++ b/docs/release-notes.txt
@@ -21,12 +21,13 @@ Version 0.17.5
 -  WebUI: Add buttons to the WebUI to create new models in the Model Registry, as well as add
    checkpoints as versions to existing models. The Register Checkpoint modal can be accessed through
    the Checkpoint modal. The New Model modal can be accessed through the Register Checkpoint modal
-   or on the Model Registry page. .. image::
-   https://user-images.githubusercontent.com/15078396/144926870-bb93d587-f7ad-4052-a338-6fc000bd2ed9.png
-   .. image::
-   https://user-images.githubusercontent.com/15078396/144926881-98aeb187-aa3f-4e40-b502-d7af624573db.png
-   .. image::
-   https://user-images.githubusercontent.com/15078396/144926889-eec0216a-dacc-4fe5-ac28-858ea6587d04.png
+   or on the Model Registry page.
+
+   .. image:: https://user-images.githubusercontent.com/15078396/144926870-bb93d587-f7ad-4052-a338-6fc000bd2ed9.png
+
+   .. image:: https://user-images.githubusercontent.com/15078396/144926881-98aeb187-aa3f-4e40-b502-d7af624573db.png
+
+   .. image:: https://user-images.githubusercontent.com/15078396/144926889-eec0216a-dacc-4fe5-ac28-858ea6587d04.png
 
 -  API: Add a method for listing trials within an experiment.
 


### PR DESCRIPTION
## Description

Looks like the spacing matters and was wrong - I didn't check the eventual formatting prior to release.

## Test Plan

Built and viewed locally: fixed.