### PR TITLE
feat: Deleting workspace/project moves its experiments [DET-7368]

### DIFF
--- a/harness/determined/cli/project.py
+++ b/harness/determined/cli/project.py
@@ -123,8 +123,8 @@ def describe_project(args: Namespace) -> None:
 @authentication.required
 def delete_project(args: Namespace) -> None:
     if args.yes or render.yes_or_no(
-        'Deleting project "' + args.project_name + '" will result in the \n'
-        "unrecoverable deletion of all associated experiments. For a recoverable \n"
+        'Deleting project "' + args.project_name + '" will delete all notes and move all \n'
+        "associated experiments to the Uncategorized workspace. For a less impactful \n"
         "alternative, see the 'archive' command. Do you still \n"
         "wish to proceed?"
     ):

--- a/harness/determined/cli/workspace.py
+++ b/harness/determined/cli/workspace.py
@@ -111,7 +111,8 @@ def describe_workspace(args: Namespace) -> None:
 def delete_workspace(args: Namespace) -> None:
     if args.yes or render.yes_or_no(
         'Deleting workspace "' + args.workspace_name + '" will result \n'
-        "in the unrecoverable deletion of all associated projects. For a \n"
+        "in the unrecoverable deletion of all associated projects and notes, and move \n"
+        "associated experiments into the Uncategorized workspace. For a \n"
         "recoverable alternative, see the 'archive' command. Do you still \n"
         "wish to proceed?"
     ):

--- a/master/static/srv/delete_project.sql
+++ b/master/static/srv/delete_project.sql
@@ -12,40 +12,9 @@ proj AS (
   )
 ),
 exper AS (
-  SELECT id FROM experiments
+  UPDATE experiments
+  SET project_id = 1
   WHERE project_id IN (SELECT id FROM proj)
-),
-o_trials AS (
-  SELECT id, task_id FROM trials
-  WHERE experiment_id IN (SELECT id FROM exper)
-),
-del_steps AS (
-  DELETE FROM raw_steps
-  WHERE trial_id IN (SELECT id FROM o_trials)
-),
-del_trials AS (
-  DELETE FROM trials
-  WHERE experiment_id IN (SELECT id FROM exper)
-),
-o_allocations AS (
-  SELECT allocation_id FROM allocations
-  WHERE task_id IN (SELECT task_id FROM o_trials)
-),
-del_task_stats AS (
-  DELETE FROM task_stats
-  WHERE allocation_id IN (SELECT allocation_id FROM o_allocations)
-),
-del_allocations AS (
-  DELETE FROM allocations
-  WHERE allocation_id IN (SELECT allocation_id FROM o_allocations)
-),
-del_tasks AS (
-  DELETE FROM tasks
-  WHERE task_id IN (SELECT task_id FROM o_trials)
-),
-del_exper AS (
-  DELETE FROM experiments
-  WHERE id IN (SELECT id FROM exper)
 )
 DELETE FROM projects
 WHERE id IN (SELECT id FROM proj)

--- a/master/static/srv/delete_workspace.sql
+++ b/master/static/srv/delete_workspace.sql
@@ -14,44 +14,9 @@ proj AS (
   WHERE workspace_id IN (SELECT id FROM w)
 ),
 exper AS (
-  SELECT id FROM experiments
+  UPDATE experiments
+  SET project_id = 1
   WHERE project_id IN (SELECT id FROM proj)
-),
-o_trials AS (
-  SELECT id, task_id FROM trials
-  WHERE experiment_id IN (SELECT id FROM exper)
-),
-del_steps AS (
-  DELETE FROM raw_steps
-  WHERE trial_id IN (SELECT id FROM o_trials)
-),
-del_trials AS (
-  DELETE FROM trials
-  WHERE experiment_id IN (SELECT id FROM exper)
-),
-o_allocations AS (
-  SELECT allocation_id FROM allocations
-  WHERE task_id IN (SELECT task_id FROM o_trials)
-),
-del_task_stats AS (
-  DELETE FROM task_stats
-  WHERE allocation_id IN (SELECT allocation_id FROM o_allocations)
-),
-del_allocations AS (
-  DELETE FROM allocations
-  WHERE allocation_id IN (SELECT allocation_id FROM o_allocations)
-),
-del_tasks AS (
-  DELETE FROM tasks
-  WHERE task_id IN (SELECT task_id FROM o_trials)
-),
-del_exper AS (
-  DELETE FROM experiments
-  WHERE id IN (SELECT id FROM exper)
-),
-del_proj AS (
-  DELETE FROM projects
-  WHERE id IN (SELECT id FROM proj)
 )
 DELETE FROM workspaces
 WHERE id IN (SELECT id FROM w)

--- a/webui/react/src/hooks/useModal/Project/useModalProjectDelete.tsx
+++ b/webui/react/src/hooks/useModal/Project/useModalProjectDelete.tsx
@@ -34,7 +34,7 @@ const useModalProjectDelete = ({ onClose, project }: Props): ModalHooks => {
     return (
       <div className={css.base}>
         <p>Are you sure you want to delete <strong>&quot;{project.name}&quot;</strong>?</p>
-        <p>All experiments within it will also be deleted. This cannot be undone.</p>
+        <p>All notes will be deleted, and experiments moved to the Uncategorized workspace. This cannot be undone.</p>
         <label className={css.label} htmlFor="name">Enter project name to confirm deletion</label>
         <Input id="name" value={name} onChange={handleNameInput} />
       </div>

--- a/webui/react/src/hooks/useModal/Project/useModalProjectDelete.tsx
+++ b/webui/react/src/hooks/useModal/Project/useModalProjectDelete.tsx
@@ -34,7 +34,8 @@ const useModalProjectDelete = ({ onClose, project }: Props): ModalHooks => {
     return (
       <div className={css.base}>
         <p>Are you sure you want to delete <strong>&quot;{project.name}&quot;</strong>?</p>
-        <p>All notes will be deleted, and experiments moved to the Uncategorized workspace. This cannot be undone.</p>
+        <p>All notes will be deleted, and experiments moved to the Uncategorized workspace. This
+          cannot be undone.</p>
         <label className={css.label} htmlFor="name">Enter project name to confirm deletion</label>
         <Input id="name" value={name} onChange={handleNameInput} />
       </div>

--- a/webui/react/src/hooks/useModal/Workspace/useModalWorkspaceDelete.tsx
+++ b/webui/react/src/hooks/useModal/Workspace/useModalWorkspaceDelete.tsx
@@ -34,7 +34,8 @@ const useModalWorkspaceDelete = ({ onClose, workspace }: Props): ModalHooks => {
     return (
       <div className={css.base}>
         <p>Are you sure you want to delete <strong>&quot;{workspace.name}&quot;</strong>?</p>
-        <p>All projects and notes within it will also be deleted, and all experiments moved to the Uncategorized workspace. This cannot be undone.</p>
+        <p>All projects and notes within it will also be deleted, and all experiments moved to
+          the Uncategorized workspace. This cannot be undone.</p>
         <label className={css.label} htmlFor="name">Enter workspace name to confirm deletion</label>
         <Input id="name" value={name} onChange={handleNameInput} />
       </div>

--- a/webui/react/src/hooks/useModal/Workspace/useModalWorkspaceDelete.tsx
+++ b/webui/react/src/hooks/useModal/Workspace/useModalWorkspaceDelete.tsx
@@ -34,7 +34,7 @@ const useModalWorkspaceDelete = ({ onClose, workspace }: Props): ModalHooks => {
     return (
       <div className={css.base}>
         <p>Are you sure you want to delete <strong>&quot;{workspace.name}&quot;</strong>?</p>
-        <p>All projects and experiments within it will also be deleted. This cannot be undone.</p>
+        <p>All projects and notes within it will also be deleted, and all experiments moved to the Uncategorized workspace. This cannot be undone.</p>
         <label className={css.label} htmlFor="name">Enter workspace name to confirm deletion</label>
         <Input id="name" value={name} onChange={handleNameInput} />
       </div>


### PR DESCRIPTION
## Description

After our discussion about when experiments can/can't be safely deleted and how that process is async / not easy to do en masse, when a project is deleted we're going to move its experiments back to the Uncategorized workspace.

This updates the language in the CLI and WebUI to inform users. Notes on a project get deleted, so I added that in.

## Checklist

- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.