### PR TITLE
docs: document using AWS Load Balancer on EKS [DET-6669]

### DIFF
--- a/docs/sysadmin-deploy-on-k8s/install-on-kubernetes.txt
+++ b/docs/sysadmin-deploy-on-k8s/install-on-kubernetes.txt
@@ -191,6 +191,8 @@ Determined itself is deployed. If this is undesirable, users can configure the H
 external Postgres database by setting ``db.hostAddress`` to the IP address of their database. If
 ``db.hostAddress`` is configured, the Determined Helm chart will not deploy a database.
 
+.. _tls-on-kubernetes:
+
 TLS (Optional)
 ==============
 
@@ -252,6 +254,9 @@ by default:
              backend:
                serviceName: determined-master-service-<name for your deployment>
                servicePort: masterPort configured in values.yaml
+
+To see information about using AWS Load Balancer instead of nginx visit :ref:`Using AWS Load
+Balancer <aws-lb>`.
 
 Default Scheduler (Optional)
 ============================

--- a/docs/sysadmin-deploy-on-k8s/setup-eks-cluster.txt
+++ b/docs/sysadmin-deploy-on-k8s/setup-eks-cluster.txt
@@ -328,6 +328,46 @@ the Helm chart to include S3, no keys or endpoint urls are needed. Additionally,
 tainted nodes, be sure to add pod tolerations to the experiment spec to ensure they will get
 scheduled.
 
+.. _aws-lb:
+
+************************************
+ Using AWS Load Balancer (optional)
+************************************
+
+It is possible to use `ALB <https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.4/>`_
+with the Determined EKS cluster instead of :ref:`nginx <tls-on-kubernetes>`. Determined expects the
+health check to be on ``/det/``, so the `config
+<https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.4/guide/ingress/annotations/#health-check>`_
+of ``alb.ingress.kubernetes.io/healthcheck-path`` must be set to ``/det/`` in the master ingress
+yaml. An example of a master ingress yaml is shown here:
+
+.. code:: yaml
+
+   apiVersion: extensions/v1beta1
+   kind: Ingress
+   metadata:
+     annotations:
+       alb.ingress.kubernetes.io/inbound-cidrs: 0.0.0.0/0
+       alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}]'
+       alb.ingress.kubernetes.io/scheme: internal
+       alb.ingress.kubernetes.io/healthcheck-path: "/det/"
+       kubernetes.io/ingress.class: alb
+     name: determined-master-ingress
+   spec:
+     rules:
+      - host: yourhost.com
+        http:
+         paths:
+         - backend:
+             serviceName: determined-master-service-determined
+             servicePort: 8080
+           path: /*
+           pathType: ImplementationSpecific
+
+In order for this ingress to work as expected the Helm parameter of ``useNodePortForMaster`` must be
+set to ``true`` and the AWS Load Balancer Controller must be `installed in the cluster
+<https://docs.aws.amazon.com/eks/latest/userguide/aws-load-balancer-controller.html>`_.
+
 #########################
  Managing an EKS Cluster
 #########################


### PR DESCRIPTION
## Description

Using AWS Load Balancer on EKS causes a failed health check due to it expecting ```/``` while we provide ```/det/```. This documents how to provide the fix.

## Test Plan

To reproduce the issue first create an EKS cluster.

Then install the AWS Load Balancer with these docs https://docs.aws.amazon.com/eks/latest/userguide/aws-load-balancer-controller.html

Then start determined through helm
```
helm install determined helm/charts/determined/ \
  --values helm/charts/determined/values.yaml \
  --set maxSlotsPerPod=1 \
  --set detVersion=0.18.0 \
  --set useNodePortForMaster=true
```

Then start an ingress for master (intentionally without the health check path)
```
apiVersion: extensions/v1beta1
kind: Ingress
metadata:
  annotations:
    alb.ingress.kubernetes.io/inbound-cidrs: 0.0.0.0/0
    alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}]'
    alb.ingress.kubernetes.io/scheme: internal
    alb.ingress.kubernetes.io/security-groups: <some_security_group>
    alb.ingress.kubernetes.io/tags: <some_tags>
    alb.ingress.kubernetes.io/target-group-attributes: deregistration_delay.timeout_seconds=5
    kubernetes.io/ingress.class: alb
  name: determined-master-ingress
  namespace: determined
spec:
  rules:
  - host: <name_of_host>
    http:
      paths:
      - backend:
          serviceName: determined-master-service-determined
          servicePort: 8080
        path: /*
        pathType: ImplementationSpecific
```

Finally in AWS Console go to ```EC2``` > ```Load Balancing``` > ```Target Groups``` and click on the created target group. You should see a failed health check on this page.

## Checklist

- [X] User-facing API changes need the "User-facing API Change" label.
- [X] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [X] Licenses should be included for new code which was copied and/or modified from any external code.

