### PR TITLE
fix: Human-readable option for empty filters in logs [DET-6781, DET-6999]

### DIFF
--- a/webui/react/src/components/LogViewer/LogViewerFilters.tsx
+++ b/webui/react/src/components/LogViewer/LogViewerFilters.tsx
@@ -90,7 +90,7 @@ const LogViewerFilters: React.FC<Props> = ({ onChange, onReset, options, values 
             value={values.allocationIds}
             onChange={handleChange('allocationIds', String)}>
             {selectOptions?.allocationIds?.map(id => (
-              <Option key={id} value={id}>{id || 'No Allocation'}</Option>
+              <Option key={id} value={id}>{id || 'No Allocation ID'}</Option>
             ))}
           </MultiSelect>
         )}
@@ -100,7 +100,7 @@ const LogViewerFilters: React.FC<Props> = ({ onChange, onReset, options, values 
             value={values.agentIds}
             onChange={handleChange('agentIds', String)}>
             {selectOptions?.agentIds?.map(id => (
-              <Option key={id} value={id}>{id || 'No Agent'}</Option>
+              <Option key={id} value={id}>{id || 'No Agent ID'}</Option>
             ))}
           </MultiSelect>
         )}
@@ -111,7 +111,7 @@ const LogViewerFilters: React.FC<Props> = ({ onChange, onReset, options, values 
             value={values.containerIds}
             onChange={handleChange('containerIds', String)}>
             {selectOptions?.containerIds?.map(id => (
-              <Option key={id} value={id}>{id || 'No Container'}</Option>
+              <Option key={id} value={id}>{id || 'No Container ID'}</Option>
             ))}
           </MultiSelect>
         )}
@@ -121,7 +121,7 @@ const LogViewerFilters: React.FC<Props> = ({ onChange, onReset, options, values 
             value={values.rankIds}
             onChange={handleChange('rankIds', Number)}>
             {selectOptions?.rankIds?.map(id => (
-              <Option key={id} value={id}>{id || 'No Rank'}</Option>
+              <Option key={id} value={id}>{id || 'No Rank ID'}</Option>
             ))}
           </MultiSelect>
         )}

--- a/webui/react/src/components/LogViewer/LogViewerFilters.tsx
+++ b/webui/react/src/components/LogViewer/LogViewerFilters.tsx
@@ -121,7 +121,7 @@ const LogViewerFilters: React.FC<Props> = ({ onChange, onReset, options, values 
             value={values.rankIds}
             onChange={handleChange('rankIds', Number)}>
             {selectOptions?.rankIds?.map(id => (
-              <Option key={id} value={id}>{id || 'No Rank ID'}</Option>
+              <Option key={id} value={id}>{id || 'No Rank'}</Option>
             ))}
           </MultiSelect>
         )}

--- a/webui/react/src/components/LogViewer/LogViewerFilters.tsx
+++ b/webui/react/src/components/LogViewer/LogViewerFilters.tsx
@@ -89,7 +89,7 @@ const LogViewerFilters: React.FC<Props> = ({ onChange, onReset, options, values 
             itemName={LABELS.allocationIds}
             value={values.allocationIds}
             onChange={handleChange('allocationIds', String)}>
-            {selectOptions?.allocationIds?.map(id => <Option key={id} value={id}>{id}</Option>)}
+            {selectOptions?.allocationIds?.map(id => <Option key={id} value={id}>{id || 'No Allocation'}</Option>)}
           </MultiSelect>
         )}
         {moreThanOne.agentIds && (
@@ -97,7 +97,7 @@ const LogViewerFilters: React.FC<Props> = ({ onChange, onReset, options, values 
             itemName={LABELS.agentIds}
             value={values.agentIds}
             onChange={handleChange('agentIds', String)}>
-            {selectOptions?.agentIds?.map(id => <Option key={id} value={id}>{id}</Option>)}
+            {selectOptions?.agentIds?.map(id => <Option key={id} value={id}>{id || 'No Agent'}</Option>)}
           </MultiSelect>
         )}
         {moreThanOne.containerIds && (
@@ -116,7 +116,7 @@ const LogViewerFilters: React.FC<Props> = ({ onChange, onReset, options, values 
             itemName={LABELS.rankIds}
             value={values.rankIds}
             onChange={handleChange('rankIds', Number)}>
-            {selectOptions?.rankIds?.map(id => <Option key={id} value={id}>{id}</Option>)}
+            {selectOptions?.rankIds?.map(id => <Option key={id} value={id}>{id || 'No Rank'}</Option>)}
           </MultiSelect>
         )}
         <MultiSelect

--- a/webui/react/src/components/LogViewer/LogViewerFilters.tsx
+++ b/webui/react/src/components/LogViewer/LogViewerFilters.tsx
@@ -89,7 +89,9 @@ const LogViewerFilters: React.FC<Props> = ({ onChange, onReset, options, values 
             itemName={LABELS.allocationIds}
             value={values.allocationIds}
             onChange={handleChange('allocationIds', String)}>
-            {selectOptions?.allocationIds?.map(id => <Option key={id} value={id}>{id || 'No Allocation'}</Option>)}
+            {selectOptions?.allocationIds?.map(id => (
+              <Option key={id} value={id}>{id || 'No Allocation'}</Option>
+            ))}
           </MultiSelect>
         )}
         {moreThanOne.agentIds && (
@@ -97,7 +99,9 @@ const LogViewerFilters: React.FC<Props> = ({ onChange, onReset, options, values 
             itemName={LABELS.agentIds}
             value={values.agentIds}
             onChange={handleChange('agentIds', String)}>
-            {selectOptions?.agentIds?.map(id => <Option key={id} value={id}>{id || 'No Agent'}</Option>)}
+            {selectOptions?.agentIds?.map(id => (
+              <Option key={id} value={id}>{id || 'No Agent'}</Option>
+            ))}
           </MultiSelect>
         )}
         {moreThanOne.containerIds && (
@@ -116,7 +120,9 @@ const LogViewerFilters: React.FC<Props> = ({ onChange, onReset, options, values 
             itemName={LABELS.rankIds}
             value={values.rankIds}
             onChange={handleChange('rankIds', Number)}>
-            {selectOptions?.rankIds?.map(id => <Option key={id} value={id}>{id || 'No Rank'}</Option>)}
+            {selectOptions?.rankIds?.map(id => (
+              <Option key={id} value={id}>{id || 'No Rank'}</Option>
+            ))}
           </MultiSelect>
         )}
         <MultiSelect


### PR DESCRIPTION
## Description

On the task logs page, the filter UI includes options for allocation, agent, container, rank, and levels.  Levels is constant, but the others are filled in by the database from all options available in the task logs.

When there is 0-1 option in a dropdown, `moreThanOne` already hides this dropdown (only Levels and Container dropdowns visible below).

<img width="583" alt="Screen Shot 2022-04-26 at 10 53 26 AM" src="https://user-images.githubusercontent.com/643918/165362194-18f17459-f886-4341-9921-3c8a4a5bf510.png">

When there is an empty string value, the containers dropdown already lists this option as "No Container". This PR adds "No Agent", "No Rank", and "No Allocation" to the other dynamic dropdowns in place of any empty string value.

## Checklist

- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.