### PR TITLE
test: add option to disable `compare_stats`.

### DIFF
--- a/e2e_tests/tests/conftest.py
+++ b/e2e_tests/tests/conftest.py
@@ -79,6 +79,7 @@ def pytest_addoption(parser: Parser) -> None:
         help="Docker compose project name",
     )
     parser.addoption("--follow-local-logs", action="store_true", help="Follow local docker logs")
+    parser.addoption("--no-compare-stats", action="store_true", help="Disable usage stats check")
 
 
 @pytest.fixture(scope="session", autouse=True)
@@ -98,6 +99,7 @@ def cluster_log_manager(request: SubRequest) -> Iterator[Optional[ClusterLogMana
     det_version = request.config.getoption("--det-version")
     follow_local_logs = request.config.getoption("--follow-local-logs")
     compose_file = request.config.getoption("--compose-file")
+    compare_stats_enabled = not request.config.getoption("--no-compare-stats")
 
     config.MASTER_SCHEME = master_scheme
     config.MASTER_IP = master_host
@@ -117,7 +119,8 @@ def cluster_log_manager(request: SubRequest) -> Iterator[Optional[ClusterLogMana
         # Yield `None` so that pytest handles the no log manager case correctly.
         yield None
 
-    compare_stats()
+    if compare_stats_enabled:
+        compare_stats()
 
 
 def pytest_itemcollected(item: Any) -> None:


### PR DESCRIPTION
## Description

- when running [failing] tests locally, extra stack traces from `compare_stats` add unnecessary logs. add an option to disable them.

## Test Plan

`pytest --no-compare-stats` skips stats comparison.

## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
