### PR TITLE
fix: Handle model name changes [DET-6648]

### DIFF
--- a/webui/react/src/components/InlineEditor.tsx
+++ b/webui/react/src/components/InlineEditor.tsx
@@ -62,14 +62,12 @@ const InlineEditor: React.FC<Props> = ({
 
   const save = useCallback(async (newValue: string) => {
     if (onSave) {
-      try {
-        setIsSaving(true);
-        await onSave(newValue);
-      } catch (e) {
+      setIsSaving(true);
+      const err = await onSave(newValue);
+      if (err !== null) {
         updateEditorValue(value);
-      } finally {
-        setIsSaving(false);
       }
+      setIsSaving(false);
     }
   }, [ onSave, updateEditorValue, value ]);
 

--- a/webui/react/src/pages/ModelDetails.tsx
+++ b/webui/react/src/pages/ModelDetails.tsx
@@ -19,6 +19,7 @@ import TagList from 'components/TagList';
 import { useStore } from 'contexts/Store';
 import usePolling from 'hooks/usePolling';
 import useSettings from 'hooks/useSettings';
+import { paths } from 'routes/utils';
 import { archiveModel, deleteModel, deleteModelVersion, getModelDetails, patchModel,
   patchModelVersion, unarchiveModel } from 'services/api';
 import { V1GetModelVersionsRequestSortBy } from 'services/api-ts-sdk';
@@ -292,14 +293,16 @@ const ModelDetails: React.FC = () => {
         body: { name: editedName },
         modelName,
       });
+      window.location.href = `/det${paths.modelDetails(editedName)}`;
     } catch (e) {
       handleError(e, {
         publicSubject: 'Unable to save name.',
         silent: true,
         type: ErrorType.Api,
       });
-      throw Error('Revert name change');
+      return e;
     }
+    return null;
   }, [ modelName ]);
 
   const saveNotes = useCallback(async (editedNotes: string) => {

--- a/webui/react/src/pages/ModelDetails.tsx
+++ b/webui/react/src/pages/ModelDetails.tsx
@@ -19,7 +19,7 @@ import TagList from 'components/TagList';
 import { useStore } from 'contexts/Store';
 import usePolling from 'hooks/usePolling';
 import useSettings from 'hooks/useSettings';
-import { paths } from 'routes/utils';
+import { paths, routeToReactUrl } from 'routes/utils';
 import { archiveModel, deleteModel, deleteModelVersion, getModelDetails, patchModel,
   patchModelVersion, unarchiveModel } from 'services/api';
 import { V1GetModelVersionsRequestSortBy } from 'services/api-ts-sdk';
@@ -293,7 +293,7 @@ const ModelDetails: React.FC = () => {
         body: { name: editedName },
         modelName,
       });
-      window.location.href = `/det${paths.modelDetails(editedName)}`;
+      routeToReactUrl(paths.modelDetails(editedName));
     } catch (e) {
       handleError(e, {
         publicSubject: 'Unable to save name.',
@@ -302,7 +302,6 @@ const ModelDetails: React.FC = () => {
       });
       return e;
     }
-    return null;
   }, [ modelName ]);
 
   const saveNotes = useCallback(async (editedNotes: string) => {


### PR DESCRIPTION
## Description

When a model successfully changes name, the browser should be redirected to the new URL (/det/models/:new_name)

When a model fails to change name, we were already resetting InlineEditor to the previous name, but this should handle it with a returned error instead of my previous `throw Error()` idea

## Test Plan

1. Change the name of a model "test" -> "test2"
2. Change the name of a model to something not allowed "hello" -> "hello/world"

## Checklist

- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.