### PR TITLE
chore: sweeping rename of Core API components

### DIFF
--- a/e2e_tests/tests/fixtures/metric_maker/metric_maker.py
+++ b/e2e_tests/tests/fixtures/metric_maker/metric_maker.py
@@ -107,7 +107,7 @@ class MetricMaker(det.TrialController):
         self.latest_batch = self.env.latest_batch
 
         if self.env.latest_checkpoint is not None:
-            with self.context._core.checkpointing.restore_path(
+            with self.context._core.checkpoint.restore_path(
                 self.env.latest_checkpoint
             ) as load_path:
                 self.load(pathlib.Path(load_path))
@@ -129,7 +129,7 @@ class MetricMaker(det.TrialController):
             elif w.kind == workload.Workload.Kind.CHECKPOINT_MODEL:
                 metadata = {"latest_batch": self.latest_batch}
                 if self.is_chief:
-                    with self.context._core.checkpointing.store_path(metadata) as (
+                    with self.context._core.checkpoint.store_path(metadata) as (
                         storage_id,
                         path,
                     ):

--- a/e2e_tests/tests/fixtures/no_op/model_def.py
+++ b/e2e_tests/tests/fixtures/no_op/model_def.py
@@ -89,7 +89,7 @@ class NoOpTrialController(det.TrialController):
         self.latest_batch = self.env.latest_batch
 
         if self.env.latest_checkpoint is not None:
-            with self.context._core.checkpointing.restore_path(
+            with self.context._core.checkpoint.restore_path(
                 self.env.latest_checkpoint
             ) as load_path:
                 self.load(pathlib.Path(load_path))
@@ -113,7 +113,7 @@ class NoOpTrialController(det.TrialController):
             elif w.kind == workload.Workload.Kind.CHECKPOINT_MODEL:
                 metadata = {"latest_batch": self.latest_batch}
                 if self.is_chief:
-                    with self.context._core.checkpointing.store_path(metadata) as (
+                    with self.context._core.checkpoint.store_path(metadata) as (
                         storage_id,
                         path,
                     ):

--- a/examples/deepspeed/gpt_neox/gpt2_trial.py
+++ b/examples/deepspeed/gpt_neox/gpt2_trial.py
@@ -42,9 +42,9 @@ class GPT2Trial(DeepSpeedTrial):
         self.wrapped_writer = TorchWriter()
         self.neox_args.tensorboard_writer = self.wrapped_writer.writer
         self.neox_args.configure_distributed_args()
-        # The tokenizer needs to be built before model initialization in order to set the 
+        # The tokenizer needs to be built before model initialization in order to set the
         # required padded_vocab_size argument.
-        self.neox_args.build_tokenizer()  
+        self.neox_args.build_tokenizer()
         megatron_train.initialize_megatron(neox_args=self.neox_args)
         self.timers = megatron_utils.Timers(
             use_wandb=False, tensorboard_writer=self.neox_args.tensorboard_writer

--- a/harness/determined/_core/__init__.py
+++ b/harness/determined/_core/__init__.py
@@ -1,17 +1,17 @@
-from determined._core._distributed import DistributedContext, DummyDistributed
-from determined._core._checkpointing import Checkpointing, DummyCheckpointing
-from determined._core._training import Training, DummyTraining, EarlyExitReason
+from determined._core._distributed import DistributedContext, DummyDistributedContext
+from determined._core._checkpoint import CheckpointContext, DummyCheckpointContext
+from determined._core._train import TrainContext, DummyTrainContext, EarlyExitReason
 from determined._core._searcher import (
-    DummySearcher,
-    OpsMode,
-    Searcher,
-    SearcherOp,
+    DummySearcherContext,
+    SearcherMode,
+    SearcherContext,
+    SearcherOperation,
     Unit,
     _parse_searcher_units,
 )
-from determined._core._preemption import (
-    DummyPreemption,
-    Preemption,
+from determined._core._preempt import (
+    DummyPreemptContext,
+    PreemptContext,
     _PreemptionWatcher,
     PreemptMode,
 )

--- a/harness/determined/_core/_checkpoint.py
+++ b/harness/determined/_core/_checkpoint.py
@@ -10,7 +10,7 @@ from determined.common.experimental.session import Session
 logger = logging.getLogger("determined.core")
 
 
-class Checkpointing:
+class CheckpointContext:
     """
     Some checkpoint-related REST API wrappers.
     """
@@ -131,7 +131,7 @@ class Checkpointing:
             self._tbd_mgr.sync()
 
 
-class DummyCheckpointing(Checkpointing):
+class DummyCheckpointContext(CheckpointContext):
     def __init__(
         self,
         dist: _core.DistributedContext,

--- a/harness/determined/_core/_context.py
+++ b/harness/determined/_core/_context.py
@@ -21,28 +21,28 @@ class Context:
 
     def __init__(
         self,
-        checkpointing: _core.Checkpointing,
+        checkpoint: _core.CheckpointContext,
         distributed: Optional[_core.DistributedContext] = None,
-        preemption: Optional[_core.Preemption] = None,
-        training: Optional[_core.Training] = None,
-        searcher: Optional[_core.Searcher] = None,
+        preempt: Optional[_core.PreemptContext] = None,
+        train: Optional[_core.TrainContext] = None,
+        searcher: Optional[_core.SearcherContext] = None,
     ) -> None:
-        self.checkpointing = checkpointing
-        self.distributed = distributed or _core.DummyDistributed()
-        self.preemption = preemption or _core.DummyPreemption(self.distributed)
-        self.training = training or _core.DummyTraining()
-        self.searcher = searcher or _core.DummySearcher(self.distributed)
+        self.checkpoint = checkpoint
+        self.distributed = distributed or _core.DummyDistributedContext()
+        self.preempt = preempt or _core.DummyPreemptContext(self.distributed)
+        self.train = train or _core.DummyTrainContext()
+        self.searcher = searcher or _core.DummySearcherContext(self.distributed)
 
     def __enter__(self) -> "Context":
-        self.preemption.start()
+        self.preempt.start()
         return self
 
     def __exit__(self, typ: type, value: Exception, tb: Any) -> None:
-        self.preemption.close()
+        self.preempt.close()
         self.distributed.close()
         # Detect some specific exceptions that are part of the user-facing API.
         if isinstance(value, det.InvalidHP):
-            self.training.report_early_exit(_core.EarlyExitReason.INVALID_HP)
+            self.train.report_early_exit(_core.EarlyExitReason.INVALID_HP)
             logger.info("InvalidHP detected during Trial init, converting InvalidHP to exit(0)")
             exit(0)
 
@@ -59,23 +59,23 @@ def _dummy_init(
     when it is detected that there is no ClusterInfo available, but can be invoked directly for
     e.g. local test mode.
     """
-    distributed = distributed or _core.DummyDistributed()
-    preemption = _core.DummyPreemption(distributed, preempt_mode)
+    distributed = distributed or _core.DummyDistributedContext()
+    preempt = _core.DummyPreemptContext(distributed, preempt_mode)
 
     if storage_manager is None:
         base_path = appdirs.user_data_dir("determined")
         logger.info("no storage_manager provided; storing checkpoints in {base_path}")
         storage_manager = storage.SharedFSStorageManager(base_path)
-    checkpointing = _core.DummyCheckpointing(distributed, storage_manager)
+    checkpoint = _core.DummyCheckpointContext(distributed, storage_manager)
 
-    training = _core.DummyTraining()
-    searcher = _core.DummySearcher(distributed)
+    train = _core.DummyTrainContext()
+    searcher = _core.DummySearcherContext(distributed)
 
     return Context(
         distributed=distributed,
-        checkpointing=checkpointing,
-        preemption=preemption,
-        training=training,
+        checkpoint=checkpoint,
+        preempt=preempt,
+        train=train,
         searcher=searcher,
     )
 
@@ -103,15 +103,15 @@ def init(
         if len(info.container_addrs) > 1 or len(info.slot_ids) > 1:
             raise ValueError("you must provide a valid DistributedContext for a multi-slot task")
 
-    distributed = distributed or _core.DummyDistributed()
+    distributed = distributed or _core.DummyDistributedContext()
 
-    preemption = _core.Preemption(session, info.allocation_id, distributed, preempt_mode)
+    preempt = _core.PreemptContext(session, info.allocation_id, distributed, preempt_mode)
 
     # At present, we only support tensorboards in Trial tasks.
     tbd_mgr = None
     tbd_writer = None
 
-    training = None
+    train = None
     searcher = None
 
     if info.task_type == "TRIAL":
@@ -125,7 +125,7 @@ def init(
         )
         tbd_writer = tensorboard.get_metric_writer()
 
-        training = _core.Training(
+        train = _core.TrainContext(
             session,
             info.trial.trial_id,
             info.trial._trial_run_id,
@@ -134,7 +134,7 @@ def init(
             tbd_writer,
         )
         units = _core._parse_searcher_units(info.trial._config)
-        searcher = _core.Searcher(
+        searcher = _core.SearcherContext(
             session,
             distributed,
             info.trial.trial_id,
@@ -155,7 +155,7 @@ def init(
             "trial_run_id": info.trial._trial_run_id,
         }
 
-        checkpointing = _core.Checkpointing(
+        checkpoint = _core.CheckpointContext(
             distributed, storage_manager, session, api_path, static_metadata, tbd_mgr
         )
 
@@ -165,12 +165,12 @@ def init(
             base_path = appdirs.user_data_dir("determined")
             logger.info("no storage_manager provided; storing checkpoints in {base_path}")
             storage_manager = storage.SharedFSStorageManager(base_path)
-        checkpointing = _core.DummyCheckpointing(distributed, storage_manager)
+        checkpoint = _core.DummyCheckpointContext(distributed, storage_manager)
 
     return Context(
         distributed=distributed,
-        checkpointing=checkpointing,
-        preemption=preemption,
-        training=training,
+        checkpoint=checkpoint,
+        preempt=preempt,
+        train=train,
         searcher=searcher,
     )

--- a/harness/determined/_core/_distributed.py
+++ b/harness/determined/_core/_distributed.py
@@ -25,6 +25,13 @@ class DistributedContext:
 
     Additionally, any time that cross_size > 1, you must also provide:
      - chief_ip: the ip address to reach the chief worker (where rank==0)
+
+    .. note::
+
+       DistributedContext has .allgather(), .gather(), and .broadcast() methods, which are easy to
+       use and which can be useful for coordinating work across workers, but it is not a replacement
+       for the allgather/gather/broadcast operations in your particular distributed training
+       framework.
     """
 
     def __init__(
@@ -135,12 +142,12 @@ class DistributedContext:
 
             # Do a global allgather to initialize local clients on every node.
             local_chief = (self.cross_rank, pub_url, pull_url)
-            _ = self._zmq_allgather(local_chief)
+            _ = self.allgather(local_chief)
             self._local_chief_zmq.safe_start(lambda: None)
 
         else:
             # Start with the global allgather.
-            all_local_chiefs = self._zmq_allgather(None)
+            all_local_chiefs = self.allgather(None)
             my_local_chief = [
                 x for x in all_local_chiefs if x is not None and x[0] == self.cross_rank
             ]
@@ -258,9 +265,12 @@ class DistributedContext:
         """
         return self.cross_size
 
-    def _zmq_gather(self, stuff: Any) -> Optional[List]:
+    def gather(self, stuff: Any) -> Optional[List]:
         """
         Gather stuff to the chief.  The chief returns a list of all stuff, and workers return None.
+
+        gather() is not a replacement for the gather functionality of your distributed training
+        framework.
         """
         if self.size < 2:
             return [stuff]
@@ -279,10 +289,13 @@ class DistributedContext:
         logging.debug(f"Worker {self.get_rank()} finished zmq gather.")
         return out
 
-    def _zmq_gather_local(self, stuff: Any) -> Optional[List]:
+    def gather_local(self, stuff: Any) -> Optional[List]:
         """
         Gather stuff to the local chief.  The local chief returns a list of all stuff, and local
         workers return None.
+
+        gather_local() is not a replacement for the gather functionality of your distributed
+        training framework.
         """
         if self.local_size < 2:
             return [stuff]
@@ -301,9 +314,12 @@ class DistributedContext:
         logging.debug(f"Worker {self.get_rank()} finished zmq gather local.")
         return out
 
-    def _zmq_allgather(self, stuff: Any) -> List:
+    def allgather(self, stuff: Any) -> List:
         """
         Gather stuff to the chief and broadcast all of it back to the workers.
+
+        allgather() is not a replacement for the allgather functionality of your distributed
+        training framework.
         """
         if self.size < 2:
             return [stuff]
@@ -319,9 +335,12 @@ class DistributedContext:
         logging.debug(f"Worker {self.get_rank()} finished zmq allgather.")
         return all_stuff
 
-    def _zmq_allgather_local(self, stuff: Any) -> List:
+    def allgather_local(self, stuff: Any) -> List:
         """
         Gather stuff to the local chief and broadcast all of it back to the local workers.
+
+        allgather_local() is not a replacement for the allgather functionality of your distributed
+        training framework.
         """
         if self.local_size < 2:
             return [stuff]
@@ -337,9 +356,12 @@ class DistributedContext:
         logging.debug(f"Worker {self.get_rank()} finished zmq local allgather.")
         return all_stuff
 
-    def _zmq_broadcast(self, stuff: Any) -> Any:
+    def broadcast(self, stuff: Any) -> Any:
         """
         Every worker gets the value sent by the chief.
+
+        broadcast() is not a replacement for the broadcast functionality of your distributed
+        training framework.
         """
         if self.size < 2:
             return stuff
@@ -349,9 +371,12 @@ class DistributedContext:
             stuff = self._worker_zmq.recv()
         return stuff
 
-    def _zmq_broadcast_local(self, stuff: Any = None) -> Any:
+    def broadcast_local(self, stuff: Any = None) -> Any:
         """
         Every worker gets the value sent by the local chief.
+
+        broadcast_local() is not a replacement for the broadcast functionality of your distributed
+        training framework.
         """
         if self.local_size < 2:
             return stuff
@@ -373,12 +398,12 @@ class DistributedContext:
             def _fn(*args: Any, **kwargs: Any) -> Any:
                 with fn(*args, **kwargs) as out:
                     # broadcast to local workers
-                    _ = self._zmq_broadcast_local(out)
+                    _ = self.broadcast_local(out)
                     try:
                         yield out
                     finally:
                         # wait for local workers
-                        _ = self._zmq_gather_local(None)
+                        _ = self.gather_local(None)
 
         else:
 
@@ -386,17 +411,17 @@ class DistributedContext:
             @contextlib.contextmanager
             def _fn(*__: Any, **___: Any) -> Any:
                 # wait for local chief
-                out = self._zmq_broadcast_local(None)
+                out = self.broadcast_local(None)
                 try:
                     yield out
                 finally:
                     # wait for local workers
-                    _ = self._zmq_gather_local(None)
+                    _ = self.gather_local(None)
 
         return _fn
 
 
-class DummyDistributed(DistributedContext):
+class DummyDistributedContext(DistributedContext):
     def __init__(self) -> None:
         super().__init__(
             rank=0,

--- a/harness/determined/_core/_train.py
+++ b/harness/determined/_core/_train.py
@@ -17,7 +17,7 @@ class EarlyExitReason(enum.Enum):
     USER_REQUESTED_STOP = "EXITED_REASON_USER_REQUESTED_STOP"
 
 
-class Training:
+class TrainContext:
     """
     Some training-related REST API wrappers.
     """
@@ -154,7 +154,7 @@ class Training:
         return float(r.json()["metric"])
 
 
-class DummyTraining(Training):
+class DummyTrainContext(TrainContext):
     """ """
 
     def __init__(self) -> None:

--- a/harness/determined/estimator/_estimator_context.py
+++ b/harness/determined/estimator/_estimator_context.py
@@ -36,7 +36,7 @@ class EstimatorTrialContext(det.TrialContext, estimator._EstimatorReducerContext
 
     def __init__(self, *arg: Any, **kwarg: Any) -> None:
         det.TrialContext.__init__(self, *arg, **kwarg)
-        estimator._EstimatorReducerContext.__init__(self, self.distributed._zmq_allgather)
+        estimator._EstimatorReducerContext.__init__(self, self.distributed.allgather)
 
         self._per_slot_batch_size, self._global_batch_size = util.calculate_batch_sizes(
             self.get_hparams(),

--- a/harness/determined/keras/_tf_keras_trial.py
+++ b/harness/determined/keras/_tf_keras_trial.py
@@ -374,7 +374,7 @@ class TFKerasTrialController(det.TrialController):
         self.multiplexer_load_state = None  # type: Optional[Dict]
         if self.env.latest_checkpoint is not None:
             logging.info(f"Restoring trial from checkpoint {self.env.latest_checkpoint}")
-            with self.context._core.checkpointing.restore_path(
+            with self.context._core.checkpoint.restore_path(
                 self.env.latest_checkpoint
             ) as load_path:
                 self._load(pathlib.Path(load_path))
@@ -828,7 +828,7 @@ class TFKerasTrialController(det.TrialController):
                             "framework": f"tensorflow-{tf.__version__}",
                             "format": "saved_weights",
                         }
-                        with self.context._core.checkpointing.store_path(metadata) as (
+                        with self.context._core.checkpoint.store_path(metadata) as (
                             storage_id,
                             path,
                         ):
@@ -962,7 +962,7 @@ class TFKerasTrialController(det.TrialController):
             # Use a global ZMQ barrier here because we have observed cases where hvd.allreduce
             # may hang when called minutes apart by different workers which may happen if
             # workers complete evaluation at different speeds.
-            _ = self.context.distributed._zmq_gather(None)
+            _ = self.context.distributed.gather(None)
 
             num_inputs = hvd.allreduce(num_inputs, average=False, name="validation_num_inputs")
             if isinstance(num_inputs, EagerTensor):

--- a/harness/determined/pytorch/_metric_utils.py
+++ b/harness/determined/pytorch/_metric_utils.py
@@ -66,7 +66,7 @@ def _combine_metrics_across_processes(
     ), "_combine_metrics_across_processes should only be called if context.distributed > 1"
 
     # all_args is a list of [(metrics, num_batches), ...] for each worker.
-    all_args = context._zmq_gather((metrics, num_batches))
+    all_args = context.gather((metrics, num_batches))
 
     if not context.rank == 0:
         return None, None

--- a/harness/determined/pytorch/_pytorch_context.py
+++ b/harness/determined/pytorch/_pytorch_context.py
@@ -50,7 +50,7 @@ class PyTorchTrialContext(det.TrialContext, pytorch._PyTorchReducerContext):
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         det.TrialContext.__init__(self, *args, **kwargs)
-        pytorch._PyTorchReducerContext.__init__(self, self.distributed._zmq_allgather)
+        pytorch._PyTorchReducerContext.__init__(self, self.distributed.allgather)
         self._per_slot_batch_size, self._global_batch_size = util.calculate_batch_sizes(
             self.get_hparams(),
             self.env.experiment_config.slots_per_trial(),

--- a/harness/determined/pytorch/_pytorch_trial.py
+++ b/harness/determined/pytorch/_pytorch_trial.py
@@ -225,7 +225,7 @@ class PyTorchTrialController(det.TrialController):
             # If a load path is provided load weights and restore the data location.
             if self.env.latest_checkpoint is not None:
                 logging.info(f"Restoring trial from checkpoint {self.env.latest_checkpoint}")
-                with self.context._core.checkpointing.restore_path(
+                with self.context._core.checkpoint.restore_path(
                     self.env.latest_checkpoint
                 ) as load_path:
                     self._load(pathlib.Path(load_path))
@@ -273,7 +273,7 @@ class PyTorchTrialController(det.TrialController):
                             "framework": f"torch-{torch.__version__}",
                             "format": "pickle",
                         }
-                        with self.context._core.checkpointing.store_path(metadata) as (
+                        with self.context._core.checkpoint.store_path(metadata) as (
                             storage_id,
                             path,
                         ):
@@ -532,7 +532,7 @@ class PyTorchTrialController(det.TrialController):
             )
 
             # Gather a list of per-worker (num_inputs, num_batches) tuples.
-            input_counts = self.context.distributed._zmq_gather((num_inputs, idx + 1))
+            input_counts = self.context.distributed.gather((num_inputs, idx + 1))
             if self.context.distributed.rank == 0:
                 assert input_counts is not None
                 # Reshape and sum.

--- a/harness/determined/pytorch/deepspeed/_deepspeed_context.py
+++ b/harness/determined/pytorch/deepspeed/_deepspeed_context.py
@@ -76,7 +76,7 @@ class DeepSpeedTrialContext(det.TrialContext, pytorch._PyTorchReducerContext):
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         det.TrialContext.__init__(self, *args, **kwargs)
-        pytorch._PyTorchReducerContext.__init__(self, self.distributed._zmq_allgather)
+        pytorch._PyTorchReducerContext.__init__(self, self.distributed.allgather)
 
         self._init_device()
 

--- a/harness/tests/experiment/pytorch/test_reducer.py
+++ b/harness/tests/experiment/pytorch/test_reducer.py
@@ -90,7 +90,7 @@ def test_custom_reducer_slot_order(cross_size: int, local_size: int) -> None:
             chief_ip="localhost",
             force_tcp=False,
         )
-        reducer_context = _PyTorchReducerContext(distributed_context._zmq_allgather)
+        reducer_context = _PyTorchReducerContext(distributed_context.allgather)
         # reducer_context.wrap_reducer(lambda x: x, "dummy")
         wrapped_reducer = reducer_context.wrap_reducer(dummy_reducer)
         return DummyDistributedReducerContext(distributed_context, reducer_context, wrapped_reducer)

--- a/harness/tests/test_ipc.py
+++ b/harness/tests/test_ipc.py
@@ -164,23 +164,23 @@ def test_distributed_context(cross_size: int, local_size: int, force_tcp: bool) 
             )
 
         # Perform a broadcast.
-        results = pex.run(lambda: contexts[pex.rank]._zmq_broadcast(pex.rank))  # type: ignore
+        results = pex.run(lambda: contexts[pex.rank].broadcast(pex.rank))  # type: ignore
         assert results == [0] * size, "not all threads ran broadcast correctly"
 
         # Perform a local broadcast.
-        results = pex.run(lambda: contexts[pex.rank]._zmq_broadcast_local(pex.rank))
+        results = pex.run(lambda: contexts[pex.rank].broadcast_local(pex.rank))
         expect = [rank - (rank % local_size) for rank in range(size)]  # type: Any
 
         assert results == expect, "not all threads ran broadcast_local correctly"
 
         # Perform a gather.
-        results = pex.run(lambda: set(contexts[pex.rank]._zmq_gather(pex.rank) or []))
+        results = pex.run(lambda: set(contexts[pex.rank].gather(pex.rank) or []))
         chief = set(range(size))
         expect = [set(range(size)) if rank == 0 else set() for rank in range(size)]
         assert results == [chief] + [set()] * (size - 1), "not all threads ran gather correctly"
 
         # Perform a local gather.
-        results = pex.run(lambda: set(contexts[pex.rank]._zmq_gather_local(pex.rank) or []))
+        results = pex.run(lambda: set(contexts[pex.rank].gather_local(pex.rank) or []))
         expect = [
             set(range(rank, rank + local_size)) if rank % local_size == 0 else set()
             for rank in range(size)
@@ -188,12 +188,12 @@ def test_distributed_context(cross_size: int, local_size: int, force_tcp: bool) 
         assert results == expect, "not all threads ran gather correctly"
 
         # Perform an allgather.
-        results = pex.run(lambda: set(contexts[pex.rank]._zmq_allgather(pex.rank)))
+        results = pex.run(lambda: set(contexts[pex.rank].allgather(pex.rank)))
         expect = set(range(size))
         assert results == [expect] * size, "not all threads ran allgather correctly"
 
         # Perform a local allgather.
-        results = pex.run(lambda: set(contexts[pex.rank]._zmq_allgather_local(pex.rank)))
+        results = pex.run(lambda: set(contexts[pex.rank].allgather_local(pex.rank)))
         expect = [
             set(range(cross_rank * local_size, (cross_rank + 1) * local_size))
             for cross_rank, _ in itertools.product(range(cross_size), range(local_size))


### PR DESCRIPTION
Part 1: shorten names and use a consistent part of speech:

    core_context.training -> core_context.train
    core_context.checkpointing -> core_context.checkpoint
    core_context.preemption -> core_context.preempt
    # core_context.distributed stays because it matches e.g. torch.distributed
    # core_context.searcher stays because we like it better.

Part 2: Change the class name of each component of the Core API to
include "Context".  This won't really affect users but it's a bit clearer.

    core.Searcher -> core.SearcherContext
    core.Training -> core.TrainContext
    core.Preemption -> core.PreemptContext
    core.Checkpointing -> core.CheckpointContext
    # core.DistributedContext remains unchanged.

Part 3: avoid abbreviations

    core_context.search.ops -> core_context.search.operations
    core.SearcherOp -> core.SearcherOperation

Part 4: anything that must only be called by the chief is named report_*

    SearcherOperation.complete() -> SearcherOperation.report_completed()

Part 5: expose DistributedContext._zmq_*, stripping the _zmq_ prefix.
Originally, the prefix was meant to make it clear that
context.distributed.allgather() was definitely not hvd.allgather(), but
We care enough about not marrying the name to a particular communication
library that we are willing to sacrifice the clear hvd/zmq distinction
to avoid that.

    DistributedContext._zmq_allgather() -> DistributedContext.allgather()
    DistributedContext._zmq_gather() -> DistributedContext.gather()
    DistributedContext._zmq_broadcast() -> DistributedContext.broadcast()
    # etc

## Commentary

This PR adds a small bit of warning text to the _zmq_* methods, but otherwise is just one big rename PR.

## Test Plan

Normal tests should still pass.
