### PR TITLE
fix: det shell start/open, in windows

### DIFF
--- a/harness/determined/cli/cli.py
+++ b/harness/determined/cli/cli.py
@@ -1,4 +1,5 @@
 import hashlib
+import os
 import socket
 import ssl
 import sys
@@ -161,6 +162,10 @@ def make_parser() -> ArgumentParser:
 def main(
     args: List[str] = sys.argv[1:],
 ) -> None:
+    if sys.platform == "win32":
+        # Magic incantation to make a Windows 10 cmd.exe process color-related ANSI escape codes.
+        os.system("")
+
     # TODO: we lazily import "det deploy" but in the future we'd want to lazily import everything.
     parser = make_parser()
 


### PR DESCRIPTION
tempfile.NamedTemporaryFile does not do what you think it does, at least
not in Windows.  Use mkstemp directly instead.

Also, fix the color-related ANSI escape codes so there's not a bunch of
raw escape codes when using det in cmd.exe.

## Test Plan

Run `det shell start` in windows, see if it works and if the colors look right.