### PR TITLE
feat: add stub RBAC API

### DIFF
--- a/harness/determined/common/api/bindings.py
+++ b/harness/determined/common/api/bindings.py
@@ -2460,6 +2460,82 @@ class v1GetResourcePoolsResponse:
             "pagination": self.pagination.to_json() if self.pagination is not None else None,
         }
 
+class v1GetRolesAssignedToGroupResponse:
+    def __init__(
+        self,
+        *,
+        roles: "typing.Optional[typing.Sequence[v1Role]]" = None,
+    ):
+        self.roles = roles
+
+    @classmethod
+    def from_json(cls, obj: Json) -> "v1GetRolesAssignedToGroupResponse":
+        return cls(
+            roles=[v1Role.from_json(x) for x in obj["roles"]] if obj.get("roles", None) is not None else None,
+        )
+
+    def to_json(self) -> typing.Any:
+        return {
+            "roles": [x.to_json() for x in self.roles] if self.roles is not None else None,
+        }
+
+class v1GetRolesAssignedToUserResponse:
+    def __init__(
+        self,
+        *,
+        roles: "typing.Optional[typing.Sequence[v1Role]]" = None,
+    ):
+        self.roles = roles
+
+    @classmethod
+    def from_json(cls, obj: Json) -> "v1GetRolesAssignedToUserResponse":
+        return cls(
+            roles=[v1Role.from_json(x) for x in obj["roles"]] if obj.get("roles", None) is not None else None,
+        )
+
+    def to_json(self) -> typing.Any:
+        return {
+            "roles": [x.to_json() for x in self.roles] if self.roles is not None else None,
+        }
+
+class v1GetRolesByIDRequest:
+    def __init__(
+        self,
+        *,
+        roleIds: "typing.Optional[typing.Sequence[int]]" = None,
+    ):
+        self.roleIds = roleIds
+
+    @classmethod
+    def from_json(cls, obj: Json) -> "v1GetRolesByIDRequest":
+        return cls(
+            roleIds=obj.get("roleIds", None),
+        )
+
+    def to_json(self) -> typing.Any:
+        return {
+            "roleIds": self.roleIds if self.roleIds is not None else None,
+        }
+
+class v1GetRolesByIDResponse:
+    def __init__(
+        self,
+        *,
+        roles: "typing.Optional[typing.Sequence[v1RoleWithAssignments]]" = None,
+    ):
+        self.roles = roles
+
+    @classmethod
+    def from_json(cls, obj: Json) -> "v1GetRolesByIDResponse":
+        return cls(
+            roles=[v1RoleWithAssignments.from_json(x) for x in obj["roles"]] if obj.get("roles", None) is not None else None,
+        )
+
+    def to_json(self) -> typing.Any:
+        return {
+            "roles": [x.to_json() for x in self.roles] if self.roles is not None else None,
+        }
+
 class v1GetShellResponse:
     def __init__(
         self,
@@ -2997,6 +3073,29 @@ class v1GroupDetails:
             "users": [x.to_json() for x in self.users] if self.users is not None else None,
         }
 
+class v1GroupRoleAssignment:
+    def __init__(
+        self,
+        *,
+        groupId: int,
+        roleAssignment: "v1RoleAssignment",
+    ):
+        self.groupId = groupId
+        self.roleAssignment = roleAssignment
+
+    @classmethod
+    def from_json(cls, obj: Json) -> "v1GroupRoleAssignment":
+        return cls(
+            groupId=obj["groupId"],
+            roleAssignment=v1RoleAssignment.from_json(obj["roleAssignment"]),
+        )
+
+    def to_json(self) -> typing.Any:
+        return {
+            "groupId": self.groupId,
+            "roleAssignment": self.roleAssignment.to_json(),
+        }
+
 class v1GroupSearchResult:
     def __init__(
         self,
@@ -3458,6 +3557,52 @@ class v1LaunchTensorboardResponse:
         return {
             "tensorboard": self.tensorboard.to_json(),
             "config": self.config,
+        }
+
+class v1ListRolesRequest:
+    def __init__(
+        self,
+        *,
+        limit: int,
+        offset: "typing.Optional[int]" = None,
+    ):
+        self.offset = offset
+        self.limit = limit
+
+    @classmethod
+    def from_json(cls, obj: Json) -> "v1ListRolesRequest":
+        return cls(
+            offset=obj.get("offset", None),
+            limit=obj["limit"],
+        )
+
+    def to_json(self) -> typing.Any:
+        return {
+            "offset": self.offset if self.offset is not None else None,
+            "limit": self.limit,
+        }
+
+class v1ListRolesResponse:
+    def __init__(
+        self,
+        *,
+        pagination: "v1Pagination",
+        roles: "typing.Sequence[v1Role]",
+    ):
+        self.roles = roles
+        self.pagination = pagination
+
+    @classmethod
+    def from_json(cls, obj: Json) -> "v1ListRolesResponse":
+        return cls(
+            roles=[v1Role.from_json(x) for x in obj["roles"]],
+            pagination=v1Pagination.from_json(obj["pagination"]),
+        )
+
+    def to_json(self) -> typing.Any:
+        return {
+            "roles": [x.to_json() for x in self.roles],
+            "pagination": self.pagination.to_json(),
         }
 
 class v1LogEntry:
@@ -4297,6 +4442,33 @@ class v1PatchWorkspaceResponse:
     def to_json(self) -> typing.Any:
         return {
             "workspace": self.workspace.to_json(),
+        }
+
+class v1Permission:
+    def __init__(
+        self,
+        *,
+        id: "typing.Optional[int]" = None,
+        isGlobal: "typing.Optional[bool]" = None,
+        name: "typing.Optional[str]" = None,
+    ):
+        self.id = id
+        self.name = name
+        self.isGlobal = isGlobal
+
+    @classmethod
+    def from_json(cls, obj: Json) -> "v1Permission":
+        return cls(
+            id=obj.get("id", None),
+            name=obj.get("name", None),
+            isGlobal=obj.get("isGlobal", None),
+        )
+
+    def to_json(self) -> typing.Any:
+        return {
+            "id": self.id if self.id is not None else None,
+            "name": self.name if self.name is not None else None,
+            "isGlobal": self.isGlobal if self.isGlobal is not None else None,
         }
 
 class v1PostAllocationProxyAddressRequest:
@@ -5453,6 +5625,83 @@ class v1ResourcePoolType(enum.Enum):
     RESOURCE_POOL_TYPE_STATIC = "RESOURCE_POOL_TYPE_STATIC"
     RESOURCE_POOL_TYPE_K8S = "RESOURCE_POOL_TYPE_K8S"
 
+class v1Role:
+    def __init__(
+        self,
+        *,
+        name: "typing.Optional[str]" = None,
+        permissions: "typing.Optional[typing.Sequence[v1Permission]]" = None,
+        roleId: "typing.Optional[int]" = None,
+    ):
+        self.roleId = roleId
+        self.name = name
+        self.permissions = permissions
+
+    @classmethod
+    def from_json(cls, obj: Json) -> "v1Role":
+        return cls(
+            roleId=obj.get("roleId", None),
+            name=obj.get("name", None),
+            permissions=[v1Permission.from_json(x) for x in obj["permissions"]] if obj.get("permissions", None) is not None else None,
+        )
+
+    def to_json(self) -> typing.Any:
+        return {
+            "roleId": self.roleId if self.roleId is not None else None,
+            "name": self.name if self.name is not None else None,
+            "permissions": [x.to_json() for x in self.permissions] if self.permissions is not None else None,
+        }
+
+class v1RoleAssignment:
+    def __init__(
+        self,
+        *,
+        role: "v1Role",
+        scopeWorkspaceId: "typing.Optional[int]" = None,
+    ):
+        self.role = role
+        self.scopeWorkspaceId = scopeWorkspaceId
+
+    @classmethod
+    def from_json(cls, obj: Json) -> "v1RoleAssignment":
+        return cls(
+            role=v1Role.from_json(obj["role"]),
+            scopeWorkspaceId=obj.get("scopeWorkspaceId", None),
+        )
+
+    def to_json(self) -> typing.Any:
+        return {
+            "role": self.role.to_json(),
+            "scopeWorkspaceId": self.scopeWorkspaceId if self.scopeWorkspaceId is not None else None,
+        }
+
+class v1RoleWithAssignments:
+    def __init__(
+        self,
+        *,
+        groupRoleAssignments: "typing.Optional[typing.Sequence[v1GroupRoleAssignment]]" = None,
+        role: "typing.Optional[v1Role]" = None,
+        userRoleAssignments: "typing.Optional[typing.Sequence[v1UserRoleAssignment]]" = None,
+    ):
+        self.role = role
+        self.groupRoleAssignments = groupRoleAssignments
+        self.userRoleAssignments = userRoleAssignments
+
+    @classmethod
+    def from_json(cls, obj: Json) -> "v1RoleWithAssignments":
+        return cls(
+            role=v1Role.from_json(obj["role"]) if obj.get("role", None) is not None else None,
+            groupRoleAssignments=[v1GroupRoleAssignment.from_json(x) for x in obj["groupRoleAssignments"]] if obj.get("groupRoleAssignments", None) is not None else None,
+            userRoleAssignments=[v1UserRoleAssignment.from_json(x) for x in obj["userRoleAssignments"]] if obj.get("userRoleAssignments", None) is not None else None,
+        )
+
+    def to_json(self) -> typing.Any:
+        return {
+            "role": self.role.to_json() if self.role is not None else None,
+            "groupRoleAssignments": [x.to_json() for x in self.groupRoleAssignments] if self.groupRoleAssignments is not None else None,
+            "userRoleAssignments": [x.to_json() for x in self.userRoleAssignments] if self.userRoleAssignments is not None else None,
+        }
+
 class v1RunnableOperation:
     def __init__(
         self,
@@ -5517,6 +5766,56 @@ class v1SchedulerType(enum.Enum):
     SCHEDULER_TYPE_KUBERNETES = "SCHEDULER_TYPE_KUBERNETES"
     SCHEDULER_TYPE_SLURM = "SCHEDULER_TYPE_SLURM"
     SCHEDULER_TYPE_PBS = "SCHEDULER_TYPE_PBS"
+
+class v1SearchRolesAssignableToScopeRequest:
+    def __init__(
+        self,
+        *,
+        limit: int,
+        offset: "typing.Optional[int]" = None,
+        workspaceId: "typing.Optional[int]" = None,
+    ):
+        self.limit = limit
+        self.offset = offset
+        self.workspaceId = workspaceId
+
+    @classmethod
+    def from_json(cls, obj: Json) -> "v1SearchRolesAssignableToScopeRequest":
+        return cls(
+            limit=obj["limit"],
+            offset=obj.get("offset", None),
+            workspaceId=obj.get("workspaceId", None),
+        )
+
+    def to_json(self) -> typing.Any:
+        return {
+            "limit": self.limit,
+            "offset": self.offset if self.offset is not None else None,
+            "workspaceId": self.workspaceId if self.workspaceId is not None else None,
+        }
+
+class v1SearchRolesAssignableToScopeResponse:
+    def __init__(
+        self,
+        *,
+        pagination: "typing.Optional[v1Pagination]" = None,
+        roles: "typing.Optional[typing.Sequence[v1Role]]" = None,
+    ):
+        self.pagination = pagination
+        self.roles = roles
+
+    @classmethod
+    def from_json(cls, obj: Json) -> "v1SearchRolesAssignableToScopeResponse":
+        return cls(
+            pagination=v1Pagination.from_json(obj["pagination"]) if obj.get("pagination", None) is not None else None,
+            roles=[v1Role.from_json(x) for x in obj["roles"]] if obj.get("roles", None) is not None else None,
+        )
+
+    def to_json(self) -> typing.Any:
+        return {
+            "pagination": self.pagination.to_json() if self.pagination is not None else None,
+            "roles": [x.to_json() for x in self.roles] if self.roles is not None else None,
+        }
 
 class v1SearcherOperation:
     def __init__(
@@ -6511,6 +6810,29 @@ class v1User:
             "modifiedAt": self.modifiedAt if self.modifiedAt is not None else None,
         }
 
+class v1UserRoleAssignment:
+    def __init__(
+        self,
+        *,
+        roleAssignment: "v1RoleAssignment",
+        userId: int,
+    ):
+        self.userId = userId
+        self.roleAssignment = roleAssignment
+
+    @classmethod
+    def from_json(cls, obj: Json) -> "v1UserRoleAssignment":
+        return cls(
+            userId=obj["userId"],
+            roleAssignment=v1RoleAssignment.from_json(obj["roleAssignment"]),
+        )
+
+    def to_json(self) -> typing.Any:
+        return {
+            "userId": self.userId,
+            "roleAssignment": self.roleAssignment.to_json(),
+        }
+
 class v1UserWebSetting:
     def __init__(
         self,
@@ -6924,6 +7246,24 @@ def post_ArchiveWorkspace(
     if _resp.status_code == 200:
         return
     raise APIHttpError("post_ArchiveWorkspace", _resp)
+
+def post_AssignRoles(
+    session: "api.Session",
+) -> None:
+    _params = None
+    _resp = session._do_request(
+        method="POST",
+        path="/api/v1/roles/add-assignments",
+        params=_params,
+        json=None,
+        data=None,
+        headers=None,
+        timeout=None,
+        stream=False,
+    )
+    if _resp.status_code == 200:
+        return
+    raise APIHttpError("post_AssignRoles", _resp)
 
 def post_CancelExperiment(
     session: "api.Session",
@@ -8085,6 +8425,66 @@ def get_GetResourcePools(
         return v1GetResourcePoolsResponse.from_json(_resp.json())
     raise APIHttpError("get_GetResourcePools", _resp)
 
+def get_GetRolesAssignedToGroup(
+    session: "api.Session",
+    *,
+    groupId: int,
+) -> "v1GetRolesAssignedToGroupResponse":
+    _params = None
+    _resp = session._do_request(
+        method="GET",
+        path=f"/api/v1/roles/search/by-group/{groupId}",
+        params=_params,
+        json=None,
+        data=None,
+        headers=None,
+        timeout=None,
+        stream=False,
+    )
+    if _resp.status_code == 200:
+        return v1GetRolesAssignedToGroupResponse.from_json(_resp.json())
+    raise APIHttpError("get_GetRolesAssignedToGroup", _resp)
+
+def get_GetRolesAssignedToUser(
+    session: "api.Session",
+    *,
+    userId: int,
+) -> "v1GetRolesAssignedToUserResponse":
+    _params = None
+    _resp = session._do_request(
+        method="GET",
+        path=f"/api/v1/roles/search/by-user/{userId}",
+        params=_params,
+        json=None,
+        data=None,
+        headers=None,
+        timeout=None,
+        stream=False,
+    )
+    if _resp.status_code == 200:
+        return v1GetRolesAssignedToUserResponse.from_json(_resp.json())
+    raise APIHttpError("get_GetRolesAssignedToUser", _resp)
+
+def post_GetRolesByID(
+    session: "api.Session",
+    *,
+    body: "v1GetRolesByIDRequest",
+) -> "v1GetRolesByIDResponse":
+    _params = None
+    _resp = session._do_request(
+        method="POST",
+        path="/api/v1/roles/search/by-ids",
+        params=_params,
+        json=body.to_json(),
+        data=None,
+        headers=None,
+        timeout=None,
+        stream=False,
+    )
+    if _resp.status_code == 200:
+        return v1GetRolesByIDResponse.from_json(_resp.json())
+    raise APIHttpError("post_GetRolesByID", _resp)
+
 def get_GetShell(
     session: "api.Session",
     *,
@@ -8780,6 +9180,26 @@ def post_LaunchTensorboard(
         return v1LaunchTensorboardResponse.from_json(_resp.json())
     raise APIHttpError("post_LaunchTensorboard", _resp)
 
+def post_ListRoles(
+    session: "api.Session",
+    *,
+    body: "v1ListRolesRequest",
+) -> "v1ListRolesResponse":
+    _params = None
+    _resp = session._do_request(
+        method="POST",
+        path="/api/v1/roles/search",
+        params=_params,
+        json=body.to_json(),
+        data=None,
+        headers=None,
+        timeout=None,
+        stream=False,
+    )
+    if _resp.status_code == 200:
+        return v1ListRolesResponse.from_json(_resp.json())
+    raise APIHttpError("post_ListRoles", _resp)
+
 def post_Login(
     session: "api.Session",
     *,
@@ -9316,6 +9736,24 @@ def put_PutTemplate(
         return v1PutTemplateResponse.from_json(_resp.json())
     raise APIHttpError("put_PutTemplate", _resp)
 
+def post_RemoveAssignments(
+    session: "api.Session",
+) -> None:
+    _params = None
+    _resp = session._do_request(
+        method="POST",
+        path="/api/v1/roles/remove-assignments",
+        params=_params,
+        json=None,
+        data=None,
+        headers=None,
+        timeout=None,
+        stream=False,
+    )
+    if _resp.status_code == 200:
+        return
+    raise APIHttpError("post_RemoveAssignments", _resp)
+
 def post_ReportCheckpoint(
     session: "api.Session",
     *,
@@ -9487,6 +9925,26 @@ def get_ResourceAllocationRaw(
     if _resp.status_code == 200:
         return v1ResourceAllocationRawResponse.from_json(_resp.json())
     raise APIHttpError("get_ResourceAllocationRaw", _resp)
+
+def post_SearchRolesAssignableToScope(
+    session: "api.Session",
+    *,
+    body: "v1SearchRolesAssignableToScopeRequest",
+) -> "v1SearchRolesAssignableToScopeResponse":
+    _params = None
+    _resp = session._do_request(
+        method="POST",
+        path="/api/v1/roles/search/by-assignability",
+        params=_params,
+        json=body.to_json(),
+        data=None,
+        headers=None,
+        timeout=None,
+        stream=False,
+    )
+    if _resp.status_code == 200:
+        return v1SearchRolesAssignableToScopeResponse.from_json(_resp.json())
+    raise APIHttpError("post_SearchRolesAssignableToScope", _resp)
 
 def post_SetCommandPriority(
     session: "api.Session",
@@ -9789,4 +10247,6 @@ Paginated = typing.Union[
     v1GetUsersResponse,
     v1GetWorkspaceProjectsResponse,
     v1GetWorkspacesResponse,
+    v1ListRolesResponse,
+    v1SearchRolesAssignableToScopeResponse,
 ]

--- a/harness/determined/common/api/bindings.py
+++ b/harness/determined/common/api/bindings.py
@@ -667,6 +667,29 @@ class v1AllocationRendezvousInfoResponse:
             "rendezvousInfo": self.rendezvousInfo.to_json(),
         }
 
+class v1AssignRolesRequest:
+    def __init__(
+        self,
+        *,
+        groupRoleAssignments: "typing.Optional[typing.Sequence[v1GroupRoleAssignment]]" = None,
+        userRoleAssignments: "typing.Optional[typing.Sequence[v1UserRoleAssignment]]" = None,
+    ):
+        self.groupRoleAssignments = groupRoleAssignments
+        self.userRoleAssignments = userRoleAssignments
+
+    @classmethod
+    def from_json(cls, obj: Json) -> "v1AssignRolesRequest":
+        return cls(
+            groupRoleAssignments=[v1GroupRoleAssignment.from_json(x) for x in obj["groupRoleAssignments"]] if obj.get("groupRoleAssignments", None) is not None else None,
+            userRoleAssignments=[v1UserRoleAssignment.from_json(x) for x in obj["userRoleAssignments"]] if obj.get("userRoleAssignments", None) is not None else None,
+        )
+
+    def to_json(self) -> typing.Any:
+        return {
+            "groupRoleAssignments": [x.to_json() for x in self.groupRoleAssignments] if self.groupRoleAssignments is not None else None,
+            "userRoleAssignments": [x.to_json() for x in self.userRoleAssignments] if self.userRoleAssignments is not None else None,
+        }
+
 class v1AwsCustomTag:
     def __init__(
         self,
@@ -5083,6 +5106,29 @@ class v1RPQueueStat:
             "aggregates": [x.to_json() for x in self.aggregates] if self.aggregates is not None else None,
         }
 
+class v1RemoveAssignmentsRequest:
+    def __init__(
+        self,
+        *,
+        groupRoleAssignments: "typing.Optional[typing.Sequence[v1GroupRoleAssignment]]" = None,
+        userRoleAssignments: "typing.Optional[typing.Sequence[v1UserRoleAssignment]]" = None,
+    ):
+        self.groupRoleAssignments = groupRoleAssignments
+        self.userRoleAssignments = userRoleAssignments
+
+    @classmethod
+    def from_json(cls, obj: Json) -> "v1RemoveAssignmentsRequest":
+        return cls(
+            groupRoleAssignments=[v1GroupRoleAssignment.from_json(x) for x in obj["groupRoleAssignments"]] if obj.get("groupRoleAssignments", None) is not None else None,
+            userRoleAssignments=[v1UserRoleAssignment.from_json(x) for x in obj["userRoleAssignments"]] if obj.get("userRoleAssignments", None) is not None else None,
+        )
+
+    def to_json(self) -> typing.Any:
+        return {
+            "groupRoleAssignments": [x.to_json() for x in self.groupRoleAssignments] if self.groupRoleAssignments is not None else None,
+            "userRoleAssignments": [x.to_json() for x in self.userRoleAssignments] if self.userRoleAssignments is not None else None,
+        }
+
 class v1RendezvousInfo:
     def __init__(
         self,
@@ -7249,13 +7295,15 @@ def post_ArchiveWorkspace(
 
 def post_AssignRoles(
     session: "api.Session",
+    *,
+    body: "v1AssignRolesRequest",
 ) -> None:
     _params = None
     _resp = session._do_request(
         method="POST",
         path="/api/v1/roles/add-assignments",
         params=_params,
-        json=None,
+        json=body.to_json(),
         data=None,
         headers=None,
         timeout=None,
@@ -9738,13 +9786,15 @@ def put_PutTemplate(
 
 def post_RemoveAssignments(
     session: "api.Session",
+    *,
+    body: "v1RemoveAssignmentsRequest",
 ) -> None:
     _params = None
     _resp = session._do_request(
         method="POST",
         path="/api/v1/roles/remove-assignments",
         params=_params,
-        json=None,
+        json=body.to_json(),
         data=None,
         headers=None,
         timeout=None,

--- a/master/internal/api.go
+++ b/master/internal/api.go
@@ -15,6 +15,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/determined-ai/determined/master/internal/api"
+	"github.com/determined-ai/determined/master/internal/rbac"
 	"github.com/determined-ai/determined/master/internal/usergroup"
 	"github.com/determined-ai/determined/master/pkg/actor"
 	"github.com/determined-ai/determined/proto/pkg/apiv1"
@@ -24,6 +25,7 @@ type apiServer struct {
 	m *Master
 
 	usergroup.UserGroupAPIServer
+	rbac.RBACAPIServer
 }
 
 // paginate returns a paginated subset of the values and sets the pagination response.

--- a/master/internal/api.go
+++ b/master/internal/api.go
@@ -25,7 +25,7 @@ type apiServer struct {
 	m *Master
 
 	usergroup.UserGroupAPIServer
-	rbac.RBACAPIServer
+	rbac.RBACAPIServerWrapper
 }
 
 // paginate returns a paginated subset of the values and sets the pagination response.

--- a/master/internal/api/apiutils/utils.go
+++ b/master/internal/api/apiutils/utils.go
@@ -10,17 +10,23 @@ import (
 )
 
 const (
+	// MaxLimit is the maximum limit value for pagination.
 	MaxLimit = 500
 )
 
 var (
-	ErrBadRequest   = status.Error(codes.InvalidArgument, "bad request")
+	// ErrBadRequest is the returned standard error for bad requests.
+	ErrBadRequest = status.Error(codes.InvalidArgument, "bad request")
+	// ErrInvalidLimit is the returned standard error for invalid limit for pagination.
 	ErrInvalidLimit = status.Errorf(codes.InvalidArgument,
 		"Bad request: limit is required and must be <= %d", MaxLimit)
-	ErrNotFound        = status.Error(codes.NotFound, "not found")
+	// ErrNotFound is the returned standard error for value(s) not found.
+	ErrNotFound = status.Error(codes.NotFound, "not found")
+	// ErrDuplicateRecord is the returned standard error for finding duplicates.
 	ErrDuplicateRecord = status.Error(codes.AlreadyExists, "duplicate record")
-	ErrInternal        = status.Error(codes.Internal, "internal server error")
-	errPassthroughMap  = map[error]bool{
+	// ErrInternal is the returned standard error for an internal error.
+	ErrInternal       = status.Error(codes.Internal, "internal server error")
+	errPassthroughMap = map[error]bool{
 		nil:                true,
 		ErrBadRequest:      true,
 		ErrInvalidLimit:    true,
@@ -30,6 +36,7 @@ var (
 	}
 )
 
+// MapAndFilterErrors takes in an error at the db level and translates it into a standard error.
 func MapAndFilterErrors(err error) error {
 	if allowed := errPassthroughMap[err]; allowed {
 		return err

--- a/master/internal/api/apiutils/utils.go
+++ b/master/internal/api/apiutils/utils.go
@@ -1,0 +1,48 @@
+package apiutils
+
+import (
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/determined-ai/determined/master/internal/db"
+)
+
+const (
+	MaxLimit = 500
+)
+
+var (
+	ErrBadRequest   = status.Error(codes.InvalidArgument, "bad request")
+	ErrInvalidLimit = status.Errorf(codes.InvalidArgument,
+		"Bad request: limit is required and must be <= %d", MaxLimit)
+	ErrNotFound        = status.Error(codes.NotFound, "not found")
+	ErrDuplicateRecord = status.Error(codes.AlreadyExists, "duplicate record")
+	ErrInternal        = status.Error(codes.Internal, "internal server error")
+	errPassthroughMap  = map[error]bool{
+		nil:                true,
+		ErrBadRequest:      true,
+		ErrInvalidLimit:    true,
+		ErrNotFound:        true,
+		ErrDuplicateRecord: true,
+		ErrInternal:        true,
+	}
+)
+
+func MapAndFilterErrors(err error) error {
+	if allowed := errPassthroughMap[err]; allowed {
+		return err
+	}
+
+	switch {
+	case errors.Is(err, db.ErrNotFound):
+		return status.Error(codes.NotFound, err.Error())
+	case errors.Is(err, db.ErrDuplicateRecord):
+		return status.Error(codes.AlreadyExists, err.Error())
+	}
+
+	logrus.WithError(err).Debug("suppressing error at API boundary")
+
+	return ErrInternal
+}

--- a/master/internal/db/utils.go
+++ b/master/internal/db/utils.go
@@ -1,0 +1,49 @@
+package db
+
+import (
+	"database/sql"
+
+	"github.com/jackc/pgconn"
+	"github.com/pkg/errors"
+)
+
+// MatchSentinelError checks if the error belongs to specific families of errors
+// and ensures that the returned error has the proper type and text.
+func MatchSentinelError(err error) error {
+	if errors.Is(err, sql.ErrNoRows) {
+		return ErrNotFound
+	}
+
+	switch pgErrCode(err) {
+	case CodeForeignKeyViolation:
+		return ErrNotFound
+	case CodeUniqueViolation:
+		return ErrDuplicateRecord
+	}
+
+	return err
+}
+
+// MustHaveAffectedRows checks if bun has affected rows in a table or not.
+// Returns ErrNotFound if no rows were affected and returns the provided error otherwise.
+func MustHaveAffectedRows(result sql.Result, err error) error {
+	if err == nil {
+		rowsAffected, affectedErr := result.RowsAffected()
+		if affectedErr != nil {
+			return affectedErr
+		}
+		if rowsAffected == 0 {
+			return ErrNotFound
+		}
+	}
+
+	return err
+}
+
+func pgErrCode(err error) string {
+	if e, ok := err.(*pgconn.PgError); ok {
+		return e.Code
+	}
+
+	return ""
+}

--- a/master/internal/rbac/api_rbac.go
+++ b/master/internal/rbac/api_rbac.go
@@ -1,0 +1,56 @@
+package rbac
+
+import (
+	"context"
+
+	"github.com/determined-ai/determined/proto/pkg/apiv1"
+)
+
+var rbacAPIServer Foo = &rbacAPIServerStub{}
+
+type Foo interface {
+	GetRolesByID(context.Context, *apiv1.GetRolesByIDRequest) (
+		resp *apiv1.GetRolesByIDResponse, err error)
+	GetRolesAssignedToUser(context.Context, *apiv1.GetRolesAssignedToUserRequest) (
+		*apiv1.GetRolesAssignedToUserResponse, error)
+	GetRolesAssignedToGroup(context.Context, *apiv1.GetRolesAssignedToGroupRequest) (
+		*apiv1.GetRolesAssignedToGroupResponse, error)
+	SearchRolesAssignableToScope(context.Context, *apiv1.SearchRolesAssignableToScopeRequest) (
+		*apiv1.SearchRolesAssignableToScopeResponse, error)
+	ListRoles(context.Context, *apiv1.ListRolesRequest) (
+		*apiv1.ListRolesResponse, error)
+	AssignRoles(context.Context, *apiv1.AssignRolesRequest) (
+		*apiv1.AssignRolesResponse, error)
+	RemoveAssignments(context.Context, *apiv1.RemoveAssignmentsRequest) (
+		*apiv1.RemoveAssignmentsResponse, error)
+}
+
+type RBACAPIServer struct{}
+
+func (s *RBACAPIServer) GetRolesByID(ctx context.Context, req *apiv1.GetRolesByIDRequest) (resp *apiv1.GetRolesByIDResponse, err error) {
+	return rbacAPIServer.GetRolesByID(ctx, req)
+}
+
+func (s *RBACAPIServer) GetRolesAssignedToUser(ctx context.Context, req *apiv1.GetRolesAssignedToUserRequest) (*apiv1.GetRolesAssignedToUserResponse, error) {
+	return rbacAPIServer.GetRolesAssignedToUser(ctx, req)
+}
+
+func (s *RBACAPIServer) GetRolesAssignedToGroup(ctx context.Context, req *apiv1.GetRolesAssignedToGroupRequest) (*apiv1.GetRolesAssignedToGroupResponse, error) {
+	return rbacAPIServer.GetRolesAssignedToGroup(ctx, req)
+}
+
+func (s *RBACAPIServer) SearchRolesAssignableToScope(ctx context.Context, req *apiv1.SearchRolesAssignableToScopeRequest) (*apiv1.SearchRolesAssignableToScopeResponse, error) {
+	return rbacAPIServer.SearchRolesAssignableToScope(ctx, req)
+}
+
+func (s *RBACAPIServer) ListRoles(ctx context.Context, req *apiv1.ListRolesRequest) (*apiv1.ListRolesResponse, error) {
+	return rbacAPIServer.ListRoles(ctx, req)
+}
+
+func (s *RBACAPIServer) AssignRoles(ctx context.Context, req *apiv1.AssignRolesRequest) (*apiv1.AssignRolesResponse, error) {
+	return rbacAPIServer.AssignRoles(ctx, req)
+}
+
+func (s *RBACAPIServer) RemoveAssignments(ctx context.Context, req *apiv1.RemoveAssignmentsRequest) (*apiv1.RemoveAssignmentsResponse, error) {
+	return rbacAPIServer.RemoveAssignments(ctx, req)
+}

--- a/master/internal/rbac/api_rbac.go
+++ b/master/internal/rbac/api_rbac.go
@@ -6,9 +6,9 @@ import (
 	"github.com/determined-ai/determined/proto/pkg/apiv1"
 )
 
-var rbacAPIServer Foo = &rbacAPIServerStub{}
+var rbacAPIServer RBACAPIServer = &rbacAPIServerStub{}
 
-type Foo interface {
+type RBACAPIServer interface {
 	GetRolesByID(context.Context, *apiv1.GetRolesByIDRequest) (
 		resp *apiv1.GetRolesByIDResponse, err error)
 	GetRolesAssignedToUser(context.Context, *apiv1.GetRolesAssignedToUserRequest) (
@@ -25,32 +25,32 @@ type Foo interface {
 		*apiv1.RemoveAssignmentsResponse, error)
 }
 
-type RBACAPIServer struct{}
+type RBACAPIServerWrapper struct{}
 
-func (s *RBACAPIServer) GetRolesByID(ctx context.Context, req *apiv1.GetRolesByIDRequest) (resp *apiv1.GetRolesByIDResponse, err error) {
+func (s *RBACAPIServerWrapper) GetRolesByID(ctx context.Context, req *apiv1.GetRolesByIDRequest) (resp *apiv1.GetRolesByIDResponse, err error) {
 	return rbacAPIServer.GetRolesByID(ctx, req)
 }
 
-func (s *RBACAPIServer) GetRolesAssignedToUser(ctx context.Context, req *apiv1.GetRolesAssignedToUserRequest) (*apiv1.GetRolesAssignedToUserResponse, error) {
+func (s *RBACAPIServerWrapper) GetRolesAssignedToUser(ctx context.Context, req *apiv1.GetRolesAssignedToUserRequest) (*apiv1.GetRolesAssignedToUserResponse, error) {
 	return rbacAPIServer.GetRolesAssignedToUser(ctx, req)
 }
 
-func (s *RBACAPIServer) GetRolesAssignedToGroup(ctx context.Context, req *apiv1.GetRolesAssignedToGroupRequest) (*apiv1.GetRolesAssignedToGroupResponse, error) {
+func (s *RBACAPIServerWrapper) GetRolesAssignedToGroup(ctx context.Context, req *apiv1.GetRolesAssignedToGroupRequest) (*apiv1.GetRolesAssignedToGroupResponse, error) {
 	return rbacAPIServer.GetRolesAssignedToGroup(ctx, req)
 }
 
-func (s *RBACAPIServer) SearchRolesAssignableToScope(ctx context.Context, req *apiv1.SearchRolesAssignableToScopeRequest) (*apiv1.SearchRolesAssignableToScopeResponse, error) {
+func (s *RBACAPIServerWrapper) SearchRolesAssignableToScope(ctx context.Context, req *apiv1.SearchRolesAssignableToScopeRequest) (*apiv1.SearchRolesAssignableToScopeResponse, error) {
 	return rbacAPIServer.SearchRolesAssignableToScope(ctx, req)
 }
 
-func (s *RBACAPIServer) ListRoles(ctx context.Context, req *apiv1.ListRolesRequest) (*apiv1.ListRolesResponse, error) {
+func (s *RBACAPIServerWrapper) ListRoles(ctx context.Context, req *apiv1.ListRolesRequest) (*apiv1.ListRolesResponse, error) {
 	return rbacAPIServer.ListRoles(ctx, req)
 }
 
-func (s *RBACAPIServer) AssignRoles(ctx context.Context, req *apiv1.AssignRolesRequest) (*apiv1.AssignRolesResponse, error) {
+func (s *RBACAPIServerWrapper) AssignRoles(ctx context.Context, req *apiv1.AssignRolesRequest) (*apiv1.AssignRolesResponse, error) {
 	return rbacAPIServer.AssignRoles(ctx, req)
 }
 
-func (s *RBACAPIServer) RemoveAssignments(ctx context.Context, req *apiv1.RemoveAssignmentsRequest) (*apiv1.RemoveAssignmentsResponse, error) {
+func (s *RBACAPIServerWrapper) RemoveAssignments(ctx context.Context, req *apiv1.RemoveAssignmentsRequest) (*apiv1.RemoveAssignmentsResponse, error) {
 	return rbacAPIServer.RemoveAssignments(ctx, req)
 }

--- a/master/internal/rbac/api_rbac.go
+++ b/master/internal/rbac/api_rbac.go
@@ -24,33 +24,3 @@ type RBACAPIServer interface {
 	RemoveAssignments(context.Context, *apiv1.RemoveAssignmentsRequest) (
 		*apiv1.RemoveAssignmentsResponse, error)
 }
-
-type RBACAPIServerWrapper struct{}
-
-func (s *RBACAPIServerWrapper) GetRolesByID(ctx context.Context, req *apiv1.GetRolesByIDRequest) (resp *apiv1.GetRolesByIDResponse, err error) {
-	return rbacAPIServer.GetRolesByID(ctx, req)
-}
-
-func (s *RBACAPIServerWrapper) GetRolesAssignedToUser(ctx context.Context, req *apiv1.GetRolesAssignedToUserRequest) (*apiv1.GetRolesAssignedToUserResponse, error) {
-	return rbacAPIServer.GetRolesAssignedToUser(ctx, req)
-}
-
-func (s *RBACAPIServerWrapper) GetRolesAssignedToGroup(ctx context.Context, req *apiv1.GetRolesAssignedToGroupRequest) (*apiv1.GetRolesAssignedToGroupResponse, error) {
-	return rbacAPIServer.GetRolesAssignedToGroup(ctx, req)
-}
-
-func (s *RBACAPIServerWrapper) SearchRolesAssignableToScope(ctx context.Context, req *apiv1.SearchRolesAssignableToScopeRequest) (*apiv1.SearchRolesAssignableToScopeResponse, error) {
-	return rbacAPIServer.SearchRolesAssignableToScope(ctx, req)
-}
-
-func (s *RBACAPIServerWrapper) ListRoles(ctx context.Context, req *apiv1.ListRolesRequest) (*apiv1.ListRolesResponse, error) {
-	return rbacAPIServer.ListRoles(ctx, req)
-}
-
-func (s *RBACAPIServerWrapper) AssignRoles(ctx context.Context, req *apiv1.AssignRolesRequest) (*apiv1.AssignRolesResponse, error) {
-	return rbacAPIServer.AssignRoles(ctx, req)
-}
-
-func (s *RBACAPIServerWrapper) RemoveAssignments(ctx context.Context, req *apiv1.RemoveAssignmentsRequest) (*apiv1.RemoveAssignmentsResponse, error) {
-	return rbacAPIServer.RemoveAssignments(ctx, req)
-}

--- a/master/internal/rbac/api_rbac.go
+++ b/master/internal/rbac/api_rbac.go
@@ -8,6 +8,7 @@ import (
 
 var rbacAPIServer RBACAPIServer = &rbacAPIServerStub{}
 
+// RBACAPIServer is the interface for all functions in RBAC.
 type RBACAPIServer interface {
 	GetRolesByID(context.Context, *apiv1.GetRolesByIDRequest) (
 		resp *apiv1.GetRolesByIDResponse, err error)

--- a/master/internal/rbac/api_rbac_stub.go
+++ b/master/internal/rbac/api_rbac_stub.go
@@ -11,7 +11,7 @@ import (
 
 type rbacAPIServerStub struct{}
 
-const stubUnimplementedMessage = "rbac API not available in this version of the software"
+const stubUnimplementedMessage = "Determined Enterprise Edition is required for this functionality"
 
 func (s *rbacAPIServerStub) GetRolesByID(ctx context.Context, req *apiv1.GetRolesByIDRequest) (
 	resp *apiv1.GetRolesByIDResponse, err error) {

--- a/master/internal/rbac/api_rbac_stub.go
+++ b/master/internal/rbac/api_rbac_stub.go
@@ -1,0 +1,50 @@
+package rbac
+
+import (
+	"context"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/determined-ai/determined/proto/pkg/apiv1"
+)
+
+type rbacAPIServerStub struct{}
+
+const stubUnimplementedMessage = "rbac API not available in this version of the software"
+
+func (s *rbacAPIServerStub) GetRolesByID(ctx context.Context, req *apiv1.GetRolesByIDRequest) (
+	resp *apiv1.GetRolesByIDResponse, err error) {
+	return nil, status.Error(codes.Unimplemented, stubUnimplementedMessage)
+}
+
+func (s *rbacAPIServerStub) GetRolesAssignedToUser(ctx context.Context,
+	req *apiv1.GetRolesAssignedToUserRequest) (*apiv1.GetRolesAssignedToUserResponse, error) {
+	return nil, status.Error(codes.Unimplemented, stubUnimplementedMessage)
+}
+
+func (s *rbacAPIServerStub) GetRolesAssignedToGroup(ctx context.Context,
+	req *apiv1.GetRolesAssignedToGroupRequest) (*apiv1.GetRolesAssignedToGroupResponse, error) {
+	return nil, status.Error(codes.Unimplemented, stubUnimplementedMessage)
+}
+
+func (s *rbacAPIServerStub) SearchRolesAssignableToScope(ctx context.Context,
+	req *apiv1.SearchRolesAssignableToScopeRequest) (*apiv1.SearchRolesAssignableToScopeResponse,
+	error) {
+	return nil, status.Error(codes.Unimplemented, stubUnimplementedMessage)
+}
+
+func (s *rbacAPIServerStub) ListRoles(ctx context.Context, req *apiv1.ListRolesRequest) (
+	*apiv1.ListRolesResponse, error) {
+	return nil, status.Error(codes.Unimplemented, stubUnimplementedMessage)
+}
+
+func (s *rbacAPIServerStub) AssignRoles(ctx context.Context, req *apiv1.AssignRolesRequest) (
+	*apiv1.AssignRolesResponse, error) {
+	return nil, status.Error(codes.Unimplemented, stubUnimplementedMessage)
+}
+
+func (s *rbacAPIServerStub) RemoveAssignments(ctx context.Context,
+	req *apiv1.RemoveAssignmentsRequest) (*apiv1.RemoveAssignmentsResponse, error) {
+	return nil, status.Error(codes.Unimplemented, stubUnimplementedMessage)
+}

--- a/master/internal/rbac/api_rbac_stub.go
+++ b/master/internal/rbac/api_rbac_stub.go
@@ -13,38 +13,40 @@ type rbacAPIServerStub struct{}
 
 const stubUnimplementedMessage = "Determined Enterprise Edition is required for this functionality"
 
+var UnimplementedError = status.Error(codes.Unimplemented, stubUnimplementedMessage)
+
 func (s *rbacAPIServerStub) GetRolesByID(ctx context.Context, req *apiv1.GetRolesByIDRequest) (
 	resp *apiv1.GetRolesByIDResponse, err error) {
-	return nil, status.Error(codes.Unimplemented, stubUnimplementedMessage)
+	return nil, UnimplementedError
 }
 
 func (s *rbacAPIServerStub) GetRolesAssignedToUser(ctx context.Context,
 	req *apiv1.GetRolesAssignedToUserRequest) (*apiv1.GetRolesAssignedToUserResponse, error) {
-	return nil, status.Error(codes.Unimplemented, stubUnimplementedMessage)
+	return nil, UnimplementedError
 }
 
 func (s *rbacAPIServerStub) GetRolesAssignedToGroup(ctx context.Context,
 	req *apiv1.GetRolesAssignedToGroupRequest) (*apiv1.GetRolesAssignedToGroupResponse, error) {
-	return nil, status.Error(codes.Unimplemented, stubUnimplementedMessage)
+	return nil, UnimplementedError
 }
 
 func (s *rbacAPIServerStub) SearchRolesAssignableToScope(ctx context.Context,
 	req *apiv1.SearchRolesAssignableToScopeRequest) (*apiv1.SearchRolesAssignableToScopeResponse,
 	error) {
-	return nil, status.Error(codes.Unimplemented, stubUnimplementedMessage)
+	return nil, UnimplementedError
 }
 
 func (s *rbacAPIServerStub) ListRoles(ctx context.Context, req *apiv1.ListRolesRequest) (
 	*apiv1.ListRolesResponse, error) {
-	return nil, status.Error(codes.Unimplemented, stubUnimplementedMessage)
+	return nil, UnimplementedError
 }
 
 func (s *rbacAPIServerStub) AssignRoles(ctx context.Context, req *apiv1.AssignRolesRequest) (
 	*apiv1.AssignRolesResponse, error) {
-	return nil, status.Error(codes.Unimplemented, stubUnimplementedMessage)
+	return nil, UnimplementedError
 }
 
 func (s *rbacAPIServerStub) RemoveAssignments(ctx context.Context,
 	req *apiv1.RemoveAssignmentsRequest) (*apiv1.RemoveAssignmentsResponse, error) {
-	return nil, status.Error(codes.Unimplemented, stubUnimplementedMessage)
+	return nil, UnimplementedError
 }

--- a/master/internal/rbac/api_rbac_stub.go
+++ b/master/internal/rbac/api_rbac_stub.go
@@ -13,40 +13,48 @@ type rbacAPIServerStub struct{}
 
 const stubUnimplementedMessage = "Determined Enterprise Edition is required for this functionality"
 
+// UnimplementedError is the error returned for unimplemented functions.
 var UnimplementedError = status.Error(codes.Unimplemented, stubUnimplementedMessage)
 
 func (s *rbacAPIServerStub) GetRolesByID(ctx context.Context, req *apiv1.GetRolesByIDRequest) (
-	resp *apiv1.GetRolesByIDResponse, err error) {
+	resp *apiv1.GetRolesByIDResponse, err error,
+) {
 	return nil, UnimplementedError
 }
 
 func (s *rbacAPIServerStub) GetRolesAssignedToUser(ctx context.Context,
-	req *apiv1.GetRolesAssignedToUserRequest) (*apiv1.GetRolesAssignedToUserResponse, error) {
+	req *apiv1.GetRolesAssignedToUserRequest,
+) (*apiv1.GetRolesAssignedToUserResponse, error) {
 	return nil, UnimplementedError
 }
 
 func (s *rbacAPIServerStub) GetRolesAssignedToGroup(ctx context.Context,
-	req *apiv1.GetRolesAssignedToGroupRequest) (*apiv1.GetRolesAssignedToGroupResponse, error) {
+	req *apiv1.GetRolesAssignedToGroupRequest,
+) (*apiv1.GetRolesAssignedToGroupResponse, error) {
 	return nil, UnimplementedError
 }
 
 func (s *rbacAPIServerStub) SearchRolesAssignableToScope(ctx context.Context,
 	req *apiv1.SearchRolesAssignableToScopeRequest) (*apiv1.SearchRolesAssignableToScopeResponse,
-	error) {
+	error,
+) {
 	return nil, UnimplementedError
 }
 
 func (s *rbacAPIServerStub) ListRoles(ctx context.Context, req *apiv1.ListRolesRequest) (
-	*apiv1.ListRolesResponse, error) {
+	*apiv1.ListRolesResponse, error,
+) {
 	return nil, UnimplementedError
 }
 
 func (s *rbacAPIServerStub) AssignRoles(ctx context.Context, req *apiv1.AssignRolesRequest) (
-	*apiv1.AssignRolesResponse, error) {
+	*apiv1.AssignRolesResponse, error,
+) {
 	return nil, UnimplementedError
 }
 
 func (s *rbacAPIServerStub) RemoveAssignments(ctx context.Context,
-	req *apiv1.RemoveAssignmentsRequest) (*apiv1.RemoveAssignmentsResponse, error) {
+	req *apiv1.RemoveAssignmentsRequest,
+) (*apiv1.RemoveAssignmentsResponse, error) {
 	return nil, UnimplementedError
 }

--- a/master/internal/rbac/api_rbac_wrapper.go
+++ b/master/internal/rbac/api_rbac_wrapper.go
@@ -1,0 +1,38 @@
+package rbac
+
+import (
+	"context"
+
+	"github.com/determined-ai/determined/proto/pkg/apiv1"
+)
+
+// RBACAPIServerWrapper is a struct
+type RBACAPIServerWrapper struct{}
+
+func (s *RBACAPIServerWrapper) GetRolesByID(ctx context.Context, req *apiv1.GetRolesByIDRequest) (resp *apiv1.GetRolesByIDResponse, err error) {
+	return rbacAPIServer.GetRolesByID(ctx, req)
+}
+
+func (s *RBACAPIServerWrapper) GetRolesAssignedToUser(ctx context.Context, req *apiv1.GetRolesAssignedToUserRequest) (*apiv1.GetRolesAssignedToUserResponse, error) {
+	return rbacAPIServer.GetRolesAssignedToUser(ctx, req)
+}
+
+func (s *RBACAPIServerWrapper) GetRolesAssignedToGroup(ctx context.Context, req *apiv1.GetRolesAssignedToGroupRequest) (*apiv1.GetRolesAssignedToGroupResponse, error) {
+	return rbacAPIServer.GetRolesAssignedToGroup(ctx, req)
+}
+
+func (s *RBACAPIServerWrapper) SearchRolesAssignableToScope(ctx context.Context, req *apiv1.SearchRolesAssignableToScopeRequest) (*apiv1.SearchRolesAssignableToScopeResponse, error) {
+	return rbacAPIServer.SearchRolesAssignableToScope(ctx, req)
+}
+
+func (s *RBACAPIServerWrapper) ListRoles(ctx context.Context, req *apiv1.ListRolesRequest) (*apiv1.ListRolesResponse, error) {
+	return rbacAPIServer.ListRoles(ctx, req)
+}
+
+func (s *RBACAPIServerWrapper) AssignRoles(ctx context.Context, req *apiv1.AssignRolesRequest) (*apiv1.AssignRolesResponse, error) {
+	return rbacAPIServer.AssignRoles(ctx, req)
+}
+
+func (s *RBACAPIServerWrapper) RemoveAssignments(ctx context.Context, req *apiv1.RemoveAssignmentsRequest) (*apiv1.RemoveAssignmentsResponse, error) {
+	return rbacAPIServer.RemoveAssignments(ctx, req)
+}

--- a/master/internal/rbac/api_rbac_wrapper.go
+++ b/master/internal/rbac/api_rbac_wrapper.go
@@ -6,33 +6,55 @@ import (
 	"github.com/determined-ai/determined/proto/pkg/apiv1"
 )
 
-// RBACAPIServerWrapper is a struct
+// RBACAPIServerWrapper is a struct that implements RBACAPIServer.
 type RBACAPIServerWrapper struct{}
 
-func (s *RBACAPIServerWrapper) GetRolesByID(ctx context.Context, req *apiv1.GetRolesByIDRequest) (resp *apiv1.GetRolesByIDResponse, err error) {
+// GetRolesByID is a wrapper the same function the RBACAPIServer interface.
+func (s *RBACAPIServerWrapper) GetRolesByID(ctx context.Context, req *apiv1.GetRolesByIDRequest) (
+	resp *apiv1.GetRolesByIDResponse, err error,
+) {
 	return rbacAPIServer.GetRolesByID(ctx, req)
 }
 
-func (s *RBACAPIServerWrapper) GetRolesAssignedToUser(ctx context.Context, req *apiv1.GetRolesAssignedToUserRequest) (*apiv1.GetRolesAssignedToUserResponse, error) {
+// GetRolesAssignedToUser is a wrapper the same function the RBACAPIServer interface.
+func (s *RBACAPIServerWrapper) GetRolesAssignedToUser(ctx context.Context,
+	req *apiv1.GetRolesAssignedToUserRequest,
+) (*apiv1.GetRolesAssignedToUserResponse, error) {
 	return rbacAPIServer.GetRolesAssignedToUser(ctx, req)
 }
 
-func (s *RBACAPIServerWrapper) GetRolesAssignedToGroup(ctx context.Context, req *apiv1.GetRolesAssignedToGroupRequest) (*apiv1.GetRolesAssignedToGroupResponse, error) {
+// GetRolesAssignedToGroup is a wrapper the same function the RBACAPIServer interface.
+func (s *RBACAPIServerWrapper) GetRolesAssignedToGroup(ctx context.Context,
+	req *apiv1.GetRolesAssignedToGroupRequest,
+) (*apiv1.GetRolesAssignedToGroupResponse, error) {
 	return rbacAPIServer.GetRolesAssignedToGroup(ctx, req)
 }
 
-func (s *RBACAPIServerWrapper) SearchRolesAssignableToScope(ctx context.Context, req *apiv1.SearchRolesAssignableToScopeRequest) (*apiv1.SearchRolesAssignableToScopeResponse, error) {
+// SearchRolesAssignableToScope is a wrapper the same function the RBACAPIServer interface.
+func (s *RBACAPIServerWrapper) SearchRolesAssignableToScope(
+	ctx context.Context,
+	req *apiv1.SearchRolesAssignableToScopeRequest,
+) (*apiv1.SearchRolesAssignableToScopeResponse, error) {
 	return rbacAPIServer.SearchRolesAssignableToScope(ctx, req)
 }
 
-func (s *RBACAPIServerWrapper) ListRoles(ctx context.Context, req *apiv1.ListRolesRequest) (*apiv1.ListRolesResponse, error) {
+// ListRoles is a wrapper the same function the RBACAPIServer interface.
+func (s *RBACAPIServerWrapper) ListRoles(ctx context.Context, req *apiv1.ListRolesRequest) (
+	*apiv1.ListRolesResponse, error,
+) {
 	return rbacAPIServer.ListRoles(ctx, req)
 }
 
-func (s *RBACAPIServerWrapper) AssignRoles(ctx context.Context, req *apiv1.AssignRolesRequest) (*apiv1.AssignRolesResponse, error) {
+// AssignRoles is a wrapper the same function the RBACAPIServer interface.
+func (s *RBACAPIServerWrapper) AssignRoles(ctx context.Context, req *apiv1.AssignRolesRequest) (
+	*apiv1.AssignRolesResponse, error,
+) {
 	return rbacAPIServer.AssignRoles(ctx, req)
 }
 
-func (s *RBACAPIServerWrapper) RemoveAssignments(ctx context.Context, req *apiv1.RemoveAssignmentsRequest) (*apiv1.RemoveAssignmentsResponse, error) {
+// RemoveAssignments is a wrapper the same function the RBACAPIServer interface.
+func (s *RBACAPIServerWrapper) RemoveAssignments(ctx context.Context,
+	req *apiv1.RemoveAssignmentsRequest,
+) (*apiv1.RemoveAssignmentsResponse, error) {
 	return rbacAPIServer.RemoveAssignments(ctx, req)
 }

--- a/master/internal/usergroup/api_groups.go
+++ b/master/internal/usergroup/api_groups.go
@@ -3,12 +3,7 @@ package usergroup
 import (
 	"context"
 
-	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
-
-	"github.com/determined-ai/determined/master/internal/db"
+	"github.com/determined-ai/determined/master/internal/api/apiutils"
 	"github.com/determined-ai/determined/master/pkg/model"
 	"github.com/determined-ai/determined/proto/pkg/apiv1"
 	"github.com/determined-ai/determined/proto/pkg/groupv1"
@@ -22,7 +17,7 @@ func (a *UserGroupAPIServer) CreateGroup(ctx context.Context, req *apiv1.CreateG
 ) (resp *apiv1.CreateGroupResponse, err error) {
 	// Detect whether we're returning special errors and convert to gRPC error
 	defer func() {
-		err = mapAndFilterErrors(err)
+		err = apiutils.MapAndFilterErrors(err)
 	}()
 
 	group := Group{
@@ -49,11 +44,11 @@ func (a *UserGroupAPIServer) GetGroups(ctx context.Context, req *apiv1.GetGroups
 ) (resp *apiv1.GetGroupsResponse, err error) {
 	// Detect whether we're returning special errors and convert to gRPC error
 	defer func() {
-		err = mapAndFilterErrors(err)
+		err = apiutils.MapAndFilterErrors(err)
 	}()
 
-	if req.Limit > maxLimit || req.Limit == 0 {
-		return nil, errInvalidLimit
+	if req.Limit > apiutils.MaxLimit || req.Limit == 0 {
+		return nil, apiutils.ErrInvalidLimit
 	}
 
 	groups, memberCounts, tableCount, err := SearchGroups(ctx,
@@ -87,7 +82,7 @@ func (a *UserGroupAPIServer) GetGroup(ctx context.Context, req *apiv1.GetGroupRe
 ) (resp *apiv1.GetGroupResponse, err error) {
 	// Detect whether we're returning special errors and convert to gRPC error
 	defer func() {
-		err = mapAndFilterErrors(err)
+		err = apiutils.MapAndFilterErrors(err)
 	}()
 
 	gid := int(req.GroupId)
@@ -117,7 +112,7 @@ func (a *UserGroupAPIServer) UpdateGroup(ctx context.Context, req *apiv1.UpdateG
 ) (resp *apiv1.UpdateGroupResponse, err error) {
 	// Detect whether we're returning special errors and convert to gRPC error
 	defer func() {
-		err = mapAndFilterErrors(err)
+		err = apiutils.MapAndFilterErrors(err)
 	}()
 
 	var addUsers []model.UserID
@@ -153,7 +148,7 @@ func (a *UserGroupAPIServer) DeleteGroup(ctx context.Context, req *apiv1.DeleteG
 ) (resp *apiv1.DeleteGroupResponse, err error) {
 	// Detect whether we're returning special errors and convert to gRPC error
 	defer func() {
-		err = mapAndFilterErrors(err)
+		err = apiutils.MapAndFilterErrors(err)
 	}()
 
 	err = DeleteGroup(ctx, int(req.GroupId))
@@ -171,43 +166,4 @@ func intsToUserIDs(ints []int32) []model.UserID {
 	}
 
 	return ids
-}
-
-const (
-	maxLimit = 500
-)
-
-var (
-	errBadRequest   = status.Error(codes.InvalidArgument, "bad request")
-	errInvalidLimit = status.Errorf(codes.InvalidArgument,
-		"Bad request: limit is required and must be <= %d", maxLimit)
-	errNotFound        = status.Error(codes.NotFound, "not found")
-	errDuplicateRecord = status.Error(codes.AlreadyExists, "duplicate record")
-	errInternal        = status.Error(codes.Internal, "internal server error")
-	errPassthroughMap  = map[error]bool{
-		nil:                true,
-		errBadRequest:      true,
-		errInvalidLimit:    true,
-		errNotFound:        true,
-		errDuplicateRecord: true,
-		errInternal:        true,
-	}
-)
-
-func mapAndFilterErrors(err error) error {
-	// FIXME: whitelist might not work.
-	if whitelisted := errPassthroughMap[err]; whitelisted {
-		return err
-	}
-
-	switch {
-	case errors.Is(err, db.ErrNotFound):
-		return status.Error(codes.NotFound, err.Error())
-	case errors.Is(err, db.ErrDuplicateRecord):
-		return status.Error(codes.AlreadyExists, err.Error())
-	}
-
-	logrus.WithError(err).Debug("suppressing error at API boundary")
-
-	return errInternal // TODO: delete comment: deliberately don't wrap this error
 }

--- a/master/internal/usergroup/postgres_groups.go
+++ b/master/internal/usergroup/postgres_groups.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"database/sql"
 
-	"github.com/jackc/pgconn"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/uptrace/bun"
@@ -23,7 +22,7 @@ func addGroup(ctx context.Context, idb bun.IDB, group Group) (Group, error) {
 	}
 
 	_, err := idb.NewInsert().Model(&group).Exec(ctx)
-	return group, errors.Wrapf(matchSentinelError(err), "Error creating group %s", group.Name)
+	return group, errors.Wrapf(db.MatchSentinelError(err), "Error creating group %s", group.Name)
 }
 
 // AddGroupWithMembers creates a group and adds members to it all in one transaction.
@@ -38,7 +37,7 @@ func AddGroupWithMembers(ctx context.Context, group Group, uids ...model.UserID)
 	tx, err := db.Bun().BeginTx(ctx, nil)
 	if err != nil {
 		return Group{}, nil, errors.Wrapf(
-			matchSentinelError(err),
+			db.MatchSentinelError(err),
 			"Error starting transaction for group %d creation",
 			group.ID)
 	}
@@ -67,7 +66,7 @@ func AddGroupWithMembers(ctx context.Context, group Group, uids ...model.UserID)
 	err = tx.Commit()
 	if err != nil {
 		return Group{}, nil, errors.Wrapf(
-			matchSentinelError(err),
+			db.MatchSentinelError(err),
 			"Error committing changes to group %d",
 			group.ID)
 	}
@@ -83,7 +82,7 @@ func GroupByIDTx(ctx context.Context, idb bun.IDB, gid int) (Group, error) {
 	var g Group
 	err := idb.NewSelect().Model(&g).Where("id = ?", gid).Scan(ctx)
 
-	return g, errors.Wrapf(matchSentinelError(err), "Error getting group %d", gid)
+	return g, errors.Wrapf(db.MatchSentinelError(err), "Error getting group %d", gid)
 }
 
 // SearchGroups searches the database for groups. userBelongsTo is "optional"
@@ -146,8 +145,8 @@ func SearchGroups(ctx context.Context,
 // group doesn't exist.
 func DeleteGroup(ctx context.Context, gid int) error {
 	res, err := db.Bun().NewDelete().Model(&Group{ID: gid}).WherePK().Exec(ctx)
-	if foundErr := mustHaveAffectedRows(res, err); foundErr != nil {
-		return errors.Wrapf(matchSentinelError(foundErr), "Error deleting group %d", gid)
+	if foundErr := db.MustHaveAffectedRows(res, err); foundErr != nil {
+		return errors.Wrapf(db.MatchSentinelError(foundErr), "Error deleting group %d", gid)
 	}
 
 	return nil
@@ -162,7 +161,7 @@ func UpdateGroupTx(ctx context.Context, idb bun.IDB, group Group) error {
 	res, err := idb.NewUpdate().Model(&group).WherePK().Exec(ctx)
 
 	return errors.Wrapf(
-		matchSentinelError(mustHaveAffectedRows(res, err)),
+		db.MatchSentinelError(db.MustHaveAffectedRows(res, err)),
 		"Error updating group %d name",
 		group.ID)
 }
@@ -189,8 +188,8 @@ func AddUsersToGroupTx(ctx context.Context, idb bun.IDB, gid int, uids ...model.
 	}
 
 	res, err := idb.NewInsert().Model(&groupMem).Exec(ctx)
-	if foundErr := mustHaveAffectedRows(res, err); foundErr != nil {
-		sError := matchSentinelError(foundErr)
+	if foundErr := db.MustHaveAffectedRows(res, err); foundErr != nil {
+		sError := db.MatchSentinelError(foundErr)
 		if errors.Is(sError, db.ErrNotFound) {
 			return errors.Wrapf(sError,
 				"Error adding %d user(s) to group %d because"+
@@ -219,8 +218,8 @@ func RemoveUsersFromGroupTx(ctx context.Context, idb bun.IDB, gid int, uids ...m
 		Where("group_id = ?", gid).
 		Where("user_id IN (?)", bun.In(uids)).
 		Exec(ctx)
-	if foundErr := mustHaveAffectedRows(res, err); foundErr != nil {
-		sError := matchSentinelError(foundErr)
+	if foundErr := db.MustHaveAffectedRows(res, err); foundErr != nil {
+		sError := db.MatchSentinelError(foundErr)
 		if errors.Is(sError, db.ErrNotFound) {
 			return errors.Wrapf(sError,
 				"Error removing %d user(s) from group %d because"+
@@ -243,7 +242,7 @@ func UpdateGroupAndMembers(
 	tx, err := db.Bun().BeginTx(ctx, nil)
 	if err != nil {
 		return nil, "", errors.Wrapf(
-			matchSentinelError(err),
+			db.MatchSentinelError(err),
 			"Error starting transaction for group %d update",
 			gid)
 	}
@@ -293,7 +292,7 @@ func UpdateGroupAndMembers(
 
 	err = tx.Commit()
 	if err != nil {
-		return nil, "", errors.Wrapf(matchSentinelError(err), "Error committing changes to group %d", gid)
+		return nil, "", errors.Wrapf(db.MatchSentinelError(err), "Error committing changes to group %d", gid)
 	}
 
 	return users, newName, nil
@@ -313,44 +312,5 @@ func UsersInGroupTx(ctx context.Context, idb bun.IDB, gid int) ([]model.User, er
 		Where("ugm.group_id = ?", gid).
 		Scan(ctx)
 
-	return users, errors.Wrapf(matchSentinelError(err), "Error getting group %d info", gid)
-}
-
-func matchSentinelError(err error) error {
-	if errors.Is(err, sql.ErrNoRows) {
-		return db.ErrNotFound
-	}
-
-	switch pgErrCode(err) {
-	case db.CodeForeignKeyViolation:
-		return db.ErrNotFound
-	case db.CodeUniqueViolation:
-		return db.ErrDuplicateRecord
-	}
-
-	return err
-}
-
-// mustHaveAffectedRows checks if bun has affected rows in a table or not.
-// Returns ErrNotFound if no rows were affected and returns the provided error otherwise.
-func mustHaveAffectedRows(result sql.Result, err error) error {
-	if err == nil {
-		rowsAffected, affectedErr := result.RowsAffected()
-		if affectedErr != nil {
-			return affectedErr
-		}
-		if rowsAffected == 0 {
-			return db.ErrNotFound
-		}
-	}
-
-	return err
-}
-
-func pgErrCode(err error) string {
-	if e, ok := err.(*pgconn.PgError); ok {
-		return e.Code
-	}
-
-	return ""
+	return users, errors.Wrapf(db.MatchSentinelError(err), "Error getting group %d info", gid)
 }

--- a/master/static/migrations/20220907145440_groups-constraint.tx.down.sql
+++ b/master/static/migrations/20220907145440_groups-constraint.tx.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE groups DROP CONSTRAINT groups_user_id_key;

--- a/master/static/migrations/20220907145440_groups-constraint.tx.up.sql
+++ b/master/static/migrations/20220907145440_groups-constraint.tx.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE groups ADD CONSTRAINT groups_user_id_key UNIQUE (user_id);

--- a/proto/src/determined/api/v1/api.proto
+++ b/proto/src/determined/api/v1/api.proto
@@ -1670,6 +1670,7 @@ service Determined {
     };
   }
 
+  // Get a set of roles by id
   rpc GetRolesByID(GetRolesByIDRequest) returns (GetRolesByIDResponse) {
     option (google.api.http) = {
       post: "/api/v1/roles/search/by-ids"
@@ -1681,6 +1682,7 @@ service Determined {
     };
   }
 
+  // Get the roles which are assigned to a user
   rpc GetRolesAssignedToUser(GetRolesAssignedToUserRequest)
       returns (GetRolesAssignedToUserResponse) {
     option (google.api.http) = {
@@ -1692,6 +1694,7 @@ service Determined {
     };
   }
 
+  // Get the roles which are assigned to a group
   rpc GetRolesAssignedToGroup(GetRolesAssignedToGroupRequest)
       returns (GetRolesAssignedToGroupResponse) {
     option (google.api.http) = {
@@ -1703,6 +1706,7 @@ service Determined {
     };
   }
 
+  // Search for roles assignable to a given scope
   rpc SearchRolesAssignableToScope(SearchRolesAssignableToScopeRequest)
       returns (SearchRolesAssignableToScopeResponse) {
     option (google.api.http) = {

--- a/proto/src/determined/api/v1/api.proto
+++ b/proto/src/determined/api/v1/api.proto
@@ -1733,6 +1733,7 @@ service Determined {
   rpc AssignRoles(AssignRolesRequest) returns (AssignRolesResponse) {
     option (google.api.http) = {
       post: "/api/v1/roles/add-assignments"
+      body: "*"
     };
     option (grpc.gateway.protoc_gen_swagger.options.openapiv2_operation) = {
       tags: "RBAC"

--- a/proto/src/determined/api/v1/api.proto
+++ b/proto/src/determined/api/v1/api.proto
@@ -1681,7 +1681,8 @@ service Determined {
     };
   }
 
-  rpc GetRolesAssignedToUser(GetRolesAssignedToUserRequest) returns (GetRolesAssignedToUserResponse) {
+  rpc GetRolesAssignedToUser(GetRolesAssignedToUserRequest)
+      returns (GetRolesAssignedToUserResponse) {
     option (google.api.http) = {
       get: "/api/v1/roles/search/by-user/{user_id}"
     };
@@ -1691,7 +1692,8 @@ service Determined {
     };
   }
 
-  rpc GetRolesAssignedToGroup(GetRolesAssignedToGroupRequest) returns (GetRolesAssignedToGroupResponse) {
+  rpc GetRolesAssignedToGroup(GetRolesAssignedToGroupRequest)
+      returns (GetRolesAssignedToGroupResponse) {
     option (google.api.http) = {
       get: "/api/v1/roles/search/by-group/{group_id}"
     };
@@ -1701,9 +1703,10 @@ service Determined {
     };
   }
 
-  rpc SearchRolesAssignableToScope(SearchRolesAssignableToScopeRequest) returns (SearchRolesAssignableToScopeResponse) {
+  rpc SearchRolesAssignableToScope(SearchRolesAssignableToScopeRequest)
+      returns (SearchRolesAssignableToScopeResponse) {
     option (google.api.http) = {
-      post: "/api/v1/roles/search"
+      post: "/api/v1/roles/search/by-assignability"
       body: "*"
     };
     option (grpc.gateway.protoc_gen_swagger.options.openapiv2_operation) = {

--- a/proto/src/determined/api/v1/api.proto
+++ b/proto/src/determined/api/v1/api.proto
@@ -1745,6 +1745,7 @@ service Determined {
       returns (RemoveAssignmentsResponse) {
     option (google.api.http) = {
       post: "/api/v1/roles/remove-assignments"
+      body: "*"
     };
     option (grpc.gateway.protoc_gen_swagger.options.openapiv2_operation) = {
       tags: "RBAC"

--- a/proto/src/determined/api/v1/api.proto
+++ b/proto/src/determined/api/v1/api.proto
@@ -1617,7 +1617,7 @@ service Determined {
     };
   }
 
-  // Get a group by id
+  // Get a group by id.
   rpc GetGroup(GetGroupRequest) returns (GetGroupResponse) {
     option (google.api.http) = {
       get: "/api/v1/groups/{group_id}"
@@ -1627,7 +1627,7 @@ service Determined {
     };
   }
 
-  // Search for groups with optional filters
+  // Search for groups with optional filters.
   rpc GetGroups(GetGroupsRequest) returns (GetGroupsResponse) {
     option (google.api.http) = {
       post: "/api/v1/groups/search"
@@ -1638,7 +1638,7 @@ service Determined {
     };
   }
 
-  // Create a group with optional members on creation
+  // Create a group with optional members on creation.
   rpc CreateGroup(CreateGroupRequest) returns (CreateGroupResponse) {
     option (google.api.http) = {
       post: "/api/v1/groups"
@@ -1649,7 +1649,7 @@ service Determined {
     };
   }
 
-  // Update group info
+  // Update group info.
   rpc UpdateGroup(UpdateGroupRequest) returns (UpdateGroupResponse) {
     option (google.api.http) = {
       put: "/api/v1/groups/{group_id}"
@@ -1660,7 +1660,7 @@ service Determined {
     };
   }
 
-  // Remove a group
+  // Remove a group.
   rpc DeleteGroup(DeleteGroupRequest) returns (DeleteGroupResponse) {
     option (google.api.http) = {
       delete: "/api/v1/groups/{group_id}"
@@ -1670,7 +1670,7 @@ service Determined {
     };
   }
 
-  // Get a set of roles by id
+  // Get a set of roles with the corresponding IDs.
   rpc GetRolesByID(GetRolesByIDRequest) returns (GetRolesByIDResponse) {
     option (google.api.http) = {
       post: "/api/v1/roles/search/by-ids"
@@ -1682,7 +1682,7 @@ service Determined {
     };
   }
 
-  // Get the roles which are assigned to a user
+  // Get the roles which are assigned to a user.
   rpc GetRolesAssignedToUser(GetRolesAssignedToUserRequest)
       returns (GetRolesAssignedToUserResponse) {
     option (google.api.http) = {
@@ -1694,7 +1694,7 @@ service Determined {
     };
   }
 
-  // Get the roles which are assigned to a group
+  // Get the roles which are assigned to a group.
   rpc GetRolesAssignedToGroup(GetRolesAssignedToGroupRequest)
       returns (GetRolesAssignedToGroupResponse) {
     option (google.api.http) = {
@@ -1706,7 +1706,7 @@ service Determined {
     };
   }
 
-  // Search for roles assignable to a given scope
+  // Search for roles assignable to a given scope.
   rpc SearchRolesAssignableToScope(SearchRolesAssignableToScopeRequest)
       returns (SearchRolesAssignableToScopeResponse) {
     option (google.api.http) = {

--- a/proto/src/determined/api/v1/api.proto
+++ b/proto/src/determined/api/v1/api.proto
@@ -17,6 +17,7 @@ import "determined/api/v1/master.proto";
 import "determined/api/v1/model.proto";
 import "determined/api/v1/notebook.proto";
 import "determined/api/v1/project.proto";
+import "determined/api/v1/rbac.proto";
 import "determined/api/v1/task.proto";
 import "determined/api/v1/template.proto";
 import "determined/api/v1/tensorboard.proto";
@@ -1666,6 +1667,79 @@ service Determined {
     };
     option (grpc.gateway.protoc_gen_swagger.options.openapiv2_operation) = {
       tags: "Internal"
+    };
+  }
+
+  rpc GetRolesByID(GetRolesByIDRequest) returns (GetRolesByIDResponse) {
+    option (google.api.http) = {
+      post: "/api/v1/roles/search/by-ids"
+      body: "*"
+    };
+
+    option (grpc.gateway.protoc_gen_swagger.options.openapiv2_operation) = {
+      tags: "RBAC"
+    };
+  }
+
+  rpc GetRolesAssignedToUser(GetRolesAssignedToUserRequest) returns (GetRolesAssignedToUserResponse) {
+    option (google.api.http) = {
+      get: "/api/v1/roles/search/by-user/{user_id}"
+    };
+
+    option (grpc.gateway.protoc_gen_swagger.options.openapiv2_operation) = {
+      tags: "RBAC"
+    };
+  }
+
+  rpc GetRolesAssignedToGroup(GetRolesAssignedToGroupRequest) returns (GetRolesAssignedToGroupResponse) {
+    option (google.api.http) = {
+      get: "/api/v1/roles/search/by-group/{group_id}"
+    };
+
+    option (grpc.gateway.protoc_gen_swagger.options.openapiv2_operation) = {
+      tags: "RBAC"
+    };
+  }
+
+  rpc SearchRolesAssignableToScope(SearchRolesAssignableToScopeRequest) returns (SearchRolesAssignableToScopeResponse) {
+    option (google.api.http) = {
+      post: "/api/v1/roles/search"
+      body: "*"
+    };
+    option (grpc.gateway.protoc_gen_swagger.options.openapiv2_operation) = {
+      tags: "RBAC"
+    };
+  }
+
+  // ListRoles returns roles and groups/users granted that role.
+  rpc ListRoles(ListRolesRequest) returns (ListRolesResponse) {
+    option (google.api.http) = {
+      post: "/api/v1/roles/search"
+      body: "*"
+    };
+    option (grpc.gateway.protoc_gen_swagger.options.openapiv2_operation) = {
+      tags: "RBAC"
+    };
+  }
+
+  // AssignRoles adds a set of role assignments to the system.
+  rpc AssignRoles(AssignRolesRequest) returns (AssignRolesResponse) {
+    option (google.api.http) = {
+      post: "/api/v1/roles/add-assignments"
+    };
+    option (grpc.gateway.protoc_gen_swagger.options.openapiv2_operation) = {
+      tags: "RBAC"
+    };
+  }
+
+  // RemoveAssignments removes a set of role assignments from the system.
+  rpc RemoveAssignments(RemoveAssignmentsRequest)
+      returns (RemoveAssignmentsResponse) {
+    option (google.api.http) = {
+      post: "/api/v1/roles/remove-assignments"
+    };
+    option (grpc.gateway.protoc_gen_swagger.options.openapiv2_operation) = {
+      tags: "RBAC"
     };
   }
 }

--- a/proto/src/determined/api/v1/rbac.proto
+++ b/proto/src/determined/api/v1/rbac.proto
@@ -36,13 +36,13 @@ message SearchRolesAssignableToScopeRequest {
     json_schema: { required: [ "limit" ] }
   };
 
-  int32 limit = 1;
-  int32 offset = 2;
+  int32 limit                 = 1;
+  int32 offset                = 2;
   optional int32 workspace_id = 3;
 }
 
 message SearchRolesAssignableToScopeResponse {
-  Pagination pagination = 1;
+  Pagination pagination                  = 1;
   repeated determined.rbac.v1.Role roles = 2;
 }
 
@@ -52,7 +52,7 @@ message ListRolesRequest {
   option (grpc.gateway.protoc_gen_swagger.options.openapiv2_schema) = {
     json_schema: { required: [ "limit" ] }
   };
-  
+
   int32 offset = 3;
   // the limit for pagination.
   int32 limit = 4;

--- a/proto/src/determined/api/v1/rbac.proto
+++ b/proto/src/determined/api/v1/rbac.proto
@@ -51,16 +51,18 @@ message SearchRolesAssignableToScopeRequest {
   };
 
   // The maximum number of results to return
-  int32 limit                 = 1;
+  int32 limit = 1;
   // The offset to use with pagination
-  int32 offset                = 2;
+  int32 offset = 2;
   // The id of the workspace to use if searching for a workspace-assignable role
   google.protobuf.Int32Value workspace_id = 3;
 }
 
 // Response object for SearchRolesAssignableToScope
 message SearchRolesAssignableToScopeResponse {
-  Pagination pagination                  = 1;
+  // pagination information.
+  Pagination pagination = 1;
+  // the set of roles and all assignments belonging to it.
   repeated determined.rbac.v1.Role roles = 2;
 }
 
@@ -70,7 +72,7 @@ message ListRolesRequest {
   option (grpc.gateway.protoc_gen_swagger.options.openapiv2_schema) = {
     json_schema: { required: [ "limit" ] }
   };
-
+  // the offset for pagination
   int32 offset = 3;
   // the limit for pagination.
   int32 limit = 4;

--- a/proto/src/determined/api/v1/rbac.proto
+++ b/proto/src/determined/api/v1/rbac.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 package determined.api.v1;
 option go_package = "github.com/determined-ai/determined/proto/pkg/apiv1";
 
+import "google/protobuf/wrappers.proto";
 import "determined/api/v1/pagination.proto";
 import "determined/rbac/v1/rbac.proto";
 import "protoc-gen-swagger/options/annotations.proto";
@@ -54,7 +55,7 @@ message SearchRolesAssignableToScopeRequest {
   // The offset to use with pagination
   int32 offset                = 2;
   // The id of the workspace to use if searching for a workspace-assignable role
-  optional int32 workspace_id = 3;
+  google.protobuf.Int32Value workspace_id = 3;
 }
 
 // Response object for SearchRolesAssignableToScope

--- a/proto/src/determined/api/v1/rbac.proto
+++ b/proto/src/determined/api/v1/rbac.proto
@@ -7,40 +7,57 @@ import "determined/api/v1/pagination.proto";
 import "determined/rbac/v1/rbac.proto";
 import "protoc-gen-swagger/options/annotations.proto";
 
+// Request object for GetRolesByID
 message GetRolesByIDRequest {
+  // The ids of the roles to be returned
   repeated int32 role_ids = 1;
 }
 
+// Response object for GetRolesByID
 message GetRolesByIDResponse {
+  // The roles requested
   repeated determined.rbac.v1.RoleWithAssignments roles = 1;
 }
 
+// Request object for GetRolesAssignedToUser
 message GetRolesAssignedToUserRequest {
+  // The id of the user to search for role assignments for
   int32 user_id = 1;
 }
 
+// Response object for GetRolesAssignedToUser
 message GetRolesAssignedToUserResponse {
+  // The roles assigned to the requested user
   repeated determined.rbac.v1.Role roles = 1;
 }
 
+// Request object for GetRolesAssignedToGroup
 message GetRolesAssignedToGroupRequest {
+  // The id of the group to search for role assignments for
   int32 group_id = 1;
 }
 
+// Response object for GetRolesAssignedToGroup
 message GetRolesAssignedToGroupResponse {
+  // The roles assigned to the requested groups
   repeated determined.rbac.v1.Role roles = 1;
 }
 
+// Request object for SearchRolesAssignableToScope
 message SearchRolesAssignableToScopeRequest {
   option (grpc.gateway.protoc_gen_swagger.options.openapiv2_schema) = {
     json_schema: { required: [ "limit" ] }
   };
 
+  // The maximum number of results to return
   int32 limit                 = 1;
+  // The offset to use with pagination
   int32 offset                = 2;
+  // The id of the workspace to use if searching for a workspace-assignable role
   optional int32 workspace_id = 3;
 }
 
+// Response object for SearchRolesAssignableToScope
 message SearchRolesAssignableToScopeResponse {
   Pagination pagination                  = 1;
   repeated determined.rbac.v1.Role roles = 2;

--- a/proto/src/determined/api/v1/rbac.proto
+++ b/proto/src/determined/api/v1/rbac.proto
@@ -1,0 +1,98 @@
+syntax = "proto3";
+
+package determined.api.v1;
+option go_package = "github.com/determined-ai/determined/proto/pkg/apiv1";
+
+import "determined/api/v1/pagination.proto";
+import "determined/rbac/v1/rbac.proto";
+import "protoc-gen-swagger/options/annotations.proto";
+
+message GetRolesByIDRequest {
+  repeated int32 role_ids = 1;
+}
+
+message GetRolesByIDResponse {
+  repeated determined.rbac.v1.RoleWithAssignments roles = 1;
+}
+
+message GetRolesAssignedToUserRequest {
+  int32 user_id = 1;
+}
+
+message GetRolesAssignedToUserResponse {
+  repeated determined.rbac.v1.Role roles = 1;
+}
+
+message GetRolesAssignedToGroupRequest {
+  int32 group_id = 1;
+}
+
+message GetRolesAssignedToGroupResponse {
+  repeated determined.rbac.v1.Role roles = 1;
+}
+
+message SearchRolesAssignableToScopeRequest {
+  option (grpc.gateway.protoc_gen_swagger.options.openapiv2_schema) = {
+    json_schema: { required: [ "limit" ] }
+  };
+
+  int32 limit = 1;
+  int32 offset = 2;
+  optional int32 workspace_id = 3;
+}
+
+message SearchRolesAssignableToScopeResponse {
+  Pagination pagination = 1;
+  repeated determined.rbac.v1.Role roles = 2;
+}
+
+// ListRolesRequest is the body of the request for the call
+// to search for a role.
+message ListRolesRequest {
+  option (grpc.gateway.protoc_gen_swagger.options.openapiv2_schema) = {
+    json_schema: { required: [ "limit" ] }
+  };
+  
+  int32 offset = 3;
+  // the limit for pagination.
+  int32 limit = 4;
+}
+
+// ListRolesResponse is the body of the response for the call
+// to search for a role.
+message ListRolesResponse {
+  option (grpc.gateway.protoc_gen_swagger.options.openapiv2_schema) = {
+    json_schema: { required: [ "roles", "pagination" ] }
+  };
+  // a set of roles and all assignments belonging to it.
+  repeated determined.rbac.v1.Role roles = 1;
+  // pagination information.
+  Pagination pagination = 2;
+}
+
+// AssignRolesRequest is the body of the request for the call to
+// grant a user or group a role. It requires group_id, role_id,
+// and either scope_workspace_id or scope_project_id.
+message AssignRolesRequest {
+  // the set of groups being assigned to a role.
+  repeated determined.rbac.v1.GroupRoleAssignment group_role_assignments = 1;
+  // the set of users being assigned to a role.
+  repeated determined.rbac.v1.UserRoleAssignment user_role_assignments = 2;
+}
+
+// AssignRolesResponse is the body of the request for the call
+// to grant a user or group a role.
+message AssignRolesResponse {}
+
+// RemoveAssignmentsRequest is the body of the request for the call
+// to remove a user or group from a role.
+message RemoveAssignmentsRequest {
+  // the set of groups being removed from a role.
+  repeated determined.rbac.v1.GroupRoleAssignment group_role_assignments = 1;
+  // the set of users being removed from a role.
+  repeated determined.rbac.v1.UserRoleAssignment user_role_assignments = 2;
+}
+
+// RemoveAssignmentsResponse is the body of the response for teh call
+// to remove a user or group from a role.
+message RemoveAssignmentsResponse {}

--- a/proto/src/determined/rbac/v1/rbac.proto
+++ b/proto/src/determined/rbac/v1/rbac.proto
@@ -15,6 +15,7 @@ message Role {
   repeated Permission permissions = 3;
 }
 
+// Permission represents an action a user can take in the system
 message Permission {
   // The id of the permission
   int32 id = 1;

--- a/proto/src/determined/rbac/v1/rbac.proto
+++ b/proto/src/determined/rbac/v1/rbac.proto
@@ -1,0 +1,73 @@
+syntax = "proto3";
+
+package determined.rbac.v1;
+option go_package = "github.com/determined-ai/determined/proto/pkg/rbacv1";
+
+import "protoc-gen-swagger/options/annotations.proto";
+
+// Role contains information about a specific Role
+message Role {
+  // The id of the role being detailed
+  int32 role_id = 1;
+  // The string of the role being detailed
+  string name = 2;
+  // The permissions granted to the role
+  repeated Permission permissions = 3;
+}
+
+message Permission {
+  // The id of the permission
+  int32 id = 1;
+  // The name of the permission
+  string name = 2;
+  // Whether the permission is a globl-only permission
+  bool is_global = 3;
+}
+
+// RoleAssignment contains information about the scope
+// of the role.
+message RoleAssignment {
+  option (grpc.gateway.protoc_gen_swagger.options.openapiv2_schema) = {
+    json_schema: { required: [ "role" ] }
+  };
+  // The role of the assignment.
+  Role role = 1;
+  // The id of the workspace the role belongs to.
+  // Omit for a global scope.
+  optional int32 scope_workspace_id = 2;
+}
+
+// GroupRoleAssignment contains information about the groups
+// belonging to a role.
+message GroupRoleAssignment {
+  option (grpc.gateway.protoc_gen_swagger.options.openapiv2_schema) = {
+    json_schema: { required: [ "group_id", "role_assignment" ] }
+  };
+  // The group id of the role assignment
+  int32 group_id = 1;
+  // The role and scope of the assignment.
+  RoleAssignment role_assignment = 2;
+}
+
+// UserRoleAssignment contains information about the users
+// belonging to a role.
+message UserRoleAssignment {
+  option (grpc.gateway.protoc_gen_swagger.options.openapiv2_schema) = {
+    json_schema: { required: [ "user_id", "role_assignment" ] }
+  };
+  // the user id of the role assignment
+  int32 user_id = 1;
+  // the role and scope of the assignment
+  RoleAssignment role_assignment = 2;
+}
+
+// RoleWithAssignments contains a detailed description of
+// a role and the groups and users belonging to it.
+message RoleWithAssignments {
+  // The embedded Role.
+  Role role = 1;
+  // The embedded GroupRoleAssignment.
+  repeated GroupRoleAssignment group_role_assignments = 2;
+  // The embedded UserRoleAssignment.
+  repeated UserRoleAssignment user_role_assignments = 3;
+}

--- a/proto/src/determined/rbac/v1/rbac.proto
+++ b/proto/src/determined/rbac/v1/rbac.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 package determined.rbac.v1;
 option go_package = "github.com/determined-ai/determined/proto/pkg/rbacv1";
 
+import "google/protobuf/wrappers.proto";
 import "protoc-gen-swagger/options/annotations.proto";
 
 // Role contains information about a specific Role
@@ -35,7 +36,7 @@ message RoleAssignment {
   Role role = 1;
   // The id of the workspace the role belongs to.
   // Omit for a global scope.
-  optional int32 scope_workspace_id = 2;
+  google.protobuf.Int32Value scope_workspace_id = 2;
 }
 
 // GroupRoleAssignment contains information about the groups

--- a/webui/react/src/services/api-ts-sdk/api.ts
+++ b/webui/react/src/services/api-ts-sdk/api.ts
@@ -1122,6 +1122,14 @@ export interface V1ArchiveWorkspaceResponse {
 }
 
 /**
+ * AssignRolesResponse is the body of the request for the call to grant a user or group a role.
+ * @export
+ * @interface V1AssignRolesResponse
+ */
+export interface V1AssignRolesResponse {
+}
+
+/**
  * 
  * @export
  * @interface V1AwsCustomTag
@@ -2958,6 +2966,62 @@ export interface V1GetResourcePoolsResponse {
 }
 
 /**
+ * 
+ * @export
+ * @interface V1GetRolesAssignedToGroupResponse
+ */
+export interface V1GetRolesAssignedToGroupResponse {
+    /**
+     * 
+     * @type {Array<V1Role>}
+     * @memberof V1GetRolesAssignedToGroupResponse
+     */
+    roles?: Array<V1Role>;
+}
+
+/**
+ * 
+ * @export
+ * @interface V1GetRolesAssignedToUserResponse
+ */
+export interface V1GetRolesAssignedToUserResponse {
+    /**
+     * 
+     * @type {Array<V1Role>}
+     * @memberof V1GetRolesAssignedToUserResponse
+     */
+    roles?: Array<V1Role>;
+}
+
+/**
+ * 
+ * @export
+ * @interface V1GetRolesByIDRequest
+ */
+export interface V1GetRolesByIDRequest {
+    /**
+     * 
+     * @type {Array<number>}
+     * @memberof V1GetRolesByIDRequest
+     */
+    roleIds?: Array<number>;
+}
+
+/**
+ * 
+ * @export
+ * @interface V1GetRolesByIDResponse
+ */
+export interface V1GetRolesByIDResponse {
+    /**
+     * 
+     * @type {Array<V1RoleWithAssignments>}
+     * @memberof V1GetRolesByIDResponse
+     */
+    roles?: Array<V1RoleWithAssignments>;
+}
+
+/**
  * Response to GetShellRequest.
  * @export
  * @interface V1GetShellResponse
@@ -3450,6 +3514,26 @@ export interface V1GroupDetails {
 }
 
 /**
+ * GroupRoleAssignment contains information about the groups belonging to a role.
+ * @export
+ * @interface V1GroupRoleAssignment
+ */
+export interface V1GroupRoleAssignment {
+    /**
+     * 
+     * @type {number}
+     * @memberof V1GroupRoleAssignment
+     */
+    groupId: number;
+    /**
+     * The role and scope of the assignment.
+     * @type {V1RoleAssignment}
+     * @memberof V1GroupRoleAssignment
+     */
+    roleAssignment: V1RoleAssignment;
+}
+
+/**
  * GroupSearchResult is the representation of groups as they're returned by the search endpoint.
  * @export
  * @interface V1GroupSearchResult
@@ -3919,6 +4003,46 @@ export interface V1LaunchTensorboardResponse {
      * @memberof V1LaunchTensorboardResponse
      */
     config: any;
+}
+
+/**
+ * ListRolesRequest is the body of the request for the call to search for a role.
+ * @export
+ * @interface V1ListRolesRequest
+ */
+export interface V1ListRolesRequest {
+    /**
+     * 
+     * @type {number}
+     * @memberof V1ListRolesRequest
+     */
+    offset?: number;
+    /**
+     * the limit for pagination.
+     * @type {number}
+     * @memberof V1ListRolesRequest
+     */
+    limit: number;
+}
+
+/**
+ * ListRolesResponse is the body of the response for the call to search for a role.
+ * @export
+ * @interface V1ListRolesResponse
+ */
+export interface V1ListRolesResponse {
+    /**
+     * a set of roles and all assignments belonging to it.
+     * @type {Array<V1Role>}
+     * @memberof V1ListRolesResponse
+     */
+    roles: Array<V1Role>;
+    /**
+     * pagination information.
+     * @type {V1Pagination}
+     * @memberof V1ListRolesResponse
+     */
+    pagination: V1Pagination;
 }
 
 /**
@@ -4823,6 +4947,32 @@ export interface V1PauseExperimentResponse {
 }
 
 /**
+ * 
+ * @export
+ * @interface V1Permission
+ */
+export interface V1Permission {
+    /**
+     * 
+     * @type {number}
+     * @memberof V1Permission
+     */
+    id?: number;
+    /**
+     * 
+     * @type {string}
+     * @memberof V1Permission
+     */
+    name?: string;
+    /**
+     * 
+     * @type {boolean}
+     * @memberof V1Permission
+     */
+    isGlobal?: boolean;
+}
+
+/**
  * Response to PinWorkspaceRequest.
  * @export
  * @interface V1PinWorkspaceResponse
@@ -5430,6 +5580,14 @@ export interface V1RPQueueStat {
      * @memberof V1RPQueueStat
      */
     aggregates?: Array<V1AggregateQueueStats>;
+}
+
+/**
+ * RemoveAssignmentsResponse is the body of the response for teh call to remove a user or group from a role.
+ * @export
+ * @interface V1RemoveAssignmentsResponse
+ */
+export interface V1RemoveAssignmentsResponse {
 }
 
 /**
@@ -6155,6 +6313,78 @@ export enum V1ResourcePoolType {
 }
 
 /**
+ * 
+ * @export
+ * @interface V1Role
+ */
+export interface V1Role {
+    /**
+     * 
+     * @type {number}
+     * @memberof V1Role
+     */
+    roleId?: number;
+    /**
+     * 
+     * @type {string}
+     * @memberof V1Role
+     */
+    name?: string;
+    /**
+     * 
+     * @type {Array<V1Permission>}
+     * @memberof V1Role
+     */
+    permissions?: Array<V1Permission>;
+}
+
+/**
+ * RoleAssignment contains information about the scope of the role.
+ * @export
+ * @interface V1RoleAssignment
+ */
+export interface V1RoleAssignment {
+    /**
+     * The role of the assignment.
+     * @type {V1Role}
+     * @memberof V1RoleAssignment
+     */
+    role: V1Role;
+    /**
+     * The id of the workspace the role belongs to. Omit for a global scope.
+     * @type {number}
+     * @memberof V1RoleAssignment
+     */
+    scopeWorkspaceId?: number;
+}
+
+/**
+ * RoleWithAssignments contains a detailed description of a role and the groups and users belonging to it.
+ * @export
+ * @interface V1RoleWithAssignments
+ */
+export interface V1RoleWithAssignments {
+    /**
+     * The embedded Role.
+     * @type {V1Role}
+     * @memberof V1RoleWithAssignments
+     */
+    role?: V1Role;
+    /**
+     * The embedded GroupRoleAssignment.
+     * @type {Array<V1GroupRoleAssignment>}
+     * @memberof V1RoleWithAssignments
+     */
+    groupRoleAssignments?: Array<V1GroupRoleAssignment>;
+    /**
+     * The embedded UserRoleAssignment.
+     * @type {Array<V1UserRoleAssignment>}
+     * @memberof V1RoleWithAssignments
+     */
+    userRoleAssignments?: Array<V1UserRoleAssignment>;
+}
+
+/**
  * RunnableOperation represents a single runnable operation emitted by a searcher.
  * @export
  * @interface V1RunnableOperation
@@ -6229,6 +6459,52 @@ export enum V1SchedulerType {
     KUBERNETES = <any> 'SCHEDULER_TYPE_KUBERNETES',
     SLURM = <any> 'SCHEDULER_TYPE_SLURM',
     PBS = <any> 'SCHEDULER_TYPE_PBS'
+}
+
+/**
+ * 
+ * @export
+ * @interface V1SearchRolesAssignableToScopeRequest
+ */
+export interface V1SearchRolesAssignableToScopeRequest {
+    /**
+     * 
+     * @type {number}
+     * @memberof V1SearchRolesAssignableToScopeRequest
+     */
+    limit: number;
+    /**
+     * 
+     * @type {number}
+     * @memberof V1SearchRolesAssignableToScopeRequest
+     */
+    offset?: number;
+    /**
+     * 
+     * @type {number}
+     * @memberof V1SearchRolesAssignableToScopeRequest
+     */
+    workspaceId?: number;
+}
+
+/**
+ * 
+ * @export
+ * @interface V1SearchRolesAssignableToScopeResponse
+ */
+export interface V1SearchRolesAssignableToScopeResponse {
+    /**
+     * pagination information.
+     * @type {V1Pagination}
+     * @memberof V1SearchRolesAssignableToScopeResponse
+     */
+    pagination?: V1Pagination;
+    /**
+     * the set of roles and all assignments belonging to it.
+     * @type {Array<V1Role>}
+     * @memberof V1SearchRolesAssignableToScopeResponse
+     */
+    roles?: Array<V1Role>;
 }
 
 /**
@@ -7259,6 +7535,26 @@ export interface V1User {
      * @memberof V1User
      */
     modifiedAt?: Date;
+}
+
+/**
+ * UserRoleAssignment contains information about the users belonging to a role.
+ * @export
+ * @interface V1UserRoleAssignment
+ */
+export interface V1UserRoleAssignment {
+    /**
+     * 
+     * @type {number}
+     * @memberof V1UserRoleAssignment
+     */
+    userId: number;
+    /**
+     * 
+     * @type {V1RoleAssignment}
+     * @memberof V1UserRoleAssignment
+     */
+    roleAssignment: V1RoleAssignment;
 }
 
 /**
@@ -19015,6 +19311,579 @@ export class ProjectsApi extends BaseAPI {
      */
     public unarchiveProject(id: number, options?: any) {
         return ProjectsApiFp(this.configuration).unarchiveProject(id, options)(this.fetch, this.basePath);
+    }
+
+}
+
+/**
+ * RBACApi - fetch parameter creator
+ * @export
+ */
+export const RBACApiFetchParamCreator = function (configuration?: Configuration) {
+    return {
+        /**
+         * 
+         * @summary AssignRoles adds a set of role assignments to the system.
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        assignRoles(options: any = {}): FetchArgs {
+            const localVarPath = `/api/v1/roles/add-assignments`;
+            const localVarUrlObj = url.parse(localVarPath, true);
+            const localVarRequestOptions = Object.assign({ method: 'POST' }, options);
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            // authentication BearerToken required
+            if (configuration && configuration.apiKey) {
+                const localVarApiKeyValue = typeof configuration.apiKey === 'function'
+					? configuration.apiKey("Authorization")
+					: configuration.apiKey;
+                localVarHeaderParameter["Authorization"] = localVarApiKeyValue;
+            }
+
+            localVarUrlObj.query = Object.assign({}, localVarUrlObj.query, localVarQueryParameter, options.query);
+            // fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
+            delete localVarUrlObj.search;
+            localVarRequestOptions.headers = Object.assign({}, localVarHeaderParameter, options.headers);
+
+            return {
+                url: url.format(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         * 
+         * @summary Get the roles which are assigned to a group
+         * @param {number} groupId The id of the group to search for role assignments for
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        getRolesAssignedToGroup(groupId: number, options: any = {}): FetchArgs {
+            // verify required parameter 'groupId' is not null or undefined
+            if (groupId === null || groupId === undefined) {
+                throw new RequiredError('groupId','Required parameter groupId was null or undefined when calling getRolesAssignedToGroup.');
+            }
+            const localVarPath = `/api/v1/roles/search/by-group/{groupId}`
+                .replace(`{${"groupId"}}`, encodeURIComponent(String(groupId)));
+            const localVarUrlObj = url.parse(localVarPath, true);
+            const localVarRequestOptions = Object.assign({ method: 'GET' }, options);
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            // authentication BearerToken required
+            if (configuration && configuration.apiKey) {
+                const localVarApiKeyValue = typeof configuration.apiKey === 'function'
+					? configuration.apiKey("Authorization")
+					: configuration.apiKey;
+                localVarHeaderParameter["Authorization"] = localVarApiKeyValue;
+            }
+
+            localVarUrlObj.query = Object.assign({}, localVarUrlObj.query, localVarQueryParameter, options.query);
+            // fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
+            delete localVarUrlObj.search;
+            localVarRequestOptions.headers = Object.assign({}, localVarHeaderParameter, options.headers);
+
+            return {
+                url: url.format(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         * 
+         * @summary Get the roles which are assigned to a user
+         * @param {number} userId The id of the user to search for role assignments for
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        getRolesAssignedToUser(userId: number, options: any = {}): FetchArgs {
+            // verify required parameter 'userId' is not null or undefined
+            if (userId === null || userId === undefined) {
+                throw new RequiredError('userId','Required parameter userId was null or undefined when calling getRolesAssignedToUser.');
+            }
+            const localVarPath = `/api/v1/roles/search/by-user/{userId}`
+                .replace(`{${"userId"}}`, encodeURIComponent(String(userId)));
+            const localVarUrlObj = url.parse(localVarPath, true);
+            const localVarRequestOptions = Object.assign({ method: 'GET' }, options);
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            // authentication BearerToken required
+            if (configuration && configuration.apiKey) {
+                const localVarApiKeyValue = typeof configuration.apiKey === 'function'
+					? configuration.apiKey("Authorization")
+					: configuration.apiKey;
+                localVarHeaderParameter["Authorization"] = localVarApiKeyValue;
+            }
+
+            localVarUrlObj.query = Object.assign({}, localVarUrlObj.query, localVarQueryParameter, options.query);
+            // fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
+            delete localVarUrlObj.search;
+            localVarRequestOptions.headers = Object.assign({}, localVarHeaderParameter, options.headers);
+
+            return {
+                url: url.format(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         * 
+         * @summary Get a set of roles by id
+         * @param {V1GetRolesByIDRequest} body 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        getRolesByID(body: V1GetRolesByIDRequest, options: any = {}): FetchArgs {
+            // verify required parameter 'body' is not null or undefined
+            if (body === null || body === undefined) {
+                throw new RequiredError('body','Required parameter body was null or undefined when calling getRolesByID.');
+            }
+            const localVarPath = `/api/v1/roles/search/by-ids`;
+            const localVarUrlObj = url.parse(localVarPath, true);
+            const localVarRequestOptions = Object.assign({ method: 'POST' }, options);
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            // authentication BearerToken required
+            if (configuration && configuration.apiKey) {
+                const localVarApiKeyValue = typeof configuration.apiKey === 'function'
+					? configuration.apiKey("Authorization")
+					: configuration.apiKey;
+                localVarHeaderParameter["Authorization"] = localVarApiKeyValue;
+            }
+
+            localVarHeaderParameter['Content-Type'] = 'application/json';
+
+            localVarUrlObj.query = Object.assign({}, localVarUrlObj.query, localVarQueryParameter, options.query);
+            // fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
+            delete localVarUrlObj.search;
+            localVarRequestOptions.headers = Object.assign({}, localVarHeaderParameter, options.headers);
+            const needsSerialization = (<any>"V1GetRolesByIDRequest" !== "string") || localVarRequestOptions.headers['Content-Type'] === 'application/json';
+            localVarRequestOptions.body =  needsSerialization ? JSON.stringify(body || {}) : (body || "");
+
+            return {
+                url: url.format(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         * 
+         * @summary ListRoles returns roles and groups/users granted that role.
+         * @param {V1ListRolesRequest} body 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        listRoles(body: V1ListRolesRequest, options: any = {}): FetchArgs {
+            // verify required parameter 'body' is not null or undefined
+            if (body === null || body === undefined) {
+                throw new RequiredError('body','Required parameter body was null or undefined when calling listRoles.');
+            }
+            const localVarPath = `/api/v1/roles/search`;
+            const localVarUrlObj = url.parse(localVarPath, true);
+            const localVarRequestOptions = Object.assign({ method: 'POST' }, options);
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            // authentication BearerToken required
+            if (configuration && configuration.apiKey) {
+                const localVarApiKeyValue = typeof configuration.apiKey === 'function'
+					? configuration.apiKey("Authorization")
+					: configuration.apiKey;
+                localVarHeaderParameter["Authorization"] = localVarApiKeyValue;
+            }
+
+            localVarHeaderParameter['Content-Type'] = 'application/json';
+
+            localVarUrlObj.query = Object.assign({}, localVarUrlObj.query, localVarQueryParameter, options.query);
+            // fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
+            delete localVarUrlObj.search;
+            localVarRequestOptions.headers = Object.assign({}, localVarHeaderParameter, options.headers);
+            const needsSerialization = (<any>"V1ListRolesRequest" !== "string") || localVarRequestOptions.headers['Content-Type'] === 'application/json';
+            localVarRequestOptions.body =  needsSerialization ? JSON.stringify(body || {}) : (body || "");
+
+            return {
+                url: url.format(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         * 
+         * @summary RemoveAssignments removes a set of role assignments from the system.
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        removeAssignments(options: any = {}): FetchArgs {
+            const localVarPath = `/api/v1/roles/remove-assignments`;
+            const localVarUrlObj = url.parse(localVarPath, true);
+            const localVarRequestOptions = Object.assign({ method: 'POST' }, options);
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            // authentication BearerToken required
+            if (configuration && configuration.apiKey) {
+                const localVarApiKeyValue = typeof configuration.apiKey === 'function'
+					? configuration.apiKey("Authorization")
+					: configuration.apiKey;
+                localVarHeaderParameter["Authorization"] = localVarApiKeyValue;
+            }
+
+            localVarUrlObj.query = Object.assign({}, localVarUrlObj.query, localVarQueryParameter, options.query);
+            // fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
+            delete localVarUrlObj.search;
+            localVarRequestOptions.headers = Object.assign({}, localVarHeaderParameter, options.headers);
+
+            return {
+                url: url.format(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         * 
+         * @summary Search for roles assignable to a given scope
+         * @param {V1SearchRolesAssignableToScopeRequest} body 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        searchRolesAssignableToScope(body: V1SearchRolesAssignableToScopeRequest, options: any = {}): FetchArgs {
+            // verify required parameter 'body' is not null or undefined
+            if (body === null || body === undefined) {
+                throw new RequiredError('body','Required parameter body was null or undefined when calling searchRolesAssignableToScope.');
+            }
+            const localVarPath = `/api/v1/roles/search/by-assignability`;
+            const localVarUrlObj = url.parse(localVarPath, true);
+            const localVarRequestOptions = Object.assign({ method: 'POST' }, options);
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            // authentication BearerToken required
+            if (configuration && configuration.apiKey) {
+                const localVarApiKeyValue = typeof configuration.apiKey === 'function'
+					? configuration.apiKey("Authorization")
+					: configuration.apiKey;
+                localVarHeaderParameter["Authorization"] = localVarApiKeyValue;
+            }
+
+            localVarHeaderParameter['Content-Type'] = 'application/json';
+
+            localVarUrlObj.query = Object.assign({}, localVarUrlObj.query, localVarQueryParameter, options.query);
+            // fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
+            delete localVarUrlObj.search;
+            localVarRequestOptions.headers = Object.assign({}, localVarHeaderParameter, options.headers);
+            const needsSerialization = (<any>"V1SearchRolesAssignableToScopeRequest" !== "string") || localVarRequestOptions.headers['Content-Type'] === 'application/json';
+            localVarRequestOptions.body =  needsSerialization ? JSON.stringify(body || {}) : (body || "");
+
+            return {
+                url: url.format(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+    }
+};
+
+/**
+ * RBACApi - functional programming interface
+ * @export
+ */
+export const RBACApiFp = function(configuration?: Configuration) {
+    return {
+        /**
+         * 
+         * @summary AssignRoles adds a set of role assignments to the system.
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        assignRoles(options?: any): (fetch?: FetchAPI, basePath?: string) => Promise<V1AssignRolesResponse> {
+            const localVarFetchArgs = RBACApiFetchParamCreator(configuration).assignRoles(options);
+            return (fetch: FetchAPI = portableFetch, basePath: string = BASE_PATH) => {
+                return fetch(basePath + localVarFetchArgs.url, localVarFetchArgs.options).then((response) => {
+                    if (response.status >= 200 && response.status < 300) {
+                        return response.json();
+                    } else {
+                        throw response;
+                    }
+                });
+            };
+        },
+        /**
+         * 
+         * @summary Get the roles which are assigned to a group
+         * @param {number} groupId The id of the group to search for role assignments for
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        getRolesAssignedToGroup(groupId: number, options?: any): (fetch?: FetchAPI, basePath?: string) => Promise<V1GetRolesAssignedToGroupResponse> {
+            const localVarFetchArgs = RBACApiFetchParamCreator(configuration).getRolesAssignedToGroup(groupId, options);
+            return (fetch: FetchAPI = portableFetch, basePath: string = BASE_PATH) => {
+                return fetch(basePath + localVarFetchArgs.url, localVarFetchArgs.options).then((response) => {
+                    if (response.status >= 200 && response.status < 300) {
+                        return response.json();
+                    } else {
+                        throw response;
+                    }
+                });
+            };
+        },
+        /**
+         * 
+         * @summary Get the roles which are assigned to a user
+         * @param {number} userId The id of the user to search for role assignments for
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        getRolesAssignedToUser(userId: number, options?: any): (fetch?: FetchAPI, basePath?: string) => Promise<V1GetRolesAssignedToUserResponse> {
+            const localVarFetchArgs = RBACApiFetchParamCreator(configuration).getRolesAssignedToUser(userId, options);
+            return (fetch: FetchAPI = portableFetch, basePath: string = BASE_PATH) => {
+                return fetch(basePath + localVarFetchArgs.url, localVarFetchArgs.options).then((response) => {
+                    if (response.status >= 200 && response.status < 300) {
+                        return response.json();
+                    } else {
+                        throw response;
+                    }
+                });
+            };
+        },
+        /**
+         * 
+         * @summary Get a set of roles by id
+         * @param {V1GetRolesByIDRequest} body 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        getRolesByID(body: V1GetRolesByIDRequest, options?: any): (fetch?: FetchAPI, basePath?: string) => Promise<V1GetRolesByIDResponse> {
+            const localVarFetchArgs = RBACApiFetchParamCreator(configuration).getRolesByID(body, options);
+            return (fetch: FetchAPI = portableFetch, basePath: string = BASE_PATH) => {
+                return fetch(basePath + localVarFetchArgs.url, localVarFetchArgs.options).then((response) => {
+                    if (response.status >= 200 && response.status < 300) {
+                        return response.json();
+                    } else {
+                        throw response;
+                    }
+                });
+            };
+        },
+        /**
+         * 
+         * @summary ListRoles returns roles and groups/users granted that role.
+         * @param {V1ListRolesRequest} body 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        listRoles(body: V1ListRolesRequest, options?: any): (fetch?: FetchAPI, basePath?: string) => Promise<V1ListRolesResponse> {
+            const localVarFetchArgs = RBACApiFetchParamCreator(configuration).listRoles(body, options);
+            return (fetch: FetchAPI = portableFetch, basePath: string = BASE_PATH) => {
+                return fetch(basePath + localVarFetchArgs.url, localVarFetchArgs.options).then((response) => {
+                    if (response.status >= 200 && response.status < 300) {
+                        return response.json();
+                    } else {
+                        throw response;
+                    }
+                });
+            };
+        },
+        /**
+         * 
+         * @summary RemoveAssignments removes a set of role assignments from the system.
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        removeAssignments(options?: any): (fetch?: FetchAPI, basePath?: string) => Promise<V1RemoveAssignmentsResponse> {
+            const localVarFetchArgs = RBACApiFetchParamCreator(configuration).removeAssignments(options);
+            return (fetch: FetchAPI = portableFetch, basePath: string = BASE_PATH) => {
+                return fetch(basePath + localVarFetchArgs.url, localVarFetchArgs.options).then((response) => {
+                    if (response.status >= 200 && response.status < 300) {
+                        return response.json();
+                    } else {
+                        throw response;
+                    }
+                });
+            };
+        },
+        /**
+         * 
+         * @summary Search for roles assignable to a given scope
+         * @param {V1SearchRolesAssignableToScopeRequest} body 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        searchRolesAssignableToScope(body: V1SearchRolesAssignableToScopeRequest, options?: any): (fetch?: FetchAPI, basePath?: string) => Promise<V1SearchRolesAssignableToScopeResponse> {
+            const localVarFetchArgs = RBACApiFetchParamCreator(configuration).searchRolesAssignableToScope(body, options);
+            return (fetch: FetchAPI = portableFetch, basePath: string = BASE_PATH) => {
+                return fetch(basePath + localVarFetchArgs.url, localVarFetchArgs.options).then((response) => {
+                    if (response.status >= 200 && response.status < 300) {
+                        return response.json();
+                    } else {
+                        throw response;
+                    }
+                });
+            };
+        },
+    }
+};
+
+/**
+ * RBACApi - factory interface
+ * @export
+ */
+export const RBACApiFactory = function (configuration?: Configuration, fetch?: FetchAPI, basePath?: string) {
+    return {
+        /**
+         * 
+         * @summary AssignRoles adds a set of role assignments to the system.
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        assignRoles(options?: any) {
+            return RBACApiFp(configuration).assignRoles(options)(fetch, basePath);
+        },
+        /**
+         * 
+         * @summary Get the roles which are assigned to a group
+         * @param {number} groupId The id of the group to search for role assignments for
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        getRolesAssignedToGroup(groupId: number, options?: any) {
+            return RBACApiFp(configuration).getRolesAssignedToGroup(groupId, options)(fetch, basePath);
+        },
+        /**
+         * 
+         * @summary Get the roles which are assigned to a user
+         * @param {number} userId The id of the user to search for role assignments for
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        getRolesAssignedToUser(userId: number, options?: any) {
+            return RBACApiFp(configuration).getRolesAssignedToUser(userId, options)(fetch, basePath);
+        },
+        /**
+         * 
+         * @summary Get a set of roles by id
+         * @param {V1GetRolesByIDRequest} body 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        getRolesByID(body: V1GetRolesByIDRequest, options?: any) {
+            return RBACApiFp(configuration).getRolesByID(body, options)(fetch, basePath);
+        },
+        /**
+         * 
+         * @summary ListRoles returns roles and groups/users granted that role.
+         * @param {V1ListRolesRequest} body 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        listRoles(body: V1ListRolesRequest, options?: any) {
+            return RBACApiFp(configuration).listRoles(body, options)(fetch, basePath);
+        },
+        /**
+         * 
+         * @summary RemoveAssignments removes a set of role assignments from the system.
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        removeAssignments(options?: any) {
+            return RBACApiFp(configuration).removeAssignments(options)(fetch, basePath);
+        },
+        /**
+         * 
+         * @summary Search for roles assignable to a given scope
+         * @param {V1SearchRolesAssignableToScopeRequest} body 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        searchRolesAssignableToScope(body: V1SearchRolesAssignableToScopeRequest, options?: any) {
+            return RBACApiFp(configuration).searchRolesAssignableToScope(body, options)(fetch, basePath);
+        },
+    };
+};
+
+/**
+ * RBACApi - object-oriented interface
+ * @export
+ * @class RBACApi
+ * @extends {BaseAPI}
+ */
+export class RBACApi extends BaseAPI {
+    /**
+     * 
+     * @summary AssignRoles adds a set of role assignments to the system.
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof RBACApi
+     */
+    public assignRoles(options?: any) {
+        return RBACApiFp(this.configuration).assignRoles(options)(this.fetch, this.basePath);
+    }
+
+    /**
+     * 
+     * @summary Get the roles which are assigned to a group
+     * @param {number} groupId The id of the group to search for role assignments for
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof RBACApi
+     */
+    public getRolesAssignedToGroup(groupId: number, options?: any) {
+        return RBACApiFp(this.configuration).getRolesAssignedToGroup(groupId, options)(this.fetch, this.basePath);
+    }
+
+    /**
+     * 
+     * @summary Get the roles which are assigned to a user
+     * @param {number} userId The id of the user to search for role assignments for
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof RBACApi
+     */
+    public getRolesAssignedToUser(userId: number, options?: any) {
+        return RBACApiFp(this.configuration).getRolesAssignedToUser(userId, options)(this.fetch, this.basePath);
+    }
+
+    /**
+     * 
+     * @summary Get a set of roles by id
+     * @param {V1GetRolesByIDRequest} body 
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof RBACApi
+     */
+    public getRolesByID(body: V1GetRolesByIDRequest, options?: any) {
+        return RBACApiFp(this.configuration).getRolesByID(body, options)(this.fetch, this.basePath);
+    }
+
+    /**
+     * 
+     * @summary ListRoles returns roles and groups/users granted that role.
+     * @param {V1ListRolesRequest} body 
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof RBACApi
+     */
+    public listRoles(body: V1ListRolesRequest, options?: any) {
+        return RBACApiFp(this.configuration).listRoles(body, options)(this.fetch, this.basePath);
+    }
+
+    /**
+     * 
+     * @summary RemoveAssignments removes a set of role assignments from the system.
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof RBACApi
+     */
+    public removeAssignments(options?: any) {
+        return RBACApiFp(this.configuration).removeAssignments(options)(this.fetch, this.basePath);
+    }
+
+    /**
+     * 
+     * @summary Search for roles assignable to a given scope
+     * @param {V1SearchRolesAssignableToScopeRequest} body 
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof RBACApi
+     */
+    public searchRolesAssignableToScope(body: V1SearchRolesAssignableToScopeRequest, options?: any) {
+        return RBACApiFp(this.configuration).searchRolesAssignableToScope(body, options)(this.fetch, this.basePath);
     }
 
 }

--- a/webui/react/src/services/api-ts-sdk/api.ts
+++ b/webui/react/src/services/api-ts-sdk/api.ts
@@ -1122,6 +1122,26 @@ export interface V1ArchiveWorkspaceResponse {
 }
 
 /**
+ * AssignRolesRequest is the body of the request for the call to grant a user or group a role. It requires group_id, role_id, and either scope_workspace_id or scope_project_id.
+ * @export
+ * @interface V1AssignRolesRequest
+ */
+export interface V1AssignRolesRequest {
+    /**
+     * the set of groups being assigned to a role.
+     * @type {Array<V1GroupRoleAssignment>}
+     * @memberof V1AssignRolesRequest
+     */
+    groupRoleAssignments?: Array<V1GroupRoleAssignment>;
+    /**
+     * the set of users being assigned to a role.
+     * @type {Array<V1UserRoleAssignment>}
+     * @memberof V1AssignRolesRequest
+     */
+    userRoleAssignments?: Array<V1UserRoleAssignment>;
+}
+
+/**
  * AssignRolesResponse is the body of the request for the call to grant a user or group a role.
  * @export
  * @interface V1AssignRolesResponse
@@ -5580,6 +5600,26 @@ export interface V1RPQueueStat {
      * @memberof V1RPQueueStat
      */
     aggregates?: Array<V1AggregateQueueStats>;
+}
+
+/**
+ * RemoveAssignmentsRequest is the body of the request for the call to remove a user or group from a role.
+ * @export
+ * @interface V1RemoveAssignmentsRequest
+ */
+export interface V1RemoveAssignmentsRequest {
+    /**
+     * the set of groups being removed from a role.
+     * @type {Array<V1GroupRoleAssignment>}
+     * @memberof V1RemoveAssignmentsRequest
+     */
+    groupRoleAssignments?: Array<V1GroupRoleAssignment>;
+    /**
+     * the set of users being removed from a role.
+     * @type {Array<V1UserRoleAssignment>}
+     * @memberof V1RemoveAssignmentsRequest
+     */
+    userRoleAssignments?: Array<V1UserRoleAssignment>;
 }
 
 /**
@@ -13075,7 +13115,7 @@ export const InternalApiFetchParamCreator = function (configuration?: Configurat
         },
         /**
          * 
-         * @summary Create a group with optional members on creation
+         * @summary Create a group with optional members on creation.
          * @param {V1CreateGroupRequest} body 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -13115,7 +13155,7 @@ export const InternalApiFetchParamCreator = function (configuration?: Configurat
         },
         /**
          * 
-         * @summary Remove a group
+         * @summary Remove a group.
          * @param {number} groupId The id of the group that should be deleted.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -13354,7 +13394,7 @@ export const InternalApiFetchParamCreator = function (configuration?: Configurat
         },
         /**
          * 
-         * @summary Get a group by id
+         * @summary Get a group by id.
          * @param {number} groupId The id of the group to return.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -13391,7 +13431,7 @@ export const InternalApiFetchParamCreator = function (configuration?: Configurat
         },
         /**
          * 
-         * @summary Search for groups with optional filters
+         * @summary Search for groups with optional filters.
          * @param {V1GetGroupsRequest} body 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -14406,7 +14446,7 @@ export const InternalApiFetchParamCreator = function (configuration?: Configurat
         },
         /**
          * 
-         * @summary Update group info
+         * @summary Update group info.
          * @param {number} groupId The id of the group
          * @param {V1UpdateGroupRequest} body 
          * @param {*} [options] Override http request option.
@@ -14679,7 +14719,7 @@ export const InternalApiFp = function(configuration?: Configuration) {
         },
         /**
          * 
-         * @summary Create a group with optional members on creation
+         * @summary Create a group with optional members on creation.
          * @param {V1CreateGroupRequest} body 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -14698,7 +14738,7 @@ export const InternalApiFp = function(configuration?: Configuration) {
         },
         /**
          * 
-         * @summary Remove a group
+         * @summary Remove a group.
          * @param {number} groupId The id of the group that should be deleted.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -14801,7 +14841,7 @@ export const InternalApiFp = function(configuration?: Configuration) {
         },
         /**
          * 
-         * @summary Get a group by id
+         * @summary Get a group by id.
          * @param {number} groupId The id of the group to return.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -14820,7 +14860,7 @@ export const InternalApiFp = function(configuration?: Configuration) {
         },
         /**
          * 
-         * @summary Search for groups with optional filters
+         * @summary Search for groups with optional filters.
          * @param {V1GetGroupsRequest} body 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -15255,7 +15295,7 @@ export const InternalApiFp = function(configuration?: Configuration) {
         },
         /**
          * 
-         * @summary Update group info
+         * @summary Update group info.
          * @param {number} groupId The id of the group
          * @param {V1UpdateGroupRequest} body 
          * @param {*} [options] Override http request option.
@@ -15400,7 +15440,7 @@ export const InternalApiFactory = function (configuration?: Configuration, fetch
         },
         /**
          * 
-         * @summary Create a group with optional members on creation
+         * @summary Create a group with optional members on creation.
          * @param {V1CreateGroupRequest} body 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -15410,7 +15450,7 @@ export const InternalApiFactory = function (configuration?: Configuration, fetch
         },
         /**
          * 
-         * @summary Remove a group
+         * @summary Remove a group.
          * @param {number} groupId The id of the group that should be deleted.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -15468,7 +15508,7 @@ export const InternalApiFactory = function (configuration?: Configuration, fetch
         },
         /**
          * 
-         * @summary Get a group by id
+         * @summary Get a group by id.
          * @param {number} groupId The id of the group to return.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -15478,7 +15518,7 @@ export const InternalApiFactory = function (configuration?: Configuration, fetch
         },
         /**
          * 
-         * @summary Search for groups with optional filters
+         * @summary Search for groups with optional filters.
          * @param {V1GetGroupsRequest} body 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -15724,7 +15764,7 @@ export const InternalApiFactory = function (configuration?: Configuration, fetch
         },
         /**
          * 
-         * @summary Update group info
+         * @summary Update group info.
          * @param {number} groupId The id of the group
          * @param {V1UpdateGroupRequest} body 
          * @param {*} [options] Override http request option.
@@ -15870,7 +15910,7 @@ export class InternalApi extends BaseAPI {
 
     /**
      * 
-     * @summary Create a group with optional members on creation
+     * @summary Create a group with optional members on creation.
      * @param {V1CreateGroupRequest} body 
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
@@ -15882,7 +15922,7 @@ export class InternalApi extends BaseAPI {
 
     /**
      * 
-     * @summary Remove a group
+     * @summary Remove a group.
      * @param {number} groupId The id of the group that should be deleted.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
@@ -15950,7 +15990,7 @@ export class InternalApi extends BaseAPI {
 
     /**
      * 
-     * @summary Get a group by id
+     * @summary Get a group by id.
      * @param {number} groupId The id of the group to return.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
@@ -15962,7 +16002,7 @@ export class InternalApi extends BaseAPI {
 
     /**
      * 
-     * @summary Search for groups with optional filters
+     * @summary Search for groups with optional filters.
      * @param {V1GetGroupsRequest} body 
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
@@ -16250,7 +16290,7 @@ export class InternalApi extends BaseAPI {
 
     /**
      * 
-     * @summary Update group info
+     * @summary Update group info.
      * @param {number} groupId The id of the group
      * @param {V1UpdateGroupRequest} body 
      * @param {*} [options] Override http request option.
@@ -19324,10 +19364,15 @@ export const RBACApiFetchParamCreator = function (configuration?: Configuration)
         /**
          * 
          * @summary AssignRoles adds a set of role assignments to the system.
+         * @param {V1AssignRolesRequest} body 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        assignRoles(options: any = {}): FetchArgs {
+        assignRoles(body: V1AssignRolesRequest, options: any = {}): FetchArgs {
+            // verify required parameter 'body' is not null or undefined
+            if (body === null || body === undefined) {
+                throw new RequiredError('body','Required parameter body was null or undefined when calling assignRoles.');
+            }
             const localVarPath = `/api/v1/roles/add-assignments`;
             const localVarUrlObj = url.parse(localVarPath, true);
             const localVarRequestOptions = Object.assign({ method: 'POST' }, options);
@@ -19342,10 +19387,14 @@ export const RBACApiFetchParamCreator = function (configuration?: Configuration)
                 localVarHeaderParameter["Authorization"] = localVarApiKeyValue;
             }
 
+            localVarHeaderParameter['Content-Type'] = 'application/json';
+
             localVarUrlObj.query = Object.assign({}, localVarUrlObj.query, localVarQueryParameter, options.query);
             // fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
             delete localVarUrlObj.search;
             localVarRequestOptions.headers = Object.assign({}, localVarHeaderParameter, options.headers);
+            const needsSerialization = (<any>"V1AssignRolesRequest" !== "string") || localVarRequestOptions.headers['Content-Type'] === 'application/json';
+            localVarRequestOptions.body =  needsSerialization ? JSON.stringify(body || {}) : (body || "");
 
             return {
                 url: url.format(localVarUrlObj),
@@ -19354,7 +19403,7 @@ export const RBACApiFetchParamCreator = function (configuration?: Configuration)
         },
         /**
          * 
-         * @summary Get the roles which are assigned to a group
+         * @summary Get the roles which are assigned to a group.
          * @param {number} groupId The id of the group to search for role assignments for
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -19391,7 +19440,7 @@ export const RBACApiFetchParamCreator = function (configuration?: Configuration)
         },
         /**
          * 
-         * @summary Get the roles which are assigned to a user
+         * @summary Get the roles which are assigned to a user.
          * @param {number} userId The id of the user to search for role assignments for
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -19428,7 +19477,7 @@ export const RBACApiFetchParamCreator = function (configuration?: Configuration)
         },
         /**
          * 
-         * @summary Get a set of roles by id
+         * @summary Get a set of roles with the corresponding IDs.
          * @param {V1GetRolesByIDRequest} body 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -19509,10 +19558,15 @@ export const RBACApiFetchParamCreator = function (configuration?: Configuration)
         /**
          * 
          * @summary RemoveAssignments removes a set of role assignments from the system.
+         * @param {V1RemoveAssignmentsRequest} body 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        removeAssignments(options: any = {}): FetchArgs {
+        removeAssignments(body: V1RemoveAssignmentsRequest, options: any = {}): FetchArgs {
+            // verify required parameter 'body' is not null or undefined
+            if (body === null || body === undefined) {
+                throw new RequiredError('body','Required parameter body was null or undefined when calling removeAssignments.');
+            }
             const localVarPath = `/api/v1/roles/remove-assignments`;
             const localVarUrlObj = url.parse(localVarPath, true);
             const localVarRequestOptions = Object.assign({ method: 'POST' }, options);
@@ -19527,10 +19581,14 @@ export const RBACApiFetchParamCreator = function (configuration?: Configuration)
                 localVarHeaderParameter["Authorization"] = localVarApiKeyValue;
             }
 
+            localVarHeaderParameter['Content-Type'] = 'application/json';
+
             localVarUrlObj.query = Object.assign({}, localVarUrlObj.query, localVarQueryParameter, options.query);
             // fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
             delete localVarUrlObj.search;
             localVarRequestOptions.headers = Object.assign({}, localVarHeaderParameter, options.headers);
+            const needsSerialization = (<any>"V1RemoveAssignmentsRequest" !== "string") || localVarRequestOptions.headers['Content-Type'] === 'application/json';
+            localVarRequestOptions.body =  needsSerialization ? JSON.stringify(body || {}) : (body || "");
 
             return {
                 url: url.format(localVarUrlObj),
@@ -19539,7 +19597,7 @@ export const RBACApiFetchParamCreator = function (configuration?: Configuration)
         },
         /**
          * 
-         * @summary Search for roles assignable to a given scope
+         * @summary Search for roles assignable to a given scope.
          * @param {V1SearchRolesAssignableToScopeRequest} body 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -19589,11 +19647,12 @@ export const RBACApiFp = function(configuration?: Configuration) {
         /**
          * 
          * @summary AssignRoles adds a set of role assignments to the system.
+         * @param {V1AssignRolesRequest} body 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        assignRoles(options?: any): (fetch?: FetchAPI, basePath?: string) => Promise<V1AssignRolesResponse> {
-            const localVarFetchArgs = RBACApiFetchParamCreator(configuration).assignRoles(options);
+        assignRoles(body: V1AssignRolesRequest, options?: any): (fetch?: FetchAPI, basePath?: string) => Promise<V1AssignRolesResponse> {
+            const localVarFetchArgs = RBACApiFetchParamCreator(configuration).assignRoles(body, options);
             return (fetch: FetchAPI = portableFetch, basePath: string = BASE_PATH) => {
                 return fetch(basePath + localVarFetchArgs.url, localVarFetchArgs.options).then((response) => {
                     if (response.status >= 200 && response.status < 300) {
@@ -19606,7 +19665,7 @@ export const RBACApiFp = function(configuration?: Configuration) {
         },
         /**
          * 
-         * @summary Get the roles which are assigned to a group
+         * @summary Get the roles which are assigned to a group.
          * @param {number} groupId The id of the group to search for role assignments for
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -19625,7 +19684,7 @@ export const RBACApiFp = function(configuration?: Configuration) {
         },
         /**
          * 
-         * @summary Get the roles which are assigned to a user
+         * @summary Get the roles which are assigned to a user.
          * @param {number} userId The id of the user to search for role assignments for
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -19644,7 +19703,7 @@ export const RBACApiFp = function(configuration?: Configuration) {
         },
         /**
          * 
-         * @summary Get a set of roles by id
+         * @summary Get a set of roles with the corresponding IDs.
          * @param {V1GetRolesByIDRequest} body 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -19683,11 +19742,12 @@ export const RBACApiFp = function(configuration?: Configuration) {
         /**
          * 
          * @summary RemoveAssignments removes a set of role assignments from the system.
+         * @param {V1RemoveAssignmentsRequest} body 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        removeAssignments(options?: any): (fetch?: FetchAPI, basePath?: string) => Promise<V1RemoveAssignmentsResponse> {
-            const localVarFetchArgs = RBACApiFetchParamCreator(configuration).removeAssignments(options);
+        removeAssignments(body: V1RemoveAssignmentsRequest, options?: any): (fetch?: FetchAPI, basePath?: string) => Promise<V1RemoveAssignmentsResponse> {
+            const localVarFetchArgs = RBACApiFetchParamCreator(configuration).removeAssignments(body, options);
             return (fetch: FetchAPI = portableFetch, basePath: string = BASE_PATH) => {
                 return fetch(basePath + localVarFetchArgs.url, localVarFetchArgs.options).then((response) => {
                     if (response.status >= 200 && response.status < 300) {
@@ -19700,7 +19760,7 @@ export const RBACApiFp = function(configuration?: Configuration) {
         },
         /**
          * 
-         * @summary Search for roles assignable to a given scope
+         * @summary Search for roles assignable to a given scope.
          * @param {V1SearchRolesAssignableToScopeRequest} body 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -19729,15 +19789,16 @@ export const RBACApiFactory = function (configuration?: Configuration, fetch?: F
         /**
          * 
          * @summary AssignRoles adds a set of role assignments to the system.
+         * @param {V1AssignRolesRequest} body 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        assignRoles(options?: any) {
-            return RBACApiFp(configuration).assignRoles(options)(fetch, basePath);
+        assignRoles(body: V1AssignRolesRequest, options?: any) {
+            return RBACApiFp(configuration).assignRoles(body, options)(fetch, basePath);
         },
         /**
          * 
-         * @summary Get the roles which are assigned to a group
+         * @summary Get the roles which are assigned to a group.
          * @param {number} groupId The id of the group to search for role assignments for
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -19747,7 +19808,7 @@ export const RBACApiFactory = function (configuration?: Configuration, fetch?: F
         },
         /**
          * 
-         * @summary Get the roles which are assigned to a user
+         * @summary Get the roles which are assigned to a user.
          * @param {number} userId The id of the user to search for role assignments for
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -19757,7 +19818,7 @@ export const RBACApiFactory = function (configuration?: Configuration, fetch?: F
         },
         /**
          * 
-         * @summary Get a set of roles by id
+         * @summary Get a set of roles with the corresponding IDs.
          * @param {V1GetRolesByIDRequest} body 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -19778,15 +19839,16 @@ export const RBACApiFactory = function (configuration?: Configuration, fetch?: F
         /**
          * 
          * @summary RemoveAssignments removes a set of role assignments from the system.
+         * @param {V1RemoveAssignmentsRequest} body 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        removeAssignments(options?: any) {
-            return RBACApiFp(configuration).removeAssignments(options)(fetch, basePath);
+        removeAssignments(body: V1RemoveAssignmentsRequest, options?: any) {
+            return RBACApiFp(configuration).removeAssignments(body, options)(fetch, basePath);
         },
         /**
          * 
-         * @summary Search for roles assignable to a given scope
+         * @summary Search for roles assignable to a given scope.
          * @param {V1SearchRolesAssignableToScopeRequest} body 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -19807,17 +19869,18 @@ export class RBACApi extends BaseAPI {
     /**
      * 
      * @summary AssignRoles adds a set of role assignments to the system.
+     * @param {V1AssignRolesRequest} body 
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof RBACApi
      */
-    public assignRoles(options?: any) {
-        return RBACApiFp(this.configuration).assignRoles(options)(this.fetch, this.basePath);
+    public assignRoles(body: V1AssignRolesRequest, options?: any) {
+        return RBACApiFp(this.configuration).assignRoles(body, options)(this.fetch, this.basePath);
     }
 
     /**
      * 
-     * @summary Get the roles which are assigned to a group
+     * @summary Get the roles which are assigned to a group.
      * @param {number} groupId The id of the group to search for role assignments for
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
@@ -19829,7 +19892,7 @@ export class RBACApi extends BaseAPI {
 
     /**
      * 
-     * @summary Get the roles which are assigned to a user
+     * @summary Get the roles which are assigned to a user.
      * @param {number} userId The id of the user to search for role assignments for
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
@@ -19841,7 +19904,7 @@ export class RBACApi extends BaseAPI {
 
     /**
      * 
-     * @summary Get a set of roles by id
+     * @summary Get a set of roles with the corresponding IDs.
      * @param {V1GetRolesByIDRequest} body 
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
@@ -19866,17 +19929,18 @@ export class RBACApi extends BaseAPI {
     /**
      * 
      * @summary RemoveAssignments removes a set of role assignments from the system.
+     * @param {V1RemoveAssignmentsRequest} body 
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof RBACApi
      */
-    public removeAssignments(options?: any) {
-        return RBACApiFp(this.configuration).removeAssignments(options)(this.fetch, this.basePath);
+    public removeAssignments(body: V1RemoveAssignmentsRequest, options?: any) {
+        return RBACApiFp(this.configuration).removeAssignments(body, options)(this.fetch, this.basePath);
     }
 
     /**
      * 
-     * @summary Search for roles assignable to a given scope
+     * @summary Search for roles assignable to a given scope.
      * @param {V1SearchRolesAssignableToScopeRequest} body 
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}


### PR DESCRIPTION
## Description

Addresses the OSS portion of [DET-7867] and [DET-8000] by adding a stub version of the RBAC API and its types.

## Test Plan

Outside of EE, the RBAC API should be available, but making requests to its endpoints should result in the error message "Determined Enterprise Edition is required for this functionality." Additionally, creating a new group with an owner should add the owning user to the group regardless of if the user is passed in as one of the users to add to the group.

<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-7867]: https://determinedai.atlassian.net/browse/DET-7867?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DET-8000]: https://determinedai.atlassian.net/browse/DET-8000?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ