### PR TITLE
fix: tensorboard metrics step count [DET-8028]

### DIFF
--- a/harness/determined/tensorboard/metric_writers/callback.py
+++ b/harness/determined/tensorboard/metric_writers/callback.py
@@ -41,7 +41,7 @@ class BatchMetricWriter:
         # Log all batch metrics.
         if batch_metrics:
             for batch_idx, batch in enumerate(batch_metrics):
-                batches_seen = steps_completed - len(batch) + batch_idx
+                batches_seen = steps_completed - len(batch_metrics) + batch_idx
                 for name, value in batch.items():
                     self._maybe_write_metric(name, value, batches_seen)
                     metrics_seen.add(name)


### PR DESCRIPTION
## Description

Metrics writer was computing step count incorrectly resulting in bad tensorboard charts (see ticket for screenshots).

## Test Plan

- run `mnist_pytorch/const.yaml` or `mnist_pytorch/distributed.yaml` experiment
- open tensorboard, zoom in on `loss` chart, ensure there're no artifacts.

## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.
- [ ] If modifying `/webui/react/src/shared/` verify `make -C webui/react test-shared` passes.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
