### PR TITLE
feat: support -i/--include [MLG-194]

### DIFF
--- a/docs/release-notes/5087-single-file-context.txt
+++ b/docs/release-notes/5087-single-file-context.txt
@@ -1,0 +1,15 @@
+:orphan:
+
+**Improvements**
+
+-  Support a new ``-i``/``--include`` option in task-starting CLI commands.  The context option
+   (``--context``) is useful for copying a directory of files into the task container, but it may
+   only be provided once, and it can be clunky if you only care about one or two files.  The
+   Include option also copies files into the task container, but:
+
+      -  The directory name is preserved, so ``-i my_data/`` would result in a directory named
+         ``my_data/`` appearing in the working directory of the task container.
+
+      -  It may point to a file, so ``-i my_data.csv`` will work.
+
+      -  It may be specified multiple times to include multiple files and/or directories.

--- a/harness/determined/cli/command.py
+++ b/harness/determined/cli/command.py
@@ -23,11 +23,19 @@ List values can be specified by comma-separated values.
 """
 
 CONTEXT_DESC = """
-The filepath to a directory that contains the set of files used to
-execute the command. All files under this directory will be packaged,
-maintaining the existing directory structure. The total byte contents
-of the directory must not exceed 96 MB. By default, the context
-directory will be empty.
+A directory whose contents should be copied into the task container.
+Unlike --include, the directory itself will not appear in the task
+container, only its contents.  The total bytes copied into the container
+must not exceed 96 MB.  By default, no files are copied.  See also:
+--include, which preserves the root directory name.
+"""
+
+INCLUDE_DESC = """
+A file or directory to copy into the task container.  May be provided more
+than once.   Unlike --context, --include will preserve the top-level
+directory name during the copy.  The total bytes copied into the
+container must not exceed 96 MB.  By default, no files are copied.  See
+also: --context, when a task should run inside a directory.
 """
 
 VOLUME_DESC = """
@@ -324,13 +332,12 @@ def launch_command(
     config: Dict[str, Any],
     template: str,
     context_path: Optional[Path] = None,
+    includes: Iterable[Path] = (),
     data: Optional[Dict[str, Any]] = None,
     preview: Optional[bool] = False,
     default_body: Optional[Dict[str, Any]] = None,
 ) -> Any:
-    user_files = []  # type: List[Dict[str, Any]]
-    if context_path:
-        user_files = context.read_legacy_context(context_path)
+    user_files = context.read_legacy_context(context_path, includes)
 
     body = {}  # type: Dict[str, Any]
     if default_body:

--- a/harness/determined/cli/experiment.py
+++ b/harness/determined/cli/experiment.py
@@ -133,7 +133,7 @@ def _parse_config_file_or_exit(config_file: io.FileIO, config_overrides: Iterabl
 @authentication.required
 def submit_experiment(args: Namespace) -> None:
     experiment_config = _parse_config_file_or_exit(args.config_file, args.config)
-    model_context = context.read_legacy_context(args.model_def)
+    model_context = context.read_legacy_context(args.model_def, args.include)
 
     additional_body_fields = {}
     if args.git:
@@ -926,6 +926,14 @@ main_cmd = Cmd(
             [
                 Arg("config_file", type=FileType("r"), help="experiment config file (.yaml)"),
                 Arg("model_def", type=Path, help="file or directory containing model definition"),
+                Arg(
+                    "-i",
+                    "--include",
+                    action="append",
+                    default=[],
+                    type=Path,
+                    help="additional files to copy into the task container",
+                ),
                 Arg(
                     "-g",
                     "--git",

--- a/harness/determined/cli/remote.py
+++ b/harness/determined/cli/remote.py
@@ -9,18 +9,17 @@ from determined.common import api
 from determined.common.api import authentication
 from determined.common.declarative_argparse import Arg, Cmd, Group
 
-from .command import CONFIG_DESC, CONTEXT_DESC, VOLUME_DESC, launch_command, parse_config
-
 
 @authentication.required
 def run_command(args: Namespace) -> None:
-    config = parse_config(args.config_file, args.entrypoint, args.config, args.volume)
-    resp = launch_command(
+    config = command.parse_config(args.config_file, args.entrypoint, args.config, args.volume)
+    resp = command.launch_command(
         args.master,
         "api/v1/commands",
         config,
         args.template,
         context_path=args.context,
+        includes=args.include,
     )["command"]
 
     if args.detach:
@@ -52,9 +51,17 @@ args_description = [
             Arg("--config-file", default=None, type=FileType("r"),
                 help="command config file (.yaml)"),
             Arg("-v", "--volume", action="append", default=[],
-                help=VOLUME_DESC),
-            Arg("-c", "--context", default=None, type=Path, help=CONTEXT_DESC),
-            Arg("--config", action="append", default=[], help=CONFIG_DESC),
+                help=command.VOLUME_DESC),
+            Arg("-c", "--context", default=None, type=Path, help=command.CONTEXT_DESC),
+            Arg(
+                "-i",
+                "--include",
+                default=[],
+                action="append",
+                type=Path,
+                help=command.INCLUDE_DESC
+            ),
+            Arg("--config", action="append", default=[], help=command.CONFIG_DESC),
             Arg("--template", type=str,
                 help="name of template to apply to the command configuration"),
             Arg("-d", "--detach", action="store_true",

--- a/harness/determined/cli/shell.py
+++ b/harness/determined/cli/shell.py
@@ -21,28 +21,20 @@ from determined.common.api import authentication, certs
 from determined.common.check import check_eq
 from determined.common.declarative_argparse import Arg, Cmd, Group
 
-from .command import (
-    CONFIG_DESC,
-    CONTEXT_DESC,
-    VOLUME_DESC,
-    launch_command,
-    parse_config,
-    render_event_stream,
-)
-
 
 @authentication.required
 def start_shell(args: Namespace) -> None:
     data = {}
     if args.passphrase:
         data["passphrase"] = getpass.getpass("Enter new passphrase: ")
-    config = parse_config(args.config_file, None, args.config, args.volume)
-    resp = launch_command(
+    config = command.parse_config(args.config_file, None, args.config, args.volume)
+    resp = command.launch_command(
         args.master,
         "api/v1/shells",
         config,
         args.template,
         context_path=args.context,
+        includes=args.include,
         data=data,
     )["shell"]
 
@@ -56,7 +48,7 @@ def start_shell(args: Namespace) -> None:
             if msg["service_ready_event"]:
                 ready = True
                 break
-            render_event_stream(msg)
+            command.render_event_stream(msg)
     if ready:
         shell = api.get(args.master, f"api/v1/shells/{resp['id']}").json()["shell"]
         check_eq(shell["state"], "STATE_RUNNING", "Shell must be in a running state")
@@ -217,9 +209,17 @@ args_description = [
             Arg("--config-file", default=None, type=FileType("r"),
                 help="command config file (.yaml)"),
             Arg("-v", "--volume", action="append", default=[],
-                help=VOLUME_DESC),
-            Arg("-c", "--context", default=None, type=Path, help=CONTEXT_DESC),
-            Arg("--config", action="append", default=[], help=CONFIG_DESC),
+                help=command.VOLUME_DESC),
+            Arg("-c", "--context", default=None, type=Path, help=command.CONTEXT_DESC),
+            Arg(
+                "-i",
+                "--include",
+                default=[],
+                action="append",
+                type=Path,
+                help=command.INCLUDE_DESC
+            ),
+            Arg("--config", action="append", default=[], help=command.CONFIG_DESC),
             Arg("-p", "--passphrase", action="store_true",
                 help="passphrase to encrypt the shell private key"),
             Arg("--template", type=str,

--- a/harness/determined/common/context.py
+++ b/harness/determined/common/context.py
@@ -1,8 +1,9 @@
 import base64
+import collections
 import os
 import pathlib
 import tarfile
-from typing import Any, Dict, List
+from typing import Any, Dict, Iterable, List, Optional
 
 import pathspec
 
@@ -35,12 +36,12 @@ def v1File_to_dict(f: bindings.v1File) -> Dict[str, Any]:
     return d
 
 
-def v1File_from_local_file(path: str, local_path: pathlib.Path) -> bindings.v1File:
-    with local_path.open("rb") as f:
+def v1File_from_local_file(archive_path: str, path: pathlib.Path) -> bindings.v1File:
+    with path.open("rb") as f:
         content = base64.b64encode(f.read()).decode("utf8")
-    st = local_path.stat()
+    st = path.stat()
     return bindings.v1File(
-        path=path,
+        path=archive_path,
         type=ord(tarfile.REGTYPE),
         content=content,
         # Protobuf expects string-encoded int64
@@ -51,10 +52,10 @@ def v1File_from_local_file(path: str, local_path: pathlib.Path) -> bindings.v1Fi
     )
 
 
-def v1File_from_local_dir(path: str, local_path: pathlib.Path) -> bindings.v1File:
-    st = local_path.stat()
+def v1File_from_local_dir(archive_path: str, path: pathlib.Path) -> bindings.v1File:
+    st = path.stat()
     return bindings.v1File(
-        path=path,
+        path=archive_path,
         type=ord(tarfile.DIRTYPE),
         content="",
         # Protobuf expects string-encoded int64
@@ -65,113 +66,155 @@ def v1File_from_local_dir(path: str, local_path: pathlib.Path) -> bindings.v1Fil
     )
 
 
+class _Builder:
+    def __init__(self, limit: int) -> None:
+        self.limit = limit
+        self.size = 0
+        self.items = []  # type: List[bindings.v1File]
+        self.msg = f"Preparing files to send to master... {sizeof_fmt(0)} and 0 files"
+        print(self.msg, end="\r", flush=True)
+
+    def add_v1File(self, f: bindings.v1File) -> None:
+        self.items.append(f)
+        self.size += v1File_size(f)
+        if self.size > self.limit:
+            raise ValueError(
+                "The total size of context directory and included files and directories exceeds "
+                f" the maximum allowed size {sizeof_fmt(self.limit)}.\n"
+                "Consider using either .detignore files inside directories to specify that certain "
+                "files or subdirectories should be omitted."
+            )
+
+    def update_msg(self) -> None:
+        print(" " * len(self.msg), end="\r")
+        self.msg = (
+            "Preparing files to send to master... "
+            f"{sizeof_fmt(self.size)} and {len(self.items)} files"
+        )
+        print(self.msg, end="\r", flush=True)
+
+    def add(self, root_path: pathlib.Path, entry_prefix: pathlib.Path) -> None:
+        root_path = root_path.resolve()
+
+        if not root_path.exists():
+            raise ValueError(f"Path '{root_path}' doesn't exist")
+
+        if root_path.is_file():
+            self.add_v1File(v1File_from_local_file(root_path.name, root_path))
+            return
+
+        if str(entry_prefix) != ".":
+            # For non-context directories, include the root directory.
+            self.add_v1File(v1File_from_local_dir(str(entry_prefix), root_path))
+
+        ignore = list(constants.DEFAULT_DETIGNORE)
+        ignore_path = root_path.joinpath(".detignore")
+        if ignore_path.is_file():
+            with ignore_path.open("r") as detignore_file:
+                ignore.extend(detignore_file)
+        ignore_spec = pathspec.PathSpec.from_lines(pathspec.patterns.GitWildMatchPattern, ignore)
+
+        # We could use pathlib.Path.rglob for scanning the directory;
+        # however, the Python documentation claims a warning that rglob may be
+        # inefficient on large directory trees, so we use the older os.walk().
+        for parent, dirs, files in os.walk(str(root_path)):
+            keep_dirs = []
+            for directory in dirs:
+                dir_path = pathlib.Path(parent).joinpath(directory)
+                dir_rel_path = dir_path.relative_to(root_path)
+
+                # If the directory matches any path specified in .detignore, then ignore it.
+                if ignore_spec.match_file(str(dir_rel_path)):
+                    continue
+                if ignore_spec.match_file(str(dir_rel_path) + "/"):
+                    continue
+                keep_dirs.append(directory)
+                # Determined only supports POSIX-style file paths.  Use as_posix() in case this code
+                # is executed in a non-POSIX environment.
+                entry_path = (entry_prefix / dir_rel_path).as_posix()
+
+                self.add_v1File(v1File_from_local_dir(entry_path, dir_path))
+            # We can modify dirs in-place so that we do not recurse into ignored directories
+            #  See https://docs.python.org/3/library/os.html#os.walk
+            dirs[:] = keep_dirs
+
+            for file in files:
+                file_path = pathlib.Path(parent).joinpath(file)
+                file_rel_path = file_path.relative_to(root_path)
+
+                # If the file is the .detignore file or matches one of the
+                # paths specified in .detignore, then ignore it.
+                if file_rel_path.name == ".detignore":
+                    continue
+                if ignore_spec.match_file(str(file_rel_path)):
+                    continue
+
+                # Determined only supports POSIX-style file paths.  Use as_posix() in case this code
+                # is executed in a non-POSIX environment.
+                entry_path = (entry_prefix / file_rel_path).as_posix()
+
+                try:
+                    entry = v1File_from_local_file(entry_path, file_path)
+                except OSError:
+                    print(f"Error reading '{entry_path}', skipping this file.")
+                    continue
+
+                self.add_v1File(entry)
+                self.update_msg()
+
+    def get_items(self) -> List[bindings.v1File]:
+        print()
+
+        # Check for conflicting root items, which may arise when --include conflicts with either
+        # the --context or another --include.
+        root_items = (f.path for f in self.items if "/" not in f.path.rstrip("/"))
+        duplicates = [k for k, v in collections.Counter(root_items).items() if v > 1]
+        if len(duplicates) == 1:
+            raise ValueError(f"duplicate path detected: {repr(duplicates[0])}")
+        elif duplicates:
+            raise ValueError(f"duplicate paths detected: {duplicates}")
+
+        return self.items
+
+
 def read_v1_context(
-    local_path: pathlib.Path,
+    context_root: Optional[pathlib.Path],
+    includes: Iterable[pathlib.Path] = (),
     limit: int = constants.MAX_CONTEXT_SIZE,
 ) -> List[bindings.v1File]:
     """
     Return a list of v1Files suitable for submitting a context directory over the v1 REST API.
 
-    A .detignore file in the directory, if specified, indicates the wildcard paths
-    that should be ignored. File paths are represented as relative paths (relative to
-    the root directory).
+    A .detignore file in a context or include directory, if specified, indicates the wildcard paths
+    that should be ignored.  File paths inside the context_root are relative to the context_root.
+    File paths from includes are prefixed by the basename of the included directory.
     """
 
-    items = []
-    size = 0
+    if context_root is None and not includes:
+        return []
 
-    def add_item(f: bindings.v1File) -> None:
-        nonlocal size
-        items.append(f)
-        size += v1File_size(f)
+    builder = _Builder(limit)
 
-    local_path = local_path.resolve()
-
-    if not local_path.exists():
-        raise Exception(f"Path '{local_path}' doesn't exist")
-
-    if local_path.is_file():
-        raise ValueError(f"Path '{local_path}' must be a directory")
-
-    root_path = local_path
-
-    ignore = list(constants.DEFAULT_DETIGNORE)
-    ignore_path = root_path.joinpath(".detignore")
-    if ignore_path.is_file():
-        with ignore_path.open("r") as detignore_file:
-            ignore.extend(detignore_file)
-    ignore_spec = pathspec.PathSpec.from_lines(pathspec.patterns.GitWildMatchPattern, ignore)
-
-    msg = f"Preparing files (in {root_path}) to send to master... {sizeof_fmt(0)} and {0} files"
-    print(msg, end="\r", flush=True)
-
-    # We could use pathlib.Path.rglob for scanning the directory;
-    # however, the Python documentation claims a warning that rglob may be
-    # inefficient on large directory trees, so we use the older os.walk().
-    for parent, dirs, files in os.walk(str(root_path)):
-        keep_dirs = []
-        for directory in dirs:
-            dir_path = pathlib.Path(parent).joinpath(directory)
-            dir_rel_path = dir_path.relative_to(root_path)
-
-            # If the directory matches any path specified in .detignore, then ignore it.
-            if ignore_spec.match_file(str(dir_rel_path)):
-                continue
-            if ignore_spec.match_file(str(dir_rel_path) + "/"):
-                continue
-            keep_dirs.append(directory)
-            # Determined only supports POSIX-style file paths.  Use as_posix() in case this code
-            # is executed in a non-POSIX environment.
-            entry_path = dir_rel_path.as_posix()
-
-            add_item(v1File_from_local_dir(entry_path, dir_path))
-        # We can modify dirs in-place so that we do not recurse into ignored directories
-        #  See https://docs.python.org/3/library/os.html#os.walk
-        dirs[:] = keep_dirs
-
-        for file in files:
-            file_path = pathlib.Path(parent).joinpath(file)
-            file_rel_path = file_path.relative_to(root_path)
-
-            # If the file is the .detignore file or matches one of the
-            # paths specified in .detignore, then ignore it.
-            if file_rel_path.name == ".detignore":
-                continue
-            if ignore_spec.match_file(str(file_rel_path)):
-                continue
-
-            # Determined only supports POSIX-style file paths.  Use as_posix() in case this code
-            # is executed in a non-POSIX environment.
-            entry_path = file_rel_path.as_posix()
-
-            try:
-                entry = v1File_from_local_file(entry_path, file_path)
-            except OSError:
-                print(f"Error reading '{entry_path}', skipping this file.")
-                continue
-
-            add_item(entry)
-            if size > limit:
-                print()
-                raise ValueError(
-                    f"Directory '{root_path}' exceeds the maximum allowed size "
-                    f"{sizeof_fmt(constants.MAX_CONTEXT_SIZE)}.\n"
-                    "Consider using a .detignore file to specify that certain files "
-                    "or directories should be omitted from the context directory."
-                )
-
-            print(" " * len(msg), end="\r")
-            msg = (
-                f"Preparing files ({root_path}) to send to master... "
-                f"{sizeof_fmt(size)} and {len(items)} files"
+    if context_root is not None:
+        # --context must always be a directory.
+        if context_root.is_file():
+            raise ValueError(
+                f"context path '{context_root}' must be a directory, maybe use an include instead?"
             )
-            print(msg, end="\r", flush=True)
-    print()
-    return items
+        builder.add(context_root, pathlib.Path(""))
+    for i in includes:
+        # Some paths like "/" don't have a name we can assign within the tarball.
+        name = i.resolve().name
+        if not name:
+            raise ValueError(f"unable to determine the name of include '{i}'")
+        builder.add(i, pathlib.Path(name))
+
+    return builder.get_items()
 
 
 def read_legacy_context(
-    local_path: pathlib.Path,
+    context_root: Optional[pathlib.Path],
+    includes: Iterable[pathlib.Path] = (),
     limit: int = constants.MAX_CONTEXT_SIZE,
 ) -> LegacyContext:
-    return [v1File_to_dict(f) for f in read_v1_context(local_path, limit)]
+    return [v1File_to_dict(f) for f in read_v1_context(context_root, includes, limit)]

--- a/harness/determined/common/experimental/determined.py
+++ b/harness/determined/common/experimental/determined.py
@@ -1,6 +1,6 @@
 import pathlib
 import warnings
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, Iterable, List, Optional, Union
 
 from determined.common import api, context, util, yaml
 from determined.common.api import authentication, bindings, certs
@@ -68,6 +68,7 @@ class Determined:
         self,
         config: Union[str, pathlib.Path, Dict],
         model_dir: Union[str, pathlib.Path],
+        includes: Optional[Iterable[Union[str, pathlib.Path]]] = None,
     ) -> experiment.ExperimentReference:
         """
         Create an experiment with config parameters and model directory. The function
@@ -77,6 +78,8 @@ class Determined:
             config(string, pathlib.Path, dictionary): experiment config filename (.yaml)
                 or a dict.
             model_dir(string): directory containing model definition.
+            iterables (Iterable[Union[str, pathlib.Path]], optional): Additional files or
+                directories to include in the model definition.  (default: ``None``)
         """
         if isinstance(config, str):
             with open(config) as f:
@@ -96,7 +99,8 @@ class Determined:
         if isinstance(model_dir, str):
             model_dir = pathlib.Path(model_dir)
 
-        model_context = context.read_v1_context(model_dir)
+        path_includes = (pathlib.Path(i) for i in includes or [])
+        model_context = context.read_v1_context(model_dir, includes=path_includes)
 
         req = bindings.v1CreateExperimentRequest(
             # TODO: add this as a param to create_experiment()

--- a/harness/determined/experimental/client.py
+++ b/harness/determined/experimental/client.py
@@ -46,7 +46,7 @@ See :ref:`use-trained-models` for more ideas on what to do next.
 import functools
 import pathlib
 import warnings
-from typing import Any, Callable, Dict, List, Optional, Union
+from typing import Any, Callable, Dict, Iterable, List, Optional, Union
 
 from determined.common.api import Session  # noqa: F401
 from determined.common.experimental.checkpoint import (  # noqa: F401
@@ -143,18 +143,21 @@ def login(
 def create_experiment(
     config: Union[str, pathlib.Path, Dict],
     model_dir: str,
+    includes: Optional[Iterable[Union[str, pathlib.Path]]] = None,
 ) -> ExperimentReference:
     """
     Creates an experiment with config parameters and model directory. The function
     returns an :class:`~determined.experimental.client.ExperimentReference` of the experiment.
 
     Arguments:
-        config (string, pathlib.Path, dictionary): Experiment config filename (.yaml)
+        config (str, pathlib.Path, dictionary): Experiment config filename (.yaml)
             or a dict.
-        model_dir (string): Directory containing model definition.
+        model_dir (str): Directory containing model definition.
+        iterables (Iterable[Union[str, pathlib.Path]], optional): Additional files or directories to
+            include in the model definition.  (default: ``None``)
     """
     assert _determined is not None
-    return _determined.create_experiment(config, model_dir)
+    return _determined.create_experiment(config, model_dir, includes)
 
 
 @_require_singleton


### PR DESCRIPTION
## Description

This is especially useful for including just one or two files in
interactive workflows without having to create an empty context
directory and copy files into it.


## Test Plan

- [x] write automated tests
- [x] try `det e create const.yaml emtpy-dir/ -i model_def.py`
- [x] try `det notebook start -i myfile`
- [x] try `det tensorboard start -i myfile`
- [x] try `det command run -i myfile cat myfile`
- [x] try `det shell start -i myfile` 


## Commentary (optional)

This PR began life as #5087.