### PR TITLE
fix: display primitive hps correctly in parallel coordinates plot

### DIFF
--- a/webui/react/src/pages/ExperimentDetails/ExperimentVisualization/HpParallelCoordinates.tsx
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentVisualization/HpParallelCoordinates.tsx
@@ -14,7 +14,7 @@ import { readStream } from 'services/utils';
 import Message, { MessageType } from 'shared/components/Message';
 import Spinner from 'shared/components/Spinner/Spinner';
 import { Primitive, Range } from 'shared/types';
-import { clone, flattenObject } from 'shared/utils/data';
+import { clone, flattenObject, isPrimitive } from 'shared/utils/data';
 import { ErrorLevel, ErrorType } from 'shared/utils/error';
 import { numericSorter } from 'shared/utils/sort';
 import {
@@ -159,7 +159,7 @@ const HpParallelCoordinates: React.FC<Props> = ({
 
       if (hp.type === HyperparameterType.Categorical || hp.vals) {
         return {
-          categories: hp.vals?.map((val) => JSON.stringify(val)) ?? [],
+          categories: hp.vals?.map((val) => isPrimitive(val) ? val :  JSON.stringify(val)) ?? [],
           key,
           label: key,
           type: DimensionType.Categorical,
@@ -233,7 +233,7 @@ const HpParallelCoordinates: React.FC<Props> = ({
           Object.keys(flatHParams).forEach((hpKey) => {
             const hpValue = flatHParams[hpKey];
             trialHpMap[hpKey] = trialHpMap[hpKey] || {};
-            trialHpMap[hpKey][id] = JSON.stringify(hpValue);
+            trialHpMap[hpKey][id] = isPrimitive(hpValue) ? hpValue :  JSON.stringify(hpValue);
           });
 
           trialHpTableMap[id] = {

--- a/webui/react/src/pages/ExperimentDetails/ExperimentVisualization/HpParallelCoordinates.tsx
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentVisualization/HpParallelCoordinates.tsx
@@ -159,7 +159,7 @@ const HpParallelCoordinates: React.FC<Props> = ({
 
       if (hp.type === HyperparameterType.Categorical || hp.vals) {
         return {
-          categories: hp.vals?.map((val) => isPrimitive(val) ? val :  JSON.stringify(val)) ?? [],
+          categories: hp.vals?.map((val) => (isPrimitive(val) ? val : JSON.stringify(val))) ?? [],
           key,
           label: key,
           type: DimensionType.Categorical,
@@ -233,7 +233,7 @@ const HpParallelCoordinates: React.FC<Props> = ({
           Object.keys(flatHParams).forEach((hpKey) => {
             const hpValue = flatHParams[hpKey];
             trialHpMap[hpKey] = trialHpMap[hpKey] || {};
-            trialHpMap[hpKey][id] = isPrimitive(hpValue) ? hpValue :  JSON.stringify(hpValue);
+            trialHpMap[hpKey][id] = isPrimitive(hpValue) ? hpValue : JSON.stringify(hpValue);
           });
 
           trialHpTableMap[id] = {


### PR DESCRIPTION
## Description


[DET-8443]


## Test Plan

do `dev.setServerAddress` against http://gke.determined.ai/det/experiments/201 to verify fix and against http://52.89.73.17:8080/api/v1/experiments/126 to verify preservation of behavior for nested hps.


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist
- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.
- [ ] If modifying `/webui/react/src/shared/` verify `make -C webui/react test-shared` passes.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-8443]: https://determinedai.atlassian.net/browse/DET-8443?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ