### PR TITLE
chore: bumpenvs for updated base AMIs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,11 +111,11 @@ commands:
       - when:
           condition: <<parameters.tf1>>
           steps:
-            - run: docker pull determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-4537b95
+            - run: docker pull determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-eb6c7d1
       - when:
           condition: <<parameters.tf2>>
           steps:
-            - run: docker pull determinedai/environments:py-3.8-pytorch-1.9-lightning-1.3-tf-2.4-cpu-4537b95
+            - run: docker pull determinedai/environments:py-3.8-pytorch-1.9-lightning-1.3-tf-2.4-cpu-eb6c7d1
 
   login-docker:
     parameters:

--- a/e2e_tests/tests/config.py
+++ b/e2e_tests/tests/config.py
@@ -13,13 +13,13 @@ MAX_TASK_SCHEDULED_SECS = 30
 MAX_TRIAL_BUILD_SECS = 90
 
 
-DEFAULT_TF1_CPU_IMAGE = "determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-4537b95"
+DEFAULT_TF1_CPU_IMAGE = "determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-eb6c7d1"
 DEFAULT_TF2_CPU_IMAGE = (
-    "determinedai/environments:py-3.8-pytorch-1.9-lightning-1.3-tf-2.4-cpu-4537b95"
+    "determinedai/environments:py-3.8-pytorch-1.9-lightning-1.3-tf-2.4-cpu-eb6c7d1"
 )
-DEFAULT_TF1_GPU_IMAGE = "determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-4537b95"
+DEFAULT_TF1_GPU_IMAGE = "determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-eb6c7d1"
 DEFAULT_TF2_GPU_IMAGE = (
-    "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-4537b95"
+    "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-eb6c7d1"
 )
 
 TF1_CPU_IMAGE = os.environ.get("TF1_CPU_IMAGE") or DEFAULT_TF1_CPU_IMAGE

--- a/examples/computer_vision/unets_tf_keras/const.yaml
+++ b/examples/computer_vision/unets_tf_keras/const.yaml
@@ -22,4 +22,4 @@ min_validation_period:
 entrypoint: model_def:UNetsTrial
 scheduling_unit: 57
 environment:
-    image: determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-4537b95
+    image: determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-eb6c7d1

--- a/examples/computer_vision/unets_tf_keras/distributed.yaml
+++ b/examples/computer_vision/unets_tf_keras/distributed.yaml
@@ -25,4 +25,4 @@ min_validation_period:
 scheduling_unit: 8
 entrypoint: model_def:UNetsTrial
 environment:
-    image: determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-4537b95
+    image: determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-eb6c7d1

--- a/harness/determined/common/schemas/expconf/_v0.py
+++ b/harness/determined/common/schemas/expconf/_v0.py
@@ -250,14 +250,14 @@ class EnvironmentImageV0(schemas.SchemaBase):
     def runtime_defaults(self) -> None:
         if self.cpu is None:
             self.cpu = (
-                "determinedai/environments:py-3.8-pytorch-1.9-lightning-1.3-tf-2.4-cpu-4537b95"
+                "determinedai/environments:py-3.8-pytorch-1.9-lightning-1.3-tf-2.4-cpu-eb6c7d1"
             )
         if self.rocm is None:
-            self.rocm = "determinedai/environments:rocm-4.2-pytorch-1.9-tf-2.5-rocm-4537b95"
+            self.rocm = "determinedai/environments:rocm-4.2-pytorch-1.9-tf-2.5-rocm-eb6c7d1"
 
         if self.cuda is None:
             self.cuda = (
-                "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-4537b95"
+                "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-eb6c7d1"
             )
 
 

--- a/harness/determined/deploy/aws/templates/efs.yaml
+++ b/harness/determined/deploy/aws/templates/efs.yaml
@@ -3,36 +3,36 @@ Description:  This template deploys a VPC, with a public and private subnet. It 
 Mappings:
   RegionMap:
     ap-northeast-1:
-      Master: ami-036d0684fc96830ca
-      Agent: ami-07be463fe74180d9c
+      Master: ami-0e07ebe171b2a7d79
+      Agent: ami-0d569357ef1359516
     # TODO(DET-4258) Uncomment these when we fully support all P3 regions.
     # ap-northeast-2:
-    #   Master: ami-0f8b8babb98cc66d0
-    #   Agent: ami-0bc9dc1a714ff6d82
+    #   Master: ami-0e9dbc02ff361d8fa
+    #   Agent: ami-048bd76a36e4d9e31
     # ap-southeast-1:
-    #   Master: ami-0fed77069cd5a6d6c
-    #   Agent: ami-0e95df3b2b20d245c
+    #   Master: ami-064ec47318a869dda
+    #   Agent: ami-0d94716e9128a94ba
     # ap-southeast-2:
-    #   Master: ami-0bf8b986de7e3c7ce
-    #   Agent: ami-054bc72b30aac5c40
+    #   Master: ami-0a00eef8760c6eddc
+    #   Agent: ami-04d0c9be63328caa3
     eu-central-1:
-      Master: ami-0a49b025fffbbdac6
-      Agent: ami-04f8cd92c6e00a1f8
+      Master: ami-05e155ca52886ffe4
+      Agent: ami-0ed13c0e25a6cb093
     eu-west-1:
-      Master: ami-08edbb0e85d6a0a07
-      Agent: ami-037c51c9b79d49a02
+      Master: ami-04db604073d3d5ce2
+      Agent: ami-000f5dffffa5fe445
     # eu-west-2:
-    #   Master: ami-0fdf70ed5c34c5f52
-    #   Agent: ami-0b159faec2954f54a
+    #   Master: ami-0ac10f53765369588
+    #   Agent: ami-0102b379095b896b6
     us-east-1:
-      Master: ami-083654bd07b5da81d
-      Agent: ami-0fb9574129921911f
+      Master: ami-06992628e0a8e044c
+      Agent: ami-0546c2d738dbe2f71
     us-east-2:
-      Master: ami-0629230e074c580f2
-      Agent: ami-0eb5a8cd6ebc8f40f
+      Master: ami-02bd262766f4f24c2
+      Agent: ami-046bcbad8e4b4f90f
     us-west-2:
-      Master: ami-036d46416a34a611c
-      Agent: ami-02d50e97a6fff984c
+      Master: ami-0ac79214f93af0a57
+      Agent: ami-0777ff1478fff7dd8
 
 Parameters:
   VpcCIDR:

--- a/harness/determined/deploy/aws/templates/fsx.yaml
+++ b/harness/determined/deploy/aws/templates/fsx.yaml
@@ -2,36 +2,36 @@ Description:  This template deploys a VPC, with a public and private subnet, and
 Mappings:
   RegionMap:
     ap-northeast-1:
-      Master: ami-036d0684fc96830ca
-      Agent: ami-07be463fe74180d9c
+      Master: ami-0e07ebe171b2a7d79
+      Agent: ami-0d569357ef1359516
     # TODO(DET-4258) Uncomment these when we fully support all P3 regions.
     # ap-northeast-2:
-    #   Master: ami-0f8b8babb98cc66d0
-    #   Agent: ami-0bc9dc1a714ff6d82
+    #   Master: ami-0e9dbc02ff361d8fa
+    #   Agent: ami-048bd76a36e4d9e31
     # ap-southeast-1:
-    #   Master: ami-0fed77069cd5a6d6c
-    #   Agent: ami-0e95df3b2b20d245c
+    #   Master: ami-064ec47318a869dda
+    #   Agent: ami-0d94716e9128a94ba
     # ap-southeast-2:
-    #   Master: ami-0bf8b986de7e3c7ce
-    #   Agent: ami-054bc72b30aac5c40
+    #   Master: ami-0a00eef8760c6eddc
+    #   Agent: ami-04d0c9be63328caa3
     eu-central-1:
-      Master: ami-0a49b025fffbbdac6
-      Agent: ami-04f8cd92c6e00a1f8
+      Master: ami-05e155ca52886ffe4
+      Agent: ami-0ed13c0e25a6cb093
     eu-west-1:
-      Master: ami-08edbb0e85d6a0a07
-      Agent: ami-037c51c9b79d49a02
+      Master: ami-04db604073d3d5ce2
+      Agent: ami-000f5dffffa5fe445
     # eu-west-2:
-    #   Master: ami-0fdf70ed5c34c5f52
-    #   Agent: ami-0b159faec2954f54a
+    #   Master: ami-0ac10f53765369588
+    #   Agent: ami-0102b379095b896b6
     us-east-1:
-      Master: ami-083654bd07b5da81d
-      Agent: ami-0fb9574129921911f
+      Master: ami-06992628e0a8e044c
+      Agent: ami-0546c2d738dbe2f71
     us-east-2:
-      Master: ami-0629230e074c580f2
-      Agent: ami-0eb5a8cd6ebc8f40f
+      Master: ami-02bd262766f4f24c2
+      Agent: ami-046bcbad8e4b4f90f
     us-west-2:
-      Master: ami-036d46416a34a611c
-      Agent: ami-02d50e97a6fff984c
+      Master: ami-0ac79214f93af0a57
+      Agent: ami-0777ff1478fff7dd8
 
 Parameters:
   VpcCIDR:

--- a/harness/determined/deploy/aws/templates/govcloud.yaml
+++ b/harness/determined/deploy/aws/templates/govcloud.yaml
@@ -4,10 +4,10 @@ Description: Determined Template
 Mappings:
   RegionMap:
     us-gov-east-1:
-      Master: ami-05c154cec85baeb50
+      Master: ami-03958388786db1513
       Agent: ami-0b71e56244b8ac1cb
     us-gov-west-1:
-      Master: ami-05776a65d52ff7a9b
+      Master: ami-066189aeb91baa0ab
       Agent: ami-0d26002529bfac823
 Parameters:
   Keypair:

--- a/harness/determined/deploy/aws/templates/secure.yaml
+++ b/harness/determined/deploy/aws/templates/secure.yaml
@@ -3,46 +3,46 @@ Description:  This template deploys a VPC, with a public and private subnet. It 
 Mappings:
   RegionMap:
     ap-northeast-1:
-      Master: ami-036d0684fc96830ca
-      Agent: ami-07be463fe74180d9c
-      Bastion: ami-036d0684fc96830ca
+      Master: ami-0e07ebe171b2a7d79
+      Agent: ami-0d569357ef1359516
+      Bastion: ami-0e07ebe171b2a7d79
     # TODO(DET-4258) Uncomment these when we fully support all P3 regions.
     # ap-northeast-2:
-    #   Master: ami-0f8b8babb98cc66d0
-    #   Agent: ami-0bc9dc1a714ff6d82
-    #   Bastion: ami-0f8b8babb98cc66d0
+    #   Master: ami-0e9dbc02ff361d8fa
+    #   Agent: ami-048bd76a36e4d9e31
+    #   Bastion: ami-0e9dbc02ff361d8fa
     # ap-southeast-1:
-    #   Master: ami-0fed77069cd5a6d6c
-    #   Agent: ami-0e95df3b2b20d245c
-    #   Bastion: ami-0fed77069cd5a6d6c
+    #   Master: ami-064ec47318a869dda
+    #   Agent: ami-0d94716e9128a94ba
+    #   Bastion: ami-064ec47318a869dda
     # ap-southeast-2:
-    #   Master: ami-0bf8b986de7e3c7ce
-    #   Agent: ami-054bc72b30aac5c40
-    #   Bastion: ami-0bf8b986de7e3c7ce
+    #   Master: ami-0a00eef8760c6eddc
+    #   Agent: ami-04d0c9be63328caa3
+    #   Bastion: ami-0a00eef8760c6eddc
     eu-central-1:
-      Master: ami-0a49b025fffbbdac6
-      Agent: ami-04f8cd92c6e00a1f8
-      Bastion: ami-0a49b025fffbbdac6
+      Master: ami-05e155ca52886ffe4
+      Agent: ami-0ed13c0e25a6cb093
+      Bastion: ami-05e155ca52886ffe4
     eu-west-1:
-      Master: ami-08edbb0e85d6a0a07
-      Agent: ami-037c51c9b79d49a02
-      Bastion: ami-08edbb0e85d6a0a07
+      Master: ami-04db604073d3d5ce2
+      Agent: ami-000f5dffffa5fe445
+      Bastion: ami-04db604073d3d5ce2
     # eu-west-2:
-    #   Master: ami-0fdf70ed5c34c5f52
-    #   Agent: ami-0b159faec2954f54a
-    #   Bastion: ami-0fdf70ed5c34c5f52
+    #   Master: ami-0ac10f53765369588
+    #   Agent: ami-0102b379095b896b6
+    #   Bastion: ami-0ac10f53765369588
     us-east-1:
-      Master: ami-083654bd07b5da81d
-      Agent: ami-0fb9574129921911f
-      Bastion: ami-083654bd07b5da81d
+      Master: ami-06992628e0a8e044c
+      Agent: ami-0546c2d738dbe2f71
+      Bastion: ami-06992628e0a8e044c
     us-east-2:
-      Master: ami-0629230e074c580f2
-      Agent: ami-0eb5a8cd6ebc8f40f
-      Bastion: ami-0629230e074c580f2
+      Master: ami-02bd262766f4f24c2
+      Agent: ami-046bcbad8e4b4f90f
+      Bastion: ami-02bd262766f4f24c2
     us-west-2:
-      Master: ami-036d46416a34a611c
-      Agent: ami-02d50e97a6fff984c
-      Bastion: ami-036d46416a34a611c
+      Master: ami-0ac79214f93af0a57
+      Agent: ami-0777ff1478fff7dd8
+      Bastion: ami-0ac79214f93af0a57
 
 Parameters:
   VpcCIDR:

--- a/harness/determined/deploy/aws/templates/simple.yaml
+++ b/harness/determined/deploy/aws/templates/simple.yaml
@@ -4,36 +4,36 @@ Description: Determined Template
 Mappings:
   RegionMap:
     ap-northeast-1:
-      Master: ami-036d0684fc96830ca
-      Agent: ami-07be463fe74180d9c
+      Master: ami-0e07ebe171b2a7d79
+      Agent: ami-0d569357ef1359516
     # TODO(DET-4258) Uncomment these when we fully support all P3 regions.
     # ap-northeast-2:
-    #   Master: ami-0f8b8babb98cc66d0
-    #   Agent: ami-0bc9dc1a714ff6d82
+    #   Master: ami-0e9dbc02ff361d8fa
+    #   Agent: ami-048bd76a36e4d9e31
     # ap-southeast-1:
-    #   Master: ami-0fed77069cd5a6d6c
-    #   Agent: ami-0e95df3b2b20d245c
+    #   Master: ami-064ec47318a869dda
+    #   Agent: ami-0d94716e9128a94ba
     # ap-southeast-2:
-    #   Master: ami-0bf8b986de7e3c7ce
-    #   Agent: ami-054bc72b30aac5c40
+    #   Master: ami-0a00eef8760c6eddc
+    #   Agent: ami-04d0c9be63328caa3
     eu-central-1:
-      Master: ami-0a49b025fffbbdac6
-      Agent: ami-04f8cd92c6e00a1f8
+      Master: ami-05e155ca52886ffe4
+      Agent: ami-0ed13c0e25a6cb093
     eu-west-1:
-      Master: ami-08edbb0e85d6a0a07
-      Agent: ami-037c51c9b79d49a02
+      Master: ami-04db604073d3d5ce2
+      Agent: ami-000f5dffffa5fe445
     # eu-west-2:
-    #   Master: ami-0fdf70ed5c34c5f52
-    #   Agent: ami-0b159faec2954f54a
+    #   Master: ami-0ac10f53765369588
+    #   Agent: ami-0102b379095b896b6
     us-east-1:
-      Master: ami-083654bd07b5da81d
-      Agent: ami-0fb9574129921911f
+      Master: ami-06992628e0a8e044c
+      Agent: ami-0546c2d738dbe2f71
     us-east-2:
-      Master: ami-0629230e074c580f2
-      Agent: ami-0eb5a8cd6ebc8f40f
+      Master: ami-02bd262766f4f24c2
+      Agent: ami-046bcbad8e4b4f90f
     us-west-2:
-      Master: ami-036d46416a34a611c
-      Agent: ami-02d50e97a6fff984c
+      Master: ami-0ac79214f93af0a57
+      Agent: ami-0777ff1478fff7dd8
 
 Parameters:
   Keypair:

--- a/harness/determined/deploy/aws/templates/vpc.yaml
+++ b/harness/determined/deploy/aws/templates/vpc.yaml
@@ -3,36 +3,36 @@ Description:  This template deploys a VPC, with a public and private subnet. It 
 Mappings:
   RegionMap:
     ap-northeast-1:
-      Master: ami-036d0684fc96830ca
-      Agent: ami-07be463fe74180d9c
+      Master: ami-0e07ebe171b2a7d79
+      Agent: ami-0d569357ef1359516
     # TODO(DET-4258) Uncomment these when we fully support all P3 regions.
     # ap-northeast-2:
-    #   Master: ami-0f8b8babb98cc66d0
-    #   Agent: ami-0bc9dc1a714ff6d82
+    #   Master: ami-0e9dbc02ff361d8fa
+    #   Agent: ami-048bd76a36e4d9e31
     # ap-southeast-1:
-    #   Master: ami-0fed77069cd5a6d6c
-    #   Agent: ami-0e95df3b2b20d245c
+    #   Master: ami-064ec47318a869dda
+    #   Agent: ami-0d94716e9128a94ba
     # ap-southeast-2:
-    #   Master: ami-0bf8b986de7e3c7ce
-    #   Agent: ami-054bc72b30aac5c40
+    #   Master: ami-0a00eef8760c6eddc
+    #   Agent: ami-04d0c9be63328caa3
     eu-central-1:
-      Master: ami-0a49b025fffbbdac6
-      Agent: ami-04f8cd92c6e00a1f8
+      Master: ami-05e155ca52886ffe4
+      Agent: ami-0ed13c0e25a6cb093
     eu-west-1:
-      Master: ami-08edbb0e85d6a0a07
-      Agent: ami-037c51c9b79d49a02
+      Master: ami-04db604073d3d5ce2
+      Agent: ami-000f5dffffa5fe445
     # eu-west-2:
-    #   Master: ami-0fdf70ed5c34c5f52
-    #   Agent: ami-0b159faec2954f54a
+    #   Master: ami-0ac10f53765369588
+    #   Agent: ami-0102b379095b896b6
     us-east-1:
-      Master: ami-083654bd07b5da81d
-      Agent: ami-0fb9574129921911f
+      Master: ami-06992628e0a8e044c
+      Agent: ami-0546c2d738dbe2f71
     us-east-2:
-      Master: ami-0629230e074c580f2
-      Agent: ami-0eb5a8cd6ebc8f40f
+      Master: ami-02bd262766f4f24c2
+      Agent: ami-046bcbad8e4b4f90f
     us-west-2:
-      Master: ami-036d46416a34a611c
-      Agent: ami-02d50e97a6fff984c
+      Master: ami-0ac79214f93af0a57
+      Agent: ami-0777ff1478fff7dd8
 
 Parameters:
   VpcCIDR:

--- a/harness/determined/deploy/gcp/constants.py
+++ b/harness/determined/deploy/gcp/constants.py
@@ -3,7 +3,7 @@ class defaults:
     AUX_AGENT_INSTANCE_TYPE = "n1-standard-4"
     COMPUTE_AGENT_INSTANCE_TYPE = "n1-standard-32"
     DB_PASSWORD = "postgres"
-    ENVIRONMENT_IMAGE = "det-environments-4537b95"
+    ENVIRONMENT_IMAGE = "det-environments-eb6c7d1"
     GPU_NUM = 8
     GPU_TYPE = "nvidia-tesla-k80"
     MASTER_INSTANCE_TYPE = "n1-standard-2"

--- a/helm/charts/determined/templates/master-config.yaml
+++ b/helm/charts/determined/templates/master-config.yaml
@@ -71,8 +71,8 @@ data:
         cpu: {{ .Values.slotResourceRequests.cpu }}
       {{- end }}
 
-    {{$cpuImage := (split "/" "determinedai/environments:py-3.8-pytorch-1.9-lightning-1.3-tf-2.4-cpu-4537b95")._1}}
-    {{- $gpuImage := (split "/" "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-4537b95")._1 -}}
+    {{$cpuImage := (split "/" "determinedai/environments:py-3.8-pytorch-1.9-lightning-1.3-tf-2.4-cpu-eb6c7d1")._1}}
+    {{- $gpuImage := (split "/" "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-eb6c7d1")._1 -}}
     {{ if .Values.taskContainerDefaults -}}
     task_container_defaults:
       {{- if .Values.taskContainerDefaults.networkMode }}

--- a/master/internal/resourcemanagers/provisioner/aws_config.go
+++ b/master/internal/resourcemanagers/provisioner/aws_config.go
@@ -45,16 +45,16 @@ type AWSClusterConfig struct {
 }
 
 var defaultAWSImageID = map[string]string{
-	"ap-northeast-1": "ami-07be463fe74180d9c",
-	"ap-northeast-2": "ami-0bc9dc1a714ff6d82",
-	"ap-southeast-1": "ami-0e95df3b2b20d245c",
-	"ap-southeast-2": "ami-054bc72b30aac5c40",
-	"us-east-2":      "ami-0eb5a8cd6ebc8f40f",
-	"us-east-1":      "ami-0fb9574129921911f",
-	"us-west-2":      "ami-02d50e97a6fff984c",
-	"eu-central-1":   "ami-04f8cd92c6e00a1f8",
-	"eu-west-2":      "ami-0b159faec2954f54a",
-	"eu-west-1":      "ami-037c51c9b79d49a02",
+	"ap-northeast-1": "ami-0d569357ef1359516",
+	"ap-northeast-2": "ami-048bd76a36e4d9e31",
+	"ap-southeast-1": "ami-0d94716e9128a94ba",
+	"ap-southeast-2": "ami-04d0c9be63328caa3",
+	"us-east-2":      "ami-046bcbad8e4b4f90f",
+	"us-east-1":      "ami-0546c2d738dbe2f71",
+	"us-west-2":      "ami-0777ff1478fff7dd8",
+	"eu-central-1":   "ami-0ed13c0e25a6cb093",
+	"eu-west-2":      "ami-0102b379095b896b6",
+	"eu-west-1":      "ami-000f5dffffa5fe445",
 }
 
 var defaultAWSClusterConfig = AWSClusterConfig{

--- a/master/internal/resourcemanagers/provisioner/gcp_config.go
+++ b/master/internal/resourcemanagers/provisioner/gcp_config.go
@@ -53,7 +53,7 @@ type GCPClusterConfig struct {
 func DefaultGCPClusterConfig() *GCPClusterConfig {
 	return &GCPClusterConfig{
 		BootDiskSize:        200,
-		BootDiskSourceImage: "projects/determined-ai/global/images/det-environments-4537b95",
+		BootDiskSourceImage: "projects/determined-ai/global/images/det-environments-eb6c7d1",
 		LabelKey:            "managed-by",
 		InstanceType: gceInstanceType{
 			MachineType: "n1-standard-32",

--- a/master/pkg/schemas/expconf/const.go
+++ b/master/pkg/schemas/expconf/const.go
@@ -8,7 +8,7 @@ const (
 
 // Default task environment docker image names.
 const (
-	CPUImage  = "determinedai/environments:py-3.8-pytorch-1.9-lightning-1.3-tf-2.4-cpu-4537b95"
-	CUDAImage = "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-4537b95"
-	ROCMImage = "determinedai/environments:rocm-4.2-pytorch-1.9-tf-2.5-rocm-4537b95"
+	CPUImage  = "determinedai/environments:py-3.8-pytorch-1.9-lightning-1.3-tf-2.4-cpu-eb6c7d1"
+	CUDAImage = "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-eb6c7d1"
+	ROCMImage = "determinedai/environments:rocm-4.2-pytorch-1.9-tf-2.5-rocm-eb6c7d1"
 )

--- a/master/pkg/schemas/expconf/legacy_test.go
+++ b/master/pkg/schemas/expconf/legacy_test.go
@@ -256,8 +256,8 @@ func TestLegacyConfig(t *testing.T) {
                     gpu: []
                   force_pull_image: false
                   image:
-                    cpu: determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-4537b95
-                    gpu: determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-4537b95
+                    cpu: determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-eb6c7d1
+                    gpu: determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-eb6c7d1
                   pod_spec:
                     apiVersion: v1
                     kind: Pod

--- a/model_hub/Makefile
+++ b/model_hub/Makefile
@@ -5,7 +5,7 @@ SHORT_GIT_HASH := $(shell git rev-parse --short HEAD)
 ARTIFACTS_DIR := /tmp/artifacts
 
 # Model-hub library environments will be built on top of the default GPU and CPU images in master/pkg/model/defaults.go
-DEFAULT_GPU_IMAGE := determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-4537b95
+DEFAULT_GPU_IMAGE := determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-eb6c7d1
 
 ############REMINDER############
 # When bumping third-party library versions, remember to bump versions in 

--- a/schemas/test_cases/v0/experiment.yaml
+++ b/schemas/test_cases/v0/experiment.yaml
@@ -31,8 +31,8 @@
       environment_variables: {}
       force_pull_image: false
       image:
-        cpu: determinedai/environments:py-3.8-pytorch-1.9-lightning-1.3-tf-2.4-cpu-4537b95
-        cuda: determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-4537b95
+        cpu: determinedai/environments:py-3.8-pytorch-1.9-lightning-1.3-tf-2.4-cpu-eb6c7d1
+        cuda: determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-eb6c7d1
         rocm: determinedai/environments:rocm-4.2-pytorch-1.9-tf-2.5-roсm-4537b95
       pod_spec: null
       ports:

--- a/tools/scripts/bumpenvs.yaml
+++ b/tools/scripts/bumpenvs.yaml
@@ -1,169 +1,170 @@
 ap_northeast_1_agent_ami:
-  new: ami-07be463fe74180d9c
-  old: ami-06f00e0cb0eece385
+  new: ami-0d569357ef1359516
+  old: ami-07be463fe74180d9c
 ap_northeast_1_bastion_ami:
-  new: ami-036d0684fc96830ca
-  old: ami-0adcb4f170c975f15
+  new: ami-0e07ebe171b2a7d79
+  old: ami-036d0684fc96830ca
 ap_northeast_1_master_ami:
-  new: ami-036d0684fc96830ca
-  old: ami-0adcb4f170c975f15
+  new: ami-0e07ebe171b2a7d79
+  old: ami-036d0684fc96830ca
 ap_northeast_2_agent_ami:
-  new: ami-0bc9dc1a714ff6d82
-  old: ami-05c155db8d723e07b
+  new: ami-048bd76a36e4d9e31
+  old: ami-0bc9dc1a714ff6d82
 ap_northeast_2_bastion_ami:
-  new: ami-0f8b8babb98cc66d0
-  old: ami-03cfe661d9d15b36a
+  new: ami-0e9dbc02ff361d8fa
+  old: ami-0f8b8babb98cc66d0
 ap_northeast_2_master_ami:
-  new: ami-0f8b8babb98cc66d0
-  old: ami-03cfe661d9d15b36a
+  new: ami-0e9dbc02ff361d8fa
+  old: ami-0f8b8babb98cc66d0
 ap_southeast_1_agent_ami:
-  new: ami-0e95df3b2b20d245c
-  old: ami-07fd7f175d15b20e1
+  new: ami-0d94716e9128a94ba
+  old: ami-0e95df3b2b20d245c
 ap_southeast_1_bastion_ami:
-  new: ami-0fed77069cd5a6d6c
-  old: ami-04f13c4c90210365a
+  new: ami-064ec47318a869dda
+  old: ami-0fed77069cd5a6d6c
 ap_southeast_1_master_ami:
-  new: ami-0fed77069cd5a6d6c
-  old: ami-04f13c4c90210365a
+  new: ami-064ec47318a869dda
+  old: ami-0fed77069cd5a6d6c
 ap_southeast_2_agent_ami:
-  new: ami-054bc72b30aac5c40
-  old: ami-0bceeb1faa2955d89
+  new: ami-04d0c9be63328caa3
+  old: ami-054bc72b30aac5c40
 ap_southeast_2_bastion_ami:
-  new: ami-0bf8b986de7e3c7ce
-  old: ami-0822e3e42cc9a4e38
+  new: ami-0a00eef8760c6eddc
+  old: ami-0bf8b986de7e3c7ce
 ap_southeast_2_master_ami:
-  new: ami-0bf8b986de7e3c7ce
-  old: ami-0822e3e42cc9a4e38
+  new: ami-0a00eef8760c6eddc
+  old: ami-0bf8b986de7e3c7ce
 eu_central_1_agent_ami:
-  new: ami-04f8cd92c6e00a1f8
-  old: ami-0427f3d3d516ebde2
+  new: ami-0ed13c0e25a6cb093
+  old: ami-04f8cd92c6e00a1f8
 eu_central_1_bastion_ami:
-  new: ami-0a49b025fffbbdac6
-  old: ami-0358b49d1ab873c60
+  new: ami-05e155ca52886ffe4
+  old: ami-0a49b025fffbbdac6
 eu_central_1_master_ami:
-  new: ami-0a49b025fffbbdac6
-  old: ami-0358b49d1ab873c60
+  new: ami-05e155ca52886ffe4
+  old: ami-0a49b025fffbbdac6
 eu_west_1_agent_ami:
-  new: ami-037c51c9b79d49a02
-  old: ami-04a190f7ec1d3445f
+  new: ami-000f5dffffa5fe445
+  old: ami-037c51c9b79d49a02
 eu_west_1_bastion_ami:
-  new: ami-08edbb0e85d6a0a07
-  old: ami-0d7f394c51e3e7d3e
+  new: ami-04db604073d3d5ce2
+  old: ami-08edbb0e85d6a0a07
 eu_west_1_master_ami:
-  new: ami-08edbb0e85d6a0a07
-  old: ami-0d7f394c51e3e7d3e
+  new: ami-04db604073d3d5ce2
+  old: ami-08edbb0e85d6a0a07
 eu_west_2_agent_ami:
-  new: ami-0b159faec2954f54a
-  old: ami-0cbf9a11092a1a5e7
+  new: ami-0102b379095b896b6
+  old: ami-0b159faec2954f54a
 eu_west_2_bastion_ami:
-  new: ami-0fdf70ed5c34c5f52
-  old: ami-0553c8e502a474394
+  new: ami-0ac10f53765369588
+  old: ami-0fdf70ed5c34c5f52
 eu_west_2_master_ami:
-  new: ami-0fdf70ed5c34c5f52
-  old: ami-0553c8e502a474394
+  new: ami-0ac10f53765369588
+  old: ami-0fdf70ed5c34c5f52
 gcp_env:
-  new: det-environments-4537b95
-  old: det-environments-825e8ee
+  new: det-environments-eb6c7d1
+  old: det-environments-4537b95
 pytorch19_tf25_rocm_hashed:
-  new: determinedai/environments:rocm-4.2-pytorch-1.9-tf-2.5-rocm-4537b95
+  new: determinedai/environments:rocm-4.2-pytorch-1.9-tf-2.5-rocm-eb6c7d1
+  old: determinedai/environments:rocm-4.2-pytorch-1.9-tf-2.5-rocm-4537b95
 pytorch19_tf25_rocm_versioned:
   new: determinedai/environments:rocm-4.2-pytorch-1.9-tf-2.5-rocm-0.17.6
 tf1_cpu_hashed:
-  new: determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-4537b95
-  old: determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-825e8ee
+  new: determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-eb6c7d1
+  old: determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-4537b95
 tf1_cpu_versioned:
   new: determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-0.17.6
   old: determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-0.17.4
 tf1_gpu_hashed:
-  new: determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-4537b95
-  old: determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-825e8ee
+  new: determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-eb6c7d1
+  old: determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-4537b95
 tf1_gpu_versioned:
   new: determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-0.17.6
   old: determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-0.17.4
 tf25_cpu_hashed:
-  new: determinedai/environments:py-3.8-tf-2.5-cpu-4537b95
-  old: determinedai/environments:py-3.8-tf-2.5-cpu-825e8ee
+  new: determinedai/environments:py-3.8-tf-2.5-cpu-eb6c7d1
+  old: determinedai/environments:py-3.8-tf-2.5-cpu-4537b95
 tf25_cpu_versioned:
   new: determinedai/environments:py-3.8-tf-2.5-cpu-0.17.6
   old: determinedai/environments:py-3.8-tf-2.5-cpu-0.17.4
 tf25_gpu_hashed:
-  new: determinedai/environments:cuda-11.2-tf-2.5-gpu-4537b95
-  old: determinedai/environments:cuda-11.2-tf-2.5-gpu-825e8ee
+  new: determinedai/environments:cuda-11.2-tf-2.5-gpu-eb6c7d1
+  old: determinedai/environments:cuda-11.2-tf-2.5-gpu-4537b95
 tf25_gpu_versioned:
   new: determinedai/environments:cuda-11.2-tf-2.5-gpu-0.17.6
   old: determinedai/environments:cuda-11.2-tf-2.5-gpu-0.17.4
 tf26_cpu_hashed:
-  new: determinedai/environments:py-3.8-tf-2.6-cpu-4537b95
-  old: determinedai/environments:py-3.8-tf-2.6-cpu-825e8ee
+  new: determinedai/environments:py-3.8-tf-2.6-cpu-eb6c7d1
+  old: determinedai/environments:py-3.8-tf-2.6-cpu-4537b95
 tf26_cpu_versioned:
   new: determinedai/environments:py-3.8-tf-2.6-cpu-0.17.6
   old: determinedai/environments:py-3.8-tf-2.6-cpu-0.17.4
 tf26_gpu_hashed:
-  new: determinedai/environments:cuda-11.2-tf-2.6-gpu-4537b95
-  old: determinedai/environments:cuda-11.2-tf-2.6-gpu-825e8ee
+  new: determinedai/environments:cuda-11.2-tf-2.6-gpu-eb6c7d1
+  old: determinedai/environments:cuda-11.2-tf-2.6-gpu-4537b95
 tf26_gpu_versioned:
   new: determinedai/environments:cuda-11.2-tf-2.6-gpu-0.17.6
   old: determinedai/environments:cuda-11.2-tf-2.6-gpu-0.17.4
 tf27_cpu_hashed:
-  new: determinedai/environments:py-3.8-tf-2.7-cpu-4537b95
-  old: determinedai/environments:py-3.8-tf-2.7-cpu-825e8ee
+  new: determinedai/environments:py-3.8-tf-2.7-cpu-eb6c7d1
+  old: determinedai/environments:py-3.8-tf-2.7-cpu-4537b95
 tf27_cpu_versioned:
   new: determinedai/environments:py-3.8-tf-2.7-cpu-0.17.6
   old: determinedai/environments:py-3.8-tf-2.7-cpu-0.17.4
 tf27_gpu_hashed:
-  new: determinedai/environments:cuda-11.2-tf-2.7-gpu-4537b95
-  old: determinedai/environments:cuda-11.2-tf-2.7-gpu-825e8ee
+  new: determinedai/environments:cuda-11.2-tf-2.7-gpu-eb6c7d1
+  old: determinedai/environments:cuda-11.2-tf-2.7-gpu-4537b95
 tf27_gpu_versioned:
   new: determinedai/environments:cuda-11.2-tf-2.7-gpu-0.17.6
   old: determinedai/environments:cuda-11.2-tf-2.7-gpu-0.17.4
 tf2_cpu_hashed:
-  new: determinedai/environments:py-3.8-pytorch-1.9-lightning-1.3-tf-2.4-cpu-4537b95
-  old: determinedai/environments:py-3.8-pytorch-1.9-lightning-1.3-tf-2.4-cpu-825e8ee
+  new: determinedai/environments:py-3.8-pytorch-1.9-lightning-1.3-tf-2.4-cpu-eb6c7d1
+  old: determinedai/environments:py-3.8-pytorch-1.9-lightning-1.3-tf-2.4-cpu-4537b95
 tf2_cpu_versioned:
   new: determinedai/environments:py-3.8-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0.17.6
   old: determinedai/environments:py-3.8-pytorch-1.9-lightning-1.3-tf-2.4-cpu-0.17.4
 tf2_gpu_hashed:
-  new: determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-4537b95
-  old: determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-825e8ee
+  new: determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-eb6c7d1
+  old: determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-4537b95
 tf2_gpu_versioned:
   new: determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0.17.6
   old: determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-0.17.4
 us_east_1_agent_ami:
-  new: ami-0fb9574129921911f
-  old: ami-05be92a5d78bf2944
+  new: ami-0546c2d738dbe2f71
+  old: ami-0fb9574129921911f
 us_east_1_bastion_ami:
-  new: ami-083654bd07b5da81d
-  old: ami-0a99b06fad09f48df
+  new: ami-06992628e0a8e044c
+  old: ami-083654bd07b5da81d
 us_east_1_master_ami:
-  new: ami-083654bd07b5da81d
-  old: ami-0a99b06fad09f48df
+  new: ami-06992628e0a8e044c
+  old: ami-083654bd07b5da81d
 us_east_2_agent_ami:
-  new: ami-0eb5a8cd6ebc8f40f
-  old: ami-073889992e7259ceb
+  new: ami-046bcbad8e4b4f90f
+  old: ami-0eb5a8cd6ebc8f40f
 us_east_2_bastion_ami:
-  new: ami-0629230e074c580f2
-  old: ami-0e5e17317f99b2932
+  new: ami-02bd262766f4f24c2
+  old: ami-0629230e074c580f2
 us_east_2_master_ami:
-  new: ami-0629230e074c580f2
-  old: ami-0e5e17317f99b2932
+  new: ami-02bd262766f4f24c2
+  old: ami-0629230e074c580f2
 us_gov_east_1_agent_ami:
-  new: ami-0e4b3836ce94a5452
-  old: ami-0580afb488d54593b
+  new: ami-0b2e8e8d056660695
+  old: ami-0e4b3836ce94a5452
 us_gov_east_1_master_ami:
-  new: ami-05c154cec85baeb50
-  old: ami-0ce79d6fa9e9a242e
+  new: ami-03958388786db1513
+  old: ami-05c154cec85baeb50
 us_gov_west_1_agent_ami:
-  new: ami-0b9e714be7bab5cc3
-  old: ami-03ab5165c1c1956c4
+  new: ami-0028fc169ca16c575
+  old: ami-0b9e714be7bab5cc3
 us_gov_west_1_master_ami:
-  new: ami-05776a65d52ff7a9b
-  old: ami-04a2f96ef9b12b2b1
+  new: ami-066189aeb91baa0ab
+  old: ami-05776a65d52ff7a9b
 us_west_2_agent_ami:
-  new: ami-02d50e97a6fff984c
-  old: ami-02e0bc462c0879512
+  new: ami-0777ff1478fff7dd8
+  old: ami-02d50e97a6fff984c
 us_west_2_bastion_ami:
-  new: ami-036d46416a34a611c
-  old: ami-08f76d3bc7a0e55ce
+  new: ami-0ac79214f93af0a57
+  old: ami-036d46416a34a611c
 us_west_2_master_ami:
-  new: ami-036d46416a34a611c
-  old: ami-08f76d3bc7a0e55ce
+  new: ami-0ac79214f93af0a57
+  old: ami-036d46416a34a611c

--- a/webui/react/src/fixtures/responses/experiment-details/non-scalar-metrics-4078.json
+++ b/webui/react/src/fixtures/responses/experiment-details/non-scalar-metrics-4078.json
@@ -32,8 +32,8 @@
     "name": "Fork of Fork of mnist_tp_to_estimator_const",
     "environment": {
       "image": {
-        "cpu": "determinedai/environments:py-3.8-pytorch-1.9-lightning-1.3-tf-2.4-cpu-4537b95",
-        "gpu": "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-4537b95"
+        "cpu": "determinedai/environments:py-3.8-pytorch-1.9-lightning-1.3-tf-2.4-cpu-eb6c7d1",
+        "gpu": "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-eb6c7d1"
       },
       "ports": null,
       "pod_spec": null,

--- a/webui/react/src/fixtures/responses/experiment-details/set-a.json
+++ b/webui/react/src/fixtures/responses/experiment-details/set-a.json
@@ -694,8 +694,8 @@
         "environment_variables": {},
         "force_pull_image": false,
         "image": {
-          "cpu": "determinedai/environments:py-3.8-pytorch-1.9-lightning-1.3-tf-2.4-cpu-4537b95",
-          "gpu": "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-4537b95"
+          "cpu": "determinedai/environments:py-3.8-pytorch-1.9-lightning-1.3-tf-2.4-cpu-eb6c7d1",
+          "gpu": "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-eb6c7d1"
         },
         "pod_spec": null,
         "ports": null
@@ -838,8 +838,8 @@
         "environment_variables": {},
         "force_pull_image": false,
         "image": {
-          "cpu": "determinedai/environments:py-3.8-pytorch-1.9-lightning-1.3-tf-2.4-cpu-4537b95",
-          "gpu": "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-4537b95"
+          "cpu": "determinedai/environments:py-3.8-pytorch-1.9-lightning-1.3-tf-2.4-cpu-eb6c7d1",
+          "gpu": "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-eb6c7d1"
         },
         "pod_spec": {
           "metadata": {
@@ -2596,8 +2596,8 @@
       "name": "noop_adaptive",
       "environment": {
         "image": {
-          "cpu": "determinedai/environments:py-3.8-pytorch-1.9-lightning-1.3-tf-2.4-cpu-4537b95",
-          "gpu": "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-4537b95"
+          "cpu": "determinedai/environments:py-3.8-pytorch-1.9-lightning-1.3-tf-2.4-cpu-eb6c7d1",
+          "gpu": "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-eb6c7d1"
         },
         "ports": null,
         "pod_spec": null,

--- a/webui/react/src/fixtures/responses/trial-details/old-trial-config-noop-adaptive.json
+++ b/webui/react/src/fixtures/responses/trial-details/old-trial-config-noop-adaptive.json
@@ -30,8 +30,8 @@
   "name": "noop_adaptive",
   "environment": {
     "image": {
-      "cpu": "determinedai/environments:py-3.8-pytorch-1.9-lightning-1.3-tf-2.4-cpu-4537b95",
-      "gpu": "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-4537b95"
+      "cpu": "determinedai/environments:py-3.8-pytorch-1.9-lightning-1.3-tf-2.4-cpu-eb6c7d1",
+      "gpu": "determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-eb6c7d1"
     },
     "ports": null,
     "force_pull_image": false,


### PR DESCRIPTION
## Description

Updating the base AMIs will cause automatic updates to not be so
aggressive in our CI instances.

Hopefully this will help stabilize CI a bit, but if not it will still
improve our overall security.