### PR TITLE
ci: long running det_deploy_local stress test to upstream

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2083,7 +2083,7 @@ jobs:
       - pull-task-images:
           tf1: True
 
-      - run-stress-test:
+      - run-det-deploy-tests:
           mark: <<parameters.mark>>
           det-version: <<parameters.det-version>>
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2053,6 +2053,40 @@ jobs:
           mark: <<parameters.mark>>
           det-version: <<parameters.det-version>>
 
+  test-stress:
+    parameters:
+      mark:
+        type: string
+      parallelism:
+        type: integer
+        default: 1
+      det-version:
+        type: string
+    machine:
+      image: <<pipeline.parameters.machine-image>>
+    resource_class: large
+    parallelism: <<parameters.parallelism>>
+    steps:
+      - checkout
+      - skip-if-docs-only
+      - skip-if-webui-only
+      - attach_workspace:
+          at: .
+      - run: docker load --input build/master.image
+      - run: docker load --input build/agent.image
+
+      - setup-python-venv:
+          determined: true
+          extra-requirements-file: "e2e_tests/tests/requirements.txt"
+          executor: <<pipeline.parameters.machine-image>>
+
+      - pull-task-images:
+          tf1: True
+
+      - run-stress-test:
+          mark: <<parameters.mark>>
+          det-version: <<parameters.det-version>>
+
   scan-docker-images:
     machine:
       image: <<pipeline.parameters.machine-image>>
@@ -2357,6 +2391,17 @@ workflows:
               environment-gpu-enabled: ["0"]
               slot-type: ["cpu"]
               slot-resource-requests-cpu: [7]
+
+      - test-stress:
+          name: test-stress
+          filters: *any-upstream
+          requires:
+            - package-and-push-system-local
+          matrix:
+            parameters:
+              parallelism: [1]
+              mark: ["stress_test"]
+              det-version: [$CIRCLE_SHA1]
 
       - test-det-deploy:
           name: test-det-deploy-local

--- a/e2e_tests/pytest.ini
+++ b/e2e_tests/pytest.ini
@@ -21,6 +21,7 @@ markers =
     deepspeed: DeepSpeedTrial tests
     nightly: nightly tests
     det_deploy_local: test det deploy local
+    stress_test: stress test for testing in a local environment
     managed_devcluster: cluster tests that require a pytest-side managed cluster
 junit_logging = all
 filterwarnings =

--- a/e2e_tests/tests/conftest.py
+++ b/e2e_tests/tests/conftest.py
@@ -26,6 +26,7 @@ _INTEG_MARKERS = {
     "e2e_cpu_elastic",
     "e2e_gpu",
     "det_deploy_local",
+    "stress_test",
     "distributed",
     "parallel",
     "nightly",

--- a/e2e_tests/tests/deploy/test_local.py
+++ b/e2e_tests/tests/deploy/test_local.py
@@ -271,7 +271,7 @@ def test_agent_up_down() -> None:
 @pytest.mark.parametrize("steps", [10])
 @pytest.mark.parametrize("num_agents", [3, 5])
 @pytest.mark.parametrize("should_disconnect", [False, True])
-@pytest.mark.det_deploy_local
+@pytest.mark.stress_test
 def test_stress_agents_reconnect(steps: int, num_agents: int, should_disconnect: bool) -> None:
     random.seed(42)
     master_host = "localhost"


### PR DESCRIPTION
## Description

This is the longest running e2e test so moving it to upstream improves CI build time. The test is also a stress test so not really needed to run on every PR.

## Test Plan

See this PR doesn't run the test and that this upstream commit ran ```test-stress``` https://github.com/determined-ai/determined/runs/7524411987


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.
- [ ] If modifying `/webui/react/src/shared/` verify `make -C webui/react test-shared` passes.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
