### PR TITLE
feat: rolling upgrades support for generic command types (notebooks etc.) [DET-7218]

### DIFF
--- a/agent/internal/agent.go
+++ b/agent/internal/agent.go
@@ -378,12 +378,16 @@ func (a *agent) attemptReconnect(ctx *actor.Context) bool {
 		case err == nil:
 			return true
 		case errors.Is(err, aproto.ErrAgentMustReconnect):
+			ctx.Log().Warn("received ErrAgentMustReconnect, exiting")
 			return false
 		default:
 			ctx.Log().WithError(err).Error("error reconnecting to master")
 		}
+		ctx.Log().Info("pre-backoff")
 		time.Sleep(time.Duration(a.Options.AgentReconnectBackoff) * time.Second)
+		ctx.Log().Info("post-backoff")
 	}
+	ctx.Log().Warn("exhausted reconnect attempts, exiting")
 	return false
 }
 

--- a/e2e_tests/tests/cluster/utils.py
+++ b/e2e_tests/tests/cluster/utils.py
@@ -2,6 +2,7 @@ import json
 import subprocess
 import time
 from typing import Any, Dict
+from typing_extensions import Literal
 
 import pytest
 import requests
@@ -46,7 +47,7 @@ def run_command(sleep: int = 30, slots: int = 1) -> str:
         "run",
         "-d",
         "--config",
-        "resources.slots=0",
+        f"resources.slots={slots}",
         "sleep",
         str(sleep),
     ]
@@ -57,21 +58,31 @@ def run_zero_slot_command(sleep: int = 30) -> str:
     return run_command(sleep=sleep, slots=0)
 
 
+TaskType = Literal["command", "notebook", "tensorboard", "shell"]
+
+def get_task_info(task_type: TaskType, task_id: str) -> Dict[str, Any]:
+    task = ["det", "-m", conf.make_master_url(), task_type, "list", "--json"]
+    task_data = json.loads(subprocess.check_output(task).decode())
+    return next((d for d in task_data if d["id"] == task_id), {})
+
+
 def get_command_info(command_id: str) -> Dict[str, Any]:
-    command = ["det", "-m", conf.make_master_url(), "command", "list", "--json"]
-    command_data = json.loads(subprocess.check_output(command).decode())
-    return next((d for d in command_data if d["id"] == command_id), {})
+    return get_task_info("command", command_id)
 
 
 def command_succeeded(command_id: str) -> bool:
     return "success" in get_command_info(command_id)["exitStatus"]
 
 
-def wait_for_command_state(command_id: str, state: str, ticks: int = 60) -> None:
+def wait_for_task_state(task_type: TaskType, task_id: str, state: str, ticks: int = 60) -> None:
     for _ in range(ticks):
-        info = get_command_info(command_id)
+        info = get_task_info(task_type, task_id)
         if info.get("state") == state:
             return
         time.sleep(1)
 
-    pytest.fail(f"Command did't reach {state} state after {ticks} secs")
+    pytest.fail(f"{task_type} did't reach {state} state after {ticks} secs")
+
+
+def wait_for_command_state(command_id: str, state: str, ticks: int = 60) -> None:
+    return wait_for_task_state("command", command_id, state, ticks)

--- a/harness/determined/cli/notebook.py
+++ b/harness/determined/cli/notebook.py
@@ -7,11 +7,12 @@ from termcolor import colored
 
 from determined.cli import command, render, task
 from determined.cli.session import setup_session
+from determined.cli.util import format_args
 from determined.common import api
 from determined.common.api import authentication, bindings
 from determined.common.check import check_eq
 from determined.common.context import Context
-from determined.common.declarative_argparse import Arg, Cmd
+from determined.common.declarative_argparse import Arg, Cmd, Group
 
 from .command import CONFIG_DESC, CONTEXT_DESC, VOLUME_DESC, parse_config, render_event_stream
 
@@ -72,7 +73,8 @@ args_description = [
             Arg("-q", "--quiet", action="store_true",
                 help="only display the IDs"),
             Arg("--all", "-a", action="store_true",
-                help="show all notebooks (including other users')")
+                help="show all notebooks (including other users')"),
+            Group(format_args["json"], format_args["csv"]),
         ], is_default=True),
         Cmd("config", partial(command.config),
             "display notebook config", [

--- a/harness/determined/cli/remote.py
+++ b/harness/determined/cli/remote.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from typing import Any, List
 
 from determined.cli import command, task
+from determined.cli.util import format_args
 from determined.common import api
 from determined.common.api import authentication
 from determined.common.declarative_argparse import Arg, Cmd, Group
@@ -38,10 +39,7 @@ args_description = [
                 help="only display the IDs"),
             Arg("--all", "-a", action="store_true",
                 help="show all commands (including other users')"),
-            Group(
-                Arg("--csv", action="store_true", help="print as CSV"),
-                Arg("--json", action="store_true", help="print as JSON"),
-            ),
+            Group(format_args["json"], format_args["csv"]),
         ], is_default=True),
         Cmd("config", partial(command.config),
             "display command config", [

--- a/harness/determined/cli/shell.py
+++ b/harness/determined/cli/shell.py
@@ -15,10 +15,11 @@ import appdirs
 from termcolor import colored
 
 from determined.cli import command, task
+from determined.cli.util import format_args
 from determined.common import api
 from determined.common.api import authentication, certs
 from determined.common.check import check_eq
-from determined.common.declarative_argparse import Arg, Cmd
+from determined.common.declarative_argparse import Arg, Cmd, Group
 
 from .command import (
     CONFIG_DESC,
@@ -204,7 +205,8 @@ args_description = [
             Arg("-q", "--quiet", action="store_true",
                 help="only display the IDs"),
             Arg("--all", "-a", action="store_true",
-                help="show all shells (including other users')")
+                help="show all shells (including other users')"),
+            Group(format_args["json"], format_args["csv"]),
         ], is_default=True),
         Cmd("config", partial(command.config),
             "display shell config", [

--- a/harness/determined/cli/tensorboard.py
+++ b/harness/determined/cli/tensorboard.py
@@ -7,17 +7,18 @@ from typing import Any, List
 from termcolor import colored
 
 from determined.cli import command, task
+from determined.cli.util import format_args
 from determined.common import api, constants, context
 from determined.common.api import authentication
 from determined.common.check import check_eq
-from determined.common.declarative_argparse import Arg, Cmd
+from determined.common.declarative_argparse import Arg, Cmd, Group
 
 from .command import CONFIG_DESC, CONTEXT_DESC, parse_config, render_event_stream
 
 
 @authentication.required
 def start_tensorboard(args: Namespace) -> None:
-    if args.trial_ids is None and args.experiment_ids is None:
+    if not (args.trial_ids or args.experiment_ids):
         print("Either experiment_ids or trial_ids must be specified.")
         sys.exit(1)
 
@@ -76,7 +77,8 @@ args_description = [
             Arg("-q", "--quiet", action="store_true",
                 help="only display the IDs"),
             Arg("--all", "-a", action="store_true",
-                help="show all TensorBoards (including other users')")
+                help="show all TensorBoards (including other users')"),
+            Group(format_args["json"], format_args["csv"]),
         ], is_default=True),
         Cmd("start", start_tensorboard, "start new TensorBoard instance", [
             Arg("experiment_ids", type=int, nargs="*",

--- a/master/internal/command/command_manager.go
+++ b/master/internal/command/command_manager.go
@@ -23,7 +23,10 @@ type commandManager struct {
 
 func (c *commandManager) Receive(ctx *actor.Context) error {
 	switch msg := ctx.Message().(type) {
-	case actor.PreStart, actor.PostStop, actor.ChildFailed, actor.ChildStopped:
+	case actor.PreStart:
+		tryRestoreCommandsByType(ctx, c.db, c.taskLogger, model.TaskTypeCommand)
+
+	case actor.PostStop, actor.ChildFailed, actor.ChildStopped:
 
 	case *apiv1.GetCommandsRequest:
 		resp := &apiv1.GetCommandsResponse{}

--- a/master/internal/command/models.go
+++ b/master/internal/command/models.go
@@ -1,0 +1,31 @@
+package command
+
+import (
+	"time"
+
+	"github.com/uptrace/bun"
+
+	"github.com/determined-ai/determined/master/pkg/model"
+	"github.com/determined-ai/determined/master/pkg/tasks"
+)
+
+// CommandSnapshot is a db representation of a generic command.
+type CommandSnapshot struct {
+	bun.BaseModel `bun:"table:command_state"`
+
+	TaskID         model.TaskID `bun:"task_id"`
+	RegisteredTime time.Time    `bun:"registered_time"`
+	// taskType can get from task.
+	// jobType can get from task -> job_id -> job_type
+	// jobid can get from task -> job_id
+	AllocationID model.AllocationID `bun:"allocation_id"`
+	// last state from allocation
+	// exit status from allocation
+
+	// GenericCommandSpec
+	GenericCommandSpec tasks.GenericCommandSpec `bun:"generic_command_spec"`
+
+	// Relations
+	Task       model.Task       `bun:"rel:belongs-to,join:task_id=task_id"`
+	Allocation model.Allocation `bun:"rel:belongs-to,join:allocation_id=allocation_id"`
+}

--- a/master/internal/command/notebook_manager.go
+++ b/master/internal/command/notebook_manager.go
@@ -24,7 +24,10 @@ type notebookManager struct {
 
 func (n *notebookManager) Receive(ctx *actor.Context) error {
 	switch msg := ctx.Message().(type) {
-	case actor.PreStart, actor.PostStop, actor.ChildFailed, actor.ChildStopped:
+	case actor.PreStart:
+		tryRestoreCommandsByType(ctx, n.db, n.taskLogger, model.TaskTypeNotebook)
+
+	case actor.PostStop, actor.ChildFailed, actor.ChildStopped:
 
 	case *apiv1.GetNotebooksRequest:
 		resp := &apiv1.GetNotebooksResponse{}

--- a/master/internal/command/shell_manager.go
+++ b/master/internal/command/shell_manager.go
@@ -25,7 +25,10 @@ type shellManager struct {
 
 func (s *shellManager) Receive(ctx *actor.Context) error {
 	switch msg := ctx.Message().(type) {
-	case actor.PreStart, actor.PostStop, actor.ChildFailed, actor.ChildStopped:
+	case actor.PreStart:
+		tryRestoreCommandsByType(ctx, s.db, s.taskLogger, model.TaskTypeShell)
+
+	case actor.PostStop, actor.ChildFailed, actor.ChildStopped:
 
 	case *apiv1.GetShellsRequest:
 		resp := &apiv1.GetShellsResponse{}

--- a/master/internal/command/summary.go
+++ b/master/internal/command/summary.go
@@ -71,7 +71,7 @@ func (c *command) summary(ctx *actor.Context) summary {
 		ID:             c.taskID,
 		Config:         c.Config,
 		State:          state.State.String(),
-		ServiceAddress: c.serviceAddress,
+		ServiceAddress: ptrs.Ptr(c.serviceAddress()),
 		Addresses:      addresses,
 		ExitStatus:     exitStatus,
 		Misc:           c.Metadata,

--- a/master/internal/command/tensorboard_manager.go
+++ b/master/internal/command/tensorboard_manager.go
@@ -24,7 +24,10 @@ type tensorboardManager struct {
 
 func (t *tensorboardManager) Receive(ctx *actor.Context) error {
 	switch msg := ctx.Message().(type) {
-	case actor.PreStart, actor.PostStop, actor.ChildFailed, actor.ChildStopped:
+	case actor.PreStart:
+		tryRestoreCommandsByType(ctx, t.db, t.taskLogger, model.TaskTypeTensorboard)
+
+	case actor.PostStop, actor.ChildFailed, actor.ChildStopped:
 
 	case *apiv1.GetTensorboardsRequest:
 		resp := &apiv1.GetTensorboardsResponse{}

--- a/master/internal/core.go
+++ b/master/internal/core.go
@@ -908,6 +908,14 @@ func (m *Master) Run(ctx context.Context) error {
 		return err
 	}
 
+	command.RegisterAPIHandler(
+		m.system,
+		m.echo,
+		m.db,
+		m.taskLogger,
+		authFuncs...,
+	)
+
 	if err = m.closeOpenAllocations(); err != nil {
 		return err
 	}
@@ -1032,13 +1040,6 @@ func (m *Master) Run(ctx context.Context) error {
 	m.echo.Any("/proxy/:service/*", handler.Get().(echo.HandlerFunc))
 
 	user.RegisterAPIHandler(m.echo, userService, authFuncs...)
-	command.RegisterAPIHandler(
-		m.system,
-		m.echo,
-		m.db,
-		m.taskLogger,
-		authFuncs...,
-	)
 	template.RegisterAPIHandler(m.echo, m.db, authFuncs...)
 
 	telemetry.Setup(

--- a/master/internal/resourcemanagers/agent/models.go
+++ b/master/internal/resourcemanagers/agent/models.go
@@ -4,6 +4,7 @@ import (
 	"github.com/uptrace/bun"
 
 	"github.com/determined-ai/determined/master/internal/sproto"
+	"github.com/determined-ai/determined/master/internal/task"
 	"github.com/determined-ai/determined/master/pkg/aproto"
 	"github.com/determined-ai/determined/master/pkg/cproto"
 	"github.com/determined-ai/determined/master/pkg/device"
@@ -43,6 +44,9 @@ type ContainerSnapshot struct {
 	ID            cproto.ID          `json:"id" bun:"container_id"`
 	State         cproto.State       `json:"state" bun:"state"`
 	Devices       []device.Device    `json:"devices" bun:"devices"`
+
+	// Relations
+	ResourcesWithState task.ResourcesWithState `bun:"rel:belongs-to,join:resource_id=resource_id"`
 }
 
 // NewContainerSnapshot creates an instance from `cproto.Container`.

--- a/master/internal/sproto/task.go
+++ b/master/internal/sproto/task.go
@@ -44,7 +44,7 @@ type (
 		// Behavioral configuration.
 		Preemptible  bool
 		IdleTimeout  *IdleTimeoutConfig
-		ProxyPort    *PortProxyConfig
+		ProxyPort    *ProxyPortConfig
 		StreamEvents *EventStreamConfig
 		Restore      bool
 	}
@@ -58,8 +58,8 @@ type (
 		Debug           bool
 	}
 
-	// PortProxyConfig configures a proxy the allocation should start.
-	PortProxyConfig struct {
+	// ProxyPortConfig configures a proxy the allocation should start.
+	ProxyPortConfig struct {
 		ServiceID       string
 		Port            int
 		ProxyTCP        bool
@@ -192,6 +192,10 @@ type ResourcesSummary struct {
 
 	// Available if the RM can give information on the container level.
 	ContainerID *cproto.ID `json:"container_id"`
+
+	// Available if the RM knows the resource is already started / exited.
+	Started *ResourcesStarted
+	Exited  *ResourcesStopped
 }
 
 // Resources is an interface that provides function for task actors

--- a/master/internal/task/allocation.go
+++ b/master/internal/task/allocation.go
@@ -416,7 +416,7 @@ func (a *Allocation) ResourcesAllocated(ctx *actor.Context, msg sproto.Resources
 		ctx.Log().Debugf("ResourcesAllocated restored state: %s", a.getModelState())
 	}
 
-	a.setModelState(model.AllocationStateAssigned)
+	a.setMostProgressedModelState(model.AllocationStateAssigned)
 	if err := a.resources.append(msg.Resources); err != nil {
 		return errors.Wrapf(err, "appending resources")
 	}
@@ -468,6 +468,13 @@ func (a *Allocation) ResourcesAllocated(ctx *actor.Context, msg sproto.Resources
 				IsMultiAgent: len(a.resources) > 1,
 			}); err != nil {
 				return fmt.Errorf("starting resources (%v): %w", r, err)
+			}
+		}
+	} else if a.getModelState() == model.AllocationStateRunning {
+		// Restore proxies.
+		for _, r := range a.resources {
+			if a.req.ProxyPort != nil && r.Started != nil && r.Started.Addresses != nil {
+				a.registerProxies(ctx, r.Started.Addresses)
 			}
 		}
 	}
@@ -778,7 +785,6 @@ func (a *Allocation) registerProxies(ctx *actor.Context, addresses []cproto.Addr
 	if cfg == nil {
 		return
 	}
-
 	if len(a.resources) > 1 {
 		// We don't support proxying multi-reservation allocations.
 		ctx.Log().Warnf("proxy for multi-reservation allocation aborted")

--- a/master/internal/task/resources_list.go
+++ b/master/internal/task/resources_list.go
@@ -23,8 +23,8 @@ type (
 		Started          *sproto.ResourcesStarted `bun:"started"`
 		Exited           *sproto.ResourcesStopped `bun:"exited"`
 		Daemon           bool                     `bun:"daemon"`
-		ResourceID       sproto.ResourcesID       `bun:"resource_id,type:text"`   // db only
-		AllocationID     model.AllocationID       `bun:"allocation_id,type:text"` // db only
+		ResourceID       sproto.ResourcesID       `bun:"resource_id,pk,type:text"` // db only
+		AllocationID     model.AllocationID       `bun:"allocation_id,type:text"`  // db only
 
 		// The container state, if we're using a RM that uses containers and it was given to us.
 		// This is a rip in the abstraction, remove eventually. Do not add usages.
@@ -43,6 +43,8 @@ func NewResourcesState(r sproto.Resources, rank int) ResourcesWithState {
 		Rank:         rank,
 		ResourceID:   summary.ResourcesID,
 		AllocationID: summary.AllocationID,
+		Started:      summary.Started,
+		Exited:       summary.Exited,
 	}
 }
 

--- a/master/pkg/model/job.go
+++ b/master/pkg/model/job.go
@@ -80,8 +80,8 @@ func JobTypeFromProto(t jobv1.Type) JobType {
 
 // Job is the model for a job in the database.
 type Job struct {
-	JobID   JobID           `db:"job_id"`
+	JobID   JobID           `db:"job_id" bun:"job_id,pk"`
 	JobType JobType         `db:"job_type"`
 	OwnerID *UserID         `db:"owner_id"`
-	QPos    decimal.Decimal `db:"q_position"`
+	QPos    decimal.Decimal `db:"q_position" bun:"q_position"`
 }

--- a/master/pkg/model/task.go
+++ b/master/pkg/model/task.go
@@ -64,13 +64,18 @@ const (
 
 // Task is the model for a task in the database.
 type Task struct {
-	TaskID    TaskID     `db:"task_id"`
+	bun.BaseModel `bun:"table:tasks"`
+
+	TaskID    TaskID     `db:"task_id" bun:"task_id,pk"`
 	JobID     *JobID     `db:"job_id"`
 	TaskType  TaskType   `db:"task_type"`
 	StartTime time.Time  `db:"start_time"`
 	EndTime   *time.Time `db:"end_time"`
 	// LogVersion indicates how the logs were stored.
 	LogVersion TaskLogVersion `db:"log_version"`
+
+	// Relations.
+	Job *Job `bun:"rel:belongs-to,join:job_id=job_id"`
 }
 
 // AllocationID is the ID of an allocation of a task. It is usually of the form
@@ -86,7 +91,7 @@ func (a AllocationID) String() string {
 type Allocation struct {
 	bun.BaseModel `bun:"table:allocations"`
 
-	AllocationID AllocationID     `db:"allocation_id" bun:"allocation_id,notnull,unique"`
+	AllocationID AllocationID     `db:"allocation_id" bun:"allocation_id,pk"`
 	TaskID       TaskID           `db:"task_id" bun:"task_id,notnull"`
 	Slots        int              `db:"slots" bun:"slots,notnull"`
 	AgentLabel   string           `db:"agent_label" bun:"agent_label,notnull"`

--- a/master/static/migrations/20220523155200_add-command-snapshot.tx.down.sql
+++ b/master/static/migrations/20220523155200_add-command-snapshot.tx.down.sql
@@ -1,0 +1,3 @@
+DROP INDEX IF EXISTS ix_command_state_allocation_id;
+
+DROP TABLE command_state;

--- a/master/static/migrations/20220523155200_add-command-snapshot.tx.up.sql
+++ b/master/static/migrations/20220523155200_add-command-snapshot.tx.up.sql
@@ -1,0 +1,8 @@
+CREATE TABLE command_state (
+	task_id text PRIMARY KEY REFERENCES tasks(task_id) ON DELETE CASCADE NOT NULL,
+	registered_time timestamp with time zone NOT NULL DEFAULT NOW(),
+	allocation_id text REFERENCES allocations(allocation_id) ON DELETE CASCADE NOT NULL,
+	generic_command_spec jsonb
+);
+
+CREATE INDEX ix_command_state_allocation_id ON command_state USING btree (allocation_id);

--- a/master/static/srv/check_idle.py
+++ b/master/static/srv/check_idle.py
@@ -15,6 +15,8 @@ class IdleType(enum.Enum):
     ACTIVITY = 3
 
 
+REPORT_IDLE_INTERVAL = 30
+
 last_activity = None
 
 
@@ -45,7 +47,7 @@ def is_idle(request_address, mode):
         kernels = requests.get(request_address + "/api/kernels").json()
         terminals = requests.get(request_address + "/api/terminals").json()
         sessions = requests.get(request_address + "/api/sessions").json()
-    except Exception as err:
+    except Exception:
         logging.warning("Cannot get notebook kernel status", exc_info=True)
         return False
 
@@ -90,9 +92,9 @@ def main():
                 {"notebook_id": notebook_id, "idle": idle},
                 cert=cert,
             )
-        except Exception as e:
+        except Exception:
             logging.warning("ignoring error communicating with master", exc_info=True)
-        time.sleep(1)
+        time.sleep(REPORT_IDLE_INTERVAL)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

- restore/continue notebooks, tensorboards, commands, shells after master restart.
- also enable `det (notebook|shell|tensorboard) list --json`.

## Test Plan

There're some tests.

## Commentary (optional)

This PR has #4370 embedded in it. This'll be solved with a rebase when it is merged.

## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
