### PR TITLE
chore: make the workload compatible with the last incomplete training batch

### DIFF
--- a/harness/determined/layers/_workload_sequencer.py
+++ b/harness/determined/layers/_workload_sequencer.py
@@ -151,12 +151,20 @@ class WorkloadSequencer(workload.Source):
             return batches
         if records is not None:
             check.gt(self.global_batch_size, 0, "global_batch_size must be positive")
-            return max(records // self.global_batch_size, 1)
+            # todo: make this compatible for determined.pytorch.DataLoader with drop_last=True (the last imcomplete batch)
+            # usually we set the drop_last to False, but some user would define it to True
+            # that meas we should pass this parameter setting to this class
+            # we're finding a more elegent way to implement it
+            return max(math.ceil(records // self.global_batch_size), 1)
         if epochs is not None:
             check.is_instance(self.records_per_epoch, int, "length must be an integer")
             assert self.records_per_epoch is not None
             check.gt(self.global_batch_size, 0, "global_batch_size must be positive")
-            return max((epochs * self.records_per_epoch) // self.global_batch_size, 1)
+            # todo: make this compatible for determined.pytorch.DataLoader with drop_last=True (the last imcomplete batch)
+            # usually we set the drop_last to False, but some user would define it to True
+            # that meas we should pass this parameter setting to this class
+            # we're finding a more elegent way to implement it
+            return max(epochs * math.ceil(self.records_per_epoch // self.global_batch_size) , 1)
         # Make mypy happy.
         raise ValueError("invalid length")
 


### PR DESCRIPTION
Make the workload more compatible with the last incomplete training batch.

## Description

For instance, given a training dataloader with 795 samples whose global batch size is set to 8, the num of the last incomplete batch is 3.
If we set `min_validation_period: epochs: 10`, the workload would validate at the `(epochs * self.records_per_epoch) // self.global_batch_size=(10*795)//8=993`-th batch before patching which is not the end of a training epoch.
After patching, it would validate at the end of the training epoch.

However, this change is not suitable for `drop_last=True`, and maybe there is a more elegant way to pass `drop_last` into this class.

<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At a minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions about this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ