### PR TITLE
feat: add name to logging for harness [DET-6919]

### DIFF
--- a/harness/determined/common/_logging.py
+++ b/harness/determined/common/_logging.py
@@ -11,6 +11,6 @@ def set_logger(debug_enabled: bool) -> None:
 
     handler = logging.StreamHandler(sys.stdout)
     handler.setLevel(logging.DEBUG if debug_enabled else logging.INFO)
-    formatter = logging.Formatter("%(levelname)s: %(message)s")
+    formatter = logging.Formatter("%(levelname)s: %(name)s: %(message)s")
     handler.setFormatter(formatter)
     root.addHandler(handler)


### PR DESCRIPTION
To test:

Run mnist example and look at trial logs. Should now see the library which is writing the log, e.g., `INFO: determined.core: report_validation_metrics(latest_batch=937, metrics={'validation_loss': 0.05719069745362411, 'accuracy': 0.9807921974522293})`