### PR TITLE
fix: deepspeedtrial validation batch size computation

### DIFF
--- a/harness/determined/pytorch/deepspeed/_deepspeed_trial.py
+++ b/harness/determined/pytorch/deepspeed/_deepspeed_trial.py
@@ -187,7 +187,7 @@ class DeepSpeedTrialController(det.TrialController):
             # like a DataLoader but is not.
             self.validation_loader = cast(torch.utils.data.DataLoader, self.validation_loader)
             self.num_validation_batches = len(self.validation_loader)
-            self.validation_batch_size = len(next(iter(self.validation_loader)))
+            self.validation_batch_size = pytorch.data_length(next(iter(self.validation_loader)))
 
             if self.context.use_pipeline_parallel:
                 self.num_validation_batches = (


### PR DESCRIPTION
## Description
We were computing the batch size for a sample from the validation loader incorrectly; the previous way did not account for batch structure (e.g. list, dictionary, etc).  This resulted in incorrect tracking of records when we logged validation timing info.  


## Test Plan
Tested locally.

## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.
- [ ] If modifying `/webui/react/src/shared/` verify `make -C webui/react test-shared` passes.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
