### PR TITLE
fix: set gc-policy broken [DET-6373]

### DIFF
--- a/harness/determined/cli/experiment.py
+++ b/harness/determined/cli/experiment.py
@@ -593,7 +593,7 @@ def set_gc_policy(args: Namespace) -> None:
                 c["uuid"],
                 render.format_resources(c["resources"]),
             ]
-            for c in sorted(checkpoints, key=lambda c: (c["trial_id"], c["step_id"]))
+            for c in sorted(checkpoints, key=lambda c: (c["trial_id"], c["step"]["id"]))
             if "step" in c and c["step"].get("validation") is not None
         ]
 

--- a/harness/determined/cli/experiment.py
+++ b/harness/determined/cli/experiment.py
@@ -593,7 +593,7 @@ def set_gc_policy(args: Namespace) -> None:
                 c["uuid"],
                 render.format_resources(c["resources"]),
             ]
-            for c in sorted(checkpoints, key=lambda c: (c["trial_id"], c["step"]["id"]))
+            for c in sorted(checkpoints, key=lambda c: (c["trial_id"], c["end_time"]))
             if "step" in c and c["step"].get("validation") is not None
         ]
 


### PR DESCRIPTION
To test fix:

1. Run an experiment which creates a checkpoint.
2. Run the following command:
det experiment set gc-policy \
  --save-experiment-best 0 \
  --save-trial-best 0 \
  --save-trial-latest 0 <exp_id>

^ this should not error and remove all the checkpoints.

Tested manually.