### PR TITLE
fix: do not default to `noverify` for `bindings` sessions in CLI.

### DIFF
--- a/docs/release-notes/fix-noverify.txt
+++ b/docs/release-notes/fix-noverify.txt
@@ -2,4 +2,5 @@
 
 **Bug Fixes**
 
--  CLI: Stop using SSL "noverify" option for some API requests.
+-  CLI: API requests executed through python bindings have been erroneously using SSL "noverify"
+   option since 0.17.6, making them potentially unsecure. This option is now disabled.

--- a/docs/release-notes/fix-noverify.txt
+++ b/docs/release-notes/fix-noverify.txt
@@ -1,0 +1,5 @@
+:orphan:
+
+**Bug Fixes**
+
+-  CLI: Stop using SSL "noverify" option for some API requests.

--- a/harness/determined/cli/session.py
+++ b/harness/determined/cli/session.py
@@ -6,12 +6,7 @@ from determined.common.experimental import session
 
 
 def setup_session(args: Namespace) -> session.Session:
-    master = args.master or util.get_default_master_address()
-    cert = certs.default_load(
-        master_url=master,
-        explicit_path=getattr(args, "cert_path", None),
-        explicit_cert_name=getattr(args, "cert_name", None),
-        explicit_noverify=getattr(args, "noverify", True),
-    )
+    master_url = args.master or util.get_default_master_address()
+    cert = certs.default_load(master_url)
 
-    return session.Session(master, args.user, authentication.cli_auth, cert)
+    return session.Session(master_url, args.user, authentication.cli_auth, cert)


### PR DESCRIPTION
## Description

OSS user has reported we were defaulting no `noverify` in `setup_session` helper: https://determined-community.slack.com/archives/CV3MTNZ6U/p1650642072594889
We don't do it in cli cert setups elsewhere, and all of `noverify`, `cert_path`, and `cert_name` options on `args` seem to be dead. 

## Test Plan

CLI shouldn't print urllib's noverify warnings when used with HTTPS cluster.

## Commentary (optional)

## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
