### PR TITLE
fix: deflake unets-tf-keras test by avoiding redundant downloads

### DIFF
--- a/e2e_tests/tests/nightly/test_distributed.py
+++ b/e2e_tests/tests/nightly/test_distributed.py
@@ -86,7 +86,7 @@ def test_unets_tf_keras_distributed() -> None:
     with tempfile.TemporaryDirectory() as tmpdir:
         copy_destination = os.path.join(tmpdir, "example")
         shutil.copytree(conf.cv_examples_path("unets_tf_keras"), copy_destination)
-        with open(os.path.join(tmpdir, "startup-hook.sh"), "a") as f:
+        with open(os.path.join(copy_destination, "startup-hook.sh"), "a") as f:
             f.write("\n")
             f.write(f"wget -O /tmp/data.tar.gz {url}\n")
             f.write(f"mkdir {download_dir}\n")

--- a/e2e_tests/tests/nightly/test_distributed.py
+++ b/e2e_tests/tests/nightly/test_distributed.py
@@ -1,3 +1,7 @@
+import os
+import shutil
+import tempfile
+
 import pytest
 
 from tests import config as conf
@@ -76,8 +80,17 @@ def test_iris_tf_keras_distributed() -> None:
 def test_unets_tf_keras_distributed() -> None:
     config = conf.load_config(conf.cv_examples_path("unets_tf_keras/distributed.yaml"))
     config = conf.set_max_length(config, {"batches": 200})
+    download_dir = "/tmp/data"
+    url = "https://s3-us-west-2.amazonaws.com/determined-ai-datasets/oxford_iiit_pet/oxford_iiit_pet.tar.gz"
 
-    exp.run_basic_test_with_temp_config(config, conf.cv_examples_path("unets_tf_keras"), 1)
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        shutil.copytree(conf.cv_examples_path("unets_tf_keras"), tmpdirname)
+        with open(os.path.join(tmpdirname, "startup-hook.sh"), "a") as f:
+            f.write("\n")
+            f.write(f"wget -O /tmp/data.tar.gz {url}\n")
+            f.write(f"mkdir {download_dir}\n")
+            f.write(f"tar -xzvf /tmp/data.tar.gz -C {download_dir}\n")
+        exp.run_basic_test_with_temp_config(config, tmpdirname, 1)
 
 
 @pytest.mark.distributed

--- a/e2e_tests/tests/nightly/test_distributed.py
+++ b/e2e_tests/tests/nightly/test_distributed.py
@@ -83,14 +83,15 @@ def test_unets_tf_keras_distributed() -> None:
     download_dir = "/tmp/data"
     url = "https://s3-us-west-2.amazonaws.com/determined-ai-datasets/oxford_iiit_pet/oxford_iiit_pet.tar.gz"
 
-    with tempfile.TemporaryDirectory() as tmpdirname:
-        shutil.copytree(conf.cv_examples_path("unets_tf_keras"), tmpdirname)
-        with open(os.path.join(tmpdirname, "startup-hook.sh"), "a") as f:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        copy_destination = os.path.join(tmpdir, "example")
+        shutil.copytree(conf.cv_examples_path("unets_tf_keras"), copy_destination)
+        with open(os.path.join(tmpdir, "startup-hook.sh"), "a") as f:
             f.write("\n")
             f.write(f"wget -O /tmp/data.tar.gz {url}\n")
             f.write(f"mkdir {download_dir}\n")
             f.write(f"tar -xzvf /tmp/data.tar.gz -C {download_dir}\n")
-        exp.run_basic_test_with_temp_config(config, tmpdirname, 1)
+        exp.run_basic_test_with_temp_config(config, copy_destination, 1)
 
 
 @pytest.mark.distributed

--- a/e2e_tests/tests/nightly/test_distributed.py
+++ b/e2e_tests/tests/nightly/test_distributed.py
@@ -81,7 +81,7 @@ def test_unets_tf_keras_distributed() -> None:
     config = conf.load_config(conf.cv_examples_path("unets_tf_keras/distributed.yaml"))
     config = conf.set_max_length(config, {"batches": 200})
     download_dir = "/tmp/data"
-    url = "https://s3-us-west-2.amazonaws.com/determined-ai-datasets/oxford_iiit_pet/oxford_iiit_pet.tar.gz"
+    url = "https://s3-us-west-2.amazonaws.com/determined-ai-datasets/oxford_iiit_pet/oxford_iiit_pet.tar.gz"  # noqa
 
     with tempfile.TemporaryDirectory() as tmpdir:
         copy_destination = os.path.join(tmpdir, "example")

--- a/examples/computer_vision/unets_tf_keras/model_def.py
+++ b/examples/computer_vision/unets_tf_keras/model_def.py
@@ -61,7 +61,7 @@ class UNetsTrial(TFKerasTrial):
         weights_dir = self.download_directory + '/weights/'
         data_file = self.context.get_data_config()['data_file']
         mobilenet_link = 'https://storage.googleapis.com/tensorflow/keras-applications/mobilenet_v2/' + data_file
-        os.mkdir(weights_dir)
+        os.makedirs(weights_dir, exist_ok=True)
 
         with filelock.FileLock(os.path.join(weights_dir, "download.lock")):
             urllib.request.urlretrieve(mobilenet_link, weights_dir + data_file)
@@ -111,6 +111,7 @@ class UNetsTrial(TFKerasTrial):
         return model
 
     def build_training_data_loader(self):
+        os.makedirs(self.download_directory, exist_ok=True)
         with filelock.FileLock(os.path.join(self.download_directory, "download.lock")):
             dataset = tfds.load(
                 'oxford_iiit_pet:3.*.*',
@@ -139,6 +140,7 @@ class UNetsTrial(TFKerasTrial):
         return train_dataset
 
     def build_validation_data_loader(self):
+        os.makedirs(self.download_directory, exist_ok=True)
         with filelock.FileLock(os.path.join(self.download_directory, "download.lock")):
             dataset, info = tfds.load(
                 'oxford_iiit_pet:3.*.*',


### PR DESCRIPTION
## Description
https://determinedai.atlassian.net/browse/DET-6598
The test is flaky because occasionally the dataset download times out. We run 8 workers, and sometimes one or two of them time out in the download; the end result is a COMPLETED experiment with a single trial that has 0 steps.

*Note*: A preprocessed version of the dataset has been uploaded to S3 and is available at https://s3-us-west-2.amazonaws.com/determined-ai-datasets/oxford_iiit_pet/oxford_iiit_pet.tar.gz
<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At a minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan

Run the e2e test against a cluster.

## Commentary (optional)

There are 2 things we consider doing:
1. Download dataset to the same nominal location `/tmp/data` instead of distinct locations by rank.
2. For CI purposes only:
  - download and preprocess the dataset into S3
  - amend the test code (the example itself as stored on github is unchanged for this purpose) to change `startup-hook.sh` on the fly to download the dataset from S3 into `/tmp/data` so that `tfds.load()` becomes a noop.

We are certain that we want to do (1). (2) may be controversial. I am doing those two things separately in this PR so that we can make separate decisions on them.
<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ