### PR TITLE
test: fix `test-k8-mount`.

### DIFF
--- a/e2e_tests/tests/command/test_run.py
+++ b/e2e_tests/tests/command/test_run.py
@@ -484,7 +484,7 @@ def test_k8_mount(using_k8s: bool, sidecar: bool) -> None:
     if sidecar:
         sidecar_container = {
             "name": "sidecar",
-            "image": conf.TF1_CPU_IMAGE,
+            "image": conf.TF2_CPU_IMAGE,
             "command": ["/bin/bash"],
             "args": ["-c", "exit 0"],
         }


### PR DESCRIPTION
## Description

`test-k8-mount` has been inexplicably failing recently with `context deadline exceeded`. 
The image it uses isn't supposed to matter, but after I've changed TF1 image to TF2 I can't get it to fail any more.

## Test Plan

N/A: this is a test.

## Commentary (optional)

## Checklist
- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.
- [ ] If modifying `/webui/react/src/shared/` verify `make -C webui/react test-shared` passes.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-1234]: https://determinedai.atlassian.net/browse/DET-1234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ