### PR TITLE
fix: Allow allocations array to be empty without null value

### DIFF
--- a/master/static/srv/get_task.sql
+++ b/master/static/srv/get_task.sql
@@ -1,11 +1,8 @@
-WITH allo AS (
+SELECT tasks.task_id, (SELECT coalesce(jsonb_agg(allo), '[]'::jsonb) FROM (
   SELECT allocation_id, task_id, state, is_ready, start_time, end_time
   FROM allocations
-  WHERE task_id = $1
+  WHERE task_id = tasks.task_id
   ORDER BY end_time DESC NULLS FIRST
-)
-SELECT tasks.task_id, json_build_array(allo) AS allocations
+) allo) AS allocations
 FROM tasks
-LEFT JOIN allo ON tasks.task_id = allo.task_id
-WHERE tasks.task_id = $1
-GROUP BY tasks.task_id, allo.*;
+WHERE tasks.task_id = $1;

--- a/master/static/srv/get_task.sql
+++ b/master/static/srv/get_task.sql
@@ -1,8 +1,7 @@
-SELECT tasks.task_id, (SELECT coalesce(jsonb_agg(allo), '[]'::jsonb) FROM (
+SELECT tasks.task_id, (SELECT coalesce(jsonb_agg(allo ORDER BY end_time DESC NULLS FIRST), '[]'::jsonb) FROM (
   SELECT allocation_id, task_id, state, is_ready, start_time, end_time
   FROM allocations
-  WHERE task_id = tasks.task_id
-  ORDER BY end_time DESC NULLS FIRST
+  WHERE allocations.task_id = tasks.task_id
 ) allo) AS allocations
 FROM tasks
 WHERE tasks.task_id = $1;

--- a/webui/react/src/pages/Wait.tsx
+++ b/webui/react/src/pages/Wait.tsx
@@ -62,7 +62,7 @@ const Wait: React.FC = () => {
     const ival = setInterval(async () => {
       try {
         const response = await getTask({ taskId });
-        if (!response) {
+        if (!response?.allocations?.length) {
           return;
         }
         const lastRun = response.allocations[0];


### PR DESCRIPTION
Fixes an issue in the new GRPC Tasks API, so that before a task gets an allocation, the Task can return an empty array  of Allocations instead of a null (causes a SQL/proto error)