### PR TITLE
build: make -C master doesn't call make fmt

### DIFF
--- a/master/Makefile
+++ b/master/Makefile
@@ -33,7 +33,7 @@ build/mock_gen.stamp: $(MOCK_GENERATION_INPUTS)
 	mockery --name=DB --dir=internal/db --output internal/mocks --filename db.go
 	mockery --name=Reservation --dir=internal/sproto --output internal/mocks --filename reservation.go
 	# fmt once since the mocks are not generated formatted.
-	$(MAKE) fmt
+	goimports -l -local github.com/determined-ai -w ./internal/mocks
 	mkdir -p build
 	touch $@
 

--- a/master/internal/resourcemanagers/task_list_test.go
+++ b/master/internal/resourcemanagers/task_list_test.go
@@ -4,8 +4,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/determined-ai/determined/master/pkg/actor"
 	"gotest.tools/assert"
+
+	"github.com/determined-ai/determined/master/pkg/actor"
 )
 
 func TestAllocateRequestComparator(t *testing.T) {


### PR DESCRIPTION
Also fix a file that wasn't formatted as a result of the accidental make
fmt.
