### PR TITLE
feat: add core.DownloadMode

### DIFF
--- a/harness/determined/_core/__init__.py
+++ b/harness/determined/_core/__init__.py
@@ -1,5 +1,9 @@
 from determined._core._distributed import DistributedContext, DummyDistributedContext
-from determined._core._checkpoint import CheckpointContext, DummyCheckpointContext
+from determined._core._checkpoint import (
+    CheckpointContext,
+    DownloadMode,
+    DummyCheckpointContext,
+)
 from determined._core._train import TrainContext, DummyTrainContext, EarlyExitReason
 from determined._core._searcher import (
     DummySearcherContext,

--- a/harness/determined/_core/_checkpoint.py
+++ b/harness/determined/_core/_checkpoint.py
@@ -1,4 +1,5 @@
 import contextlib
+import enum
 import logging
 import os
 import pathlib
@@ -12,6 +13,25 @@ from determined.common.api import bindings
 from determined.common.experimental.session import Session
 
 logger = logging.getLogger("determined.core")
+
+
+class DownloadMode(enum.Enum):
+    """
+    DownloadMode defines the calling behavior of the .download() and the .restore_path() methods of
+    CheckpointContext. Frequently in Determined,
+
+    When mode=LocalWorkersShareDownload (the default), workers on the same physical node (the same
+    distributed.cross_rank) will share a single downloaded version of the checkpoint.  On an 8-GPU
+    node, this will frequently result in 8x bandwidth savings.  In this mode, all workers must call
+    .download() or .restore_path() in-step.
+
+    When mode=NoSharedDownload, no coordination is done.  This is useful if you either have
+    configured your own coordination, or if only a single worker needs a particular checkpoint.
+    There is no in-step calling requirement.
+    """
+
+    LocalWorkersShareDownload = "LOCAL_WORKERS_SHARE_DOWNLOAD"
+    NoSharedDownload = "NO_SHARED_DOWNLOAD"
 
 
 class CheckpointContext:
@@ -51,8 +71,8 @@ class CheckpointContext:
         """
 
         if self._dist.rank != 0:
-            raise ValueError(
-                "cannot call checkpointing.upload() from non-chief worker "
+            raise RuntimeError(
+                "cannot call CheckpointContext.upload() from non-chief worker "
                 f"(rank={self._dist.rank})"
             )
 
@@ -60,11 +80,16 @@ class CheckpointContext:
 
         storage_id = str(uuid.uuid4())
         self._storage_manager.upload(src=ckpt_dir, dst=storage_id)
-        resources = storage.StorageManager._list_directory(ckpt_dir)
+        resources = self._storage_manager._list_directory(ckpt_dir)
         self._report_checkpoint(storage_id, resources, metadata)
         return storage_id
 
-    def download(self, storage_id: str, ckpt_dir: Union[str, os.PathLike]) -> None:
+    def download(
+        self,
+        storage_id: str,
+        ckpt_dir: Union[str, os.PathLike],
+        download_mode: DownloadMode = DownloadMode.LocalWorkersShareDownload,
+    ) -> None:
         """
         Download the contents of a checkpoint from checkpoint storage into a directory specified by
         ckpt_dir, which will be created if it does not exist.
@@ -75,10 +100,21 @@ class CheckpointContext:
             the :class:`~determined.experiment.common.Checkpoint` class in the Determined Python
             SDK.  This .download() is here as a convenience.
         """
-
         ckpt_dir = os.fspath(ckpt_dir)
+        download_mode = DownloadMode(download_mode)
 
-        self._storage_manager.download(src=storage_id, dst=ckpt_dir)
+        if download_mode == DownloadMode.NoSharedDownload:
+            self._storage_manager.download(src=storage_id, dst=ckpt_dir)
+            return
+
+        # LocalWorkersShareDownload case.
+        if self._dist.local_rank == 0:
+            self._storage_manager.download(src=storage_id, dst=ckpt_dir)
+            # Tell local workers we finished.
+            _ = self._dist.broadcast_local(None)
+        else:
+            # Wait for chief to finish.
+            _ = self._dist.broadcast_local(None)
 
     def get_metadata(self, storage_id: str) -> Dict[str, Any]:
         """
@@ -106,44 +142,70 @@ class CheckpointContext:
 
         .. code::
 
-           with checkpointing.store_path() as (path, storage_id):
+           with core_context.checkpoint.store_path() as (path, storage_id):
                my_save_model(my_model, path)
                print(f"done saving checkpoint {storage_id}")
            print(f"done uploading checkpoint {storage_id}")
         """
 
         if self._dist.rank != 0:
-            raise ValueError(
-                "cannot call checkpointing.store_path() from non-chief worker "
+            raise RuntimeError(
+                "cannot call CheckpointContext.store_path() from non-chief worker "
                 f"(rank={self._dist.rank})"
             )
 
         storage_id = str(uuid.uuid4())
         with self._storage_manager.store_path(storage_id) as path:
             yield path, storage_id
-            resources = storage.StorageManager._list_directory(path)
+            resources = self._storage_manager._list_directory(path)
         self._report_checkpoint(storage_id, resources, metadata)
 
     @contextlib.contextmanager
-    def restore_path(self, storage_id: str) -> Iterator[pathlib.Path]:
+    def restore_path(
+        self,
+        storage_id: str,
+        download_mode: DownloadMode = DownloadMode.LocalWorkersShareDownload,
+    ) -> Iterator[pathlib.Path]:
         """
         restore_path is a context manager which downloads a checkpoint (if required by the storage
-        backend) and cleans it up afterwards (if necessary).
+        backend) and cleans up the temporary files afterwards (if applicable).
 
-        Note that with multiple workers, all workers must call restore_path, but only the local
-        chief worker on each node (distributed.local_rank==0) will actually download data.
+        In multi-worker scenarios, with the default download_mode (LocalWorkersShareDownload),
+        all workers must call restore_path, but only the local chief worker on each node
+        (distributed.local_rank==0) will actually download data.
 
         Example:
 
         .. code::
 
-           with checkpointing.restore_path(my_checkpoint_uuid) as path:
+           with core_context.checkpoint.restore_path(my_checkpoint_uuid) as path:
                my_model = my_load_model(path)
         """
+        download_mode = DownloadMode(download_mode)
 
-        restore_path = self._dist._local_chief_contextmanager(self._storage_manager.restore_path)
-        with restore_path(storage_id) as path:
-            yield path
+        if download_mode == DownloadMode.NoSharedDownload:
+            with self._storage_manager.restore_path(storage_id) as path:
+                yield path
+            return
+
+        # LocalWorkersShareDownload case.
+        if self._dist.local_rank == 0:
+            with self._storage_manager.restore_path(storage_id) as path:
+                # Broadcast to local workers.
+                _ = self._dist.broadcast_local(path)
+                try:
+                    yield path
+                finally:
+                    # Wait for local workers to finish.
+                    _ = self._dist.gather_local(None)
+        else:
+            # Wait for local chief to broadcast.
+            path = self._dist.broadcast_local(None)
+            try:
+                yield path
+            finally:
+                # Tell local chief we're done.
+                _ = self._dist.gather_local(None)
 
     def delete(self, storage_id: str) -> None:
         """

--- a/harness/tests/core/test_checkpoint.py
+++ b/harness/tests/core/test_checkpoint.py
@@ -1,0 +1,132 @@
+import contextlib
+import pathlib
+from typing import Any, Iterator
+from unittest import mock
+
+import pytest
+
+from determined import _core
+from tests import parallel
+
+
+def make_mock_storage_manager() -> Any:
+    @contextlib.contextmanager
+    def store_path(dst: str) -> Iterator[pathlib.Path]:
+        yield pathlib.Path("/store-path")
+
+    @contextlib.contextmanager
+    def restore_path(storage_id: str) -> Iterator[pathlib.Path]:
+        yield pathlib.Path("/restore-path")
+
+    storage_manager = mock.MagicMock()
+    storage_manager.store_path = mock.MagicMock(side_effect=store_path)
+    storage_manager.restore_path = mock.MagicMock(side_effect=restore_path)
+    storage_manager._list_directory = mock.MagicMock(return_value={"one": 1, "two": 2})
+
+    return storage_manager
+
+
+@pytest.mark.parametrize(
+    "mode",
+    [
+        _core.DownloadMode.LocalWorkersShareDownload,
+        _core.DownloadMode.NoSharedDownload,
+    ],
+    ids=lambda x: f"mode={x.name}",
+)
+@pytest.mark.parametrize("dummy", [False, True], ids=lambda x: f"dummy:{x}")
+def test_checkpoint_context(dummy: bool, mode: _core.DownloadMode) -> None:
+    with parallel.Execution(2) as pex:
+
+        @pex.run
+        def do_test() -> None:
+            storage_manager = make_mock_storage_manager()
+            if not dummy:
+                session = mock.MagicMock()
+                tbd_mgr = mock.MagicMock()
+                checkpoint_context = _core.CheckpointContext(
+                    pex.distributed,
+                    storage_manager,
+                    session=session,
+                    api_path="",
+                    static_metadata=None,
+                    tbd_mgr=tbd_mgr,
+                )
+            else:
+                checkpoint_context = _core.DummyCheckpointContext(pex.distributed, storage_manager)
+
+            # Test upload.
+            with parallel.raises_when(
+                pex.distributed.rank == 1,
+                RuntimeError,
+                match="upload.*non-chief",
+            ):
+                checkpoint_context.upload("ckpt-dir", metadata={"latest_batch": 1})
+            if pex.rank == 0:
+                storage_manager.upload.assert_called_once()
+                storage_manager.upload.reset_mock()
+                storage_manager._list_directory.assert_called_once()
+                storage_manager._list_directory.reset_mock()
+                if not dummy:
+                    session.post.assert_called_once()
+                    session.post.reset_mock()
+            else:
+                storage_manager.upload.assert_not_called()
+                storage_manager._list_directory.assert_not_called()
+                if not dummy:
+                    session.post.assert_not_called()
+                    tbd_mgr.sync.assert_not_called()
+
+            # Test store_path.
+            with parallel.raises_when(
+                pex.distributed.rank == 1,
+                RuntimeError,
+                match=r"\.store_path.*non-chief",
+            ):
+                with checkpoint_context.store_path(metadata={"latest_batch": 1}) as _:
+                    pass
+            if pex.rank == 0:
+                storage_manager.store_path.assert_called_once()
+                storage_manager.store_path.reset_mock()
+                storage_manager._list_directory.assert_called_once()
+                storage_manager._list_directory.reset_mock()
+                if not dummy:
+                    session.post.assert_called_once()
+                    session.post.reset_mock()
+            else:
+                storage_manager.store_path.assert_not_called()
+                storage_manager._list_directory.assert_not_called()
+                if not dummy:
+                    session.post.assert_not_called()
+                    tbd_mgr.sync.assert_not_called()
+
+            # Test download.
+            unique_string = "arbitrary-string"
+            if pex.distributed.rank == 0:
+                checkpoint_context.download("ckpt-uuid", "ckpt-dir", mode)
+                if mode == _core.DownloadMode.NoSharedDownload:
+                    # Send broadcast after download.
+                    _ = pex.distributed.broadcast_local(unique_string)
+            else:
+                if mode == _core.DownloadMode.NoSharedDownload:
+                    # Receive broadcast before download, to ensure the download is not synchronized.
+                    recvd = pex.distributed.broadcast_local(unique_string)
+                    assert recvd == unique_string, recvd
+                checkpoint_context.download("ckpt-uuid", "ckpt-dir", mode)
+            storage_manager.download.assert_called_once()
+            storage_manager.download.reset_mock()
+
+            # Test restore_path.
+            if pex.distributed.rank == 0:
+                with checkpoint_context.restore_path("ckpt-uuid", mode) as _:
+                    pass
+                if mode == _core.DownloadMode.NoSharedDownload:
+                    _ = pex.distributed.broadcast_local(unique_string)
+            else:
+                if mode == _core.DownloadMode.NoSharedDownload:
+                    recvd = pex.distributed.broadcast_local(unique_string)
+                    assert recvd == unique_string, recvd
+                with checkpoint_context.restore_path("ckpt-uuid", mode) as _:
+                    pass
+            storage_manager.restore_path.assert_called_once()
+            storage_manager.restore_path.reset_mock()


### PR DESCRIPTION
In multi-worker settings, it is important that workers on the same node
share a single copy of a downloaded checkpoint.  On an 8-GPU compute
node, that amounts to an 8x bandwidth savings, and also it prevents
workers from stepping on each other's files.

This PR introduces DownloadMode.LocalWorkersShareDownload and
DownloadMode.NoSharedDownload settings, which apply to both
CheckpointContext.download() and CheckpointContext.restore_path().
This allows users to use .download() with or without this coordination,
in case they have special use cases that don't need coordination.

This PR also introduces unit tests for the CheckpointContext.