### PR TITLE
chore: replacing globalOnly/workspaceOnly with isGlobal [DET-8370]

### DIFF
--- a/webui/react/src/contexts/Store.tsx
+++ b/webui/react/src/contexts/Store.tsx
@@ -161,10 +161,9 @@ const initState: State = {
     id: -1,
     name: 'OSS User',
     permissions: [ {
-      globalOnly: true,
       id: -1,
+      isGlobal: true,
       name: 'oss_user',
-      workspaceOnly: false,
     } ],
   } ],
   users: [],

--- a/webui/react/src/hooks/useModal/UserSettings/useModalCreateUser.tsx
+++ b/webui/react/src/hooks/useModal/UserSettings/useModalCreateUser.tsx
@@ -14,7 +14,7 @@ import handleError from 'utils/error';
 
 export const ADMIN_NAME = 'admin';
 export const ADMIN_LABEL = 'Admin';
-export const API_SUCCESS_MESSAGE_CREATE = `New user with empty password has been created, 
+export const API_SUCCESS_MESSAGE_CREATE = `New user with empty password has been created,
 advise user to reset password as soon as possible.`;
 export const API_SUCCESS_MESSAGE_EDIT = 'User has been updated';
 export const DISPLAY_NAME_NAME = 'displayName';
@@ -70,15 +70,15 @@ const ModalForm: React.FC<Props> = ({ form, branding, user, groups, viewOnly }) 
       title: 'Name',
     },
     {
-      dataIndex: 'globalOnly',
-      key: 'globalOnly',
+      dataIndex: 'isGlobal',
+      key: 'isGlobal',
       render: (val: boolean) => val ? <Icon name="checkmark" /> : '',
       title: 'Global?',
     },
     {
-      dataIndex: 'workspaceOnly',
+      dataIndex: 'isGlobal',
       key: 'workspaceOnly',
-      render: (val: boolean) => val ? <Icon name="checkmark" /> : '',
+      render: (val: boolean) => val ? '' : <Icon name="checkmark" />,
       title: 'Workspaces?',
     },
   ];

--- a/webui/react/src/hooks/usePermissions.ts
+++ b/webui/react/src/hooks/usePermissions.ts
@@ -137,7 +137,7 @@ const relevantPermissions = (
   userRoles.filter((r) => relevantAssigned.includes(r.name)).forEach((r) => {
     // TODO: is it possible a role is assigned to this workspace,
     // but not all of its permissions?
-    permissions = permissions.concat(r.permissions.filter((p) => p.globalOnly || workspaceId));
+    permissions = permissions.concat(r.permissions.filter((p) => p.isGlobal || workspaceId));
   });
   return new Set<string>(permissions.map((p) => p.name));
 };

--- a/webui/react/src/services/apiConfig.ts
+++ b/webui/react/src/services/apiConfig.ts
@@ -204,10 +204,9 @@ export const getUserPermissions: DetApi<
   name: 'getUserPermissions',
   postProcess: (response) => {
     const fillerPermission: Type.Permission = {
-      globalOnly: true,
       id: response,
+      isGlobal: true,
       name: 'oss_user',
-      workspaceOnly: false,
     };
     return [ fillerPermission ];
   },

--- a/webui/react/src/types.ts
+++ b/webui/react/src/types.ts
@@ -806,10 +806,9 @@ export interface UserAssignment {
 }
 
 export interface Permission {
-  globalOnly: boolean;
   id: number;
+  isGlobal: boolean;
   name: string;
-  workspaceOnly: boolean;
 }
 
 export interface UserRole {


### PR DESCRIPTION
## Description

To match the draft spec, we included `globalOnly` and `workspaceOnly` fields. The API implementation has only one `isGlobal` field. For consistency we can change this now.

If this merges first, I need to update #5022 

## Test Plan

`globalOnly` should not exist in the code. `workspaceOnly` is kept in one place for the user modal permissions table for admins.

## Checklist
- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.
- [x] If modifying `/webui/react/src/shared/` verify `make -C webui/react test-shared` passes.