### PR TITLE
fix: persist task state update in interactive task view [DET-7929]

### DIFF
--- a/webui/react/src/pages/Wait.tsx
+++ b/webui/react/src/pages/Wait.tsx
@@ -67,7 +67,6 @@ const Wait: React.FC = () => {
           return;
         }
         const lastRun = response.allocations[0];
-        window.parent.postMessage({ commandState: lastRun.state });
         if (!lastRun) {
           return;
         }


### PR DESCRIPTION
## Description

fix: persist task state update in interactive task view [DET-7929]

The previous implementation of tracking the `Command` state for the `InteractiveTask` did not fully solve the problem since the `Wait` page ultimately gets redirected and the `Command` state polling is stopped. Since the polling would stop users would not be notified of any `Command` state changes. 

The initial implementation was chosen as a way to avoid additional polling for the command state but this PR does add additional polling within the `InteractiveTask` component. The decision comes with two advantages: 

1. Now the `InteractiveTask` page will always receive the most up to date information about the appropriate task, and no longer depend on the `Wait` component,  which will be beneficial as more features are added to the page itself. 
2. The `Wait` component does eventually stop polling once a task is either `ready` or `terminated` so the dual polling only occurs for a short period of time meaning resources are not wasted for identical API calls.

  
<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At a minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan
 
1. Start a task ensure that during all tasks states the page title does not change while the tab in the browser is active.
2. Start a task and open another tab in the same browser, the page title for the original task tab should update to the most recent task state.
    - Ensure that when the task is `Running` the page title is the normal title "Tasks - Determined" 
    - Ensure once a task is terminated the page title is "Terminated"
Note: The task state is only updated every 2 seconds so if a state changes very rapidly you may not see the state change in the tab which is expected.

<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions about this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

Polling is configured to only occur ever `2` seconds. If we find this is not fast enough for the user we can update the configuration.

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.
- [ ] If modifying `/webui/react/src/shared/` verify `make -C webui/react test-shared` passes.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[DET-7929]: https://determinedai.atlassian.net/browse/DET-7929?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ