### PR TITLE
chore: Avoid error from RBAC listRole endpoint [DET-8395]

### DIFF
--- a/webui/react/src/services/apiConfig.ts
+++ b/webui/react/src/services/apiConfig.ts
@@ -288,10 +288,12 @@ export const listRoles: DetApi<Service.ListRolesParams, Api.V1ListRolesResponse,
   {
     name: 'listRoles',
     postProcess: (response) => response.roles.map(decoder.mapV1Role),
-    request: (params) =>
-      detApi.RBAC.listRoles({
-        limit: params.limit || 0,
-        offset: params.offset || 0,
+    request: () =>
+      new Promise((resolve) => {
+        resolve({
+          pagination: {},
+          roles: new Array<Api.V1Role>(),
+        });
       }),
   };
 

--- a/webui/react/src/utils/error.ts
+++ b/webui/react/src/utils/error.ts
@@ -71,11 +71,6 @@ const handleError = (error: DetError | unknown, options?: DetErrorOptions): DetE
     }
   }
 
-  // RBAC 501 errors skip notification, log, telemetry.
-  if (e.srcError.status === 501) {
-    return e;
-  }
-
   // TODO add support for checking, saving, and dismissing class of errors as a user preference
   // using id.
   const skipNotification = e.silent || (e.level === ErrorLevel.Warn && !e.publicMessage);

--- a/webui/react/src/utils/error.ts
+++ b/webui/react/src/utils/error.ts
@@ -71,6 +71,11 @@ const handleError = (error: DetError | unknown, options?: DetErrorOptions): DetE
     }
   }
 
+  // RBAC 501 errors skip notification, log, telemetry.
+  if (e.srcError.status === 501) {
+    return e;
+  }
+
   // TODO add support for checking, saving, and dismissing class of errors as a user preference
   // using id.
   const skipNotification = e.silent || (e.level === ErrorLevel.Warn && !e.publicMessage);


### PR DESCRIPTION
## Description

Returns an empty list of possible roles to `listRoles`. This is separate from the what-role-am-I request.

First commit was an attempt to silence the 501 error, but TypeScript does not like it.

## Testing

No error appears in browser console, no request outbound to `roles/search`

## Checklist
- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.
- [x] If modifying `/webui/react/src/shared/` verify `make -C webui/react test-shared` passes.