### PR TITLE
fix: Update sample models code for Determined client

### DIFF
--- a/harness/determined/common/experimental/determined.py
+++ b/harness/determined/common/experimental/determined.py
@@ -164,6 +164,17 @@ class Determined:
         r = self._session.get("/api/v1/models/{}".format(model_id))
         return model.Model.from_json(r.json().get("model"), self._session)
 
+    def get_model_by_name(self, name: str) -> model.Model:
+        """
+        Get the :class:`~determined.experimental.Model` from the model registry
+        with the provided name. If no model with that name is found in the registry,
+        an exception is raised.
+        """
+        r = self._session.get("/api/v1/models?name={}".format(name))
+        models = r.json().get("models")
+        assert len(models) > 0
+        return model.Model.from_json(models[0], self._session)
+
     def get_models(
         self,
         sort_by: model.ModelSortBy = model.ModelSortBy.NAME,

--- a/harness/determined/experimental/client.py
+++ b/harness/determined/experimental/client.py
@@ -212,7 +212,7 @@ def create_model(
 def get_model(model_id: int) -> Model:
     """
     Get the :class:`~determined.experimental.client.Model` from the model registry
-    with the provided name. If no model with that name is found in the registry,
+    with the provided numeric id. If no model with that id is found in the registry,
     an exception is raised.
 
     Arguments:
@@ -220,6 +220,22 @@ def get_model(model_id: int) -> Model:
     """
     assert _determined is not None
     return _determined.get_model(model_id)
+
+
+@_require_singleton
+def get_model_by_name(name: str) -> Model:
+    """
+    Get the :class:`~determined.experimental.client.Model` from the model registry
+    with the provided name. If no model with that name is found in the registry,
+    an exception is raised.
+
+    Arguments:
+        name (str): The unique name of the model.
+    """
+    assert _determined is not None
+    matching_models = _determined.get_models(name=name)
+    assert len(matching_models) > 0
+    return matching_models[0]
 
 
 @_require_singleton

--- a/webui/react/src/pages/ModelVersionDetails/ModelVersionHeader.tsx
+++ b/webui/react/src/pages/ModelVersionDetails/ModelVersionHeader.tsx
@@ -130,8 +130,9 @@ const ModelVersionHeader: React.FC<Props> = (
     return (
       `from determined.experimental import Determined
 client = Determined()
-model_entry = client.get_model(name="${modelVersion.model.name}")
-ckpt = model_entry.get_version(${modelVersion.version})
+model_entry = client.get_model_by_name("${modelVersion.model.name}")
+version = model_entry.get_version(${modelVersion.version})
+ckpt = version.checkpoint
       
 ################ Approach 1 ################
 # You can load the trial directly without having to instantiate the model. 


### PR DESCRIPTION
## Description

- Adds `client.get_model_by_name("ABCDE")` to Determined client
- Fix non-working code sample on `/det/models/{model_id}/versions/{version_id}/overview`

## Checklist

- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.