### PR TITLE
fix: new states can be paused, canceled, killed [DET-8449]

### DIFF
--- a/webui/react/src/constants/states.ts
+++ b/webui/react/src/constants/states.ts
@@ -23,17 +23,19 @@ export const activeRunStates: Array<
   'STATE_ACTIVE' | 'STATE_STOPPING_COMPLETED' | 'STATE_STOPPING_CANCELED' | 'STATE_STOPPING_ERROR'
 > = ['STATE_ACTIVE', 'STATE_STOPPING_CANCELED', 'STATE_STOPPING_COMPLETED', 'STATE_STOPPING_ERROR'];
 
-const jobStates: Array<JobState> = [
-  JobState.QUEUED,
-  JobState.SCHEDULED,
-  JobState.SCHEDULEDBACKFILLED,
-];
+/* activeStates are sub-states which replace the previous Active RunState,
+  and Active for backward compatibility  */
 const activeStates: Array<RunState> = [
   RunState.Active,
   RunState.Pulling,
   RunState.Queued,
   RunState.Running,
   RunState.Starting,
+];
+const jobStates: Array<JobState> = [
+  JobState.QUEUED,
+  JobState.SCHEDULED,
+  JobState.SCHEDULEDBACKFILLED,
 ];
 export const killableRunStates: CompoundRunState[] = [
   ...activeStates,

--- a/webui/react/src/constants/states.ts
+++ b/webui/react/src/constants/states.ts
@@ -28,17 +28,24 @@ const jobStates: Array<JobState> = [
   JobState.SCHEDULED,
   JobState.SCHEDULEDBACKFILLED,
 ];
-export const killableRunStates: CompoundRunState[] = [
+const activeStates: Array<RunState> = [
   RunState.Active,
+  RunState.Pulling,
+  RunState.Queued,
+  RunState.Running,
+  RunState.Starting,
+];
+export const killableRunStates: CompoundRunState[] = [
+  ...activeStates,
   RunState.Paused,
   RunState.StoppingCanceled,
   ...jobStates,
 ];
 
-export const pausableRunStates: Set<CompoundRunState> = new Set([RunState.Active, ...jobStates]);
+export const pausableRunStates: Set<CompoundRunState> = new Set([...activeStates, ...jobStates]);
 
 export const cancellableRunStates: Set<CompoundRunState> = new Set([
-  RunState.Active,
+  ...activeStates,
   RunState.Paused,
   ...jobStates,
 ]);


### PR DESCRIPTION
## Description

Addressing an issue in the release - when 1+ experiments are selected, the new run states should allow the same actions which were allowed for Active state.  This is pause/cancel/kill.

## Test Plan

On Project details page or Experiment details page, try to cancel or kill a running experiment.

## Checklist
- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.
- [x] If modifying `/webui/react/src/shared/` verify `make -C webui/react test-shared` passes.