### PR TITLE
fix: keep page from crashing when trial/hyperparameters are not loaded yet [DET-6951]

### DIFF
--- a/webui/react/src/pages/TrialDetails/TrialDetailsHyperparameters.tsx
+++ b/webui/react/src/pages/TrialDetails/TrialDetailsHyperparameters.tsx
@@ -36,6 +36,7 @@ const TrialDetailsHyperparameters: React.FC<Props> = ({ trial }: Props) => {
   ], []);
 
   const dataSource: HyperParameter[] = useMemo(() => {
+    if (trial?.hyperparameters == null) return [];
     return Object.entries(trial.hyperparameters).map(([ hyperparameter, value ]) => {
       return {
         hyperparameter,
@@ -43,7 +44,7 @@ const TrialDetailsHyperparameters: React.FC<Props> = ({ trial }: Props) => {
         value: isObject(value) ? JSON.stringify(value, null, 2) : String(value),
       };
     });
-  }, [ trial.hyperparameters ]);
+  }, [ trial?.hyperparameters ]);
 
   return (
     <div className={css.base}>


### PR DESCRIPTION
## Description

fix: keep page from crashing when trial/hyperparameters are not loaded yet [DET-6951]

## Test Plan

- `cd examples/computer_vision/cifar10_pytorch`

- `det e create distributed.yaml .`

navigate to /experiments/<new_experimentid> and click on hyperparameters before experiment is able to start.

page should not crash


## Commentary (optional)

It looks like it first crops up in [3743](https://github.com/determined-ai/determined/pull/3743), which prevented the loading limbo state.

seems like if there is only one trial for an experiment we shouldn't have to wait for it to start in order to be able to display the hyperparameters, but [this](https://github.com/determined-ai/determined/blob/e35972d83ca67b5fe3b4672248e0db6d940e97b5/webui/react/src/pages/ExperimentDetails/ExperimentSingleTrialTabs.tsx#L64) is unable to fetch. 

more investigation could probably be made into being able to show hyperparams for queued experiments..


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-6951]: https://determinedai.atlassian.net/browse/DET-6951?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ