### PR TITLE
fix: update types for pytorch custom reducers

### DIFF
--- a/model_hub/model_hub/mmdetection/_trial.py
+++ b/model_hub/model_hub/mmdetection/_trial.py
@@ -201,7 +201,7 @@ class MMDetTrial(det_torch.PyTorchTrial):
                 (bbox_results, mmdet.core.encode_mask_results(mask_results))
                 for bbox_results, mask_results in result
             ]
-        self.reducer.update(([b["idx"] for b in batch["img_metas"][0]], result))  # type: ignore
+        self.reducer.update(([b["idx"] for b in batch["img_metas"][0]], result))
         return {}
 
     def build_training_data_loader(self) -> det_torch.DataLoader:


### PR DESCRIPTION
## Description

Use @typing.overload and typing.TypeVar to make sure that the following
code snippets avoid static analysis issues:

    # simple api case
    reducer = wrap_reducer(my_reducer_fn, ...)
    reducer.update()  # avoid "MetricReducer has no .update"

    # full api case
    class MyReducer():
        def my_update(...):
            ...
    reducer = wrap_reducer(MyReducer(), ...)
    reducer.my_update()  # avoid "MetricReducer has no .my_update"

## Commentary

`mypy` is capable enough to handle this, but IMO this means that the `wrap_reducer` API should really be two separate calls:
- `wrap_simple_reducer(fn: Callable) -> SimpleReducer`
- `register_reducer(metric_reducer: MetricReducer) -> None`

## Test Plan

I verified that running `mypy model_def.py` on the following model definition reproduced the errors without this fix, and I made sure that the errors were gone with this fix.

```python
from typing import Any, Dict, Sequence, Tuple, Union, cast, List, Callable

import torch
from torch import nn

from determined import pytorch

class OnesDataset(torch.utils.data.Dataset):
    def __len__(self) -> int:
        return 64

    def __getitem__(self, index: int) -> torch.Tensor:
        return torch.Tensor([1.0])


def custom_reducer(ins: List[Any]) -> Any:
    return 2.5


class CustomReducer(pytorch.MetricReducer):
    def __init__(self) -> None:
        pass

    def reset(self) -> None:
        pass

    def per_slot_reduce(self) -> None:
        pass

    def cross_slot_reduce(self, psm: List) -> Any:
        return 3.5

    def my_update(self, t: torch.Tensor) -> None:
        print('my update', t)



class OneVarPytorchTrial(pytorch.PyTorchTrial):
    def __init__(self, context: pytorch.PyTorchTrialContext) -> None:
        self.context = context

        self.model = context.wrap_model(nn.Linear(1, 1, False))
        # initialize weights to 0
        self.model.weight.data.fill_(0)
        self.opt = context.wrap_optimizer(
            torch.optim.SGD(self.model.parameters(), lr=0.001), backward_passes_per_step=2
        )
        self.fnreducer = self.context.wrap_reducer(custom_reducer, "custom_metric")
        self.clsreducer = self.context.wrap_reducer(CustomReducer(), "CustomMetric")

    def train_batch(
        self, batch: pytorch.TorchData, epoch_idx: int, batch_idx: int
    ) -> Dict[str, torch.Tensor]:
        loss = torch.nn.MSELoss()(self.model(batch), batch)
        self.context.backward(loss)
        self.context.step_optimizer(self.opt)
        self.fnreducer.update(1)
        self.clsreducer.my_update(loss)
        return {"loss": loss}

    def evaluate_batch(self, batch: pytorch.TorchData, batch_idx: int) -> Dict[str, Any]:
        data = labels = batch
        loss = torch.nn.MSELoss()(self.model(data), labels)
        return {"loss": loss}

    def build_training_data_loader(self) -> pytorch.DataLoader:
        return pytorch.DataLoader(
            OnesDataset(), batch_size=self.context.get_per_slot_batch_size()
        )

    def build_validation_data_loader(self) -> pytorch.DataLoader:
        return pytorch.DataLoader(
            OnesDataset(), batch_size=self.context.get_per_slot_batch_size()
        )
```