### PR TITLE
chore: usePolling on fetchMyRoles [WEB-3]

### DIFF
--- a/webui/react/src/components/Navigation.tsx
+++ b/webui/react/src/components/Navigation.tsx
@@ -34,19 +34,21 @@ const Navigation: React.FC<Props> = ({ children }) => {
   usePolling(fetchPinnedWorkspaces);
   usePolling(fetchUserSettings, { interval: 60000 });
 
+  const rbacEnabled = useFeature().isOn('rbac');
+  usePolling(
+    () => {
+      if (rbacEnabled) {
+        fetchMyRoles();
+      }
+    },
+    { interval: 120000 },
+  );
+
   useEffect(() => {
     fetchResourcePools();
 
     return () => canceler.abort();
   }, [canceler, fetchResourcePools]);
-
-  const rbacEnabled = useFeature().isOn('rbac');
-  useEffect(() => {
-    if (rbacEnabled) {
-      fetchMyRoles();
-    }
-    return () => canceler.abort();
-  }, [canceler, fetchMyRoles, rbacEnabled]);
 
   return (
     <Spinner spinning={ui.showSpinner}>


### PR DESCRIPTION
## Description

Now that `fetchMyRoles` is called when we load Determined WebUI (#5185) , I am following the ticket to periodically request an update from the API for the relevant RBAC roles.  In this code it is every 120 seconds, but it could be adjusted. We previously implemented polling on `fetchUserSettings` every 60 seconds.

## Test Plan

When loading the WebUI with `?f_rbac=on`, you should see an immediate request to `permissions/summary`, and a following request 120 seconds later.

## Checklist
- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.
- [x] If modifying `/webui/react/src/shared/` verify `make -C webui/react test-shared` passes.