### PR TITLE
chore: resolve warnings from yaml and numpy, fix supposed fstrings, black formatting

### DIFF
--- a/harness/determined/cli/command.py
+++ b/harness/determined/cli/command.py
@@ -12,7 +12,7 @@ from determined.cli import render
 from determined.common import api, context, util, yaml
 from determined.common.api import authentication
 
-yaml = yaml.YAML(typ="safe", pure=True)
+yaml = yaml.YAML(typ="safe", pure=True)  # type: ignore
 
 
 CONFIG_DESC = """

--- a/harness/determined/cli/command.py
+++ b/harness/determined/cli/command.py
@@ -12,6 +12,9 @@ from determined.cli import render
 from determined.common import api, context, util, yaml
 from determined.common.api import authentication
 
+yaml = yaml.YAML(typ="safe", pure=True)
+
+
 CONFIG_DESC = """
 Additional configuration arguments for setting up a command.
 Arguments should be specified as `key=value`. Nested configuration
@@ -266,12 +269,12 @@ def parse_config_overrides(config: Dict[str, Any], overrides: Iterable[str]) -> 
 
         key, value = config_arg.split("=", maxsplit=1)  # type: Tuple[str, Any]
 
-        # Separate values if a comma exists. Use yaml.safe_load() to cast
+        # Separate values if a comma exists. Use yaml.load() to cast
         # the value(s) to the type YAML would use, e.g., "4" -> 4.
         if "," in value:
-            value = [yaml.safe_load(v) for v in value.split(",")]
+            value = [yaml.load(v) for v in value.split(",")]
         else:
-            value = yaml.safe_load(value)
+            value = yaml.load(value)
 
             # Certain configurations keys are expected to have list values.
             # Convert a single value to a singleton list if needed.

--- a/harness/determined/common/util.py
+++ b/harness/determined/common/util.py
@@ -9,6 +9,8 @@ from typing import IO, Any, Callable, Iterator, Optional, Sequence, TypeVar, Uni
 
 from determined.common import yaml
 
+yaml = yaml.YAML(typ="safe", pure=True)
+
 T = TypeVar("T")
 
 
@@ -105,7 +107,7 @@ def safe_load_yaml_with_exceptions(yaml_file: Union[io.FileIO, IO[Any]]) -> Any:
     ---------------------------------------------------------------------------------------------
     """
     try:
-        config = yaml.safe_load(yaml_file)
+        config = yaml.load(yaml_file)
     except (
         yaml.error.MarkedYAMLWarning,
         yaml.error.MarkedYAMLError,

--- a/harness/determined/common/util.py
+++ b/harness/determined/common/util.py
@@ -9,7 +9,7 @@ from typing import IO, Any, Callable, Iterator, Optional, Sequence, TypeVar, Uni
 
 from determined.common import yaml
 
-yaml = yaml.YAML(typ="safe", pure=True)
+yaml = yaml.YAML(typ="safe", pure=True)  # type: ignore
 
 T = TypeVar("T")
 

--- a/harness/determined/ipc.py
+++ b/harness/determined/ipc.py
@@ -88,7 +88,7 @@ class ZMQBroadcastServer:
 
     def safe_start(self) -> None:
         """
-        Broadcast Hello messages over and over until all clients response with a Hello message.
+        Broadcast Hello messages over and over until all clients respond with a Hello message.
 
         The reason for this is that the only way to be 100% confident that a subscriber has
         connected is for it to actually receive a message over the pub/sub connection.
@@ -144,7 +144,7 @@ class ZMQBroadcastServer:
         self._send_serial += 1
 
     def gather(self) -> List[Any]:
-        out = [self._recv_one() for i in range(self._num_connections)]
+        out = [self._recv_one() for _ in range(self._num_connections)]
 
         self._recv_serial += 1
 
@@ -305,7 +305,7 @@ class PIDServer:
                 self.listener = socket.socket()
                 self.listener.bind(("", self.addr))
             else:
-                # A address and a port.
+                # An address and a port.
                 self.listener = socket.socket()
                 self.listener.bind(self.addr)
             self.listener.listen(self.num_clients)
@@ -377,7 +377,7 @@ class PIDServer:
         if mask & selectors.EVENT_READ:
             data = conn.recv(4096)
         # Messages are all one-byte codes for easy parsing.
-        # The protocol is "any number of keepalive "k"s followed by a quit "q", so we can
+        # The protocol is "any number of keepalive "k"s followed by a quit "q"", so we can
         # safely ignore everything except the final byte of the message.
         if data:
             if data[-1:] == b"k":
@@ -506,7 +506,7 @@ class PIDClient:
                 self.sock = socket.socket()
                 self.sock.connect(("127.0.0.1", self.addr))
             else:
-                # A address and a port.
+                # An address and a port.
                 self.sock = socket.socket()
                 self.sock.connect(self.addr)
             # Send our PID to the PIDServer.

--- a/harness/determined/load.py
+++ b/harness/determined/load.py
@@ -54,8 +54,8 @@ def trial_class_from_entrypoint(entrypoint_spec: str) -> Type[det.Trial]:
         for attr in qualname.split("."):
             obj = getattr(obj, attr)
 
-    assert isinstance(obj, type), "entrypoint ({entrypoint_spec}) is not a class"
-    assert issubclass(obj, det.Trial), "entrypoint ({entrypoint_spec}) is not a det.Trial subclass"
+    assert isinstance(obj, type), f"entrypoint ({entrypoint_spec}) is not a class"
+    assert issubclass(obj, det.Trial), f"entrypoint ({entrypoint_spec}) is not a det.Trial subclass"
     return cast(Type[det.Trial], obj)
 
 

--- a/harness/determined/pytorch/_pytorch_trial.py
+++ b/harness/determined/pytorch/_pytorch_trial.py
@@ -720,7 +720,7 @@ class PyTorchTrialController(det.TrialController):
                 self.callbacks[name].load_state_dict(callback_state[name])
             elif util.is_overridden(self.callbacks[name].load_state_dict, pytorch.PyTorchCallback):
                 logging.warning(
-                    "Callback '{}' implements load_state_dict(), but no callback state "
+                    f"Callback '{name}' implements load_state_dict(), but no callback state "
                     "was found for that name when restoring from checkpoint. This "
                     "callback will be initialized from scratch"
                 )

--- a/harness/determined/pytorch/_reducer.py
+++ b/harness/determined/pytorch/_reducer.py
@@ -29,7 +29,7 @@ class Reducer(enum.Enum):
 
 def _simple_reduce_metrics(
     reducer: Reducer, metrics: np.array, num_batches: Optional[List[int]] = None
-) -> np.float:
+) -> float:
     if reducer == Reducer.AVG:
         if num_batches:
             check.check_eq(len(metrics), len(num_batches))

--- a/harness/determined/pytorch/_reducer.py
+++ b/harness/determined/pytorch/_reducer.py
@@ -28,7 +28,7 @@ class Reducer(enum.Enum):
 
 
 def _simple_reduce_metrics(
-    reducer: Reducer, metrics: np.array, num_batches: Optional[List[int]] = None
+    reducer: Reducer, metrics: np.ndarray, num_batches: Optional[List[int]] = None
 ) -> np.float64:
     if reducer == Reducer.AVG:
         if num_batches:

--- a/harness/determined/pytorch/_reducer.py
+++ b/harness/determined/pytorch/_reducer.py
@@ -29,7 +29,7 @@ class Reducer(enum.Enum):
 
 def _simple_reduce_metrics(
     reducer: Reducer, metrics: np.array, num_batches: Optional[List[int]] = None
-) -> float:
+) -> np.float64:
     if reducer == Reducer.AVG:
         if num_batches:
             check.check_eq(len(metrics), len(num_batches))

--- a/harness/determined/util.py
+++ b/harness/determined/util.py
@@ -124,7 +124,7 @@ def make_metrics(num_inputs: Optional[int], batch_metrics: List[Dict[str, Any]])
     for name, values in metric_dict.items():
         m = None  # type: Optional[float]
         try:
-            values = np.array(values)  # type: ignore
+            values = np.array(values)
             filtered_values = values[values != None]  # noqa: E711
             m = np.mean(filtered_values).item()
         except (TypeError, ValueError):

--- a/harness/determined/util.py
+++ b/harness/determined/util.py
@@ -41,7 +41,7 @@ def download_gcs_blob_with_backoff(blob: Any, n_retries: int = 32, max_backoff: 
 
 
 def is_overridden(full_method: Any, parent_class: Any) -> bool:
-    """Check if a function is overriden over the given parent class.
+    """Check if a function is overridden over the given parent class.
 
     Note that full_method should always be the name of a method, but users may override
     that name with a variable anyway. In that case we treat full_method as not overridden.
@@ -124,9 +124,9 @@ def make_metrics(num_inputs: Optional[int], batch_metrics: List[Dict[str, Any]])
     for name, values in metric_dict.items():
         m = None  # type: Optional[float]
         try:
-            values = np.array(values)
+            values = np.array(values)  # type: ignore
             filtered_values = values[values != None]  # noqa: E711
-            m = np.mean(filtered_values)
+            m = np.mean(filtered_values).item()
         except (TypeError, ValueError):
             # If we get here, values are non-scalars, which cannot be averaged.
             # We keep the key so consumers can see all the metric names but
@@ -163,7 +163,7 @@ def json_encode(obj: Any, indent: Optional[str] = None, sort_keys: bool = False)
             if math.isnan(obj):
                 return "NaN"
             if math.isinf(obj):
-                return "Infinity" if obj > 0 else "-Infinity"
+                return "Infinity" if float(obj) > 0.0 else "-Infinity"
             return float(obj)
         if isinstance(obj, bytes):
             # Assume bytes are utf8 (json can't encode arbitrary binary data).

--- a/harness/tests/common/test_schemas.py
+++ b/harness/tests/common/test_schemas.py
@@ -8,7 +8,7 @@ from determined.common import schemas, yaml
 from determined.common.schemas import expconf
 from determined.common.schemas.expconf import _v0
 
-yaml = yaml.YAML(typ="safe", pure=True)
+yaml = yaml.YAML(typ="safe", pure=True)  # type: ignore
 
 
 def strip_runtime_defaultable(obj: Any, defaulted: Any) -> Any:

--- a/harness/tests/common/test_schemas.py
+++ b/harness/tests/common/test_schemas.py
@@ -8,6 +8,8 @@ from determined.common import schemas, yaml
 from determined.common.schemas import expconf
 from determined.common.schemas.expconf import _v0
 
+yaml = yaml.YAML(typ="safe", pure=True)
+
 
 def strip_runtime_defaultable(obj: Any, defaulted: Any) -> Any:
     """
@@ -209,7 +211,7 @@ def all_cases() -> Iterator["str"]:
             if file.endswith(".yaml"):
                 path = os.path.join(root, file)
                 with open(path) as f:
-                    cases = yaml.safe_load(f)
+                    cases = yaml.load(f)
                 for case in cases:
                     display_path = os.path.relpath(path, CASES_ROOT)
                     yield display_path + "::" + case["name"]
@@ -219,7 +221,7 @@ def all_cases() -> Iterator["str"]:
 def test_schemas(test_case: str) -> None:
     cases_file, case_name = test_case.split("::", 1)
     with open(os.path.join(CASES_ROOT, cases_file)) as f:
-        cases = yaml.safe_load(f)
+        cases = yaml.load(f)
     # Find the right test from the file of test cases.
     case = [c for c in cases if c["name"] == case_name][0]
     Case(**case).run()

--- a/harness/tests/experiment/keras/test_tf_keras_trial.py
+++ b/harness/tests/experiment/keras/test_tf_keras_trial.py
@@ -349,7 +349,11 @@ class TestKerasTrial:
             trainer = utils.TrainAndValidate()
             yield from trainer.send(steps=1, validation_freq=1, scheduling_unit=1)
 
-        hparams = {"learning_rate": 0.001, "global_batch_size": 3, "dataset_range": 10}
+        hparams = {
+            "learning_rate": 0.001,
+            "global_batch_size": 3,
+            "dataset_range": 10,
+        }
         controller = utils.make_trial_controller_from_trial_implementation(
             ancient_keras_ckpt.AncientTrial,
             hparams,

--- a/harness/tests/experiment/pytorch/test_metric_utils.py
+++ b/harness/tests/experiment/pytorch/test_metric_utils.py
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 
 
 def test_process_combined_metrics_and_batches() -> None:
-    # Test empty metrics. This case can arise when custom reducers are used so it's okay for
+    # Test empty metrics. This case can arise when custom reducers are used, so it's okay for
     # evaluate_batch to return an empty dict.
     combined_metrics_and_batches = [
         ({}, 2),  # this is from a rank actually computing metrics but returning an empty dict
@@ -73,14 +73,14 @@ def test_average_training_metrics() -> None:
     # Test single array metrics
     combined_timeseries = {
         "loss1": [[1, 2], [3, 4]],
-        "loss2": [[np.array(-1), np.array(-2)], [np.array(-3), np.array(-4)]],
+        "loss2": [[np.array(-1), np.array(-2)], [np.array(-3), np.array(-4)]],  # type: ignore
     }
     averaged_metrics = metric_utils._average_training_metrics(
         combined_timeseries, combined_num_batches
     )
     expected_metrics = [
-        {"loss1": 2, "loss2": np.array(-2)},
-        {"loss1": 3, "loss2": np.array(-3)},
+        {"loss1": 2, "loss2": np.array(-2)},  # type: ignore
+        {"loss1": 3, "loss2": np.array(-3)},  # type: ignore
     ]
     assert averaged_metrics == expected_metrics
 

--- a/harness/tests/experiment/pytorch/test_metric_utils.py
+++ b/harness/tests/experiment/pytorch/test_metric_utils.py
@@ -73,14 +73,14 @@ def test_average_training_metrics() -> None:
     # Test single array metrics
     combined_timeseries = {
         "loss1": [[1, 2], [3, 4]],
-        "loss2": [[np.array(-1), np.array(-2)], [np.array(-3), np.array(-4)]],  # type: ignore
+        "loss2": [[np.array(-1), np.array(-2)], [np.array(-3), np.array(-4)]],
     }
     averaged_metrics = metric_utils._average_training_metrics(
         combined_timeseries, combined_num_batches
     )
     expected_metrics = [
-        {"loss1": 2, "loss2": np.array(-2)},  # type: ignore
-        {"loss1": 3, "loss2": np.array(-3)},  # type: ignore
+        {"loss1": 2, "loss2": np.array(-2)},
+        {"loss1": 3, "loss2": np.array(-3)},
     ]
     assert averaged_metrics == expected_metrics
 

--- a/harness/tests/experiment/utils.py
+++ b/harness/tests/experiment/utils.py
@@ -68,7 +68,7 @@ class TrainAndValidate:
                 v_metrics = validation["metrics"]["validation_metrics"]
                 self._validation_metrics.append(v_metrics)
                 if validation.get("stop_requested"):
-                    assert step_id == self.request_stop_step_id
+                    assert step_id == self.request_stop_step_id, (step_id, self)
                     stop_requested = True
 
             if stop_requested:
@@ -177,7 +177,7 @@ def assert_equivalent_metrics(metrics_A: Dict[str, Any], metrics_B: Dict[str, An
     """
     assert set(metrics_A.keys()) == set(metrics_B.keys())
     for key in metrics_A.keys():
-        if isinstance(metrics_A[key], (float, np.float)):
+        if isinstance(metrics_A[key], (float, float)):
             assert metrics_A[key] == pytest.approx(metrics_B[key])
         elif isinstance(metrics_A[key], np.ndarray):
             assert np.array_equal(metrics_A[key], metrics_B[key])

--- a/harness/tests/experiment/utils.py
+++ b/harness/tests/experiment/utils.py
@@ -185,7 +185,7 @@ def assert_equivalent_metrics(metrics_A: Dict[str, Any], metrics_B: Dict[str, An
             assert metrics_A[key] == metrics_B[key]
 
 
-def xor_data(dtype: np.dtype = np.int64) -> Tuple[np.ndarray, np.ndarray]:
+def xor_data(dtype: Type[Any] = np.int64) -> Tuple[np.ndarray, np.ndarray]:
     training_data = np.array([[0, 0], [0, 1], [1, 0], [1, 1]], dtype=dtype)
     training_labels = np.array([0, 1, 1, 0], dtype=dtype)
     return training_data, training_labels
@@ -194,7 +194,7 @@ def xor_data(dtype: np.dtype = np.int64) -> Tuple[np.ndarray, np.ndarray]:
 def make_xor_data_sequences(
     shuffle: bool = False,
     seed: Optional[int] = None,
-    dtype: np.dtype = np.int64,
+    dtype: Type[Any] = np.int64,
     multi_input_output: bool = False,
     batch_size: int = 1,
 ) -> Tuple[keras_utils.Sequence, keras_utils.Sequence]:

--- a/harness/tests/experiment/utils.py
+++ b/harness/tests/experiment/utils.py
@@ -177,7 +177,7 @@ def assert_equivalent_metrics(metrics_A: Dict[str, Any], metrics_B: Dict[str, An
     """
     assert set(metrics_A.keys()) == set(metrics_B.keys())
     for key in metrics_A.keys():
-        if isinstance(metrics_A[key], (float, float)):
+        if isinstance(metrics_A[key], (float, np.float64)):
             assert metrics_A[key] == pytest.approx(metrics_B[key])
         elif isinstance(metrics_A[key], np.ndarray):
             assert np.array_equal(metrics_A[key], metrics_B[key])


### PR DESCRIPTION
## Description

Fix some warnings from `yaml` and `numpy`.
Fix a few fstrings missing the prefix `f`.
Fix some typing mismatches, solving several `mypy` errors.
Fix a little bit of code formatting and typos.


## Test Plan

To see the reduction in `numpy` warnings, in the directory `determined/harness`, running the command
`pytest tests/experiment/pytorch/test_reducer.py tests/experiment/tensorflow/test_estimator_trial.py`
would result in 4140 warnings. After the proposed changes, this reduces to 29 warnings. There are certainly repeated warnings.

The output of `mypy` as used in, say, `make -C harness check` is now as follows:
```
determined/pytorch/_reducer.py:36: error: Returning Any from function declared to return "floating[_64Bit]"
determined/pytorch/_reducer.py:38: error: Returning Any from function declared to return "floating[_64Bit]"
determined/pytorch/_reducer.py:40: error: Returning Any from function declared to return "floating[_64Bit]"
determined/pytorch/_reducer.py:42: error: Returning Any from function declared to return "floating[_64Bit]"
determined/ipc.py:68: error: Call to untyped function "Context" in typed context
determined/ipc.py:70: error: Call to untyped function "socket" in typed context
determined/ipc.py:71: error: Call to untyped function "socket" in typed context
determined/ipc.py:175: error: Call to untyped function "Context" in typed context
determined/ipc.py:177: error: Call to untyped function "socket" in typed context
determined/ipc.py:182: error: Call to untyped function "socket" in typed context
Found 10 errors in 2 files (checked 277 source files)
```
The solutions to these remaining errors are not clear (and writing `# type: ignore` everywhere doesn't seem appropriate in these places), so they will be left for now, unless someone has a suggestion!


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
