### PR TITLE
chore: set torch_geometric version in example to fix e2e test.

### DIFF
--- a/examples/graphs/proteins_pytorch_geometric/startup-hook.sh
+++ b/examples/graphs/proteins_pytorch_geometric/startup-hook.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-pip install torch_geometric
+pip install torch_geometric==2.0.4
 pip install torch_sparse torch_scatter -f https://pytorch-geometric.com/whl/torch-1.10.2+cu113.html


### PR DESCRIPTION
## Description

Set `torch_geometric==2.0.4` in example to avoid behavior change in `2.1.0` that breaks nightly e2e gpu test.


## Test Plan

Verify the `test-e2e-gpu-nightly` CI test `test_protein_pytorch_geometric` runs successfully.

## Checklist
- [X] Changes have been manually QA'd
- [N/A] User-facing API changes need the "User-facing API Change" label.
- [N/A] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [N/A] Licenses should be included for new code which was copied and/or modified from any external code.
- [N/A] If modifying `/webui/react/src/shared/` verify `make -C webui/react test-shared` passes.