### PR TITLE
feat: det deploy now can use --yes to skip prompts [DET-7408]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -517,7 +517,7 @@ commands:
               --compute-agent-instance-type <<parameters.compute-agent-instance-type>> \
               --max-dynamic-agents <<parameters.max-dynamic-agents>> \
               --keypair <<parameters.keypair>> \
-              --no-prompt
+              --yes
 
   terminate-aws-cluster:
     parameters:
@@ -529,7 +529,7 @@ commands:
           when: always
           command: |
             det deploy aws down \
-              --cluster-id <<parameters.cluster-id>> --no-prompt
+              --cluster-id <<parameters.cluster-id>> --yes
 
   setup-aws-cluster:
     parameters:

--- a/docs/release-notes/det-deploy-no-prompt-yes.txt
+++ b/docs/release-notes/det-deploy-no-prompt-yes.txt
@@ -1,0 +1,6 @@
+:orphan:
+
+**Improvements**
+
+-  CLI: ``det deploy aws up``, ``det deploy aws down``, and ``det deploy gcp down`` now take
+   ``--yes`` to skip prompts asking for confirmation. ``--no-prompt`` is still usable.

--- a/harness/determined/deploy/aws/cli.py
+++ b/harness/determined/deploy/aws/cli.py
@@ -298,6 +298,11 @@ args_description = Cmd(
                 Arg(
                     "--no-prompt",
                     action="store_true",
+                    help=argparse.SUPPRESS,
+                ),
+                Arg(
+                    "--yes",
+                    action="store_true",
                     help="no prompt when deleting resources",
                 ),
             ],
@@ -485,9 +490,14 @@ args_description = Cmd(
                     "able to connect to the FSx instance.",
                 ),
                 Arg(
-                    "--no-prompt",
+                    "--yes",
                     action="store_true",
                     help="no prompt when deployment would delete existing database",
+                ),
+                Arg(
+                    "--no-prompt",
+                    action="store_true",
+                    help=argparse.SUPPRESS,
                 ),
             ],
         ),

--- a/harness/determined/deploy/aws/cli.py
+++ b/harness/determined/deploy/aws/cli.py
@@ -93,7 +93,7 @@ def deploy_aws(command: str, args: argparse.Namespace) -> None:
         sys.exit(1)
 
     if command == "down":
-        if not args.no_prompt:
+        if not args.yes:
             val = input(
                 "Deleting an AWS stack will lose all your data, including the created network "
                 "file system. Please back up the file system before deleting it. Do you still "
@@ -204,7 +204,7 @@ def deploy_aws(command: str, args: argparse.Namespace) -> None:
 
     print("Starting Determined Deployment")
     try:
-        deployment_object.deploy(args.no_prompt)
+        deployment_object.deploy(args.yes)
     except NoCredentialsError:
         error_no_credentials()
     except Exception as e:
@@ -297,6 +297,7 @@ args_description = Cmd(
                 Arg("--profile", type=str, default=None, help="AWS profile"),
                 Arg(
                     "--no-prompt",
+                    dest="yes",
                     action="store_true",
                     help=argparse.SUPPRESS,
                 ),
@@ -496,6 +497,7 @@ args_description = Cmd(
                 ),
                 Arg(
                     "--no-prompt",
+                    dest="yes",
                     action="store_true",
                     help=argparse.SUPPRESS,
                 ),

--- a/harness/determined/deploy/gcp/cli.py
+++ b/harness/determined/deploy/gcp/cli.py
@@ -57,7 +57,7 @@ def deploy_gcp(command: str, args: argparse.Namespace) -> None:
 
     # Handle down subcommand.
     if command == "down":
-        gcp.delete(det_configs, env, args.no_prompt)
+        gcp.delete(det_configs, env, args.yes)
         print("Delete Successful")
         return
 
@@ -88,6 +88,7 @@ def deploy_gcp(command: str, args: argparse.Namespace) -> None:
         "user",
         "no_preflight_checks",
         "no_wait_for_master",
+        "yes",
         "no_prompt",
         "master_config_template_path",
         "tf_state_gcs_bucket_name",
@@ -170,6 +171,7 @@ args_description = Cmd(
                         ),
                         Arg(
                             "--no-prompt",
+                            dest="yes",
                             action="store_true",
                             help=argparse.SUPPRESS,
                         ),

--- a/harness/determined/deploy/gcp/cli.py
+++ b/harness/determined/deploy/gcp/cli.py
@@ -164,9 +164,14 @@ args_description = Cmd(
                             help="local directory for storing cluster state",
                         ),
                         Arg(
-                            "--no-prompt",
+                            "--yes",
                             action="store_true",
                             help="no prompt when deleting resources",
+                        ),
+                        Arg(
+                            "--no-prompt",
+                            action="store_true",
+                            help=argparse.SUPPRESS,
                         ),
                     ],
                 ),

--- a/harness/determined/deploy/gcp/gcp.py
+++ b/harness/determined/deploy/gcp/gcp.py
@@ -303,7 +303,7 @@ def delete(configs: Dict, env: Dict, no_prompt: bool) -> None:
 
     command += ["-input=false"]
 
-    if not no_prompt:
+    if no_prompt:
         command += ["-auto-approve"]
 
     command += [f"-var-file={vars_file_path}"]


### PR DESCRIPTION
## Description

```det deploy``` commands now can take ```--yes``` to skip prompts. 

## Test Plan

Deploy a aws cluster using det deploy. Redeploy with changes with ```--no-prompt``` then again with ``--yes`` to ensure prompts are skipped. 

Then run
```
det deploy aws down --cluster-id nblaskey-test --yes
det deploy aws down --cluster-id nblaskey-test --no-prompt
det deploy aws down --cluster-id nblaskey-test # Should ask for prompt
```


Deploy a gcs cluster.

Run
```
det deploy gcp down --yes
det deploy gcp down --no-prompt
det deploy gcp down # Should ask for prompt
```

## Checklist

- [X] User-facing API changes need the "User-facing API Change" label.
- [X] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [X] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
