### PR TITLE
build: fix make -C harness clean

### DIFF
--- a/bindings/Makefile
+++ b/bindings/Makefile
@@ -2,7 +2,7 @@ SWAGGER_SPEC := ../proto/build/swagger/determined/api/v1/api.swagger.json
 CODEGEN_BIN := swagger-codegen-cli-2.4.14.jar
 py_bindings_dest := ../harness/determined/common/api/bindings.py
 ts_bindings_dest := ../webui/react/src/services/api-ts-sdk
-py_generator = generate_bindings.py
+py_generator := generate_bindings.py
 
 .PHONY: all
 all: get-deps
@@ -62,7 +62,7 @@ clean-deps:
 
 .PHONY: clean
 clean:
-	rm -rf build/
+	rm -rf build/ $(py_bindings_dest) $(ts_bindings_dest)
 
 .PHONY: clean-all
 clean-all: clean clean-deps

--- a/harness/Makefile
+++ b/harness/Makefile
@@ -1,7 +1,7 @@
 py_bindings_dest=determined/common/api/bindings.py
 
 .PHONY: build
-build: gen $(py_bindings_dest)
+build: gen
 	python -W ignore:Normalizing:UserWarning:setuptools.dist setup.py -q bdist_wheel
 
 .PHONY: publish
@@ -43,7 +43,6 @@ clean: ungen
 	rm -rf pip-wheel-metadata/
 	rm -rf dist/
 	rm -rf build/
-	rm $(py_bindings_dest)
 	find . \( -name __pycache__ -o -name \*.pyc \) -delete
 
 AWS_TEMPLATES_PATH := determined/deploy/aws/templates


### PR DESCRIPTION
This also fixes make devcluster, which invokes:

    make -C harness clean build

as one of its startup steps.