### PR TITLE
fix: rocm-smi workaround without product info

### DIFF
--- a/agent/internal/rocm.go
+++ b/agent/internal/rocm.go
@@ -125,6 +125,7 @@ func detectRocmGPUs(visibleGPUs string) ([]device.Device, error) {
 				"error while executing rocm-smi to detect GPUs")
 			return nil, nil
 		}
+		log.Warn("rocm-smi detected a card without a product name, firmware issue possible")
 	}
 
 	discoveredRocmDevices, err = parseRocmSmi(out)

--- a/agent/internal/rocm.go
+++ b/agent/internal/rocm.go
@@ -117,7 +117,7 @@ func detectRocmGPUs(visibleGPUs string) ([]device.Device, error) {
 
 		cmd := exec.Command("rocm-smi", args...)
 
-		out, err := cmd.Output()
+		out, err = cmd.Output()
 		if execError, ok := err.(*exec.Error); ok && execError.Err == exec.ErrNotFound {
 			return nil, nil
 		} else if err != nil {

--- a/agent/internal/rocm.go
+++ b/agent/internal/rocm.go
@@ -92,7 +92,7 @@ func parseRocmSmi(jsonData []byte) ([]RocmDevice, error) {
 }
 
 func detectRocmGPUs(visibleGPUs string) ([]device.Device, error) {
-	args := []string{"--showuniqueid", "--showproductname", "--showbus", "--json"}
+	args := []string{"--showuniqueid", "--showbus", "--json"}
 
 	if visibleGPUs != "" {
 		gpuIds := strings.Split(visibleGPUs, ",")

--- a/harness/determined/gpu.py
+++ b/harness/determined/gpu.py
@@ -81,7 +81,6 @@ def _get_rocm_gpus() -> List[GPU]:
                 "rocm-smi",
                 "--showid",
                 "--showuniqueid",
-                "--showproductname",
                 "--json",
             ],
             check=True,


### PR DESCRIPTION
## Description

an rocm-smi bug throws up when GPU vendor information isn't present/corrupted on a machine. since this information isn't strictly required by the backend (only web UI), a workaround is to try again to retrieve the needed GPU ID info without the "--showproductinfo" flag.

<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At a minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions about this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ