### PR TITLE
feat: Users-specific pinned workspaces

### DIFF
--- a/e2e_tests/tests/cluster/test_workspace_org.py
+++ b/e2e_tests/tests/cluster/test_workspace_org.py
@@ -99,6 +99,20 @@ def test_workspace_org() -> None:
             map(lambda w: w.name, list_test_3)
         )
 
+        # Test pinned workspaces.
+        bindings.post_PinWorkspace(sess, id=made_workspace.id)
+        pinned = bindings.get_GetWorkspaces(
+            sess,
+            pinned="true",
+        ).workspaces
+        assert len(pinned) == 1 and pinned[0].id == made_workspace.id
+        bindings.post_UnpinWorkspace(sess, id=made_workspace.id)
+        pinned = bindings.get_GetWorkspaces(
+            sess,
+            pinned="true",
+        ).workspaces
+        assert len(pinned) == 0
+
         # Add a test project to a workspace.
         r4 = bindings.post_PostProject(
             sess,

--- a/e2e_tests/tests/cluster/test_workspace_org.py
+++ b/e2e_tests/tests/cluster/test_workspace_org.py
@@ -103,13 +103,13 @@ def test_workspace_org() -> None:
         bindings.post_PinWorkspace(sess, id=made_workspace.id)
         pinned = bindings.get_GetWorkspaces(
             sess,
-            pinned="true",
+            pinned=True,
         ).workspaces
         assert len(pinned) == 1 and pinned[0].id == made_workspace.id
         bindings.post_UnpinWorkspace(sess, id=made_workspace.id)
         pinned = bindings.get_GetWorkspaces(
             sess,
-            pinned="true",
+            pinned=True,
         ).workspaces
         assert len(pinned) == 0
 

--- a/harness/determined/common/api/bindings.py
+++ b/harness/determined/common/api/bindings.py
@@ -5641,6 +5641,7 @@ class v1Workspace:
         immutable: bool,
         name: str,
         numProjects: int,
+        pinned: bool,
         username: str,
     ):
         self.id = id
@@ -5649,6 +5650,7 @@ class v1Workspace:
         self.username = username
         self.immutable = immutable
         self.numProjects = numProjects
+        self.pinned = pinned
 
     @classmethod
     def from_json(cls, obj: Json) -> "v1Workspace":
@@ -5659,6 +5661,7 @@ class v1Workspace:
             username=obj["username"],
             immutable=obj["immutable"],
             numProjects=obj["numProjects"],
+            pinned=obj["pinned"],
         )
 
     def to_json(self) -> typing.Any:
@@ -5669,6 +5672,7 @@ class v1Workspace:
             "username": self.username,
             "immutable": self.immutable,
             "numProjects": self.numProjects,
+            "pinned": self.pinned,
         }
 
 def post_AckAllocationPreemptionSignal(
@@ -7210,6 +7214,7 @@ def get_GetWorkspaces(
     name: "typing.Optional[str]" = None,
     offset: "typing.Optional[int]" = None,
     orderBy: "typing.Optional[v1OrderBy]" = None,
+    pinned: "typing.Optional[bool]" = None,
     sortBy: "typing.Optional[v1GetWorkspacesRequestSortBy]" = None,
     users: "typing.Optional[typing.Sequence[str]]" = None,
 ) -> "v1GetWorkspacesResponse":
@@ -7219,6 +7224,7 @@ def get_GetWorkspaces(
         "name": name,
         "offset": offset,
         "orderBy": orderBy.value if orderBy else None,
+        "pinned": pinned,
         "sortBy": sortBy.value if sortBy else None,
         "users": users,
     }
@@ -7681,6 +7687,25 @@ def post_PauseExperiment(
     if _resp.status_code == 200:
         return
     raise APIHttpError("post_PauseExperiment", _resp)
+
+def post_PinWorkspace(
+    session: "client.Session",
+    *,
+    id: int,
+) -> None:
+    _params = None
+    _resp = session._do_request(
+        method="POST",
+        path=f"/api/v1/workspaces/{id}/pin",
+        params=_params,
+        json=None,
+        data=None,
+        headers=None,
+        timeout=None,
+    )
+    if _resp.status_code == 200:
+        return
+    raise APIHttpError("post_PinWorkspace", _resp)
 
 def post_PostCheckpointMetadata(
     session: "client.Session",
@@ -8200,6 +8225,25 @@ def post_UnarchiveWorkspace(
     if _resp.status_code == 200:
         return
     raise APIHttpError("post_UnarchiveWorkspace", _resp)
+
+def post_UnpinWorkspace(
+    session: "client.Session",
+    *,
+    id: int,
+) -> None:
+    _params = None
+    _resp = session._do_request(
+        method="POST",
+        path=f"/api/v1/workspaces/{id}/unpin",
+        params=_params,
+        json=None,
+        data=None,
+        headers=None,
+        timeout=None,
+    )
+    if _resp.status_code == 200:
+        return
+    raise APIHttpError("post_UnpinWorkspace", _resp)
 
 def post_UpdateJobQueue(
     session: "client.Session",

--- a/harness/determined/common/experimental/session.py
+++ b/harness/determined/common/experimental/session.py
@@ -29,6 +29,10 @@ class Session:
         headers: Optional[Dict[str, Any]],
         timeout: Optional[int],
     ) -> requests.Response:
+        if params:
+            for k, v in params.iteritems():
+                if type(v) == bool:
+                    params[k] = str(v).lower()
         return request.do_request(
             method,
             self._master,

--- a/harness/determined/common/experimental/session.py
+++ b/harness/determined/common/experimental/session.py
@@ -30,7 +30,7 @@ class Session:
         timeout: Optional[int],
     ) -> requests.Response:
         if params:
-            for k, v in params.iteritems():
+            for k, v in params.items():
                 if type(v) == bool:
                     params[k] = str(v).lower()
         return request.do_request(

--- a/master/internal/api_project.go
+++ b/master/internal/api_project.go
@@ -128,7 +128,7 @@ func (a *apiServer) PostProject(
 		return nil, err
 	}
 
-	w, err := a.GetWorkspaceFromID(req.WorkspaceId)
+	w, err := a.GetWorkspaceFromID(req.WorkspaceId, 0)
 	if err != nil {
 		return nil, err
 	}
@@ -235,7 +235,7 @@ func (a *apiServer) DeleteProject(
 func (a *apiServer) MoveProject(
 	ctx context.Context, req *apiv1.MoveProjectRequest) (*apiv1.MoveProjectResponse,
 	error) {
-	w, err := a.GetWorkspaceFromID(req.DestinationWorkspaceId)
+	w, err := a.GetWorkspaceFromID(req.DestinationWorkspaceId, 0)
 	if err != nil {
 		return nil, err
 	}

--- a/master/internal/api_workspace.go
+++ b/master/internal/api_workspace.go
@@ -16,10 +16,10 @@ import (
 	"github.com/determined-ai/determined/proto/pkg/workspacev1"
 )
 
-func (a *apiServer) GetWorkspaceFromID(id int32, user_id int32) (*workspacev1.Workspace,
+func (a *apiServer) GetWorkspaceFromID(id int32, userID int32) (*workspacev1.Workspace,
 	error) {
 	w := &workspacev1.Workspace{}
-	switch err := a.m.db.QueryProto("get_workspace", w, id, user_id); err {
+	switch err := a.m.db.QueryProto("get_workspace", w, id, userID); err {
 	case db.ErrNotFound:
 		return nil, status.Errorf(
 			codes.NotFound, "workspace (%d) not found", id)

--- a/master/internal/api_workspace.go
+++ b/master/internal/api_workspace.go
@@ -16,9 +16,10 @@ import (
 	"github.com/determined-ai/determined/proto/pkg/workspacev1"
 )
 
-func (a *apiServer) GetWorkspaceFromID(id int32) (*workspacev1.Workspace, error) {
+func (a *apiServer) GetWorkspaceFromID(id int32, user_id int32) (*workspacev1.Workspace,
+	error) {
 	w := &workspacev1.Workspace{}
-	switch err := a.m.db.QueryProto("get_workspace", w, id); err {
+	switch err := a.m.db.QueryProto("get_workspace", w, id, user_id); err {
 	case db.ErrNotFound:
 		return nil, status.Errorf(
 			codes.NotFound, "workspace (%d) not found", id)
@@ -29,8 +30,13 @@ func (a *apiServer) GetWorkspaceFromID(id int32) (*workspacev1.Workspace, error)
 }
 
 func (a *apiServer) GetWorkspace(
-	_ context.Context, req *apiv1.GetWorkspaceRequest) (*apiv1.GetWorkspaceResponse, error) {
-	w, err := a.GetWorkspaceFromID(req.Id)
+	ctx context.Context, req *apiv1.GetWorkspaceRequest) (*apiv1.GetWorkspaceResponse, error) {
+	user, err := a.CurrentUser(ctx, &apiv1.CurrentUserRequest{})
+	if err != nil {
+		return nil, err
+	}
+
+	w, err := a.GetWorkspaceFromID(req.Id, user.User.Id)
 	return &apiv1.GetWorkspaceResponse{Workspace: w}, err
 }
 
@@ -89,12 +95,20 @@ func (a *apiServer) GetWorkspaceProjects(ctx context.Context,
 }
 
 func (a *apiServer) GetWorkspaces(
-	_ context.Context, req *apiv1.GetWorkspacesRequest) (*apiv1.GetWorkspacesResponse, error) {
-	resp := &apiv1.GetWorkspacesResponse{}
+	ctx context.Context, req *apiv1.GetWorkspacesRequest) (*apiv1.GetWorkspacesResponse, error) {
+	user, err := a.CurrentUser(ctx, &apiv1.CurrentUserRequest{})
+	if err != nil {
+		return nil, err
+	}
+
 	nameFilter := req.Name
 	archFilterExpr := ""
 	if req.Archived != nil {
 		archFilterExpr = strconv.FormatBool(req.Archived.Value)
+	}
+	pinFilterExpr := ""
+	if req.Pinned != nil {
+		pinFilterExpr = strconv.FormatBool(req.Pinned.Value)
 	}
 	userFilterExpr := strings.Join(req.Users, ",")
 	// Construct the ordering expression.
@@ -120,13 +134,17 @@ func (a *apiServer) GetWorkspaces(
 	default:
 		orderExpr = fmt.Sprintf("id %s", orderByMap[req.OrderBy])
 	}
-	err := a.m.db.QueryProtof(
+
+	resp := &apiv1.GetWorkspacesResponse{}
+	err = a.m.db.QueryProtof(
 		"get_workspaces",
 		[]interface{}{orderExpr},
 		&resp.Workspaces,
 		userFilterExpr,
 		nameFilter,
 		archFilterExpr,
+		pinFilterExpr,
+		user.User.Id,
 	)
 	if err != nil {
 		return nil, err
@@ -149,9 +167,14 @@ func (a *apiServer) PostWorkspace(
 }
 
 func (a *apiServer) PatchWorkspace(
-	_ context.Context, req *apiv1.PatchWorkspaceRequest) (*apiv1.PatchWorkspaceResponse, error) {
+	ctx context.Context, req *apiv1.PatchWorkspaceRequest) (*apiv1.PatchWorkspaceResponse, error) {
+	user, err := a.CurrentUser(ctx, &apiv1.CurrentUserRequest{})
+	if err != nil {
+		return nil, err
+	}
+
 	// Verify current workspace exists and can be edited.
-	currWorkspace, err := a.GetWorkspaceFromID(req.Id)
+	currWorkspace, err := a.GetWorkspaceFromID(req.Id, user.User.Id)
 	if err != nil {
 		return nil, err
 	}
@@ -245,4 +268,32 @@ func (a *apiServer) UnarchiveWorkspace(
 
 	return &apiv1.UnarchiveWorkspaceResponse{},
 		errors.Wrapf(err, "error unarchiving workspace (%d)", req.Id)
+}
+
+func (a *apiServer) PinWorkspace(
+	ctx context.Context, req *apiv1.PinWorkspaceRequest) (*apiv1.PinWorkspaceResponse, error) {
+	user, err := a.CurrentUser(ctx, &apiv1.CurrentUserRequest{})
+	if err != nil {
+		return nil, err
+	}
+
+	holder := &workspacev1.Workspace{}
+	err = a.m.db.QueryProto("pin_workspace", holder, req.Id, user.User.Id)
+
+	return &apiv1.PinWorkspaceResponse{},
+		errors.Wrapf(err, "error pinning workspace (%d)", req.Id)
+}
+
+func (a *apiServer) UnpinWorkspace(
+	ctx context.Context, req *apiv1.UnpinWorkspaceRequest) (*apiv1.UnpinWorkspaceResponse, error) {
+	user, err := a.CurrentUser(ctx, &apiv1.CurrentUserRequest{})
+	if err != nil {
+		return nil, err
+	}
+
+	holder := &workspacev1.Workspace{}
+	err = a.m.db.QueryProto("unpin_workspace", holder, req.Id, user.User.Id)
+
+	return &apiv1.UnpinWorkspaceResponse{},
+		errors.Wrapf(err, "error un-pinning workspace (%d)", req.Id)
 }

--- a/master/internal/api_workspace.go
+++ b/master/internal/api_workspace.go
@@ -201,7 +201,7 @@ func (a *apiServer) PatchWorkspace(
 
 	finalWorkspace := &workspacev1.Workspace{}
 	err = a.m.db.QueryProto("update_workspace",
-		finalWorkspace, currWorkspace.Id, currWorkspace.Name)
+		finalWorkspace, currWorkspace.Id, currWorkspace.Name, user.User.Id)
 
 	return &apiv1.PatchWorkspaceResponse{Workspace: finalWorkspace},
 		errors.Wrapf(err, "error updating workspace (%d) in database", currWorkspace.Id)

--- a/master/static/migrations/20220422101847_pin-workspaces.down.sql
+++ b/master/static/migrations/20220422101847_pin-workspaces.down.sql
@@ -1,0 +1,2 @@
+DROP INDEX ix_workspace_pins;
+DROP TABLE workspace_pins;

--- a/master/static/migrations/20220422101847_pin-workspaces.up.sql
+++ b/master/static/migrations/20220422101847_pin-workspaces.up.sql
@@ -1,0 +1,9 @@
+CREATE TABLE workspace_pins (
+  id SERIAL PRIMARY KEY,
+  workspace_id INT REFERENCES workspaces(id),
+  user_id INT REFERENCES users(id),
+  created_at TIMESTAMP with time zone NOT NULL DEFAULT NOW(),
+  UNIQUE (user_id, workspace_id)
+);
+
+CREATE INDEX ix_workspace_pins ON public.workspace_pins USING btree (workspace_id);

--- a/master/static/srv/delete_workspace.sql
+++ b/master/static/srv/delete_workspace.sql
@@ -1,5 +1,14 @@
+WITH w AS (
+  SELECT id
+  FROM workspaces
+  WHERE id = $1
+  AND NOT immutable
+  AND (user_id = $2 OR $3 IS TRUE)
+),
+pins AS (
+  DELETE FROM workspace_pins
+  WHERE workspace_id IN (SELECT id FROM w)
+)
 DELETE FROM workspaces
-WHERE id = $1
-AND NOT immutable
-AND (user_id = $2 OR $3 IS TRUE)
-RETURNING workspaces.id;
+WHERE id IN (SELECT id FROM w)
+RETURNING id;

--- a/master/static/srv/get_workspace.sql
+++ b/master/static/srv/get_workspace.sql
@@ -1,5 +1,8 @@
 SELECT w.id, w.name, w.archived, w.immutable, u.username,
-  (SELECT COUNT(*) FROM projects WHERE workspace_id = $1) AS num_projects
+  (SELECT COUNT(*) FROM projects WHERE workspace_id = $1) AS num_projects,
+  (SELECT COUNT(*) > 0 FROM workspace_pins
+    WHERE workspace_id = $1 AND user_id = $2
+  ) AS pinned
 FROM workspaces as w
   LEFT JOIN users as u ON u.id = w.user_id
 WHERE w.id = $1;

--- a/master/static/srv/get_workspaces.sql
+++ b/master/static/srv/get_workspaces.sql
@@ -1,8 +1,18 @@
+WITH wp AS (
+  SELECT id, workspace_id, created_at
+  FROM workspace_pins
+  WHERE user_id = $5
+)
 SELECT w.id, w.name, w.archived, w.immutable, u.username,
+(wp.id IS NOT NULL) AS pinned,
 (SELECT COUNT(*) FROM projects WHERE workspace_id = w.id) AS num_projects
+
 FROM workspaces as w
 LEFT JOIN users as u ON u.id = w.user_id
+LEFT JOIN wp ON wp.workspace_id = w.id
+
 WHERE ($1 = '' OR (u.username IN (SELECT unnest(string_to_array($1, ',')))))
 AND ($2 = '' OR w.name ILIKE $2)
 AND ($3 = '' OR w.archived = $3::BOOL)
-ORDER BY %s;
+AND ($4 = '' OR (wp.id IS NOT NULL) = $4::BOOL)
+ORDER BY %s, wp.created_at DESC;

--- a/master/static/srv/pin_workspace.sql
+++ b/master/static/srv/pin_workspace.sql
@@ -1,0 +1,3 @@
+INSERT INTO workspace_pins (workspace_id, user_id, created_at)
+VALUES ($1, $2, NOW())
+RETURNING id;

--- a/master/static/srv/unpin_workspace.sql
+++ b/master/static/srv/unpin_workspace.sql
@@ -1,0 +1,4 @@
+DELETE FROM workspace_pins
+WHERE workspace_id = $1
+AND user_id = $2
+RETURNING id;

--- a/master/static/srv/update_workspace.sql
+++ b/master/static/srv/update_workspace.sql
@@ -13,5 +13,8 @@ p AS (
   WHERE workspace_id = $1
 )
 SELECT w.id, w.name, w.archived, w.immutable,
-  u.username, p.num_projects
+  u.username, p.num_projects,
+  (SELECT COUNT(*) > 0 FROM workspace_pins
+    WHERE workspace_id = $1 AND user_id = $3
+  ) AS pinned
 FROM w, u, p;

--- a/proto/src/determined/api/v1/api.proto
+++ b/proto/src/determined/api/v1/api.proto
@@ -1353,6 +1353,24 @@ service Determined {
       tags: "Workspaces"
     };
   }
+  // Pin a workspace.
+  rpc PinWorkspace(PinWorkspaceRequest) returns (PinWorkspaceResponse) {
+    option (google.api.http) = {
+      post: "/api/v1/workspaces/{id}/pin"
+    };
+    option (grpc.gateway.protoc_gen_swagger.options.openapiv2_operation) = {
+      tags: "Workspaces"
+    };
+  }
+  // Unpin a workspace.
+  rpc UnpinWorkspace(UnpinWorkspaceRequest) returns (UnpinWorkspaceResponse) {
+    option (google.api.http) = {
+      post: "/api/v1/workspaces/{id}/unpin"
+    };
+    option (grpc.gateway.protoc_gen_swagger.options.openapiv2_operation) = {
+      tags: "Workspaces"
+    };
+  }
 
   // Get the requested project.
   rpc GetProject(GetProjectRequest) returns (GetProjectResponse) {

--- a/proto/src/determined/api/v1/workspace.proto
+++ b/proto/src/determined/api/v1/workspace.proto
@@ -114,6 +114,8 @@ message GetWorkspacesRequest {
   google.protobuf.BoolValue archived = 6;
   // Limit the workspaces to those from particular users.
   repeated string users = 7;
+  // Limit the workspaces to those with pinned status by the current user.
+  google.protobuf.BoolValue pinned = 8;
 }
 
 // Response to GetWorkspacesRequest.
@@ -208,3 +210,29 @@ message UnarchiveWorkspaceRequest {
 
 // Response to UnarchiveWorkspaceRequest.
 message UnarchiveWorkspaceResponse {}
+
+// Request for pinning a workspace.
+message PinWorkspaceRequest {
+  option (grpc.gateway.protoc_gen_swagger.options.openapiv2_schema) = {
+    json_schema: { required: [ "id" ] }
+  };
+
+  // The id of the workspace.
+  int32 id = 1;
+}
+
+// Response to PinWorkspaceRequest.
+message PinWorkspaceResponse {}
+
+// Request for un-pinning a workspace.
+message UnpinWorkspaceRequest {
+  option (grpc.gateway.protoc_gen_swagger.options.openapiv2_schema) = {
+    json_schema: { required: [ "id" ] }
+  };
+
+  // The id of the workspace.
+  int32 id = 1;
+}
+
+// Response to UnpinWorkspaceRequest.
+message UnpinWorkspaceResponse {}

--- a/proto/src/determined/workspace/v1/workspace.proto
+++ b/proto/src/determined/workspace/v1/workspace.proto
@@ -16,6 +16,7 @@ message Workspace {
         "immutable",
         "name",
         "num_projects",
+        "pinned",
         "username"
       ]
     }
@@ -34,6 +35,8 @@ message Workspace {
   bool immutable = 5;
   // Number of projects associated with this workspace.
   int32 num_projects = 6;
+  // Pin status of this workspace for the current user.
+  bool pinned = 7;
 }
 
 // PatchWorkspace is a partial update to a workspace with all optional fields.

--- a/webui/react/src/services/api-ts-sdk/api.ts
+++ b/webui/react/src/services/api-ts-sdk/api.ts
@@ -4322,6 +4322,14 @@ export interface V1PauseExperimentResponse {
 }
 
 /**
+ * Response to PinWorkspaceRequest.
+ * @export
+ * @interface V1PinWorkspaceResponse
+ */
+export interface V1PinWorkspaceResponse {
+}
+
+/**
  * Request for updating a checkpoints metadata.
  * @export
  * @interface V1PostCheckpointMetadataRequest
@@ -6446,6 +6454,14 @@ export interface V1UnarchiveWorkspaceResponse {
 }
 
 /**
+ * Response to UnpinWorkspaceRequest.
+ * @export
+ * @interface V1UnpinWorkspaceResponse
+ */
+export interface V1UnpinWorkspaceResponse {
+}
+
+/**
  * Request to update the job queue.
  * @export
  * @interface V1UpdateJobQueueRequest
@@ -6593,6 +6609,12 @@ export interface V1Workspace {
      * @memberof V1Workspace
      */
     numProjects: number;
+    /**
+     * Pin status of this workspace for the current user.
+     * @type {boolean}
+     * @memberof V1Workspace
+     */
+    pinned: boolean;
 }
 
 
@@ -19682,10 +19704,11 @@ export const WorkspacesApiFetchParamCreator = function (configuration?: Configur
          * @param {string} [name] Limit the workspaces to those matching the name.
          * @param {boolean} [archived] Limit the workspaces to those with an archived status.
          * @param {Array<string>} [users] Limit the workspaces to those from particular users.
+         * @param {boolean} [pinned] Limit the workspaces to those with pinned status by the current user.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        getWorkspaces(sortBy?: 'SORT_BY_UNSPECIFIED' | 'SORT_BY_ID' | 'SORT_BY_NAME', orderBy?: 'ORDER_BY_UNSPECIFIED' | 'ORDER_BY_ASC' | 'ORDER_BY_DESC', offset?: number, limit?: number, name?: string, archived?: boolean, users?: Array<string>, options: any = {}): FetchArgs {
+        getWorkspaces(sortBy?: 'SORT_BY_UNSPECIFIED' | 'SORT_BY_ID' | 'SORT_BY_NAME', orderBy?: 'ORDER_BY_UNSPECIFIED' | 'ORDER_BY_ASC' | 'ORDER_BY_DESC', offset?: number, limit?: number, name?: string, archived?: boolean, users?: Array<string>, pinned?: boolean, options: any = {}): FetchArgs {
             const localVarPath = `/api/v1/workspaces`;
             const localVarUrlObj = url.parse(localVarPath, true);
             const localVarRequestOptions = Object.assign({ method: 'GET' }, options);
@@ -19726,6 +19749,10 @@ export const WorkspacesApiFetchParamCreator = function (configuration?: Configur
 
             if (users) {
                 localVarQueryParameter['users'] = users;
+            }
+
+            if (pinned !== undefined) {
+                localVarQueryParameter['pinned'] = pinned;
             }
 
             localVarUrlObj.query = Object.assign({}, localVarUrlObj.query, localVarQueryParameter, options.query);
@@ -19786,6 +19813,43 @@ export const WorkspacesApiFetchParamCreator = function (configuration?: Configur
         },
         /**
          * 
+         * @summary Pin a workspace.
+         * @param {number} id The id of the workspace.
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        pinWorkspace(id: number, options: any = {}): FetchArgs {
+            // verify required parameter 'id' is not null or undefined
+            if (id === null || id === undefined) {
+                throw new RequiredError('id','Required parameter id was null or undefined when calling pinWorkspace.');
+            }
+            const localVarPath = `/api/v1/workspaces/{id}/pin`
+                .replace(`{${"id"}}`, encodeURIComponent(String(id)));
+            const localVarUrlObj = url.parse(localVarPath, true);
+            const localVarRequestOptions = Object.assign({ method: 'POST' }, options);
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            // authentication BearerToken required
+            if (configuration && configuration.apiKey) {
+                const localVarApiKeyValue = typeof configuration.apiKey === 'function'
+					? configuration.apiKey("Authorization")
+					: configuration.apiKey;
+                localVarHeaderParameter["Authorization"] = localVarApiKeyValue;
+            }
+
+            localVarUrlObj.query = Object.assign({}, localVarUrlObj.query, localVarQueryParameter, options.query);
+            // fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
+            delete localVarUrlObj.search;
+            localVarRequestOptions.headers = Object.assign({}, localVarHeaderParameter, options.headers);
+
+            return {
+                url: url.format(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         * 
          * @summary Create a workspace.
          * @param {V1PostWorkspaceRequest} body 
          * @param {*} [options] Override http request option.
@@ -19837,6 +19901,43 @@ export const WorkspacesApiFetchParamCreator = function (configuration?: Configur
                 throw new RequiredError('id','Required parameter id was null or undefined when calling unarchiveWorkspace.');
             }
             const localVarPath = `/api/v1/workspaces/{id}/unarchive`
+                .replace(`{${"id"}}`, encodeURIComponent(String(id)));
+            const localVarUrlObj = url.parse(localVarPath, true);
+            const localVarRequestOptions = Object.assign({ method: 'POST' }, options);
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            // authentication BearerToken required
+            if (configuration && configuration.apiKey) {
+                const localVarApiKeyValue = typeof configuration.apiKey === 'function'
+					? configuration.apiKey("Authorization")
+					: configuration.apiKey;
+                localVarHeaderParameter["Authorization"] = localVarApiKeyValue;
+            }
+
+            localVarUrlObj.query = Object.assign({}, localVarUrlObj.query, localVarQueryParameter, options.query);
+            // fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
+            delete localVarUrlObj.search;
+            localVarRequestOptions.headers = Object.assign({}, localVarHeaderParameter, options.headers);
+
+            return {
+                url: url.format(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         * 
+         * @summary Unpin a workspace.
+         * @param {number} id The id of the workspace.
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        unpinWorkspace(id: number, options: any = {}): FetchArgs {
+            // verify required parameter 'id' is not null or undefined
+            if (id === null || id === undefined) {
+                throw new RequiredError('id','Required parameter id was null or undefined when calling unpinWorkspace.');
+            }
+            const localVarPath = `/api/v1/workspaces/{id}/unpin`
                 .replace(`{${"id"}}`, encodeURIComponent(String(id)));
             const localVarUrlObj = url.parse(localVarPath, true);
             const localVarRequestOptions = Object.assign({ method: 'POST' }, options);
@@ -19963,11 +20064,12 @@ export const WorkspacesApiFp = function(configuration?: Configuration) {
          * @param {string} [name] Limit the workspaces to those matching the name.
          * @param {boolean} [archived] Limit the workspaces to those with an archived status.
          * @param {Array<string>} [users] Limit the workspaces to those from particular users.
+         * @param {boolean} [pinned] Limit the workspaces to those with pinned status by the current user.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        getWorkspaces(sortBy?: 'SORT_BY_UNSPECIFIED' | 'SORT_BY_ID' | 'SORT_BY_NAME', orderBy?: 'ORDER_BY_UNSPECIFIED' | 'ORDER_BY_ASC' | 'ORDER_BY_DESC', offset?: number, limit?: number, name?: string, archived?: boolean, users?: Array<string>, options?: any): (fetch?: FetchAPI, basePath?: string) => Promise<V1GetWorkspacesResponse> {
-            const localVarFetchArgs = WorkspacesApiFetchParamCreator(configuration).getWorkspaces(sortBy, orderBy, offset, limit, name, archived, users, options);
+        getWorkspaces(sortBy?: 'SORT_BY_UNSPECIFIED' | 'SORT_BY_ID' | 'SORT_BY_NAME', orderBy?: 'ORDER_BY_UNSPECIFIED' | 'ORDER_BY_ASC' | 'ORDER_BY_DESC', offset?: number, limit?: number, name?: string, archived?: boolean, users?: Array<string>, pinned?: boolean, options?: any): (fetch?: FetchAPI, basePath?: string) => Promise<V1GetWorkspacesResponse> {
+            const localVarFetchArgs = WorkspacesApiFetchParamCreator(configuration).getWorkspaces(sortBy, orderBy, offset, limit, name, archived, users, pinned, options);
             return (fetch: FetchAPI = portableFetch, basePath: string = BASE_PATH) => {
                 return fetch(basePath + localVarFetchArgs.url, localVarFetchArgs.options).then((response) => {
                     if (response.status >= 200 && response.status < 300) {
@@ -19988,6 +20090,25 @@ export const WorkspacesApiFp = function(configuration?: Configuration) {
          */
         patchWorkspace(id: number, body: V1PatchWorkspace, options?: any): (fetch?: FetchAPI, basePath?: string) => Promise<V1PatchWorkspaceResponse> {
             const localVarFetchArgs = WorkspacesApiFetchParamCreator(configuration).patchWorkspace(id, body, options);
+            return (fetch: FetchAPI = portableFetch, basePath: string = BASE_PATH) => {
+                return fetch(basePath + localVarFetchArgs.url, localVarFetchArgs.options).then((response) => {
+                    if (response.status >= 200 && response.status < 300) {
+                        return response.json();
+                    } else {
+                        throw response;
+                    }
+                });
+            };
+        },
+        /**
+         * 
+         * @summary Pin a workspace.
+         * @param {number} id The id of the workspace.
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        pinWorkspace(id: number, options?: any): (fetch?: FetchAPI, basePath?: string) => Promise<V1PinWorkspaceResponse> {
+            const localVarFetchArgs = WorkspacesApiFetchParamCreator(configuration).pinWorkspace(id, options);
             return (fetch: FetchAPI = portableFetch, basePath: string = BASE_PATH) => {
                 return fetch(basePath + localVarFetchArgs.url, localVarFetchArgs.options).then((response) => {
                     if (response.status >= 200 && response.status < 300) {
@@ -20026,6 +20147,25 @@ export const WorkspacesApiFp = function(configuration?: Configuration) {
          */
         unarchiveWorkspace(id: number, options?: any): (fetch?: FetchAPI, basePath?: string) => Promise<V1UnarchiveWorkspaceResponse> {
             const localVarFetchArgs = WorkspacesApiFetchParamCreator(configuration).unarchiveWorkspace(id, options);
+            return (fetch: FetchAPI = portableFetch, basePath: string = BASE_PATH) => {
+                return fetch(basePath + localVarFetchArgs.url, localVarFetchArgs.options).then((response) => {
+                    if (response.status >= 200 && response.status < 300) {
+                        return response.json();
+                    } else {
+                        throw response;
+                    }
+                });
+            };
+        },
+        /**
+         * 
+         * @summary Unpin a workspace.
+         * @param {number} id The id of the workspace.
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        unpinWorkspace(id: number, options?: any): (fetch?: FetchAPI, basePath?: string) => Promise<V1UnpinWorkspaceResponse> {
+            const localVarFetchArgs = WorkspacesApiFetchParamCreator(configuration).unpinWorkspace(id, options);
             return (fetch: FetchAPI = portableFetch, basePath: string = BASE_PATH) => {
                 return fetch(basePath + localVarFetchArgs.url, localVarFetchArgs.options).then((response) => {
                     if (response.status >= 200 && response.status < 300) {
@@ -20102,11 +20242,12 @@ export const WorkspacesApiFactory = function (configuration?: Configuration, fet
          * @param {string} [name] Limit the workspaces to those matching the name.
          * @param {boolean} [archived] Limit the workspaces to those with an archived status.
          * @param {Array<string>} [users] Limit the workspaces to those from particular users.
+         * @param {boolean} [pinned] Limit the workspaces to those with pinned status by the current user.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        getWorkspaces(sortBy?: 'SORT_BY_UNSPECIFIED' | 'SORT_BY_ID' | 'SORT_BY_NAME', orderBy?: 'ORDER_BY_UNSPECIFIED' | 'ORDER_BY_ASC' | 'ORDER_BY_DESC', offset?: number, limit?: number, name?: string, archived?: boolean, users?: Array<string>, options?: any) {
-            return WorkspacesApiFp(configuration).getWorkspaces(sortBy, orderBy, offset, limit, name, archived, users, options)(fetch, basePath);
+        getWorkspaces(sortBy?: 'SORT_BY_UNSPECIFIED' | 'SORT_BY_ID' | 'SORT_BY_NAME', orderBy?: 'ORDER_BY_UNSPECIFIED' | 'ORDER_BY_ASC' | 'ORDER_BY_DESC', offset?: number, limit?: number, name?: string, archived?: boolean, users?: Array<string>, pinned?: boolean, options?: any) {
+            return WorkspacesApiFp(configuration).getWorkspaces(sortBy, orderBy, offset, limit, name, archived, users, pinned, options)(fetch, basePath);
         },
         /**
          * 
@@ -20118,6 +20259,16 @@ export const WorkspacesApiFactory = function (configuration?: Configuration, fet
          */
         patchWorkspace(id: number, body: V1PatchWorkspace, options?: any) {
             return WorkspacesApiFp(configuration).patchWorkspace(id, body, options)(fetch, basePath);
+        },
+        /**
+         * 
+         * @summary Pin a workspace.
+         * @param {number} id The id of the workspace.
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        pinWorkspace(id: number, options?: any) {
+            return WorkspacesApiFp(configuration).pinWorkspace(id, options)(fetch, basePath);
         },
         /**
          * 
@@ -20138,6 +20289,16 @@ export const WorkspacesApiFactory = function (configuration?: Configuration, fet
          */
         unarchiveWorkspace(id: number, options?: any) {
             return WorkspacesApiFp(configuration).unarchiveWorkspace(id, options)(fetch, basePath);
+        },
+        /**
+         * 
+         * @summary Unpin a workspace.
+         * @param {number} id The id of the workspace.
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        unpinWorkspace(id: number, options?: any) {
+            return WorkspacesApiFp(configuration).unpinWorkspace(id, options)(fetch, basePath);
         },
     };
 };
@@ -20214,12 +20375,13 @@ export class WorkspacesApi extends BaseAPI {
      * @param {string} [name] Limit the workspaces to those matching the name.
      * @param {boolean} [archived] Limit the workspaces to those with an archived status.
      * @param {Array<string>} [users] Limit the workspaces to those from particular users.
+     * @param {boolean} [pinned] Limit the workspaces to those with pinned status by the current user.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof WorkspacesApi
      */
-    public getWorkspaces(sortBy?: 'SORT_BY_UNSPECIFIED' | 'SORT_BY_ID' | 'SORT_BY_NAME', orderBy?: 'ORDER_BY_UNSPECIFIED' | 'ORDER_BY_ASC' | 'ORDER_BY_DESC', offset?: number, limit?: number, name?: string, archived?: boolean, users?: Array<string>, options?: any) {
-        return WorkspacesApiFp(this.configuration).getWorkspaces(sortBy, orderBy, offset, limit, name, archived, users, options)(this.fetch, this.basePath);
+    public getWorkspaces(sortBy?: 'SORT_BY_UNSPECIFIED' | 'SORT_BY_ID' | 'SORT_BY_NAME', orderBy?: 'ORDER_BY_UNSPECIFIED' | 'ORDER_BY_ASC' | 'ORDER_BY_DESC', offset?: number, limit?: number, name?: string, archived?: boolean, users?: Array<string>, pinned?: boolean, options?: any) {
+        return WorkspacesApiFp(this.configuration).getWorkspaces(sortBy, orderBy, offset, limit, name, archived, users, pinned, options)(this.fetch, this.basePath);
     }
 
     /**
@@ -20233,6 +20395,18 @@ export class WorkspacesApi extends BaseAPI {
      */
     public patchWorkspace(id: number, body: V1PatchWorkspace, options?: any) {
         return WorkspacesApiFp(this.configuration).patchWorkspace(id, body, options)(this.fetch, this.basePath);
+    }
+
+    /**
+     * 
+     * @summary Pin a workspace.
+     * @param {number} id The id of the workspace.
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof WorkspacesApi
+     */
+    public pinWorkspace(id: number, options?: any) {
+        return WorkspacesApiFp(this.configuration).pinWorkspace(id, options)(this.fetch, this.basePath);
     }
 
     /**
@@ -20257,6 +20431,18 @@ export class WorkspacesApi extends BaseAPI {
      */
     public unarchiveWorkspace(id: number, options?: any) {
         return WorkspacesApiFp(this.configuration).unarchiveWorkspace(id, options)(this.fetch, this.basePath);
+    }
+
+    /**
+     * 
+     * @summary Unpin a workspace.
+     * @param {number} id The id of the workspace.
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof WorkspacesApi
+     */
+    public unpinWorkspace(id: number, options?: any) {
+        return WorkspacesApiFp(this.configuration).unpinWorkspace(id, options)(this.fetch, this.basePath);
     }
 
 }

--- a/webui/react/src/services/apiConfig.ts
+++ b/webui/react/src/services/apiConfig.ts
@@ -638,6 +638,7 @@ export const getWorkspaces: Service.DetApi<
       params.name,
       params.archived,
       params.users,
+      params.pinned,
       options,
     );
   },

--- a/webui/react/src/services/types.ts
+++ b/webui/react/src/services/types.ts
@@ -274,6 +274,7 @@ export interface GetWorkspacesParams extends PaginationParams {
   name?: string;
   sortBy?: 'SORT_BY_UNSPECIFIED' | 'SORT_BY_ID' | 'SORT_BY_NAME';
   users?: string[];
+  pinned?: boolean;
 }
 
 export interface GetWorkspaceParams {

--- a/webui/react/src/services/types.ts
+++ b/webui/react/src/services/types.ts
@@ -272,9 +272,9 @@ export interface AddProjectNoteParams {
 export interface GetWorkspacesParams extends PaginationParams {
   archived?: boolean;
   name?: string;
+  pinned?: boolean;
   sortBy?: 'SORT_BY_UNSPECIFIED' | 'SORT_BY_ID' | 'SORT_BY_NAME';
   users?: string[];
-  pinned?: boolean;
 }
 
 export interface GetWorkspaceParams {


### PR DESCRIPTION
## Description

- A user can pin a workspace to signify that it is important / current to their work.
- API supports pinning, unpinning, GetWorkspaces optional filtering by pinned/unpinned
- Returned Workspace object (GetWorkspace, GetWorkspaces, PatchWorkspace) include `"pinned": bool` field
- Pins contain a `created_at` column which could be used for sorting, but TODO

## Testing

- Includes e2e_tests for pinning, checking len(pinned) = 1, unpinning, then checking len(pinned) = 0.
- Should test GetWorkspace and GetWorkspaces

## Checklist

- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.