### PR TITLE
fix: Restore /model_def / getExperimentModelDefinition

### DIFF
--- a/master/internal/core.go
+++ b/master/internal/core.go
@@ -882,6 +882,7 @@ func (m *Master) Run(ctx context.Context) error {
 	m.echo.GET("/logs", api.Route(m.getMasterLogs), authFuncs...)
 
 	experimentsGroup := m.echo.Group("/experiments", authFuncs...)
+	experimentsGroup.GET("/:experiment_id/model_def", m.getExperimentModelDefinition)
 	experimentsGroup.GET("/:experiment_id/preview_gc", api.Route(m.getExperimentCheckpointsToGC))
 	experimentsGroup.PATCH("/:experiment_id", api.Route(m.patchExperiment))
 	experimentsGroup.POST("", api.Route(m.postExperiment))

--- a/master/internal/core_experiment.go
+++ b/master/internal/core_experiment.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"regexp"
 	"time"
 
 	"github.com/determined-ai/determined/proto/pkg/apiv1"
@@ -86,6 +87,45 @@ func (m *Master) getExperimentCheckpointsToGC(c echo.Context) (interface{}, erro
 	}
 	return m.db.ExperimentCheckpointsToGCRaw(
 		args.ExperimentID, args.ExperimentBest, args.TrialBest, args.TrialLatest, false)
+}
+
+func (m *Master) getExperimentModelDefinition(c echo.Context) error {
+	args := struct {
+		ExperimentID int `path:"experiment_id"`
+	}{}
+	if err := api.BindArgs(&args, c); err != nil {
+		return err
+	}
+
+	modelDef, err := m.db.ExperimentModelDefinitionRaw(args.ExperimentID)
+	if err != nil {
+		return err
+	}
+
+	expConfig, err := m.db.ExperimentConfig(args.ExperimentID)
+	if err != nil {
+		return err
+	}
+
+	// Make a Regex to remove everything but a whitelist of characters.
+	reg := regexp.MustCompile(`[^A-Za-z0-9_ \-()[\].{}]+`)
+	cleanName := reg.ReplaceAllString(expConfig.Name().String(), "")
+
+	// Truncate name to a smaller size to both accommodate file name and path size
+	// limits on different platforms as well as get users more accustom to picking shorter
+	// names as we move toward "name as mnemonic for an experiment".
+	maxNameLength := 50
+	if len(cleanName) > maxNameLength {
+		cleanName = cleanName[0:maxNameLength]
+	}
+
+	c.Response().Header().Set(
+		"Content-Disposition",
+		fmt.Sprintf(
+			`attachment; filename="exp%d_%s_model_def.tar.gz"`,
+			args.ExperimentID,
+			cleanName))
+	return c.Blob(http.StatusOK, "application/x-gtar", modelDef)
 }
 
 func (m *Master) patchExperiment(c echo.Context) (interface{}, error) {


### PR DESCRIPTION
## Description

The "Download Experiment Code" button uses this legacy API route, which we now return. The Web UI would not be able to convert the encoded ZIP / JSON from the new `/api/v1/experiments/:id/model_def` endpoint without some additional work.

## Test Plan

On latest-master, go to an experiment detail page and click "Download Experiment Code". If the button is not visible, click the three dots in the top right to select it from the dropdown.

## Checklist

- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.