### PR TITLE
feat: Telemetry of use of workspaces and projects

### DIFF
--- a/e2e_tests/tests/cluster/test_workspace_org.py
+++ b/e2e_tests/tests/cluster/test_workspace_org.py
@@ -297,6 +297,7 @@ def test_workspace_org() -> None:
         assert test_exp.projectId == default_project.id
 
         # Move the test experiment into a user-made project
+        dproj_exp = bindings.get_GetProjectExperiments(sess, id=default_project.id).experiments
         exp_count = len(bindings.get_GetProjectExperiments(sess, id=made_project.id).experiments)
         assert exp_count == 0
         mbody = bindings.v1MoveExperimentRequest(
@@ -305,8 +306,12 @@ def test_workspace_org() -> None:
         bindings.post_MoveExperiment(sess, experimentId=test_exp_id, body=mbody)
         modified_exp = bindings.get_GetExperiment(sess, experimentId=test_exp_id).experiment
         assert modified_exp.projectId == made_project.id
+
+        # Confirm the test experiment is in the new project, no longer in old project.
         exp_count = len(bindings.get_GetProjectExperiments(sess, id=made_project.id).experiments)
         assert exp_count == 1
+        dproj_exp2 = bindings.get_GetProjectExperiments(sess, id=default_project.id).experiments
+        assert len(dproj_exp2) == len(dproj_exp) - 1
 
         # Cannot move an experiment out of an archived project
         bindings.post_ArchiveProject(sess, id=made_project.id)

--- a/master/internal/db/postgres_cluster.go
+++ b/master/internal/db/postgres_cluster.go
@@ -51,6 +51,16 @@ SELECT jsonb_build_object(
 	'num_allocations', (SELECT count(*) FROM allocations),
     'num_allocations_today', (
 		SELECT count(*) FROM allocations WHERE DATE(start_time) >= CURRENT_DATE
+	),
+	'num_workspaces', (SELECT count(*) FROM workspaces),
+	'num_projects', (SELECT count(*) FROM projects),
+	'avg_projects_per_workspace', (
+		(SELECT count(*) FROM projects WHERE id > 1)::float
+		/ (SELECT greatest(count(*), 1) FROM workspaces WHERE id > 1)
+	),
+	'avg_experiments_per_project', (
+		(SELECT count(*) FROM experiments WHERE project_id > 1)::float
+		/ (SELECT greatest(count(*), 1) FROM projects WHERE id > 1)
 	)
 );
 `)

--- a/master/static/srv/get_experiments.sql
+++ b/master/static/srv/get_experiments.sql
@@ -64,6 +64,7 @@ WITH page_info AS (
             )
         AND ($5 = '' OR (e.config->>'description') ILIKE  ('%%' || $5 || '%%'))
         AND ($6 = '' OR (e.config->>'name') ILIKE ('%%' || $6 || '%%'))
+        AND ($7 = 0 OR e.project_id = $7)
     ORDER BY %s
     OFFSET (SELECT p.page_info->>'start_index' FROM page_info p)::bigint
     LIMIT (SELECT (p.page_info->>'end_index')::bigint - (p.page_info->>'start_index')::bigint FROM page_info p)


### PR DESCRIPTION
## Description

Include our planned telemetry on workspace and project features:
- total count of workspaces and projects
- average projects-per-workspace and average experiments-per-project (excepting those in the default workspace + project)

Uses `::float` for averages, and `greatest(count(*), 1)` to avoid dividing by 0. You cannot make new projects in the default workspace, so there are no user-created projects in this situation.

## Checklist

- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.