### PR TITLE
chore: Add interaction tests for RadioGroup [DET-6662]

### DIFF
--- a/webui/react/src/components/RadioGroup.test.tsx
+++ b/webui/react/src/components/RadioGroup.test.tsx
@@ -1,4 +1,5 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import React from 'react';
 
 import { RadioGroupOption } from 'types';
@@ -18,40 +19,39 @@ const setup = (options: RadioGroupOption[], iconOnly = false) => {
 };
 
 describe('RadioGroup', () => {
+  const firstOption = 'First Option';
+  const secondOption = 'Second Option';
+
   const radioOptions: RadioGroupOption[] = [
-    { icon: 'learning', id: '1st', label: 'First Option' },
-    { icon: 'heat', id: '2nd', label: 'Second Option' },
+    { icon: 'learning', id: '1st', label: firstOption },
+    { icon: 'heat', id: '2nd', label: secondOption },
   ];
 
   it('displays two radio button options with labels', () => {
     setup(radioOptions);
-    expect(screen.getByText('First Option')).toBeInTheDocument();
-    expect(screen.getByText('Second Option')).toBeInTheDocument();
+    expect(screen.getByText(firstOption)).toBeInTheDocument();
+    expect(screen.getByText(secondOption)).toBeInTheDocument();
   });
 
   it('displays two radio button options without labels (icon only)', () => {
     setup(radioOptions, true);
-    expect(() => screen.getByText('First Option')).toThrow();
-    expect(() => screen.getByText('Second Option')).toThrow();
+    expect(() => screen.getByText(firstOption)).toThrow();
+    expect(() => screen.getByText(secondOption)).toThrow();
   });
 
   it('updates state when radio button labels are clicked', async () => {
     const { handleOnChange, view } = setup(radioOptions);
-    fireEvent.click(await view.findByText('First Option'));
-    expect(handleOnChange.mock.calls).toHaveLength(1);
-    expect(handleOnChange.mock.calls[0][0]).toBe('1st');
-    fireEvent.click(await view.findByText('Second Option'));
-    expect(handleOnChange.mock.calls).toHaveLength(2);
-    expect(handleOnChange.mock.calls[1][0]).toBe('2nd');
+    userEvent.click(await view.findByText(firstOption));
+    expect(handleOnChange).toHaveBeenCalledWith('1st');
+    userEvent.click(await view.findByText(secondOption));
+    expect(handleOnChange).toHaveBeenCalledWith('2nd');
   });
 
   it('updates state when icon-only radio buttons are clicked', () => {
     const { handleOnChange } = setup(radioOptions, true);
-    fireEvent.click(document.querySelectorAll('.ant-radio-button')[0]);
-    expect(handleOnChange.mock.calls).toHaveLength(1);
-    expect(handleOnChange.mock.calls[0][0]).toBe('1st');
-    fireEvent.click(document.querySelectorAll('.ant-radio-button')[1]);
-    expect(handleOnChange.mock.calls).toHaveLength(2);
-    expect(handleOnChange.mock.calls[1][0]).toBe('2nd');
+    userEvent.click(document.querySelectorAll('.ant-radio-button')[0]);
+    expect(handleOnChange).toHaveBeenCalledWith('1st');
+    userEvent.click(document.querySelectorAll('.ant-radio-button')[1]);
+    expect(handleOnChange).toHaveBeenCalledWith('2nd');
   });
 });

--- a/webui/react/src/components/RadioGroup.test.tsx
+++ b/webui/react/src/components/RadioGroup.test.tsx
@@ -1,0 +1,57 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+
+import { RadioGroupOption } from 'types';
+
+import RadioGroup from './RadioGroup';
+
+const setup = (options: RadioGroupOption[], iconOnly = false) => {
+  const handleOnChange = jest.fn();
+  const view = render(
+    <RadioGroup
+      iconOnly={iconOnly}
+      options={options}
+      onChange={handleOnChange}
+    />,
+  );
+  return { handleOnChange, view };
+};
+
+describe('RadioGroup', () => {
+  const radioOptions: RadioGroupOption[] = [
+    { icon: 'learning', id: '1st', label: 'First Option' },
+    { icon: 'heat', id: '2nd', label: 'Second Option' },
+  ];
+
+  it('displays two radio button options with labels', () => {
+    setup(radioOptions);
+    expect(screen.getByText('First Option')).toBeInTheDocument();
+    expect(screen.getByText('Second Option')).toBeInTheDocument();
+  });
+
+  it('displays two radio button options without labels (icon only)', () => {
+    setup(radioOptions, true);
+    expect(() => screen.getByText('First Option')).toThrow();
+    expect(() => screen.getByText('Second Option')).toThrow();
+  });
+
+  it('updates state when radio button labels are clicked', async () => {
+    const { handleOnChange, view } = setup(radioOptions);
+    fireEvent.click(await view.findByText('First Option'));
+    expect(handleOnChange.mock.calls).toHaveLength(1);
+    expect(handleOnChange.mock.calls[0][0]).toBe('1st');
+    fireEvent.click(await view.findByText('Second Option'));
+    expect(handleOnChange.mock.calls).toHaveLength(2);
+    expect(handleOnChange.mock.calls[1][0]).toBe('2nd');
+  });
+
+  it('updates state when icon-only radio buttons are clicked', () => {
+    const { handleOnChange } = setup(radioOptions, true);
+    fireEvent.click(document.querySelectorAll('.ant-radio-button')[0]);
+    expect(handleOnChange.mock.calls).toHaveLength(1);
+    expect(handleOnChange.mock.calls[0][0]).toBe('1st');
+    fireEvent.click(document.querySelectorAll('.ant-radio-button')[1]);
+    expect(handleOnChange.mock.calls).toHaveLength(2);
+    expect(handleOnChange.mock.calls[1][0]).toBe('2nd');
+  });
+});


### PR DESCRIPTION
## Description

Following our WebUI plan, adding interaction tests to RadioGroups with labels, and RadioGroups with icons only.

## Test Plan

`make test` in webui/react

For the icons I needed to do document.querySelector. I tried adding `role="button"` or `role="radio"` to the radio button options for accessibility and to use screen.getAllByRole. This got the typescript error `Property 'role' does not exist on type 'IntrinsicAttributes & RadioButtonProps & RefAttributes<any>'` during build. 

## Checklist

- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.