### PR TITLE
fix: get trial datapoints from trial comparison/summarization endpoint

### DIFF
--- a/master/internal/api_trials.go
+++ b/master/internal/api_trials.go
@@ -526,6 +526,9 @@ func (a *apiServer) MultiTrialSample(trialID int32, metricNames []string,
 	var err error
 
 	var metrics []*apiv1.SummarizedMetric
+	if endBatches == 0 {
+		endBatches = math.MaxInt32
+	}
 
 	for _, name := range metricNames {
 		if (metricType == apiv1.MetricType_METRIC_TYPE_TRAINING) ||

--- a/webui/react/src/pages/TrialDetails/TrialChart.tsx
+++ b/webui/react/src/pages/TrialDetails/TrialChart.tsx
@@ -10,9 +10,10 @@ import UPlotChart, { Options } from 'components/UPlot/UPlotChart';
 import { tooltipsPlugin } from 'components/UPlot/UPlotChart/tooltipsPlugin';
 import { trackAxis } from 'components/UPlot/UPlotChart/trackAxis';
 import css from 'pages/TrialDetails/TrialChart.module.scss';
+import { compareTrials } from 'services/api';
 import Spinner from 'shared/components/Spinner';
 import { glasbeyColor } from 'shared/utils/color';
-import { MetricName, MetricType, Scale, WorkloadGroup } from 'types';
+import { MetricContainer, MetricName, Scale } from 'types';
 
 interface Props {
   defaultMetricNames: MetricName[];
@@ -21,7 +22,6 @@ interface Props {
   metrics: MetricName[];
   onMetricChange: (value: MetricName[]) => void;
   trialId?: number;
-  workloads?: WorkloadGroup[];
 }
 
 const getChartMetricLabel = (metric: MetricName): string => {
@@ -35,31 +35,42 @@ const TrialChart: React.FC<Props> = ({
   metricNames,
   metrics,
   onMetricChange,
-  workloads,
   trialId,
 }: Props) => {
   const [ scale, setScale ] = useState<Scale>(Scale.Linear);
+  const [ trialSumm, setTrialSummary ] = useState<MetricContainer[]>([]);
+
+  useMemo(async () => {
+    if (trialId) {
+      const summ = await compareTrials({
+        maxDatapoints: screen.width > 1600 ? 1500 : 1000,
+        metricNames: metricNames,
+        scale: scale,
+        startBatches: 0,
+        trialIds: [ trialId ],
+      });
+      setTrialSummary(summ[0].metrics);
+    }
+  }, [ metricNames, scale, trialId ]);
 
   const chartData: AlignedData = useMemo(() => {
     const xValues: number[] = [];
     const yValues: Record<string, Record<string, number | null>> = {};
-    metrics.forEach((metric, index) => yValues[index] = {});
 
-    (workloads || []).forEach((wlWrapper) => {
-      metrics.forEach((metric, index) => {
-        const metricsWl = metric.type === MetricType.Training ?
-          wlWrapper.training : wlWrapper.validation;
-        if (!metricsWl || !metricsWl.metrics) return;
+    metrics.forEach((metric, index) => {
+      yValues[index] = {};
 
-        const x = metricsWl.totalBatches;
-        if (!xValues.includes(x)) xValues.push(x);
+      const mWrapper = trialSumm.find((mContainer) =>
+        mContainer.name === metric.name && mContainer.type === metric.type);
+      if (!mWrapper || !mWrapper.data) {
+        return;
+      }
 
-        /**
-         * TODO: filtering NaN, +/- Infinity for now, but handle it later with
-         * dynamic min/max ranges via uPlot.Scales.
-         */
-        const y = metricsWl.metrics[metric.name];
-        yValues[index][x] = Number.isFinite(y) ? y : null;
+      mWrapper.data.forEach((pt) => {
+        if (!xValues.includes(pt.batches)) {
+          xValues.push(pt.batches);
+        }
+        yValues[index][pt.batches] = Number.isFinite(pt.value) ? pt.value : null;
       });
     });
 
@@ -70,7 +81,7 @@ const TrialChart: React.FC<Props> = ({
     });
 
     return [ xValues, ...yValuesArray ];
-  }, [ metrics, workloads ]);
+  }, [ metrics, trialSumm ]);
 
   const chartOptions: Options = useMemo(() => {
     return {

--- a/webui/react/src/pages/TrialDetails/TrialDetailsOverview.tsx
+++ b/webui/react/src/pages/TrialDetails/TrialDetailsOverview.tsx
@@ -4,7 +4,7 @@ import useMetricNames from 'hooks/useMetricNames';
 import useSettings from 'hooks/useSettings';
 import TrialInfoBox from 'pages/TrialDetails/TrialInfoBox';
 import { ErrorType } from 'shared/utils/error';
-import { ExperimentBase, MetricName, MetricType, TrialDetails } from 'types';
+import { ExperimentBase, MetricName, MetricType, RunState, TrialDetails } from 'types';
 import handleError from 'utils/error';
 
 import TrialChart from './TrialChart';
@@ -71,6 +71,9 @@ const TrialDetailsOverview: React.FC<Props> = ({ experiment, trial }: Props) => 
         metricNames={metricNames}
         metrics={metrics}
         trialId={trial?.id}
+        trialTerminated={trial ?
+          [ RunState.Completed, RunState.Errored ].includes(trial.state)
+          : false}
         onMetricChange={handleMetricChange}
       />
       <TrialDetailsWorkloads


### PR DESCRIPTION
## Description

Use the trial-comparison / trial-summarization endpoint to get downsampled metrics from an experimental run. As intended back in #4300 and missed in #4703 .

## Test Plan

Single-trial experiments should have an experiment graph with metrics added/removed

## Checklist

- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.
- [x] If modifying `/webui/react/src/shared/` verify `make -C webui/react test-shared` passes.