### PR TITLE
ci: run releases for tags with new proper SemVer format

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,7 @@ release-and-rc-filters: &release-and-rc-filters
   tags:
     only:
       - /(\d)+(\.(\d)+)+/
-      - /((\d)+(\.(\d)+)+)(rc)(\d)+/
+      - /((\d)+(\.(\d)+)+)(-rc)(\d)+/
 
 rc-filters: &rc-filters
   branches:
@@ -54,7 +54,7 @@ rc-filters: &rc-filters
       - /.*/
   tags:
     only:
-      - /((\d)+(\.(\d)+)+)(rc)(\d)+/
+      - /((\d)+(\.(\d)+)+)(-rc)(\d)+/
 
 release-filters: &release-filters
   branches:


### PR DESCRIPTION
## Description

As it says on the tin.

## Test Plan

This already got used during the last release, but I only put the change on the release branch and never brought it back to master.