### PR TITLE
fix: replace carriage returns with newlines in task output [DET-5302]

### DIFF
--- a/master/static/srv/task-logging-teardown.sh
+++ b/master/static/srv/task-logging-teardown.sh
@@ -1,11 +1,10 @@
 #!/usr/bin/env bash
 
-if [ -n "$DET_K8S_LOG_TO_FILE" ]; then
-	# Replace overriden stdout and stderr with original and close them, since the command is finished.
-	exec >&1- >&2- 1>&$ORIGINAL_STDOUT 2>&$ORIGINAL_STDERR
+# Replace overridden stdout and stderr with original and close them, since the
+# command is finished.
+exec >&1- >&2- 1>&$ORIGINAL_STDOUT 2>&$ORIGINAL_STDERR
 
-	for ((i = 0; i < $DET_LOG_WAIT_COUNT; i++)); do
-		# read returns 1 on EOF, but it's a fifo so that is OK.
-		read <$DET_LOG_WAIT_FIFO || true
-	done
-fi
+for ((i = 0; i < $DET_LOG_WAIT_COUNT; i++)); do
+	# read returns 1 on EOF, but it's a fifo so that is OK.
+	read <$DET_LOG_WAIT_FIFO || true
+done


### PR DESCRIPTION
## Description

A task may output carriage return characters (\r) do something mildly
fancy with the terminal like update a progress bar in place on one
line. Python's tqdm library is a common way to do this. That works
poorly with our logging, since Fluent Bit interprets everything as one
line, causing it to mash everything together and buffer the output for
way too long. Since we're not going to do anything like interpreting the
carriage returns in our log displays, here we simply replace them all
with newlines to get a reasonable effect in those cases.

An alternative might be trying to manipulate tqdm itself, as the
original ticket proposes. But that comes with the issue that dealing
with `det cmd run ...` case would require us to ship a patched copy of
tqdm, since we don't have direct control over the Python interpreter in
that case. And of course that doesn't address similar output from other
sources.

## Test Plan

- [x] run tqdm in commands and trials, check that output comes out without excessive buffering and shows up in the UI
