### PR TITLE
ci: merge separate codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,13 @@
 # Determined codeowners file
 
+# explicit default to no owner (this should be the first line)
+*
+
 # Notify eng-infra team of .github changes
 /.github  @determined-ai/infrastructure
 
-# default to no owner (this should be the last line)
-*
+# Ilia cares about agent RM.
+/master/internal/resourcemanagers/ @ioga
+/master/internal/sproto/ @ioga
+/proto/src/determined/ @ioga
+/agent/ @ioga

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,5 +1,0 @@
-# Ilia cares about agent RM.
-/master/internal/resourcemanagers/ @ioga
-/master/internal/sproto/ @ioga
-/proto/src/determined/ @ioga
-/agent/ @ioga


### PR DESCRIPTION
## Description

Merge top-level codeowners into .github location

## Test Plan

Make more PRs!

## Commentary (optional)

In general, I'm partial to having GitHub-control stuff located in the .github directory, so my opinion is that this is the "right" place for this file. I'm open to dissent, though.

The individual users in here should be converted to GH Teams later, but that's a problem for the future.

## Checklist

- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.