### PR TITLE
feat: add `accelerator` field for resource pool [DET-6755]

### DIFF
--- a/harness/determined/common/api/bindings.py
+++ b/harness/determined/common/api/bindings.py
@@ -3842,6 +3842,7 @@ class v1ResourcePool:
         slotsUsed: int,
         startupScript: str,
         type: "v1ResourcePoolType",
+        accelerator: "typing.Optional[str]" = None,
         slotsPerAgent: "typing.Optional[int]" = None,
     ):
         self.name = name
@@ -3876,6 +3877,7 @@ class v1ResourcePool:
         self.maxIdleAgentPeriod = maxIdleAgentPeriod
         self.maxAgentStartingPeriod = maxAgentStartingPeriod
         self.details = details
+        self.accelerator = accelerator
 
     @classmethod
     def from_json(cls, obj: Json) -> "v1ResourcePool":
@@ -3912,6 +3914,7 @@ class v1ResourcePool:
             maxIdleAgentPeriod=float(obj["maxIdleAgentPeriod"]),
             maxAgentStartingPeriod=float(obj["maxAgentStartingPeriod"]),
             details=v1ResourcePoolDetail.from_json(obj["details"]),
+            accelerator=obj.get("accelerator", None),
         )
 
     def to_json(self) -> typing.Any:
@@ -3948,6 +3951,7 @@ class v1ResourcePool:
             "maxIdleAgentPeriod": dump_float(self.maxIdleAgentPeriod),
             "maxAgentStartingPeriod": dump_float(self.maxAgentStartingPeriod),
             "details": self.details.to_json(),
+            "accelerator": self.accelerator if self.accelerator is not None else None,
         }
 
 class v1ResourcePoolAwsDetail:

--- a/master/internal/resourcemanagers/agent_resource_manager.go
+++ b/master/internal/resourcemanagers/agent_resource_manager.go
@@ -294,6 +294,7 @@ func (a *agentResourceManager) createResourcePoolSummary(
 	instanceType := ""
 	slotsPerAgent := -1
 	slotType := device.ZeroSlot
+	accelerator := "-"
 
 	if pool.Provider != nil {
 		if pool.Provider.AWS != nil {
@@ -304,6 +305,7 @@ func (a *agentResourceManager) createResourcePoolSummary(
 			instanceType = string(pool.Provider.AWS.InstanceType)
 			slotsPerAgent = pool.Provider.AWS.SlotsPerInstance()
 			slotType = pool.Provider.AWS.SlotType()
+			accelerator = pool.Provider.AWS.Accelerator()
 		}
 		if pool.Provider.GCP != nil {
 			poolType = resourcepoolv1.ResourcePoolType_RESOURCE_POOL_TYPE_GCP
@@ -312,6 +314,7 @@ func (a *agentResourceManager) createResourcePoolSummary(
 			imageID = pool.Provider.GCP.BootDiskSourceImage
 			slotsPerAgent = pool.Provider.GCP.SlotsPerInstance()
 			slotType = pool.Provider.GCP.SlotType()
+			accelerator = pool.Provider.GCP.Accelerator()
 			if pool.Provider.GCP.InstanceType.GPUNum == 0 {
 				instanceType = pool.Provider.GCP.InstanceType.MachineType
 			} else {
@@ -359,6 +362,7 @@ func (a *agentResourceManager) createResourcePoolSummary(
 		InstanceType:                 instanceType,
 		Details:                      &resourcepoolv1.ResourcePoolDetail{},
 		SlotType:                     slotType.Proto(),
+		Accelerator:                  accelerator,
 	}
 	if pool.Provider != nil {
 		resp.MinAgents = int32(pool.Provider.MinInstances)

--- a/master/internal/resourcemanagers/agent_resource_manager.go
+++ b/master/internal/resourcemanagers/agent_resource_manager.go
@@ -294,7 +294,7 @@ func (a *agentResourceManager) createResourcePoolSummary(
 	instanceType := ""
 	slotsPerAgent := -1
 	slotType := device.ZeroSlot
-	accelerator := "-"
+	accelerator := ""
 
 	if pool.Provider != nil {
 		if pool.Provider.AWS != nil {

--- a/master/internal/resourcemanagers/provisioner/aws_config.go
+++ b/master/internal/resourcemanagers/provisioner/aws_config.go
@@ -238,6 +238,7 @@ func (t ec2InstanceType) Slots() int {
 	return 0
 }
 
+// source: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/accelerated-computing-instances.html
 func (t ec2InstanceType) Accelerator() string {
 	instanceType := t.name()
 	if strings.HasPrefix(instanceType, "p2") {

--- a/master/internal/resourcemanagers/provisioner/aws_config.go
+++ b/master/internal/resourcemanagers/provisioner/aws_config.go
@@ -185,6 +185,11 @@ func (c AWSClusterConfig) SlotType() device.Type {
 	return device.ZeroSlot
 }
 
+// Accelerator returns the GPU accelerator for the instance.
+func (c AWSClusterConfig) Accelerator() string {
+	return c.InstanceType.Accelerator()
+}
+
 func validateMaxSpotPrice(spotMaxPriceInput string) error {
 	// Must have 1 or 0 decimalPoints. All other characters must be digits
 	numDecimalPoints := strings.Count(spotMaxPriceInput, ".")
@@ -231,6 +236,38 @@ func (t ec2InstanceType) Slots() int {
 		return s
 	}
 	return 0
+}
+
+func (t ec2InstanceType) Accelerator() string {
+	instanceType := t.name()
+	if strings.HasPrefix(instanceType, "p2") {
+		return "NVIDIA Tesla K80"
+	}
+	if strings.HasPrefix(instanceType, "p3") {
+		return "NVIDIA Tesla V100"
+	}
+	if strings.HasPrefix(instanceType, "p4d") {
+		return "NVIDIA A100"
+	}
+	if strings.HasPrefix(instanceType, "g3") {
+		return "NVIDIA Tesla M60"
+	}
+	if strings.HasPrefix(instanceType, "g2") {
+		return "NVIDIA GRID K520"
+	}
+	if strings.HasPrefix(instanceType, "g5g") {
+		return "NVIDIA T4G"
+	}
+	if strings.HasPrefix(instanceType, "g5") {
+		return "NVIDIA A10G"
+	}
+	if strings.HasPrefix(instanceType, "g4ad") {
+		return "AMD Radeon Pro V520"
+	}
+	if strings.HasPrefix(instanceType, "g4dn") {
+		return "NVIDIA T4 Tensor Core"
+	}
+	return "-"
 }
 
 // This map tracks how many slots are available in each instance type. It also

--- a/master/internal/resourcemanagers/provisioner/aws_config.go
+++ b/master/internal/resourcemanagers/provisioner/aws_config.go
@@ -253,22 +253,16 @@ func (t ec2InstanceType) Accelerator() string {
 	if strings.HasPrefix(instanceType, "g3") {
 		return "NVIDIA Tesla M60"
 	}
-	if strings.HasPrefix(instanceType, "g2") {
-		return "NVIDIA GRID K520"
-	}
 	if strings.HasPrefix(instanceType, "g5g") {
 		return "NVIDIA T4G"
 	}
 	if strings.HasPrefix(instanceType, "g5") {
 		return "NVIDIA A10G"
 	}
-	if strings.HasPrefix(instanceType, "g4ad") {
-		return "AMD Radeon Pro V520"
-	}
 	if strings.HasPrefix(instanceType, "g4dn") {
 		return "NVIDIA T4 Tensor Core"
 	}
-	return "-"
+	return ""
 }
 
 // This map tracks how many slots are available in each instance type. It also

--- a/master/internal/resourcemanagers/provisioner/gcp_config.go
+++ b/master/internal/resourcemanagers/provisioner/gcp_config.go
@@ -223,6 +223,11 @@ func (c GCPClusterConfig) SlotType() device.Type {
 	return device.ZeroSlot
 }
 
+// Accelerator returns the GPU accelerator for the instance.
+func (c GCPClusterConfig) Accelerator() string {
+	return c.InstanceType.GPUType
+}
+
 func (c GCPClusterConfig) buildDockerLogString() string {
 	if c.UseCloudLogging {
 		return "--log-driver gcplogs"

--- a/proto/src/determined/resourcepool/v1/resourcepool.proto
+++ b/proto/src/determined/resourcepool/v1/resourcepool.proto
@@ -171,6 +171,8 @@ message ResourcePool {
 
   // GCP, AWS and Priority Scheduler details
   determined.resourcepool.v1.ResourcePoolDetail details = 31;
+  // GCP, AWS accelerator information
+  string accelerator = 33;
 }
 
 // Detailed information about the resource pool

--- a/webui/react/src/services/api-ts-sdk/api.ts
+++ b/webui/react/src/services/api-ts-sdk/api.ts
@@ -4666,6 +4666,12 @@ export interface V1ResourcePool {
      * @memberof V1ResourcePool
      */
     details: V1ResourcePoolDetail;
+    /**
+     * 
+     * @type {string}
+     * @memberof V1ResourcePool
+     */
+    accelerator?: string;
 }
 
 /**


### PR DESCRIPTION
## Description

Add GPU accelerator field for resource pool.
For AWS instance, accelerator is implied from this article: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/accelerated-computing-instances.html 


## Test Plan

Ping `/resource-pools` endpoint to verify new field `accelerator` is added


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ