### PR TITLE
fix: prevent trial being saved before allocation cancellation is acknowledged

### DIFF
--- a/master/internal/task/errors.go
+++ b/master/internal/task/errors.go
@@ -67,3 +67,11 @@ type ErrBehaviorDisabled struct {
 func (e ErrBehaviorDisabled) Error() string {
 	return fmt.Sprintf("%s not enabled for this allocation", e.Behavior)
 }
+
+// ErrAlreadyCancelled is returned to the allocation when it tries to take an action but has an
+// unread cancellation in its inbox.
+type ErrAlreadyCancelled struct{}
+
+func (e ErrAlreadyCancelled) Error() string {
+	return "the allocation was canceled while this message was waiting"
+}


### PR DESCRIPTION
## Description
A bug occurred where, in quick succession, a RM granted an allocation resources and it reached out to build its task spec/save the trial to the DB, and the trial was canceled. This caused a trial to get saved in the `ACTIVE` state (as it always defaults to) instead of its actual state `STOPPING_CANCELED`. Rather than just save the state correctly by saving it as `STOPPING_CANCELED`, we introduce a new error type and return it to the allocation when it takes an action with an unreceived cancellation in its inbox. This stops the task from pointlessly allocating then killing itself and prevents the bug since we only add an active trial when the trial is active. 
<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan
- [x] add a test case
<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ