### PR TITLE
fix: Patch issue with registering a checkpoint to a model version [DET-6622]

### DIFF
--- a/webui/react/src/hooks/useRegisterCheckpointModal.tsx
+++ b/webui/react/src/hooks/useRegisterCheckpointModal.tsx
@@ -208,7 +208,7 @@ const useRegisterCheckpointModal = (onClose?: (checkpointUuid?: string) => void)
           <Select
             optionFilterProp="label"
             options={modelOptions.map(option => (
-              { label: option.name, value: option.id }))}
+              { label: option.name, value: option.name }))}
             placeholder="Select a model..."
             showSearch
             style={{ width: '100%' }}


### PR DESCRIPTION
## Description

One-line patch, when I have an experiment checkpoint and register it to a model > model version, it should use the updated models/:name/versions endpoint, instead of sending the ID.

## Checklist

- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.