### PR TITLE
fix: loadingState cleanup for WorkspaceList

### DIFF
--- a/webui/react/src/pages/ProjectDetails.tsx
+++ b/webui/react/src/pages/ProjectDetails.tsx
@@ -587,7 +587,7 @@ const ProjectDetails: React.FC = () => {
           return Promise.resolve();
       }
     }));
-  }, [ settings.row, openMoveModal, project?.workspaceId, project?.id ]);
+  }, [ settings.row, openMoveModal, project?.workspaceId, project?.id, experimentMap, user ]);
 
   const submitBatchAction = useCallback(async (action: Action) => {
     try {

--- a/webui/react/src/pages/TrialDetails/TrialChart.module.scss
+++ b/webui/react/src/pages/TrialDetails/TrialChart.module.scss
@@ -4,10 +4,9 @@
   height: 400px;
   justify-content: center;
 }
-
 .spinner {
-  width: 100%;
+  align-items: center;
   display: flex;
   justify-content: center;
-  align-items: center;
+  width: 100%;
 }

--- a/webui/react/src/pages/WorkspaceList.tsx
+++ b/webui/react/src/pages/WorkspaceList.tsx
@@ -273,8 +273,7 @@ const WorkspaceList: React.FC = () => {
 
   useEffect(() => {
     setIsLoading(true);
-    fetchWorkspaces();
-    setIsLoading(false);
+    fetchWorkspaces().then(() => setIsLoading(false));
   }, [ fetchWorkspaces ]);
 
   useEffect(() => {

--- a/webui/react/src/pages/WorkspaceList.tsx
+++ b/webui/react/src/pages/WorkspaceList.tsx
@@ -62,7 +62,6 @@ const WorkspaceList: React.FC = () => {
   }, [ modalOpen ]);
 
   const fetchWorkspaces = useCallback(async () => {
-    setIsLoading(true);
     try {
       const response = await getWorkspaces({
         archived: settings.archived ? undefined : false,

--- a/webui/react/src/pages/WorkspaceList.tsx
+++ b/webui/react/src/pages/WorkspaceList.tsx
@@ -93,7 +93,7 @@ const WorkspaceList: React.FC = () => {
     settings.tableOffset,
     settings.user ]);
 
-  usePolling(fetchWorkspaces, { rerunOnNewFn: true });
+  usePolling(fetchWorkspaces);
 
   const handleViewSelect = useCallback((value) => {
     setWorkspaceFilter(value as WorkspaceFilters);
@@ -272,7 +272,9 @@ const WorkspaceList: React.FC = () => {
     workspaces ]);
 
   useEffect(() => {
+    setIsLoading(true);
     fetchWorkspaces();
+    setIsLoading(false);
   }, [ fetchWorkspaces ]);
 
   useEffect(() => {


### PR DESCRIPTION
## Description

setting `isLoading=true` for every poll results in the following flashing behavior

https://user-images.githubusercontent.com/28383080/176763109-6381cc34-5fe1-4038-bd32-bc08eb629ed3.mov


## Test Plan

use network throttling:
 - both table and grid don't flash as long as you don't do anything
 - when you update dropdowns/filters the loading state should be reflected

## Commentary (optional)


left some comments in the code.



## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
