### PR TITLE
feat: Record parent_id from WebUI, return forkedFrom from API

### DIFF
--- a/harness/determined/common/api/bindings.py
+++ b/harness/determined/common/api/bindings.py
@@ -1031,6 +1031,7 @@ class v1Experiment:
         username: str,
         description: "typing.Optional[str]" = None,
         endTime: "typing.Optional[str]" = None,
+        forkedFrom: "typing.Optional[int]" = None,
         labels: "typing.Optional[typing.Sequence[str]]" = None,
         notes: "typing.Optional[str]" = None,
         progress: "typing.Optional[float]" = None,
@@ -1051,6 +1052,7 @@ class v1Experiment:
         self.name = name
         self.notes = notes
         self.jobId = jobId
+        self.forkedFrom = forkedFrom
 
     @classmethod
     def from_json(cls, obj: Json) -> "v1Experiment":
@@ -1070,6 +1072,7 @@ class v1Experiment:
             name=obj["name"],
             notes=obj["notes"] if obj.get("notes", None) is not None else None,
             jobId=obj["jobId"],
+            forkedFrom=obj["forkedFrom"] if obj.get("forkedFrom", None) is not None else None,
         )
 
     def to_json(self) -> typing.Any:
@@ -1089,6 +1092,7 @@ class v1Experiment:
             "name": self.name,
             "notes": self.notes if self.notes is not None else None,
             "jobId": self.jobId,
+            "forkedFrom": self.forkedFrom if self.forkedFrom is not None else None,
         }
 
 class v1ExperimentSimulation:

--- a/master/internal/db/postgres_experiments.go
+++ b/master/internal/db/postgres_experiments.go
@@ -1132,9 +1132,9 @@ func (db *PgDB) AddExperiment(experiment *model.Experiment) (err error) {
 		}
 		err := namedGet(tx, &experiment.ID, `
 	INSERT INTO experiments
-	(state, config, model_definition, start_time, end_time, archived,
+	(state, config, model_definition, start_time, end_time, archived, parent_id,
 	 git_remote, git_commit, git_committer, git_commit_date, owner_id, original_config, notes, job_id)
-	VALUES (:state, :config, :model_definition, :start_time, :end_time, :archived,
+	VALUES (:state, :config, :model_definition, :start_time, :end_time, :archived, :parent_id,
 					:git_remote, :git_commit, :git_committer, :git_commit_date, :owner_id, :original_config,
 					:notes, :job_id)
 	RETURNING id`, experiment)

--- a/master/static/srv/get_experiment.sql
+++ b/master/static/srv/get_experiment.sql
@@ -13,6 +13,7 @@ SELECT
     e.archived AS archived,
     COALESCE(e.progress, 0) AS progress,
     e.job_id AS job_id,
+    e.parent_id AS forked_from,
     u.username AS username
 FROM
     experiments e

--- a/master/static/srv/get_experiments.sql
+++ b/master/static/srv/get_experiments.sql
@@ -17,6 +17,7 @@ WITH filtered_exps AS (
         e.archived AS archived,
         COALESCE(e.progress, 0) AS progress,
         e.job_id AS job_id,
+        e.parent_id AS forked_from,
         u.username AS username
     FROM experiments e
     JOIN users u ON e.owner_id = u.id

--- a/proto/src/determined/experiment/v1/experiment.proto
+++ b/proto/src/determined/experiment/v1/experiment.proto
@@ -4,6 +4,7 @@ package determined.experiment.v1;
 option go_package = "github.com/determined-ai/determined/proto/pkg/experimentv1";
 
 import "google/protobuf/timestamp.proto";
+import "google/protobuf/wrappers.proto";
 import "protoc-gen-swagger/options/annotations.proto";
 
 // The current state of the experiment.
@@ -85,6 +86,8 @@ message Experiment {
   string notes = 14;
   // Associated job's id.
   string job_id = 15;
+  // Original id of a forked or continued experiment.
+  google.protobuf.Int32Value forked_from = 16;
 }
 
 // ValidationHistoryEntry is a single entry for a validation history for an

--- a/webui/react/src/services/api-ts-sdk/api.ts
+++ b/webui/react/src/services/api-ts-sdk/api.ts
@@ -1577,6 +1577,12 @@ export interface V1Experiment {
      * @memberof V1Experiment
      */
     jobId: string;
+    /**
+     * Original id of a forked or continued experiment.
+     * @type {number}
+     * @memberof V1Experiment
+     */
+    forkedFrom?: number;
 }
 
 /**


### PR DESCRIPTION
## Description

- Fixes an issue where experiments forked and continued from the Web UI were stored with parent_id = NULL
- Returns parent_id in the experiments API

## Checklist

- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.