### PR TITLE
fix: Roles should be fetched immediately when logging in

### DIFF
--- a/webui/react/src/components/DeterminedAuth.tsx
+++ b/webui/react/src/components/DeterminedAuth.tsx
@@ -3,6 +3,7 @@ import React, { useCallback, useState } from 'react';
 
 import Link from 'components/Link';
 import { StoreAction, useStoreDispatch } from 'contexts/Store';
+import { useFetchMyRoles } from 'hooks/useFetch';
 import { paths } from 'routes/utils';
 import { login } from 'services/api';
 import { updateDetApi } from 'services/apiConfig';
@@ -29,6 +30,7 @@ const STORAGE_KEY_LAST_USERNAME = 'lastUsername';
 
 const DeterminedAuth: React.FC<Props> = ({ canceler }: Props) => {
   const storeDispatch = useStoreDispatch();
+  const fetchMyRoles = useFetchMyRoles(canceler);
   const [isBadCredentials, setIsBadCredentials] = useState(false);
   const [canSubmit, setCanSubmit] = useState(!!storage.get(STORAGE_KEY_LAST_USERNAME));
 
@@ -49,6 +51,7 @@ const DeterminedAuth: React.FC<Props> = ({ canceler }: Props) => {
           type: StoreAction.SetAuth,
           value: { isAuthenticated: true, token, user },
         });
+        fetchMyRoles();
         storage.set(STORAGE_KEY_LAST_USERNAME, creds.username);
       } catch (e) {
         const isBadCredentialsSync = isLoginFailure(e);


### PR DESCRIPTION
## Description

This fixes an issue noticed by @ioga where it took a bit to populate roles when logging in. This happened because we immediately fetch roles when the page loads then poll for them on an interval; the initial call fails because the user is not yet logged in. There are broader problems with this method of data fetching but I'm not addressing those in this PR.

Specifically for roles I added a fetch when a user logs in.


## Test Plan

1. Run devcluster against determined-ee with rba enabled
2. Without this change, log in and navigate to http://localhost:3000/settings/user-management
3. log out then log back in, note the page is blank but populates after a few seconds
4. Apply this change
5. Log out then log back in, note the page immediately lists users


## Commentary

It seems to me that we might need to [all of these fetches]() to the login action. Were these working correctly before rbac? Did the API maybe not check if you were logged in prior to rbac when performing certain GETs?


## Checklist
- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.
- [x] If modifying `/webui/react/src/shared/` verify `make -C webui/react test-shared` passes.

## Ticket
No ticket