### PR TITLE
ci: make test-unit-storage run on any upstream branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,6 +75,11 @@ upstream-feature-branch: &upstream-feature-branch
       - /release-.*/
       - master
 
+any-upstream: &any-upstream
+  branches:
+    ignore:
+      - /pull\/.*/
+
 commands:
   fix-circle-working-directory:
     description: "Fix CIRCLE_WORKING_DIRECTORY"
@@ -2034,7 +2039,7 @@ workflows:
       - test-unit-model-hub
       - test-unit-storage:
           context: storage-unit-tests
-          filters: *upstream-feature-branch
+          filters: *any-upstream
       - test-examples
       - python-coverage:
           requires:
@@ -2074,10 +2079,7 @@ workflows:
           requires:
             - build-react
             - build-docs
-          filters:
-            branches:
-              ignore:
-                - /pull\/.*/
+          filters: *any-upstream
 
       - test-debian-packaging:
           requires:


### PR DESCRIPTION
I mistakenly configured it so it only ran on upstream feature branches
originally.