### PR TITLE
fix: .detignore interprets wildcards like .gitignore [DET-7094]

### DIFF
--- a/harness/determined/common/context.py
+++ b/harness/determined/common/context.py
@@ -133,8 +133,8 @@ def read_v1_context(
             file_path = pathlib.Path(parent).joinpath(file)
             file_rel_path = file_path.relative_to(root_path)
 
-            # If the file is the .detignore file, it matches one of the
-            #  paths specified in .detignore, or if its parent directory does, then ignore it.
+            # If the file is the .detignore file or matches one of the
+            # paths specified in .detignore, then ignore it.
             if file_rel_path.name == ".detignore":
                 continue
             if ignore_spec.match_file(str(file_rel_path)):

--- a/harness/determined/common/context.py
+++ b/harness/determined/common/context.py
@@ -125,7 +125,7 @@ def read_v1_context(
             entry_path = dir_rel_path.as_posix()
 
             add_item(v1File_from_local_dir(entry_path, dir_path))
-        # We can modify dirs in-place so that ignored directories are not recused into
+        # We can modify dirs in-place so that we do not recurse into ignored directories
         #  See https://docs.python.org/3/library/os.html#os.walk
         dirs[:] = keep_dirs
 

--- a/harness/determined/common/context.py
+++ b/harness/determined/common/context.py
@@ -113,7 +113,9 @@ def read_v1_context(
             dir_path = pathlib.Path(parent).joinpath(directory)
             dir_rel_path = dir_path.relative_to(root_path)
 
-            # If the file matches any path specified in .detignore, then ignore it.
+            # If the directory matches any path specified in .detignore, then ignore it.
+            if ignore_spec.match_file(str(dir_rel_path)):
+                continue
             if ignore_spec.match_file(str(dir_rel_path) + "/"):
                 continue
 
@@ -126,12 +128,17 @@ def read_v1_context(
         for file in files:
             file_path = pathlib.Path(parent).joinpath(file)
             file_rel_path = file_path.relative_to(root_path)
+            parent_rel_path = pathlib.Path(parent).relative_to(root_path)
 
-            # If the file is the .detignore file or matches one of the
-            # paths specified in .detignore, then ignore it.
+            # If the file is the .detignore file, it matches one of the
+            #  paths specified in .detignore, or if its parent directory does, then ignore it.
             if file_rel_path.name == ".detignore":
                 continue
             if ignore_spec.match_file(str(file_rel_path)):
+                continue
+            if ignore_spec.match_file(str(parent_rel_path)):
+                continue
+            if ignore_spec.match_file(str(parent_rel_path) + "/"):
                 continue
 
             # Determined only supports POSIX-style file paths.  Use as_posix() in case this code

--- a/harness/tests/cli/test_cli.py
+++ b/harness/tests/cli/test_cli.py
@@ -229,6 +229,7 @@ def test_read_context_with_detignore_wildcard(tmp_path: Path) -> None:
             "dir/file.py": "",
             "dir/subdir/A.py": "",
             "dir/subdir/B.py": "",
+            "dir/subdir/subdir/subdir/C.py": "",
             ".detignore": "\ndir/sub*/\n",
         },
     ) as tree:
@@ -241,6 +242,7 @@ def test_read_context_with_detignore_wildcard(tmp_path: Path) -> None:
             "dir/file.py": "",
             "dir/subdir/A.py": "",
             "dir/subdir/B.py": "",
+            "dir/subdir/subdir/subdir/C.py": "",
             ".detignore": "\ndir/sub*\n",
         },
     ) as tree:
@@ -253,6 +255,7 @@ def test_read_context_with_detignore_wildcard(tmp_path: Path) -> None:
             "dir/file.py": "",
             "dir/subdir/A.py": "",
             "dir/subdir/B.py": "",
+            "dir/subdir/subdir/subdir/C.py": "",
             ".detignore": "\ndir/*/\n",
         },
     ) as tree:
@@ -265,6 +268,7 @@ def test_read_context_with_detignore_wildcard(tmp_path: Path) -> None:
             "dir/file.py": "",
             "dir/subdir/A.py": "",
             "dir/subdir/B.py": "",
+            "dir/subdir/subdir/subdir/C.py": "",
             ".detignore": "\ndir/*\n",
         },
     ) as tree:

--- a/harness/tests/cli/test_cli.py
+++ b/harness/tests/cli/test_cli.py
@@ -222,6 +222,32 @@ def test_read_context_with_detignore_subdirs(tmp_path: Path) -> None:
         assert {f["path"] for f in model_def} == {"A.py", "B.py"}
 
 
+def test_read_context_with_detignore_wildcard(tmp_path: Path) -> None:
+    with FileTree(
+        tmp_path,
+        {
+            "dir/file.py": "",
+            "dir/subdir/A.py": "",
+            "dir/subdir/B.py": "",
+            ".detignore": "\ndir/*/\n",
+        },
+    ) as tree:
+        model_def = context.read_legacy_context(tree)
+        assert {f["path"] for f in model_def} == {"dir", "dir/file.py"}
+
+    with FileTree(
+        tmp_path,
+        {
+            "dir/file.py": "",
+            "dir/subdir/A.py": "",
+            "dir/subdir/B.py": "",
+            ".detignore": "\ndir/*\n",
+        },
+    ) as tree:
+        model_def = context.read_legacy_context(tree)
+        assert {f["path"] for f in model_def} == {"dir"}
+
+
 def test_read_context_ignore_pycaches(tmp_path: Path) -> None:
     with FileTree(
         tmp_path,

--- a/harness/tests/cli/test_cli.py
+++ b/harness/tests/cli/test_cli.py
@@ -229,6 +229,30 @@ def test_read_context_with_detignore_wildcard(tmp_path: Path) -> None:
             "dir/file.py": "",
             "dir/subdir/A.py": "",
             "dir/subdir/B.py": "",
+            ".detignore": "\ndir/sub*/\n",
+        },
+    ) as tree:
+        model_def = context.read_legacy_context(tree)
+        assert {f["path"] for f in model_def} == {"dir", "dir/file.py"}
+
+    with FileTree(
+        tmp_path,
+        {
+            "dir/file.py": "",
+            "dir/subdir/A.py": "",
+            "dir/subdir/B.py": "",
+            ".detignore": "\ndir/sub*\n",
+        },
+    ) as tree:
+        model_def = context.read_legacy_context(tree)
+        assert {f["path"] for f in model_def} == {"dir", "dir/file.py"}
+
+    with FileTree(
+        tmp_path,
+        {
+            "dir/file.py": "",
+            "dir/subdir/A.py": "",
+            "dir/subdir/B.py": "",
             ".detignore": "\ndir/*/\n",
         },
     ) as tree:


### PR DESCRIPTION
## Description

There is a bug in how Determined deals with wildcard patterns in `.detignore`.


## Test Plan

The new `test_cli.test_read_context_with_detignore_wildcard` should be run by CircleCI and should pass.



## Checklist
- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.
- [ ] If modifying `/webui/react/src/shared/` verify `make -C webui/react test-shared` passes.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ