### PR TITLE
chore: add conditionalRender prop to Spinner

### DIFF
--- a/webui/react/src/components/Spinner.tsx
+++ b/webui/react/src/components/Spinner.tsx
@@ -8,6 +8,7 @@ import css from './Spinner.module.scss';
 
 interface Props extends Omit<SpinProps, 'size'>, SpinState {
   center?: boolean;
+  conditionalRender?: boolean;
   inline?: boolean;
   size?: IconSize;
 }
@@ -15,7 +16,9 @@ interface Props extends Omit<SpinProps, 'size'>, SpinState {
 const Spinner: React.FC<Props> = ({
   center,
   className,
+  conditionalRender,
   size,
+  spinning,
   tip,
   ...props
 }: PropsWithChildren<Props>) => {
@@ -32,9 +35,10 @@ const Spinner: React.FC<Props> = ({
             <Icon name="spinner" size={size} />
           </div>
         )}
+        spinning={spinning}
         tip={tip}
         {...props}>
-        {props.children}
+        {conditionalRender ? (spinning ? null : props.children) : props.children}
       </Spin>
     </div>
   );


### PR DESCRIPTION
## Description

Add a prop to the `<Spinner>` component that provides the option to not render content while loading/spinning [DET-6275]
<img width="1066" alt="Screen Shot 2022-03-31 at 9 34 28 AM" src="https://user-images.githubusercontent.com/97752292/161105704-9c79a1e4-d53c-48e5-921a-5a576c94d8bb.png">
<img width="1070" alt="Screen Shot 2022-03-31 at 9 34 00 AM" src="https://user-images.githubusercontent.com/97752292/161105708-7b421b82-4918-4d1a-a94c-93632cb1e848.png">

## Test Plan

- [ ] try using the prop in Page.tsx and confirm that the page content is not rendered

## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-6275]: https://determinedai.atlassian.net/browse/DET-6275?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ