### PR TITLE
ci: fix "previous tag" logic

### DIFF
--- a/agent/Makefile
+++ b/agent/Makefile
@@ -58,7 +58,7 @@ package: packaging/LICENSE
 
 .PHONY: release
 release: export GORELEASER_CURRENT_TAG := $(VERSION)
-release: export GORELEASER_PREVIOUS_TAG := $(shell git tag --sort=-creatordate | grep -v "rc" | grep "v$(VERSION)" -A1 | sed -n '2 p')
+release: export GORELEASER_PREVIOUS_TAG := $(shell git tag --sort=-creatordate | egrep '^[0-9.]+$' | grep "$(VERSION)" -A1 | sed -n '2 p')
 release: packaging/LICENSE
 	goreleaser --rm-dist
 

--- a/helm/Makefile
+++ b/helm/Makefile
@@ -27,7 +27,7 @@ release:
 
 .PHONY: release-gh
 release-gh: export GORELEASER_CURRENT_TAG := $(VERSION)
-release-gh: export GORELEASER_PREVIOUS_TAG := $(shell git tag --sort=-creatordate | grep -v "rc" | grep "v$(VERSION)" -A1 | sed -n '2 p')
+release-gh: export GORELEASER_PREVIOUS_TAG := $(shell git tag --sort=-creatordate | egrep '^[0-9.]+$' | grep "$(VERSION)" -A1 | sed -n '2 p')
 release-gh:
 	go install github.com/goreleaser/goreleaser@v1.1.0
 	git clean -df

--- a/master/Makefile
+++ b/master/Makefile
@@ -120,7 +120,7 @@ package: gen
 release: export DET_SEGMENT_MASTER_KEY ?=
 release: export DET_SEGMENT_WEBUI_KEY ?=
 release: export GORELEASER_CURRENT_TAG := $(VERSION)
-release: export GORELEASER_PREVIOUS_TAG := $(shell git tag --sort=-creatordate | grep -v "rc\|v" | grep "$(VERSION)" -A1 | sed -n '2 p')
+release: export GORELEASER_PREVIOUS_TAG := $(shell git tag --sort=-creatordate | egrep '^[0-9.]+$' | grep "$(VERSION)" -A1 | sed -n '2 p')
 release: gen
 	goreleaser --rm-dist
 


### PR DESCRIPTION
## Description

The agent and helm releases were failing to get the previous tag completely (we don't use a `v` prefix any longer) Also adjust the grep to include only what we want instead of excluding known unwanted tags.  The previous tag functionality doesn't make much of a difference, but the exclusion was brittle; any new tag which happened to get added would break the exclusion logic.

~Marking as draft since there's a conflicting helm Makefile update in-flight; this will need updated to reflect that change.~

## Test Plan

Run shell commands in a shell and confirm expected behavior.  Pay attention on next release to make sure things actually work as planned. :)

## Commentary (optional)

It's tough to suppress my urge to also convert the `grep "$VERSION" -A1 | sed -n '2 p'` into just `sed -n "/$VERSION/{n;p;}"`, and it's a real bummer that git pattern matching is limited to `fnmatch()` without the GNU extended patterns enabled, but this all gives me an opportunity to practice being calm. :lotus_position: 

Since these three all use the same logic, it might actually make sense for that one-liner to be a helper script in a parent directory instead of being duplicated across multiple files. :shrug: 

## Checklist
- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.
- [x] If modifying `/webui/react/src/shared/` verify `make -C webui/react test-shared` passes.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
