### PR TITLE
fix: flaky test failure: test_agent_reconnect_keep_cmd [DET-7695]

### DIFF
--- a/e2e_tests/tests/cluster/test_agent_restart.py
+++ b/e2e_tests/tests/cluster/test_agent_restart.py
@@ -277,7 +277,7 @@ def test_agent_reconnect_keep_cmd(managed_cluster: ManagedCluster) -> None:
         time.sleep(1)
         managed_cluster.restart_proxy()
 
-        wait_for_command_state(command_id, "TERMINATED", 30)
+        wait_for_command_state(command_id, "TERMINATED", 60)
 
         assert "success" in get_command_info(command_id)["exitStatus"]
     except Exception:


### PR DESCRIPTION
## Description

fix: flaky test failure: test_agent_reconnect_keep_cmd [DET-7695]


[DET-7695]: https://determinedai.atlassian.net/browse/DET-7695?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ