### PR TITLE
chore: add tensborboard timeout logging [DET-6317] 

### DIFF
--- a/master/internal/command/command.go
+++ b/master/internal/command/command.go
@@ -153,6 +153,7 @@ func (c *command) Receive(ctx *actor.Context) error {
 				UseProxyState:   c.WatchProxyIdleTimeout,
 				UseRunnerState:  c.WatchRunnerIdleTimeout,
 				TimeoutDuration: time.Duration(*c.Config.IdleTimeout),
+				Debug:           c.Config.Debug,
 			}
 		}
 

--- a/master/internal/sproto/task.go
+++ b/master/internal/sproto/task.go
@@ -49,6 +49,7 @@ type (
 		UseProxyState   bool
 		UseRunnerState  bool
 		TimeoutDuration time.Duration
+		Debug           bool
 	}
 
 	// PortProxyConfig configures a proxy the allocation should start.

--- a/master/pkg/model/command_config.go
+++ b/master/pkg/model/command_config.go
@@ -46,6 +46,7 @@ type CommandConfig struct {
 	IdleTimeout      *Duration        `json:"idle_timeout"`
 	NotebookIdleType string           `json:"notebook_idle_type"`
 	WorkDir          *string          `json:"work_dir"`
+	Debug            bool             `json:"debug"`
 }
 
 // Validate implements the check.Validatable interface.


### PR DESCRIPTION
Test by launching a Tensorboard with these options:

`det tensorboard start -t <trial_id> --config=debug=true` and note that we get INFO level logging about the IdleTimeoutTicker state.