### PR TITLE
chore: allow OrderBy in GetExperimentCheckpoints for SortBy SearcherMetrics

### DIFF
--- a/master/internal/api_experiment.go
+++ b/master/internal/api_experiment.go
@@ -642,15 +642,10 @@ func (a *apiServer) GetExperimentCheckpoints(
 		return nil, status.Errorf(codes.NotFound, "experiment %d not found", req.Id)
 	}
 
-	// Override the order by for searcher metric.
-	if req.SortBy == apiv1.GetExperimentCheckpointsRequest_SORT_BY_SEARCHER_METRIC {
-		if req.OrderBy != apiv1.OrderBy_ORDER_BY_UNSPECIFIED {
-			return nil, status.Error(
-				codes.InvalidArgument,
-				"cannot specify order by which is implied with sort by searcher metric",
-			)
-		}
-
+	// If SORT_BY_SEARCHER_METRIC is specified without an OrderBy
+	// default to ordering by "better" checkpoints.
+	if req.SortBy == apiv1.GetExperimentCheckpointsRequest_SORT_BY_SEARCHER_METRIC &&
+		req.OrderBy == apiv1.OrderBy_ORDER_BY_UNSPECIFIED {
 		exp, err := a.m.db.ExperimentByID(int(req.Id))
 		if err != nil {
 			return nil, fmt.Errorf("scanning for experiment: %w", err)


### PR DESCRIPTION

## Description

If OrderBy is unspecified for sortBy SearcherMetrics sort by best, otherwise follow ASC or DESC. 


## Test Plan

Call ```GetExperimentsCheckpoints``` with ```SearcherMetrics``` 

With ```OrderBy``` unspecified and make sure ```searcherMetrics``` in the response has "best" according to metric at the top

With ```OrderBy``` DESC and make sure ```searcherMetrics``` is in DESC order
With ```OrderBy``` ASC and make sure ```searcherMetrics``` is in ASC order


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist
- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.
- [ ] If modifying `/webui/react/src/shared/` verify `make -C webui/react test-shared` passes.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
