### PR TITLE
fix: remove icon for LOG_LEVEL_UNSPECIFIED log [DET-6436]

### DIFF
--- a/webui/react/src/components/LogViewerEntry.tsx
+++ b/webui/react/src/components/LogViewerEntry.tsx
@@ -39,7 +39,7 @@ const LogViewerEntry: React.FC<Prop> = ({
   timeStyle,
 }) => {
   const classes = [ css.base ];
-  const logLevel = level ? level : LogLevel.Info;
+  const logLevel = level;
   const levelClasses = [ css.level, css[logLevel] ];
   const messageClasses = [ css.message ];
 
@@ -48,12 +48,12 @@ const LogViewerEntry: React.FC<Prop> = ({
 
   return (
     <div className={classes.join(' ')} style={style}>
-      <Tooltip placement="top" title={`Level: ${capitalize(logLevel)}`}>
+      {logLevel ? <Tooltip placement="top" title={`Level: ${capitalize(logLevel)}`}>
         <div className={levelClasses.join(' ')} style={{ width: ICON_WIDTH }}>
           <div className={css.levelLabel}>&lt;[{logLevel}]&gt;</div>
           <Icon name={logLevel} size="small" />
         </div>
-      </Tooltip>
+      </Tooltip> : <div style={{ width: ICON_WIDTH }} /> }
       <div className={css.time} style={timeStyle}>{formattedTime}</div>
       <div
         className={messageClasses.join(' ')}

--- a/webui/react/src/components/LogViewerEntry.tsx
+++ b/webui/react/src/components/LogViewerEntry.tsx
@@ -48,12 +48,14 @@ const LogViewerEntry: React.FC<Prop> = ({
 
   return (
     <div className={classes.join(' ')} style={style}>
-      {logLevel ? <Tooltip placement="top" title={`Level: ${capitalize(logLevel)}`}>
-        <div className={levelClasses.join(' ')} style={{ width: ICON_WIDTH }}>
-          <div className={css.levelLabel}>&lt;[{logLevel}]&gt;</div>
-          <Icon name={logLevel} size="small" />
-        </div>
-      </Tooltip> : <div style={{ width: ICON_WIDTH }} /> }
+      {logLevel ? (
+        <Tooltip placement="top" title={`Level: ${capitalize(logLevel)}`}>
+          <div className={levelClasses.join(' ')} style={{ width: ICON_WIDTH }}>
+            <div className={css.levelLabel}>&lt;[{logLevel}]&gt;</div>
+            <Icon name={logLevel} size="small" />
+          </div>
+        </Tooltip>
+      ) : <div style={{ width: ICON_WIDTH }} /> }
       <div className={css.time} style={timeStyle}>{formattedTime}</div>
       <div
         className={messageClasses.join(' ')}


### PR DESCRIPTION
## Description

Remove icon for log with level `LOG_LEVEL_UNSPECIFIED`


## Test Plan

Navigate to log tab and verify log with level `LOG_LEVEL_UNSPECIFIED` not have an icon in front of the row.

Before:
<img width="1470" alt="Screen Shot 2022-02-07 at 4 20 03 PM" src="https://user-images.githubusercontent.com/40620519/152894237-c8514fa4-bea2-48dd-a8c2-8bad649c6ea7.png">

After:
<img width="1470" alt="Screen Shot 2022-02-07 at 4 19 48 PM" src="https://user-images.githubusercontent.com/40620519/152894226-e20589fa-d320-4ce2-a3ff-9fb672a2de91.png">
 