### PR TITLE
fix: download cifar10 only once per node in cifar10_pytorch example

### DIFF
--- a/examples/computer_vision/cifar10_pytorch/model_def.py
+++ b/examples/computer_vision/cifar10_pytorch/model_def.py
@@ -108,7 +108,7 @@ class CIFARTrial(PyTorchTrial):
         transform = transforms.Compose(
             [transforms.ToTensor(), transforms.Normalize((0.5, 0.5, 0.5), (0.5, 0.5, 0.5))]
         )
-        with filelock.FileLock(os.path.join(self.download_directory, "train_lock")):
+        with filelock.FileLock(os.path.join(self.download_directory, "lock")):
             trainset = torchvision.datasets.CIFAR10(
                 root=self.download_directory, train=True, download=True, transform=transform
             )
@@ -118,7 +118,7 @@ class CIFARTrial(PyTorchTrial):
         transform = transforms.Compose(
             [transforms.ToTensor(), transforms.Normalize((0.5, 0.5, 0.5), (0.5, 0.5, 0.5))]
         )
-        with filelock.FileLock(os.path.join(self.download_directory, "validation_lock")):
+        with filelock.FileLock(os.path.join(self.download_directory, "lock")):
             valset = torchvision.datasets.CIFAR10(
                 root=self.download_directory, train=False, download=True, transform=transform
             )


### PR DESCRIPTION
## Description

Download cifar10 only once per node in cifar10_pytorch example. [DET-6801]

## Test Plan

Run the example at `computer_vision/cifar10_pytorch/distributed.yaml`, i.e. from root directory run:
```
cd computer_vision/cifar10_pytorch/distributed.yaml && det experiment create distributed.yaml .
```

The trial logs should contain the string `Downloading https://www.cs.toronto.edu/~kriz/cifar-10-python.tar.gz to data/cifar-10-python.tar.gz` exactly once per node.  It's a 16 GPU experiment, so if nodes have 8 GPUs it should appear twice.

## Commentary (optional)

Previously, a different temp directory was made for each rank to hold independent copies of the dataset.  Instead, this changes the model to use a single fixed directory `data`, and FileLocks to ensure only one rank attempts to download at once.  All other ranks after the first on a node will skip downloading, as the files will already be fully downloaded.


## Checklist
(None of the below should apply, minor fix.)

- [] User-facing API changes need the "User-facing API Change" label.
- [] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details. 
- [] Licenses should be included for new code which was copied and/or modified from any external code.


[DET-6801]: https://determinedai.atlassian.net/browse/DET-6801?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ