### PR TITLE
fix: use bigint for checkpoint size in `proto_get_trials_plus`

### DIFF
--- a/master/static/srv/proto_get_trials_plus.sql
+++ b/master/static/srv/proto_get_trials_plus.sql
@@ -176,7 +176,7 @@ SELECT
     WHERE a.task_id = t.task_id
   ) AS wall_clock_time,
   (
-    SELECT sum((jsonb_each).value::text::int)
+    SELECT sum((jsonb_each).value::text::bigint)
     FROM (
         SELECT jsonb_each(resources) FROM checkpoints_old_view c WHERE c.trial_id = t.id
         UNION ALL


### PR DESCRIPTION
## Description

Checkpoint size calculation was using `int` causing it to fail for checkpoints over 2 gigabytes. Transformers test `huggingface_squad_v2_with_beam_search` had 4 gig checkpoints.

[Example](https://gcloud2.determined.ai/det/experiments/1726/overview)

## Test Plan

Run `model_hub/examples/huggingface/question-answering/squad_v2_beam_search.yaml` with 200 batches and `--config resources.slots_per_trial=8 --config hyperparameters.global_batch_size=16`.

## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
