### PR TITLE
chore: print trial logs if trial ends with 0 steps

### DIFF
--- a/e2e_tests/tests/experiment/experiment.py
+++ b/e2e_tests/tests/experiment/experiment.py
@@ -510,7 +510,9 @@ def verify_completed_experiment_metadata(
             report_failed_trial(trial["id"], trial["state"])
             pytest.fail(f"Trial {trial['id']} was not COMPLETED but {trial['state']}")
 
-        assert len(trial["steps"]) > 0
+        if len(trial["steps"]) == 0:
+            print_trial_logs(trial["id"])
+            assert False, f"trial {trial['id']} is in {trial['state']} state but has 0 steps"
 
         # Check that batches appear in increasing order.
         batch_ids = [s["total_batches"] for s in trial["steps"]]

--- a/e2e_tests/tests/experiment/experiment.py
+++ b/e2e_tests/tests/experiment/experiment.py
@@ -512,7 +512,9 @@ def verify_completed_experiment_metadata(
 
         if len(trial["steps"]) == 0:
             print_trial_logs(trial["id"])
-            assert False, f"trial {trial['id']} is in {trial['state']} state but has 0 steps"
+            raise AssertionError(
+                f"trial {trial['id']} is in {trial['state']} state but has 0 steps"
+            )
 
         # Check that batches appear in increasing order.
         batch_ids = [s["total_batches"] for s in trial["steps"]]


### PR DESCRIPTION
## Description
In e2e distributed tests, print trial logs when a trial is completed but has 0 steps.
While trying to detect the cause of flakiness of test_unets_tf_keras_distributed ( https://determinedai.atlassian.net/browse/DET-6598 ) I realized we were not retaining (printing) the trial logs when the trial ends in a COMPLETED state but something goes wrong and it has 0 steps. This was the case in the 3 failures of this test: the assertion that then number of steps is positive failed but pytest logs did not have sufficient information to understand what went wrong.

<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At a minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Commentary (optional)

A more general solution would be to modify our CI code to retain trial logs as build artifacts.

## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ