### PR TITLE
fix: only call fetchKnownRoles in RBAC, closing testing issue

### DIFF
--- a/webui/react/src/pages/Settings/GroupManagement.tsx
+++ b/webui/react/src/pages/Settings/GroupManagement.tsx
@@ -7,6 +7,7 @@ import InteractiveTable, {
 } from 'components/InteractiveTable';
 import Page from 'components/Page';
 import { defaultRowClassName, getFullPaginationConfig } from 'components/Table';
+import useFeature from 'hooks/useFeature';
 import { useFetchKnownRoles } from 'hooks/useFetch';
 import useModalCreateGroup from 'hooks/useModal/UserSettings/useModalCreateGroup';
 import useModalDeleteGroup from 'hooks/useModal/UserSettings/useModalDeleteGroup';
@@ -147,6 +148,7 @@ const GroupManagement: React.FC = () => {
     fetchUsers();
   }, [settings.tableLimit, settings.tableOffset, fetchGroups, fetchUsers]);
 
+  const rbacEnabled = useFeature().isOn('rbac');
   useEffect(() => {
     if (rbacEnabled) {
       fetchKnownRoles();

--- a/webui/react/src/pages/Settings/GroupManagement.tsx
+++ b/webui/react/src/pages/Settings/GroupManagement.tsx
@@ -148,8 +148,10 @@ const GroupManagement: React.FC = () => {
   }, [settings.tableLimit, settings.tableOffset, fetchGroups, fetchUsers]);
 
   useEffect(() => {
-    fetchKnownRoles();
-  }, [fetchKnownRoles]);
+    if (rbacEnabled) {
+      fetchKnownRoles();
+    }
+  }, [fetchKnownRoles, rbacEnabled]);
 
   const { modalOpen: openCreateGroupModal, contextHolder: modalCreateGroupContextHolder } =
     useModalCreateGroup({ onClose: fetchGroups, users: users });

--- a/webui/react/src/pages/Settings/UserManagement.tsx
+++ b/webui/react/src/pages/Settings/UserManagement.tsx
@@ -166,8 +166,10 @@ const UserManagement: React.FC = () => {
   }, [fetchGroups]);
 
   useEffect(() => {
-    fetchKnownRoles();
-  }, [fetchKnownRoles]);
+    if (rbacEnabled) {
+      fetchKnownRoles();
+    }
+  }, [fetchKnownRoles, rbacEnabled]);
 
   const { modalOpen: openCreateUserModal, contextHolder: modalCreateUserContextHolder } =
     useModalCreateUser({ groups, onClose: fetchUsers });


### PR DESCRIPTION
## Description

Tests of UserSettings and GroupSettings were calling fetchKnownRoles without RBAC responses. The error is supposed to be processed by handleError , but that's not possible during these tests.

Situation is resolved by only calling fetchKnownRoles when rbacEnabled 

## Test Plan

Passing CI

## Checklist
- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.
- [x] If modifying `/webui/react/src/shared/` verify `make -C webui/react test-shared` passes.
