### PR TITLE
fix: Add Workspace and Project name params to experiment yaml

### DIFF
--- a/harness/determined/common/schemas/expconf/_gen.py
+++ b/harness/determined/common/schemas/expconf/_gen.py
@@ -1178,6 +1178,13 @@ schemas = {
             "default": {},
             "optionalRef": "http://determined.ai/schemas/expconf/v0/profiling.json"
         },
+        "project": {
+            "type": [
+                "string",
+                "null"
+            ],
+            "default": ""
+        },
         "records_per_epoch": {
             "type": [
                 "integer",
@@ -1232,6 +1239,13 @@ schemas = {
             ],
             "default": null,
             "optionalRef": "http://determined.ai/schemas/expconf/v0/tensorboard-storage.json"
+        },
+        "workspace": {
+            "type": [
+                "string",
+                "null"
+            ],
+            "default": ""
         }
     },
     "allOf": [

--- a/harness/determined/common/schemas/expconf/_v0.py
+++ b/harness/determined/common/schemas/expconf/_v0.py
@@ -942,12 +942,14 @@ class ExperimentConfigV0(schemas.SchemaBase):
     optimizations: Optional[OptimizationsConfigV0] = None
     perform_initial_validation: Optional[bool] = None
     profiling: Optional[ProfilingConfigV0] = None
+    project: Optional[str] = None
     records_per_epoch: Optional[int] = None
     reproducibility: Optional[ReproducibilityConfigV0] = None
     resources: Optional[ResourcesConfigV0] = None
     scheduling_unit: Optional[int] = None
     # security: Optional[SecurityConfigV0] = None
     # tensorboard_storage: Optional[TensorboardStorageConfigV0_Type] = None
+    workspace: Optional[str] = None
 
     @schemas.auto_init
     def __init__(
@@ -972,12 +974,14 @@ class ExperimentConfigV0(schemas.SchemaBase):
         optimizations: Optional[OptimizationsConfigV0] = None,
         perform_initial_validation: Optional[bool] = None,
         profiling: Optional[ProfilingConfigV0] = None,
+        project: Optional[str] = None,
         records_per_epoch: Optional[int] = None,
         reproducibility: Optional[ReproducibilityConfigV0] = None,
         resources: Optional[ResourcesConfigV0] = None,
         scheduling_unit: Optional[int] = None,
         # security: Optional[SecurityConfigV0] = None,
         # tensorboard_storage: Optional[TensorboardStorageConfigV0_Type] = None,
+        workspace: Optional[str] = None,
     ) -> None:
         pass
 

--- a/master/internal/core_experiment.go
+++ b/master/internal/core_experiment.go
@@ -352,8 +352,13 @@ func (m *Master) parseCreateExperiment(params *CreateExperimentParams, user *mod
 	taskSpec.UserSessionToken = token
 	taskSpec.Owner = user
 
-	if (config.Workspace() == "" && config.Project() != "") || (config.Workspace() != "" && config.Project() == "") {
-		return nil, false, nil, errors.New("Workspace and Project must both be included in config if one is provided")
+	if config.Workspace() == "" && config.Project() != "" {
+		return nil, false, nil,
+			errors.New("workspace and project must both be included in config if one is provided")
+	}
+	if config.Workspace() != "" && config.Project() == "" {
+		return nil, false, nil,
+			errors.New("workspace and project must both be included in config if one is provided")
 	}
 	projectID := 1
 	if config.Workspace() != "" && config.Project() != "" {

--- a/master/internal/db/postgres_experiments.go
+++ b/master/internal/db/postgres_experiments.go
@@ -41,7 +41,7 @@ func (db *PgDB) ProjectFromNames(workspaceName string, projectName string) (int,
 		return 1, err
 	}
 	if p.Id < 1 {
-		return 1, fmt.Errorf("Workspace and Project names did not match any known project.")
+		return 1, fmt.Errorf("workspace and project names did not match any known project")
 	}
 	return int(p.Id), nil
 }

--- a/master/internal/db/postgres_experiments.go
+++ b/master/internal/db/postgres_experiments.go
@@ -17,6 +17,8 @@ import (
 	"github.com/determined-ai/determined/master/pkg/schemas"
 	"github.com/determined-ai/determined/master/pkg/schemas/expconf"
 	"github.com/determined-ai/determined/proto/pkg/apiv1"
+	"github.com/determined-ai/determined/proto/pkg/projectv1"
+	"github.com/determined-ai/determined/proto/pkg/workspacev1"
 )
 
 const (
@@ -25,6 +27,24 @@ const (
 	max  = "max"
 	min  = "min"
 )
+
+// ProjectFromNames returns a project's ID if it exists in the given workspace.
+func (db *PgDB) ProjectFromNames(workspaceName string, projectName string) (int, error) {
+	w := workspacev1.Workspace{}
+	err := db.Query("get_workspace_from_name", &w, workspaceName)
+	if err != nil {
+		return 1, err
+	}
+	p := projectv1.Project{}
+	err = db.Query("get_project_from_name", &p, w.Id, projectName)
+	if err != nil {
+		return 1, err
+	}
+	if p.Id < 1 {
+		return 1, fmt.Errorf("Workspace and Project names did not match any known project.")
+	}
+	return int(p.Id), nil
+}
 
 // ExperimentLabelUsage returns a flattened and deduplicated list of all the
 // labels in use across all experiments.
@@ -699,10 +719,11 @@ func (db *PgDB) AddExperiment(experiment *model.Experiment) (err error) {
 		err := namedGet(tx, &experiment.ID, `
 	INSERT INTO experiments
 	(state, config, model_definition, start_time, end_time, archived, parent_id, progress,
-	 git_remote, git_commit, git_committer, git_commit_date, owner_id, original_config, notes, job_id)
+	 git_remote, git_commit, git_committer, git_commit_date, owner_id, original_config, notes, job_id,
+ 	project_id)
 	VALUES (:state, :config, :model_definition, :start_time, :end_time, :archived, :parent_id, 0,
 					:git_remote, :git_commit, :git_committer, :git_commit_date, :owner_id, :original_config,
-					:notes, :job_id)
+					:notes, :job_id, :project_id)
 	RETURNING id`, experiment)
 		if err != nil {
 			return errors.Wrapf(err, "error inserting experiment %v", *experiment)

--- a/master/pkg/model/experiment.go
+++ b/master/pkg/model/experiment.go
@@ -305,6 +305,7 @@ func NewExperiment(
 	archived bool,
 	gitRemote, gitCommit, gitCommitter *string,
 	gitCommitDate *time.Time,
+	projectID int,
 ) (*Experiment, error) {
 	if len(modelDefinitionBytes) == 0 {
 		return nil, errors.New("empty model definition")
@@ -327,6 +328,7 @@ func NewExperiment(
 		GitCommit:            gitCommit,
 		GitCommitter:         gitCommitter,
 		GitCommitDate:        gitCommitDate,
+		ProjectID:            projectID,
 	}, nil
 }
 

--- a/master/pkg/schemas/expconf/experiment_config.go
+++ b/master/pkg/schemas/expconf/experiment_config.go
@@ -35,6 +35,7 @@ type ExperimentConfigV0 struct {
 	RawOptimizations            *OptimizationsConfigV0      `json:"optimizations"`
 	RawPerformInitialValidation *bool                       `json:"perform_initial_validation"`
 	RawProfiling                *ProfilingConfigV0          `json:"profiling"`
+	RawProject                  *string                     `json:"project"`
 	RawRecordsPerEpoch          *int                        `json:"records_per_epoch"`
 	RawReproducibility          *ReproducibilityConfigV0    `json:"reproducibility"`
 	RawResources                *ResourcesConfigV0          `json:"resources"`
@@ -42,6 +43,7 @@ type ExperimentConfigV0 struct {
 	RawSearcher                 *SearcherConfigV0           `json:"searcher"`
 	RawSecurity                 *SecurityConfigV0           `json:"security,omitempty"`
 	RawTensorboardStorage       *TensorboardStorageConfigV0 `json:"tensorboard_storage,omitempty"`
+	RawWorkspace                *string                     `json:"workspace"`
 }
 
 // Unit implements the model.InUnits interface.

--- a/master/pkg/schemas/expconf/zgen_experiment_config_v0.go
+++ b/master/pkg/schemas/expconf/zgen_experiment_config_v0.go
@@ -193,6 +193,17 @@ func (e *ExperimentConfigV0) SetProfiling(val ProfilingConfigV0) {
 	e.RawProfiling = &val
 }
 
+func (e ExperimentConfigV0) Project() string {
+	if e.RawProject == nil {
+		panic("You must call WithDefaults on ExperimentConfigV0 before .Project")
+	}
+	return *e.RawProject
+}
+
+func (e *ExperimentConfigV0) SetProject(val string) {
+	e.RawProject = &val
+}
+
 func (e ExperimentConfigV0) RecordsPerEpoch() int {
 	if e.RawRecordsPerEpoch == nil {
 		panic("You must call WithDefaults on ExperimentConfigV0 before .RecordsPerEpoch")
@@ -262,6 +273,17 @@ func (e ExperimentConfigV0) TensorboardStorage() *TensorboardStorageConfigV0 {
 
 func (e *ExperimentConfigV0) SetTensorboardStorage(val *TensorboardStorageConfigV0) {
 	e.RawTensorboardStorage = val
+}
+
+func (e ExperimentConfigV0) Workspace() string {
+	if e.RawWorkspace == nil {
+		panic("You must call WithDefaults on ExperimentConfigV0 before .Workspace")
+	}
+	return *e.RawWorkspace
+}
+
+func (e *ExperimentConfigV0) SetWorkspace(val string) {
+	e.RawWorkspace = &val
 }
 
 func (e ExperimentConfigV0) ParsedSchema() interface{} {

--- a/master/pkg/schemas/zgen_schemas.go
+++ b/master/pkg/schemas/zgen_schemas.go
@@ -1105,6 +1105,13 @@ var (
             "default": {},
             "optionalRef": "http://determined.ai/schemas/expconf/v0/profiling.json"
         },
+        "project": {
+            "type": [
+                "string",
+                "null"
+            ],
+            "default": ""
+        },
         "records_per_epoch": {
             "type": [
                 "integer",
@@ -1159,6 +1166,13 @@ var (
             ],
             "default": null,
             "optionalRef": "http://determined.ai/schemas/expconf/v0/tensorboard-storage.json"
+        },
+        "workspace": {
+            "type": [
+                "string",
+                "null"
+            ],
+            "default": ""
         }
     },
     "allOf": [

--- a/master/static/srv/get_project_from_name.sql
+++ b/master/static/srv/get_project_from_name.sql
@@ -1,0 +1,3 @@
+SELECT p.id, p.name, p.description, p.immutable
+FROM projects p
+WHERE p.workspace_id = $1 AND p.name = $2;

--- a/master/static/srv/get_workspace_from_name.sql
+++ b/master/static/srv/get_workspace_from_name.sql
@@ -1,0 +1,3 @@
+SELECT w.id, w.name, w.archived, w.immutable
+FROM workspaces w
+WHERE w.name = $1;

--- a/schemas/expconf/v0/experiment.json
+++ b/schemas/expconf/v0/experiment.json
@@ -171,6 +171,13 @@
             "default": {},
             "optionalRef": "http://determined.ai/schemas/expconf/v0/profiling.json"
         },
+        "project": {
+            "type": [
+                "string",
+                "null"
+            ],
+            "default": ""
+        },
         "records_per_epoch": {
             "type": [
                 "integer",
@@ -225,6 +232,13 @@
             ],
             "default": null,
             "optionalRef": "http://determined.ai/schemas/expconf/v0/tensorboard-storage.json"
+        },
+        "workspace": {
+            "type": [
+                "string",
+                "null"
+            ],
+            "default": ""
         }
     },
     "allOf": [

--- a/schemas/test_cases/v0/experiment.yaml
+++ b/schemas/test_cases/v0/experiment.yaml
@@ -216,6 +216,8 @@
       smaller_is_better: true
       source_checkpoint_uuid: null
       source_trial_id: null
+    workspace: ''
+    project: ''
 
 - name: records_per_epoch conditional (valid)
   sane_as:


### PR DESCRIPTION
## Description

The YAML for an experiment loaded from the command line, forked from another experiment, etc. can include optional Workspace and Project parameters.  These should be the names of a current Workspace and nested Project.  If provided, the experiment should become associated with the Project.   If the named workspace/project is not found, or only one of the two parameters is provided, it should raise an error and prevent the experiment from being created or run.


## Checklist

- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.
