### PR TITLE
fix: create user with password broken [DET-6852]

### DIFF
--- a/master/internal/api_user.go
+++ b/master/internal/api_user.go
@@ -88,6 +88,7 @@ func (a *apiServer) GetUser(
 func (a *apiServer) PostUser(
 	ctx context.Context, req *apiv1.PostUserRequest) (*apiv1.PostUserResponse, error) {
 	curUser, _, err := grpcutil.GetUser(ctx, a.m.db, &a.m.config.InternalConfig.ExternalSessions)
+
 	if err != nil {
 		return nil, err
 	}
@@ -105,7 +106,7 @@ func (a *apiServer) PostUser(
 		Admin:    req.User.Admin,
 		Active:   req.User.Active,
 	}
-	if err = user.UpdatePasswordHash(req.Password); err != nil {
+	if err = user.UpdatePasswordHash(replicateClientSideSaltAndHash(req.Password)); err != nil {
 		return nil, err
 	}
 	var agentUserGroup *model.AgentUserGroup

--- a/master/internal/db/postgres_users.go
+++ b/master/internal/db/postgres_users.go
@@ -185,8 +185,8 @@ func (db *PgDB) UserByUsername(username string) (*model.User, error) {
 func addUser(tx *sqlx.Tx, user *model.User) (model.UserID, error) {
 	stmt, err := tx.PrepareNamed(`
 INSERT INTO users
-(username, admin, active)
-VALUES (:username, :admin, :active)
+(username, admin, active, password_hash)
+VALUES (:username, :admin, :active, :password_hash)
 RETURNING id`)
 	if err != nil {
 		return 0, errors.WithStack(err)
@@ -233,7 +233,7 @@ func deleteAgentUserGroup(tx *sqlx.Tx, userID model.UserID) error {
 	return nil
 }
 
-// AddUser creates a new user without a password.
+// AddUser creates a new user.
 func (db *PgDB) AddUser(user *model.User, ug *model.AgentUserGroup) error {
 	tx, err := db.sql.Beginx()
 	if err != nil {


### PR DESCRIPTION
## Test Plan

Create a user with a password via the REST API.

```
# Set a curl'able master URL:
export DET_MASTER=http://localhost:8080

# Login as admin
export TOKEN=$(curl -X POST -d '{"username": "admin", "password": ""}' ${DET_MASTER}/api/v1/auth/login | jq '.token' | sed 's/"//g')

# Create a user with password:
curl -H "Authorization: Bearer ${TOKEN}" -H  "accept: application/json" -X POST "${DET_MASTER}/api/v1/users" -d '{"user": {"username": "mytestuser", "admin": false, "active": true}, "password": "asdf"}'

# Try to login as the user using the password "asdf"
det user login mytestuser
```
