### PR TITLE
chore: bring in can-ndjson-stream and apply patch [DET-7121]

### DIFF
--- a/webui/react/src/services/can-ndjson-stream.js
+++ b/webui/react/src/services/can-ndjson-stream.js
@@ -1,0 +1,77 @@
+"use strict";
+/*exported ndjsonStream*/
+
+var namespace = require('can-namespace');
+
+/**
+ * Brought this MIT library in to our source because...
+ * 1. it doesn't seem to be an active project anymore
+ * 2. there is a patch we want to apply
+ * 3. it is only ~60 lines and fairly easy to maintain
+ * https://github.com/canjs/can-ndjson-stream
+ */
+var ndjsonStream = function(response) {
+  // For cancellation
+  var is_reader, cancellationRequest = false;
+  return new ReadableStream({
+    start: function(controller) {
+      var reader = response.getReader();
+      is_reader = reader;
+      var decoder = new TextDecoder();
+      var data_buf = "";
+      var errorHandler = controller.error.bind(controller);
+
+      reader.read().then(function processResult(result) {
+        if (result.done) {
+          if (cancellationRequest) {
+            // Immediately exit
+            return;
+          }
+
+          data_buf = data_buf.trim();
+          if (data_buf.length !== 0) {
+            try {
+              var data_l = JSON.parse(data_buf);
+              controller.enqueue(data_l);
+            } catch(e) {
+              controller.error(e);
+              return;
+            }
+          }
+          controller.close();
+          return;
+        }
+
+        var data = decoder.decode(result.value, {stream: true});
+        data_buf += data;
+        var lines = data_buf.split("\n");
+        for(var i = 0; i < lines.length - 1; ++i) {
+          var l = lines[i].trim();
+          if (l.length > 0) {
+            try {
+              var data_line = JSON.parse(l);
+              controller.enqueue(data_line);
+            } catch(e) {
+              controller.error(e);
+              cancellationRequest = true;
+              reader.cancel();
+              return;
+            }
+          }
+        }
+        data_buf = lines[lines.length-1];
+
+        return reader.read().then(processResult).catch(errorHandler);
+      }).catch(errorHandler);
+
+    },
+    cancel: function(reason) {
+      console.log("Cancel registered due to ", reason);
+      cancellationRequest = true;
+      is_reader.cancel();
+    }
+  });
+};
+
+module.exports = namespace.ndjsonStream = ndjsonStream;
+

--- a/webui/react/src/services/utils.ts
+++ b/webui/react/src/services/utils.ts
@@ -6,7 +6,7 @@ import { DetError, DetErrorOptions, ErrorLevel, ErrorType, isDetError } from 'ut
 import { DetApi, FetchOptions } from './types';
 
 /* eslint-disable @typescript-eslint/no-var-requires */
-const ndjsonStream = require('can-ndjson-stream');
+const ndjsonStream = require('./can-ndjson-stream');
 
 /* Response Helpers */
 


### PR DESCRIPTION
## Description

This only impacts our dev environment but there is a lot of noise when we call the AbortController cancel for a ndjson streaming endpoint. The issue is that there are uncaught errors within the `can-ndjson-stream` library.

Sample error we encounter on the browser client.
<img width="636" alt="image (1)" src="https://user-images.githubusercontent.com/220971/164740902-e9cc7d00-d86e-422c-8eec-ca764d51d9be.png">

Different browsers behave differently. FireFox notably shows a full page error and hitting escape allows you to continue on. On Chrome, it shows up in the console as an error but continues to function.

Decided to bring this MIT library into our project because...
1. it doesn't seem to be an active project anymore
2. there is a patch we want to apply to fix the describe problem above
3. it is only ~60 lines and fairly easy to maintain

<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At a minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan

- [ ] run a local web development instance (via `make live`) and ensure that there are no `The operation was aborted by the user` or any message in that similar vein.

<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions about this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ