### PR TITLE
feat: make k8s fluent bit sidecar image configurable

### DIFF
--- a/docs/sysadmin-basics/cluster-config.txt
+++ b/docs/sysadmin-basics/cluster-config.txt
@@ -360,6 +360,10 @@ The master supports the following configuration settings:
       -  ``master_service_name``: The service account Determined uses to interact with the
          Kubernetes API.
 
+      -  ``fluent``: Options for configuring how Fluent Bit sidecars are run.
+
+            -  ``image``: The Fluent Bit image to use. Defaults to ``fluent/fluent-bit:1.6``.
+
 -  ``resource_pools``: A list of resource pools. A resource pool is a collection of identical
    computational resources. Users can specify which resource pool a job should be assigned to when
    the job is submitted. Refer to the documentation on :ref:`resource-pools` for more information.

--- a/master/internal/resourcemanagers/kubernetes/pod.go
+++ b/master/internal/resourcemanagers/kubernetes/pod.go
@@ -53,6 +53,7 @@ type pod struct {
 	scheduler                string
 	slotType                 device.Type
 	slotResourceRequests     PodSlotResourceRequests
+	fluentConfig             FluentConfig
 
 	pod              *k8sV1.Pod
 	podName          string
@@ -68,6 +69,16 @@ type pod struct {
 // PodSlotResourceRequests contains the per-slot container requests.
 type PodSlotResourceRequests struct {
 	CPU float32 `json:"cpu"`
+}
+
+// FluentConfig stores k8s-configurable Fluent Bit-related options.
+type FluentConfig struct {
+	Image string `json:"image"`
+}
+
+// DefaultFluentConfig stores defaults for k8s-configurable Fluent Bit-related options.
+var DefaultFluentConfig = FluentConfig{
+	Image: "fluent/fluent-bit:1.6",
 }
 
 type getPodNodeInfo struct{}
@@ -97,6 +108,7 @@ func newPod(
 	slotType device.Type,
 	slotResourceRequests PodSlotResourceRequests,
 	scheduler string,
+	fluentConfig FluentConfig,
 ) *pod {
 	podContainer := cproto.Container{
 		Parent: msg.TaskActor.Address(),
@@ -133,6 +145,7 @@ func newPod(
 		scheduler:                scheduler,
 		slotType:                 slotType,
 		slotResourceRequests:     slotResourceRequests,
+		fluentConfig:             fluentConfig,
 	}
 }
 

--- a/master/internal/resourcemanagers/kubernetes/pod_test.go
+++ b/master/internal/resourcemanagers/kubernetes/pod_test.go
@@ -83,7 +83,7 @@ func createPod(
 		model.TLSClientConfig{}, model.TLSClientConfig{},
 		model.LoggingConfig{DefaultLoggingConfig: &model.DefaultLoggingConfig{}},
 		podInterface, configMapInterface, resourceRequestQueue, leaveKubernetesResources,
-		slotType, slotResourceRequests, "default-scheduler",
+		slotType, slotResourceRequests, "default-scheduler", DefaultFluentConfig,
 	)
 
 	return newPodHandler

--- a/master/internal/resourcemanagers/kubernetes/pods.go
+++ b/master/internal/resourcemanagers/kubernetes/pods.go
@@ -53,6 +53,7 @@ type pods struct {
 	scheduler                string
 	slotType                 device.Type
 	slotResourceRequests     PodSlotResourceRequests
+	fluentConfig             FluentConfig
 
 	clientSet        *k8sClient.Clientset
 	masterIP         string
@@ -92,6 +93,7 @@ func Initialize(
 	scheduler string,
 	slotType device.Type,
 	slotResourceRequests PodSlotResourceRequests,
+	fluentConfig FluentConfig,
 ) *actor.Ref {
 	loggingTLSConfig := masterTLSConfig
 	if loggingConfig.ElasticLoggingConfig != nil {
@@ -114,6 +116,7 @@ func Initialize(
 		leaveKubernetesResources:     leaveKubernetesResources,
 		slotType:                     slotType,
 		slotResourceRequests:         slotResourceRequests,
+		fluentConfig:                 fluentConfig,
 		currentNodes:                 make(map[string]*k8sV1.Node),
 		nodeToSystemResourceRequests: make(map[string]int64),
 	})
@@ -321,7 +324,7 @@ func (p *pods) receiveStartTaskPod(ctx *actor.Context, msg StartTaskPod) error {
 		msg, p.cluster, msg.Spec.ClusterID, p.clientSet, p.namespace, p.masterIP, p.masterPort,
 		p.masterTLSConfig, p.loggingTLSConfig, p.loggingConfig, p.podInterface, p.configMapInterface,
 		p.resourceRequestQueue, p.leaveKubernetesResources,
-		p.slotType, p.slotResourceRequests, p.scheduler,
+		p.slotType, p.slotResourceRequests, p.scheduler, p.fluentConfig,
 	)
 	ref, ok := ctx.ActorOf(fmt.Sprintf("pod-%s", msg.Spec.ContainerID), newPodHandler)
 	if !ok {

--- a/master/internal/resourcemanagers/kubernetes/spec.go
+++ b/master/internal/resourcemanagers/kubernetes/spec.go
@@ -458,7 +458,7 @@ func (p *pod) createPodSpec(ctx *actor.Context, scheduler string) error {
 		sidecars = append(sidecars, k8sV1.Container{
 			Name:            model.DeterminedK8FluentContainerName,
 			Command:         fluentArgs,
-			Image:           "fluent/fluent-bit:1.6",
+			Image:           p.fluentConfig.Image,
 			ImagePullPolicy: configureImagePullPolicy(spec.Environment),
 			SecurityContext: fluentSecCtx,
 			VolumeMounts:    loggingMounts,

--- a/master/internal/resourcemanagers/kubernetes_resource_manager.go
+++ b/master/internal/resourcemanagers/kubernetes_resource_manager.go
@@ -88,6 +88,7 @@ func (k *kubernetesResourceManager) Receive(ctx *actor.Context) error {
 			k.config.DefaultScheduler,
 			k.config.SlotType,
 			kubernetes.PodSlotResourceRequests{CPU: k.config.SlotResourceRequests.CPU},
+			k.config.Fluent,
 		)
 		k.agent = &agentState{
 			handler:            podsActor,

--- a/master/internal/resourcemanagers/resource_manager_config.go
+++ b/master/internal/resourcemanagers/resource_manager_config.go
@@ -102,10 +102,12 @@ type KubernetesResourceManagerConfig struct {
 	DefaultScheduler         string                             `json:"default_scheduler"`
 	SlotType                 device.Type                        `json:"slot_type"`
 	SlotResourceRequests     kubernetes.PodSlotResourceRequests `json:"slot_resource_requests"`
+	Fluent                   kubernetes.FluentConfig            `json:"fluent"`
 }
 
 var defaultKubernetesResourceManagerConfig = KubernetesResourceManagerConfig{
 	SlotType: device.CUDA, // default to CUDA-backed slots.
+	Fluent:   kubernetes.DefaultFluentConfig,
 }
 
 // GetPreemption returns whether the RM is set to preempt.


### PR DESCRIPTION
## Description
This change adds a config section to the Kubernetes resource manager config to make the image for the fluentbit sidecar configurable.
<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At a minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan
- [ ] run it locally, launch a cluster with it non defaulted, make sure it works.
<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions about this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)
This is a bit unfortunate, that there are agent fluent configs in the agents, fluent configs in dynamic agents configs and now another section in k8s. We should consider a master config refactor probably, one day.
<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ