### PR TITLE
fix: Restore det preview-search in CLI [DET-6850]

### DIFF
--- a/master/internal/core.go
+++ b/master/internal/core.go
@@ -894,6 +894,9 @@ func (m *Master) Run(ctx context.Context) error {
 	experimentsGroup.PATCH("/:experiment_id", api.Route(m.patchExperiment))
 	experimentsGroup.POST("", api.Route(m.postExperiment))
 
+	searcherGroup := m.echo.Group("/searcher", authFuncs...)
+	searcherGroup.POST("/preview", api.Route(m.getSearcherPreview))
+
 	trialsGroup := m.echo.Group("/trials", authFuncs...)
 	trialsGroup.GET("/:trial_id", api.Route(m.getTrial))
 	trialsGroup.GET("/:trial_id/details", api.Route(m.getTrialDetails))

--- a/master/internal/core_searcher.go
+++ b/master/internal/core_searcher.go
@@ -1,8 +1,57 @@
 package internal
 
 import (
+	"io/ioutil"
+
+	"github.com/labstack/echo/v4"
+	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
+
+	"github.com/determined-ai/determined/master/pkg/schemas"
+	"github.com/determined-ai/determined/master/pkg/schemas/expconf"
+	"github.com/determined-ai/determined/master/pkg/searcher"
 )
+
+func (m *Master) getSearcherPreview(c echo.Context) (interface{}, error) {
+	bytes, err := ioutil.ReadAll(c.Request().Body)
+	if err != nil {
+		return nil, err
+	}
+
+	// Parse the provided experiment config.
+	config, err := expconf.ParseAnyExperimentConfigYAML(bytes)
+	if err != nil {
+		return nil, errors.Wrapf(err, "invalid experiment configuration")
+	}
+
+	// Get the useful subconfigs for preview search.
+	if config.RawSearcher == nil {
+		return nil, errors.New("invalid experiment configuration; missing searcher")
+	}
+	sc := *config.RawSearcher
+	hc := config.RawHyperparameters
+
+	// Apply any json-schema-defined defaults.
+	sc = schemas.WithDefaults(sc).(expconf.SearcherConfig)
+	hc = schemas.WithDefaults(hc).(expconf.Hyperparameters)
+
+	// Make sure the searcher config has all eventuallyRequired fields.
+	if err = schemas.IsComplete(sc); err != nil {
+		return nil, errors.Wrapf(err, "invalid searcher configuration")
+	}
+	if err = schemas.IsComplete(hc); err != nil {
+		return nil, errors.Wrapf(err, "invalid hyperparameters configuration")
+	}
+
+	// Disallow EOL searchers.
+	if err = sc.AssertCurrent(); err != nil {
+		return nil, errors.Wrap(err, "invalid experiment configuration")
+	}
+
+	sm := searcher.NewSearchMethod(sc)
+	s := searcher.NewSearcher(0, sm, hc)
+	return searcher.Simulate(s, nil, searcher.RandomValidation, true, config.Searcher().Metric())
+}
 
 // cleanUpExperimentSnapshots deletes all snapshots for terminal state experiments from
 // the database.


### PR DESCRIPTION
## Description

Returns an API endpoint which is used by the CLI's `det preview-search`. Re-implementing the code in the new API would take an additional time commitment.

## Test Plan

`det preview-search path/to/configfile.yaml`

## Checklist

- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.