### PR TITLE
fix: Convert all experiment and job states to labels

### DIFF
--- a/webui/react/src/pages/ExperimentDetails/ExperimentDetailsHeader.tsx
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentDetailsHeader.tsx
@@ -13,7 +13,7 @@ import {
   deletableRunStates,
   pausableRunStates,
   stateToLabel,
-  terminalRunStates
+  terminalRunStates,
 } from 'constants/states';
 import handleError, { ErrorLevel, ErrorType } from 'ErrorHandler';
 import useExperimentTags from 'hooks/useExperimentTags';

--- a/webui/react/src/pages/ExperimentDetails/ExperimentDetailsHeader.tsx
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentDetailsHeader.tsx
@@ -9,7 +9,12 @@ import Spinner from 'components/Spinner';
 import TagList from 'components/TagList';
 import TimeAgo from 'components/TimeAgo';
 import TimeDuration from 'components/TimeDuration';
-import { deletableRunStates, pausableRunStates, terminalRunStates } from 'constants/states';
+import {
+  deletableRunStates,
+  pausableRunStates,
+  stateToLabel,
+  terminalRunStates
+} from 'constants/states';
 import handleError, { ErrorLevel, ErrorType } from 'ErrorHandler';
 import useExperimentTags from 'hooks/useExperimentTags';
 import useModalExperimentCreate, {
@@ -339,7 +344,7 @@ const ExperimentDetailsHeader: React.FC<Props> = ({
                       onClick={handleStopClick}
                     />
                   )}
-                  <span className={css.state}>{experiment.state}</span>
+                  <span className={css.state}>{stateToLabel(experiment.state)}</span>
                 </div>
               </Spinner>
               <div className={css.experimentId}>Experiment {experiment.id}</div>


### PR DESCRIPTION
## Description

Raw values I believe came from JobState (STATE_QUEUED, STATE_SCHEDULED, and STOPPING_CANCELED) were displayed on the experiment details header, instead of human format (Queued, Scheduled, Canceling). This patch uses the unified `stateToLabel` to guarantee whatever relevant state object is coming through, it's decoded for human user.

## Checklist

- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.