### PR TITLE
ci: fix flakes in test_max_concurrent_trials

### DIFF
--- a/e2e_tests/tests/experiment/__init__.py
+++ b/e2e_tests/tests/experiment/__init__.py
@@ -11,6 +11,7 @@ from .experiment import (
     experiment_has_active_workload,
     experiment_has_completed_workload,
     wait_for_experiment_active_workload,
+    wait_for_at_least_n_trials,
     wait_for_experiment_workload_progress,
     experiment_config_json,
     experiment_state,

--- a/e2e_tests/tests/experiment/experiment.py
+++ b/e2e_tests/tests/experiment/experiment.py
@@ -210,6 +210,21 @@ def wait_for_experiment_active_workload(
     )
 
 
+def wait_for_at_least_n_trials(
+    experiment_id: int,
+    n: int,
+    timeout: int = 30,
+) -> List["TrialPlusWorkload"]:
+    """Wait for enough trials to start, then return the trials found."""
+    deadline = time.time() + timeout
+    while True:
+        trials = experiment_trials(experiment_id)
+        if len(trials) >= n:
+            return trials
+        if time.time() > deadline:
+            raise TimeoutError(f"did not see {n} trials running in {timeout}s; trials={trials}")
+
+
 def wait_for_experiment_workload_progress(
     experiment_id: int, max_ticks: int = conf.MAX_TRIAL_BUILD_SECS
 ) -> None:


### PR DESCRIPTION
There was a race condition where two trials might not get created at the
exact same time, creating the possibility for false negatives