### PR TITLE
fix: allow `internal: null` for pre-0.15.6 experiments

### DIFF
--- a/harness/determined/common/schemas/expconf/_gen.py
+++ b/harness/determined/common/schemas/expconf/_gen.py
@@ -1103,6 +1103,11 @@ schemas = {
             "default": {},
             "optionalRef": "http://determined.ai/schemas/expconf/v0/hyperparameters.json"
         },
+        "internal": {
+            "$comment": "allow forking pre-0.15.6 non-Native-API experiments",
+            "type": "null",
+            "default": null
+        },
         "labels": {
             "type": [
                 "array",

--- a/master/pkg/schemas/zgen_schemas.go
+++ b/master/pkg/schemas/zgen_schemas.go
@@ -1030,6 +1030,11 @@ var (
             "default": {},
             "optionalRef": "http://determined.ai/schemas/expconf/v0/hyperparameters.json"
         },
+        "internal": {
+            "$comment": "allow forking pre-0.15.6 non-Native-API experiments",
+            "type": "null",
+            "default": null
+        },
         "labels": {
             "type": [
                 "array",

--- a/schemas/expconf/v0/experiment.json
+++ b/schemas/expconf/v0/experiment.json
@@ -96,6 +96,11 @@
             "default": {},
             "optionalRef": "http://determined.ai/schemas/expconf/v0/hyperparameters.json"
         },
+        "internal": {
+            "$comment": "allow forking pre-0.15.6 non-Native-API experiments",
+            "type": "null",
+            "default": null
+        },
         "labels": {
             "type": [
                 "array",

--- a/schemas/test_cases/v0/experiment.yaml
+++ b/schemas/test_cases/v0/experiment.yaml
@@ -74,6 +74,8 @@
       categorical_hparam:
         type: categorical
         vals: [1, 2, 3, 4]
+    # pre-0.15.6 non-Native-API experiments emitted `internal: null` configs
+    internal: null
     labels: []
     max_restarts: 5
     min_validation_period:


### PR DESCRIPTION
The internal field was removed with 0.18.0, along with the Native API.
But before 0.15.6, the `internal` field did not have an `omitempty` tag,
so it was still being stored in the database as `null`.  This causes
forking and certain REST API endpoints to fail on older experiments.

## Test Plan

Find a pre-0.15.6 experiment on a test cluster and see if the webui is broken for it or not.