### PR TITLE
feat: can see users' permissions if view_permissions enabled [DET-8222]

### DIFF
--- a/webui/react/src/hooks/useModal/UserSettings/useModalCreateUser.tsx
+++ b/webui/react/src/hooks/useModal/UserSettings/useModalCreateUser.tsx
@@ -6,6 +6,7 @@ import { useStore } from 'contexts/Store';
 import usePermissions from 'hooks/usePermissions';
 import { getUserPermissions, patchUser, postUser, updateGroup } from 'services/api';
 import { V1GroupSearchResult } from 'services/api-ts-sdk';
+import Icon from 'shared/components/Icon/Icon';
 import useModal, { ModalHooks } from 'shared/hooks/useModal/useModal';
 import { ErrorType } from 'shared/utils/error';
 import { BrandingType, DetailedUser, Permission } from 'types';
@@ -70,13 +71,13 @@ const ModalForm: React.FC<Props> = ({ form, branding, user, groups }) => {
     {
       dataIndex: 'globalOnly',
       key: 'globalOnly',
-      render: (val: boolean) => val ? '✓' : '',
+      render: (val: boolean) => val ? <Icon name="checkmark" /> : '',
       title: 'Global?',
     },
     {
       dataIndex: 'workspaceOnly',
       key: 'workspaceOnly',
-      render: (val: boolean) => val ? '✓' : '',
+      render: (val: boolean) => val ? <Icon name="checkmark" /> : '',
       title: 'Workspaces?',
     },
   ];

--- a/webui/react/src/hooks/useModal/UserSettings/useModalCreateUser.tsx
+++ b/webui/react/src/hooks/useModal/UserSettings/useModalCreateUser.tsx
@@ -136,6 +136,7 @@ const ModalForm: React.FC<Props> = ({ form, branding, user, groups }) => {
         <Table
           columns={columns}
           dataSource={permissions}
+          pagination={{ hideOnSinglePage: true, size: 'small' }}
         />
       )}
     </Form>

--- a/webui/react/src/hooks/usePermissions.ts
+++ b/webui/react/src/hooks/usePermissions.ts
@@ -39,6 +39,7 @@ interface PermissionsHook {
   canDeleteModelVersion: (arg0: ModelVersionPermissionsArgs) => boolean;
   canDeleteProjects: (arg0: ProjectPermissionsArgs) => boolean;
   canDeleteWorkspace: (arg0: WorkspacePermissionsArgs) => boolean;
+  canGetPermissions: () => boolean;
   canModifyProjects: (arg0: ProjectPermissionsArgs) => boolean;
   canModifyWorkspace: (arg0: WorkspacePermissionsArgs) => boolean;
   canMoveExperiment: (arg0: ExperimentPermissionsArgs) => boolean;
@@ -76,6 +77,11 @@ const usePermissions = (): PermissionsHook => {
     ),
     canDeleteWorkspace: (args: WorkspacePermissionsArgs) => canDeleteWorkspace(
       args.workspace,
+      user,
+      userAssignments,
+      userRoles,
+    ),
+    canGetPermissions: () => canGetPermissions(
       user,
       userAssignments,
       userRoles,
@@ -153,6 +159,17 @@ const canMoveExperiment = (
   return !!experiment && !!user &&
     permitted.has('oss_user') ? (user.isAdmin || user.id === experiment.userId)
     : permitted.has('move_experiment');
+};
+
+// User actions
+const canGetPermissions = (
+  user?: DetailedUser,
+  userAssignments?: UserAssignment[],
+  userRoles?: UserRole[],
+): boolean => {
+  const permitted = relevantPermissions(userAssignments, userRoles);
+  return !!user && (permitted.has('oss_user') ? user.isAdmin
+    : permitted.has('view_permissions'));
 };
 
 // Model and ModelVersion actions

--- a/webui/react/src/hooks/usePermissions.ts
+++ b/webui/react/src/hooks/usePermissions.ts
@@ -145,8 +145,8 @@ const canDeleteExperiment = (
 ): boolean => {
   const permitted = relevantPermissions(userAssignments, userRoles, experiment.workspaceId);
   return !!experiment && !!user &&
-    permitted.has('oss_user') ? (user.isAdmin || user.id === experiment.userId)
-    : permitted.has('delete_experiment');
+    (permitted.has('oss_user') ? (user.isAdmin || user.id === experiment.userId)
+    : permitted.has('delete_experiment'));
 };
 
 const canMoveExperiment = (
@@ -157,8 +157,8 @@ const canMoveExperiment = (
 ): boolean => {
   const permitted = relevantPermissions(userAssignments, userRoles, experiment.workspaceId);
   return !!experiment && !!user &&
-    permitted.has('oss_user') ? (user.isAdmin || user.id === experiment.userId)
-    : permitted.has('move_experiment');
+    (permitted.has('oss_user') ? (user.isAdmin || user.id === experiment.userId)
+    : permitted.has('move_experiment'));
 };
 
 // User actions
@@ -181,8 +181,8 @@ const canDeleteModel = (
 ): boolean => {
   const permitted = relevantPermissions(userAssignments, userRoles);
   return !!model && !!user &&
-    permitted.has('oss_user') ? (user.isAdmin || user.id === model.userId)
-    : permitted.has('delete_model');
+    (permitted.has('oss_user') ? (user.isAdmin || user.id === model.userId)
+    : permitted.has('delete_model'));
 };
 
 const canDeleteModelVersion = (
@@ -193,8 +193,8 @@ const canDeleteModelVersion = (
 ): boolean => {
   const permitted = relevantPermissions(userAssignments, userRoles);
   return !!modelVersion && !!user &&
-    permitted.has('oss_user') ? (user.isAdmin || user.id === modelVersion.userId)
-    : permitted.has('delete_model_version');
+    (permitted.has('oss_user') ? (user.isAdmin || user.id === modelVersion.userId)
+    : permitted.has('delete_model_version'));
 };
 
 // Project actions
@@ -208,8 +208,8 @@ const canDeleteWorkspaceProjects = (
 ): boolean => {
   const permitted = relevantPermissions(userAssignments, userRoles, workspace?.id);
   return !!workspace && !!user && !!project &&
-    permitted.has('oss_user') ? (user.isAdmin || user.id === project.userId)
-    : permitted.has('delete_projects');
+    (permitted.has('oss_user') ? (user.isAdmin || user.id === project.userId)
+    : permitted.has('delete_projects'));
 };
 
 const canModifyWorkspaceProjects = (
@@ -221,8 +221,8 @@ const canModifyWorkspaceProjects = (
 ): boolean => {
   const permitted = relevantPermissions(userAssignments, userRoles, workspace?.id);
   return !!workspace && !!user && !!project &&
-    permitted.has('oss_user') ? (user.isAdmin || user.id === project.userId)
-    : permitted.has('modify_projects');
+    (permitted.has('oss_user') ? (user.isAdmin || user.id === project.userId)
+    : permitted.has('modify_projects'));
 };
 
 const canMoveWorkspaceProjects = (
@@ -234,8 +234,8 @@ const canMoveWorkspaceProjects = (
 ): boolean => {
   const permitted = relevantPermissions(userAssignments, userRoles, workspace?.id);
   return !!workspace && !!user && !!project &&
-    permitted.has('oss_user') ? (user.isAdmin || user.id === project.userId)
-    : permitted.has('move_projects');
+    (permitted.has('oss_user') ? (user.isAdmin || user.id === project.userId)
+    : permitted.has('move_projects'));
 };
 
 // Workspace actions
@@ -247,8 +247,8 @@ const canDeleteWorkspace = (
 ): boolean => {
   const permitted = relevantPermissions(userAssignments, userRoles, workspace?.id);
   return !!workspace && !!user &&
-    permitted.has('oss_user') ? (user.isAdmin || user.id === workspace.userId)
-    : permitted.has('delete_workspace');
+    (permitted.has('oss_user') ? (user.isAdmin || user.id === workspace.userId)
+    : permitted.has('delete_workspace'));
 };
 
 const canModifyWorkspace = (
@@ -259,8 +259,8 @@ const canModifyWorkspace = (
 ): boolean => {
   const permitted = relevantPermissions(userAssignments, userRoles, workspace?.id);
   return !!workspace && !!user &&
-    permitted.has('oss_user') ? (user.isAdmin || user.id === workspace.userId)
-    : permitted.has('modify_workspace');
+    (permitted.has('oss_user') ? (user.isAdmin || user.id === workspace.userId)
+    : permitted.has('modify_workspace'));
 };
 
 export default usePermissions;

--- a/webui/react/src/hooks/usePermissions.ts
+++ b/webui/react/src/hooks/usePermissions.ts
@@ -146,7 +146,7 @@ const canDeleteExperiment = (
   const permitted = relevantPermissions(userAssignments, userRoles, experiment.workspaceId);
   return !!experiment && !!user &&
     (permitted.has('oss_user') ? (user.isAdmin || user.id === experiment.userId)
-    : permitted.has('delete_experiment'));
+      : permitted.has('delete_experiment'));
 };
 
 const canMoveExperiment = (
@@ -158,7 +158,7 @@ const canMoveExperiment = (
   const permitted = relevantPermissions(userAssignments, userRoles, experiment.workspaceId);
   return !!experiment && !!user &&
     (permitted.has('oss_user') ? (user.isAdmin || user.id === experiment.userId)
-    : permitted.has('move_experiment'));
+      : permitted.has('move_experiment'));
 };
 
 // User actions
@@ -182,7 +182,7 @@ const canDeleteModel = (
   const permitted = relevantPermissions(userAssignments, userRoles);
   return !!model && !!user &&
     (permitted.has('oss_user') ? (user.isAdmin || user.id === model.userId)
-    : permitted.has('delete_model'));
+      : permitted.has('delete_model'));
 };
 
 const canDeleteModelVersion = (
@@ -194,7 +194,7 @@ const canDeleteModelVersion = (
   const permitted = relevantPermissions(userAssignments, userRoles);
   return !!modelVersion && !!user &&
     (permitted.has('oss_user') ? (user.isAdmin || user.id === modelVersion.userId)
-    : permitted.has('delete_model_version'));
+      : permitted.has('delete_model_version'));
 };
 
 // Project actions
@@ -209,7 +209,7 @@ const canDeleteWorkspaceProjects = (
   const permitted = relevantPermissions(userAssignments, userRoles, workspace?.id);
   return !!workspace && !!user && !!project &&
     (permitted.has('oss_user') ? (user.isAdmin || user.id === project.userId)
-    : permitted.has('delete_projects'));
+      : permitted.has('delete_projects'));
 };
 
 const canModifyWorkspaceProjects = (
@@ -222,7 +222,7 @@ const canModifyWorkspaceProjects = (
   const permitted = relevantPermissions(userAssignments, userRoles, workspace?.id);
   return !!workspace && !!user && !!project &&
     (permitted.has('oss_user') ? (user.isAdmin || user.id === project.userId)
-    : permitted.has('modify_projects'));
+      : permitted.has('modify_projects'));
 };
 
 const canMoveWorkspaceProjects = (
@@ -235,7 +235,7 @@ const canMoveWorkspaceProjects = (
   const permitted = relevantPermissions(userAssignments, userRoles, workspace?.id);
   return !!workspace && !!user && !!project &&
     (permitted.has('oss_user') ? (user.isAdmin || user.id === project.userId)
-    : permitted.has('move_projects'));
+      : permitted.has('move_projects'));
 };
 
 // Workspace actions
@@ -248,7 +248,7 @@ const canDeleteWorkspace = (
   const permitted = relevantPermissions(userAssignments, userRoles, workspace?.id);
   return !!workspace && !!user &&
     (permitted.has('oss_user') ? (user.isAdmin || user.id === workspace.userId)
-    : permitted.has('delete_workspace'));
+      : permitted.has('delete_workspace'));
 };
 
 const canModifyWorkspace = (
@@ -260,7 +260,7 @@ const canModifyWorkspace = (
   const permitted = relevantPermissions(userAssignments, userRoles, workspace?.id);
   return !!workspace && !!user &&
     (permitted.has('oss_user') ? (user.isAdmin || user.id === workspace.userId)
-    : permitted.has('modify_workspace'));
+      : permitted.has('modify_workspace'));
 };
 
 export default usePermissions;

--- a/webui/react/src/services/api.ts
+++ b/webui/react/src/services/api.ts
@@ -67,6 +67,10 @@ export const resetUserSetting = generateDetApi<
   EmptyParams, Api.V1ResetUserSettingResponse, void
 >(Config.resetUserSetting);
 
+export const getUserPermissions = generateDetApi<
+  Service.GetUserParams, number, Type.Permission[]
+>(Config.getUserPermissions);
+
 /* Groups */
 
 export const createGroup = generateDetApi<

--- a/webui/react/src/services/apiConfig.ts
+++ b/webui/react/src/services/apiConfig.ts
@@ -198,6 +198,24 @@ export const resetUserSetting: DetApi<
   request: () => detApi.Users.resetUserSetting(),
 };
 
+export const getUserPermissions: DetApi<
+  Service.GetUserParams, number, Type.Permission[]
+> = {
+  name: 'getUserPermissions',
+  postProcess: (response) => {
+    const fillerPermission: Type.Permission = {
+      globalOnly: true,
+      id: response,
+      name: 'oss_user',
+      workspaceOnly: false,
+    };
+    return [ fillerPermission ];
+  },
+  request: (params) => new Promise((resolve) => {
+    resolve(-1 * params.userId);
+  }),
+};
+
 /* Group */
 
 export const createGroup: DetApi<


### PR DESCRIPTION
## Description

When viewing a user profile in RBAC, their permissions are listed in an `antd.Table` component. 

For testing purposes, this is available to OSS admin users, and the mock response is a global `oss_user` permission.

<img width="434" alt="Screen Shot 2022-09-08 at 2 38 42 PM" src="https://user-images.githubusercontent.com/643918/189211109-01d0d66d-97e7-44db-a72b-5b988cd6624a.png">

## Test Plan

[to test in OSS]
- While logged in as admin, go to `/det/settings/user-management/rbac-enabled`. Click "Edit User" (or view, if it's available). You should see the table and oss_user permission.
- Log in as determined / other user, and go to the same page. There is no table.

## Checklist
- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.
- [x] If modifying `/webui/react/src/shared/` verify `make -C webui/react test-shared` passes.