### PR TITLE
fix: End agent stats log to debug level

### DIFF
--- a/master/internal/db/database.go
+++ b/master/internal/db/database.go
@@ -164,7 +164,6 @@ type DB interface {
 	TrialLogsCount(trialID int, fs []api.Filter) (int, error)
 	TrialLogsFields(trialID int) (*apiv1.TrialLogsFieldsResponse, error)
 	RecordAgentStats(a *model.AgentStats) error
-	EndAgentStats(a *model.AgentStats) error
 	EndAllAgentStats() error
 	RecordInstanceStats(a *model.InstanceStats) error
 	EndInstanceStats(a *model.InstanceStats) error

--- a/master/internal/db/postgres_agent.go
+++ b/master/internal/db/postgres_agent.go
@@ -1,6 +1,10 @@
 package db
 
 import (
+	"context"
+
+	log "github.com/sirupsen/logrus"
+
 	"github.com/determined-ai/determined/master/pkg/model"
 )
 
@@ -17,12 +21,17 @@ WHERE NOT EXISTS (
 }
 
 // EndAgentStats updates the end time of an instance.
-func (db *PgDB) EndAgentStats(a *model.AgentStats) error {
-	return db.namedExecOne(`
-UPDATE agent_stats
-SET end_time = (SELECT CURRENT_TIMESTAMP)
-WHERE agent_id = :agent_id AND end_time IS NULL
-`, a)
+func EndAgentStats(a *model.AgentStats) error {
+	res, err := Bun().NewUpdate().Table("agent_stats").Set("end_time = (SELECT CURRENT_TIMESTAMP)").Where(
+		"agent_id = ?", a.AgentID).Where("end_time IS NULL").Exec(context.TODO())
+	if err != nil {
+		return err
+	}
+	count, err := res.RowsAffected()
+	if count != 1 {
+		log.Debugf("End agent stats call affects %d row(s), this number is suppose to be 1.", count)
+	}
+	return err
 }
 
 // EndAllAgentStats called at master starts, in case master previously crushed

--- a/master/internal/db/postgres_agent.go
+++ b/master/internal/db/postgres_agent.go
@@ -22,7 +22,8 @@ WHERE NOT EXISTS (
 
 // EndAgentStats updates the end time of an instance.
 func EndAgentStats(a *model.AgentStats) error {
-	res, err := Bun().NewUpdate().Table("agent_stats").Set("end_time = (SELECT CURRENT_TIMESTAMP)").Where(
+	res, err := Bun().NewUpdate().Table("agent_stats").Set(
+		"end_time = (SELECT CURRENT_TIMESTAMP)").Where(
 		"agent_id = ?", a.AgentID).Where("end_time IS NULL").Exec(context.TODO())
 	if err != nil {
 		return err

--- a/master/internal/mocks/db.go
+++ b/master/internal/mocks/db.go
@@ -481,20 +481,6 @@ func (_m *DB) DeleteUserSessionByToken(userSessionToken string) error {
 	return r0
 }
 
-// EndAgentStats provides a mock function with given fields: a
-func (_m *DB) EndAgentStats(a *model.AgentStats) error {
-	ret := _m.Called(a)
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func(*model.AgentStats) error); ok {
-		r0 = rf(a)
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
-}
-
 // EndAllAgentStats provides a mock function with given fields:
 func (_m *DB) EndAllAgentStats() error {
 	ret := _m.Called()

--- a/master/internal/resourcemanagers/resource_pool.go
+++ b/master/internal/resourcemanagers/resource_pool.go
@@ -732,7 +732,7 @@ func (rp *ResourcePool) updateAgentStartStats(
 }
 
 func (rp *ResourcePool) updateAgentEndStats(agentID string) error {
-	return rp.db.EndAgentStats(&model.AgentStats{
+	return db.EndAgentStats(&model.AgentStats{
 		AgentID: agentID,
 	})
 }

--- a/master/internal/resourcemanagers/resource_pool_test.go
+++ b/master/internal/resourcemanagers/resource_pool_test.go
@@ -224,7 +224,6 @@ func TestAddRemoveAgent(t *testing.T) {
 	db.On("RecordAgentStats", mock.Anything).Return(nil)
 
 	system.Tell(ref, sproto.RemoveAgent{Agent: agentRef})
-	db.On("EndAgentStats", mock.Anything).Return(nil)
 }
 
 func setupRPSamePriority(t *testing.T) *ResourcePool {


### PR DESCRIPTION
## Description

Suppress unnecessary log to debug level. 


## Test Plan

Simulate a situation where agent is up but stats is not recorded, then kill the agent, there should be a debug level log `End agent stats call affects 0 row(s), this number is suppose to be 1.` instead of any error.


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ