### PR TITLE
chore: add dev server support for embedded tasks view

### DIFF
--- a/webui/react/Makefile
+++ b/webui/react/Makefile
@@ -37,7 +37,7 @@ clean:
 
 .PHONY: live
 live:
-	SERVER_ADDRESS=http://localhost:8080 npm start
+	npm start
 
 .PHONY: check-js
 check-js:

--- a/webui/react/craco.config.js
+++ b/webui/react/craco.config.js
@@ -23,6 +23,18 @@ module.exports = {
       ],
     ],
   },
+  devServer: {
+    proxy:
+    /**
+     * ideally, we could proxy all {serverAddress}:3000/{api|proxy}
+     * to {serverAddress}:8080{api|proxy}. devServer only intercepts
+     * requests to the server itself though
+     */
+    {
+      '/api': { target: 'http://localhost:8080' },
+      '/proxy': { target: 'http://localhost:8080' },
+    },
+  },
   eslint: { enable: false },
   plugins: [
     {


### PR DESCRIPTION
## Description

causes the webpack dev server "`make live`" to proxy requests from `localhost:3000/api` to `localhost:8080/proxy` and from `localhost:3000/proxy` to `localhost:8080/proxy`. this allows the jupyter view to be embedded since it is considered to have the same source, getting around:

```Refused to frame 'http://localhost:8080/' because an ancestor violates the following Content Security Policy directive: "frame-ancestors 'self'".```

we no longer need `SERVER_ADDRESS=http://localhost:8080` in the Makefile, because we are proxying there by default.

in order for it to work you need to `dev.resetServerAddress`. proxy is not compatible, so it only works against local `devcluster`.


## Test Plan

dogfood

If you want to do against external cluster, change `localhost:8080` to desired `cluster:port` AND do `dev.resetServerAddress()` 

## Considerations

It would be possible to take `DET_MASTER` and proxy to that. I decided against this to minimize possible confusion about the interactions between `DET_MASTER` and `dev.setServerAddress` in the webui. `DET_MASTER` is not currently being used in the webui at all.

## Alternatives

I also fiddled around with `scripts/proxy.js` to try get it to proxy `/proxy` and strip CSP headers, but not luck. (in theory we could kick off `proxy.js` and set the proxy server as the server address as a part of make live, but with that approach, you would have to restart to change backend server --- not ideal)

it could also be possible to do something where you do something with local [DNS alias](https://stackoverflow.com/a/31252683/9778768), but there could be the problem of collision between local server and `DET_MASTER`, I did not explore this approach.


