### PR TITLE
fix: trial rendezvous timeout should just warn

### DIFF
--- a/master/internal/task/allocation.go
+++ b/master/internal/task/allocation.go
@@ -328,7 +328,6 @@ func (a *Allocation) ResourcesAllocated(ctx *actor.Context, msg sproto.Resources
 
 	if a.req.DoRendezvous {
 		a.rendezvous = NewRendezvous(a.model.AllocationID, a.reservations)
-		a.rendezvous.PreStart(ctx)
 	}
 
 	if cfg := a.req.IdleTimeout; cfg != nil {

--- a/master/internal/task/allocation.go
+++ b/master/internal/task/allocation.go
@@ -215,7 +215,12 @@ func (a *Allocation) Receive(ctx *actor.Context) error {
 			}
 			return nil
 		}
-		if err := a.rendezvous.ReceiveMsg(ctx); err != nil {
+		switch err := a.rendezvous.ReceiveMsg(ctx).(type) {
+		case nil:
+			return nil
+		case ErrTimeoutExceeded:
+			a.logger.Insert(ctx, a.enrichLog(model.TaskLog{Log: err.Error()}))
+		default:
 			a.logger.Insert(ctx, a.enrichLog(model.TaskLog{Log: err.Error()}))
 			a.Error(ctx, err)
 		}

--- a/master/internal/task/rendezvous.go
+++ b/master/internal/task/rendezvous.go
@@ -78,13 +78,6 @@ func NewRendezvous(allocationID model.AllocationID, rs reservations) *Rendezvous
 	}
 }
 
-// PreStart just steps up the rendezvous watcher.
-func (r *Rendezvous) PreStart(ctx *actor.Context) {
-	actors.NotifyAfter(ctx, RendezvousTimeoutDuration, RendezvousTimeout{
-		AllocationID: r.allocationID,
-	})
-}
-
 // ReceiveMsg receives rendezvous-specific messages.
 func (r *Rendezvous) ReceiveMsg(ctx *actor.Context) error {
 	if r == nil {
@@ -93,6 +86,12 @@ func (r *Rendezvous) ReceiveMsg(ctx *actor.Context) error {
 
 	switch msg := ctx.Message().(type) {
 	case WatchRendezvousInfo:
+		if len(r.watchers) == 0 {
+			actors.NotifyAfter(ctx, RendezvousTimeoutDuration, RendezvousTimeout{
+				AllocationID: r.allocationID,
+			})
+		}
+
 		if w, err := r.watch(msg.AllocationID, msg.ContainerID); err != nil {
 			ctx.Respond(err)
 		} else {


### PR DESCRIPTION
## Description
In 0.17.0 (push arch) we had a regression such that failing to rendezvous after 10m would cause a failure rather than just a warning. This PR comprises 2 small changes. First, the behavior is reverted back to the old. Second, the deadline does not start until the first connection to avoid spurious warnings for things such as long start up scripts. Both are done rather than just the second since for k8s the kill resulting from not suppressing the error could still be incorrect.
<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At a minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan
- [ ] add a release note, at least
<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions about this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ