### PR TITLE
chore: add authz on moving experiments between projects [DET-7750]

### DIFF
--- a/e2e_tests/tests/cluster/test_workspace_org.py
+++ b/e2e_tests/tests/cluster/test_workspace_org.py
@@ -344,8 +344,12 @@ def test_workspace_org() -> None:
             bindings.post_MoveExperiment(sess, experimentId=test_exp_id, body=mbody2)
         bindings.post_UnarchiveProject(sess, id=made_project.id)
 
-        # Moving an experiment into default project
-        bindings.post_MoveExperiment(sess, experimentId=test_exp_id, body=mbody2)
+        # Non-admin user cannot move experiment into default project
+        with pytest.raises(errors.ForbiddenException):
+            bindings.post_MoveExperiment(sess, experimentId=test_exp_id, body=mbody2)
+
+        # Moving an experiment into default project (by admin)
+        bindings.post_MoveExperiment(admin_sess, experimentId=test_exp_id, body=mbody2)
 
         # Cannot move an experiment into an archived project
         bindings.post_ArchiveProject(sess, id=made_project.id)

--- a/e2e_tests/tests/cluster/test_workspace_org.py
+++ b/e2e_tests/tests/cluster/test_workspace_org.py
@@ -344,12 +344,8 @@ def test_workspace_org() -> None:
             bindings.post_MoveExperiment(sess, experimentId=test_exp_id, body=mbody2)
         bindings.post_UnarchiveProject(sess, id=made_project.id)
 
-        # Non-admin user cannot move experiment into default project
-        with pytest.raises(errors.ForbiddenException):
-            bindings.post_MoveExperiment(sess, experimentId=test_exp_id, body=mbody2)
-
-        # Moving an experiment into default project (by admin)
-        bindings.post_MoveExperiment(admin_sess, experimentId=test_exp_id, body=mbody2)
+        # Moving an experiment into default project
+        bindings.post_MoveExperiment(sess, experimentId=test_exp_id, body=mbody2)
 
         # Cannot move an experiment into an archived project
         bindings.post_ArchiveProject(sess, id=made_project.id)

--- a/harness/determined/common/api/bindings.py
+++ b/harness/determined/common/api/bindings.py
@@ -1330,6 +1330,7 @@ class v1Experiment:
         numTrials: int,
         originalConfig: str,
         projectId: int,
+        projectOwnerId: int,
         searcherType: str,
         startTime: str,
         state: "determinedexperimentv1State",
@@ -1376,6 +1377,7 @@ class v1Experiment:
         self.parentArchived = parentArchived
         self.config = config
         self.originalConfig = originalConfig
+        self.projectOwnerId = projectOwnerId
 
     @classmethod
     def from_json(cls, obj: Json) -> "v1Experiment":
@@ -1406,6 +1408,7 @@ class v1Experiment:
             parentArchived=obj.get("parentArchived", None),
             config=obj.get("config", None),
             originalConfig=obj["originalConfig"],
+            projectOwnerId=obj["projectOwnerId"],
         )
 
     def to_json(self) -> typing.Any:
@@ -1436,6 +1439,7 @@ class v1Experiment:
             "parentArchived": self.parentArchived if self.parentArchived is not None else None,
             "config": self.config if self.config is not None else None,
             "originalConfig": self.originalConfig,
+            "projectOwnerId": self.projectOwnerId,
         }
 
 class v1ExperimentSimulation:

--- a/master/internal/api_experiment.go
+++ b/master/internal/api_experiment.go
@@ -1614,7 +1614,7 @@ func (a *apiServer) MoveExperiment(
 			srcProject.Id)
 	}
 
-	if err = project.AuthZProvider.Get().CanMoveProjectExperiments(*curUser, srcProject,
+	if err = project.AuthZProvider.Get().CanMoveProjectExperiments(*curUser, exp, srcProject,
 		destProject); err != nil {
 		return nil, status.Error(codes.PermissionDenied, err.Error())
 	}

--- a/master/internal/api_experiment.go
+++ b/master/internal/api_experiment.go
@@ -1606,6 +1606,11 @@ func (a *apiServer) MoveExperiment(
 	if err != nil {
 		return nil, err
 	}
+	if srcProject.Archived {
+		return nil, errors.Errorf("project (%v) is archived and cannot have experiments moved from it.",
+			srcProject.Id)
+	}
+
 	if err = project.AuthZProvider.Get().CanMoveProjectExperiments(*curUser, srcProject,
 		destProject); err != nil {
 		return nil, status.Error(codes.PermissionDenied, err.Error())

--- a/master/internal/api_experiment.go
+++ b/master/internal/api_experiment.go
@@ -1600,6 +1600,9 @@ func (a *apiServer) MoveExperiment(
 	if err != nil {
 		return nil, err
 	}
+	if exp.Archived {
+		return nil, errors.Errorf("experiment (%v) is archived and cannot be moved.", exp.Id)
+	}
 
 	// check that user can view source project
 	srcProject, err := a.GetProjectByID(exp.ProjectId, *curUser)

--- a/master/internal/api_project_intg_test.go
+++ b/master/internal/api_project_intg_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -19,6 +20,8 @@ import (
 	"github.com/determined-ai/determined/master/internal/mocks"
 	"github.com/determined-ai/determined/master/internal/project"
 	"github.com/determined-ai/determined/master/pkg/model"
+	"github.com/determined-ai/determined/master/pkg/ptrs"
+	"github.com/determined-ai/determined/master/pkg/schemas/expconf"
 	"github.com/determined-ai/determined/proto/pkg/apiv1"
 	"github.com/determined-ai/determined/proto/pkg/projectv1"
 )
@@ -27,6 +30,47 @@ var projectAuthZ *mocks.ProjectAuthZ
 
 func projectNotFoundErr(id int) error {
 	return status.Errorf(codes.NotFound, fmt.Sprintf("project (%d) not found", id))
+}
+
+var minExpConfig = expconf.ExperimentConfig{
+	RawResources: &expconf.ResourcesConfig{
+		RawResourcePool: ptrs.Ptr("kubernetes"),
+	},
+	RawEntrypoint: &expconf.EntrypointV0{"test"},
+	RawCheckpointStorage: &expconf.CheckpointStorageConfig{
+		RawSharedFSConfig: &expconf.SharedFSConfig{
+			RawHostPath: ptrs.Ptr("/"),
+		},
+	},
+	RawHyperparameters: expconf.Hyperparameters{},
+	RawName:            expconf.Name{ptrs.Ptr("name")},
+	RawReproducibility: &expconf.ReproducibilityConfig{ptrs.Ptr(uint32(42))},
+	RawSearcher: &expconf.SearcherConfig{
+		RawMetric: ptrs.Ptr("loss"),
+		RawSingleConfig: &expconf.SingleConfig{
+			&expconf.Length{Units: 10, Unit: "batches"},
+		},
+	},
+}
+
+func createTestExpWithProjectID(
+	t *testing.T, api *apiServer, curUser model.User, projectID int,
+) *model.Experiment {
+	exp := &model.Experiment{
+		JobID:                model.JobID(uuid.New().String()),
+		State:                model.PausedState,
+		OwnerID:              &curUser.ID,
+		ProjectID:            projectID,
+		StartTime:            time.Now(),
+		ModelDefinitionBytes: []byte{10, 11, 12},
+		Config:               minExpConfig,
+	}
+	require.NoError(t, api.m.db.AddExperiment(exp))
+
+	// Get experiment as our API mostly will to make it easier to mock.
+	exp, err := api.m.db.ExperimentWithoutConfigByID(exp.ID)
+	require.NoError(t, err)
+	return exp
 }
 
 func SetupProjectAuthZTest(
@@ -149,7 +193,7 @@ func TestAuthZCanMoveProject(t *testing.T) {
 
 func TestAuthZCanMoveProjectExperiments(t *testing.T) {
 	// Setup.
-	api, projectAuthZ, workspaceAuthZ, _, ctx := SetupProjectAuthZTest(t)
+	api, projectAuthZ, workspaceAuthZ, curUser, ctx := SetupProjectAuthZTest(t)
 
 	workspaceAuthZ.On("CanCreateWorkspace", mock.Anything, mock.Anything).Return(nil).Once()
 	wResp, err := api.PostWorkspace(ctx, &apiv1.PostWorkspaceRequest{Name: uuid.New().String()})
@@ -164,11 +208,8 @@ func TestAuthZCanMoveProjectExperiments(t *testing.T) {
 	require.NoError(t, err)
 	srcProjectID := resp.Project.Id
 
-	expResp, err := api.CreateExperiment(ctx, &apiv1.CreateExperimentRequest{
-		ProjectId: srcProjectID,
-	})
-	require.NoError(t, err)
-	experimentID := expResp.Experiment.Id
+	exp := createTestExpWithProjectID(t, api, curUser, int(srcProjectID))
+	experimentID := exp.ID
 
 	workspaceAuthZ.On("CanGetWorkspace", mock.Anything, mock.Anything).Return(true, nil).Once()
 	projectAuthZ.On("CanCreateProject", mock.Anything, mock.Anything).Return(nil).Once()
@@ -178,23 +219,25 @@ func TestAuthZCanMoveProjectExperiments(t *testing.T) {
 	require.NoError(t, err)
 	destProjectID := resp.Project.Id
 
-	req := &apiv1.MoveExperimentRequest{ExperimentId: experimentID, DestinationProjectId: destProjectID}
+	req := &apiv1.MoveExperimentRequest{
+		ExperimentId:         int32(experimentID),
+		DestinationProjectId: destProjectID,
+	}
 
-	// Can't view project.
+	// Can't view destination project.
+	projectAuthZ.On("CanGetProject", mock.Anything, mock.Anything).Return(false, nil).Once()
+	_, err = api.MoveExperiment(ctx, req)
+	require.Equal(t, projectNotFoundErr(int(destProjectID)).Error(), err.Error())
+
+	// Can't view source project
+	projectAuthZ.On("CanGetProject", mock.Anything, mock.Anything).Return(true, nil).Once()
 	projectAuthZ.On("CanGetProject", mock.Anything, mock.Anything).Return(false, nil).Once()
 	_, err = api.MoveExperiment(ctx, req)
 	require.Equal(t, projectNotFoundErr(int(srcProjectID)).Error(), err.Error())
 
-	// Can't view workspace.
-	projectAuthZ.On("CanGetProject", mock.Anything, mock.Anything).Return(true, nil).Once()
-	workspaceAuthZ.On("CanGetWorkspace", mock.Anything, mock.Anything).Return(false, nil).Once()
-	_, err = api.MoveExperiment(ctx, req)
-	require.Equal(t, workspaceNotFoundErr(int(workspaceID)).Error(), err.Error())
-
 	// Can't move experiment.
 	expectedErr := status.Error(codes.PermissionDenied, "canMoveProjectExperimentsDeny")
-	projectAuthZ.On("CanGetProject", mock.Anything, mock.Anything).Return(true, nil).Once()
-	workspaceAuthZ.On("CanGetWorkspace", mock.Anything, mock.Anything).Return(true, nil).Twice()
+	projectAuthZ.On("CanGetProject", mock.Anything, mock.Anything).Return(true, nil).Twice()
 	projectAuthZ.On("CanMoveProjectExperiments", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return(fmt.Errorf("canMoveProjectExperimentsDeny")).Once()
 	_, err = api.MoveExperiment(ctx, req)

--- a/master/internal/mocks/project_authz_iface.go
+++ b/master/internal/mocks/project_authz_iface.go
@@ -5,6 +5,8 @@ package mocks
 import (
 	mock "github.com/stretchr/testify/mock"
 
+	experimentv1 "github.com/determined-ai/determined/proto/pkg/experimentv1"
+
 	model "github.com/determined-ai/determined/master/pkg/model"
 
 	projectv1 "github.com/determined-ai/determined/proto/pkg/projectv1"
@@ -94,13 +96,13 @@ func (_m *ProjectAuthZ) CanMoveProject(curUser model.User, _a1 *projectv1.Projec
 	return r0
 }
 
-// CanMoveProjectExperiments provides a mock function with given fields: curUser, from, to
-func (_m *ProjectAuthZ) CanMoveProjectExperiments(curUser model.User, from *projectv1.Project, to *projectv1.Project) error {
-	ret := _m.Called(curUser, from, to)
+// CanMoveProjectExperiments provides a mock function with given fields: curUser, exp, from, to
+func (_m *ProjectAuthZ) CanMoveProjectExperiments(curUser model.User, exp *experimentv1.Experiment, from *projectv1.Project, to *projectv1.Project) error {
+	ret := _m.Called(curUser, exp, from, to)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(model.User, *projectv1.Project, *projectv1.Project) error); ok {
-		r0 = rf(curUser, from, to)
+	if rf, ok := ret.Get(0).(func(model.User, *experimentv1.Experiment, *projectv1.Project, *projectv1.Project) error); ok {
+		r0 = rf(curUser, exp, from, to)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/master/internal/mocks/project_authz_iface.go
+++ b/master/internal/mocks/project_authz_iface.go
@@ -94,6 +94,20 @@ func (_m *ProjectAuthZ) CanMoveProject(curUser model.User, _a1 *projectv1.Projec
 	return r0
 }
 
+// CanMoveProjectExperiments provides a mock function with given fields: curUser, from, to
+func (_m *ProjectAuthZ) CanMoveProjectExperiments(curUser model.User, from *projectv1.Project, to *projectv1.Project) error {
+	ret := _m.Called(curUser, from, to)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(model.User, *projectv1.Project, *projectv1.Project) error); ok {
+		r0 = rf(curUser, from, to)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // CanSetProjectDescription provides a mock function with given fields: curUser, _a1
 func (_m *ProjectAuthZ) CanSetProjectDescription(curUser model.User, _a1 *projectv1.Project) error {
 	ret := _m.Called(curUser, _a1)

--- a/master/internal/project/authz_basic_impl.go
+++ b/master/internal/project/authz_basic_impl.go
@@ -101,7 +101,7 @@ func (a *ProjectAuthZBasic) CanMoveProject(
 func (a *ProjectAuthZBasic) CanMoveProjectExperiments(
 	curUser model.User, exp *experimentv1.Experiment, from, to *projectv1.Project,
 ) error {
-	if !curUser.Admin || model.UserID(exp.UserId) != curUser.ID {
+	if !curUser.Admin && curUser.ID != model.UserID(exp.UserId) {
 		return fmt.Errorf("non admin users can't move others' experiments")
 	}
 	return nil

--- a/master/internal/project/authz_basic_impl.go
+++ b/master/internal/project/authz_basic_impl.go
@@ -104,11 +104,7 @@ func (a *ProjectAuthZBasic) CanMoveProjectExperiments(
 	if !curUser.Admin || model.UserID(exp.UserId) != curUser.ID {
 		return fmt.Errorf("non admin users can't move others' experiments")
 	}
-	if curUser.Admin || ((from.Immutable || model.UserID(from.UserId) == curUser.ID) &&
-		model.UserID(to.UserId) == curUser.ID) {
-		return nil
-	}
-	return fmt.Errorf("non admin users can't move experiments from or into others' projects")
+	return nil
 }
 
 // CanArchiveProject returns an error if a non admin isn't the owner of the project or workspace.

--- a/master/internal/project/authz_basic_impl.go
+++ b/master/internal/project/authz_basic_impl.go
@@ -96,6 +96,17 @@ func (a *ProjectAuthZBasic) CanMoveProject(
 	return nil
 }
 
+// CanMoveProjectExperiments returns an error if the user isn't a admin or owner of a project.
+func (a *ProjectAuthZBasic) CanMoveProjectExperiments(
+	curUser model.User, from, to *projectv1.Project,
+) error {
+	if !curUser.Admin && !from.Immutable && ((curUser.ID != model.UserID(from.UserId)) ||
+		(curUser.ID != model.UserID(to.UserId))) {
+		return fmt.Errorf("non admin users can't move experiments from others' projects")
+	}
+	return nil
+}
+
 // CanArchiveProject returns an error if a non admin isn't the owner of the project or workspace.
 func (a *ProjectAuthZBasic) CanArchiveProject(
 	curUser model.User, project *projectv1.Project,

--- a/master/internal/project/authz_basic_impl.go
+++ b/master/internal/project/authz_basic_impl.go
@@ -100,11 +100,11 @@ func (a *ProjectAuthZBasic) CanMoveProject(
 func (a *ProjectAuthZBasic) CanMoveProjectExperiments(
 	curUser model.User, from, to *projectv1.Project,
 ) error {
-	if !curUser.Admin && !from.Immutable && ((curUser.ID != model.UserID(from.UserId)) ||
-		(curUser.ID != model.UserID(to.UserId))) {
-		return fmt.Errorf("non admin users can't move experiments from others' projects")
+	if curUser.Admin || from.Immutable || ((model.UserID(from.UserId) == curUser.ID) &&
+		(model.UserID(to.UserId) == curUser.ID)) {
+		return nil
 	}
-	return nil
+	return fmt.Errorf("non admin users can't move experiments from others' projects")
 }
 
 // CanArchiveProject returns an error if a non admin isn't the owner of the project or workspace.

--- a/master/internal/project/authz_iface.go
+++ b/master/internal/project/authz_iface.go
@@ -3,6 +3,7 @@ package project
 import (
 	"github.com/determined-ai/determined/master/internal/authz"
 	"github.com/determined-ai/determined/master/pkg/model"
+	"github.com/determined-ai/determined/proto/pkg/experimentv1"
 	"github.com/determined-ai/determined/proto/pkg/projectv1"
 	"github.com/determined-ai/determined/proto/pkg/workspacev1"
 )
@@ -34,7 +35,9 @@ type ProjectAuthZ interface {
 	) error
 
 	// POST /api/v1/experiments/:experiment_id/move
-	CanMoveProjectExperiments(curUser model.User, from, to *projectv1.Project) error
+	CanMoveProjectExperiments(
+		curUser model.User, exp *experimentv1.Experiment, from, to *projectv1.Project,
+	) error
 
 	// POST /api/v1/projects/:project_id/archive
 	CanArchiveProject(curUser model.User, project *projectv1.Project) error

--- a/master/internal/project/authz_iface.go
+++ b/master/internal/project/authz_iface.go
@@ -33,6 +33,9 @@ type ProjectAuthZ interface {
 		curUser model.User, project *projectv1.Project, from, to *workspacev1.Workspace,
 	) error
 
+	// POST /api/v1/experiments/:experiment_id/move
+	CanMoveProjectExperiments(curUser model.User, from, to *projectv1.Project) error
+
 	// POST /api/v1/projects/:project_id/archive
 	CanArchiveProject(curUser model.User, project *projectv1.Project) error
 	// POST /api/v1/projects/:project_id/unarchive

--- a/master/static/srv/get_experiment.sql
+++ b/master/static/srv/get_experiment.sql
@@ -26,6 +26,7 @@ SELECT
 	  (SELECT count(id) FROM trial_ids) AS num_trials,
     p.id AS project_id,
     p.name AS project_name,
+    p.user_id AS project_owner_id,
     w.id AS workspace_id,
     w.name AS workspace_name,
     (w.archived OR p.archived) AS parent_archived

--- a/master/static/srv/get_experiments.sql
+++ b/master/static/srv/get_experiments.sql
@@ -25,7 +25,8 @@ WITH page_info AS (
     ), $9, $10) AS page_info
 ),
 pj AS (
-  SELECT projects.id, projects.name AS project_name, workspaces.name AS workspace_name
+  SELECT projects.id, projects.name AS project_name, projects.user_id AS project_owner_id,
+    workspaces.name AS workspace_name
   FROM projects
   JOIN workspaces ON workspaces.id = projects.workspace_id
 ),
@@ -55,6 +56,7 @@ exps AS (
         u.username AS username,
         COALESCE(u.display_name, u.username) as display_name,
         pj.project_name,
+        pj.project_owner_id,
         pj.workspace_name
     FROM experiments e
     JOIN users u ON e.owner_id = u.id

--- a/master/static/srv/move_experiment.sql
+++ b/master/static/srv/move_experiment.sql
@@ -1,20 +1,3 @@
-WITH e AS (
-  SELECT id, project_id FROM experiments
-  WHERE id = $1
-  AND NOT archived
-),
-p AS (
-  SELECT projects.id, projects.workspace_id FROM projects, e
-  WHERE projects.id = e.project_id
-  AND NOT projects.archived
-),
-w AS (
-  SELECT COUNT(*) FROM workspaces, p
-  WHERE workspaces.id = p.workspace_id
-  AND NOT workspaces.archived
-)
 UPDATE experiments SET project_id = $2
-WHERE experiments.id = (SELECT id FROM e)
-AND experiments.project_id = (SELECT id FROM p)
-AND (SELECT count FROM w) > 0
-RETURNING experiments.id;
+WHERE id = $1
+RETURNING id;

--- a/proto/src/determined/experiment/v1/experiment.proto
+++ b/proto/src/determined/experiment/v1/experiment.proto
@@ -54,7 +54,8 @@ message Experiment {
         "job_id",
         "searcher_type",
         "project_id",
-        "original_config"
+        "original_config",
+        "project_owner_id"
       ]
     }
   };
@@ -111,6 +112,8 @@ message Experiment {
   google.protobuf.Struct config = 26;
   // The original configuration that the user submitted.
   string original_config = 27;
+  // The id of the user who created the parent project.
+  int32 project_owner_id = 28;
 }
 
 // PatchExperiment is a partial update to an experiment with only id required.

--- a/webui/react/src/hooks/useModal/Experiment/useModalExperimentMove.tsx
+++ b/webui/react/src/hooks/useModal/Experiment/useModalExperimentMove.tsx
@@ -108,7 +108,7 @@ const useModalExperimentMove = ({ onClose, user }: Props): ModalHooks => {
       const response = await getWorkspaceProjects({
         id: destSettings.workspaceId,
         limit: 0,
-        users: (!user || !user.isAdmin) ? [] : [ user.username ],
+        users: (!user || user.isAdmin) ? [] : [ user.username ],
       });
       setProjects((prev) => (isEqual(prev, response.projects) ? prev : response.projects));
     } catch (e) {

--- a/webui/react/src/hooks/useModal/Experiment/useModalExperimentMove.tsx
+++ b/webui/react/src/hooks/useModal/Experiment/useModalExperimentMove.tsx
@@ -73,7 +73,7 @@ const moveExperimentWithHandler = async (
   }
 };
 
-const useModalExperimentMove = ({ onClose, user }: Props): ModalHooks => {
+const useModalExperimentMove = ({ onClose }: Props): ModalHooks => {
   const {
     settings: destSettings,
     updateSettings: updateDestSettings,
@@ -108,7 +108,7 @@ const useModalExperimentMove = ({ onClose, user }: Props): ModalHooks => {
       const response = await getWorkspaceProjects({
         id: destSettings.workspaceId,
         limit: 0,
-        users: (!user || user.isAdmin) ? [] : [ user.username ],
+        // users: (!user || user.isAdmin) ? [] : [ user.username ],
       });
       setProjects((prev) => (isEqual(prev, response.projects) ? prev : response.projects));
     } catch (e) {
@@ -120,7 +120,7 @@ const useModalExperimentMove = ({ onClose, user }: Props): ModalHooks => {
         type: ErrorType.Server,
       });
     }
-  }, [ destSettings.workspaceId, user ]);
+  }, [ destSettings.workspaceId ]);
 
   useEffect(() => {
     if (modalRef.current) fetchWorkspaces();

--- a/webui/react/src/hooks/useModal/Experiment/useModalExperimentMove.tsx
+++ b/webui/react/src/hooks/useModal/Experiment/useModalExperimentMove.tsx
@@ -13,7 +13,7 @@ import Icon from 'shared/components/Icon/Icon';
 import useModal, { ModalHooks as Hooks } from 'shared/hooks/useModal/useModal';
 import { isEqual } from 'shared/utils/data';
 import { ErrorLevel, ErrorType } from 'shared/utils/error';
-import { Project, Workspace } from 'types';
+import { DetailedUser, Project, Workspace } from 'types';
 import handleError from 'utils/error';
 
 import css from './useModalExperimentMove.module.scss';
@@ -22,6 +22,7 @@ const { Option } = Select;
 
 interface Props {
   onClose?: () => void;
+  user?: DetailedUser;
 }
 
 export interface ShowModalProps {
@@ -72,7 +73,7 @@ const moveExperimentWithHandler = async (
   }
 };
 
-const useModalExperimentMove = ({ onClose }: Props): ModalHooks => {
+const useModalExperimentMove = ({ onClose, user }: Props): ModalHooks => {
   const {
     settings: destSettings,
     updateSettings: updateDestSettings,
@@ -107,6 +108,7 @@ const useModalExperimentMove = ({ onClose }: Props): ModalHooks => {
       const response = await getWorkspaceProjects({
         id: destSettings.workspaceId,
         limit: 0,
+        users: (!user || !user.isAdmin) ? [] : [ user.username ],
       });
       setProjects((prev) => (isEqual(prev, response.projects) ? prev : response.projects));
     } catch (e) {
@@ -118,7 +120,7 @@ const useModalExperimentMove = ({ onClose }: Props): ModalHooks => {
         type: ErrorType.Server,
       });
     }
-  }, [ destSettings.workspaceId ]);
+  }, [ destSettings.workspaceId, user ]);
 
   useEffect(() => {
     if (modalRef.current) fetchWorkspaces();

--- a/webui/react/src/pages/ProjectDetails.tsx
+++ b/webui/react/src/pages/ProjectDetails.tsx
@@ -554,7 +554,7 @@ const ProjectDetails: React.FC = () => {
   const {
     contextHolder: modalExperimentMoveContextHolder,
     modalOpen: openMoveModal,
-  } = useModalExperimentMove({ onClose: handleActionComplete });
+  } = useModalExperimentMove({ onClose: handleActionComplete, user });
 
   const sendBatchActions = useCallback((action: Action): Promise<void[] | CommandTask> | void => {
     if (!settings.row) return;

--- a/webui/react/src/pages/TrialDetails/TrialInfoBox.stories.tsx
+++ b/webui/react/src/pages/TrialDetails/TrialInfoBox.stories.tsx
@@ -44,6 +44,7 @@ const trialDetails: TrialDetails = {
 const experimentDetails: ExperimentBase = {
   parentArchived: false,
   projectName: 'Uncategorized',
+  projectOwnerId: 1,
   workspaceId: 1,
   workspaceName: 'Uncategorized',
   ...sampleExperiment,

--- a/webui/react/src/pages/TrialDetails/TrialRangeHyperparameters.stories.tsx
+++ b/webui/react/src/pages/TrialDetails/TrialRangeHyperparameters.stories.tsx
@@ -227,6 +227,7 @@ const TrialRangeHyperparametersContainer = () => {
     parentArchived: false,
     projectId: 1,
     projectName: 'Uncategorized',
+    projectOwnerId: 1,
     resourcePool: 'default',
     startTime: '2021-06-09T15:26:57.610700Z',
     state: RunState.Completed,

--- a/webui/react/src/services/api-ts-sdk/api.ts
+++ b/webui/react/src/services/api-ts-sdk/api.ts
@@ -1977,6 +1977,12 @@ export interface V1Experiment {
      * @memberof V1Experiment
      */
     originalConfig: string;
+    /**
+     * The id of the user who created the parent project.
+     * @type {number}
+     * @memberof V1Experiment
+     */
+    projectOwnerId: number;
 }
 
 /**

--- a/webui/react/src/services/decoder.ts
+++ b/webui/react/src/services/decoder.ts
@@ -384,6 +384,7 @@ export const mapV1GetExperimentDetailsResponse = (
     originalConfig: exp.originalConfig,
     parentArchived: exp.parentArchived ?? false,
     projectName: exp.projectName ?? '',
+    projectOwnerId: exp.projectOwnerId ?? 0,
     workspaceId: exp.workspaceId ?? 0,
     workspaceName: exp.workspaceName ?? '',
   };

--- a/webui/react/src/storybook/shared/generateTestExperiments.ts
+++ b/webui/react/src/storybook/shared/generateTestExperiments.ts
@@ -225,6 +225,7 @@ export const generateTestExperimentData = ():
     parentArchived: false,
     projectId: 1,
     projectName: 'project',
+    projectOwnerId: 1,
     resourcePool: 'default',
     startTime: '2021-06-09T15:26:57.610700Z',
     state: RunState.Completed,

--- a/webui/react/src/types.ts
+++ b/webui/react/src/types.ts
@@ -507,6 +507,7 @@ export interface ExperimentItem {
 export interface ProjectExperiment extends ExperimentItem {
   parentArchived: boolean;
   projectName: string;
+  projectOwnerId: number;
   workspaceId: number;
   workspaceName: string;
 }

--- a/webui/react/src/utils/experiment.ts
+++ b/webui/react/src/utils/experiment.ts
@@ -153,7 +153,6 @@ const experimentCheckers: Record<ExperimentAction, ExperimentChecker> = {
   [ExperimentAction.Move]: (experiment, user) =>
     !!user &&
     (user.isAdmin || user.id === experiment.userId) &&
-    (user.id === experiment.projectOwnerId || experiment.projectId === 1) &&
     !experiment?.parentArchived &&
     !experiment.archived,
 

--- a/webui/react/src/utils/experiment.ts
+++ b/webui/react/src/utils/experiment.ts
@@ -152,7 +152,8 @@ const experimentCheckers: Record<ExperimentAction, ExperimentChecker> = {
 
   [ExperimentAction.Move]: (experiment, user) =>
     !!user &&
-    (user.isAdmin || user.id === experiment.projectOwnerId || experiment.projectId === 1) &&
+    (user.isAdmin || user.id === experiment.userId) &&
+    (user.id === experiment.projectOwnerId || experiment.projectId === 1) &&
     !experiment?.parentArchived &&
     !experiment.archived,
 

--- a/webui/react/src/utils/experiment.ts
+++ b/webui/react/src/utils/experiment.ts
@@ -152,7 +152,7 @@ const experimentCheckers: Record<ExperimentAction, ExperimentChecker> = {
 
   [ExperimentAction.Move]: (experiment, user) =>
     !!user &&
-    (user.isAdmin || user.id === experiment.userId) &&
+    (user.isAdmin || user.id === experiment.projectOwnerId || experiment.projectId === 1) &&
     !experiment?.parentArchived &&
     !experiment.archived,
 
@@ -215,6 +215,7 @@ export const getProjectExperimentForExperimentItem = (
     parentArchived: !!project?.archived,
     projectId: project?.id ?? 0,
     projectName: project?.name,
+    projectOwnerId: project?.userId ?? 0,
     workspaceId: project?.workspaceId ?? 0,
     workspaceName: project?.workspaceName,
   } as ProjectExperiment);


### PR DESCRIPTION
## Description

My goal is to add permissions on moving experiments and incorporate it into the authz interface

- [Already required] Destination project must be visible to the user (through `GetProjectByID`)
- [Already required] Destination project cannot be archived
- Moved experiment must be visible to the user (runs through `getExperiment`, which doesn't use authz yet, but will)
- Experiment's source project must be visible to the user (through `GetProjectByID`)
- Call new `CanMoveProjectExperiments` authz

Conditions to allow `CanMoveProjectExperiments`:
- admin user
- immutable source project [not quite right, but tl;dr I don't want to block users from withdrawing experiments from their default Uncategorized project]
- user with ownership of both source and destination projects [this doesn't seem right, maybe it should be user owns experiment, and we already have restrictions on viewable source and destination?]
 
## Checklist

- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.
- [x] If modifying `/webui/react/src/shared/` verify `make -C webui/react test-shared` passes.