### PR TITLE
ci: add check to prevent ssh git url

### DIFF
--- a/webui/react/Makefile
+++ b/webui/react/Makefile
@@ -45,8 +45,11 @@ check-js:
 .PHONY: check-css
 check-css:
 	npm run lint:css
+.PHONY: check-package-lock
+check-package-lock:
+	if grep 'ssh://' package-lock.json ; then echo "ssh url in package-lock.json, please convert to https url" ; false ; fi
 .PHONY: check
-check: check-js check-css
+check: check-js check-css check-package-lock
 
 .PHONY: fmt-js
 fmt-js:
@@ -54,8 +57,11 @@ fmt-js:
 .PHONY: fmt-css
 fmt-css:
 	npm run lint:css -- --fix
+.PHONY: fmt-package-lock
+fmt-package-lock:
+	sed -i -e 's|git+ssh://git@github.com|https://github.com|' package-lock.json
 .PHONY: fmt
-fmt: fmt-js fmt-css
+fmt: fmt-js fmt-css fmt-package-lock
 
 .PHONY: test
 test:

--- a/webui/react/package-lock.json
+++ b/webui/react/package-lock.json
@@ -23937,7 +23937,7 @@
     },
     "node_modules/omnibar": {
       "version": "2.3.5",
-      "resolved": "git+ssh://git@github.com/hamidzr/omnibar.git",
+      "resolved": "https://github.com/hamidzr/omnibar.git",
       "integrity": "sha512-tjds/yG6geUTn1lE9fjWmISCt7a8IzrOwNl7hmAcv020fcuyhCbstXoVzUCWX337MqFj/1wzS1oYNeNh/myjfg==",
       "license": "MIT",
       "peerDependencies": {
@@ -54546,7 +54546,7 @@
       "dev": true
     },
     "omnibar": {
-      "version": "git+ssh://git@github.com/hamidzr/omnibar.git",
+      "version": "https://github.com/hamidzr/omnibar.git",
       "integrity": "sha512-tjds/yG6geUTn1lE9fjWmISCt7a8IzrOwNl7hmAcv020fcuyhCbstXoVzUCWX337MqFj/1wzS1oYNeNh/myjfg==",
       "from": "omnibar@github:hamidzr/omnibar"
     },


### PR DESCRIPTION
Something keeps setting up hamidzr/omnibar as an ssh url instead of an
https url.  Fix it, add a lint checker, and a fmt fixer.