### PR TITLE
ci: remove overzealous assert that can finish after noop trial

### DIFF
--- a/e2e_tests/tests/cluster/test_resource_manager.py
+++ b/e2e_tests/tests/cluster/test_resource_manager.py
@@ -12,7 +12,7 @@ from determined.common.api.bindings import determinedexperimentv1State
 from tests import config as conf
 from tests import experiment as exp
 
-from ..experiment.experiment import determined_test_session, num_active_trials
+from ..experiment.experiment import determined_test_session
 from .test_agent_disable import _wait_for_slots
 
 # How long we should for the Nth = 1 rank to free.
@@ -57,7 +57,6 @@ def test_allocation_resources_incremental_release() -> None:
             determinedexperimentv1State.STATE_ACTIVE,
         )
         exp.wait_for_experiment_active_workload(exp_id)
-        assert num_active_trials(exp_id) == 1
 
         # And wait for exactly one of the resources to free, while one is still in use.
         confirmations = 0


### PR DESCRIPTION
## Description
Disable assert that races with a no op trial completing.
<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At a minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan
- [x] is a test
<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions about this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ