### PR TITLE
fix: make "Show full config" modal larger

### DIFF
--- a/webui/react/src/hooks/useModal/useModalExperimentCreate.tsx
+++ b/webui/react/src/hooks/useModal/useModalExperimentCreate.tsx
@@ -298,6 +298,7 @@ const useModalExperimentCreate = (props?: Props): ModalHooks => {
         </div>
       ),
       visible,
+      width: isAdvancedMode ? (isFork ? 760 : 1000) : undefined,
     };
 
     return props;


### PR DESCRIPTION
## Description

The "full config" version of the "Fork" and "Continue Trial" modals need to be wider than the current default of 416px.

![image](https://user-images.githubusercontent.com/97752292/160924081-9a6f8611-7809-4890-836c-6e610841ad58.png)

## Test Plan

- [ ] Modal window size changes to 760px wide when clicking “show full config” from the “Fork” modal. (exists on both experiment and trial detail pages)
- [ ] Modal window size changes to 1000px wide when clicking “show full config” from the “Continue trial” modal. (exists on both experiment and trial detail pages)
- [ ] User clicks “Show simple config” and modal returns to previous size.

## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
