### PR TITLE
fix: log viewer bug

### DIFF
--- a/webui/react/src/components/LogViewerCore.tsx
+++ b/webui/react/src/components/LogViewerCore.tsx
@@ -188,7 +188,6 @@ const LogViewerCore: React.FC<Props> = ({
     if (!local.current.isScrollReady) return;
 
     local.current.isOnTop = visibleStartIndex === 0;
-    // mismatch between visibleStopIndex and logs updates causes flickering and disappearing logs:
     local.current.isOnBottom = visibleStopIndex === logs.length - 1;
 
     setIsTailing(local.current.isOnBottom && isNewestFirst);

--- a/webui/react/src/components/LogViewerCore.tsx
+++ b/webui/react/src/components/LogViewerCore.tsx
@@ -188,7 +188,8 @@ const LogViewerCore: React.FC<Props> = ({
     if (!local.current.isScrollReady) return;
 
     local.current.isOnTop = visibleStartIndex === 0;
-    local.current.isOnBottom = visibleStopIndex === logs.length - 1;
+    // mismatch between visibleStopIndex and logs updates causes flickering and disappearing logs:
+    local.current.isOnBottom = visibleStopIndex + 1 === logs.length - 1;
 
     setIsTailing(local.current.isOnBottom && isNewestFirst);
 

--- a/webui/react/src/components/LogViewerCore.tsx
+++ b/webui/react/src/components/LogViewerCore.tsx
@@ -189,7 +189,7 @@ const LogViewerCore: React.FC<Props> = ({
 
     local.current.isOnTop = visibleStartIndex === 0;
     // mismatch between visibleStopIndex and logs updates causes flickering and disappearing logs:
-    local.current.isOnBottom = visibleStopIndex + 1 === logs.length - 1;
+    local.current.isOnBottom = visibleStopIndex === logs.length - 1;
 
     setIsTailing(local.current.isOnBottom && isNewestFirst);
 
@@ -315,7 +315,7 @@ const LogViewerCore: React.FC<Props> = ({
 
         addLogs(logs);
 
-        if (currentIsOnBottom) listRef.current?.scrollTo(Number.MAX_SAFE_INTEGER);
+        if (currentIsOnBottom) listRef.current?.scrollToItem(Number.MAX_SAFE_INTEGER, 'end');
       }
     };
     const throttledProcessBuffer = throttle(THROTTLE_TIME, processBuffer);


### PR DESCRIPTION
## Description

Fix for bug where log viewer was flickering (scrolling to top) and some log entries would disappear. Flickering/scrolling issue was more noticeable in Safari but both issues appeared in both Safari and Chrome.

https://user-images.githubusercontent.com/97752292/153456995-9b812e8d-114c-4624-a507-838d12137815.mov

## Test Plan

- [ ] Run experiments and make sure that the logs display without flickering or disappearing issues. 


## Commentary (optional)

Seemed to be an issue where the update to `logs.length` made the `handleItemsRendered` callback run before `visibleStopIndex` updated. There may be another way to make sure these values match, but checking that `visibleStopIndex` matches `logs.length - 2` instead of `logs.length - 1` seems to fix the problem.

## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
