### PR TITLE
fix: remove python 3.10 union-type syntax

### DIFF
--- a/harness/determined/cli/experiment.py
+++ b/harness/determined/cli/experiment.py
@@ -9,7 +9,7 @@ import time
 from argparse import FileType, Namespace
 from pathlib import Path
 from pprint import pformat
-from typing import Any, Callable, Dict, Iterable, List, Optional, Sequence, Set, Tuple
+from typing import Any, Callable, Dict, Iterable, List, Optional, Sequence, Set, Tuple, Union
 
 import tabulate
 
@@ -342,7 +342,9 @@ def describe(args: Namespace) -> None:
             workloads = bindings.get_GetTrial(session, trialId=trial.id).workloads or []
             for workload in workloads:
                 t_metrics_fields = []
-                wl_detail: bindings.v1MetricsWorkload | bindings.v1CheckpointWorkload | None = None
+                wl_detail: Optional[
+                    Union[bindings.v1MetricsWorkload | bindings.v1CheckpointWorkload]
+                ] = None
                 if workload.training:
                     wl_detail = workload.training
                     for name in t_metrics_names:

--- a/harness/determined/cli/experiment.py
+++ b/harness/determined/cli/experiment.py
@@ -343,7 +343,7 @@ def describe(args: Namespace) -> None:
             for workload in workloads:
                 t_metrics_fields = []
                 wl_detail: Optional[
-                    Union[bindings.v1MetricsWorkload | bindings.v1CheckpointWorkload]
+                    Union[bindings.v1MetricsWorkload, bindings.v1CheckpointWorkload]
                 ] = None
                 if workload.training:
                     wl_detail = workload.training


### PR DESCRIPTION
## Description

This removes a [python 3.10-specific syntax](https://peps.python.org/pep-0604/) from the codebase.

I can't figure out how the code in question runs at all.  It must be some sort of runtime optimization that isn't considering types at all, because a simple command like:
```
python -c 'a: int | str = 1'
```
throws an error:
```
TypeError: unsupported operand type(s) for |: 'type' and 'type'
```

I was occasionally (but not consistently) seeing mypy errors in make check.