### PR TITLE
remove leftover pagination total fields

### DIFF
--- a/webui/react/src/pages/TrialsComparison/Table/TrialTable.tsx
+++ b/webui/react/src/pages/TrialsComparison/Table/TrialTable.tsx
@@ -44,7 +44,6 @@ interface Props {
   containerRef : MutableRefObject<HTMLElement | null>,
   highlights: Highlights<V1AugmentedTrial>;
   tableSettingsHook: SettingsHook<InteractiveTableSettings>;
-  total: number;
   trialsWithMetadata: TrialsWithMetadata;
 }
 
@@ -66,7 +65,6 @@ const TrialTable: React.FC<Props> = ({
   containerRef,
   highlights,
   tableSettingsHook,
-  total,
 }: Props) => {
 
   const { settings, updateSettings } = tableSettingsHook;
@@ -466,8 +464,8 @@ const TrialTable: React.FC<Props> = ({
     return getFullPaginationConfig({
       limit,
       offset,
-    }, total);
-  }, [ settings.tableLimit, settings.tableOffset, total ]);
+    }, fakeTotal);
+  }, [ settings.tableLimit, settings.tableOffset ]);
 
   return (
     <InteractiveTable<V1AugmentedTrial>

--- a/webui/react/src/pages/TrialsComparison/Trials/data.ts
+++ b/webui/react/src/pages/TrialsComparison/Trials/data.ts
@@ -49,7 +49,6 @@ export interface TrialsWithMetadata {
   maxBatch: number;
   metricKeys: Record<MetricKey, boolean>;
   metrics: Metric[];
-  total: number;
 }
 
 export const aggregrateTrialsMetadata =
@@ -64,7 +63,6 @@ export const aggregrateTrialsMetadata =
     maxBatch: Math.max(agg.maxBatch, trial.totalBatches),
     metricKeys: { ...agg.metricKeys, ...tMetrics, ...vMetrics },
     metrics: [],
-    total: 0, //overwritten outside
   };
 };
 

--- a/webui/react/src/pages/TrialsComparison/TrialsComparison.tsx
+++ b/webui/react/src/pages/TrialsComparison/TrialsComparison.tsx
@@ -96,7 +96,6 @@ const TrialsComparison: React.FC<Props> = ({ projectId }) => {
             containerRef={containerRef}
             highlights={highlights}
             tableSettingsHook={tableSettingsHook}
-            total={trials.total}
             trialsWithMetadata={trials}
           />
         </div>


### PR DESCRIPTION
we do not do a total count for performance reasons.

`fakeTotal` is a hack to get infinite pagination

antd complains with 
```
Warning: [antd: Table] `dataSource` length is less than `pagination.total` but large than `pagination.pageSize`. Please make sure your config correct data with async mode. 
```
but it doesn't seem to matter?