### PR TITLE
fix: mobile view icons for experiment header [DET-6011]

### DIFF
--- a/webui/react/src/components/Icon.stories.tsx
+++ b/webui/react/src/components/Icon.stories.tsx
@@ -31,7 +31,7 @@ export const OverflowHorizontal = (): React.ReactNode => <Icon name="overflow-ho
 export const OverflowVertical = (): React.ReactNode => <Icon name="overflow-vertical" />;
 export const Shell = (): React.ReactNode => <Icon name="shell" />;
 export const Star = (): React.ReactNode => <Icon name="star" />;
-export const TensorBoard = (): React.ReactNode => <Icon name="tensorboard" />;
+export const TensorBoard = (): React.ReactNode => <Icon name="tensor-board" />;
 export const TensorFlow = (): React.ReactNode => <Icon name="tensorflow" />;
 export const User = (): React.ReactNode => <Icon name="user" />;
 export const UserSmall = (): React.ReactNode => <Icon name="user-small" />;

--- a/webui/react/src/pages/ExperimentDetails/ExperimentDetailsHeader.module.scss
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentDetailsHeader.module.scss
@@ -8,9 +8,9 @@
   }
   .experimentState {
     align-items: center;
-    justify-content: center;
     border-radius: 20px;
     display: flex;
+    justify-content: center;
     margin-right: var(--theme-sizes-layout-medium);
     padding: var(--theme-sizes-layout-tiny);
 

--- a/webui/react/src/pages/ExperimentDetails/ExperimentDetailsHeader.module.scss
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentDetailsHeader.module.scss
@@ -8,6 +8,7 @@
   }
   .experimentState {
     align-items: center;
+    justify-content: center;
     border-radius: 20px;
     display: flex;
     margin-right: var(--theme-sizes-layout-medium);
@@ -83,7 +84,6 @@
     .trial {
       font-size: var(--theme-sizes-font-medium);
     }
-    [class*=Icon_base_] { display: none; }
   }
 }
 .foldableSection {

--- a/webui/react/src/pages/ExperimentDetails/ExperimentDetailsHeader.tsx
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentDetailsHeader.tsx
@@ -204,7 +204,7 @@ const ExperimentDetailsHeader: React.FC<Props> = ({
         onClick: handleForkClick,
       },
       tensorboard: {
-        icon: <Icon name="tensorboard" size="small" />,
+        icon: <Icon name="tensor-board" size="small" />,
         isLoading: isRunningTensorBoard,
         key: 'tensorboard',
         label: 'TensorBoard',

--- a/webui/react/src/pages/TrialDetails/TrialDetailsHeader.tsx
+++ b/webui/react/src/pages/TrialDetails/TrialDetailsHeader.tsx
@@ -47,7 +47,7 @@ const TrialDetailsHeader: React.FC<Props> = ({
 
     if (!trialWillNeverHaveData(trial)) {
       options.push({
-        icon: <Icon name="tensorboard" size="small" />,
+        icon: <Icon name="tensor-board" size="small" />,
         isLoading: isRunningTensorBoard,
         key: Action.OpenTensorBoard,
         label: 'TensorBoard',


### PR DESCRIPTION
## Description

Display experiment status icon for mobile view.
Place experiment status in the center of tag.
Display tensor board icon where needed.


## Test Plan

Manual tested

