### PR TITLE
fix: cli win tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1357,7 +1357,7 @@ jobs:
       - setup-python-venv:
           determined: true
           extras-requires: "tensorflow==2.4.3 torch==1.9.0 torchvision==0.10.0"
-          extra-requirements-file: "harness/tests/requirements.txt"
+          extra-requirements-file: "harness/tests/requirements/requirements-harness.txt"
           executor: <<pipeline.parameters.docker-image>>
       - run: COVERAGE_FILE=$PWD/test-unit-harness-cpu-pycov make -C harness test-cpu
       - persist_to_workspace:
@@ -1374,7 +1374,7 @@ jobs:
       - setup-python-venv:
           determined: true
           extras-requires: "tensorflow==2.4.3 torch==1.9.0 torchvision==0.10.0"
-          extra-requirements-file: "harness/tests/requirements.txt"
+          extra-requirements-file: "harness/tests/requirements/requirements-harness.txt"
           executor: <<pipeline.parameters.docker-image>>
       - run: COVERAGE_FILE=$PWD/test-unit-harness-gpu-pycov make -C harness test-gpu
       - persist_to_workspace:
@@ -1390,7 +1390,7 @@ jobs:
       - setup-python-venv:
           determined: true
           extras-requires: "tensorflow==2.4.3"
-          extra-requirements-file: "harness/tests/requirements.txt"
+          extra-requirements-file: "harness/tests/requirements/requirements-harness.txt"
           executor: <<pipeline.parameters.docker-image>>
       - run: COVERAGE_FILE=$PWD/test-unit-harness-tf2-pycov make -C harness test-tf2
       - persist_to_workspace:
@@ -1406,7 +1406,7 @@ jobs:
       - setup-python-venv:
           determined: true
           extras-requires: "tensorflow==2.4.3"
-          extra-requirements-file: "harness/tests/requirements.txt"
+          extra-requirements-file: "harness/tests/requirements/requirements-harness.txt"
           executor: <<pipeline.parameters.docker-image>>
       - run: COVERAGE_FILE=$PWD/test-unit-storage-pycov coverage run -m pytest -v --durations=0 --require-secrets -m cloud harness/tests
       - persist_to_workspace:
@@ -1488,7 +1488,7 @@ jobs:
       # Ensure Determined cli can run without installing cli test requirements
       - run: det --help
       - run: pip install setuptools_scm
-      - run: pip install -r harness/tests/requirements.txt
+      - run: pip install -r harness/tests/requirements/requirements-cli.txt
       - run: pip freeze --all
       - run: sh -c "pip check || true"
       - run: pytest harness/tests/cli

--- a/harness/tests/requirements/requirements-cli.txt
+++ b/harness/tests/requirements/requirements-cli.txt
@@ -1,8 +1,4 @@
 # pytest 6.0 has linter-breaking changes
 pytest>=6.0.1
 mypy==0.910
-pytorch_lightning==1.5.9
-deepspeed==0.5.10
-attrdict
 requests_mock
-coverage

--- a/harness/tests/requirements/requirements-harness.txt
+++ b/harness/tests/requirements/requirements-harness.txt
@@ -1,0 +1,8 @@
+# pytest 6.0 has linter-breaking changes
+pytest>=6.0.1
+mypy==0.910
+requests_mock
+coverage
+pytorch_lightning==1.5.9
+deepspeed==0.5.10
+attrdict

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@
 -e deploy
 -e model_hub
 -r docs/requirements.txt
--r harness/tests/requirements.txt
+-r harness/tests/requirements/requirements-harness.txt
 -r model_hub/tests/requirements.txt
 -r e2e_tests/tests/requirements.txt
 


### PR DESCRIPTION
## Description
windows CLI tests broken due to uninstallable deepspeed dependency.  fix by separating out dependencies for cli tests and other harness tests.  

## Test Plan
CLI and harness-unit tests should pass.


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
