### PR TITLE
chore: oss refactor for auto assign WorkspaceCreator role plugin

### DIFF
--- a/master/internal/api_user_intg_test.go
+++ b/master/internal/api_user_intg_test.go
@@ -66,6 +66,7 @@ func SetupAPITest(t *testing.T) (*apiServer, model.User, context.Context) {
 			taskSpec: &tasks.TaskSpec{},
 		},
 	}
+	config.GetMasterConfig().Security.AuthZ = config.AuthZConfig{Type: "basic"}
 
 	userModel, err := user.UserByUsername("admin")
 	require.NoError(t, err, "Couldn't get admin user")

--- a/master/internal/api_workspace.go
+++ b/master/internal/api_workspace.go
@@ -258,7 +258,7 @@ func (a *apiServer) PostWorkspace(
 		return nil, errors.Wrapf(err, "error creating workspace %s in database", req.Name)
 	}
 
-	if err = a.AssignWorkspaceAdminToUser(ctx, tx, w.ID, w.UserID); err != nil {
+	if err = a.AssignWorkspaceAdminToUserTx(ctx, tx, w.ID, w.UserID); err != nil {
 		return nil, errors.Wrap(err, "error assigning workspace admin")
 	}
 

--- a/master/internal/api_workspace.go
+++ b/master/internal/api_workspace.go
@@ -253,21 +253,6 @@ func (a *apiServer) PostWorkspace(
 	protoWorkspace.Username = curUser.Username
 	protoWorkspace.Pinned = true
 	return &apiv1.PostWorkspaceResponse{Workspace: protoWorkspace}, nil
-
-	/*
-		w := &workspacev1.Workspace{}
-		err = a.m.db.QueryProto("insert_workspace", w, req.Name, curUser.ID)
-		if err == nil && w.Id > 0 {
-			holder := &workspacev1.Workspace{}
-			err = a.m.db.QueryProto("pin_workspace", holder, w.Id, curUser.ID)
-			if err == nil {
-				w.Pinned = true
-			}
-		}
-
-		return &apiv1.PostWorkspaceResponse{Workspace: w},
-			errors.Wrapf(err, "error creating workspace %s in database", req.Name)
-	*/
 }
 
 func (a *apiServer) PatchWorkspace(

--- a/master/internal/api_workspace_intg_test.go
+++ b/master/internal/api_workspace_intg_test.go
@@ -10,6 +10,7 @@ import (
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/mock"
@@ -23,6 +24,45 @@ import (
 	"github.com/determined-ai/determined/proto/pkg/projectv1"
 	"github.com/determined-ai/determined/proto/pkg/workspacev1"
 )
+
+func TestPostWorkspace(t *testing.T) {
+	api, curUser, ctx := SetupAPITest(t)
+
+	// Name min error.
+	_, err := api.PostWorkspace(ctx, &apiv1.PostWorkspaceRequest{Name: ""})
+	require.Error(t, err)
+
+	// Name max error.
+	_, err = api.PostWorkspace(ctx, &apiv1.PostWorkspaceRequest{Name: string(make([]byte, 81))})
+	require.Error(t, err)
+
+	workspaceName := uuid.New().String()
+	resp, err := api.PostWorkspace(ctx, &apiv1.PostWorkspaceRequest{Name: workspaceName})
+	require.NoError(t, err)
+
+	// Workspace returned correctly?
+	expected := &workspacev1.Workspace{
+		Id:             resp.Workspace.Id,
+		Name:           workspaceName,
+		Archived:       false,
+		Username:       curUser.Username,
+		Immutable:      false,
+		NumProjects:    0,
+		Pinned:         true,
+		UserId:         int32(curUser.ID),
+		NumExperiments: 0,
+		State:          workspacev1.WorkspaceState_WORKSPACE_STATE_UNSPECIFIED,
+		ErrorMessage:   "",
+	}
+	proto.Equal(expected, resp.Workspace)
+	require.Equal(t, expected, resp.Workspace)
+
+	// Workspace persisted correctly?
+	getWorkResp, err := api.GetWorkspace(ctx, &apiv1.GetWorkspaceRequest{Id: resp.Workspace.Id})
+	require.NoError(t, err)
+	proto.Equal(expected, getWorkResp.Workspace)
+	require.Equal(t, expected, getWorkResp.Workspace)
+}
 
 var workspaceAuthZ *mocks.WorkspaceAuthZ
 

--- a/master/internal/api_workspace_intg_test.go
+++ b/master/internal/api_workspace_intg_test.go
@@ -159,6 +159,7 @@ func TestAuthzPostWorkspace(t *testing.T) {
 	workspaceAuthZ.On("CanGetWorkspace", mock.Anything, mock.Anything).Return(true, nil).Once()
 	getResp, err := api.GetWorkspace(ctx, &apiv1.GetWorkspaceRequest{Id: resp.Workspace.Id})
 	require.NoError(t, err)
+	proto.Equal(resp.Workspace, getResp.Workspace)
 	require.Equal(t, resp.Workspace, getResp.Workspace)
 }
 

--- a/master/internal/rbac/api_rbac.go
+++ b/master/internal/rbac/api_rbac.go
@@ -29,7 +29,7 @@ type RBACAPIServer interface {
 		*apiv1.AssignRolesResponse, error)
 	RemoveAssignments(context.Context, *apiv1.RemoveAssignmentsRequest) (
 		*apiv1.RemoveAssignmentsResponse, error)
-	AssignWorkspaceAdminToUser(
+	AssignWorkspaceAdminToUserTx(
 		ctx context.Context, idb bun.IDB, workspaceID int, userID model.UserID,
 	) error
 }

--- a/master/internal/rbac/api_rbac.go
+++ b/master/internal/rbac/api_rbac.go
@@ -3,6 +3,9 @@ package rbac
 import (
 	"context"
 
+	"github.com/uptrace/bun"
+
+	"github.com/determined-ai/determined/master/pkg/model"
 	"github.com/determined-ai/determined/proto/pkg/apiv1"
 )
 
@@ -26,4 +29,7 @@ type RBACAPIServer interface {
 		*apiv1.AssignRolesResponse, error)
 	RemoveAssignments(context.Context, *apiv1.RemoveAssignmentsRequest) (
 		*apiv1.RemoveAssignmentsResponse, error)
+	AssignWorkspaceAdminToUser(
+		ctx context.Context, idb bun.IDB, workspaceID int, userID model.UserID,
+	) error
 }

--- a/master/internal/rbac/api_rbac_stub.go
+++ b/master/internal/rbac/api_rbac_stub.go
@@ -3,9 +3,12 @@ package rbac
 import (
 	"context"
 
+	"github.com/uptrace/bun"
+
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	"github.com/determined-ai/determined/master/pkg/model"
 	"github.com/determined-ai/determined/proto/pkg/apiv1"
 )
 
@@ -63,4 +66,11 @@ func (s *rbacAPIServerStub) RemoveAssignments(ctx context.Context,
 	req *apiv1.RemoveAssignmentsRequest,
 ) (*apiv1.RemoveAssignmentsResponse, error) {
 	return nil, UnimplementedError
+}
+
+func (s *rbacAPIServerStub) AssignWorkspaceAdminToUser(
+	ctx context.Context, idb bun.IDB, workspaceID int, userID model.UserID,
+) error {
+	return nil
+	// return UnimplementedError
 }

--- a/master/internal/rbac/api_rbac_stub.go
+++ b/master/internal/rbac/api_rbac_stub.go
@@ -68,9 +68,8 @@ func (s *rbacAPIServerStub) RemoveAssignments(ctx context.Context,
 	return nil, UnimplementedError
 }
 
-func (s *rbacAPIServerStub) AssignWorkspaceAdminToUser(
+func (s *rbacAPIServerStub) AssignWorkspaceAdminToUserTx(
 	ctx context.Context, idb bun.IDB, workspaceID int, userID model.UserID,
 ) error {
 	return nil
-	// return UnimplementedError
 }

--- a/master/internal/rbac/api_rbac_wrapper.go
+++ b/master/internal/rbac/api_rbac_wrapper.go
@@ -69,9 +69,9 @@ func (s *RBACAPIServerWrapper) RemoveAssignments(ctx context.Context,
 	return rbacAPIServer.RemoveAssignments(ctx, req)
 }
 
-// AssignWorkspaceAdminToUser is a wrapper the same function the RBACAPIServer interface.
-func (s *RBACAPIServerWrapper) AssignWorkspaceAdminToUser(
+// AssignWorkspaceAdminToUserTx is a wrapper the same function the RBACAPIServer interface.
+func (s *RBACAPIServerWrapper) AssignWorkspaceAdminToUserTx(
 	ctx context.Context, idb bun.IDB, workspaceID int, userID model.UserID,
 ) error {
-	return rbacAPIServer.AssignWorkspaceAdminToUser(ctx, idb, workspaceID, userID)
+	return rbacAPIServer.AssignWorkspaceAdminToUserTx(ctx, idb, workspaceID, userID)
 }

--- a/master/internal/rbac/api_rbac_wrapper.go
+++ b/master/internal/rbac/api_rbac_wrapper.go
@@ -3,6 +3,9 @@ package rbac
 import (
 	"context"
 
+	"github.com/uptrace/bun"
+
+	"github.com/determined-ai/determined/master/pkg/model"
 	"github.com/determined-ai/determined/proto/pkg/apiv1"
 )
 
@@ -64,4 +67,11 @@ func (s *RBACAPIServerWrapper) RemoveAssignments(ctx context.Context,
 	req *apiv1.RemoveAssignmentsRequest,
 ) (*apiv1.RemoveAssignmentsResponse, error) {
 	return rbacAPIServer.RemoveAssignments(ctx, req)
+}
+
+// AssignWorkspaceAdminToUser is a wrapper the same function the RBACAPIServer interface.
+func (s *RBACAPIServerWrapper) AssignWorkspaceAdminToUser(
+	ctx context.Context, idb bun.IDB, workspaceID int, userID model.UserID,
+) error {
+	return rbacAPIServer.AssignWorkspaceAdminToUser(ctx, idb, workspaceID, userID)
 }

--- a/master/pkg/model/workspace.go
+++ b/master/pkg/model/workspace.go
@@ -1,0 +1,61 @@
+package model
+
+import (
+	"time"
+
+	"github.com/uptrace/bun"
+
+	"github.com/determined-ai/determined/proto/pkg/workspacev1"
+)
+
+// Workspace is the bun model of a workspace.
+type Workspace struct {
+	bun.BaseModel `bun:"table:workspaces"`
+	ID            int             `bun:"id,pk,autoincrement"`
+	Name          string          `bun:"name"`
+	Archived      bool            `bun:"archived"`
+	CreatedAt     time.Time       `bun:"created_at"`
+	UserID        UserID          `bun:"user_id"`
+	Immutable     bool            `bun:"immutable"`
+	State         *WorkspaceState `bun:"state"`
+}
+
+// ToProto converts a bun model of a workspace to a proto object.
+// Some fields like username and pinned are not included since they are
+// not on the bun model.
+func (w *Workspace) ToProto() *workspacev1.Workspace {
+	return &workspacev1.Workspace{
+		Id:        int32(w.ID),
+		Name:      w.Name,
+		Archived:  w.Archived,
+		UserId:    int32(w.UserID),
+		Immutable: w.Immutable,
+		State:     w.State.ToProto(),
+	}
+}
+
+// WorkspaceState is the state of the workspace state with regards to being deleted.
+type WorkspaceState string
+
+const (
+	// WorkspaceStateDeleting constant.
+	WorkspaceStateDeleting WorkspaceState = "DELETING"
+	// WorkspaceStateDeleteFailed constant.
+	WorkspaceStateDeleteFailed WorkspaceState = "DELETE_FAILED"
+	// WorkspaceStateDeleted constant.
+	WorkspaceStateDeleted WorkspaceState = "DELETED"
+)
+
+func (s *WorkspaceState) ToProto() workspacev1.WorkspaceState {
+	if s == nil {
+		return workspacev1.WorkspaceState_WORKSPACE_STATE_UNSPECIFIED
+	}
+	return workspacev1.WorkspaceState(workspacev1.WorkspaceState_value["WORKSPACE_STATE_"+string(*s)])
+}
+
+// WorkspacePin is the bun model of a workspace.
+type WorkspacePin struct {
+	bun.BaseModel `bun:"table:workspace_pins"`
+	WorkspaceID   int    `bun:"workspace_id"`
+	UserID        UserID `bun:"user_id"`
+}

--- a/master/pkg/model/workspace.go
+++ b/master/pkg/model/workspace.go
@@ -46,6 +46,7 @@ const (
 	WorkspaceStateDeleted WorkspaceState = "DELETED"
 )
 
+// ToProto converts a WorkspaceState to a proto workspacev1.Workspace state.
 func (s *WorkspaceState) ToProto() workspacev1.WorkspaceState {
 	if s == nil {
 		return workspacev1.WorkspaceState_WORKSPACE_STATE_UNSPECIFIED

--- a/master/static/srv/insert_workspace.sql
+++ b/master/static/srv/insert_workspace.sql
@@ -1,8 +1,0 @@
-WITH w AS (
-  INSERT INTO workspaces (name, user_id)
-  VALUES ($1, $2)
-  RETURNING id, name, archived, immutable, user_id
-)
-SELECT w.id, w.name, w.archived, w.immutable, u.username, w.user_id
-FROM w
-JOIN users u on u.id = w.user_id;


### PR DESCRIPTION
## Description

Converts ```PostWorkspace``` to bun so we can share a transaction with EE adding the user role and adds ```AssignWorkspaceAdminToUserTx``` as a plugin metod to APIServer which is a no-op in oss.

## Test Plan

Integration test to make sure we didn't break existing behavior.

## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist
- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.
- [ ] If modifying `/webui/react/src/shared/` verify `make -C webui/react test-shared` passes.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
