### PR TITLE
fix: sync agent actor init on master restart [DET-7746]

### DIFF
--- a/master/internal/resourcemanagers/agent/agent.go
+++ b/master/internal/resourcemanagers/agent/agent.go
@@ -117,7 +117,8 @@ func (a *agent) receive(ctx *actor.Context, msg interface{}) error {
 			a.socketDisconnected(ctx)
 			// TODO(ilia): Adding restored agent here will overcount AgentStarts by maximum
 			// agentReconnectWait if it never reconnects.
-			ctx.Tell(a.resourcePool, sproto.AddAgent{Agent: ctx.Self(), Label: a.agentState.Label})
+			// Ensure RP is aware of the agent.
+			ctx.Ask(a.resourcePool, sproto.AddAgent{Agent: ctx.Self(), Label: a.agentState.Label}).Get()
 		}
 		a.slots, _ = ctx.ActorOf("slots", &slots{})
 	case model.AgentSummary:


### PR DESCRIPTION
## Description

Wait until agents actor initializes agent actors and they add themselves to a resource pool to avoid a race condition in restoring tasks on master restart. 
This is a race condition which happens 100% of the time when manually cycling `det deploy aws` clusters, but not in CircleCI or local tests.

## Test Plan

1. Make a `det deploy aws` cluster
2. ssh into the cluster and set `agent_reattach_enabled: true` for both resource pools in the master config in `/usr/local/determined/etc/master.yaml`.
3. Start a jupyter notebook
4. `sudo docker restart determined-master`
5. The notebook should still be running and accessible (jupyterlab will show a disconnection message).

## Commentary (optional)

## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
