### PR TITLE
feat: add cache control headers to static web assets [DET-7450]

### DIFF
--- a/master/internal/core.go
+++ b/master/internal/core.go
@@ -74,6 +74,7 @@ const (
 	maxConcurrentRestores = 10
 	defaultAskTimeout     = 2 * time.Second
 	webuiBaseRoute        = "/det"
+	
 )
 
 // staticWebDirectoryPaths are the locations of static files that comprise the webui.
@@ -722,6 +723,7 @@ func updateClusterHeartbeat(ctx context.Context, db *db.PgDB) {
 	}
 }
 
+
 func (m *Master) postTaskLogs(c echo.Context) (interface{}, error) {
 	var logs []*model.TaskLog
 	if err := json.NewDecoder(c.Request().Body).Decode(&logs); err != nil {
@@ -970,6 +972,7 @@ func (m *Master) Run(ctx context.Context) error {
 	webuiGroup := m.echo.Group(webuiBaseRoute)
 	webuiGroup.File("/", reactIndex)
 	webuiGroup.GET("/*", func(c echo.Context) error {
+
 		groupPath := strings.TrimPrefix(c.Request().URL.Path, webuiBaseRoute+"/")
 		requestedFile := filepath.Join(reactRoot, groupPath)
 		// We do a simple check against directory traversal attacks.
@@ -994,13 +997,18 @@ func (m *Master) Run(ctx context.Context) error {
 		default:
 			hasMatchingFile = !stat.IsDir()
 		}
+
+		cacheForever := regexp.MustCompile(`.(js|css|woff2|woff)$`)
+		cacheShortly := regexp.MustCompile(`.(ico)$`)
+		
+		if ca
+
 		if hasMatchingFile {
 			return c.File(requestedFile)
 		}
 
 		return c.File(reactIndex)
 	})
-
 	m.echo.Static("/api/v1/api.swagger.json",
 		filepath.Join(m.config.Root, "swagger/determined/api/v1/api.swagger.json"))
 

--- a/master/internal/core.go
+++ b/master/internal/core.go
@@ -1005,9 +1005,6 @@ func (m *Master) Run(ctx context.Context) error {
 		} else if cacheFileShortTerm.MatchString(requestedFile) {
 			c.Response().Header().Set("cache-control", "max-age=600")
 		}
-		
-
-		
 
 		if hasMatchingFile {
 			return c.File(requestedFile)

--- a/master/internal/core.go
+++ b/master/internal/core.go
@@ -74,7 +74,6 @@ const (
 	maxConcurrentRestores = 10
 	defaultAskTimeout     = 2 * time.Second
 	webuiBaseRoute        = "/det"
-	
 )
 
 // staticWebDirectoryPaths are the locations of static files that comprise the webui.
@@ -723,7 +722,6 @@ func updateClusterHeartbeat(ctx context.Context, db *db.PgDB) {
 	}
 }
 
-
 func (m *Master) postTaskLogs(c echo.Context) (interface{}, error) {
 	var logs []*model.TaskLog
 	if err := json.NewDecoder(c.Request().Body).Decode(&logs); err != nil {
@@ -972,7 +970,6 @@ func (m *Master) Run(ctx context.Context) error {
 	webuiGroup := m.echo.Group(webuiBaseRoute)
 	webuiGroup.File("/", reactIndex)
 	webuiGroup.GET("/*", func(c echo.Context) error {
-
 		groupPath := strings.TrimPrefix(c.Request().URL.Path, webuiBaseRoute+"/")
 		requestedFile := filepath.Join(reactRoot, groupPath)
 		// We do a simple check against directory traversal attacks.
@@ -1018,6 +1015,7 @@ func (m *Master) Run(ctx context.Context) error {
 
 		return c.File(reactIndex)
 	})
+
 	m.echo.Static("/api/v1/api.swagger.json",
 		filepath.Join(m.config.Root, "swagger/determined/api/v1/api.swagger.json"))
 

--- a/master/internal/core.go
+++ b/master/internal/core.go
@@ -998,7 +998,7 @@ func (m *Master) Run(ctx context.Context) error {
 		// Files that receive a unique hash when bundled and deployed can be cached forever
 		// Other static files should only be cached for a short period of time
 		cacheFileLongTerm := regexp.MustCompile(`.(chunk\.(css|js)|woff2|woff)$`)
-		cacheFileShortTerm := regexp.MustCompile(`.(ico|png|jpe*g|gif|svg)$`)
+		cacheFileShortTerm := regexp.MustCompile(`.(antd.\S+(.css)|ico|png|jpe*g|gif|svg)$`)
 
 		if cacheFileLongTerm.MatchString(requestedFile) {
 			c.Response().Header().Set("cache-control", "max-age=31536000")

--- a/master/internal/core.go
+++ b/master/internal/core.go
@@ -1001,9 +1001,9 @@ func (m *Master) Run(ctx context.Context) error {
 		cacheFileShortTerm := regexp.MustCompile(`.(antd.\S+(.css)|ico|png|jpe*g|gif|svg)$`)
 
 		if cacheFileLongTerm.MatchString(requestedFile) {
-			c.Response().Header().Set("cache-control", "max-age=31536000")
+			c.Response().Header().Set("cache-control", "public, max-age=31536000")
 		} else if cacheFileShortTerm.MatchString(requestedFile) {
-			c.Response().Header().Set("cache-control", "max-age=600")
+			c.Response().Header().Set("cache-control", "public, max-age=600")
 		}
 
 		if hasMatchingFile {

--- a/master/internal/core.go
+++ b/master/internal/core.go
@@ -998,10 +998,19 @@ func (m *Master) Run(ctx context.Context) error {
 			hasMatchingFile = !stat.IsDir()
 		}
 
-		cacheForever := regexp.MustCompile(`.(js|css|woff2|woff)$`)
-		cacheShortly := regexp.MustCompile(`.(ico)$`)
+		// Files that receive a unique hash when bundled and deployed can be cached forever
+		// Other static files should only be cached for a short period of time
+		cacheFileLongTerm := regexp.MustCompile(`.(chunk\.(css|js)|woff2|woff)$`)
+		cacheFileShortTerm := regexp.MustCompile(`.(ico|png|jpe*g|gif|svg)$`)
+
+		if cacheFileLongTerm.MatchString(requestedFile) {
+			c.Response().Header().Set("cache-control", "max-age=31536000")
+		} else if cacheFileShortTerm.MatchString(requestedFile) {
+			c.Response().Header().Set("cache-control", "max-age=600")
+		}
 		
-		if ca
+
+		
 
 		if hasMatchingFile {
 			return c.File(requestedFile)


### PR DESCRIPTION
## Description

feat: add cache control headers to static web assets [DET-7450]

Currently we are not sending any cache-control headers with server responses for static assets for the WebUI. This change 
will add cache control headers to static assets. 
Assets that are given a unique filename per deployment we can cache "forever", one year according to [RFC 2616 14.21](https://www.ietf.org/rfc/rfc2616.txt). Assets that we may expect to change regularly such as image files we will only cache for a short period of 5 minutes.

![Screen Shot 2022-09-12 at 12 44 30 PM](https://user-images.githubusercontent.com/103522725/189721259-756ef1d2-88a1-474a-8545-5c1d12e0aae4.png)

<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At a minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan

1. Navigate to the  Determined website. Open up the network tab. The next few steps can be verified by looking at the `Headers` tab as shown above.
2. Ensure that all of our bundled and hashed files which are the `chunk.js or chunk.css`, `woff`, `woff2`, contain a `Cache-Control` header with a value of `max-age=31536000`
3. Ensure that all image files `png/jpeg/jpg/ico/gif` or any other WebUI static files contain a `Cache-Control` header with a value of `max-age=600`
<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions about this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist
- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.
- [ ] If modifying `/webui/react/src/shared/` verify `make -C webui/react test-shared` passes.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-7450]: https://determinedai.atlassian.net/browse/DET-7450?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ