### PR TITLE
fix: do not bypass torch.distributed.launch for single-slot trials

### DIFF
--- a/docs/release-notes/torch-distributed-single-slot.txt
+++ b/docs/release-notes/torch-distributed-single-slot.txt
@@ -1,0 +1,5 @@
+:orphan:
+
+**Breaking Changes**
+-  Distributed training: experiments launched with the torch distributed launch layer previously would override
+single-slot behavior to skip torch.distributed.run.

--- a/docs/release-notes/torch-distributed-single-slot.txt
+++ b/docs/release-notes/torch-distributed-single-slot.txt
@@ -1,7 +1,7 @@
 :orphan:
 
-**Breaking Changes**
--  Distributed training: previously, experiments launched with determined.launch.torch_distributed was wrongly skipping
+**Fixes**
+-  Distributed training: previously, experiments launched with determined.launch.torch_distributed were wrongly skipping
 torch.distributed.run for single-slot trials and invoking training scripts directly. As a result, functions such as
 torch.distributed.init_process_group() would fail, but only inside single-slot trials. Now,
 determined.launch.torch_distributed will be more in line with intended behavior as a wrapper around

--- a/docs/release-notes/torch-distributed-single-slot.txt
+++ b/docs/release-notes/torch-distributed-single-slot.txt
@@ -1,5 +1,8 @@
 :orphan:
 
 **Breaking Changes**
--  Distributed training: experiments launched with the torch distributed launch layer previously would override
-single-slot behavior to skip torch.distributed.run.
+-  Distributed training: previously, experiments launched with determined.launch.torch_distributed was wrongly skipping
+torch.distributed.run for single-slot trials and invoking training scripts directly. As a result, functions such as
+torch.distributed.init_process_group() would fail, but only inside single-slot trials. Now,
+determined.launch.torch_distributed will be more in line with intended behavior as a wrapper around
+torch.distributed.run and will invoke torch.distributed.run on all training scripts.

--- a/docs/release-notes/torch-distributed-single-slot.txt
+++ b/docs/release-notes/torch-distributed-single-slot.txt
@@ -4,5 +4,5 @@
 -  Distributed training: previously, experiments launched with determined.launch.torch_distributed were wrongly skipping
 torch.distributed.run for single-slot trials and invoking training scripts directly. As a result, functions such as
 torch.distributed.init_process_group() would fail, but only inside single-slot trials. Now,
-determined.launch.torch_distributed will be more in line with intended behavior as a wrapper around
+determined.launch.torch_distributed will conform to the intended behavior as a wrapper around
 torch.distributed.run and will invoke torch.distributed.run on all training scripts.

--- a/harness/determined/launch/torch_distributed.py
+++ b/harness/determined/launch/torch_distributed.py
@@ -75,14 +75,6 @@ def main(override_args: List[str], script: List[str]) -> int:
     info = det.get_cluster_info()
     assert info is not None, "must be run on-cluster"
 
-    single_slot = len(info.container_addrs) == 1 and len(info.slot_ids) <= 1
-
-    # Detect single-slot trials and skip distributed launch
-    if single_slot:
-        p = subprocess.Popen(script)
-        with det.util.forward_signals(p):
-            return p.wait()
-
     os.environ["USE_TORCH_DISTRIBUTED"] = "True"
 
     chief_ip = info.container_addrs[0]


### PR DESCRIPTION
## Description

we bypass torch.distributed.launch behavior by automatically detecting single-slot trials and just calling the training script. 
<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At a minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions about this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist
- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.
- [ ] If modifying `/webui/react/src/shared/` verify `make -C webui/react test-shared` passes.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ