### PR TITLE
fix: add pytorch as requirement before deepspeed is installed

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1337,6 +1337,7 @@ jobs:
       - setup-python-venv:
           determined: true
           model-hub: true
+          extras-requires: "torch==1.9.0"
           extra-requirements-file: "requirements.txt"
           executor: <<pipeline.parameters.docker-image>>
       - run: make -C cli check

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ get-deps-%:
 
 .PHONY: get-deps-pip
 get-deps-pip:
+	pip install torch==1.9.0
 	pip install -r requirements.txt
 
 .PHONY: get-deps-go

--- a/harness/tests/requirements/requirements-harness.txt
+++ b/harness/tests/requirements/requirements-harness.txt
@@ -3,7 +3,6 @@ pytest>=6.0.1
 mypy==0.910
 requests_mock
 coverage
-torch==1.9.0
 pytorch_lightning==1.5.9
 deepspeed==0.6.0
 attrdict


### PR DESCRIPTION
## Description
Make sure pytorch is always installed before deepspeed when installing from requirements files.  

`pip install -r requirements.txt` does not guarantee items are installed in order so there may be flaky tests if deepspeed is installed before pytorch.  This PR makes sure to install torch before we install deepspeed when developing locally and for ci.  


## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions about this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
