### PR TITLE
chore: AdvancedSearcher->Searcher

### DIFF
--- a/harness/determined/_core/__init__.py
+++ b/harness/determined/_core/__init__.py
@@ -1,6 +1,6 @@
 from determined._core._distributed import DistributedContext, DummyDistributed
 from determined._core._checkpointing import Checkpointing, DummyCheckpointing
 from determined._core._training import Training, DummyTraining, EarlyExitReason
-from determined._core._searcher import AdvancedSearcher, DummyAdvancedSearcher, SearcherOp, Unit
+from determined._core._searcher import Searcher, DummySearcher, SearcherOp, Unit
 from determined._core._preemption import Preemption, DummyPreemption, _PreemptionWatcher
 from determined._core._context import Context, init, _dummy_init

--- a/harness/determined/_core/_context.py
+++ b/harness/determined/_core/_context.py
@@ -23,15 +23,13 @@ class Context:
         distributed: Optional[_core.DistributedContext] = None,
         preemption: Optional[_core.Preemption] = None,
         training: Optional[_core.Training] = None,
-        searcher: Optional[_core.AdvancedSearcher] = None,
+        searcher: Optional[_core.Searcher] = None,
     ) -> None:
         self.checkpointing = checkpointing
         self.distributed = distributed or _core.DummyDistributed()
         self.preemption = preemption or _core.DummyPreemption()
         self.training = training or _core.DummyTraining()
-        # TODO(DET-6083): Finalize BasicSearcher.  Figure out if calling this .searcher is going to
-        # create a name conflict between AdvancedSearcher and BasicSearcher
-        self.searcher = searcher or _core.DummyAdvancedSearcher()
+        self.searcher = searcher or _core.DummySearcher()
 
     def __enter__(self) -> "Context":
         self.preemption.start()
@@ -68,7 +66,7 @@ def _dummy_init(
     checkpointing = _core.DummyCheckpointing(distributed, storage_manager)
 
     training = _core.DummyTraining()
-    searcher = _core.DummyAdvancedSearcher()
+    searcher = _core.DummySearcher()
 
     return Context(
         distributed=distributed,
@@ -131,7 +129,7 @@ def init(
             tbd_mgr,
             tbd_writer,
         )
-        searcher = _core.AdvancedSearcher(
+        searcher = _core.Searcher(
             session, info.trial.trial_id, info.trial._trial_run_id, info.allocation_id
         )
 


### PR DESCRIPTION
Turns out that the master doesn't even need units when configuring the
searcher.  That means that the basic searcher doesn't make much since,
since it only really worked with a large unit (epochs) rather than a
small unit (batches/records), so for now the Core API will only support
SearcherOp-based training loops.

This is a bit unforunate, since a SearcherOp-based training loop
requires an extra layer of for loop that is not totally intuitive.  We
can revisit this at a later time when it is clearer how we can reduce
user friction.  In the mean time, keeping the Core API barebones is a
good idea.