### PR TITLE
feat: Add overall allocation bar to new cluster page [DET-7074]

### DIFF
--- a/webui/react/src/components/ResourcePoolCardLight.module.scss
+++ b/webui/react/src/components/ResourcePoolCardLight.module.scss
@@ -11,7 +11,7 @@ $line-height: 22px;
   font-size: var(--theme-sizes-font-medium);
   line-height: $line-height;
   overflow: hidden;
-  padding: var(--theme-sizes-layout-tiny) $padding 0;
+  padding: var(--theme-sizes-layout-medium) $padding var(--theme-sizes-layout-medium);
   text-overflow: ellipsis;
 
   .body {
@@ -58,6 +58,7 @@ section.details {
   display: flex;
   flex-direction: column;
   flex-grow: 1;
+  font-size: var(--theme-sizes-font-small);
 
   ul {
     flex-grow: 1;

--- a/webui/react/src/components/ResourcePoolCardLight.tsx
+++ b/webui/react/src/components/ResourcePoolCardLight.tsx
@@ -146,7 +146,7 @@ const ResourcePoolCardLight: React.FC<Props> = ({
               isAux={true}
               poolType={pool.type}
               resourceStates={computeContainerStates}
-              size={ShirtSize.large}
+              size={ShirtSize.big}
               totalSlots={totalComputeSlots}
             />
           )}

--- a/webui/react/src/pages/Cluster/ClusterHistoricalUsage.module.scss
+++ b/webui/react/src/pages/Cluster/ClusterHistoricalUsage.module.scss
@@ -3,8 +3,8 @@
   border-bottom: 1px solid var(--theme-colors-monochrome-12);
   left: 0;
   margin-bottom: var(--theme-sizes-layout-big);
-  margin-top: calc(var(--theme-sizes-layout-medium) * -2);
   padding-bottom: var(--theme-sizes-layout-medium);
+  padding-right: var(--theme-sizes-layout-big);
   padding-top: var(--theme-sizes-layout-medium);
   position: absolute;
   right: 0;

--- a/webui/react/src/pages/Cluster/ClusterOverallBar.tsx
+++ b/webui/react/src/pages/Cluster/ClusterOverallBar.tsx
@@ -1,0 +1,82 @@
+import React, { useMemo } from 'react';
+
+import Message, { MessageType } from 'components/Message';
+import Section from 'components/Section';
+import SlotAllocationBar from 'components/SlotAllocationBar';
+import { useStore } from 'contexts/Store';
+import { ShirtSize } from 'themes';
+import {
+  ResourceType,
+} from 'types';
+import { getSlotContainerStates } from 'utils/cluster';
+
+export const ClusterOverallBar: React.FC = () => {
+
+  const { agents, cluster: overview, resourcePools } = useStore();
+
+  const cudaSlotStates = useMemo(() => {
+    return getSlotContainerStates(agents || [], ResourceType.CUDA);
+  }, [ agents ]);
+
+  const rocmSlotStates = useMemo(() => {
+    return getSlotContainerStates(agents || [], ResourceType.ROCM);
+  }, [ agents ]);
+
+  const cpuSlotStates = useMemo(() => {
+    return getSlotContainerStates(agents || [], ResourceType.CPU);
+  }, [ agents ]);
+
+  const [ cudaTotalSlots, rocmTotalSlots ] = useMemo(() => {
+    return resourcePools.reduce((acc, pool) => {
+      let index;
+      switch (pool.slotType) {
+        case ResourceType.CUDA:
+          index = 0;
+          break;
+        case ResourceType.ROCM:
+          index = 1;
+          break;
+        default:
+          index = undefined;
+      }
+      if (index === undefined) return acc;
+      acc[index] += pool.maxAgents * (pool.slotsPerAgent ?? 0);
+      return acc;
+    }, [ 0, 0 ]);
+  }, [ resourcePools ]);
+
+  return (
+    <Section hideTitle title="Overall Allocation">
+      {cudaTotalSlots + rocmTotalSlots + overview.CPU.total === 0 ? (
+        <Message title="No connected agents." type={MessageType.Empty} />
+      ) : null }
+      {cudaTotalSlots > 0 && (
+        <SlotAllocationBar
+          resourceStates={cudaSlotStates}
+          showLegends
+          size={ShirtSize.enormous}
+          title={`Compute (${ResourceType.CUDA})`}
+          totalSlots={cudaTotalSlots}
+        />
+      )}
+      {rocmTotalSlots > 0 && (
+        <SlotAllocationBar
+          resourceStates={rocmSlotStates}
+          showLegends
+          size={ShirtSize.enormous}
+          title={`Compute (${ResourceType.ROCM})`}
+          totalSlots={rocmTotalSlots}
+        />
+      )}
+      {overview.CPU.total > 0 && (
+        <SlotAllocationBar
+          resourceStates={cpuSlotStates}
+          showLegends
+          size={ShirtSize.enormous}
+          title={`Compute (${ResourceType.CPU})`}
+          totalSlots={overview.CPU.total}
+        />
+      )}
+    </Section>
+  );
+};

--- a/webui/react/src/pages/Cluster/ClusterOverview.tsx
+++ b/webui/react/src/pages/Cluster/ClusterOverview.tsx
@@ -3,7 +3,6 @@ import React, { useCallback, useEffect, useMemo, useState } from 'react';
 
 import Grid, { GridMode } from 'components/Grid';
 import GridListRadioGroup, { GridListView } from 'components/GridListRadioGroup';
-import Message, { MessageType } from 'components/Message';
 import OverviewStats from 'components/OverviewStats';
 import ResourcePoolCard from 'components/ResourcePoolCard';
 import ResourcePoolDetails from 'components/ResourcePoolDetails';
@@ -24,6 +23,7 @@ import {
 } from 'types';
 import { getSlotContainerStates } from 'utils/cluster';
 
+import { ClusterOverallBar } from './ClusterOverallBar';
 import css from './ClusterOverview.module.scss';
 
 const STORAGE_PATH = 'cluster';
@@ -69,18 +69,6 @@ const ClusterOverview: React.FC = () => {
     });
     return tally;
   }, [ resourcePools ]);
-
-  const cudaSlotStates = useMemo(() => {
-    return getSlotContainerStates(agents || [], ResourceType.CUDA);
-  }, [ agents ]);
-
-  const rocmSlotStates = useMemo(() => {
-    return getSlotContainerStates(agents || [], ResourceType.ROCM);
-  }, [ agents ]);
-
-  const cpuSlotStates = useMemo(() => {
-    return getSlotContainerStates(agents || [], ResourceType.CPU);
-  }, [ agents ]);
 
   const [ cudaTotalSlots, rocmTotalSlots ] = useMemo(() => {
     return resourcePools.reduce((acc, pool) => {
@@ -213,38 +201,7 @@ const ClusterOverview: React.FC = () => {
           ) : null}
         </Grid>
       </Section>
-      <Section hideTitle title="Overall Allocation">
-        {cudaTotalSlots + rocmTotalSlots + overview.CPU.total === 0 ? (
-          <Message title="No connected agents." type={MessageType.Empty} />
-        ) : null }
-        {cudaTotalSlots > 0 && (
-          <SlotAllocationBar
-            resourceStates={cudaSlotStates}
-            showLegends
-            size={ShirtSize.enormous}
-            title={`Compute (${ResourceType.CUDA})`}
-            totalSlots={cudaTotalSlots}
-          />
-        )}
-        {rocmTotalSlots > 0 && (
-          <SlotAllocationBar
-            resourceStates={rocmSlotStates}
-            showLegends
-            size={ShirtSize.enormous}
-            title={`Compute (${ResourceType.ROCM})`}
-            totalSlots={rocmTotalSlots}
-          />
-        )}
-        {overview.CPU.total > 0 && (
-          <SlotAllocationBar
-            resourceStates={cpuSlotStates}
-            showLegends
-            size={ShirtSize.enormous}
-            title={`Compute (${ResourceType.CPU})`}
-            totalSlots={overview.CPU.total}
-          />
-        )}
-      </Section>
+      <ClusterOverallBar />
       <Section
         options={<GridListRadioGroup value={selectedView} onChange={handleRadioChange} />}
         title={`${resourcePools.length} Resource Pools`}>

--- a/webui/react/src/pages/Clusters.module.scss
+++ b/webui/react/src/pages/Clusters.module.scss
@@ -1,0 +1,3 @@
+.tab {
+  padding: 0 var(--theme-sizes-layout-big);
+}

--- a/webui/react/src/pages/Clusters.tsx
+++ b/webui/react/src/pages/Clusters.tsx
@@ -8,7 +8,9 @@ import { paths } from 'routes/utils';
 import { ResourceType } from 'types';
 import { percent } from 'utils/number';
 
+import ClusterHistoricalUsage from './Cluster/ClusterHistoricalUsage';
 import ClusterLogs from './ClusterLogs';
+import css from './Clusters.module.scss';
 import ClustersOverview from './Clusters/ClustersOverview';
 
 const { TabPane } = Tabs;
@@ -57,7 +59,10 @@ const Clusters: React.FC = () => {
         <TabPane key="overview" tab="Overview">
           <ClustersOverview />
         </TabPane>
-        <TabPane key="logs" tab="Cluster Logs">
+        <TabPane className={css.tab} key="historical-usage" tab="Historical Usage">
+          <ClusterHistoricalUsage />
+        </TabPane>
+        <TabPane key="logs" tab="Master Logs">
           <ClusterLogs />
         </TabPane>
       </Tabs>

--- a/webui/react/src/pages/Clusters/ClustersOverview.tsx
+++ b/webui/react/src/pages/Clusters/ClustersOverview.tsx
@@ -13,6 +13,8 @@ import {
 } from 'types';
 import { getSlotContainerStates } from 'utils/cluster';
 
+import { ClusterOverallBar } from '../Cluster/ClusterOverallBar';
+
 import css from './ClustersOverview.module.scss';
 
 const ClusterOverview: React.FC = () => {
@@ -37,6 +39,7 @@ const ClusterOverview: React.FC = () => {
 
   return (
     <div className={css.base}>
+      <ClusterOverallBar />
       <Section
         title={'Resource Pools'}>
         <Grid gap={ShirtSize.medium} minItemWidth={300} mode={GridMode.AutoFill}>


### PR DESCRIPTION
## Description

Add overall allocation bar and historical usage page to new cluster page, allocation bar and historical page should behave exactly like the old one.


## Test Plan

Navigate to `/clusters` page to verify the allocation bar and `Historical Usage` tab exists.

<img width="1456" alt="Screen Shot 2022-04-21 at 5 08 10 PM" src="https://user-images.githubusercontent.com/40620519/164570366-e2b48add-ac16-4a63-b8f1-91980bb5790a.png">

