### PR TITLE
chore: Remove unnecessary imports and fields in proto

### DIFF
--- a/proto/src/determined/api/v1/experiment.proto
+++ b/proto/src/determined/api/v1/experiment.proto
@@ -33,7 +33,7 @@ message GetExperimentRequest {
 // Response to GetExperimentRequest.
 message GetExperimentResponse {
   option (grpc.gateway.protoc_gen_swagger.options.openapiv2_schema) = {
-    json_schema: { required: [ "experiment", "config" ] }
+    json_schema: { required: [ "experiment" ] }
   };
   // The requested experiment.
   determined.experiment.v1.Experiment experiment = 1;

--- a/proto/src/determined/api/v1/notebook.proto
+++ b/proto/src/determined/api/v1/notebook.proto
@@ -7,7 +7,6 @@ import "google/protobuf/struct.proto";
 
 import "determined/api/v1/pagination.proto";
 import "determined/notebook/v1/notebook.proto";
-import "determined/log/v1/log.proto";
 import "determined/util/v1/util.proto";
 import "protoc-gen-swagger/options/annotations.proto";
 

--- a/proto/src/determined/api/v1/task.proto
+++ b/proto/src/determined/api/v1/task.proto
@@ -4,8 +4,6 @@ package determined.api.v1;
 option go_package = "github.com/determined-ai/determined/proto/pkg/apiv1";
 
 import "google/protobuf/timestamp.proto";
-import "google/protobuf/struct.proto";
-import "google/protobuf/wrappers.proto";
 import "determined/checkpoint/v1/checkpoint.proto";
 import "determined/api/v1/pagination.proto";
 import "determined/task/v1/task.proto";

--- a/proto/src/determined/experiment/v1/searcher.proto
+++ b/proto/src/determined/experiment/v1/searcher.proto
@@ -4,7 +4,6 @@ package determined.experiment.v1;
 option go_package = "github.com/determined-ai/determined/proto/pkg/experimentv1";
 
 import "google/protobuf/struct.proto";
-import "protoc-gen-swagger/options/annotations.proto";
 
 // ValidateAfterOperation means the trial should train and validate after
 // training the given length.

--- a/proto/src/determined/user/v1/user.proto
+++ b/proto/src/determined/user/v1/user.proto
@@ -1,5 +1,4 @@
 syntax = "proto3";
-import "google/protobuf/struct.proto";
 import "google/protobuf/timestamp.proto";
 import "google/protobuf/wrappers.proto";
 import "protoc-gen-swagger/options/annotations.proto";


### PR DESCRIPTION
## Description

Trent pointed out that a removed field is still marked as "required" in the proto, which this fixes. I used this opportunity to clean up unused imports which have show up as warnings on `make -C proto build`

## Checklist

- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.
- [x] If modifying `/webui/react/src/shared/` verify `make -C webui/react test-shared` passes.