### PR TITLE
added interaction test for inline editor, fixed component to preserve…

### DIFF
--- a/e2e_tests/tests/nightly/test_distributed.py
+++ b/e2e_tests/tests/nightly/test_distributed.py
@@ -170,6 +170,6 @@ def test_word_language_lstm_const() -> None:
 @pytest.mark.gpu_required
 def test_byol_pytorch_distributed() -> None:
     config = conf.load_config(conf.cv_examples_path("byol_pytorch/distributed-stl10.yaml"))
-    config = conf.set_max_length(config, {"batches": 200})
+    config = conf.set_max_length(config, {"epochs": 1})
 
     exp.run_basic_test_with_temp_config(config, conf.cv_examples_path("byol_pytorch"), 1)

--- a/master/internal/db/postgres_tasks.go
+++ b/master/internal/db/postgres_tasks.go
@@ -109,13 +109,13 @@ WHERE allocation_id = :allocation_id
 func (db *PgDB) CompleteAllocationTelemetry(aID model.AllocationID) ([]byte, error) {
 	return db.rawQuery(`
 SELECT json_build_object(
-	'allocation_id', a.allocation_id, 
+	'allocation_id', a.allocation_id,
 	'job_id', t.job_id,
 	'task_type', t.task_type,
     'duration_sec', COALESCE(EXTRACT(EPOCH FROM (a.end_time - a.start_time)), 0)
-) 
-FROM allocations as a JOIN tasks as t 
-ON a.task_id = t.task_id 
+)
+FROM allocations as a JOIN tasks as t
+ON a.task_id = t.task_id
 WHERE a.allocation_id = $1;
 `, aID)
 }
@@ -287,7 +287,7 @@ VALUES
 		fmt.Fprintf(&text, " ($%d, $%d, $%d, $%d, $%d, $%d, $%d, $%d, $%d, $%d)",
 			i*10+1, i*10+2, i*10+3, i*10+4, i*10+5, i*10+6, i*10+7, i*10+8, i*10+9, i*10+10)
 
-		args = append(args, log.TaskID, log.AllocationID, log.Log, log.AgentID, log.ContainerID,
+		args = append(args, log.TaskID, log.AllocationID, []byte(log.Log), log.AgentID, log.ContainerID,
 			log.RankID, log.Timestamp, log.Level, log.StdType, log.Source)
 	}
 

--- a/webui/react/src/components/InlineEditor.test.tsx
+++ b/webui/react/src/components/InlineEditor.test.tsx
@@ -1,0 +1,74 @@
+import {
+  render,
+  screen,
+  waitForElementToBeRemoved,
+} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import React from "react";
+
+import InlineEditor from "./InlineEditor";
+
+const setup = (text: string = "", disabled = false) => {
+  const onSave = jest.fn();
+  const onCancel = jest.fn();
+  const { container } = render(
+    <InlineEditor
+      value={text}
+      onSave={onSave}
+      onCancel={onCancel}
+      disabled={disabled}
+    />
+  );
+
+  const waitForSpinnerToDisappear = async () =>
+    await waitForElementToBeRemoved(
+      () => container.getElementsByClassName("ant-spin-spinning")[0]
+    );
+  return { onSave, onCancel, waitForSpinnerToDisappear };
+};
+
+describe("InlineEditor", () => {
+  it("displays the value passed as prop", async () => {
+    setup("before");
+    expect(screen.getByDisplayValue("before")).toBeInTheDocument();
+  });
+
+  it("preserves input when focus leaves", async () => {
+    const { waitForSpinnerToDisappear } = setup("before");
+    userEvent.clear(screen.getByRole("textbox"));
+    userEvent.type(screen.getByRole("textbox"), "after");
+    userEvent.click(document.body);
+    expect(screen.getByRole("textbox")).not.toHaveFocus();
+    expect(screen.getByDisplayValue("after")).toBeInTheDocument();
+
+    // wait for spinner to go away
+    // to avoid "test not wrapped in act(...)"
+    await waitForSpinnerToDisappear();
+  });
+
+  it("calls save with input on blur", async () => {
+    const { onSave, waitForSpinnerToDisappear } = setup("before");
+    userEvent.clear(screen.getByRole("textbox"));
+    userEvent.type(screen.getByRole("textbox"), "after");
+    userEvent.click(document.body);
+
+    await waitForSpinnerToDisappear();
+    expect(onSave).toHaveBeenCalledWith("after");
+    expect(screen.getByRole("textbox")).not.toHaveFocus();
+  });
+
+  it("calls restores previous value when esc is pressed", async () => {
+    setup("before");
+    userEvent.clear(screen.getByRole("textbox"));
+    userEvent.type(screen.getByRole("textbox"), "after{escape}");
+    expect(screen.getByDisplayValue("before")).toBeInTheDocument();
+  });
+
+  it("doesnt allow user input when disabled", async () => {
+    setup("before", true);
+    userEvent.clear(screen.getByRole("textbox"));
+    userEvent.type(screen.getByRole("textbox"), "after");
+    expect(screen.getByDisplayValue("before")).toBeInTheDocument();
+  });
+});

--- a/webui/react/src/components/InlineEditor.tsx
+++ b/webui/react/src/components/InlineEditor.tsx
@@ -1,9 +1,15 @@
 import React, {
-  ChangeEvent, HTMLAttributes, KeyboardEvent, useCallback, useEffect, useRef, useState,
-} from 'react';
+  ChangeEvent,
+  HTMLAttributes,
+  KeyboardEvent,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
 
-import css from './InlineEditor.module.scss';
-import Spinner from './Spinner';
+import css from "./InlineEditor.module.scss";
+import Spinner from "./Spinner";
 
 interface Props extends HTMLAttributes<HTMLDivElement> {
   allowClear?: boolean;
@@ -17,8 +23,8 @@ interface Props extends HTMLAttributes<HTMLDivElement> {
   value: string;
 }
 
-const CODE_ENTER = 'Enter';
-const CODE_ESCAPE = 'Escape';
+export const CODE_ENTER = "Enter";
+export const CODE_ESCAPE = "Escape";
 
 const InlineEditor: React.FC<Props> = ({
   allowClear = true,
@@ -34,10 +40,10 @@ const InlineEditor: React.FC<Props> = ({
 }: Props) => {
   const growWrapRef = useRef<HTMLDivElement>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
-  const [ currentValue, setCurrentValue ] = useState(value);
-  const [ isEditable, setIsEditable ] = useState(false);
-  const [ isSaving, setIsSaving ] = useState(false);
-  const classes = [ css.base ];
+  const [currentValue, setCurrentValue] = useState(value);
+  const [isEditable, setIsEditable] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
+  const classes = [css.base];
 
   if (isOnDark) classes.push(css.onDark);
   if (isEditable) classes.push(css.editable);
@@ -47,34 +53,45 @@ const InlineEditor: React.FC<Props> = ({
   }
   if (disabled) classes.push(css.disabled);
 
-  const updateEditorValue = useCallback((value: string) => {
-    let newValue = value;
-    if (maxLength) newValue = newValue.slice(0, maxLength);
-    if (textareaRef.current) textareaRef.current.value = newValue;
-    if (growWrapRef.current) growWrapRef.current.dataset.value = newValue;
-    setCurrentValue(newValue);
-  }, [ maxLength ]);
+  const updateEditorValue = useCallback(
+    (value: string) => {
+      let newValue = value;
+      if (maxLength) newValue = newValue.slice(0, maxLength);
+      if (textareaRef.current) textareaRef.current.value = newValue;
+      if (growWrapRef.current) growWrapRef.current.dataset.value = newValue;
+      setCurrentValue(newValue);
+    },
+    [maxLength]
+  );
 
   const cancel = useCallback(() => {
     updateEditorValue(value);
     if (onCancel) onCancel();
-  }, [ onCancel, updateEditorValue, value ]);
+  }, [onCancel, updateEditorValue, value]);
 
-  const save = useCallback(async (newValue: string) => {
-    if (onSave) {
-      setIsSaving(true);
-      const err = await onSave(newValue);
-      if (err !== null) {
-        updateEditorValue(value);
+  const save = useCallback(
+    async (newValue: string) => {
+      if (onSave) {
+        setIsSaving(true);
+
+        try {
+          await onSave(newValue);
+          updateEditorValue(newValue);
+        } catch {
+          // send warning unable to save ?
+          updateEditorValue(value);
+        } finally {
+          setIsSaving(false);
+        }
       }
-      setIsSaving(false);
-    }
-  }, [ onSave, updateEditorValue, value ]);
+    },
+    [onSave, updateEditorValue, value]
+  );
 
   const handleWrapperClick = useCallback(() => {
     if (disabled) return;
     setIsEditable(true);
-  }, [ disabled ]);
+  }, [disabled]);
 
   /*
    * To trigger a save or cancel, we trigger the blur.
@@ -85,51 +102,67 @@ const InlineEditor: React.FC<Props> = ({
     if (!textareaRef.current) return;
 
     const newValue = textareaRef.current.value.trim();
-    (!!newValue || allowClear) && newValue !== value ? save(newValue) : cancel();
+    (!!newValue || allowClear) && newValue !== value
+      ? save(newValue)
+      : cancel();
 
     // Reset `isEditable` to false if the blur was user triggered.
     setIsEditable(false);
-  }, [ allowClear, cancel, save, value ]);
+  }, [allowClear, cancel, save, value]);
 
-  const handleTextareaChange = useCallback((e: ChangeEvent<HTMLTextAreaElement>) => {
-    const textarea = e.target as HTMLTextAreaElement;
-    let newValue = textarea.value;
-    if (!allowNewline) newValue = newValue.replace(/(\r?\n|\r\n?)/g, '');
-    updateEditorValue(newValue);
-  }, [ allowNewline, updateEditorValue ]);
+  const handleTextareaChange = useCallback(
+    (e: ChangeEvent<HTMLTextAreaElement>) => {
+      const textarea = e.target as HTMLTextAreaElement;
+      let newValue = textarea.value;
+      if (!allowNewline) newValue = newValue.replace(/(\r?\n|\r\n?)/g, "");
+      updateEditorValue(newValue);
+    },
+    [allowNewline, updateEditorValue]
+  );
 
-  const handleTextareaKeyPress = useCallback((e: KeyboardEvent<HTMLTextAreaElement>) => {
-    if (!isEditable) {
-      e.preventDefault();
-      return;
-    }
-    if (e.code === CODE_ENTER) {
-      if (!allowNewline || !e.shiftKey) e.preventDefault();
-    }
-  }, [ allowNewline, isEditable ]);
+  const handleTextareaKeyPress = useCallback(
+    (e: KeyboardEvent<HTMLTextAreaElement>) => {
+      if (!isEditable) {
+        e.preventDefault();
+        return;
+      }
+      if (e.code === CODE_ENTER) {
+        if (!allowNewline || !e.shiftKey) e.preventDefault();
+      }
+    },
+    [allowNewline, isEditable]
+  );
 
-  const handleTextareaKeyUp = useCallback((e: KeyboardEvent<HTMLTextAreaElement>) => {
-    if (e.code === CODE_ESCAPE) {
-      // Restore the original value upon escape key.
-      updateEditorValue(value);
-      setIsEditable(false);
-    } else if (!e.shiftKey && e.code === CODE_ENTER) {
-      setIsEditable(false);
-    }
-  }, [ updateEditorValue, value ]);
+  const handleTextareaKeyUp = useCallback(
+    (e: KeyboardEvent<HTMLTextAreaElement>) => {
+      if (e.code === CODE_ESCAPE) {
+        // Restore the original value upon escape key.
+        updateEditorValue(value);
+        setIsEditable(false);
+      } else if (!e.shiftKey && e.code === CODE_ENTER) {
+        setIsEditable(false);
+      }
+    },
+    [updateEditorValue, value]
+  );
 
   useEffect(() => {
     updateEditorValue(value);
-  }, [ updateEditorValue, value ]);
+  }, [updateEditorValue, value]);
 
   useEffect(() => {
-    if (!textareaRef.current || document.activeElement !== textareaRef.current) return;
+    if (!textareaRef.current || document.activeElement !== textareaRef.current)
+      return;
     isEditable ? textareaRef.current.focus() : textareaRef.current.blur();
-  }, [ isEditable ]);
+  }, [isEditable]);
 
   return (
-    <div className={classes.join(' ')} {...props}>
-      <div className={css.growWrap} ref={growWrapRef} onClick={handleWrapperClick}>
+    <div className={classes.join(" ")} {...props}>
+      <div
+        className={css.growWrap}
+        ref={growWrapRef}
+        onClick={handleWrapperClick}
+      >
         <textarea
           maxLength={maxLength}
           placeholder={placeholder}


### PR DESCRIPTION
Created tests for InlineEditor.tsx

Noticed this behavior, which I targeted with test called "preserves input when focus leaves"

![editor](https://user-images.githubusercontent.com/28383080/155209658-1a8489fa-f3be-4919-8ca1-527c5b22715b.gif)



