### PR TITLE
chore: containers should always be killed by their parent, remove incorrect exits with 0

### DIFF
--- a/agent/internal/container.go
+++ b/agent/internal/container.go
@@ -122,14 +122,15 @@ func (c *containerActor) Receive(ctx *actor.Context) error {
 		case cproto.Assigned, cproto.Pulling:
 			switch msg.Signal {
 			case syscall.SIGINT, syscall.SIGTERM, syscall.SIGKILL:
-				msg := "attempting to stop container while in [%s] state"
-				ctx.Log().Infof(msg, c.State)
+				msg := "attempting to stop container %s while in [%s] state"
+				ctx.Log().Infof(msg, c.ID, c.State)
 				ctx.Self().Stop()
 				c.containerStopped(ctx,
-					aproto.ContainerError(aproto.ContainerAborted, fmt.Errorf(msg, c.State)))
+					aproto.ContainerError(aproto.ContainerAborted, fmt.Errorf(msg, c.ID, c.State)))
 			default:
 				ctx.Log().Warnf(
-					"ignoring signal, signal not supported while container in [%s] state", c.State)
+					"ignoring signal, signal not supported while container %s in [%s] state",
+					c.ID, c.State)
 			}
 		case cproto.Starting:
 			// Delay signaling the container until the container is actually running.

--- a/agent/internal/container.go
+++ b/agent/internal/container.go
@@ -122,9 +122,11 @@ func (c *containerActor) Receive(ctx *actor.Context) error {
 		case cproto.Assigned, cproto.Pulling:
 			switch msg.Signal {
 			case syscall.SIGINT, syscall.SIGTERM, syscall.SIGKILL:
-				ctx.Log().Infof("attempting to stop container while in [%s] state", c.State)
+				msg := "attempting to stop container while in [%s] state"
+				ctx.Log().Infof(msg, c.State)
 				ctx.Self().Stop()
-				c.containerStopped(ctx, aproto.ContainerStopped{})
+				c.containerStopped(ctx,
+					aproto.ContainerError(aproto.ContainerAborted, fmt.Errorf(msg, c.State)))
 			default:
 				ctx.Log().Warnf(
 					"ignoring signal, signal not supported while container in [%s] state", c.State)

--- a/master/internal/checkpoint_gc.go
+++ b/master/internal/checkpoint_gc.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/determined-ai/determined/master/internal/db"
 	"github.com/determined-ai/determined/master/internal/sproto"
+	"github.com/determined-ai/determined/master/internal/task"
 	"github.com/determined-ai/determined/master/pkg/actor"
 	"github.com/determined-ai/determined/master/pkg/cproto"
 	"github.com/determined-ai/determined/master/pkg/tasks"
@@ -62,7 +63,7 @@ func (t *checkpointGCTask) Receive(ctx *actor.Context) error {
 			AgentRank:    0,
 			IsMultiAgent: false,
 		})
-	case sproto.ReleaseResources:
+	case sproto.ReleaseResources, task.AllocationSignal:
 		// Ignore the release resource message and wait for the GC job to finish.
 
 	case sproto.TaskContainerStateChanged:

--- a/master/internal/resourcemanagers/agent/agent.go
+++ b/master/internal/resourcemanagers/agent/agent.go
@@ -12,6 +12,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/determined-ai/determined/master/internal/sproto"
+	"github.com/determined-ai/determined/master/internal/task"
 	"github.com/determined-ai/determined/master/pkg/actor"
 	"github.com/determined-ai/determined/master/pkg/actor/actors"
 	ws "github.com/determined-ai/determined/master/pkg/actor/api"
@@ -228,8 +229,7 @@ func (a *agent) receive(ctx *actor.Context, msg interface{}) error {
 		// Kill both slotted and zero-slot tasks, unless draining.
 		if !msg.Drain {
 			for cid := range a.containers {
-				// TODO(DET-5916): This kill should not count towards max_restarts.
-				ctx.Tell(ctx.Self(), sproto.KillTaskContainer{ContainerID: cid})
+				ctx.Tell(a.containers[cid], task.Kill)
 			}
 		}
 		ctx.Respond(&proto.DisableAgentResponse{Agent: a.summarize(ctx).ToProto()})

--- a/master/internal/task/allocation.go
+++ b/master/internal/task/allocation.go
@@ -657,7 +657,7 @@ func (a *Allocation) terminated(ctx *actor.Context) {
 				ctx.Log().WithError(err).Warnf("allocation exited due to agent (%s)", err.FailureType)
 				exit.Err = err
 				return
-			case aproto.TaskAborted:
+			case aproto.TaskAborted, aproto.ContainerAborted:
 				ctx.Log().WithError(err).Debugf("allocation aborted (%s)", err.FailureType)
 				exit.Err = err
 				return

--- a/master/pkg/aproto/exit.go
+++ b/master/pkg/aproto/exit.go
@@ -70,6 +70,9 @@ const (
 	// ContainerFailed denotes that the container ran but failed with a non-zero exit code.
 	ContainerFailed = FailureType("container failed with non-zero exit code")
 
+	// ContainerAborted denotes the container was canceled before it was started.
+	ContainerAborted = FailureType("container was aborted before it started")
+
 	// TaskAborted denotes that the task was canceled before it was started.
 	TaskAborted = FailureType("task was aborted before the task was started")
 
@@ -95,7 +98,7 @@ func IsRestartableSystemError(err error) bool {
 		case AgentError, AgentFailed:
 			return true
 		// Definitely not a failure.
-		case TaskAborted:
+		case TaskAborted, ContainerAborted:
 			return true
 		default:
 			return false


### PR DESCRIPTION
## Description
Previously if a container was killed through the agent/slot disable code path, it would kill containers directly rather than telling the allocation actor to kill itself. In all cases, a spurious container death will cause the allocation to die anyway and `det a --drain` is available when killing the allocation is not optimal (despite its issues, this will be true eventually). Moreover, a spurious container exit while the container is pulling causes the allocation actor to just receive an empty `containerStopped{}` which is indistinguishable from an exit 0. The allocation actor would interpret that exit incorrectly as a container deciding to exit early. 

This change makes kills always go through the allocation actor, so logic like counting towards max restarts is taken into account, and also fixes this bug since the allocation knows it was killed. Also a new container exit 'ContainerAborted' is added for cases where a container is killed before the agent can start it, rather than just returning 'container exited 0' since this is just wrong and could easily other issues.
<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At a minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan
- [x] run an experiment and disable agents. it should reschedule itself and re-enabling the agent it should allow the job to run to completion. 
<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions about this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)
Separately the new exit failure type and killing through the allocation actor both fix the bug that was seen. But also separately, they're both more 'correct' than they were previously, and it's possible the same error manifested through their 'incorrectness' in ways I haven't seen through static analysis. E.G. returning 'exited with 0' ever when we haven't is nonsense, and could cause other bugs on its own.
<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ