### PR TITLE
fix: add return to SDK command

### DIFF
--- a/harness/determined/experimental/_native.py
+++ b/harness/determined/experimental/_native.py
@@ -182,7 +182,7 @@ def create(
     context_dir: str = "",
     command: Optional[List[str]] = None,
     master_url: Optional[str] = None,
-) -> Any:
+) -> int:
     # TODO: Add a reference to the local development tutorial.
     """
     Create an experiment.
@@ -235,6 +235,9 @@ def create(
             An optional string to use as the Determined master URL when
             ``local=False``. If not specified, will be inferred from the
             environment variable ``DET_MASTER``.
+
+    Returns:
+        int: the created experiment ID.
     """
 
     if local and not test:
@@ -257,7 +260,7 @@ def create(
 
     elif not load.in_runpy:
         # Cluster mode, but still running locally; submit the experiment.
-        _submit_experiment(
+        return _submit_experiment(
             config=config,
             test=test,
             context_dir=context_dir,


### PR DESCRIPTION
## Description
`determined.experimenta.create` was missing a return statement.


## Test Plan
Technically there could be a unit test to check the return value, but I'm not sure how valuable this is, especially if there's a more general system of dynamic type checking, e.g. `typeguard`.


## Commentary (optional)


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.