### PR TITLE
feat: normalize URLs for CLI auth.json [DET-7357]

### DIFF
--- a/docs/release-notes/normalize-auth-json.txt
+++ b/docs/release-notes/normalize-auth-json.txt
@@ -1,0 +1,6 @@
+:orphan:
+
+**Improvements**
+
+-  CLI: URLs stored in ``auth.json`` are now normalized to prevent issues with the same URL being
+   stored in different ways such as with ``http://example.com`` and ``example.com:80``.

--- a/harness/determined/common/api/authentication.py
+++ b/harness/determined/common/api/authentication.py
@@ -282,7 +282,7 @@ class TokenStore:
             for url in store.get("masters", {}):
                 if normalize_url(url) == self.master_address:
                     # Assume config is corrupted if we have multiple
-                    # that refer to the same url.
+                    # master urls that normalize to the same URL.
                     if to_remove:
                         raise api.errors.CorruptTokenCacheException()
                     to_remove = url

--- a/harness/tests/cli/test_auth.py
+++ b/harness/tests/cli/test_auth.py
@@ -119,7 +119,9 @@ def test_auth_json_v0_upgrade() -> None:
         ("127.0.0.1", False),
         ("localhost:8080", True),
         ("localhost/", True),
-        ("localhost/det/test", True),  # Somewhat surprising behaviour.
+        ("localhost//", True),
+        ("localhost/det/test", True), # Somewhat surprising behaviour.
+        ("localhost/det/test/", True), # Somewhat surprising behaviour.
         ("http://localhost", False),
         ("https://localhost:8080", False),
         ("http://localhost:8080", True),
@@ -153,15 +155,13 @@ def test_auth_url_conflict(merge_url: str, should_corrupt: bool) -> None:
     with use_test_config_dir() as config_dir:
         auth_json_path = config_dir / "auth.json"
         with open(auth_json_path, "w") as f:
-            auth_json = copy.deepcopy(AUTH_JSON)
-            masters: Dict[str, Any] = auth_json["masters"]
-            to_add = {
+            auth_json: Dict[str, Any] = copy.deepcopy(AUTH_JSON)
+            auth_json["masters"][merge_url] = {
                 "active_user": "joe",
                 "tokens": {
                     "joe": "joe.token",
                 },
             }
-            masters[merge_url] = to_add
             json.dump(auth_json, f)
         if should_corrupt:
             with pytest.raises(CorruptTokenCacheException):

--- a/harness/tests/cli/test_auth.py
+++ b/harness/tests/cli/test_auth.py
@@ -120,8 +120,8 @@ def test_auth_json_v0_upgrade() -> None:
         ("localhost:8080", True),
         ("localhost/", True),
         ("localhost//", True),
-        ("localhost/det/test", True), # Somewhat surprising behaviour.
-        ("localhost/det/test/", True), # Somewhat surprising behaviour.
+        ("localhost/det/test", True),  # Somewhat surprising behaviour.
+        ("localhost/det/test/", True),  # Somewhat surprising behaviour.
         ("http://localhost", False),
         ("https://localhost:8080", False),
         ("http://localhost:8080", True),


### PR DESCRIPTION
## Description

Normalize URLs in auth.json to prevent weird behavior between entries like ```http://example.com``` and ```example.com:80```.

## Test Plan

CLI unit tests.

## Commentary (optional)

Went back and fourth on how much should the CLI try to fix a config with entries of ```localhost``` and ```localhost:8080```. Was not able to come up with a way that could avoid potentially cause surprising behavior, so decided in that case to raise the corrupted config exception which deletes the config. 

## Checklist

- [X] User-facing API changes need the "User-facing API Change" label.
- [X] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [X] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
