### PR TITLE
fix: reject reconnecting agents with different device configuration  [DET-7568]

### DIFF
--- a/.circleci/devcluster/double-reattach.devcluster.yaml
+++ b/.circleci/devcluster/double-reattach.devcluster.yaml
@@ -69,3 +69,15 @@ stages:
         agent_reconnect_attempts: 24
         agent_reconnect_backoff: 5
         container_auto_remove_disabled: true
+
+  - agent:
+      name: agent10  # Copy of agent1, but with different slots.
+      config_file:
+        master_host: 127.0.0.1
+        master_port: 8081
+        agent_id: agent1
+        container_master_host: $DOCKER_LOCALHOST
+        agent_reconnect_attempts: 24
+        agent_reconnect_backoff: 5
+        container_auto_remove_disabled: true
+        artificial_slots: 4

--- a/agent/internal/agent.go
+++ b/agent/internal/agent.go
@@ -92,6 +92,9 @@ func (a *agent) Receive(ctx *actor.Context) error {
 			ctx.Tell(a.cm, *msg.StartContainer)
 		case msg.SignalContainer != nil:
 			ctx.Tell(a.cm, *msg.SignalContainer)
+		case msg.AgentShutdown != nil:
+			ctx.Log().Infof("shutting down agent due to master message: %s", msg.AgentShutdown.ErrMsg)
+			ctx.Self().Stop()
 		default:
 			panic(fmt.Sprintf("unknown message received: %+v", msg))
 		}

--- a/e2e_tests/tests/cluster/managed_cluster.py
+++ b/e2e_tests/tests/cluster/managed_cluster.py
@@ -20,7 +20,7 @@ DEVCLUSTER_PRIORITY_SCHEDULER_CONFIG_PATH = DEVCLUSTER_CONFIG_ROOT_PATH / "prior
 DEVCLUSTER_LOG_PATH = Path("/tmp/devcluster")
 
 
-def _get_agent_data(master_url: str) -> List[Dict[str, Any]]:
+def get_agent_data(master_url: str) -> List[Dict[str, Any]]:
     command = ["det", "-m", master_url, "agent", "list", "--json"]
     output = subprocess.check_output(command).decode()
     agent_data = cast(List[Dict[str, Any]], json.loads(output))
@@ -62,7 +62,7 @@ class ManagedCluster:
 
         WAIT_FOR_KILL = 5
         for _i in range(WAIT_FOR_KILL):
-            agent_data = _get_agent_data(conf.make_master_url())
+            agent_data = get_agent_data(conf.make_master_url())
             if len(agent_data) == 0:
                 break
             if len(agent_data) == 1 and agent_data[0]["draining"] is True:
@@ -72,7 +72,7 @@ class ManagedCluster:
             pytest.fail(f"Agent is still present after {WAIT_FOR_KILL} seconds")
 
     def restart_agent(self, wait_for_amnesia: bool = True) -> None:
-        agent_data = _get_agent_data(conf.make_master_url())
+        agent_data = get_agent_data(conf.make_master_url())
         if len(agent_data) == 1 and agent_data[0]["enabled"]:
             return
 
@@ -80,7 +80,7 @@ class ManagedCluster:
             # Currently, we've got to wait for master to "forget" the agent before reconnecting.
             WAIT_FOR_AMNESIA = 60
             for _i in range(WAIT_FOR_AMNESIA):
-                agent_data = _get_agent_data(conf.make_master_url())
+                agent_data = get_agent_data(conf.make_master_url())
                 if len(agent_data) == 0:
                     break
                 time.sleep(1)
@@ -99,7 +99,7 @@ class ManagedCluster:
         self.dc.restart_stage("proxy")
         if wait_for_reconnect:
             for _i in range(25):
-                agent_data = _get_agent_data(conf.make_master_url())
+                agent_data = get_agent_data(conf.make_master_url())
                 if (
                     len(agent_data) == 1
                     and agent_data[0]["enabled"] is True
@@ -111,14 +111,14 @@ class ManagedCluster:
                 pytest.fail(f"Agent didn't reconnect after {_i} seconds")
 
     def ensure_agent_ok(self) -> None:
-        agent_data = _get_agent_data(conf.make_master_url())
+        agent_data = get_agent_data(conf.make_master_url())
         assert len(agent_data) == 1
         assert agent_data[0]["enabled"] is True
         assert agent_data[0]["draining"] is False
 
     def wait_for_agent_ok(self, ticks: int) -> None:
         for _i in range(ticks):
-            agent_data = _get_agent_data(conf.make_master_url())
+            agent_data = get_agent_data(conf.make_master_url())
             if (
                 len(agent_data) == 1
                 and agent_data[0]["enabled"] is True

--- a/master/internal/resourcemanagers/agent/agent.go
+++ b/master/internal/resourcemanagers/agent/agent.go
@@ -438,8 +438,8 @@ func (a *agent) handleIncomingWSMessage(ctx *actor.Context, msg aproto.MasterMes
 				}
 				if err = ctx.Ask(a.socket, wsm).Error(); err != nil {
 					log.WithError(err).Error("failed to tell agent to reconnect")
+					panic(err)
 				}
-				check.Panic(err)
 				ctx.Self().Stop()
 				return
 			}

--- a/master/internal/resourcemanagers/agent/agent.go
+++ b/master/internal/resourcemanagers/agent/agent.go
@@ -418,22 +418,39 @@ func (a *agent) handleAPIRequest(ctx *actor.Context, apiCtx echo.Context) {
 }
 
 func (a *agent) handleIncomingWSMessage(ctx *actor.Context, msg aproto.MasterMessage) {
+	log := ctx.Log().WithField("agent-id", ctx.Self().Address().Local())
 	switch {
 	case msg.AgentStarted != nil:
 		ctx.Log().Infof("agent connected ip: %v resource pool: %s slots: %d",
 			a.address, a.resourcePoolName, len(msg.AgentStarted.Devices))
 
-		// TODO(ilia): Error out on a change in devices.
-		if !a.started {
+		if a.started {
+			err := a.agentState.checkAgentStartedDevicesMatch(ctx, msg.AgentStarted)
+			if err != nil {
+				log.WithError(err).
+					Error("change in agent devices was detected")
+				wsm := ws.WriteMessage{
+					Message: aproto.AgentMessage{
+						AgentShutdown: &aproto.AgentShutdown{
+							ErrMsg: aproto.ErrAgentMustReconnect.Error(),
+						},
+					},
+				}
+				if err = ctx.Ask(a.socket, wsm).Error(); err != nil {
+					log.WithError(err).Error("failed to tell agent to reconnect")
+				}
+				check.Panic(err)
+				ctx.Self().Stop()
+				return
+			}
+		} else {
 			a.agentStarted(ctx, msg.AgentStarted)
 		}
 
 		a.started = true
 
 		if err := a.handleContainersReattached(ctx, msg.AgentStarted); err != nil {
-			ctx.Log().
-				WithError(err).
-				WithField("agent-id", ctx.Self().Address().Local()).
+			log.WithError(err).
 				Error("failure in handleContainersReattached")
 		}
 	case msg.ContainerStateChanged != nil:
@@ -442,7 +459,7 @@ func (a *agent) handleIncomingWSMessage(ctx *actor.Context, msg aproto.MasterMes
 		ref, ok := a.agentState.containerAllocation[msg.ContainerLog.Container.ID]
 		if !ok {
 			containerID := msg.ContainerLog.Container.ID
-			ctx.Log().WithField("container-id", containerID).Warnf(
+			log.WithField("container-id", containerID).Warnf(
 				"received ContainerLog from container not allocated to agent: "+
 					"container %s, message: %v", containerID, msg.ContainerLog)
 			return
@@ -464,7 +481,7 @@ func (a *agent) handleIncomingWSMessage(ctx *actor.Context, msg aproto.MasterMes
 				err = db.RecordTaskStatsBun(msg.ContainerStatsRecord.Stats)
 			}
 			if err != nil {
-				ctx.Log().Errorf("Error record task stats %s", err)
+				log.Errorf("error recording task stats %s", err)
 			}
 		}
 
@@ -481,7 +498,7 @@ func (a *agent) agentStarted(ctx *actor.Context, agentStarted *aproto.AgentStart
 	a.agentState = NewAgentState(
 		sproto.AddAgent{Agent: ctx.Self(), Label: agentStarted.Label},
 		a.maxZeroSlotContainers)
-	a.agentState.resourcePoolName = a.resourcePoolName // TODO that's where it gets set
+	a.agentState.resourcePoolName = a.resourcePoolName
 	a.agentState.agentStarted(ctx, agentStarted)
 	ctx.Tell(a.resourcePool, sproto.AddAgent{
 		Agent: ctx.Self(),

--- a/master/pkg/aproto/agent_message.go
+++ b/master/pkg/aproto/agent_message.go
@@ -10,11 +10,17 @@ import (
 	"github.com/determined-ai/determined/master/pkg/cproto"
 )
 
+// AgentShutdown is an explicit message from master to agent it should shutdown itself.
+type AgentShutdown struct {
+	ErrMsg string
+}
+
 // AgentMessage is a union type for all messages sent to agents.
 type AgentMessage struct {
 	MasterSetAgentOptions *MasterSetAgentOptions
 	StartContainer        *StartContainer
 	SignalContainer       *SignalContainer
+	AgentShutdown         *AgentShutdown
 }
 
 // MasterSetAgentOptions is the first message sent to an agent by the master. It lets


### PR DESCRIPTION
## Description

When master/agent task restoration is enabled (i.e. `agent_reattach_enabled: true`), and devices change on reconnect, discard the corresponding agent state and tell the agent to shutdown (and restart) as a way to not overly complicate the restore process and keep sanity. 
We use device count and their UUIDs to match the devices. UUIDs for CPUs, CUDA, and ROCM should be stable. In this change, we also introduce stability for artificial slot UUIDs, using agent id as a seed.

## Test Plan

- Automated test added. 
- Normal task restoration should continue working the same for existing setups.

For manually testing the device change handling:
1. ensure `agent_reattach_enabled: true` in master config
2.a for CUDA agent, change `NVIDIA_VISIBLE_DEVICES` on the agent container on restart so it sees different number of cards
2.b for artificial slots agent, change the number of artificial slots exposed.
3. Have agent reconnect back to master
4. Agent state will be wiped and it will be told it needs to restart
5. After another reconnection agent and master should work ok

## Commentary (optional)

In the future it'd be great to handle this case internally, without having agent restart and reconnect again.
<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
