### PR TITLE
fix: refreshing profiler results in blank screen [DET-6673]

### DIFF
--- a/webui/react/src/pages/TrialDetails/Profiles/SystemMetricFilter.tsx
+++ b/webui/react/src/pages/TrialDetails/Profiles/SystemMetricFilter.tsx
@@ -53,7 +53,7 @@ const SystemMetricFilter: React.FC = () => {
         style={{ width: 220 }}
         value={settings.agentId}
         onChange={handleChangeAgentId}>
-        {settings.name && Object.keys(systemSeries[settings.name]).map(agentId => (
+        {settings.name && systemSeries && Object.keys(systemSeries[settings.name]).map(agentId => (
           <Option key={agentId} value={agentId}>{agentId}</Option>
         ))}
       </SelectFilter>


### PR DESCRIPTION
## Description

fix: refreshing profiler with blank screen results blank screen [DET-6673]


## Test Plan

Set http://34.105.48.209:8080 as the backend and go to /det/experiments/41/profiler

Wait for page to load. This can take a while, see [6672](https://determinedai.atlassian.net/browse/DET-6672). Once it is loaded, the address will have additional query parameters, e.g. http://34.105.48.209:8080/det/experiments/41/profiler?agentId=det-dynamic-agent-corey-preemptible-0-17-7-apt-tiger&name=gpu_util.  

Refreshing the page then, or navigating to that url should load the page, whereas before user got  "unknown error" popups and a blank screen.


## Commentary (optional)

This PR is just one line of defensive coding, the underlying reason is that `ProfilesFiltersProvider.tsx` is providing `systemMetrics` metadata that say `systemSeries` is not loading and not empty when `systemSeries` is undefined (`systemMetrics` and `systemSeries`  accessed in [`ProfilesEnabled.tsx`](https://github.com/determined-ai/determined/blob/96b1e462a93b3a745a8798ee10d653d40afe0ee8/webui/react/src/pages/TrialDetails/Profiles/ProfilesEnabled.tsx#L71) and[`SystemMetricFilter.tsx`](https://github.com/determined-ai/determined/blob/0f45c4a7e1be7821ea4e148e57619cc687b89342/webui/react/src/pages/TrialDetails/Profiles/SystemMetricFilter.tsx#L17), respectively) 

Meanwhile, commenting out [this line](https://github.com/determined-ai/determined/blob/1bdb8271923e6c724f85deea870e94cb515f6e16/webui/react/src/pages/TrialDetails/Profiles/useFetchMetrics.tsx#L74) also resolves the issue, but I'm not sure about the broader impact there. Maybe just something to be aware of for now.


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.



[DET-6673]: https://determinedai.atlassian.net/browse/DET-6673?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ