### PR TITLE
ci: increase timeouts for GKE cluster creation, move notifications from #ml-ag to #ci-bots.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2453,7 +2453,6 @@ workflows:
               parallelism: [2]
               cluster-id-prefix: ["nightly"]
               mark: ["nightly"]
-              slack-mentions: ["${SLACK_USER_ID}"]
       - test-e2e-aws:
           name: test-e2e-gpu-distributed
           context: aws
@@ -2464,7 +2463,6 @@ workflows:
               compute-agent-instance-type: ["p2.8xlarge"]
               aux-agent-instance-type: ["m5.large"]
               max-dynamic-agents: [2]
-              slack-mentions: ["${SLACK_USER_ID}"]
       - test-e2e-aws:
           name: test-e2e-gpu-transformers
           context: aws
@@ -2475,7 +2473,6 @@ workflows:
               compute-agent-instance-type: ["p2.8xlarge"]
               aux-agent-instance-type: ["m5.large"]
               max-dynamic-agents: [2]
-              slack-mentions: ["${SLACK_USER_ID}"]
       - test-e2e-aws:
           name: test-e2e-gpu-transformers-amp
           context: aws
@@ -2486,7 +2483,6 @@ workflows:
               compute-agent-instance-type: ["p2.8xlarge"]
               aux-agent-instance-type: ["m5.large"]
               max-dynamic-agents: [2]
-              slack-mentions: ["${SLACK_USER_ID}"]
       - test-e2e-aws:
           name: test-e2e-gpu-mmdetection
           context: aws
@@ -2497,7 +2493,6 @@ workflows:
               compute-agent-instance-type: ["p2.8xlarge"]
               aux-agent-instance-type: ["m5.large"]
               max-dynamic-agents: [2]
-              slack-mentions: ["${SLACK_USER_ID}"]
       - test-e2e-aws:
           name: test-e2e-cpu-distributed
           context: aws
@@ -2509,7 +2504,6 @@ workflows:
               environment-gpu-enabled: ["0"]
               aux-agent-instance-type: ["m5.large"]
               max-dynamic-agents: [16]
-              slack-mentions: ["${SLACK_USER_ID}"]
 
   weekly-cuda-11:
     triggers:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -606,6 +606,7 @@ commands:
       - run:
           command: gcloud container clusters create ${CLUSTER_ID} --machine-type=n1-standard-8 --cluster-version=<<parameters.gke-version>> --region=<<parameters.region>> --node-locations=<<parameters.node-locations>> --scopes storage-rw,cloud-platform --num-nodes 1 --labels environment=ci
           name: Create GKE cluster
+          no_output_timeout: 30m
       - run:
           command: gcloud container clusters get-credentials ${CLUSTER_ID} --project determined-ai --region <<parameters.region>>
           name: Get Kubeconfig
@@ -706,6 +707,7 @@ commands:
       - run:
           command: gcloud container clusters create ${CLUSTER_ID} --machine-type=n1-standard-8 --cluster-version=<<parameters.gke-version>> --region=<<parameters.region>> --node-locations=<<parameters.node-locations>> --scopes storage-rw,cloud-platform --num-nodes 1
           name: Create GKE cluster
+          no_output_timeout: 30m
       - run:
           command: gcloud container node-pools create accel --cluster ${CLUSTER_ID} --region <<parameters.region>> --num-nodes <<parameters.num-machines>> --accelerator type=<<parameters.gpu-type>>,count=<<parameters.gpus-per-machine>> --machine-type=<<parameters.machine-type>> --scopes cloud-platform
           name: Create GPU node pool
@@ -2451,8 +2453,7 @@ workflows:
               parallelism: [2]
               cluster-id-prefix: ["nightly"]
               mark: ["nightly"]
-              slack-mentions: ["channel"]
-              slack-channel: ["ml-ag"]
+              slack-mentions: ["${SLACK_USER_ID}"]
       - test-e2e-aws:
           name: test-e2e-gpu-distributed
           context: aws
@@ -2463,8 +2464,7 @@ workflows:
               compute-agent-instance-type: ["p2.8xlarge"]
               aux-agent-instance-type: ["m5.large"]
               max-dynamic-agents: [2]
-              slack-mentions: ["channel"]
-              slack-channel: ["ml-ag"]
+              slack-mentions: ["${SLACK_USER_ID}"]
       - test-e2e-aws:
           name: test-e2e-gpu-transformers
           context: aws
@@ -2475,8 +2475,7 @@ workflows:
               compute-agent-instance-type: ["p2.8xlarge"]
               aux-agent-instance-type: ["m5.large"]
               max-dynamic-agents: [2]
-              slack-mentions: ["channel"]
-              slack-channel: ["ml-ag"]
+              slack-mentions: ["${SLACK_USER_ID}"]
       - test-e2e-aws:
           name: test-e2e-gpu-transformers-amp
           context: aws
@@ -2487,8 +2486,7 @@ workflows:
               compute-agent-instance-type: ["p2.8xlarge"]
               aux-agent-instance-type: ["m5.large"]
               max-dynamic-agents: [2]
-              slack-mentions: ["channel"]
-              slack-channel: ["ml-ag"]
+              slack-mentions: ["${SLACK_USER_ID}"]
       - test-e2e-aws:
           name: test-e2e-gpu-mmdetection
           context: aws
@@ -2499,8 +2497,7 @@ workflows:
               compute-agent-instance-type: ["p2.8xlarge"]
               aux-agent-instance-type: ["m5.large"]
               max-dynamic-agents: [2]
-              slack-mentions: ["channel"]
-              slack-channel: ["ml-ag"]
+              slack-mentions: ["${SLACK_USER_ID}"]
       - test-e2e-aws:
           name: test-e2e-cpu-distributed
           context: aws
@@ -2512,8 +2509,7 @@ workflows:
               environment-gpu-enabled: ["0"]
               aux-agent-instance-type: ["m5.large"]
               max-dynamic-agents: [16]
-              slack-mentions: ["channel"]
-              slack-channel: ["ml-ag"]
+              slack-mentions: ["${SLACK_USER_ID}"]
 
   weekly-cuda-11:
     triggers:


### PR DESCRIPTION
## Description

- Bump GKE cluster creation timeout to 30 minutes.
- Move current #ml-ag notifications to #ci-bots. Since it's not valuable to notify neither the entire channel or the last committer for these nightly tests, remove the mentions.

## Test Plan

N/A

## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
