### PR TITLE
fix: provide unique port offsets to trials

### DIFF
--- a/master/internal/resourcemanagers/resource_pool.go
+++ b/master/internal/resourcemanagers/resource_pool.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
+	"strconv"
 
 	"golang.org/x/exp/maps"
 
@@ -811,6 +812,8 @@ func (c containerResources) Start(
 	spec.ExtraEnvVars[sproto.ResourcesTypeEnvVar] = string(sproto.ResourcesTypeDockerContainer)
 	spec.UseHostMode = rri.IsMultiAgent
 	spec.Devices = c.devices
+	// Write the real DET_UNIQUE_PORT_OFFSET value now that we know which devices to use.
+	spec.ExtraEnvVars["DET_UNIQUE_PORT_OFFSET"] = strconv.Itoa(tasks.UniquePortOffset(spec.Devices))
 	return ctx.Ask(handler, sproto.StartTaskContainer{
 		TaskActor: c.req.TaskActor,
 		StartContainer: aproto.StartContainer{

--- a/master/pkg/tasks/ports.go
+++ b/master/pkg/tasks/ports.go
@@ -13,9 +13,9 @@ const (
 	hostMode container.NetworkMode = "host"
 )
 
-// trialUniquePortOffset determines a deterministic, unique offset for ports that would otherwise
-// collide when using host networking.
-func trialUniquePortOffset(devices []device.Device) int {
+// UniquePortOffset determines a deterministic, unique offset for ports that would otherwise collide
+// when using host networking.
+func UniquePortOffset(devices []device.Device) int {
 	if len(devices) == 0 {
 		return 0
 	}

--- a/master/pkg/tasks/task_trial.go
+++ b/master/pkg/tasks/task_trial.go
@@ -100,15 +100,18 @@ func (s TrialSpec) ToTaskSpec(keys *ssh.PrivateAndPublicKeys) TaskSpec {
 	res.Entrypoint = []string{"/run/determined/train/entrypoint.sh"}
 
 	envVars := map[string]string{
-		"DET_EXPERIMENT_ID":      strconv.Itoa(s.ExperimentID),
-		"DET_TRIAL_ID":           strconv.Itoa(s.TrialID),
-		"DET_TRIAL_RUN_ID":       strconv.Itoa(s.TrialRunID),
-		"DET_TRIAL_SEED":         strconv.FormatUint(uint64(s.TrialSeed), 10),
-		"DET_EXPERIMENT_CONFIG":  jsonify(s.ExperimentConfig),
-		"DET_HPARAMS":            jsonify(s.HParams),
-		"DET_STEPS_COMPLETED":    strconv.Itoa(s.StepsCompleted),
-		"DET_UNIQUE_PORT_OFFSET": strconv.Itoa(trialUniquePortOffset(s.Base.Devices)),
-		"DET_TASK_TYPE":          string(model.TaskTypeTrial),
+		"DET_EXPERIMENT_ID":     strconv.Itoa(s.ExperimentID),
+		"DET_TRIAL_ID":          strconv.Itoa(s.TrialID),
+		"DET_TRIAL_RUN_ID":      strconv.Itoa(s.TrialRunID),
+		"DET_TRIAL_SEED":        strconv.FormatUint(uint64(s.TrialSeed), 10),
+		"DET_EXPERIMENT_CONFIG": jsonify(s.ExperimentConfig),
+		"DET_HPARAMS":           jsonify(s.HParams),
+		"DET_STEPS_COMPLETED":   strconv.Itoa(s.StepsCompleted),
+		"DET_TASK_TYPE":         string(model.TaskTypeTrial),
+		// DET_UNIQUE_PORT_OFFSET will be overwritten by the agent resource manager when the
+		// container is started, but only on agent resource pools.  This default value will apply
+		// to k8s and slurm (though slurm will override it in a startup hook).
+		"DET_UNIQUE_PORT_OFFSET": "0",
 	}
 	if s.LatestCheckpoint != nil && s.LatestCheckpoint.UUID != nil {
 		envVars["DET_LATEST_CHECKPOINT"] = s.LatestCheckpoint.UUID.String()


### PR DESCRIPTION
The DET_UNIQUE_PORT_OFFSET was always coming out to zero, which
prevented host-mode networking in multi-tenant dtrain scenarios.

The source of the bug was that the unique port offset was being
calculated before the TaskSpec.Devices was populated.

## Test Plan

- Configure `task_container_defaults.network_mode: host` in master
- Start an `artificial_slots:4` agent
- Start two simultaneous `slots_per_trial: 2` trials
- Make sure both trials succeed.

## Commentary (optional)

This bug was difficult to track down because the TaskSpec means multiple different things at different points in time (something I did not previously realize).  Initially, a trial actor is started with a "base" TaskSpec.  I think this has some defaults from the master.  Then the TrialSpec (which has a base TaskSpec as its member) creates a new TaskSpec in TrialSpec.ToTaskSpec.  Why does TrialSpec contain a TaskSpec and still have a ToTaskSpec() method?  Seems confusing to me.  Then later, the containerResources.Start fills the remaining fields of the TaskSpec, to create the actually usable TaskSpec.

Probably these should be three different structs, each extending the previous with struct composition, which is pretty nice and easy in Go.