### PR TITLE
chore: Add nolintlint to deadcode for unused oss method

### DIFF
--- a/master/internal/resourcemanagers/job.go
+++ b/master/internal/resourcemanagers/job.go
@@ -54,7 +54,7 @@ func jobStats(taskList *taskList) *jobv1.QueueStats {
 	return stats
 }
 
-//nolint:deadcode // Method used by Slurm support in determined-ee
+//nolint:deadcode,nolintlint // Method used by Slurm support in determined-ee
 func jobStatsByPool(taskList *taskList, resourcePool string) *jobv1.QueueStats {
 	reqs := make(AllocReqs, 0)
 	for it := taskList.iterator(); it.next(); {


### PR DESCRIPTION

## Description

jobStatsByPool is only used in determined-ee and thus has a nolint:deadcode directive, however, since it is used in
determined-ee it additionally needs ,nolintlint to avoid a linter error that it is not needed.

## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions about this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
