### PR TITLE
fix: use custom image for tensor board [DET-7242]

### DIFF
--- a/e2e_tests/tests/command/command.py
+++ b/e2e_tests/tests/command/command.py
@@ -12,7 +12,7 @@ from tests import config as conf
 
 
 @contextmanager
-def interactive_command(*args: str, task_id: Optional[str] = None) -> Generator:
+def interactive_command(*args: str) -> Generator:
     """
     Runs a Determined CLI command in a subprocess. On exit, it kills the
     corresponding Determined task if possible before closing the subprocess.
@@ -26,14 +26,11 @@ def interactive_command(*args: str, task_id: Optional[str] = None) -> Generator:
     """
 
     class _InteractiveCommandProcess:
-        def __init__(
-            self, process: subprocess.Popen, detach: bool = False, task_id: Optional[str] = None
-        ):
+        def __init__(self, process: subprocess.Popen, detach: bool = False):
             self.process = process
             self.detach = detach
-            self.task_id = task_id  # type: Optional[str]
-            if task_id is not None:
-                return
+            self.task_id = None  # type: Optional[str]
+
             if self.detach:
                 iterator = iter(self.process.stdout)  # type: ignore
                 line = next(iterator)
@@ -67,7 +64,7 @@ def interactive_command(*args: str, task_id: Optional[str] = None) -> Generator:
         stdout=subprocess.PIPE,
         env={"PYTHONUNBUFFERED": "1", **os.environ},
     ) as p:
-        cmd = _InteractiveCommandProcess(p, detach="--detach" in args, task_id=task_id)
+        cmd = _InteractiveCommandProcess(p, detach="--detach" in args)
         if cmd.task_id is None:
             raise AssertionError(
                 "Task ID for '{}' could not be found. "

--- a/e2e_tests/tests/command/test_tensorboard.py
+++ b/e2e_tests/tests/command/test_tensorboard.py
@@ -163,13 +163,11 @@ def test_start_tensorboard_for_multi_experiment(tmp_path: Path, secrets: Dict[st
 
 @pytest.mark.slow
 @pytest.mark.e2e_cpu
-def test_start_tensorboard_with_custom_image(
-    tmp_path: Path
-) -> None:
+def test_start_tensorboard_with_custom_image(tmp_path: Path) -> None:
     """
     Start a random experiment configured with the shared_fs backend, start a
-    TensorBoard instance pointed to the experiment with custom image, verify the image has been set, and kill the TensorBoard
-    instance.
+    TensorBoard instance pointed to the experiment with custom image, verify 
+    the image has been set, and kill the TensorBoard instance.
     """
     with FileTree(tmp_path, {"config.yaml": shared_fs_config(1)}) as tree:
         config_path = tree.joinpath("config.yaml")

--- a/e2e_tests/tests/command/test_tensorboard.py
+++ b/e2e_tests/tests/command/test_tensorboard.py
@@ -12,7 +12,6 @@ from tests.filetree import FileTree
 AWAITING_METRICS = "TensorBoard is awaiting metrics"
 SERVICE_READY = "TensorBoard is running at: http"
 num_trials = 1
-custom_image_for_testing = "custom_alpine"
 
 
 def shared_fs_config(num_trials: int) -> str:
@@ -163,23 +162,21 @@ def test_start_tensorboard_for_multi_experiment(tmp_path: Path, secrets: Dict[st
 
 
 @pytest.mark.slow
-@pytest.mark.e2e_gpu
-@pytest.mark.tensorflow2
-@pytest.mark.parametrize("prefix", [None, "my/test/prefix"])
+@pytest.mark.e2e_cpu
 def test_start_tensorboard_with_custom_image(
-    tmp_path: Path, secrets: Dict[str, str], prefix: Optional[str]
+    tmp_path: Path
 ) -> None:
     """
     Start a random experiment configured with the shared_fs backend, start a
-    TensorBoard instance pointed to the experiment, and kill the TensorBoard
+    TensorBoard instance pointed to the experiment with custom image, verify the image has been set, and kill the TensorBoard
     instance.
     """
-    with FileTree(tmp_path, {"config.yaml": s3_config(1, secrets, prefix)}) as tree:
+    with FileTree(tmp_path, {"config.yaml": shared_fs_config(1)}) as tree:
         config_path = tree.joinpath("config.yaml")
         experiment_id = exp.run_basic_test(
             str(config_path), conf.fixtures_path("no_op"), num_trials
         )
-
+    not_a_real_image = "not_a_real_image"
     command = [
         "tensorboard",
         "start",
@@ -187,15 +184,15 @@ def test_start_tensorboard_with_custom_image(
         "--no-browser",
         "--detach",
         "--config",
-        f"environment.image={custom_image_for_testing}",
+        f"environment.image={not_a_real_image}",
     ]
     with cmd.interactive_command(*command) as tensorboard:
         t_id = tensorboard.task_id
         commandt = ["tensorboard", "config", t_id]
         with cmd.interactive_command(*commandt, task_id=t_id) as tensorboard_config:
             for line in tensorboard_config.stdout:
-                if "cpu" in line or "cuda:" in line or "rocm" in line:
-                    if custom_image_for_testing in line:
+                if "cpu" in line or "cuda" in line or "rocm" in line:
+                    if not_a_real_image in line:
                         break
                     else:
                         raise AssertionError(f"Setting custom image not working properly: {line}")

--- a/e2e_tests/tests/command/test_tensorboard.py
+++ b/e2e_tests/tests/command/test_tensorboard.py
@@ -161,7 +161,6 @@ def test_start_tensorboard_for_multi_experiment(tmp_path: Path, secrets: Dict[st
             raise AssertionError(f"Did not find {SERVICE_READY} in output")
 
 
-@pytest.mark.slow
 @pytest.mark.e2e_cpu
 def test_start_tensorboard_with_custom_image(tmp_path: Path) -> None:
     """

--- a/e2e_tests/tests/command/test_tensorboard.py
+++ b/e2e_tests/tests/command/test_tensorboard.py
@@ -1,4 +1,3 @@
-import os
 import subprocess
 from pathlib import Path
 from typing import Dict, Optional
@@ -166,8 +165,8 @@ def test_start_tensorboard_for_multi_experiment(tmp_path: Path, secrets: Dict[st
 @pytest.mark.e2e_cpu
 def test_start_tensorboard_with_custom_image(tmp_path: Path) -> None:
     """
-    Start a random experiment, start a TensorBoard instance pointed 
-    to the experiment with custom image, verify the image has been set, 
+    Start a random experiment, start a TensorBoard instance pointed
+    to the experiment with custom image, verify the image has been set,
     and kill the TensorBoard instance.
     """
     experiment_id = exp.run_basic_test(
@@ -187,14 +186,10 @@ def test_start_tensorboard_with_custom_image(tmp_path: Path) -> None:
         "--config",
         "environment.image=alpine",
     ]
-    res = subprocess.run(
-        command, universal_newlines=True, stdout=subprocess.PIPE, check=True
-    )
-    t_id = res.stdout.strip('\n')
+    res = subprocess.run(command, universal_newlines=True, stdout=subprocess.PIPE, check=True)
+    t_id = res.stdout.strip("\n")
     command = ["det", "-m", conf.make_master_url(), "tensorboard", "config", t_id]
-    res = subprocess.run(
-        command, universal_newlines=True, stdout=subprocess.PIPE, check=True
-    )
+    res = subprocess.run(command, universal_newlines=True, stdout=subprocess.PIPE, check=True)
     config = yaml.safe_load(res.stdout)
     assert (
         config["environment"]["image"]["cpu"] == "alpine"

--- a/e2e_tests/tests/command/test_tensorboard.py
+++ b/e2e_tests/tests/command/test_tensorboard.py
@@ -166,7 +166,7 @@ def test_start_tensorboard_for_multi_experiment(tmp_path: Path, secrets: Dict[st
 def test_start_tensorboard_with_custom_image(tmp_path: Path) -> None:
     """
     Start a random experiment configured with the shared_fs backend, start a
-    TensorBoard instance pointed to the experiment with custom image, verify 
+    TensorBoard instance pointed to the experiment with custom image, verify
     the image has been set, and kill the TensorBoard instance.
     """
     with FileTree(tmp_path, {"config.yaml": shared_fs_config(1)}) as tree:

--- a/e2e_tests/tests/command/test_tensorboard.py
+++ b/e2e_tests/tests/command/test_tensorboard.py
@@ -201,9 +201,4 @@ def test_start_tensorboard_with_custom_image(
                         raise AssertionError(f"Setting custom image not working properly: {line}")
             else:
                 raise AssertionError("Did not find custom image in output")
-        #     if SERVICE_READY in line:
-        #         break
-        #     if AWAITING_METRICS in line:
-        #         raise AssertionError("Tensorboard did not find metrics")
-        # else:
-        #     raise AssertionError(f"Did not find {SERVICE_READY} in output")
+                

--- a/e2e_tests/tests/command/test_tensorboard.py
+++ b/e2e_tests/tests/command/test_tensorboard.py
@@ -173,7 +173,6 @@ def test_start_tensorboard_with_custom_image(tmp_path: Path) -> None:
         experiment_id = exp.run_basic_test(
             str(config_path), conf.fixtures_path("no_op"), num_trials
         )
-    not_a_real_image = "not_a_real_image"
     command = [
         "tensorboard",
         "start",
@@ -181,7 +180,7 @@ def test_start_tensorboard_with_custom_image(tmp_path: Path) -> None:
         "--no-browser",
         "--detach",
         "--config",
-        f"environment.image={not_a_real_image}",
+        "environment.image=alpine",
     ]
     with cmd.interactive_command(*command) as tensorboard:
         t_id = tensorboard.task_id
@@ -189,7 +188,7 @@ def test_start_tensorboard_with_custom_image(tmp_path: Path) -> None:
         with cmd.interactive_command(*commandt, task_id=t_id) as tensorboard_config:
             for line in tensorboard_config.stdout:
                 if "cpu" in line or "cuda" in line or "rocm" in line:
-                    if not_a_real_image in line:
+                    if "alpine" in line:
                         break
                     else:
                         raise AssertionError(f"Setting custom image not working properly: {line}")

--- a/e2e_tests/tests/command/test_tensorboard.py
+++ b/e2e_tests/tests/command/test_tensorboard.py
@@ -201,4 +201,3 @@ def test_start_tensorboard_with_custom_image(
                         raise AssertionError(f"Setting custom image not working properly: {line}")
             else:
                 raise AssertionError("Did not find custom image in output")
-                

--- a/master/internal/api_tensorboard.go
+++ b/master/internal/api_tensorboard.go
@@ -14,10 +14,8 @@ import (
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-	"google.golang.org/protobuf/encoding/protojson"
 
 	petname "github.com/dustinkirkland/golang-petname"
-	"github.com/ghodss/yaml"
 
 	"github.com/pkg/errors"
 
@@ -267,7 +265,7 @@ func (a *apiServer) LaunchTensorboard(
 
 	spec.Base.ExtraEnvVars = uniqEnvVars
 
-	if !usingCustomImage(req) {
+	if !model.UsingCustomImage(req) {
 		spec.Config.Environment.Image = model.RuntimeItem{
 			CPU:  expConf.Environment().Image().CPU(),
 			CUDA: expConf.Environment().Image().CUDA(),
@@ -319,31 +317,6 @@ func (a *apiServer) LaunchTensorboard(
 		Tensorboard: tb,
 		Config:      protoutils.ToStruct(spec.Config),
 	}, err
-}
-
-func usingCustomImage(req *apiv1.LaunchTensorboardRequest) bool {
-	if req.Config == nil {
-		return false
-	}
-
-	configBytes, err := protojson.Marshal(req.Config)
-	if err != nil {
-		return false
-	}
-
-	type DummyImg struct {
-		Image string `json:"image"`
-	}
-	type DummyEnv struct {
-		Environment DummyImg `json:"environment"`
-	}
-	dummy := DummyEnv{
-		Environment: DummyImg{},
-	}
-
-	err = yaml.Unmarshal(configBytes, &dummy)
-
-	return err == nil && dummy.Environment.Image != ""
 }
 
 type tensorboardConfig struct {


### PR DESCRIPTION
## Description

When start a tensor board, disable override environment image when custom image is presented. 


## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions about this test plan to ensure adequate manual coverage of changes.
-->


