### PR TITLE
fix: Drop rendezvous interface warning (FOUNDENG-139)

### DIFF
--- a/harness/determined/exec/prep_container.py
+++ b/harness/determined/exec/prep_container.py
@@ -88,16 +88,13 @@ def do_rendezvous_slurm(
     assert num_peers_str, "Unable to complete rendezvous without SLURM_NPROCS"
     num_peers = int(num_peers_str)
 
-    rendezvous_ip, resolution_error = None, None
+    rendezvous_ip = socket.gethostbyname(socket.gethostname())
     for rendezvous_iface in rendezvous_ifaces():
         try:
             rendezvous_ip = get_ip_from_interface(rendezvous_iface)
             break
         except ValueError as e:
-            resolution_error = e
-    else:
-        logging.warning(f"falling back to naive ip resolution after:\n\t{resolution_error}")
-        rendezvous_ip = socket.gethostbyname(socket.gethostname())
+            logging.warning(f"Unable to resolve ip for {rendezvous_iface}: {str(e)}")
 
     # Note, rendezvous must be sorted in rank order.
     resp = bindings.post_AllocationAllGather(


### PR DESCRIPTION

## Description

On Slurm we attempt prioritize an eth* interface for rendezvous to make sure we have a reachable address for the master.  It appears common for systems to not have an eth* interface, so drop the warning to avoid the noise.

If the eth* interface did not have a valid address, the fallback to hostname would not have been applied, so fixed
that as well.

## Test Plan

No behavior change, just changed warning logs.

## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
