### PR TITLE
chore: remove det.pytorch.reset_parameters()

### DIFF
--- a/docs/release-notes/4066-reset-params.txt
+++ b/docs/release-notes/4066-reset-params.txt
@@ -1,0 +1,5 @@
+:orphan:
+
+**Removed Features**
+
+-  Remove the ``det.pytorch.reset_parameters()`` call, which was deprecated in 0.12.13 (Aug 2020).

--- a/harness/determined/pytorch/__init__.py
+++ b/harness/determined/pytorch/__init__.py
@@ -25,5 +25,5 @@ from determined.pytorch._metric_utils import (
 )
 from determined.pytorch._experimental import PyTorchExperimentalContext
 from determined.pytorch._pytorch_context import PyTorchTrialContext
-from determined.pytorch._pytorch_trial import PyTorchTrial, PyTorchTrialController, reset_parameters
+from determined.pytorch._pytorch_trial import PyTorchTrial, PyTorchTrialController
 from determined.pytorch._load import load_trial_from_checkpoint_path

--- a/harness/determined/pytorch/_pytorch_trial.py
+++ b/harness/determined/pytorch/_pytorch_trial.py
@@ -1070,25 +1070,3 @@ class PyTorchTrial(det.Trial):
             batch (Any): input training or validation data batch object.
         """
         return pytorch.data_length(batch)
-
-
-def reset_parameters(model: torch.nn.Module) -> None:
-    """
-    .. warning::
-        ``det.pytorch.reset_parameters()`` is deprecated and should not be called. For custom
-        nn.Modules which do need a call to reset_parameters(), it is recommended to call
-        self.reset_parameters() directly in their __init__() function, as is standard in all
-        built-in nn.Modules.
-
-    Recursively calls ``reset_parameters()`` for all modules.
-    """
-    logging.warning(
-        "det.pytorch.reset_parameters() is deprecated and should not be called.  For custom "
-        "nn.Modules which do need a call to reset_parameters(), it is recommended to call "
-        "self.reset_parameters() directly in their __init__() function, as is standard in all "
-        "built-in nn.Modules."
-    )
-    for _, module in model.named_modules():
-        reset_params = getattr(module, "reset_parameters", None)
-        if callable(reset_params):
-            reset_params()


### PR DESCRIPTION
reset_parameters was deprecated in 0.12.13 (Aug 2020).