### PR TITLE
fix: handle calls to old command endpoints, make it harder to crash cmd managers [DET-6336]

### DIFF
--- a/master/internal/command/api.go
+++ b/master/internal/command/api.go
@@ -2,11 +2,16 @@ package command
 
 import (
 	"github.com/labstack/echo/v4"
+	"github.com/pkg/errors"
 
 	"github.com/determined-ai/determined/master/internal/db"
 	"github.com/determined-ai/determined/master/pkg/actor"
 	"github.com/determined-ai/determined/master/pkg/actor/api"
 )
+
+// ErrAPIRemoved is an error to inform the client they are calling an old, removed API.
+var ErrAPIRemoved = errors.New(`the API being called was removed,
+please ensure the client consuming the API is up to date and report a bug if the problem persists`)
 
 // RegisterAPIHandler initializes and registers the API handlers for all command related features.
 func RegisterAPIHandler(

--- a/master/internal/command/command.go
+++ b/master/internal/command/command.go
@@ -64,11 +64,12 @@ func createGenericCommandActor(
 	a, _ := ctx.ActorOf(cmd.taskID, cmd)
 	summaryFut := ctx.Ask(a, getSummary{})
 	if err := summaryFut.Error(); err != nil {
-		ctx.Respond(errors.Wrap(err, "failed to create generic command"))
-		return nil
+		return errors.Wrap(err, "failed to create generic command")
 	}
-	summary := summaryFut.Get().(summary)
-	ctx.Respond(summary.ID)
+	// Sync with the actor, but we don't really need the summary. actor.Ping works too,
+	// but this makes sure it can form some sort of useful response (ping doesn't actually
+	// hit the receive block).
+	summaryFut.Get()
 	return nil
 }
 

--- a/master/internal/command/command_manager.go
+++ b/master/internal/command/command_manager.go
@@ -3,6 +3,8 @@
 package command
 
 import (
+	"net/http"
+
 	"github.com/labstack/echo/v4"
 
 	"github.com/determined-ai/determined/master/internal/db"
@@ -47,7 +49,7 @@ func (c *commandManager) Receive(ctx *actor.Context) error {
 		}
 
 	case echo.Context:
-		ctx.Respond(echo.ErrNotFound)
+		ctx.Respond(echo.NewHTTPError(http.StatusNotFound, ErrAPIRemoved))
 
 	default:
 		return actor.ErrUnexpectedMessage(ctx)

--- a/master/internal/command/notebook_manager.go
+++ b/master/internal/command/notebook_manager.go
@@ -1,6 +1,10 @@
+// Package command provides utilities for commands.
+//nolint:dupl
 package command
 
 import (
+	"github.com/labstack/echo/v4"
+
 	"github.com/determined-ai/determined/master/pkg/model"
 
 	"github.com/determined-ai/determined/master/internal/db"
@@ -34,9 +38,17 @@ func (n *notebookManager) Receive(ctx *actor.Context) error {
 	case tasks.GenericCommandSpec:
 		taskID := model.NewTaskID()
 		jobID := model.NewJobID()
-		return createGenericCommandActor(
+		if err := createGenericCommandActor(
 			ctx, n.db, taskID, model.TaskTypeNotebook, jobID, model.JobTypeNotebook, msg,
-		)
+		); err != nil {
+			ctx.Log().WithError(err).Error("failed to launch notebook")
+			ctx.Respond(err)
+		} else {
+			ctx.Respond(taskID)
+		}
+
+	case echo.Context:
+		ctx.Respond(echo.ErrNotFound)
 
 	default:
 		return actor.ErrUnexpectedMessage(ctx)

--- a/master/internal/command/notebook_manager.go
+++ b/master/internal/command/notebook_manager.go
@@ -3,6 +3,8 @@
 package command
 
 import (
+	"net/http"
+
 	"github.com/labstack/echo/v4"
 
 	"github.com/determined-ai/determined/master/pkg/model"
@@ -48,7 +50,7 @@ func (n *notebookManager) Receive(ctx *actor.Context) error {
 		}
 
 	case echo.Context:
-		ctx.Respond(echo.ErrNotFound)
+		ctx.Respond(echo.NewHTTPError(http.StatusNotFound, ErrAPIRemoved))
 
 	default:
 		return actor.ErrUnexpectedMessage(ctx)

--- a/master/internal/command/shell_manager.go
+++ b/master/internal/command/shell_manager.go
@@ -4,6 +4,8 @@
 package command
 
 import (
+	"net/http"
+
 	"github.com/labstack/echo/v4"
 
 	"github.com/determined-ai/determined/master/pkg/model"
@@ -49,7 +51,7 @@ func (s *shellManager) Receive(ctx *actor.Context) error {
 		}
 
 	case echo.Context:
-		ctx.Respond(echo.ErrNotFound)
+		ctx.Respond(echo.NewHTTPError(http.StatusNotFound, ErrAPIRemoved))
 
 	default:
 		return actor.ErrUnexpectedMessage(ctx)

--- a/master/internal/command/shell_manager.go
+++ b/master/internal/command/shell_manager.go
@@ -1,6 +1,11 @@
+// Package command provides utilities for commands. This package comment is to satisfy linters
+// without disabling golint for the file.
+//nolint:dupl // So easy with generics, so hard without; just wait.
 package command
 
 import (
+	"github.com/labstack/echo/v4"
+
 	"github.com/determined-ai/determined/master/pkg/model"
 
 	"github.com/determined-ai/determined/master/internal/db"
@@ -34,9 +39,17 @@ func (s *shellManager) Receive(ctx *actor.Context) error {
 	case tasks.GenericCommandSpec:
 		taskID := model.NewTaskID()
 		jobID := model.NewJobID()
-		return createGenericCommandActor(
+		if err := createGenericCommandActor(
 			ctx, s.db, taskID, model.TaskTypeShell, jobID, model.JobTypeShell, msg,
-		)
+		); err != nil {
+			ctx.Log().WithError(err).Error("failed to launch shell")
+			ctx.Respond(err)
+		} else {
+			ctx.Respond(taskID)
+		}
+
+	case echo.Context:
+		ctx.Respond(echo.ErrNotFound)
 
 	default:
 		return actor.ErrUnexpectedMessage(ctx)

--- a/master/internal/command/tensorboard_manager.go
+++ b/master/internal/command/tensorboard_manager.go
@@ -1,6 +1,10 @@
+// Package command provides utilities for commands.
+//nolint:dupl
 package command
 
 import (
+	"github.com/labstack/echo/v4"
+
 	"github.com/determined-ai/determined/master/pkg/model"
 
 	"github.com/determined-ai/determined/master/internal/db"
@@ -34,9 +38,17 @@ func (t *tensorboardManager) Receive(ctx *actor.Context) error {
 	case tasks.GenericCommandSpec:
 		taskID := model.NewTaskID()
 		jobID := model.NewJobID()
-		return createGenericCommandActor(
+		if err := createGenericCommandActor(
 			ctx, t.db, taskID, model.TaskTypeTensorboard, jobID, model.JobTypeTensorboard, msg,
-		)
+		); err != nil {
+			ctx.Log().WithError(err).Error("failed to launch tensorboard")
+			ctx.Respond(err)
+		} else {
+			ctx.Respond(taskID)
+		}
+
+	case echo.Context:
+		ctx.Respond(echo.ErrNotFound)
 
 	default:
 		return actor.ErrUnexpectedMessage(ctx)

--- a/master/internal/command/tensorboard_manager.go
+++ b/master/internal/command/tensorboard_manager.go
@@ -3,6 +3,8 @@
 package command
 
 import (
+	"net/http"
+
 	"github.com/labstack/echo/v4"
 
 	"github.com/determined-ai/determined/master/pkg/model"
@@ -48,7 +50,7 @@ func (t *tensorboardManager) Receive(ctx *actor.Context) error {
 		}
 
 	case echo.Context:
-		ctx.Respond(echo.ErrNotFound)
+		ctx.Respond(echo.NewHTTPError(http.StatusNotFound, ErrAPIRemoved))
 
 	default:
 		return actor.ErrUnexpectedMessage(ctx)


### PR DESCRIPTION
## Description
This change updates the command manager code to not crash permanently when receiving API calls from echo routed through the actor system. The actor's handling of these calls was removed but the system still could route calls to it, so, for example, an old CLI could crash commands until a restart occurred. We still need to route to the actors below `/commands/...`, `/shells/...`, etc, for the event endpoints et al, so the routing cannot just be purged.
<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan
- [x] make sure an old cli can't crash us
<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ