### PR TITLE
chore: reuse experiment patch logic

### DIFF
--- a/master/internal/api_experiment.go
+++ b/master/internal/api_experiment.go
@@ -11,8 +11,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/determined-ai/determined/master/internal/prom"
-
 	"github.com/google/uuid"
 	"github.com/sirupsen/logrus"
 
@@ -563,76 +561,44 @@ func (a *apiServer) UnarchiveExperiment(
 func (a *apiServer) PatchExperiment(
 	ctx context.Context, req *apiv1.PatchExperimentRequest,
 ) (*apiv1.PatchExperimentResponse, error) {
-	var exp experimentv1.Experiment
-	switch err := a.m.db.QueryProto("get_experiment", &exp, req.Experiment.Id); {
-	case err == db.ErrNotFound:
-		return nil, status.Errorf(codes.NotFound, "experiment not found: %d", req.Experiment.Id)
-	case err != nil:
-		return nil, errors.Wrapf(err, "error fetching experiment from database: %d", req.Experiment.Id)
-	}
-
 	paths := req.UpdateMask.GetPaths()
-	shouldUpdateNotes := false
-	shouldUpdateConfig := false
+	patch := ExperimentPatch{}
 	for _, path := range paths {
 		switch {
 		case path == "name":
 			if len(strings.TrimSpace(req.Experiment.Name)) == 0 {
 				return nil, status.Errorf(codes.InvalidArgument, "`name` is required.")
 			}
-			exp.Name = req.Experiment.Name
+			patch.Name = &req.Experiment.Name
 		case path == "notes":
-			shouldUpdateNotes = true
-			exp.Notes = req.Experiment.Notes
+			patch.Notes = &req.Experiment.Notes
 		case path == "labels":
-			exp.Labels = req.Experiment.Labels
-			prom.AssociateExperimentIDLabels(strconv.Itoa(int(req.Experiment.Id)),
-				req.Experiment.Labels)
+			// TODO convert labels
+			// exp.Labels = req.Experiment.Labels
+			// prom.AssociateExperimentIDLabels(strconv.Itoa(int(req.Experiment.Id)),
+			// 	req.Experiment.Labels)
 		case path == "description":
-			exp.Description = req.Experiment.Description
+			patch.Description = &req.Experiment.Description
 		case !strings.HasPrefix(path, "update_mask"):
 			return nil, status.Errorf(
 				codes.InvalidArgument,
 				"only 'name', 'notes', 'description', and 'labels' fields are mutable. cannot update %s", path)
 		}
 	}
-	shouldUpdateConfig = (shouldUpdateNotes && len(paths) > 1) ||
-		(!shouldUpdateNotes && len(paths) > 0)
-
-	if shouldUpdateNotes {
-		_, err := a.m.db.RawQuery(
-			"patch_experiment_notes",
-			req.Experiment.Id,
-			req.Experiment.Notes,
-		)
-		if err != nil {
-			return nil, status.Errorf(codes.Internal, "failed to update experiment")
-		}
+	dbExp, err := a.m.db.ExperimentByID(int(req.Experiment.Id))
+	if err != nil {
+		return nil, errors.Wrapf(err, "loading experiment %v", req.Experiment.Id)
+	}
+	if err = a.m.patchExperiment(dbExp, &patch); err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to update experiment")
 	}
 
-	if shouldUpdateConfig {
-		type experimentPatch struct {
-			Labels      []string `json:"labels"`
-			Description string   `json:"description"`
-			Name        string   `json:"name"`
-		}
-		patches := experimentPatch{
-			Labels:      exp.Labels,
-			Description: exp.Description,
-			Name:        exp.Name,
-		}
-		marshalledPatches, err := json.Marshal(patches)
-		if err != nil {
-			return nil, status.Errorf(codes.Internal, "failed to marshal experiment patch")
-		}
-		_, err = a.m.db.RawQuery(
-			"patch_experiment_config",
-			req.Experiment.Id,
-			marshalledPatches,
-		)
-		if err != nil {
-			return nil, status.Errorf(codes.Internal, "failed to update experiment")
-		}
+	var exp experimentv1.Experiment
+	switch err := a.m.db.QueryProto("get_experiment", &exp, req.Experiment.Id); {
+	case err == db.ErrNotFound:
+		return nil, status.Errorf(codes.NotFound, "experiment not found: %d", req.Experiment.Id)
+	case err != nil:
+		return nil, errors.Wrapf(err, "error fetching experiment from database: %d", req.Experiment.Id)
 	}
 
 	return &apiv1.PatchExperimentResponse{Experiment: &exp}, nil

--- a/master/internal/api_experiment.go
+++ b/master/internal/api_experiment.go
@@ -11,6 +11,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/determined-ai/determined/master/internal/prom"
+
 	"github.com/google/uuid"
 	"github.com/sirupsen/logrus"
 
@@ -561,42 +563,76 @@ func (a *apiServer) UnarchiveExperiment(
 func (a *apiServer) PatchExperiment(
 	ctx context.Context, req *apiv1.PatchExperimentRequest,
 ) (*apiv1.PatchExperimentResponse, error) {
-	paths := req.UpdateMask.GetPaths()
-	expPatch := ExperimentPatch{}
-	configPatch := ExperimentConfigPatch{}
-	expID := int(req.Experiment.Id)
-	for _, path := range paths {
-		switch {
-		case path == "notes":
-			expPatch.Notes = &req.Experiment.Notes
-		case path == "name":
-			if len(strings.TrimSpace(req.Experiment.Name)) == 0 {
-				return nil, status.Errorf(codes.InvalidArgument, "`name` is required.")
-			}
-			configPatch.Name = &req.Experiment.Name
-		case path == "labels":
-			// TODO convert labels
-			// exp.Labels = req.Experiment.Labels
-			// prom.AssociateExperimentIDLabels(strconv.Itoa(int(req.Experiment.Id)),
-			// 	req.Experiment.Labels)
-		case path == "description":
-			configPatch.Description = &req.Experiment.Description
-		case !strings.HasPrefix(path, "update_mask"):
-			return nil, status.Errorf(
-				codes.InvalidArgument,
-				"only 'name', 'notes', 'description', and 'labels' fields are mutable. cannot update %s", path)
-		}
-	}
-	if err := a.m.patchExperiment(expID, &expPatch, &configPatch); err != nil {
-		return nil, status.Errorf(codes.Internal, "failed to update experiment")
-	}
-
 	var exp experimentv1.Experiment
 	switch err := a.m.db.QueryProto("get_experiment", &exp, req.Experiment.Id); {
 	case err == db.ErrNotFound:
 		return nil, status.Errorf(codes.NotFound, "experiment not found: %d", req.Experiment.Id)
 	case err != nil:
 		return nil, errors.Wrapf(err, "error fetching experiment from database: %d", req.Experiment.Id)
+	}
+
+	paths := req.UpdateMask.GetPaths()
+	shouldUpdateNotes := false
+	shouldUpdateConfig := false
+	for _, path := range paths {
+		switch {
+		case path == "name":
+			if len(strings.TrimSpace(req.Experiment.Name)) == 0 {
+				return nil, status.Errorf(codes.InvalidArgument, "`name` is required.")
+			}
+			exp.Name = req.Experiment.Name
+		case path == "notes":
+			shouldUpdateNotes = true
+			exp.Notes = req.Experiment.Notes
+		case path == "labels":
+			exp.Labels = req.Experiment.Labels
+			prom.AssociateExperimentIDLabels(strconv.Itoa(int(req.Experiment.Id)),
+				req.Experiment.Labels)
+		case path == "description":
+			exp.Description = req.Experiment.Description
+		case !strings.HasPrefix(path, "update_mask"):
+			return nil, status.Errorf(
+				codes.InvalidArgument,
+				"only 'name', 'notes', 'description', and 'labels' fields are mutable. cannot update %s", path)
+		}
+	}
+	shouldUpdateConfig = (shouldUpdateNotes && len(paths) > 1) ||
+		(!shouldUpdateNotes && len(paths) > 0)
+
+	if shouldUpdateNotes {
+		_, err := a.m.db.RawQuery(
+			"patch_experiment_notes",
+			req.Experiment.Id,
+			req.Experiment.Notes,
+		)
+		if err != nil {
+			return nil, status.Errorf(codes.Internal, "failed to update experiment")
+		}
+	}
+
+	if shouldUpdateConfig {
+		type experimentPatch struct {
+			Labels      []string `json:"labels"`
+			Description string   `json:"description"`
+			Name        string   `json:"name"`
+		}
+		patches := experimentPatch{
+			Labels:      exp.Labels,
+			Description: exp.Description,
+			Name:        exp.Name,
+		}
+		marshalledPatches, err := json.Marshal(patches)
+		if err != nil {
+			return nil, status.Errorf(codes.Internal, "failed to marshal experiment patch")
+		}
+		_, err = a.m.db.RawQuery(
+			"patch_experiment_config",
+			req.Experiment.Id,
+			marshalledPatches,
+		)
+		if err != nil {
+			return nil, status.Errorf(codes.Internal, "failed to update experiment")
+		}
 	}
 
 	return &apiv1.PatchExperimentResponse{Experiment: &exp}, nil

--- a/master/internal/api_experiment.go
+++ b/master/internal/api_experiment.go
@@ -563,6 +563,7 @@ func (a *apiServer) PatchExperiment(
 ) (*apiv1.PatchExperimentResponse, error) {
 	paths := req.UpdateMask.GetPaths()
 	patch := ExperimentPatch{}
+	expID := int(req.Experiment.Id)
 	for _, path := range paths {
 		switch {
 		case path == "name":
@@ -585,11 +586,7 @@ func (a *apiServer) PatchExperiment(
 				"only 'name', 'notes', 'description', and 'labels' fields are mutable. cannot update %s", path)
 		}
 	}
-	dbExp, err := a.m.db.ExperimentByID(int(req.Experiment.Id))
-	if err != nil {
-		return nil, errors.Wrapf(err, "loading experiment %v", req.Experiment.Id)
-	}
-	if err = a.m.patchExperiment(dbExp, &patch); err != nil {
+	if err := a.m.patchExperiment(expID, &patch); err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to update experiment")
 	}
 

--- a/master/internal/core.go
+++ b/master/internal/core.go
@@ -830,7 +830,7 @@ func (m *Master) Run(ctx context.Context) error {
 	experimentsGroup.GET("/:experiment_id/preview_gc", api.Route(m.getExperimentCheckpointsToGC))
 	experimentsGroup.GET("/:experiment_id/summary", api.Route(m.getExperimentSummary))
 	experimentsGroup.GET("/:experiment_id/metrics/summary", api.Route(m.getExperimentSummaryMetrics))
-	experimentsGroup.PATCH("/:experiment_id", api.Route(m.patchExperiment))
+	experimentsGroup.PATCH("/:experiment_id", api.Route(m.patchExperimentHandler))
 	experimentsGroup.POST("", api.Route(m.postExperiment))
 	experimentsGroup.POST("/:experiment_id/kill", api.Route(m.postExperimentKill))
 

--- a/master/internal/core_experiment.go
+++ b/master/internal/core_experiment.go
@@ -391,9 +391,6 @@ func (m *Master) patchExperimentHandler(c echo.Context) (interface{}, error) {
 	if err := api.BindArgs(&args, c); err != nil {
 		return nil, err
 	}
-	// `patch` represents the allowed mutations that can be performed on an experiment, in JSON
-	// Merge Patch (RFC 7386) format.
-	// TODO: check for extraneous fields.
 	expPatch := ExperimentPatch{}
 	if err := api.BindPatch(&expPatch, c); err != nil {
 		return nil, err

--- a/master/internal/core_experiment.go
+++ b/master/internal/core_experiment.go
@@ -251,7 +251,12 @@ type ExperimentPatch struct {
 	Notes    *string `json:"notes"`
 }
 
-func (m *Master) patchExperiment(dbExp *model.Experiment, patch *ExperimentPatch) error {
+func (m *Master) patchExperiment(expID int, patch *ExperimentPatch) error {
+	dbExp, err := m.db.ExperimentByID(expID)
+	if err != nil {
+		return errors.Wrapf(err, "loading experiment %v", expID)
+	}
+
 	agentUserGroup, err := m.db.AgentUserGroup(*dbExp.OwnerID)
 	if err != nil {
 		return errors.Errorf("cannot find user and group for experiment %v", dbExp.OwnerID)
@@ -390,12 +395,7 @@ func (m *Master) patchExperimentHandler(c echo.Context) (interface{}, error) {
 		return nil, err
 	}
 
-	dbExp, err := m.db.ExperimentByID(args.ExperimentID)
-	if err != nil {
-		return nil, errors.Wrapf(err, "loading experiment %v", args.ExperimentID)
-	}
-
-	return nil, m.patchExperiment(dbExp, &patch)
+	return nil, m.patchExperiment(args.ExperimentID, &patch)
 }
 
 // CreateExperimentParams defines a request to create an experiment.

--- a/master/internal/core_experiment.go
+++ b/master/internal/core_experiment.go
@@ -234,6 +234,7 @@ type ExperimentPatch struct {
 	// than the top-level items, we should reorganize this into ExperimentPatch and
 	// ExperimentConfigPatch.
 	Description *string `json:"description"`
+	Name        *string `json:"name"`
 	// Labels set to nil are deleted.
 	Labels    map[string]*bool `json:"labels"`
 	Resources *struct {
@@ -280,6 +281,9 @@ func (m *Master) patchExperiment(dbExp *model.Experiment, patch *ExperimentPatch
 	}
 	if patch.Description != nil {
 		dbExp.Config.SetDescription(patch.Description)
+	}
+	if patch.Name != nil {
+		dbExp.Config.SetName(expconf.Name{RawString: patch.Name})
 	}
 	labels := dbExp.Config.Labels()
 	for label, keep := range patch.Labels {


### PR DESCRIPTION
## Description

- add patch note and name support to old experiment patch endpoint

<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At a minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions about this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

building block for #3390 

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ