### PR TITLE
fix: allow ranks to report independent early exits [DET-6792, DET-6835]

### DIFF
--- a/docs/release-notes/invalid-hp-dtrain.txt
+++ b/docs/release-notes/invalid-hp-dtrain.txt
@@ -1,0 +1,6 @@
+:orphan:
+
+**Bug Fixes**
+
+-  Allow multiple ranks within a distributed training job to report invalid hyperparameter exits.
+   Previously, if more than one report was received, the experiment would fail.

--- a/master/internal/api_trials.go
+++ b/master/internal/api_trials.go
@@ -746,9 +746,9 @@ func (a *apiServer) ReportTrialSearcherEarlyExit(
 	case err != nil:
 		return nil, err
 	}
-	exp := actor.Addr("experiments", eID)
+	trial := actor.Addr("experiments", eID, rID)
 
-	if err = a.ask(exp, trialReportEarlyExit{
+	if err = a.ask(trial, userInitiatedEarlyExit{
 		requestID: rID,
 		reason:    model.ExitedReasonFromProto(req.EarlyExit.Reason),
 	}, nil); err != nil {

--- a/master/internal/experiment.go
+++ b/master/internal/experiment.go
@@ -54,10 +54,18 @@ type (
 	trialGetSearcherState struct {
 		requestID model.RequestID
 	}
-	// trialClosed is used to replay closes missed when the master dies between when a trial closing in
-	// its actor.PostStop and when the experiment snapshots the trial closed.
+
+	// trialClosed is used to replay closes missed when the master dies between when a trial closing
+	// in its actor.PostStop and when the experiment snapshots the trial closed.
 	trialClosed struct {
 		requestID model.RequestID
+	}
+
+	// userInitiatedEarlyExit is a user-injected message, provided through the early exit API. It
+	// _should_ indicate the user is exiting, but in the event they don't, we will clean them up.
+	userInitiatedEarlyExit struct {
+		requestID model.RequestID
+		reason    model.ExitedReason
 	}
 )
 

--- a/master/internal/trial.go
+++ b/master/internal/trial.go
@@ -244,7 +244,7 @@ func (t *trial) maybeAllocateTask(ctx *actor.Context) error {
 
 const (
 	// InvalidHPKillDelay the delay before we forcibly kill a trial that said it had an invalid HP.
-	InvalidHPKillDelay = 10 * time.Second
+	InvalidHPKillDelay = 3 * time.Second
 )
 
 func (t *trial) handleUserInitiatedStops(ctx *actor.Context, msg userInitiatedEarlyExit) error {

--- a/master/pkg/searcher/searcher.go
+++ b/master/pkg/searcher/searcher.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"math"
 
-	"github.com/determined-ai/determined/master/internal/api"
-
 	"github.com/pkg/errors"
 
 	"github.com/determined-ai/determined/master/pkg/model"
@@ -93,7 +91,9 @@ func (s *Searcher) TrialExitedEarly(
 	requestID model.RequestID, exitedReason model.ExitedReason,
 ) ([]Operation, error) {
 	if s.Exits[requestID] {
-		return nil, api.AsValidationError("trial %d reported an exit twice", requestID)
+		// If a trial reports an early exit twice, just ignore it (it can be convenient for each
+		// rank to be allowed to report it without synchronization).
+		return nil, nil
 	}
 
 	switch exitedReason {


### PR DESCRIPTION
## Description
This change modifies the searcher logic to allow multiple invalid HP exits per trial. Exits after the first are ignored. This is useful for multi-rank trials to invalid HP without coordination. The change in behavior in this change is that now, rather than the experiment failing violently on the receipt of the 2nd invalid HP, nothing will happen. Nothing includes no kill, cancel, etc. The master will just wait for the trial to exit on its own, so it is a bit susceptible to hangs.
<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At a minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan
- [ ] run invalid hp dtrain, see less failures
<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions about this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ