### PR TITLE
docs: fix mismatched tutorial links

### DIFF
--- a/docs/tutorials/index.txt
+++ b/docs/tutorials/index.txt
@@ -12,7 +12,7 @@ number of features.
 *********
 
 For PyTorch users, begin with :doc:`the MNIST tutorial, which uses the simplest model
-</tutorials/tf-mnist-tutorial>`. If you already have runnable code, follow the
+</tutorials/pytorch-mnist-tutorial>`. If you already have runnable code, follow the
 :doc:`/tutorials/pytorch-porting-tutorial` steps to port your code to use Determined Pytorch APIs.
 
 ******************
@@ -20,7 +20,7 @@ For PyTorch users, begin with :doc:`the MNIST tutorial, which uses the simplest 
 ******************
 
 TensorFlow Keras users can begin with :doc:`the MNIST tutorial, which uses the simplest model
-</tutorials/pytorch-mnist-tutorial>`.
+</tutorials/tf-mnist-tutorial>`.
 
 .. toctree::
    :maxdepth: 1


### PR DESCRIPTION
## Description

docs: fix mismatched tutorial links

right now:
For PyTorch users, begin with the MNIST tutorial, which uses the simplest model
--> links to tf keras

and 

TensorFlow Keras users can begin with the MNIST tutorial, which uses the simplest model
--> links to pytorch

## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions about this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
