### PR TITLE
feat: view code improvements

### DIFF
--- a/webui/react/src/pages/ExperimentDetails/CodeViewer/CodeViewer.module.scss
+++ b/webui/react/src/pages/ExperimentDetails/CodeViewer/CodeViewer.module.scss
@@ -72,7 +72,12 @@
   }
 }
 .pageError {
-  grid-row: 2/6;
+  grid-column: 2 / 3;
+  grid-row: 2 / 3;
+
+  @media screen and (max-width: 1024px) {
+    grid-column: 1 / 2;
+  }
 }
 .editor {
   grid-column: 2 / 3;

--- a/webui/react/src/pages/ExperimentDetails/CodeViewer/CodeViewer.module.scss
+++ b/webui/react/src/pages/ExperimentDetails/CodeViewer/CodeViewer.module.scss
@@ -1,14 +1,14 @@
 .base {
   display: grid;
-  grid-template-columns: minmax(auto, 30%) auto;
-  grid-template-rows: auto;
+  grid-template-columns: minmax(15%, auto) minmax(40%, auto);
+  grid-template-rows: 38px auto;
   height: 100%;
+  max-width: 100vw;
 
   .fileTree {
     background-color: transparent;
     color: var(--theme-background-on-strong);
     height: 100%;
-    overflow-x: scroll;
     padding: 0;
 
     span {
@@ -75,7 +75,7 @@
   grid-row: 2/6;
 }
 .editor {
-  grid-column: 2 / auto;
+  grid-column: 2 / 3;
   grid-row: 2 / 3;
 
   @media screen and (max-width: 1024px) {

--- a/webui/react/src/pages/ExperimentDetails/CodeViewer/CodeViewer.tsx
+++ b/webui/react/src/pages/ExperimentDetails/CodeViewer/CodeViewer.tsx
@@ -50,6 +50,7 @@ const convertV1FileNodeToTreeNode = (node: V1FileNode): TreeNode => ({
 
 enum PageError {
   decode = 'Could not decode file.',
+  empty = 'Empty file.',
   fetch = 'Unable to fetch file.',
   none = ''
 }
@@ -237,6 +238,8 @@ const CodeViewer: React.FC<Props> = ({
     let text = '';
     try {
       text = decodeURIComponent(escape(window.atob(file)));
+
+      if (!text) setPageError(PageError.empty); // Emmits a "Empty file" error message
     } catch {
       setPageError(PageError.decode);
     }
@@ -289,9 +292,9 @@ const CodeViewer: React.FC<Props> = ({
   ]);
 
   const getSyntaxHighlight = useCallback(() => {
-    if (String(activeFile?.key).includes('py')) return 'python';
+    if (String(activeFile?.key).includes('.py')) return 'python';
 
-    if (String(activeFile?.key).includes('md')) return 'markdown';
+    if (String(activeFile?.key).includes('.md')) return 'markdown';
 
     return 'yaml';
   }, [ activeFile ]);

--- a/webui/react/src/pages/ExperimentDetails/CodeViewer/CodeViewer.tsx
+++ b/webui/react/src/pages/ExperimentDetails/CodeViewer/CodeViewer.tsx
@@ -50,7 +50,7 @@ const convertV1FileNodeToTreeNode = (node: V1FileNode): TreeNode => ({
 
 enum PageError {
   decode = 'Could not decode file.',
-  empty = 'Empty file.',
+  empty = 'Empty file! Please choose a diferent file.',
   fetch = 'Unable to fetch file.',
   none = ''
 }

--- a/webui/react/src/pages/ExperimentDetails/CodeViewer/CodeViewer.tsx
+++ b/webui/react/src/pages/ExperimentDetails/CodeViewer/CodeViewer.tsx
@@ -91,6 +91,8 @@ const CodeViewer: React.FC<Props> = ({
   const resize = useResize();
 
   const submittedConfig = useMemo(() => {
+    if (!_submittedConfig) return;
+
     const { hyperparameters, ...restConfig } = yaml.load(_submittedConfig) as RawJson;
 
     // don't ask me why this works.. it gets rid of the JSON though
@@ -156,8 +158,12 @@ const CodeViewer: React.FC<Props> = ({
   }, [ submittedConfig, runtimeConfig, switchTreeViewToEditor ]);
 
   useEffect(() => {
-    handleSelectConfig(Config.submitted);
-  }, [ handleSelectConfig ]);
+    if (submittedConfig) {
+      handleSelectConfig(Config.submitted);
+    } else {
+      handleSelectConfig(Config.runtime);
+    }
+  }, [ handleSelectConfig, submittedConfig ]);
 
   useEffect(() => {
     if (resize.width <= 1024) {

--- a/webui/react/src/pages/ExperimentDetails/CodeViewer/CodeViewer.tsx
+++ b/webui/react/src/pages/ExperimentDetails/CodeViewer/CodeViewer.tsx
@@ -342,13 +342,13 @@ const CodeViewer: React.FC<Props> = ({
                   */
                   <Tooltip title="Download File">
                     {
-                      !String(activeFile.key).includes('config') && (
+                      !String(activeFile.key).includes('Configuration') && (
                         // hiding the download for configs until next iteration
                         <DownloadOutlined
                           className={css.noBorderButton}
                           onClick={(e) => {
                             const filePath = String(activeFile.key);
-                            if (filePath.includes('config')) {
+                            if (filePath.includes('Configuration')) {
                               const url = filePath.includes('runtime')
                                 ? URL.createObjectURL(new Blob([ runtimeConfig ]))
                                 : URL.createObjectURL(new Blob([ submittedConfig as string ]));

--- a/webui/react/src/pages/ExperimentDetails/CodeViewer/CodeViewer.tsx
+++ b/webui/react/src/pages/ExperimentDetails/CodeViewer/CodeViewer.tsx
@@ -340,20 +340,33 @@ const CodeViewer: React.FC<Props> = ({
                   * TODO: Add notebook integration
                   * <Button className={css.noBorderButton}>Open in Notebook</Button>
                   */
-                  !isConfig(activeFile.key) && (
-                    <Tooltip title="Download File">
-                      <DownloadOutlined
-                        className={css.noBorderButton}
-                        onClick={(e) => handlePath(e, {
-                          external: true,
-                          path: paths.experimentFileFromTree(
-                            experimentId,
-                            String(activeFile.key),
-                          ),
-                        })}
-                      />
-                    </Tooltip>
-                  )
+                  <Tooltip title="Download File">
+                    <DownloadOutlined
+                      className={css.noBorderButton}
+                      onClick={(e) => {
+                        console.log(e);
+                        const filePath = String(activeFile.key);
+                        if (filePath.includes('config')) {
+                          const url = filePath.includes('runtime')
+                            ? URL.createObjectURL(new Blob([ runtimeConfig ]))
+                            : URL.createObjectURL(new Blob([ submittedConfig as string ]));
+
+                          handlePath(e, {
+                            external: true,
+                            path: url,
+                          });
+                        } else {
+                          handlePath(e, {
+                            external: true,
+                            path: paths.experimentFileFromTree(
+                              experimentId,
+                              String(activeFile.key),
+                            ),
+                          });
+                        }
+                      }}
+                    />
+                  </Tooltip>
                 }
               </div>
             </div>

--- a/webui/react/src/pages/ExperimentDetails/CodeViewer/CodeViewer.tsx
+++ b/webui/react/src/pages/ExperimentDetails/CodeViewer/CodeViewer.tsx
@@ -341,30 +341,35 @@ const CodeViewer: React.FC<Props> = ({
                   * <Button className={css.noBorderButton}>Open in Notebook</Button>
                   */
                   <Tooltip title="Download File">
-                    <DownloadOutlined
-                      className={css.noBorderButton}
-                      onClick={(e) => {
-                        const filePath = String(activeFile.key);
-                        if (filePath.includes('config')) {
-                          const url = filePath.includes('runtime')
-                            ? URL.createObjectURL(new Blob([ runtimeConfig ]))
-                            : URL.createObjectURL(new Blob([ submittedConfig as string ]));
+                    {
+                      !String(activeFile.key).includes('config') && (
+                        // hiding the download for configs until next iteration
+                        <DownloadOutlined
+                          className={css.noBorderButton}
+                          onClick={(e) => {
+                            const filePath = String(activeFile.key);
+                            if (filePath.includes('config')) {
+                              const url = filePath.includes('runtime')
+                                ? URL.createObjectURL(new Blob([ runtimeConfig ]))
+                                : URL.createObjectURL(new Blob([ submittedConfig as string ]));
 
-                          handlePath(e, {
-                            external: true,
-                            path: url,
-                          });
-                        } else {
-                          handlePath(e, {
-                            external: true,
-                            path: paths.experimentFileFromTree(
-                              experimentId,
-                              String(activeFile.key),
-                            ),
-                          });
-                        }
-                      }}
-                    />
+                              handlePath(e, {
+                                external: true,
+                                path: url,
+                              });
+                            } else {
+                              handlePath(e, {
+                                external: true,
+                                path: paths.experimentFileFromTree(
+                                  experimentId,
+                                  String(activeFile.key),
+                                ),
+                              });
+                            }
+                          }}
+                        />
+                      )
+                    }
                   </Tooltip>
                 }
               </div>

--- a/webui/react/src/pages/ExperimentDetails/CodeViewer/CodeViewer.tsx
+++ b/webui/react/src/pages/ExperimentDetails/CodeViewer/CodeViewer.tsx
@@ -344,7 +344,6 @@ const CodeViewer: React.FC<Props> = ({
                     <DownloadOutlined
                       className={css.noBorderButton}
                       onClick={(e) => {
-                        console.log(e);
                         const filePath = String(activeFile.key);
                         if (filePath.includes('config')) {
                           const url = filePath.includes('runtime')

--- a/webui/react/src/pages/ExperimentDetails/CodeViewer/index.scss
+++ b/webui/react/src/pages/ExperimentDetails/CodeViewer/index.scss
@@ -13,12 +13,12 @@
 }
 #fileTree {
   border-right: solid var(--theme-stroke-width) var(--theme-stage-border);
-  grid-column: 1 / 1;
+  grid-column: 1 / 2;
   grid-row: 1 / 3;
   padding: 1em;
 
   @media screen and (max-width: 1024px) {
-    grid-column: 1 / 2;
+    grid-column: 1 / 3;
   }
 }
 .ant-tree-node-content-wrapper.ant-tree-node-content-wrapper-normal {


### PR DESCRIPTION
## Description

tickets: 
- [DET-7872]
- [DET-7873]
- [DET-8058]
- [DET-8059]
- [DET-8060]
- [DET-8061]

This PR implements some of the points taken in a dogfooding session. 

Here's the summary of the current changes:

- handle when the file returns an error (can't render the file)
- handle unsupported file types
- display appropriate syntax for the selected file (especially python)
- display error message for empty files
- improve rendering for the tree
    - improve CSS for the tree overall
    - improve the rendering logic to avoid rendering invalid items (as in "Original config" when it's not there)
    - improve the tree behavior, right now it expands horizontally when the tree gets expanded, up to a limit

<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At a minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan

Go to any experiment `/det/experiments/<experiment_id>`, then click the `Code` tab.

The initial render should be the file tree, with the `Configuration` being selected and displayed at the side.
__there shouldn't be any dowload button available__

You can, then, pick any other file from the tree. it should replace the current one (configuration) and you should see the representation as follows.
- a file info component should be atop of the editor containing the file info/path and a downlaod button.
- the editor should be "read only" (for now).

It also has a different layout for screens with `<= 1024px`.

<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions about this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.
- [ ] If modifying `/webui/react/src/shared/` verify `make -C webui/react test-shared` passes.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[DET-7872]: https://determinedai.atlassian.net/browse/DET-7872?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DET-7873]: https://determinedai.atlassian.net/browse/DET-7873?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DET-8058]: https://determinedai.atlassian.net/browse/DET-8058?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DET-8059]: https://determinedai.atlassian.net/browse/DET-8059?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DET-8060]: https://determinedai.atlassian.net/browse/DET-8060?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DET-8061]: https://determinedai.atlassian.net/browse/DET-8061?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ