### PR TITLE
Use modal context

### DIFF
--- a/webui/react/src/components/Avatar.tsx
+++ b/webui/react/src/components/Avatar.tsx
@@ -1,6 +1,7 @@
 import { Tooltip } from 'antd';
 import React from 'react';
 
+import { useStore } from 'contexts/Store';
 import { hex2hsl, hsl2str } from 'utils/color';
 import md5 from 'utils/md5';
 
@@ -32,7 +33,12 @@ const getColor = (name = ''): string => {
 const Avatar: React.FC<Props> = ({ hideTooltip, name, large }: Props) => {
   const style = { backgroundColor: getColor(name) };
   const classes = [ css.base ];
+  const { users } = useStore();
+
   if (large) classes.push(css.large);
+
+  console.log('users', users);
+
   const avatar = (
     <div className={classes.join(' ')} id="avatar" style={style}>
       {getInitials(name)}

--- a/webui/react/src/components/NavigationSideBar.tsx
+++ b/webui/react/src/components/NavigationSideBar.tsx
@@ -1,4 +1,4 @@
-import { Button, Menu, Tooltip } from 'antd';
+import { Button, Menu, Modal, Tooltip } from 'antd';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useLocation } from 'react-router-dom';
 import { CSSTransition } from 'react-transition-group';
@@ -93,7 +93,8 @@ const NavigationSideBar: React.FC = () => {
   const { auth, cluster: overview, ui, resourcePools } = useStore();
   const [ showJupyterLabModal, setShowJupyterLabModal ] = useState(false);
   const { settings, updateSettings } = useSettings<Settings>(settingsConfig);
-  const { modalOpen: openUserSettingsModal } = useModalUserSettings();
+  const [ modal, contextHolder ] = Modal.useModal();
+  const { modalOpen: openUserSettingsModal } = useModalUserSettings(modal);
 
   const showNavigation = auth.isAuthenticated && ui.showChrome;
   const version = process.env.VERSION || '';
@@ -135,6 +136,7 @@ const NavigationSideBar: React.FC = () => {
       nodeRef={nodeRef}
       timeout={200}>
       <nav className={css.base} ref={nodeRef}>
+        {contextHolder}
         <header>
           <Dropdown
             content={(

--- a/webui/react/src/hooks/useModal/useModal.tsx
+++ b/webui/react/src/hooks/useModal/useModal.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { Modal } from 'antd';
-import { ModalFunc } from 'antd/es/modal/confirm';
+import { ModalFunc, ModalStaticFunctions } from 'antd/es/modal/confirm';
 import { ModalFuncProps } from 'antd/es/modal/Modal';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 
@@ -40,10 +40,11 @@ const DEFAULT_MODAL_PROPS: Partial<ModalFuncProps> = {
 
 type AntModalPromise = (...args: any[]) => any;
 
-const useModal = (
+const useModal = (config: {
+  modal?: Omit<ModalStaticFunctions, 'warn'>,
   onClose?: (reason: ModalCloseReason) => void,
   options?: ModalOptions,
-): ModalHooks => {
+} = {}): ModalHooks => {
   const modalRef = useRef<ReturnType<ModalFunc>>();
   const componentUnmounting = useRef(false);
   const [ modalProps, setModalProps ] = useState<ModalFuncProps>();
@@ -57,8 +58,8 @@ const useModal = (
     if (!modalRef.current) return;
     modalRef.current.destroy();
     modalRef.current = undefined;
-    if (reason) onClose?.(reason);
-  }, [ onClose ]);
+    if (reason) config.onClose?.(reason);
+  }, [ config ]);
 
   /*
    * Adds `modalClose` to event handlers `onOk` and `onCancel`.
@@ -91,10 +92,10 @@ const useModal = (
     const completeModalProps: ModalFuncProps = {
       ...DEFAULT_MODAL_PROPS,
       ...modalProps,
-      onCancel: options?.rawCancel
+      onCancel: config.options?.rawCancel
         ? modalProps.onCancel
         : extendEventHandler(modalProps.onCancel, ModalCloseReason.Cancel),
-      onOk: options?.rawOk
+      onOk: config.options?.rawOk
         ? modalProps.onOk
         : extendEventHandler(modalProps.onOk, ModalCloseReason.Ok),
     };
@@ -103,9 +104,9 @@ const useModal = (
     if (modalRef.current) {
       modalRef.current.update(completeModalProps);
     } else {
-      modalRef.current = Modal.confirm(completeModalProps);
+      modalRef.current = (config.modal || Modal).confirm(completeModalProps);
     }
-  }, [ extendEventHandler, modalProps, options, prevModalProps ]);
+  }, [ config, extendEventHandler, modalProps, prevModalProps ]);
 
   /**
    * Sets componentUnmounting to true only when the parent component is unmounting so that the next

--- a/webui/react/src/hooks/useModal/useModalExperimentCreate.tsx
+++ b/webui/react/src/hooks/useModal/useModalExperimentCreate.tsx
@@ -100,10 +100,10 @@ const useModalExperimentCreate = (props?: Props): ModalHooks => {
     props?.onClose?.();
   }, [ props ]);
 
-  const { modalClose, modalOpen: openOrUpdate, modalRef } = useModal(
-    handleModalClose,
-    { rawCancel: true },
-  );
+  const { modalClose, modalOpen: openOrUpdate, modalRef } = useModal({
+    onClose: handleModalClose,
+    options: { rawCancel: true },
+  });
 
   const handleEditorChange = useCallback((newConfigString: string) => {
     // Update config string and config error upon each keystroke change.

--- a/webui/react/src/hooks/useModal/useModalExperimentDelete.tsx
+++ b/webui/react/src/hooks/useModal/useModalExperimentDelete.tsx
@@ -14,7 +14,7 @@ interface Props {
 }
 
 const useModalExperimentDelete = ({ experimentId, onClose }: Props): ModalHooks => {
-  const { modalClose, modalOpen: openOrUpdate, modalRef } = useModal(() => onClose?.());
+  const { modalClose, modalOpen: openOrUpdate, modalRef } = useModal({ onClose });
 
   const handleOk = useCallback(async () => {
     try {

--- a/webui/react/src/hooks/useModal/useModalExperimentStop.tsx
+++ b/webui/react/src/hooks/useModal/useModalExperimentStop.tsx
@@ -26,7 +26,7 @@ const useModalExperimentStop = ({ experimentId, onClose }: Props): ModalHooks =>
     onClose?.(reason === ModalCloseReason.Ok ? type : undefined);
   }, [ onClose, type ]);
 
-  const { modalClose, modalOpen: openOrUpdate, modalRef } = useModal(handleClose);
+  const { modalClose, modalOpen: openOrUpdate, modalRef } = useModal({ onClose: handleClose });
 
   const modalContent = useMemo(() => {
     const isCancel = type === ActionType.Cancel;

--- a/webui/react/src/hooks/useModal/useModalUserSettings.tsx
+++ b/webui/react/src/hooks/useModal/useModalUserSettings.tsx
@@ -1,4 +1,5 @@
 import { Button } from 'antd';
+import { ModalStaticFunctions } from 'antd/es/modal/confirm';
 import React, { useCallback } from 'react';
 
 import Avatar from 'components/Avatar';
@@ -8,8 +9,8 @@ import useModalChangePassword from 'hooks/useModal/useModalChangePassword';
 import useModal, { ModalHooks } from './useModal';
 import css from './useModalUserSettings.module.scss';
 
-const useModalUserSettings = (): ModalHooks => {
-  const { modalClose, modalOpen: openOrUpdate, modalRef } = useModal();
+const useModalUserSettings = (modal: Omit<ModalStaticFunctions, 'warn'>): ModalHooks => {
+  const { modalClose, modalOpen: openOrUpdate, modalRef } = useModal({ modal });
   const { auth } = useStore();
   const username = auth.user?.username || 'Anonymous';
 


### PR DESCRIPTION
## Description

PROBLEM:
The context that is provided through a Provider that is wrapped at the App level is not accessible via dynamically created modals in Antd. The modal is created via `ReactDom.render`, as such causing the context to be different.

SOLUTION:
Antd provides a `contextHolder` via `Modal.useModal()` that allows you place a React element into the component or hook you are looking to pin to to make the context of that "location" accessible.

<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At a minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions about this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ