### PR TITLE
chore: support out-of-k8s dev workflow [DET-8107]

### DIFF
--- a/master/internal/config/resource_manager_config.go
+++ b/master/internal/config/resource_manager_config.go
@@ -106,6 +106,9 @@ type KubernetesResourceManagerConfig struct {
 	SlotType                 device.Type                        `json:"slot_type"`
 	SlotResourceRequests     kubernetes.PodSlotResourceRequests `json:"slot_resource_requests"`
 	Fluent                   kubernetes.FluentConfig            `json:"fluent"`
+	CredsDir                 string                             `json:"_creds_dir,omitempty"`
+	MasterIP                 string                             `json:"_master_ip,omitempty"`
+	MasterPort               int32                              `json:"_master_port,omitempty"`
 }
 
 var defaultKubernetesResourceManagerConfig = KubernetesResourceManagerConfig{

--- a/master/internal/rm/kubernetes_resource_manager.go
+++ b/master/internal/rm/kubernetes_resource_manager.go
@@ -200,6 +200,9 @@ func (k *kubernetesResourceManager) Receive(ctx *actor.Context) error {
 			k.config.SlotType,
 			kubernetes.PodSlotResourceRequests{CPU: k.config.SlotResourceRequests.CPU},
 			k.config.Fluent,
+			k.config.CredsDir,
+			k.config.MasterIP,
+			k.config.MasterPort,
 		)
 
 	case

--- a/tools/k8s/README.md
+++ b/tools/k8s/README.md
@@ -1,0 +1,38 @@
+# Determined + Kubernetes Developer Guide
+
+This tooling exists to run Determined backed by Kubernetes, but outside of
+Kubernetes.  The reason for this is rapid development.  Each change to the
+`determined-master` can be tested with a quick recompile and rerun.
+
+## Step 1: Get a working kubernetes cluster
+
+To use these files, you'll need a working Kubernetes cluster (not included).
+I (rb) highly recommend [kind](https://github.com/kubernetes-sigs/kind), but
+[minikube](https://minikube.sigs.k8s.io/docs/) is also popular.
+
+If you want to configure a cloud cluster, these steps should work, but keep in
+mind that you'll need your `determined-master` instance to be accessible from
+all of your pods.  That means either port forwarding, or following these steps
+on some cloud machine.
+
+If you go the GKE cloude route, keep in mind that some GKE configurations
+create an API server that is not generally accessible.
+
+## Step 2: Install a suitable service account to your cluster
+
+Read `tools/k8s/my-service-account.yaml` so you know what it's doing, then apply
+it:
+
+```
+kubectl apply -f tools/k8s/my-service-account.yaml
+```
+
+This step is only required once after creating your cluster.
+
+## Step 3: Run `determined-master` with a special `devcluster.yaml`
+
+Read `tools/k8s/devcluster.yaml` so you know what it's doing, then run it:
+
+```
+devcluster -c tools/k8s/devcluster.yaml
+```

--- a/tools/k8s/devcluster.yaml
+++ b/tools/k8s/devcluster.yaml
@@ -1,0 +1,93 @@
+commands:
+  p: make -C harness clean build  # rebuild Python
+  w: make -C webui build          # rebuild Webui
+  c: make -C docs build           # rebuild doCs
+
+stages:
+  - db:
+      port: 5432
+      db_name: determined
+      password: postgres
+      container_name: determined_db
+      image_name: "postgres:10.14"
+      data_dir: ~/.postgres
+
+  # To run the application with valid service-account credentials, we'll
+  # fetch suitable credentials for `my-service-account`, and store them in
+  # /tmp/det-creds.  This runs as its own stage because k8s v1.24+ expects to
+  # only use time-limited tokens, which must be continuously refreshed.
+  # Run `tools/k8s/fetch-creds.sh --help` for more info.
+  - custom:
+      name: creds
+      cmd:
+        - tools/k8s/fetch-creds.sh
+        - /tmp/det-creds
+        - my-service-account
+      post:
+        - logcheck:
+            regex: successfully fetched initial token
+
+  # We'll run the coscheduler in a docker container.  In real life, if you are
+  # not actually developing a custom sheduler, you might choose to run the
+  # coscheduler via a k8s deployment, rather than here in devcluster.  But this
+  # also works and it illustrates how to combine fetch-creds.sh with a k8s
+  # application packaged as a docker image.
+  - custom_docker:
+      name: coscheduler
+      container_name: coscheduler
+      run_args:
+        # options for docker run
+        - "-v=/tmp/det-creds:/var/run/secrets/kubernetes.io/serviceaccount"
+        - "--env-file=/tmp/det-creds/docker-env-file"
+        - "--network=host"
+        # image name
+        - "k8s.gcr.io/scheduler-plugins/kube-scheduler:v0.21.6"
+        # command + args
+        - "kube-scheduler"
+        - "-v=7"
+        - "--scheduler-name=coscheduler"
+        - "--leader-elect=false"
+
+  - master:
+      pre:
+        - sh: make -C proto build
+        - sh: make -C master build
+        - sh: make -C tools prep-root
+        - sh: mkdir -p /tmp/determined-cp
+      post:
+        - logcheck:
+            regex: accepting incoming connections on port
+      cmdline:
+        - master/build/determined-master
+        - --config-file
+        - :config
+
+      config_file:
+        db:
+          host: localhost
+          port: 5432
+          password: postgres
+          user: postgres
+          name: determined
+        checkpoint_storage:
+          type: shared_fs
+          host_path: /tmp/determined-cp
+        cache:
+          cache_dir: /tmp/determined-cache
+        log:
+          level: debug
+        enable_cors: true
+        root: tools/build
+
+        resource_manager:
+          type: kubernetes
+          namespace: default
+          max_slots_per_pod: 1
+          slot_type: "cpu"
+          slot_resource_requests:
+            cpu: 1
+          default_scheduler: "coscheduler"
+          # Special settings for running determined-master outside of k8s:
+          _creds_dir: /tmp/det-creds
+          _master_ip: $DOCKER_LOCALHOST
+          _master_port: 8080

--- a/tools/k8s/fetch-creds.sh
+++ b/tools/k8s/fetch-creds.sh
@@ -1,0 +1,229 @@
+#!/bin/sh
+
+set -o pipefail
+set -e
+
+prog="$0"
+
+print_help () {
+    echo "usage: $prog [OPTIONS] OUTDIR SERVICE_ACCOUNT"
+    echo ""
+    echo "where OPTIONS may be any of:"
+    echo "  -h, --help             Show this output."
+    echo "  -c, --context CONTEXT  Specify a kubectl context to use."
+    echo "                         Default: use the kubectl default context."
+    echo "  -s, --static           Fetch static credentials once and exit."
+    echo "                         This is mostly useful for k8s before v1.21"
+    echo "                         when the TokenRequest API feature was not"
+    echo "                         yet GA."
+    echo "                         Default: fetch a fresh token every minute."
+    echo "  -p, --period PERIOD    Configure the wait time between refreshes."
+    echo "                         PERIOD will be passed to the sleep command."
+    echo "                         Default: 60"
+    echo "  -v, --verbose          Log more stuff to stdout."
+    echo ""
+    echo "This script uses kubectl to fetch suitable credentials for a"
+    echo "particular service account, which are stored in OUTDIR."
+    echo ""
+    echo "By default, $prog will run in a loop and continuously refresh the"
+    echo "credentials in OUTDIR."
+    echo ""
+    echo "If CONTEXT is not provided, the default k8s context will be used."
+    echo ""
+    echo "The resulting OUTDIR will look like:"
+    echo ""
+    echo "    OUTDIR"
+    echo "    ├── ca.crt           # a file expected by InClusterConfig()"
+    echo "    ├── token            # a file expected by InClusterConfig()"
+    echo "    ├── docker-env-file  # for docker run --env-file"
+    echo "    └── server           # for k8s apps without InClusterConfig()"
+    echo ""
+    echo "Afterwards, there are two recommended ways to use OUTDIR:"
+    echo ""
+    echo "  - Modify a k8s application to read from OUTDIR directly"
+    echo "    (for example, determined-master does this)"
+    echo ""
+    echo "  - Run an unmodified k8s application via docker run:"
+    echo ""
+    echo "      docker run \\"
+    echo "          -v OUTDIR:/var/run/secrets/kubernetes.io/serviceaccount \\"
+    echo "          --env-file OUTDIR/docker-env-file \\"
+    echo "          my_image_name"
+}
+
+context=""
+static=n
+period="60"
+verbose=n
+outdir=""
+account=""
+
+# Manually parse args since getopt varies across unices.
+while test -n "$1"; do
+    case "$1" in
+        # flags
+        --help) print_help && exit 0;;
+        -h)     print_help && exit 0;;
+        --context) context="$2"; shift; shift;;
+        -c)        context="$2"; shift; shift;;
+        --static) static=y; shift;;
+        -s)       static=y; shift;;
+        --period) period="$2"; shift; shift;;
+        -p)       period="$2"; shift; shift;;
+        --verbose) verbose=y; shift;;
+        -v)        verbose=y; shift;;
+
+        -*)     echo "unrecognized flag: $1" >&2 && exit 1;;
+
+        # positional arguments
+        *)
+            if [ -z "$outdir" ] ; then outdir="$1"
+            elif [ -z "$account" ]; then account="$1"
+            else
+                echo "too many positional arguments!" >&2
+                print_help >&2
+                exit 1
+            fi
+            shift;
+        ;;
+    esac
+done
+
+# detect required external tools (after processing --help)
+ok=y
+need_bin () {
+    if ! which "$1" >/dev/null 2>/dev/null ; then
+        echo "missing required executable: $1"
+        ok=n
+    fi
+}
+need_bin kubectl
+need_bin jq
+test "$ok" = n && exit 1
+
+if [ -z "$account" ] ; then
+    echo "too few positional arguments!" >&2
+    print_help >&2
+    exit 1
+fi
+
+if [ -z "$context" ] ; then
+    # by default, pick the current-context from kubectl config
+    context="$(kubectl config view -o json | jq -r '."current-context"')"
+fi
+
+# first extract server information from the kubectl config
+server_info="$(
+    kubectl config view --raw -o json \
+    | jq -r '.clusters[] | select(.name=="'"$context"'")'
+)"
+server_url="$(echo "$server_info" | jq -r '.cluster.server')"
+ca_crt="$(
+    echo "$server_info" \
+        | jq -r '.cluster."certificate-authority-data"' \
+        | base64 -d
+)"
+
+mkdir -p "$outdir"
+
+# Write the server info to OUTDIR.
+echo "$server_url" > "$outdir/server"
+echo "$ca_crt" > "$outdir/ca.crt"
+
+host="$(echo "$server_url" | sed -e 's|[^/]*//||; s/:[0-9]*$//')"
+
+# port is tricky; handle scheme://host:port and scheme://host
+port="$(echo "$server_url" | sed -e 's/^[^:]*:[^:]*://')"
+if [ "$port" = "$server_url" ] ; then
+    # scheme://host case (it didn't have enough colons to match the regex)
+    if echo "$port" | grep -q '^https' ; then
+        port="443"
+    else
+        port="80"
+    fi
+fi
+
+# --host=network mode doesn't work on macos
+if [ "$(uname)" = "Darwin" ] && [ "$host" = "127.0.0.1" ]; then
+    dockerhost="host.docker.internal"
+else
+    dockerhost="$host"
+fi
+
+# Write a suitable --env-file for a docker run command.  These variables are
+# what an unmodified k8s client will expect to see in its environment, when it
+# calls rest.InClusterConfig().
+cat > "$outdir/docker-env-file" << EOF
+KUBERNETES_SERVICE_HOST=$dockerhost
+KUBERNETES_SERVICE_PORT=$port
+EOF
+
+if [ "$static" = "y" ] ; then
+    # User specified a static tokens instead of the TokenRequest API.
+
+    secret_name="$(
+        kubectl get serviceaccounts "$account" -o json | jq -r .secrets[0].name
+    )"
+
+    # Make sure a secret was found.
+    if [ "$secret_name" = "null" ] ; then
+        echo "no secret found for service account \"$account\", is this a" >&2
+        echo "k8s installation with static service account keys enabled?" >&2
+        echo "(static service account keys are not created by default" >&2
+        echo "starting with k8s v1.24)" >&2
+        exit 1
+    fi
+
+    # Write the token to OUTDIR.
+    kubectl --context "$context" get secrets "$secret_name" -o json \
+        | jq -r '.data."token"' | base64 -d \
+        > "$outdir/token"
+
+    echo "$prog: success!"
+    if [ "$verbose" = "y" ] ; then
+        echo -e "\x1b[31mserver:\x1b[m"
+        cat "$outdir/server"
+        echo -e "\x1b[31mca.crt:\x1b[m"
+        cat "$outdir/ca.crt"
+        echo -e "\x1b[31mtoken:\x1b[m"
+        cat "$outdir/token"
+    fi
+    exit 0
+fi
+
+dump_token () {
+    # token is an rfc 7515 JWS in compressed serialization format.
+    # The format is "$b64url_protected.$b64url_payload.$b64url_signature".
+    token="$1"
+    # First, extract the payload between the two '.'s.
+    payload="$(echo "$token" | sed -e 's/^[^.]*\.//; s/\.[^.]*$//;')"
+    # Swap out characters from b64url encoding to standard b64 encoding.
+    payload="$(echo "$payload" | sed -e 's/\+/-/; s/_/\//')"
+    # Add standard b64 padding, which b64url encoding skips.
+    padding="$(
+        echo "$payload" \
+            | sed -e 's/....//g ; s/^.$/===/; s/^..$/==/; s/^[^=]../=/'
+    )"
+    echo "Got token:"
+    echo "$payload$padding" | base64 -d | jq -C
+}
+
+refresh_token () {
+    token="$(kubectl --context "$context" create token "$account")"
+    if [ "$verbose" = "y" ] ; then
+        dump_token "$token"
+    fi
+    echo "$token" > "$outdir/token"
+}
+
+refresh_token
+echo "$prog: successfully fetched initial token; starting refresh loop..."
+
+while true; do
+    # HACK: close stdout and stderr to avoid hangs in devcluster after SIGKILL.
+    # This will leave an orphaned sleep process, but that's pretty harmless.
+    sleep "$period" >/dev/null 2>/dev/null
+    if ! refresh_token ; then
+        echo "$prog: failed to refresh k8s token, will try again later..."
+    fi
+done

--- a/tools/k8s/my-service-account.yaml
+++ b/tools/k8s/my-service-account.yaml
@@ -1,0 +1,26 @@
+# Configure a service account with cluster-admin credentials.
+#
+# This is probably more permissions than what should be granted in a production
+# deployment, but this is ok for dev deployments, and it will work for both
+# determined-master and a custom scheduler application.
+#
+# Run `kubectl apply -f my-service-account.yaml` once on your k8s cluster for
+# the tools/k8s/devcluster.yaml to work.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: my-service-account
+  namespace: default
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: my-service-account
+subjects:
+- kind: ServiceAccount
+  name: my-service-account
+  namespace: default
+roleRef:
+  kind: ClusterRole
+  apiGroup: rbac.authorization.k8s.io
+  name: cluster-admin


### PR DESCRIPTION
## Description

See the [README in the PR](https://github.com/rb-determined-ai/determined/blob/local-k8s/tools/k8s/README.md) for more info.

## Commentary

* Adding dev flags to the master isn't strictly necessary, but it does make rebuilding and rerunning fast and easy.
* There are authentication plugins that you can use, which would make `fetch-creds.sh` unnecessary.  Basically, if `kubectl` can be configured to authenticate, so can any piece of go code.  I didn't pick that strategy for two reasons:
    * It is less flexible.  `fetch-creds.sh` works on unmodified k8s apps as well (as demonstrated with the coscheduler in this pr)
    * The auth plugins get compiled into the application, and are not guaranteed to work across versions.  `fetch-creds.sh` lets `kubectl` figure out the auth plugins and just uses the end-state credentials, which seems less fragile to me.