### PR TITLE
feat: Reject experiments which take too many slots to run [DET-7722]

### DIFF
--- a/e2e_tests/tests/experiment/test_noop.py
+++ b/e2e_tests/tests/experiment/test_noop.py
@@ -96,6 +96,16 @@ def test_noop_pause_of_experiment_without_trials() -> None:
     impossibly_large = 100
     config_obj["max_restarts"] = 0
     config_obj["resources"] = {"slots_per_trial": impossibly_large}
+
+    # test that normally this slots_per_trial config would be rejected
+    with tempfile.NamedTemporaryFile() as tf:
+        with open(tf.name, "w") as f:
+            yaml.dump(config_obj, f)
+        with pytest.raises(AssertionError):
+            exp.create_experiment(tf.name, conf.fixtures_path("no_op"), None)
+
+    # resume original test with an override
+    config_obj["resources"]["force_queue"] = True
     with tempfile.NamedTemporaryFile() as tf:
         with open(tf.name, "w") as f:
             yaml.dump(config_obj, f)

--- a/e2e_tests/tests/fixtures/no_op/single.yaml
+++ b/e2e_tests/tests/fixtures/no_op/single.yaml
@@ -22,4 +22,7 @@ min_validation_period:
 min_checkpoint_period:
   batches: 100
 max_restarts: 0
+resources:
+  slots_per_trial: 1
+  force_queue: true
 entrypoint: model_def:NoOpTrial

--- a/harness/determined/common/schemas/expconf/_gen.py
+++ b/harness/determined/common/schemas/expconf/_gen.py
@@ -2025,6 +2025,13 @@ schemas = {
             "default": [],
             "optionalRef": "http://determined.ai/schemas/expconf/v0/devices.json"
         },
+        "force_queue": {
+            "type": [
+                "boolean",
+                "null"
+            ],
+            "default": false
+        },
         "max_slots": {
             "type": [
                 "integer",

--- a/harness/determined/common/schemas/expconf/_v0.py
+++ b/harness/determined/common/schemas/expconf/_v0.py
@@ -25,6 +25,7 @@ class ResourcesConfigV0(schemas.SchemaBase):
     _id = "http://determined.ai/schemas/expconf/v0/resources.json"
     agent_label: Optional[str] = None
     devices: Optional[List[DeviceV0]] = None
+    force_queue: Optional[bool] = None
     max_slots: Optional[int] = None
     native_parallel: Optional[bool] = None
     priority: Optional[int] = None
@@ -38,6 +39,7 @@ class ResourcesConfigV0(schemas.SchemaBase):
         self,
         agent_label: Optional[str] = None,
         devices: Optional[List[DeviceV0]] = None,
+        force_queue: Optional[bool] = None,
         max_slots: Optional[int] = None,
         native_parallel: Optional[bool] = None,
         priority: Optional[int] = None,

--- a/master/internal/core_experiment.go
+++ b/master/internal/core_experiment.go
@@ -374,16 +374,13 @@ func (m *Master) parseCreateExperiment(params *CreateExperimentParams, user *mod
 			return nil, false, nil, agReq.Error()
 		}
 		getAgentsResponse := agReq.Get().(*apiv1.GetAgentsResponse)
-		foundAgent := false
+		maxSlots := 0
 		for _, agent := range getAgentsResponse.Agents {
-			if len(agent.Slots) >= resources.SlotsPerTrial() {
-				foundAgent = true
-				break
-			}
+			maxSlots += len(agent.Slots)
 		}
-		if !foundAgent {
+		if maxSlots < resources.SlotsPerTrial() {
 			return nil, false, nil, echo.NewHTTPError(http.StatusBadRequest,
-				fmt.Sprintf("no agent has enough slots (%d) to run experiment",
+				fmt.Sprintf("instance does not have enough slots (%d) to run experiment",
 					resources.SlotsPerTrial()))
 		}
 	}

--- a/master/pkg/model/compat.go
+++ b/master/pkg/model/compat.go
@@ -42,6 +42,7 @@ func (r ResourcesConfig) ToExpconf() expconf.ResourcesConfig {
 		RawResourcePool:   ptrs.Ptr(r.ResourcePool),
 		RawPriority:       r.Priority,
 		RawDevices:        r.Devices.ToExpconf(),
+		RawForceQueue:     ptrs.Ptr(false),
 	}).(expconf.ResourcesConfig)
 }
 

--- a/master/pkg/schemas/expconf/experiment_config.go
+++ b/master/pkg/schemas/expconf/experiment_config.go
@@ -195,6 +195,7 @@ type ResourcesConfigV0 struct {
 	RawAgentLabel     *string  `json:"agent_label"`
 	RawResourcePool   *string  `json:"resource_pool"`
 	RawPriority       *int     `json:"priority"`
+	RawForceQueue     *bool    `json:"force_queue"`
 
 	RawDevices DevicesConfigV0 `json:"devices"`
 }

--- a/master/pkg/schemas/expconf/zgen_resources_config_v0.go
+++ b/master/pkg/schemas/expconf/zgen_resources_config_v0.go
@@ -95,6 +95,17 @@ func (r *ResourcesConfigV0) SetPriority(val *int) {
 	r.RawPriority = val
 }
 
+func (r ResourcesConfigV0) ForceQueue() bool {
+	if r.RawForceQueue == nil {
+		panic("You must call WithDefaults on ResourcesConfigV0 before .ForceQueue")
+	}
+	return *r.RawForceQueue
+}
+
+func (r *ResourcesConfigV0) SetForceQueue(val bool) {
+	r.RawForceQueue = &val
+}
+
 func (r ResourcesConfigV0) Devices() DevicesConfigV0 {
 	return r.RawDevices
 }

--- a/master/pkg/schemas/zgen_schemas.go
+++ b/master/pkg/schemas/zgen_schemas.go
@@ -1888,6 +1888,13 @@ var (
             "default": [],
             "optionalRef": "http://determined.ai/schemas/expconf/v0/devices.json"
         },
+        "force_queue": {
+            "type": [
+                "boolean",
+                "null"
+            ],
+            "default": false
+        },
         "max_slots": {
             "type": [
                 "integer",

--- a/schemas/expconf/v0/resources.json
+++ b/schemas/expconf/v0/resources.json
@@ -21,6 +21,13 @@
             "default": [],
             "optionalRef": "http://determined.ai/schemas/expconf/v0/devices.json"
         },
+        "force_queue": {
+            "type": [
+                "boolean",
+                "null"
+            ],
+            "default": false
+        },
         "max_slots": {
             "type": [
                 "integer",

--- a/schemas/test_cases/v0/experiment.yaml
+++ b/schemas/test_cases/v0/experiment.yaml
@@ -209,6 +209,7 @@
       max_slots: null
       priority: null
       resource_pool: ''
+      force_queue: false
     scheduling_unit: 100
     searcher:
       max_length:


### PR DESCRIPTION
## Description

A known problem in our queuing system is that if an experiment's slotsPerTrial is larger than the largest agent, it will be queued forever and never run ( https://determinedai.atlassian.net/browse/DET-7722 ).  I'm working on flagging these experiments in the UI (#4420) but the consensus was that we should raise an error and not create these experiments in the first place.

This code returns an error from `parseCreateExperiment` because it's used by all paths to create an experiment (CLI, forks, new API, old API, wherever).

I've added `force_queue` as an experiment config option to override this check.

## Test Plan

We already had a test that creates an infinite-queue experiment. I modified the test so we expect an error, then add `force_queue` to the experiment config and resume the original experiment.

## Checklist

- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.