### PR TITLE
feat: master config option for additional fluent outputs [DET-7549]

### DIFF
--- a/docs/release-notes/additional_fluent_outputs.txt
+++ b/docs/release-notes/additional_fluent_outputs.txt
@@ -1,0 +1,6 @@
+:orphan:
+
+**New Features**
+
+-  Logging: Master configuration now supports ```logging.additional_fluent_outputs``` allowing
+   advanced users to specify custom integrations for task logs.

--- a/docs/sysadmin-basics/cluster-config.txt
+++ b/docs/sysadmin-basics/cluster-config.txt
@@ -817,6 +817,11 @@ The master supports the following configuration settings:
                if the certificate is not signed by a well-known CA; cannot be specified if
                ``skip_verify`` is enabled.
 
+   -  ``additional_fluent_outputs``: An optional configuration string containing additional Fluent
+      Bit outputs for advanced users to specify logging integrations. See the `Fluent Bit
+      documentation <https://docs.fluentbit.io/manual/pipeline/outputs>`__ for the format and
+      supported logging outputs.
+
 -  ``scim``: (EE-only) Specifies whether the SCIM service is enabled and the credentials for clients
    to use it.
 

--- a/master/pkg/fluent/fluent.go
+++ b/master/pkg/fluent/fluent.go
@@ -66,7 +66,6 @@ func makeOutputConfig(
 				tlsConfig.CertificateName = localhost
 			}
 		}
-		fmt.Println("DEFAULT LOGGING CONFIG!!!")
 		fmt.Fprintf(config, `
 [OUTPUT]
   Name http
@@ -115,8 +114,7 @@ func makeOutputConfig(
 	}
 
 	if c := loggingConfig.AdditionalFluentOutputs; c != nil {
-		fmt.Println("\n|", *c, "|\n")
-		fmt.Fprintf(config, *c)
+		fmt.Fprint(config, *c)
 	}
 
 	const (

--- a/master/pkg/fluent/fluent.go
+++ b/master/pkg/fluent/fluent.go
@@ -66,6 +66,7 @@ func makeOutputConfig(
 				tlsConfig.CertificateName = localhost
 			}
 		}
+
 		fmt.Fprintf(config, `
 [OUTPUT]
   Name http
@@ -109,6 +110,7 @@ func makeOutputConfig(
   HTTP_Passwd %s
 `, *elasticOpts.Security.Username, *elasticOpts.Security.Password)
 		}
+
 	default:
 		panic("no log driver set for agent")
 	}

--- a/master/pkg/fluent/fluent.go
+++ b/master/pkg/fluent/fluent.go
@@ -66,7 +66,7 @@ func makeOutputConfig(
 				tlsConfig.CertificateName = localhost
 			}
 		}
-
+		fmt.Println("DEFAULT LOGGING CONFIG!!!")
 		fmt.Fprintf(config, `
 [OUTPUT]
   Name http
@@ -110,9 +110,13 @@ func makeOutputConfig(
   HTTP_Passwd %s
 `, *elasticOpts.Security.Username, *elasticOpts.Security.Password)
 		}
-
 	default:
 		panic("no log driver set for agent")
+	}
+
+	if c := loggingConfig.AdditionalFluentOutputs; c != nil {
+		fmt.Println("\n|", *c, "|\n")
+		fmt.Fprintf(config, *c)
 	}
 
 	const (

--- a/master/pkg/fluent/fluent_test.go
+++ b/master/pkg/fluent/fluent_test.go
@@ -1,0 +1,45 @@
+package fluent
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/determined-ai/determined/master/pkg/model"
+	"github.com/determined-ai/determined/master/pkg/ptrs"
+)
+
+func TestAdditionalOutputConfig(t *testing.T) {
+	additionalFluentOutputs := `
+[OUTPUT]
+  Name file
+  File test.log
+  Match *
+  Path /run/determined/fluent
+`
+	loggingConfigs := []model.LoggingConfig{
+		model.LoggingConfig{
+			DefaultLoggingConfig:    &model.DefaultLoggingConfig{},
+			AdditionalFluentOutputs: ptrs.Ptr(additionalFluentOutputs),
+		},
+		model.LoggingConfig{
+			ElasticLoggingConfig: &model.ElasticLoggingConfig{
+				Host: "test",
+				Port: 9200,
+				Security: model.ElasticSecurityConfig{
+					Username: ptrs.Ptr("username"),
+					Password: ptrs.Ptr("password"),
+				},
+			},
+			AdditionalFluentOutputs: ptrs.Ptr(additionalFluentOutputs),
+		},
+	}
+
+	for _, loggingConfig := range loggingConfigs {
+		c := &strings.Builder{}
+		makeOutputConfig(c, nil, "127.0.0.1", 8080, loggingConfig, model.TLSClientConfig{})
+		require.Contains(t, c.String(), additionalFluentOutputs,
+			"outputs did not contain additional fluent options")
+	}
+}

--- a/master/pkg/model/logging_config.go
+++ b/master/pkg/model/logging_config.go
@@ -109,8 +109,3 @@ func (t *TLSClientConfig) Resolve() error {
 	t.CertBytes = certBytes
 	return nil
 }
-
-// CustomFluentOutputs configures custom output options for fluent logging.
-type CustomFluentOutputs struct {
-	Config string `json:"config"`
-}

--- a/master/pkg/model/logging_config.go
+++ b/master/pkg/model/logging_config.go
@@ -11,8 +11,9 @@ import (
 
 // LoggingConfig configures logging for tasks (currently only trials) in Determined.
 type LoggingConfig struct {
-	DefaultLoggingConfig *DefaultLoggingConfig `union:"type,default" json:"-"`
-	ElasticLoggingConfig *ElasticLoggingConfig `union:"type,elastic" json:"-"`
+	DefaultLoggingConfig    *DefaultLoggingConfig `union:"type,default" json:"-"`
+	ElasticLoggingConfig    *ElasticLoggingConfig `union:"type,elastic" json:"-"`
+	AdditionalFluentOutputs *string               `json:"additional_fluent_outputs"`
 }
 
 // Resolve resolves the parts of the TaskContainerDefaultsConfig that must be evaluated on
@@ -107,4 +108,9 @@ func (t *TLSClientConfig) Resolve() error {
 	}
 	t.CertBytes = certBytes
 	return nil
+}
+
+// CustomFluentOutputs configures custom output options for fluent logging.
+type CustomFluentOutputs struct {
+	Config string `json:"config"`
 }


### PR DESCRIPTION
## Description

Adds ```logging.additional_fluent_outputs``` to allow advanced users to specify custom logging integrations.

## Test Plan

Go unit tests.


Manual test add this to master config  
```yaml
        logging:
          type: default
          additional_fluent_outputs: |
            [OUTPUT]
              Name file
              File test.log
              Match *
              Path /run/determined/fluent
```
Run an experiment then run
```
docker cp determined-fluent:/run/determined/fluent/test.log . && cat test.log
```
and you should see logs.

You could also make an account / follow the instructions to test with [Loki here](https://grafana.com/oss/loki/) then use this config to send logs to Loki 
```yaml
          additional_fluent_outputs: |
             [OUTPUT]
               Name        loki
               Match       *
               Host        logs-prod3.grafana.net
               port        443
               tls         on
               tls.verify  on
               labels      job=determinedai               
               http_user   <granfa_user>
               http_passwd <grafna_apitoken>
```

## Checklist

- [X] User-facing API changes need the "User-facing API Change" label.
- [X] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [X] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
