### PR TITLE
feat: Prevent PATCH/DELETE on default workspace/project [DET-6952]

### DIFF
--- a/harness/determined/common/api/bindings.py
+++ b/harness/determined/common/api/bindings.py
@@ -3954,6 +3954,7 @@ class v1Project:
         self,
         archived: bool,
         id: int,
+        immutable: bool,
         name: str,
         notes: "typing.Sequence[v1Note]",
         numActiveExperiments: int,
@@ -3961,7 +3962,6 @@ class v1Project:
         username: str,
         workspaceId: int,
         description: "typing.Optional[str]" = None,
-        immutable: "typing.Optional[bool]" = None,
         lastExperimentStartedAt: "typing.Optional[str]" = None,
     ):
         self.id = id
@@ -3989,7 +3989,7 @@ class v1Project:
             numActiveExperiments=obj["numActiveExperiments"],
             archived=obj["archived"],
             username=obj["username"],
-            immutable=obj.get("immutable", None),
+            immutable=obj["immutable"],
         )
 
     def to_json(self) -> typing.Any:
@@ -4004,7 +4004,7 @@ class v1Project:
             "numActiveExperiments": self.numActiveExperiments,
             "archived": self.archived,
             "username": self.username,
-            "immutable": self.immutable if self.immutable is not None else None,
+            "immutable": self.immutable,
         }
 
 class v1PutTemplateResponse:
@@ -5594,9 +5594,9 @@ class v1Workspace:
         self,
         archived: bool,
         id: int,
+        immutable: bool,
         name: str,
         username: str,
-        immutable: "typing.Optional[bool]" = None,
     ):
         self.id = id
         self.name = name
@@ -5611,7 +5611,7 @@ class v1Workspace:
             name=obj["name"],
             archived=obj["archived"],
             username=obj["username"],
-            immutable=obj.get("immutable", None),
+            immutable=obj["immutable"],
         )
 
     def to_json(self) -> typing.Any:
@@ -5620,7 +5620,7 @@ class v1Workspace:
             "name": self.name,
             "archived": self.archived,
             "username": self.username,
-            "immutable": self.immutable if self.immutable is not None else None,
+            "immutable": self.immutable,
         }
 
 def post_AckAllocationPreemptionSignal(

--- a/harness/determined/common/api/bindings.py
+++ b/harness/determined/common/api/bindings.py
@@ -3961,6 +3961,7 @@ class v1Project:
         username: str,
         workspaceId: int,
         description: "typing.Optional[str]" = None,
+        immutable: "typing.Optional[bool]" = None,
         lastExperimentStartedAt: "typing.Optional[str]" = None,
     ):
         self.id = id
@@ -3973,6 +3974,7 @@ class v1Project:
         self.numActiveExperiments = numActiveExperiments
         self.archived = archived
         self.username = username
+        self.immutable = immutable
 
     @classmethod
     def from_json(cls, obj: Json) -> "v1Project":
@@ -3987,6 +3989,7 @@ class v1Project:
             numActiveExperiments=obj["numActiveExperiments"],
             archived=obj["archived"],
             username=obj["username"],
+            immutable=obj.get("immutable", None),
         )
 
     def to_json(self) -> typing.Any:
@@ -4001,6 +4004,7 @@ class v1Project:
             "numActiveExperiments": self.numActiveExperiments,
             "archived": self.archived,
             "username": self.username,
+            "immutable": self.immutable if self.immutable is not None else None,
         }
 
 class v1PutTemplateResponse:
@@ -5592,11 +5596,13 @@ class v1Workspace:
         id: int,
         name: str,
         username: str,
+        immutable: "typing.Optional[bool]" = None,
     ):
         self.id = id
         self.name = name
         self.archived = archived
         self.username = username
+        self.immutable = immutable
 
     @classmethod
     def from_json(cls, obj: Json) -> "v1Workspace":
@@ -5605,6 +5611,7 @@ class v1Workspace:
             name=obj["name"],
             archived=obj["archived"],
             username=obj["username"],
+            immutable=obj.get("immutable", None),
         )
 
     def to_json(self) -> typing.Any:
@@ -5613,6 +5620,7 @@ class v1Workspace:
             "name": self.name,
             "archived": self.archived,
             "username": self.username,
+            "immutable": self.immutable if self.immutable is not None else None,
         }
 
 def post_AckAllocationPreemptionSignal(

--- a/master/internal/api_project.go
+++ b/master/internal/api_project.go
@@ -148,6 +148,10 @@ func (a *apiServer) PatchProject(
 		return nil, errors.Errorf("project (%d) is archived and cannot have attributes updated.",
 			currProject.Id)
 	}
+	if currProject.Immutable {
+		return nil, errors.Errorf("project (%v) is immutable and cannot have attributes updated.",
+			currProject.Id)
+	}
 
 	madeChanges := false
 	if req.Project.Name != nil && req.Project.Name.Value != currProject.Name {

--- a/master/internal/api_workspace.go
+++ b/master/internal/api_workspace.go
@@ -156,7 +156,11 @@ func (a *apiServer) PatchWorkspace(
 		return nil, err
 	}
 	if currWorkspace.Archived {
-		return nil, errors.Errorf("workspace (%d) is archived and cannot have attributes updated.",
+		return nil, errors.Errorf("workspace (%v) is archived and cannot have attributes updated.",
+			currWorkspace.Id)
+	}
+	if currWorkspace.Immutable {
+		return nil, errors.Errorf("workspace (%v) is immutable and cannot have attributes updated.",
 			currWorkspace.Id)
 	}
 

--- a/master/static/srv/delete_project.sql
+++ b/master/static/srv/delete_project.sql
@@ -1,4 +1,5 @@
 DELETE FROM projects
 WHERE id = $1
+AND NOT immutable
 AND (user_id = $2 OR $3 IS TRUE)
 RETURNING projects.id;

--- a/master/static/srv/delete_workspace.sql
+++ b/master/static/srv/delete_workspace.sql
@@ -1,4 +1,5 @@
 DELETE FROM workspaces
 WHERE id = $1
+AND NOT immutable
 AND (user_id = $2 OR $3 IS TRUE)
 RETURNING workspaces.id;

--- a/master/static/srv/get_project.sql
+++ b/master/static/srv/get_project.sql
@@ -6,7 +6,7 @@ WITH pe AS (
   FROM experiments
   WHERE project_id = $1
 )
-SELECT p.id, p.name, p.workspace_id, p.description, p.archived, p.notes,
+SELECT p.id, p.name, p.workspace_id, p.description, p.archived, p.immutable, p.notes,
   MAX(pe.num_experiments) AS num_experiments,
   MAX(pe.num_active_experiments) AS num_active_experiments,
   MAX(pe.last_experiment_started_at) AS last_experiment_started_at,

--- a/master/static/srv/get_workspace.sql
+++ b/master/static/srv/get_workspace.sql
@@ -1,4 +1,4 @@
-SELECT w.id, w.name, w.archived, u.username
+SELECT w.id, w.name, w.archived, w.immutable, u.username
 FROM workspaces as w
   LEFT JOIN users as u ON u.id = w.user_id
 WHERE w.id = $1;

--- a/master/static/srv/get_workspace_projects.sql
+++ b/master/static/srv/get_workspace_projects.sql
@@ -2,7 +2,7 @@ WITH pe AS (
   SELECT project_id, state, start_time
   FROM experiments
 )
-SELECT p.id, p.name, p.workspace_id, p.description, p.archived, p.notes,
+SELECT p.id, p.name, p.workspace_id, p.description, p.archived, p.immutable, p.notes,
   SUM(case when pe.project_id = p.id then 1 else 0 end) AS num_experiments,
   SUM(case when pe.project_id = p.id AND pe.state = 'ACTIVE' then 1 else 0 end) AS num_active_experiments,
   MAX(case when pe.project_id = p.id then pe.start_time else TO_TIMESTAMP(0) end) AS last_experiment_started_at,

--- a/master/static/srv/get_workspaces.sql
+++ b/master/static/srv/get_workspaces.sql
@@ -1,4 +1,4 @@
-SELECT w.id, w.name, w.archived, u.username
+SELECT w.id, w.name, w.archived, w.immutable, u.username
 FROM workspaces as w
 LEFT JOIN users as u ON u.id = w.user_id
 WHERE ($1 = '' OR (u.username IN (SELECT unnest(string_to_array($1, ',')))))

--- a/master/static/srv/insert_project.sql
+++ b/master/static/srv/insert_project.sql
@@ -1,8 +1,8 @@
 WITH p AS (
   INSERT INTO projects (name, description, workspace_id, user_id)
   VALUES ($1, $2, $3, $4)
-  RETURNING id, name, description, archived, workspace_id, user_id
+  RETURNING id, name, description, archived, immutable, workspace_id, user_id
 )
-SELECT p.id, p.name, p.description, p.archived, p.workspace_id, u.username
+SELECT p.id, p.name, p.description, p.archived, p.immutable, p.workspace_id, u.username
 FROM p
 JOIN users u on u.id = p.user_id;

--- a/master/static/srv/insert_workspace.sql
+++ b/master/static/srv/insert_workspace.sql
@@ -1,8 +1,8 @@
 WITH w AS (
   INSERT INTO workspaces (name, user_id)
   VALUES ($1, $2)
-  RETURNING id, name, archived, user_id
+  RETURNING id, name, archived, immutable, user_id
 )
-SELECT w.id, w.name, w.archived, u.username
+SELECT w.id, w.name, w.archived, w.immutable, u.username
 FROM w
 JOIN users u on u.id = w.user_id;

--- a/master/static/srv/update_project.sql
+++ b/master/static/srv/update_project.sql
@@ -15,7 +15,7 @@ u AS (
   SELECT username FROM users, p
   WHERE users.id = p.user_id
 )
-SELECT p.id, p.name, p.workspace_id, p.description, p.archived, p.notes,
+SELECT p.id, p.name, p.workspace_id, p.description, p.archived, p.immutable, p.notes,
 pe.last_experiment_started_at, pe.num_experiments, pe.num_active_experiments,
 u.username
 FROM p, pe, u;

--- a/master/static/srv/update_workspace.sql
+++ b/master/static/srv/update_workspace.sql
@@ -7,5 +7,5 @@ u AS (
   SELECT username FROM users, w
   WHERE users.id = w.user_id
 )
-SELECT w.id, w.name, w.archived, u.username
+SELECT w.id, w.name, w.archived, w.immutable, u.username
 FROM w, u;

--- a/proto/src/determined/project/v1/project.proto
+++ b/proto/src/determined/project/v1/project.proto
@@ -58,6 +58,8 @@ message Project {
   bool archived = 9;
   // User who created this project.
   string username = 10;
+  // Whether this project is immutable (default uncategorized project).
+  bool immutable = 11;
 }
 
 // ProjectModel is a checkpoint associated with a project.

--- a/proto/src/determined/project/v1/project.proto
+++ b/proto/src/determined/project/v1/project.proto
@@ -25,14 +25,15 @@ message Project {
   option (grpc.gateway.protoc_gen_swagger.options.openapiv2_schema) = {
     json_schema: {
       required: [
-        "id",
-        "name",
-        "workspace_id",
-        "notes",
-        "num_experiments",
-        "num_active_experiments",
         "archived",
-        "username"
+        "id",
+        "immutable",
+        "name",
+        "notes",
+        "num_active_experiments",
+        "num_experiments",
+        "username",
+        "workspace_id"
       ]
     }
   };

--- a/proto/src/determined/workspace/v1/workspace.proto
+++ b/proto/src/determined/workspace/v1/workspace.proto
@@ -9,7 +9,9 @@ import "google/protobuf/wrappers.proto";
 // Workspace is a named collection of projects.
 message Workspace {
   option (grpc.gateway.protoc_gen_swagger.options.openapiv2_schema) = {
-    json_schema: { required: [ "id", "name", "archived", "username" ] }
+    json_schema: {
+      required: [ "archived", "id", "immutable", "name", "username" ]
+    }
   };
   // The unique id of the workspace.
   int32 id = 1;

--- a/proto/src/determined/workspace/v1/workspace.proto
+++ b/proto/src/determined/workspace/v1/workspace.proto
@@ -21,6 +21,8 @@ message Workspace {
   bool archived = 3;
   // User who created this workspace.
   string username = 4;
+  // Whether this workspace is immutable (default uncategorized workspace).
+  bool immutable = 5;
 }
 
 // PatchWorkspace is a partial update to a workspace with all optional fields.

--- a/webui/react/src/services/api-ts-sdk/api.ts
+++ b/webui/react/src/services/api-ts-sdk/api.ts
@@ -4624,7 +4624,7 @@ export interface V1Project {
      * @type {boolean}
      * @memberof V1Project
      */
-    immutable?: boolean;
+    immutable: boolean;
 }
 
 /**
@@ -6474,7 +6474,7 @@ export interface V1Workspace {
      * @type {boolean}
      * @memberof V1Workspace
      */
-    immutable?: boolean;
+    immutable: boolean;
 }
 
 

--- a/webui/react/src/services/api-ts-sdk/api.ts
+++ b/webui/react/src/services/api-ts-sdk/api.ts
@@ -4619,6 +4619,12 @@ export interface V1Project {
      * @memberof V1Project
      */
     username: string;
+    /**
+     * Whether this project is immutable (default uncategorized project).
+     * @type {boolean}
+     * @memberof V1Project
+     */
+    immutable?: boolean;
 }
 
 /**
@@ -6463,6 +6469,12 @@ export interface V1Workspace {
      * @memberof V1Workspace
      */
     username: string;
+    /**
+     * Whether this workspace is immutable (default uncategorized workspace).
+     * @type {boolean}
+     * @memberof V1Workspace
+     */
+    immutable?: boolean;
 }
 
 


### PR DESCRIPTION
## Description

Handles the special case of immutable workspaces and projects (the default ones created to hold existing experiments). This should prevent PATCH to change their name or DELETE to remove them.  The column already existed but here we're adding it to the proto / API.

I added some lines to the `e2e_test`

## Checklist

- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.