### PR TITLE
docs: bump rstfmt requirement

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,7 +1,7 @@
 # pin docutils at 0.15.2 to avoid transitive dependency conflict with botocore (requires < 0.16)
 docutils==0.15.2
 pillow
-rstfmt==0.0.10
+rstfmt==0.0.11
 
 # Plugins
 sphinx-reredirects>=0.0.1


### PR DESCRIPTION
## Description

The new version (mostly) supports Sphinx's glossary directive.