### PR TITLE
fix: gpt_neox deepspeed example

### DIFF
--- a/examples/deepspeed/gpt_neox/det_utils.py
+++ b/examples/deepspeed/gpt_neox/det_utils.py
@@ -17,7 +17,7 @@ def get_neox_args(context):
     exp_config = context.get_experiment_config()
 
     # Gather overrides.
-    overwrite_values = args.pop("overwrite_values")
+    overwrite_values = args.pop("overwrite_values", {})
     # We are going to overwrite certain neox_args with determined config values
     # from the experiment config to ensure consistency.
     assert (

--- a/examples/deepspeed/gpt_neox/gpt2_trial.py
+++ b/examples/deepspeed/gpt_neox/gpt2_trial.py
@@ -1,7 +1,6 @@
 from attrdict import AttrMap
 from datetime import datetime
 import traceback
-import numpy as np
 import torch
 import deepspeed
 import pathlib
@@ -176,7 +175,6 @@ class GPT2Trial(DeepSpeedTrial):
         ):
             torch.distributed.barrier()
             time_str = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
-            rank = torch.distributed.get_rank()
             megatron_utils.print_rank_0(
                 "time: {} | exiting the program at iteration {}".format(
                     time_str, self.neox_args.iteration
@@ -231,7 +229,6 @@ class GPT2Trial(DeepSpeedTrial):
         ) = build_datasets_from_neox_args(self.neox_args)
         self.timers("train/valid/test data dataset").stop()
         self.timers.log(["train/valid/test data dataset"])
-
         return DataLoader(
             self.train_data,
             batch_size=self.neox_args.train_micro_batch_size_per_gpu,


### PR DESCRIPTION
## Description
fix a minor issue with the example:
- parsing args failed if `overwrite_values` is not provided in the determined experiment config -> now we will return an empty dict

Note that we do not have a dataloader resume issue since we are relying on determined's dataloader to skip the correct number of datapoints when resuming.  If we were using gpt-neox's dataloader directly, we'd need to make sure to set start_iter after loading a checkpoint.  

<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At a minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan
Tested manually
<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions about this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.
- [ ] If modifying `/webui/react/src/shared/` verify `make -C webui/react test-shared` passes.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ