### PR TITLE
feat: Return additional workspace and project fields in an experiment

### DIFF
--- a/harness/determined/common/api/bindings.py
+++ b/harness/determined/common/api/bindings.py
@@ -1120,10 +1120,14 @@ class v1Experiment:
         forkedFrom: "typing.Optional[int]" = None,
         labels: "typing.Optional[typing.Sequence[str]]" = None,
         notes: "typing.Optional[str]" = None,
+        parentArchived: "typing.Optional[bool]" = None,
         progress: "typing.Optional[float]" = None,
+        projectName: "typing.Optional[str]" = None,
         resourcePool: "typing.Optional[str]" = None,
         trialIds: "typing.Optional[typing.Sequence[int]]" = None,
         userId: "typing.Optional[int]" = None,
+        workspaceId: "typing.Optional[int]" = None,
+        workspaceName: "typing.Optional[str]" = None,
     ):
         self.id = id
         self.description = description
@@ -1145,6 +1149,10 @@ class v1Experiment:
         self.forkedFrom = forkedFrom
         self.progress = progress
         self.projectId = projectId
+        self.projectName = projectName
+        self.workspaceId = workspaceId
+        self.workspaceName = workspaceName
+        self.parentArchived = parentArchived
 
     @classmethod
     def from_json(cls, obj: Json) -> "v1Experiment":
@@ -1169,6 +1177,10 @@ class v1Experiment:
             forkedFrom=obj.get("forkedFrom", None),
             progress=float(obj["progress"]) if obj.get("progress", None) is not None else None,
             projectId=obj["projectId"],
+            projectName=obj.get("projectName", None),
+            workspaceId=obj.get("workspaceId", None),
+            workspaceName=obj.get("workspaceName", None),
+            parentArchived=obj.get("parentArchived", None),
         )
 
     def to_json(self) -> typing.Any:
@@ -1193,6 +1205,10 @@ class v1Experiment:
             "forkedFrom": self.forkedFrom if self.forkedFrom is not None else None,
             "progress": dump_float(self.progress) if self.progress is not None else None,
             "projectId": self.projectId,
+            "projectName": self.projectName if self.projectName is not None else None,
+            "workspaceId": self.workspaceId if self.workspaceId is not None else None,
+            "workspaceName": self.workspaceName if self.workspaceName is not None else None,
+            "parentArchived": self.parentArchived if self.parentArchived is not None else None,
         }
 
 class v1ExperimentSimulation:

--- a/master/static/srv/get_experiment.sql
+++ b/master/static/srv/get_experiment.sql
@@ -14,7 +14,7 @@ SELECT
     e.start_time AS start_time,
     e.end_time AS end_time,
     'STATE_' || e.state AS state,
-    (w.archived OR p.archived OR e.archived) AS archived,
+    e.archived AS archived,
     e.progress AS progress,
     e.job_id AS job_id,
     e.parent_id AS forked_from,
@@ -22,7 +22,11 @@ SELECT
     u.username AS username,
     (SELECT json_agg(id) FROM trial_ids) AS trial_ids,
 	  (SELECT count(id) FROM trial_ids) AS num_trials,
-    e.project_id AS project_id
+    p.id AS project_id,
+    p.name AS project_name,
+    w.id AS workspace_id,
+    w.name AS workspace_name,
+    (w.archived OR p.archived) AS parent_archived
 FROM
     experiments e
 JOIN users u ON e.owner_id = u.id

--- a/master/static/srv/get_experiment.sql
+++ b/master/static/srv/get_experiment.sql
@@ -14,7 +14,7 @@ SELECT
     e.start_time AS start_time,
     e.end_time AS end_time,
     'STATE_' || e.state AS state,
-    e.archived AS archived,
+    (w.archived OR p.archived OR e.archived) AS archived,
     e.progress AS progress,
     e.job_id AS job_id,
     e.parent_id AS forked_from,
@@ -26,4 +26,6 @@ SELECT
 FROM
     experiments e
 JOIN users u ON e.owner_id = u.id
+LEFT JOIN projects p ON e.project_id = p.id
+LEFT JOIN workspaces w ON p.workspace_id = w.id
 WHERE e.id = $1

--- a/proto/src/determined/experiment/v1/experiment.proto
+++ b/proto/src/determined/experiment/v1/experiment.proto
@@ -95,8 +95,17 @@ message Experiment {
   google.protobuf.Int32Value forked_from = 16;
   // The current progress of a running experiment.
   google.protobuf.DoubleValue progress = 17;
-  // The id of a project associated with this experiment.
+  // The id of the project associated with this experiment.
   int32 project_id = 21;
+  // The name of the project associated with this experiment.
+  string project_name = 22;
+  // The id of the workspace associated with this experiment.
+  int32 workspace_id = 23;
+  // The name of the workspace associated with this experiment.
+  string workspace_name = 24;
+  // The archived status of the parent project (can be inherited from
+  // workspace).
+  bool parent_archived = 25;
 }
 
 // PatchExperiment is a partial update to an experiment with only id required.

--- a/webui/react/src/services/api-ts-sdk/api.ts
+++ b/webui/react/src/services/api-ts-sdk/api.ts
@@ -1746,11 +1746,35 @@ export interface V1Experiment {
      */
     progress?: number;
     /**
-     * The id of a project associated with this experiment.
+     * The id of the project associated with this experiment.
      * @type {number}
      * @memberof V1Experiment
      */
     projectId: number;
+    /**
+     * The name of the project associated with this experiment.
+     * @type {string}
+     * @memberof V1Experiment
+     */
+    projectName?: string;
+    /**
+     * The id of the workspace associated with this experiment.
+     * @type {number}
+     * @memberof V1Experiment
+     */
+    workspaceId?: number;
+    /**
+     * The name of the workspace associated with this experiment.
+     * @type {string}
+     * @memberof V1Experiment
+     */
+    workspaceName?: string;
+    /**
+     * The archived status of the parent project (can be inherited from workspace).
+     * @type {boolean}
+     * @memberof V1Experiment
+     */
+    parentArchived?: boolean;
 }
 
 /**


### PR DESCRIPTION
## Description

Individual experiments return workspace_id, workspace_name, project_id, project_name, and parent_archived (w.archived OR p.archived).

## Test Plan

Check API response from an experiment in a non-default workspace

## Checklist

- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.
