### PR TITLE
fix: streaming errors not being handled

### DIFF
--- a/webui/react/src/hooks/useTelemetry.ts
+++ b/webui/react/src/hooks/useTelemetry.ts
@@ -60,7 +60,7 @@ class Telemetry {
         this.isLoaded = true;
       }
     } catch (e) {
-      handleError({
+      handleError(e, {
         level: ErrorLevel.Error,
         publicMessage: 'Failed to load telemetry.',
         silent: true,
@@ -92,7 +92,7 @@ class Telemetry {
         this.isIdentified = false;
       }
     } catch (e) {
-      handleError({
+      handleError(e, {
         level: ErrorLevel.Error,
         publicMessage: 'Failed to set telemetry identity.',
         silent: true,

--- a/webui/react/src/pages/ExperimentComparison/CompareVisualization.tsx
+++ b/webui/react/src/pages/ExperimentComparison/CompareVisualization.tsx
@@ -205,9 +205,8 @@ const CompareVisualization: React.FC = () => {
         );
         setChartData(newChartData);
       },
-    ).catch((e) => {
-      setPageError(e);
-    });
+      () => setPageError(PageError.ExperimentSample),
+    );
 
     return () => canceler.abort();
   }, [filters.metric, ui.isPageHidden, filters.maxTrial, experimentIds]);
@@ -236,9 +235,8 @@ const CompareVisualization: React.FC = () => {
         ];
         setMetrics(newMetrics);
       },
-    ).catch(() => {
-      setPageError(PageError.MetricNames);
-    });
+      () => setPageError(PageError.MetricNames),
+    );
 
     return () => canceler.abort();
   }, [trialIds, ui.isPageHidden]);

--- a/webui/react/src/pages/ExperimentDetails/ExperimentVisualization.tsx
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentVisualization.tsx
@@ -117,9 +117,15 @@ const ExperimentVisualization: React.FC<Props> = ({ basePath, experiment, type }
   const [filters, setFilters] = useState<VisualizationFilters>(initFilters);
   const [activeMetric, setActiveMetric] = useState<MetricName>(initFilters.metric);
   const [batches, setBatches] = useState<number[]>();
-  const [metricNames, setMetricNames] = useState<MetricName[]>([]);
   const [hpImportanceMap, setHpImportanceMap] = useState<HpImportanceMap>();
   const [pageError, setPageError] = useState<PageError>();
+
+  const handleMetricNamesError = useCallback(() => {
+    setPageError(PageError.MetricNames);
+  }, []);
+
+  // Stream available metrics.
+  const metricNames = useMetricNames(experiment.id, handleMetricNamesError);
 
   const { hasData, hasLoaded, isExperimentTerminal, isSupported } = useMemo(() => {
     return {
@@ -170,16 +176,6 @@ const ExperimentVisualization: React.FC<Props> = ({ basePath, experiment, type }
     }
   }, [basePath, navigate, location, type, typeKey]);
 
-  // Stream available metrics.
-  useMetricNames({
-    errorHandler: () => {
-      setPageError(PageError.MetricNames);
-    },
-    experimentId: experiment.id,
-    metricNames,
-    setMetricNames,
-  });
-
   useEffect(() => {
     if (!isSupported || ui.isPageHidden) return;
     const canceler = new AbortController();
@@ -195,9 +191,8 @@ const ExperimentVisualization: React.FC<Props> = ({ basePath, experiment, type }
           [MetricType.Validation]: getHpImportanceMap(event.validationMetrics),
         });
       },
-    ).catch(() => {
-      setPageError(PageError.MetricHpImportance);
-    });
+      () => setPageError(PageError.MetricHpImportance),
+    );
 
     return () => canceler.abort();
   }, [experiment.id, filters?.metric, isSupported, metricNames, ui.isPageHidden]);
@@ -225,9 +220,8 @@ const ExperimentVisualization: React.FC<Props> = ({ basePath, experiment, type }
         const newBatches = Object.values(batchesMap).sort(alphaNumericSorter);
         setBatches(newBatches);
       },
-    ).catch(() => {
-      setPageError(PageError.MetricBatches);
-    });
+      () => setPageError(PageError.MetricBatches),
+    );
 
     return () => canceler.abort();
   }, [activeMetric, experiment.id, filters.batch, isSupported, ui.isPageHidden]);
@@ -290,7 +284,7 @@ const ExperimentVisualization: React.FC<Props> = ({ basePath, experiment, type }
         />
       </div>
     );
-  } else if (pageError) {
+  } else if (pageError !== undefined) {
     return <Message title={PAGE_ERROR_MESSAGES[pageError]} type={MessageType.Alert} />;
   } else if (!hasLoaded && experiment.state !== RunState.Paused) {
     return <Spinner tip="Fetching metrics..." />;

--- a/webui/react/src/pages/ExperimentDetails/ExperimentVisualization/HpHeatMaps.tsx
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentVisualization/HpHeatMaps.tsx
@@ -316,10 +316,11 @@ const HpHeatMaps: React.FC<Props> = ({
         });
         setHasLoaded(true);
       },
-    ).catch((e) => {
-      setPageError(e);
-      setHasLoaded(true);
-    });
+      (e) => {
+        setPageError(e);
+        setHasLoaded(true);
+      },
+    );
 
     return () => canceler.abort();
   }, [

--- a/webui/react/src/pages/ExperimentDetails/ExperimentVisualization/HpParallelCoordinates.tsx
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentVisualization/HpParallelCoordinates.tsx
@@ -271,10 +271,11 @@ const HpParallelCoordinates: React.FC<Props> = ({
         });
         setHasLoaded(true);
       },
-    ).catch((e) => {
-      setPageError(e);
-      setHasLoaded(true);
-    });
+      (e) => {
+        setPageError(e);
+        setHasLoaded(true);
+      },
+    );
 
     return () => canceler.abort();
   }, [

--- a/webui/react/src/pages/ExperimentDetails/ExperimentVisualization/HpScatterPlots.tsx
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentVisualization/HpScatterPlots.tsx
@@ -215,10 +215,11 @@ const ScatterPlots: React.FC<Props> = ({
         });
         setHasLoaded(true);
       },
-    ).catch((e) => {
-      setPageError(e);
-      setHasLoaded(true);
-    });
+      (e) => {
+        setPageError(e);
+        setHasLoaded(true);
+      },
+    );
 
     return () => canceler.abort();
   }, [

--- a/webui/react/src/pages/ExperimentDetails/ExperimentVisualization/LearningCurve.tsx
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentVisualization/LearningCurve.tsx
@@ -181,10 +181,11 @@ const LearningCurve: React.FC<Props> = ({
         // One successful event as come through.
         setHasLoaded(true);
       },
-    ).catch((e) => {
-      setPageError(e);
-      setHasLoaded(true);
-    });
+      (e) => {
+        setPageError(e);
+        setHasLoaded(true);
+      },
+    );
 
     return () => canceler.abort();
   }, [experiment.id, selectedMaxTrial, selectedMetric, ui.isPageHidden]);

--- a/webui/react/src/pages/ExperimentDetails/TrialsComparisonModal.tsx
+++ b/webui/react/src/pages/ExperimentDetails/TrialsComparisonModal.tsx
@@ -119,19 +119,18 @@ const TrialsComparisonTable: React.FC<TableProps> = ({
     [getCheckpointSize, trialsDetails],
   );
 
-  const [metricNames, setMetricNames] = useState<MetricName[]>([]);
-  useMetricNames({
-    errorHandler: () => {
-      handleError({
+  const handleMetricNamesError = useCallback(
+    (e: unknown) => {
+      handleError(e, {
         publicMessage: `Failed to load metric names for experiment ${experiment.id}.`,
         publicSubject: 'Experiment metric name stream failed.',
         type: ErrorType.Api,
       });
     },
-    experimentId: experiment.id,
-    metricNames,
-    setMetricNames,
-  });
+    [experiment.id],
+  );
+
+  const metricNames = useMetricNames(experiment.id, handleMetricNamesError);
 
   useEffect(() => {
     setSelectedMetrics(metricNames);

--- a/webui/react/src/pages/InteractiveTask.tsx
+++ b/webui/react/src/pages/InteractiveTask.tsx
@@ -83,9 +83,8 @@ export const InteractiveTask: React.FC = () => {
           }
         }
       } catch (e) {
-        handleError({
-          error: e,
-          message: 'failed querying for command state',
+        handleError(e, {
+          publicMessage: 'failed querying for command state',
           silent: true,
         });
         clearInterval(queryTask);

--- a/webui/react/src/pages/Wait.tsx
+++ b/webui/react/src/pages/Wait.tsx
@@ -55,10 +55,9 @@ const Wait: React.FC = () => {
     return () => storeDispatch({ type: StoreActionUI.ShowUIChrome });
   }, [storeDispatch]);
 
-  const handleTaskError = (err: Error) => {
-    handleError({
-      error: err,
-      message: 'failed while waiting for command to be ready',
+  const handleTaskError = (e: Error) => {
+    handleError(e, {
+      publicMessage: 'Failed while waiting for command to be ready',
       silent: false,
       type: ErrorType.Server,
     });

--- a/webui/react/src/services/utils.ts
+++ b/webui/react/src/services/utils.ts
@@ -26,6 +26,7 @@ export const isLoginFailure = (e: unknown): boolean => {
 export const readStream = async <T = unknown>(
   fetchArgs: Api.FetchArgs,
   onEvent?: (event: T) => void,
+  onError?: (e?: Error) => void,
 ): Promise<unknown> => {
   try {
     const options = isObject(fetchArgs.options) ? fetchArgs.options : {};
@@ -37,6 +38,14 @@ export const readStream = async <T = unknown>(
     if (process.env.IS_DEV) options.credentials = 'include';
 
     const response = await fetch(serverAddress(fetchArgs.url), options);
+
+    if (!response.ok) {
+      const body = await response.json();
+      const e = new Error(body?.error?.message);
+      onError?.(e);
+      return;
+    }
+
     if (!response.body) throw new DetError(`Unable to fetch stream from ${fetchArgs.url}.`);
 
     const decoder = new TextDecoder();
@@ -59,7 +68,11 @@ export const readStream = async <T = unknown>(
       if (isCancelled) return;
       try {
         const ndjson = JSON.parse(line);
-        onEvent?.(ndjson.result);
+        if (ndjson.error) {
+          onError?.(ndjson.error);
+        } else {
+          onEvent?.(ndjson.result);
+        }
       } catch {
         // JSON parsing error occurred, no-op.
       }

--- a/webui/react/src/shared/utils/error.ts
+++ b/webui/react/src/shared/utils/error.ts
@@ -1,6 +1,6 @@
 import rootLogger from 'shared/utils/Logger';
 
-import { isString } from './data';
+import { isObject, isString } from './data';
 import { LoggerInterface } from './Logger';
 
 export const ERROR_NAMESPACE = 'EH';
@@ -80,24 +80,24 @@ export class DetError extends Error implements DetErrorOptions {
   /** the wrapped error if one was provided. */
   sourceErr: unknown;
 
-  constructor(e?: unknown, options: DetErrorOptions = {}) {
+  /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+  constructor(e?: any, options: DetErrorOptions = {}) {
     const defaultMessage = isError(e) ? e.message : isString(e) ? e : DEFAULT_ERROR_MESSAGE;
     const message = options.publicSubject || options.publicMessage || defaultMessage;
     super(message);
 
-    const eOpts: DetErrorOptions = isDetError(e)
-      ? {
-          id: e.id,
-          isUserTriggered: e.isUserTriggered,
-          level: e.level,
-          logger: e.logger,
-          payload: e.payload,
-          publicMessage: e.publicMessage,
-          publicSubject: e.publicSubject,
-          silent: e.silent,
-          type: e.type,
-        }
-      : {};
+    const eOpts: Partial<DetErrorOptions> = {};
+    if (isObject(e)) {
+      if ('id' in e && e.id != null) eOpts.id = e.id;
+      if ('isUserTriggered' in e && e.isUserTriggered != null)
+        eOpts.isUserTriggered = e.isUserTriggered;
+      if ('level' in e && e.level != null) eOpts.level = e.level;
+      if ('logger' in e && e.logger != null) eOpts.logger = e.logger;
+      if ('payload' in e && e.payload != null) eOpts.payload = e.payload;
+      if ('publicMessage' in e && e.publicMessage != null) eOpts.publicMessage = e.publicMessage;
+      if ('silent' in e && e.silent != null) eOpts.silent = e.silent;
+      if ('type' in e && e.type != null) eOpts.type = e.type;
+    }
 
     this.loadOptions({ ...defaultErrOptions, ...eOpts, ...options });
     this.isHandled = false;


### PR DESCRIPTION
## Description

[WEB-502](https://determinedai.atlassian.net/browse/WEB-502)
[WEB-492](https://determinedai.atlassian.net/browse/WEB-492)
[WEB-505](https://determinedai.atlassian.net/browse/WEB-505)
[WEB-503](https://determinedai.atlassian.net/browse/WEB-503)

This PR addresses a few related issues:
- errors in streaming APIs are not caught
- object literals sent to `handleError` are ignored
- infinite loading spinners for canceled/errored experiments with no trials


## Test Plan

to test streaming APIs errors are caught:
- `make live` against devcluster on this branch (there is debugging code to generate errors)
- filter network tab to requests that include "metric-names"
- go to experiment visualization page. 
  -  refresh until you see a 500
  - that means API failed when it was first called
  - you should see a message on the page that metric names could not be fetched
- start a new experiment
- go to experiment visualization page for that experiment.
  - refresh until you see a 200 for metric names
  - what that means is that an error was sent back mid stream
    - you can verify this by looking at the response
    - the last line of the ndjson should look like `{"error" : ...`
  - you should see a message on the page that metric names could not be fetched



to test infinite loading state fix:
- go [here](http://latest-master.determined.ai:8080/det/experiments/1193/overview), see infinite loading state
- `make live` against latest-master and verify that it's resolved



<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions about this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist
- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.
- [ ] If modifying `/webui/react/src/shared/` verify `make -C webui/react test-shared` passes.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
