### PR TITLE
fix: Assorted fixes for Workspaces/Projects

### DIFF
--- a/harness/determined/common/api/bindings.py
+++ b/harness/determined/common/api/bindings.py
@@ -906,6 +906,7 @@ class v1CreateExperimentRequest:
         config: "typing.Optional[str]" = None,
         modelDefinition: "typing.Optional[typing.Sequence[v1File]]" = None,
         parentId: "typing.Optional[int]" = None,
+        projectId: "typing.Optional[int]" = None,
         validateOnly: "typing.Optional[bool]" = None,
     ):
         self.modelDefinition = modelDefinition
@@ -913,6 +914,7 @@ class v1CreateExperimentRequest:
         self.validateOnly = validateOnly
         self.parentId = parentId
         self.activate = activate
+        self.projectId = projectId
 
     @classmethod
     def from_json(cls, obj: Json) -> "v1CreateExperimentRequest":
@@ -922,6 +924,7 @@ class v1CreateExperimentRequest:
             validateOnly=obj.get("validateOnly", None),
             parentId=obj.get("parentId", None),
             activate=obj.get("activate", None),
+            projectId=obj.get("projectId", None),
         )
 
     def to_json(self) -> typing.Any:
@@ -931,6 +934,7 @@ class v1CreateExperimentRequest:
             "validateOnly": self.validateOnly if self.validateOnly is not None else None,
             "parentId": self.parentId if self.parentId is not None else None,
             "activate": self.activate if self.activate is not None else None,
+            "projectId": self.projectId if self.projectId is not None else None,
         }
 
 class v1CreateExperimentResponse:

--- a/harness/determined/common/api/bindings.py
+++ b/harness/determined/common/api/bindings.py
@@ -3977,6 +3977,7 @@ class v1Project:
         notes: "typing.Sequence[v1Note]",
         numActiveExperiments: int,
         numExperiments: int,
+        userId: int,
         username: str,
         workspaceId: int,
         description: "typing.Optional[str]" = None,
@@ -3993,6 +3994,7 @@ class v1Project:
         self.archived = archived
         self.username = username
         self.immutable = immutable
+        self.userId = userId
 
     @classmethod
     def from_json(cls, obj: Json) -> "v1Project":
@@ -4008,6 +4010,7 @@ class v1Project:
             archived=obj["archived"],
             username=obj["username"],
             immutable=obj["immutable"],
+            userId=obj["userId"],
         )
 
     def to_json(self) -> typing.Any:
@@ -4023,6 +4026,7 @@ class v1Project:
             "archived": self.archived,
             "username": self.username,
             "immutable": self.immutable,
+            "userId": self.userId,
         }
 
 class v1PutProjectNotesRequest:
@@ -5672,6 +5676,7 @@ class v1Workspace:
         name: str,
         numProjects: int,
         pinned: bool,
+        userId: int,
         username: str,
     ):
         self.id = id
@@ -5681,6 +5686,7 @@ class v1Workspace:
         self.immutable = immutable
         self.numProjects = numProjects
         self.pinned = pinned
+        self.userId = userId
 
     @classmethod
     def from_json(cls, obj: Json) -> "v1Workspace":
@@ -5692,6 +5698,7 @@ class v1Workspace:
             immutable=obj["immutable"],
             numProjects=obj["numProjects"],
             pinned=obj["pinned"],
+            userId=obj["userId"],
         )
 
     def to_json(self) -> typing.Any:
@@ -5703,6 +5710,7 @@ class v1Workspace:
             "immutable": self.immutable,
             "numProjects": self.numProjects,
             "pinned": self.pinned,
+            "userId": self.userId,
         }
 
 def post_AckAllocationPreemptionSignal(

--- a/master/internal/api_experiment.go
+++ b/master/internal/api_experiment.go
@@ -722,6 +722,10 @@ func (a *apiServer) CreateExperiment(
 		parentID := int(req.ParentId)
 		detParams.ParentID = &parentID
 	}
+	if req.ProjectId > 1 {
+		projectID := int(req.ProjectId)
+		detParams.ProjectID = &projectID
+	}
 
 	user, _, err := grpcutil.GetUser(ctx, a.m.db, &a.m.config.InternalConfig.ExternalSessions)
 	if err != nil {

--- a/master/internal/core_experiment.go
+++ b/master/internal/core_experiment.go
@@ -271,6 +271,7 @@ type CreateExperimentParams struct {
 	GitCommitDate *time.Time      `json:"git_commit_date"`
 	ValidateOnly  bool            `json:"validate_only"`
 	Project       *string         `json:"project"`
+	ProjectID     *int            `json:"project_id"`
 	Workspace     *string         `json:"workspace"`
 }
 

--- a/master/internal/db/database.go
+++ b/master/internal/db/database.go
@@ -112,6 +112,7 @@ type DB interface {
 	GetTrialProfilerMetricsBatches(
 		labelsJSON []byte, offset, limit int,
 	) (model.TrialProfilerMetricsBatchBatch, error)
+	ProjectFromNames(workspaceName string, projectName string) (projectID int, err error)
 	ExperimentLabelUsage(projectID int32) (labelUsage map[string]int, err error)
 	GetExperimentStatus(experimentID int) (state model.State, progress float64,
 		err error)

--- a/master/internal/db/postgres_experiments.go
+++ b/master/internal/db/postgres_experiments.go
@@ -43,6 +43,9 @@ func (db *PgDB) ProjectFromNames(workspaceName string, projectName string) (int,
 	if p.Id < 1 {
 		return 1, fmt.Errorf("workspace and project names did not match any known project")
 	}
+	if p.Archived {
+		return 1, fmt.Errorf("given workspace or project is archived and cannot add new experiments")
+	}
 	return int(p.Id), nil
 }
 

--- a/master/internal/mocks/db.go
+++ b/master/internal/mocks/db.go
@@ -697,6 +697,28 @@ func (_m *DB) ExperimentIDByTrialID(trialID int) (int, error) {
 	return r0, r1
 }
 
+// ProjectFromNames provides a mock function with workspaceName and projectName fields.
+func (db *PgDB) ProjectFromNames(workspaceName string, projectName string) (int, error) {
+	ret := _m.Called(workspaceName)
+	ret2 := _m.Called(projectName)
+
+	var r0 int
+	if rf, ok := ret.Get(ret, ret2).(func(string, string) int); ok {
+		r0 = rf(workspaceName, projectName)
+	} else {
+		r0 = ret.Get("test", "testp").(int)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(ret, ret2).(func(string, string) error); ok {
+		r1 = rf(workspaceName, projectName)
+	} else {
+		r1 = ret.Error("test", "testp")
+	}
+
+	return r0, r1
+}
+
 // ExperimentLabelUsage provides a mock function with given fields: projectID
 func (_m *DB) ExperimentLabelUsage(projectID int32) (map[string]int, error) {
 	ret := _m.Called(projectID)

--- a/master/internal/mocks/db.go
+++ b/master/internal/mocks/db.go
@@ -697,28 +697,6 @@ func (_m *DB) ExperimentIDByTrialID(trialID int) (int, error) {
 	return r0, r1
 }
 
-// ProjectFromNames provides a mock function with workspaceName and projectName fields.
-func (db *PgDB) ProjectFromNames(workspaceName string, projectName string) (int, error) {
-	ret := _m.Called(workspaceName)
-	ret2 := _m.Called(projectName)
-
-	var r0 int
-	if rf, ok := ret.Get(ret, ret2).(func(string, string) int); ok {
-		r0 = rf(workspaceName, projectName)
-	} else {
-		r0 = ret.Get("test", "testp").(int)
-	}
-
-	var r1 error
-	if rf, ok := ret.Get(ret, ret2).(func(string, string) error); ok {
-		r1 = rf(workspaceName, projectName)
-	} else {
-		r1 = ret.Error("test", "testp")
-	}
-
-	return r0, r1
-}
-
 // ExperimentLabelUsage provides a mock function with given fields: projectID
 func (_m *DB) ExperimentLabelUsage(projectID int32) (map[string]int, error) {
 	ret := _m.Called(projectID)
@@ -1264,6 +1242,27 @@ func (_m *DB) PeriodicTelemetryInfo() ([]byte, error) {
 	var r1 error
 	if rf, ok := ret.Get(1).(func() error); ok {
 		r1 = rf()
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// ProjectFromNames provides a mock function with given fields: workspaceName, projectName
+func (_m *DB) ProjectFromNames(workspaceName string, projectName string) (int, error) {
+	ret := _m.Called(workspaceName, projectName)
+
+	var r0 int
+	if rf, ok := ret.Get(0).(func(string, string) int); ok {
+		r0 = rf(workspaceName, projectName)
+	} else {
+		r0 = ret.Get(0).(int)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(string, string) error); ok {
+		r1 = rf(workspaceName, projectName)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/master/static/migrations/20220505122814_workspace-name-restrictions.tx.down.sql
+++ b/master/static/migrations/20220505122814_workspace-name-restrictions.tx.down.sql
@@ -1,0 +1,4 @@
+ALTER TABLE workspaces DROP CONSTRAINT namemin;
+ALTER TABLE workspaces DROP CONSTRAINT namemax;
+ALTER TABLE projects DROP CONSTRAINT namemin;
+ALTER TABLE projects DROP CONSTRAINT namemax;

--- a/master/static/migrations/20220505122814_workspace-name-restrictions.tx.up.sql
+++ b/master/static/migrations/20220505122814_workspace-name-restrictions.tx.up.sql
@@ -1,0 +1,8 @@
+ALTER TABLE workspaces
+	ADD CONSTRAINT namemin CHECK (char_length(name) >= 1);
+ALTER TABLE workspaces
+	ADD CONSTRAINT namemax CHECK (char_length(name) <= 80);
+ALTER TABLE projects
+	ADD CONSTRAINT namemin CHECK (char_length(name) >= 1);
+ALTER TABLE projects
+	ADD CONSTRAINT namemax CHECK (char_length(name) <= 80);

--- a/master/static/srv/delete_project.sql
+++ b/master/static/srv/delete_project.sql
@@ -12,8 +12,40 @@ proj AS (
   )
 ),
 exper AS (
-  UPDATE experiments SET project_id = 1
+  SELECT id FROM experiments
   WHERE project_id IN (SELECT id FROM proj)
+),
+o_trials AS (
+  SELECT id, task_id FROM trials
+  WHERE experiment_id IN (SELECT id FROM exper)
+),
+del_steps AS (
+  DELETE FROM raw_steps
+  WHERE trial_id IN (SELECT id FROM o_trials)
+),
+del_trials AS (
+  DELETE FROM trials
+  WHERE experiment_id IN (SELECT id FROM exper)
+),
+o_allocations AS (
+  SELECT allocation_id FROM allocations
+  WHERE task_id IN (SELECT task_id FROM o_trials)
+),
+del_task_stats AS (
+  DELETE FROM task_stats
+  WHERE allocation_id IN (SELECT allocation_id FROM o_allocations)
+),
+del_allocations AS (
+  DELETE FROM allocations
+  WHERE allocation_id IN (SELECT allocation_id FROM o_allocations)
+),
+del_tasks AS (
+  DELETE FROM tasks
+  WHERE task_id IN (SELECT task_id FROM o_trials)
+),
+del_exper AS (
+  DELETE FROM experiments
+  WHERE id IN (SELECT id FROM exper)
 )
 DELETE FROM projects
 WHERE id IN (SELECT id FROM proj)

--- a/master/static/srv/delete_workspace.sql
+++ b/master/static/srv/delete_workspace.sql
@@ -8,6 +8,18 @@ WITH w AS (
 pins AS (
   DELETE FROM workspace_pins
   WHERE workspace_id IN (SELECT id FROM w)
+),
+proj AS (
+  SELECT id FROM projects
+  WHERE workspace_id IN (SELECT id FROM w)
+),
+exper AS (
+  UPDATE experiments SET project_id = 1
+  WHERE project_id IN (SELECT id FROM proj)
+),
+del_proj AS (
+  DELETE FROM projects
+  WHERE id IN (SELECT id FROM proj)
 )
 DELETE FROM workspaces
 WHERE id IN (SELECT id FROM w)

--- a/master/static/srv/delete_workspace.sql
+++ b/master/static/srv/delete_workspace.sql
@@ -14,8 +14,40 @@ proj AS (
   WHERE workspace_id IN (SELECT id FROM w)
 ),
 exper AS (
-  UPDATE experiments SET project_id = 1
+  SELECT id FROM experiments
   WHERE project_id IN (SELECT id FROM proj)
+),
+o_trials AS (
+  SELECT id, task_id FROM trials
+  WHERE experiment_id IN (SELECT id FROM exper)
+),
+del_steps AS (
+  DELETE FROM raw_steps
+  WHERE trial_id IN (SELECT id FROM o_trials)
+),
+del_trials AS (
+  DELETE FROM trials
+  WHERE experiment_id IN (SELECT id FROM exper)
+),
+o_allocations AS (
+  SELECT allocation_id FROM allocations
+  WHERE task_id IN (SELECT task_id FROM o_trials)
+),
+del_task_stats AS (
+  DELETE FROM task_stats
+  WHERE allocation_id IN (SELECT allocation_id FROM o_allocations)
+),
+del_allocations AS (
+  DELETE FROM allocations
+  WHERE allocation_id IN (SELECT allocation_id FROM o_allocations)
+),
+del_tasks AS (
+  DELETE FROM tasks
+  WHERE task_id IN (SELECT task_id FROM o_trials)
+),
+del_exper AS (
+  DELETE FROM experiments
+  WHERE id IN (SELECT id FROM exper)
 ),
 del_proj AS (
   DELETE FROM projects

--- a/master/static/srv/get_project.sql
+++ b/master/static/srv/get_project.sql
@@ -11,7 +11,7 @@ SELECT p.id, p.name, p.workspace_id, p.description, p.immutable, p.notes,
   MAX(pe.num_experiments) AS num_experiments,
   MAX(pe.num_active_experiments) AS num_active_experiments,
   COALESCE(MAX(pe.last_experiment_started_at), NULL) AS last_experiment_started_at,
-  u.username
+  u.username, p.user_id
 FROM pe, projects as p
   LEFT JOIN users as u ON u.id = p.user_id
   LEFT JOIN workspaces AS w on w.id = p.workspace_id

--- a/master/static/srv/get_project_from_name.sql
+++ b/master/static/srv/get_project_from_name.sql
@@ -1,3 +1,4 @@
-SELECT p.id, p.name, p.description, p.immutable
+SELECT p.id, p.name, p.description, p.immutable, (p.archived OR w.archived) AS archived
 FROM projects p
+JOIN workspaces w ON w.id = p.workspace_id
 WHERE p.workspace_id = $1 AND p.name = $2;

--- a/master/static/srv/get_workspace.sql
+++ b/master/static/srv/get_workspace.sql
@@ -1,4 +1,4 @@
-SELECT w.id, w.name, w.archived, w.immutable, u.username,
+SELECT w.id, w.name, w.archived, w.immutable, u.username, w.user_id,
   (SELECT COUNT(*) FROM projects WHERE workspace_id = $1) AS num_projects,
   (SELECT COUNT(*) > 0 FROM workspace_pins
     WHERE workspace_id = $1 AND user_id = $2

--- a/master/static/srv/get_workspace_projects.sql
+++ b/master/static/srv/get_workspace_projects.sql
@@ -13,12 +13,12 @@ SELECT p.id, p.name, p.workspace_id, p.description, p.immutable, p.notes,
   SUM(case when pe.project_id = p.id then 1 else 0 end) AS num_experiments,
   SUM(case when pe.project_id = p.id AND pe.state = 'ACTIVE' then 1 else 0 end) AS num_active_experiments,
   MAX(case when pe.project_id = p.id then pe.start_time else NULL end) AS last_experiment_started_at,
-  u.username
+  u.username, p.user_id
 FROM pe, w, projects as p
   LEFT JOIN users as u ON u.id = p.user_id
   WHERE p.workspace_id = $1
   AND ($2 = '' OR (u.username IN (SELECT unnest(string_to_array($2, ',')))))
   AND ($3 = '' OR p.name ILIKE $3)
   AND ($4 = '' OR p.archived = $4::BOOL)
-GROUP BY p.id, u.username, w.archived
+GROUP BY p.id, u.username, p.user_id, w.archived
 ORDER BY %s;

--- a/master/static/srv/get_workspaces.sql
+++ b/master/static/srv/get_workspaces.sql
@@ -3,7 +3,7 @@ WITH wp AS (
   FROM workspace_pins
   WHERE user_id = $5
 )
-SELECT w.id, w.name, w.archived, w.immutable, u.username,
+SELECT w.id, w.name, w.archived, w.immutable, u.username, w.user_id,
 (wp.id IS NOT NULL) AS pinned,
 (SELECT COUNT(*) FROM projects WHERE workspace_id = w.id) AS num_projects
 

--- a/master/static/srv/insert_project.sql
+++ b/master/static/srv/insert_project.sql
@@ -3,6 +3,7 @@ WITH p AS (
   VALUES ($1, $2, $3, $4)
   RETURNING id, name, description, archived, immutable, workspace_id, user_id
 )
-SELECT p.id, p.name, p.description, p.archived, p.immutable, p.workspace_id, u.username
+SELECT p.id, p.name, p.description, p.archived, p.immutable, p.workspace_id,
+  p.user_id, u.username
 FROM p
 JOIN users u on u.id = p.user_id;

--- a/master/static/srv/insert_workspace.sql
+++ b/master/static/srv/insert_workspace.sql
@@ -3,6 +3,6 @@ WITH w AS (
   VALUES ($1, $2)
   RETURNING id, name, archived, immutable, user_id
 )
-SELECT w.id, w.name, w.archived, w.immutable, u.username
+SELECT w.id, w.name, w.archived, w.immutable, u.username, w.user_id
 FROM w
 JOIN users u on u.id = w.user_id;

--- a/master/static/srv/update_project.sql
+++ b/master/static/srv/update_project.sql
@@ -17,5 +17,5 @@ u AS (
 )
 SELECT p.id, p.name, p.workspace_id, p.description, p.archived, p.immutable, p.notes,
 pe.last_experiment_started_at, pe.num_experiments, pe.num_active_experiments,
-u.username
+u.username, p.user_id
 FROM p, pe, u;

--- a/master/static/srv/update_workspace.sql
+++ b/master/static/srv/update_workspace.sql
@@ -13,7 +13,7 @@ p AS (
   WHERE workspace_id = $1
 )
 SELECT w.id, w.name, w.archived, w.immutable,
-  u.username, p.num_projects,
+  u.username, w.user_id, p.num_projects,
   (SELECT COUNT(*) > 0 FROM workspace_pins
     WHERE workspace_id = $1 AND user_id = $3
   ) AS pinned

--- a/proto/src/determined/api/v1/experiment.proto
+++ b/proto/src/determined/api/v1/experiment.proto
@@ -292,6 +292,8 @@ message CreateExperimentRequest {
   int32 parent_id = 4;
   // Request to auto-activate the experiment.
   bool activate = 5;
+  // Project id to contain the experiment.
+  int32 project_id = 6;
 }
 // Response to CreateExperimentRequest.
 message CreateExperimentResponse {

--- a/proto/src/determined/project/v1/project.proto
+++ b/proto/src/determined/project/v1/project.proto
@@ -32,6 +32,7 @@ message Project {
         "notes",
         "num_active_experiments",
         "num_experiments",
+        "user_id",
         "username",
         "workspace_id"
       ]
@@ -61,6 +62,8 @@ message Project {
   string username = 10;
   // Whether this project is immutable (default uncategorized project).
   bool immutable = 11;
+  // ID of the user who created this project.
+  int32 user_id = 12;
 }
 
 // ProjectModel is a checkpoint associated with a project.

--- a/proto/src/determined/workspace/v1/workspace.proto
+++ b/proto/src/determined/workspace/v1/workspace.proto
@@ -17,7 +17,8 @@ message Workspace {
         "name",
         "num_projects",
         "pinned",
-        "username"
+        "username",
+        "user_id"
       ]
     }
   };
@@ -37,6 +38,8 @@ message Workspace {
   int32 num_projects = 6;
   // Pin status of this workspace for the current user.
   bool pinned = 7;
+  // ID of the user who created this project.
+  int32 user_id = 8;
 }
 
 // PatchWorkspace is a partial update to a workspace with all optional fields.

--- a/webui/react/src/hooks/useModal/useModalExperimentCreate.tsx
+++ b/webui/react/src/hooks/useModal/useModalExperimentCreate.tsx
@@ -197,6 +197,7 @@ const useModalExperimentCreate = (props?: Props): ModalHooks => {
         activate: true,
         experimentConfig: newConfig,
         parentId: modalState.experiment.id,
+        projectId: modalState.experiment.projectId,
       });
 
       // Route to reload path to forcibly remount experiment page.

--- a/webui/react/src/services/api-ts-sdk/api.ts
+++ b/webui/react/src/services/api-ts-sdk/api.ts
@@ -4683,6 +4683,12 @@ export interface V1Project {
      * @memberof V1Project
      */
     immutable: boolean;
+    /**
+     * ID of the user who created this project.
+     * @type {number}
+     * @memberof V1Project
+     */
+    userId: number;
 }
 
 /**
@@ -6627,6 +6633,12 @@ export interface V1Workspace {
      * @memberof V1Workspace
      */
     pinned: boolean;
+    /**
+     * ID of the user who created this project.
+     * @type {number}
+     * @memberof V1Workspace
+     */
+    userId: number;
 }
 
 

--- a/webui/react/src/services/api-ts-sdk/api.ts
+++ b/webui/react/src/services/api-ts-sdk/api.ts
@@ -1427,6 +1427,12 @@ export interface V1CreateExperimentRequest {
      * @memberof V1CreateExperimentRequest
      */
     activate?: boolean;
+    /**
+     * Project id to contain the experiment.
+     * @type {number}
+     * @memberof V1CreateExperimentRequest
+     */
+    projectId?: number;
 }
 
 /**

--- a/webui/react/src/services/apiConfig.ts
+++ b/webui/react/src/services/apiConfig.ts
@@ -259,6 +259,7 @@ export const createExperiment: Service.DetApi<
         activate: params.activate,
         config: params.experimentConfig,
         parentId: params.parentId,
+        projectId: params.projectId,
       },
       options,
     );

--- a/webui/react/src/services/types.ts
+++ b/webui/react/src/services/types.ts
@@ -179,6 +179,7 @@ export interface CreateExperimentParams {
   activate?: boolean;
   experimentConfig: string;
   parentId: number;
+  projectId: number;
 }
 
 export interface PatchExperimentParams extends ExperimentIdParams {


### PR DESCRIPTION
## Description

- Workspaces and projects have a name between 1 and 80 chars.
- Forking an experiment in the WebUI keeps it in the same project.
- Allow user to delete workspaces with a project, projects with an experiment, or combined (deleting workspaces with a project with an experiment).  The experiments are not deleted and go to the Uncategorized project (project_id = 1).

## Test Plan

- [x] Workspaces and projects have a name between 1 and 80 chars.
- [x] Forking an experiment in the WebUI keeps it in the same project.
- [x] Allow user to delete workspaces with a project, projects with an experiment, or combined (deleting workspaces with a project with an experiment). The experiments are not deleted and go to the Uncategorized project (project_id = 1).



## Checklist

- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.