### PR TITLE
fix: actor deadlock causing shells and shell related commands to hang

### DIFF
--- a/master/internal/command/command.go
+++ b/master/internal/command/command.go
@@ -71,14 +71,7 @@ func createGenericCommandActor(
 	}
 
 	a, _ := ctx.ActorOf(cmd.taskID, cmd)
-	summaryFut := ctx.Ask(a, getSummary{})
-	if err := summaryFut.Error(); err != nil {
-		return errors.Wrap(err, "failed to create generic command")
-	}
-	// Sync with the actor, but we don't really need the summary. actor.Ping works too,
-	// but this makes sure it can form some sort of useful response (ping doesn't actually
-	// hit the receive block).
-	summaryFut.Get()
+	ctx.Ask(a, actor.Ping{}).Get()
 	return nil
 }
 


### PR DESCRIPTION
## Description

Race condition causing actor deadlock. 

command actor is stuck in ```getSummary``` asking for ```AllocationState```
allocation is stuck in ```resourcesAllocated``` asking for ```buildTaskSpec```

## Test Plan

Upstream tests and manual testing of race condition.

The steps to reproduce the race condition were creating an experiment then quickly creating a shell. Then if that didn't work restart master. Was really inconsistent and annoying happened like after 1 try or 15 tries sometimes.

## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
