### PR TITLE
perf: improve plan for proto_get_trial_plus.sql

### DIFF
--- a/master/static/migrations/20220504154053_add-checkpoints-v2-steps-completed-index.tx.down.sql
+++ b/master/static/migrations/20220504154053_add-checkpoints-v2-steps-completed-index.tx.down.sql
@@ -1,0 +1,2 @@
+-- This change wasn't caught on a version boundary; if a version downgrade is run, the down
+-- migration prior to us will also run, and it runs a delete cascade that will drop all our stuff.

--- a/master/static/migrations/20220504154053_add-checkpoints-v2-steps-completed-index.tx.up.sql
+++ b/master/static/migrations/20220504154053_add-checkpoints-v2-steps-completed-index.tx.up.sql
@@ -1,0 +1,93 @@
+DROP INDEX ix_checkpoints_v2_task_id;
+
+CREATE INDEX ix_checkpoints_v2_task_id_steps_completed
+    ON public.checkpoints_v2
+    USING btree (task_id, (metadata->>'steps_completed'));
+
+CREATE OR REPLACE VIEW public.checkpoints_old_view AS
+    SELECT
+        c.id AS id,
+        c.uuid AS uuid,
+        t.task_id,
+        CASE
+        WHEN t.task_id is NULL THEN
+            NULL
+        ELSE
+            t.task_id || '.' || c.trial_run_id
+        END allocation_id,
+        c.end_time as report_time,
+        c.state,
+        c.resources,
+        -- construct a metadata json from the user's metadata plus our training-specific fields that the
+        -- TrialControllers inject when creating checkpoints.  Those values used to be "system" values,
+        -- but since the release of Core API, the TrialControllers are no longer part of the system
+        -- proper but are considered userspace tools.
+        jsonb_build_object(
+            'steps_completed', c.total_batches,
+            'framework', c.framework,
+            'format', c.format,
+            'determined_version', c.determined_version,
+            'experiment_config', e.config,
+            'hparams', t.hparams
+        ) || COALESCE(c.metadata, '{}'::jsonb) AS metadata,
+        t.id AS trial_id,
+        e.id AS experiment_id,
+        e.config AS experiment_config,
+        t.hparams AS hparams,
+        s.metrics AS training_metrics,
+        v.metrics->'validation_metrics' AS validation_metrics,
+        (v.metrics->'validation_metrics'->>(e.config->'searcher'->>'metric'))::float8 AS searcher_metric,
+        c.total_batches as steps_completed,
+        1 as checkpoint_version
+    FROM raw_checkpoints AS c
+    LEFT JOIN trials AS t on c.trial_id = t.id
+    LEFT JOIN experiments AS e on t.experiment_id = e.id
+    LEFT JOIN raw_steps AS s ON (
+        -- Hint to the query planner to use the matching index.
+        s.trial_id = t.id
+        AND s.trial_run_id = c.trial_run_id
+        AND s.total_batches = c.total_batches
+    )
+    LEFT JOIN raw_validations AS v ON (
+        -- Hint to the query planner to use the matching index.
+        v.trial_id = c.trial_id
+        AND v.trial_run_id = c.trial_run_id
+        AND v.total_batches = c.total_batches
+    )
+    -- Avoiding the steps and validation view causes Postgres to not "Materialize" in this join.
+    WHERE s.archived IS NULL OR s.archived = false
+      AND v.archived IS NULL OR v.archived = false;
+
+CREATE OR REPLACE VIEW public.checkpoints_new_view AS
+    SELECT
+        c.id AS id,
+        c.uuid AS uuid,
+        c.task_id,
+        c.allocation_id,
+        c.report_time,
+        c.state,
+        c.resources,
+        c.metadata,
+        t.id AS trial_id,
+        e.id AS experiment_id,
+        e.config AS experiment_config,
+        t.hparams AS hparams,
+        s.metrics AS training_metrics,
+        v.metrics->'validation_metrics' AS validation_metrics,
+        (v.metrics->'validation_metrics'->>(e.config->'searcher'->>'metric'))::float8 AS searcher_metric,
+        CAST(c.metadata->>'steps_completed' AS int) as steps_completed,
+        2 AS checkpoint_version
+    FROM checkpoints_v2 AS c
+    LEFT JOIN trials AS t on c.task_id = t.task_id
+    LEFT JOIN experiments AS e on t.experiment_id = e.id
+    LEFT JOIN raw_validations AS v on CAST(c.metadata->>'steps_completed' AS int) = v.total_batches and t.id = v.trial_id
+    LEFT JOIN raw_steps AS s on CAST(c.metadata->>'steps_completed' AS int) = s.total_batches and t.id = s.trial_id
+    -- avoiding the steps view causes Postgres to not "Materialize" in this join.
+    WHERE s.archived IS NULL OR s.archived = false
+      AND v.archived IS NULL OR v.archived = false;
+
+-- checkpoints_view returns all checkpoints in the current format.
+CREATE OR REPLACE VIEW public.checkpoints_view AS
+    SELECT * FROM checkpoints_new_view
+    UNION ALL
+    SELECT * FROM checkpoints_old_view;

--- a/master/static/srv/proto_get_trials_plus.sql
+++ b/master/static/srv/proto_get_trials_plus.sql
@@ -81,20 +81,49 @@ best_checkpoint AS (
     c.resources,
     'STATE_' || c.state AS state
   FROM (
-      SELECT c.*,
-        ROW_NUMBER() OVER(
-          PARTITION BY v.trial_id
-          ORDER BY v.signed_searcher_metric ASC
-        ) AS rank
-      FROM trial_validations v
-      INNER JOIN checkpoints_view c ON (
-        c.steps_completed = v.total_batches
-        AND c.trial_id = v.trial_id
-      )
-      WHERE c.state = 'COMPLETED'
+    -- Using `public.checkpoints_view` directly results in performance regressions
+    -- identical to those described below.
+    SELECT c.*,
+      ROW_NUMBER() OVER(
+        PARTITION BY c.trial_id
+        ORDER BY c.signed_searcher_metric ASC
+      ) AS rank
+    FROM (
+      SELECT old_c.*
+      FROM (
+          SELECT c.*, v.signed_searcher_metric,
+            ROW_NUMBER() OVER(
+              PARTITION BY v.trial_id
+              ORDER BY v.signed_searcher_metric ASC
+            ) AS rank
+          FROM trial_validations v
+          INNER JOIN checkpoints_old_view c ON (
+            c.steps_completed = v.total_batches
+            AND c.trial_id = v.trial_id
+          )
+          WHERE c.state = 'COMPLETED'
+        ) old_c
+      WHERE old_c.rank = 1
+      UNION ALL
+      SELECT new_c.*
+      FROM (
+          SELECT c.*, v.signed_searcher_metric,
+            ROW_NUMBER() OVER(
+              PARTITION BY v.trial_id
+              ORDER BY v.signed_searcher_metric ASC
+            ) AS rank
+          FROM trial_validations v
+          INNER JOIN checkpoints_new_view c ON (
+            c.steps_completed = v.total_batches
+            AND c.trial_id = v.trial_id
+          )
+          WHERE c.state = 'COMPLETED'
+        ) new_c
+      WHERE new_c.rank = 1
     ) c
-  WHERE c.rank = 1
-),
+    WHERE c.rank = 1
+  ) c
+,
 latest_training AS (
   SELECT s.trial_id,
     s.total_batches,
@@ -118,7 +147,7 @@ SELECT
   t.start_time,
   t.end_time,
   t.hparams,
-  ckpt.uuid AS warm_start_checkpoint_uuid,
+  coalesce(new_ckpt.uuid, old_ckpt.uuid) AS warm_start_checkpoint_uuid,
   t.task_id,
   (
     SELECT s.total_batches
@@ -143,7 +172,10 @@ FROM searcher_info
   LEFT JOIN best_validation bv ON bv.trial_id = searcher_info.trial_id
   LEFT JOIN latest_validation lv ON lv.trial_id = searcher_info.trial_id
   LEFT JOIN best_checkpoint bc ON bc.trial_id = searcher_info.trial_id
-  LEFT JOIN checkpoints_view ckpt ON ckpt.id = t.warm_start_checkpoint_id
+  -- Using `public.checkpoints_view` directly here results in the query planner being unable to push
+  -- filters into the union all, resulting in costly scans of steps, validations and checkpoints.
+  LEFT JOIN checkpoints_old_view old_ckpt ON old_ckpt.id = t.warm_start_checkpoint_id
+  LEFT JOIN checkpoints_new_view new_ckpt ON new_ckpt.id = t.warm_start_checkpoint_id
   LEFT JOIN latest_training lt ON lt.trial_id = searcher_info.trial_id
   -- Return the same ordering of IDs given by $1.
   JOIN (


### PR DESCRIPTION
## Description
Ran into some fairly serious perf issues without this index due to joins, wheres and sorts using this fields.
<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At a minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan
- [x] test for perf improvement
<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions about this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)
Before
```
   QUERY PLAN                                                                                                                                                                                                                                                         
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Nested Loop Left Join  (cost=281552.23..283718.73 rows=1 width=532) (actual time=4163.052..4184.213 rows=1 loops=1)
   Join Filter: (bc.trial_id = searcher_info.trial_id)
   CTE searcher_info
     ->  Nested Loop  (cost=2.33..782.42 rows=100 width=40) (actual time=0.108..0.114 rows=1 loops=1)
           ->  Nested Loop  (cost=2.06..741.33 rows=100 width=8) (actual time=0.042..0.046 rows=1 loops=1)
                 ->  HashAggregate  (cost=1.77..2.77 rows=100 width=4) (actual time=0.013..0.015 rows=1 loops=1)
                       Group Key: unnest('{24348}'::integer[])
                       ->  ProjectSet  (cost=0.00..0.52 rows=100 width=4) (actual time=0.006..0.009 rows=1 loops=1)
                             ->  Result  (cost=0.00..0.01 rows=1 width=0) (actual time=0.001..0.002 rows=1 loops=1)
                 ->  Index Scan using trials_pkey on trials t_3  (cost=0.29..7.38 rows=1 width=8) (actual time=0.024..0.024 rows=1 loops=1)
                       Index Cond: (id = (unnest('{24348}'::integer[])))
           ->  Index Scan using experiments_pkey on experiments e_2  (cost=0.28..0.39 rows=1 width=822) (actual time=0.008..0.008 rows=1 loops=1)
                 Index Cond: (id = t_3.experiment_id)
           SubPlan 1
             ->  Result  (cost=0.00..0.02 rows=1 width=4) (actual time=0.016..0.016 rows=1 loops=1)
   CTE trial_validations
     ->  Nested Loop  (cost=0.29..954.11 rows=309 width=167) (actual time=0.025..0.027 rows=1 loops=1)
           ->  CTE Scan on searcher_info searcher_info_1  (cost=0.00..2.00 rows=100 width=40) (actual time=0.001..0.001 rows=1 loops=1)
           ->  Index Scan using ix_validations_trial_id on raw_validations raw_validations_2  (cost=0.29..9.44 rows=3 width=159) (actual time=0.013..0.013 rows=1 loops=1)
                 Index Cond: (trial_id = searcher_info_1.trial_id)
                 Filter: ((NOT archived) AND (state = 'COMPLETED'::validation_state) AND (((metrics -> 'validation_metrics'::text) ->> searcher_info_1.metric_name) IS NOT NULL))
   CTE best_validation
     ->  Hash Join  (cost=29.03..31.42 rows=1 width=112) (actual time=0.090..0.094 rows=1 loops=1)
           Hash Cond: (searcher_info_2.trial_id = v.trial_id)
           ->  CTE Scan on searcher_info searcher_info_2  (cost=0.00..2.00 rows=100 width=4) (actual time=0.000..0.001 rows=1 loops=1)
           ->  Hash  (cost=29.00..29.00 rows=2 width=52) (actual time=0.054..0.057 rows=1 loops=1)
                 Buckets: 1024  Batches: 1  Memory Usage: 9kB
                 ->  Subquery Scan on v  (cost=18.96..29.00 rows=2 width=52) (actual time=0.051..0.054 rows=1 loops=1)
                       Filter: (v.rank = 1)
                       ->  WindowAgg  (cost=18.96..25.14 rows=309 width=68) (actual time=0.049..0.051 rows=1 loops=1)
                             ->  Sort  (cost=18.96..19.73 rows=309 width=60) (actual time=0.040..0.041 rows=1 loops=1)
                                   Sort Key: v_1.trial_id, v_1.signed_searcher_metric
                                   Sort Method: quicksort  Memory: 25kB
                                   ->  CTE Scan on trial_validations v_1  (cost=0.00..6.18 rows=309 width=60) (actual time=0.028..0.029 rows=1 loops=1)
   CTE latest_validation
     ->  Hash Join  (cost=29.03..31.42 rows=1 width=112) (actual time=0.038..0.044 rows=1 loops=1)
           Hash Cond: (searcher_info_3.trial_id = v_2.trial_id)
           ->  CTE Scan on searcher_info searcher_info_3  (cost=0.00..2.00 rows=100 width=4) (actual time=0.001..0.002 rows=1 loops=1)
           ->  Hash  (cost=29.00..29.00 rows=2 width=52) (actual time=0.021..0.024 rows=1 loops=1)
                 Buckets: 1024  Batches: 1  Memory Usage: 9kB
                 ->  Subquery Scan on v_2  (cost=18.96..29.00 rows=2 width=52) (actual time=0.018..0.021 rows=1 loops=1)
                       Filter: (v_2.rank = 1)
                       ->  WindowAgg  (cost=18.96..25.14 rows=309 width=68) (actual time=0.016..0.018 rows=1 loops=1)
                             ->  Sort  (cost=18.96..19.73 rows=309 width=52) (actual time=0.013..0.014 rows=1 loops=1)
                                   Sort Key: v_3.trial_id, v_3.end_time DESC
                                   Sort Method: quicksort  Memory: 25kB
                                   ->  CTE Scan on trial_validations v_3  (cost=0.00..6.18 rows=309 width=52) (actual time=0.001..0.002 rows=1 loops=1)
   CTE best_checkpoint
     ->  Subquery Scan on c_2  (cost=125755.38..125760.85 rows=1 width=112) (actual time=1844.831..1856.115 rows=1 loops=1)
           Filter: (c_2.rank = 1)
           ->  WindowAgg  (cost=125755.38..125758.74 rows=168 width=336) (actual time=1844.823..1856.105 rows=1 loops=1)
                 ->  Sort  (cost=125755.38..125755.80 rows=168 width=80) (actual time=1844.813..1856.093 rows=1 loops=1)
                       Sort Key: v_4.trial_id, v_4.signed_searcher_metric
                       Sort Method: quicksort  Memory: 25kB
                       ->  Hash Join  (cost=122763.19..125749.17 rows=168 width=80) (actual time=1844.644..1856.077 rows=1 loops=1)
                             Hash Cond: (("*SELECT* 1_1".steps_completed = v_4.total_batches) AND ("*SELECT* 1_1".trial_id = v_4.trial_id))
                             ->  Unique  (cost=122752.37..123729.05 rows=21704 width=316) (actual time=1765.224..1851.322 rows=21449 loops=1)
                                   ->  Sort  (cost=122752.37..122806.63 rows=21704 width=316) (actual time=1765.221..1828.297 rows=21449 loops=1)
                                         Sort Key: (("*SELECT* 1_1".id)::bigint), "*SELECT* 1_1".uuid, "*SELECT* 1_1".task_id, "*SELECT* 1_1".allocation_id, "*SELECT* 1_1".report_time, "*SELECT* 1_1".state, "*SELECT* 1_1".resources, "*SELECT* 1_1".metadata, "*SELECT* 1_1".trial_id, "*SELECT* 1_1".experiment_id, "*SELECT* 1_1".experiment_config, "*SELECT* 1_1".hparams, "*SELECT* 1_1".training_metrics, "*SELECT* 1_1".validation_metrics, "*SELECT* 1_1".searcher_metric, "*SELECT* 1_1".steps_completed, (1)
                                         Sort Method: external merge  Disk: 118400kB
                                         ->  Append  (cost=21016.37..117997.07 rows=21704 width=316) (actual time=317.043..1279.272 rows=21449 loops=1)
                                               ->  Subquery Scan on "*SELECT* 1_1"  (cost=21016.37..112649.67 rows=21614 width=2862) (actual time=317.041..1243.336 rows=21357 loops=1)
                                                     ->  Gather  (cost=21016.37..112379.50 rows=21614 width=2858) (actual time=317.038..1233.187 rows=21357 loops=1)
                                                           Workers Planned: 1
                                                           Workers Launched: 1
                                                           ->  Hash Left Join  (cost=20016.37..109218.10 rows=12714 width=2858) (actual time=316.245..1234.277 rows=10678 loops=2)
                                                                 Hash Cond: (t_4.experiment_id = e_3.id)
                                                                 ->  Nested Loop Left Join  (cost=19437.01..108192.07 rows=12714 width=2115) (actual time=313.647..460.773 rows=10678 loops=2)
                                                                       Filter: ((s_2.archived IS NULL) OR (NOT s_2.archived))
                                                                       ->  Parallel Hash Left Join  (cost=19436.58..22452.09 rows=12801 width=850) (actual time=313.594..340.221 rows=10674 loops=2)
                                                                             Hash Cond: (c_3.trial_id = t_4.id)
                                                                             ->  Merge Left Join  (cost=15910.13..16572.03 rows=12801 width=509) (actual time=163.707..235.877 rows=10674 loops=2)
                                                                                   Merge Cond: ((c_3.trial_id = raw_validations_3.trial_id) AND (c_3.total_batches = raw_validations_3.total_batches))
                                                                                   ->  Sort  (cost=4911.41..4943.42 rows=12801 width=370) (actual time=37.272..43.798 rows=10674 loops=2)
                                                                                         Sort Key: c_3.trial_id, c_3.total_batches
                                                                                         Sort Method: external merge  Disk: 4848kB
                                                                                         Worker 0:  Sort Method: external merge  Disk: 3152kB
                                                                                         ->  Parallel Seq Scan on raw_checkpoints c_3  (cost=0.00..1847.13 rows=12801 width=370) (actual time=0.013..9.701 rows=10674 loops=2)
                                                                                               Filter: (state = 'COMPLETED'::checkpoint_state)
                                                                                               Rows Removed by Filter: 3682
                                                                                   ->  Materialize  (cost=10998.72..11273.18 rows=54893 width=147) (actual time=126.410..163.213 rows=55776 loops=2)
                                                                                         ->  Sort  (cost=10998.72..11135.95 rows=54893 width=147) (actual time=126.402..150.738 rows=55776 loops=2)
                                                                                               Sort Key: raw_validations_3.trial_id, raw_validations_3.total_batches
                                                                                               Sort Method: external merge  Disk: 8488kB
                                                                                               Worker 0:  Sort Method: external merge  Disk: 8488kB
                                                                                               ->  Seq Scan on raw_validations raw_validations_3  (cost=0.00..2547.45 rows=54893 width=147) (actual time=0.040..28.815 rows=55916 loops=2)
                                                                                                     Filter: (NOT archived)
                                                                                                     Rows Removed by Filter: 247
                                                                             ->  Parallel Hash  (cost=2703.31..2703.31 rows=14331 width=341) (actual time=21.121..21.121 rows=12192 loops=2)
                                                                                   Buckets: 16384  Batches: 4  Memory Usage: 2464kB
                                                                                   ->  Parallel Seq Scan on trials t_4  (cost=0.00..2703.31 rows=14331 width=341) (actual time=0.014..7.479 rows=12192 loops=2)
                                                                       ->  Index Scan using steps_trial_id_run_id_total_batches_unique on raw_steps s_2  (cost=0.42..6.69 rows=1 width=1278) (actual time=0.009..0.010 rows=1 loops=21349)
                                                                             Index Cond: ((c_3.trial_id = trial_id) AND (c_3.total_batches = total_batches))
                                                                 ->  Hash  (cost=559.16..559.16 rows=1616 width=822) (actual time=2.450..2.450 rows=1618 loops=2)
                                                                       Buckets: 2048  Batches: 1  Memory Usage: 1368kB
                                                                       ->  Seq Scan on experiments e_3  (cost=0.00..559.16 rows=1616 width=822) (actual time=0.019..1.287 rows=1618 loops=2)
                                               ->  Nested Loop Left Join  (cost=25.94..5237.98 rows=90 width=3285) (actual time=0.349..31.548 rows=92 loops=1)
                                                     Join Filter: (((c_4.metadata ->> 'steps_completed'::text))::integer = raw_validations_4.total_batches)
                                                     Rows Removed by Join Filter: 62
                                                     ->  Nested Loop Left Join  (cost=25.65..4888.66 rows=90 width=3237) (actual time=0.270..28.937 rows=92 loops=1)
                                                           ->  Nested Loop Left Join  (cost=25.37..4640.51 rows=90 width=2419) (actual time=0.235..28.587 rows=92 loops=1)
                                                                 Filter: ((s_3.archived IS NULL) OR (NOT s_3.archived))
                                                                 ->  Hash Right Join  (cost=24.94..3804.00 rows=91 width=1150) (actual time=0.203..21.577 rows=92 loops=1)
                                                                       Hash Cond: (t_5.task_id = c_4.task_id)
                                                                       ->  Seq Scan on trials t_5  (cost=0.00..2803.63 rows=24363 width=341) (actual time=0.011..14.781 rows=24383 loops=1)
                                                                       ->  Hash  (cost=23.80..23.80 rows=91 width=827) (actual time=0.167..0.168 rows=92 loops=1)
                                                                             Buckets: 1024  Batches: 1  Memory Usage: 98kB
                                                                             ->  Seq Scan on checkpoints_v2 c_4  (cost=0.00..23.80 rows=91 width=827) (actual time=0.015..0.117 rows=92 loops=1)
                                                                                   Filter: (state = 'COMPLETED'::checkpoint_state)
                                                                                   Rows Removed by Filter: 52
                                                                 ->  Index Scan using steps_trial_id_run_id_total_batches_unique on raw_steps s_3  (cost=0.43..9.18 rows=1 width=1278) (actual time=0.074..0.074 rows=1 loops=92)
                                                                       Index Cond: ((t_5.id = trial_id) AND (((c_4.metadata ->> 'steps_completed'::text))::integer = total_batches))
                                                           ->  Index Scan using experiments_pkey on experiments e_4  (cost=0.28..2.76 rows=1 width=822) (actual time=0.003..0.003 rows=1 loops=92)
                                                                 Index Cond: (t_5.experiment_id = id)
                                                     ->  Index Scan using ix_validations_trial_id on raw_validations raw_validations_4  (cost=0.29..3.80 rows=3 width=147) (actual time=0.003..0.004 rows=1 loops=92)
                                                           Index Cond: (t_5.id = trial_id)
                                                           Filter: (NOT archived)
                             ->  Hash  (cost=6.18..6.18 rows=309 width=16) (actual time=0.003..0.004 rows=1 loops=1)
                                   Buckets: 1024  Batches: 1  Memory Usage: 9kB
                                   ->  CTE Scan on trial_validations v_4  (cost=0.00..6.18 rows=309 width=16) (actual time=0.001..0.001 rows=1 loops=1)
   ->  Nested Loop Left Join  (cost=153992.00..155792.04 rows=1 width=456) (actual time=2317.305..2327.157 rows=1 loops=1)
         Join Filter: (lv.trial_id = searcher_info.trial_id)
         ->  Nested Loop Left Join  (cost=153992.00..155792.01 rows=1 width=428) (actual time=2317.257..2327.102 rows=1 loops=1)
               Join Filter: (bv.trial_id = searcher_info.trial_id)
               ->  Nested Loop  (cost=153992.00..155791.98 rows=1 width=400) (actual time=2317.155..2326.996 rows=1 loops=1)
                     Join Filter: (t.id = unnest.unnest)
                     ->  Function Scan on unnest  (cost=0.00..1.00 rows=100 width=12) (actual time=0.007..0.008 rows=1 loops=1)
                     ->  Materialize  (cost=153992.00..155641.22 rows=100 width=392) (actual time=2317.145..2326.983 rows=1 loops=1)
                           ->  Merge Right Join  (cost=153992.00..155640.72 rows=100 width=392) (actual time=2317.143..2326.979 rows=1 loops=1)
                                 Merge Cond: ((("*SELECT* 1".id)::bigint) = t.warm_start_checkpoint_id)
                                 ->  Unique  (cost=153248.18..154537.97 rows=28662 width=316) (actual time=2317.006..2326.837 rows=1 loops=1)
                                       ->  Sort  (cost=153248.18..153319.83 rows=28662 width=316) (actual time=2317.003..2326.833 rows=1 loops=1)
                                             Sort Key: (("*SELECT* 1".id)::bigint), "*SELECT* 1".uuid, "*SELECT* 1".task_id, "*SELECT* 1".allocation_id, "*SELECT* 1".report_time, "*SELECT* 1".state, "*SELECT* 1".resources, "*SELECT* 1".metadata, "*SELECT* 1".trial_id, "*SELECT* 1".experiment_id, "*SELECT* 1".experiment_config, "*SELECT* 1".hparams, "*SELECT* 1".training_metrics, "*SELECT* 1".validation_metrics, "*SELECT* 1".searcher_metric, "*SELECT* 1".steps_completed, (1)
                                             Sort Method: external merge  Disk: 159352kB
                                             ->  Append  (cost=21983.44..146912.21 rows=28662 width=316) (actual time=370.698..1618.561 rows=28866 loops=1)
                                                   ->  Subquery Scan on "*SELECT* 1"  (cost=21983.44..140697.62 rows=28519 width=2862) (actual time=370.696..1585.670 rows=28722 loops=1)
                                                         ->  Gather  (cost=21983.44..140341.13 rows=28519 width=2858) (actual time=370.693..1571.896 rows=28722 loops=1)
                                                               Workers Planned: 1
                                                               Workers Launched: 1
                                                               ->  Hash Left Join  (cost=20983.44..136489.23 rows=16776 width=2858) (actual time=370.183..1577.453 rows=14361 loops=2)
                                                                     Hash Cond: (t_1.experiment_id = e.id)
                                                                     ->  Nested Loop Left Join  (cost=20404.08..135320.50 rows=16776 width=2115) (actual time=367.027..581.637 rows=14361 loops=2)
                                                                           Filter: ((s.archived IS NULL) OR (NOT s.archived))
                                                                           Rows Removed by Filter: 0
                                                                           ->  Parallel Hash Left Join  (cost=20403.66..24027.15 rows=16891 width=850) (actual time=366.957..401.876 rows=14357 loops=2)
                                                                                 Hash Cond: (c.trial_id = t_1.id)
                                                                                 ->  Merge Left Join  (cost=16877.21..17600.35 rows=16891 width=509) (actual time=217.095..283.987 rows=14357 loops=2)
                                                                                       Merge Cond: ((c.trial_id = raw_validations.trial_id) AND (c.total_batches = raw_validations.total_batches))
                                                                                       ->  Sort  (cost=5878.49..5920.72 rows=16891 width=370) (actual time=73.905..81.497 rows=14357 loops=2)
                                                                                             Sort Key: c.trial_id, c.total_batches
                                                                                             Sort Method: external merge  Disk: 5288kB
                                                                                             Worker 0:  Sort Method: external merge  Disk: 5440kB
                                                                                             ->  Parallel Seq Scan on raw_checkpoints c  (cost=0.00..1804.91 rows=16891 width=370) (actual time=0.013..10.007 rows=14357 loops=2)
                                                                                       ->  Materialize  (cost=10998.72..11273.18 rows=54893 width=147) (actual time=143.165..175.895 rows=55776 loops=2)
                                                                                             ->  Sort  (cost=10998.72..11135.95 rows=54893 width=147) (actual time=143.156..162.744 rows=55776 loops=2)
                                                                                                   Sort Key: raw_validations.trial_id, raw_validations.total_batches
                                                                                                   Sort Method: external merge  Disk: 8488kB
                                                                                                   Worker 0:  Sort Method: external merge  Disk: 8488kB
                                                                                                   ->  Seq Scan on raw_validations  (cost=0.00..2547.45 rows=54893 width=147) (actual time=0.063..30.187 rows=55916 loops=2)
                                                                                                         Filter: (NOT archived)
                                                                                                         Rows Removed by Filter: 247
                                                                                 ->  Parallel Hash  (cost=2703.31..2703.31 rows=14331 width=341) (actual time=33.807..33.807 rows=12192 loops=2)
                                                                                       Buckets: 16384  Batches: 4  Memory Usage: 2464kB
                                                                                       ->  Parallel Seq Scan on trials t_1  (cost=0.00..2703.31 rows=14331 width=341) (actual time=0.017..9.006 rows=12192 loops=2)
                                                                           ->  Index Scan using steps_trial_id_run_id_total_batches_unique on raw_steps s  (cost=0.42..6.58 rows=1 width=1278) (actual time=0.009..0.011 rows=1 loops=28714)
                                                                                 Index Cond: ((c.trial_id = trial_id) AND (c.total_batches = total_batches))
                                                                     ->  Hash  (cost=559.16..559.16 rows=1616 width=822) (actual time=3.003..3.003 rows=1618 loops=2)
                                                                           Buckets: 2048  Batches: 1  Memory Usage: 1368kB
                                                                           ->  Seq Scan on experiments e  (cost=0.00..559.16 rows=1616 width=822) (actual time=0.022..1.623 rows=1618 loops=2)
                                                   ->  Nested Loop Left Join  (cost=26.24..6069.85 rows=143 width=3285) (actual time=0.397..26.949 rows=144 loops=1)
                                                         Join Filter: (((c_1.metadata ->> 'steps_completed'::text))::integer = raw_validations_1.total_batches)
                                                         Rows Removed by Join Filter: 836
                                                         ->  Nested Loop Left Join  (cost=25.95..5514.82 rows=143 width=3237) (actual time=0.307..17.746 rows=144 loops=1)
                                                               ->  Nested Loop Left Join  (cost=25.67..5120.55 rows=143 width=2419) (actual time=0.257..17.336 rows=144 loops=1)
                                                                     Filter: ((s_1.archived IS NULL) OR (NOT s_1.archived))
                                                                     ->  Hash Right Join  (cost=25.24..3804.83 rows=144 width=1150) (actual time=0.222..15.960 rows=144 loops=1)
                                                                           Hash Cond: (t_2.task_id = c_1.task_id)
                                                                           ->  Seq Scan on trials t_2  (cost=0.00..2803.63 rows=24363 width=341) (actual time=0.014..12.449 rows=24383 loops=1)
                                                                           ->  Hash  (cost=23.44..23.44 rows=144 width=827) (actual time=0.178..0.179 rows=144 loops=1)
                                                                                 Buckets: 1024  Batches: 1  Memory Usage: 134kB
                                                                                 ->  Seq Scan on checkpoints_v2 c_1  (cost=0.00..23.44 rows=144 width=827) (actual time=0.016..0.097 rows=144 loops=1)
                                                                     ->  Index Scan using steps_trial_id_run_id_total_batches_unique on raw_steps s_1  (cost=0.43..9.13 rows=1 width=1278) (actual time=0.007..0.008 rows=1 loops=144)
                                                                           Index Cond: ((t_2.id = trial_id) AND (((c_1.metadata ->> 'steps_completed'::text))::integer = total_batches))
                                                               ->  Index Scan using experiments_pkey on experiments e_1  (cost=0.28..2.76 rows=1 width=822) (actual time=0.002..0.002 rows=1 loops=144)
                                                                     Index Cond: (t_2.experiment_id = id)
                                                         ->  Index Scan using ix_validations_trial_id on raw_validations raw_validations_1  (cost=0.29..3.80 rows=3 width=147) (actual time=0.003..0.008 rows=7 loops=144)
                                                               Index Cond: (t_2.id = trial_id)
                                                               Filter: (NOT archived)
                                 ->  Sort  (cost=743.82..744.07 rows=100 width=380) (actual time=0.131..0.133 rows=1 loops=1)
                                       Sort Key: t.warm_start_checkpoint_id
                                       Sort Method: quicksort  Memory: 25kB
                                       ->  Nested Loop  (cost=0.29..740.50 rows=100 width=380) (actual time=0.118..0.120 rows=1 loops=1)
                                             ->  CTE Scan on searcher_info  (cost=0.00..2.00 rows=100 width=4) (actual time=0.111..0.112 rows=1 loops=1)
                                             ->  Index Scan using trials_pkey on trials t  (cost=0.29..7.38 rows=1 width=376) (actual time=0.003..0.004 rows=1 loops=1)
                                                   Index Cond: (id = searcher_info.trial_id)
               ->  CTE Scan on best_validation bv  (cost=0.00..0.02 rows=1 width=32) (actual time=0.098..0.101 rows=1 loops=1)
         ->  CTE Scan on latest_validation lv  (cost=0.00..0.02 rows=1 width=32) (actual time=0.045..0.049 rows=1 loops=1)
   ->  CTE Scan on best_checkpoint bc  (cost=0.00..0.02 rows=1 width=32) (actual time=1844.841..1844.845 rows=1 loops=1)
   SubPlan 7
     ->  Limit  (cost=153.35..153.35 rows=1 width=4) (actual time=0.057..0.059 rows=1 loops=1)
           ->  Sort  (cost=153.35..153.53 rows=73 width=4) (actual time=0.056..0.057 rows=1 loops=1)
                 Sort Key: raw_steps.total_batches DESC
                 Sort Method: top-N heapsort  Memory: 25kB
                 ->  Index Scan using steps_trial_id_run_id_total_batches_unique on raw_steps  (cost=0.42..152.98 rows=73 width=4) (actual time=0.017..0.033 rows=10 loops=1)
                       Index Cond: (trial_id = t.id)
                       Filter: ((NOT archived) AND (state = 'COMPLETED'::step_state))
   SubPlan 8
     ->  Aggregate  (cost=213.03..213.04 rows=1 width=8) (actual time=0.755..0.757 rows=1 loops=1)
           ->  Seq Scan on allocations a  (cost=0.00..212.99 rows=3 width=16) (actual time=0.640..0.746 rows=1 loops=1)
                 Filter: (task_id = t.task_id)
                 Rows Removed by Filter: 5583
 Planning Time: 7.118 ms
 Execution Time: 4259.708 ms
(213 rows)
```

After
```
                                                                                                                       QUERY PLAN                                                                                                                    
   
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
---
 Sort  (cost=11205.71..11205.72 rows=1 width=532) (actual time=18.485..18.539 rows=1 loops=1)
   Sort Key: unnest.ordinality
   Sort Method: quicksort  Memory: 27kB
   CTE searcher_info
     ->  Nested Loop  (cost=2.33..782.42 rows=100 width=40) (actual time=0.086..0.092 rows=1 loops=1)
           ->  Nested Loop  (cost=2.06..741.33 rows=100 width=8) (actual time=0.024..0.028 rows=1 loops=1)
                 ->  HashAggregate  (cost=1.77..2.77 rows=100 width=4) (actual time=0.009..0.011 rows=1 loops=1)
                       Group Key: unnest('{24348}'::integer[])
                       ->  ProjectSet  (cost=0.00..0.52 rows=100 width=4) (actual time=0.004..0.006 rows=1 loops=1)
                             ->  Result  (cost=0.00..0.01 rows=1 width=0) (actual time=0.001..0.002 rows=1 loops=1)
                 ->  Index Scan using trials_pkey on trials t_3  (cost=0.29..7.38 rows=1 width=8) (actual time=0.013..0.013 rows=1 loops=1)
                       Index Cond: (id = (unnest('{24348}'::integer[])))
           ->  Index Scan using experiments_pkey on experiments e  (cost=0.28..0.39 rows=1 width=822) (actual time=0.005..0.005 rows=1 loops=1)
                 Index Cond: (id = t_3.experiment_id)
           SubPlan 1
             ->  Result  (cost=0.00..0.02 rows=1 width=4) (actual time=0.016..0.016 rows=1 loops=1)
   CTE trial_validations
     ->  Nested Loop  (cost=0.29..954.11 rows=309 width=167) (actual time=0.021..0.024 rows=1 loops=1)
           ->  CTE Scan on searcher_info searcher_info_1  (cost=0.00..2.00 rows=100 width=40) (actual time=0.000..0.002 rows=1 loops=1)
           ->  Index Scan using ix_validations_trial_id on raw_validations  (cost=0.29..9.44 rows=3 width=159) (actual time=0.012..0.012 rows=1 loops=1)
                 Index Cond: (trial_id = searcher_info_1.trial_id)
                 Filter: ((NOT archived) AND (state = 'COMPLETED'::validation_state) AND (((metrics -> 'validation_metrics'::text) ->> searcher_info_1.metric_name) IS NOT NULL))
   CTE best_validation
     ->  Hash Join  (cost=29.03..31.42 rows=1 width=112) (actual time=0.054..0.059 rows=1 loops=1)
           Hash Cond: (searcher_info_2.trial_id = v_2.trial_id)
           ->  CTE Scan on searcher_info searcher_info_2  (cost=0.00..2.00 rows=100 width=4) (actual time=0.000..0.001 rows=1 loops=1)
           ->  Hash  (cost=29.00..29.00 rows=2 width=52) (actual time=0.044..0.047 rows=1 loops=1)
                 Buckets: 1024  Batches: 1  Memory Usage: 9kB
                 ->  Subquery Scan on v_2  (cost=18.96..29.00 rows=2 width=52) (actual time=0.040..0.043 rows=1 loops=1)
                       Filter: (v_2.rank = 1)
                       ->  WindowAgg  (cost=18.96..25.14 rows=309 width=68) (actual time=0.039..0.041 rows=1 loops=1)
                             ->  Sort  (cost=18.96..19.73 rows=309 width=60) (actual time=0.033..0.034 rows=1 loops=1)
                                   Sort Key: v_3.trial_id, v_3.signed_searcher_metric
                                   Sort Method: quicksort  Memory: 25kB
                                   ->  CTE Scan on trial_validations v_3  (cost=0.00..6.18 rows=309 width=60) (actual time=0.024..0.025 rows=1 loops=1)
   CTE latest_validation
     ->  Hash Join  (cost=29.03..31.42 rows=1 width=112) (actual time=0.018..0.022 rows=1 loops=1)
           Hash Cond: (searcher_info_3.trial_id = v_4.trial_id)
           ->  CTE Scan on searcher_info searcher_info_3  (cost=0.00..2.00 rows=100 width=4) (actual time=0.000..0.001 rows=1 loops=1)
           ->  Hash  (cost=29.00..29.00 rows=2 width=52) (actual time=0.011..0.014 rows=1 loops=1)
                 Buckets: 1024  Batches: 1  Memory Usage: 9kB
                 ->  Subquery Scan on v_4  (cost=18.96..29.00 rows=2 width=52) (actual time=0.009..0.012 rows=1 loops=1)
                       Filter: (v_4.rank = 1)
                       ->  WindowAgg  (cost=18.96..25.14 rows=309 width=68) (actual time=0.008..0.010 rows=1 loops=1)
                             ->  Sort  (cost=18.96..19.73 rows=309 width=52) (actual time=0.006..0.007 rows=1 loops=1)
                                   Sort Key: v_5.trial_id, v_5.end_time DESC
                                   Sort Method: quicksort  Memory: 25kB
                                   ->  CTE Scan on trial_validations v_5  (cost=0.00..6.18 rows=309 width=52) (actual time=0.001..0.001 rows=1 loops=1)
  CTE best_checkpoint
     ->  Subquery Scan on c_2  (cost=1880.16..2802.65 rows=2 width=112) (actual time=0.278..0.300 rows=1 loops=1)
           ->  Subquery Scan on c_3  (cost=1880.16..2802.61 rows=2 width=340) (actual time=0.276..0.296 rows=1 loops=1)
                 ->  Append  (cost=1880.16..2802.59 rows=2 width=332) (actual time=0.274..0.293 rows=1 loops=1)
                       ->  Subquery Scan on "*SELECT* 1"  (cost=1880.16..1880.24 rows=1 width=2878) (actual time=0.012..0.020 rows=0 loops=1)
                             ->  Subquery Scan on old_c  (cost=1880.16..1880.23 rows=1 width=2874) (actual time=0.012..0.019 rows=0 loops=1)
                                   Filter: (old_c.rank = 1)
                                   ->  WindowAgg  (cost=1880.16..1880.22 rows=1 width=2878) (actual time=0.012..0.018 rows=0 loops=1)
                                         ->  Sort  (cost=1880.16..1880.17 rows=1 width=2945) (actual time=0.011..0.017 rows=0 loops=1)
                                               Sort Key: v_6.trial_id, v_6.signed_searcher_metric
                                               Sort Method: quicksort  Memory: 25kB
                                               ->  Nested Loop Left Join  (cost=1.57..1880.15 rows=1 width=2945) (actual time=0.008..0.013 rows=0 loops=1)
                                                     Filter: ((s_2.archived IS NULL) OR ((NOT s_2.archived) AND (v_7.archived IS NULL)) OR (NOT v_7.archived))
                                                     ->  Nested Loop Left Join  (cost=1.28..1876.97 rows=1 width=2811) (actual time=0.008..0.012 rows=0 loops=1)
                                                           ->  Nested Loop Left Join  (cost=0.85..1871.01 rows=1 width=1541) (actual time=0.007..0.011 rows=0 loops=1)
                                                                 ->  Nested Loop  (cost=0.57..1868.24 rows=1 width=723) (actual time=0.007..0.009 rows=0 loops=1)
                                                                       ->  Nested Loop  (cost=0.29..1865.06 rows=1 width=382) (actual time=0.007..0.008 rows=0 loops=1)
                                                                             ->  CTE Scan on trial_validations v_6  (cost=0.00..6.18 rows=309 width=16) (actual time=0.000..0.001 rows=1 loops=1)
                                                                             ->  Index Scan using checkpoints_trial_id_run_id_total_batches_unique on raw_checkpoints c_4  (cost=0.29..6.01 rows=1 width=370) (actual time=0.005..0.006 rows=0 loops=
1)
                                                                                   Index Cond: ((trial_id = v_6.trial_id) AND (total_batches = v_6.total_batches))
                                                                                   Filter: (state = 'COMPLETED'::checkpoint_state)
                                                                       ->  Index Scan using trials_pkey on trials t_4  (cost=0.29..3.18 rows=1 width=341) (never executed)
                                                                             Index Cond: (id = c_4.trial_id)
                                                                 ->  Index Scan using experiments_pkey on experiments e_1  (cost=0.28..2.77 rows=1 width=822) (never executed)
                                                                       Index Cond: (t_4.experiment_id = id)
                                                           ->  Index Scan using steps_trial_id_run_id_total_batches_unique on raw_steps s_2  (cost=0.42..5.96 rows=1 width=1282) (never executed)
                                                                 Index Cond: ((trial_id = t_4.id) AND (trial_run_id = c_4.trial_run_id) AND (total_batches = c_4.total_batches))
                                                     ->  Index Scan using validations_trial_id_run_id_total_batches_unique on raw_validations v_7  (cost=0.29..3.17 rows=1 width=152) (never executed)
                                                           Index Cond: ((trial_id = c_4.trial_id) AND (trial_run_id = c_4.trial_run_id) AND (total_batches = c_4.total_batches))
                       ->  Subquery Scan on new_c  (cost=922.27..922.33 rows=1 width=3301) (actual time=0.261..0.271 rows=1 loops=1)
                             Filter: (new_c.rank = 1)
                             ->  WindowAgg  (cost=922.27..922.31 rows=1 width=3305) (actual time=0.260..0.268 rows=1 loops=1)
                                   ->  Sort  (cost=922.27..922.27 rows=1 width=3388) (actual time=0.235..0.243 rows=1 loops=1)
                                         Sort Key: v_8.trial_id, v_8.signed_searcher_metric
                                         Sort Method: quicksort  Memory: 29kB
                                         ->  Nested Loop Left Join  (cost=26.23..922.26 rows=1 width=3388) (actual time=0.220..0.237 rows=1 loops=1)
                                               Filter: ((s_3.archived IS NULL) OR ((NOT s_3.archived) AND (v_9.archived IS NULL)) OR (NOT v_9.archived))
                                               ->  Nested Loop Left Join  (cost=25.79..913.06 rows=1 width=2120) (actual time=0.207..0.222 rows=1 loops=1)
                                                     Join Filter: (((c_5.metadata ->> 'steps_completed'::text))::integer = v_9.total_batches)
                                                     ->  Nested Loop Left Join  (cost=25.50..909.21 rows=1 width=1980) (actual time=0.200..0.213 rows=1 loops=1)
                                                           ->  Nested Loop  (cost=25.23..906.45 rows=1 width=1162) (actual time=0.195..0.206 rows=1 loops=1)
                                                                 Join Filter: (c_5.task_id = t_5.task_id)
                                                                 Rows Removed by Join Filter: 7
                                                                 ->  Hash Join  (cost=24.94..34.84 rows=141 width=839) (actual time=0.176..0.183 rows=8 loops=1)
                                                                       Hash Cond: (v_8.total_batches = ((c_5.metadata ->> 'steps_completed'::text))::integer)
                                                                       ->  CTE Scan on trial_validations v_8  (cost=0.00..6.18 rows=309 width=16) (actual time=0.000..0.001 rows=1 loops=1)
                                                                       ->  Hash  (cost=23.80..23.80 rows=91 width=827) (actual time=0.169..0.170 rows=92 loops=1)
                                                                             Buckets: 1024  Batches: 1  Memory Usage: 98kB
                                                                             ->  Seq Scan on checkpoints_v2 c_5  (cost=0.00..23.80 rows=91 width=827) (actual time=0.009..0.105 rows=92 loops=1)
                                                                                   Filter: (state = 'COMPLETED'::checkpoint_state)
                                                                                   Rows Removed by Filter: 52
                                                                 ->  Index Scan using trials_pkey on trials t_5  (cost=0.29..6.17 rows=1 width=341) (actual time=0.002..0.002 rows=1 loops=8)
                                                                       Index Cond: (id = v_8.trial_id)
                                                           ->  Index Scan using experiments_pkey on experiments e_2  (cost=0.28..2.76 rows=1 width=822) (actual time=0.003..0.003 rows=1 loops=1)
                                                                 Index Cond: (t_5.experiment_id = id)
                                                     ->  Index Scan using ix_validations_trial_id on raw_validations v_9  (cost=0.29..3.80 rows=3 width=148) (actual time=0.004..0.005 rows=1 loops=1)
                                                           Index Cond: (t_5.id = trial_id)
                                               ->  Index Scan using steps_trial_id_run_id_total_batches_unique on raw_steps s_3  (cost=0.43..9.18 rows=1 width=1278) (actual time=0.010..0.011 rows=1 loops=1)
                                                     Index Cond: ((t_5.id = trial_id) AND (((c_5.metadata ->> 'steps_completed'::text))::integer = total_batches))
   ->  Nested Loop Left Join  (cost=3112.85..6603.67 rows=1 width=532) (actual time=18.470..18.491 rows=1 loops=1)
         ->  Nested Loop Left Join  (cost=3111.56..6213.17 rows=1 width=484) (actual time=17.514..17.529 rows=1 loops=1)
               Join Filter: (c_1.id = t.warm_start_checkpoint_id)
               Rows Removed by Join Filter: 144
               ->  Hash Join  (cost=2.67..748.43 rows=1 width=468) (actual time=0.501..0.512 rows=1 loops=1)
                     Hash Cond: (t.id = unnest.unnest)
                     ->  Nested Loop  (cost=0.42..745.80 rows=100 width=464) (actual time=0.490..0.499 rows=1 loops=1)
                           ->  Hash Left Join  (cost=0.13..3.29 rows=100 width=88) (actual time=0.485..0.492 rows=1 loops=1)
                                 Hash Cond: (searcher_info.trial_id = bc.trial_id)
                                 ->  Hash Left Join  (cost=0.07..2.83 rows=100 width=60) (actual time=0.188..0.193 rows=1 loops=1)
                                       Hash Cond: (searcher_info.trial_id = lv.trial_id)
                                       ->  Hash Left Join  (cost=0.03..2.42 rows=100 width=32) (actual time=0.159..0.162 rows=1 loops=1)
                                             Hash Cond: (searcher_info.trial_id = bv.trial_id)
                                             ->  CTE Scan on searcher_info  (cost=0.00..2.00 rows=100 width=4) (actual time=0.088..0.089 rows=1 loops=1)
                                             ->  Hash  (cost=0.02..0.02 rows=1 width=32) (actual time=0.064..0.064 rows=1 loops=1)
                                                   Buckets: 1024  Batches: 1  Memory Usage: 9kB
                                                   ->  CTE Scan on best_validation bv  (cost=0.00..0.02 rows=1 width=32) (actual time=0.061..0.062 rows=1 loops=1)
                                       ->  Hash  (cost=0.02..0.02 rows=1 width=32) (actual time=0.023..0.024 rows=1 loops=1)
                                             Buckets: 1024  Batches: 1  Memory Usage: 9kB
                                             ->  CTE Scan on latest_validation lv  (cost=0.00..0.02 rows=1 width=32) (actual time=0.021..0.022 rows=1 loops=1)
                                 ->  Hash  (cost=0.04..0.04 rows=2 width=32) (actual time=0.292..0.292 rows=1 loops=1)
                                       Buckets: 1024  Batches: 1  Memory Usage: 9kB
                                       ->  CTE Scan on best_checkpoint bc  (cost=0.00..0.04 rows=2 width=32) (actual time=0.282..0.283 rows=1 loops=1)
                           ->  Index Scan using trials_pkey on trials t  (cost=0.29..7.42 rows=1 width=376) (actual time=0.003..0.003 rows=1 loops=1)
                                 Index Cond: (id = searcher_info.trial_id)
                     ->  Hash  (cost=1.00..1.00 rows=100 width=12) (actual time=0.005..0.006 rows=1 loops=1)
                           Buckets: 1024  Batches: 1  Memory Usage: 9kB
                           ->  Function Scan on unnest  (cost=0.00..1.00 rows=100 width=12) (actual time=0.004..0.004 rows=1 loops=1)
               ->  Nested Loop Left Join  (cost=3108.89..5462.95 rows=143 width=24) (actual time=14.855..16.991 rows=144 loops=1)
                     Filter: ((s_1.archived IS NULL) OR ((NOT s_1.archived) AND (v_1.archived IS NULL)) OR (NOT v_1.archived))
                     ->  Nested Loop Left Join  (cost=3108.46..4147.23 rows=144 width=123) (actual time=14.837..16.090 rows=144 loops=1)
                           Join Filter: (((c_1.metadata ->> 'steps_completed'::text))::integer = v_1.total_batches)
                           Rows Removed by Join Filter: 836
                           ->  Hash Left Join  (cost=3108.17..3133.59 rows=144 width=122) (actual time=14.811..15.004 rows=144 loops=1)
                                 Hash Cond: (c_1.task_id = t_2.task_id)
                                 ->  Seq Scan on checkpoints_v2 c_1  (cost=0.00..23.44 rows=144 width=160) (actual time=0.003..0.056 rows=144 loops=1)
                                 ->  Hash  (cost=2803.63..2803.63 rows=24363 width=26) (actual time=14.594..14.595 rows=24383 loops=1)
                                       Buckets: 32768  Batches: 1  Memory Usage: 1689kB
                                       ->  Seq Scan on trials t_2  (cost=0.00..2803.63 rows=24363 width=26) (actual time=0.005..9.934 rows=24383 loops=1)
                           ->  Index Scan using ix_validations_trial_id on raw_validations v_1  (cost=0.29..6.98 rows=3 width=9) (actual time=0.002..0.005 rows=7 loops=144)
                                 Index Cond: (t_2.id = trial_id)
                     ->  Index Scan using steps_trial_id_run_id_total_batches_unique on raw_steps s_1  (cost=0.43..9.13 rows=1 width=9) (actual time=0.005..0.005 rows=1 loops=144)
                           Index Cond: ((t_2.id = trial_id) AND (((c_1.metadata ->> 'steps_completed'::text))::integer = total_batches))
         ->  Nested Loop Left Join  (cost=1.29..24.07 rows=1 width=20) (actual time=0.007..0.009 rows=0 loops=1)
               Filter: ((s.archived IS NULL) OR ((NOT s.archived) AND (v.archived IS NULL)) OR (NOT v.archived))
               ->  Nested Loop Left Join  (cost=1.00..18.37 rows=1 width=33) (actual time=0.005..0.007 rows=0 loops=1)
                     ->  Nested Loop Left Join  (cost=0.57..11.36 rows=1 width=36) (actual time=0.004..0.005 rows=0 loops=1)
                           ->  Index Scan using checkpoints_pkey on raw_checkpoints c  (cost=0.29..5.67 rows=1 width=32) (actual time=0.003..0.003 rows=0 loops=1)
                                 Index Cond: (id = t.warm_start_checkpoint_id)
                           ->  Index Scan using trials_pkey on trials t_1  (cost=0.29..5.68 rows=1 width=8) (never executed)
                                 Index Cond: (c.trial_id = id)
                     ->  Index Scan using steps_trial_id_run_id_total_batches_unique on raw_steps s  (cost=0.42..7.02 rows=1 width=13) (never executed)
                           Index Cond: ((trial_id = t_1.id) AND (trial_run_id = c.trial_run_id) AND (total_batches = c.total_batches))
               ->  Index Scan using validations_trial_id_run_id_total_batches_unique on raw_validations v  (cost=0.29..5.68 rows=1 width=13) (never executed)
                     Index Cond: ((trial_id = c.trial_id) AND (trial_run_id = c.trial_run_id) AND (total_batches = c.total_batches))
         SubPlan 7
           ->  Limit  (cost=153.35..153.35 rows=1 width=4) (actual time=0.034..0.035 rows=1 loops=1)
                 ->  Sort  (cost=153.35..153.53 rows=73 width=4) (actual time=0.033..0.034 rows=1 loops=1)
                       Sort Key: raw_steps.total_batches DESC
                       Sort Method: top-N heapsort  Memory: 25kB
                       ->  Index Scan using steps_trial_id_run_id_total_batches_unique on raw_steps  (cost=0.42..152.98 rows=73 width=4) (actual time=0.008..0.020 rows=10 loops=1)
                             Index Cond: (trial_id = t.id)
                             Filter: ((NOT archived) AND (state = 'COMPLETED'::step_state))
         SubPlan 8
           ->  Aggregate  (cost=213.03..213.04 rows=1 width=8) (actual time=0.763..0.763 rows=1 loops=1)
                 ->  Seq Scan on allocations a  (cost=0.00..212.99 rows=3 width=16) (actual time=0.650..0.753 rows=1 loops=1)
                       Filter: (task_id = t.task_id)
                       Rows Removed by Filter: 5583
 Planning Time: 7.140 ms
 Execution Time: 19.243 ms
(177 rows)
```

so ~4s -> ~20ms

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ