### PR TITLE
feat: Place experiment in a project using CLI [DET-7720]

### DIFF
--- a/harness/determined/cli/experiment.py
+++ b/harness/determined/cli/experiment.py
@@ -145,6 +145,12 @@ def submit_experiment(args: Namespace) -> None:
             additional_body_fields["git_commit_date"],
         ) = read_git_metadata(args.model_def)
 
+    if args.project_id:
+        sess = setup_session(args)
+        p = bindings.get_GetProject(sess, id=args.project_id).project
+        experiment_config["project"] = p.name
+        experiment_config["workspace"] = p.workspaceName
+
     if args.test_mode:
         api.experiment.create_test_experiment_and_follow_logs(
             args.master,
@@ -919,6 +925,7 @@ main_cmd = Cmd(
                     type=str,
                     help="name of template to apply to the experiment configuration",
                 ),
+                Arg("--project_id", type=int, help="place this experiment inside this project"),
                 Arg("--config", action="append", default=[], help=CONFIG_DESC),
                 Group(
                     Arg(

--- a/harness/determined/cli/experiment.py
+++ b/harness/determined/cli/experiment.py
@@ -554,6 +554,8 @@ def list_experiments(args: Namespace) -> None:
             render.format_time(e.endTime),
             e.resourcePool,
         ]
+        if args.show_project:
+            result = [e.workspaceName, e.projectName] + result
         if args.all:
             result.append(e.archived)
         return result
@@ -569,6 +571,8 @@ def list_experiments(args: Namespace) -> None:
         "End Time",
         "Resource Pool",
     ]
+    if args.show_project:
+        headers = ["Workspace", "Project"] + headers
     if args.all:
         headers.append("Archived")
 
@@ -831,6 +835,11 @@ main_cmd = Cmd(
                     "-a",
                     action="store_true",
                     help="show all experiments (including archived and other users')",
+                ),
+                Arg(
+                    "--show_project",
+                    action="store_true",
+                    help="include columns for workspace name and project name",
                 ),
                 *pagination_args,
                 Arg("--csv", action="store_true", help="print as CSV"),

--- a/master/static/srv/get_experiments.sql
+++ b/master/static/srv/get_experiments.sql
@@ -23,7 +23,13 @@ WITH page_info AS (
             AND ($7 = '' OR (e.config->>'name') ILIKE ('%%' || $7 || '%%'))
             AND ($8 = 0 OR e.project_id = $8)
     ), $9, $10) AS page_info
-), exps AS (
+),
+pj AS (
+  SELECT projects.id, projects.name AS project_name, workspaces.name AS workspace_name
+  FROM projects
+  JOIN workspaces ON workspaces.id = projects.workspace_id
+),
+exps AS (
     SELECT
         e.id AS id,
         e.config->>'name' AS name,
@@ -46,9 +52,12 @@ WITH page_info AS (
         e.owner_id AS user_id,
         e.project_id AS project_id,
         u.username AS username,
-        COALESCE(u.display_name, u.username) as display_name
+        COALESCE(u.display_name, u.username) as display_name,
+        pj.project_name,
+        pj.workspace_name
     FROM experiments e
     JOIN users u ON e.owner_id = u.id
+    JOIN pj ON e.project_id = pj.id
     WHERE
         ($1 = '' OR e.state IN (SELECT unnest(string_to_array($1, ','))::experiment_state))
         AND ($2 = '' OR e.archived = $2::BOOL)


### PR DESCRIPTION
## Description

Responding to DET-7720, this makes two changes to the Experiment CLI, which includes a change to how we respond to CreateExperiment and GetExperiments.

- CreateExperiment CLI will accept a numeric `--project_id`. We get that workspace / project, and overwrite any workspace / project in the config yaml file.
- GetExperiments will use JOINs to put the workspace name and project name in the response (previously left these fields blank except in singular GetExperiment)
- GetExperiments CLI with `--show_project` will prepend two columns: Workspace and Project

## Test Plan

(create a project and get its numeric ID)

`det e create decision_trees/gbt_titanic_estimator/const.yaml decision_trees/gbt_titanic_estimator/ --project_id 200`

`det e list` and `det e list --show_project`

## Checklist

- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.