### PR TITLE
chore: restore determined_version in Trial checkpoint metadata

### DIFF
--- a/docs/release-notes/4288-version.txt
+++ b/docs/release-notes/4288-version.txt
@@ -1,0 +1,7 @@
+:orphan:
+
+**Fixes**
+
+-  Automatically add a ``determined_version`` key to the metadata of checkpoints created by any of
+   the Trial APIs. This automatic key was accidentally dropped in release 0.18.0. Note that Core API
+   checkpoints have full control over their checkpoint metadata and so are unaffected.

--- a/e2e_tests/tests/experiment/test_core.py
+++ b/e2e_tests/tests/experiment/test_core.py
@@ -297,15 +297,22 @@ def test_end_to_end_adaptive() -> None:
     checkpoint.add_metadata({"testing": "metadata"})
     db_check = d.get_checkpoint(checkpoint.uuid)
     # Make sure the checkpoint metadata is correct and correctly saved to the db.
-    # Beginning with 0.18 the system contributes a few items to the dict
+    # Beginning with 0.18 the TrialController contributes a few items to the dict.
     assert checkpoint.metadata.get("testing") == "metadata"
-    assert checkpoint.metadata.keys() == {"format", "framework", "steps_completed", "testing"}
+    assert checkpoint.metadata.keys() == {
+        "determined_version",
+        "format",
+        "framework",
+        "steps_completed",
+        "testing",
+    }
     assert checkpoint.metadata == db_check.metadata
 
     checkpoint.add_metadata({"some_key": "some_value"})
     db_check = d.get_checkpoint(checkpoint.uuid)
     assert checkpoint.metadata.items() > {"testing": "metadata", "some_key": "some_value"}.items()
     assert checkpoint.metadata.keys() == {
+        "determined_version",
         "format",
         "framework",
         "steps_completed",

--- a/harness/determined/estimator/_estimator_trial.py
+++ b/harness/determined/estimator/_estimator_trial.py
@@ -311,6 +311,7 @@ class DeterminedControlHook(estimator.RunHook):
                     self._save_model()
                     if self.estimator_trial_controller.is_chief:
                         metadata = {
+                            "determined_version": det.__version__,
                             "steps_completed": self.steps_completed,
                             "framework": f"tensorflow-{tf.__version__}",
                             "format": "saved_model",

--- a/harness/determined/keras/_tf_keras_trial.py
+++ b/harness/determined/keras/_tf_keras_trial.py
@@ -819,6 +819,7 @@ class TFKerasTrialController(det.TrialController):
                     action = "checkpointing"
                     if self.is_chief:
                         metadata = {
+                            "determined_version": det.__version__,
                             "steps_completed": self.steps_completed,
                             "framework": f"tensorflow-{tf.__version__}",
                             "format": "saved_weights",

--- a/harness/determined/pytorch/_pytorch_trial.py
+++ b/harness/determined/pytorch/_pytorch_trial.py
@@ -277,6 +277,7 @@ class PyTorchTrialController(det.TrialController):
                     action = "checkpointing"
                     if self.is_chief:
                         metadata = {
+                            "determined_version": det.__version__,
                             "steps_completed": self.steps_completed,
                             "framework": f"torch-{torch.__version__}",
                             "format": "pickle",


### PR DESCRIPTION
This was accidentally dropped from the automatically-stored metadata as
part of the generic checkpoint feature branch (4fb1886b).

## Commentary

This was probably my mistake.