### PR TITLE
fix: correct overflow action buttons [DET-8322]

### DIFF
--- a/webui/react/src/components/PageHeaderFoldable.module.scss
+++ b/webui/react/src/components/PageHeaderFoldable.module.scss
@@ -37,8 +37,13 @@
       justify-content: flex-end;
       max-width: fit-content;
 
-      .optionsMainButton {
-        display: none;
+      .optionsButtons {
+        display: flex;
+        gap: 8px;
+
+        .optionsMainButton {
+          display: none;
+        }
       }
     }
     .optionsDropdown {
@@ -76,7 +81,7 @@
   .options {
     flex: 1 0 45%;
   }
-  .optionsMainButton:nth-of-type(1) {
+  .optionsButtons :nth-child(1) {
     display: inline-block !important;
   }
   .optionsDropdownItem:nth-child(1) {
@@ -88,7 +93,7 @@
 }
 
 @media only screen and (min-width: $breakpoint-desktop-medium) {
-  .optionsMainButton:nth-of-type(2) {
+  .optionsButtons :nth-child(2) {
     display: inline-block !important;
   }
   .optionsDropdownItem:nth-child(2) {
@@ -100,7 +105,7 @@
 }
 
 @media only screen and (min-width: $breakpoint-desktop-large) {
-  .optionsMainButton:nth-of-type(3) {
+  .optionsButtons :nth-child(3) {
     display: inline-block !important;
   }
   .optionsDropdownItem:nth-child(3) {

--- a/webui/react/src/components/PageHeaderFoldable.tsx
+++ b/webui/react/src/components/PageHeaderFoldable.tsx
@@ -68,28 +68,27 @@ const PageHeaderFoldable: React.FC<Props> = (
         </div>
         <div className={css.options}>
           {foldableContent && (
-            // div is needed to make nth-of-type selectors for overflow actions work correctly
-            <div>
-              <IconButton
-                icon={isExpanded ? 'arrow-up' : 'arrow-down'}
-                iconSize="tiny"
-                label="Toggle"
-                type="text"
-                onClick={() => setIsExpanded((prev) => !prev)}
-              />
-            </div>
+            <IconButton
+              icon={isExpanded ? 'arrow-up' : 'arrow-down'}
+              iconSize="tiny"
+              label="Toggle"
+              type="text"
+              onClick={() => setIsExpanded((prev) => !prev)}
+            />
           )}
-          {options?.slice(0, 3).map((option) => (
-            <Button
-              className={css.optionsMainButton}
-              disabled={option.disabled || !option.onClick}
-              ghost
-              icon={option?.icon}
-              key={option.key}
-              loading={option.isLoading}
-              onClick={option.onClick}>{renderOptionLabel(option)}
-            </Button>
-          ))}
+          <div className={css.optionsButtons}>
+            {options?.slice(0, 3).map((option) => (
+              <Button
+                className={css.optionsMainButton}
+                disabled={option.disabled || !option.onClick}
+                ghost
+                icon={option?.icon}
+                key={option.key}
+                loading={option.isLoading}
+                onClick={option.onClick}>{renderOptionLabel(option)}
+              </Button>
+            ))}
+          </div>
           {dropdownOptions && (
             <Dropdown overlay={dropdownOptions} placement="bottomRight" trigger={[ 'click' ]}>
               <Button

--- a/webui/react/src/components/PageHeaderFoldable.tsx
+++ b/webui/react/src/components/PageHeaderFoldable.tsx
@@ -68,13 +68,16 @@ const PageHeaderFoldable: React.FC<Props> = (
         </div>
         <div className={css.options}>
           {foldableContent && (
-            <IconButton
-              icon={isExpanded ? 'arrow-up' : 'arrow-down'}
-              iconSize="tiny"
-              label="Toggle"
-              type="text"
-              onClick={() => setIsExpanded((prev) => !prev)}
-            />
+            // div is needed to make nth-of-type selectors for overflow actions work correctly
+            <div>
+              <IconButton
+                icon={isExpanded ? 'arrow-up' : 'arrow-down'}
+                iconSize="tiny"
+                label="Toggle"
+                type="text"
+                onClick={() => setIsExpanded((prev) => !prev)}
+              />
+            </div>
           )}
           {options?.slice(0, 3).map((option) => (
             <Button


### PR DESCRIPTION
## Description
`.optionsMainButton:nth-of-type(1)` doesn't select the first element with the class `.optionsMainButton`. Apparently it actually selects the element with the class `.optionsMainButton` that is the first of its type (button). Since the first sibling button didn't have the class `.optionsMainButton`, it didn't select anything. It's very confusing, here are some more details: https://stackoverflow.com/questions/30603786/nth-of-type2-is-targeting-the-first-of-type
<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At a minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan
Go to an experiment details page and change the width of the window. The actions buttons should swap between the button row and the overflow menu smoothly.
![image](https://user-images.githubusercontent.com/15078396/189145611-7a4e17b8-656b-415f-8fec-d2adee7edce9.png)

<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions about this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist
- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.
- [ ] If modifying `/webui/react/src/shared/` verify `make -C webui/react test-shared` passes.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ