### PR TITLE
test: tune web tests

### DIFF
--- a/webui/react/src/components/LogViewer/LogViewerFilters.tsx
+++ b/webui/react/src/components/LogViewer/LogViewerFilters.tsx
@@ -90,7 +90,7 @@ const LogViewerFilters: React.FC<Props> = ({ onChange, onReset, options, values 
             value={values.allocationIds}
             onChange={handleChange('allocationIds', String)}>
             {selectOptions?.allocationIds?.map(id => (
-              <Option key={id} value={id}>{id || 'No Allocation ID'}</Option>
+              <Option key={id || 'no-id'} value={id}>{id || 'No Allocation ID'}</Option>
             ))}
           </MultiSelect>
         )}
@@ -100,7 +100,7 @@ const LogViewerFilters: React.FC<Props> = ({ onChange, onReset, options, values 
             value={values.agentIds}
             onChange={handleChange('agentIds', String)}>
             {selectOptions?.agentIds?.map(id => (
-              <Option key={id} value={id}>{id || 'No Agent ID'}</Option>
+              <Option key={id || 'no-id'} value={id}>{id || 'No Agent ID'}</Option>
             ))}
           </MultiSelect>
         )}
@@ -111,7 +111,7 @@ const LogViewerFilters: React.FC<Props> = ({ onChange, onReset, options, values 
             value={values.containerIds}
             onChange={handleChange('containerIds', String)}>
             {selectOptions?.containerIds?.map(id => (
-              <Option key={id} value={id}>{id || 'No Container ID'}</Option>
+              <Option key={id || 'no-id'} value={id}>{id || 'No Container ID'}</Option>
             ))}
           </MultiSelect>
         )}
@@ -121,7 +121,7 @@ const LogViewerFilters: React.FC<Props> = ({ onChange, onReset, options, values 
             value={values.rankIds}
             onChange={handleChange('rankIds', Number)}>
             {selectOptions?.rankIds?.map(id => (
-              <Option key={id} value={id}>{id ?? 'No Rank'}</Option>
+              <Option key={id ?? 'no-id'} value={id}>{id ?? 'No Rank'}</Option>
             ))}
           </MultiSelect>
         )}

--- a/webui/react/src/components/LogViewer/LogViewerFilters.tsx
+++ b/webui/react/src/components/LogViewer/LogViewerFilters.tsx
@@ -89,8 +89,8 @@ const LogViewerFilters: React.FC<Props> = ({ onChange, onReset, options, values 
             itemName={LABELS.allocationIds}
             value={values.allocationIds}
             onChange={handleChange('allocationIds', String)}>
-            {selectOptions?.allocationIds?.map(id => (
-              <Option key={id || 'no-id'} value={id}>{id || 'No Allocation ID'}</Option>
+            {selectOptions?.allocationIds?.map((id, index) => (
+              <Option key={id || `no-id-${index}`} value={id}>{id || 'No Allocation ID'}</Option>
             ))}
           </MultiSelect>
         )}
@@ -99,8 +99,8 @@ const LogViewerFilters: React.FC<Props> = ({ onChange, onReset, options, values 
             itemName={LABELS.agentIds}
             value={values.agentIds}
             onChange={handleChange('agentIds', String)}>
-            {selectOptions?.agentIds?.map(id => (
-              <Option key={id || 'no-id'} value={id}>{id || 'No Agent ID'}</Option>
+            {selectOptions?.agentIds?.map((id, index) => (
+              <Option key={id || `no-id-${index}`} value={id}>{id || 'No Agent ID'}</Option>
             ))}
           </MultiSelect>
         )}
@@ -110,8 +110,8 @@ const LogViewerFilters: React.FC<Props> = ({ onChange, onReset, options, values 
             style={{ width: 150 }}
             value={values.containerIds}
             onChange={handleChange('containerIds', String)}>
-            {selectOptions?.containerIds?.map(id => (
-              <Option key={id || 'no-id'} value={id}>{id || 'No Container ID'}</Option>
+            {selectOptions?.containerIds?.map((id, index) => (
+              <Option key={id || `no-id-${index}`} value={id}>{id || 'No Container ID'}</Option>
             ))}
           </MultiSelect>
         )}
@@ -120,8 +120,8 @@ const LogViewerFilters: React.FC<Props> = ({ onChange, onReset, options, values 
             itemName={LABELS.rankIds}
             value={values.rankIds}
             onChange={handleChange('rankIds', Number)}>
-            {selectOptions?.rankIds?.map(id => (
-              <Option key={id ?? 'no-id'} value={id}>{id ?? 'No Rank'}</Option>
+            {selectOptions?.rankIds?.map((id, index) => (
+              <Option key={id ?? `no-id-${index}`} value={id}>{id ?? 'No Rank'}</Option>
             ))}
           </MultiSelect>
         )}

--- a/webui/react/src/components/MultiSelect.tsx
+++ b/webui/react/src/components/MultiSelect.tsx
@@ -57,7 +57,7 @@ const MultiSelect: React.FC<SelectFilterProps> = ({ itemName, onChange, value, .
       onDeselect={handleDeselect}
       onSelect={handleSelect}
       {...props}>
-      <Option value={ALL_VALUE}>{allLabel}</Option>
+      <Option key={ALL_VALUE} value={ALL_VALUE}>{allLabel}</Option>
       {props.children}
     </SelectFilter>
   );

--- a/webui/react/src/setupTests.ts
+++ b/webui/react/src/setupTests.ts
@@ -8,6 +8,16 @@ import '@testing-library/jest-dom/extend-expect';
 import 'shared/prototypes';
 import { readFileSync } from 'fs';
 
+import Schema from 'async-validator';
+
+import { noOp } from 'shared/utils/service';
+
+/**
+ * To clean up the async-validator console warning that get generated during testing.
+ * https://github.com/yiminghe/async-validator#how-to-avoid-global-warning
+ */
+Schema.warning = noOp;
+
 Object.defineProperty(window, 'matchMedia', {
   value: () => ({
     addEventListener: jest.fn(),
@@ -21,12 +31,12 @@ Object.defineProperty(window, 'matchMedia', {
 });
 
 Object.defineProperty(window, 'loadAntdStyleSheet', {
-  /*
-  * function to load ant styles into test environment
-  * https://github.com/testing-library/jest-dom/issues/113#issuecomment-496971128
-  * https://github.com/testing-library/jest-dom
-  * /blob/09f7f041805b2a4bcf5ac5c1e8201ee10a69ab9b/src/__tests__/to-have-style.js#L12-L18
-  */
+  /**
+   * function to load ant styles into test environment
+   * https://github.com/testing-library/jest-dom/issues/113#issuecomment-496971128
+   * https://github.com/testing-library/jest-dom
+   * /blob/09f7f041805b2a4bcf5ac5c1e8201ee10a69ab9b/src/__tests__/to-have-style.js#L12-L18
+   */
   value: () => {
     const antdStyleSheet = readFileSync('node_modules/antd/dist/antd.css').toString();
     const style = document.createElement('style');


### PR DESCRIPTION
## Description

Address the following:
- silence async-validator warnings show around `antd` forms (not test failures but adds a lot of noise)
- fix missing `key` error in `LogViewerFilter` tests

Sample `async-validator` warning:
```
 PASS  src/hooks/useModal/UserSettings/useModalChangeName.test.tsx (42.857 s)
  ● Console

    console.warn
      async-validator: [ "'displayName' cannot be longer than 80 characters" ]

      at Function.warning (node_modules/src/util.js:18:17)
      at callback (node_modules/src/index.js:162:20)
      at Object.validator (node_modules/src/validator/string.js:32:3)
      at func (node_modules/src/index.js:237:22)
      at forEach (node_modules/src/util.js:113:5)
          at Array.forEach (<anonymous>)
      at asyncParallelArray (node_modules/src/util.js:112:7)
      at node_modules/src/util.js:199:9
```

Sample `LogViewerFilter` missing key warning:
```
 PASS  src/components/LogViewer/LogViewerFilters.test.tsx (40.121 s)
  ● Console

    console.error
      Warning: Each child in a list should have a unique "key" prop.
      
      Check the render method of `LogViewerFilters`. See https://reactjs.org/link/warning-keys for more information.
          at Option
          at LogViewerFilters (/home/circleci/project/webui/react/src/components/LogViewer/LogViewerFilters.tsx:38:46)

      117 |         )}
      118 |         {moreThanOne.rankIds && (
    > 119 |           <MultiSelect
          |           ^
      120 |             itemName={LABELS.rankIds}
      121 |             value={values.rankIds}
      122 |             onChange={handleChange('rankIds', Number)}>

```

<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At a minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan

- [ ] check test logs to ensure there are no `async-validator` warnings
- [ ] check that LogViewerFilter tests are not warning about missing `key` attribute

<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions about this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ