### PR TITLE
feat: CLI supports Projects [DET-6820]

### DIFF
--- a/harness/determined/cli/__init__.py
+++ b/harness/determined/cli/__init__.py
@@ -7,6 +7,7 @@ from . import (
     master,
     model,
     notebook,
+    project,
     remote,
     render,
     resources,

--- a/harness/determined/cli/cli.py
+++ b/harness/determined/cli/cli.py
@@ -23,6 +23,7 @@ from determined.cli.master import args_description as master_args_description
 from determined.cli.model import args_description as model_args_description
 from determined.cli.notebook import args_description as notebook_args_description
 from determined.cli.oauth import args_description as oauth_args_description
+from determined.cli.project import args_description as project_args_description
 from determined.cli.remote import args_description as remote_args_description
 from determined.cli.resources import args_description as resources_args_description
 from determined.cli.shell import args_description as shell_args_description
@@ -140,6 +141,7 @@ all_args_description = (
     + notebook_args_description
     + job_args_description
     + resources_args_description
+    + project_args_description
     + shell_args_description
     + task_args_description
     + template_args_description

--- a/harness/determined/cli/project.py
+++ b/harness/determined/cli/project.py
@@ -166,7 +166,6 @@ args_description = [
                     ),
                     Arg("--json", action="store_true", help="print as JSON"),
                 ],
-                is_default=True,
             ),
             Cmd(
                 "list-experiments",
@@ -197,7 +196,6 @@ args_description = [
                     ),
                     Arg("--json", action="store_true", help="print as JSON"),
                 ],
-                is_default=True,
             ),
             Cmd(
                 "create",

--- a/harness/determined/cli/project.py
+++ b/harness/determined/cli/project.py
@@ -72,18 +72,15 @@ def project_by_name(
 def list_project_experiments(args: Namespace) -> None:
     sess = setup_session(args)
     (w, p) = project_by_name(sess, args.workspace_name, args.project_name)
-    orderArg = bindings.v1OrderBy[f"ORDER_BY_{args.order_by.upper()}"]
-    sortArg = bindings.v1GetProjectExperimentsRequestSortBy[f"SORT_BY_{args.sort_by.upper()}"]
-    users: List[str] = []
-    if args.all:
-        experiments = bindings.get_GetProjectExperiments(
-            sess, id=p.id, orderBy=orderArg, sortBy=sortArg
-        ).experiments
-    else:
-        users = [authentication.must_cli_auth().get_session_user()]
-        experiments = bindings.get_GetProjectExperiments(
-            sess, archived="false", id=p.id, orderBy=orderArg, sortBy=sortArg, users=users
-        ).experiments
+    kwargs = {
+        "id": p.id,
+        "orderBy": bindings.v1OrderBy[f"ORDER_BY_{args.order_by.upper()}"],
+        "sortBy": bindings.v1GetProjectExperimentsRequestSortBy[f"SORT_BY_{args.sort_by.upper()}"],
+    }
+    if not args.all:
+        kwargs["users"] = [authentication.must_cli_auth().get_session_user()]
+        kwargs["archived"] = "false"
+    experiments = bindings.get_GetProjectExperiments(sess, **kwargs).experiments
     if args.json:
         print(json.dumps([e.to_json() for e in experiments], indent=2))
     else:

--- a/harness/determined/cli/project.py
+++ b/harness/determined/cli/project.py
@@ -50,10 +50,11 @@ def render_project(project: v1Project) -> None:
     values = [
         project.id,
         project.name,
+        project.description,
         project.numExperiments,
         project.numActiveExperiments,
     ]
-    PROJECT_HEADERS = ["ID", "Name", "# Experiments", "# Active Experiments"]
+    PROJECT_HEADERS = ["ID", "Name", "Description", "# Experiments", "# Active Experiments"]
     render.tabulate_or_csv(PROJECT_HEADERS, [values], False)
 
 

--- a/harness/determined/cli/project.py
+++ b/harness/determined/cli/project.py
@@ -1,6 +1,6 @@
 import json
 from argparse import Namespace
-from typing import Any, List, Sequence, Tuple
+from typing import Any, Dict, List, Sequence, Tuple
 
 from determined.cli.session import setup_session
 from determined.common.api import authentication, bindings
@@ -72,7 +72,7 @@ def project_by_name(
 def list_project_experiments(args: Namespace) -> None:
     sess = setup_session(args)
     (w, p) = project_by_name(sess, args.workspace_name, args.project_name)
-    kwargs = {
+    kwargs: Dict[str, Any] = {
         "id": p.id,
         "orderBy": bindings.v1OrderBy[f"ORDER_BY_{args.order_by.upper()}"],
         "sortBy": bindings.v1GetProjectExperimentsRequestSortBy[f"SORT_BY_{args.sort_by.upper()}"],
@@ -110,14 +110,13 @@ def describe_project(args: Namespace) -> None:
     else:
         render_project(p)
         print("\nAssociated Experiments")
-        users: List[str] = []
-        if args.all:
-            experiments = bindings.get_GetProjectExperiments(sess, id=p.id).experiments
-        else:
-            users = [authentication.must_cli_auth().get_session_user()]
-            experiments = bindings.get_GetProjectExperiments(
-                sess, archived="false", id=p.id, users=users
-            ).experiments
+        kwargs: Dict[str, Any] = {
+            "id": p.id,
+        }
+        if not args.all:
+            kwargs["users"] = [authentication.must_cli_auth().get_session_user()]
+            kwargs["archived"] = "false"
+        experiments = bindings.get_GetProjectExperiments(sess, **kwargs).experiments
         render_experiments(args, experiments)
 
 

--- a/harness/determined/cli/project.py
+++ b/harness/determined/cli/project.py
@@ -1,0 +1,201 @@
+import json
+from argparse import Namespace
+from typing import Any, List, Tuple
+
+from determined.cli.session import setup_session
+from determined.common.api import authentication, bindings
+from determined.common.api.bindings import v1Project, v1Workspace
+from determined.common.declarative_argparse import Arg, Cmd
+from determined.common.experimental import session
+
+from workspace import get_workspace_by_name, list_workspace_projects
+
+from . import render
+
+PROJECT_HEADERS = ["ID", "Name", "# Experiments", "# Active Experiments"]
+WORKSPACE_HEADERS = ["ID", "Name"]
+
+
+def render_project(project: v1Project) -> None:
+    values = [
+        project.id,
+        project.name,
+        project.numExperiments,
+        project.numActiveExperiments,
+    ]
+    render.tabulate_or_csv(PROJECT_HEADERS, [values], False)
+
+
+def project_by_name(sess: session.Session, workspace_name: str, project_name: str) -> Tuple[int, int]:
+    w = get_workspace_by_name(sess, workspace_name)
+    p = bindings.get_GetWorkspaceProjects(sess, name=project_name).projects
+    if len(p) == 0:
+        raise Exception(f'No project found on this workspace with name: "{project_name}"')
+    return (w.id, p[0].id)
+
+
+@authentication.required
+def list_projects(args: Namespace) -> None:
+    list_workspace_projects(args)
+
+
+@authentication.required
+def list_workspace_projects(args: Namespace) -> None:
+    sess = setup_session(args)
+    w = workspace_by_name(sess, args.workspace_name)
+
+    orderArg = bindings.v1OrderBy[f"ORDER_BY_{args.order_by.upper()}"]
+    sortArg = bindings.v1GetWorkspaceProjectsRequestSortBy[f"SORT_BY_{args.sort_by.upper()}"]
+    projects = bindings.get_GetWorkspaceProjects(sess, id=w.id, orderBy=orderArg, sortBy=sortArg).projects
+    if args.json:
+        print(json.dumps([p.to_json() for p in projects], indent=2))
+    else:
+        values = [
+            [
+                p.id,
+                p.name,
+                p.numExperiments,
+                p.numActiveExperiments,
+            ]
+            for p in projects
+        ]
+        render.tabulate_or_csv(PROJECT_HEADERS, values, False)
+
+
+@authentication.required
+def create_workspace(args: Namespace) -> None:
+    content = bindings.v1PostWorkspaceRequest(args.name)
+    w = bindings.post_PostWorkspace(setup_session(args), body=content).workspace
+
+    if args.json:
+        print(json.dumps(w.to_json(), indent=2))
+    else:
+        render_workspace(w)
+
+
+@authentication.required
+def describe_workspace(args: Namespace) -> None:
+    sess = setup_session(args)
+    w = workspace_by_name(sess, args.workspace_name)
+    if args.json:
+        print(json.dumps(w.to_json(), indent=2))
+    else:
+        render_workspace(w)
+        print("\nAssociated Projects")
+        projects = bindings.get_GetWorkspaceProjects(sess, id=w.id).projects
+        values = [
+            [
+                p.id,
+                p.name,
+                p.numExperiments,
+                p.numActiveExperiments,
+            ]
+            for p in projects
+        ]
+        render.tabulate_or_csv(PROJECT_HEADERS, values, False)
+
+
+@authentication.required
+def delete_workspace(args: Namespace) -> None:
+    if args.yes or render.yes_or_no(
+        "Deleting a workspace will result in the unrecoverable \n"
+        "deletion of all associated projects. For a recoverable \n"
+        "alternative, see the 'archive' command. Do you still \n"
+        "wish to proceed?"
+    ):
+        sess = setup_session(args)
+        w = workspace_by_name(sess, args.workspace_name)
+        bindings.delete_DeleteWorkspace(sess, id=w.id)
+        print(f"Successfully deleted workspace {args.workspace_name}.")
+    else:
+        print("Aborting workspace deletion.")
+
+
+@authentication.required
+def edit_workspace(args: Namespace) -> None:
+    sess = setup_session(args)
+    current = workspace_by_name(sess, args.workspace_name)
+    updated = bindings.v1PatchWorkspace(name=args.new_name)
+    w = bindings.patch_PatchWorkspace(sess, body=updated, id=current.id).workspace
+
+    if args.json:
+        print(json.dumps(w.to_json(), indent=2))
+    else:
+        render_workspace(w)
+
+
+args_description = [
+    Cmd(
+        "p|roject",
+        None,
+        "manage projects",
+        [
+            Cmd(
+                "list",
+                list_workspace_projects,
+                "list the projects associated with a workspace",
+                [
+                    Arg("workspace_name", type=str, help="name of the workspace"),
+                    Arg(
+                        "--sort-by",
+                        type=str,
+                        choices=["id", "name"],
+                        default="id",
+                        help="sort workspaces by the given field",
+                    ),
+                    Arg(
+                        "--order-by",
+                        type=str,
+                        choices=["asc", "desc"],
+                        default="asc",
+                        help="order workspaces in either ascending or descending order",
+                    ),
+                    Arg("--json", action="store_true", help="print as JSON"),
+                ],
+                is_default=True,
+            ),
+            Cmd(
+                "create",
+                create_workspace,
+                "create workspace",
+                [
+                    Arg("name", type=str, help="unique name of the workspace"),
+                    Arg("--json", action="store_true", help="print as JSON"),
+                ],
+            ),
+            Cmd(
+                "delete",
+                delete_workspace,
+                "delete workspace",
+                [
+                    Arg("workspace_name", type=str, help="name of the workspace"),
+                    Arg(
+                        "--yes",
+                        action="store_true",
+                        default=False,
+                        help="automatically answer yes to prompts",
+                    ),
+                ],
+            ),
+            Cmd(
+                "describe",
+                describe_workspace,
+                "describe workspace",
+                [
+                    Arg("workspace_name", type=str, help="name of the workspace"),
+                    Arg("--json", action="store_true", help="print as JSON"),
+                ],
+            ),
+            Cmd(
+                "edit",
+                edit_workspace,
+                "edit workspace",
+                [
+                    Arg("workspace_name", type=str, help="current name of the workspace"),
+                    Arg("new_name", type=str, help="new name of the workspace"),
+                    Arg("--json", action="store_true", help="print as JSON"),
+                ],
+            ),
+        ],
+    )
+]  # type: List[Any]

--- a/harness/determined/cli/project.py
+++ b/harness/determined/cli/project.py
@@ -113,8 +113,8 @@ def describe_project(args: Namespace) -> None:
 @authentication.required
 def delete_project(args: Namespace) -> None:
     if args.yes or render.yes_or_no(
-        "Deleting a project will result in the unrecoverable \n"
-        "deletion of all associated experiments. For a recoverable \n"
+        "Deleting project \"" + args.project_name + "\" will result in the \n"
+        "unrecoverable deletion of all associated experiments. For a recoverable \n"
         "alternative, see the 'archive' command. Do you still \n"
         "wish to proceed?"
     ):

--- a/harness/determined/cli/workspace.py
+++ b/harness/determined/cli/workspace.py
@@ -10,7 +10,7 @@ from determined.common.experimental import session
 
 from . import render
 
-PROJECT_HEADERS = ["ID", "Name", "# Experiments", "# Active Experiments"]
+PROJECT_HEADERS = ["ID", "Name", "Description", "# Experiments", "# Active Experiments"]
 WORKSPACE_HEADERS = ["ID", "Name"]
 
 
@@ -67,6 +67,7 @@ def list_workspace_projects(args: Namespace) -> None:
             [
                 p.id,
                 p.name,
+                p.description,
                 p.numExperiments,
                 p.numActiveExperiments,
             ]
@@ -100,6 +101,7 @@ def describe_workspace(args: Namespace) -> None:
             [
                 p.id,
                 p.name,
+                p.description,
                 p.numExperiments,
                 p.numActiveExperiments,
             ]

--- a/harness/determined/cli/workspace.py
+++ b/harness/determined/cli/workspace.py
@@ -113,9 +113,9 @@ def describe_workspace(args: Namespace) -> None:
 @authentication.required
 def delete_workspace(args: Namespace) -> None:
     if args.yes or render.yes_or_no(
-        "Deleting a workspace will result in the unrecoverable \n"
-        "deletion of all associated projects. For a recoverable \n"
-        "alternative, see the 'archive' command. Do you still \n"
+        "Deleting workspace \"" + args.workspace_name + "\" will result \n"
+        "in the unrecoverable deletion of all associated projects. For a \n"
+        "recoverable alternative, see the 'archive' command. Do you still \n"
         "wish to proceed?"
     ):
         sess = setup_session(args)

--- a/harness/determined/cli/workspace.py
+++ b/harness/determined/cli/workspace.py
@@ -113,7 +113,7 @@ def describe_workspace(args: Namespace) -> None:
 @authentication.required
 def delete_workspace(args: Namespace) -> None:
     if args.yes or render.yes_or_no(
-        "Deleting workspace \"" + args.workspace_name + "\" will result \n"
+        'Deleting workspace "' + args.workspace_name + '" will result \n'
         "in the unrecoverable deletion of all associated projects. For a \n"
         "recoverable alternative, see the 'archive' command. Do you still \n"
         "wish to proceed?"

--- a/master/internal/api_model.go
+++ b/master/internal/api_model.go
@@ -331,7 +331,7 @@ func (a *apiServer) DeleteModel(
 		user.User.Admin)
 
 	if holder.Id == 0 {
-		return nil, errors.Wrapf(err, "model %q does not exist or not delete-able by this user",
+		return nil, errors.Wrapf(err, "model %q does not exist or not deletable by this user",
 			req.ModelName)
 	}
 
@@ -523,7 +523,7 @@ func (a *apiServer) DeleteModelVersion(
 		user.User.Id, user.User.Admin)
 
 	if holder.Id == 0 {
-		return nil, errors.Wrapf(err, "model version %v does not exist or not delete-able by this user",
+		return nil, errors.Wrapf(err, "model version %v does not exist or not deletable by this user",
 			req.ModelVersionId)
 	}
 

--- a/master/internal/api_project.go
+++ b/master/internal/api_project.go
@@ -222,7 +222,7 @@ func (a *apiServer) DeleteProject(
 		user.User.Admin)
 
 	if holder.Id == 0 {
-		return nil, errors.Wrapf(err, "project (%d) does not exist or not delete-able by this user",
+		return nil, errors.Wrapf(err, "project (%d) does not exist or not deletable by this user",
 			req.Id)
 	}
 

--- a/master/internal/api_workspace.go
+++ b/master/internal/api_workspace.go
@@ -199,7 +199,7 @@ func (a *apiServer) DeleteWorkspace(
 		user.User.Admin)
 
 	if holder.Id == 0 {
-		return nil, errors.Wrapf(err, "workspace (%d) does not exist or not delete-able by this user",
+		return nil, errors.Wrapf(err, "workspace (%d) does not exist or not deletable by this user",
 			req.Id)
 	}
 


### PR DESCRIPTION
## Description

Adds CLI commands which call the Python API bindings for Projects.

**This merges into the workspace/projects feature branch**

## Test Plan

can use `det project help` or `det p help`
`det p list Uncategorized` - the default workspace ("Uncategorized") will already be set up on your db and have a default project (also named "Uncategorized")
`det p list-experiments Uncategorized Uncategorized` - should list all experiments in your db
`det p create Uncategorized Added` - creates a new project inside Uncategorized workspace
`det p describe Uncategorized Added` - prints the new project row and an (empty) table of experiments
`det p list Uncategorized --sort-by name` - order should be Added, Uncategorized
`det p edit Uncategorized Added --new_name UpdatedName --description Example` - updates project
`det p delete Uncategorized UpdatedName` - given y/n prompt, deletes project

## Checklist

- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.