### PR TITLE
fix: directly return object-not-found errors instead of rewrapping them

### DIFF
--- a/master/internal/db/postgres_proto.go
+++ b/master/internal/db/postgres_proto.go
@@ -15,10 +15,11 @@ import (
 // QueryProto returns the result of the query. Any placeholder parameters are replaced
 // with supplied args. Enum values must be the full name of the enum.
 func (db *PgDB) QueryProto(queryName string, v interface{}, args ...interface{}) error {
-	return errors.Wrapf(
-		db.queryRowsWithParser(db.queries.getOrLoad(queryName), protoParser, v, args...),
-		"error running query: %v", queryName,
-	)
+	err := db.queryRowsWithParser(db.queries.getOrLoad(queryName), protoParser, v, args...)
+	if err == ErrNotFound {
+		return err
+	}
+	return errors.Wrapf(err, "error running query: %v", queryName)
 }
 
 // QueryProtof returns the result of the formated query. Any placeholder parameters are replaced


### PR DESCRIPTION
## Description

We have a specific message and `codes.NotFound` response when an experiment/model/project/workspace does not exist:

```go
	switch err := a.m.db.QueryProto("get_experiment", exp, experimentID); {
	case err == db.ErrNotFound:
		return nil, status.Errorf(codes.NotFound, "experiment not found: %d", experimentID)
```

but `QueryProto` always wraps the error inside of a new internal error, so err never matches db.ErrNotFound

this moves code around in `QueryProto` to let the ErrNotFound message pass through unwrapped

## Test Plan

Go to /api/v1/workspaces/1000 to trigger a not-found response

## Checklist

- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.
- [x] If modifying `/webui/react/src/shared/` verify `make -C webui/react test-shared` passes.