### PR TITLE
ci: Lints migrations to ensure new migrations have higher timestamps than old ones [DET-7146]

### DIFF
--- a/.github/scripts/lint-migrations.sh
+++ b/.github/scripts/lint-migrations.sh
@@ -1,0 +1,24 @@
+# Get added files migration files.
+ADDED_MIGRATIONS=$(git diff --name-only --diff-filter=A $GITHUB_BASE_REF $GITHUB_HEAD_REF -- master/static/migrations/*.sql) 
+if [ ! -z "$ADDED_MIGRATIONS" ]; then
+    ADDED_MIGRATIONS=$(echo $ADDED_MIGRATIONS | xargs -n1 basename)
+    for val in $ADDED_MIGRATIONS; do # Validate the filenames.
+        REGEX="^[0-9]{14}[a-zA-Z_-]+\.tx\.(up|down)\.sql$"
+        [[ $val =~ $REGEX ]] ||
+            (EXIT=true && echo "migration $val is not in a valid format (does not pass $REGEX)")
+    done
+    [ -v $EXIT ] && exit 1;    
+    
+    # Get highest timestamp of migrations from branch you are trying to merge into.
+    git checkout $GITHUB_BASE_REF
+    HIGHEST_BEFORE=$(find ./master/static/migrations/*.sql -printf "%f\n" | sort -n -t _ -k 1 -s | tail -1)
+    git checkout $GITHUB_HEAD_REF
+
+    # Check that the highest timestamp from before is lower than every added timestamp.
+    HIGHEST=$(echo $ADDED_MIGRATIONS $HIGHEST_BEFORE | xargs -n1 | sort -n -t _ -k 1 -s | head -1)
+    if [ "$HIGHEST_BEFORE" != "$HIGHEST" ]; then
+        echo "Migration $HIGHEST has a timestamp smaller than a previously existing one $HIGHEST_BEFORE"
+        echo "Please run migration-move-to-top.sh on the migrations if this is not intentional"
+        exit 1
+    fi
+fi

--- a/.github/workflows/lint-migrations.yml
+++ b/.github/workflows/lint-migrations.yml
@@ -1,0 +1,15 @@
+name: "Lint migrations"
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+jobs:
+  lint-migrations:
+    steps:
+      - name: Run migration lint
+        run: ./.github/scripts/lint-migrations.sh
+        shell: bash


### PR DESCRIPTION
## Description

<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At a minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions about this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
