### PR TITLE
chore: check git state in lock-api-state.sh

### DIFF
--- a/proto/Makefile
+++ b/proto/Makefile
@@ -66,8 +66,6 @@ $(swagger_out): $(source_files) build/swagger $(echo_swagger_patch)
 # Update buf image for breaking change check.
 .PHONY: gen-buf-image
 gen-buf-image:
-	# disallow untracked or dirty files.
-	# test -z "$(shell git status --porcelain)"
 	buf build -o $(buf_image)
 
 .PHONY: check

--- a/tools/scripts/lock-api-state.sh
+++ b/tools/scripts/lock-api-state.sh
@@ -1,5 +1,11 @@
 #!/bin/bash -ex
 
+# check for dirty changes
+if [[ -n "$(git status --porcelain)" ]]; then
+    echo "untracked or dirty files are not allowed, cleanup before running lock-api-state.sh"
+    exit 1
+fi
+
 ## lock in current protobuf state
 
 # make gen-buf-image ensures that it starts with a clean git state


### PR DESCRIPTION
## Description

<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At a minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions about this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ