### PR TITLE
refactor: rename `usergroup.APIServer` -> `usergroup.UserGroupAPIServer`

### DIFF
--- a/master/internal/api.go
+++ b/master/internal/api.go
@@ -23,7 +23,7 @@ import (
 type apiServer struct {
 	m *Master
 
-	usergroup.APIServer
+	usergroup.UserGroupAPIServer
 }
 
 // paginate returns a paginated subset of the values and sets the pagination response.

--- a/master/internal/usergroup/api_groups.go
+++ b/master/internal/usergroup/api_groups.go
@@ -14,11 +14,11 @@ import (
 	"github.com/determined-ai/determined/proto/pkg/groupv1"
 )
 
-// APIServer is an embedded api server struct.
-type APIServer struct{}
+// UserGroupAPIServer is an embedded api server struct.
+type UserGroupAPIServer struct{}
 
 // CreateGroup creates a group and adds members to it, if any.
-func (a *APIServer) CreateGroup(ctx context.Context, req *apiv1.CreateGroupRequest,
+func (a *UserGroupAPIServer) CreateGroup(ctx context.Context, req *apiv1.CreateGroupRequest,
 ) (resp *apiv1.CreateGroupResponse, err error) {
 	// Detect whether we're returning special errors and convert to gRPC error
 	defer func() {
@@ -45,7 +45,7 @@ func (a *APIServer) CreateGroup(ctx context.Context, req *apiv1.CreateGroupReque
 }
 
 // GetGroups searches for groups that fulfills the criteria given by the user.
-func (a *APIServer) GetGroups(ctx context.Context, req *apiv1.GetGroupsRequest,
+func (a *UserGroupAPIServer) GetGroups(ctx context.Context, req *apiv1.GetGroupsRequest,
 ) (resp *apiv1.GetGroupsResponse, err error) {
 	// Detect whether we're returning special errors and convert to gRPC error
 	defer func() {
@@ -83,7 +83,7 @@ func (a *APIServer) GetGroups(ctx context.Context, req *apiv1.GetGroupsRequest,
 }
 
 // GetGroup finds and returns details of the group specified.
-func (a *APIServer) GetGroup(ctx context.Context, req *apiv1.GetGroupRequest,
+func (a *UserGroupAPIServer) GetGroup(ctx context.Context, req *apiv1.GetGroupRequest,
 ) (resp *apiv1.GetGroupResponse, err error) {
 	// Detect whether we're returning special errors and convert to gRPC error
 	defer func() {
@@ -113,7 +113,7 @@ func (a *APIServer) GetGroup(ctx context.Context, req *apiv1.GetGroupRequest,
 }
 
 // UpdateGroup updates the group and returns the newly updated group details.
-func (a *APIServer) UpdateGroup(ctx context.Context, req *apiv1.UpdateGroupRequest,
+func (a *UserGroupAPIServer) UpdateGroup(ctx context.Context, req *apiv1.UpdateGroupRequest,
 ) (resp *apiv1.UpdateGroupResponse, err error) {
 	// Detect whether we're returning special errors and convert to gRPC error
 	defer func() {
@@ -149,7 +149,7 @@ func (a *APIServer) UpdateGroup(ctx context.Context, req *apiv1.UpdateGroupReque
 }
 
 // DeleteGroup deletes the database entry for the group.
-func (a *APIServer) DeleteGroup(ctx context.Context, req *apiv1.DeleteGroupRequest,
+func (a *UserGroupAPIServer) DeleteGroup(ctx context.Context, req *apiv1.DeleteGroupRequest,
 ) (resp *apiv1.DeleteGroupResponse, err error) {
 	// Detect whether we're returning special errors and convert to gRPC error
 	defer func() {


### PR DESCRIPTION
## Description

Should avoid name clash when embedding multiple APIServers within the main one.

## Test Plan

N/A

## Commentary (optional)

I've hit that in my current work in progress, and it'd also be an improvement for https://github.com/determined-ai/determined-ee/pull/409/files#diff-3917b52e2d2657bb4bd3d17fa4f229e3fd52b6ed36cf831921870b7fc7f853f9R27

## Checklist
- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.
- [ ] If modifying `/webui/react/src/shared/` verify `make -C webui/react test-shared` passes.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
