### PR TITLE
chore: add stream argument to Session._do_request

### DIFF
--- a/bindings/generate_bindings.py
+++ b/bindings/generate_bindings.py
@@ -447,6 +447,7 @@ class Function:
         out += ["        data=None,"]
         out += ["        headers=None,"]
         out += ["        timeout=None,"]
+        out += ["        stream=False,"]
         out += ["    )"]
         for expect, returntype in responses.items():
             out += [f"    if _resp.status_code == {expect}:"]

--- a/harness/determined/common/api/_session.py
+++ b/harness/determined/common/api/_session.py
@@ -31,6 +31,7 @@ class Session:
         data: Optional[str],
         headers: Optional[Dict[str, Any]],
         timeout: Optional[int],
+        stream: bool,
     ) -> requests.Response:
         return request.do_request(
             method,
@@ -43,6 +44,7 @@ class Session:
             cert=self._cert,
             headers=headers,
             timeout=timeout,
+            stream=stream,
             max_retries=self._max_retries,
         )
 
@@ -52,8 +54,9 @@ class Session:
         params: Optional[Dict[str, Any]] = None,
         headers: Optional[Dict[str, Any]] = None,
         timeout: Optional[int] = None,
+        stream: bool = False,
     ) -> requests.Response:
-        return self._do_request("GET", path, params, None, None, headers, timeout)
+        return self._do_request("GET", path, params, None, None, headers, timeout, stream)
 
     def delete(
         self,
@@ -62,7 +65,7 @@ class Session:
         headers: Optional[Dict[str, Any]] = None,
         timeout: Optional[int] = None,
     ) -> requests.Response:
-        return self._do_request("DELETE", path, params, None, None, headers, timeout)
+        return self._do_request("DELETE", path, params, None, None, headers, timeout, False)
 
     def post(
         self,
@@ -73,7 +76,7 @@ class Session:
         headers: Optional[Dict[str, Any]] = None,
         timeout: Optional[int] = None,
     ) -> requests.Response:
-        return self._do_request("POST", path, params, json, data, headers, timeout)
+        return self._do_request("POST", path, params, json, data, headers, timeout, False)
 
     def patch(
         self,
@@ -84,7 +87,7 @@ class Session:
         headers: Optional[Dict[str, Any]] = None,
         timeout: Optional[int] = None,
     ) -> requests.Response:
-        return self._do_request("PATCH", path, params, json, data, headers, timeout)
+        return self._do_request("PATCH", path, params, json, data, headers, timeout, False)
 
     def put(
         self,
@@ -95,4 +98,4 @@ class Session:
         headers: Optional[Dict[str, Any]] = None,
         timeout: Optional[int] = None,
     ) -> requests.Response:
-        return self._do_request("PUT", path, params, json, data, headers, timeout)
+        return self._do_request("PUT", path, params, json, data, headers, timeout, False)

--- a/harness/determined/common/api/bindings.py
+++ b/harness/determined/common/api/bindings.py
@@ -6439,6 +6439,7 @@ def post_AckAllocationPreemptionSignal(
         data=None,
         headers=None,
         timeout=None,
+        stream=False,
     )
     if _resp.status_code == 200:
         return
@@ -6458,6 +6459,7 @@ def post_ActivateExperiment(
         data=None,
         headers=None,
         timeout=None,
+        stream=False,
     )
     if _resp.status_code == 200:
         return
@@ -6478,6 +6480,7 @@ def post_AddProjectNote(
         data=None,
         headers=None,
         timeout=None,
+        stream=False,
     )
     if _resp.status_code == 200:
         return v1AddProjectNoteResponse.from_json(_resp.json())
@@ -6498,6 +6501,7 @@ def post_AllocationAllGather(
         data=None,
         headers=None,
         timeout=None,
+        stream=False,
     )
     if _resp.status_code == 200:
         return v1AllocationAllGatherResponse.from_json(_resp.json())
@@ -6518,6 +6522,7 @@ def post_AllocationPendingPreemptionSignal(
         data=None,
         headers=None,
         timeout=None,
+        stream=False,
     )
     if _resp.status_code == 200:
         return
@@ -6540,6 +6545,7 @@ def get_AllocationPreemptionSignal(
         data=None,
         headers=None,
         timeout=None,
+        stream=False,
     )
     if _resp.status_code == 200:
         return v1AllocationPreemptionSignalResponse.from_json(_resp.json())
@@ -6560,6 +6566,7 @@ def post_AllocationReady(
         data=None,
         headers=None,
         timeout=None,
+        stream=False,
     )
     if _resp.status_code == 200:
         return
@@ -6580,6 +6587,7 @@ def get_AllocationRendezvousInfo(
         data=None,
         headers=None,
         timeout=None,
+        stream=False,
     )
     if _resp.status_code == 200:
         return v1AllocationRendezvousInfoResponse.from_json(_resp.json())
@@ -6599,6 +6607,7 @@ def post_ArchiveExperiment(
         data=None,
         headers=None,
         timeout=None,
+        stream=False,
     )
     if _resp.status_code == 200:
         return
@@ -6618,6 +6627,7 @@ def post_ArchiveModel(
         data=None,
         headers=None,
         timeout=None,
+        stream=False,
     )
     if _resp.status_code == 200:
         return
@@ -6637,6 +6647,7 @@ def post_ArchiveProject(
         data=None,
         headers=None,
         timeout=None,
+        stream=False,
     )
     if _resp.status_code == 200:
         return
@@ -6656,6 +6667,7 @@ def post_ArchiveWorkspace(
         data=None,
         headers=None,
         timeout=None,
+        stream=False,
     )
     if _resp.status_code == 200:
         return
@@ -6675,6 +6687,7 @@ def post_CancelExperiment(
         data=None,
         headers=None,
         timeout=None,
+        stream=False,
     )
     if _resp.status_code == 200:
         return
@@ -6708,6 +6721,7 @@ def get_CompareTrials(
         data=None,
         headers=None,
         timeout=None,
+        stream=False,
     )
     if _resp.status_code == 200:
         return v1CompareTrialsResponse.from_json(_resp.json())
@@ -6728,6 +6742,7 @@ def post_CompleteTrialSearcherValidation(
         data=None,
         headers=None,
         timeout=None,
+        stream=False,
     )
     if _resp.status_code == 200:
         return
@@ -6747,6 +6762,7 @@ def post_ComputeHPImportance(
         data=None,
         headers=None,
         timeout=None,
+        stream=False,
     )
     if _resp.status_code == 200:
         return
@@ -6766,6 +6782,7 @@ def post_CreateExperiment(
         data=None,
         headers=None,
         timeout=None,
+        stream=False,
     )
     if _resp.status_code == 200:
         return v1CreateExperimentResponse.from_json(_resp.json())
@@ -6783,6 +6800,7 @@ def get_CurrentUser(
         data=None,
         headers=None,
         timeout=None,
+        stream=False,
     )
     if _resp.status_code == 200:
         return v1CurrentUserResponse.from_json(_resp.json())
@@ -6802,6 +6820,7 @@ def delete_DeleteCheckpoints(
         data=None,
         headers=None,
         timeout=None,
+        stream=False,
     )
     if _resp.status_code == 200:
         return
@@ -6821,6 +6840,7 @@ def delete_DeleteExperiment(
         data=None,
         headers=None,
         timeout=None,
+        stream=False,
     )
     if _resp.status_code == 200:
         return
@@ -6840,6 +6860,7 @@ def delete_DeleteModel(
         data=None,
         headers=None,
         timeout=None,
+        stream=False,
     )
     if _resp.status_code == 200:
         return
@@ -6860,6 +6881,7 @@ def delete_DeleteModelVersion(
         data=None,
         headers=None,
         timeout=None,
+        stream=False,
     )
     if _resp.status_code == 200:
         return
@@ -6879,6 +6901,7 @@ def delete_DeleteProject(
         data=None,
         headers=None,
         timeout=None,
+        stream=False,
     )
     if _resp.status_code == 200:
         return v1DeleteProjectResponse.from_json(_resp.json())
@@ -6898,6 +6921,7 @@ def delete_DeleteTemplate(
         data=None,
         headers=None,
         timeout=None,
+        stream=False,
     )
     if _resp.status_code == 200:
         return
@@ -6917,6 +6941,7 @@ def delete_DeleteWorkspace(
         data=None,
         headers=None,
         timeout=None,
+        stream=False,
     )
     if _resp.status_code == 200:
         return v1DeleteWorkspaceResponse.from_json(_resp.json())
@@ -6937,6 +6962,7 @@ def post_DisableAgent(
         data=None,
         headers=None,
         timeout=None,
+        stream=False,
     )
     if _resp.status_code == 200:
         return v1DisableAgentResponse.from_json(_resp.json())
@@ -6957,6 +6983,7 @@ def post_DisableSlot(
         data=None,
         headers=None,
         timeout=None,
+        stream=False,
     )
     if _resp.status_code == 200:
         return v1DisableSlotResponse.from_json(_resp.json())
@@ -6976,6 +7003,7 @@ def post_EnableAgent(
         data=None,
         headers=None,
         timeout=None,
+        stream=False,
     )
     if _resp.status_code == 200:
         return v1EnableAgentResponse.from_json(_resp.json())
@@ -6996,6 +7024,7 @@ def post_EnableSlot(
         data=None,
         headers=None,
         timeout=None,
+        stream=False,
     )
     if _resp.status_code == 200:
         return v1EnableSlotResponse.from_json(_resp.json())
@@ -7013,6 +7042,7 @@ def get_GetActiveTasksCount(
         data=None,
         headers=None,
         timeout=None,
+        stream=False,
     )
     if _resp.status_code == 200:
         return v1GetActiveTasksCountResponse.from_json(_resp.json())
@@ -7032,6 +7062,7 @@ def get_GetAgent(
         data=None,
         headers=None,
         timeout=None,
+        stream=False,
     )
     if _resp.status_code == 200:
         return v1GetAgentResponse.from_json(_resp.json())
@@ -7061,6 +7092,7 @@ def get_GetAgents(
         data=None,
         headers=None,
         timeout=None,
+        stream=False,
     )
     if _resp.status_code == 200:
         return v1GetAgentsResponse.from_json(_resp.json())
@@ -7080,6 +7112,7 @@ def get_GetBestSearcherValidationMetric(
         data=None,
         headers=None,
         timeout=None,
+        stream=False,
     )
     if _resp.status_code == 200:
         return v1GetBestSearcherValidationMetricResponse.from_json(_resp.json())
@@ -7099,6 +7132,7 @@ def get_GetCheckpoint(
         data=None,
         headers=None,
         timeout=None,
+        stream=False,
     )
     if _resp.status_code == 200:
         return v1GetCheckpointResponse.from_json(_resp.json())
@@ -7118,6 +7152,7 @@ def get_GetCommand(
         data=None,
         headers=None,
         timeout=None,
+        stream=False,
     )
     if _resp.status_code == 200:
         return v1GetCommandResponse.from_json(_resp.json())
@@ -7149,6 +7184,7 @@ def get_GetCommands(
         data=None,
         headers=None,
         timeout=None,
+        stream=False,
     )
     if _resp.status_code == 200:
         return v1GetCommandsResponse.from_json(_resp.json())
@@ -7168,6 +7204,7 @@ def get_GetCurrentTrialSearcherOperation(
         data=None,
         headers=None,
         timeout=None,
+        stream=False,
     )
     if _resp.status_code == 200:
         return v1GetCurrentTrialSearcherOperationResponse.from_json(_resp.json())
@@ -7187,6 +7224,7 @@ def get_GetExperiment(
         data=None,
         headers=None,
         timeout=None,
+        stream=False,
     )
     if _resp.status_code == 200:
         return v1GetExperimentResponse.from_json(_resp.json())
@@ -7217,6 +7255,7 @@ def get_GetExperimentCheckpoints(
         data=None,
         headers=None,
         timeout=None,
+        stream=False,
     )
     if _resp.status_code == 200:
         return v1GetExperimentCheckpointsResponse.from_json(_resp.json())
@@ -7238,6 +7277,7 @@ def get_GetExperimentLabels(
         data=None,
         headers=None,
         timeout=None,
+        stream=False,
     )
     if _resp.status_code == 200:
         return v1GetExperimentLabelsResponse.from_json(_resp.json())
@@ -7268,6 +7308,7 @@ def get_GetExperimentTrials(
         data=None,
         headers=None,
         timeout=None,
+        stream=False,
     )
     if _resp.status_code == 200:
         return v1GetExperimentTrialsResponse.from_json(_resp.json())
@@ -7287,6 +7328,7 @@ def get_GetExperimentValidationHistory(
         data=None,
         headers=None,
         timeout=None,
+        stream=False,
     )
     if _resp.status_code == 200:
         return v1GetExperimentValidationHistoryResponse.from_json(_resp.json())
@@ -7330,6 +7372,7 @@ def get_GetExperiments(
         data=None,
         headers=None,
         timeout=None,
+        stream=False,
     )
     if _resp.status_code == 200:
         return v1GetExperimentsResponse.from_json(_resp.json())
@@ -7351,6 +7394,7 @@ def get_GetJobQueueStats(
         data=None,
         headers=None,
         timeout=None,
+        stream=False,
     )
     if _resp.status_code == 200:
         return v1GetJobQueueStatsResponse.from_json(_resp.json())
@@ -7380,6 +7424,7 @@ def get_GetJobs(
         data=None,
         headers=None,
         timeout=None,
+        stream=False,
     )
     if _resp.status_code == 200:
         return v1GetJobsResponse.from_json(_resp.json())
@@ -7397,6 +7442,7 @@ def get_GetMaster(
         data=None,
         headers=None,
         timeout=None,
+        stream=False,
     )
     if _resp.status_code == 200:
         return v1GetMasterResponse.from_json(_resp.json())
@@ -7414,6 +7460,7 @@ def get_GetMasterConfig(
         data=None,
         headers=None,
         timeout=None,
+        stream=False,
     )
     if _resp.status_code == 200:
         return v1GetMasterConfigResponse.from_json(_resp.json())
@@ -7433,6 +7480,7 @@ def get_GetModel(
         data=None,
         headers=None,
         timeout=None,
+        stream=False,
     )
     if _resp.status_code == 200:
         return v1GetModelResponse.from_json(_resp.json())
@@ -7452,6 +7500,7 @@ def get_GetModelDef(
         data=None,
         headers=None,
         timeout=None,
+        stream=False,
     )
     if _resp.status_code == 200:
         return v1GetModelDefResponse.from_json(_resp.json())
@@ -7472,6 +7521,7 @@ def post_GetModelDefFile(
         data=None,
         headers=None,
         timeout=None,
+        stream=False,
     )
     if _resp.status_code == 200:
         return v1GetModelDefFileResponse.from_json(_resp.json())
@@ -7491,6 +7541,7 @@ def get_GetModelDefTree(
         data=None,
         headers=None,
         timeout=None,
+        stream=False,
     )
     if _resp.status_code == 200:
         return v1GetModelDefTreeResponse.from_json(_resp.json())
@@ -7508,6 +7559,7 @@ def get_GetModelLabels(
         data=None,
         headers=None,
         timeout=None,
+        stream=False,
     )
     if _resp.status_code == 200:
         return v1GetModelLabelsResponse.from_json(_resp.json())
@@ -7528,6 +7580,7 @@ def get_GetModelVersion(
         data=None,
         headers=None,
         timeout=None,
+        stream=False,
     )
     if _resp.status_code == 200:
         return v1GetModelVersionResponse.from_json(_resp.json())
@@ -7556,6 +7609,7 @@ def get_GetModelVersions(
         data=None,
         headers=None,
         timeout=None,
+        stream=False,
     )
     if _resp.status_code == 200:
         return v1GetModelVersionsResponse.from_json(_resp.json())
@@ -7597,6 +7651,7 @@ def get_GetModels(
         data=None,
         headers=None,
         timeout=None,
+        stream=False,
     )
     if _resp.status_code == 200:
         return v1GetModelsResponse.from_json(_resp.json())
@@ -7616,6 +7671,7 @@ def get_GetNotebook(
         data=None,
         headers=None,
         timeout=None,
+        stream=False,
     )
     if _resp.status_code == 200:
         return v1GetNotebookResponse.from_json(_resp.json())
@@ -7647,6 +7703,7 @@ def get_GetNotebooks(
         data=None,
         headers=None,
         timeout=None,
+        stream=False,
     )
     if _resp.status_code == 200:
         return v1GetNotebooksResponse.from_json(_resp.json())
@@ -7666,6 +7723,7 @@ def get_GetProject(
         data=None,
         headers=None,
         timeout=None,
+        stream=False,
     )
     if _resp.status_code == 200:
         return v1GetProjectResponse.from_json(_resp.json())
@@ -7689,6 +7747,7 @@ def get_GetResourcePools(
         data=None,
         headers=None,
         timeout=None,
+        stream=False,
     )
     if _resp.status_code == 200:
         return v1GetResourcePoolsResponse.from_json(_resp.json())
@@ -7708,6 +7767,7 @@ def get_GetShell(
         data=None,
         headers=None,
         timeout=None,
+        stream=False,
     )
     if _resp.status_code == 200:
         return v1GetShellResponse.from_json(_resp.json())
@@ -7739,6 +7799,7 @@ def get_GetShells(
         data=None,
         headers=None,
         timeout=None,
+        stream=False,
     )
     if _resp.status_code == 200:
         return v1GetShellsResponse.from_json(_resp.json())
@@ -7759,6 +7820,7 @@ def get_GetSlot(
         data=None,
         headers=None,
         timeout=None,
+        stream=False,
     )
     if _resp.status_code == 200:
         return v1GetSlotResponse.from_json(_resp.json())
@@ -7778,6 +7840,7 @@ def get_GetSlots(
         data=None,
         headers=None,
         timeout=None,
+        stream=False,
     )
     if _resp.status_code == 200:
         return v1GetSlotsResponse.from_json(_resp.json())
@@ -7797,6 +7860,7 @@ def get_GetTask(
         data=None,
         headers=None,
         timeout=None,
+        stream=False,
     )
     if _resp.status_code == 200:
         return v1GetTaskResponse.from_json(_resp.json())
@@ -7814,6 +7878,7 @@ def get_GetTelemetry(
         data=None,
         headers=None,
         timeout=None,
+        stream=False,
     )
     if _resp.status_code == 200:
         return v1GetTelemetryResponse.from_json(_resp.json())
@@ -7833,6 +7898,7 @@ def get_GetTemplate(
         data=None,
         headers=None,
         timeout=None,
+        stream=False,
     )
     if _resp.status_code == 200:
         return v1GetTemplateResponse.from_json(_resp.json())
@@ -7862,6 +7928,7 @@ def get_GetTemplates(
         data=None,
         headers=None,
         timeout=None,
+        stream=False,
     )
     if _resp.status_code == 200:
         return v1GetTemplatesResponse.from_json(_resp.json())
@@ -7881,6 +7948,7 @@ def get_GetTensorboard(
         data=None,
         headers=None,
         timeout=None,
+        stream=False,
     )
     if _resp.status_code == 200:
         return v1GetTensorboardResponse.from_json(_resp.json())
@@ -7912,6 +7980,7 @@ def get_GetTensorboards(
         data=None,
         headers=None,
         timeout=None,
+        stream=False,
     )
     if _resp.status_code == 200:
         return v1GetTensorboardsResponse.from_json(_resp.json())
@@ -7931,6 +8000,7 @@ def get_GetTrial(
         data=None,
         headers=None,
         timeout=None,
+        stream=False,
     )
     if _resp.status_code == 200:
         return v1GetTrialResponse.from_json(_resp.json())
@@ -7961,6 +8031,7 @@ def get_GetTrialCheckpoints(
         data=None,
         headers=None,
         timeout=None,
+        stream=False,
     )
     if _resp.status_code == 200:
         return v1GetTrialCheckpointsResponse.from_json(_resp.json())
@@ -7993,6 +8064,7 @@ def get_GetTrialWorkloads(
         data=None,
         headers=None,
         timeout=None,
+        stream=False,
     )
     if _resp.status_code == 200:
         return v1GetTrialWorkloadsResponse.from_json(_resp.json())
@@ -8012,6 +8084,7 @@ def get_GetUser(
         data=None,
         headers=None,
         timeout=None,
+        stream=False,
     )
     if _resp.status_code == 200:
         return v1GetUserResponse.from_json(_resp.json())
@@ -8029,6 +8102,7 @@ def get_GetUserSetting(
         data=None,
         headers=None,
         timeout=None,
+        stream=False,
     )
     if _resp.status_code == 200:
         return v1GetUserSettingResponse.from_json(_resp.json())
@@ -8056,6 +8130,7 @@ def get_GetUsers(
         data=None,
         headers=None,
         timeout=None,
+        stream=False,
     )
     if _resp.status_code == 200:
         return v1GetUsersResponse.from_json(_resp.json())
@@ -8075,6 +8150,7 @@ def get_GetWorkspace(
         data=None,
         headers=None,
         timeout=None,
+        stream=False,
     )
     if _resp.status_code == 200:
         return v1GetWorkspaceResponse.from_json(_resp.json())
@@ -8109,6 +8185,7 @@ def get_GetWorkspaceProjects(
         data=None,
         headers=None,
         timeout=None,
+        stream=False,
     )
     if _resp.status_code == 200:
         return v1GetWorkspaceProjectsResponse.from_json(_resp.json())
@@ -8144,6 +8221,7 @@ def get_GetWorkspaces(
         data=None,
         headers=None,
         timeout=None,
+        stream=False,
     )
     if _resp.status_code == 200:
         return v1GetWorkspacesResponse.from_json(_resp.json())
@@ -8164,6 +8242,7 @@ def put_IdleNotebook(
         data=None,
         headers=None,
         timeout=None,
+        stream=False,
     )
     if _resp.status_code == 200:
         return
@@ -8183,6 +8262,7 @@ def post_KillCommand(
         data=None,
         headers=None,
         timeout=None,
+        stream=False,
     )
     if _resp.status_code == 200:
         return v1KillCommandResponse.from_json(_resp.json())
@@ -8202,6 +8282,7 @@ def post_KillExperiment(
         data=None,
         headers=None,
         timeout=None,
+        stream=False,
     )
     if _resp.status_code == 200:
         return
@@ -8221,6 +8302,7 @@ def post_KillNotebook(
         data=None,
         headers=None,
         timeout=None,
+        stream=False,
     )
     if _resp.status_code == 200:
         return v1KillNotebookResponse.from_json(_resp.json())
@@ -8240,6 +8322,7 @@ def post_KillShell(
         data=None,
         headers=None,
         timeout=None,
+        stream=False,
     )
     if _resp.status_code == 200:
         return v1KillShellResponse.from_json(_resp.json())
@@ -8259,6 +8342,7 @@ def post_KillTensorboard(
         data=None,
         headers=None,
         timeout=None,
+        stream=False,
     )
     if _resp.status_code == 200:
         return v1KillTensorboardResponse.from_json(_resp.json())
@@ -8278,6 +8362,7 @@ def post_KillTrial(
         data=None,
         headers=None,
         timeout=None,
+        stream=False,
     )
     if _resp.status_code == 200:
         return
@@ -8297,6 +8382,7 @@ def post_LaunchCommand(
         data=None,
         headers=None,
         timeout=None,
+        stream=False,
     )
     if _resp.status_code == 200:
         return v1LaunchCommandResponse.from_json(_resp.json())
@@ -8316,6 +8402,7 @@ def post_LaunchNotebook(
         data=None,
         headers=None,
         timeout=None,
+        stream=False,
     )
     if _resp.status_code == 200:
         return v1LaunchNotebookResponse.from_json(_resp.json())
@@ -8335,6 +8422,7 @@ def post_LaunchShell(
         data=None,
         headers=None,
         timeout=None,
+        stream=False,
     )
     if _resp.status_code == 200:
         return v1LaunchShellResponse.from_json(_resp.json())
@@ -8354,6 +8442,7 @@ def post_LaunchTensorboard(
         data=None,
         headers=None,
         timeout=None,
+        stream=False,
     )
     if _resp.status_code == 200:
         return v1LaunchTensorboardResponse.from_json(_resp.json())
@@ -8373,6 +8462,7 @@ def post_Login(
         data=None,
         headers=None,
         timeout=None,
+        stream=False,
     )
     if _resp.status_code == 200:
         return v1LoginResponse.from_json(_resp.json())
@@ -8390,6 +8480,7 @@ def post_Logout(
         data=None,
         headers=None,
         timeout=None,
+        stream=False,
     )
     if _resp.status_code == 200:
         return
@@ -8411,6 +8502,7 @@ def post_MarkAllocationResourcesDaemon(
         data=None,
         headers=None,
         timeout=None,
+        stream=False,
     )
     if _resp.status_code == 200:
         return
@@ -8431,6 +8523,7 @@ def post_MoveExperiment(
         data=None,
         headers=None,
         timeout=None,
+        stream=False,
     )
     if _resp.status_code == 200:
         return
@@ -8451,6 +8544,7 @@ def post_MoveProject(
         data=None,
         headers=None,
         timeout=None,
+        stream=False,
     )
     if _resp.status_code == 200:
         return
@@ -8471,6 +8565,7 @@ def patch_PatchExperiment(
         data=None,
         headers=None,
         timeout=None,
+        stream=False,
     )
     if _resp.status_code == 200:
         return v1PatchExperimentResponse.from_json(_resp.json())
@@ -8491,6 +8586,7 @@ def patch_PatchModel(
         data=None,
         headers=None,
         timeout=None,
+        stream=False,
     )
     if _resp.status_code == 200:
         return v1PatchModelResponse.from_json(_resp.json())
@@ -8512,6 +8608,7 @@ def patch_PatchModelVersion(
         data=None,
         headers=None,
         timeout=None,
+        stream=False,
     )
     if _resp.status_code == 200:
         return v1PatchModelVersionResponse.from_json(_resp.json())
@@ -8532,6 +8629,7 @@ def patch_PatchProject(
         data=None,
         headers=None,
         timeout=None,
+        stream=False,
     )
     if _resp.status_code == 200:
         return v1PatchProjectResponse.from_json(_resp.json())
@@ -8552,6 +8650,7 @@ def patch_PatchUser(
         data=None,
         headers=None,
         timeout=None,
+        stream=False,
     )
     if _resp.status_code == 200:
         return v1PatchUserResponse.from_json(_resp.json())
@@ -8572,6 +8671,7 @@ def patch_PatchWorkspace(
         data=None,
         headers=None,
         timeout=None,
+        stream=False,
     )
     if _resp.status_code == 200:
         return v1PatchWorkspaceResponse.from_json(_resp.json())
@@ -8591,6 +8691,7 @@ def post_PauseExperiment(
         data=None,
         headers=None,
         timeout=None,
+        stream=False,
     )
     if _resp.status_code == 200:
         return
@@ -8610,6 +8711,7 @@ def post_PinWorkspace(
         data=None,
         headers=None,
         timeout=None,
+        stream=False,
     )
     if _resp.status_code == 200:
         return
@@ -8630,6 +8732,7 @@ def post_PostAllocationProxyAddress(
         data=None,
         headers=None,
         timeout=None,
+        stream=False,
     )
     if _resp.status_code == 200:
         return
@@ -8650,6 +8753,7 @@ def post_PostCheckpointMetadata(
         data=None,
         headers=None,
         timeout=None,
+        stream=False,
     )
     if _resp.status_code == 200:
         return v1PostCheckpointMetadataResponse.from_json(_resp.json())
@@ -8669,6 +8773,7 @@ def post_PostModel(
         data=None,
         headers=None,
         timeout=None,
+        stream=False,
     )
     if _resp.status_code == 200:
         return v1PostModelResponse.from_json(_resp.json())
@@ -8689,6 +8794,7 @@ def post_PostModelVersion(
         data=None,
         headers=None,
         timeout=None,
+        stream=False,
     )
     if _resp.status_code == 200:
         return v1PostModelVersionResponse.from_json(_resp.json())
@@ -8709,6 +8815,7 @@ def post_PostProject(
         data=None,
         headers=None,
         timeout=None,
+        stream=False,
     )
     if _resp.status_code == 200:
         return v1PostProjectResponse.from_json(_resp.json())
@@ -8728,6 +8835,7 @@ def post_PostTrialProfilerMetricsBatch(
         data=None,
         headers=None,
         timeout=None,
+        stream=False,
     )
     if _resp.status_code == 200:
         return
@@ -8748,6 +8856,7 @@ def post_PostTrialRunnerMetadata(
         data=None,
         headers=None,
         timeout=None,
+        stream=False,
     )
     if _resp.status_code == 200:
         return
@@ -8767,6 +8876,7 @@ def post_PostUser(
         data=None,
         headers=None,
         timeout=None,
+        stream=False,
     )
     if _resp.status_code == 200:
         return v1PostUserResponse.from_json(_resp.json())
@@ -8786,6 +8896,7 @@ def post_PostUserSetting(
         data=None,
         headers=None,
         timeout=None,
+        stream=False,
     )
     if _resp.status_code == 200:
         return
@@ -8805,6 +8916,7 @@ def post_PostWorkspace(
         data=None,
         headers=None,
         timeout=None,
+        stream=False,
     )
     if _resp.status_code == 200:
         return v1PostWorkspaceResponse.from_json(_resp.json())
@@ -8824,6 +8936,7 @@ def post_PreviewHPSearch(
         data=None,
         headers=None,
         timeout=None,
+        stream=False,
     )
     if _resp.status_code == 200:
         return v1PreviewHPSearchResponse.from_json(_resp.json())
@@ -8844,6 +8957,7 @@ def put_PutProjectNotes(
         data=None,
         headers=None,
         timeout=None,
+        stream=False,
     )
     if _resp.status_code == 200:
         return v1PutProjectNotesResponse.from_json(_resp.json())
@@ -8864,6 +8978,7 @@ def put_PutTemplate(
         data=None,
         headers=None,
         timeout=None,
+        stream=False,
     )
     if _resp.status_code == 200:
         return v1PutTemplateResponse.from_json(_resp.json())
@@ -8883,6 +8998,7 @@ def post_ReportCheckpoint(
         data=None,
         headers=None,
         timeout=None,
+        stream=False,
     )
     if _resp.status_code == 200:
         return
@@ -8903,6 +9019,7 @@ def post_ReportTrialProgress(
         data=None,
         headers=None,
         timeout=None,
+        stream=False,
     )
     if _resp.status_code == 200:
         return
@@ -8923,6 +9040,7 @@ def post_ReportTrialSearcherEarlyExit(
         data=None,
         headers=None,
         timeout=None,
+        stream=False,
     )
     if _resp.status_code == 200:
         return
@@ -8943,6 +9061,7 @@ def post_ReportTrialTrainingMetrics(
         data=None,
         headers=None,
         timeout=None,
+        stream=False,
     )
     if _resp.status_code == 200:
         return
@@ -8963,6 +9082,7 @@ def post_ReportTrialValidationMetrics(
         data=None,
         headers=None,
         timeout=None,
+        stream=False,
     )
     if _resp.status_code == 200:
         return
@@ -8980,6 +9100,7 @@ def post_ResetUserSetting(
         data=None,
         headers=None,
         timeout=None,
+        stream=False,
     )
     if _resp.status_code == 200:
         return
@@ -9005,6 +9126,7 @@ def get_ResourceAllocationAggregated(
         data=None,
         headers=None,
         timeout=None,
+        stream=False,
     )
     if _resp.status_code == 200:
         return v1ResourceAllocationAggregatedResponse.from_json(_resp.json())
@@ -9028,6 +9150,7 @@ def get_ResourceAllocationRaw(
         data=None,
         headers=None,
         timeout=None,
+        stream=False,
     )
     if _resp.status_code == 200:
         return v1ResourceAllocationRawResponse.from_json(_resp.json())
@@ -9048,6 +9171,7 @@ def post_SetCommandPriority(
         data=None,
         headers=None,
         timeout=None,
+        stream=False,
     )
     if _resp.status_code == 200:
         return v1SetCommandPriorityResponse.from_json(_resp.json())
@@ -9068,6 +9192,7 @@ def post_SetNotebookPriority(
         data=None,
         headers=None,
         timeout=None,
+        stream=False,
     )
     if _resp.status_code == 200:
         return v1SetNotebookPriorityResponse.from_json(_resp.json())
@@ -9088,6 +9213,7 @@ def post_SetShellPriority(
         data=None,
         headers=None,
         timeout=None,
+        stream=False,
     )
     if _resp.status_code == 200:
         return v1SetShellPriorityResponse.from_json(_resp.json())
@@ -9108,6 +9234,7 @@ def post_SetTensorboardPriority(
         data=None,
         headers=None,
         timeout=None,
+        stream=False,
     )
     if _resp.status_code == 200:
         return v1SetTensorboardPriorityResponse.from_json(_resp.json())
@@ -9128,6 +9255,7 @@ def post_SetUserPassword(
         data=None,
         headers=None,
         timeout=None,
+        stream=False,
     )
     if _resp.status_code == 200:
         return v1SetUserPasswordResponse.from_json(_resp.json())
@@ -9160,6 +9288,7 @@ def get_SummarizeTrial(
         data=None,
         headers=None,
         timeout=None,
+        stream=False,
     )
     if _resp.status_code == 200:
         return v1SummarizeTrialResponse.from_json(_resp.json())
@@ -9179,6 +9308,7 @@ def post_UnarchiveExperiment(
         data=None,
         headers=None,
         timeout=None,
+        stream=False,
     )
     if _resp.status_code == 200:
         return
@@ -9198,6 +9328,7 @@ def post_UnarchiveModel(
         data=None,
         headers=None,
         timeout=None,
+        stream=False,
     )
     if _resp.status_code == 200:
         return
@@ -9217,6 +9348,7 @@ def post_UnarchiveProject(
         data=None,
         headers=None,
         timeout=None,
+        stream=False,
     )
     if _resp.status_code == 200:
         return
@@ -9236,6 +9368,7 @@ def post_UnarchiveWorkspace(
         data=None,
         headers=None,
         timeout=None,
+        stream=False,
     )
     if _resp.status_code == 200:
         return
@@ -9255,6 +9388,7 @@ def post_UnpinWorkspace(
         data=None,
         headers=None,
         timeout=None,
+        stream=False,
     )
     if _resp.status_code == 200:
         return
@@ -9274,6 +9408,7 @@ def post_UpdateJobQueue(
         data=None,
         headers=None,
         timeout=None,
+        stream=False,
     )
     if _resp.status_code == 200:
         return


### PR DESCRIPTION
This is a step towards slowly migrating old cli code to the new
generated bindings.

In the short term, this will allow a migration of
determined/common/api/experiment.py to newer patterns (mostly generated
bindings, but a few manual Session.get(stream=True) calls).

In the long term, the generated bindings should also automatically
support streaming endpoints.

## Test Plan

No differences in code execution as of this PR.