### PR TITLE
refactor: rewrite docker lib without actors [DET-8300]

### DIFF
--- a/agent/pkg/docker/docker.go
+++ b/agent/pkg/docker/docker.go
@@ -1,0 +1,464 @@
+package docker
+
+import (
+	"bufio"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+	"syscall"
+
+	"github.com/docker/distribution/reference"
+	"github.com/docker/docker/api/types"
+	dcontainer "github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/filters"
+	"github.com/docker/docker/client"
+	"github.com/docker/docker/pkg/jsonmessage"
+	"github.com/docker/docker/registry"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"golang.org/x/sys/unix"
+
+	"github.com/determined-ai/determined/agent/pkg/events"
+	"github.com/determined-ai/determined/master/pkg/aproto"
+	"github.com/determined-ai/determined/master/pkg/archive"
+	"github.com/determined-ai/determined/master/pkg/cproto"
+	"github.com/determined-ai/determined/master/pkg/model"
+	"github.com/determined-ai/determined/master/pkg/ptrs"
+)
+
+const (
+	// ContainerTypeLabel describes container type.
+	ContainerTypeLabel = "ai.determined.container.type"
+	// ContainerTypeValue is the corresponding value for 'normal tasks'.
+	ContainerTypeValue = "task-container"
+	// ContainerVersionLabel describes the container version.
+	ContainerVersionLabel = "ai.determined.container.version"
+	// ContainerVersionValue is the current (and only) container version.
+	ContainerVersionValue = "0"
+	// ContainerIDLabel gives the Determined container ID (cproto.ID).
+	ContainerIDLabel = "ai.determined.container.id"
+	// ContainerDevicesLabel describes the devices allocated to the container.
+	ContainerDevicesLabel = "ai.determined.container.devices"
+	// AgentLabel gives the agent the container is managed by.
+	AgentLabel = "ai.determined.container.agent"
+	// ClusterLabel gives the cluster the container is managed by.
+	ClusterLabel = "ai.determined.container.cluster"
+	// MasterLabel gives the master the container is managed by.
+	MasterLabel = "ai.determined.container.master"
+
+	// ImagePullStatsKind describes the IMAGEPULL event.
+	ImagePullStatsKind = "IMAGEPULL"
+)
+
+type (
+	// ContainerWaiter contains channels to wait on the termination of a running container.
+	// Results on the Waiter channel indicate changes in container state, while results on the
+	// Errs channel indicate failures to watch for updates.
+	ContainerWaiter struct {
+		Waiter <-chan dcontainer.ContainerWaitOKBody
+		Errs   <-chan error
+	}
+	// Container contains details about a running container and waiters to await its termination.
+	Container struct {
+		ContainerInfo   types.ContainerJSON
+		ContainerWaiter ContainerWaiter
+	}
+)
+
+// Client wraps the Docker client, augmenting it with a few higher level convenience APIs.
+type Client struct {
+	// Configuration details. Set during initialization, never modified afterwards.
+	credentialStores map[string]*credentialStore
+	authConfigs      map[string]types.AuthConfig
+
+	// System dependencies. Also set during initialization, never modified afterwards.
+	cl     *client.Client
+	logger *logrus.Entry
+}
+
+// NewClient populates credentials from the Daemon config returns a new Client that uses them.
+func NewClient(cl *client.Client) *Client {
+	d := &Client{
+		cl:     cl,
+		logger: logrus.WithField("component", "docker-client"),
+	}
+
+	stores, auths, err := processDockerConfig()
+	if err != nil {
+		d.logger.Infof("couldn't process ~/.docker/config.json %v", err)
+	}
+	if len(stores) == 0 {
+		d.logger.Info("can't find any docker credential stores, continuing without them")
+	}
+	if len(auths) == 0 {
+		d.logger.Info("can't find any auths in ~/.docker/config.json, continuing without them")
+	}
+	d.credentialStores, d.authConfigs = stores, auths
+
+	return d
+}
+
+// Inner returns the underlying Docker client, to be used sparingly.
+// TODO(???): Consolidate around usage of the wrapper client, remove this.
+func (d *Client) Inner() *client.Client {
+	return d.cl
+}
+
+// Close closes the underlying Docker client.
+func (d *Client) Close() error {
+	return d.cl.Close()
+}
+
+// ReattachContainer looks for a single running or terminated container that matches the given
+// filters and returns whether it can be reattached or has terminated.
+func (d *Client) ReattachContainer(
+	ctx context.Context,
+	filter filters.Args,
+) (*Container, *aproto.ExitCode, error) {
+	containers, err := d.cl.ContainerList(ctx, types.ContainerListOptions{Filters: filter})
+	if err != nil {
+		return nil, nil, fmt.Errorf("while reattaching container: %w", err)
+	}
+
+	if len(containers) > 1 {
+		return nil, nil, errors.New("reattach filters matched more than one container")
+	}
+
+	context.Background()
+
+	for _, cont := range containers {
+		// Subscribe to termination notifications first.
+		waiter, errs := d.cl.ContainerWait(ctx, cont.ID, dcontainer.WaitConditionNextExit)
+
+		// Restore containerInfo.
+		containerInfo, err := d.cl.ContainerInspect(ctx, cont.ID)
+		if err != nil {
+			return nil, nil, fmt.Errorf("inspecting reattached container: %w", err)
+		}
+
+		// Check if container has exited while we were trying to reattach it.
+		if !containerInfo.State.Running {
+			return nil, ptrs.Ptr(aproto.ExitCode(containerInfo.State.ExitCode)), nil
+		}
+		return &Container{
+			ContainerInfo: containerInfo,
+			ContainerWaiter: ContainerWaiter{
+				Waiter: waiter,
+				Errs:   errs,
+			},
+		}, nil, nil
+	}
+	return nil, nil, nil
+}
+
+// PullImage describes a request to pull an image.
+type PullImage struct {
+	Name      string
+	ForcePull bool
+	Registry  *types.AuthConfig
+}
+
+// PullImage pulls an image according to the given request and credentials initialized at client
+// creation from the Daemon config or credentials helpers configured there. It takes a
+// caller-provided channel on which docker events are sent. Slow receivers will block the call.
+func (d *Client) PullImage(ctx context.Context, req PullImage, p events.Publisher[Event]) error {
+	ref, err := reference.ParseNormalizedNamed(req.Name)
+	if err != nil {
+		return fmt.Errorf("error parsing image name %s: %w", req.Name, err)
+	}
+	ref = reference.TagNameOnly(ref)
+
+	switch _, _, err = d.cl.ImageInspectWithRaw(ctx, ref.String()); {
+	case req.ForcePull:
+		if err != nil {
+			break
+		}
+
+		if err = p.Publish(ctx, NewLogEvent(model.LogLevelInfo, fmt.Sprintf(
+			"image present, but force_pull_image is set; checking for updates: %s",
+			ref.String(),
+		))); err != nil {
+			return err
+		}
+	case client.IsErrNotFound(err):
+		if err = p.Publish(ctx, NewLogEvent(model.LogLevelInfo, fmt.Sprintf(
+			"image not found, pulling image: %s", ref.String(),
+		))); err != nil {
+			return err
+		}
+	case err != nil:
+		return fmt.Errorf("error checking if image exists %s: %w", ref.String(), err)
+	default:
+		if err = p.Publish(ctx, NewLogEvent(model.LogLevelInfo, fmt.Sprintf(
+			"image already found, skipping pull phase: %s",
+			ref.String(),
+		))); err != nil {
+			return err
+		}
+		return nil
+	}
+
+	if err = p.Publish(ctx, NewBeginStatsEvent(ImagePullStatsKind)); err != nil {
+		return err
+	}
+	defer func() {
+		if scErr := p.Publish(ctx, NewEndStatsEvent(ImagePullStatsKind)); scErr != nil {
+			d.logger.WithError(scErr).Warn("did not send image pull done stats")
+		}
+	}()
+
+	auth, err := d.getDockerAuths(ctx, ref, req.Registry, p)
+	if err != nil {
+		return fmt.Errorf("could not get docker authentication: %w", err)
+	}
+
+	authString, err := registryToString(*auth)
+	if err != nil {
+		return fmt.Errorf("error encoding docker credentials: %w", err)
+	}
+
+	logs, err := d.cl.ImagePull(ctx, ref.String(), types.ImagePullOptions{
+		All:          false,
+		RegistryAuth: authString,
+	})
+	if err != nil {
+		return errors.Wrapf(err, "error pulling image: %s", ref.String())
+	}
+	defer func() {
+		if err = logs.Close(); err != nil {
+			d.logger.WithError(err).Error("error closing log stream")
+		}
+	}()
+
+	if err = d.sendPullLogs(ctx, logs, p); err != nil {
+		return fmt.Errorf("error processing pull log stream: %w", err)
+	}
+	return nil
+}
+
+// CreateContainer creates a container according to the given spec, returning a docker container ID
+// to start it. It takes a caller-provided channel on which docker events are sent. Slow receivers
+// will block the call.
+func (d *Client) CreateContainer(
+	ctx context.Context,
+	req cproto.RunSpec,
+	p events.Publisher[Event],
+) (string, error) {
+	response, err := d.cl.ContainerCreate(
+		ctx, &req.ContainerConfig, &req.HostConfig, &req.NetworkingConfig, nil, "")
+	if err != nil {
+		return "", fmt.Errorf("creating container: %w", err)
+	}
+	id := response.ID
+	for _, w := range response.Warnings {
+		if err = p.Publish(ctx, NewLogEvent(model.LogLevelWarning, fmt.Sprintf(
+			"warning when creating container: %s", w,
+		))); err != nil {
+			return "", err
+		}
+	}
+
+	for _, copyArx := range req.Archives {
+		if err = p.Publish(ctx, NewLogEvent(model.LogLevelInfo, fmt.Sprintf(
+			"copying files to container: %s", copyArx.Path,
+		))); err != nil {
+			return "", err
+		}
+
+		files, cErr := archive.ToIOReader(copyArx.Archive)
+		if cErr != nil {
+			return "", fmt.Errorf("converting RunSpec Archive files to io.Reader: %w", cErr)
+		}
+		if err = d.cl.CopyToContainer(ctx, id, copyArx.Path, files, copyArx.CopyOptions); err != nil {
+			return "", fmt.Errorf("copying files to container: %w", err)
+		}
+	}
+	return id, nil
+}
+
+// RunContainer runs a container by docker container ID. It takes a caller-provided channel on which
+// docker events are sent. Slow receivers will block the call.
+func (d *Client) RunContainer(ctx context.Context, id string) (*Container, error) {
+	// Wait before start to not miss immediate exits.
+	waiter, errs := d.cl.ContainerWait(ctx, id, dcontainer.WaitConditionNextExit)
+
+	if err := d.cl.ContainerStart(ctx, id, types.ContainerStartOptions{}); err != nil {
+		return nil, fmt.Errorf("starting container: %w", err)
+	}
+
+	// If we specified a port to expose but not the host port to bind, Docker assigns an arbitrary host
+	// port, which we ask for here. (If we did specify a host port, this gives the same one back.)
+	containerInfo, err := d.cl.ContainerInspect(ctx, id)
+	if err != nil {
+		if cErr := d.RemoveContainer(ctx, id, true); cErr != nil {
+			d.logger.WithError(cErr).Errorf("removing container %s after inspect failure", id)
+		}
+		return nil, fmt.Errorf("inspecting, container may be orphaned: %w", err)
+	}
+	return &Container{
+		ContainerInfo: containerInfo,
+		ContainerWaiter: ContainerWaiter{
+			Waiter: waiter,
+			Errs:   errs,
+		},
+	}, nil
+}
+
+// SignalContainer signals the container, by docker container ID, with the requested signal,
+// returning an error if the Docker daemon is unable to process our request.
+func (d *Client) SignalContainer(ctx context.Context, id string, sig syscall.Signal) error {
+	return d.cl.ContainerKill(ctx, id, unix.SignalName(sig))
+}
+
+// RemoveContainer removes a Docker container by ID.
+func (d *Client) RemoveContainer(ctx context.Context, id string, force bool) error {
+	return d.cl.ContainerRemove(ctx, id, types.ContainerRemoveOptions{Force: force})
+}
+
+// ListRunningContainers lists running Docker containers satisfying the given filters.
+func (d *Client) ListRunningContainers(ctx context.Context, fs filters.Args) (
+	map[cproto.ID]types.Container, error,
+) {
+	// List "our" running containers, based on `dockerAgentLabel`.
+	// This doesn't affect fluentbit, or containers spawned by other agents.
+	containers, err := d.cl.ContainerList(ctx, types.ContainerListOptions{All: false, Filters: fs})
+	if err != nil {
+		return nil, err
+	}
+
+	result := make(map[cproto.ID]types.Container, len(containers))
+	for _, cont := range containers {
+		containerID, ok := cont.Labels[ContainerIDLabel]
+		if ok {
+			result[cproto.ID(containerID)] = cont
+		} else {
+			d.logger.Warnf("container %v has agent label but no container id", cont.ID)
+		}
+	}
+	return result, nil
+}
+
+// LabelFilter is a convenience that takes a key and value and returns a docker label filter.
+func LabelFilter(key, val string) filters.Args {
+	return filters.NewArgs(filters.Arg("label", key+"="+val))
+}
+
+func (d *Client) getDockerAuths(
+	ctx context.Context,
+	image reference.Named,
+	userRegistry *types.AuthConfig,
+	p events.Publisher[Event],
+) (*types.AuthConfig, error) {
+	imageDomain := reference.Domain(image)
+	// Try user submitted registry auth config.
+	if userRegistry != nil {
+		// TODO: remove didNotPassServerAddress when it becomes required.
+		didNotPassServerAddress := userRegistry.ServerAddress == ""
+		if didNotPassServerAddress {
+			if err := p.Publish(ctx, NewLogEvent(model.LogLevelWarning,
+				"setting registry_auth without registry_auth.serveraddress is deprecated "+
+					"and will soon be required")); err != nil {
+				return nil, err
+			}
+		}
+
+		registryDomain := registry.ConvertToHostname(userRegistry.ServerAddress)
+		if registryDomain == imageDomain || didNotPassServerAddress {
+			return userRegistry, nil
+		}
+		if err := p.Publish(ctx, NewLogEvent(model.LogLevelWarning, fmt.Sprintf(
+			"not using expconfig registry_auth since expconf "+
+				"registry_auth.serverAddress %s did not match the image serverAddress %s",
+			registryDomain, imageDomain,
+		))); err != nil {
+			return nil, err
+		}
+	}
+
+	// Try using credential stores specified in ~/.docker/config.json.
+	if store, ok := d.credentialStores[imageDomain]; ok {
+		creds, err := store.get()
+		if err != nil {
+			return nil, fmt.Errorf("unable to get credentials from helper: %w", err)
+		}
+
+		if err := p.Publish(ctx, NewLogEvent(model.LogLevelInfo, fmt.Sprintf(
+			"domain '%s' found in 'credHelpers' config. Using credentials helper.",
+			imageDomain,
+		))); err != nil {
+			return nil, err
+		}
+
+		return &creds, nil
+	}
+
+	// Finally try using auths section of users ~/.docker/config.json.
+	index, err := registry.ParseSearchIndexInfo(image.String())
+	if err != nil {
+		return nil, fmt.Errorf("error invalid docker repo name: %w", err)
+	}
+	reg := registry.ResolveAuthConfig(d.authConfigs, index)
+	if reg != (types.AuthConfig{}) {
+		if err := p.Publish(ctx, NewLogEvent(model.LogLevelInfo, fmt.Sprintf(
+			"domain '%s' found in 'auths' ~/.docker/config.json", imageDomain,
+		))); err != nil {
+			return nil, err
+		}
+	}
+	return &reg, nil
+}
+
+// registryToString converts the Registry struct to a base64 encoding for json strings.
+func registryToString(reg types.AuthConfig) (string, error) {
+	// Docker stores the username and password in an auth section types.AuthConfig
+	// formatted as user:pass then base64ed. This is not documented clearly.
+	// https://github.com/docker/cli/blob/master/cli/config/configfile/file.go#L76
+	if reg.Auth != "" {
+		bytes, err := base64.StdEncoding.DecodeString(reg.Auth)
+		if err != nil {
+			return "", err
+		}
+		userAndPass := strings.SplitN(string(bytes), ":", 2)
+		if len(userAndPass) != 2 {
+			return "", errors.Errorf("auth field of docker authConfig must be base64ed user:pass")
+		}
+		reg.Username, reg.Password = userAndPass[0], userAndPass[1]
+		reg.Auth = ""
+	}
+	bs, err := json.Marshal(reg)
+	if err != nil {
+		return "", err
+	}
+
+	return base64.URLEncoding.EncodeToString(bs), nil
+}
+
+func (d *Client) sendPullLogs(ctx context.Context, r io.Reader, p events.Publisher[Event]) error {
+	plf := pullLogFormatter{Known: map[string]*pullInfo{}}
+
+	scanner := bufio.NewScanner(r)
+	for scanner.Scan() {
+		log := jsonmessage.JSONMessage{}
+		if err := json.Unmarshal(scanner.Bytes(), &log); err != nil {
+			return fmt.Errorf("error parsing log message: %#v: %w", log, err)
+		}
+
+		logMsg := plf.Update(log)
+		if logMsg == nil {
+			continue
+		}
+
+		if err := p.Publish(ctx, NewLogEvent(model.LogLevelInfo, *logMsg)); err != nil {
+			return err
+		}
+	}
+	// Always print the complete progress bar, regardless of the backoff time.
+	finalLogMsg := plf.RenderProgress()
+	if err := p.Publish(ctx, NewLogEvent(model.LogLevelInfo, finalLogMsg)); err != nil {
+		return err
+	}
+	return scanner.Err()
+}

--- a/agent/pkg/docker/docker.go
+++ b/agent/pkg/docker/docker.go
@@ -124,7 +124,7 @@ func (d *Client) ReattachContainer(
 	}
 
 	for _, cont := range containers {
-		// Subscribe to termination notifications first, to not miss immediately exits.
+		// Subscribe to termination notifications first, to not miss immediate exits.
 		waiter, errs := d.cl.ContainerWait(ctx, cont.ID, dcontainer.WaitConditionNextExit)
 
 		// Restore containerInfo.

--- a/agent/pkg/docker/docker_api_test.go
+++ b/agent/pkg/docker/docker_api_test.go
@@ -33,12 +33,12 @@ func TestPullImage(t *testing.T) {
 	t.Log("building client")
 	rawCl, err := dclient.NewClientWithOpts(dclient.WithAPIVersionNegotiation(), dclient.FromEnv)
 	require.NoError(t, err)
-	cl := docker.NewClient(rawCl)
 	defer func() {
-		if cErr := cl.Close(); cErr != nil {
+		if cErr := rawCl.Close(); cErr != nil {
 			t.Logf("closing docker client: %s", cErr)
 		}
 	}()
+	cl := docker.NewClient(rawCl)
 
 	t.Log("removing image")
 	switch _, err = rawCl.ImageRemove(ctx, testImage, types.ImageRemoveOptions{Force: true}); {
@@ -128,12 +128,13 @@ func TestRunContainer(t *testing.T) {
 	t.Log("building client")
 	rawCl, err := dclient.NewClientWithOpts(dclient.WithAPIVersionNegotiation(), dclient.FromEnv)
 	require.NoError(t, err)
-	cl := docker.NewClient(rawCl)
 	defer func() {
-		if cErr := cl.Close(); cErr != nil {
+		if cErr := rawCl.Close(); cErr != nil {
 			t.Logf("closing docker client: %s", cErr)
 		}
 	}()
+	cl := docker.NewClient(rawCl)
+
 	t.Log("pull test image")
 	evs := make(chan docker.Event, 1024)
 	pub := events.ChannelPublisher(evs)
@@ -204,12 +205,13 @@ func TestRunContainerWithService(t *testing.T) {
 	t.Log("building client")
 	rawCl, err := dclient.NewClientWithOpts(dclient.WithAPIVersionNegotiation(), dclient.FromEnv)
 	require.NoError(t, err)
-	cl := docker.NewClient(rawCl)
 	defer func() {
-		if cErr := cl.Close(); cErr != nil {
+		if cErr := rawCl.Close(); cErr != nil {
 			t.Logf("closing docker client: %s", cErr)
 		}
 	}()
+	cl := docker.NewClient(rawCl)
+
 	t.Log("pull test image")
 	evs := make(chan docker.Event, 1024)
 	pub := events.ChannelPublisher(evs)

--- a/agent/pkg/docker/docker_api_test.go
+++ b/agent/pkg/docker/docker_api_test.go
@@ -1,0 +1,297 @@
+//go:build integration
+
+package docker_test
+
+import (
+	"archive/tar"
+	"context"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/container"
+	dclient "github.com/docker/docker/client"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/determined-ai/determined/agent/pkg/docker"
+	"github.com/determined-ai/determined/agent/pkg/events"
+	"github.com/determined-ai/determined/master/pkg/archive"
+	"github.com/determined-ai/determined/master/pkg/cproto"
+)
+
+const (
+	testImage = "determinedai/determined-agent:7c12bd2545e4e98018fa37f5326f377ff58583b2"
+)
+
+func TestPullImage(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	t.Log("building client")
+	rawCl, err := dclient.NewClientWithOpts(dclient.WithAPIVersionNegotiation(), dclient.FromEnv)
+	require.NoError(t, err)
+	cl := docker.NewClient(rawCl)
+	defer func() {
+		if cErr := cl.Close(); cErr != nil {
+			t.Logf("closing docker client: %s", cErr)
+		}
+	}()
+
+	t.Log("removing image")
+	switch _, err = rawCl.ImageRemove(ctx, testImage, types.ImageRemoveOptions{Force: true}); {
+	case err == nil, strings.Contains(err.Error(), "No such image"):
+		break
+	case err != nil:
+		t.Errorf("removing image: %s", err.Error())
+		return
+	}
+
+	t.Log("normal pull, image not pulled")
+	evs := make(chan docker.Event, 1024)
+	pub := events.ChannelPublisher(evs)
+	if err = cl.PullImage(ctx, docker.PullImage{Name: testImage}, pub); err != nil {
+		t.Errorf("pulling image: %s", err.Error())
+		return
+	}
+	close(evs)
+	if !witnessedPull(t, evs) {
+		t.Errorf("did not witness expected pull events")
+		return
+	}
+	_, _, err = rawCl.ImageInspectWithRaw(ctx, testImage)
+	require.NoError(t, err)
+
+	t.Log("normal pull, image already pulled")
+	evs = make(chan docker.Event, 64) // Excessively large value, so the client never blocks.
+	pub = events.ChannelPublisher(evs)
+	if err = cl.PullImage(ctx, docker.PullImage{Name: testImage}, pub); err != nil {
+		t.Errorf("pulling image: %s", err.Error())
+		return
+	}
+	close(evs)
+	if witnessedPull(t, evs) {
+		t.Error("saw pull of pulled image")
+		return
+	}
+	_, _, err = rawCl.ImageInspectWithRaw(ctx, testImage)
+	require.NoError(t, err)
+
+	t.Log("force pull, image already pulled")
+	evs = make(chan docker.Event, 64) // Excessively large value, so the client never blocks.
+	pub = events.ChannelPublisher(evs)
+	if err = cl.PullImage(ctx, docker.PullImage{
+		Name:      testImage,
+		ForcePull: true,
+	}, pub); err != nil {
+		t.Errorf("pulling image: %s", err.Error())
+		return
+	}
+	close(evs)
+	if !witnessedPull(t, evs) {
+		t.Errorf("did not witness expected pull events")
+		return
+	}
+	_, _, err = rawCl.ImageInspectWithRaw(ctx, testImage)
+	require.NoError(t, err)
+}
+
+func witnessedPull(t *testing.T, events <-chan docker.Event) bool {
+	pullWitnessed, statsBeginWitnessed, statsEndWitnessed := false, false, false
+	for event := range events {
+		switch {
+		case event.Log != nil:
+			switch log := event.Log; {
+			case strings.Contains(log.Message, "pulling image"):
+				pullWitnessed = true
+			case strings.Contains(log.Message, "checking for updates"):
+				pullWitnessed = true
+			}
+		case event.Stats != nil:
+			switch stats := event.Stats; {
+			case stats.Kind == docker.ImagePullStatsKind && stats.StartTime != nil:
+				statsBeginWitnessed = true
+			case stats.Kind == docker.ImagePullStatsKind && stats.EndTime != nil:
+				statsEndWitnessed = true
+			}
+		}
+	}
+	return pullWitnessed && statsBeginWitnessed && statsEndWitnessed
+}
+
+func TestRunContainer(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	t.Log("building client")
+	rawCl, err := dclient.NewClientWithOpts(dclient.WithAPIVersionNegotiation(), dclient.FromEnv)
+	require.NoError(t, err)
+	cl := docker.NewClient(rawCl)
+	defer func() {
+		if cErr := cl.Close(); cErr != nil {
+			t.Logf("closing docker client: %s", cErr)
+		}
+	}()
+	t.Log("pull test image")
+	evs := make(chan docker.Event, 1024)
+	pub := events.ChannelPublisher(evs)
+	if err = cl.PullImage(ctx, docker.PullImage{Name: testImage}, pub); err != nil {
+		t.Errorf("pulling image: %s", err.Error())
+		return
+	}
+	close(evs)
+	_, _, err = rawCl.ImageInspectWithRaw(ctx, testImage)
+	require.NoError(t, err)
+
+	t.Log("creating simple container")
+	evs = make(chan docker.Event, 64)
+	pub = events.ChannelPublisher(evs)
+	dockerID, err := cl.CreateContainer(ctx, cproto.RunSpec{
+		ContainerConfig: container.Config{
+			Image:      testImage,
+			Entrypoint: []string{"cat", "/tmp/whatever"},
+		},
+		Archives: []cproto.RunArchive{
+			{
+				Path: "/tmp",
+				Archive: []archive.Item{
+					{
+						Path:     "/whatever",
+						Type:     tar.TypeReg,
+						Content:  []byte("hello"),
+						FileMode: 0o0777,
+					},
+				},
+			},
+		},
+	}, pub)
+	require.NoError(t, err)
+
+	t.Log("running simple container")
+	c, err := cl.RunContainer(ctx, dockerID)
+	require.NoError(t, err)
+
+	close(evs)
+	defer func() {
+		if err := rawCl.ContainerRemove(
+			ctx,
+			dockerID,
+			types.ContainerRemoveOptions{Force: true},
+		); err != nil {
+			t.Errorf("failed to cleanup container %s: %s", dockerID, err)
+		}
+	}()
+
+	select {
+	case err := <-c.ContainerWaiter.Errs:
+		t.Errorf("failed to wait for container: %s", err.Error())
+	case exit := <-c.ContainerWaiter.Waiter:
+		require.Equal(t, int64(0), exit.StatusCode)
+		return
+	}
+}
+
+const testServiceImage = "nginx:latest"
+
+func TestRunContainerWithService(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	agentID := uuid.NewString()
+	containerID := uuid.NewString()
+
+	t.Log("building client")
+	rawCl, err := dclient.NewClientWithOpts(dclient.WithAPIVersionNegotiation(), dclient.FromEnv)
+	require.NoError(t, err)
+	cl := docker.NewClient(rawCl)
+	defer func() {
+		if cErr := cl.Close(); cErr != nil {
+			t.Logf("closing docker client: %s", cErr)
+		}
+	}()
+	t.Log("pull test image")
+	evs := make(chan docker.Event, 1024)
+	pub := events.ChannelPublisher(evs)
+	if err = cl.PullImage(ctx, docker.PullImage{Name: testServiceImage}, pub); err != nil {
+		t.Errorf("pulling image: %s", err.Error())
+		return
+	}
+	close(evs)
+	_, _, err = rawCl.ImageInspectWithRaw(ctx, testImage)
+	require.NoError(t, err)
+
+	t.Log("creating simple container")
+	evs = make(chan docker.Event, 64)
+	pub = events.ChannelPublisher(evs)
+	dockerID, err := cl.CreateContainer(ctx, cproto.RunSpec{
+		ContainerConfig: container.Config{
+			Image: testServiceImage,
+			Labels: map[string]string{
+				docker.AgentLabel:       agentID,
+				docker.ContainerIDLabel: containerID,
+			},
+		},
+	}, pub)
+	require.NoError(t, err)
+
+	t.Log("running simple container")
+	c, err := cl.RunContainer(ctx, dockerID)
+	require.NoError(t, err)
+
+	close(evs)
+	defer func() {
+		if rErr := rawCl.ContainerRemove(
+			ctx,
+			c.ContainerInfo.ID,
+			types.ContainerRemoveOptions{Force: true},
+		); rErr != nil {
+			t.Errorf("failed to cleanup container %s: %s", c.ContainerInfo.ID, rErr)
+		}
+	}()
+
+	t.Log("ensure it is listed when searching docker for our containers")
+	containers, err := cl.ListRunningContainers(ctx, docker.LabelFilter(docker.AgentLabel, agentID))
+	require.NoError(t, err)
+	found := false
+	for id := range containers {
+		if id == cproto.ID(containerID) {
+			found = true
+			break
+		}
+	}
+	require.True(t, found, "did not find our container")
+
+	t.Log("ensure it can be reattached")
+	reattached, terminated, err := cl.ReattachContainer(
+		ctx,
+		docker.LabelFilter(docker.ContainerIDLabel, containerID),
+	)
+	require.NoError(t, err)
+	require.Nil(t, terminated)
+
+	t.Log("original waiters should exit after being killed")
+	select {
+	case <-time.After(time.Second):
+		if err := cl.SignalContainer(ctx, c.ContainerInfo.ID, syscall.SIGTERM); err != nil {
+			t.Errorf("failed to signal container: %s", err)
+			return
+		}
+	case err := <-c.ContainerWaiter.Errs:
+		t.Errorf("failed to wait for container: %s", err)
+		return
+	case exit := <-c.ContainerWaiter.Waiter:
+		require.Equal(t, int64(0), exit.StatusCode)
+		break
+	}
+
+	t.Log("reattached waiters should also exit after being killed")
+	select {
+	case err := <-reattached.ContainerWaiter.Errs:
+		t.Errorf("failed to wait for reattached container: %s", err)
+		return
+	case exit := <-reattached.ContainerWaiter.Waiter:
+		require.Equal(t, int64(0), exit.StatusCode)
+		break
+	}
+}

--- a/agent/pkg/docker/docker_credential_store.go
+++ b/agent/pkg/docker/docker_credential_store.go
@@ -29,7 +29,7 @@ func getDockerConfigPath() (string, error) {
 	return path.Join(homeDir, ".docker", "config.json"), nil
 }
 
-// processDockerConfig reads a users ~/.docker/config.json and returns
+// processDockerConfig reads a user's ~/.docker/config.json and returns
 // credential helpers configured and the "auths" section of the config.
 func processDockerConfig() (map[string]*credentialStore, map[string]types.AuthConfig, error) {
 	dockerConfigFile, err := getDockerConfigPath()
@@ -39,7 +39,7 @@ func processDockerConfig() (map[string]*credentialStore, map[string]types.AuthCo
 
 	b, err := os.ReadFile(dockerConfigFile) // #nosec: G304
 	if err != nil {
-		return nil, nil, errors.Wrap(err, "can't read docker config")
+		return nil, nil, errors.Wrap(err, "can't read Docker config")
 	}
 
 	var config struct {

--- a/agent/pkg/docker/docker_credential_store.go
+++ b/agent/pkg/docker/docker_credential_store.go
@@ -1,0 +1,82 @@
+package docker
+
+import (
+	"encoding/json"
+	"os"
+	"path"
+
+	hclient "github.com/docker/docker-credential-helpers/client"
+	"github.com/docker/docker/api/types"
+	"github.com/pkg/errors"
+)
+
+const (
+	//nolint:gosec // It thinks these are credentials...
+	credentialsHelperPrefix = "docker-credential-"
+	tokenUsername           = "<token>"
+)
+
+type credentialStore struct {
+	registry string
+	store    hclient.ProgramFunc
+}
+
+func getDockerConfigPath() (string, error) {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return homeDir, errors.Wrap(err, "unable to find user's HOME directory")
+	}
+	return path.Join(homeDir, ".docker", "config.json"), nil
+}
+
+// processDockerConfig reads a users ~/.docker/config.json and returns
+// credential helpers configured and the "auths" section of the config.
+func processDockerConfig() (map[string]*credentialStore, map[string]types.AuthConfig, error) {
+	dockerConfigFile, err := getDockerConfigPath()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	b, err := os.ReadFile(dockerConfigFile) // #nosec: G304
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "can't read docker config")
+	}
+
+	var config struct {
+		CredentialHelpers map[string]string           `json:"credHelpers"`
+		Auths             map[string]types.AuthConfig `json:"auths"`
+	}
+	if err := json.Unmarshal(b, &config); err != nil {
+		return nil, nil, errors.Wrap(err, "can't parse docker config")
+	}
+
+	credStores := make(map[string]*credentialStore, len(config.CredentialHelpers))
+	for hostname, helper := range config.CredentialHelpers {
+		credStores[hostname] = &credentialStore{
+			registry: hostname,
+			store:    hclient.NewShellProgramFunc(credentialsHelperPrefix + helper),
+		}
+	}
+
+	return credStores, config.Auths, nil
+}
+
+// get executes the command to get the credentials from the native store.
+func (s *credentialStore) get() (types.AuthConfig, error) {
+	var ret types.AuthConfig
+
+	creds, err := hclient.Get(s.store, s.registry)
+	if err != nil {
+		return ret, err
+	}
+
+	if creds.Username == tokenUsername {
+		ret.IdentityToken = creds.Secret
+	} else {
+		ret.Password = creds.Secret
+		ret.Username = creds.Username
+	}
+
+	ret.ServerAddress = s.registry
+	return ret, nil
+}

--- a/agent/pkg/docker/docker_test.go
+++ b/agent/pkg/docker/docker_test.go
@@ -1,0 +1,119 @@
+package docker
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"testing"
+
+	"github.com/docker/distribution/reference"
+	"github.com/docker/docker/api/types"
+
+	"github.com/determined-ai/determined/agent/pkg/events"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetDockerAuths(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	dockerhubAuthConfig := types.AuthConfig{
+		Username:      "username",
+		Password:      "password",
+		ServerAddress: "docker.io",
+	}
+
+	exampleDockerConfig := types.AuthConfig{
+		Auth:          "token",
+		ServerAddress: "https://example.com",
+	}
+
+	noServerAuthConfig := types.AuthConfig{
+		Username: "username",
+		Password: "password",
+	}
+
+	dockerAuthSection := map[string]types.AuthConfig{
+		"https://index.docker.io/v1/": {
+			Auth:          "dockerhubtoken",
+			ServerAddress: "docker.io",
+		},
+		"example.com": {
+			Auth:          "exampletoken",
+			ServerAddress: "example.com",
+		},
+	}
+
+	cases := []struct {
+		image       string
+		expconfReg  *types.AuthConfig
+		authConfigs map[string]types.AuthConfig
+		expected    types.AuthConfig
+	}{
+		// No authentication passed in.
+		{"detai", nil, nil, types.AuthConfig{}},
+		// Correct server passed in for dockerhub.
+		{"detai", &dockerhubAuthConfig, nil, dockerhubAuthConfig},
+		// Correct server passed in for example.com.
+		{"example.com/detai", &exampleDockerConfig, nil, exampleDockerConfig},
+		// Different server passed than specified auth.
+		{"example.com/detai", &dockerhubAuthConfig, nil, types.AuthConfig{}},
+		// No server (behavior is deprecated).
+		{"detai", &noServerAuthConfig, nil, noServerAuthConfig},
+		{"example.com/detai", &noServerAuthConfig, nil, noServerAuthConfig},
+
+		// Docker auth config gets used.
+		{"detai", nil, dockerAuthSection, dockerAuthSection["https://index.docker.io/v1/"]},
+		// Expconf takes precedence over docker config.
+		{"detai", &dockerhubAuthConfig, dockerAuthSection, dockerhubAuthConfig},
+		// We fallback to auths if docker hub has wrong server.
+		{
+			"example.com/detai", &dockerhubAuthConfig, dockerAuthSection,
+			dockerAuthSection["example.com"],
+		},
+		// We don't return a result if we don't have that serveraddress.
+		{"determined.ai/detai", nil, dockerAuthSection, types.AuthConfig{}},
+	}
+
+	evs := make(chan Event, 100)
+	for _, testCase := range cases {
+		d := Client{
+			authConfigs: testCase.authConfigs,
+		}
+
+		// Parse image to correct format.
+		ref, err := reference.ParseNormalizedNamed(testCase.image)
+		require.NoError(t, err, "could not get image to correct format")
+		ref = reference.TagNameOnly(ref)
+
+		actual, err := d.getDockerAuths(ctx, ref, testCase.expconfReg, events.ChannelPublisher(evs))
+		require.NoError(t, err)
+		require.Equal(t, testCase.expected, *actual)
+	}
+}
+
+func TestRegistryToString(t *testing.T) {
+	// No auth just base64ed.
+	case1 := types.AuthConfig{
+		Email:    "det@example.com",
+		Password: "password",
+	}
+	expected := base64.URLEncoding.EncodeToString(
+		[]byte(`{"password":"password","email":"det@example.com"}`))
+	actual, err := registryToString(case1)
+	require.NoError(t, err, "could not to string auth config")
+	require.Equal(t, expected, actual)
+
+	// Auth gets split.
+	user, pass := "user", "pass"
+	auth := fmt.Sprintf("%s:%s", user, pass)
+	case2 := types.AuthConfig{
+		Auth: base64.StdEncoding.EncodeToString([]byte(auth)),
+	}
+	expected = base64.URLEncoding.EncodeToString([]byte(fmt.Sprintf(
+		`{"username":"%s","password":"%s"}`, user, pass)))
+	actual, err = registryToString(case2)
+	require.NoError(t, err, "could not to string auth config")
+	require.Equal(t, expected, actual)
+}

--- a/agent/pkg/docker/events.go
+++ b/agent/pkg/docker/events.go
@@ -1,0 +1,42 @@
+package docker
+
+import (
+	"time"
+
+	"github.com/determined-ai/determined/master/pkg/ptrs"
+)
+
+type (
+	// Event describes some Docker-layer event.
+	Event struct {
+		Log   *LogEvent
+		Stats *StatsEvent
+	}
+	// LogEvent describes a log emitted from the Docker layer.
+	LogEvent struct {
+		Level     string
+		Timestamp time.Time
+		Message   string
+	}
+	// StatsEvent describes some stats about a Docker operation, such as IMAGEPULL.
+	StatsEvent struct {
+		Kind      string
+		StartTime *time.Time
+		EndTime   *time.Time
+	}
+)
+
+// NewLogEvent initializes a new Event that is of kind 'LogEvent'.
+func NewLogEvent(level, message string) Event {
+	return Event{Log: &LogEvent{Level: level, Timestamp: time.Now().UTC(), Message: message}}
+}
+
+// NewBeginStatsEvent initializes a new beginning Event that is of kind 'StatsEvent' for the kind.
+func NewBeginStatsEvent(kind string) Event {
+	return Event{Stats: &StatsEvent{Kind: kind, StartTime: ptrs.Ptr(time.Now().UTC())}}
+}
+
+// NewEndStatsEvent initializes a new ending Event that is of kind 'StatsEvent' for the kind.
+func NewEndStatsEvent(kind string) Event {
+	return Event{Stats: &StatsEvent{Kind: kind, EndTime: ptrs.Ptr(time.Now().UTC())}}
+}

--- a/agent/pkg/docker/pull_log_formatter.go
+++ b/agent/pkg/docker/pull_log_formatter.go
@@ -1,0 +1,173 @@
+package docker
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/docker/docker/pkg/jsonmessage"
+	"github.com/sirupsen/logrus"
+)
+
+type pullInfo struct {
+	DownloadStarted bool
+	ExtractStarted  bool
+	Total           int64
+	Downloaded      int64
+	Extracted       int64
+}
+
+type pullLogFormatter struct {
+	Order   []string
+	Known   map[string]*pullInfo
+	Backoff time.Time
+}
+
+// renderProgress generates human-readable and log-file-friendly progress messages.
+//
+// Every layer goes through the following stages:
+// - 1 Pulling fs layer (ID but no size)
+// - 1 Waiting (ID but no size)
+// - 1+ Downloading
+// - 1 Verifying Checksum
+// - 1 Download Complete
+// - 1+ Extracting
+// - 1 Pull Complete
+//
+// You can't really estimate global progress because the log stream doesn't tell you how big the
+// full download size is at any point, it only tells you how big each layer is, and only when that
+// layer starts downloading.  The downloads are staggered, so when many layers are present you
+// wouldn't know the full download size until you're basically done.
+//
+// Showing a per-layer status bar is practically impossible without an interactive terminal (as
+// docker run would have).
+//
+// So instead we create a weighted-average status bar, where every layer's download and extraction
+// count as equal parts.  The status bar ends up pretty jerky but it still gives a "sensation" of
+// progress; things don't look frozen, the user has a rough idea of how far along you are, and the
+// logs are still sane afterwards.
+func (f *pullLogFormatter) RenderProgress() string {
+	var downloaded int64
+	var extracted int64
+	progress := 0.0
+	for _, id := range f.Order {
+		info := f.Known[id]
+		downloaded += info.Downloaded
+		extracted += info.Extracted
+		switch {
+		case !info.DownloadStarted:
+			// no progress on this layer
+		case info.Extracted == info.Total:
+			// this layer is complete
+			progress += 1.0
+		case info.Downloaded == info.Total:
+			// download complete, extraction in progress
+			progress += 0.5 + 0.5*float64(info.Extracted)/float64(info.Total)
+		default:
+			progress += 0.5 * float64(info.Downloaded) / float64(info.Total)
+		}
+	}
+
+	// Normalize by layer count.
+	progress /= float64(len(f.Known))
+
+	// 40-character progress bar
+	prog := int(40.0 * progress)
+
+	bar := ""
+	for i := 0; i < 40; i++ {
+		if i <= prog {
+			if prog == 40 || i+1 <= prog {
+				// Download is full, or middle of bar.
+				bar += "="
+			} else {
+				// Boundary between bar and spaces.
+				bar += ">"
+			}
+		} else {
+			bar += " "
+		}
+	}
+
+	return fmt.Sprintf(
+		"[%v] Downloaded: %.1fMB, Extracted %.1fMB",
+		bar,
+		float64(downloaded)/1e6,
+		float64(extracted)/1e6,
+	)
+}
+
+func (f *pullLogFormatter) backoffOrRenderProgress() *string {
+	// log at most one line every 1 second
+	now := time.Now().UTC()
+	if now.Before(f.Backoff) {
+		return nil
+	}
+	f.Backoff = now.Add(1 * time.Second)
+
+	progress := f.RenderProgress()
+	return &progress
+}
+
+// Update returns nil or a rendered progress update for the end user.
+func (f *pullLogFormatter) Update(msg jsonmessage.JSONMessage) *string {
+	if msg.Error != nil {
+		logrus.Errorf("%d: %v", msg.Error.Code, msg.Error.Message)
+		return nil
+	}
+
+	var info *pullInfo
+	var ok bool
+
+	switch msg.Status {
+	case "Pulling fs layer":
+		fallthrough
+	case "Waiting":
+		if _, ok = f.Known[msg.ID]; !ok {
+			// New layer!
+			f.Known[msg.ID] = &pullInfo{}
+			f.Order = append(f.Order, msg.ID)
+		}
+		return nil
+
+	case "Downloading":
+		if info, ok = f.Known[msg.ID]; !ok {
+			logrus.Error("message ID not found for downloading message!")
+			return nil
+		}
+		if info.ExtractStarted {
+			logrus.Error("got downloading message after extraction started!")
+			return nil
+		}
+		info.Downloaded = msg.Progress.Current
+		// The first "Downloading" msg is important, as it gives us the layer size.
+		if !info.DownloadStarted {
+			info.DownloadStarted = true
+			info.Total = msg.Progress.Total
+		}
+		return f.backoffOrRenderProgress()
+
+	case "Extracting":
+		if info, ok = f.Known[msg.ID]; !ok {
+			logrus.Error("message ID not found for extracting message!")
+			return nil
+		}
+		info.Extracted = msg.Progress.Current
+		if !info.ExtractStarted {
+			info.ExtractStarted = true
+			// Forcibly mark Downloaded as completed.
+			info.Downloaded = info.Total
+		}
+		return f.backoffOrRenderProgress()
+
+	case "Pull complete":
+		if info, ok = f.Known[msg.ID]; !ok {
+			logrus.Error("message ID not found for completed message!")
+			return nil
+		}
+		// Forcibly mark Extracted as completed.
+		info.Extracted = info.Total
+		return f.backoffOrRenderProgress()
+	}
+
+	return nil
+}

--- a/agent/pkg/docker/pull_log_formatter.go
+++ b/agent/pkg/docker/pull_log_formatter.go
@@ -55,7 +55,7 @@ func (f *pullLogFormatter) RenderProgress() string {
 		extracted += info.Extracted
 		switch {
 		case !info.DownloadStarted:
-			// no progress on this layer
+			// No progress on this layer.
 		case info.Extracted == info.Total:
 			// this layer is complete
 			progress += 1.0
@@ -70,7 +70,7 @@ func (f *pullLogFormatter) RenderProgress() string {
 	// Normalize by layer count.
 	progress /= float64(len(f.Known))
 
-	// 40-character progress bar
+	// 40-character progress bar.
 	prog := int(40.0 * progress)
 
 	bar := ""
@@ -97,7 +97,7 @@ func (f *pullLogFormatter) RenderProgress() string {
 }
 
 func (f *pullLogFormatter) backoffOrRenderProgress() *string {
-	// log at most one line every 1 second
+	// Log at most one line every 1 second.
 	now := time.Now().UTC()
 	if now.Before(f.Backoff) {
 		return nil
@@ -119,9 +119,7 @@ func (f *pullLogFormatter) Update(msg jsonmessage.JSONMessage) *string {
 	var ok bool
 
 	switch msg.Status {
-	case "Pulling fs layer":
-		fallthrough
-	case "Waiting":
+	case "Pulling fs layer", "Waiting":
 		if _, ok = f.Known[msg.ID]; !ok {
 			// New layer!
 			f.Known[msg.ID] = &pullInfo{}

--- a/agent/pkg/docker/pull_log_formatter.go
+++ b/agent/pkg/docker/pull_log_formatter.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/determined-ai/determined/master/pkg/ptrs"
 	"github.com/docker/docker/pkg/jsonmessage"
 	"github.com/sirupsen/logrus"
 )
@@ -104,8 +105,7 @@ func (f *pullLogFormatter) backoffOrRenderProgress() *string {
 	}
 	f.Backoff = now.Add(1 * time.Second)
 
-	progress := f.RenderProgress()
-	return &progress
+	return ptrs.Ptr(f.RenderProgress())
 }
 
 // Update returns nil or a rendered progress update for the end user.

--- a/agent/pkg/docker/pull_log_formatter.go
+++ b/agent/pkg/docker/pull_log_formatter.go
@@ -4,9 +4,10 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/determined-ai/determined/master/pkg/ptrs"
 	"github.com/docker/docker/pkg/jsonmessage"
 	"github.com/sirupsen/logrus"
+
+	"github.com/determined-ai/determined/master/pkg/ptrs"
 )
 
 type pullInfo struct {

--- a/agent/pkg/events/types.go
+++ b/agent/pkg/events/types.go
@@ -1,0 +1,37 @@
+package events
+
+import "context"
+
+// Publisher defines an interface on which the Docker lib publishes asynchronous events, such as
+// logs or stats.
+type Publisher[T any] interface {
+	Publish(context.Context, T) error
+}
+
+// FuncPublisher wraps a plain func as a Publisher.
+type FuncPublisher[T any] func(context.Context, T) error
+
+// Publish implements Publisher for FuncPublisher.
+func (f FuncPublisher[T]) Publish(ctx context.Context, e T) error {
+	return f(ctx, e)
+}
+
+// NilPublisher is a publisher than does nothing and returns no errors. Useful for testing.
+type NilPublisher[T any] struct{}
+
+// Publish implements Publisher for NilPublisher.
+func (f NilPublisher[T]) Publish(ctx context.Context, e T) error {
+	return nil
+}
+
+// ChannelPublisher wraps a plain channel as a Publisher.
+func ChannelPublisher[T any](events chan<- T) FuncPublisher[T] {
+	return func(ctx context.Context, e T) error {
+		select {
+		case events <- e:
+			return nil
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+}


### PR DESCRIPTION
## Description
I've taken a lot of care to pull stuff like `aproto.MasterMessage` and `cproto.ID`'s out of this interface. I figured the better, more encapsulated our interfaces, the easier stuff would get to test, and to extend and reuse. So far I feel validated.

I also took a lot of care to design the concurrent parts of the API in a way that is the most user friendly; APIs mostly take channels instead of returning them, to let users control back pressure and reuse channels in their code without much fuss, some APIs return channels, but only if they are returning a bounded result, and I used directional channels everywhere, etc. Probably the most important is it is as un-concurrent as possible so it feels as much like "normal code" as possible.

<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At a minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan
- [x] has tests (coverage went from <15% to 70% from the old package to this one)
<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions about this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)
Order to review this set of PRs:
* [refactor: rewrite websocket lib without actors [DET-8299]](https://github.com/determined-ai/determined/pull/5382)
* [refactor: rewrite our docker lib without actors [DET-8300]](https://github.com/determined-ai/determined/pull/4943)
* [refactor: rewrite container lib without actors](https://github.com/determined-ai/determined/pull/5384)
* [refactor: rewrite fluent lib without actors](https://github.com/determined-ai/determined/pull/5385)
* [refactor: rewrite container manager lib without actors](https://github.com/determined-ai/determined/pull/5386)
* [refactor: rewrite agent without actors](https://github.com/determined-ai/determined/pull/5387)
<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist
- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.
- [x] If modifying `/webui/react/src/shared/` verify `make -C webui/react test-shared` passes.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ