### PR TITLE
fix: resolve previous `/agents` fetch before polling for a new one [DET-6490]

### DIFF
--- a/webui/react/src/components/Navigation.tsx
+++ b/webui/react/src/components/Navigation.tsx
@@ -21,8 +21,8 @@ const Navigation: React.FC<Props> = ({ children }) => {
   const fetchAgents = useFetchAgents(canceler);
   const fetchResourcePools = useFetchResourcePools(canceler);
 
-  const fetchAuthOnly = useCallback(() => {
-    if (auth.isAuthenticated) fetchAgents();
+  const fetchAuthOnly = useCallback(async () => {
+    if (auth.isAuthenticated) await fetchAgents();
   }, [ auth.isAuthenticated, fetchAgents ]);
 
   usePolling(fetchAuthOnly);

--- a/webui/react/src/hooks/usePolling.ts
+++ b/webui/react/src/hooks/usePolling.ts
@@ -28,6 +28,12 @@ const DEFAULT_OPTIONS: PollingOptions = {
   runImmediately: true,
 };
 
+/**
+ * Polling hook that polls a given polling function.
+ * @param pollingFn
+ *    The function to poll. Pass an async/await function to ensure
+ *    the previous poll resolves first before making a new call.
+ */
 const usePolling = (pollingFn: PollingFn, options: PollingOptions = {}): PollingHooks => {
   const savedPollingFn = useRef<PollingFn>(pollingFn);
   const pollingOptions = useRef<PollingOptions>({ ...DEFAULT_OPTIONS, ...options });


### PR DESCRIPTION
## Description

There seems to be multiple problems within the reported issue with over polling `/agents`. The known and addressable issue is to ensure that the WebUI doesn't poll the agents endpoint while an existing one is still in progress. Update the polling policy for `agents` to only continue polling if an existing agents poll is not currently in progress.

<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At a minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan

A couple of ways to test this...

Way to test without editing code:
- [ ] Open 6 or more tabs and watch for `/agents` endpoint to eventually enter a `pending` state (force saturation). When this occurs, the `usePolling` shouldn't continue to make additional `/agents` calls if it is behaving properly.

Ways to test via editing code:
- [ ] Modify an existing polling async endpoint call to take more than 5 seconds (default polling interval is 5, make it take 10 seconds via setTimeout) and check to make sure that the endpoint only gets called at a 10 sec interval instead.

<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions about this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ