### PR TITLE
fix: handle pausing experiment [MLG-55]

### DIFF
--- a/e2e_tests/tests/experiment/__init__.py
+++ b/e2e_tests/tests/experiment/__init__.py
@@ -13,6 +13,7 @@ from .experiment import (
     wait_for_experiment_active_workload,
     wait_for_at_least_n_trials,
     wait_for_experiment_workload_progress,
+    wait_for_experiment_by_name_is_active,
     experiment_config_json,
     experiment_state,
     experiment_trials,

--- a/e2e_tests/tests/experiment/experiment.py
+++ b/e2e_tests/tests/experiment/experiment.py
@@ -72,6 +72,76 @@ def cancel_trial(trial_id: int) -> None:
     wait_for_trial_state(trial_id, determinedexperimentv1State.STATE_CANCELED)
 
 
+def wait_for_experiment_by_name_is_active(
+    experiment_name: str,
+    min_trials: int = 1,
+    max_wait_secs: int = conf.DEFAULT_MAX_WAIT_SECS,
+    log_every: int = 60,
+) -> int:
+    for seconds_waited in range(max_wait_secs):
+        try:
+            response = bindings.get_GetExperiments(
+                determined_test_session(), name=experiment_name
+            ).experiments
+            if len(response) == 0:
+                time.sleep(1)
+                continue
+            if len(response) > 1:
+                pytest.fail(
+                    f"Multiple experiments with name={experiment_name}, "
+                    f"expected only 1 experiment."
+                )
+            experiment = response[0]
+            experiment_id = experiment.id
+        # Ignore network errors while polling for experiment state to avoid a
+        # single network flake to cause a test suite failure. If the master is
+        # unreachable multiple times, this test will fail after max_wait_secs.
+        except api.errors.MasterNotFoundException:
+            logging.warning(
+                "Network failure ignored when polling for state of "
+                "experiment {}".format(experiment_name)
+            )
+            time.sleep(1)
+            continue
+        except api.errors.NotFoundException:
+            logging.warning(
+                "Experiment not yet available to check state: "
+                "experiment {}".format(experiment_name)
+            )
+            time.sleep(0.25)
+            continue
+
+        if experiment.state == determinedexperimentv1State.STATE_ACTIVE:
+            if experiment.numTrials > min_trials:
+                return experiment_id
+            time.sleep(1)
+            continue
+
+        if is_terminal_state(experiment.state):
+            report_failed_experiment(experiment_id)
+
+            pytest.fail(
+                f"Experiment {experiment_id} terminated in {experiment.state.value} state, "
+                f"expected {determinedexperimentv1State.STATE_ACTIVE}"
+            )
+
+        if seconds_waited > 0 and seconds_waited % log_every == 0:
+            print(
+                f"Waited {seconds_waited} seconds for experiment {experiment_name} "
+                f"(currently {experiment.state.value}) to reach "
+                f"{determinedexperimentv1State.STATE_ACTIVE}"
+            )
+
+        time.sleep(1)
+
+    else:
+        pytest.fail(
+            "Experiment {} did not start any trial {} seconds".format(
+                experiment_name, max_wait_secs
+            )
+        )
+
+
 def wait_for_experiment_state(
     experiment_id: int,
     target_state: determinedexperimentv1State,

--- a/e2e_tests/tests/experiment/experiment.py
+++ b/e2e_tests/tests/experiment/experiment.py
@@ -114,7 +114,7 @@ def wait_for_experiment_by_name_is_active(
         if experiment.state == determinedexperimentv1State.STATE_ACTIVE:
             if experiment.numTrials > min_trials:
                 return experiment_id
-            time.sleep(1)
+            time.sleep(0.25)
             continue
 
         if is_terminal_state(experiment.state):

--- a/e2e_tests/tests/experiment/experiment.py
+++ b/e2e_tests/tests/experiment/experiment.py
@@ -135,11 +135,7 @@ def wait_for_experiment_by_name_is_active(
         time.sleep(1)
 
     else:
-        pytest.fail(
-            "Experiment {} did not start any trial {} seconds".format(
-                experiment_name, max_wait_secs
-            )
-        )
+        pytest.fail(f"Experiment {experiment_name} did not start any trial {max_wait_secs} seconds")
 
 
 def wait_for_experiment_state(

--- a/e2e_tests/tests/experiment/test_custom_searcher.py
+++ b/e2e_tests/tests/experiment/test_custom_searcher.py
@@ -6,9 +6,11 @@ from pathlib import Path
 from typing import List, Optional
 
 import pytest
+import yaml
 from urllib3.connectionpool import HTTPConnectionPool, MaxRetryError
 
 from determined.common.api import bindings
+from determined.common.api.bindings import determinedexperimentv1State
 from determined.experimental import client
 from determined.searcher.search_method import Operation, SearchMethod
 from determined.searcher.search_runner import LocalSearchRunner
@@ -174,6 +176,168 @@ def test_run_random_searcher_exp_core_api(
     # check for resubmitting operations
     resubmissions = logs.count("root: Resubmitting operations for event.id=")
     assert resubmissions == sum([x == "after_save" for x in exception_points])
+
+
+@pytest.mark.e2e_cpu_2a
+def test_pause_random_searcher_core_api() -> None:
+    config = conf.load_config(conf.fixtures_path("custom_searcher/core_api_searcher_random.yaml"))
+    exp_name = f"random-pause-{TIMESTAMP}"
+    config["entrypoint"] += " --exp-name " + exp_name
+    config["entrypoint"] += " --config-name noop.yaml"
+
+    model_def_path = conf.fixtures_path("custom_searcher")
+
+    with tempfile.NamedTemporaryFile() as tf:
+        with open(tf.name, "w") as f:
+            yaml.dump(config, f)
+
+        searcher_exp_id = exp.create_experiment(tf.name, model_def_path, None)
+        exp.wait_for_experiment_state(
+            searcher_exp_id,
+            determinedexperimentv1State.STATE_ACTIVE,
+            max_wait_secs=conf.DEFAULT_MAX_WAIT_SECS,
+        )
+    # make sure both experiments have started by checking
+    # that multi-trial experiment has at least 1 running trials
+    multi_trial_exp_id = exp.wait_for_experiment_by_name_is_active(exp_name, 1)
+
+    # pause searcher
+    exp.pause_experiment(searcher_exp_id)
+    exp.wait_for_experiment_state(
+        searcher_exp_id, bindings.determinedexperimentv1State.STATE_PAUSED
+    )
+    time.sleep(10)
+
+    # multi-trial should be paused after pausing searcher
+    exp.wait_for_experiment_state(
+        multi_trial_exp_id, bindings.determinedexperimentv1State.STATE_PAUSED
+    )
+    time.sleep(10)
+
+    # activate multi-trial experiment
+    exp.activate_experiment(multi_trial_exp_id)
+    exp.wait_for_experiment_state(
+        multi_trial_exp_id, bindings.determinedexperimentv1State.STATE_ACTIVE
+    )
+
+    # activate searcher
+    exp.activate_experiment(searcher_exp_id)
+    exp.wait_for_experiment_state(
+        searcher_exp_id, bindings.determinedexperimentv1State.STATE_ACTIVE
+    )
+
+    # wait for experiment to complete
+    exp.wait_for_experiment_state(
+        searcher_exp_id, bindings.determinedexperimentv1State.STATE_COMPLETED
+    )
+
+    # searcher experiment
+    searcher_exp = bindings.get_GetExperiment(
+        exp.determined_test_session(), experimentId=searcher_exp_id
+    ).experiment
+    assert searcher_exp.state == bindings.determinedexperimentv1State.STATE_COMPLETED
+
+    # actual experiment
+    experiment = bindings.get_GetExperiment(
+        exp.determined_test_session(), experimentId=multi_trial_exp_id
+    ).experiment
+    assert experiment.numTrials == 5
+
+    trials = bindings.get_GetExperimentTrials(
+        exp.determined_test_session(), experimentId=experiment.id
+    ).trials
+    for trial in trials:
+        assert trial.state == bindings.determinedexperimentv1State.STATE_COMPLETED
+        assert trial.totalBatchesProcessed == 500
+
+    check_if_experiment_was_paused(searcher_exp_id)
+
+
+@pytest.mark.e2e_cpu_2a
+def test_pause_multi_trial_random_searcher_core_api() -> None:
+    config = conf.load_config(conf.fixtures_path("custom_searcher/core_api_searcher_random.yaml"))
+    exp_name = f"random-pause-{TIMESTAMP}"
+    config["entrypoint"] += " --exp-name " + exp_name
+    config["entrypoint"] += " --config-name noop.yaml"
+
+    model_def_path = conf.fixtures_path("custom_searcher")
+
+    with tempfile.NamedTemporaryFile() as tf:
+        with open(tf.name, "w") as f:
+            yaml.dump(config, f)
+
+        searcher_exp_id = exp.create_experiment(tf.name, model_def_path, None)
+        exp.wait_for_experiment_state(
+            searcher_exp_id,
+            determinedexperimentv1State.STATE_ACTIVE,
+            max_wait_secs=conf.DEFAULT_MAX_WAIT_SECS,
+        )
+    # make sure both experiments have started by checking
+    # that multi-trial experiment has at least 1 running trials
+    multi_trial_exp_id = exp.wait_for_experiment_by_name_is_active(exp_name, 0)
+
+    # pause multi-trial experiment
+    exp.pause_experiment(multi_trial_exp_id)
+    exp.wait_for_experiment_state(
+        multi_trial_exp_id, bindings.determinedexperimentv1State.STATE_PAUSED
+    )
+    time.sleep(10)
+
+    # searcher should be paused after pausing multi-trial experiment
+    exp.wait_for_experiment_state(
+        searcher_exp_id, bindings.determinedexperimentv1State.STATE_PAUSED
+    )
+    time.sleep(10)
+
+    # activate multi-trial experiment
+    exp.activate_experiment(multi_trial_exp_id)
+    exp.wait_for_experiment_state(
+        multi_trial_exp_id, bindings.determinedexperimentv1State.STATE_ACTIVE
+    )
+
+    # activate searcher
+    exp.activate_experiment(searcher_exp_id)
+    exp.wait_for_experiment_state(
+        searcher_exp_id, bindings.determinedexperimentv1State.STATE_ACTIVE
+    )
+
+    # wait for experiment to complete
+    exp.wait_for_experiment_state(
+        searcher_exp_id, bindings.determinedexperimentv1State.STATE_COMPLETED
+    )
+
+    # searcher experiment
+    searcher_exp = bindings.get_GetExperiment(
+        exp.determined_test_session(), experimentId=searcher_exp_id
+    ).experiment
+    assert searcher_exp.state == bindings.determinedexperimentv1State.STATE_COMPLETED
+
+    # actual experiment
+    experiment = bindings.get_GetExperiment(
+        exp.determined_test_session(), experimentId=multi_trial_exp_id
+    ).experiment
+    assert experiment.numTrials == 5
+
+    trials = bindings.get_GetExperimentTrials(
+        exp.determined_test_session(), experimentId=experiment.id
+    ).trials
+    for trial in trials:
+        assert trial.state == bindings.determinedexperimentv1State.STATE_COMPLETED
+        assert trial.totalBatchesProcessed == 500
+
+    check_if_experiment_was_paused(searcher_exp_id)
+
+
+def check_if_experiment_was_paused(experiment_id: int, count: int = 1) -> None:
+    # check logs to ensure failures actually happened
+    logs = str(
+        subprocess.check_output(
+            ["det", "-m", conf.make_master_url(), "experiment", "logs", str(experiment_id)]
+        )
+    )
+    # check for pausing operations
+    pausing_count = logs.count("root: Pausing")
+    assert pausing_count == count
 
 
 @pytest.mark.e2e_cpu_2a

--- a/e2e_tests/tests/experiment/test_custom_searcher.py
+++ b/e2e_tests/tests/experiment/test_custom_searcher.py
@@ -181,7 +181,7 @@ def test_run_random_searcher_exp_core_api(
 @pytest.mark.e2e_cpu_2a
 def test_pause_random_searcher_core_api() -> None:
     config = conf.load_config(conf.fixtures_path("custom_searcher/core_api_searcher_random.yaml"))
-    exp_name = f"random-pause-{TIMESTAMP}"
+    exp_name = f"random-pause1-{TIMESTAMP}"
     config["entrypoint"] += " --exp-name " + exp_name
     config["entrypoint"] += " --config-name noop.yaml"
 
@@ -256,7 +256,7 @@ def test_pause_random_searcher_core_api() -> None:
 @pytest.mark.e2e_cpu_2a
 def test_pause_multi_trial_random_searcher_core_api() -> None:
     config = conf.load_config(conf.fixtures_path("custom_searcher/core_api_searcher_random.yaml"))
-    exp_name = f"random-pause-{TIMESTAMP}"
+    exp_name = f"random-pause2-{TIMESTAMP}"
     config["entrypoint"] += " --exp-name " + exp_name
     config["entrypoint"] += " --config-name noop.yaml"
 
@@ -274,7 +274,7 @@ def test_pause_multi_trial_random_searcher_core_api() -> None:
         )
     # make sure both experiments have started by checking
     # that multi-trial experiment has at least 1 running trials
-    multi_trial_exp_id = exp.wait_for_experiment_by_name_is_active(exp_name, 0)
+    multi_trial_exp_id = exp.wait_for_experiment_by_name_is_active(exp_name, 1)
 
     # pause multi-trial experiment
     exp.pause_experiment(multi_trial_exp_id)

--- a/e2e_tests/tests/fixtures/custom_searcher/core_api_custom_searcher.py
+++ b/e2e_tests/tests/fixtures/custom_searcher/core_api_custom_searcher.py
@@ -63,7 +63,8 @@ class FallibleSearchRunner(CoreSearchRunner):
         # since that exception was raised in the previous run;
         # this testing approach works as long as the there is
         # at least one save between consecutive exceptions
-        self.search_method.exception_points.pop(0)
+        if len(search_method.exception_points) > 0:
+            self.search_method.exception_points.pop(0)
 
         if len(self.search_method.exception_points) > 0:
             if self.search_method.exception_points[0] == "after_save":


### PR DESCRIPTION
## Description
LocalSearchRunner: 
* when an experiment is stopped in the WebUI, print warning to the user and allow them to manually CTRL+C the process

CoreSearchRunner:
* when a searcher experiment is paused → preempt the experiment
* when the experiment is paused → preempt the searcher experiment
<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At a minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan
Added tests for Core Search Runner pausing searcher first or multi-trial experiment first.
LocalSearchRunner tested manually.
<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions about this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist
- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.
- [ ] If modifying `/webui/react/src/shared/` verify `make -C webui/react test-shared` passes.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ