### PR TITLE
fix: Support rendering rank of 0 [DET-7186]

### DIFF
--- a/webui/react/src/components/LogViewer/LogViewerFilters.test.tsx
+++ b/webui/react/src/components/LogViewer/LogViewerFilters.test.tsx
@@ -63,6 +63,24 @@ describe('LogViewerFilter', () => {
     });
   });
 
+  it('should render filters with rank 0 and no rank', async () => {
+    const values: Filters = {
+      agentIds: [],
+      allocationIds: [],
+      containerIds: [],
+      levels: [],
+      rankIds: [ 0, undefined ],
+    };
+    setup(values, { ...values, rankIds: [] });
+
+    const agentOption1 = screen.getByText('All Ranks');
+    userEvent.click(agentOption1, undefined, { skipPointerEventsCheck: true });
+    await waitFor(async () => {
+      expect(await screen.findAllByText('0')).toHaveLength(2);
+      expect(screen.queryByText('No Rank')).toBeInTheDocument();
+    });
+  });
+
   it('should call onChange when options are selected', async () => {
     const { handleOnChange } = setup(DEFAULT_FILTER_OPTIONS, {});
 

--- a/webui/react/src/components/LogViewer/LogViewerFilters.tsx
+++ b/webui/react/src/components/LogViewer/LogViewerFilters.tsx
@@ -121,7 +121,7 @@ const LogViewerFilters: React.FC<Props> = ({ onChange, onReset, options, values 
             value={values.rankIds}
             onChange={handleChange('rankIds', Number)}>
             {selectOptions?.rankIds?.map(id => (
-              <Option key={id} value={id}>{id || 'No Rank'}</Option>
+              <Option key={id} value={id}>{id ?? 'No Rank'}</Option>
             ))}
           </MultiSelect>
         )}


### PR DESCRIPTION
## Description

Supports '0' as a Rank and not as a falsey value rendered as 'No Rank'.

## Test Plan

Includes a test that 0 and undefined appear as options (as '0' and 'No Rank').
'0' appears somewhere else in the DOM, so we check that '0' appears twice.

## Checklist

- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.