### PR TITLE
fix: associate allocation sessions with users

### DIFF
--- a/harness/determined/common/api/request.py
+++ b/harness/determined/common/api/request.py
@@ -11,7 +11,6 @@ import urllib3
 
 import determined as det
 import determined.common.requests
-from determined.common import util
 from determined.common.api import authentication, certs, errors
 
 
@@ -77,10 +76,6 @@ def add_token_to_headers(
     user_token = ""
     if auth is not None:
         user_token = auth.get_session_token()
-    else:
-        token = util.get_det_user_token_from_env()
-        if token is not None:
-            user_token = token
 
     if user_token:
         return {**headers, "Authorization": "Bearer {}".format(user_token)}

--- a/master/internal/api_auth.go
+++ b/master/internal/api_auth.go
@@ -87,6 +87,11 @@ func (a *apiServer) Logout(
 	if err != nil {
 		return nil, err
 	}
+	if userSession == nil {
+		return nil, status.Error(codes.InvalidArgument,
+			"cannot manually logout of an allocation session")
+	}
+
 	err = a.m.db.DeleteUserSessionByID(userSession.ID)
 	return &apiv1.LogoutResponse{}, err
 }

--- a/master/internal/db/database.go
+++ b/master/internal/db/database.go
@@ -149,7 +149,7 @@ type DB interface {
 	SetHPImportance(experimentID int, value model.ExperimentHPImportance) error
 	GetPartialHPImportance() ([]int, []model.ExperimentHPImportance, error)
 	ExperimentBestSearcherValidation(id int) (float32, error)
-	StartAllocationSession(allocationID model.AllocationID) (string, error)
+	StartAllocationSession(allocationID model.AllocationID, owner *model.User) (string, error)
 	AllocationSessionByToken(token string) (*model.AllocationSession, error)
 	DeleteAllocationSession(allocationID model.AllocationID) error
 	UpdateAllocationState(allocation model.Allocation) error

--- a/master/internal/db/postgres_tasks.go
+++ b/master/internal/db/postgres_tasks.go
@@ -161,11 +161,11 @@ func (db *PgDB) StartAllocationSession(
 		AllocationID: allocationID,
 	}
 	if owner != nil {
-		taskSession.OwnerID = owner.ID
+		taskSession.OwnerID = &owner.ID
 	}
 
 	query := `
-INSERT INTO allocation_sessions (allocation_id, user_id) VALUES 
+INSERT INTO allocation_sessions (allocation_id, owner_id) VALUES 
 	(:allocation_id, :owner_id) RETURNING id`
 	if err := db.namedGet(&taskSession.ID, query, *taskSession); err != nil {
 		return "", err

--- a/master/internal/db/postgres_tasks.go
+++ b/master/internal/db/postgres_tasks.go
@@ -154,12 +154,19 @@ WHERE allocation_id = $1
 }
 
 // StartAllocationSession creates a row in the allocation_sessions table.
-func (db *PgDB) StartAllocationSession(allocationID model.AllocationID) (string, error) {
+func (db *PgDB) StartAllocationSession(
+	allocationID model.AllocationID, owner *model.User,
+) (string, error) {
 	taskSession := &model.AllocationSession{
 		AllocationID: allocationID,
 	}
+	if owner != nil {
+		taskSession.OwnerID = owner.ID
+	}
 
-	query := "INSERT INTO allocation_sessions (allocation_id) VALUES (:allocation_id) RETURNING id"
+	query := `
+INSERT INTO allocation_sessions (allocation_id, user_id) VALUES 
+	(:allocation_id, :owner_id) RETURNING id`
 	if err := db.namedGet(&taskSession.ID, query, *taskSession); err != nil {
 		return "", err
 	}

--- a/master/internal/mocks/db.go
+++ b/master/internal/mocks/db.go
@@ -1589,20 +1589,20 @@ func (_m *DB) SetHPImportance(experimentID int, value model.ExperimentHPImportan
 	return r0
 }
 
-// StartAllocationSession provides a mock function with given fields: allocationID
-func (_m *DB) StartAllocationSession(allocationID model.AllocationID) (string, error) {
-	ret := _m.Called(allocationID)
+// StartAllocationSession provides a mock function with given fields: allocationID, owner
+func (_m *DB) StartAllocationSession(allocationID model.AllocationID, owner *model.User) (string, error) {
+	ret := _m.Called(allocationID, owner)
 
 	var r0 string
-	if rf, ok := ret.Get(0).(func(model.AllocationID) string); ok {
-		r0 = rf(allocationID)
+	if rf, ok := ret.Get(0).(func(model.AllocationID, *model.User) string); ok {
+		r0 = rf(allocationID, owner)
 	} else {
 		r0 = ret.Get(0).(string)
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(model.AllocationID) error); ok {
-		r1 = rf(allocationID)
+	if rf, ok := ret.Get(1).(func(model.AllocationID, *model.User) error); ok {
+		r1 = rf(allocationID, owner)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/master/internal/task/allocation.go
+++ b/master/internal/task/allocation.go
@@ -447,7 +447,7 @@ func (a *Allocation) ResourcesAllocated(ctx *actor.Context, msg sproto.Resources
 	}
 
 	if !a.req.Restore {
-		token, err := a.db.StartAllocationSession(a.model.AllocationID)
+		token, err := a.db.StartAllocationSession(a.model.AllocationID, spec.Owner)
 		if err != nil {
 			return errors.Wrap(err, "starting a new allocation session")
 		}

--- a/master/pkg/model/task_session.go
+++ b/master/pkg/model/task_session.go
@@ -4,5 +4,5 @@ package model
 type AllocationSession struct {
 	ID           SessionID    `db:"id" json:"id"`
 	AllocationID AllocationID `db:"allocation_id" json:"allocation_id"`
-	OwnerID      UserID       `db:"user_id" json:"user_id"`
+	OwnerID      *UserID      `db:"owner_id" json:"owner_id"`
 }

--- a/master/pkg/model/task_session.go
+++ b/master/pkg/model/task_session.go
@@ -4,4 +4,5 @@ package model
 type AllocationSession struct {
 	ID           SessionID    `db:"id" json:"id"`
 	AllocationID AllocationID `db:"allocation_id" json:"allocation_id"`
+	OwnerID      UserID       `db:"user_id" json:"user_id"`
 }

--- a/master/static/migrations/20220902141323_add-user-to-allocation-session.tx.down.sql
+++ b/master/static/migrations/20220902141323_add-user-to-allocation-session.tx.down.sql
@@ -1,2 +1,2 @@
 ALTER TABLE public.allocation_sessions
-	DROP COLUMN owner_id int REFERENCES users(id);
+	DROP COLUMN owner_id;

--- a/master/static/migrations/20220902141323_add-user-to-allocation-session.tx.down.sql
+++ b/master/static/migrations/20220902141323_add-user-to-allocation-session.tx.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE public.allocation_sessions
+	DROP COLUMN owner_id int REFERENCES users(id);

--- a/master/static/migrations/20220902141323_add-user-to-allocation-session.tx.up.sql
+++ b/master/static/migrations/20220902141323_add-user-to-allocation-session.tx.up.sql
@@ -1,0 +1,10 @@
+ALTER TABLE public.allocation_sessions
+	ADD COLUMN owner_id int REFERENCES users(id);
+
+-- Add owner_id to for in progress trials.
+UPDATE public.allocation_sessions allocation_sessions
+	SET owner_id = experiments.owner_id
+    FROM public.experiments experiments
+    INNER JOIN public.trials trials ON experiments.id = trials.experiment_id
+    INNER JOIN public.allocations allocations ON trials.task_id = allocations.task_id
+    WHERE allocation_sessions.allocation_id = allocations.allocation_id;

--- a/master/static/migrations/20220902141323_add-user-to-allocation-session.tx.up.sql
+++ b/master/static/migrations/20220902141323_add-user-to-allocation-session.tx.up.sql
@@ -1,7 +1,7 @@
 ALTER TABLE public.allocation_sessions
 	ADD COLUMN owner_id int REFERENCES users(id);
 
--- Add owner_id to for in progress trials.
+-- Add owner_id for in progress trials.
 UPDATE public.allocation_sessions allocation_sessions
 	SET owner_id = experiments.owner_id
     FROM public.experiments experiments

--- a/master/static/migrations/20220902141323_add-user-to-allocation-session.tx.up.sql
+++ b/master/static/migrations/20220902141323_add-user-to-allocation-session.tx.up.sql
@@ -1,9 +1,9 @@
 ALTER TABLE public.allocation_sessions
-	ADD COLUMN owner_id int REFERENCES users(id);
+    ADD COLUMN owner_id int REFERENCES users(id);
 
 -- Add owner_id for in progress trials.
 UPDATE public.allocation_sessions allocation_sessions
-	SET owner_id = experiments.owner_id
+    SET owner_id = experiments.owner_id
     FROM public.experiments experiments
     INNER JOIN public.trials trials ON experiments.id = trials.experiment_id
     INNER JOIN public.allocations allocations ON trials.task_id = allocations.task_id


### PR DESCRIPTION
## Description

#4905 assumed that using user session would be ok. I wasn't considering user sessions expiring to be an issue so switched back to using allocation sessions. This change associates allocation sessions with users so that they can use ```grpcutil.GetUser``` which is needed for RBAC to determined access for users.

## Test Plan

Run an experiment and see no errors.

## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist
- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.
- [ ] If modifying `/webui/react/src/shared/` verify `make -C webui/react test-shared` passes.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
