### PR TITLE
feat: Add numProjects field to workspaces API, CLI [DET-7064]

### DIFF
--- a/harness/determined/cli/workspace.py
+++ b/harness/determined/cli/workspace.py
@@ -11,15 +11,19 @@ from determined.common.experimental import session
 from . import render
 
 PROJECT_HEADERS = ["ID", "Name", "Description", "# Experiments", "# Active Experiments"]
-WORKSPACE_HEADERS = ["ID", "Name"]
+WORKSPACE_HEADERS = ["ID", "Name", "# Projects"]
 
 
-def render_workspace(workspace: v1Workspace) -> None:
+def render_workspaces(workspaces: List[v1Workspace]) -> None:
     values = [
-        workspace.id,
-        workspace.name,
+        [
+            w.id,
+            w.name,
+            w.numProjects,
+        ]
+        for w in workspaces
     ]
-    render.tabulate_or_csv(WORKSPACE_HEADERS, [values], False)
+    render.tabulate_or_csv(WORKSPACE_HEADERS, values, False)
 
 
 def workspace_by_name(sess: session.Session, name: str) -> v1Workspace:
@@ -40,14 +44,7 @@ def list_workspaces(args: Namespace) -> None:
     if args.json:
         print(json.dumps([w.to_json() for w in workspaces], indent=2))
     else:
-        values = [
-            [
-                w.id,
-                w.name,
-            ]
-            for w in workspaces
-        ]
-        render.tabulate_or_csv(WORKSPACE_HEADERS, values, False)
+        render_workspaces(workspaces)
 
 
 @authentication.required
@@ -84,7 +81,7 @@ def create_workspace(args: Namespace) -> None:
     if args.json:
         print(json.dumps(w.to_json(), indent=2))
     else:
-        render_workspace(w)
+        render_workspaces([w])
 
 
 @authentication.required
@@ -94,7 +91,7 @@ def describe_workspace(args: Namespace) -> None:
     if args.json:
         print(json.dumps(w.to_json(), indent=2))
     else:
-        render_workspace(w)
+        render_workspaces([w])
         print("\nAssociated Projects")
         projects = bindings.get_GetWorkspaceProjects(sess, id=w.id).projects
         values = [
@@ -152,7 +149,7 @@ def edit_workspace(args: Namespace) -> None:
     if args.json:
         print(json.dumps(w.to_json(), indent=2))
     else:
-        render_workspace(w)
+        render_workspaces([w])
 
 
 args_description = [

--- a/harness/determined/cli/workspace.py
+++ b/harness/determined/cli/workspace.py
@@ -1,6 +1,6 @@
 import json
 from argparse import Namespace
-from typing import Any, List
+from typing import Any, List, Sequence
 
 from determined.cli.session import setup_session
 from determined.common.api import authentication, bindings
@@ -14,7 +14,7 @@ PROJECT_HEADERS = ["ID", "Name", "Description", "# Experiments", "# Active Exper
 WORKSPACE_HEADERS = ["ID", "Name", "# Projects"]
 
 
-def render_workspaces(workspaces: List[v1Workspace]) -> None:
+def render_workspaces(workspaces: Sequence[v1Workspace]) -> None:
     values = [
         [
             w.id,

--- a/harness/determined/common/api/bindings.py
+++ b/harness/determined/common/api/bindings.py
@@ -5637,6 +5637,7 @@ class v1Workspace:
         id: int,
         immutable: bool,
         name: str,
+        numProjects: int,
         username: str,
     ):
         self.id = id
@@ -5644,6 +5645,7 @@ class v1Workspace:
         self.archived = archived
         self.username = username
         self.immutable = immutable
+        self.numProjects = numProjects
 
     @classmethod
     def from_json(cls, obj: Json) -> "v1Workspace":
@@ -5653,6 +5655,7 @@ class v1Workspace:
             archived=obj["archived"],
             username=obj["username"],
             immutable=obj["immutable"],
+            numProjects=obj["numProjects"],
         )
 
     def to_json(self) -> typing.Any:
@@ -5662,6 +5665,7 @@ class v1Workspace:
             "archived": self.archived,
             "username": self.username,
             "immutable": self.immutable,
+            "numProjects": self.numProjects,
         }
 
 def post_AckAllocationPreemptionSignal(

--- a/master/static/srv/get_workspace.sql
+++ b/master/static/srv/get_workspace.sql
@@ -1,4 +1,5 @@
-SELECT w.id, w.name, w.archived, w.immutable, u.username
+SELECT w.id, w.name, w.archived, w.immutable, u.username,
+  (SELECT COUNT(*) FROM projects WHERE workspace_id = $1) AS num_projects
 FROM workspaces as w
   LEFT JOIN users as u ON u.id = w.user_id
 WHERE w.id = $1;

--- a/master/static/srv/get_workspaces.sql
+++ b/master/static/srv/get_workspaces.sql
@@ -1,4 +1,5 @@
-SELECT w.id, w.name, w.archived, w.immutable, u.username
+SELECT w.id, w.name, w.archived, w.immutable, u.username,
+(SELECT COUNT(*) FROM projects WHERE workspace_id = w.id) AS num_projects
 FROM workspaces as w
 LEFT JOIN users as u ON u.id = w.user_id
 WHERE ($1 = '' OR (u.username IN (SELECT unnest(string_to_array($1, ',')))))

--- a/master/static/srv/update_workspace.sql
+++ b/master/static/srv/update_workspace.sql
@@ -6,6 +6,12 @@ WITH w AS (
 u AS (
   SELECT username FROM users, w
   WHERE users.id = w.user_id
+),
+p AS (
+  SELECT COUNT(*) AS num_projects
+  FROM projects
+  WHERE workspace_id = $1
 )
-SELECT w.id, w.name, w.archived, w.immutable, u.username
-FROM w, u;
+SELECT w.id, w.name, w.archived, w.immutable,
+  u.username, p.num_projects
+FROM w, u, p;

--- a/proto/src/determined/workspace/v1/workspace.proto
+++ b/proto/src/determined/workspace/v1/workspace.proto
@@ -10,7 +10,14 @@ import "google/protobuf/wrappers.proto";
 message Workspace {
   option (grpc.gateway.protoc_gen_swagger.options.openapiv2_schema) = {
     json_schema: {
-      required: [ "archived", "id", "immutable", "name", "username" ]
+      required: [
+        "archived",
+        "id",
+        "immutable",
+        "name",
+        "num_projects",
+        "username"
+      ]
     }
   };
   // The unique id of the workspace.
@@ -25,6 +32,8 @@ message Workspace {
   string username = 4;
   // Whether this workspace is immutable (default uncategorized workspace).
   bool immutable = 5;
+  // Number of projects associated with this workspace.
+  int32 num_projects = 6;
 }
 
 // PatchWorkspace is a partial update to a workspace with all optional fields.

--- a/webui/react/src/services/api-ts-sdk/api.ts
+++ b/webui/react/src/services/api-ts-sdk/api.ts
@@ -6584,6 +6584,12 @@ export interface V1Workspace {
      * @memberof V1Workspace
      */
     immutable: boolean;
+    /**
+     * Number of projects associated with this workspace.
+     * @type {number}
+     * @memberof V1Workspace
+     */
+    numProjects: number;
 }
 
 


### PR DESCRIPTION
## Description

Adds numProjects / num_projects count associated with each workspace. Affects API and CLI.

## Test Plan

- The /api/v1/workspaces response should include numProjects in each record (with workspace 1 having numProjects: 1)
- The /api/v1/workspaces/1 (default workspace) should include numProjects: 1
- In the CLI, `det w list` should list workspaces table with "# Projects" column, default workspace has "1"
- `det w describe Uncategorized` should print table with numProjects = 1
- `det w create test` should create a workspace and print out table numProjects = 0
- `det w describe test`, `det w edit test test`, etc. should return table with numProjects = 0

## Checklist

- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.