### PR TITLE
fix: comment to gen swagger [DET-7926]

### DIFF
--- a/master/internal/core_experiment.go
+++ b/master/internal/core_experiment.go
@@ -93,11 +93,11 @@ func (m *Master) getExperimentCheckpointsToGC(c echo.Context) (interface{}, erro
 // @ID get-experiment-model-file
 // @Accept  json
 // @Produce  text/plain; charset=utf-8
-// @Param   experiment_id query string true "Id of the experiment"
+// @Param   experiment_id path int  true  "Experiment ID"
 // @Param   path query string true "Path to the target file"
 // @Success 200 {} string ""
 //nolint:godot
-// @Router /experiment_id/file/download [get]
+// @Router /experiments/{experiment_id}/file/download [get]
 func (m *Master) getExperimentModelFile(c echo.Context) error {
 	args := struct {
 		ExperimentID int    `path:"experiment_id"`

--- a/webui/react/src/services/api-ts-sdk/api.ts
+++ b/webui/react/src/services/api-ts-sdk/api.ts
@@ -9854,12 +9854,12 @@ export const ExperimentsApiFetchParamCreator = function (configuration?: Configu
         /**
          * 
          * @summary Get individual file from modal definitions for download.
-         * @param {string} experimentId Id of the experiment
+         * @param {number} experimentId Experiment ID
          * @param {string} path Path to the target file
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        getExperimentModelFile(experimentId: string, path: string, options: any = {}): FetchArgs {
+        getExperimentModelFile(experimentId: number, path: string, options: any = {}): FetchArgs {
             // verify required parameter 'experimentId' is not null or undefined
             if (experimentId === null || experimentId === undefined) {
                 throw new RequiredError('experimentId','Required parameter experimentId was null or undefined when calling getExperimentModelFile.');
@@ -9868,7 +9868,8 @@ export const ExperimentsApiFetchParamCreator = function (configuration?: Configu
             if (path === null || path === undefined) {
                 throw new RequiredError('path','Required parameter path was null or undefined when calling getExperimentModelFile.');
             }
-            const localVarPath = `/experiment_id/file/download`;
+            const localVarPath = `/experiments/{experiment_id}/file/download`
+                .replace(`{${"experiment_id"}}`, encodeURIComponent(String(experimentId)));
             const localVarUrlObj = url.parse(localVarPath, true);
             const localVarRequestOptions = Object.assign({ method: 'GET' }, options);
             const localVarHeaderParameter = {} as any;
@@ -9880,10 +9881,6 @@ export const ExperimentsApiFetchParamCreator = function (configuration?: Configu
 					? configuration.apiKey("Authorization")
 					: configuration.apiKey;
                 localVarHeaderParameter["Authorization"] = localVarApiKeyValue;
-            }
-
-            if (experimentId !== undefined) {
-                localVarQueryParameter['experiment_id'] = experimentId;
             }
 
             if (path !== undefined) {
@@ -10970,12 +10967,12 @@ export const ExperimentsApiFp = function(configuration?: Configuration) {
         /**
          * 
          * @summary Get individual file from modal definitions for download.
-         * @param {string} experimentId Id of the experiment
+         * @param {number} experimentId Experiment ID
          * @param {string} path Path to the target file
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        getExperimentModelFile(experimentId: string, path: string, options?: any): (fetch?: FetchAPI, basePath?: string) => Promise<Response> {
+        getExperimentModelFile(experimentId: number, path: string, options?: any): (fetch?: FetchAPI, basePath?: string) => Promise<Response> {
             const localVarFetchArgs = ExperimentsApiFetchParamCreator(configuration).getExperimentModelFile(experimentId, path, options);
             return (fetch: FetchAPI = portableFetch, basePath: string = BASE_PATH) => {
                 return fetch(basePath + localVarFetchArgs.url, localVarFetchArgs.options).then((response) => {
@@ -11475,12 +11472,12 @@ export const ExperimentsApiFactory = function (configuration?: Configuration, fe
         /**
          * 
          * @summary Get individual file from modal definitions for download.
-         * @param {string} experimentId Id of the experiment
+         * @param {number} experimentId Experiment ID
          * @param {string} path Path to the target file
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        getExperimentModelFile(experimentId: string, path: string, options?: any) {
+        getExperimentModelFile(experimentId: number, path: string, options?: any) {
             return ExperimentsApiFp(configuration).getExperimentModelFile(experimentId, path, options)(fetch, basePath);
         },
         /**
@@ -11826,13 +11823,13 @@ export class ExperimentsApi extends BaseAPI {
     /**
      * 
      * @summary Get individual file from modal definitions for download.
-     * @param {string} experimentId Id of the experiment
+     * @param {number} experimentId Experiment ID
      * @param {string} path Path to the target file
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof ExperimentsApi
      */
-    public getExperimentModelFile(experimentId: string, path: string, options?: any) {
+    public getExperimentModelFile(experimentId: number, path: string, options?: any) {
         return ExperimentsApiFp(this.configuration).getExperimentModelFile(experimentId, path, options)(this.fetch, this.basePath);
     }
 


### PR DESCRIPTION
## Description

Before:
<img width="1451" alt="Screen Shot 2022-07-27 at 5 01 06 PM" src="https://user-images.githubusercontent.com/40620519/181380195-79feaeb3-8edc-49e7-b8dc-bdfb00304665.png">

After:
<img width="1435" alt="Screen Shot 2022-07-27 at 5 00 29 PM" src="https://user-images.githubusercontent.com/40620519/181380211-a3a7d705-8e5d-4539-bb39-08a7ded44dcd.png">


## Test Plan

Go to swagger page (click `API (Beta)` on the side navigation) and verify `/{experiment_id}/file/download` works as expected. 


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.
- [ ] If modifying `/webui/react/src/shared/` verify `make -C webui/react test-shared` passes.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
