### PR TITLE
chore: Round Robin scheduler message [WEB-515]

### DIFF
--- a/webui/react/src/pages/ResourcepoolDetail.tsx
+++ b/webui/react/src/pages/ResourcepoolDetail.tsx
@@ -11,16 +11,16 @@ import { V1SchedulerTypeToLabel } from 'constants/states';
 import { useStore } from 'contexts/Store';
 import { paths } from 'routes/utils';
 import { getJobQStats } from 'services/api';
-import { V1GetJobQueueStatsResponse, V1RPQueueStat } from 'services/api-ts-sdk';
+import { V1GetJobQueueStatsResponse, V1RPQueueStat, V1SchedulerType } from 'services/api-ts-sdk';
 import Icon from 'shared/components/Icon/Icon';
+import Message, { MessageType } from 'shared/components/Message';
 import usePolling from 'shared/hooks/usePolling';
 import { clone } from 'shared/utils/data';
 import { ErrorLevel, ErrorType } from 'shared/utils/error';
 import { camelCaseToSentence } from 'shared/utils/string';
 import { floatToPercent } from 'shared/utils/string';
 import { ShirtSize } from 'themes';
-import { ResourceState } from 'types';
-import { JobState } from 'types';
+import { JobState, ResourceState } from 'types';
 import { getSlotContainerStates } from 'utils/cluster';
 import handleError from 'utils/error';
 
@@ -135,6 +135,7 @@ const ResourcepoolDetail: React.FC = () => {
   }, [pool]);
 
   if (!pool) return <div />;
+
   return (
     <Page className={css.poolDetailPage}>
       <Section>
@@ -158,24 +159,35 @@ const ResourcepoolDetail: React.FC = () => {
         />
       </Section>
       <Section>
-        <Tabs
-          activeKey={tabKey}
-          className="no-padding"
-          destroyInactiveTabPane={true}
-          onChange={handleTabChange}>
-          <TabPane key={TabType.Active} tab={`${poolStats?.stats.scheduledCount ?? ''} Active`}>
-            <JobQueue bodyNoPadding jobState={JobState.SCHEDULED} selectedRp={pool} />
-          </TabPane>
-          <TabPane key={TabType.Queued} tab={`${poolStats?.stats.queuedCount ?? ''} Queued`}>
-            <JobQueue bodyNoPadding jobState={JobState.QUEUED} selectedRp={pool} />
-          </TabPane>
-          <TabPane key={TabType.Stats} tab="Stats">
-            <ClustersQueuedChart poolStats={poolStats} />
-          </TabPane>
-          <TabPane key={TabType.Configuration} tab="Configuration">
-            {renderPoolConfig()}
-          </TabPane>
-        </Tabs>
+        {pool.schedulerType === V1SchedulerType.ROUNDROBIN ? (
+          <Page className={css.poolDetailPage}>
+            <Section>
+              <Message
+                title="Resource Pool is unavailable for Round Robin schedulers."
+                type={MessageType.Empty}
+              />
+            </Section>
+          </Page>
+        ) : (
+          <Tabs
+            activeKey={tabKey}
+            className="no-padding"
+            destroyInactiveTabPane={true}
+            onChange={handleTabChange}>
+            <TabPane key={TabType.Active} tab={`${poolStats?.stats.scheduledCount ?? ''} Active`}>
+              <JobQueue bodyNoPadding jobState={JobState.SCHEDULED} selectedRp={pool} />
+            </TabPane>
+            <TabPane key={TabType.Queued} tab={`${poolStats?.stats.queuedCount ?? ''} Queued`}>
+              <JobQueue bodyNoPadding jobState={JobState.QUEUED} selectedRp={pool} />
+            </TabPane>
+            <TabPane key={TabType.Stats} tab="Stats">
+              <ClustersQueuedChart poolStats={poolStats} />
+            </TabPane>
+            <TabPane key={TabType.Configuration} tab="Configuration">
+              {renderPoolConfig()}
+            </TabPane>
+          </Tabs>
+        )}
       </Section>
     </Page>
   );


### PR DESCRIPTION
## Description

Request was that on a round-robin scheduler type cluster, we obscure the usual information on the resource pool page and instead show a message about the scheduler type.

<img width="674" alt="Screen Shot 2022-10-07 at 10 18 56 AM" src="https://user-images.githubusercontent.com/643918/194589738-ea11a761-737d-4572-818a-ce6c6bf54657.png">

Let me know if we should hide other elements on this page.

## Test Plan

If you are familiar with the resource pool system, feel free to test on a resource pool with round robin scheduler type

Testing locally, I edited `master/internal/rm/agent_resource_manager.go` , around line 514 , to always return `schedulerType = resourcepoolv1.SchedulerType_SCHEDULER_TYPE_ROUND_ROBIN`

## Checklist
- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.
- [x] If modifying `/webui/react/src/shared/` verify `make -C webui/react test-shared` passes.