### PR TITLE
7121 rewrite ndjson streamer

### DIFF
--- a/webui/react/src/components/LogViewer/LogViewer.test.tsx
+++ b/webui/react/src/components/LogViewer/LogViewer.test.tsx
@@ -75,7 +75,7 @@ const setup = (props: src.Props) => render(<src.default {...props} />);
 /**
  * canceler -        AbortController to manually stop ongoing API calls.
  * logsReference -   Allows tests to pass in an array to reflect the current state of loaded logs.
- * skipStreaming -   Disables the streaming portion of the mocked `consumeStream` function.
+ * skipStreaming -   Disables the streaming portion of the mocked `readStream` function.
  * streamingRounds - How many rounds of stream chunks to simulate.
  */
 const mockOnFetch = (mockOptions: {
@@ -135,7 +135,7 @@ jest.mock('hooks/useGetCharMeasureInContainer', () => ({
 jest.mock('services/utils', () => ({
   __esModule: true,
   ...jest.requireActual('services/utils'),
-  consumeStream: ({ options }: FetchArgs, onEvent: (event: unknown) => void): void => {
+  readStream: ({ options }: FetchArgs, onEvent: (event: unknown) => void): void => {
     // Default mocking options.
     const existingLogs = options.existingLogs ?? [];
     const skipStreaming = options.skipStreaming ?? true;

--- a/webui/react/src/components/LogViewer/LogViewer.tsx
+++ b/webui/react/src/components/LogViewer/LogViewer.tsx
@@ -13,7 +13,7 @@ import Section from 'components/Section';
 import useGetCharMeasureInContainer from 'hooks/useGetCharMeasureInContainer';
 import useResize from 'hooks/useResize';
 import { FetchArgs } from 'services/api-ts-sdk';
-import { consumeStream } from 'services/utils';
+import { readStream } from 'services/utils';
 import { Log, LogLevel, RecordKey } from 'types';
 import { clone } from 'utils/data';
 import { formatDatetime } from 'utils/datetime';
@@ -173,7 +173,7 @@ const LogViewer: React.FC<Props> = ({
 
     local.current.isFetching = true;
 
-    await consumeStream(
+    await readStream(
       onFetch({ limit: PAGE_LIMIT, ...config } as FetchConfig, type),
       event => {
         const logEntry = decoder(event);
@@ -378,7 +378,7 @@ const LogViewer: React.FC<Props> = ({
     const throttledProcessBuffer = throttle(THROTTLE_TIME, processBuffer);
 
     if (fetchDirection === FetchDirection.Older && onFetch) {
-      consumeStream(
+      readStream(
         onFetch({ canceler, fetchDirection, limit: PAGE_LIMIT }, FetchType.Stream),
         event => {
           buffer.push(decoder(event));

--- a/webui/react/src/components/TrialLogPreview.tsx
+++ b/webui/react/src/components/TrialLogPreview.tsx
@@ -8,7 +8,7 @@ import LogViewerEntry, {
 import useGetCharMeasureInContainer from 'hooks/useGetCharMeasureInContainer';
 import { detApi } from 'services/apiConfig';
 import { mapV1LogsResponse } from 'services/decoder';
-import { consumeStream } from 'services/utils';
+import { readStream } from 'services/utils';
 import { LogLevel, RunState, TrialDetails } from 'types';
 import { formatDatetime } from 'utils/datetime';
 
@@ -37,7 +37,7 @@ const TrialLogPreview: React.FC<PropsWithChildren<Props>> = ({
   if (hidePreview || !logEntry) classes.push(css.hidePreview);
 
   const fetchTrialLogs = useCallback((trialId: number, time: string, canceler: AbortController) => {
-    consumeStream(
+    readStream(
       detApi.StreamingExperiments.trialLogs(
         trialId,
         undefined,
@@ -69,7 +69,7 @@ const TrialLogPreview: React.FC<PropsWithChildren<Props>> = ({
     trialState: RunState,
     canceler: AbortController,
   ) => {
-    consumeStream(
+    readStream(
       detApi.StreamingExperiments.trialLogs(
         trialId,
         100,

--- a/webui/react/src/pages/ExperimentDetails/ExperimentVisualization.tsx
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentVisualization.tsx
@@ -14,7 +14,7 @@ import {
   V1GetHPImportanceResponse, V1MetricBatchesResponse, V1MetricNamesResponse,
 } from 'services/api-ts-sdk';
 import { detApi } from 'services/apiConfig';
-import { consumeStream } from 'services/utils';
+import { readStream } from 'services/utils';
 import {
   ExperimentBase, ExperimentSearcherName, ExperimentVisualizationType,
   HpImportanceMap, HpImportanceMetricMap, HyperparameterType, MetricName, MetricType, RunState,
@@ -162,7 +162,7 @@ const ExperimentVisualization: React.FC<Props> = ({
     const trainingMetricsMap: Record<string, boolean> = {};
     const validationMetricsMap: Record<string, boolean> = {};
 
-    consumeStream<V1MetricNamesResponse>(
+    readStream<V1MetricNamesResponse>(
       detApi.StreamingInternal.metricNames(
         experiment.id,
         undefined,
@@ -189,7 +189,7 @@ const ExperimentVisualization: React.FC<Props> = ({
       setPageError(PageError.MetricNames);
     });
 
-    consumeStream<V1GetHPImportanceResponse>(
+    readStream<V1GetHPImportanceResponse>(
       detApi.StreamingInternal.getHPImportance(
         experiment.id,
         undefined,
@@ -218,7 +218,7 @@ const ExperimentVisualization: React.FC<Props> = ({
       ? 'METRIC_TYPE_TRAINING' : 'METRIC_TYPE_VALIDATION';
     const batchesMap: Record<number, number> = {};
 
-    consumeStream<V1MetricBatchesResponse>(
+    readStream<V1MetricBatchesResponse>(
       detApi.StreamingInternal.metricBatches(
         experiment.id,
         activeMetric.name,

--- a/webui/react/src/pages/ExperimentDetails/ExperimentVisualization/HpHeatMaps.tsx
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentVisualization/HpHeatMaps.tsx
@@ -15,7 +15,7 @@ import { useStore } from 'contexts/Store';
 import useResize from 'hooks/useResize';
 import { V1TrialsSnapshotResponse } from 'services/api-ts-sdk';
 import { detApi } from 'services/apiConfig';
-import { consumeStream } from 'services/utils';
+import { readStream } from 'services/utils';
 import {
   ExperimentBase, HyperparameterType, MetricName, MetricType,
   metricTypeParamMap, Primitive, Range,
@@ -220,7 +220,7 @@ const HpHeatMaps: React.FC<Props> = ({
 
     setHasLoaded(false);
 
-    consumeStream<V1TrialsSnapshotResponse>(
+    readStream<V1TrialsSnapshotResponse>(
       detApi.StreamingInternal.trialsSnapshot(
         experiment.id,
         selectedMetric.name,

--- a/webui/react/src/pages/ExperimentDetails/ExperimentVisualization/HpParallelCoordinates.tsx
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentVisualization/HpParallelCoordinates.tsx
@@ -12,7 +12,7 @@ import { useStore } from 'contexts/Store';
 import { openOrCreateTensorBoard } from 'services/api';
 import { V1TrialsSnapshotResponse } from 'services/api-ts-sdk';
 import { detApi } from 'services/apiConfig';
-import { consumeStream } from 'services/utils';
+import { readStream } from 'services/utils';
 import {
   ExperimentAction as Action, CommandTask, ExperimentBase, Hyperparameter,
   HyperparameterType, MetricName, MetricType, metricTypeParamMap, Primitive, Range,
@@ -168,7 +168,7 @@ const HpParallelCoordinates: React.FC<Props> = ({
 
     setHasLoaded(false);
 
-    consumeStream<V1TrialsSnapshotResponse>(
+    readStream<V1TrialsSnapshotResponse>(
       detApi.StreamingInternal.trialsSnapshot(
         experiment.id,
         selectedMetric.name,

--- a/webui/react/src/pages/ExperimentDetails/ExperimentVisualization/HpScatterPlots.tsx
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentVisualization/HpScatterPlots.tsx
@@ -13,7 +13,7 @@ import { useStore } from 'contexts/Store';
 import useResize from 'hooks/useResize';
 import { V1TrialsSnapshotResponse } from 'services/api-ts-sdk';
 import { detApi } from 'services/apiConfig';
-import { consumeStream } from 'services/utils';
+import { readStream } from 'services/utils';
 import {
   ExperimentBase, HyperparameterType, MetricName, metricTypeParamMap, Primitive,
 } from 'types';
@@ -137,7 +137,7 @@ const ScatterPlots: React.FC<Props> = ({
 
     setHasLoaded(false);
 
-    consumeStream<V1TrialsSnapshotResponse>(
+    readStream<V1TrialsSnapshotResponse>(
       detApi.StreamingInternal.trialsSnapshot(
         experiment.id,
         selectedMetric.name,

--- a/webui/react/src/pages/ExperimentDetails/ExperimentVisualization/LearningCurve.tsx
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentVisualization/LearningCurve.tsx
@@ -12,7 +12,7 @@ import { isNewTabClickEvent, openBlank, paths, routeToReactUrl } from 'routes/ut
 import { openOrCreateTensorBoard } from 'services/api';
 import { V1TrialsSampleResponse } from 'services/api-ts-sdk';
 import { detApi } from 'services/apiConfig';
-import { consumeStream } from 'services/utils';
+import { readStream } from 'services/utils';
 import {
   ExperimentAction as Action, CommandTask, ExperimentBase, Hyperparameter, MetricName,
   metricTypeParamMap, RunState,
@@ -98,7 +98,7 @@ const LearningCurve: React.FC<Props> = ({
 
     setHasLoaded(false);
 
-    consumeStream<V1TrialsSampleResponse>(
+    readStream<V1TrialsSampleResponse>(
       detApi.StreamingInternal.trialsSample(
         experiment.id,
         selectedMetric.name,

--- a/webui/react/src/pages/TaskLogs.tsx
+++ b/webui/react/src/pages/TaskLogs.tsx
@@ -11,7 +11,7 @@ import useSettings from 'hooks/useSettings';
 import { paths } from 'routes/utils';
 import { detApi } from 'services/apiConfig';
 import { mapV1LogsResponse } from 'services/decoder';
-import { consumeStream } from 'services/utils';
+import { readStream } from 'services/utils';
 import { CommandType } from 'types';
 
 import css from './TaskLogs.module.scss';
@@ -102,7 +102,7 @@ const TaskLogs: React.FC = () => {
   useEffect(() => {
     const canceler = new AbortController();
 
-    consumeStream(
+    readStream(
       detApi.StreamingJobs.taskLogsFields(
         taskId,
         true,

--- a/webui/react/src/pages/TrialDetails/Profiles/useFetchAvailableSeries.ts
+++ b/webui/react/src/pages/TrialDetails/Profiles/useFetchAvailableSeries.ts
@@ -3,7 +3,7 @@ import { useEffect, useState } from 'react';
 import { useStore } from 'contexts/Store';
 import { V1GetTrialProfilerAvailableSeriesResponse } from 'services/api-ts-sdk';
 import { detApi } from 'services/apiConfig';
-import { consumeStream } from 'services/utils';
+import { readStream } from 'services/utils';
 
 import { AvailableSeries } from './types';
 
@@ -16,7 +16,7 @@ export const useFetchAvailableSeries = (trialId: number): AvailableSeries => {
 
     const canceler = new AbortController();
 
-    consumeStream(
+    readStream(
       detApi.StreamingProfiler.getTrialProfilerAvailableSeries(
         trialId,
         true,

--- a/webui/react/src/pages/TrialDetails/Profiles/useFetchMetrics.tsx
+++ b/webui/react/src/pages/TrialDetails/Profiles/useFetchMetrics.tsx
@@ -4,7 +4,7 @@ import { terminalRunStates } from 'constants/states';
 import { useStore } from 'contexts/Store';
 import { V1GetTrialProfilerMetricsResponse } from 'services/api-ts-sdk';
 import { detApi } from 'services/apiConfig';
-import { consumeStream } from 'services/utils';
+import { readStream } from 'services/utils';
 import { RunState } from 'types';
 import { clone, hasObjectKeys } from 'utils/data';
 
@@ -36,7 +36,7 @@ export const useFetchMetrics = (
     const canceler = new AbortController();
     const follow = !terminalRunStates.has(trialState);
 
-    consumeStream(
+    readStream(
       detApi.StreamingProfiler.getTrialProfilerMetrics(
         trialId,
         labelsName,

--- a/webui/react/src/pages/TrialDetails/TrialDetailsLogs.tsx
+++ b/webui/react/src/pages/TrialDetails/TrialDetailsLogs.tsx
@@ -10,7 +10,7 @@ import useSettings from 'hooks/useSettings';
 import { serverAddress } from 'routes/utils';
 import { detApi } from 'services/apiConfig';
 import { mapV1LogsResponse } from 'services/decoder';
-import { consumeStream } from 'services/utils';
+import { readStream } from 'services/utils';
 import { ExperimentBase, TrialDetails } from 'types';
 import { downloadTrialLogs } from 'utils/browser';
 import handleError, { ErrorType } from 'utils/error';
@@ -144,7 +144,7 @@ const TrialDetailsLogs: React.FC<Props> = ({ experiment, trial }: Props) => {
 
     const canceler = new AbortController();
 
-    consumeStream(
+    readStream(
       detApi.StreamingExperiments.trialLogsFields(
         trial.id,
         true,

--- a/webui/react/src/services/utils.ts
+++ b/webui/react/src/services/utils.ts
@@ -1,12 +1,11 @@
 import { serverAddress } from 'routes/utils';
 import * as Api from 'services/api-ts-sdk';
 import { isObject } from 'utils/data';
-import { DetError, DetErrorOptions, ErrorLevel, ErrorType, isDetError } from 'utils/error';
+import handleError, {
+  DetError, DetErrorOptions, ErrorLevel, ErrorType, isDetError,
+} from 'utils/error';
 
 import { DetApi, FetchOptions } from './types';
-
-/* eslint-disable @typescript-eslint/no-var-requires */
-const ndjsonStream = require('can-ndjson-stream');
 
 /* Response Helpers */
 
@@ -97,17 +96,7 @@ export function generateDetApi<Input, DetOutput, Output>(api: DetApi<Input, DetO
 
 /* gRPC Helpers */
 
-/*
-  consumeStream is used to consume streams from the generated TS client.
-  We use the provided fetchParamCreator to create fetch arguments and use that
-  to make a request and handle events one by one.
-  Example:
-  consumeStream<Api.V1TrialLogsResponse>(
-    Api.ExperimentsApiFetchParamCreator().trialLogs(1, undefined, undefined, true),
-    console.log,
-  ).then(() => console.log('finished'));
-*/
-export const consumeStream = async <T = unknown>(
+export const readStream = async <T = unknown>(
   fetchArgs: Api.FetchArgs,
   onEvent: (event: T) => void,
 ): Promise<void> => {
@@ -121,31 +110,62 @@ export const consumeStream = async <T = unknown>(
     if (process.env.IS_DEV) options.credentials = 'include';
 
     const response = await fetch(serverAddress(fetchArgs.url), options);
-    const reader = ndjsonStream(response.body).getReader();
+    if (!response.body) throw new DetError(`Unable to fetch stream from ${fetchArgs.url}.`);
+
+    const decoder = new TextDecoder();
+    const reader = response.body.getReader();
+    let buffer = '';
+    let isCancelled = false;
 
     // Cancel reader if an abort signal is received.
     if (options?.signal) {
       const signal: AbortSignal = options.signal;
       const abortHandler = () => {
-        reader.cancel();
         signal.removeEventListener('abort', abortHandler);
+        isCancelled = true;
       };
       signal.addEventListener('abort', abortHandler);
     }
 
-    let result;
-    while (!result || !result.done) {
-      result = await reader.read();
-      if (result.done) return;
-      if (result.value.error) {
-        throw result.value.error;
-      } else {
-        onEvent(result.value.result);
+    const handleStreamError = (e: unknown) => handleError(e, { silent: true });
+    const handleStreamLine = (line: string) => {
+      if (isCancelled) return;
+      try {
+        const ndjson = JSON.parse(line);
+        onEvent(ndjson.result);
+      } catch {
+        // JSON parsing occurred, no-op.
       }
-    }
+    };
+    const handleStreamRead = (result: ReadableStreamDefaultReadResult<ArrayBuffer>): unknown => {
+      if (result.done || isCancelled) {
+        // Process any data buffer remainder.
+        buffer = buffer.trim();
+        if (buffer.length !== 0) handleStreamLine(buffer);
+        return;
+      }
+
+      // Append incoming streaming data to buffer.
+      buffer += decoder.decode(result.value, { stream: true });
+
+      // Process only newline delimited data buffer.
+      const lines = buffer.split('\n');
+      for(let i = 0; i < lines.length - 1; ++i) {
+        const line = lines[i].trim();
+        if (line.length === 0) continue;
+        handleStreamLine(line);
+      }
+
+      // Keep the unprocessed buffer data.
+      buffer = lines[lines.length - 1];
+
+      // Keep reading.
+      return reader.read().then(handleStreamRead).catch(handleStreamError);
+    };
+
+    reader.read().then(handleStreamRead).catch(handleStreamError);
   } catch (e) {
-    const err = await processApiError(fetchArgs.url, e);
-    if (!isAborted(e)) throw err;
+    handleError(await processApiError(fetchArgs.url, e));
   }
 };
 

--- a/webui/react/src/utils/browser.ts
+++ b/webui/react/src/utils/browser.ts
@@ -2,7 +2,7 @@ import { parseUrl, routeToExternalUrl } from 'routes/utils';
 import { getTrialDetails } from 'services/api';
 import { V1TrialLogsResponse } from 'services/api-ts-sdk';
 import { detApi } from 'services/apiConfig';
-import { consumeStream } from 'services/utils';
+import { readStream } from 'services/utils';
 import { BrandingType } from 'types';
 
 /*
@@ -42,7 +42,7 @@ export const downloadTrialLogs = async (trialId: number): Promise<void> => {
   const MAX_PART_SIZE = 128 * Math.pow(2, 20); // 128m * CHAR_SIZE
   const parts: BlobPart[] = [];
   let downloadStringBuffer = '';
-  await consumeStream<V1TrialLogsResponse>(
+  await readStream<V1TrialLogsResponse>(
     detApi.StreamingExperiments.trialLogs(trialId),
     (ev) => {
       downloadStringBuffer += ev.message;


### PR DESCRIPTION
## Description

Rewrite the our stream reader by bringing in the same concepts from `can-ndjson-stream` for data parsing. The `can-ndjson-stream` has plagued us with numerous uncaught exceptions. More noticeable on FireFox than other browsers (other browsers tend to just show it as console.errors, where as FireFox breaks the page with something like the screenshot below).

![Screen Shot 2022-04-26 at 10 08 31 AM](https://user-images.githubusercontent.com/220971/165345308-e25d64db-a6f1-4dd8-af39-6150781e23ab.png)

Improvements:
* Reduce the `consumeStream` and `ndjsonStream` into a single `readStream`.
* Update `readStream` to process data as `ndjson` streams, but also handle url fetching.
* Gracefully terminate stream reader when `AbortController` cancel signal is received.

<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At a minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan

Pages that uses streaming:
- log pages (Master, Trial, Task)
- active experiment detail pages, particularly multi-trial experiments

Tests
- [ ] check to ensure that the streaming data is properly coming through on the streaming pages.
- [ ] check that when navigating away from the pages, the streaming endpoints terminate.
![2022-04-26 at 10 05 AM](https://user-images.githubusercontent.com/220971/165344103-97334200-a6a1-48fa-b5a5-54430abf48ab.png)
- [ ] check that the page no longer breaks (especially on FireFox) with `user aborted` message (via uncaught exceptions). A easy way to trigger this is to fork a single trial experiment on FireFox, navigate to the logs section of the new experiment, way for log entries to show up, and before the experiment ends, navigate to the experiments page.

<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions about this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ