### PR TITLE
feat: enable configuring the agent to shut down on connection failure [DET-7022]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -427,6 +427,9 @@ commands:
       extra-pytest-flags:
         type: string
         default: ""
+      wait-for-master:
+        type: boolean
+        default: true
     steps:
       - run:
           name: Split tests
@@ -445,8 +448,11 @@ commands:
             echo "Running tests from these files:"
             sed 's/^/- /' </tmp/tests-to-run
 
-      - unless:
-          condition: <<parameters.managed-devcluster>>
+      - when:
+          condition:
+            and:
+              - not: <<parameters.managed-devcluster>>
+              - <<parameters.wait-for-master>>
           steps:
             - wait-for-master:
                 scheme: <<parameters.master-scheme>>
@@ -1708,6 +1714,9 @@ jobs:
       extra-pytest-flags:
         type: string
         default: ""
+      wait-for-master:
+        type: boolean
+        default: true
     machine:
       image: <<pipeline.parameters.machine-image>>
     resource_class: large
@@ -1750,6 +1759,7 @@ jobs:
           master-host: localhost
           managed-devcluster: <<parameters.managed-devcluster>>
           extra-pytest-flags: <<parameters.extra-pytest-flags>>
+          wait-for-master: <<parameters.wait-for-master>>
 
       - store_test_results:
           path: /tmp/test-results/
@@ -2305,6 +2315,16 @@ workflows:
           matrix:
             parameters:
               agent-version: ['0.17.10']
+
+      - test-e2e:
+          name: test-e2e-agent-connection-loss
+          requires:
+            - build-go
+          parallelism: 1
+          mark: e2e_cpu_agent_connection_loss
+          devcluster-config: agent-no-connection.devcluster.yaml
+          target-stage: agent
+          wait-for-master: false
 
       - deploy:
           name: deploy-latest-master-cluster

--- a/.circleci/devcluster/agent-no-connection.devcluster.yaml
+++ b/.circleci/devcluster/agent-no-connection.devcluster.yaml
@@ -1,0 +1,9 @@
+stages:
+  - agent:
+      name: agent
+      config_file:
+        master_host: 127.0.0.1
+        master_port: 8080
+        agent_id: agent
+        hooks:
+          on_connection_lost: ["touch", "/tmp/agent-connection-lost"]

--- a/.circleci/devcluster/double-reattach.devcluster.yaml
+++ b/.circleci/devcluster/double-reattach.devcluster.yaml
@@ -54,6 +54,8 @@ stages:
         agent_reconnect_attempts: 24
         agent_reconnect_backoff: 5
         container_auto_remove_disabled: true
+        hooks:
+          on_connection_lost: ["touch", "/tmp/agent1-connection-lost"]
 
 
   - agent:

--- a/.circleci/devcluster/double.devcluster.yaml
+++ b/.circleci/devcluster/double.devcluster.yaml
@@ -40,6 +40,8 @@ stages:
         agent_id: agent1
         container_master_host: $DOCKER_LOCALHOST
         container_auto_remove_disabled: true
+        hooks:
+          on_connection_lost: ["touch", "/tmp/agent1-connection-lost"]
 
   - agent:
       name: agent2

--- a/agent/internal/options.go
+++ b/agent/internal/options.go
@@ -50,6 +50,8 @@ type Options struct {
 	// TODO(ilia): switch this to better parsing with `model.Duration` similar to
 	// master config.
 	AgentReconnectBackoff int `json:"agent_reconnect_backoff"`
+
+	Hooks HooksOptions `json:"hooks"`
 }
 
 // Validate validates the state of the Options struct.
@@ -121,4 +123,9 @@ type FluentOptions struct {
 	Image         string `json:"image"`
 	Port          int    `json:"port"`
 	ContainerName string `json:"container_name"`
+}
+
+// HooksOptions contains external commands to be run when specific things happen.
+type HooksOptions struct {
+	OnConnectionLost []string `json:"on_connection_lost"`
 }

--- a/docs/reference/reference-deploy/config/agent-config-reference.rst
+++ b/docs/reference/reference-deploy/config/agent-config-reference.rst
@@ -93,3 +93,16 @@
 
 -  ``container_auto_remove_disabled`` (debug): Whether to disable setting ``AutoRemove`` flag on
    task containers. Defaults to false.
+
+-  ``hooks``: Configuration for commands to run when certain events occur. The value of each option
+   in this section is an array of strings specifying the command and its arguments.
+
+   -  ``on_connection_lost``: A command to run when the agent fails to either connect to the master
+      on startup or reconnect after a loss of connection. (When reconnecting, the agent will make
+      several attempts as specified by the ``agent_reconnect_attempts`` and
+      ``agent_reconnect_backoff`` configuration options.)
+
+      In order to shut down the machine on which the agent is running, set this to ``["sudo",
+      "shutdown", "now"]``, or just ``["shutdown", "now"]`` if the agent is running as root.
+      Additional system configuration may be required in order to allow the agent to execute the
+      command from inside a Docker container or without the need to enter a password.

--- a/e2e_tests/pytest.ini
+++ b/e2e_tests/pytest.ini
@@ -11,6 +11,7 @@ markers =
     e2e_cpu_elastic: end to end CPU tests with elasticsearch for logging
     e2e_cpu_postgres: end to end CPU tests for testing basic database functionality
     e2e_cpu_cross_version: end to end CPU tests for testing basic cluster functionality with differing master/agent versions
+    e2e_cpu_agent_connection_loss: end to end CPU tests for testing agent functionality on connection loss
     e2e_gpu: end to end GPU tests
     gpu_required: tests with a hard CUDA requirement
     distributed: distributed training tests

--- a/e2e_tests/tests/cluster/managed_cluster.py
+++ b/e2e_tests/tests/cluster/managed_cluster.py
@@ -71,7 +71,7 @@ class ManagedCluster:
         else:
             pytest.fail(f"Agent is still present after {WAIT_FOR_KILL} seconds")
 
-    def restart_agent(self, wait_for_amnesia: bool = True) -> None:
+    def restart_agent(self, wait_for_amnesia: bool = True, wait_for_agent: bool = True) -> None:
         agent_data = get_agent_data(conf.make_master_url())
         if len(agent_data) == 1 and agent_data[0]["enabled"]:
             return
@@ -87,10 +87,11 @@ class ManagedCluster:
             else:
                 pytest.fail(f"Agent is still not forgotten after {WAIT_FOR_AMNESIA} seconds")
 
-        self.dc.restart_stage("agent1", wait=True, timeout=10)
+        self.dc.restart_stage("agent1", wait=wait_for_agent, timeout=10)
 
         WAIT_FOR_STARTUP = 10
-        self.wait_for_agent_ok(WAIT_FOR_STARTUP)
+        if wait_for_agent:
+            self.wait_for_agent_ok(WAIT_FOR_STARTUP)
 
     def kill_proxy(self) -> None:
         subprocess.run(["killall", "socat"])

--- a/e2e_tests/tests/cluster/test_agent.py
+++ b/e2e_tests/tests/cluster/test_agent.py
@@ -1,10 +1,13 @@
 import os
+import time
 
 import pytest
 
 import determined
 from determined.common import api
 from tests import config as conf
+
+from .managed_cluster import ManagedCluster
 
 
 # TODO: This should be marked as a cross-version test, but it can't actually be at the time of
@@ -17,3 +20,31 @@ def test_agent_version() -> None:
     agents = api.get(conf.make_master_url(), "agents").json()
 
     assert all(agent["version"] == target_version for agent in agents.values())
+
+
+@pytest.mark.e2e_cpu_agent_connection_loss
+def test_agent_never_connect() -> None:
+    for _ in range(15):
+        if os.path.exists("/tmp/agent-connection-lost"):
+            break
+        time.sleep(1)
+    else:
+        pytest.fail("Did not find expected file from agent connection loss hook")
+
+
+@pytest.mark.managed_devcluster
+def test_agent_fail_reconnect(managed_cluster_session: ManagedCluster) -> None:
+    if managed_cluster_session.reattach:
+        pytest.skip()
+
+    managed_cluster_session.ensure_agent_ok()
+    managed_cluster_session.kill_proxy()
+
+    for _ in range(30):
+        if os.path.exists("/tmp/agent1-connection-lost"):
+            managed_cluster_session.restart_agent(wait_for_agent=False)
+            managed_cluster_session.restart_proxy()
+            break
+        time.sleep(1)
+    else:
+        pytest.fail("Did not find expected file from agent connection loss hook")

--- a/e2e_tests/tests/conftest.py
+++ b/e2e_tests/tests/conftest.py
@@ -23,6 +23,7 @@ _INTEG_MARKERS = {
     "tensorflow2",
     "e2e_cpu",
     "e2e_cpu_2a",
+    "e2e_cpu_agent_connection_loss",
     "e2e_cpu_elastic",
     "e2e_gpu",
     "det_deploy_local",


### PR DESCRIPTION
## Description


## Test Plan

- [x] run cluster configured to make agent fail to connect, see that it runs the configured command and provides output if that fails fails

## Commentary (optional)

In the latest commit, the command is configured through a new  "hooks" section in the agent config; in the intermediate one, the config is more specifically tailored to this scenario of shutting down on connection failure. The former both is more extensible and allows for nicer names in the code; I don't think I see any downside except that it may cause users to expect us to have more hooks available in the near future.

Of course, we may not want to allow the agent to run arbitrary commands on the host at all. But I feel like we need some amount of flexibility, and I couldn't think of a way I liked to have some without doing this. (Maybe just specifying arguments to be passed to `shutdown`? But maybe there's a reason to run a command other than `shutdown`. I don't really know.)