### PR TITLE
fix: add unit to custom searcher config

### DIFF
--- a/e2e_tests/tests/experiment/test_custom_searcher.py
+++ b/e2e_tests/tests/experiment/test_custom_searcher.py
@@ -91,6 +91,7 @@ def test_run_random_searcher_exp() -> None:
         "name": "custom",
         "metric": "validation_error",
         "smaller_is_better": True,
+        "unit": "batches",
     }
     config["description"] = "custom searcher"
 

--- a/harness/determined/common/schemas/expconf/_gen.py
+++ b/harness/determined/common/schemas/expconf/_gen.py
@@ -2663,10 +2663,6 @@ schemas = {
             "default": true
         },
         "unit": {
-            "type": [
-                "string",
-                "null"
-            ],
             "enum": [
                 "batches",
                 "records",
@@ -3097,7 +3093,8 @@ schemas = {
         "source_trial_id": true,
         "source_checkpoint_uuid": true,
         "budget": true,
-        "train_stragglers": true
+        "train_stragglers": true,
+        "unit": true
     }
 }
 

--- a/harness/determined/common/schemas/expconf/_gen.py
+++ b/harness/determined/common/schemas/expconf/_gen.py
@@ -2661,6 +2661,19 @@ schemas = {
                 "null"
             ],
             "default": true
+        },
+        "unit": {
+            "type": [
+                "string",
+                "null"
+            ],
+            "enum": [
+                "batches",
+                "records",
+                "epochs",
+                null
+            ],
+            "default": null
         }
     }
 }

--- a/harness/determined/common/schemas/expconf/_v0.py
+++ b/harness/determined/common/schemas/expconf/_v0.py
@@ -463,6 +463,13 @@ class AdaptiveMode(enum.Enum):
     AGGRESSIVE = "aggressive"
 
 
+@schemas.register_known_type
+class Unit(enum.Enum):
+    BATCHES = "batches"
+    EPOCHS = "epochs"
+    RECORDS = "records"
+
+
 class SearcherConfigV0(schemas.UnionBase):
     _id = "http://determined.ai/schemas/expconf/v0/searcher.json"
     _union_key = "name"
@@ -494,12 +501,14 @@ class CustomConfigV0(schemas.SchemaBase):
     _id = "http://determined.ai/schemas/expconf/v0/searcher-custom.json"
     metric: str
     smaller_is_better: Optional[bool] = None
+    unit: Optional[Unit] = None
 
     @schemas.auto_init
     def __init__(
         self,
         metric: str,
         smaller_is_better: Optional[bool] = None,
+        unit: Optional[Unit] = None,
     ) -> None:
         pass
 

--- a/harness/determined/core/_searcher.py
+++ b/harness/determined/core/_searcher.py
@@ -1,6 +1,6 @@
 import enum
 import logging
-from typing import Iterator, Optional, Any
+from typing import Any, Iterator, Optional
 
 import determined as det
 from determined import core

--- a/harness/determined/core/_searcher.py
+++ b/harness/determined/core/_searcher.py
@@ -1,6 +1,6 @@
 import enum
 import logging
-from typing import Iterator, Optional
+from typing import Iterator, Optional, Any
 
 import determined as det
 from determined import core
@@ -17,10 +17,17 @@ class Unit(enum.Enum):
 
 def _parse_searcher_units(experiment_config: dict) -> Optional[Unit]:
     searcher = experiment_config.get("searcher", {})
+
+    def convert_key(key: Any) -> Optional[Unit]:
+        return {"records": Unit.RECORDS, "epochs": Unit.EPOCHS, "batches": Unit.BATCHES}.get(key)
+
+    if "unit" in searcher:
+        return convert_key(searcher["unit"])
+
     length_example = searcher.get("max_length")
     if isinstance(length_example, dict) and len(length_example) == 1:
         key = next(iter(length_example.keys()))
-        return {"records": Unit.RECORDS, "epochs": Unit.EPOCHS, "batches": Unit.BATCHES}.get(key)
+        return convert_key(key)
     # Either a `max_length: 50` situation or a broken config.
     return None
 

--- a/master/pkg/schemas/expconf/length.go
+++ b/master/pkg/schemas/expconf/length.go
@@ -16,7 +16,7 @@ type Unit string
 const (
 	Records     Unit = "records"
 	Batches     Unit = "batches"
-	Epochs      Unit = "epoches"
+	Epochs      Unit = "epochs"
 	Unitless    Unit = "unitless"
 	Unspecified Unit = "unspecified"
 )

--- a/master/pkg/schemas/expconf/searcher_config.go
+++ b/master/pkg/schemas/expconf/searcher_config.go
@@ -78,6 +78,7 @@ func (s SearcherConfigV0) Unit() Unit {
 //go:generate ../gen.sh
 // CustomConfigV0 configures a custom search.
 type CustomConfigV0 struct {
+	RawUnit *Unit `json:"unit"`
 }
 
 //go:generate ../gen.sh

--- a/master/pkg/schemas/expconf/zgen_custom_config_v0.go
+++ b/master/pkg/schemas/expconf/zgen_custom_config_v0.go
@@ -8,6 +8,14 @@ import (
 	"github.com/determined-ai/determined/master/pkg/schemas"
 )
 
+func (c CustomConfigV0) Unit() *Unit {
+	return c.RawUnit
+}
+
+func (c *CustomConfigV0) SetUnit(val *Unit) {
+	c.RawUnit = val
+}
+
 func (c CustomConfigV0) ParsedSchema() interface{} {
 	return schemas.ParsedCustomConfigV0()
 }

--- a/master/pkg/schemas/zgen_schemas.go
+++ b/master/pkg/schemas/zgen_schemas.go
@@ -2500,6 +2500,19 @@ var (
                 "null"
             ],
             "default": true
+        },
+        "unit": {
+            "type": [
+                "string",
+                "null"
+            ],
+            "enum": [
+                "batches",
+                "records",
+                "epochs",
+                null
+            ],
+            "default": null
         }
     }
 }

--- a/master/pkg/schemas/zgen_schemas.go
+++ b/master/pkg/schemas/zgen_schemas.go
@@ -2502,10 +2502,6 @@ var (
             "default": true
         },
         "unit": {
-            "type": [
-                "string",
-                "null"
-            ],
             "enum": [
                 "batches",
                 "records",
@@ -2912,7 +2908,8 @@ var (
         "source_trial_id": true,
         "source_checkpoint_uuid": true,
         "budget": true,
-        "train_stragglers": true
+        "train_stragglers": true,
+        "unit": true
     }
 }
 `)

--- a/schemas/expconf/v0/searcher-custom.json
+++ b/schemas/expconf/v0/searcher-custom.json
@@ -27,6 +27,15 @@
                 "null"
             ],
             "default": true
+        },
+        "unit": {
+            "enum": [
+                "batches",
+                "records",
+                "epochs",
+                null
+            ],
+            "default": null
         }
     }
 }

--- a/schemas/expconf/v0/searcher.json
+++ b/schemas/expconf/v0/searcher.json
@@ -87,6 +87,7 @@
         "source_trial_id": true,
         "source_checkpoint_uuid": true,
         "budget": true,
-        "train_stragglers": true
+        "train_stragglers": true,
+        "unit": true
     }
 }


### PR DESCRIPTION
## Description

Trials require the unit to be specified. All searchers have it included in MaxLength but custom searcher does not.

### Background
We noticed that after I removed max_length from the custom searcher configuration (because it is not supposed to be required), the custom searcher test started only running a single batch in each trial. Furthermore, the following message appeared in the trial logs:

```
root: The searcher configuration provided was configured without units, but the training loop you are using (one of the Trial APIs) requires a searcher configured with units.  Proceeding anyway, and assuming that the lengths configured in the searcher are in terms of epochs.
```

Trials quietly default to epochs as a unit.

## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions about this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.
- [ ] If modifying `/webui/react/src/shared/` verify `make -C webui/react test-shared` passes.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
