### PR TITLE
ci: cache more Go files

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,7 +41,7 @@ parameters:
   # the old build may be cached, and you may need to invalidate it.
   cache-buster:
     type: string
-    default: v1dev12
+    default: v1dev13-will-remove-this-before-landing-just-want-to-make-sure-not-to-put-a-bad-version-in-the-cache
   gke-version:
     type: string
     default: "1.21.14"
@@ -228,14 +228,15 @@ commands:
       - install-protoc
       - restore_cache:
           keys:
-            - det-go-deps-<<pipeline.parameters.cache-buster>>-{{ checksum  "master/go.sum" }}-{{ checksum  "agent/go.sum" }}-{{ checksum  "proto/go.sum" }}
+            - det-go-deps-<<pipeline.parameters.cache-buster>>-{{ checksum  "master/get-deps.sh" }}-{{ checksum  "master/go.sum" }}-{{ checksum  "agent/get-deps.sh" }}-{{ checksum  "agent/go.sum" }}-{{ checksum  "proto/get-deps.sh" }}-{{ checksum  "proto/go.sum" }}
       - run: make -C proto get-deps
       - run: make -C master get-deps
       - run: make -C agent get-deps
       - save_cache:
-          key: det-go-deps-<<pipeline.parameters.cache-buster>>-{{ checksum  "master/go.sum" }}-{{ checksum  "agent/go.sum" }}-{{ checksum  "proto/go.sum" }}
+          key: det-go-deps-<<pipeline.parameters.cache-buster>>-{{ checksum  "master/get-deps.sh" }}-{{ checksum  "master/go.sum" }}-{{ checksum  "agent/get-deps.sh" }}-{{ checksum  "agent/go.sum" }}-{{ checksum  "proto/get-deps.sh" }}-{{ checksum  "proto/go.sum" }}
           paths:
-            - "/home/circleci/go/pkg/mod/"
+            - "/home/circleci/go/"
+            - "/home/circleci/.cache/go-build/"
   react-get-deps:
     steps:
       - attach_workspace:

--- a/agent/Makefile
+++ b/agent/Makefile
@@ -9,10 +9,7 @@ clean:
 
 .PHONY: get-deps
 get-deps:
-	go install mvdan.cc/gofumpt@v0.3.1
-	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.45.2
-	go install golang.org/x/tools/cmd/goimports@v0.1.5
-	go install github.com/goreleaser/goreleaser@v1.1.0
+	./get-deps.sh
 
 .PHONY: build
 build:

--- a/agent/get-deps.sh
+++ b/agent/get-deps.sh
@@ -1,0 +1,4 @@
+go install mvdan.cc/gofumpt@v0.3.1
+go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.45.2
+go install golang.org/x/tools/cmd/goimports@v0.1.5
+go install github.com/goreleaser/goreleaser@v1.1.0

--- a/master/Makefile
+++ b/master/Makefile
@@ -50,14 +50,7 @@ check-gen: force-gen gen
 
 .PHONY: get-deps
 get-deps:
-	go install mvdan.cc/gofumpt@v0.3.1
-	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.45.2
-	go install github.com/bufbuild/buf/cmd/buf@v0.42.1
-	go install golang.org/x/tools/cmd/goimports@v0.1.5
-	go install github.com/goreleaser/goreleaser@v1.1.0
-	go install github.com/ryanbressler/CloudForest/growforest@v0.0.0-20161201194407-d014dc32840a
-	go install github.com/swaggo/swag/cmd/swag@v1.7.0
-	go install github.com/vektra/mockery/v2@v2.13.1
+	./get-deps.sh
 
 .PHONY: build
 build: export DET_SEGMENT_MASTER_KEY ?=

--- a/master/get-deps.sh
+++ b/master/get-deps.sh
@@ -1,0 +1,8 @@
+go install mvdan.cc/gofumpt@v0.3.1
+go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.45.2
+go install github.com/bufbuild/buf/cmd/buf@v0.42.1
+go install golang.org/x/tools/cmd/goimports@v0.1.5
+go install github.com/goreleaser/goreleaser@v1.1.0
+go install github.com/ryanbressler/CloudForest/growforest@v0.0.0-20161201194407-d014dc32840a
+go install github.com/swaggo/swag/cmd/swag@v1.7.0
+go install github.com/vektra/mockery/v2@v2.13.1

--- a/proto/Makefile
+++ b/proto/Makefile
@@ -29,13 +29,9 @@ build: build/proto.stamp $(swagger_out)
 clean:
 	rm -rf build pkg
 
+.PHONY: get-deps
 get-deps:
-	go install github.com/bufbuild/buf/cmd/buf@v0.42.1
-	go install github.com/golang/protobuf/protoc-gen-go@v1.5.2
-	go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.2.0
-	go install github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway@v1.14.6
-	go install github.com/grpc-ecosystem/grpc-gateway/protoc-gen-swagger@v1.14.6
-	go install github.com/swaggo/swag/cmd/swag@v1.7.0
+	./get-deps.sh
 
 build/proto.stamp: $(source_files)
 	rm -rf build/proto pkg

--- a/proto/get-deps.sh
+++ b/proto/get-deps.sh
@@ -1,0 +1,6 @@
+go install github.com/bufbuild/buf/cmd/buf@v0.42.1
+go install github.com/golang/protobuf/protoc-gen-go@v1.5.2
+go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.2.0
+go install github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway@v1.14.6
+go install github.com/grpc-ecosystem/grpc-gateway/protoc-gen-swagger@v1.14.6
+go install github.com/swaggo/swag/cmd/swag@v1.7.0


### PR DESCRIPTION
## Description

Despite the caching that was in place previously, the `go-get-deps` stage still took quite a while because the caching did not cover everything that `go install` touches. This change expands the caching to cover the relevant directories. It also moves the `go install` commands into separate files so that they can be accounted for in the cache key.

In my testing, this saves 60-90 seconds each time `go-get-deps` is run, which speeds up several different jobs. Meanwhile, it increases the cache size from 465 MiB to 676 MiB.

## Test Plan

- [x] run timing tests on an upstream branch (https://app.circleci.com/pipelines/github/determined-ai/determined?branch=go-cache-more)
- [x] check that changing one of the `get-deps.sh` scripts breaks the caching

## Commentary (optional)

Is there some functional reason not to do this? I've thought about doing it before, but I vaguely feel like there was something that stopped me (besides, you know, time and attention).