### PR TITLE
chore: bring webui checkpoint types into alignment with CoreAPI [DET-6676]

### DIFF
--- a/webui/react/src/components/CheckpointModal.tsx
+++ b/webui/react/src/components/CheckpointModal.tsx
@@ -6,17 +6,21 @@ import HumanReadableNumber from 'components/HumanReadableNumber';
 import useCreateModelModal from 'hooks/useCreateModelModal';
 import useRegisterCheckpointModal from 'hooks/useRegisterCheckpointModal';
 import { paths } from 'routes/utils';
-import { CheckpointDetail, CheckpointStorageType, CheckpointWorkload, CheckpointWorkloadExtended,
-  ExperimentConfig, RunState } from 'types';
+import {
+  CheckpointStorageType,
+  CheckpointWorkloadExtended,
+  ExperimentConfig,
+  RunState,
+} from 'types';
 import { formatDatetime } from 'utils/datetime';
 import { humanReadableBytes } from 'utils/string';
-import { checkpointSize, getBatchNumber } from 'utils/workload';
+import { checkpointSize } from 'utils/workload';
 
 import css from './CheckpointModal.module.scss';
 import Link from './Link';
 
 interface Props {
-  checkpoint: CheckpointWorkloadExtended | CheckpointDetail;
+  checkpoint: CheckpointWorkloadExtended;
   config: ExperimentConfig;
   onHide?: () => void;
   searcherValidation?: number;
@@ -26,7 +30,7 @@ interface Props {
 
 const getStorageLocation = (
   config: ExperimentConfig,
-  checkpoint: CheckpointDetail | CheckpointWorkload,
+  checkpoint: CheckpointWorkloadExtended,
 ): string => {
   const hostPath = config.checkpointStorage?.hostPath;
   const storagePath = config.checkpointStorage?.storagePath;
@@ -101,11 +105,9 @@ const CheckpointModal: React.FC<Props> = (
     showRegisterCheckpointModal({ checkpointUuid: checkpoint.uuid });
   }, [ checkpoint.uuid, onHide, showRegisterCheckpointModal ]);
 
-  const totalBatchesProcessed = getBatchNumber(checkpoint);
+  const totalBatchesProcessed = checkpoint.totalBatches;
 
-  const searcherMetric = props.searcherValidation !== undefined ?
-    props.searcherValidation :
-    ('validationMetric' in checkpoint ? checkpoint.validationMetric : undefined);
+  const searcherMetric = props.searcherValidation;
 
   if (!checkpoint.experimentId || !checkpoint.trialId) {
     return null;

--- a/webui/react/src/components/CheckpointModal.tsx
+++ b/webui/react/src/components/CheckpointModal.tsx
@@ -9,6 +9,7 @@ import { paths } from 'routes/utils';
 import {
   CheckpointStorageType,
   CheckpointWorkloadExtended,
+  CoreApiGenericCheckpoint,
   ExperimentConfig,
   RunState,
 } from 'types';
@@ -20,7 +21,7 @@ import css from './CheckpointModal.module.scss';
 import Link from './Link';
 
 interface Props {
-  checkpoint: CheckpointWorkloadExtended;
+  checkpoint: CheckpointWorkloadExtended | CoreApiGenericCheckpoint;
   config: ExperimentConfig;
   onHide?: () => void;
   searcherValidation?: number;
@@ -30,7 +31,7 @@ interface Props {
 
 const getStorageLocation = (
   config: ExperimentConfig,
-  checkpoint: CheckpointWorkloadExtended,
+  checkpoint: CheckpointWorkloadExtended | CoreApiGenericCheckpoint,
 ): string => {
   const hostPath = config.checkpointStorage?.hostPath;
   const storagePath = config.checkpointStorage?.storagePath;
@@ -105,13 +106,16 @@ const CheckpointModal: React.FC<Props> = (
     showRegisterCheckpointModal({ checkpointUuid: checkpoint.uuid });
   }, [ checkpoint.uuid, onHide, showRegisterCheckpointModal ]);
 
-  const totalBatchesProcessed = checkpoint.totalBatches;
+  const searcherMetric =
+    props.searcherValidation ??
+    ('searcherMetric' in checkpoint ? checkpoint.searcherMetric : undefined);
 
-  const searcherMetric = props.searcherValidation;
-
-  if (!checkpoint.experimentId || !checkpoint.trialId) {
-    return null;
-  }
+  const checkpointTime =
+    'endTime' in checkpoint
+      ? checkpoint.endTime
+      : 'reportTime' in checkpoint
+        ? checkpoint.reportTime
+        : undefined;
 
   return (
     <Modal
@@ -123,21 +127,28 @@ const CheckpointModal: React.FC<Props> = (
       width={768}
       onCancel={onHide}>
       <div className={css.base}>
-        {renderRow(
-          'Source', (
-            <div className={css.source}>
-              <Link path={paths.experimentDetails(checkpoint.experimentId)}>
-                Experiment {checkpoint.experimentId}
-              </Link>
-              <span className={css.sourceDivider} />
-              <Link path={paths.trialDetails(checkpoint.trialId, checkpoint.experimentId)}>
-                Trial {checkpoint.trialId}
-              </Link>
-              <span className={css.sourceDivider} />
-              <span>Batch {totalBatchesProcessed}</span>
-            </div>
-          ),
-        )}
+        {renderRow('Source', checkpoint.experimentId ? (
+          <div className={css.source}>
+            <Link path={paths.experimentDetails(checkpoint.experimentId.toString())}>
+              Experiment {checkpoint.experimentId}
+            </Link>
+            {!!checkpoint.trialId && (
+              <><span className={css.sourceDivider} />
+                <Link path={paths.trialDetails(checkpoint.trialId, checkpoint.experimentId)}>
+                  Trial {checkpoint.trialId}
+                </Link>
+              </>
+            )}
+            {!!checkpoint.totalBatches && (
+              <>
+                <span className={css.sourceDivider} />
+                <span>Batch {checkpoint.totalBatches}</span>
+              </>
+            )}
+          </div>
+        ) : 'taskId' in checkpoint
+          ? (<div className={css.source}><span>Task {checkpoint.taskId}</span></div>)
+          : null)}
         {renderRow('State', <Badge state={state} type={BadgeType.State} />)}
         {checkpoint.uuid && renderRow('UUID', checkpoint.uuid)}
         {renderRow('Location', getStorageLocation(config, checkpoint))}
@@ -147,7 +158,7 @@ const CheckpointModal: React.FC<Props> = (
             <HumanReadableNumber num={searcherMetric} /> {`(${config.searcher.metric})`}
           </>,
         )}
-        {checkpoint.endTime && renderRow('End Time', formatDatetime(checkpoint.endTime))}
+        {checkpointTime && renderRow('Checkpoint Time', formatDatetime(checkpointTime))}
         {renderRow('Total Size', totalSize)}
         {resources.length !== 0 && renderRow(
           'Resources', (

--- a/webui/react/src/pages/ModelVersionDetails.tsx
+++ b/webui/react/src/pages/ModelVersionDetails.tsx
@@ -17,7 +17,7 @@ import { ModelVersion } from 'types';
 import { isEqual } from 'utils/data';
 import handleError, { ErrorType } from 'utils/error';
 import { humanReadableBytes } from 'utils/string';
-import { checkpointSize, getBatchNumber } from 'utils/workload';
+import { checkpointSize } from 'utils/workload';
 
 import css from './ModelVersionDetails.module.scss';
 import ModelVersionHeader from './ModelVersionDetails/ModelVersionHeader';
@@ -179,25 +179,36 @@ const ModelVersionDetails: React.FC = () => {
     const resources = Object.keys(modelVersion.checkpoint.resources || {})
       .sort((a, b) => checkpointResources[a] - checkpointResources[b])
       .map(key => ({ name: key, size: humanReadableBytes(checkpointResources[key]) }));
-    const totalBatchesProcessed = getBatchNumber(modelVersion.checkpoint);
+    const hasExperiment = !!modelVersion.checkpoint.experimentId;
     return [
       {
-        content: (
+        content: hasExperiment ? (
           <Breadcrumb className={css.link}>
             <Breadcrumb.Item>
               <Link path={paths.experimentDetails(modelVersion.checkpoint.experimentId || '')}>
                 Experiment {modelVersion.checkpoint.experimentId}
               </Link>
             </Breadcrumb.Item>
+            {!!modelVersion.checkpoint.trialId && (
+              <Breadcrumb.Item>
+                <Link
+                  path={paths.trialDetails(
+                    modelVersion.checkpoint.trialId,
+                    modelVersion.checkpoint.experimentId,
+                  )}>
+                  Trial {modelVersion.checkpoint.trialId}
+                </Link>
+              </Breadcrumb.Item>
+            )}
+            {!!modelVersion.checkpoint.totalBatches && (
+              <Breadcrumb.Item>Batch {modelVersion.checkpoint.totalBatches}</Breadcrumb.Item>
+            )}
+          </Breadcrumb>
+        ) : (
+          <Breadcrumb>
             <Breadcrumb.Item>
-              <Link path={paths.trialDetails(
-                modelVersion.checkpoint.trialId,
-                modelVersion.checkpoint.experimentId,
-              )}>
-                Trial {modelVersion.checkpoint.trialId}
-              </Link>
+              Task {modelVersion.checkpoint.taskId}
             </Breadcrumb.Item>
-            <Breadcrumb.Item>Batch {totalBatchesProcessed}</Breadcrumb.Item>
           </Breadcrumb>
         ),
         label: 'Source',
@@ -215,7 +226,7 @@ const ModelVersionDetails: React.FC = () => {
 
   const validationMetrics = useMemo(() => {
     if (!modelVersion?.checkpoint) return [];
-    const metrics = Object.entries(modelVersion?.checkpoint.metrics?.validationMetrics || {});
+    const metrics = Object.entries(modelVersion?.checkpoint?.validationMetrics?.avgMetrics || {});
     return metrics.map(metric => ({
       content: metric[1],
       label: metric[0],

--- a/webui/react/src/pages/TrialDetails/TrialDetailsWorkloads.tsx
+++ b/webui/react/src/pages/TrialDetails/TrialDetailsWorkloads.tsx
@@ -13,7 +13,7 @@ import Section from 'components/Section';
 import SelectFilter from 'components/SelectFilter';
 import { defaultRowClassName, getFullPaginationConfig } from 'components/Table';
 import {
-  CheckpointDetail, CommandTask, ExperimentBase, MetricName,
+  CheckpointWorkloadExtended, CommandTask, ExperimentBase, MetricName,
   Step, TrialDetails,
 } from 'types';
 import { isEqual } from 'utils/data';
@@ -44,7 +44,7 @@ const TrialDetailsWorkloads: React.FC<Props> = ({
   trial,
   updateSettings,
 }: Props) => {
-  const [ activeCheckpoint, setActiveCheckpoint ] = useState<CheckpointDetail>();
+  const [ activeCheckpoint, setActiveCheckpoint ] = useState<CheckpointWorkloadExtended>();
   const [ showCheckpoint, setShowCheckpoint ] = useState(false);
 
   const hasFiltersApplied = useMemo(() => {
@@ -58,9 +58,8 @@ const TrialDetailsWorkloads: React.FC<Props> = ({
       if (trial && record.checkpoint && hasCheckpointStep(record)) {
         const checkpoint = {
           ...record.checkpoint,
-          batch: record.checkpoint.totalBatches,
-          experimentId: trial?.experimentId,
-          trialId: trial?.id,
+          experimentId: trial.experimentId,
+          trialId: trial.id,
         };
         return (
           <Tooltip title="View Checkpoint">
@@ -130,7 +129,10 @@ const TrialDetailsWorkloads: React.FC<Props> = ({
       });
   }, [ settings.filter, trial?.workloads ]);
 
-  const handleCheckpointShow = (event: React.MouseEvent, checkpoint: CheckpointDetail) => {
+  const handleCheckpointShow = (
+    event: React.MouseEvent,
+    checkpoint: CheckpointWorkloadExtended,
+  ) => {
     event.stopPropagation();
     setActiveCheckpoint(checkpoint);
     setShowCheckpoint(true);
@@ -195,7 +197,7 @@ const TrialDetailsWorkloads: React.FC<Props> = ({
           checkpoint={activeCheckpoint}
           config={experiment?.config}
           show={showCheckpoint}
-          title={`Checkpoint for Batch ${activeCheckpoint.batch}`}
+          title={`Checkpoint for Batch ${activeCheckpoint.totalBatches}`}
           onHide={handleCheckpointDismiss}
         />
       )}

--- a/webui/react/src/pages/TrialDetails/TrialInfoBox.tsx
+++ b/webui/react/src/pages/TrialDetails/TrialInfoBox.tsx
@@ -7,7 +7,7 @@ import Section from 'components/Section';
 import TimeAgo from 'components/TimeAgo';
 import { ShirtSize } from 'themes';
 import {
-  CheckpointDetail, CheckpointState, CheckpointWorkload, ExperimentBase, TrialDetails,
+  CheckpointState, CheckpointWorkload, CheckpointWorkloadExtended, ExperimentBase, TrialDetails,
 } from 'types';
 import { humanReadableBytes } from 'utils/string';
 import { checkpointSize } from 'utils/workload';
@@ -20,14 +20,13 @@ interface Props {
 const TrialInfoBox: React.FC<Props> = ({ trial, experiment }: Props) => {
   const [ showBestCheckpoint, setShowBestCheckpoint ] = useState(false);
 
-  const bestCheckpoint: CheckpointDetail | undefined = useMemo(() => {
+  const bestCheckpoint: CheckpointWorkloadExtended | undefined = useMemo(() => {
     if (!trial) return;
     const cp = trial.bestAvailableCheckpoint;
     if (!cp) return;
 
     return {
       ...cp,
-      batch: cp.totalBatches,
       experimentId: trial.experimentId,
       trialId: trial.id,
     };
@@ -66,7 +65,7 @@ const TrialInfoBox: React.FC<Props> = ({ trial, experiment }: Props) => {
         )}
         {bestCheckpoint && (
           <OverviewStats title="Best Checkpoint" onClick={handleShowBestCheckpoint}>
-            Batch {bestCheckpoint.batch}
+            Batch {bestCheckpoint.totalBatches}
           </OverviewStats>
         )}
       </Grid>

--- a/webui/react/src/services/decoder.ts
+++ b/webui/react/src/services/decoder.ts
@@ -1,4 +1,5 @@
 import dayjs from 'dayjs';
+
 import * as ioTypes from 'ioTypes';
 import * as types from 'types';
 import { flattenObject, isNullOrUndefined, isNumber, isObject, isPrimitive } from 'utils/data';

--- a/webui/react/src/services/decoder.ts
+++ b/webui/react/src/services/decoder.ts
@@ -444,6 +444,26 @@ const decodeCheckpointWorkload = (data: Sdk.V1CheckpointWorkload): types.Checkpo
   };
 };
 
+/* using any here because this comes from the api as any /*
+/* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+export const decodeMetricStruct = (data: any): Record<string, number> => {
+  const metrics: Record<string, number> = {};
+  Object.entries(data || {}).forEach(([ metric, value ]) => {
+    if (typeof metric === 'string' && (typeof value === 'number' || typeof value === 'string')) {
+      const numberValue = (typeof value === 'number') ? value : parseFloat(value);
+      if (!isNaN(numberValue)) metrics[metric] = numberValue;
+    }
+  });
+  return metrics;
+};
+
+export const decodeMetrics = (data: Sdk.V1Metrics): types.Metrics => {
+  return {
+    avgMetrics: decodeMetricStruct(data.avgMetrics),
+    batchMetrics: data.batchMetrics?.map(decodeMetricStruct),
+  };
+};
+
 export const decodeCheckpoint = (data: Sdk.V1Checkpoint): types.CoreApiGenericCheckpoint => {
   const resources: Record<string, number> = {};
   Object.entries(data.resources || {}).forEach(([ res, val ]) => {
@@ -460,12 +480,12 @@ export const decodeCheckpoint = (data: Sdk.V1Checkpoint): types.CoreApiGenericCh
     searcherMetric: data.training.searcherMetric,
     state: decodeCheckpointState(data.state || Sdk.Determinedcheckpointv1State.UNSPECIFIED),
     taskId: data.taskId,
-    totalBatches:
-      data.metadata['latest_batch'] ?? 0,
-    trainingMetrics: data.training.trainingMetrics,
+    totalBatches: data.metadata['latest_batch'] ?? 0,
+    trainingMetrics: data.training.trainingMetrics && decodeMetrics(data.training.trainingMetrics),
     trialId: data.training.trialId,
     uuid: data.uuid,
-    validationMetrics: data.training.validationMetrics,
+    validationMetrics:
+      data.training.validationMetrics && decodeMetrics(data.training.validationMetrics),
   };
 };
 

--- a/webui/react/src/services/decoder.ts
+++ b/webui/react/src/services/decoder.ts
@@ -444,20 +444,22 @@ const decodeCheckpointWorkload = (data: Sdk.V1CheckpointWorkload): types.Checkpo
   };
 };
 
-/* using any here because this comes from the api as any */
-/* eslint-disable-next-line @typescript-eslint/no-explicit-any */
-export const decodeMetricStruct = (data: any): Record<string, number> => {
-  const metrics: Record<string, number> = {};
-  Object.entries(data || {}).forEach(([ metric, value ]) => {
-    if (typeof metric === 'string' && (typeof value === 'number' || typeof value === 'string')) {
-      const numberValue = (typeof value === 'number') ? value : parseFloat(value);
-      if (!isNaN(numberValue)) metrics[metric] = numberValue;
-    }
-  });
-  return metrics;
-};
-
 export const decodeMetrics = (data: Sdk.V1Metrics): types.Metrics => {
+  /**
+   * using any here because this comes from the api as any
+   * however, the protos indicate that it is a Struct/Record
+   */
+  /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+  const decodeMetricStruct = (data: any): Record<string, number> => {
+    const metrics: Record<string, number> = {};
+    Object.entries(data || {}).forEach(([ metric, value ]) => {
+      if (typeof metric === 'string' && (typeof value === 'number' || typeof value === 'string')) {
+        const numberValue = (typeof value === 'number') ? value : parseFloat(value);
+        if (!isNaN(numberValue)) metrics[metric] = numberValue;
+      }
+    });
+    return metrics;
+  };
   return {
     avgMetrics: decodeMetricStruct(data.avgMetrics),
     batchMetrics: data.batchMetrics?.map(decodeMetricStruct),

--- a/webui/react/src/services/decoder.ts
+++ b/webui/react/src/services/decoder.ts
@@ -444,30 +444,28 @@ const decodeCheckpointWorkload = (data: Sdk.V1CheckpointWorkload): types.Checkpo
   };
 };
 
-const decodeValidationMetrics = (data: Sdk.V1Metrics): types.Metrics => {
-  return { validationMetrics: data.avgMetrics };
-};
-
-export const decodeCheckpoint = (data: Sdk.V1Checkpoint): types.CheckpointDetail => {
+export const decodeCheckpoint = (data: Sdk.V1Checkpoint): types.CoreApiGenericCheckpoint => {
   const resources: Record<string, number> = {};
   Object.entries(data.resources || {}).forEach(([ res, val ]) => {
     resources[res] = parseFloat(val);
   });
-
-  // TODO @emily the following has been brainlessly changed to compile
-
   return {
-    batch: data.metadata['latest_batch'],
-    endTime: data.reportTime && data.reportTime as unknown as string,
+    allocationId: data.allocationId,
+    experimentConfig: data.training.experimentConfig,
     experimentId: data.training.experimentId,
-    metrics: data.training.validationMetrics ? decodeValidationMetrics(
-      data.training.validationMetrics,
-    ) : undefined,
-    resources,
+    hparams: data.training.hparams,
+    metadata: data.metadata,
+    reportTime: data.reportTime?.toString(),
+    resources: resources,
+    searcherMetric: data.training.searcherMetric,
     state: decodeCheckpointState(data.state || Sdk.Determinedcheckpointv1State.UNSPECIFIED),
-    trialId: data.training.trialId || -1, // TODO maybe it becomes required again
+    taskId: data.taskId,
+    totalBatches:
+      data.metadata['latest_batch'] ?? data.training.trainingMetrics?.batchMetrics?.length ?? 0,
+    trainingMetrics: data.training.trainingMetrics,
+    trialId: data.training.trialId,
     uuid: data.uuid,
-    validationMetric: data.training.searcherMetric,
+    validationMetrics: data.training.validationMetrics,
   };
 };
 

--- a/webui/react/src/services/decoder.ts
+++ b/webui/react/src/services/decoder.ts
@@ -1,5 +1,4 @@
 import dayjs from 'dayjs';
-
 import * as ioTypes from 'ioTypes';
 import * as types from 'types';
 import { flattenObject, isNullOrUndefined, isNumber, isObject, isPrimitive } from 'utils/data';
@@ -461,7 +460,7 @@ export const decodeCheckpoint = (data: Sdk.V1Checkpoint): types.CoreApiGenericCh
     state: decodeCheckpointState(data.state || Sdk.Determinedcheckpointv1State.UNSPECIFIED),
     taskId: data.taskId,
     totalBatches:
-      data.metadata['latest_batch'] ?? data.training.trainingMetrics?.batchMetrics?.length ?? 0,
+      data.metadata['latest_batch'] ?? 0,
     trainingMetrics: data.training.trainingMetrics,
     trialId: data.training.trialId,
     uuid: data.uuid,

--- a/webui/react/src/services/decoder.ts
+++ b/webui/react/src/services/decoder.ts
@@ -444,7 +444,7 @@ const decodeCheckpointWorkload = (data: Sdk.V1CheckpointWorkload): types.Checkpo
   };
 };
 
-/* using any here because this comes from the api as any /*
+/* using any here because this comes from the api as any */
 /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
 export const decodeMetricStruct = (data: any): Record<string, number> => {
   const metrics: Record<string, number> = {};

--- a/webui/react/src/types.ts
+++ b/webui/react/src/types.ts
@@ -367,14 +367,6 @@ export interface MetricName {
   type: MetricType;
 }
 
-export interface Checkpoint extends EndTimes {
-  resources?: Record<string, number>;
-  state: CheckpointState;
-  trialId: number;
-  uuid?: string;
-  validationMetric?: number;
-}
-
 export interface BaseWorkload extends EndTimes {
   totalBatches: number;
 }
@@ -406,18 +398,32 @@ export interface Step extends WorkloadGroup, StartEndTimes {
   training: MetricsWorkload;
 }
 
-export interface Metrics {
-  numInputs?: number;
-  validationMetrics?: Record<string, number>;
+export interface Metrics extends Api.V1Metrics {
+  // these two fields are present in the protos
+  // as a struct and list of structs, respectively
+  // here, we are being a bit more precise
+  avgMetrics: Record<string, number>;
+  batchMetrics?: Array<Record<string, number>>;
 }
 
 export type Metadata = Record<RecordKey, string>;
 
-export interface CheckpointDetail extends Checkpoint {
-  batch: number;
+export interface CoreApiGenericCheckpoint {
+  allocationId: string;
+  experimentConfig?: ExperimentConfig;
   experimentId?: number;
-  metadata?: Metadata;
-  metrics?: Metrics;
+  hparams?: TrialHyperparameters;
+  metadata: Metadata;
+  reportTime?: string;
+  resources: Record<string, number>;
+  searcherMetric?: number;
+  state?: CheckpointState;
+  taskId: string;
+  totalBatches: number;
+  trainingMetrics?: Metrics;
+  trialId?: number;
+  uuid: string;
+  validationMetrics?: Metrics;
 }
 
 export interface TrialPagination extends WithPagination {
@@ -507,7 +513,7 @@ export interface ModelItem {
 }
 
 export interface ModelVersion {
-  checkpoint: CheckpointDetail;
+  checkpoint: CoreApiGenericCheckpoint;
   comment?: string;
   creationTime: string;
   id: number;

--- a/webui/react/src/types.ts
+++ b/webui/react/src/types.ts
@@ -398,12 +398,13 @@ export interface Step extends WorkloadGroup, StartEndTimes {
   training: MetricsWorkload;
 }
 
+type MetricStruct = Record<string, number>;
 export interface Metrics extends Api.V1Metrics {
   // these two fields are present in the protos
   // as a struct and list of structs, respectively
   // here, we are being a bit more precise
-  avgMetrics: Record<string, number>;
-  batchMetrics?: Array<Record<string, number>>;
+  avgMetrics: MetricStruct;
+  batchMetrics?: Array<MetricStruct>;
 }
 
 export type Metadata = Record<RecordKey, string>;

--- a/webui/react/src/types.ts
+++ b/webui/react/src/types.ts
@@ -417,7 +417,7 @@ export interface CoreApiGenericCheckpoint {
   reportTime?: string;
   resources: Record<string, number>;
   searcherMetric?: number;
-  state?: CheckpointState;
+  state: CheckpointState;
   taskId: string;
   totalBatches: number;
   trainingMetrics?: Metrics;

--- a/webui/react/src/utils/workload.test.ts
+++ b/webui/react/src/utils/workload.test.ts
@@ -59,13 +59,6 @@ describe('Workload Utilities', () => {
     });
   });
 
-  describe('getBatchNumber', () => {
-    it('should return `batch` or `totalBatches` as batch count', () => {
-      expect(utils.getBatchNumber({ batch: 100 })).toBe(100);
-      expect(utils.getBatchNumber({ totalBatches: 100 })).toBe(100);
-    });
-  });
-
   describe('getWorkload', () => {
     it('should extract first available training workload', () => {
       expect(utils.getWorkload(WORKLOADS[0])).toStrictEqual(WORKLOADS[0].training);

--- a/webui/react/src/utils/workload.ts
+++ b/webui/react/src/utils/workload.ts
@@ -10,13 +10,6 @@ export const checkpointSize = (
   return 0;
 };
 
-export const getBatchNumber = (
-  data: { batch: number } | { totalBatches: number },
-): number => {
-  if ('batch' in data) return data.batch;
-  return data.totalBatches;
-};
-
 export const getWorkload = (
   workload: Type.WorkloadGroup,
 ): Type.MetricsWorkload | Type.CheckpointWorkload => {


### PR DESCRIPTION
## Description

chore: bring webui checkpoint types into alignment with CoreAPI [DET-6676]

Many fields previously required in checkpoints are now optional. This PR brings the WebUI types into alignment and provides a fallback UX on the ModelVersionDetails page for when experiment_id, trial_id, etc. are not available.

## Test Plan

Check out the branch and build devcluster from scratch. May have to `rm -rf ~/.postgres` (proceed with care) in order to get the migrations to run properly.

Create a simple mnist pytorch with a checkpoint, register the checkpoint to a model, and go to model version page. things should be ok.

The real test is that with the new schema, many fields are optional that were previously required. model checkpoints automatically have most of those fields, but one way to simulate their absence is to change the return statement of `decodeCheckpoint` in `decoders.ts` to:

```
return {
    allocationId: data.allocationId,
    metadata: {},
    resources: {},
    state: decodeCheckpointState(Sdk.Determinedcheckpointv1State.UNSPECIFIED),
    taskId: data.taskId,
    totalBatches: 0,
    uuid: data.uuid,
  };
```

as well as to various intermediate states between that and the one in the PR.


## Commentary (optional)

There are two main 'checkpoint' types in the API that are actually completely separate: `CheckpointWorkload`, from `trials.proto` and `Checkpoint` from `checkpoint.proto`. As of this PR, their corresponding types in the WebUI are called `CheckpointWorkloadExtended` and `CoreApiGenericCheckpoint`, respectively. The latter is the one we are concerned with here. 

However, in the existing code there is quite a bit of entanglement between them. Specifically, data coming from `CheckpointWorkload` is augmented and cast as `Checkpoint`. As a result `CheckpointModal.tsx` is erroneously called with props of both types, even though the data only ever comes from `CheckpointWorkload`. 

This PR disentangles them, so that the checkpoint prop type of `CheckpointModal` can be narrowed to just that of `CheckpointWorkload`, and we don't have to special-case based on props. This is especially useful given that the backend work in this branch has the types diverging further.

That said, I have included the adaptations needed for `CheckpointModal` to handle `Checkpoint` as well, in case we want to make it available for future use. 

Now is probably a good time to decide whether to keep those or not. My vote would be no: it's kinda messy and promotes more entanglement.

The UI changes in the `CheckpointModal` to accommodate potential missing data exactly parallel those in `ModelVersionDetails`.

If you would like to test checkpoint modal against actual `Checkpoint` type, you can paste this somewhere into `ModelVersionDetails.tsx` (do with decoder modifications for the full effect)

```
      <CheckpointModal
        checkpoint={modelVersion.checkpoint}
        config={modelVersion.checkpoint.experimentConfig || {} as ExperimentConfig}
        show={true}
        title={'Modal!'}
      />
```


## Checklist

- [X] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-6676]: https://determinedai.atlassian.net/browse/DET-6676?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ