### PR TITLE
feat: use task names for interactive task page titles.

### DIFF
--- a/webui/react/src/pages/InteractiveTask.tsx
+++ b/webui/react/src/pages/InteractiveTask.tsx
@@ -26,7 +26,7 @@ enum PageView {
 
 const DEFAULT_PAGE_TITLE = 'Tasks - Determined';
 
-const getTitleState = (commandState?: CommandState): string => {
+const getTitleState = (commandState?: CommandState, taskName?: string): string => {
   if (!commandState){
     return DEFAULT_PAGE_TITLE;
   }
@@ -34,7 +34,7 @@ const getTitleState = (commandState?: CommandState): string => {
     [CommandState.Pending]: 'Pending',
     [CommandState.Assigned]: 'Assigned',
     [CommandState.Pulling]: 'Pulling',
-    [CommandState.Running]: DEFAULT_PAGE_TITLE,
+    [CommandState.Running]: taskName || DEFAULT_PAGE_TITLE,
     [CommandState.Terminating]: 'Terminating',
     [CommandState.Terminated]: 'Terminated',
     [CommandState.Starting]: 'Starting',
@@ -85,7 +85,7 @@ export const InteractiveTask: React.FC = () => {
     return () => clearInterval(queryTask);
   }, [ taskId ]);
 
-  const title = ui.isPageHidden ? getTitleState(taskState) : DEFAULT_PAGE_TITLE;
+  const title = ui.isPageHidden ? getTitleState(taskState, taskName) : taskName;
 
   return (
     <>


### PR DESCRIPTION
## Description

Interactive task pages (e.g. Jupyterlab pages) were using the default page title `Tasks - Determined` (in HTML sense). When you have multiple tabs running simultaneously, it becomes challenging to distinguish these pages between each other and the "normal" tasks page at `/det/tasks`. With this PR, well show the task name instead, e.g. `Jupyterlab (brightly-capable-corgi)`

## Test Plan

Run a couple jupyterlabs and see they have unique page titles names.

## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist
- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.
- [ ] If modifying `/webui/react/src/shared/` verify `make -C webui/react test-shared` passes.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
