### PR TITLE
test: add test for cross-version master/agent clusters

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1434,12 +1434,16 @@ jobs:
       postgres-version:
         type: string
         default: '10'
+      agent-version:
+        type: string
+        default: ''
     machine:
       image: <<pipeline.parameters.machine-image>>
     resource_class: large
     parallelism: <<parameters.parallelism>>
     environment:
       DET_POSTGRES_VERSION: <<parameters.postgres-version>>
+      DET_AGENT_VERSION: <<parameters.agent-version>>
     steps:
       - checkout
       - attach_workspace:
@@ -1967,6 +1971,18 @@ workflows:
           devcluster-config: postgres-with-ssl.devcluster.yaml
           target-stage: agent
           postgres-version: '14'
+
+      - test-e2e:
+          name: test-e2e-old-agent-versions
+          requires:
+            - build-go
+          parallelism: 1
+          mark: e2e_cpu_postgres
+          devcluster-config: custom-agent-version.devcluster.yaml
+          target-stage: agent
+          matrix:
+            parameters:
+              agent-version: ['0.17.10']
 
       - deploy:
           enable-cors: true

--- a/.circleci/devcluster/custom-agent-version.devcluster.yaml
+++ b/.circleci/devcluster/custom-agent-version.devcluster.yaml
@@ -1,0 +1,48 @@
+stages:
+  - db:
+      name: db
+
+  - master:
+      pre:
+        - sh: make -C tools prep-root
+      config_file:
+        db:
+          host: localhost
+          port: 5432
+          password: postgres
+          user: postgres
+          name: determined
+        checkpoint_storage:
+          type: shared_fs
+          host_path: /tmp
+          storage_path: determined-cp
+        log:
+          level: debug
+        root: tools/build
+
+  - custom_docker:
+      name: agent
+
+      container_name: determined_agent
+      kill_signal: TERM
+
+      pre:
+        - sh: |
+            set -ex
+            mkdir -p /tmp/det
+            cat >/tmp/det/agent.yaml <<EOF
+            master_host: 127.0.0.1
+            master_port: 8080
+            agent_id: agent
+            container_master_host: $DOCKER_LOCALHOST
+            EOF
+
+      run_args:
+        - -v
+        - /tmp/det:/etc/determined
+        - -v
+        - /var/run/docker.sock:/var/run/docker.sock
+        - --net
+        - host
+        - determinedai/determined-agent:$DET_AGENT_VERSION
+        - run

--- a/.circleci/devcluster/postgres-with-ssl.devcluster.yaml
+++ b/.circleci/devcluster/postgres-with-ssl.devcluster.yaml
@@ -1,5 +1,5 @@
 stages:
-  # Use a custom Docker stage rather than the normal DB one because thelatter currently doesn't
+  # Use a custom Docker stage rather than the normal DB one because the latter currently doesn't
   # support mounting an extra volume or specifying the initdb args variable that we need.
   - custom_docker:
       name: db

--- a/e2e_tests/pytest.ini
+++ b/e2e_tests/pytest.ini
@@ -10,6 +10,7 @@ markers =
     e2e_cpu_2a: end to end CPU tests with two agents
     e2e_cpu_elastic: end to end CPU tests with elasticsearch for logging
     e2e_cpu_postgres: end to end CPU tests for testing basic database functionality
+    e2e_cpu_cross_version: end to end CPU tests for testing basic cluster functionality with differing master/agent versions
     e2e_gpu: end to end GPU tests
     gpu_required: tests with a hard CUDA requirement
     distributed: distributed training tests

--- a/e2e_tests/tests/cluster/test_users.py
+++ b/e2e_tests/tests/cluster/test_users.py
@@ -273,6 +273,7 @@ def test_change_password(clean_auth: None) -> None:
 
 @pytest.mark.e2e_cpu
 @pytest.mark.e2e_cpu_postgres
+@pytest.mark.e2e_cpu_cross_version
 def test_experiment_creation_and_listing(clean_auth: None) -> None:
     # Create 2 users.
     creds1 = create_test_user(ADMIN_CREDENTIALS, True)

--- a/e2e_tests/tests/template/test_template.py
+++ b/e2e_tests/tests/template/test_template.py
@@ -17,6 +17,7 @@ def test_set_template() -> None:
 
 @pytest.mark.slow
 @pytest.mark.e2e_cpu
+@pytest.mark.e2e_cpu_cross_version
 def test_start_notebook_with_template() -> None:
     template_name = "test_start_notebook_with_template"
     tpl.set_template(template_name, conf.fixtures_path("templates/template.yaml"))
@@ -27,6 +28,7 @@ def test_start_notebook_with_template() -> None:
 
 @pytest.mark.slow
 @pytest.mark.e2e_cpu
+@pytest.mark.e2e_cpu_cross_version
 def test_start_command_with_template() -> None:
     template_name = "test_start_command_with_template"
     tpl.set_template(template_name, conf.fixtures_path("templates/template.yaml"))
@@ -39,6 +41,7 @@ def test_start_command_with_template() -> None:
 
 @pytest.mark.slow
 @pytest.mark.e2e_cpu
+@pytest.mark.e2e_cpu_cross_version
 def test_start_shell_with_template() -> None:
     template_name = "test_start_shell_with_template"
     tpl.set_template(template_name, conf.fixtures_path("templates/template.yaml"))

--- a/e2e_tests/tests/test_logging.py
+++ b/e2e_tests/tests/test_logging.py
@@ -13,6 +13,7 @@ from tests import experiment as exp
 @pytest.mark.e2e_cpu
 @pytest.mark.e2e_cpu_elastic
 @pytest.mark.e2e_cpu_postgres
+@pytest.mark.e2e_cpu_cross_version
 @pytest.mark.e2e_gpu
 @pytest.mark.timeout(300)
 def test_trial_logs() -> None:
@@ -37,6 +38,7 @@ def test_trial_logs() -> None:
 
 @pytest.mark.e2e_cpu
 @pytest.mark.e2e_cpu_elastic
+@pytest.mark.e2e_cpu_cross_version
 @pytest.mark.e2e_gpu  # Note, e2e_gpu and not gpu_required hits k8s cpu tests.
 @pytest.mark.timeout(300)
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Description

For rolling upgrades to work properly, we need the master to be able to
communicate with agents from previous versions of Determined. (At least
for now, we're focusing on an upgrade strategy where the master is
upgraded first and the agents second.) And a first step toward ensuring
that is running tests on a cluster with mismatched versions, which this
adds using a custom devcluster config.

## Commentary

Strategy for determining which previous version(s) to use in general
TBD; perhaps 0.x.0 for each minor version, and maybe an occasional later
0.x.y, though that won't work right now because of a recent change to
logging.
