### PR TITLE
fix: shells fail if vars contain a newline [FOUNDENG-251]

### DIFF
--- a/master/static/srv/shell-entrypoint.sh
+++ b/master/static/srv/shell-entrypoint.sh
@@ -77,6 +77,8 @@ options="$(
             continue
         fi
 
+        # Convert any explicit newline to \n
+        val="${val//$'\n'/'\n'}"
         # Backslash-escape quotes so that sshd works.
         val="${val//\"/\\\"}"
         # Backslash-escape backslashes so that sed doesn't interpret them.


### PR DESCRIPTION
## Description

If a variable contains an explcit newline, det shell start fails because the sed pattern replacement to inject the environment into the ssh authorized_keys file fails with the sed error:

  sed: -e expression #1, char 100: unterminated `s' command

Translate any env var value that contains a newline to \n.

## Test Plan

Manually verified that this change enables `det shell start` succeeds with the variable `IFS="  \n"` set (that is an explicit newline) on casablanca-login2.   The value is properly maintained in the started shell.

## Commentary (optional)

Oddly, IFS is somehow set to `IFS="  \n"`  -- presumably by PBS.   Using Slurm on the same system does not  have this problem.

## Checklist
- [X] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.
- [ ] If modifying `/webui/react/src/shared/` verify `make -C webui/react test-shared` passes.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
