### PR TITLE
chore: Placeholder when notes/markdown is disabled [DET-8409]

### DIFF
--- a/webui/react/src/components/Markdown.stories.tsx
+++ b/webui/react/src/components/Markdown.stories.tsx
@@ -139,7 +139,7 @@ export const Default = (): React.ReactNode => (
 
 export const Disabled = (): React.ReactNode => (
   <div style={{ height: '80vh', width: '600px' }}>
-    <Markdown disabled={true} markdown={''} />
+    <Markdown disabled={true} markdown="" />
   </div>
 );
 

--- a/webui/react/src/components/Markdown.stories.tsx
+++ b/webui/react/src/components/Markdown.stories.tsx
@@ -137,6 +137,12 @@ export const Default = (): React.ReactNode => (
   </div>
 );
 
+export const Disabled = (): React.ReactNode => (
+  <div style={{ height: '80vh', width: '600px' }}>
+    <Markdown disabled={true} markdown={''} />
+  </div>
+);
+
 export const Editing = (): React.ReactNode => {
   const [editedMarkdown, setEditedMarkdown] = useState(markdown);
 

--- a/webui/react/src/components/Markdown.tsx
+++ b/webui/react/src/components/Markdown.tsx
@@ -50,7 +50,7 @@ const Markdown: React.FC<Props> = ({
 }: Props) => {
   return (
     <div aria-label="markdown-editor" className={css.base}>
-      {editing ? (
+      {editing && !disabled ? (
         <Tabs className="no-padding">
           <TabPane className={css.noOverflow} key={TabType.Edit} tab="Edit">
             <React.Suspense

--- a/webui/react/src/components/Markdown.tsx
+++ b/webui/react/src/components/Markdown.tsx
@@ -10,6 +10,7 @@ const { TabPane } = Tabs;
 const MonacoEditor = React.lazy(() => import('components/MonacoEditor'));
 
 interface Props {
+  disabled?: boolean;
   editing?: boolean;
   markdown: string;
   onChange?: (editedMarkdown: string) => void;
@@ -40,7 +41,13 @@ const MarkdownRender: React.FC<RenderProps> = ({ markdown, placeholder, onClick 
   );
 };
 
-const Markdown: React.FC<Props> = ({ editing = false, markdown, onChange, onClick }: Props) => {
+const Markdown: React.FC<Props> = ({
+  disabled = false,
+  editing = false,
+  markdown,
+  onChange,
+  onClick,
+}: Props) => {
   return (
     <div aria-label="markdown-editor" className={css.base}>
       {editing ? (
@@ -75,7 +82,11 @@ const Markdown: React.FC<Props> = ({ editing = false, markdown, onChange, onClic
           </TabPane>
         </Tabs>
       ) : (
-        <MarkdownRender markdown={markdown} placeholder="Add notes..." onClick={onClick} />
+        <MarkdownRender
+          markdown={markdown}
+          placeholder={disabled ? 'No note present.' : 'Add notes...'}
+          onClick={onClick}
+        />
       )}
     </div>
   );

--- a/webui/react/src/components/NotesCard.tsx
+++ b/webui/react/src/components/NotesCard.tsx
@@ -139,6 +139,7 @@ const NotesCard: React.FC<Props> = ({
       }>
       <Spinner spinning={isLoading}>
         <Markdown
+          disabled={disabled}
           editing={isEditing}
           markdown={isEditing ? editedNotes : notes}
           onChange={handleEditedNotes}


### PR DESCRIPTION
## Description

As we're adding RBAC permissions, we sometimes disable NotesCard. The underlying Markdown placeholder says "Add notes..." even if no changes can be made.

This is a minor change to the NotesCard component to pass disabled attribute to Markdown, and changing the placeholder for that case.

## Test Plan

Most Notes should stay the same. You can use the storybook or set the NotesCard component on a page to be `disabled={true}`


## Checklist
- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.
- [x] If modifying `/webui/react/src/shared/` verify `make -C webui/react test-shared` passes.