### PR TITLE
fix: give a reasonable name to model def download

### DIFF
--- a/docs/release-notes/4493-model-def.txt
+++ b/docs/release-notes/4493-model-def.txt
@@ -1,0 +1,7 @@
+:orphan:
+
+**Fixes**
+
+-  Since 0.17.7, ``det experiment download-model-def $ID`` has been saving the downloaded tarballs
+   as just ``$ID``. This release corrects that behavior and names them
+   ``experiment_$ID_model_def.tgz`` instead.

--- a/harness/determined/cli/experiment.py
+++ b/harness/determined/cli/experiment.py
@@ -474,7 +474,8 @@ def config(args: Namespace) -> None:
 @authentication.required
 def download_model_def(args: Namespace) -> None:
     resp = bindings.get_GetModelDef(setup_session(args), experimentId=args.experiment_id)
-    with args.output_dir.joinpath(str(args.experiment_id)).open("wb") as f:
+    dst = f"experiment_{args.experiment_id}_model_def.tgz"
+    with args.output_dir.joinpath(dst).open("wb") as f:
         f.write(base64.b64decode(resp.b64Tgz))
 
 


### PR DESCRIPTION
A tarball named "4" is not a reasonable name.