### PR TITLE
fix: Prevent archived models from appearing in the Register Checkpoint modal [DET-7132]

### DIFF
--- a/webui/react/src/hooks/useRegisterCheckpointModal.tsx
+++ b/webui/react/src/hooks/useRegisterCheckpointModal.tsx
@@ -52,6 +52,7 @@ const useRegisterCheckpointModal = (onClose?: (checkpointUuid?: string) => void)
   const fetchModels = useCallback(async () => {
     try {
       const response = await getModels({
+        archived: false,
         orderBy: 'ORDER_BY_DESC',
         sortBy: validateDetApiEnum(
           V1GetModelsRequestSortBy,


### PR DESCRIPTION
## Description

After a model is archived, it cannot add new Model Versions, so it should not be in the list of selectable models in the Register Checkpoint / new Model Version modal window.

In the current version the model appears, and trying to register a new model version throws an error. 

## Test Plan

- Archive a model
- Go to an experiment with checkpoints
- Check list of models available when you register a checkpoint

## Checklist

- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.