### PR TITLE
fix: correctly aggregate allocation resources by agent label.

### DIFF
--- a/master/internal/command/command.go
+++ b/master/internal/command/command.go
@@ -300,7 +300,7 @@ func (c *command) Receive(ctx *actor.Context) error {
 			Group:             ctx.Self(),
 
 			SlotsNeeded:  c.Config.Resources.Slots,
-			Label:        c.Config.Resources.AgentLabel,
+			AgentLabel:   c.Config.Resources.AgentLabel,
 			ResourcePool: c.Config.Resources.ResourcePool,
 			FittingRequirements: sproto.FittingRequirements{
 				SingleAgent: true,

--- a/master/internal/rm/fair_share.go
+++ b/master/internal/rm/fair_share.go
@@ -134,7 +134,7 @@ func calculateGroupStates(
 	groupMapping := make(map[*group]*groupState)
 	for it := taskList.iterator(); it.next(); {
 		req := it.value()
-		if req.SlotsNeeded == 0 || req.SlotsNeeded > capacities[req.Label] {
+		if req.SlotsNeeded == 0 || req.SlotsNeeded > capacities[req.AgentLabel] {
 			continue
 		}
 		group := groups[req.Group]
@@ -144,7 +144,7 @@ func calculateGroupStates(
 				group:    group,
 				disabled: false,
 			}
-			states[req.Label] = append(states[req.Label], state)
+			states[req.AgentLabel] = append(states[req.AgentLabel], state)
 			groupMapping[group] = state
 		}
 		state.reqs = append(state.reqs, req)

--- a/master/internal/rm/fitting_methods.go
+++ b/master/internal/rm/fitting_methods.go
@@ -13,7 +13,7 @@ func slotsSatisfied(req *sproto.AllocateRequest, agent *AgentState) bool {
 }
 
 func labelSatisfied(req *sproto.AllocateRequest, agent *AgentState) bool {
-	return req.Label == agent.Label
+	return req.AgentLabel == agent.Label
 }
 
 func maxZeroSlotContainersSatisfied(req *sproto.AllocateRequest, agent *AgentState) bool {

--- a/master/internal/rm/fitting_test.go
+++ b/master/internal/rm/fitting_test.go
@@ -96,7 +96,7 @@ func TestFindFits(t *testing.T) {
 		},
 		{
 			Name: "0-slot multiple fits, label hard constraint",
-			Task: sproto.AllocateRequest{AllocationID: "task1", SlotsNeeded: 0, Label: "label2"},
+			Task: sproto.AllocateRequest{AllocationID: "task1", SlotsNeeded: 0, AgentLabel: "label2"},
 			Agents: []*mockAgent{
 				newMockAgent("agent1", "label1", 4, 0, 100, 0),
 				newMockAgent("agent2", "label2", 4, 0, 100, 0),
@@ -262,7 +262,7 @@ func TestFindFits(t *testing.T) {
 		},
 		{
 			Name: "4-slot multiple fits, label hard constraint",
-			Task: sproto.AllocateRequest{AllocationID: "task1", Label: "label2", SlotsNeeded: 4},
+			Task: sproto.AllocateRequest{AllocationID: "task1", AgentLabel: "label2", SlotsNeeded: 4},
 			Agents: []*mockAgent{
 				newMockAgent("agent1", "label1", 4, 0, 100, 0),
 				newMockAgent("agent2", "label2", 4, 0, 100, 0),

--- a/master/internal/rm/priority.go
+++ b/master/internal/rm/priority.go
@@ -410,6 +410,6 @@ func splitAgentsByLabel(
 
 func taskFilter(label string, zeroSlots bool) func(*sproto.AllocateRequest) bool {
 	return func(request *sproto.AllocateRequest) bool {
-		return request.Label == label && (request.SlotsNeeded == 0) == zeroSlots
+		return request.AgentLabel == label && (request.SlotsNeeded == 0) == zeroSlots
 	}
 }

--- a/master/internal/rm/scheduler_test.go
+++ b/master/internal/rm/scheduler_test.go
@@ -82,7 +82,7 @@ func (t *mockTask) Receive(ctx *actor.Context) error {
 			Name:              string(t.id),
 			SlotsNeeded:       t.slotsNeeded,
 			Preemptible:       !t.nonPreemptible,
-			Label:             t.label,
+			AgentLabel:        t.label,
 			ResourcePool:      t.resourcePool,
 			AllocationRef:     ctx.Self(),
 		}
@@ -334,7 +334,7 @@ func mockTaskToAllocateRequest(
 		AllocationID:      mockTask.id,
 		JobID:             model.JobID(jobID),
 		SlotsNeeded:       mockTask.slotsNeeded,
-		Label:             mockTask.label,
+		AgentLabel:        mockTask.label,
 		IsUserVisible:     true,
 		AllocationRef:     allocationRef,
 		Preemptible:       !mockTask.nonPreemptible,

--- a/master/internal/sproto/task.go
+++ b/master/internal/sproto/task.go
@@ -36,7 +36,7 @@ type (
 
 		// Resource configuration.
 		SlotsNeeded         int
-		Label               string
+		AgentLabel          string
 		ResourcePool        string
 		FittingRequirements FittingRequirements
 

--- a/master/internal/task/allocation.go
+++ b/master/internal/task/allocation.go
@@ -143,7 +143,7 @@ func NewAllocation(
 			AllocationID: req.AllocationID,
 			TaskID:       req.TaskID,
 			Slots:        req.SlotsNeeded,
-			AgentLabel:   req.Name,
+			AgentLabel:   req.AgentLabel,
 			ResourcePool: req.ResourcePool,
 		},
 

--- a/master/internal/trial.go
+++ b/master/internal/trial.go
@@ -288,7 +288,7 @@ func (t *trial) maybeAllocateTask(ctx *actor.Context) error {
 			AllocationRef:     ctx.Self(),
 			Group:             ctx.Self().Parent(),
 			SlotsNeeded:       t.config.Resources().SlotsPerTrial(),
-			Label:             t.config.Resources().AgentLabel(),
+			AgentLabel:        t.config.Resources().AgentLabel(),
 			ResourcePool:      t.config.Resources().ResourcePool(),
 			FittingRequirements: sproto.FittingRequirements{
 				SingleAgent: false,
@@ -323,7 +323,7 @@ func (t *trial) maybeAllocateTask(ctx *actor.Context) error {
 		Group:             ctx.Self().Parent(),
 
 		SlotsNeeded:  t.config.Resources().SlotsPerTrial(),
-		Label:        t.config.Resources().AgentLabel(),
+		AgentLabel:   t.config.Resources().AgentLabel(),
 		ResourcePool: t.config.Resources().ResourcePool(),
 		FittingRequirements: sproto.FittingRequirements{
 			SingleAgent: false,


### PR DESCRIPTION
## Description

Resource aggregation has been incorrectly using the task name instead of agent label.

<img width="1805" alt="Screen Shot 2022-10-06 at 20 10 31" src="https://user-images.githubusercontent.com/839187/194459910-73a8b592-5ec8-41ac-ad40-ec1dc3556f7b.png">

## Test Plan

## Commentary (optional)

Also rename `Label` field to `AgentLabel` because we have so many different labels.

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist
- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.
- [ ] If modifying `/webui/react/src/shared/` verify `make -C webui/react test-shared` passes.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
