### PR TITLE
fix: Prevent archived experiments from being moved or forked

### DIFF
--- a/master/static/srv/move_experiment.sql
+++ b/master/static/srv/move_experiment.sql
@@ -1,6 +1,7 @@
 WITH e AS (
   SELECT id, project_id FROM experiments
   WHERE id = $1
+  AND NOT archived
 ),
 p AS (
   SELECT projects.id, projects.workspace_id FROM projects, e

--- a/webui/react/src/components/PageHeaderFoldable.tsx
+++ b/webui/react/src/components/PageHeaderFoldable.tsx
@@ -7,6 +7,7 @@ import { isMouseEvent } from 'routes/utils';
 import css from './PageHeaderFoldable.module.scss';
 
 export interface Option {
+  disabled?: boolean,
   icon?: React.ReactNode,
   isLoading?: boolean,
   key: string;
@@ -45,7 +46,7 @@ const PageHeaderFoldable: React.FC<Props> = (
         {options.map(opt => (
           <Menu.Item
             className={css.optionsDropdownItem}
-            disabled={!opt.onClick}
+            disabled={opt.disabled || !opt.onClick}
             key={opt.key}
             onClick={(e) => isMouseEvent(e.domEvent) && opt.onClick && opt.onClick(e.domEvent)}>
             {renderOptionLabel(opt)}
@@ -70,7 +71,7 @@ const PageHeaderFoldable: React.FC<Props> = (
           {options?.slice(0, 3).map((opt, i) => (
             <Button
               className={css.optionsMainButton}
-              disabled={!opt.onClick}
+              disabled={opt.disabled || !opt.onClick}
               ghost={i !== 0}
               icon={opt?.icon}
               key={opt.key}

--- a/webui/react/src/pages/ExperimentDetails/ExperimentDetailsHeader.tsx
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentDetailsHeader.tsx
@@ -201,6 +201,7 @@ const ExperimentDetailsHeader: React.FC<Props> = ({
         },
       },
       fork: {
+        disabled: experiment.archived || experiment.parentArchived,
         icon: <Icon name="fork" size="small" />,
         key: 'fork',
         label: 'Fork',
@@ -253,6 +254,7 @@ const ExperimentDetailsHeader: React.FC<Props> = ({
     isRunningDelete,
     experiment.archived,
     experiment.id,
+    experiment.parentArchived,
     experiment.state,
     experiment.username,
     fetchExperimentDetails,

--- a/webui/react/src/services/decoder.ts
+++ b/webui/react/src/services/decoder.ts
@@ -395,6 +395,7 @@ export const mapV1Experiment = (
     name: data.name,
     notes: data.notes,
     numTrials: data.numTrials || 0,
+    parentArchived: data.parentArchived || false,
     progress: data.progress != null ? data.progress : undefined,
     projectId: data.projectId,
     resourcePool: data.resourcePool || '',

--- a/webui/react/src/types.ts
+++ b/webui/react/src/types.ts
@@ -456,6 +456,7 @@ export interface ExperimentItem {
   name: string;
   notes?: string;
   numTrials: number;
+  parentArchived: boolean;
   progress?: number;
   projectId: number;
   resourcePool: string;
@@ -547,6 +548,7 @@ export type CompoundRunState = RunState | JobState
 
 export interface ExperimentTask extends Task {
   archived: boolean;
+  parentArchived?: boolean;
   progress?: number;
   projectId: number;
   resourcePool: string;

--- a/webui/react/src/utils/task.ts
+++ b/webui/react/src/utils/task.ts
@@ -48,6 +48,7 @@ export function generateExperimentTask(idx: number): Type.RecentExperimentTask {
   return {
     ...task,
     archived: false,
+    parentArchived: false,
     progress,
     projectId: 1,
     state: state as Type.RunState,


### PR DESCRIPTION
## Description

One-line fix to prevent an archived experiment from being selected and moved between projects from CLI/API

## Checklist

- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.