### PR TITLE
fix: HP viz 'Apply' button style [DET-6442]

### DIFF
--- a/webui/react/src/pages/ExperimentDetails/ExperimentVisualization/ExperimentVisualizationFilters.tsx
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentVisualization/ExperimentVisualizationFilters.tsx
@@ -231,7 +231,7 @@ const ExperimentVisualizationFilters: React.FC<Props> = ({
       )}
       <div className={css.buttons}>
         <IconButton icon="reset" label="Reset" onClick={handleReset} />
-        <IconButton icon="checkmark" label="Apply" type="primary" onClick={handleApply} />
+        <IconButton icon="checkmark" label="Apply" onClick={handleApply} />
       </div>
     </>
   );


### PR DESCRIPTION
## Description
Under "visualization" tab,  the button for "Apply" is not properly styled.

Before:
<img width="1471" alt="Screen Shot 2022-01-20 at 9 55 25 AM" src="https://user-images.githubusercontent.com/40620519/150395867-1c63ecc1-0a0b-4cf0-97f5-2c11e958a9c1.png">

After:
<img width="1481" alt="Screen Shot 2022-01-20 at 9 56 08 AM" src="https://user-images.githubusercontent.com/40620519/150395923-4939fb2c-4626-48b9-ba06-6b09b727b870.png">

## Test Plan
- [ ] Navigate to "visualization" tab the button should look normal instead of disabled under all tabs. 
