### PR TITLE
fix: reshow drop targets for customize columns modal

### DIFF
--- a/webui/react/src/components/DraggableListItem.module.scss
+++ b/webui/react/src/components/DraggableListItem.module.scss
@@ -1,6 +1,6 @@
 .aboveDropTarget {
-  border-top: solid 1px var(--theme-colors-action-normal);
+  border-top: solid 1px var(--theme-status-active);
 }
 .belowDropTarget {
-  border-bottom: solid 1px var(--theme-colors-action-normal);
+  border-bottom: solid 1px var(--theme-status-active);
 }


### PR DESCRIPTION
clobbered by theme arch