### PR TITLE
fix: gcp vm image with google guest agent working [DET-6489]

### DIFF
--- a/harness/determined/deploy/gcp/constants.py
+++ b/harness/determined/deploy/gcp/constants.py
@@ -3,7 +3,7 @@ class defaults:
     AUX_AGENT_INSTANCE_TYPE = "n1-standard-4"
     COMPUTE_AGENT_INSTANCE_TYPE = "n1-standard-32"
     DB_PASSWORD = "postgres"
-    ENVIRONMENT_IMAGE = "det-environments-08f9c9b"
+    ENVIRONMENT_IMAGE = "det-environments-f403806"
     GPU_NUM = 8
     GPU_TYPE = "nvidia-tesla-k80"
     MASTER_INSTANCE_TYPE = "n1-standard-2"

--- a/master/internal/resourcemanagers/provisioner/gcp_config.go
+++ b/master/internal/resourcemanagers/provisioner/gcp_config.go
@@ -53,7 +53,7 @@ type GCPClusterConfig struct {
 func DefaultGCPClusterConfig() *GCPClusterConfig {
 	return &GCPClusterConfig{
 		BootDiskSize:        200,
-		BootDiskSourceImage: "projects/determined-ai/global/images/det-environments-08f9c9b",
+		BootDiskSourceImage: "projects/determined-ai/global/images/det-environments-f403806",
 		LabelKey:            "managed-by",
 		InstanceType: gceInstanceType{
 			MachineType: "n1-standard-32",

--- a/tools/scripts/bumpenvs.yaml
+++ b/tools/scripts/bumpenvs.yaml
@@ -62,8 +62,8 @@ eu_west_2_master_ami:
   new: ami-0ac10f53765369588
   old: ami-0fdf70ed5c34c5f52
 gcp_env:
-  new: det-environments-08f9c9b
-  old: det-environments-eb6c7d1
+  new: det-environments-f403806
+  old: det-environments-08f9c9b
 pytorch19_tf25_rocm_hashed:
   new: determinedai/environments:rocm-4.2-pytorch-1.9-tf-2.5-rocm-08f9c9b
   old: determinedai/environments:rocm-4.2-pytorch-1.9-tf-2.5-rocm-eb6c7d1


### PR DESCRIPTION
## Description

- Use new gcp vm image that is based on a newer base image from google. google guest agent seems to be running fine on it from the first boot, enabling `gcloud compute ssh` usage.

## Test Plan

1. Deploy a new cluster via `det deploy gcp ...`
2. Run a job on it to have a dynamic agent spun up (e.g. `det shell start --config resources.slots=1`
3. Use `det agent list` to get agent name list.
4. Use `gcloud compute ssh AGENT_NAME` to ssh into the node.
5. It should work okay (and not throw `publickey` error).

## Commentary (optional)

For mysterious reasons, systemctl on the previous image won't launch `google-guest-agent.service` on first startup; worked okay on reboot (or if you explicitly start it up). Updating the base image also helped.

## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
