### PR TITLE
feat: support slots_per_trial=0 in Trial classes

### DIFF
--- a/harness/determined/launch/horovod.py
+++ b/harness/determined/launch/horovod.py
@@ -240,7 +240,7 @@ def parse_args(args: List[str]) -> Tuple[List[str], List[str], bool]:
     )
 
     # --autohorovod is an internal-only flag.  What it does is it causes the code skip the
-    # horovodrun wrapper when slots_per_trial == 1.  This has two effects:
+    # horovodrun wrapper when slots_per_trial <= 1.  This has two effects:
     # 1. the execution stack for non-distributed training is simpler, because horovodrun would only
     #    add complexity, and
     # 2. the training code becomes more complex because it has to be aware of multi-vs-single-slot

--- a/harness/determined/util.py
+++ b/harness/determined/util.py
@@ -256,6 +256,7 @@ def calculate_batch_sizes(
     slots_per_trial: int,
     trialname: str,
 ) -> Tuple[int, int]:
+    slots_per_trial = max(slots_per_trial, 1)
     if "global_batch_size" not in hparams:
         raise det.errors.InvalidExperimentException(
             "Please specify an integer `global_batch_size` hyperparameter in your experiment "


### PR DESCRIPTION
## Description

Apparently batch size calculation is the only reason left why zero-slot
experiments didn't work.

## Test Plan

- [x] test pytorch example with slots_per_trial=0
- [x] test keras example with slots_per_trial=0