### PR TITLE
fix: upstream test failures due to config being admin protected

### DIFF
--- a/e2e_tests/tests/conftest.py
+++ b/e2e_tests/tests/conftest.py
@@ -14,6 +14,7 @@ from tests import config
 from tests.experiment import profile_test
 from tests.nightly.compute_stats import compare_stats
 
+from .cluster.test_users import ADMIN_CREDENTIALS, logged_in_user
 from .cluster_log_manager import ClusterLogManager
 
 _INTEG_MARKERS = {
@@ -161,7 +162,8 @@ def using_k8s(request: SubRequest) -> bool:
         "--json",
     ]
 
-    output = subprocess.check_output(command, universal_newlines=True, stderr=subprocess.PIPE)
+    with logged_in_user(ADMIN_CREDENTIALS):
+        output = subprocess.check_output(command, universal_newlines=True, stderr=subprocess.PIPE)
 
     rp = json.loads(output)["resource_manager"]["type"]
     return bool(rp == "kubernetes")


### PR DESCRIPTION
## Description

Upstream tests relied on getting master configuration without being logged in as admin. This makes sure when the tests call config they are logged in as admin.

## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions about this test plan to ensure adequate manual coverage of changes.
-->

## Checklist

- [X] User-facing API changes need the "User-facing API Change" label.
- [X] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [X] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
