### PR TITLE
test: add interaction test for inline editor [DET-6667]

### DIFF
--- a/webui/react/src/components/InlineEditor.test.tsx
+++ b/webui/react/src/components/InlineEditor.test.tsx
@@ -1,0 +1,75 @@
+import {
+    render,
+    screen,
+    waitForElementToBeRemoved,
+  } from "@testing-library/react";
+  import userEvent from "@testing-library/user-event";
+  
+  import React from "react";
+  
+  import InlineEditor from "./InlineEditor";
+  
+  const setup = (text: string = "", disabled = false) => {
+    const onSave = jest.fn();
+    const onCancel = jest.fn();
+    const { container } = render(
+      <InlineEditor
+        value={text}
+        onSave={onSave}
+        onCancel={onCancel}
+        disabled={disabled}
+      />
+    );
+  
+    const waitForSpinnerToDisappear = async () =>
+      await waitForElementToBeRemoved(
+        () => container.getElementsByClassName("ant-spin-spinning")[0]
+      );
+    return { onSave, onCancel, waitForSpinnerToDisappear };
+  };
+  
+  describe("InlineEditor", () => {
+    it("displays the value passed as prop", async () => {
+      setup("before");
+      expect(screen.getByDisplayValue("before")).toBeInTheDocument();
+    });
+  
+    it("preserves input when focus leaves", async () => {
+      const { waitForSpinnerToDisappear } = setup("before");
+      userEvent.clear(screen.getByRole("textbox"));
+      userEvent.type(screen.getByRole("textbox"), "after");
+      userEvent.click(document.body);
+      expect(screen.getByRole("textbox")).not.toHaveFocus();
+      expect(screen.getByDisplayValue("after")).toBeInTheDocument();
+  
+      // wait for spinner to go away
+      // to avoid "test not wrapped in act(...)"
+      await waitForSpinnerToDisappear();
+    });
+  
+    it("calls save with input on blur", async () => {
+      const { onSave, waitForSpinnerToDisappear } = setup("before");
+      userEvent.clear(screen.getByRole("textbox"));
+      userEvent.type(screen.getByRole("textbox"), "after");
+      userEvent.click(document.body);
+  
+      await waitForSpinnerToDisappear();
+      expect(onSave).toHaveBeenCalledWith("after");
+      expect(screen.getByRole("textbox")).not.toHaveFocus();
+    });
+  
+    it("calls restores previous value when esc is pressed", async () => {
+      setup("before");
+      userEvent.clear(screen.getByRole("textbox"));
+      userEvent.type(screen.getByRole("textbox"), "after{escape}");
+      expect(screen.getByDisplayValue("before")).toBeInTheDocument();
+    });
+  
+    it("doesnt allow user input when disabled", async () => {
+      setup("before", true);
+      userEvent.clear(screen.getByRole("textbox"));
+      userEvent.type(screen.getByRole("textbox"), "after");
+      expect(screen.getByDisplayValue("before")).toBeInTheDocument();
+    });
+  });
+  

--- a/webui/react/src/components/InlineEditor.test.tsx
+++ b/webui/react/src/components/InlineEditor.test.tsx
@@ -1,75 +1,94 @@
 import {
-    render,
-    screen,
-    waitForElementToBeRemoved,
-  } from "@testing-library/react";
-  import userEvent from "@testing-library/user-event";
-  
-  import React from "react";
-  
-  import InlineEditor from "./InlineEditor";
-  
-  const setup = (text: string = "", disabled = false) => {
-    const onSave = jest.fn();
-    const onCancel = jest.fn();
-    const { container } = render(
-      <InlineEditor
-        value={text}
-        onSave={onSave}
-        onCancel={onCancel}
-        disabled={disabled}
-      />
+  render,
+  screen,
+  waitForElementToBeRemoved,
+} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+
+import InlineEditor from './InlineEditor';
+
+const setup = (
+  { disabled, onSaveReturnsError, value } = {
+    disabled: false,
+    onSaveReturnsError: false,
+    value: 'before',
+  },
+) => {
+  // const onSave=jest.fn(async () => {})
+  const onSave = onSaveReturnsError
+    ? jest.fn(() => Promise.resolve(new Error()))
+    : jest.fn(() => Promise.resolve());
+  const onCancel = jest.fn();
+  const { container } = render(
+    <InlineEditor
+      disabled={disabled}
+      value={value}
+      onCancel={onCancel}
+      onSave={onSave}
+    />,
+  );
+
+  const waitForSpinnerToDisappear = async () =>
+    await waitForElementToBeRemoved(
+      () => container.getElementsByClassName('ant-spin-spinning')[0],
     );
-  
-    const waitForSpinnerToDisappear = async () =>
-      await waitForElementToBeRemoved(
-        () => container.getElementsByClassName("ant-spin-spinning")[0]
-      );
-    return { onSave, onCancel, waitForSpinnerToDisappear };
-  };
-  
-  describe("InlineEditor", () => {
-    it("displays the value passed as prop", async () => {
-      setup("before");
-      expect(screen.getByDisplayValue("before")).toBeInTheDocument();
-    });
-  
-    it("preserves input when focus leaves", async () => {
-      const { waitForSpinnerToDisappear } = setup("before");
-      userEvent.clear(screen.getByRole("textbox"));
-      userEvent.type(screen.getByRole("textbox"), "after");
-      userEvent.click(document.body);
-      expect(screen.getByRole("textbox")).not.toHaveFocus();
-      expect(screen.getByDisplayValue("after")).toBeInTheDocument();
-  
-      // wait for spinner to go away
-      // to avoid "test not wrapped in act(...)"
-      await waitForSpinnerToDisappear();
-    });
-  
-    it("calls save with input on blur", async () => {
-      const { onSave, waitForSpinnerToDisappear } = setup("before");
-      userEvent.clear(screen.getByRole("textbox"));
-      userEvent.type(screen.getByRole("textbox"), "after");
-      userEvent.click(document.body);
-  
-      await waitForSpinnerToDisappear();
-      expect(onSave).toHaveBeenCalledWith("after");
-      expect(screen.getByRole("textbox")).not.toHaveFocus();
-    });
-  
-    it("calls restores previous value when esc is pressed", async () => {
-      setup("before");
-      userEvent.clear(screen.getByRole("textbox"));
-      userEvent.type(screen.getByRole("textbox"), "after{escape}");
-      expect(screen.getByDisplayValue("before")).toBeInTheDocument();
-    });
-  
-    it("doesnt allow user input when disabled", async () => {
-      setup("before", true);
-      userEvent.clear(screen.getByRole("textbox"));
-      userEvent.type(screen.getByRole("textbox"), "after");
-      expect(screen.getByDisplayValue("before")).toBeInTheDocument();
-    });
+  return { onCancel, onSave, waitForSpinnerToDisappear };
+};
+
+describe('InlineEditor', () => {
+  it('displays the value passed as prop', () => {
+    setup();
+    expect(screen.getByDisplayValue('before')).toBeInTheDocument();
   });
-  
+
+  it('preserves input when focus leaves', async () => {
+    const { waitForSpinnerToDisappear } = setup();
+    userEvent.clear(screen.getByRole('textbox'));
+    userEvent.type(screen.getByRole('textbox'), 'after');
+    userEvent.click(document.body);
+    expect(screen.getByRole('textbox')).not.toHaveFocus();
+    await waitForSpinnerToDisappear();
+    expect(screen.getByDisplayValue('after')).toBeInTheDocument();
+  });
+
+  it('calls save with input on blur', async () => {
+    const { onSave, waitForSpinnerToDisappear } = setup();
+    userEvent.clear(screen.getByRole('textbox'));
+    userEvent.type(screen.getByRole('textbox'), 'after');
+    userEvent.click(document.body);
+    expect(screen.getByRole('textbox')).not.toHaveFocus();
+    await waitForSpinnerToDisappear();
+    expect(onSave).toHaveBeenCalledWith('after');
+  });
+
+  it('restores value when save fails', async () => {
+    const { onSave, waitForSpinnerToDisappear } = setup({
+      disabled: false,
+      onSaveReturnsError: true,
+      value: 'before',
+    });
+    userEvent.clear(screen.getByRole('textbox'));
+    userEvent.type(screen.getByRole('textbox'), 'after');
+    userEvent.keyboard('{enter}');
+    await waitForSpinnerToDisappear();
+    expect(onSave).toHaveBeenCalledWith('after');
+    expect(screen.getByDisplayValue('before')).toBeInTheDocument();
+  });
+
+  it('calls cancel and restores previous value when esc is pressed', () => {
+    const { onCancel } = setup();
+    userEvent.clear(screen.getByRole('textbox'));
+    userEvent.type(screen.getByRole('textbox'), 'after');
+    userEvent.keyboard('{escape}');
+    expect(screen.getByDisplayValue('before')).toBeInTheDocument();
+    expect(onCancel).toHaveBeenCalled();
+  });
+
+  it('doesnt allow user input when disabled', () => {
+    setup({ disabled: true, onSaveReturnsError: true, value: 'before' });
+    userEvent.clear(screen.getByRole('textbox'));
+    userEvent.type(screen.getByRole('textbox'), 'after');
+    expect(screen.getByDisplayValue('before')).toBeInTheDocument();
+  });
+});

--- a/webui/react/src/components/InlineEditor.tsx
+++ b/webui/react/src/components/InlineEditor.tsx
@@ -12,7 +12,7 @@ interface Props extends HTMLAttributes<HTMLDivElement> {
   isOnDark?: boolean;
   maxLength?: number;
   onCancel?: () => void;
-  onSave?: (newValue: string) => Promise<void>;
+  onSave?: (newValue: string) => Promise<Error|void>;
   placeholder?: string;
   value: string;
 }

--- a/webui/react/src/components/InlineEditor.tsx
+++ b/webui/react/src/components/InlineEditor.tsx
@@ -63,8 +63,11 @@ const InlineEditor: React.FC<Props> = ({
   const save = useCallback(async (newValue: string) => {
     if (onSave) {
       setIsSaving(true);
-      const err = await onSave(newValue);
-      if (err !== null) {
+      try{
+        await onSave(newValue);
+      }
+      catch {
+        // send user error
         updateEditorValue(value);
       }
       setIsSaving(false);

--- a/webui/react/src/components/InlineEditor.tsx
+++ b/webui/react/src/components/InlineEditor.tsx
@@ -1,15 +1,9 @@
 import React, {
-  ChangeEvent,
-  HTMLAttributes,
-  KeyboardEvent,
-  useCallback,
-  useEffect,
-  useRef,
-  useState,
-} from "react";
+  ChangeEvent, HTMLAttributes, KeyboardEvent, useCallback, useEffect, useRef, useState,
+} from 'react';
 
-import css from "./InlineEditor.module.scss";
-import Spinner from "./Spinner";
+import css from './InlineEditor.module.scss';
+import Spinner from './Spinner';
 
 interface Props extends HTMLAttributes<HTMLDivElement> {
   allowClear?: boolean;
@@ -23,8 +17,8 @@ interface Props extends HTMLAttributes<HTMLDivElement> {
   value: string;
 }
 
-const CODE_ENTER = "Enter";
-const CODE_ESCAPE = "Escape";
+const CODE_ENTER = 'Enter';
+const CODE_ESCAPE = 'Escape';
 
 const InlineEditor: React.FC<Props> = ({
   allowClear = true,
@@ -40,10 +34,10 @@ const InlineEditor: React.FC<Props> = ({
 }: Props) => {
   const growWrapRef = useRef<HTMLDivElement>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
-  const [currentValue, setCurrentValue] = useState(value);
-  const [isEditable, setIsEditable] = useState(false);
-  const [isSaving, setIsSaving] = useState(false);
-  const classes = [css.base];
+  const [ currentValue, setCurrentValue ] = useState(value);
+  const [ isEditable, setIsEditable ] = useState(false);
+  const [ isSaving, setIsSaving ] = useState(false);
+  const classes = [ css.base ];
 
   if (isOnDark) classes.push(css.onDark);
   if (isEditable) classes.push(css.editable);
@@ -53,40 +47,34 @@ const InlineEditor: React.FC<Props> = ({
   }
   if (disabled) classes.push(css.disabled);
 
-  const updateEditorValue = useCallback(
-    (value: string) => {
-      let newValue = value;
-      if (maxLength) newValue = newValue.slice(0, maxLength);
-      if (textareaRef.current) textareaRef.current.value = newValue;
-      if (growWrapRef.current) growWrapRef.current.dataset.value = newValue;
-      setCurrentValue(newValue);
-    },
-    [maxLength]
-  );
+  const updateEditorValue = useCallback((value: string) => {
+    let newValue = value;
+    if (maxLength) newValue = newValue.slice(0, maxLength);
+    if (textareaRef.current) textareaRef.current.value = newValue;
+    if (growWrapRef.current) growWrapRef.current.dataset.value = newValue;
+    setCurrentValue(newValue);
+  }, [ maxLength ]);
 
   const cancel = useCallback(() => {
     updateEditorValue(value);
     if (onCancel) onCancel();
-  }, [onCancel, updateEditorValue, value]);
+  }, [ onCancel, updateEditorValue, value ]);
 
-  const save = useCallback(
-    async (newValue: string) => {
-      if (onSave) {
-        setIsSaving(true);
-        const err = await onSave(newValue);
-        if (err != null) {
-          updateEditorValue(value);
-        }
-        setIsSaving(false);
+  const save = useCallback(async (newValue: string) => {
+    if (onSave) {
+      setIsSaving(true);
+      const err = await onSave(newValue);
+      if (err != null) {
+        updateEditorValue(value);
       }
-    },
-    [onSave, updateEditorValue, value]
-  );
+      setIsSaving(false);
+    }
+  }, [ onSave, updateEditorValue, value ]);
 
   const handleWrapperClick = useCallback(() => {
     if (disabled) return;
     setIsEditable(true);
-  }, [disabled]);
+  }, [ disabled ]);
 
   /*
    * To trigger a save or cancel, we trigger the blur.
@@ -97,67 +85,51 @@ const InlineEditor: React.FC<Props> = ({
     if (!textareaRef.current) return;
 
     const newValue = textareaRef.current.value.trim();
-    (!!newValue || allowClear) && newValue !== value
-      ? save(newValue)
-      : cancel();
+    (!!newValue || allowClear) && newValue !== value ? save(newValue) : cancel();
 
     // Reset `isEditable` to false if the blur was user triggered.
     setIsEditable(false);
-  }, [allowClear, cancel, save, value]);
+  }, [ allowClear, cancel, save, value ]);
 
-  const handleTextareaChange = useCallback(
-    (e: ChangeEvent<HTMLTextAreaElement>) => {
-      const textarea = e.target as HTMLTextAreaElement;
-      let newValue = textarea.value;
-      if (!allowNewline) newValue = newValue.replace(/(\r?\n|\r\n?)/g, "");
-      updateEditorValue(newValue);
-    },
-    [allowNewline, updateEditorValue]
-  );
+  const handleTextareaChange = useCallback((e: ChangeEvent<HTMLTextAreaElement>) => {
+    const textarea = e.target as HTMLTextAreaElement;
+    let newValue = textarea.value;
+    if (!allowNewline) newValue = newValue.replace(/(\r?\n|\r\n?)/g, '');
+    updateEditorValue(newValue);
+  }, [ allowNewline, updateEditorValue ]);
 
-  const handleTextareaKeyPress = useCallback(
-    (e: KeyboardEvent<HTMLTextAreaElement>) => {
-      if (!isEditable) {
-        e.preventDefault();
-        return;
-      }
-      if (e.code === CODE_ENTER) {
-        if (!allowNewline || !e.shiftKey) e.preventDefault();
-      }
-    },
-    [allowNewline, isEditable]
-  );
+  const handleTextareaKeyPress = useCallback((e: KeyboardEvent<HTMLTextAreaElement>) => {
+    if (!isEditable) {
+      e.preventDefault();
+      return;
+    }
+    if (e.code === CODE_ENTER) {
+      if (!allowNewline || !e.shiftKey) e.preventDefault();
+    }
+  }, [ allowNewline, isEditable ]);
 
-  const handleTextareaKeyUp = useCallback(
-    (e: KeyboardEvent<HTMLTextAreaElement>) => {
-      if (e.code === CODE_ESCAPE) {
-        // Restore the original value upon escape key.
-        updateEditorValue(value);
-        setIsEditable(false);
-      } else if (!e.shiftKey && e.code === CODE_ENTER) {
-        setIsEditable(false);
-      }
-    },
-    [updateEditorValue, value]
-  );
+  const handleTextareaKeyUp = useCallback((e: KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.code === CODE_ESCAPE) {
+      // Restore the original value upon escape key.
+      updateEditorValue(value);
+      setIsEditable(false);
+    } else if (!e.shiftKey && e.code === CODE_ENTER) {
+      setIsEditable(false);
+    }
+  }, [ updateEditorValue, value ]);
 
   useEffect(() => {
     updateEditorValue(value);
-  }, [updateEditorValue, value]);
+  }, [ updateEditorValue, value ]);
 
   useEffect(() => {
-    if (!textareaRef.current || document.activeElement !== textareaRef.current)
-      return;
+    if (!textareaRef.current || document.activeElement !== textareaRef.current) return;
     isEditable ? textareaRef.current.focus() : textareaRef.current.blur();
-  }, [isEditable]);
+  }, [ isEditable ]);
 
   return (
-    <div className={classes.join(" ")} {...props}>
-      <div
-        className={css.growWrap}
-        ref={growWrapRef}
-        onClick={handleWrapperClick}
-      >
+    <div className={classes.join(' ')} {...props}>
+      <div className={css.growWrap} ref={growWrapRef} onClick={handleWrapperClick}>
         <textarea
           maxLength={maxLength}
           placeholder={placeholder}


### PR DESCRIPTION
Added interaction tests to InlineEditor

specifically targeted the observed behavior below: value being reset onBlur 

![editor](https://user-images.githubusercontent.com/28383080/155214777-1ff9ca64-d09a-42f8-aa68-312806a37b46.gif)

implemented simple fix, but there are other considerations, see [3559](https://github.com/determined-ai/determined/pull/3559) and [3612](https://github.com/determined-ai/determined/pull/3612). In particular, if the save fails, we want to display a message to the user