### PR TITLE
feat: support gcs backend for terraform state in `det deploy gcp`.

### DIFF
--- a/harness/determined/deploy/gcp/cli.py
+++ b/harness/determined/deploy/gcp/cli.py
@@ -48,7 +48,11 @@ def deploy_gcp(command: str, args: argparse.Namespace) -> None:
     if not os.path.exists(args.local_state_path):
         os.makedirs(args.local_state_path)
     os.chdir(args.local_state_path)
-    print("Using local state path:", args.local_state_path)
+
+    if args.tf_state_gcs_bucket_name:
+        print("Using GCS bucket for state:", args.tf_state_gcs_bucket_name)
+    else:
+        print("Using local state path:", args.local_state_path)
 
     # Set the TF_DATA_DIR where Terraform will store its supporting files
     env = os.environ.copy()
@@ -96,6 +100,7 @@ def deploy_gcp(command: str, args: argparse.Namespace) -> None:
         "no_wait_for_master",
         "no_prompt",
         "master_config_template_path",
+        "tf_state_gcs_bucket_name",
         "func",
         "_command",
         "_subcommand",
@@ -408,6 +413,13 @@ args_description = Cmd(
                             type=Path,
                             default=None,
                             help="path to master yaml template",
+                        ),
+                        Arg(
+                            "--tf-state-gcs-bucket-name",
+                            type=str,
+                            default=None,
+                            help="use the GCS bucket to store the terraform state "
+                            "instead of a local directory"
                         ),
                     ],
                 ),


### PR DESCRIPTION
## Description

Add an option to store terraform state of `det deploy gcp` in a provided GCS bucket. This enables users to update or delete a cluster even if they lose the local terraform state files, and it enables us to create GCP clusters via CI, and be able to clean them up later on crashes, e.g. in terminator. 

## Test Plan

0. Make an initial working directory for a cluster (`mkdir -p ~/dev/cluster/gcp/lost-1 && cd !$`)
1. Create a cluster: `det deploy gcp up --cluster-id ilia-test-ci-4 --project-id determined-ai-ci --max-dynamic-agents 2 --tf-state-gcs-bucket-name determined-ai-ci-det-deploy-terraform`
2. "Lose" the initial working directory and make a new one(`mkdir -p ~/dev/cluster/gcp/lost-2 && cd !$`)
3. Dry-running with the same command will retried the state from GCS and recover what you need `det deploy gcp up --cluster-id ilia-test-ci-4 --project-id determined-ai-ci --max-dynamic-agents 2 --tf-state-gcs-bucket-name determined-ai-ci-det-deploy-terraform --dry-run`
4. `det deploy gcp down` will now work and blow away the stack.

## Commentary (optional)

GCP labels turned out to be limited: you can't label *everything* but only a subset of resources. Therefore storing TF state in GCS seems like the better solution for cleanup/recovery of lost stacks.

## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
