### PR TITLE
chore: improve rate of false OK sends on websockets

### DIFF
--- a/agent/internal/agent.go
+++ b/agent/internal/agent.go
@@ -117,7 +117,7 @@ func (a *agent) Receive(ctx *actor.Context) error {
 				a.bufferSendForRecovery(ctx, wsm)
 			}
 		} else {
-			ctx.Log().Warnf("Not sending container log change to the master: %+v", msg)
+			ctx.Log().Warnf("Not sending container log to the master: %+v", msg)
 		}
 
 	case model.TrialLog:

--- a/master/pkg/actor/api/ws.go
+++ b/master/pkg/actor/api/ws.go
@@ -35,7 +35,7 @@ const (
 
 // MaxMaxWebsocketMessageSizeExceededError indicates to the call that the message exceeded the
 // maximum websocket size.
-type MaxMaxWebsocketMessageSizeExceededError struct {
+type MaxWebsocketMessageSizeExceededError struct {
 	size int
 }
 


### PR DESCRIPTION
## Description
This PR comprises two small changes. First, we try to return errors from writes on websockets to the caller more promptly by returning the error from `s.conn.WriteMessage` rather than returning success always. Second, we buffer failed sends when the error was not ours (validation), assuming the socket will be closed immediately and the recovery routine will kick off. When finished, we resend the buffered messages.
<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At a minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan
- [ ] run all upstream CI a few times, try to write a test.
<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions about this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ