### PR TITLE
feat: pass metrics to simple reducer in original order

### DIFF
--- a/harness/determined/_core/_distributed.py
+++ b/harness/determined/_core/_distributed.py
@@ -4,7 +4,7 @@ import logging
 import shutil
 import socket
 import tempfile
-from typing import Any, Callable, List, Optional, Tuple, cast
+from typing import Any, Callable, List, Optional
 
 from determined import constants, ipc
 

--- a/harness/determined/_core/_distributed.py
+++ b/harness/determined/_core/_distributed.py
@@ -4,9 +4,13 @@ import logging
 import shutil
 import socket
 import tempfile
-from typing import Any, Callable, List, Optional
+from typing import Any, Callable, List, Optional, Tuple, cast
 
 from determined import constants, ipc
+
+
+def _tuple_key_function(v: Any) -> int:
+    return cast(Tuple[Any, int], v)[1]
 
 
 class DistributedContext:
@@ -215,11 +219,13 @@ class DistributedContext:
             return [stuff]
         logging.debug(f"Worker {self.get_rank()} beginning zmq gather.")
         if self._is_chief:
-            worker_stuff, _ = self._chief_zmq.gather_with_polling(lambda: None)
+            worker_stuff_ranked, _ = self._chief_zmq.gather_with_polling(lambda: None)
+            worker_stuff_ranked.sort(key=_tuple_key_function)
+            worker_stuff = [value for value, _ in worker_stuff_ranked]
             self._chief_zmq.broadcast(None)
             out = [stuff, *worker_stuff]  # type: Optional[List]
         else:
-            self._worker_zmq.send(stuff)
+            self._worker_zmq.send((stuff, self.get_rank()))
             # Synchronize with the chief so that there is no risk of accidentally calling send()
             # for a future gather before all workers have called send() on this gather.
             _ = self._worker_zmq.recv()
@@ -236,11 +242,13 @@ class DistributedContext:
             return [stuff]
         logging.debug(f"Worker {self.get_rank()} beginning zmq gather local.")
         if self._is_local_chief:
-            worker_stuff, _ = self._local_chief_zmq.gather_with_polling(lambda: None)
+            worker_stuff_ranked, _ = self._local_chief_zmq.gather_with_polling(lambda: None)
+            worker_stuff_ranked.sort(key=_tuple_key_function)
+            worker_stuff = [value for value, _ in worker_stuff_ranked]
             self._local_chief_zmq.broadcast(None)
             out = [stuff, *worker_stuff]  # type: Optional[List]
         else:
-            self._local_worker_zmq.send(stuff)
+            self._local_worker_zmq.send((stuff, self.get_local_rank()))
             # Synchronize with the chief so that there is no risk of accidentally calling send()
             # for a future gather before all workers have called send() on this gather.
             _ = self._local_worker_zmq.recv()
@@ -257,8 +265,8 @@ class DistributedContext:
         logging.debug(f"Worker {self.get_rank()} beginning zmq allgather.")
         if self._is_chief:
             worker_stuff_ranked, _ = self._chief_zmq.gather_with_polling(lambda: None)
-            worker_stuff_ranked.sort(key=lambda x: x[1])
-            worker_stuff = [value for value, index in worker_stuff_ranked]
+            worker_stuff_ranked.sort(key=_tuple_key_function)
+            worker_stuff = [value for value, _ in worker_stuff_ranked]
             all_stuff = [stuff, *worker_stuff]
             self._chief_zmq.broadcast(all_stuff)
         else:
@@ -275,11 +283,13 @@ class DistributedContext:
             return [stuff]
         logging.debug(f"Worker {self.get_rank()} beginning zmq local allgather.")
         if self._is_local_chief:
-            worker_stuff, _ = self._local_chief_zmq.gather_with_polling(lambda: None)
+            worker_stuff_ranked, _ = self._local_chief_zmq.gather_with_polling(lambda: None)
+            worker_stuff_ranked.sort(key=_tuple_key_function)
+            worker_stuff = [value for value, _ in worker_stuff_ranked]
             all_stuff = [stuff, *worker_stuff]
             self._local_chief_zmq.broadcast(all_stuff)
         else:
-            self._local_worker_zmq.send(stuff)
+            self._local_worker_zmq.send((stuff, self.get_local_rank()))
             all_stuff = self._local_worker_zmq.recv()
         logging.debug(f"Worker {self.get_rank()} finished zmq local allgather.")
         return all_stuff

--- a/harness/determined/pytorch/_reducer.py
+++ b/harness/determined/pytorch/_reducer.py
@@ -1,5 +1,6 @@
 import abc
 import enum
+import itertools
 import logging
 from typing import Any, Callable, Dict, List, Optional, Union
 
@@ -185,20 +186,16 @@ class _SimpleReducer(MetricReducer):
         return self.values
 
     def cross_slot_reduce(self, per_slot_metrics: List) -> Any:
+        """
+        Call the reducer function on metrics in their original order.
 
-        # restore the initial (pre-sharding) order of metrics
-        flat_metrics = []
-        i = 0
-        has_non_exhausted_sublist = True
-        while has_non_exhausted_sublist:
-            has_non_exhausted_sublist = False
-            for sublist in per_slot_metrics:
-                try:
-                    flat_metrics.append(sublist[i])
-                    has_non_exhausted_sublist = True
-                except IndexError:
-                    pass
-            i += 1
+        Interleave metrics from different slots as we flatten
+        the list of metrics to undo the effect of sharding.
+        Note: this will only reconstruct the original order if the user
+        calls ``update()`` the same number of times per batch
+        """
+        interleaved = itertools.zip_longest(*per_slot_metrics)
+        flat_metrics = [m for sublist in interleaved for m in sublist if m is not None]
 
         return self.fn(flat_metrics)
 
@@ -424,14 +421,10 @@ class _PyTorchReducerContext:
 
         metrics = {}
 
-        # gatherables = enumerate(wrapped.per_slot_reduce() for wrapped in reducables)
-        # print(f"gatherables={gatherables}")
         gatherables = [wrapped.per_slot_reduce() for wrapped in reducables]
 
         # Do one allgather for all metrics to improve .
         gathered = self._allgather_fn(gatherables)
-
-        logging.debug(f"len(gathered)={len(gathered)}")
 
         # Reshape list from per-slot-list-of-all-metrics to a per-metric-list-of-all-slots.
         all_per_slot_metrics = zip(*gathered)

--- a/harness/determined/pytorch/_reducer.py
+++ b/harness/determined/pytorch/_reducer.py
@@ -1,7 +1,6 @@
 import abc
 import enum
 import itertools
-import logging
 from typing import Any, Callable, Dict, List, Optional, Union
 
 import numpy as np

--- a/harness/tests/experiment/pytorch/test_reducer.py
+++ b/harness/tests/experiment/pytorch/test_reducer.py
@@ -1,6 +1,17 @@
-import numpy as np
+import itertools
+import logging
+import threading
+import traceback
+from collections import namedtuple
+from typing import Any, Callable, List
 
-from determined.pytorch import Reducer, _reduce_metrics
+import numpy as np
+import pytest
+
+from determined import _core
+from determined.pytorch import Reducer, _PyTorchReducerContext, _reduce_metrics
+
+logger = logging.getLogger(__name__)
 
 
 def test_reducer() -> None:
@@ -12,3 +23,95 @@ def test_reducer() -> None:
 
     batches_per_process = [1, 2, 5, 4, 5, 6]
     assert np.around(_reduce_metrics(Reducer.AVG, metrics, batches_per_process), decimals=2) == 6.43
+
+
+DummyTrial = namedtuple("DummyTrial", "distributed_context reducer_context wrapped_reducer")
+
+
+def dummy_reducer(values: List) -> Any:
+    logger.info(f"reducing {values}")
+    flat = [v for sublist in values for v in sublist]
+    return {"values": flat, "sum": sum(flat)}
+
+
+@pytest.mark.parametrize("cross_size", [1, 3])
+@pytest.mark.parametrize("local_size", [1, 3])
+def test_custom_reducer_slot_order(cross_size: int, local_size: int) -> None:
+    size = cross_size * local_size
+    dataset_size = 47
+
+    def do_parallel(fn: Callable) -> List:
+        """
+        Run the same function on one-thread-per-rank, assert there were no exceptions, and return
+        the results from each rank.
+        """
+        results = [None] * size  # type: List
+        errors = [None] * size  # type: List
+        threads = []
+
+        for cross_rank, local_rank in itertools.product(range(cross_size), range(local_size)):
+            rank = cross_rank * local_size + local_rank
+
+            def _fn(rank: int, cross_rank: int, local_rank: int) -> None:
+                try:
+                    results[rank] = fn(rank, cross_rank, local_rank)
+                except Exception:
+                    errors[rank] = traceback.format_exc()
+                    raise
+
+            threads.append(threading.Thread(target=_fn, args=(rank, cross_rank, local_rank)))
+
+        for thread in reversed(threads):
+            thread.start()
+
+        for thread in threads:
+            thread.join()
+
+        assert errors == [None] * size, "not all threads exited without error"
+
+        return results
+
+    def make_reducer_context(rank: int, cross_rank: int, local_rank: int) -> DummyTrial:
+        distributed_context = _core.DistributedContext(
+            rank=cross_rank * local_size + local_rank,
+            size=cross_size * local_size,
+            local_rank=local_rank,
+            local_size=local_size,
+            cross_rank=cross_rank,
+            cross_size=cross_size,
+            chief_ip="localhost",
+            force_tcp=False,
+        )
+        reducer_context = _PyTorchReducerContext(distributed_context._zmq_allgather)
+        # reducer_context.wrap_reducer(lambda x: x, "dummy")
+        wrapped_reducer = reducer_context.wrap_reducer(dummy_reducer)
+        return DummyTrial(distributed_context, reducer_context, wrapped_reducer)
+
+    trials = do_parallel(make_reducer_context)
+
+    def get_batch_list(rank, batch_size, num_workers, seq):
+        total_batches = (len(seq) + (batch_size - 1)) // batch_size
+        my_batch_indices = [i for i in range(total_batches) if i % num_workers == rank]
+        all_batches = [
+            seq[batch_size * k : min(batch_size * k + batch_size, len(seq))]
+            for k in range(total_batches)
+        ]
+        logger.debug(f"{total_batches}, {my_batch_indices}, {all_batches}")
+        return [b for i, b in enumerate(all_batches) if i in my_batch_indices]
+
+    observations = list(range(dataset_size))
+    for rank, trial in enumerate(trials):
+        for batch in get_batch_list(rank, 2, len(trials), observations):
+            trial.wrapped_reducer.update(batch)
+
+    results = do_parallel(lambda rank, _, __: trials[rank].reducer_context.reduce_metrics(False))
+    logger.debug(results)
+
+    # Close all distributed contexts
+    for trial in trials:
+        trial.distributed_context.close()
+
+    assert results[0]["sum"] == dataset_size * (dataset_size - 1) // 2
+    assert all(
+        i == v for i, v in enumerate(results[0]["values"])
+    ), f"{results[0]} is not in original order"

--- a/harness/tests/experiment/pytorch/test_reducer.py
+++ b/harness/tests/experiment/pytorch/test_reducer.py
@@ -63,6 +63,7 @@ def test_custom_reducer_slot_order(cross_size: int, local_size: int) -> None:
 
             threads.append(threading.Thread(target=_fn, args=(rank, cross_rank, local_rank)))
 
+        # encourage allgather to occur in not-the-correct order to test the reordering
         for thread in reversed(threads):
             thread.start()
 

--- a/harness/tests/experiment/pytorch/test_reducer.py
+++ b/harness/tests/experiment/pytorch/test_reducer.py
@@ -89,14 +89,15 @@ def test_custom_reducer_slot_order(cross_size: int, local_size: int) -> None:
 
     trials = do_parallel(make_reducer_context)
 
-    def get_batch_list(rank, batch_size, num_workers, seq):
+    def get_batch_list(
+        rank: int, batch_size: int, num_workers: int, seq: List[int]
+    ) -> List[List[int]]:
         total_batches = (len(seq) + (batch_size - 1)) // batch_size
         my_batch_indices = [i for i in range(total_batches) if i % num_workers == rank]
         all_batches = [
             seq[batch_size * k : min(batch_size * k + batch_size, len(seq))]
             for k in range(total_batches)
         ]
-        logger.debug(f"{total_batches}, {my_batch_indices}, {all_batches}")
         return [b for i, b in enumerate(all_batches) if i in my_batch_indices]
 
     observations = list(range(dataset_size))


### PR DESCRIPTION
## Description
Pass metrics to simple reducer in original order
[DET-5726]

The way that we shard changes the order of the observations (metric values captured by calls to `update`) when we later gather observations for custom reducers.

At a small extra cost we put the observations back in the original order before passing them to the reducer.

Note: 
1. This is only implemented for Pytorch and only for the "simple" metric reducer, i.e. one that is a function as opposed to a `MetricReducer`.
2. If the user calls `update` a variable number of times per batch (whether in training or validation) we cannot guarantee the order.

## Test Plan

A new unit test creates a bare-bones Trial-like object and distributes calls to `update` in a way consistent with how `DistributedBatchSampler` does it.
It then confirms that the reducer receives values in the original order.

## Commentary
Restoring the original order relies on two things: 1) allgather returning collected data in the order of worker rank (as opposed to a presumably random order gather_with_polling could return it) and 2) `_SimpleReducer.cross_slot_reduce` performing a zip-like "sweep" over the gathered metrics. The standard zip does not work because the number of batches/metrics handled by different workers may be off by one if the total number of batches is not divisible by the number of workers. Also, although it is impossible to support restoring the original order in case the user calls `update` a random number of times per batch, we take care to still submit _all_ the gathered metrics to the reducer. This makes for a slightly more complex implementation of `cross_slot_reduce`.

## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.




[DET-5726]: https://determinedai.atlassian.net/browse/DET-5726?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ