### PR TITLE
fix: agent entrypoint should use `exec`. [DET-7834]

### DIFF
--- a/agent/packaging/entrypoint.sh
+++ b/agent/packaging/entrypoint.sh
@@ -3,4 +3,4 @@
 chmod +x /usr/local/determined/container_startup_script
 /usr/local/determined/container_startup_script
 
-/usr/bin/determined-agent "$@"
+exec /usr/bin/determined-agent "$@"


### PR DESCRIPTION
## Description

Agent entrypoint shell script should use `exec`. This allows `SIGTERM` to be forwarded on container stop, which in order makes agent stop its fluentd.

Fixes #4565 

## Test Plan

1. `det deploy local cluster-up`
2. `det deploy cluster cluster-down` 
3. `docker ps`: there should be NO orphaned `determined-fluent` container.

## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.
- [ ] If modifying `/webui/react/src/shared/` verify `make -C webui/react test-shared` passes.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
