### PR TITLE
chore: ez live server

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,6 +84,11 @@ test-%:
 .PHONY: test
 test: test-harness test-model_hub test-master test-agent test-webui
 
+# local frontend dev server against current DET_MASTER
+.PHONY: localfrontend
+local: build-bindings get-deps-webui
+	HOST="localhost" DET_WEBPACK_PROXY_URL=${DET_MASTER} $(MAKE) -C webui live
+
 .PHONY: devcluster
 devcluster:
 	devcluster -c tools/devcluster.yaml

--- a/webui/Makefile
+++ b/webui/Makefile
@@ -34,3 +34,7 @@ test: test-react
 .PHONY: test-%
 test-%:
 	$(MAKE) -C $* test
+
+.PHONY: live
+live: 
+	$(MAKE) -C react live

--- a/webui/react/craco.config.js
+++ b/webui/react/craco.config.js
@@ -12,6 +12,11 @@ const webpackEnvPlugin = new DefinePlugin({
   'process.env.VERSION': '"0.19.5-dev0"',
 });
 
+
+// want to fallback in case of empty string, hence no ??
+const webpackProxyUrl = process.env.DET_WEBPACK_PROXY_URL || 'http://localhost:8080'
+
+
 /**
  * Add theme override support for antd. For more options:
  * https://github.com/mzohaibqc/antd-theme-webpack-plugin
@@ -36,8 +41,8 @@ module.exports = {
      * requests to the server itself though
      */
     {
-      '/api': { target: 'http://localhost:8080' },
-      '/proxy': { target: 'http://localhost:8080' },
+      '/api': { target: webpackProxyUrl },
+      '/proxy': { target: webpackProxyUrl },
     },
   },
   webpack: {


### PR DESCRIPTION
## Description

allow personages to run `make local` from repo root to install and run frontend dev server against current `DET_MASTER`

to make easier for non-webs to test/try/debug things


## Test Plan

from repo root
`make clean`
`export DET_MASTER=$YOUR_SECRET_CLUSTER`
`export HOST=hey-yall-its-conda` # this is for testing something tim encountered
`make local`

should work

## Commentary (optional)

support team sometimes experiences issues with the node version dependency changing.

is there a sane way to install a specific node version to be used just in the context of the determined repo without messing anything else up for the user as a part of `make get-deps`.




## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
