### PR TITLE
perf: refactor get_experiments.sql for a better query plan

### DIFF
--- a/master/static/srv/get_experiments.sql
+++ b/master/static/srv/get_experiments.sql
@@ -1,4 +1,27 @@
-WITH filtered_exps AS (
+WITH page_info AS (
+    SELECT public.page_info((
+        -- Count the rows matching filters. Needed by pagination to show page numbers.
+        SELECT COUNT(*) AS count
+        FROM experiments e
+        JOIN users u ON e.owner_id = u.id
+        WHERE
+            ($1 = '' OR e.state IN (SELECT unnest(string_to_array($1, ','))::experiment_state))
+            AND ($2 = '' OR e.archived = $2::BOOL)
+            AND ($3 = '' OR (u.username IN (SELECT unnest(string_to_array($3, ',')))))
+            AND (
+                    $4 = ''
+                    OR string_to_array($4, ',') <@ ARRAY(SELECT jsonb_array_elements_text(
+                        -- In the event labels were removed, if all were removed we insert null,
+                        -- which previously broke this query.
+                        CASE WHEN e.config->'labels'::text = 'null'
+                        THEN NULL
+                        ELSE e.config->'labels' END
+                    ))
+                )
+            AND ($5 = '' OR (e.config->>'description') ILIKE  ('%%' || $5 || '%%'))
+            AND ($6 = '' OR (e.config->>'name') ILIKE ('%%' || $6 || '%%'))
+    ), $7, $8) AS page_info
+), exps AS (
     SELECT
         e.id AS id,
         e.config->>'name' AS name,
@@ -37,15 +60,11 @@ WITH filtered_exps AS (
             )
         AND ($5 = '' OR (e.config->>'description') ILIKE  ('%%' || $5 || '%%'))
         AND ($6 = '' OR (e.config->>'name') ILIKE ('%%' || $6 || '%%'))
-), page_info AS (
-    SELECT public.page_info((SELECT COUNT(*) AS count FROM filtered_exps), $7, $8) AS page_info
+    ORDER BY %s
+    OFFSET (SELECT p.page_info->>'start_index' FROM page_info p)::bigint
+    LIMIT (SELECT (p.page_info->>'end_index')::bigint - (p.page_info->>'start_index')::bigint FROM page_info p)
 )
 SELECT
-   (SELECT coalesce(json_agg(paginated_exps), '[]'::json) FROM (
-        SELECT * FROM filtered_exps
-        ORDER BY %s
-        OFFSET (SELECT p.page_info->>'start_index' FROM page_info p)::bigint
-        LIMIT (SELECT (p.page_info->>'end_index')::bigint - (p.page_info->>'start_index')::bigint FROM page_info p)
-    ) AS paginated_exps) AS experiments,
+    (SELECT coalesce(json_agg(exps), '[]'::json) FROM exps) AS experiments,
     (SELECT p.page_info FROM page_info p) AS pagination
 


### PR DESCRIPTION
## Description
Previously, the query for `get_experiments.sql` was something like: CTE with filtered experiments, CTE to make page info from filtered experiments, CTE to apply page info to filtered experiments (so, filtered paginated experiments), then form the result from these CTEs. The first CTE is very expensive because it does a lot of work that gets thrown away by pagination; this change refactors the query to minimize this wasted work. This results in a bit of unfortunate code duplication but I think this is fine.
<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At a minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan
- [x] automated
<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions about this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)
previous plan (on a db with 3k experiments)
```
 Result  (cost=30629.29..30629.30 rows=1 width=64) (actual time=84.627..84.633 rows=1 loops=1)
   CTE filtered_exps
     ->  Hash Join  (cost=23.95..30263.61 rows=3540 width=334) (actual time=0.070..81.317 rows=3540 loops=1)
           Hash Cond: (e.owner_id = u.id)
           ->  Seq Scan on experiments e  (cost=0.00..724.40 rows=3540 width=97) (actual time=0.004..0.934 rows=3540 loops=1)
           ->  Hash  (cost=16.20..16.20 rows=620 width=36) (actual time=0.004..0.004 rows=2 loops=1)
                 Buckets: 1024  Batches: 1  Memory Usage: 9kB
                 ->  Seq Scan on users u  (cost=0.00..16.20 rows=620 width=36) (actual time=0.001..0.002 rows=2 loops=1)
           SubPlan 1
             ->  Aggregate  (cost=8.30..8.31 rows=1 width=8) (actual time=0.001..0.001 rows=1 loops=3540)
                   ->  Index Only Scan using ix_trials_experiment_id on trials t  (cost=0.28..8.29 rows=1 width=0) (actual time=0.001..0.001 rows=0 loops=3540)
                         Index Cond: (experiment_id = e.id)
                         Heap Fetches: 1046
   CTE page_info
     ->  Result  (cost=79.66..79.92 rows=1 width=32) (actual time=83.847..83.848 rows=1 loops=1)
           InitPlan 3 (returns $2)
             ->  Aggregate  (cost=79.65..79.66 rows=1 width=8) (actual time=83.655..83.656 rows=1 loops=1)
                   ->  CTE Scan on filtered_exps  (cost=0.00..70.80 rows=3540 width=0) (actual time=0.071..83.293 rows=3540 loops=1)
   InitPlan 7 (returns $6)
     ->  Aggregate  (cost=285.73..285.74 rows=1 width=32) (actual time=84.623..84.624 rows=1 loops=1)
           ->  Subquery Scan on paginated_exps  (cost=280.42..284.84 rows=354 width=353) (actual time=84.194..84.242 rows=100 loops=1)
                 ->  Limit  (cost=280.42..281.30 rows=354 width=329) (actual time=84.189..84.199 rows=100 loops=1)
                       InitPlan 5 (returns $4)
                         ->  CTE Scan on page_info p  (cost=0.00..0.02 rows=1 width=32) (actual time=83.852..83.852 rows=1 loops=1)
                       InitPlan 6 (returns $5)
                         ->  CTE Scan on page_info p_1  (cost=0.00..0.04 rows=1 width=8) (actual time=0.002..0.002 rows=1 loops=1)
                       ->  Sort  (cost=279.47..288.32 rows=3540 width=329) (actual time=0.331..0.337 rows=100 loops=1)
                             Sort Key: filtered_exps_1.id
                             Sort Method: top-N heapsort  Memory: 69kB
                             ->  CTE Scan on filtered_exps filtered_exps_1  (cost=0.00..70.80 rows=3540 width=329) (actual time=0.000..0.170 rows=3540 loops=1)
   InitPlan 8 (returns $7)
     ->  CTE Scan on page_info p_2  (cost=0.00..0.02 rows=1 width=32) (actual time=0.000..0.001 rows=1 loops=1)
 Planning time: 0.444 ms
 Execution time: 84.754 ms
```
now
```
 Result  (cost=7261.18..7261.19 rows=1 width=64) (actual time=4.680..4.688 rows=1 loops=1)
   CTE page_info
     ->  Result  (cost=766.57..766.83 rows=1 width=32) (actual time=1.735..1.739 rows=1 loops=1)
           InitPlan 1 (returns $0)
             ->  Aggregate  (cost=766.56..766.57 rows=1 width=8) (actual time=1.539..1.543 rows=1 loops=1)
                   ->  Hash Join  (cost=23.95..757.71 rows=3540 width=0) (actual time=0.013..1.400 rows=3540 loops=1)
                         Hash Cond: (e.owner_id = u.id)
                         ->  Seq Scan on experiments e  (cost=0.00..724.40 rows=3540 width=4) (actual time=0.005..0.595 rows=3540 loops=1)
                         ->  Hash  (cost=16.20..16.20 rows=620 width=4) (actual time=0.004..0.005 rows=2 loops=1)
                               Buckets: 1024  Batches: 1  Memory Usage: 9kB
                               ->  Seq Scan on users u  (cost=0.00..16.20 rows=620 width=4) (actual time=0.002..0.002 rows=2 loops=1)
   CTE exps
     ->  Limit  (cost=3243.42..6486.36 rows=354 width=334) (actual time=1.844..4.076 rows=100 loops=1)
           InitPlan 4 (returns $3)
             ->  CTE Scan on page_info p  (cost=0.00..0.02 rows=1 width=32) (actual time=1.741..1.742 rows=1 loops=1)
           InitPlan 5 (returns $4)
             ->  CTE Scan on page_info p_1  (cost=0.00..0.04 rows=1 width=8) (actual time=0.002..0.003 rows=1 loops=1)
           ->  Nested Loop  (cost=0.43..32429.76 rows=3540 width=334) (actual time=0.097..2.320 rows=100 loops=1)
                 ->  Index Scan using experiments_pkey on experiments e_1  (cost=0.28..2283.09 rows=3540 width=97) (actual time=0.008..0.074 rows=100 loops=1)
                 ->  Index Scan using users_pkey on users u_1  (cost=0.15..0.18 rows=1 width=36) (actual time=0.000..0.000 rows=1 loops=100)
                       Index Cond: (id = e_1.owner_id)
                 SubPlan 3
                   ->  Aggregate  (cost=8.30..8.31 rows=1 width=8) (actual time=0.002..0.002 rows=1 loops=100)
                         ->  Index Only Scan using ix_trials_experiment_id on trials t  (cost=0.28..8.29 rows=1 width=0) (actual time=0.001..0.001 rows=1 loops=100)
                               Index Cond: (experiment_id = e_1.id)
                               Heap Fetches: 100
   InitPlan 7 (returns $7)
     ->  Aggregate  (cost=7.97..7.98 rows=1 width=32) (actual time=4.673..4.674 rows=1 loops=1)
           ->  CTE Scan on exps  (cost=0.00..7.08 rows=354 width=24) (actual time=1.852..4.173 rows=100 loops=1)
   InitPlan 8 (returns $8)
     ->  CTE Scan on page_info p_2  (cost=0.00..0.02 rows=1 width=32) (actual time=0.000..0.001 rows=1 loops=1)
 Planning time: 0.351 ms
 Execution time: 4.761 ms
```
easy to see 84ms to 4ms, but also the cost is an ok indicator (? maybe idk, honestly). if we able to _not_ include count in page info, this optimization would not be necessary (we could just not do a lot of this), but it is a requirement. i think this is pretty good considering the constraints.
<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ