### PR TITLE
feat: Tensorboard use local storage [DET-6029]

### DIFF
--- a/harness/determined/common/storage/azure_client.py
+++ b/harness/determined/common/storage/azure_client.py
@@ -25,6 +25,8 @@ class AzureStorageClient(object):
             self.client = blob.BlobServiceClient.from_connection_string(connection_string)
         elif account_url:
             self.client = blob.BlobServiceClient(account_url, credential)
+        else:
+            raise ValueError("Either 'connection_string' or 'account_url' must be specified.")
 
         logging.info(f"Trying to create Azure Blob Storage Container: {container}.")
         try:
@@ -50,7 +52,7 @@ class AzureStorageClient(object):
     def put(self, container_name: str, blob_name: str, filename: Union[str, Path]) -> None:
         """Upload a file to the specified blob in the specified container."""
         with open(filename, "rb") as file:
-            self.client.get_blob_client(container_name, blob_name).upload_blob(file)
+            self.client.get_blob_client(container_name, blob_name).upload_blob(file, overwrite=True)
 
     @util.preserve_random_state
     def get(self, container_name: str, blob_name: str, filename: str) -> None:

--- a/harness/determined/tensorboard/fetchers/__init__.py
+++ b/harness/determined/tensorboard/fetchers/__init__.py
@@ -1,0 +1,33 @@
+from typing import Any, Dict, List, Optional, Type
+
+from .azure import AzureFetcher
+from .base import Fetcher
+from .gcs import GCSFetcher
+from .s3 import S3Fetcher
+from .shared import SharedFSFetcher
+
+__all__ = [
+    "S3Fetcher",
+    "GCSFetcher",
+    "AzureFetcher",
+    "SharedFSFetcher",
+]
+
+_FETCHERS = {
+    "s3": S3Fetcher,
+    "gcs": GCSFetcher,
+    "azure": AzureFetcher,
+    "shared_fs": SharedFSFetcher,
+}  # type: Dict[str, Type[Fetcher]]
+
+
+def build(config: Dict[str, Any], paths: List[str], local_dir: str) -> Fetcher:
+    storage_config = config.get("checkpoint_storage")
+    if storage_config is None:
+        raise ValueError("config does not contain a 'checkpoint_storage' key")
+
+    storage_type = storage_config.get("type")
+    if storage_type not in _FETCHERS:
+        raise ValueError(f"checkpoint_storage type '{storage_type}' is not supported")
+
+    return _FETCHERS[storage_type](storage_config, paths, local_dir)

--- a/harness/determined/tensorboard/fetchers/azure.py
+++ b/harness/determined/tensorboard/fetchers/azure.py
@@ -1,0 +1,73 @@
+import datetime
+import logging
+import os
+import urllib
+from typing import Any, Dict, Generator, List, Tuple
+
+from .base import Fetcher
+
+logger = logging.getLogger(__name__)
+
+
+class AzureFetcher(Fetcher):
+    def __init__(self, storage_config: Dict[str, Any], storage_paths: List[str], local_dir: str):
+        from azure.storage import blob
+
+        connection_string = storage_config.get("connection_string")
+        container = storage_config.get("container")
+        account_url = storage_config.get("account_url")
+        credential = storage_config.get("credential")
+
+        if storage_config.get("connection_string"):
+            self.client = blob.BlobServiceClient.from_connection_string(connection_string)
+        elif account_url:
+            self.client = blob.BlobServiceClient(account_url, credential)
+        else:
+            raise ValueError("Either 'container_string' or 'account_url' must be specified.")
+
+        if container is None:
+            raise ValueError("'container' must be specified.")
+
+        self.container_name = container if not container.endswith("/") else container[:-1]
+
+        self.local_dir = local_dir
+        self.storage_paths = storage_paths
+        self._file_records = {}  # type: Dict[str, datetime.datetime]
+
+    def _list(self, prefix: str) -> Generator[Tuple[str, datetime.datetime], None, None]:
+        logger.debug(f"Listing keys in container '{self.container_name}' with '{prefix}'")
+        container = self.client.get_container_client(self.container_name)
+        prefix = urllib.parse.urlparse(prefix).path.lstrip("/")
+
+        blobs = container.list_blobs(name_starts_with=prefix)
+        for blob in blobs:
+            yield (blob["name"], blob["last_modified"])
+
+    def fetch_new(self) -> int:
+        new_files = []
+
+        # Look at all files in our storage location.
+        for storage_path in self.storage_paths:
+            for filepath, mtime in self._list(storage_path):
+                prev_mtime = self._file_records.get(filepath)
+
+                if prev_mtime is not None and prev_mtime >= mtime:
+                    continue
+
+                new_files.append(filepath)
+                self._file_records[filepath] = mtime
+
+        # Download the new or updated files.
+        for filepath in new_files:
+            local_path = os.path.join(self.local_dir, self.container_name, filepath)
+
+            dir_path = os.path.dirname(local_path)
+            os.makedirs(dir_path, exist_ok=True)
+
+            with open(local_path, "wb") as local_file:
+                stream = self.client.get_blob_client(self.container_name, filepath).download_blob()
+                stream.readinto(local_file)
+
+            logger.debug(f"Downloaded file to local: {local_path}")
+
+        return len(new_files)

--- a/harness/determined/tensorboard/fetchers/base.py
+++ b/harness/determined/tensorboard/fetchers/base.py
@@ -1,0 +1,24 @@
+import abc
+from typing import Any, Dict, List
+
+
+class Fetcher(metaclass=abc.ABCMeta):
+    """Abstract base class for Tensorflow fetchers.
+
+    Responsible for syncing tensorflow files from a list of storage paths to a local directory.
+    """
+
+    storage_paths: List[str]
+
+    @abc.abstractmethod
+    def __init__(self, storage_config: Dict[str, Any], storage_paths: List[str], local_dir: str):
+        pass
+
+    @abc.abstractmethod
+    def fetch_new(self) -> int:
+        """Fetches changed files found in storage paths to local disk.
+
+        Returns: count of new files fetched.
+
+        """
+        pass

--- a/harness/determined/tensorboard/fetchers/gcs.py
+++ b/harness/determined/tensorboard/fetchers/gcs.py
@@ -1,0 +1,59 @@
+import datetime
+import logging
+import os
+import posixpath
+import urllib
+from typing import Any, Dict, Generator, List, Tuple
+
+from .base import Fetcher
+
+logger = logging.getLogger(__name__)
+
+
+class GCSFetcher(Fetcher):
+    def __init__(self, storage_config: Dict[str, Any], storage_paths: List[str], local_dir: str):
+        import google.cloud.storage
+
+        self.client = google.cloud.storage.Client()
+        self.bucket_name = str(storage_config["bucket"])
+
+        self.local_dir = local_dir
+        self.storage_paths = storage_paths
+        self._file_records = {}  # type: Dict[str, datetime.datetime]
+
+    def _list(self, prefix: str) -> Generator[Tuple[str, datetime.datetime], None, None]:
+        logger.debug(f"Listing keys in bucket '{self.bucket_name}' with '{prefix}'")
+        prefix = urllib.parse.urlparse(prefix).path.lstrip("/")
+        blobs = self.client.list_blobs(self.bucket_name, prefix=prefix)
+
+        for blob in blobs:
+            yield (blob.name, blob.updated)
+
+    def fetch_new(self) -> int:
+        new_files = []
+        bucket = self.client.bucket(self.bucket_name)
+
+        # Look at all files in our storage location.
+        for storage_path in self.storage_paths:
+            logger.debug(f"Looking at path: {storage_path}")
+
+            for filepath, mtime in self._list(storage_path):
+                prev_mtime = self._file_records.get(filepath)
+
+                if prev_mtime is not None and prev_mtime >= mtime:
+                    continue
+
+                new_files.append(filepath)
+                self._file_records[filepath] = mtime
+
+        # Download the new or updated files.
+        for filepath in new_files:
+            local_path = posixpath.join(self.local_dir, self.bucket_name, filepath)
+            dir_path = os.path.dirname(local_path)
+            os.makedirs(dir_path, exist_ok=True)
+
+            bucket.blob(filepath).download_to_filename(local_path)
+
+            logger.debug(f"Downloaded file to local: {local_path}")
+
+        return len(new_files)

--- a/harness/determined/tensorboard/fetchers/s3.py
+++ b/harness/determined/tensorboard/fetchers/s3.py
@@ -1,0 +1,74 @@
+import datetime
+import logging
+import os
+import urllib.parse
+from typing import Any, Dict, Generator, List, Tuple
+
+from .base import Fetcher
+
+logger = logging.getLogger(__name__)
+
+
+class S3Fetcher(Fetcher):
+    def __init__(
+        self, storage_config: Dict[str, Any], storage_paths: List[str], local_dir: str
+    ) -> None:
+        import boto3
+
+        from determined.common.storage import boto3_credential_manager
+
+        boto3_credential_manager.initialize_boto3_credential_providers()
+        self.s3 = boto3.resource(
+            "s3",
+            endpoint_url=storage_config.get("endpoint_url"),
+            aws_access_key_id=storage_config.get("access_key"),
+            aws_secret_access_key=storage_config.get("secret_key"),
+        )
+        self.client = self.s3.meta.client
+        self.bucket_name = str(storage_config["bucket"])
+
+        self.local_dir = local_dir
+        self.storage_paths = storage_paths
+        self._file_records = {}  # type: Dict[str, datetime.datetime]
+
+    def _find_keys(self, prefix: str) -> Generator[Tuple[str, datetime.datetime], None, None]:
+        logger.debug(f"Listing keys in bucket '{self.bucket_name}' with prefix '{prefix}'")
+        prefix = urllib.parse.urlparse(prefix).path.lstrip("/")
+
+        paginator = self.client.get_paginator("list_objects_v2")
+        page_iterator = paginator.paginate(Bucket=self.bucket_name, Prefix=prefix)
+        page_count = 0
+        for page in page_iterator:
+            page_count += 1
+            for s3_obj in page.get("Contents", []):
+                yield (s3_obj["Key"], s3_obj["LastModified"])
+        if page_count > 1:
+            logger.info(f"Fetched {page_count} number of list_objects_v2 pages")
+
+    def fetch_new(self) -> int:
+        """Fetches changes files found in storage paths to local disk."""
+        new_files = []
+
+        # Look at all files in our storage location.
+        for storage_path in self.storage_paths:
+            for filepath, mtime in self._find_keys(storage_path):
+                prev_mtime = self._file_records.get(filepath)
+
+                if prev_mtime is not None and prev_mtime >= mtime:
+                    continue
+
+                new_files.append(filepath)
+                self._file_records[filepath] = mtime
+
+        # Download the new or updated files.
+        for filepath in new_files:
+            local_path = os.path.join(self.local_dir, self.bucket_name, filepath)
+            dir_path = os.path.dirname(local_path)
+            os.makedirs(dir_path, exist_ok=True)
+
+            with open(local_path, "wb") as local_file:
+                self.client.download_fileobj(self.bucket_name, filepath, local_file)
+
+            logger.debug(f"Downloaded file to local: {local_path}")
+
+        return len(new_files)

--- a/harness/determined/tensorboard/fetchers/shared.py
+++ b/harness/determined/tensorboard/fetchers/shared.py
@@ -1,0 +1,55 @@
+import datetime
+import logging
+import os
+import posixpath
+import shutil
+from typing import Any, Dict, Generator, List, Tuple
+
+from .base import Fetcher
+
+logger = logging.getLogger(__name__)
+
+
+class SharedFSFetcher(Fetcher):
+    def __init__(self, storage_config: Dict[str, Any], storage_paths: List[str], local_dir: str):
+        """Fetch tensorboard events files from storage and save to local directory"""
+        _ = storage_config
+        self.local_dir = local_dir
+        self.storage_paths = storage_paths
+        self._file_records = {}  # type: Dict[str, datetime.datetime]
+
+    def _list(self, log_dir: str) -> Generator[Tuple[str, datetime.datetime], None, None]:
+        logger.debug(f"Finding files in log directory '{log_dir}'")
+
+        for root, _, files in os.walk(log_dir):
+            for file in files:
+                filepath = posixpath.join(root, file)
+                mtime = os.path.getmtime(filepath)
+                yield (filepath, datetime.datetime.fromtimestamp(mtime))
+
+    def fetch_new(self) -> int:
+        new_files = []
+
+        # Look at all files in our storage location.
+        for storage_path in self.storage_paths:
+            for filepath, mdatetime in self._list(storage_path):
+                prev_mdatetime = self._file_records.get(filepath)
+
+                if prev_mdatetime is not None and prev_mdatetime >= mdatetime:
+                    continue
+
+                new_files.append(filepath)
+                self._file_records[filepath] = mdatetime
+
+        # Download the new or updated files.
+        for filepath in new_files:
+            local_path = posixpath.join(self.local_dir, filepath.lstrip("/"))
+
+            dir_path = os.path.dirname(local_path)
+            os.makedirs(dir_path, exist_ok=True)
+
+            shutil.copyfile(filepath, local_path)
+
+            logger.debug(f"Transfered '{filepath}' to '{local_path}'")
+
+        return len(new_files)

--- a/harness/tests/storage/test_azure.py
+++ b/harness/tests/storage/test_azure.py
@@ -1,0 +1,127 @@
+import io
+import os
+import tempfile
+import uuid
+from pathlib import Path
+from typing import Dict, List
+
+import pytest
+
+from determined.common import storage
+from determined.tensorboard.fetchers.azure import AzureFetcher
+from tests.storage import util
+
+CONTAINER_NAME = "storage-unit-tests"
+CHECK_ACCESS_KEY = "check-access"
+CHECK_KEY_CONTENT = b"yo, you have access"
+
+
+def get_live_azure_manager(require_secrets: bool, tmp_path: Path) -> storage.AzureStorageManager:
+    """Return a working AzureStorageManager connected to a real bucket.
+
+    Check for the environment variable we pass as part of circleci's "storage-unit-tests" context.
+
+    Note that the Azure credentials in the "storage-unit-tests" context are available at the
+    following location:
+
+    github.com/determined-ai/secrets/blob/master/azure/connection-strings/storage-unit-tests.txt
+
+    The service account should only have permission to view the "storage-unit-tests" bucket.
+
+    Note: this connection_string can be set via the DET_AZURE_TEST_CREDS environment variable.
+    """
+    connection_string = os.environ.get("DET_AZURE_TEST_CREDS")
+
+    import azure.core.exceptions
+
+    try:
+        manager = storage.AzureStorageManager(CONTAINER_NAME, connection_string)
+        with tempfile.TemporaryDirectory() as tmp_dirname:
+            tmp_filepath = os.path.join(tmp_dirname, "access.file")
+            manager.client.get(CONTAINER_NAME, CHECK_ACCESS_KEY, tmp_filepath)
+
+            with open(tmp_filepath, "rb") as f:
+                data = f.read()
+                assert data == CHECK_KEY_CONTENT
+
+        return manager
+
+    except (
+        ValueError,
+        azure.core.exceptions.ClientAuthenticationError,
+        azure.core.exceptions.ResourceNotFoundError,
+    ):
+        if require_secrets:
+            raise
+        pytest.skip("No Azure access")
+
+
+@pytest.mark.cloud
+def test_live_azure_lifecycle(require_secrets: bool, tmp_path: Path) -> None:
+    live_manager = get_live_azure_manager(require_secrets, tmp_path)
+
+    def post_delete_cb(storage_id: str) -> None:
+        """Search Azure directly to ensure that a checkpoint is actually deleted."""
+        found = [
+            blob["name"] for blob in live_manager.client.list_files(CONTAINER_NAME, storage_id)
+        ]
+        if found:
+            file_list = "    " + "\n    ".join(found)
+            raise ValueError(f"found {len(found)} files in container after delete:\n{file_list}")
+
+    util.run_storage_lifecycle_test(live_manager, post_delete_cb)
+
+
+def get_tensorboard_fetcher_azure(
+    require_secrets: bool, local_sync_dir: str, paths_to_sync: List[str]
+) -> AzureFetcher:
+
+    connection_string = os.environ.get("DET_AZURE_TEST_CREDS")
+    storage_config = {"connection_string": connection_string, "container": CONTAINER_NAME}
+
+    import azure.core.exceptions
+
+    try:
+        fetcher = AzureFetcher(storage_config, paths_to_sync, local_sync_dir)
+        data = io.BytesIO()
+
+        blob_client = fetcher.client.get_blob_client(CONTAINER_NAME, CHECK_ACCESS_KEY)
+        blob_client.download_blob().readinto(data)
+
+        data.seek(0)
+        assert data.read() == CHECK_KEY_CONTENT
+
+        return fetcher
+
+    except (
+        ValueError,
+        azure.core.exceptions.ClientAuthenticationError,
+        azure.core.exceptions.ResourceNotFoundError,
+    ):
+        if require_secrets:
+            raise
+        pytest.skip("No Azure access")
+
+
+@pytest.mark.cloud
+def test_tensorboard_fetcher_azure(require_secrets: bool, tmp_path: Path) -> None:
+
+    local_sync_dir = os.path.join(tmp_path, "sync_dir")
+    storage_relpath = os.path.join(local_sync_dir, CONTAINER_NAME)
+
+    # Create two paths as multi-trial sync could happen.
+    paths_to_sync = [os.path.join("test_dir", str(uuid.uuid4()), "subdir") for _ in range(2)]
+
+    fetcher = get_tensorboard_fetcher_azure(require_secrets, local_sync_dir, paths_to_sync)
+
+    def put_files(filepath_content: Dict[str, bytes]) -> None:
+        for filepath, content in filepath_content.items():
+            blob_client = fetcher.client.get_blob_client(CONTAINER_NAME, filepath)
+            blob_client.upload_blob(content, overwrite=True)
+
+    def rm_files(filepaths: List[str]) -> None:
+        for filepath in filepaths:
+            blob_client = fetcher.client.get_blob_client(CONTAINER_NAME, filepath)
+            blob_client.delete_blob()
+
+    util.run_tensorboard_fetcher_test(local_sync_dir, fetcher, storage_relpath, put_files, rm_files)

--- a/harness/tests/storage/util.py
+++ b/harness/tests/storage/util.py
@@ -1,10 +1,12 @@
 import os
-from typing import Callable, Optional
+import time
+from typing import Callable, Dict, List, Optional, Tuple
 
 import pytest
 
 from determined import errors
 from determined.common import storage
+from determined.tensorboard.fetchers import base
 
 EXPECTED_FILES = {
     "root.txt": "root file",
@@ -64,3 +66,94 @@ def run_storage_lifecycle_test(
         # Allow for backend-specific inspection.
         if post_delete_cb is not None:
             post_delete_cb(storage_id)
+
+
+def run_tensorboard_fetcher_test(
+    local_sync_dir: str,
+    fetcher: base.Fetcher,
+    storage_relpath: str,
+    put_files: Callable,
+    rm_files: Callable,
+) -> None:
+    def list_files(path: str) -> List[str]:
+        return [os.path.join(root, file) for root, _, files in os.walk(path) for file in files]
+
+    def get_filepath_dict(file_tups: List[Tuple[str, bytes]]) -> Dict[str, bytes]:
+        return {
+            os.path.join(storage_path, file_tup[0]): file_tup[1]
+            for file_tup in file_tups
+            for storage_path in fetcher.storage_paths
+        }
+
+    def verify_files(expected_files: Dict[str, bytes]) -> None:
+        # SharedFS has absolute paths
+        expected_files = {k.lstrip("/"): v for k, v in expected_files.items()}
+
+        full_paths = list_files(local_sync_dir)
+        local_files = [os.path.relpath(fp, storage_relpath) for fp in full_paths]
+        for local_file in local_files:
+            expected_content = expected_files.get(local_file)
+            assert expected_content is not None
+
+            with open(os.path.join(storage_relpath, local_file), "rb") as f:
+                observed_content = f.read()
+                if not expected_content == observed_content:
+                    raise AssertionError(
+                        "Expected: '{!r}', Observed: '{!r}'".format(
+                            expected_content, observed_content
+                        )
+                    )
+                expected_files.pop(local_file)
+
+        missing_files = len(expected_files)
+        if missing_files != 0:
+            raise AssertionError(
+                f"There were {missing_files} missing files: {expected_files.keys()}"
+            )
+
+    def timed_backoff_sync_check(expected_files: Dict[str, bytes]) -> None:
+        # Prevent failures due storage propagation delay.
+        num_retries = 5
+        for retry_num in range(num_retries + 1):
+            try:
+                fetcher.fetch_new()
+                verify_files(expected_files)
+                break
+            except AssertionError as e:
+                if retry_num == num_retries:
+                    raise
+                sleep_time = 2 ** retry_num
+                print(f"{e}: sleeping: {sleep_time} seconds")
+                time.sleep(sleep_time)
+
+    files_to_remove = []  # type: List[str]
+
+    try:
+        # (Empty Sync) Ensure empty sync is ok
+        fetcher.fetch_new()
+        local_file_list = list_files(local_sync_dir)
+        assert len(local_file_list) == 0
+
+        # (New Sync) Upload a set of files, sync, ensure files downloaded.
+        first_files = get_filepath_dict([("foo", b"foo"), ("bar", b"bar")])
+        put_files(first_files)
+        files_to_remove.extend(first_files.keys())
+
+        timed_backoff_sync_check(first_files)
+        time.sleep(1)  # racy storage propagation with Azure
+
+        # (Update Sync) Upload new content to same set of files, sync, ensure local files updated.
+        second_files = get_filepath_dict([("foo", b"foo2"), ("bar", b"bar2")])
+        put_files(second_files)
+
+        # Prevent failures due storage propagation delay.
+        timed_backoff_sync_check(second_files)
+
+        # (Additional Sync) Upload a new set of files, sync, ensure new files downloaded.
+        third_files = get_filepath_dict([("baz", b"baz"), ("qux", b"qux")])
+        put_files(third_files)
+        files_to_remove.extend(third_files.keys())
+
+        timed_backoff_sync_check({**second_files, **third_files})
+    finally:
+        rm_files(files_to_remove)


### PR DESCRIPTION
Features:
 - Tensorboard rewrite to sync to local storage.
 - Start of named logger use
 - Added debug flag for task specs. Only used by Tensorboard.
 - Tensorboard now starts for any new files found, i.e., profiler fix

Tensorboard Fetchers:
 - GCS Fetcher
 - S3 Fetcher
 - Azure Fetcher
 - SharedFS

Bug Fixes:
 - Empty directories in checkpoints did not work for Azure
 - Upload for azure_client should overwrite to match S3 behavior.

Unit Tests added:
 - Azure live storage manager test.
 - S3 Tensorboard Fetcher
 - GCS Tensorboard Fetcher
 - Azure Tensorboard Fetcher
 - SharedFS Tensorboard Fetcher
