### PR TITLE
chore: fix migration helper scripts

### DIFF
--- a/master/static/migrations/README.md
+++ b/master/static/migrations/README.md
@@ -20,9 +20,16 @@ determined-master --config-file /path/to/master.yaml migrate down 20210917133742
 ## Creating new migrations
 
 We use timestamps instead of sequential numbers, standard for `go-pg/migrations`.
-When creating a new migration, either write it manually, or use this script:
+When creating a new migration, either write it manually, or try:
 
 ```bash
+./migration-create.sh my-migration-name
+```
 
-touch $(date +%Y%m%d%H%M%S)_migration_name.{up,down}.sql
+If there is a chance another migration has landed between when you created
+yours and when your PR lands, you should update your filename so the migrations
+land in-order:
+
+```bash
+./migration-move-to-top.sh my-migration-name
 ```

--- a/master/static/migrations/migration-create.sh
+++ b/master/static/migrations/migration-create.sh
@@ -1,10 +1,12 @@
 #!/bin/bash
 
-name=$1
+set -e
 
-if [ -z name ]; then
-    echo "missing migration name"
+name="$1"
+
+if [ -z "$name" ]; then
+    echo "usage: $0 NAME"
     exit 1
 fi
 
-touch $(date +%Y%m%d%H%M%S)_${name}.{up,down}.sql
+touch "$(date +%Y%m%d%H%M%S)_$name."{up,down}".sql"

--- a/master/static/migrations/migration-move-to-top.sh
+++ b/master/static/migrations/migration-move-to-top.sh
@@ -1,15 +1,16 @@
 #!/bin/bash
 
-migration=$1
+set -e
 
-if [ -z migration ]; then
-    echo "missing migration"
+name="$1"
+
+if [ -z "$name" ]; then
+    echo "usage: $0 NAME"
+    echo "where NAME for '20200401000000_initial.up.sql' would be 'initial'"
     exit 1
 fi
 
-seq_num=$(echo $migration | cut -d '_' -f1)
-name=$(echo $migration | cut -d '_' -f2- | cut -d '.' -f1)
-new_seq=$(date +%Y%m%d%H%M%S)
+new_base="$(date +%Y%m%d%H%M%S)_$name"
 
-mv "${seq_num}_${name}.up.sql" "${new_seq}_${name}.up.sql" 
-mv "${seq_num}_${name}.down.sql" "${new_seq}_${name}.down.sql" 
+mv *"_$name.up.sql" "$new_base.up.sql"
+mv *"_$name.down.sql" "$new_base.down.sql"


### PR DESCRIPTION
Previously, the `[ -z migration ]` test was broken.

Additionally, use quotes around all variable expansions, make the API
for the two scripts consistent, and document the scripts in the README.