### PR TITLE
fix: `accelerator` field for GCP instance

### DIFF
--- a/master/internal/resourcemanagers/agent_resource_manager.go
+++ b/master/internal/resourcemanagers/agent_resource_manager.go
@@ -344,15 +344,9 @@ func (a *agentResourceManager) createResourcePoolSummary(
 			imageID = pool.Provider.GCP.BootDiskSourceImage
 			slotsPerAgent = pool.Provider.GCP.SlotsPerInstance()
 			slotType = pool.Provider.GCP.SlotType()
-			accelerator = pool.Provider.GCP.Accelerator()
-			if pool.Provider.GCP.InstanceType.GPUNum == 0 {
-				instanceType = pool.Provider.GCP.InstanceType.MachineType
-			} else {
-				instanceType = fmt.Sprintf("%s, %d x %s",
-					pool.Provider.GCP.InstanceType.MachineType,
-					pool.Provider.GCP.InstanceType.GPUNum,
-					pool.Provider.GCP.InstanceType.GPUType,
-				)
+			instanceType = pool.Provider.GCP.InstanceType.MachineType
+			if pool.Provider.GCP.InstanceType.GPUNum > 0 {
+				accelerator = pool.Provider.GCP.Accelerator()
 			}
 		}
 	}

--- a/master/internal/resourcemanagers/provisioner/aws_config.go
+++ b/master/internal/resourcemanagers/provisioner/aws_config.go
@@ -268,7 +268,6 @@ func (t ec2InstanceType) Accelerator() string {
 		return ""
 	}
 	return fmt.Sprintf("%d x %s", numGpu, accelerator)
-
 }
 
 // This map tracks how many slots are available in each instance type. It also

--- a/master/internal/resourcemanagers/provisioner/aws_config.go
+++ b/master/internal/resourcemanagers/provisioner/aws_config.go
@@ -241,28 +241,34 @@ func (t ec2InstanceType) Slots() int {
 // source: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/accelerated-computing-instances.html
 func (t ec2InstanceType) Accelerator() string {
 	instanceType := t.name()
+	numGpu := t.Slots()
+	accelerator := ""
 	if strings.HasPrefix(instanceType, "p2") {
-		return "NVIDIA Tesla K80"
+		accelerator = "NVIDIA Tesla K80"
 	}
 	if strings.HasPrefix(instanceType, "p3") {
-		return "NVIDIA Tesla V100"
+		accelerator = "NVIDIA Tesla V100"
 	}
 	if strings.HasPrefix(instanceType, "p4d") {
-		return "NVIDIA A100"
+		accelerator = "NVIDIA A100"
 	}
 	if strings.HasPrefix(instanceType, "g3") {
-		return "NVIDIA Tesla M60"
+		accelerator = "NVIDIA Tesla M60"
 	}
 	if strings.HasPrefix(instanceType, "g5g") {
-		return "NVIDIA T4G"
+		accelerator = "NVIDIA T4G"
 	}
 	if strings.HasPrefix(instanceType, "g5") {
-		return "NVIDIA A10G"
+		accelerator = "NVIDIA A10G"
 	}
 	if strings.HasPrefix(instanceType, "g4dn") {
-		return "NVIDIA T4 Tensor Core"
+		accelerator = "NVIDIA T4 Tensor Core"
 	}
-	return ""
+	if accelerator == "" {
+		return ""
+	}
+	return fmt.Sprintf("%d x %s", numGpu, accelerator)
+
 }
 
 // This map tracks how many slots are available in each instance type. It also

--- a/master/internal/resourcemanagers/provisioner/gcp_config.go
+++ b/master/internal/resourcemanagers/provisioner/gcp_config.go
@@ -225,7 +225,10 @@ func (c GCPClusterConfig) SlotType() device.Type {
 
 // Accelerator returns the GPU accelerator for the instance.
 func (c GCPClusterConfig) Accelerator() string {
-	return c.InstanceType.GPUType
+	return fmt.Sprintf("%d x %s",
+		c.InstanceType.GPUNum,
+		c.InstanceType.GPUType,
+	)
 }
 
 func (c GCPClusterConfig) buildDockerLogString() string {

--- a/webui/react/src/components/ResourcePoolCardLight.tsx
+++ b/webui/react/src/components/ResourcePoolCardLight.tsx
@@ -127,10 +127,7 @@ const ResourcePoolCardLight: React.FC<Props> = ({
         <section>
           {poolOverview[pool.name]?.total > 0 && (
             <SlotAllocationBar
-              footer={{
-                isAux: false,
-                queued: pool?.stats?.queuedCount,
-              }}
+              footer={{ queued: pool?.stats?.queuedCount }}
               hideHeader
               poolType={pool.type}
               resourceStates={computeContainerStates}
@@ -144,9 +141,9 @@ const ResourcePoolCardLight: React.FC<Props> = ({
               footer={{
                 auxContainerCapacity: pool.auxContainerCapacity,
                 auxContainersRunning: pool.auxContainersRunning,
-                isAux: true,
               }}
               hideHeader
+              isAux={true}
               poolType={pool.type}
               resourceStates={computeContainerStates}
               size={ShirtSize.large}


### PR DESCRIPTION
## Description

For GCP instances, move accelerator information from `InstanceType` to `Accelerator`
For AWS instances, add number of GPU for `Accelerator`
Minor fix for allocation bar to accommodate aux containers 


## Test Plan

Navigate to `/clusters` page with AWS/GCP clusters and verify `Accelerator` field displayed as expected


