### PR TITLE
feat: add on_trial_{startup,shutdown} hooks to PyTorchCallback

### DIFF
--- a/docs/release-notes/3643-callbacks.txt
+++ b/docs/release-notes/3643-callbacks.txt
@@ -1,0 +1,10 @@
+:orphan:
+
+**New Features**
+
+-  Add ``on_trial_startup()`` and ``on_trial_shutdown()`` methods to
+   :class:`~determined.pytorch.PyTorchCallback`. Whenever ``on_trial_startup()`` is called,
+   ``on_trial_shutdown()`` is always called before the trial container shuts down. These callbacks
+   make it possible to do reliable resource management in a training container, such as if you wish
+   to start a background thread or process for data loading and shut it down before the process
+   exits.

--- a/harness/determined/pytorch/_callback.py
+++ b/harness/determined/pytorch/_callback.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 
 class PyTorchCallback:
@@ -18,6 +18,34 @@ class PyTorchCallback:
         :meth:`on_checkpoint_end`). To configure a callback implementation to execute on a subset of
         GPUs, please condition your implementation on ``trial.context.distributed.get_rank()``.
     """
+
+    def on_trial_startup(self, first_batch_idx: int, checkpoint_uuid: Optional[str]) -> None:
+        """
+        Runs before, training, validation, or building dataloaders.
+
+        Arguments:
+            first_batch_idx (int):  The first batch index to be trained.  If the trial has already
+                completed some amount of training in a previous allocation on the cluster, this will
+                be nonzero.
+            checkpoint_uuid (str or None):  The checkpoint from which weight, optimizer state, etc
+                will be loaded.  When ``first_batch_idx > 0`` this will contain the uuid of the
+                most recent checkpoint saved by this trial.  Otherwise, it will contain the uuid of
+                the checkpoint from which this trial was configured to warm_start from, or None if
+                no warm start was configured.
+        """
+        pass
+
+    def on_trial_shutdown(self) -> None:
+        """
+        Runs just before shutting down training to get off of the cluster.  This does not imply that
+        the trial is complete; it may just be paused or preempted by a higher-priority task.
+
+        .. warning::
+            This callback runs each time a Trial shuts down gracefully to come off the cluster.
+            This callback does not mean that the Trial is done training.  Additionally, if the trial
+            is killed the container will be destroyed without this callback running.
+        """
+        pass
 
     def on_validation_start(self) -> None:
         """

--- a/harness/determined/pytorch/_callback.py
+++ b/harness/determined/pytorch/_callback.py
@@ -21,7 +21,7 @@ class PyTorchCallback:
 
     def on_trial_startup(self, first_batch_idx: int, checkpoint_uuid: Optional[str]) -> None:
         """
-        Runs before, training, validation, or building dataloaders.
+        Runs before training, validation, or building dataloaders.
 
         Arguments:
             first_batch_idx (int):  The first batch index to be trained.  If the trial has already
@@ -30,8 +30,9 @@ class PyTorchCallback:
             checkpoint_uuid (str or None):  The checkpoint from which weight, optimizer state, etc
                 will be loaded.  When ``first_batch_idx > 0`` this will contain the uuid of the
                 most recent checkpoint saved by this trial.  Otherwise, it will contain the uuid of
-                the checkpoint from which this trial was configured to warm_start from, or None if
-                no warm start was configured.
+                the checkpoint from which this trial was configured to warm start from (via
+                ``source_trial_id`` or ``source_checkpoint_uuid`` in the searcher config), or None
+                if no warm start was configured.
         """
         pass
 

--- a/harness/tests/experiment/fixtures/pytorch_xor_model.py
+++ b/harness/tests/experiment/fixtures/pytorch_xor_model.py
@@ -300,6 +300,8 @@ class Counter(det.pytorch.PyTorchCallback):
         self.training_started_times = 0
         self.training_epochs_started = 0
         self.training_epochs_ended = 0
+        self.trial_startups = 0
+        self.trial_shutdowns = 0
 
     def on_validation_start(self) -> None:
         self.validation_steps_started += 1
@@ -327,6 +329,12 @@ class Counter(det.pytorch.PyTorchCallback):
 
     def load_state_dict(self, state_dict: Dict[str, Any]) -> None:
         self.__dict__ = state_dict
+
+    def on_trial_startup(self, *arg):
+        self.trial_startups += 1
+
+    def on_trial_shutdown(self):
+        self.trial_shutdowns += 1
 
 
 class EphemeralLegacyCallbackCounter(det.pytorch.PyTorchCallback):

--- a/harness/tests/experiment/pytorch/test_pytorch_trial.py
+++ b/harness/tests/experiment/pytorch/test_pytorch_trial.py
@@ -534,12 +534,13 @@ class TestPyTorchTrial:
         hparams["disable_dataset_reproducibility_checks"] = False
 
         with pytest.raises(RuntimeError, match="you can disable this check by calling"):
-            _ = utils.make_trial_controller_from_trial_implementation(
+            controller = utils.make_trial_controller_from_trial_implementation(
                 trial_class=pytorch_onevar_model.OneVarTrial,
                 hparams=hparams,
                 workloads=make_workloads(),
                 trial_seed=self.trial_seed,
             )
+            controller.run()
 
     def test_custom_dataloader(self) -> None:
         def make_workloads() -> workload.Stream:

--- a/harness/tests/experiment/pytorch/test_pytorch_trial.py
+++ b/harness/tests/experiment/pytorch/test_pytorch_trial.py
@@ -320,16 +320,19 @@ class TestPyTorchTrial:
 
         def make_workloads1() -> workload.Stream:
             nonlocal controller
+            assert controller.trial.counter.trial_startups == 1
 
             yield workload.train_workload(1, 1, 0, 4), workload.ignore_workload_response
             assert controller is not None, "controller was never set!"
             assert controller.trial.counter.__dict__ == {
+                "trial_startups": 1,
                 "validation_steps_started": 0,
                 "validation_steps_ended": 0,
                 "checkpoints_ended": 0,
                 "training_started_times": 1,
                 "training_epochs_started": 2,
                 "training_epochs_ended": 2,
+                "trial_shutdowns": 0,
             }
             assert controller.trial.legacy_counter.__dict__ == {
                 "legacy_on_training_epochs_start_calls": 2
@@ -337,12 +340,14 @@ class TestPyTorchTrial:
 
             yield workload.validation_workload(), workload.ignore_workload_response
             assert controller.trial.counter.__dict__ == {
+                "trial_startups": 1,
                 "validation_steps_started": 1,
                 "validation_steps_ended": 1,
                 "checkpoints_ended": 0,
                 "training_started_times": 1,
                 "training_epochs_started": 2,
                 "training_epochs_ended": 2,
+                "trial_shutdowns": 0,
             }
             assert controller.trial.legacy_counter.__dict__ == {
                 "legacy_on_training_epochs_start_calls": 2
@@ -354,12 +359,14 @@ class TestPyTorchTrial:
             latest_checkpoint = interceptor.metrics_result()["uuid"]
             latest_batch = 1
             assert controller.trial.counter.__dict__ == {
+                "trial_startups": 1,
                 "validation_steps_started": 1,
                 "validation_steps_ended": 1,
                 "checkpoints_ended": 1,
                 "training_started_times": 1,
                 "training_epochs_started": 2,
                 "training_epochs_ended": 2,
+                "trial_shutdowns": 0,
             }
             assert controller.trial.legacy_counter.__dict__ == {
                 "legacy_on_training_epochs_start_calls": 2
@@ -374,6 +381,7 @@ class TestPyTorchTrial:
             checkpoint_dir=str(checkpoint_dir),
         )
         controller.run()
+        assert controller.trial.counter.trial_shutdowns == 1
 
         # Verify the checkpoint loading callback works.
 
@@ -390,12 +398,16 @@ class TestPyTorchTrial:
         )
         controller.run()
         assert controller.trial.counter.__dict__ == {
+            # Note: trial_startups will get reset by the loading logic.
+            "trial_startups": 1,
             "validation_steps_started": 1,
             "validation_steps_ended": 1,
             "checkpoints_ended": 0,
             "training_started_times": 2,
             "training_epochs_started": 3,
             "training_epochs_ended": 3,
+            # Note: trial_shutdowns cannot be persisted, since it is called after checkpointing.
+            "trial_shutdowns": 1,
         }
         assert controller.trial.legacy_counter.__dict__ == {
             "legacy_on_training_epochs_start_calls": 1


### PR DESCRIPTION
## Commentary

I have argued against this feature for a _long_ time because of how users frequently ask for it looking for an end-of-trial hook, rather than an end-of-allocation hook.  We can't deliver the first one.  But I've finally assented. I think this is a pretty basic feature that we should just support.