### PR TITLE
fix: update test:coverage and makefile to enable coverage report locally

### DIFF
--- a/webui/react/Makefile
+++ b/webui/react/Makefile
@@ -64,4 +64,4 @@ test:
 
 .PHONY: test-ci
 test-ci:
-	JEST_JUNIT_OUTPUT_DIR=coverage npm run test:coverage -- --watchAll=false --reporters=jest-junit
+	JEST_JUNIT_OUTPUT_DIR=coverage npm run test:coverage -- --reporters=jest-junit

--- a/webui/react/package.json
+++ b/webui/react/package.json
@@ -13,7 +13,7 @@
     "lint:js": "eslint \"src/**/*.{js,jsx,ts,tsx}\"",
     "lint:css": "stylelint --config .stylelintrc.js \"src/**/*.{css,less,scss}\"",
     "test": "craco test --config jest.config.js",
-    "test:coverage": "npm test -- --env=jsdom --coverage --reporters default",
+    "test:coverage": "npm test -- --env=jsdom --coverage --reporters default --watchAll=false",
     "eject": "react-scripts eject",
     "analyze": "source-map-explorer 'build/static/js/*.js'",
     "storybook": "NODE_PATH=src start-storybook -p 9009",


### PR DESCRIPTION
## Description

local coverage report didn't generate properly after `npm run test:coverage`, thought Circle CI coverage report looked great.

BEFORE:
![Screen Shot 2022-01-31 at 7 32 16 PM](https://user-images.githubusercontent.com/220971/151904997-55afc22b-b9df-4a5b-97a5-48539918e037.png)

AFTER:
![Screen Shot 2022-01-31 at 7 33 19 PM](https://user-images.githubusercontent.com/220971/151905015-4d58888d-00f0-44bb-ba6d-111ea343ed09.png)


<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At a minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan

- [ ] check to ensure `test-unit-react` generates coverage report properly in the circle CI artifacts
- [ ] check that locally `webui/react npm run test:coverage` generates a coverage report under `webui/react/coverage/lcov-report/index.html` with full data.

<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions about this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ