### PR TITLE
fix: add abort mechanism to stop actor deadlocks, check resource staleness on receipt

### DIFF
--- a/master/internal/task/allocation.go
+++ b/master/internal/task/allocation.go
@@ -315,7 +315,7 @@ func (a *Allocation) ResourcesAllocated(ctx *actor.Context, msg sproto.Resources
 
 	// Get the task spec first, so the trial/task table is populated before allocations.
 	resp := ctx.Ask(ctx.Self().Parent(), BuildTaskSpec{})
-	switch err, ok := resp.ErrorOrTimeout(time.Hour); {
+	switch ok, err := resp.ErrorOrTimeout(time.Hour); {
 	case err != nil:
 		return errors.Wrapf(err, "could not get task spec")
 	case !ok:

--- a/master/internal/task/allocation.go
+++ b/master/internal/task/allocation.go
@@ -508,6 +508,7 @@ func (a *Allocation) Kill(ctx *actor.Context) {
 
 // Error closes the allocation due to an error, beginning the kill flow.
 func (a *Allocation) Error(ctx *actor.Context, err error) {
+	ctx.Log().WithError(err).Errorf("allocation encountered fatal error")
 	if a.exitReason == nil {
 		a.exitReason = err
 	}

--- a/master/internal/task/allocation.go
+++ b/master/internal/task/allocation.go
@@ -304,13 +304,22 @@ func (a *Allocation) Cleanup(ctx *actor.Context) {
 // heavy stuff unless it is necessarily (which also works to spread occurrences of the same work
 // out). Eventually, Allocations should just be started with their TaskSpec.
 func (a *Allocation) ResourcesAllocated(ctx *actor.Context, msg sproto.ResourcesAllocated) error {
+	if a.state != model.AllocationStatePending {
+		// If we have moved on from the pending state, these must be stale (and we must have
+		// already released them, just the scheduler hasn't gotten word yet).
+		return ErrStaleResourcesReceived{}
+	}
+
 	a.state = model.AllocationStateAssigned
 	a.reservations.append(msg.Reservations)
 
 	// Get the task spec first, so the trial/task table is populated before allocations.
 	resp := ctx.Ask(ctx.Self().Parent(), BuildTaskSpec{})
-	if err := resp.Error(); err != nil {
+	switch err, ok := resp.ErrorOrTimeout(time.Hour); {
+	case err != nil:
 		return errors.Wrapf(err, "could not get task spec")
+	case !ok:
+		return errors.Wrapf(err, "timeout getting task spec, likely a deadlock")
 	}
 	spec := resp.Get().(tasks.TaskSpec)
 

--- a/master/internal/task/errors.go
+++ b/master/internal/task/errors.go
@@ -34,6 +34,14 @@ func (e ErrAllocationUnfulfilled) Error() string {
 	return fmt.Sprintf("%s not valid without active allocation", e.Action)
 }
 
+// ErrStaleResourcesReceived is returned the scheduler gives an allocation resources between
+// when it requests them and it deciding, for some reason or another, they are not needed.
+type ErrStaleResourcesReceived struct{}
+
+func (e ErrStaleResourcesReceived) Error() string {
+	return "allocation no longer needs these resources"
+}
+
 // ErrStaleAllocation is returned when an operation was attempted by a stale task.
 type ErrStaleAllocation struct {
 	Received, Actual model.AllocationID

--- a/master/pkg/actor/response.go
+++ b/master/pkg/actor/response.go
@@ -29,7 +29,7 @@ type Response interface {
 	Error() (err error)
 	// ErrorOrTimeout returns the error, or nil if there is none, if the actor returned an error
 	// response within the deadline. If the deadline is exceeded, the bool returned false.
-	ErrorOrTimeout(timeout time.Duration) (error, bool)
+	ErrorOrTimeout(timeout time.Duration) (bool, error)
 }
 
 type response struct {
@@ -110,16 +110,16 @@ func (r *response) Error() error {
 	return err
 }
 
-func (r *response) ErrorOrTimeout(timeout time.Duration) (error, bool) {
+func (r *response) ErrorOrTimeout(timeout time.Duration) (bool, error) {
 	msg, ok := r.GetOrElseTimeout(nil, timeout)
 	if !ok {
-		return nil, false
+		return false, nil
 	}
 	err, ok := msg.(error)
 	if r.Empty() || !ok {
-		return nil, true
+		return true, nil
 	}
-	return err, true
+	return true, err
 }
 
 func (r *response) MarshalJSON() ([]byte, error) {


### PR DESCRIPTION
## Description
This change aims to prevent a bug where an allocation may receive resources when it no longer needs them. From static analysis of the code, it should be semi-apparent to the reader that the scheduler may send the allocation actor resources as it pleases so long as it has not received notice that the resources have been released, and also that the allocation actor checks no preconditions upon receipt but moves straight along with launching on the resources. This change has 3 parts: ensure we _always_ log allocation errors, since it was very annoying in debugging, make the allocation actor check the precondition "am i still pending" in the event it decided to exit already _and_ the trial already received the allocationExited message, and as a last line of defense, don't make a bidirectional blocking ask _forever_.. timeout eventually.
<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At a minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan
- [ ] trying to reliable repro, but the trace is pretty illuminating (that this is correct).
<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions about this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)
The trace:
```
(determined) ➜  ~ cat stack.txt | rg -C 4 trial.go
goroutine 251547 [chan receive, 697 minutes]:
github.com/determined-ai/determined/master/pkg/actor.(*Ref).AwaitTermination(0xc001341440)
	/home/circleci/project/master/pkg/actor/ref.go:287 +0x15a
github.com/determined-ai/determined/master/internal.(*trial).allocationExited(0xc000fcac00, 0xc000d21700, 0xc0010054c0)
	/home/circleci/project/master/internal/trial.go:305 +0x50
github.com/determined-ai/determined/master/internal.(*trial).Receive(0xc000fcac00, 0xc000d21700)
	/home/circleci/project/master/internal/trial.go:154 +0x128a
github.com/determined-ai/determined/master/pkg/actor.(*Ref).processMessage(0xc000c1ecc0)
	/home/circleci/project/master/pkg/actor/ref.go:253 +0x672
github.com/determined-ai/determined/master/pkg/actor.(*Ref).run(0xc000c1ecc0)
	/home/circleci/project/master/pkg/actor/ref.go:265 +0xb5
--
goroutine 251540 [chan receive, 697 minutes]:
github.com/determined-ai/determined/master/pkg/actor.(*Ref).AwaitTermination(0xc000c4fb00)
	/home/circleci/project/master/pkg/actor/ref.go:287 +0x15a
github.com/determined-ai/determined/master/internal.(*trial).allocationExited(0xc00186ce00, 0xc000f4a080, 0xc0012ca680)
	/home/circleci/project/master/internal/trial.go:305 +0x50
github.com/determined-ai/determined/master/internal.(*trial).Receive(0xc00186ce00, 0xc000f4a080)
	/home/circleci/project/master/internal/trial.go:154 +0x128a
github.com/determined-ai/determined/master/pkg/actor.(*Ref).processMessage(0xc000c1e780)
	/home/circleci/project/master/pkg/actor/ref.go:253 +0x672
github.com/determined-ai/determined/master/pkg/actor.(*Ref).run(0xc000c1e780)
	/home/circleci/project/master/pkg/actor/ref.go:265 +0xb5
--
	/usr/local/go/src/database/sql/sql.go:2248 +0x10f
github.com/determined-ai/determined/master/internal/db.(*PgDB).withTransaction(0xc006502fc0, {0x2cffc80, 0x14}, 0xc001525768)
	/home/circleci/project/master/internal/db/postgres.go:257 +0xf6
github.com/determined-ai/determined/master/internal/db.(*PgDB).AddTrainingMetrics(0x40cc65, {0x3208130, 0xc006502990}, 0x0)
	/home/circleci/project/master/internal/db/postgres_trial.go:261 +0x67
github.com/determined-ai/determined/master/internal.(*apiServer).ReportTrialTrainingMetrics(0xc00063bbc8, {0x3208130, 0xc006502990}, 0xc0013f10b0)
	/home/circleci/project/master/internal/api_trials.go:716 +0x69
github.com/determined-ai/determined/proto/pkg/apiv1._Determined_ReportTrialTrainingMetrics_Handler.func1({0x3208130, 0xc006502990}, {0x297bfe0, 0xc0013f10b0})
	/home/circleci/project/proto/pkg/apiv1/api.pb.go:4899 +0x7b
(determined) ➜  ~ cat stack.txt | rg -C 4 allocation.go
	/home/circleci/project/master/pkg/actor/response.go:60 +0x9f
github.com/determined-ai/determined/master/pkg/actor.(*response).Error(0xc001a2ddd0)
	/home/circleci/project/master/pkg/actor/response.go:103 +0x25
github.com/determined-ai/determined/master/internal/task.(*Allocation).ResourcesAllocated(0xc001a69880, 0xc001065c80, {{0xc001342450, 0x2b}, {0xc00079fd40, 0x14}, {0xc001995b50, 0x1, 0x1}})
	/home/circleci/project/master/internal/task/allocation.go:312 +0x152
github.com/determined-ai/determined/master/internal/task.(*Allocation).Receive(0xc001a69880, 0xc001065c80)
	/home/circleci/project/master/internal/task/allocation.go:164 +0x67c
github.com/determined-ai/determined/master/pkg/actor.(*Ref).processMessage(0xc001341440)
	/home/circleci/project/master/pkg/actor/ref.go:253 +0x672
github.com/determined-ai/determined/master/pkg/actor.(*Ref).run(0xc001341440)
	/home/circleci/project/master/pkg/actor/ref.go:265 +0xb5
--
	/home/circleci/project/master/pkg/actor/response.go:60 +0x9f
github.com/determined-ai/determined/master/pkg/actor.(*response).Error(0xc000fdda40)
	/home/circleci/project/master/pkg/actor/response.go:103 +0x25
github.com/determined-ai/determined/master/internal/task.(*Allocation).ResourcesAllocated(0xc0002b8e00, 0xc001065900, {{0xc0010c8930, 0x2b}, {0xc00079fd40, 0x14}, {0xc0019958d0, 0x1, 0x1}})
	/home/circleci/project/master/internal/task/allocation.go:312 +0x152
github.com/determined-ai/determined/master/internal/task.(*Allocation).Receive(0xc0002b8e00, 0xc001065900)
	/home/circleci/project/master/internal/task/allocation.go:164 +0x67c
github.com/determined-ai/determined/master/pkg/actor.(*Ref).processMessage(0xc000c4fb00)
	/home/circleci/project/master/pkg/actor/ref.go:253 +0x672
github.com/determined-ai/determined/master/pkg/actor.(*Ref).run(0xc000c4fb00)
	/home/circleci/project/master/pkg/actor/ref.go:265 +0xb5
```
<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ