### PR TITLE
feat: RBAC for experiment actions [DET-8372]

### DIFF
--- a/webui/react/src/components/Badge.module.scss
+++ b/webui/react/src/components/Badge.module.scss
@@ -8,6 +8,7 @@
   line-height: 18px;
   padding: 0 6px;
   text-align: center;
+  white-space: break-spaces;
 }
 .dashed {
   border: dashed var(--theme-stroke-width) var(--theme-float-border-strong);

--- a/webui/react/src/components/ExperimentActionDropdown.tsx
+++ b/webui/react/src/components/ExperimentActionDropdown.tsx
@@ -183,15 +183,16 @@ const ExperimentActionDropdown: React.FC<Props> = ({
     // TODO show loading indicator when we have a button component that supports it.
   };
 
-  const menuItems = getActionsForExperiment(experiment, dropdownActions, usePermissions())
-    .map((action) => {
+  const menuItems = getActionsForExperiment(experiment, dropdownActions, usePermissions()).map(
+    (action) => {
       if (action === Action.SwitchPin) {
         const label = (settings?.pinned[experiment.projectId] ?? []).includes(id) ? 'Unpin' : 'Pin';
         return { key: action, label };
       } else {
         return { danger: action === Action.Delete, key: action, label: action };
       }
-    });
+    },
+  );
 
   if (menuItems.length === 0) {
     return (

--- a/webui/react/src/components/ExperimentActionDropdown.tsx
+++ b/webui/react/src/components/ExperimentActionDropdown.tsx
@@ -183,15 +183,7 @@ const ExperimentActionDropdown: React.FC<Props> = ({
     // TODO show loading indicator when we have a button component that supports it.
   };
 
-  const { canMoveExperiment, canDeleteExperiment } = usePermissions();
-
-  const menuItems = getActionsForExperiment(experiment, dropdownActions)
-    .filter((action) =>
-      [Action.Delete, Action.Move].includes(action)
-        ? (action === Action.Delete && canDeleteExperiment({ experiment })) ||
-          (action === Action.Move && canMoveExperiment({ experiment }))
-        : true,
-    )
+  const menuItems = getActionsForExperiment(experiment, dropdownActions, usePermissions())
     .map((action) => {
       if (action === Action.SwitchPin) {
         const label = (settings?.pinned[experiment.projectId] ?? []).includes(id) ? 'Unpin' : 'Pin';

--- a/webui/react/src/hooks/usePermissions.ts
+++ b/webui/react/src/hooks/usePermissions.ts
@@ -50,6 +50,7 @@ interface PermissionsHook {
   canMoveExperiment: (arg0: ExperimentPermissionsArgs) => boolean;
   canMoveProjects: (arg0: ProjectPermissionsArgs) => boolean;
   canUpdateRoles: (arg0: ProjectPermissionsArgs) => boolean;
+  canViewExperimentArtifacts: (arg0: WorkspacePermissionsArgs) => boolean;
   canViewGroups: boolean;
   canViewUsers: boolean;
   canViewWorkspace: (arg0: WorkspacePermissionsArgs) => boolean;
@@ -97,6 +98,8 @@ const usePermissions = (): PermissionsHook => {
       canMoveWorkspaceProjects(args.workspace, args.project, user, userAssignments, userRoles),
     canUpdateRoles: (args: WorkspacePermissionsArgs) =>
       canUpdateRoles(args.workspace, user, userAssignments, userRoles),
+    canViewExperimentArtifacts: (args: WorkspacePermissionsArgs) =>
+      canViewExperimentArtifacts(args.workspace, userAssignments, userRoles),
     canViewGroups: canViewGroups(user, userAssignments, userRoles),
     canViewUsers: canAdministrateUsers(user, userAssignments, userRoles),
     canViewWorkspace: (args: WorkspacePermissionsArgs) =>
@@ -146,6 +149,16 @@ const canAdministrateUsers = (
     !!user &&
     (permitted.has('oss_user') ? user.isAdmin : permitted.has('PERMISSION_CAN_ADMINISTRATE_USERS'))
   );
+};
+
+// experiment artifacts (usually checkpoints)
+const canViewExperimentArtifacts = (
+  workspace?: PermissionWorkspace,
+  userAssignments?: UserAssignment[],
+  userRoles?: UserRole[],
+): boolean => {
+  const permitted = relevantPermissions(userAssignments, userRoles, workspace?.id);
+  return workspace && permitted.has('oss_user') || permitted.has('view_experiment_artifacts');
 };
 
 const canViewGroups = (

--- a/webui/react/src/hooks/usePermissions.ts
+++ b/webui/react/src/hooks/usePermissions.ts
@@ -206,10 +206,7 @@ const canModifyExperiment = (
   userRoles?: UserRole[],
 ): boolean => {
   const permitted = relevantPermissions(userAssignments, userRoles, workspace?.id);
-  return (
-    !!workspace &&
-    (permitted.has('oss_user') || permitted.has('update_experiments'))
-  );
+  return !!workspace && (permitted.has('oss_user') || permitted.has('update_experiments'));
 };
 
 const canModifyExperimentMetadata = (
@@ -218,10 +215,7 @@ const canModifyExperimentMetadata = (
   userRoles?: UserRole[],
 ): boolean => {
   const permitted = relevantPermissions(userAssignments, userRoles, workspace?.id);
-  return (
-    !!workspace &&
-    (permitted.has('oss_user') || permitted.has('update_experiment_metadata'))
-  );
+  return !!workspace && (permitted.has('oss_user') || permitted.has('update_experiment_metadata'));
 };
 
 const canMoveExperiment = (

--- a/webui/react/src/hooks/usePermissions.ts
+++ b/webui/react/src/hooks/usePermissions.ts
@@ -234,7 +234,7 @@ const canMoveExperiment = (
   );
 };
 
-// experiment artifacts (usually checkpoints)
+// experiment artifacts (checkpoints, metrics, etc.)
 const canViewExperimentArtifacts = (
   workspace?: PermissionWorkspace,
   userAssignments?: UserAssignment[],

--- a/webui/react/src/hooks/usePermissions.ts
+++ b/webui/react/src/hooks/usePermissions.ts
@@ -28,8 +28,8 @@ interface ProjectPermissionsArgs {
 
 interface PermissionsHook {
   canAssignRoles: (arg0: WorkspacePermissionsArgs) => boolean;
-  canCreateWorkspace: boolean;
   canCreateExperiment: (arg0: WorkspacePermissionsArgs) => boolean;
+  canCreateWorkspace: boolean;
   canDeleteExperiment: (arg0: ExperimentPermissionsArgs) => boolean;
   canDeleteModel: (arg0: ModelPermissionsArgs) => boolean;
   canDeleteModelVersion: (arg0: ModelVersionPermissionsArgs) => boolean;
@@ -69,9 +69,9 @@ const usePermissions = (): PermissionsHook => {
   return {
     canAssignRoles: (args: WorkspacePermissionsArgs) =>
       canAssignRoles(args.workspace, user, userAssignments, userRoles),
-    canCreateWorkspace: canCreateWorkspace(userAssignments, userRoles),
     canCreateExperiment: (args: WorkspacePermissionsArgs) =>
       canCreateExperiment(args.workspace, userAssignments, userRoles),
+    canCreateWorkspace: canCreateWorkspace(userAssignments, userRoles),
     canDeleteExperiment: (args: ExperimentPermissionsArgs) =>
       canDeleteExperiment(args.experiment, user, userAssignments, userRoles),
     canDeleteModel: (args: ModelPermissionsArgs) =>

--- a/webui/react/src/hooks/usePermissions.ts
+++ b/webui/react/src/hooks/usePermissions.ts
@@ -38,7 +38,7 @@ interface PermissionsHook {
   canGetPermissions: boolean;
   canModifyExperiment: (arg0: WorkspacePermissionsArgs) => boolean;
   canModifyExperimentMetadata: (arg0: WorkspacePermissionsArgs) => boolean;
-  canModifyGroups: () => boolean;
+  canModifyGroups: boolean;
   canModifyPermissions: boolean;
   canModifyProjects: (arg0: ProjectPermissionsArgs) => boolean;
   canModifyUsers: boolean;
@@ -87,7 +87,7 @@ const usePermissions = (): PermissionsHook => {
       canModifyExperiment(args.workspace, userAssignments, userRoles),
     canModifyExperimentMetadata: (args: WorkspacePermissionsArgs) =>
       canModifyExperimentMetadata(args.workspace, userAssignments, userRoles),
-    canModifyGroups: () => canModifyGroups(user, userAssignments, userRoles),
+    canModifyGroups: canModifyGroups(user, userAssignments, userRoles),
     canModifyPermissions: canAdministrateUsers(user, userAssignments, userRoles),
     canModifyProjects: (args: ProjectPermissionsArgs) =>
       canModifyWorkspaceProjects(args.workspace, args.project, user, userAssignments, userRoles),

--- a/webui/react/src/hooks/usePermissions.ts
+++ b/webui/react/src/hooks/usePermissions.ts
@@ -36,7 +36,9 @@ interface PermissionsHook {
   canDeleteProjects: (arg0: ProjectPermissionsArgs) => boolean;
   canDeleteWorkspace: (arg0: WorkspacePermissionsArgs) => boolean;
   canGetPermissions: boolean;
-  canModifyGroups: boolean;
+  canModifyExperiment: (arg0: WorkspacePermissionsArgs) => boolean;
+  canModifyExperimentMetadata: (arg0: WorkspacePermissionsArgs) => boolean;
+  canModifyGroups: () => boolean;
   canModifyPermissions: boolean;
   canModifyProjects: (arg0: ProjectPermissionsArgs) => boolean;
   canModifyUsers: boolean;
@@ -80,8 +82,12 @@ const usePermissions = (): PermissionsHook => {
       canDeleteWorkspaceProjects(args.workspace, args.project, user, userAssignments, userRoles),
     canDeleteWorkspace: (args: WorkspacePermissionsArgs) =>
       canDeleteWorkspace(args.workspace, user, userAssignments, userRoles),
-    canGetPermissions: canAdministrateUsers(user, userAssignments, userRoles),
-    canModifyGroups: canModifyGroups(user, userAssignments, userRoles),
+    canGetPermissions: canGetPermissions(user, userAssignments, userRoles),
+    canModifyExperiment: (args: WorkspacePermissionsArgs) =>
+      canModifyExperiment(args.workspace, userAssignments, userRoles),
+    canModifyExperimentMetadata: (args: WorkspacePermissionsArgs) =>
+      canModifyExperimentMetadata(args.workspace, userAssignments, userRoles),
+    canModifyGroups: () => canModifyGroups(user, userAssignments, userRoles),
     canModifyPermissions: canAdministrateUsers(user, userAssignments, userRoles),
     canModifyProjects: (args: ProjectPermissionsArgs) =>
       canModifyWorkspaceProjects(args.workspace, args.project, user, userAssignments, userRoles),
@@ -191,6 +197,30 @@ const canDeleteExperiment = (
     (permitted.has('oss_user')
       ? user.isAdmin || user.id === experiment.userId
       : permitted.has('delete_experiment'))
+  );
+};
+
+const canModifyExperiment = (
+  workspace?: PermissionWorkspace,
+  userAssignments?: UserAssignment[],
+  userRoles?: UserRole[],
+): boolean => {
+  const permitted = relevantPermissions(userAssignments, userRoles, workspace?.id);
+  return (
+    !!workspace &&
+    (permitted.has('oss_user') || permitted.has('update_experiments'))
+  );
+};
+
+const canModifyExperimentMetadata = (
+  workspace?: PermissionWorkspace,
+  userAssignments?: UserAssignment[],
+  userRoles?: UserRole[],
+): boolean => {
+  const permitted = relevantPermissions(userAssignments, userRoles, workspace?.id);
+  return (
+    !!workspace &&
+    (permitted.has('oss_user') || permitted.has('update_experiment_metadata'))
   );
 };
 

--- a/webui/react/src/pages/ExperimentDetails/ExperimentDetailsHeader.module.scss
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentDetailsHeader.module.scss
@@ -13,6 +13,11 @@
       background-color: transparent;
       color: #fff;
       opacity: 0.75;
+
+      &[disabled], &[disabled]:active, &[disabled]:focus, &[disabled]:hover {
+        background-color: transparent !important;
+        border-color: transparent !important;
+      }
     }
     .buttonPause,
     .buttonPlay {

--- a/webui/react/src/pages/ExperimentDetails/ExperimentDetailsHeader.module.scss
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentDetailsHeader.module.scss
@@ -14,7 +14,10 @@
       color: #fff;
       opacity: 0.75;
 
-      &[disabled], &[disabled]:active, &[disabled]:focus, &[disabled]:hover {
+      &[disabled],
+      &[disabled]:active,
+      &[disabled]:focus,
+      &[disabled]:hover {
         background-color: transparent !important;
         border-color: transparent !important;
       }

--- a/webui/react/src/pages/ExperimentDetails/ExperimentDetailsHeader.tsx
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentDetailsHeader.tsx
@@ -94,6 +94,9 @@ const ExperimentDetailsHeader: React.FC<Props> = ({
   const isMovable =
     canActionExperiment(Action.Move, experiment) &&
     expPermissions.canMoveExperiment({ experiment });
+  const canPausePlay = expPermissions.canModifyExperiment({
+    workspace: { id: experiment.workspaceId },
+  });
 
   const { contextHolder: modalExperimentStopContextHolder, modalOpen: openModalStop } =
     useModalExperimentStop({ experimentId: experiment.id, onClose: handleModalClose });
@@ -405,6 +408,7 @@ const ExperimentDetailsHeader: React.FC<Props> = ({
                 {isPausable && (
                   <Button
                     className={css.buttonPause}
+                    disabled={!canPausePlay}
                     icon={<Icon name="pause" size="large" />}
                     shape="circle"
                     onClick={handlePauseClick}
@@ -413,6 +417,7 @@ const ExperimentDetailsHeader: React.FC<Props> = ({
                 {isPaused && (
                   <Button
                     className={css.buttonPlay}
+                    disabled={!canPausePlay}
                     icon={<Icon name="play" size="large" />}
                     shape="circle"
                     onClick={handlePlayClick}
@@ -421,6 +426,7 @@ const ExperimentDetailsHeader: React.FC<Props> = ({
                 {!isTerminated && (
                   <Button
                     className={css.buttonStop}
+                    disabled={!canPausePlay}
                     icon={<Icon name="stop" size="large" />}
                     shape="circle"
                     onClick={handleStopClick}

--- a/webui/react/src/pages/ExperimentDetails/ExperimentDetailsHeader.tsx
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentDetailsHeader.tsx
@@ -118,7 +118,8 @@ const ExperimentDetailsHeader: React.FC<Props> = ({
     }),
     [experiment.state],
   );
-  const disabled = experiment?.parentArchived || experiment?.archived;
+  const disabled = experiment?.parentArchived || experiment?.archived ||
+    !expPermissions.canModifyExperimentMetadata({ workspace: { id: experiment?.workspaceId } });
 
   const handlePauseClick = useCallback(async () => {
     setIsChangingState(true);

--- a/webui/react/src/pages/ExperimentDetails/ExperimentDetailsHeader.tsx
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentDetailsHeader.tsx
@@ -91,7 +91,8 @@ const ExperimentDetailsHeader: React.FC<Props> = ({
   const handleModalClose = useCallback(() => fetchExperimentDetails(), [fetchExperimentDetails]);
 
   const expPermissions = usePermissions();
-  const isMovable = canActionExperiment(Action.Move, experiment) &&
+  const isMovable =
+    canActionExperiment(Action.Move, experiment) &&
     expPermissions.canMoveExperiment({ experiment });
 
   const { contextHolder: modalExperimentStopContextHolder, modalOpen: openModalStop } =
@@ -118,7 +119,9 @@ const ExperimentDetailsHeader: React.FC<Props> = ({
     }),
     [experiment.state],
   );
-  const disabled = experiment?.parentArchived || experiment?.archived ||
+  const disabled =
+    experiment?.parentArchived ||
+    experiment?.archived ||
     !expPermissions.canModifyExperimentMetadata({ workspace: { id: experiment?.workspaceId } });
 
   const handlePauseClick = useCallback(async () => {

--- a/webui/react/src/pages/ExperimentDetails/ExperimentDetailsHeader.tsx
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentDetailsHeader.tsx
@@ -90,10 +90,9 @@ const ExperimentDetailsHeader: React.FC<Props> = ({
 
   const handleModalClose = useCallback(() => fetchExperimentDetails(), [fetchExperimentDetails]);
 
-  const { canDeleteExperiment, canMoveExperiment } = usePermissions();
-
-  const isMovable =
-    canActionExperiment(Action.Move, experiment) && canMoveExperiment({ experiment });
+  const expPermissions = usePermissions();
+  const isMovable = canActionExperiment(Action.Move, experiment) &&
+    expPermissions.canMoveExperiment({ experiment });
 
   const { contextHolder: modalExperimentStopContextHolder, modalOpen: openModalStop } =
     useModalExperimentStop({ experimentId: experiment.id, onClose: handleModalClose });
@@ -256,7 +255,6 @@ const ExperimentDetailsHeader: React.FC<Props> = ({
         onClick: handleContinueTrialClick,
       },
       [Action.Delete]: {
-        icon: <Icon name="fork" size="small" />,
         isLoading: isRunningDelete,
         key: 'delete',
         label: 'Delete',
@@ -318,17 +316,11 @@ const ExperimentDetailsHeader: React.FC<Props> = ({
       },
     };
 
-    const availableActions = getActionsForExperiment(experiment, headerActions).filter((action) =>
-      [Action.Delete, Action.Move].includes(action)
-        ? (action === Action.Delete && canDeleteExperiment({ experiment })) ||
-          (action === Action.Move && canMoveExperiment({ experiment }))
-        : true,
-    );
+    const availableActions = getActionsForExperiment(experiment, headerActions, expPermissions);
 
     return availableActions.map((action) => options[action]) as Option[];
   }, [
-    canDeleteExperiment,
-    canMoveExperiment,
+    expPermissions,
     isRunningArchive,
     handleContinueTrialClick,
     isRunningDelete,

--- a/webui/react/src/pages/ExperimentDetails/ExperimentMultiTrialTabs.tsx
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentMultiTrialTabs.tsx
@@ -3,6 +3,7 @@ import React, { useCallback, useEffect, useState } from 'react';
 import { useHistory, useParams } from 'react-router';
 
 import NotesCard from 'components/NotesCard';
+import usePermissions from 'hooks/usePermissions';
 import ExperimentTrials from 'pages/ExperimentDetails/ExperimentTrials';
 import { paths } from 'routes/utils';
 import { patchExperiment } from 'services/api';
@@ -88,6 +89,10 @@ const ExperimentMultiTrialTabs: React.FC<Props> = ({
     [experiment.id, fetchExperimentDetails],
   );
 
+  const showExperimentArtifacts = usePermissions().canViewExperimentArtifacts({
+    workspace: { id: experiment.workspaceId },
+  });
+
   return (
     <Tabs className="no-padding" defaultActiveKey={tabKey} onChange={handleTabChange}>
       <TabPane key="visualization" tab="Visualization">
@@ -102,18 +107,22 @@ const ExperimentMultiTrialTabs: React.FC<Props> = ({
       <TabPane key="trials" tab="Trials">
         <ExperimentTrials experiment={experiment} pageRef={pageRef} />
       </TabPane>
-      <TabPane key="checkpoints" tab="Checkpoints">
-        <ExperimentCheckpoints experiment={experiment} pageRef={pageRef} />
-      </TabPane>
-      <TabPane key="code" tab="Code">
-        <React.Suspense fallback={<Spinner tip="Loading code viewer..." />}>
-          <CodeViewer
-            experimentId={experiment.id}
-            runtimeConfig={experiment.configRaw}
-            submittedConfig={experiment.originalConfig}
-          />
-        </React.Suspense>
-      </TabPane>
+      {showExperimentArtifacts ? (
+        <>
+          <TabPane key="checkpoints" tab="Checkpoints">
+            <ExperimentCheckpoints experiment={experiment} pageRef={pageRef} />
+          </TabPane>
+          <TabPane key="code" tab="Code">
+            <React.Suspense fallback={<Spinner tip="Loading code viewer..." />}>
+              <CodeViewer
+                experimentId={experiment.id}
+                runtimeConfig={experiment.configRaw}
+                submittedConfig={experiment.originalConfig}
+              />
+            </React.Suspense>
+          </TabPane>
+        </>
+      ) : null}
       <TabPane key="notes" tab="Notes">
         <NotesCard
           notes={experiment.notes ?? ''}

--- a/webui/react/src/pages/ExperimentDetails/ExperimentMultiTrialTabs.tsx
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentMultiTrialTabs.tsx
@@ -89,7 +89,11 @@ const ExperimentMultiTrialTabs: React.FC<Props> = ({
     [experiment.id, fetchExperimentDetails],
   );
 
-  const showExperimentArtifacts = usePermissions().canViewExperimentArtifacts({
+  const { canModifyExperimentMetadata, canViewExperimentArtifacts } = usePermissions();
+  const showExperimentArtifacts = canViewExperimentArtifacts({
+    workspace: { id: experiment.workspaceId },
+  });
+  const editableNotes = canModifyExperimentMetadata({
     workspace: { id: experiment.workspaceId },
   });
 
@@ -125,6 +129,7 @@ const ExperimentMultiTrialTabs: React.FC<Props> = ({
       ) : null}
       <TabPane key="notes" tab="Notes">
         <NotesCard
+          disabled={!editableNotes}
           notes={experiment.notes ?? ''}
           style={{ border: 0 }}
           onSave={handleNotesUpdate}

--- a/webui/react/src/pages/ExperimentDetails/ExperimentSingleTrialTabs.tsx
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentSingleTrialTabs.tsx
@@ -188,13 +188,12 @@ const ExperimentSingleTrialTabs: React.FC<Props> = ({
     openHyperparameterSearchModal({});
   }, [openHyperparameterSearchModal]);
 
-  const { canModifyExperimentMetadata, canViewExperimentArtifacts } = usePermissions();
-  const showExperimentArtifacts = canViewExperimentArtifacts({
-    workspace: { id: experiment.workspaceId },
-  });
-  const editableNotes = canModifyExperimentMetadata({
-    workspace: { id: experiment.workspaceId },
-  });
+  const { canCreateExperiment, canModifyExperimentMetadata, canViewExperimentArtifacts } =
+    usePermissions();
+  const workspace = { id: experiment.workspaceId };
+  const editableNotes = canModifyExperimentMetadata({ workspace });
+  const showCreateExperiment = canCreateExperiment({ workspace });
+  const showExperimentArtifacts = canViewExperimentArtifacts({ workspace });
 
   return (
     <TrialLogPreview
@@ -204,7 +203,7 @@ const ExperimentSingleTrialTabs: React.FC<Props> = ({
       <Tabs
         activeKey={tabKey}
         tabBarExtraContent={
-          tabKey === 'hyperparameters' ? (
+          tabKey === 'hyperparameters' && showCreateExperiment ? (
             <div style={{ padding: 8 }}>
               <Button onClick={handleHPSearch}>Hyperparameter Search</Button>
             </div>

--- a/webui/react/src/pages/ExperimentDetails/ExperimentSingleTrialTabs.tsx
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentSingleTrialTabs.tsx
@@ -192,8 +192,8 @@ const ExperimentSingleTrialTabs: React.FC<Props> = ({
     usePermissions();
   const workspace = { id: experiment.workspaceId };
   const editableNotes = canModifyExperimentMetadata({ workspace });
-  const showCreateExperiment = canCreateExperiment({ workspace });
   const showExperimentArtifacts = canViewExperimentArtifacts({ workspace });
+  const showCreateExperiment = canCreateExperiment({ workspace }) && showExperimentArtifacts;
 
   return (
     <TrialLogPreview

--- a/webui/react/src/pages/ExperimentDetails/ExperimentSingleTrialTabs.tsx
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentSingleTrialTabs.tsx
@@ -5,7 +5,10 @@ import { useHistory, useParams } from 'react-router';
 import NotesCard from 'components/NotesCard';
 import TrialLogPreview from 'components/TrialLogPreview';
 import { terminalRunStates } from 'constants/states';
-import useModalHyperparameterSearch from 'hooks/useModal/HyperparameterSearch/useModalHyperparameterSearch';
+import useModalHyperparameterSearch
+  from 'hooks/useModal/HyperparameterSearch/useModalHyperparameterSearch';
+import usePermissions from 'hooks/usePermissions';
+import usePolling from 'hooks/usePolling';
 import { paths } from 'routes/utils';
 import { getExpTrials, getTrialDetails, patchExperiment } from 'services/api';
 import Spinner from 'shared/components/Spinner/Spinner';
@@ -186,6 +189,10 @@ const ExperimentSingleTrialTabs: React.FC<Props> = ({
     openHyperparameterSearchModal({});
   }, [openHyperparameterSearchModal]);
 
+  const showExperimentArtifacts = usePermissions().canViewExperimentArtifacts({
+    workspace: { id: experiment.workspaceId },
+  });
+
   return (
     <TrialLogPreview
       hidePreview={tabKey === TabType.Logs}
@@ -208,18 +215,22 @@ const ExperimentSingleTrialTabs: React.FC<Props> = ({
         <TabPane key="hyperparameters" tab="Hyperparameters">
           <TrialDetailsHyperparameters pageRef={pageRef} trial={trialDetails as TrialDetails} />
         </TabPane>
-        <TabPane key="checkpoints" tab="Checkpoints">
-          <ExperimentCheckpoints experiment={experiment} pageRef={pageRef} />
-        </TabPane>
-        <TabPane key="code" tab="Code">
-          <React.Suspense fallback={<Spinner tip="Loading code viewer..." />}>
-            <CodeViewer
-              experimentId={experiment.id}
-              runtimeConfig={experiment.configRaw}
-              submittedConfig={experiment.originalConfig}
-            />
-          </React.Suspense>
-        </TabPane>
+        {showExperimentArtifacts ? (
+          <>
+            <TabPane key="checkpoints" tab="Checkpoints">
+              <ExperimentCheckpoints experiment={experiment} pageRef={pageRef} />
+            </TabPane>
+            <TabPane key="code" tab="Code">
+              <React.Suspense fallback={<Spinner tip="Loading code viewer..." />}>
+                <CodeViewer
+                  experimentId={experiment.id}
+                  runtimeConfig={experiment.configRaw}
+                  submittedConfig={experiment.originalConfig}
+                />
+              </React.Suspense>
+            </TabPane>
+          </>
+        ) : null}
         <TabPane key="notes" tab="Notes">
           <NotesCard
             notes={experiment.notes ?? ''}

--- a/webui/react/src/pages/ExperimentDetails/ExperimentSingleTrialTabs.tsx
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentSingleTrialTabs.tsx
@@ -189,7 +189,11 @@ const ExperimentSingleTrialTabs: React.FC<Props> = ({
     openHyperparameterSearchModal({});
   }, [openHyperparameterSearchModal]);
 
-  const showExperimentArtifacts = usePermissions().canViewExperimentArtifacts({
+  const { canModifyExperimentMetadata, canViewExperimentArtifacts } = usePermissions();
+  const showExperimentArtifacts = canViewExperimentArtifacts({
+    workspace: { id: experiment.workspaceId },
+  });
+  const editableNotes = canModifyExperimentMetadata({
     workspace: { id: experiment.workspaceId },
   });
 
@@ -233,6 +237,7 @@ const ExperimentSingleTrialTabs: React.FC<Props> = ({
         ) : null}
         <TabPane key="notes" tab="Notes">
           <NotesCard
+            disabled={!editableNotes}
             notes={experiment.notes ?? ''}
             style={{ border: 0, height: '100%' }}
             onSave={handleNotesUpdate}
@@ -241,9 +246,11 @@ const ExperimentSingleTrialTabs: React.FC<Props> = ({
         <TabPane key="profiler" tab="Profiler">
           <TrialDetailsProfiles experiment={experiment} trial={trialDetails as TrialDetails} />
         </TabPane>
-        <TabPane key="logs" tab="Logs">
-          <TrialDetailsLogs experiment={experiment} trial={trialDetails as TrialDetails} />
-        </TabPane>
+        {showExperimentArtifacts ? (
+          <TabPane key="logs" tab="Logs">
+            <TrialDetailsLogs experiment={experiment} trial={trialDetails as TrialDetails} />
+          </TabPane>
+        ) : null}
       </Tabs>
       {modalHyperparameterSearchContextHolder}
     </TrialLogPreview>

--- a/webui/react/src/pages/ExperimentDetails/ExperimentSingleTrialTabs.tsx
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentSingleTrialTabs.tsx
@@ -7,7 +7,6 @@ import TrialLogPreview from 'components/TrialLogPreview';
 import { terminalRunStates } from 'constants/states';
 import useModalHyperparameterSearch from 'hooks/useModal/HyperparameterSearch/useModalHyperparameterSearch';
 import usePermissions from 'hooks/usePermissions';
-import usePolling from 'hooks/usePolling';
 import { paths } from 'routes/utils';
 import { getExpTrials, getTrialDetails, patchExperiment } from 'services/api';
 import Spinner from 'shared/components/Spinner/Spinner';

--- a/webui/react/src/pages/ExperimentDetails/ExperimentSingleTrialTabs.tsx
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentSingleTrialTabs.tsx
@@ -5,8 +5,7 @@ import { useHistory, useParams } from 'react-router';
 import NotesCard from 'components/NotesCard';
 import TrialLogPreview from 'components/TrialLogPreview';
 import { terminalRunStates } from 'constants/states';
-import useModalHyperparameterSearch
-  from 'hooks/useModal/HyperparameterSearch/useModalHyperparameterSearch';
+import useModalHyperparameterSearch from 'hooks/useModal/HyperparameterSearch/useModalHyperparameterSearch';
 import usePermissions from 'hooks/usePermissions';
 import usePolling from 'hooks/usePolling';
 import { paths } from 'routes/utils';

--- a/webui/react/src/pages/ExperimentDetails/ExperimentTrials.tsx
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentTrials.tsx
@@ -16,7 +16,6 @@ import TableFilterDropdown from 'components/TableFilterDropdown';
 import { terminalRunStates } from 'constants/states';
 import useModalHyperparameterSearch from 'hooks/useModal/HyperparameterSearch/useModalHyperparameterSearch';
 import usePermissions from 'hooks/usePermissions';
-import usePolling from 'hooks/usePolling';
 import useSettings, { UpdateSettings } from 'hooks/useSettings';
 import { paths } from 'routes/utils';
 import { getExpTrials, openOrCreateTensorBoard } from 'services/api';

--- a/webui/react/src/pages/ExperimentDetails/ExperimentTrials.tsx
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentTrials.tsx
@@ -67,11 +67,9 @@ const ExperimentTrials: React.FC<Props> = ({ experiment, pageRef }: Props) => {
 
   const { settings, updateSettings } = useSettings<Settings>(settingsConfig);
 
-  const canCreateExperiment = usePermissions().canCreateExperiment({
-    workspace: {
-      id: experiment.workspaceId,
-    },
-  });
+  const workspace = { id: experiment.workspaceId };
+  const { canCreateExperiment, canViewExperimentArtifacts } = usePermissions();
+  const canHparam = canCreateExperiment({ workspace }) && canViewExperimentArtifacts({ workspace });
 
   const {
     contextHolder: modalHyperparameterSearchContextHolder,
@@ -134,12 +132,12 @@ const ExperimentTrials: React.FC<Props> = ({ experiment, pageRef }: Props) => {
         [TrialAction.ViewLogs]: () => handleViewLogs(trial),
         [TrialAction.HyperparameterSearch]: () => handleHyperparameterSearch(trial),
       };
-      if (!canCreateExperiment) {
+      if (!canHparam) {
         delete opts[TrialAction.HyperparameterSearch];
       }
       return opts;
     },
-    [canCreateExperiment, handleHyperparameterSearch, handleOpenTensorBoard, handleViewLogs],
+    [canHparam, handleHyperparameterSearch, handleOpenTensorBoard, handleViewLogs],
   );
 
   const columns = useMemo(() => {

--- a/webui/react/src/pages/ProjectDetails.tsx
+++ b/webui/react/src/pages/ProjectDetails.tsx
@@ -165,11 +165,7 @@ const ProjectDetails: React.FC = () => {
 
   const availableBatchActions = useMemo(() => {
     const experiments = settings.row?.map((id) => experimentMap[id]) ?? [];
-    return getActionsForExperimentsUnion(
-      experiments,
-      batchActions,
-      expPermissions,
-    );
+    return getActionsForExperimentsUnion(experiments, batchActions, expPermissions);
   }, [experimentMap, expPermissions, settings.row]);
 
   const fetchProject = useCallback(async () => {
@@ -679,14 +675,7 @@ const ProjectDetails: React.FC = () => {
         }),
       );
     },
-    [
-      expPermissions,
-      settings.row,
-      openMoveModal,
-      project?.workspaceId,
-      project?.id,
-      experimentMap,
-    ],
+    [expPermissions, settings.row, openMoveModal, project?.workspaceId, project?.id, experimentMap],
   );
 
   const submitBatchAction = useCallback(
@@ -1088,8 +1077,7 @@ const ProjectDetails: React.FC = () => {
     );
   }
 
-  if (!canViewWorkspaces) return <NoPermissions />;
-  if (project && !canViewWorkspace({ workspace: { id: project.workspaceId } })) {
+  if (project && !expPermissions.canViewWorkspace({ workspace: { id: project.workspaceId } })) {
     return <PageNotFound />;
   }
 

--- a/webui/react/src/pages/ProjectDetails.tsx
+++ b/webui/react/src/pages/ProjectDetails.tsx
@@ -391,10 +391,16 @@ const ProjectDetails: React.FC = () => {
     }
   }, []);
 
+  const canEditExperiment =
+    !!project &&
+    expPermissions.canModifyExperimentMetadata({
+      workspace: { id: project.workspaceId },
+    });
+
   const columns = useMemo(() => {
     const tagsRenderer = (value: string, record: ExperimentItem) => (
       <TagList
-        disabled={record.archived || project?.archived}
+        disabled={record.archived || project?.archived || !canEditExperiment}
         tags={record.labels}
         onChange={experimentTags.handleTagListChange(record.id)}
       />
@@ -413,7 +419,7 @@ const ProjectDetails: React.FC = () => {
 
     const descriptionRenderer = (value: string, record: ExperimentItem) => (
       <TextEditorModal
-        disabled={record.archived}
+        disabled={record.archived || !canEditExperiment}
         placeholder={record.archived ? 'Archived' : 'Add description...'}
         title="Edit description"
         value={value}
@@ -590,6 +596,7 @@ const ProjectDetails: React.FC = () => {
     users,
     project,
     experimentTags,
+    canEditExperiment,
     settings,
     updateSettings,
     handleActionComplete,

--- a/webui/react/src/pages/ProjectDetails.tsx
+++ b/webui/react/src/pages/ProjectDetails.tsx
@@ -96,7 +96,6 @@ import {
 import { getDisplayName } from 'utils/user';
 import { openCommand } from 'utils/wait';
 
-import NoPermissions from './NoPermissions';
 import css from './ProjectDetails.module.scss';
 import settingsConfig, {
   DEFAULT_COLUMN_WIDTHS,

--- a/webui/react/src/pages/ProjectDetails.tsx
+++ b/webui/react/src/pages/ProjectDetails.tsx
@@ -420,7 +420,7 @@ const ProjectDetails: React.FC = () => {
     const descriptionRenderer = (value: string, record: ExperimentItem) => (
       <TextEditorModal
         disabled={record.archived || !canEditExperiment}
-        placeholder={record.archived ? 'Archived' : 'Add description...'}
+        placeholder={record.archived ? 'Archived' : canEditExperiment ? 'Add description...' : ''}
         title="Edit description"
         value={value}
         onSave={(newDescription: string) => saveExperimentDescription(newDescription, record.id)}

--- a/webui/react/src/pages/ProjectDetails.tsx
+++ b/webui/react/src/pages/ProjectDetails.tsx
@@ -139,8 +139,7 @@ const ProjectDetails: React.FC = () => {
   const [total, setTotal] = useState(0);
   const [canceler] = useState(new AbortController());
   const pageRef = useRef<HTMLElement>(null);
-  const { canDeleteExperiment, canMoveExperiment, canViewWorkspace, canViewWorkspaces } =
-    usePermissions();
+  const expPermissions = usePermissions();
 
   const { updateSettings: updateDestinationSettings } = useSettings<MoveExperimentSettings>(
     moveExperimentSettingsConfig,
@@ -169,10 +168,9 @@ const ProjectDetails: React.FC = () => {
     return getActionsForExperimentsUnion(
       experiments,
       batchActions,
-      canDeleteExperiment,
-      canMoveExperiment,
+      expPermissions,
     );
-  }, [canDeleteExperiment, canMoveExperiment, experimentMap, settings.row]);
+  }, [experimentMap, expPermissions, settings.row]);
 
   const fetchProject = useCallback(async () => {
     try {
@@ -645,7 +643,7 @@ const ProjectDetails: React.FC = () => {
           experimentIds: settings.row.filter(
             (id) =>
               canActionExperiment(Action.Move, experimentMap[id]) &&
-              canMoveExperiment({ experiment: experimentMap[id] }),
+              expPermissions.canMoveExperiment({ experiment: experimentMap[id] }),
           ),
           sourceProjectId: project?.id,
           sourceWorkspaceId: project?.workspaceId,
@@ -682,7 +680,7 @@ const ProjectDetails: React.FC = () => {
       );
     },
     [
-      canMoveExperiment,
+      expPermissions,
       settings.row,
       openMoveModal,
       project?.workspaceId,

--- a/webui/react/src/pages/TrialDetails/TrialDetailsOverview.tsx
+++ b/webui/react/src/pages/TrialDetails/TrialDetailsOverview.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useMemo, useState } from 'react';
 
 import useMetricNames from 'hooks/useMetricNames';
+import usePermissions from 'hooks/usePermissions';
 import useSettings from 'hooks/useSettings';
 import TrialInfoBox from 'pages/TrialDetails/TrialInfoBox';
 import { ErrorType } from 'shared/utils/error';
@@ -20,6 +21,10 @@ export interface Props {
 const TrialDetailsOverview: React.FC<Props> = ({ experiment, trial }: Props) => {
   const storagePath = `trial-detail/experiment/${experiment.id}`;
   const { settings, updateSettings } = useSettings<Settings>(settingsConfig, { storagePath });
+
+  const showExperimentArtifacts = usePermissions().canViewExperimentArtifacts({
+    workspace: { id: experiment.workspaceId },
+  });
 
   const [metricNames, setMetricNames] = useState<MetricName[]>([]);
   useMetricNames({
@@ -67,25 +72,29 @@ const TrialDetailsOverview: React.FC<Props> = ({ experiment, trial }: Props) => 
   return (
     <div className={css.base}>
       <TrialInfoBox experiment={experiment} trial={trial} />
-      <TrialChart
-        defaultMetricNames={defaultMetrics}
-        metricNames={metricNames}
-        metrics={metrics}
-        trialId={trial?.id}
-        trialTerminated={
-          trial ? trial.state === RunState.Completed || trial.state === RunState.Error : false
-        }
-        onMetricChange={handleMetricChange}
-      />
-      <TrialDetailsWorkloads
-        defaultMetrics={defaultMetrics}
-        experiment={experiment}
-        metricNames={metricNames}
-        metrics={metrics}
-        settings={settings}
-        trial={trial}
-        updateSettings={updateSettings}
-      />
+      {showExperimentArtifacts ? (
+        <>
+          <TrialChart
+            defaultMetricNames={defaultMetrics}
+            metricNames={metricNames}
+            metrics={metrics}
+            trialId={trial?.id}
+            trialTerminated={
+              trial ? trial.state === RunState.Completed || trial.state === RunState.Error : false
+            }
+            onMetricChange={handleMetricChange}
+          />
+          <TrialDetailsWorkloads
+            defaultMetrics={defaultMetrics}
+            experiment={experiment}
+            metricNames={metricNames}
+            metrics={metrics}
+            settings={settings}
+            trial={trial}
+            updateSettings={updateSettings}
+          />
+        </>
+      ) : null}
     </div>
   );
 };

--- a/webui/react/src/types.ts
+++ b/webui/react/src/types.ts
@@ -829,4 +829,13 @@ export interface ExperimentPermissionsArgs {
   experiment: ProjectExperiment;
 }
 
+export interface PermissionWorkspace {
+  id: number;
+  userId?: number;
+}
+
+export interface WorkspacePermissionsArgs {
+  workspace?: PermissionWorkspace;
+}
+
 export type UserOrGroup = User | V1Group;

--- a/webui/react/src/utils/experiment.ts
+++ b/webui/react/src/utils/experiment.ts
@@ -40,7 +40,7 @@ type ExperimentPermissionSet = {
   canModifyExperiment: (arg0: WorkspacePermissionsArgs) => boolean;
   canMoveExperiment: (arg0: ExperimentPermissionsArgs) => boolean;
   canViewExperimentArtifacts: (arg0: WorkspacePermissionsArgs) => boolean;
-}
+};
 
 // Differentiate Experiment from Task.
 export const isExperiment = (obj: AnyTask | ExperimentItem): obj is ExperimentItem => {
@@ -185,14 +185,17 @@ export const getActionsForExperiment = (
 ): ExperimentAction[] => {
   if (!experiment) return []; // redundant, for clarity
   const workspace = { id: experiment.workspaceId };
-  return targets.filter((action) => canActionExperiment(action, experiment))
+  return targets
+    .filter((action) => canActionExperiment(action, experiment))
     .filter((action) => {
       switch (action) {
         case ExperimentAction.ContinueTrial:
         case ExperimentAction.Fork:
         case ExperimentAction.HyperparameterSearch:
-          return permissions.canViewExperimentArtifacts({ workspace }) &&
-            permissions.canCreateExperiment({ workspace });
+          return (
+            permissions.canViewExperimentArtifacts({ workspace }) &&
+            permissions.canCreateExperiment({ workspace })
+          );
 
         case ExperimentAction.Delete:
           return permissions.canDeleteExperiment({ experiment });
@@ -215,7 +218,7 @@ export const getActionsForExperiment = (
         default:
           return true;
       }
-  });
+    });
 };
 
 export const getActionsForExperimentsUnion = (

--- a/webui/react/src/utils/experiment.ts
+++ b/webui/react/src/utils/experiment.ts
@@ -37,6 +37,7 @@ type ExperimentChecker = (experiment: ProjectExperiment, trial?: TrialDetails) =
 type ExperimentPermissionSet = {
   canCreateExperiment: (arg0: WorkspacePermissionsArgs) => boolean;
   canDeleteExperiment: (arg0: ExperimentPermissionsArgs) => boolean;
+  canModifyExperiment: (arg0: WorkspacePermissionsArgs) => boolean;
   canMoveExperiment: (arg0: ExperimentPermissionsArgs) => boolean;
   canViewExperimentArtifacts: (arg0: WorkspacePermissionsArgs) => boolean;
 }
@@ -188,15 +189,29 @@ export const getActionsForExperiment = (
     .filter((action) => {
       switch (action) {
         case ExperimentAction.ContinueTrial:
+        case ExperimentAction.Fork:
+        case ExperimentAction.HyperparameterSearch:
           return permissions.canViewExperimentArtifacts({ workspace }) &&
             permissions.canCreateExperiment({ workspace });
+
         case ExperimentAction.Delete:
           return permissions.canDeleteExperiment({ experiment });
-        case ExperimentAction.Fork:
-          return permissions.canViewExperimentArtifacts({ workspace }) &&
-            permissions.canCreateExperiment({ workspace });
+
+        case ExperimentAction.DownloadCode:
+        case ExperimentAction.OpenTensorBoard:
+          return permissions.canViewExperimentArtifacts({ workspace });
+
         case ExperimentAction.Move:
           return permissions.canMoveExperiment({ experiment });
+
+        case ExperimentAction.Activate:
+        case ExperimentAction.Archive:
+        case ExperimentAction.Cancel:
+        case ExperimentAction.Kill:
+        case ExperimentAction.Pause:
+        case ExperimentAction.Unarchive:
+          return permissions.canModifyExperiment({ workspace });
+
         default:
           return true;
       }


### PR DESCRIPTION
## Description

Permissions:
- creating an experiment (forking, continuing a trial, or starting a new hyperparameter search [ includes button in hparam tab, dropdown in multi-trial experiment trials tab ])
- editing metadata (unable to change name, description, tags, notes - exp. details and project details pages)
- modifying an experiment (archive/unarchive, pause/cancel/stop)
- viewing experiment metadata (will be handled server-side by not returning experiments to ProjectDetails)
- viewing experiment artifacts (hides Checkpoints, Code, and Logs tabs on experiment details; prevents forking or continuing a trial, downloading code or opening tensorboard, hides metrics / workloads on trial details page; arguably this may as well hide an experiment as in metadata permission)

## Test Plan

Create your own workspace and experiment, so by default you can do any action. All actions should be allowed for an OSS user. You can negate a permission ( `!permitted.has('oss_user')` ) in hooks/usePermissions to test not having that permission.

## Checklist
- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.
- [x] If modifying `/webui/react/src/shared/` verify `make -C webui/react test-shared` passes.