### PR TITLE
chore: add additional flags to pid_server

### DIFF
--- a/harness/determined/exec/pid_server.py
+++ b/harness/determined/exec/pid_server.py
@@ -1,6 +1,7 @@
 import argparse
 import signal
 import sys
+import time
 from typing import Optional
 
 from determined import ipc
@@ -22,6 +23,10 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("-x", "--on-fail", dest="on_fail", action="store", default="SIGTERM")
     parser.add_argument("-e", "--on-exit", dest="on_exit", action="store", default="WAIT")
+    parser.add_argument("--grace-period", dest="grace_period", type=int, default=3)
+    parser.add_argument(
+        "--return-one-on-worker-error", dest="return_one_on_worker_error", action="store_true"
+    )
     parser.add_argument("addr")
     parser.add_argument("num_workers", type=int)
     parser.add_argument("cmd")
@@ -32,11 +37,14 @@ if __name__ == "__main__":
     on_exit = read_action("--on-exit", args.on_exit)
     addr = ipc.read_pid_server_addr(args.addr)
 
+    start_time = time.time()
     with ipc.PIDServer(addr, args.num_workers) as pid_server:
         sys.exit(
             pid_server.run_subprocess(
                 cmd=[args.cmd] + args.cmd_args,
                 on_fail=on_fail,
                 on_exit=on_exit,
+                grace_period=args.grace_period,
+                return_one_on_worker_error=args.return_one_on_worker_error,
             ),
         )


### PR DESCRIPTION
## Description
Add grace period and option to return error code on pid_client error. 

We can start a pid_server with a cmd via `run_subprocess`.  This is how we launch horovodrun, which in turn will spawn pid_client worker processes that report to the server.  In the case of deepspeed, the launch is handled through pdsh, which ssh's into each node to launch the harness.  pdsh will return 0 even if the ssh processes it spawned errored out so we need to have the error surface through to the pid_server to error correctly.   

## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions about this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
