### PR TITLE
fix: show learning curve

### DIFF
--- a/master/internal/api_experiment.go
+++ b/master/internal/api_experiment.go
@@ -1139,11 +1139,11 @@ func (a *apiServer) topTrials(experimentID int, maxTrials int, s expconf.Searche
 		ranking = ByMetricOfInterest
 	case expconf.GridConfig:
 		ranking = ByMetricOfInterest
+	case expconf.CustomConfig:
+		ranking = ByMetricOfInterest
 	case expconf.AsyncHalvingConfig:
 		ranking = ByTrainingLength
 	case expconf.AdaptiveASHAConfig:
-		ranking = ByTrainingLength
-	case expconf.CustomConfig:
 		ranking = ByTrainingLength
 	case expconf.SingleConfig:
 		return nil, errors.New("single-trial experiments are not supported for trial sampling")

--- a/master/internal/api_experiment.go
+++ b/master/internal/api_experiment.go
@@ -1143,6 +1143,8 @@ func (a *apiServer) topTrials(experimentID int, maxTrials int, s expconf.Searche
 		ranking = ByTrainingLength
 	case expconf.AdaptiveASHAConfig:
 		ranking = ByTrainingLength
+	case expconf.CustomConfig:
+		ranking = ByTrainingLength
 	case expconf.SingleConfig:
 		return nil, errors.New("single-trial experiments are not supported for trial sampling")
 	// EOL searcher configs:
@@ -1152,8 +1154,6 @@ func (a *apiServer) topTrials(experimentID int, maxTrials int, s expconf.Searche
 		ranking = ByTrainingLength
 	case expconf.SyncHalvingConfig:
 		ranking = ByTrainingLength
-	case expconf.CustomConfig:
-		return nil, errors.New("experiments with custom searcher are not supported for trial sampling")
 	default:
 		return nil, errors.New("unable to detect a searcher algorithm for trial sampling")
 	}


### PR DESCRIPTION
## Description
Learning Curve in Experiment visualization was empty due to 
```
case expconf.CustomConfig:
	return nil, errors.New("experiments with custom searcher are not supported for trial sampling")
```
Now we are returning top trials by `ByMetricOfInterest`


<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At a minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan
```
cd e2e
pytest tests/experiment/test_custom_searcher.py --log-cli-level=info
```
check if learning curve shows plot

<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions about this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.
- [ ] If modifying `/webui/react/src/shared/` verify `make -C webui/react test-shared` passes.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ