### PR TITLE
fix: remove dead shell start code [DET-7131]

### DIFF
--- a/e2e_tests/tests/cluster/test_users.py
+++ b/e2e_tests/tests/cluster/test_users.py
@@ -357,7 +357,8 @@ def test_auth_inside_shell() -> None:
         child = det_spawn(["shell", "start"])
         child.setecho(True)
         # shells take time to start; use the default timeout which is longer
-        child.expect(r".*Permanently added \'\[(.*)\]:\d+.+known hosts\.")
+        child.expect(r".*Permanently added.+([0-9a-f-]{36}).+known hosts\.")
+
         shell_id = child.match.group(1).decode("utf-8")
 
         def check_whoami(expected_username: str) -> None:

--- a/harness/determined/cli/shell.py
+++ b/harness/determined/cli/shell.py
@@ -13,7 +13,7 @@ from termcolor import colored
 from determined.cli import command, task
 from determined.common import api
 from determined.common.api import authentication, certs
-from determined.common.check import check_eq, check_len
+from determined.common.check import check_eq
 from determined.common.declarative_argparse import Arg, Cmd
 
 from .command import (
@@ -126,9 +126,6 @@ def _open_shell(
         keyfile.write(shell["privateKey"])
         keyfile.flush()
 
-        check_len(shell["addresses"], 1, "Cannot find address for shell")
-        _, port = shell["addresses"][0]["host_ip"], shell["addresses"][0]["host_port"]
-
         # Use determined.cli.tunnel as a portable script for using the HTTP CONNECT mechanism,
         # similar to `nc -X CONNECT -x ...` but without any dependency on external binaries.
         python = sys.executable
@@ -156,8 +153,6 @@ def _open_shell(
             "IdentitiesOnly=yes",
             "-i",
             str(keyfile.name),
-            "-p",
-            str(port),
             "{}@{}".format(username, shell["id"]),
             *additional_opts,
         ]


### PR DESCRIPTION
Tested manually.

To test, see description in DET-7131