### PR TITLE
fix: Model/Experiment API and error codes [DET-6711]

### DIFF
--- a/master/internal/api_model.go
+++ b/master/internal/api_model.go
@@ -131,7 +131,8 @@ func (a *apiServer) clearModelName(ctx context.Context, modelName string) error 
 func (a *apiServer) PostModel(
 	ctx context.Context, req *apiv1.PostModelRequest) (*apiv1.PostModelResponse, error) {
 	if err := a.clearModelName(ctx, req.Name); err != nil {
-		return nil, errors.Wrap(err, "error setting model name")
+		return nil, status.Errorf(codes.AlreadyExists,
+			"Error renaming model: %s", err.Error())
 	}
 
 	b, err := protojson.Marshal(req.Metadata)
@@ -173,7 +174,8 @@ func (a *apiServer) PatchModel(
 		log.Infof("model (%d) name changing from \"%s\" to \"%s\"",
 			currModel.Id, currModel.Name, req.Model.Name.Value)
 		if err = a.clearModelName(ctx, req.Model.Name.Value); err != nil {
-			return nil, errors.Wrap(err, "error renaming model")
+			return nil, status.Errorf(codes.AlreadyExists,
+				"Error renaming model: %s", err.Error())
 		}
 		madeChanges = true
 		currModel.Name = req.Model.Name.Value

--- a/master/internal/api_model.go
+++ b/master/internal/api_model.go
@@ -123,7 +123,7 @@ func (a *apiServer) clearModelName(ctx context.Context, modelName string) error 
 		return err
 	}
 	if len(getResp.Models) > 0 {
-		return status.Errorf(codes.AlreadyExists, "avoid names similar too other models (case-insensitive)")
+		return status.Errorf(codes.AlreadyExists, "avoid names equal to other models (case-insensitive)")
 	}
 	return nil
 }

--- a/master/internal/api_model.go
+++ b/master/internal/api_model.go
@@ -105,17 +105,17 @@ func (a *apiServer) GetModelLabels(
 
 func (a *apiServer) clearModelName(ctx context.Context, modelName string) error {
 	if len(strings.ReplaceAll(modelName, " ", "")) == 0 {
-		return errors.Errorf("model names cannot be blank")
+		return status.Errorf(codes.InvalidArgument, "model names cannot be blank")
 	}
 	if strings.Contains(modelName, "  ") {
-		return errors.Errorf("model names cannot have excessive spacing")
+		return status.Errorf(codes.InvalidArgument, "model names cannot have excessive spacing")
 	}
 	if strings.Contains(modelName, "/") || strings.Contains(modelName, "\\") {
-		return errors.Errorf("model names cannot have slashes")
+		return status.Errorf(codes.InvalidArgument, "model names cannot have slashes")
 	}
 	re := regexp.MustCompile(`^\d+$`)
 	if len(re.FindAllString(modelName, 1)) > 0 {
-		return errors.Errorf("model names cannot be only numbers")
+		return status.Errorf(codes.InvalidArgument, "model names cannot be only numbers")
 	}
 	getResp, err := a.GetModels(ctx,
 		&apiv1.GetModelsRequest{Name: modelName, NameCaseInsensitive: true})
@@ -123,7 +123,7 @@ func (a *apiServer) clearModelName(ctx context.Context, modelName string) error 
 		return err
 	}
 	if len(getResp.Models) > 0 {
-		return errors.Errorf("avoid using model names with case-sensitive similar names")
+		return status.Errorf(codes.AlreadyExists, "avoid names similar too other models (case-insensitive)")
 	}
 	return nil
 }
@@ -131,8 +131,7 @@ func (a *apiServer) clearModelName(ctx context.Context, modelName string) error 
 func (a *apiServer) PostModel(
 	ctx context.Context, req *apiv1.PostModelRequest) (*apiv1.PostModelResponse, error) {
 	if err := a.clearModelName(ctx, req.Name); err != nil {
-		return nil, status.Errorf(codes.AlreadyExists,
-			"Error renaming model: %s", err.Error())
+		return nil, err
 	}
 
 	b, err := protojson.Marshal(req.Metadata)
@@ -174,8 +173,7 @@ func (a *apiServer) PatchModel(
 		log.Infof("model (%d) name changing from \"%s\" to \"%s\"",
 			currModel.Id, currModel.Name, req.Model.Name.Value)
 		if err = a.clearModelName(ctx, req.Model.Name.Value); err != nil {
-			return nil, status.Errorf(codes.AlreadyExists,
-				"Error renaming model: %s", err.Error())
+			return nil, err
 		}
 		madeChanges = true
 		currModel.Name = req.Model.Name.Value


### PR DESCRIPTION
## Description

This is a WIP of returning 400 error codes when the server or DB reports an input-related error, instead of a 500.  Right now it is returning a 400 when we discussed using a 409.  If this code makes sense then I can generalize the error-capture code to other PG functions and Model/Experiment API endpoints.

## Test Plan

- When creating an invalid model name (such as "a/b") or changing the name (to an invalid or duplicate name), the server should return the error with an InvalidArgument code and not a 500
- When the Postgres Database returns an error code which we recognize (such as uniqueness or bad param), that code should be turned to a message and passed up with an InvalidArgument code. I'm not sure an example how to test this (int/string API error?) it needs to be a constraint where we don't already block it in the protocol or server code

## Checklist

- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.