### PR TITLE
feat: Accept model.id for lookups, show model.id in UI [DPS-49]

### DIFF
--- a/docs/release-notes/3723-model-registry-api.txt
+++ b/docs/release-notes/3723-model-registry-api.txt
@@ -1,0 +1,6 @@
+:orphan:
+
+**API Changes**
+
+The model registry API now will accept either the ID or Model Name in ``/api/v1/models/:name`` or
+``/api/v1/models/:id``. This applies to all API routes for Models and Model Versions.

--- a/docs/release-notes/3723-model-registry-api.txt
+++ b/docs/release-notes/3723-model-registry-api.txt
@@ -2,5 +2,7 @@
 
 **API Changes**
 
-The model registry API now will accept either the ID or Model Name in ``/api/v1/models/:name`` or
-``/api/v1/models/:id``. This applies to all API routes for Models and Model Versions.
+The model registry API now accepts either the ID or model name in ``/api/v1/models/:id`` or
+``/api/v1/models/:name``. This applies to all API routes for models and model versions.
+
+The ID can be used in the API and the WebUI (``/det/models/:id``) as a permanent link to the model.

--- a/e2e_tests/tests/cluster/test_model_registry.py
+++ b/e2e_tests/tests/cluster/test_model_registry.py
@@ -32,7 +32,7 @@ def test_model_registry() -> None:
         # Confirm we can look up a model by its ID
         db_model = d.get_model_by_id(mnist.model_id)
         assert db_model.name == "mnist"
-        db_model = d.get_model(str(mnist.model_id))
+        db_model = d.get_model(mnist.model_id)
         assert db_model.name == "mnist"
 
         # Confirm DB assigned username

--- a/e2e_tests/tests/cluster/test_model_registry.py
+++ b/e2e_tests/tests/cluster/test_model_registry.py
@@ -29,6 +29,12 @@ def test_model_registry() -> None:
         assert mnist.metadata == db_model.metadata
         assert mnist.metadata == {"testing": "metadata"}
 
+        # Confirm we can look up a model by its ID
+        db_model = d.get_model_by_id(mnist.model_id)
+        assert db_model.name == "mnist"
+        db_model = d.get_model(str(mnist.model_id))
+        assert db_model.name == "mnist"
+
         # Confirm DB assigned username
         assert db_model.username == "determined"
 

--- a/harness/determined/common/experimental/determined.py
+++ b/harness/determined/common/experimental/determined.py
@@ -155,14 +155,15 @@ class Determined:
 
         return model.Model._from_json(r.json().get("model"), self._session)
 
-    def get_model(self, name: str) -> model.Model:
+    def get_model(self, identifier: Union[str, int]) -> model.Model:
         """
         Get the :class:`~determined.experimental.Model` from the model registry
-        with the provided name. If no model with that id is found in the registry,
+        with the provided name or ID. If no corresponding model is found in the registry,
         an exception is raised.
         """
-        r = self._session.get("/api/v1/models/{}".format(name))
-        return model.Model._from_json(r.json().get("model"), self._session)
+        r = self._session.get("/api/v1/models/{}".format(identifier)).json()
+        assert r.get("model", False)
+        return model.Model._from_json(r.get("model"), self._session)
 
     def get_model_by_id(self, model_id: int) -> model.Model:
         """
@@ -170,10 +171,7 @@ class Determined:
         with the provided id. If no model with that id is found in the registry,
         an exception is raised.
         """
-        r = self._session.get("/api/v1/models?id={}".format(model_id))
-        models = r.json().get("models")
-        assert len(models) == 1
-        return model.Model._from_json(models[0], self._session)
+        return self.get_model(model_id)
 
     def get_models(
         self,

--- a/harness/determined/common/experimental/determined.py
+++ b/harness/determined/common/experimental/determined.py
@@ -183,9 +183,9 @@ class Determined:
            an integer-type model ID.
         """
         warnings.warn(
-            "Determined.get_model_by_id() has been deprecated and will be removed",
-            "in a future version.\n",
-            "Please call Determined.get_model() with either a string-type name or",
+            "Determined.get_model_by_id() has been deprecated and will be removed"
+            "in a future version.\n"
+            "Please call Determined.get_model() with either a string-type name or"
             "an integer-type model ID.",
             FutureWarning,
         )

--- a/harness/determined/common/experimental/determined.py
+++ b/harness/determined/common/experimental/determined.py
@@ -1,4 +1,5 @@
 import pathlib
+import warnings
 from typing import Any, Dict, List, Optional, Union, cast
 
 from determined.common import check, context, util, yaml
@@ -130,7 +131,7 @@ class Determined:
         Get the :class:`~determined.experimental.Checkpoint` representing the
         checkpoint with the provided UUID.
         """
-        r = self._session.get("/api/v1/checkpoints/{}".format(uuid)).json()
+        r = self._session.get(f"/api/v1/checkpoints/{uuid}").json()
         return checkpoint.Checkpoint._from_json(r["checkpoint"], self._session)
 
     def create_model(
@@ -158,10 +159,14 @@ class Determined:
     def get_model(self, identifier: Union[str, int]) -> model.Model:
         """
         Get the :class:`~determined.experimental.Model` from the model registry
-        with the provided name or ID. If no corresponding model is found in the registry,
+        with the provided identifer, which is either a string-type name or an
+        integer-type model ID. If no corresponding model is found in the registry,
         an exception is raised.
+
+        Arguments:
+            identifier (string, int): The unique name or ID of the model.
         """
-        r = self._session.get("/api/v1/models/{}".format(identifier)).json()
+        r = self._session.get(f"/api/v1/models/{identifier}").json()
         assert r.get("model", False)
         return model.Model._from_json(r.get("model"), self._session)
 
@@ -170,7 +175,20 @@ class Determined:
         Get the :class:`~determined.experimental.Model` from the model registry
         with the provided id. If no model with that id is found in the registry,
         an exception is raised.
+
+        .. warning::
+           Determined.get_model_by_id() has been deprecated and will be removed
+           in a future version.
+           Please call Determined.get_model() with either a string-type name or
+           an integer-type model ID.
         """
+        warnings.warn(
+            "Determined.get_model_by_id() has been deprecated and will be removed",
+            "in a future version.\n",
+            "Please call Determined.get_model() with either a string-type name or",
+            "an integer-type model ID.",
+            FutureWarning,
+        )
         return self.get_model(model_id)
 
     def get_models(

--- a/harness/determined/experimental/client.py
+++ b/harness/determined/experimental/client.py
@@ -233,7 +233,7 @@ def get_model_by_id(model_id: int) -> Model:
         model_id (int): The unique id of the model.
     """
     assert _determined is not None
-    return _determined.get_model_by_id(model_id=model_id)
+    return _determined.get_model_by_id(model_id)
 
 
 @_require_singleton

--- a/harness/determined/experimental/client.py
+++ b/harness/determined/experimental/client.py
@@ -45,6 +45,7 @@ See :ref:`use-trained-models` for more ideas on what to do next.
 
 import functools
 import pathlib
+import warnings
 from typing import Any, Callable, Dict, List, Optional, Union
 
 from determined.common.experimental.checkpoint import Checkpoint
@@ -209,17 +210,18 @@ def create_model(
 
 
 @_require_singleton
-def get_model(name: str) -> Model:
+def get_model(identifier: Union[str, int]) -> Model:
     """
     Get the :class:`~determined.experimental.client.Model` from the model registry
-    with the provided name. If no model with that name is found in the registry,
-    an exception is raised.
+    with the provided identifier, which is either a string-type name or an
+    integer-type model ID.
+    If no model with that name is found in the registry, an exception is raised.
 
     Arguments:
-        name (str): The unique name of the model.
+        identifier (string, int): The unique name or ID of the model.
     """
     assert _determined is not None
-    return _determined.get_model(name)
+    return _determined.get_model(identifier)
 
 
 @_require_singleton
@@ -231,9 +233,22 @@ def get_model_by_id(model_id: int) -> Model:
 
     Arguments:
         model_id (int): The unique id of the model.
+
+    .. warning::
+       client.get_model_by_id() has been deprecated and will be removed
+       in a future version.
+       Please call client.get_model() with either a string-type name or
+       an integer-type model ID.
     """
+    warnings.warn(
+        "client.get_model_by_id() has been deprecated and will be removed",
+        "in a future version.\n",
+        "Please call client.get_model() with either a string-type name or",
+        "an integer-type model ID.",
+        FutureWarning,
+    )
     assert _determined is not None
-    return _determined.get_model_by_id(model_id)
+    return _determined.get_model(model_id)
 
 
 @_require_singleton

--- a/harness/determined/experimental/client.py
+++ b/harness/determined/experimental/client.py
@@ -241,9 +241,9 @@ def get_model_by_id(model_id: int) -> Model:
        an integer-type model ID.
     """
     warnings.warn(
-        "client.get_model_by_id() has been deprecated and will be removed",
-        "in a future version.\n",
-        "Please call client.get_model() with either a string-type name or",
+        "client.get_model_by_id() has been deprecated and will be removed"
+        "in a future version.\n"
+        "Please call client.get_model() with either a string-type name or"
         "an integer-type model ID.",
         FutureWarning,
     )

--- a/master/internal/api_model.go
+++ b/master/internal/api_model.go
@@ -252,8 +252,13 @@ func (a *apiServer) PatchModel(
 
 func (a *apiServer) ArchiveModel(
 	ctx context.Context, req *apiv1.ArchiveModelRequest) (*apiv1.ArchiveModelResponse, error) {
+	getResp, err := a.GetModel(ctx, &apiv1.GetModelRequest{ModelName: req.ModelName})
+	if err != nil {
+		return nil, err
+	}
+
 	holder := &modelv1.Model{}
-	err := a.m.db.QueryProto("archive_model", holder, req.ModelName)
+	err = a.m.db.QueryProto("archive_model", holder, getResp.Model.Name)
 
 	if holder.Id == 0 {
 		return nil, errors.Wrapf(err, "model \"%s\" was not found and cannot be archived",
@@ -266,8 +271,13 @@ func (a *apiServer) ArchiveModel(
 
 func (a *apiServer) UnarchiveModel(
 	ctx context.Context, req *apiv1.UnarchiveModelRequest) (*apiv1.UnarchiveModelResponse, error) {
+	getResp, err := a.GetModel(ctx, &apiv1.GetModelRequest{ModelName: req.ModelName})
+	if err != nil {
+		return nil, err
+	}
+
 	holder := &modelv1.Model{}
-	err := a.m.db.QueryProto("unarchive_model", holder, req.ModelName)
+	err = a.m.db.QueryProto("unarchive_model", holder, getResp.Model.Name)
 
 	if holder.Id == 0 {
 		return nil, errors.Wrapf(err, "model \"%s\" was not found and cannot be un-archived",
@@ -286,8 +296,13 @@ func (a *apiServer) DeleteModel(
 		return nil, err
 	}
 
+	getResp, err := a.GetModel(ctx, &apiv1.GetModelRequest{ModelName: req.ModelName})
+	if err != nil {
+		return nil, err
+	}
+
 	holder := &modelv1.Model{}
-	err = a.m.db.QueryProto("delete_model", holder, req.ModelName, user.User.Id,
+	err = a.m.db.QueryProto("delete_model", holder, getResp.Model.Name, user.User.Id,
 		user.User.Admin)
 
 	if holder.Id == 0 {

--- a/master/internal/api_model.go
+++ b/master/internal/api_model.go
@@ -42,18 +42,19 @@ func (a *apiServer) ModelFromIdentifier(identifier string) (*modelv1.Model, erro
 	}
 }
 
-func (a *apiServer) ModelVersionFromID(model_ident string, version_id int32) (*modelv1.ModelVersion, error) {
+func (a *apiServer) ModelVersionFromID(modelIdentifier string,
+	versionID int32) (*modelv1.ModelVersion, error) {
 	mv := &modelv1.ModelVersion{}
-	parentModel, err := a.ModelFromIdentifier(model_ident)
+	parentModel, err := a.ModelFromIdentifier(modelIdentifier)
 	if err != nil {
 		return nil, err
 	}
 
 	switch err = a.m.db.QueryProto(
-		"get_model_version", mv, parentModel.Id, version_id); {
+		"get_model_version", mv, parentModel.Id, versionID); {
 	case err == db.ErrNotFound:
 		return nil, status.Errorf(
-			codes.NotFound, "model %s version %d not found", model_ident, version_id)
+			codes.NotFound, "model %s version %d not found", modelIdentifier, versionID)
 	default:
 		return mv, err
 	}

--- a/master/internal/api_model.go
+++ b/master/internal/api_model.go
@@ -42,7 +42,7 @@ func (a *apiServer) ModelFromIdentifier(identifier string) (*modelv1.Model, erro
 	}
 }
 
-func (a *apiServer) ModelVersionFromId(model_ident string, version_id int32) (*modelv1.ModelVersion, error) {
+func (a *apiServer) ModelVersionFromID(model_ident string, version_id int32) (*modelv1.ModelVersion, error) {
 	mv := &modelv1.ModelVersion{}
 	parentModel, err := a.ModelFromIdentifier(model_ident)
 	if err != nil {
@@ -61,7 +61,6 @@ func (a *apiServer) ModelVersionFromId(model_ident string, version_id int32) (*m
 
 func (a *apiServer) GetModel(
 	_ context.Context, req *apiv1.GetModelRequest) (*apiv1.GetModelResponse, error) {
-
 	m, err := a.ModelFromIdentifier(req.ModelName)
 	return &apiv1.GetModelResponse{Model: m}, err
 }
@@ -337,7 +336,7 @@ func (a *apiServer) DeleteModel(
 
 func (a *apiServer) GetModelVersion(
 	ctx context.Context, req *apiv1.GetModelVersionRequest) (*apiv1.GetModelVersionResponse, error) {
-	mv, err := a.ModelVersionFromId(req.ModelName, req.ModelVersion)
+	mv, err := a.ModelVersionFromID(req.ModelName, req.ModelVersion)
 	resp := &apiv1.GetModelVersionResponse{}
 	resp.ModelVersion = mv
 	return resp, err
@@ -426,7 +425,7 @@ func (a *apiServer) PostModelVersion(
 func (a *apiServer) PatchModelVersion(
 	ctx context.Context, req *apiv1.PatchModelVersionRequest) (*apiv1.PatchModelVersionResponse,
 	error) {
-	currModelVersion, err := a.ModelVersionFromId(req.ModelName, req.ModelVersionId)
+	currModelVersion, err := a.ModelVersionFromID(req.ModelName, req.ModelVersionId)
 	if err != nil {
 		return nil, err
 	}

--- a/master/internal/api_model.go
+++ b/master/internal/api_model.go
@@ -342,7 +342,7 @@ func (a *apiServer) DeleteModel(
 func (a *apiServer) GetModelVersion(
 	ctx context.Context, req *apiv1.GetModelVersionRequest) (*apiv1.GetModelVersionResponse, error) {
 	mv, err := a.ModelVersionFromID(req.ModelName, req.ModelVersion)
-	if err {
+	if err != nil {
 		return nil, err
 	}
 	resp := &apiv1.GetModelVersionResponse{}

--- a/master/internal/api_model.go
+++ b/master/internal/api_model.go
@@ -35,10 +35,10 @@ func (a *apiServer) ModelFromIdentifier(identifier string) (*modelv1.Model, erro
 	switch err {
 	case db.ErrNotFound:
 		return nil, status.Errorf(
-			codes.NotFound, "model \"%s\" not found", identifier)
+			codes.NotFound, "model %q not found", identifier)
 	default:
 		return m, errors.Wrapf(err,
-			"error fetching model \"%s\" from database", identifier)
+			"error fetching model %q from database", identifier)
 	}
 }
 
@@ -54,10 +54,10 @@ func (a *apiServer) ModelVersionFromID(modelIdentifier string,
 		"get_model_version", mv, parentModel.Id, versionID); {
 	case err == db.ErrNotFound:
 		return nil, status.Errorf(
-			codes.NotFound, "model \"%s\" version %d not found", modelIdentifier, versionID)
+			codes.NotFound, "version %v for model %q not found", versionID, modelIdentifier)
 	default:
 		return mv, errors.Wrapf(err,
-			"error fetching model \"%s\" version %d from database", modelIdentifier, versionID)
+			"error fetching version %v for model %q from database", versionID, modelIdentifier)
 	}
 }
 
@@ -187,7 +187,7 @@ func (a *apiServer) PostModel(
 	)
 
 	return &apiv1.PostModelResponse{Model: m},
-		errors.Wrapf(err, "error creating model %s in database", req.Name)
+		errors.Wrapf(err, "error creating model %q in database", req.Name)
 }
 
 func (a *apiServer) PatchModel(
@@ -198,13 +198,13 @@ func (a *apiServer) PatchModel(
 	}
 
 	if currModel.Archived {
-		return nil, errors.Errorf("model \"%s\" is archived and cannot have attributes updated.",
+		return nil, errors.Errorf("model %q is archived and cannot have attributes updated.",
 			currModel.Name)
 	}
 
 	madeChanges := false
 	if req.Model.Name != nil && req.Model.Name.Value != currModel.Name {
-		log.Infof("model (%d) name changing from \"%s\" to \"%s\"",
+		log.Infof("model (%v) name changing from %q to %q",
 			currModel.Id, currModel.Name, req.Model.Name.Value)
 		if err = a.clearModelName(ctx, req.Model.Name.Value); err != nil {
 			return nil, err
@@ -214,14 +214,14 @@ func (a *apiServer) PatchModel(
 	}
 
 	if req.Model.Description != nil && req.Model.Description.Value != currModel.Description {
-		log.Infof("model \"%s\" description changing from \"%s\" to \"%s\"",
+		log.Infof("model %q description changing from %q to %q",
 			currModel.Name, currModel.Description, req.Model.Description.Value)
 		madeChanges = true
 		currModel.Description = req.Model.Description.Value
 	}
 
 	if req.Model.Notes != nil && req.Model.Notes.Value != currModel.Notes {
-		log.Infof("model \"%s\" notes changing from \"%s\" to \"%s\"",
+		log.Infof("model %q notes changing from %q to %q",
 			currModel.Name, currModel.Notes, req.Model.Notes.Value)
 		madeChanges = true
 		currModel.Notes = req.Model.Notes.Value
@@ -238,7 +238,7 @@ func (a *apiServer) PatchModel(
 		}
 
 		if !bytes.Equal(currMeta, newMeta) {
-			log.Infof("model \"%s\" metadata changing from %s to %s",
+			log.Infof("model %q metadata changing from %q to %q",
 				currModel.Name, currMeta, newMeta)
 			madeChanges = true
 			currMeta = newMeta
@@ -255,7 +255,7 @@ func (a *apiServer) PatchModel(
 		}
 		reqLabels := strings.Join(reqLabelList, ",")
 		if currLabels != reqLabels {
-			log.Infof("model \"%s\" labels changing from %s to %s",
+			log.Infof("model %q labels changing from %q to %q",
 				currModel.Name, currModel.Labels, reqLabels)
 			madeChanges = true
 		}
@@ -272,7 +272,7 @@ func (a *apiServer) PatchModel(
 		currModel.Notes, currMeta, currLabels)
 
 	return &apiv1.PatchModelResponse{Model: finalModel},
-		errors.Wrapf(err, "error updating model \"%s\" in database", currModel.Name)
+		errors.Wrapf(err, "error updating model %q in database", currModel.Name)
 }
 
 func (a *apiServer) ArchiveModel(
@@ -286,12 +286,12 @@ func (a *apiServer) ArchiveModel(
 	err = a.m.db.QueryProto("archive_model", holder, currModel.Name)
 
 	if holder.Id == 0 {
-		return nil, errors.Wrapf(err, "model \"%s\" was not found and cannot be archived",
+		return nil, errors.Wrapf(err, "model %q was not found and cannot be archived",
 			req.ModelName)
 	}
 
 	return &apiv1.ArchiveModelResponse{},
-		errors.Wrapf(err, "error archiving model \"%s\"", req.ModelName)
+		errors.Wrapf(err, "error archiving model %q", req.ModelName)
 }
 
 func (a *apiServer) UnarchiveModel(
@@ -305,12 +305,12 @@ func (a *apiServer) UnarchiveModel(
 	err = a.m.db.QueryProto("unarchive_model", holder, currModel.Name)
 
 	if holder.Id == 0 {
-		return nil, errors.Wrapf(err, "model \"%s\" was not found and cannot be un-archived",
+		return nil, errors.Wrapf(err, "model %q was not found and cannot be un-archived",
 			req.ModelName)
 	}
 
 	return &apiv1.UnarchiveModelResponse{},
-		errors.Wrapf(err, "error unarchiving model \"%s\"", req.ModelName)
+		errors.Wrapf(err, "error unarchiving model %q", req.ModelName)
 }
 
 func (a *apiServer) DeleteModel(
@@ -331,12 +331,12 @@ func (a *apiServer) DeleteModel(
 		user.User.Admin)
 
 	if holder.Id == 0 {
-		return nil, errors.Wrapf(err, "model \"%s\" does not exist or not delete-able by this user",
+		return nil, errors.Wrapf(err, "model %q does not exist or not delete-able by this user",
 			req.ModelName)
 	}
 
 	return &apiv1.DeleteModelResponse{},
-		errors.Wrapf(err, "error deleting model \"%s\"", req.ModelName)
+		errors.Wrapf(err, "error deleting model %q", req.ModelName)
 }
 
 func (a *apiServer) GetModelVersion(
@@ -376,7 +376,7 @@ func (a *apiServer) PostModelVersion(
 	}
 
 	if modelResp.Archived {
-		return nil, errors.Errorf("model \"%s\" is archived and cannot register new versions.",
+		return nil, errors.Errorf("model %q is archived and cannot register new versions.",
 			modelResp.Name)
 	}
 
@@ -426,7 +426,7 @@ func (a *apiServer) PostModelVersion(
 		user.User.Id,
 	)
 
-	return respModelVersion, errors.Wrapf(err, "error adding model version to model \"%s\"",
+	return respModelVersion, errors.Wrapf(err, "error adding model version to model %q",
 		req.ModelName)
 }
 
@@ -442,21 +442,21 @@ func (a *apiServer) PatchModelVersion(
 	madeChanges := false
 
 	if req.ModelVersion.Name != nil && req.ModelVersion.Name.Value != currModelVersion.Name {
-		log.Infof("model version (%d) name changing from \"%s\" to \"%s\"",
+		log.Infof("model version (%v) name changing from %q to %q",
 			req.ModelVersionId, currModelVersion.Name, req.ModelVersion.Name.Value)
 		madeChanges = true
 		currModelVersion.Name = req.ModelVersion.Name.Value
 	}
 
 	if req.ModelVersion.Comment != nil && req.ModelVersion.Comment.Value != currModelVersion.Comment {
-		log.Infof("model version (%d) comment changing from \"%s\" to \"%s\"",
+		log.Infof("model version (%v) comment changing from %q to %q",
 			req.ModelVersionId, currModelVersion.Comment, req.ModelVersion.Comment.Value)
 		madeChanges = true
 		currModelVersion.Comment = req.ModelVersion.Comment.Value
 	}
 
 	if req.ModelVersion.Notes != nil && req.ModelVersion.Notes.Value != currModelVersion.Notes {
-		log.Infof("model version (%d) notes changing from \"%s\" to \"%s\"",
+		log.Infof("model version (%v) notes changing from %q to %q",
 			req.ModelVersionId, currModelVersion.Notes, req.ModelVersion.Notes.Value)
 		madeChanges = true
 		currModelVersion.Notes = req.ModelVersion.Notes.Value
@@ -473,7 +473,7 @@ func (a *apiServer) PatchModelVersion(
 		}
 
 		if !bytes.Equal(currMeta, newMeta) {
-			log.Infof("model version (%d) metadata changing from %s to %s",
+			log.Infof("model version (%v) metadata changing from %q to %q",
 				req.ModelVersionId, currMeta, newMeta)
 			madeChanges = true
 			currMeta = newMeta
@@ -490,7 +490,7 @@ func (a *apiServer) PatchModelVersion(
 		}
 		reqLabels := strings.Join(reqLabelList, ",")
 		if currLabels != reqLabels {
-			log.Infof("model version (%d) labels changing from %s to %s",
+			log.Infof("model version (%v) labels changing from %q to %q",
 				req.ModelVersionId, currModelVersion.Labels, reqLabels)
 			madeChanges = true
 		}
@@ -507,7 +507,7 @@ func (a *apiServer) PatchModelVersion(
 		currMeta, currLabels)
 
 	return &apiv1.PatchModelVersionResponse{ModelVersion: finalModelVersion},
-		errors.Wrapf(err, "error updating model version %d in database", req.ModelVersionId)
+		errors.Wrapf(err, "error updating model version %v in database", req.ModelVersionId)
 }
 
 func (a *apiServer) DeleteModelVersion(
@@ -523,10 +523,10 @@ func (a *apiServer) DeleteModelVersion(
 		user.User.Id, user.User.Admin)
 
 	if holder.Id == 0 {
-		return nil, errors.Wrapf(err, "model version %d does not exist or not delete-able by this user",
+		return nil, errors.Wrapf(err, "model version %v does not exist or not delete-able by this user",
 			req.ModelVersionId)
 	}
 
 	return &apiv1.DeleteModelVersionResponse{},
-		errors.Wrapf(err, "error deleting model version %d", req.ModelVersionId)
+		errors.Wrapf(err, "error deleting model version %v", req.ModelVersionId)
 }

--- a/master/internal/api_model.go
+++ b/master/internal/api_model.go
@@ -25,7 +25,16 @@ import (
 func (a *apiServer) GetModel(
 	_ context.Context, req *apiv1.GetModelRequest) (*apiv1.GetModelResponse, error) {
 	m := &modelv1.Model{}
-	switch err := a.m.db.QueryProto("get_model", m, req.ModelName); err {
+	var err error
+
+	allNumbers, _ := regexp.MatchString("^\\d+$", req.ModelName)
+	if allNumbers {
+		err = a.m.db.QueryProto("get_model_by_id", m, req.ModelName)
+	} else {
+		err = a.m.db.QueryProto("get_model", m, req.ModelName)
+	}
+
+	switch err {
 	case db.ErrNotFound:
 		return nil, status.Errorf(
 			codes.NotFound, "model \"%s\" not found", req.ModelName)

--- a/master/internal/api_model.go
+++ b/master/internal/api_model.go
@@ -54,15 +54,19 @@ func (a *apiServer) ModelVersionFromID(modelIdentifier string,
 		"get_model_version", mv, parentModel.Id, versionID); {
 	case err == db.ErrNotFound:
 		return nil, status.Errorf(
-			codes.NotFound, "model %s version %d not found", modelIdentifier, versionID)
+			codes.NotFound, "model \"%s\" version %d not found", modelIdentifier, versionID)
 	default:
-		return mv, err
+		return mv, errors.Wrapf(err,
+			"error fetching model \"%s\" version %d from database", modelIdentifier, versionID)
 	}
 }
 
 func (a *apiServer) GetModel(
 	_ context.Context, req *apiv1.GetModelRequest) (*apiv1.GetModelResponse, error) {
 	m, err := a.ModelFromIdentifier(req.ModelName)
+	if err != nil {
+		return nil, err
+	}
 	return &apiv1.GetModelResponse{Model: m}, err
 }
 
@@ -338,6 +342,9 @@ func (a *apiServer) DeleteModel(
 func (a *apiServer) GetModelVersion(
 	ctx context.Context, req *apiv1.GetModelVersionRequest) (*apiv1.GetModelVersionResponse, error) {
 	mv, err := a.ModelVersionFromID(req.ModelName, req.ModelVersion)
+	if err {
+		return nil, err
+	}
 	resp := &apiv1.GetModelVersionResponse{}
 	resp.ModelVersion = mv
 	return resp, err

--- a/master/static/srv/get_model_by_id.sql
+++ b/master/static/srv/get_model_by_id.sql
@@ -1,0 +1,7 @@
+SELECT m.id, m.name, m.description, m.notes, m.metadata, m.creation_time, m.last_updated_time, array_to_json(m.labels) AS labels, u.username, m.archived, COUNT(mv.version) as num_versions
+FROM models as m
+  LEFT JOIN model_versions as mv
+    ON mv.model_id = m.id
+  LEFT JOIN users as u ON u.id = m.user_id
+WHERE m.id = $1
+GROUP BY m.id, u.id;

--- a/master/static/srv/get_model_by_id.sql
+++ b/master/static/srv/get_model_by_id.sql
@@ -1,4 +1,4 @@
-SELECT m.id, m.name, m.description, m.notes, m.metadata, m.creation_time, m.last_updated_time, array_to_json(m.labels) AS labels, u.username, m.archived, COUNT(mv.version) as num_versions
+SELECT m.id, m.name, m.description, m.notes, m.metadata, m.creation_time, m.last_updated_time, array_to_json(m.labels) AS labels, m.user_id, u.username, m.archived, COUNT(mv.version) as num_versions
 FROM models as m
   LEFT JOIN model_versions as mv
     ON mv.model_id = m.id

--- a/webui/react/src/components/Table.tsx
+++ b/webui/react/src/components/Table.tsx
@@ -11,8 +11,8 @@ import { commandTypeToLabel } from 'constants/states';
 import { paths } from 'routes/utils';
 import { StateOfUnion } from 'themes';
 import {
-  CommandTask, CommandType, ExperimentItem, ModelVersion, Pagination,
-  StartEndTimes, TrialItem,
+  CommandTask, CommandType, ExperimentItem, ModelItem, ModelVersion,
+  Pagination, StartEndTimes, TrialItem,
 } from 'types';
 import { getDuration } from 'utils/datetime';
 import { canBeOpened } from 'utils/task';
@@ -155,17 +155,17 @@ export const experimentProgressRenderer: ExperimentRenderer = (_, record) => {
 
 /* Model Table Column Renderers */
 
-export const modelNameRenderer = (value: string): React.ReactNode => (
+export const modelNameRenderer = (value: string, record: ModelItem): React.ReactNode => (
   <Space>
     <div style={{ paddingInline: 4 }}>
       <Icon name="model" size="medium" />
     </div>
-    <Link path={paths.modelDetails(value)}>{value}</Link>
+    <Link path={paths.modelDetails(String(record.id))}>{value}</Link>
   </Space>
 );
 
 export const modelVersionNameRenderer = (value: string, record: ModelVersion): React.ReactNode => (
-  <Link path={paths.modelVersionDetails(record.model?.name ?? '', record.id)}>
+  <Link path={paths.modelVersionDetails(String(record.model?.id ?? ''), record.id)}>
     {value ? value : 'Version ' + record.version}
   </Link>
 );

--- a/webui/react/src/pages/ModelDetails/ModelHeader.tsx
+++ b/webui/react/src/pages/ModelDetails/ModelHeader.tsx
@@ -101,7 +101,7 @@ const ModelHeader: React.FC<Props> = (
             </Link>
           </Breadcrumb.Item>
           <Breadcrumb.Separator />
-          <Breadcrumb.Item>{model.name}</Breadcrumb.Item>
+          <Breadcrumb.Item>{model.name} ({model.id})</Breadcrumb.Item>
         </Breadcrumb>
       </div>
       {model.archived && (

--- a/webui/react/src/pages/ModelVersionDetails/ModelVersionHeader.tsx
+++ b/webui/react/src/pages/ModelVersionDetails/ModelVersionHeader.tsx
@@ -168,7 +168,7 @@ my_model.load_state_dict(ckpt['models_state_dict'][0])`);
           <Breadcrumb.Separator />
           <Breadcrumb.Item>
             <Link path={paths.modelDetails(modelVersion.model.name)}>
-              {modelVersion.model.name}
+              {modelVersion.model.name} ({modelVersion.model.id})
             </Link>
           </Breadcrumb.Item>
           <Breadcrumb.Separator />

--- a/webui/react/src/routes/utils.ts
+++ b/webui/react/src/routes/utils.ts
@@ -213,7 +213,6 @@ export const paths = {
   },
   jobs: (): string => {
     return routeById.jobs.path;
-
   },
   login: (): string => {
     return '/login';


### PR DESCRIPTION
## Description

This change would accept  `/det/models/:model_id` and `/api/v1/models/:model_id` as valid routes. A model name can't be all digits, so there should be no collision between model names and IDs.  The `GetModel` Go code is also used in PatchModel, GetModelVersion, PostModelVersion, and GetModelVersions, but we don't need to support IDs there explicitly.

The second part of the request is **displaying** the ID and **making the permalink visible**. I've added the number to breadcrumbs in the PR as a start. We could change to use the model ID in WebUI's links, so you are always on the permalink URL. Or we can make a permalink button.

Current proposal for updated breadcrumbs:

<img width="583" alt="Screen Shot 2022-03-10 at 11 40 51 AM" src="https://user-images.githubusercontent.com/643918/157742695-6121565b-f417-4524-83a9-af505fcbb422.png">

## Test Plan

Go to `/api/v1/models` to see your list of models

- Given any model, `/api/v1/models/:model_name` and `/api/v1/models/:model_id` should get the same response
- Given a numeric ID for a model which doesn't exist, the API should return not found

## Checklist

- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.