### PR TITLE
fix: ignore order for Set isEqual [DET-7822]

### DIFF
--- a/webui/react/src/shared/utils/data.test.ts
+++ b/webui/react/src/shared/utils/data.test.ts
@@ -185,6 +185,20 @@ describe('Data Utilities', () => {
         ],
         output: false,
       },
+      /**
+       * for now isEquals for set elements respects how the set views
+       * equality of its members, as opposed to how isEquals views them
+       * otherwise you would have the following:
+       * > a.forEach(x => b.delete(x)); isEquals(a, b)
+       * true
+       */ 
+      {
+        input: [
+          new Set([[ 1 ]]),
+          new Set([[ 1 ]]),
+        ],
+        output: false,
+      },
     ];
     tests.forEach((test) => {
       const [ a, b ] = test.input;

--- a/webui/react/src/shared/utils/data.test.ts
+++ b/webui/react/src/shared/utils/data.test.ts
@@ -143,8 +143,8 @@ describe('Data Utilities', () => {
       { input: [ Symbol('bit'), 123 ], output: false },
       {
         input: [
-          new Set([ 'abc', 123, Symbol('xyz') ]),
-          new Set([ 'abc', 123, Symbol('xyz') ]),
+          new Set([ 'abc', 123 ]),
+          new Set([ 'abc', 123 ]),
         ],
         output: true,
       },
@@ -161,6 +161,27 @@ describe('Data Utilities', () => {
         input: [
           new Map([ [ 'abc', 123 ] ]),
           new Map([ [ 'abc', 123 ], [ 'def', 456 ] ]),
+        ],
+        output: false,
+      },
+      {
+        input: [
+          new Set([ 1, 2, 3 ]),
+          new Set([ 1, 3, 2 ]),
+        ],
+        output: true,
+      },
+      {
+        input: [
+          new Set([ 1, 2, 3 ]),
+          new Set([ 1, 2, 3, 4 ]),
+        ],
+        output: false,
+      },
+      {
+        input: [
+          new Set([ 1, 2, 3 ]),
+          new Set([ 1, 2, 5 ]),
         ],
         output: false,
       },

--- a/webui/react/src/shared/utils/data.test.ts
+++ b/webui/react/src/shared/utils/data.test.ts
@@ -191,11 +191,11 @@ describe('Data Utilities', () => {
        * otherwise you would have the following:
        * > a.forEach(x => b.delete(x)); isEquals(a, b)
        * true
-       */ 
+       */
       {
         input: [
-          new Set([[ 1 ]]),
-          new Set([[ 1 ]]),
+          new Set([ [ 1 ] ]),
+          new Set([ [ 1 ] ]),
         ],
         output: false,
       },

--- a/webui/react/src/shared/utils/data.ts
+++ b/webui/react/src/shared/utils/data.ts
@@ -23,7 +23,7 @@ export const isPromise = (data: unknown): data is Promise<unknown> => {
   if (!isObject(data)) return false;
   return typeof (data as { then?: any }).then === 'function';
 };
-export const isSet = (data: unknown): boolean => data instanceof Set;
+export const isSet = (data: unknown): data is Set<unknown> => data instanceof Set;
 export const isString = (data: unknown): data is string => typeof data === 'string';
 export const isSymbol = (data: unknown): data is symbol => typeof data === 'symbol';
 export const isFunction = (fn: unknown): boolean => typeof fn === 'function';
@@ -38,11 +38,20 @@ export const isSyncFunction = (fn: unknown): boolean => {
 };
 
 export const isEqual = (a: unknown, b: unknown): boolean => {
-  if ((isMap(a) || isSet(b)) && (isMap(b) || isSet(b))) {
+  if (isMap(a) && isMap(b)) {
     return JSON.stringify(Array.from(a as any)) === JSON.stringify(Array.from(b as any));
   }
   if (isSymbol(a) && isSymbol(b)) return a.toString() === b.toString();
   if (isObject(a) && isObject(b)) return JSON.stringify(a) === JSON.stringify(b);
+  if (isSet(a) && isSet(b)) {
+    if (a.size !== b.size) return false;
+    for (const elem of a.values()) {
+      if (!b.has(elem)) {
+        return false;
+      }
+    }
+    return true;
+  }
   if (Array.isArray(a) && Array.isArray(b))
     return a.length === b.length && a.every((x, i) => isEqual(x, b[i]));
   return a === b;


### PR DESCRIPTION
## Description
[DET-7822]

`Sets` are the same if they have the same size and their elements are equal.

Note: with the logic in this PR, 
```
isEqual(new Set([[1]]), new Set([[1]])) === false
``` 

This is in keeping with how `Sets` see things though: `Sets` see different arrays containing the same elements as distinct, e.g.
```
> new Set([[1], [1]]).size 
2
```
so that seemed the appropriate way to handle it. 

It would not be possible to implement custom `isEquals` for individual set elements while maintaining performance characteristics one would expect for an `isEqual(a: Set, b: Set)` function (caveat: runtime for `Set` is not part of the JS spec).


## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions about this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-7822]: https://determinedai.atlassian.net/browse/DET-7822?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ