### PR TITLE
fix: limit waiting for logger to 30 seconds

### DIFF
--- a/master/static/srv/task-logging-setup.sh
+++ b/master/static/srv/task-logging-setup.sh
@@ -41,11 +41,11 @@ if [ -n "$DET_K8S_LOG_TO_FILE" ]; then
 
 	exec 1> >(
 		multilog n2 "$STDOUT_ROTATE_DIR"
-		: >$DET_LOG_WAIT_FIFO
+		printf x >$DET_LOG_WAIT_FIFO
 	) \
 	2> >(
 		multilog n2 "$STDERR_ROTATE_DIR"
-		: >$DET_LOG_WAIT_FIFO
+		printf x  >$DET_LOG_WAIT_FIFO
 	)
 
 	((DET_LOG_WAIT_COUNT += 2))
@@ -62,10 +62,10 @@ fi
 # redirections are applied in reverse order.
 exec > >(
 	stdbuf -o0 tr '\r' '\n'
-	: >$DET_LOG_WAIT_FIFO
+	printf x >$DET_LOG_WAIT_FIFO
 ) 2> >(
 	stdbuf -o0 tr '\r' '\n' >&2
-	: >$DET_LOG_WAIT_FIFO
+	printf x >$DET_LOG_WAIT_FIFO
 )
 
 ((DET_LOG_WAIT_COUNT += 2))

--- a/master/static/srv/task-logging-teardown.sh
+++ b/master/static/srv/task-logging-teardown.sh
@@ -4,7 +4,22 @@
 # command is finished.
 exec >&1- >&2- 1>&$ORIGINAL_STDOUT 2>&$ORIGINAL_STDERR
 
+# We use the bash builtin printf for getting the epoch time in seconds.
+# This requires bash 4.2 (from 2011) and it depends on strftime(3) supporting
+# the %s directive, which is not in posix.
+epoch_seconds () {
+    printf '%(%s)T\n' -1
+}
+
+# Wait for 30 seconds total for the logging to finish, otherwise just exit.
+waitfor="${DET_LOG_WAIT_TIME:-30}"
+deadline="$(($(epoch_seconds) + waitfor))"
 for ((i = 0; i < $DET_LOG_WAIT_COUNT; i++)); do
-	# read returns 1 on EOF, but it's a fifo so that is OK.
-	read <$DET_LOG_WAIT_FIFO || true
+    timeout="$((deadline - $(epoch_seconds)))"
+    test "$timeout" -le 0 && break
+    # read returns 1 on EOF or >128 with timeout, but it's a fifo so that is OK.
+    # For read's -t timeout feature to work, we need to open the fifo for
+    # reading and writing for some reason, which is what the `<>` is for.
+    # See https://stackoverflow.com/a/6448737.
+    read -N 1 -t "$timeout" <>"$DET_LOG_WAIT_FIFO" || true
 done


### PR DESCRIPTION
If the main process exits and the logger is still going after 30
seconds, assumes something is wrong and give up.

The 30 second window is configurabe by setting DET_LOG_WAIT_TIME in the
environment, in case of emergency.

An automated test is included to make sure that we log things after the
main process exits, but not after the DET_LOG_WAIT_TIME is exceeded.
