### PR TITLE
fix: agent can now be control-C while connecting to master [DET-6287]

### DIFF
--- a/docs/release-notes/fix-cant-cancel-agent-master-con.txt
+++ b/docs/release-notes/fix-cant-cancel-agent-master-con.txt
@@ -1,0 +1,5 @@
+:orphan:
+
+**Bug Fixes**
+
+-  Agent: Fix being unable to use control-C to cancel the agent when it is connecting to master.


### PR DESCRIPTION
## Description

Previously the agent was unable to be canceled while connecting to master. This makes it so it can be.

## Test Plan

Run
```
./determined-agent --master-host 34.215.4.95 --master-port 8080
```

and verify control-C closes the agent

## Commentary (optional)

This fix won't cause the ```ctx.Self().Stop()``` to be called or the agent message to be printed. Not sure how important that is because the agent connection to master happens before the agent is initialized completely.  

## Checklist

- [X] User-facing API changes need the "User-facing API Change" label.
- [X] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [X] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
