### PR TITLE
fix: No redirecting url when model name is changed

### DIFF
--- a/webui/react/src/pages/ModelDetails.tsx
+++ b/webui/react/src/pages/ModelDetails.tsx
@@ -298,7 +298,6 @@ const ModelDetails: React.FC = () => {
         body: { name: editedName },
         modelName,
       });
-      routeToReactUrl(paths.modelDetails(editedName));
     } catch (e) {
       handleError(e, {
         publicSubject: 'Unable to save name.',

--- a/webui/react/src/pages/ModelDetails.tsx
+++ b/webui/react/src/pages/ModelDetails.tsx
@@ -19,7 +19,6 @@ import TagList from 'components/TagList';
 import { useStore } from 'contexts/Store';
 import usePolling from 'hooks/usePolling';
 import useSettings from 'hooks/useSettings';
-import { paths } from 'routes/utils';
 import {
   archiveModel, deleteModel, deleteModelVersion, getModelDetails, isNotFound, patchModel,
   patchModelVersion, unarchiveModel,
@@ -31,7 +30,6 @@ import { ModelVersion, ModelVersions } from 'types';
 import handleError from 'utils/error';
 
 import { ErrorType } from '../shared/utils/error';
-import { routeToReactUrl } from '../shared/utils/routes';
 import { isAborted, validateDetApiEnum } from '../shared/utils/service';
 
 import css from './ModelDetails.module.scss';


### PR DESCRIPTION
## Description

For complicated reasons, we have linked to models by name (`/det/models/:name`) in the past. When the model name changed, we used #3559 to redirect to the new model URL.
We now prefer a permanent link with the numeric id  (`/det/models/:id`) so this redirect can be removed.
I don't think there's anywhere else in Web UI where the model name can be changed.

## Test Plan

- Create a model
- Visit that model's detail page
- Change the name of the model (we should not be redirected)
- Refresh the page to confirm that the name was successfully changed

## Checklist

- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.