### PR TITLE
chore: fix deepspeed nightly tests

### DIFF
--- a/e2e_tests/tests/nightly/test_distributed.py
+++ b/e2e_tests/tests/nightly/test_distributed.py
@@ -229,7 +229,7 @@ def test_gpt_neox_zero_3D_parallel() -> None:
 @pytest.mark.deepspeed
 @pytest.mark.gpu_required
 def test_deepspeed_dcgan() -> None:
-    config = conf.load_config(conf.deepspeed_examples_path("dcgan/mnist.yaml"))
+    config = conf.load_config(conf.deepspeed_examples_path("deepspeed_dcgan/mnist.yaml"))
     config = conf.set_max_length(config, {"batches": 200})
 
     exp.run_basic_test_with_temp_config(config, conf.deepspeed_examples_path("dcgan"), 1)

--- a/e2e_tests/tests/nightly/test_distributed.py
+++ b/e2e_tests/tests/nightly/test_distributed.py
@@ -232,4 +232,4 @@ def test_deepspeed_dcgan() -> None:
     config = conf.load_config(conf.deepspeed_examples_path("deepspeed_dcgan/mnist.yaml"))
     config = conf.set_max_length(config, {"batches": 200})
 
-    exp.run_basic_test_with_temp_config(config, conf.deepspeed_examples_path("dcgan"), 1)
+    exp.run_basic_test_with_temp_config(config, conf.deepspeed_examples_path("deepspeed_dcgan"), 1)

--- a/examples/deepspeed/deepspeed_dcgan/cifar10_zero2.yaml
+++ b/examples/deepspeed/deepspeed_dcgan/cifar10_zero2.yaml
@@ -30,6 +30,7 @@ min_validation_period:
 entrypoint:
   - python3
   - -m
-  - determined.launch.autodeepspeed
+  - determined.launch.deepspeed
+  - --trial
   - model_def:DCGANTrial
 max_restarts: 0

--- a/examples/deepspeed/deepspeed_dcgan/mnist.yaml
+++ b/examples/deepspeed/deepspeed_dcgan/mnist.yaml
@@ -27,6 +27,7 @@ min_validation_period:
 entrypoint:
   - python3
   - -m
-  - determined.launch.autodeepspeed
+  - determined.launch.deepspeed
+  - --trial
   - model_def:DCGANTrial
 max_restarts: 0

--- a/examples/deepspeed/deepspeed_dcgan/mnist_grad_accum.yaml
+++ b/examples/deepspeed/deepspeed_dcgan/mnist_grad_accum.yaml
@@ -29,6 +29,7 @@ min_validation_period:
 entrypoint:
   - python3
   - -m
-  - determined.launch.autodeepspeed
+  - determined.launch.deepspeed
+  - --trial
   - model_def:DCGANTrial
 max_restarts: 0


### PR DESCRIPTION
## Description

Typo made it into `test_distributed` for DeepSpeed DCGAN example because I ran the wrong nightlies on the PR.

Also fixes entrypoint formatting.

## Test Plan

Check that DeepSpeed distributed nightly passes