### PR TITLE
fix: prevent experiment name in header from overflowing entire vertical

### DIFF
--- a/webui/react/src/pages/ExperimentDetails/ExperimentDetailsHeader.module.scss
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentDetailsHeader.module.scss
@@ -54,6 +54,7 @@
     flex-shrink: 1;
     overflow: hidden;
     text-overflow: ellipsis;
+    word-break: normal;
   }
 }
 .foldableSection {


### PR DESCRIPTION
fix: prevent experiment name in header from overflowing entire vertical [DET-7342]

## Before

https://user-images.githubusercontent.com/28383080/168981826-c66c486c-82a0-4db0-87f2-220921ce982b.mov

## After

https://user-images.githubusercontent.com/28383080/168981886-4d8bfb3d-fec9-425d-8e4b-04759263a3ac.mov


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-7342]: https://determinedai.atlassian.net/browse/DET-7342?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ