### PR TITLE
ci: unflake master `IdleTimeoutWatcher` test.

### DIFF
--- a/master/internal/task/idle_timeout_test.go
+++ b/master/internal/task/idle_timeout_test.go
@@ -48,7 +48,17 @@ func TestIdleTimeoutWatcher(t *testing.T) {
 
 	system.Ask(mActor, actor.Ping{}).Get()
 	assert.Equal(t, actionDone, false)
-	time.Sleep(2 * tickInterval)
-	system.Ask(mActor, actor.Ping{}).Get()
+
+	// Go scheduling may sometimes be late to schedule the `IdleTimeoutWatcherTick`.
+	// The earliest it'd run is after `tickInterval`.
+	// To make the check more reliable, we wait between 2 and 10 `tickIntervals`.
+	for i := 0; i < 5; i++ {
+		time.Sleep(2 * tickInterval)
+		system.Ask(mActor, actor.Ping{}).Get()
+		if actionDone == true {
+			break
+		}
+	}
+
 	assert.Equal(t, actionDone, true)
 }


### PR DESCRIPTION
## Description

`IdleTimeoutWatcher` test has been a bit flaky recently. It boils down to Go being late to schedule and execute the `NotifyAfter` message. In my anecdotal tests on a test machine, it was up to 0.4ms late. I suspect on a busy shared circleci environment it ends up being worse (>1ms), which causes the test to fail. 
Let's try to wait a bit longer, opportunistically breaking early if all is well.

## Test Plan

N/A but CI should get greener.

## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
