### PR TITLE
feat: make notebook timeout more configurable [DET-6268]

### DIFF
--- a/docs/features/command-notebook-config.txt
+++ b/docs/features/command-notebook-config.txt
@@ -141,10 +141,25 @@ The following configuration settings are supported:
 -  ``tensorboard_args``: Lists optional arguments for launching TensorBoard. Each element of the
    list should be a string of the form ``NAME=VALUE``.
 
--  ``idle_timeout``: Specifies the duration before idle instances are
-      automatically terminated. This string is a sequence of decimal numbers, each with optional
-      fraction and a unit suffix, such as "30s", "1h", or "1m30s". Valid time units are "s", "m",
-      "h". The default value is ``20m``. This is only used by TensorBoard and Notebook instances. A
-      TensorBoard instance is considered to be idle if it does not receive any HTTP traffic. A
-      Notebook instance is considered to be idle if it does not receive any HTTP traffic and no
-      kernels and terminals are running. The default timeout for TensorBoard is ``5m`` (5 minutes).
+-  ``idle_timeout``: Specifies the duration before idle instances are automatically terminated. This
+   string is a sequence of decimal numbers, each with optional fraction and a unit suffix, such as
+   "30s", "1h", or "1m30s". Valid time units are "s", "m", "h". The default value is ``20m``. This
+   is only used by TensorBoard and notebook instances. A TensorBoard instance is considered to be
+   idle if it does not receive any HTTP traffic. A notebook instance is considered to be idle if it
+   is not receiving any HTTP traffic and it is not otherwise active (as defined by the
+   ``notebook_idle_type`` option). The default timeout for TensorBoard is ``5m`` (5 minutes).
+
+-  ``notebook_idle_type``: Specifies how to decide whether a notebook is idle or active. Valid
+   values are:
+
+   -  ``kernels_or_terminals`` (default): The notebook is considered active if any kernels or
+      terminals are running.
+
+   -  ``kernel_connections``: The notebook is considered active if there are any open connections
+      from any web connections to any kernels. (JupyterLab does not report connections to terminals,
+      so they cannot be counted.)
+
+   -  ``activity``: The notebook is considered active if any kernel is executing a command or any
+      terminal that is currently being viewed in JupyterLab is inputting or outputting any data. (A
+      terminal that is running a command but not being viewed or running a command with no output is
+      treated as idle, since JupyterLab does not provide activity information for those case.)

--- a/docs/features/notebooks.txt
+++ b/docs/features/notebooks.txt
@@ -15,8 +15,9 @@ Determined Notebooks have the following benefits:
    master proxy from and to the container.
 
 -  Jupyter Notebooks are automatically terminated if they are idle for a configurable duration to
-   release resources. Notebooks are considered busy when there are running terminals and kernels and
-   active HTTP traffic.
+   release resources. A notebook instance is considered to be idle if it is not receiving any HTTP
+   traffic and it is not otherwise active (as defined by the ``notebook_idle_type`` option in the
+   :ref:`task configuration <command-notebook-configuration>`).
 
 .. warning::
 

--- a/docs/release-notes/notebook-idle.txt
+++ b/docs/release-notes/notebook-idle.txt
@@ -1,0 +1,8 @@
+:orphan:
+
+**New Features**
+
+-  Notebooks: Add a config field ``notebook_idle_type`` that changes how the idleness of a notebook
+   is determined for the idle timeout feature. If the value is different from the default, users do
+   not need to manually shut down kernels to allow the idle timeout to take effect. See :ref:`the
+   documentation <command-notebook-configuration>` for more information.

--- a/master/internal/api_notebook.go
+++ b/master/internal/api_notebook.go
@@ -152,9 +152,10 @@ func (a *apiServer) LaunchNotebook(
 		return nil, status.Errorf(codes.Internal, "cannot marshal notebook config: %s", err.Error())
 	}
 	spec.Base.ExtraEnvVars = map[string]string{
-		"NOTEBOOK_PORT":   strconv.Itoa(port),
-		"NOTEBOOK_CONFIG": string(configBytes),
-		"DET_TASK_TYPE":   model.TaskTypeNotebook,
+		"NOTEBOOK_PORT":      strconv.Itoa(port),
+		"NOTEBOOK_CONFIG":    string(configBytes),
+		"NOTEBOOK_IDLE_TYPE": spec.Config.NotebookIdleType,
+		"DET_TASK_TYPE":      model.TaskTypeNotebook,
 	}
 	spec.Port = &port
 	spec.Config.Environment.Ports = map[string]int{"notebook": port}

--- a/master/pkg/model/command_config.go
+++ b/master/pkg/model/command_config.go
@@ -4,13 +4,26 @@ import (
 	"github.com/determined-ai/determined/master/pkg/check"
 )
 
+const (
+	// NotebookIdleTypeKernelsOrTerminals indicates that a notebook should be considered active if any
+	// kernels or terminals are open.
+	NotebookIdleTypeKernelsOrTerminals = "kernels_or_terminals"
+	// NotebookIdleTypeKernelConnections indicates that a notebook should be considered active if any
+	// connections to kernels are open.
+	NotebookIdleTypeKernelConnections = "kernel_connections"
+	// NotebookIdleTypeActivity indicates that a notebook should be considered active if any kernel is
+	// running a command or any terminal is inputting or outputting data.
+	NotebookIdleTypeActivity = "activity"
+)
+
 // DefaultConfig is the default configuration used by all
 // commands (e.g., commands, notebooks, shells) if a request
 // does not specify any configuration options.
 func DefaultConfig(taskContainerDefaults *TaskContainerDefaultsConfig) CommandConfig {
 	out := CommandConfig{
-		Resources:   DefaultResourcesConfig(taskContainerDefaults),
-		Environment: DefaultEnvConfig(taskContainerDefaults),
+		Resources:        DefaultResourcesConfig(taskContainerDefaults),
+		Environment:      DefaultEnvConfig(taskContainerDefaults),
+		NotebookIdleType: NotebookIdleTypeKernelsOrTerminals,
 	}
 
 	if taskContainerDefaults != nil {
@@ -24,14 +37,15 @@ func DefaultConfig(taskContainerDefaults *TaskContainerDefaultsConfig) CommandCo
 // CommandConfig holds the necessary configurations to launch a command task in
 // the cluster.
 type CommandConfig struct {
-	Description     string           `json:"description"`
-	BindMounts      BindMountsConfig `json:"bind_mounts"`
-	Environment     Environment      `json:"environment"`
-	Resources       ResourcesConfig  `json:"resources"`
-	Entrypoint      []string         `json:"entrypoint"`
-	TensorBoardArgs []string         `json:"tensorboard_args,omitempty"`
-	IdleTimeout     *Duration        `json:"idle_timeout"`
-	WorkDir         *string          `json:"work_dir"`
+	Description      string           `json:"description"`
+	BindMounts       BindMountsConfig `json:"bind_mounts"`
+	Environment      Environment      `json:"environment"`
+	Resources        ResourcesConfig  `json:"resources"`
+	Entrypoint       []string         `json:"entrypoint"`
+	TensorBoardArgs  []string         `json:"tensorboard_args,omitempty"`
+	IdleTimeout      *Duration        `json:"idle_timeout"`
+	NotebookIdleType string           `json:"notebook_idle_type"`
+	WorkDir          *string          `json:"work_dir"`
 }
 
 // Validate implements the check.Validatable interface.
@@ -39,5 +53,14 @@ func (c *CommandConfig) Validate() []error {
 	return []error{
 		check.GreaterThanOrEqualTo(c.Resources.Slots, 0, "resources.slots must be >= 0"),
 		check.GreaterThan(len(c.Entrypoint), 0, "entrypoint must be non-empty"),
+		check.Contains(
+			c.NotebookIdleType,
+			[]interface{}{
+				NotebookIdleTypeKernelsOrTerminals,
+				NotebookIdleTypeKernelConnections,
+				NotebookIdleTypeActivity,
+			},
+			"invalid notebook idle type",
+		),
 	}
 }

--- a/master/pkg/model/command_config_test.go
+++ b/master/pkg/model/command_config_test.go
@@ -8,11 +8,12 @@ import (
 
 func TestConfigValidate(t *testing.T) {
 	type fields struct {
-		Description string
-		BindMounts  []BindMount
-		Environment Environment
-		Resources   ResourcesConfig
-		Entrypoint  []string
+		Description      string
+		BindMounts       []BindMount
+		Environment      Environment
+		Resources        ResourcesConfig
+		Entrypoint       []string
+		NotebookIdleType string
 	}
 	type testCase struct {
 		name    string
@@ -34,6 +35,7 @@ func TestConfigValidate(t *testing.T) {
 				Entrypoint: []string{
 					"test",
 				},
+				NotebookIdleType: NotebookIdleTypeActivity,
 			},
 		},
 		{
@@ -44,15 +46,28 @@ func TestConfigValidate(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		{
+			name: "invalid-notebook-idle-type",
+			fields: fields{
+				Resources:   resources,
+				Environment: environment,
+				Entrypoint: []string{
+					"test",
+				},
+				NotebookIdleType: NotebookIdleTypeActivity + "x",
+			},
+			wantErr: true,
+		},
 	}
 	runTestCase := func(t *testing.T, tc testCase) {
 		t.Run(tc.name, func(t *testing.T) {
 			c := &CommandConfig{
-				Description: tc.fields.Description,
-				BindMounts:  tc.fields.BindMounts,
-				Environment: tc.fields.Environment,
-				Resources:   tc.fields.Resources,
-				Entrypoint:  tc.fields.Entrypoint,
+				Description:      tc.fields.Description,
+				BindMounts:       tc.fields.BindMounts,
+				Environment:      tc.fields.Environment,
+				Resources:        tc.fields.Resources,
+				Entrypoint:       tc.fields.Entrypoint,
+				NotebookIdleType: tc.fields.NotebookIdleType,
 			}
 			if err := check.Validate(c); (err != nil) != tc.wantErr {
 				t.Errorf("config.Validate() error = %v, wantErr %v", err, tc.wantErr)

--- a/master/static/srv/check_idle.py
+++ b/master/static/srv/check_idle.py
@@ -1,41 +1,63 @@
-import requests
-import json
+import enum
+import logging
 import os
 from time import sleep
+
+import requests
 from determined.common import api
 from determined.common.api import certs
-import logging
-
-ACTIVE = False
-IDLE = True
 
 
-def get_execution_state(request_address):
+class IdleType(enum.Enum):
+    KERNELS_OR_TERMINALS = 1
+    KERNEL_CONNECTIONS = 2
+    ACTIVITY = 3
+
+
+last_activity = None
+
+
+def is_idle(request_address, mode):
     try:
-        kernels_res = requests.get(request_address + "/api/kernels")
-        kernels_data = json.loads(kernels_res.text)
-
-        terminals_res = requests.get(request_address + "/api/terminals")
-        terminals_data = json.loads(terminals_res.text)
-
-        sessions_res = requests.get(request_address + "/api/sessions")
-        sessions_data = json.loads(sessions_res.text)
+        kernels = requests.get(request_address + "/api/kernels").json()
+        terminals = requests.get(request_address + "/api/terminals").json()
+        sessions = requests.get(request_address + "/api/sessions").json()
     except Exception as err:
-        print("Cannot get notebook kernel status", err)
-        return ACTIVE
+        logging.warning("Cannot get notebook kernel status", exc_info=True)
+        return False
 
-    if len(kernels_data) == 0 and len(terminals_data) == 0 and len(sessions_data) == 0:
-        return IDLE
-    return ACTIVE
+    if mode == IdleType.KERNELS_OR_TERMINALS:
+        return len(kernels) == 0 and len(terminals) == 0 and len(sessions) == 0
+    elif mode == IdleType.KERNEL_CONNECTIONS:
+        # Unfortunately, the terminals API doesn't return a connection count.
+        return all(k["connections"] == 0 for k in kernels)
+    elif mode == IdleType.ACTIVITY:
+        global last_activity
+
+        old_last_activity = last_activity
+        if kernels or terminals:
+            last_activity = max(x["last_activity"] for x in kernels + terminals)
+        no_busy_kernels = all(k["execution_state"] != "busy" for k in kernels)
+
+        return no_busy_kernels and (last_activity == old_last_activity)
+
 
 def main():
+    port = os.environ["NOTEBOOK_PORT"]
+    notebook_id = os.environ["DET_TASK_ID"]
+    notebook_server = f"http://127.0.0.1:{port}/proxy/{notebook_id}"
+    master_url = os.environ["DET_MASTER"]
+    cert = certs.default_load(master_url)
+    try:
+        idle_type = IdleType[os.environ["NOTEBOOK_IDLE_TYPE"].upper()]
+    except KeyError:
+        logging.warning(
+            "unknown idle type '%s', using default value", os.environ["NOTEBOOK_IDLE_TYPE"]
+        )
+        idle_type = IdleType.KERNELS_OR_TERMINALS
+
     while True:
         sleep(1)
-        port = str(os.environ["NOTEBOOK_PORT"])
-        notebook_id = str(os.environ["DET_TASK_ID"])
-        notebook_server = f"http://127.0.0.1:{port}/proxy/{notebook_id}"
-        master_url = str(os.environ["DET_MASTER"])
-        cert = certs.default_load(master_url)
 
         try:
             api.put(
@@ -43,7 +65,7 @@ def main():
                 f"/api/v1/notebooks/{notebook_id}/report_idle",
                 {
                     "notebook_id": notebook_id,
-                    "idle": get_execution_state(notebook_server),
+                    "idle": is_idle(notebook_server, idle_type),
                 },
                 cert=cert,
             )


### PR DESCRIPTION
## Description

Previously, we could only set the idle timeout for notebooks to start
counting if there were no kernels; that requires users to manually shut
down kernels to take advantage of the feature. This change allows the
notebook idle timeout to be based on either the presence of connections
to kernels or the last activity on any kernel or terminal (as well as
the method from before).

## Test Plan

- [x] start notebook with `--config idle_timeout=10s` and various values of `--config notebook_idle_type=...` (both valid and invalid), do things in the notebook, check that it stays alive where appropriate
  - primarily, start a long-running notebook command and then close the tab
  - also manually stop all kernels and terminals and make sure that still works

## Commentary (optional)

I realized after writing this that the kernel connections option is redundant with the existing HTTP proxy traffic check. I've left it in in case there's some way I've missed in which it's not _completely_ redundant, but obviously I will quickly remove it upon hearing an opinion that it is.
