### PR TITLE
feat: add det.LOG_FORMAT constant

### DIFF
--- a/docs/training-apis/api-core/distributed.txt
+++ b/docs/training-apis/api-core/distributed.txt
@@ -66,7 +66,7 @@ considerations are:
       :language: python
       :dedent:
       :start-after: some logs are easier to read
-      :end-at: print
+      :end-at: logging.info
 
 #. Only the chief worker is permitted to report training metrics, report validation metrics, upload
    checkpoints, or report searcher operations completed. This rule applies to the steps you take
@@ -83,7 +83,7 @@ considerations are:
    .. literalinclude:: ../../../examples/tutorials/core_api/4_distributed.py
       :language: python
       :dedent:
-      :start-after: only the chief is able to report_validation_metrics
+      :start-after: only the chief may report validation metrics
       :end-at: op.report_completed
 
    The rule also applies to the conditional save after the main loop completes:
@@ -91,7 +91,7 @@ considerations are:
    .. literalinclude:: ../../../examples/tutorials/core_api/4_distributed.py
       :language: python
       :dedent:
-      :start-at: again, only the chief uploads checkpoints
+      :start-at: again, only the chief may upload checkpoints
       :end-at: save_state
 
 #. Create a ``4_distributed.yaml`` file by copying the ``3_distributed.yaml`` file and changing the

--- a/docs/training-apis/api-core/getting-started.txt
+++ b/docs/training-apis/api-core/getting-started.txt
@@ -12,8 +12,7 @@ The ``0_start.py`` training script used in this example contains your simple "mo
 
 .. literalinclude:: ../../../examples/tutorials/core_api/0_start.py
    :language: python
-   :start-after: START getting-started doc
-   :end-before: END getting-started doc
+   :start-at: import
 
 To run this script, create a configuration file with at least the following values:
 

--- a/docs/training-apis/api-core/metrics.txt
+++ b/docs/training-apis/api-core/metrics.txt
@@ -17,6 +17,15 @@ with only a few new lines of code.
       :start-after: NEW: import determined
       :end-before: def main
 
+#. Enable ``logging``, using the ``det.LOG_FORMAT`` for logs. Enabling ``logging`` enables useful
+   log messages from the ``determined`` library, and det.LOG_FORMAT enables filter-by-level in the
+   WebUI.
+
+   .. literalinclude:: ../../../examples/tutorials/core_api/1_metrics.py
+      :language: python
+      :start-at: logging.basicConfig
+      :end-at: logging.error
+
 #. In your ``if __name__ == "__main__"`` block, wrap the entire execution of ``main()`` within the
    scope of :meth:`determined.core.init`, which prepares resources for training and cleans them up
    afterward. Add the ``core_context`` as a new argument to ``main()`` because the Core API is
@@ -24,7 +33,7 @@ with only a few new lines of code.
 
    .. literalinclude:: ../../../examples/tutorials/core_api/1_metrics.py
       :language: python
-      :start-at: if __name__ == "__main__"
+      :start-at: with det.core.init
 
 #. Within ``main()``, add two calls. One to report training metrics, which is called periodically
    during training, and one to report validation metrics, which is called every time a validation

--- a/examples/tutorials/core_api/0_start.py
+++ b/examples/tutorials/core_api/0_start.py
@@ -9,7 +9,6 @@ than this.  By following these examples you can get an idea of how to modify
 your own script to integrate with the Core API.
 """
 
-# START getting-started doc
 import logging
 import sys
 import time
@@ -20,11 +19,8 @@ def main(increment_by):
     for batch in range(100):
         x += increment_by
         time.sleep(.1)
-        print("x is now", x)
+        print(f"x is now {x}")
 
 
 if __name__ == "__main__":
-    logging.basicConfig(stream=sys.stdout, level=logging.INFO)
-
     main(increment_by=1)
-# END getting-started doc

--- a/examples/tutorials/core_api/1_metrics.py
+++ b/examples/tutorials/core_api/1_metrics.py
@@ -19,7 +19,7 @@ def main(core_context, increment_by):
         x += increment_by
         steps_completed = batch + 1
         time.sleep(.1)
-        print("x is now", x)
+        logging.info(f"x is now {x}")
         # NEW: report training metrics.
         if steps_completed % 10 == 0:
             core_context.train.report_training_metrics(
@@ -32,7 +32,15 @@ def main(core_context, increment_by):
 
 
 if __name__ == "__main__":
-    logging.basicConfig(stream=sys.stdout, level=logging.INFO)
+    # NEW: enable logging, using the det.LOG_FORMAT.  Enabling
+    # logging enables useful log messages from the determined library,
+    # and det.LOG_FORMAT enables filter-by-level in the WebUI.
+    logging.basicConfig(level=logging.DEBUG, format=det.LOG_FORMAT)
+    # Log at different levels to demonstrate filter-by-level in the WebUI.
+    logging.debug("debug-level message")
+    logging.info("info-level message")
+    logging.warning("warning-level message")
+    logging.error("error-level message")
 
     # NEW: create a context, and pass it to the main function.
     with det.core.init() as core_context:

--- a/examples/tutorials/core_api/2_checkpoints.py
+++ b/examples/tutorials/core_api/2_checkpoints.py
@@ -54,7 +54,7 @@ def main(core_context, latest_checkpoint, trial_id, increment_by):
         x += increment_by
         steps_completed = batch + 1
         time.sleep(.1)
-        print("x is now", x)
+        logging.info(f"x is now {x}")
         if steps_completed % 10 == 0:
             core_context.train.report_training_metrics(
                 steps_completed=steps_completed, metrics={"x": x}
@@ -80,7 +80,7 @@ def main(core_context, latest_checkpoint, trial_id, increment_by):
 
 
 if __name__ == "__main__":
-    logging.basicConfig(stream=sys.stdout, level=logging.INFO)
+    logging.basicConfig(level=logging.INFO, format=det.LOG_FORMAT)
 
     # NEW: use the ClusterInfo API to access information about the current running task.  We
     # choose to extract the information we need from the ClusterInfo API here and pass it into

--- a/examples/tutorials/core_api/3_hpsearch.py
+++ b/examples/tutorials/core_api/3_hpsearch.py
@@ -44,7 +44,7 @@ def main(core_context, latest_checkpoint, trial_id, increment_by):
             x += increment_by
             steps_completed = batch + 1
             time.sleep(.1)
-            print("x is now", x)
+            logging.info(f"x is now {x}")
             if steps_completed % 10 == 0:
                 core_context.train.report_training_metrics(
                     steps_completed=steps_completed, metrics={"x": x}
@@ -75,7 +75,7 @@ def main(core_context, latest_checkpoint, trial_id, increment_by):
 
 
 if __name__ == "__main__":
-    logging.basicConfig(stream=sys.stdout, level=logging.INFO)
+    logging.basicConfig(level=logging.INFO, format=det.LOG_FORMAT)
 
     info = det.get_cluster_info()
     assert info is not None, "this example only runs on-cluster"

--- a/harness/determined/__init__.py
+++ b/harness/determined/__init__.py
@@ -19,3 +19,9 @@ from determined._execution import (
 from determined._hparam import Categorical, Constant, Double, Integer, Log
 from determined import errors
 from determined import util
+
+# LOG_FORMAT is the standard format for use with the logging module, which is required for the
+# WebUI's log viewer to filter logs by log level.
+#
+# Dev note: if this format is changed, the fluentbit log parsing must be updated as well.
+LOG_FORMAT = "%(levelname)s: [%(process)s] %(name)s: %(message)s"

--- a/harness/determined/common/_logging.py
+++ b/harness/determined/common/_logging.py
@@ -1,6 +1,8 @@
 import logging
 import sys
 
+import determined as det
+
 
 def set_logger(debug_enabled: bool) -> None:
     root = logging.getLogger()
@@ -11,7 +13,6 @@ def set_logger(debug_enabled: bool) -> None:
 
     handler = logging.StreamHandler(sys.stdout)
     handler.setLevel(logging.DEBUG if debug_enabled else logging.INFO)
-    # If this format is changed, we must update fluentbit, which attempts to parse these logs.
-    formatter = logging.Formatter("%(levelname)s: [%(process)s] %(name)s: %(message)s")
+    formatter = logging.Formatter(det.LOG_FORMAT)
     handler.setFormatter(formatter)
     root.addHandler(handler)


### PR DESCRIPTION
Expose our log format to Core API users, who are responsible for
configuring logging on their own.  However, they need to user our format
for the log-level filtering to work in the WebUI.

## Commentary

Since we concluded that we _had_ to make users use a [per-rank wrapper script](https://github.com/determined-ai/determined/pull/4086), I didn't see a reason to have a `det.configure_logging(level=...)` call when there's a perfectly good `logging.basicConfig()` in the standard library that only needs a `format=det.LOG_FORMAT` parameter to work for us.

Telling users they need to use this format, however they decide to set up their logging, is much more flexible to the end user, which is in line with the philosophy of the core api.