### PR TITLE
chore: Add logging - checkpoint storage validation [DET-6623]

### DIFF
--- a/harness/determined/exec/launch.py
+++ b/harness/determined/exec/launch.py
@@ -83,6 +83,7 @@ if __name__ == "__main__":
 
     # Perform validations
     try:
+        logging.info("Validating checkpoint storage ...")
         storage.validate_config(
             experiment_config.get_checkpoint_storage(),
             container_path=constants.SHARED_FS_CONTAINER_PATH,


### PR DESCRIPTION
We should make it clear that the action we are taking at the beginning
of a trial is to validate the checkpoint storage. In the event that
storage hangs, it isn't clear what the system is doing. This will
hopefully hint to folks that they need to look at their storage.

To test:
Start a trial, make sure there is a log line in the trial logs after "New trial runner"