### PR TITLE
feat: shm_size can take a string with units like docker run allows

### DIFF
--- a/docs/features/command-notebook-config.txt
+++ b/docs/features/command-notebook-config.txt
@@ -95,9 +95,10 @@ The following configuration settings are supported:
       agents. An agent's label can be configured via the ``label`` field in the :ref:`agent
       configuration <agent-configuration>`.
 
-   -  ``shm_size``: The size in bytes of ``/dev/shm`` for task containers. Defaults to
-      ``4294967296`` (4GiB). If set, this value overrides the value specified in the :ref:`master
-      configuration <master-configuration>`.
+   -  ``shm_size``: The size in ``<number><unit>`` (examples ``1.5 G``, ``128 MiB``, ``1000`` will
+      be 1000 bytes) of ``/dev/shm`` for task containers. Defaults to ``4294967296`` (4GiB). If set,
+      this value overrides the value specified in the :ref:`master configuration
+      <master-configuration>`.
 
    -  ``priority``: The priority assigned to this task. Tasks with smaller priority values are
       scheduled before tasks with higher priority values. Only applicable when using the

--- a/docs/release-notes/shm-size-str.txt
+++ b/docs/release-notes/shm-size-str.txt
@@ -1,0 +1,6 @@
+:orphan:
+
+**Improvements**
+
+-  Configuration: Experiment configuration`resources.shm_size`` now supports passing in a unit like
+   ``4.5 G`` or ``128MiB``.

--- a/docs/training-apis/experiment-config.txt
+++ b/docs/training-apis/experiment-config.txt
@@ -928,9 +928,9 @@ The ``resources`` section defines the resources that an experiment is allowed to
    <weight>``. The default weight is ``1``.
 
 ``shm_size``
-   The size in bytes of ``/dev/shm`` for trial containers. Defaults to ``4294967296`` (4GiB). If
-   set, this value overrides the value specified in the :ref:`master configuration
-   <master-configuration>`.
+   The size in ``<number><unit>`` (examples ``1.5 G``, ``128 MiB``, ``1000`` will be 1000 bytes) of
+   ``/dev/shm`` for trial containers. Defaults to ``4294967296`` (4GiB). If set, this value
+   overrides the value specified in the :ref:`master configuration <master-configuration>`.
 
 ``priority``
    The priority assigned to this experiment. Only applicable when using the ``priority`` scheduler.

--- a/e2e_tests/tests/command/test_run.py
+++ b/e2e_tests/tests/command/test_run.py
@@ -265,6 +265,40 @@ def test_environment_variables_command() -> None:
     )
 
 
+@pytest.mark.parametrize("actual,expected", [("24576", "24K"), ("1.5g", "1.5G")])
+@pytest.mark.parametrize("use_config_file", [True, False])
+@pytest.mark.slow
+@pytest.mark.e2e_cpu
+def test_shm_size_command(
+    tmp_path: Path, actual: str, expected: str, use_config_file: bool
+) -> None:
+    with FileTree(
+        tmp_path,
+        {
+            "config.yaml": f"""
+resources:
+  shm_size: {actual}
+"""
+        },
+    ) as tree:
+        config_path = tree.joinpath("config.yaml")
+        cmd = ["det", "-m", conf.make_master_url(), "cmd", "run"]
+        if use_config_file:
+            cmd += ["--config-file", str(config_path)]
+        else:
+            cmd += ["--config", f"resources.shm_size={actual}"]
+        cmd += [
+            f"""echo '' > /dev/shm/test && \
+df -h /dev/shm && \
+df -h /dev/shm | \
+tail -1 | \
+[ $(awk '{{print $2}}') != '{expected}' ] && \
+exit 1 || \
+exit 0"""
+        ]
+        _run_and_verify_exit_code_zero(cmd)
+
+
 @pytest.mark.slow
 @pytest.mark.e2e_cpu
 def test_absolute_bind_mount(tmp_path: Path) -> None:

--- a/harness/determined/common/schemas/expconf/_gen.py
+++ b/harness/determined/common/schemas/expconf/_gen.py
@@ -935,25 +935,6 @@ schemas = {
                 "type": "string"
             }
         },
-        "shm_size": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "checks": {
-                "must be a valid memory size": {
-                    "pattern": "^([0-9]*[.])?[0-9]+ ?[kmgtpKMGTP]?[iI]?[bB]?$"
-                }
-            },
-            "default": null
-        },
-        "ipc": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "default": null
-        },
         "pod_spec": {
             "type": [
                 "object",
@@ -2063,8 +2044,14 @@ schemas = {
         "shm_size": {
             "type": [
                 "integer",
+                "string",
                 "null"
             ],
+            "checks": {
+                "must be a valid memory size": {
+                    "pattern": "^([0-9]*[.])?[0-9]+ ?[kmgtpKMGTP]?[iI]?[bB]?$"
+                }
+            },
             "default": null
         },
         "slots": {

--- a/harness/determined/common/schemas/expconf/_gen.py
+++ b/harness/determined/common/schemas/expconf/_gen.py
@@ -935,6 +935,25 @@ schemas = {
                 "type": "string"
             }
         },
+        "shm_size": {
+            "type": [
+                "string",
+                "null"
+            ],
+            "checks": {
+                "must be a valid memory size": {
+                    "pattern": "^([0-9]*[.])?[0-9]+ ?[kmgtpKMGTP]?[iI]?[bB]?$"
+                }
+            },
+            "default": null
+        },
+        "ipc": {
+            "type": [
+                "string",
+                "null"
+            ],
+            "default": null
+        },
         "pod_spec": {
             "type": [
                 "object",

--- a/master/go.mod
+++ b/master/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/determined-ai/determined/proto v0.0.0-00010101000000-000000000000
 	github.com/docker/docker v20.10.12+incompatible
 	github.com/docker/go-connections v0.4.0
-	github.com/docker/go-units v0.4.0 // indirect
+	github.com/docker/go-units v0.4.0
 	github.com/dustinkirkland/golang-petname v0.0.0-20191129215211-8e5a1ed0cff0
 	github.com/elastic/go-elasticsearch/v7 v7.9.0
 	github.com/emirpasic/gods v1.12.0

--- a/master/pkg/model/compat.go
+++ b/master/pkg/model/compat.go
@@ -26,13 +26,18 @@ func (d DevicesConfig) ToExpconf() expconf.DevicesConfig {
 
 // ToExpconf translates old model objects into an expconf object.
 func (r ResourcesConfig) ToExpconf() expconf.ResourcesConfig {
+	var shm *int
+	if r.ShmSize != nil {
+		shm = ptrs.Ptr(int(*r.ShmSize))
+	}
+
 	return schemas.WithDefaults(expconf.ResourcesConfig{
 		RawSlots:          ptrs.Ptr(r.Slots),
 		RawMaxSlots:       r.MaxSlots,
 		RawSlotsPerTrial:  ptrs.Ptr(1),
 		RawWeight:         ptrs.Ptr(r.Weight),
 		RawNativeParallel: ptrs.Ptr(r.NativeParallel),
-		RawShmSize:        r.ShmSize,
+		RawShmSize:        shm,
 		RawAgentLabel:     ptrs.Ptr(r.AgentLabel),
 		RawResourcePool:   ptrs.Ptr(r.ResourcePool),
 		RawPriority:       r.Priority,

--- a/master/pkg/model/experiment_config.go
+++ b/master/pkg/model/experiment_config.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/pkg/errors"
 
+	"github.com/docker/go-units"
+
 	"github.com/ghodss/yaml"
 
 	"github.com/determined-ai/determined/master/pkg/check"
@@ -64,15 +66,42 @@ func (d *DeviceConfig) UnmarshalJSON(data []byte) error {
 type ResourcesConfig struct {
 	Slots int `json:"slots"`
 
-	MaxSlots       *int    `json:"max_slots,omitempty"`
-	Weight         float64 `json:"weight"`
-	NativeParallel bool    `json:"native_parallel,omitempty"`
-	ShmSize        *int    `json:"shm_size,omitempty"`
-	AgentLabel     string  `json:"agent_label"`
-	ResourcePool   string  `json:"resource_pool"`
-	Priority       *int    `json:"priority,omitempty"`
+	MaxSlots       *int         `json:"max_slots,omitempty"`
+	Weight         float64      `json:"weight"`
+	NativeParallel bool         `json:"native_parallel,omitempty"`
+	ShmSize        *StorageSize `json:"shm_size,omitempty"`
+	AgentLabel     string       `json:"agent_label"`
+	ResourcePool   string       `json:"resource_pool"`
+	Priority       *int         `json:"priority,omitempty"`
 
 	Devices DevicesConfig `json:"devices"`
+}
+
+// StorageSize is a named type for custom marshaling behavior for shm_size.
+type StorageSize int64
+
+// UnmarshalJSON implements the json.Unmarshaler interface.
+func (d *StorageSize) UnmarshalJSON(data []byte) error {
+	// Passed in as an int (for backwards compatibility)?
+	type DefaultParser *StorageSize
+	if err := json.Unmarshal(data, DefaultParser(d)); err == nil {
+		return nil
+	} else if _, ok := err.(*json.UnmarshalTypeError); !ok {
+		return err
+	}
+
+	// Passed in as a string?
+	var s string
+	if err := json.Unmarshal(data, &s); err != nil {
+		return err
+	}
+
+	b, err := units.RAMInBytes(s)
+	if err != nil {
+		return errors.Wrap(err, "shm_size not a valid size")
+	}
+	*d = StorageSize(b)
+	return nil
 }
 
 // ParseJustResources is a helper function for breaking the circular dependency where we need the
@@ -117,7 +146,6 @@ func (r ResourcesConfig) Validate() []error {
 	errs := []error{
 		check.GreaterThanOrEqualTo(r.Slots, 0, "slots must be >= 0"),
 		check.GreaterThan(r.Weight, float64(0), "weight must be > 0"),
-		check.GreaterThanOrEqualTo(r.ShmSize, 0, "shm_size must be >= 0"),
 	}
 	errs = append(errs, ValidatePrioritySetting(r.Priority)...)
 	return errs

--- a/master/pkg/model/experiment_config.go
+++ b/master/pkg/model/experiment_config.go
@@ -95,7 +95,6 @@ func (d *StorageSize) UnmarshalJSON(data []byte) error {
 	if err := json.Unmarshal(data, &s); err != nil {
 		return err
 	}
-
 	b, err := units.RAMInBytes(s)
 	if err != nil {
 		return errors.Wrap(err, "shm_size not a valid size")

--- a/master/pkg/schemas/zgen_schemas.go
+++ b/master/pkg/schemas/zgen_schemas.go
@@ -1907,8 +1907,14 @@ var (
         "shm_size": {
             "type": [
                 "integer",
+                "string",
                 "null"
             ],
+            "checks": {
+                "must be a valid memory size": {
+                    "pattern": "^([0-9]*[.])?[0-9]+ ?[kmgtpKMGTP]?[iI]?[bB]?$"
+                }
+            },
             "default": null
         },
         "slots": {

--- a/schemas/expconf/v0/resources.json
+++ b/schemas/expconf/v0/resources.json
@@ -54,8 +54,14 @@
         "shm_size": {
             "type": [
                 "integer",
+                "string",
                 "null"
             ],
+            "checks": {
+                "must be a valid memory size": {
+                    "pattern": "^([0-9]*[.])?[0-9]+ ?[kmgtpKMGTP]?[iI]?[bB]?$"
+                }
+            },
             "default": null
         },
         "slots": {

--- a/schemas/test_cases/v0/misc.yaml
+++ b/schemas/test_cases/v0/misc.yaml
@@ -335,3 +335,34 @@
     bucket: determined-cp
     prefix: "this/is/a/prefix/.."
     
+- name: shm size valid 1.5 gb
+  complete_as:
+    - http://determined.ai/schemas/expconf/v0/resources.json
+  case:
+    shm_size: 1.5 gb
+
+- name: shm size valid 1 (omitting bytes)
+  complete_as:
+    - http://determined.ai/schemas/expconf/v0/resources.json
+  case:
+    shm_size: 1
+
+- name: shm size valid 1219021b
+  complete_as:
+    - http://determined.ai/schemas/expconf/v0/resources.json
+  case:
+    shm_size: 1219021b
+
+- name: shm size invalid giga
+  sanity_errors:
+    http://determined.ai/schemas/expconf/v0/resources.json:
+      - "<config>.shm_size: must be a valid memory size"  
+  case:
+    shm_size: giga
+    
+- name: shm size invalid 1.gb
+  sanity_errors:
+    http://determined.ai/schemas/expconf/v0/resources.json:
+      - "<config>.shm_size: must be a valid memory size"  
+  case:
+    shm_size: 1.gb


### PR DESCRIPTION
## Description

Allows shm_size to have the same options passed to it as ```docker run --shm-size``` does.

## Test Plan

e2e tests.

## Commentary (optional)

This change currently does not affect ```task_container_defaults.shm_size_bytes```. It feels a little awkward to also allow a string to be passed for ```shm_size_bytes``` due to the ending ```_bytes``` somewhat already specifying it. Not sure if it makes sense to add a field ```shm_size``` or allow ```shm_size_bytes``` to take both. Or if we should just leave that decision to next time breaking changes happen to config. 

## Checklist

- [X] User-facing API changes need the "User-facing API Change" label.
- [X] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [X] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
