### PR TITLE
fix: address experiment name going out of sync with db

### DIFF
--- a/docs/release-notes/3414-fix-jobname-not-updating.txt
+++ b/docs/release-notes/3414-fix-jobname-not-updating.txt
@@ -1,0 +1,6 @@
+:orphan:
+
+**Bug Fixes**
+
+-  fix an issue where the updating an experiment name wouldn't reflect the change in its job
+   representation until a master restart.

--- a/master/internal/api_experiment.go
+++ b/master/internal/api_experiment.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/determined-ai/determined/master/internal/config"
 	"github.com/determined-ai/determined/master/internal/prom"
 
 	"github.com/google/uuid"
@@ -581,6 +582,10 @@ func (a *apiServer) PatchExperiment(
 				return nil, status.Errorf(codes.InvalidArgument, "`name` is required.")
 			}
 			exp.Name = req.Experiment.Name
+			patch := config.ExperimentConfigPatch{
+				Name: &req.Experiment.Name,
+			}
+			a.m.system.TellAt(actor.Addr("experiments", req.Experiment.Id), patch)
 		case path == "notes":
 			shouldUpdateNotes = true
 			exp.Notes = req.Experiment.Notes

--- a/master/internal/config/config.go
+++ b/master/internal/config/config.go
@@ -25,6 +25,13 @@ var (
 var once sync.Once
 var masterConfig *Config
 
+type (
+	// ExperimentConfigPatch is the updatedble fields for patching an experiment.
+	ExperimentConfigPatch struct {
+		Name *string `json:"name,omitempty"`
+	}
+)
+
 // DefaultConfig returns the default configuration of the master.
 func DefaultConfig() *Config {
 	return &Config{

--- a/master/internal/experiment.go
+++ b/master/internal/experiment.go
@@ -247,6 +247,8 @@ func (e *experiment) Receive(ctx *actor.Context) error {
 	// Patch experiment messages.
 	case model.State:
 		e.updateState(ctx, msg)
+	case config.ExperimentConfigPatch:
+		e.Config.SetName(expconf.Name{RawString: msg.Name})
 	case sproto.SetGroupMaxSlots:
 		resources := e.Config.Resources()
 		resources.SetMaxSlots(msg.MaxSlots)


### PR DESCRIPTION

## Description

a more comprehensive solution could start from https://github.com/determined-ai/determined/pull/3396 but 
1. it'd take longer to flush out 
2. we're working to remove the patchExperiment from core_experiment module soon
<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At a minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->

fixes #3390 

## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions about this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ