### PR TITLE
fix: Pass user ids for experiments users filter

### DIFF
--- a/webui/react/src/pages/ProjectDetails.tsx
+++ b/webui/react/src/pages/ProjectDetails.tsx
@@ -485,7 +485,7 @@ const ProjectDetails: React.FC = () => {
         dataIndex: 'user',
         defaultWidth: DEFAULT_COLUMN_WIDTHS['user'],
         filterDropdown: userFilterDropdown,
-        filters: users.map((user) => ({ text: getDisplayName(user), value: user.username })),
+        filters: users.map((user) => ({ text: getDisplayName(user), value: user.id })),
         isFiltered: (settings: ProjectDetailsSettings) => !!settings.user,
         key: V1GetExperimentsRequestSortBy.USER,
         render: userRenderer,


### PR DESCRIPTION
## Description

Fixing a reported issue with the experiment users filter -- the intention is to list users by display name in the UI, and send user-IDs to apiConfig to query the API.  In this table, the selector value was still username, so users were ignored unless their username could be parsed as an int ("123-abc").

I checked the similar code for the Models and Tasks tables and both use this line to have the user ID as the value.

## Test Plan

- Select one or more users from the users dropdown
- Verify that only experiments matching those users appear in the table
- Reset users list
- Models and tasks filter successfully

## Checklist
- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.
- [x] If modifying `/webui/react/src/shared/` verify `make -C webui/react test-shared` passes.