### PR TITLE
chore: add additional logging for creds helper [DET-6710]

### DIFF
--- a/agent/internal/docker.go
+++ b/agent/internal/docker.go
@@ -131,17 +131,25 @@ func (d *dockerActor) pullImage(ctx *actor.Context, msg pullImage) {
 			sendErr(ctx, errors.Wrap(err, "error encoding registry credentials"))
 			return
 		}
-	} else if store, ok := d.credentialStores[reference.Domain(ref)]; ok {
-		var creds types.AuthConfig
-		creds, err = store.get()
-		if err != nil {
-			sendErr(ctx, errors.Wrap(err, "unable to get credentials from helper"))
-			return
-		}
-		reg, err = registryToString(creds)
-		if err != nil {
-			sendErr(ctx, errors.Wrap(err, "error encoding registry credentials from helper"))
-			return
+	} else {
+		domain := reference.Domain(ref)
+		if store, ok := d.credentialStores[domain]; ok {
+			var creds types.AuthConfig
+			creds, err = store.get()
+			if err != nil {
+				sendErr(ctx, errors.Wrap(err, "unable to get credentials from helper"))
+				return
+			}
+			reg, err = registryToString(creds)
+			if err != nil {
+				sendErr(ctx, errors.Wrap(err, "error encoding registry credentials from helper"))
+				return
+			}
+			d.sendAuxLog(ctx, fmt.Sprintf(
+				"domain '%s' found in 'credHelpers' config. Using credentials helper.", domain))
+		} else {
+			d.sendAuxLog(ctx, fmt.Sprintf(
+				"domain '%s' not found in 'credHelpers' config. Using anonymous credentials.", domain))
 		}
 	}
 


### PR DESCRIPTION
How to test:

Launch an experiment and use a container on a repo which doesn't allow anonymous credential without the domain specified in your `~/.docker/config.json`

Exp config:
environment:
  image: us-east1-docker.pkg.dev/determined-ai/msuarez-test-f/cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-9f0cb26

Make sure you don't have, `us-east1-docker.pkg.dev` in your `~/.docker/config.json` `credHelpers`.

Note that it fails with a message saying that we couldn't find the domain.

----

Update your `~/.docker/config.json` to have this:

```
{
  "auths": {...}
  },
  "credHelpers": {
    ...
    "us-east1-docker.pkg.dev": "gcloud"
  }
}
```

Run the same experiment and verify that there is a log line indicating we are using the credential helper for the domain.