### PR TITLE
chore: strict yaml parsing warning for master and error for templates [DET-7639, DET-7640]

### DIFF
--- a/docs/release-notes/strict-parsing-master-templates.txt
+++ b/docs/release-notes/strict-parsing-master-templates.txt
@@ -3,4 +3,4 @@
 **Improvements**
 
 -  Configuration: Master configuration will give warnings for duplicate and extraneous fields.
--  Templates: New template creation will now give errors warnings for extraneous fields.
+-  Templates: New template creation will now give errors for extraneous fields.

--- a/docs/release-notes/strict-parsing-master-templates.txt
+++ b/docs/release-notes/strict-parsing-master-templates.txt
@@ -1,0 +1,6 @@
+:orphan:
+
+**Improvements**
+
+-  Configuration: Master configuration will give warnings for duplicate and extraneous fields.
+-  Templates: New template creation will now give errors warnings for extraneous fields.

--- a/e2e_tests/tests/fixtures/templates/invalid_template.yaml
+++ b/e2e_tests/tests/fixtures/templates/invalid_template.yaml
@@ -1,0 +1,6 @@
+description: test_template
+resources:
+  agent_label: ""
+  slots: 100
+  slots: 100
+extra: true

--- a/e2e_tests/tests/template/__init__.py
+++ b/e2e_tests/tests/template/__init__.py
@@ -1,1 +1,1 @@
-from .template import describe_template, set_template
+from .template import describe_template, set_template, maybe_set_template

--- a/e2e_tests/tests/template/test_template.py
+++ b/e2e_tests/tests/template/test_template.py
@@ -22,7 +22,7 @@ def test_set_template_fail_strict() -> None:
     res = tpl.maybe_set_template(template_name, template_path)
     assert res.returncode != 0
     assert "duplicate key" in str(res.stdout)
-    
+
 
 @pytest.mark.slow
 @pytest.mark.e2e_cpu

--- a/e2e_tests/tests/template/test_template.py
+++ b/e2e_tests/tests/template/test_template.py
@@ -15,6 +15,15 @@ def test_set_template() -> None:
     assert config == conf.load_config(template_path)
 
 
+@pytest.mark.e2e_cpu
+def test_set_template_fail_strict() -> None:
+    template_name = "test_set_template_invalid"
+    template_path = conf.fixtures_path("templates/invalid_template.yaml")
+    res = tpl.maybe_set_template(template_name, template_path)
+    assert res.returncode != 0
+    assert "duplicate key" in str(res.stdout)
+    
+
 @pytest.mark.slow
 @pytest.mark.e2e_cpu
 @pytest.mark.e2e_cpu_cross_version

--- a/master/cmd/determined-master/root.go
+++ b/master/cmd/determined-master/root.go
@@ -86,7 +86,7 @@ func initializeConfig() error {
 	// not_a_real_key: {}
 	var c *config.Config
 	if err = yaml.UnmarshalStrict(bs, &c, yaml.DisallowUnknownFields); err != nil {
-		log.Warnf("master configuration parsing warning (will soon be error) %s", err)
+		log.Warnf("master configuration parsing warning: %s", err.Error())
 		// TODO uncomment to turn strict parsing warnings into errors next breaking change.
 		// return err
 	}

--- a/master/cmd/determined-master/root.go
+++ b/master/cmd/determined-master/root.go
@@ -79,6 +79,18 @@ func initializeConfig() error {
 	if err != nil {
 		return err
 	}
+
+	// Validate warnings for extraneous and duplicate keys before
+	// Viper merges configuration. Viper does some weird merging logic
+	// that appears to dedupe some values along with ignoring config like
+	// not_a_real_key: {}
+	var c *config.Config
+	if err := yaml.UnmarshalStrict(bs, &c, yaml.DisallowUnknownFields); err != nil {
+		log.Warnf("master configuration parsing warning (will soon be error) %s", err)
+		// TODO uncomment to turn strict parsing warnings into errors next breaking change.
+		//return err
+	}
+
 	if err = mergeConfigBytesIntoViper(bs); err != nil {
 		return err
 	}

--- a/master/cmd/determined-master/root.go
+++ b/master/cmd/determined-master/root.go
@@ -85,10 +85,10 @@ func initializeConfig() error {
 	// that appears to dedupe some values along with ignoring config like
 	// not_a_real_key: {}
 	var c *config.Config
-	if err := yaml.UnmarshalStrict(bs, &c, yaml.DisallowUnknownFields); err != nil {
+	if err = yaml.UnmarshalStrict(bs, &c, yaml.DisallowUnknownFields); err != nil {
 		log.Warnf("master configuration parsing warning (will soon be error) %s", err)
 		// TODO uncomment to turn strict parsing warnings into errors next breaking change.
-		//return err
+		// return err
 	}
 
 	if err = mergeConfigBytesIntoViper(bs); err != nil {

--- a/master/internal/template/api.go
+++ b/master/internal/template/api.go
@@ -10,6 +10,7 @@ import (
 	"github.com/determined-ai/determined/master/internal/api"
 	"github.com/determined-ai/determined/master/internal/db"
 	"github.com/determined-ai/determined/master/pkg/model"
+	"github.com/determined-ai/determined/master/pkg/schemas/expconf"
 )
 
 // RegisterAPIHandler initializes and registers the API handlers for all template related features.
@@ -44,7 +45,10 @@ func (m *manager) put(c echo.Context) (interface{}, error) {
 	if err != nil {
 		return nil, err
 	}
-	if err := yaml.Unmarshal(body, make(map[interface{}]interface{})); err != nil {
+
+	// Validate template.
+	var t expconf.ExperimentConfig
+	if err := yaml.UnmarshalStrict(body, &t, yaml.DisallowUnknownFields); err != nil {
 		return nil, errors.Wrap(err, "invalid YAML for template")
 	}
 	return nil, errors.Wrapf(


### PR DESCRIPTION
## Description

Strict yaml parsing warning for master and error for templates. Templates already give an error but when you try and use the templates not when you create them.

## Test Plan

Templates e2e tests.

Master yaml
```
db: {}
db:
  name: test
  name: abcd
```

Should print
```
WARN[2022-06-24T11:46:53-04:00] master configuration parsing warning (will soon be error) error converting YAML to JSON: yaml: unmarshal errors:
  line 4: key "name" already set in map
  line 3: key "db" already set in map 
```

Extra keys
```
extra: {}
```

Should print
```
WARN[2022-06-24T11:47:35-04:00] master configuration parsing warning (will soon be error) error unmarshaling JSON: while decoding JSON: json: unknown field "extra" 
```

Extra key with a value should have already given an error 
```
extra=true
```

```
ERRO[2022-06-24T11:48:25-04:00] error unmarshaling JSON: while decoding JSON: json: unknown field "extra"
```


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
