### PR TITLE
chore: HAL-2879 Cleanly shutdown all sshd servers on exit (#176)

### DIFF
--- a/harness/determined/launch/horovod.py
+++ b/harness/determined/launch/horovod.py
@@ -31,7 +31,7 @@ def create_sshd_worker_cmd(allocation_id: str, num_slot_ids: int) -> Tuple[List[
         "--on-fail",
         "SIGTERM",
         "--on-exit",
-        "WAIT",
+        "SIGTERM",
         f"/tmp/pid_server-{allocation_id}",
         str(num_slot_ids),
         "--",


### PR DESCRIPTION
## Description

Change the pidserver settings for sshd launches to SIGTERM during
pidserver exit.  Previously the setting was to wait for the sshd
processes, but they never exit so it can cause a hang.  With
this change when when the horovodrun command completes, and the
pidserver is about to exit, it instead sends SIGTERM to the
sshd processes and all containers can exit cleanly.

## Test Plan

Verified with successful run and test completion and shutdown using. SLURM  on casablanca & horizon with cifar10_pytorch distributed (8 slots).


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
