### PR TITLE
feat: allow setting of checkpointStorage.prefix through helm [DET-7152]

### DIFF
--- a/docs/release-notes/checkpoint-prefix.txt
+++ b/docs/release-notes/checkpoint-prefix.txt
@@ -1,0 +1,5 @@
+:orphan:
+
+**Bug Fixes**
+
+-  Kubernetes: Specifying `checkpointStorage.prefix` for `checkpointStorage.type=s3` will now upload checkpoints correctly while before it was ignored.

--- a/docs/release-notes/checkpoint-prefix.txt
+++ b/docs/release-notes/checkpoint-prefix.txt
@@ -1,6 +1,5 @@
 :orphan:
 
-**Bug Fixes**
+**New Features**
 
--  Kubernetes: Specifying `checkpointStorage.prefix` for `checkpointStorage.type=s3` will now upload
-   checkpoints correctly while before it was ignored.
+- Kubernetes: Users may now specify a ``checkpointStorage.prefix`` in the Determined helm chart if using s3 buckets for checkpoint storage. Checkpoints will now be uploaded with the path prefix whereas before it was ignored.

--- a/docs/release-notes/checkpoint-prefix.txt
+++ b/docs/release-notes/checkpoint-prefix.txt
@@ -2,4 +2,6 @@
 
 **New Features**
 
-- Kubernetes: Users may now specify a ``checkpointStorage.prefix`` in the Determined helm chart if using s3 buckets for checkpoint storage. Checkpoints will now be uploaded with the path prefix whereas before it was ignored.
+-  Kubernetes: Users may now specify a ``checkpointStorage.prefix`` in the Determined helm chart if
+   using s3 buckets for checkpoint storage. Checkpoints will now be uploaded with the path prefix
+   whereas before it was ignored.

--- a/docs/release-notes/checkpoint-prefix.txt
+++ b/docs/release-notes/checkpoint-prefix.txt
@@ -2,4 +2,5 @@
 
 **Bug Fixes**
 
--  Kubernetes: Specifying `checkpointStorage.prefix` for `checkpointStorage.type=s3` will now upload checkpoints correctly while before it was ignored.
+-  Kubernetes: Specifying `checkpointStorage.prefix` for `checkpointStorage.type=s3` will now upload
+   checkpoints correctly while before it was ignored.

--- a/helm/charts/determined/templates/master-config.yaml
+++ b/helm/charts/determined/templates/master-config.yaml
@@ -19,6 +19,7 @@ data:
       access_key: {{ .Values.checkpointStorage.accessKey | quote }}
       secret_key: {{ .Values.checkpointStorage.secretKey | quote }}
       endpoint_url: {{ .Values.checkpointStorage.endpointUrl | quote }}
+      prefix: {{ .Values.checkpointStorage.prefix | quote }}
       {{- else if eq .Values.checkpointStorage.type "azure" }}
       {{- if and .Values.checkpointStorage.connection_string .Values.checkpointStorage.account_url }}
       {{ required "Exactly one of .Values.checkpointStorage.connection_string or .Values.checkpointStorage.account_url must be specified!" "" }}

--- a/helm/charts/determined/values.yaml
+++ b/helm/charts/determined/values.yaml
@@ -94,7 +94,7 @@ checkpointStorage:
   # accessKey: <access_key>
   # secretKey: <secret_key>
   # endpointUrl: <endpoint_url>
-
+  # prefix: <prefix>
 
   # For storing in Azure Blob Storage with a connection string.
   # Do NOT use if already using Azure Blob Storage with account URL


### PR DESCRIPTION
## Description

Previously, checkpointStorage could not be set through helm. This change allows it.

## Test Plan

Create a publicly accessible s3 bucket 

Login
```
gcloud auth login
```

Switch project
```
gcloud config set project determined-ai
```

Create cluster (this takes awhile)
```
gcloud container clusters create nblaskey-test \
 --region us-west1 \
 --node-locations us-west1-b\
 --num-nodes=1 \
 --image-type=UBUNTU \
 --cluster- --cluster-version=1.22.8-gke.200 \
 --machine-type=n1-standard-8
```

Creates a node pool for GPUs
```
gcloud container node-pools create node-pool-name \
 --cluster nblaskey-test \
 --accelerator type=nvidia-tesla-k80,count=1 \
 --zone us-west1 \
 --num-nodes=1 \
 --image-type=UBUNTU \
 --machine-type=n1-standard-8 \
 --scopes=storage-full
```

Apply DaemonSet to enable nodes to detect GPUs
```
kubectl apply -f https://raw.githubusercontent.com/GoogleCloudPlatform/container-engine-accelerators/master/nvidia-driver-installer/ubuntu/daemonset-preloaded.yaml
```

Install determined using helm 
```
helm install determined helm/charts/determined/ \
  --values helm/charts/determined/values.yaml \
  --set maxSlotsPerPod=1 \
  --set detVersion=0.18.0 \
  --set checkpointStorage.type=s3
  --set bucket=*****
  --set access_key=*****
  --set secret_key=*****
```

Port forward
```
kubectl port-forward service/determined-master-service-determined 8080:8080
```

Create and wait for an experiment to finish
```
det e create examples/computer_vision/mnist_estimator/const.yaml examples/computer_vision/mnist_estimator/
```

Validate checkpoints were created with the prefix on s3

## Checklist

- [X] User-facing API changes need the "User-facing API Change" label.
- [X] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [X] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
