### PR TITLE
chore: resolve conflicting cli abbreviation

### DIFF
--- a/harness/determined/cli/master.py
+++ b/harness/determined/cli/master.py
@@ -68,7 +68,7 @@ def logs(args: Namespace) -> None:
 # fmt: off
 
 args_description = [
-    Cmd("m|aster", None, "manage master", [
+    Cmd("master", None, "manage master", [
         Cmd("config", config, "fetch master config", [
             Group(format_args["json"], format_args["yaml"])
         ]),


### PR DESCRIPTION
## Description

`det master` and `det model` both showed as allowing `det m`.

In practice `det m` only referred to `det model`.