### PR TITLE
fix: registry auth in master.yaml [DET-7629]

### DIFF
--- a/docs/release-notes/4412-registry-auth.txt
+++ b/docs/release-notes/4412-registry-auth.txt
@@ -1,0 +1,6 @@
+:orphan:
+
+**Fixes**
+
+-  Since 0.17.15, there was a bug where ``task_container_defaults.registry_auth`` was not correctly
+   passed to tasks, resulting in tasks being unable to pull images.

--- a/master/internal/config/config.go
+++ b/master/internal/config/config.go
@@ -170,7 +170,11 @@ func (c Config) Printable() ([]byte, error) {
 	}
 	if c.TaskContainerDefaults.RegistryAuth != nil {
 		if c.TaskContainerDefaults.RegistryAuth.Password != "" {
-			c.TaskContainerDefaults.RegistryAuth.Password = hiddenValue
+			// RegistryAuth is a pointer, so if we need to hide the password we need to be very
+			// careful to replace the pointer, not the contents behind the pointer.
+			printable := *c.TaskContainerDefaults.RegistryAuth
+			printable.Password = hiddenValue
+			c.TaskContainerDefaults.RegistryAuth = &printable
 		}
 	}
 

--- a/master/internal/config/config_test.go
+++ b/master/internal/config/config_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/docker/docker/api/types"
 	"github.com/ghodss/yaml"
 	"gotest.tools/assert"
 
@@ -248,6 +249,7 @@ func TestPrintableConfig(t *testing.T) {
 	s3Secret := "my_secret_key_secret"
 	masterSecret := "my_master_secret"
 	webuiSecret := "my_webui_secret"
+	registryAuthSecret := "i_love_cellos"
 
 	raw := fmt.Sprintf(`
 db:
@@ -266,7 +268,14 @@ telemetry:
   enabled: true
   segment_master_key: %v
   segment_webui_key: %v
-`, s3Key, s3Secret, masterSecret, webuiSecret)
+
+task_container_defaults:
+  registry_auth:
+    username: yo-yo-ma
+    password: %v
+    shm_size_bytes: 4294967296
+    network_mode: bridge
+`, s3Key, s3Secret, masterSecret, webuiSecret, registryAuthSecret)
 
 	expected := Config{
 		Logging: model.LoggingConfig{
@@ -290,6 +299,14 @@ telemetry:
 			SegmentMasterKey: masterSecret,
 			SegmentWebUIKey:  webuiSecret,
 		},
+		TaskContainerDefaults: model.TaskContainerDefaultsConfig{
+			RegistryAuth: &types.AuthConfig{
+				Username: "yo-yo-ma",
+				Password: registryAuthSecret,
+			},
+			ShmSizeBytes: 4294967296,
+			NetworkMode:  "bridge",
+		},
 	}
 
 	unmarshaled := Config{
@@ -309,6 +326,7 @@ telemetry:
 	assert.Assert(t, !bytes.Contains(printable, []byte(s3Secret)))
 	assert.Assert(t, !bytes.Contains(printable, []byte(masterSecret)))
 	assert.Assert(t, !bytes.Contains(printable, []byte(webuiSecret)))
+	assert.Assert(t, !bytes.Contains(printable, []byte(registryAuthSecret)))
 
 	// Ensure that the original was unmodified.
 	assert.DeepEqual(t, unmarshaled, expected)


### PR DESCRIPTION
Since 0.17.15, there was a bug where registry auth configured in
master.yaml was not correctly passed to tasks.

This change fixes it and adds it to the config unit test.

## Test Plan

- [x] added a unit test
- [x] launching a container with valid docker creds and force_pull_image=true in master.yaml is successful