### PR TITLE
fix: running experiment log misbehave [DET-6339]

### DIFF
--- a/webui/react/src/components/LogViewerCore.tsx
+++ b/webui/react/src/components/LogViewerCore.tsx
@@ -148,14 +148,14 @@ const LogViewerCore: React.FC<Props> = ({
 
   const addLogs = useCallback((newLogs: ViewerLog[], prepend = false): void => {
     if (newLogs.length === 0) return;
-    setLogs(prevLogs =>  {
+    setLogs(prevLogs => {
       // Indicator for running experments when log stream is stable
       if(local.current.isScrollReady && prevLogs.length > 0 && newLogs.length === 1) {
-        local.current.isStreamReady = true
+        local.current.isStreamReady = true;
       }
-      return prepend ? [ ...newLogs, ...prevLogs ] : [ ...prevLogs, ...newLogs ]
+      return prepend ? [ ...newLogs, ...prevLogs ] : [ ...prevLogs, ...newLogs ];
     });
-    
+
     resizeLogs();
   }, [ resizeLogs ]);
 
@@ -284,7 +284,7 @@ const LogViewerCore: React.FC<Props> = ({
       addLogs(logs);
 
       if (isNewestFirst) {
-        logs.length>0 && listRef.current?.scrollToItem(logs.length, 'end');
+        logs.length > 0 && listRef.current?.scrollToItem(logs.length, 'end');
       } else {
         listRef.current?.scrollToItem(0, 'start');
       }
@@ -348,9 +348,9 @@ const LogViewerCore: React.FC<Props> = ({
     return () => canceler.abort();
   }, [ canceler ]);
 
-  useEffect(()=>{
-    if(local.current.isStreamReady) handleEnableTailing()
-  }, [local.current.isStreamReady])
+  useEffect(() => {
+    if(local.current.isStreamReady) handleEnableTailing();
+  }, [ local.current.isStreamReady, handleEnableTailing ]);
 
   // Force recomputing messages height when container size changes.
   useLayoutEffect(() => {

--- a/webui/react/src/components/LogViewerCore.tsx
+++ b/webui/react/src/components/LogViewerCore.tsx
@@ -274,9 +274,9 @@ const LogViewerCore: React.FC<Props> = ({
   useEffect(() => {
     fetchLogs({ canceler, isNewestFirst }, FetchType.Initial).then(logs => {
       addLogs(logs);
-
+    
       if (isNewestFirst) {
-        listRef.current?.scrollToItem(logs.length, 'end');
+        logs.length>0 && listRef.current?.scrollToItem(logs.length, 'end');
       } else {
         listRef.current?.scrollToItem(0, 'start');
       }

--- a/webui/react/src/components/LogViewerCore.tsx
+++ b/webui/react/src/components/LogViewerCore.tsx
@@ -63,6 +63,7 @@ const defaultLocal = {
   isOnBottom: false,
   isOnTop: false,
   isScrollReady: false,
+  isStreamReady: false,
   previousHeight: 0,
   previousWidth: 0,
 };
@@ -147,7 +148,14 @@ const LogViewerCore: React.FC<Props> = ({
 
   const addLogs = useCallback((newLogs: ViewerLog[], prepend = false): void => {
     if (newLogs.length === 0) return;
-    setLogs(prevLogs => prepend ? [ ...newLogs, ...prevLogs ] : [ ...prevLogs, ...newLogs ]);
+    setLogs(prevLogs =>  {
+      // Indicator for running experments when log stream is stable
+      if(local.current.isScrollReady && prevLogs.length > 0 && newLogs.length === 1) {
+        local.current.isStreamReady = true
+      }
+      return prepend ? [ ...newLogs, ...prevLogs ] : [ ...prevLogs, ...newLogs ]
+    });
+    
     resizeLogs();
   }, [ resizeLogs ]);
 
@@ -180,7 +188,7 @@ const LogViewerCore: React.FC<Props> = ({
 
     local.current.isOnTop = visibleStartIndex === 0;
     local.current.isOnBottom = visibleStopIndex === logs.length - 1;
-
+    
     setIsTailing(local.current.isOnBottom && isNewestFirst);
 
     // Still busy with a previous fetch, prevent another fetch.
@@ -339,6 +347,10 @@ const LogViewerCore: React.FC<Props> = ({
   useEffect(() => {
     return () => canceler.abort();
   }, [ canceler ]);
+
+  useEffect(()=>{
+    if(local.current.isStreamReady) handleEnableTailing()
+  }, [local.current.isStreamReady])
 
   // Force recomputing messages height when container size changes.
   useLayoutEffect(() => {

--- a/webui/react/src/components/LogViewerCore.tsx
+++ b/webui/react/src/components/LogViewerCore.tsx
@@ -188,7 +188,7 @@ const LogViewerCore: React.FC<Props> = ({
 
     local.current.isOnTop = visibleStartIndex === 0;
     local.current.isOnBottom = visibleStopIndex === logs.length - 1;
-    
+
     setIsTailing(local.current.isOnBottom && isNewestFirst);
 
     // Still busy with a previous fetch, prevent another fetch.
@@ -282,7 +282,7 @@ const LogViewerCore: React.FC<Props> = ({
   useEffect(() => {
     fetchLogs({ canceler, isNewestFirst }, FetchType.Initial).then(logs => {
       addLogs(logs);
-    
+
       if (isNewestFirst) {
         logs.length>0 && listRef.current?.scrollToItem(logs.length, 'end');
       } else {


### PR DESCRIPTION
## Description

For running experiment, there is a chance that when first navigate to logs tab, (especially when logs are long and appearing quickly), logs are not automatically tailing. 

## Test Plan

Navigate to a running experiments with continuous long log 10+ times (or just refresh the logs page), verify that logs are tailing. 
Also verify that scrolling up/down, scroll to oldest, tailing enable are all functional. 


## Commentary (optional)

Upon observation of `addLogs` and `handleItemsRendered`, I noticed that when the page loaded, `addLogs` is triggered several times with different length of `newLogs` argument, and I noticed that logs only misbehave when `handleItemsRendered` is triggered (with `isScrollReady` being true) before `addLogs` triggered with `newLogs.length` equal to 1 (after initialization), so I add an indicator for this event to `handleEnableTailing` manually. 

Before:

https://user-images.githubusercontent.com/40620519/150706180-e6aad909-f171-44ac-bc6e-f162d4675dd8.mov

After:

https://user-images.githubusercontent.com/40620519/150706184-f41f6881-dc23-4253-b336-23e4864106d2.mov



