### PR TITLE
fix: make actor system `GetOrElseTimeout` actually timeout.

### DIFF
--- a/master/pkg/actor/response.go
+++ b/master/pkg/actor/response.go
@@ -53,15 +53,20 @@ func (r *response) Source() *Ref {
 	return r.source
 }
 
-func (r *response) get() Message {
+func (r *response) get(cancel <-chan bool) Message {
 	if r.fetched {
 		return r.result
 	}
 	r.lock.Lock()
 	defer r.lock.Unlock()
 	r.fetched = true
-	r.result = <-r.future
-	return r.result
+	select {
+	case result := <-r.future:
+		r.result = result
+		return r.result
+	case <-cancel:
+		return nil
+	}
 }
 
 func (r *response) Get() Message {
@@ -76,13 +81,15 @@ func (r *response) GetOrElse(defaultValue Message) Message {
 	if r.Empty() {
 		return defaultValue
 	}
-	return r.get()
+	return r.get(nil)
 }
 
 func (r *response) GetOrElseTimeout(defaultValue Message, timeout time.Duration) (Message, bool) {
 	future := make(chan Message, 1)
+	cancel := make(chan bool, 1)
+
 	go func() {
-		future <- r.get()
+		future <- r.get(cancel)
 	}()
 	t := time.NewTimer(timeout)
 	defer t.Stop()
@@ -90,6 +97,7 @@ func (r *response) GetOrElseTimeout(defaultValue Message, timeout time.Duration)
 	case result := <-future:
 		return result, true
 	case <-t.C:
+		cancel <- true
 		r.lock.Lock()
 		defer r.lock.Unlock()
 		r.fetched = true
@@ -99,11 +107,11 @@ func (r *response) GetOrElseTimeout(defaultValue Message, timeout time.Duration)
 }
 
 func (r *response) Empty() bool {
-	return r.get() == errNoResponse
+	return r.get(nil) == errNoResponse
 }
 
 func (r *response) Error() error {
-	err, ok := r.get().(error)
+	err, ok := r.get(nil).(error)
 	if r.Empty() || !ok {
 		return nil
 	}

--- a/master/pkg/actor/response.go
+++ b/master/pkg/actor/response.go
@@ -61,8 +61,7 @@ func (r *response) get(cancel <-chan bool) Message {
 	defer r.lock.Unlock()
 	r.fetched = true
 	select {
-	case result := <-r.future:
-		r.result = result
+	case r.result = <-r.future:
 		return r.result
 	case <-cancel:
 		return nil

--- a/master/pkg/actor/response_test.go
+++ b/master/pkg/actor/response_test.go
@@ -9,14 +9,35 @@ import (
 
 func TestResponseTimeout(t *testing.T) {
 	system := NewSystem(t.Name())
+	sleepDuration := 1 * time.Second
 	ref, _ := system.ActorOf(Addr("test"), ActorFunc(func(context *Context) error {
 		if context.ExpectingResponse() {
-			time.Sleep(1 * time.Second)
+			time.Sleep(sleepDuration)
 			context.Respond(false)
 		}
 		return nil
 	}))
+	start := time.Now()
 	result, ok := system.Ask(ref, "").GetOrElseTimeout(true, 1*time.Millisecond)
+	duration := time.Now().Sub(start)
+	assert.Assert(t, duration < sleepDuration, "test duration: %d ms", duration.Milliseconds())
 	assert.Assert(t, result.(bool))
 	assert.Assert(t, !ok)
+}
+
+func TestResponseTimeoutOk(t *testing.T) {
+	system := NewSystem(t.Name())
+	ref, _ := system.ActorOf(Addr("test"), ActorFunc(func(context *Context) error {
+		if context.ExpectingResponse() {
+			context.Respond(false)
+		}
+		return nil
+	}))
+	start := time.Now()
+	timeoutDuration := 1 * time.Second
+	result, ok := system.Ask(ref, "").GetOrElseTimeout(true, timeoutDuration)
+	duration := time.Now().Sub(start)
+	assert.Assert(t, duration < timeoutDuration, "test duration: %d ms", duration.Milliseconds())
+	assert.Assert(t, result.(bool) == false)
+	assert.Assert(t, ok)
 }


### PR DESCRIPTION
## Description

- `GetOrElseTimeout` was de-facto only returning once it's got the
  response, regardless of the timeout value. The unit test for it was
  testing it wrong.

## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions about this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
