### PR TITLE
fix: tensorboard inherits imagePullSecrets from experiment [DET-8458]

### DIFF
--- a/docs/release-notes/5123-tb-secrets.txt
+++ b/docs/release-notes/5123-tb-secrets.txt
@@ -1,0 +1,7 @@
+:orphan:
+
+**Fixes**
+
+-  Tensorboards in Kubernetes now inherit the environment.pod_spec.spec.imagePullSecrets value from
+   the relevant experiment configuration any time the tensorboard task inherits its image from that
+   experiment configuration.


### PR DESCRIPTION
The secrets are inherited only when the image from that experiment is also inherited.

## Test Plan

- [x] added an automated test