### PR TITLE
feat: Modal to add role to group [DET-8220]

### DIFF
--- a/harness/determined/common/api/bindings.py
+++ b/harness/determined/common/api/bindings.py
@@ -2462,6 +2462,29 @@ class v1GetNotebooksResponse:
             "pagination": self.pagination.to_json() if self.pagination is not None else None,
         }
 
+class v1GetPermissionsSummaryResponse:
+    def __init__(
+        self,
+        *,
+        assignments: "typing.Sequence[v1RoleAssignmentSummary]",
+        roles: "typing.Sequence[v1Role]",
+    ):
+        self.roles = roles
+        self.assignments = assignments
+
+    @classmethod
+    def from_json(cls, obj: Json) -> "v1GetPermissionsSummaryResponse":
+        return cls(
+            roles=[v1Role.from_json(x) for x in obj["roles"]],
+            assignments=[v1RoleAssignmentSummary.from_json(x) for x in obj["assignments"]],
+        )
+
+    def to_json(self) -> typing.Any:
+        return {
+            "roles": [x.to_json() for x in self.roles],
+            "assignments": [x.to_json() for x in self.assignments],
+        }
+
 class v1GetProjectResponse:
     def __init__(
         self,
@@ -4535,7 +4558,7 @@ class v1Permission:
     def __init__(
         self,
         *,
-        id: int,
+        id: "v1PermissionType",
         isGlobal: "typing.Optional[bool]" = None,
         name: "typing.Optional[str]" = None,
     ):
@@ -4546,17 +4569,38 @@ class v1Permission:
     @classmethod
     def from_json(cls, obj: Json) -> "v1Permission":
         return cls(
-            id=obj["id"],
+            id=v1PermissionType(obj["id"]),
             name=obj.get("name", None),
             isGlobal=obj.get("isGlobal", None),
         )
 
     def to_json(self) -> typing.Any:
         return {
-            "id": self.id,
+            "id": self.id.value,
             "name": self.name if self.name is not None else None,
             "isGlobal": self.isGlobal if self.isGlobal is not None else None,
         }
+
+class v1PermissionType(enum.Enum):
+    PERMISSION_TYPE_UNSPECIFIED = "PERMISSION_TYPE_UNSPECIFIED"
+    PERMISSION_TYPE_ADMINISTRATE_USER = "PERMISSION_TYPE_ADMINISTRATE_USER"
+    PERMISSION_TYPE_CREATE_EXPERIMENT = "PERMISSION_TYPE_CREATE_EXPERIMENT"
+    PERMISSION_TYPE_VIEW_EXPERIMENT_ARTIFACTS = "PERMISSION_TYPE_VIEW_EXPERIMENT_ARTIFACTS"
+    PERMISSION_TYPE_VIEW_EXPERIMENT_METADATA = "PERMISSION_TYPE_VIEW_EXPERIMENT_METADATA"
+    PERMISSION_TYPE_UPDATE_EXPERIMENT = "PERMISSION_TYPE_UPDATE_EXPERIMENT"
+    PERMISSION_TYPE_UPDATE_EXPERIMENT_METADATA = "PERMISSION_TYPE_UPDATE_EXPERIMENT_METADATA"
+    PERMISSION_TYPE_DELETE_EXPERIMENT = "PERMISSION_TYPE_DELETE_EXPERIMENT"
+    PERMISSION_TYPE_UPDATE_GROUP = "PERMISSION_TYPE_UPDATE_GROUP"
+    PERMISSION_TYPE_CREATE_WORKSPACE = "PERMISSION_TYPE_CREATE_WORKSPACE"
+    PERMISSION_TYPE_VIEW_WORKSPACE = "PERMISSION_TYPE_VIEW_WORKSPACE"
+    PERMISSION_TYPE_UPDATE_WORKSPACE = "PERMISSION_TYPE_UPDATE_WORKSPACE"
+    PERMISSION_TYPE_DELETE_WORKSPACE = "PERMISSION_TYPE_DELETE_WORKSPACE"
+    PERMISSION_TYPE_CREATE_PROJECT = "PERMISSION_TYPE_CREATE_PROJECT"
+    PERMISSION_TYPE_VIEW_PROJECT = "PERMISSION_TYPE_VIEW_PROJECT"
+    PERMISSION_TYPE_UPDATE_PROJECT = "PERMISSION_TYPE_UPDATE_PROJECT"
+    PERMISSION_TYPE_DELETE_PROJECT = "PERMISSION_TYPE_DELETE_PROJECT"
+    PERMISSION_TYPE_UPDATE_ROLES = "PERMISSION_TYPE_UPDATE_ROLES"
+    PERMISSION_TYPE_ASSIGN_ROLES = "PERMISSION_TYPE_ASSIGN_ROLES"
 
 class v1PostAllocationProxyAddressRequest:
     def __init__(
@@ -5783,6 +5827,33 @@ class v1RoleAssignment:
         return {
             "role": self.role.to_json(),
             "scopeWorkspaceId": self.scopeWorkspaceId if self.scopeWorkspaceId is not None else None,
+        }
+
+class v1RoleAssignmentSummary:
+    def __init__(
+        self,
+        *,
+        isGlobal: "typing.Optional[bool]" = None,
+        roleId: "typing.Optional[int]" = None,
+        scopeWorkspaceIds: "typing.Optional[typing.Sequence[int]]" = None,
+    ):
+        self.roleId = roleId
+        self.scopeWorkspaceIds = scopeWorkspaceIds
+        self.isGlobal = isGlobal
+
+    @classmethod
+    def from_json(cls, obj: Json) -> "v1RoleAssignmentSummary":
+        return cls(
+            roleId=obj.get("roleId", None),
+            scopeWorkspaceIds=obj.get("scopeWorkspaceIds", None),
+            isGlobal=obj.get("isGlobal", None),
+        )
+
+    def to_json(self) -> typing.Any:
+        return {
+            "roleId": self.roleId if self.roleId is not None else None,
+            "scopeWorkspaceIds": self.scopeWorkspaceIds if self.scopeWorkspaceIds is not None else None,
+            "isGlobal": self.isGlobal if self.isGlobal is not None else None,
         }
 
 class v1RoleWithAssignments:
@@ -8611,6 +8682,24 @@ def get_GetNotebooks(
     if _resp.status_code == 200:
         return v1GetNotebooksResponse.from_json(_resp.json())
     raise APIHttpError("get_GetNotebooks", _resp)
+
+def get_GetPermissionsSummary(
+    session: "api.Session",
+) -> "v1GetPermissionsSummaryResponse":
+    _params = None
+    _resp = session._do_request(
+        method="GET",
+        path="/api/v1/permissions/summary",
+        params=_params,
+        json=None,
+        data=None,
+        headers=None,
+        timeout=None,
+        stream=False,
+    )
+    if _resp.status_code == 200:
+        return v1GetPermissionsSummaryResponse.from_json(_resp.json())
+    raise APIHttpError("get_GetPermissionsSummary", _resp)
 
 def get_GetProject(
     session: "api.Session",

--- a/harness/determined/common/api/bindings.py
+++ b/harness/determined/common/api/bindings.py
@@ -2462,29 +2462,6 @@ class v1GetNotebooksResponse:
             "pagination": self.pagination.to_json() if self.pagination is not None else None,
         }
 
-class v1GetPermissionsSummaryResponse:
-    def __init__(
-        self,
-        *,
-        assignments: "typing.Sequence[v1RoleAssignmentSummary]",
-        roles: "typing.Sequence[v1Role]",
-    ):
-        self.roles = roles
-        self.assignments = assignments
-
-    @classmethod
-    def from_json(cls, obj: Json) -> "v1GetPermissionsSummaryResponse":
-        return cls(
-            roles=[v1Role.from_json(x) for x in obj["roles"]],
-            assignments=[v1RoleAssignmentSummary.from_json(x) for x in obj["assignments"]],
-        )
-
-    def to_json(self) -> typing.Any:
-        return {
-            "roles": [x.to_json() for x in self.roles],
-            "assignments": [x.to_json() for x in self.assignments],
-        }
-
 class v1GetProjectResponse:
     def __init__(
         self,
@@ -3669,23 +3646,27 @@ class v1ListRolesRequest:
     def __init__(
         self,
         *,
+        isGlobal: bool,
         limit: int,
         offset: "typing.Optional[int]" = None,
     ):
         self.offset = offset
         self.limit = limit
+        self.isGlobal = isGlobal
 
     @classmethod
     def from_json(cls, obj: Json) -> "v1ListRolesRequest":
         return cls(
             offset=obj.get("offset", None),
             limit=obj["limit"],
+            isGlobal=obj["isGlobal"],
         )
 
     def to_json(self) -> typing.Any:
         return {
             "offset": self.offset if self.offset is not None else None,
             "limit": self.limit,
+            "isGlobal": self.isGlobal,
         }
 
 class v1ListRolesResponse:
@@ -4554,7 +4535,7 @@ class v1Permission:
     def __init__(
         self,
         *,
-        id: "typing.Optional[v1PermissionType]" = None,
+        id: int,
         isGlobal: "typing.Optional[bool]" = None,
         name: "typing.Optional[str]" = None,
     ):
@@ -4565,38 +4546,17 @@ class v1Permission:
     @classmethod
     def from_json(cls, obj: Json) -> "v1Permission":
         return cls(
-            id=v1PermissionType(obj["id"]) if obj.get("id", None) is not None else None,
+            id=obj["id"],
             name=obj.get("name", None),
             isGlobal=obj.get("isGlobal", None),
         )
 
     def to_json(self) -> typing.Any:
         return {
-            "id": self.id.value if self.id is not None else None,
+            "id": self.id,
             "name": self.name if self.name is not None else None,
             "isGlobal": self.isGlobal if self.isGlobal is not None else None,
         }
-
-class v1PermissionType(enum.Enum):
-    PERMISSION_TYPE_UNSPECIFIED = "PERMISSION_TYPE_UNSPECIFIED"
-    PERMISSION_TYPE_ADMINISTRATE_USER = "PERMISSION_TYPE_ADMINISTRATE_USER"
-    PERMISSION_TYPE_CREATE_EXPERIMENT = "PERMISSION_TYPE_CREATE_EXPERIMENT"
-    PERMISSION_TYPE_VIEW_EXPERIMENT_ARTIFACTS = "PERMISSION_TYPE_VIEW_EXPERIMENT_ARTIFACTS"
-    PERMISSION_TYPE_VIEW_EXPERIMENT_METADATA = "PERMISSION_TYPE_VIEW_EXPERIMENT_METADATA"
-    PERMISSION_TYPE_UPDATE_EXPERIMENT = "PERMISSION_TYPE_UPDATE_EXPERIMENT"
-    PERMISSION_TYPE_UPDATE_EXPERIMENT_METADATA = "PERMISSION_TYPE_UPDATE_EXPERIMENT_METADATA"
-    PERMISSION_TYPE_DELETE_EXPERIMENT = "PERMISSION_TYPE_DELETE_EXPERIMENT"
-    PERMISSION_TYPE_UPDATE_GROUP = "PERMISSION_TYPE_UPDATE_GROUP"
-    PERMISSION_TYPE_CREATE_WORKSPACE = "PERMISSION_TYPE_CREATE_WORKSPACE"
-    PERMISSION_TYPE_VIEW_WORKSPACE = "PERMISSION_TYPE_VIEW_WORKSPACE"
-    PERMISSION_TYPE_UPDATE_WORKSPACE = "PERMISSION_TYPE_UPDATE_WORKSPACE"
-    PERMISSION_TYPE_DELETE_WORKSPACE = "PERMISSION_TYPE_DELETE_WORKSPACE"
-    PERMISSION_TYPE_CREATE_PROJECT = "PERMISSION_TYPE_CREATE_PROJECT"
-    PERMISSION_TYPE_VIEW_PROJECT = "PERMISSION_TYPE_VIEW_PROJECT"
-    PERMISSION_TYPE_UPDATE_PROJECT = "PERMISSION_TYPE_UPDATE_PROJECT"
-    PERMISSION_TYPE_DELETE_PROJECT = "PERMISSION_TYPE_DELETE_PROJECT"
-    PERMISSION_TYPE_UPDATE_ROLES = "PERMISSION_TYPE_UPDATE_ROLES"
-    PERMISSION_TYPE_ASSIGN_ROLES = "PERMISSION_TYPE_ASSIGN_ROLES"
 
 class v1PostAllocationProxyAddressRequest:
     def __init__(
@@ -5779,9 +5739,9 @@ class v1Role:
     def __init__(
         self,
         *,
+        roleId: int,
         name: "typing.Optional[str]" = None,
         permissions: "typing.Optional[typing.Sequence[v1Permission]]" = None,
-        roleId: "typing.Optional[int]" = None,
     ):
         self.roleId = roleId
         self.name = name
@@ -5790,14 +5750,14 @@ class v1Role:
     @classmethod
     def from_json(cls, obj: Json) -> "v1Role":
         return cls(
-            roleId=obj.get("roleId", None),
+            roleId=obj["roleId"],
             name=obj.get("name", None),
             permissions=[v1Permission.from_json(x) for x in obj["permissions"]] if obj.get("permissions", None) is not None else None,
         )
 
     def to_json(self) -> typing.Any:
         return {
-            "roleId": self.roleId if self.roleId is not None else None,
+            "roleId": self.roleId,
             "name": self.name if self.name is not None else None,
             "permissions": [x.to_json() for x in self.permissions] if self.permissions is not None else None,
         }
@@ -5823,33 +5783,6 @@ class v1RoleAssignment:
         return {
             "role": self.role.to_json(),
             "scopeWorkspaceId": self.scopeWorkspaceId if self.scopeWorkspaceId is not None else None,
-        }
-
-class v1RoleAssignmentSummary:
-    def __init__(
-        self,
-        *,
-        isGlobal: "typing.Optional[bool]" = None,
-        roleId: "typing.Optional[int]" = None,
-        scopeWorkspaceIds: "typing.Optional[typing.Sequence[int]]" = None,
-    ):
-        self.roleId = roleId
-        self.scopeWorkspaceIds = scopeWorkspaceIds
-        self.isGlobal = isGlobal
-
-    @classmethod
-    def from_json(cls, obj: Json) -> "v1RoleAssignmentSummary":
-        return cls(
-            roleId=obj.get("roleId", None),
-            scopeWorkspaceIds=obj.get("scopeWorkspaceIds", None),
-            isGlobal=obj.get("isGlobal", None),
-        )
-
-    def to_json(self) -> typing.Any:
-        return {
-            "roleId": self.roleId if self.roleId is not None else None,
-            "scopeWorkspaceIds": self.scopeWorkspaceIds if self.scopeWorkspaceIds is not None else None,
-            "isGlobal": self.isGlobal if self.isGlobal is not None else None,
         }
 
 class v1RoleWithAssignments:
@@ -8678,24 +8611,6 @@ def get_GetNotebooks(
     if _resp.status_code == 200:
         return v1GetNotebooksResponse.from_json(_resp.json())
     raise APIHttpError("get_GetNotebooks", _resp)
-
-def get_GetPermissionsSummary(
-    session: "api.Session",
-) -> "v1GetPermissionsSummaryResponse":
-    _params = None
-    _resp = session._do_request(
-        method="GET",
-        path="/api/v1/permissions/summary",
-        params=_params,
-        json=None,
-        data=None,
-        headers=None,
-        timeout=None,
-        stream=False,
-    )
-    if _resp.status_code == 200:
-        return v1GetPermissionsSummaryResponse.from_json(_resp.json())
-    raise APIHttpError("get_GetPermissionsSummary", _resp)
 
 def get_GetProject(
     session: "api.Session",

--- a/harness/determined/common/api/bindings.py
+++ b/harness/determined/common/api/bindings.py
@@ -3669,27 +3669,23 @@ class v1ListRolesRequest:
     def __init__(
         self,
         *,
-        isGlobal: bool,
         limit: int,
         offset: "typing.Optional[int]" = None,
     ):
         self.offset = offset
         self.limit = limit
-        self.isGlobal = isGlobal
 
     @classmethod
     def from_json(cls, obj: Json) -> "v1ListRolesRequest":
         return cls(
             offset=obj.get("offset", None),
             limit=obj["limit"],
-            isGlobal=obj["isGlobal"],
         )
 
     def to_json(self) -> typing.Any:
         return {
             "offset": self.offset if self.offset is not None else None,
             "limit": self.limit,
-            "isGlobal": self.isGlobal,
         }
 
 class v1ListRolesResponse:

--- a/proto/src/determined/api/v1/rbac.proto
+++ b/proto/src/determined/api/v1/rbac.proto
@@ -85,12 +85,14 @@ message SearchRolesAssignableToScopeResponse {
 // to search for a role.
 message ListRolesRequest {
   option (grpc.gateway.protoc_gen_swagger.options.openapiv2_schema) = {
-    json_schema: { required: [ "limit" ] }
+    json_schema: { required: [ "is_global", "limit" ] }
   };
-  // the offset for pagination
+  // the offset for pagination.
   int32 offset = 3;
   // the limit for pagination.
   int32 limit = 4;
+  // searching global roles.
+  bool is_global = 5;
 }
 
 // ListRolesResponse is the body of the response for the call

--- a/proto/src/determined/api/v1/rbac.proto
+++ b/proto/src/determined/api/v1/rbac.proto
@@ -85,14 +85,12 @@ message SearchRolesAssignableToScopeResponse {
 // to search for a role.
 message ListRolesRequest {
   option (grpc.gateway.protoc_gen_swagger.options.openapiv2_schema) = {
-    json_schema: { required: [ "is_global", "limit" ] }
+    json_schema: { required: [ "limit" ] }
   };
   // the offset for pagination.
   int32 offset = 3;
   // the limit for pagination.
   int32 limit = 4;
-  // searching global roles.
-  bool is_global = 5;
 }
 
 // ListRolesResponse is the body of the response for the call

--- a/proto/src/determined/rbac/v1/rbac.proto
+++ b/proto/src/determined/rbac/v1/rbac.proto
@@ -9,7 +9,7 @@ import "protoc-gen-swagger/options/annotations.proto";
 // Role contains information about a specific Role
 message Role {
   option (grpc.gateway.protoc_gen_swagger.options.openapiv2_schema) = {
-    json_schema: { required: [ "name", "permissions", "role_id" ] }
+    json_schema: { required: [ "role_id" ] }
   };
   // The id of the role being detailed
   int32 role_id = 1;

--- a/proto/src/determined/rbac/v1/rbac.proto
+++ b/proto/src/determined/rbac/v1/rbac.proto
@@ -22,7 +22,7 @@ message Role {
 // Permission represents an action a user can take in the system
 message Permission {
   option (grpc.gateway.protoc_gen_swagger.options.openapiv2_schema) = {
-    json_schema: { required: [ "id", "is_global", "name" ] }
+    json_schema: { required: [ "id" ] }
   };
   // The id of the permission
   PermissionType id = 1;

--- a/proto/src/determined/rbac/v1/rbac.proto
+++ b/proto/src/determined/rbac/v1/rbac.proto
@@ -8,6 +8,9 @@ import "protoc-gen-swagger/options/annotations.proto";
 
 // Role contains information about a specific Role
 message Role {
+  option (grpc.gateway.protoc_gen_swagger.options.openapiv2_schema) = {
+    json_schema: { required: [ "name", "permissions", "role_id" ] }
+  };
   // The id of the role being detailed
   int32 role_id = 1;
   // The string of the role being detailed
@@ -18,6 +21,9 @@ message Role {
 
 // Permission represents an action a user can take in the system
 message Permission {
+  option (grpc.gateway.protoc_gen_swagger.options.openapiv2_schema) = {
+    json_schema: { required: [ "id", "is_global", "name" ] }
+  };
   // The id of the permission
   PermissionType id = 1;
   // The name of the permission

--- a/webui/react/src/components/Navigation.tsx
+++ b/webui/react/src/components/Navigation.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 
 import { useStore } from 'contexts/Store';
-import { useFetchAgents, useFetchPinnedWorkspaces,
+import { useFetchAgents, useFetchKnownRoles, useFetchPinnedWorkspaces,
   useFetchResourcePools, useFetchUserSettings } from 'hooks/useFetch';
 import usePolling from 'hooks/usePolling';
 import Spinner from 'shared/components/Spinner/Spinner';
@@ -22,6 +22,7 @@ const Navigation: React.FC<Props> = ({ children }) => {
   const fetchResourcePools = useFetchResourcePools(canceler);
   const fetchPinnedWorkspaces = useFetchPinnedWorkspaces(canceler);
   const fetchUserSettings = useFetchUserSettings(canceler);
+  const fetchKnownRoles = useFetchKnownRoles(canceler);
 
   usePolling(fetchAgents);
   usePolling(fetchPinnedWorkspaces);
@@ -32,6 +33,11 @@ const Navigation: React.FC<Props> = ({ children }) => {
 
     return () => canceler.abort();
   }, [ canceler, fetchResourcePools ]);
+
+  useEffect(() => {
+    fetchKnownRoles();
+    return () => canceler.abort();
+  }, [ canceler, fetchKnownRoles ]);
 
   return (
     <Spinner spinning={ui.showSpinner}>

--- a/webui/react/src/contexts/Store.tsx
+++ b/webui/react/src/contexts/Store.tsx
@@ -31,6 +31,7 @@ interface State {
   auth: Auth & { checked: boolean };
   cluster: ClusterOverview;
   info: DeterminedInfo;
+  knownRoles: UserRole[];
   pinnedWorkspaces: Workspace[];
   pool: PoolOverview;
   resourcePools: ResourcePool[];
@@ -83,6 +84,7 @@ export enum StoreAction {
   SetActiveExperiments = 'SetActiveExperiments',
 
   // User assignments, roles, and derived permissions
+  SetKnownRoles = 'SetKnownRoles',
   SetUserAssignments = 'SetUserAssignments',
   SetUserRoles = 'SetUserRoles',
 }
@@ -109,6 +111,7 @@ type Action =
   tensorboards: number;
 }}
 | { type: StoreAction.SetActiveExperiments, value: number }
+| { type: StoreAction.SetKnownRoles, value: UserRole[] }
 | { type: StoreAction.SetUserRoles, value: UserRole[] }
 | { type: StoreAction.SetUserAssignments, value: UserAssignment[] }
 | ActionUI;
@@ -149,6 +152,7 @@ const initState: State = {
   auth: initAuth,
   cluster: initClusterOverview,
   info: initInfo,
+  knownRoles: [],
   pinnedWorkspaces: [],
   pool: {},
   resourcePools: [],
@@ -289,6 +293,9 @@ const reducer = (state: State, action: Action): State => {
     case StoreAction.SetActiveTasks:
       if (isEqual(state.activeTasks, action.value)) return state;
       return { ...state, activeTasks: action.value };
+    case StoreAction.SetKnownRoles:
+      if (isEqual(state.knownRoles, action.value)) return state;
+      return { ...state, knownRoles: action.value };
     case StoreAction.SetUserRoles:
       if (isEqual(state.userRoles, action.value)) return state;
       return { ...state, userRoles: action.value };

--- a/webui/react/src/hooks/useFetch.ts
+++ b/webui/react/src/hooks/useFetch.ts
@@ -11,6 +11,7 @@ import {
   getUsers,
   getUserSetting,
   getWorkspaces,
+  listRoles,
 } from 'services/api';
 import { ErrorType } from 'shared/utils/error';
 import { BrandingType, ResourceType } from 'types';
@@ -125,6 +126,19 @@ export const useFetchPinnedWorkspaces = (canceler: AbortController): () => Promi
         { signal: canceler.signal },
       );
       storeDispatch({ type: StoreAction.SetPinnedWorkspaces, value: pinnedWorkspaces.workspaces });
+    } catch (e) { handleError(e); }
+  }, [ canceler, storeDispatch ]);
+};
+
+export const useFetchKnownRoles = (canceler: AbortController): () => Promise<void> => {
+  const storeDispatch = useStoreDispatch();
+  return useCallback(async (): Promise<void> => {
+    try {
+      const roles = await listRoles(
+        { limit: 0 },
+        { signal: canceler.signal },
+      );
+      storeDispatch({ type: StoreAction.SetKnownRoles, value: roles });
     } catch (e) { handleError(e); }
   }, [ canceler, storeDispatch ]);
 };

--- a/webui/react/src/hooks/useModal/UserSettings/useModalCreateUser.tsx
+++ b/webui/react/src/hooks/useModal/UserSettings/useModalCreateUser.tsx
@@ -41,10 +41,30 @@ interface FormValues {
   USER_NAME_NAME: string;
 }
 
+const permissionColumns = [
+  {
+    dataIndex: 'name',
+    key: 'name',
+    title: 'Name',
+  },
+  {
+    dataIndex: 'isGlobal',
+    key: 'isGlobal',
+    render: (val: boolean) => val ? <Icon name="checkmark" /> : '',
+    title: 'Global?',
+  },
+  {
+    dataIndex: 'workspaceOnly',
+    key: 'workspaceOnly',
+    render: (val: boolean) => val ? '' : <Icon name="checkmark" />,
+    title: 'Workspaces?',
+  },
+];
+
 const ModalForm: React.FC<Props> = ({ form, branding, user, groups, viewOnly }) => {
   const [ permissions, setPermissions ] = useState<Permission[]>([]);
 
-  const canSeePermissions = usePermissions().canGetPermissions();
+  const canSeePermissions = usePermissions().canGetPermissions;
 
   const updatePermissions = useCallback(async () => {
     if (user && canSeePermissions) {
@@ -62,26 +82,6 @@ const ModalForm: React.FC<Props> = ({ form, branding, user, groups, viewOnly }) 
       updatePermissions();
     }
   }, [ form, updatePermissions, user ]);
-
-  const columns = [
-    {
-      dataIndex: 'name',
-      key: 'name',
-      title: 'Name',
-    },
-    {
-      dataIndex: 'isGlobal',
-      key: 'isGlobal',
-      render: (val: boolean) => val ? <Icon name="checkmark" /> : '',
-      title: 'Global?',
-    },
-    {
-      dataIndex: 'isGlobal',
-      key: 'workspaceOnly',
-      render: (val: boolean) => val ? '' : <Icon name="checkmark" />,
-      title: 'Workspaces?',
-    },
-  ];
 
   return (
     <Form<FormValues>
@@ -135,7 +135,7 @@ const ModalForm: React.FC<Props> = ({ form, branding, user, groups, viewOnly }) 
       )}
       {!!user && canSeePermissions && (
         <Table
-          columns={columns}
+          columns={permissionColumns}
           dataSource={permissions}
           pagination={{ hideOnSinglePage: true, size: 'small' }}
         />

--- a/webui/react/src/hooks/useModal/UserSettings/useModalGroupRoles.test.tsx
+++ b/webui/react/src/hooks/useModal/UserSettings/useModalGroupRoles.test.tsx
@@ -1,0 +1,89 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Button } from 'antd';
+import React from 'react';
+
+import StoreProvider from 'contexts/Store';
+
+import useModalGroupRoles from './useModalGroupRoles';
+
+const OPEN_MODAL_TEXT = 'Open';
+const GROUP_NAME = 'Test Group';
+
+jest.mock('services/api', () => ({
+  getGroupRoles: () => {
+    return Promise.resolve([]);
+  },
+}));
+
+const user = userEvent.setup();
+
+const Container: React.FC = () => {
+  const group = {
+    group: {
+      groupId: -1,
+      name: GROUP_NAME,
+    },
+  };
+  const roles = [ {
+    id: -2,
+    name: 'Test Role',
+  } ];
+
+  const { contextHolder, modalOpen } = useModalGroupRoles({ group, roles });
+
+  return (
+    <div>
+      <Button onClick={() => modalOpen()}>Open</Button>
+      {contextHolder}
+    </div>
+  );
+};
+
+const setup = async () => {
+  const view = render(
+    <StoreProvider>
+      <Container />
+    </StoreProvider>,
+  );
+
+  await user.click(await view.findByText(OPEN_MODAL_TEXT));
+  await view.findByRole('heading', { name: 'Update Roles' });
+
+  return view;
+};
+
+describe('useModalGropRoles', () => {
+  it('should open modal with group name and a section for roles', async () => {
+    await setup();
+
+    expect(screen.getByText(`Add Roles to: ${GROUP_NAME}`)).toBeInTheDocument();
+    expect(screen.getByLabelText('Roles')).toBeInTheDocument();
+  });
+
+  it('should close the modal via upper right close button', async () => {
+    await setup();
+
+    await user.click(await screen.findByLabelText('Close'));
+
+    // Check for the modal to be dismissed.
+    await waitFor(() => {
+      expect(
+        screen.queryByRole('heading', { name: 'Update Roles' }),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  it('should close the modal via cancel button', async () => {
+    await setup();
+
+    await user.click(await screen.findByText('Cancel'));
+
+    // Check for the modal to be dismissed.
+    await waitFor(() => {
+      expect(
+        screen.queryByRole('heading', { name: 'Update Roles' }),
+      ).not.toBeInTheDocument();
+    });
+  });
+});

--- a/webui/react/src/hooks/useModal/UserSettings/useModalGroupRoles.tsx
+++ b/webui/react/src/hooks/useModal/UserSettings/useModalGroupRoles.tsx
@@ -42,7 +42,7 @@ const ModalForm: React.FC<Props> = ({ form, group }) => {
     {
       dataIndex: 'name',
       key: 'name',
-      title: 'Name',
+      title: 'Role Name',
     },
   ];
 
@@ -51,16 +51,16 @@ const ModalForm: React.FC<Props> = ({ form, group }) => {
       form={form}
       labelCol={{ span: 8 }}
       wrapperCol={{ span: 14 }}>
+      {groupRoles.length
+        ? (
+          <Table
+            columns={roleColumns}
+            dataSource={groupRoles}
+            pagination={{ hideOnSinglePage: true, size: 'small' }}
+          />
+        )
+        : null}
       <Form.Item label="Roles" name="roles">
-        {groupRoles.length
-          ? (
-            <Table
-              columns={roleColumns}
-              dataSource={groupRoles}
-              pagination={{ hideOnSinglePage: true, size: 'small' }}
-            />
-          )
-          : null}
         <Select
           loading={isLoading}
           mode="multiple"

--- a/webui/react/src/hooks/useModal/UserSettings/useModalGroupRoles.tsx
+++ b/webui/react/src/hooks/useModal/UserSettings/useModalGroupRoles.tsx
@@ -2,7 +2,7 @@ import { Form, message, Select } from 'antd';
 import { FormInstance } from 'antd/lib/form/hooks/useForm';
 import React, { useCallback, useEffect, useState } from 'react';
 
-import { getGroupRoles, updateGroup } from 'services/api';
+import { assignRolesToGroup, getGroupRoles } from 'services/api';
 import { V1GroupSearchResult } from 'services/api-ts-sdk';
 import useModal, { ModalHooks } from 'shared/hooks/useModal/useModal';
 import { ErrorType } from 'shared/utils/error';
@@ -82,7 +82,10 @@ const useModalGroupRoles = ({ onClose, group, roles }: ModalProps): ModalHooks =
 
     try {
       const formData = form.getFieldsValue();
-      await updateGroup({ groupId: group.group.groupId, ...formData });
+      await assignRolesToGroup({
+        groupId: group.group.groupId,
+        ...formData,
+      });
       message.success('Updated group roles.');
       form.resetFields();
       onClose?.();

--- a/webui/react/src/hooks/useModal/UserSettings/useModalGroupRoles.tsx
+++ b/webui/react/src/hooks/useModal/UserSettings/useModalGroupRoles.tsx
@@ -1,0 +1,113 @@
+import { Form, message, Select } from 'antd';
+import { FormInstance } from 'antd/lib/form/hooks/useForm';
+import React, { useCallback, useEffect, useState } from 'react';
+
+import { getGroupRoles, updateGroup } from 'services/api';
+import { V1GroupSearchResult } from 'services/api-ts-sdk';
+import useModal, { ModalHooks } from 'shared/hooks/useModal/useModal';
+import { ErrorType } from 'shared/utils/error';
+import { UserRole } from 'types';
+import handleError from 'utils/error';
+
+interface Props {
+  form: FormInstance;
+  group: V1GroupSearchResult;
+  roles: UserRole[];
+}
+
+const ModalForm: React.FC<Props> = ({ form, roles, group }) => {
+  const [ groupRoles, setGroupRoles ] = useState<UserRole[]>([]);
+  const [ isLoading, setIsLoading ] = useState(true);
+
+  const fetchGroupRoles = useCallback(async () => {
+    if (group?.group.groupId) {
+      try {
+        const roles = await getGroupRoles({ groupId: group.group.groupId });
+        setGroupRoles(roles);
+      } catch (e) {
+        handleError(e, { publicSubject: 'Unable to fetch this group\'s roles.' });
+      } finally {
+        setIsLoading(false);
+      }
+    } else {
+      setIsLoading(false);
+    }
+  }, [ group ]);
+  useEffect(() => {
+    fetchGroupRoles();
+  }, [ fetchGroupRoles ]);
+
+  return (
+    <Form
+      form={form}
+      labelCol={{ span: 8 }}
+      wrapperCol={{ span: 14 }}>
+      <Form.Item label="Roles" name="roles">
+        <Select
+          loading={isLoading}
+          mode="multiple"
+          optionFilterProp="children"
+          placeholder={`Add Roles to: ${group.group.name}`}
+          showSearch>{
+            roles.filter(
+              (r) => !groupRoles.find((gr) => gr.id === r.id),
+            ).map((r) => (
+              <Select.Option key={r.id} value={r.id}>{r.name}</Select.Option>
+            ))
+          }
+        </Select>
+      </Form.Item>
+    </Form>
+  );
+};
+
+interface ModalProps {
+  group: V1GroupSearchResult;
+  onClose?: () => void;
+  roles: UserRole[];
+}
+
+const useModalGroupRoles = ({ onClose, group, roles }: ModalProps): ModalHooks => {
+
+  const [ form ] = Form.useForm();
+
+  const { modalOpen: openOrUpdate, ...modalHook } = useModal();
+
+  const handleCancel = useCallback(() => {
+    form.resetFields();
+  }, [ form ]);
+
+  const onOk = useCallback(async () => {
+    await form.validateFields();
+
+    try {
+      const formData = form.getFieldsValue();
+      await updateGroup({ groupId: group.group.groupId, ...formData });
+      message.success('Updated group roles.');
+      form.resetFields();
+      onClose?.();
+    } catch (e) {
+      message.error('Error updating group roles.');
+      handleError(e, { silent: true, type: ErrorType.Input });
+
+      // Re-throw error to prevent modal from getting dismissed.
+      throw e;
+    }
+  }, [ form, onClose, group ]);
+
+  const modalOpen = useCallback(() => {
+    openOrUpdate({
+      closable: true,
+      content: <ModalForm form={form} group={group} roles={roles} />,
+      icon: null,
+      okText: 'Update Roles',
+      onCancel: handleCancel,
+      onOk: onOk,
+      title: <h5>Update Roles</h5>,
+    });
+  }, [ form, handleCancel, onOk, openOrUpdate, roles, group ]);
+
+  return { modalOpen, ...modalHook };
+};
+
+export default useModalGroupRoles;

--- a/webui/react/src/hooks/useModal/UserSettings/useModalGroupRoles.tsx
+++ b/webui/react/src/hooks/useModal/UserSettings/useModalGroupRoles.tsx
@@ -78,13 +78,16 @@ const useModalGroupRoles = ({ onClose, group, roles }: ModalProps): ModalHooks =
   }, [ form ]);
 
   const onOk = useCallback(async () => {
+    if (!group.group.groupId) {
+      return;
+    }
     await form.validateFields();
 
     try {
       const formData = form.getFieldsValue();
       await assignRolesToGroup({
         groupId: group.group.groupId,
-        ...formData,
+        roleIds: formData.roles,
       });
       message.success('Updated group roles.');
       form.resetFields();

--- a/webui/react/src/hooks/useModal/UserSettings/useModalGroupRoles.tsx
+++ b/webui/react/src/hooks/useModal/UserSettings/useModalGroupRoles.tsx
@@ -1,4 +1,4 @@
-import { Form, message, Select } from 'antd';
+import { Form, message, Select, Table } from 'antd';
 import { FormInstance } from 'antd/lib/form/hooks/useForm';
 import React, { useCallback, useEffect, useState } from 'react';
 
@@ -38,12 +38,29 @@ const ModalForm: React.FC<Props> = ({ form, group }) => {
     fetchGroupRoles();
   }, [ fetchGroupRoles ]);
 
+  const roleColumns = [
+    {
+      dataIndex: 'name',
+      key: 'name',
+      title: 'Name',
+    },
+  ];
+
   return (
     <Form
       form={form}
       labelCol={{ span: 8 }}
       wrapperCol={{ span: 14 }}>
       <Form.Item label="Roles" name="roles">
+        {groupRoles.length
+          ? (
+            <Table
+              columns={roleColumns}
+              dataSource={groupRoles}
+              pagination={{ hideOnSinglePage: true, size: 'small' }}
+            />
+          )
+          : null}
         <Select
           loading={isLoading}
           mode="multiple"

--- a/webui/react/src/hooks/usePermissions.ts
+++ b/webui/react/src/hooks/usePermissions.ts
@@ -39,7 +39,7 @@ interface PermissionsHook {
   canDeleteModelVersion: (arg0: ModelVersionPermissionsArgs) => boolean;
   canDeleteProjects: (arg0: ProjectPermissionsArgs) => boolean;
   canDeleteWorkspace: (arg0: WorkspacePermissionsArgs) => boolean;
-  canGetPermissions: () => boolean;
+  canGetPermissions: boolean;
   canModifyProjects: (arg0: ProjectPermissionsArgs) => boolean;
   canModifyWorkspace: (arg0: WorkspacePermissionsArgs) => boolean;
   canMoveExperiment: (arg0: ExperimentPermissionsArgs) => boolean;
@@ -86,7 +86,7 @@ const usePermissions = (): PermissionsHook => {
       userAssignments,
       userRoles,
     ),
-    canGetPermissions: () => canGetPermissions(
+    canGetPermissions: canGetPermissions(
       user,
       userAssignments,
       userRoles,

--- a/webui/react/src/pages/Settings/GroupManagement.tsx
+++ b/webui/react/src/pages/Settings/GroupManagement.tsx
@@ -9,13 +9,13 @@ import useModalCreateGroup from 'hooks/useModal/UserSettings/useModalCreateGroup
 import useModalDeleteGroup from 'hooks/useModal/UserSettings/useModalDeleteGroup';
 import useModalGroupRoles from 'hooks/useModal/UserSettings/useModalGroupRoles';
 import useSettings, { UpdateSettings } from 'hooks/useSettings';
-import { getGroup, getGroups, getUsers, listRoles, updateGroup } from 'services/api';
+import { getGroup, getGroups, getUsers, updateGroup } from 'services/api';
 import { V1GroupDetails, V1GroupSearchResult, V1User } from 'services/api-ts-sdk';
 import dropdownCss from 'shared/components/ActionDropdown/ActionDropdown.module.scss';
 import Icon from 'shared/components/Icon/Icon';
 import { isEqual } from 'shared/utils/data';
 import { ErrorType } from 'shared/utils/error';
-import { DetailedUser, UserRole } from 'types';
+import { DetailedUser } from 'types';
 import handleError from 'utils/error';
 
 import css from './GroupManagement.module.scss';
@@ -27,7 +27,6 @@ interface DropdownProps {
   fetchGroup: (groupId: number) => void;
   fetchGroups: () => void;
   group: V1GroupSearchResult;
-  roles: UserRole[];
   users: DetailedUser[];
 }
 
@@ -36,7 +35,6 @@ const GroupActionDropdown = ({
   fetchGroups,
   fetchGroup,
   group,
-  roles,
   users,
 }: DropdownProps) => {
   const onFinishEdit = () => {
@@ -50,7 +48,7 @@ const GroupActionDropdown = ({
   const {
     modalOpen: openEditGroupRolesModal,
     contextHolder: modalEditGroupRolesContextHolder,
-  } = useModalGroupRoles({ group, onClose: onFinishEdit, roles });
+  } = useModalGroupRoles({ group, onClose: onFinishEdit });
   const {
     modalOpen: openDeleteGroupModal,
     contextHolder: modalDeleteGroupContextHolder,
@@ -90,7 +88,6 @@ const GroupActionDropdown = ({
 const GroupManagement: React.FC = () => {
   const [ groups, setGroups ] = useState<V1GroupSearchResult[]>([]);
   const [ groupUsers, setGroupUsers ] = useState<V1GroupDetails[]>([]);
-  const [ roles, setRoles ] = useState<UserRole[]>([]);
   const [ users, setUsers ] = useState<DetailedUser[]>([]);
   const [ isLoading, setIsLoading ] = useState(true);
   const [ total, setTotal ] = useState(0);
@@ -135,11 +132,6 @@ const GroupManagement: React.FC = () => {
     setGroupUsers(groupUsers);
   }, [ groupUsers ]);
 
-  const fetchRoles = useCallback(async (): Promise<void> => {
-    const response = await listRoles({ isGlobal: true });
-    setRoles(response);
-  }, [ ]);
-
   const fetchUsers = useCallback(async (): Promise<void> => {
     try {
       const response = await getUsers(
@@ -158,12 +150,10 @@ const GroupManagement: React.FC = () => {
   useEffect(() => {
     fetchGroups();
     fetchUsers();
-    fetchRoles();
   }, [
     settings.tableLimit,
     settings.tableOffset,
     fetchGroups,
-    fetchRoles,
     fetchUsers ]);
 
   const {
@@ -236,7 +226,6 @@ const GroupManagement: React.FC = () => {
           fetchGroup={fetchGroup}
           fetchGroups={fetchGroups}
           group={record}
-          roles={roles}
           users={users}
         />
       );
@@ -270,7 +259,7 @@ const GroupManagement: React.FC = () => {
         width: DEFAULT_COLUMN_WIDTHS['action'],
       },
     ];
-  }, [ roles, users, fetchGroups, expandedKeys, fetchGroup ]);
+  }, [ users, fetchGroups, expandedKeys, fetchGroup ]);
 
   const table = useMemo(() => {
     return (

--- a/webui/react/src/pages/Settings/GroupManagement.tsx
+++ b/webui/react/src/pages/Settings/GroupManagement.tsx
@@ -60,7 +60,7 @@ const GroupActionDropdown = ({
         Edit/Add Users
       </Menu.Item>
       <Menu.Item key="roles" onClick={() => openEditGroupRolesModal()}>
-        Edit/Add Roles
+        Add Roles
       </Menu.Item>
       <Menu.Item danger key="delete" onClick={() => openDeleteGroupModal()}>
         Delete

--- a/webui/react/src/pages/Settings/GroupManagement.tsx
+++ b/webui/react/src/pages/Settings/GroupManagement.tsx
@@ -136,7 +136,7 @@ const GroupManagement: React.FC = () => {
   }, [ groupUsers ]);
 
   const fetchRoles = useCallback(async (): Promise<void> => {
-    const response = await listRoles({});
+    const response = await listRoles({ isGlobal: true });
     setRoles(response);
   }, [ ]);
 

--- a/webui/react/src/services/api-ts-sdk/api.ts
+++ b/webui/react/src/services/api-ts-sdk/api.ts
@@ -2961,26 +2961,6 @@ export interface V1GetNotebooksResponse {
 }
 
 /**
- * Response to GetPermissionsSummaryRequest.
- * @export
- * @interface V1GetPermissionsSummaryResponse
- */
-export interface V1GetPermissionsSummaryResponse {
-    /**
-     * A group of roles in cluster and other scopes.
-     * @type {Array<V1Role>}
-     * @memberof V1GetPermissionsSummaryResponse
-     */
-    roles: Array<V1Role>;
-    /**
-     * Lists of assignments for the cluster and other scopes.
-     * @type {Array<V1RoleAssignmentSummary>}
-     * @memberof V1GetPermissionsSummaryResponse
-     */
-    assignments: Array<V1RoleAssignmentSummary>;
-}
-
-/**
  * Response to GetProjectRequest.
  * @export
  * @interface V1GetProjectResponse
@@ -4105,7 +4085,7 @@ export interface V1LaunchTensorboardResponse {
  */
 export interface V1ListRolesRequest {
     /**
-     * 
+     * the offset for pagination.
      * @type {number}
      * @memberof V1ListRolesRequest
      */
@@ -4116,6 +4096,12 @@ export interface V1ListRolesRequest {
      * @memberof V1ListRolesRequest
      */
     limit: number;
+    /**
+     * searching global roles.
+     * @type {boolean}
+     * @memberof V1ListRolesRequest
+     */
+    isGlobal: boolean;
 }
 
 /**
@@ -5047,10 +5033,10 @@ export interface V1PauseExperimentResponse {
 export interface V1Permission {
     /**
      * 
-     * @type {V1PermissionType}
+     * @type {number}
      * @memberof V1Permission
      */
-    id?: V1PermissionType;
+    id: number;
     /**
      * 
      * @type {string}
@@ -5063,33 +5049,6 @@ export interface V1Permission {
      * @memberof V1Permission
      */
     isGlobal?: boolean;
-}
-
-/**
- * List of permissions types. Value of the enum has 9xxxx for global only permissions. Permissions on the same object share the thousands place value like 2001 and 2002.   - PERMISSION_TYPE_UNSPECIFIED: The permission type is unknown.  - PERMISSION_TYPE_ADMINISTRATE_USER: Can create and update other users. Allows updating other users passwords making this permission give all other permissions effectively.  - PERMISSION_TYPE_CREATE_EXPERIMENT: Ability to create experiments.  - PERMISSION_TYPE_VIEW_EXPERIMENT_ARTIFACTS: Ability to view experiment's model code, checkpoints, trials.  - PERMISSION_TYPE_VIEW_EXPERIMENT_METADATA: Ability to view experiment's metadata like experiment config, progress.  - PERMISSION_TYPE_UPDATE_EXPERIMENT: Ability to update experiment and experiment's lifecycle.  - PERMISSION_TYPE_UPDATE_EXPERIMENT_METADATA: Ability to update experiment's metadata.  - PERMISSION_TYPE_DELETE_EXPERIMENT: Ability to delete experiment.  - PERMISSION_TYPE_UPDATE_GROUP: Ability to create, update, and add / remove users from groups.  - PERMISSION_TYPE_CREATE_WORKSPACE: Ability to create workspaces.  - PERMISSION_TYPE_VIEW_WORKSPACE: Ability to view workspace.  - PERMISSION_TYPE_UPDATE_WORKSPACE: Ability to update workspace.  - PERMISSION_TYPE_DELETE_WORKSPACE: Ability to delete workspace.  - PERMISSION_TYPE_CREATE_PROJECT: Ability to create projects.  - PERMISSION_TYPE_VIEW_PROJECT: Ability to view projects.  - PERMISSION_TYPE_UPDATE_PROJECT: Ability to update projects.  - PERMISSION_TYPE_DELETE_PROJECT: Ability to delete projects.  - PERMISSION_TYPE_UPDATE_ROLES: Ability to create and update role definitions.  - PERMISSION_TYPE_ASSIGN_ROLES: Ability to assign roles to groups / users. If assigned at a workspace scope, can only assign roles to that workspace scope.
- * @export
- * @enum {string}
- */
-export enum V1PermissionType {
-    UNSPECIFIED = <any> 'PERMISSION_TYPE_UNSPECIFIED',
-    ADMINISTRATEUSER = <any> 'PERMISSION_TYPE_ADMINISTRATE_USER',
-    CREATEEXPERIMENT = <any> 'PERMISSION_TYPE_CREATE_EXPERIMENT',
-    VIEWEXPERIMENTARTIFACTS = <any> 'PERMISSION_TYPE_VIEW_EXPERIMENT_ARTIFACTS',
-    VIEWEXPERIMENTMETADATA = <any> 'PERMISSION_TYPE_VIEW_EXPERIMENT_METADATA',
-    UPDATEEXPERIMENT = <any> 'PERMISSION_TYPE_UPDATE_EXPERIMENT',
-    UPDATEEXPERIMENTMETADATA = <any> 'PERMISSION_TYPE_UPDATE_EXPERIMENT_METADATA',
-    DELETEEXPERIMENT = <any> 'PERMISSION_TYPE_DELETE_EXPERIMENT',
-    UPDATEGROUP = <any> 'PERMISSION_TYPE_UPDATE_GROUP',
-    CREATEWORKSPACE = <any> 'PERMISSION_TYPE_CREATE_WORKSPACE',
-    VIEWWORKSPACE = <any> 'PERMISSION_TYPE_VIEW_WORKSPACE',
-    UPDATEWORKSPACE = <any> 'PERMISSION_TYPE_UPDATE_WORKSPACE',
-    DELETEWORKSPACE = <any> 'PERMISSION_TYPE_DELETE_WORKSPACE',
-    CREATEPROJECT = <any> 'PERMISSION_TYPE_CREATE_PROJECT',
-    VIEWPROJECT = <any> 'PERMISSION_TYPE_VIEW_PROJECT',
-    UPDATEPROJECT = <any> 'PERMISSION_TYPE_UPDATE_PROJECT',
-    DELETEPROJECT = <any> 'PERMISSION_TYPE_DELETE_PROJECT',
-    UPDATEROLES = <any> 'PERMISSION_TYPE_UPDATE_ROLES',
-    ASSIGNROLES = <any> 'PERMISSION_TYPE_ASSIGN_ROLES'
 }
 
 /**
@@ -6463,7 +6422,7 @@ export interface V1Role {
      * @type {number}
      * @memberof V1Role
      */
-    roleId?: number;
+    roleId: number;
     /**
      * 
      * @type {string}
@@ -6496,32 +6455,6 @@ export interface V1RoleAssignment {
      * @memberof V1RoleAssignment
      */
     scopeWorkspaceId?: number;
-}
-
-/**
- * RoleAssignmentSummary is used to describe permissions a user has.
- * @export
- * @interface V1RoleAssignmentSummary
- */
-export interface V1RoleAssignmentSummary {
-    /**
-     * 
-     * @type {number}
-     * @memberof V1RoleAssignmentSummary
-     */
-    roleId?: number;
-    /**
-     * List of workspace IDs to apply the role.
-     * @type {Array<number>}
-     * @memberof V1RoleAssignmentSummary
-     */
-    scopeWorkspaceIds?: Array<number>;
-    /**
-     * 
-     * @type {boolean}
-     * @memberof V1RoleAssignmentSummary
-     */
-    isGlobal?: boolean;
 }
 
 /**
@@ -19577,37 +19510,6 @@ export const RBACApiFetchParamCreator = function (configuration?: Configuration)
         },
         /**
          * 
-         * @summary List all permissions for the logged in user in all scopes.
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        getPermissionsSummary(options: any = {}): FetchArgs {
-            const localVarPath = `/api/v1/permissions/summary`;
-            const localVarUrlObj = url.parse(localVarPath, true);
-            const localVarRequestOptions = Object.assign({ method: 'GET' }, options);
-            const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
-
-            // authentication BearerToken required
-            if (configuration && configuration.apiKey) {
-                const localVarApiKeyValue = typeof configuration.apiKey === 'function'
-					? configuration.apiKey("Authorization")
-					: configuration.apiKey;
-                localVarHeaderParameter["Authorization"] = localVarApiKeyValue;
-            }
-
-            localVarUrlObj.query = Object.assign({}, localVarUrlObj.query, localVarQueryParameter, options.query);
-            // fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
-            delete localVarUrlObj.search;
-            localVarRequestOptions.headers = Object.assign({}, localVarHeaderParameter, options.headers);
-
-            return {
-                url: url.format(localVarUrlObj),
-                options: localVarRequestOptions,
-            };
-        },
-        /**
-         * 
          * @summary Get the roles which are assigned to a group.
          * @param {number} groupId The id of the group to search for role assignments for
          * @param {*} [options] Override http request option.
@@ -19870,24 +19772,6 @@ export const RBACApiFp = function(configuration?: Configuration) {
         },
         /**
          * 
-         * @summary List all permissions for the logged in user in all scopes.
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        getPermissionsSummary(options?: any): (fetch?: FetchAPI, basePath?: string) => Promise<V1GetPermissionsSummaryResponse> {
-            const localVarFetchArgs = RBACApiFetchParamCreator(configuration).getPermissionsSummary(options);
-            return (fetch: FetchAPI = portableFetch, basePath: string = BASE_PATH) => {
-                return fetch(basePath + localVarFetchArgs.url, localVarFetchArgs.options).then((response) => {
-                    if (response.status >= 200 && response.status < 300) {
-                        return response.json();
-                    } else {
-                        throw response;
-                    }
-                });
-            };
-        },
-        /**
-         * 
          * @summary Get the roles which are assigned to a group.
          * @param {number} groupId The id of the group to search for role assignments for
          * @param {*} [options] Override http request option.
@@ -20021,15 +19905,6 @@ export const RBACApiFactory = function (configuration?: Configuration, fetch?: F
         },
         /**
          * 
-         * @summary List all permissions for the logged in user in all scopes.
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        getPermissionsSummary(options?: any) {
-            return RBACApiFp(configuration).getPermissionsSummary(options)(fetch, basePath);
-        },
-        /**
-         * 
          * @summary Get the roles which are assigned to a group.
          * @param {number} groupId The id of the group to search for role assignments for
          * @param {*} [options] Override http request option.
@@ -20108,17 +19983,6 @@ export class RBACApi extends BaseAPI {
      */
     public assignRoles(body: V1AssignRolesRequest, options?: any) {
         return RBACApiFp(this.configuration).assignRoles(body, options)(this.fetch, this.basePath);
-    }
-
-    /**
-     * 
-     * @summary List all permissions for the logged in user in all scopes.
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof RBACApi
-     */
-    public getPermissionsSummary(options?: any) {
-        return RBACApiFp(this.configuration).getPermissionsSummary(options)(this.fetch, this.basePath);
     }
 
     /**

--- a/webui/react/src/services/api-ts-sdk/api.ts
+++ b/webui/react/src/services/api-ts-sdk/api.ts
@@ -4116,12 +4116,6 @@ export interface V1ListRolesRequest {
      * @memberof V1ListRolesRequest
      */
     limit: number;
-    /**
-     * searching global roles.
-     * @type {boolean}
-     * @memberof V1ListRolesRequest
-     */
-    isGlobal: boolean;
 }
 
 /**

--- a/webui/react/src/services/api-ts-sdk/api.ts
+++ b/webui/react/src/services/api-ts-sdk/api.ts
@@ -2961,6 +2961,26 @@ export interface V1GetNotebooksResponse {
 }
 
 /**
+ * Response to GetPermissionsSummaryRequest.
+ * @export
+ * @interface V1GetPermissionsSummaryResponse
+ */
+export interface V1GetPermissionsSummaryResponse {
+    /**
+     * A group of roles in cluster and other scopes.
+     * @type {Array<V1Role>}
+     * @memberof V1GetPermissionsSummaryResponse
+     */
+    roles: Array<V1Role>;
+    /**
+     * Lists of assignments for the cluster and other scopes.
+     * @type {Array<V1RoleAssignmentSummary>}
+     * @memberof V1GetPermissionsSummaryResponse
+     */
+    assignments: Array<V1RoleAssignmentSummary>;
+}
+
+/**
  * Response to GetProjectRequest.
  * @export
  * @interface V1GetProjectResponse
@@ -5033,10 +5053,10 @@ export interface V1PauseExperimentResponse {
 export interface V1Permission {
     /**
      * 
-     * @type {number}
+     * @type {V1PermissionType}
      * @memberof V1Permission
      */
-    id: number;
+    id: V1PermissionType;
     /**
      * 
      * @type {string}
@@ -5049,6 +5069,33 @@ export interface V1Permission {
      * @memberof V1Permission
      */
     isGlobal?: boolean;
+}
+
+/**
+ * List of permissions types. Value of the enum has 9xxxx for global only permissions. Permissions on the same object share the thousands place value like 2001 and 2002.   - PERMISSION_TYPE_UNSPECIFIED: The permission type is unknown.  - PERMISSION_TYPE_ADMINISTRATE_USER: Can create and update other users. Allows updating other users passwords making this permission give all other permissions effectively.  - PERMISSION_TYPE_CREATE_EXPERIMENT: Ability to create experiments.  - PERMISSION_TYPE_VIEW_EXPERIMENT_ARTIFACTS: Ability to view experiment's model code, checkpoints, trials.  - PERMISSION_TYPE_VIEW_EXPERIMENT_METADATA: Ability to view experiment's metadata like experiment config, progress.  - PERMISSION_TYPE_UPDATE_EXPERIMENT: Ability to update experiment and experiment's lifecycle.  - PERMISSION_TYPE_UPDATE_EXPERIMENT_METADATA: Ability to update experiment's metadata.  - PERMISSION_TYPE_DELETE_EXPERIMENT: Ability to delete experiment.  - PERMISSION_TYPE_UPDATE_GROUP: Ability to create, update, and add / remove users from groups.  - PERMISSION_TYPE_CREATE_WORKSPACE: Ability to create workspaces.  - PERMISSION_TYPE_VIEW_WORKSPACE: Ability to view workspace.  - PERMISSION_TYPE_UPDATE_WORKSPACE: Ability to update workspace.  - PERMISSION_TYPE_DELETE_WORKSPACE: Ability to delete workspace.  - PERMISSION_TYPE_CREATE_PROJECT: Ability to create projects.  - PERMISSION_TYPE_VIEW_PROJECT: Ability to view projects.  - PERMISSION_TYPE_UPDATE_PROJECT: Ability to update projects.  - PERMISSION_TYPE_DELETE_PROJECT: Ability to delete projects.  - PERMISSION_TYPE_UPDATE_ROLES: Ability to create and update role definitions.  - PERMISSION_TYPE_ASSIGN_ROLES: Ability to assign roles to groups / users. If assigned at a workspace scope, can only assign roles to that workspace scope.
+ * @export
+ * @enum {string}
+ */
+export enum V1PermissionType {
+    UNSPECIFIED = <any> 'PERMISSION_TYPE_UNSPECIFIED',
+    ADMINISTRATEUSER = <any> 'PERMISSION_TYPE_ADMINISTRATE_USER',
+    CREATEEXPERIMENT = <any> 'PERMISSION_TYPE_CREATE_EXPERIMENT',
+    VIEWEXPERIMENTARTIFACTS = <any> 'PERMISSION_TYPE_VIEW_EXPERIMENT_ARTIFACTS',
+    VIEWEXPERIMENTMETADATA = <any> 'PERMISSION_TYPE_VIEW_EXPERIMENT_METADATA',
+    UPDATEEXPERIMENT = <any> 'PERMISSION_TYPE_UPDATE_EXPERIMENT',
+    UPDATEEXPERIMENTMETADATA = <any> 'PERMISSION_TYPE_UPDATE_EXPERIMENT_METADATA',
+    DELETEEXPERIMENT = <any> 'PERMISSION_TYPE_DELETE_EXPERIMENT',
+    UPDATEGROUP = <any> 'PERMISSION_TYPE_UPDATE_GROUP',
+    CREATEWORKSPACE = <any> 'PERMISSION_TYPE_CREATE_WORKSPACE',
+    VIEWWORKSPACE = <any> 'PERMISSION_TYPE_VIEW_WORKSPACE',
+    UPDATEWORKSPACE = <any> 'PERMISSION_TYPE_UPDATE_WORKSPACE',
+    DELETEWORKSPACE = <any> 'PERMISSION_TYPE_DELETE_WORKSPACE',
+    CREATEPROJECT = <any> 'PERMISSION_TYPE_CREATE_PROJECT',
+    VIEWPROJECT = <any> 'PERMISSION_TYPE_VIEW_PROJECT',
+    UPDATEPROJECT = <any> 'PERMISSION_TYPE_UPDATE_PROJECT',
+    DELETEPROJECT = <any> 'PERMISSION_TYPE_DELETE_PROJECT',
+    UPDATEROLES = <any> 'PERMISSION_TYPE_UPDATE_ROLES',
+    ASSIGNROLES = <any> 'PERMISSION_TYPE_ASSIGN_ROLES'
 }
 
 /**
@@ -6455,6 +6502,32 @@ export interface V1RoleAssignment {
      * @memberof V1RoleAssignment
      */
     scopeWorkspaceId?: number;
+}
+
+/**
+ * RoleAssignmentSummary is used to describe permissions a user has.
+ * @export
+ * @interface V1RoleAssignmentSummary
+ */
+export interface V1RoleAssignmentSummary {
+    /**
+     * 
+     * @type {number}
+     * @memberof V1RoleAssignmentSummary
+     */
+    roleId?: number;
+    /**
+     * List of workspace IDs to apply the role.
+     * @type {Array<number>}
+     * @memberof V1RoleAssignmentSummary
+     */
+    scopeWorkspaceIds?: Array<number>;
+    /**
+     * 
+     * @type {boolean}
+     * @memberof V1RoleAssignmentSummary
+     */
+    isGlobal?: boolean;
 }
 
 /**
@@ -19510,6 +19583,37 @@ export const RBACApiFetchParamCreator = function (configuration?: Configuration)
         },
         /**
          * 
+         * @summary List all permissions for the logged in user in all scopes.
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        getPermissionsSummary(options: any = {}): FetchArgs {
+            const localVarPath = `/api/v1/permissions/summary`;
+            const localVarUrlObj = url.parse(localVarPath, true);
+            const localVarRequestOptions = Object.assign({ method: 'GET' }, options);
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            // authentication BearerToken required
+            if (configuration && configuration.apiKey) {
+                const localVarApiKeyValue = typeof configuration.apiKey === 'function'
+					? configuration.apiKey("Authorization")
+					: configuration.apiKey;
+                localVarHeaderParameter["Authorization"] = localVarApiKeyValue;
+            }
+
+            localVarUrlObj.query = Object.assign({}, localVarUrlObj.query, localVarQueryParameter, options.query);
+            // fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
+            delete localVarUrlObj.search;
+            localVarRequestOptions.headers = Object.assign({}, localVarHeaderParameter, options.headers);
+
+            return {
+                url: url.format(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         * 
          * @summary Get the roles which are assigned to a group.
          * @param {number} groupId The id of the group to search for role assignments for
          * @param {*} [options] Override http request option.
@@ -19772,6 +19876,24 @@ export const RBACApiFp = function(configuration?: Configuration) {
         },
         /**
          * 
+         * @summary List all permissions for the logged in user in all scopes.
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        getPermissionsSummary(options?: any): (fetch?: FetchAPI, basePath?: string) => Promise<V1GetPermissionsSummaryResponse> {
+            const localVarFetchArgs = RBACApiFetchParamCreator(configuration).getPermissionsSummary(options);
+            return (fetch: FetchAPI = portableFetch, basePath: string = BASE_PATH) => {
+                return fetch(basePath + localVarFetchArgs.url, localVarFetchArgs.options).then((response) => {
+                    if (response.status >= 200 && response.status < 300) {
+                        return response.json();
+                    } else {
+                        throw response;
+                    }
+                });
+            };
+        },
+        /**
+         * 
          * @summary Get the roles which are assigned to a group.
          * @param {number} groupId The id of the group to search for role assignments for
          * @param {*} [options] Override http request option.
@@ -19905,6 +20027,15 @@ export const RBACApiFactory = function (configuration?: Configuration, fetch?: F
         },
         /**
          * 
+         * @summary List all permissions for the logged in user in all scopes.
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        getPermissionsSummary(options?: any) {
+            return RBACApiFp(configuration).getPermissionsSummary(options)(fetch, basePath);
+        },
+        /**
+         * 
          * @summary Get the roles which are assigned to a group.
          * @param {number} groupId The id of the group to search for role assignments for
          * @param {*} [options] Override http request option.
@@ -19983,6 +20114,17 @@ export class RBACApi extends BaseAPI {
      */
     public assignRoles(body: V1AssignRolesRequest, options?: any) {
         return RBACApiFp(this.configuration).assignRoles(body, options)(this.fetch, this.basePath);
+    }
+
+    /**
+     * 
+     * @summary List all permissions for the logged in user in all scopes.
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof RBACApi
+     */
+    public getPermissionsSummary(options?: any) {
+        return RBACApiFp(this.configuration).getPermissionsSummary(options)(this.fetch, this.basePath);
     }
 
     /**

--- a/webui/react/src/services/api.ts
+++ b/webui/react/src/services/api.ts
@@ -98,6 +98,18 @@ Service.DeleteGroupParams,
  Api.V1DeleteGroupResponse, Api.V1DeleteGroupResponse
 >(Config.deleteGroup);
 
+/* Roles */
+
+export const getGroupRoles = generateDetApi<
+  Service.GetGroupParams,
+  Api.V1GetRolesAssignedToGroupResponse, Type.UserRole[]
+>(Config.getGroupRoles);
+
+export const listRoles = generateDetApi<
+  EmptyParams,
+   Api.V1ListRolesResponse, Type.UserRole[]
+>(Config.listRoles);
+
 /* Info */
 
 export const getInfo = generateDetApi<

--- a/webui/react/src/services/api.ts
+++ b/webui/react/src/services/api.ts
@@ -106,8 +106,8 @@ export const getGroupRoles = generateDetApi<
 >(Config.getGroupRoles);
 
 export const listRoles = generateDetApi<
-  EmptyParams,
-   Api.V1ListRolesResponse, Type.UserRole[]
+  Service.ListRolesParams,
+  Api.V1ListRolesResponse, Type.UserRole[]
 >(Config.listRoles);
 
 export const assignRolesToGroup = generateDetApi<

--- a/webui/react/src/services/api.ts
+++ b/webui/react/src/services/api.ts
@@ -110,6 +110,11 @@ export const listRoles = generateDetApi<
    Api.V1ListRolesResponse, Type.UserRole[]
 >(Config.listRoles);
 
+export const assignRolesToGroup = generateDetApi<
+  Service.AssignRolesToGroupParams,
+  Api.V1AssignRolesResponse, Api.V1AssignRolesResponse
+>(Config.assignRolesToGroup);
+
 /* Info */
 
 export const getInfo = generateDetApi<

--- a/webui/react/src/services/apiConfig.ts
+++ b/webui/react/src/services/apiConfig.ts
@@ -31,6 +31,7 @@ const generateApiConfig = (apiConfig?: Api.ConfigurationParameters) => {
     Models: new Api.ModelsApi(config),
     Notebooks: new Api.NotebooksApi(config),
     Projects: new Api.ProjectsApi(config),
+    RBAC: new Api.RBACApi(config),
     Shells: new Api.ShellsApi(config),
     StreamingCluster: Api.ClusterApiFetchParamCreator(config),
     StreamingExperiments: Api.ExperimentsApiFetchParamCreator(config),
@@ -280,6 +281,26 @@ Service.DeleteGroupParams,
   request: (params) => detApi.Internal.deleteGroup(
     params.groupId,
   ),
+};
+
+/* Roles */
+
+export const getGroupRoles: DetApi<
+  Service.GetGroupParams,
+  Api.V1GetRolesAssignedToGroupResponse, Type.UserRole[]
+> = {
+  name: 'getRolesAssignedToGroup',
+  postProcess: (response) => (response.roles || []).map(decoder.mapV1Role),
+  request: (params) => detApi.RBAC.getRolesAssignedToGroup(params.groupId),
+};
+
+export const listRoles: DetApi<
+  EmptyParams,
+  Api.V1ListRolesResponse, Type.UserRole[]
+> = {
+  name: 'listRoles',
+  postProcess: (response) => response.roles.map(decoder.mapV1Role),
+  request: () => detApi.RBAC.listRoles({ limit: 0 }),
 };
 
 /* Info */

--- a/webui/react/src/services/apiConfig.ts
+++ b/webui/react/src/services/apiConfig.ts
@@ -301,7 +301,6 @@ export const listRoles: DetApi<
   name: 'listRoles',
   postProcess: (response) => response.roles.map(decoder.mapV1Role),
   request: (params) => detApi.RBAC.listRoles({
-    isGlobal: params.isGlobal,
     limit: params.limit || 0,
     offset: params.offset || 0,
   }),

--- a/webui/react/src/services/apiConfig.ts
+++ b/webui/react/src/services/apiConfig.ts
@@ -295,12 +295,16 @@ export const getGroupRoles: DetApi<
 };
 
 export const listRoles: DetApi<
-  EmptyParams,
+  Service.ListRolesParams,
   Api.V1ListRolesResponse, Type.UserRole[]
 > = {
   name: 'listRoles',
   postProcess: (response) => response.roles.map(decoder.mapV1Role),
-  request: () => detApi.RBAC.listRoles({ limit: 0 }),
+  request: (params) => detApi.RBAC.listRoles({
+    isGlobal: params.isGlobal,
+    limit: params.limit || 0,
+    offset: params.offset || 0,
+  }),
 };
 
 export const assignRolesToGroup: DetApi<
@@ -310,9 +314,9 @@ export const assignRolesToGroup: DetApi<
   name: 'assignRolesToGroup',
   postProcess: (response) => response,
   request: (params) => detApi.RBAC.assignRoles({
-    groupRoleAssignments: params.roles.map((role) => ({
+    groupRoleAssignments: params.roleIds.map((roleId) => ({
       groupId: params.groupId,
-      roleAssignment: { role: { roleId: role.id } },
+      roleAssignment: { role: { roleId } },
     })),
   }),
 };

--- a/webui/react/src/services/apiConfig.ts
+++ b/webui/react/src/services/apiConfig.ts
@@ -303,6 +303,20 @@ export const listRoles: DetApi<
   request: () => detApi.RBAC.listRoles({ limit: 0 }),
 };
 
+export const assignRolesToGroup: DetApi<
+  Service.AssignRolesToGroupParams,
+  Api.V1AssignRolesResponse, Api.V1AssignRolesResponse
+> = {
+  name: 'assignRolesToGroup',
+  postProcess: (response) => response,
+  request: (params) => detApi.RBAC.assignRoles({
+    groupRoleAssignments: params.roles.map((role) => ({
+      groupId: params.groupId,
+      roleAssignment: { role: { roleId: role.id } },
+    })),
+  }),
+};
+
 /* Info */
 
 export const getInfo: DetApi<

--- a/webui/react/src/services/decoder.ts
+++ b/webui/react/src/services/decoder.ts
@@ -35,7 +35,7 @@ export const mapV1Role = (role: Sdk.V1Role): types.UserRole => {
 export const mapV1Permission = (permission: Sdk.V1Permission): types.Permission => {
   return {
     id: permission.id,
-    isGlobal: permission.isGlobal,
+    isGlobal: permission.isGlobal || false,
     name: permission.name || '',
   };
 };

--- a/webui/react/src/services/decoder.ts
+++ b/webui/react/src/services/decoder.ts
@@ -24,6 +24,23 @@ export const mapV1UserList = (data: Sdk.V1GetUsersResponse): types.DetailedUser[
   return (data.users || []).map((user) => mapV1User(user));
 };
 
+export const mapV1Role = (role: Sdk.V1Role): types.UserRole => {
+  return {
+    id: role.roleId,
+    name: role.name,
+    permissions: role.permissions.map(mapV1Permission),
+  };
+};
+
+export const mapV1Permission = (permission: Sdk.V1Permission): types.Permission => {
+  return {
+    globalOnly: permission.isGlobal,
+    id: permission.id,
+    name: permission.name,
+    workspaceOnly: !permission.isGlobal,
+  };
+};
+
 export const mapV1Pagination = (data?: Sdk.V1Pagination): Pagination => {
   return {
     limit: data?.limit ?? 0,

--- a/webui/react/src/services/decoder.ts
+++ b/webui/react/src/services/decoder.ts
@@ -34,9 +34,9 @@ export const mapV1Role = (role: Sdk.V1Role): types.UserRole => {
 
 export const mapV1Permission = (permission: Sdk.V1Permission): types.Permission => {
   return {
-    globalOnly: permission.isGlobal,
+    globalOnly: !!permission.isGlobal,
     id: permission.id,
-    name: permission.name,
+    name: permission.name || '',
     workspaceOnly: !permission.isGlobal,
   };
 };

--- a/webui/react/src/services/decoder.ts
+++ b/webui/react/src/services/decoder.ts
@@ -34,10 +34,9 @@ export const mapV1Role = (role: Sdk.V1Role): types.UserRole => {
 
 export const mapV1Permission = (permission: Sdk.V1Permission): types.Permission => {
   return {
-    globalOnly: !!permission.isGlobal,
     id: permission.id,
+    isGlobal: permission.isGlobal,
     name: permission.name || '',
-    workspaceOnly: !permission.isGlobal,
   };
 };
 

--- a/webui/react/src/services/decoder.ts
+++ b/webui/react/src/services/decoder.ts
@@ -27,8 +27,8 @@ export const mapV1UserList = (data: Sdk.V1GetUsersResponse): types.DetailedUser[
 export const mapV1Role = (role: Sdk.V1Role): types.UserRole => {
   return {
     id: role.roleId,
-    name: role.name,
-    permissions: role.permissions.map(mapV1Permission),
+    name: role.name || '',
+    permissions: (role.permissions || []).map(mapV1Permission),
   };
 };
 

--- a/webui/react/src/services/types.ts
+++ b/webui/react/src/services/types.ts
@@ -2,7 +2,7 @@ import { Dayjs } from 'dayjs';
 
 import { FetchOptions, RecordKey, SingleEntityParams } from 'shared/types';
 import { DetailedUser, Job, Metadata, MetricName, MetricType, Note,
-  Scale, TrialWorkloadFilter, UserRole } from 'types';
+  Scale, TrialWorkloadFilter } from 'types';
 
 import * as Api from './api-ts-sdk/api';
 
@@ -314,7 +314,13 @@ export type GetGroupsParams = PaginationParams
 
 export interface AssignRolesToGroupParams {
   groupId: number;
-  roles: UserRole[];
+  roleIds: number[];
+}
+
+export interface ListRolesParams {
+  isGlobal: boolean;
+  limit?: number;
+  offset?: number;
 }
 
 export interface GetProjectParams {

--- a/webui/react/src/services/types.ts
+++ b/webui/react/src/services/types.ts
@@ -318,7 +318,7 @@ export interface AssignRolesToGroupParams {
 }
 
 export interface ListRolesParams {
-  isGlobal: boolean;
+  isGlobal?: boolean;
   limit?: number;
   offset?: number;
 }

--- a/webui/react/src/services/types.ts
+++ b/webui/react/src/services/types.ts
@@ -2,7 +2,7 @@ import { Dayjs } from 'dayjs';
 
 import { FetchOptions, RecordKey, SingleEntityParams } from 'shared/types';
 import { DetailedUser, Job, Metadata, MetricName, MetricType, Note,
-  Scale, TrialWorkloadFilter } from 'types';
+  Scale, TrialWorkloadFilter, UserRole } from 'types';
 
 import * as Api from './api-ts-sdk/api';
 
@@ -311,6 +311,11 @@ export interface GetGroupParams {
 }
 
 export type GetGroupsParams = PaginationParams
+
+export interface AssignRolesToGroupParams {
+  groupId: number;
+  roles: UserRole[];
+}
 
 export interface GetProjectParams {
   id: number;


### PR DESCRIPTION
## Description

- New modal, based on the Create/Edit Group modal and its tests.
- Calls `listRoles` for all global roles, `getRolesAssignedToGroup` to filter out current roles, `assignRoles` to add role to a group.
- Require role.id and permission.id fields for convenience. Don't require other fields (such as role.permissions) as these would be annoying to send back to the API.

In the future we might want to list existing roles (and users) and make them removable with checkboxes or other UI.

## Test Plan

In contexts/Store.tsx , replace the `knownRoles: [],` line with a initial demo role (since listRoles will not return content).

```typescript
knownRoles: [{
  id: -1,
  name: 'Test OSS',
  permissions: [{
    id: -2,
    isGlobal: true,
    name: 'oss_user',
  }],
}],  // comma before pinnedWorkspaces
```

## Checklist
- [ ] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.
- [x] If modifying `/webui/react/src/shared/` verify `make -C webui/react test-shared` passes.