### PR TITLE
chore: support concurrent agents with matching fluent names.

### DIFF
--- a/agent/internal/fluent.go
+++ b/agent/internal/fluent.go
@@ -55,6 +55,7 @@ func removeContainerByName(docker *client.Client, name string) error {
 				if err != nil {
 					return err
 				}
+				break
 			}
 		}
 	}


### PR DESCRIPTION
## Description

When running multiple agents on the same host with fluent container names such as `determined-fluent` and `determined-fluent-2`, the first agent will try to erroneously remove both fluent containers. This may cause issues but itself, but if you run the second at the same time, it'll try to kill its own `determined-fluent-2` as well and hit an error because this container is already being removed.

This is caused by docker's `ContainerList` filtering by prefix (with a possible extra slash) and not exact match. With this fix, we do the exact match on our end.

While this may theoretically happen to a real customer running multiple agents, we don't officially support this configuration, and this change is primarily aimed at local development.

## Test Plan

Run devcluster when multiple agents starting concurrently with fluent container names structured as `prefix` and `prefix-suffix`.

## Commentary (optional)

## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
