### PR TITLE
chore: WebUI interaction test on MetricBadgeTag [DET-6424]

### DIFF
--- a/webui/react/src/components/MetricBadgeTag.test.tsx
+++ b/webui/react/src/components/MetricBadgeTag.test.tsx
@@ -1,0 +1,52 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+
+import MetricBadgeTag from './MetricBadgeTag';
+
+jest.mock('antd', () => {
+  const antd = jest.requireActual('antd');
+
+  /** mocking Tooltip based on Avatar test */
+  const Tooltip = (props) => {
+    return (
+      <antd.Tooltip
+        {...props}
+        getPopupContainer={(trigger: HTMLElement) => trigger}
+        mouseEnterDelay={0}
+      />
+    );
+  };
+
+  return {
+    __esModule: true,
+    ...antd,
+    Tooltip,
+  };
+});
+
+const setup = (metric) => {
+  const handleOnChange = jest.fn();
+  const view = render(
+    <MetricBadgeTag metric={metric} />,
+  );
+  return { handleOnChange, view };
+};
+
+describe('MetricBadgeTag', () => {
+  const sampleMetric = {
+    name: 'accuracy',
+    type: 'validation',
+  };
+
+  it('displays metric name and first letter of type', () => {
+    setup(sampleMetric);
+    expect(screen.getByText('accuracy')).toBeInTheDocument();
+    expect(screen.getByText('V')).toBeInTheDocument();
+  });
+
+  it('displays name on hover', async () => {
+    const { view } = setup(sampleMetric);
+    fireEvent.mouseOver(await view.findByText('V'));
+    expect(await screen.getByText('validation')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Description

Based on the test for Avatar, verify that this component on the Experiment Detail page displays the accuracy validation metric as "[ V ] accuracy" and has a "validation" tooltip.

<img width="519" alt="Screen Shot 2022-02-01 at 12 30 51 PM" src="https://user-images.githubusercontent.com/643918/152029180-9e077942-64ec-404a-b2f4-35ce1fcfe6c4.png">

## Test Plan

`make test` inside of `webui/react`

## Checklist

- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.