### PR TITLE
feat: cluster_admin permission and related user/group admin permissions [DET-8229]

### DIFF
--- a/webui/react/src/hooks/usePermissions.ts
+++ b/webui/react/src/hooks/usePermissions.ts
@@ -146,11 +146,13 @@ const usePermissions = (): PermissionsHook => {
 };
 
 // Permissions inside this workspace scope (no workspace = cluster-wide scope)
+// Typically returns a Set<string> of permissions.
 const relevantPermissions = (
   userAssignments?: UserAssignment[],
   userRoles?: UserRole[],
   workspaceId?: number,
-): Set<string> => {
+): { has: (arg0: string
+) => boolean } => {
   if (!userAssignments || !userRoles) {
     // console.error('missing UserAssignment or UserRole');
     return new Set<string>();
@@ -163,7 +165,12 @@ const relevantPermissions = (
     // but not all of its permissions?
     permissions = permissions.concat(r.permissions.filter((p) => p.isGlobal || workspaceId));
   });
-  return new Set<string>(permissions.map((p) => p.name));
+  const permitter = new Set<string>(permissions.map((p) => p.name));
+  // a cluster_admin has all permissions
+  if (permitter.has('cluster_admin')) {
+    return { has: () => true };
+  }
+  return permitter;
 };
 
 // User actions


### PR DESCRIPTION
## Description

- The cluster_admin has all possible permissions, so I modified `relevantPermissions` to return `{ has: () => true }` in this case instead of a Set<string>.
- Without OSS admin or permission CAN_ADMINISTRATE_USERS, the RBAC table dropdown menu has only a View Profile option.
- Without OSS admin or permission CAN_UPDATE_GROUP, the RBAC table has no dropdown menu
- I liked how canViewWorkspaces is static, so I had other globally applicable permissions (view-permissions, and the new user-admin and group-admin) also be static.

## Test Plan

- On OSS, non-admin users have fewer options on /settings/user-management and no options /settings/group-management
- relevantPermissions workflow makes sense for OSS admin/non-admin and RBAC cluster_admin / other permissions

## Checklist
- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.
- [x] If modifying `/webui/react/src/shared/` verify `make -C webui/react test-shared` passes.