### PR TITLE
chore: Use bindings.v1File instead of ContextItem

### DIFF
--- a/e2e_tests/tests/cluster/test_users_experiment_api.py
+++ b/e2e_tests/tests/cluster/test_users_experiment_api.py
@@ -17,7 +17,7 @@ def test_experimental_experiment_api_determined_disabled() -> None:
     context_path = pathlib.Path(conf.fixtures_path("no_op"))
     model_def_path = pathlib.Path(conf.fixtures_path("no_op/single-medium-train-step.yaml"))
 
-    model_context = context.Context.from_local(context_path)
+    model_context = context.read_legacy_context(context_path)
 
     with model_def_path.open("r") as fin:
         dai_experiment_config = util.safe_load_yaml_with_exceptions(fin)

--- a/harness/determined/cli/command.py
+++ b/harness/determined/cli/command.py
@@ -330,7 +330,7 @@ def launch_command(
 ) -> Any:
     user_files = []  # type: List[Dict[str, Any]]
     if context_path:
-        user_files, _ = context.read_context(context_path)
+        user_files = context.read_legacy_context(context_path)
 
     body = {}  # type: Dict[str, Any]
     if default_body:

--- a/harness/determined/cli/experiment.py
+++ b/harness/determined/cli/experiment.py
@@ -134,7 +134,7 @@ def _parse_config_file_or_exit(config_file: io.FileIO, config_overrides: Iterabl
 @authentication.required
 def submit_experiment(args: Namespace) -> None:
     experiment_config = _parse_config_file_or_exit(args.config_file, args.config)
-    model_context = context.Context.from_local(args.model_def, constants.MAX_CONTEXT_SIZE)
+    model_context = context.read_legacy_context(args.model_def)
 
     additional_body_fields = {}
     if args.git:

--- a/harness/determined/cli/notebook.py
+++ b/harness/determined/cli/notebook.py
@@ -8,10 +8,9 @@ from termcolor import colored
 from determined.cli import command, render, task
 from determined.cli.session import setup_session
 from determined.cli.util import format_args
-from determined.common import api
+from determined.common import api, context
 from determined.common.api import authentication, bindings, request
 from determined.common.check import check_eq
-from determined.common.context import Context
 from determined.common.declarative_argparse import Arg, Cmd, Group
 
 from .command import CONFIG_DESC, CONTEXT_DESC, VOLUME_DESC, parse_config, render_event_stream
@@ -21,21 +20,7 @@ from .command import CONFIG_DESC, CONTEXT_DESC, VOLUME_DESC, parse_config, rende
 def start_notebook(args: Namespace) -> None:
     config = parse_config(args.config_file, None, args.config, args.volume)
 
-    files = None
-    if args.context is not None:
-        context = Context.from_local(args.context)
-        files = [
-            bindings.v1File(
-                content=e.content.decode("utf-8"),
-                gid=e.gid,
-                mode=e.mode,
-                mtime=e.mtime,
-                path=e.path,
-                type=e.type,
-                uid=e.uid,
-            )
-            for e in context.entries
-        ]
+    files = args.context and context.read_v1_context(args.context)
     body = bindings.v1LaunchNotebookRequest(
         config=config, files=files, preview=args.preview, templateName=args.template
     )

--- a/harness/determined/cli/tensorboard.py
+++ b/harness/determined/cli/tensorboard.py
@@ -8,7 +8,7 @@ from termcolor import colored
 
 from determined.cli import command, task
 from determined.cli.util import format_args
-from determined.common import api, constants, context
+from determined.common import api, context
 from determined.common.api import authentication, request
 from determined.common.check import check_eq
 from determined.common.declarative_argparse import Arg, Cmd, Group
@@ -30,7 +30,7 @@ def start_tensorboard(args: Namespace) -> None:
     }
 
     if args.context is not None:
-        req_body["files"], _ = context.read_context(args.context, constants.MAX_CONTEXT_SIZE)
+        req_body["files"] = context.read_legacy_context(args.context)
 
     resp = api.post(args.master, "api/v1/tensorboards", json=req_body).json()["tensorboard"]
 

--- a/harness/determined/common/api/experiment.py
+++ b/harness/determined/common/api/experiment.py
@@ -120,7 +120,7 @@ def follow_test_experiment_logs(master_url: str, exp_id: int) -> None:
 def create_experiment(
     master_url: str,
     config: Dict[str, Any],
-    model_context: context.Context,
+    model_context: context.LegacyContext,
     template: Optional[str] = None,
     validate_only: bool = False,
     archived: bool = False,
@@ -130,7 +130,7 @@ def create_experiment(
     body = {
         "activate": False,
         "experiment_config": yaml.safe_dump(config),
-        "model_definition": [e.dict() for e in model_context.entries],
+        "model_definition": model_context,
         "validate_only": validate_only,
     }
     if template:
@@ -233,7 +233,7 @@ def make_test_experiment_config(config: Dict[str, Any]) -> Dict[str, Any]:
 def create_experiment_and_follow_logs(
     master_url: str,
     config: Dict[str, Any],
-    model_context: context.Context,
+    model_context: context.LegacyContext,
     template: Optional[str] = None,
     additional_body_fields: Optional[Dict[str, Any]] = None,
     activate: bool = True,
@@ -256,7 +256,7 @@ def create_experiment_and_follow_logs(
 def create_test_experiment_and_follow_logs(
     master_url: str,
     config: Dict[str, Any],
-    model_context: context.Context,
+    model_context: context.LegacyContext,
     template: Optional[str] = None,
     additional_body_fields: Optional[Dict[str, Any]] = None,
 ) -> int:

--- a/harness/determined/common/context.py
+++ b/harness/determined/common/context.py
@@ -1,223 +1,171 @@
 import base64
-import collections
 import os
 import pathlib
 import tarfile
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List
 
 import pathspec
 
-from determined.common import check, constants
+from determined.common import constants
+from determined.common.api import bindings
 from determined.common.util import sizeof_fmt
 
-
-class ContextItem:
-    """
-    ContextItem wraps the content and metadata of a file or a directory.
-    """
-
-    def __init__(self, path: str):
-        self.path = path
-        self.type = ord(tarfile.REGTYPE)
-        self.uid = 0
-        self.gid = 0
-        self.content = bytes()
-        self.mtime = -1
-        self.mode = -1
-
-    @property
-    def size(self) -> int:
-        if self.content:
-            # The content is already base64-encoded, and we want the real length.
-            return len(self.content) // 4 * 3
-        return 0
-
-    def dict(self) -> Dict[str, Any]:
-        d = {"path": self.path, "type": self.type, "uid": self.uid, "gid": self.gid}
-        if self.type in (ord(tarfile.REGTYPE), ord(tarfile.DIRTYPE)):
-            d["content"] = self.content
-        if self.mtime != -1:
-            d["mtime"] = self.mtime
-        if self.mode != -1:
-            d["mode"] = self.mode
-        return d
-
-    @classmethod
-    def from_content_str(cls, path: str, content: str) -> "ContextItem":
-        context_item = ContextItem(path)
-        context_item.type = ord(tarfile.REGTYPE)
-        context_item.content = base64.b64encode(content.encode("utf-8"))
-        return context_item
-
-    @classmethod
-    def from_local_file(cls, path: str, local_path: pathlib.Path) -> "ContextItem":
-        context_item = ContextItem(path)
-        context_item.type = ord(tarfile.REGTYPE)
-        context_item.mtime = int(local_path.stat().st_mtime)
-        context_item.mode = local_path.stat().st_mode
-        with local_path.open("rb") as f:
-            content = f.read()
-            context_item.content = base64.b64encode(content)
-        return context_item
-
-    @classmethod
-    def from_local_dir(cls, path: str, local_path: pathlib.Path) -> "ContextItem":
-        context_item = ContextItem(path)
-        context_item.type = ord(tarfile.DIRTYPE)
-        context_item.mtime = int(local_path.stat().st_mtime)
-        context_item.mode = local_path.stat().st_mode
-        return context_item
+LegacyContext = List[Dict[str, Any]]
 
 
-class Context:
-    """
-    Context wraps the content and metadata of a collection of files and directories.
-    """
-
-    def __init__(self) -> None:
-        self._items = {}  # type: Dict[str, ContextItem]
-        self._size = 0
-
-    def __len__(self) -> int:
-        return len(self._items)
-
-    @property
-    def size(self) -> int:
-        return self._size
-
-    @property
-    def entries(self) -> collections.abc.ValuesView:
-        return self._items.values()
-
-    def add_item(self, entry: ContextItem) -> None:
-        self._items[entry.path] = entry
-        self._size += entry.size
-
-    @classmethod
-    def from_local(
-        cls,
-        local_path: pathlib.Path,
-        limit: int = constants.MAX_CONTEXT_SIZE,
-    ) -> "Context":
-        """
-        Given the path to a local directory, return a Context object.
-
-        A .detignore file in the directory, if specified, indicates the wildcard paths
-        that should be ignored. File paths are represented as relative paths (relative to
-        the root directory).
-        """
-
-        context = Context()
-        local_path = local_path.resolve()
-
-        if not local_path.exists():
-            raise Exception("Path '{}' doesn't exist".format(local_path))
-
-        if local_path.is_file():
-            raise ValueError("Path '{}' must be a directory".format(local_path))
-
-        root_path = local_path
-
-        ignore = list(constants.DEFAULT_DETIGNORE)
-        ignore_path = root_path.joinpath(".detignore")
-        if ignore_path.is_file():
-            with ignore_path.open("r") as detignore_file:
-                ignore.extend(detignore_file)
-        ignore_spec = pathspec.PathSpec.from_lines(pathspec.patterns.GitWildMatchPattern, ignore)
-
-        msg = "Preparing files (in {}) to send to master... {} and {} files".format(
-            root_path, sizeof_fmt(0), 0
-        )
-        print(msg, end="\r", flush=True)
-
-        # We could use pathlib.Path.rglob for scanning the directory;
-        # however, the Python documentation claims a warning that rglob may be
-        # inefficient on large directory trees, so we use the older os.walk().
-        for parent, dirs, files in os.walk(str(root_path)):
-            for directory in dirs:
-                dir_path = pathlib.Path(parent).joinpath(directory)
-                dir_rel_path = dir_path.relative_to(root_path)
-
-                # If the file matches any path specified in .detignore, then ignore it.
-                if ignore_spec.match_file(str(dir_rel_path) + "/"):
-                    continue
-
-                # Determined only supports POSIX-style file paths.  Use as_posix() in case this code
-                # is executed in a non-POSIX environment.
-                entry_path = dir_rel_path.as_posix()
-
-                context.add_item(ContextItem.from_local_dir(entry_path, dir_path))
-
-            for file in files:
-                file_path = pathlib.Path(parent).joinpath(file)
-                file_rel_path = file_path.relative_to(root_path)
-
-                # If the file is the .detignore file or matches one of the
-                # paths specified in .detignore, then ignore it.
-                if file_rel_path.name == ".detignore":
-                    continue
-                if ignore_spec.match_file(str(file_rel_path)):
-                    continue
-
-                # Determined only supports POSIX-style file paths.  Use as_posix() in case this code
-                # is executed in a non-POSIX environment.
-                entry_path = file_rel_path.as_posix()
-
-                try:
-                    entry = ContextItem.from_local_file(entry_path, file_path)
-                except OSError:
-                    print("Error reading '{}', skipping this file.".format(entry_path))
-                    continue
-
-                context.add_item(entry)
-                if context.size > limit:
-                    print()
-                    raise ValueError(
-                        "Directory '{}' exceeds the maximum allowed size {}.\n"
-                        "Consider using a .detignore file to specify that certain files "
-                        "or directories should be omitted from the model.".format(
-                            root_path, sizeof_fmt(constants.MAX_CONTEXT_SIZE)
-                        )
-                    )
-
-                print(" " * len(msg), end="\r")
-                msg = "Preparing files ({}) to send to master... {} and {} files".format(
-                    root_path, sizeof_fmt(context.size), len(context)
-                )
-                print(msg, end="\r", flush=True)
-        print()
-        return context
+def v1File_size(f: bindings.v1File) -> int:
+    if f.content:
+        # The content is already base64-encoded, and we want the real length.
+        return len(f.content) // 4 * 3
+    return 0
 
 
-def read_context(
+def v1File_to_dict(f: bindings.v1File) -> Dict[str, Any]:
+    d = {
+        "path": f.path,
+        "type": f.type,
+        "uid": f.uid,
+        "gid": f.gid,
+        # Echo API expects int-type int64 value
+        "mtime": int(f.mtime),
+        "mode": f.mode,
+    }
+    if f.type in (ord(tarfile.REGTYPE), ord(tarfile.DIRTYPE)):
+        d["content"] = f.content
+    return d
+
+
+def v1File_from_local_file(path: str, local_path: pathlib.Path) -> bindings.v1File:
+    with local_path.open("rb") as f:
+        content = base64.b64encode(f.read()).decode("utf8")
+    st = local_path.stat()
+    return bindings.v1File(
+        path=path,
+        type=ord(tarfile.REGTYPE),
+        content=content,
+        # Protobuf expects string-encoded int64
+        mtime=str(int(st.st_mtime)),
+        mode=st.st_mode,
+        uid=0,
+        gid=0,
+    )
+
+
+def v1File_from_local_dir(path: str, local_path: pathlib.Path) -> bindings.v1File:
+    st = local_path.stat()
+    return bindings.v1File(
+        path=path,
+        type=ord(tarfile.DIRTYPE),
+        content="",
+        # Protobuf expects string-encoded int64
+        mtime=str(int(st.st_mtime)),
+        mode=st.st_mode,
+        uid=0,
+        gid=0,
+    )
+
+
+def read_v1_context(
     local_path: pathlib.Path,
     limit: int = constants.MAX_CONTEXT_SIZE,
-) -> Tuple[List[Dict[str, Any]], int]:
-    context = Context.from_local(local_path, limit)
-    return [e.dict() for e in context.entries], context.size
-
-
-def read_single_file(file_path: Optional[pathlib.Path]) -> Tuple[bytes, int]:
+) -> List[bindings.v1File]:
     """
-    Given a path to a file, return the base64-encoded contents of the file and its original size.
+    Return a list of v1Files suitable for submitting a context directory over the v1 REST API.
+
+    A .detignore file in the directory, if specified, indicates the wildcard paths
+    that should be ignored. File paths are represented as relative paths (relative to
+    the root directory).
     """
-    if not file_path:
-        return b"", 0
 
-    check.check_true(file_path.is_file(), 'The file at "{}" could not be found'.format(file_path))
+    items = []
+    size = 0
 
-    content = file_path.read_bytes()
+    def add_item(f: bindings.v1File) -> None:
+        nonlocal size
+        items.append(f)
+        size += v1File_size(f)
 
-    return base64.b64encode(content), len(content)
+    local_path = local_path.resolve()
+
+    if not local_path.exists():
+        raise Exception(f"Path '{local_path}' doesn't exist")
+
+    if local_path.is_file():
+        raise ValueError(f"Path '{local_path}' must be a directory")
+
+    root_path = local_path
+
+    ignore = list(constants.DEFAULT_DETIGNORE)
+    ignore_path = root_path.joinpath(".detignore")
+    if ignore_path.is_file():
+        with ignore_path.open("r") as detignore_file:
+            ignore.extend(detignore_file)
+    ignore_spec = pathspec.PathSpec.from_lines(pathspec.patterns.GitWildMatchPattern, ignore)
+
+    msg = f"Preparing files (in {root_path}) to send to master... {sizeof_fmt(0)} and {0} files"
+    print(msg, end="\r", flush=True)
+
+    # We could use pathlib.Path.rglob for scanning the directory;
+    # however, the Python documentation claims a warning that rglob may be
+    # inefficient on large directory trees, so we use the older os.walk().
+    for parent, dirs, files in os.walk(str(root_path)):
+        for directory in dirs:
+            dir_path = pathlib.Path(parent).joinpath(directory)
+            dir_rel_path = dir_path.relative_to(root_path)
+
+            # If the file matches any path specified in .detignore, then ignore it.
+            if ignore_spec.match_file(str(dir_rel_path) + "/"):
+                continue
+
+            # Determined only supports POSIX-style file paths.  Use as_posix() in case this code
+            # is executed in a non-POSIX environment.
+            entry_path = dir_rel_path.as_posix()
+
+            add_item(v1File_from_local_dir(entry_path, dir_path))
+
+        for file in files:
+            file_path = pathlib.Path(parent).joinpath(file)
+            file_rel_path = file_path.relative_to(root_path)
+
+            # If the file is the .detignore file or matches one of the
+            # paths specified in .detignore, then ignore it.
+            if file_rel_path.name == ".detignore":
+                continue
+            if ignore_spec.match_file(str(file_rel_path)):
+                continue
+
+            # Determined only supports POSIX-style file paths.  Use as_posix() in case this code
+            # is executed in a non-POSIX environment.
+            entry_path = file_rel_path.as_posix()
+
+            try:
+                entry = v1File_from_local_file(entry_path, file_path)
+            except OSError:
+                print(f"Error reading '{entry_path}', skipping this file.")
+                continue
+
+            add_item(entry)
+            if size > limit:
+                print()
+                raise ValueError(
+                    f"Directory '{root_path}' exceeds the maximum allowed size "
+                    f"{sizeof_fmt(constants.MAX_CONTEXT_SIZE)}.\n"
+                    "Consider using a .detignore file to specify that certain files "
+                    "or directories should be omitted from the context directory."
+                )
+
+            print(" " * len(msg), end="\r")
+            msg = (
+                f"Preparing files ({root_path}) to send to master... "
+                f"{sizeof_fmt(size)} and {len(items)} files"
+            )
+            print(msg, end="\r", flush=True)
+    print()
+    return items
 
 
-def get_invalid_model_def_path_message() -> str:
-    """
-    get_invalid_model_def_path_message is used by get_all_file_entries to generate an appropriate
-    error message to display when a user tries to create an experiment using a model definition
-    contained in a directory whose name conflicts with the Determined package name
-    (i.e. "determined").
-
-    The function is also used in test_cli.py::test_create_reject_bad_path.
-    """
-    return 'A model definition cannot be contained in a directory named "determined"'
+def read_legacy_context(
+    local_path: pathlib.Path,
+    limit: int = constants.MAX_CONTEXT_SIZE,
+) -> LegacyContext:
+    return [v1File_to_dict(f) for f in read_v1_context(local_path, limit)]

--- a/harness/determined/common/util.py
+++ b/harness/determined/common/util.py
@@ -9,7 +9,7 @@ from typing import IO, Any, Callable, Iterator, Optional, Sequence, TypeVar, Uni
 
 from determined.common import yaml
 
-yaml = yaml.YAML(typ="safe", pure=True)  # type: ignore
+_yaml = yaml.YAML(typ="safe", pure=True)
 
 T = TypeVar("T")
 
@@ -80,7 +80,7 @@ def preserve_random_state(fn: Callable) -> Callable:
     return wrapped
 
 
-def safe_load_yaml_with_exceptions(yaml_file: Union[io.FileIO, IO[Any]]) -> Any:
+def safe_load_yaml_with_exceptions(yaml_file: Union[io.FileIO, IO[Any], str]) -> Any:
     """Attempts to use ruamel.yaml.safe_load on the specified file. If successful, returns
     the output. If not, formats a ruamel.yaml Exception so that the user does not see a traceback
     of our internal APIs.
@@ -111,14 +111,14 @@ def safe_load_yaml_with_exceptions(yaml_file: Union[io.FileIO, IO[Any]]) -> Any:
     ---------------------------------------------------------------------------------------------
     """
     try:
-        config = yaml.load(yaml_file)
+        config = _yaml.load(yaml_file)
     except (
         yaml.error.MarkedYAMLWarning,
         yaml.error.MarkedYAMLError,
         yaml.error.MarkedYAMLFutureWarning,
     ) as e:
         err_msg = (
-            f"Error: invalid experiment config file {yaml_file.name!r}.\n"
+            f"Error: invalid experiment config file.\n"
             f"{e.__class__.__name__}: {e.problem}\n{e.problem_mark}"
         )
         print(err_msg)

--- a/harness/tests/cli/test_cli.py
+++ b/harness/tests/cli/test_cli.py
@@ -125,21 +125,21 @@ def test_create_reject_large_model_def(requests_mock: requests_mock.Mocker, tmp_
 
 def test_read_context(tmp_path: Path) -> None:
     with FileTree(tmp_path, {"A.py": "", "B.py": "", "C.py": ""}) as tree:
-        model_def, _ = context.read_context(tree)
+        model_def = context.read_legacy_context(tree)
         assert {f["path"] for f in model_def} == {"A.py", "B.py", "C.py"}
 
 
 def test_read_context_with_detignore(tmp_path: Path) -> None:
     with FileTree(tmp_path, {"A.py": "", "B.py": "", "C.py": ""}) as tree:
-        model_def, _ = context.read_context(tree)
+        model_def = context.read_legacy_context(tree)
         assert {f["path"] for f in model_def} == {"A.py", "B.py", "C.py"}
 
     with FileTree(tmp_path, {"A.py": "", "B.py": "", "C.py": "", ".detignore": "\nA.py\n"}) as tree:
-        model_def, size = context.read_context(tree)
+        model_def = context.read_legacy_context(tree)
         assert {f["path"] for f in model_def} == {"B.py", "C.py"}
 
     with FileTree(tmp_path, {"A.py": "", "B.py": "", "C.py": "", ".detignore": "\n*.py\n"}) as tree:
-        model_def, size = context.read_context(tree)
+        model_def = context.read_legacy_context(tree)
         assert model_def == []
 
 
@@ -153,7 +153,7 @@ def test_read_context_with_detignore_subdirs(tmp_path: Path) -> None:
             Path("subdir").joinpath("B.py"): "",
         },
     ) as tree:
-        model_def, _ = context.read_context(tree)
+        model_def = context.read_legacy_context(tree)
         assert {f["path"] for f in model_def} == {
             "A.py",
             "B.py",
@@ -172,7 +172,7 @@ def test_read_context_with_detignore_subdirs(tmp_path: Path) -> None:
             Path("subdir").joinpath("B.py"): "",
         },
     ) as tree:
-        model_def, size = context.read_context(tree)
+        model_def = context.read_legacy_context(tree)
         assert {f["path"] for f in model_def} == {"B.py", "subdir", "subdir/B.py"}
 
     with FileTree(
@@ -185,7 +185,7 @@ def test_read_context_with_detignore_subdirs(tmp_path: Path) -> None:
             ".detignore": "\nsubdir/A.py\n",
         },
     ) as tree:
-        model_def, size = context.read_context(tree)
+        model_def = context.read_legacy_context(tree)
         assert {f["path"] for f in model_def} == {"A.py", "B.py", "subdir", "subdir/B.py"}
 
     with FileTree(
@@ -198,14 +198,14 @@ def test_read_context_with_detignore_subdirs(tmp_path: Path) -> None:
             ".detignore": "\n*.py\n",
         },
     ) as tree:
-        model_def, size = context.read_context(tree)
+        model_def = context.read_legacy_context(tree)
         assert len(model_def) == 1
 
     with FileTree(
         tmp_path,
         {"A.py": "", "B.py": "", "subdir/A.py": "", "subdir/B.py": "", ".detignore": "\nsubdir\n"},
     ) as tree:
-        model_def, size = context.read_context(tree)
+        model_def = context.read_legacy_context(tree)
         assert {f["path"] for f in model_def} == {"A.py", "B.py"}
 
     with FileTree(
@@ -218,7 +218,7 @@ def test_read_context_with_detignore_subdirs(tmp_path: Path) -> None:
             ".detignore": "\nsubdir/\n",
         },
     ) as tree:
-        model_def, size = context.read_context(tree)
+        model_def = context.read_legacy_context(tree)
         assert {f["path"] for f in model_def} == {"A.py", "B.py"}
 
 
@@ -232,7 +232,7 @@ def test_read_context_ignore_pycaches(tmp_path: Path) -> None:
             "subdir/__pycache__/A.cpython-37.pyc": "",
         },
     ) as tree:
-        model_def, _ = context.read_context(tree)
+        model_def = context.read_legacy_context(tree)
         assert {f["path"] for f in model_def} == {"A.py", "subdir", "subdir/A.py"}
 
 

--- a/master/internal/core_experiment.go
+++ b/master/internal/core_experiment.go
@@ -378,14 +378,10 @@ func (m *Master) parseCreateExperiment(params *CreateExperimentParams, user *mod
 	taskSpec.Owner = user
 
 	// Place experiment in Uncategorized, unless project set in config or CreateExperimentParams
-	// CreateExperimentParams has highest priority (coming from WebUI)
+	// CreateExperimentParams has highest priority.
 	projectID := 1
 	if params.ProjectID == nil {
-		if config.Workspace() == "" && config.Project() != "" {
-			return nil, false, nil,
-				errors.New("workspace and project must both be included in config if one is provided")
-		}
-		if config.Workspace() != "" && config.Project() == "" {
+		if (config.Workspace() == "") != (config.Project() == "") {
 			return nil, false, nil,
 				errors.New("workspace and project must both be included in config if one is provided")
 		}


### PR DESCRIPTION
This is an early part of a larger refactor.  Overall, the goal is to
move away from handcrafted API requests towards using the generated
bindings.

One blocker to that effort is that the creation of context directories
is definitely based on the handcrafted APIs.

Additionally, the context loading code has grown "crusty" over time; it
involved a lot of bandaid-style coversions between old and new formats,
in addition to the fact that a Context class existed, but it didn't
really do anything.  This PR focuses on migrating to a bindings-native
storage structure and reducing overall "crustiness".