### PR TITLE
fix: No Permissions page vs. 404 page

### DIFF
--- a/webui/react/src/pages/ProjectDetails.tsx
+++ b/webui/react/src/pages/ProjectDetails.tsx
@@ -970,7 +970,6 @@ const ProjectDetails: React.FC = () => {
       return { items: menuItems, onClick: onItemClick };
     };
 
-    if (!canViewWorkspaces) return <NoPermissions />;
     return (
       <div className={css.tabOptions}>
         <Space className={css.actionList}>
@@ -1106,6 +1105,7 @@ const ProjectDetails: React.FC = () => {
     );
   }
 
+  if (!canViewWorkspaces) return <NoPermissions />;
   if (project && !canViewWorkspace({ workspace: { id: project.workspaceId } })) {
     return <PageNotFound />;
   }


### PR DESCRIPTION
## Description

When I added a 404 page in #5045 , I accidentally blocked the NoPermissions page from showing up in that case. This moves the NoPermissions check to happen first.  Should not block release.

## Test Plan

Remove initial permissions ( oss_user ) from contexts/Store.tsx

## Checklist
- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.
- [x] If modifying `/webui/react/src/shared/` verify `make -C webui/react test-shared` passes.