### PR TITLE
fix: more correctly compute TLS cert hash in CLI

### DIFF
--- a/harness/determined/cli/cli.py
+++ b/harness/determined/cli/cli.py
@@ -230,21 +230,23 @@ def main(
                     conn.connect(cast(Sequence[Union[str, int]], (addr.hostname, addr.port)))
                     conn.do_handshake()
                     peer_cert_chain = conn.get_peer_cert_chain()
-                    if peer_cert_chain is None:
+                    if peer_cert_chain is None or len(peer_cert_chain) == 0:
                         # Peer presented no cert.  It seems unlikely that this is possible after
                         # do_handshake() succeeded, but checking for None makes mypy happy.
                         raise crypto.Error()
-                    cert_pem_data = "".join(
+                    cert_pem_data = [
                         crypto.dump_certificate(crypto.FILETYPE_PEM, cert).decode()
                         for cert in peer_cert_chain
-                    )
+                    ]
                 except crypto.Error:
                     die(
                         "Tried to connect over HTTPS but couldn't get a certificate from the "
                         "master; consider using HTTP"
                     )
 
-                cert_hash = hashlib.sha256(ssl.PEM_cert_to_DER_cert(cert_pem_data)).hexdigest()
+                # Compute the fingerprint of the certificate; this is the same as the output of
+                # `openssl x509 -fingerprint -sha256 -inform pem -noout -in <cert>`.
+                cert_hash = hashlib.sha256(ssl.PEM_cert_to_DER_cert(cert_pem_data[0])).hexdigest()
                 cert_fingerprint = ":".join(chunks(cert_hash, 2))
 
                 if not render.yes_or_no(
@@ -255,10 +257,11 @@ def main(
                 ):
                     die("Unable to verify master certificate")
 
-                certs.CertStore(certs.default_store()).set_cert(parsed_args.master, cert_pem_data)
+                joined_certs = "".join(cert_pem_data)
+                certs.CertStore(certs.default_store()).set_cert(parsed_args.master, joined_certs)
                 # Reconfigure the CLI's Cert singleton, but preserve the certificate name.
                 old_cert_name = certs.cli_cert.name
-                certs.cli_cert = certs.Cert(cert_pem=cert_pem_data, name=old_cert_name)
+                certs.cli_cert = certs.Cert(cert_pem=joined_certs, name=old_cert_name)
 
                 check_version(parsed_args)
 


### PR DESCRIPTION
## Description

While doing some testing, I realized that `PEM_cert_to_DER_cert` is only supposed to operate on one certificate, though it sometimes can work on more than one (if, say, the first ends with Base64 padding characters, or possibly if the certs up to the first one ending in padding happen to together contain a valid number of Base64 characters), which is how this didn't get caught before.

## Test Plan

- [x] check that the CLI does not crashes on some certs where it did before
- [x] check that the hash still matches the result of `openssl x509 -fingerprint -sha256 -inform pem -noout -in <cert>`