### PR TITLE
chore: remove container_id from ClusterInfo

### DIFF
--- a/harness/determined/_env_context.py
+++ b/harness/determined/_env_context.py
@@ -11,7 +11,6 @@ class EnvContext:
         master_url: str,
         master_cert_file: Optional[str],
         master_cert_name: Optional[str],
-        container_id: str,
         experiment_config: Dict[str, Any],
         hparams: Dict[str, Any],
         latest_checkpoint: Optional[str],
@@ -35,7 +34,6 @@ class EnvContext:
         self.master_url = master_url
         self.master_cert_file = master_cert_file
         self.master_cert_name = master_cert_name
-        self.container_id = container_id
         self.experiment_config = det.ExperimentConfig(experiment_config)
         self.hparams = hparams
         self.latest_checkpoint = latest_checkpoint

--- a/harness/determined/_execution.py
+++ b/harness/determined/_execution.py
@@ -107,7 +107,6 @@ def _make_local_execution_env(
         master_url="",
         master_cert_file=None,
         master_cert_name=None,
-        container_id="",
         experiment_config=config,
         hparams=hparams,
         latest_checkpoint=None,

--- a/harness/determined/_info.py
+++ b/harness/determined/_info.py
@@ -178,7 +178,6 @@ class ClusterInfo:
         master_url: str,
         cluster_id: str,
         agent_id: str,
-        container_id: str,
         slot_ids: List[int],
         task_id: str,
         allocation_id: str,
@@ -196,7 +195,6 @@ class ClusterInfo:
         self.master_url = master_url
         self.cluster_id = cluster_id
         self.agent_id = agent_id
-        self.container_id = container_id
         self.slot_ids = slot_ids
         self.task_id = task_id
         self.allocation_id = allocation_id
@@ -217,7 +215,6 @@ class ClusterInfo:
             "DET_MASTER",
             "DET_CLUSTER_ID",
             "DET_AGENT_ID",
-            "DET_CONTAINER_ID",
             "DET_SLOT_IDS",
             "DET_TASK_ID",
             "DET_ALLOCATION_ID",
@@ -233,7 +230,6 @@ class ClusterInfo:
             master_url=os.environ["DET_MASTER"],
             cluster_id=os.environ["DET_CLUSTER_ID"],
             agent_id=os.environ["DET_AGENT_ID"],
-            container_id=os.environ["DET_CONTAINER_ID"],
             slot_ids=json.loads(os.environ["DET_SLOT_IDS"]),
             task_id=os.environ["DET_TASK_ID"],
             allocation_id=os.environ["DET_ALLOCATION_ID"],

--- a/harness/determined/exec/harness.py
+++ b/harness/determined/exec/harness.py
@@ -54,7 +54,6 @@ def main(train_entrypoint: Optional[str]) -> int:
         master_cert_file=info.master_cert_file,
         master_cert_name=info.master_cert_name,
         experiment_config=info.trial._config,
-        container_id=info.container_id,
         hparams=info.trial.hparams,
         latest_checkpoint=info.latest_checkpoint,
         latest_batch=info.trial._latest_batch,

--- a/harness/determined/exec/launch.py
+++ b/harness/determined/exec/launch.py
@@ -1,6 +1,7 @@
 import copy
 import json
 import logging
+import os
 import re
 import subprocess
 import sys
@@ -71,13 +72,17 @@ if __name__ == "__main__":
     assert info is not None, "must be run on-cluster"
     assert info.task_type == "TRIAL", f'must be run with task_type="TRIAL", not "{info.task_type}"'
 
+    # Hack: get the container id from the environment.
+    container_id = os.environ.get("DET_CONTAINER_ID")
+    assert container_id is not None, "Unable to run with DET_CONTAINER_ID unset"
+
     # Hack: read the full config.  The experiment config is not a stable API!
     experiment_config = det.ExperimentConfig(info.trial._config)
 
     determined.common.set_logger(experiment_config.debug_enabled())
 
     logging.info(
-        f"New trial runner in (container {info.container_id}) on agent {info.agent_id}: "
+        f"New trial runner in (container {container_id}) on agent {info.agent_id}: "
         + json.dumps(mask_config_dict(info.trial._config))
     )
 

--- a/harness/determined/exec/prep_container.py
+++ b/harness/determined/exec/prep_container.py
@@ -55,9 +55,14 @@ def trial_prep(info: det.ClusterInfo, cert: certs.Cert) -> None:
 
 
 def do_rendezvous(info: det.ClusterInfo, cert: certs.Cert) -> None:
+    # Even though container_id is not part of the ClusterInfo API, we still depend on it in all
+    # current Determined backends (agents and k8s).
+    container_id = os.environ.get("DET_CONTAINER_ID")
+    assert container_id, "Unable to complete rendezvous info without DET_CONTAINER_ID"
+
     r = request.get(
         info.master_url,
-        path=f"/api/v1/allocations/{info.allocation_id}/rendezvous_info/{info.container_id}",
+        path=f"/api/v1/allocations/{info.allocation_id}/rendezvous_info/{container_id}",
         cert=cert,
     )
 

--- a/harness/determined/launch/autohorovod.py
+++ b/harness/determined/launch/autohorovod.py
@@ -24,6 +24,10 @@ def main(train_entrypoint: str) -> int:
     assert info is not None, "must be run on-cluster"
     assert info.task_type == "TRIAL", f'must be run with task_type="TRIAL", not "{info.task_type}"'
 
+    # Hack: get the container id from the environment.
+    container_id = os.environ.get("DET_CONTAINER_ID")
+    assert container_id is not None, "Unable to run with DET_CONTAINER_ID unset"
+
     # Hack: read the full config.  The experiment config is not a stable API!
     experiment_config = info.trial._config
 
@@ -48,7 +52,7 @@ def main(train_entrypoint: str) -> int:
         # contiainers (horovodrun, in this case) have exited.
         api.post(
             info.master_url,
-            path=f"/api/v1/allocations/{info.allocation_id}/containers/{info.container_id}/daemon",
+            path=f"/api/v1/allocations/{info.allocation_id}/containers/{container_id}/daemon",
             cert=cert,
         )
 

--- a/harness/tests/experiment/utils.py
+++ b/harness/tests/experiment/utils.py
@@ -135,7 +135,6 @@ def make_default_env_context(
         master_url="",
         master_cert_file=None,
         master_cert_name=None,
-        container_id="",
         hparams=hparams,
         latest_checkpoint=latest_checkpoint,
         latest_batch=latest_batch,

--- a/harness/tests/tensorboard/test_util.py
+++ b/harness/tests/tensorboard/test_util.py
@@ -14,7 +14,6 @@ def get_dummy_env() -> det.EnvContext:
         master_url="",
         master_cert_file=None,
         master_cert_name=None,
-        container_id="",
         experiment_config={"resources": {"slots_per_trial": 1, "native_parallel": False}},
         latest_checkpoint=None,
         latest_batch=0,


### PR DESCRIPTION
Even though agents and k8s let us see the container ids before we
actually start the container, for other runtimes we plan to support
(like slurm) are likely not to support such a workflow.  A simpler, more
universal workflow is to ask some external resource manager, "please
give us N containers with this environment" and we get N containers with
identical environments.

This means that we should not be relying on container_id anywhere in the
harness (except perhaps Rendezvous API which can just use a different
implementation at some point when we have to support non-agent, non-k8s
rendezvous).  But the ClusterInfo API, which will become a public API
soon, should certainly not expose a container_id.


## Commentary (optional)

I noticed that there are a few API routes that require a container_id, which need to be modified.  I'm ok landing this with the hacks in place, but I'd like to make the `# HACK` comments into `# TODO (DET-NNNN)` comments (I mean, I'd like to discuss what it would take to change them, and to make a ticket for that work)