### PR TITLE
fix: handle avgMetrics response on trials of multi-trial experiment

### DIFF
--- a/webui/react/src/services/decoder.ts
+++ b/webui/react/src/services/decoder.ts
@@ -430,6 +430,9 @@ export const mapV1ExperimentList = (data: Sdk.V1Experiment[]): types.ExperimentI
 
 const filterNonScalarMetrics = (metrics: RawJson): RawJson | undefined => {
   if (!isObject(metrics)) return undefined;
+  if (metrics.avgMetrics) {
+    return filterNonScalarMetrics(metrics.avgMetrics);
+  }
   const scalarMetrics: RawJson = {};
   for (const key in metrics) {
     if ([ 'Infinity', '-Infinity', 'NaN' ].includes(metrics[key])) {


### PR DESCRIPTION
## Description

When viewing an individual trial on a multi-trial experiment, the endpoint returns `metrics: { avgMetrics: {...}, batchMetrics: [ ... ] }` instead of a single `metrics` object. On [latest-master](http://latest-master.determined.ai:8080/det/experiments/1292/trials/3709?filter=All&metric=validation%7Cvalidation_loss&metric=training%7Closs) the result is a workloads table with no numbers.

This modifies `filterNonScalarMetrics` to get metrics out of `metrics.avgMetrics` if it exists.

Edit: this also fixes `bestValidationMetric` and `latestValidationMetric` in the trial comparison table.

## Test Plan

- Single-trial experiment has numbers in workloads table.
- While running a multi-trial experiment, numbers appear in `bestValidationMetric` and `latestValidationMetric` columns.
- After running a multi-trial experiment, select one trial, and confirm numbers appear in the workloads table

## Checklist

- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.
- [x] If modifying `/webui/react/src/shared/` verify `make -C webui/react test-shared` passes.