### PR TITLE
docs: PyTorchTrialCallback.on_validation_end

### DIFF
--- a/harness/determined/pytorch/_callback.py
+++ b/harness/determined/pytorch/_callback.py
@@ -57,9 +57,6 @@ class PyTorchCallback:
     def on_validation_end(self, metrics: Dict[str, Any]) -> None:
         """
         Run after every validation ends.
-
-        .. warning::
-            This callback only executes on the chief GPU when doing distributed training.
         """
         pass
 
@@ -73,9 +70,6 @@ class PyTorchCallback:
     def on_validation_step_end(self, metrics: Dict[str, Any]) -> None:
         """
         Run after every validation step ends.
-
-        .. warning::
-            This callback only executes on the chief GPU when doing distributed training.
         """
         # TODO(DET-3555): remove this once it has been deprecated long enough.
         pass


### PR DESCRIPTION
It is called on every rank, but the docs said it wasn't.

It should be called on every rank, so fix the docs.