### PR TITLE
fix: allocation errors on finished hp search [DET-7724]

### DIFF
--- a/master/internal/task/allocation.go
+++ b/master/internal/task/allocation.go
@@ -907,6 +907,11 @@ func (a *Allocation) terminated(ctx *actor.Context, reason string) {
 		case sproto.ResourcesFailure:
 			switch err.FailureType {
 			case sproto.ResourcesFailed, sproto.TaskError:
+				if a.killedDaemons {
+					exitReason = fmt.Sprint("allocation terminated daemon processes as part of normal exit")
+					ctx.Log().Info(exitReason)
+					return
+				}
 				exitReason = fmt.Sprintf("allocation failed: %s", err)
 				ctx.Log().Info(exitReason)
 				exit.Err = err

--- a/master/internal/task/allocation.go
+++ b/master/internal/task/allocation.go
@@ -88,10 +88,8 @@ type (
 	AllocationExited struct {
 		// userRequestedStop is when a container unexpectedly exits with 0.
 		UserRequestedStop bool
-		// DaemonsKilled is when a container stops with 0, but reports 137 due to kill command.
-		DaemonsKilledNominal bool
-		Err                  error
-		FinalState           AllocationState
+		Err               error
+		FinalState        AllocationState
 	}
 	// BuildTaskSpec is a message to request the task spec from the parent task. This
 	// is just a hack since building a task spec cant be semi-costly and we want to defer it
@@ -914,11 +912,12 @@ func (a *Allocation) terminated(ctx *actor.Context, reason string) {
 		case sproto.ResourcesFailure:
 			switch err.FailureType {
 			case sproto.ResourcesFailed, sproto.TaskError:
-				exitReason = fmt.Sprintf("allocation failed: %s", err)
 				if a.killedDaemonsNominal {
 					exitReason = fmt.Sprint("allocation terminated daemon processes as part of normal exit")
-					exit.DaemonsKilledNominal = true
+					ctx.Log().Info(exitReason)
+					return
 				}
+				exitReason = fmt.Sprintf("allocation failed: %s", err)
 				ctx.Log().Info(exitReason)
 				exit.Err = err
 				return

--- a/master/internal/task/allocation.go
+++ b/master/internal/task/allocation.go
@@ -740,7 +740,7 @@ func (a *Allocation) allNonDaemonsExited() bool {
 	return true
 }
 
-func (a *Allocation) exitWithoutErr() bool {
+func (a *Allocation) exitedWithoutErr() bool {
 	for _, r := range a.resources.failed() {
 		code := r.Exited.Failure.ExitCode
 		if code != nil && *code != 0 {

--- a/master/internal/task/allocation.go
+++ b/master/internal/task/allocation.go
@@ -770,6 +770,15 @@ func (a *Allocation) kill(ctx *actor.Context, reason string) {
 		return
 	}
 
+	ctx.Log().WithField("reason", reason).Info("decided to kill allocation")
+	a.logger.Insert(ctx, a.enrichLog(model.TaskLog{
+		Level: ptrs.Ptr(model.LogLevelInfo),
+		Log: fmt.Sprintf(
+			"forcibly killing allocation's remaining resources (reason: %s)",
+			reason,
+		),
+	}))
+
 	for _, r := range a.resources.active() {
 		r.Kill(ctx, a.logCtx)
 	}

--- a/master/internal/trial.go
+++ b/master/internal/trial.go
@@ -476,6 +476,12 @@ func (t *trial) allocationExited(ctx *actor.Context, exit *task.AllocationExited
 			State:               model.CompletedState,
 			InformationalReason: "hp search is finished",
 		})
+	case exit.Err != nil && exit.DaemonsKilledNominal:
+		return t.transition(ctx, model.StateWithReason{
+			State:               model.CompletedState,
+			InformationalReason: "trial stopped",
+		})
+
 	case exit.Err != nil && sproto.IsUnrecoverableSystemError(exit.Err):
 		ctx.Log().
 			WithError(exit.Err).

--- a/master/internal/trial.go
+++ b/master/internal/trial.go
@@ -476,11 +476,6 @@ func (t *trial) allocationExited(ctx *actor.Context, exit *task.AllocationExited
 			State:               model.CompletedState,
 			InformationalReason: "hp search is finished",
 		})
-	case exit.Err != nil && exit.DaemonsKilled:
-		return t.transition(ctx, model.StateWithReason{
-			State:               model.CompletedState,
-			InformationalReason: "trial stopped",
-		})
 	case exit.Err != nil && sproto.IsUnrecoverableSystemError(exit.Err):
 		ctx.Log().
 			WithError(exit.Err).

--- a/master/internal/trial.go
+++ b/master/internal/trial.go
@@ -476,6 +476,11 @@ func (t *trial) allocationExited(ctx *actor.Context, exit *task.AllocationExited
 			State:               model.CompletedState,
 			InformationalReason: "hp search is finished",
 		})
+	case exit.Err != nil && exit.DaemonsKilled:
+		return t.transition(ctx, model.StateWithReason{
+			State:               model.CompletedState,
+			InformationalReason: "trial stopped",
+		})
 	case exit.Err != nil && sproto.IsUnrecoverableSystemError(exit.Err):
 		ctx.Log().
 			WithError(exit.Err).

--- a/master/internal/trial.go
+++ b/master/internal/trial.go
@@ -476,12 +476,6 @@ func (t *trial) allocationExited(ctx *actor.Context, exit *task.AllocationExited
 			State:               model.CompletedState,
 			InformationalReason: "hp search is finished",
 		})
-	case exit.Err != nil && exit.DaemonsKilledNominal:
-		return t.transition(ctx, model.StateWithReason{
-			State:               model.CompletedState,
-			InformationalReason: "trial stopped",
-		})
-
 	case exit.Err != nil && sproto.IsUnrecoverableSystemError(exit.Err):
 		ctx.Log().
 			WithError(exit.Err).


### PR DESCRIPTION
## Description
Sometimes a trial will report errored even though it has exited with code 0. This is because even if it has exited successfully, the daemon process might still need to be killed. This change make sure that we don't report an error after slaying the daemon. 
<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At a minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan
Run some tensorflow or deepspeed hp search jobs with a `slots_per_trial` value greater than the slots in one node. Make sure that no trials error with exit code 0.
<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions about this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ