### PR TITLE
perf: avoid Seq Scanning raw steps

### DIFF
--- a/master/static/migrations/20220528215116_reindex-raw-steps.tx.down.sql
+++ b/master/static/migrations/20220528215116_reindex-raw-steps.tx.down.sql
@@ -1,0 +1,4 @@
+DROP INDEX steps_trial_id_total_batches_run_id_unique;
+DROP INDEX steps_archived;
+ALTER TABLE raw_steps ADD CONSTRAINT steps_trial_id_run_id_total_batches_unique UNIQUE (trial_id, trial_run_id, total_batches);
+

--- a/master/static/migrations/20220528215116_reindex-raw-steps.tx.up.sql
+++ b/master/static/migrations/20220528215116_reindex-raw-steps.tx.up.sql
@@ -1,0 +1,13 @@
+-- all we really need
+CREATE INDEX steps_archived ON raw_steps(archived);
+
+
+ALTER TABLE raw_steps DROP CONSTRAINT steps_trial_id_run_id_total_batches_unique;
+
+-- not needed, but presumably better? no performance sensitive queries
+-- check based on trian_run_id, so better to put it after?
+CREATE UNIQUE INDEX steps_trial_id_total_batches_run_id_unique ON raw_steps(trial_id, total_batches, trial_run_id);
+
+
+-- not needed for existing queries to be performant, but maybe worth it?
+-- CREATE UNIQUE INDEX steps_end_time ON raw_steps(end_time);


### PR DESCRIPTION
## Description

#### note: these migrations are currently in effect on latest-master (er at least until the next commit?), but can easily be rolled back

There have been many issues in latest-master recently for queries that involve `raw_steps` taking 30+ seconds due to Seq Scans. Might or might not have to do with a certain someone launching a bunch experiments to generate a tons of data to test their graphs. In any case it is a good thing to address. [DET-7473]

Among the offenders:
- [proto_get_trials_plus](https://determinedai.atlassian.net/browse/DET-7352): this one was resolved by [4206](https://github.com/determined-ai/determined/pull/4206), but included here for context
- [metric_names](https://determined-ai.slack.com/archives/CT01QS70Q/p1652736744444729)
- [get_model_versions](https://determined-ai.slack.com/archives/CKQ3EV0G6/p1653595557956529)

common theme is query planner not using index on `raw_steps`

`raw_steps` has index  `(trial_id, trial_run_id, total_batches)`, so planner is discouraged from using it for lookup on  (`trial_id`, `total_batches`). `trial_run_id` is never used in lookup without `total_batches`, so better off reordering them.

#### (EDIT: it looks like just putting an index on `raw_steps(archived)` solves all our problems.. still think reordering the index to `(trial_id, total_batches, trial_run_id)` makes sense though.


## Test Plan 

test against latest-master (migrations are currently in effect). then run migrations down, and notice a performance degradation. then run them up and see things improve.

can use [cloudwatch `auto_explain` logs](https://determined-ai.slack.com/archives/C03HCRJV4LB) to verify as well

- A: Sample Bad Queries: [raw-steps-index-tests.zip](https://github.com/determined-ai/determined/files/8792926/raw-steps-index-tests.zip) 
  - this contains the problem queries, including a version of proto_get_trials from before the perf fix.


- B: web facing 
  - visit a bunch of pages on latest master, particularly `/det/experiments/212/visualization/learning-curve` and `/det/models/74`. Log hopefully doesnt have anything for the `metric_names` or `model_versions`
  - execute migration down, then do the same. probably you will see some come in.


## Commentary

#### here is the planner not using index on total_batches/trial_id

```
get_model_versions
________________________________________________


{
  "Hash Cond": "((s.total_batches = ((c_1.metadata ->> 'steps_completed'::text))::integer) AND (s.trial_id = t.id))",
  "Plans": [
    {
      "Node Type": "Seq Scan",
      "Parent Relationship": "Outer",
      "Parallel Aware": false,
      "Relation Name": "raw_steps",
      "Schema": "public",
      "Alias": "s",
      "Startup Cost": 0,
      "Total Cost": 1197184.22,
      "Plan Rows": 719522,
      "Plan Width": 825,
      "Actual Startup Time": 0.033,
      "Actual Total Time": 51451.589,
      "Actual Rows": 720038,
      "Actual Loops": 1,
      "Output": ["s.metrics", "s.total_batches", "s.trial_id", "s.archived"]
    }
```

#### here's get_trials_proto 

(This issue was resolved by [4206](https://github.com/determined-ai/determined/pull/4206), but as an additional check, I have tested these changes against the query as it was before that PR, and it also resolves the issue)

```
proto_get_trials_plus
________________________________________________

{
  "Hash Cond": "(raw_steps.trial_id = searcher_info_5.trial_id)",
  "Plans": [
    {
      "Node Type": "Seq Scan",
      "Parent Relationship": "Outer",
      "Parallel Aware": false,
      "Relation Name": "raw_steps",
      "Schema": "public",
      "Alias": "raw_steps",
      "Startup Cost": 0,
      "Total Cost": 1198989.48,
      "Plan Rows": 105423,
      "Plan Width": 836,
      "Actual Startup Time": 0.034,
      "Actual Total Time": 32874.275,
      "Actual Rows": 109158,
      "Actual Loops": 1,
      "Output": [
        "raw_steps.trial_id",
        "raw_steps.state",
        "raw_steps.end_time",
        "raw_steps.metrics",
        "raw_steps.total_batches"
      ],
      "Filter": "((NOT raw_steps.archived) AND (raw_steps.state = 'COMPLETED'::step_state))",
      "Rows Removed by Filter": 610880
    }
  ]
}
```


#### also:

```  
metric_names
________________________________________________

"Plans": [
    {
      "Node Type": "Seq Scan",
      "Parent Relationship": "Outer",
      "Parallel Aware": true,
      "Relation Name": "raw_steps",
      "Schema": "public",
      "Alias": "raw_steps",
      "Startup Cost": 0,
      "Total Cost": 1193736.51,
      "Plan Rows": 43890,
      "Plan Width": 828,
      "Actual Startup Time": 1.993,
      "Actual Total Time": 25640.219,
      "Actual Rows": 36386,
      "Actual Loops": 3,
      "Output": ["raw_steps.metrics", "raw_steps.end_time", "raw_steps.trial_id"],
      "Filter": "((NOT raw_steps.archived) AND (raw_steps.end_time > '0001-01-01 00:00:00+00'::timestamp with time zone))",
      "Rows Removed by Filter": 203627,
      "Workers": [
        {
          "Worker Number": 0,
          "Actual Startup Time": 2.636,
          "Actual Total Time": 25730.598,
          "Actual Rows": 33847,
          "Actual Loops": 1
        },
        {
          "Worker Number": 1,
          "Actual Startup Time": 3.335,
          "Actual Total Time": 25627.992,
          "Actual Rows": 40980,
          "Actual Loops": 1
        }
      ]
    }
```


________________________________________________


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-4743]: https://determinedai.atlassian.net/browse/DET-4743?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[DET-7473]: https://determinedai.atlassian.net/browse/DET-7473?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ