### PR TITLE
chore: multiple distributed jobs collide on horovod run sshd port [HAL-2894]

### DIFF
--- a/harness/determined/constants.py
+++ b/harness/determined/constants.py
@@ -1,3 +1,5 @@
+import os
+
 # The maximum number of slots we expect any agent to have. Since we offset some ports
 # by the min(device_id) belonging to the trial, if we have two ports offset in this way,
 # we separate them by the max(min(device_id)) to avoid collisions. The two rendezvous ports
@@ -24,16 +26,21 @@ DEFAULT_EXP_CFG = {
     "optimizations": DEFAULT_OPTIMIZATIONS,
 }
 
+# Until we implement a more automatic solution, expose a temporary workaround of
+# allowing ports to be changed using envionment variables for the rare case that
+# the default ports are already in use by other processes.
+
 # TODO (DET-1189): Use port registry to allocate ssh port.
 # SSH port used for agents during dtrain (currently used with horovod and deepspeed backend).
-DTRAIN_SSH_PORT = 12350
+DTRAIN_SSH_PORT = int(str(os.getenv("DTRAIN_SSH_PORT", "12350")))
 
 # GLOO port used by Horovod for the Gloo controller.
-HOROVOD_GLOO_RENDEZVOUS_PORT = 12355
+HOROVOD_GLOO_RENDEZVOUS_PORT = int(str(os.getenv("HOROVOD_GLOO_RENDEZVOUS_PORT", "12355")))
 
 # Port for communicating between training processes. Used for reducing
 # validation metrics.
-INTER_TRAIN_PROCESS_COMM_PORT_1 = 12360
+INTER_TRAIN_PROCESS_COMM_PORT_1 = int(str(os.getenv("INTER_TRAIN_PROCESS_COMM_PORT_1", "12360")))
+
 INTER_TRAIN_PROCESS_COMM_PORT_2 = INTER_TRAIN_PROCESS_COMM_PORT_1 + MAX_SLOTS_PER_AGENT
 
 # How many seconds horovod waits for startup to complete before failing.


### PR DESCRIPTION
… port

## Description

Allow the user to change the ports used by Determined do deal with the situation where those ports may already be in use by another process on the compute node.

## Test Plan

Tested using the "cifar10_pytorch" experiment with the "distributed.yaml" file and these environment variables.  The experiment completed successfully.

```
environment:
  environment_variables:
     - DTRAIN_SSH_PORT=13000
     - HOROVOD_GLOO_RENDEZVOUS_PORT=13010
     - INTER_TRAIN_PROCESS_COMM_PORT_1=13020
```

Bradley said that users will typically be instructed to set these environment variables in "startup-hook.sh", rather than in the experiment's YAML file.  I set them in the experiment's YAML file for testing.

```
you dont even need to make configurations for all of this, for now
it can be 'secret'
we source startup-hook.sh where the hook is user provided
they can just set there if they need
it's a lot of work and much more public to open configs
```

## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
