### PR TITLE
chore: add key attribute to avatar ActionCard action [DET-7015]

### DIFF
--- a/webui/react/src/components/NavigationTabbar.tsx
+++ b/webui/react/src/components/NavigationTabbar.tsx
@@ -87,7 +87,7 @@ const NavigationTabbar: React.FC = () => {
         actions={[
           {
             render: () => {
-              return <AvatarCard className={css.user} user={auth.user} />;
+              return <AvatarCard key='Avatar' className={css.user} user={auth.user} />;
             },
           },
           {


### PR DESCRIPTION
## Description

Adds a `key` attribute to the AvatarCard child within the ActionSheet actions list prop. The other actions within the list are rendered with keys that are equal to the actions `label` however the AvatarCard entry does not currently specify a `key` for the rendered component. Adding this `key` attribute fixes the `unique key` warning due to the currently missing key. 

## Test Plan
1. Pull branch
2. Run the webui 
 - `cd webui/react`
 -`make live`
3.  Open the web browser console, and ensure there is no `unique key` warning.

## Commentary (optional)

## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.