### PR TITLE
fix: use different tf on macos

### DIFF
--- a/e2e_tests/tests/requirements.txt
+++ b/e2e_tests/tests/requirements.txt
@@ -5,8 +5,8 @@ pytest-timeout
 pexpect
 torch==1.9.0
 torchvision==0.10.0
-tensorflow==2.4.3; sys_platform != 'darwin'
-tensorflow-macos==2.7.0; sys_platform == 'darwin'
+tensorflow==2.4.3; sys_platform != 'darwin' or platform_machine != 'arm64'
+tensorflow-macos==2.7.0; sys_platform == 'darwin' and platform_machine == 'arm64'
 pandas
 pyyaml
 docker

--- a/e2e_tests/tests/requirements.txt
+++ b/e2e_tests/tests/requirements.txt
@@ -5,7 +5,8 @@ pytest-timeout
 pexpect
 torch==1.9.0
 torchvision==0.10.0
-tensorflow==2.4.3
+tensorflow==2.4.3; sys_platform != 'darwin'
+tensorflow-macos==2.7.0; sys_platform == 'darwin'
 pandas
 pyyaml
 docker

--- a/examples/tests/requirements.txt
+++ b/examples/tests/requirements.txt
@@ -1,7 +1,7 @@
 # pytest 6.0 has linter-breaking changes
 pytest>=6.0.1
-tensorflow==2.4.3; sys_platform != 'darwin'
-tensorflow-macos==2.7.0; sys_platform == 'darwin'
+tensorflow==2.4.3; sys_platform != 'darwin' or platform_machine != 'arm64'
+tensorflow-macos==2.7.0; sys_platform == 'darwin' and platform_machine == 'arm64'
 torch==1.7.1
 torchvision==0.8.2
 pandas==1.0.3

--- a/examples/tests/requirements.txt
+++ b/examples/tests/requirements.txt
@@ -1,6 +1,7 @@
 # pytest 6.0 has linter-breaking changes
 pytest>=6.0.1
-tensorflow==2.4.3
+tensorflow==2.4.3; sys_platform != 'darwin'
+tensorflow-macos==2.7.0; sys_platform == 'darwin'
 torch==1.7.1
 torchvision==0.8.2
 pandas==1.0.3


### PR DESCRIPTION
## Description

Running `make all` on Mac results in
```
ERROR: Could not find a version that satisfies the requirement tensorflow==2.4.3 (from versions: none)
ERROR: No matching distribution found for tensorflow==2.4.3
make[1]: *** [get-deps-pip] Error 1
make: *** [all] Error 2
```

The problem is tensorflow-macos does not exist for 2.4.3; it only begins with 2.5.0.

## Test Plan

Have new users ( @johnkim-det ) try it :)


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ