### PR TITLE
feat: Change workspace deletion - workspace must be empty to delete

### DIFF
--- a/harness/determined/cli/project.py
+++ b/harness/determined/cli/project.py
@@ -130,8 +130,8 @@ def describe_project(args: Namespace) -> None:
 @authentication.required
 def delete_project(args: Namespace) -> None:
     if args.yes or render.yes_or_no(
-        'Deleting project "' + args.project_name + '" will delete all notes and move all \n'
-        "associated experiments to the Uncategorized workspace. For a less impactful \n"
+        'Deleting project "' + args.project_name + '" will result in the \n'
+        "unrecoverable deletion of all associated experiments. For a recoverable \n"
         "alternative, see the 'archive' command. Do you still \n"
         "wish to proceed?"
     ):

--- a/harness/determined/cli/project.py
+++ b/harness/determined/cli/project.py
@@ -1,5 +1,6 @@
 import json
 from argparse import Namespace
+from time import sleep
 from typing import Any, Dict, List, Sequence, Tuple
 
 from determined.cli.session import setup_session
@@ -137,6 +138,35 @@ def delete_project(args: Namespace) -> None:
     ):
         sess = setup_session(args)
         (w, p) = project_by_name(sess, args.workspace_name, args.project_name)
+
+        current_user = authentication.must_cli_auth().get_session_user()
+        if current_user not in [w.username, p.username]:
+            raise Exception("Workspace and Project are owned by another user.")
+        if p.immutable:
+            raise Exception("Project is immutable and cannot be deleted.")
+
+        loops = 0
+        exps = bindings.get_GetProjectExperiments(sess, id=p.id, limit=100, offset=0).experiments
+        while len(exps) > 0:
+            pending_experiments: List[int] = []
+            for e in exps:
+                try:
+                    pending_experiments.append(e.id)
+                    bindings.delete_DeleteExperiment(sess, experimentId=e.id)
+                except:
+                    sleep(0.05)
+            sleep(1)
+            exps = bindings.get_GetProjectExperiments(
+                sess, id=p.id, limit=100, offset=0
+            ).experiments
+            loops += 1
+            if loops > 120:
+                print(pending_experiments)
+                raise Exception(
+                    "Failed to delete above experiment ids after two minutes. "
+                    + "An experiment may have failed to delete."
+                )
+
         bindings.delete_DeleteProject(sess, id=p.id)
         print(f"Successfully deleted project {args.project_name}.")
     else:

--- a/harness/determined/cli/project.py
+++ b/harness/determined/cli/project.py
@@ -133,7 +133,8 @@ def delete_project(args: Namespace) -> None:
     (w, p) = project_by_name(sess, args.workspace_name, args.project_name)
     if p.numExperiments > 0:
         raise Exception(
-            "Projects with associated experiments currently cannot be deleted. Use archive to hide projects."
+            "Projects with associated experiments currently cannot be deleted. "
+            "Use archive to hide projects."
         )
     if args.yes or render.yes_or_no(
         'Deleting project "' + args.project_name + '" will result in the \n'

--- a/harness/determined/cli/workspace.py
+++ b/harness/determined/cli/workspace.py
@@ -1,6 +1,5 @@
 import json
 from argparse import Namespace
-from time import sleep
 from typing import Any, List, Sequence
 
 from determined.cli.session import setup_session
@@ -127,50 +126,18 @@ def describe_workspace(args: Namespace) -> None:
 
 @authentication.required
 def delete_workspace(args: Namespace) -> None:
+    sess = setup_session(args)
+    w = workspace_by_name(sess, args.workspace_name)
+    if w.numExperiments > 0:
+        raise Exception(
+            "Workspaces with associated experiments currently cannot be deleted. Use archive to hide workspaces."
+        )
     if args.yes or render.yes_or_no(
         'Deleting workspace "' + args.workspace_name + '" will result \n'
-        "in the unrecoverable deletion of all associated projects and experiments. For a \n"
+        "in the unrecoverable deletion of all associated projects. For a \n"
         "recoverable alternative, see the 'archive' command. Do you still \n"
         "wish to proceed?"
     ):
-        sess = setup_session(args)
-        w = workspace_by_name(sess, args.workspace_name)
-
-        current_user = authentication.must_cli_auth().get_session_user()
-        if current_user != w.username:
-            raise Exception("Workspace is owned by another user.")
-        if w.immutable:
-            raise Exception("Workspace is immutable and cannot be deleted.")
-
-        projs = bindings.get_GetWorkspaceProjects(sess, id=w.id, limit=100, offset=0).projects
-        for p in projs:
-            loops = 0
-            print(f"Deletion in progress - deleting project {p.name} within workspace {w.name}.")
-            exps = bindings.get_GetProjectExperiments(
-                sess, id=p.id, limit=100, offset=0
-            ).experiments
-            while len(exps) > 0:
-                pending_experiments: List[int] = []
-                for e in exps:
-                    try:
-                        pending_experiments.append(e.id)
-                        bindings.delete_DeleteExperiment(sess, experimentId=e.id)
-                    except:
-                        sleep(0.05)
-                sleep(1)
-                exps = bindings.get_GetProjectExperiments(
-                    sess, id=p.id, limit=100, offset=0
-                ).experiments
-                loops += 1
-                if loops > 120:
-                    print(pending_experiments)
-                    raise Exception(
-                        "Failed to delete above experiment ids after two minutes. "
-                        + "An experiment may have failed to delete."
-                    )
-            bindings.delete_DeleteProject(sess, id=p.id)
-            print(f"Deletion in progress - deleted project {p.name} within workspace {w.name}.")
-
         bindings.delete_DeleteWorkspace(sess, id=w.id)
         print(f"Successfully deleted workspace {args.workspace_name}.")
     else:

--- a/harness/determined/cli/workspace.py
+++ b/harness/determined/cli/workspace.py
@@ -130,7 +130,8 @@ def delete_workspace(args: Namespace) -> None:
     w = workspace_by_name(sess, args.workspace_name)
     if w.numExperiments > 0:
         raise Exception(
-            "Workspaces with associated experiments currently cannot be deleted. Use archive to hide workspaces."
+            "Workspaces with associated experiments currently cannot be deleted. "
+            "Use archive to hide workspaces."
         )
     if args.yes or render.yes_or_no(
         'Deleting workspace "' + args.workspace_name + '" will result \n'

--- a/harness/determined/cli/workspace.py
+++ b/harness/determined/cli/workspace.py
@@ -128,8 +128,7 @@ def describe_workspace(args: Namespace) -> None:
 def delete_workspace(args: Namespace) -> None:
     if args.yes or render.yes_or_no(
         'Deleting workspace "' + args.workspace_name + '" will result \n'
-        "in the unrecoverable deletion of all associated projects and notes, and move \n"
-        "associated experiments into the Uncategorized workspace. For a \n"
+        "in the unrecoverable deletion of all associated projects. For a \n"
         "recoverable alternative, see the 'archive' command. Do you still \n"
         "wish to proceed?"
     ):

--- a/harness/determined/common/api/bindings.py
+++ b/harness/determined/common/api/bindings.py
@@ -5750,6 +5750,7 @@ class v1Workspace:
         id: int,
         immutable: bool,
         name: str,
+        numExperiments: int,
         numProjects: int,
         pinned: bool,
         userId: int,
@@ -5763,6 +5764,7 @@ class v1Workspace:
         self.numProjects = numProjects
         self.pinned = pinned
         self.userId = userId
+        self.numExperiments = numExperiments
 
     @classmethod
     def from_json(cls, obj: Json) -> "v1Workspace":
@@ -5775,6 +5777,7 @@ class v1Workspace:
             numProjects=obj["numProjects"],
             pinned=obj["pinned"],
             userId=obj["userId"],
+            numExperiments=obj["numExperiments"],
         )
 
     def to_json(self) -> typing.Any:
@@ -5787,6 +5790,7 @@ class v1Workspace:
             "numProjects": self.numProjects,
             "pinned": self.pinned,
             "userId": self.userId,
+            "numExperiments": self.numExperiments,
         }
 
 def post_AckAllocationPreemptionSignal(

--- a/master/static/migrations/20220422101847_pin-workspaces.up.sql
+++ b/master/static/migrations/20220422101847_pin-workspaces.up.sql
@@ -1,7 +1,7 @@
 CREATE TABLE workspace_pins (
   id SERIAL PRIMARY KEY,
-  workspace_id INT REFERENCES workspaces(id),
-  user_id INT REFERENCES users(id),
+  workspace_id INT REFERENCES workspaces(id) ON DELETE CASCADE,
+  user_id INT REFERENCES users(id) ON DELETE CASCADE,
   created_at TIMESTAMP with time zone NOT NULL DEFAULT NOW(),
   UNIQUE (user_id, workspace_id)
 );

--- a/master/static/srv/delete_project.sql
+++ b/master/static/srv/delete_project.sql
@@ -12,41 +12,11 @@ proj AS (
   )
 ),
 exper AS (
-  SELECT id FROM experiments
+  SELECT COUNT(*) AS count
+  FROM experiments
   WHERE project_id IN (SELECT id FROM proj)
-),
-o_trials AS (
-  SELECT id, task_id FROM trials
-  WHERE experiment_id IN (SELECT id FROM exper)
-),
-del_steps AS (
-  DELETE FROM raw_steps
-  WHERE trial_id IN (SELECT id FROM o_trials)
-),
-del_trials AS (
-  DELETE FROM trials
-  WHERE experiment_id IN (SELECT id FROM exper)
-),
-o_allocations AS (
-  SELECT allocation_id FROM allocations
-  WHERE task_id IN (SELECT task_id FROM o_trials)
-),
-del_task_stats AS (
-  DELETE FROM task_stats
-  WHERE allocation_id IN (SELECT allocation_id FROM o_allocations)
-),
-del_allocations AS (
-  DELETE FROM allocations
-  WHERE allocation_id IN (SELECT allocation_id FROM o_allocations)
-),
-del_tasks AS (
-  DELETE FROM tasks
-  WHERE task_id IN (SELECT task_id FROM o_trials)
-),
-del_exper AS (
-  DELETE FROM experiments
-  WHERE id IN (SELECT id FROM exper)
 )
 DELETE FROM projects
 WHERE id IN (SELECT id FROM proj)
+AND (SELECT count FROM exper) = 0
 RETURNING projects.id;

--- a/master/static/srv/delete_project.sql
+++ b/master/static/srv/delete_project.sql
@@ -12,9 +12,40 @@ proj AS (
   )
 ),
 exper AS (
-  UPDATE experiments
-  SET project_id = 1
+  SELECT id FROM experiments
   WHERE project_id IN (SELECT id FROM proj)
+),
+o_trials AS (
+  SELECT id, task_id FROM trials
+  WHERE experiment_id IN (SELECT id FROM exper)
+),
+del_steps AS (
+  DELETE FROM raw_steps
+  WHERE trial_id IN (SELECT id FROM o_trials)
+),
+del_trials AS (
+  DELETE FROM trials
+  WHERE experiment_id IN (SELECT id FROM exper)
+),
+o_allocations AS (
+  SELECT allocation_id FROM allocations
+  WHERE task_id IN (SELECT task_id FROM o_trials)
+),
+del_task_stats AS (
+  DELETE FROM task_stats
+  WHERE allocation_id IN (SELECT allocation_id FROM o_allocations)
+),
+del_allocations AS (
+  DELETE FROM allocations
+  WHERE allocation_id IN (SELECT allocation_id FROM o_allocations)
+),
+del_tasks AS (
+  DELETE FROM tasks
+  WHERE task_id IN (SELECT task_id FROM o_trials)
+),
+del_exper AS (
+  DELETE FROM experiments
+  WHERE id IN (SELECT id FROM exper)
 )
 DELETE FROM projects
 WHERE id IN (SELECT id FROM proj)

--- a/master/static/srv/delete_workspace.sql
+++ b/master/static/srv/delete_workspace.sql
@@ -5,54 +5,16 @@ WITH w AS (
   AND NOT immutable
   AND (user_id = $2 OR $3 IS TRUE)
 ),
-pins AS (
-  DELETE FROM workspace_pins
-  WHERE workspace_id IN (SELECT id FROM w)
-),
 proj AS (
   SELECT id FROM projects
   WHERE workspace_id IN (SELECT id FROM w)
 ),
 exper AS (
-  SELECT id FROM experiments
+  SELECT COUNT(*) AS count
+  FROM experiments
   WHERE project_id IN (SELECT id FROM proj)
-),
-o_trials AS (
-  SELECT id, task_id FROM trials
-  WHERE experiment_id IN (SELECT id FROM exper)
-),
-del_steps AS (
-  DELETE FROM raw_steps
-  WHERE trial_id IN (SELECT id FROM o_trials)
-),
-del_trials AS (
-  DELETE FROM trials
-  WHERE experiment_id IN (SELECT id FROM exper)
-),
-o_allocations AS (
-  SELECT allocation_id FROM allocations
-  WHERE task_id IN (SELECT task_id FROM o_trials)
-),
-del_task_stats AS (
-  DELETE FROM task_stats
-  WHERE allocation_id IN (SELECT allocation_id FROM o_allocations)
-),
-del_allocations AS (
-  DELETE FROM allocations
-  WHERE allocation_id IN (SELECT allocation_id FROM o_allocations)
-),
-del_tasks AS (
-  DELETE FROM tasks
-  WHERE task_id IN (SELECT task_id FROM o_trials)
-),
-del_exper AS (
-  DELETE FROM experiments
-  WHERE id IN (SELECT id FROM exper)
-),
-del_proj AS (
-  DELETE FROM projects
-  WHERE id IN (SELECT id FROM proj)
 )
 DELETE FROM workspaces
 WHERE id IN (SELECT id FROM w)
+AND (SELECT count FROM exper) = 0
 RETURNING id;

--- a/master/static/srv/delete_workspace.sql
+++ b/master/static/srv/delete_workspace.sql
@@ -14,9 +14,44 @@ proj AS (
   WHERE workspace_id IN (SELECT id FROM w)
 ),
 exper AS (
-  UPDATE experiments
-  SET project_id = 1
+  SELECT id FROM experiments
   WHERE project_id IN (SELECT id FROM proj)
+),
+o_trials AS (
+  SELECT id, task_id FROM trials
+  WHERE experiment_id IN (SELECT id FROM exper)
+),
+del_steps AS (
+  DELETE FROM raw_steps
+  WHERE trial_id IN (SELECT id FROM o_trials)
+),
+del_trials AS (
+  DELETE FROM trials
+  WHERE experiment_id IN (SELECT id FROM exper)
+),
+o_allocations AS (
+  SELECT allocation_id FROM allocations
+  WHERE task_id IN (SELECT task_id FROM o_trials)
+),
+del_task_stats AS (
+  DELETE FROM task_stats
+  WHERE allocation_id IN (SELECT allocation_id FROM o_allocations)
+),
+del_allocations AS (
+  DELETE FROM allocations
+  WHERE allocation_id IN (SELECT allocation_id FROM o_allocations)
+),
+del_tasks AS (
+  DELETE FROM tasks
+  WHERE task_id IN (SELECT task_id FROM o_trials)
+),
+del_exper AS (
+  DELETE FROM experiments
+  WHERE id IN (SELECT id FROM exper)
+),
+del_proj AS (
+  DELETE FROM projects
+  WHERE id IN (SELECT id FROM proj)
 )
 DELETE FROM workspaces
 WHERE id IN (SELECT id FROM w)

--- a/master/static/srv/delete_workspace.sql
+++ b/master/static/srv/delete_workspace.sql
@@ -13,6 +13,11 @@ exper AS (
   SELECT COUNT(*) AS count
   FROM experiments
   WHERE project_id IN (SELECT id FROM proj)
+),
+del_p AS (
+  DELETE FROM projects
+  WHERE id IN (SELECT id FROM proj)
+  AND (SELECT count FROM exper) = 0
 )
 DELETE FROM workspaces
 WHERE id IN (SELECT id FROM w)

--- a/master/static/srv/get_workspace.sql
+++ b/master/static/srv/get_workspace.sql
@@ -1,5 +1,14 @@
+WITH p AS (
+  SELECT id FROM projects
+  WHERE workspace_id = $1
+),
+exp_count AS (
+  SELECT COUNT(*) AS count FROM experiments
+  WHERE project_id IN (SELECT id FROM p)
+)
 SELECT w.id, w.name, w.archived, w.immutable, u.username, w.user_id,
-  (SELECT COUNT(*) FROM projects WHERE workspace_id = $1) AS num_projects,
+  (SELECT COUNT(*) FROM p) AS num_projects,
+  (SELECT count FROM exp_count) AS num_experiments,
   (SELECT COUNT(*) > 0 FROM workspace_pins
     WHERE workspace_id = $1 AND user_id = $2
   ) AS pinned

--- a/master/static/srv/get_workspaces.sql
+++ b/master/static/srv/get_workspaces.sql
@@ -1,18 +1,23 @@
-WITH wp AS (
+WITH pins AS (
   SELECT id, workspace_id, created_at
   FROM workspace_pins
   WHERE user_id = $5
+),
+exp_count_by_project AS (
+  SELECT COUNT(*) AS count, project_id FROM experiments
+  GROUP BY project_id
 )
 SELECT w.id, w.name, w.archived, w.immutable, u.username, w.user_id,
-(wp.id IS NOT NULL) AS pinned,
-(SELECT COUNT(*) FROM projects WHERE workspace_id = w.id) AS num_projects
-
+(pins.id IS NOT NULL) AS pinned,
+(SELECT COUNT(*) FROM projects WHERE workspace_id = w.id) AS num_projects,
+(SELECT SUM(count) FROM exp_count_by_project WHERE project_id IN
+  (SELECT id FROM projects WHERE workspace_id = w.id)) AS num_experiments
 FROM workspaces as w
 LEFT JOIN users as u ON u.id = w.user_id
-LEFT JOIN wp ON wp.workspace_id = w.id
+LEFT JOIN pins ON pins.workspace_id = w.id
 
 WHERE ($1 = '' OR (u.username IN (SELECT unnest(string_to_array($1, ',')))))
 AND ($2 = '' OR w.name ILIKE $2)
 AND ($3 = '' OR w.archived = $3::BOOL)
-AND ($4 = '' OR (wp.id IS NOT NULL) = $4::BOOL)
-ORDER BY %s, wp.created_at DESC;
+AND ($4 = '' OR (pins.id IS NOT NULL) = $4::BOOL)
+ORDER BY %s, pins.created_at DESC;

--- a/master/static/srv/update_workspace.sql
+++ b/master/static/srv/update_workspace.sql
@@ -14,6 +14,8 @@ p AS (
 )
 SELECT w.id, w.name, w.archived, w.immutable,
   u.username, w.user_id, p.num_projects,
+  (SELECT COUNT(*) FROM experiments WHERE project_id IN (SELECT id FROM p))
+    AS num_experiments,
   (SELECT COUNT(*) > 0 FROM workspace_pins
     WHERE workspace_id = $1 AND user_id = $3
   ) AS pinned

--- a/proto/src/determined/workspace/v1/workspace.proto
+++ b/proto/src/determined/workspace/v1/workspace.proto
@@ -15,6 +15,7 @@ message Workspace {
         "id",
         "immutable",
         "name",
+        "num_experiments",
         "num_projects",
         "pinned",
         "username",
@@ -40,6 +41,8 @@ message Workspace {
   bool pinned = 7;
   // ID of the user who created this project.
   int32 user_id = 8;
+  // Number of experiments associated with this workspace.
+  int32 num_experiments = 9;
 }
 
 // PatchWorkspace is a partial update to a workspace with all optional fields.

--- a/webui/react/src/hooks/useModal/Project/useModalProjectDelete.tsx
+++ b/webui/react/src/hooks/useModal/Project/useModalProjectDelete.tsx
@@ -34,9 +34,7 @@ const useModalProjectDelete = ({ onClose, project }: Props): ModalHooks => {
     return (
       <div className={css.base}>
         <p>Are you sure you want to delete <strong>&quot;{project.name}&quot;</strong>?</p>
-        <p>All notes will be deleted, and experiments moved to the Uncategorized workspace. This
-          cannot be undone.
-        </p>
+        <p>All notes within it will also be deleted. This cannot be undone.</p>
         <label className={css.label} htmlFor="name">Enter project name to confirm deletion</label>
         <Input id="name" value={name} onChange={handleNameInput} />
       </div>

--- a/webui/react/src/hooks/useModal/Workspace/useModalWorkspaceDelete.tsx
+++ b/webui/react/src/hooks/useModal/Workspace/useModalWorkspaceDelete.tsx
@@ -34,9 +34,7 @@ const useModalWorkspaceDelete = ({ onClose, workspace }: Props): ModalHooks => {
     return (
       <div className={css.base}>
         <p>Are you sure you want to delete <strong>&quot;{workspace.name}&quot;</strong>?</p>
-        <p>All projects and notes within it will also be deleted, and all experiments moved to
-          the Uncategorized workspace. This cannot be undone.
-        </p>
+        <p>All projects and notes within it will also be deleted. This cannot be undone.</p>
         <label className={css.label} htmlFor="name">Enter workspace name to confirm deletion</label>
         <Input id="name" value={name} onChange={handleNameInput} />
       </div>

--- a/webui/react/src/pages/WorkspaceDetails/ProjectActionDropdown.tsx
+++ b/webui/react/src/pages/WorkspaceDetails/ProjectActionDropdown.tsx
@@ -86,7 +86,7 @@ const ProjectActionDropdown: React.FC<Props> = (
           {project.archived ? 'Unarchive' : 'Archive'}
         </Menu.Item>));
     }
-    if (userHasPermissions && !project.archived) {
+    if (userHasPermissions && !project.archived && project.numExperiments === 0) {
       items.push(<Menu.Item danger key="delete" onClick={handleDeleteClick}>Delete...</Menu.Item>);
     }
     return items;
@@ -95,6 +95,7 @@ const ProjectActionDropdown: React.FC<Props> = (
     handleEditClick,
     handleMoveClick,
     project.archived,
+    project.numExperiments,
     userHasPermissions,
     workspaceArchived ]);
 

--- a/webui/react/src/pages/WorkspaceList/WorkspaceActionDropdown.tsx
+++ b/webui/react/src/pages/WorkspaceList/WorkspaceActionDropdown.tsx
@@ -106,7 +106,7 @@ const WorkspaceActionDropdown: React.FC<Props> = (
             {workspace.archived ? 'Unarchive' : 'Archive'}
           </Menu.Item>
         )}
-        {(userHasPermissions) && (
+        {(userHasPermissions && workspace.numExperiments === 0) && (
           <>
             <Menu.Divider />
             <Menu.Item danger key="delete" onClick={handleDeleteClick}>Delete...</Menu.Item>
@@ -117,6 +117,7 @@ const WorkspaceActionDropdown: React.FC<Props> = (
   }, [ handlePinClick,
     workspace.pinned,
     workspace.archived,
+    workspace.numExperiments,
     userHasPermissions,
     handleEditClick,
     handleArchiveClick,

--- a/webui/react/src/services/api-ts-sdk/api.ts
+++ b/webui/react/src/services/api-ts-sdk/api.ts
@@ -6719,6 +6719,12 @@ export interface V1Workspace {
      * @memberof V1Workspace
      */
     userId: number;
+    /**
+     * Number of experiments associated with this workspace.
+     * @type {number}
+     * @memberof V1Workspace
+     */
+    numExperiments: number;
 }
 
 

--- a/webui/react/src/services/decoder.ts
+++ b/webui/react/src/services/decoder.ts
@@ -622,6 +622,7 @@ export const mapV1Workspace = (data: Sdk.V1Workspace): types.Workspace => {
     id: data.id,
     immutable: data.immutable,
     name: data.name,
+    numExperiments: data.numExperiments,
     numProjects: data.numProjects,
     pinned: data.pinned,
     username: data.username,

--- a/webui/react/src/types.ts
+++ b/webui/react/src/types.ts
@@ -697,6 +697,7 @@ export interface Workspace {
   id: number;
   immutable: boolean;
   name: string;
+  numExperiments: number;
   numProjects: number;
   pinned: boolean;
   username: string;


### PR DESCRIPTION
## Description

Hoping to discuss this later today - this PR adds to workspaces branch a new plan for deleting workspaces and projects.

- Remove previous deletion / movement commit
- Block deletion (server-side, in SQL) of workspaces and projects with associated experiments
- Add a numExperiments item to Workspace API endpoints (similar to Project.numExperiments)
- Only show "Delete" in WebUI when Workspace/Project have no Experiments
- The CLI deletes Workspaces/Projects by looping through associated experiments and attempting to delete for 2 minutes per project.

## Test plan

CLI testing:

det w create apple
det p create apple orange
(empty workspace and project show deletion option in WebUI)
det e list
(pick an experiment id in COMPLETED state for success, trapped in DELETING stage to see errors)
det e move 220 apple orange
det p list-experiments apple orange
(no longer see deletion option for apple workspace or orange project in WebUI)
det w delete apple

If an experiment fails to delete after two minutes, CLI raises an exception and prints relevant experiment IDs.

## Checklist

- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.