### PR TITLE
fix: small bug in log message

### DIFF
--- a/master/internal/sproto/agent_resource_manager.go
+++ b/master/internal/sproto/agent_resource_manager.go
@@ -123,7 +123,7 @@ type TerminateDecision struct {
 
 // String returns a representative string.
 func (t TerminateDecision) String() string {
-	item := make([]string, len(t.Reasons))
+	var item []string
 	for id, reason := range t.Reasons {
 		item = append(item, fmt.Sprintf("%s (reason: %s)", id, reason))
 	}


### PR DESCRIPTION
Prefer something which is obviously correct in this case, since it
doesn't run frequently enough to bother with optimizing memory patterns.