### PR TITLE
feat: support single-file contexts in cli

### DIFF
--- a/docs/release-notes/5087-single-file-context.txt
+++ b/docs/release-notes/5087-single-file-context.txt
@@ -1,0 +1,8 @@
+:orphan:
+
+**Improvements**
+
+-  Support single-file contexts in the CLI.  Users who want to upload a single file into a notebook
+   or shell may  now specify a single file as the ``--context`` argument, like ``det notebook start
+   --context MY_FILE``.  Previously accomplishing the same required creating an empty directory,
+   copying the file into that directory, and specifying the directory as the ``--context``.

--- a/harness/tests/cli/test_cli.py
+++ b/harness/tests/cli/test_cli.py
@@ -1,3 +1,4 @@
+import base64
 import os
 import tempfile
 import uuid
@@ -288,6 +289,16 @@ def test_read_context_ignore_pycaches(tmp_path: Path) -> None:
     ) as tree:
         model_def = context.read_legacy_context(tree)
         assert {f["path"] for f in model_def} == {"A.py", "subdir", "subdir/A.py"}
+
+
+def test_single_file_context(tmp_path: Path) -> None:
+    name = "the-itsy-bitsy-spider"
+    content = "went up the water spout"
+    with FileTree(tmp_path, {name: content}) as tree:
+        model_def = context.read_v1_context(tree)
+        assert {f.path for f in model_def} == {name}, {f.path for f in model_def}
+        got_content = base64.b64decode(model_def[0].content).decode("utf8")
+        assert got_content == content, got_content
 
 
 def test_cli_args_exist() -> None:


### PR DESCRIPTION
This is especially useful for interactive things like notebooks or shells, where a user may want to upload a single file, but not want to move that file into an empty directory.

It also works for experiments, though presumably it's less useful in those cases.

## Test Plan

- [x] added unit tests to provide automated coverage