### PR TITLE
fix: notebook ignores --template CLI param and notebooks still launch if --preview param is set [DET-7632]

### DIFF
--- a/docs/release-notes/fix-notebook-ignore-template.txt
+++ b/docs/release-notes/fix-notebook-ignore-template.txt
@@ -4,4 +4,4 @@
 
 -  Notebooks: Fix a bug where notebooks would ignore the ``--template`` CLI argument.
 -  Notebooks: Fix a bug where notebooks with the CLI argument ``--preview`` would still launch a
-   notebook.
+   notebook instead of just displaying the configuration.

--- a/docs/release-notes/fix-notebook-ignore-template.txt
+++ b/docs/release-notes/fix-notebook-ignore-template.txt
@@ -1,0 +1,5 @@
+:orphan:
+
+**Bug Fixes**
+
+-  Notebooks: Fix a bug where notebooks would ignore the ``--template`` CLI argument.

--- a/docs/release-notes/fix-notebook-ignore-template.txt
+++ b/docs/release-notes/fix-notebook-ignore-template.txt
@@ -3,3 +3,5 @@
 **Bug Fixes**
 
 -  Notebooks: Fix a bug where notebooks would ignore the ``--template`` CLI argument.
+-  Notebooks: Fix a bug where notebooks with the CLI argument ``--preview`` would still launch a
+   notebook.

--- a/e2e_tests/tests/fixtures/templates/template.yaml
+++ b/e2e_tests/tests/fixtures/templates/template.yaml
@@ -4,3 +4,6 @@ resources:
   slots: 100
   slots_per_trial: 100
   weight: 1
+environment:
+  environment_variables:
+    - SHOULDBE=SET

--- a/e2e_tests/tests/template/test_template.py
+++ b/e2e_tests/tests/template/test_template.py
@@ -22,8 +22,10 @@ def test_start_notebook_with_template() -> None:
     template_name = "test_start_notebook_with_template"
     tpl.set_template(template_name, conf.fixtures_path("templates/template.yaml"))
 
-    with cmd.interactive_command("notebook", "start", "--template", template_name, "--detach"):
-        pass
+    with cmd.interactive_command(
+        "notebook", "start", "--template", template_name, "--detach"
+    ) as nb:
+        assert "SHOULDBE=SET" in cmd.get_command_config("notebook", str(nb.task_id))
 
 
 @pytest.mark.slow
@@ -35,8 +37,8 @@ def test_start_command_with_template() -> None:
 
     with cmd.interactive_command(
         "command", "run", "--template", template_name, "--detach", "sleep infinity"
-    ):
-        pass
+    ) as command:
+        assert "SHOULDBE=SET" in cmd.get_command_config("command", str(command.task_id))
 
 
 @pytest.mark.slow
@@ -46,5 +48,7 @@ def test_start_shell_with_template() -> None:
     template_name = "test_start_shell_with_template"
     tpl.set_template(template_name, conf.fixtures_path("templates/template.yaml"))
 
-    with cmd.interactive_command("shell", "start", "--template", template_name, "--detach"):
-        pass
+    with cmd.interactive_command(
+        "shell", "start", "--template", template_name, "--detach"
+    ) as shell:
+        assert "SHOULDBE=SET" in cmd.get_command_config("shell", str(shell.task_id))

--- a/harness/determined/cli/notebook.py
+++ b/harness/determined/cli/notebook.py
@@ -37,7 +37,7 @@ def start_notebook(args: Namespace) -> None:
             for e in context.entries
         ]
     body = bindings.v1LaunchNotebookRequest(
-        config, files=files, preview=False, templateName=args.template
+        config, files=files, preview=args.preview, templateName=args.template
     )
     resp = bindings.post_LaunchNotebook(setup_session(args), body=body)
 

--- a/harness/determined/cli/notebook.py
+++ b/harness/determined/cli/notebook.py
@@ -36,7 +36,9 @@ def start_notebook(args: Namespace) -> None:
             )
             for e in context.entries
         ]
-    body = bindings.v1LaunchNotebookRequest(config, files=files, preview=False)
+    body = bindings.v1LaunchNotebookRequest(
+        config, files=files, preview=False, templateName=args.template
+    )
     resp = bindings.post_LaunchNotebook(setup_session(args), body=body)
 
     if args.preview:


### PR DESCRIPTION
## Description

Notebook now correctly uses the ```--template``` CLI parameter. In addition notebooks now won't launch if ```--preview``` is passed in.

## Test Plan

Create the following template with the file below
```
environment:
  environment_variables:
    - "TEST=true"
```

Using the command
```
det tpl set test <path to above.yaml>
```

Then start a notebook with the option
```
det notebook start --template test
```

Then in the notebook run this in a cell and verify that the environment variable set above is actually set
```
import os
os.environ["TEST"]
```


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
