### PR TITLE
fix: job queue experiment restore

### DIFF
--- a/docs/release-notes/experiment-restore.txt
+++ b/docs/release-notes/experiment-restore.txt
@@ -1,0 +1,6 @@
+:orphan:
+
+**Bug Fixes**
+
+-  Fix an issue where restoring a job in into a Kubernetes set up could crash the
+   resource manager.

--- a/master/internal/experiment.go
+++ b/master/internal/experiment.go
@@ -214,7 +214,7 @@ func (e *experiment) Receive(ctx *actor.Context) error {
 				return err
 			}
 
-			if j.QPos.GreaterThanOrEqual(decimal.Zero) {
+			if j.QPos.GreaterThan(decimal.Zero) {
 				e.rm.RecoverJobPosition(ctx, sproto.RecoverJobPosition{
 					JobID:        e.JobID,
 					JobPosition:  j.QPos,

--- a/master/internal/experiment.go
+++ b/master/internal/experiment.go
@@ -214,7 +214,7 @@ func (e *experiment) Receive(ctx *actor.Context) error {
 				return err
 			}
 
-			if !j.QPos.Equals(decimal.Zero) {
+			if j.QPos.GreaterThanOrEqual(decimal.Zero) {
 				e.rm.RecoverJobPosition(ctx, sproto.RecoverJobPosition{
 					JobID:        e.JobID,
 					JobPosition:  j.QPos,

--- a/master/internal/rm/job.go
+++ b/master/internal/rm/job.go
@@ -12,6 +12,8 @@ import (
 	"github.com/determined-ai/determined/proto/pkg/jobv1"
 )
 
+var invalidJobQPos = decimal.NewFromInt(-1)
+
 func reduceToJobQInfo(reqs AllocReqs) map[model.JobID]*sproto.RMJobInfo {
 	isAdded := make(map[model.JobID]*sproto.RMJobInfo)
 	jobsAhead := 0
@@ -142,22 +144,22 @@ func computeNewJobPos(
 	qPositions jobSortState,
 ) (decimal.Decimal, error) {
 	if anchor1 == jobID || anchor2 == jobID {
-		return decimal.NewFromInt(0), fmt.Errorf("cannot move job relative to itself")
+		return invalidJobQPos, fmt.Errorf("cannot move job relative to itself")
 	}
 
 	qPos1, ok := qPositions[anchor1]
 	if !ok {
-		return decimal.NewFromInt(0), fmt.Errorf("could not find anchor job %s", anchor1)
+		return invalidJobQPos, fmt.Errorf("could not find anchor job %s", anchor1)
 	}
 
 	qPos2, ok := qPositions[anchor2]
 	if !ok {
-		return decimal.NewFromInt(0), fmt.Errorf("could not find anchor job %s", anchor2)
+		return invalidJobQPos, fmt.Errorf("could not find anchor job %s", anchor2)
 	}
 
 	qPos3, ok := qPositions[jobID]
 	if !ok {
-		return decimal.NewFromInt(0), fmt.Errorf("could not find job %s", jobID)
+		return invalidJobQPos, fmt.Errorf("could not find job %s", jobID)
 	}
 
 	// check if qPos3 is between qPos1 and qPos2
@@ -170,7 +172,7 @@ func computeNewJobPos(
 	newPos := decimal.Avg(qPos1, qPos2)
 
 	if newPos.Equal(qPos1) || newPos.Equal(qPos2) {
-		return decimal.NewFromInt(0), fmt.Errorf("unable to compute a new job position for job %s",
+		return invalidJobQPos, fmt.Errorf("unable to compute a new job position for job %s",
 			jobID)
 	}
 

--- a/master/internal/rm/job.go
+++ b/master/internal/rm/job.go
@@ -12,7 +12,7 @@ import (
 	"github.com/determined-ai/determined/proto/pkg/jobv1"
 )
 
-var invalidJobQPos = decimal.NewFromInt(-1)
+var invalidJobQPos = decimal.NewFromInt(0)
 
 func reduceToJobQInfo(reqs AllocReqs) map[model.JobID]*sproto.RMJobInfo {
 	isAdded := make(map[model.JobID]*sproto.RMJobInfo)

--- a/master/internal/rm/kubernetes_resource_manager.go
+++ b/master/internal/rm/kubernetes_resource_manager.go
@@ -219,6 +219,7 @@ func (k *kubernetesResourceManager) Receive(ctx *actor.Context) error {
 		sproto.SetGroupPriority,
 		sproto.MoveJob,
 		sproto.DeleteJob,
+		sproto.RecoverJobPosition,
 		*apiv1.GetJobQueueStatsRequest:
 		return k.receiveJobQueueMsg(ctx)
 


### PR DESCRIPTION
## Description

the k8 resource manager's actor was missing a handler for RecoverJobPosition msg

<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At a minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan

reproduced the issue through minikube and manually setting q_position to -1
  - the job positions does get defaulted to 0 somewhere I'm not sure where. in the customer's case they might have ran an older migration where it had translated into -1
  - `for i in $(seq 1 4); do det e create ./examples/gan/gan_mnist_pytorch/const.yaml ./examples/gan/gan_mnist_pytorch/&; done`
  - `update jobs set q_position=-1;`
repeated the steps in this branch and the resource manager did not crash

![DeepinScreenshot_Alacritty_20220823130720](https://user-images.githubusercontent.com/12127420/186255781-cfbfed42-8415-44c6-9403-9821c3e96fbb.png)


<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions about this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)



<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.
- [ ] If modifying `/webui/react/src/shared/` verify `make -C webui/react test-shared` passes.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ