### PR TITLE
feat: support streaming logs in Python SDK [MLG-46]

### DIFF
--- a/e2e_tests/tests/test_sdk.py
+++ b/e2e_tests/tests/test_sdk.py
@@ -31,11 +31,22 @@ def test_completed_experiment_and_checkpoint_apis(client: _client.Determined) ->
         exp = client.create_experiment(config, emptydir, includes=[model_def])
     finally:
         os.rmdir(emptydir)
+    exp = client.create_experiment(config, conf.fixtures_path("no_op"))
+
+    # Await first trial is safe to call before a trial has started.
+    trial = exp.await_first_trial()
+
+    # .logs(follow=True) block until the trial completes.
+    all_logs = list(trial.logs(follow=True))
+
     assert exp.wait() == _client.ExperimentState.COMPLETED
+
+    assert all_logs == list(trial.logs())
+    assert list(trial.logs(head=10)) == all_logs[:10]
+    assert list(trial.logs(tail=10)) == all_logs[-10:]
 
     trials = exp.get_trials()
     assert len(trials) == 1, trials
-    trial = trials[0]
     assert client.get_trial(trial.id).id == trial.id
 
     ckpt = trial.top_checkpoint()

--- a/harness/determined/common/experimental/experiment.py
+++ b/harness/determined/common/experimental/experiment.py
@@ -109,6 +109,16 @@ class ExperimentReference:
 
         return [trial.TrialReference(t.id, self._session) for r in resps for t in r.trials]
 
+    def await_first_trial(self, interval: float = 0.1) -> trial.TrialReference:
+        """
+        Wait for the first trial to be started for this experiment.
+        """
+        while True:
+            resp = bindings.get_GetExperimentTrials(self._session, experimentId=self._id)
+            if len(resp.trials) > 0:
+                return trial.TrialReference(resp.trials[0].id, self._session)
+            time.sleep(interval)
+
     def kill(self) -> None:
         bindings.post_KillExperiment(self._session, id=self._id)
 


### PR DESCRIPTION
The CLI command:

    det e create const.yaml -f

can now be expressed via the Python SDK:

    e = client.create_experiment()
    t = e.await_first_trial()
    for log in t.logs(follow=True):
        print(log, end="")

## Test Plan

- [x] write automated tests

## Commentary

I'd like to agree on the API before writing tests and landing it.