### PR TITLE
feat: stopping and starting polling based on page visibility [DET-6604]

### DIFF
--- a/docs/release-notes/3500-page-visibility-polling.txt
+++ b/docs/release-notes/3500-page-visibility-polling.txt
@@ -1,0 +1,8 @@
+:orphan:
+
+**New Features**
+
+-  Web: Polling can potentially be an expensive operation. To reduce unnecessary polling, we use
+   modern browser Page Visiblity API to detect changes in page visibility, which maps to whether the
+   user is activately focused on the page/tab or not. If the page is hidden, ongoing polling are
+   stopped. When the page becomes visible again, the previously active polling are restarted.

--- a/webui/react/src/App.tsx
+++ b/webui/react/src/App.tsx
@@ -68,6 +68,7 @@ const AppView: React.FC = () => {
     }
   }, [ info ]);
 
+  // Detect telemetry settings changes and update telemetry library.
   useEffect(() => {
     updateTelemetry(auth, info);
   }, [ auth, info, updateTelemetry ]);
@@ -79,10 +80,12 @@ const AppView: React.FC = () => {
     }
   }, [ info.checked, info.branding, setThemeId ]);
 
+  // Abort cancel signal when app unmounts.
   useEffect(() => {
     return () => canceler.abort();
   }, [ canceler ]);
 
+  // Detect and handle key events.
   useEffect(() => {
     const keyDownListener = (e: KeyboardEvent) => {
       if (e.code === KeyCode.Space && e.ctrlKey) {

--- a/webui/react/src/App.tsx
+++ b/webui/react/src/App.tsx
@@ -10,6 +10,7 @@ import Spinner from 'components/Spinner';
 import StoreProvider, { StoreAction, useStore, useStoreDispatch } from 'contexts/Store';
 import { useFetchInfo } from 'hooks/useFetch';
 import useKeyTracker, { KeyCode, keyEmitter, KeyEvent } from 'hooks/useKeyTracker';
+import usePageVisibility from 'hooks/usePageVisibility';
 import usePolling from 'hooks/usePolling';
 import useResize from 'hooks/useResize';
 import useRouteTracker from 'hooks/useRouteTracker';
@@ -37,6 +38,7 @@ const AppView: React.FC = () => {
   const fetchInfo = useFetchInfo(canceler);
 
   useKeyTracker();
+  usePageVisibility();
   useRouteTracker();
 
   // Poll every 10 minutes

--- a/webui/react/src/contexts/Store.tsx
+++ b/webui/react/src/contexts/Store.tsx
@@ -18,6 +18,7 @@ interface OmnibarState {
 
 interface UI {
   chromeCollapsed: boolean;
+  isPageHidden: boolean;
   omnibar: OmnibarState;
   showChrome: boolean;
   showSpinner: boolean;
@@ -52,6 +53,7 @@ export enum StoreAction {
   // UI
   HideUIChrome,
   HideUISpinner,
+  SetPageVisibility,
   ShowUIChrome,
   ShowUISpinner,
 
@@ -77,6 +79,7 @@ export type Action =
 | { type: StoreAction.SetInfoCheck }
 | { type: StoreAction.HideUIChrome }
 | { type: StoreAction.HideUISpinner }
+| { type: StoreAction.SetPageVisibility; value: boolean }
 | { type: StoreAction.ShowUIChrome }
 | { type: StoreAction.ShowUISpinner }
 | { type: StoreAction.SetUsers; value: DetailedUser[] }
@@ -109,6 +112,7 @@ const initInfo = {
 };
 const initUI = {
   chromeCollapsed: false,
+  isPageHidden: false,
   omnibar: { isShowing: false },
   showChrome: true,
   showSpinner: false,
@@ -191,6 +195,8 @@ const reducer = (state: State, action: Action): State => {
     case StoreAction.HideUISpinner:
       if (!state.ui.showSpinner) return state;
       return { ...state, ui: { ...state.ui, showSpinner: false } };
+    case StoreAction.SetPageVisibility:
+      return { ...state, ui: { ...state.ui, isPageHidden: action.value } };
     case StoreAction.ShowUIChrome:
       if (state.ui.showChrome) return state;
       return { ...state, ui: { ...state.ui, showChrome: true } };

--- a/webui/react/src/hooks/usePageVisibility.ts
+++ b/webui/react/src/hooks/usePageVisibility.ts
@@ -1,0 +1,46 @@
+import { useCallback, useEffect, useMemo } from 'react';
+
+import { StoreAction, useStoreDispatch } from 'contexts/Store';
+
+interface DocumentHidden {
+  hidden?: unknown;
+  msHidden?: unknown;
+  webkitHidden?: unknown;
+}
+
+const usePageVisibility = (): void => {
+  const storeDispatch = useStoreDispatch();
+
+  const [ hidden, visibilityChange ] = useMemo(() => {
+    if (typeof (document as DocumentHidden).hidden !== 'undefined') {
+      return [ 'hidden', 'visibilitychange' ];
+    } else if (typeof (document as DocumentHidden).msHidden !== 'undefined') {
+      return [ 'msHidden', 'msvisibilitychange' ];
+    } else if (typeof (document as DocumentHidden).webkitHidden !== 'undefined') {
+      return [ 'webkitHidden', 'webkitvisibilitychange' ];
+    }
+    return [ undefined, undefined ];
+  }, []);
+
+  const handleVisibilityChange = useCallback(() => {
+    if (!hidden) return;
+    storeDispatch({
+      type: StoreAction.SetPageVisibility,
+      value: !!(document as DocumentHidden)[hidden as keyof DocumentHidden],
+    });
+  }, [ hidden, storeDispatch ]);
+
+  useEffect(() => {
+    if (visibilityChange) {
+      document.addEventListener(visibilityChange, handleVisibilityChange);
+    }
+
+    return () => {
+      if (visibilityChange) {
+        document.removeEventListener(visibilityChange, handleVisibilityChange);
+      }
+    };
+  }, [ handleVisibilityChange, visibilityChange ]);
+};
+
+export default usePageVisibility;


### PR DESCRIPTION
## Description

PROBLEM
Polling can potentially be an expensive operation, using up power and bandwidth.

SOLUTION
Use the Page Visibility API that is supported by most modern browsers to store the state of whether the current page/tab is visible (aka user is focused on the tab/page or not). Using that state, to stop polling when the page is hidden and start polling if the page is visible and previously polling (meaning if it was stopped prior to the page becoming hidden, then when the page becomes visible, don't attempt to reactivate the polling).

<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At a minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->

## Test Plan

- [ ] on the WebUI, as long as the navigation is visible, it polls against the `/agents` endpoint. Simply monitor the `Network` tab for `/agents` endpoint to ensure it is polling. Count how many `agents` calls there are, then quickly change to a different tab for a while (agents polls every 5 seconds, so maybe come back in 30 seconds). Then go back to the original page and check to make sure there are no new `agents` calls (or possibly just one more than what you previously counted because it might have called it before you were able to check it).

<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions about this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ