### PR TITLE
fix: sync slot usage for k8s [DET-7350]

### DIFF
--- a/docs/release-notes/7073-cluster-ui-improvement
+++ b/docs/release-notes/7073-cluster-ui-improvement
@@ -2,5 +2,6 @@
 
 **Improvements**
 
-- Combine sidebar options `Cluster`, `Job Queues` and `Cluster Logs` into `Cluster` page.
+- Centralize sidebar options `Cluster`, `Job Queues` and `Cluster Logs` into `Cluster` page for a simplified layout.
+- In order to provide a more precise view of resource pools, new fields like `accelerator` and `warm slots` have been added.
 - Clicking on resource pool cards will lead to a detail page, which also includes a `Stats` tab showing average queued time by day. 

--- a/webui/react/src/utils/cluster.ts
+++ b/webui/react/src/utils/cluster.ts
@@ -5,6 +5,8 @@ export const getSlotContainerStates = (
   resourceType: ResourceType,
   resourcePoolName?: string,
 ): ResourceState[] => {
+  // agents of k8s clusters do not have resource pool name
+  // assume that k8s clusters only have 1 resource pool named 'kubernetes'
   const slotContainerStates = agents
     .filter(agent => resourcePoolName && resourcePoolName !== 'kubernetes' ?
       agent.resourcePool === resourcePoolName : true)

--- a/webui/react/src/utils/cluster.ts
+++ b/webui/react/src/utils/cluster.ts
@@ -6,7 +6,8 @@ export const getSlotContainerStates = (
   resourcePoolName?: string,
 ): ResourceState[] => {
   const slotContainerStates = agents
-    .filter(agent => resourcePoolName ? agent.resourcePool === resourcePoolName : true)
+    .filter(agent => resourcePoolName && resourcePoolName !== 'kubernetes' ?
+      agent.resourcePool === resourcePoolName : true)
     .map(agent => {
       return deviceTypes.has(resourceType)
         ? agent.resources.filter(res => res.type === resourceType)


### PR DESCRIPTION
## Description

Agents for K8s clusters do not have resource pool, and we assume that k8s clusters only have 1 resource pool named 'kubernetes'. 


## Test Plan

On k8s cluster, run tasks and verify slot allocation bar on resource pool card sync with overall slot allocation.


