### PR TITLE
fix: FOUNDENG-246 Task reports "RuntimeError: Dataset not found or corrupted"

### DIFF
--- a/harness/determined/launch/wrap_rank.py
+++ b/harness/determined/launch/wrap_rank.py
@@ -74,20 +74,23 @@ def main() -> int:
             )
             return 1
 
-    # Slurm/PBS: Hack to refresh the working directory using the softlink in the current container.
-    # Each container's "/run/determined/workdir" is actually a symlink to a mounted shared directory
-    # on the host whose path contains "*/procs/${SLURM_PROCID}/run/determined/workdir". "os.getcwd()"
-    # returns the real path pointed to by the symlink, instead of the symlink itself. Because the
-    # chief is using "os.getcwd()" to get the working directory, it is propagating its rank-specifc
-    # directory to all the workers, causing the workers' working directory to be set to
-    # "*/procs/0/run/determined/workdir". This results in collisions when the workers are downloading
-    # the dataset, because all the workers are downloading to the same directory.  Each worker needs to
-    # refresh its working directory by getting the real path of the symlink pointed to by
-    # "/run/determined/workdir" to its own working directory (e.g., "*/procs/1/run/determined/workdir",
+    # Slurm/PBS: Hack to refresh the working directory using the softlink in the
+    # current container.  Each container's "/run/determined/workdir" is actually
+    # a symlink to a mounted shared directory on the host whose path contains
+    # "*/procs/${SLURM_PROCID}/run/determined/workdir". "os.getcwd()" returns
+    # the real path pointed to by the symlink, instead of the symlink itself.
+    # Because the chief is using "os.getcwd()" to get the working directory, it
+    # is propagating its rank-specific directory to all the workers, causing the
+    # workers' working directory to be set to "*/procs/0/run/determined/workdir".
+    # This results in collisions when the workers are downloading the dataset,
+    # because all the workers are downloading to the same directory.  Each worker
+    # needs to refresh its working directory by getting the real path of the
+    # symlink pointed to by "/run/determined/workdir" to its own working
+    # directory (e.g., "*/procs/1/run/determined/workdir",
     # "*/procs/2/run/determined/workdir", and so on).
-    cwd=os.getcwd()
-    if cwd.endswith('/run/determined/workdir'):
-        os.chdir('/run/determined/workdir')
+    cwd = os.getcwd()
+    if cwd.endswith("/run/determined/workdir"):
+        os.chdir("/run/determined/workdir")
 
     proc = subprocess.Popen(args.script, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     with det.util.forward_signals(proc):

--- a/harness/determined/launch/wrap_rank.py
+++ b/harness/determined/launch/wrap_rank.py
@@ -74,6 +74,21 @@ def main() -> int:
             )
             return 1
 
+    # Slurm/PBS: Hack to refresh the working directory using the softlink in the current container.
+    # Each container's "/run/determined/workdir" is actually a symlink to a mounted shared directory
+    # on the host whose path contains "*/procs/${SLURM_PROCID}/run/determined/workdir". "os.getcwd()"
+    # returns the real path pointed to by the symlink, instead of the symlink itself. Because the
+    # chief is using "os.getcwd()" to get the working directory, it is propagating its rank-specifc
+    # directory to all the workers, causing the workers' working directory to be set to
+    # "*/procs/0/run/determined/workdir". This results in collisions when the workers are downloading
+    # the dataset, because all the workers are downloading to the same directory.  Each worker needs to
+    # refresh its working directory by getting the real path of the symlink pointed to by
+    # "/run/determined/workdir" to its own working directory (e.g., "*/procs/1/run/determined/workdir",
+    # "*/procs/2/run/determined/workdir", and so on).
+    cwd=os.getcwd()
+    if cwd.endswith('/run/determined/workdir'):
+        os.chdir('/run/determined/workdir')
+
     proc = subprocess.Popen(args.script, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     with det.util.forward_signals(proc):
         with contextlib.ExitStack() as exit_stack:


### PR DESCRIPTION
## Description

Ran the "computer_vision/cifar10_pytorch" experiment on "casablanca-login2" with PBS using the dev launcher, using the experiment file shown below.

```
(base) rcorujo@C02FJ0T8MD6Q cifar10_pytorch % cat rig_distributed.yaml 
name: cifar10_pytorch_distributed
hyperparameters:
  learning_rate: 1.0e-4
  learning_rate_decay: 1.0e-6
  layer1_dropout: 0.25
  layer2_dropout: 0.25
  layer3_dropout: 0.5
  global_batch_size: 512 # Per-GPU batch size of 32
resources:
  slots_per_trial: 12
records_per_epoch: 50000
searcher:
  name: single
  metric: validation_error
  max_length:
    epochs: 32
entrypoint: model_def:CIFARTrial
min_validation_period:
  epochs: 1
environment:
    environment_variables:
        - NCCL_DEBUG=DEBUG
        # You may need to modify this to match your network configuration.
        #- NCCL_SOCKET_IFNAME=ens5np0
        - NCCL_IB_DISABLE=1
        - CUDA_VISIBLE_DEVICES=0,1,2,3
    image:
        cuda: /mnt/lustre/foundation_engineering/images2/determinedai/environments:cuda-11.3-pytorch-1.10-tf-2.8-gpu-9119094
        cpu: /mnt/lustre/foundation_engineering/images2/determinedai/environments:cuda-11.3-pytorch-1.10-tf-2.8-gpu-9119094
```

Sometimes "gloo_run.py" would report, "RuntimeError: Dataset not found or corrupted.".

The root cause is as follows.  On each container, of which we run one per node, "/run/determined/workdir" is a symlink to "/determined_local_fs/procs/${SLURM_PROCID}/run/determined/workdir", where "/determined_local_fs" is the mount point inside the container for "/mnt/lustre/foundation_engineering/determined-cp" on the compute node.  In other words, each container gets its own unique directory on the compute node based on its ${SLURM_PROCID}, so when the containers write data to "/run/determined/workdir", they don't step on each other's files.

However, "/opt/conda/lib/python3.8/site-packages/horovod/runner/gloo_run.py", which is delivered with the container and we cannot change, is passing the Horovod chief's working directory (e.g., "/determined_local_fs/procs/0/run/determined/workdir") to all the worker nodes and telling the worker nodes to make that their working directory too.

```
    def _exec_command(command, slot_info, events):
        index = slot_info.rank
        host_name = slot_info.hostname


        host_address = network.resolve_host_address(host_name)
        local_addresses = network.get_local_host_addresses()
        if host_address not in local_addresses:
            local_command = quote('cd {pwd} > /dev/null 2>&1 ; {command}'
                                  .format(pwd=os.getcwd(), command=command))
            command = get_remote_command(local_command,
                                         host=host_name,
                                         port=settings.ssh_port,
                                         identity_file=settings.ssh_identity_
```

So, if you do a "ps -fe | grep corujor" on the compute nodes, you'll see this.

```
corujor   636675  636669  0 14:07 ?        00:00:00 bash -c cd /determined_local_fs/procs/0/run/determined/workdir > /dev/null 2>&1 ; HOROVOD_HOSTNAME=172.23.0.3 ..........
```

Since all the worker nodes are trying to download the dataset to the same "/determined_local_fs/procs/0/run/determined/workdir" directory, they are stepping on each other's "cifar-10-python.tar.gz" file that is being, or has been, downloaded.  This results in the "RuntimeError: Dataset not found or corrupted." error.

 
The desired behavior is really for worker node with SLURM_PROCID=1 to have a working directory of "/determined_local_fs/procs/1/run/determined/workdir", the worker node with SLURM_PROCID=2 to have a working directory of "/determined_local_fs/procs/2/run/determined/workdir", and so on.

The code changes being submitted here were developed by Jerry Harrow.

With these changes, each worker node replaces its current working directory of "/determined_local_fs/procs/0/run/determined/workdir", with "/run/determined/workdir", which is a symlink to the working directory that it really should have. Hence, when the worker node calls "os.getcwd()", the "getcwd()" command will follow the symlink and return "/determined_local_fs/procs/1/run/determined/workdir", for example, if it's being called from the worker node whose SLURM_PROCID=1.

## Test Plan

Ran the "computer_vision/cifar10_pytorch" distributed experiment on "casablanca-login2" at least 10 times and it completed successfully each time.

## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist
- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.
- [ ] If modifying `/webui/react/src/shared/` verify `make -C webui/react test-shared` passes.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
