### PR TITLE
fix: move deploy dependencies to `extras_require`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -202,8 +202,8 @@ commands:
           working_directory: <<parameters.package-location>>
           command: |
             make build
-            pip install --find-links dist <<parameters.package-name>>==<< pipeline.parameters.det-version >>
-            pip install --no-deps --force-reinstall --find-links dist <<parameters.package-name>>==<< pipeline.parameters.det-version >>
+            pip install --find-links dist <<parameters.package-name>>[deploy]==<< pipeline.parameters.det-version >>
+            pip install --no-deps --force-reinstall --find-links dist <<parameters.package-name>>[deploy]==<< pipeline.parameters.det-version >>
   setup-python-venv:
     description: Set up and create Python venv.
     parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1455,7 +1455,7 @@ jobs:
       # Windows needs special treatment of cryptography for unknown reasons.
       # LMDB also has special requirements that only apply to windows (patch-ng).
       - run: sh -c "if which conda ; then conda install cryptography patch-ng --yes ; fi"
-      - run: pip install --find-links build determined==<< pipeline.parameters.det-version >>
+      - run: pip install --find-links build determined[deploy]==<< pipeline.parameters.det-version >>
       - run: pip freeze --all
       # Allow this to fail, but it is useful for debugging.
       - run: sh -c "pip check || true"

--- a/harness/setup.py
+++ b/harness/setup.py
@@ -42,17 +42,20 @@ setup(
         "tabulate>=0.8.3",
         # det preview-search "pretty-dumps" a sub-yaml with an API added in 0.15.29
         "ruamel.yaml>=0.15.29",
-        # Deploy
-        # "docker[ssh]>=3.7.3",
-        # "google-api-python-client>=1.12.1",
-        # "paramiko>=2.4.2",  # explicitly pull in paramiko to prevent DistributionNotFound error
-        # "docker-compose>=1.13.0",
-        # "tqdm",
-        # "appdirs",
-        # "websocket-client",
         # Telemetry
         "analytics-python",
     ],
+    extras_require={
+        "deploy": [
+            "docker[ssh]>=3.7.3",
+            "google-api-python-client>=1.12.1",
+            "paramiko>=2.4.2",  # explicitly pull in paramiko to prevent DistributionNotFound error
+            "docker-compose>=1.13.0",
+            "tqdm",
+            "appdirs",
+            "websocket-client",
+        ]
+    },
     zip_safe=False,
     entry_points={
         "console_scripts": [

--- a/harness/setup.py
+++ b/harness/setup.py
@@ -49,9 +49,7 @@ setup(
         "docker-compose>=1.13.0",
         "tqdm",
         "appdirs",
-        # docker-compose has a requirement not properly propagated with semi-old pip installations;
-        # so we expose that requirement here.
-        "websocket-client<1",
+        "websocket-client",
         # Telemetry
         "analytics-python",
     ],

--- a/harness/setup.py
+++ b/harness/setup.py
@@ -53,7 +53,7 @@ setup(
             "docker-compose>=1.13.0",
             "tqdm",
             "appdirs",
-            "websocket-client",
+            "websocket-client<1",
         ]
     },
     zip_safe=False,

--- a/harness/setup.py
+++ b/harness/setup.py
@@ -43,13 +43,13 @@ setup(
         # det preview-search "pretty-dumps" a sub-yaml with an API added in 0.15.29
         "ruamel.yaml>=0.15.29",
         # Deploy
-        "docker[ssh]>=3.7.3",
-        "google-api-python-client>=1.12.1",
-        "paramiko>=2.4.2",  # explicitly pull in paramiko to prevent DistributionNotFound error
-        "docker-compose>=1.13.0",
-        "tqdm",
-        "appdirs",
-        "websocket-client",
+        # "docker[ssh]>=3.7.3",
+        # "google-api-python-client>=1.12.1",
+        # "paramiko>=2.4.2",  # explicitly pull in paramiko to prevent DistributionNotFound error
+        # "docker-compose>=1.13.0",
+        # "tqdm",
+        # "appdirs",
+        # "websocket-client",
         # Telemetry
         "analytics-python",
     ],

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
--e harness
+-e harness[deploy]
 -e common
 -e cli
 -e deploy


### PR DESCRIPTION
## Description
Moves "deploy" dependencies to an extras section. This helps segment dependencies that may not be needed for every use case. In particular, this will help reduce the odds of determined causing dependency conflicts with other python dependencies users need to install for their project.


## Test Plan
Update the existing tests to install the extra and run them.

## Commentary (optional)

What pieces of the documentation need to be updated?

## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ