### PR TITLE
feat: support k8s db ssl [DET-6364]

### DIFF
--- a/docs/release-notes/3624-support-k8s-ssl.txt
+++ b/docs/release-notes/3624-support-k8s-ssl.txt
@@ -1,0 +1,9 @@
+:orphan:
+
+**New Features**
+
+-  Now supports setting root certificates for the DB via the determined helm chart. This allows
+   determined to use SSL to connect to the DB without having to replace the master config manually.
+   To use this feature, save the certificate in a configmap or secret and fill out the following
+   fields from ``values.yaml``: ``sslMode``, ``sslRootCert``, ``resourceType``, and
+   ``certResourceName``

--- a/helm/charts/determined/templates/master-config.yaml
+++ b/helm/charts/determined/templates/master-config.yaml
@@ -47,10 +47,9 @@ data:
       name: {{ .Values.db.name | quote }}
       {{- if .Values.db.sslMode }}
       ssl_mode: {{ .Values.db.sslMode }}
+      {{- $rootCert := (required "A valid .Values.db.sslRootCert entry required!" .Values.db.sslRootCert )}}
+      ssl_root_cert: {{ include "determined.secretPath" . }}{{ $rootCert }}
       {{- end }}
-      {{- if .Values.db.sslRootCert }}
-      ssl_root_cert: {{ include "determined.secretPath" . }}{{ .Values.db.sslRootCert }}
-      {{ end }}
 
     {{- if .Values.tlsSecret }}
     security:

--- a/helm/charts/determined/templates/master-config.yaml
+++ b/helm/charts/determined/templates/master-config.yaml
@@ -45,6 +45,12 @@ data:
       {{- end  }}
       port: {{ .Values.db.port }}
       name: {{ .Values.db.name | quote }}
+      {{- if .Values.db.sslMode }}
+      ssl_mode: {{ .Values.db.sslMode }}
+      {{- end }}
+      {{- if .Values.db.sslRootCert }}
+      ssl_root_cert: {{ include "determined.secretPath" . }}{{ .Values.db.sslRootCert }}
+      {{ end }}
 
     {{- if .Values.tlsSecret }}
     security:

--- a/helm/charts/determined/templates/master-deployment.yaml
+++ b/helm/charts/determined/templates/master-deployment.yaml
@@ -45,6 +45,11 @@ spec:
             mountPath: {{ include "determined.secretPath" . }}
             readOnly: true
           {{ end }}
+          {{- if .Values.db.certSecretName }}
+          - name: database-cert-secret
+            mountPath: {{ include "determined.secretPath" . }}
+            readOnly: true
+          {{ end }}
         resources:
           requests:
             {{- if .Values.masterCpuRequest }}
@@ -65,4 +70,9 @@ spec:
         - name: tls-secret
           secret:
             secretName: {{ .Values.tlsSecret }}
+        {{ end }}
+        {{- if .Values.db.certSecretName }}
+        - name: database-cert-secret
+          secret:
+            secretName: {{ .Values.db.certSecretName }}
         {{ end }}

--- a/helm/charts/determined/templates/master-deployment.yaml
+++ b/helm/charts/determined/templates/master-deployment.yaml
@@ -71,7 +71,7 @@ spec:
           secret:
             secretName: {{ .Values.tlsSecret }}
         {{ end }}
-        {{- if .Values.db.certResourceName }}
+        {{- if .Values.db.sslMode }}
         - name: database-cert
           {{- $resourceType := (required "A valid .Values.db.resourceType entry required!" .Values.db.resourceType | trim)}}
           {{- if eq $resourceType "configMap"}}

--- a/helm/charts/determined/templates/master-deployment.yaml
+++ b/helm/charts/determined/templates/master-deployment.yaml
@@ -45,8 +45,8 @@ spec:
             mountPath: {{ include "determined.secretPath" . }}
             readOnly: true
           {{ end }}
-          {{- if .Values.db.certSecretName }}
-          - name: database-cert-secret
+          {{- if .Values.db.certResourceName }}
+          - name: database-cert
             mountPath: {{ include "determined.secretPath" . }}
             readOnly: true
           {{ end }}
@@ -71,8 +71,14 @@ spec:
           secret:
             secretName: {{ .Values.tlsSecret }}
         {{ end }}
-        {{- if .Values.db.certSecretName }}
-        - name: database-cert-secret
+        {{- if .Values.db.certResourceName }}
+        - name: database-cert
+          {{- $resourceType := (required "A valid .Values.db.resourceType entry required!" .Values.db.resourceType | trim)}}
+          {{- if eq $resourceType "configMap"}}
+          configMap:
+            name: {{ required  "A valid Values.db.certResourceName entry is required!" .Values.db.certResourceName }}
+          {{- else }}
           secret:
-            secretName: {{ .Values.db.certSecretName }}
+            secretName: {{ required  "A valid Values.db.certResourceName entry is required!" .Values.db.certResourceName }}
+          {{- end }}
         {{ end }}

--- a/helm/charts/determined/values.yaml
+++ b/helm/charts/determined/values.yaml
@@ -60,6 +60,14 @@ db:
   # create a PersistentVolume that will match the PersistentVolumeClaim.
   # storageClassName:
 
+  # ssl_mode and ssl_root_cert configure the TLS connection to the database. Currently, only
+  # verify-ca is supported for ssl_mode. To specify a certificate, add the name of the file (no path)
+  # for ssl_root_cert.
+  # sslMode: verify-ca
+  # sslRootCert: <cert name>
+  # certSecretName:
+
+
 # checkpointStorage controls where checkpoints are stored. Supported types include `shared_fs`,
 # `gcs`, and `s3`.
 checkpointStorage:

--- a/helm/charts/determined/values.yaml
+++ b/helm/charts/determined/values.yaml
@@ -60,9 +60,10 @@ db:
   # create a PersistentVolume that will match the PersistentVolumeClaim.
   # storageClassName:
 
-  # ssl_mode and ssl_root_cert configure the TLS connection to the database. Currently, only
-  # verify-ca is supported for ssl_mode. To specify a certificate, add the name of the file (no path)
-  # for ssl_root_cert.
+  # ssl_mode and ssl_root_cert configure the TLS connection to the database. Users must first
+  # create a kubernetes secret containing their certificate and specify its name in certSecretName.
+  # For ssl_mode, only verify-ca is currently supported. For sslRootCert, specify the name of the file
+  # only (not path).
   # sslMode: verify-ca
   # sslRootCert: <cert name>
   # certSecretName:

--- a/helm/charts/determined/values.yaml
+++ b/helm/charts/determined/values.yaml
@@ -61,12 +61,12 @@ db:
   # storageClassName:
 
   # ssl_mode and ssl_root_cert configure the TLS connection to the database. Users must first
-  # create a kubernetes secret containing their certificate and specify its name in certSecretName.
-  # For ssl_mode, only verify-ca is currently supported. For sslRootCert, specify the name of the file
-  # only (not path).
+  # create a kubernetes secret or configMap containing their certificate and specify its name in
+  # certResourceName. For sslRootCert, specify the name of the file only (not path).
   # sslMode: verify-ca
-  # sslRootCert: <cert name>
-  # certSecretName:
+  # sslRootCert: <cert_name>
+  # resourceType: <secret/configMap>
+  # certResourceName: <secret/configMap name>
 
 
 # checkpointStorage controls where checkpoints are stored. Supported types include `shared_fs`,


### PR DESCRIPTION
## Description
Lets users specify a secret name and ssl certificate name for postgres. Ssl mode is configurable, but only `verify-ca` is supported at this moment.
<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At a minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan
Uncomment the relevant fields in `db` of `values.yaml` and deploy using helm. You might have to generate keys/certificates and create a secret in kubernetes first. Then, ssh into the master container and check to see that the secret you specified is present under `/mount/determined/secrets/` and that the `ssl_root_cert` is populated in the master config.

Additionally, you may deploy a db instance with ssl enabled. Add your certificate to the `db` fields and check that your master instance is able to launch and connect to the db. Steps here:

Start by generating keys and create a kubernetes secret.
```
openssl req -new -x509 -days 365 -nodes -text -out server.crt \
  -keyout server.key -subj "/CN=dbhost.fakedomain.com"

chmod og-rwx server.key

openssl req -new -nodes -text -out root.csr \
  -keyout root.key -subj "/CN=root.fakedomain.com"
chmod og-rwx root.key

openssl x509 -req -in root.csr -text -days 3650 \
  -extfile /etc/ssl/openssl.cnf -extensions v3_ca \
  -signkey root.key -out root.crt

openssl req -new -nodes -text -out server.csr \
  -keyout server.key -subj "/CN=dbhost.fakedomain.com"
chmod og-rwx server.key

openssl x509 -req -in server.csr -text -days 365 \
  -CA root.crt -CAkey root.key -CAcreateserial \
  -out server.crt

kubectl create secret tls tls-secret-postgres --cert=server.crt --key=server.key
```
Create a file named `db.yaml` and insert the following:
```
tls:
  enabled: true
  certificatesSecret: tls-secret-postgres
  certFilename: tls.crt
  certKeyFilename: tls.key
volumePermissions:
  enabled: true
```

Install bitnami postgres with the config you just create:
```
helm install postgresql bitnami/postgresql -f db.yaml
```

Find the password for the postgres user and login:
```
export PASS=$(kubectl get secret postgresql -o jsonpath="{.data.postgresql-password}" | base64 --decode) 
kubectl exec -it pod/postgresql-0 -- psql -U postgres
```

Once logged in, create a user `determined` with password `determined`. Also create a new table named `determined`. Verify that the user has been created and can be logged into.

Modify the `values.yaml` file in the helm chart so that the db uses `determined` as username and password.  Then, create a configmap with the certificate:
```
kubectl create cm root-cert -n determined --from-file=certs/root.crt
```

Use `kubernetes get services` to identify the name of the postgres service. Copy the ip address of the database and edit `master-deployment.yaml`. We want to add the `hostAliasses` field at the same level as the `containers` field:
```
containers:
- image: determinedai/determined-master:0.17.9-rc1
  imagePullPolicy: Always
  name: determined-master-determined-ai
  .
  .
hostAliases:
- hostnames:
  - dbhost.fakedomain.com
  ip: <postgres IP address>
```

Finally, populate the `values.yaml` DB fields for `ssl_mode`:
```
sslMode: verify-ca
sslRootCert: root.crt
certSecretName: root-cert
resourceType: configmap
```

run `helm install <deployment name> <local path to determined/helm/charts/determined>` and check the log of the master instance with `kubectl logs <master instance ID>`. Make sure the logs indicate the instance is running properly; any DB issue should result in it not being able to connect and Determined not launching.

<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions about this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ