### PR TITLE
fix: add test warmup command e2e [DET-5803] 

### DIFF
--- a/e2e_tests/tests/cluster/test_logging.py
+++ b/e2e_tests/tests/cluster/test_logging.py
@@ -16,7 +16,7 @@ from tests import experiment as exp
 @pytest.mark.e2e_cpu_postgres
 @pytest.mark.e2e_cpu_cross_version
 @pytest.mark.e2e_gpu
-@pytest.mark.timeout(30 * 60)
+@pytest.mark.timeout(5 * 60)
 def test_trial_logs() -> None:
     # TODO: refactor tests to not use cli singleton auth.
     master_url = conf.make_master_url()
@@ -42,7 +42,7 @@ def test_trial_logs() -> None:
 @pytest.mark.e2e_cpu_elastic
 @pytest.mark.e2e_cpu_cross_version
 @pytest.mark.e2e_gpu  # Note, e2e_gpu and not gpu_required hits k8s cpu tests.
-@pytest.mark.timeout(30 * 60)
+@pytest.mark.timeout(5 * 60)
 @pytest.mark.parametrize(
     "task_type,task_config,log_regex",
     [

--- a/e2e_tests/tests/cluster/test_logging.py
+++ b/e2e_tests/tests/cluster/test_logging.py
@@ -16,7 +16,7 @@ from tests import experiment as exp
 @pytest.mark.e2e_cpu_postgres
 @pytest.mark.e2e_cpu_cross_version
 @pytest.mark.e2e_gpu
-# TODO(DET-5803): We need a GPU warm-up job to be able to use timeouts.
+@pytest.mark.timeout(30 * 60)
 def test_trial_logs() -> None:
     # TODO: refactor tests to not use cli singleton auth.
     master_url = conf.make_master_url()
@@ -42,7 +42,7 @@ def test_trial_logs() -> None:
 @pytest.mark.e2e_cpu_elastic
 @pytest.mark.e2e_cpu_cross_version
 @pytest.mark.e2e_gpu  # Note, e2e_gpu and not gpu_required hits k8s cpu tests.
-# TODO(DET-5803): We need a GPU warm-up job to be able to use timeouts.
+@pytest.mark.timeout(30 * 60)
 @pytest.mark.parametrize(
     "task_type,task_config,log_regex",
     [

--- a/e2e_tests/tests/conftest.py
+++ b/e2e_tests/tests/conftest.py
@@ -91,7 +91,7 @@ def instantiate_gpu() -> None:
     ]
 
     subprocess.run(
-        command, universal_newlines=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=env
+        command, universal_newlines=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE
     )
 
 @pytest.fixture(scope="session", autouse=True)

--- a/e2e_tests/tests/conftest.py
+++ b/e2e_tests/tests/conftest.py
@@ -80,19 +80,13 @@ def pytest_addoption(parser: Parser) -> None:
     )
     parser.addoption("--follow-local-logs", action="store_true", help="Follow local docker logs")
 
-@pytest.fixture(scope="session", autouse=True)
-def instantiate_gpu() -> None: 
-    command = [
-        "det",
-        "cmd",
-        "--config",
-        "resources.slots=1", 
-        "'sleep 30'"
-    ]
 
-    subprocess.run(
-        command, universal_newlines=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE
-    )
+@pytest.fixture(scope="session", autouse=True)
+def instantiate_gpu() -> None:
+    command = ["det", "cmd", "--config", "resources.slots=1", "'sleep 30'"]
+
+    subprocess.run(command, universal_newlines=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
 
 @pytest.fixture(scope="session", autouse=True)
 def cluster_log_manager(request: SubRequest) -> Iterator[Optional[ClusterLogManager]]:

--- a/e2e_tests/tests/conftest.py
+++ b/e2e_tests/tests/conftest.py
@@ -80,6 +80,19 @@ def pytest_addoption(parser: Parser) -> None:
     )
     parser.addoption("--follow-local-logs", action="store_true", help="Follow local docker logs")
 
+@pytest.fixture(scope="session", autouse=True)
+def instantiate_gpu() -> None: 
+    command = [
+        "det",
+        "cmd",
+        "--config",
+        "resources.slots=1", 
+        "'sleep 30'"
+    ]
+
+    subprocess.run(
+        command, universal_newlines=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=env
+    )
 
 @pytest.fixture(scope="session", autouse=True)
 def cluster_log_manager(request: SubRequest) -> Iterator[Optional[ClusterLogManager]]:

--- a/e2e_tests/tests/experiment/test_profiling.py
+++ b/e2e_tests/tests/experiment/test_profiling.py
@@ -13,7 +13,6 @@ from tests import experiment as exp
 
 
 @pytest.mark.e2e_gpu
-# TODO(DET-5803): We need a GPU warm-up job to prevent this excessive time limit.
 @pytest.mark.timeout(30 * 60)
 @pytest.mark.parametrize(
     "framework_base_experiment,framework_timings_enabled",

--- a/e2e_tests/tests/experiment/test_profiling.py
+++ b/e2e_tests/tests/experiment/test_profiling.py
@@ -13,7 +13,7 @@ from tests import experiment as exp
 
 
 @pytest.mark.e2e_gpu
-@pytest.mark.timeout(30 * 60)
+@pytest.mark.timeout(5 * 60)
 @pytest.mark.parametrize(
     "framework_base_experiment,framework_timings_enabled",
     [


### PR DESCRIPTION
## Description

fix: add test warmup command e2e [DET=5803] 

## Test Plan

Made sure the e2e_tests run fine (even with the timeouts specified for tests in test_logging.py and and test_profiling.py) 