### PR TITLE
fix: test agent config flake

### DIFF
--- a/e2e_tests/tests/deploy/test_local.py
+++ b/e2e_tests/tests/deploy/test_local.py
@@ -152,14 +152,15 @@ def test_agent_config_path() -> None:
     with open(etc_path) as f:
         assert f.read() == out.decode("utf-8")
 
-    fluent = None
     for _ in range(10):
         try:
-            fluent = client.containers.get("test-fluent")
+            client.containers.get("test-fluent")
+            break
         except docker.errors.NotFound:
             print("Waiting for 'test-fluent' container to be created")
             time.sleep(10)
-    assert fluent is not None  # Ensure config actually took effect.
+    else:
+        pytest.fail("uh-oh, fluent didn't come online")
     agent_down(["--agent-name", agent_name])
 
     # Validate CLI flags overwrite config file options.

--- a/e2e_tests/tests/deploy/test_local.py
+++ b/e2e_tests/tests/deploy/test_local.py
@@ -152,7 +152,14 @@ def test_agent_config_path() -> None:
     with open(etc_path) as f:
         assert f.read() == out.decode("utf-8")
 
-    client.containers.get("test-fluent")  # Ensure config actually took effect.
+    fluent = None
+    for _ in range(10):
+        try:
+            fluent = client.containers.get("test-fluent")
+        except docker.errors.NotFound:
+            print("Waiting for 'test-fluent' container to be created")
+            time.sleep(10)
+    assert fluent is not None  # Ensure config actually took effect.
     agent_down(["--agent-name", agent_name])
 
     # Validate CLI flags overwrite config file options.


### PR DESCRIPTION
## Description

Test flake occurring whenever test_agent_config_path runs and needs to pull the fluent docker image. We did not wait properly for the agent to create the fluent container.

## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions about this test plan to ensure adequate manual coverage of changes.
-->

## Checklist

- [X] User-facing API changes need the "User-facing API Change" label.
- [X] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [X] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
