### PR TITLE
fix: avoid type mismatch in update_model_version.sql

### DIFF
--- a/master/static/srv/update_model_version.sql
+++ b/master/static/srv/update_model_version.sql
@@ -17,7 +17,7 @@ m AS (
 c AS (
   SELECT *
   FROM proto_checkpoints_view c
-  WHERE c.uuid = (SELECT checkpoint_uuid FROM mv)
+  WHERE c.uuid = (SELECT checkpoint_uuid::text FROM mv)
 )
 SELECT
     to_json(c) AS checkpoint,


### PR DESCRIPTION
## Description

Micro-fix for this [error](https://app.circleci.com/pipelines/github/determined-ai/determined/21155/workflows/83aad580-1cad-4ecb-ab22-980cf33e7933/jobs/665352):

```
determined.common.api.errors.APIException: {"error":{"code":13,"reason":"Internal","error":"error updating model version 1 in database: error running query: update_model_version: ERROR: operator does not exist: text = uuid (SQLSTATE 42883)"}}
```
