### PR TITLE
feat: Undo changes and warn user when InlineEditor fails to update db [DET-6659]

### DIFF
--- a/webui/react/src/pages/ExperimentDetails/ExperimentDetailsHeader.tsx
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentDetailsHeader.tsx
@@ -143,6 +143,7 @@ const ExperimentDetailsHeader: React.FC<Props> = ({
         silent: false,
         type: ErrorType.Server,
       });
+      return e;
     }
   }, [ experiment.id, fetchExperimentDetails ]);
 
@@ -158,6 +159,7 @@ const ExperimentDetailsHeader: React.FC<Props> = ({
         silent: false,
         type: ErrorType.Server,
       });
+      return e;
     }
   }, [ experiment.id, fetchExperimentDetails ]);
 

--- a/webui/react/src/pages/ExperimentList.tsx
+++ b/webui/react/src/pages/ExperimentList.tsx
@@ -268,9 +268,10 @@ const ExperimentList: React.FC = () => {
       handleError(e, {
         isUserTriggered: true,
         publicMessage: 'Unable to save experiment description.',
-        silent: true,
+        silent: false,
       });
       setIsLoading(false);
+      return e;
     }
   }, [ ]);
 

--- a/webui/react/src/pages/ModelDetails.tsx
+++ b/webui/react/src/pages/ModelDetails.tsx
@@ -131,9 +131,10 @@ const ModelDetails: React.FC = () => {
       } catch (e) {
         handleError(e, {
           publicSubject: 'Unable to save version description.',
-          silent: true,
+          silent: false,
           type: ErrorType.Api,
         });
+        return e;
       }
     }, [ modelName ]);
 
@@ -264,7 +265,7 @@ const ModelDetails: React.FC = () => {
     } catch (e) {
       handleError(e, {
         publicSubject: 'Unable to save metadata.',
-        silent: true,
+        silent: false,
         type: ErrorType.Api,
       });
     }
@@ -280,7 +281,7 @@ const ModelDetails: React.FC = () => {
     } catch (e) {
       handleError(e, {
         publicSubject: 'Unable to save description.',
-        silent: true,
+        silent: false,
         type: ErrorType.Api,
       });
       setIsLoading(false);
@@ -297,7 +298,7 @@ const ModelDetails: React.FC = () => {
     } catch (e) {
       handleError(e, {
         publicSubject: 'Unable to save name.',
-        silent: true,
+        silent: false,
         type: ErrorType.Api,
       });
       return e;

--- a/webui/react/src/pages/ModelRegistry.tsx
+++ b/webui/react/src/pages/ModelRegistry.tsx
@@ -262,10 +262,11 @@ const ModelRegistry: React.FC = () => {
     } catch (e) {
       handleError(e, {
         publicSubject: 'Unable to save model description.',
-        silent: true,
+        silent: false,
         type: ErrorType.Api,
       });
       setIsLoading(false);
+      return e;
     }
   }, [ ]);
 

--- a/webui/react/src/pages/ModelVersionDetails.tsx
+++ b/webui/react/src/pages/ModelVersionDetails.tsx
@@ -100,7 +100,7 @@ const ModelVersionDetails: React.FC = () => {
     } catch (e) {
       handleError(e, {
         publicSubject: 'Unable to update notes.',
-        silent: false,
+        silent: true,
         type: ErrorType.Api,
       });
     }

--- a/webui/react/src/pages/ModelVersionDetails.tsx
+++ b/webui/react/src/pages/ModelVersionDetails.tsx
@@ -83,7 +83,7 @@ const ModelVersionDetails: React.FC = () => {
     } catch (e) {
       handleError(e, {
         publicSubject: 'Unable to save metadata.',
-        silent: true,
+        silent: false,
         type: ErrorType.Api,
       });
     }
@@ -100,7 +100,7 @@ const ModelVersionDetails: React.FC = () => {
     } catch (e) {
       handleError(e, {
         publicSubject: 'Unable to update notes.',
-        silent: true,
+        silent: false,
         type: ErrorType.Api,
       });
     }
@@ -116,7 +116,7 @@ const ModelVersionDetails: React.FC = () => {
     } catch (e) {
       handleError(e, {
         publicSubject: 'Unable to save description.',
-        silent: true,
+        silent: false,
         type: ErrorType.Api,
       });
     }
@@ -132,7 +132,7 @@ const ModelVersionDetails: React.FC = () => {
     } catch (e) {
       handleError(e, {
         publicSubject: 'Unable to save name.',
-        silent: true,
+        silent: false,
         type: ErrorType.Api,
       });
     }
@@ -149,7 +149,7 @@ const ModelVersionDetails: React.FC = () => {
     } catch (e) {
       handleError(e, {
         publicSubject: 'Unable to save tags.',
-        silent: true,
+        silent: false,
         type: ErrorType.Api,
       });
     }


### PR DESCRIPTION
## Description

On pages where we use the InlineEditor component (listed in Test Plan) we should return a server-side error to the component so it reverts the user's change and shows the original/stored value. This also uses `handleError({ silent: false })` to make sure the user knows what's happened.

Note: I changed silent from true to false in a few other places (I think model and model version metadata / notes). If this is excessive then I can change those back.


## Test Plan

To test DB failures, in `master/static/srv/update_model.sql` and `patch_experiment.sql` write a SQL bug like `name = $2::int` to fail every update.

Uses of InlineEditor:
- description on Experiments (list)
- name and description on ExperimentDetails
- description on Model Registry (model list)
- name, description, and descriptions of model versions on ModelDetails
- name and description on ModelVersionDetails


## Checklist

- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.