### PR TITLE
feat: additional pytorch callbacks [DET-5180]

### DIFF
--- a/docs/release-notes/3479-new-pytorch-callback-method.txt
+++ b/docs/release-notes/3479-new-pytorch-callback-method.txt
@@ -1,0 +1,5 @@
+:orphan:
+
+**New Features**
+
+- API: Add ``on_training_epoch_end`` to PytorchCallback. Add ``epoch_idx`` argument to ``on_training_epoch_start``.

--- a/docs/release-notes/3479-new-pytorch-callback-method.txt
+++ b/docs/release-notes/3479-new-pytorch-callback-method.txt
@@ -2,4 +2,5 @@
 
 **New Features**
 
-- API: Add ``on_training_epoch_end`` to PytorchCallback. Add ``epoch_idx`` argument to ``on_training_epoch_start``.
+-  API: Add ``on_training_epoch_end`` to PytorchCallback. Add ``epoch_idx`` argument to
+   ``on_training_epoch_start``.

--- a/docs/release-notes/3479-new-pytorch-callback-method.txt
+++ b/docs/release-notes/3479-new-pytorch-callback-method.txt
@@ -3,4 +3,6 @@
 **New Features**
 
 -  API: Add ``on_training_epoch_end`` to PytorchCallback. Add ``epoch_idx`` argument to
-   ``on_training_epoch_start``.
+   ``on_training_epoch_start``. Overriding ``on_training_epoch_start`` without ``epoch_idx``
+   argument is still supported for backwards compatibility but using this outdated signature is
+   discouraged.

--- a/harness/determined/pytorch/_callback.py
+++ b/harness/determined/pytorch/_callback.py
@@ -91,7 +91,7 @@ class PyTorchCallback:
         """
         pass
 
-    def on_training_batch_start(self) -> None:
+    def on_training_batch_start(self, batch_idx: int) -> None:
         """
         Run on start of a new training batch
         """
@@ -103,7 +103,7 @@ class PyTorchCallback:
         """
         pass
 
-    def on_training_epoch_start(self) -> None:
+    def on_training_epoch_start(self, epoch_idx: int) -> None:
         """
         Run on start of a new training epoch
         """

--- a/harness/determined/pytorch/_callback.py
+++ b/harness/determined/pytorch/_callback.py
@@ -91,6 +91,18 @@ class PyTorchCallback:
         """
         pass
 
+    def on_training_batch_start(self) -> None:
+        """
+        Run on start of a new training batch
+        """
+        pass
+
+    def on_training_batch_end(self, batch_idx: int) -> None:
+        """
+        Run on end of a training batch
+        """
+        pass
+
     def on_training_epoch_start(self) -> None:
         """
         Run on start of a new training epoch

--- a/harness/determined/pytorch/_callback.py
+++ b/harness/determined/pytorch/_callback.py
@@ -91,19 +91,22 @@ class PyTorchCallback:
         """
         pass
 
-    def on_training_batch_start(self, epoch_idx, batch_idx: int) -> None:
+    def on_training_batch_start(self, epoch_idx: int, batch_idx: int) -> None:
         """
         Run on start of a new training batch
         """
         pass
 
-    def on_training_batch_end(self, epoch_idx: int, batch_idx: int) -> None:
+    def on_training_batch_end(
+        self, epoch_idx: int, batch_idx: int, batch_metrics: Dict[str, Any]
+    ) -> None:
         """
         Run on end of a training batch
 
         Arguments:
             epoch_idx (int): index of the current epoch
             batch_idx (int): global batch index (does not get reset between epochs)
+            batch_metrics (Dict[str, Any]): metrics for this batch
         """
         pass
 

--- a/harness/determined/pytorch/_callback.py
+++ b/harness/determined/pytorch/_callback.py
@@ -97,6 +97,12 @@ class PyTorchCallback:
         """
         pass
 
+    def on_training_epoch_end(self, epoch_idx: int) -> None:
+        """
+        Run on end of a training epoch
+        """
+        pass
+
     def on_validation_epoch_start(self) -> None:
         """
         Run on start of a new validation epoch

--- a/harness/determined/pytorch/_callback.py
+++ b/harness/determined/pytorch/_callback.py
@@ -91,15 +91,19 @@ class PyTorchCallback:
         """
         pass
 
-    def on_training_batch_start(self, batch_idx: int) -> None:
+    def on_training_batch_start(self, epoch_idx, batch_idx: int) -> None:
         """
         Run on start of a new training batch
         """
         pass
 
-    def on_training_batch_end(self, batch_idx: int) -> None:
+    def on_training_batch_end(self, epoch_idx: int, batch_idx: int) -> None:
         """
         Run on end of a training batch
+
+        Arguments:
+            epoch_idx (int): index of the current epoch
+            batch_idx (int): global batch index (does not get reset between epochs)
         """
         pass
 

--- a/harness/determined/pytorch/_callback.py
+++ b/harness/determined/pytorch/_callback.py
@@ -91,25 +91,6 @@ class PyTorchCallback:
         """
         pass
 
-    def on_training_batch_start(self, epoch_idx: int, batch_idx: int) -> None:
-        """
-        Run on start of a new training batch
-        """
-        pass
-
-    def on_training_batch_end(
-        self, epoch_idx: int, batch_idx: int, batch_metrics: Dict[str, Any]
-    ) -> None:
-        """
-        Run on end of a training batch
-
-        Arguments:
-            epoch_idx (int): index of the current epoch
-            batch_idx (int): global batch index (does not get reset between epochs)
-            batch_metrics (Dict[str, Any]): metrics for this batch
-        """
-        pass
-
     def on_training_epoch_start(self, epoch_idx: int) -> None:
         """
         Run on start of a new training epoch

--- a/harness/determined/pytorch/_pytorch_trial.py
+++ b/harness/determined/pytorch/_pytorch_trial.py
@@ -397,7 +397,7 @@ class PyTorchTrialController(det.TrialController):
                                 "on_training_epoch_start() without parameters is deprecated."
                                 "Please add epoch_idx parameter"
                             )
-                            callback.on_training_epoch_start()
+                            callback.on_training_epoch_start()  # type: ignore[call-arg]
 
             self.context._loss_ids = {}
             for callback in self.callbacks.values():

--- a/harness/determined/pytorch/_pytorch_trial.py
+++ b/harness/determined/pytorch/_pytorch_trial.py
@@ -391,7 +391,7 @@ class PyTorchTrialController(det.TrialController):
             self.context._loss_ids = {}
             for callback in self.callbacks.values():
                 with self.prof.record_timing(
-                        f"callbacks.{callback.__class__.__name__}.on_training_batch_start"
+                    f"callbacks.{callback.__class__.__name__}.on_training_batch_start"
                 ):
                     callback.on_training_batch_start()
 
@@ -443,7 +443,7 @@ class PyTorchTrialController(det.TrialController):
 
             for callback in self.callbacks.values():
                 with self.prof.record_timing(
-                        f"callbacks.{callback.__class__.__name__}.on_training_batch_end"
+                    f"callbacks.{callback.__class__.__name__}.on_training_batch_end"
                 ):
                     callback.on_training_batch_end(batch_idx)
 

--- a/harness/determined/pytorch/_pytorch_trial.py
+++ b/harness/determined/pytorch/_pytorch_trial.py
@@ -394,8 +394,8 @@ class PyTorchTrialController(det.TrialController):
                             callback.on_training_epoch_start(epoch_idx)
                         else:
                             logging.warning(
-                                "on_training_epoch_start() without parameters is deprecated."
-                                "Please add epoch_idx parameter"
+                                "on_training_epoch_start() without parameters is deprecated in 0.17.7."
+                                " Please add epoch_idx parameter"
                             )
                             callback.on_training_epoch_start()  # type: ignore[call-arg]
 

--- a/harness/determined/pytorch/_pytorch_trial.py
+++ b/harness/determined/pytorch/_pytorch_trial.py
@@ -436,6 +436,14 @@ class PyTorchTrialController(det.TrialController):
             self.prof.record_metric("samples_per_second", samples_per_second)
             per_batch_metrics.append(tr_metrics)
 
+            if self.context.is_epoch_end():
+                epoch_idx = self.get_epoch_idx(batch_idx)
+                for callback in self.callbacks.values():
+                    with self.prof.record_timing(
+                        f"callbacks.{callback.__class__.__name__}.on_training_epoch_end"
+                    ):
+                        callback.on_training_epoch_end(epoch_idx)
+
         # Aggregate and reduce training metrics from all the training processes.
         if self.context.distributed.size > 1 and self.context._average_training_metrics:
             with self.prof.record_timing("average_training_metrics"):

--- a/harness/determined/pytorch/_pytorch_trial.py
+++ b/harness/determined/pytorch/_pytorch_trial.py
@@ -394,8 +394,8 @@ class PyTorchTrialController(det.TrialController):
                             callback.on_training_epoch_start(epoch_idx)
                         else:
                             logging.warning(
-                                "on_training_epoch_start() without parameters is deprecated in 0.17.7."
-                                " Please add epoch_idx parameter"
+                                "on_training_epoch_start() without parameters is deprecated"
+                                " in 0.17.7. Please add epoch_idx parameter."
                             )
                             callback.on_training_epoch_start()  # type: ignore[call-arg]
 

--- a/harness/determined/pytorch/_pytorch_trial.py
+++ b/harness/determined/pytorch/_pytorch_trial.py
@@ -395,7 +395,7 @@ class PyTorchTrialController(det.TrialController):
                         else:
                             logging.warning(
                                 "on_training_epoch_start() without parameters is deprecated"
-                                " in 0.17.7. Please add epoch_idx parameter."
+                                " in 0.17.8. Please add epoch_idx parameter."
                             )
                             callback.on_training_epoch_start()  # type: ignore[call-arg]
 

--- a/harness/determined/pytorch/_pytorch_trial.py
+++ b/harness/determined/pytorch/_pytorch_trial.py
@@ -395,7 +395,7 @@ class PyTorchTrialController(det.TrialController):
                         else:
                             logging.warning(
                                 "on_training_epoch_start() without parameters is deprecated"
-                                " in 0.17.8. Please add epoch_idx parameter."
+                                " since 0.17.8. Please add epoch_idx parameter."
                             )
                             callback.on_training_epoch_start()  # type: ignore[call-arg]
 

--- a/harness/determined/pytorch/_pytorch_trial.py
+++ b/harness/determined/pytorch/_pytorch_trial.py
@@ -389,6 +389,11 @@ class PyTorchTrialController(det.TrialController):
                     ):
                         callback.on_training_epoch_start()
             self.context._loss_ids = {}
+            for callback in self.callbacks.values():
+                with self.prof.record_timing(
+                        f"callbacks.{callback.__class__.__name__}.on_training_batch_start"
+                ):
+                    callback.on_training_batch_start()
 
             with self.prof.record_timing("train_batch", requires_sync=False):
                 if self.context.profiler:
@@ -435,6 +440,12 @@ class PyTorchTrialController(det.TrialController):
             samples_per_second *= self.context.distributed.size
             self.prof.record_metric("samples_per_second", samples_per_second)
             per_batch_metrics.append(tr_metrics)
+
+            for callback in self.callbacks.values():
+                with self.prof.record_timing(
+                        f"callbacks.{callback.__class__.__name__}.on_training_batch_end"
+                ):
+                    callback.on_training_batch_end(batch_idx)
 
             if self.context.is_epoch_end():
                 epoch_idx = self.get_epoch_idx(batch_idx)

--- a/harness/determined/pytorch/_pytorch_trial.py
+++ b/harness/determined/pytorch/_pytorch_trial.py
@@ -457,7 +457,7 @@ class PyTorchTrialController(det.TrialController):
                 with self.prof.record_timing(
                     f"callbacks.{callback.__class__.__name__}.on_training_batch_end"
                 ):
-                    callback.on_training_batch_end(epoch_idx, batch_idx)
+                    callback.on_training_batch_end(epoch_idx, batch_idx, tr_metrics)
 
             if self.context.is_epoch_end():
                 for callback in self.callbacks.values():

--- a/harness/determined/pytorch/_pytorch_trial.py
+++ b/harness/determined/pytorch/_pytorch_trial.py
@@ -401,11 +401,6 @@ class PyTorchTrialController(det.TrialController):
 
             self.context._loss_ids = {}
             epoch_idx = self.get_epoch_idx(batch_idx)
-            for callback in self.callbacks.values():
-                with self.prof.record_timing(
-                    f"callbacks.{callback.__class__.__name__}.on_training_batch_start"
-                ):
-                    callback.on_training_batch_start(epoch_idx, batch_idx)
 
             with self.prof.record_timing("train_batch", requires_sync=False):
                 if self.context.profiler:
@@ -452,12 +447,6 @@ class PyTorchTrialController(det.TrialController):
             samples_per_second *= self.context.distributed.size
             self.prof.record_metric("samples_per_second", samples_per_second)
             per_batch_metrics.append(tr_metrics)
-
-            for callback in self.callbacks.values():
-                with self.prof.record_timing(
-                    f"callbacks.{callback.__class__.__name__}.on_training_batch_end"
-                ):
-                    callback.on_training_batch_end(epoch_idx, batch_idx, tr_metrics)
 
             if self.context.is_epoch_end():
                 for callback in self.callbacks.values():

--- a/harness/determined/pytorch/_pytorch_trial.py
+++ b/harness/determined/pytorch/_pytorch_trial.py
@@ -383,8 +383,8 @@ class PyTorchTrialController(det.TrialController):
                     batch = self.context.to_device(batch)
 
             self.context._current_batch_idx = batch_idx
+            epoch_idx = self.get_epoch_idx(batch_idx)
             if self.context.is_epoch_start():
-                epoch_idx = self.get_epoch_idx(batch_idx)
                 for callback in self.callbacks.values():
                     with self.prof.record_timing(
                         f"callbacks.{callback.__class__.__name__}.on_training_epoch_start"
@@ -400,7 +400,6 @@ class PyTorchTrialController(det.TrialController):
                             callback.on_training_epoch_start()  # type: ignore[call-arg]
 
             self.context._loss_ids = {}
-            epoch_idx = self.get_epoch_idx(batch_idx)
 
             with self.prof.record_timing("train_batch", requires_sync=False):
                 if self.context.profiler:

--- a/harness/determined/pytorch/lightning/_adapter.py
+++ b/harness/determined/pytorch/lightning/_adapter.py
@@ -215,7 +215,7 @@ class LightningAdapter(PyTorchTrial):
         lm = self._pls.lm
 
         class LightningAdapterCallback(PyTorchCallback):
-            def on_training_epoch_start(self) -> None:
+            def on_training_epoch_start(self, epoch_idx: int) -> None:
                 if context._current_batch_idx is not None:
                     type(lm).current_epoch = context.current_train_epoch()  # type: ignore
                 lm.on_train_epoch_start()

--- a/harness/determined/pytorch/lightning/_adapter.py
+++ b/harness/determined/pytorch/lightning/_adapter.py
@@ -220,6 +220,9 @@ class LightningAdapter(PyTorchTrial):
                     type(lm).current_epoch = context.current_train_epoch()  # type: ignore
                 lm.on_train_epoch_start()
 
+            def on_training_epoch_end(self, epoch_idx: int) -> None:
+                lm.on_train_epoch_end()
+
             def on_validation_epoch_start(self) -> None:
                 lm.on_validation_epoch_start()
 

--- a/harness/determined/pytorch/lightning/_adapter.py
+++ b/harness/determined/pytorch/lightning/_adapter.py
@@ -40,7 +40,6 @@ def check_compatibility(lm: pl.LightningModule) -> None:
         "on_test_batch_start",
         "on_test_epoch_end",
         "on_test_epoch_start",
-        "on_train_epoch_end",
         "optimizer_step",
         "optimizer_zero_grad",
         "setup",

--- a/harness/tests/experiment/fixtures/pytorch_xor_model.py
+++ b/harness/tests/experiment/fixtures/pytorch_xor_model.py
@@ -299,8 +299,6 @@ class Counter(det.pytorch.PyTorchCallback):
         self.checkpoints_ended = 0
         self.training_started_times = 0
         self.training_epochs_started = 0
-        self.training_batches_started = 0
-        self.training_batches_ended = 0
         self.training_epochs_ended = 0
 
     def on_validation_start(self) -> None:
@@ -315,16 +313,6 @@ class Counter(det.pytorch.PyTorchCallback):
     def on_training_start(self) -> None:
         logging.debug("starting training")
         self.training_started_times += 1
-
-    def on_training_batch_start(self, epoch_idx: int, batch_idx: int) -> None:
-        logging.debug(f"epoch {epoch_idx}, starting batch {batch_idx}")
-        self.training_batches_started += 1
-
-    def on_training_batch_end(
-        self, epoch_idx: int, batch_idx: int, batch_metrics: Dict[str, Any]
-    ) -> None:
-        logging.debug(f"epoch {epoch_idx}, ending batch {batch_idx}; metrics={batch_metrics}")
-        self.training_batches_ended += 1
 
     def on_training_epoch_start(self) -> None:
         logging.debug("starting epoch")

--- a/harness/tests/experiment/fixtures/pytorch_xor_model.py
+++ b/harness/tests/experiment/fixtures/pytorch_xor_model.py
@@ -316,8 +316,8 @@ class Counter(det.pytorch.PyTorchCallback):
         logging.debug("starting training")
         self.training_started_times += 1
 
-    def on_training_batch_start(self) -> None:
-        logging.debug("starting batch")
+    def on_training_batch_start(self, batch_idx: int) -> None:
+        logging.debug(f"starting batch {batch_idx}")
         self.training_batches_started += 1
 
     def on_training_batch_end(self, batch_idx: int) -> None:

--- a/harness/tests/experiment/fixtures/pytorch_xor_model.py
+++ b/harness/tests/experiment/fixtures/pytorch_xor_model.py
@@ -1,4 +1,5 @@
 # type: ignore
+import logging
 from typing import Any, Dict, cast
 
 import numpy as np
@@ -296,6 +297,9 @@ class Counter(det.pytorch.PyTorchCallback):
         self.validation_steps_started = 0
         self.validation_steps_ended = 0
         self.checkpoints_ended = 0
+        self.training_started_times = 0
+        self.training_epochs_started = 0
+        self.training_epochs_ended = 0
 
     def on_validation_start(self) -> None:
         self.validation_steps_started += 1
@@ -305,6 +309,18 @@ class Counter(det.pytorch.PyTorchCallback):
 
     def on_checkpoint_end(self, checkpoint_dir: str):
         self.checkpoints_ended += 1
+
+    def on_training_start(self) -> None:
+        logging.debug("starting training")
+        self.training_started_times += 1
+
+    def on_training_epoch_start(self) -> None:
+        logging.debug("starting epoch")
+        self.training_epochs_started += 1
+
+    def on_training_epoch_end(self, epoch_idx: int) -> None:
+        logging.debug(f"end of an epoch {epoch_idx}")
+        self.training_epochs_ended += 1
 
     def state_dict(self) -> Dict[str, Any]:
         return self.__dict__

--- a/harness/tests/experiment/fixtures/pytorch_xor_model.py
+++ b/harness/tests/experiment/fixtures/pytorch_xor_model.py
@@ -329,15 +329,31 @@ class Counter(det.pytorch.PyTorchCallback):
         self.__dict__ = state_dict
 
 
+class EphemeralLegacyCallbackCounter(det.pytorch.PyTorchCallback):
+    """
+    Callback with legacy signature for on_training_epoch_start
+    that takes no arguments. It is ephemeral: it does not implement
+    state_dict and load_state_dict.
+    """
+
+    def __init__(self) -> None:
+        self.legacy_on_training_epochs_start_calls = 0
+
+    def on_training_epoch_start(self) -> None:
+        logging.debug(f"calling {__name__} without arguments")
+        self.legacy_on_training_epochs_start_calls += 1
+
+
 class XORTrialCallbacks(XORTrialMulti):
     def __init__(self, context: pytorch.PyTorchTrialContext) -> None:
         super().__init__(context)
 
         self.context = context
         self.counter = Counter()
+        self.legacy_counter = EphemeralLegacyCallbackCounter()
 
     def build_callbacks(self) -> Dict[str, det.pytorch.PyTorchCallback]:
-        return {"counter": self.counter}
+        return {"counter": self.counter, "legacyCounter": self.legacy_counter}
 
 
 class XORTrialAccessContext(BaseXORTrial):

--- a/harness/tests/experiment/fixtures/pytorch_xor_model.py
+++ b/harness/tests/experiment/fixtures/pytorch_xor_model.py
@@ -299,6 +299,8 @@ class Counter(det.pytorch.PyTorchCallback):
         self.checkpoints_ended = 0
         self.training_started_times = 0
         self.training_epochs_started = 0
+        self.training_batches_started = 0
+        self.training_batches_ended = 0
         self.training_epochs_ended = 0
 
     def on_validation_start(self) -> None:
@@ -314,12 +316,20 @@ class Counter(det.pytorch.PyTorchCallback):
         logging.debug("starting training")
         self.training_started_times += 1
 
+    def on_training_batch_start(self) -> None:
+        logging.debug("starting batch")
+        self.training_batches_started += 1
+
+    def on_training_batch_end(self, batch_idx: int) -> None:
+        logging.debug(f"ending batch {batch_idx}")
+        self.training_batches_ended += 1
+
     def on_training_epoch_start(self) -> None:
         logging.debug("starting epoch")
         self.training_epochs_started += 1
 
     def on_training_epoch_end(self, epoch_idx: int) -> None:
-        logging.debug(f"end of an epoch {epoch_idx}")
+        logging.debug(f"end of epoch {epoch_idx}")
         self.training_epochs_ended += 1
 
     def state_dict(self) -> Dict[str, Any]:

--- a/harness/tests/experiment/fixtures/pytorch_xor_model.py
+++ b/harness/tests/experiment/fixtures/pytorch_xor_model.py
@@ -320,8 +320,10 @@ class Counter(det.pytorch.PyTorchCallback):
         logging.debug(f"epoch {epoch_idx}, starting batch {batch_idx}")
         self.training_batches_started += 1
 
-    def on_training_batch_end(self, epoch_idx: int, batch_idx: int) -> None:
-        logging.debug(f"epoch {epoch_idx}, ending batch {batch_idx}")
+    def on_training_batch_end(
+        self, epoch_idx: int, batch_idx: int, batch_metrics: Dict[str, Any]
+    ) -> None:
+        logging.debug(f"epoch {epoch_idx}, ending batch {batch_idx}; metrics={batch_metrics}")
         self.training_batches_ended += 1
 
     def on_training_epoch_start(self) -> None:

--- a/harness/tests/experiment/fixtures/pytorch_xor_model.py
+++ b/harness/tests/experiment/fixtures/pytorch_xor_model.py
@@ -314,8 +314,8 @@ class Counter(det.pytorch.PyTorchCallback):
         logging.debug("starting training")
         self.training_started_times += 1
 
-    def on_training_epoch_start(self) -> None:
-        logging.debug("starting epoch")
+    def on_training_epoch_start(self, epoch_idx) -> None:
+        logging.debug(f"starting epoch {epoch_idx}")
         self.training_epochs_started += 1
 
     def on_training_epoch_end(self, epoch_idx: int) -> None:

--- a/harness/tests/experiment/fixtures/pytorch_xor_model.py
+++ b/harness/tests/experiment/fixtures/pytorch_xor_model.py
@@ -316,12 +316,12 @@ class Counter(det.pytorch.PyTorchCallback):
         logging.debug("starting training")
         self.training_started_times += 1
 
-    def on_training_batch_start(self, batch_idx: int) -> None:
-        logging.debug(f"starting batch {batch_idx}")
+    def on_training_batch_start(self, epoch_idx: int, batch_idx: int) -> None:
+        logging.debug(f"epoch {epoch_idx}, starting batch {batch_idx}")
         self.training_batches_started += 1
 
-    def on_training_batch_end(self, batch_idx: int) -> None:
-        logging.debug(f"ending batch {batch_idx}")
+    def on_training_batch_end(self, epoch_idx: int, batch_idx: int) -> None:
+        logging.debug(f"epoch {epoch_idx}, ending batch {batch_idx}")
         self.training_batches_ended += 1
 
     def on_training_epoch_start(self) -> None:

--- a/harness/tests/experiment/pytorch/test_pytorch_trial.py
+++ b/harness/tests/experiment/pytorch/test_pytorch_trial.py
@@ -321,7 +321,7 @@ class TestPyTorchTrial:
         def make_workloads1() -> workload.Stream:
             nonlocal controller
 
-            yield workload.train_workload(1, 1, 0, 2), workload.ignore_workload_response
+            yield workload.train_workload(1, 1, 0, 4), workload.ignore_workload_response
             assert controller is not None, "controller was never set!"
             assert controller.trial.counter.__dict__ == {
                 "validation_steps_started": 0,
@@ -330,6 +330,8 @@ class TestPyTorchTrial:
                 "training_started_times": 1,
                 "training_epochs_started": 2,
                 "training_epochs_ended": 2,
+                "training_batches_started": 4,
+                "training_batches_ended": 4,
             }
 
             yield workload.validation_workload(), workload.ignore_workload_response
@@ -340,6 +342,8 @@ class TestPyTorchTrial:
                 "training_started_times": 1,
                 "training_epochs_started": 2,
                 "training_epochs_ended": 2,
+                "training_batches_started": 4,
+                "training_batches_ended": 4,
             }
 
             interceptor = workload.WorkloadResponseInterceptor()
@@ -354,11 +358,15 @@ class TestPyTorchTrial:
                 "training_started_times": 1,
                 "training_epochs_started": 2,
                 "training_epochs_ended": 2,
+                "training_batches_started": 4,
+                "training_batches_ended": 4,
             }
 
+        hparams1 = dict(self.hparams)
+        hparams1["global_batch_size"] = 2
         controller = utils.make_trial_controller_from_trial_implementation(
             trial_class=pytorch_xor_model.XORTrialCallbacks,
-            hparams=self.hparams,
+            hparams=hparams1,
             workloads=make_workloads1(),
             checkpoint_dir=str(checkpoint_dir),
         )
@@ -385,6 +393,8 @@ class TestPyTorchTrial:
             "training_started_times": 2,
             "training_epochs_started": 3,
             "training_epochs_ended": 3,
+            "training_batches_started": 5,
+            "training_batches_ended": 5,
         }
 
     def test_context(self) -> None:

--- a/harness/tests/experiment/pytorch/test_pytorch_trial.py
+++ b/harness/tests/experiment/pytorch/test_pytorch_trial.py
@@ -397,7 +397,6 @@ class TestPyTorchTrial:
             "training_epochs_started": 3,
             "training_epochs_ended": 3,
         }
-        # a stateless callback will not remember
         assert controller.trial.legacy_counter.__dict__ == {
             "legacy_on_training_epochs_start_calls": 1
         }

--- a/harness/tests/experiment/pytorch/test_pytorch_trial.py
+++ b/harness/tests/experiment/pytorch/test_pytorch_trial.py
@@ -331,6 +331,9 @@ class TestPyTorchTrial:
                 "training_epochs_started": 2,
                 "training_epochs_ended": 2,
             }
+            assert controller.trial.legacy_counter.__dict__ == {
+                "legacy_on_training_epochs_start_calls": 2
+            }
 
             yield workload.validation_workload(), workload.ignore_workload_response
             assert controller.trial.counter.__dict__ == {
@@ -340,6 +343,9 @@ class TestPyTorchTrial:
                 "training_started_times": 1,
                 "training_epochs_started": 2,
                 "training_epochs_ended": 2,
+            }
+            assert controller.trial.legacy_counter.__dict__ == {
+                "legacy_on_training_epochs_start_calls": 2
             }
 
             interceptor = workload.WorkloadResponseInterceptor()
@@ -354,6 +360,9 @@ class TestPyTorchTrial:
                 "training_started_times": 1,
                 "training_epochs_started": 2,
                 "training_epochs_ended": 2,
+            }
+            assert controller.trial.legacy_counter.__dict__ == {
+                "legacy_on_training_epochs_start_calls": 2
             }
 
         hparams1 = dict(self.hparams)
@@ -387,6 +396,10 @@ class TestPyTorchTrial:
             "training_started_times": 2,
             "training_epochs_started": 3,
             "training_epochs_ended": 3,
+        }
+        # a stateless callback will not remember
+        assert controller.trial.legacy_counter.__dict__ == {
+            "legacy_on_training_epochs_start_calls": 1
         }
 
     def test_context(self) -> None:

--- a/harness/tests/experiment/pytorch/test_pytorch_trial.py
+++ b/harness/tests/experiment/pytorch/test_pytorch_trial.py
@@ -330,8 +330,6 @@ class TestPyTorchTrial:
                 "training_started_times": 1,
                 "training_epochs_started": 2,
                 "training_epochs_ended": 2,
-                "training_batches_started": 4,
-                "training_batches_ended": 4,
             }
 
             yield workload.validation_workload(), workload.ignore_workload_response
@@ -342,8 +340,6 @@ class TestPyTorchTrial:
                 "training_started_times": 1,
                 "training_epochs_started": 2,
                 "training_epochs_ended": 2,
-                "training_batches_started": 4,
-                "training_batches_ended": 4,
             }
 
             interceptor = workload.WorkloadResponseInterceptor()
@@ -358,8 +354,6 @@ class TestPyTorchTrial:
                 "training_started_times": 1,
                 "training_epochs_started": 2,
                 "training_epochs_ended": 2,
-                "training_batches_started": 4,
-                "training_batches_ended": 4,
             }
 
         hparams1 = dict(self.hparams)
@@ -393,8 +387,6 @@ class TestPyTorchTrial:
             "training_started_times": 2,
             "training_epochs_started": 3,
             "training_epochs_ended": 3,
-            "training_batches_started": 5,
-            "training_batches_ended": 5,
         }
 
     def test_context(self) -> None:

--- a/harness/tests/experiment/pytorch/test_pytorch_trial.py
+++ b/harness/tests/experiment/pytorch/test_pytorch_trial.py
@@ -321,12 +321,15 @@ class TestPyTorchTrial:
         def make_workloads1() -> workload.Stream:
             nonlocal controller
 
-            yield workload.train_workload(1, 1, 0), workload.ignore_workload_response
+            yield workload.train_workload(1, 1, 0, 2), workload.ignore_workload_response
             assert controller is not None, "controller was never set!"
             assert controller.trial.counter.__dict__ == {
                 "validation_steps_started": 0,
                 "validation_steps_ended": 0,
                 "checkpoints_ended": 0,
+                "training_started_times": 1,
+                "training_epochs_started": 2,
+                "training_epochs_ended": 2,
             }
 
             yield workload.validation_workload(), workload.ignore_workload_response
@@ -334,6 +337,9 @@ class TestPyTorchTrial:
                 "validation_steps_started": 1,
                 "validation_steps_ended": 1,
                 "checkpoints_ended": 0,
+                "training_started_times": 1,
+                "training_epochs_started": 2,
+                "training_epochs_ended": 2,
             }
 
             interceptor = workload.WorkloadResponseInterceptor()
@@ -345,6 +351,9 @@ class TestPyTorchTrial:
                 "validation_steps_started": 1,
                 "validation_steps_ended": 1,
                 "checkpoints_ended": 1,
+                "training_started_times": 1,
+                "training_epochs_started": 2,
+                "training_epochs_ended": 2,
             }
 
         controller = utils.make_trial_controller_from_trial_implementation(
@@ -373,6 +382,9 @@ class TestPyTorchTrial:
             "validation_steps_started": 1,
             "validation_steps_ended": 1,
             "checkpoints_ended": 0,
+            "training_started_times": 2,
+            "training_epochs_started": 3,
+            "training_epochs_ended": 3,
         }
 
     def test_context(self) -> None:

--- a/model_hub/model_hub/mmdetection/_callbacks.py
+++ b/model_hub/model_hub/mmdetection/_callbacks.py
@@ -122,7 +122,7 @@ class LrUpdaterCallback(det_torch.PyTorchCallback):
     def on_training_start(self) -> None:
         self.hook.before_run(self.runner)
 
-    def on_training_epoch_start(self) -> None:
+    def on_training_epoch_start(self, epoch_idx: int) -> None:
         self.hook.before_train_epoch(self.runner)
 
     def on_batch_start(self) -> None:


### PR DESCRIPTION
## Description
DET-5180 additional pytorch callbacks
https://determinedai.atlassian.net/browse/DET-5180

Added
- `on_training_epoch_end(self, epoch_idx: int)`

Modified
- `on_training_epoch_start(self, epoch_idx: int)`  (legacy callbacks will log a warning `[2022-01-25 00:09:56] 9ef58fcb [rank=1] || 2022-01-25 00:09:56,151:WARNING [81]: on_training_epoch_start() without parameters is deprecated in 0.17.7. Please add epoch_idx parameter
`)

## Test Plan

Enhanced unit test for pytorch callbacks


## Commentary (optional)

1. The way I read other implementations of callbacks, `on_training_epoch_end` should be called _after_ processing the last batch in an epoch.
2. As I mentioned earlier, it is possible that `on_training_epoch_end` will not get invoked after the latest batch in an epoch if `is_epoch_end()` returns `False`.
3. Upon discussion with @liamcli we decided not to add `on_training_batch_(start|end)` for now since we are not sure of the performance hit of aggregating batch metrics if we were to add `on_training_batch_end` that would have a metrics argument. Here is his take on it:

> To answer this question, i think it helps to think about what the user would put in an on_train_batch_end callback vs just in train_batch at the end.  the two things that come to mind that are better in on_train_batch_end are things that we do not want to impact the profiler and things that depend on aggregated metrics.  otherwise, i don't see a reason to not put it in train_batch.  If we believe this, then i think we should take out on_train_batch until we can safely pass in aggregated global batch metrics.

## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
