### PR TITLE
fix: record operations at the right places around shutting down

### DIFF
--- a/master/pkg/searcher/random_test.go
+++ b/master/pkg/searcher/random_test.go
@@ -103,3 +103,18 @@ func TestSingleSearchMethod(t *testing.T) {
 
 	runValueSimulationTestCases(t, testCases)
 }
+
+func TestRandomSearcherSingleConcurrent(t *testing.T) {
+	actual := expconf.RandomConfig{
+		RawMaxTrials:           ptrs.Ptr(2),
+		RawMaxLength:           ptrs.Ptr(expconf.NewLengthInRecords(100)),
+		RawMaxConcurrentTrials: ptrs.Ptr(1),
+	}
+	actual = schemas.WithDefaults(actual).(expconf.RandomConfig)
+	expected := [][]ValidateAfter{
+		toOps("100R"),
+		toOps("100R"),
+	}
+	search := newRandomSearch(actual)
+	checkSimulation(t, search, nil, ConstantValidation, expected)
+}

--- a/master/pkg/searcher/searcher.go
+++ b/master/pkg/searcher/searcher.go
@@ -142,11 +142,12 @@ func (s *Searcher) TrialClosed(requestID model.RequestID) ([]Operation, error) {
 	if err != nil {
 		return nil, errors.Wrapf(err, "error while handling a trial closed event: %s", requestID)
 	}
+	s.Record(operations)
 	if s.TrialsRequested == len(s.TrialsClosed) {
 		shutdown := Shutdown{Failure: len(s.Failures) >= s.TrialsRequested}
+		s.Record([]Operation{shutdown})
 		operations = append(operations, shutdown)
 	}
-	s.Record(operations)
 	return operations, nil
 }
 


### PR DESCRIPTION
## Description

The `s.Record` call was previously moved after the `if` block so that
the `Shutdown` operation was correctly recorded. However, this meant
that, running, e.g., random search with `max_concurrent_trials = 1`
would shut down after one trial, since the request to create the next
trial would not be counted in the check. So we simply have to record the
other operations first and then the `Shutdown` separately.

## Test Plan

- [x] test manually
- [x] add test
