### PR TITLE
feat: Add endpoints to move projects and experiments [DET-6817]

### DIFF
--- a/e2e_tests/tests/cluster/test_workspace_org.py
+++ b/e2e_tests/tests/cluster/test_workspace_org.py
@@ -5,6 +5,7 @@ import pytest
 from determined.common.api import authentication, bindings, certs, errors
 from determined.common.experimental import session
 from tests import config as conf
+from tests import experiment as exp
 
 
 @pytest.mark.e2e_cpu
@@ -14,8 +15,10 @@ def test_workspace_org() -> None:
     authentication.cli_auth = authentication.Authentication(master_url, try_reauth=True)
     sess = session.Session(master_url, "determined", authentication.cli_auth, certs.cli_cert)
 
-    test_workspaces: List[bindings.v1Workspace] = []
+
+    test_experiments: List[bindings.v1Experiment] = []
     test_projects: List[bindings.v1Project] = []
+    test_workspaces: List[bindings.v1Workspace] = []
 
     try:
         # Uncategorized workspace / project should exist already.
@@ -126,6 +129,18 @@ def test_workspace_org() -> None:
         assert ["_TestEarly", "_TestPatchedProject", "_TestPRJ"] == list(
             map(lambda w: w.name, list_test_6)
         )
+<<<<<<< HEAD
+=======
+
+        # Move a project to another workspace
+        bindings.post_MoveProject(
+            sess,
+            projectId=madeProject.id,
+            body=ww.workspace.id,
+        )
+        get_project = bindings.get_GetProject(sess, id=madeProject.id).project
+        assert get_project.workspaceId == ww.workspace.id
+>>>>>>> 98ff70ecd (code the move endpoint and tests)
 
         # Add a test note to a project.
         note = bindings.v1Note(name="Hello", contents="Hello World")
@@ -145,7 +160,9 @@ def test_workspace_org() -> None:
 
     finally:
         # Clean out test workspaces and projects
-        # Projects must be deleted first
+        # In dependency order:
+        for e in test_experiments:
+            bindings.delete_DeleteExperiment(sess, experimentId=e.id)
         for p in test_projects:
             bindings.delete_DeleteProject(sess, id=p.id)
         for w in test_workspaces:

--- a/e2e_tests/tests/cluster/test_workspace_org.py
+++ b/e2e_tests/tests/cluster/test_workspace_org.py
@@ -5,7 +5,7 @@ import pytest
 from determined.common.api import authentication, bindings, certs, errors
 from determined.common.experimental import session
 from tests import config as conf
-from tests import experiment as exp
+#from tests import experiment as exp
 
 
 @pytest.mark.e2e_cpu
@@ -14,7 +14,6 @@ def test_workspace_org() -> None:
     certs.cli_cert = certs.default_load(master_url)
     authentication.cli_auth = authentication.Authentication(master_url, try_reauth=True)
     sess = session.Session(master_url, "determined", authentication.cli_auth, certs.cli_cert)
-
 
     test_experiments: List[bindings.v1Experiment] = []
     test_projects: List[bindings.v1Project] = []
@@ -129,8 +128,6 @@ def test_workspace_org() -> None:
         assert ["_TestEarly", "_TestPatchedProject", "_TestPRJ"] == list(
             map(lambda w: w.name, list_test_6)
         )
-<<<<<<< HEAD
-=======
 
         # Move a project to another workspace
         bindings.post_MoveProject(
@@ -140,7 +137,6 @@ def test_workspace_org() -> None:
         )
         get_project = bindings.get_GetProject(sess, id=madeProject.id).project
         assert get_project.workspaceId == ww.workspace.id
->>>>>>> 98ff70ecd (code the move endpoint and tests)
 
         # Add a test note to a project.
         note = bindings.v1Note(name="Hello", contents="Hello World")
@@ -159,7 +155,7 @@ def test_workspace_org() -> None:
         assert returned_notes and len(returned_notes) == 2
 
     finally:
-        # Clean out test workspaces and projects
+        # Clean out experiments, projects, workspaces.
         # In dependency order:
         for e in test_experiments:
             bindings.delete_DeleteExperiment(sess, experimentId=e.id)

--- a/e2e_tests/tests/cluster/test_workspace_org.py
+++ b/e2e_tests/tests/cluster/test_workspace_org.py
@@ -40,7 +40,7 @@ def test_workspace_org() -> None:
         test_workspaces.append(made_workspace)
         get_workspace = bindings.get_GetWorkspace(sess, id=made_workspace.id).workspace
         assert get_workspace and get_workspace.name == "_TestOnly"
-        assert not madeWorkspace.immutable and not get_workspace.immutable
+        assert not made_workspace.immutable and not get_workspace.immutable
 
         # Patch the workspace
         w_patch = bindings.v1PatchWorkspace.from_json(made_workspace.to_json())
@@ -81,7 +81,7 @@ def test_workspace_org() -> None:
         test_projects.append(made_project)
         get_project = bindings.get_GetProject(sess, id=made_project.id).project
         assert get_project and get_project.name == "_TestOnly"
-        assert not madeProject.immutable and not get_project.immutable
+        assert not made_project.immutable and not get_project.immutable
 
         # Patch the project
         p_patch = bindings.v1PatchProject.from_json(made_project.to_json())

--- a/e2e_tests/tests/cluster/test_workspace_org.py
+++ b/e2e_tests/tests/cluster/test_workspace_org.py
@@ -5,7 +5,7 @@ import pytest
 from determined.common.api import authentication, bindings, certs, errors
 from determined.common.experimental import session
 from tests import config as conf
-#from tests import experiment as exp
+from tests.experiment import run_basic_test, wait_for_experiment_state
 
 
 @pytest.mark.e2e_cpu
@@ -35,18 +35,18 @@ def test_workspace_org() -> None:
         r3 = bindings.post_PostWorkspace(
             sess, body=bindings.v1PostWorkspaceRequest(name="_TestOnly")
         )
-        madeWorkspace = r3.workspace
-        assert madeWorkspace is not None
-        test_workspaces.append(madeWorkspace)
-        get_workspace = bindings.get_GetWorkspace(sess, id=madeWorkspace.id).workspace
+        made_workspace = r3.workspace
+        assert made_workspace is not None
+        test_workspaces.append(made_workspace)
+        get_workspace = bindings.get_GetWorkspace(sess, id=made_workspace.id).workspace
         assert get_workspace and get_workspace.name == "_TestOnly"
         assert not madeWorkspace.immutable and not get_workspace.immutable
 
         # Patch the workspace
-        w_patch = bindings.v1PatchWorkspace.from_json(madeWorkspace.to_json())
+        w_patch = bindings.v1PatchWorkspace.from_json(made_workspace.to_json())
         w_patch.name = "_TestPatched"
-        bindings.patch_PatchWorkspace(sess, body=w_patch, id=madeWorkspace.id)
-        get_workspace = bindings.get_GetWorkspace(sess, id=madeWorkspace.id).workspace
+        bindings.patch_PatchWorkspace(sess, body=w_patch, id=made_workspace.id)
+        get_workspace = bindings.get_GetWorkspace(sess, id=made_workspace.id).workspace
         assert get_workspace.name == "_TestPatched"
 
         # Sort test and default workspaces.
@@ -73,21 +73,21 @@ def test_workspace_org() -> None:
         # Add a test project to a workspace.
         r4 = bindings.post_PostProject(
             sess,
-            body=bindings.v1PostProjectRequest(name="_TestOnly", workspaceId=madeWorkspace.id),
-            workspaceId=madeWorkspace.id,
+            body=bindings.v1PostProjectRequest(name="_TestOnly", workspaceId=made_workspace.id),
+            workspaceId=made_workspace.id,
         )
-        madeProject = r4.project
-        assert madeProject is not None
-        test_projects.append(madeProject)
-        get_project = bindings.get_GetProject(sess, id=madeProject.id).project
+        made_project = r4.project
+        assert made_project is not None
+        test_projects.append(made_project)
+        get_project = bindings.get_GetProject(sess, id=made_project.id).project
         assert get_project and get_project.name == "_TestOnly"
         assert not madeProject.immutable and not get_project.immutable
 
         # Patch the project
-        p_patch = bindings.v1PatchProject.from_json(madeProject.to_json())
+        p_patch = bindings.v1PatchProject.from_json(made_project.to_json())
         p_patch.name = "_TestPatchedProject"
-        bindings.patch_PatchProject(sess, body=p_patch, id=madeProject.id)
-        get_project = bindings.get_GetProject(sess, id=madeProject.id).project
+        bindings.patch_PatchProject(sess, body=p_patch, id=made_project.id)
+        get_project = bindings.get_GetProject(sess, id=made_project.id).project
         assert get_project.name == "_TestPatchedProject"
 
         # Refuse to patch the default project
@@ -97,23 +97,23 @@ def test_workspace_org() -> None:
         # Sort workspaces' projects.
         p1 = bindings.post_PostProject(
             sess,
-            body=bindings.v1PostProjectRequest(name="_TestPRJ", workspaceId=madeWorkspace.id),
-            workspaceId=madeWorkspace.id,
+            body=bindings.v1PostProjectRequest(name="_TestPRJ", workspaceId=made_workspace.id),
+            workspaceId=made_workspace.id,
         ).project
         p2 = bindings.post_PostProject(
             sess,
-            body=bindings.v1PostProjectRequest(name="_TestEarly", workspaceId=madeWorkspace.id),
-            workspaceId=madeWorkspace.id,
+            body=bindings.v1PostProjectRequest(name="_TestEarly", workspaceId=made_workspace.id),
+            workspaceId=made_workspace.id,
         ).project
         assert p1 and p2
         test_projects += [p1, p2]
-        list_test_4 = bindings.get_GetWorkspaceProjects(sess, id=madeWorkspace.id).projects
+        list_test_4 = bindings.get_GetWorkspaceProjects(sess, id=made_workspace.id).projects
         assert list_test_4 is not None
         assert ["_TestPatchedProject", "_TestPRJ", "_TestEarly"] == list(
             map(lambda w: w.name, list_test_4)
         )
         list_test_5 = bindings.get_GetWorkspaceProjects(
-            sess, id=madeWorkspace.id, orderBy=bindings.v1OrderBy.ORDER_BY_DESC
+            sess, id=made_workspace.id, orderBy=bindings.v1OrderBy.ORDER_BY_DESC
         ).projects
         assert list_test_5 is not None
         assert ["_TestEarly", "_TestPRJ", "_TestPatchedProject"] == list(
@@ -121,7 +121,7 @@ def test_workspace_org() -> None:
         )
         list_test_6 = bindings.get_GetWorkspaceProjects(
             sess,
-            id=madeWorkspace.id,
+            id=made_workspace.id,
             sortBy=bindings.v1GetWorkspaceProjectsRequestSortBy.SORT_BY_NAME,
         ).projects
         assert list_test_6 is not None
@@ -132,10 +132,10 @@ def test_workspace_org() -> None:
         # Move a project to another workspace
         bindings.post_MoveProject(
             sess,
-            projectId=madeProject.id,
+            projectId=made_project.id,
             body=ww.workspace.id,
         )
-        get_project = bindings.get_GetProject(sess, id=madeProject.id).project
+        get_project = bindings.get_GetProject(sess, id=made_project.id).project
         assert get_project.workspaceId == ww.workspace.id
 
         # Add a test note to a project.
@@ -144,15 +144,28 @@ def test_workspace_org() -> None:
         bindings.post_AddProjectNote(
             sess,
             body=note,
-            projectId=madeProject.id,
+            projectId=made_project.id,
         )
         r5 = bindings.post_AddProjectNote(
             sess,
             body=note2,
-            projectId=madeProject.id,
+            projectId=made_project.id,
         )
         returned_notes = r5.notes
         assert returned_notes and len(returned_notes) == 2
+
+        # Create an experiment in the default project and move to a test project.
+        test_exp_id = run_basic_test(
+            conf.fixtures_path("no_op/single.yaml"), conf.fixtures_path("no_op"), 1
+        )
+        test_exp = bindings.get_GetExperiment(sess, experimentId=test_exp_id).experiment
+        test_experiments.append(test_exp)
+        wait_for_experiment_state(test_exp_id, bindings.determinedexperimentv1State.STATE_COMPLETED)
+        assert test_exp.projectId == default_project.id
+        bindings.post_MoveExperiment(sess, experimentId=test_exp_id, body=made_project.id)
+        modified_exp = bindings.get_GetExperiment(sess, experimentId=test_exp_id).experiment
+        assert modified_exp.projectId == made_project.id
+        bindings.post_MoveExperiment(sess, experimentId=test_exp_id, body=default_project.id)
 
     finally:
         # Clean out experiments, projects, workspaces.

--- a/harness/determined/common/api/bindings.py
+++ b/harness/determined/common/api/bindings.py
@@ -1108,6 +1108,7 @@ class v1Experiment:
         labels: "typing.Optional[typing.Sequence[str]]" = None,
         notes: "typing.Optional[str]" = None,
         progress: "typing.Optional[float]" = None,
+        projectId: "typing.Optional[int]" = None,
         resourcePool: "typing.Optional[str]" = None,
     ):
         self.id = id
@@ -1127,6 +1128,7 @@ class v1Experiment:
         self.jobId = jobId
         self.forkedFrom = forkedFrom
         self.progress = progress
+        self.projectId = projectId
 
     @classmethod
     def from_json(cls, obj: Json) -> "v1Experiment":
@@ -1148,6 +1150,7 @@ class v1Experiment:
             jobId=obj["jobId"],
             forkedFrom=obj.get("forkedFrom", None),
             progress=float(obj["progress"]) if obj.get("progress", None) is not None else None,
+            projectId=obj.get("projectId", None),
         )
 
     def to_json(self) -> typing.Any:
@@ -1169,6 +1172,7 @@ class v1Experiment:
             "jobId": self.jobId,
             "forkedFrom": self.forkedFrom if self.forkedFrom is not None else None,
             "progress": dump_float(self.progress) if self.progress is not None else None,
+            "projectId": self.projectId if self.projectId is not None else None,
         }
 
 class v1ExperimentSimulation:
@@ -7417,6 +7421,7 @@ def post_MarkAllocationResourcesDaemon(
 def post_MoveExperiment(
     session: "client.Session",
     *,
+    body: int,
     experimentId: int,
 ) -> None:
     _params = None
@@ -7424,7 +7429,7 @@ def post_MoveExperiment(
         method="POST",
         path=f"/api/v1/experiments/{experimentId}/move",
         params=_params,
-        json=None,
+        json=body,
         data=None,
         headers=None,
         timeout=None,
@@ -7436,6 +7441,7 @@ def post_MoveExperiment(
 def post_MoveProject(
     session: "client.Session",
     *,
+    body: int,
     projectId: int,
 ) -> None:
     _params = None
@@ -7443,7 +7449,7 @@ def post_MoveProject(
         method="POST",
         path=f"/api/v1/projects/{projectId}/move",
         params=_params,
-        json=None,
+        json=body,
         data=None,
         headers=None,
         timeout=None,

--- a/harness/determined/common/api/bindings.py
+++ b/harness/determined/common/api/bindings.py
@@ -7414,6 +7414,44 @@ def post_MarkAllocationResourcesDaemon(
         return
     raise APIHttpError("post_MarkAllocationResourcesDaemon", _resp)
 
+def post_MoveExperiment(
+    session: "client.Session",
+    *,
+    experimentId: int,
+) -> None:
+    _params = None
+    _resp = session._do_request(
+        method="POST",
+        path=f"/api/v1/experiments/{experimentId}/move",
+        params=_params,
+        json=None,
+        data=None,
+        headers=None,
+        timeout=None,
+    )
+    if _resp.status_code == 200:
+        return
+    raise APIHttpError("post_MoveExperiment", _resp)
+
+def post_MoveProject(
+    session: "client.Session",
+    *,
+    projectId: int,
+) -> None:
+    _params = None
+    _resp = session._do_request(
+        method="POST",
+        path=f"/api/v1/projects/{projectId}/move",
+        params=_params,
+        json=None,
+        data=None,
+        headers=None,
+        timeout=None,
+    )
+    if _resp.status_code == 200:
+        return
+    raise APIHttpError("post_MoveProject", _resp)
+
 def patch_PatchExperiment(
     session: "client.Session",
     *,

--- a/harness/determined/common/api/bindings.py
+++ b/harness/determined/common/api/bindings.py
@@ -1097,6 +1097,7 @@ class v1Experiment:
         jobId: str,
         name: str,
         numTrials: int,
+        projectId: int,
         searcherType: str,
         startTime: str,
         state: "determinedexperimentv1State",
@@ -1108,7 +1109,6 @@ class v1Experiment:
         labels: "typing.Optional[typing.Sequence[str]]" = None,
         notes: "typing.Optional[str]" = None,
         progress: "typing.Optional[float]" = None,
-        projectId: "typing.Optional[int]" = None,
         resourcePool: "typing.Optional[str]" = None,
     ):
         self.id = id
@@ -1150,7 +1150,7 @@ class v1Experiment:
             jobId=obj["jobId"],
             forkedFrom=obj.get("forkedFrom", None),
             progress=float(obj["progress"]) if obj.get("progress", None) is not None else None,
-            projectId=obj.get("projectId", None),
+            projectId=obj["projectId"],
         )
 
     def to_json(self) -> typing.Any:
@@ -1172,7 +1172,7 @@ class v1Experiment:
             "jobId": self.jobId,
             "forkedFrom": self.forkedFrom if self.forkedFrom is not None else None,
             "progress": dump_float(self.progress) if self.progress is not None else None,
-            "projectId": self.projectId if self.projectId is not None else None,
+            "projectId": self.projectId,
         }
 
 class v1ExperimentSimulation:

--- a/master/internal/api_experiment.go
+++ b/master/internal/api_experiment.go
@@ -1289,3 +1289,18 @@ func (a *apiServer) GetModelDef(
 
 	return &apiv1.GetModelDefResponse{B64Tgz: b64Tgz}, nil
 }
+
+func (a *apiServer) MoveExperiment(
+	_ context.Context, req *apiv1.MoveExperimentRequest) (*apiv1.MoveExperimentResponse, error) {
+	holder := &experimentv1.Experiment{}
+	err := a.m.db.QueryProto("move_experiment", holder, req.ExperimentId,
+		req.DestinationProjectId)
+
+	if holder.Id == 0 {
+		return nil, errors.Wrapf(err, "experiment (%d) does not exist or not moveable by this user",
+			req.ExperimentId)
+	}
+
+	return &apiv1.MoveExperimentResponse{},
+		errors.Wrapf(err, "error moving experiment (%d)", req.ExperimentId)
+}

--- a/master/internal/api_project.go
+++ b/master/internal/api_project.go
@@ -200,3 +200,18 @@ func (a *apiServer) DeleteProject(
 	return &apiv1.DeleteProjectResponse{},
 		errors.Wrapf(err, "error deleting project (%d)", req.Id)
 }
+
+func (a *apiServer) MoveProject(
+	_ context.Context, req *apiv1.MoveProjectRequest) (*apiv1.MoveProjectResponse, error) {
+	holder := &projectv1.Project{}
+	err := a.m.db.QueryProto("move_project", holder, req.ProjectId,
+		req.DestinationWorkspaceId)
+
+	if holder.Id == 0 {
+		return nil, errors.Wrapf(err, "project (%d) does not exist or not moveable by this user",
+			req.ProjectId)
+	}
+
+	return &apiv1.MoveProjectResponse{},
+		errors.Wrapf(err, "error moving project (%d)", req.ProjectId)
+}

--- a/master/static/srv/get_experiment.sql
+++ b/master/static/srv/get_experiment.sql
@@ -14,6 +14,7 @@ SELECT
     e.progress AS progress,
     e.job_id AS job_id,
     e.parent_id AS forked_from,
+    e.project_id AS project_id,
     u.username AS username
 FROM
     experiments e

--- a/master/static/srv/get_experiments.sql
+++ b/master/static/srv/get_experiments.sql
@@ -42,6 +42,7 @@ WITH page_info AS (
         e.progress AS progress,
         e.job_id AS job_id,
         e.parent_id AS forked_from,
+        e.project_id AS project_id,
         u.username AS username,
         COALESCE(u.display_name, u.username) as display_name
     FROM experiments e

--- a/master/static/srv/move_experiment.sql
+++ b/master/static/srv/move_experiment.sql
@@ -1,0 +1,3 @@
+UPDATE experiments SET project_id = $2
+WHERE experiments.id = $1
+RETURNING experiments.id;

--- a/master/static/srv/move_project.sql
+++ b/master/static/srv/move_project.sql
@@ -1,0 +1,3 @@
+UPDATE projects SET workspace_id = $2
+WHERE projects.id = $1
+RETURNING projects.id;

--- a/proto/src/determined/api/v1/api.proto
+++ b/proto/src/determined/api/v1/api.proto
@@ -1395,8 +1395,8 @@ service Determined {
   // Move a project into a workspace.
   rpc MoveProject(MoveProjectRequest) returns (MoveProjectResponse) {
     option (google.api.http) = {
-      post: "/api/v1/projects/{projectId}/move"
-      body: "destinationWorkspaceId"
+      post: "/api/v1/projects/{project_id}/move"
+      body: "destination_workspace_id"
     };
     option (grpc.gateway.protoc_gen_swagger.options.openapiv2_operation) = {
       tags: "Projects"
@@ -1405,8 +1405,8 @@ service Determined {
   // Move an experiment into a project.
   rpc MoveExperiment(MoveExperimentRequest) returns (MoveExperimentResponse) {
     option (google.api.http) = {
-      post: "/api/v1/experiments/{experimentId}/move"
-      body: "destinationProjectId"
+      post: "/api/v1/experiments/{experiment_id}/move"
+      body: "destination_project_id"
     };
     option (grpc.gateway.protoc_gen_swagger.options.openapiv2_operation) = {
       tags: "Experiments"

--- a/proto/src/determined/api/v1/api.proto
+++ b/proto/src/determined/api/v1/api.proto
@@ -1396,6 +1396,7 @@ service Determined {
   rpc MoveProject(MoveProjectRequest) returns (MoveProjectResponse) {
     option (google.api.http) = {
       post: "/api/v1/projects/{projectId}/move"
+      body: "destinationWorkspaceId"
     };
     option (grpc.gateway.protoc_gen_swagger.options.openapiv2_operation) = {
       tags: "Projects"
@@ -1405,6 +1406,7 @@ service Determined {
   rpc MoveExperiment(MoveExperimentRequest) returns (MoveExperimentResponse) {
     option (google.api.http) = {
       post: "/api/v1/experiments/{experimentId}/move"
+      body: "destinationProjectId"
     };
     option (grpc.gateway.protoc_gen_swagger.options.openapiv2_operation) = {
       tags: "Experiments"

--- a/proto/src/determined/api/v1/api.proto
+++ b/proto/src/determined/api/v1/api.proto
@@ -1392,4 +1392,22 @@ service Determined {
       tags: "Projects"
     };
   }
+  // Move a project into a workspace.
+  rpc MoveProject(MoveProjectRequest) returns (MoveProjectResponse) {
+    option (google.api.http) = {
+      post: "/api/v1/projects/{projectId}/move"
+    };
+    option (grpc.gateway.protoc_gen_swagger.options.openapiv2_operation) = {
+      tags: "Projects"
+    };
+  }
+  // Move an experiment into a project.
+  rpc MoveExperiment(MoveExperimentRequest) returns (MoveExperimentResponse) {
+    option (google.api.http) = {
+      post: "/api/v1/experiments/{experimentId}/move"
+    };
+    option (grpc.gateway.protoc_gen_swagger.options.openapiv2_operation) = {
+      tags: "Experiments"
+    };
+  }
 }

--- a/proto/src/determined/api/v1/experiment.proto
+++ b/proto/src/determined/api/v1/experiment.proto
@@ -550,3 +550,18 @@ message GetModelDefResponse {
   // The base64-encoded, gzipped, tarball.
   string b64_tgz = 1;
 }
+
+// Request to move an experiment into a project.
+message MoveExperimentRequest {
+  option (grpc.gateway.protoc_gen_swagger.options.openapiv2_schema) = {
+    json_schema: { required: [ "destinationProjectId", "experimentId" ] }
+  };
+
+  // The id of the experiment being moved.
+  int32 experimentId = 1;
+  // The id of the new parent project.
+  int32 destinationProjectId = 2;
+}
+
+// Response to MoveExperimentRequest.
+message MoveExperimentResponse {}

--- a/proto/src/determined/api/v1/experiment.proto
+++ b/proto/src/determined/api/v1/experiment.proto
@@ -554,13 +554,13 @@ message GetModelDefResponse {
 // Request to move an experiment into a project.
 message MoveExperimentRequest {
   option (grpc.gateway.protoc_gen_swagger.options.openapiv2_schema) = {
-    json_schema: { required: [ "destinationProjectId", "experimentId" ] }
+    json_schema: { required: [ "destination_project_id", "experiment_id" ] }
   };
 
   // The id of the experiment being moved.
-  int32 experimentId = 1;
+  int32 experiment_id = 1;
   // The id of the new parent project.
-  int32 destinationProjectId = 2;
+  int32 destination_project_id = 2;
 }
 
 // Response to MoveExperimentRequest.

--- a/proto/src/determined/api/v1/project.proto
+++ b/proto/src/determined/api/v1/project.proto
@@ -180,13 +180,13 @@ message DeleteProjectResponse {}
 // Request to move a project into a workspace.
 message MoveProjectRequest {
   option (grpc.gateway.protoc_gen_swagger.options.openapiv2_schema) = {
-    json_schema: { required: [ "destinationWorkspaceId", "projectId" ] }
+    json_schema: { required: [ "destination_workspace_id", "project_id" ] }
   };
 
   // The id of the project being moved.
-  int32 projectId = 1;
+  int32 project_id = 1;
   // The id of the new parent workspace.
-  int32 destinationWorkspaceId = 2;
+  int32 destination_workspace_id = 2;
 }
 
 // Response to MoveProjectRequest.

--- a/proto/src/determined/api/v1/project.proto
+++ b/proto/src/determined/api/v1/project.proto
@@ -176,3 +176,18 @@ message DeleteProjectRequest {
 
 // Response to DeleteProjectRequest.
 message DeleteProjectResponse {}
+
+// Request to move a project into a workspace.
+message MoveProjectRequest {
+  option (grpc.gateway.protoc_gen_swagger.options.openapiv2_schema) = {
+    json_schema: { required: [ "destinationWorkspaceId", "projectId" ] }
+  };
+
+  // The id of the project being moved.
+  int32 projectId = 1;
+  // The id of the new parent workspace.
+  int32 destinationWorkspaceId = 2;
+}
+
+// Response to MoveProjectRequest.
+message MoveProjectResponse {}

--- a/proto/src/determined/experiment/v1/experiment.proto
+++ b/proto/src/determined/experiment/v1/experiment.proto
@@ -53,7 +53,8 @@ message Experiment {
         "job_id",
         "username",
         "job_id",
-        "searcher_type"
+        "searcher_type",
+        "project_id"
       ]
     }
   };

--- a/proto/src/determined/experiment/v1/experiment.proto
+++ b/proto/src/determined/experiment/v1/experiment.proto
@@ -91,6 +91,8 @@ message Experiment {
   google.protobuf.Int32Value forked_from = 16;
   // The current progress of a running experiment.
   google.protobuf.DoubleValue progress = 17;
+  // The id of a project associated with this experiment.
+  int32 project_id = 18;
 }
 
 // PatchExperiment is a partial update to an experiment with only id required.

--- a/proto/src/determined/experiment/v1/experiment.proto
+++ b/proto/src/determined/experiment/v1/experiment.proto
@@ -92,7 +92,7 @@ message Experiment {
   // The current progress of a running experiment.
   google.protobuf.DoubleValue progress = 17;
   // The id of a project associated with this experiment.
-  int32 project_id = 18;
+  int32 project_id = 19;
 }
 
 // PatchExperiment is a partial update to an experiment with only id required.

--- a/webui/react/src/services/api-ts-sdk/api.ts
+++ b/webui/react/src/services/api-ts-sdk/api.ts
@@ -3755,6 +3755,22 @@ export interface V1ModelVersion {
 }
 
 /**
+ * Response to MoveExperimentRequest.
+ * @export
+ * @interface V1MoveExperimentResponse
+ */
+export interface V1MoveExperimentResponse {
+}
+
+/**
+ * Response to MoveProjectRequest.
+ * @export
+ * @interface V1MoveProjectResponse
+ */
+export interface V1MoveProjectResponse {
+}
+
+/**
  * Note is a user comment connected to a project.
  * @export
  * @interface V1Note
@@ -9416,6 +9432,43 @@ export const ExperimentsApiFetchParamCreator = function (configuration?: Configu
         },
         /**
          * 
+         * @summary Move an experiment into a project.
+         * @param {number} experimentId The id of the experiment being moved.
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        moveExperiment(experimentId: number, options: any = {}): FetchArgs {
+            // verify required parameter 'experimentId' is not null or undefined
+            if (experimentId === null || experimentId === undefined) {
+                throw new RequiredError('experimentId','Required parameter experimentId was null or undefined when calling moveExperiment.');
+            }
+            const localVarPath = `/api/v1/experiments/{experimentId}/move`
+                .replace(`{${"experimentId"}}`, encodeURIComponent(String(experimentId)));
+            const localVarUrlObj = url.parse(localVarPath, true);
+            const localVarRequestOptions = Object.assign({ method: 'POST' }, options);
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            // authentication BearerToken required
+            if (configuration && configuration.apiKey) {
+                const localVarApiKeyValue = typeof configuration.apiKey === 'function'
+					? configuration.apiKey("Authorization")
+					: configuration.apiKey;
+                localVarHeaderParameter["Authorization"] = localVarApiKeyValue;
+            }
+
+            localVarUrlObj.query = Object.assign({}, localVarUrlObj.query, localVarQueryParameter, options.query);
+            // fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
+            delete localVarUrlObj.search;
+            localVarRequestOptions.headers = Object.assign({}, localVarHeaderParameter, options.headers);
+
+            return {
+                url: url.format(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         * 
          * @summary Patch an experiment's fields.
          * @param {number} experimentId The id of the experiment.
          * @param {V1PatchExperiment} body Patched experiment attributes.
@@ -10029,6 +10082,25 @@ export const ExperimentsApiFp = function(configuration?: Configuration) {
         },
         /**
          * 
+         * @summary Move an experiment into a project.
+         * @param {number} experimentId The id of the experiment being moved.
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        moveExperiment(experimentId: number, options?: any): (fetch?: FetchAPI, basePath?: string) => Promise<V1MoveExperimentResponse> {
+            const localVarFetchArgs = ExperimentsApiFetchParamCreator(configuration).moveExperiment(experimentId, options);
+            return (fetch: FetchAPI = portableFetch, basePath: string = BASE_PATH) => {
+                return fetch(basePath + localVarFetchArgs.url, localVarFetchArgs.options).then((response) => {
+                    if (response.status >= 200 && response.status < 300) {
+                        return response.json();
+                    } else {
+                        throw response;
+                    }
+                });
+            };
+        },
+        /**
+         * 
          * @summary Patch an experiment's fields.
          * @param {number} experimentId The id of the experiment.
          * @param {V1PatchExperiment} body Patched experiment attributes.
@@ -10340,6 +10412,16 @@ export const ExperimentsApiFactory = function (configuration?: Configuration, fe
         },
         /**
          * 
+         * @summary Move an experiment into a project.
+         * @param {number} experimentId The id of the experiment being moved.
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        moveExperiment(experimentId: number, options?: any) {
+            return ExperimentsApiFp(configuration).moveExperiment(experimentId, options)(fetch, basePath);
+        },
+        /**
+         * 
          * @summary Patch an experiment's fields.
          * @param {number} experimentId The id of the experiment.
          * @param {V1PatchExperiment} body Patched experiment attributes.
@@ -10624,6 +10706,18 @@ export class ExperimentsApi extends BaseAPI {
      */
     public killTrial(id: number, options?: any) {
         return ExperimentsApiFp(this.configuration).killTrial(id, options)(this.fetch, this.basePath);
+    }
+
+    /**
+     * 
+     * @summary Move an experiment into a project.
+     * @param {number} experimentId The id of the experiment being moved.
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof ExperimentsApi
+     */
+    public moveExperiment(experimentId: number, options?: any) {
+        return ExperimentsApiFp(this.configuration).moveExperiment(experimentId, options)(this.fetch, this.basePath);
     }
 
     /**
@@ -15909,6 +16003,43 @@ export const ProjectsApiFetchParamCreator = function (configuration?: Configurat
         },
         /**
          * 
+         * @summary Move a project into a workspace.
+         * @param {number} projectId The id of the project being moved.
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        moveProject(projectId: number, options: any = {}): FetchArgs {
+            // verify required parameter 'projectId' is not null or undefined
+            if (projectId === null || projectId === undefined) {
+                throw new RequiredError('projectId','Required parameter projectId was null or undefined when calling moveProject.');
+            }
+            const localVarPath = `/api/v1/projects/{projectId}/move`
+                .replace(`{${"projectId"}}`, encodeURIComponent(String(projectId)));
+            const localVarUrlObj = url.parse(localVarPath, true);
+            const localVarRequestOptions = Object.assign({ method: 'POST' }, options);
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            // authentication BearerToken required
+            if (configuration && configuration.apiKey) {
+                const localVarApiKeyValue = typeof configuration.apiKey === 'function'
+					? configuration.apiKey("Authorization")
+					: configuration.apiKey;
+                localVarHeaderParameter["Authorization"] = localVarApiKeyValue;
+            }
+
+            localVarUrlObj.query = Object.assign({}, localVarUrlObj.query, localVarQueryParameter, options.query);
+            // fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
+            delete localVarUrlObj.search;
+            localVarRequestOptions.headers = Object.assign({}, localVarHeaderParameter, options.headers);
+
+            return {
+                url: url.format(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         * 
          * @summary Update a project.
          * @param {number} id The id of the project.
          * @param {V1PatchProject} body The desired project fields and values to update.
@@ -16097,6 +16228,25 @@ export const ProjectsApiFp = function(configuration?: Configuration) {
         },
         /**
          * 
+         * @summary Move a project into a workspace.
+         * @param {number} projectId The id of the project being moved.
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        moveProject(projectId: number, options?: any): (fetch?: FetchAPI, basePath?: string) => Promise<V1MoveProjectResponse> {
+            const localVarFetchArgs = ProjectsApiFetchParamCreator(configuration).moveProject(projectId, options);
+            return (fetch: FetchAPI = portableFetch, basePath: string = BASE_PATH) => {
+                return fetch(basePath + localVarFetchArgs.url, localVarFetchArgs.options).then((response) => {
+                    if (response.status >= 200 && response.status < 300) {
+                        return response.json();
+                    } else {
+                        throw response;
+                    }
+                });
+            };
+        },
+        /**
+         * 
          * @summary Update a project.
          * @param {number} id The id of the project.
          * @param {V1PatchProject} body The desired project fields and values to update.
@@ -16197,6 +16347,16 @@ export const ProjectsApiFactory = function (configuration?: Configuration, fetch
         },
         /**
          * 
+         * @summary Move a project into a workspace.
+         * @param {number} projectId The id of the project being moved.
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        moveProject(projectId: number, options?: any) {
+            return ProjectsApiFp(configuration).moveProject(projectId, options)(fetch, basePath);
+        },
+        /**
+         * 
          * @summary Update a project.
          * @param {number} id The id of the project.
          * @param {V1PatchProject} body The desired project fields and values to update.
@@ -16284,6 +16444,18 @@ export class ProjectsApi extends BaseAPI {
      */
     public getProjectExperiments(id: number, sortBy?: 'SORT_BY_UNSPECIFIED' | 'SORT_BY_ID' | 'SORT_BY_DESCRIPTION' | 'SORT_BY_START_TIME' | 'SORT_BY_END_TIME' | 'SORT_BY_STATE' | 'SORT_BY_NUM_TRIALS' | 'SORT_BY_PROGRESS' | 'SORT_BY_USER' | 'SORT_BY_NAME', orderBy?: 'ORDER_BY_UNSPECIFIED' | 'ORDER_BY_ASC' | 'ORDER_BY_DESC', offset?: number, limit?: number, name?: string, description?: string, labels?: Array<string>, archived?: boolean, states?: Array<'STATE_UNSPECIFIED' | 'STATE_ACTIVE' | 'STATE_PAUSED' | 'STATE_STOPPING_COMPLETED' | 'STATE_STOPPING_CANCELED' | 'STATE_STOPPING_ERROR' | 'STATE_COMPLETED' | 'STATE_CANCELED' | 'STATE_ERROR' | 'STATE_DELETED' | 'STATE_DELETING' | 'STATE_DELETE_FAILED' | 'STATE_STOPPING_KILLED'>, users?: Array<string>, options?: any) {
         return ProjectsApiFp(this.configuration).getProjectExperiments(id, sortBy, orderBy, offset, limit, name, description, labels, archived, states, users, options)(this.fetch, this.basePath);
+    }
+
+    /**
+     * 
+     * @summary Move a project into a workspace.
+     * @param {number} projectId The id of the project being moved.
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof ProjectsApi
+     */
+    public moveProject(projectId: number, options?: any) {
+        return ProjectsApiFp(this.configuration).moveProject(projectId, options)(this.fetch, this.basePath);
     }
 
     /**

--- a/webui/react/src/services/api-ts-sdk/api.ts
+++ b/webui/react/src/services/api-ts-sdk/api.ts
@@ -1719,6 +1719,12 @@ export interface V1Experiment {
      * @memberof V1Experiment
      */
     progress?: number;
+    /**
+     * The id of a project associated with this experiment.
+     * @type {number}
+     * @memberof V1Experiment
+     */
+    projectId?: number;
 }
 
 /**
@@ -9434,13 +9440,18 @@ export const ExperimentsApiFetchParamCreator = function (configuration?: Configu
          * 
          * @summary Move an experiment into a project.
          * @param {number} experimentId The id of the experiment being moved.
+         * @param {number} body The id of the new parent project.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        moveExperiment(experimentId: number, options: any = {}): FetchArgs {
+        moveExperiment(experimentId: number, body: number, options: any = {}): FetchArgs {
             // verify required parameter 'experimentId' is not null or undefined
             if (experimentId === null || experimentId === undefined) {
                 throw new RequiredError('experimentId','Required parameter experimentId was null or undefined when calling moveExperiment.');
+            }
+            // verify required parameter 'body' is not null or undefined
+            if (body === null || body === undefined) {
+                throw new RequiredError('body','Required parameter body was null or undefined when calling moveExperiment.');
             }
             const localVarPath = `/api/v1/experiments/{experimentId}/move`
                 .replace(`{${"experimentId"}}`, encodeURIComponent(String(experimentId)));
@@ -9457,10 +9468,14 @@ export const ExperimentsApiFetchParamCreator = function (configuration?: Configu
                 localVarHeaderParameter["Authorization"] = localVarApiKeyValue;
             }
 
+            localVarHeaderParameter['Content-Type'] = 'application/json';
+
             localVarUrlObj.query = Object.assign({}, localVarUrlObj.query, localVarQueryParameter, options.query);
             // fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
             delete localVarUrlObj.search;
             localVarRequestOptions.headers = Object.assign({}, localVarHeaderParameter, options.headers);
+            const needsSerialization = (<any>"number" !== "string") || localVarRequestOptions.headers['Content-Type'] === 'application/json';
+            localVarRequestOptions.body =  needsSerialization ? JSON.stringify(body || {}) : (body || "");
 
             return {
                 url: url.format(localVarUrlObj),
@@ -10084,11 +10099,12 @@ export const ExperimentsApiFp = function(configuration?: Configuration) {
          * 
          * @summary Move an experiment into a project.
          * @param {number} experimentId The id of the experiment being moved.
+         * @param {number} body The id of the new parent project.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        moveExperiment(experimentId: number, options?: any): (fetch?: FetchAPI, basePath?: string) => Promise<V1MoveExperimentResponse> {
-            const localVarFetchArgs = ExperimentsApiFetchParamCreator(configuration).moveExperiment(experimentId, options);
+        moveExperiment(experimentId: number, body: number, options?: any): (fetch?: FetchAPI, basePath?: string) => Promise<V1MoveExperimentResponse> {
+            const localVarFetchArgs = ExperimentsApiFetchParamCreator(configuration).moveExperiment(experimentId, body, options);
             return (fetch: FetchAPI = portableFetch, basePath: string = BASE_PATH) => {
                 return fetch(basePath + localVarFetchArgs.url, localVarFetchArgs.options).then((response) => {
                     if (response.status >= 200 && response.status < 300) {
@@ -10414,11 +10430,12 @@ export const ExperimentsApiFactory = function (configuration?: Configuration, fe
          * 
          * @summary Move an experiment into a project.
          * @param {number} experimentId The id of the experiment being moved.
+         * @param {number} body The id of the new parent project.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        moveExperiment(experimentId: number, options?: any) {
-            return ExperimentsApiFp(configuration).moveExperiment(experimentId, options)(fetch, basePath);
+        moveExperiment(experimentId: number, body: number, options?: any) {
+            return ExperimentsApiFp(configuration).moveExperiment(experimentId, body, options)(fetch, basePath);
         },
         /**
          * 
@@ -10712,12 +10729,13 @@ export class ExperimentsApi extends BaseAPI {
      * 
      * @summary Move an experiment into a project.
      * @param {number} experimentId The id of the experiment being moved.
+     * @param {number} body The id of the new parent project.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof ExperimentsApi
      */
-    public moveExperiment(experimentId: number, options?: any) {
-        return ExperimentsApiFp(this.configuration).moveExperiment(experimentId, options)(this.fetch, this.basePath);
+    public moveExperiment(experimentId: number, body: number, options?: any) {
+        return ExperimentsApiFp(this.configuration).moveExperiment(experimentId, body, options)(this.fetch, this.basePath);
     }
 
     /**
@@ -16005,13 +16023,18 @@ export const ProjectsApiFetchParamCreator = function (configuration?: Configurat
          * 
          * @summary Move a project into a workspace.
          * @param {number} projectId The id of the project being moved.
+         * @param {number} body The id of the new parent workspace.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        moveProject(projectId: number, options: any = {}): FetchArgs {
+        moveProject(projectId: number, body: number, options: any = {}): FetchArgs {
             // verify required parameter 'projectId' is not null or undefined
             if (projectId === null || projectId === undefined) {
                 throw new RequiredError('projectId','Required parameter projectId was null or undefined when calling moveProject.');
+            }
+            // verify required parameter 'body' is not null or undefined
+            if (body === null || body === undefined) {
+                throw new RequiredError('body','Required parameter body was null or undefined when calling moveProject.');
             }
             const localVarPath = `/api/v1/projects/{projectId}/move`
                 .replace(`{${"projectId"}}`, encodeURIComponent(String(projectId)));
@@ -16028,10 +16051,14 @@ export const ProjectsApiFetchParamCreator = function (configuration?: Configurat
                 localVarHeaderParameter["Authorization"] = localVarApiKeyValue;
             }
 
+            localVarHeaderParameter['Content-Type'] = 'application/json';
+
             localVarUrlObj.query = Object.assign({}, localVarUrlObj.query, localVarQueryParameter, options.query);
             // fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
             delete localVarUrlObj.search;
             localVarRequestOptions.headers = Object.assign({}, localVarHeaderParameter, options.headers);
+            const needsSerialization = (<any>"number" !== "string") || localVarRequestOptions.headers['Content-Type'] === 'application/json';
+            localVarRequestOptions.body =  needsSerialization ? JSON.stringify(body || {}) : (body || "");
 
             return {
                 url: url.format(localVarUrlObj),
@@ -16230,11 +16257,12 @@ export const ProjectsApiFp = function(configuration?: Configuration) {
          * 
          * @summary Move a project into a workspace.
          * @param {number} projectId The id of the project being moved.
+         * @param {number} body The id of the new parent workspace.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        moveProject(projectId: number, options?: any): (fetch?: FetchAPI, basePath?: string) => Promise<V1MoveProjectResponse> {
-            const localVarFetchArgs = ProjectsApiFetchParamCreator(configuration).moveProject(projectId, options);
+        moveProject(projectId: number, body: number, options?: any): (fetch?: FetchAPI, basePath?: string) => Promise<V1MoveProjectResponse> {
+            const localVarFetchArgs = ProjectsApiFetchParamCreator(configuration).moveProject(projectId, body, options);
             return (fetch: FetchAPI = portableFetch, basePath: string = BASE_PATH) => {
                 return fetch(basePath + localVarFetchArgs.url, localVarFetchArgs.options).then((response) => {
                     if (response.status >= 200 && response.status < 300) {
@@ -16349,11 +16377,12 @@ export const ProjectsApiFactory = function (configuration?: Configuration, fetch
          * 
          * @summary Move a project into a workspace.
          * @param {number} projectId The id of the project being moved.
+         * @param {number} body The id of the new parent workspace.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        moveProject(projectId: number, options?: any) {
-            return ProjectsApiFp(configuration).moveProject(projectId, options)(fetch, basePath);
+        moveProject(projectId: number, body: number, options?: any) {
+            return ProjectsApiFp(configuration).moveProject(projectId, body, options)(fetch, basePath);
         },
         /**
          * 
@@ -16450,12 +16479,13 @@ export class ProjectsApi extends BaseAPI {
      * 
      * @summary Move a project into a workspace.
      * @param {number} projectId The id of the project being moved.
+     * @param {number} body The id of the new parent workspace.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof ProjectsApi
      */
-    public moveProject(projectId: number, options?: any) {
-        return ProjectsApiFp(this.configuration).moveProject(projectId, options)(this.fetch, this.basePath);
+    public moveProject(projectId: number, body: number, options?: any) {
+        return ProjectsApiFp(this.configuration).moveProject(projectId, body, options)(this.fetch, this.basePath);
     }
 
     /**

--- a/webui/react/src/services/api-ts-sdk/api.ts
+++ b/webui/react/src/services/api-ts-sdk/api.ts
@@ -1724,7 +1724,7 @@ export interface V1Experiment {
      * @type {number}
      * @memberof V1Experiment
      */
-    projectId?: number;
+    projectId: number;
 }
 
 /**


### PR DESCRIPTION
## Description

Add endpoints to move a project between workspaces, or move an experiment between projects.

**This merges into the workspaces_projects feature branch.**

## Test Plan

The automated tests move a project, but do not properly test moving an experiment, there is an issue with how deleting the experiment would work.

## Checklist

- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.