### PR TITLE
fix: Escape model name in Python sample code [DET-6603]

### DIFF
--- a/webui/react/src/pages/ModelVersionDetails/ModelVersionHeader.tsx
+++ b/webui/react/src/pages/ModelVersionDetails/ModelVersionHeader.tsx
@@ -127,10 +127,11 @@ const ModelVersionHeader: React.FC<Props> = (
   }, [ isDeletable, showConfirmDelete ]);
 
   const referenceText = useMemo(() => {
+    const escapedModelName = modelVersion.model.name.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
     return (
       `from determined.experimental import Determined
 client = Determined()
-model_entry = client.get_model("${modelVersion.model.name}")
+model_entry = client.get_model("${escapedModelName}")
 version = model_entry.get_version(${modelVersion.version})
 ckpt = version.checkpoint
 


### PR DESCRIPTION
## Description

Replaces double quotes and backslash in the model name, so that the Python code on the Model Version / Use in Notebook modal can be copied into a code editor.

If you rename a model `mni<">st`, then the output line of code should be `client.get_model("mni<\">st")`. This is already inside of standard HTML escaping.

## Checklist

- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.