### PR TITLE
feat: support non-root init container k8s [DET-7109]

### DIFF
--- a/docs/release-notes/non-root-init-k8s.txt
+++ b/docs/release-notes/non-root-init-k8s.txt
@@ -1,0 +1,5 @@
+:orphan:
+
+**New Features**
+
+- Kubernetes: Init container no longer requires root privileges.

--- a/docs/release-notes/non-root-init-k8s.txt
+++ b/docs/release-notes/non-root-init-k8s.txt
@@ -2,4 +2,4 @@
 
 **New Features**
 
-- Kubernetes: Init container no longer requires root privileges.
+-  Kubernetes: Task init containers no longer require root privileges.

--- a/master/internal/resourcemanagers/kubernetes/volumes.go
+++ b/master/internal/resourcemanagers/kubernetes/volumes.go
@@ -10,6 +10,7 @@ import (
 
 	k8sV1 "k8s.io/api/core/v1"
 
+	"github.com/determined-ai/determined/master/pkg/archive"
 	"github.com/determined-ai/determined/master/pkg/cproto"
 )
 
@@ -107,7 +108,7 @@ func configureAdditionalFilesVolumes(
 	initContainerVolumeMounts = append(initContainerVolumeMounts, archiveVolumeMount)
 
 	entryPointVolumeName := "entrypoint-volume"
-	var entryPointVolumeMode int32 = 0700
+	var entryPointVolumeMode int32 = 0555
 	entryPointVolume := k8sV1.Volume{
 		Name: entryPointVolumeName,
 		VolumeSource: k8sV1.VolumeSource{
@@ -142,14 +143,56 @@ func configureAdditionalFilesVolumes(
 	}
 	initContainerVolumeMounts = append(initContainerVolumeMounts, dstVolumeMount)
 
+	rootPathsToItem := make(map[string][]archive.Item)
 	for idx, runArchive := range runArchives {
 		for _, item := range runArchive.Archive {
-			mainContainerVolumeMounts = append(mainContainerVolumeMounts, k8sV1.VolumeMount{
-				Name:      additionalFilesVolumeName,
-				MountPath: path.Join(runArchive.Path, item.Path),
-				SubPath:   path.Join(fmt.Sprintf("%d", idx), item.Path),
+			// Files that aren't owned by root can get extracted.
+			if !item.NeedsRoot {
+				mainContainerVolumeMounts = append(mainContainerVolumeMounts, k8sV1.VolumeMount{
+					Name:      additionalFilesVolumeName,
+					MountPath: path.Join(runArchive.Path, item.Path),
+					SubPath:   path.Join(fmt.Sprintf("%d", idx), item.Path),
+				})
+			} else {
+				dir := path.Dir(item.Path)
+				rootPathsToItem[dir] = append(rootPathsToItem[dir], item)
+			}
+		}
+	}
+
+	// Files owned by root will be added as a config map unextracted.
+	i := 0
+	for dir, items := range rootPathsToItem {
+		volumeName := fmt.Sprintf("root-volume-%d", i)
+		i++
+
+		var keyToPaths []k8sV1.KeyToPath
+		for _, item := range items {
+			itemBase := path.Base(item.Path)
+			mode := int32(item.FileMode)
+			keyToPaths = append(keyToPaths, k8sV1.KeyToPath{
+				Key:  itemBase,
+				Path: itemBase,
+				Mode: &mode,
 			})
 		}
+		volumes = append(volumes, k8sV1.Volume{
+			Name: volumeName,
+			VolumeSource: k8sV1.VolumeSource{
+				ConfigMap: &k8sV1.ConfigMapVolumeSource{
+					LocalObjectReference: k8sV1.LocalObjectReference{
+						Name: configMapName,
+					},
+					Items: keyToPaths,
+				},
+			},
+		})
+
+		mainContainerVolumeMounts = append(mainContainerVolumeMounts, k8sV1.VolumeMount{
+			Name:      volumeName,
+			MountPath: dir,
+			ReadOnly:  true, // Assume root files will be read only.
+		})
 	}
 
 	return initContainerVolumeMounts, mainContainerVolumeMounts, volumes

--- a/master/internal/resourcemanagers/kubernetes/volumes.go
+++ b/master/internal/resourcemanagers/kubernetes/volumes.go
@@ -10,7 +10,6 @@ import (
 
 	k8sV1 "k8s.io/api/core/v1"
 
-	"github.com/determined-ai/determined/master/pkg/archive"
 	"github.com/determined-ai/determined/master/pkg/cproto"
 )
 
@@ -143,56 +142,14 @@ func configureAdditionalFilesVolumes(
 	}
 	initContainerVolumeMounts = append(initContainerVolumeMounts, dstVolumeMount)
 
-	rootPathsToItem := make(map[string][]archive.Item)
 	for idx, runArchive := range runArchives {
 		for _, item := range runArchive.Archive {
-			// Files that aren't owned by root can get extracted.
-			if !item.NeedsRoot {
-				mainContainerVolumeMounts = append(mainContainerVolumeMounts, k8sV1.VolumeMount{
-					Name:      additionalFilesVolumeName,
-					MountPath: path.Join(runArchive.Path, item.Path),
-					SubPath:   path.Join(fmt.Sprintf("%d", idx), item.Path),
-				})
-			} else {
-				dir := path.Dir(item.Path)
-				rootPathsToItem[dir] = append(rootPathsToItem[dir], item)
-			}
-		}
-	}
-
-	// Files owned by root will be added as a config map unextracted.
-	i := 0
-	for dir, items := range rootPathsToItem {
-		volumeName := fmt.Sprintf("root-volume-%d", i)
-		i++
-
-		var keyToPaths []k8sV1.KeyToPath
-		for _, item := range items {
-			itemBase := path.Base(item.Path)
-			mode := int32(item.FileMode)
-			keyToPaths = append(keyToPaths, k8sV1.KeyToPath{
-				Key:  itemBase,
-				Path: itemBase,
-				Mode: &mode,
+			mainContainerVolumeMounts = append(mainContainerVolumeMounts, k8sV1.VolumeMount{
+				Name:      additionalFilesVolumeName,
+				MountPath: path.Join(runArchive.Path, item.Path),
+				SubPath:   path.Join(fmt.Sprintf("%d", idx), item.Path),
 			})
 		}
-		volumes = append(volumes, k8sV1.Volume{
-			Name: volumeName,
-			VolumeSource: k8sV1.VolumeSource{
-				ConfigMap: &k8sV1.ConfigMapVolumeSource{
-					LocalObjectReference: k8sV1.LocalObjectReference{
-						Name: configMapName,
-					},
-					Items: keyToPaths,
-				},
-			},
-		})
-
-		mainContainerVolumeMounts = append(mainContainerVolumeMounts, k8sV1.VolumeMount{
-			Name:      volumeName,
-			MountPath: dir,
-			ReadOnly:  true, // Assume root files will be read only.
-		})
 	}
 
 	return initContainerVolumeMounts, mainContainerVolumeMounts, volumes

--- a/master/pkg/archive/archive.go
+++ b/master/pkg/archive/archive.go
@@ -41,6 +41,7 @@ type Item struct {
 	ModifiedTime UnixTime    `json:"mtime"`
 	UserID       int         `json:"uid"`
 	GroupID      int         `json:"gid"`
+	NeedsRoot    bool        `josn:"needsRoot"`
 }
 
 // BaseName returns the base name of the file.
@@ -86,7 +87,9 @@ func (ar Archive) ContainsFilePrefix(prefix string) bool {
 
 // RootItem returns a new Item which will be owned by root when embedded in a container.
 func RootItem(path string, content []byte, mode int, fileType byte) Item {
-	return UserItem(path, content, mode, fileType, 0, 0)
+	i := UserItem(path, content, mode, fileType, 0, 0)
+	i.NeedsRoot = true
+	return i
 }
 
 // UserItem returns a new Item which will be owned by the user under which the container runs.

--- a/master/pkg/archive/archive.go
+++ b/master/pkg/archive/archive.go
@@ -1,6 +1,8 @@
 package archive
 
 import (
+	"fmt"
+
 	"archive/tar"
 	"bytes"
 	"compress/gzip"
@@ -41,7 +43,7 @@ type Item struct {
 	ModifiedTime UnixTime    `json:"mtime"`
 	UserID       int         `json:"uid"`
 	GroupID      int         `json:"gid"`
-	NeedsRoot    bool        `josn:"needsRoot"`
+	IsRootItem   bool        `json:"isRootItem"`
 }
 
 // BaseName returns the base name of the file.
@@ -87,8 +89,9 @@ func (ar Archive) ContainsFilePrefix(prefix string) bool {
 
 // RootItem returns a new Item which will be owned by root when embedded in a container.
 func RootItem(path string, content []byte, mode int, fileType byte) Item {
+	fmt.Println("ROOT ITEM!!!", path)
 	i := UserItem(path, content, mode, fileType, 0, 0)
-	i.NeedsRoot = true
+	i.IsRootItem = true
 	return i
 }
 

--- a/master/pkg/archive/archive.go
+++ b/master/pkg/archive/archive.go
@@ -1,8 +1,6 @@
 package archive
 
 import (
-	"fmt"
-
 	"archive/tar"
 	"bytes"
 	"compress/gzip"
@@ -89,7 +87,6 @@ func (ar Archive) ContainsFilePrefix(prefix string) bool {
 
 // RootItem returns a new Item which will be owned by root when embedded in a container.
 func RootItem(path string, content []byte, mode int, fileType byte) Item {
-	fmt.Println("ROOT ITEM!!!", path)
 	i := UserItem(path, content, mode, fileType, 0, 0)
 	i.IsRootItem = true
 	return i

--- a/master/pkg/model/agent_user_group.go
+++ b/master/pkg/model/agent_user_group.go
@@ -51,7 +51,7 @@ func (c *AgentUserGroup) OwnedArchiveItem(
 	path string, content []byte, mode int, fileType byte,
 ) archive.Item {
 	if c == nil {
-		return archive.RootItem(path, content, mode, fileType)
+		return archive.UserItem(path, content, mode, fileType, 0, 0)
 	}
 	return archive.UserItem(path, content, mode, fileType, c.UID, c.GID)
 }

--- a/master/pkg/tasks/task.go
+++ b/master/pkg/tasks/task.go
@@ -106,10 +106,9 @@ func (t *TaskSpec) Archives() ([]cproto.RunArchive, []cproto.RunArchive) {
 	}
 	res = append(res, t.ExtraArchives...)
 
-	// Split into root and non root required files.
-	// In the case the all files are root we will
-	// still differentiate files that need to be root
-	// verse files that owned by the user.
+	// Split into root and non root required files. In the case the user
+	// is root we will still differentiate files that need to be root
+	// versus files that should be owned by the user.
 	var user, root []cproto.RunArchive
 	for _, a := range res {
 		var uItems, rItems archive.Archive

--- a/master/pkg/tasks/task.go
+++ b/master/pkg/tasks/task.go
@@ -96,7 +96,7 @@ func (t *TaskSpec) ResolveWorkDir() {
 }
 
 // Archives returns all the archives.
-func (t *TaskSpec) Archives() []cproto.RunArchive {
+func (t *TaskSpec) Archives() ([]cproto.RunArchive, []cproto.RunArchive) {
 	res := []cproto.RunArchive{
 		workDirArchive(t.AgentUserGroup, t.WorkDir, t.WorkDir == DefaultWorkDir),
 		runDirHelpersArchive(t.AgentUserGroup),
@@ -105,7 +105,36 @@ func (t *TaskSpec) Archives() []cproto.RunArchive {
 		masterCertArchive(t.MasterCert),
 	}
 	res = append(res, t.ExtraArchives...)
-	return res
+
+	// Split into root and non root required files.
+	// In the case the all files are root we will
+	// still differentiate files that need to be root
+	// verse files that owned by the user.
+	var user, root []cproto.RunArchive
+	for _, a := range res {
+		var uItems, rItems archive.Archive
+		for _, item := range a.Archive {
+			if item.IsRootItem {
+				rItems = append(rItems, item)
+			} else {
+				uItems = append(uItems, item)
+			}
+		}
+
+		if len(rItems) > 0 {
+			root = append(root, cproto.RunArchive{
+				Path:        a.Path,
+				CopyOptions: a.CopyOptions,
+				Archive:     rItems})
+		}
+		if len(uItems) > 0 {
+			user = append(user, cproto.RunArchive{
+				Path:        a.Path,
+				CopyOptions: a.CopyOptions,
+				Archive:     uItems})
+		}
+	}
+	return user, root
 }
 
 // EnvVars returns all the environment variables.
@@ -196,6 +225,7 @@ func (t *TaskSpec) ToDockerSpec() cproto.Spec {
 		})
 	}
 
+	runArchives, rootArchives := t.Archives()
 	spec := cproto.Spec{
 		TaskType: string(t.TaskType),
 		PullSpec: cproto.PullSpec{
@@ -223,7 +253,7 @@ func (t *TaskSpec) ToDockerSpec() cproto.Spec {
 					Devices: devices,
 				},
 			},
-			Archives:         t.Archives(),
+			Archives:         append(runArchives, rootArchives...),
 			UseFluentLogging: true,
 		},
 	}

--- a/master/static/srv/k8_init_container_entrypoint.sh
+++ b/master/static/srv/k8_init_container_entrypoint.sh
@@ -13,9 +13,5 @@ do
     SRC=$2/$IDX.tar.gz
     DST=$3/$IDX
     mkdir $DST
-
-    if [ -f $SRC ]
-    then
-        tar -xvf $SRC -C $DST
-    fi
+    tar -xvf $SRC -C $DST
 done

--- a/master/static/srv/k8_init_container_entrypoint.sh
+++ b/master/static/srv/k8_init_container_entrypoint.sh
@@ -13,6 +13,9 @@ do
     SRC=$2/$IDX.tar.gz
     DST=$3/$IDX
     mkdir $DST
-    # TODO(Brad): init container runs as root to use --same-owner, could be a problem.
-    tar --same-owner -xvf $SRC -C $DST
+
+    if [ -f $SRC ]
+    then
+        tar -xvf $SRC -C $DST
+    fi
 done


### PR DESCRIPTION
## Description

Support non root init container k8s.

## Test Plan

Run a dtrain job as admin and non admin on k8s and verify it works correctly and that the root container is running as non root. 

To run as a nonroot user you can link determined agent to linux user / group on the nodes of the k8 cluster.

SSH into all the nodes of the cluster with
```
gcloud compute ssh <node name from kubectl get nodes>
```

then run the following commands to create a user
```
sudo useradd normal
id -u  normal  # user id
id -g  normal  # group id
sudo mkdir /checkpoints && sudo chown normal: /checkpoints  
sudo chmod u+w /checkpoints
```

Then link the determined user with this linux user / group and all following experiments should run as that user
```
det -u admin user link-with-agent-user determined --agent-uid 1038 --agent-user normal --agent-gid 1039 --agent-group normal
```

This can be validated by doing a ```kubectl describe pod``` on the running pod and seeing the init container correctly having a non zero ```runAsUser``` in security context for the container.


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [X] User-facing API changes need the "User-facing API Change" label.
- [X] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [X] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
