### PR TITLE
fix: move python launch logger setup to not miss important log

### DIFF
--- a/harness/determined/exec/launch.py
+++ b/harness/determined/exec/launch.py
@@ -71,15 +71,15 @@ if __name__ == "__main__":
     assert info is not None, "must be run on-cluster"
     assert info.task_type == "TRIAL", f'must be run with task_type="TRIAL", not "{info.task_type}"'
 
-    logging.info(
-        f"New trial runner in (container {info.container_id}) on agent {info.agent_id}: "
-        + json.dumps(mask_config_dict(info.trial._config))
-    )
-
     # Hack: read the full config.  The experiment config is not a stable API!
     experiment_config = det.ExperimentConfig(info.trial._config)
 
     determined.common.set_logger(experiment_config.debug_enabled())
+
+    logging.info(
+        f"New trial runner in (container {info.container_id}) on agent {info.agent_id}: "
+        + json.dumps(mask_config_dict(info.trial._config))
+    )
 
     # Perform validations
     try:


### PR DESCRIPTION
## Description
This change moves the launch script code around a tad so that logging setup happens before the first log is print, since the first log is fairly important.
<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At a minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan
- [x] technically tested through automated tests on the task logs branch, but I'll test locally
<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions about this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ