### PR TITLE
fix: nightly test errors for BYOL.

### DIFF
--- a/e2e_tests/tests/nightly/test_convergence.py
+++ b/e2e_tests/tests/nightly/test_convergence.py
@@ -336,6 +336,9 @@ def test_data_layer_mnist_tf_keras_accuracy() -> None:
 @pytest.mark.nightly
 def test_cifar10_byol_pytorch_accuracy() -> None:
     config = conf.load_config(conf.cv_examples_path("byol_pytorch/const-cifar10.yaml"))
+    # Limit convergence time, since was running over 30 minute limit.
+    config["searcher"]["max_length"]["epochs"] = 20
+    config["hyperparameters"]["classifier"]["train_epochs"] = 1
     config = conf.set_random_seed(config, 1591280374)
     experiment_id = exp.run_basic_test_with_temp_config(
         config, conf.cv_examples_path("byol_pytorch"), 1
@@ -350,7 +353,8 @@ def test_cifar10_byol_pytorch_accuracy() -> None:
         if step.get("validation")
     ]
 
-    target_accuracy = 0.70
+    # Accuracy reachable within limited convergence time -- goes higher given full training.
+    target_accuracy = 0.40
     assert max(validation_accuracies) > target_accuracy, (
         "cifar10_byol_pytorch did not reach minimum target accuracy {} in {} steps."
         " full validation accuracy history: {}".format(

--- a/examples/computer_vision/byol_pytorch/const-cifar10.yaml
+++ b/examples/computer_vision/byol_pytorch/const-cifar10.yaml
@@ -3,6 +3,7 @@ entrypoint: model_def:BYOLTrial
 records_per_epoch: 45000
 resources:
   slots_per_trial: 1
+  shm_size: 17179869184
 min_validation_period:
   epochs: 2
 

--- a/examples/computer_vision/byol_pytorch/distributed-imagenet.yaml
+++ b/examples/computer_vision/byol_pytorch/distributed-imagenet.yaml
@@ -3,6 +3,7 @@ entrypoint: model_def:BYOLTrial
 records_per_epoch: 1271158
 resources:
   slots_per_trial: 64
+  shm_size: 17179869184
 min_checkpoint_period:
   epochs: 1
 min_validation_period:

--- a/examples/computer_vision/byol_pytorch/distributed-stl10.yaml
+++ b/examples/computer_vision/byol_pytorch/distributed-stl10.yaml
@@ -6,6 +6,7 @@ entrypoint: model_def:BYOLTrial
 records_per_epoch: 105000
 resources:
   slots_per_trial: 8
+  shm_size: 17179869184
 min_validation_period:
   epochs: 2
 


### PR DESCRIPTION
## Description

Fixes two errors popping up in nightlies:
- shm_size too low in BYOL example configs.
- BYOL `const-cifar10.yaml` convergence was taking more than 30 minutes and being canceled.


## Test Plan

Run nightlies.
