### PR TITLE
fix: wrap torch.distributed launch in pid server/client 

### DIFF
--- a/harness/determined/exec/pid_client.py
+++ b/harness/determined/exec/pid_client.py
@@ -7,7 +7,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("addr")
     parser.add_argument("cmd")
-    parser.add_argument("cmd_args", nargs="*")
+    parser.add_argument("cmd_args", nargs=argparse.REMAINDER)
     args = parser.parse_args()
 
     addr = ipc.read_pid_server_addr(args.addr)

--- a/harness/determined/launch/torch_distributed.py
+++ b/harness/determined/launch/torch_distributed.py
@@ -38,8 +38,33 @@ def create_launch_cmd(
 
 def create_log_redirect_cmd() -> List[str]:
     return [
+        "python3",
+        "-m",
         "determined.exec.worker_process_wrapper",
         "RANK",
+        "--",
+    ]
+
+
+def create_pid_server_cmd(allocation_id: str, num_slot_ids: int) -> List[str]:
+    return [
+        "python3",
+        "-m",
+        "determined.exec.pid_server",
+        "--on-fail",
+        "SIGTERM",
+        "--on-exit",
+        "WAIT",
+        f"/tmp/pid_server-{allocation_id}",
+        str(num_slot_ids),
+        "--",
+    ]
+
+
+def create_pid_client_cmd(allocation_id: str) -> List[str]:
+    return [
+        "determined.exec.pid_client",
+        f"/tmp/pid_server-{allocation_id}",
         "--",
     ]
 
@@ -71,11 +96,18 @@ def main(override_args: List[str], script: List[str]) -> int:
 
     log_redirect_cmd = create_log_redirect_cmd()
 
+    # Due to a bug in PyTorch, we need to wrap the launcher in pid_server/pid_client to correctly
+    # handle errors and ensure workers don't hang when a process fails
+    pid_server_cmd = create_pid_server_cmd(info.allocation_id, len(info.slot_ids))
+    pid_client_cmd = create_pid_client_cmd(info.allocation_id)
+
+    launch_cmd = pid_server_cmd + torch_distributed_cmd + pid_client_cmd + log_redirect_cmd + script
+
     logging.debug(
-        f"Torch distributed launching with: {torch_distributed_cmd + log_redirect_cmd + script}"
+        f"Torch distributed launching with: {launch_cmd}"
     )
 
-    return subprocess.Popen(torch_distributed_cmd + log_redirect_cmd + script).wait()
+    return subprocess.Popen(launch_cmd).wait()
 
 
 def parse_args(args: List[str]) -> Tuple[List[str], List[str]]:


### PR DESCRIPTION
## Description

<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At a minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->

due to a bug in Pytorch which doesn't catch NCCL failures, wrap the launch command in PID server/client

## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions about this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
