### PR TITLE
fix: custom error requires permission object

### DIFF
--- a/master/internal/authz/permission_denied_error.go
+++ b/master/internal/authz/permission_denied_error.go
@@ -10,7 +10,7 @@ import (
 // PermissionDeniedError represents an error that arises when a user does not have sufficient
 // access privileges. RequiredPermissions can be empty for non-rbac errors.
 type PermissionDeniedError struct {
-	RequiredPermissions []*rbacv1.Permission
+	RequiredPermissions []rbacv1.PermissionType
 }
 
 // Error returns an error string.
@@ -21,7 +21,7 @@ func (p PermissionDeniedError) Error() string {
 
 	permissions := make([]string, len(p.RequiredPermissions))
 	for i, perm := range p.RequiredPermissions {
-		permissions[i] = perm.Name
+		permissions[i] = rbacv1.PermissionType_name[int32(perm)]
 	}
 	return fmt.Sprintf("access denied; required permissions: %s", strings.Join(
 		permissions, ", "))


### PR DESCRIPTION
## Description
The custom `PermissionDeniedError` previously took in a `Permission` object that required overhead to build - this change makes the error take in `PermissionType` (int32) which is much more efficient and cuts unnecessary struct building.
<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At a minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions about this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist
- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.
- [ ] If modifying `/webui/react/src/shared/` verify `make -C webui/react test-shared` passes.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
