### PR TITLE
fix: long tag display

### DIFF
--- a/webui/react/src/components/TagList.module.scss
+++ b/webui/react/src/components/TagList.module.scss
@@ -16,6 +16,7 @@
   }
   .tagEdit {
     white-space: break-spaces;
+    word-break: break-word;
   }
   .tagPlus:hover,
   .tagEdit:hover {


### PR DESCRIPTION
## Description

Fix long tag display in experiment table

Before: 
<img width="994" alt="Screen Shot 2022-06-29 at 1 22 54 PM" src="https://user-images.githubusercontent.com/40620519/176509801-47cac949-f7a1-4208-896c-f08736bc0bd1.png">

After: 
<img width="859" alt="Screen Shot 2022-06-29 at 1 23 07 PM" src="https://user-images.githubusercontent.com/40620519/176509809-c18dba5f-e426-4105-b22d-50761864216b.png">



## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
