### PR TITLE
fix: update experiment list tag truncate rule [DET-7530]

### DIFF
--- a/webui/react/src/components/TagList.module.scss
+++ b/webui/react/src/components/TagList.module.scss
@@ -14,6 +14,9 @@
     background: var(--theme-colors-monochrome-17);
     border-style: dashed;
   }
+  .tagEdit {
+    white-space: break-spaces;
+  }
   .tagPlus:hover,
   .tagEdit:hover {
     border-color: var(--theme-status-active);

--- a/webui/react/src/components/TagList.tsx
+++ b/webui/react/src/components/TagList.tsx
@@ -20,7 +20,7 @@ export const ARIA_LABEL_CONTAINER = 'new-tag-container';
 export const ARIA_LABEL_TRIGGER = 'new-tag-trigger';
 export const ARIA_LABEL_INPUT = 'new-tag-input';
 
-const TAG_MAX_LENGTH = 10;
+const TAG_MAX_LENGTH = 50;
 const COMPACT_MAX_THRESHOLD = 4;
 
 const EditableTagList: React.FC<Props> = (
@@ -72,21 +72,6 @@ const EditableTagList: React.FC<Props> = (
     setState(state => ({ ...state, editInputIndex: -1, inputVisible: false }));
   }, [ onChange, tags ]);
 
-  const toHex = (str: string) => {
-    let hash = 0;
-    if (str.length === 0) return '';
-    for (let i = 0; i < str.length; i++) {
-      hash = str.charCodeAt(i) + ((hash << 5) - hash);
-      hash = hash & hash;
-    }
-    let color = '#';
-    for (let i = 0; i < 3; i++) {
-      const value = (hash >> (i * 8)) & 255;
-      color += ('00' + value.toString(16)).substr(-2);
-    }
-    return color;
-  };
-
   const { editInputIndex, inputVisible, inputWidth } = state;
 
   const classes = [ css.base ];
@@ -129,7 +114,6 @@ const EditableTagList: React.FC<Props> = (
             <Tag
               className={css.tagEdit}
               closable={!disabled}
-              color={toHex(tag)}
               id={htmlId}
               key={tag}
               onClose={() => handleClose(tag)}>

--- a/webui/react/src/components/TagList.tsx
+++ b/webui/react/src/components/TagList.tsx
@@ -72,6 +72,21 @@ const EditableTagList: React.FC<Props> = (
     setState(state => ({ ...state, editInputIndex: -1, inputVisible: false }));
   }, [ onChange, tags ]);
 
+  const toHex = (str: string) => {
+    let hash = 0;
+    if (str.length === 0) return '';
+    for (let i = 0; i < str.length; i++) {
+      hash = str.charCodeAt(i) + ((hash << 5) - hash);
+      hash = hash & hash;
+    }
+    let color = '#';
+    for (let i = 0; i < 3; i++) {
+      const value = (hash >> (i * 8)) & 255;
+      color += ('00' + value.toString(16)).substr(-2);
+    }
+    return color;
+  };
+
   const { editInputIndex, inputVisible, inputWidth } = state;
 
   const classes = [ css.base ];
@@ -114,6 +129,7 @@ const EditableTagList: React.FC<Props> = (
             <Tag
               className={css.tagEdit}
               closable={!disabled}
+              color={toHex(tag)}
               id={htmlId}
               key={tag}
               onClose={() => handleClose(tag)}>

--- a/webui/react/src/pages/ProjectDetails.tsx
+++ b/webui/react/src/pages/ProjectDetails.tsx
@@ -316,7 +316,6 @@ const ProjectDetails: React.FC = () => {
   const columns = useMemo(() => {
     const tagsRenderer = (value: string, record: ExperimentItem) => (
       <TagList
-        compact
         disabled={record.archived || project?.archived}
         tags={record.labels}
         onChange={experimentTags.handleTagListChange(record.id)}


### PR DESCRIPTION
## Description

Per customer request, we increate the tag max length to 50, and remove tags overflow in experiment list table.

Before
<img width="729" alt="Screen Shot 2022-06-16 at 11 06 20 AM" src="https://user-images.githubusercontent.com/40620519/174115990-aae0ef67-8fb4-4e59-8f3e-1ffdcf383dc0.png">

After
<img width="699" alt="Screen Shot 2022-06-16 at 11 06 38 AM" src="https://user-images.githubusercontent.com/40620519/174116006-3b11084f-fb4b-4b69-aa71-732fd24c6b8c.png">


## Test Plan

At experiment list table, create tags with various length, verify the content can be displayed up to 50 characters. 
Create multiple tags (>5), verify all can be displayed. 





[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ