### PR TITLE
fix: CLI describes experiment with zero trials

### DIFF
--- a/harness/determined/cli/experiment.py
+++ b/harness/determined/cli/experiment.py
@@ -336,10 +336,10 @@ def describe(args: Namespace) -> None:
         + v_metrics_headers
     )
 
+    wl_output: Dict[int, List[Any]] = {}
     for exp in exps:
         for trial in trials_for_experiment[exp.id]:
             workloads = bindings.get_GetTrial(session, trialId=trial.id).workloads or []
-            wl_output: Dict[int, List[Any]] = {}
             for workload in workloads:
                 t_metrics_fields = []
                 wl_detail: bindings.v1MetricsWorkload | bindings.v1CheckpointWorkload | None = None


### PR DESCRIPTION
## Description

Change where we define `wl_output` so that `det e describe` works on zero-trial experiments.

## Checklist

- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.