### PR TITLE
docs: move description of agent client cert fields to the right place

### DIFF
--- a/docs/sysadmin-basics/cluster-config.txt
+++ b/docs/sysadmin-basics/cluster-config.txt
@@ -817,9 +817,6 @@ The master supports the following configuration settings:
                if the certificate is not signed by a well-known CA; cannot be specified if
                ``skip_verify`` is enabled.
 
-            -  ``client_cert``/``client_key``: Paths to files containing the client TLS certificate
-               and key to use when connecting to the master.
-
 -  ``scim``: (EE-only) Specifies whether the SCIM service is enabled and the credentials for clients
    to use it.
 
@@ -919,6 +916,9 @@ The master supports the following configuration settings:
       -  ``master_cert_name``: A hostname for which the master's TLS certificate is valid, if the
          value of the ``master_host`` option is an IP address or is not contained in the
          certificate.
+
+      -  ``client_cert``/``client_key``: Paths to files containing the client TLS certificate and
+         key to use when connecting to the master.
 
 -  ``fluent``: fluentd settings.
       -  ``image``: Docker image to use for the managed Fluent Bit daemon. Defaults to


### PR DESCRIPTION
Accidentally put the new stuff into a different TLS-related section before.