### PR TITLE
fix: jupyterlab modal stale values, not sending values to api

### DIFF
--- a/webui/react/src/hooks/useModal/useJupyterLabModal.test.tsx
+++ b/webui/react/src/hooks/useModal/useJupyterLabModal.test.tsx
@@ -2,6 +2,7 @@ import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { Button, Modal } from 'antd';
 import React, { useEffect } from 'react';
+import { BrowserRouter } from 'react-router-dom';
 
 import StoreProvider, { StoreAction, useStoreDispatch } from 'contexts/Store';
 
@@ -55,9 +56,11 @@ const ModalTrigger: React.FC = () => {
 
 const ModalTriggerContainer: React.FC = () => {
   return (
-    <StoreProvider>
-      <ModalTrigger />
-    </StoreProvider>
+    <BrowserRouter>
+      <StoreProvider>
+        <ModalTrigger />
+      </StoreProvider>
+    </BrowserRouter>
   );
 };
 

--- a/webui/react/src/hooks/useModal/useJupyterLabModal.tsx
+++ b/webui/react/src/hooks/useModal/useJupyterLabModal.tsx
@@ -30,20 +30,24 @@ const settingsConfig : SettingsConfig = {
     {
       defaultValue: '',
       key: 'name',
+      skipUrlEncoding: true,
       type: { baseType: BaseType.String },
     },
     {
       defaultValue: '',
       key: 'pool',
+      skipUrlEncoding: true,
       type: { baseType: BaseType.String },
     },
     {
       defaultValue: DEFAULT_SLOT_COUNT,
       key: 'slots',
+      skipUrlEncoding: true,
       type: { baseType: BaseType.Integer },
     },
     {
       key: 'template',
+      skipUrlEncoding: true,
       type: { baseType: BaseType.String },
     },
   ],
@@ -288,8 +292,10 @@ const JupyterLabForm: React.FC<FormProps> = (
   }, [ fetchTemplates ]);
 
   useEffect(() => {
-    if (!fields.pool && resourcePools[0])
-      updateFields?.({ pool: resourcePools[0]?.toString() });
+    if (!fields.pool && resourcePools[0]?.name) {
+      const pool = resourcePools[0]?.name;
+      updateFields?.({ pool });
+    }
   }, [ resourcePools, fields.pool, updateFields ]);
 
   return (

--- a/webui/react/src/hooks/useModal/useJupyterLabModal.tsx
+++ b/webui/react/src/hooks/useModal/useJupyterLabModal.tsx
@@ -3,16 +3,16 @@ import { Form, Input, Select } from 'antd';
 import { ModalFuncProps } from 'antd';
 import { ModalStaticFunctions } from 'antd/es/modal/confirm';
 import yaml from 'js-yaml';
-import React, { Dispatch, useCallback, useEffect, useMemo, useReducer, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 
 import Link from 'components/Link';
-import useJupyterLab from 'hooks/useJupyterLab';
 import usePrevious from 'hooks/usePrevious';
-import useStorage from 'hooks/useStorage';
+import useSettings, { BaseType, SettingsConfig, UpdateSettings } from 'hooks/useSettings';
 import { getResourcePools, getTaskTemplates } from 'services/api';
 import Spinner from 'shared/components/Spinner/Spinner';
-import { JupyterLabConfig, ResourcePool, Template } from 'types';
+import { ResourcePool, Template } from 'types';
 import handleError from 'utils/error';
+import { JupyterLabOptions, launchJupyterLab, previewJupyterLab } from 'utils/jupyter';
 
 import { RawJson } from '../../shared/types';
 
@@ -22,43 +22,37 @@ import useModal, { ModalHooks } from './useModal';
 const { Option } = Select;
 const { Item } = Form;
 
-const STORAGE_PATH = 'jupyter-lab-launch';
-const STORAGE_KEY = 'jupyter-lab-config';
+const STORAGE_PATH = 'jupyter-lab';
 const DEFAULT_SLOT_COUNT = 1;
 
-type DispatchFunction = Dispatch<{
-  key: keyof JupyterLabConfig,
-  value: string | number | undefined
-}>;
-
-function reducer(
-  state: JupyterLabConfig,
-  action: { key: keyof JupyterLabConfig, value: string | number | undefined },
-): JupyterLabConfig {
-  return { ...state, [action.key]: action.value };
-}
-
-const useJupyterLabForm = (): [ JupyterLabConfig, DispatchFunction ] => {
-  const storage = useStorage(STORAGE_PATH);
-  const [ state, dispatch ] = useReducer(
-    reducer,
-    storage.getWithDefault(STORAGE_KEY, { slots: DEFAULT_SLOT_COUNT }),
-  );
-
-  const storeConfig = useCallback((values: JupyterLabConfig) => {
-    const { name, ...storedValues } = values;
-    storage.set(STORAGE_KEY, storedValues);
-  }, [ storage ]);
-
-  useEffect(() => {
-    storeConfig(state);
-  }, [ state, storeConfig ]);
-
-  return [ state, dispatch ];
+const settingsConfig : SettingsConfig = {
+  settings: [
+    {
+      defaultValue: '',
+      key: 'name',
+      type: { baseType: BaseType.String },
+    },
+    {
+      defaultValue: '',
+      key: 'pool',
+      type: { baseType: BaseType.String },
+    },
+    {
+      defaultValue: DEFAULT_SLOT_COUNT,
+      key: 'slots',
+      type: { baseType: BaseType.Integer },
+    },
+    {
+      key: 'template',
+      type: { baseType: BaseType.String },
+    },
+  ],
+  storagePath: STORAGE_PATH,
 };
+
 interface FormProps {
-  fields: JupyterLabConfig;
-  onChange?: DispatchFunction;
+  fields: JupyterLabOptions;
+  updateFields?: UpdateSettings<JupyterLabOptions>;
 }
 
 interface FullConfigProps {
@@ -71,7 +65,11 @@ interface FullConfigProps {
 const MonacoEditor = React.lazy(() => import('components/MonacoEditor'));
 
 const useJupyterLabModal = (modal: Omit<ModalStaticFunctions, 'warn'>): ModalHooks => {
-  const { modalClose, modalOpen: openOrUpdate, modalRef } = useModal({ modal });
+  const [ visible, setVisible ] = useState(false);
+  const handleModalClose = useCallback(() => setVisible(false), []);
+  const { modalClose, modalOpen: openOrUpdate, modalRef } = useModal(
+    { modal, onClose: handleModalClose },
+  );
 
   const [ showFullConfig, setShowFullConfig ] = useState(false);
   const [ config, setConfig ] = useState<string | undefined>();
@@ -79,8 +77,10 @@ const useJupyterLabModal = (modal: Omit<ModalStaticFunctions, 'warn'>): ModalHoo
   const previousShowConfig = usePrevious(showFullConfig, showFullConfig);
   const [ buttonDisabled, setButtonDisabled ] = useState(false);
 
-  const [ fields, dispatch ] = useJupyterLabForm();
-  const { launchJupyterLab, previewJupyterLab } = useJupyterLab();
+  const { settings: fields, updateSettings: updateFields } = useSettings<JupyterLabOptions>(
+    settingsConfig,
+  );
+  const previousFields = usePrevious(fields, undefined);
 
   const fetchConfig = useCallback(async () => {
     try {
@@ -88,13 +88,13 @@ const useJupyterLabModal = (modal: Omit<ModalStaticFunctions, 'warn'>): ModalHoo
         name: fields.name,
         pool: fields.pool,
         slots: fields.slots,
-        templateName: fields.template,
+        template: fields.template,
       });
       setConfig(yaml.dump(newConfig));
     } catch (e) {
       setConfig(undefined);
     }
-  }, [ fields, previewJupyterLab ]);
+  }, [ fields ]);
 
   const handleSecondary = useCallback(() => {
     if (showFullConfig) setButtonDisabled(false);
@@ -109,11 +109,11 @@ const useJupyterLabModal = (modal: Omit<ModalStaticFunctions, 'warn'>): ModalHoo
         name: fields.name,
         pool: fields.pool,
         slots: fields.slots,
-        templateName: fields.template,
+        template: fields.template,
       });
     }
     modalClose();
-  }, [ config, fields, launchJupyterLab, showFullConfig, modalClose ]);
+  }, [ config, fields, showFullConfig, modalClose ]);
 
   const handleConfigChange = useCallback((config: string) => setConfig(config), []);
 
@@ -124,8 +124,8 @@ const useJupyterLabModal = (modal: Omit<ModalStaticFunctions, 'warn'>): ModalHoo
       onChange={handleConfigChange}
     />
   ) : (
-    <JupyterLabForm fields={fields} onChange={dispatch} />
-  ), [ config, dispatch, fields, handleConfigChange, showFullConfig ]);
+    <JupyterLabForm fields={fields} updateFields={updateFields} />
+  ), [ config, fields, handleConfigChange, showFullConfig, updateFields ]);
 
   const content = useMemo(() => (
     <>
@@ -146,12 +146,15 @@ const useJupyterLabModal = (modal: Omit<ModalStaticFunctions, 'warn'>): ModalHoo
 
   const modalProps: ModalFuncProps = useMemo(() => ({
     className: css.noFooter,
+    closable: true,
     content: content,
+    icon: null,
     title: 'Launch JupyterLab',
     width: 540,
   }), [ content ]);
 
   const modalOpen = useCallback((initialModalProps: ModalFuncProps = {}) => {
+    setVisible(true);
     openOrUpdate({ ...modalProps, ...initialModalProps });
   }, [ modalProps, openOrUpdate ]);
 
@@ -167,6 +170,11 @@ const useJupyterLabModal = (modal: Omit<ModalStaticFunctions, 'warn'>): ModalHoo
   useEffect(() => {
     if (showFullConfig) fetchConfig();
   }, [ fetchConfig, showFullConfig ]);
+
+  useEffect(() => {
+    if (visible && fields !== previousFields)
+      openOrUpdate(modalProps);
+  }, [ fields, previousFields, openOrUpdate, modalProps, visible ]);
 
   return { modalClose, modalOpen, modalRef };
 };
@@ -231,7 +239,7 @@ const JupyterLabFullConfig: React.FC<FullConfigProps> = (
 };
 
 const JupyterLabForm: React.FC<FormProps> = (
-  { onChange, fields }: FormProps,
+  { updateFields, fields }: FormProps,
 ) => {
   const [ templates, setTemplates ] = useState<Template[]>([]);
   const [ resourcePools, setResourcePools ] = useState<ResourcePool[]>([]);
@@ -249,14 +257,15 @@ const JupyterLabForm: React.FC<FormProps> = (
     const maxSlots = selectedPool.slotsPerAgent ?? 0;
     const hasSlotsPerAgent = maxSlots !== 0;
     const hasComputeCapacity = hasSlots || hasSlotsPerAgent;
-    if (hasAuxCapacity && !hasComputeCapacity) onChange?.({ key: 'slots', value: 0 });
+    if (hasAuxCapacity && !hasComputeCapacity) updateFields?.({ slots: 0 });
+    if (hasComputeCapacity && !fields.slots) updateFields?.({ slots: DEFAULT_SLOT_COUNT });
 
     return {
       hasAux: hasAuxCapacity,
       hasCompute: hasComputeCapacity,
       maxSlots: maxSlots,
     };
-  }, [ fields.pool, onChange, resourcePools ]);
+  }, [ fields.pool, updateFields, resourcePools, fields.slots ]);
 
   const fetchResourcePools = useCallback(async () => {
     try {
@@ -278,6 +287,11 @@ const JupyterLabForm: React.FC<FormProps> = (
     fetchTemplates();
   }, [ fetchTemplates ]);
 
+  useEffect(() => {
+    if (!fields.pool && resourcePools[0])
+      updateFields?.({ pool: resourcePools[0]?.toString() });
+  }, [ resourcePools, fields.pool, updateFields ]);
+
   return (
     <div className={css.form}>
       {[
@@ -287,7 +301,7 @@ const JupyterLabForm: React.FC<FormProps> = (
               allowClear
               placeholder="No template (optional)"
               value={fields.template}
-              onChange={value => onChange?.({ key: 'template', value: value?.toString() })}>
+              onChange={value => updateFields?.({ template: value?.toString() })}>
               {templates.map(temp => (
                 <Option key={temp.name} value={temp.name}>{temp.name}</Option>
               ))}
@@ -298,9 +312,9 @@ const JupyterLabForm: React.FC<FormProps> = (
         {
           content: (
             <Input
-              placeholder="Name"
+              placeholder="Name (optional)"
               value={fields.name}
-              onChange={(e) => onChange?.({ key: 'name', value: e.target.value })}
+              onChange={(e) => updateFields?.({ name: e.target.value })}
             />
           ),
           label: 'Name',
@@ -311,7 +325,7 @@ const JupyterLabForm: React.FC<FormProps> = (
               allowClear
               placeholder="Pick the best option"
               value={fields.pool}
-              onChange={value => onChange?.({ key: 'pool', value: value })}>
+              onChange={value => updateFields?.({ pool: value })}>
               {resourcePools.map(pool => (
                 <Option key={pool.name} value={pool.name}>{pool.name}</Option>
               ))}
@@ -327,7 +341,7 @@ const JupyterLabForm: React.FC<FormProps> = (
               max={resourceInfo.maxSlots === -1 ? Number.MAX_SAFE_INTEGER : resourceInfo.maxSlots}
               min={resourceInfo.hasAux ? 0 : 1}
               value={fields.slots}
-              onChange={(value) => onChange?.({ key: 'slots', value: value })}
+              onChange={(value) => updateFields?.({ slots: value })}
             />
           ),
           label: 'Slots',

--- a/webui/react/src/omnibar/tree-extension/trees/index.ts
+++ b/webui/react/src/omnibar/tree-extension/trees/index.ts
@@ -1,5 +1,4 @@
 import { activeRunStates, terminalCommandStates, terminalRunStates } from 'constants/states';
-import { launchJupyterLab } from 'hooks/useJupyterLab';
 import { displayHelp, parseIds, visitAction } from 'omnibar/tree-extension/trees/actions';
 import dev from 'omnibar/tree-extension/trees/dev';
 import locations from 'omnibar/tree-extension/trees/goto';
@@ -8,6 +7,7 @@ import { paths } from 'routes/utils';
 import { activateExperiment, archiveExperiment, getExperiments, getJupyterLabs, getTensorBoards,
   killExperiment, killJupyterLab, killTensorBoard, openOrCreateTensorBoard,
   pauseExperiment } from 'services/api';
+import { launchJupyterLab } from 'utils/jupyter';
 
 const root: NonLeafNode = {
   options: [

--- a/webui/react/src/types.ts
+++ b/webui/react/src/types.ts
@@ -186,13 +186,6 @@ export interface Command {
   user: User;
 }
 
-export interface JupyterLabConfig {
-  name?: string;
-  pool?: string;
-  slots?: number;
-  template?: string;
-}
-
 export enum CheckpointStorageType {
   AWS = 'aws',
   GCS = 'gcs',

--- a/webui/react/src/utils/jupyter.ts
+++ b/webui/react/src/utils/jupyter.ts
@@ -6,20 +6,15 @@ import { openCommand } from 'wait';
 import { RawJson } from '../shared/types';
 import { ErrorLevel, ErrorType } from '../shared/utils/error';
 
-interface JupyterLabOptions {
+export interface JupyterLabOptions {
   name?: string,
   pool?:string,
   slots?: number,
-  templateName?: string,
+  template?: string,
 }
 
 interface JupyterLabLaunchOptions extends JupyterLabOptions {
   config?: RawJson,
-}
-
-interface JupyterLabHooks {
-  launchJupyterLab: (options: JupyterLabLaunchOptions) => Promise<void>;
-  previewJupyterLab: (options: JupyterLabOptions) => Promise<RawJson>;
 }
 
 export const launchJupyterLab = async (
@@ -34,7 +29,7 @@ export const launchJupyterLab = async (
           slots: options.slots,
         },
       },
-      templateName: options.templateName === '' ? undefined : options.templateName,
+      templateName: options.template === '' ? undefined : options.template,
     });
     openCommand(jupyterLab);
   } catch (e) {
@@ -61,16 +56,10 @@ export const previewJupyterLab = async (
         },
       },
       preview: true,
-      templateName: options.templateName === '' ? undefined : options.templateName,
+      templateName: options.template === '' ? undefined : options.template,
     });
     return config;
   } catch (e) {
     throw new Error('Unable to load JupyterLab config.');
   }
 };
-
-const useJupyterLab = (): JupyterLabHooks => {
-  return { launchJupyterLab, previewJupyterLab };
-};
-
-export default useJupyterLab;


### PR DESCRIPTION
## Description

[DET-7478] [DET-7389]

fixes some staleness with jupyterlab modal in both the ui and values that get sent to API 

also does some refactoring/cleanup of the adjacent code (mainly the older parts of the code, from before the recent refactor)

## Before

jupyterlab modal has stale values for compute pool (clicking in dropdown doesnt update value):

https://user-images.githubusercontent.com/28383080/172557596-60342111-e605-4063-ad30-f9ee647d37e7.mov

and slots (pressing enter or clicking away causes the current input value to be clobbered by previous):

https://user-images.githubusercontent.com/28383080/172557934-b56badca-dbfa-47b8-b2c4-efa1d496e4b8.mov

and sends empty/stale values to api:

https://user-images.githubusercontent.com/28383080/172558702-7bd90a52-d4b2-4974-bdad-54a54090b8a1.mov

there is a warning logo on the top left, which isn't suitable.

also there was some accumulated messy code (going way back before recent refactor)

`useJupyterlabModal` calls `useJupyterLab` and `useJupyterLabForm`

`useJupyterLab` is actually just some util functions so i moved them to `utils/jupyter`

`useJupyterLabForm` is a wrapper around a reducer that does `useStorage` to manage state. we prefer `useSettings` now to `useStorage`


## After

these are hopefully all now resolved.



https://user-images.githubusercontent.com/28383080/172563126-3d525796-819a-461f-8806-3f254a9bcaa4.mov





## Test Plan

Test creation of jupyterlab with all the various options, verify that the POST payloads are correct.



## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-7478]: https://determinedai.atlassian.net/browse/DET-7478?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[DET-7389]: https://determinedai.atlassian.net/browse/DET-7389?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ