### PR TITLE
fix: word break in description

### DIFF
--- a/webui/react/src/components/InlineEditor.module.scss
+++ b/webui/react/src/components/InlineEditor.module.scss
@@ -13,6 +13,7 @@
      */
     display: grid;
     position: relative;
+    word-break: break-word;
   }
   .growWrap::after {
     /* Extra space needed to prevent jumpy behavior. */


### PR DESCRIPTION
## Description
I found that sentences in description are sometimes invisible when width is narrow and sentences are long.
Sentences should be always visible 
<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At a minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->

## Screenshots

### Before

https://user-images.githubusercontent.com/109113616/182296754-9b0c0136-1909-4903-860d-3d43cc76d876.mov

### After

https://user-images.githubusercontent.com/109113616/182296648-db2b52db-377c-4efa-895b-829aceb29481.mov


## Test Plan
- Check if sentences are visible in any length and type of sentences and description width
<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions about this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)
Description in experiment detail has 500 letters limit but the one in experiment list doesnt. Should we add one?
<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.
- [ ] If modifying `/webui/react/src/shared/` verify `make -C webui/react test-shared` passes.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ