### PR TITLE
fix: correctly display nested categorical hyperparameters [DET-8074]

### DIFF
--- a/webui/react/src/pages/ExperimentDetails/ExperimentVisualization.tsx
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentVisualization.tsx
@@ -86,6 +86,7 @@ const ExperimentVisualization: React.FC<Props> = ({
     name: experiment.config.searcher.metric,
     type: MetricType.Validation,
   });
+  console.log(experiment.hyperparameters);
   const fullHParams = useRef<string[]>(
     (Object.keys(experiment.hyperparameters || {}).filter((key) => {
       // Constant hyperparameters are not useful for visualizations.

--- a/webui/react/src/pages/ExperimentDetails/ExperimentVisualization.tsx
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentVisualization.tsx
@@ -86,7 +86,6 @@ const ExperimentVisualization: React.FC<Props> = ({
     name: experiment.config.searcher.metric,
     type: MetricType.Validation,
   });
-  console.log(experiment.hyperparameters);
   const fullHParams = useRef<string[]>(
     (Object.keys(experiment.hyperparameters || {}).filter((key) => {
       // Constant hyperparameters are not useful for visualizations.

--- a/webui/react/src/pages/ExperimentDetails/ExperimentVisualization/HpParallelCoordinates.tsx
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentVisualization/HpParallelCoordinates.tsx
@@ -214,7 +214,7 @@ const HpParallelCoordinates: React.FC<Props> = ({
           Object.keys(flatHParams).forEach((hpKey) => {
             const hpValue = flatHParams[hpKey];
             trialHpMap[hpKey] = trialHpMap[hpKey] || {};
-            trialHpMap[hpKey][id] = hpValue;
+            trialHpMap[hpKey][id] = JSON.stringify(hpValue);
           });
 
           trialHpTableMap[id] = {
@@ -243,8 +243,6 @@ const HpParallelCoordinates: React.FC<Props> = ({
         // Gather hparams for trial table.
         const newTrialHps = trialIds.map((id) => trialHpTableMap[id]);
         setTrialHps(newTrialHps);
-
-        console.log(data);
 
         setChartData({
           data,

--- a/webui/react/src/pages/ExperimentDetails/ExperimentVisualization/HpParallelCoordinates.tsx
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentVisualization/HpParallelCoordinates.tsx
@@ -143,7 +143,12 @@ const HpParallelCoordinates: React.FC<Props> = ({
       const hp = hyperparameters[key] || {};
 
       if (hp.type === HyperparameterType.Categorical || hp.vals) {
-        return { categories: hp.vals ?? [], key, label: key, type: DimensionType.Categorical };
+        return {
+          categories: hp.vals?.map((val) => JSON.stringify(val)) ?? [],
+          key,
+          label: key,
+          type: DimensionType.Categorical,
+        };
       } else if (hp.type === HyperparameterType.Log) {
         return { key, label: key, logBase: hp.base, type: DimensionType.Logarithmic };
       }

--- a/webui/react/src/pages/ExperimentDetails/ExperimentVisualization/HpParallelCoordinates.tsx
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentVisualization/HpParallelCoordinates.tsx
@@ -244,6 +244,8 @@ const HpParallelCoordinates: React.FC<Props> = ({
         const newTrialHps = trialIds.map((id) => trialHpTableMap[id]);
         setTrialHps(newTrialHps);
 
+        console.log(data);
+
         setChartData({
           data,
           metricRange,

--- a/webui/react/src/pages/ExperimentDetails/ExperimentVisualization/HpParallelCoordinates.tsx
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentVisualization/HpParallelCoordinates.tsx
@@ -207,7 +207,10 @@ const HpParallelCoordinates: React.FC<Props> = ({
           trialMetricsMap[id] = trial.metric;
           trialMetricRange = updateRange<number>(trialMetricRange, trial.metric);
 
-          const flatHParams = flattenObject(trial.hparams || {});
+          // This allows for both typical nested hyperparameters and nested categorgical
+          // hyperparameter values to be shown, with HpTrialTable deciding which are displayed.
+          const flatHParams = { ...trial.hparams, ...flattenObject(trial.hparams || {}) };
+
           Object.keys(flatHParams).forEach((hpKey) => {
             const hpValue = flatHParams[hpKey];
             trialHpMap[hpKey] = trialHpMap[hpKey] || {};

--- a/webui/react/src/pages/ExperimentDetails/ExperimentVisualization/HpTrialTable.module.scss
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentVisualization/HpTrialTable.module.scss
@@ -1,10 +1,16 @@
-.idLayout {
-  align-items: center;
-  display: flex;
-}
-.colorLegend {
-  border-radius: var(--theme-border-radius);
-  height: 20px;
-  margin-right: 8px;
-  width: 20px;
+
+.base {
+  .idLayout {
+    align-items: center;
+    display: flex;
+  }
+  .colorLegend {
+    border-radius: var(--theme-border-radius);
+    height: 20px;
+    margin-right: 8px;
+    width: 20px;
+  }
+  :global(.ant-table-cell) {
+    max-width: 400px;
+  }
 }

--- a/webui/react/src/pages/ExperimentDetails/ExperimentVisualization/HpTrialTable.tsx
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentVisualization/HpTrialTable.tsx
@@ -1,3 +1,4 @@
+import { Typography } from 'antd';
 import React, { useCallback, useMemo, useState } from 'react';
 
 import HumanReadableNumber from 'components/HumanReadableNumber';
@@ -111,7 +112,11 @@ const HpTrialTable: React.FC<Props> = ({
         if (isNumber(value) && isValidType) {
           return <HumanReadableNumber num={value} />;
         }
-        return value + '';
+        return (
+          <Typography.Paragraph ellipsis={{ rows: 1, tooltip: true }}>
+            {JSON.stringify(value)}
+          </Typography.Paragraph>
+        );
       };
     };
     const hpColumnSorter = (key: string) => {
@@ -157,6 +162,7 @@ const HpTrialTable: React.FC<Props> = ({
 
   return (
     <ResponsiveTable<TrialHParams>
+      className={css.base}
       columns={columns}
       dataSource={dataSource}
       pagination={getPaginationConfig(dataSource.length, pageSize)}

--- a/webui/react/src/pages/ExperimentDetails/ExperimentVisualization/LearningCurve.tsx
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentVisualization/LearningCurve.tsx
@@ -61,15 +61,12 @@ const LearningCurve: React.FC<Props> = ({
   const hasTrials = trialHps.length !== 0;
   const isExperimentTerminal = terminalRunStates.has(experiment.state as RunState);
 
-  console.log({ fullHParams });
-
   const hyperparameters = useMemo(() => {
     return fullHParams.reduce((acc, key) => {
       acc[key] = experiment.hyperparameters[key];
       return acc;
     }, {} as Record<string, Hyperparameter>);
   }, [ experiment.hyperparameters, fullHParams ]);
-  console.log({ hyperparameters });
 
   const handleTrialClick = useCallback((event: MouseEvent, trialId: number) => {
     const href = paths.trialDetails(trialId, experiment.id);
@@ -133,9 +130,11 @@ const LearningCurve: React.FC<Props> = ({
 
         (event.trials || []).forEach((trial) => {
           const id = trial.trialId;
-          //console.log(flattenObject(trial.hparams));
-          //const flatHParams = flattenObject(trial.hparams || {});
-          const flatHParams = trial.hparams;
+
+          // This allows for both typical nested hyperparameters and nested categorgical
+          // hyperparameter values to be shown, with HpTrialTable deciding which are displayed.
+          const flatHParams = { ...trial.hparams, ...flattenObject(trial.hparams || {}) };
+
           const hasHParams = Object.keys(flatHParams).length !== 0;
 
           if (hasHParams && !trialHpMap[id]) {

--- a/webui/react/src/pages/ExperimentDetails/ExperimentVisualization/LearningCurve.tsx
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentVisualization/LearningCurve.tsx
@@ -61,12 +61,15 @@ const LearningCurve: React.FC<Props> = ({
   const hasTrials = trialHps.length !== 0;
   const isExperimentTerminal = terminalRunStates.has(experiment.state as RunState);
 
+  console.log({ fullHParams });
+
   const hyperparameters = useMemo(() => {
     return fullHParams.reduce((acc, key) => {
       acc[key] = experiment.hyperparameters[key];
       return acc;
     }, {} as Record<string, Hyperparameter>);
   }, [ experiment.hyperparameters, fullHParams ]);
+  console.log({ hyperparameters });
 
   const handleTrialClick = useCallback((event: MouseEvent, trialId: number) => {
     const href = paths.trialDetails(trialId, experiment.id);
@@ -130,7 +133,9 @@ const LearningCurve: React.FC<Props> = ({
 
         (event.trials || []).forEach((trial) => {
           const id = trial.trialId;
-          const flatHParams = flattenObject(trial.hparams || {});
+          //console.log(flattenObject(trial.hparams));
+          //const flatHParams = flattenObject(trial.hparams || {});
+          const flatHParams = trial.hparams;
           const hasHParams = Object.keys(flatHParams).length !== 0;
 
           if (hasHParams && !trialHpMap[id]) {

--- a/webui/react/src/pages/TrialDetails/TrialRangeHyperparameters.module.scss
+++ b/webui/react/src/pages/TrialDetails/TrialRangeHyperparameters.module.scss
@@ -11,7 +11,8 @@
     align-self: center;
     display: flex;
     flex-direction: column;
-    min-width: 200px;
+    max-width: 500px;
+    min-width: 250px;
   }
   .title {
     align-self: center;
@@ -88,6 +89,7 @@
   .pointerText {
     background-color: var(--theme-float);
     border-radius: 2px;
+    max-width: 100%;
     padding: 2px 8px;
 
     &::after {
@@ -100,5 +102,8 @@
       top: 0;
       width: 8px;
     }
+  }
+  :global(.ant-typography) {
+    margin: 0;
   }
 }

--- a/webui/react/src/pages/TrialDetails/TrialRangeHyperparameters.tsx
+++ b/webui/react/src/pages/TrialDetails/TrialRangeHyperparameters.tsx
@@ -1,8 +1,9 @@
-import { Tooltip } from 'antd';
+import { Tooltip, Typography } from 'antd';
 import React, { useMemo } from 'react';
 
 import HumanReadableNumber from 'components/HumanReadableNumber';
 import Section from 'components/Section';
+import { unflattenObject } from 'shared/utils/data';
 import { clamp } from 'shared/utils/number';
 import {
   ExperimentBase, HyperparameterType, TrialDetails,
@@ -29,13 +30,14 @@ const TrialRangeHyperparameters: React.FC<Props> = ({ experiment, trial }: Props
       return {
         name: name,
         range: value.type === HyperparameterType.Log ?
-          [ (value.base || 10) ** (value.minval || -5),
-            (value.base || 10) ** (value.maxval || 1) ] :
-          [ value.minval || 0, value.maxval || 1 ],
+          [ (value.base ?? 10) ** (value.minval ?? -5),
+            (value.base ?? 10) ** (value.maxval ?? 1) ] :
+          [ value.minval ?? 0, value.maxval ?? 1 ],
         type: value.type,
-        val: String(trial.hyperparameters[name] || 0),
-        vals: value.vals?.map((val) => String(val)) ||
-          [ String(value.minval || 0), String(value.maxval || 1) ],
+        val: JSON.stringify(trial.hyperparameters[name] ??
+          unflattenObject(trial.hyperparameters)[name] ?? 0),
+        vals: value.vals?.map((val) => JSON.stringify(val)) ??
+          [ JSON.stringify(value.minval ?? 0), JSON.stringify(value.maxval ?? 1) ],
       };
     });
   }, [ experiment.hyperparameters, trial.hyperparameters ]);
@@ -106,8 +108,13 @@ const ValuesTrack: React.FC<TrackProps> = ({ hp }: TrackProps) => {
     case HyperparameterType.Categorical:
       return (
         <div className={css.valuesTrack}>
-          {hp.vals.map((option) =>
-            <p className={css.text} key={option.toString()}>{option}</p>)}
+          {hp.vals.map((option) => (
+            <Typography.Paragraph
+              ellipsis={{ rows: 1, tooltip: true }}
+              key={option.toString()}>
+              <p className={css.text}>{option}</p>
+            </Typography.Paragraph>
+          ))}
         </div>
       );
     case HyperparameterType.Log:
@@ -116,7 +123,7 @@ const ValuesTrack: React.FC<TrackProps> = ({ hp }: TrackProps) => {
           {(new Array(Math.floor(Math.log10((hp.range[1]) / (hp.range[0])) + 1))).fill(null)
             .map((_, idx) => (
               <p className={css.text} key={idx}>
-                {String((hp.range[1]) / (10 ** idx)).length > 4 ?
+                {JSON.stringify((hp.range[1]) / (10 ** idx)).length > 4 ?
                   ((hp.range[1]) / (10 ** idx)).toExponential() :
                   (hp.range[1]) / (10 ** idx)}
               </p>
@@ -173,9 +180,12 @@ interface PHRVProps {
 const ParsedHumanReadableValue: React.FC<PHRVProps> = ({ hp }: PHRVProps) => {
   switch (hp.type) {
     case HyperparameterType.Categorical:
-      return <p className={css.text}>{hp.val}</p>;
     case HyperparameterType.Constant:
-      return <p className={css.text}>{hp.val}</p>;
+      return (
+        <Typography.Paragraph ellipsis={{ rows: 1, tooltip: true }}>
+          <p className={css.text}>{hp.val}</p>
+        </Typography.Paragraph>
+      );
     case HyperparameterType.Double:
       return (
         <p className={css.text}>

--- a/webui/react/src/routes/routes.ts
+++ b/webui/react/src/routes/routes.ts
@@ -35,25 +35,25 @@ const routes: RouteConfig[] = [
   {
     id: 'trialDetails',
     needAuth: true,
-    path: '/experiments/:experimentId/trials/:trialId',
-    title: 'Trial',
-  },
-  {
-    id: 'trialDetails',
-    needAuth: true,
     path: '/experiments/:experimentId/trials/:trialId/:tab',
     title: 'Trial',
   },
   {
     id: 'trialDetails',
     needAuth: true,
-    path: '/trials/:trialId',
+    path: '/experiments/:experimentId/trials/:trialId',
     title: 'Trial',
   },
   {
     id: 'trialDetails',
     needAuth: true,
     path: '/trials/:trialId/:tab',
+    title: 'Trial',
+  },
+  {
+    id: 'trialDetails',
+    needAuth: true,
+    path: '/trials/:trialId',
     title: 'Trial',
   },
   {
@@ -125,7 +125,7 @@ const routes: RouteConfig[] = [
     icon: 'cluster',
     id: 'cluster',
     needAuth: true,
-    path: '/cluster',
+    path: '/cluster/:tab',
     redirect: '/clusters',
     title: 'Cluster',
   },
@@ -133,15 +133,8 @@ const routes: RouteConfig[] = [
     icon: 'cluster',
     id: 'cluster',
     needAuth: true,
-    path: '/cluster/:tab',
+    path: '/cluster',
     redirect: '/clusters',
-    title: 'Cluster',
-  },
-  {
-    icon: 'cluster',
-    id: 'clusters',
-    needAuth: true,
-    path: '/clusters',
     title: 'Cluster',
   },
   {
@@ -151,6 +144,14 @@ const routes: RouteConfig[] = [
     path: '/clusters/:tab',
     title: 'Cluster',
   },
+  {
+    icon: 'cluster',
+    id: 'clusters',
+    needAuth: true,
+    path: '/clusters',
+    title: 'Cluster',
+  },
+
   {
     id: 'resourcepool',
     needAuth: true,


### PR DESCRIPTION
## Description
From ticket:

> To repro, run a hp search experiment where one of parameters is categorical, e.g. as suggested in the thread:
> ```
> scheduler:
>       type: categorical
>       vals:
>         - _type: "WarmupDecayLR"
>           params:
>             warmup_min_lr: 0
>             warmup_num_steps: 100
>             total_num_steps: 1841
>             warmup_type: "linear"
>         - _type: "WarmupLR"
>           params:
>             warmup_min_lr: 0
>             warmup_num_steps: 100
>             warmup_type: "linear"
> ```
> Issue:
- >  In visualization → learning curve UI the parameter value is displayed as “undefined”.
- >  In visualization → hp parallel coordinates it is displayed as “[object Object]”

<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At a minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan
Try to repro, parameter values should show up as stringified JSON instead of `undefined` or `[object Object]`
<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions about this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.
- [ ] If modifying `/webui/react/src/shared/` verify `make -C webui/react test-shared` passes.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ