### PR TITLE
feat: docker auth improvements [DET-7633, DET-7636]

### DIFF
--- a/agent/go.mod
+++ b/agent/go.mod
@@ -26,6 +26,7 @@ require (
 
 require (
 	github.com/determined-ai/determined/proto v0.0.0-00010101000000-000000000000
+	github.com/stretchr/testify v1.7.1
 	golang.org/x/exp v0.0.0-20220328175248-053ad81199eb
 )
 
@@ -49,6 +50,7 @@ require (
 	github.com/containerd/containerd v1.5.8 // indirect
 	github.com/coreos/go-systemd v0.0.0-20190719114852-fd7a80b32e1f // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/docker/go-metrics v0.0.1 // indirect
 	github.com/docker/go-units v0.4.0 // indirect
 	github.com/dustinkirkland/golang-petname v0.0.0-20191129215211-8e5a1ed0cff0 // indirect
 	github.com/elastic/go-elasticsearch/v7 v7.9.0 // indirect
@@ -111,7 +113,6 @@ require (
 	github.com/segmentio/backo-go v0.0.0-20200129164019-23eae7c10bd3 // indirect
 	github.com/shopspring/decimal v1.2.0 // indirect
 	github.com/soheilhy/cmux v0.1.4 // indirect
-	github.com/stretchr/testify v1.7.1 // indirect
 	github.com/tmthrgd/go-hex v0.0.0-20190904060850-447a3041c3bc // indirect
 	github.com/uber/jaeger-client-go v2.25.0+incompatible // indirect
 	github.com/uber/jaeger-lib v2.4.0+incompatible // indirect

--- a/agent/go.sum
+++ b/agent/go.sum
@@ -324,9 +324,11 @@ github.com/docker/go-connections v0.4.0/go.mod h1:Gbd7IOopHjR8Iph03tsViu4nIes5Xh
 github.com/docker/go-events v0.0.0-20170721190031-9461782956ad/go.mod h1:Uw6UezgYA44ePAFQYUehOuCzmy5zmg/+nl2ZfMWGkpA=
 github.com/docker/go-events v0.0.0-20190806004212-e31b211e4f1c/go.mod h1:Uw6UezgYA44ePAFQYUehOuCzmy5zmg/+nl2ZfMWGkpA=
 github.com/docker/go-metrics v0.0.0-20180209012529-399ea8c73916/go.mod h1:/u0gXw0Gay3ceNrsHubL3BtdOL2fHf93USgMTe0W5dI=
+github.com/docker/go-metrics v0.0.1 h1:AgB/0SvBxihN0X8OR4SjsblXkbMvalQ8cjmtKQ2rQV8=
 github.com/docker/go-metrics v0.0.1/go.mod h1:cG1hvH2utMXtqgqqYE9plW6lDxS3/5ayHzueweSI3Vw=
 github.com/docker/go-units v0.4.0 h1:3uh0PgVws3nIA0Q+MwDC8yjEPf9zjRfZZWXZYDct3Tw=
 github.com/docker/go-units v0.4.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
+github.com/docker/libtrust v0.0.0-20150114040149-fa567046d9b1 h1:ZClxb8laGDf5arXfYcAtECDFgAgHklGI8CxgjHnXKJ4=
 github.com/docker/libtrust v0.0.0-20150114040149-fa567046d9b1/go.mod h1:cyGadeNEkKy96OOhEzfZl+yxihPEzKnqJwvfuSUqbZE=
 github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96/go.mod h1:Qh8CwZgvJUkLughtfhJv5dyTYa91l1fOUCrgjqmcifM=
 github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=

--- a/agent/internal/docker.go
+++ b/agent/internal/docker.go
@@ -221,10 +221,15 @@ func (d *dockerActor) getDockerAuths(
 			d.sendAuxLog(ctx, "warning setting registry_auth without registry_auth.serveraddress "+
 				"is deprecated and will soon be required")
 		}
-		if registry.ConvertToHostname(expconfReg.ServerAddress) == imageDomain ||
+
+		expconfDomain := registry.ConvertToHostname(expconfReg.ServerAddress)
+		if expconfDomain == imageDomain ||
 			didNotPassServerAddress { // TODO remove didNotPassServerAddress when it becomes required.
 			return *expconfReg, nil
 		}
+		d.sendAuxLog(ctx, fmt.Sprintf("warning not using expconfig registry_auth "+
+			"since expconf registry_auth.serverAddress %s did not match the image serverAddress %s",
+			expconfDomain, imageDomain))
 	}
 
 	// Try using credential stores specified in ~/.docker/config.json.

--- a/agent/internal/docker.go
+++ b/agent/internal/docker.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"strings"
 	"syscall"
 	"time"
 
@@ -17,6 +18,7 @@ import (
 	"github.com/docker/docker/client"
 	"github.com/docker/docker/pkg/jsonmessage"
 	"github.com/docker/docker/pkg/stdcopy"
+	"github.com/docker/docker/registry"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/sys/unix"
@@ -31,6 +33,7 @@ import (
 type dockerActor struct {
 	*client.Client
 	credentialStores map[string]*credentialStore
+	authConfigs      map[string]types.AuthConfig
 }
 
 type (
@@ -68,6 +71,21 @@ type (
 
 // registryToString converts the Registry struct to a base64 encoding for json strings.
 func registryToString(reg types.AuthConfig) (string, error) {
+	// Docker stores the username and password in an auth section types.AuthConfig
+	// formatted as user:pass then base64ed. This is not documented clearly.
+	// https://github.com/docker/cli/blob/master/cli/config/configfile/file.go#L76
+	if reg.Auth != "" {
+		bytes, err := base64.StdEncoding.DecodeString(reg.Auth)
+		if err != nil {
+			return "", err
+		}
+		userAndPass := strings.SplitN(string(bytes), ":", 2)
+		if len(userAndPass) != 2 {
+			return "", errors.Errorf("auth field of docker authConfig must be base64ed user:pass")
+		}
+		reg.Username, reg.Password = userAndPass[0], userAndPass[1]
+		reg.Auth = ""
+	}
 	bs, err := json.Marshal(reg)
 	if err != nil {
 		return "", err
@@ -79,13 +97,17 @@ func registryToString(reg types.AuthConfig) (string, error) {
 func (d *dockerActor) Receive(ctx *actor.Context) error {
 	switch msg := ctx.Message().(type) {
 	case actor.PreStart:
-		stores, err := getAllCredentialStores()
+		stores, auths, err := processDockerConfig()
 		if err != nil {
-			ctx.Log().Infof(
-				"can't find any docker credential stores, continuing without them %v", err)
+			ctx.Log().Infof("couldn't process ~/.docker/config.json %v", err)
 		}
-		d.credentialStores = stores
-
+		if len(stores) == 0 {
+			ctx.Log().Info("can't find any docker credential stores, continuing without them")
+		}
+		if len(auths) == 0 {
+			ctx.Log().Info("can't find any auths in ~/.docker/config.json, continuing without them")
+		}
+		d.credentialStores, d.authConfigs = stores, auths
 	case pullImage:
 		go d.pullImage(ctx, msg)
 
@@ -153,35 +175,19 @@ func (d *dockerActor) pullImage(ctx *actor.Context, msg pullImage) {
 			}})
 	}()
 
-	// TODO: replace with command.EncodeAuthToBase64
-	reg := ""
-	if msg.Registry != nil {
-		if reg, err = registryToString(*msg.Registry); err != nil {
-			sendErr(ctx, errors.Wrap(err, "error encoding registry credentials"))
-			return
-		}
-	} else {
-		domain := reference.Domain(ref)
-		if store, ok := d.credentialStores[domain]; ok {
-			var creds types.AuthConfig
-			creds, err = store.get()
-			if err != nil {
-				sendErr(ctx, errors.Wrap(err, "unable to get credentials from helper"))
-				return
-			}
-			reg, err = registryToString(creds)
-			if err != nil {
-				sendErr(ctx, errors.Wrap(err, "error encoding registry credentials from helper"))
-				return
-			}
-			d.sendAuxLog(ctx, fmt.Sprintf(
-				"domain '%s' found in 'credHelpers' config. Using credentials helper.", domain))
-		}
+	auth, err := d.getDockerAuths(ctx, msg.Registry, ref)
+	if err != nil {
+		sendErr(ctx, errors.Wrap(err, "could not get docker authentication"))
+		return
 	}
-
+	authString, err := registryToString(auth)
+	if err != nil {
+		sendErr(ctx, errors.Wrap(err, "error encoding docker credentials"))
+		return
+	}
 	opts := types.ImagePullOptions{
 		All:          false,
-		RegistryAuth: reg,
+		RegistryAuth: authString,
 	}
 
 	logs, err := d.ImagePull(context.Background(), ref.String(), opts)
@@ -200,6 +206,48 @@ func (d *dockerActor) pullImage(ctx *actor.Context, msg pullImage) {
 	}
 
 	ctx.Tell(ctx.Sender(), imagePulled{})
+}
+
+func (d *dockerActor) getDockerAuths(
+	ctx *actor.Context,
+	expconfReg *types.AuthConfig,
+	image reference.Named,
+) (types.AuthConfig, error) {
+	imageDomain := reference.Domain(image)
+	// Try expconf registry auth config.
+	if expconfReg != nil {
+		didNotPassServerAddress := expconfReg.ServerAddress == ""
+		if didNotPassServerAddress {
+			d.sendAuxLog(ctx, "warning setting registry_auth without registry_auth.serveraddress "+
+				"is deprecated and will soon be required")
+		}
+		if registry.ConvertToHostname(expconfReg.ServerAddress) == imageDomain ||
+			didNotPassServerAddress { // TODO remove didNotPassServerAddress when it becomes required.
+			return *expconfReg, nil
+		}
+	}
+
+	// Try using credential stores specified in ~/.docker/config.json.
+	if store, ok := d.credentialStores[imageDomain]; ok {
+		creds, err := store.get()
+		if err == nil {
+			d.sendAuxLog(ctx, fmt.Sprintf(
+				"domain '%s' found in 'credHelpers' config. Using credentials helper.", imageDomain))
+		}
+		return creds, errors.Wrap(err, "unable to get credentials from helper")
+	}
+
+	// Finally try using auths section of users ~/.docker/config.json.
+	index, err := registry.ParseSearchIndexInfo(image.String())
+	if err != nil {
+		return types.AuthConfig{}, errors.Wrap(err, "error invalid docker repo name")
+	}
+	reg := registry.ResolveAuthConfig(d.authConfigs, index)
+	if reg != (types.AuthConfig{}) {
+		d.sendAuxLog(ctx, fmt.Sprintf(
+			"domain '%s' found in 'auths' ~/.docker/config.json", imageDomain))
+	}
+	return reg, nil
 }
 
 func (d *dockerActor) runContainer(ctx *actor.Context, msg cproto.RunSpec) {

--- a/agent/internal/docker_credential_store.go
+++ b/agent/internal/docker_credential_store.go
@@ -30,47 +30,42 @@ func getDockerConfigPath() (string, error) {
 	return path.Join(homeDir, ".docker", "config.json"), nil
 }
 
-// getAllCredentialStores returns the credential helpers configured in the default docker
-// config or an error.
-func getAllCredentialStores() (map[string]*credentialStore, error) {
-	type ConfigFile struct {
-		CredentialHelpers map[string]string `json:"credHelpers,omitempty"`
-	}
+// processDockerConfig reads a users ~/.docker/config.json and returns
+// credential helpers configured and the "auths" section of the config.
+func processDockerConfig() (map[string]*credentialStore, map[string]types.AuthConfig, error) {
+	credStores := make(map[string]*credentialStore) // Always return non nil maps.
+	authConfig := make(map[string]types.AuthConfig)
 
-	credentialsStores := map[string]*credentialStore{}
 	dockerConfigFile, err := getDockerConfigPath()
 	if err != nil {
-		return credentialsStores, err
+		return credStores, authConfig, err
 	}
-
 	configFile, err := os.Open(dockerConfigFile) // #nosec: G304
 	if err != nil {
-		return credentialsStores, errors.Wrap(err, "can't open docker config")
+		return credStores, authConfig, errors.Wrap(err, "can't open docker config")
 	}
-
 	b, err := ioutil.ReadAll(configFile)
 	if err != nil {
-		return credentialsStores, errors.Wrap(err, "can't read docker config")
+		return credStores, authConfig, errors.Wrap(err, "can't read docker config")
 	}
 
-	var config ConfigFile
-	err = json.Unmarshal(b, &config)
-	if err != nil {
-		return credentialsStores, errors.Wrap(err, "can't parse docker config")
+	var config struct {
+		CredentialHelpers map[string]string           `json:"credHelpers"`
+		Auths             map[string]types.AuthConfig `json:"auths"`
 	}
-
-	if config.CredentialHelpers == nil {
-		return credentialsStores, nil
+	if err := json.Unmarshal(b, &config); err != nil {
+		return credStores, authConfig, errors.Wrap(err, "can't parse docker config")
 	}
-
 	for hostname, helper := range config.CredentialHelpers {
-		credentialsStores[hostname] = &credentialStore{
+		credStores[hostname] = &credentialStore{
 			registry: hostname,
 			store:    hclient.NewShellProgramFunc(credentialsHelperPrefix + helper),
 		}
 	}
-
-	return credentialsStores, nil
+	if config.Auths != nil {
+		authConfig = config.Auths
+	}
+	return credStores, authConfig, nil
 }
 
 // get executes the command to get the credentials from the native store.

--- a/agent/internal/docker_test.go
+++ b/agent/internal/docker_test.go
@@ -1,0 +1,128 @@
+package internal
+
+import (
+	"encoding/base64"
+	"fmt"
+	"testing"
+
+	"github.com/determined-ai/determined/master/pkg/actor"
+
+	"github.com/docker/distribution/reference"
+	"github.com/docker/docker/api/types"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetDockerAuths(t *testing.T) {
+	dockerhubAuthConfig := types.AuthConfig{
+		Username:      "username",
+		Password:      "password",
+		ServerAddress: "docker.io",
+	}
+
+	exampleDockerConfig := types.AuthConfig{
+		Auth:          "token",
+		ServerAddress: "https://example.com",
+	}
+
+	noServerAuthConfig := types.AuthConfig{
+		Username: "username",
+		Password: "password",
+	}
+
+	dockerAuthSection := map[string]types.AuthConfig{
+		"https://index.docker.io/v1/": {
+			Auth:          "dockerhubtoken",
+			ServerAddress: "docker.io",
+		},
+		"example.com": {
+			Auth:          "exampletoken",
+			ServerAddress: "example.com",
+		},
+	}
+
+	cases := []struct {
+		image       string
+		expconfReg  *types.AuthConfig
+		authConfigs map[string]types.AuthConfig
+		expected    types.AuthConfig
+	}{
+		// No authentication passed in.
+		{"detai", nil, nil, types.AuthConfig{}},
+		// Correct server passed in for dockerhub.
+		{"detai", &dockerhubAuthConfig, nil, dockerhubAuthConfig},
+		// Correct server passed in for example.com.
+		{"example.com/detai", &exampleDockerConfig, nil, exampleDockerConfig},
+		// Different server passed than specified auth.
+		{"example.com/detai", &dockerhubAuthConfig, nil, types.AuthConfig{}},
+		// No server (behavior is deprecated).
+		{"detai", &noServerAuthConfig, nil, noServerAuthConfig},
+		{"example.com/detai", &noServerAuthConfig, nil, noServerAuthConfig},
+
+		// Docker auth config gets used.
+		{"detai", nil, dockerAuthSection, dockerAuthSection["https://index.docker.io/v1/"]},
+		// Expconf takes precedence over docker config.
+		{"detai", &dockerhubAuthConfig, dockerAuthSection, dockerhubAuthConfig},
+		// We fallback to auths if docker hub has wrong server.
+		{"example.com/detai", &dockerhubAuthConfig, dockerAuthSection,
+			dockerAuthSection["example.com"]},
+		// We don't return a result if we don't have that serveraddress.
+		{"determined.ai/detai", nil, dockerAuthSection, types.AuthConfig{}},
+	}
+
+	ctx := getMockDockerActorCtx()
+	for _, testCase := range cases {
+		d := dockerActor{
+			authConfigs: testCase.authConfigs,
+		}
+
+		// Parse image to correct format.
+		ref, err := reference.ParseNormalizedNamed(testCase.image)
+		require.NoError(t, err, "could not get image to correct format")
+		ref = reference.TagNameOnly(ref)
+
+		actual, err := d.getDockerAuths(ctx, testCase.expconfReg, ref)
+		require.NoError(t, err)
+		require.Equal(t, testCase.expected, actual)
+	}
+}
+
+func getMockDockerActorCtx() *actor.Context {
+	var ctx *actor.Context
+	sys := actor.NewSystem("")
+	child, _ := sys.ActorOf(actor.Addr("child"), actor.ActorFunc(func(context *actor.Context) error {
+		ctx = context
+		return nil
+	}))
+	parent, _ := sys.ActorOf(actor.Addr("parent"), actor.ActorFunc(func(context *actor.Context) error {
+		context.Ask(child, "").Get()
+		return nil
+	}))
+	sys.Ask(parent, "").Get()
+	return ctx
+}
+
+func TestRegistryToString(t *testing.T) {
+	// No auth just base64ed.
+	case1 := types.AuthConfig{
+		Email:    "det@example.com",
+		Password: "password",
+	}
+	expected := base64.URLEncoding.EncodeToString(
+		[]byte(`{"password":"password","email":"det@example.com"}`))
+	actual, err := registryToString(case1)
+	require.NoError(t, err, "could not to string auth config")
+	require.Equal(t, expected, actual)
+
+	// Auth gets split.
+	user, pass := "user", "pass"
+	auth := fmt.Sprintf("%s:%s", user, pass)
+	case2 := types.AuthConfig{
+		Auth: base64.StdEncoding.EncodeToString([]byte(auth)),
+	}
+	expected = base64.URLEncoding.EncodeToString([]byte(fmt.Sprintf(
+		`{"username":"%s","password":"%s"}`, user, pass)))
+	actual, err = registryToString(case2)
+	require.NoError(t, err, "could not to string auth config")
+	require.Equal(t, expected, actual)
+}

--- a/agent/internal/docker_test.go
+++ b/agent/internal/docker_test.go
@@ -5,12 +5,12 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/determined-ai/determined/master/pkg/actor"
-
 	"github.com/docker/distribution/reference"
 	"github.com/docker/docker/api/types"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/determined-ai/determined/master/pkg/actor"
 )
 
 func TestGetDockerAuths(t *testing.T) {

--- a/docs/release-notes/dont-send-docker-creds-to-any-server.txt
+++ b/docs/release-notes/dont-send-docker-creds-to-any-server.txt
@@ -3,7 +3,8 @@
 **Improvements**
 
 -  Security: Setting ``registry_auth.serveraddress`` will now only send credentials to the server
-   configured. Not setting ``registry_auth`` is now deprecated and will be required soon.
+   configured. Not setting ``registry_auth.serveraddress`` is now deprecated and will be required
+   soon.
 
 -  Agent: Users may now run ``docker login`` on agent host machines to authenticate with Docker
    registries. Note if an agent is running inside a Docker container then ``~/.docker/config.json``

--- a/docs/release-notes/dont-send-docker-creds-to-any-server.txt
+++ b/docs/release-notes/dont-send-docker-creds-to-any-server.txt
@@ -3,8 +3,8 @@
 **Improvements**
 
 -  Security: Setting ``registry_auth.serveraddress`` will now only send credentials to the server
-   configured. Not setting ``registry_auth.serveraddress`` is now deprecated and will be required
-   soon.
+   configured. Not setting ``registry_auth.serveraddress`` is now deprecated when ``registry_auth``
+   is set. Soon ``serveraddress`` will be required whenever ``registry_auth`` is set.
 
 -  Agent: Users may now run ``docker login`` on agent host machines to authenticate with Docker
    registries. Note if an agent is running inside a Docker container then ``~/.docker/config.json``

--- a/docs/release-notes/dont-send-docker-creds-to-any-server.txt
+++ b/docs/release-notes/dont-send-docker-creds-to-any-server.txt
@@ -8,4 +8,5 @@
 
 -  Agent: Users may now run ``docker login`` on agent host machines to authenticate with Docker
    registries. Note if an agent is running inside a Docker container then ``~/.docker/config.json``
-   will need to be mounted to the same path inside the container.
+   will need to be mounted inside the container to ``$HOME/.docker/config.json`` (by default
+   ``/root/.docker/config.json``).

--- a/docs/release-notes/dont-send-docker-creds-to-any-server.txt
+++ b/docs/release-notes/dont-send-docker-creds-to-any-server.txt
@@ -1,0 +1,10 @@
+:orphan:
+
+**Improvements**
+
+-  Security: Setting ``registry_auth.serveraddress`` will now only send credentials to the server
+   configured. Not setting ``registry_auth`` is now deprecated and will be required soon.
+
+-  Agent: Users may now run ``docker login`` on agent host machines to authenticate with Docker
+   registries. Note if an agent is running inside a Docker container then ``~/.docker/config.json``
+   will need to be mounted to the same path inside the container.

--- a/docs/sysadmin-basics/cluster-config.txt
+++ b/docs/sysadmin-basics/cluster-config.txt
@@ -263,7 +263,7 @@ The master supports the following configuration settings:
 
       -  ``username`` (required)
       -  ``password`` (required)
-      -  ``serveraddress`` (optional)
+      -  ``serveraddress`` (required)
       -  ``email`` (optional)
 
    -  ``add_capabilities``: The default list of Linux capabilities to grant to task containers.

--- a/docs/training-apis/experiment-config.txt
+++ b/docs/training-apis/experiment-config.txt
@@ -1055,7 +1055,7 @@ workloads for this experiment. For more information on customizing the trial env
 
    -  ``username`` (required)
    -  ``password`` (required)
-   -  ``server`` (optional)
+   -  ``serveraddress`` (optional)
    -  ``email`` (optional)
 
 ``environment_variables``

--- a/docs/training-apis/experiment-config.txt
+++ b/docs/training-apis/experiment-config.txt
@@ -1055,7 +1055,7 @@ workloads for this experiment. For more information on customizing the trial env
 
    -  ``username`` (required)
    -  ``password`` (required)
-   -  ``serveraddress`` (optional)
+   -  ``serveraddress`` (required)
    -  ``email`` (optional)
 
 ``environment_variables``

--- a/e2e_tests/tests/deploy/test_local.py
+++ b/e2e_tests/tests/deploy/test_local.py
@@ -152,7 +152,7 @@ def test_agent_config_path() -> None:
     with open(etc_path) as f:
         assert f.read() == out.decode("utf-8")
 
-    for _ in range(10):
+    for _ in range(30):
         try:
             client.containers.get("test-fluent")
             break


### PR DESCRIPTION
## Description

Docker auth is improved in two ways. First if a serveraddress is specified in experiment config we will not send credentials to another server. The second is we now read the ```auths``` section of a users ```~/.docker/config.json``` file meaning users can now use ```docker login``` on their agent nodes.

## Test Plan

Go unit tests.

### Set up

Note it is expected commands fail with a message like
```
[2022-07-11T17:36:29.317436Z] 3ecfd61a || env: can't execute 'bash': No such file or directory
```

Host a local dockerhub registry
```
docker run -e "REGISTRY_AUTH_HTPASSWD_REALM=default" -e "REGISTRY_AUTH_HTPASSWD_PATH=registry" -p 5000:5000 registry:2
```

Get password and username from this line printed from above command
```
time="2022-07-11T18:40:28.564679738Z" level=warning msg="htpasswd is missing, provisioning with default user" go.version=go1.16.15 password=$PASS user=docker 
```

Login with above credentials
```
docker login 127.0.0.1:5000
```

Push an image to that registry locally
```
docker tag gcr.io/google-samples/hello-app:1.0 127.0.0.1:5000/test-image:test
docker push 127.0.0.1:5000/test-image:test
```

### Using ```~/.docker/config.json```

Restart devcluster and test that ```~/.docker/config.json``` is used to pull the image
```
det command run --config="environment.force_pull_image=true" --config="environment.image=127.0.0.1:5000/test-image:test" "echo hello" 
```

Clear ```~/.docker/config.json``` of our local registry auth to test passing in experiment config
```
docker logout 127.0.0.1:5000
```

### expconfig auth tests

Should give warning for not setting serveraddress
```
det command run --config="environment.registry_auth.username=docker" --config="environment.registry_auth.password=$PASS" --config="environment.force_pull_image=true" --config="environment.image=127.0.0.1:5000/test-image:test" "echo hello" 
```

Should not give warning
```
det command run --config="environment.registry_auth.serveraddress=127.0.0.1:5000" --config="environment.registry_auth.username=docker" --config="environment.registry_auth.password=$PASS" --config="environment.force_pull_image=true" --config="environment.image=127.0.0.1:5000/test-image:test" "echo hello" 
```

Should not work since ```serveraddress``` is different than our image
```
det command run --config="environment.registry_auth.serveraddress=example.com" --config="environment.registry_auth.username=docker" --config="environment.registry_auth.password=$PASS" --config="environment.force_pull_image=true" --config="environment.image=127.0.0.1:5000/test-image:test" "echo hello" 
```

### Credential helper

Ensure we didn't break cred helper functionality by pushing a private image to gcr following this guide https://console.cloud.google.com/gcr/images/determined-ai/global/nblaskey-test-image?project=determined-ai 

After the image is pushed run the following
```
gcloud auth configure-docker
det command run --config="environment.force_pull_image=true" --config="environment.image=gcr.io/determined-ai/nblaskey-test-image:test" "echo hello" 
```
## Checklist

- [X] User-facing API changes need the "User-facing API Change" label.
- [X] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [X] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
