### PR TITLE
fix: avoid null allocation id in checkpoint view

### DIFF
--- a/harness/determined/common/api/bindings.py
+++ b/harness/determined/common/api/bindings.py
@@ -616,14 +616,14 @@ class v1AwsCustomTag:
 class v1Checkpoint:
     def __init__(
         self,
-        allocationId: str,
         metadata: "typing.Dict[str, typing.Any]",
         resources: "typing.Dict[str, str]",
-        taskId: str,
         training: "v1CheckpointTrainingMetadata",
         uuid: str,
+        allocationId: "typing.Optional[str]" = None,
         reportTime: "typing.Optional[str]" = None,
         state: "typing.Optional[determinedcheckpointv1State]" = None,
+        taskId: "typing.Optional[str]" = None,
     ):
         self.taskId = taskId
         self.allocationId = allocationId
@@ -637,8 +637,8 @@ class v1Checkpoint:
     @classmethod
     def from_json(cls, obj: Json) -> "v1Checkpoint":
         return cls(
-            taskId=obj["taskId"],
-            allocationId=obj["allocationId"],
+            taskId=obj.get("taskId", None),
+            allocationId=obj.get("allocationId", None),
             uuid=obj["uuid"],
             reportTime=obj.get("reportTime", None),
             resources=obj["resources"],
@@ -649,8 +649,8 @@ class v1Checkpoint:
 
     def to_json(self) -> typing.Any:
         return {
-            "taskId": self.taskId,
-            "allocationId": self.allocationId,
+            "taskId": self.taskId if self.taskId is not None else None,
+            "allocationId": self.allocationId if self.allocationId is not None else None,
             "uuid": self.uuid,
             "reportTime": self.reportTime if self.reportTime is not None else None,
             "resources": self.resources,

--- a/master/pkg/model/experiment.go
+++ b/master/pkg/model/experiment.go
@@ -469,13 +469,13 @@ type CheckpointTrainingMetadata struct {
 type Checkpoint struct {
 	ID int `db:"id"`
 
-	UUID         *uuid.UUID   `db:"uuid"`
-	TaskID       TaskID       `db:"task_id"`
-	AllocationID AllocationID `db:"allocation_id"`
-	ReportTime   time.Time    `db:"report_time"`
-	State        State        `db:"state"`
-	Resources    JSONObj      `db:"resources"`
-	Metadata     JSONObj      `db:"metadata"`
+	UUID         *uuid.UUID    `db:"uuid"`
+	TaskID       *TaskID       `db:"task_id"`
+	AllocationID *AllocationID `db:"allocation_id"`
+	ReportTime   time.Time     `db:"report_time"`
+	State        State         `db:"state"`
+	Resources    JSONObj       `db:"resources"`
+	Metadata     JSONObj       `db:"metadata"`
 
 	CheckpointTrainingMetadata
 

--- a/master/static/migrations/20220423162505_generic-checkpoints.tx.up.sql
+++ b/master/static/migrations/20220423162505_generic-checkpoints.tx.up.sql
@@ -19,7 +19,12 @@ CREATE OR REPLACE VIEW public.checkpoints_view AS
         c.id AS id,
         c.uuid AS uuid,
         t.task_id,
-        t.task_id||'.'||t.run_id as allocation_id,
+        CASE
+        WHEN t.task_id is NULL THEN
+            NULL
+        ELSE
+            t.task_id || '.' || c.trial_run_id
+        END allocation_id,
         c.end_time as report_time,
         c.state,
         c.resources,

--- a/master/static/migrations/20220423162505_generic-checkpoints.tx.up.sql
+++ b/master/static/migrations/20220423162505_generic-checkpoints.tx.up.sql
@@ -19,7 +19,7 @@ CREATE OR REPLACE VIEW public.checkpoints_view AS
         c.id AS id,
         c.uuid AS uuid,
         t.task_id,
-        NULL as allocation_id, -- TODO, is there any trickery to deduce allocation_id?
+        t.task_id||'.'||t.run_id as allocation_id,
         c.end_time as report_time,
         c.state,
         c.resources,
@@ -30,8 +30,6 @@ CREATE OR REPLACE VIEW public.checkpoints_view AS
         jsonb_build_object(
             'latest_batch', c.total_batches,
             'framework', c.framework,
-            -- XXX: we definitely need to add this to the migration, so old
-            -- tensorflow checkpoints can be loaded.
             'format', c.format,
             'determined_version', c.determined_version
         ) || COALESCE(c.metadata, '{}'::jsonb) AS metadata,

--- a/proto/src/determined/checkpoint/v1/checkpoint.proto
+++ b/proto/src/determined/checkpoint/v1/checkpoint.proto
@@ -58,16 +58,7 @@ message CheckpointTrainingMetadata {
 // Checkpoint a collection of files saved by a task.
 message Checkpoint {
   option (grpc.gateway.protoc_gen_swagger.options.openapiv2_schema) = {
-    json_schema: {
-      required: [
-        "task_id",
-        "allocation_id",
-        "uuid",
-        "resources",
-        "metadata",
-        "training"
-      ]
-    }
+    json_schema: { required: [ "uuid", "resources", "metadata", "training" ] }
   };
   // ID of the task which generated this checkpoint.
   string task_id = 1;

--- a/webui/react/src/services/api-ts-sdk/api.ts
+++ b/webui/react/src/services/api-ts-sdk/api.ts
@@ -1032,13 +1032,13 @@ export interface V1Checkpoint {
      * @type {string}
      * @memberof V1Checkpoint
      */
-    taskId: string;
+    taskId?: string;
     /**
      * ID of the allocation which generated this checkpoint.
      * @type {string}
      * @memberof V1Checkpoint
      */
-    allocationId: string;
+    allocationId?: string;
     /**
      * UUID of the checkpoint.
      * @type {string}

--- a/webui/react/src/types.ts
+++ b/webui/react/src/types.ts
@@ -410,7 +410,7 @@ export interface Metrics extends Api.V1Metrics {
 export type Metadata = Record<RecordKey, string>;
 
 export interface CoreApiGenericCheckpoint {
-  allocationId: string;
+  allocationId?: string;
   experimentConfig?: ExperimentConfig;
   experimentId?: number;
   hparams?: TrialHyperparameters;
@@ -419,7 +419,7 @@ export interface CoreApiGenericCheckpoint {
   resources: Record<string, number>;
   searcherMetric?: number;
   state: CheckpointState;
-  taskId: string;
+  taskId?: string;
   totalBatches: number;
   trainingMetrics?: Metrics;
   trialId?: number;


### PR DESCRIPTION
## Description

Testing upgrade (creating a bunch of experiments with 0.17.6, upgrading to the current version, then accessing existing experiments, trials, checkpoints).

Error:
```
time="2022-04-28T03:27:32Z" level=error msg="finished unary call with code Internal" error="rpc error: code = Internal desc = failed to create experiment: failed to get checkpoint for source trial 162: error querying for latest trial checkpoint (162): sql: Scan error on column index 3, name \"allocation_id\": converting NULL to string is unsupported" grpc.code=Internal grpc.method=CreateExperiment grpc.service=determined.api.v1.Determined grpc.start_time="2022-04-28T03:27:32Z" grpc.time_ms=59.749 span.kind=server system=grpc
```

when trying to continue trial created with 0.17.6 after upgrading to the current version.

## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions about this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
