### PR TITLE
feat: support agent on Apple Silicon without Rosetta

### DIFF
--- a/agent/internal/agent_test.go
+++ b/agent/internal/agent_test.go
@@ -111,7 +111,7 @@ func defaultAgentConfig() Options {
 }
 
 func defaultContainerMasterHost() string {
-	if runtime.GOOS == "darwin" {
+	if runtime.GOOS == osDarwin {
 		return "host.docker.internal"
 	}
 	return ""

--- a/agent/internal/detect.go
+++ b/agent/internal/detect.go
@@ -21,6 +21,10 @@ import (
 	"github.com/determined-ai/determined/master/pkg/device"
 )
 
+const (
+	osDarwin = "darwin"
+)
+
 func (a *agent) detect() error {
 	switch {
 	case a.ArtificialSlots > 0:
@@ -70,11 +74,10 @@ func detectCPUs() ([]device.Device, error) {
 		if errno, ok := err.(syscall.Errno); ok {
 			switch errno {
 			case syscall.ENOENT:
-				if runtime.GOARCH == "arm64" && runtime.GOOS == "darwin" {
+				if runtime.GOARCH == "arm64" && runtime.GOOS == osDarwin {
 					return []device.Device{{ID: 0, Brand: "Apple", UUID: "AppleM1", Type: device.CPU}}, nil
-				} else {
-					return nil, errors.Wrap(err, "error while gathering CPU info on a non-AppleM1 system")
 				}
+				return nil, errors.Wrap(err, "error while gathering CPU info on a non-AppleM1 system")
 			default:
 				return nil, errors.Wrap(err, "error while gathering CPU info")
 			}

--- a/agent/internal/detect.go
+++ b/agent/internal/detect.go
@@ -75,7 +75,7 @@ func detectCPUs() ([]device.Device, error) {
 			switch errno {
 			case syscall.ENOENT:
 				if runtime.GOARCH == "arm64" && runtime.GOOS == osDarwin {
-					return []device.Device{{ID: 0, Brand: "Apple", UUID: "AppleM1", Type: device.CPU}}, nil
+					return []device.Device{{ID: 0, Brand: "Apple", UUID: "AppleSilicon", Type: device.CPU}}, nil
 				}
 				return nil, errors.Wrap(err, "error while gathering CPU info on a non-AppleM1 system")
 			default:


### PR DESCRIPTION
## Description

Agent exits on Apple with M1 chip because of an error when obtaining the CPU info using gopsutil ( https://github.com/shirou/gopsutil/issues/1000 ). This PR works around the error by providing placeholder values for brand and UUID.

## Test Plan

Start Agent successfully on M1 Mac.


## Commentary (optional)

We may choose to wait for the fix to gopsutil or we can merge this fix now and replace it with an upgrade of gopsutil when a fix becomes available there.


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
