### PR TITLE
chore: update deepspeed launcher to work with newer versions

### DIFF
--- a/harness/tests/launch/test_deepspeed.py
+++ b/harness/tests/launch/test_deepspeed.py
@@ -57,7 +57,7 @@ def test_launch_multi_slot_chief(
         cluster_info.allocation_id, len(cluster_info.slot_ids)
     )
     deepspeed_cmd = launch.deepspeed.create_run_command(
-        cluster_info.container_addrs[0], launch.deepspeed.get_hostfile_path()
+        cluster_info.container_addrs[0], launch.deepspeed.get_hostfile_path(multi_machine=True)
     )
     pid_client_cmd = launch.deepspeed.create_pid_client_cmd(cluster_info.allocation_id)
     log_redirect_cmd = launch.deepspeed.create_log_redirect_cmd()
@@ -130,7 +130,7 @@ def test_launch_multi_slot_fail(
         cluster_info.allocation_id, len(cluster_info.slot_ids)
     )
     deepspeed_cmd = launch.deepspeed.create_run_command(
-        cluster_info.container_addrs[0], launch.deepspeed.get_hostfile_path()
+        cluster_info.container_addrs[0], launch.deepspeed.get_hostfile_path(multi_machine=True)
     )
     pid_client_cmd = launch.deepspeed.create_pid_client_cmd(cluster_info.allocation_id)
     log_redirect_cmd = launch.deepspeed.create_log_redirect_cmd()
@@ -188,7 +188,7 @@ def test_launch_one_slot(
         cluster_info.allocation_id, len(cluster_info.slot_ids)
     )
     deepspeed_cmd = launch.deepspeed.create_run_command(
-        "localhost", launch.deepspeed.get_hostfile_path()
+        "localhost", launch.deepspeed.get_hostfile_path(multi_machine=False)
     )
     pid_client_cmd = launch.deepspeed.create_pid_client_cmd(cluster_info.allocation_id)
     log_redirect_cmd = launch.deepspeed.create_log_redirect_cmd()
@@ -215,7 +215,7 @@ def test_launch_fail(mock_cluster_info: mock.MagicMock, mock_subprocess: mock.Ma
         cluster_info.allocation_id, len(cluster_info.slot_ids)
     )
     deepspeed_cmd = launch.deepspeed.create_run_command(
-        "localhost", launch.deepspeed.get_hostfile_path()
+        "localhost", launch.deepspeed.get_hostfile_path(multi_machine=False)
     )
     pid_client_cmd = launch.deepspeed.create_pid_client_cmd(cluster_info.allocation_id)
     log_redirect_cmd = launch.deepspeed.create_log_redirect_cmd()


### PR DESCRIPTION
## Description
There have been changes to the deepspeed launcher in newer versions that break compatibility with our launcher.  This PR addresses those compatibility issues introduced in 

- https://github.com/microsoft/DeepSpeed/pull/1832
- https://github.com/microsoft/DeepSpeed/pull/1907

Using deepspeed versions > 0.6.4 will depend on this upstream PR https://github.com/microsoft/DeepSpeed/pull/1957


## Test Plan
Tested single and multinode for 0.5.10 and 0.6.5.dev with the PR above


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
