### PR TITLE
ci: make managed devcluster tests run in parallel

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2122,7 +2122,7 @@ workflows:
           name: test-e2e-managed-devcluster
           requires:
             - build-go
-          parallelism: 1
+          parallelism: 4
           tf1: false
           tf2: true
           mark: managed_devcluster


### PR DESCRIPTION
## Description

These tests have been the longest part of PR E2E tests, so let's speed
them up.

## Test Plan

- [ ] see how long the CI takes
