### PR TITLE
fix: Use pagination in CLI to return all experiments, not the default limit

### DIFF
--- a/harness/determined/cli/experiment.py
+++ b/harness/determined/cli/experiment.py
@@ -426,7 +426,7 @@ def list_experiments(args: Namespace) -> None:
     if not args.all:
         users = [authentication.must_cli_auth().get_session_user()]
 
-    r = bindings.get_GetExperiments(setup_session(args), users=users)
+    r = bindings.get_GetExperiments(setup_session(args), users=users, limit=100_000)
 
     def format_experiment(e: Any) -> List[Any]:
         result = [
@@ -499,7 +499,9 @@ def scalar_validation_metrics_names(exp: Dict[str, Any]) -> Set[str]:
 
 @authentication.required
 def list_trials(args: Namespace) -> None:
-    r = bindings.get_GetExperimentTrials(setup_session(args), experimentId=args.experiment_id)
+    r = bindings.get_GetExperimentTrials(
+        setup_session(args), experimentId=args.experiment_id, limit=100_000
+    )
     trials = r.trials
 
     headers = ["Trial ID", "State", "H-Params", "Start Time", "End Time", "# of Batches"]

--- a/harness/determined/cli/experiment.py
+++ b/harness/determined/cli/experiment.py
@@ -196,7 +196,7 @@ def create(args: Namespace) -> None:
 
 
 def limit_offset_paginator(
-    method: Callable, agg_field: str, connection_args: Namespace, **kwargs
+    method: Callable, agg_field: str, connection_args: Namespace, **kwargs: Any
 ) -> List[Union[bindings.v1Experiment, bindings.trialv1Trial]]:
     all_objects: List[Union[bindings.v1Experiment, bindings.trialv1Trial]] = []
     offset = 0
@@ -533,7 +533,7 @@ def list_trials(args: Namespace) -> None:
             render.format_time(t.endTime),
             t.totalBatchesProcessed,
         ]
-        for t in all_trials
+        for t in filter(lambda t: t.__class__ == bindings.trialv1Trial, all_trials)
     ]
 
     render.tabulate_or_csv(headers, values, args.csv)

--- a/harness/determined/cli/experiment.py
+++ b/harness/determined/cli/experiment.py
@@ -426,7 +426,7 @@ def list_experiments(args: Namespace) -> None:
     if not args.all:
         users = [authentication.must_cli_auth().get_session_user()]
 
-    all_experiments = []
+    all_experiments: List[bindings.v1Experiment] = []
     offset = 0
     while True:
         # pagination of experiments
@@ -508,7 +508,7 @@ def scalar_validation_metrics_names(exp: Dict[str, Any]) -> Set[str]:
 
 @authentication.required
 def list_trials(args: Namespace) -> None:
-    all_trials = []
+    all_trials: List[bindings.v1Trial] = []
     offset = 0
     while True:
         # pagination of experiment trials

--- a/harness/determined/cli/experiment.py
+++ b/harness/determined/cli/experiment.py
@@ -519,7 +519,7 @@ def scalar_validation_metrics_names(exp: Dict[str, Any]) -> Set[str]:
 
 @authentication.required
 def list_trials(args: Namespace) -> None:
-    all_trials = limit_offset_paginator(
+    all_trials: List[bindings.trialv1Trial] = limit_offset_paginator(
         bindings.get_GetExperimentTrials, "trials", args, experimentId=args.experiment_id
     )
 
@@ -533,7 +533,7 @@ def list_trials(args: Namespace) -> None:
             render.format_time(t.endTime),
             t.totalBatchesProcessed,
         ]
-        for t in filter(lambda t: t.__class__ == bindings.trialv1Trial, all_trials)
+        for t in all_trials
     ]
 
     render.tabulate_or_csv(headers, values, args.csv)

--- a/harness/determined/cli/experiment.py
+++ b/harness/determined/cli/experiment.py
@@ -9,7 +9,7 @@ import time
 from argparse import FileType, Namespace
 from pathlib import Path
 from pprint import pformat
-from typing import Any, Dict, Iterable, List, Optional, Set, Tuple
+from typing import Any, Callable, Dict, Iterable, List, Optional, Set, Tuple, Union
 
 import tabulate
 
@@ -195,8 +195,10 @@ def create(args: Namespace) -> None:
         submit_experiment(args)
 
 
-def limit_offset_paginator(method, agg_field: str, connection_args: Namespace, **kwargs):
-    all_objects: List[bindings.v1Experiment | bindings.v1Trial] = []
+def limit_offset_paginator(
+    method: Callable, agg_field: str, connection_args: Namespace, **kwargs
+) -> List[Union[bindings.v1Experiment, bindings.trialv1Trial]]:
+    all_objects: List[Union[bindings.v1Experiment, bindings.trialv1Trial]] = []
     offset = 0
     while True:
         r = method(setup_session(connection_args), limit=200, offset=offset, **kwargs)

--- a/harness/determined/cli/experiment.py
+++ b/harness/determined/cli/experiment.py
@@ -199,19 +199,18 @@ def limit_offset_paginator(
     method: Callable,
     agg_field: str,
     sess: session.Session,
-    page_limit: Optional[int] = 200,
+    limit: int = 200,
     offset: Optional[int] = None,
     **kwargs: Any
 ) -> List[Any]:
     all_objects: List[Any] = []
-    limit = page_limit or 200
     internal_offset = offset or 0
     while True:
         r = method(sess, limit=limit, offset=internal_offset, **kwargs)
         page_objects = getattr(r, agg_field)
         all_objects += page_objects
         internal_offset += len(page_objects)
-        if offset or len(page_objects) < limit:
+        if offset is not None or len(page_objects) < limit:
             break
     return all_objects
 
@@ -698,19 +697,19 @@ def experiment_id_arg(help: str) -> Arg:  # noqa: A002
     return Arg("experiment_id", type=int, help=help)
 
 
+# do not use util.py's pagination_args because default behavior here is
+# to hide pagination and unify all experiment pages into one output
 pagination_args = [
     Arg(
         "--limit",
-        "-l",
         type=int,
         default=200,
         help="Maximum items per page of results",
     ),
     Arg(
         "--offset",
-        "-off",
         type=int,
-        default=0,
+        default=None,
         help="Number of items to skip before starting page of results",
     ),
 ]


### PR DESCRIPTION
## Description

Fixes the CLI's `det experiment list` and `det experiment list-trials` to use API pagination to return all items (when >100 results). This expects 200 items / request until there are no more pages.

An alternative would be one request with a huge limit parameter (such as limit=100000); first commit shows this approach

## Test Plan

Run `det experiment list` on a server with more than 200 experiments.
- All experiments should be returned.
- Order should be first to last.
- There should be no seams between pages.

## Checklist

- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.