### PR TITLE
docs: more consistently use Determined AI vs. Determined

### DIFF
--- a/docs/concepts/index.txt
+++ b/docs/concepts/index.txt
@@ -6,9 +6,9 @@
 
 Deep learning practitioners come from a variety of disciplines. Depending on their background, some
 practitioners have strong foundations in engineering, while others focus on statistics and domain
-expertise. Determined AI is a deep learning training platform that simplifies infrastructure
-management for domain experts while enabling configuration-based deep learning functionality that is
-generally inconvenient to implement for engineering-oriented practitioners.
+expertise. Determined is a deep learning training platform that simplifies infrastructure management
+for domain experts while enabling configuration-based deep learning functionality that is generally
+inconvenient to implement for engineering-oriented practitioners.
 
 Many current systems are point solutions for specific problems in deep learning, so combining the
 systems is tough and inefficient. Determined's cohesive end-to-end training platform provides

--- a/docs/index.txt
+++ b/docs/index.txt
@@ -69,22 +69,22 @@
    attributions
    release-notes
 
-###############
- Determined AI
-###############
+############
+ Determined
+############
 
 |h3| *Welcome to Determined!*
 
-************************
- What is Determined AI?
-************************
+*********************
+ What is Determined?
+*********************
 
 Determined is an open source deep learning training platform that makes building models fast and
 easy.
 
-********************
- Why Determined AI?
-********************
+*****************
+ Why Determined?
+*****************
 
 With Determined you can:
 


### PR DESCRIPTION
## Description

To aid automated rebranding, strengthen the pattern of using
"Determined" to refer to the product and "Determined AI" to refer to the
related business entity.