### PR TITLE
fix: include both old and new checkpoints in total checkpoint size

### DIFF
--- a/master/static/srv/proto_get_trials_plus.sql
+++ b/master/static/srv/proto_get_trials_plus.sql
@@ -171,7 +171,11 @@ SELECT
   ) AS wall_clock_time,
   (
     SELECT sum((jsonb_each).value::text::int)
-    FROM (SELECT jsonb_each(resources) FROM checkpoints c WHERE c.trial_id = t.id) r
+    FROM (
+        SELECT jsonb_each(resources) FROM checkpoints_old_view c WHERE c.trial_id = t.id
+        UNION ALL
+        SELECT jsonb_each(resources) FROM checkpoints_new_view c WHERE c.trial_id = t.id
+    ) r
   ) AS total_checkpoint_size
 FROM searcher_info
   INNER JOIN trials t ON t.id = searcher_info.trial_id


### PR DESCRIPTION
## Description

Due to recent reshuffling of the checkpoints tables, part of this query
ended up including only the old checkpoints table and ignoring the new
one, where instead it should consider both the old and new views, like
the rest of the query.

## Test Plan

- [x] check that the query returns a reasonable-looking value where it was returning 0 before on a trial with only new-style checkpoints.

## Commentary (optional)

I'm kind of cargo-culting the exact form of the query; improvement suggestions welcome.
