### PR TITLE
feat: rbac CLI [DET-7868] 

### DIFF
--- a/e2e_tests/tests/cluster/test_rbac.py
+++ b/e2e_tests/tests/cluster/test_rbac.py
@@ -1,0 +1,195 @@
+import json
+import subprocess
+from typing import Any, List
+
+import pytest
+
+from tests import config as conf
+
+from .test_users import get_random_string, ADMIN_CREDENTIALS, create_test_user, logged_in_user
+
+
+def det_cmd(cmd: List[str], **kwargs: Any) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["det", "-m", conf.make_master_url()] + cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        **kwargs,
+    )
+
+
+def det_cmd_json(cmd: List[str]) -> Any:
+    res = det_cmd(cmd, check=True)
+    return json.loads(res.stdout)
+
+
+def det_cmd_expect_error(cmd: List[str], expected: str) -> None:
+    res = det_cmd(cmd)
+    assert res.returncode != 0
+    assert expected in res.stderr.decode()
+
+
+@pytest.mark.e2e_cpu
+#@pytest.mark.parametrize("add_users", [[], ["admin", "determined"]])
+def test_rbac_permission_assignment() -> None:
+    test_user_creds = create_test_user(ADMIN_CREDENTIALS)
+    
+    # User has no permissions.
+    with logged_in_user(test_user_creds):
+        assert "no permissions" in det_cmd(["rbac", "my-permissions"], check=True).stdout.decode()
+        json_out = det_cmd_json(["rbac", "my-permissions", "--json"])
+        assert json_out["roles"] == []
+        assert json_out["assignments"] == []
+
+    group_name = get_random_string()        
+    with logged_in_user(ADMIN_CREDENTIALS):
+        # Assign user to role directly.
+        det_cmd(["rbac", "assign-role", "WorkspaceCreator", "--username-to-assign",
+                 test_user_creds.username], check=True)
+        det_cmd(["rbac", "assign-role", "Viewer", "--username-to-assign",
+                 test_user_creds.username, "--workspace-name", "Uncategorized"], check=True)
+
+        # Assign user to a group with roles.
+        det_cmd(["user-group", "create", group_name, "--add-user",
+                 test_user_creds.username], check=True)
+        det_cmd(["rbac", "assign-role", "WorkspaceCreator", "--group-name-to-assign",
+                 group_name], check=True)        
+        det_cmd(["rbac", "assign-role", "Editor", "--group-name-to-assign",
+                 group_name], check=True)
+        det_cmd(["rbac", "assign-role", "Editor", "--group-name-to-assign",
+                 group_name, "--workspace-name", "Uncategorized"], check=True)
+        
+    # User has those roles assigned.
+    with logged_in_user(test_user_creds):
+        assert "no permissions" not in det_cmd(["rbac", "my-permissions"], check=True).stdout.decode()
+        json_out = det_cmd_json(["rbac", "my-permissions", "--json"])        
+        assert len(json_out["roles"]) == 3
+        assert len(json_out["assignments"]) == 3
+        
+        creator = [role for role in json_out["roles"] if role["name"] == "WorkspaceCreator"]
+        assert len(creator) == 1
+        creator_assignment = [a for a in json_out["assignments"] if a["roleId"] == creator[0]["roleId"]]
+        assert creator_assignment[0]["scopeWorkspaceIds"] == []
+        assert creator_assignment[0]["isGlobal"]
+
+        viewer = [role for role in json_out["roles"] if role["name"] == "Viewer"]
+        assert len(viewer) == 1        
+        viewer_assignment = [a for a in json_out["assignments"] if a["roleId"] == viewer[0]["roleId"]]
+        assert viewer_assignment[0]["scopeWorkspaceIds"] == [1]
+        assert not viewer_assignment[0]["isGlobal"]
+
+        editor = [role for role in json_out["roles"] if role["name"] == "Editor"]
+        assert len(editor) == 1        
+        editor_assignment = [a for a in json_out["assignments"] if a["roleId"] == editor[0]["roleId"]]
+        assert editor_assignment[0]["scopeWorkspaceIds"] == [1]
+        assert editor_assignment[0]["isGlobal"]
+
+    # Remove from the group.
+    with logged_in_user(ADMIN_CREDENTIALS):
+        det_cmd(["user-group", "remove-user", group_name, test_user_creds.username], check=True)
+
+    # User doesn't have any group roles assigned.
+    with logged_in_user(test_user_creds):
+        assert "no permissions" not in det_cmd(["rbac", "my-permissions"], check=True).stdout.decode()
+        json_out = det_cmd_json(["rbac", "my-permissions", "--json"])
+        
+        assert len(json_out["roles"]) == 2
+        assert len(json_out["assignments"]) == 2
+        assert len([role for role in json_out["roles"] if role["name"] == "Editor"]) == 0
+
+    # Remove user assignments.
+    with logged_in_user(ADMIN_CREDENTIALS):
+        # Assign user to role directly.
+        det_cmd(["rbac", "unassign-role", "WorkspaceCreator", "--username-to-assign",
+                 test_user_creds.username], check=True)
+        det_cmd(["rbac", "unassign-role", "Viewer", "--username-to-assign",
+                 test_user_creds.username, "--workspace-name", "Uncategorized"], check=True)    
+    
+    # User has no permissions.
+    with logged_in_user(test_user_creds):
+        assert "no permissions" in det_cmd(["rbac", "my-permissions"], check=True).stdout.decode()
+        json_out = det_cmd_json(["rbac", "my-permissions", "--json"])
+        assert json_out["roles"] == []
+        assert json_out["assignments"] == []
+
+        
+
+@pytest.mark.e2e_cpu
+def test_rbac_permission_assignment_errors() -> None:
+    # Specifying args incorrectly.
+    det_cmd_expect_error(["rbac", "assign-role", "Viewer"], "must provide exactly one of")
+    det_cmd_expect_error(["rbac", "unassign-role", "Viewer"], "must provide exactly one of")
+    det_cmd_expect_error(["rbac", "assign-role", "Viewer",
+                          "--username-to-assign", "u", "--group-name-to-assign", "g"],
+                         "must provide exactly one of")
+    det_cmd_expect_error(["rbac", "unassign-role", "Viewer",
+                          "--username-to-assign", "u", "--group-name-to-assign", "g"],
+                         "must provide exactly one of")
+    
+    # Non existent role.
+    det_cmd_expect_error(["rbac", "assign-role", "fakeRoleNameThatDoesntExist",
+                          "--username-to-assign", "admin"], "could not find role name")    
+    det_cmd_expect_error(["rbac", "unassign-role", "fakeRoleNameThatDoesntExist",
+                          "--username-to-assign", "admin"], "could not find role name")
+    
+    # Non existent user
+    det_cmd_expect_error(["rbac", "assign-role", "Viewer",
+                          "--username-to-assign", "fakeUserNotExist"], "could not find user")    
+    det_cmd_expect_error(["rbac", "unassign-role", "Viewer",
+                          "--username-to-assign", "fakeUserNotExist"], "could not find user")    
+    
+    # Non existent group.
+    det_cmd_expect_error(["rbac", "assign-role", "Viewer", "--group-name-to-assign",
+                          "fakeGroupNotExist"], "could not find user group")    
+    det_cmd_expect_error(["rbac", "unassign-role", "Viewer", "--group-name-to-assign",
+                          "fakeGroupNotExist"], "could not find user group")    
+    
+    # Non existent workspace
+    det_cmd_expect_error(["rbac", "assign-role", "Viewer", "--workspace-name", "fakeWorkspace",
+                          "--username-to-assign", "admin"], "not find a workspace")    
+    det_cmd_expect_error(["rbac", "unassign-role", "Viewer", "--workspace-name", "fakeWorkspace",
+                          "--username-to-assign", "admin"], "not find a workspace")
+
+    test_user_creds = create_test_user(ADMIN_CREDENTIALS)
+    group_name = get_random_string()        
+    with logged_in_user(ADMIN_CREDENTIALS):                
+        det_cmd(["user-group", "create", group_name], check=True)
+        det_cmd(["rbac", "assign-role", "Viewer", "--group-name-to-assign",
+                 group_name], check=True)                
+        det_cmd(["rbac", "assign-role", "Viewer", "--username-to-assign",
+                 test_user_creds.username], check=True)
+        
+        # Unassigned role group doesn't have.
+        det_cmd_expect_error(["rbac", "unassign-role", "Editor", "--group-name-to-assign",
+                              group_name], "not found")        
+        det_cmd_expect_error(["rbac", "unassign-role", "Viewer", "--group-name-to-assign",
+                              group_name, "--workspace-name", "Uncategorized"], "not found")                
+        
+        # Unassigned role user doesn't have.
+        det_cmd_expect_error(["rbac", "unassign-role", "Editor", "--username-to-assign",
+                              test_user_creds.username], "not found")        
+        det_cmd_expect_error(["rbac", "unassign-role", "Viewer", "--username-to-assign",
+                              test_user_creds.username, "--workspace-name", "Uncategorized"],
+                             "not found")                
+        
+    
+@pytest.mark.e2e_cpu
+def test_rbac_list_roles() -> None:
+    pass
+
+@pytest.mark.e2e_cpu
+def test_rbac_describe_role() -> None:
+    pass
+
+        
+
+        
+# assign_role (x)
+# unassign_role (x)
+# my_permissions (x) (technically don't check no json output since it is too hard...)
+        
+# list_roles
+# list_users_roles
+# list_groups_roles
+
+# describe_role 

--- a/e2e_tests/tests/cluster/test_rbac.py
+++ b/e2e_tests/tests/cluster/test_rbac.py
@@ -1,39 +1,23 @@
-import json
-import subprocess
-from typing import Any, List
+# from typing import Any, List
 
 import pytest
 
-from tests import config as conf
+from determined.cli.user_groups import group_name_to_group_id, usernames_to_user_ids
+from tests.experiment import determined_test_session
 
-from .test_users import get_random_string, ADMIN_CREDENTIALS, create_test_user, logged_in_user
-
-
-def det_cmd(cmd: List[str], **kwargs: Any) -> subprocess.CompletedProcess:
-    return subprocess.run(
-        ["det", "-m", conf.make_master_url()] + cmd,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        **kwargs,
-    )
+from .test_groups import det_cmd, det_cmd_expect_error, det_cmd_json
+from .test_users import ADMIN_CREDENTIALS, create_test_user, get_random_string, logged_in_user
 
 
-def det_cmd_json(cmd: List[str]) -> Any:
-    res = det_cmd(cmd, check=True)
-    return json.loads(res.stdout)
-
-
-def det_cmd_expect_error(cmd: List[str], expected: str) -> None:
-    res = det_cmd(cmd)
-    assert res.returncode != 0
-    assert expected in res.stderr.decode()
+def roles_not_implemented() -> bool:
+    return "Unimplemented" in det_cmd(["rbac", "my-permissions"]).stderr.decode()
 
 
 @pytest.mark.e2e_cpu
-#@pytest.mark.parametrize("add_users", [[], ["admin", "determined"]])
+@pytest.mark.skipif(roles_not_implemented(), reason="ee is required for this test")
 def test_rbac_permission_assignment() -> None:
     test_user_creds = create_test_user(ADMIN_CREDENTIALS)
-    
+
     # User has no permissions.
     with logged_in_user(test_user_creds):
         assert "no permissions" in det_cmd(["rbac", "my-permissions"], check=True).stdout.decode()
@@ -41,46 +25,84 @@ def test_rbac_permission_assignment() -> None:
         assert json_out["roles"] == []
         assert json_out["assignments"] == []
 
-    group_name = get_random_string()        
+    group_name = get_random_string()
     with logged_in_user(ADMIN_CREDENTIALS):
         # Assign user to role directly.
-        det_cmd(["rbac", "assign-role", "WorkspaceCreator", "--username-to-assign",
-                 test_user_creds.username], check=True)
-        det_cmd(["rbac", "assign-role", "Viewer", "--username-to-assign",
-                 test_user_creds.username, "--workspace-name", "Uncategorized"], check=True)
+        det_cmd(
+            [
+                "rbac",
+                "assign-role",
+                "WorkspaceCreator",
+                "--username-to-assign",
+                test_user_creds.username,
+            ],
+            check=True,
+        )
+        det_cmd(
+            [
+                "rbac",
+                "assign-role",
+                "Viewer",
+                "--username-to-assign",
+                test_user_creds.username,
+                "--workspace-name",
+                "Uncategorized",
+            ],
+            check=True,
+        )
 
         # Assign user to a group with roles.
-        det_cmd(["user-group", "create", group_name, "--add-user",
-                 test_user_creds.username], check=True)
-        det_cmd(["rbac", "assign-role", "WorkspaceCreator", "--group-name-to-assign",
-                 group_name], check=True)        
-        det_cmd(["rbac", "assign-role", "Editor", "--group-name-to-assign",
-                 group_name], check=True)
-        det_cmd(["rbac", "assign-role", "Editor", "--group-name-to-assign",
-                 group_name, "--workspace-name", "Uncategorized"], check=True)
-        
+        det_cmd(
+            ["user-group", "create", group_name, "--add-user", test_user_creds.username], check=True
+        )
+        det_cmd(
+            ["rbac", "assign-role", "WorkspaceCreator", "--group-name-to-assign", group_name],
+            check=True,
+        )
+        det_cmd(["rbac", "assign-role", "Editor", "--group-name-to-assign", group_name], check=True)
+        det_cmd(
+            [
+                "rbac",
+                "assign-role",
+                "Editor",
+                "--group-name-to-assign",
+                group_name,
+                "--workspace-name",
+                "Uncategorized",
+            ],
+            check=True,
+        )
+
     # User has those roles assigned.
     with logged_in_user(test_user_creds):
-        assert "no permissions" not in det_cmd(["rbac", "my-permissions"], check=True).stdout.decode()
-        json_out = det_cmd_json(["rbac", "my-permissions", "--json"])        
+        assert (
+            "no permissions" not in det_cmd(["rbac", "my-permissions"], check=True).stdout.decode()
+        )
+        json_out = det_cmd_json(["rbac", "my-permissions", "--json"])
         assert len(json_out["roles"]) == 3
         assert len(json_out["assignments"]) == 3
-        
+
         creator = [role for role in json_out["roles"] if role["name"] == "WorkspaceCreator"]
         assert len(creator) == 1
-        creator_assignment = [a for a in json_out["assignments"] if a["roleId"] == creator[0]["roleId"]]
+        creator_assignment = [
+            a for a in json_out["assignments"] if a["roleId"] == creator[0]["roleId"]
+        ]
         assert creator_assignment[0]["scopeWorkspaceIds"] == []
         assert creator_assignment[0]["isGlobal"]
 
         viewer = [role for role in json_out["roles"] if role["name"] == "Viewer"]
-        assert len(viewer) == 1        
-        viewer_assignment = [a for a in json_out["assignments"] if a["roleId"] == viewer[0]["roleId"]]
+        assert len(viewer) == 1
+        viewer_assignment = [
+            a for a in json_out["assignments"] if a["roleId"] == viewer[0]["roleId"]
+        ]
         assert viewer_assignment[0]["scopeWorkspaceIds"] == [1]
         assert not viewer_assignment[0]["isGlobal"]
 
         editor = [role for role in json_out["roles"] if role["name"] == "Editor"]
-        assert len(editor) == 1        
-        editor_assignment = [a for a in json_out["assignments"] if a["roleId"] == editor[0]["roleId"]]
+        assert len(editor) == 1
+        editor_assignment = [
+            a for a in json_out["assignments"] if a["roleId"] == editor[0]["roleId"]
+        ]
         assert editor_assignment[0]["scopeWorkspaceIds"] == [1]
         assert editor_assignment[0]["isGlobal"]
 
@@ -90,9 +112,11 @@ def test_rbac_permission_assignment() -> None:
 
     # User doesn't have any group roles assigned.
     with logged_in_user(test_user_creds):
-        assert "no permissions" not in det_cmd(["rbac", "my-permissions"], check=True).stdout.decode()
+        assert (
+            "no permissions" not in det_cmd(["rbac", "my-permissions"], check=True).stdout.decode()
+        )
         json_out = det_cmd_json(["rbac", "my-permissions", "--json"])
-        
+
         assert len(json_out["roles"]) == 2
         assert len(json_out["assignments"]) == 2
         assert len([role for role in json_out["roles"] if role["name"] == "Editor"]) == 0
@@ -100,11 +124,29 @@ def test_rbac_permission_assignment() -> None:
     # Remove user assignments.
     with logged_in_user(ADMIN_CREDENTIALS):
         # Assign user to role directly.
-        det_cmd(["rbac", "unassign-role", "WorkspaceCreator", "--username-to-assign",
-                 test_user_creds.username], check=True)
-        det_cmd(["rbac", "unassign-role", "Viewer", "--username-to-assign",
-                 test_user_creds.username, "--workspace-name", "Uncategorized"], check=True)    
-    
+        det_cmd(
+            [
+                "rbac",
+                "unassign-role",
+                "WorkspaceCreator",
+                "--username-to-assign",
+                test_user_creds.username,
+            ],
+            check=True,
+        )
+        det_cmd(
+            [
+                "rbac",
+                "unassign-role",
+                "Viewer",
+                "--username-to-assign",
+                test_user_creds.username,
+                "--workspace-name",
+                "Uncategorized",
+            ],
+            check=True,
+        )
+
     # User has no permissions.
     with logged_in_user(test_user_creds):
         assert "no permissions" in det_cmd(["rbac", "my-permissions"], check=True).stdout.decode()
@@ -112,84 +154,313 @@ def test_rbac_permission_assignment() -> None:
         assert json_out["roles"] == []
         assert json_out["assignments"] == []
 
-        
 
 @pytest.mark.e2e_cpu
+@pytest.mark.skipif(roles_not_implemented(), reason="ee is required for this test")
 def test_rbac_permission_assignment_errors() -> None:
     # Specifying args incorrectly.
     det_cmd_expect_error(["rbac", "assign-role", "Viewer"], "must provide exactly one of")
     det_cmd_expect_error(["rbac", "unassign-role", "Viewer"], "must provide exactly one of")
-    det_cmd_expect_error(["rbac", "assign-role", "Viewer",
-                          "--username-to-assign", "u", "--group-name-to-assign", "g"],
-                         "must provide exactly one of")
-    det_cmd_expect_error(["rbac", "unassign-role", "Viewer",
-                          "--username-to-assign", "u", "--group-name-to-assign", "g"],
-                         "must provide exactly one of")
-    
+    det_cmd_expect_error(
+        [
+            "rbac",
+            "assign-role",
+            "Viewer",
+            "--username-to-assign",
+            "u",
+            "--group-name-to-assign",
+            "g",
+        ],
+        "must provide exactly one of",
+    )
+    det_cmd_expect_error(
+        [
+            "rbac",
+            "unassign-role",
+            "Viewer",
+            "--username-to-assign",
+            "u",
+            "--group-name-to-assign",
+            "g",
+        ],
+        "must provide exactly one of",
+    )
+
     # Non existent role.
-    det_cmd_expect_error(["rbac", "assign-role", "fakeRoleNameThatDoesntExist",
-                          "--username-to-assign", "admin"], "could not find role name")    
-    det_cmd_expect_error(["rbac", "unassign-role", "fakeRoleNameThatDoesntExist",
-                          "--username-to-assign", "admin"], "could not find role name")
-    
+    det_cmd_expect_error(
+        ["rbac", "assign-role", "fakeRoleNameThatDoesntExist", "--username-to-assign", "admin"],
+        "could not find role name",
+    )
+    det_cmd_expect_error(
+        ["rbac", "unassign-role", "fakeRoleNameThatDoesntExist", "--username-to-assign", "admin"],
+        "could not find role name",
+    )
+
     # Non existent user
-    det_cmd_expect_error(["rbac", "assign-role", "Viewer",
-                          "--username-to-assign", "fakeUserNotExist"], "could not find user")    
-    det_cmd_expect_error(["rbac", "unassign-role", "Viewer",
-                          "--username-to-assign", "fakeUserNotExist"], "could not find user")    
-    
+    det_cmd_expect_error(
+        ["rbac", "assign-role", "Viewer", "--username-to-assign", "fakeUserNotExist"],
+        "could not find user",
+    )
+    det_cmd_expect_error(
+        ["rbac", "unassign-role", "Viewer", "--username-to-assign", "fakeUserNotExist"],
+        "could not find user",
+    )
+
     # Non existent group.
-    det_cmd_expect_error(["rbac", "assign-role", "Viewer", "--group-name-to-assign",
-                          "fakeGroupNotExist"], "could not find user group")    
-    det_cmd_expect_error(["rbac", "unassign-role", "Viewer", "--group-name-to-assign",
-                          "fakeGroupNotExist"], "could not find user group")    
-    
+    det_cmd_expect_error(
+        ["rbac", "assign-role", "Viewer", "--group-name-to-assign", "fakeGroupNotExist"],
+        "could not find user group",
+    )
+    det_cmd_expect_error(
+        ["rbac", "unassign-role", "Viewer", "--group-name-to-assign", "fakeGroupNotExist"],
+        "could not find user group",
+    )
+
     # Non existent workspace
-    det_cmd_expect_error(["rbac", "assign-role", "Viewer", "--workspace-name", "fakeWorkspace",
-                          "--username-to-assign", "admin"], "not find a workspace")    
-    det_cmd_expect_error(["rbac", "unassign-role", "Viewer", "--workspace-name", "fakeWorkspace",
-                          "--username-to-assign", "admin"], "not find a workspace")
+    det_cmd_expect_error(
+        [
+            "rbac",
+            "assign-role",
+            "Viewer",
+            "--workspace-name",
+            "fakeWorkspace",
+            "--username-to-assign",
+            "admin",
+        ],
+        "not find a workspace",
+    )
+    det_cmd_expect_error(
+        [
+            "rbac",
+            "unassign-role",
+            "Viewer",
+            "--workspace-name",
+            "fakeWorkspace",
+            "--username-to-assign",
+            "admin",
+        ],
+        "not find a workspace",
+    )
 
     test_user_creds = create_test_user(ADMIN_CREDENTIALS)
-    group_name = get_random_string()        
-    with logged_in_user(ADMIN_CREDENTIALS):                
+    group_name = get_random_string()
+    with logged_in_user(ADMIN_CREDENTIALS):
         det_cmd(["user-group", "create", group_name], check=True)
-        det_cmd(["rbac", "assign-role", "Viewer", "--group-name-to-assign",
-                 group_name], check=True)                
-        det_cmd(["rbac", "assign-role", "Viewer", "--username-to-assign",
-                 test_user_creds.username], check=True)
-        
+        det_cmd(["rbac", "assign-role", "Viewer", "--group-name-to-assign", group_name], check=True)
+        det_cmd(
+            ["rbac", "assign-role", "Viewer", "--username-to-assign", test_user_creds.username],
+            check=True,
+        )
+
+        # Assign a role multiple times.
+        det_cmd_expect_error(
+            ["rbac", "assign-role", "Viewer", "--group-name-to-assign", group_name],
+            "row already exists",
+        )
+
         # Unassigned role group doesn't have.
-        det_cmd_expect_error(["rbac", "unassign-role", "Editor", "--group-name-to-assign",
-                              group_name], "not found")        
-        det_cmd_expect_error(["rbac", "unassign-role", "Viewer", "--group-name-to-assign",
-                              group_name, "--workspace-name", "Uncategorized"], "not found")                
-        
+        det_cmd_expect_error(
+            ["rbac", "unassign-role", "Editor", "--group-name-to-assign", group_name], "not found"
+        )
+        det_cmd_expect_error(
+            [
+                "rbac",
+                "unassign-role",
+                "Viewer",
+                "--group-name-to-assign",
+                group_name,
+                "--workspace-name",
+                "Uncategorized",
+            ],
+            "not found",
+        )
+
         # Unassigned role user doesn't have.
-        det_cmd_expect_error(["rbac", "unassign-role", "Editor", "--username-to-assign",
-                              test_user_creds.username], "not found")        
-        det_cmd_expect_error(["rbac", "unassign-role", "Viewer", "--username-to-assign",
-                              test_user_creds.username, "--workspace-name", "Uncategorized"],
-                             "not found")                
-        
-    
+        det_cmd_expect_error(
+            ["rbac", "unassign-role", "Editor", "--username-to-assign", test_user_creds.username],
+            "not found",
+        )
+        det_cmd_expect_error(
+            [
+                "rbac",
+                "unassign-role",
+                "Viewer",
+                "--username-to-assign",
+                test_user_creds.username,
+                "--workspace-name",
+                "Uncategorized",
+            ],
+            "not found",
+        )
+
+
 @pytest.mark.e2e_cpu
+@pytest.mark.skipif(roles_not_implemented(), reason="ee is required for this test")
 def test_rbac_list_roles() -> None:
-    pass
+    with logged_in_user(ADMIN_CREDENTIALS):
+        # Test list-roles exluding properly.
+        det_cmd(["rbac", "list-roles"], check=True)
+        all_roles = det_cmd_json(["rbac", "list-roles", "--json"])["roles"]
+        exluded_global_roles = det_cmd_json(
+            ["rbac", "list-roles", "--exclude-global-roles", "--json"]
+        )["roles"]
+        for all_role in all_roles:
+            exluded_role = [r for r in exluded_global_roles if r["roleId"] == all_role["roleId"]]
+            has_global_role = any([p for p in all_role["permissions"] if p["isGlobal"]])
+            if len(exluded_role) == 0:
+                # Didn't find our role in exluded role. Needs to have a global only permission.
+                assert has_global_role
+            else:
+                # Did find our role in exluded role. Needs to have no global only permissions.
+                assert not has_global_role
+
+        # Test list-roles pagination.
+        json_out = det_cmd_json(["rbac", "list-roles", "--limit=2", "--json"])
+        assert len(json_out["roles"]) == 2
+        assert json_out["pagination"]["limit"] == 2
+        assert json_out["pagination"]["total"] == len(all_roles)
+        assert json_out["pagination"]["offset"] == 0
+
+        json_out = det_cmd_json(["rbac", "list-roles", "--offset=1", "--limit=199", "--json"])
+        assert len(json_out["roles"]) == len(all_roles) - 1
+        assert json_out["pagination"]["limit"] == 199
+        assert json_out["pagination"]["total"] == len(all_roles)
+        assert json_out["pagination"]["offset"] == 1
+
+        # Setup group / user to test with.
+        test_user_creds = create_test_user(ADMIN_CREDENTIALS)
+        group_name = get_random_string()
+        det_cmd(
+            ["user-group", "create", group_name, "--add-user", test_user_creds.username], check=True
+        )
+
+        # No roles should be returned since no assignmnets have happened.
+        list_user_roles = ["rbac", "list-users-roles", test_user_creds.username]
+        list_group_roles = ["rbac", "list-groups-roles", group_name]
+
+        assert det_cmd_json(list_user_roles + ["--json"])["roles"] == []
+        assert (
+            "user has no role assignments" in det_cmd(list_user_roles, check=True).stdout.decode()
+        )
+
+        assert det_cmd_json(list_group_roles + ["--json"])["roles"] == []
+        assert (
+            "group has no role assignments" in det_cmd(list_group_roles, check=True).stdout.decode()
+        )
+
+        # Assign roles.
+        det_cmd(
+            ["rbac", "assign-role", "Viewer", "--username-to-assign", test_user_creds.username],
+            check=True,
+        )
+        det_cmd(
+            [
+                "rbac",
+                "assign-role",
+                "Viewer",
+                "--username-to-assign",
+                test_user_creds.username,
+                "--workspace-name",
+                "Uncategorized",
+            ],
+            check=True,
+        )
+
+        det_cmd(["rbac", "assign-role", "Editor", "--group-name-to-assign", group_name], check=True)
+        det_cmd(
+            [
+                "rbac",
+                "assign-role",
+                "Editor",
+                "--group-name-to-assign",
+                group_name,
+                "--workspace-name",
+                "Uncategorized",
+            ],
+            check=True,
+        )
+
+        # Test list-users-roles.
+        det_cmd(list_user_roles, check=True)
+        json_out = det_cmd_json(list_user_roles + ["--json"])
+        assert len(json_out["roles"]) == 2
+        json_out["roles"].sort(key=lambda x: -1 if x["name"] == "Viewer" else 1)
+        assert json_out["roles"][0]["name"] == "Viewer"
+        assert json_out["roles"][1]["name"] == "Editor"
+
+        # Test list-groups-roles.
+        det_cmd(list_group_roles, check=True)
+        json_out = det_cmd_json(list_group_roles + ["--json"])
+        assert len(json_out["roles"]) == 1
+        assert json_out["roles"][0]["name"] == "Editor"
+
 
 @pytest.mark.e2e_cpu
+@pytest.mark.skipif(roles_not_implemented(), reason="ee is required for this test")
 def test_rbac_describe_role() -> None:
-    pass
+    with logged_in_user(ADMIN_CREDENTIALS):
+        # Role doesn't exist.
+        det_cmd_expect_error(
+            ["rbac", "describe-role", "roleDoesntExist"], "could not find role name"
+        )
 
-        
+        # Role is assigned to our group and user.
+        test_user_creds = create_test_user(ADMIN_CREDENTIALS)
+        group_name = get_random_string()
 
-        
-# assign_role (x)
-# unassign_role (x)
-# my_permissions (x) (technically don't check no json output since it is too hard...)
-        
-# list_roles
-# list_users_roles
-# list_groups_roles
+        det_cmd(["user-group", "create", group_name], check=True)
+        det_cmd(["rbac", "assign-role", "Viewer", "--group-name-to-assign", group_name], check=True)
+        det_cmd(
+            [
+                "rbac",
+                "assign-role",
+                "Viewer",
+                "--group-name-to-assign",
+                group_name,
+                "--workspace-name",
+                "Uncategorized",
+            ],
+            check=True,
+        )
 
-# describe_role 
+        sess = determined_test_session()
+        user_id = usernames_to_user_ids(sess, [test_user_creds.username])[0]
+        group_id = group_name_to_group_id(sess, group_name)
+
+        det_cmd(
+            ["rbac", "assign-role", "Viewer", "--username-to-assign", test_user_creds.username],
+            check=True,
+        )
+        det_cmd(
+            [
+                "rbac",
+                "assign-role",
+                "Viewer",
+                "--username-to-assign",
+                test_user_creds.username,
+                "--workspace-name",
+                "Uncategorized",
+            ],
+            check=True,
+        )
+
+        # No errors printing non-json output.
+        det_cmd(["rbac", "describe-role", "Viewer"], check=True)
+
+        # Output is returned correctly.
+        json_out = det_cmd_json(["rbac", "describe-role", "Viewer", "--json"])
+        assert json_out["role"]["name"] == "Viewer"
+
+        group_assign = [a for a in json_out["groupRoleAssignments"] if a["groupId"] == group_id]
+        assert len(group_assign) == 2
+        group_assign.sort(
+            key=lambda x: -1 if x["roleAssignment"]["scopeWorkspaceId"] is None else 1
+        )
+        assert group_assign[0]["roleAssignment"]["scopeWorkspaceId"] is None
+        assert group_assign[1]["roleAssignment"]["scopeWorkspaceId"] == 1
+
+        user_assign = [a for a in json_out["userRoleAssignments"] if a["userId"] == user_id]
+        assert len(user_assign) == 2
+        user_assign.sort(key=lambda x: -1 if x["roleAssignment"]["scopeWorkspaceId"] is None else 1)
+        assert user_assign[0]["roleAssignment"]["scopeWorkspaceId"] is None
+        assert user_assign[1]["roleAssignment"]["scopeWorkspaceId"] == 1

--- a/e2e_tests/tests/cluster/test_rbac.py
+++ b/e2e_tests/tests/cluster/test_rbac.py
@@ -1,5 +1,3 @@
-# from typing import Any, List
-
 import pytest
 
 from determined.cli.user_groups import group_name_to_group_id, usernames_to_user_ids

--- a/harness/determined/cli/cli.py
+++ b/harness/determined/cli/cli.py
@@ -36,6 +36,7 @@ from determined.cli.top_arg_descriptions import deploy_cmd
 from determined.cli.trial import args_description as trial_args_description
 from determined.cli.user import args_description as user_args_description
 from determined.cli.user_groups import args_description as user_groups_args_description
+from determined.cli.rbac import args_description as rbac_args_description
 from determined.cli.version import args_description as version_args_description
 from determined.cli.version import check_version
 from determined.cli.workspace import args_description as workspace_args_description
@@ -152,6 +153,7 @@ all_args_description = (
     + remote_args_description
     + user_args_description
     + user_groups_args_description
+    + rbac_args_description
     + version_args_description
     + workspace_args_description
     + auth_args_description

--- a/harness/determined/cli/cli.py
+++ b/harness/determined/cli/cli.py
@@ -25,6 +25,7 @@ from determined.cli.model import args_description as model_args_description
 from determined.cli.notebook import args_description as notebook_args_description
 from determined.cli.oauth import args_description as oauth_args_description
 from determined.cli.project import args_description as project_args_description
+from determined.cli.rbac import args_description as rbac_args_description
 from determined.cli.remote import args_description as remote_args_description
 from determined.cli.resources import args_description as resources_args_description
 from determined.cli.shell import args_description as shell_args_description
@@ -36,7 +37,6 @@ from determined.cli.top_arg_descriptions import deploy_cmd
 from determined.cli.trial import args_description as trial_args_description
 from determined.cli.user import args_description as user_args_description
 from determined.cli.user_groups import args_description as user_groups_args_description
-from determined.cli.rbac import args_description as rbac_args_description
 from determined.cli.version import args_description as version_args_description
 from determined.cli.version import check_version
 from determined.cli.workspace import args_description as workspace_args_description

--- a/harness/determined/cli/rbac.py
+++ b/harness/determined/cli/rbac.py
@@ -104,10 +104,6 @@ def list_users_roles(args: Namespace) -> None:
         return
     for r in resp.roles:
         print(f"user is assigned to role '{r.name}' with ID {r.roleId}")
-        if r.permissions is None:
-            continue
-        for p in r.permissions:
-            print(f"\twith{' global' if p.isGlobal else ''} permission '{p.name}' with type {p.id}")
 
 
 @authentication.required
@@ -125,10 +121,6 @@ def list_groups_roles(args: Namespace) -> None:
         return
     for r in resp.roles:
         print(f"group is assigned to role '{r.name}' with ID {r.roleId}")
-        if r.permissions is None:
-            continue
-        for p in r.permissions:
-            print(f"\twith{' global' if p.isGlobal else ''} permission '{p.name}' with type {p.id}")
 
 
 @authentication.required
@@ -157,30 +149,31 @@ def describe_role(args: Namespace) -> None:
     print()
 
     group_assignments = resp.roles[0].groupRoleAssignments
-    if group_assignments is None:
-        group_assignments = []
-    for group_assignment in group_assignments:
-        scope = "globally"
-        workspace_id = group_assignment.roleAssignment.scopeWorkspaceId
-        if workspace_id is not None:
-            workspace_name = bindings.get_GetWorkspace(session, id=workspace_id).workspace.name
-            scope = f"over workspace '{workspace_name}' with ID {workspace_id}"
+    if group_assignments is not None:
+        for group_assignment in group_assignments:
+            scope = "globally"
+            workspace_id = group_assignment.roleAssignment.scopeWorkspaceId
+            if workspace_id is not None:
+                workspace_name = bindings.get_GetWorkspace(session, id=workspace_id).workspace.name
+                scope = f"over workspace '{workspace_name}' with ID {workspace_id}"
 
-        group_name = bindings.get_GetGroup(session, groupId=group_assignment.groupId).group.name
-        print(f"\tassigned to group '{group_name}' with ID {group_assignment.groupId} {scope}")
+                group_name = bindings.get_GetGroup(session,
+                                                   groupId=group_assignment.groupId).group.name
+                print(f"\tassigned to group '{group_name}' with ID " +
+                      f"{group_assignment.groupId} {scope}")
 
     user_assignments = resp.roles[0].userRoleAssignments
-    if user_assignments is None:
-        user_assignments = []
-    for user_assignment in user_assignments:
-        scope = "globally"
-        workspace_id = user_assignment.roleAssignment.scopeWorkspaceId
-        if workspace_id is not None:
-            workspace_name = bindings.get_GetWorkspace(session, id=workspace_id).workspace.name
-            scope = f"over workspace '{workspace_name}' with ID {workspace_id}"
+    if user_assignments is not None:
+        for user_assignment in user_assignments:
+            scope = "globally"
+            workspace_id = user_assignment.roleAssignment.scopeWorkspaceId
+            if workspace_id is not None:
+                workspace_name = bindings.get_GetWorkspace(session, id=workspace_id).workspace.name
+                scope = f"over workspace '{workspace_name}' with ID {workspace_id}"
 
-        username = bindings.get_GetUser(session, userId=user_assignment.userId).user.username
-        print(f"\tassigned directly to user '{username}' with ID {user_assignment.userId} {scope}")
+                username = bindings.get_GetUser(session, userId=user_assignment.userId).user.username
+                print(f"\tassigned directly to user '{username}' with ID " +
+                      f"{user_assignment.userId} {scope}")
 
 
 def create_assignment_request(
@@ -310,7 +303,7 @@ args_description = [
                 list_groups_roles,
                 "list group's roles",
                 [
-                    Arg("group_name", help="name of group to list role's assigned to"),
+                    Arg("group_name", help="name of the group for which to list assigned roles"),
                     Arg("--json", action="store_true", help="print as JSON"),
                 ],
             ),
@@ -332,7 +325,7 @@ args_description = [
                     Arg(
                         "--workspace-name",
                         default=None,
-                        help="workspace name of the scope of the role assignment",
+                        help="name of the workspace the role is assigned to",
                     ),
                     Arg(
                         "--username-to-assign", default=None, help="username to assign the role to"
@@ -340,7 +333,7 @@ args_description = [
                     Arg(
                         "--group-name-to-assign",
                         default=None,
-                        help="group name to assign the role to",
+                        help="name of the group the role is assigned to",
                     ),
                 ],
             ),
@@ -353,17 +346,17 @@ args_description = [
                     Arg(
                         "--workspace-name",
                         default=None,
-                        help="workspace name of the scope of the role assignment",
+                        help="name of the workspace the role is unassigned from",
                     ),
                     Arg(
                         "--username-to-assign",
                         default=None,
-                        help="username to unassign the role to",
+                        help="username the role is unassigned from",
                     ),
                     Arg(
                         "--group-name-to-assign",
                         default=None,
-                        help="group name to unassign the role to",
+                        help="name of the group the role is unassigned from",
                     ),
                 ],
             ),

--- a/harness/determined/cli/rbac.py
+++ b/harness/determined/cli/rbac.py
@@ -1,0 +1,307 @@
+import json
+from argparse import Namespace
+from collections import namedtuple
+from typing import Any, Dict, List, Optional
+
+from determined.cli import default_pagination_args, render, setup_session, workspace, user_groups
+from determined.common import api
+from determined.common.api import authentication, bindings
+from determined.common.declarative_argparse import Arg, Cmd
+from determined.common.experimental import session
+
+rbac_flag_disabled_message = (
+    "RBAC commands require the Determined Enterprise Edition "
+    + "and the Master Configuration option security.authz.rbac_ui_enabled."
+)
+
+@authentication.required
+@require_feature_flag("rbacEnabled", rbac_flag_disabled_message)
+def my_permissions(args: Namespace) -> None:
+    session = setup_session(args)
+    resp = bindings.get_GetPermissionsSummary(session)
+    if args.json:
+        print(json.dumps(resp.to_json(), indent=2))
+        return
+
+    role_id_to_permissions = {}
+    for r in resp.roles:
+        role_id_to_permissions[r.roleId] = set(r.permissions)
+
+    scope_id_to_permissions = {}
+    for a in resp.assignments:
+        if a.isGlobal:
+            if 0 not in scope_id_to_permissions:
+                scope_id_to_permissions[0] = set()            
+            scope_id_to_permissions[0].update(role_id_to_permissions[a.roleId])
+            
+        for wid in a.scopeWorkspaceIds:
+            if wid not in scope_id_to_permissions:
+                scope_id_to_permissions[wid] = set()            
+            scope_id_to_permissions[wid].update(role_id_to_permissions[a.roleId])
+
+            
+    for wid, perms in scope_id_to_permissions.items():
+        if wid == 0:
+            print("global permissions assigned")
+        else:
+            workspace_name = bindings.get_GetWorkspace(session, id=wid).workspace.name
+            print(f"permissions assigned over workspace {'workspace_name'} with ID '{wid}'")
+        for p in perms:
+            print(f"\tpermission '{p.name}' with type {p.id}")
+        print()
+
+        
+@authentication.required
+@require_feature_flag("rbacEnabled", rbac_flag_disabled_message)
+def list_roles(args: Namespace) -> None:
+    req = bindings.v1SearchRolesAssignableToScopeRequest(
+        limit=args.limit,
+        offset=args.offset,
+        workspaceId=1 if args.exclude_global_roles else None,
+    )
+    resp = bindings.post_SearchRolesAssignableToScope(setup_session(args), body=req)
+    if args.json:
+        print(json.dumps(resp.to_json(), indent=2))
+        return
+
+    if len(resp.roles) == 0:
+        print("no roles found")
+    for r in resp.roles:
+        print(f"role '{r.name}' with ID {r.roleId}")        
+        for p in r.permissions:
+            print(f"\twith{' global' if p.isGlobal else ''} permission '{p.name}' with type {p.id}")
+
+
+@authentication.required
+@require_feature_flag("rbacEnabled", rbac_flag_disabled_message)
+def list_users_roles(args: Namespace) -> None:    
+    session = setup_session(args)
+    user_id = user_groups.usernames_to_user_ids(session, [args.username])[0]
+    resp = bindings.get_GetRolesAssignedToUser(session, userId=user_id)
+    if args.json:
+        print(json.dumps(resp.to_json(), indent=2))
+        return
+
+    if len(resp.roles) == 0:
+        print("user has no role assignments")
+    for r in resp.roles:
+        print(f"user is assigned to role '{r.name}' with ID {r.roleId}")
+        for p in r.permissions:
+            print(f"\twith{' global' if p.isGlobal else ''} permission '{p.name}' with type {p.id}")
+
+
+@authentication.required
+@require_feature_flag("rbacEnabled", rbac_flag_disabled_message)
+def list_groups_roles(args: Namespace) -> None:
+    session = setup_session(args)
+    group_id = user_groups.group_name_to_group_id(session, args.group_name)
+    resp = bindings.get_GetRolesAssignedToGroup(session, groupId=group_id)
+    if args.json:
+        print(json.dumps(resp.to_json(), indent=2))
+        return
+
+    if len(resp.roles) == 0:
+        print("group has no role assignments")
+    for r in resp.roles:
+        print(f"group is assigned to role '{r.name}' with ID {r.roleId}")
+        for p in r.permissions:
+            print(f"\twith{' global' if p.isGlobal else ''} permission '{p.name}' with type {p.id}")
+
+
+@authentication.required
+@require_feature_flag("rbacEnabled", rbac_flag_disabled_message)
+def describe_role(args: Namespace) -> None:
+    session = setup_session(args)
+    role_id = role_name_to_role_id(session, args.role_name)
+    req = bindings.v1GetRolesByIDRequest(roleIds=[role_id])
+    resp = bindings.post_GetRolesByID(session, body=req)
+    if args.json:
+        print(json.dumps(resp.to_json().get("roles")[0], indent=2))
+        return
+
+    role = resp.roles[0]
+    print(f"role '{role.role.name}' with ID {role.role.roleId}")
+    for p in role.role.permissions:
+        print(f"\twith{' global' if p.isGlobal else ''} permission '{p.name}' with type {p.id}")
+    print()
+
+    for group_assignment in role.groupRoleAssignments:
+        scope = "globally"
+        workspace_id = group_assignment.roleAssignment.scopeWorkspaceId
+        if workspace_id is not None:
+            workspace_name = bindings.get_GetWorkspace(session, id=workspace_id).workspace.name
+            scope = f"over workspace '{workspace_name}' with ID {workspace_id}"
+
+        group_name = bindings.get_GetGroup(session, groupId=group_assignment.groupId).group.name
+        print(f"\tassigned to group '{group_name}' with ID {group_assignment.groupId} {scope}")
+
+    for user_assignment in role.userRoleAssignments:
+        scope = "globally"
+        workspace_id = user_assignment.roleAssignment.scopeWorkspaceId        
+        if workspace_id is not None:
+            workspace_name = bindings.get_GetWorkspace(session, id=workspace_id).workspace.name
+            scope = f"over workspace '{workspace_name}' with ID {workspace_id}"
+
+
+        username = bindings.get_GetUser(session, userId=user_assignment.userId).user.username        
+        print(f"\tassigned directly to user '{username}' with ID {user_assignment.userId} {scope}")
+
+
+def create_assignment_request(session: session.Session, args: Namespace) -> (List[bindings.v1UserRoleAssignment], List[bindings.v1GroupRoleAssignment]):
+    if (args.username_to_assign is None) == (args.group_name_to_assign is None):
+        raise api.errors.BadRequestException(
+            "must provide exactly one of --username-to-assign or --group-name-to-assign")
+
+    role = bindings.v1Role(roleId=role_name_to_role_id(session, args.role_name))
+
+    workspace_id = None
+    if args.workspace_name is not None:
+        workspace_id = workspace.workspace_by_name(session, args.workspace_name).id
+    role_assign = bindings.v1RoleAssignment(role=role, scopeWorkspaceId=workspace_id)
+
+    if args.username_to_assign is not None:
+        user_id = user_groups.usernames_to_user_ids(session, [args.username_to_assign])[0]
+        return [bindings.v1UserRoleAssignment(userId=user_id, roleAssignment=role_assign)], []
+
+    group_id = user_groups.group_name_to_group_id(session, args.group_name_to_assign)
+    return [], [bindings.v1GroupRoleAssignment(groupId=group_id, roleAssignment=role_assign)]        
+
+
+@authentication.required
+@require_feature_flag("rbacEnabled", rbac_flag_disabled_message)
+def assign_role(args: Namespace) -> None:    
+    session = setup_session(args)
+    user_assign, group_assign = create_assignment_request(session, args)
+    req = bindings.v1AssignRolesRequest(userRoleAssignments=user_assign,
+                                        groupRoleAssignments=group_assign)
+    bindings.post_AssignRoles(session, body=req)
+
+    scope = " globally"
+    if args.workspace_name:
+        scope = f" to workspace {args.workspace_name}"
+    if len(user_assign) > 0:
+        print(
+            f"assigned role '{args.role_name}' with ID {user_assign[0].roleAssignment.role.roleId} " +
+            f"to user '{args.username_to_assign}' with ID {user_assign[0].userId}{scope}")
+    else:
+        print(
+            f"assigned role '{args.role_name}' with ID {group_assign[0].roleAssignment.role.roleId} " +
+            f"to group '{args.group_name_to_assign}' with ID {group_assign[0].groupId}{scope}")
+
+
+@authentication.required
+@require_feature_flag("rbacEnabled", rbac_flag_disabled_message)
+def unassign_role(args: Namespace) -> None:
+    session = setup_session(args)
+    user_assign, group_assign = create_assignment_request(session, args)
+    req = bindings.v1RemoveAssignmentsRequest(userRoleAssignments=user_assign,
+                                              groupRoleAssignments=group_assign)
+    bindings.post_RemoveAssignments(session, body=req)
+
+    scope = " globally"
+    if args.workspace_name:
+        scope = f" to workspace {args.workspace_name}"
+    if len(user_assign) > 0:
+        print(
+            f"removed role '{args.role_name}' with ID {user_assign[0].roleAssignment.role.roleId} " +
+            f"from user '{args.username_to_assign}' with ID {user_assign[0].userId}{scope}")        
+    else:
+        print(
+            f"removed role '{args.role_name}' with ID {group_assign[0].roleAssignment.role.roleId} " +
+            f"from group '{args.group_name_to_assign}' with ID {group_assign[0].groupId}{scope}")
+
+
+def role_name_to_role_id(session: session.Session, role_name: str) -> int:
+    req = bindings.v1ListRolesRequest(limit=499, offset=0)
+    resp = bindings.post_ListRoles(session=session, body=req)
+    for r in resp.roles:
+        if r.name == role_name:
+            return r.roleId
+    raise api.errors.BadRequestException(f"could not find role name {role_name}")
+
+
+args_description = [
+    Cmd(
+        "rbac",
+        None,
+        "manage roles based access controls",
+        [
+            Cmd(
+                "my-permissions",
+                my_permissions,
+                "list permissions the current user has",
+                [
+                    Arg("--json", action="store_true", help="print as JSON"),
+                ],
+            ),
+            Cmd(
+                "list-roles",
+                list_roles,
+                "list roles",
+                [
+                    Arg("--exclude-global-roles", action="store_true",
+                        help="Ignore roles with global permissions"),
+                    Arg("--json", action="store_true", help="print as JSON"),
+                    *default_pagination_args,
+                ],
+                is_default=True,
+            ),
+            Cmd(
+                "list-users-roles",
+                list_users_roles,
+                "list user's roles",
+                [
+                    Arg("username", help="username of user to list role's assigned to"),
+                    Arg("--json", action="store_true", help="print as JSON"),
+                ],
+            ),
+            Cmd(
+                "list-groups-roles",
+                list_groups_roles,
+                "list group's roles",
+                [
+                    Arg("group_name", help="name of group to list role's assigned to"),
+                    Arg("--json", action="store_true", help="print as JSON"),
+                ],
+            ),
+            Cmd(
+                "describe-role",
+                describe_role,
+                "describe a role",
+                [
+                    Arg("role_name", help="name of role to describe"),
+                    Arg("--json", action="store_true", help="print as JSON"),                    
+                ],
+            ),
+            Cmd(
+                "assign-role",
+                assign_role,
+                "assign a role to a user or group",
+                [
+                    Arg("role_name", help="name of role to assign"),
+                    Arg("--workspace-name", default=None,
+                        help="workspace name of the scope of the role assignment"), 
+                    Arg("--username-to-assign", default=None,
+                        help="username to assign the role to"),
+                    Arg("--group-name-to-assign", default=None,
+                        help="group name to assign the role to"),
+                ],
+            ),
+            Cmd(
+                "unassign-role",
+                unassign_role,
+                "unassign a role from a user or group",
+                [
+                    Arg("role_name", help="name of role to unassign"),
+                    Arg("--workspace-name", default=None,
+                        help="workspace name of the scope of the role assignment"),
+                    Arg("--username-to-assign", default=None,
+                        help="username to unassign the role to"),
+                    Arg("--group-name-to-assign", default=None,
+                        help="group name to unassign the role to"),
+                ],
+            )                    
+        ]
+    )
+]  # type: List[Any]
+

--- a/harness/determined/cli/rbac.py
+++ b/harness/determined/cli/rbac.py
@@ -51,6 +51,9 @@ def my_permissions(args: Namespace) -> None:
                 scope_id_to_permissions[wid] = set()
             scope_id_to_permissions[wid].update(role_id_to_permissions[a.roleId])
 
+    if len(scope_id_to_permissions) == 0:
+        print("no permissions assigned")
+        return
     for wid, perms in scope_id_to_permissions.items():
         if wid == 0:
             print("global permissions assigned")


### PR DESCRIPTION
## Description

RBAC CLI implementation with e2e tests. Requires EE to use and run the tests.  

## Test Plan

E2e tests. They are skipped in OSS so to test you can run a ee devcluster with config the following config

```
        security:
          authz:
            rbac_ui_enabled: true
```

## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist
- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.
- [ ] If modifying `/webui/react/src/shared/` verify `make -C webui/react test-shared` passes.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
