### PR TITLE
feat: Permissions to create and view workspaces [DET-8373]

### DIFF
--- a/webui/react/src/components/NavigationSideBar.tsx
+++ b/webui/react/src/components/NavigationSideBar.tsx
@@ -10,6 +10,7 @@ import AvatarCard from 'components/UserAvatarCard';
 import { useStore } from 'contexts/Store';
 import useModalJupyterLab from 'hooks/useModal/JupyterLab/useModalJupyterLab';
 import useModalWorkspaceCreate from 'hooks/useModal/Workspace/useModalWorkspaceCreate';
+import usePermissions from 'hooks/usePermissions';
 import useSettings, { BaseType, SettingsConfig } from 'hooks/useSettings';
 import { clusterStatusText } from 'pages/Clusters/ClustersOverview';
 import WorkspaceQuickSearch from 'pages/WorkspaceDetails/WorkspaceQuickSearch';
@@ -147,6 +148,8 @@ const NavigationSideBar: React.FC = () => {
     openWorkspaceCreateModal();
   }, [openWorkspaceCreateModal]);
 
+  const { canCreateWorkspace } = usePermissions();
+
   if (!showNavigation) return null;
 
   return (
@@ -223,9 +226,13 @@ const NavigationSideBar: React.FC = () => {
                       <Icon name="search" size="tiny" />
                     </Button>
                   </WorkspaceQuickSearch>
-                  <Button type="text" onClick={handleCreateWorkspace}>
-                    <Icon name="add-small" size="tiny" />
-                  </Button>
+                  {canCreateWorkspace
+                    ? (
+                      <Button type="text" onClick={handleCreateWorkspace}>
+                        <Icon name="add-small" size="tiny" />
+                      </Button>
+                    )
+                    : null}
                 </div>
               }
               icon="workspaces"

--- a/webui/react/src/pages/ProjectDetails.tsx
+++ b/webui/react/src/pages/ProjectDetails.tsx
@@ -139,7 +139,10 @@ const ProjectDetails: React.FC = () => {
   const [total, setTotal] = useState(0);
   const [canceler] = useState(new AbortController());
   const pageRef = useRef<HTMLElement>(null);
-  const { canDeleteExperiment, canMoveExperiment, canViewWorkspaces } = usePermissions();
+  const {
+    canDeleteExperiment, canMoveExperiment, canViewWorkspace,
+    canViewWorkspaces,
+  } = usePermissions();
 
   const { updateSettings: updateDestinationSettings } = useSettings<MoveExperimentSettings>(
     moveExperimentSettingsConfig,
@@ -1096,6 +1099,10 @@ const ProjectDetails: React.FC = () => {
     return (
       <Spinner tip={projectId === '1' ? 'Loading...' : `Loading project ${projectId} details...`} />
     );
+  }
+
+  if (project && !canViewWorkspace({ workspace: { id: project.workspaceId } })) {
+    return <PageNotFound />;
   }
 
   return (

--- a/webui/react/src/pages/WorkspaceDetails.tsx
+++ b/webui/react/src/pages/WorkspaceDetails.tsx
@@ -25,6 +25,7 @@ import {
 import Toggle from 'components/Toggle';
 import { useStore } from 'contexts/Store';
 import { useFetchUsers } from 'hooks/useFetch';
+import usePermissions from 'hooks/usePermissions';
 import usePolling from 'hooks/usePolling';
 import useSettings, { UpdateSettings } from 'hooks/useSettings';
 import { paths } from 'routes/utils';
@@ -69,6 +70,7 @@ const WorkspaceDetails: React.FC = () => {
   const [total, setTotal] = useState(0);
   const [canceler] = useState(new AbortController());
   const pageRef = useRef<HTMLElement>(null);
+  const { canViewWorkspace } = usePermissions();
 
   const id = parseInt(workspaceId);
 
@@ -394,6 +396,10 @@ const WorkspaceDetails: React.FC = () => {
     return <Message title={message} type={MessageType.Warning} />;
   } else if (!workspace) {
     return <Spinner tip={`Loading workspace ${workspaceId} details...`} />;
+  }
+
+  if (!canViewWorkspace({ workspace: { id } })) {
+    return <PageNotFound />;
   }
 
   return (

--- a/webui/react/src/pages/WorkspaceList.tsx
+++ b/webui/react/src/pages/WorkspaceList.tsx
@@ -21,6 +21,7 @@ import {
 import Toggle from 'components/Toggle';
 import { useStore } from 'contexts/Store';
 import useModalWorkspaceCreate from 'hooks/useModal/Workspace/useModalWorkspaceCreate';
+import usePermissions from 'hooks/usePermissions';
 import usePolling from 'hooks/usePolling';
 import useSettings, { UpdateSettings } from 'hooks/useSettings';
 import { paths } from 'routes/utils';
@@ -57,6 +58,8 @@ const WorkspaceList: React.FC = () => {
   const [isLoading, setIsLoading] = useState(true);
   const pageRef = useRef<HTMLElement>(null);
   const [canceler] = useState(new AbortController());
+
+  const { canCreateWorkspace } = usePermissions();
 
   const { contextHolder, modalOpen } = useModalWorkspaceCreate();
 
@@ -316,7 +319,9 @@ const WorkspaceList: React.FC = () => {
       className={css.base}
       containerRef={pageRef}
       id="workspaces"
-      options={<Button onClick={handleWorkspaceCreateClick}>New Workspace</Button>}
+      options={canCreateWorkspace
+        ? <Button onClick={handleWorkspaceCreateClick}>New Workspace</Button>
+        : null}
       title="Workspaces">
       <div className={css.controls}>
         <SelectFilter


### PR DESCRIPTION
## Description

Completes the current spec of workspace permissions with `create_workspace` (global) and `view_workspace` (a specific workspace).

- Creating a workspace is possible from the + icon in sidebar, or from the New Workspace button on `/det/workspaces`. No permission = we hide these buttons.
- You might view workspace content by loading Determined (`/` -> `/det/projects/1`) or a link. In RBAC, the API will return a 404 if these are not accessible. I implemented `canViewWorkspace({ id: workspaceId })` to show the 404 page.
- You might go to WorkspaceDetails from those listed in pinned workspaces or WorkspaceList. When RBAC is on, the API will not return un-viewable workspaces to these lists. No need to implement client-side filtering.

## Test Plan

Creating and viewing workspaces continues to be allowed on OSS.

You can test not having permission by editing `hooks/usePermissions` to return the opposite for canCreateWorkspace and canViewWorkspace, i.e. `!permitted.has('oss_user')`.
Make sure to test canView**Workspace** and not canViewWorkspace**s**

## Checklist
- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.
- [x] If modifying `/webui/react/src/shared/` verify `make -C webui/react test-shared` passes.