### PR TITLE
docs: fix description of scheduling_unit behavior

### DIFF
--- a/docs/training-apis/experiment-config.txt
+++ b/docs/training-apis/experiment-config.txt
@@ -83,10 +83,12 @@ example:
    preemption, in the unit of batches. The number of records in a batch is controlled by the
    :ref:`global_batch_size <config-global-batch-size>` hyperparameter. Defaults to ``100``.
 
-   -  Setting this to be a small number can reduce the overhead of system operations.
-   -  Setting this to be too large might prevent the system to preempt the resources of this trial
-      to run other tasks.
-   -  As a rule of thumb, it should be set to make each step take 60--180 seconds.
+   -  Setting this value too small can increase the overhead of system operations and decrease
+      training throughput.
+   -  Setting this value too large might prevent the system from reallocating resources from this
+      workload to another, potentially more important, workload.
+   -  As a rule of thumb, it should be set to the number of batches that can be trained in roughly
+      60--180 seconds.
 
 .. _config-records-per-epoch:
 
@@ -508,7 +510,7 @@ This configuration defines the following hyperparameters:
 -  ``layer1_dropout``: a double hyperparameter
 
 The field ``optimizer_config`` demonstrates how nesting can be used to organize hyperparameters.
-Arbitrary levels of nesting is supported with all types of hyperparameters. Aside from
+Arbitrary levels of nesting are supported with all types of hyperparameters. Aside from
 hyperparameters with constant values, the four types of hyperparameters -- ``categorical``,
 ``double``, ``int``, and ``log`` -- can take on a range of possible values. The following sections
 cover how to configure the hyperparameter range for each type of hyperparameter.
@@ -936,7 +938,7 @@ The ``resources`` section defines the resources that an experiment is allowed to
 ``priority``
    The priority assigned to this experiment. Only applicable when using the ``priority`` scheduler.
    Experiments with smaller priority values are scheduled before experiments with higher priority
-   values. If using Kubernetes, the opposite is true; experiments with higher priorites are
+   values. If using Kubernetes, the opposite is true; experiments with higher priorities are
    scheduled before those with lower priorities. Refer to :ref:`scheduling` for more information.
 
 ``resource_pool``
@@ -1278,9 +1280,10 @@ would read as shown below.
    max_length:
      batches: 900
 
-To express it terms of records or epochs, ``records`` or ``epochs`` would be specified in place of
-``batches``. In the case of epochs, :ref:`records_per_epoch <config-records-per-epoch>` must also be
-specified. Below is an example that configures a ``single`` searcher to train a model for 64 epochs.
+To express it in terms of records or epochs, ``records`` or ``epochs`` would be specified in place
+of ``batches``. In the case of epochs, :ref:`records_per_epoch <config-records-per-epoch>` must also
+be specified. Below is an example that configures a ``single`` searcher to train a model for 64
+epochs.
 
 .. code:: yaml
 


### PR DESCRIPTION
Make a few other minor fixes.

## Description

<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At a minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions about this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ