### PR TITLE
fix: det task logs unable to use trial task IDs and checkpoint GC task IDs [DET-7424]

### DIFF
--- a/docs/release-notes/fix-task-logs.txt
+++ b/docs/release-notes/fix-task-logs.txt
@@ -1,0 +1,7 @@
+:orphan:
+
+**Bug Fixes**
+
+-  CLI: Fix an issue for ``det task logs`` where short versions of task IDs could not be used.
+
+-  CLI: Fix an issue for ``det task logs`` where trial task IDs and Checkpoint GC task IDs could not be used.      

--- a/docs/release-notes/fix-task-logs.txt
+++ b/docs/release-notes/fix-task-logs.txt
@@ -2,6 +2,5 @@
 
 **Bug Fixes**
 
--  CLI: Fix an issue for ``det task logs`` where short versions of task IDs could not be used.
-
--  CLI: Fix an issue for ``det task logs`` where trial task IDs and Checkpoint GC task IDs could not be used.      
+-  CLI: Fix an issue for ``det task logs`` where trial task IDs and checkpoint GC task IDs could not
+   be used.

--- a/harness/determined/cli/command.py
+++ b/harness/determined/cli/command.py
@@ -39,7 +39,7 @@ _CONFIG_PATHS_COERCE_TO_LIST = {
 }
 
 UUID_REGEX = re.compile(
-    "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$", re.IGNORECASE
+    "^(?:[0-9]+\.)?[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$", re.IGNORECASE
 )
 
 CommandTableHeader = OrderedDict(

--- a/harness/determined/cli/command.py
+++ b/harness/determined/cli/command.py
@@ -38,8 +38,8 @@ _CONFIG_PATHS_COERCE_TO_LIST = {
     "bind_mounts",
 }
 
-UUID_REGEX = re.compile(
-    "^(?:[0-9]+\.)?[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$", re.IGNORECASE
+TASK_ID_REGEX = re.compile(
+    r"^(?:[0-9]+\.)?[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$", re.IGNORECASE
 )
 
 CommandTableHeader = OrderedDict(
@@ -142,22 +142,18 @@ def expand_uuid_prefixes(
         prefixes = [prefixes]
 
     # Avoid making a network request if everything is already a full UUID.
-    if not all(UUID_REGEX.match(p) for p in prefixes):
-        # If we are unable to determine what specific task type something is
-        # such as when we are calling det task logs we need to check all
-        # of the possible API options.
-        api_paths = list(RemoteTaskNewAPIs.values())
-        if args._command in RemoteTaskNewAPIs:
-            api_paths = [RemoteTaskNewAPIs[args._command]]
-
-        all_ids = []  # type: List[str]
-        for api_path in api_paths:
-            api_full_path = "api/v1/{}".format(api_path)
-            res = api.get(args.master, api_full_path).json()[api_path]
-            all_ids.extend([x["id"] for x in res])
+    if not all(TASK_ID_REGEX.match(p) for p in prefixes):
+        if args._command not in RemoteTaskNewAPIs:
+            raise api.errors.BadRequestException(
+                f"partial UUIDs not supported for 'det {args._command} {args._subcommand}'"
+            )
+        api_path = RemoteTaskNewAPIs[args._command]
+        api_full_path = "api/v1/{}".format(api_path)
+        res = api.get(args.master, api_full_path).json()[api_path]
+        all_ids: List[str] = [x["id"] for x in res]
 
         def expand(prefix: str) -> str:
-            if UUID_REGEX.match(prefix):
+            if TASK_ID_REGEX.match(prefix):
                 return prefix
 
             # Could do better algorithmically than repeated linear scans, but let's not complicate

--- a/harness/tests/cli/test_cli.py
+++ b/harness/tests/cli/test_cli.py
@@ -103,42 +103,6 @@ def test_uuid_prefix(requests_mock: requests_mock.Mocker) -> None:
         cli.main(["shell", "config", "x"])
 
 
-@pytest.mark.parametrize("index", range(len(command.RemoteTaskNewAPIs)))
-def test_uuid_prefix_task(requests_mock: requests_mock.Mocker, index: int) -> None:
-    task_id = str(uuid.uuid4())
-
-    requests_mock.get("/info", status_code=200, json={"version": "1.0"})
-    requests_mock.get(
-        "/users/me", status_code=200, json={"username": constants.DEFAULT_DETERMINED_USER}
-    )
-    requests_mock.get(
-        f"/api/v1/tasks/{task_id}/logs",
-        status_code=requests.codes.ok,
-        json={
-            "result": {
-                "message": "test",
-            }
-        },
-    )
-
-    for i, api in enumerate(command.RemoteTaskNewAPIs.values()):
-        ids = [{"id": task_id}]
-        if index != i:
-            ids = []
-
-        requests_mock.get(
-            f"/api/v1/{api}",
-            status_code=requests.codes.ok,
-            json={api: ids},
-        )
-
-    cli.main(["task", "logs", task_id[:4]])
-
-    # Non nonexistent prefix.
-    with pytest.raises(SystemExit):
-        cli.main(["task", "logs", task_id[:4] + "lightningstrike"])
-
-
 @pytest.mark.slow
 def test_create_reject_large_model_def(requests_mock: requests_mock.Mocker, tmp_path: Path) -> None:
     requests_mock.get("/info", status_code=200, json={"version": "1.0"})

--- a/harness/tests/cli/test_cli.py
+++ b/harness/tests/cli/test_cli.py
@@ -105,7 +105,6 @@ def test_uuid_prefix(requests_mock: requests_mock.Mocker) -> None:
 
 @pytest.mark.parametrize("index", range(len(command.RemoteTaskNewAPIs)))
 def test_uuid_prefix_task(requests_mock: requests_mock.Mocker, index: int) -> None:
-    index = 0
     task_id = str(uuid.uuid4())
 
     requests_mock.get("/info", status_code=200, json={"version": "1.0"})

--- a/harness/tests/cli/test_cli.py
+++ b/harness/tests/cli/test_cli.py
@@ -103,6 +103,43 @@ def test_uuid_prefix(requests_mock: requests_mock.Mocker) -> None:
         cli.main(["shell", "config", "x"])
 
 
+@pytest.mark.parametrize("index", range(len(command.RemoteTaskNewAPIs)))
+def test_uuid_prefix_task(requests_mock: requests_mock.Mocker, index: int) -> None:
+    index = 0
+    task_id = str(uuid.uuid4())
+
+    requests_mock.get("/info", status_code=200, json={"version": "1.0"})
+    requests_mock.get(
+        "/users/me", status_code=200, json={"username": constants.DEFAULT_DETERMINED_USER}
+    )
+    requests_mock.get(
+        f"/api/v1/tasks/{task_id}/logs",
+        status_code=requests.codes.ok,
+        json={
+            "result": {
+                "message": "test",
+            }
+        },
+    )
+
+    for i, api in enumerate(command.RemoteTaskNewAPIs.values()):
+        ids = [{"id": task_id}]
+        if index != i:
+            ids = []
+
+        requests_mock.get(
+            f"/api/v1/{api}",
+            status_code=requests.codes.ok,
+            json={api: ids},
+        )
+
+    cli.main(["task", "logs", task_id[:4]])
+
+    # Non nonexistent prefix.
+    with pytest.raises(SystemExit):
+        cli.main(["task", "logs", task_id[:4] + "lightningstrike"])
+
+
 @pytest.mark.slow
 def test_create_reject_large_model_def(requests_mock: requests_mock.Mocker, tmp_path: Path) -> None:
     requests_mock.get("/info", status_code=200, json={"version": "1.0"})


### PR DESCRIPTION
## Description

```det task logs``` now works for trial task IDs and checkpoint GC task IDs.

## Test Plan

CLI unit test and running ```det task logs <CHECKPOINT_GC_TASK_ID>```

## Commentary (optional)


## Checklist

- [X] User-facing API changes need the "User-facing API Change" label.
- [X] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [X] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
