### PR TITLE
fix: make experiment names unique across test runs

### DIFF
--- a/e2e_tests/tests/experiment/test_custom_searcher.py
+++ b/e2e_tests/tests/experiment/test_custom_searcher.py
@@ -1,6 +1,7 @@
 import logging
 import subprocess
 import tempfile
+import time
 from pathlib import Path
 from typing import List, Optional
 
@@ -18,6 +19,8 @@ from tests.fixtures.custom_searcher.searchers import (
     RandomSearchMethod,
     SingleSearchMethod,
 )
+
+TIMESTAMP = int(time.time())
 
 
 @pytest.mark.e2e_cpu
@@ -80,25 +83,25 @@ def test_run_random_searcher_exp() -> None:
 @pytest.mark.parametrize(
     "config_name,exp_name,exception_points",
     [
-        ("core_api_model.yaml", "custom-searcher-random-test", []),
+        ("core_api_model.yaml", f"custom-searcher-random-test-{TIMESTAMP}", []),
         (
             "core_api_model.yaml",
-            "custom-searcher-random-test-fail1",
+            f"custom-searcher-random-test-fail1-{TIMESTAMP}",
             ["initial_operations_start", "progress_middle", "on_trial_closed_shutdown"],
         ),
         (
             "core_api_model.yaml",
-            "custom-searcher-random-test-fail2",
+            f"custom-searcher-random-test-fail2-{TIMESTAMP}",
             ["on_validation_completed", "on_trial_closed_end", "on_trial_created_5"],
         ),
         (
             "core_api_model.yaml",
-            "custom-searcher-random-test-fail3",
+            f"custom-searcher-random-test-fail3-{TIMESTAMP}",
             ["on_trial_created", "after_save"],
         ),
         (
             "core_api_model.yaml",
-            "custom-searcher-random-test-fail5",
+            f"custom-searcher-random-test-fail5-{TIMESTAMP}",
             [
                 "on_trial_created",
                 "after_save",
@@ -110,12 +113,12 @@ def test_run_random_searcher_exp() -> None:
         ("noop.yaml", "custom-searcher-random-test-noop", []),
         (
             "noop.yaml",
-            "custom-searcher-random-test-noop-fail1",
+            f"custom-searcher-random-test-noop-fail1-{TIMESTAMP}",
             ["initial_operations_start", "progress_middle", "on_trial_closed_shutdown"],
         ),
         (
             "noop.yaml",
-            "custom-searcher-random-test-noop-fail2",
+            f"custom-searcher-random-test-noop-fail2-{TIMESTAMP}",
             [
                 "on_trial_created",
                 "after_save",
@@ -303,12 +306,12 @@ def test_run_asha_batches_exp(tmp_path: Path) -> None:
 @pytest.mark.parametrize(
     "config_name,exp_name,exception_points",
     [
-        ("core_api_model.yaml", "custom-searcher-asha-test", []),
+        ("core_api_model.yaml", f"custom-searcher-asha-test-{TIMESTAMP}", []),
         (  # test fail on initialization
             # test single resubmit of operations
             # test resumption on fail before saving
             "core_api_model.yaml",
-            "custom-searcher-asha-test-fail1",
+            f"custom-searcher-asha-test-fail1-{TIMESTAMP}",
             [
                 "initial_operations_start",
                 "after_save",
@@ -318,7 +321,7 @@ def test_run_asha_batches_exp(tmp_path: Path) -> None:
         (  # test resubmitting operations multiple times
             # test fail on shutdown
             "core_api_model.yaml",
-            "custom-searcher-asha-test-fail2",
+            f"custom-searcher-asha-test-fail2-{TIMESTAMP}",
             [
                 "on_validation_completed",
                 "after_save",
@@ -327,10 +330,10 @@ def test_run_asha_batches_exp(tmp_path: Path) -> None:
                 "shutdown",
             ],
         ),
-        ("noop.yaml", "custom-searcher-asha-noop-test", []),
+        ("noop.yaml", f"custom-searcher-asha-noop-test-{TIMESTAMP}", []),
         (
             "noop.yaml",
-            "custom-searcher-asha-test-noop-fail1",
+            f"custom-searcher-asha-test-noop-fail1-{TIMESTAMP}",
             [
                 "initial_operations_start",
                 "after_save",

--- a/e2e_tests/tests/experiment/test_custom_searcher.py
+++ b/e2e_tests/tests/experiment/test_custom_searcher.py
@@ -110,7 +110,7 @@ def test_run_random_searcher_exp() -> None:
                 "after_save",
             ],
         ),
-        ("noop.yaml", "custom-searcher-random-test-noop", []),
+        ("noop.yaml", f"custom-searcher-random-test-noop-{TIMESTAMP}", []),
         (
             "noop.yaml",
             f"custom-searcher-random-test-noop-fail1-{TIMESTAMP}",

--- a/master/internal/api_experiment.go
+++ b/master/internal/api_experiment.go
@@ -159,7 +159,6 @@ func (a *apiServer) PostSearcherOperations(ctx context.Context,
 	req *apiv1.PostSearcherOperationsRequest) (
 	resp *apiv1.PostSearcherOperationsResponse, err error,
 ) {
-
 	_, _, err = a.getExperimentAndCheckCanDoActions(ctx, int(req.ExperimentId), false,
 		expauth.AuthZProvider.Get().CanRunCustomSearch)
 	if err != nil {

--- a/master/internal/mocks/authz_experiment_iface.go
+++ b/master/internal/mocks/authz_experiment_iface.go
@@ -136,6 +136,20 @@ func (_m *ExperimentAuthZ) CanPreviewHPSearch(curUser model.User) error {
 	return r0
 }
 
+// CanRunCustomSearch provides a mock function with given fields: curUser, e
+func (_m *ExperimentAuthZ) CanRunCustomSearch(curUser model.User, e *model.Experiment) error {
+	ret := _m.Called(curUser, e)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(model.User, *model.Experiment) error); ok {
+		r0 = rf(curUser, e)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // CanSetExperimentsCheckpointGCPolicy provides a mock function with given fields: curUser, e
 func (_m *ExperimentAuthZ) CanSetExperimentsCheckpointGCPolicy(curUser model.User, e *model.Experiment) error {
 	ret := _m.Called(curUser, e)


### PR DESCRIPTION
## Description

When I run custom searcher tests multiple times _locally_ they fail after the first run because experiments with expected names already exist (they have been created by previous runs). This does not affect circleci but is still quite annoying:

```
FAILED tests/experiment/test_custom_searcher.py::test_run_random_searcher_exp_core_api[core_api_model.yaml-custom-searcher-random-test-exception_points0] - assert 6 == 1
FAILED tests/experiment/test_custom_searcher.py::test_run_random_searcher_exp_core_api[core_api_model.yaml-custom-searcher-random-test-fail1-exception_points1] - assert 2 == 1
FAILED tests/experiment/test_custom_searcher.py::test_run_random_searcher_exp_core_api[core_api_model.yaml-custom-searcher-random-test-fail2-exception_points2] - assert 2 == 1
FAILED tests/experiment/test_custom_searcher.py::test_run_random_searcher_exp_core_api[core_api_model.yaml-custom-searcher-random-test-fail3-exception_points3] - assert 2 == 1
FAILED tests/experiment/test_custom_searcher.py::test_run_random_searcher_exp_core_api[core_api_model.yaml-custom-searcher-random-test-fail5-exception_points4] - assert 2 == 1
FAILED tests/experiment/test_custom_searcher.py::test_run_asha_searcher_exp_core_api[core_api_model.yaml-custom-searcher-asha-test-exception_points0] - assert 4 == 1
FAILED tests/experiment/test_custom_searcher.py::test_run_asha_searcher_exp_core_api[core_api_model.yaml-custom-searcher-asha-test-fail1-exception_points1] - assert 2 == 1
FAILED tests/experiment/test_custom_searcher.py::test_run_asha_searcher_exp_core_api[core_api_model.yaml-custom-searcher-asha-test-fail2-exception_points2] - assert 2 == 1
```

## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions about this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist
- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.
- [ ] If modifying `/webui/react/src/shared/` verify `make -C webui/react test-shared` passes.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
