### PR TITLE
feat: helm chart: add OIDC and SCIM options [DPS-204]

### DIFF
--- a/helm/charts/determined/templates/master-config.yaml
+++ b/helm/charts/determined/templates/master-config.yaml
@@ -70,6 +70,34 @@ data:
       {{- end }}
     port: {{ include "determined.masterPort" . }}
 
+    {{- if .Values.enterpriseEdition }}
+    {{- if .Values.oidc }}
+    oidc:
+      enabled: {{ .Values.oidc.enabled | default true }}
+      provider: {{ required "A valid provider entry is required!" .Values.oidc.provider}}
+      idp_recipient_url: {{ required "A valid recipient url is required!" .Values.oidc.idpRecipientUrl }}
+      idp_sso_url: {{ required "A valid sso url is required!" .Values.oidc.idpSsoUrl }}
+      client_id: {{ required "A valid client ID is required!" .Values.oidc.clientId }}
+      {{- if .Values.oidc.authenticationClaim }}
+      authentication_claim: {{ .Values.oidc.authenticationClaim }}
+      {{- end }}
+      {{- if .Values.oidc.scimAuthenticationAttribute }}
+      scim_authentication_attribute: {{ .Values.oidc.scimAuthenticationAttribute }}
+      {{- end }}
+    {{- end }}
+
+    {{- if .Values.scim }}
+    scim:
+      enabled: {{ .Values.scim.enabled | default true }}
+      auth:
+        type: {{ required "A valid authentication type is required!" .Values.scim.auth.type }}
+        {{- if eq .Values.scim.auth.type "basic" }}
+        username: {{ required "A valid username is required!" .Values.scim.auth.username }}
+        password: {{ required "A valid password type is required!" .Values.scim.auth.password }}
+        {{- end }}
+    {{- end }}
+    {{- end }}
+
     resource_manager:
       type: "kubernetes"
       namespace: {{ .Release.Namespace }}

--- a/helm/charts/determined/templates/master-deployment.yaml
+++ b/helm/charts/determined/templates/master-deployment.yaml
@@ -27,7 +27,7 @@ spec:
       - name: determined-master-{{ .Release.Name }}
         {{ $image := "determined-master" }}
         {{- if .Values.enterpriseEdition -}}
-          {{ $image = "hpecaide-master" }}
+          {{ $image = "hpe-mlde-master" }}
         {{- end -}}
         {{ $tag := (required "A valid Chart.AppVersion entry required!" .Chart.AppVersion) }}
         {{- /* detVersion is used for CI to override the appVersion. */ -}}
@@ -36,6 +36,17 @@ spec:
         {{- end -}}
         image: {{ .Values.imageRegistry }}/{{ $image }}:{{ $tag }}
         imagePullPolicy: "Always"
+        {{- if .Values.enterpriseEdition }}
+        {{- if .Values.oidc }}
+        env:
+          - name: DETERMINED_OIDC_CLIENT_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: {{ required "A valid client secret name is required!" .Values.oidc.clientSecretName }}
+                key: {{ required "A valid client secret filename is required!" .Values.oidc.clientSecretKey }}
+                optional: false
+        {{- end }}
+        {{- end }}
         volumeMounts:
           - name: master-config
             mountPath: /etc/determined/

--- a/helm/charts/determined/values.yaml
+++ b/helm/charts/determined/values.yaml
@@ -43,6 +43,30 @@ useNodePortForMaster: false
   #   group: det-nobody
   #   gid: 65533
 
+# oidc (EE-only) enables OpenID Connect Integration, which is only available if enterpriseEdition
+# is true. It allows users to use single sign-on with their organization’s identity provider.
+# clientSecretKey is the key of the secret contained in the secret.
+# oidc:
+#   enabled:
+#   provider:
+#   idpRecipientUrl:
+#   idpSsoUrl:
+#   clientId:
+#   clientSecretKey:
+#   clientSecretName:
+#   authenticationClaim:
+#   scimAuthenticationAttribute:
+
+# scim (EE-only) enables System for Cross-domain Identity Management (SCIM) integration, which is
+# only available if enterpriseEdition is true. It allows administrators to easily and securely
+# provision users and groups through their standard identity provider (IdP).
+# scim:
+#   enabled: true
+#   auth:
+#     type: basic
+#     username: determined
+#     password: password
+
 # db sets the configurations for the database.
 db:
   # To deploy your own Postgres DB, provide a hostAddress. If hostAddress is provided, Determined


### PR DESCRIPTION
## Description

add OIDC and SCIM (EE-only) configuration options to helm chart [DPS-204]

## Test Plan

1. Fill in the new options in `helm/charts/determined/values.yaml`:

```yaml
enterpriseEdition: true
oidc:
  enabled: true
  provider: Okta
  idpRecipientUrl: http://localhost:8080
  idpSsoUrl: https://dev-########.okta.com
  clientId: <client_id>
  clientSecretKey: client-secret
  clientSecretName: oidc
scim:
  enabled: true
  auth:
    type: basic
    username: determined
    password: password
```

2. Add `command` and `args` keys under the hierarchy below in `helm/charts/determined/templates/master-deployment.yaml`:

```yaml
spec:
  template:
    spec:
      containers:
      - name: determined-master-{{ .Release.Name }}
        command: ["sleep"]
        args: ["999d"]
```

3. Store the OIDC client secret in a k8s secret:

```Shell
$ kubectl create secret generic oidc --from-literal=client-secret=<client_secret>
```

4. Deploy the helm chart

```Shell
$ helm install foo helm/charts/determined
```

5. Get the master pod name:

```Shell
$ kubectl get pods
NAME                              READY  STATUS   RESTARTS  AGE
determined-db-deployment-foo      1/1    Running  1         4h40m
determined-master-deployment-foo  1/1    Running  0         47m
```

6. Verify `DETERMINED_OIDC_CLIENT_SECRET` contains the OIDC client secret:

```
$ kubectl exec -it determined-master-deployment-foo -- printenv | grep OIDC_CLIENT_SECRET
DETERMINED_OIDC_CLIENT_SECRET=<client_secret>
```

7. Verify `oidc` and `scim` stanzas in the master config:

```Shell
$ det -u admin master config | sed -n '/^ /H; /^ /!x; /^oidc/p; /^scim/p'
oidc:
  authentication_claim: email
  client_id: <client_id>
  client_secret: ''
  enabled: true
  idp_recipient_url: http://localhost:8080
  idp_sso_url: https://dev-########.okta.com
  provider: Okta
  scim_authentication_attribute: userName
scim:
  auth:
    password: '********'
    type: basic
    username: '********'
  enabled: true
```

## Checklist
- [x] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.
- [x] If modifying `/webui/react/src/shared/` verify `make -C webui/react test-shared` passes.

[DPS-204]: https://determinedai.atlassian.net/browse/DPS-204?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ