### PR TITLE
ci: add dependabot for all the things

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,128 @@
+---
+version: 2
+updates:
+
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 10
+    reviewers:
+      - determined-ai/infrastructure
+
+  # Maintain dependencies for leader Docker
+  - package-ecosystem: docker
+    directory: /master
+    schedule:
+      interval: daily
+    # reviewers:
+    #   - determined-ai/someteam
+
+  # Maintain dependencies for agent Docker
+  - package-ecosystem: docker
+    directory: /agent
+    schedule:
+      interval: daily
+    # reviewers:
+    #   - determined-ai/someteam
+
+  # Maintain dependencies for leader Golang
+  - package-ecosystem: gomod
+    directory: /master
+    schedule:
+      interval: daily
+    # reviewers:
+    #   - determined-ai/someteam
+
+  # Maintain dependencies for agent Golang
+  - package-ecosystem: gomod
+    directory: /agent
+    schedule:
+      interval: daily
+    # reviewers:
+    #   - determined-ai/someteam
+
+  # Maintain prod dependencies for WebUI
+  - package-ecosystem: npm
+    directory: /webui/react/
+    schedule:
+      interval: daily
+    allow:
+      # Leave the dev dependencies alone
+      - dependency-type: production
+      # Allow updates for React and any packages starting with "react"
+      #   - dependency-name: "react*"
+    # reviewers:
+    #   - determined-ai/someteam
+
+  # Maintain dev verion dependencies for WebUI monthly
+  - package-ecosystem: npm
+    directory: /webui/react/
+    target-branch: master  # trick dependabot into thinking this is different
+    schedule:
+      interval: monthly  # security checks still happen daily
+    allow:
+      - dependency-type: development
+    labels:
+      - dependencies
+      - javascript
+      - web development env
+    # reviewers:
+    #   - determined-ai/someteam
+
+  # Maintain python dependencies for main product
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: daily
+    # reviewers:
+    #   - determined-ai/someteam
+
+  # Maintain python dependencies for examples
+  - package-ecosystem: pip
+    directory: /examples/tests
+    schedule:
+      interval: daily
+    # reviewers:
+    #   - determined-ai/someteam
+
+  # Maintain python dependencies for Model Hub
+  - package-ecosystem: pip
+    directory: /model-hub/tests
+    schedule:
+      interval: daily
+    # reviewers:
+    #   - determined-ai/someteam
+
+  # Maintain python dependencies for docs
+  - package-ecosystem: pip
+    directory: /docs
+    schedule:
+      interval: daily
+    # reviewers:
+    #   - determined-ai/someteam
+
+  # Maintain python dependencies for end-to-end tests
+  - package-ecosystem: pip
+    directory: /e2e_tests/tests
+    schedule:
+      interval: daily
+    # reviewers:
+    #   - determined-ai/someteam
+
+  # Maintain python dependencies for harness tests
+  - package-ecosystem: pip
+    directory: /harness/tests/requirements/requirements-harness.txt
+    schedule:
+      interval: daily
+    # reviewers:
+    #   - determined-ai/someteam
+
+  # Maintain python dependencies for harness tests
+  - package-ecosystem: pip
+    directory: /harness/tests/requirements/requirements-cli.txt
+    schedule:
+      interval: daily
+    # reviewers:
+    #   - determined-ai/someteam


### PR DESCRIPTION
## Description

Enable Dependabot version updates for the various sub-projects within the repo.


## Test Plan

Watch dozens of PRs start opening up.
(Effect was pre-tested on my personal fork - https://github.com/dannysauer/determined.ai_determined/pulls)


## Commentary (optional)

This is going to open a lot of PRs, many of which are version bumps that do not have immediate security implications.  By default, it will open no more than five at a time for each package manager type and sub-project (there's an additional limit of ten at a time for security-specific dependencies).  They will all have the dependabot label, making them relatively easy to sort, and will include the path to the sub-project to which they apply.  The web environment PRs will get an additional label assigned to distinguish those which are version bumps in the web dev environment v/s the prod web site.


## Checklist

- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.