### PR TITLE
fix: allow zero slots for JupyterLab in modal

### DIFF
--- a/webui/react/src/hooks/useModal/JupyterLab/useModalJupyterLab.tsx
+++ b/webui/react/src/hooks/useModal/JupyterLab/useModalJupyterLab.tsx
@@ -360,7 +360,7 @@ const JupyterLabForm: React.FC<FormProps> = ({ updateFields, fields }: FormProps
             <InputNumber
               defaultValue={fields.slots !== undefined ? fields.slots : DEFAULT_SLOT_COUNT}
               max={resourceInfo.maxSlots === -1 ? Number.MAX_SAFE_INTEGER : resourceInfo.maxSlots}
-              min={resourceInfo.hasAux ? 0 : 1}
+              min={0}
               value={fields.slots}
               onChange={(value) => updateFields?.({ slots: value })}
             />

--- a/webui/react/src/hooks/useModal/JupyterLab/useModalJupyterLab.tsx
+++ b/webui/react/src/hooks/useModal/JupyterLab/useModalJupyterLab.tsx
@@ -277,7 +277,7 @@ const JupyterLabForm: React.FC<FormProps> = ({ updateFields, fields }: FormProps
     const hasSlotsPerAgent = maxSlots !== 0;
     const hasComputeCapacity = hasSlots || hasSlotsPerAgent;
     if (hasAuxCapacity && !hasComputeCapacity) updateFields?.({ slots: 0 });
-    if (hasComputeCapacity && !fields.slots) updateFields?.({ slots: DEFAULT_SLOT_COUNT });
+    if (hasComputeCapacity && fields.slots == null) updateFields?.({ slots: DEFAULT_SLOT_COUNT });
 
     return {
       hasAux: hasAuxCapacity,
@@ -360,7 +360,7 @@ const JupyterLabForm: React.FC<FormProps> = ({ updateFields, fields }: FormProps
             <InputNumber
               defaultValue={fields.slots !== undefined ? fields.slots : DEFAULT_SLOT_COUNT}
               max={resourceInfo.maxSlots === -1 ? Number.MAX_SAFE_INTEGER : resourceInfo.maxSlots}
-              min={0}
+              min={resourceInfo.hasAux ? 0 : 1}
               value={fields.slots}
               onChange={(value) => updateFields?.({ slots: value })}
             />


### PR DESCRIPTION
## Description

we were restoring the default when slots input was 0. this fixes that.

<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At a minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan

do `devcluster`, go to JupyterLab modal, click down arrow on slots, should allow a selection of zero. 

## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ