### PR TITLE
chore: Use new boolean patch in workspaces bindings

### DIFF
--- a/harness/determined/cli/experiment.py
+++ b/harness/determined/cli/experiment.py
@@ -507,7 +507,7 @@ def list_experiments(args: Namespace) -> None:
         "offset": args.offset,
     }
     if not args.all:
-        kwargs["archived"] = "false"
+        kwargs["archived"] = False
         kwargs["users"] = [authentication.must_cli_auth().get_session_user()]
     all_experiments: List[bindings.v1Experiment] = limit_offset_paginator(
         bindings.get_GetExperiments, "experiments", setup_session(args), **kwargs

--- a/harness/determined/common/api/bindings.py
+++ b/harness/determined/common/api/bindings.py
@@ -78,32 +78,6 @@ class GetHPImportanceResponseMetricHPImportance:
             "inProgress": self.inProgress if self.inProgress is not None else None,
         }
 
-class GetTrialResponseWorkloadContainer:
-    def __init__(
-        self,
-        checkpoint: "typing.Optional[v1CheckpointWorkload]" = None,
-        training: "typing.Optional[v1MetricsWorkload]" = None,
-        validation: "typing.Optional[v1MetricsWorkload]" = None,
-    ):
-        self.training = training
-        self.validation = validation
-        self.checkpoint = checkpoint
-
-    @classmethod
-    def from_json(cls, obj: Json) -> "GetTrialResponseWorkloadContainer":
-        return cls(
-            training=v1MetricsWorkload.from_json(obj["training"]) if obj.get("training", None) is not None else None,
-            validation=v1MetricsWorkload.from_json(obj["validation"]) if obj.get("validation", None) is not None else None,
-            checkpoint=v1CheckpointWorkload.from_json(obj["checkpoint"]) if obj.get("checkpoint", None) is not None else None,
-        )
-
-    def to_json(self) -> typing.Any:
-        return {
-            "training": self.training.to_json() if self.training is not None else None,
-            "validation": self.validation.to_json() if self.validation is not None else None,
-            "checkpoint": self.checkpoint.to_json() if self.checkpoint is not None else None,
-        }
-
 class TrialEarlyExitExitedReason(enum.Enum):
     EXITED_REASON_UNSPECIFIED = "EXITED_REASON_UNSPECIFIED"
     EXITED_REASON_INVALID_HP = "EXITED_REASON_INVALID_HP"
@@ -299,9 +273,11 @@ class trialv1Trial:
         bestCheckpoint: "typing.Optional[v1CheckpointWorkload]" = None,
         bestValidation: "typing.Optional[v1MetricsWorkload]" = None,
         endTime: "typing.Optional[str]" = None,
+        latestTraining: "typing.Optional[v1MetricsWorkload]" = None,
         latestValidation: "typing.Optional[v1MetricsWorkload]" = None,
         runnerState: "typing.Optional[str]" = None,
         taskId: "typing.Optional[str]" = None,
+        totalCheckpointSize: "typing.Optional[str]" = None,
         wallClockTime: "typing.Optional[float]" = None,
         warmStartCheckpointUuid: "typing.Optional[str]" = None,
     ):
@@ -315,10 +291,12 @@ class trialv1Trial:
         self.bestValidation = bestValidation
         self.latestValidation = latestValidation
         self.bestCheckpoint = bestCheckpoint
+        self.latestTraining = latestTraining
         self.runnerState = runnerState
         self.wallClockTime = wallClockTime
         self.warmStartCheckpointUuid = warmStartCheckpointUuid
         self.taskId = taskId
+        self.totalCheckpointSize = totalCheckpointSize
 
     @classmethod
     def from_json(cls, obj: Json) -> "trialv1Trial":
@@ -333,10 +311,12 @@ class trialv1Trial:
             bestValidation=v1MetricsWorkload.from_json(obj["bestValidation"]) if obj.get("bestValidation", None) is not None else None,
             latestValidation=v1MetricsWorkload.from_json(obj["latestValidation"]) if obj.get("latestValidation", None) is not None else None,
             bestCheckpoint=v1CheckpointWorkload.from_json(obj["bestCheckpoint"]) if obj.get("bestCheckpoint", None) is not None else None,
+            latestTraining=v1MetricsWorkload.from_json(obj["latestTraining"]) if obj.get("latestTraining", None) is not None else None,
             runnerState=obj.get("runnerState", None),
             wallClockTime=float(obj["wallClockTime"]) if obj.get("wallClockTime", None) is not None else None,
             warmStartCheckpointUuid=obj.get("warmStartCheckpointUuid", None),
             taskId=obj.get("taskId", None),
+            totalCheckpointSize=obj.get("totalCheckpointSize", None),
         )
 
     def to_json(self) -> typing.Any:
@@ -351,10 +331,12 @@ class trialv1Trial:
             "bestValidation": self.bestValidation.to_json() if self.bestValidation is not None else None,
             "latestValidation": self.latestValidation.to_json() if self.latestValidation is not None else None,
             "bestCheckpoint": self.bestCheckpoint.to_json() if self.bestCheckpoint is not None else None,
+            "latestTraining": self.latestTraining.to_json() if self.latestTraining is not None else None,
             "runnerState": self.runnerState if self.runnerState is not None else None,
             "wallClockTime": dump_float(self.wallClockTime) if self.wallClockTime is not None else None,
             "warmStartCheckpointUuid": self.warmStartCheckpointUuid if self.warmStartCheckpointUuid is not None else None,
             "taskId": self.taskId if self.taskId is not None else None,
+            "totalCheckpointSize": self.totalCheckpointSize if self.totalCheckpointSize is not None else None,
         }
 
 class v1AckAllocationPreemptionSignalRequest:
@@ -373,24 +355,6 @@ class v1AckAllocationPreemptionSignalRequest:
     def to_json(self) -> typing.Any:
         return {
             "allocationId": self.allocationId,
-        }
-
-class v1AddProjectNoteResponse:
-    def __init__(
-        self,
-        notes: "typing.Sequence[v1Note]",
-    ):
-        self.notes = notes
-
-    @classmethod
-    def from_json(cls, obj: Json) -> "v1AddProjectNoteResponse":
-        return cls(
-            notes=[v1Note.from_json(x) for x in obj["notes"]],
-        )
-
-    def to_json(self) -> typing.Any:
-        return {
-            "notes": [x.to_json() for x in self.notes],
         }
 
 class v1Agent:
@@ -634,125 +598,89 @@ class v1AwsCustomTag:
 class v1Checkpoint:
     def __init__(
         self,
-        batchNumber: int,
-        experimentId: int,
-        state: "determinedcheckpointv1State",
-        trialId: int,
-        determinedVersion: "typing.Optional[str]" = None,
-        endTime: "typing.Optional[str]" = None,
-        experimentConfig: "typing.Optional[typing.Dict[str, typing.Any]]" = None,
-        format: "typing.Optional[str]" = None,
-        framework: "typing.Optional[str]" = None,
-        hparams: "typing.Optional[typing.Dict[str, typing.Any]]" = None,
-        metadata: "typing.Optional[typing.Dict[str, typing.Any]]" = None,
-        metrics: "typing.Optional[v1Metrics]" = None,
-        resources: "typing.Optional[typing.Dict[str, str]]" = None,
-        searcherMetric: "typing.Optional[float]" = None,
-        uuid: "typing.Optional[str]" = None,
-        validationState: "typing.Optional[determinedcheckpointv1State]" = None,
+        metadata: "typing.Dict[str, typing.Any]",
+        resources: "typing.Dict[str, str]",
+        training: "v1CheckpointTrainingMetadata",
+        uuid: str,
+        allocationId: "typing.Optional[str]" = None,
+        reportTime: "typing.Optional[str]" = None,
+        state: "typing.Optional[determinedcheckpointv1State]" = None,
+        taskId: "typing.Optional[str]" = None,
     ):
+        self.taskId = taskId
+        self.allocationId = allocationId
         self.uuid = uuid
-        self.experimentConfig = experimentConfig
-        self.experimentId = experimentId
-        self.trialId = trialId
-        self.hparams = hparams
-        self.batchNumber = batchNumber
-        self.endTime = endTime
+        self.reportTime = reportTime
         self.resources = resources
         self.metadata = metadata
-        self.framework = framework
-        self.format = format
-        self.determinedVersion = determinedVersion
-        self.metrics = metrics
-        self.validationState = validationState
         self.state = state
-        self.searcherMetric = searcherMetric
+        self.training = training
 
     @classmethod
     def from_json(cls, obj: Json) -> "v1Checkpoint":
         return cls(
-            uuid=obj.get("uuid", None),
+            taskId=obj.get("taskId", None),
+            allocationId=obj.get("allocationId", None),
+            uuid=obj["uuid"],
+            reportTime=obj.get("reportTime", None),
+            resources=obj["resources"],
+            metadata=obj["metadata"],
+            state=determinedcheckpointv1State(obj["state"]) if obj.get("state", None) is not None else None,
+            training=v1CheckpointTrainingMetadata.from_json(obj["training"]),
+        )
+
+    def to_json(self) -> typing.Any:
+        return {
+            "taskId": self.taskId if self.taskId is not None else None,
+            "allocationId": self.allocationId if self.allocationId is not None else None,
+            "uuid": self.uuid,
+            "reportTime": self.reportTime if self.reportTime is not None else None,
+            "resources": self.resources,
+            "metadata": self.metadata,
+            "state": self.state.value if self.state is not None else None,
+            "training": self.training.to_json(),
+        }
+
+class v1CheckpointTrainingMetadata:
+    def __init__(
+        self,
+        experimentConfig: "typing.Optional[typing.Dict[str, typing.Any]]" = None,
+        experimentId: "typing.Optional[int]" = None,
+        hparams: "typing.Optional[typing.Dict[str, typing.Any]]" = None,
+        searcherMetric: "typing.Optional[float]" = None,
+        trainingMetrics: "typing.Optional[v1Metrics]" = None,
+        trialId: "typing.Optional[int]" = None,
+        validationMetrics: "typing.Optional[v1Metrics]" = None,
+    ):
+        self.trialId = trialId
+        self.experimentId = experimentId
+        self.experimentConfig = experimentConfig
+        self.hparams = hparams
+        self.trainingMetrics = trainingMetrics
+        self.validationMetrics = validationMetrics
+        self.searcherMetric = searcherMetric
+
+    @classmethod
+    def from_json(cls, obj: Json) -> "v1CheckpointTrainingMetadata":
+        return cls(
+            trialId=obj.get("trialId", None),
+            experimentId=obj.get("experimentId", None),
             experimentConfig=obj.get("experimentConfig", None),
-            experimentId=obj["experimentId"],
-            trialId=obj["trialId"],
             hparams=obj.get("hparams", None),
-            batchNumber=obj["batchNumber"],
-            endTime=obj.get("endTime", None),
-            resources=obj.get("resources", None),
-            metadata=obj.get("metadata", None),
-            framework=obj.get("framework", None),
-            format=obj.get("format", None),
-            determinedVersion=obj.get("determinedVersion", None),
-            metrics=v1Metrics.from_json(obj["metrics"]) if obj.get("metrics", None) is not None else None,
-            validationState=determinedcheckpointv1State(obj["validationState"]) if obj.get("validationState", None) is not None else None,
-            state=determinedcheckpointv1State(obj["state"]),
+            trainingMetrics=v1Metrics.from_json(obj["trainingMetrics"]) if obj.get("trainingMetrics", None) is not None else None,
+            validationMetrics=v1Metrics.from_json(obj["validationMetrics"]) if obj.get("validationMetrics", None) is not None else None,
             searcherMetric=float(obj["searcherMetric"]) if obj.get("searcherMetric", None) is not None else None,
         )
 
     def to_json(self) -> typing.Any:
         return {
-            "uuid": self.uuid if self.uuid is not None else None,
+            "trialId": self.trialId if self.trialId is not None else None,
+            "experimentId": self.experimentId if self.experimentId is not None else None,
             "experimentConfig": self.experimentConfig if self.experimentConfig is not None else None,
-            "experimentId": self.experimentId,
-            "trialId": self.trialId,
             "hparams": self.hparams if self.hparams is not None else None,
-            "batchNumber": self.batchNumber,
-            "endTime": self.endTime if self.endTime is not None else None,
-            "resources": self.resources if self.resources is not None else None,
-            "metadata": self.metadata if self.metadata is not None else None,
-            "framework": self.framework if self.framework is not None else None,
-            "format": self.format if self.format is not None else None,
-            "determinedVersion": self.determinedVersion if self.determinedVersion is not None else None,
-            "metrics": self.metrics.to_json() if self.metrics is not None else None,
-            "validationState": self.validationState.value if self.validationState is not None else None,
-            "state": self.state.value,
+            "trainingMetrics": self.trainingMetrics.to_json() if self.trainingMetrics is not None else None,
+            "validationMetrics": self.validationMetrics.to_json() if self.validationMetrics is not None else None,
             "searcherMetric": dump_float(self.searcherMetric) if self.searcherMetric is not None else None,
-        }
-
-class v1CheckpointMetadata:
-    def __init__(
-        self,
-        determinedVersion: str,
-        format: str,
-        framework: str,
-        resources: "typing.Dict[str, str]",
-        trialId: int,
-        trialRunId: int,
-        uuid: str,
-        latestBatch: "typing.Optional[int]" = None,
-    ):
-        self.trialId = trialId
-        self.trialRunId = trialRunId
-        self.uuid = uuid
-        self.resources = resources
-        self.framework = framework
-        self.format = format
-        self.determinedVersion = determinedVersion
-        self.latestBatch = latestBatch
-
-    @classmethod
-    def from_json(cls, obj: Json) -> "v1CheckpointMetadata":
-        return cls(
-            trialId=obj["trialId"],
-            trialRunId=obj["trialRunId"],
-            uuid=obj["uuid"],
-            resources=obj["resources"],
-            framework=obj["framework"],
-            format=obj["format"],
-            determinedVersion=obj["determinedVersion"],
-            latestBatch=obj.get("latestBatch", None),
-        )
-
-    def to_json(self) -> typing.Any:
-        return {
-            "trialId": self.trialId,
-            "trialRunId": self.trialRunId,
-            "uuid": self.uuid,
-            "resources": self.resources,
-            "framework": self.framework,
-            "format": self.format,
-            "determinedVersion": self.determinedVersion,
-            "latestBatch": self.latestBatch if self.latestBatch is not None else None,
         }
 
 class v1CheckpointWorkload:
@@ -906,7 +834,6 @@ class v1CreateExperimentRequest:
         config: "typing.Optional[str]" = None,
         modelDefinition: "typing.Optional[typing.Sequence[v1File]]" = None,
         parentId: "typing.Optional[int]" = None,
-        projectId: "typing.Optional[int]" = None,
         validateOnly: "typing.Optional[bool]" = None,
     ):
         self.modelDefinition = modelDefinition
@@ -914,7 +841,6 @@ class v1CreateExperimentRequest:
         self.validateOnly = validateOnly
         self.parentId = parentId
         self.activate = activate
-        self.projectId = projectId
 
     @classmethod
     def from_json(cls, obj: Json) -> "v1CreateExperimentRequest":
@@ -924,7 +850,6 @@ class v1CreateExperimentRequest:
             validateOnly=obj.get("validateOnly", None),
             parentId=obj.get("parentId", None),
             activate=obj.get("activate", None),
-            projectId=obj.get("projectId", None),
         )
 
     def to_json(self) -> typing.Any:
@@ -934,7 +859,6 @@ class v1CreateExperimentRequest:
             "validateOnly": self.validateOnly if self.validateOnly is not None else None,
             "parentId": self.parentId if self.parentId is not None else None,
             "activate": self.activate if self.activate is not None else None,
-            "projectId": self.projectId if self.projectId is not None else None,
         }
 
 class v1CreateExperimentResponse:
@@ -1109,7 +1033,6 @@ class v1Experiment:
         jobId: str,
         name: str,
         numTrials: int,
-        projectId: int,
         searcherType: str,
         startTime: str,
         state: "determinedexperimentv1State",
@@ -1120,14 +1043,10 @@ class v1Experiment:
         forkedFrom: "typing.Optional[int]" = None,
         labels: "typing.Optional[typing.Sequence[str]]" = None,
         notes: "typing.Optional[str]" = None,
-        parentArchived: "typing.Optional[bool]" = None,
         progress: "typing.Optional[float]" = None,
-        projectName: "typing.Optional[str]" = None,
         resourcePool: "typing.Optional[str]" = None,
         trialIds: "typing.Optional[typing.Sequence[int]]" = None,
         userId: "typing.Optional[int]" = None,
-        workspaceId: "typing.Optional[int]" = None,
-        workspaceName: "typing.Optional[str]" = None,
     ):
         self.id = id
         self.description = description
@@ -1148,11 +1067,6 @@ class v1Experiment:
         self.jobId = jobId
         self.forkedFrom = forkedFrom
         self.progress = progress
-        self.projectId = projectId
-        self.projectName = projectName
-        self.workspaceId = workspaceId
-        self.workspaceName = workspaceName
-        self.parentArchived = parentArchived
 
     @classmethod
     def from_json(cls, obj: Json) -> "v1Experiment":
@@ -1176,11 +1090,6 @@ class v1Experiment:
             jobId=obj["jobId"],
             forkedFrom=obj.get("forkedFrom", None),
             progress=float(obj["progress"]) if obj.get("progress", None) is not None else None,
-            projectId=obj["projectId"],
-            projectName=obj.get("projectName", None),
-            workspaceId=obj.get("workspaceId", None),
-            workspaceName=obj.get("workspaceName", None),
-            parentArchived=obj.get("parentArchived", None),
         )
 
     def to_json(self) -> typing.Any:
@@ -1204,11 +1113,6 @@ class v1Experiment:
             "jobId": self.jobId,
             "forkedFrom": self.forkedFrom if self.forkedFrom is not None else None,
             "progress": dump_float(self.progress) if self.progress is not None else None,
-            "projectId": self.projectId,
-            "projectName": self.projectName if self.projectName is not None else None,
-            "workspaceId": self.workspaceId if self.workspaceId is not None else None,
-            "workspaceName": self.workspaceName if self.workspaceName is not None else None,
-            "parentArchived": self.parentArchived if self.parentArchived is not None else None,
         }
 
 class v1ExperimentSimulation:
@@ -1443,9 +1347,7 @@ class v1GetExperimentCheckpointsRequestSortBy(enum.Enum):
     SORT_BY_UUID = "SORT_BY_UUID"
     SORT_BY_TRIAL_ID = "SORT_BY_TRIAL_ID"
     SORT_BY_BATCH_NUMBER = "SORT_BY_BATCH_NUMBER"
-    SORT_BY_START_TIME = "SORT_BY_START_TIME"
     SORT_BY_END_TIME = "SORT_BY_END_TIME"
-    SORT_BY_VALIDATION_STATE = "SORT_BY_VALIDATION_STATE"
     SORT_BY_STATE = "SORT_BY_STATE"
     SORT_BY_SEARCHER_METRIC = "SORT_BY_SEARCHER_METRIC"
 
@@ -1579,7 +1481,6 @@ class v1GetExperimentsRequestSortBy(enum.Enum):
     SORT_BY_NAME = "SORT_BY_NAME"
     SORT_BY_FORKED_FROM = "SORT_BY_FORKED_FROM"
     SORT_BY_RESOURCE_POOL = "SORT_BY_RESOURCE_POOL"
-    SORT_BY_PROJECT_ID = "SORT_BY_PROJECT_ID"
 
 class v1GetExperimentsResponse:
     def __init__(
@@ -1916,60 +1817,6 @@ class v1GetNotebooksResponse:
             "pagination": self.pagination.to_json() if self.pagination is not None else None,
         }
 
-class v1GetProjectExperimentsRequestSortBy(enum.Enum):
-    SORT_BY_UNSPECIFIED = "SORT_BY_UNSPECIFIED"
-    SORT_BY_ID = "SORT_BY_ID"
-    SORT_BY_DESCRIPTION = "SORT_BY_DESCRIPTION"
-    SORT_BY_START_TIME = "SORT_BY_START_TIME"
-    SORT_BY_END_TIME = "SORT_BY_END_TIME"
-    SORT_BY_STATE = "SORT_BY_STATE"
-    SORT_BY_NUM_TRIALS = "SORT_BY_NUM_TRIALS"
-    SORT_BY_PROGRESS = "SORT_BY_PROGRESS"
-    SORT_BY_USER = "SORT_BY_USER"
-    SORT_BY_NAME = "SORT_BY_NAME"
-    SORT_BY_FORKED_FROM = "SORT_BY_FORKED_FROM"
-    SORT_BY_RESOURCE_POOL = "SORT_BY_RESOURCE_POOL"
-
-class v1GetProjectExperimentsResponse:
-    def __init__(
-        self,
-        experiments: "typing.Sequence[v1Experiment]",
-        pagination: "v1Pagination",
-    ):
-        self.experiments = experiments
-        self.pagination = pagination
-
-    @classmethod
-    def from_json(cls, obj: Json) -> "v1GetProjectExperimentsResponse":
-        return cls(
-            experiments=[v1Experiment.from_json(x) for x in obj["experiments"]],
-            pagination=v1Pagination.from_json(obj["pagination"]),
-        )
-
-    def to_json(self) -> typing.Any:
-        return {
-            "experiments": [x.to_json() for x in self.experiments],
-            "pagination": self.pagination.to_json(),
-        }
-
-class v1GetProjectResponse:
-    def __init__(
-        self,
-        project: "v1Project",
-    ):
-        self.project = project
-
-    @classmethod
-    def from_json(cls, obj: Json) -> "v1GetProjectResponse":
-        return cls(
-            project=v1Project.from_json(obj["project"]),
-        )
-
-    def to_json(self) -> typing.Any:
-        return {
-            "project": self.project.to_json(),
-        }
-
 class v1GetResourcePoolsResponse:
     def __init__(
         self,
@@ -2216,9 +2063,7 @@ class v1GetTrialCheckpointsRequestSortBy(enum.Enum):
     SORT_BY_UNSPECIFIED = "SORT_BY_UNSPECIFIED"
     SORT_BY_UUID = "SORT_BY_UUID"
     SORT_BY_BATCH_NUMBER = "SORT_BY_BATCH_NUMBER"
-    SORT_BY_START_TIME = "SORT_BY_START_TIME"
     SORT_BY_END_TIME = "SORT_BY_END_TIME"
-    SORT_BY_VALIDATION_STATE = "SORT_BY_VALIDATION_STATE"
     SORT_BY_STATE = "SORT_BY_STATE"
 
 class v1GetTrialCheckpointsResponse:
@@ -2283,7 +2128,7 @@ class v1GetTrialResponse:
     def __init__(
         self,
         trial: "trialv1Trial",
-        workloads: "typing.Sequence[GetTrialResponseWorkloadContainer]",
+        workloads: "typing.Sequence[v1WorkloadContainer]",
     ):
         self.trial = trial
         self.workloads = workloads
@@ -2292,13 +2137,35 @@ class v1GetTrialResponse:
     def from_json(cls, obj: Json) -> "v1GetTrialResponse":
         return cls(
             trial=trialv1Trial.from_json(obj["trial"]),
-            workloads=[GetTrialResponseWorkloadContainer.from_json(x) for x in obj["workloads"]],
+            workloads=[v1WorkloadContainer.from_json(x) for x in obj["workloads"]],
         )
 
     def to_json(self) -> typing.Any:
         return {
             "trial": self.trial.to_json(),
             "workloads": [x.to_json() for x in self.workloads],
+        }
+
+class v1GetTrialWorkloadsResponse:
+    def __init__(
+        self,
+        pagination: "v1Pagination",
+        workloads: "typing.Sequence[v1WorkloadContainer]",
+    ):
+        self.workloads = workloads
+        self.pagination = pagination
+
+    @classmethod
+    def from_json(cls, obj: Json) -> "v1GetTrialWorkloadsResponse":
+        return cls(
+            workloads=[v1WorkloadContainer.from_json(x) for x in obj["workloads"]],
+            pagination=v1Pagination.from_json(obj["pagination"]),
+        )
+
+    def to_json(self) -> typing.Any:
+        return {
+            "workloads": [x.to_json() for x in self.workloads],
+            "pagination": self.pagination.to_json(),
         }
 
 class v1GetUserResponse:
@@ -2335,81 +2202,6 @@ class v1GetUsersResponse:
     def to_json(self) -> typing.Any:
         return {
             "users": [x.to_json() for x in self.users] if self.users is not None else None,
-        }
-
-class v1GetWorkspaceProjectsRequestSortBy(enum.Enum):
-    SORT_BY_UNSPECIFIED = "SORT_BY_UNSPECIFIED"
-    SORT_BY_CREATION_TIME = "SORT_BY_CREATION_TIME"
-    SORT_BY_LAST_EXPERIMENT_START_TIME = "SORT_BY_LAST_EXPERIMENT_START_TIME"
-    SORT_BY_NAME = "SORT_BY_NAME"
-    SORT_BY_DESCRIPTION = "SORT_BY_DESCRIPTION"
-    SORT_BY_ID = "SORT_BY_ID"
-
-class v1GetWorkspaceProjectsResponse:
-    def __init__(
-        self,
-        pagination: "v1Pagination",
-        projects: "typing.Sequence[v1Project]",
-    ):
-        self.projects = projects
-        self.pagination = pagination
-
-    @classmethod
-    def from_json(cls, obj: Json) -> "v1GetWorkspaceProjectsResponse":
-        return cls(
-            projects=[v1Project.from_json(x) for x in obj["projects"]],
-            pagination=v1Pagination.from_json(obj["pagination"]),
-        )
-
-    def to_json(self) -> typing.Any:
-        return {
-            "projects": [x.to_json() for x in self.projects],
-            "pagination": self.pagination.to_json(),
-        }
-
-class v1GetWorkspaceResponse:
-    def __init__(
-        self,
-        workspace: "v1Workspace",
-    ):
-        self.workspace = workspace
-
-    @classmethod
-    def from_json(cls, obj: Json) -> "v1GetWorkspaceResponse":
-        return cls(
-            workspace=v1Workspace.from_json(obj["workspace"]),
-        )
-
-    def to_json(self) -> typing.Any:
-        return {
-            "workspace": self.workspace.to_json(),
-        }
-
-class v1GetWorkspacesRequestSortBy(enum.Enum):
-    SORT_BY_UNSPECIFIED = "SORT_BY_UNSPECIFIED"
-    SORT_BY_ID = "SORT_BY_ID"
-    SORT_BY_NAME = "SORT_BY_NAME"
-
-class v1GetWorkspacesResponse:
-    def __init__(
-        self,
-        pagination: "v1Pagination",
-        workspaces: "typing.Sequence[v1Workspace]",
-    ):
-        self.workspaces = workspaces
-        self.pagination = pagination
-
-    @classmethod
-    def from_json(cls, obj: Json) -> "v1GetWorkspacesResponse":
-        return cls(
-            workspaces=[v1Workspace.from_json(x) for x in obj["workspaces"]],
-            pagination=v1Pagination.from_json(obj["pagination"]),
-        )
-
-    def to_json(self) -> typing.Any:
-        return {
-            "workspaces": [x.to_json() for x in self.workspaces],
-            "pagination": self.pagination.to_json(),
         }
 
 class v1IdleNotebookRequest:
@@ -3015,23 +2807,23 @@ class v1MetricType(enum.Enum):
 class v1Metrics:
     def __init__(
         self,
-        numInputs: "typing.Optional[int]" = None,
-        validationMetrics: "typing.Optional[typing.Dict[str, typing.Any]]" = None,
+        avgMetrics: "typing.Dict[str, typing.Any]",
+        batchMetrics: "typing.Optional[typing.Sequence[typing.Dict[str, typing.Any]]]" = None,
     ):
-        self.numInputs = numInputs
-        self.validationMetrics = validationMetrics
+        self.avgMetrics = avgMetrics
+        self.batchMetrics = batchMetrics
 
     @classmethod
     def from_json(cls, obj: Json) -> "v1Metrics":
         return cls(
-            numInputs=obj.get("numInputs", None),
-            validationMetrics=obj.get("validationMetrics", None),
+            avgMetrics=obj["avgMetrics"],
+            batchMetrics=obj.get("batchMetrics", None),
         )
 
     def to_json(self) -> typing.Any:
         return {
-            "numInputs": self.numInputs if self.numInputs is not None else None,
-            "validationMetrics": self.validationMetrics if self.validationMetrics is not None else None,
+            "avgMetrics": self.avgMetrics,
+            "batchMetrics": self.batchMetrics if self.batchMetrics is not None else None,
         }
 
 class v1MetricsWorkload:
@@ -3194,72 +2986,6 @@ class v1ModelVersion:
             "userId": self.userId if self.userId is not None else None,
             "labels": self.labels if self.labels is not None else None,
             "notes": self.notes if self.notes is not None else None,
-        }
-
-class v1MoveExperimentRequest:
-    def __init__(
-        self,
-        destinationProjectId: int,
-        experimentId: int,
-    ):
-        self.experimentId = experimentId
-        self.destinationProjectId = destinationProjectId
-
-    @classmethod
-    def from_json(cls, obj: Json) -> "v1MoveExperimentRequest":
-        return cls(
-            experimentId=obj["experimentId"],
-            destinationProjectId=obj["destinationProjectId"],
-        )
-
-    def to_json(self) -> typing.Any:
-        return {
-            "experimentId": self.experimentId,
-            "destinationProjectId": self.destinationProjectId,
-        }
-
-class v1MoveProjectRequest:
-    def __init__(
-        self,
-        destinationWorkspaceId: int,
-        projectId: int,
-    ):
-        self.projectId = projectId
-        self.destinationWorkspaceId = destinationWorkspaceId
-
-    @classmethod
-    def from_json(cls, obj: Json) -> "v1MoveProjectRequest":
-        return cls(
-            projectId=obj["projectId"],
-            destinationWorkspaceId=obj["destinationWorkspaceId"],
-        )
-
-    def to_json(self) -> typing.Any:
-        return {
-            "projectId": self.projectId,
-            "destinationWorkspaceId": self.destinationWorkspaceId,
-        }
-
-class v1Note:
-    def __init__(
-        self,
-        contents: str,
-        name: str,
-    ):
-        self.name = name
-        self.contents = contents
-
-    @classmethod
-    def from_json(cls, obj: Json) -> "v1Note":
-        return cls(
-            name=obj["name"],
-            contents=obj["contents"],
-        )
-
-    def to_json(self) -> typing.Any:
-        return {
-            "name": self.name,
-            "contents": self.contents,
         }
 
 class v1Notebook:
@@ -3545,46 +3271,6 @@ class v1PatchModelVersionResponse:
             "modelVersion": self.modelVersion.to_json(),
         }
 
-class v1PatchProject:
-    def __init__(
-        self,
-        description: "typing.Optional[str]" = None,
-        name: "typing.Optional[str]" = None,
-    ):
-        self.name = name
-        self.description = description
-
-    @classmethod
-    def from_json(cls, obj: Json) -> "v1PatchProject":
-        return cls(
-            name=obj.get("name", None),
-            description=obj.get("description", None),
-        )
-
-    def to_json(self) -> typing.Any:
-        return {
-            "name": self.name if self.name is not None else None,
-            "description": self.description if self.description is not None else None,
-        }
-
-class v1PatchProjectResponse:
-    def __init__(
-        self,
-        project: "v1Project",
-    ):
-        self.project = project
-
-    @classmethod
-    def from_json(cls, obj: Json) -> "v1PatchProjectResponse":
-        return cls(
-            project=v1Project.from_json(obj["project"]),
-        )
-
-    def to_json(self) -> typing.Any:
-        return {
-            "project": self.project.to_json(),
-        }
-
 class v1PatchUser:
     def __init__(
         self,
@@ -3621,40 +3307,26 @@ class v1PatchUserResponse:
             "user": self.user.to_json(),
         }
 
-class v1PatchWorkspace:
+class v1PostAllocationProxyAddressRequest:
     def __init__(
         self,
-        name: "typing.Optional[str]" = None,
+        allocationId: "typing.Optional[str]" = None,
+        proxyAddress: "typing.Optional[str]" = None,
     ):
-        self.name = name
+        self.allocationId = allocationId
+        self.proxyAddress = proxyAddress
 
     @classmethod
-    def from_json(cls, obj: Json) -> "v1PatchWorkspace":
+    def from_json(cls, obj: Json) -> "v1PostAllocationProxyAddressRequest":
         return cls(
-            name=obj.get("name", None),
+            allocationId=obj.get("allocationId", None),
+            proxyAddress=obj.get("proxyAddress", None),
         )
 
     def to_json(self) -> typing.Any:
         return {
-            "name": self.name if self.name is not None else None,
-        }
-
-class v1PatchWorkspaceResponse:
-    def __init__(
-        self,
-        workspace: "v1Workspace",
-    ):
-        self.workspace = workspace
-
-    @classmethod
-    def from_json(cls, obj: Json) -> "v1PatchWorkspaceResponse":
-        return cls(
-            workspace=v1Workspace.from_json(obj["workspace"]),
-        )
-
-    def to_json(self) -> typing.Any:
-        return {
-            "workspace": self.workspace.to_json(),
+            "allocationId": self.allocationId if self.allocationId is not None else None,
+            "proxyAddress": self.proxyAddress if self.proxyAddress is not None else None,
         }
 
 class v1PostCheckpointMetadataRequest:
@@ -3805,50 +3477,6 @@ class v1PostModelVersionResponse:
             "modelVersion": self.modelVersion.to_json(),
         }
 
-class v1PostProjectRequest:
-    def __init__(
-        self,
-        name: str,
-        workspaceId: int,
-        description: "typing.Optional[str]" = None,
-    ):
-        self.name = name
-        self.description = description
-        self.workspaceId = workspaceId
-
-    @classmethod
-    def from_json(cls, obj: Json) -> "v1PostProjectRequest":
-        return cls(
-            name=obj["name"],
-            description=obj.get("description", None),
-            workspaceId=obj["workspaceId"],
-        )
-
-    def to_json(self) -> typing.Any:
-        return {
-            "name": self.name,
-            "description": self.description if self.description is not None else None,
-            "workspaceId": self.workspaceId,
-        }
-
-class v1PostProjectResponse:
-    def __init__(
-        self,
-        project: "v1Project",
-    ):
-        self.project = project
-
-    @classmethod
-    def from_json(cls, obj: Json) -> "v1PostProjectResponse":
-        return cls(
-            project=v1Project.from_json(obj["project"]),
-        )
-
-    def to_json(self) -> typing.Any:
-        return {
-            "project": self.project.to_json(),
-        }
-
 class v1PostTrialProfilerMetricsBatchRequest:
     def __init__(
         self,
@@ -3907,42 +3535,6 @@ class v1PostUserResponse:
             "user": self.user.to_json() if self.user is not None else None,
         }
 
-class v1PostWorkspaceRequest:
-    def __init__(
-        self,
-        name: str,
-    ):
-        self.name = name
-
-    @classmethod
-    def from_json(cls, obj: Json) -> "v1PostWorkspaceRequest":
-        return cls(
-            name=obj["name"],
-        )
-
-    def to_json(self) -> typing.Any:
-        return {
-            "name": self.name,
-        }
-
-class v1PostWorkspaceResponse:
-    def __init__(
-        self,
-        workspace: "v1Workspace",
-    ):
-        self.workspace = workspace
-
-    @classmethod
-    def from_json(cls, obj: Json) -> "v1PostWorkspaceResponse":
-        return cls(
-            workspace=v1Workspace.from_json(obj["workspace"]),
-        )
-
-    def to_json(self) -> typing.Any:
-        return {
-            "workspace": self.workspace.to_json(),
-        }
-
 class v1PreviewHPSearchRequest:
     def __init__(
         self,
@@ -3981,108 +3573,6 @@ class v1PreviewHPSearchResponse:
     def to_json(self) -> typing.Any:
         return {
             "simulation": self.simulation.to_json() if self.simulation is not None else None,
-        }
-
-class v1Project:
-    def __init__(
-        self,
-        archived: bool,
-        id: int,
-        immutable: bool,
-        name: str,
-        notes: "typing.Sequence[v1Note]",
-        numActiveExperiments: int,
-        numExperiments: int,
-        userId: int,
-        username: str,
-        workspaceId: int,
-        description: "typing.Optional[str]" = None,
-        lastExperimentStartedAt: "typing.Optional[str]" = None,
-    ):
-        self.id = id
-        self.name = name
-        self.workspaceId = workspaceId
-        self.description = description
-        self.lastExperimentStartedAt = lastExperimentStartedAt
-        self.notes = notes
-        self.numExperiments = numExperiments
-        self.numActiveExperiments = numActiveExperiments
-        self.archived = archived
-        self.username = username
-        self.immutable = immutable
-        self.userId = userId
-
-    @classmethod
-    def from_json(cls, obj: Json) -> "v1Project":
-        return cls(
-            id=obj["id"],
-            name=obj["name"],
-            workspaceId=obj["workspaceId"],
-            description=obj.get("description", None),
-            lastExperimentStartedAt=obj.get("lastExperimentStartedAt", None),
-            notes=[v1Note.from_json(x) for x in obj["notes"]],
-            numExperiments=obj["numExperiments"],
-            numActiveExperiments=obj["numActiveExperiments"],
-            archived=obj["archived"],
-            username=obj["username"],
-            immutable=obj["immutable"],
-            userId=obj["userId"],
-        )
-
-    def to_json(self) -> typing.Any:
-        return {
-            "id": self.id,
-            "name": self.name,
-            "workspaceId": self.workspaceId,
-            "description": self.description if self.description is not None else None,
-            "lastExperimentStartedAt": self.lastExperimentStartedAt if self.lastExperimentStartedAt is not None else None,
-            "notes": [x.to_json() for x in self.notes],
-            "numExperiments": self.numExperiments,
-            "numActiveExperiments": self.numActiveExperiments,
-            "archived": self.archived,
-            "username": self.username,
-            "immutable": self.immutable,
-            "userId": self.userId,
-        }
-
-class v1PutProjectNotesRequest:
-    def __init__(
-        self,
-        notes: "typing.Sequence[v1Note]",
-        projectId: int,
-    ):
-        self.notes = notes
-        self.projectId = projectId
-
-    @classmethod
-    def from_json(cls, obj: Json) -> "v1PutProjectNotesRequest":
-        return cls(
-            notes=[v1Note.from_json(x) for x in obj["notes"]],
-            projectId=obj["projectId"],
-        )
-
-    def to_json(self) -> typing.Any:
-        return {
-            "notes": [x.to_json() for x in self.notes],
-            "projectId": self.projectId,
-        }
-
-class v1PutProjectNotesResponse:
-    def __init__(
-        self,
-        notes: "typing.Sequence[v1Note]",
-    ):
-        self.notes = notes
-
-    @classmethod
-    def from_json(cls, obj: Json) -> "v1PutProjectNotesResponse":
-        return cls(
-            notes=[v1Note.from_json(x) for x in obj["notes"]],
-        )
-
-    def to_json(self) -> typing.Any:
-        return {
-            "notes": [x.to_json() for x in self.notes],
         }
 
 class v1PutTemplateResponse:
@@ -5344,15 +4834,15 @@ class v1TrialLogsResponse:
 class v1TrialMetrics:
     def __init__(
         self,
-        latestBatch: int,
         metrics: "typing.Dict[str, typing.Any]",
+        stepsCompleted: int,
         trialId: int,
         trialRunId: int,
         batchMetrics: "typing.Optional[typing.Sequence[typing.Dict[str, typing.Any]]]" = None,
     ):
         self.trialId = trialId
         self.trialRunId = trialRunId
-        self.latestBatch = latestBatch
+        self.stepsCompleted = stepsCompleted
         self.metrics = metrics
         self.batchMetrics = batchMetrics
 
@@ -5361,7 +4851,7 @@ class v1TrialMetrics:
         return cls(
             trialId=obj["trialId"],
             trialRunId=obj["trialRunId"],
-            latestBatch=obj["latestBatch"],
+            stepsCompleted=obj["stepsCompleted"],
             metrics=obj["metrics"],
             batchMetrics=obj.get("batchMetrics", None),
         )
@@ -5370,7 +4860,7 @@ class v1TrialMetrics:
         return {
             "trialId": self.trialId,
             "trialRunId": self.trialRunId,
-            "latestBatch": self.latestBatch,
+            "stepsCompleted": self.stepsCompleted,
             "metrics": self.metrics,
             "batchMetrics": self.batchMetrics if self.batchMetrics is not None else None,
         }
@@ -5602,10 +5092,10 @@ class v1User:
         self,
         active: bool,
         admin: bool,
-        id: int,
         username: str,
         agentUserGroup: "typing.Optional[v1AgentUserGroup]" = None,
         displayName: "typing.Optional[str]" = None,
+        id: "typing.Optional[int]" = None,
         modifiedAt: "typing.Optional[str]" = None,
     ):
         self.id = id
@@ -5619,7 +5109,7 @@ class v1User:
     @classmethod
     def from_json(cls, obj: Json) -> "v1User":
         return cls(
-            id=obj["id"],
+            id=obj.get("id", None),
             username=obj["username"],
             admin=obj["admin"],
             active=obj["active"],
@@ -5630,7 +5120,7 @@ class v1User:
 
     def to_json(self) -> typing.Any:
         return {
-            "id": self.id,
+            "id": self.id if self.id is not None else None,
             "username": self.username,
             "admin": self.admin,
             "active": self.active,
@@ -5683,50 +5173,30 @@ class v1ValidationHistoryEntry:
             "searcherMetric": dump_float(self.searcherMetric),
         }
 
-class v1Workspace:
+class v1WorkloadContainer:
     def __init__(
         self,
-        archived: bool,
-        id: int,
-        immutable: bool,
-        name: str,
-        numProjects: int,
-        pinned: bool,
-        userId: int,
-        username: str,
+        checkpoint: "typing.Optional[v1CheckpointWorkload]" = None,
+        training: "typing.Optional[v1MetricsWorkload]" = None,
+        validation: "typing.Optional[v1MetricsWorkload]" = None,
     ):
-        self.id = id
-        self.name = name
-        self.archived = archived
-        self.username = username
-        self.immutable = immutable
-        self.numProjects = numProjects
-        self.pinned = pinned
-        self.userId = userId
+        self.training = training
+        self.validation = validation
+        self.checkpoint = checkpoint
 
     @classmethod
-    def from_json(cls, obj: Json) -> "v1Workspace":
+    def from_json(cls, obj: Json) -> "v1WorkloadContainer":
         return cls(
-            id=obj["id"],
-            name=obj["name"],
-            archived=obj["archived"],
-            username=obj["username"],
-            immutable=obj["immutable"],
-            numProjects=obj["numProjects"],
-            pinned=obj["pinned"],
-            userId=obj["userId"],
+            training=v1MetricsWorkload.from_json(obj["training"]) if obj.get("training", None) is not None else None,
+            validation=v1MetricsWorkload.from_json(obj["validation"]) if obj.get("validation", None) is not None else None,
+            checkpoint=v1CheckpointWorkload.from_json(obj["checkpoint"]) if obj.get("checkpoint", None) is not None else None,
         )
 
     def to_json(self) -> typing.Any:
         return {
-            "id": self.id,
-            "name": self.name,
-            "archived": self.archived,
-            "username": self.username,
-            "immutable": self.immutable,
-            "numProjects": self.numProjects,
-            "pinned": self.pinned,
-            "userId": self.userId,
+            "training": self.training.to_json() if self.training is not None else None,
+            "validation": self.validation.to_json() if self.validation is not None else None,
+            "checkpoint": self.checkpoint.to_json() if self.checkpoint is not None else None,
         }
 
 def post_AckAllocationPreemptionSignal(
@@ -5767,26 +5237,6 @@ def post_ActivateExperiment(
     if _resp.status_code == 200:
         return
     raise APIHttpError("post_ActivateExperiment", _resp)
-
-def post_AddProjectNote(
-    session: "client.Session",
-    *,
-    body: "v1Note",
-    projectId: int,
-) -> "v1AddProjectNoteResponse":
-    _params = None
-    _resp = session._do_request(
-        method="POST",
-        path=f"/api/v1/projects/{projectId}/notes",
-        params=_params,
-        json=body.to_json(),
-        data=None,
-        headers=None,
-        timeout=None,
-    )
-    if _resp.status_code == 200:
-        return v1AddProjectNoteResponse.from_json(_resp.json())
-    raise APIHttpError("post_AddProjectNote", _resp)
 
 def post_AllocationAllGather(
     session: "client.Session",
@@ -5907,44 +5357,6 @@ def post_ArchiveModel(
     if _resp.status_code == 200:
         return
     raise APIHttpError("post_ArchiveModel", _resp)
-
-def post_ArchiveProject(
-    session: "client.Session",
-    *,
-    id: int,
-) -> None:
-    _params = None
-    _resp = session._do_request(
-        method="POST",
-        path=f"/api/v1/projects/{id}/archive",
-        params=_params,
-        json=None,
-        data=None,
-        headers=None,
-        timeout=None,
-    )
-    if _resp.status_code == 200:
-        return
-    raise APIHttpError("post_ArchiveProject", _resp)
-
-def post_ArchiveWorkspace(
-    session: "client.Session",
-    *,
-    id: int,
-) -> None:
-    _params = None
-    _resp = session._do_request(
-        method="POST",
-        path=f"/api/v1/workspaces/{id}/archive",
-        params=_params,
-        json=None,
-        data=None,
-        headers=None,
-        timeout=None,
-    )
-    if _resp.status_code == 200:
-        return
-    raise APIHttpError("post_ArchiveWorkspace", _resp)
 
 def post_CancelExperiment(
     session: "client.Session",
@@ -6098,25 +5510,6 @@ def delete_DeleteModelVersion(
         return
     raise APIHttpError("delete_DeleteModelVersion", _resp)
 
-def delete_DeleteProject(
-    session: "client.Session",
-    *,
-    id: int,
-) -> None:
-    _params = None
-    _resp = session._do_request(
-        method="DELETE",
-        path=f"/api/v1/projects/{id}",
-        params=_params,
-        json=None,
-        data=None,
-        headers=None,
-        timeout=None,
-    )
-    if _resp.status_code == 200:
-        return
-    raise APIHttpError("delete_DeleteProject", _resp)
-
 def delete_DeleteTemplate(
     session: "client.Session",
     *,
@@ -6135,25 +5528,6 @@ def delete_DeleteTemplate(
     if _resp.status_code == 200:
         return
     raise APIHttpError("delete_DeleteTemplate", _resp)
-
-def delete_DeleteWorkspace(
-    session: "client.Session",
-    *,
-    id: int,
-) -> None:
-    _params = None
-    _resp = session._do_request(
-        method="DELETE",
-        path=f"/api/v1/workspaces/{id}",
-        params=_params,
-        json=None,
-        data=None,
-        headers=None,
-        timeout=None,
-    )
-    if _resp.status_code == 200:
-        return
-    raise APIHttpError("delete_DeleteWorkspace", _resp)
 
 def post_DisableAgent(
     session: "client.Session",
@@ -6266,8 +5640,8 @@ def get_GetAgents(
         "label": label,
         "limit": limit,
         "offset": offset,
-        "orderBy": orderBy.value if orderBy else None,
-        "sortBy": sortBy.value if sortBy else None,
+        "orderBy": orderBy.value if orderBy is not None else None,
+        "sortBy": sortBy.value if sortBy is not None else None,
     }
     _resp = session._do_request(
         method="GET",
@@ -6352,8 +5726,8 @@ def get_GetCommands(
     _params = {
         "limit": limit,
         "offset": offset,
-        "orderBy": orderBy.value if orderBy else None,
-        "sortBy": sortBy.value if sortBy else None,
+        "orderBy": orderBy.value if orderBy is not None else None,
+        "sortBy": sortBy.value if sortBy is not None else None,
         "userIds": userIds,
         "users": users,
     }
@@ -6417,15 +5791,13 @@ def get_GetExperimentCheckpoints(
     orderBy: "typing.Optional[v1OrderBy]" = None,
     sortBy: "typing.Optional[v1GetExperimentCheckpointsRequestSortBy]" = None,
     states: "typing.Optional[typing.Sequence[determinedcheckpointv1State]]" = None,
-    validationStates: "typing.Optional[typing.Sequence[determinedcheckpointv1State]]" = None,
 ) -> "v1GetExperimentCheckpointsResponse":
     _params = {
         "limit": limit,
         "offset": offset,
-        "orderBy": orderBy.value if orderBy else None,
-        "sortBy": sortBy.value if sortBy else None,
-        "states": [x.value for x in states] if states else None,
-        "validationStates": [x.value for x in validationStates] if validationStates else None,
+        "orderBy": orderBy.value if orderBy is not None else None,
+        "sortBy": sortBy.value if sortBy is not None else None,
+        "states": [x.value for x in states] if states is not None else None,
     }
     _resp = session._do_request(
         method="GET",
@@ -6442,12 +5814,8 @@ def get_GetExperimentCheckpoints(
 
 def get_GetExperimentLabels(
     session: "client.Session",
-    *,
-    projectId: "typing.Optional[int]" = None,
 ) -> "v1GetExperimentLabelsResponse":
-    _params = {
-        "projectId": projectId,
-    }
+    _params = None
     _resp = session._do_request(
         method="GET",
         path="/api/v1/experiment/labels",
@@ -6474,9 +5842,9 @@ def get_GetExperimentTrials(
     _params = {
         "limit": limit,
         "offset": offset,
-        "orderBy": orderBy.value if orderBy else None,
-        "sortBy": sortBy.value if sortBy else None,
-        "states": [x.value for x in states] if states else None,
+        "orderBy": orderBy.value if orderBy is not None else None,
+        "sortBy": sortBy.value if sortBy is not None else None,
+        "states": [x.value for x in states] if states is not None else None,
     }
     _resp = session._do_request(
         method="GET",
@@ -6526,15 +5894,15 @@ def get_GetExperiments(
     users: "typing.Optional[typing.Sequence[str]]" = None,
 ) -> "v1GetExperimentsResponse":
     _params = {
-        "archived": archived,
+        "archived": str(archived).lower() if archived is not None else None,
         "description": description,
         "labels": labels,
         "limit": limit,
         "name": name,
         "offset": offset,
-        "orderBy": orderBy.value if orderBy else None,
-        "sortBy": sortBy.value if sortBy else None,
-        "states": [x.value for x in states] if states else None,
+        "orderBy": orderBy.value if orderBy is not None else None,
+        "sortBy": sortBy.value if sortBy is not None else None,
+        "states": [x.value for x in states] if states is not None else None,
         "userIds": userIds,
         "users": users,
     }
@@ -6581,7 +5949,7 @@ def get_GetJobs(
     resourcePool: "typing.Optional[str]" = None,
 ) -> "v1GetJobsResponse":
     _params = {
-        "orderBy": orderBy.value if orderBy else None,
+        "orderBy": orderBy.value if orderBy is not None else None,
         "pagination.limit": pagination_limit,
         "pagination.offset": pagination_offset,
         "resourcePool": resourcePool,
@@ -6720,8 +6088,8 @@ def get_GetModelVersions(
     _params = {
         "limit": limit,
         "offset": offset,
-        "orderBy": orderBy.value if orderBy else None,
-        "sortBy": sortBy.value if sortBy else None,
+        "orderBy": orderBy.value if orderBy is not None else None,
+        "sortBy": sortBy.value if sortBy is not None else None,
     }
     _resp = session._do_request(
         method="GET",
@@ -6752,15 +6120,15 @@ def get_GetModels(
     users: "typing.Optional[typing.Sequence[str]]" = None,
 ) -> "v1GetModelsResponse":
     _params = {
-        "archived": archived,
+        "archived": str(archived).lower() if archived is not None else None,
         "description": description,
         "id": id,
         "labels": labels,
         "limit": limit,
         "name": name,
         "offset": offset,
-        "orderBy": orderBy.value if orderBy else None,
-        "sortBy": sortBy.value if sortBy else None,
+        "orderBy": orderBy.value if orderBy is not None else None,
+        "sortBy": sortBy.value if sortBy is not None else None,
         "userIds": userIds,
         "users": users,
     }
@@ -6809,8 +6177,8 @@ def get_GetNotebooks(
     _params = {
         "limit": limit,
         "offset": offset,
-        "orderBy": orderBy.value if orderBy else None,
-        "sortBy": sortBy.value if sortBy else None,
+        "orderBy": orderBy.value if orderBy is not None else None,
+        "sortBy": sortBy.value if sortBy is not None else None,
         "userIds": userIds,
         "users": users,
     }
@@ -6826,67 +6194,6 @@ def get_GetNotebooks(
     if _resp.status_code == 200:
         return v1GetNotebooksResponse.from_json(_resp.json())
     raise APIHttpError("get_GetNotebooks", _resp)
-
-def get_GetProject(
-    session: "client.Session",
-    *,
-    id: int,
-) -> "v1GetProjectResponse":
-    _params = None
-    _resp = session._do_request(
-        method="GET",
-        path=f"/api/v1/projects/{id}",
-        params=_params,
-        json=None,
-        data=None,
-        headers=None,
-        timeout=None,
-    )
-    if _resp.status_code == 200:
-        return v1GetProjectResponse.from_json(_resp.json())
-    raise APIHttpError("get_GetProject", _resp)
-
-def get_GetProjectExperiments(
-    session: "client.Session",
-    *,
-    id: int,
-    archived: "typing.Optional[bool]" = None,
-    description: "typing.Optional[str]" = None,
-    labels: "typing.Optional[typing.Sequence[str]]" = None,
-    limit: "typing.Optional[int]" = None,
-    name: "typing.Optional[str]" = None,
-    offset: "typing.Optional[int]" = None,
-    orderBy: "typing.Optional[v1OrderBy]" = None,
-    sortBy: "typing.Optional[v1GetProjectExperimentsRequestSortBy]" = None,
-    states: "typing.Optional[typing.Sequence[determinedexperimentv1State]]" = None,
-    userIds: "typing.Optional[typing.Sequence[int]]" = None,
-    users: "typing.Optional[typing.Sequence[str]]" = None,
-) -> "v1GetProjectExperimentsResponse":
-    _params = {
-        "archived": archived,
-        "description": description,
-        "labels": labels,
-        "limit": limit,
-        "name": name,
-        "offset": offset,
-        "orderBy": orderBy.value if orderBy else None,
-        "sortBy": sortBy.value if sortBy else None,
-        "states": [x.value for x in states] if states else None,
-        "userIds": userIds,
-        "users": users,
-    }
-    _resp = session._do_request(
-        method="GET",
-        path=f"/api/v1/projects/{id}/experiments",
-        params=_params,
-        json=None,
-        data=None,
-        headers=None,
-        timeout=None,
-    )
-    if _resp.status_code == 200:
-        return v1GetProjectExperimentsResponse.from_json(_resp.json())
-    raise APIHttpError("get_GetProjectExperiments", _resp)
 
 def get_GetResourcePools(
     session: "client.Session",
@@ -6943,8 +6250,8 @@ def get_GetShells(
     _params = {
         "limit": limit,
         "offset": offset,
-        "orderBy": orderBy.value if orderBy else None,
-        "sortBy": sortBy.value if sortBy else None,
+        "orderBy": orderBy.value if orderBy is not None else None,
+        "sortBy": sortBy.value if sortBy is not None else None,
         "userIds": userIds,
         "users": users,
     }
@@ -7068,8 +6375,8 @@ def get_GetTemplates(
         "limit": limit,
         "name": name,
         "offset": offset,
-        "orderBy": orderBy.value if orderBy else None,
-        "sortBy": sortBy.value if sortBy else None,
+        "orderBy": orderBy.value if orderBy is not None else None,
+        "sortBy": sortBy.value if sortBy is not None else None,
     }
     _resp = session._do_request(
         method="GET",
@@ -7116,8 +6423,8 @@ def get_GetTensorboards(
     _params = {
         "limit": limit,
         "offset": offset,
-        "orderBy": orderBy.value if orderBy else None,
-        "sortBy": sortBy.value if sortBy else None,
+        "orderBy": orderBy.value if orderBy is not None else None,
+        "sortBy": sortBy.value if sortBy is not None else None,
         "userIds": userIds,
         "users": users,
     }
@@ -7162,15 +6469,13 @@ def get_GetTrialCheckpoints(
     orderBy: "typing.Optional[v1OrderBy]" = None,
     sortBy: "typing.Optional[v1GetTrialCheckpointsRequestSortBy]" = None,
     states: "typing.Optional[typing.Sequence[determinedcheckpointv1State]]" = None,
-    validationStates: "typing.Optional[typing.Sequence[determinedcheckpointv1State]]" = None,
 ) -> "v1GetTrialCheckpointsResponse":
     _params = {
         "limit": limit,
         "offset": offset,
-        "orderBy": orderBy.value if orderBy else None,
-        "sortBy": sortBy.value if sortBy else None,
-        "states": [x.value for x in states] if states else None,
-        "validationStates": [x.value for x in validationStates] if validationStates else None,
+        "orderBy": orderBy.value if orderBy is not None else None,
+        "sortBy": sortBy.value if sortBy is not None else None,
+        "states": [x.value for x in states] if states is not None else None,
     }
     _resp = session._do_request(
         method="GET",
@@ -7184,6 +6489,32 @@ def get_GetTrialCheckpoints(
     if _resp.status_code == 200:
         return v1GetTrialCheckpointsResponse.from_json(_resp.json())
     raise APIHttpError("get_GetTrialCheckpoints", _resp)
+
+def get_GetTrialWorkloads(
+    session: "client.Session",
+    *,
+    trialId: int,
+    limit: "typing.Optional[int]" = None,
+    offset: "typing.Optional[int]" = None,
+    orderBy: "typing.Optional[v1OrderBy]" = None,
+) -> "v1GetTrialWorkloadsResponse":
+    _params = {
+        "limit": limit,
+        "offset": offset,
+        "orderBy": orderBy.value if orderBy is not None else None,
+    }
+    _resp = session._do_request(
+        method="GET",
+        path=f"/api/v1/trials/{trialId}/workloads",
+        params=_params,
+        json=None,
+        data=None,
+        headers=None,
+        timeout=None,
+    )
+    if _resp.status_code == 200:
+        return v1GetTrialWorkloadsResponse.from_json(_resp.json())
+    raise APIHttpError("get_GetTrialWorkloads", _resp)
 
 def get_GetUser(
     session: "client.Session",
@@ -7220,94 +6551,6 @@ def get_GetUsers(
     if _resp.status_code == 200:
         return v1GetUsersResponse.from_json(_resp.json())
     raise APIHttpError("get_GetUsers", _resp)
-
-def get_GetWorkspace(
-    session: "client.Session",
-    *,
-    id: int,
-) -> "v1GetWorkspaceResponse":
-    _params = None
-    _resp = session._do_request(
-        method="GET",
-        path=f"/api/v1/workspaces/{id}",
-        params=_params,
-        json=None,
-        data=None,
-        headers=None,
-        timeout=None,
-    )
-    if _resp.status_code == 200:
-        return v1GetWorkspaceResponse.from_json(_resp.json())
-    raise APIHttpError("get_GetWorkspace", _resp)
-
-def get_GetWorkspaceProjects(
-    session: "client.Session",
-    *,
-    id: int,
-    archived: "typing.Optional[bool]" = None,
-    limit: "typing.Optional[int]" = None,
-    name: "typing.Optional[str]" = None,
-    offset: "typing.Optional[int]" = None,
-    orderBy: "typing.Optional[v1OrderBy]" = None,
-    sortBy: "typing.Optional[v1GetWorkspaceProjectsRequestSortBy]" = None,
-    users: "typing.Optional[typing.Sequence[str]]" = None,
-) -> "v1GetWorkspaceProjectsResponse":
-    _params = {
-        "archived": archived,
-        "limit": limit,
-        "name": name,
-        "offset": offset,
-        "orderBy": orderBy.value if orderBy else None,
-        "sortBy": sortBy.value if sortBy else None,
-        "users": users,
-    }
-    _resp = session._do_request(
-        method="GET",
-        path=f"/api/v1/workspaces/{id}/projects",
-        params=_params,
-        json=None,
-        data=None,
-        headers=None,
-        timeout=None,
-    )
-    if _resp.status_code == 200:
-        return v1GetWorkspaceProjectsResponse.from_json(_resp.json())
-    raise APIHttpError("get_GetWorkspaceProjects", _resp)
-
-def get_GetWorkspaces(
-    session: "client.Session",
-    *,
-    archived: "typing.Optional[bool]" = None,
-    limit: "typing.Optional[int]" = None,
-    name: "typing.Optional[str]" = None,
-    offset: "typing.Optional[int]" = None,
-    orderBy: "typing.Optional[v1OrderBy]" = None,
-    pinned: "typing.Optional[bool]" = None,
-    sortBy: "typing.Optional[v1GetWorkspacesRequestSortBy]" = None,
-    users: "typing.Optional[typing.Sequence[str]]" = None,
-) -> "v1GetWorkspacesResponse":
-    _params = {
-        "archived": archived,
-        "limit": limit,
-        "name": name,
-        "offset": offset,
-        "orderBy": orderBy.value if orderBy else None,
-        "pinned": pinned,
-        "sortBy": sortBy.value if sortBy else None,
-        "users": users,
-    }
-    _resp = session._do_request(
-        method="GET",
-        path="/api/v1/workspaces",
-        params=_params,
-        json=None,
-        data=None,
-        headers=None,
-        timeout=None,
-    )
-    if _resp.status_code == 200:
-        return v1GetWorkspacesResponse.from_json(_resp.json())
-    raise APIHttpError("get_GetWorkspaces", _resp)
 
 def put_IdleNotebook(
     session: "client.Session",
@@ -7576,46 +6819,6 @@ def post_MarkAllocationResourcesDaemon(
         return
     raise APIHttpError("post_MarkAllocationResourcesDaemon", _resp)
 
-def post_MoveExperiment(
-    session: "client.Session",
-    *,
-    body: "v1MoveExperimentRequest",
-    experimentId: int,
-) -> None:
-    _params = None
-    _resp = session._do_request(
-        method="POST",
-        path=f"/api/v1/experiments/{experimentId}/move",
-        params=_params,
-        json=body.to_json(),
-        data=None,
-        headers=None,
-        timeout=None,
-    )
-    if _resp.status_code == 200:
-        return
-    raise APIHttpError("post_MoveExperiment", _resp)
-
-def post_MoveProject(
-    session: "client.Session",
-    *,
-    body: "v1MoveProjectRequest",
-    projectId: int,
-) -> None:
-    _params = None
-    _resp = session._do_request(
-        method="POST",
-        path=f"/api/v1/projects/{projectId}/move",
-        params=_params,
-        json=body.to_json(),
-        data=None,
-        headers=None,
-        timeout=None,
-    )
-    if _resp.status_code == 200:
-        return
-    raise APIHttpError("post_MoveProject", _resp)
-
 def patch_PatchExperiment(
     session: "client.Session",
     *,
@@ -7677,26 +6880,6 @@ def patch_PatchModelVersion(
         return v1PatchModelVersionResponse.from_json(_resp.json())
     raise APIHttpError("patch_PatchModelVersion", _resp)
 
-def patch_PatchProject(
-    session: "client.Session",
-    *,
-    body: "v1PatchProject",
-    id: int,
-) -> "v1PatchProjectResponse":
-    _params = None
-    _resp = session._do_request(
-        method="PATCH",
-        path=f"/api/v1/projects/{id}",
-        params=_params,
-        json=body.to_json(),
-        data=None,
-        headers=None,
-        timeout=None,
-    )
-    if _resp.status_code == 200:
-        return v1PatchProjectResponse.from_json(_resp.json())
-    raise APIHttpError("patch_PatchProject", _resp)
-
 def patch_PatchUser(
     session: "client.Session",
     *,
@@ -7717,26 +6900,6 @@ def patch_PatchUser(
         return v1PatchUserResponse.from_json(_resp.json())
     raise APIHttpError("patch_PatchUser", _resp)
 
-def patch_PatchWorkspace(
-    session: "client.Session",
-    *,
-    body: "v1PatchWorkspace",
-    id: int,
-) -> "v1PatchWorkspaceResponse":
-    _params = None
-    _resp = session._do_request(
-        method="PATCH",
-        path=f"/api/v1/workspaces/{id}",
-        params=_params,
-        json=body.to_json(),
-        data=None,
-        headers=None,
-        timeout=None,
-    )
-    if _resp.status_code == 200:
-        return v1PatchWorkspaceResponse.from_json(_resp.json())
-    raise APIHttpError("patch_PatchWorkspace", _resp)
-
 def post_PauseExperiment(
     session: "client.Session",
     *,
@@ -7756,24 +6919,25 @@ def post_PauseExperiment(
         return
     raise APIHttpError("post_PauseExperiment", _resp)
 
-def post_PinWorkspace(
+def post_PostAllocationProxyAddress(
     session: "client.Session",
     *,
-    id: int,
+    allocationId: str,
+    body: "v1PostAllocationProxyAddressRequest",
 ) -> None:
     _params = None
     _resp = session._do_request(
         method="POST",
-        path=f"/api/v1/workspaces/{id}/pin",
+        path=f"/api/v1/allocations/{allocationId}/proxy_address",
         params=_params,
-        json=None,
+        json=body.to_json(),
         data=None,
         headers=None,
         timeout=None,
     )
     if _resp.status_code == 200:
         return
-    raise APIHttpError("post_PinWorkspace", _resp)
+    raise APIHttpError("post_PostAllocationProxyAddress", _resp)
 
 def post_PostCheckpointMetadata(
     session: "client.Session",
@@ -7834,26 +6998,6 @@ def post_PostModelVersion(
         return v1PostModelVersionResponse.from_json(_resp.json())
     raise APIHttpError("post_PostModelVersion", _resp)
 
-def post_PostProject(
-    session: "client.Session",
-    *,
-    body: "v1PostProjectRequest",
-    workspaceId: int,
-) -> "v1PostProjectResponse":
-    _params = None
-    _resp = session._do_request(
-        method="POST",
-        path=f"/api/v1/workspaces/{workspaceId}/projects",
-        params=_params,
-        json=body.to_json(),
-        data=None,
-        headers=None,
-        timeout=None,
-    )
-    if _resp.status_code == 200:
-        return v1PostProjectResponse.from_json(_resp.json())
-    raise APIHttpError("post_PostProject", _resp)
-
 def post_PostTrialProfilerMetricsBatch(
     session: "client.Session",
     *,
@@ -7912,25 +7056,6 @@ def post_PostUser(
         return v1PostUserResponse.from_json(_resp.json())
     raise APIHttpError("post_PostUser", _resp)
 
-def post_PostWorkspace(
-    session: "client.Session",
-    *,
-    body: "v1PostWorkspaceRequest",
-) -> "v1PostWorkspaceResponse":
-    _params = None
-    _resp = session._do_request(
-        method="POST",
-        path="/api/v1/workspaces",
-        params=_params,
-        json=body.to_json(),
-        data=None,
-        headers=None,
-        timeout=None,
-    )
-    if _resp.status_code == 200:
-        return v1PostWorkspaceResponse.from_json(_resp.json())
-    raise APIHttpError("post_PostWorkspace", _resp)
-
 def post_PreviewHPSearch(
     session: "client.Session",
     *,
@@ -7949,26 +7074,6 @@ def post_PreviewHPSearch(
     if _resp.status_code == 200:
         return v1PreviewHPSearchResponse.from_json(_resp.json())
     raise APIHttpError("post_PreviewHPSearch", _resp)
-
-def put_PutProjectNotes(
-    session: "client.Session",
-    *,
-    body: "v1PutProjectNotesRequest",
-    projectId: int,
-) -> "v1PutProjectNotesResponse":
-    _params = None
-    _resp = session._do_request(
-        method="PUT",
-        path=f"/api/v1/projects/{projectId}/notes",
-        params=_params,
-        json=body.to_json(),
-        data=None,
-        headers=None,
-        timeout=None,
-    )
-    if _resp.status_code == 200:
-        return v1PutProjectNotesResponse.from_json(_resp.json())
-    raise APIHttpError("put_PutProjectNotes", _resp)
 
 def put_PutTemplate(
     session: "client.Session",
@@ -7990,16 +7095,15 @@ def put_PutTemplate(
         return v1PutTemplateResponse.from_json(_resp.json())
     raise APIHttpError("put_PutTemplate", _resp)
 
-def post_ReportTrialCheckpointMetadata(
+def post_ReportCheckpoint(
     session: "client.Session",
     *,
-    body: "v1CheckpointMetadata",
-    checkpointMetadata_trialId: int,
+    body: "v1Checkpoint",
 ) -> None:
     _params = None
     _resp = session._do_request(
         method="POST",
-        path=f"/api/v1/trials/{checkpointMetadata_trialId}/checkpoint_metadata",
+        path="/api/v1/checkpoints",
         params=_params,
         json=body.to_json(),
         data=None,
@@ -8008,7 +7112,7 @@ def post_ReportTrialCheckpointMetadata(
     )
     if _resp.status_code == 200:
         return
-    raise APIHttpError("post_ReportTrialCheckpointMetadata", _resp)
+    raise APIHttpError("post_ReportCheckpoint", _resp)
 
 def post_ReportTrialProgress(
     session: "client.Session",
@@ -8099,7 +7203,7 @@ def get_ResourceAllocationAggregated(
 ) -> "v1ResourceAllocationAggregatedResponse":
     _params = {
         "endDate": endDate,
-        "period": period.value if period else None,
+        "period": period.value if period is not None else None,
         "startDate": startDate,
     }
     _resp = session._do_request(
@@ -8275,63 +7379,6 @@ def post_UnarchiveModel(
     if _resp.status_code == 200:
         return
     raise APIHttpError("post_UnarchiveModel", _resp)
-
-def post_UnarchiveProject(
-    session: "client.Session",
-    *,
-    id: int,
-) -> None:
-    _params = None
-    _resp = session._do_request(
-        method="POST",
-        path=f"/api/v1/projects/{id}/unarchive",
-        params=_params,
-        json=None,
-        data=None,
-        headers=None,
-        timeout=None,
-    )
-    if _resp.status_code == 200:
-        return
-    raise APIHttpError("post_UnarchiveProject", _resp)
-
-def post_UnarchiveWorkspace(
-    session: "client.Session",
-    *,
-    id: int,
-) -> None:
-    _params = None
-    _resp = session._do_request(
-        method="POST",
-        path=f"/api/v1/workspaces/{id}/unarchive",
-        params=_params,
-        json=None,
-        data=None,
-        headers=None,
-        timeout=None,
-    )
-    if _resp.status_code == 200:
-        return
-    raise APIHttpError("post_UnarchiveWorkspace", _resp)
-
-def post_UnpinWorkspace(
-    session: "client.Session",
-    *,
-    id: int,
-) -> None:
-    _params = None
-    _resp = session._do_request(
-        method="POST",
-        path=f"/api/v1/workspaces/{id}/unpin",
-        params=_params,
-        json=None,
-        data=None,
-        headers=None,
-        timeout=None,
-    )
-    if _resp.status_code == 200:
-        return
-    raise APIHttpError("post_UnpinWorkspace", _resp)
 
 def post_UpdateJobQueue(
     session: "client.Session",

--- a/harness/determined/common/api/bindings.py
+++ b/harness/determined/common/api/bindings.py
@@ -78,6 +78,32 @@ class GetHPImportanceResponseMetricHPImportance:
             "inProgress": self.inProgress if self.inProgress is not None else None,
         }
 
+class GetTrialResponseWorkloadContainer:
+    def __init__(
+        self,
+        checkpoint: "typing.Optional[v1CheckpointWorkload]" = None,
+        training: "typing.Optional[v1MetricsWorkload]" = None,
+        validation: "typing.Optional[v1MetricsWorkload]" = None,
+    ):
+        self.training = training
+        self.validation = validation
+        self.checkpoint = checkpoint
+
+    @classmethod
+    def from_json(cls, obj: Json) -> "GetTrialResponseWorkloadContainer":
+        return cls(
+            training=v1MetricsWorkload.from_json(obj["training"]) if obj.get("training", None) is not None else None,
+            validation=v1MetricsWorkload.from_json(obj["validation"]) if obj.get("validation", None) is not None else None,
+            checkpoint=v1CheckpointWorkload.from_json(obj["checkpoint"]) if obj.get("checkpoint", None) is not None else None,
+        )
+
+    def to_json(self) -> typing.Any:
+        return {
+            "training": self.training.to_json() if self.training is not None else None,
+            "validation": self.validation.to_json() if self.validation is not None else None,
+            "checkpoint": self.checkpoint.to_json() if self.checkpoint is not None else None,
+        }
+
 class TrialEarlyExitExitedReason(enum.Enum):
     EXITED_REASON_UNSPECIFIED = "EXITED_REASON_UNSPECIFIED"
     EXITED_REASON_INVALID_HP = "EXITED_REASON_INVALID_HP"
@@ -273,11 +299,9 @@ class trialv1Trial:
         bestCheckpoint: "typing.Optional[v1CheckpointWorkload]" = None,
         bestValidation: "typing.Optional[v1MetricsWorkload]" = None,
         endTime: "typing.Optional[str]" = None,
-        latestTraining: "typing.Optional[v1MetricsWorkload]" = None,
         latestValidation: "typing.Optional[v1MetricsWorkload]" = None,
         runnerState: "typing.Optional[str]" = None,
         taskId: "typing.Optional[str]" = None,
-        totalCheckpointSize: "typing.Optional[str]" = None,
         wallClockTime: "typing.Optional[float]" = None,
         warmStartCheckpointUuid: "typing.Optional[str]" = None,
     ):
@@ -291,12 +315,10 @@ class trialv1Trial:
         self.bestValidation = bestValidation
         self.latestValidation = latestValidation
         self.bestCheckpoint = bestCheckpoint
-        self.latestTraining = latestTraining
         self.runnerState = runnerState
         self.wallClockTime = wallClockTime
         self.warmStartCheckpointUuid = warmStartCheckpointUuid
         self.taskId = taskId
-        self.totalCheckpointSize = totalCheckpointSize
 
     @classmethod
     def from_json(cls, obj: Json) -> "trialv1Trial":
@@ -311,12 +333,10 @@ class trialv1Trial:
             bestValidation=v1MetricsWorkload.from_json(obj["bestValidation"]) if obj.get("bestValidation", None) is not None else None,
             latestValidation=v1MetricsWorkload.from_json(obj["latestValidation"]) if obj.get("latestValidation", None) is not None else None,
             bestCheckpoint=v1CheckpointWorkload.from_json(obj["bestCheckpoint"]) if obj.get("bestCheckpoint", None) is not None else None,
-            latestTraining=v1MetricsWorkload.from_json(obj["latestTraining"]) if obj.get("latestTraining", None) is not None else None,
             runnerState=obj.get("runnerState", None),
             wallClockTime=float(obj["wallClockTime"]) if obj.get("wallClockTime", None) is not None else None,
             warmStartCheckpointUuid=obj.get("warmStartCheckpointUuid", None),
             taskId=obj.get("taskId", None),
-            totalCheckpointSize=obj.get("totalCheckpointSize", None),
         )
 
     def to_json(self) -> typing.Any:
@@ -331,12 +351,10 @@ class trialv1Trial:
             "bestValidation": self.bestValidation.to_json() if self.bestValidation is not None else None,
             "latestValidation": self.latestValidation.to_json() if self.latestValidation is not None else None,
             "bestCheckpoint": self.bestCheckpoint.to_json() if self.bestCheckpoint is not None else None,
-            "latestTraining": self.latestTraining.to_json() if self.latestTraining is not None else None,
             "runnerState": self.runnerState if self.runnerState is not None else None,
             "wallClockTime": dump_float(self.wallClockTime) if self.wallClockTime is not None else None,
             "warmStartCheckpointUuid": self.warmStartCheckpointUuid if self.warmStartCheckpointUuid is not None else None,
             "taskId": self.taskId if self.taskId is not None else None,
-            "totalCheckpointSize": self.totalCheckpointSize if self.totalCheckpointSize is not None else None,
         }
 
 class v1AckAllocationPreemptionSignalRequest:
@@ -355,6 +373,24 @@ class v1AckAllocationPreemptionSignalRequest:
     def to_json(self) -> typing.Any:
         return {
             "allocationId": self.allocationId,
+        }
+
+class v1AddProjectNoteResponse:
+    def __init__(
+        self,
+        notes: "typing.Sequence[v1Note]",
+    ):
+        self.notes = notes
+
+    @classmethod
+    def from_json(cls, obj: Json) -> "v1AddProjectNoteResponse":
+        return cls(
+            notes=[v1Note.from_json(x) for x in obj["notes"]],
+        )
+
+    def to_json(self) -> typing.Any:
+        return {
+            "notes": [x.to_json() for x in self.notes],
         }
 
 class v1Agent:
@@ -598,89 +634,125 @@ class v1AwsCustomTag:
 class v1Checkpoint:
     def __init__(
         self,
-        metadata: "typing.Dict[str, typing.Any]",
-        resources: "typing.Dict[str, str]",
-        training: "v1CheckpointTrainingMetadata",
-        uuid: str,
-        allocationId: "typing.Optional[str]" = None,
-        reportTime: "typing.Optional[str]" = None,
-        state: "typing.Optional[determinedcheckpointv1State]" = None,
-        taskId: "typing.Optional[str]" = None,
+        batchNumber: int,
+        experimentId: int,
+        state: "determinedcheckpointv1State",
+        trialId: int,
+        determinedVersion: "typing.Optional[str]" = None,
+        endTime: "typing.Optional[str]" = None,
+        experimentConfig: "typing.Optional[typing.Dict[str, typing.Any]]" = None,
+        format: "typing.Optional[str]" = None,
+        framework: "typing.Optional[str]" = None,
+        hparams: "typing.Optional[typing.Dict[str, typing.Any]]" = None,
+        metadata: "typing.Optional[typing.Dict[str, typing.Any]]" = None,
+        metrics: "typing.Optional[v1Metrics]" = None,
+        resources: "typing.Optional[typing.Dict[str, str]]" = None,
+        searcherMetric: "typing.Optional[float]" = None,
+        uuid: "typing.Optional[str]" = None,
+        validationState: "typing.Optional[determinedcheckpointv1State]" = None,
     ):
-        self.taskId = taskId
-        self.allocationId = allocationId
         self.uuid = uuid
-        self.reportTime = reportTime
+        self.experimentConfig = experimentConfig
+        self.experimentId = experimentId
+        self.trialId = trialId
+        self.hparams = hparams
+        self.batchNumber = batchNumber
+        self.endTime = endTime
         self.resources = resources
         self.metadata = metadata
+        self.framework = framework
+        self.format = format
+        self.determinedVersion = determinedVersion
+        self.metrics = metrics
+        self.validationState = validationState
         self.state = state
-        self.training = training
+        self.searcherMetric = searcherMetric
 
     @classmethod
     def from_json(cls, obj: Json) -> "v1Checkpoint":
         return cls(
-            taskId=obj.get("taskId", None),
-            allocationId=obj.get("allocationId", None),
-            uuid=obj["uuid"],
-            reportTime=obj.get("reportTime", None),
-            resources=obj["resources"],
-            metadata=obj["metadata"],
-            state=determinedcheckpointv1State(obj["state"]) if obj.get("state", None) is not None else None,
-            training=v1CheckpointTrainingMetadata.from_json(obj["training"]),
-        )
-
-    def to_json(self) -> typing.Any:
-        return {
-            "taskId": self.taskId if self.taskId is not None else None,
-            "allocationId": self.allocationId if self.allocationId is not None else None,
-            "uuid": self.uuid,
-            "reportTime": self.reportTime if self.reportTime is not None else None,
-            "resources": self.resources,
-            "metadata": self.metadata,
-            "state": self.state.value if self.state is not None else None,
-            "training": self.training.to_json(),
-        }
-
-class v1CheckpointTrainingMetadata:
-    def __init__(
-        self,
-        experimentConfig: "typing.Optional[typing.Dict[str, typing.Any]]" = None,
-        experimentId: "typing.Optional[int]" = None,
-        hparams: "typing.Optional[typing.Dict[str, typing.Any]]" = None,
-        searcherMetric: "typing.Optional[float]" = None,
-        trainingMetrics: "typing.Optional[v1Metrics]" = None,
-        trialId: "typing.Optional[int]" = None,
-        validationMetrics: "typing.Optional[v1Metrics]" = None,
-    ):
-        self.trialId = trialId
-        self.experimentId = experimentId
-        self.experimentConfig = experimentConfig
-        self.hparams = hparams
-        self.trainingMetrics = trainingMetrics
-        self.validationMetrics = validationMetrics
-        self.searcherMetric = searcherMetric
-
-    @classmethod
-    def from_json(cls, obj: Json) -> "v1CheckpointTrainingMetadata":
-        return cls(
-            trialId=obj.get("trialId", None),
-            experimentId=obj.get("experimentId", None),
+            uuid=obj.get("uuid", None),
             experimentConfig=obj.get("experimentConfig", None),
+            experimentId=obj["experimentId"],
+            trialId=obj["trialId"],
             hparams=obj.get("hparams", None),
-            trainingMetrics=v1Metrics.from_json(obj["trainingMetrics"]) if obj.get("trainingMetrics", None) is not None else None,
-            validationMetrics=v1Metrics.from_json(obj["validationMetrics"]) if obj.get("validationMetrics", None) is not None else None,
+            batchNumber=obj["batchNumber"],
+            endTime=obj.get("endTime", None),
+            resources=obj.get("resources", None),
+            metadata=obj.get("metadata", None),
+            framework=obj.get("framework", None),
+            format=obj.get("format", None),
+            determinedVersion=obj.get("determinedVersion", None),
+            metrics=v1Metrics.from_json(obj["metrics"]) if obj.get("metrics", None) is not None else None,
+            validationState=determinedcheckpointv1State(obj["validationState"]) if obj.get("validationState", None) is not None else None,
+            state=determinedcheckpointv1State(obj["state"]),
             searcherMetric=float(obj["searcherMetric"]) if obj.get("searcherMetric", None) is not None else None,
         )
 
     def to_json(self) -> typing.Any:
         return {
-            "trialId": self.trialId if self.trialId is not None else None,
-            "experimentId": self.experimentId if self.experimentId is not None else None,
+            "uuid": self.uuid if self.uuid is not None else None,
             "experimentConfig": self.experimentConfig if self.experimentConfig is not None else None,
+            "experimentId": self.experimentId,
+            "trialId": self.trialId,
             "hparams": self.hparams if self.hparams is not None else None,
-            "trainingMetrics": self.trainingMetrics.to_json() if self.trainingMetrics is not None else None,
-            "validationMetrics": self.validationMetrics.to_json() if self.validationMetrics is not None else None,
+            "batchNumber": self.batchNumber,
+            "endTime": self.endTime if self.endTime is not None else None,
+            "resources": self.resources if self.resources is not None else None,
+            "metadata": self.metadata if self.metadata is not None else None,
+            "framework": self.framework if self.framework is not None else None,
+            "format": self.format if self.format is not None else None,
+            "determinedVersion": self.determinedVersion if self.determinedVersion is not None else None,
+            "metrics": self.metrics.to_json() if self.metrics is not None else None,
+            "validationState": self.validationState.value if self.validationState is not None else None,
+            "state": self.state.value,
             "searcherMetric": dump_float(self.searcherMetric) if self.searcherMetric is not None else None,
+        }
+
+class v1CheckpointMetadata:
+    def __init__(
+        self,
+        determinedVersion: str,
+        format: str,
+        framework: str,
+        resources: "typing.Dict[str, str]",
+        trialId: int,
+        trialRunId: int,
+        uuid: str,
+        latestBatch: "typing.Optional[int]" = None,
+    ):
+        self.trialId = trialId
+        self.trialRunId = trialRunId
+        self.uuid = uuid
+        self.resources = resources
+        self.framework = framework
+        self.format = format
+        self.determinedVersion = determinedVersion
+        self.latestBatch = latestBatch
+
+    @classmethod
+    def from_json(cls, obj: Json) -> "v1CheckpointMetadata":
+        return cls(
+            trialId=obj["trialId"],
+            trialRunId=obj["trialRunId"],
+            uuid=obj["uuid"],
+            resources=obj["resources"],
+            framework=obj["framework"],
+            format=obj["format"],
+            determinedVersion=obj["determinedVersion"],
+            latestBatch=obj.get("latestBatch", None),
+        )
+
+    def to_json(self) -> typing.Any:
+        return {
+            "trialId": self.trialId,
+            "trialRunId": self.trialRunId,
+            "uuid": self.uuid,
+            "resources": self.resources,
+            "framework": self.framework,
+            "format": self.format,
+            "determinedVersion": self.determinedVersion,
+            "latestBatch": self.latestBatch if self.latestBatch is not None else None,
         }
 
 class v1CheckpointWorkload:
@@ -834,6 +906,7 @@ class v1CreateExperimentRequest:
         config: "typing.Optional[str]" = None,
         modelDefinition: "typing.Optional[typing.Sequence[v1File]]" = None,
         parentId: "typing.Optional[int]" = None,
+        projectId: "typing.Optional[int]" = None,
         validateOnly: "typing.Optional[bool]" = None,
     ):
         self.modelDefinition = modelDefinition
@@ -841,6 +914,7 @@ class v1CreateExperimentRequest:
         self.validateOnly = validateOnly
         self.parentId = parentId
         self.activate = activate
+        self.projectId = projectId
 
     @classmethod
     def from_json(cls, obj: Json) -> "v1CreateExperimentRequest":
@@ -850,6 +924,7 @@ class v1CreateExperimentRequest:
             validateOnly=obj.get("validateOnly", None),
             parentId=obj.get("parentId", None),
             activate=obj.get("activate", None),
+            projectId=obj.get("projectId", None),
         )
 
     def to_json(self) -> typing.Any:
@@ -859,6 +934,7 @@ class v1CreateExperimentRequest:
             "validateOnly": self.validateOnly if self.validateOnly is not None else None,
             "parentId": self.parentId if self.parentId is not None else None,
             "activate": self.activate if self.activate is not None else None,
+            "projectId": self.projectId if self.projectId is not None else None,
         }
 
 class v1CreateExperimentResponse:
@@ -1033,6 +1109,7 @@ class v1Experiment:
         jobId: str,
         name: str,
         numTrials: int,
+        projectId: int,
         searcherType: str,
         startTime: str,
         state: "determinedexperimentv1State",
@@ -1043,10 +1120,14 @@ class v1Experiment:
         forkedFrom: "typing.Optional[int]" = None,
         labels: "typing.Optional[typing.Sequence[str]]" = None,
         notes: "typing.Optional[str]" = None,
+        parentArchived: "typing.Optional[bool]" = None,
         progress: "typing.Optional[float]" = None,
+        projectName: "typing.Optional[str]" = None,
         resourcePool: "typing.Optional[str]" = None,
         trialIds: "typing.Optional[typing.Sequence[int]]" = None,
         userId: "typing.Optional[int]" = None,
+        workspaceId: "typing.Optional[int]" = None,
+        workspaceName: "typing.Optional[str]" = None,
     ):
         self.id = id
         self.description = description
@@ -1067,6 +1148,11 @@ class v1Experiment:
         self.jobId = jobId
         self.forkedFrom = forkedFrom
         self.progress = progress
+        self.projectId = projectId
+        self.projectName = projectName
+        self.workspaceId = workspaceId
+        self.workspaceName = workspaceName
+        self.parentArchived = parentArchived
 
     @classmethod
     def from_json(cls, obj: Json) -> "v1Experiment":
@@ -1090,6 +1176,11 @@ class v1Experiment:
             jobId=obj["jobId"],
             forkedFrom=obj.get("forkedFrom", None),
             progress=float(obj["progress"]) if obj.get("progress", None) is not None else None,
+            projectId=obj["projectId"],
+            projectName=obj.get("projectName", None),
+            workspaceId=obj.get("workspaceId", None),
+            workspaceName=obj.get("workspaceName", None),
+            parentArchived=obj.get("parentArchived", None),
         )
 
     def to_json(self) -> typing.Any:
@@ -1113,6 +1204,11 @@ class v1Experiment:
             "jobId": self.jobId,
             "forkedFrom": self.forkedFrom if self.forkedFrom is not None else None,
             "progress": dump_float(self.progress) if self.progress is not None else None,
+            "projectId": self.projectId,
+            "projectName": self.projectName if self.projectName is not None else None,
+            "workspaceId": self.workspaceId if self.workspaceId is not None else None,
+            "workspaceName": self.workspaceName if self.workspaceName is not None else None,
+            "parentArchived": self.parentArchived if self.parentArchived is not None else None,
         }
 
 class v1ExperimentSimulation:
@@ -1347,7 +1443,9 @@ class v1GetExperimentCheckpointsRequestSortBy(enum.Enum):
     SORT_BY_UUID = "SORT_BY_UUID"
     SORT_BY_TRIAL_ID = "SORT_BY_TRIAL_ID"
     SORT_BY_BATCH_NUMBER = "SORT_BY_BATCH_NUMBER"
+    SORT_BY_START_TIME = "SORT_BY_START_TIME"
     SORT_BY_END_TIME = "SORT_BY_END_TIME"
+    SORT_BY_VALIDATION_STATE = "SORT_BY_VALIDATION_STATE"
     SORT_BY_STATE = "SORT_BY_STATE"
     SORT_BY_SEARCHER_METRIC = "SORT_BY_SEARCHER_METRIC"
 
@@ -1481,6 +1579,7 @@ class v1GetExperimentsRequestSortBy(enum.Enum):
     SORT_BY_NAME = "SORT_BY_NAME"
     SORT_BY_FORKED_FROM = "SORT_BY_FORKED_FROM"
     SORT_BY_RESOURCE_POOL = "SORT_BY_RESOURCE_POOL"
+    SORT_BY_PROJECT_ID = "SORT_BY_PROJECT_ID"
 
 class v1GetExperimentsResponse:
     def __init__(
@@ -1817,6 +1916,60 @@ class v1GetNotebooksResponse:
             "pagination": self.pagination.to_json() if self.pagination is not None else None,
         }
 
+class v1GetProjectExperimentsRequestSortBy(enum.Enum):
+    SORT_BY_UNSPECIFIED = "SORT_BY_UNSPECIFIED"
+    SORT_BY_ID = "SORT_BY_ID"
+    SORT_BY_DESCRIPTION = "SORT_BY_DESCRIPTION"
+    SORT_BY_START_TIME = "SORT_BY_START_TIME"
+    SORT_BY_END_TIME = "SORT_BY_END_TIME"
+    SORT_BY_STATE = "SORT_BY_STATE"
+    SORT_BY_NUM_TRIALS = "SORT_BY_NUM_TRIALS"
+    SORT_BY_PROGRESS = "SORT_BY_PROGRESS"
+    SORT_BY_USER = "SORT_BY_USER"
+    SORT_BY_NAME = "SORT_BY_NAME"
+    SORT_BY_FORKED_FROM = "SORT_BY_FORKED_FROM"
+    SORT_BY_RESOURCE_POOL = "SORT_BY_RESOURCE_POOL"
+
+class v1GetProjectExperimentsResponse:
+    def __init__(
+        self,
+        experiments: "typing.Sequence[v1Experiment]",
+        pagination: "v1Pagination",
+    ):
+        self.experiments = experiments
+        self.pagination = pagination
+
+    @classmethod
+    def from_json(cls, obj: Json) -> "v1GetProjectExperimentsResponse":
+        return cls(
+            experiments=[v1Experiment.from_json(x) for x in obj["experiments"]],
+            pagination=v1Pagination.from_json(obj["pagination"]),
+        )
+
+    def to_json(self) -> typing.Any:
+        return {
+            "experiments": [x.to_json() for x in self.experiments],
+            "pagination": self.pagination.to_json(),
+        }
+
+class v1GetProjectResponse:
+    def __init__(
+        self,
+        project: "v1Project",
+    ):
+        self.project = project
+
+    @classmethod
+    def from_json(cls, obj: Json) -> "v1GetProjectResponse":
+        return cls(
+            project=v1Project.from_json(obj["project"]),
+        )
+
+    def to_json(self) -> typing.Any:
+        return {
+            "project": self.project.to_json(),
+        }
+
 class v1GetResourcePoolsResponse:
     def __init__(
         self,
@@ -2063,7 +2216,9 @@ class v1GetTrialCheckpointsRequestSortBy(enum.Enum):
     SORT_BY_UNSPECIFIED = "SORT_BY_UNSPECIFIED"
     SORT_BY_UUID = "SORT_BY_UUID"
     SORT_BY_BATCH_NUMBER = "SORT_BY_BATCH_NUMBER"
+    SORT_BY_START_TIME = "SORT_BY_START_TIME"
     SORT_BY_END_TIME = "SORT_BY_END_TIME"
+    SORT_BY_VALIDATION_STATE = "SORT_BY_VALIDATION_STATE"
     SORT_BY_STATE = "SORT_BY_STATE"
 
 class v1GetTrialCheckpointsResponse:
@@ -2128,7 +2283,7 @@ class v1GetTrialResponse:
     def __init__(
         self,
         trial: "trialv1Trial",
-        workloads: "typing.Sequence[v1WorkloadContainer]",
+        workloads: "typing.Sequence[GetTrialResponseWorkloadContainer]",
     ):
         self.trial = trial
         self.workloads = workloads
@@ -2137,35 +2292,13 @@ class v1GetTrialResponse:
     def from_json(cls, obj: Json) -> "v1GetTrialResponse":
         return cls(
             trial=trialv1Trial.from_json(obj["trial"]),
-            workloads=[v1WorkloadContainer.from_json(x) for x in obj["workloads"]],
+            workloads=[GetTrialResponseWorkloadContainer.from_json(x) for x in obj["workloads"]],
         )
 
     def to_json(self) -> typing.Any:
         return {
             "trial": self.trial.to_json(),
             "workloads": [x.to_json() for x in self.workloads],
-        }
-
-class v1GetTrialWorkloadsResponse:
-    def __init__(
-        self,
-        pagination: "v1Pagination",
-        workloads: "typing.Sequence[v1WorkloadContainer]",
-    ):
-        self.workloads = workloads
-        self.pagination = pagination
-
-    @classmethod
-    def from_json(cls, obj: Json) -> "v1GetTrialWorkloadsResponse":
-        return cls(
-            workloads=[v1WorkloadContainer.from_json(x) for x in obj["workloads"]],
-            pagination=v1Pagination.from_json(obj["pagination"]),
-        )
-
-    def to_json(self) -> typing.Any:
-        return {
-            "workloads": [x.to_json() for x in self.workloads],
-            "pagination": self.pagination.to_json(),
         }
 
 class v1GetUserResponse:
@@ -2202,6 +2335,81 @@ class v1GetUsersResponse:
     def to_json(self) -> typing.Any:
         return {
             "users": [x.to_json() for x in self.users] if self.users is not None else None,
+        }
+
+class v1GetWorkspaceProjectsRequestSortBy(enum.Enum):
+    SORT_BY_UNSPECIFIED = "SORT_BY_UNSPECIFIED"
+    SORT_BY_CREATION_TIME = "SORT_BY_CREATION_TIME"
+    SORT_BY_LAST_EXPERIMENT_START_TIME = "SORT_BY_LAST_EXPERIMENT_START_TIME"
+    SORT_BY_NAME = "SORT_BY_NAME"
+    SORT_BY_DESCRIPTION = "SORT_BY_DESCRIPTION"
+    SORT_BY_ID = "SORT_BY_ID"
+
+class v1GetWorkspaceProjectsResponse:
+    def __init__(
+        self,
+        pagination: "v1Pagination",
+        projects: "typing.Sequence[v1Project]",
+    ):
+        self.projects = projects
+        self.pagination = pagination
+
+    @classmethod
+    def from_json(cls, obj: Json) -> "v1GetWorkspaceProjectsResponse":
+        return cls(
+            projects=[v1Project.from_json(x) for x in obj["projects"]],
+            pagination=v1Pagination.from_json(obj["pagination"]),
+        )
+
+    def to_json(self) -> typing.Any:
+        return {
+            "projects": [x.to_json() for x in self.projects],
+            "pagination": self.pagination.to_json(),
+        }
+
+class v1GetWorkspaceResponse:
+    def __init__(
+        self,
+        workspace: "v1Workspace",
+    ):
+        self.workspace = workspace
+
+    @classmethod
+    def from_json(cls, obj: Json) -> "v1GetWorkspaceResponse":
+        return cls(
+            workspace=v1Workspace.from_json(obj["workspace"]),
+        )
+
+    def to_json(self) -> typing.Any:
+        return {
+            "workspace": self.workspace.to_json(),
+        }
+
+class v1GetWorkspacesRequestSortBy(enum.Enum):
+    SORT_BY_UNSPECIFIED = "SORT_BY_UNSPECIFIED"
+    SORT_BY_ID = "SORT_BY_ID"
+    SORT_BY_NAME = "SORT_BY_NAME"
+
+class v1GetWorkspacesResponse:
+    def __init__(
+        self,
+        pagination: "v1Pagination",
+        workspaces: "typing.Sequence[v1Workspace]",
+    ):
+        self.workspaces = workspaces
+        self.pagination = pagination
+
+    @classmethod
+    def from_json(cls, obj: Json) -> "v1GetWorkspacesResponse":
+        return cls(
+            workspaces=[v1Workspace.from_json(x) for x in obj["workspaces"]],
+            pagination=v1Pagination.from_json(obj["pagination"]),
+        )
+
+    def to_json(self) -> typing.Any:
+        return {
+            "workspaces": [x.to_json() for x in self.workspaces],
+            "pagination": self.pagination.to_json(),
         }
 
 class v1IdleNotebookRequest:
@@ -2807,23 +3015,23 @@ class v1MetricType(enum.Enum):
 class v1Metrics:
     def __init__(
         self,
-        avgMetrics: "typing.Dict[str, typing.Any]",
-        batchMetrics: "typing.Optional[typing.Sequence[typing.Dict[str, typing.Any]]]" = None,
+        numInputs: "typing.Optional[int]" = None,
+        validationMetrics: "typing.Optional[typing.Dict[str, typing.Any]]" = None,
     ):
-        self.avgMetrics = avgMetrics
-        self.batchMetrics = batchMetrics
+        self.numInputs = numInputs
+        self.validationMetrics = validationMetrics
 
     @classmethod
     def from_json(cls, obj: Json) -> "v1Metrics":
         return cls(
-            avgMetrics=obj["avgMetrics"],
-            batchMetrics=obj.get("batchMetrics", None),
+            numInputs=obj.get("numInputs", None),
+            validationMetrics=obj.get("validationMetrics", None),
         )
 
     def to_json(self) -> typing.Any:
         return {
-            "avgMetrics": self.avgMetrics,
-            "batchMetrics": self.batchMetrics if self.batchMetrics is not None else None,
+            "numInputs": self.numInputs if self.numInputs is not None else None,
+            "validationMetrics": self.validationMetrics if self.validationMetrics is not None else None,
         }
 
 class v1MetricsWorkload:
@@ -2986,6 +3194,72 @@ class v1ModelVersion:
             "userId": self.userId if self.userId is not None else None,
             "labels": self.labels if self.labels is not None else None,
             "notes": self.notes if self.notes is not None else None,
+        }
+
+class v1MoveExperimentRequest:
+    def __init__(
+        self,
+        destinationProjectId: int,
+        experimentId: int,
+    ):
+        self.experimentId = experimentId
+        self.destinationProjectId = destinationProjectId
+
+    @classmethod
+    def from_json(cls, obj: Json) -> "v1MoveExperimentRequest":
+        return cls(
+            experimentId=obj["experimentId"],
+            destinationProjectId=obj["destinationProjectId"],
+        )
+
+    def to_json(self) -> typing.Any:
+        return {
+            "experimentId": self.experimentId,
+            "destinationProjectId": self.destinationProjectId,
+        }
+
+class v1MoveProjectRequest:
+    def __init__(
+        self,
+        destinationWorkspaceId: int,
+        projectId: int,
+    ):
+        self.projectId = projectId
+        self.destinationWorkspaceId = destinationWorkspaceId
+
+    @classmethod
+    def from_json(cls, obj: Json) -> "v1MoveProjectRequest":
+        return cls(
+            projectId=obj["projectId"],
+            destinationWorkspaceId=obj["destinationWorkspaceId"],
+        )
+
+    def to_json(self) -> typing.Any:
+        return {
+            "projectId": self.projectId,
+            "destinationWorkspaceId": self.destinationWorkspaceId,
+        }
+
+class v1Note:
+    def __init__(
+        self,
+        contents: str,
+        name: str,
+    ):
+        self.name = name
+        self.contents = contents
+
+    @classmethod
+    def from_json(cls, obj: Json) -> "v1Note":
+        return cls(
+            name=obj["name"],
+            contents=obj["contents"],
+        )
+
+    def to_json(self) -> typing.Any:
+        return {
+            "name": self.name,
+            "contents": self.contents,
         }
 
 class v1Notebook:
@@ -3271,6 +3545,46 @@ class v1PatchModelVersionResponse:
             "modelVersion": self.modelVersion.to_json(),
         }
 
+class v1PatchProject:
+    def __init__(
+        self,
+        description: "typing.Optional[str]" = None,
+        name: "typing.Optional[str]" = None,
+    ):
+        self.name = name
+        self.description = description
+
+    @classmethod
+    def from_json(cls, obj: Json) -> "v1PatchProject":
+        return cls(
+            name=obj.get("name", None),
+            description=obj.get("description", None),
+        )
+
+    def to_json(self) -> typing.Any:
+        return {
+            "name": self.name if self.name is not None else None,
+            "description": self.description if self.description is not None else None,
+        }
+
+class v1PatchProjectResponse:
+    def __init__(
+        self,
+        project: "v1Project",
+    ):
+        self.project = project
+
+    @classmethod
+    def from_json(cls, obj: Json) -> "v1PatchProjectResponse":
+        return cls(
+            project=v1Project.from_json(obj["project"]),
+        )
+
+    def to_json(self) -> typing.Any:
+        return {
+            "project": self.project.to_json(),
+        }
+
 class v1PatchUser:
     def __init__(
         self,
@@ -3307,26 +3621,40 @@ class v1PatchUserResponse:
             "user": self.user.to_json(),
         }
 
-class v1PostAllocationProxyAddressRequest:
+class v1PatchWorkspace:
     def __init__(
         self,
-        allocationId: "typing.Optional[str]" = None,
-        proxyAddress: "typing.Optional[str]" = None,
+        name: "typing.Optional[str]" = None,
     ):
-        self.allocationId = allocationId
-        self.proxyAddress = proxyAddress
+        self.name = name
 
     @classmethod
-    def from_json(cls, obj: Json) -> "v1PostAllocationProxyAddressRequest":
+    def from_json(cls, obj: Json) -> "v1PatchWorkspace":
         return cls(
-            allocationId=obj.get("allocationId", None),
-            proxyAddress=obj.get("proxyAddress", None),
+            name=obj.get("name", None),
         )
 
     def to_json(self) -> typing.Any:
         return {
-            "allocationId": self.allocationId if self.allocationId is not None else None,
-            "proxyAddress": self.proxyAddress if self.proxyAddress is not None else None,
+            "name": self.name if self.name is not None else None,
+        }
+
+class v1PatchWorkspaceResponse:
+    def __init__(
+        self,
+        workspace: "v1Workspace",
+    ):
+        self.workspace = workspace
+
+    @classmethod
+    def from_json(cls, obj: Json) -> "v1PatchWorkspaceResponse":
+        return cls(
+            workspace=v1Workspace.from_json(obj["workspace"]),
+        )
+
+    def to_json(self) -> typing.Any:
+        return {
+            "workspace": self.workspace.to_json(),
         }
 
 class v1PostCheckpointMetadataRequest:
@@ -3477,6 +3805,50 @@ class v1PostModelVersionResponse:
             "modelVersion": self.modelVersion.to_json(),
         }
 
+class v1PostProjectRequest:
+    def __init__(
+        self,
+        name: str,
+        workspaceId: int,
+        description: "typing.Optional[str]" = None,
+    ):
+        self.name = name
+        self.description = description
+        self.workspaceId = workspaceId
+
+    @classmethod
+    def from_json(cls, obj: Json) -> "v1PostProjectRequest":
+        return cls(
+            name=obj["name"],
+            description=obj.get("description", None),
+            workspaceId=obj["workspaceId"],
+        )
+
+    def to_json(self) -> typing.Any:
+        return {
+            "name": self.name,
+            "description": self.description if self.description is not None else None,
+            "workspaceId": self.workspaceId,
+        }
+
+class v1PostProjectResponse:
+    def __init__(
+        self,
+        project: "v1Project",
+    ):
+        self.project = project
+
+    @classmethod
+    def from_json(cls, obj: Json) -> "v1PostProjectResponse":
+        return cls(
+            project=v1Project.from_json(obj["project"]),
+        )
+
+    def to_json(self) -> typing.Any:
+        return {
+            "project": self.project.to_json(),
+        }
+
 class v1PostTrialProfilerMetricsBatchRequest:
     def __init__(
         self,
@@ -3535,6 +3907,42 @@ class v1PostUserResponse:
             "user": self.user.to_json() if self.user is not None else None,
         }
 
+class v1PostWorkspaceRequest:
+    def __init__(
+        self,
+        name: str,
+    ):
+        self.name = name
+
+    @classmethod
+    def from_json(cls, obj: Json) -> "v1PostWorkspaceRequest":
+        return cls(
+            name=obj["name"],
+        )
+
+    def to_json(self) -> typing.Any:
+        return {
+            "name": self.name,
+        }
+
+class v1PostWorkspaceResponse:
+    def __init__(
+        self,
+        workspace: "v1Workspace",
+    ):
+        self.workspace = workspace
+
+    @classmethod
+    def from_json(cls, obj: Json) -> "v1PostWorkspaceResponse":
+        return cls(
+            workspace=v1Workspace.from_json(obj["workspace"]),
+        )
+
+    def to_json(self) -> typing.Any:
+        return {
+            "workspace": self.workspace.to_json(),
+        }
+
 class v1PreviewHPSearchRequest:
     def __init__(
         self,
@@ -3573,6 +3981,108 @@ class v1PreviewHPSearchResponse:
     def to_json(self) -> typing.Any:
         return {
             "simulation": self.simulation.to_json() if self.simulation is not None else None,
+        }
+
+class v1Project:
+    def __init__(
+        self,
+        archived: bool,
+        id: int,
+        immutable: bool,
+        name: str,
+        notes: "typing.Sequence[v1Note]",
+        numActiveExperiments: int,
+        numExperiments: int,
+        userId: int,
+        username: str,
+        workspaceId: int,
+        description: "typing.Optional[str]" = None,
+        lastExperimentStartedAt: "typing.Optional[str]" = None,
+    ):
+        self.id = id
+        self.name = name
+        self.workspaceId = workspaceId
+        self.description = description
+        self.lastExperimentStartedAt = lastExperimentStartedAt
+        self.notes = notes
+        self.numExperiments = numExperiments
+        self.numActiveExperiments = numActiveExperiments
+        self.archived = archived
+        self.username = username
+        self.immutable = immutable
+        self.userId = userId
+
+    @classmethod
+    def from_json(cls, obj: Json) -> "v1Project":
+        return cls(
+            id=obj["id"],
+            name=obj["name"],
+            workspaceId=obj["workspaceId"],
+            description=obj.get("description", None),
+            lastExperimentStartedAt=obj.get("lastExperimentStartedAt", None),
+            notes=[v1Note.from_json(x) for x in obj["notes"]],
+            numExperiments=obj["numExperiments"],
+            numActiveExperiments=obj["numActiveExperiments"],
+            archived=obj["archived"],
+            username=obj["username"],
+            immutable=obj["immutable"],
+            userId=obj["userId"],
+        )
+
+    def to_json(self) -> typing.Any:
+        return {
+            "id": self.id,
+            "name": self.name,
+            "workspaceId": self.workspaceId,
+            "description": self.description if self.description is not None else None,
+            "lastExperimentStartedAt": self.lastExperimentStartedAt if self.lastExperimentStartedAt is not None else None,
+            "notes": [x.to_json() for x in self.notes],
+            "numExperiments": self.numExperiments,
+            "numActiveExperiments": self.numActiveExperiments,
+            "archived": self.archived,
+            "username": self.username,
+            "immutable": self.immutable,
+            "userId": self.userId,
+        }
+
+class v1PutProjectNotesRequest:
+    def __init__(
+        self,
+        notes: "typing.Sequence[v1Note]",
+        projectId: int,
+    ):
+        self.notes = notes
+        self.projectId = projectId
+
+    @classmethod
+    def from_json(cls, obj: Json) -> "v1PutProjectNotesRequest":
+        return cls(
+            notes=[v1Note.from_json(x) for x in obj["notes"]],
+            projectId=obj["projectId"],
+        )
+
+    def to_json(self) -> typing.Any:
+        return {
+            "notes": [x.to_json() for x in self.notes],
+            "projectId": self.projectId,
+        }
+
+class v1PutProjectNotesResponse:
+    def __init__(
+        self,
+        notes: "typing.Sequence[v1Note]",
+    ):
+        self.notes = notes
+
+    @classmethod
+    def from_json(cls, obj: Json) -> "v1PutProjectNotesResponse":
+        return cls(
+            notes=[v1Note.from_json(x) for x in obj["notes"]],
+        )
+
+    def to_json(self) -> typing.Any:
+        return {
+            "notes": [x.to_json() for x in self.notes],
         }
 
 class v1PutTemplateResponse:
@@ -4834,15 +5344,15 @@ class v1TrialLogsResponse:
 class v1TrialMetrics:
     def __init__(
         self,
+        latestBatch: int,
         metrics: "typing.Dict[str, typing.Any]",
-        stepsCompleted: int,
         trialId: int,
         trialRunId: int,
         batchMetrics: "typing.Optional[typing.Sequence[typing.Dict[str, typing.Any]]]" = None,
     ):
         self.trialId = trialId
         self.trialRunId = trialRunId
-        self.stepsCompleted = stepsCompleted
+        self.latestBatch = latestBatch
         self.metrics = metrics
         self.batchMetrics = batchMetrics
 
@@ -4851,7 +5361,7 @@ class v1TrialMetrics:
         return cls(
             trialId=obj["trialId"],
             trialRunId=obj["trialRunId"],
-            stepsCompleted=obj["stepsCompleted"],
+            latestBatch=obj["latestBatch"],
             metrics=obj["metrics"],
             batchMetrics=obj.get("batchMetrics", None),
         )
@@ -4860,7 +5370,7 @@ class v1TrialMetrics:
         return {
             "trialId": self.trialId,
             "trialRunId": self.trialRunId,
-            "stepsCompleted": self.stepsCompleted,
+            "latestBatch": self.latestBatch,
             "metrics": self.metrics,
             "batchMetrics": self.batchMetrics if self.batchMetrics is not None else None,
         }
@@ -5092,10 +5602,10 @@ class v1User:
         self,
         active: bool,
         admin: bool,
+        id: int,
         username: str,
         agentUserGroup: "typing.Optional[v1AgentUserGroup]" = None,
         displayName: "typing.Optional[str]" = None,
-        id: "typing.Optional[int]" = None,
         modifiedAt: "typing.Optional[str]" = None,
     ):
         self.id = id
@@ -5109,7 +5619,7 @@ class v1User:
     @classmethod
     def from_json(cls, obj: Json) -> "v1User":
         return cls(
-            id=obj.get("id", None),
+            id=obj["id"],
             username=obj["username"],
             admin=obj["admin"],
             active=obj["active"],
@@ -5120,7 +5630,7 @@ class v1User:
 
     def to_json(self) -> typing.Any:
         return {
-            "id": self.id if self.id is not None else None,
+            "id": self.id,
             "username": self.username,
             "admin": self.admin,
             "active": self.active,
@@ -5173,30 +5683,50 @@ class v1ValidationHistoryEntry:
             "searcherMetric": dump_float(self.searcherMetric),
         }
 
-class v1WorkloadContainer:
+class v1Workspace:
     def __init__(
         self,
-        checkpoint: "typing.Optional[v1CheckpointWorkload]" = None,
-        training: "typing.Optional[v1MetricsWorkload]" = None,
-        validation: "typing.Optional[v1MetricsWorkload]" = None,
+        archived: bool,
+        id: int,
+        immutable: bool,
+        name: str,
+        numProjects: int,
+        pinned: bool,
+        userId: int,
+        username: str,
     ):
-        self.training = training
-        self.validation = validation
-        self.checkpoint = checkpoint
+        self.id = id
+        self.name = name
+        self.archived = archived
+        self.username = username
+        self.immutable = immutable
+        self.numProjects = numProjects
+        self.pinned = pinned
+        self.userId = userId
 
     @classmethod
-    def from_json(cls, obj: Json) -> "v1WorkloadContainer":
+    def from_json(cls, obj: Json) -> "v1Workspace":
         return cls(
-            training=v1MetricsWorkload.from_json(obj["training"]) if obj.get("training", None) is not None else None,
-            validation=v1MetricsWorkload.from_json(obj["validation"]) if obj.get("validation", None) is not None else None,
-            checkpoint=v1CheckpointWorkload.from_json(obj["checkpoint"]) if obj.get("checkpoint", None) is not None else None,
+            id=obj["id"],
+            name=obj["name"],
+            archived=obj["archived"],
+            username=obj["username"],
+            immutable=obj["immutable"],
+            numProjects=obj["numProjects"],
+            pinned=obj["pinned"],
+            userId=obj["userId"],
         )
 
     def to_json(self) -> typing.Any:
         return {
-            "training": self.training.to_json() if self.training is not None else None,
-            "validation": self.validation.to_json() if self.validation is not None else None,
-            "checkpoint": self.checkpoint.to_json() if self.checkpoint is not None else None,
+            "id": self.id,
+            "name": self.name,
+            "archived": self.archived,
+            "username": self.username,
+            "immutable": self.immutable,
+            "numProjects": self.numProjects,
+            "pinned": self.pinned,
+            "userId": self.userId,
         }
 
 def post_AckAllocationPreemptionSignal(
@@ -5237,6 +5767,26 @@ def post_ActivateExperiment(
     if _resp.status_code == 200:
         return
     raise APIHttpError("post_ActivateExperiment", _resp)
+
+def post_AddProjectNote(
+    session: "client.Session",
+    *,
+    body: "v1Note",
+    projectId: int,
+) -> "v1AddProjectNoteResponse":
+    _params = None
+    _resp = session._do_request(
+        method="POST",
+        path=f"/api/v1/projects/{projectId}/notes",
+        params=_params,
+        json=body.to_json(),
+        data=None,
+        headers=None,
+        timeout=None,
+    )
+    if _resp.status_code == 200:
+        return v1AddProjectNoteResponse.from_json(_resp.json())
+    raise APIHttpError("post_AddProjectNote", _resp)
 
 def post_AllocationAllGather(
     session: "client.Session",
@@ -5357,6 +5907,44 @@ def post_ArchiveModel(
     if _resp.status_code == 200:
         return
     raise APIHttpError("post_ArchiveModel", _resp)
+
+def post_ArchiveProject(
+    session: "client.Session",
+    *,
+    id: int,
+) -> None:
+    _params = None
+    _resp = session._do_request(
+        method="POST",
+        path=f"/api/v1/projects/{id}/archive",
+        params=_params,
+        json=None,
+        data=None,
+        headers=None,
+        timeout=None,
+    )
+    if _resp.status_code == 200:
+        return
+    raise APIHttpError("post_ArchiveProject", _resp)
+
+def post_ArchiveWorkspace(
+    session: "client.Session",
+    *,
+    id: int,
+) -> None:
+    _params = None
+    _resp = session._do_request(
+        method="POST",
+        path=f"/api/v1/workspaces/{id}/archive",
+        params=_params,
+        json=None,
+        data=None,
+        headers=None,
+        timeout=None,
+    )
+    if _resp.status_code == 200:
+        return
+    raise APIHttpError("post_ArchiveWorkspace", _resp)
 
 def post_CancelExperiment(
     session: "client.Session",
@@ -5510,6 +6098,25 @@ def delete_DeleteModelVersion(
         return
     raise APIHttpError("delete_DeleteModelVersion", _resp)
 
+def delete_DeleteProject(
+    session: "client.Session",
+    *,
+    id: int,
+) -> None:
+    _params = None
+    _resp = session._do_request(
+        method="DELETE",
+        path=f"/api/v1/projects/{id}",
+        params=_params,
+        json=None,
+        data=None,
+        headers=None,
+        timeout=None,
+    )
+    if _resp.status_code == 200:
+        return
+    raise APIHttpError("delete_DeleteProject", _resp)
+
 def delete_DeleteTemplate(
     session: "client.Session",
     *,
@@ -5528,6 +6135,25 @@ def delete_DeleteTemplate(
     if _resp.status_code == 200:
         return
     raise APIHttpError("delete_DeleteTemplate", _resp)
+
+def delete_DeleteWorkspace(
+    session: "client.Session",
+    *,
+    id: int,
+) -> None:
+    _params = None
+    _resp = session._do_request(
+        method="DELETE",
+        path=f"/api/v1/workspaces/{id}",
+        params=_params,
+        json=None,
+        data=None,
+        headers=None,
+        timeout=None,
+    )
+    if _resp.status_code == 200:
+        return
+    raise APIHttpError("delete_DeleteWorkspace", _resp)
 
 def post_DisableAgent(
     session: "client.Session",
@@ -5791,6 +6417,7 @@ def get_GetExperimentCheckpoints(
     orderBy: "typing.Optional[v1OrderBy]" = None,
     sortBy: "typing.Optional[v1GetExperimentCheckpointsRequestSortBy]" = None,
     states: "typing.Optional[typing.Sequence[determinedcheckpointv1State]]" = None,
+    validationStates: "typing.Optional[typing.Sequence[determinedcheckpointv1State]]" = None,
 ) -> "v1GetExperimentCheckpointsResponse":
     _params = {
         "limit": limit,
@@ -5798,6 +6425,7 @@ def get_GetExperimentCheckpoints(
         "orderBy": orderBy.value if orderBy is not None else None,
         "sortBy": sortBy.value if sortBy is not None else None,
         "states": [x.value for x in states] if states is not None else None,
+        "validationStates": [x.value for x in validationStates] if validationStates is not None else None,
     }
     _resp = session._do_request(
         method="GET",
@@ -5814,8 +6442,12 @@ def get_GetExperimentCheckpoints(
 
 def get_GetExperimentLabels(
     session: "client.Session",
+    *,
+    projectId: "typing.Optional[int]" = None,
 ) -> "v1GetExperimentLabelsResponse":
-    _params = None
+    _params = {
+        "projectId": projectId,
+    }
     _resp = session._do_request(
         method="GET",
         path="/api/v1/experiment/labels",
@@ -6195,6 +6827,67 @@ def get_GetNotebooks(
         return v1GetNotebooksResponse.from_json(_resp.json())
     raise APIHttpError("get_GetNotebooks", _resp)
 
+def get_GetProject(
+    session: "client.Session",
+    *,
+    id: int,
+) -> "v1GetProjectResponse":
+    _params = None
+    _resp = session._do_request(
+        method="GET",
+        path=f"/api/v1/projects/{id}",
+        params=_params,
+        json=None,
+        data=None,
+        headers=None,
+        timeout=None,
+    )
+    if _resp.status_code == 200:
+        return v1GetProjectResponse.from_json(_resp.json())
+    raise APIHttpError("get_GetProject", _resp)
+
+def get_GetProjectExperiments(
+    session: "client.Session",
+    *,
+    id: int,
+    archived: "typing.Optional[bool]" = None,
+    description: "typing.Optional[str]" = None,
+    labels: "typing.Optional[typing.Sequence[str]]" = None,
+    limit: "typing.Optional[int]" = None,
+    name: "typing.Optional[str]" = None,
+    offset: "typing.Optional[int]" = None,
+    orderBy: "typing.Optional[v1OrderBy]" = None,
+    sortBy: "typing.Optional[v1GetProjectExperimentsRequestSortBy]" = None,
+    states: "typing.Optional[typing.Sequence[determinedexperimentv1State]]" = None,
+    userIds: "typing.Optional[typing.Sequence[int]]" = None,
+    users: "typing.Optional[typing.Sequence[str]]" = None,
+) -> "v1GetProjectExperimentsResponse":
+    _params = {
+        "archived": str(archived).lower() if archived is not None else None,
+        "description": description,
+        "labels": labels,
+        "limit": limit,
+        "name": name,
+        "offset": offset,
+        "orderBy": orderBy.value if orderBy is not None else None,
+        "sortBy": sortBy.value if sortBy is not None else None,
+        "states": [x.value for x in states] if states is not None else None,
+        "userIds": userIds,
+        "users": users,
+    }
+    _resp = session._do_request(
+        method="GET",
+        path=f"/api/v1/projects/{id}/experiments",
+        params=_params,
+        json=None,
+        data=None,
+        headers=None,
+        timeout=None,
+    )
+    if _resp.status_code == 200:
+        return v1GetProjectExperimentsResponse.from_json(_resp.json())
+    raise APIHttpError("get_GetProjectExperiments", _resp)
+
 def get_GetResourcePools(
     session: "client.Session",
     *,
@@ -6469,6 +7162,7 @@ def get_GetTrialCheckpoints(
     orderBy: "typing.Optional[v1OrderBy]" = None,
     sortBy: "typing.Optional[v1GetTrialCheckpointsRequestSortBy]" = None,
     states: "typing.Optional[typing.Sequence[determinedcheckpointv1State]]" = None,
+    validationStates: "typing.Optional[typing.Sequence[determinedcheckpointv1State]]" = None,
 ) -> "v1GetTrialCheckpointsResponse":
     _params = {
         "limit": limit,
@@ -6476,6 +7170,7 @@ def get_GetTrialCheckpoints(
         "orderBy": orderBy.value if orderBy is not None else None,
         "sortBy": sortBy.value if sortBy is not None else None,
         "states": [x.value for x in states] if states is not None else None,
+        "validationStates": [x.value for x in validationStates] if validationStates is not None else None,
     }
     _resp = session._do_request(
         method="GET",
@@ -6489,32 +7184,6 @@ def get_GetTrialCheckpoints(
     if _resp.status_code == 200:
         return v1GetTrialCheckpointsResponse.from_json(_resp.json())
     raise APIHttpError("get_GetTrialCheckpoints", _resp)
-
-def get_GetTrialWorkloads(
-    session: "client.Session",
-    *,
-    trialId: int,
-    limit: "typing.Optional[int]" = None,
-    offset: "typing.Optional[int]" = None,
-    orderBy: "typing.Optional[v1OrderBy]" = None,
-) -> "v1GetTrialWorkloadsResponse":
-    _params = {
-        "limit": limit,
-        "offset": offset,
-        "orderBy": orderBy.value if orderBy is not None else None,
-    }
-    _resp = session._do_request(
-        method="GET",
-        path=f"/api/v1/trials/{trialId}/workloads",
-        params=_params,
-        json=None,
-        data=None,
-        headers=None,
-        timeout=None,
-    )
-    if _resp.status_code == 200:
-        return v1GetTrialWorkloadsResponse.from_json(_resp.json())
-    raise APIHttpError("get_GetTrialWorkloads", _resp)
 
 def get_GetUser(
     session: "client.Session",
@@ -6551,6 +7220,94 @@ def get_GetUsers(
     if _resp.status_code == 200:
         return v1GetUsersResponse.from_json(_resp.json())
     raise APIHttpError("get_GetUsers", _resp)
+
+def get_GetWorkspace(
+    session: "client.Session",
+    *,
+    id: int,
+) -> "v1GetWorkspaceResponse":
+    _params = None
+    _resp = session._do_request(
+        method="GET",
+        path=f"/api/v1/workspaces/{id}",
+        params=_params,
+        json=None,
+        data=None,
+        headers=None,
+        timeout=None,
+    )
+    if _resp.status_code == 200:
+        return v1GetWorkspaceResponse.from_json(_resp.json())
+    raise APIHttpError("get_GetWorkspace", _resp)
+
+def get_GetWorkspaceProjects(
+    session: "client.Session",
+    *,
+    id: int,
+    archived: "typing.Optional[bool]" = None,
+    limit: "typing.Optional[int]" = None,
+    name: "typing.Optional[str]" = None,
+    offset: "typing.Optional[int]" = None,
+    orderBy: "typing.Optional[v1OrderBy]" = None,
+    sortBy: "typing.Optional[v1GetWorkspaceProjectsRequestSortBy]" = None,
+    users: "typing.Optional[typing.Sequence[str]]" = None,
+) -> "v1GetWorkspaceProjectsResponse":
+    _params = {
+        "archived": str(archived).lower() if archived is not None else None,
+        "limit": limit,
+        "name": name,
+        "offset": offset,
+        "orderBy": orderBy.value if orderBy is not None else None,
+        "sortBy": sortBy.value if sortBy is not None else None,
+        "users": users,
+    }
+    _resp = session._do_request(
+        method="GET",
+        path=f"/api/v1/workspaces/{id}/projects",
+        params=_params,
+        json=None,
+        data=None,
+        headers=None,
+        timeout=None,
+    )
+    if _resp.status_code == 200:
+        return v1GetWorkspaceProjectsResponse.from_json(_resp.json())
+    raise APIHttpError("get_GetWorkspaceProjects", _resp)
+
+def get_GetWorkspaces(
+    session: "client.Session",
+    *,
+    archived: "typing.Optional[bool]" = None,
+    limit: "typing.Optional[int]" = None,
+    name: "typing.Optional[str]" = None,
+    offset: "typing.Optional[int]" = None,
+    orderBy: "typing.Optional[v1OrderBy]" = None,
+    pinned: "typing.Optional[bool]" = None,
+    sortBy: "typing.Optional[v1GetWorkspacesRequestSortBy]" = None,
+    users: "typing.Optional[typing.Sequence[str]]" = None,
+) -> "v1GetWorkspacesResponse":
+    _params = {
+        "archived": str(archived).lower() if archived is not None else None,
+        "limit": limit,
+        "name": name,
+        "offset": offset,
+        "orderBy": orderBy.value if orderBy is not None else None,
+        "pinned": str(pinned).lower() if pinned is not None else None,
+        "sortBy": sortBy.value if sortBy is not None else None,
+        "users": users,
+    }
+    _resp = session._do_request(
+        method="GET",
+        path="/api/v1/workspaces",
+        params=_params,
+        json=None,
+        data=None,
+        headers=None,
+        timeout=None,
+    )
+    if _resp.status_code == 200:
+        return v1GetWorkspacesResponse.from_json(_resp.json())
+    raise APIHttpError("get_GetWorkspaces", _resp)
 
 def put_IdleNotebook(
     session: "client.Session",
@@ -6819,6 +7576,46 @@ def post_MarkAllocationResourcesDaemon(
         return
     raise APIHttpError("post_MarkAllocationResourcesDaemon", _resp)
 
+def post_MoveExperiment(
+    session: "client.Session",
+    *,
+    body: "v1MoveExperimentRequest",
+    experimentId: int,
+) -> None:
+    _params = None
+    _resp = session._do_request(
+        method="POST",
+        path=f"/api/v1/experiments/{experimentId}/move",
+        params=_params,
+        json=body.to_json(),
+        data=None,
+        headers=None,
+        timeout=None,
+    )
+    if _resp.status_code == 200:
+        return
+    raise APIHttpError("post_MoveExperiment", _resp)
+
+def post_MoveProject(
+    session: "client.Session",
+    *,
+    body: "v1MoveProjectRequest",
+    projectId: int,
+) -> None:
+    _params = None
+    _resp = session._do_request(
+        method="POST",
+        path=f"/api/v1/projects/{projectId}/move",
+        params=_params,
+        json=body.to_json(),
+        data=None,
+        headers=None,
+        timeout=None,
+    )
+    if _resp.status_code == 200:
+        return
+    raise APIHttpError("post_MoveProject", _resp)
+
 def patch_PatchExperiment(
     session: "client.Session",
     *,
@@ -6880,6 +7677,26 @@ def patch_PatchModelVersion(
         return v1PatchModelVersionResponse.from_json(_resp.json())
     raise APIHttpError("patch_PatchModelVersion", _resp)
 
+def patch_PatchProject(
+    session: "client.Session",
+    *,
+    body: "v1PatchProject",
+    id: int,
+) -> "v1PatchProjectResponse":
+    _params = None
+    _resp = session._do_request(
+        method="PATCH",
+        path=f"/api/v1/projects/{id}",
+        params=_params,
+        json=body.to_json(),
+        data=None,
+        headers=None,
+        timeout=None,
+    )
+    if _resp.status_code == 200:
+        return v1PatchProjectResponse.from_json(_resp.json())
+    raise APIHttpError("patch_PatchProject", _resp)
+
 def patch_PatchUser(
     session: "client.Session",
     *,
@@ -6900,6 +7717,26 @@ def patch_PatchUser(
         return v1PatchUserResponse.from_json(_resp.json())
     raise APIHttpError("patch_PatchUser", _resp)
 
+def patch_PatchWorkspace(
+    session: "client.Session",
+    *,
+    body: "v1PatchWorkspace",
+    id: int,
+) -> "v1PatchWorkspaceResponse":
+    _params = None
+    _resp = session._do_request(
+        method="PATCH",
+        path=f"/api/v1/workspaces/{id}",
+        params=_params,
+        json=body.to_json(),
+        data=None,
+        headers=None,
+        timeout=None,
+    )
+    if _resp.status_code == 200:
+        return v1PatchWorkspaceResponse.from_json(_resp.json())
+    raise APIHttpError("patch_PatchWorkspace", _resp)
+
 def post_PauseExperiment(
     session: "client.Session",
     *,
@@ -6919,25 +7756,24 @@ def post_PauseExperiment(
         return
     raise APIHttpError("post_PauseExperiment", _resp)
 
-def post_PostAllocationProxyAddress(
+def post_PinWorkspace(
     session: "client.Session",
     *,
-    allocationId: str,
-    body: "v1PostAllocationProxyAddressRequest",
+    id: int,
 ) -> None:
     _params = None
     _resp = session._do_request(
         method="POST",
-        path=f"/api/v1/allocations/{allocationId}/proxy_address",
+        path=f"/api/v1/workspaces/{id}/pin",
         params=_params,
-        json=body.to_json(),
+        json=None,
         data=None,
         headers=None,
         timeout=None,
     )
     if _resp.status_code == 200:
         return
-    raise APIHttpError("post_PostAllocationProxyAddress", _resp)
+    raise APIHttpError("post_PinWorkspace", _resp)
 
 def post_PostCheckpointMetadata(
     session: "client.Session",
@@ -6998,6 +7834,26 @@ def post_PostModelVersion(
         return v1PostModelVersionResponse.from_json(_resp.json())
     raise APIHttpError("post_PostModelVersion", _resp)
 
+def post_PostProject(
+    session: "client.Session",
+    *,
+    body: "v1PostProjectRequest",
+    workspaceId: int,
+) -> "v1PostProjectResponse":
+    _params = None
+    _resp = session._do_request(
+        method="POST",
+        path=f"/api/v1/workspaces/{workspaceId}/projects",
+        params=_params,
+        json=body.to_json(),
+        data=None,
+        headers=None,
+        timeout=None,
+    )
+    if _resp.status_code == 200:
+        return v1PostProjectResponse.from_json(_resp.json())
+    raise APIHttpError("post_PostProject", _resp)
+
 def post_PostTrialProfilerMetricsBatch(
     session: "client.Session",
     *,
@@ -7056,6 +7912,25 @@ def post_PostUser(
         return v1PostUserResponse.from_json(_resp.json())
     raise APIHttpError("post_PostUser", _resp)
 
+def post_PostWorkspace(
+    session: "client.Session",
+    *,
+    body: "v1PostWorkspaceRequest",
+) -> "v1PostWorkspaceResponse":
+    _params = None
+    _resp = session._do_request(
+        method="POST",
+        path="/api/v1/workspaces",
+        params=_params,
+        json=body.to_json(),
+        data=None,
+        headers=None,
+        timeout=None,
+    )
+    if _resp.status_code == 200:
+        return v1PostWorkspaceResponse.from_json(_resp.json())
+    raise APIHttpError("post_PostWorkspace", _resp)
+
 def post_PreviewHPSearch(
     session: "client.Session",
     *,
@@ -7074,6 +7949,26 @@ def post_PreviewHPSearch(
     if _resp.status_code == 200:
         return v1PreviewHPSearchResponse.from_json(_resp.json())
     raise APIHttpError("post_PreviewHPSearch", _resp)
+
+def put_PutProjectNotes(
+    session: "client.Session",
+    *,
+    body: "v1PutProjectNotesRequest",
+    projectId: int,
+) -> "v1PutProjectNotesResponse":
+    _params = None
+    _resp = session._do_request(
+        method="PUT",
+        path=f"/api/v1/projects/{projectId}/notes",
+        params=_params,
+        json=body.to_json(),
+        data=None,
+        headers=None,
+        timeout=None,
+    )
+    if _resp.status_code == 200:
+        return v1PutProjectNotesResponse.from_json(_resp.json())
+    raise APIHttpError("put_PutProjectNotes", _resp)
 
 def put_PutTemplate(
     session: "client.Session",
@@ -7095,15 +7990,16 @@ def put_PutTemplate(
         return v1PutTemplateResponse.from_json(_resp.json())
     raise APIHttpError("put_PutTemplate", _resp)
 
-def post_ReportCheckpoint(
+def post_ReportTrialCheckpointMetadata(
     session: "client.Session",
     *,
-    body: "v1Checkpoint",
+    body: "v1CheckpointMetadata",
+    checkpointMetadata_trialId: int,
 ) -> None:
     _params = None
     _resp = session._do_request(
         method="POST",
-        path="/api/v1/checkpoints",
+        path=f"/api/v1/trials/{checkpointMetadata_trialId}/checkpoint_metadata",
         params=_params,
         json=body.to_json(),
         data=None,
@@ -7112,7 +8008,7 @@ def post_ReportCheckpoint(
     )
     if _resp.status_code == 200:
         return
-    raise APIHttpError("post_ReportCheckpoint", _resp)
+    raise APIHttpError("post_ReportTrialCheckpointMetadata", _resp)
 
 def post_ReportTrialProgress(
     session: "client.Session",
@@ -7379,6 +8275,63 @@ def post_UnarchiveModel(
     if _resp.status_code == 200:
         return
     raise APIHttpError("post_UnarchiveModel", _resp)
+
+def post_UnarchiveProject(
+    session: "client.Session",
+    *,
+    id: int,
+) -> None:
+    _params = None
+    _resp = session._do_request(
+        method="POST",
+        path=f"/api/v1/projects/{id}/unarchive",
+        params=_params,
+        json=None,
+        data=None,
+        headers=None,
+        timeout=None,
+    )
+    if _resp.status_code == 200:
+        return
+    raise APIHttpError("post_UnarchiveProject", _resp)
+
+def post_UnarchiveWorkspace(
+    session: "client.Session",
+    *,
+    id: int,
+) -> None:
+    _params = None
+    _resp = session._do_request(
+        method="POST",
+        path=f"/api/v1/workspaces/{id}/unarchive",
+        params=_params,
+        json=None,
+        data=None,
+        headers=None,
+        timeout=None,
+    )
+    if _resp.status_code == 200:
+        return
+    raise APIHttpError("post_UnarchiveWorkspace", _resp)
+
+def post_UnpinWorkspace(
+    session: "client.Session",
+    *,
+    id: int,
+) -> None:
+    _params = None
+    _resp = session._do_request(
+        method="POST",
+        path=f"/api/v1/workspaces/{id}/unpin",
+        params=_params,
+        json=None,
+        data=None,
+        headers=None,
+        timeout=None,
+    )
+    if _resp.status_code == 200:
+        return
+    raise APIHttpError("post_UnpinWorkspace", _resp)
 
 def post_UpdateJobQueue(
     session: "client.Session",

--- a/harness/determined/common/experimental/session.py
+++ b/harness/determined/common/experimental/session.py
@@ -29,10 +29,6 @@ class Session:
         headers: Optional[Dict[str, Any]],
         timeout: Optional[int],
     ) -> requests.Response:
-        if params:
-            for k, v in params.items():
-                if type(v) == bool:
-                    params[k] = str(v).lower()
         return request.do_request(
             method,
             self._master,


### PR DESCRIPTION
## Description

- Cherry-picks a commit on master branch to support True/False in GET params (previously "True" and "False" were rejected and we needed to send a string such as "false")
- Removes my related patch on workspaces

This branch merges into the workspaces feature branch.  We should probably wait to merge after other PRs are merged, because it will rewrite a lot of the Python bindings.py

## Test Plan

Existing e2e_tests already include boolean values


## Checklist

- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.