### PR TITLE
fix: don't hardcode /bin/which in entrypoints

### DIFF
--- a/docs/release-notes/4257-which.txt
+++ b/docs/release-notes/4257-which.txt
@@ -1,0 +1,7 @@
+:orphan:
+
+**Fixes**
+
+-  Supports running in containers which do not have a /bin/which path, such as python-slim. The
+   error was caused by accidentally hardcoding ``/bin/which`` instead of letting the shell find
+   ``which`` on the path.

--- a/master/static/srv/entrypoint.sh
+++ b/master/static/srv/entrypoint.sh
@@ -10,7 +10,7 @@ export PATH="/run/determined/pythonuserbase/bin:$PATH"
 if [ -z "$DET_PYTHON_EXECUTABLE" ] ; then
     export DET_PYTHON_EXECUTABLE="python3"
 fi
-if ! /bin/which "$DET_PYTHON_EXECUTABLE" >/dev/null 2>&1 ; then
+if ! which "$DET_PYTHON_EXECUTABLE" >/dev/null 2>&1 ; then
     echo "error: unable to find python3 as \"$DET_PYTHON_EXECUTABLE\"" >&2
     echo "please install python3 or set the environment variable DET_PYTHON_EXECUTABLE=/path/to/python3" >&2
     exit 1

--- a/master/static/srv/gc-checkpoints-entrypoint.sh
+++ b/master/static/srv/gc-checkpoints-entrypoint.sh
@@ -9,7 +9,7 @@ export PATH="/run/determined/pythonuserbase/bin:$PATH"
 if [ -z "$DET_PYTHON_EXECUTABLE" ] ; then
     export DET_PYTHON_EXECUTABLE="python3"
 fi
-if ! /bin/which "$DET_PYTHON_EXECUTABLE" >/dev/null 2>&1 ; then
+if ! which "$DET_PYTHON_EXECUTABLE" >/dev/null 2>&1 ; then
     echo "error: unable to find python3 as \"$DET_PYTHON_EXECUTABLE\"" >&2
     echo "please install python3 or set the environment variable DET_PYTHON_EXECUTABLE=/path/to/python3" >&2
     exit 1

--- a/master/static/srv/notebook-entrypoint.sh
+++ b/master/static/srv/notebook-entrypoint.sh
@@ -10,7 +10,7 @@ export PATH="/run/determined/pythonuserbase/bin:$PATH"
 if [ -z "$DET_PYTHON_EXECUTABLE" ] ; then
     export DET_PYTHON_EXECUTABLE="python3"
 fi
-if ! /bin/which "$DET_PYTHON_EXECUTABLE" >/dev/null 2>&1 ; then
+if ! which "$DET_PYTHON_EXECUTABLE" >/dev/null 2>&1 ; then
     echo "error: unable to find python3 as \"$DET_PYTHON_EXECUTABLE\"" >&2
     echo "please install python3 or set the environment variable DET_PYTHON_EXECUTABLE=/path/to/python3" >&2
     exit 1

--- a/master/static/srv/shell-entrypoint.sh
+++ b/master/static/srv/shell-entrypoint.sh
@@ -10,7 +10,7 @@ export PATH="/run/determined/pythonuserbase/bin:$PATH"
 if [ -z "$DET_PYTHON_EXECUTABLE" ] ; then
     export DET_PYTHON_EXECUTABLE="python3"
 fi
-if ! /bin/which "$DET_PYTHON_EXECUTABLE" >/dev/null 2>&1 ; then
+if ! which "$DET_PYTHON_EXECUTABLE" >/dev/null 2>&1 ; then
     echo "error: unable to find python3 as \"$DET_PYTHON_EXECUTABLE\"" >&2
     echo "please install python3 or set the environment variable DET_PYTHON_EXECUTABLE=/path/to/python3" >&2
     exit 1

--- a/master/static/srv/tensorboard-entrypoint.sh
+++ b/master/static/srv/tensorboard-entrypoint.sh
@@ -10,7 +10,7 @@ export PATH="/run/determined/pythonuserbase/bin:$PATH"
 if [ -z "$DET_PYTHON_EXECUTABLE" ] ; then
     export DET_PYTHON_EXECUTABLE="python3"
 fi
-if ! /bin/which "$DET_PYTHON_EXECUTABLE" >/dev/null 2>&1 ; then
+if ! which "$DET_PYTHON_EXECUTABLE" >/dev/null 2>&1 ; then
     echo "error: unable to find python3 as \"$DET_PYTHON_EXECUTABLE\"" >&2
     echo "please install python3 or set the environment variable DET_PYTHON_EXECUTABLE=/path/to/python3" >&2
     exit 1


### PR DESCRIPTION
This was my bug, introduced in #1967.

I have no idea why I wrote it that way.

## Test Plan

Run a notebook in an image that doesn't have /bin/which, like:

```python
det notebook start --config=environment.image=python:3.9.11-slim
```

Check the logs, ensuring the following log does NOT appear:
```
error: unable to find python3 as "python3"
```