### PR TITLE
docs: Determined AI Slurm jobs do not require gres.

### DIFF
--- a/docs/cluster-setup-guide/deploy-cluster/sysadmin-deploy-on-slurm/install-on-slurm.rst
+++ b/docs/cluster-setup-guide/deploy-cluster/sysadmin-deploy-on-slurm/install-on-slurm.rst
@@ -162,7 +162,13 @@ recommended to optimize how Determined interacts with Slurm:
    <https://slurm.schedmd.com/gres.html#GPU_Management>`__ such that Slurm can schedule nodes with
    the GPUs you want.
 
-   Minimally, Slurm must be configured for ``GresTypes=gpu``.
+   For the automatic selection of nodes with GPUs, Slurm must be configured for ``GresTypes=gpu``
+   and nodes with GPUs must have properly configured GRES indicating the presence of any GPUs. If
+   Slurm GRES cannot be properly configured, specify the :ref:`slurm section
+   <cluster-configuration-slurm>` ``gres_supported`` option to ``false``, and it is the user's
+   responsibility to ensure that GPUs will be available on nodes selected for the job using other
+   configurations such as targeting a specific resource pool with only GPU nodes, or specifying a
+   Slurm constraint in the experiment configuration.
 
 -  Ensure homogeneous Slurm partitions.
 

--- a/docs/reference/reference-deploy/config/master-config-reference.rst
+++ b/docs/reference/reference-deploy/config/master-config-reference.rst
@@ -286,6 +286,14 @@ The master supports the following configuration settings:
       -  ``tres_supported``: Indicates if ``SelectType=select/cons_tres`` is set in the Slurm
          configuration. Affects how Determined requests GPUs from Slurm. The default is true.
 
+      -  ``gres_supported``: Indicates if ``GresTypes=gpu`` is set in the Slurm configuration, and
+         nodes with GPUs have properly configured GRES indicating the presence of any GPUs. The
+         default is true. When false, Determined will request slots_per_trial nodes and utilize only
+         GPU 0 on each node. It is the user's responsibility to ensure that GPUs will be available
+         on nodes selected for the job using other configurations such as targeting a specific
+         resource pool with only GPU nodes or specifying a Slurm constraint in the experiment
+         configuration.
+
       -  ``partition_overrides``: A map of Slurm partition names to partition-level overrides. For
          each configuration, if it is set for a given partition, it overrides the setting at the
          root level.


### PR DESCRIPTION
## Description

Relax the minimal requirement that Slurm must be configured for GresTypes=gpu. Add gres_supported option to resource_manager section of Determined-AI master.yaml.

## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions about this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist
- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.
- [ ] If modifying `/webui/react/src/shared/` verify `make -C webui/react test-shared` passes.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
