### PR TITLE
fix: actually send the context directory for notebooks [DET-6634]

### DIFF
--- a/harness/determined/cli/notebook.py
+++ b/harness/determined/cli/notebook.py
@@ -9,6 +9,7 @@ from determined.cli.session import setup_session
 from determined.common import api
 from determined.common.api import authentication, bindings
 from determined.common.check import check_eq
+from determined.common.context import Context
 from determined.common.declarative_argparse import Arg, Cmd
 
 from .command import CONFIG_DESC, CONTEXT_DESC, VOLUME_DESC, parse_config, render_event_stream
@@ -18,7 +19,22 @@ from .command import CONFIG_DESC, CONTEXT_DESC, VOLUME_DESC, parse_config, rende
 def start_notebook(args: Namespace) -> None:
     config = parse_config(args.config_file, None, args.config, args.volume)
 
-    body = bindings.v1LaunchNotebookRequest(config, preview=False)
+    files = None
+    if args.context is not None:
+        context = Context.from_local(args.context)
+        files = [
+            bindings.v1File(
+                content=e.content.decode("utf-8"),
+                gid=e.gid,
+                mode=e.mode,
+                mtime=e.mtime,
+                path=e.path,
+                type=e.type,
+                uid=e.uid,
+            )
+            for e in context.entries
+        ]
+    body = bindings.v1LaunchNotebookRequest(config, files=files, preview=False)
     resp = bindings.post_LaunchNotebook(setup_session(args), body=body)
 
     if args.preview:


### PR DESCRIPTION
## Description

When the CLI started switching over to the new binding code, handling of
the context argument got left out of the notebook launch function, so
here we put that back in. Just need to do a bit of translation to the
new type for a context file.

## Test Plan

- [x] run `det notebook start -c ctx`, where `ctx` contains a startup hook, a `.detignore`, another file, another file to ignore, and some nested directories with files in them; check that the expected contents get through and the startup hook runs

## Commentary (optional)

Should be pretty straightforward, but I haven't investigated to see if there are any subtle mismatches in semantics between the corresponding fields of `ContextItem` and `v1File`. One visible difference is that `content` is `bytes` in one and `str` in the other, hence the `.decode()`, but the value is always a Base64-encoded string, so that shouldn't be a problem.
