### PR TITLE
chore: only request listRoles with rbac on [DET-8419]

### DIFF
--- a/webui/react/src/components/Navigation.tsx
+++ b/webui/react/src/components/Navigation.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 
 import { useStore } from 'contexts/Store';
+import useFeature from 'hooks/useFeature';
 import {
   useFetchAgents,
   useFetchKnownRoles,
@@ -39,10 +40,11 @@ const Navigation: React.FC<Props> = ({ children }) => {
     return () => canceler.abort();
   }, [canceler, fetchResourcePools]);
 
+  const makeListRoleCalls = useFeature().isOn('rbac');
   useEffect(() => {
-    fetchKnownRoles();
+    makeListRoleCalls && fetchKnownRoles();
     return () => canceler.abort();
-  }, [canceler, fetchKnownRoles]);
+  }, [canceler, fetchKnownRoles, makeListRoleCalls]);
 
   return (
     <Spinner spinning={ui.showSpinner}>

--- a/webui/react/src/components/Navigation.tsx
+++ b/webui/react/src/components/Navigation.tsx
@@ -40,11 +40,13 @@ const Navigation: React.FC<Props> = ({ children }) => {
     return () => canceler.abort();
   }, [canceler, fetchResourcePools]);
 
-  const makeListRoleCalls = useFeature().isOn('rbac');
+  const rbacEnabled = useFeature().isOn('rbac');
   useEffect(() => {
-    makeListRoleCalls && fetchKnownRoles();
+    if (rbacEnabled) {
+      fetchKnownRoles();
+    }
     return () => canceler.abort();
-  }, [canceler, fetchKnownRoles, makeListRoleCalls]);
+  }, [canceler, fetchKnownRoles, rbacEnabled]);
 
   return (
     <Spinner spinning={ui.showSpinner}>

--- a/webui/react/src/services/apiConfig.ts
+++ b/webui/react/src/services/apiConfig.ts
@@ -288,12 +288,10 @@ export const listRoles: DetApi<Service.ListRolesParams, Api.V1ListRolesResponse,
   {
     name: 'listRoles',
     postProcess: (response) => response.roles.map(decoder.mapV1Role),
-    request: () =>
-      new Promise((resolve) => {
-        resolve({
-          pagination: {},
-          roles: new Array<Api.V1Role>(),
-        });
+    request: (params) =>
+      detApi.RBAC.listRoles({
+        limit: params.limit || 0,
+        offset: params.offset || 0,
       }),
   };
 


### PR DESCRIPTION
## Description

Removes the mock added in #5079 - instead `listRoles` only happens with RBAC on.

## Test Plan

For OSS user - load `/det/projects/1?f_rbac=on` and see request to `roles/search` (will error out). 

Request the page *without* `f_rbac=on` and there should be no request / error from `roles/search`

## Checklist
- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.
- [x] If modifying `/webui/react/src/shared/` verify `make -C webui/react test-shared` passes.