### PR TITLE
test: Fix cluster utils cluster_slots() API

### DIFF
--- a/e2e_tests/tests/cluster/utils.py
+++ b/e2e_tests/tests/cluster/utils.py
@@ -20,10 +20,10 @@ def cluster_slots() -> Dict[str, Any]:
     # TODO: refactor tests to not use cli singleton auth.
     certs.cli_cert = certs.default_load(conf.make_master_url())
     authentication.cli_auth = authentication.Authentication(conf.make_master_url(), try_reauth=True)
-    r = api.get(conf.make_master_url(), "agents")
+    r = api.get(conf.make_master_url(), "api/v1/agents")
     assert r.status_code == requests.codes.ok, r.text
-    json = r.json()  # type: Dict[str, Any]
-    return {agent["id"]: agent["slots"].values() for agent in json.values()}
+    jvals = r.json()  # type: Dict[str, Any]
+    return {agent["id"]: agent["slots"].values() for agent in jvals["agents"]}
 
 
 def get_master_port(loaded_config: dict) -> str:


### PR DESCRIPTION
## Description

Fix the cluster utils cluster_slots()  agents url, and properly
reference the agents dict within the response.
This code was apparently not exercised without custom
resource pools defined during the test?

## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions about this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.
- [ ] If modifying `/webui/react/src/shared/` verify `make -C webui/react test-shared` passes.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
