### PR TITLE
fix: allocation count should be source of truth for trial run id [DET-7953]

### DIFF
--- a/master/internal/db/database.go
+++ b/master/internal/db/database.go
@@ -76,8 +76,8 @@ type DB interface {
 	AddAllocation(a *model.Allocation) error
 	CompleteAllocation(a *model.Allocation) error
 	CompleteAllocationTelemetry(aID model.AllocationID) ([]byte, error)
-	TrialRunIDAndRestarts(trialID int) (int, int, error)
-	UpdateTrialRunID(id, runID int) error
+	TrialRestarts(trialID int) (int, error)
+	TaskRuns(model.TaskID) (int, error)
 	UpdateTrialRestarts(id, restarts int) error
 	AddTrainingMetrics(ctx context.Context, m *trialv1.TrialMetrics) error
 	AddValidationMetrics(

--- a/master/internal/mocks/db.go
+++ b/master/internal/mocks/db.go
@@ -1608,6 +1608,27 @@ func (_m *DB) StartUserSession(user *model.User) (string, error) {
 	return r0, r1
 }
 
+// TaskRuns provides a mock function with given fields: _a0
+func (_m *DB) TaskRuns(_a0 model.TaskID) (int, error) {
+	ret := _m.Called(_a0)
+
+	var r0 int
+	if rf, ok := ret.Get(0).(func(model.TaskID) int); ok {
+		r0 = rf(_a0)
+	} else {
+		r0 = ret.Get(0).(int)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(model.TaskID) error); ok {
+		r1 = rf(_a0)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // TemplateByName provides a mock function with given fields: name
 func (_m *DB) TemplateByName(name string) (model.Template, error) {
 	ret := _m.Called(name)
@@ -1954,8 +1975,8 @@ func (_m *DB) TrialLogsFields(trialID int) (*apiv1.TrialLogsFieldsResponse, erro
 	return r0, r1
 }
 
-// TrialRunIDAndRestarts provides a mock function with given fields: trialID
-func (_m *DB) TrialRunIDAndRestarts(trialID int) (int, int, error) {
+// TrialRestarts provides a mock function with given fields: trialID
+func (_m *DB) TrialRestarts(trialID int) (int, error) {
 	ret := _m.Called(trialID)
 
 	var r0 int
@@ -1965,21 +1986,14 @@ func (_m *DB) TrialRunIDAndRestarts(trialID int) (int, int, error) {
 		r0 = ret.Get(0).(int)
 	}
 
-	var r1 int
-	if rf, ok := ret.Get(1).(func(int) int); ok {
+	var r1 error
+	if rf, ok := ret.Get(1).(func(int) error); ok {
 		r1 = rf(trialID)
 	} else {
-		r1 = ret.Get(1).(int)
+		r1 = ret.Error(1)
 	}
 
-	var r2 error
-	if rf, ok := ret.Get(2).(func(int) error); ok {
-		r2 = rf(trialID)
-	} else {
-		r2 = ret.Error(2)
-	}
-
-	return r0, r1, r2
+	return r0, r1
 }
 
 // TrialState provides a mock function with given fields: trialID
@@ -2096,20 +2110,6 @@ func (_m *DB) UpdateTrialRestarts(id int, restarts int) error {
 	var r0 error
 	if rf, ok := ret.Get(0).(func(int, int) error); ok {
 		r0 = rf(id, restarts)
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
-}
-
-// UpdateTrialRunID provides a mock function with given fields: id, runID
-func (_m *DB) UpdateTrialRunID(id int, runID int) error {
-	ret := _m.Called(id, runID)
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func(int, int) error); ok {
-		r0 = rf(id, runID)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/master/internal/trial_test.go
+++ b/master/internal/trial_test.go
@@ -50,7 +50,6 @@ func TestTrial(t *testing.T) {
 
 	// Pre-allocated stage.
 	db.On("AddTrial", mock.Anything).Return(nil)
-	db.On("UpdateTrialRunID", 0, 1).Return(nil)
 	db.On("LatestCheckpointForTrial", 0).Return(&model.Checkpoint{}, nil)
 	require.NoError(t, system.Ask(tr.allocation, actors.ForwardThroughMock{
 		To:  self,
@@ -107,7 +106,6 @@ func TestTrialRestarts(t *testing.T) {
 		if i == 0 {
 			db.On("AddTrial", mock.Anything).Return(nil)
 		}
-		db.On("UpdateTrialRunID", 0, i+1).Return(nil)
 		db.On("LatestCheckpointForTrial", 0).Return(&model.Checkpoint{}, nil)
 		require.NoError(t, system.Ask(tr.allocation, actors.ForwardThroughMock{
 			To:  self,

--- a/master/pkg/opentelemetry/otel.go
+++ b/master/pkg/opentelemetry/otel.go
@@ -61,11 +61,10 @@ func newExporter(ctx context.Context, endpoint string) (*otlptrace.Exporter, err
 
 func newTraceProvider(exp *otlptrace.Exporter, serviceName string) *sdktrace.TracerProvider {
 	// The service.name attribute is required.
-	resource :=
-		resource.NewWithAttributes(
-			semconv.SchemaURL,
-			semconv.ServiceNameKey.String(serviceName),
-		)
+	resource := resource.NewWithAttributes(
+		semconv.SchemaURL,
+		semconv.ServiceNameKey.String(serviceName),
+	)
 
 	return sdktrace.NewTracerProvider(
 		sdktrace.WithBatcher(exp),

--- a/master/static/migrations/20220801142125_task-run-id.tx.down.sql
+++ b/master/static/migrations/20220801142125_task-run-id.tx.down.sql
@@ -1,0 +1,3 @@
+-- Since the migration was destructive, it cannot truly be undone.
+ALTER TABLE public.trials
+ADD COLUMN run_id integer NOT NULL DEFAULT 0;

--- a/master/static/migrations/20220801142125_task-run-id.tx.up.sql
+++ b/master/static/migrations/20220801142125_task-run-id.tx.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE public.trials
+DROP COLUMN run_id;


### PR DESCRIPTION
## Description
Allocation count must be the source of truth for trial run id since trial run id cannot be written, as is, until after it would be required.
<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At a minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan
- [x] run an experiment that will never schedule, restart the cluster. allocation shouldn't fail on restart.
<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions about this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)
I would just write the trial row first, but that impacts UX a lot, so I wanted to avoid making such a change so quickly.

Going to followup to remove trial run ID altogether shortly
<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.
- [ ] If modifying `/webui/react/src/shared/` verify `make -C webui/react test-shared` passes.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ