### PR TITLE
feat: show agent version in `/agents` and `det agent list` [DET-6847]

### DIFF
--- a/agent/internal/agent.go
+++ b/agent/internal/agent.go
@@ -315,8 +315,8 @@ func (a *agent) makeMasterWebsocket(ctx *actor.Context) error {
 		TLSClientConfig:  tlsConfig,
 	}
 
-	masterAddr := fmt.Sprintf("%s://%s:%d/agents?id=%s&resource_pool=%s&reconnect=%t",
-		masterProto, a.MasterHost, a.MasterPort, a.AgentID, a.ResourcePool, a.reconnecting)
+	masterAddr := fmt.Sprintf("%s://%s:%d/agents?id=%s&version=%s&resource_pool=%s&reconnect=%t",
+		masterProto, a.MasterHost, a.MasterPort, a.AgentID, a.Version, a.ResourcePool, a.reconnecting)
 	ctx.Log().Infof("connecting to master at: %s", masterAddr)
 	conn, resp, err := dialer.Dial(masterAddr, nil)
 	if resp != nil {

--- a/e2e_tests/tests/cluster/test_agent.py
+++ b/e2e_tests/tests/cluster/test_agent.py
@@ -1,0 +1,19 @@
+import os
+
+import pytest
+
+import determined
+from determined.common import api
+from tests import config as conf
+
+
+# TODO: This should be marked as a cross-version test, but it can't actually be at the time of
+# writing, since older agent versions don't report their versions.
+@pytest.mark.e2e_cpu
+def test_agent_version() -> None:
+    # DET_AGENT_VERSION is available and specifies the agent version in cross-version tests; for
+    # other tests, this evaluates to the current version.
+    target_version = os.environ.get("DET_AGENT_VERSION") or determined.__version__
+    agents = api.get(conf.make_master_url(), "agents").json()
+
+    assert all(agent["version"] == target_version for agent in agents.values())

--- a/harness/determined/cli/agent.py
+++ b/harness/determined/cli/agent.py
@@ -26,6 +26,7 @@ def list_agents(args: argparse.Namespace) -> None:
         OrderedDict(
             [
                 ("id", local_id(agent_id)),
+                ("version", agent["version"]),
                 ("registered_time", render.format_time(agent["registered_time"])),
                 ("num_slots", len(agent["slots"])),
                 ("num_containers", agent["num_containers"]),
@@ -45,6 +46,7 @@ def list_agents(args: argparse.Namespace) -> None:
 
     headers = [
         "Agent ID",
+        "Version",
         "Registered Time",
         "Slots",
         "Containers",

--- a/harness/determined/common/api/bindings.py
+++ b/harness/determined/common/api/bindings.py
@@ -387,6 +387,7 @@ class v1Agent:
         registeredTime: "typing.Optional[str]" = None,
         resourcePool: "typing.Optional[str]" = None,
         slots: "typing.Optional[typing.Dict[str, v1Slot]]" = None,
+        version: "typing.Optional[str]" = None,
     ):
         self.id = id
         self.registeredTime = registeredTime
@@ -397,6 +398,7 @@ class v1Agent:
         self.addresses = addresses
         self.enabled = enabled
         self.draining = draining
+        self.version = version
 
     @classmethod
     def from_json(cls, obj: Json) -> "v1Agent":
@@ -410,6 +412,7 @@ class v1Agent:
             addresses=obj.get("addresses", None),
             enabled=obj.get("enabled", None),
             draining=obj.get("draining", None),
+            version=obj.get("version", None),
         )
 
     def to_json(self) -> typing.Any:
@@ -423,6 +426,7 @@ class v1Agent:
             "addresses": self.addresses if self.addresses is not None else None,
             "enabled": self.enabled if self.enabled is not None else None,
             "draining": self.draining if self.draining is not None else None,
+            "version": self.version if self.version is not None else None,
         }
 
 class v1AgentUserGroup:

--- a/master/internal/resourcemanagers/agent/agent.go
+++ b/master/internal/resourcemanagers/agent/agent.go
@@ -34,6 +34,7 @@ type (
 		resourcePoolName string
 		// started tracks if we have received the AgentStarted message.
 		started bool
+		version string
 
 		maxZeroSlotContainers int
 		agentReconnectWait    time.Duration
@@ -118,6 +119,7 @@ func (a *agent) receive(ctx *actor.Context, msg interface{}) error {
 		socket, ok := msg.Accept(ctx, aproto.MasterMessage{}, true)
 		check.Panic(check.True(ok, "failed to accept websocket connection"))
 		a.socket = socket
+		a.version = msg.Ctx.QueryParam("version")
 
 		lastColonIndex := strings.LastIndex(msg.Ctx.Request().RemoteAddr, ":")
 		if lastColonIndex == -1 {
@@ -470,6 +472,7 @@ func (a *agent) summarize(ctx *actor.Context) model.AgentSummary {
 		Enabled:       true,
 		Draining:      false,
 		NumContainers: 0,
+		Version:       a.version,
 	}
 
 	if a.agentState != nil {

--- a/master/internal/resourcemanagers/agent/agents.go
+++ b/master/internal/resourcemanagers/agent/agents.go
@@ -68,7 +68,8 @@ func (a *agents) Receive(ctx *actor.Context) error {
 			return nil
 		}
 
-		if ref, err := a.createAgentActor(ctx, id, resourcePool, a.opts); err != nil {
+		version := msg.Ctx.QueryParam("version")
+		if ref, err := a.createAgentActor(ctx, id, version, resourcePool, a.opts); err != nil {
 			ctx.Respond(err)
 		} else {
 			ctx.Respond(ctx.Ask(ref, msg).Get())
@@ -89,7 +90,7 @@ func (a *agents) Receive(ctx *actor.Context) error {
 }
 
 func (a *agents) createAgentActor(
-	ctx *actor.Context, id, resourcePool string, opts *aproto.MasterSetAgentOptions,
+	ctx *actor.Context, id, version, resourcePool string, opts *aproto.MasterSetAgentOptions,
 ) (*actor.Ref, error) {
 	if id == "" {
 		return nil, errors.Errorf("invalid agent id specified: %s", id)
@@ -107,6 +108,7 @@ func (a *agents) createAgentActor(
 	ref, ok := ctx.ActorOf(id, &agent{
 		resourcePool:          resourcePoolRef,
 		resourcePoolName:      resourcePool,
+		version:               version,
 		maxZeroSlotContainers: rpConfig.MaxZeroSlotContainers,
 		agentReconnectWait:    time.Duration(rpConfig.AgentReconnectWait),
 		agentReattachEnabled:  rpConfig.AgentReattachEnabled,

--- a/master/pkg/model/agent.go
+++ b/master/pkg/model/agent.go
@@ -20,6 +20,7 @@ type AgentSummary struct {
 	Addresses      []string     `json:"addresses"`
 	Enabled        bool         `json:"enabled"`
 	Draining       bool         `json:"draining"`
+	Version        string       `json:"version"`
 }
 
 // ToProto converts an agent summary to a proto struct.
@@ -38,6 +39,7 @@ func (a AgentSummary) ToProto() *agentv1.Agent {
 		Addresses:      a.Addresses,
 		Enabled:        a.Enabled,
 		Draining:       a.Draining,
+		Version:        a.Version,
 	}
 }
 

--- a/proto/src/determined/agent/v1/agent.proto
+++ b/proto/src/determined/agent/v1/agent.proto
@@ -29,6 +29,8 @@ message Agent {
   // Flag notifying if this agent is in the draining mode: current containers
   // will be allowed to finish but no new ones will be scheduled.
   bool draining = 9;
+  // The Determined version that this agent was built from.
+  string version = 10;
 }
 
 // Slot wraps a single device on the agent.

--- a/webui/react/src/services/api-ts-sdk/api.ts
+++ b/webui/react/src/services/api-ts-sdk/api.ts
@@ -829,6 +829,12 @@ export interface V1Agent {
      * @memberof V1Agent
      */
     draining?: boolean;
+    /**
+     * The Determined version that this agent was built from.
+     * @type {string}
+     * @memberof V1Agent
+     */
+    version?: string;
 }
 
 /**


### PR DESCRIPTION
## Description

Simply make the agent report its Determined version as a query parameter
when it connects to the master, and then thread that information through
to the API endpoint and CLI.

## Test Plan

- [x] manual: start cluster, check `det a` output, kill agent, change `VERSION` file, rebuild and rerun agent, check `det a` output
- [x] add test that API endpoint reports current version

## Commentary (optional)

The test should ideally be a cross-version test so that we can confirm that the endpoint returns the actual agent version and not always the current master version, but we can't do that right now because older agents don't report their versions at all. (At least using older agents just leads to the master treating the version as an empty string, not erroring out.)
