### PR TITLE
test: fix test_start_and_write_to_shell

### DIFF
--- a/e2e_tests/tests/command/test_shell.py
+++ b/e2e_tests/tests/command/test_shell.py
@@ -11,7 +11,7 @@ from tests import command as cmd
 def test_start_and_write_to_shell(tmp_path: Path) -> None:
     with cmd.interactive_command("shell", "start") as shell:
         # Call our cli to ensure that PATH and PYTHONUSERBASE are properly set.
-        shell.stdin.write(b"det --version\n")
+        shell.stdin.write(b"COLUMNS=80 det --version\n")
         shell.stdin.close()
 
         for line in shell.stdout:


### PR DESCRIPTION
## Description
`test_start_and_write_to_shell` was flaking recently after bumping the version of Determined. `argparse` calls `shutil.get_terminal_size().columns` to figure out how to do indenting and line breaking. `argparse` also calls `textwrap.fill` with `break_on_hyphens` defaulted to `True`. Because of this, only in e2e tests where the size of the 'terminal' can't be properly discerned by `shutils`, tests fail because we grep for `0.17.10-dev0` and find `0.17.10\n-dev0`. This only happened now because the default width is `max()`'d with `11` in `argparse` and `"det 0.17.10-dev0"[:11] == 'det 0.17.10'` so the hyphen is where `textwrap` will wrap it.
<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At a minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan
- [x] run the test locally
<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions about this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)
~~I will explain why this works later, after sleep.~~
<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ