### PR TITLE
fix: Alter Boolean arg default handling

### DIFF
--- a/harness/determined/common/declarative_argparse.py
+++ b/harness/determined/common/declarative_argparse.py
@@ -201,12 +201,19 @@ def add_args(parser: ArgumentParser, description: List[Any], depth: int = 0) -> 
 
         elif isinstance(thing, BoolOptArg):
             parser.add_argument(
-                thing.true_name, dest=thing.dest, action="store_true", help=thing.true_help
+                thing.true_name,
+                dest=thing.dest,
+                action="store_true",
+                help=thing.true_help,
+                default=thing.default,
             )
             parser.add_argument(
-                thing.false_name, dest=thing.dest, action="store_false", help=thing.false_help
+                thing.false_name,
+                dest=thing.dest,
+                action="store_false",
+                help=thing.false_help,
+                default=SUPPRESS,
             )
-            parser.set_defaults(**{thing.dest: thing.default})
 
     # If there are any subcommands but none claimed the default action, make
     # the default print help.


### PR DESCRIPTION
## Description

Adjust the default value when adding Boolean args for improved help output clarity.
Closes #4037

## Test Plan

The `make test` is misbehaving on this old machine, but here's sketchy PoC output in the interim:
```python
Python 3.6.12 (default, Dec 02 2020, 09:44:23) [GCC] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import argparse
>>> p = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
>>> k = False
>>> out = None
>>> p.add_argument("--k", dest="out", action="store_true", help="enable k", default=k)
_StoreTrueAction(option_strings=['--k'], dest='out', nargs=0, const=True, default=False, type=None, choices=None, help='enable k', metavar=None)
>>> p.add_argument("--no-k", dest="out", action="store_false", help="disable k", default=argparse.SUPPRESS)
_StoreFalseAction(option_strings=['--no-k'], dest='out', nargs=0, const=False, default='==SUPPRESS==', type=None, choices=None, help='disable k', metavar=None)
>>> p.parse_args()
Namespace(out=False)
>>> p.parse_args(["--k"])
Namespace(out=True)
>>> p.parse_args(["--no-k"])
Namespace(out=False)
>>> p.print_help()
usage: [-h] [--k] [--no-k]

optional arguments:
  -h, --help  show this help message and exit
  --k         enable k (default: False)
  --no-k      disable k
```


## Commentary (optional)

First: I'm not yet quite comfortable enough with the codebase to be sure this is all done the happiest way possible, so feedback is very much encouraged. I just set this all up for the first time this morning. 😅  So, "Draft PR" FTW.

With python versions 3.9 and newer, argparse can automatically create the `--no-x` option and resolve this whole mess (using `add_argument('--someflag', action=argparse.BooleanOptionalAction)`), but presumably the intent is to maintain compatibility with earlier python versions.

In those earlier versions, setting the default of the false parameter to `argparse.SUPPRESS` suppresses output of a default in the help text without breaking the dest's default value as set in a previous call.  I learned while playing with this that `None` does not suppress output (it prints `default: None`). 🤷 By only showing dest's default on the "positive" argument, the end user doesn't have to do any mental gymnastics with double negatives or knowing the code's internals and, IMO, ends up less confused.

It appears (from [the argparse code](https://github.com/python/cpython/blob/11652ceccf1dbf9dd332ad52ac9bd41b4adff274/Lib/argparse.py#L1844-L1849)) that the first default added for a given destination is the one used for that destination, so defaults on subsequent arguments are redundant as far as assigning a value to the dest (same code block linked above), but still matter to the output formatter.  So, by adding the true argument first with the desired default value, this all continues working as expected.  See sketchy proof of concept output above.

## Checklist

- [x] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
