### PR TITLE
feat: add modal to explain why users cannot delete items [DET-6998]

### DIFF
--- a/webui/react/src/components/ModalItemDelete.tsx
+++ b/webui/react/src/components/ModalItemDelete.tsx
@@ -3,8 +3,7 @@ import { Modal } from 'antd';
 const showModalItemCannotDelete = (): void => {
   Modal.confirm({
     closable: true,
-    content: `Only the item creator or an admin can 
-    delete items from the model registry.`,
+    content: 'Only the item creator or an admin can delete this item.',
     icon: null,
     maskClosable: true,
     okText: 'Ok',

--- a/webui/react/src/components/ModalItemDelete.tsx
+++ b/webui/react/src/components/ModalItemDelete.tsx
@@ -1,0 +1,15 @@
+import { Modal } from 'antd';
+
+const showModalItemCannotDelete = (): void => {
+  Modal.confirm({
+    closable: true,
+    content: `Only the item creator or an admin can 
+    delete items from the model registry.`,
+    icon: null,
+    maskClosable: true,
+    okText: 'Ok',
+    title: 'Unable to Delete',
+  });
+};
+
+export default showModalItemCannotDelete;

--- a/webui/react/src/pages/ModelDetails.tsx
+++ b/webui/react/src/pages/ModelDetails.tsx
@@ -120,6 +120,17 @@ const ModelDetails: React.FC = () => {
     });
   }, [ deleteVersion ]);
 
+  const showCannotDelete = () => {
+    Modal.confirm({
+      closable: true,
+      content: 'Only the item creator or an admin can delete items from the model registry.',
+      icon: null,
+      maskClosable: true,
+      okText: 'Ok',
+      title: 'Unable to Delete',
+    });
+  };
+
   const saveVersionDescription =
     useCallback(async (editedDescription: string, versionId: number) => {
       try {
@@ -159,9 +170,9 @@ const ModelDetails: React.FC = () => {
               {useActionRenderer(_, record)}
               <Menu.Item
                 danger
-                disabled={!isDeletable}
+
                 key="delete-version"
-                onClick={() => showConfirmDelete(record)}>
+                onClick={() => isDeletable ? showConfirmDelete(record) : showCannotDelete()}>
                 Delete Version
               </Menu.Item>
             </Menu>

--- a/webui/react/src/pages/ModelDetails.tsx
+++ b/webui/react/src/pages/ModelDetails.tsx
@@ -9,6 +9,7 @@ import Icon from 'components/Icon';
 import InlineEditor from 'components/InlineEditor';
 import Message, { MessageType } from 'components/Message';
 import MetadataCard from 'components/Metadata/MetadataCard';
+import showModalItemCannotDelete from 'components/ModalItemDelete';
 import NotesCard from 'components/NotesCard';
 import Page from 'components/Page';
 import ResponsiveTable from 'components/ResponsiveTable';
@@ -120,17 +121,6 @@ const ModelDetails: React.FC = () => {
     });
   }, [ deleteVersion ]);
 
-  const showCannotDelete = () => {
-    Modal.confirm({
-      closable: true,
-      content: 'Only the item creator or an admin can delete items from the model registry.',
-      icon: null,
-      maskClosable: true,
-      okText: 'Ok',
-      title: 'Unable to Delete',
-    });
-  };
-
   const saveVersionDescription =
     useCallback(async (editedDescription: string, versionId: number) => {
       try {
@@ -172,7 +162,8 @@ const ModelDetails: React.FC = () => {
                 danger
 
                 key="delete-version"
-                onClick={() => isDeletable ? showConfirmDelete(record) : showCannotDelete()}>
+                onClick={() => isDeletable ?
+                  showConfirmDelete(record) : showModalItemCannotDelete()}>
                 Delete Version
               </Menu.Item>
             </Menu>

--- a/webui/react/src/pages/ModelDetails/ModelHeader.tsx
+++ b/webui/react/src/pages/ModelDetails/ModelHeader.tsx
@@ -7,6 +7,7 @@ import Icon from 'components/Icon';
 import InfoBox, { InfoRow } from 'components/InfoBox';
 import InlineEditor from 'components/InlineEditor';
 import Link from 'components/Link';
+import showModalItemCannotDelete from 'components/ModalItemDelete';
 import { relativeTimeRenderer } from 'components/Table';
 import TagList from 'components/TagList';
 import { useStore } from 'contexts/Store';
@@ -86,17 +87,6 @@ const ModelHeader: React.FC<Props> = (
     });
   }, [ onDelete ]);
 
-  const showCannotDelete = () => {
-    Modal.confirm({
-      closable: true,
-      content: 'Only the item creator or an admin can delete items from the model registry.',
-      icon: null,
-      maskClosable: true,
-      okText: 'Ok',
-      title: 'Unable to Delete',
-    });
-  };
-
   return (
     <header className={css.base}>
       <div className={css.breadcrumbs}>
@@ -147,7 +137,8 @@ const ModelHeader: React.FC<Props> = (
                   <Menu.Item
                     danger
                     key="delete-model"
-                    onClick={() => isDeletable ? showConfirmDelete(model) : showCannotDelete()}>
+                    onClick={() => isDeletable ?
+                      showConfirmDelete(model) : showModalItemCannotDelete()}>
                     Delete
                   </Menu.Item>
                 </Menu>

--- a/webui/react/src/pages/ModelDetails/ModelHeader.tsx
+++ b/webui/react/src/pages/ModelDetails/ModelHeader.tsx
@@ -86,6 +86,17 @@ const ModelHeader: React.FC<Props> = (
     });
   }, [ onDelete ]);
 
+  const showCannotDelete = () => {
+    Modal.confirm({
+      closable: true,
+      content: 'Only the item creator or an admin can delete items from the model registry.',
+      icon: null,
+      maskClosable: true,
+      okText: 'Ok',
+      title: 'Unable to Delete',
+    });
+  };
+
   return (
     <header className={css.base}>
       <div className={css.breadcrumbs}>
@@ -135,9 +146,8 @@ const ModelHeader: React.FC<Props> = (
                   </Menu.Item>
                   <Menu.Item
                     danger
-                    disabled={!isDeletable}
                     key="delete-model"
-                    onClick={() => showConfirmDelete(model)}>
+                    onClick={() => isDeletable ? showConfirmDelete(model) : showCannotDelete()}>
                     Delete
                   </Menu.Item>
                 </Menu>

--- a/webui/react/src/pages/ModelRegistry.tsx
+++ b/webui/react/src/pages/ModelRegistry.tsx
@@ -254,6 +254,17 @@ const ModelRegistry: React.FC = () => {
     });
   }, [ deleteCurrentModel ]);
 
+  const showCannotDelete = () => {
+    Modal.confirm({
+      closable: true,
+      content: 'Only the item creator or an admin can delete items from the model registry.',
+      icon: null,
+      maskClosable: true,
+      okText: 'Ok',
+      title: 'Unable to Delete',
+    });
+  };
+
   const saveModelDescription = useCallback(async (modelName: string, editedDescription: string) => {
     try {
       await patchModel({
@@ -294,9 +305,8 @@ const ModelRegistry: React.FC = () => {
               </Menu.Item>
               <Menu.Item
                 danger
-                disabled={!isDeletable}
                 key="delete-model"
-                onClick={() => showConfirmDelete(record)}>
+                onClick={() => isDeletable ? showConfirmDelete(record) : showCannotDelete()}>
                 Delete Model
               </Menu.Item>
             </Menu>

--- a/webui/react/src/pages/ModelRegistry.tsx
+++ b/webui/react/src/pages/ModelRegistry.tsx
@@ -6,6 +6,7 @@ import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import Icon from 'components/Icon';
 import InlineEditor from 'components/InlineEditor';
 import Link from 'components/Link';
+import showModalItemCannotDelete from 'components/ModalItemDelete';
 import Page from 'components/Page';
 import ResponsiveTable from 'components/ResponsiveTable';
 import tableCss from 'components/ResponsiveTable.module.scss';
@@ -254,17 +255,6 @@ const ModelRegistry: React.FC = () => {
     });
   }, [ deleteCurrentModel ]);
 
-  const showCannotDelete = () => {
-    Modal.confirm({
-      closable: true,
-      content: 'Only the item creator or an admin can delete items from the model registry.',
-      icon: null,
-      maskClosable: true,
-      okText: 'Ok',
-      title: 'Unable to Delete',
-    });
-  };
-
   const saveModelDescription = useCallback(async (modelName: string, editedDescription: string) => {
     try {
       await patchModel({
@@ -306,7 +296,8 @@ const ModelRegistry: React.FC = () => {
               <Menu.Item
                 danger
                 key="delete-model"
-                onClick={() => isDeletable ? showConfirmDelete(record) : showCannotDelete()}>
+                onClick={() => isDeletable ?
+                  showConfirmDelete(record) : showModalItemCannotDelete()}>
                 Delete Model
               </Menu.Item>
             </Menu>

--- a/webui/react/src/pages/ModelVersionDetails/ModelVersionHeader.tsx
+++ b/webui/react/src/pages/ModelVersionDetails/ModelVersionHeader.tsx
@@ -56,6 +56,17 @@ const ModelVersionHeader: React.FC<Props> = (
     });
   }, [ onDeregisterVersion, modelVersion.version ]);
 
+  const showCannotDelete = () => {
+    Modal.confirm({
+      closable: true,
+      content: 'Only the item creator or an admin can delete items from the model registry.',
+      icon: null,
+      maskClosable: true,
+      okText: 'Ok',
+      title: 'Unable to Delete',
+    });
+  };
+
   const infoRows: InfoRow[] = useMemo(() => {
     return [ {
       content: (
@@ -117,9 +128,9 @@ const ModelVersionHeader: React.FC<Props> = (
       },
       {
         danger: true,
-        disabled: !isDeletable,
+        disabled: false,
         key: 'deregister-version',
-        onClick: showConfirmDelete,
+        onClick: () => isDeletable ? showConfirmDelete() : showCannotDelete(),
         text: 'Deregister Version',
       },
     ];

--- a/webui/react/src/pages/ModelVersionDetails/ModelVersionHeader.tsx
+++ b/webui/react/src/pages/ModelVersionDetails/ModelVersionHeader.tsx
@@ -9,6 +9,7 @@ import Icon from 'components/Icon';
 import InfoBox, { InfoRow } from 'components/InfoBox';
 import InlineEditor from 'components/InlineEditor';
 import Link from 'components/Link';
+import showModalItemCannotDelete from 'components/ModalItemDelete';
 import { relativeTimeRenderer } from 'components/Table';
 import TagList from 'components/TagList';
 import { useStore } from 'contexts/Store';
@@ -55,17 +56,6 @@ const ModelVersionHeader: React.FC<Props> = (
       title: 'Confirm Delete',
     });
   }, [ onDeregisterVersion, modelVersion.version ]);
-
-  const showCannotDelete = () => {
-    Modal.confirm({
-      closable: true,
-      content: 'Only the item creator or an admin can delete items from the model registry.',
-      icon: null,
-      maskClosable: true,
-      okText: 'Ok',
-      title: 'Unable to Delete',
-    });
-  };
 
   const infoRows: InfoRow[] = useMemo(() => {
     return [ {
@@ -130,7 +120,8 @@ const ModelVersionHeader: React.FC<Props> = (
         danger: true,
         disabled: false,
         key: 'deregister-version',
-        onClick: () => isDeletable ? showConfirmDelete() : showCannotDelete(),
+        onClick: () => isDeletable ?
+          showConfirmDelete() : showModalItemCannotDelete(),
         text: 'Deregister Version',
       },
     ];

--- a/webui/react/src/pages/ModelVersionDetails/ModelVersionHeader.tsx
+++ b/webui/react/src/pages/ModelVersionDetails/ModelVersionHeader.tsx
@@ -118,7 +118,6 @@ const ModelVersionHeader: React.FC<Props> = (
       },
       {
         danger: true,
-        disabled: false,
         key: 'deregister-version',
         onClick: () => isDeletable ?
           showConfirmDelete() : showModalItemCannotDelete(),


### PR DESCRIPTION
## Description

feat: add modal to explain why users cannot delete items [DET-6998]

The "Delete" button is no longer disabled when deleting a model or deregistering a model version. Instead a modal is shown explaining that only an admin or the user who created the item is able to delete it. 

![20FB050E-AD2E-44BE-BC4E-181BA4B8FDA4](https://user-images.githubusercontent.com/103522725/164774279-566acc46-8397-4146-9ab7-e9127cbe1d93.jpeg)

![Screen Shot 2022-04-25 at 2 23 50 PM](https://user-images.githubusercontent.com/103522725/165159532-af96921a-f13f-4399-a10e-11186faf09de.png)

## Test Plan

1. Using an admin account or the account of a user that has created the model or version, attempt to delete a model or deregister version. Everything should work as expected.
2. Using a non admin account or account of a user that did not create a model or version. Attempt to deregister a model or version. The "Delete" or "Deregister" button should be enabled. After clicking the button, a modal should show explaining that "Only the item creator or an admin can delete items from the model registry".


## Commentary (optional)

The `showCannotDelete` function has been defined several times in this PR but would seeming be more appropriate defined in a single place such as in a `helpers` file. However, it does not seem as though any such directory is currently defined. I wondered if that was due in an effort to explicitly separate function/utility concerns. However, if we do think this function should be defined in one place only I will refactor. 

update: The refactor mentioned above has been implemented.


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

[DET-6998]: https://determinedai.atlassian.net/browse/DET-6998?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ