### PR TITLE
feat: allow the CLI to accept incomplete task UUIDs [DET-6706]

### DIFF
--- a/docs/release-notes/cli-uuid-prefixes.txt
+++ b/docs/release-notes/cli-uuid-prefixes.txt
@@ -1,0 +1,7 @@
+:orphan:
+
+**New Features**
+
+-  CLI: Allow the CLI to accept any unique prefix of a task UUID to refer to the task, rather than
+   requiring the entire UUID. In some places, Determined only displays the first few characters of a
+   UUID.

--- a/harness/determined/cli/notebook.py
+++ b/harness/determined/cli/notebook.py
@@ -57,7 +57,8 @@ def start_notebook(args: Namespace) -> None:
 
 @authentication.required
 def open_notebook(args: Namespace) -> None:
-    resp = api.get(args.master, "api/v1/notebooks/{}".format(args.notebook_id)).json()["notebook"]
+    notebook_id = command.expand_uuid_prefixes(args)
+    resp = api.get(args.master, "api/v1/notebooks/{}".format(notebook_id)).json()["notebook"]
     check_eq(resp["state"], "STATE_RUNNING", "Notebook must be in a running state")
     api.browser_open(args.master, resp["serviceAddress"])
 
@@ -74,7 +75,7 @@ args_description = [
         ], is_default=True),
         Cmd("config", command.config,
             "display notebook config", [
-                Arg("id", type=str, help="notebook ID"),
+                Arg("notebook_id", type=str, help="notebook ID"),
             ]),
         Cmd("start", start_notebook, "start a new notebook", [
             Arg("--config-file", default=None, type=FileType("r"),

--- a/harness/determined/cli/remote.py
+++ b/harness/determined/cli/remote.py
@@ -44,7 +44,7 @@ args_description = [
         ], is_default=True),
         Cmd("config", command.config,
             "display command config", [
-                Arg("id", type=str, help="command ID"),
+                Arg("command_id", type=str, help="command ID"),
             ]),
         Cmd("run", run_command, "create command", [
             Arg("entrypoint", type=str, nargs=REMAINDER,

--- a/harness/determined/cli/shell.py
+++ b/harness/determined/cli/shell.py
@@ -66,7 +66,8 @@ def start_shell(args: Namespace) -> None:
 
 @authentication.required
 def open_shell(args: Namespace) -> None:
-    shell = api.get(args.master, "api/v1/shells/{}".format(args.shell_id)).json()["shell"]
+    shell_id = command.expand_uuid_prefixes(args)
+    shell = api.get(args.master, "api/v1/shells/{}".format(shell_id)).json()["shell"]
     check_eq(shell["state"], "STATE_RUNNING", "Shell must be in a running state")
     _open_shell(
         args.master,
@@ -79,7 +80,8 @@ def open_shell(args: Namespace) -> None:
 
 @authentication.required
 def show_ssh_command(args: Namespace) -> None:
-    shell = api.get(args.master, "api/v1/shells/{}".format(args.shell_id)).json()["shell"]
+    shell_id = command.expand_uuid_prefixes(args)
+    shell = api.get(args.master, "api/v1/shells/{}".format(shell_id)).json()["shell"]
     check_eq(shell["state"], "STATE_RUNNING", "Shell must be in a running state")
     _open_shell(args.master, shell, args.ssh_opts, retain_keys_and_print=True, print_only=True)
 
@@ -182,7 +184,7 @@ args_description = [
         ], is_default=True),
         Cmd("config", command.config,
             "display shell config", [
-                Arg("id", type=str, help="shell ID"),
+                Arg("shell_id", type=str, help="shell ID"),
             ]),
         Cmd("start", start_shell, "start a new shell", [
             Arg("ssh_opts", nargs="*", help="additional SSH options when connecting to the shell"),

--- a/harness/determined/cli/task.py
+++ b/harness/determined/cli/task.py
@@ -1,8 +1,8 @@
 import json
 from argparse import Namespace
-from typing import Any, Dict, List, Union
+from typing import Any, Dict, List, Union, cast
 
-from determined.cli import render
+from determined.cli import command, render
 from determined.common import api
 from determined.common.api import authentication
 from determined.common.declarative_argparse import Arg, Cmd, Group
@@ -62,9 +62,10 @@ def list_tasks(args: Namespace) -> None:
 
 @authentication.required
 def logs(args: Namespace) -> None:
+    task_id = cast(str, command.expand_uuid_prefixes(args, args.task_id))
     api.pprint_task_logs(
         args.master,
-        args.task_id,
+        task_id,
         head=args.head,
         tail=args.tail,
         follow=args.follow,

--- a/harness/determined/cli/tensorboard.py
+++ b/harness/determined/cli/tensorboard.py
@@ -59,7 +59,8 @@ def start_tensorboard(args: Namespace) -> None:
 
 @authentication.required
 def open_tensorboard(args: Namespace) -> None:
-    resp = api.get(args.master, "api/v1/tensorboards/{}".format(args.tensorboard_id)).json()[
+    tensorboard_id = command.expand_uuid_prefixes(args)
+    resp = api.get(args.master, "api/v1/tensorboards/{}".format(tensorboard_id)).json()[
         "tensorboard"
     ]
     check_eq(resp["state"], "STATE_RUNNING", "TensorBoard must be in a running state")
@@ -96,7 +97,7 @@ args_description = [
         ]),
         Cmd("config", command.config,
             "display TensorBoard config", [
-                Arg("id", type=str, help="TensorBoard ID")
+                Arg("tensorboard_id", type=str, help="TensorBoard ID")
             ]),
         Cmd("open", open_tensorboard,
             "open existing TensorBoard instance", [


### PR DESCRIPTION
## Description

For user convenience, this allows the CLI to accept an incomplete prefix
of a task UUID as long as there is a unique UUID that it corresponds to.

## Test Plan

- [x] manual testing
- [ ] new tests (partially done, want to cover all task types without being totally awful)
