### PR TITLE
feat: Create a table of user profile pictures [DET-6739]

### DIFF
--- a/harness/determined/common/api/bindings.py
+++ b/harness/determined/common/api/bindings.py
@@ -5110,6 +5110,7 @@ class v1User:
         username: str,
         agentUserGroup: "typing.Optional[v1AgentUserGroup]" = None,
         displayName: "typing.Optional[str]" = None,
+        modifiedAt: "typing.Optional[str]" = None,
     ):
         self.id = id
         self.username = username
@@ -5117,6 +5118,7 @@ class v1User:
         self.active = active
         self.agentUserGroup = agentUserGroup
         self.displayName = displayName
+        self.modifiedAt = modifiedAt
 
     @classmethod
     def from_json(cls, obj: Json) -> "v1User":
@@ -5127,6 +5129,7 @@ class v1User:
             active=obj["active"],
             agentUserGroup=v1AgentUserGroup.from_json(obj["agentUserGroup"]) if obj.get("agentUserGroup", None) is not None else None,
             displayName=obj.get("displayName", None),
+            modifiedAt=obj.get("modifiedAt", None),
         )
 
     def to_json(self) -> typing.Any:
@@ -5137,6 +5140,7 @@ class v1User:
             "active": self.active,
             "agentUserGroup": self.agentUserGroup.to_json() if self.agentUserGroup is not None else None,
             "displayName": self.displayName if self.displayName is not None else None,
+            "modifiedAt": self.modifiedAt if self.modifiedAt is not None else None,
         }
 
 class v1ValidateAfterOperation:

--- a/master/internal/api_user.go
+++ b/master/internal/api_user.go
@@ -6,6 +6,7 @@ import (
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
 	"gopkg.in/guregu/null.v3"
 
 	"github.com/determined-ai/determined/master/internal/db"
@@ -33,6 +34,7 @@ func toProtoUserFromFullUser(user model.FullUser) *userv1.User {
 		Active:         user.Active,
 		AgentUserGroup: agentUserGroup,
 		DisplayName:    displayNameString,
+		ModifiedAt:     timestamppb.New(user.ModifiedAt),
 	}
 }
 

--- a/master/internal/db/postgres_users.go
+++ b/master/internal/db/postgres_users.go
@@ -344,6 +344,16 @@ func (db *PgDB) UserList() (values []model.FullUser, err error) {
 	return values, err
 }
 
+// UserImage returns the profile picture associated with the user.
+func (db *PgDB) UserImage(username string) (photo []byte, err error) {
+	type photoRow struct {
+		Photo []byte
+	}
+	var userPhoto photoRow
+	err = db.Query("get_user_image", &userPhoto, username)
+	return userPhoto.Photo, err
+}
+
 // UserByID returns the full user for a given ID.
 func (db *PgDB) UserByID(userID model.UserID) (*model.FullUser, error) {
 	var fu model.FullUser

--- a/master/internal/user/api.go
+++ b/master/internal/user/api.go
@@ -16,4 +16,5 @@ func RegisterAPIHandler(echo *echo.Echo, m *Service, middleware ...echo.Middlewa
 	usersGroup.GET("/me", api.Route(m.getMe))
 	usersGroup.PATCH("/:username", api.Route(m.patchUser))
 	usersGroup.PATCH("/:username/username", api.Route(m.patchUsername))
+	usersGroup.GET("/:username/image", api.Route(m.getUserImage))
 }

--- a/master/internal/user/service.go
+++ b/master/internal/user/service.go
@@ -427,3 +427,15 @@ func (s *Service) postUser(c echo.Context) (interface{}, error) {
 		message: fmt.Sprintf("successfully created user: %s", params.Username),
 	}, nil
 }
+
+func (s *Service) getUserImage(c echo.Context) (interface{}, error) {
+	args := struct {
+		Username string `path:"username"`
+	}{}
+	if err := api.BindArgs(&args, c); err != nil {
+		return nil, err
+	}
+	c.Response().Header().Set("cache-control", "public, max-age=3600")
+
+	return s.db.UserImage(args.Username)
+}

--- a/master/pkg/model/user.go
+++ b/master/pkg/model/user.go
@@ -24,6 +24,7 @@ type User struct {
 	DisplayName  null.String `db:"display_name" json:"display_name"`
 	Admin        bool        `db:"admin" json:"admin"`
 	Active       bool        `db:"active" json:"active"`
+	ModifiedAt   time.Time   `db:"modified_at" json:"modified_at"`
 }
 
 // UserSession corresponds to a row in the "user_sessions" DB table.
@@ -40,6 +41,7 @@ type FullUser struct {
 	Username    string      `db:"username" json:"username"`
 	Admin       bool        `db:"admin" json:"admin"`
 	Active      bool        `db:"active" json:"active"`
+	ModifiedAt  time.Time   `db:"modified_at" json:"modified_at"`
 
 	AgentUID   null.Int    `db:"agent_uid" json:"agent_uid"`
 	AgentGID   null.Int    `db:"agent_gid" json:"agent_gid"`

--- a/master/static/srv/20220228132402_store-profile-pics.down.sql
+++ b/master/static/srv/20220228132402_store-profile-pics.down.sql
@@ -1,0 +1,2 @@
+DROP TABLE user_profile_images;
+ALTER TABLE users DROP COLUMN modified_at;

--- a/master/static/srv/20220228132402_store-profile-pics.up.sql
+++ b/master/static/srv/20220228132402_store-profile-pics.up.sql
@@ -1,0 +1,33 @@
+CREATE TABLE user_profile_images (
+  id SERIAL PRIMARY KEY,
+  user_id INT,
+  file_data BYTEA NOT NULL,
+  CONSTRAINT photo_for_user
+   FOREIGN KEY(user_id)
+      REFERENCES users(id)
+   ON DELETE CASCADE
+);
+
+ALTER TABLE users ADD COLUMN modified_at TIMESTAMP DEFAULT current_timestamp;
+
+CREATE OR REPLACE FUNCTION autoupdate_user_image_modified() RETURNS trigger AS $$
+BEGIN
+  UPDATE users SET modified_at = NOW() WHERE users.id = NEW.user_id;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER autoupdate_user_image_modified
+BEFORE INSERT OR UPDATE ON user_profile_images
+FOR EACH ROW EXECUTE PROCEDURE autoupdate_user_image_modified();
+
+CREATE OR REPLACE FUNCTION autoupdate_user_image_deleted() RETURNS trigger AS $$
+BEGIN
+  UPDATE users SET modified_at = NOW() WHERE users.id = OLD.user_id;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER autoupdate_user_image_deleted
+BEFORE DELETE ON user_profile_images
+FOR EACH ROW EXECUTE PROCEDURE autoupdate_user_image_deleted();

--- a/master/static/srv/get_user_image.sql
+++ b/master/static/srv/get_user_image.sql
@@ -1,0 +1,5 @@
+SELECT file_data AS photo
+FROM users u
+LEFT JOIN user_profile_images img ON u.id = img.user_id
+WHERE u.username = $1
+LIMIT 1;

--- a/master/static/srv/list_users.sql
+++ b/master/static/srv/list_users.sql
@@ -1,5 +1,5 @@
 SELECT
-	u.id, u.display_name, u.username, u.admin, u.active,
+	u.id, u.display_name, u.username, u.admin, u.active, u.modified_at,
 	h.uid AS agent_uid, h.gid AS agent_gid, h.user_ AS agent_user, h.group_ AS agent_group
 FROM users u
 LEFT OUTER JOIN agent_user_groups h ON (u.id = h.user_id);

--- a/proto/src/determined/user/v1/user.proto
+++ b/proto/src/determined/user/v1/user.proto
@@ -1,5 +1,6 @@
 syntax = "proto3";
 
+import "google/protobuf/timestamp.proto";
 import "protoc-gen-swagger/options/annotations.proto";
 
 package determined.user.v1;
@@ -22,6 +23,8 @@ message User {
   AgentUserGroup agent_user_group = 5;
   // Name to display in the web UI.
   string display_name = 6;
+  // The version of the user object for caching purposes.
+  google.protobuf.Timestamp modified_at = 7;
 }
 
 // Request to edit fields for a user.

--- a/webui/react/src/services/api-ts-sdk/api.ts
+++ b/webui/react/src/services/api-ts-sdk/api.ts
@@ -5993,6 +5993,12 @@ export interface V1User {
      * @memberof V1User
      */
     displayName?: string;
+    /**
+     * The version of the user object for caching purposes.
+     * @type {Date}
+     * @memberof V1User
+     */
+    modifiedAt?: Date;
 }
 
 /**

--- a/webui/react/src/services/decoder.ts
+++ b/webui/react/src/services/decoder.ts
@@ -13,6 +13,7 @@ export const mapV1User = (data: Sdk.V1User): types.DetailedUser => {
     id: data.id,
     isActive: data.active,
     isAdmin: data.admin,
+    modifiedAt: (new Date(data.modifiedAt || 1)).getTime(),
     username: data.username,
   };
 };

--- a/webui/react/src/types.ts
+++ b/webui/react/src/types.ts
@@ -19,11 +19,11 @@ export type PropsWithStoragePath<T> = T & { storagePath?: string };
 
 export interface User {
   displayName?: string;
+  modifiedAt?: number;
   username: string;
 }
 
 export interface DetailedUser extends User {
-  displayName?: string;
   id: number;
   isActive: boolean;
   isAdmin: boolean;


### PR DESCRIPTION
## Description

Adds a database table to store a profile picture / user image. Adds an API endpoint for the client to fetch the user's profile image, showing it as the CSS background-image for the Avatar component (circle representing user).

**[edit: these were the issues with implementing in GRPC - we now use images directly]**:
- Type for images is `bytea` in Postgres, and `bytes` in GRPC. There is a size limit for `bytes` which is preventing larger images from being returned by the API. It's unclear whether we will continue using base64 to download images. It would be more efficient to have a URL which returns the image file not in a JSON wrapper.
- When we have multiple Avatar components (as in the Experiments table) these each make a request to the image API endpoint. Ideally the image would be cached across components and pages.

**current issues**
- One feature request was that when a user is deleted, their image is deleted.  The table is not yet linked strongly enough to the users table.

## Test Plan

Uploading/editing images will be in future PRs. To add a neural network image for the determined user:

```
insert into user_profile_images (user_id, file_data) values (2, 'abcde'::bytea);
update user_profile_images set file_data = decode('/9j/4AAQSkZJRgABAQAAAQABAAD/4gIoSUNDX1BST0ZJTEUAAQEAAAIYAAAAAAQwAABtbnRyUkdCIFhZWiAAAAAAAAAAAAAAAABhY3NwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAA9tYAAQAAAADTLQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAlkZXNjAAAA8AAAAHRyWFlaAAABZAAAABRnWFlaAAABeAAAABRiWFlaAAABjAAAABRyVFJDAAABoAAAAChnVFJDAAABoAAAAChiVFJDAAABoAAAACh3dHB0AAAByAAAABRjcHJ0AAAB3AAAADxtbHVjAAAAAAAAAAEAAAAMZW5VUwAAAFgAAAAcAHMAUgBHAEIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFhZWiAAAAAAAABvogAAOPUAAAOQWFlaIAAAAAAAAGKZAAC3hQAAGNpYWVogAAAAAAAAJKAAAA+EAAC2z3BhcmEAAAAAAAQAAAACZmYAAPKnAAANWQAAE9AAAApbAAAAAAAAAABYWVogAAAAAAAA9tYAAQAAAADTLW1sdWMAAAAAAAAAAQAAAAxlblVTAAAAIAAAABwARwBvAG8AZwBsAGUAIABJAG4AYwAuACAAMgAwADEANv/bAEMAAwICAgICAwICAgMDAwMEBgQEBAQECAYGBQYJCAoKCQgJCQoMDwwKCw4LCQkNEQ0ODxAQERAKDBITEhATDxAQEP/bAEMBAwMDBAMECAQECBALCQsQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEP/AABEIADwAPAMBIgACEQEDEQH/xAAZAAEBAQADAAAAAAAAAAAAAAAACAkBBgr/xAAmEAABBAICAgMAAgMAAAAAAAACAQMEBQAGBxESEwgJFCEiFyNR/8QAFwEBAQEBAAAAAAAAAAAAAAAAAAQDAv/EACcRAAEDAwQBAwUAAAAAAAAAAAEAAhEDEiEEMUFhURMjMiJCYnGh/9oADAMBAAIRAxEAPwCEvin8U+RvlpyOGkaS2MKthIEi9vZDalGqoqqqIRIip7HTVFFtpFRTJFVVEBccDTo/r7+E3Buk2QTNWY5P26lerGrJu72h2K6ws54GW1NiKqCyJqjhMibZE4aI2jn8+Y9O+E3xwZd+Eus8m1Oyw6c7GTebFcvy3noyMnHfWPHkI8x2aLHbhGYL0hgsl1WzbVS86q/yDeadbyNm2motj1mZTMRWaWHUwDi3Lr/brlmspfB1FTxdAo7gh1+oCIVU/wDXFX1BYyrf7bWjDzBGRvH497q/TaZtR9Gz3HOOWCQcEYmPuHImOVLW1fV1wRz9xiG58IQZvFO4k1IQaSXZPWNabrMiQwiue3ykA08bCqDwL1608kZJexzKjfdC3Di/cbbj/f6CTS7BRyCiz4MhE82nERFRUUVUTEhVCExVRMSEhVRVFX0I80cgcfS+M62wqNzuNTu7ynkzNVn1EMRmijEb9RsJ7ERgQVttPJt8waXxRVIVBCHMP7Xp+rb7tumcu0+vu09zNSfrN6wStELjsJuHIZd8w/sRK1YoC+wRNBaD+PD1kWrK7GubRc+XET+wIk/1Yv09RzX12sIYDB6JmB54UF4xjKFMmMYwi1H+urnjkvdeAmvjzx3ZNx7fSJc6a5GYCIs2XXSngcZ9QSUUHGRkOzEkEqdh7Yadq2bvjZrdfxhqe3T7HfYumS7JKWLb7OhPuu3lTNInGmvyRgaVxYbhPSxFRUCT2EiebbnQYEaLvW4cZ7dV75oOwzKO/pn/ANEGfEPxcaPpRVP+EJCpCQEiiQkQkiiqot60f3D7Re6Ommc7cIVm4mhRTWwp716kcdNghMXHAFt1FIjAVIQUGyRTBW1AlDJn0XS97DJcIAPxBE8dznyq6ddkU6dQQGmSW/IgxOeo+nwStRINk/yjWa87w9tBa9qVXLjHMeGmb9djFZNBdqgjyG0JkFAVA3RQVbXoQ7JD9eQ32r8q8fbDzBScIcTVVPXavxTGlQzj1MNiPEbtpbouTQaFn+vQ+tgD7RFR0XkVO0VS45X+1Xl7ZNNe474U1aHxXRSidN+REsHLC2JXVNXkGYYgjSETiqittCYeICBiI9ZEebMutF+/MbTzCnqWXn05tnE7xxPaYxjO1wmMYwiYxjCJjGMImMYwiYxjCJjGMImMYwiYxjCJjGMIv//Z', 'base64');
```

## Checklist

- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.