### PR TITLE
chore: cleanup container terminations resent on agent exit [DET-7533]

### DIFF
--- a/agent/internal/agent.go
+++ b/agent/internal/agent.go
@@ -119,7 +119,6 @@ func (a *agent) Receive(ctx *actor.Context) error {
 		switch msg.Child {
 		case a.socket:
 			if a.attemptReconnect(ctx) {
-				ctx.Tell(a.cm, requestResendRecentExits{})
 				return nil
 			}
 			ctx.Log().Warn("master socket disconnected, shutting down agent...")

--- a/e2e_tests/tests/experiment/test_launch.py
+++ b/e2e_tests/tests/experiment/test_launch.py
@@ -52,5 +52,5 @@ def test_launch_layer_exit(collect_trial_profiles: Callable[[int], None]) -> Non
     collect_trial_profiles(trials[0].trial.id)
 
     assert exp.check_if_string_present_in_trial_logs(
-        trials[0].trial.id, "allocation failed with non-zero exit code: 1"
+        trials[0].trial.id, "container failed with non-zero exit code: 1"
     )

--- a/master/internal/resourcemanagers/agent/agent.go
+++ b/master/internal/resourcemanagers/agent/agent.go
@@ -567,18 +567,39 @@ func (a *agent) handleContainersReattached(
 		a.address, agentStarted.ContainersReattached, maps.Keys(a.agentState.containerState))
 
 	recovered := map[cproto.ID]aproto.ContainerReattachAck{}
+	doomed := map[cproto.ID]aproto.ContainerReattachAck{}
 
 	for _, containerRestored := range agentStarted.ContainersReattached {
-		if containerRestored.Failure != nil {
+		cid := containerRestored.Container.ID
+		if containerRestored.Failure != nil &&
+			containerRestored.Failure.FailureType == aproto.RestoreError {
 			ctx.Log().Infof(
-				"agent failed to restore container: %v: %v",
-				containerRestored.Container.ID, containerRestored.Failure.ErrMsg)
+				"agent failed to restore container: %s: %s",
+				cid, containerRestored.Failure.ErrMsg)
+			doomed[cid] = containerRestored
 			continue
 		}
 
-		cid := containerRestored.Container.ID
+		if containerRestored.Failure != nil {
+			ctx.Log().Infof(
+				"reattached container %s terminated while away: %s",
+				cid, containerRestored.Failure.ErrMsg)
+			doomed[cid] = containerRestored
+			continue
+		}
+
+		if containerRestored.Container.State == cproto.Terminated {
+			ctx.Log().Warnf(
+				"reattached container %s terminated while away", cid)
+			doomed[cid] = containerRestored
+			continue
+		}
+
 		_, ok := a.agentState.containerAllocation[cid]
 		if !ok {
+			ctx.Log().Warnf(
+				"agent state is missing container %s on reattach", cid)
+			doomed[cid] = containerRestored
 			continue
 		}
 
@@ -587,6 +608,7 @@ func (a *agent) handleContainersReattached(
 				"reattached container %s has changed state: %s to %s",
 				cid, a.agentState.containerState[cid].State,
 				containerRestored.Container.State)
+			doomed[cid] = containerRestored
 			continue
 		}
 
@@ -594,45 +616,56 @@ func (a *agent) handleContainersReattached(
 	}
 
 	// Mark the rest as dead.
-	return a.clearNonReattachedContainers(ctx, recovered)
+	return a.clearNonReattachedContainers(ctx, recovered, doomed)
 }
 
 func (a *agent) clearNonReattachedContainers(
-	ctx *actor.Context, recovered map[cproto.ID]aproto.ContainerReattachAck) error {
+	ctx *actor.Context,
+	recovered map[cproto.ID]aproto.ContainerReattachAck,
+	explicitlyDoomed map[cproto.ID]aproto.ContainerReattachAck,
+) error {
 	for cid, allocation := range a.agentState.containerAllocation {
-		_, ok := recovered[cid]
+		if _, ok := recovered[cid]; ok {
+			continue
+		}
 
-		if !ok {
-			errorMsg := "container cleaned up on reconnect"
-			if a.agentReattachEnabled {
-				errorMsg = "failed to reattach container on reconnect"
+		resp := ctx.Ask(allocation, sproto.GetResourcesContainerState{
+			ResourcesID: sproto.ResourcesID(cid),
+		})
+		switch {
+		case resp.Error() != nil:
+			ctx.Log().Warnf(
+				"allocation GetTaskContainerState id: %s, got error: %s", cid, resp.Error())
+		case resp.Get() == nil:
+			ctx.Log().Warnf("allocation GetTaskContainerState id: %s, is nil", cid)
+		default:
+			containerState := resp.Get().(cproto.Container)
+			containerState.State = cproto.Terminated
+
+			var stopped aproto.ContainerStopped
+			ack, ok := explicitlyDoomed[cid]
+			if ok {
+				stopped = aproto.ContainerStopped{Failure: ack.Failure}
+			} else {
+				stopped = a.defaultReattachFailureMessage()
 			}
 
-			stopped := aproto.ContainerError(aproto.AgentFailed, errors.New(errorMsg))
-			ctx.Log().Infof("killing container that didn't restore: %s", cid.String())
-
-			resp := ctx.Ask(allocation, sproto.GetResourcesContainerState{
-				ResourcesID: sproto.ResourcesID(cid),
+			a.containerStateChanged(ctx, aproto.ContainerStateChanged{
+				Container:        containerState,
+				ContainerStopped: &stopped,
 			})
-			switch {
-			case resp.Error() != nil:
-				ctx.Log().Warnf(
-					"allocation GetTaskContainerState id: %s, got error: %s", cid, resp.Error())
-			case resp.Get() == nil:
-				ctx.Log().Warnf("allocation GetTaskContainerState id: %s, is nil", cid)
-			default:
-				containerState := resp.Get().(cproto.Container)
-				containerState.State = cproto.Terminated
-
-				a.containerStateChanged(ctx, aproto.ContainerStateChanged{
-					Container:        containerState,
-					ContainerStopped: &stopped,
-				})
-			}
 		}
 	}
 
 	return a.agentState.clearUnlessRecovered(recovered)
+}
+
+func (a *agent) defaultReattachFailureMessage() aproto.ContainerStopped {
+	errorMsg := "container cleaned up on reconnect"
+	if a.agentReattachEnabled {
+		errorMsg = "failed to reattach container on reconnect"
+	}
+	return aproto.ContainerError(aproto.AgentFailed, errors.New(errorMsg))
 }
 
 func (a *agent) socketDisconnected(ctx *actor.Context) {

--- a/master/internal/resourcemanagers/resource_pool.go
+++ b/master/internal/resourcemanagers/resource_pool.go
@@ -330,7 +330,9 @@ func (rp *ResourcePool) resourcesReleased(
 	case a == nil:
 		rp.taskList.RemoveTaskByHandler(msg.TaskActor)
 	case msg.ResourcesID != nil:
-		ctx.Log().Infof("resource %v is released for %s", msg.ResourcesID, msg.TaskActor.Address())
+		ctx.Log().Infof(
+			"resources %v are released for %s",
+			*msg.ResourcesID, msg.TaskActor.Address())
 		for rID, r := range a.Resources {
 			if r.Summary().ResourcesID != *msg.ResourcesID {
 				continue

--- a/master/internal/sproto/resources.go
+++ b/master/internal/sproto/resources.go
@@ -228,6 +228,8 @@ func FromContainerFailureType(t aproto.FailureType) FailureType {
 		return AgentFailed
 	case aproto.AgentError:
 		return AgentError
+	case aproto.RestoreError:
+		return RestoreError
 	default:
 		return FailureType(fmt.Sprintf(UnknownError, t))
 	}

--- a/master/internal/task/allocation.go
+++ b/master/internal/task/allocation.go
@@ -534,8 +534,8 @@ func (a *Allocation) ResourcesStateChanged(
 	}
 
 	a.resources[msg.ResourcesID].container = msg.Container
-	ctx.Log().Debugf("resources %s (rank %d) is %s [container=%v]",
-		msg.ResourcesID, a.resources[msg.ResourcesID].Rank, msg.ResourcesState, msg.Container,
+	ctx.Log().Debugf("resources %v are %s [rank=%d, container=%+v]",
+		msg.ResourcesID, msg.ResourcesState, a.resources[msg.ResourcesID].Rank, msg.Container,
 	)
 	switch msg.ResourcesState {
 	case sproto.Pulling:

--- a/master/pkg/aproto/exit.go
+++ b/master/pkg/aproto/exit.go
@@ -68,10 +68,10 @@ type FailureType string
 
 const (
 	// ContainerFailed denotes that the container ran but failed with a non-zero exit code.
-	ContainerFailed FailureType = "allocation failed with non-zero exit code"
+	ContainerFailed FailureType = "container failed with non-zero exit code"
 
 	// ContainerAborted denotes the container was canceled before it was started.
-	ContainerAborted FailureType = "allocation was aborted before it started"
+	ContainerAborted FailureType = "container was aborted before it started"
 
 	// ContainerMissing denotes the container was missing when the master asked about it.
 	ContainerMissing FailureType = "request for action on unknown container"
@@ -85,28 +85,9 @@ const (
 	// AgentFailed denotes that the agent failed while the container was running.
 	AgentFailed FailureType = "agent failed while the container was running"
 
+	// RestoreError denotes that we failed to restore the container after some agent failure.
+	RestoreError FailureType = "container failed to restore after agent failure"
+
 	// AgentError denotes that the agent failed to launch the container.
 	AgentError FailureType = "agent failed to launch the container"
 )
-
-// IsRestartableSystemError checks if the error is caused by the system and
-// shouldn't count against `max_restarts`.
-func IsRestartableSystemError(err error) bool {
-	switch contErr := err.(type) {
-	case ContainerFailure:
-		switch contErr.FailureType {
-		case ContainerFailed, TaskError:
-			return false
-		// Questionable, could be considered failures, but for now we don't.
-		case AgentError, AgentFailed:
-			return true
-		// Definitely not a failure.
-		case TaskAborted, ContainerAborted:
-			return true
-		default:
-			return false
-		}
-	default:
-		return false
-	}
-}


### PR DESCRIPTION
## Description
Original I just chunked the extra exits over the wall on reconnect and made exits idempotent. This "technically worked" because allocations ignored all but the first exit but printed really weird/misleading logs, so this change works resending terminations into the revalidate path instead.
<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At a minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan
- [x] test with toxiproxy, will follow up with e2es for this code
<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions about this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)
Need to also do this for the reattach path, I think.
<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ