### PR TITLE
feat: add systemd socket activation support to the master

### DIFF
--- a/agent/go.mod
+++ b/agent/go.mod
@@ -88,6 +88,7 @@ require (
 	github.com/cenkalti/backoff v2.2.1+incompatible // indirect
 	github.com/cespare/xxhash/v2 v2.1.1 // indirect
 	github.com/containerd/containerd v1.5.8 // indirect
+	github.com/coreos/go-systemd v0.0.0-20190719114852-fd7a80b32e1f // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.1 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/denis-tingajkin/go-header v0.3.1 // indirect

--- a/agent/go.sum
+++ b/agent/go.sum
@@ -430,6 +430,7 @@ github.com/coreos/go-semver v0.3.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3Ee
 github.com/coreos/go-systemd v0.0.0-20161114122254-48702e0da86b/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/go-systemd v0.0.0-20180511133405-39ca1b05acc7/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
+github.com/coreos/go-systemd v0.0.0-20190719114852-fd7a80b32e1f h1:JOrtw2xFKzlg+cbHpyrpLDmnN1HqhBfnX7WDiW7eG2c=
 github.com/coreos/go-systemd v0.0.0-20190719114852-fd7a80b32e1f/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/go-systemd/v22 v22.0.0/go.mod h1:xO0FLkIi5MaZafQlIrOotqXZ90ih+1atmu1JpKERPPk=
 github.com/coreos/go-systemd/v22 v22.1.0/go.mod h1:xO0FLkIi5MaZafQlIrOotqXZ90ih+1atmu1JpKERPPk=

--- a/docs/release-notes/socket-activation.txt
+++ b/docs/release-notes/socket-activation.txt
@@ -1,0 +1,7 @@
+:orphan:
+
+**New Features**
+
+-  Add support for `systemd socket activation
+   <https://0pointer.de/blog/projects/socket-activation.html>`__ to the master. See :ref:`the
+   documentation <socket-activation>` for more information.

--- a/docs/sysadmin-deploy-on-prem/linux-packages.txt
+++ b/docs/sysadmin-deploy-on-prem/linux-packages.txt
@@ -194,6 +194,50 @@ Master and Agent
    the right-hand side of the top navigation bar, and if you select the ``Cluster`` view in the
    left-hand navigation panel.
 
+.. _socket-activation:
+
+Socket Activation
+=================
+
+The master can be configured to use `systemd socket activation
+<https://0pointer.de/blog/projects/socket-activation.html>`__, allowing it to be started
+automatically on demand (i.e., when a client makes a network connection to the port) and restarted
+with reduced loss of connection state. To switch to socket activation, run the following commands:
+
+.. code::
+
+   sudo systemctl disable --now determined-master
+   sudo systemctl enable --now determined-master.socket
+
+When socket activation is in use, the port on which the master listens is configured differently;
+the port listed in the master config file is not used, since systemd manages the listening socket.
+Instead, run
+
+.. code::
+
+   sudo systemctl edit determined-master.socket
+
+which will open a text editor window. To change the listening port, insert the following text (with
+the port number substituted appropriately) into the editor and then exit the editor:
+
+.. code::
+
+   [Socket]
+   ListenStream=
+   ListenStream=0.0.0.0:<port>
+
+After updating the configuration, run the following commands to put the change into effect (this
+will restart the master):
+
+.. code::
+
+   sudo systemctl stop determined-master
+   sudo systemctl restart determined-master.socket
+
+See the systemd documentation on `socket unit files
+<https://www.freedesktop.org/software/systemd/man/systemd.socket.html>`__ or `systemctl
+<https://www.freedesktop.org/software/systemd/man/systemctl.html>`__ for more information.
+
 **********************
  Managing the Cluster
 **********************

--- a/master/.goreleaser.yml
+++ b/master/.goreleaser.yml
@@ -51,6 +51,8 @@ nfpms:
         dst: "/usr/share/determined/master/static"
       - src: "packaging/determined-master.service"
         dst: "/lib/systemd/system/determined-master.service"
+      - src: "packaging/determined-master.socket"
+        dst: "/lib/systemd/system/determined-master.socket"
 
       - src: "packaging/LICENSE"
         dst: "/usr/share/doc/determined-master/copyright"

--- a/master/go.mod
+++ b/master/go.mod
@@ -71,6 +71,8 @@ require (
 	k8s.io/client-go v0.20.14
 )
 
+require github.com/coreos/go-systemd v0.0.0-20190719114852-fd7a80b32e1f
+
 require (
 	cloud.google.com/go/kms v0.1.0 // indirect
 	cloud.google.com/go/storage v1.16.1 // indirect

--- a/master/go.sum
+++ b/master/go.sum
@@ -304,6 +304,7 @@ github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3Ee
 github.com/coreos/go-semver v0.3.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
 github.com/coreos/go-systemd v0.0.0-20180511133405-39ca1b05acc7/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
+github.com/coreos/go-systemd v0.0.0-20190719114852-fd7a80b32e1f h1:JOrtw2xFKzlg+cbHpyrpLDmnN1HqhBfnX7WDiW7eG2c=
 github.com/coreos/go-systemd v0.0.0-20190719114852-fd7a80b32e1f/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/go-systemd/v22 v22.3.2/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/coreos/pkg v0.0.0-20160727233714-3ac0863d7acf/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=

--- a/master/packaging/determined-master.socket
+++ b/master/packaging/determined-master.socket
@@ -1,0 +1,5 @@
+[Socket]
+ListenStream=0.0.0.0:8080
+
+[Install]
+WantedBy=sockets.target


### PR DESCRIPTION
## Description

This change allows the master to be run using systemd's socket
activation feature. It simply changes the creation of the base socket
listener to check for one provided by systemd or fall back to a manually
created listener; everything else built on that stays the same.

We also ship a new socket unit file so that users can switch to socket
activation easily with a few `systemctl` invocations.

## Test Plan

- [x] spin up a VM and go through installing from the package and trying out the various documented `systemctl` commands
