### PR TITLE
fix: handle infinite metrics in searcher snapshots [DET-7122]

### DIFF
--- a/master/pkg/searcher/asha.go
+++ b/master/pkg/searcher/asha.go
@@ -33,8 +33,8 @@ type (
 	}
 
 	trialMetric struct {
-		RequestID model.RequestID `json:"request_id"`
-		Metric    float64         `json:"metric"`
+		RequestID model.RequestID       `json:"request_id"`
+		Metric    model.ExtendedFloat64 `json:"metric"`
 		// fields below used by asha.go.
 		Promoted bool `json:"promoted"`
 	}
@@ -98,7 +98,7 @@ func (r *rung) promotionsAsync(
 	// Insert the new trial result in the appropriate place in the sorted list.
 	insertIndex := sort.Search(
 		len(r.Metrics),
-		func(i int) bool { return r.Metrics[i].Metric > metric },
+		func(i int) bool { return float64(r.Metrics[i].Metric) > metric },
 	)
 	promoteNow := insertIndex < numPromote
 
@@ -106,7 +106,7 @@ func (r *rung) promotionsAsync(
 	copy(r.Metrics[insertIndex+1:], r.Metrics[insertIndex:])
 	r.Metrics[insertIndex] = trialMetric{
 		RequestID: requestID,
-		Metric:    metric,
+		Metric:    model.ExtendedFloat64(metric),
 		Promoted:  promoteNow,
 	}
 
@@ -199,7 +199,7 @@ func (s *asyncHalvingSearch) promoteAsync(
 		rung.Metrics = append(rung.Metrics,
 			trialMetric{
 				RequestID: requestID,
-				Metric:    metric,
+				Metric:    model.ExtendedFloat64(metric),
 			},
 		)
 

--- a/master/pkg/searcher/asha_stopping.go
+++ b/master/pkg/searcher/asha_stopping.go
@@ -71,7 +71,7 @@ func (r *rung) continueTraining(requestID model.RequestID, metric float64, divis
 	// Insert the new trial result in the appropriate place in the sorted list.
 	insertIndex := sort.Search(
 		len(r.Metrics),
-		func(i int) bool { return r.Metrics[i].Metric >= metric },
+		func(i int) bool { return float64(r.Metrics[i].Metric) >= metric },
 	)
 	// We will continue training if trial ranked in top 1/divisor for the rung or
 	// if there are fewere than divisor trials in the rung.
@@ -81,7 +81,7 @@ func (r *rung) continueTraining(requestID model.RequestID, metric float64, divis
 	copy(r.Metrics[insertIndex+1:], r.Metrics[insertIndex:])
 	r.Metrics[insertIndex] = trialMetric{
 		RequestID: requestID,
-		Metric:    metric,
+		Metric:    model.ExtendedFloat64(metric),
 		Promoted:  promoteNow,
 	}
 
@@ -158,7 +158,7 @@ func (s *asyncHalvingStoppingSearch) promoteAsync(
 		rung.Metrics = append(rung.Metrics,
 			trialMetric{
 				RequestID: requestID,
-				Metric:    metric,
+				Metric:    model.ExtendedFloat64(metric),
 			},
 		)
 


### PR DESCRIPTION
## Description

This is simply applying the recently added "float extended with JSON
handling for infinite values" type to another place (and moving it to a
public place, and adding unmarshalling support, where it only had
marshalling before). See f915a695 for its introduction and other
context.

Possibly we should look into redoing marshalling entirely so we can add
support for infinities (and anything else that might require special
handling in the future) in just the one place rather than peppering this
type and type conversions everywhere. But that's going to be a whole
other thing.

## Test Plan

- [x] run an experiment with infinite metrics, see that the error messages go away and the experiment can be restored
