### PR TITLE
fix: avoid double-timestamps in logs

### DIFF
--- a/harness/determined/common/_logging.py
+++ b/harness/determined/common/_logging.py
@@ -11,6 +11,6 @@ def set_logger(debug_enabled: bool) -> None:
 
     handler = logging.StreamHandler(sys.stdout)
     handler.setLevel(logging.DEBUG if debug_enabled else logging.INFO)
-    formatter = logging.Formatter("%(levelname)s [%(process)s]: %(message)s")
+    formatter = logging.Formatter("%(levelname)s [%(process)s]: %(name)s: %(message)s")
     handler.setFormatter(formatter)
     root.addHandler(handler)

--- a/harness/determined/common/_logging.py
+++ b/harness/determined/common/_logging.py
@@ -11,6 +11,6 @@ def set_logger(debug_enabled: bool) -> None:
 
     handler = logging.StreamHandler(sys.stdout)
     handler.setLevel(logging.DEBUG if debug_enabled else logging.INFO)
-    formatter = logging.Formatter("%(levelname)s: %(message)s")
+    formatter = logging.Formatter("%(levelname)s [%(process)s]: %(message)s")
     handler.setFormatter(formatter)
     root.addHandler(handler)

--- a/harness/determined/exec/harness.py
+++ b/harness/determined/exec/harness.py
@@ -10,15 +10,6 @@ from determined import _core, horovod, load
 from determined.common.api import analytics, certs
 
 
-def config_logging(debug: bool) -> None:
-    log_level = logging.DEBUG if debug else logging.INFO
-    logging.basicConfig(
-        level=log_level, format="%(asctime)s:%(levelname)s [%(process)s]: %(message)s"
-    )
-    logging.getLogger().setLevel(log_level)
-    logging.debug("Starting harness.")
-
-
 @contextlib.contextmanager
 def maybe_periodic_stacktraces(debug_enabled: bool) -> Iterator[None]:
     if debug_enabled:
@@ -75,7 +66,8 @@ def main(train_entrypoint: Optional[str]) -> int:
         on_cluster=True,
     )
 
-    config_logging(env.debug)
+    det.common.set_logger(env.debug)
+    logging.debug("Starting harness.")
 
     with maybe_periodic_stacktraces(env.debug):
         # Step 1: Load user code.


### PR DESCRIPTION
We attach timestamps to all logs after-the-fact, so the python logging
library needs to be configured to not also emit timestamps.

Apparently, this was broken in distributed training since 0.17.0, and
recently it became broken in non-distributed training as well.

The source of the bug was that there used to be two common paths by
which we configured logs, which I did not realize, and so in the push
architecture refactor I unwittingly took the worse one and used it on a
new code path.

This fix deletes that way to configure logs and uses the remaining way
everywhere.