### PR TITLE
fix: hide uncategorized from nav, when it is not available to RBAC user [WEB-509]

### DIFF
--- a/webui/react/src/components/NavigationSideBar.tsx
+++ b/webui/react/src/components/NavigationSideBar.tsx
@@ -116,8 +116,15 @@ const NavigationSideBar: React.FC = () => {
   const shortVersion = version.replace(/^(\d+\.\d+\.\d+).*?$/i, '$1');
   const isVersionLong = version !== shortVersion;
 
-  const menuConfig = useMemo(
-    () => ({
+  const { canCreateWorkspace, canViewWorkspace } = usePermissions();
+
+  const canAccessUncategorized = canViewWorkspace({ workspace: { id: 1 } });
+
+  const menuConfig = useMemo(() => {
+    const topNav = canAccessUncategorized
+      ? [{ icon: 'experiment', label: 'Uncategorized', path: paths.uncategorized() }]
+      : [];
+    return {
       bottom: [
         { external: true, icon: 'docs', label: 'Docs', path: paths.docs(), popout: true },
         {
@@ -136,14 +143,13 @@ const NavigationSideBar: React.FC = () => {
         },
       ],
       top: [
-        { icon: 'experiment', label: 'Uncategorized', path: paths.uncategorized() },
+        ...topNav,
         { icon: 'model', label: 'Model Registry', path: paths.modelList() },
         { icon: 'tasks', label: 'Tasks', path: paths.taskList() },
         { icon: 'cluster', label: 'Cluster', path: paths.cluster() },
       ],
-    }),
-    [info.branding],
-  );
+    };
+  }, [canAccessUncategorized, info.branding]);
 
   const handleCollapse = useCallback(() => {
     updateSettings({ navbarCollapsed: !settings.navbarCollapsed });
@@ -152,8 +158,6 @@ const NavigationSideBar: React.FC = () => {
   const handleCreateWorkspace = useCallback(() => {
     openWorkspaceCreateModal();
   }, [openWorkspaceCreateModal]);
-
-  const { canCreateWorkspace } = usePermissions();
 
   if (!showNavigation) return null;
 


### PR DESCRIPTION
## Description

If an RBAC user has no permission to view the Uncategorized workspace (aka the default workspace/project) then that option should be hidden from navigation.  Other sections should be visible.

## Test Plan

- Visit `/det/models` and see Uncategorized in the left nav menu. With RBAC off there is no change
- Visit `/det/models?f_rbac=on` and see Uncategorized is hidden. In this setting with no permissions, it's hidden
- Visit `/det/models?f_rbac=on&f_mock_permissions_read=on` and Uncategorized reappears

## Checklist
- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.
- [x] If modifying `/webui/react/src/shared/` verify `make -C webui/react test-shared` passes.