### PR TITLE
fix: GET /api/v1/trial/:id/logs/fields should return all filters

### DIFF
--- a/e2e_tests/tests/test_logging.py
+++ b/e2e_tests/tests/test_logging.py
@@ -101,6 +101,8 @@ def check_logs(
 
     # Convert fields to log_fn filters and check all are valid.
     fields = fields_list[0]
+    assert any(fields.values()), "no filter values were returned"
+
     for k, v in fields.items():
         if not any(v):
             continue

--- a/master/internal/api_trials.go
+++ b/master/internal/api_trials.go
@@ -287,7 +287,7 @@ func (a *apiServer) TrialLogsFields(
 	// And merge the available filters.
 	return zipBatches(resOld, resNew, func(b1, b2 api.Batch) error {
 		r1 := b1.(api.BatchOfOne).Inner.(*apiv1.TrialLogsFieldsResponse)
-		r2 := b1.(api.BatchOfOne).Inner.(*apiv1.TrialLogsFieldsResponse)
+		r2 := b2.(api.BatchOfOne).Inner.(*apiv1.TrialLogsFieldsResponse)
 		return resp.Send(&apiv1.TrialLogsFieldsResponse{
 			AgentIds:     setString(append(r1.AgentIds, r2.AgentIds...)...),
 			ContainerIds: setString(append(r1.ContainerIds, r2.ContainerIds...)...),

--- a/master/internal/api_trials.go
+++ b/master/internal/api_trials.go
@@ -242,27 +242,58 @@ func constructTrialLogsFilters(req *apiv1.TrialLogsRequest) ([]api.Filter, error
 
 func (a *apiServer) TrialLogsFields(
 	req *apiv1.TrialLogsFieldsRequest, resp apiv1.Determined_TrialLogsFieldsServer) error {
-	fetch := func(lr api.BatchRequest) (api.Batch, error) {
-		fields, err := a.m.trialLogBackend.TrialLogsFields(int(req.TrialId))
-		return api.ToBatchOfOne(fields), err
+	trial, err := a.m.db.TrialByID(int(req.TrialId))
+	if err != nil {
+		return errors.Wrap(err, "retreiving trial")
 	}
 
 	ctx, cancel := context.WithCancel(resp.Context())
 	defer cancel()
 
-	res := make(chan api.BatchResult)
+	// Stream fields from trial logs table, just to support pre-task-logs trials with old logs.
+	resOld := make(chan api.BatchResult)
 	go api.NewBatchStreamProcessor(
 		api.BatchRequest{Follow: req.Follow},
-		fetch,
+		func(lr api.BatchRequest) (api.Batch, error) {
+			fields, err := a.m.trialLogBackend.TrialLogsFields(int(req.TrialId))
+			return api.ToBatchOfOne(fields), err
+		},
 		a.isTrialTerminalFunc(int(req.TrialId), a.m.taskLogBackend.MaxTerminationDelay()),
 		true,
 		&distinctFieldBatchWaitTime,
 		&distinctFieldBatchWaitTime,
-	).Run(ctx, res)
+	).Run(ctx, resOld)
 
-	return processBatches(res, func(b api.Batch) error {
-		return b.ForEach(func(r interface{}) error {
-			return resp.Send(r.(*apiv1.TrialLogsFieldsResponse))
+	// Also stream fields from task logs table, for ordinary logs (as they are written now).
+	resNew := make(chan api.BatchResult)
+	go api.NewBatchStreamProcessor(
+		api.BatchRequest{Follow: req.Follow},
+		func(lr api.BatchRequest) (api.Batch, error) {
+			fields, err := a.m.taskLogBackend.TaskLogsFields(trial.TaskID)
+			return api.ToBatchOfOne(&apiv1.TrialLogsFieldsResponse{
+				AgentIds:     fields.AgentIds,
+				ContainerIds: fields.ContainerIds,
+				RankIds:      fields.RankIds,
+				Stdtypes:     fields.Stdtypes,
+				Sources:      fields.Sources,
+			}), err
+		},
+		a.isTaskTerminalFunc(trial.TaskID, a.m.taskLogBackend.MaxTerminationDelay()),
+		true,
+		&distinctFieldBatchWaitTime,
+		&distinctFieldBatchWaitTime,
+	).Run(ctx, resNew)
+
+	// And merge the available filters.
+	return zipBatches(resOld, resNew, func(b1, b2 api.Batch) error {
+		r1 := b1.(api.BatchOfOne).Inner.(*apiv1.TrialLogsFieldsResponse)
+		r2 := b1.(api.BatchOfOne).Inner.(*apiv1.TrialLogsFieldsResponse)
+		return resp.Send(&apiv1.TrialLogsFieldsResponse{
+			AgentIds:     setString(append(r1.AgentIds, r2.AgentIds...)...),
+			ContainerIds: setString(append(r1.ContainerIds, r2.ContainerIds...)...),
+			RankIds:      setInt32(append(r1.RankIds, r2.RankIds...)...),
+			Stdtypes:     setString(append(r1.Stdtypes, r2.Stdtypes...)...),
+			Sources:      setString(append(r1.Sources, r2.Sources...)...),
 		})
 	})
 }
@@ -862,4 +893,30 @@ func (a *apiServer) isTrialTerminalFunc(trialID int, buffer time.Duration) api.T
 		}
 		return false, nil
 	}
+}
+
+func setInt32(xs ...int32) []int32 {
+	s := map[int32]bool{}
+	for _, x := range xs {
+		s[x] = true
+	}
+
+	var nxs []int32
+	for x := range s {
+		nxs = append(nxs, x)
+	}
+	return nxs
+}
+
+func setString(xs ...string) []string {
+	s := map[string]bool{}
+	for _, x := range xs {
+		s[x] = true
+	}
+
+	var nxs []string
+	for x := range s {
+		nxs = append(nxs, x)
+	}
+	return nxs
 }


### PR DESCRIPTION
## Description
Task logs now get written to a new table, and the old trial logs endpoint merges the results of reading both tables, but this merging was missed for `GET /api/v1/trial/logs/fields`. This change adds this functionality.

<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At a minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan
- [x] figure out why the automated test didn't fail (i'm pretty sure it should have)
- [x] add new assert so tests would fail in this case
<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions about this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ