### PR TITLE
fix: helm option "defaultPassword" caused the deployment to hang [DET-7814]

### DIFF
--- a/docs/release-notes/default-password-k8-fix.txt
+++ b/docs/release-notes/default-password-k8-fix.txt
@@ -1,0 +1,5 @@
+:orphan:
+
+**Bug Fixes**
+
+-  Kubernetes: Fix an issue where the Helm option ``defaultPassword`` caused the deployment to hang.

--- a/helm/charts/determined/scripts/k8s-password-change.py
+++ b/helm/charts/determined/scripts/k8s-password-change.py
@@ -1,0 +1,90 @@
+import json
+import sys
+import time
+from typing import List
+
+from determined_common import api
+from kubernetes import client, config
+
+
+def pwChange(user: str, password: str, entrypoint: str) -> None:
+    print(f"Trying to change {user}'s password", flush=True)
+    while True:
+        try:
+            resp = api.post(
+                entrypoint,
+                "/api/v1/auth/login",
+                body={"username": user, "password": ""},
+                authenticated=False,
+            )
+
+            data = json.loads(resp.text)
+            api.post(
+                entrypoint,
+                f"/api/v1/users/{data['user']['id']}/password",
+                body=password,
+                headers={"Authorization": f"Bearer {data['token']}"},
+                authenticated=False,
+            )
+            print(f"Sucessfully changed {user}'s password", flush=True)
+            return
+        except Exception as e:
+            print(f"Encountered exception: {e}", flush=True)
+            return
+
+
+def checkPortAlive(entrypoint: str) -> None:
+    while True:
+        try:
+            api.get(entrypoint, "/api/v1/master", authenticated=False)
+            return
+        except Exception as e:
+            print(f"Encountered exception: {e}")
+            continue
+
+
+def getMasterAddress(namespace: str, service_name: str, master_port: str, node_port: str) -> str:
+    config.load_incluster_config()
+    v1 = client.CoreV1Api()
+    target_service = f"determined-master-service-{service_name}"
+
+    if node_port != "true":
+        while True:
+            services = v1.list_namespaced_service(namespace)
+            for svc in services.items:
+                if target_service in svc.metadata.name:
+                    ingress = svc.status.load_balancer.ingress
+                    if ingress is None:
+                        time.sleep(1)
+                        break
+                    if ingress[0].hostname is not None:
+                        # use hostname over ip address, if available
+                        return f"{ingress[0].hostname}:{master_port}"
+                    else:
+                        return f"{ingress[0].ip}:{master_port}"
+
+    services = v1.list_namespaced_service(namespace)
+    for svc in services.items:
+        if target_service in svc.metadata.name:
+            entrypoint = f"{svc.spec.cluster_ip}:{master_port}"
+            checkPortAlive(entrypoint)
+
+            return entrypoint
+    return ""
+
+
+def main(argv: List[str]) -> None:
+    if len(argv) < 5:
+        raise Exception("not enough args")
+    if argv[4] == "":
+        raise Exception("no password supplied")
+
+    for i in range(len(argv)):
+        argv[i] = argv[i].strip()
+    addr = getMasterAddress(argv[0], argv[1], argv[2], argv[3])
+    pwChange("determined", argv[4], addr)
+    pwChange("admin", argv[4], addr)
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/helm/charts/determined/templates/change-password.yaml
+++ b/helm/charts/determined/templates/change-password.yaml
@@ -28,7 +28,6 @@ spec:
         args:
           - "-c"
           - >-
-            sleep 5 &&
             echo -e {{ .Files.Get "scripts/k8s-password-change.py" | quote }} > change-pw.py &&
             python3 change-pw.py
             {{ .Release.Namespace | quote }} \

--- a/helm/charts/determined/templates/change-password.yaml
+++ b/helm/charts/determined/templates/change-password.yaml
@@ -24,12 +24,16 @@ spec:
       - name: change-password
         image: "{{ .Values.imageRegistry }}/utility:py-3.7-pw-changer"
         imagePullPolicy: "Always"
-        command: ["python3"]
+        command: ["/bin/bash"]
         args:
-          - "opt/determined/change-password.py"
-          - {{ .Release.Namespace }}
-          - {{ .Release.Name }}
-          - {{ .Values.masterPort | quote }}
-          - {{ .Values.useNodePortForMaster | quote }}
-          - {{ .Values.defaultPassword | default ""}}
+          - "-c"
+          - >-
+            sleep 5 &&
+            echo -e {{ .Files.Get "scripts/k8s-password-change.py" | quote }} > change-pw.py &&
+            python3 change-pw.py
+            {{ .Release.Namespace | quote }} \
+            {{ .Release.Name | quote }} \
+            {{ .Values.masterPort | quote }} \
+            {{ .Values.useNodePortForMaster | quote }} \
+            {{ .Values.defaultPassword | default ""}}
 {{- end }}


### PR DESCRIPTION
## Description

API changes had caused this option to cause any deployment with a non empty ```defaultPassword``` to hang.

## Test Plan

On a GKE cluster run a deployment with (any recent determined version should be fine) 
```
helm install determined helm/charts/determined/ --set maxSlotsPerPod=2 --set defaultPassword=secret --set detVersion=0.18.4
``` 
Above command can take a minute but it should not hang

Then running
```
det user login admin
det user login determined
```

should both work when ```secret``` is used as the password.

## Commentary (optional)

Moves the python code out of this repo https://github.com/determined-ai/k8s-utility and we should ideally replace the image to something we maintain actively (possible dev image we are making with all determined dependencies?) 

## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
