### PR TITLE
fix: support setting agent username and group in user APIs.

### DIFF
--- a/e2e_tests/tests/cluster/test_users.py
+++ b/e2e_tests/tests/cluster/test_users.py
@@ -183,18 +183,44 @@ def extract_id_and_owner_from_exp_list(output: str) -> List[Tuple[int, str]]:
 
 @pytest.mark.e2e_cpu
 def test_post_user_api(clean_auth: None) -> None:
-    master_url = conf.make_master_url()
-    authentication.cli_auth = authentication.Authentication(
-        conf.make_master_url(), requested_user="admin", password="", try_reauth=True
-    )
     new_username = get_random_string()
+
+    sess = exp.determined_test_session(admin=True)
 
     user = bindings.v1User(active=True, admin=False, username=new_username)
     body = bindings.v1PostUserRequest(password="", user=user)
-    resp = bindings.post_PostUser(
-        api.Session(master_url, "admin", authentication.cli_auth, None), body=body
-    )
+    resp = bindings.post_PostUser(sess, body=body)
+    assert resp and resp.user
     assert resp.to_json()["user"]["username"] == new_username
+    assert resp.user.agentUserGroup is None
+
+    user = bindings.v1User(
+        active=True,
+        admin=False,
+        username=get_random_string(),
+        agentUserGroup=bindings.v1AgentUserGroup(
+            agentUid=1000, agentGid=1001, agentUser="username", agentGroup="groupname"
+        ),
+    )
+    resp = bindings.post_PostUser(sess, body=bindings.v1PostUserRequest(user=user))
+    assert resp and resp.user and resp.user.agentUserGroup
+    assert resp.user.agentUserGroup.agentUser == "username"
+    assert resp.user.agentUserGroup.agentGroup == "groupname"
+    assert resp.user.agentUserGroup.agentUid == 1000
+    assert resp.user.agentUserGroup.agentGid == 1001
+
+    user = bindings.v1User(
+        active=True,
+        admin=False,
+        username=get_random_string(),
+        agentUserGroup=bindings.v1AgentUserGroup(
+            agentUid=1000,
+            agentGid=1001,
+        ),
+    )
+
+    with pytest.raises(errors.APIException):
+        bindings.post_PostUser(sess, body=bindings.v1PostUserRequest(user=user))
 
 
 @pytest.mark.e2e_cpu
@@ -896,6 +922,13 @@ def test_experiment_delete() -> None:
                 pytest.fail("experiment didn't delete after timeout")
 
 
+def _fetch_user_by_username(sess: api.Session, username: str) -> bindings.v1User:
+    # Get API bindings object for the created test user
+    all_users = bindings.get_GetUsers(sess).users
+    assert all_users is not None
+    return next(u for u in all_users if u.username == username)
+
+
 @pytest.mark.e2e_cpu
 @pytest.mark.e2e_cpu_postgres
 def test_change_displayname(clean_auth: None) -> None:
@@ -909,10 +942,7 @@ def test_change_displayname(clean_auth: None) -> None:
     )
     sess = api.Session(master_url, original_name, authentication.cli_auth, certs.cli_cert)
 
-    # Get API bindings object for the created test user
-    all_users = bindings.get_GetUsers(sess).users
-    assert all_users is not None
-    current_user = list(filter(lambda u: u.username == original_name, all_users))[0]
+    current_user = _fetch_user_by_username(sess, original_name)
     assert current_user is not None and current_user.id
 
     # Rename user using display name
@@ -935,3 +965,33 @@ def test_change_displayname(clean_auth: None) -> None:
     modded_user = bindings.get_GetUser(sess, userId=current_user.id).user
     assert modded_user is not None
     assert modded_user.displayName == ""
+
+
+@pytest.mark.e2e_cpu
+def test_patch_agentusergroup(clean_auth: None) -> None:
+    test_user_credentials = create_test_user(ADMIN_CREDENTIALS, False)
+    test_username = test_user_credentials.username
+
+    # Patch - normal.
+    sess = exp.determined_test_session(admin=True)
+    patch_user = bindings.v1PatchUser(
+        agentUserGroup=bindings.v1AgentUserGroup(
+            agentGid=1000, agentUid=1000, agentUser="username", agentGroup="groupname"
+        )
+    )
+    test_user = _fetch_user_by_username(sess, test_username)
+    assert test_user.id
+    bindings.patch_PatchUser(sess, body=patch_user, userId=test_user.id)
+    patched_user = bindings.get_GetUser(sess, userId=test_user.id).user
+    assert patched_user is not None and patched_user.agentUserGroup is not None
+    assert patched_user.agentUserGroup.agentUser == "username"
+    assert patched_user.agentUserGroup.agentGroup == "groupname"
+
+    # Patch - missing username/groupname.
+    patch_user = bindings.v1PatchUser(
+        agentUserGroup=bindings.v1AgentUserGroup(agentGid=1000, agentUid=1000)
+    )
+    test_user = _fetch_user_by_username(sess, test_username)
+    assert test_user.id
+    with pytest.raises(errors.APIException):
+        bindings.patch_PatchUser(sess, body=patch_user, userId=test_user.id)

--- a/e2e_tests/tests/experiment/experiment.py
+++ b/e2e_tests/tests/experiment/experiment.py
@@ -272,11 +272,14 @@ def experiment_first_trial(exp_id: int) -> int:
     return trial_id
 
 
-def determined_test_session() -> api.Session:
+def determined_test_session(admin: bool = False) -> api.Session:
     murl = conf.make_master_url()
     certs.cli_cert = certs.default_load(murl)
-    authentication.cli_auth = authentication.Authentication(murl, try_reauth=True)
-    return api.Session(murl, "determined", authentication.cli_auth, certs.cli_cert)
+    username = "admin" if admin else "determined"
+    authentication.cli_auth = authentication.Authentication(
+        murl, requested_user=username, password="", try_reauth=True
+    )
+    return api.Session(murl, username, authentication.cli_auth, certs.cli_cert)
 
 
 def experiment_config_json(experiment_id: int) -> Dict[str, Any]:

--- a/harness/determined/common/api/bindings.py
+++ b/harness/determined/common/api/bindings.py
@@ -478,22 +478,30 @@ class v1AgentUserGroup:
         self,
         *,
         agentGid: "typing.Optional[int]" = None,
+        agentGroup: "typing.Optional[str]" = None,
         agentUid: "typing.Optional[int]" = None,
+        agentUser: "typing.Optional[str]" = None,
     ):
         self.agentUid = agentUid
         self.agentGid = agentGid
+        self.agentUser = agentUser
+        self.agentGroup = agentGroup
 
     @classmethod
     def from_json(cls, obj: Json) -> "v1AgentUserGroup":
         return cls(
             agentUid=obj.get("agentUid", None),
             agentGid=obj.get("agentGid", None),
+            agentUser=obj.get("agentUser", None),
+            agentGroup=obj.get("agentGroup", None),
         )
 
     def to_json(self) -> typing.Any:
         return {
             "agentUid": self.agentUid if self.agentUid is not None else None,
             "agentGid": self.agentGid if self.agentGid is not None else None,
+            "agentUser": self.agentUser if self.agentUser is not None else None,
+            "agentGroup": self.agentGroup if self.agentGroup is not None else None,
         }
 
 class v1AggregateQueueStats:

--- a/master/internal/api_user_intg_test.go
+++ b/master/internal/api_user_intg_test.go
@@ -145,7 +145,12 @@ func TestAuthzPostUser(t *testing.T) {
 	expectedErr := status.Error(codes.PermissionDenied, "canCreateUserError")
 	authzUsers.On("CanCreateUser", curUser,
 		model.User{Username: "admin", Admin: true},
-		&model.AgentUserGroup{UID: 5, GID: 6}).Return(fmt.Errorf("canCreateUserError")).Once()
+		&model.AgentUserGroup{
+			UID:   5,
+			GID:   6,
+			User:  "five",
+			Group: "six",
+		}).Return(fmt.Errorf("canCreateUserError")).Once()
 
 	_, err := api.PostUser(ctx, &apiv1.PostUserRequest{
 		User: &userv1.User{

--- a/master/internal/api_user_intg_test.go
+++ b/master/internal/api_user_intg_test.go
@@ -149,9 +149,14 @@ func TestAuthzPostUser(t *testing.T) {
 
 	_, err := api.PostUser(ctx, &apiv1.PostUserRequest{
 		User: &userv1.User{
-			Username:       "admin",
-			Admin:          true,
-			AgentUserGroup: &userv1.AgentUserGroup{AgentUid: 5, AgentGid: 6},
+			Username: "admin",
+			Admin:    true,
+			AgentUserGroup: &userv1.AgentUserGroup{
+				AgentUid:   5,
+				AgentGid:   6,
+				AgentUser:  "five",
+				AgentGroup: "six",
+			},
 		},
 	})
 	require.Equal(t, expectedErr.Error(), err.Error())

--- a/proto/src/determined/user/v1/user.proto
+++ b/proto/src/determined/user/v1/user.proto
@@ -46,6 +46,10 @@ message AgentUserGroup {
   int32 agent_uid = 1;
   // The group id on the agent.
   int32 agent_gid = 2;
+  // User name.
+  string agent_user = 3;
+  // Group name.
+  string agent_group = 4;
 }
 
 // UserWebSetting represents user web setting.

--- a/webui/react/src/services/api-ts-sdk/api.ts
+++ b/webui/react/src/services/api-ts-sdk/api.ts
@@ -908,6 +908,18 @@ export interface V1AgentUserGroup {
      * @memberof V1AgentUserGroup
      */
     agentGid?: number;
+    /**
+     * User name.
+     * @type {string}
+     * @memberof V1AgentUserGroup
+     */
+    agentUser?: string;
+    /**
+     * Group name.
+     * @type {string}
+     * @memberof V1AgentUserGroup
+     */
+    agentGroup?: string;
 }
 
 /**


### PR DESCRIPTION
## Description

grpc-style user APIs were missing support for username / groupname fields in `AgentUserGroups`, i.e. `link-with-agent-user` feature. This is not an externally facing fix: `AgentUserGroups` isn't currently in use by WebUI, CLI still uses the old style.

Under the hood, user name and group name are NOT NULL fields in the table. Prior to this fix, they'd be reset to empty strings due to protobuf / golang empty struct initializations.

Technically, uid and gid are critical for the system, while user name and group name are cosmetic, however if we enforce them in one place (db and `link-with-agent-user`) it probably makes sense to enforce them everywhere.

## Test Plan

Expanded automated testing.

## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist
- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.
- [ ] If modifying `/webui/react/src/shared/` verify `make -C webui/react test-shared` passes.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
