### PR TITLE
ci: increase resource_class for Docker image scan

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1862,6 +1862,7 @@ jobs:
   scan-docker-images:
     machine:
       image: <<pipeline.parameters.machine-image>>
+    resource_class: xlarge
     steps:
       - checkout
       - set-slack-user-id


### PR DESCRIPTION
## Description

The scan is timing out. I suspect (and am confirming) that a larger resource class would address this.