### PR TITLE
chore: Merge Slurm-infrastructure support changes task_trial

### DIFF
--- a/master/pkg/tasks/task_trial.go
+++ b/master/pkg/tasks/task_trial.go
@@ -54,7 +54,9 @@ func (s TrialSpec) ToTaskSpec(keys *ssh.PrivateAndPublicKeys) TaskSpec {
 			trialEntrypointMode,
 			tar.TypeReg,
 		),
+	}
 
+	additionalSSHFiles := archive.Archive{
 		s.Base.AgentUserGroup.OwnedArchiveItem(sshDir, nil, sshDirMode, tar.TypeDir),
 		s.Base.AgentUserGroup.OwnedArchiveItem(trialAuthorizedKeysFile,
 			keys.PublicKey,
@@ -72,6 +74,9 @@ func (s TrialSpec) ToTaskSpec(keys *ssh.PrivateAndPublicKeys) TaskSpec {
 			sshdConfigMode,
 			tar.TypeReg,
 		),
+	}
+
+	additionalRootFiles := archive.Archive{
 		archive.RootItem(
 			trialSSHConfigFile,
 			etc.MustStaticFile(etc.SSHConfigResource),
@@ -89,6 +94,8 @@ func (s TrialSpec) ToTaskSpec(keys *ssh.PrivateAndPublicKeys) TaskSpec {
 			rootDir,
 		),
 		wrapArchive(additionalFiles, rootDir),
+		wrapArchive(additionalRootFiles, rootDir),
+		wrapArchive(additionalSSHFiles, rootDir),
 	}
 
 	res.Description = fmt.Sprintf(


### PR DESCRIPTION
## Description

One of many small changes coming to make the diff more manageable.
Keep files that are read-only in separate archives than those
that are kept per-container instance to enabble Slurm to place them
properly.

## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions about this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
