### PR TITLE
feat: make core.Searcher multiworker-safe

### DIFF
--- a/harness/determined/_core/_context.py
+++ b/harness/determined/_core/_context.py
@@ -29,7 +29,7 @@ class Context:
         self.distributed = distributed or _core.DummyDistributed()
         self.preemption = preemption or _core.DummyPreemption()
         self.training = training or _core.DummyTraining()
-        self.searcher = searcher or _core.DummySearcher()
+        self.searcher = searcher or _core.DummySearcher(self.distributed)
 
     def __enter__(self) -> "Context":
         self.preemption.start()
@@ -66,7 +66,7 @@ def _dummy_init(
     checkpointing = _core.DummyCheckpointing(distributed, storage_manager)
 
     training = _core.DummyTraining()
-    searcher = _core.DummySearcher()
+    searcher = _core.DummySearcher(distributed)
 
     return Context(
         distributed=distributed,
@@ -131,7 +131,12 @@ def init(
         )
         units = _core._parse_searcher_units(info.trial._config)
         searcher = _core.Searcher(
-            session, info.trial.trial_id, info.trial._trial_run_id, info.allocation_id, units
+            session,
+            distributed,
+            info.trial.trial_id,
+            info.trial._trial_run_id,
+            info.allocation_id,
+            units,
         )
 
         if storage_manager is None:

--- a/harness/determined/_core/_searcher.py
+++ b/harness/determined/_core/_searcher.py
@@ -93,9 +93,8 @@ class Searcher:
 
     .. code:: python
 
-       # We'll pretend we configured we configured the searcher
-       # in terms of batches, so we will interpet the the op.length as a
-       # count of batches.
+       # We'll pretend we configured the searcher in terms of batches,
+       # so we will interpet the the op.length as a count of batches.
        # Note that you'll have to load your starting point from a
        # checkpoint if you want to support pausing/continuing training.
        batches_trained = 0
@@ -169,7 +168,9 @@ class Searcher:
             while True:
                 op = self._get_searcher_op()
                 if not chief_only:
-                    # Broadcast op.length (or None) to workers.
+                    # Broadcast op.length (or None) to workers.  We broadcast just the length
+                    # because SearcherOp is not serializable, and the is_chief attribute obviously
+                    # must be set on a per-worker basis.
                     _ = self._dist._zmq_broadcast(op and op.length)
                 if op is None:
                     if auto_ack:

--- a/harness/determined/layers/_workload_sequencer.py
+++ b/harness/determined/layers/_workload_sequencer.py
@@ -383,7 +383,7 @@ class WorkloadSequencer(workload.Source):
             ):
                 yield from self.validate(None)
 
-            for op in self.core_context.searcher.ops():
+            for op in self.core_context.searcher.ops(chief_only=True):
                 while self.batches_until_op_complete(op) > 0:
                     # Do some training.
                     yield from self.train(

--- a/harness/tests/core/test_searcher.py
+++ b/harness/tests/core/test_searcher.py
@@ -1,0 +1,111 @@
+from typing import Any, List
+from unittest import mock
+
+import pytest
+
+from determined import _core
+from tests import parallel
+
+
+def make_test_searcher(ops: List[int], dist: _core.DistributedContext) -> _core.Searcher:
+    # Mock the session.get to return a few searcher ops
+    final_op = ops[-1]
+    ops = list(ops)
+
+    def session_get(_: Any) -> Any:
+        assert dist.rank == 0, "worker Searchers must not GET new ops, but ask the chief instead"
+        resp = mock.MagicMock()
+        if ops:
+            resp.json.return_value = {
+                "op": {"validateAfter": {"length": str(ops.pop(0))}},
+                "completed": False,
+            }
+        else:
+            resp.json.return_value = {
+                "op": {"validateAfter": {"length": str(final_op)}},
+                "completed": True,
+            }
+        return resp
+
+    session = mock.MagicMock()
+    session.get.side_effect = session_get
+
+    searcher = _core.Searcher(
+        session=session,
+        dist=dist,
+        trial_id=1,
+        run_id=2,
+        allocation_id="3",
+    )
+    return searcher
+
+
+@pytest.mark.parametrize("dummy", [False, True])
+def test_parallel_searcher(dummy: bool) -> None:
+    with parallel.Execution(2) as pex:
+
+        @pex.run
+        def searchers() -> _core.Searcher:
+            if not dummy:
+                searcher = make_test_searcher([5, 10, 15], pex.distributed)
+            else:
+                searcher = _core.DummySearcher(dist=pex.distributed)
+            epochs_trained = 0
+            # Iterate through ops.
+            for op in searcher.ops():
+                assert pex.distributed._zmq_allgather(op.length) == [op.length] * pex.size
+                while epochs_trained < op.length:
+                    epochs_trained += 1
+                    expect = [epochs_trained] * pex.size
+                    assert pex.distributed._zmq_allgather(epochs_trained) == expect
+                    with parallel.raises_when(
+                        pex.rank != 0, RuntimeError, match="op.report_progress.*chief"
+                    ):
+                        op.report_progress(epochs_trained)
+                with parallel.raises_when(pex.rank != 0, RuntimeError, match="op.complete.*chief"):
+                    op.complete(0.0)
+
+            return searcher
+
+        if not dummy:
+            # Expect calls from chief: 15x progress, 4x completions
+            chief = searchers[0]
+            post_mock: Any = chief._session.post
+            assert post_mock.call_count == 19, post_mock.call_args_list
+
+            # The workers must not make any REST API calls at all.
+            worker = searchers[1]
+            post_mock = worker._session.post
+            post_mock.assert_not_called()
+
+
+def test_completion_check() -> None:
+    with parallel.Execution(2) as pex:
+
+        @pex.run
+        def do_test() -> None:
+            searcher = make_test_searcher([5], pex.distributed)
+
+            ops = iter(searcher.ops())
+            next(ops)
+            # Don't complete the op.
+            with parallel.raises_when(pex.rank == 0, RuntimeError, match="must call op.complete"):
+                next(ops)
+            # Wake up worker manually; it is hung waiting for the now-failed chief.
+            if pex.rank == 0:
+                pex.distributed._zmq_broadcast(10)
+
+
+@pytest.mark.parametrize("dummy", [False, True])
+def test_chief_only(dummy: bool) -> None:
+    with parallel.Execution(2) as pex:
+
+        @pex.run
+        def do_test() -> None:
+            if not dummy:
+                searcher = make_test_searcher([5, 10, 15], pex.distributed)
+            else:
+                searcher = _core.DummySearcher(dist=pex.distributed)
+
+            with parallel.raises_when(pex.rank != 0, RuntimeError, match="searcher.ops.*chief"):
+                next(iter(searcher.ops(chief_only=True)))

--- a/harness/tests/parallel.py
+++ b/harness/tests/parallel.py
@@ -1,0 +1,175 @@
+import contextlib
+import itertools
+import sys
+import threading
+import traceback
+from typing import Any, Callable, Dict, Iterator, List, Tuple, TypeVar
+
+import pytest
+
+from determined import _core
+
+T = TypeVar("T")
+
+
+class Execution:
+    """
+    parallel.Execution is a tool for writing easy threading-based parallel tests.
+
+    Execution.run is the main helper function, but there are a few magic getters that return
+    correct thread-specific values when called from within an Execution.run-wrapped function.
+
+    Example usage:
+
+        SIZE = 10
+        with parallel.Execution(SIZE) as pex:
+            @pex.run
+            def all_ranks():
+                return pex.rank
+
+            assert all_ranks == list(range(SIZE))
+
+    """
+
+    def __init__(
+        self, size: int, local_size: int = 1, make_distributed_context: bool = True
+    ) -> None:
+        assert size % local_size == 0, f"size%local_size must be 0 ({size}%{local_size})"
+        self.size = size
+        self.local_size = local_size
+        self.cross_size = size // local_size
+        # We keep some thread-specific info to implement the magic getters.
+        self._info: Dict[int, Tuple[int, int, int]] = {}
+
+        self._dist = None
+        if make_distributed_context:
+
+            def _make_distributed_context() -> _core.DistributedContext:
+                return _core.DistributedContext(
+                    rank=self.rank,
+                    size=self.size,
+                    local_rank=self.local_rank,
+                    local_size=self.local_size,
+                    cross_rank=self.cross_rank,
+                    cross_size=self.cross_size,
+                    chief_ip="localhost",
+                )
+
+            self._dist = self.run(_make_distributed_context)
+
+    def __enter__(self) -> "Execution":
+        return self
+
+    def __exit__(self, *arg: Any) -> None:
+        if not self._dist:
+            return
+        for dist in self._dist:
+            dist.close()
+
+    def run(self, fn: Callable[[], T]) -> List[T]:
+        """
+        Run the same function on one-thread-per-rank, assert there were no exceptions, and return
+        the results from each rank.
+
+        run can be used as a decorator or called directly.
+        """
+        results = [None] * self.size  # type: List
+        errors = [None] * self.size  # type: List
+        threads = []
+
+        for cross_rank, local_rank in itertools.product(
+            range(self.cross_size), range(self.local_size)
+        ):
+            rank = cross_rank * self.local_size + local_rank
+
+            def _fn(rank: int, cross_rank: int, local_rank: int) -> None:
+                thread_id = threading.get_ident()
+                self._info[thread_id] = (rank, cross_rank, local_rank)
+                try:
+                    results[rank] = fn()
+                # Catch anything, including a pytest.Fail (so we can preserve it).
+                except BaseException as e:
+                    errors[rank] = (rank, e, sys.exc_info())
+                finally:
+                    del self._info[thread_id]
+
+            threads.append(threading.Thread(target=_fn, args=(rank, cross_rank, local_rank)))
+
+        for thread in threads:
+            thread.start()
+
+        for thread in threads:
+            thread.join()
+
+        # Filter empty errors.
+        errors = [e for e in errors if e is not None]
+        if len(errors) > 1:
+            # In multi-errors situations, print all of them
+            for rank, _, exc_info in errors:
+                print(f"\nERROR ON RANK={rank}:", file=sys.stderr)
+                traceback.print_exception(*exc_info)
+            print(file=sys.stderr)
+        if errors:
+            # Reraise just the first exception.
+            _, e, _ = errors[0]
+            raise e
+
+        return results
+
+    @property
+    def rank(self) -> int:
+        """
+        Only callable within an @Execution.run-wrapped function.
+
+        Use the thread identifier to figure out what the rank is for the caller, and return the
+        rank of that caller.
+
+        This is syntactic sugar to avoid having to write a large number of functions that take
+        parameters of (rank, cross_rank, local_rank).
+        """
+        thread_id = threading.get_ident()
+        assert thread_id in self._info, "must be called from within an @Execute-decorated function"
+        return self._info[thread_id][0]
+
+    @property
+    def cross_rank(self) -> int:
+        thread_id = threading.get_ident()
+        assert thread_id in self._info, "must be called from within an @Execute-decorated function"
+        return self._info[thread_id][1]
+
+    @property
+    def local_rank(self) -> int:
+        thread_id = threading.get_ident()
+        assert thread_id in self._info, "must be called from within an @Execute-decorated function"
+        return self._info[thread_id][2]
+
+    @property
+    def distributed(self) -> _core.DistributedContext:
+        assert self._dist is not None, "Execute was configured make_distributed_context=False"
+        thread_id = threading.get_ident()
+        assert thread_id in self._info, "must be called from within an @Execute-decorated function"
+        return self._dist[self.rank]
+
+
+@contextlib.contextmanager
+def raises_when(pred: bool, *args: Any, **kwargs: Any) -> Iterator[None]:
+    """
+    A wrapper around pytest.raises that has a handy predicate argument.
+
+    Useful in @parallel.Execution.run-wrapped functions.
+
+    Example usage:
+
+        with parallel.Execution(2) as pex:
+            @pex.run
+            def all_workers_fn():
+                with raises_when(pex.rank!=0, AssertionError):
+                    assert pex.rank == 0
+
+    """
+    if not pred:
+        yield
+        return
+
+    with pytest.raises(*args, **kwargs):
+        yield


### PR DESCRIPTION
## Description

core_context.searcher.ops() needs to be coordinated across workers
the same way that core_context.preemption.should_preempt() is
coordinated across workers.

This change also includes tests for the new functionality.

## Commentary

I labeled this as a "user-facing change" because it's a deviation from previously-advertised Core API specs, even though technically it's still not a released API so it isn't any sort of breaking change.