### PR TITLE
feat: option to skip determined wheel installation [DET-6650]

### DIFF
--- a/master/static/srv/entrypoint.sh
+++ b/master/static/srv/entrypoint.sh
@@ -55,7 +55,7 @@ if [ "$HOME" = "/" ] ; then
     export HOME
 fi
 
-if [ "$DET_SKIP_WHEEL_INSTALL" -ne 1 ]; then
+if [ -z "$DET_SKIP_WHEEL_INSTALL" ]; then
     "$DET_PYTHON_EXECUTABLE" -m pip install -q --user /opt/determined/wheels/determined*.whl
 fi
 

--- a/master/static/srv/entrypoint.sh
+++ b/master/static/srv/entrypoint.sh
@@ -55,7 +55,7 @@ if [ "$HOME" = "/" ] ; then
     export HOME
 fi
 
-if [ -z "$DET_SKIP_WHEEL_INSTALL" ]; then
+if [ -z "$DET_SKIP_PIP_INSTALL" ]; then
     "$DET_PYTHON_EXECUTABLE" -m pip install -q --user /opt/determined/wheels/determined*.whl
 fi
 

--- a/master/static/srv/entrypoint.sh
+++ b/master/static/srv/entrypoint.sh
@@ -55,7 +55,9 @@ if [ "$HOME" = "/" ] ; then
     export HOME
 fi
 
-"$DET_PYTHON_EXECUTABLE" -m pip install -q --user /opt/determined/wheels/determined*.whl
+if [ "$DET_SKIP_WHEEL_INSTALL" -ne 1 ]; then
+    "$DET_PYTHON_EXECUTABLE" -m pip install -q --user /opt/determined/wheels/determined*.whl
+fi
 
 "$DET_PYTHON_EXECUTABLE" -m determined.exec.prep_container --trial --resources
 

--- a/master/static/srv/gc-checkpoints-entrypoint.sh
+++ b/master/static/srv/gc-checkpoints-entrypoint.sh
@@ -13,7 +13,7 @@ if ! /bin/which "$DET_PYTHON_EXECUTABLE" >/dev/null 2>&1 ; then
 fi
 
 
-if [ -z "$DET_SKIP_WHEEL_INSTALL" ]; then
+if [ -z "$DET_SKIP_PIP_INSTALL" ]; then
 	"$DET_PYTHON_EXECUTABLE" -m pip install -q --user /opt/determined/wheels/determined*.whl
 fi
 

--- a/master/static/srv/gc-checkpoints-entrypoint.sh
+++ b/master/static/srv/gc-checkpoints-entrypoint.sh
@@ -13,7 +13,9 @@ if ! /bin/which "$DET_PYTHON_EXECUTABLE" >/dev/null 2>&1 ; then
 fi
 
 
-"$DET_PYTHON_EXECUTABLE" -m pip install -q --user /opt/determined/wheels/determined*.whl
+if [ "$DET_SKIP_WHEEL_INSTALL" -ne 1 ]; then
+	"$DET_PYTHON_EXECUTABLE" -m pip install -q --user /opt/determined/wheels/determined*.whl
+fi
 
 "$DET_PYTHON_EXECUTABLE" -m determined.exec.prep_container
 

--- a/master/static/srv/gc-checkpoints-entrypoint.sh
+++ b/master/static/srv/gc-checkpoints-entrypoint.sh
@@ -13,7 +13,7 @@ if ! /bin/which "$DET_PYTHON_EXECUTABLE" >/dev/null 2>&1 ; then
 fi
 
 
-if [ "$DET_SKIP_WHEEL_INSTALL" -ne 1 ]; then
+if [ -z "$DET_SKIP_WHEEL_INSTALL" ]; then
 	"$DET_PYTHON_EXECUTABLE" -m pip install -q --user /opt/determined/wheels/determined*.whl
 fi
 

--- a/master/static/srv/notebook-entrypoint.sh
+++ b/master/static/srv/notebook-entrypoint.sh
@@ -28,7 +28,7 @@ fi
 SHELL="$(set -o pipefail; getent passwd "$(whoami)" | cut -d: -f7)" || SHELL="/bin/bash"
 export SHELL
 
-if [ -z "$DET_SKIP_WHEEL_INSTALL" ]; then
+if [ -z "$DET_SKIP_PIP_INSTALL" ]; then
 	"$DET_PYTHON_EXECUTABLE" -m pip install -q --user /opt/determined/wheels/determined*.whl
 fi
 

--- a/master/static/srv/notebook-entrypoint.sh
+++ b/master/static/srv/notebook-entrypoint.sh
@@ -28,7 +28,7 @@ fi
 SHELL="$(set -o pipefail; getent passwd "$(whoami)" | cut -d: -f7)" || SHELL="/bin/bash"
 export SHELL
 
-if [ "$DET_SKIP_WHEEL_INSTALL" -ne 1 ]; then
+if [ -z "$DET_SKIP_WHEEL_INSTALL" ]; then
 	"$DET_PYTHON_EXECUTABLE" -m pip install -q --user /opt/determined/wheels/determined*.whl
 fi
 

--- a/master/static/srv/notebook-entrypoint.sh
+++ b/master/static/srv/notebook-entrypoint.sh
@@ -28,7 +28,9 @@ fi
 SHELL="$(set -o pipefail; getent passwd "$(whoami)" | cut -d: -f7)" || SHELL="/bin/bash"
 export SHELL
 
-"$DET_PYTHON_EXECUTABLE" -m pip install -q --user /opt/determined/wheels/determined*.whl
+if [ "$DET_SKIP_WHEEL_INSTALL" -ne 1 ]; then
+	"$DET_PYTHON_EXECUTABLE" -m pip install -q --user /opt/determined/wheels/determined*.whl
+fi
 
 "$DET_PYTHON_EXECUTABLE" -m determined.exec.prep_container --resources
 

--- a/master/static/srv/shell-entrypoint.sh
+++ b/master/static/srv/shell-entrypoint.sh
@@ -17,7 +17,9 @@ fi
 # modified in this entrypoint because the HOME in the user's ssh session is set
 # by sshd at a later time.
 
-"$DET_PYTHON_EXECUTABLE" -m pip install -q --user /opt/determined/wheels/determined*.whl
+if [ "$DET_SKIP_WHEEL_INSTALL" -ne 1 ]; then
+	"$DET_PYTHON_EXECUTABLE" -m pip install -q --user /opt/determined/wheels/determined*.whl
+fi
 
 "$DET_PYTHON_EXECUTABLE" -m determined.exec.prep_container --resources
 

--- a/master/static/srv/shell-entrypoint.sh
+++ b/master/static/srv/shell-entrypoint.sh
@@ -17,7 +17,7 @@ fi
 # modified in this entrypoint because the HOME in the user's ssh session is set
 # by sshd at a later time.
 
-if [ "$DET_SKIP_WHEEL_INSTALL" -ne 1 ]; then
+if [ -z "$DET_SKIP_WHEEL_INSTALL" ]; then
 	"$DET_PYTHON_EXECUTABLE" -m pip install -q --user /opt/determined/wheels/determined*.whl
 fi
 

--- a/master/static/srv/shell-entrypoint.sh
+++ b/master/static/srv/shell-entrypoint.sh
@@ -17,7 +17,7 @@ fi
 # modified in this entrypoint because the HOME in the user's ssh session is set
 # by sshd at a later time.
 
-if [ -z "$DET_SKIP_WHEEL_INSTALL" ]; then
+if [ -z "$DET_SKIP_PIP_INSTALL" ]; then
 	"$DET_PYTHON_EXECUTABLE" -m pip install -q --user /opt/determined/wheels/determined*.whl
 fi
 

--- a/master/static/srv/tensorboard-entrypoint.sh
+++ b/master/static/srv/tensorboard-entrypoint.sh
@@ -14,7 +14,9 @@ if ! /bin/which "$DET_PYTHON_EXECUTABLE" >/dev/null 2>&1 ; then
     exit 1
 fi
 
-"$DET_PYTHON_EXECUTABLE" -m pip install -q --user /opt/determined/wheels/determined*.whl
+if [ "$DET_SKIP_WHEEL_INSTALL" -ne 1 ]; then
+	"$DET_PYTHON_EXECUTABLE" -m pip install -q --user /opt/determined/wheels/determined*.whl
+fi
 
 "$DET_PYTHON_EXECUTABLE" -m determined.exec.prep_container
 

--- a/master/static/srv/tensorboard-entrypoint.sh
+++ b/master/static/srv/tensorboard-entrypoint.sh
@@ -14,7 +14,7 @@ if ! /bin/which "$DET_PYTHON_EXECUTABLE" >/dev/null 2>&1 ; then
     exit 1
 fi
 
-if [ "$DET_SKIP_WHEEL_INSTALL" -ne 1 ]; then
+if [ -z "$DET_SKIP_WHEEL_INSTALL" ]; then
 	"$DET_PYTHON_EXECUTABLE" -m pip install -q --user /opt/determined/wheels/determined*.whl
 fi
 

--- a/master/static/srv/tensorboard-entrypoint.sh
+++ b/master/static/srv/tensorboard-entrypoint.sh
@@ -14,17 +14,16 @@ if ! /bin/which "$DET_PYTHON_EXECUTABLE" >/dev/null 2>&1 ; then
     exit 1
 fi
 
-if [ -z "$DET_SKIP_WHEEL_INSTALL" ]; then
+if [ -z "$DET_SKIP_PIP_INSTALL" ]; then
 	"$DET_PYTHON_EXECUTABLE" -m pip install -q --user /opt/determined/wheels/determined*.whl
+
+	# Install tensorboard if not already installed (for custom PyTorch images)
+	"$DET_PYTHON_EXECUTABLE" -m pip install tensorboard tensorboard-plugin-profile
 fi
 
 "$DET_PYTHON_EXECUTABLE" -m determined.exec.prep_container
 
-# Install tensorboard if not already installed (for custom PyTorch images)
-"$DET_PYTHON_EXECUTABLE" -m pip install tensorboard
-"$DET_PYTHON_EXECUTABLE" -m pip install tensorboard-plugin-profile
-
 test -f "${STARTUP_HOOK}" && source "${STARTUP_HOOK}"
 
-TENSORBOARD_VERSION=$(pip show tensorboard | grep Version | sed "s/[^:]*: *//")
+TENSORBOARD_VERSION=$("$DET_PYTHON_EXECUTABLE" -c "import tensorboard; print(tensorboard.__version__)")
 exec "$DET_PYTHON_EXECUTABLE" -m determined.exec.tensorboard "$TENSORBOARD_VERSION" "$@"


### PR DESCRIPTION
## Description

A user requested an option to disable determined wheel installation at runtime because they want to prepackage all python libraries at container build time - see ticket for context. 

## Test Plan

We don't have env images with preinstalled determined at the moment, so rigging up an automated test for this would be a chore.

Manual test plan: 
1. Build an env container which has determined installed, and `DET_SKIP_PIP_INSTALL=1` env var set.
2. Check it doesn't reinstall the wheel and uses the preinstalled one when you run trials, tensorboards, etc.

## Commentary (optional)

Technically it's a new feature, but it is very marginal and so I don't think we want to advertise it in release notes or docs.

## Checklist

- [x] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
