### PR TITLE
feat: add spinner to show data fetching

### DIFF
--- a/webui/react/src/components/LogViewer/LogViewer.tsx
+++ b/webui/react/src/components/LogViewer/LogViewer.tsx
@@ -115,7 +115,7 @@ const LogViewer: React.FC<Props> = ({
   const baseRef = useRef<HTMLDivElement>(null);
   const logsRef = useRef<HTMLDivElement>(null);
   const listRef = useRef<VariableSizeList>(null);
-  const [ isFetching, setIsFectching ] = useState(false);
+  const [ isFetching, setIsFetching ] = useState(false);
   const local = useRef(clone(defaultLocal));
   const [ canceler ] = useState(new AbortController());
   const [ fetchDirection, setFetchDirection ] = useState(FetchDirection.Older);
@@ -178,7 +178,8 @@ const LogViewer: React.FC<Props> = ({
 
     const buffer: Log[] = [];
 
-    setIsFectching(true);
+    setIsFetching(true);
+    local.current.isFetching = true;
 
     await readStream(
       onFetch({ limit: PAGE_LIMIT, ...config } as FetchConfig, type),
@@ -188,7 +189,8 @@ const LogViewer: React.FC<Props> = ({
       },
     );
 
-    setIsFectching(false);
+    setIsFetching(false);
+    local.current.isFetching = false;
 
     return processLogs(buffer);
   }, [ decoder, fetchDirection, onFetch, processLogs ]);
@@ -542,16 +544,6 @@ const LogViewer: React.FC<Props> = ({
     />
   ), [ dateTimeWidth ]);
 
-  const getChildrenWhenEmpty = (): JSX.Element | undefined => {
-    // TODO: improve the usage of the prop onFetch...
-    if (isFetching) return <Spinner className={css.empty} spinning />;
-    if (logs.length === 0) return (
-      <div className={css.empty}>
-        <Message title="No logs to show." type={MessageType.Empty} />
-      </div>
-    );
-  };
-
   return (
     <Section
       bodyNoPadding
@@ -575,7 +567,17 @@ const LogViewer: React.FC<Props> = ({
               {LogViewerRow}
             </VariableSizeList>
           </div>
-          {getChildrenWhenEmpty()}
+          {
+            <Spinner className={css.empty} conditionalRender spinning={isFetching}>
+              {
+                (logs.length === 0) && (
+                  <div className={css.empty}>
+                    <Message title="No logs to show." type={MessageType.Empty} />
+                  </div>
+                )
+              }
+            </Spinner>
+          }
         </div>
         <div className={css.buttons} style={{ display: showButtons ? 'flex' : 'none' }}>
           <Tooltip placement="left" title={ARIA_LABEL_SCROLL_TO_OLDEST}>

--- a/webui/react/src/components/LogViewer/LogViewer.tsx
+++ b/webui/react/src/components/LogViewer/LogViewer.tsx
@@ -15,6 +15,7 @@ import { FetchArgs } from 'services/api-ts-sdk';
 import { readStream } from 'services/utils';
 import Icon from 'shared/components/Icon/Icon';
 import Message, { MessageType } from 'shared/components/Message';
+import Spinner from 'shared/components/Spinner';
 import { clone } from 'shared/utils/data';
 import { formatDatetime } from 'shared/utils/datetime';
 import { copyToClipboard } from 'shared/utils/dom';
@@ -114,6 +115,7 @@ const LogViewer: React.FC<Props> = ({
   const baseRef = useRef<HTMLDivElement>(null);
   const logsRef = useRef<HTMLDivElement>(null);
   const listRef = useRef<VariableSizeList>(null);
+  const [ isFetching, setIsFectching ] = useState(false);
   const local = useRef(clone(defaultLocal));
   const [ canceler ] = useState(new AbortController());
   const [ fetchDirection, setFetchDirection ] = useState(FetchDirection.Older);
@@ -176,7 +178,7 @@ const LogViewer: React.FC<Props> = ({
 
     const buffer: Log[] = [];
 
-    local.current.isFetching = true;
+    setIsFectching(true);
 
     await readStream(
       onFetch({ limit: PAGE_LIMIT, ...config } as FetchConfig, type),
@@ -186,7 +188,7 @@ const LogViewer: React.FC<Props> = ({
       },
     );
 
-    local.current.isFetching = false;
+    setIsFectching(false);
 
     return processLogs(buffer);
   }, [ decoder, fetchDirection, onFetch, processLogs ]);
@@ -540,6 +542,16 @@ const LogViewer: React.FC<Props> = ({
     />
   ), [ dateTimeWidth ]);
 
+  const getChildrenWhenEmpty = (): JSX.Element | undefined => {
+    // TODO: improve the usage of the prop onFetch...
+    if (isFetching) return <Spinner className={css.empty} spinning />;
+    if (logs.length === 0) return (
+      <div className={css.empty}>
+        <Message title="No logs to show." type={MessageType.Empty} />
+      </div>
+    );
+  };
+
   return (
     <Section
       bodyNoPadding
@@ -563,11 +575,7 @@ const LogViewer: React.FC<Props> = ({
               {LogViewerRow}
             </VariableSizeList>
           </div>
-          {logs.length === 0 && (
-            <div className={css.empty}>
-              <Message title="No logs to show." type={MessageType.Empty} />
-            </div>
-          )}
+          {getChildrenWhenEmpty()}
         </div>
         <div className={css.buttons} style={{ display: showButtons ? 'flex' : 'none' }}>
           <Tooltip placement="left" title={ARIA_LABEL_SCROLL_TO_OLDEST}>

--- a/webui/react/src/components/ResponsiveTable.tsx
+++ b/webui/react/src/components/ResponsiveTable.tsx
@@ -86,14 +86,17 @@ const ResponsiveTable: ResponsiveTable = ({
 
   return (
     <div ref={tableRef}>
-      <Spinner spinning={spinning}>
-        <Table
-          bordered
-          scroll={tableScroll}
-          tableLayout="auto"
-          {...props}
-        />
-      </Spinner>
+      {
+        spinning ? <Spinner spinning={true} />
+          : (
+            <Table
+              bordered
+              scroll={tableScroll}
+              tableLayout="auto"
+              {...props}
+            />
+          )
+      }
     </div>
   );
 };

--- a/webui/react/src/components/ResponsiveTable.tsx
+++ b/webui/react/src/components/ResponsiveTable.tsx
@@ -86,17 +86,14 @@ const ResponsiveTable: ResponsiveTable = ({
 
   return (
     <div ref={tableRef}>
-      {
-        spinning ? <Spinner spinning={true} />
-          : (
-            <Table
-              bordered
-              scroll={tableScroll}
-              tableLayout="auto"
-              {...props}
-            />
-          )
-      }
+      <Spinner conditionalRender spinning={spinning}>
+        <Table
+          bordered
+          scroll={tableScroll}
+          tableLayout="auto"
+          {...props}
+        />
+      </Spinner>
     </div>
   );
 };

--- a/webui/react/src/pages/TrialDetails/TrialChart.module.scss
+++ b/webui/react/src/pages/TrialDetails/TrialChart.module.scss
@@ -4,3 +4,10 @@
   height: 400px;
   justify-content: center;
 }
+
+.spinner {
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}

--- a/webui/react/src/pages/TrialDetails/TrialChart.tsx
+++ b/webui/react/src/pages/TrialDetails/TrialChart.tsx
@@ -108,21 +108,18 @@ const TrialChart: React.FC<Props> = ({
     </ResponsiveFilters>
   );
 
-  const getChildren = (): JSX.Element => {
-    if (!trialId) return (
-      <Spinner className={css.spinner} spinning />
-    );
-
-    if (chartData[0].length === 0)
-      return <Empty description="No data to plot." image={Empty.PRESENTED_IMAGE_SIMPLE} />;
-
-    return <UPlotChart data={chartData} options={chartOptions} />;
-  };
-
   return (
     <Section bodyBorder options={options} title="Metrics">
       <div className={css.base}>
-        {getChildren()}
+        {
+          <Spinner className={css.spinner} conditionalRender spinning={!trialId}>
+            {
+              chartData[0].length === 0
+                ? <Empty description="No data to plot." image={Empty.PRESENTED_IMAGE_SIMPLE} />
+                : <UPlotChart data={chartData} options={chartOptions} />
+            }
+          </Spinner>
+        }
       </div>
     </Section>
   );

--- a/webui/react/src/pages/TrialDetails/TrialChart.tsx
+++ b/webui/react/src/pages/TrialDetails/TrialChart.tsx
@@ -10,6 +10,7 @@ import UPlotChart, { Options } from 'components/UPlot/UPlotChart';
 import { tooltipsPlugin } from 'components/UPlot/UPlotChart/tooltipsPlugin';
 import { trackAxis } from 'components/UPlot/UPlotChart/trackAxis';
 import css from 'pages/TrialDetails/TrialChart.module.scss';
+import Spinner from 'shared/components/Spinner';
 import { glasbeyColor } from 'shared/utils/color';
 import { MetricName, MetricType, Scale, WorkloadGroup } from 'types';
 
@@ -107,12 +108,21 @@ const TrialChart: React.FC<Props> = ({
     </ResponsiveFilters>
   );
 
+  const getChildren = (): JSX.Element => {
+    if (!trialId) return (
+      <Spinner className={css.spinner} spinning />
+    );
+
+    if (chartData[0].length === 0)
+      return <Empty description="No data to plot." image={Empty.PRESENTED_IMAGE_SIMPLE} />;
+
+    return <UPlotChart data={chartData} options={chartOptions} />;
+  };
+
   return (
     <Section bodyBorder options={options} title="Metrics">
       <div className={css.base}>
-        {chartData[0].length === 0 ?
-          <Empty description="No data to plot." image={Empty.PRESENTED_IMAGE_SIMPLE} /> :
-          <UPlotChart data={chartData} options={chartOptions} />}
+        {getChildren()}
       </div>
     </Section>
   );

--- a/webui/react/src/pages/TrialDetails/TrialDetailsHyperparameters.tsx
+++ b/webui/react/src/pages/TrialDetails/TrialDetailsHyperparameters.tsx
@@ -58,23 +58,20 @@ const TrialDetailsHyperparameters: React.FC<Props> = ({ trial, pageRef }: Props)
 
   return (
     <div className={css.base}>
-      {
-        trial ? (
-          <InteractiveTable
-            columns={columns}
-            containerRef={pageRef}
-            dataSource={dataSource}
-            pagination={false}
-            rowClassName={defaultRowClassName({ clickable: false })}
-            rowKey="hyperparameter"
-            settings={settings as InteractiveTableSettings}
-            showSorterTooltip={false}
-            size="small"
-            updateSettings={updateSettings as UpdateSettings<InteractiveTableSettings>}
-          />
-        )
-          : <Spinner spinning />
-      }
+      <Spinner conditionalRender spinning={!trial}>
+        <InteractiveTable
+          columns={columns}
+          containerRef={pageRef}
+          dataSource={dataSource}
+          pagination={false}
+          rowClassName={defaultRowClassName({ clickable: false })}
+          rowKey="hyperparameter"
+          settings={settings as InteractiveTableSettings}
+          showSorterTooltip={false}
+          size="small"
+          updateSettings={updateSettings as UpdateSettings<InteractiveTableSettings>}
+        />
+      </Spinner>
     </div>
   );
 };

--- a/webui/react/src/pages/TrialDetails/TrialDetailsHyperparameters.tsx
+++ b/webui/react/src/pages/TrialDetails/TrialDetailsHyperparameters.tsx
@@ -3,6 +3,7 @@ import React, { useMemo } from 'react';
 import InteractiveTable, { ColumnDef, InteractiveTableSettings } from 'components/InteractiveTable';
 import { defaultRowClassName } from 'components/Table';
 import useSettings, { UpdateSettings } from 'hooks/useSettings';
+import Spinner from 'shared/components/Spinner';
 import { isObject } from 'shared/utils/data';
 import { TrialDetails } from 'types';
 import { alphaNumericSorter } from 'utils/sort';
@@ -57,18 +58,23 @@ const TrialDetailsHyperparameters: React.FC<Props> = ({ trial, pageRef }: Props)
 
   return (
     <div className={css.base}>
-      <InteractiveTable
-        columns={columns}
-        containerRef={pageRef}
-        dataSource={dataSource}
-        pagination={false}
-        rowClassName={defaultRowClassName({ clickable: false })}
-        rowKey="hyperparameter"
-        settings={settings as InteractiveTableSettings}
-        showSorterTooltip={false}
-        size="small"
-        updateSettings={updateSettings as UpdateSettings<InteractiveTableSettings>}
-      />
+      {
+        trial ? (
+          <InteractiveTable
+            columns={columns}
+            containerRef={pageRef}
+            dataSource={dataSource}
+            pagination={false}
+            rowClassName={defaultRowClassName({ clickable: false })}
+            rowKey="hyperparameter"
+            settings={settings as InteractiveTableSettings}
+            showSorterTooltip={false}
+            size="small"
+            updateSettings={updateSettings as UpdateSettings<InteractiveTableSettings>}
+          />
+        )
+          : <Spinner spinning />
+      }
     </div>
   );
 };

--- a/webui/react/src/pages/TrialDetails/TrialDetailsLogs.tsx
+++ b/webui/react/src/pages/TrialDetails/TrialDetailsLogs.tsx
@@ -172,17 +172,14 @@ const TrialDetailsLogs: React.FC<Props> = ({ experiment, trial }: Props) => {
 
   return (
     <div className={css.base}>
-      {
-        trial ? (
-          <LogViewer
-            decoder={mapV1LogsResponse}
-            title={logFilters}
-            onDownload={handleDownloadLogs}
-            onFetch={handleFetch}
-          />
-        )
-          : <Spinner spinning />
-      }
+      <Spinner conditionalRender spinning={!trial}>
+        <LogViewer
+          decoder={mapV1LogsResponse}
+          title={logFilters}
+          onDownload={handleDownloadLogs}
+          onFetch={handleFetch}
+        />
+      </Spinner>
     </div>
   );
 };

--- a/webui/react/src/pages/TrialDetails/TrialDetailsLogs.tsx
+++ b/webui/react/src/pages/TrialDetails/TrialDetailsLogs.tsx
@@ -11,6 +11,7 @@ import { serverAddress } from 'routes/utils';
 import { detApi } from 'services/apiConfig';
 import { mapV1LogsResponse } from 'services/decoder';
 import { readStream } from 'services/utils';
+import Spinner from 'shared/components/Spinner';
 import { ExperimentBase, TrialDetails } from 'types';
 import { downloadTrialLogs } from 'utils/browser';
 import handleError from 'utils/error';
@@ -171,12 +172,17 @@ const TrialDetailsLogs: React.FC<Props> = ({ experiment, trial }: Props) => {
 
   return (
     <div className={css.base}>
-      <LogViewer
-        decoder={mapV1LogsResponse}
-        title={logFilters}
-        onDownload={handleDownloadLogs}
-        onFetch={trial && handleFetch}
-      />
+      {
+        trial ? (
+          <LogViewer
+            decoder={mapV1LogsResponse}
+            title={logFilters}
+            onDownload={handleDownloadLogs}
+            onFetch={handleFetch}
+          />
+        )
+          : <Spinner spinning />
+      }
     </div>
   );
 };

--- a/webui/react/src/pages/TrialDetails/TrialDetailsOverview.tsx
+++ b/webui/react/src/pages/TrialDetails/TrialDetailsOverview.tsx
@@ -28,7 +28,7 @@ const TrialDetailsOverview: React.FC<Props> = ({ experiment, trial }: Props) => 
     const defaultValidationMetric = metricNames.find(metricName => (
       metricName.name === validationMetric && metricName.type === MetricType.Validation
     ));
-    const fallbackMetric = metricNames && metricNames.length !== 0 ? metricNames[0] : undefined;
+    const fallbackMetric = metricNames[0];
     const defaultMetric = defaultValidationMetric || fallbackMetric;
     const defaultMetrics = defaultMetric ? [ defaultMetric ] : [];
     const settingMetrics: MetricName[] = (settings.metric || []).map(metric => {

--- a/webui/react/src/pages/TrialDetails/TrialDetailsWorkloads.tsx
+++ b/webui/react/src/pages/TrialDetails/TrialDetailsWorkloads.tsx
@@ -164,6 +164,7 @@ const TrialDetailsWorkloads: React.FC<Props> = ({
         <ResponsiveTable<Step>
           columns={columns}
           dataSource={workloadSteps}
+          loading={!trial}
           pagination={getFullPaginationConfig({
             limit: settings.tableLimit,
             offset: settings.tableOffset,


### PR DESCRIPTION
## Description

Original ticket: [DET-7180]

Some of the tabs from the `ExperimentSingleTrialTabs` component were showing a "No data" message and icon while the component fetches the experiment/trial details in the background.

So, to better visualize the initial data fetching, I've bound the `trial` prop (which is `undefined` while it fetches) to a spinner conditional rendering on the affected component tabs (Overview, Hyperparameters and Logs).

<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At a minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan

To test this implementation, go to any experiment overview page `/experiments/<experiment_id>/overview`, upon reaching the page, the spinner should appear to highlight data fetching, instead of the "No Data" background.

The same behavior is expected for each experiment tab on this page.

For more context, check the gifs linked below.

<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions about this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

Here's some gifs to better visualize the changes:


https://user-images.githubusercontent.com/104855841/176259925-e6d8d9d1-9ae7-47a4-a5c2-0b93f1a6d689.mp4


https://user-images.githubusercontent.com/104855841/176259941-8736fe88-6920-4908-baa8-5ba36b765038.mp4


https://user-images.githubusercontent.com/104855841/176259949-9d9532a2-612f-45c4-b11f-dc17ed26a0d1.mp4



<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[DET-7180]: https://determinedai.atlassian.net/browse/DET-7180?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ