### PR TITLE
chore: workaround upstream torch bug

### DIFF
--- a/harness/determined/tensorboard/metric_writers/pytorch.py
+++ b/harness/determined/tensorboard/metric_writers/pytorch.py
@@ -1,9 +1,15 @@
 from typing import Any, Union
 
 import numpy as np
-from torch.utils.tensorboard import SummaryWriter
 
 from determined import tensorboard
+
+# As of torch v1.9.0, torch.utils.tensorboard has a bug that is exposed by setuptools 59.6.0.  The
+# bug is that it attempts to import distutils then access distutils.version without actually
+# importing distutils.version.  We can workaround this by prepopulating the distutils.version
+# submodule in the distutils module.
+import distutils.version  # isort:skip  # noqa: F401
+from torch.utils.tensorboard import SummaryWriter  # isort:skip
 
 
 class TorchWriter(tensorboard.MetricWriter):


### PR DESCRIPTION
setuptools 59.6.0 exposed a bug in pytorch, where pytorch is improperly
importing a particular submodule of distutils.  In old setuptools,
distutils.version was automatically imported, but in new setuptools, it
is not.  For details, see:

    https://github.com/pytorch/pytorch/issues/69894

Since forcing users to upgrade pytorch is not feasible, we intervene by
enforcing that distutils.version is imported before we try to import the
problematic torch.utils.tensorboard submodule.  This workaround will not
help users who import torch.utils.tensorboard directly, but it will
protect users who only import torch.utils.tensorboard because of us.

## Test Plan

I imported `determined.tensorboard.metric_writers.torch` with and without the fix.

## Commentary

Example test failure [here](https://app.circleci.com/pipelines/github/determined-ai/determined/17542/workflows/cd0043c8-11ed-4b6a-a63e-39d9391bc88b/jobs/536910/parallel-runs/1)