### PR TITLE
fix: deepspeed examples config

### DIFF
--- a/examples/deepspeed/cifar10_moe/moe.yaml
+++ b/examples/deepspeed/cifar10_moe/moe.yaml
@@ -13,7 +13,10 @@ hyperparameters:
   moe_param_group: true
 
 environment:
-    #environment_variables:
+    environment_variables:                                                                          
+        - NCCL_DEBUG=INFO                                                                           
+        # You may need to modify this to match your network configuration.                          
+        - NCCL_SOCKET_IFNAME=ens,eth,ib
     #    - CUDA_LAUNCH_BLOCKING=1
     #    - NCCL_BLOCKING_WAIT=1
     #    - NCCL_DEBUG=INFO

--- a/examples/deepspeed/cifar10_moe/zero_stages.yaml
+++ b/examples/deepspeed/cifar10_moe/zero_stages.yaml
@@ -14,7 +14,10 @@ hyperparameters:
   overwrite_deepspeed_args:
       zero_optimization.stage: 2
 environment:
-    #environment_variables:
+    environment_variables:                                                                          
+        - NCCL_DEBUG=INFO                                                                           
+        # You may need to modify this to match your network configuration.                          
+        - NCCL_SOCKET_IFNAME=ens,eth,ib
     #    - CUDA_LAUNCH_BLOCKING=1
     #    - NCCL_BLOCKING_WAIT=1
     #    - NCCL_DEBUG=INFO

--- a/examples/deepspeed/deepspeed_dcgan/cifar10_zero2.yaml
+++ b/examples/deepspeed/deepspeed_dcgan/cifar10_zero2.yaml
@@ -13,6 +13,10 @@ hyperparameters:
       zero_optimization.stage: 2
       fp16.enabled: true
 environment:
+    environment_variables:                                                                          
+        - NCCL_DEBUG=INFO                                                                           
+        # You may need to modify this to match your network configuration.                          
+        - NCCL_SOCKET_IFNAME=ens,eth,ib
     image:
         gpu: determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.5-tf-2.4-deepspeed-0.5.10-gpu-5158dec
 bind_mounts:

--- a/examples/deepspeed/deepspeed_dcgan/mnist.yaml
+++ b/examples/deepspeed/deepspeed_dcgan/mnist.yaml
@@ -10,6 +10,10 @@ hyperparameters:
   discriminator_width_base: 64
   data_workers: 16
 environment:
+    environment_variables:                                                                          
+        - NCCL_DEBUG=INFO                                                                           
+        # You may need to modify this to match your network configuration.                          
+        - NCCL_SOCKET_IFNAME=ens,eth,ib
     image:
         gpu: determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.5-tf-2.4-deepspeed-0.5.10-gpu-5158dec
 bind_mounts:

--- a/examples/deepspeed/deepspeed_dcgan/mnist_grad_accum.yaml
+++ b/examples/deepspeed/deepspeed_dcgan/mnist_grad_accum.yaml
@@ -12,6 +12,10 @@ hyperparameters:
   overwrite_deepspeed_args:
     gradient_accumulation_steps: 4
 environment:
+    environment_variables:                                                                          
+        - NCCL_DEBUG=INFO                                                                           
+        # You may need to modify this to match your network configuration.                          
+        - NCCL_SOCKET_IFNAME=ens,eth,ib
     image:
         gpu: determinedai/environments:cuda-11.1-pytorch-1.9-lightning-1.5-tf-2.4-deepspeed-0.5.10-gpu-5158dec
 bind_mounts:

--- a/examples/deepspeed/pipeline_parallelism/distributed.yaml
+++ b/examples/deepspeed/pipeline_parallelism/distributed.yaml
@@ -13,7 +13,10 @@ bind_mounts:
     container_path: /root/.cache
 environment:
     #force_pull_image: true
-    #environment_variables:
+    environment_variables:
+      - NCCL_DEBUG=INFO
+      # You may need to modify this to match your network configuration.
+      - NCCL_SOCKET_IFNAME=ens,eth,ib
     #  - CUDA_LAUNCH_BLOCKING=1
     #  - NCCL_BLOCKING_WAIT=1
     image:


### PR DESCRIPTION
## Description

Deepspeed examples in `cifar10_moe`, `deepspeed_dcgan` and `pipeline_parallelism` are failing on GCP/AWS. Solution was to add the following NCCL config (as in `gpt_neox`):
```
    environment_variables:                                                                          
        - NCCL_DEBUG=INFO                                                                           
        # You may need to modify this to match your network configuration.                          
        - NCCL_SOCKET_IFNAME=ens,eth,ib
```

## Test Plan
Tested on old .yaml files - Errors
Tested on new .yaml files - Experiments are starting and running.

## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
