### PR TITLE
feat: add --agent-config-path to det deploy local agent-up [DET-6278]

### DIFF
--- a/docs/release-notes/agent-config-path.txt
+++ b/docs/release-notes/agent-config-path.txt
@@ -1,0 +1,7 @@
+:orphan:
+
+**Improvements**
+
+-  CLI:
+      Add new flag ``--agent-config-path`` to ``det deploy local agent-up``` allowing custom agent
+      configs to be used.

--- a/e2e_tests/tests/deploy/etc/agent.yaml
+++ b/e2e_tests/tests/deploy/etc/agent.yaml
@@ -1,0 +1,6 @@
+agent_id: test-path-agent
+master_host: 127.0.0.1
+master_port: 8080
+label: yaml-conf
+fluent:
+  container_name: test-fluent

--- a/e2e_tests/tests/deploy/test_local.py
+++ b/e2e_tests/tests/deploy/test_local.py
@@ -133,7 +133,7 @@ def test_agent_config_path() -> None:
         ["--agent-name", agent_name, "--agent-config-path", etc_path, "--agent-label", "cli-flag"]
     )
     agent_list = json.loads(subprocess.check_output(["det", "a", "list", "--json"]).decode())
-    agent_list = list(filter(lambda x: x["id"] == agent_name, agent_list))
+    agent_list = [el for el in agent_list if el["id"] == agent_name]
     assert len(agent_list) == 1
     assert agent_list[0]["label"] == "cli-flag"
     agent_down(["--agent-name", agent_name])

--- a/harness/determined/deploy/local/cluster_utils.py
+++ b/harness/determined/deploy/local/cluster_utils.py
@@ -282,7 +282,7 @@ def agent_up(
     if agent_config_path is not None:
         with agent_config_path.open() as f:
             agent_conf = yaml.safe_load(f)
-        volumes += f"{agent_config_path}:/etc/determined/agent.yaml"
+        volumes += [f"{agent_config_path}:/etc/determined/agent.yaml"]
 
     # Fallback on agent config for options not specified as flags.
     if agent_name == AGENT_NAME_DEFAULT:


### PR DESCRIPTION
## Description

Adds a new CLI option ```--agent-config-path``` to allow users to specify a custom agent yaml.

## Test Plan

e2e tests along with manual regression testing of 

```
det deploy local agent-up
```
CLI flags

```
--master-port
--agent-name
--agent-label
--agent-resource-pool
```

## Checklist

- [X] User-facing API changes need the "User-facing API Change" label.
- [X] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [X] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
