### PR TITLE
chore: stop streaming when page loses focus and restart them when they are [DET-6629]

### DIFF
--- a/webui/react/src/pages/ExperimentDetails/ExperimentVisualization.tsx
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentVisualization.tsx
@@ -6,6 +6,7 @@ import Link from 'components/Link';
 import Message, { MessageType } from 'components/Message';
 import Spinner from 'components/Spinner';
 import { terminalRunStates } from 'constants/states';
+import { useStore } from 'contexts/Store';
 import useStorage from 'hooks/useStorage';
 import { paths } from 'routes/utils';
 import {
@@ -73,6 +74,7 @@ const ExperimentVisualization: React.FC<Props> = ({
   experiment,
   type,
 }: Props) => {
+  const { ui } = useStore();
   const history = useHistory();
   const location = useLocation();
   const storage = useStorage(`${STORAGE_PATH}/${experiment.id}`);
@@ -154,7 +156,7 @@ const ExperimentVisualization: React.FC<Props> = ({
 
   // Stream available metrics.
   useEffect(() => {
-    if (!isSupported) return;
+    if (!isSupported || ui.isPageHidden) return;
 
     const canceler = new AbortController();
     const trainingMetricsMap: Record<string, boolean> = {};
@@ -205,11 +207,11 @@ const ExperimentVisualization: React.FC<Props> = ({
     });
 
     return () => canceler.abort();
-  }, [ experiment.id, filters?.metric, isSupported ]);
+  }, [ experiment.id, filters?.metric, isSupported, ui.isPageHidden ]);
 
   // Stream available batches.
   useEffect(() => {
-    if (!isSupported) return;
+    if (!isSupported || ui.isPageHidden) return;
 
     const canceler = new AbortController();
     const metricTypeParam = activeMetric.type === MetricType.Training
@@ -235,7 +237,7 @@ const ExperimentVisualization: React.FC<Props> = ({
     });
 
     return () => canceler.abort();
-  }, [ activeMetric, experiment.id, filters.batch, isSupported ]);
+  }, [ activeMetric, experiment.id, filters.batch, isSupported, ui.isPageHidden ]);
 
   // Set the default filter batch.
   useEffect(() => {

--- a/webui/react/src/pages/ExperimentDetails/ExperimentVisualization/HpHeatMaps.tsx
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentVisualization/HpHeatMaps.tsx
@@ -11,6 +11,7 @@ import Spinner from 'components/Spinner';
 import { FacetedData, UPlotScatterProps } from 'components/UPlot/types';
 import UPlotScatter from 'components/UPlot/UPlotScatter';
 import { terminalRunStates } from 'constants/states';
+import { useStore } from 'contexts/Store';
 import useResize from 'hooks/useResize';
 import { V1TrialsSnapshotResponse } from 'services/api-ts-sdk';
 import { detApi } from 'services/apiConfig';
@@ -73,6 +74,7 @@ const HpHeatMaps: React.FC<Props> = ({
   selectedMetric,
   selectedView,
 }: Props) => {
+  const { ui } = useStore();
   const baseRef = useRef<HTMLDivElement>(null);
   const resize = useResize(baseRef);
   const [ hasLoaded, setHasLoaded ] = useState(false);
@@ -207,6 +209,8 @@ const HpHeatMaps: React.FC<Props> = ({
   }, [ selectedHParams ]);
 
   useEffect(() => {
+    if (ui.isPageHidden) return;
+
     const canceler = new AbortController();
     const trialIds: number[] = [];
     const hpMetricMap: Record<number, Record<string, number>> = {};
@@ -308,7 +312,14 @@ const HpHeatMaps: React.FC<Props> = ({
     });
 
     return () => canceler.abort();
-  }, [ experiment, fullHParams, selectedBatch, selectedBatchMargin, selectedMetric ]);
+  }, [
+    experiment,
+    fullHParams,
+    selectedBatch,
+    selectedBatchMargin,
+    selectedMetric,
+    ui.isPageHidden,
+  ]);
 
   useEffect(() => setGalleryHeight(resize.height), [ resize ]);
 

--- a/webui/react/src/pages/ExperimentDetails/ExperimentVisualization/HpParallelCoordinates.tsx
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentVisualization/HpParallelCoordinates.tsx
@@ -9,6 +9,7 @@ import Section from 'components/Section';
 import Spinner from 'components/Spinner';
 import TableBatch from 'components/TableBatch';
 import { terminalRunStates } from 'constants/states';
+import { useStore } from 'contexts/Store';
 import { openOrCreateTensorBoard } from 'services/api';
 import { V1TrialsSnapshotResponse } from 'services/api-ts-sdk';
 import { detApi } from 'services/apiConfig';
@@ -55,6 +56,7 @@ const HpParallelCoordinates: React.FC<Props> = ({
   selectedHParams,
   selectedMetric,
 }: Props) => {
+  const { ui } = useStore();
   const tooltipRef = useRef<HTMLDivElement>(null);
   const trialIdRef = useRef<HTMLDivElement>(null);
   const metricValueRef = useRef<HTMLDivElement>(null);
@@ -148,6 +150,8 @@ const HpParallelCoordinates: React.FC<Props> = ({
   }, []);
 
   useEffect(() => {
+    if (ui.isPageHidden) return;
+
     const canceler = new AbortController();
     const trialMetricsMap: Record<number, number> = {};
     const trialHpTableMap: Record<number, TrialHParams> = {};
@@ -224,7 +228,7 @@ const HpParallelCoordinates: React.FC<Props> = ({
     });
 
     return () => canceler.abort();
-  }, [ experiment.id, selectedBatch, selectedBatchMargin, selectedMetric ]);
+  }, [ experiment.id, selectedBatch, selectedBatchMargin, selectedMetric, ui.isPageHidden ]);
 
   const sendBatchActions = useCallback(async (action: Action) => {
     if (action === Action.OpenTensorBoard) {

--- a/webui/react/src/pages/ExperimentDetails/ExperimentVisualization/HpScatterPlots.tsx
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentVisualization/HpScatterPlots.tsx
@@ -9,6 +9,7 @@ import Spinner from 'components/Spinner';
 import { FacetedData, UPlotScatterProps } from 'components/UPlot/types';
 import UPlotScatter from 'components/UPlot/UPlotScatter';
 import { terminalRunStates } from 'constants/states';
+import { useStore } from 'contexts/Store';
 import useResize from 'hooks/useResize';
 import { V1TrialsSnapshotResponse } from 'services/api-ts-sdk';
 import { detApi } from 'services/apiConfig';
@@ -48,6 +49,7 @@ const ScatterPlots: React.FC<Props> = ({
   selectedHParams,
   selectedMetric,
 }: Props) => {
+  const { ui } = useStore();
   const baseRef = useRef<HTMLDivElement>(null);
   const [ hasLoaded, setHasLoaded ] = useState(false);
   const [ chartData, setChartData ] = useState<HpMetricData>();
@@ -127,6 +129,8 @@ const ScatterPlots: React.FC<Props> = ({
   }, [ selectedHParams ]);
 
   useEffect(() => {
+    if (ui.isPageHidden) return;
+
     const canceler = new AbortController();
     const trialIds: number[] = [];
     const hpTrialMap: Record<string, Record<number, { hp: Primitive, metric: number }>> = {};
@@ -208,7 +212,14 @@ const ScatterPlots: React.FC<Props> = ({
     });
 
     return () => canceler.abort();
-  }, [ experiment, fullHParams, selectedBatch, selectedBatchMargin, selectedMetric ]);
+  }, [
+    experiment,
+    fullHParams,
+    selectedBatch,
+    selectedBatchMargin,
+    selectedMetric,
+    ui.isPageHidden,
+  ]);
 
   useEffect(() => setGalleryHeight(resize.height), [ resize ]);
 

--- a/webui/react/src/pages/ExperimentDetails/ExperimentVisualization/LearningCurve.tsx
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentVisualization/LearningCurve.tsx
@@ -7,6 +7,7 @@ import Section from 'components/Section';
 import Spinner from 'components/Spinner';
 import TableBatch from 'components/TableBatch';
 import { terminalRunStates } from 'constants/states';
+import { useStore } from 'contexts/Store';
 import { isNewTabClickEvent, openBlank, paths, routeToReactUrl } from 'routes/utils';
 import { openOrCreateTensorBoard } from 'services/api';
 import { V1TrialsSampleResponse } from 'services/api-ts-sdk';
@@ -42,6 +43,7 @@ const LearningCurve: React.FC<Props> = ({
   selectedMaxTrial,
   selectedMetric,
 }: Props) => {
+  const { ui } = useStore();
   const [ trialIds, setTrialIds ] = useState<number[]>([]);
   const [ batches, setBatches ] = useState<number[]>([]);
   const [ chartData, setChartData ] = useState<(number | null)[][]>([]);
@@ -85,6 +87,8 @@ const LearningCurve: React.FC<Props> = ({
   }, []);
 
   useEffect(() => {
+    if (ui.isPageHidden) return;
+
     const canceler = new AbortController();
     const trialIdsMap: Record<number, number> = {};
     const trialDataMap: Record<number, number[]> = {};
@@ -160,7 +164,7 @@ const LearningCurve: React.FC<Props> = ({
     });
 
     return () => canceler.abort();
-  }, [ experiment.id, selectedMaxTrial, selectedMetric ]);
+  }, [ experiment.id, selectedMaxTrial, selectedMetric, ui.isPageHidden ]);
 
   const sendBatchActions = useCallback(async (action: Action) => {
     if (action === Action.OpenTensorBoard) {

--- a/webui/react/src/pages/TrialDetails/Profiles/useFetchAvailableSeries.ts
+++ b/webui/react/src/pages/TrialDetails/Profiles/useFetchAvailableSeries.ts
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 
+import { useStore } from 'contexts/Store';
 import { V1GetTrialProfilerAvailableSeriesResponse } from 'services/api-ts-sdk';
 import { detApi } from 'services/apiConfig';
 import { consumeStream } from 'services/utils';
@@ -7,9 +8,12 @@ import { consumeStream } from 'services/utils';
 import { AvailableSeries } from './types';
 
 export const useFetchAvailableSeries = (trialId: number): AvailableSeries => {
+  const { ui } = useStore();
   const [ availableSeries, setAvailableSeries ] = useState<AvailableSeries>({});
 
   useEffect(() => {
+    if (ui.isPageHidden) return;
+
     const canceler = new AbortController();
 
     consumeStream(
@@ -45,7 +49,7 @@ export const useFetchAvailableSeries = (trialId: number): AvailableSeries => {
     );
 
     return () => canceler.abort();
-  }, [ trialId ]);
+  }, [ trialId, ui.isPageHidden ]);
 
   return availableSeries;
 };

--- a/webui/react/src/pages/TrialDetails/Profiles/useFetchMetrics.tsx
+++ b/webui/react/src/pages/TrialDetails/Profiles/useFetchMetrics.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 
 import { terminalRunStates } from 'constants/states';
+import { useStore } from 'contexts/Store';
 import { V1GetTrialProfilerMetricsResponse } from 'services/api-ts-sdk';
 import { detApi } from 'services/apiConfig';
 import { consumeStream } from 'services/utils';
@@ -24,9 +25,12 @@ export const useFetchMetrics = (
   labelsAgentId: string|undefined = undefined,
   labelsGpuUuid: string|undefined = undefined,
 ): MetricsAggregateInterface => {
+  const { ui } = useStore();
   const [ data, setData ] = useState<MetricsAggregateInterface>(clone(DEFAULT_DATA));
 
   useEffect(() => {
+    if (ui.isPageHidden) return;
+
     setData(clone(DEFAULT_DATA));
 
     const canceler = new AbortController();
@@ -71,7 +75,15 @@ export const useFetchMetrics = (
     });
 
     return () => canceler.abort();
-  }, [ labelsAgentId, labelsGpuUuid, labelsMetricType, labelsName, trialId, trialState ]);
+  }, [
+    labelsAgentId,
+    labelsGpuUuid,
+    labelsMetricType,
+    labelsName,
+    trialId,
+    trialState,
+    ui.isPageHidden,
+  ]);
 
   return data;
 };

--- a/webui/react/src/pages/TrialDetails/TrialDetailsLogs.tsx
+++ b/webui/react/src/pages/TrialDetails/TrialDetailsLogs.tsx
@@ -3,6 +3,7 @@ import { Modal } from 'antd';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 
 import LogViewerCore, { FetchConfig, FetchType } from 'components/LogViewerCore';
+import { useStore } from 'contexts/Store';
 import useSettings from 'hooks/useSettings';
 import TrialLogFilters, { Filters } from 'pages/TrialDetails/Logs/TrialLogFilters';
 import { serverAddress } from 'routes/utils';
@@ -24,6 +25,7 @@ export interface Props {
 type OrderBy = 'ORDER_BY_UNSPECIFIED' | 'ORDER_BY_ASC' | 'ORDER_BY_DESC';
 
 const TrialDetailsLogs: React.FC<Props> = ({ experiment, trial }: Props) => {
+  const { ui } = useStore();
   const [ filterOptions, setFilterOptions ] = useState<Filters>({});
   const [ downloadModal, setDownloadModal ] = useState<{ destroy: () => void }>();
 
@@ -133,6 +135,8 @@ const TrialDetailsLogs: React.FC<Props> = ({ experiment, trial }: Props) => {
   }, [ settings, trial.id ]);
 
   useEffect(() => {
+    if (ui.isPageHidden) return;
+
     const canceler = new AbortController();
 
     consumeStream(
@@ -145,7 +149,7 @@ const TrialDetailsLogs: React.FC<Props> = ({ experiment, trial }: Props) => {
     );
 
     return () => canceler.abort();
-  }, [ trial.id ]);
+  }, [ trial.id, ui.isPageHidden ]);
 
   const trialLogFilters = (
     <div className={css.filters}>


### PR DESCRIPTION
## Description

PROBLEM
gRPC streaming are HTTP2 based connections so a typical browser limits them to about 6 per host. Which means when the user is opening multiple tabs, it can quickly saturate the browser's ability to make new connections. New connections are made but end up in a `pending` state until the previous ones resolves, but with streaming endpoints they generally do not resolve unless the backend closes the connection or if it errors out.

SOLUTION
We previously [applied the logic](https://github.com/determined-ai/determined/pull/3500) of canceling any ongoing polling endpoint calls when the user switches to another window or tab, and reactivating them when they come back to the page/window/tab. Apply the same logic for streaming endpoints.

<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At a minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan

- [ ] open a page with streaming endpoints (such as a trial detail page for an active trial with the profiler enabled). Check to see that the streaming endpoints are open and have not reached terminal state (under Console > Network), and then click on a different tab. Come back to the tab you were on and check to see that the previous streaming endpoints have terminated and new ones are started.

<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions about this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ