### PR TITLE
fix: dtrain + native api

### DIFF
--- a/e2e_tests/tests/experiment/test_pytorch.py
+++ b/e2e_tests/tests/experiment/test_pytorch.py
@@ -242,3 +242,12 @@ def test_distributed_logging() -> None:
         assert exp.check_if_string_present_in_trial_logs(
             t_id, "finished train_batch for rank {}".format(i)
         )
+
+
+@pytest.mark.parallel
+def test_pytorch_native_api_parallel() -> None:
+    exp_id = exp.create_native_experiment(
+        conf.fixtures_path("pytorch_no_op"),
+        [sys.executable, "model_def.py", "--slots-per-trial", "8"],
+    )
+    exp.wait_for_experiment_state(exp_id, "COMPLETED")

--- a/e2e_tests/tests/fixtures/pytorch_no_op/model_def.py
+++ b/e2e_tests/tests/fixtures/pytorch_no_op/model_def.py
@@ -69,6 +69,7 @@ class NoopPyTorchTrial(pytorch.PyTorchTrial):
 
 if __name__ == "__main__":
     import argparse
+
     parser = argparse.ArgumentParser()
     parser.add_argument("--slots-per-trial", default="1")
     args = parser.parse_args()

--- a/e2e_tests/tests/fixtures/pytorch_no_op/model_def.py
+++ b/e2e_tests/tests/fixtures/pytorch_no_op/model_def.py
@@ -68,8 +68,13 @@ class NoopPyTorchTrial(pytorch.PyTorchTrial):
 
 
 if __name__ == "__main__":
+    import argparse
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--slots-per-trial", default="1")
+    args = parser.parse_args()
+
     conf = yaml.safe_load(
-        """
+        f"""
     description: noop-pytorch-native-api
     data:
       model_type: single_output
@@ -87,6 +92,8 @@ if __name__ == "__main__":
       batches: 1
     min_validation_period:
       batches: 1
+    resources:
+      slots_per_trial: {args.slots_per_trial}
     """
     )
     experimental.create(NoopPyTorchTrial, conf, context_dir=".")

--- a/harness/determined/exec/harness.py
+++ b/harness/determined/exec/harness.py
@@ -32,6 +32,8 @@ def maybe_periodic_stacktraces(debug_enabled: bool) -> Iterator[None]:
 
 
 def main(train_entrypoint: Optional[str]) -> int:
+    if train_entrypoint == "__NATIVE__":
+        train_entrypoint = None
     info = det.get_cluster_info()
     assert info is not None, "must be run on-cluster"
     assert info.task_type == "TRIAL", f'must be run with task_type="TRIAL", not "{info.task_type}"'

--- a/harness/determined/exec/launch.py
+++ b/harness/determined/exec/launch.py
@@ -20,14 +20,17 @@ def match_legacy_trial_class(arg: str) -> bool:
 
 
 def launch(experiment_config: det.ExperimentConfig) -> int:
+    slots_per_trial = experiment_config.slots_per_trial()
+    entrypoint = experiment_config.get_entrypoint()
+
     # If native is enabled, harness will load from native entrypoint command
     if experiment_config.native_enabled():
-        from determined.exec import harness
+        if slots_per_trial < 2:
+            from determined.exec import harness
 
-        return harness.main(train_entrypoint=None)
-
-    entrypoint = experiment_config.get_entrypoint()
-    slots_per_trial = experiment_config.slots_per_trial()
+            return harness.main(train_entrypoint=None)
+        else:
+            entrypoint = ["python3", "-m", "determined.launch.autohorovod", "__NATIVE__"]
 
     if not entrypoint:
         raise AssertionError("Entrypoint not found in experiment config")

--- a/harness/tests/test_launch.py
+++ b/harness/tests/test_launch.py
@@ -12,7 +12,8 @@ def test_launch_native(mock_harness: MagicMock, mock_subprocess: MagicMock) -> N
     Native enabled -> launch harness.py
     """
     native = {
-        "internal": {"native": {"command": ["script.py"]}}, "resources": {"slots_per_trial": 1}
+        "internal": {"native": {"command": ["script.py"]}},
+        "resources": {"slots_per_trial": 1},
     }
 
     launch.launch(det.ExperimentConfig(native))
@@ -28,7 +29,8 @@ def test_launch_native_parallel(mock_harness: MagicMock, mock_subprocess: MagicM
     Native enabled -> launch harness.py
     """
     native = {
-        "internal": {"native": {"command": ["script.py"]}}, "resources": {"slots_per_trial": 4}
+        "internal": {"native": {"command": ["script.py"]}},
+        "resources": {"slots_per_trial": 4},
     }
 
     launch.launch(det.ExperimentConfig(native))

--- a/harness/tests/test_launch.py
+++ b/harness/tests/test_launch.py
@@ -11,11 +11,30 @@ def test_launch_native(mock_harness: MagicMock, mock_subprocess: MagicMock) -> N
     entrypoint: None
     Native enabled -> launch harness.py
     """
-    native = {"internal": {"native": {"command": ["script.py"]}}}
+    native = {
+        "internal": {"native": {"command": ["script.py"]}}, "resources": {"slots_per_trial": 1}
+    }
 
     launch.launch(det.ExperimentConfig(native))
     mock_harness.assert_called_once_with(train_entrypoint=None)
     mock_subprocess.assert_not_called()
+
+
+@patch("subprocess.Popen")
+@patch("determined.exec.harness.main")
+def test_launch_native_parallel(mock_harness: MagicMock, mock_subprocess: MagicMock) -> None:
+    """
+    entrypoint: None
+    Native enabled -> launch harness.py
+    """
+    native = {
+        "internal": {"native": {"command": ["script.py"]}}, "resources": {"slots_per_trial": 4}
+    }
+
+    launch.launch(det.ExperimentConfig(native))
+    mock_harness.assert_not_called()
+    entrypoint_list = ["python3", "-m", "determined.launch.autohorovod", "__NATIVE__"]
+    mock_subprocess.assert_called_once_with(entrypoint_list)
 
 
 @patch("subprocess.Popen")


### PR DESCRIPTION
Previously, Native API-launched experiments always took the non-dtrain
codepath.