### PR TITLE
fix: update task list Resource Pool sorter to alphaNumericSorter [DET-6434]

### DIFF
--- a/webui/react/src/pages/TaskList.tsx
+++ b/webui/react/src/pages/TaskList.tsx
@@ -334,7 +334,7 @@ const TaskList: React.FC = () => {
       {
         dataIndex: 'resourcePool',
         key: 'resourcePool',
-        sorter: true,
+        sorter: (a: CommandTask, b: CommandTask): number => alphaNumericSorter(a.resourcePool, b.resourcePool),
         title: 'Resource Pool',
       },
       {

--- a/webui/react/src/pages/TaskList.tsx
+++ b/webui/react/src/pages/TaskList.tsx
@@ -334,8 +334,8 @@ const TaskList: React.FC = () => {
       {
         dataIndex: 'resourcePool',
         key: 'resourcePool',
-        sorter: (a: CommandTask, b: CommandTask): number => 
-            alphaNumericSorter(a.resourcePool, b.resourcePool),
+        sorter: (a: CommandTask, b: CommandTask): number =>
+          alphaNumericSorter(a.resourcePool, b.resourcePool),
         title: 'Resource Pool',
       },
       {

--- a/webui/react/src/pages/TaskList.tsx
+++ b/webui/react/src/pages/TaskList.tsx
@@ -334,7 +334,8 @@ const TaskList: React.FC = () => {
       {
         dataIndex: 'resourcePool',
         key: 'resourcePool',
-        sorter: (a: CommandTask, b: CommandTask): number => alphaNumericSorter(a.resourcePool, b.resourcePool),
+        sorter: (a: CommandTask, b: CommandTask): number => 
+            alphaNumericSorter(a.resourcePool, b.resourcePool),
         title: 'Resource Pool',
       },
       {


### PR DESCRIPTION
## Description 
Update task list "Resource Pool" column sorting to sort by alphabetical order.

Before:

https://user-images.githubusercontent.com/40620519/150424829-4b798328-d27e-4df6-80e3-05f089f1ba9b.mov

After:

https://user-images.githubusercontent.com/40620519/150424869-6f5ae74b-7284-4be9-88cd-b5f557c9b94f.mov

## Test Plan
- [ ] Navigate to "Tasks", click on "Resource Pool" header to verify sorting works.
