### PR TITLE
fix: fix incorrect preemption status report from Kubernetes RP

### DIFF
--- a/master/internal/command/command.go
+++ b/master/internal/command/command.go
@@ -424,7 +424,7 @@ func (c *command) toV1Job() *jobv1.Job {
 		Name:           c.Config.Description,
 	}
 
-	j.IsPreemptible = config.ReadRMPreemptionStatus(j.ResourcePool) && false // CHECK we can't make command preemptible can we?
+	j.IsPreemptible = config.ReadRMPreemptionStatus(j.ResourcePool) && false
 	j.Priority = int32(config.ReadPriority(j.ResourcePool, &c.Config))
 	j.Weight = config.ReadWeight(j.ResourcePool, &c.Config)
 

--- a/master/internal/command/command.go
+++ b/master/internal/command/command.go
@@ -424,7 +424,7 @@ func (c *command) toV1Job() *jobv1.Job {
 		Name:           c.Config.Description,
 	}
 
-	j.IsPreemptible = config.ReadPreemptionStatus(j.ResourcePool, &c.Config)
+	j.IsPreemptible = config.ReadPreemptionStatus(j.ResourcePool, false) // CHECK we can't make command preemptible can we?
 	j.Priority = int32(config.ReadPriority(j.ResourcePool, &c.Config))
 	j.Weight = config.ReadWeight(j.ResourcePool, &c.Config)
 

--- a/master/internal/command/command.go
+++ b/master/internal/command/command.go
@@ -424,7 +424,7 @@ func (c *command) toV1Job() *jobv1.Job {
 		Name:           c.Config.Description,
 	}
 
-	j.IsPreemptible = config.ReadPreemptionStatus(j.ResourcePool, false) // CHECK we can't make command preemptible can we?
+	j.IsPreemptible = config.ReadRMPreemptionStatus(j.ResourcePool) && false // CHECK we can't make command preemptible can we?
 	j.Priority = int32(config.ReadPriority(j.ResourcePool, &c.Config))
 	j.Weight = config.ReadWeight(j.ResourcePool, &c.Config)
 

--- a/master/internal/config/config.go
+++ b/master/internal/config/config.go
@@ -12,6 +12,7 @@ import (
 	"github.com/determined-ai/determined/master/internal/db"
 	"github.com/determined-ai/determined/master/internal/hpimportance"
 	"github.com/determined-ai/determined/master/internal/resourcemanagers"
+	"github.com/determined-ai/determined/master/internal/resourcemanagers/kubernetes"
 	"github.com/determined-ai/determined/master/pkg/logger"
 	"github.com/determined-ai/determined/master/pkg/model"
 	"github.com/determined-ai/determined/master/pkg/schemas/expconf"
@@ -268,7 +269,7 @@ func ReadRMPreemptionStatus(rpName string) bool {
 		}
 		return config.ResourceManager.AgentRM.Scheduler.GetPreemption()
 	case config.ResourceManager.KubernetesRM != nil:
-		return config.ResourceManager.KubernetesRM.DefaultScheduler == "preemption"
+		return config.ResourceManager.KubernetesRM.DefaultScheduler == kubernetes.PreemptionScheduler
 	default:
 		panic("unexpected resource configuration")
 	}

--- a/master/internal/config/config.go
+++ b/master/internal/config/config.go
@@ -257,9 +257,6 @@ func readRMPreemptionStatus(config *Config, rpName string) bool {
 		if rpConfig.Scheduler != nil {
 			return rpConfig.Scheduler.GetPreemption()
 		}
-		if rpConfig.Provider != nil && rpConfig.Provider.GCP != nil {
-			return rpConfig.Provider.GCP.InstanceType.Preemptible
-		}
 		break
 	}
 

--- a/master/internal/config/config.go
+++ b/master/internal/config/config.go
@@ -243,13 +243,8 @@ func readPriorityFromScheduler(conf *resourcemanagers.SchedulerConfig) *int {
 	return conf.Priority.DefaultPriority
 }
 
-// TODO rename to preemtible
-// ReadPreemptionStatus resolves the final preemtible status for a job.
-func ReadPreemptionStatus(rpName string, jobPreemptible bool) bool {
-	return jobPreemptible && readRMPreemptionStatus(rpName)
-}
-
-func readRMPreemptionStatus(rpName string) bool {
+// ReadRMPreemptionStatus resolves the preemption status for a resource manager.
+func ReadRMPreemptionStatus(rpName string) bool {
 	config := GetMasterConfig()
 
 	for _, rpConfig := range config.ResourcePools {

--- a/master/internal/config/config.go
+++ b/master/internal/config/config.go
@@ -12,7 +12,6 @@ import (
 	"github.com/determined-ai/determined/master/internal/db"
 	"github.com/determined-ai/determined/master/internal/hpimportance"
 	"github.com/determined-ai/determined/master/internal/resourcemanagers"
-	"github.com/determined-ai/determined/master/internal/resourcemanagers/kubernetes"
 	"github.com/determined-ai/determined/master/pkg/logger"
 	"github.com/determined-ai/determined/master/pkg/model"
 	"github.com/determined-ai/determined/master/pkg/schemas/expconf"
@@ -272,7 +271,7 @@ func readRMPreemptionStatus(config *Config, rpName string) bool {
 		}
 		return config.ResourceManager.AgentRM.Scheduler.GetPreemption()
 	case config.ResourceManager.KubernetesRM != nil:
-		return config.ResourceManager.KubernetesRM.DefaultScheduler == kubernetes.PreemptionScheduler
+		return config.ResourceManager.KubernetesRM.GetPreemption()
 	default:
 		panic("unexpected resource configuration")
 	}

--- a/master/internal/config/config.go
+++ b/master/internal/config/config.go
@@ -247,7 +247,10 @@ func readPriorityFromScheduler(conf *resourcemanagers.SchedulerConfig) *int {
 // ReadRMPreemptionStatus resolves the preemption status for a resource manager.
 func ReadRMPreemptionStatus(rpName string) bool {
 	config := GetMasterConfig()
+	return readRMPreemptionStatus(config, rpName)
+}
 
+func readRMPreemptionStatus(config *Config, rpName string) bool {
 	for _, rpConfig := range config.ResourcePools {
 		if rpConfig.PoolName != rpName {
 			continue

--- a/master/internal/config/config.go
+++ b/master/internal/config/config.go
@@ -236,13 +236,6 @@ type ObservabilityConfig struct {
 	EnablePrometheus bool `json:"enable_prometheus"`
 }
 
-func readPreemptionFromScheduler(conf *resourcemanagers.SchedulerConfig) *bool {
-	if conf == nil || conf.Priority == nil {
-		return nil
-	}
-	return &conf.Priority.Preemption
-}
-
 func readPriorityFromScheduler(conf *resourcemanagers.SchedulerConfig) *int {
 	if conf == nil || conf.Priority == nil {
 		return nil
@@ -269,7 +262,7 @@ func ReadPreemptionStatus(rpName string, jobConf interface{}) bool {
 		if rpConfig.PoolName != rpName {
 			continue
 		}
-		if preemption := readPreemptionFromScheduler(rpConfig.Scheduler); preemption != nil {
+		if preemption := resourcemanagers.ReadPreemptionFromScheduler(rpConfig.Scheduler); preemption != nil {
 			RMPremption = *preemption
 			return jobPreemptible && RMPremption
 		}
@@ -282,7 +275,7 @@ func ReadPreemptionStatus(rpName string, jobConf interface{}) bool {
 
 	// if not found, fall back to resource manager config
 	if config.ResourceManager.AgentRM != nil {
-		if preemption := readPreemptionFromScheduler(
+		if preemption := resourcemanagers.ReadPreemptionFromScheduler(
 			config.ResourceManager.AgentRM.Scheduler,
 		); preemption != nil {
 			RMPremption = *preemption

--- a/master/internal/config/config_test.go
+++ b/master/internal/config/config_test.go
@@ -465,5 +465,4 @@ resource_manager:
 			test(t, tc.configRaw, tc.rpName, tc.preemptionEnabled)
 		})
 	}
-
 }

--- a/master/internal/config/config_test.go
+++ b/master/internal/config/config_test.go
@@ -316,10 +316,11 @@ telemetry:
 
 func TestRMPreemptionStatus(t *testing.T) {
 	test := func(t *testing.T, configRaw string, rpName string, expected bool) {
-		unmarshaled := Config{}
-		err := yaml.Unmarshal([]byte(configRaw), &unmarshaled, yaml.DisallowUnknownFields)
+		unmarshaled := DefaultConfig()
+		err := yaml.Unmarshal([]byte(configRaw), unmarshaled, yaml.DisallowUnknownFields)
+		assert.NilError(t, unmarshaled.Resolve())
 		assert.NilError(t, err)
-		assert.DeepEqual(t, readRMPreemptionStatus(&unmarshaled, rpName), expected)
+		assert.DeepEqual(t, readRMPreemptionStatus(unmarshaled, rpName), expected)
 	}
 
 	testCases := []struct {
@@ -436,6 +437,25 @@ resource_pools:
   - pool_name: preemtible
 `,
 			rpName:            "preemtible",
+			preemptionEnabled: true,
+		},
+		{
+			name: "k8 default",
+			configRaw: `
+resource_manager:
+  type: kubernetes
+`,
+			rpName:            "",
+			preemptionEnabled: false,
+		},
+		{
+			name: "k8 with preemption plugin",
+			configRaw: `
+resource_manager:
+  type: kubernetes
+  default_scheduler: preemption
+`,
+			rpName:            "default",
 			preemptionEnabled: true,
 		},
 	}

--- a/master/internal/experiment.go
+++ b/master/internal/experiment.go
@@ -581,7 +581,7 @@ func (e *experiment) toV1Job() *jobv1.Job {
 		Name:           e.Config.Name().String(),
 	}
 
-	j.IsPreemptible = config.ReadRMPreemptionStatus(j.ResourcePool) // && true; Experiment jobs are always preemptible.
+	j.IsPreemptible = config.ReadRMPreemptionStatus(j.ResourcePool) // && true
 	j.Priority = int32(config.ReadPriority(j.ResourcePool, &e.Config))
 	j.Weight = config.ReadWeight(j.ResourcePool, &e.Config)
 	job.UpdateJobQInfo(&j, e.rmJobInfo)

--- a/master/internal/experiment.go
+++ b/master/internal/experiment.go
@@ -581,7 +581,7 @@ func (e *experiment) toV1Job() *jobv1.Job {
 		Name:           e.Config.Name().String(),
 	}
 
-	j.IsPreemptible = config.ReadPreemptionStatus(j.ResourcePool, true)
+	j.IsPreemptible = config.ReadRMPreemptionStatus(j.ResourcePool) // && true; Experiment jobs are always preemptible.
 	j.Priority = int32(config.ReadPriority(j.ResourcePool, &e.Config))
 	j.Weight = config.ReadWeight(j.ResourcePool, &e.Config)
 	job.UpdateJobQInfo(&j, e.rmJobInfo)

--- a/master/internal/experiment.go
+++ b/master/internal/experiment.go
@@ -581,7 +581,7 @@ func (e *experiment) toV1Job() *jobv1.Job {
 		Name:           e.Config.Name().String(),
 	}
 
-	j.IsPreemptible = config.ReadPreemptionStatus(j.ResourcePool, &e.Config)
+	j.IsPreemptible = config.ReadPreemptionStatus(j.ResourcePool, true)
 	j.Priority = int32(config.ReadPriority(j.ResourcePool, &e.Config))
 	j.Weight = config.ReadWeight(j.ResourcePool, &e.Config)
 	job.UpdateJobQInfo(&j, e.rmJobInfo)

--- a/master/internal/resourcemanagers/kubernetes/spec.go
+++ b/master/internal/resourcemanagers/kubernetes/spec.go
@@ -29,9 +29,10 @@ import (
 )
 
 const (
-	fluentBaseDir       = "/run/determined/fluent/"
-	coscheduler         = "coscheduler"
-	preemptionScheduler = "preemption"
+	fluentBaseDir = "/run/determined/fluent/"
+	coscheduler   = "coscheduler"
+	// PreemptionScheduler is the name of the preemption scheduler for k8.
+	PreemptionScheduler = "preemption"
 	gcTask              = "gc"
 	cmdTask             = "cmd"
 
@@ -212,7 +213,7 @@ func (p *pod) modifyPodSpec(newPod *k8sV1.Pod, scheduler string) {
 			)
 		}
 		newPod.Spec.PriorityClassName = "determined-system-priority"
-	} else if scheduler == coscheduler || scheduler == preemptionScheduler {
+	} else if scheduler == coscheduler || scheduler == PreemptionScheduler {
 		if newPod.Spec.SchedulerName == "" {
 			newPod.Spec.SchedulerName = scheduler
 		}

--- a/master/internal/resourcemanagers/kubernetes_resource_manager.go
+++ b/master/internal/resourcemanagers/kubernetes_resource_manager.go
@@ -184,7 +184,7 @@ func (k *kubernetesResourceManager) summarizeDummyResourcePool(
 		AuxContainersRunning:         int32(k.agent.numUsedZeroSlots()),
 		DefaultComputePool:           true,
 		DefaultAuxPool:               true,
-		Preemptible:                  false,
+		Preemptible:                  k.config.GetPreemption(),
 		MinAgents:                    0,
 		MaxAgents:                    0,
 		SlotsPerAgent:                int32(k.config.MaxSlotsPerPod),

--- a/master/internal/resourcemanagers/resource_manager_config.go
+++ b/master/internal/resourcemanagers/resource_manager_config.go
@@ -108,6 +108,11 @@ var defaultKubernetesResourceManagerConfig = KubernetesResourceManagerConfig{
 	SlotType: device.GPU, // default to CUDA-backed slots.
 }
 
+// GetPreemption returns whether the RM is set to preempt.
+func (k *KubernetesResourceManagerConfig) GetPreemption() bool {
+	return k.DefaultScheduler == kubernetes.PreemptionScheduler
+}
+
 // UnmarshalJSON implements the json.Unmarshaler interface.
 func (k *KubernetesResourceManagerConfig) UnmarshalJSON(data []byte) error {
 	*k = defaultKubernetesResourceManagerConfig

--- a/master/internal/resourcemanagers/resource_pool.go
+++ b/master/internal/resourcemanagers/resource_pool.go
@@ -450,31 +450,12 @@ func (c containerReservation) Kill(ctx *actor.Context) {
 	})
 }
 
-// ReadPreemptionFromScheduler resolves preemption status for a scheduler.
-func ReadPreemptionFromScheduler(config *SchedulerConfig) *bool {
-	if config == nil {
-		return nil
-	}
-	var preemptionEnabled bool
-	switch {
-	case config.FairShare != nil:
-		preemptionEnabled = true
-	case config.Priority != nil:
-		preemptionEnabled = config.Priority.Preemption
-	case config.RoundRobin != nil:
-		preemptionEnabled = false
-	}
-	return &preemptionEnabled
-}
-
 func reportResourcePoolCreated(system *actor.System, config *ResourcePoolConfig) {
-	preemptionEnabled := ReadPreemptionFromScheduler(config.Scheduler)
-	if preemptionEnabled == nil {
+	if config.Scheduler == nil {
 		panic("scheduler not configured in resource pool")
 	}
-
 	telemetry.ReportResourcePoolCreated(
 		system, config.PoolName, config.Scheduler.GetType(),
-		config.Scheduler.FittingPolicy, *preemptionEnabled,
+		config.Scheduler.FittingPolicy, config.Scheduler.GetPreemption(),
 	)
 }

--- a/master/internal/resourcemanagers/scheduler_config.go
+++ b/master/internal/resourcemanagers/scheduler_config.go
@@ -91,7 +91,7 @@ func (s *SchedulerConfig) GetType() string {
 	}
 }
 
-// GetType returns the type of scheduler that is configured.
+// GetPreemption returns whether the scheduler is set to preempt.
 func (s *SchedulerConfig) GetPreemption() bool {
 	var preemptionEnabled bool
 	switch {

--- a/master/internal/resourcemanagers/scheduler_config.go
+++ b/master/internal/resourcemanagers/scheduler_config.go
@@ -106,7 +106,6 @@ func (s *SchedulerConfig) GetPreemption() bool {
 }
 
 // FairShareSchedulerConfig holds configurations for the fair share scheduler.
-// FairShareSchedulerConfig holds configurations for the fair share scheduler.
 type FairShareSchedulerConfig struct{}
 
 // PrioritySchedulerConfig holds the configurations for the priority scheduler.

--- a/master/internal/resourcemanagers/scheduler_config.go
+++ b/master/internal/resourcemanagers/scheduler_config.go
@@ -91,6 +91,21 @@ func (s *SchedulerConfig) GetType() string {
 	}
 }
 
+// GetType returns the type of scheduler that is configured.
+func (s *SchedulerConfig) GetPreemption() bool {
+	var preemptionEnabled bool
+	switch {
+	case s.FairShare != nil:
+		preemptionEnabled = true
+	case s.Priority != nil:
+		preemptionEnabled = s.Priority.Preemption
+	case s.RoundRobin != nil:
+		preemptionEnabled = false
+	}
+	return preemptionEnabled
+}
+
+// FairShareSchedulerConfig holds configurations for the fair share scheduler.
 // FairShareSchedulerConfig holds configurations for the fair share scheduler.
 type FairShareSchedulerConfig struct{}
 


### PR DESCRIPTION
## Description

- dummy k8 resource pool reported inaccurate preemption status when using the `preemption` scheduler plugin
- set up scheduler and Kubernetes config structs to report their own preemption status

<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ