### PR TITLE
feat: add master-side verification for agent mTLS

### DIFF
--- a/agent/internal/options.go
+++ b/agent/internal/options.go
@@ -109,7 +109,7 @@ func (t TLSOptions) Validate() []error {
 // ReadClientCertificate returns the client certificate described by this configuration (nil if it
 // does not allow TLS to be enabled).
 func (t TLSOptions) ReadClientCertificate() (*tls.Certificate, error) {
-	if t.ClientCert != "" && t.ClientKey != "" {
+	if t.ClientCert == "" || t.ClientKey == "" {
 		return nil, nil
 	}
 	cert, err := tls.LoadX509KeyPair(t.ClientCert, t.ClientKey)

--- a/docs/sysadmin-basics/cluster-config.txt
+++ b/docs/sysadmin-basics/cluster-config.txt
@@ -339,6 +339,11 @@ The master supports the following configuration settings:
          compute resources, e.g. GPUs or dedicated CPUs. Defaults to ``default`` if no resource pool
          is specified.
 
+      -  ``require_authentication``: Whether to require that agent connections be verified using
+         mutual TLS.
+
+      -  ``client_ca``: Certificate authority file to use for verifying agent certificates.
+
    -  ``type: kubernetes``: The ``kubernetes`` resource manager launches tasks on a Kubernetes
       cluster. The Determined master must be running within the Kubernetes cluster. When using the
       ``kubernetes`` resource manager, we recommend deploying Determined using the :ref:`Determined
@@ -818,6 +823,9 @@ The master supports the following configuration settings:
             -  ``certificate``: Path to a file containing the cluster's TLS certificate. Only needed
                if the certificate is not signed by a well-known CA; cannot be specified if
                ``skip_verify`` is enabled.
+
+            -  ``client_cert``/``client_key``: Paths to files containing the client TLS certificate
+               and key to use when connecting to the master.
 
 -  ``scim``: (EE-only) Specifies whether the SCIM service is enabled and the credentials for clients
    to use it.

--- a/master/internal/config/resource_manager_config.go
+++ b/master/internal/config/resource_manager_config.go
@@ -57,6 +57,9 @@ type AgentResourceManagerConfig struct {
 	DefaultCPUResourcePool string `json:"default_cpu_resource_pool,omitempty"`
 	// Deprecated: use DefaultComputeResourcePool instead.
 	DefaultGPUResourcePool string `json:"default_gpu_resource_pool,omitempty"`
+
+	RequireAuthentication bool   `json:"require_authentication"`
+	ClientCA              string `json:"client_ca"`
 }
 
 // UnmarshalJSON implements the json.Unmarshaler interface.

--- a/master/internal/core.go
+++ b/master/internal/core.go
@@ -4,10 +4,12 @@ import (
 	"bufio"
 	"context"
 	"crypto/tls"
+	"crypto/x509"
 	"encoding/csv"
 	"encoding/json"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"net"
 	"net/http"
 	"net/http/pprof"
@@ -37,6 +39,7 @@ import (
 	"github.com/determined-ai/determined/master/internal/cluster"
 	"github.com/determined-ai/determined/master/internal/command"
 	"github.com/determined-ai/determined/master/internal/config"
+	"github.com/determined-ai/determined/master/internal/connsave"
 	detContext "github.com/determined-ai/determined/master/internal/context"
 	"github.com/determined-ai/determined/master/internal/db"
 	"github.com/determined-ai/determined/master/internal/elastic"
@@ -476,10 +479,32 @@ func (m *Master) startServers(ctx context.Context, cert *tls.Certificate) error 
 
 	// If configured, set up TLS wrapping.
 	if cert != nil {
+		var clientCAs *x509.CertPool
+		clientAuthMode := tls.NoClientCert
+
+		if agentRM := m.config.ResourceManager.AgentRM; agentRM != nil && agentRM.RequireAuthentication {
+			// Most connections don't require client certificates, but we do want to make sure that any that
+			// are provided are valid, so individual handlers that care can just check for the presence of
+			// certificates.
+			clientAuthMode = tls.VerifyClientCertIfGiven
+
+			if agentRM.ClientCA != "" {
+				clientCAs = x509.NewCertPool()
+				clientRootCA, iErr := ioutil.ReadFile(agentRM.ClientCA)
+				if iErr != nil {
+					return errors.Wrap(err, "failed to read agent CA file")
+				}
+				clientCAs.AppendCertsFromPEM(clientRootCA)
+			}
+		}
+
+		fmt.Println(clientAuthMode)
 		baseListener = tls.NewListener(baseListener, &tls.Config{
 			Certificates:             []tls.Certificate{*cert},
 			MinVersion:               tls.VersionTLS12,
 			PreferServerCipherSuites: true,
+			ClientCAs:                clientCAs,
+			ClientAuth:               clientAuthMode,
 		})
 	}
 
@@ -524,6 +549,7 @@ func (m *Master) startServers(ctx context.Context, cert *tls.Certificate) error 
 	start("HTTP server", func() error {
 		m.echo.Listener = httpListener
 		m.echo.HidePort = true
+		m.echo.Server.ConnContext = connsave.SaveConn
 		defer closeWithErrCheck("echo", m.echo)
 		return m.echo.StartServer(m.echo.Server)
 	})


### PR DESCRIPTION
## Description

<will add something here later, but don't feel like it at the moment>

## Test Plan

- [x] check that the master rejects unauthenticated agent WebSocket requests
