### PR TITLE
fix: correct path selector for tensorboard upload

### DIFF
--- a/harness/determined/_trial_controller.py
+++ b/harness/determined/_trial_controller.py
@@ -125,6 +125,6 @@ class TrialController(metaclass=abc.ABCMeta):
 
     def upload_tb_files(self) -> None:
         self.context._core.train.upload_tensorboard_files(
-            lambda _: True if self.is_chief else lambda p: not p.match("*tfevents*"),
+            (lambda _: True) if self.is_chief else (lambda p: not p.match("*tfevents*")),
             get_rank_aware_path,
         )

--- a/harness/determined/tensorboard/util.py
+++ b/harness/determined/tensorboard/util.py
@@ -18,6 +18,7 @@ profiler_file_extensions = [
     ".kernel_stats.pb",
     ".overview_page.pb",
     ".trace.json.gz",
+    ".trace.json",
 ]
 
 


### PR DESCRIPTION
## Description

**Note: this is a release blocker**
**Note 2: the issue being fixed is introduced in this release**.
https://determinedai.atlassian.net/browse/DET-7770

The symptom is a deepspeed trial getting a 429 rate limit exceeded response from GCS.

An incorrect expression was given as a selector for files to be uploaded. The intent was to upload all files from chief and all but `tfevents` files from the (other) workers. But `lambda _: True if self.is_chief else lambda p: not p.match("*tfevents*")` is actually a single lambda that would map any path to `True` on chief and to another lambda on a non-chief, and lambda is apparently is a truthy value. The correct expression would put parentheses around lambdas.

## Test Plan

I don't find it practical to write a brand new test for TrialController just to test the correctness of one expression. Instead here is my inline test:

```
class SelectorTest:
  def __init__(self, is_chief: bool):
    self.is_chief = is_chief
    
  def test_selectors(self):
    selector1 = lambda _: True if self.is_chief else lambda p: not p.match("*tfevents*")
    selector2 = (lambda _: True) if self.is_chief else (lambda p: not p.match("*tfevents*"))

    for f in ["foo", "bar/tfevents.1234567.hmm"]:
      path = pathlib.Path(f)
      print(f"is_chief={self.is_chief} selector=selector1 for {f}: {bool(selector1(path))}")
      print(f"is_chief={self.is_chief} selector=selector2 for {f}: {bool(selector2(path))}")


SelectorTest(is_chief=True).test_selectors()
SelectorTest(is_chief=False).test_selectors()
```

and this is the output:
```
is_chief=True selector=selector1 for foo: True
is_chief=True selector=selector2 for foo: True
is_chief=True selector=selector1 for bar/tfevents.1234567.hmm: True
is_chief=True selector=selector2 for bar/tfevents.1234567.hmm: True
is_chief=False selector=selector1 for foo: True
is_chief=False selector=selector2 for foo: True
is_chief=False selector=selector1 for bar/tfevents.1234567.hmm: True
is_chief=False selector=selector2 for bar/tfevents.1234567.hmm: False
```


## Commentary (optional)

Logs:
```
[2022-07-01T18:30:09.003257Z] a9924afd [rank=3] || Traceback (most recent call last):
[2022-07-01T18:30:09.003262Z] a9924afd [rank=3] ||   File "/opt/conda/lib/python3.8/site-packages/google/cloud/storage/blob.py", line 2577, in upload_from_file
[2022-07-01T18:30:09.003768Z] a9924afd [rank=3] ||     created_json = self._do_upload(
[2022-07-01T18:30:09.003770Z] a9924afd [rank=3] ||   File "/opt/conda/lib/python3.8/site-packages/google/cloud/storage/blob.py", line 2379, in _do_upload
[2022-07-01T18:30:09.004206Z] a9924afd [rank=3] ||     response = self._do_multipart_upload(
[2022-07-01T18:30:09.004209Z] a9924afd [rank=3] ||   File "/opt/conda/lib/python3.8/site-packages/google/cloud/storage/blob.py", line 1914, in _do_multipart_upload
[2022-07-01T18:30:09.004533Z] a9924afd [rank=3] ||     response = upload.transmit(
[2022-07-01T18:30:09.004535Z] a9924afd [rank=3] ||   File "/opt/conda/lib/python3.8/site-packages/google/resumable_media/requests/upload.py", line 153, in transmit
[2022-07-01T18:30:09.004565Z] a9924afd [rank=3] ||     return _request_helpers.wait_and_retry(
[2022-07-01T18:30:09.004566Z] a9924afd [rank=3] ||   File "/opt/conda/lib/python3.8/site-packages/google/resumable_media/requests/_request_helpers.py", line 170, in wait_and_retry
[2022-07-01T18:30:09.004720Z] a9924afd [rank=3] ||     raise error
[2022-07-01T18:30:09.004723Z] a9924afd [rank=3] ||   File "/opt/conda/lib/python3.8/site-packages/google/resumable_media/requests/_request_helpers.py", line 147, in wait_and_retry
[2022-07-01T18:30:09.004724Z] a9924afd [rank=3] ||     response = func()
[2022-07-01T18:30:09.004727Z] a9924afd [rank=3] ||   File "/opt/conda/lib/python3.8/site-packages/google/resumable_media/requests/upload.py", line 149, in retriable_request
[2022-07-01T18:30:09.004786Z] a9924afd [rank=3] ||     self._process_response(result)
[2022-07-01T18:30:09.004788Z] a9924afd [rank=3] ||   File "/opt/conda/lib/python3.8/site-packages/google/resumable_media/_upload.py", line 114, in _process_response
[2022-07-01T18:30:09.004882Z] a9924afd [rank=3] ||     _helpers.require_status_code(response, (http.client.OK,), self._get_status_code)
[2022-07-01T18:30:09.004883Z] a9924afd [rank=3] ||   File "/opt/conda/lib/python3.8/site-packages/google/resumable_media/_helpers.py", line 105, in require_status_code
[2022-07-01T18:30:09.004883Z] a9924afd [rank=3] ||     raise common.InvalidResponse(
[2022-07-01T18:30:09.004903Z] a9924afd [rank=3] || google.resumable_media.common.InvalidResponse: ('Request failed with status code', 429, 'Expected one of', <HTTPStatus.OK: 200>)
[2022-07-01T18:30:09.004904Z] a9924afd [rank=3] || 
[2022-07-01T18:30:09.004904Z] a9924afd [rank=3] || During handling of the above exception, another exception occurred:
[2022-07-01T18:30:09.004908Z] a9924afd [rank=3] || 
[2022-07-01T18:30:09.004911Z] a9924afd [rank=3] || Traceback (most recent call last):
[2022-07-01T18:30:09.004915Z] a9924afd [rank=3] ||   File "/opt/conda/lib/python3.8/runpy.py", line 194, in _run_module_as_main
[2022-07-01T18:30:09.005024Z] a9924afd [rank=3] ||     return _run_code(code, main_globals, None,
[2022-07-01T18:30:09.005026Z] a9924afd [rank=3] ||   File "/opt/conda/lib/python3.8/runpy.py", line 87, in _run_code
[2022-07-01T18:30:09.005059Z] a9924afd [rank=3] ||     exec(code, run_globals)
[2022-07-01T18:30:09.005062Z] a9924afd [rank=3] ||   File "/run/determined/pythonuserbase/lib/python3.8/site-packages/determined/exec/harness.py", line 132, in <module>
[2022-07-01T18:30:09.005116Z] a9924afd [rank=3] ||     sys.exit(main(args.train_entrypoint))
[2022-07-01T18:30:09.005118Z] a9924afd [rank=3] ||   File "/run/determined/pythonuserbase/lib/python3.8/site-packages/determined/exec/harness.py", line 123, in main
[2022-07-01T18:30:09.005192Z] a9924afd [rank=3] ||     controller.run()
[2022-07-01T18:30:09.005194Z] a9924afd [rank=3] ||   File "/run/determined/pythonuserbase/lib/python3.8/site-packages/determined/pytorch/deepspeed/_deepspeed_trial.py", line 296, in run
[2022-07-01T18:30:09.005341Z] a9924afd [rank=3] ||     self._run()
[2022-07-01T18:30:09.005343Z] a9924afd [rank=3] ||   File "/run/determined/pythonuserbase/lib/python3.8/site-packages/determined/pytorch/deepspeed/_deepspeed_trial.py", line 367, in _run
[2022-07-01T18:30:09.005379Z] a9924afd [rank=3] ||     self.upload_tb_files()
[2022-07-01T18:30:09.005382Z] a9924afd [rank=3] ||   File "/run/determined/pythonuserbase/lib/python3.8/site-packages/determined/_trial_controller.py", line 127, in upload_tb_files
[2022-07-01T18:30:09.005446Z] a9924afd [rank=3] ||     self.context._core.train.upload_tensorboard_files(
[2022-07-01T18:30:09.005449Z] a9924afd [rank=3] ||   File "/run/determined/pythonuserbase/lib/python3.8/site-packages/determined/core/_train.py", line 125, in upload_tensorboard_files
[2022-07-01T18:30:09.005507Z] a9924afd [rank=3] ||     self._tensorboard_manager.sync(selector, mangler, self._distributed.rank)
[2022-07-01T18:30:09.005509Z] a9924afd [rank=3] ||   File "/run/determined/pythonuserbase/lib/python3.8/site-packages/determined/common/util.py", line 72, in wrapped
[2022-07-01T18:30:09.005570Z] a9924afd [rank=3] ||     return fn(*arg, **kwarg)
[2022-07-01T18:30:09.005573Z] a9924afd [rank=3] ||   File "/run/determined/pythonuserbase/lib/python3.8/site-packages/determined/tensorboard/gcs.py", line 50, in sync
[2022-07-01T18:30:09.005607Z] a9924afd [rank=3] ||     blob.upload_from_filename(str(path))
[2022-07-01T18:30:09.005610Z] a9924afd [rank=3] ||   File "/opt/conda/lib/python3.8/site-packages/google/cloud/storage/blob.py", line 2718, in upload_from_filename
[2022-07-01T18:30:09.006146Z] a9924afd [rank=3] ||     self.upload_from_file(
[2022-07-01T18:30:09.006148Z] a9924afd [rank=3] ||   File "/opt/conda/lib/python3.8/site-packages/google/cloud/storage/blob.py", line 2594, in upload_from_file
[2022-07-01T18:30:09.006592Z] a9924afd [rank=3] ||     _raise_from_invalid_response(exc)
[2022-07-01T18:30:09.006594Z] a9924afd [rank=3] ||   File "/opt/conda/lib/python3.8/site-packages/google/cloud/storage/blob.py", line 4466, in _raise_from_invalid_response
[2022-07-01T18:30:09.007294Z] a9924afd [rank=3] ||     raise exceptions.from_http_status(response.status_code, message, response=response)
[2022-07-01T18:30:09.007343Z] a9924afd [rank=3] || google.api_core.exceptions.TooManyRequests: 429 POST https://storage.googleapis.com/upload/storage/v1/b/det-checkpoints-liam-ds-demo-582733/o?uploadType=multipart: {
[2022-07-01T18:30:09.007346Z] a9924afd [rank=3] ||   "error": {
[2022-07-01T18:30:09.007347Z] a9924afd [rank=3] ||     "code": 429,
[2022-07-01T18:30:09.007349Z] a9924afd [rank=3] ||     "message": "The rate of change requests to the object det-checkpoints-liam-ds-demo-582733/4a2a6e6e-031a-41a1-8e7d-dcb12daa0d94/tensorboard/experiment/44/trial/113/events.out.tfevents.1656699949.det-dynamic-agent-liam-ds-demo-cf737c649142-related-ladybug.305.1 exceeds the rate limit. Please reduce the rate of create, update, and delete requests.",
[2022-07-01T18:30:09.007350Z] a9924afd [rank=3] ||     "errors": [
[2022-07-01T18:30:09.007352Z] a9924afd [rank=3] ||       {
[2022-07-01T18:30:09.007355Z] a9924afd [rank=3] ||         "message": "The rate of change requests to the object det-checkpoints-liam-ds-demo-582733/4a2a6e6e-031a-41a1-8e7d-dcb12daa0d94/tensorboard/experiment/44/trial/113/events.out.tfevents.1656699949.det-dynamic-agent-liam-ds-demo-cf737c649142-related-ladybug.305.1 exceeds the rate limit. Please reduce the rate of create, update, and delete requests.",
[2022-07-01T18:30:09.007357Z] a9924afd [rank=3] ||         "domain": "usageLimits",
[2022-07-01T18:30:09.007361Z] a9924afd [rank=3] ||         "reason": "rateLimitExceeded"
[2022-07-01T18:30:09.007365Z] a9924afd [rank=3] ||       }
[2022-07-01T18:30:09.007368Z] a9924afd [rank=3] ||     ]
[2022-07-01T18:30:09.007372Z] a9924afd [rank=3] ||   }
[2022-07-01T18:30:09.007376Z] a9924afd [rank=3] || }
[2022-07-01T18:30:09.007379Z] a9924afd [rank=3] || : ('Request failed with status code', 429, 'Expected one of', <HTTPStatus.OK: 200>)
```

## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
