### PR TITLE
fix: Trial.TotalCheckpointSize considers deleted checkpoints [DET-8399]

### DIFF
--- a/master/static/srv/proto_get_trials_plus.sql
+++ b/master/static/srv/proto_get_trials_plus.sql
@@ -179,8 +179,10 @@ SELECT
     SELECT sum((jsonb_each).value::text::bigint)
     FROM (
         SELECT jsonb_each(resources) FROM checkpoints_old_view c WHERE c.trial_id = t.id
+          AND state != 'DELETED'
         UNION ALL
         SELECT jsonb_each(resources) FROM checkpoints_new_view c WHERE c.trial_id = t.id
+          AND state != 'DELETED'
     ) r
   ) AS total_checkpoint_size,
   -- `restart` count is incremented before `restart <= max_restarts` stop restart check,


### PR DESCRIPTION
## Description

Fix issue where Total Checkpoint Size was showing the size of all checkpoints, even deleted ones.

## To Test:
1. Create an single trial experiment which creates multiple trials (set min_checkpoint_period to something small).
2. Wait for trial to complete and GC task to run,.
3. Go to `http://host:8080/det/experiments/<exp_id>/overview`
4. Observe that the "Total Checkpoint Size" matches the total for non-deleted checkpoints in: `http://host:8080/det/experiments/<exp_id>/checkpoints`
