### PR TITLE
feat: add right click context menu for Experiment List Row [DET-6439]

### DIFF
--- a/webui/react/src/components/ResponsiveTable.tsx
+++ b/webui/react/src/components/ResponsiveTable.tsx
@@ -83,7 +83,17 @@ const ResponsiveTable: ResponsiveTable = ({ loading, scroll, ...props }) => {
   return (
     <div ref={tableRef}>
       <Spinner spinning={spinning}>
-        <Table scroll={tableScroll} tableLayout="auto" {...props} />
+        <Table
+          scroll={tableScroll}
+          tableLayout="auto"
+          onRow={(record, rowIndex) => ({
+            onContextMenu: e => {
+              e.preventDefault()
+              console.log("row right click")
+              // toggle visibility of custom action menu
+            }
+            })}
+          {...props} />
       </Spinner>
     </div>
   );

--- a/webui/react/src/components/ResponsiveTable.tsx
+++ b/webui/react/src/components/ResponsiveTable.tsx
@@ -88,9 +88,7 @@ const ResponsiveTable: ResponsiveTable = ({ loading, scroll, ...props }) => {
           tableLayout="auto"
           onRow={(record, rowIndex) => ({
             onContextMenu: e => {
-              e.preventDefault()
-              console.log("row right click")
-              // toggle visibility of custom action menu
+              // placeholder to display custom menu
             }
             })}
           {...props} />

--- a/webui/react/src/components/TaskActionDropdown.tsx
+++ b/webui/react/src/components/TaskActionDropdown.tsx
@@ -28,11 +28,12 @@ interface Props {
   curUser?: DetailedUser;
   onComplete?: (action?: Action) => void;
   task: AnyTask;
+  children?: React.ReactNode;
 }
 
 const stopPropagation = (e: React.MouseEvent): void => e.stopPropagation();
 
-const TaskActionDropdown: React.FC<Props> = ({ task, onComplete, curUser }: Props) => {
+const TaskActionDropdown: React.FC<Props> = ({ task, onComplete, curUser,  children }: Props) => {
   const id = isNumber(task.id) ? task.id : parseInt(task.id);
   const isExperiment = isExperimentTask(task);
   const isExperimentTerminal = terminalRunStates.has(task.state as RunState);
@@ -171,10 +172,21 @@ const TaskActionDropdown: React.FC<Props> = ({ task, onComplete, curUser }: Prop
   const menu = <Menu onClick={handleMenuClick}>{menuItems}</Menu>;
 
   return (
-    <div className={css.base} title="Open actions menu" onClick={stopPropagation}>
-      <Dropdown overlay={menu} placement="bottomRight" trigger={[ 'click' ]}>
+    <div
+      className={css.base}
+      title="Open actions menu"
+      onClick={stopPropagation}
+      onContextMenu={stopPropagation}
+    >
+      <Dropdown
+        overlay={menu}
+        placement={children ? "bottomLeft" : "bottomRight"}
+        trigger={children ? ["contextMenu"] : ["click"]}
+      >
         <button onClick={stopPropagation}>
+        {children || (
           <Icon name="overflow-vertical" />
+          )}
         </button>
       </Dropdown>
     </div>

--- a/webui/react/src/pages/ExperimentList.tsx
+++ b/webui/react/src/pages/ExperimentList.tsx
@@ -326,7 +326,7 @@ const ExperimentList: React.FC = () => {
       {
         dataIndex: 'id',
         key: V1GetExperimentsRequestSortBy.ID,
-        render: experimentNameRenderer,
+        render: contextualNameRenderer,
         sorter: true,
         title: 'ID',
       },

--- a/webui/react/src/pages/ExperimentList.tsx
+++ b/webui/react/src/pages/ExperimentList.tsx
@@ -275,6 +275,21 @@ const ExperimentList: React.FC = () => {
     }
   }, [ ]);
 
+  const contextualNameRenderer = (
+    value: string | number | undefined,
+    record: ExperimentItem
+  ): React.ReactNode => (
+    <TaskActionDropdown
+      curUser={user}
+      task={taskFromExperiment(record)}
+      onComplete={handleActionComplete}
+    >
+      <Link path={paths.experimentDetails(record.id)}>
+        {value === undefined ? "" : value}
+      </Link>
+    </TaskActionDropdown>
+);
+
   const columns = useMemo(() => {
     const tagsRenderer = (value: string, record: ExperimentItem) => (
       <TagList
@@ -321,7 +336,7 @@ const ExperimentList: React.FC = () => {
         filterIcon: tableSearchIcon,
         key: V1GetExperimentsRequestSortBy.NAME,
         onHeaderCell: () => settings.search ? { className: tableCss.headerFilterOn } : {},
-        render: experimentNameRenderer,
+        render: contextualNameRenderer,
         sorter: true,
         title: 'Name',
         width: 240,


### PR DESCRIPTION
## Description

add right click context menu for Experiment List Row [DET-6439]

## Test Plan

This is just a draft for now.

## Commentary (optional)

Here is a first stab at adding a context menu to experiment list rows. Feedback very much encouraged.

I tried to do it in the simplest way possible to start, by just adapting TaskActionDropdown to pass down props.children if present, then having a render function in columns in ExperimentsList.tsx that wraps the cell contents with said dropdown.

This results in the context menu being brought up when the cell contents are right clicked, see [the preview](https://deploy-preview-3671--determined-ui.netlify.app/experiments) This is different than what is described in the ticket which reads as saying:
* right click behavior of cell contents is preserved
* right clicking in the row outside of cell contents, i.e. the background, brings up the experiment actions context menu

To me, having the background of something be a target for user action seems a little less than intuitive. On top of that it seems significantly more involved to implement (I could be wrong though, details below).

There's also the issue of overriding default right click being potentially annoying. One possibility (maybe) is to include custom context menu actions to copy experiment name/id/link. Not sure what all that would entail though.

As far as implementing the right click for the row background and not the contents: it seems you would do that with the [onRow prop of antd table](https://ant.design/components/table/#onRow-usage), which lets you supply a function that takes the (record, index) corresponding to a table row, and returns event handler props, including onContextMenu. 

But the Dropdown component for ant design (and by extension our TaskActionDropdown) requires that you wrap the event target for the dropdown within it. Since antd Table does not give you direct access to the table row, I do not see a way of having a table row event trigger the context menu. So it seems like we would be left with implementing our own component (and all the TaskActionsDropdown functionality around it) that we trigger using the event handlers supplied to onRow prop of antd table. Or maybe we already have such a component? Or maybe there is a suitable alternative component in antd? Let me know if I am missing anything.


## Checklist

- [X] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


[DET-6439]: https://determinedai.atlassian.net/browse/DET-6439?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ