### PR TITLE
test: master test-intg `TestDeleteCheckpoints` stability.

### DIFF
--- a/master/internal/db/postgres_checkpoints_intg_test.go
+++ b/master/internal/db/postgres_checkpoints_intg_test.go
@@ -5,6 +5,7 @@ package db
 
 import (
 	"context"
+	"sort"
 	"strings"
 	"testing"
 	"time"
@@ -17,6 +18,12 @@ import (
 	"github.com/determined-ai/determined/proto/pkg/checkpointv1"
 	"github.com/determined-ai/determined/proto/pkg/modelv1"
 )
+
+func sortUuidSlice(uuids []uuid.UUID) {
+	sort.Slice(uuids, func(i, j int) bool {
+		return uuids[i].String() < uuids[j].String()
+	})
+}
 
 func TestDeleteCheckpoints(t *testing.T) {
 	etc.SetRootPath(RootFromDB)
@@ -95,6 +102,8 @@ func TestDeleteCheckpoints(t *testing.T) {
 	reqCheckpointUUIDs := []uuid.UUID{checkpoint1.UUID, checkpoint2.UUID, checkpoint3.UUID}
 	checkpointsByUUIDs, err := db.CheckpointByUUIDs(reqCheckpointUUIDs)
 	dbCheckpointsUUIDs := []uuid.UUID{*checkpointsByUUIDs[0].UUID, *checkpointsByUUIDs[1].UUID, *checkpointsByUUIDs[2].UUID}
+	sortUuidSlice(reqCheckpointUUIDs)
+	sortUuidSlice(dbCheckpointsUUIDs)
 	require.NoError(t, err)
 	require.Equal(t, reqCheckpointUUIDs, dbCheckpointsUUIDs)
 


### PR DESCRIPTION
## Description

`db.CheckpointByUUIDs` query doesn't sort it's results, so they're up to postgres to decide. On my local dev setup, they always come out in an "unexpected" order. To make the equality check stable, let's sort both expected & actual uuid slices.

## Test Plan

N/A - this is a fix for a test.

## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist
- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.
- [ ] If modifying `/webui/react/src/shared/` verify `make -C webui/react test-shared` passes.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
