### PR TITLE
feat: PutProjectNotes to set notes on workspaces/projects

### DIFF
--- a/e2e_tests/tests/cluster/test_workspace_org.py
+++ b/e2e_tests/tests/cluster/test_workspace_org.py
@@ -287,6 +287,15 @@ def test_workspace_org() -> None:
         returned_notes = r5.notes
         assert len(returned_notes) == 2
 
+        # Put notes
+        r6 = bindings.put_PutProjectNotes(
+            sess,
+            body=bindings.v1PutProjectNotesRequest(notes=[note], projectId=made_project.id),
+            projectId=made_project.id
+        )
+        returned_notes = r6.notes
+        assert len(returned_notes) == 1
+
         # Create an experiment in the default project.
         test_exp_id = run_basic_test(
             conf.fixtures_path("no_op/single.yaml"), conf.fixtures_path("no_op"), 1

--- a/e2e_tests/tests/cluster/test_workspace_org.py
+++ b/e2e_tests/tests/cluster/test_workspace_org.py
@@ -291,7 +291,7 @@ def test_workspace_org() -> None:
         r6 = bindings.put_PutProjectNotes(
             sess,
             body=bindings.v1PutProjectNotesRequest(notes=[note], projectId=made_project.id),
-            projectId=made_project.id
+            projectId=made_project.id,
         )
         returned_notes = r6.notes
         assert len(returned_notes) == 1

--- a/harness/determined/common/api/bindings.py
+++ b/harness/determined/common/api/bindings.py
@@ -4039,6 +4039,46 @@ class v1Project:
             "immutable": self.immutable,
         }
 
+class v1PutProjectNotesRequest:
+    def __init__(
+        self,
+        notes: "typing.Sequence[v1Note]",
+        projectId: int,
+    ):
+        self.notes = notes
+        self.projectId = projectId
+
+    @classmethod
+    def from_json(cls, obj: Json) -> "v1PutProjectNotesRequest":
+        return cls(
+            notes=[v1Note.from_json(x) for x in obj["notes"]],
+            projectId=obj["projectId"],
+        )
+
+    def to_json(self) -> typing.Any:
+        return {
+            "notes": [x.to_json() for x in self.notes],
+            "projectId": self.projectId,
+        }
+
+class v1PutProjectNotesResponse:
+    def __init__(
+        self,
+        notes: "typing.Sequence[v1Note]",
+    ):
+        self.notes = notes
+
+    @classmethod
+    def from_json(cls, obj: Json) -> "v1PutProjectNotesResponse":
+        return cls(
+            notes=[v1Note.from_json(x) for x in obj["notes"]],
+        )
+
+    def to_json(self) -> typing.Any:
+        return {
+            "notes": [x.to_json() for x in self.notes],
+        }
+
 class v1PutTemplateResponse:
     def __init__(
         self,
@@ -7881,6 +7921,26 @@ def post_PreviewHPSearch(
     if _resp.status_code == 200:
         return v1PreviewHPSearchResponse.from_json(_resp.json())
     raise APIHttpError("post_PreviewHPSearch", _resp)
+
+def put_PutProjectNotes(
+    session: "client.Session",
+    *,
+    body: "v1PutProjectNotesRequest",
+    projectId: int,
+) -> "v1PutProjectNotesResponse":
+    _params = None
+    _resp = session._do_request(
+        method="PUT",
+        path=f"/api/v1/projects/{projectId}/notes",
+        params=_params,
+        json=body.to_json(),
+        data=None,
+        headers=None,
+        timeout=None,
+    )
+    if _resp.status_code == 200:
+        return v1PutProjectNotesResponse.from_json(_resp.json())
+    raise APIHttpError("put_PutProjectNotes", _resp)
 
 def put_PutTemplate(
     session: "client.Session",

--- a/master/internal/api_project.go
+++ b/master/internal/api_project.go
@@ -168,6 +168,14 @@ func (a *apiServer) AddProjectNote(
 		errors.Wrapf(err, "error adding project note")
 }
 
+func (a *apiServer) PutProjectNotes(
+	_ context.Context, req *apiv1.PutProjectNotesRequest) (*apiv1.PutProjectNotesResponse, error) {
+	newp := &projectv1.Project{}
+	err := a.m.db.QueryProto("insert_project_note", newp, req.ProjectId, req.Notes)
+	return &apiv1.PutProjectNotesResponse{Notes: newp.Notes},
+		errors.Wrapf(err, "error putting project notes")
+}
+
 func (a *apiServer) PatchProject(
 	_ context.Context, req *apiv1.PatchProjectRequest) (*apiv1.PatchProjectResponse, error) {
 	// Verify current project exists and can be edited.

--- a/master/internal/db/postgres_cluster.go
+++ b/master/internal/db/postgres_cluster.go
@@ -61,6 +61,14 @@ SELECT jsonb_build_object(
 	'avg_experiments_per_project', (
 		(SELECT count(*) FROM experiments WHERE project_id > 1)::float
 		/ (SELECT greatest(count(*), 1) FROM projects WHERE id > 1)
+	),
+	'notes_gt_zero', (
+		(SELECT count(*) FROM projects WHERE id > 1 AND jsonb_array_length(notes) > 0)::float
+		/ (SELECT greatest(count(*), 1) FROM projects WHERE id > 1)
+	),
+	'notes_gt_one', (
+		(SELECT count(*) FROM projects WHERE id > 1 AND jsonb_array_length(notes) > 1)::float
+		/ (SELECT greatest(count(*), 1) FROM projects WHERE id > 1)
 	)
 );
 `)

--- a/proto/src/determined/api/v1/api.proto
+++ b/proto/src/determined/api/v1/api.proto
@@ -1411,6 +1411,17 @@ service Determined {
       tags: "Projects"
     };
   }
+  // Set project notes.
+  rpc PutProjectNotes(PutProjectNotesRequest)
+      returns (PutProjectNotesResponse) {
+    option (google.api.http) = {
+      put: "/api/v1/projects/{project_id}/notes"
+      body: "*"
+    };
+    option (grpc.gateway.protoc_gen_swagger.options.openapiv2_operation) = {
+      tags: "Projects"
+    };
+  }
   // Update a project.
   rpc PatchProject(PatchProjectRequest) returns (PatchProjectResponse) {
     option (google.api.http) = {

--- a/proto/src/determined/api/v1/project.proto
+++ b/proto/src/determined/api/v1/project.proto
@@ -146,6 +146,27 @@ message AddProjectNoteResponse {
   repeated determined.project.v1.Note notes = 1;
 }
 
+// Request for setting project notes.
+message PutProjectNotesRequest {
+  option (grpc.gateway.protoc_gen_swagger.options.openapiv2_schema) = {
+    json_schema: { required: [ "notes", "project_id" ] }
+  };
+  // The complete list of notes.
+  repeated determined.project.v1.Note notes = 1;
+  // The id of the project.
+  int32 project_id = 2;
+}
+
+// Response to PutProjectNotesRequest.
+message PutProjectNotesResponse {
+  option (grpc.gateway.protoc_gen_swagger.options.openapiv2_schema) = {
+    json_schema: { required: [ "notes" ] }
+  };
+
+  // The complete list of notes on a project.
+  repeated determined.project.v1.Note notes = 1;
+}
+
 // Request for updating a project.
 message PatchProjectRequest {
   option (grpc.gateway.protoc_gen_swagger.options.openapiv2_schema) = {

--- a/webui/react/src/services/api-ts-sdk/api.ts
+++ b/webui/react/src/services/api-ts-sdk/api.ts
@@ -4714,6 +4714,40 @@ export interface V1Project {
 }
 
 /**
+ * Request for setting project notes.
+ * @export
+ * @interface V1PutProjectNotesRequest
+ */
+export interface V1PutProjectNotesRequest {
+    /**
+     * The complete list of notes.
+     * @type {Array<V1Note>}
+     * @memberof V1PutProjectNotesRequest
+     */
+    notes: Array<V1Note>;
+    /**
+     * The id of the project.
+     * @type {number}
+     * @memberof V1PutProjectNotesRequest
+     */
+    projectId: number;
+}
+
+/**
+ * Response to PutProjectNotesRequest.
+ * @export
+ * @interface V1PutProjectNotesResponse
+ */
+export interface V1PutProjectNotesResponse {
+    /**
+     * The complete list of notes on a project.
+     * @type {Array<V1Note>}
+     * @memberof V1PutProjectNotesResponse
+     */
+    notes: Array<V1Note>;
+}
+
+/**
  * Response to PutTemplateRequest.
  * @export
  * @interface V1PutTemplateResponse
@@ -16314,6 +16348,52 @@ export const ProjectsApiFetchParamCreator = function (configuration?: Configurat
         },
         /**
          * 
+         * @summary Set project notes.
+         * @param {number} projectId The id of the project.
+         * @param {V1PutProjectNotesRequest} body 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        putProjectNotes(projectId: number, body: V1PutProjectNotesRequest, options: any = {}): FetchArgs {
+            // verify required parameter 'projectId' is not null or undefined
+            if (projectId === null || projectId === undefined) {
+                throw new RequiredError('projectId','Required parameter projectId was null or undefined when calling putProjectNotes.');
+            }
+            // verify required parameter 'body' is not null or undefined
+            if (body === null || body === undefined) {
+                throw new RequiredError('body','Required parameter body was null or undefined when calling putProjectNotes.');
+            }
+            const localVarPath = `/api/v1/projects/{projectId}/notes`
+                .replace(`{${"projectId"}}`, encodeURIComponent(String(projectId)));
+            const localVarUrlObj = url.parse(localVarPath, true);
+            const localVarRequestOptions = Object.assign({ method: 'PUT' }, options);
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            // authentication BearerToken required
+            if (configuration && configuration.apiKey) {
+                const localVarApiKeyValue = typeof configuration.apiKey === 'function'
+					? configuration.apiKey("Authorization")
+					: configuration.apiKey;
+                localVarHeaderParameter["Authorization"] = localVarApiKeyValue;
+            }
+
+            localVarHeaderParameter['Content-Type'] = 'application/json';
+
+            localVarUrlObj.query = Object.assign({}, localVarUrlObj.query, localVarQueryParameter, options.query);
+            // fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
+            delete localVarUrlObj.search;
+            localVarRequestOptions.headers = Object.assign({}, localVarHeaderParameter, options.headers);
+            const needsSerialization = (<any>"V1PutProjectNotesRequest" !== "string") || localVarRequestOptions.headers['Content-Type'] === 'application/json';
+            localVarRequestOptions.body =  needsSerialization ? JSON.stringify(body || {}) : (body || "");
+
+            return {
+                url: url.format(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         * 
          * @summary Unarchive a project.
          * @param {number} id The id of the project.
          * @param {*} [options] Override http request option.
@@ -16526,6 +16606,26 @@ export const ProjectsApiFp = function(configuration?: Configuration) {
         },
         /**
          * 
+         * @summary Set project notes.
+         * @param {number} projectId The id of the project.
+         * @param {V1PutProjectNotesRequest} body 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        putProjectNotes(projectId: number, body: V1PutProjectNotesRequest, options?: any): (fetch?: FetchAPI, basePath?: string) => Promise<V1PutProjectNotesResponse> {
+            const localVarFetchArgs = ProjectsApiFetchParamCreator(configuration).putProjectNotes(projectId, body, options);
+            return (fetch: FetchAPI = portableFetch, basePath: string = BASE_PATH) => {
+                return fetch(basePath + localVarFetchArgs.url, localVarFetchArgs.options).then((response) => {
+                    if (response.status >= 200 && response.status < 300) {
+                        return response.json();
+                    } else {
+                        throw response;
+                    }
+                });
+            };
+        },
+        /**
+         * 
          * @summary Unarchive a project.
          * @param {number} id The id of the project.
          * @param {*} [options] Override http request option.
@@ -16645,6 +16745,17 @@ export const ProjectsApiFactory = function (configuration?: Configuration, fetch
          */
         postProject(workspaceId: number, body: V1PostProjectRequest, options?: any) {
             return ProjectsApiFp(configuration).postProject(workspaceId, body, options)(fetch, basePath);
+        },
+        /**
+         * 
+         * @summary Set project notes.
+         * @param {number} projectId The id of the project.
+         * @param {V1PutProjectNotesRequest} body 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        putProjectNotes(projectId: number, body: V1PutProjectNotesRequest, options?: any) {
+            return ProjectsApiFp(configuration).putProjectNotes(projectId, body, options)(fetch, basePath);
         },
         /**
          * 
@@ -16774,6 +16885,19 @@ export class ProjectsApi extends BaseAPI {
      */
     public postProject(workspaceId: number, body: V1PostProjectRequest, options?: any) {
         return ProjectsApiFp(this.configuration).postProject(workspaceId, body, options)(this.fetch, this.basePath);
+    }
+
+    /**
+     * 
+     * @summary Set project notes.
+     * @param {number} projectId The id of the project.
+     * @param {V1PutProjectNotesRequest} body 
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof ProjectsApi
+     */
+    public putProjectNotes(projectId: number, body: V1PutProjectNotesRequest, options?: any) {
+        return ProjectsApiFp(this.configuration).putProjectNotes(projectId, body, options)(this.fetch, this.basePath);
     }
 
     /**


### PR DESCRIPTION
## Description

- PutProjectNotes replaces any existing notes with the given array
- Includes telemetry for notes
- Includes e2e_test for PutProjectNotes

## Checklist

- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.