### PR TITLE
docs: update required python to 3.7

### DIFF
--- a/docs/interfaces/commands-and-shells.rst
+++ b/docs/interfaces/commands-and-shells.rst
@@ -56,7 +56,7 @@ Installation
 The CLI is distributed as a Python wheel package. Each user should install a copy of the CLI on
 their local development machine.
 
-The CLI requires Python >= 3.6. It is recommended that you install the CLI into a `virtualenv
+The CLI requires Python >= 3.7. It is recommended that you install the CLI into a `virtualenv
 <https://virtualenv.pypa.io/en/latest/>`__, although this is optional. To install the CLI into a
 virtualenv, activate the virtualenv before entering the following command.
 

--- a/docs/training/setup-guide/custom-env.rst
+++ b/docs/training/setup-guide/custom-env.rst
@@ -198,7 +198,7 @@ environments using :ref:`custom images <custom-docker-images>`:
    FROM determinedai/environments:py-3.8-pytorch-1.10-tf-2.8-cpu-0.19.1
 
    # Create a virtual environment
-   RUN conda create -n myenv python=3.6
+   RUN conda create -n myenv python=3.8
    RUN eval "$(conda shell.bash hook)" && \
       conda activate myenv && \
       pip install scikit-learn

--- a/harness/setup.py
+++ b/harness/setup.py
@@ -11,6 +11,8 @@ setup(
     license="Apache License 2.0",
     classifiers=["License :: OSI Approved :: Apache Software License"],
     packages=find_packages(exclude=["*.tests", "*.tests.*", "tests.*", "tests"]),
+    # Technically, we haven't supported 3.6 or tested against it since it went EOL.  But some users
+    # are still using it successfully so there's hardly a point in breaking them.
     python_requires=">=3.6",
     package_data={"determined": ["py.typed"]},
     include_package_data=True,

--- a/master/static/srv/notebook-template.ipynb
+++ b/master/static/srv/notebook-template.ipynb
@@ -89,7 +89,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.8"
+   "version": "3.8.13"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
We stopped supporting Python 3.6 when it went EOL.

I reported it in the release notes in #3377, but forgot to fix the rest
of the docs.

Note that setup.py has not been modified; there's no need to break
existing users who are succesfully using an usupported old version.