### PR TITLE
fix: prevent pytorch geometric nightly test timeout

### DIFF
--- a/examples/graphs/proteins_pytorch_geometric/adaptive.yaml
+++ b/examples/graphs/proteins_pytorch_geometric/adaptive.yaml
@@ -32,5 +32,4 @@ searcher:
 entrypoint: model_def:GraphConvTrial
 environment:
   image:
-    cpu: determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-b06dafb
-    cuda: determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-b06dafb
+    cuda: determinedai/environments:cuda-11.3-pytorch-1.10-lightning-1.5-tf-2.8-gpu-97e4c60

--- a/examples/graphs/proteins_pytorch_geometric/const.yaml
+++ b/examples/graphs/proteins_pytorch_geometric/const.yaml
@@ -18,5 +18,4 @@ searcher:
 entrypoint: model_def:GraphConvTrial
 environment:
   image:
-    cpu: determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-b06dafb
-    cuda: determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-b06dafb
+    cuda: determinedai/environments:cuda-11.3-pytorch-1.10-lightning-1.5-tf-2.8-gpu-97e4c60

--- a/examples/graphs/proteins_pytorch_geometric/distributed.yaml
+++ b/examples/graphs/proteins_pytorch_geometric/distributed.yaml
@@ -18,6 +18,6 @@ searcher:
 entrypoint: model_def:GraphConvTrial
 environment:
   image:
-    cuda: determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-b06dafb
+    cuda: determinedai/environments:cuda-11.3-pytorch-1.10-lightning-1.5-tf-2.8-gpu-97e4c60
 resources:
   slots_per_trial: 4

--- a/examples/graphs/proteins_pytorch_geometric/distributed.yaml
+++ b/examples/graphs/proteins_pytorch_geometric/distributed.yaml
@@ -18,7 +18,6 @@ searcher:
 entrypoint: model_def:GraphConvTrial
 environment:
   image:
-    cpu: determinedai/environments:py-3.7-pytorch-1.9-lightning-1.3-tf-2.4-cpu-b06dafb
     cuda: determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.3-tf-2.4-gpu-b06dafb
 resources:
   slots_per_trial: 4

--- a/examples/graphs/proteins_pytorch_geometric/startup-hook.sh
+++ b/examples/graphs/proteins_pytorch_geometric/startup-hook.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 pip install torch_geometric
-pip install torch_sparse torch_scatter -f https://pytorch-geometric.com/whl/torch-1.9.0+cu111.html
+pip install torch_sparse torch_scatter -f https://pytorch-geometric.com/whl/torch-1.10.2+cu113.html


### PR DESCRIPTION
## Description

Prevent pytorch geometric nightly test timeout

## Test Plan
`test_protein_pytorch_geometric` in nightly E2E GPU job should run successfully.

No testing needed for release / outside of CI.

## Commentary (optional)
Needed to update image/wheel for install to be quick enough, due to order of installs and incompatibility with the current `torch-geometric` version.

Also removed `cpu` images since it appears CUDA is required to run the model.
