### PR TITLE
feat: non-training-specific checkpoints

### DIFF
--- a/master/TODO
+++ b/master/TODO
@@ -1,0 +1,35 @@
+# git grep -liE 'from (raw_|)checkpoints' static/srv internal
+
+DONE: static/srv/get_checkpoint.sql
+DONE: static/srv/get_checkpoints_for_trial.sql
+DONE: static/srv/get_model_version.sql
+
+static/srv/get_checkpoints_for_experiment.sql
+static/srv/get_model_versions.sql
+static/srv/get_trial.sql
+static/srv/get_trial_metrics.sql
+static/srv/insert_model_version.sql
+static/srv/proto_get_trial_workloads.sql
+static/srv/update_model_version.sql
+internal/db/postgres_trial.go
+internal/db/postgres_experiments.go
+
+static/srv/get_checkpoint.sql
+    internal/api_checkpoint.go::GetCheckpoint()
+        moved to internal/ckpts/api.go::CkptsAPI.GetCheckpoint()
+        Replaced with ckpts.ByUUID()
+    internal/api_model.go::PostModelVersion()
+        Used only to verify checkpoint existence and state==COMPLETED.
+        Replaced with new method ckpts.State(), which only touches the
+        checkpoints tables (or at least, there's an XXX to make it so)
+
+static/srv/get_checkpoints_for_trial.sql
+    internal/api_trials.go::GetTrialCheckpoints()
+        moved to internal/ckpts/api.go::CkptsAPI.GetTrialCheckpoints()
+        Replaced with a Count/Limit.Offset.Scan pattern in a bun.Tx
+        was a 404 possible with no checkpoints?  It's not clear to me.
+
+static/srv/get_model_version.sql
+    internal/api_model.go::GetModelVerison()
+        moved to internal/models/api.go::Server.GetModelVersion()
+        replaced with models.ByNameTx, models.VersionTx, ckpts.ByIDTx

--- a/master/internal/api.go
+++ b/master/internal/api.go
@@ -15,12 +15,16 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/determined-ai/determined/master/internal/api"
+	"github.com/determined-ai/determined/master/internal/ckpts"
+	"github.com/determined-ai/determined/master/internal/models"
 	"github.com/determined-ai/determined/master/pkg/actor"
 	"github.com/determined-ai/determined/proto/pkg/apiv1"
 )
 
 type apiServer struct {
 	m *Master
+	ckpts.CkptsAPI
+	models.ModelsAPI
 }
 
 // paginate returns a paginated subset of the values and sets the pagination response.

--- a/master/internal/api_checkpoint.go
+++ b/master/internal/api_checkpoint.go
@@ -5,28 +5,11 @@ import (
 
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/encoding/protojson"
 
-	"github.com/determined-ai/determined/master/internal/db"
 	"github.com/determined-ai/determined/proto/pkg/apiv1"
 	"github.com/determined-ai/determined/proto/pkg/checkpointv1"
 )
-
-func (a *apiServer) GetCheckpoint(
-	_ context.Context, req *apiv1.GetCheckpointRequest) (*apiv1.GetCheckpointResponse, error) {
-	resp := &apiv1.GetCheckpointResponse{}
-	resp.Checkpoint = &checkpointv1.Checkpoint{}
-	switch err := a.m.db.QueryProto("get_checkpoint", resp.Checkpoint, req.CheckpointUuid); err {
-	case db.ErrNotFound:
-		return nil, status.Errorf(
-			codes.NotFound, "checkpoint %s not found", req.CheckpointUuid)
-	default:
-		return resp,
-			errors.Wrapf(err, "error fetching checkpoint %s from database", req.CheckpointUuid)
-	}
-}
 
 func (a *apiServer) PostCheckpointMetadata(
 	ctx context.Context, req *apiv1.PostCheckpointMetadataRequest,

--- a/master/internal/ckpts/api.go
+++ b/master/internal/ckpts/api.go
@@ -1,0 +1,103 @@
+package ckpts
+
+import (
+	"context"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/determined-ai/determined/master/pkg/protoutils"
+	"github.com/determined-ai/determined/proto/pkg/apiv1"
+	"github.com/determined-ai/determined/proto/pkg/checkpointv1"
+)
+
+type CkptsAPI struct{}
+
+func (s *CkptsAPI) GetCheckpoint(
+	ctx context.Context, req *apiv1.GetCheckpointRequest) (*apiv1.GetCheckpointResponse, error) {
+	ckpt, err := ByUUIDExpanded(ctx, req.CheckpointUuid)
+	if err != nil {
+		return nil, err
+	}
+
+	pc := protoutils.ProtoConverter{}
+	protoCkpt := ckpt.ToProto(&pc)
+	resp := &apiv1.GetCheckpointResponse{Checkpoint: &protoCkpt}
+	return resp, pc.Error()
+}
+
+func (a *CkptsAPI) GetTrialCheckpoints(
+	ctx context.Context, req *apiv1.GetTrialCheckpointsRequest,
+) (*apiv1.GetTrialCheckpointsResponse, error) {
+	// // XXX: check trial exists
+	// switch exists, err := a.m.db.CheckTrialExists(int(req.Id)); {
+	// case err != nil:
+	// 	return nil, err
+	// case !exists:
+	// 	return nil, status.Error(codes.NotFound, "trial not found")
+	// }
+
+	var validationStates []string
+	for _, vstate := range req.ValidationStates {
+		switch vstate {
+		case checkpointv1.State_STATE_ACTIVE:
+			validationStates = append(validationStates, "'ACTIVE'")
+		case checkpointv1.State_STATE_COMPLETED:
+			validationStates = append(validationStates, "'COMPLETED'")
+		case checkpointv1.State_STATE_ERROR:
+			validationStates = append(validationStates, "'ERROR'")
+		case checkpointv1.State_STATE_DELETED:
+			validationStates = append(validationStates, "'DELETED'")
+		default:
+			// XXX: throw an error to the user
+		}
+	}
+
+	// choose an ordering
+	asc := req.OrderBy != apiv1.OrderBy_ORDER_BY_DESC
+	var orderBy string
+	switch req.SortBy {
+	case apiv1.GetTrialCheckpointsRequest_SORT_BY_UNSPECIFIED:
+		// noop, use the default
+	case apiv1.GetTrialCheckpointsRequest_SORT_BY_BATCH_NUMBER:
+		// noop, this is the default
+	case apiv1.GetTrialCheckpointsRequest_SORT_BY_START_TIME:
+		// noop, this field doesn't exist anymore
+	case apiv1.GetTrialCheckpointsRequest_SORT_BY_END_TIME:
+		orderBy = "report_time"
+	case apiv1.GetTrialCheckpointsRequest_SORT_BY_VALIDATION_STATE:
+		orderBy = "validation_metrics != 'null'::jsonb"
+	case apiv1.GetTrialCheckpointsRequest_SORT_BY_STATE:
+		orderBy = "state"
+	}
+
+	ckpts, total, err := GetTrialCheckpointsExpanded(
+		ctx, int(req.Id), validationStates, orderBy, asc, int(req.Limit), int(req.Offset),
+	)
+	if err != nil {
+		return nil, err
+	}
+	if len(ckpts) == 0 {
+		// XXX: Why not return an empty array?
+		return nil, status.Errorf(codes.NotFound, "no checkpoints found for trial %d", req.Id)
+	}
+
+	pc := protoutils.ProtoConverter{}
+	resp := &apiv1.GetTrialCheckpointsResponse{}
+	resp.Checkpoints = make([]*checkpointv1.Checkpoint, len(ckpts))
+	for i, ckpt := range ckpts {
+		protoCkpt := ckpt.ToProto(&pc)
+		// XXX taking address of protoCkpt looks buggy to me
+		resp.Checkpoints[i] = &protoCkpt
+	}
+	resp.Pagination = &apiv1.Pagination{
+		Offset: req.Offset,
+		Limit:  req.Limit,
+		// XXX  Why have both offset and start_idx?
+		StartIndex: req.Offset,
+		EndIndex:   pc.ToInt32(int(req.Offset) + len(ckpts)),
+		Total:      pc.ToInt32(total),
+	}
+
+	return resp, pc.Error()
+}

--- a/master/internal/ckpts/ckpts.go
+++ b/master/internal/ckpts/ckpts.go
@@ -1,0 +1,103 @@
+package ckpts
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	"github.com/uptrace/bun"
+
+	"github.com/determined-ai/determined/master/internal/db"
+	"github.com/determined-ai/determined/master/pkg/model"
+)
+
+func ByUUID(ctx context.Context, uuid string) (model.Checkpoint, error) {
+	var out model.Checkpoint
+	err := db.Bun().NewSelect().Model(&out).
+		Where("uuid = ?", uuid).
+		Scan(ctx)
+	if err != nil {
+		return model.Checkpoint{}, errors.Wrapf(err, "error selecting checkpoint(%v)", uuid)
+	}
+	return out, err
+}
+
+func ByUUIDExpanded(ctx context.Context, uuid string) (model.CheckpointExpanded, error) {
+	var out model.CheckpointExpanded
+	err := db.Bun().NewSelect().Model(&out).
+		Where("uuid = ?", uuid).
+		Scan(ctx)
+	if err != nil {
+		return model.CheckpointExpanded{}, errors.Wrapf(err, "error selecting checkpoint(%v)", uuid)
+	}
+	return out, err
+}
+
+func ByIDExpanded(ctx context.Context, id int) (model.CheckpointExpanded, error) {
+	var out model.CheckpointExpanded
+	err := db.Bun().NewSelect().Model(&out).
+		Where("id = ?", id).
+		Scan(ctx)
+	if err != nil {
+		return model.CheckpointExpanded{}, errors.Wrapf(err, "error selecting checkpoint(%v)", id)
+	}
+	return out, err
+}
+
+// if model.State is nil, that indicates the checkpoint does not exist
+// returns sql.ErrNoRows when no suitable checkpoint state is found
+func State(ctx context.Context, uuid string) (model.State, error) {
+	// Use ByUUID and not ByUUIDExpanded to avoid scanning many different tables.
+	ckpt, err := ByUUID(ctx, uuid)
+	return ckpt.State, err
+}
+
+func GetTrialCheckpointsExpanded(
+	ctx context.Context,
+	trial int,
+	validationStates []string,
+	orderBy string,
+	asc bool,
+	limit int,
+	offset int,
+) ([]model.CheckpointExpanded, int, error) {
+	var ckpts []model.CheckpointExpanded
+	q := db.Bun().NewSelect().Model(&ckpts)
+
+	// Apply filters
+	q = q.Where("trial_id = ?", trial)
+	if len(validationStates) > 0 {
+		// XXX: rb, were there supposed to be two filters here?  this looks like the wrong filter.
+		q = q.Where("checkpoint_state IN (?)", bun.In(validationStates))
+	}
+
+	// choose an ordering
+	direction := " ASC"
+	if !asc {
+		direction = " DESC"
+	}
+
+	if orderBy != "" {
+		q = q.Order(orderBy + direction)
+	}
+
+	// secondary/default ordering is based on latest_batch
+	// XXX: the get_checkpoints_for_trial also had an ORDER BY clause for report time
+	q = q.Order("(metadata->>'latest_batch')::int8" + direction)
+
+	total, err := q.Count(ctx)
+	if err != nil {
+		return nil, 0, errors.Wrapf(
+			err, "error counting checkpoints for trial %d from database", trial,
+		)
+	}
+
+	// apply pagination and get the actual list of checkpoints
+	err = q.Limit(limit).Offset(offset).Scan(ctx)
+	if err != nil {
+		return nil, 0, errors.Wrapf(
+			err, "error fetching checkpoints for trial %d from database", trial,
+		)
+	}
+
+	return ckpts, total, nil
+}

--- a/master/internal/db/database.go
+++ b/master/internal/db/database.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"context"
+	"database/sql"
 	"time"
 
 	"github.com/google/uuid"
@@ -15,7 +16,7 @@ import (
 	"github.com/determined-ai/determined/proto/pkg/trialv1"
 )
 
-// DB is an interface for _all_ the functionality packed into the DB.
+// DB is an interface for the legacy (non-bun) functionality packed into the DB.
 type DB interface {
 	StartUserSession(user *model.User) (string, error)
 	UserByToken(token string, ext *model.ExternalSessions) (*model.User, *model.UserSession, error)
@@ -167,7 +168,7 @@ type DB interface {
 }
 
 // ErrNotFound is returned if nothing is found.
-var ErrNotFound = errors.New("not found")
+var ErrNotFound = sql.ErrNoRows
 
 // ErrTooManyRowsAffected is returned if too many rows are affected.
 var ErrTooManyRowsAffected = errors.New("too many rows are affected")

--- a/master/internal/db/postgres_trial.go
+++ b/master/internal/db/postgres_trial.go
@@ -435,7 +435,7 @@ VALUES
 			State:             model.CompletedState,
 			TotalBatches:      int(m.LatestBatch),
 			UUID:              &m.Uuid,
-			Resources:         model.JSONObjFromMapStringInt64(m.Resources),
+			Resources:         m.Resources,
 			Framework:         m.Framework,
 			Format:            m.Format,
 			DeterminedVersion: m.DeterminedVersion,

--- a/master/internal/models/api.go
+++ b/master/internal/models/api.go
@@ -1,0 +1,69 @@
+package models
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/determined-ai/determined/master/internal/ckpts"
+	"github.com/determined-ai/determined/master/internal/db"
+	"github.com/determined-ai/determined/master/pkg/protoutils"
+	"github.com/determined-ai/determined/proto/pkg/apiv1"
+)
+
+type ModelsAPI struct{}
+
+// // XXX: replace api_models.go::apiServer.GetModel() with this.
+// func (s *ModelsAPI) GetModel(
+// 	ctx context.Context, req *apiv1.GetModelRequest) (*apiv1.GetModelResponse, error) {
+// 	m, err := ByName(ctx, req.ModelName)
+// 	if err != nil {
+// 		return nil, err
+// 	}
+// 	pc := protoutils.ProtoConverter{}
+// 	pmv := m.ToProto(&pc)
+// 	return &apiv1.GetModelResponse{Model: &pmv}, pc.Error()
+// }
+
+func (s *ModelsAPI) GetModelVersion(
+	ctx context.Context, req *apiv1.GetModelVersionRequest,
+) (*apiv1.GetModelVersionResponse, error) {
+	m, err := ByName(ctx, req.ModelName)
+	switch {
+	case err == db.ErrNotFound:
+		return nil, status.Errorf(codes.NotFound, "model %s not found", req.ModelName)
+	case err != nil:
+		return nil, err
+	}
+
+	// Note: we are passing req.ModelVersion as an id intentionally; it's named wrong.
+	// XXX: make Version accept int or int32, with generics
+	mv, err := VersionByID(ctx, int(req.ModelVersion))
+	switch {
+	case err == db.ErrNotFound:
+		return nil, status.Errorf(
+			// XXX: wait I thought req.ModelVersion was secretly the model.id?
+			// XXX: That would also imply that the protobuf request fields are overdefined.
+			codes.NotFound, "model %s version %d not found", req.ModelName, req.ModelVersion)
+	case err != nil:
+		return nil, err
+	}
+
+	ckpt, err := ckpts.ByIDExpanded(ctx, mv.CheckpointID)
+	switch {
+	case err == db.ErrNotFound:
+		// This should not happen.
+		return nil, status.Errorf(codes.Internal, "checkpoint missing")
+	case err != nil:
+		return nil, err
+	}
+
+	resp := &apiv1.GetModelVersionResponse{}
+	pc := protoutils.ProtoConverter{}
+	mvv1 := mv.ToProto(&pc, m, ckpt)
+	resp.ModelVersion = &mvv1
+
+	return resp, pc.Error()
+}

--- a/master/internal/models/models.go
+++ b/master/internal/models/models.go
@@ -1,0 +1,53 @@
+package models
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+
+	"github.com/determined-ai/determined/master/internal/db"
+	"github.com/determined-ai/determined/master/pkg/model"
+)
+
+func ByID(ctx context.Context, id int) (model.Model, error) {
+	var out model.Model
+	err := db.Bun().NewSelect().
+		Model(&out).
+		// XXX: a better way to do a count query as a subquery?
+		ColumnExpr(`(select count (*) from model_versions
+					where model_versions.model_id = models.id) as num_versions`).
+		Where("id = ?", id).
+		Scan(ctx)
+	if err != nil {
+		return model.Model{}, errors.Wrapf(err, "error selecting model(%v)", id)
+	}
+	return out, err
+}
+
+func ByName(ctx context.Context, name string) (model.Model, error) {
+	var out model.Model
+	err := db.Bun().NewSelect().
+		Model(&out).
+		// XXX: a better way to do a count query as a subquery?
+		ColumnExpr(`(select count (*) from model_versions
+					where model_versions.model_id = models.id) as num_versions`).
+		Where("name = ?", name).
+		Scan(ctx)
+	if err != nil {
+		return model.Model{}, errors.Wrapf(err, "error selecting model(%v)", name)
+	}
+	return out, err
+}
+
+func VersionByID(ctx context.Context, id int) (model.ModelVersion, error) {
+	var out model.ModelVersion
+	err := db.Bun().NewSelect().
+		Model(&out).
+		Where("id = ?", id).
+		Scan(ctx)
+	if err != nil {
+		return model.ModelVersion{},
+			errors.Wrapf(err, "error selecting model(id=%v)", id)
+	}
+	return out, nil
+}

--- a/master/pkg/model/checkpoints.go
+++ b/master/pkg/model/checkpoints.go
@@ -1,0 +1,117 @@
+package model
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/uptrace/bun"
+
+	"github.com/determined-ai/determined/master/pkg/protoutils"
+	"github.com/determined-ai/determined/proto/pkg/checkpointv1"
+)
+
+// Resources maps filenames to file sizes.
+type Resources map[string]int64
+
+// Scan converts jsonb from postgres into a Resources object.
+// TODO: Combine all json.unmarshal-based Scanners into a single Scan implementation.
+func (r *Resources) Scan(src interface{}) error {
+	if src == nil {
+		*r = nil
+		return nil
+	}
+	bytes, ok := src.([]byte)
+	if !ok {
+		return errors.Errorf("unable to convert to []byte: %v", src)
+	}
+	obj := make(map[string]int64)
+	if err := json.Unmarshal(bytes, &obj); err != nil {
+		return errors.Wrapf(err, "unable to unmarshal Resources: %v", src)
+	}
+	*r = Resources(obj)
+	return nil
+}
+
+// Checkpoint represents a row from the `checkpoints` table.
+type Checkpoint struct {
+	bun.BaseModel
+
+	ID                int        `db:"id" json:"id"`
+	TrialID           int        `db:"trial_id" json:"trial_id"`
+	TrialRunID        int        `db:"trial_run_id" json:"-"`
+	TotalBatches      int        `db:"total_batches" json:"total_batches"`
+	State             State      `db:"state" json:"state"`
+	EndTime           *time.Time `db:"end_time" json:"end_time"`
+	UUID              *string    `db:"uuid" json:"uuid"`
+	Resources         Resources  `db:"resources" json:"resources"`
+	Metadata          JSONObj    `db:"metadata" json:"metadata"`
+	Framework         string     `db:"framework" json:"framework"`
+	Format            string     `db:"format" json:"format"`
+	DeterminedVersion string     `db:"determined_version" json:"determined_version"`
+}
+
+// ValidationMetrics is based on the checkpointsv1.Metrics protobuf message.
+type ValidationMetrics struct {
+	NumInputs         int     `json:"num_inputs"`
+	ValidationMetrics JSONObj `json:"validation_metrics"`
+}
+
+// CheckpointExpanded represents a row from the `checkpoints_expanded` view.  It is called
+// "expanded" because it includes various data from non-checkpoint tables that our system
+// auto-associates with checkpoints.  Likely this object is only useful to REST API endpoint code;
+// most of the rest of the system will prefer the more specific Checkpoint object.
+type CheckpointExpanded struct {
+	bun.BaseModel
+
+	// CheckpointExpanded is not json-serialized, so no `json:""` struct tags.
+	// CheckpointExpanded is only used by bun code, so no `db:""` struct tags.
+
+	ID                int
+	TrialID           int
+	TrialRunID        int
+	TotalBatches      int
+	State             State
+	EndTime           *time.Time
+	UUID              string
+	Resources         Resources
+	Metadata          JSONObj
+	Framework         string
+	Format            string
+	DeterminedVersion string
+
+	ExperimentConfig  JSONObj
+	ExperimentID      int
+	Hparams           JSONObj
+	Metadata          JSONObj
+	ValidationMetrics ValidationMetrics
+	ValidationState   State
+	SearcherMetric    float64
+}
+
+func (c CheckpointExpanded) ToProto(pc *protoutils.ProtoConverter) checkpointv1.Checkpoint {
+	if pc.Error() != nil {
+		return checkpointv1.Checkpoint{}
+	}
+
+	out := checkpointv1.Checkpoint{
+		uuid:              c.UUID,
+		ExperimentConfig:  pc.ToStruct(c.ExperimentConfig),
+		ExperimentID:      pc.ToInt32(c.ExperimentID),
+		TrialId:           c.TrialID,
+		Hparams:           pc.ToStruct(c.Hparams),
+		BatchNumber:       pc.ToInt32(c.TotalBatches),
+		EndTime:           pc.ToTimestamp(c.EndTime),
+		Resources:         c.Resources,
+		Metadata:          pc.ToStruct(c.Metadata),
+		Framework:         c.Framework,
+		Format:            c.Format,
+		DeterminedVersion: c.DeterminedVersion,
+		Metrics:           c.ValidationMetrics.ToProto(pc),
+		ValidationState:   pc.ToCheckpointv1State(c.ValidationState),
+		State:             pc.ToCheckpointv1State(c.ValidationState),
+		SearcherMetric:    c.SearcherMetric,
+	}
+
+	return out
+}

--- a/master/pkg/model/checkpoints.go.task3
+++ b/master/pkg/model/checkpoints.go.task3
@@ -1,0 +1,92 @@
+package model
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/uptrace/bun"
+
+	"github.com/determined-ai/determined/master/pkg/protoutils"
+	"github.com/determined-ai/determined/proto/pkg/checkpointv1"
+)
+
+// Resources maps filenames to file sizes.
+type Resources map[string]int64
+
+// Scan converts jsonb from postgres into a Resources object.
+// TODO: Combine all json.unmarshal-based Scanners into a single Scan implementation.
+func (r *Resources) Scan(src interface{}) error {
+	if src == nil {
+		*r = nil
+		return nil
+	}
+	bytes, ok := src.([]byte)
+	if !ok {
+		return errors.Errorf("unable to convert to []byte: %v", src)
+	}
+	obj := make(map[string]int64)
+	if err := json.Unmarshal(bytes, &obj); err != nil {
+		return errors.Wrapf(err, "unable to unmarshal Resources: %v", src)
+	}
+	*r = Resources(obj)
+	return nil
+}
+
+// RBCheckpoint is rb's checkpoint.
+type RBCheckpoint struct {
+	bun.BaseModel
+
+	// Basic data, common to all checkpoints
+	// ID           int       // `db:"id" json:"id"`
+	UUID         string    // `db:"uuid" json:"uuid"`
+	TaskID       *string   // `db:"trial_id" json:"task_id"`
+	AllocationID *string   // `db:"trial_id" json:"task_id"`
+	ReportTime   time.Time // `db:"end_time" json:"report_time"`
+	State        State     // `db:"state" json:"state"
+	Resources    Resources // `db:"resources" json:"resources"`
+	Metadata     JSONObj   // `db:"metadata" json:"metadata"`
+
+	// Training data, flattened to work with the database.  Considered empty if TrialID == 0.
+	TrialID           int
+	ExperimentID      int
+	ExperimentConfig  JSONObj
+	Hparams           JSONObj
+	TrainingMetrics   JSONObj
+	ValidationMetrics JSONObj
+}
+
+func (c RBCheckpoint) ToProto(pc *protoutils.ProtoConverter) checkpointv1.Checkpoint {
+	if pc.Error() != nil {
+		return checkpointv1.Checkpoint{}
+	}
+
+	nilToStr := func(v *string) string {
+		if v == nil {
+			return ""
+		}
+		return *v
+	}
+
+	out := checkpointv1.Checkpoint{
+		TaskId:       nilToStr(c.TaskID),
+		AllocationId: nilToStr(c.AllocationID),
+		Uuid:         c.UUID,
+		ReportTime:   pc.ToTimestamp(c.ReportTime),
+		State:        pc.ToCheckpointv1State(string(c.State)),
+		Resources:    c.Resources,
+		Metadata:     pc.ToStruct(c.Metadata, "metadata"),
+	}
+	if c.TrialID != 0 {
+		out.Training = &checkpointv1.CheckpointTrainingData{
+			TrialId:           int32(c.TrialID),
+			ExperimentId:      int32(c.ExperimentID),
+			ExperimentConfig:  pc.ToStruct(c.ExperimentConfig, "experiment config"),
+			Hparams:           pc.ToStruct(c.Hparams, "hparams"),
+			TrainingMetrics:   pc.ToStruct(c.TrainingMetrics, "training metrics"),
+			ValidationMetrics: pc.ToStruct(c.ValidationMetrics, "validation metrics"),
+		}
+	}
+
+	return out
+}

--- a/master/pkg/model/experiment.go
+++ b/master/pkg/model/experiment.go
@@ -6,20 +6,17 @@ import (
 	"strings"
 	"time"
 
-	"github.com/determined-ai/determined/master/pkg/protoutils"
-
 	"github.com/jackc/pgtype"
-	"google.golang.org/protobuf/encoding/protojson"
-
-	"github.com/determined-ai/determined/proto/pkg/experimentv1"
-	"github.com/determined-ai/determined/proto/pkg/trialv1"
-
 	"github.com/pkg/errors"
+	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
+	"github.com/determined-ai/determined/master/pkg/protoutils"
 	"github.com/determined-ai/determined/master/pkg/schemas/expconf"
 	"github.com/determined-ai/determined/proto/pkg/apiv1"
+	"github.com/determined-ai/determined/proto/pkg/experimentv1"
 	"github.com/determined-ai/determined/proto/pkg/logv1"
+	"github.com/determined-ai/determined/proto/pkg/trialv1"
 )
 
 // State is the run state of an experiment / trial / step / etc.
@@ -404,22 +401,6 @@ type TrialMetrics struct {
 	State        State      `db:"state" json:"state"`
 	EndTime      *time.Time `db:"end_time" json:"end_time"`
 	Metrics      JSONObj    `db:"metrics" json:"metrics"`
-}
-
-// Checkpoint represents a row from the `checkpoints` table.
-type Checkpoint struct {
-	ID                int        `db:"id" json:"id"`
-	TrialID           int        `db:"trial_id" json:"trial_id"`
-	TrialRunID        int        `db:"trial_run_id" json:"-"`
-	TotalBatches      int        `db:"total_batches" json:"total_batches"`
-	State             State      `db:"state" json:"state"`
-	EndTime           *time.Time `db:"end_time" json:"end_time"`
-	UUID              *string    `db:"uuid" json:"uuid"`
-	Resources         JSONObj    `db:"resources" json:"resources"`
-	Metadata          JSONObj    `db:"metadata" json:"metadata"`
-	Framework         string     `db:"framework" json:"framework"`
-	Format            string     `db:"format" json:"format"`
-	DeterminedVersion string     `db:"determined_version" json:"determined_version"`
 }
 
 // TrialLog represents a row from the `trial_logs` table.

--- a/master/pkg/model/model.go
+++ b/master/pkg/model/model.go
@@ -1,11 +1,20 @@
 package model
 
 import (
+	"encoding/json"
 	"time"
+
+	"github.com/pkg/errors"
+	"github.com/uptrace/bun"
+
+	"github.com/determined-ai/determined/master/pkg/protoutils"
+	"github.com/determined-ai/determined/proto/pkg/modelv1"
 )
 
 // Model represents a row from the `models` table.
 type Model struct {
+	bun.BaseModel
+
 	ID              int       `db:"id" json:"id"`
 	Name            string    `db:"name" json:"name"`
 	Description     string    `db:"description" json:"description"`
@@ -13,13 +22,38 @@ type Model struct {
 	CreationTime    time.Time `db:"creation_time" json:"creation_time"`
 	LastUpdatedTime time.Time `db:"last_updated_time" json:"last_updated_time"`
 	Labels          []string  `db:"labels" json:"labels"`
-	Username        string    `db:"username" json:"username"`
 	Archived        bool      `db:"archived" json:"archived"`
 	NumVersions     int       `db:"num_versions" json:"num_versions"`
+	Notes           string
+
+	UserID UserID
+	// "join users on models.user_id = users.id"
+	Username string `bun:",rel:belongs-to,join:user_id=id`
+}
+
+func (m Model) ToProto(pc *protoutils.ProtoConverter) modelv1.Model {
+	if pc.Error() != nil {
+		return modelv1.Model{}
+	}
+
+	return modelv1.Model{
+		Description:     m.Description,
+		Metadata:        pc.ToStruct(m.Metadata, "metadata"),
+		CreationTime:    pc.ToTimestamp(m.CreationTime),
+		LastUpdatedTime: pc.ToTimestamp(m.LastUpdatedTime),
+		Id:              pc.ToInt32(m.ID),
+		NumVersions:     pc.ToInt32(m.NumVersions),
+		Labels:          m.Labels,
+		Username:        m.Username,
+		Archived:        m.Archived,
+		Notes:           m.Notes,
+	}
 }
 
 // ModelVersion represents a row from the `model_versions` table.
 type ModelVersion struct {
+	bun.BaseModel
+
 	ID              int       `db:"id" json:"id"`
 	Version         int       `db:"version" json:"version"`
 	CheckpointID    int       `db:"checkpoint_id" json:"checkpoint_id"`
@@ -29,6 +63,60 @@ type ModelVersion struct {
 	Name            string    `db:"name" json:"name"`
 	LastUpdatedTime time.Time `db:"last_updated_time" json:"last_updated_time"`
 	Comment         string    `db:"comment" json:"comment"`
-	Notes           string    `db:"readme" json:"notes"`
+	Notes           string    `db:"notes" json:"notes"` // XXX: why was this db:"readme"?
 	Username        string    `db:"username" json:"username"`
+	Labels          Labels
+
+	UserID UserID
+	// "join users on models.user_id = users.id"
+	// XXX: does this get picked up automatically??
+	Username string `bun:",rel:belongs-to,join:user_id=id`
+}
+
+func (v ModelVersion) ToProto(
+	pc *protoutils.ProtoConverter, model Model, checkpoint CheckpointExpanded,
+) modelv1.ModelVersion {
+	if pc.Error() != nil {
+		return modelv1.ModelVersion{}
+	}
+
+	m := model.ToProto(pc)
+	c := checkpoint.ToProto(pc)
+
+	return modelv1.ModelVersion{
+		Model:           &m,
+		Checkpoint:      &c,
+		Version:         pc.ToInt32(v.Version),
+		CreationTime:    pc.ToTimestamp(v.CreationTime),
+		Id:              pc.ToInt32(v.ID),
+		Name:            v.Name,
+		Metadata:        pc.ToStruct(v.Metadata, "metadata"),
+		LastUpdatedTime: pc.ToTimestamp(v.LastUpdatedTime),
+		Comment:         v.Comment, // XXX: why do we have .Comment and .Notes?
+		Notes:           v.Notes,
+		Username:        v.Username,
+		Labels:          v.Labels,
+	}
+}
+
+// Labels maps filenames to file sizes.
+type Labels []string
+
+// Scan converts jsonb from postgres into a Resources object.
+// TODO: Combine all json.unmarshal-based Scanners into a single Scan implementation.
+func (l *Labels) Scan(src interface{}) error {
+	if src == nil {
+		*l = nil
+		return nil
+	}
+	bytes, ok := src.([]byte)
+	if !ok {
+		return errors.Errorf("unable to convert to []byte: %v", src)
+	}
+	obj := []string{}
+	if err := json.Unmarshal(bytes, &obj); err != nil {
+		return errors.Wrapf(err, "unable to unmarshal Labels: %v", src)
+	}
+	*l = Labels(obj)
+	return nil
 }

--- a/master/pkg/model/model.go
+++ b/master/pkg/model/model.go
@@ -64,13 +64,12 @@ type ModelVersion struct {
 	LastUpdatedTime time.Time `db:"last_updated_time" json:"last_updated_time"`
 	Comment         string    `db:"comment" json:"comment"`
 	Notes           string    `db:"notes" json:"notes"` // XXX: why was this db:"readme"?
-	Username        string    `db:"username" json:"username"`
 	Labels          Labels
 
 	UserID UserID
 	// "join users on models.user_id = users.id"
 	// XXX: does this get picked up automatically??
-	Username string `bun:",rel:belongs-to,join:user_id=id`
+	Username string `bun:",rel:belongs-to,join:user_id=id" db:"username" json:"username"`
 }
 
 func (v ModelVersion) ToProto(

--- a/master/pkg/protoutils/converter.go
+++ b/master/pkg/protoutils/converter.go
@@ -7,6 +7,7 @@ import (
 	"github.com/pkg/errors"
 	"google.golang.org/protobuf/types/known/structpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	"github.com/determined-ai/determined/proto/pkg/checkpointv1"
 )
@@ -65,4 +66,13 @@ func (c *ProtoConverter) ToInt32(i int) int32 {
 		return 0
 	}
 	return int32(i)
+}
+
+// ToDoubleValue converts a float32 pointer into the nullable DoubleValue type.
+func (c *ProtoConverter) ToDoubleValue(v *float64) *wrapperspb.DoubleValue {
+	if v == nil {
+		// XXX: does this properly distinguish 0 and nil values?
+		return nil
+	}
+	return &wrapperspb.DoubleValue{Value: *v}
 }

--- a/master/task2-migration.sql
+++ b/master/task2-migration.sql
@@ -1,0 +1,25 @@
+CREATE VIEW checkpoints_expanded AS
+    SELECT
+        c.id,
+        c.trial_id,
+        c.trial_run_id,
+        c.total_batches,
+        c.state,
+        c.end_time,
+        c.uuid,
+        c.resources,
+        c.metadata,
+        c.framework,
+        c.format,
+        c.determined_version,
+
+        e.config AS experiment_config,
+        e.id AS experiment_id
+        t.hparams,
+        v.metrics AS validation_metrics,
+        -- XXX where do I get the validation state from?
+        v.metrics->'validation_metrics'->>(experiment_config->'searcher'->>'metric')::float8 AS searcher_metric
+    FROM checkpoints AS c
+    LEFT JOIN trials AS t ON c.trial_id = t.id
+    LEFT JOIN experiments AS e ON t.experiment_id = e.id
+    LEFT JOIN validations AS v ON c.total_batches = v.total_batches and c.trial_id = v.trial_id;

--- a/master/task3-checkpoints.proto
+++ b/master/task3-checkpoints.proto
@@ -1,0 +1,72 @@
+syntax = "proto3";
+
+package determined.checkpoint.v1;
+option go_package = "github.com/determined-ai/determined/proto/pkg/checkpointv1";
+
+import "google/protobuf/struct.proto";
+import "google/protobuf/timestamp.proto";
+import "google/protobuf/wrappers.proto";
+import "protoc-gen-swagger/options/annotations.proto";
+
+// The current state of the checkpoint.
+enum State {
+  // The state of the checkpoint is unknown.
+  STATE_UNSPECIFIED = 0;
+  // The checkpoint is in an active state.
+  STATE_ACTIVE = 1;
+  // The checkpoint is persisted to checkpoint storage.
+  STATE_COMPLETED = 2;
+  // The checkpoint errored.
+  STATE_ERROR = 3;
+  // The checkpoint has been deleted.
+  STATE_DELETED = 4;
+}
+
+message CheckpointTrainingData {
+  // The ID of the trial that created this checkpoint.
+  int32 trial_id = 1;
+  // The ID of the experiment that created this checkpoint.
+  int32 experiment_id = 2;
+  // The configuration of the experiment that created this checkpoint.
+  google.protobuf.Struct experiment_config = 3;
+  // Hyperparameter values for the trial that created this checkpoint.
+  google.protobuf.Struct hparams = 4;
+  // Training metrics reported at the same latest_batch as the checkpoint.
+  google.protobuf.Struct training_metrics = 5;
+  // Validation metrics reported at the same latest_batch as the checkpoint.
+  google.protobuf.Struct validation_metrics = 6;
+  // TODO: is this actually a good idea?  It couples a lot of parts of the
+  // system pretty tightly, and if we had a good metrics api it would be a much
+  // more natural way to serve this information.
+  google.protobuf.DoubleValue searcher_metric = 17;
+}
+
+// Checkpoint is a collection of files.
+message Checkpoint {
+  option (grpc.gateway.protoc_gen_swagger.options.openapiv2_schema) = {
+    json_schema: { required: [] }
+  };
+  // The ID of the task which generated this checkpoint.
+  // (Future): Might be empty for an imported checkpoint.
+  string task_id = 1;
+  // The ID of the allocation which generated this checkpoint.
+  // (Future): Might be empty for an imported checkpoint.
+  string allocation_id = 2;
+  // UUID of the checkpoint.
+  string uuid = 3;
+  // Timestamp when the checkpoint was reported.
+  google.protobuf.Timestamp report_time = 4;
+  // Dictionary of file paths to file sizes in bytes of all files in the
+  // checkpoint.
+  map<string, int64> resources = 5;
+  // User defined metadata associated with the checkpoint.
+  google.protobuf.Struct metadata = 6;
+  // Training-related data for this checkpoint.
+  // (Future): Present only when a training originated from a Trial.  If
+  // training.trial_id is zero the struct is empty.
+  CheckpointTrainingData training = 7;
+  State state = 8;
+
+  // TODO: delete this and fix the master so it still compiles.
+  State validation_state = 9;
+}

--- a/master/task3-migration.sql
+++ b/master/task3-migration.sql
@@ -1,0 +1,75 @@
+-- XXX We'll need to key checkpoints by UUID and not by ID;
+-- when we see a checkpoint id we'll have to assume its old, and when we see
+-- a uuid we should not assume if it is old or new.
+-- XXX: foreign key to new_checkpoints?
+alter table trials add column warm_start_checkpoint_uuid uuid;
+
+create table public.checkpoints_new (
+    -- XXX: why not just use uuid as the primary key?
+    id bigserial PRIMARY KEY,
+    uuid uuid NOT NULL UNIQUE,
+    -- XXX: foreign key to tasks table
+    task_id text,
+    -- XXX: add this later?  Or what?
+    allocation_id text,
+    -- XXX: why on earth do we allow time zone?
+    report_time timestamp with time zone,
+    -- XXX: default these?
+    state public.checkpoint_state NOT NULL,
+    resources jsonb DEFAULT '{}'::jsonb,
+    metadata jsonb DEFAULT '{}'::jsonb
+);
+
+-- This is fairly well-optimized already, mostly by @stokc
+CREATE VIEW checkpoints_expanded AS
+    SELECT
+        c.uuid,
+        t.task_id,
+        c.end_time as report_time,
+        c.state,
+        c.resources,
+        -- construct a metadata json from the user's metadata plus our training-specific fields that the
+        -- TrialControllers inject when creating checkpoints.  Those values used to be "system" values,
+        -- but since the release of Core API, the TrialControllers are no longer part of the system
+        -- proper but are considered userspace tools.
+        jsonb_build_object(
+            'latest_batch', c.total_batches,
+            'framework', c.framework,
+            'determined_version', c.determined_version
+        ) || COALESCE(c.metadata, '{}'::jsonb) as metadata,
+        -- .Training substruct
+        c.trial_id,
+        t.experiment_id,
+        e.config as experiment_config,
+        t.hparams,
+        s.metrics as training_metrics,
+        v.metrics as validation_metrics
+    FROM raw_checkpoints AS c
+    LEFT JOIN trials AS t on c.trial_id = t.id
+    LEFT JOIN experiments AS e on t.experiment_id = e.id
+    LEFT JOIN validations AS v on c.total_batches = v.total_batches and c.trial_id = v.trial_id
+    -- avoiding the steps view causes Postgres to not "Materialize" in this join.
+    LEFT JOIN raw_steps AS s on c.total_batches = s.total_batches and c.trial_id = s.trial_id
+    where s.archived = false
+    UNION
+    SELECT
+        c.uuid,
+        c.task_id,
+        c.report_time,
+        c.state,
+        c.resources,
+        c.metadata,
+        -- .Training substruct
+        t.id as trial_id,
+        t.experiment_id,
+        e.config as experiment_config,
+        t.hparams,
+        s.metrics as training_metrics,
+        v.metrics as validation_metrics
+    FROM checkpoints_new AS c
+    LEFT JOIN trials AS t on c.task_id = t.task_id
+    LEFT JOIN experiments AS e on t.experiment_id = e.id
+    LEFT JOIN validations AS v on c.metadata->>'latest_batch' = v.total_batches::text and t.id = v.trial_id
+    -- avoiding the steps view causes Postgres to not "Materialize" in this join.
+    LEFT JOIN raw_steps AS s on c.metadata->>'latest_batch' = s.total_batches::text and t.id = s.trial_id
+    where s.archived = false;


### PR DESCRIPTION
## Description

Checkpoints in Determined were originally designed exclusively for
training.  We would like in the future to support checkpointing for all
tasks.  To get there, we need to change what data we keep about
checkpoints.  This change focuses on migrating existing
training-specific data into checkpoint metadata, modifying how
checkpoints are uploaded so that the Core API checkpointing does not
feel training-specific, and updating the WebUI to reflect the new
schema.

## Test Plan


## Commentary (optional)

This upstream feature branch will include backend work, webui client-side work, and python client-side work before it is complete.