### PR TITLE
chore: make core-api tutorial Windows-friendly

### DIFF
--- a/examples/tutorials/core_api/0_start.py
+++ b/examples/tutorials/core_api/0_start.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 """
 Let's pretend our goal is to increment an integer over and over.  It'll be fun.
 

--- a/examples/tutorials/core_api/0_start.yaml
+++ b/examples/tutorials/core_api/0_start.yaml
@@ -1,5 +1,5 @@
 name: core-api-stage-0
-entrypoint: ./0_start.py
+entrypoint: python3 0_start.py
 
 # Use the single-searcher to run just one instance of the training script
 searcher:

--- a/examples/tutorials/core_api/1_metrics.py
+++ b/examples/tutorials/core_api/1_metrics.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 """
 Stage 1: Let's create the core_context, and use it to start logging metrics.
 This is just a few lines of code, and we'll be able to see the results in the

--- a/examples/tutorials/core_api/1_metrics.yaml
+++ b/examples/tutorials/core_api/1_metrics.yaml
@@ -1,5 +1,5 @@
 name: core-api-stage-1
-entrypoint: ./1_metrics.py
+entrypoint: python3 1_metrics.py
 
 # Remaining configuration is unchanged since stage 0.
 

--- a/examples/tutorials/core_api/2_checkpoints.py
+++ b/examples/tutorials/core_api/2_checkpoints.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 """
 Stage 2: Let's add checkpointing and preemption support to our "training" code.  After this, we will
 be able to stop and restart training in two different ways: either by pausing and reactivating

--- a/examples/tutorials/core_api/2_checkpoints.yaml
+++ b/examples/tutorials/core_api/2_checkpoints.yaml
@@ -1,5 +1,5 @@
 name: core-api-stage-2
-entrypoint: ./2_checkpoints.py
+entrypoint: python3 2_checkpoints.py
 
 # Remaining configuration is unchanged since stage 0.
 

--- a/examples/tutorials/core_api/3_hpsearch.py
+++ b/examples/tutorials/core_api/3_hpsearch.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 """
 Stage 3: Let's add hyperparameter search to our model.
 """

--- a/examples/tutorials/core_api/3_hpsearch.yaml
+++ b/examples/tutorials/core_api/3_hpsearch.yaml
@@ -1,5 +1,5 @@
 name: core-api-stage-3
-entrypoint: ./3_hpsearch.py
+entrypoint: python3 3_hpsearch.py
 
 # NEW: configure a single "increment_by" hyperparameter
 hyperparameters:

--- a/examples/tutorials/core_api/4_distributed.py
+++ b/examples/tutorials/core_api/4_distributed.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 """
 Stage 4: Let's do all the same things, but across multiple workers.
 

--- a/examples/tutorials/core_api/4_distributed.yaml
+++ b/examples/tutorials/core_api/4_distributed.yaml
@@ -1,5 +1,5 @@
 name: core-api-stage-4
-entrypoint: ./4_distributed.py launcher
+entrypoint: python3 4_distributed.py launcher
 
 # NEW: configure multiple slots per trial.
 resources:


### PR DESCRIPTION
There are two problems which can arise with Windows clients:

- Windows doesn't have an executable bit, so ./script.py fails
- Windows uses \r\n line endings, which is not allowed in a shebang line

The easiest cross-platform solution is to set the entrypoints to
`python3 script.py` instead of `./script.py`, which solves both
problems.