### PR TITLE
ci: store docs output as a single file

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1022,8 +1022,9 @@ jobs:
             - harness/dist
             - model_hub/dist
             - docs/site/html
+      - run: tar czf docs.tgz docs/site/html
       - store_artifacts:
-          path: docs/site/html
+          path: docs.tgz
 
   publish-docs:
     docker:


### PR DESCRIPTION
## Description

Uploading the directory containing the docs output takes a considerable amount of time, due to the large number of files involved.

## Test Plan

- [x] check that CircleCI does the right thing on this PR