### PR TITLE
feat: support configuring agent self-shutdown for `det deploy aws`

### DIFF
--- a/docs/cluster-setup-guide/deploy-cluster/sysadmin-deploy-on-aws/install-on-aws.rst
+++ b/docs/cluster-setup-guide/deploy-cluster/sysadmin-deploy-on-aws/install-on-aws.rst
@@ -229,6 +229,11 @@ Spinning up or updating the Cluster
 
       -  Not set
 
+   -  -  ``--shut-down-on-connection-loss``, ``--no-shut-down-on-connection-loss``
+      -  Whether or not agent instances should automatically shut down when they lose connection to
+         the master.
+      -  Shut down automatically
+
 Tearing Down the Cluster
 ------------------------
 

--- a/docs/release-notes/det-deploy-clean-orphaned.rst
+++ b/docs/release-notes/det-deploy-clean-orphaned.rst
@@ -1,0 +1,7 @@
+:orphan:
+
+**Improvements**
+
+-  **Breaking Change:** ``det deploy aws`` by default now configures agent instances to
+   automatically shut down if they lose their connection to the master. The
+   ``--no-shut-down-agents-on-connection-loss`` option can be used to turn off this behavior.

--- a/harness/determined/deploy/aws/cli.py
+++ b/harness/determined/deploy/aws/cli.py
@@ -1,5 +1,6 @@
 import argparse
 import base64
+import json
 import re
 import sys
 from pathlib import Path
@@ -151,6 +152,11 @@ def deploy_aws(command: str, args: argparse.Namespace) -> None:
         with open(args.master_tls_key, "rb") as f:
             master_tls_key = base64.b64encode(f.read()).decode()
 
+    config_file_contents = {}
+
+    if args.shut_down_on_connection_loss:
+        config_file_contents["hooks"] = {"on_connection_lost": ["shutdown", "now"]}
+
     det_configs = {
         constants.cloudformation.KEYPAIR: args.keypair,
         constants.cloudformation.ENABLE_CORS: args.enable_cors,
@@ -185,6 +191,7 @@ def deploy_aws(command: str, args: argparse.Namespace) -> None:
         constants.cloudformation.AGENT_REATTACH_ENABLED: args.agent_reattach_enabled,
         constants.cloudformation.AGENT_RECONNECT_ATTEMPTS: args.agent_reconnect_attempts,
         constants.cloudformation.AGENT_RECONNECT_BACKOFF: args.agent_reconnect_backoff,
+        constants.cloudformation.AGENT_CONFIG_FILE_CONTENTS: json.dumps(config_file_contents),
     }
 
     if args.master_config_template_path:
@@ -508,6 +515,14 @@ args_description = Cmd(
                     type=int,
                     default=5,
                     help="time between reconnect attempts, with the exception of the first.",
+                ),
+                BoolOptArg(
+                    "--shut-down-agents-on-connection-loss",
+                    "--no-shut-down-agents-on-connection-loss",
+                    dest="shut_down_on_connection_loss",
+                    default=True,
+                    true_help="shut down agent instances on connection loss",
+                    false_help="do not shut down agent instances on connection loss",
                 ),
                 BoolOptArg(
                     "--update-terminate-agents",

--- a/harness/determined/deploy/aws/constants.py
+++ b/harness/determined/deploy/aws/constants.py
@@ -62,6 +62,7 @@ class cloudformation:
     AGENT_REATTACH_ENABLED = "AgentReattachEnabled"
     AGENT_RECONNECT_ATTEMPTS = "AgentReconnectAttempts"
     AGENT_RECONNECT_BACKOFF = "AgentReconnectBackoff"
+    AGENT_CONFIG_FILE_CONTENTS = "AgentConfigFileContents"
 
 
 class misc:

--- a/harness/determined/deploy/aws/deployment_types/govcloud.py
+++ b/harness/determined/deploy/aws/deployment_types/govcloud.py
@@ -44,6 +44,7 @@ class Govcloud(base.DeterminedDeployment):
         constants.cloudformation.AGENT_REATTACH_ENABLED,
         constants.cloudformation.AGENT_RECONNECT_ATTEMPTS,
         constants.cloudformation.AGENT_RECONNECT_BACKOFF,
+        constants.cloudformation.AGENT_CONFIG_FILE_CONTENTS,
     ]
 
     def deploy(self, no_prompt: bool, update_terminate_agents: bool) -> None:

--- a/harness/determined/deploy/aws/deployment_types/secure.py
+++ b/harness/determined/deploy/aws/deployment_types/secure.py
@@ -53,6 +53,7 @@ class Secure(base.DeterminedDeployment):
         constants.cloudformation.AGENT_REATTACH_ENABLED,
         constants.cloudformation.AGENT_RECONNECT_ATTEMPTS,
         constants.cloudformation.AGENT_RECONNECT_BACKOFF,
+        constants.cloudformation.AGENT_CONFIG_FILE_CONTENTS,
     ]
 
     def deploy(self, no_prompt: bool, update_terminate_agents: bool) -> None:

--- a/harness/determined/deploy/aws/deployment_types/simple.py
+++ b/harness/determined/deploy/aws/deployment_types/simple.py
@@ -36,6 +36,7 @@ class Simple(base.DeterminedDeployment):
         constants.cloudformation.AGENT_REATTACH_ENABLED,
         constants.cloudformation.AGENT_RECONNECT_ATTEMPTS,
         constants.cloudformation.AGENT_RECONNECT_BACKOFF,
+        constants.cloudformation.AGENT_CONFIG_FILE_CONTENTS,
     ]
 
     def deploy(self, no_prompt: bool, update_terminate_agents: bool) -> None:

--- a/harness/determined/deploy/aws/deployment_types/vpc.py
+++ b/harness/determined/deploy/aws/deployment_types/vpc.py
@@ -33,6 +33,7 @@ class VPCBase(base.DeterminedDeployment):
         constants.cloudformation.AGENT_REATTACH_ENABLED,
         constants.cloudformation.AGENT_RECONNECT_ATTEMPTS,
         constants.cloudformation.AGENT_RECONNECT_BACKOFF,
+        constants.cloudformation.AGENT_CONFIG_FILE_CONTENTS,
     ]
 
     def deploy(self, no_prompt: bool, update_terminate_agents: bool) -> None:

--- a/harness/determined/deploy/aws/templates/efs.yaml
+++ b/harness/determined/deploy/aws/templates/efs.yaml
@@ -170,6 +170,11 @@ Parameters:
     Description: Time between reconnect attempts, with the exception of the first.
     Default: 5
 
+  AgentConfigFileContents:
+    Type: String
+    Description: Contents of the agent config file
+    Default: ''
+
 
   CpuEnvImage:
     Type: String
@@ -812,6 +817,7 @@ Resources:
                 tag_value: det-agent-${AWS::StackName}
                 agent_reconnect_attempts: ${AgentReconnectAttempts}
                 agent_reconnect_backoff: ${AgentReconnectBackoff}
+                agent_config_file_contents: ${AgentConfigFileContents}
                 startup_script: |
                   apt-get update
                   apt-get -y install binutils

--- a/harness/determined/deploy/aws/templates/fsx.yaml
+++ b/harness/determined/deploy/aws/templates/fsx.yaml
@@ -170,6 +170,11 @@ Parameters:
     Description: Time between reconnect attempts, with the exception of the first.
     Default: 5
 
+  AgentConfigFileContents:
+    Type: String
+    Description: Contents of the agent config file
+    Default: ''
+
 
   CpuEnvImage:
     Type: String
@@ -832,6 +837,7 @@ Resources:
                 tag_value: det-agent-${AWS::StackName}
                 agent_reconnect_attempts: ${AgentReconnectAttempts}
                 agent_reconnect_backoff: ${AgentReconnectBackoff}
+                agent_config_file_contents: ${AgentConfigFileContents}
                 startup_script: |
                   wget -O - https://fsx-lustre-client-repo-public-keys.s3.amazonaws.com/fsx-ubuntu-public-key.asc | sudo apt-key add -
                   bash -c 'echo "deb https://fsx-lustre-client-repo.s3.amazonaws.com/ubuntu xenial main" > /etc/apt/sources.list.d/fsxlustreclientrepo.list && apt-get update'

--- a/harness/determined/deploy/aws/templates/govcloud.yaml
+++ b/harness/determined/deploy/aws/templates/govcloud.yaml
@@ -621,6 +621,7 @@ Resources:
                 ssh_key_name: ${Keypair}
                 tag_key: det-${AWS::StackName}
                 tag_value: det-agent-${AWS::StackName}
+                agent_config_file_contents: ${AgentConfigFileContents}
 
             scheme: $scheme
             cpu_env_image: ${CpuEnvImage}

--- a/harness/determined/deploy/aws/templates/secure.yaml
+++ b/harness/determined/deploy/aws/templates/secure.yaml
@@ -827,6 +827,7 @@ Resources:
                 ssh_key_name: ${Keypair}
                 tag_key: det-${AWS::StackName}
                 tag_value: det-agent-${AWS::StackName}
+                agent_config_file_contents: ${AgentConfigFileContents}
 
             scheme: $scheme
             cpu_env_image: ${CpuEnvImage}

--- a/harness/determined/deploy/aws/templates/simple.yaml
+++ b/harness/determined/deploy/aws/templates/simple.yaml
@@ -162,6 +162,11 @@ Parameters:
     Description: Time between reconnect attempts, with the exception of the first.
     Default: 5
 
+  AgentConfigFileContents:
+    Type: String
+    Description: Contents of the agent config file
+    Default: ''
+
 
   CpuEnvImage:
     Type: String
@@ -661,6 +666,7 @@ Resources:
                 tag_value: det-agent-${AWS::StackName}
                 agent_reconnect_attempts: ${AgentReconnectAttempts}
                 agent_reconnect_backoff: ${AgentReconnectBackoff}
+                agent_config_file_contents: ${AgentConfigFileContents}
 
             scheme: $scheme
             cpu_env_image: ${CpuEnvImage}

--- a/harness/determined/deploy/gcp/terraform/modules/compute/main.tf
+++ b/harness/determined/deploy/gcp/terraform/modules/compute/main.tf
@@ -203,6 +203,10 @@ resource "google_compute_instance" "agent_instance" {
         --network ${var.agent_docker_network} \
         --restart unless-stopped \
         -v /var/run/docker.sock:/var/run/docker.sock \
+        -v /usr/sbin/shutdown:/usr/sbin/shutdown \
+        -v /run/systemd/system:/run/systemd/system \
+        -v /var/run/dbus/system_bus_socket:/var/run/dbus/system_bus_socket \
+        -v /sys/fs/cgroup:/sys/fs/cgroup \
         -e DET_MASTER_HOST=${google_compute_instance.master_instance.network_interface.0.network_ip} \
         -e DET_RESOURCE_POOL=compute-pool \
         ${var.image_repo_prefix}/determined-agent:${var.det_version}  run --master-port=${var.port}

--- a/master/internal/config/provconfig/config.go
+++ b/master/internal/config/provconfig/config.go
@@ -20,22 +20,23 @@ const defaultMasterPort = "8080"
 
 // Config describes config for provisioner.
 type Config struct {
-	MasterURL              string            `json:"master_url"`
-	MasterCertName         string            `json:"master_cert_name"`
-	StartupScript          string            `json:"startup_script"`
-	ContainerStartupScript string            `json:"container_startup_script"`
-	AgentDockerNetwork     string            `json:"agent_docker_network"`
-	AgentDockerRuntime     string            `json:"agent_docker_runtime"`
-	AgentDockerImage       string            `json:"agent_docker_image"`
-	AgentFluentImage       string            `json:"agent_fluent_image"`
-	AgentReconnectAttempts int               `json:"agent_reconnect_attempts"`
-	AgentReconnectBackoff  int               `json:"agent_reconnect_backoff"`
-	AWS                    *AWSClusterConfig `union:"type,aws" json:"-"`
-	GCP                    *GCPClusterConfig `union:"type,gcp" json:"-"`
-	MaxIdleAgentPeriod     model.Duration    `json:"max_idle_agent_period"`
-	MaxAgentStartingPeriod model.Duration    `json:"max_agent_starting_period"`
-	MinInstances           int               `json:"min_instances"`
-	MaxInstances           int               `json:"max_instances"`
+	MasterURL               string            `json:"master_url"`
+	MasterCertName          string            `json:"master_cert_name"`
+	StartupScript           string            `json:"startup_script"`
+	ContainerStartupScript  string            `json:"container_startup_script"`
+	AgentDockerNetwork      string            `json:"agent_docker_network"`
+	AgentDockerRuntime      string            `json:"agent_docker_runtime"`
+	AgentDockerImage        string            `json:"agent_docker_image"`
+	AgentFluentImage        string            `json:"agent_fluent_image"`
+	AgentReconnectAttempts  int               `json:"agent_reconnect_attempts"`
+	AgentReconnectBackoff   int               `json:"agent_reconnect_backoff"`
+	AgentConfigFileContents json.RawMessage   `json:"agent_config_file_contents"`
+	AWS                     *AWSClusterConfig `union:"type,aws" json:"-"`
+	GCP                     *GCPClusterConfig `union:"type,gcp" json:"-"`
+	MaxIdleAgentPeriod      model.Duration    `json:"max_idle_agent_period"`
+	MaxAgentStartingPeriod  model.Duration    `json:"max_agent_starting_period"`
+	MinInstances            int               `json:"min_instances"`
+	MaxInstances            int               `json:"max_instances"`
 }
 
 // DefaultConfig returns the default configuration of the provisioner.

--- a/master/internal/rm/provisioner/agent_setup.go
+++ b/master/internal/rm/provisioner/agent_setup.go
@@ -16,6 +16,7 @@ type agentSetupScriptConfig struct {
 	StartupScriptBase64          string
 	ContainerStartupScriptBase64 string
 	MasterCertBase64             string
+	ConfigFileBase64             string
 	SlotType                     device.Type
 	AgentDockerRuntime           string
 	AgentNetwork                 string

--- a/master/internal/rm/provisioner/agent_setup_test.go
+++ b/master/internal/rm/provisioner/agent_setup_test.go
@@ -48,6 +48,11 @@ echo "#### PRINTING STARTUP SCRIPT END ####"
 chmod +x /usr/local/determined/startup_script
 /usr/local/determined/startup_script
 
+echo  | base64 --decode > /usr/local/determined/agent.yaml
+echo "#### PRINTING CONFIG FILE START ####"
+cat /usr/local/determined/agent.yaml
+echo "#### PRINTING CONFIG FILE END ####"
+
 slot_type="cuda"
 if [ $slot_type == "cuda" ] || [ $slot_type == "gpu" ]; then
     echo "#### Starting agent with NVIDIA GPUs"
@@ -78,6 +83,7 @@ cat /usr/local/determined/container_startup_script
 echo "#### PRINTING CONTAINER STARTUP SCRIPT END ####"
 
 docker run --init --name determined-agent  \
+    --privileged \
     --restart always \
     --network default \
     --runtime=runc \
@@ -89,8 +95,13 @@ docker run --init --name determined-agent  \
     -e DET_FLUENT_IMAGE="fluent-test" \
     -e DET_AGENT_RECONNECT_ATTEMPTS="5" \
     -e DET_AGENT_RECONNECT_BACKOFF="5" \
+    -v /usr/sbin/shutdown:/usr/sbin/shutdown \
+    -v /run/systemd/system:/run/systemd/system \
+    -v /var/run/dbus/system_bus_socket:/var/run/dbus/system_bus_socket \
+    -v /sys/fs/cgroup:/sys/fs/cgroup \
     -v /var/run/docker.sock:/var/run/docker.sock \
     -v /usr/local/determined/container_startup_script:/usr/local/determined/container_startup_script \
+    -v /usr/local/determined/agent.yaml:/etc/determined/agent.yaml \
     "${docker_args[@]}" \
     "test_docker_image"
 `

--- a/master/internal/rm/provisioner/aws.go
+++ b/master/internal/rm/provisioner/aws.go
@@ -85,6 +85,7 @@ func newAWSCluster(
 		}
 	}
 	masterCertBase64 := base64.StdEncoding.EncodeToString(certBytes)
+	configFileBase64 := base64.StdEncoding.EncodeToString(config.AgentConfigFileContents)
 
 	cluster := &awsCluster{
 		resourcePool:     resourcePool,
@@ -98,6 +99,7 @@ func newAWSCluster(
 			StartupScriptBase64:          startupScriptBase64,
 			ContainerStartupScriptBase64: containerScriptBase64,
 			MasterCertBase64:             masterCertBase64,
+			ConfigFileBase64:             configFileBase64,
 			SlotType:                     config.AWS.SlotType(),
 			AgentDockerRuntime:           config.AgentDockerRuntime,
 			AgentNetwork:                 config.AgentDockerNetwork,
@@ -337,12 +339,13 @@ func (c *awsCluster) launchInstances(instanceNum int, dryRun bool) (*ec2.Reserva
 				},
 			},
 		},
-		DryRun:       aws.Bool(dryRun),
-		ImageId:      aws.String(c.ImageID),
-		InstanceType: aws.String(c.AWSClusterConfig.InstanceType.Name()),
-		KeyName:      aws.String(c.SSHKeyName),
-		MaxCount:     aws.Int64(int64(instanceNum)),
-		MinCount:     aws.Int64(1),
+		DryRun:                            aws.Bool(dryRun),
+		ImageId:                           aws.String(c.ImageID),
+		InstanceInitiatedShutdownBehavior: aws.String(ec2.ShutdownBehaviorTerminate),
+		InstanceType:                      aws.String(c.AWSClusterConfig.InstanceType.Name()),
+		KeyName:                           aws.String(c.SSHKeyName),
+		MaxCount:                          aws.Int64(int64(instanceNum)),
+		MinCount:                          aws.Int64(1),
 		TagSpecifications: []*ec2.TagSpecification{
 			{
 				ResourceType: aws.String("instance"),

--- a/master/static/srv/agent_setup_script.sh.template
+++ b/master/static/srv/agent_setup_script.sh.template
@@ -10,6 +10,11 @@ echo "#### PRINTING STARTUP SCRIPT END ####"
 chmod +x /usr/local/determined/startup_script
 /usr/local/determined/startup_script
 
+echo {{.ConfigFileBase64}} | base64 --decode > /usr/local/determined/agent.yaml
+echo "#### PRINTING CONFIG FILE START ####"
+cat /usr/local/determined/agent.yaml
+echo "#### PRINTING CONFIG FILE END ####"
+
 slot_type="{{.SlotType}}"
 if [ $slot_type == "cuda" ] || [ $slot_type == "gpu" ]; then
     echo "#### Starting agent with NVIDIA GPUs"
@@ -40,6 +45,7 @@ cat /usr/local/determined/container_startup_script
 echo "#### PRINTING CONTAINER STARTUP SCRIPT END ####"
 
 docker run --init --name determined-agent {{.LogOptions}} \
+    --privileged \
     --restart always \
     --network {{.AgentNetwork}} \
     --runtime={{.AgentDockerRuntime}} \
@@ -51,7 +57,12 @@ docker run --init --name determined-agent {{.LogOptions}} \
     -e DET_FLUENT_IMAGE="{{.AgentFluentImage}}" \
     -e DET_AGENT_RECONNECT_ATTEMPTS="{{.AgentReconnectAttempts}}" \
     -e DET_AGENT_RECONNECT_BACKOFF="{{.AgentReconnectBackoff}}" \
+    -v /usr/sbin/shutdown:/usr/sbin/shutdown \
+    -v /run/systemd/system:/run/systemd/system \
+    -v /var/run/dbus/system_bus_socket:/var/run/dbus/system_bus_socket \
+    -v /sys/fs/cgroup:/sys/fs/cgroup \
     -v /var/run/docker.sock:/var/run/docker.sock \
     -v /usr/local/determined/container_startup_script:/usr/local/determined/container_startup_script \
+    -v /usr/local/determined/agent.yaml:/etc/determined/agent.yaml \
     "${docker_args[@]}" \
     "{{.AgentDockerImage}}"


### PR DESCRIPTION
## Description

This just threads through a command-line option to `det deploy aws` all the way down to adding the appropriate config entry to the agent. Since the hook is configured in a nested object in the config and has a list value, I didn't want to use another environment variable to configure it, so the provisioner config now includes a free-form JSON field that gets inserted into the agent config file.

The new arguments to `docker run` in the agent setup script are necessary to access and run `shutdown` from within the container.

## Test Plan

- [x] run a cluster with `det deploy aws`, manually stop the master Docker container, make sure the agents shut down and terminate after trying to reconnect

## Commentary (optional)

Might be a bit weird to have `loss` here and `lost` in the agent config. For some reason each of those sounds the most natural to me in its own context, but I'd be willing to change either one to match the other.