### PR TITLE
fix: _report_checkpoint correct POST payload

### DIFF
--- a/e2e_tests/tests/experiment/test_core.py
+++ b/e2e_tests/tests/experiment/test_core.py
@@ -276,7 +276,7 @@ def test_end_to_end_adaptive() -> None:
     assert top_2_uuids == top_k_uuids[:2]
 
     # Check that metrics are truly in sorted order.
-    metrics = [c.validation_metrics["avgMetrics"]["validation_loss"] for c in top_k]
+    metrics = [c.get_training().validation_metrics["avgMetrics"]["validation_loss"] for c in top_k]
 
     assert metrics == sorted(metrics)
 

--- a/e2e_tests/tests/experiment/test_core.py
+++ b/e2e_tests/tests/experiment/test_core.py
@@ -292,22 +292,32 @@ def test_end_to_end_adaptive() -> None:
     checkpoint.add_metadata({"testing": "metadata"})
     db_check = d.get_checkpoint(checkpoint.uuid)
     # Make sure the checkpoint metadata is correct and correctly saved to the db.
-    assert checkpoint.metadata == {"testing": "metadata"}
+    # Beginning with 0.18 the system contributes a few items to the dict
+    assert checkpoint.metadata.get("testing") == "metadata"
+    assert checkpoint.metadata.keys() == {"format", "framework", "latest_batch", "testing"}
     assert checkpoint.metadata == db_check.metadata
 
     checkpoint.add_metadata({"some_key": "some_value"})
     db_check = d.get_checkpoint(checkpoint.uuid)
-    assert checkpoint.metadata == {"testing": "metadata", "some_key": "some_value"}
+    assert checkpoint.metadata.items() > {"testing": "metadata", "some_key": "some_value"}.items()
+    assert checkpoint.metadata.keys() == {
+        "format",
+        "framework",
+        "latest_batch",
+        "testing",
+        "some_key",
+    }
     assert checkpoint.metadata == db_check.metadata
 
     checkpoint.add_metadata({"testing": "override"})
     db_check = d.get_checkpoint(checkpoint.uuid)
-    assert checkpoint.metadata == {"testing": "override", "some_key": "some_value"}
+    assert checkpoint.metadata.items() > {"testing": "override", "some_key": "some_value"}.items()
     assert checkpoint.metadata == db_check.metadata
 
     checkpoint.remove_metadata(["some_key"])
     db_check = d.get_checkpoint(checkpoint.uuid)
-    assert checkpoint.metadata == {"testing": "override"}
+    assert "some_key" not in checkpoint.metadata
+    assert checkpoint.metadata["testing"] == "override"
     assert checkpoint.metadata == db_check.metadata
 
 

--- a/harness/determined/cli/checkpoint.py
+++ b/harness/determined/cli/checkpoint.py
@@ -47,12 +47,12 @@ def render_checkpoint(checkpoint: experimental.Checkpoint, path: Optional[str] =
 
     # Print information about the downloaded step/checkpoint.
     table = [
-        ["Experiment ID", checkpoint.experiment_id],
-        ["Trial ID", checkpoint.trial_id],
-        ["Batch #", checkpoint.batch_number],
+        ["Experiment ID", checkpoint.get_training().experiment_id],
+        ["Trial ID", checkpoint.get_training().trial_id],
+        ["Batch #", checkpoint.metadata.get("latest_batch")],
         ["Report Time", render.format_time(checkpoint.report_time)],
         ["Checkpoint UUID", checkpoint.uuid],
-        ["Validation Metrics", json.dumps(checkpoint.validation_metrics, indent=4)],
+        ["Validation Metrics", json.dumps(checkpoint.get_training().validation_metrics, indent=4)],
         ["Metadata", json.dumps(checkpoint.metadata or {}, indent=4)],
     ]
 

--- a/harness/determined/cli/experiment.py
+++ b/harness/determined/cli/experiment.py
@@ -843,6 +843,7 @@ main_cmd = Cmd(
                     help="Return the best N checkpoints for this experiment. "
                     "If this flag is used, only checkpoints with an associated "
                     "validation metric will be considered.",
+                    metavar="N",
                 ),
                 Arg("--csv", action="store_true", help="print as CSV"),
             ],

--- a/harness/determined/cli/model.py
+++ b/harness/determined/cli/model.py
@@ -45,10 +45,10 @@ def render_model_version(model_version: ModelVersion) -> None:
     values = [
         [
             model_version.model_version,
-            checkpoint.trial_id,
-            checkpoint.batch_number,
+            checkpoint.get_training().trial_id,
+            checkpoint.metadata["latest_batch"],
             checkpoint.uuid,
-            json.dumps(checkpoint.validation_metrics, indent=2),
+            json.dumps(checkpoint.get_training().validation_metrics, indent=2),
             json.dumps(checkpoint.metadata, indent=2),
         ]
     ]
@@ -112,10 +112,10 @@ def list_versions(args: Namespace) -> None:
         values = [
             [
                 version.model_version,
-                version.checkpoint.trial_id,
-                version.checkpoint.batch_number,
+                version.checkpoint.get_training().trial_id,
+                version.checkpoint.metadata["latest_batch"],
                 version.checkpoint.uuid,
-                json.dumps(version.checkpoint.validation_metrics, indent=2),
+                json.dumps(version.checkpoint.get_training().validation_metrics, indent=2),
                 json.dumps(version.checkpoint.metadata, indent=2),
             ]
             for version in model.get_versions()

--- a/harness/determined/common/experimental/checkpoint/_checkpoint.py
+++ b/harness/determined/common/experimental/checkpoint/_checkpoint.py
@@ -163,9 +163,6 @@ class Checkpoint(object):
         # checkpoint protobuf and now that we are releasing a breaking change to the Checkpoint
         # export api, we need to start writing a different format (the user-defined metadata only),
         # and we need to start writing it at upload time, not download time.
-        #
-        # see https://rb.gy/vaxl7a
-        # for more context.
         self.write_metadata_file(str(local_ckpt_dir.joinpath("metadata.json")))
 
         return str(local_ckpt_dir)

--- a/harness/determined/common/experimental/checkpoint/_checkpoint.py
+++ b/harness/determined/common/experimental/checkpoint/_checkpoint.py
@@ -47,8 +47,6 @@ class Checkpoint(object):
     that return instances of this class.
     """
 
-    # XXX: this object ends updating to correspond to new protobuf spec
-    # see breaking change warning: https://determined-ai.slack.com/archives/C7E6HPZ5F/p1644019706340119
     def __init__(
         self,
         session: session.Session,
@@ -59,7 +57,7 @@ class Checkpoint(object):
         resources: Dict[str, Any],
         metadata: Dict[str, Any],
         state: CheckpointState,
-        training: Optional[CheckpointTrainingMetadata] = None
+        training: Optional[CheckpointTrainingMetadata] = None,
     ):
         self._session = session
         self.task_id = task_id
@@ -71,12 +69,18 @@ class Checkpoint(object):
         self.state = state
         self.training = training
 
+    def get_training(self) -> CheckpointTrainingMetadata:
+        if self.training is None:
+            raise RuntimeError("Non-training checkpoints are not yet supported.")
+        return self.training
+
     def _find_shared_fs_path(self) -> pathlib.Path:
         """Attempt to find the path of the checkpoint if being configured to shared fs.
         This function assumes the host path of the shared fs exists.
         """
-        host_path = self.experiment_config["checkpoint_storage"]["host_path"]
-        storage_path = self.experiment_config["checkpoint_storage"].get("storage_path")
+        checkpoint_storage = self.get_training().experiment_config["checkpoint_storage"]
+        host_path = checkpoint_storage["host_path"]
+        storage_path = checkpoint_storage.get("storage_path")
         potential_paths = [
             pathlib.Path(shared._full_storage_path(host_path, storage_path), self.uuid),
             pathlib.Path(
@@ -128,13 +132,14 @@ class Checkpoint(object):
         if not any(p.exists() for p in potential_metadata_paths):
             # If the target directory doesn't already appear to contain a
             # checkpoint, attempt to fetch one.
-            if self.experiment_config["checkpoint_storage"]["type"] == "shared_fs":
+            checkpoint_storage = self.get_training().experiment_config["checkpoint_storage"]
+            if checkpoint_storage["type"] == "shared_fs":
                 src_ckpt_dir = self._find_shared_fs_path()
                 shutil.copytree(str(src_ckpt_dir), str(local_ckpt_dir))
             else:
                 local_ckpt_dir.mkdir(parents=True, exist_ok=True)
                 manager = storage.build(
-                    self.experiment_config["checkpoint_storage"],
+                    checkpoint_storage,
                     container_path=None,
                 )
                 if not isinstance(
@@ -148,7 +153,7 @@ class Checkpoint(object):
                     raise AssertionError(
                         "Downloading from Azure, S3 or GCS requires the experiment to be "
                         "configured with Azure, S3 or GCS checkpointing, {} found instead".format(
-                            self.experiment_config["checkpoint_storage"]["type"]
+                            checkpoint_storage["type"]
                         )
                     )
 
@@ -159,7 +164,7 @@ class Checkpoint(object):
         # export api, we need to start writing a different format (the user-defined metadata only),
         # and we need to start writing it at upload time, not download time.
         #
-        # see https://determined-ai.slack.com/archives/CSLAGUF3M/p1642188450030600?thread_ts=1642115346.016000&cid=CSLAGUF3M
+        # see https://rb.gy/vaxl7a
         # for more context.
         self.write_metadata_file(str(local_ckpt_dir.joinpath("metadata.json")))
 
@@ -174,23 +179,8 @@ class Checkpoint(object):
         use this method directly to obtain the latest metadata.
         """
         with open(path, "w") as f:
-            # XXX: this is the old metadata checkpoint protobuf format.  Needs to become the new
-            # user metadata field of the new checkpoint protobuf format.
-            # XXX: maybe we need to look at the determined_version
-            json.dump(
-                {
-                    "determined_version": self.determined_version,
-                    "framework": self.framework,
-                    "format": self.format,
-                    "experiment_id": self.experiment_id,
-                    "trial_id": self.trial_id,
-                    "hparams": self.hparams,
-                    "experiment_config": self.experiment_config,
-                    "metadata": self.metadata,
-                },
-                f,
-                indent=2,
-            )
+            # YYY: only dump user metadata
+            json.dump(self.metadata, f, indent=2)
 
     def load(
         self, path: Optional[str] = None, tags: Optional[List[str]] = None, **kwargs: Any
@@ -385,23 +375,29 @@ class Checkpoint(object):
         return Checkpoint._get_type(metadata)
 
     def __repr__(self) -> str:
-        if self.model_id is not None:
-            return "Checkpoint(uuid={}, trial_id={}, model={}, version={})".format(
-                self.uuid, self.trial_id, self.model_id, self.model_version
+        if self.training is not None:
+            return (
+                f"Checkpoint(uuid={self.uuid}, task_id={self.task_id},"
+                f" trial_id={self.training.trial_id})"
             )
-        return "Checkpoint(uuid={}, trial_id={})".format(self.uuid, self.trial_id)
+        else:
+            return f"Checkpoint(uuid={self.uuid}, task_id={self.task_id})"
 
     @classmethod
     def _from_json(cls, data: Dict[str, Any], session: session.Session) -> "Checkpoint":
         metadata = data.get("metadata", {})
         training_data = data["training"]
-        training = CheckpointTrainingMetadata(
-            training_data["experimentConfig"],
-            training_data["experimentId"],
-            training_data["trialId"],
-            training_data["hparams"],
-            training_data["validationMetrics"],
-        ) if training_data else None
+        training = (
+            CheckpointTrainingMetadata(
+                training_data["experimentConfig"],
+                training_data["experimentId"],
+                training_data["trialId"],
+                training_data["hparams"],
+                training_data["validationMetrics"],
+            )
+            if training_data
+            else None
+        )
 
         return cls(
             session,

--- a/harness/determined/core/_checkpoint.py
+++ b/harness/determined/core/_checkpoint.py
@@ -4,12 +4,12 @@ import logging
 import os
 import pathlib
 import uuid
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Dict, Iterator, Optional, Tuple, Union
 
 import determined as det
 from determined import core, tensorboard
-from determined.common import storage, constants
+from determined.common import storage
 from determined.common.api import bindings
 from determined.common.experimental.session import Session
 
@@ -235,10 +235,10 @@ class CheckpointContext:
             "taskId": self._task_id,
             "allocationId": self._allocation_id,
             "uuid": storage_id,
-            "reportTime": datetime.now(),  # YYY or should it be settable?
+            "reportTime": datetime.now(timezone.utc),  # YYY or should it be settable?
             "resources": resources,
             "metadata": metadata,
-            "state": constants.COMPLETED,  # YYY can it be anything else?
+            "state": bindings.determinedcheckpointv1State.STATE_COMPLETED,  # YYY a new const?
         }
         logger.info(f"Reported checkpoint to master {storage_id}")
         api_path = "/api/v1/checkpoints"


### PR DESCRIPTION
## Description

Handle multiple issues:
1. Align the shape of `experimental.Checkpoint` with the Checkpoint protobuf representation.
2. Handle downstream issues detected by integration and e2e tests:
    a. As the generic json encoder does not handle some corner cases we could not rely on bindings to invoke Report Checkpoint endpoint. So we have to switch back to raw requests posting.
    b. Adjust an e2e test to reflect the fact that we now have `format`, `framework`, and `latest_batch` automatically added into the "free form" metadata dict.

## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions about this test plan to ensure adequate manual coverage of changes.
-->


## Commentary

Note: `XXX` prefix in comments is @rb-determined-ai 's way to designate unfinished CoreAPI items in `generic-checkpoints`.

### Checkpoint changes
| Old Checkpoint Attribute | Disposition |
| ------------------------|--------------|
| Checkpoint.uuid                |   |
| Checkpoint.experiment_config   | goes to training substruct |
| Checkpoint.experiment_id       | goes to training substruct |
| Checkpoint.trial_id            | goes to training substruct |
| Checkpoint.hparams             | goes to training substruct |
| Checkpoint.batch_number        | goes to metadata["latest_batch"] |
| Checkpoint.start_time          | deleted (not recorded anymore) |
| Checkpoint.end_time            | renamed to report_time |
| Checkpoint.resources           |   |
| Checkpoint.validation          | goes to training substruct |
| Checkpoint.framework           | goes to metadata["framework"] |
| Checkpoint.format              | goes to metadata["format"] |
| Checkpoint.determined_version  | goes to metadata["determined_version"] |
| Checkpoint.metadata            |  |
| Checkpoint.model_version       | deleted |
| Checkpoint.model_id            | deleted |

## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
