### PR TITLE
feat: text search for task/trial logs [DET-7446]

### DIFF
--- a/master/internal/api/filters.go
+++ b/master/internal/api/filters.go
@@ -10,6 +10,8 @@ const (
 	FilterOperationGreaterThan
 	// FilterOperationLessThanEqual checks if the field is less than or equal to a value.
 	FilterOperationLessThanEqual
+	// FilterOperationStringContainment checks if the field a value as a substring.
+	FilterOperationStringContainment
 )
 
 // Filter is a general representation for a filter provided to an API.

--- a/master/internal/api/filters.go
+++ b/master/internal/api/filters.go
@@ -10,7 +10,7 @@ const (
 	FilterOperationGreaterThan
 	// FilterOperationLessThanEqual checks if the field is less than or equal to a value.
 	FilterOperationLessThanEqual
-	// FilterOperationStringContainment checks if the field a value as a substring.
+	// FilterOperationStringContainment checks if the field contains a value as a substring.
 	FilterOperationStringContainment
 )
 

--- a/master/internal/api_tasks.go
+++ b/master/internal/api_tasks.go
@@ -236,6 +236,14 @@ func constructTaskLogsFilters(req *apiv1.TaskLogsRequest) ([]api.Filter, error) 
 			Values:    req.TimestampAfter.AsTime(),
 		})
 	}
+
+	if req.SearchText != "" {
+		filters = append(filters, api.Filter{
+			Field:     "log",
+			Operation: api.FilterOperationStringContainment,
+			Values:    req.SearchText,
+		})
+	}
 	return filters, nil
 }
 

--- a/master/internal/api_trials.go
+++ b/master/internal/api_trials.go
@@ -120,6 +120,7 @@ func (a *apiServer) TrialLogs(
 			TimestampBefore: req.TimestampBefore,
 			TimestampAfter:  req.TimestampAfter,
 			OrderBy:         req.OrderBy,
+			SearchText:      req.SearchText,
 		}, res)
 		return processBatches(res, func(b api.Batch) error {
 			return b.ForEach(func(i interface{}) error {

--- a/master/internal/db/postgres_filters.go
+++ b/master/internal/db/postgres_filters.go
@@ -62,7 +62,9 @@ func filterToSQL(
 		return fmt.Sprintf("AND %s <= $%d", field, paramID)
 	case api.FilterOperationStringContainment:
 		// Works for both bytea and text fields
-		return fmt.Sprintf("AND encode(%s::bytea, 'escape') ILIKE  ('%%%%' || $%d || '%%%%')", field, paramID)
+		return fmt.Sprintf("AND encode(%s::bytea, 'escape') ILIKE  ('%%%%' || $%d || '%%%%')",
+			field,
+			paramID)
 	default:
 		panic(fmt.Sprintf("cannot convert operation %d to SQL", f.Operation))
 	}

--- a/master/internal/db/postgres_filters.go
+++ b/master/internal/db/postgres_filters.go
@@ -60,6 +60,10 @@ func filterToSQL(
 		return fmt.Sprintf("AND %s > $%d", field, paramID)
 	case api.FilterOperationLessThanEqual:
 		return fmt.Sprintf("AND %s <= $%d", field, paramID)
+	case api.FilterOperationStringContainment:
+		// Suprisingly (?) this work for both bytea (needed for current)
+		// as well as plain text fields (not needed atm)
+		return fmt.Sprintf("AND encode(%s::bytea, 'escape') ILIKE  ('%%%%' || $%d || '%%%%')", field, paramID)
 	default:
 		panic(fmt.Sprintf("cannot convert operation %d to SQL", f.Operation))
 	}
@@ -72,6 +76,9 @@ func filterToParams(f api.Filter) []interface{} {
 		for _, v := range vs {
 			params = append(params, v)
 		}
+	case string:
+		// any reason not to do this?
+		params = append(params, vs)
 	case []int64:
 		for _, v := range vs {
 			params = append(params, v)

--- a/master/internal/db/postgres_filters.go
+++ b/master/internal/db/postgres_filters.go
@@ -61,8 +61,7 @@ func filterToSQL(
 	case api.FilterOperationLessThanEqual:
 		return fmt.Sprintf("AND %s <= $%d", field, paramID)
 	case api.FilterOperationStringContainment:
-		// Suprisingly (?) this work for both bytea (needed for current)
-		// as well as plain text fields (not needed atm)
+		// Works for both bytea and text fields
 		return fmt.Sprintf("AND encode(%s::bytea, 'escape') ILIKE  ('%%%%' || $%d || '%%%%')", field, paramID)
 	default:
 		panic(fmt.Sprintf("cannot convert operation %d to SQL", f.Operation))
@@ -77,7 +76,6 @@ func filterToParams(f api.Filter) []interface{} {
 			params = append(params, v)
 		}
 	case string:
-		// any reason not to do this?
 		params = append(params, vs)
 	case []int64:
 		for _, v := range vs {

--- a/master/internal/db/postgres_tasks.go
+++ b/master/internal/db/postgres_tasks.go
@@ -266,7 +266,6 @@ type taskLogsFollowState struct {
 func (db *PgDB) TaskLogs(
 	taskID model.TaskID, limit int, fs []api.Filter, order apiv1.OrderBy, followState interface{},
 ) ([]*model.TaskLog, interface{}, error) {
-	fmt.Println("pg logs")
 	if followState != nil {
 		fs = append(fs, api.Filter{
 			Field:     "id",

--- a/master/internal/db/postgres_tasks.go
+++ b/master/internal/db/postgres_tasks.go
@@ -266,6 +266,7 @@ type taskLogsFollowState struct {
 func (db *PgDB) TaskLogs(
 	taskID model.TaskID, limit int, fs []api.Filter, order apiv1.OrderBy, followState interface{},
 ) ([]*model.TaskLog, interface{}, error) {
+	fmt.Println("pg logs")
 	if followState != nil {
 		fs = append(fs, api.Filter{
 			Field:     "id",

--- a/master/internal/elastic/elastic_task_logs.go
+++ b/master/internal/elastic/elastic_task_logs.go
@@ -92,7 +92,6 @@ func (e *Elastic) TaskLogs(
 	taskID model.TaskID, limit int, fs []api.Filter, order apiv1.OrderBy,
 	searchAfter interface{},
 ) ([]*model.TaskLog, interface{}, error) {
-	fmt.Println("elastic logs")
 	if limit > elasticMaxQuerySize {
 		limit = elasticMaxQuerySize
 	}

--- a/master/internal/elastic/elastic_task_logs.go
+++ b/master/internal/elastic/elastic_task_logs.go
@@ -92,6 +92,7 @@ func (e *Elastic) TaskLogs(
 	taskID model.TaskID, limit int, fs []api.Filter, order apiv1.OrderBy,
 	searchAfter interface{},
 ) ([]*model.TaskLog, interface{}, error) {
+	fmt.Println("elastic logs")
 	if limit > elasticMaxQuerySize {
 		limit = elasticMaxQuerySize
 	}

--- a/master/internal/elastic/elastic_task_logs.go
+++ b/master/internal/elastic/elastic_task_logs.go
@@ -412,6 +412,16 @@ func filtersToElastic(fs []api.Filter) []jsonObj {
 						},
 					},
 				})
+		case api.FilterOperationStringContainment:
+			terms = append(terms,
+				jsonObj{
+					"wildcard": jsonObj{
+						f.Field: jsonObj{
+							"value": fmt.Sprintf("*%s*", f.Values),
+						},
+					},
+				})
+
 		default:
 			panic(fmt.Sprintf("unsupported filter operation: %d", f.Operation))
 		}

--- a/proto/src/determined/api/v1/task.proto
+++ b/proto/src/determined/api/v1/task.proto
@@ -63,6 +63,8 @@ message TaskLogsRequest {
   google.protobuf.Timestamp timestamp_after = 14;
   // Order logs in either ascending or descending order by timestamp.
   OrderBy order_by = 15;
+  // Search the logs by whether the text contains a substring.
+  string searchText = 16;
 }
 
 // Response to TaskLogsRequest.

--- a/proto/src/determined/api/v1/task.proto
+++ b/proto/src/determined/api/v1/task.proto
@@ -64,7 +64,7 @@ message TaskLogsRequest {
   // Order logs in either ascending or descending order by timestamp.
   OrderBy order_by = 15;
   // Search the logs by whether the text contains a substring.
-  string searchText = 16;
+  string search_text = 16;
 }
 
 // Response to TaskLogsRequest.

--- a/proto/src/determined/api/v1/trial.proto
+++ b/proto/src/determined/api/v1/trial.proto
@@ -74,7 +74,7 @@ message TrialLogsRequest {
   // Order logs in either ascending or descending order by timestamp.
   OrderBy order_by = 14;
   // Search the logs by whether the text contains a substring.
-  string searchText = 15;
+  string search_text = 15;
 }
 
 // Response to TrialLogsRequest.

--- a/proto/src/determined/api/v1/trial.proto
+++ b/proto/src/determined/api/v1/trial.proto
@@ -73,6 +73,8 @@ message TrialLogsRequest {
   google.protobuf.Timestamp timestamp_after = 13;
   // Order logs in either ascending or descending order by timestamp.
   OrderBy order_by = 14;
+  // Search the logs by whether the text contains a substring.
+  string searchText = 15;
 }
 
 // Response to TrialLogsRequest.

--- a/webui/react/src/components/LogViewer/LogViewerFilters.settings.ts
+++ b/webui/react/src/components/LogViewer/LogViewerFilters.settings.ts
@@ -7,6 +7,7 @@ export interface Settings {
   containerId?: string[];
   level?: LogLevelFromApi[];
   rankId?: number[];
+  searchText?: string;
 }
 
 const config: SettingsConfig = {
@@ -45,6 +46,10 @@ const config: SettingsConfig = {
         baseType: BaseType.String,
         isArray: true,
       },
+    },
+    {
+      key: 'searchText',
+      type: { baseType: BaseType.String },
     },
   ],
   storagePath: 'log-viewer-filters',

--- a/webui/react/src/components/LogViewer/LogViewerFilters.test.tsx
+++ b/webui/react/src/components/LogViewer/LogViewerFilters.test.tsx
@@ -37,7 +37,7 @@ describe('LogViewerFilter', () => {
 
     await waitFor(() => {
       Object.values(LABELS).forEach((label) => {
-        if (!DEFAULT_FILTER_OPTIONS[label]) return
+        if (!DEFAULT_FILTER_OPTIONS[label]) return;
         const regex = new RegExp(`All ${label}`, 'i');
         expect(screen.queryByText(regex)).toBeInTheDocument();
       });

--- a/webui/react/src/components/LogViewer/LogViewerFilters.test.tsx
+++ b/webui/react/src/components/LogViewer/LogViewerFilters.test.tsx
@@ -32,18 +32,19 @@ const setup = (filterOptions: Filters, filterValues: Filters) => {
 };
 
 describe('LogViewerFilter', () => {
-  it('should render all filters with options', async () => {
+  it('should render all select filters with options', async () => {
     setup(DEFAULT_FILTER_OPTIONS, {});
 
     await waitFor(() => {
       Object.values(LABELS).forEach((label) => {
+        if (!DEFAULT_FILTER_OPTIONS[label]) return
         const regex = new RegExp(`All ${label}`, 'i');
         expect(screen.queryByText(regex)).toBeInTheDocument();
       });
     });
   });
 
-  it('should render filters with selected options', async () => {
+  it('should render select filters with selected options', async () => {
     const values: Filters = {
       agentIds: [ DEFAULT_FILTER_OPTIONS.agentIds[1] ],
       allocationIds: [ DEFAULT_FILTER_OPTIONS.allocationIds[1] ],
@@ -56,7 +57,7 @@ describe('LogViewerFilter', () => {
     await waitFor(() => {
       Object.keys(LABELS).forEach((labelKey) => {
         const key = labelKey as keyof Filters;
-        if (values[key]?.length ?? 0 === 0) return;
+        if (!values[key]?.length) return;
 
         const regex = new RegExp(`${values[key]?.length} ${LABELS[key]}`, 'i');
         expect(screen.queryByText(regex)).toBeInTheDocument();

--- a/webui/react/src/components/LogViewer/LogViewerFilters.tsx
+++ b/webui/react/src/components/LogViewer/LogViewerFilters.tsx
@@ -1,4 +1,4 @@
-import { Button, Select, Space } from 'antd';
+import { Button, Input, Select, Space } from 'antd';
 import { SelectValue } from 'antd/es/select';
 import React, { useCallback, useMemo } from 'react';
 
@@ -12,6 +12,7 @@ interface Props {
   onChange?: (filters: Filters) => void;
   onReset?: () => void;
   options: Filters;
+  showSearch: boolean;
   values: Filters;
 }
 
@@ -21,6 +22,7 @@ export interface Filters {
   containerIds?: string[],
   levels?: LogLevelFromApi[],
   rankIds?: number[],
+  searchText?: string,
   // sources?: string[],
   // stdtypes?: string[],
 }
@@ -33,9 +35,16 @@ export const LABELS: Record<keyof Filters, string> = {
   containerIds: 'Container',
   levels: 'Level',
   rankIds: 'Rank',
+  searchText: 'Search',
 };
 
-const LogViewerFilters: React.FC<Props> = ({ onChange, onReset, options, values }: Props) => {
+const LogViewerFilters: React.FC<Props> = ({
+  onChange,
+  onReset,
+  options,
+  showSearch,
+  values,
+}: Props) => {
   const selectOptions = useMemo(() => {
     const { agentIds, allocationIds, containerIds, rankIds } = options;
     return {
@@ -78,6 +87,11 @@ const LogViewerFilters: React.FC<Props> = ({ onChange, onReset, options, values 
   ) => (value: SelectValue) => {
     onChange?.({ ...values, [key]: (value as Array<string>).map((item) => caster(item)) });
   }, [ onChange, values ]);
+
+  const handleSearch = useCallback(
+    (e) => onChange?.({ ...values, searchText: e.target.value })
+    , [ onChange, values ],
+  );
 
   const handleReset = useCallback(() => onReset?.(), [ onReset ]);
 
@@ -133,6 +147,13 @@ const LogViewerFilters: React.FC<Props> = ({ onChange, onReset, options, values 
             <Option key={level.value} value={level.value}>{level.label}</Option>
           ))}
         </MultiSelect>
+        {showSearch && (
+          <Input
+            placeholder="Search Logs..."
+            value={values.searchText}
+            onChange={handleSearch}
+          />
+        )}
         {isResetShown && <Button onClick={handleReset}>{ARIA_LABEL_RESET}</Button>}
       </Space>
     </>

--- a/webui/react/src/components/LogViewer/LogViewerFilters.tsx
+++ b/webui/react/src/components/LogViewer/LogViewerFilters.tsx
@@ -153,13 +153,6 @@ const LogViewerFilters: React.FC<Props> = ({
             <Option key={level.value} value={level.value}>{level.label}</Option>
           ))}
         </MultiSelect>
-        {showSearch && (
-          <Input
-            placeholder="Search Logs..."
-            value={values.searchText}
-            onChange={handleSearch}
-          />
-        )}
         {isResetShown && <Button onClick={handleReset}>{ARIA_LABEL_RESET}</Button>}
       </Space>
     </>

--- a/webui/react/src/components/LogViewer/LogViewerFilters.tsx
+++ b/webui/react/src/components/LogViewer/LogViewerFilters.tsx
@@ -98,6 +98,12 @@ const LogViewerFilters: React.FC<Props> = ({
   return (
     <>
       <Space>
+       {showSearch && (
+          <Input 
+          placeholder="Search Logs..." 
+          value={values.searchText} 
+          onChange={handleSearch} />
+        )}
         {moreThanOne.allocationIds && (
           <MultiSelect
             itemName={LABELS.allocationIds}

--- a/webui/react/src/components/LogViewer/LogViewerFilters.tsx
+++ b/webui/react/src/components/LogViewer/LogViewerFilters.tsx
@@ -98,11 +98,12 @@ const LogViewerFilters: React.FC<Props> = ({
   return (
     <>
       <Space>
-       {showSearch && (
-          <Input 
-          placeholder="Search Logs..." 
-          value={values.searchText} 
-          onChange={handleSearch} />
+        {showSearch && (
+          <Input
+            placeholder="Search Logs..."
+            value={values.searchText}
+            onChange={handleSearch}
+          />
         )}
         {moreThanOne.allocationIds && (
           <MultiSelect

--- a/webui/react/src/components/TrialLogPreview.tsx
+++ b/webui/react/src/components/TrialLogPreview.tsx
@@ -51,6 +51,7 @@ const TrialLogPreview: React.FC<PropsWithChildren<Props>> = ({
         undefined,
         dayjs(time).toDate(),
         'ORDER_BY_ASC',
+        undefined,
         { signal: canceler.signal },
       ),
       (event) => {
@@ -83,6 +84,7 @@ const TrialLogPreview: React.FC<PropsWithChildren<Props>> = ({
         undefined,
         undefined,
         'ORDER_BY_DESC',
+        undefined,
         { signal: canceler.signal },
       ),
       (event) => {

--- a/webui/react/src/pages/TaskLogs.tsx
+++ b/webui/react/src/pages/TaskLogs.tsx
@@ -51,6 +51,7 @@ const TaskLogs: React.FC<Props> = ({ taskId, taskType, onCloseLogs, headerCompon
     containerIds: settings.containerId,
     levels: settings.level,
     rankIds: settings.rankId,
+    searchText: settings.searchText,
   }), [ settings ]);
 
   const handleFilterChange = useCallback((filters: Filters) => {
@@ -60,6 +61,7 @@ const TaskLogs: React.FC<Props> = ({ taskId, taskType, onCloseLogs, headerCompon
       containerId: filters.containerIds,
       level: filters.levels,
       rankId: filters.rankIds,
+      searchText: filters.searchText,
     });
   }, [ updateSettings ]);
 
@@ -104,6 +106,7 @@ const TaskLogs: React.FC<Props> = ({ taskId, taskType, onCloseLogs, headerCompon
       options.timestampBefore ? new Date(options.timestampBefore) : undefined,
       options.timestampAfter ? new Date(options.timestampAfter) : undefined,
       options.orderBy as OrderBy,
+      settings.searchText,
       { signal: config.canceler.signal },
     );
   }, [ settings, taskId ]);
@@ -127,6 +130,7 @@ const TaskLogs: React.FC<Props> = ({ taskId, taskType, onCloseLogs, headerCompon
     <div className={css.filters}>
       <LogViewerFilters
         options={filterOptions}
+        showSearch={true}
         values={filterValues}
         onChange={handleFilterChange}
         onReset={handleFilterReset}

--- a/webui/react/src/pages/TrialDetails/TrialDetailsLogs.tsx
+++ b/webui/react/src/pages/TrialDetails/TrialDetailsLogs.tsx
@@ -42,6 +42,7 @@ const TrialDetailsLogs: React.FC<Props> = ({ experiment, trial }: Props) => {
     containerIds: settings.containerId,
     levels: settings.level,
     rankIds: settings.rankId,
+    searchText: settings.searchText,
   }), [ settings ]);
 
   const handleFilterChange = useCallback((filters: Filters) => {
@@ -50,6 +51,7 @@ const TrialDetailsLogs: React.FC<Props> = ({ experiment, trial }: Props) => {
       containerId: filters.containerIds,
       level: filters.levels,
       rankId: filters.rankIds,
+      searchText: filters.searchText,
     });
   }, [ updateSettings ]);
 
@@ -136,6 +138,7 @@ const TrialDetailsLogs: React.FC<Props> = ({ experiment, trial }: Props) => {
       options.timestampBefore ? new Date(options.timestampBefore) : undefined,
       options.timestampAfter ? new Date(options.timestampAfter) : undefined,
       options.orderBy as OrderBy,
+      settings.searchText,
       { signal: config.canceler.signal },
     );
   }, [ settings, trial?.id ]);
@@ -162,6 +165,7 @@ const TrialDetailsLogs: React.FC<Props> = ({ experiment, trial }: Props) => {
     <div className={css.filters}>
       <LogViewerFilters
         options={filterOptions}
+        showSearch={true}
         values={filterValues}
         onChange={handleFilterChange}
         onReset={handleFilterReset}

--- a/webui/react/src/services/api-ts-sdk/api.ts
+++ b/webui/react/src/services/api-ts-sdk/api.ts
@@ -10617,7 +10617,7 @@ export const ExperimentsApiFetchParamCreator = function (configuration?: Configu
          * @param {Date} [timestampBefore] Limit the trial logs to ones with a timestamp before a given time.
          * @param {Date} [timestampAfter] Limit the trial logs to ones with a timestamp after a given time.
          * @param {'ORDER_BY_UNSPECIFIED' | 'ORDER_BY_ASC' | 'ORDER_BY_DESC'} [orderBy] Order logs in either ascending or descending order by timestamp.   - ORDER_BY_UNSPECIFIED: Returns records in no specific order.  - ORDER_BY_ASC: Returns records in ascending order.  - ORDER_BY_DESC: Returns records in descending order.
-         * @param {string} [searchText] 
+         * @param {string} [searchText] Search the logs by whether the text contains a substring.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
@@ -11299,7 +11299,7 @@ export const ExperimentsApiFp = function(configuration?: Configuration) {
          * @param {Date} [timestampBefore] Limit the trial logs to ones with a timestamp before a given time.
          * @param {Date} [timestampAfter] Limit the trial logs to ones with a timestamp after a given time.
          * @param {'ORDER_BY_UNSPECIFIED' | 'ORDER_BY_ASC' | 'ORDER_BY_DESC'} [orderBy] Order logs in either ascending or descending order by timestamp.   - ORDER_BY_UNSPECIFIED: Returns records in no specific order.  - ORDER_BY_ASC: Returns records in ascending order.  - ORDER_BY_DESC: Returns records in descending order.
-         * @param {string} [searchText] 
+         * @param {string} [searchText] Search the logs by whether the text contains a substring.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
@@ -11659,7 +11659,7 @@ export const ExperimentsApiFactory = function (configuration?: Configuration, fe
          * @param {Date} [timestampBefore] Limit the trial logs to ones with a timestamp before a given time.
          * @param {Date} [timestampAfter] Limit the trial logs to ones with a timestamp after a given time.
          * @param {'ORDER_BY_UNSPECIFIED' | 'ORDER_BY_ASC' | 'ORDER_BY_DESC'} [orderBy] Order logs in either ascending or descending order by timestamp.   - ORDER_BY_UNSPECIFIED: Returns records in no specific order.  - ORDER_BY_ASC: Returns records in ascending order.  - ORDER_BY_DESC: Returns records in descending order.
-         * @param {string} [searchText] 
+         * @param {string} [searchText] Search the logs by whether the text contains a substring.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
@@ -12041,7 +12041,7 @@ export class ExperimentsApi extends BaseAPI {
      * @param {Date} [timestampBefore] Limit the trial logs to ones with a timestamp before a given time.
      * @param {Date} [timestampAfter] Limit the trial logs to ones with a timestamp after a given time.
      * @param {'ORDER_BY_UNSPECIFIED' | 'ORDER_BY_ASC' | 'ORDER_BY_DESC'} [orderBy] Order logs in either ascending or descending order by timestamp.   - ORDER_BY_UNSPECIFIED: Returns records in no specific order.  - ORDER_BY_ASC: Returns records in ascending order.  - ORDER_BY_DESC: Returns records in descending order.
-     * @param {string} [searchText] 
+     * @param {string} [searchText] Search the logs by whether the text contains a substring.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof ExperimentsApi
@@ -15259,7 +15259,7 @@ export const JobsApiFetchParamCreator = function (configuration?: Configuration)
          * @param {Date} [timestampBefore] Limit the trial logs to ones with a timestamp before a given time.
          * @param {Date} [timestampAfter] Limit the trial logs to ones with a timestamp after a given time.
          * @param {'ORDER_BY_UNSPECIFIED' | 'ORDER_BY_ASC' | 'ORDER_BY_DESC'} [orderBy] Order logs in either ascending or descending order by timestamp.   - ORDER_BY_UNSPECIFIED: Returns records in no specific order.  - ORDER_BY_ASC: Returns records in ascending order.  - ORDER_BY_DESC: Returns records in descending order.
-         * @param {string} [searchText] 
+         * @param {string} [searchText] Search the logs by whether the text contains a substring.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
@@ -15412,7 +15412,7 @@ export const JobsApiFp = function(configuration?: Configuration) {
          * @param {Date} [timestampBefore] Limit the trial logs to ones with a timestamp before a given time.
          * @param {Date} [timestampAfter] Limit the trial logs to ones with a timestamp after a given time.
          * @param {'ORDER_BY_UNSPECIFIED' | 'ORDER_BY_ASC' | 'ORDER_BY_DESC'} [orderBy] Order logs in either ascending or descending order by timestamp.   - ORDER_BY_UNSPECIFIED: Returns records in no specific order.  - ORDER_BY_ASC: Returns records in ascending order.  - ORDER_BY_DESC: Returns records in descending order.
-         * @param {string} [searchText] 
+         * @param {string} [searchText] Search the logs by whether the text contains a substring.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
@@ -15473,7 +15473,7 @@ export const JobsApiFactory = function (configuration?: Configuration, fetch?: F
          * @param {Date} [timestampBefore] Limit the trial logs to ones with a timestamp before a given time.
          * @param {Date} [timestampAfter] Limit the trial logs to ones with a timestamp after a given time.
          * @param {'ORDER_BY_UNSPECIFIED' | 'ORDER_BY_ASC' | 'ORDER_BY_DESC'} [orderBy] Order logs in either ascending or descending order by timestamp.   - ORDER_BY_UNSPECIFIED: Returns records in no specific order.  - ORDER_BY_ASC: Returns records in ascending order.  - ORDER_BY_DESC: Returns records in descending order.
-         * @param {string} [searchText] 
+         * @param {string} [searchText] Search the logs by whether the text contains a substring.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
@@ -15517,7 +15517,7 @@ export class JobsApi extends BaseAPI {
      * @param {Date} [timestampBefore] Limit the trial logs to ones with a timestamp before a given time.
      * @param {Date} [timestampAfter] Limit the trial logs to ones with a timestamp after a given time.
      * @param {'ORDER_BY_UNSPECIFIED' | 'ORDER_BY_ASC' | 'ORDER_BY_DESC'} [orderBy] Order logs in either ascending or descending order by timestamp.   - ORDER_BY_UNSPECIFIED: Returns records in no specific order.  - ORDER_BY_ASC: Returns records in ascending order.  - ORDER_BY_DESC: Returns records in descending order.
-     * @param {string} [searchText] 
+     * @param {string} [searchText] Search the logs by whether the text contains a substring.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof JobsApi
@@ -18982,7 +18982,7 @@ export const TasksApiFetchParamCreator = function (configuration?: Configuration
          * @param {Date} [timestampBefore] Limit the trial logs to ones with a timestamp before a given time.
          * @param {Date} [timestampAfter] Limit the trial logs to ones with a timestamp after a given time.
          * @param {'ORDER_BY_UNSPECIFIED' | 'ORDER_BY_ASC' | 'ORDER_BY_DESC'} [orderBy] Order logs in either ascending or descending order by timestamp.   - ORDER_BY_UNSPECIFIED: Returns records in no specific order.  - ORDER_BY_ASC: Returns records in ascending order.  - ORDER_BY_DESC: Returns records in descending order.
-         * @param {string} [searchText] 
+         * @param {string} [searchText] Search the logs by whether the text contains a substring.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
@@ -19154,7 +19154,7 @@ export const TasksApiFp = function(configuration?: Configuration) {
          * @param {Date} [timestampBefore] Limit the trial logs to ones with a timestamp before a given time.
          * @param {Date} [timestampAfter] Limit the trial logs to ones with a timestamp after a given time.
          * @param {'ORDER_BY_UNSPECIFIED' | 'ORDER_BY_ASC' | 'ORDER_BY_DESC'} [orderBy] Order logs in either ascending or descending order by timestamp.   - ORDER_BY_UNSPECIFIED: Returns records in no specific order.  - ORDER_BY_ASC: Returns records in ascending order.  - ORDER_BY_DESC: Returns records in descending order.
-         * @param {string} [searchText] 
+         * @param {string} [searchText] Search the logs by whether the text contains a substring.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
@@ -19225,7 +19225,7 @@ export const TasksApiFactory = function (configuration?: Configuration, fetch?: 
          * @param {Date} [timestampBefore] Limit the trial logs to ones with a timestamp before a given time.
          * @param {Date} [timestampAfter] Limit the trial logs to ones with a timestamp after a given time.
          * @param {'ORDER_BY_UNSPECIFIED' | 'ORDER_BY_ASC' | 'ORDER_BY_DESC'} [orderBy] Order logs in either ascending or descending order by timestamp.   - ORDER_BY_UNSPECIFIED: Returns records in no specific order.  - ORDER_BY_ASC: Returns records in ascending order.  - ORDER_BY_DESC: Returns records in descending order.
-         * @param {string} [searchText] 
+         * @param {string} [searchText] Search the logs by whether the text contains a substring.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
@@ -19281,7 +19281,7 @@ export class TasksApi extends BaseAPI {
      * @param {Date} [timestampBefore] Limit the trial logs to ones with a timestamp before a given time.
      * @param {Date} [timestampAfter] Limit the trial logs to ones with a timestamp after a given time.
      * @param {'ORDER_BY_UNSPECIFIED' | 'ORDER_BY_ASC' | 'ORDER_BY_DESC'} [orderBy] Order logs in either ascending or descending order by timestamp.   - ORDER_BY_UNSPECIFIED: Returns records in no specific order.  - ORDER_BY_ASC: Returns records in ascending order.  - ORDER_BY_DESC: Returns records in descending order.
-     * @param {string} [searchText] 
+     * @param {string} [searchText] Search the logs by whether the text contains a substring.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof TasksApi
@@ -20518,7 +20518,7 @@ export const TrialsApiFetchParamCreator = function (configuration?: Configuratio
          * @param {Date} [timestampBefore] Limit the trial logs to ones with a timestamp before a given time.
          * @param {Date} [timestampAfter] Limit the trial logs to ones with a timestamp after a given time.
          * @param {'ORDER_BY_UNSPECIFIED' | 'ORDER_BY_ASC' | 'ORDER_BY_DESC'} [orderBy] Order logs in either ascending or descending order by timestamp.   - ORDER_BY_UNSPECIFIED: Returns records in no specific order.  - ORDER_BY_ASC: Returns records in ascending order.  - ORDER_BY_DESC: Returns records in descending order.
-         * @param {string} [searchText] 
+         * @param {string} [searchText] Search the logs by whether the text contains a substring.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
@@ -20800,7 +20800,7 @@ export const TrialsApiFp = function(configuration?: Configuration) {
          * @param {Date} [timestampBefore] Limit the trial logs to ones with a timestamp before a given time.
          * @param {Date} [timestampAfter] Limit the trial logs to ones with a timestamp after a given time.
          * @param {'ORDER_BY_UNSPECIFIED' | 'ORDER_BY_ASC' | 'ORDER_BY_DESC'} [orderBy] Order logs in either ascending or descending order by timestamp.   - ORDER_BY_UNSPECIFIED: Returns records in no specific order.  - ORDER_BY_ASC: Returns records in ascending order.  - ORDER_BY_DESC: Returns records in descending order.
-         * @param {string} [searchText] 
+         * @param {string} [searchText] Search the logs by whether the text contains a substring.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
@@ -20940,7 +20940,7 @@ export const TrialsApiFactory = function (configuration?: Configuration, fetch?:
          * @param {Date} [timestampBefore] Limit the trial logs to ones with a timestamp before a given time.
          * @param {Date} [timestampAfter] Limit the trial logs to ones with a timestamp after a given time.
          * @param {'ORDER_BY_UNSPECIFIED' | 'ORDER_BY_ASC' | 'ORDER_BY_DESC'} [orderBy] Order logs in either ascending or descending order by timestamp.   - ORDER_BY_UNSPECIFIED: Returns records in no specific order.  - ORDER_BY_ASC: Returns records in ascending order.  - ORDER_BY_DESC: Returns records in descending order.
-         * @param {string} [searchText] 
+         * @param {string} [searchText] Search the logs by whether the text contains a substring.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
@@ -21075,7 +21075,7 @@ export class TrialsApi extends BaseAPI {
      * @param {Date} [timestampBefore] Limit the trial logs to ones with a timestamp before a given time.
      * @param {Date} [timestampAfter] Limit the trial logs to ones with a timestamp after a given time.
      * @param {'ORDER_BY_UNSPECIFIED' | 'ORDER_BY_ASC' | 'ORDER_BY_DESC'} [orderBy] Order logs in either ascending or descending order by timestamp.   - ORDER_BY_UNSPECIFIED: Returns records in no specific order.  - ORDER_BY_ASC: Returns records in ascending order.  - ORDER_BY_DESC: Returns records in descending order.
-     * @param {string} [searchText] 
+     * @param {string} [searchText] Search the logs by whether the text contains a substring.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof TrialsApi

--- a/webui/react/src/services/api-ts-sdk/api.ts
+++ b/webui/react/src/services/api-ts-sdk/api.ts
@@ -10617,10 +10617,11 @@ export const ExperimentsApiFetchParamCreator = function (configuration?: Configu
          * @param {Date} [timestampBefore] Limit the trial logs to ones with a timestamp before a given time.
          * @param {Date} [timestampAfter] Limit the trial logs to ones with a timestamp after a given time.
          * @param {'ORDER_BY_UNSPECIFIED' | 'ORDER_BY_ASC' | 'ORDER_BY_DESC'} [orderBy] Order logs in either ascending or descending order by timestamp.   - ORDER_BY_UNSPECIFIED: Returns records in no specific order.  - ORDER_BY_ASC: Returns records in ascending order.  - ORDER_BY_DESC: Returns records in descending order.
+         * @param {string} [searchText] 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        trialLogs(trialId: number, limit?: number, follow?: boolean, agentIds?: Array<string>, containerIds?: Array<string>, rankIds?: Array<number>, levels?: Array<'LOG_LEVEL_UNSPECIFIED' | 'LOG_LEVEL_TRACE' | 'LOG_LEVEL_DEBUG' | 'LOG_LEVEL_INFO' | 'LOG_LEVEL_WARNING' | 'LOG_LEVEL_ERROR' | 'LOG_LEVEL_CRITICAL'>, stdtypes?: Array<string>, sources?: Array<string>, timestampBefore?: Date, timestampAfter?: Date, orderBy?: 'ORDER_BY_UNSPECIFIED' | 'ORDER_BY_ASC' | 'ORDER_BY_DESC', options: any = {}): FetchArgs {
+        trialLogs(trialId: number, limit?: number, follow?: boolean, agentIds?: Array<string>, containerIds?: Array<string>, rankIds?: Array<number>, levels?: Array<'LOG_LEVEL_UNSPECIFIED' | 'LOG_LEVEL_TRACE' | 'LOG_LEVEL_DEBUG' | 'LOG_LEVEL_INFO' | 'LOG_LEVEL_WARNING' | 'LOG_LEVEL_ERROR' | 'LOG_LEVEL_CRITICAL'>, stdtypes?: Array<string>, sources?: Array<string>, timestampBefore?: Date, timestampAfter?: Date, orderBy?: 'ORDER_BY_UNSPECIFIED' | 'ORDER_BY_ASC' | 'ORDER_BY_DESC', searchText?: string, options: any = {}): FetchArgs {
             // verify required parameter 'trialId' is not null or undefined
             if (trialId === null || trialId === undefined) {
                 throw new RequiredError('trialId','Required parameter trialId was null or undefined when calling trialLogs.');
@@ -10682,6 +10683,10 @@ export const ExperimentsApiFetchParamCreator = function (configuration?: Configu
 
             if (orderBy !== undefined) {
                 localVarQueryParameter['orderBy'] = orderBy;
+            }
+
+            if (searchText !== undefined) {
+                localVarQueryParameter['searchText'] = searchText;
             }
 
             localVarUrlObj.query = Object.assign({}, localVarUrlObj.query, localVarQueryParameter, options.query);
@@ -11294,11 +11299,12 @@ export const ExperimentsApiFp = function(configuration?: Configuration) {
          * @param {Date} [timestampBefore] Limit the trial logs to ones with a timestamp before a given time.
          * @param {Date} [timestampAfter] Limit the trial logs to ones with a timestamp after a given time.
          * @param {'ORDER_BY_UNSPECIFIED' | 'ORDER_BY_ASC' | 'ORDER_BY_DESC'} [orderBy] Order logs in either ascending or descending order by timestamp.   - ORDER_BY_UNSPECIFIED: Returns records in no specific order.  - ORDER_BY_ASC: Returns records in ascending order.  - ORDER_BY_DESC: Returns records in descending order.
+         * @param {string} [searchText] 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        trialLogs(trialId: number, limit?: number, follow?: boolean, agentIds?: Array<string>, containerIds?: Array<string>, rankIds?: Array<number>, levels?: Array<'LOG_LEVEL_UNSPECIFIED' | 'LOG_LEVEL_TRACE' | 'LOG_LEVEL_DEBUG' | 'LOG_LEVEL_INFO' | 'LOG_LEVEL_WARNING' | 'LOG_LEVEL_ERROR' | 'LOG_LEVEL_CRITICAL'>, stdtypes?: Array<string>, sources?: Array<string>, timestampBefore?: Date, timestampAfter?: Date, orderBy?: 'ORDER_BY_UNSPECIFIED' | 'ORDER_BY_ASC' | 'ORDER_BY_DESC', options?: any): (fetch?: FetchAPI, basePath?: string) => Promise<StreamResultOfV1TrialLogsResponse> {
-            const localVarFetchArgs = ExperimentsApiFetchParamCreator(configuration).trialLogs(trialId, limit, follow, agentIds, containerIds, rankIds, levels, stdtypes, sources, timestampBefore, timestampAfter, orderBy, options);
+        trialLogs(trialId: number, limit?: number, follow?: boolean, agentIds?: Array<string>, containerIds?: Array<string>, rankIds?: Array<number>, levels?: Array<'LOG_LEVEL_UNSPECIFIED' | 'LOG_LEVEL_TRACE' | 'LOG_LEVEL_DEBUG' | 'LOG_LEVEL_INFO' | 'LOG_LEVEL_WARNING' | 'LOG_LEVEL_ERROR' | 'LOG_LEVEL_CRITICAL'>, stdtypes?: Array<string>, sources?: Array<string>, timestampBefore?: Date, timestampAfter?: Date, orderBy?: 'ORDER_BY_UNSPECIFIED' | 'ORDER_BY_ASC' | 'ORDER_BY_DESC', searchText?: string, options?: any): (fetch?: FetchAPI, basePath?: string) => Promise<StreamResultOfV1TrialLogsResponse> {
+            const localVarFetchArgs = ExperimentsApiFetchParamCreator(configuration).trialLogs(trialId, limit, follow, agentIds, containerIds, rankIds, levels, stdtypes, sources, timestampBefore, timestampAfter, orderBy, searchText, options);
             return (fetch: FetchAPI = portableFetch, basePath: string = BASE_PATH) => {
                 return fetch(basePath + localVarFetchArgs.url, localVarFetchArgs.options).then((response) => {
                     if (response.status >= 200 && response.status < 300) {
@@ -11653,11 +11659,12 @@ export const ExperimentsApiFactory = function (configuration?: Configuration, fe
          * @param {Date} [timestampBefore] Limit the trial logs to ones with a timestamp before a given time.
          * @param {Date} [timestampAfter] Limit the trial logs to ones with a timestamp after a given time.
          * @param {'ORDER_BY_UNSPECIFIED' | 'ORDER_BY_ASC' | 'ORDER_BY_DESC'} [orderBy] Order logs in either ascending or descending order by timestamp.   - ORDER_BY_UNSPECIFIED: Returns records in no specific order.  - ORDER_BY_ASC: Returns records in ascending order.  - ORDER_BY_DESC: Returns records in descending order.
+         * @param {string} [searchText] 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        trialLogs(trialId: number, limit?: number, follow?: boolean, agentIds?: Array<string>, containerIds?: Array<string>, rankIds?: Array<number>, levels?: Array<'LOG_LEVEL_UNSPECIFIED' | 'LOG_LEVEL_TRACE' | 'LOG_LEVEL_DEBUG' | 'LOG_LEVEL_INFO' | 'LOG_LEVEL_WARNING' | 'LOG_LEVEL_ERROR' | 'LOG_LEVEL_CRITICAL'>, stdtypes?: Array<string>, sources?: Array<string>, timestampBefore?: Date, timestampAfter?: Date, orderBy?: 'ORDER_BY_UNSPECIFIED' | 'ORDER_BY_ASC' | 'ORDER_BY_DESC', options?: any) {
-            return ExperimentsApiFp(configuration).trialLogs(trialId, limit, follow, agentIds, containerIds, rankIds, levels, stdtypes, sources, timestampBefore, timestampAfter, orderBy, options)(fetch, basePath);
+        trialLogs(trialId: number, limit?: number, follow?: boolean, agentIds?: Array<string>, containerIds?: Array<string>, rankIds?: Array<number>, levels?: Array<'LOG_LEVEL_UNSPECIFIED' | 'LOG_LEVEL_TRACE' | 'LOG_LEVEL_DEBUG' | 'LOG_LEVEL_INFO' | 'LOG_LEVEL_WARNING' | 'LOG_LEVEL_ERROR' | 'LOG_LEVEL_CRITICAL'>, stdtypes?: Array<string>, sources?: Array<string>, timestampBefore?: Date, timestampAfter?: Date, orderBy?: 'ORDER_BY_UNSPECIFIED' | 'ORDER_BY_ASC' | 'ORDER_BY_DESC', searchText?: string, options?: any) {
+            return ExperimentsApiFp(configuration).trialLogs(trialId, limit, follow, agentIds, containerIds, rankIds, levels, stdtypes, sources, timestampBefore, timestampAfter, orderBy, searchText, options)(fetch, basePath);
         },
         /**
          * 
@@ -12034,12 +12041,13 @@ export class ExperimentsApi extends BaseAPI {
      * @param {Date} [timestampBefore] Limit the trial logs to ones with a timestamp before a given time.
      * @param {Date} [timestampAfter] Limit the trial logs to ones with a timestamp after a given time.
      * @param {'ORDER_BY_UNSPECIFIED' | 'ORDER_BY_ASC' | 'ORDER_BY_DESC'} [orderBy] Order logs in either ascending or descending order by timestamp.   - ORDER_BY_UNSPECIFIED: Returns records in no specific order.  - ORDER_BY_ASC: Returns records in ascending order.  - ORDER_BY_DESC: Returns records in descending order.
+     * @param {string} [searchText] 
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof ExperimentsApi
      */
-    public trialLogs(trialId: number, limit?: number, follow?: boolean, agentIds?: Array<string>, containerIds?: Array<string>, rankIds?: Array<number>, levels?: Array<'LOG_LEVEL_UNSPECIFIED' | 'LOG_LEVEL_TRACE' | 'LOG_LEVEL_DEBUG' | 'LOG_LEVEL_INFO' | 'LOG_LEVEL_WARNING' | 'LOG_LEVEL_ERROR' | 'LOG_LEVEL_CRITICAL'>, stdtypes?: Array<string>, sources?: Array<string>, timestampBefore?: Date, timestampAfter?: Date, orderBy?: 'ORDER_BY_UNSPECIFIED' | 'ORDER_BY_ASC' | 'ORDER_BY_DESC', options?: any) {
-        return ExperimentsApiFp(this.configuration).trialLogs(trialId, limit, follow, agentIds, containerIds, rankIds, levels, stdtypes, sources, timestampBefore, timestampAfter, orderBy, options)(this.fetch, this.basePath);
+    public trialLogs(trialId: number, limit?: number, follow?: boolean, agentIds?: Array<string>, containerIds?: Array<string>, rankIds?: Array<number>, levels?: Array<'LOG_LEVEL_UNSPECIFIED' | 'LOG_LEVEL_TRACE' | 'LOG_LEVEL_DEBUG' | 'LOG_LEVEL_INFO' | 'LOG_LEVEL_WARNING' | 'LOG_LEVEL_ERROR' | 'LOG_LEVEL_CRITICAL'>, stdtypes?: Array<string>, sources?: Array<string>, timestampBefore?: Date, timestampAfter?: Date, orderBy?: 'ORDER_BY_UNSPECIFIED' | 'ORDER_BY_ASC' | 'ORDER_BY_DESC', searchText?: string, options?: any) {
+        return ExperimentsApiFp(this.configuration).trialLogs(trialId, limit, follow, agentIds, containerIds, rankIds, levels, stdtypes, sources, timestampBefore, timestampAfter, orderBy, searchText, options)(this.fetch, this.basePath);
     }
 
     /**
@@ -15251,10 +15259,11 @@ export const JobsApiFetchParamCreator = function (configuration?: Configuration)
          * @param {Date} [timestampBefore] Limit the trial logs to ones with a timestamp before a given time.
          * @param {Date} [timestampAfter] Limit the trial logs to ones with a timestamp after a given time.
          * @param {'ORDER_BY_UNSPECIFIED' | 'ORDER_BY_ASC' | 'ORDER_BY_DESC'} [orderBy] Order logs in either ascending or descending order by timestamp.   - ORDER_BY_UNSPECIFIED: Returns records in no specific order.  - ORDER_BY_ASC: Returns records in ascending order.  - ORDER_BY_DESC: Returns records in descending order.
+         * @param {string} [searchText] 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        taskLogs(taskId: string, limit?: number, follow?: boolean, allocationIds?: Array<string>, agentIds?: Array<string>, containerIds?: Array<string>, rankIds?: Array<number>, levels?: Array<'LOG_LEVEL_UNSPECIFIED' | 'LOG_LEVEL_TRACE' | 'LOG_LEVEL_DEBUG' | 'LOG_LEVEL_INFO' | 'LOG_LEVEL_WARNING' | 'LOG_LEVEL_ERROR' | 'LOG_LEVEL_CRITICAL'>, stdtypes?: Array<string>, sources?: Array<string>, timestampBefore?: Date, timestampAfter?: Date, orderBy?: 'ORDER_BY_UNSPECIFIED' | 'ORDER_BY_ASC' | 'ORDER_BY_DESC', options: any = {}): FetchArgs {
+        taskLogs(taskId: string, limit?: number, follow?: boolean, allocationIds?: Array<string>, agentIds?: Array<string>, containerIds?: Array<string>, rankIds?: Array<number>, levels?: Array<'LOG_LEVEL_UNSPECIFIED' | 'LOG_LEVEL_TRACE' | 'LOG_LEVEL_DEBUG' | 'LOG_LEVEL_INFO' | 'LOG_LEVEL_WARNING' | 'LOG_LEVEL_ERROR' | 'LOG_LEVEL_CRITICAL'>, stdtypes?: Array<string>, sources?: Array<string>, timestampBefore?: Date, timestampAfter?: Date, orderBy?: 'ORDER_BY_UNSPECIFIED' | 'ORDER_BY_ASC' | 'ORDER_BY_DESC', searchText?: string, options: any = {}): FetchArgs {
             // verify required parameter 'taskId' is not null or undefined
             if (taskId === null || taskId === undefined) {
                 throw new RequiredError('taskId','Required parameter taskId was null or undefined when calling taskLogs.');
@@ -15320,6 +15329,10 @@ export const JobsApiFetchParamCreator = function (configuration?: Configuration)
 
             if (orderBy !== undefined) {
                 localVarQueryParameter['orderBy'] = orderBy;
+            }
+
+            if (searchText !== undefined) {
+                localVarQueryParameter['searchText'] = searchText;
             }
 
             localVarUrlObj.query = Object.assign({}, localVarUrlObj.query, localVarQueryParameter, options.query);
@@ -15399,11 +15412,12 @@ export const JobsApiFp = function(configuration?: Configuration) {
          * @param {Date} [timestampBefore] Limit the trial logs to ones with a timestamp before a given time.
          * @param {Date} [timestampAfter] Limit the trial logs to ones with a timestamp after a given time.
          * @param {'ORDER_BY_UNSPECIFIED' | 'ORDER_BY_ASC' | 'ORDER_BY_DESC'} [orderBy] Order logs in either ascending or descending order by timestamp.   - ORDER_BY_UNSPECIFIED: Returns records in no specific order.  - ORDER_BY_ASC: Returns records in ascending order.  - ORDER_BY_DESC: Returns records in descending order.
+         * @param {string} [searchText] 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        taskLogs(taskId: string, limit?: number, follow?: boolean, allocationIds?: Array<string>, agentIds?: Array<string>, containerIds?: Array<string>, rankIds?: Array<number>, levels?: Array<'LOG_LEVEL_UNSPECIFIED' | 'LOG_LEVEL_TRACE' | 'LOG_LEVEL_DEBUG' | 'LOG_LEVEL_INFO' | 'LOG_LEVEL_WARNING' | 'LOG_LEVEL_ERROR' | 'LOG_LEVEL_CRITICAL'>, stdtypes?: Array<string>, sources?: Array<string>, timestampBefore?: Date, timestampAfter?: Date, orderBy?: 'ORDER_BY_UNSPECIFIED' | 'ORDER_BY_ASC' | 'ORDER_BY_DESC', options?: any): (fetch?: FetchAPI, basePath?: string) => Promise<StreamResultOfV1TaskLogsResponse> {
-            const localVarFetchArgs = JobsApiFetchParamCreator(configuration).taskLogs(taskId, limit, follow, allocationIds, agentIds, containerIds, rankIds, levels, stdtypes, sources, timestampBefore, timestampAfter, orderBy, options);
+        taskLogs(taskId: string, limit?: number, follow?: boolean, allocationIds?: Array<string>, agentIds?: Array<string>, containerIds?: Array<string>, rankIds?: Array<number>, levels?: Array<'LOG_LEVEL_UNSPECIFIED' | 'LOG_LEVEL_TRACE' | 'LOG_LEVEL_DEBUG' | 'LOG_LEVEL_INFO' | 'LOG_LEVEL_WARNING' | 'LOG_LEVEL_ERROR' | 'LOG_LEVEL_CRITICAL'>, stdtypes?: Array<string>, sources?: Array<string>, timestampBefore?: Date, timestampAfter?: Date, orderBy?: 'ORDER_BY_UNSPECIFIED' | 'ORDER_BY_ASC' | 'ORDER_BY_DESC', searchText?: string, options?: any): (fetch?: FetchAPI, basePath?: string) => Promise<StreamResultOfV1TaskLogsResponse> {
+            const localVarFetchArgs = JobsApiFetchParamCreator(configuration).taskLogs(taskId, limit, follow, allocationIds, agentIds, containerIds, rankIds, levels, stdtypes, sources, timestampBefore, timestampAfter, orderBy, searchText, options);
             return (fetch: FetchAPI = portableFetch, basePath: string = BASE_PATH) => {
                 return fetch(basePath + localVarFetchArgs.url, localVarFetchArgs.options).then((response) => {
                     if (response.status >= 200 && response.status < 300) {
@@ -15459,11 +15473,12 @@ export const JobsApiFactory = function (configuration?: Configuration, fetch?: F
          * @param {Date} [timestampBefore] Limit the trial logs to ones with a timestamp before a given time.
          * @param {Date} [timestampAfter] Limit the trial logs to ones with a timestamp after a given time.
          * @param {'ORDER_BY_UNSPECIFIED' | 'ORDER_BY_ASC' | 'ORDER_BY_DESC'} [orderBy] Order logs in either ascending or descending order by timestamp.   - ORDER_BY_UNSPECIFIED: Returns records in no specific order.  - ORDER_BY_ASC: Returns records in ascending order.  - ORDER_BY_DESC: Returns records in descending order.
+         * @param {string} [searchText] 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        taskLogs(taskId: string, limit?: number, follow?: boolean, allocationIds?: Array<string>, agentIds?: Array<string>, containerIds?: Array<string>, rankIds?: Array<number>, levels?: Array<'LOG_LEVEL_UNSPECIFIED' | 'LOG_LEVEL_TRACE' | 'LOG_LEVEL_DEBUG' | 'LOG_LEVEL_INFO' | 'LOG_LEVEL_WARNING' | 'LOG_LEVEL_ERROR' | 'LOG_LEVEL_CRITICAL'>, stdtypes?: Array<string>, sources?: Array<string>, timestampBefore?: Date, timestampAfter?: Date, orderBy?: 'ORDER_BY_UNSPECIFIED' | 'ORDER_BY_ASC' | 'ORDER_BY_DESC', options?: any) {
-            return JobsApiFp(configuration).taskLogs(taskId, limit, follow, allocationIds, agentIds, containerIds, rankIds, levels, stdtypes, sources, timestampBefore, timestampAfter, orderBy, options)(fetch, basePath);
+        taskLogs(taskId: string, limit?: number, follow?: boolean, allocationIds?: Array<string>, agentIds?: Array<string>, containerIds?: Array<string>, rankIds?: Array<number>, levels?: Array<'LOG_LEVEL_UNSPECIFIED' | 'LOG_LEVEL_TRACE' | 'LOG_LEVEL_DEBUG' | 'LOG_LEVEL_INFO' | 'LOG_LEVEL_WARNING' | 'LOG_LEVEL_ERROR' | 'LOG_LEVEL_CRITICAL'>, stdtypes?: Array<string>, sources?: Array<string>, timestampBefore?: Date, timestampAfter?: Date, orderBy?: 'ORDER_BY_UNSPECIFIED' | 'ORDER_BY_ASC' | 'ORDER_BY_DESC', searchText?: string, options?: any) {
+            return JobsApiFp(configuration).taskLogs(taskId, limit, follow, allocationIds, agentIds, containerIds, rankIds, levels, stdtypes, sources, timestampBefore, timestampAfter, orderBy, searchText, options)(fetch, basePath);
         },
         /**
          * 
@@ -15502,12 +15517,13 @@ export class JobsApi extends BaseAPI {
      * @param {Date} [timestampBefore] Limit the trial logs to ones with a timestamp before a given time.
      * @param {Date} [timestampAfter] Limit the trial logs to ones with a timestamp after a given time.
      * @param {'ORDER_BY_UNSPECIFIED' | 'ORDER_BY_ASC' | 'ORDER_BY_DESC'} [orderBy] Order logs in either ascending or descending order by timestamp.   - ORDER_BY_UNSPECIFIED: Returns records in no specific order.  - ORDER_BY_ASC: Returns records in ascending order.  - ORDER_BY_DESC: Returns records in descending order.
+     * @param {string} [searchText] 
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof JobsApi
      */
-    public taskLogs(taskId: string, limit?: number, follow?: boolean, allocationIds?: Array<string>, agentIds?: Array<string>, containerIds?: Array<string>, rankIds?: Array<number>, levels?: Array<'LOG_LEVEL_UNSPECIFIED' | 'LOG_LEVEL_TRACE' | 'LOG_LEVEL_DEBUG' | 'LOG_LEVEL_INFO' | 'LOG_LEVEL_WARNING' | 'LOG_LEVEL_ERROR' | 'LOG_LEVEL_CRITICAL'>, stdtypes?: Array<string>, sources?: Array<string>, timestampBefore?: Date, timestampAfter?: Date, orderBy?: 'ORDER_BY_UNSPECIFIED' | 'ORDER_BY_ASC' | 'ORDER_BY_DESC', options?: any) {
-        return JobsApiFp(this.configuration).taskLogs(taskId, limit, follow, allocationIds, agentIds, containerIds, rankIds, levels, stdtypes, sources, timestampBefore, timestampAfter, orderBy, options)(this.fetch, this.basePath);
+    public taskLogs(taskId: string, limit?: number, follow?: boolean, allocationIds?: Array<string>, agentIds?: Array<string>, containerIds?: Array<string>, rankIds?: Array<number>, levels?: Array<'LOG_LEVEL_UNSPECIFIED' | 'LOG_LEVEL_TRACE' | 'LOG_LEVEL_DEBUG' | 'LOG_LEVEL_INFO' | 'LOG_LEVEL_WARNING' | 'LOG_LEVEL_ERROR' | 'LOG_LEVEL_CRITICAL'>, stdtypes?: Array<string>, sources?: Array<string>, timestampBefore?: Date, timestampAfter?: Date, orderBy?: 'ORDER_BY_UNSPECIFIED' | 'ORDER_BY_ASC' | 'ORDER_BY_DESC', searchText?: string, options?: any) {
+        return JobsApiFp(this.configuration).taskLogs(taskId, limit, follow, allocationIds, agentIds, containerIds, rankIds, levels, stdtypes, sources, timestampBefore, timestampAfter, orderBy, searchText, options)(this.fetch, this.basePath);
     }
 
     /**
@@ -18966,10 +18982,11 @@ export const TasksApiFetchParamCreator = function (configuration?: Configuration
          * @param {Date} [timestampBefore] Limit the trial logs to ones with a timestamp before a given time.
          * @param {Date} [timestampAfter] Limit the trial logs to ones with a timestamp after a given time.
          * @param {'ORDER_BY_UNSPECIFIED' | 'ORDER_BY_ASC' | 'ORDER_BY_DESC'} [orderBy] Order logs in either ascending or descending order by timestamp.   - ORDER_BY_UNSPECIFIED: Returns records in no specific order.  - ORDER_BY_ASC: Returns records in ascending order.  - ORDER_BY_DESC: Returns records in descending order.
+         * @param {string} [searchText] 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        taskLogs(taskId: string, limit?: number, follow?: boolean, allocationIds?: Array<string>, agentIds?: Array<string>, containerIds?: Array<string>, rankIds?: Array<number>, levels?: Array<'LOG_LEVEL_UNSPECIFIED' | 'LOG_LEVEL_TRACE' | 'LOG_LEVEL_DEBUG' | 'LOG_LEVEL_INFO' | 'LOG_LEVEL_WARNING' | 'LOG_LEVEL_ERROR' | 'LOG_LEVEL_CRITICAL'>, stdtypes?: Array<string>, sources?: Array<string>, timestampBefore?: Date, timestampAfter?: Date, orderBy?: 'ORDER_BY_UNSPECIFIED' | 'ORDER_BY_ASC' | 'ORDER_BY_DESC', options: any = {}): FetchArgs {
+        taskLogs(taskId: string, limit?: number, follow?: boolean, allocationIds?: Array<string>, agentIds?: Array<string>, containerIds?: Array<string>, rankIds?: Array<number>, levels?: Array<'LOG_LEVEL_UNSPECIFIED' | 'LOG_LEVEL_TRACE' | 'LOG_LEVEL_DEBUG' | 'LOG_LEVEL_INFO' | 'LOG_LEVEL_WARNING' | 'LOG_LEVEL_ERROR' | 'LOG_LEVEL_CRITICAL'>, stdtypes?: Array<string>, sources?: Array<string>, timestampBefore?: Date, timestampAfter?: Date, orderBy?: 'ORDER_BY_UNSPECIFIED' | 'ORDER_BY_ASC' | 'ORDER_BY_DESC', searchText?: string, options: any = {}): FetchArgs {
             // verify required parameter 'taskId' is not null or undefined
             if (taskId === null || taskId === undefined) {
                 throw new RequiredError('taskId','Required parameter taskId was null or undefined when calling taskLogs.');
@@ -19035,6 +19052,10 @@ export const TasksApiFetchParamCreator = function (configuration?: Configuration
 
             if (orderBy !== undefined) {
                 localVarQueryParameter['orderBy'] = orderBy;
+            }
+
+            if (searchText !== undefined) {
+                localVarQueryParameter['searchText'] = searchText;
             }
 
             localVarUrlObj.query = Object.assign({}, localVarUrlObj.query, localVarQueryParameter, options.query);
@@ -19133,11 +19154,12 @@ export const TasksApiFp = function(configuration?: Configuration) {
          * @param {Date} [timestampBefore] Limit the trial logs to ones with a timestamp before a given time.
          * @param {Date} [timestampAfter] Limit the trial logs to ones with a timestamp after a given time.
          * @param {'ORDER_BY_UNSPECIFIED' | 'ORDER_BY_ASC' | 'ORDER_BY_DESC'} [orderBy] Order logs in either ascending or descending order by timestamp.   - ORDER_BY_UNSPECIFIED: Returns records in no specific order.  - ORDER_BY_ASC: Returns records in ascending order.  - ORDER_BY_DESC: Returns records in descending order.
+         * @param {string} [searchText] 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        taskLogs(taskId: string, limit?: number, follow?: boolean, allocationIds?: Array<string>, agentIds?: Array<string>, containerIds?: Array<string>, rankIds?: Array<number>, levels?: Array<'LOG_LEVEL_UNSPECIFIED' | 'LOG_LEVEL_TRACE' | 'LOG_LEVEL_DEBUG' | 'LOG_LEVEL_INFO' | 'LOG_LEVEL_WARNING' | 'LOG_LEVEL_ERROR' | 'LOG_LEVEL_CRITICAL'>, stdtypes?: Array<string>, sources?: Array<string>, timestampBefore?: Date, timestampAfter?: Date, orderBy?: 'ORDER_BY_UNSPECIFIED' | 'ORDER_BY_ASC' | 'ORDER_BY_DESC', options?: any): (fetch?: FetchAPI, basePath?: string) => Promise<StreamResultOfV1TaskLogsResponse> {
-            const localVarFetchArgs = TasksApiFetchParamCreator(configuration).taskLogs(taskId, limit, follow, allocationIds, agentIds, containerIds, rankIds, levels, stdtypes, sources, timestampBefore, timestampAfter, orderBy, options);
+        taskLogs(taskId: string, limit?: number, follow?: boolean, allocationIds?: Array<string>, agentIds?: Array<string>, containerIds?: Array<string>, rankIds?: Array<number>, levels?: Array<'LOG_LEVEL_UNSPECIFIED' | 'LOG_LEVEL_TRACE' | 'LOG_LEVEL_DEBUG' | 'LOG_LEVEL_INFO' | 'LOG_LEVEL_WARNING' | 'LOG_LEVEL_ERROR' | 'LOG_LEVEL_CRITICAL'>, stdtypes?: Array<string>, sources?: Array<string>, timestampBefore?: Date, timestampAfter?: Date, orderBy?: 'ORDER_BY_UNSPECIFIED' | 'ORDER_BY_ASC' | 'ORDER_BY_DESC', searchText?: string, options?: any): (fetch?: FetchAPI, basePath?: string) => Promise<StreamResultOfV1TaskLogsResponse> {
+            const localVarFetchArgs = TasksApiFetchParamCreator(configuration).taskLogs(taskId, limit, follow, allocationIds, agentIds, containerIds, rankIds, levels, stdtypes, sources, timestampBefore, timestampAfter, orderBy, searchText, options);
             return (fetch: FetchAPI = portableFetch, basePath: string = BASE_PATH) => {
                 return fetch(basePath + localVarFetchArgs.url, localVarFetchArgs.options).then((response) => {
                     if (response.status >= 200 && response.status < 300) {
@@ -19203,11 +19225,12 @@ export const TasksApiFactory = function (configuration?: Configuration, fetch?: 
          * @param {Date} [timestampBefore] Limit the trial logs to ones with a timestamp before a given time.
          * @param {Date} [timestampAfter] Limit the trial logs to ones with a timestamp after a given time.
          * @param {'ORDER_BY_UNSPECIFIED' | 'ORDER_BY_ASC' | 'ORDER_BY_DESC'} [orderBy] Order logs in either ascending or descending order by timestamp.   - ORDER_BY_UNSPECIFIED: Returns records in no specific order.  - ORDER_BY_ASC: Returns records in ascending order.  - ORDER_BY_DESC: Returns records in descending order.
+         * @param {string} [searchText] 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        taskLogs(taskId: string, limit?: number, follow?: boolean, allocationIds?: Array<string>, agentIds?: Array<string>, containerIds?: Array<string>, rankIds?: Array<number>, levels?: Array<'LOG_LEVEL_UNSPECIFIED' | 'LOG_LEVEL_TRACE' | 'LOG_LEVEL_DEBUG' | 'LOG_LEVEL_INFO' | 'LOG_LEVEL_WARNING' | 'LOG_LEVEL_ERROR' | 'LOG_LEVEL_CRITICAL'>, stdtypes?: Array<string>, sources?: Array<string>, timestampBefore?: Date, timestampAfter?: Date, orderBy?: 'ORDER_BY_UNSPECIFIED' | 'ORDER_BY_ASC' | 'ORDER_BY_DESC', options?: any) {
-            return TasksApiFp(configuration).taskLogs(taskId, limit, follow, allocationIds, agentIds, containerIds, rankIds, levels, stdtypes, sources, timestampBefore, timestampAfter, orderBy, options)(fetch, basePath);
+        taskLogs(taskId: string, limit?: number, follow?: boolean, allocationIds?: Array<string>, agentIds?: Array<string>, containerIds?: Array<string>, rankIds?: Array<number>, levels?: Array<'LOG_LEVEL_UNSPECIFIED' | 'LOG_LEVEL_TRACE' | 'LOG_LEVEL_DEBUG' | 'LOG_LEVEL_INFO' | 'LOG_LEVEL_WARNING' | 'LOG_LEVEL_ERROR' | 'LOG_LEVEL_CRITICAL'>, stdtypes?: Array<string>, sources?: Array<string>, timestampBefore?: Date, timestampAfter?: Date, orderBy?: 'ORDER_BY_UNSPECIFIED' | 'ORDER_BY_ASC' | 'ORDER_BY_DESC', searchText?: string, options?: any) {
+            return TasksApiFp(configuration).taskLogs(taskId, limit, follow, allocationIds, agentIds, containerIds, rankIds, levels, stdtypes, sources, timestampBefore, timestampAfter, orderBy, searchText, options)(fetch, basePath);
         },
         /**
          * 
@@ -19258,12 +19281,13 @@ export class TasksApi extends BaseAPI {
      * @param {Date} [timestampBefore] Limit the trial logs to ones with a timestamp before a given time.
      * @param {Date} [timestampAfter] Limit the trial logs to ones with a timestamp after a given time.
      * @param {'ORDER_BY_UNSPECIFIED' | 'ORDER_BY_ASC' | 'ORDER_BY_DESC'} [orderBy] Order logs in either ascending or descending order by timestamp.   - ORDER_BY_UNSPECIFIED: Returns records in no specific order.  - ORDER_BY_ASC: Returns records in ascending order.  - ORDER_BY_DESC: Returns records in descending order.
+     * @param {string} [searchText] 
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof TasksApi
      */
-    public taskLogs(taskId: string, limit?: number, follow?: boolean, allocationIds?: Array<string>, agentIds?: Array<string>, containerIds?: Array<string>, rankIds?: Array<number>, levels?: Array<'LOG_LEVEL_UNSPECIFIED' | 'LOG_LEVEL_TRACE' | 'LOG_LEVEL_DEBUG' | 'LOG_LEVEL_INFO' | 'LOG_LEVEL_WARNING' | 'LOG_LEVEL_ERROR' | 'LOG_LEVEL_CRITICAL'>, stdtypes?: Array<string>, sources?: Array<string>, timestampBefore?: Date, timestampAfter?: Date, orderBy?: 'ORDER_BY_UNSPECIFIED' | 'ORDER_BY_ASC' | 'ORDER_BY_DESC', options?: any) {
-        return TasksApiFp(this.configuration).taskLogs(taskId, limit, follow, allocationIds, agentIds, containerIds, rankIds, levels, stdtypes, sources, timestampBefore, timestampAfter, orderBy, options)(this.fetch, this.basePath);
+    public taskLogs(taskId: string, limit?: number, follow?: boolean, allocationIds?: Array<string>, agentIds?: Array<string>, containerIds?: Array<string>, rankIds?: Array<number>, levels?: Array<'LOG_LEVEL_UNSPECIFIED' | 'LOG_LEVEL_TRACE' | 'LOG_LEVEL_DEBUG' | 'LOG_LEVEL_INFO' | 'LOG_LEVEL_WARNING' | 'LOG_LEVEL_ERROR' | 'LOG_LEVEL_CRITICAL'>, stdtypes?: Array<string>, sources?: Array<string>, timestampBefore?: Date, timestampAfter?: Date, orderBy?: 'ORDER_BY_UNSPECIFIED' | 'ORDER_BY_ASC' | 'ORDER_BY_DESC', searchText?: string, options?: any) {
+        return TasksApiFp(this.configuration).taskLogs(taskId, limit, follow, allocationIds, agentIds, containerIds, rankIds, levels, stdtypes, sources, timestampBefore, timestampAfter, orderBy, searchText, options)(this.fetch, this.basePath);
     }
 
     /**
@@ -20494,10 +20518,11 @@ export const TrialsApiFetchParamCreator = function (configuration?: Configuratio
          * @param {Date} [timestampBefore] Limit the trial logs to ones with a timestamp before a given time.
          * @param {Date} [timestampAfter] Limit the trial logs to ones with a timestamp after a given time.
          * @param {'ORDER_BY_UNSPECIFIED' | 'ORDER_BY_ASC' | 'ORDER_BY_DESC'} [orderBy] Order logs in either ascending or descending order by timestamp.   - ORDER_BY_UNSPECIFIED: Returns records in no specific order.  - ORDER_BY_ASC: Returns records in ascending order.  - ORDER_BY_DESC: Returns records in descending order.
+         * @param {string} [searchText] 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        trialLogs(trialId: number, limit?: number, follow?: boolean, agentIds?: Array<string>, containerIds?: Array<string>, rankIds?: Array<number>, levels?: Array<'LOG_LEVEL_UNSPECIFIED' | 'LOG_LEVEL_TRACE' | 'LOG_LEVEL_DEBUG' | 'LOG_LEVEL_INFO' | 'LOG_LEVEL_WARNING' | 'LOG_LEVEL_ERROR' | 'LOG_LEVEL_CRITICAL'>, stdtypes?: Array<string>, sources?: Array<string>, timestampBefore?: Date, timestampAfter?: Date, orderBy?: 'ORDER_BY_UNSPECIFIED' | 'ORDER_BY_ASC' | 'ORDER_BY_DESC', options: any = {}): FetchArgs {
+        trialLogs(trialId: number, limit?: number, follow?: boolean, agentIds?: Array<string>, containerIds?: Array<string>, rankIds?: Array<number>, levels?: Array<'LOG_LEVEL_UNSPECIFIED' | 'LOG_LEVEL_TRACE' | 'LOG_LEVEL_DEBUG' | 'LOG_LEVEL_INFO' | 'LOG_LEVEL_WARNING' | 'LOG_LEVEL_ERROR' | 'LOG_LEVEL_CRITICAL'>, stdtypes?: Array<string>, sources?: Array<string>, timestampBefore?: Date, timestampAfter?: Date, orderBy?: 'ORDER_BY_UNSPECIFIED' | 'ORDER_BY_ASC' | 'ORDER_BY_DESC', searchText?: string, options: any = {}): FetchArgs {
             // verify required parameter 'trialId' is not null or undefined
             if (trialId === null || trialId === undefined) {
                 throw new RequiredError('trialId','Required parameter trialId was null or undefined when calling trialLogs.');
@@ -20559,6 +20584,10 @@ export const TrialsApiFetchParamCreator = function (configuration?: Configuratio
 
             if (orderBy !== undefined) {
                 localVarQueryParameter['orderBy'] = orderBy;
+            }
+
+            if (searchText !== undefined) {
+                localVarQueryParameter['searchText'] = searchText;
             }
 
             localVarUrlObj.query = Object.assign({}, localVarUrlObj.query, localVarQueryParameter, options.query);
@@ -20771,11 +20800,12 @@ export const TrialsApiFp = function(configuration?: Configuration) {
          * @param {Date} [timestampBefore] Limit the trial logs to ones with a timestamp before a given time.
          * @param {Date} [timestampAfter] Limit the trial logs to ones with a timestamp after a given time.
          * @param {'ORDER_BY_UNSPECIFIED' | 'ORDER_BY_ASC' | 'ORDER_BY_DESC'} [orderBy] Order logs in either ascending or descending order by timestamp.   - ORDER_BY_UNSPECIFIED: Returns records in no specific order.  - ORDER_BY_ASC: Returns records in ascending order.  - ORDER_BY_DESC: Returns records in descending order.
+         * @param {string} [searchText] 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        trialLogs(trialId: number, limit?: number, follow?: boolean, agentIds?: Array<string>, containerIds?: Array<string>, rankIds?: Array<number>, levels?: Array<'LOG_LEVEL_UNSPECIFIED' | 'LOG_LEVEL_TRACE' | 'LOG_LEVEL_DEBUG' | 'LOG_LEVEL_INFO' | 'LOG_LEVEL_WARNING' | 'LOG_LEVEL_ERROR' | 'LOG_LEVEL_CRITICAL'>, stdtypes?: Array<string>, sources?: Array<string>, timestampBefore?: Date, timestampAfter?: Date, orderBy?: 'ORDER_BY_UNSPECIFIED' | 'ORDER_BY_ASC' | 'ORDER_BY_DESC', options?: any): (fetch?: FetchAPI, basePath?: string) => Promise<StreamResultOfV1TrialLogsResponse> {
-            const localVarFetchArgs = TrialsApiFetchParamCreator(configuration).trialLogs(trialId, limit, follow, agentIds, containerIds, rankIds, levels, stdtypes, sources, timestampBefore, timestampAfter, orderBy, options);
+        trialLogs(trialId: number, limit?: number, follow?: boolean, agentIds?: Array<string>, containerIds?: Array<string>, rankIds?: Array<number>, levels?: Array<'LOG_LEVEL_UNSPECIFIED' | 'LOG_LEVEL_TRACE' | 'LOG_LEVEL_DEBUG' | 'LOG_LEVEL_INFO' | 'LOG_LEVEL_WARNING' | 'LOG_LEVEL_ERROR' | 'LOG_LEVEL_CRITICAL'>, stdtypes?: Array<string>, sources?: Array<string>, timestampBefore?: Date, timestampAfter?: Date, orderBy?: 'ORDER_BY_UNSPECIFIED' | 'ORDER_BY_ASC' | 'ORDER_BY_DESC', searchText?: string, options?: any): (fetch?: FetchAPI, basePath?: string) => Promise<StreamResultOfV1TrialLogsResponse> {
+            const localVarFetchArgs = TrialsApiFetchParamCreator(configuration).trialLogs(trialId, limit, follow, agentIds, containerIds, rankIds, levels, stdtypes, sources, timestampBefore, timestampAfter, orderBy, searchText, options);
             return (fetch: FetchAPI = portableFetch, basePath: string = BASE_PATH) => {
                 return fetch(basePath + localVarFetchArgs.url, localVarFetchArgs.options).then((response) => {
                     if (response.status >= 200 && response.status < 300) {
@@ -20910,11 +20940,12 @@ export const TrialsApiFactory = function (configuration?: Configuration, fetch?:
          * @param {Date} [timestampBefore] Limit the trial logs to ones with a timestamp before a given time.
          * @param {Date} [timestampAfter] Limit the trial logs to ones with a timestamp after a given time.
          * @param {'ORDER_BY_UNSPECIFIED' | 'ORDER_BY_ASC' | 'ORDER_BY_DESC'} [orderBy] Order logs in either ascending or descending order by timestamp.   - ORDER_BY_UNSPECIFIED: Returns records in no specific order.  - ORDER_BY_ASC: Returns records in ascending order.  - ORDER_BY_DESC: Returns records in descending order.
+         * @param {string} [searchText] 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        trialLogs(trialId: number, limit?: number, follow?: boolean, agentIds?: Array<string>, containerIds?: Array<string>, rankIds?: Array<number>, levels?: Array<'LOG_LEVEL_UNSPECIFIED' | 'LOG_LEVEL_TRACE' | 'LOG_LEVEL_DEBUG' | 'LOG_LEVEL_INFO' | 'LOG_LEVEL_WARNING' | 'LOG_LEVEL_ERROR' | 'LOG_LEVEL_CRITICAL'>, stdtypes?: Array<string>, sources?: Array<string>, timestampBefore?: Date, timestampAfter?: Date, orderBy?: 'ORDER_BY_UNSPECIFIED' | 'ORDER_BY_ASC' | 'ORDER_BY_DESC', options?: any) {
-            return TrialsApiFp(configuration).trialLogs(trialId, limit, follow, agentIds, containerIds, rankIds, levels, stdtypes, sources, timestampBefore, timestampAfter, orderBy, options)(fetch, basePath);
+        trialLogs(trialId: number, limit?: number, follow?: boolean, agentIds?: Array<string>, containerIds?: Array<string>, rankIds?: Array<number>, levels?: Array<'LOG_LEVEL_UNSPECIFIED' | 'LOG_LEVEL_TRACE' | 'LOG_LEVEL_DEBUG' | 'LOG_LEVEL_INFO' | 'LOG_LEVEL_WARNING' | 'LOG_LEVEL_ERROR' | 'LOG_LEVEL_CRITICAL'>, stdtypes?: Array<string>, sources?: Array<string>, timestampBefore?: Date, timestampAfter?: Date, orderBy?: 'ORDER_BY_UNSPECIFIED' | 'ORDER_BY_ASC' | 'ORDER_BY_DESC', searchText?: string, options?: any) {
+            return TrialsApiFp(configuration).trialLogs(trialId, limit, follow, agentIds, containerIds, rankIds, levels, stdtypes, sources, timestampBefore, timestampAfter, orderBy, searchText, options)(fetch, basePath);
         },
         /**
          * 
@@ -21044,12 +21075,13 @@ export class TrialsApi extends BaseAPI {
      * @param {Date} [timestampBefore] Limit the trial logs to ones with a timestamp before a given time.
      * @param {Date} [timestampAfter] Limit the trial logs to ones with a timestamp after a given time.
      * @param {'ORDER_BY_UNSPECIFIED' | 'ORDER_BY_ASC' | 'ORDER_BY_DESC'} [orderBy] Order logs in either ascending or descending order by timestamp.   - ORDER_BY_UNSPECIFIED: Returns records in no specific order.  - ORDER_BY_ASC: Returns records in ascending order.  - ORDER_BY_DESC: Returns records in descending order.
+     * @param {string} [searchText] 
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof TrialsApi
      */
-    public trialLogs(trialId: number, limit?: number, follow?: boolean, agentIds?: Array<string>, containerIds?: Array<string>, rankIds?: Array<number>, levels?: Array<'LOG_LEVEL_UNSPECIFIED' | 'LOG_LEVEL_TRACE' | 'LOG_LEVEL_DEBUG' | 'LOG_LEVEL_INFO' | 'LOG_LEVEL_WARNING' | 'LOG_LEVEL_ERROR' | 'LOG_LEVEL_CRITICAL'>, stdtypes?: Array<string>, sources?: Array<string>, timestampBefore?: Date, timestampAfter?: Date, orderBy?: 'ORDER_BY_UNSPECIFIED' | 'ORDER_BY_ASC' | 'ORDER_BY_DESC', options?: any) {
-        return TrialsApiFp(this.configuration).trialLogs(trialId, limit, follow, agentIds, containerIds, rankIds, levels, stdtypes, sources, timestampBefore, timestampAfter, orderBy, options)(this.fetch, this.basePath);
+    public trialLogs(trialId: number, limit?: number, follow?: boolean, agentIds?: Array<string>, containerIds?: Array<string>, rankIds?: Array<number>, levels?: Array<'LOG_LEVEL_UNSPECIFIED' | 'LOG_LEVEL_TRACE' | 'LOG_LEVEL_DEBUG' | 'LOG_LEVEL_INFO' | 'LOG_LEVEL_WARNING' | 'LOG_LEVEL_ERROR' | 'LOG_LEVEL_CRITICAL'>, stdtypes?: Array<string>, sources?: Array<string>, timestampBefore?: Date, timestampAfter?: Date, orderBy?: 'ORDER_BY_UNSPECIFIED' | 'ORDER_BY_ASC' | 'ORDER_BY_DESC', searchText?: string, options?: any) {
+        return TrialsApiFp(this.configuration).trialLogs(trialId, limit, follow, agentIds, containerIds, rankIds, levels, stdtypes, sources, timestampBefore, timestampAfter, orderBy, searchText, options)(this.fetch, this.basePath);
     }
 
     /**


### PR DESCRIPTION
## Description

add text search to trial logs. [DET-7446]


added support to text search for trial/task logs stored in postgres.

made an attempt to do the same for elastic, but dont know how to test. I tried uncommenting the `elastic` stage in `devcluster.yaml` then starting a task, but the new tasks still ended up using the postgres backend. in any case not all filtering functionalities are implemented for elasticsearch anyways.

https://user-images.githubusercontent.com/28383080/179709684-3d302f9d-b38e-4ac5-9ebf-8e061978990b.mov



## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions about this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

streaming causes the api to get hit pretty frequently. if we think queries might get expensive, we may want to increase the interval.




## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-7446]: https://determinedai.atlassian.net/browse/DET-7446?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ