### PR TITLE
feat: short options for RBAC CLI.

### DIFF
--- a/harness/determined/cli/rbac.py
+++ b/harness/determined/cli/rbac.py
@@ -386,14 +386,19 @@ args_description = [
                 [
                     Arg("role_name", help="name of role to assign"),
                     Arg(
+                        "-w",
                         "--workspace-name",
                         default=None,
                         help="name of the workspace the role is assigned to",
                     ),
                     Arg(
-                        "--username-to-assign", default=None, help="username to assign the role to"
+                        "-u",
+                        "--username-to-assign",
+                        default=None,
+                        help="username to assign the role to",
                     ),
                     Arg(
+                        "-g",
                         "--group-name-to-assign",
                         default=None,
                         help="name of the group the role is assigned to",
@@ -407,16 +412,19 @@ args_description = [
                 [
                     Arg("role_name", help="name of role to unassign"),
                     Arg(
+                        "-w",
                         "--workspace-name",
                         default=None,
                         help="name of the workspace the role is unassigned from",
                     ),
                     Arg(
+                        "-u",
                         "--username-to-assign",
                         default=None,
                         help="username the role is unassigned from",
                     ),
                     Arg(
+                        "-g",
                         "--group-name-to-assign",
                         default=None,
                         help="name of the group the role is unassigned from",


### PR DESCRIPTION
## Description

I've typed full parameters twice and my fingers got tired, so I made this.

## Test Plan

1. login as `admin`.
2. `det rbac assign-role --username-to-assign admin ClusterAdmin`
3. `det user create creator`
4.  login as `determined`.
5. `det rbac assign-role -u creator WorkspaceCreator` -- should fail because you are logged in as a simple user.
6. `det -u admin rbac assign-role -u creator WorkspaceCreator`  -- should work, because duplicate `-u` options make sense and don't conflict.

## Commentary (optional)


## Checklist
- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.
- [ ] If modifying `/webui/react/src/shared/` verify `make -C webui/react test-shared` passes.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
