### PR TITLE
fix: ensure allocation end time is always valid

### DIFF
--- a/master/internal/db/postgres_cluster_intg_test.go
+++ b/master/internal/db/postgres_cluster_intg_test.go
@@ -7,9 +7,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/determined-ai/determined/master/pkg/etc"
 	"github.com/determined-ai/determined/master/pkg/model"
-	"github.com/stretchr/testify/require"
 )
 
 func TestClusterAPI(t *testing.T) {
@@ -20,15 +21,6 @@ func TestClusterAPI(t *testing.T) {
 
 	_, err := db.GetOrCreateClusterID()
 	require.NoError(t, err, "failed to get or create cluster id")
-
-	currentTime := time.Now().UTC().Truncate(time.Millisecond)
-	db.UpdateClusterHeartBeat(currentTime)
-
-	var clusterHeartbeat time.Time
-	err = db.sql.QueryRow("SELECT cluster_heartbeat FROM cluster_id").Scan(&clusterHeartbeat)
-	require.NoError(t, err, "error reading cluster_heartbeat from cluster_id table")
-
-	require.Equal(t, currentTime, clusterHeartbeat, "Retrieved cluster heartbeat doesn't match the correct time")
 
 	// Add a mock user
 	user := requireMockUser(t, db)
@@ -69,6 +61,16 @@ func TestClusterAPI(t *testing.T) {
 
 	err = db.AddAllocation(aIn)
 	require.NoError(t, err, "failed to add allocation")
+
+	// Add a cluster heartbeat after allocation, so it is as if the master died with it open.
+	currentTime := time.Now().UTC().Truncate(time.Millisecond)
+	db.UpdateClusterHeartBeat(currentTime)
+
+	var clusterHeartbeat time.Time
+	err = db.sql.QueryRow("SELECT cluster_heartbeat FROM cluster_id").Scan(&clusterHeartbeat)
+	require.NoError(t, err, "error reading cluster_heartbeat from cluster_id table")
+
+	require.Equal(t, currentTime, clusterHeartbeat, "Retrieved cluster heartbeat doesn't match the correct time")
 
 	// Don't complete the above allocation and call CloseOpenAllocations
 	db.CloseOpenAllocations()

--- a/master/internal/db/postgres_tasks.go
+++ b/master/internal/db/postgres_tasks.go
@@ -194,7 +194,8 @@ func (db *PgDB) UpdateAllocationState(a model.Allocation) error {
 func (db *PgDB) CloseOpenAllocations() error {
 	if _, err := db.sql.Exec(`
 UPDATE allocations
-SET end_time = cluster_heartbeat FROM cluster_id
+SET end_time = greatest(cluster_heartbeat, start_time)
+FROM cluster_id
 WHERE end_time IS NULL`); err != nil {
 		return errors.Wrap(err, "closing old allocations")
 	}


### PR DESCRIPTION
## Description
An edge case arose with our cluster heartbeat scheme where we save the heartbeat, an allocation is started and the cluster dies. In this case, the end time will be set to the most recent cluster heartbeat but that is before end time so the logs show `failed to aggregate resource allocation: failed to add aggregate: ERROR: range lower bound must be less than or equal to range upper bound (SQLSTATE 22000)  id="allocation-aggregator" system="master" type="allocationAggregator"`.
<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At a minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions about this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ