### PR TITLE
fix: Hide archived experiments unless using --all [DET-7042]

### DIFF
--- a/harness/determined/cli/experiment.py
+++ b/harness/determined/cli/experiment.py
@@ -501,17 +501,15 @@ def wait(args: Namespace) -> None:
 
 @authentication.required
 def list_experiments(args: Namespace) -> None:
-    users: List[str] = []
+    kwargs = {
+        "limit": args.limit,
+        "offset": args.offset,
+    }
     if not args.all:
-        users = [authentication.must_cli_auth().get_session_user()]
-
+        kwargs["archived"] = "false"
+        kwargs["users"] = [authentication.must_cli_auth().get_session_user()]
     all_experiments: List[bindings.v1Experiment] = limit_offset_paginator(
-        bindings.get_GetExperiments,
-        "experiments",
-        setup_session(args),
-        users=users,
-        limit=args.limit,
-        offset=args.offset,
+        bindings.get_GetExperiments, "experiments", setup_session(args), **kwargs
     )
 
     def format_experiment(e: Any) -> List[Any]:


### PR DESCRIPTION
## Description

As we were working on the Determined Project CLI, I noticed that the experiments CLI claims that the `--all` flag is needed to show archived experiments in `det experiment list`. Yet currently archived experiments are included by default.

Bug originated in #3418 because we started using the new API instead of sending filter=all to the legacy API.

This does not affect the Experiments API -- it is just changing what the CLI calls.

## Test Plan

Run `det experiment list` to see which experiments are visible and completed running.

Pick one and archive it: `det experiment archive [id]`
Try `det experiment list` (archived experiment is now hidden)
Try `det experiment list --all` (archived experiment is included)

If you have access to an instance with other users' experiments, `det -m URL experiment list --all` should show those.

## Checklist

- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.