### PR TITLE
feat: allow NaN validation metrics [DET-7177]

### DIFF
--- a/e2e_tests/tests/experiment/test_noop.py
+++ b/e2e_tests/tests/experiment/test_noop.py
@@ -59,6 +59,21 @@ def test_noop_pause() -> None:
 
 
 @pytest.mark.e2e_cpu
+def test_noop_nan_validations() -> None:
+    """
+    Ensure that NaN validation metric values don't prevent an experiment from completing.
+    """
+    experiment_id = exp.create_experiment(
+        conf.fixtures_path("no_op/single-nan-validations.yaml"),
+        conf.fixtures_path("no_op"),
+        None,
+    )
+    exp.wait_for_experiment_state(
+        experiment_id, bindings.determinedexperimentv1State.STATE_COMPLETED
+    )
+
+
+@pytest.mark.e2e_cpu
 def test_noop_load() -> None:
     """
     Load a checkpoint

--- a/e2e_tests/tests/fixtures/no_op/model_def.py
+++ b/e2e_tests/tests/fixtures/no_op/model_def.py
@@ -56,6 +56,7 @@ class NoOpTrialController(det.TrialController):
         self.chaos_probability_train = self.env.hparams.get("chaos_probability_train")
         self.chaos_probability_validate = self.env.hparams.get("chaos_probability_validate")
         self.chaos_probability_checkpoint = self.env.hparams.get("chaos_probability_checkpoint")
+        self.nan_probability_validate = self.env.hparams.get("nan_probability_validate", 0)
         self.fail_on_first_validation = self.env.hparams.get("fail_on_first_validation", "")
         self.fail_on_chechpoint_save = self.env.hparams.get("fail_on_chechpoint_save", "")
         self.validation_set_size = self.env.hparams.get("validation_set_size", 32 * 32)
@@ -165,7 +166,10 @@ class NoOpTrialController(det.TrialController):
         self.chaos_failure(self.chaos_probability_validate)
         time.sleep(self.validation_secs)
         metrics = {
-            name: self.current_metric() for name in ["validation_error", *self.validation_metrics()]
+            name: (
+                np.nan if random.random() < self.nan_probability_validate else self.current_metric()
+            )
+            for name in ["validation_error", *self.validation_metrics()]
         }
         response = {
             "metrics": {"validation_metrics": metrics, "num_inputs": self.validation_set_size},

--- a/e2e_tests/tests/fixtures/no_op/single-nan-validations.yaml
+++ b/e2e_tests/tests/fixtures/no_op/single-nan-validations.yaml
@@ -1,0 +1,26 @@
+description: noop_single
+checkpoint_storage:
+  type: shared_fs
+  host_path: /tmp
+  storage_path: determined-integration-checkpoints
+  save_trial_best: 30
+hyperparameters:
+  global_batch_size: 32
+  metrics_progression: decreasing
+  metrics_base: 0.9
+  metrics_sigma: 0
+  nan_probability_validate: .6
+searcher:
+  metric: validation_error
+  smaller_is_better: true
+  name: single
+  max_length:
+    batches: 3000
+reproducibility:
+  experiment_seed: 999
+min_validation_period:
+  batches: 100
+min_checkpoint_period:
+  batches: 100
+max_restarts: 0
+entrypoint: model_def:NoOpTrial

--- a/harness/determined/core/_searcher.py
+++ b/harness/determined/core/_searcher.py
@@ -1,6 +1,5 @@
 import enum
 import logging
-import math
 from typing import Iterator, Optional
 
 import determined as det
@@ -94,8 +93,6 @@ class SearcherOperation:
             raise RuntimeError("you must only call op.report_completed() from the chief worker")
         if self._completed:
             raise RuntimeError("you may only call op.report_completed() once")
-        if math.isnan(searcher_metric):
-            raise RuntimeError("searcher_metric may not be NaN")
         self._completed = True
         body = {"op": {"length": self._length}, "searcherMetric": searcher_metric}
         logger.debug(f"op.report_completed({searcher_metric})")
@@ -306,8 +303,6 @@ class DummySearcherOperation(SearcherOperation):
             raise RuntimeError("you must only call op.report_completed() from the chief worker")
         if self._completed:
             raise RuntimeError("you may only call op.report_completed() once")
-        if math.isnan(searcher_metric):
-            raise RuntimeError("searcher_metric may not be NaN")
         self._completed = True
         logger.info(
             f"SearcherOperation Complete: searcher_metric={det.util.json_encode(searcher_metric)}"

--- a/harness/determined/layers/_workload_sequencer.py
+++ b/harness/determined/layers/_workload_sequencer.py
@@ -1,5 +1,4 @@
 import logging
-import math
 import sys
 from typing import Any, Generator, Optional, Tuple
 
@@ -272,11 +271,6 @@ class WorkloadSequencer(workload.Source):
             raise RuntimeError(
                 f"Searcher validation metric '{searcher_metric_name}' returned "
                 f"a non-scalar value: {searcher_metric}"
-            )
-
-        if math.isnan(searcher_metric):
-            raise RuntimeError(
-                f"Searcher validation metric '{searcher_metric_name}' returned a NaN value"
             )
 
         # Report to the searcher API first, so we don't end up in a situation where we die between


### PR DESCRIPTION
## Description

In several places, the harness had checks to filter out NaN validation
metric values, which previously could not be handled. This change
removes the checks, and testing has seemed to indicate that NaN values
are serialized and otherwise handled just fine without causing any
errors.

As a historical note, I found while tracing the history of this code
that NaN values were originally considered an error, then changed to not
being an error, then changed back again. The comment I changed was
actually incorrect until just now, as it applied to an older version of
the code.

## Test Plan

- [x] add test for NaN validation metrics

## Commentary

I noticed while 