### PR TITLE
chore: update StorageManager and extend CheckpointContext

### DIFF
--- a/e2e_tests/tests/fixtures/metric_maker/metric_maker.py
+++ b/e2e_tests/tests/fixtures/metric_maker/metric_maker.py
@@ -130,10 +130,10 @@ class MetricMaker(det.TrialController):
                 metadata = {"latest_batch": self.latest_batch}
                 if self.is_chief:
                     with self.context._core.checkpoint.store_path(metadata) as (
-                        storage_id,
                         path,
+                        storage_id,
                     ):
-                        self.save(pathlib.Path(path))
+                        self.save(path)
                         response = {"uuid": storage_id}
                 else:
                     response = {}

--- a/e2e_tests/tests/fixtures/no_op/model_def.py
+++ b/e2e_tests/tests/fixtures/no_op/model_def.py
@@ -114,10 +114,10 @@ class NoOpTrialController(det.TrialController):
                 metadata = {"latest_batch": self.latest_batch}
                 if self.is_chief:
                     with self.context._core.checkpoint.store_path(metadata) as (
-                        storage_id,
                         path,
+                        storage_id,
                     ):
-                        self.save(pathlib.Path(path))
+                        self.save(path)
                     response = {"uuid": storage_id}
                 else:
                     response = {}

--- a/harness/determined/common/storage/cloud.py
+++ b/harness/determined/common/storage/cloud.py
@@ -1,0 +1,30 @@
+import contextlib
+import os
+import pathlib
+import shutil
+from typing import Iterator
+
+from determined.common import storage
+
+
+class CloudStorageManager(storage.StorageManager):
+    @contextlib.contextmanager
+    def restore_path(self, src: str) -> Iterator[pathlib.Path]:
+        dst = os.path.join(self._base_path, src)
+        os.makedirs(dst, exist_ok=True)
+
+        self.download(src, dst)
+
+        try:
+            yield pathlib.Path(dst)
+        finally:
+            shutil.rmtree(dst, ignore_errors=True)
+
+    def post_store_path(self, src: str, dst: str) -> None:
+        """
+        post_store_path uploads the checkpoint to cloud storage and deletes the original files.
+        """
+        try:
+            self.upload(src, dst)
+        finally:
+            shutil.rmtree(src, ignore_errors=True)

--- a/harness/determined/estimator/_estimator_trial.py
+++ b/harness/determined/estimator/_estimator_trial.py
@@ -313,8 +313,8 @@ class DeterminedControlHook(estimator.RunHook):
                             "framework": f"tensorflow-{tf.__version__}",
                             "format": "saved_model",
                         }
-                        with _core.checkpoint.store_path(metadata) as (storage_id, path):
-                            self._checkpoint_model(pathlib.Path(path))
+                        with _core.checkpoint.store_path(metadata) as (path, storage_id):
+                            self._checkpoint_model(path)
                         response = {"uuid": storage_id}
                     else:
                         response = {}
@@ -748,9 +748,9 @@ class EstimatorTrialController(det.TrialController):
             logging.debug(f"Load path set to {self.estimator_dir}.")
 
             # Load WorkloadSequencer state.
-            wlsq_path = os.path.join(load_path, "workload_sequencer.pkl")
-            if self.wlsq is not None and os.path.exists(wlsq_path):
-                with open(wlsq_path, "rb") as f:
+            wlsq_path = load_path / "workload_sequencer.pkl"
+            if self.wlsq is not None and wlsq_path.exists():
+                with wlsq_path.open("rb") as f:
                     self.wlsq.load_state(pickle.load(f))
 
     def compute_validation_metrics(self) -> workload.Response:

--- a/harness/determined/keras/_tf_keras_trial.py
+++ b/harness/determined/keras/_tf_keras_trial.py
@@ -377,7 +377,7 @@ class TFKerasTrialController(det.TrialController):
             with self.context._core.checkpoint.restore_path(
                 self.env.latest_checkpoint
             ) as load_path:
-                self._load(pathlib.Path(load_path))
+                self._load(load_path)
 
         self._configure_callbacks(train_config.callbacks)
 
@@ -829,10 +829,10 @@ class TFKerasTrialController(det.TrialController):
                             "format": "saved_weights",
                         }
                         with self.context._core.checkpoint.store_path(metadata) as (
-                            storage_id,
                             path,
+                            storage_id,
                         ):
-                            self._save_checkpoint(pathlib.Path(path))
+                            self._save_checkpoint(path)
                         response = {"uuid": storage_id}
                     else:
                         response = {}

--- a/harness/determined/pytorch/_pytorch_trial.py
+++ b/harness/determined/pytorch/_pytorch_trial.py
@@ -228,7 +228,7 @@ class PyTorchTrialController(det.TrialController):
                 with self.context._core.checkpoint.restore_path(
                     self.env.latest_checkpoint
                 ) as load_path:
-                    self._load(pathlib.Path(load_path))
+                    self._load(load_path)
 
             if self.context.distributed.size > 1:
                 hvd.broadcast_parameters(self.context._main_model.state_dict(), root_rank=0)
@@ -274,10 +274,10 @@ class PyTorchTrialController(det.TrialController):
                             "format": "pickle",
                         }
                         with self.context._core.checkpoint.store_path(metadata) as (
-                            storage_id,
                             path,
+                            storage_id,
                         ):
-                            self._save(pathlib.Path(path))
+                            self._save(path)
                         response = {"uuid": storage_id}
                     else:
                         response = {}

--- a/harness/tests/storage/test_shared_fs.py
+++ b/harness/tests/storage/test_shared_fs.py
@@ -2,7 +2,7 @@ import os
 import unittest.mock
 import uuid
 from pathlib import Path
-from typing import Dict, List
+from typing import Any, Dict, List
 
 import pytest
 
@@ -63,14 +63,15 @@ def test_validate(manager: storage.SharedFSStorageManager) -> None:
 
 
 def test_validate_read_only_dir(manager: storage.SharedFSStorageManager) -> None:
-    def permission_error(_1: str, _2: str) -> None:
+    def permission_error(_: Any, __: str) -> None:
         raise PermissionError("Permission denied")
 
-    with unittest.mock.patch("builtins.open", permission_error):
-        assert len(os.listdir(manager._base_path)) == 0
-        with pytest.raises(PermissionError, match="Permission denied"):
-            storage.validate_manager(manager)
-        assert len(os.listdir(manager._base_path)) == 1
+    with unittest.mock.patch("pathlib.Path.open", permission_error):
+        with unittest.mock.patch("builtins.open", permission_error):
+            assert len(os.listdir(manager._base_path)) == 0
+            with pytest.raises(PermissionError, match="Permission denied"):
+                storage.validate_manager(manager)
+            assert len(os.listdir(manager._base_path)) == 1
 
 
 @pytest.mark.cloud

--- a/harness/tests/test_gc_harness.py
+++ b/harness/tests/test_gc_harness.py
@@ -1,5 +1,6 @@
 import os
-from pathlib import Path
+import pathlib
+import uuid
 from typing import Any, List
 
 import pytest
@@ -10,7 +11,7 @@ from tests.storage import util as storage_util
 
 
 @pytest.fixture()
-def manager(tmp_path: Path) -> storage.StorageManager:
+def manager(tmp_path: pathlib.Path) -> storage.StorageManager:
     return storage.SharedFSStorageManager(str(tmp_path))
 
 
@@ -18,7 +19,8 @@ def manager(tmp_path: Path) -> storage.StorageManager:
 def to_delete(request: Any, manager: storage.StorageManager) -> List[str]:
     storage_ids = []
     for _ in range(request.param):
-        with manager.store_path() as (storage_id, path):
+        storage_id = str(uuid.uuid4())
+        with manager.store_path(storage_id) as path:
             storage_util.create_checkpoint(path)
             storage_ids.append(storage_id)
 


### PR DESCRIPTION
## Description

- Take checkpointing business logic out of StorageManager; functions now
  operate in terms of src and dst, not storage_id (checkpoint uuid).
  This is not clearly necessary yet, but when we support sharded
  checkpointing we will certainly need to separate the storage layer
  from the checkpointing layer (so as to support multiple storage layer
  calls for a single checkpointing operation).

- Add upload(src,dst) and download(src,dst) to the StorageManager
  interface. Also add unit tests for upload/download.

- Redesign StorageManager to use pathlib.Path everywhere, which makes
  the src/dst distinction a bit clearer.

- Introduce CloudStorageManager, which defines restore_path() and
  post_store_path() for all cloud-based storage managers in terms of
  upload. This saves a good chunk of duplicate code.

- Settle on argument ordering; be consistent with (src,dst) everywhere.

- Move checkpointing business logic to core.CheckpointContext and
  use that everywhere.

- (TODO, not this pr): add sharding extensions to core.Checkpointing.

## Test plan

I added unit tests for upload/download.