### PR TITLE
chore: promote Session to a first-class citizen

### DIFF
--- a/e2e_tests/tests/cluster/test_logging.py
+++ b/e2e_tests/tests/cluster/test_logging.py
@@ -6,7 +6,6 @@ import pytest
 from determined.cli import command
 from determined.common import api
 from determined.common.api import authentication, bindings, certs
-from determined.common.experimental import session
 from tests import config as conf
 from tests import experiment as exp
 
@@ -59,7 +58,7 @@ def test_task_logs(task_type: str, task_config: Dict[str, Any], log_regex: Any) 
     authentication.cli_auth = authentication.Authentication(conf.make_master_url(), try_reauth=True)
 
     rps = bindings.get_GetResourcePools(
-        session.Session(master_url, "determined", authentication.cli_auth, certs.cli_cert)
+        api.Session(master_url, "determined", authentication.cli_auth, certs.cli_cert)
     )
     assert rps.resourcePools and len(rps.resourcePools) > 0, "missing resource pool"
 

--- a/e2e_tests/tests/cluster/test_users.py
+++ b/e2e_tests/tests/cluster/test_users.py
@@ -14,9 +14,8 @@ import pexpect
 import pytest
 from pexpect import spawn
 
-from determined.common import constants, yaml
+from determined.common import api, constants, yaml
 from determined.common.api import authentication, bindings, certs, errors
-from determined.common.experimental import session
 from tests import command
 from tests import config as conf
 from tests import experiment as exp
@@ -193,7 +192,7 @@ def test_post_user_api(clean_auth: None) -> None:
     user = bindings.v1User(active=True, admin=False, username=new_username)
     body = bindings.v1PostUserRequest(password="", user=user)
     resp = bindings.post_PostUser(
-        session.Session(master_url, "admin", authentication.cli_auth, None), body=body
+        api.Session(master_url, "admin", authentication.cli_auth, None), body=body
     )
     assert resp.to_json()["user"]["username"] == new_username
 
@@ -908,7 +907,7 @@ def test_change_displayname(clean_auth: None) -> None:
     authentication.cli_auth = authentication.Authentication(
         conf.make_master_url(), requested_user=original_name, password="", try_reauth=True
     )
-    sess = session.Session(master_url, original_name, authentication.cli_auth, certs.cli_cert)
+    sess = api.Session(master_url, original_name, authentication.cli_auth, certs.cli_cert)
 
     # Get API bindings object for the created test user
     all_users = bindings.get_GetUsers(sess).users

--- a/e2e_tests/tests/cluster/test_workspace_org.py
+++ b/e2e_tests/tests/cluster/test_workspace_org.py
@@ -2,8 +2,8 @@ from typing import List
 
 import pytest
 
+from determined.common import api
 from determined.common.api import authentication, bindings, errors
-from determined.common.experimental import session
 from tests import config as conf
 from tests.cluster.test_users import ADMIN_CREDENTIALS
 from tests.experiment import run_basic_test, wait_for_experiment_state
@@ -13,11 +13,11 @@ from tests.experiment import run_basic_test, wait_for_experiment_state
 def test_workspace_org() -> None:
     master_url = conf.make_master_url()
     authentication.cli_auth = authentication.Authentication(master_url, try_reauth=True)
-    sess = session.Session(master_url, None, None, None)
+    sess = api.Session(master_url, None, None, None)
     admin_auth = authentication.Authentication(
         master_url, ADMIN_CREDENTIALS.username, ADMIN_CREDENTIALS.password, try_reauth=True
     )
-    admin_sess = session.Session(master_url, ADMIN_CREDENTIALS.username, admin_auth, None)
+    admin_sess = api.Session(master_url, ADMIN_CREDENTIALS.username, admin_auth, None)
 
     test_experiments: List[bindings.v1Experiment] = []
     test_projects: List[bindings.v1Project] = []

--- a/e2e_tests/tests/experiment/experiment.py
+++ b/e2e_tests/tests/experiment/experiment.py
@@ -12,7 +12,6 @@ import pytest
 from determined.common import api, yaml
 from determined.common.api import authentication, bindings, certs
 from determined.common.api.bindings import determinedexperimentv1State
-from determined.common.experimental import session
 from tests import config as conf
 from tests.cluster import utils as cluster_utils
 
@@ -198,11 +197,11 @@ def experiment_first_trial(exp_id: int) -> int:
     return trial_id
 
 
-def determined_test_session() -> session.Session:
+def determined_test_session() -> api.Session:
     murl = conf.make_master_url()
     certs.cli_cert = certs.default_load(murl)
     authentication.cli_auth = authentication.Authentication(murl, try_reauth=True)
-    return session.Session(murl, "determined", authentication.cli_auth, certs.cli_cert)
+    return api.Session(murl, "determined", authentication.cli_auth, certs.cli_cert)
 
 
 def experiment_config_json(experiment_id: int) -> Dict[str, Any]:

--- a/e2e_tests/tests/nightly/compute_stats.py
+++ b/e2e_tests/tests/nightly/compute_stats.py
@@ -6,8 +6,8 @@ from typing import Any, Dict, Tuple
 
 from dateutil import parser
 
+from determined.common import api
 from determined.common.api import authentication, bindings, certs
-from determined.common.experimental import session
 from tests import config as conf
 
 ADD_KEY = "adding"
@@ -91,11 +91,11 @@ def fetch_master_log() -> bool:
     return True
 
 
-def create_test_session() -> session.Session:
+def create_test_session() -> api.Session:
     murl = conf.make_master_url()
     certs.cli_cert = certs.default_load(murl)
     authentication.cli_auth = authentication.Authentication(murl, try_reauth=True)
-    return session.Session(murl, "determined", authentication.cli_auth, certs.cli_cert)
+    return api.Session(murl, "determined", authentication.cli_auth, certs.cli_cert)
 
 
 def compare_stats() -> None:

--- a/harness/determined/cli/job.py
+++ b/harness/determined/cli/job.py
@@ -9,9 +9,9 @@ import yaml
 from determined.cli import render
 from determined.cli.session import setup_session
 from determined.cli.util import format_args, pagination_args_fetchone
+from determined.common import api
 from determined.common.api import authentication, bindings
 from determined.common.declarative_argparse import Arg, Cmd, Group
-from determined.common.experimental import Session
 
 
 @authentication.required
@@ -98,7 +98,7 @@ def process_updates(args: Namespace) -> None:
 
 def _single_update(
     job_id: str,
-    session: Session,
+    session: api.Session,
     priority: str = "",
     weight: str = "",
     resource_pool: str = "",

--- a/harness/determined/cli/project.py
+++ b/harness/determined/cli/project.py
@@ -4,10 +4,10 @@ from time import sleep
 from typing import Any, Dict, List, Sequence, Tuple
 
 from determined.cli.session import setup_session
+from determined.common import api
 from determined.common.api import authentication, bindings, errors
 from determined.common.api.bindings import v1Experiment, v1Project, v1Workspace
 from determined.common.declarative_argparse import Arg, Cmd
-from determined.common.experimental import session
 
 from . import render
 from .workspace import list_workspace_projects, pagination_args, workspace_by_name
@@ -60,7 +60,7 @@ def render_project(project: v1Project) -> None:
 
 
 def project_by_name(
-    sess: session.Session, workspace_name: str, project_name: str
+    sess: api.Session, workspace_name: str, project_name: str
 ) -> Tuple[v1Workspace, v1Project]:
     w = workspace_by_name(sess, workspace_name)
     p = bindings.get_GetWorkspaceProjects(sess, id=w.id, name=project_name).projects

--- a/harness/determined/cli/session.py
+++ b/harness/determined/cli/session.py
@@ -1,12 +1,11 @@
 from argparse import Namespace
 
-from determined.common import util
+from determined.common import api, util
 from determined.common.api import authentication, certs
-from determined.common.experimental import session
 
 
-def setup_session(args: Namespace) -> session.Session:
+def setup_session(args: Namespace) -> api.Session:
     master_url = args.master or util.get_default_master_address()
     cert = certs.default_load(master_url)
 
-    return session.Session(master_url, args.user, authentication.cli_auth, cert)
+    return api.Session(master_url, args.user, authentication.cli_auth, cert)

--- a/harness/determined/cli/util.py
+++ b/harness/determined/cli/util.py
@@ -1,7 +1,7 @@
 from typing import Any, Callable, Dict, List, Optional
 
+from determined.common import api
 from determined.common.declarative_argparse import Arg
-from determined.common.experimental import session
 
 format_args: Dict[str, Arg] = {
     "json": Arg(
@@ -71,7 +71,7 @@ pagination_args_fetchall = make_pagination_args_fetchall()
 def limit_offset_paginator(
     method: Callable,
     agg_field: str,
-    sess: session.Session,
+    sess: api.Session,
     limit: int = 200,
     offset: Optional[int] = None,
     **kwargs: Any,

--- a/harness/determined/cli/workspace.py
+++ b/harness/determined/cli/workspace.py
@@ -4,10 +4,10 @@ from time import sleep
 from typing import Any, List, Sequence
 
 from determined.cli.session import setup_session
+from determined.common import api
 from determined.common.api import authentication, bindings, errors
 from determined.common.api.bindings import v1Workspace
 from determined.common.declarative_argparse import Arg, Cmd
-from determined.common.experimental import session
 
 from . import render
 
@@ -27,7 +27,7 @@ def render_workspaces(workspaces: Sequence[v1Workspace]) -> None:
     render.tabulate_or_csv(WORKSPACE_HEADERS, values, False)
 
 
-def workspace_by_name(sess: session.Session, name: str) -> v1Workspace:
+def workspace_by_name(sess: api.Session, name: str) -> v1Workspace:
     w = bindings.get_GetWorkspaces(sess, name=name).workspaces
     if len(w) == 0:
         raise errors.EmptyResultException(f'Did not find a workspace with name "{name}".')

--- a/harness/determined/common/__init__.py
+++ b/harness/determined/common/__init__.py
@@ -4,5 +4,6 @@ except ModuleNotFoundError:
     # Inexplicably, sometimes ruamel.yaml is pacakged as ruamel_yaml instead.
     import ruamel_yaml as yaml  # type: ignore
 
-from . import api, check, constants, context, requests, storage, util
-from ._logging import set_logger
+from determined.common import util
+from determined.common import api, check, constants, context, requests, storage
+from determined.common._logging import set_logger

--- a/harness/determined/common/api/__init__.py
+++ b/harness/determined/common/api/__init__.py
@@ -1,5 +1,6 @@
 from determined.common.api import authentication, errors, metric, request
-from determined.common.api.authentication import Authentication, Session, salt_and_hash
+from determined.common.api._session import Session
+from determined.common.api.authentication import Authentication, salt_and_hash
 from determined.common.api.experiment import (
     create_experiment,
     create_experiment_and_follow_logs,

--- a/harness/determined/common/api/_session.py
+++ b/harness/determined/common/api/_session.py
@@ -1,5 +1,3 @@
-import json
-import os
 from typing import Any, Dict, Optional
 
 import requests
@@ -7,34 +5,6 @@ import urllib3
 
 from determined.common import util
 from determined.common.api import authentication, certs, request
-
-
-def get_max_retries_config() -> urllib3.util.retry.Retry:
-    # Allow overriding retry settings when necessary.
-    # `DET_RETRY_CONFIG` env variable can contain `urllib3` `Retry` parameters,
-    # encoded as JSON.
-    # For example:
-    #  - disable retries: {"total":0}
-    #  - shorten the wait times {"total":10,"backoff_factor":0.5,"method_whitelist":false}
-
-    config_data = os.environ.get("DET_RETRY_CONFIG")
-    if config_data is not None:
-        config = json.loads(config_data)
-        return urllib3.util.retry.Retry(**config)
-
-    # Defaults.
-    try:
-        return urllib3.util.retry.Retry(
-            total=20,
-            backoff_factor=0.5,
-            allowed_methods=False,
-        )
-    except TypeError:  # Support urllib3 prior to 1.26
-        return urllib3.util.retry.Retry(
-            total=20,
-            backoff_factor=0.5,
-            method_whitelist=False,  # type: ignore
-        )
 
 
 class Session:

--- a/harness/determined/common/api/authentication.py
+++ b/harness/determined/common/api/authentication.py
@@ -32,7 +32,7 @@ def salt_and_hash(password: str) -> str:
         return password
 
 
-class Session:
+class UsernameTokenPair:
     def __init__(self, username: str, token: str):
         self.username = username
         self.token = token
@@ -58,7 +58,7 @@ class Authentication:
         password: Optional[str],
         try_reauth: bool,
         cert: Optional[certs.Cert],
-    ) -> Session:
+    ) -> UsernameTokenPair:
         session_user = (
             requested_user
             or self.token_store.get_active_user()
@@ -87,7 +87,7 @@ class Authentication:
             token = util.get_det_user_token_from_env()
 
         if token is not None:
-            return Session(session_user, token)
+            return UsernameTokenPair(session_user, token)
 
         if token is None and not try_reauth:
             raise api.errors.UnauthenticatedException(username=session_user)
@@ -113,7 +113,7 @@ class Authentication:
 
         self.token_store.set_token(session_user, token)
 
-        return Session(session_user, token)
+        return UsernameTokenPair(session_user, token)
 
     def is_user_active(self, username: str) -> bool:
         return self.token_store.get_active_user() == username

--- a/harness/determined/common/api/experiment.py
+++ b/harness/determined/common/api/experiment.py
@@ -10,7 +10,6 @@ from termcolor import colored
 from determined.common import api, constants, context, yaml
 from determined.common.api import bindings, logs
 from determined.common.api import request as req
-from determined.common.experimental import session
 
 
 def patch_experiment(master_url: str, exp_id: int, patch_doc: Dict[str, Any]) -> None:
@@ -22,7 +21,7 @@ def patch_experiment(master_url: str, exp_id: int, patch_doc: Dict[str, Any]) ->
 def follow_experiment_logs(master_url: str, exp_id: int) -> None:
     # Get the ID of this experiment's first trial (i.e., the one with the lowest ID).
     print("Waiting for first trial to begin...")
-    sess = session.Session(master_url, None, None, None)
+    sess = api.Session(master_url, None, None, None)
     while True:
         trials = bindings.get_GetExperimentTrials(sess, experimentId=exp_id).trials
         if len(trials) > 0:
@@ -64,7 +63,7 @@ def follow_test_experiment_logs(master_url: str, exp_id: int) -> None:
             else:
                 print(", ", end="")
 
-    sess = session.Session(master_url, None, None, None)
+    sess = api.Session(master_url, None, None, None)
     while True:
         r = bindings.get_GetExperiment(sess, experimentId=exp_id).experiment
         trials = bindings.get_GetExperimentTrials(sess, experimentId=exp_id).trials
@@ -151,7 +150,7 @@ def create_experiment(
     experiment_id = int(new_resource.split("/")[-1])
 
     if activate:
-        sess = session.Session(master_url, None, None, None)
+        sess = api.Session(master_url, None, None, None)
         bindings.post_ActivateExperiment(sess, id=experiment_id)
 
     return experiment_id

--- a/harness/determined/common/experimental/__init__.py
+++ b/harness/determined/common/experimental/__init__.py
@@ -1,6 +1,7 @@
+# TODO: delete all of these when det.experimental.client is removed.
+from determined.common.api import Session
 from determined.common.experimental.checkpoint import Checkpoint
 from determined.common.experimental.determined import Determined
 from determined.common.experimental.experiment import ExperimentReference
-from determined.common.experimental.session import Session, get_max_retries_config
 from determined.common.experimental.trial import TrialReference, TrialSortBy, TrialOrderBy
 from determined.common.experimental.model import Model, ModelOrderBy, ModelSortBy, ModelVersion

--- a/harness/determined/common/experimental/_session.py
+++ b/harness/determined/common/experimental/_session.py
@@ -1,0 +1,7 @@
+# link for backwards compatibility, since this was the original place that Session was exposed.
+# At the present time, users should be using `determined.experimental.client.Session` instead, but
+# since there's a big breaking change after we remove `client` from `determined.experimental`, we
+# should remove this at that time.
+# TODO: remove this link when we remove `client` from `determined.experimental`.
+
+from determined.common.api import Session  # noqa: F401

--- a/harness/determined/common/experimental/checkpoint/_checkpoint.py
+++ b/harness/determined/common/experimental/checkpoint/_checkpoint.py
@@ -6,8 +6,7 @@ import shutil
 import warnings
 from typing import Any, Dict, List, Optional, cast
 
-from determined.common import constants, storage
-from determined.common.experimental import session
+from determined.common import api, constants, storage
 from determined.common.storage import shared
 
 
@@ -49,7 +48,7 @@ class Checkpoint(object):
 
     def __init__(
         self,
-        session: session.Session,
+        session: api.Session,
         task_id: str,
         allocation_id: str,
         uuid: str,
@@ -384,7 +383,7 @@ class Checkpoint(object):
             return f"Checkpoint(uuid={self.uuid}, task_id={self.task_id})"
 
     @classmethod
-    def _from_json(cls, data: Dict[str, Any], session: session.Session) -> "Checkpoint":
+    def _from_json(cls, data: Dict[str, Any], session: api.Session) -> "Checkpoint":
         metadata = data.get("metadata", {})
         training_data = data.get("training")
         training = (
@@ -412,7 +411,7 @@ class Checkpoint(object):
         )
 
     @classmethod
-    def from_json(cls, data: Dict[str, Any], session: session.Session) -> "Checkpoint":
+    def from_json(cls, data: Dict[str, Any], session: api.Session) -> "Checkpoint":
         warnings.warn(
             "Checkpoint.from_json() is deprecated and will be removed from the public API "
             "in a future version",

--- a/harness/determined/common/experimental/determined.py
+++ b/harness/determined/common/experimental/determined.py
@@ -2,9 +2,9 @@ import pathlib
 import warnings
 from typing import Any, Dict, List, Optional, Union, cast
 
-from determined.common import context, util, yaml
+from determined.common import api, context, util, yaml
 from determined.common.api import authentication, bindings, certs
-from determined.common.experimental import checkpoint, experiment, model, session, trial
+from determined.common.experimental import checkpoint, experiment, model, trial
 
 
 class _CreateExperimentResponse:
@@ -62,7 +62,7 @@ class Determined:
         # a REST API call against the master.
         auth = authentication.Authentication(master, user, password, try_reauth=True, cert=cert)
 
-        self._session = session.Session(master, user, auth, cert)
+        self._session = api.Session(master, user, auth, cert)
 
     def create_experiment(
         self,

--- a/harness/determined/common/experimental/experiment.py
+++ b/harness/determined/common/experimental/experiment.py
@@ -3,7 +3,8 @@ import sys
 import time
 from typing import Any, Dict, List, Optional, cast
 
-from determined.common.experimental import checkpoint, session, trial
+from determined.common import api
+from determined.common.experimental import checkpoint, trial
 
 
 class ExperimentState(enum.Enum):
@@ -65,7 +66,7 @@ class ExperimentReference:
     def __init__(
         self,
         experiment_id: int,
-        session: session.Session,
+        session: api.Session,
     ):
         self._id = experiment_id
         self._session = session

--- a/harness/determined/common/experimental/model.py
+++ b/harness/determined/common/experimental/model.py
@@ -4,7 +4,8 @@ import json
 import warnings
 from typing import Any, Dict, Iterable, List, Optional
 
-from determined.common.experimental import checkpoint, session
+from determined.common import api
+from determined.common.experimental import checkpoint
 
 
 class ModelVersion:
@@ -15,7 +16,7 @@ class ModelVersion:
 
     def __init__(
         self,
-        session: session.Session,
+        session: api.Session,
         model_version_id: int,  # unique DB id
         checkpoint: checkpoint.Checkpoint,
         metadata: Dict[str, Any],
@@ -74,7 +75,7 @@ class ModelVersion:
         )
 
     @classmethod
-    def _from_json(cls, data: Dict[str, Any], session: session.Session) -> "ModelVersion":
+    def _from_json(cls, data: Dict[str, Any], session: api.Session) -> "ModelVersion":
         ckpt_data = data.get("checkpoint", {})
         ckpt = checkpoint.Checkpoint._from_json(ckpt_data, session)
 
@@ -92,7 +93,7 @@ class ModelVersion:
         )
 
     @classmethod
-    def from_json(cls, data: Dict[str, Any], session: session.Session) -> "ModelVersion":
+    def from_json(cls, data: Dict[str, Any], session: api.Session) -> "ModelVersion":
         warnings.warn(
             "ModelVersion.from_json() is deprecated and will be removed from the public API "
             "in a future version",
@@ -161,7 +162,7 @@ class Model:
 
     def __init__(
         self,
-        session: session.Session,
+        session: api.Session,
         model_id: int,
         name: str,
         description: str = "",
@@ -366,7 +367,7 @@ class Model:
         )
 
     @classmethod
-    def _from_json(cls, data: Dict[str, Any], session: session.Session) -> "Model":
+    def _from_json(cls, data: Dict[str, Any], session: api.Session) -> "Model":
         return cls(
             session,
             data["id"],
@@ -381,7 +382,7 @@ class Model:
         )
 
     @classmethod
-    def from_json(cls, data: Dict[str, Any], session: session.Session) -> "Model":
+    def from_json(cls, data: Dict[str, Any], session: api.Session) -> "Model":
         warnings.warn(
             "Model.from_json() is deprecated and will be removed from the public API "
             "in a future version",

--- a/harness/determined/common/experimental/trial.py
+++ b/harness/determined/common/experimental/trial.py
@@ -1,8 +1,8 @@
 import enum
 from typing import Any, Callable, Dict, Optional
 
-from determined.common import check
-from determined.common.experimental import checkpoint, session
+from determined.common import api
+from determined.common.experimental import checkpoint
 
 
 class TrialReference:
@@ -14,7 +14,7 @@ class TrialReference:
     :class:`~determined.experimental.Checkpoint` instances.
     """
 
-    def __init__(self, trial_id: int, session: session.Session):
+    def __init__(self, trial_id: int, session: api.Session):
         self.id = trial_id
         self._session = session
 
@@ -82,17 +82,11 @@ class TrialReference:
                 this parameter is ignored. By default, the value of ``smaller_is_better``
                 from the experiment's configuration is used.
         """
-        check.eq(
-            sum([int(latest), int(best), int(uuid is not None)]),
-            1,
-            "Exactly one of latest, best, or uuid must be set",
-        )
+        if sum([int(latest), int(best), int(uuid is not None)]) != 1:
+            raise AssertionError("Exactly one of latest, best, or uuid must be set")
 
-        check.eq(
-            sort_by is None,
-            smaller_is_better is None,
-            "sort_by and smaller_is_better must be set together",
-        )
+        if (sort_by is None) != (smaller_is_better is None):
+            raise AssertionError("sort_by and smaller_is_better must be set together")
 
         if sort_by is not None and not best:
             raise AssertionError(

--- a/harness/determined/common/util.py
+++ b/harness/determined/common/util.py
@@ -1,11 +1,14 @@
 import functools
 import io
+import json
 import os
 import pathlib
 import platform
 import random
 import sys
 from typing import IO, Any, Callable, Iterator, Optional, Sequence, TypeVar, Union, overload
+
+import urllib3
 
 from determined.common import yaml
 
@@ -141,3 +144,31 @@ def get_config_path() -> pathlib.Path:
         config_path = pathlib.Path.home().joinpath(".config")
 
     return config_path.joinpath("determined")
+
+
+def get_max_retries_config() -> urllib3.util.retry.Retry:
+    # Allow overriding retry settings when necessary.
+    # `DET_RETRY_CONFIG` env variable can contain `urllib3` `Retry` parameters,
+    # encoded as JSON.
+    # For example:
+    #  - disable retries: {"total":0}
+    #  - shorten the wait times {"total":10,"backoff_factor":0.5,"method_whitelist":false}
+
+    config_data = os.environ.get("DET_RETRY_CONFIG")
+    if config_data is not None:
+        config = json.loads(config_data)
+        return urllib3.util.retry.Retry(**config)
+
+    # Defaults.
+    try:
+        return urllib3.util.retry.Retry(
+            total=20,
+            backoff_factor=0.5,
+            allowed_methods=False,
+        )
+    except TypeError:  # Support urllib3 prior to 1.26
+        return urllib3.util.retry.Retry(
+            total=20,
+            backoff_factor=0.5,
+            method_whitelist=False,  # type: ignore
+        )

--- a/harness/determined/core/_checkpoint.py
+++ b/harness/determined/core/_checkpoint.py
@@ -9,9 +9,8 @@ from datetime import datetime, timezone
 from typing import Any, Dict, Iterator, Optional, Tuple, Union
 
 from determined import core, tensorboard
-from determined.common import storage
+from determined.common import api, storage
 from determined.common.api import bindings
-from determined.common.experimental.session import Session
 
 logger = logging.getLogger("determined.core")
 
@@ -44,7 +43,7 @@ class CheckpointContext:
         self,
         dist: core.DistributedContext,
         storage_manager: storage.StorageManager,
-        session: Session,
+        session: api.Session,
         task_id: str,
         allocation_id: str,
         tbd_sync_mode: core.TensorboardMode,

--- a/harness/determined/core/_context.py
+++ b/harness/determined/core/_context.py
@@ -8,9 +8,8 @@ import appdirs
 
 import determined as det
 from determined import core, tensorboard
-from determined.common import constants, storage
+from determined.common import api, constants, storage, util
 from determined.common.api import certs
-from determined.common.experimental.session import Session, get_max_retries_config
 
 logger = logging.getLogger("determined.core")
 
@@ -156,7 +155,9 @@ def init(
 
     # We are on the cluster.
     cert = certs.default_load(info.master_url)
-    session = Session(info.master_url, None, None, cert, max_retries=get_max_retries_config())
+    session = api.Session(
+        info.master_url, None, None, cert, max_retries=util.get_max_retries_config()
+    )
 
     if distributed is None:
         if len(info.container_addrs) > 1 or len(info.slot_ids) > 1:

--- a/harness/determined/core/_preempt.py
+++ b/harness/determined/core/_preempt.py
@@ -7,7 +7,7 @@ from typing import Any, Optional
 import requests
 
 from determined import core
-from determined.common.experimental.session import Session
+from determined.common import api
 
 logger = logging.getLogger("determined.core")
 
@@ -35,7 +35,7 @@ class _PreemptionWatcher(threading.Thread):
                print('finished without preemption signal')
     """
 
-    def __init__(self, session: Session, allocation_id: str) -> None:
+    def __init__(self, session: api.Session, allocation_id: str) -> None:
         self._session = session
         self._allocation_id = allocation_id
 
@@ -153,7 +153,7 @@ class PreemptContext:
 
     def __init__(
         self,
-        session: Session,
+        session: api.Session,
         allocation_id: str,
         dist: core.DistributedContext,
         preempt_mode: PreemptMode = PreemptMode.WorkersAskChief,

--- a/harness/determined/core/_searcher.py
+++ b/harness/determined/core/_searcher.py
@@ -4,7 +4,7 @@ from typing import Iterator, Optional
 
 import determined as det
 from determined import core
-from determined.common.experimental.session import Session
+from determined.common import api
 
 logger = logging.getLogger("determined.core")
 
@@ -43,7 +43,7 @@ class SearcherOperation:
 
     def __init__(
         self,
-        session: Session,
+        session: api.Session,
         trial_id: int,
         length: int,
         is_chief: bool,
@@ -171,7 +171,7 @@ class SearcherContext:
 
     def __init__(
         self,
-        session: Session,
+        session: api.Session,
         dist: core.DistributedContext,
         trial_id: int,
         run_id: int,

--- a/harness/determined/core/_train.py
+++ b/harness/determined/core/_train.py
@@ -5,8 +5,8 @@ from typing import Any, Callable, Dict, List, Optional, Set
 
 import determined as det
 from determined import tensorboard
+from determined.common import api
 from determined.common.api import errors
-from determined.common.experimental.session import Session
 from determined.core import DistributedContext, TensorboardMode
 
 logger = logging.getLogger("determined.core")
@@ -26,7 +26,7 @@ class TrainContext:
 
     def __init__(
         self,
-        session: Session,
+        session: api.Session,
         trial_id: int,
         run_id: int,
         exp_id: int,

--- a/harness/determined/experimental/client.py
+++ b/harness/determined/experimental/client.py
@@ -48,6 +48,7 @@ import pathlib
 import warnings
 from typing import Any, Callable, Dict, List, Optional, Union
 
+from determined.common.api import Session  # noqa: F401
 from determined.common.experimental.checkpoint import Checkpoint
 from determined.common.experimental.determined import Determined
 from determined.common.experimental.experiment import (  # noqa: F401
@@ -55,7 +56,6 @@ from determined.common.experimental.experiment import (  # noqa: F401
     ExperimentState,
 )
 from determined.common.experimental.model import Model, ModelOrderBy, ModelSortBy
-from determined.common.experimental.session import Session  # noqa: F401
 from determined.common.experimental.trial import (  # noqa: F401
     TrialOrderBy,
     TrialReference,


### PR DESCRIPTION
Originally, Session was part of the python sdk, and not used anywhere
else.  Slowly it has come to be preferred for REST API interactions,
especially now that it is used with the new generated bindings.

Most things need bindings to work, and this requirement will grow
stronger as we port more and more code to use the generated bindings.
Bindings needs Session to work.  Session needs api.requests and
api.authentication to work.  This is all a big mess unless the importing
of Session is carefully controlled.

This PR promotes Session to be part of determined.common.api, with a
controlled import order to prevent failed circular imports.  Python
SDK-related import paths just point at the real definition now.

Additionally, this renames the old api.authentication.Session class to
UserTokenPair, to reduce confusion.