### PR TITLE
fix: make SelectFilter input wide enough to see what I type in MetricSelectFilter [DPS-30] [DET-6642]

### DIFF
--- a/webui/react/src/components/MetricSelectFilter.tsx
+++ b/webui/react/src/components/MetricSelectFilter.tsx
@@ -162,6 +162,7 @@ const MetricSelectFilter: React.FC<Props> = ({
   return (
     <SelectFilter
       autoClearSearchValue={false}
+      className="metric-search"
       disableTags
       dropdownMatchSelectWidth={dropdownMatchSelectWidth}
       filterOption={handleFiltering}

--- a/webui/react/src/components/SelectFilter.module.scss
+++ b/webui/react/src/components/SelectFilter.module.scss
@@ -26,3 +26,6 @@
   & > *:first-child { margin-bottom: var(--theme-sizes-layout-tiny); }
   & > *:not(:first-child) { margin-left: 0; }
 }
+:global(.ant-select-selection-search-input) {
+  width: auto !important;
+}

--- a/webui/react/src/components/SelectFilter.module.scss
+++ b/webui/react/src/components/SelectFilter.module.scss
@@ -6,6 +6,9 @@
     margin-left: var(--theme-sizes-layout-medium);
   }
 }
+:global(.metric-search .ant-select-selection-search-input) {
+  width: auto;
+}
 .disableTags {
   :global(.ant-select-multiple .ant-select-selection-item) {
     background-color: transparent;
@@ -25,7 +28,4 @@
 
   & > *:first-child { margin-bottom: var(--theme-sizes-layout-tiny); }
   & > *:not(:first-child) { margin-left: 0; }
-}
-:global(.ant-select-selection-search-input) {
-  width: auto !important;
 }


### PR DESCRIPTION
## Description

On the Experiment Detail page / TrialDetails chart, in the dropdown where you select Metrics for the chart, this fixes an issue where you couldn't see what you were typing ( https://determinedai.atlassian.net/browse/DET-6642 )

The only Ant Select component / prop-level issue I could see is this happens when we set  mode='multiple', which we need.

## Test Plan

Select a metric (such as loss) by typing a metric such as 'loss' in the MetricSelectFilter dropdown of the TrialDetails chart.

## Checklist

- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.