### PR TITLE
chore: remove deprecated experimental custom reducer methods

### DIFF
--- a/docs/release-notes/4060-custom-reducers.txt
+++ b/docs/release-notes/4060-custom-reducers.txt
@@ -1,0 +1,8 @@
+:orphan:
+
+**Removed Features**
+
+-  The old experimental namespace methods for custom reducers in both PyTorchTrial and
+   EstimatorTrial have been removed. The experimental names were deprecated in 0.15.2 (April 2021)
+   when custom reducers were promoted to general availability. Any users who have not already
+   migrated to the non-experimental namespace for custom reducer methods must do so.

--- a/harness/determined/estimator/_estimator_context.py
+++ b/harness/determined/estimator/_estimator_context.py
@@ -1,6 +1,6 @@
 import inspect
 import logging
-from typing import Any, Callable, List, Tuple, Union, cast
+from typing import Any, Callable, Union, cast
 
 import tensorflow as tf
 
@@ -46,7 +46,6 @@ class EstimatorTrialContext(det.TrialContext, estimator._EstimatorReducerContext
 
         self.experimental = EstimatorExperimentalContext(
             self.env,
-            self,
             self.distributed,
             self._per_slot_batch_size,
         )
@@ -164,29 +163,7 @@ class EstimatorExperimentalContext(_data_layer.DataLayerContext):
     def __init__(
         self,
         env: det.EnvContext,
-        parent: EstimatorTrialContext,
         distributed_context: _core.DistributedContext,
         per_slot_batch_size: int,
     ) -> None:
         super().__init__(env, distributed_context, per_slot_batch_size)
-        self._parent = parent
-
-    @util.deprecated(
-        "context.experimental.allgather_metrics() is deprecated since 0.15.2 and will be removed "
-        "in a future version.  It is not intended to have a replacement; please contact Determined "
-        "if you depend on this experimental method."
-    )
-    def allgather_metrics(self, metrics: Any) -> List:
-        return self._parent._allgather_fn(metrics)
-
-    @util.deprecated(
-        "context.experimental.make_metric() is deprecated since 0.15.2 and will be removed in a "
-        "future version; use context.make_metric() directly."
-    )
-    def make_metric(
-        self,
-        metric: Any,
-        reducer: Union[Callable[[List[Any]], Any], "estimator.MetricReducer"],
-        numpy_dtype: Any,
-    ) -> Tuple[tf.Operation, tf.Operation]:
-        return self._parent.make_metric(metric, reducer, numpy_dtype)

--- a/harness/determined/pytorch/_experimental.py
+++ b/harness/determined/pytorch/_experimental.py
@@ -1,7 +1,5 @@
 import logging
-from typing import Any, Callable, Dict, Optional, Union, cast
-
-from determined import pytorch, util
+from typing import Any
 
 # AMP is only available in PyTorch 1.6+
 try:
@@ -80,36 +78,3 @@ class PyTorchExperimentalContext:
         """
         self._auto_to_device = False
         logging.info("disabled automatically moving data to device")
-
-    @util.deprecated(
-        "context.experimental.reset_reducers() is deprecated since 0.15.2 and will be removed in a "
-        "future version; use context.reset_reducers() directly."
-    )
-    def reset_reducers(self) -> None:
-        self._parent.reset_reducers()
-
-    @util.deprecated(
-        "context.experimental.wrap_reducer() is deprecated since 0.15.2 and will be removed in a "
-        "future version; use context.wrap_reducer() directly."
-    )
-    def wrap_reducer(
-        self,
-        reducer: Union[Callable, pytorch.MetricReducer],
-        name: Optional[str] = None,
-        for_training: bool = True,
-        for_validation: bool = True,
-    ) -> pytorch.MetricReducer:
-        return cast(
-            pytorch.MetricReducer,
-            self._parent.wrap_reducer(reducer, name, for_training, for_validation),
-        )
-
-    @util.deprecated(
-        "context.experimental.reduce_metrics() is deprecated since 0.15.2 and will be removed in a "
-        "future version; use context.reduce_metrics() directly."
-    )
-    def reduce_metrics(self, for_training: bool) -> Dict[str, Any]:
-        return cast(
-            dict,
-            self._parent.reduce_metrics(for_training),
-        )

--- a/harness/determined/util.py
+++ b/harness/determined/util.py
@@ -14,8 +14,7 @@ import shutil
 import socket
 import time
 import uuid
-import warnings
-from typing import Any, Callable, Dict, List, Optional, Set, SupportsFloat, Tuple, TypeVar, cast
+from typing import Any, Callable, Dict, List, Optional, Set, SupportsFloat, Tuple, cast
 
 import determined as det
 from determined import constants
@@ -224,20 +223,6 @@ def filter_duplicates(
             duplicates.add(item)
         last_item = item
     return duplicates
-
-
-T = TypeVar("T", bound=Callable[..., Any])
-
-
-def deprecated(msg: str) -> Callable[[T], T]:
-    def make_wrapper(fn: T) -> T:
-        def wrapper(*arg: List, **kwarg: Dict) -> Any:
-            warnings.warn(msg, FutureWarning)
-            return fn(*arg, **kwarg)
-
-        return cast(T, wrapper)
-
-    return make_wrapper
 
 
 def humanize_float(n: float) -> float:


### PR DESCRIPTION
When custom reducers were promoted from experimental to GA in 0.15.2, we
left forward references in the old experimental namespace.  This PR
cleans those up.