### PR TITLE
fix: allow list hparams in local mode

### DIFF
--- a/harness/determined/common/api/experiment.py
+++ b/harness/determined/common/api/experiment.py
@@ -181,7 +181,7 @@ def generate_random_hparam_values(hparam_def: Dict[str, Any]) -> Dict[str, Any]:
                 return math.pow(hparam["base"], random.uniform(hparam["minval"], hparam["maxval"]))
             else:
                 raise Exception("Wrong type of hyperparameter: {}".format(hparam["type"]))
-        elif isinstance(hparam, (int, float, str, type(None))):
+        elif isinstance(hparam, (int, float, str, list, type(None))):
             return hparam
         else:
             raise Exception("Wrong type of hyperparameter: {}".format(type(hparam)))


### PR DESCRIPTION
## Description

Allow list hparams in --local mode.

## Test Plan

Run an experiment that uses a list in hparams and ensure it does not error out during loading.  A good example is `cd examples/computer_vision/byol_pytorch && det experiment create --local --test const-cifar10.yaml .`

## Commentary

List hparams work just fine normally, but the function `generate_random_hparam_values` (accidentally?) excluded them.

## Checklist

- [X] User-facing API changes need the "User-facing API Change" label.
- [] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [X] Licenses should be included for new code which was copied and/or modified from any external code.
