### PR TITLE
fix: check if data file exists before downloading

### DIFF
--- a/examples/computer_vision/unets_tf_keras/model_def.py
+++ b/examples/computer_vision/unets_tf_keras/model_def.py
@@ -61,7 +61,8 @@ class UNetsTrial(TFKerasTrial):
 
         # Use a file lock so only one worker on each node does the download
         with filelock.FileLock(os.path.join(weights_dir, "download.lock")):
-            urllib.request.urlretrieve(mobilenet_link, weights_dir + data_file)
+            if not os.path.exists(weights_dir + data_file):
+                urllib.request.urlretrieve(mobilenet_link, weights_dir + data_file)
         return weights_dir + data_file
 
     def build_model(self):

--- a/examples/computer_vision/unets_tf_keras/model_def.py
+++ b/examples/computer_vision/unets_tf_keras/model_def.py
@@ -5,8 +5,6 @@ regarding the optional flags view the original script linked below.
 This implementation is based on:
 https://github.com/tensorflow/docs/blob/master/site/en/tutorials/images/segmentation.ipynb
 """
-import tempfile
-
 import filelock
 import tensorflow as tf
 from tensorflow_examples.models.pix2pix import pix2pix
@@ -65,9 +63,8 @@ class UNetsTrial(TFKerasTrial):
         with filelock.FileLock(os.path.join(weights_dir, "download.lock")):
             full_weights_path = weights_dir + data_file
             if not os.path.exists(full_weights_path):
-                with tempfile.NamedTemporaryFile(delete=False) as ntf:
-                    urllib.request.urlretrieve(mobilenet_link, ntf.name)
-                    os.rename(ntf.name, full_weights_path)
+                urllib.request.urlretrieve(mobilenet_link, full_weights_path + ".part")
+                os.rename(full_weights_path + ".part", full_weights_path)
         return full_weights_path
 
     def build_model(self):

--- a/examples/computer_vision/unets_tf_keras/model_def.py
+++ b/examples/computer_vision/unets_tf_keras/model_def.py
@@ -5,6 +5,8 @@ regarding the optional flags view the original script linked below.
 This implementation is based on:
 https://github.com/tensorflow/docs/blob/master/site/en/tutorials/images/segmentation.ipynb
 """
+import tempfile
+
 import filelock
 import tensorflow as tf
 from tensorflow_examples.models.pix2pix import pix2pix
@@ -61,9 +63,12 @@ class UNetsTrial(TFKerasTrial):
 
         # Use a file lock so only one worker on each node does the download
         with filelock.FileLock(os.path.join(weights_dir, "download.lock")):
-            if not os.path.exists(weights_dir + data_file):
-                urllib.request.urlretrieve(mobilenet_link, weights_dir + data_file)
-        return weights_dir + data_file
+            full_weights_path = weights_dir + data_file
+            if not os.path.exists(full_weights_path):
+                with tempfile.NamedTemporaryFile(delete=False) as ntf:
+                    urllib.request.urlretrieve(mobilenet_link, ntf.name)
+                    os.rename(ntf.name, full_weights_path)
+        return full_weights_path
 
     def build_model(self):
         model_weights_loc =  self.download_weights()


### PR DESCRIPTION
## Description

The previous fix to test_unets_tf_keras_distributed protected model data file loading with filelock but did not forego loading file if it was already present. As a result, other workers started downloading the file as soon as they got the lock and the file appeared as truncated to some workers. The solution is to check if file exists inside the lock and not download it again if it does.

<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At a minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions about this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ