### PR TITLE
feat: pluggable authorization for RBAC.

### DIFF
--- a/master/.golangci.yml
+++ b/master/.golangci.yml
@@ -80,6 +80,7 @@ linters:
     - exhaustive
     - funlen
     - gochecknoglobals
+    - gochecknoinits
     - gocognit
     - gocyclo
     - godox

--- a/master/internal/api_user.go
+++ b/master/internal/api_user.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/determined-ai/determined/master/internal/db"
 	"github.com/determined-ai/determined/master/internal/grpcutil"
+	"github.com/determined-ai/determined/master/internal/user"
 	"github.com/determined-ai/determined/master/pkg/model"
 	"github.com/determined-ai/determined/proto/pkg/apiv1"
 	"github.com/determined-ai/determined/proto/pkg/userv1"
@@ -149,14 +150,15 @@ func (a *apiServer) SetUserPassword(
 	if err != nil {
 		return nil, err
 	}
-	if !curUser.Admin && curUser.ID != model.UserID(req.UserId) {
+	targetUser := &model.User{ID: model.UserID(req.UserId)}
+	if err := user.AuthZProvider.Get().CanSetUserPassword(*curUser, *targetUser); err != nil {
 		return nil, grpcutil.ErrPermissionDenied
 	}
-	user := &model.User{ID: model.UserID(req.UserId)}
-	if err = user.UpdatePasswordHash(replicateClientSideSaltAndHash(req.Password)); err != nil {
+
+	if err = targetUser.UpdatePasswordHash(replicateClientSideSaltAndHash(req.Password)); err != nil {
 		return nil, err
 	}
-	switch err = a.m.db.UpdateUser(user, []string{"password_hash"}, nil); {
+	switch err = a.m.db.UpdateUser(targetUser, []string{"password_hash"}, nil); {
 	case err == db.ErrNotFound:
 		return nil, errUserNotFound
 	case err != nil:

--- a/master/internal/api_user.go
+++ b/master/internal/api_user.go
@@ -151,7 +151,7 @@ func (a *apiServer) SetUserPassword(
 		return nil, err
 	}
 	targetUser := &model.User{ID: model.UserID(req.UserId)}
-	if err := user.AuthZProvider.Get().CanSetUserPassword(*curUser, *targetUser); err != nil {
+	if err = user.AuthZProvider.Get().CanSetUserPassword(*curUser, *targetUser); err != nil {
 		return nil, grpcutil.ErrPermissionDenied
 	}
 

--- a/master/internal/authz/authz_provider_type.go
+++ b/master/internal/authz/authz_provider_type.go
@@ -1,0 +1,63 @@
+package authz
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+	"sync"
+
+	"github.com/determined-ai/determined/master/internal/config"
+	"golang.org/x/exp/maps"
+)
+
+type AuthZProviderType[T any] struct {
+	registry map[string]T
+	once     sync.Once
+}
+
+func (p *AuthZProviderType[T]) Register(authZType string, impl T) {
+	p.once.Do(func() {
+		p.registry = make(map[string]T)
+	})
+	// TODO(ilia): keep registry here or global in internal/authz/authz_basic.go
+	config.RegisterAuthZType(authZType)
+	if _, ok := p.registry[authZType]; ok {
+		panic(fmt.Errorf("can't do double register of type %s for: %s", authZType, p.string()))
+	}
+	p.registry[authZType] = impl
+}
+
+func (p *AuthZProviderType[T]) string() string {
+	return reflect.TypeOf((*T)(nil)).Elem().String()
+}
+
+func (p *AuthZProviderType[T]) Get() T {
+	if len(p.registry) == 0 {
+		panic(fmt.Errorf("empty registry for: %s", p.string()))
+	}
+
+	authZConfig := config.GetAuthZConfig()
+
+	res, ok := p.registry[authZConfig.Type]
+	if ok {
+		return res
+	}
+
+	okTypes := strings.Join(maps.Keys(p.registry), ", ")
+
+	if authZConfig.FallbackType == nil {
+		panic(fmt.Errorf(
+			"failed to find authz type %s in %s for: %s",
+			authZConfig.Type, okTypes, p.string()))
+	}
+
+	res, ok = p.registry[*authZConfig.FallbackType]
+	if ok {
+		return res
+	}
+
+	panic(fmt.Errorf(
+		"failed to find authz types %s, %s in %s for: %s",
+		authZConfig.Type, *authZConfig.FallbackType, okTypes, p.string()))
+
+}

--- a/master/internal/authz/authz_provider_type.go
+++ b/master/internal/authz/authz_provider_type.go
@@ -6,15 +6,18 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/determined-ai/determined/master/internal/config"
 	"golang.org/x/exp/maps"
+
+	"github.com/determined-ai/determined/master/internal/config"
 )
 
+// AuthZProviderType is a per-module registry for authz implementations.
 type AuthZProviderType[T any] struct {
 	registry map[string]T
 	once     sync.Once
 }
 
+// Register adds new implementation.
 func (p *AuthZProviderType[T]) Register(authZType string, impl T) {
 	p.once.Do(func() {
 		p.registry = make(map[string]T)
@@ -31,6 +34,7 @@ func (p *AuthZProviderType[T]) string() string {
 	return reflect.TypeOf((*T)(nil)).Elem().String()
 }
 
+// Get returns the selected implementation.
 func (p *AuthZProviderType[T]) Get() T {
 	if len(p.registry) == 0 {
 		panic(fmt.Errorf("empty registry for: %s", p.string()))
@@ -59,5 +63,4 @@ func (p *AuthZProviderType[T]) Get() T {
 	panic(fmt.Errorf(
 		"failed to find authz types %s, %s in %s for: %s",
 		authZConfig.Type, *authZConfig.FallbackType, okTypes, p.string()))
-
 }

--- a/master/internal/config/authz_config.go
+++ b/master/internal/config/authz_config.go
@@ -5,20 +5,26 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/determined-ai/determined/master/pkg/ptrs"
 	"golang.org/x/exp/maps"
+
+	"github.com/determined-ai/determined/master/pkg/ptrs"
 )
 
-var knownAuthZTypes map[string]bool
-var authZConfigMutex sync.Mutex
+var (
+	knownAuthZTypes  map[string]bool
+	authZConfigMutex sync.Mutex
+)
 
+// BasicAuthZType is the default authz string id.
 const BasicAuthZType = "basic"
 
+// AuthZConfig is a authz-related section of master config.
 type AuthZConfig struct {
 	Type         string  `json:"type"`
 	FallbackType *string `json:"fallback"`
 }
 
+// DefaultAuthZConfig returns default authz config.
 func DefaultAuthZConfig() *AuthZConfig {
 	return &AuthZConfig{
 		Type: BasicAuthZType,
@@ -27,6 +33,7 @@ func DefaultAuthZConfig() *AuthZConfig {
 	}
 }
 
+// Validate the authz config.
 func (c *AuthZConfig) Validate() []error {
 	var errs []error
 
@@ -57,6 +64,7 @@ func initAuthZTypes() {
 	knownAuthZTypes[BasicAuthZType] = true
 }
 
+// RegisterAuthZType adds new known authz type.
 func RegisterAuthZType(authzType string) {
 	initAuthZTypes()
 
@@ -66,6 +74,7 @@ func RegisterAuthZType(authzType string) {
 	knownAuthZTypes[authzType] = true
 }
 
+// GetAuthZConfig returns current global authz config.
 func GetAuthZConfig() AuthZConfig {
 	return GetMasterConfig().Security.AuthZ
 }

--- a/master/internal/config/authz_config.go
+++ b/master/internal/config/authz_config.go
@@ -1,0 +1,71 @@
+package config
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/determined-ai/determined/master/pkg/ptrs"
+	"golang.org/x/exp/maps"
+)
+
+var knownAuthZTypes map[string]bool
+var authZConfigMutex sync.Mutex
+
+const BasicAuthZType = "basic"
+
+type AuthZConfig struct {
+	Type         string  `json:"type"`
+	FallbackType *string `json:"fallback"`
+}
+
+func DefaultAuthZConfig() *AuthZConfig {
+	return &AuthZConfig{
+		Type: BasicAuthZType,
+		// TODO(ilia): Maybe default to nil?
+		FallbackType: ptrs.Ptr(BasicAuthZType),
+	}
+}
+
+func (c *AuthZConfig) Validate() []error {
+	var errs []error
+
+	okTypes := strings.Join(maps.Keys(knownAuthZTypes), ", ")
+	errorTmpl := "\"%s\" is not a known authz type, must be one of: %s"
+	if _, ok := knownAuthZTypes[c.Type]; !ok {
+		errs = append(errs, fmt.Errorf(errorTmpl, c.Type, okTypes))
+	}
+
+	if c.FallbackType != nil {
+		if _, ok := knownAuthZTypes[*c.FallbackType]; !ok {
+			errs = append(errs, fmt.Errorf(errorTmpl, *c.FallbackType, okTypes))
+		}
+	}
+
+	return errs
+}
+
+func initAuthZTypes() {
+	authZConfigMutex.Lock()
+	defer authZConfigMutex.Unlock()
+
+	if knownAuthZTypes != nil {
+		return
+	}
+
+	knownAuthZTypes = make(map[string]bool)
+	knownAuthZTypes[BasicAuthZType] = true
+}
+
+func RegisterAuthZType(authzType string) {
+	initAuthZTypes()
+
+	authZConfigMutex.Lock()
+	defer authZConfigMutex.Unlock()
+
+	knownAuthZTypes[authzType] = true
+}
+
+func GetAuthZConfig() AuthZConfig {
+	return GetMasterConfig().Security.AuthZ
+}

--- a/master/internal/config/config.go
+++ b/master/internal/config/config.go
@@ -90,6 +90,7 @@ func DefaultConfig() *Config {
 			SSH: SSHConfig{
 				RsaKeySize: 1024,
 			},
+			AuthZ: *DefaultAuthZConfig(),
 		},
 		// If left unspecified, the port is later filled in with 8080 (no TLS) or 8443 (TLS).
 		Port:        0,
@@ -237,6 +238,7 @@ type SecurityConfig struct {
 	DefaultTask model.AgentUserGroup `json:"default_task"`
 	TLS         TLSConfig            `json:"tls"`
 	SSH         SSHConfig            `json:"ssh"`
+	AuthZ       AuthZConfig          `json:"authz"`
 }
 
 // SSHConfig is the configuration setting for SSH.

--- a/master/internal/db/postgres.go
+++ b/master/internal/db/postgres.go
@@ -80,8 +80,8 @@ func ConnectPostgres(url string) (*PgDB, error) {
 }
 
 const (
-	// CodeUniqueViolation is the error code that Postgres uses to indicate that an attempted insert/update
-	// violates a uniqueness constraint.  Obtained from:
+	// CodeUniqueViolation is the error code that Postgres uses to indicate that an attempted
+	// insert/update violates a uniqueness constraint.  Obtained from:
 	// https://www.postgresql.org/docs/10/errcodes-appendix.html
 	CodeUniqueViolation = "23505"
 	// CodeForeignKeyViolation is the error code that Postgres uses to indicate that an attempted

--- a/master/internal/user/authz_basic_impl.go
+++ b/master/internal/user/authz_basic_impl.go
@@ -6,9 +6,10 @@ import (
 	"github.com/determined-ai/determined/master/pkg/model"
 )
 
-type UserAuthZBasic struct {
-}
+// UserAuthZBasic is basic.
+type UserAuthZBasic struct{}
 
+// CanSetUserPassword for basic authz.
 func (a *UserAuthZBasic) CanSetUserPassword(currentUser model.User, targetUser model.User) error {
 	if !currentUser.Admin && currentUser.ID != targetUser.ID {
 		return fmt.Errorf("non-admin users can only change their own password")

--- a/master/internal/user/authz_basic_impl.go
+++ b/master/internal/user/authz_basic_impl.go
@@ -1,0 +1,21 @@
+package user
+
+import (
+	"fmt"
+
+	"github.com/determined-ai/determined/master/pkg/model"
+)
+
+type UserAuthZBasic struct {
+}
+
+func (a *UserAuthZBasic) CanSetUserPassword(currentUser model.User, targetUser model.User) error {
+	if !currentUser.Admin && currentUser.ID != targetUser.ID {
+		return fmt.Errorf("non-admin users can only change their own password")
+	}
+	return nil
+}
+
+func init() {
+	AuthZProvider.Register("basic", &UserAuthZBasic{})
+}

--- a/master/internal/user/authz_iface.go
+++ b/master/internal/user/authz_iface.go
@@ -1,0 +1,12 @@
+package user
+
+import (
+	"github.com/determined-ai/determined/master/internal/authz"
+	"github.com/determined-ai/determined/master/pkg/model"
+)
+
+type UserAuthZ interface {
+	CanSetUserPassword(currentUser model.User, targetUser model.User) error
+}
+
+var AuthZProvider authz.AuthZProviderType[UserAuthZ]

--- a/master/internal/user/authz_iface.go
+++ b/master/internal/user/authz_iface.go
@@ -5,8 +5,10 @@ import (
 	"github.com/determined-ai/determined/master/pkg/model"
 )
 
+// UserAuthZ describes authz methods for `user` package.
 type UserAuthZ interface {
 	CanSetUserPassword(currentUser model.User, targetUser model.User) error
 }
 
+// AuthZProvider is the authz registry for `user` package.
 var AuthZProvider authz.AuthZProviderType[UserAuthZ]

--- a/master/internal/user/authz_unrestricted_impl.go
+++ b/master/internal/user/authz_unrestricted_impl.go
@@ -1,0 +1,17 @@
+package user
+
+import (
+	"github.com/determined-ai/determined/master/pkg/model"
+)
+
+// TODO XXX: this is for demo purposes only. Remove before merging to master branch.
+type UserAuthZUnrestricted struct {
+}
+
+func (a *UserAuthZUnrestricted) CanSetUserPassword(currentUser model.User, targetUser model.User) error {
+	return nil
+}
+
+func init() {
+	AuthZProvider.Register("unrestricted", &UserAuthZUnrestricted{})
+}

--- a/master/internal/user/authz_unrestricted_impl.go
+++ b/master/internal/user/authz_unrestricted_impl.go
@@ -4,11 +4,14 @@ import (
 	"github.com/determined-ai/determined/master/pkg/model"
 )
 
+// UserAuthZUnrestricted is unrestricted.
 // TODO XXX: this is for demo purposes only. Remove before merging to master branch.
-type UserAuthZUnrestricted struct {
-}
+type UserAuthZUnrestricted struct{}
 
-func (a *UserAuthZUnrestricted) CanSetUserPassword(currentUser model.User, targetUser model.User) error {
+// CanSetUserPassword for unresticted authz.
+func (a *UserAuthZUnrestricted) CanSetUserPassword(
+	currentUser model.User, targetUser model.User,
+) error {
 	return nil
 }
 

--- a/master/internal/user/service.go
+++ b/master/internal/user/service.go
@@ -324,7 +324,7 @@ func (s *Service) patchUser(c echo.Context) (interface{}, error) {
 	var toUpdate []string
 
 	if params.Password != nil {
-		if err := AuthZProvider.Get().CanSetUserPassword(authenticatedUser, *user); err != nil {
+		if err = AuthZProvider.Get().CanSetUserPassword(authenticatedUser, *user); err != nil {
 			return nil, forbiddenError
 		}
 		if err = user.UpdatePasswordHash(*params.Password); err != nil {

--- a/master/internal/user/service.go
+++ b/master/internal/user/service.go
@@ -324,7 +324,7 @@ func (s *Service) patchUser(c echo.Context) (interface{}, error) {
 	var toUpdate []string
 
 	if params.Password != nil {
-		if !user.PasswordCanBeModifiedBy(authenticatedUser) {
+		if err := AuthZProvider.Get().CanSetUserPassword(authenticatedUser, *user); err != nil {
 			return nil, forbiddenError
 		}
 		if err = user.UpdatePasswordHash(*params.Password); err != nil {

--- a/master/internal/usergroup/postgres_groups.go
+++ b/master/internal/usergroup/postgres_groups.go
@@ -32,7 +32,8 @@ func GroupByID(ctx context.Context, gid int) (Group, error) {
 // does not return an error if no groups are found, as that is considered a
 // successful search.
 func SearchGroups(ctx context.Context,
-	userBelongsTo model.UserID) ([]Group, error) {
+	userBelongsTo model.UserID,
+) ([]Group, error) {
 	var groups []Group
 	query := db.Bun().NewSelect().Model(&groups)
 


### PR DESCRIPTION
## Description

We'd like to enable pluggable authorization so:
1. it can be added and enabled in EE in an easier, additive-only fashion to
   minimize EE issues.
2. it's modular: no single interface, authorization can instead be implemented
   for modules (i.e. `internal/*` subdirectories).

See `AuthZProviderType` in `internal/authz/authz_provider_type.go` for the core implementation.

As an example, the "can user change someone's password" APIs were modified to use it:
- `internal/user/authz_iface.go` contains an interface that all AuthZ types will need to implement and "the registry" (`AuthZProvider`) 
- `internal/user/authz_basic_impl.go` implements this interface for our existing authorization (users can change their own password, admins can change anyones)
- `internal/user/authz_unrestricted_impl.go` is a toy implementation which allows anyone to do anything. this only serves as an example and should be removed before we merge to master.
- see changes in `internal/api_user.go` and `internal/user/service.go` for interface usage examples.

When implementing authorization for new module (e.g. usergroups), one would need to:
- add `internal/usergroups/authz_iface.go` with an interface (`UserGroupAuthZ`) describing all permission `Can*` or `Filter*` functions, and `var AuthZProvider authz.AuthZProviderType[UserGroupAuthZ]`
- use the interface's methods in API handlers
- add `internal/usergroups/authz_basic_impl.go` with interface implementation for basic OSS auth
- [IN EE ONLY] add `internal/usergroups/authz_rbac_impl.go` with RBAC authz.

In configuration, `security.authz` contains required `Type` field and optional `Fallback`:
- `Type` is the selected authz implementation
- `FallbackType` is an optional backup to be used when the selected implementation is not available *for some modules*, allowing us to partially implement RBAC authz on per-module basis, falling back to basic in the interim. It is likely this can also be removed at merge.

## Test Plan

Given admin user A, and normal users U1 and U2:
- with default config (or security -> authz -> type set to "basic")
    - A can change A, U1, and U2 passwords
    - U1 can change their own password
    - U1 cannot change A or U2 password
- with security -> authz -> type set to "unrestricted":
    - anyone can change anyone's password. yolo.

## Commentary (optional)

Some people call this "dependency injection" or "inversion of control".

## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.
- [ ] If modifying `/webui/react/src/shared/` verify `make -C webui/react test-shared` passes.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
