### PR TITLE
fix: use displayNames in ClusterHistoricalUsage

### DIFF
--- a/webui/react/src/pages/Cluster/ClusterHistoricalUsage.tsx
+++ b/webui/react/src/pages/Cluster/ClusterHistoricalUsage.tsx
@@ -2,8 +2,8 @@ import { Button, Col, Row } from 'antd';
 import dayjs from 'dayjs';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
-import { useStore } from 'contexts/Store';
 import Section from 'components/Section';
+import { useStore } from 'contexts/Store';
 import useResize from 'hooks/useResize';
 import useSettings from 'hooks/useSettings';
 import { getResourceAllocationAggregated } from 'services/api';

--- a/webui/react/src/pages/Cluster/ClusterHistoricalUsage.tsx
+++ b/webui/react/src/pages/Cluster/ClusterHistoricalUsage.tsx
@@ -2,6 +2,7 @@ import { Button, Col, Row } from 'antd';
 import dayjs from 'dayjs';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
+import { useStore } from 'contexts/Store';
 import Section from 'components/Section';
 import useResize from 'hooks/useResize';
 import useSettings from 'hooks/useSettings';
@@ -26,6 +27,7 @@ const ClusterHistoricalUsage: React.FC = () => {
   const [ isCsvModalVisible, setIsCsvModalVisible ] = useState<boolean>(false);
   const filterBarRef = useRef<HTMLDivElement>(null);
   const { settings, updateSettings } = useSettings<Settings>(settingsConfig);
+  const { users } = useStore();
 
   const filters = useMemo(() => {
     const filters: ClusterHistoricalUsageFiltersInterface = {
@@ -103,10 +105,10 @@ const ClusterHistoricalUsage: React.FC = () => {
       });
 
       setChartSeries(
-        mapResourceAllocationApiToChartSeries(res.resourceEntries, filters.groupBy),
+        mapResourceAllocationApiToChartSeries(res.resourceEntries, filters.groupBy, users),
       );
     })();
-  }, [ filters ]);
+  }, [ filters, users ]);
 
   return (
     <>

--- a/webui/react/src/pages/Cluster/utils.ts
+++ b/webui/react/src/pages/Cluster/utils.ts
@@ -1,10 +1,10 @@
 import { V1ResourceAllocationAggregatedEntry } from 'services/api-ts-sdk';
+import { DetailedUser } from 'types';
 import { sumArrays } from 'utils/array';
 import { secondToHour } from 'utils/datetime';
+import { getDisplayName } from 'utils/user';
 
 import { GroupBy } from './ClusterHistoricalUsage.settings';
-import { DetailedUser } from 'types';
-import { getDisplayName } from 'utils/user';
 
 export interface ResourceAllocationChartSeries {
   groupedBy: GroupBy,

--- a/webui/react/src/pages/Cluster/utils.ts
+++ b/webui/react/src/pages/Cluster/utils.ts
@@ -3,7 +3,7 @@ import { sumArrays } from 'utils/array';
 import { secondToHour } from 'utils/datetime';
 
 import { GroupBy } from './ClusterHistoricalUsage.settings';
-import { DetailedUser, User } from 'types';
+import { DetailedUser } from 'types';
 import { getDisplayName } from 'utils/user';
 
 export interface ResourceAllocationChartSeries {
@@ -19,7 +19,7 @@ export interface ResourceAllocationChartSeries {
 export const mapResourceAllocationApiToChartSeries = (
   apiRes: Array<V1ResourceAllocationAggregatedEntry>,
   grouping: GroupBy,
-  users: DetailedUser[] | User[],
+  users: DetailedUser[],
 ): ResourceAllocationChartSeries => {
   return {
     groupedBy: grouping,
@@ -36,7 +36,7 @@ export const mapResourceAllocationApiToChartSeries = (
 
 const mapPeriodToDisplayNames = (
   period: Record<string, number>,
-  users: DetailedUser[] | User[],
+  users: DetailedUser[],
 ): Record<string, number> => {
   const result:Record<string, number> = {};
   Object.keys(period).forEach(key => {


### PR DESCRIPTION
## Description

"Compute Hours by User" chart is not displaying `displayName` for users, still uses `username` only.

<img width="1486" alt="Screen Shot 2022-05-03 at 12 39 37 PM" src="https://user-images.githubusercontent.com/97752292/166553285-d4bdf3a3-ff41-4f6b-a53a-bf0ece8a454d.png">


## Test Plan

- [ ] make sure "Computer Hours by User" chart shows the display name if it exists


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
