### PR TITLE
chore: fix random/grid searcher bug with max_concurrent_trials

### DIFF
--- a/docs/release-notes/max-cc-searcher-bugs.rst
+++ b/docs/release-notes/max-cc-searcher-bugs.rst
@@ -1,0 +1,6 @@
+:orphan:
+
+**Bug Fixes**
+
+-  Hyperparameter Search: Prevent the random and grid hyperparameter searches from spawning more
+   trials than allowed by ``max_concurrent_trials`` in the event of trial failures.

--- a/e2e_tests/tests/experiment/__init__.py
+++ b/e2e_tests/tests/experiment/__init__.py
@@ -28,6 +28,7 @@ from .experiment import (
     trial_logs,
     trial_metrics,
     wait_for_experiment_state,
+    wait_for_trial_state,
     workloads_with_checkpoint,
     workloads_with_training,
     workloads_with_validation,

--- a/e2e_tests/tests/experiment/experiment.py
+++ b/e2e_tests/tests/experiment/experiment.py
@@ -67,6 +67,11 @@ def cancel_experiment(experiment_id: int) -> None:
     wait_for_experiment_state(experiment_id, determinedexperimentv1State.STATE_CANCELED)
 
 
+def cancel_trial(trial_id: int) -> None:
+    bindings.post_KillTrial(determined_test_session(), id=trial_id)
+    wait_for_trial_state(trial_id, determinedexperimentv1State.STATE_CANCELED)
+
+
 def wait_for_experiment_state(
     experiment_id: int,
     target_state: determinedexperimentv1State,
@@ -120,6 +125,61 @@ def wait_for_experiment_state(
         report_failed_experiment(experiment_id)
         pytest.fail(
             "Experiment did not reach target state {} after {} seconds".format(
+                target_state.value, max_wait_secs
+            )
+        )
+
+
+def wait_for_trial_state(
+    trial_id: int,
+    target_state: determinedexperimentv1State,
+    max_wait_secs: int = conf.DEFAULT_MAX_WAIT_SECS,
+    log_every: int = 60,
+) -> None:
+    for seconds_waited in range(max_wait_secs):
+        try:
+            state = trial_state(trial_id)
+        # Ignore network errors while polling for experiment state to avoid a
+        # single network flake to cause a test suite failure. If the master is
+        # unreachable multiple times, this test will fail after max_wait_secs.
+        except api.errors.MasterNotFoundException:
+            logging.warning(
+                "Network failure ignored when polling for state of " "trial {}".format(trial_id)
+            )
+            time.sleep(1)
+            continue
+        except api.errors.NotFoundException:
+            logging.warning("Trial not yet available to check state: " "trial {}".format(trial_id))
+            time.sleep(0.25)
+            continue
+
+        if state == target_state:
+            return
+
+        if is_terminal_state(state):
+            if state != target_state:
+                report_failed_trial(trial_id, target_state=target_state, state=state)
+
+            pytest.fail(
+                f"Trial {trial_id} terminated in {state.value} state, "
+                f"expected {target_state.value}"
+            )
+
+        if seconds_waited > 0 and seconds_waited % log_every == 0:
+            print(
+                f"Waited {seconds_waited} seconds for trial {trial_id} "
+                f"(currently {state.value}) to reach {target_state.value}"
+            )
+
+        time.sleep(1)
+
+    else:
+        state = trial_state(trial_id)
+        if target_state == determinedexperimentv1State.STATE_COMPLETED:
+            cancel_trial(trial_id)
+        report_failed_trial(trial_id, target_state=target_state, state=state)
+        pytest.fail(
+            "Trial did not reach target state {} after {} seconds".format(
                 target_state.value, max_wait_secs
             )
         )
@@ -213,6 +273,11 @@ def experiment_config_json(experiment_id: int) -> Dict[str, Any]:
 def experiment_state(experiment_id: int) -> determinedexperimentv1State:
     r = bindings.get_GetExperiment(determined_test_session(), experimentId=experiment_id)
     return r.experiment.state
+
+
+def trial_state(trial_id: int) -> determinedexperimentv1State:
+    r = bindings.get_GetTrial(determined_test_session(), trialId=trial_id)
+    return r.trial.state
 
 
 class TrialPlusWorkload:
@@ -529,8 +594,10 @@ def report_failed_experiment(experiment_id: int) -> None:
         print_trial_logs(trial.trial.id)
 
 
-def report_failed_trial(trial_id: int, state: str) -> None:
-    print(f"Trial {trial_id} was not COMPLETED but {state}", file=sys.stderr)
+def report_failed_trial(
+    trial_id: int, target_state: determinedexperimentv1State, state: determinedexperimentv1State
+) -> None:
+    print(f"Trial {trial_id} was not {target_state.value} but {state.value}", file=sys.stderr)
     print_trial_logs(trial_id)
 
 
@@ -609,7 +676,11 @@ def verify_completed_experiment_metadata(
     for t in trials:
         trial = t.trial
         if trial.state != determinedexperimentv1State.STATE_COMPLETED:
-            report_failed_trial(trial.id, trial.state.value)
+            report_failed_trial(
+                trial.id,
+                target_state=determinedexperimentv1State.STATE_COMPLETED,
+                state=trial.state,
+            )
             pytest.fail(f"Trial {trial.id} was not STATE_COMPLETED but {trial.state.value}")
 
         if not expect_workloads:

--- a/e2e_tests/tests/experiment/experiment.py
+++ b/e2e_tests/tests/experiment/experiment.py
@@ -311,10 +311,6 @@ def cancel_single(experiment_id: int, should_have_trial: bool = False) -> None:
         assert trial.state == determinedexperimentv1State.STATE_CANCELED
 
 
-def cancel_trial(trial_id: int) -> None:
-    bindings.post_KillTrial(determined_test_session(), id=trial_id)
-
-
 def is_terminal_state(state: determinedexperimentv1State) -> bool:
     return state in (
         determinedexperimentv1State.STATE_CANCELED,

--- a/master/pkg/searcher/grid.go
+++ b/master/pkg/searcher/grid.go
@@ -95,18 +95,7 @@ func (s *gridSearch) progress(
 func (s *gridSearch) trialExitedEarly(
 	ctx context, requestID model.RequestID, exitedReason model.ExitedReason,
 ) ([]Operation, error) {
-	s.PendingTrials--
-	var ops []Operation
-	if len(s.RemainingTrials) > 0 {
-		params := s.RemainingTrials[len(s.RemainingTrials)-1]
-		s.RemainingTrials = s.RemainingTrials[:len(s.RemainingTrials)-1]
-		create := NewCreate(ctx.rand, params, model.TrialWorkloadSequencerType)
-		ops = append(ops, create)
-		ops = append(ops, NewValidateAfter(create.RequestID, s.MaxLength().Units))
-		ops = append(ops, NewClose(create.RequestID))
-		s.PendingTrials++
-	}
-	return ops, nil
+	return nil, nil
 }
 
 func (s *gridSearch) trialClosed(ctx context, _ model.RequestID) ([]Operation, error) {

--- a/master/pkg/searcher/random.go
+++ b/master/pkg/searcher/random.go
@@ -103,14 +103,10 @@ func (s *randomSearch) trialExitedEarly(
 	s.PendingTrials--
 	if s.SearchMethodType == RandomSearch {
 		if exitedReason == model.InvalidHP || exitedReason == model.InitInvalidHP {
-			var ops []Operation
-			create := NewCreate(ctx.rand, sampleAll(ctx.hparams, ctx.rand), model.TrialWorkloadSequencerType)
-			ops = append(ops, create)
-			ops = append(ops, NewValidateAfter(create.RequestID, s.MaxLength().Units))
-			ops = append(ops, NewClose(create.RequestID))
-			// We don't increment CreatedTrials here because this trial is replacing the invalid trial.
-			s.PendingTrials++
-			return ops, nil
+			// We decrement CreatedTrials here because this trial is replacing the invalid trial.
+			// It will be created by trialClosed when the close is received for this trial.
+			s.CreatedTrials--
+			return nil, nil
 		}
 	}
 	return nil, nil


### PR DESCRIPTION
## Description
This change fixes a bug where, if trials exited early under the grid or random searchers when using `max_concurrent_trials`, it would cause double the amount of trials to be spawned in its place, exceeding max concurrent trials. This was caused by the searcher hooking into both 'trial exited early' and 'trial closed' events as notification a trial had closed when 'trial closed' is already emitted for every trial ('trial exited early' is just an additive event for failed and invalid HP trials).
<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At a minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan
- [x] add an e2e (this is an e2e and not a searcher unit because this was an experiment<->trial<->searcher interaction bug)
<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions about this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist
- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.
- [x] If modifying `/webui/react/src/shared/` verify `make -C webui/react test-shared` passes.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ