### PR TITLE
chore: demote _get_last_validation to internal

### DIFF
--- a/harness/determined/layers/_workload_sequencer.py
+++ b/harness/determined/layers/_workload_sequencer.py
@@ -109,7 +109,7 @@ class WorkloadSequencer(workload.Source):
             unit = _core.Unit.EPOCHS
         self._unit = unit
 
-        self.val_from_previous_run = self.core_context.train.get_last_validation()
+        self.val_from_previous_run = self.core_context.train._get_last_validation()
 
         self.want_initial_val = self.env.experiment_config.get("perform_initial_validation", False)
 


### PR DESCRIPTION
get_last_validation() had a bug where it might return a different value
before vs after you report any metrics.

Fixing it would require reconsidering how metrics are archived in the
master, which is a lot of work for an API that seems unlikely to be
useful to users, so we'll just make it internal.