### PR TITLE
chore: remove internal flag from det.launch.horovod --help

### DIFF
--- a/harness/determined/launch/horovod.py
+++ b/harness/determined/launch/horovod.py
@@ -189,7 +189,7 @@ def parse_args(args: List[str]) -> Tuple[List[str], List[str], bool]:
 
     # Then parse the rest of the commands normally.
     parser = argparse.ArgumentParser(
-        usage="%(prog)s [[HVD_OVERRIDES...] --] [--autohorovod] (--trial TRIAL)|(SCRIPT...)",
+        usage="%(prog)s [[HVD_OVERRIDES...] --] (--trial TRIAL)|(SCRIPT...)",
         description=(
             "Launch a script under horovodrun on a Determined cluster, with automatic handling of "
             "IP addresses, sshd containers, and shutdown mechanics."


### PR DESCRIPTION
This flag was left in the --help text on accident.