### PR TITLE
fix: Set default project for experiments.project_id [DET-6958]

### DIFF
--- a/master/static/migrations/20220329122139_set_default_exp_project.down.sql
+++ b/master/static/migrations/20220329122139_set_default_exp_project.down.sql
@@ -1,1 +1,2 @@
+ALTER TABLE experiments ALTER COLUMN project_id DROP NOT NULL;
 ALTER TABLE experiments ALTER COLUMN project_id SET DEFAULT NULL;

--- a/master/static/migrations/20220329122139_set_default_exp_project.down.sql
+++ b/master/static/migrations/20220329122139_set_default_exp_project.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE experiments ALTER COLUMN project_id SET DEFAULT NULL;

--- a/master/static/migrations/20220329122139_set_default_exp_project.up.sql
+++ b/master/static/migrations/20220329122139_set_default_exp_project.up.sql
@@ -10,3 +10,6 @@ UPDATE experiments SET project_id = (
   SELECT MIN(id) FROM projects WHERE name = 'Uncategorized'
 )
 WHERE project_id IS NULL;
+
+-- Disallow nulls in the future
+ALTER TABLE experiments ALTER project_id SET NOT NULL;

--- a/master/static/migrations/20220329122139_set_default_exp_project.up.sql
+++ b/master/static/migrations/20220329122139_set_default_exp_project.up.sql
@@ -1,0 +1,12 @@
+-- Set default project (usually 1, but make sure)
+DO $$
+BEGIN
+EXECUTE format('ALTER TABLE experiments ALTER COLUMN project_id SET DEFAULT %L'
+             , (SELECT MIN(id) FROM projects WHERE name = 'Uncategorized'));
+END $$;
+
+-- Update any experiments after the previous release
+UPDATE experiments SET project_id = (
+  SELECT MIN(id) FROM projects WHERE name = 'Uncategorized'
+)
+WHERE project_id IS NULL;


### PR DESCRIPTION
## Description

This updates the experiments table project_id column to have a default value (the ID of the Uncategorized project).

The Uncategorized / default project was created in the same migration as the table was created, so project_id is probably 1, but I wanted to avoid assumptions and errors about the IDs, so I needed to do this `EXECUTE format` query.
It's not possible to do a `WITH (SELECT min(id) from projects)` before `ALTER TABLE ALTER COLUMN...` or use a more conventional `\set variable`, as best I can tell.

## Test Plan

New experiments should have project_id = 1 (or whatever the default project is) instead of NULL.

This should also update recent experiments.

## Checklist

- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.