### PR TITLE
chore: remove legacy code/docs for NCCL/Gloo port range config

### DIFF
--- a/docs/sysadmin-basics/cluster-config.txt
+++ b/docs/sysadmin-basics/cluster-config.txt
@@ -224,14 +224,6 @@ The master supports the following configuration settings:
       detection is not finding the appropriate interface, the ``dtrain_network_interface`` option
       can be used to set it explicitly (e.g., ``eth11``).
 
-   -  ``nccl_port_range``: The range of ports that NCCL is permitted to use during distributed
-      training. A valid port range is in the format of ``MIN:MAX``. By default, no restrictions are
-      placed on the NCCL port range.
-
-   -  ``gloo_port_range``: The range of ports that Gloo is permitted to use during distributed
-      training. A valid port range is in the format of ``MIN:MAX``. By default, no restrictions are
-      placed on the Gloo port range.
-
    -  ``cpu_pod_spec``: Defines the default pod spec which will be applied to all CPU-only tasks
       when running on Kubernetes. See :ref:`custom-pod-specs` for details.
 

--- a/docs/sysadmin-basics/network-requirements.txt
+++ b/docs/sysadmin-basics/network-requirements.txt
@@ -75,24 +75,19 @@ Determined agents need the following network access:
 
    -  Inbound and outbound TCP ports 1734 and 1750 are used for synchronization between trial
       containers.
-
    -  Inbound and outbound TCP port 12350 is used for internal SSH-based communication between trial
       containers.
-
-   -  Inbound and outbound TCP port 12355 is used for GLOO rendezvous between trial containers.
-
+   -  When using ``DeepSpeedTrial``, port 29500 is used by for rendezvous between trial containers.
+   -  When using ``PyTorchTrial`` with the "torch" distributed training backend, port 29400 is used
+      for rendezvous between trial containers
+   -  For all other distributed training modes, inbound and outbound TCP port 12355 is used for GLOO
+      rendezvous between trial containers.
    -  Inbound and outbound ephemeral TCP ports in the range 1024-65536 are used for communication
-      between trials via GLOO. This range is configured by the configuration parameter
-      ``task_container_defaults.gloo_port_range`` inside ``master.yaml`` as described in the
-      :ref:`cluster-configuration` guide.
-
+      between trials via GLOO.
    -  For every GPU on each agent machine, an inbound and outbound ephemeral TCP port in the range
-      1024-65536 is used for communication between trials via NCCL. This range is configured by the
-      configuration parameter ``task_container_defaults.nccl_port_range`` inside ``master.yaml`` as
-      described in the :ref:`cluster-configuration` guide.
-
+      1024-65536 is used for communication between trials via NCCL.
    -  Two additional ephemeral TCP ports in the range 1024-65536 are used for additional intra-trial
       communication between trial containers.
-
-   -  For Tensorboards, an inbound and outbound TCP port between 2600-2900 is used to connect the
-      master and the tensorboard container.
+   -  Each TensorBoard uses a port in the range 2600–2899
+   -  Each notebook uses a port in the range 2900–3199
+   -  Each shell uses a port in the range 3200–3599

--- a/docs/sysadmin-deploy-on-k8s/helm-config.txt
+++ b/docs/sysadmin-deploy-on-k8s/helm-config.txt
@@ -154,12 +154,6 @@ should be configured by editing the ``values.yaml`` and ``Chart.yaml`` files in 
       interface, the ``dtrainNetworkInterface`` option can be used to set it explicitly (e.g.,
       ``eth11``).
 
-   -  ``ncclPortRange``: The range of ports that nccl is permitted to use during distributed
-      training. A valid port range is in the format of ``MIN:MAX``.
-
-   -  ``glooPortRange``: The range of ports that gloo is permitted to use during distributed
-      training. A valid port range is in the format of ``MIN:MAX``.
-
    -  ``forcePullImage``: Defines the default policy for forcibly pulling images from the docker
       registry and bypassing the docker cache. If a pull policy is specified in the :ref:`experiment
       config <exp-environment-image>` this default is overriden. Please note that as of November

--- a/helm/charts/determined/templates/master-config.yaml
+++ b/helm/charts/determined/templates/master-config.yaml
@@ -93,12 +93,6 @@ data:
       {{- if .Values.taskContainerDefaults.dtrainNetworkInterface }}
       dtrain_network_interface: {{ .Values.taskContainerDefaults.dtrainNetworkInterface }}
       {{- end }}
-      {{- if .Values.taskContainerDefaults.ncclPortRange }}
-      nccl_port_range: {{ .Values.taskContainerDefaults.ncclPortRange }}
-      {{- end }}
-      {{- if .Values.taskContainerDefaults.glooPortRange }}
-      gloo_port_range: {{ .Values.taskContainerDefaults.glooPortRange }}
-      {{- end }}
       {{- if .Values.taskContainerDefaults.cpuPodSpec }}
       cpu_pod_spec: {{ .Values.taskContainerDefaults.cpuPodSpec | toJson }}
       {{- end }}

--- a/helm/charts/determined/values.yaml
+++ b/helm/charts/determined/values.yaml
@@ -132,14 +132,10 @@ masterMemRequest: 8Gi
 
 ## Configure the task container defaults. Tasks include trials, commands, TensorBoards, notebooks,
 ## and shells. For all task containers, shm_size_bytes and network_mode are configurable. For
-## trials, the network interface used by distributed (multi-machine) training and ports used by the
-## NCCL and GLOO libraries during distributed training are configurable. These default to
-## auto-discovery and random non-privileged ports, respectively.
+## trials, the network interface used by distributed (multi-machine) training is configurable.
 taskContainerDefaults:
   # networkMode: bridge
   # dtrainNetworkInterface: <network interface name>
-  # ncclPortRange: <MIN:MAX>
-  # glooPortRange: <MIN:MAX>
   # forcePullImage: <true or false>
 
   # Configure a default pod spec for all GPU tasks (experiments, notebooks, commands) and CPU tasks

--- a/master/packaging/master.yaml
+++ b/master/packaging/master.yaml
@@ -1,14 +1,10 @@
 ## Configure the task container defaults. Tasks include trials, commands, tensorboards and more.
 ## For all task containers, shm_size_bytes and network_mode are configurable. For trials, the
-## network interface used by distributed (multi-machine) training and ports used by the NCCL and
-## GLOO libraries during distributed training are configurable. These default to auto-discovery and
-## random non-privileged ports, respectively.
+## network interface used by distributed (multi-machine) training is configurable.
 #task_container_defaults:
 #  shm_size_bytes: 4294967296
 #  network_mode: bridge
 #  dtrain_network_interface: <network interface name>
-#  nccl_port_range: <MIN:MAX>
-#  gloo_port_range: <MIN:MAX>
 
 ## Resource manager configuration. Defaults to using the agent resource manager.
 #resource_manager:

--- a/master/pkg/tasks/task.go
+++ b/master/pkg/tasks/task.go
@@ -121,12 +121,6 @@ func (t TaskSpec) EnvVars() map[string]string {
 		"DET_USER_TOKEN":    t.UserSessionToken,
 		"DET_USER":          t.Owner.Username,
 	}
-	if t.TaskContainerDefaults.NCCLPortRange != "" {
-		e["NCCL_PORT_RANGE"] = t.TaskContainerDefaults.NCCLPortRange
-	}
-	if t.TaskContainerDefaults.NCCLPortRange != "" {
-		e["GLOO_PORT_RANGE"] = t.TaskContainerDefaults.NCCLPortRange
-	}
 
 	networkInterface := t.TaskContainerDefaults.DtrainNetworkInterface
 	if networkInterface != "" {


### PR DESCRIPTION
The port ranges used by NCCL and Gloo were previously configurable, but support
for this feature was removed quite a while ago. This commit removes the vestiges
of the previous feature, including docs and config parsing code. (We continue to
allow `nccl_port_range` and `gloo_port_range` to be specified in `master.yaml`
but those values are now ignored.)

## Description

<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At a minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions about this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ