### PR TITLE
chore: Remove deprecated routes from old API

### DIFF
--- a/docs/release-notes/3483-remove-deprecated-from-experiment-api.txt
+++ b/docs/release-notes/3483-remove-deprecated-from-experiment-api.txt
@@ -2,6 +2,6 @@
 
 **Removed Features**
 
--  Master: removes /experiment-list, /experiment-summaries, and /:experiment_id/kill
-  endpoints from the legacy API. These functions are now replaced by the GRPC API
-  (/api/v1/experiments) in the Web UI, CLI, and tests.
+-  Master: removes /experiment-list, /experiment-summaries, and /:experiment_id/kill endpoints from
+   the legacy API. These functions are now replaced by the GRPC API (/api/v1/experiments) in the Web
+   UI, CLI, and tests.

--- a/docs/release-notes/3483-remove-deprecated-from-experiment-api.txt
+++ b/docs/release-notes/3483-remove-deprecated-from-experiment-api.txt
@@ -1,0 +1,7 @@
+:orphan:
+
+**Removed Features**
+
+-  Master: removes /experiment-list, /experiment-summaries, and /:experiment_id/kill
+  endpoints from the legacy API. These functions are now replaced by the GRPC API
+  (/api/v1/experiments) in the Web UI, CLI, and tests.

--- a/harness/determined/cli/experiment.py
+++ b/harness/determined/cli/experiment.py
@@ -656,14 +656,8 @@ def none_or_int(string: str) -> Optional[int]:
     return int(string)
 
 
-def experiment_id_completer(prefix: str, parsed_args: Namespace, **kwargs: Any) -> List[str]:
-    params = {"filter": "all"}
-    r = api.get(parsed_args.master, "experiment-list", params=params)
-    return [str(e["id"]) for e in r.json()]
-
-
 def experiment_id_arg(help: str) -> Arg:  # noqa: A002
-    return Arg("experiment_id", type=int, help=help, completer=experiment_id_completer)
+    return Arg("experiment_id", type=int, help=help)
 
 
 main_cmd = Cmd(

--- a/master/internal/core.go
+++ b/master/internal/core.go
@@ -863,11 +863,7 @@ func (m *Master) Run(ctx context.Context) error {
 	m.echo.GET("/info", api.Route(m.getInfo))
 	m.echo.GET("/logs", api.Route(m.getMasterLogs), authFuncs...)
 
-	m.echo.GET("/experiment-list", api.Route(m.getExperimentList), authFuncs...)
-	m.echo.GET("/experiment-summaries", api.Route(m.getExperimentSummaries), authFuncs...)
-
 	experimentsGroup := m.echo.Group("/experiments", authFuncs...)
-	experimentsGroup.GET("", api.Route(m.getExperiments))
 	experimentsGroup.GET("/:experiment_id", api.Route(m.getExperiment))
 	experimentsGroup.GET("/:experiment_id/checkpoints", api.Route(m.getExperimentCheckpoints))
 	experimentsGroup.GET("/:experiment_id/config", api.Route(m.getExperimentConfig))
@@ -877,7 +873,6 @@ func (m *Master) Run(ctx context.Context) error {
 	experimentsGroup.GET("/:experiment_id/metrics/summary", api.Route(m.getExperimentSummaryMetrics))
 	experimentsGroup.PATCH("/:experiment_id", api.Route(m.patchExperiment))
 	experimentsGroup.POST("", api.Route(m.postExperiment))
-	experimentsGroup.POST("/:experiment_id/kill", api.Route(m.postExperimentKill))
 
 	searcherGroup := m.echo.Group("/searcher", authFuncs...)
 	searcherGroup.POST("/preview", api.Route(m.getSearcherPreview))


### PR DESCRIPTION
## Description

Removes deprecated code from core_experiment.go (old API)

Specifically: experiment-list, experiment-summaries, and kill

Work in progress

## Checklist

- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.