### PR TITLE
feat: CLI supports Workspaces [DET-6819]

### DIFF
--- a/harness/determined/cli/__init__.py
+++ b/harness/determined/cli/__init__.py
@@ -15,4 +15,5 @@ from . import (
     tensorboard,
     trial,
     user,
+    workspace,
 )

--- a/harness/determined/cli/cli.py
+++ b/harness/determined/cli/cli.py
@@ -35,6 +35,7 @@ from determined.cli.trial import args_description as trial_args_description
 from determined.cli.user import args_description as user_args_description
 from determined.cli.version import args_description as version_args_description
 from determined.cli.version import check_version
+from determined.cli.workspace import args_description as workspace_args_description
 from determined.common import api, yaml
 from determined.common.api import authentication, certs
 from determined.common.check import check_not_none
@@ -147,6 +148,7 @@ all_args_description = (
     + remote_args_description
     + user_args_description
     + version_args_description
+    + workspace_args_description
     + auth_args_description
     + oauth_args_description
 )

--- a/harness/determined/cli/workspace.py
+++ b/harness/determined/cli/workspace.py
@@ -188,7 +188,6 @@ args_description = [
                     ),
                     Arg("--json", action="store_true", help="print as JSON"),
                 ],
-                is_default=True,
             ),
             Cmd(
                 "create",

--- a/harness/determined/cli/workspace.py
+++ b/harness/determined/cli/workspace.py
@@ -1,0 +1,110 @@
+import json
+from argparse import Namespace
+from typing import Any, List
+
+from determined.common import api
+from determined.common.api import authentication, bindings
+from determined.common.api.bindings import v1Project, v1Workspace
+from determined.common.declarative_argparse import Arg, Cmd
+from determined.common.experimental import Determined, session
+
+from . import render
+
+
+def d_session(args: Namespace) -> session.Session:
+    d = Determined(args.master, None)
+    return d._session
+
+
+def render_workspace(workspace: v1Workspace) -> None:
+    table = [
+        ["ID", workspace.id],
+        ["Name", workspace.name],
+    ]
+    headers, values = zip(*table)  # type: ignore
+    render.tabulate_or_csv(headers, [values], False)
+
+
+def render_project(project: v1Project) -> None:
+    table = [
+        ["ID", project.id],
+        ["Name", project.name],
+        ["# Experiments", project.num_experiments],
+        ["# Active Experiments", project.num_active_experiments],
+    ]
+    headers, values = zip(*table)  # type: ignore
+    render.tabulate_or_csv(headers, [values], False)
+
+
+def list_workspaces(args: Namespace) -> None:
+    sess = d_session(args)
+    # limit, name, offset, users
+    orderArg = bindings.v1OrderBy[f"ORDER_BY_{args.order_by.upper()}"]
+    sortArg = bindings.v1GetWorkspacesRequestSortBy[f"SORT_BY_{args.sort_by.upper()}"]
+    workspaces = bindings.get_GetWorkspaces(sess, orderBy=orderArg, sortBy=sortArg).workspaces
+    if args.json:
+        print(json.dumps([w.to_json() for w in workspaces], indent=2))
+    else:
+        headers = ["ID", "Name"]
+        values = [
+            [
+                w.id,
+                w.name,
+            ]
+            for w in workspaces
+        ]
+        render.tabulate_or_csv(headers, values, False)
+
+
+def create_workspace(args: Namespace) -> None:
+    sess = d_session(args)
+    content = bindings.v1PostWorkspaceRequest(args.name)
+    w = bindings.post_PostWorkspace(sess, body=content).workspace
+
+    if args.json:
+        print(json.dumps(w.to_json(), indent=2))
+    else:
+        render_workspace(w)
+
+
+args_description = [
+    Cmd(
+        "w|orkspace",
+        None,
+        "manage workspaces",
+        [
+            Cmd(
+                "list",
+                list_workspaces,
+                "list all workspaces",
+                [
+                    Arg(
+                        "--sort-by",
+                        type=str,
+                        choices=["id", "name"],
+                        default="id",
+                        help="sort workspaces by the given field",
+                    ),
+                    Arg(
+                        "--order-by",
+                        type=str,
+                        choices=["asc", "desc"],
+                        default="asc",
+                        help="order workspaces in either ascending or descending order",
+                    ),
+                    Arg("--json", action="store_true", help="print as JSON"),
+                ],
+                is_default=True,
+            ),
+            Cmd(
+                "create",
+                create_workspace,
+                "create workspace",
+                [
+                    Arg("name", type=str, help="unique name of the workspace"),
+                    Arg("--json", action="store_true", help="print as JSON"),
+                ],
+            ),
+        ],
+    )
+]  # type: List[Any]

--- a/harness/determined/cli/workspace.py
+++ b/harness/determined/cli/workspace.py
@@ -2,50 +2,46 @@ import json
 from argparse import Namespace
 from typing import Any, List
 
-from determined.common import api
+from determined.cli.session import setup_session
 from determined.common.api import authentication, bindings
 from determined.common.api.bindings import v1Project, v1Workspace
 from determined.common.declarative_argparse import Arg, Cmd
-from determined.common.experimental import Determined, session
 
 from . import render
 
-
-def d_session(args: Namespace) -> session.Session:
-    d = Determined(args.master, None)
-    return d._session
+PROJECT_HEADERS = ["ID", "Name", "# Experiments", "# Active Experiments"]
+WORKSPACE_HEADERS = ["ID", "Name"]
 
 
 def render_workspace(workspace: v1Workspace) -> None:
-    table = [
-        ["ID", workspace.id],
-        ["Name", workspace.name],
+    values = [
+        workspace.id,
+        workspace.name,
     ]
-    headers, values = zip(*table)  # type: ignore
-    render.tabulate_or_csv(headers, [values], False)
+    render.tabulate_or_csv(WORKSPACE_HEADERS, [values], False)
 
 
 def render_project(project: v1Project) -> None:
-    table = [
-        ["ID", project.id],
-        ["Name", project.name],
-        ["# Experiments", project.num_experiments],
-        ["# Active Experiments", project.num_active_experiments],
+    values = [
+        project.id,
+        project.name,
+        project.numExperiments,
+        project.numActiveExperiments,
     ]
-    headers, values = zip(*table)  # type: ignore
-    render.tabulate_or_csv(headers, [values], False)
+    render.tabulate_or_csv(PROJECT_HEADERS, [values], False)
 
 
+@authentication.required
 def list_workspaces(args: Namespace) -> None:
-    sess = d_session(args)
     # limit, name, offset, users
     orderArg = bindings.v1OrderBy[f"ORDER_BY_{args.order_by.upper()}"]
     sortArg = bindings.v1GetWorkspacesRequestSortBy[f"SORT_BY_{args.sort_by.upper()}"]
-    workspaces = bindings.get_GetWorkspaces(sess, orderBy=orderArg, sortBy=sortArg).workspaces
+    workspaces = bindings.get_GetWorkspaces(
+        setup_session(args), orderBy=orderArg, sortBy=sortArg
+    ).workspaces
     if args.json:
         print(json.dumps([w.to_json() for w in workspaces], indent=2))
     else:
-        headers = ["ID", "Name"]
         values = [
             [
                 w.id,
@@ -53,13 +49,73 @@ def list_workspaces(args: Namespace) -> None:
             ]
             for w in workspaces
         ]
-        render.tabulate_or_csv(headers, values, False)
+        render.tabulate_or_csv(WORKSPACE_HEADERS, values, False)
 
 
+@authentication.required
+def list_workspace_projects(args: Namespace) -> None:
+    orderArg = bindings.v1OrderBy[f"ORDER_BY_{args.order_by.upper()}"]
+    sortArg = bindings.v1GetWorkspaceProjectsRequestSortBy[f"SORT_BY_{args.sort_by.upper()}"]
+    projects = bindings.get_GetWorkspaceProjects(
+        setup_session(args), id=args.id, orderBy=orderArg, sortBy=sortArg
+    ).projects
+    if args.json:
+        print(json.dumps([p.to_json() for p in projects], indent=2))
+    else:
+        values = [
+            [
+                p.id,
+                p.name,
+                p.numExperiments,
+                p.numActiveExperiments,
+            ]
+            for p in projects
+        ]
+        render.tabulate_or_csv(PROJECT_HEADERS, values, False)
+
+
+@authentication.required
 def create_workspace(args: Namespace) -> None:
-    sess = d_session(args)
     content = bindings.v1PostWorkspaceRequest(args.name)
-    w = bindings.post_PostWorkspace(sess, body=content).workspace
+    w = bindings.post_PostWorkspace(setup_session(args), body=content).workspace
+
+    if args.json:
+        print(json.dumps(w.to_json(), indent=2))
+    else:
+        render_workspace(w)
+
+
+@authentication.required
+def describe_workspace(args: Namespace) -> None:
+    w = bindings.get_GetWorkspace(setup_session(args), id=args.id).workspace
+    if args.json:
+        print(json.dumps(w.to_json(), indent=2))
+    else:
+        render_workspace(w)
+        print("\nAssociated Projects")
+        args.order_by = "asc"
+        args.sort_by = "id"
+        list_workspace_projects(args)
+
+
+@authentication.required
+def delete_workspace(args: Namespace) -> None:
+    if args.yes or render.yes_or_no(
+        "Deleting a workspace will result in the unrecoverable \n"
+        "deletion of all associated projects. For a recoverable \n"
+        "alternative, see the 'archive' command. Do you still \n"
+        "wish to proceed?"
+    ):
+        bindings.delete_DeleteWorkspace(setup_session(args), id=args.id)
+        print("Successfully deleted workspace {}.".format(args.id))
+    else:
+        print("Aborting workspace deletion.")
+
+
+@authentication.required
+def edit_workspace(args: Namespace) -> None:
+    content = bindings.v1PatchWorkspace(name=args.name)
+    w = bindings.patch_PatchWorkspace(setup_session(args), body=content, id=args.id).workspace
 
     if args.json:
         print(json.dumps(w.to_json(), indent=2))
@@ -97,11 +153,68 @@ args_description = [
                 is_default=True,
             ),
             Cmd(
+                "list-projects",
+                list_workspace_projects,
+                "list the projects associated with a workspace",
+                [
+                    Arg("id", type=int, help="unique id of the workspace"),
+                    Arg(
+                        "--sort-by",
+                        type=str,
+                        choices=["id", "name"],
+                        default="id",
+                        help="sort workspaces by the given field",
+                    ),
+                    Arg(
+                        "--order-by",
+                        type=str,
+                        choices=["asc", "desc"],
+                        default="asc",
+                        help="order workspaces in either ascending or descending order",
+                    ),
+                    Arg("--json", action="store_true", help="print as JSON"),
+                ],
+                is_default=True,
+            ),
+            Cmd(
                 "create",
                 create_workspace,
                 "create workspace",
                 [
                     Arg("name", type=str, help="unique name of the workspace"),
+                    Arg("--json", action="store_true", help="print as JSON"),
+                ],
+            ),
+            Cmd(
+                "delete",
+                delete_workspace,
+                "delete workspace",
+                [
+                    Arg("id", type=int, help="unique ID of the workspace"),
+                    Arg(
+                        "--yes",
+                        action="store_true",
+                        default=False,
+                        help="automatically answer yes to prompts",
+                    ),
+                ],
+            ),
+            Cmd(
+                "describe",
+                describe_workspace,
+                "describe workspace",
+                [
+                    Arg("id", type=int, help="unique ID of the workspace"),
+                    Arg("--json", action="store_true", help="print as JSON"),
+                ],
+            ),
+            Cmd(
+                "edit",
+                edit_workspace,
+                "edit workspace",
+                [
+                    Arg("id", type=str, help="unique ID of the workspace"),
+                    Arg("name", type=str, help="new name of the workspace"),
                     Arg("--json", action="store_true", help="print as JSON"),
                 ],
             ),

--- a/harness/determined/common/api/bindings.py
+++ b/harness/determined/common/api/bindings.py
@@ -2316,6 +2316,7 @@ class v1GetWorkspaceProjectsRequestSortBy(enum.Enum):
     SORT_BY_LAST_EXPERIMENT_START_TIME = "SORT_BY_LAST_EXPERIMENT_START_TIME"
     SORT_BY_NAME = "SORT_BY_NAME"
     SORT_BY_DESCRIPTION = "SORT_BY_DESCRIPTION"
+    SORT_BY_ID = "SORT_BY_ID"
 
 class v1GetWorkspaceProjectsResponse:
     def __init__(

--- a/master/internal/api_workspace.go
+++ b/master/internal/api_workspace.go
@@ -49,6 +49,7 @@ func (a *apiServer) GetWorkspaceProjects(ctx context.Context,
 		apiv1.GetWorkspaceProjectsRequest_SORT_BY_UNSPECIFIED:   "id",
 		apiv1.GetWorkspaceProjectsRequest_SORT_BY_CREATION_TIME: "created_at",
 		startTime: "last_experiment_started_at",
+		apiv1.GetWorkspaceProjectsRequest_SORT_BY_ID:          "id",
 		apiv1.GetWorkspaceProjectsRequest_SORT_BY_NAME:        "name",
 		apiv1.GetWorkspaceProjectsRequest_SORT_BY_DESCRIPTION: "description",
 	}

--- a/master/internal/api_workspace.go
+++ b/master/internal/api_workspace.go
@@ -101,6 +101,7 @@ func (a *apiServer) GetWorkspaces(
 	// Construct the ordering expression.
 	sortColMap := map[apiv1.GetWorkspacesRequest_SortBy]string{
 		apiv1.GetWorkspacesRequest_SORT_BY_UNSPECIFIED: "id",
+		apiv1.GetWorkspacesRequest_SORT_BY_ID:          "id",
 		apiv1.GetWorkspacesRequest_SORT_BY_NAME:        "name",
 	}
 	orderByMap := map[apiv1.OrderBy]string{

--- a/proto/src/determined/api/v1/workspace.proto
+++ b/proto/src/determined/api/v1/workspace.proto
@@ -47,6 +47,8 @@ message GetWorkspaceProjectsRequest {
     SORT_BY_NAME = 3;
     // Returns projects sorted by description.
     SORT_BY_DESCRIPTION = 4;
+    // Returns projects sorted by ID.
+    SORT_BY_ID = 5;
   }
 
   // Sort the projects by the given field.

--- a/webui/react/src/services/api-ts-sdk/api.ts
+++ b/webui/react/src/services/api-ts-sdk/api.ts
@@ -2849,7 +2849,7 @@ export interface V1GetUsersResponse {
 }
 
 /**
- * Sort associated projects by the given field.   - SORT_BY_UNSPECIFIED: Returns projects in an unsorted list.  - SORT_BY_CREATION_TIME: Returns projects sorted by time that they were created.  - SORT_BY_LAST_EXPERIMENT_START_TIME: Returns projects sorted by most recent start of an experiment.  - SORT_BY_NAME: Returns projects sorted by name.  - SORT_BY_DESCRIPTION: Returns projects sorted by description.
+ * Sort associated projects by the given field.   - SORT_BY_UNSPECIFIED: Returns projects in an unsorted list.  - SORT_BY_CREATION_TIME: Returns projects sorted by time that they were created.  - SORT_BY_LAST_EXPERIMENT_START_TIME: Returns projects sorted by most recent start of an experiment.  - SORT_BY_NAME: Returns projects sorted by name.  - SORT_BY_DESCRIPTION: Returns projects sorted by description.  - SORT_BY_ID: Returns projects sorted by ID.
  * @export
  * @enum {string}
  */
@@ -2858,7 +2858,8 @@ export enum V1GetWorkspaceProjectsRequestSortBy {
     CREATIONTIME = <any> 'SORT_BY_CREATION_TIME',
     LASTEXPERIMENTSTARTTIME = <any> 'SORT_BY_LAST_EXPERIMENT_START_TIME',
     NAME = <any> 'SORT_BY_NAME',
-    DESCRIPTION = <any> 'SORT_BY_DESCRIPTION'
+    DESCRIPTION = <any> 'SORT_BY_DESCRIPTION',
+    ID = <any> 'SORT_BY_ID'
 }
 
 /**
@@ -19363,7 +19364,7 @@ export const WorkspacesApiFetchParamCreator = function (configuration?: Configur
          * 
          * @summary Get projects associated with a workspace.
          * @param {number} id The id of the workspace.
-         * @param {'SORT_BY_UNSPECIFIED' | 'SORT_BY_CREATION_TIME' | 'SORT_BY_LAST_EXPERIMENT_START_TIME' | 'SORT_BY_NAME' | 'SORT_BY_DESCRIPTION'} [sortBy] Sort the projects by the given field.   - SORT_BY_UNSPECIFIED: Returns projects in an unsorted list.  - SORT_BY_CREATION_TIME: Returns projects sorted by time that they were created.  - SORT_BY_LAST_EXPERIMENT_START_TIME: Returns projects sorted by most recent start of an experiment.  - SORT_BY_NAME: Returns projects sorted by name.  - SORT_BY_DESCRIPTION: Returns projects sorted by description.
+         * @param {'SORT_BY_UNSPECIFIED' | 'SORT_BY_CREATION_TIME' | 'SORT_BY_LAST_EXPERIMENT_START_TIME' | 'SORT_BY_NAME' | 'SORT_BY_DESCRIPTION' | 'SORT_BY_ID'} [sortBy] Sort the projects by the given field.   - SORT_BY_UNSPECIFIED: Returns projects in an unsorted list.  - SORT_BY_CREATION_TIME: Returns projects sorted by time that they were created.  - SORT_BY_LAST_EXPERIMENT_START_TIME: Returns projects sorted by most recent start of an experiment.  - SORT_BY_NAME: Returns projects sorted by name.  - SORT_BY_DESCRIPTION: Returns projects sorted by description.  - SORT_BY_ID: Returns projects sorted by ID.
          * @param {'ORDER_BY_UNSPECIFIED' | 'ORDER_BY_ASC' | 'ORDER_BY_DESC'} [orderBy] Order projects in either ascending or descending order.   - ORDER_BY_UNSPECIFIED: Returns records in no specific order.  - ORDER_BY_ASC: Returns records in ascending order.  - ORDER_BY_DESC: Returns records in descending order.
          * @param {number} [offset] Skip the number of projects before returning results. Negative values denote number of projects to skip from the end before returning results.
          * @param {number} [limit] Limit the number of projects. A value of 0 denotes no limit.
@@ -19373,7 +19374,7 @@ export const WorkspacesApiFetchParamCreator = function (configuration?: Configur
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        getWorkspaceProjects(id: number, sortBy?: 'SORT_BY_UNSPECIFIED' | 'SORT_BY_CREATION_TIME' | 'SORT_BY_LAST_EXPERIMENT_START_TIME' | 'SORT_BY_NAME' | 'SORT_BY_DESCRIPTION', orderBy?: 'ORDER_BY_UNSPECIFIED' | 'ORDER_BY_ASC' | 'ORDER_BY_DESC', offset?: number, limit?: number, name?: string, archived?: boolean, users?: Array<string>, options: any = {}): FetchArgs {
+        getWorkspaceProjects(id: number, sortBy?: 'SORT_BY_UNSPECIFIED' | 'SORT_BY_CREATION_TIME' | 'SORT_BY_LAST_EXPERIMENT_START_TIME' | 'SORT_BY_NAME' | 'SORT_BY_DESCRIPTION' | 'SORT_BY_ID', orderBy?: 'ORDER_BY_UNSPECIFIED' | 'ORDER_BY_ASC' | 'ORDER_BY_DESC', offset?: number, limit?: number, name?: string, archived?: boolean, users?: Array<string>, options: any = {}): FetchArgs {
             // verify required parameter 'id' is not null or undefined
             if (id === null || id === undefined) {
                 throw new RequiredError('id','Required parameter id was null or undefined when calling getWorkspaceProjects.');
@@ -19634,7 +19635,7 @@ export const WorkspacesApiFp = function(configuration?: Configuration) {
          * 
          * @summary Get projects associated with a workspace.
          * @param {number} id The id of the workspace.
-         * @param {'SORT_BY_UNSPECIFIED' | 'SORT_BY_CREATION_TIME' | 'SORT_BY_LAST_EXPERIMENT_START_TIME' | 'SORT_BY_NAME' | 'SORT_BY_DESCRIPTION'} [sortBy] Sort the projects by the given field.   - SORT_BY_UNSPECIFIED: Returns projects in an unsorted list.  - SORT_BY_CREATION_TIME: Returns projects sorted by time that they were created.  - SORT_BY_LAST_EXPERIMENT_START_TIME: Returns projects sorted by most recent start of an experiment.  - SORT_BY_NAME: Returns projects sorted by name.  - SORT_BY_DESCRIPTION: Returns projects sorted by description.
+         * @param {'SORT_BY_UNSPECIFIED' | 'SORT_BY_CREATION_TIME' | 'SORT_BY_LAST_EXPERIMENT_START_TIME' | 'SORT_BY_NAME' | 'SORT_BY_DESCRIPTION' | 'SORT_BY_ID'} [sortBy] Sort the projects by the given field.   - SORT_BY_UNSPECIFIED: Returns projects in an unsorted list.  - SORT_BY_CREATION_TIME: Returns projects sorted by time that they were created.  - SORT_BY_LAST_EXPERIMENT_START_TIME: Returns projects sorted by most recent start of an experiment.  - SORT_BY_NAME: Returns projects sorted by name.  - SORT_BY_DESCRIPTION: Returns projects sorted by description.  - SORT_BY_ID: Returns projects sorted by ID.
          * @param {'ORDER_BY_UNSPECIFIED' | 'ORDER_BY_ASC' | 'ORDER_BY_DESC'} [orderBy] Order projects in either ascending or descending order.   - ORDER_BY_UNSPECIFIED: Returns records in no specific order.  - ORDER_BY_ASC: Returns records in ascending order.  - ORDER_BY_DESC: Returns records in descending order.
          * @param {number} [offset] Skip the number of projects before returning results. Negative values denote number of projects to skip from the end before returning results.
          * @param {number} [limit] Limit the number of projects. A value of 0 denotes no limit.
@@ -19644,7 +19645,7 @@ export const WorkspacesApiFp = function(configuration?: Configuration) {
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        getWorkspaceProjects(id: number, sortBy?: 'SORT_BY_UNSPECIFIED' | 'SORT_BY_CREATION_TIME' | 'SORT_BY_LAST_EXPERIMENT_START_TIME' | 'SORT_BY_NAME' | 'SORT_BY_DESCRIPTION', orderBy?: 'ORDER_BY_UNSPECIFIED' | 'ORDER_BY_ASC' | 'ORDER_BY_DESC', offset?: number, limit?: number, name?: string, archived?: boolean, users?: Array<string>, options?: any): (fetch?: FetchAPI, basePath?: string) => Promise<V1GetWorkspaceProjectsResponse> {
+        getWorkspaceProjects(id: number, sortBy?: 'SORT_BY_UNSPECIFIED' | 'SORT_BY_CREATION_TIME' | 'SORT_BY_LAST_EXPERIMENT_START_TIME' | 'SORT_BY_NAME' | 'SORT_BY_DESCRIPTION' | 'SORT_BY_ID', orderBy?: 'ORDER_BY_UNSPECIFIED' | 'ORDER_BY_ASC' | 'ORDER_BY_DESC', offset?: number, limit?: number, name?: string, archived?: boolean, users?: Array<string>, options?: any): (fetch?: FetchAPI, basePath?: string) => Promise<V1GetWorkspaceProjectsResponse> {
             const localVarFetchArgs = WorkspacesApiFetchParamCreator(configuration).getWorkspaceProjects(id, sortBy, orderBy, offset, limit, name, archived, users, options);
             return (fetch: FetchAPI = portableFetch, basePath: string = BASE_PATH) => {
                 return fetch(basePath + localVarFetchArgs.url, localVarFetchArgs.options).then((response) => {
@@ -19753,7 +19754,7 @@ export const WorkspacesApiFactory = function (configuration?: Configuration, fet
          * 
          * @summary Get projects associated with a workspace.
          * @param {number} id The id of the workspace.
-         * @param {'SORT_BY_UNSPECIFIED' | 'SORT_BY_CREATION_TIME' | 'SORT_BY_LAST_EXPERIMENT_START_TIME' | 'SORT_BY_NAME' | 'SORT_BY_DESCRIPTION'} [sortBy] Sort the projects by the given field.   - SORT_BY_UNSPECIFIED: Returns projects in an unsorted list.  - SORT_BY_CREATION_TIME: Returns projects sorted by time that they were created.  - SORT_BY_LAST_EXPERIMENT_START_TIME: Returns projects sorted by most recent start of an experiment.  - SORT_BY_NAME: Returns projects sorted by name.  - SORT_BY_DESCRIPTION: Returns projects sorted by description.
+         * @param {'SORT_BY_UNSPECIFIED' | 'SORT_BY_CREATION_TIME' | 'SORT_BY_LAST_EXPERIMENT_START_TIME' | 'SORT_BY_NAME' | 'SORT_BY_DESCRIPTION' | 'SORT_BY_ID'} [sortBy] Sort the projects by the given field.   - SORT_BY_UNSPECIFIED: Returns projects in an unsorted list.  - SORT_BY_CREATION_TIME: Returns projects sorted by time that they were created.  - SORT_BY_LAST_EXPERIMENT_START_TIME: Returns projects sorted by most recent start of an experiment.  - SORT_BY_NAME: Returns projects sorted by name.  - SORT_BY_DESCRIPTION: Returns projects sorted by description.  - SORT_BY_ID: Returns projects sorted by ID.
          * @param {'ORDER_BY_UNSPECIFIED' | 'ORDER_BY_ASC' | 'ORDER_BY_DESC'} [orderBy] Order projects in either ascending or descending order.   - ORDER_BY_UNSPECIFIED: Returns records in no specific order.  - ORDER_BY_ASC: Returns records in ascending order.  - ORDER_BY_DESC: Returns records in descending order.
          * @param {number} [offset] Skip the number of projects before returning results. Negative values denote number of projects to skip from the end before returning results.
          * @param {number} [limit] Limit the number of projects. A value of 0 denotes no limit.
@@ -19763,7 +19764,7 @@ export const WorkspacesApiFactory = function (configuration?: Configuration, fet
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        getWorkspaceProjects(id: number, sortBy?: 'SORT_BY_UNSPECIFIED' | 'SORT_BY_CREATION_TIME' | 'SORT_BY_LAST_EXPERIMENT_START_TIME' | 'SORT_BY_NAME' | 'SORT_BY_DESCRIPTION', orderBy?: 'ORDER_BY_UNSPECIFIED' | 'ORDER_BY_ASC' | 'ORDER_BY_DESC', offset?: number, limit?: number, name?: string, archived?: boolean, users?: Array<string>, options?: any) {
+        getWorkspaceProjects(id: number, sortBy?: 'SORT_BY_UNSPECIFIED' | 'SORT_BY_CREATION_TIME' | 'SORT_BY_LAST_EXPERIMENT_START_TIME' | 'SORT_BY_NAME' | 'SORT_BY_DESCRIPTION' | 'SORT_BY_ID', orderBy?: 'ORDER_BY_UNSPECIFIED' | 'ORDER_BY_ASC' | 'ORDER_BY_DESC', offset?: number, limit?: number, name?: string, archived?: boolean, users?: Array<string>, options?: any) {
             return WorkspacesApiFp(configuration).getWorkspaceProjects(id, sortBy, orderBy, offset, limit, name, archived, users, options)(fetch, basePath);
         },
         /**
@@ -19841,7 +19842,7 @@ export class WorkspacesApi extends BaseAPI {
      * 
      * @summary Get projects associated with a workspace.
      * @param {number} id The id of the workspace.
-     * @param {'SORT_BY_UNSPECIFIED' | 'SORT_BY_CREATION_TIME' | 'SORT_BY_LAST_EXPERIMENT_START_TIME' | 'SORT_BY_NAME' | 'SORT_BY_DESCRIPTION'} [sortBy] Sort the projects by the given field.   - SORT_BY_UNSPECIFIED: Returns projects in an unsorted list.  - SORT_BY_CREATION_TIME: Returns projects sorted by time that they were created.  - SORT_BY_LAST_EXPERIMENT_START_TIME: Returns projects sorted by most recent start of an experiment.  - SORT_BY_NAME: Returns projects sorted by name.  - SORT_BY_DESCRIPTION: Returns projects sorted by description.
+     * @param {'SORT_BY_UNSPECIFIED' | 'SORT_BY_CREATION_TIME' | 'SORT_BY_LAST_EXPERIMENT_START_TIME' | 'SORT_BY_NAME' | 'SORT_BY_DESCRIPTION' | 'SORT_BY_ID'} [sortBy] Sort the projects by the given field.   - SORT_BY_UNSPECIFIED: Returns projects in an unsorted list.  - SORT_BY_CREATION_TIME: Returns projects sorted by time that they were created.  - SORT_BY_LAST_EXPERIMENT_START_TIME: Returns projects sorted by most recent start of an experiment.  - SORT_BY_NAME: Returns projects sorted by name.  - SORT_BY_DESCRIPTION: Returns projects sorted by description.  - SORT_BY_ID: Returns projects sorted by ID.
      * @param {'ORDER_BY_UNSPECIFIED' | 'ORDER_BY_ASC' | 'ORDER_BY_DESC'} [orderBy] Order projects in either ascending or descending order.   - ORDER_BY_UNSPECIFIED: Returns records in no specific order.  - ORDER_BY_ASC: Returns records in ascending order.  - ORDER_BY_DESC: Returns records in descending order.
      * @param {number} [offset] Skip the number of projects before returning results. Negative values denote number of projects to skip from the end before returning results.
      * @param {number} [limit] Limit the number of projects. A value of 0 denotes no limit.
@@ -19852,7 +19853,7 @@ export class WorkspacesApi extends BaseAPI {
      * @throws {RequiredError}
      * @memberof WorkspacesApi
      */
-    public getWorkspaceProjects(id: number, sortBy?: 'SORT_BY_UNSPECIFIED' | 'SORT_BY_CREATION_TIME' | 'SORT_BY_LAST_EXPERIMENT_START_TIME' | 'SORT_BY_NAME' | 'SORT_BY_DESCRIPTION', orderBy?: 'ORDER_BY_UNSPECIFIED' | 'ORDER_BY_ASC' | 'ORDER_BY_DESC', offset?: number, limit?: number, name?: string, archived?: boolean, users?: Array<string>, options?: any) {
+    public getWorkspaceProjects(id: number, sortBy?: 'SORT_BY_UNSPECIFIED' | 'SORT_BY_CREATION_TIME' | 'SORT_BY_LAST_EXPERIMENT_START_TIME' | 'SORT_BY_NAME' | 'SORT_BY_DESCRIPTION' | 'SORT_BY_ID', orderBy?: 'ORDER_BY_UNSPECIFIED' | 'ORDER_BY_ASC' | 'ORDER_BY_DESC', offset?: number, limit?: number, name?: string, archived?: boolean, users?: Array<string>, options?: any) {
         return WorkspacesApiFp(this.configuration).getWorkspaceProjects(id, sortBy, orderBy, offset, limit, name, archived, users, options)(this.fetch, this.basePath);
     }
 


### PR DESCRIPTION
## Description

Adds CLI commands which call the Python API bindings for Workspaces.

I decided to add a sort-by-id option to GetWorkspaces and GetWorkspaceProjects instead of sending "Unspecified"

**This merges into the workspace/projects feature branch**

## Test Plan

`det workspace help` == `det w help`
`det w list` - the default workspace ("Uncategorized") should already be here
`det w list-projects Uncategorized` - the default project ("Uncategorized") should already be here
`det w describe Uncategorized` - prints this workspace row and then a table of projects
`det w create NewName` - creates a new workspace verifiable with `det w list`
`det w list` - order should be Uncategorized, NewName
`det w list --sort-by name` - order should be NewName, Uncategorized
`det w edit NewName UpdatedName`
`det w delete UpdatedName` - given y/n prompt, then deletion verifiable with `det w list`


## Checklist

- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.