### PR TITLE
fix: zero slot tasks k8s using wrong image and exposing all GPUs [DET-7808]

### DIFF
--- a/docs/release-notes/zero-slot-k8s.txt
+++ b/docs/release-notes/zero-slot-k8s.txt
@@ -1,0 +1,6 @@
+:orphan:
+
+**Bug Fixes**
+
+-  Kubernetes: Fix an issue where zero slot trials would use the GPU image instead of the CPU image.
+-  Kubernetes: Fix an issue where zero slot trials would incorrectly be exposed all GPUs.

--- a/docs/release-notes/zero-slot-k8s.txt
+++ b/docs/release-notes/zero-slot-k8s.txt
@@ -2,5 +2,5 @@
 
 **Bug Fixes**
 
--  Kubernetes: Fix an issue where zero slot trials would use the GPU image instead of the CPU image.
--  Kubernetes: Fix an issue where zero slot trials would incorrectly be exposed all GPUs.
+-  Kubernetes: Fix an issue where zero slot tasks would use the GPU image instead of the CPU image.
+-  Kubernetes: Fix an issue where zero slot tasks would incorrectly be exposed all GPUs.

--- a/docs/release-notes/zero-slot-k8s.txt
+++ b/docs/release-notes/zero-slot-k8s.txt
@@ -3,4 +3,4 @@
 **Bug Fixes**
 
 -  Kubernetes: Fix an issue where zero slot tasks would use the GPU image instead of the CPU image.
--  Kubernetes: Fix an issue where zero slot tasks would incorrectly be exposed all GPUs.
+-  Kubernetes: Fix an issue where zero slot tasks would incorrectly be exposed to all GPUs.

--- a/master/internal/resourcemanagers/kubernetes/spec.go
+++ b/master/internal/resourcemanagers/kubernetes/spec.go
@@ -98,6 +98,12 @@ func (p *pod) configureEnvVars(
 		envVarsMap["DET_MASTER_CERT_NAME"] = p.masterTLSConfig.CertificateName
 	}
 
+	// Without this zero slot trials will have access to all GPUs.
+	// https://github.com/NVIDIA/k8s-device-plugin/issues/61
+	if p.slots == 0 {
+		envVarsMap["NVIDIA_VISIBLE_DEVICES"] = "void"
+	}
+
 	envVars := make([]k8sV1.EnvVar, 0, len(envVarsMap))
 	for envVarKey, envVarValue := range envVarsMap {
 		envVars = append(envVars, k8sV1.EnvVar{Name: envVarKey, Value: envVarValue})

--- a/master/internal/resourcemanagers/kubernetes/spec.go
+++ b/master/internal/resourcemanagers/kubernetes/spec.go
@@ -41,8 +41,8 @@ const (
 	rootUserName = "root"
 )
 
-func (p *pod) configureResourcesRequirements(deviceType device.Type) k8sV1.ResourceRequirements {
-	switch deviceType {
+func (p *pod) configureResourcesRequirements() k8sV1.ResourceRequirements {
+	switch p.slotType {
 	case device.CPU:
 		cpuMillisRequested := int64(p.slotResourceRequests.CPU * float32(p.slots) * 1000)
 		return k8sV1.ResourceRequirements{

--- a/master/internal/resourcemanagers/kubernetes/spec.go
+++ b/master/internal/resourcemanagers/kubernetes/spec.go
@@ -98,7 +98,7 @@ func (p *pod) configureEnvVars(
 		envVarsMap["DET_MASTER_CERT_NAME"] = p.masterTLSConfig.CertificateName
 	}
 
-	// Without this zero slot trials will have access to all GPUs.
+	// Without this zero slot tasks will have access to all GPUs.
 	// https://github.com/NVIDIA/k8s-device-plugin/issues/61
 	if deviceType == device.CPU || deviceType == device.ZeroSlot {
 		envVarsMap["NVIDIA_VISIBLE_DEVICES"] = "void"


### PR DESCRIPTION
## Description

Zero slot tasks would use the GPU image before this fix. 

In addition zero slot tasks would end up getting exposed all GPUs (not sure if all in the cluster or on the node but still a problem either way).

## Test Plan

Create a EKS cluster with a GPU

then run and verify that we can see the GPUs (and the image used has ```-gpu-``` in the name)
```
det cmd run --config="resources.slots=1" nvidia-smi
```

now run a zero slot command and verify we do not see any GPUs (should get command not found with image with ```-cpu-``` in the name)
```
det cmd run --config="resources.slots=0" nvidia-smi
```

Then start a notebook verify the image has ```-cpu-``` in the name
```
det notebook start --config="resources.slots=0"
```


Then run the following snippet in a notebook and verify that the output is ```0``` 
```python
import torch
torch.cuda.device_count()
```


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
