### PR TITLE
ci: stop testing EOL python

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,9 +10,6 @@ orbs:
   queue: eddiewebb/queue@volatile
 
 executors:
-  python-36:
-    docker:
-      - image: python:3.6-slim-buster
   python-37:
     docker:
       - image: python:3.7-slim-buster
@@ -1886,7 +1883,6 @@ workflows:
             parameters:
               executor-name:
                 [
-                  "python-36",
                   "python-37",
                   "python-38",
                   "python-39",

--- a/docs/release-notes/3377-rm36.txt
+++ b/docs/release-notes/3377-rm36.txt
@@ -1,0 +1,5 @@
+:orphan:
+
+**Removed Features**
+
+-  No longer support Python 3.6, which has reached end-of-life.


### PR DESCRIPTION
Python 3.6 became EOL on 23 Dec 2021:

    www.python.org/dev/peps/pep-0494/#lifespan

The Python 3.6 CLI test started failing because psutil no longer ships
wheels for Python 3.6 for the latest post-3.6-eof version, which means
our CI would need gcc to build that package.  Instead, just delete the
test.