### PR TITLE
fix: stale agent state crashes resource pool [DET-7493]

### DIFF
--- a/master/internal/resourcemanagers/priority.go
+++ b/master/internal/resourcemanagers/priority.go
@@ -358,9 +358,9 @@ func removeTaskFromAgents(
 		// lead to issues in many cases.
 		agentState := agents[allocation.agent.Handler]
 		if agentState == nil {
-			log.Errorf("tried to remove an allocation (containerID: %s) "+
-				"from an agent: (agentID: %+v) but scheduler could not find the agent in the cache",
-				allocation.containerID,
+			log.Errorf("tried to remove an allocation (allocationID: %s containerID: %s) "+
+				"from an agent: (agentID: %+v) but scheduler could not find the agent",
+				allocation.req.AllocationID, allocation.containerID,
 				allocation.agent.Handler.Address().Local(),
 			)
 			continue

--- a/master/internal/resourcemanagers/priority.go
+++ b/master/internal/resourcemanagers/priority.go
@@ -353,7 +353,19 @@ func removeTaskFromAgents(
 ) {
 	for _, allocation := range resourcesAllocated.Resources {
 		allocation := allocation.(*containerResources)
+
+		// TODO properly handle this case since this will likely
+		// lead to issues in many cases.
 		agentState := agents[allocation.agent.Handler]
+		if agentState == nil {
+			log.Errorf("tried to remove an allocation (containerID: %s) "+
+				"from an agent: (agentID: %+v) but scheduler could not find the agent in the cache",
+				allocation.containerID,
+				allocation.agent.Handler.Address().Local(),
+			)
+			continue
+		}
+
 		agentState.DeallocateContainer(allocation.containerID)
 	}
 }


### PR DESCRIPTION
## Description

Band aid fix for resource pool crashing when our local agent state doesn't include an agent that an allocation references.

## Test Plan

Run priority scheduler with preemption enabled 

add this below line 358 in ```master/internal/resourcemanagers/priority.go```
```
		delete(agents, allocation.agent.Handler)
```

then have the scheduler preempt a task and you should see a log along with the resource manager not crashing
```
det e create --config="resources.priority=80" examples/tutorials/mnist_pytorch/const.yaml examples/tutorials/mnist_pytorch/ && sleep 5 && det e create --config="resources.priority=1" examples/tutorials/mnist_pytorch/const.yaml examples/tutorials/mnist_pytorch/
```

## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [X] User-facing API changes need the "User-facing API Change" label.
- [X] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [X] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
