### PR TITLE
chore: agent sends log level with agent added container logs

### DIFF
--- a/agent/internal/container.go
+++ b/agent/internal/container.go
@@ -215,6 +215,9 @@ func (c *containerActor) makeTaskLog(log aproto.ContainerLog) model.TaskLog {
 	l := c.baseTaskLog
 	timestamp := time.Now().UTC()
 	l.Timestamp = &timestamp
+	if log.Level != nil {
+		l.Level = log.Level
+	}
 
 	var source string
 	var msg string

--- a/agent/internal/docker.go
+++ b/agent/internal/docker.go
@@ -28,6 +28,7 @@ import (
 	"github.com/determined-ai/determined/master/pkg/archive"
 	"github.com/determined-ai/determined/master/pkg/cproto"
 	"github.com/determined-ai/determined/master/pkg/model"
+	"github.com/determined-ai/determined/master/pkg/ptrs"
 )
 
 type dockerActor struct {
@@ -137,17 +138,19 @@ func (d *dockerActor) pullImage(ctx *actor.Context, msg pullImage) {
 	switch {
 	case msg.ForcePull:
 		if err == nil {
-			d.sendAuxLog(ctx, fmt.Sprintf(
+			d.sendAuxLog(ctx, ptrs.Ptr(model.LogLevelInfo), fmt.Sprintf(
 				"image present, but force_pull_image is set; checking for updates: %s",
 				ref.String(),
 			))
 		}
 	case err == nil:
-		d.sendAuxLog(ctx, fmt.Sprintf("image already found, skipping pull phase: %s", ref.String()))
+		d.sendAuxLog(ctx, ptrs.Ptr(model.LogLevelInfo),
+			fmt.Sprintf("image already found, skipping pull phase: %s", ref.String()))
 		ctx.Tell(ctx.Sender(), imagePulled{})
 		return
 	case client.IsErrNotFound(err):
-		d.sendAuxLog(ctx, fmt.Sprintf("image not found, pulling image: %s", ref.String()))
+		d.sendAuxLog(ctx, ptrs.Ptr(model.LogLevelInfo),
+			fmt.Sprintf("image not found, pulling image: %s", ref.String()))
 	default:
 		sendErr(ctx, errors.Wrapf(err, "error checking if image exists: %s", ref.String()))
 		return
@@ -218,8 +221,8 @@ func (d *dockerActor) getDockerAuths(
 	if expconfReg != nil {
 		didNotPassServerAddress := expconfReg.ServerAddress == ""
 		if didNotPassServerAddress {
-			d.sendAuxLog(ctx, "warning setting registry_auth without registry_auth.serveraddress "+
-				"is deprecated and will soon be required")
+			d.sendAuxLog(ctx, ptrs.Ptr(model.LogLevelWarning), "setting registry_auth "+
+				"without registry_auth.serveraddress is deprecated and will soon be required")
 		}
 
 		expconfDomain := registry.ConvertToHostname(expconfReg.ServerAddress)
@@ -227,16 +230,17 @@ func (d *dockerActor) getDockerAuths(
 			didNotPassServerAddress { // TODO remove didNotPassServerAddress when it becomes required.
 			return *expconfReg, nil
 		}
-		d.sendAuxLog(ctx, fmt.Sprintf("warning not using expconfig registry_auth "+
-			"since expconf registry_auth.serverAddress %s did not match the image serverAddress %s",
-			expconfDomain, imageDomain))
+		d.sendAuxLog(ctx, ptrs.Ptr(model.LogLevelWarning),
+			fmt.Sprintf("warning not using expconfig registry_auth since expconf "+
+				"registry_auth.serverAddress %s did not match the image serverAddress %s",
+				expconfDomain, imageDomain))
 	}
 
 	// Try using credential stores specified in ~/.docker/config.json.
 	if store, ok := d.credentialStores[imageDomain]; ok {
 		creds, err := store.get()
 		if err == nil {
-			d.sendAuxLog(ctx, fmt.Sprintf(
+			d.sendAuxLog(ctx, ptrs.Ptr(model.LogLevelInfo), fmt.Sprintf(
 				"domain '%s' found in 'credHelpers' config. Using credentials helper.", imageDomain))
 		}
 		return creds, errors.Wrap(err, "unable to get credentials from helper")
@@ -249,7 +253,7 @@ func (d *dockerActor) getDockerAuths(
 	}
 	reg := registry.ResolveAuthConfig(d.authConfigs, index)
 	if reg != (types.AuthConfig{}) {
-		d.sendAuxLog(ctx, fmt.Sprintf(
+		d.sendAuxLog(ctx, ptrs.Ptr(model.LogLevelInfo), fmt.Sprintf(
 			"domain '%s' found in 'auths' ~/.docker/config.json", imageDomain))
 	}
 	return reg, nil
@@ -264,11 +268,13 @@ func (d *dockerActor) runContainer(ctx *actor.Context, msg cproto.RunSpec) {
 	}
 	containerID := response.ID
 	for _, w := range response.Warnings {
-		d.sendAuxLog(ctx, fmt.Sprintf("warning when creating container: %s", w))
+		d.sendAuxLog(ctx, ptrs.Ptr(model.LogLevelWarning),
+			fmt.Sprintf("warning when creating container: %s", w))
 	}
 
 	for _, copyArx := range msg.Archives {
-		d.sendAuxLog(ctx, fmt.Sprintf("copying files to container: %s", copyArx.Path))
+		d.sendAuxLog(ctx, ptrs.Ptr(model.LogLevelInfo),
+			fmt.Sprintf("copying files to container: %s", copyArx.Path))
 		files, aerr := archive.ToIOReader(copyArx.Archive)
 		if aerr != nil {
 			sendErr(ctx, errors.Wrap(aerr, "error converting RunSpec Archive files to io.Reader"))
@@ -374,9 +380,10 @@ func sendErr(ctx *actor.Context, err error) {
 	ctx.Tell(ctx.Sender(), dockerErr{Error: err})
 }
 
-func (d *dockerActor) sendAuxLog(ctx *actor.Context, msg string) {
+func (d *dockerActor) sendAuxLog(ctx *actor.Context, level *string, msg string) {
 	ctx.Tell(ctx.Sender(), aproto.ContainerLog{
 		Timestamp:  time.Now().UTC(),
+		Level:      level,
 		AuxMessage: &msg,
 	})
 }

--- a/agent/internal/docker.go
+++ b/agent/internal/docker.go
@@ -231,7 +231,7 @@ func (d *dockerActor) getDockerAuths(
 			return *expconfReg, nil
 		}
 		d.sendAuxLog(ctx, ptrs.Ptr(model.LogLevelWarning),
-			fmt.Sprintf("warning not using expconfig registry_auth since expconf "+
+			fmt.Sprintf("not using expconfig registry_auth since expconf "+
 				"registry_auth.serverAddress %s did not match the image serverAddress %s",
 				expconfDomain, imageDomain))
 	}

--- a/master/internal/resourcemanagers/agent/agent.go
+++ b/master/internal/resourcemanagers/agent/agent.go
@@ -449,6 +449,7 @@ func (a *agent) handleIncomingWSMessage(ctx *actor.Context, msg aproto.MasterMes
 		}
 		ctx.Tell(ref, sproto.ContainerLog{
 			Container:   msg.ContainerLog.Container,
+			Level:       msg.ContainerLog.Level,
 			Timestamp:   msg.ContainerLog.Timestamp,
 			PullMessage: msg.ContainerLog.PullMessage,
 			RunMessage:  msg.ContainerLog.RunMessage,

--- a/master/pkg/aproto/master_message.go
+++ b/master/pkg/aproto/master_message.go
@@ -165,9 +165,9 @@ func (c ContainerStopped) String() string {
 
 // ContainerLog notifies the master that a new log message is available for the container.
 type ContainerLog struct {
-	Container cproto.Container
-	Timestamp time.Time
-
+	Container   cproto.Container
+	Timestamp   time.Time
+	Level       *string
 	PullMessage *string
 	RunMessage  *RunMessage
 	AuxMessage  *string


### PR DESCRIPTION
## Description

This change actually sends the log level for agent added container logs.

## Test Plan

The following command 
```
det command run --config="environment.registry_auth.password=docker" --config="environment.force_pull_image=true"  "echo hello" 
```

should print
```
[2022-07-13T14:09:22.225898Z] f9d23f8f || WARNING: setting registry_auth without registry_auth.serveraddress is deprecated and will soon be required
```

## Checklist

- [X] User-facing API changes need the "User-facing API Change" label.
- [X] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [X] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
