### PR TITLE
ci: add helm repo [infeng 1]

### DIFF
--- a/.github/workflows/publish-helm.yml
+++ b/.github/workflows/publish-helm.yml
@@ -15,6 +15,7 @@ on:  # yamllint disable-line rule:truthy
 
   job:
     publish:
+      if: github.repository == "determined-ai/determined"
       runs-on: ubuntu-latest
       permissions:
         contents: write
@@ -22,13 +23,13 @@ on:  # yamllint disable-line rule:truthy
         NEW_CHART_DIR: /tmp/newchart
       steps:
         # figure out release ID based on how we were run
-        - if: ${{ github.event_name == "release" }}
+        - if: github.event_name == "release"
           run: |
             # does github.event have the id in it already?  Hmm...
             #API=repos/{{ github.repository }}/releases/latest
             #gh api $API -q -q '"rel_id=" + (.id|tostring)' >> $GITHUB_ENV
             printf 'rel_id={{ github.event.release.id }}\n' >> $GITHUB_ENV
-        - if: ${{ github.event_name == "workflow-dispatch" }}
+        - if: github.event_name == "workflow-dispatch"
           run: |
             API=repos/{{ github.repository }}/releases/latest/{{ inputs.tag }}
             gh api $API -q -q '"rel_id=" + (.id|tostring)' >> $GITHUB_ENV
@@ -62,9 +63,11 @@ on:  # yamllint disable-line rule:truthy
         # TODO: consider also publishing to artifact hub
         - name: update index
           run: |
-            helm repo index "$NEW_CHART_DIR" --merge index.yaml
+            helm repo index "$NEW_CHART_DIR" --merge index.yaml --url=replaceme
             diff {"$NEW_CHART_DIR",.}/index.yaml
-            cp -v "$NEW_CHART_DIR"/index.yaml .
+            sed "s|replaceme.*|${CHART_URL}|" \
+              < "$NEW_CHART_DIR"/index.yaml \
+              > index.yaml
         - name: replace chart file with redirect
           shell: python
           run: |

--- a/.github/workflows/publish-helm.yml
+++ b/.github/workflows/publish-helm.yml
@@ -1,0 +1,56 @@
+---
+name: publish-helm-chart
+
+on:  # yamllint disable-line rule:truthy
+  workflow-dispatch:
+    inputs:
+      tag:
+        description: "Release Tag"
+        required: "true"
+        default: "0.0.0"
+        type: string
+  release:
+    types:
+      - published
+
+  job:
+    publish:
+      runs-on: ubuntu-latest
+      permissions:
+        contents: write
+      steps:
+        - if: ${{ github.event_name == "release" }}
+          run: |
+            # does github.event have the id in it already?  Hmm...
+            APISTR=repos/{{ github.repository }}/releases/latest
+            gh api $APISTR -q -q '"rel_id=" + (.id|tostring)' >> $GITHUB_ENV
+        - if: ${{ github.event_name == "workflow-dispatch" }}
+          run: |
+            APISTR=repos/{{ github.repository }}/releases/latest/{{ inputs.tag }}
+            gh api $APISTR -q -q '"rel_id=" + (.id|tostring)' >> $GITHUB_ENV
+        - uses: actions/checkout@v3.0.2
+          with:
+            ref: helm-chart-repository
+        - name: get chart artifact
+          run: |
+            ASSET_URL=$( \
+              gh api "${rel_id}/assets"
+              -q '.[] | select(.name|test("determined-helm-chart.*")) | .url' \
+              )
+            CHART_NAME=$( gh api $ASSET_URL -q '.name | sub("-helm-chart";"")' )
+            gh api -H "Accept: application/octet-stream" "$ASSET_URL" \
+              > "$CHART_NAME"
+            printf 'CHART_NAME=%s' "$CHART_NAME" >> $GITHUB_ENV
+            printf 'CHART_URL=%s' \
+              "$( gh api "$ASSET_URL" -q '.browser_download_url')" >> $GITHUB_ENV
+
+        - name: update index
+          # helm repo index . --merge index.yaml
+        - name: replace chart file with redirect
+          # https://stackoverflow.com/questions/39657226/jekyll-redirect-link
+        - name: commit back
+
+# if release
+#  get current release
+# else
+#  find release corresponding to tag?

--- a/.github/workflows/publish-helm.yml
+++ b/.github/workflows/publish-helm.yml
@@ -18,39 +18,74 @@ on:  # yamllint disable-line rule:truthy
       runs-on: ubuntu-latest
       permissions:
         contents: write
+      env:
+        NEW_CHART_DIR: /tmp/newchart
       steps:
+        # figure out release ID based on how we were run
         - if: ${{ github.event_name == "release" }}
           run: |
             # does github.event have the id in it already?  Hmm...
-            APISTR=repos/{{ github.repository }}/releases/latest
-            gh api $APISTR -q -q '"rel_id=" + (.id|tostring)' >> $GITHUB_ENV
+            #APISTR=repos/{{ github.repository }}/releases/latest
+            #gh api $APISTR -q -q '"rel_id=" + (.id|tostring)' >> $GITHUB_ENV
+            printf 'rel_id={{ github.event.release.id }}\n' >> $GITHUB_ENV
         - if: ${{ github.event_name == "workflow-dispatch" }}
           run: |
             APISTR=repos/{{ github.repository }}/releases/latest/{{ inputs.tag }}
             gh api $APISTR -q -q '"rel_id=" + (.id|tostring)' >> $GITHUB_ENV
-        - uses: actions/checkout@v3.0.2
+
+        # get the artifact for the chart and the branch for pages (the chart repo)
+        - name: check out chart repo branch
+          uses: actions/checkout@v3.0.2
           with:
             ref: helm-chart-repository
         - name: get chart artifact
           run: |
+            NEW_CHART_DIR=$( mktemp -d )
+            pushd "$NEW_CHART_DIR"
             ASSET_URL=$( \
               gh api "${rel_id}/assets"
               -q '.[] | select(.name|test("determined-helm-chart.*")) | .url' \
               )
-            CHART_NAME=$( gh api $ASSET_URL -q '.name | sub("-helm-chart";"")' )
+            #CHART_NAME=$( gh api $ASSET_URL -q '.name | sub("-helm-chart";"")' )
+            CHART_NAME=$( gh api $ASSET_URL -q .name )
             gh api -H "Accept: application/octet-stream" "$ASSET_URL" \
               > "$CHART_NAME"
-            printf 'CHART_NAME=%s' "$CHART_NAME" >> $GITHUB_ENV
-            printf 'CHART_URL=%s' \
+            popd
+            printf 'NEW_CHART_DIR=%s\n' "$NEW_CHART_DIR" >> $GITHUB_ENV
+            printf 'CHART_NAME=%s\n' "$CHART_NAME" >> $GITHUB_ENV
+            printf 'CHART_URL=%s\n' \
               "$( gh api "$ASSET_URL" -q '.browser_download_url')" >> $GITHUB_ENV
 
+        # publish to GH Pages repository
+        # TODO: consider also publishing to artifact hub
         - name: update index
-          # helm repo index . --merge index.yaml
+          run: |
+            helm repo index "$NEW_CHART_DIR" --merge index.yaml
+            diff {"$NEW_CHART_DIR",.}/index.yaml
+            cp -v "$NEW_CHART_DIR"/index.yaml .
         - name: replace chart file with redirect
-          # https://stackoverflow.com/questions/39657226/jekyll-redirect-link
-        - name: commit back
+          shell: python
+          run: |
+            from os import environ
+            from os.path import basename
+            from string import Template
 
-# if release
-#  get current release
-# else
-#  find release corresponding to tag?
+            chart_basename = basename( environ.get( 'CHART_NAME' )
+            environ['CHART_PERMALINK'] = '/' + chart_basename
+            with open('redirect_template.yaml', 'r') as src:
+              t = Template(src.read())
+
+            with open(chart_basename, 'w') as dst:
+              dst.write( t.safe_substitute(environ) )
+
+            with open( environ.get('GITHUB_ENV'), 'w+' ) as envfile:
+              envfile.write( f'CHART_REDIR_FILE={chart_basename}' )
+        - name: commit back
+          run: |
+            git add "$CHART_REDIR_FILE"
+            # extract version from Chart.yaml
+            v=$( tar xOzf $CHART_NAME --wildcards '*/Chart.yaml' \
+              | sed -n 's/^version: *//ip' )
+            msg="Add chart '$v' due to {{ github.event_name }}"
+            git commit index.yaml CHART_REDIR_FILE -m "$msg"
+            git push

--- a/.github/workflows/publish-helm.yml
+++ b/.github/workflows/publish-helm.yml
@@ -25,15 +25,15 @@ on:  # yamllint disable-line rule:truthy
         - if: ${{ github.event_name == "release" }}
           run: |
             # does github.event have the id in it already?  Hmm...
-            #APISTR=repos/{{ github.repository }}/releases/latest
-            #gh api $APISTR -q -q '"rel_id=" + (.id|tostring)' >> $GITHUB_ENV
+            #API=repos/{{ github.repository }}/releases/latest
+            #gh api $API -q -q '"rel_id=" + (.id|tostring)' >> $GITHUB_ENV
             printf 'rel_id={{ github.event.release.id }}\n' >> $GITHUB_ENV
         - if: ${{ github.event_name == "workflow-dispatch" }}
           run: |
-            APISTR=repos/{{ github.repository }}/releases/latest/{{ inputs.tag }}
-            gh api $APISTR -q -q '"rel_id=" + (.id|tostring)' >> $GITHUB_ENV
+            API=repos/{{ github.repository }}/releases/latest/{{ inputs.tag }}
+            gh api $API -q -q '"rel_id=" + (.id|tostring)' >> $GITHUB_ENV
 
-        # get the artifact for the chart and the branch for pages (the chart repo)
+        # get the artifact for the chart and the branch for the chart repo
         - name: check out chart repo branch
           uses: actions/checkout@v3.0.2
           with:
@@ -46,15 +46,17 @@ on:  # yamllint disable-line rule:truthy
               gh api "${rel_id}/assets"
               -q '.[] | select(.name|test("determined-helm-chart.*")) | .url' \
               )
-            #CHART_NAME=$( gh api $ASSET_URL -q '.name | sub("-helm-chart";"")' )
+            #CHART_NAME=$( gh api $ASSET_URL -q '.name|sub("-helm-chart";"")' )
             CHART_NAME=$( gh api $ASSET_URL -q .name )
             gh api -H "Accept: application/octet-stream" "$ASSET_URL" \
               > "$CHART_NAME"
             popd
-            printf 'NEW_CHART_DIR=%s\n' "$NEW_CHART_DIR" >> $GITHUB_ENV
-            printf 'CHART_NAME=%s\n' "$CHART_NAME" >> $GITHUB_ENV
-            printf 'CHART_URL=%s\n' \
-              "$( gh api "$ASSET_URL" -q '.browser_download_url')" >> $GITHUB_ENV
+            {
+              printf 'NEW_CHART_DIR=%s\n' "$NEW_CHART_DIR"
+              printf 'CHART_NAME=%s\n' "$CHART_NAME"
+              printf 'CHART_URL=%s\n' \
+                "$( gh api "$ASSET_URL" -q '.browser_download_url')"
+            } >> $GITHUB_ENV
 
         # publish to GH Pages repository
         # TODO: consider also publishing to artifact hub


### PR DESCRIPTION
## Description

Add an action to update the GH pages-hosted helm chart repo with the new chart when a new release is cut.  Backwards compatibility workflow-dispatch trigger also included to retrofit previous releases.


## Test Plan

Run it manually and hope the world doesn't burn.


## Commentary (optional)

This is gross because I'm a sysadmin and sysadmins can only write gross, mostly-functional scripts. :bomb:  Commit messages are also gross because I figured it'd be easier to wait until merge time to squash them into something better instead of bothering with rebase. :D 


## Checklist

- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.
- [x] If modifying `/webui/react/src/shared/` verify `make -C webui/react test-shared` passes.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
