### PR TITLE
fix: expconf copy timeout triggering when it shouldn't

### DIFF
--- a/master/internal/experiment.go
+++ b/master/internal/experiment.go
@@ -279,11 +279,6 @@ func (e *experiment) Receive(ctx *actor.Context) error {
 	case trialClosed:
 		e.trialClosed(ctx, msg.requestID)
 
-	// Deep copys the experiment's config.
-	case expconf.ExperimentConfig:
-		if ctx.ExpectingResponse() {
-			ctx.Respond(schemas.Copy(e.Config).(expconf.ExperimentConfig))
-		}
 	// Patch experiment messages.
 	case model.StateWithReason:
 		e.updateState(ctx, msg)


### PR DESCRIPTION
## Description

#4533 caused a test failure due to it timing out, not sure if the timeout was just experiment config copying taking longer than the timeout (2 seconds) or if the experiment actor was busy with another message. Either way this change is a lot safer moving the copy before we create the actor since it doesn't add anything interesting to the config.

## Test Plan

upstream tests

## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
