### PR TITLE
chore: Clean up tests with fewer Optional types and asserts

### DIFF
--- a/e2e_tests/tests/cluster/test_agent_disable.py
+++ b/e2e_tests/tests/cluster/test_agent_disable.py
@@ -156,7 +156,6 @@ def test_drain_agent() -> None:
         exp.wait_for_experiment_state(experiment_id, determinedexperimentv1State.STATE_COMPLETED)
         trials = exp.experiment_trials(experiment_id)
         assert len(trials) == 1
-        assert trials[0].workloads is not None
         assert len(trials[0].workloads) == 7
 
         # Ensure the slot is empty.
@@ -226,7 +225,6 @@ def test_drain_agent_sched() -> None:
         trials1 = exp.experiment_trials(exp_id1)
         trials2 = exp.experiment_trials(exp_id2)
         assert len(trials1) == len(trials2) == 1
-        assert (trials1[0].workloads is not None) and (trials2[0].workloads is not None)
         assert len(trials1[0].workloads) == len(trials2[0].workloads) == 7
 
 

--- a/e2e_tests/tests/cluster/test_agent_restart.py
+++ b/e2e_tests/tests/cluster/test_agent_restart.py
@@ -376,7 +376,7 @@ def test_agent_restart_recover_experiment(managed_cluster: ManagedCluster, downt
         trials = exp.experiment_trials(exp_id)
 
         assert len(trials) == 1
-        train_wls = exp.workloads_for_mode(trials[0].workloads, "training")
+        train_wls = exp.workloads_with_training(trials[0].workloads)
         assert len(train_wls) == 5
     except Exception:
         managed_cluster.restart_agent()
@@ -403,7 +403,7 @@ def test_agent_reconnect_keep_experiment(managed_cluster: ManagedCluster) -> Non
         trials = exp.experiment_trials(exp_id)
 
         assert len(trials) == 1
-        train_wls = exp.workloads_for_mode(trials[0].workloads, "training")
+        train_wls = exp.workloads_with_training(trials[0].workloads)
         assert len(train_wls) == 5
     except Exception:
         managed_cluster.restart_proxy(wait_for_reconnect=False)

--- a/e2e_tests/tests/cluster/test_checkpoints.py
+++ b/e2e_tests/tests/cluster/test_checkpoints.py
@@ -108,10 +108,7 @@ def run_gc_checkpoints_test(checkpoint_storage: Dict[str, str]) -> None:
             trials = exp.experiment_trials(experiment_id)
             assert len(trials) == 1
 
-            cpoints = []
-            for cpoint in exp.workloads_for_mode(trials[0].workloads, "checkpoint"):
-                if cpoint.checkpoint:
-                    cpoints.append(cpoint.checkpoint)
+            cpoints = exp.workloads_with_checkpoint(trials[0].workloads)
             sorted_checkpoints = sorted(
                 cpoints,
                 key=lambda ckp: int(ckp.totalBatches),
@@ -144,7 +141,7 @@ def run_gc_checkpoints_test(checkpoint_storage: Dict[str, str]) -> None:
                 storage_manager = storage.build(checkpoint_config, container_path=None)
                 storage_state = {}  # type: Dict[str, Any]
                 for checkpoint in checkpoints:
-                    assert checkpoint.uuid
+                    assert checkpoint.uuid is not None
                     storage_id = checkpoint.uuid
                     storage_state[storage_id] = {}
                     if checkpoint.state == bindings.determinedcheckpointv1State.STATE_COMPLETED:

--- a/e2e_tests/tests/experiment/__init__.py
+++ b/e2e_tests/tests/experiment/__init__.py
@@ -29,7 +29,9 @@ from .experiment import (
     trial_logs,
     trial_metrics,
     wait_for_experiment_state,
-    workloads_for_mode,
+    workloads_with_checkpoint,
+    workloads_with_training,
+    workloads_with_validation,
 )
 
 from .record_profiling import (

--- a/e2e_tests/tests/experiment/test_core.py
+++ b/e2e_tests/tests/experiment/test_core.py
@@ -65,10 +65,8 @@ def test_metric_gathering() -> None:
         batches_trained = step["total_batches"]
 
     # Check validation metrics.
-    validation_workloads = exp.workloads_for_mode(trials[0].workloads, "validation")
-    for val in validation_workloads:
-        validation = val.validation
-        assert validation
+    validation_workloads = exp.workloads_with_validation(trials[0].workloads)
+    for validation in validation_workloads:
         actual = validation.metrics
         batches_trained = validation.totalBatches
 
@@ -112,10 +110,8 @@ def test_nan_metrics() -> None:
         batches_trained = step["total_batches"]
 
     # Check validation metrics.
-    validation_workloads = exp.workloads_for_mode(trials[0].workloads, "validation")
-    for val in validation_workloads:
-        validation = val.validation
-        assert validation and validation.metrics
+    validation_workloads = exp.workloads_with_validation(trials[0].workloads)
+    for validation in validation_workloads:
         actual = validation.metrics
         batches_trained = validation.totalBatches
         expected = structure_to_metrics(base_value, validation_structure)
@@ -254,10 +250,9 @@ def test_end_to_end_adaptive() -> None:
     trials = exp.experiment_trials(exp_id)
     best = None
     for trial in trials:
-        assert len(trial.workloads or [])
-        last_validation = exp.workloads_for_mode(trial.workloads, "validation")[-1]
-        assert last_validation.validation and last_validation.validation.metrics
-        accuracy = last_validation.validation.metrics["accuracy"]
+        assert len(trial.workloads) > 0
+        last_validation = exp.workloads_with_validation(trial.workloads)[-1]
+        accuracy = last_validation.metrics["accuracy"]
         if not best or accuracy > best:
             best = accuracy
 

--- a/e2e_tests/tests/experiment/test_noop.py
+++ b/e2e_tests/tests/experiment/test_noop.py
@@ -99,16 +99,13 @@ def test_noop_single_warm_start() -> None:
     first_trial_id = first_trial.id
 
     first_workloads = trials[0].workloads
-    assert len(first_workloads or []) == 90
-    checkpoints = exp.workloads_for_mode(first_workloads, "checkpoint")
-    assert len(checkpoints or []) == 30
-    assert checkpoints[0] and checkpoints[0].checkpoint
-    first_checkpoint_uuid = checkpoints[0].checkpoint.uuid
-    assert checkpoints[-1] and checkpoints[-1].checkpoint
-    last_checkpoint_uuid = checkpoints[-1].checkpoint.uuid
-    last_validation = exp.workloads_for_mode(first_workloads, "validation")[-1]
-    assert last_validation and last_validation.validation and last_validation.validation.metrics
-    assert last_validation.validation.metrics["validation_error"] == pytest.approx(0.9 ** 30)
+    assert len(first_workloads) == 90
+    checkpoints = exp.workloads_with_checkpoint(first_workloads)
+    assert len(checkpoints) == 30
+    first_checkpoint_uuid = checkpoints[0].uuid
+    last_checkpoint_uuid = checkpoints[-1].uuid
+    last_validation = exp.workloads_with_validation(first_workloads)[-1]
+    assert last_validation.metrics["validation_error"] == pytest.approx(0.9 ** 30)
 
     config_base = conf.load_config(conf.fixtures_path("no_op/single.yaml"))
 
@@ -123,22 +120,18 @@ def test_noop_single_warm_start() -> None:
     assert len(trials) == 1
 
     second_trial = trials[0]
-    assert len(second_trial.workloads or []) == 90
+    assert len(second_trial.workloads) == 90
 
     # Second trial should have a warm start checkpoint id.
-    assert second_trial.trial
     assert second_trial.trial.warmStartCheckpointUuid == last_checkpoint_uuid
 
-    val_workloads = exp.workloads_for_mode(second_trial.workloads, "validation")
-    assert (
-        val_workloads[-1] and val_workloads[-1].validation and val_workloads[-1].validation.metrics
-    )
-    assert val_workloads[-1].validation.metrics["validation_error"] == pytest.approx(0.9 ** 60)
+    val_workloads = exp.workloads_with_validation(second_trial.workloads)
+    assert val_workloads[-1].metrics["validation_error"] == pytest.approx(0.9 ** 60)
 
     # Now test source_checkpoint_uuid.
     config_obj = copy.deepcopy(config_base)
     # Add a source trial ID to warm start from.
-    config_obj["searcher"]["source_checkpoint_uuid"] = checkpoints[0].checkpoint.uuid
+    config_obj["searcher"]["source_checkpoint_uuid"] = checkpoints[0].uuid
 
     with tempfile.NamedTemporaryFile() as tf:
         with open(tf.name, "w") as f:
@@ -150,13 +143,11 @@ def test_noop_single_warm_start() -> None:
     assert len(trials) == 1
 
     third_trial = trials[0]
-    assert len(third_trial.workloads or []) == 90
+    assert len(third_trial.workloads) == 90
 
-    assert third_trial.trial
     assert third_trial.trial.warmStartCheckpointUuid == first_checkpoint_uuid
-    validations = exp.workloads_for_mode(third_trial.workloads, "validation")
-    assert validations[1] and validations[1].validation and validations[1].validation.metrics
-    assert validations[1].validation.metrics["validation_error"] == pytest.approx(0.9 ** 3)
+    validations = exp.workloads_with_validation(third_trial.workloads)
+    assert validations[1].metrics["validation_error"] == pytest.approx(0.9 ** 3)
 
 
 @pytest.mark.e2e_cpu
@@ -285,42 +276,31 @@ def _test_rng_restore(fixture: str, metrics: list, tf2: Union[None, bool] = None
 
     first_trial = exp.experiment_trials(experiment)[0]
 
-    assert len(first_trial.workloads or []) >= 4
+    assert len(first_trial.workloads) >= 4
 
-    first_checkpoint = exp.workloads_for_mode(first_trial.workloads, "checkpoint")[0]
-    assert first_checkpoint and first_checkpoint.checkpoint
-    first_checkpoint_uuid = first_checkpoint.checkpoint.uuid
+    first_checkpoint = exp.workloads_with_checkpoint(first_trial.workloads)[0]
+    first_checkpoint_uuid = first_checkpoint.uuid
 
     config = copy.deepcopy(config_base)
     if tf2 is not None:
         config = conf.set_tf2_image(config) if tf2 else conf.set_tf1_image(config)
-    config["searcher"]["source_checkpoint_uuid"] = first_checkpoint.checkpoint.uuid
+    config["searcher"]["source_checkpoint_uuid"] = first_checkpoint.uuid
 
     experiment2 = exp.run_basic_test_with_temp_config(config, conf.fixtures_path(fixture), 1)
 
     second_trial = exp.experiment_trials(experiment2)[0]
 
-    assert len(second_trial.workloads or []) >= 4
+    assert len(second_trial.workloads) >= 4
     assert second_trial.trial.warmStartCheckpointUuid == first_checkpoint_uuid
-    first_trial_validations = exp.workloads_for_mode(first_trial.workloads, "validation")
-    second_trial_validations = exp.workloads_for_mode(second_trial.workloads, "validation")
+    first_trial_validations = exp.workloads_with_validation(first_trial.workloads)
+    second_trial_validations = exp.workloads_with_validation(second_trial.workloads)
 
     for wl in range(0, 2):
         for metric in metrics:
             first_trial_val = first_trial_validations[wl + 1]
-            assert (
-                first_trial_val
-                and first_trial_val.validation
-                and first_trial_val.validation.metrics
-            )
-            first_metric = first_trial_val.validation.metrics[metric]
+            first_metric = first_trial_val.metrics[metric]
             second_trial_val = second_trial_validations[wl]
-            assert (
-                second_trial_val
-                and second_trial_val.validation
-                and second_trial_val.validation.metrics
-            )
-            second_metric = second_trial_val.validation.metrics[metric]
+            second_metric = second_trial_val.metrics[metric]
             assert (
                 first_metric == second_metric
             ), f"failures on iteration: {wl} with metric: {metric}"

--- a/e2e_tests/tests/experiment/test_pytorch.py
+++ b/e2e_tests/tests/experiment/test_pytorch.py
@@ -78,11 +78,10 @@ def test_pytorch_const_warm_start() -> None:
     first_trial = trials[0]
     first_trial_id = first_trial.trial.id
 
-    assert len(first_trial.workloads or []) == 4
-    checkpoints = exp.workloads_for_mode(first_trial.workloads, "checkpoint")
+    assert len(first_trial.workloads) == 4
+    checkpoints = exp.workloads_with_checkpoint(first_trial.workloads)
     first_checkpoint = checkpoints[-1]
-    assert first_checkpoint and first_checkpoint.checkpoint
-    first_checkpoint_uuid = first_checkpoint.checkpoint.uuid
+    first_checkpoint_uuid = first_checkpoint.uuid
 
     config_obj = conf.load_config(conf.tutorials_path("mnist_pytorch/const.yaml"))
 
@@ -176,11 +175,11 @@ def test_pytorch_gradient_aggregation() -> None:
     exp_id = exp.run_basic_test_with_temp_config(config, conf.fixtures_path("pytorch_identity"), 1)
     trials = exp.experiment_trials(exp_id)
     assert len(trials) == 1
-    workloads = exp.workloads_for_mode(trials[0].workloads, "validation")
+    workloads = exp.workloads_with_validation(trials[0].workloads)
     actual_weights = []
     for wl in workloads:
-        if wl.validation and wl.validation.metrics:
-            actual_weights.append(wl.validation.metrics["weight"])
+        if wl.metrics:
+            actual_weights.append(wl.metrics["weight"])
 
     # independently compute expected metrics
     batch_size = 4

--- a/e2e_tests/tests/experiment/test_tf_estimator.py
+++ b/e2e_tests/tests/experiment/test_tf_estimator.py
@@ -59,11 +59,9 @@ def test_mnist_estimator_warm_start(tf2: bool) -> None:
     first_trial = trials[0]
     first_trial_id = first_trial.trial.id
 
-    assert len(first_trial.workloads or []) == 3
-    checkpoint_workloads = exp.workloads_for_mode(first_trial.workloads, "checkpoint")
-    assert len(checkpoint_workloads)
-    assert checkpoint_workloads[0].checkpoint
-    first_checkpoint_uuid = checkpoint_workloads[0].checkpoint.uuid
+    assert len(first_trial.workloads) == 3
+    checkpoint_workloads = exp.workloads_with_checkpoint(first_trial.workloads)
+    first_checkpoint_uuid = checkpoint_workloads[0].uuid
 
     config_obj = conf.load_config(conf.fixtures_path("mnist_estimator/single.yaml"))
 
@@ -106,8 +104,7 @@ def test_custom_reducer_distributed(secrets: Dict[str, str], tf2: bool) -> None:
     )
 
     trial = exp.experiment_trials(experiment_id)[0]
-    last_validation = exp.workloads_for_mode(trial.workloads, "validation")[-1].validation
-    assert last_validation and last_validation.metrics
+    last_validation = exp.workloads_with_validation(trial.workloads)[-1]
     metrics = last_validation.metrics
     label_sum = 2 * sum(range(16))
     assert metrics["label_sum_fn"] == label_sum

--- a/e2e_tests/tests/experiment/test_tf_keras.py
+++ b/e2e_tests/tests/experiment/test_tf_keras.py
@@ -58,10 +58,9 @@ def test_tf_keras_const_warm_start(
     first_trial = trials[0]
     first_trial_id = first_trial.trial.id
 
-    assert len(first_trial.workloads or []) == 4
-    checkpoints = exp.workloads_for_mode(first_trial.workloads, "checkpoint")
-    assert checkpoints[0].checkpoint
-    first_checkpoint_uuid = checkpoints[0].checkpoint.uuid
+    assert len(first_trial.workloads) == 4
+    checkpoints = exp.workloads_with_checkpoint(first_trial.workloads)
+    first_checkpoint_uuid = checkpoints[0].uuid
 
     # Add a source trial ID to warm start from.
     config["searcher"]["source_trial_id"] = first_trial_id

--- a/harness/determined/cli/checkpoint.py
+++ b/harness/determined/cli/checkpoint.py
@@ -73,7 +73,7 @@ def list_checkpoints(args: Namespace) -> None:
         limit=args.best,
         sortBy=sorter,
     )
-    checkpoints = r.checkpoints or []
+    checkpoints = r.checkpoints
     searcher_metric = ""
     if len(checkpoints) > 0:
         config = checkpoints[0].experimentConfig or {}

--- a/harness/determined/cli/experiment.py
+++ b/harness/determined/cli/experiment.py
@@ -349,7 +349,7 @@ def describe(args: Namespace) -> None:
     wl_output: Dict[int, List[Any]] = {}
     for exp in exps:
         for trial in trials_for_experiment[exp.id]:
-            workloads = bindings.get_GetTrial(session, trialId=trial.id).workloads or []
+            workloads = bindings.get_GetTrial(session, trialId=trial.id).workloads
             for workload in workloads:
                 t_metrics_fields = []
                 wl_detail: Optional[
@@ -563,7 +563,7 @@ def scalar_training_metrics_names(
     consistent training metric names and types. Therefore, the first
     non-null batch metrics dictionary is used to extract names.
     """
-    for workload in workloads or []:
+    for workload in workloads:
         if workload.training:
             metrics = workload.training.metrics
             if not metrics:
@@ -576,7 +576,7 @@ def scalar_training_metrics_names(
 def scalar_validation_metrics_names(
     workloads: Optional[Sequence[bindings.GetTrialResponseWorkloadContainer]],
 ) -> Set[str]:
-    for workload in workloads or []:
+    for workload in workloads:
         if workload.validation:
             metrics = workload.validation.metrics
             if not metrics:

--- a/harness/determined/cli/experiment.py
+++ b/harness/determined/cli/experiment.py
@@ -553,7 +553,7 @@ def is_number(value: Any) -> bool:
 
 
 def scalar_training_metrics_names(
-    workloads: Optional[Sequence[bindings.GetTrialResponseWorkloadContainer]],
+    workloads: Sequence[bindings.GetTrialResponseWorkloadContainer],
 ) -> Set[str]:
     """
     Given an experiment history, return the names of training metrics
@@ -574,7 +574,7 @@ def scalar_training_metrics_names(
 
 
 def scalar_validation_metrics_names(
-    workloads: Optional[Sequence[bindings.GetTrialResponseWorkloadContainer]],
+    workloads: Sequence[bindings.GetTrialResponseWorkloadContainer],
 ) -> Set[str]:
     for workload in workloads:
         if workload.validation:

--- a/harness/determined/common/api/bindings.py
+++ b/harness/determined/common/api/bindings.py
@@ -2182,7 +2182,7 @@ class v1GetTrialResponse:
     def __init__(
         self,
         trial: "trialv1Trial",
-        workloads: "typing.Optional[typing.Sequence[GetTrialResponseWorkloadContainer]]" = None,
+        workloads: "typing.Sequence[GetTrialResponseWorkloadContainer]",
     ):
         self.trial = trial
         self.workloads = workloads
@@ -2191,13 +2191,13 @@ class v1GetTrialResponse:
     def from_json(cls, obj: Json) -> "v1GetTrialResponse":
         return cls(
             trial=trialv1Trial.from_json(obj["trial"]),
-            workloads=[GetTrialResponseWorkloadContainer.from_json(x) for x in obj["workloads"]] if obj.get("workloads", None) is not None else None,
+            workloads=[GetTrialResponseWorkloadContainer.from_json(x) for x in obj["workloads"]],
         )
 
     def to_json(self) -> typing.Any:
         return {
             "trial": self.trial.to_json(),
-            "workloads": [x.to_json() for x in self.workloads] if self.workloads is not None else None,
+            "workloads": [x.to_json() for x in self.workloads],
         }
 
 class v1GetUserResponse:
@@ -2861,11 +2861,11 @@ class v1Metrics:
 class v1MetricsWorkload:
     def __init__(
         self,
+        metrics: "typing.Dict[str, typing.Any]",
         numInputs: int,
         state: "determinedexperimentv1State",
         totalBatches: int,
         endTime: "typing.Optional[str]" = None,
-        metrics: "typing.Optional[typing.Dict[str, typing.Any]]" = None,
     ):
         self.endTime = endTime
         self.state = state
@@ -2878,7 +2878,7 @@ class v1MetricsWorkload:
         return cls(
             endTime=obj.get("endTime", None),
             state=determinedexperimentv1State(obj["state"]),
-            metrics=obj.get("metrics", None),
+            metrics=obj["metrics"],
             numInputs=obj["numInputs"],
             totalBatches=obj["totalBatches"],
         )
@@ -2887,7 +2887,7 @@ class v1MetricsWorkload:
         return {
             "endTime": self.endTime if self.endTime is not None else None,
             "state": self.state.value,
-            "metrics": self.metrics if self.metrics is not None else None,
+            "metrics": self.metrics,
             "numInputs": self.numInputs,
             "totalBatches": self.totalBatches,
         }

--- a/harness/determined/common/api/bindings.py
+++ b/harness/determined/common/api/bindings.py
@@ -1406,8 +1406,8 @@ class v1GetExperimentCheckpointsRequestSortBy(enum.Enum):
 class v1GetExperimentCheckpointsResponse:
     def __init__(
         self,
-        checkpoints: "typing.Optional[typing.Sequence[v1Checkpoint]]" = None,
-        pagination: "typing.Optional[v1Pagination]" = None,
+        checkpoints: "typing.Sequence[v1Checkpoint]",
+        pagination: "v1Pagination",
     ):
         self.checkpoints = checkpoints
         self.pagination = pagination
@@ -1415,14 +1415,14 @@ class v1GetExperimentCheckpointsResponse:
     @classmethod
     def from_json(cls, obj: Json) -> "v1GetExperimentCheckpointsResponse":
         return cls(
-            checkpoints=[v1Checkpoint.from_json(x) for x in obj["checkpoints"]] if obj.get("checkpoints", None) is not None else None,
-            pagination=v1Pagination.from_json(obj["pagination"]) if obj.get("pagination", None) is not None else None,
+            checkpoints=[v1Checkpoint.from_json(x) for x in obj["checkpoints"]],
+            pagination=v1Pagination.from_json(obj["pagination"]),
         )
 
     def to_json(self) -> typing.Any:
         return {
-            "checkpoints": [x.to_json() for x in self.checkpoints] if self.checkpoints is not None else None,
-            "pagination": self.pagination.to_json() if self.pagination is not None else None,
+            "checkpoints": [x.to_json() for x in self.checkpoints],
+            "pagination": self.pagination.to_json(),
         }
 
 class v1GetExperimentLabelsResponse:

--- a/proto/src/determined/api/v1/experiment.proto
+++ b/proto/src/determined/api/v1/experiment.proto
@@ -244,6 +244,10 @@ message GetExperimentCheckpointsRequest {
 
 // Response to GetExperimentCheckpointsRequest.
 message GetExperimentCheckpointsResponse {
+  option (grpc.gateway.protoc_gen_swagger.options.openapiv2_schema) = {
+    json_schema: { required: [ "checkpoints", "pagination" ] }
+  };
+
   // The list of returned checkpoints.
   repeated determined.checkpoint.v1.Checkpoint checkpoints = 1;
   // Pagination information of the full dataset.

--- a/proto/src/determined/api/v1/trial.proto
+++ b/proto/src/determined/api/v1/trial.proto
@@ -203,7 +203,7 @@ message GetTrialRequest {
 // Response to GetTrialRequest.
 message GetTrialResponse {
   option (grpc.gateway.protoc_gen_swagger.options.openapiv2_schema) = {
-    json_schema: { required: [ "trial" ] }
+    json_schema: { required: [ "trial", "workloads" ] }
   };
   // WorkloadContainer is a wrapper for Determined workloads to allow repeated
   // oneof types.

--- a/proto/src/determined/trial/v1/trial.proto
+++ b/proto/src/determined/trial/v1/trial.proto
@@ -30,7 +30,9 @@ message CheckpointWorkload {
 // MetricsWorkload is a workload generating metrics.
 message MetricsWorkload {
   option (grpc.gateway.protoc_gen_swagger.options.openapiv2_schema) = {
-    json_schema: { required: [ "state", "num_inputs", "total_batches" ] }
+    json_schema: {
+      required: [ "metrics", "state", "num_inputs", "total_batches" ]
+    }
   };
   // The time the workload finished or was stopped.
   google.protobuf.Timestamp end_time = 2;

--- a/webui/react/src/services/api-ts-sdk/api.ts
+++ b/webui/react/src/services/api-ts-sdk/api.ts
@@ -2729,7 +2729,7 @@ export interface V1GetTrialResponse {
      * @type {Array<GetTrialResponseWorkloadContainer>}
      * @memberof V1GetTrialResponse
      */
-    workloads?: Array<GetTrialResponseWorkloadContainer>;
+    workloads: Array<GetTrialResponseWorkloadContainer>;
 }
 
 /**
@@ -3449,7 +3449,7 @@ export interface V1MetricsWorkload {
      * @type {any}
      * @memberof V1MetricsWorkload
      */
-    metrics?: any;
+    metrics: any;
     /**
      * Number of inputs processed.
      * @type {number}

--- a/webui/react/src/services/api-ts-sdk/api.ts
+++ b/webui/react/src/services/api-ts-sdk/api.ts
@@ -1970,13 +1970,13 @@ export interface V1GetExperimentCheckpointsResponse {
      * @type {Array<V1Checkpoint>}
      * @memberof V1GetExperimentCheckpointsResponse
      */
-    checkpoints?: Array<V1Checkpoint>;
+    checkpoints: Array<V1Checkpoint>;
     /**
      * Pagination information of the full dataset.
      * @type {V1Pagination}
      * @memberof V1GetExperimentCheckpointsResponse
      */
-    pagination?: V1Pagination;
+    pagination: V1Pagination;
 }
 
 /**

--- a/webui/react/src/services/apiConfig.ts
+++ b/webui/react/src/services/apiConfig.ts
@@ -378,7 +378,7 @@ export const getExpTrials: Service.DetApi<
   postProcess: (response) => {
     return {
       pagination: response.pagination,
-      trials: response.trials.map(trial => decoder.decodeTrialResponseToTrialDetails({ trial })),
+      trials: response.trials.map(trial => ({ workloads: [], ...decoder.decodeV1TrialToTrialItem(trial)})),
     };
   },
   request: (params, options) => {

--- a/webui/react/src/services/apiConfig.ts
+++ b/webui/react/src/services/apiConfig.ts
@@ -378,7 +378,10 @@ export const getExpTrials: Service.DetApi<
   postProcess: (response) => {
     return {
       pagination: response.pagination,
-      trials: response.trials.map(trial => ({ workloads: [], ...decoder.decodeV1TrialToTrialItem(trial)})),
+      trials: response.trials.map(trial => ({
+        workloads: [],
+        ...decoder.decodeV1TrialToTrialItem(trial),
+      })),
     };
   },
   request: (params, options) => {

--- a/webui/react/src/services/decoder.ts
+++ b/webui/react/src/services/decoder.ts
@@ -463,7 +463,7 @@ export const decodeCheckpoint = (data: Sdk.V1Checkpoint): types.CheckpointDetail
   };
 };
 
-const decodeV1TrialToTrialItem = (data: Sdk.Trialv1Trial): types.TrialItem => {
+export const decodeV1TrialToTrialItem = (data: Sdk.Trialv1Trial): types.TrialItem => {
   return {
     bestAvailableCheckpoint: data.bestCheckpoint && decodeCheckpointWorkload(data.bestCheckpoint),
     bestValidationMetric: data.bestValidation && decodeMetricsWorkload(data.bestValidation),


### PR DESCRIPTION
## Description

During earlier changes to e2e_tests (#3539) I avoided issues with `Optional[]` types with some additional code -- `assert training_workloads is not None` or `for w in (workloads or []):`. Even if a trial has 0 workloads, the API will return an empty array, so we can mark this field as required and avoid `Optional[]` typing.  Similar reasoning to require metrics on a `MetricsWorkload`.

Marking these as required allows us to remove or simplify some code in e2e_tests.

I also replace `workloads_for_mode(wl, "training")` with `workloads_with_training(wl)` and other specific functions to avoid type differences between MetricWorkload and CheckpointWorkload.


## Checklist

- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.