### PR TITLE
docs: update pytorch-mnist-tutorial.txt

### DIFF
--- a/docs/tutorials/pytorch-mnist-tutorial.txt
+++ b/docs/tutorials/pytorch-mnist-tutorial.txt
@@ -188,7 +188,7 @@ Defining ``train_batch``
 ========================
 
 The :func:`~determined.pytorch.PyTorchTrial.train_batch` method is passed a single batch of data
-from the validation data set; it should run the forward passes on the models, the backward passes on
+from the training data set; it should run the forward passes on the models, the backward passes on
 the losses, and step the optimizers. This method should return a dictionary with user-defined
 training metrics; Determined will automatically average all the metrics across batches. If an
 optimizer is set to automatically handle zeroing out the gradients, ``step_optimizer`` will zero out


### PR DESCRIPTION
## Title
docs: update pytorch-mnist-tutorial.txt

## Description
Corrected line 191 from saying validation data set to training data set.
No Jira Ticket. Discussed with Hoang Phan.

## Test Plan
no testing, just doc change. (wording)



