### PR TITLE
chore: FOUNDENG-55 For deepspeed, set the NCCL_SOCKET_IFNAME env variable based on dtrain_network_interface

### DIFF
--- a/harness/determined/launch/deepspeed.py
+++ b/harness/determined/launch/deepspeed.py
@@ -9,6 +9,7 @@ import os
 import pathlib
 import subprocess
 import sys
+import tempfile
 import time
 from typing import List
 
@@ -19,7 +20,53 @@ from determined import constants, util
 from determined.common import api
 from determined.common.api import certs
 
-hostfile_path = "/tmp/hostfile.txt"
+hostfile_path = None
+
+
+def is_using_cuda() -> bool:
+
+    val = os.getenv("CUDA_VISIBLE_DEVICES")
+
+    if val is None or len(val.strip()) == 0:
+        return False
+    else:
+        return True
+
+
+def is_nccl_socket_ifname_env_var_set() -> bool:
+
+    val = os.getenv("NCCL_SOCKET_IFNAME")
+
+    if val is None or len(val.strip()) == 0:
+        return False
+    else:
+        return True
+
+
+def get_hostfile_path() -> str:
+
+    global hostfile_path
+
+    # Ensure that "hostfile_path" is initialized only once. All subsquent calls
+    # will return the same file name.  The production code calls this only once,
+    # but the tests call it multiple times and the tests will fail if a
+    # a different name is returned, because the expected value will not match
+    # the actual value of the command line that the test creates due to the
+    # difference in the file name.
+    if hostfile_path is None:
+        # When the task container uses "/tmp" from the host, having a file with
+        # a well-known name in a world writable directory is not only a security
+        # issue, but it can also cause a user's experiment to fail due to the
+        # file being owned by another user.  Create the file securely with a
+        # random name to avoid file name clashes between two different
+        # experiments.
+        temp_hostfile = tempfile.NamedTemporaryFile(
+            prefix="/tmp/hostfile-", suffix=".txt", delete=False
+        )
+        hostfile_path = temp_hostfile.name
+        temp_hostfile.close()
+
+    return hostfile_path
 
 
 def create_hostlist_file(
@@ -95,7 +142,13 @@ def create_deepspeed_env_file() -> None:
     There are certain variables that we need to be set that we can pass to deepspeed using
     a custom env vars file.
     """
-    INCLUDE = ["PATH", "USE_DEEPSPEED", "DET_CHIEF_IP", "DET_MANUAL_INIT_DISTRIBUTED"]
+    INCLUDE = [
+        "PATH",
+        "LD_LIBRARY_PATH",
+        "USE_DEEPSPEED",
+        "DET_CHIEF_IP",
+        "DET_MANUAL_INIT_DISTRIBUTED",
+    ]
     with open(DEEPSPEED_ENVIRONMENT_NAME, "w") as f:
         environ = os.environ.copy()
         for k, v in environ.items():
@@ -139,6 +192,16 @@ def main(script: List[str]) -> int:
     # Chief IP is set as an environment variable to support nested launch layers
     os.environ["DET_CHIEF_IP"] = chief_ip
 
+    # If the NCCL_SOCKET_IFNAME environment variable wasn't explicitly set by
+    # the user in the experiment's YAML file, then set it to the distributed
+    # network interface, if the value of "dtrain_network_interface" under
+    # "task_container_defaults" has been set in the "master.yaml".
+    if is_using_cuda() and not is_nccl_socket_ifname_env_var_set():
+        dtrain_network_interface = os.environ.get("DET_INTER_NODE_NETWORK_INTERFACE", None)
+
+        if dtrain_network_interface is not None and len(dtrain_network_interface) > 0:
+            os.environ["NCCL_SOCKET_IFNAME"] = dtrain_network_interface
+
     # All ranks will need to run sshd.
     run_sshd_command = create_sshd_cmd()
 
@@ -178,6 +241,8 @@ def main(script: List[str]) -> int:
     #     - harness.py, which actually does the training for the worker
 
     pid_server_cmd = create_pid_server_cmd(info.allocation_id, len(info.slot_ids))
+
+    hostfile_path = get_hostfile_path()
 
     master_address = create_hostlist_file(
         hostfile_path=pathlib.Path(hostfile_path),

--- a/harness/tests/launch/test_deepspeed.py
+++ b/harness/tests/launch/test_deepspeed.py
@@ -57,7 +57,7 @@ def test_launch_multi_slot_chief(
         cluster_info.allocation_id, len(cluster_info.slot_ids)
     )
     deepspeed_cmd = launch.deepspeed.create_run_command(
-        cluster_info.container_addrs[0], launch.deepspeed.hostfile_path
+        cluster_info.container_addrs[0], launch.deepspeed.get_hostfile_path()
     )
     pid_client_cmd = launch.deepspeed.create_pid_client_cmd(cluster_info.allocation_id)
     log_redirect_cmd = launch.deepspeed.create_log_redirect_cmd()
@@ -130,7 +130,7 @@ def test_launch_multi_slot_fail(
         cluster_info.allocation_id, len(cluster_info.slot_ids)
     )
     deepspeed_cmd = launch.deepspeed.create_run_command(
-        cluster_info.container_addrs[0], launch.deepspeed.hostfile_path
+        cluster_info.container_addrs[0], launch.deepspeed.get_hostfile_path()
     )
     pid_client_cmd = launch.deepspeed.create_pid_client_cmd(cluster_info.allocation_id)
     log_redirect_cmd = launch.deepspeed.create_log_redirect_cmd()
@@ -187,7 +187,9 @@ def test_launch_one_slot(
     pid_server_cmd = launch.deepspeed.create_pid_server_cmd(
         cluster_info.allocation_id, len(cluster_info.slot_ids)
     )
-    deepspeed_cmd = launch.deepspeed.create_run_command("localhost", launch.deepspeed.hostfile_path)
+    deepspeed_cmd = launch.deepspeed.create_run_command(
+        "localhost", launch.deepspeed.get_hostfile_path()
+    )
     pid_client_cmd = launch.deepspeed.create_pid_client_cmd(cluster_info.allocation_id)
     log_redirect_cmd = launch.deepspeed.create_log_redirect_cmd()
     launch_cmd = pid_server_cmd + deepspeed_cmd + pid_client_cmd + log_redirect_cmd + script
@@ -212,7 +214,9 @@ def test_launch_fail(mock_cluster_info: mock.MagicMock, mock_subprocess: mock.Ma
     pid_server_cmd = launch.deepspeed.create_pid_server_cmd(
         cluster_info.allocation_id, len(cluster_info.slot_ids)
     )
-    deepspeed_cmd = launch.deepspeed.create_run_command("localhost", launch.deepspeed.hostfile_path)
+    deepspeed_cmd = launch.deepspeed.create_run_command(
+        "localhost", launch.deepspeed.get_hostfile_path()
+    )
     pid_client_cmd = launch.deepspeed.create_pid_client_cmd(cluster_info.allocation_id)
     log_redirect_cmd = launch.deepspeed.create_log_redirect_cmd()
     launch_cmd = pid_server_cmd + deepspeed_cmd + pid_client_cmd + log_redirect_cmd + script


### PR DESCRIPTION
## Description

There are 3 issues being addressed in this PR.

The first issue is that the "LD_LIBRARY_PATH" variable was not in the INCLUDE list of environment variables that needed to be passed to deepspeed, so the experiment failed with the following error, because the CUDA libraries could not be found.

```
[rank=0] RuntimeError: ProcessGroupNCCL is only supported with GPUs, no GPUs found!
```

The second issue is that the "/tmp/hostfile.txt" is being written to a shared "/tmp" directory, so all users write to the same file.   If the file already exists and is owned by another user, it will fail to be created by the current user.  It is also a security issue to write to well-known file names in a world-writable directory, such as "/tmp", because it's vulnerable to a symlink attack.

The third issue is that the NCCL library was picking the wrong interface.  The details are as follows:

On the "horizon" cluster, which does not have Infiniband (has the Gemini Fabric (IPoGIF) module), the Nvidia NCCL code is picking up the wrong interface.  It is picking "rsip", which has a "172.x.x.x" address, instead of "ipogif0", which has a "10.x.x.x" address.

```
nid00153:~ # ifconfig -a
ipogif0: flags=193<UP,RUNNING,NOARP>  mtu 65520
        inet 10.128.0.154  netmask 255.252.0.0
        ether 00:01:01:00:00:99  txqueuelen 1000  (Ethernet)
        RX packets 225854  bytes 1042470410 (994.1 MiB)
        RX errors 0  dropped 0  overruns 0  frame 0
        TX packets 231281  bytes 1038038963 (989.9 MiB)
        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0

lo: flags=73<UP,LOOPBACK,RUNNING>  mtu 65536
        inet 127.0.0.1  netmask 255.0.0.0
        loop  txqueuelen 1000  (Local Loopback)
        RX packets 539451  bytes 29386310 (28.0 MiB)
        RX errors 0  dropped 0  overruns 0  frame 0
        TX packets 539451  bytes 29386310 (28.0 MiB)
        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0

rsip: flags=209<UP,POINTOPOINT,RUNNING,NOARP>  mtu 1520
        inet 172.30.48.181  netmask 255.255.255.255  destination 172.30.48.181
        tunnel   txqueuelen 1000  (IPIP Tunnel)
        RX packets 18378  bytes 20327676 (19.3 MiB)
        RX errors 0  dropped 0  overruns 0  frame 0
        TX packets 16270  bytes 1448965 (1.3 MiB)
        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0

tunl0: flags=128<NOARP>  mtu 1480
        tunnel   txqueuelen 1000  (IPIP Tunnel)
        RX packets 0  bytes 0 (0.0 B)
        RX errors 0  dropped 0  overruns 0  frame 0
        TX packets 0  bytes 0 (0.0 B)
        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0
```

As a result, the experiment fails because the workers cannot communicate with the chief over the "172.x.x.x" address.

```
corujor@horizon:~> grep 181 /home/users/launcher/.capsules/dispatcher/environments/corujor/f56e0a24780b4d3e-95d673d2c3e54aad/ai_exp-761-trial-738-output.log
[rank=1] nid00154:32841:32841 [0] NCCL INFO NET/Socket : Using [0]ipogif0:10.128.0.155<0> [1]rsip:172.30.48.181<0>
[rank=0] nid00153:3063:3063 [0] NCCL INFO NET/Socket : Using [0]ipogif0:10.128.0.154<0> [1]rsip:172.30.48.181<0>
[rank=1] nid00154:32841:32964 [0] include/socket.h:409 NCCL WARN Net : Connect to 172.30.48.181<46127> failed : Connection refused
[rank=0] nid00153:3063:3189 [0] include/socket.h:409 NCCL WARN Net : Connect to 172.30.48.181<37161> failed : Connection refused
```

The user does have the ability to set the distributed training network interface in the "master.yaml".

```
        task_container_defaults:
          #  shm_size_bytes: 4294967296
          #  network_mode: bridge
          dtrain_network_interface: ipogif0
          #  nccl_port_range: <MIN:MAX>
          #  gloo_port_range: <MIN:MAX>
```

However, unlike Horovod, which gets passed the distributed training network interface as a parameter (see below), "deepspeed.py" does not.

```
hvd_cmd = horovod.create_run_command(
        num_proc_per_machine=len(info.slot_ids),
        ip_addresses=info.container_addrs,
        inter_node_network_interface=info.trial._inter_node_network_interface,
        optimizations=experiment_config["optimizations"],
        debug=debug,
        optional_args=hvd_optional_args,
    )
```

We had originally modified "deepspeed.py" in the "dispatcher" branch to automatically pick the network interface that is used to connect to the chief's IP addresss and set NCCL_SOCKET_IFNAME to that interface (see Pull Request https://github.com/determined-ai/determined-ee/pull/227).

However, Bradley found that the Nvidia NCCL code favors Infiniband.

https://github.com/NVIDIA/nccl/blob/2dfd83752cc17e7962fb2842c44bfcc0216c8b40/src/misc/socket.cc#L289-L302

```
    // Try to automatically pick the right one
    // Start with IB
    nIfs = findInterfaces("ib", ifNames, ifAddrs, sock_family, ifNameMaxSize, maxIfs);
    // else see if we can get some hint from COMM ID
    if (nIfs == 0) {
```

Therefore, we should probably not try to autodetect it ourselves, even though on the "horizon" cluster, which does not have Infiniband, the NCCL code picks the wrong interface.

Instead, let's address the issue where the "dtrain_network_interface", which can be specified by the user in the "master.yaml", is not being used by deepspeed to set the NCCL_SOCKET_IFNAME.

## Test Plan

Tested on the "horizon" cluster:

* Not setting dtrain_network_interface or the NCCL_SOCKET_IFNAME environment variable results in the NCCL code picking the wrong network interface, so the test fails.
* Setting dtrain_network_interface in "master.yaml" to the correct network interface results in the experiment running successfully.
* Not setting dtrain_network_interface in "master.yaml", but setting the NCCL_SOCKET_IFNAME environment variable in the experiment's YAML file to the correct network interface, results in the experiment running successfully.

## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
