### PR TITLE
feat: save metadata pre-upload

### DIFF
--- a/examples/tutorials/core_api/4_distributed.py
+++ b/examples/tutorials/core_api/4_distributed.py
@@ -64,7 +64,7 @@ def main(core_context, latest_checkpoint, trial_id, increment_by):
                     op.report_progress(batch)
                     checkpoint_metadata = {"latest_batch": batch}
                     with core_context.checkpoint.store_path(checkpoint_metadata) as (checkpoint_directory, uuid):
-                        save_state(x, batch, trial_id, path)
+                        save_state(x, batch, trial_id, checkpoint_directory)
                     last_checkpoint_batch = batch
                 if core_context.preempt.should_preempt():
                     return

--- a/harness/determined/common/experimental/checkpoint/_checkpoint.py
+++ b/harness/determined/common/experimental/checkpoint/_checkpoint.py
@@ -156,12 +156,6 @@ class Checkpoint(object):
 
                 manager.download(self.uuid, str(local_ckpt_dir))
 
-        # XXX: this used to be the only place we write metadata but now that we've fixed our
-        # checkpoint protobuf and now that we are releasing a breaking change to the Checkpoint
-        # export api, we need to start writing a different format (the user-defined metadata only),
-        # and we need to start writing it at upload time, not download time.
-        self.write_metadata_file(str(local_ckpt_dir.joinpath("metadata.json")))
-
         return str(local_ckpt_dir)
 
     def write_metadata_file(self, path: str) -> None:
@@ -208,8 +202,8 @@ class Checkpoint(object):
 
            Please combine Checkpoint.download() with one of the following instead:
              - ``det.pytorch.load_trial_from_checkpoint()``
-             - ``det.keras.load_trial_from_checkpoint()``
-             - ``det.estimator.load_trial_from_checkpoint()``
+             - ``det.keras.load_model_from_checkpoint()``
+             - ``det.estimator.load_estimator_from_checkpoint_path()``
         """
         warnings.warn(
             "Checkpoint.load() has been deprecated and will be removed in a future version.\n"

--- a/harness/determined/common/experimental/checkpoint/_checkpoint.py
+++ b/harness/determined/common/experimental/checkpoint/_checkpoint.py
@@ -224,6 +224,8 @@ class Checkpoint(object):
         the checkpoint metadata, the corresponding dictionary entries in the checkpoint are
         replaced by the passed-in dictionary values.
 
+        Warning: this metadata change is not propagated to the checkpoint storage.
+
         Arguments:
             metadata (dict): Dictionary of metadata to add to the checkpoint.
         """
@@ -239,6 +241,8 @@ class Checkpoint(object):
         """
         Removes user-defined metadata from the checkpoint. Any top-level keys that
         appear in the ``keys`` list are removed from the checkpoint.
+
+        Warning: this metadata change is not propagated to the checkpoint storage.
 
         Arguments:
             keys (List[string]): Top-level keys to remove from the checkpoint metadata.

--- a/harness/determined/core/_checkpoint.py
+++ b/harness/determined/core/_checkpoint.py
@@ -222,8 +222,8 @@ class CheckpointContext:
 
     def _write_metadata_file(self, ckpt_dir: str, metadata: Optional[Dict[str, Any]]) -> None:
         if metadata is not None:
-            metadata_path = str(pathlib.Path(ckpt_dir).joinpath("metadata.json"))
-            with open(metadata_path, "w") as f:
+            metadata_path = pathlib.Path(ckpt_dir).joinpath("metadata.json")
+            with metadata_path.open("w") as f:
                 json.dump(metadata, f, indent=2)
 
     def _report_checkpoint(

--- a/harness/determined/core/_checkpoint.py
+++ b/harness/determined/core/_checkpoint.py
@@ -1,5 +1,6 @@
 import contextlib
 import enum
+import json
 import logging
 import os
 import pathlib
@@ -78,10 +79,13 @@ class CheckpointContext:
         ckpt_dir = os.fspath(ckpt_dir)
 
         storage_id = str(uuid.uuid4())
-        # XXX we would like to add metadata.json here but we shouldn't
-        # since it will get out of date if user adds custom key-value pairs to it
-        self._storage_manager.upload(src=ckpt_dir, dst=storage_id)
         resources = self._storage_manager._list_directory(ckpt_dir)
+
+        # add metadata pre-upload but without counting it among resources
+        if metadata is not None:
+            self._write_metadata_file(ckpt_dir, metadata)
+
+        self._storage_manager.upload(src=ckpt_dir, dst=storage_id)
         self._report_checkpoint(storage_id, resources, metadata)
         return storage_id
 
@@ -159,6 +163,8 @@ class CheckpointContext:
         with self._storage_manager.store_path(storage_id) as path:
             yield path, storage_id
             resources = self._storage_manager._list_directory(path)
+            self._write_metadata_file(os.fspath(path), metadata)
+
         self._report_checkpoint(storage_id, resources, metadata)
 
     @contextlib.contextmanager
@@ -213,6 +219,12 @@ class CheckpointContext:
         Delete a checkpoint from the storage backend.
         """
         self._storage_manager.delete(storage_id)
+
+    def _write_metadata_file(self, ckpt_dir: str, metadata: Optional[Dict[str, Any]]) -> None:
+        if metadata is not None:
+            metadata_path = str(pathlib.Path(ckpt_dir).joinpath("metadata.json"))
+            with open(metadata_path, "w") as f:
+                json.dump(metadata, f, indent=2)
 
     def _report_checkpoint(
         self,


### PR DESCRIPTION
## Description

A less ambitious change: save metadata to `metadata.json` as part of upload.

Initially (https://github.com/determined-ai/determined/pull/4010) I tried to push `metadata.json` into the checkpoint storage as part of `Checkpoint.add_metadata` and `Checkpoint.remove_metadata`. That did not work as the client typically does not have write access to the checkpoint storage directory in the case of shared_fs.

Instead we still save metadata into the local directory just before uploading it but only in `CheckpointContext`.
The good news: metadata is saved to checkpoint storage as part of `CheckpointContext.upload` and `CheckpointContext.store_path` (in addition to being saved to DB).
The sad news: if the user mutates metadata locally with python SDK (outside of Contexts/experiment execution) those updates only get to the database but not to the checkpoint storage.

## Docstring change
Note the "Warning" line.
<img width="767" alt="image" src="https://user-images.githubusercontent.com/17324129/165640176-5ac31cbf-700f-4912-95ac-c1548291e870.png">
