### PR TITLE
chore: CLI resource-setting replaced with new API routes [DET-6487]

### DIFF
--- a/docs/release-notes/3629-experiment-resources-to-rest-api.txt
+++ b/docs/release-notes/3629-experiment-resources-to-rest-api.txt
@@ -1,6 +1,7 @@
 :orphan:
 
--  **API Change** the `/api/v1/experiment/{id}` PATCH endpoint allows you to PATCH scheduling fields
-   (priority, weight, and maxSlots).
--  **Breaking Change** the legacy API `/experiment/{id}` PATCH endpoint no longer supports the
-   scheduling fields (priority, weight, and maxSlots)
+**Breaking Change**
+
+The legacy Experiment API (PATCH requests to ``/experiments/{id}``) is no longer used to set the
+scheduling fields (priority, weight, and maxSlots). These should instead be passed to the REST API
+(``/api/v1/experiments/{id}``).

--- a/docs/release-notes/3629-experiment-resources-to-rest-api.txt
+++ b/docs/release-notes/3629-experiment-resources-to-rest-api.txt
@@ -1,0 +1,6 @@
+:orphan:
+
+-  **API Change** the `/api/v1/experiment/{id}` PATCH endpoint allows you to PATCH scheduling fields
+   (priority, weight, and maxSlots).
+-  **Breaking Change** the legacy API `/experiment/{id}` PATCH endpoint no longer supports the
+   scheduling fields (priority, weight, and maxSlots)

--- a/harness/determined/cli/experiment.py
+++ b/harness/determined/cli/experiment.py
@@ -603,19 +603,34 @@ def remove_label(args: Namespace) -> None:
 
 @authentication.required
 def set_max_slots(args: Namespace) -> None:
-    patch_experiment(args, "change `max_slots` of", {"resources": {"max_slots": args.max_slots}})
+    session = setup_session(args)
+    r = bindings.get_GetExperiment(session, experimentId=args.experiment_id).experiment
+    exp = r.to_json()
+    exp["maxSlots"] = args.max_slots
+    exp_patch = bindings.v1PatchExperiment.from_json(exp)
+    bindings.patch_PatchExperiment(session, body=exp_patch, experiment_id=args.experiment_id)
     print("Set `max_slots` of experiment {} to {}".format(args.experiment_id, args.max_slots))
 
 
 @authentication.required
 def set_weight(args: Namespace) -> None:
-    patch_experiment(args, "change `weight` of", {"resources": {"weight": args.weight}})
+    session = setup_session(args)
+    r = bindings.get_GetExperiment(session, experimentId=args.experiment_id).experiment
+    exp = r.to_json()
+    exp["weight"] = args.weight
+    exp_patch = bindings.v1PatchExperiment.from_json(exp)
+    bindings.patch_PatchExperiment(session, body=exp_patch, experiment_id=args.experiment_id)
     print("Set `weight` of experiment {} to {}".format(args.experiment_id, args.weight))
 
 
 @authentication.required
 def set_priority(args: Namespace) -> None:
-    patch_experiment(args, "change `priority` of", {"resources": {"priority": args.priority}})
+    session = setup_session(args)
+    r = bindings.get_GetExperiment(session, experimentId=args.experiment_id).experiment
+    exp = r.to_json()
+    exp["priority"] = args.priority
+    exp_patch = bindings.v1PatchExperiment.from_json(exp)
+    bindings.patch_PatchExperiment(session, body=exp_patch, experiment_id=args.experiment_id)
     print("Set `priority` of experiment {} to {}".format(args.experiment_id, args.priority))
 
 

--- a/harness/determined/cli/experiment.py
+++ b/harness/determined/cli/experiment.py
@@ -604,10 +604,9 @@ def remove_label(args: Namespace) -> None:
 @authentication.required
 def set_max_slots(args: Namespace) -> None:
     session = setup_session(args)
-    r = bindings.get_GetExperiment(session, experimentId=args.experiment_id).experiment
-    exp = r.to_json()
-    exp["maxSlots"] = args.max_slots
-    exp_patch = bindings.v1PatchExperiment.from_json(exp)
+    exp_patch = bindings.v1PatchExperiment.from_json(
+        {"id": args.experiment_id, "maxSlots": args.max_slots}
+    )
     bindings.patch_PatchExperiment(session, body=exp_patch, experiment_id=args.experiment_id)
     print("Set `max_slots` of experiment {} to {}".format(args.experiment_id, args.max_slots))
 
@@ -615,10 +614,9 @@ def set_max_slots(args: Namespace) -> None:
 @authentication.required
 def set_weight(args: Namespace) -> None:
     session = setup_session(args)
-    r = bindings.get_GetExperiment(session, experimentId=args.experiment_id).experiment
-    exp = r.to_json()
-    exp["weight"] = args.weight
-    exp_patch = bindings.v1PatchExperiment.from_json(exp)
+    exp_patch = bindings.v1PatchExperiment.from_json(
+        {"id": args.experiment_id, "weight": args.weight}
+    )
     bindings.patch_PatchExperiment(session, body=exp_patch, experiment_id=args.experiment_id)
     print("Set `weight` of experiment {} to {}".format(args.experiment_id, args.weight))
 
@@ -626,10 +624,9 @@ def set_weight(args: Namespace) -> None:
 @authentication.required
 def set_priority(args: Namespace) -> None:
     session = setup_session(args)
-    r = bindings.get_GetExperiment(session, experimentId=args.experiment_id).experiment
-    exp = r.to_json()
-    exp["priority"] = args.priority
-    exp_patch = bindings.v1PatchExperiment.from_json(exp)
+    exp_patch = bindings.v1PatchExperiment.from_json(
+        {"id": args.experiment_id, "priority": args.priority}
+    )
     bindings.patch_PatchExperiment(session, body=exp_patch, experiment_id=args.experiment_id)
     print("Set `priority` of experiment {} to {}".format(args.experiment_id, args.priority))
 

--- a/harness/determined/common/api/bindings.py
+++ b/harness/determined/common/api/bindings.py
@@ -3069,14 +3069,20 @@ class v1PatchExperiment:
         id: int,
         description: "typing.Optional[str]" = None,
         labels: "typing.Optional[typing.Sequence[typing.Dict[str, typing.Any]]]" = None,
+        maxSlots: "typing.Optional[int]" = None,
         name: "typing.Optional[str]" = None,
         notes: "typing.Optional[str]" = None,
+        priority: "typing.Optional[int]" = None,
+        weight: "typing.Optional[float]" = None,
     ):
         self.id = id
         self.description = description
         self.labels = labels
         self.name = name
         self.notes = notes
+        self.maxSlots = maxSlots
+        self.weight = weight
+        self.priority = priority
 
     @classmethod
     def from_json(cls, obj: Json) -> "v1PatchExperiment":
@@ -3086,6 +3092,9 @@ class v1PatchExperiment:
             labels=obj.get("labels", None),
             name=obj.get("name", None),
             notes=obj.get("notes", None),
+            maxSlots=obj.get("maxSlots", None),
+            weight=float(obj["weight"]) if obj.get("weight", None) is not None else None,
+            priority=obj.get("priority", None),
         )
 
     def to_json(self) -> typing.Any:
@@ -3095,6 +3104,9 @@ class v1PatchExperiment:
             "labels": self.labels if self.labels is not None else None,
             "name": self.name if self.name is not None else None,
             "notes": self.notes if self.notes is not None else None,
+            "maxSlots": self.maxSlots if self.maxSlots is not None else None,
+            "weight": dump_float(self.weight) if self.weight is not None else None,
+            "priority": self.priority if self.priority is not None else None,
         }
 
 class v1PatchExperimentResponse:

--- a/master/internal/api_experiment.go
+++ b/master/internal/api_experiment.go
@@ -582,7 +582,8 @@ func (a *apiServer) PatchExperiment(
 		}
 	}
 
-	if req.Experiment.MaxSlots != nil || req.Experiment.Weight != nil || req.Experiment.Priority != nil {
+	if req.Experiment.MaxSlots != nil || req.Experiment.Weight != nil ||
+		req.Experiment.Priority != nil {
 		dbExp, err := a.m.db.ExperimentByID(int(req.Experiment.Id))
 		resources := dbExp.Config.Resources()
 		if err != nil {
@@ -605,13 +606,10 @@ func (a *apiServer) PatchExperiment(
 				job.SetGroupPriority{Priority: int(req.Experiment.Priority.Value)})
 		}
 		dbExp.Config.SetResources(resources)
-		a.m.db.SaveExperimentConfig(dbExp)
+		if err = a.m.db.SaveExperimentConfig(dbExp); err != nil {
+			return nil, errors.Wrapf(err, "patching experiment %d", dbExp.ID)
+		}
 	}
-
-	// if req.Experiment.GCPolicy != nil {
-	// 	exp.Resources.GCPolicy = req.Experiment.GCPolicy
-	// 	madeChanges = true
-	// }
 
 	if madeChanges {
 		type experimentPatch struct {

--- a/proto/src/determined/experiment/v1/experiment.proto
+++ b/proto/src/determined/experiment/v1/experiment.proto
@@ -106,6 +106,12 @@ message PatchExperiment {
   google.protobuf.StringValue name = 4;
   // The experiment notes.
   google.protobuf.StringValue notes = 5;
+  // The maximum resources in slots.
+  google.protobuf.Int32Value max_slots = 6;
+  // The weight for allocating resources to the experiment.
+  google.protobuf.FloatValue weight = 7;
+  // The priority level for the experiment.
+  google.protobuf.Int32Value priority = 8;
 }
 
 // ValidationHistoryEntry is a single entry for a validation history for an

--- a/webui/react/src/services/api-ts-sdk/api.ts
+++ b/webui/react/src/services/api-ts-sdk/api.ts
@@ -3709,6 +3709,24 @@ export interface V1PatchExperiment {
      * @memberof V1PatchExperiment
      */
     notes?: string;
+    /**
+     * The maximum resources in slots.
+     * @type {number}
+     * @memberof V1PatchExperiment
+     */
+    maxSlots?: number;
+    /**
+     * The weight for allocating resources to the experiment.
+     * @type {number}
+     * @memberof V1PatchExperiment
+     */
+    weight?: number;
+    /**
+     * The priority level for the experiment.
+     * @type {number}
+     * @memberof V1PatchExperiment
+     */
+    priority?: number;
 }
 
 /**


### PR DESCRIPTION
## Description

Move resource allocation settings (max_slots, weight, priority) from old core_experiment to the new REST API. We only call this from the CLI, so this updates that as well.

When combined with #3539 (which removes State) then core_experiment PATCH will only be used for gc-policy

## Test Plan

Confirm CLI `det experiment set weight id 1` still changes values of weight in `/api/v1/experiments/id`
Same for `max-slots` and `priority`.

## Checklist

- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.