### PR TITLE
fix: default shell/cmd slots should be 1.

### DIFF
--- a/master/internal/api_command.go
+++ b/master/internal/api_command.go
@@ -96,6 +96,10 @@ func (a *apiServer) getCommandLaunchParams(ctx context.Context, req *protoComman
 
 	// Get the full configuration.
 	config := model.DefaultConfig(&taskSpec.TaskContainerDefaults)
+	// Copy discovered (default) resource pool name and slot count.
+	config.Resources.ResourcePool = poolName
+	config.Resources.Slots = resources.Slots
+
 	workDirInDefaults := config.WorkDir
 	if req.TemplateName != "" {
 		template, err := a.m.db.TemplateByName(req.TemplateName)
@@ -118,7 +122,6 @@ func (a *apiServer) getCommandLaunchParams(ctx context.Context, req *protoComman
 					"unable to decode the merged config: %s", string(configBytes)).Error())
 		}
 	}
-	config.Resources.ResourcePool = poolName
 	if req.MustZeroSlot {
 		config.Resources.Slots = 0
 	}


### PR DESCRIPTION
## Description

Fixing a regression in #3362 
Removal of this line: https://github.com/determined-ai/determined/pull/3362/files#diff-abb761c42fd4f61b025150aed52216a0a00a28c27958b5abd28f9278bc7e0e79L12
caused the shells & cmds to default to running on *compute pool* with 0 slots.
- that was not intended change
- it cannot be scheduled in some setups, causing a CI failure in `test_start_and_write_to_shell`.

## Test Plan

Run a shell or cmd and ensure that:
- by default, it runs on 1 slot in compute pool
- `--config resources.slots=0` will cause it to run in 0 slots in aux pool

This should also fix `test_start_and_write_to_shell`

## Commentary (optional)

## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
