### PR TITLE
fix: Incompatible variable type fixed

### DIFF
--- a/harness/determined/cli/command.py
+++ b/harness/determined/cli/command.py
@@ -267,7 +267,7 @@ def parse_config_overrides(config: Dict[str, Any], overrides: Iterable[str]) -> 
                 "Expecting:\n{}".format(config_arg, CONFIG_DESC)
             )
 
-        key, value = config_arg.split("=", maxsplit=1)  # type: Tuple[str, Any]
+        key, value = config_arg.split("=", maxsplit=1)
 
         # Separate values if a comma exists. Use yaml.load() to cast
         # the value(s) to the type YAML would use, e.g., "4" -> 4.


### PR DESCRIPTION
**"filename"**: "harness/determined/cli/command.py"
**"warning_type"**: "Incompatible variable type [9]",
**"warning_message"**: " Unable to unpack `str`, expected a tuple.",
**"warning_line"**: 270,
**"fix"**: remove type