### PR TITLE
fix: show notification when delete experiment fail [DET-6811]

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
 [submodule "webui/react/src/shared"]
 	path = webui/react/src/shared
 	url = https://github.com/determined-ai/shared-web.git
-[submodule "webui/react/src/shared-web"]
-	path = webui/react/src/shared-web
-	url = https://github.com/determined-ai/shared-web.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "webui/react/src/shared"]
 	path = webui/react/src/shared
 	url = https://github.com/determined-ai/shared-web.git
+[submodule "webui/react/src/shared-web"]
+	path = webui/react/src/shared-web
+	url = https://github.com/determined-ai/shared-web.git

--- a/webui/react/src/components/TaskActionDropdown.tsx
+++ b/webui/react/src/components/TaskActionDropdown.tsx
@@ -58,7 +58,7 @@ const TaskActionDropdown: React.FC<Props> = ({
   ) ? deletableRunStates.has(task.state) : false;
 
   const { modalOpen: openModalDelete } = useModalExperimentDelete(
-    { experimentId: id, onClose: () => onComplete && onComplete(Action.Delete) },
+    { experimentId: id, onClose: () => onComplete?.(Action.Delete) },
   );
   const handleDeleteClick = useCallback(() => openModalDelete(), [ openModalDelete ]);
 

--- a/webui/react/src/components/TaskActionDropdown.tsx
+++ b/webui/react/src/components/TaskActionDropdown.tsx
@@ -3,14 +3,15 @@ import { isNumber } from 'util';
 import { ExclamationCircleOutlined } from '@ant-design/icons';
 import { Dropdown, Menu, Modal } from 'antd';
 import { MenuInfo } from 'rc-menu/lib/interface';
-import React, { PropsWithChildren } from 'react';
+import React, { PropsWithChildren, useCallback } from 'react';
 
 import Icon from 'components/Icon';
 import { cancellableRunStates, deletableRunStates, pausableRunStates,
   terminalRunStates } from 'constants/states';
+import useModalExperimentDelete from 'hooks/useModal/useModalExperimentDelete';
 import { paths } from 'routes/utils';
 import {
-  activateExperiment, archiveExperiment, cancelExperiment, deleteExperiment, killExperiment,
+  activateExperiment, archiveExperiment, cancelExperiment, killExperiment,
   killTask, openOrCreateTensorBoard, pauseExperiment, unarchiveExperiment,
 } from 'services/api';
 import {
@@ -55,6 +56,11 @@ const TaskActionDropdown: React.FC<Props> = ({
   const isDeletable = (
     isExperimentTask(task) && curUser && (curUser.isAdmin || curUser.username === task.username)
   ) ? deletableRunStates.has(task.state) : false;
+
+  const { modalOpen: openModalDelete } = useModalExperimentDelete(
+    { experimentId: id, onClose: () => onComplete && onComplete(Action.Delete) },
+  );
+  const handleDeleteClick = useCallback(() => openModalDelete(), [ openModalDelete ]);
 
   const handleMenuClick = async (params: MenuInfo): Promise<void> => {
     params.domEvent.stopPropagation();
@@ -121,19 +127,7 @@ const TaskActionDropdown: React.FC<Props> = ({
           break;
         case Action.Delete:
           if (!isExperiment) break;
-          Modal.confirm({
-            content: `
-            Are you sure you want to delete
-            experiment ${id}?
-          `,
-            icon: <ExclamationCircleOutlined />,
-            okText: 'Delete',
-            onOk: async () => {
-              await deleteExperiment({ experimentId: id });
-              if (onComplete) onComplete(action);
-            },
-            title: 'Confirm Experiment Deletion',
-          });
+          handleDeleteClick();
       }
     } catch (e) {
       handleError(e, {

--- a/webui/react/src/hooks/useModal/useModalExperimentDelete.tsx
+++ b/webui/react/src/hooks/useModal/useModalExperimentDelete.tsx
@@ -33,7 +33,7 @@ const useModalExperimentDelete = ({ experimentId, onClose }: Props): ModalHooks 
 
   const modalProps: ModalFuncProps = useMemo(() => {
     return {
-      content: 'Are you sure you want to delete\nthis experiment?',
+      content: `Are you sure you want to delete\n experiment ${experimentId}?`,
       icon: <ExclamationCircleOutlined />,
       okText: 'Delete',
       onOk: handleOk,

--- a/webui/react/src/hooks/useModal/useModalExperimentDelete.tsx
+++ b/webui/react/src/hooks/useModal/useModalExperimentDelete.tsx
@@ -39,7 +39,7 @@ const useModalExperimentDelete = ({ experimentId, onClose }: Props): ModalHooks 
       onOk: handleOk,
       title: 'Confirm Experiment Deletion',
     };
-  }, [ handleOk ]);
+  }, [ handleOk, experimentId ]);
 
   const modalOpen = useCallback((initialModalProps: ModalFuncProps = {}) => {
     openOrUpdate({ ...modalProps, ...initialModalProps });


### PR DESCRIPTION
## Description

When deleting experiment from experiment list and the action fails from server side error, fix notification to pop. 


## Test Plan

- Verify delete experiment function works as expected at experiment list page and experiment detail page. 
- Create server side error for `func (a *apiServer) DeleteExperiment` and verify delete experiment pops notification as expected. 
- As suggested by Trent, another way to create server side error during testing is to disconnect WIFI. 





