### PR TITLE
fix: pass signals through wrapper processes

### DIFF
--- a/docs/release-notes/4286-passthru.txt
+++ b/docs/release-notes/4286-passthru.txt
@@ -1,0 +1,7 @@
+:orphan:
+
+**Fixes**
+
+-  Prevent certain hangs when using one of Determined's built-in launchers, which begin in release
+   0.18.0. These hangs were caused by wrapper processes which were seeing SIGTERM but not passing it
+   to their child process.

--- a/harness/determined/exec/launch.py
+++ b/harness/determined/exec/launch.py
@@ -49,7 +49,9 @@ def launch(experiment_config: det.ExperimentConfig) -> int:
 
     logging.info(f"Launching: {entrypoint}")
 
-    return subprocess.Popen(entrypoint).wait()
+    p = subprocess.Popen(entrypoint)
+    with det.util.forward_signals(p):
+        return p.wait()
 
 
 def mask_config_dict(d: Dict) -> Dict:

--- a/harness/determined/launch/torch_distributed.py
+++ b/harness/determined/launch/torch_distributed.py
@@ -79,7 +79,9 @@ def main(override_args: List[str], script: List[str]) -> int:
 
     # Detect single-slot trials and skip distributed launch
     if single_slot:
-        return subprocess.Popen(script).wait()
+        p = subprocess.Popen(script)
+        with det.util.forward_signals(p):
+            return p.wait()
 
     os.environ["USE_TORCH_DISTRIBUTED"] = "True"
 
@@ -105,7 +107,9 @@ def main(override_args: List[str], script: List[str]) -> int:
 
     logging.debug(f"Torch distributed launching with: {launch_cmd}")
 
-    return subprocess.Popen(launch_cmd).wait()
+    p = subprocess.Popen(launch_cmd)
+    with det.util.forward_signals(p):
+        return p.wait()
 
 
 def parse_args(args: List[str]) -> Tuple[List[str], List[str]]:

--- a/harness/determined/util.py
+++ b/harness/determined/util.py
@@ -1,4 +1,5 @@
 import collections
+import contextlib
 import datetime
 import enum
 import inspect
@@ -11,10 +12,12 @@ import pathlib
 import random
 import re
 import shutil
+import signal
 import socket
+import subprocess
 import time
 import uuid
-from typing import Any, Callable, Dict, List, Optional, Set, SupportsFloat, Tuple, cast
+from typing import Any, Callable, Dict, Iterator, List, Optional, Set, SupportsFloat, Tuple, cast
 
 import determined as det
 from determined import constants
@@ -325,3 +328,28 @@ def match_legacy_trial_class(arg: str) -> bool:
 
 def legacy_trial_entrypoint_to_script(trial_entrypoint: str) -> List[str]:
     return ["python3", "-m", "determined.exec.harness", trial_entrypoint]
+
+
+@contextlib.contextmanager
+def forward_signals(p: subprocess.Popen, *signums: signal.Signals) -> Iterator[None]:
+    """Forward a list of signals to a subprocess, restoring the original handlers afterwards."""
+    if not signums:
+        # Pick a useful default for wrapper processes.
+        names = ["SIGINT", "SIGTERM", "SIGHUP", "SIGUSR1", "SIGUSR2", "SIGWINCH", "SIGBREAK"]
+        signums = tuple(getattr(signal, name) for name in names if hasattr(signal, name))
+
+    def signal_passthru(signum: Any, frame: Any) -> None:
+        p.send_signal(signum)
+
+    old_handlers = [None for n in signums]  # type: List[Any]
+    try:
+        # Install passthru handlers.
+        for i, n in enumerate(signums):
+            old_handlers[i] = signal.signal(n, signal_passthru)
+        yield
+    finally:
+        # restore original handlers
+        for n, old in zip(signums, old_handlers):
+            if old is None:
+                continue
+            signal.signal(n, old)


### PR DESCRIPTION
I thought we were cleaning things up nicely, but when logging started
keeping containers open until all copies of the stdout file descriptor
closed, it became obvious that the pid_client was being killed by
horovodrun without shutting down its child wrap_rank script, causing the
logging to stay active and the container to hang.

This first fix is to pass signals through wrapper processes, so that
normal graceful shutdowns complete as-expected.

## Test Plan

With a 0.18.1 master:
- start a trial with a context.distributed.allgather in one rank, with an exit(1) in another rank
- observe horovod try to shut down training
- observe training does not stop
- observe pid_server gets impatient and SIGKILLs horovodrun
- observe the container is hung
- docker exec into the container, and see that the pid_client is gone, but the wrap_rank process is not.

After this fix, the same procedure should result in everything shutting down properly.

## Commentary

I sheepishly admit that I always wondered how all the processes were getting cleaned up, and I'm very embarrassed that even so I've always been very confident we cleaned things up properly.