### PR TITLE
feat: save metadata pre-upload

### DIFF
--- a/e2e_tests/tests/fixtures/mnist_pytorch/adaptive_short.yaml
+++ b/e2e_tests/tests/fixtures/mnist_pytorch/adaptive_short.yaml
@@ -40,3 +40,6 @@ max_restarts: 0
 bind_mounts:
   - host_path: /tmp
     container_path: /tmp/work_dir
+  - host_path: /tmp/determined-cp
+    container_path: /tmp/determined-cp
+

--- a/harness/determined/common/experimental/checkpoint/_checkpoint.py
+++ b/harness/determined/common/experimental/checkpoint/_checkpoint.py
@@ -156,12 +156,6 @@ class Checkpoint(object):
 
                 manager.download(self.uuid, str(local_ckpt_dir))
 
-        # XXX: this used to be the only place we write metadata but now that we've fixed our
-        # checkpoint protobuf and now that we are releasing a breaking change to the Checkpoint
-        # export api, we need to start writing a different format (the user-defined metadata only),
-        # and we need to start writing it at upload time, not download time.
-        self.write_metadata_file(str(local_ckpt_dir.joinpath("metadata.json")))
-
         return str(local_ckpt_dir)
 
     def write_metadata_file(self, path: str) -> None:
@@ -208,8 +202,8 @@ class Checkpoint(object):
 
            Please combine Checkpoint.download() with one of the following instead:
              - ``det.pytorch.load_trial_from_checkpoint()``
-             - ``det.keras.load_trial_from_checkpoint()``
-             - ``det.estimator.load_trial_from_checkpoint()``
+             - ``det.keras.load_model_from_checkpoint()``
+             - ``det.estimator.load_estimator_from_checkpoint_path()``
         """
         warnings.warn(
             "Checkpoint.load() has been deprecated and will be removed in a future version.\n"

--- a/harness/determined/common/storage/azure.py
+++ b/harness/determined/common/storage/azure.py
@@ -34,6 +34,14 @@ class AzureStorageManager(storage.CloudStorageManager):
         self.container = container if not container.endswith("/") else container[:-1]
 
     @util.preserve_random_state
+    def upload_file(self, src: Union[str, os.PathLike], dst: str, filename: str) -> None:
+        src = os.path.join(src, filename)
+        logging.info(f"Uploading to Azuer Blob Storage: {dst}/{filename}")
+        container_blob = posixpath.join(self.container, dst, filename)
+        blob_dir, blob_base = posixpath.split(container_blob)
+        self.client.put(blob_dir, blob_base, src)
+
+    @util.preserve_random_state
     def upload(self, src: Union[str, os.PathLike], dst: str) -> None:
         src = os.fspath(src)
         logging.info(f"Uploading to Azure Blob Storage: {dst}")

--- a/harness/determined/common/storage/base.py
+++ b/harness/determined/common/storage/base.py
@@ -87,6 +87,10 @@ class StorageManager(metaclass=abc.ABCMeta):
         pass
 
     @abc.abstractmethod
+    def upload_file(self, src: Union[str, os.PathLike], dst: str, filename: str) -> None:
+        pass
+
+    @abc.abstractmethod
     def download(self, src: str, dst: Union[str, os.PathLike]) -> None:
         pass
 

--- a/harness/determined/common/storage/hdfs.py
+++ b/harness/determined/common/storage/hdfs.py
@@ -29,6 +29,12 @@ class HDFSStorageManager(storage.CloudStorageManager):
         self.client = InsecureClient(self.hdfs_url, root=self.hdfs_path, user=self.user)
 
     @util.preserve_random_state
+    def upload_file(self, src: Union[str, os.PathLike], dst: str, filename: str) -> None:
+        src = os.path.join(src, filename)
+        logging.info(f"Uploading to HDFS: {dst}/{filename}")
+        self.client.upload(f"{dst}/{filename}", src)
+
+    @util.preserve_random_state
     def upload(self, src: Union[str, os.PathLike], dst: str) -> None:
         src = os.fspath(src)
         logging.info(f"Uploading to HDFS: {dst}")

--- a/harness/determined/common/storage/s3.py
+++ b/harness/determined/common/storage/s3.py
@@ -71,10 +71,17 @@ class S3StorageManager(storage.CloudStorageManager):
         return os.path.join(self.prefix, storage_id)
 
     @util.preserve_random_state
+    def upload_file(self, src: Union[str, os.PathLike], dst: str, filename: str) -> None:
+        src = os.path.join(src, filename)
+        prefix = self.get_storage_prefix(dst)
+        logging.info(f"Uploading {filename} to s3://{prefix}/{filename}")
+        self.bucket.upload_file(src, f"{prefix}/{filename}")
+
+    @util.preserve_random_state
     def upload(self, src: Union[str, os.PathLike], dst: str) -> None:
         src = os.fspath(src)
         prefix = self.get_storage_prefix(dst)
-        logging.info(f"Uploading to s3: {prefix}/{dst}")
+        logging.info(f"Uploading to s3: {prefix}")
         for rel_path in sorted(self._list_directory(src)):
             key_name = f"{prefix}/{rel_path}"
             logging.debug(f"Uploading {rel_path} to s3://{self.bucket_name}/{key_name}")

--- a/harness/determined/common/storage/shared.py
+++ b/harness/determined/common/storage/shared.py
@@ -89,6 +89,13 @@ class SharedFSStorageManager(StorageManager):
         src = os.fspath(src)
         shutil.copytree(src, os.path.join(self._base_path, dst))
 
+    def upload_file(self, src: Union[str, os.PathLike], dst: str, filename: str) -> None:
+        src = os.path.join(src, filename)
+        dst = os.path.join(self._base_path, dst)
+        os.makedirs(dst, exist_ok=True)
+        dst = os.path.join(dst, filename)
+        shutil.copyfile(src, dst)
+
     def download(self, src: str, dst: Union[str, os.PathLike]) -> None:
         dst = os.fspath(dst)
         try:

--- a/harness/determined/core/_checkpoint.py
+++ b/harness/determined/core/_checkpoint.py
@@ -163,7 +163,7 @@ class CheckpointContext:
         with self._storage_manager.store_path(storage_id) as path:
             yield path, storage_id
             resources = self._storage_manager._list_directory(path)
-            self._write_metadata_file(path, metadata)
+            self._write_metadata_file(os.fspath(path), metadata)
 
         self._report_checkpoint(storage_id, resources, metadata)
 


### PR DESCRIPTION
## Description

The goal here was to have checkpoint storage be the authoritative record for the checkpoint, the DB serving merely as an index that we could potentially use for search.

When the user changes the checkpoint metadata we would push the changes to checkpoint storage. I hit a wall right there: when the checkpoint storage is shared_fs `metadata.json` is typically not writable for the user running the client. (It is readable which is why download works). See the test failure.

```
        checkpoint = top_k[0]
>       checkpoint.add_metadata({"testing": "metadata"})

tests/experiment/test_core.py:297: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
/tmp/venv/lib/python3.7/site-packages/determined/common/experimental/checkpoint/_checkpoint.py:229: in add_metadata
    self._upload_metadata()
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = Checkpoint(uuid=d0ad4362-3b9c-4490-8dfe-adbacd9cf0b7, task_id=9.f532caea-8f33-4bb1-a242-e5a0d87b7e01, trial_id=8)

    def _upload_metadata(self) -> None:
        if self.training is None:
            raise NotImplementedError("Non-training checkpoints cannot be uploaded")
        checkpoint_storage = self.training.experiment_config["checkpoint_storage"]
        storage_type = checkpoint_storage["type"]
        if storage_type == "shared_fs":
            ckpt_dir = self._find_shared_fs_path(checkpoint_storage)
>           with open(ckpt_dir.joinpath("metadata.json"), "w") as dest:
E           PermissionError: [Errno 13] Permission denied: '/tmp/determined-cp/d0ad4362-3b9c-4490-8dfe-adbacd9cf0b7/metadata.json'

/tmp/venv/lib/python3.7/site-packages/determined/common/experimental/checkpoint/_checkpoint.py:281: PermissionError
```

## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions about this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
