### PR TITLE
fix: position resize shadow under cursor at start

### DIFF
--- a/webui/react/src/components/InteractiveTable.tsx
+++ b/webui/react/src/components/InteractiveTable.tsx
@@ -21,6 +21,7 @@ import {
   DraggableEventHandler,
 } from 'react-draggable';
 
+import SkeletonTable from 'components/Skeleton/SkeletonTable';
 import useResize from 'hooks/useResize';
 import { UpdateSettings } from 'hooks/useSettings';
 import Spinner from 'shared/components/Spinner/Spinner';
@@ -28,7 +29,6 @@ import { Primitive, UnknownRecord } from 'shared/types';
 import { isEqual } from 'shared/utils/data';
 
 import css from './InteractiveTable.module.scss';
-import SkeletonTable from './Skeleton/SkeletonTable';
 
 /*
  * This indicates that the cell contents are rightClickable
@@ -113,6 +113,7 @@ interface HeaderCellProps {
   filterActive: boolean;
   index: number;
   isResizing: boolean;
+  minWidth: number;
   moveColumn: (source: number, destination: number) => void;
   onResize: (e: DraggableEvent, data: DraggableData) => number;
   onResizeStart: DraggableEventHandler;
@@ -241,6 +242,7 @@ const HeaderCell = ({
   className,
   columnName,
   filterActive,
+  minWidth,
   moveColumn,
   index,
   title: unusedTitleFromAntd,
@@ -306,19 +308,22 @@ const HeaderCell = ({
       <div
         className={`${className} ${css.columnDraggingDiv}`}
         ref={drag}
-        title={columnName}
+        title={unusedTitleFromAntd as string}
         onClick={(e) => e.stopPropagation()}
         {...props}
       />
       <DraggableCore
         nodeRef={resizingRef}
         onDrag={(e, data) => {
-          const minWidth = onResize(e, data);
+          onResize(e, data);
           const newWidth = data.x < minWidth ? minWidth : data.x;
 
           if (newWidth !== xValue) setXValue(newWidth);
         }}
         onStart={(e, data) => {
+          setShadowVisibility('block');
+          const newWidth = data.x < minWidth ? minWidth : data.x;
+          if (newWidth !== xValue) setXValue(newWidth);
           onResizeStart(e, data);
           setShadowVisibility('block');
         }}
@@ -475,7 +480,7 @@ const InteractiveTable: InteractiveTable = ({
       return (e: Event, { x }: DraggableData) => {
         if (timeout.current) clearTimeout(timeout.current);
         const column = settings.columns[resizeIndex];
-        const minWidth = columnDefs[column].defaultWidth;
+        const minWidth = columnDefs[column]?.defaultWidth ?? 40;
         const currentWidths = widthData.widths;
 
         if (x === currentWidths[resizeIndex]) return;
@@ -511,8 +516,6 @@ const InteractiveTable: InteractiveTable = ({
         timeout.current = setTimeout(() => {
           setWidthData({ dropLeftStyles, dropRightStyles, widths: targetWidths });
         }, DEFAULT_RESIZE_THROTTLE_TIME);
-
-        return minWidth;
       };
     },
     [settings.columns, widthData.widths, pageWidth, columnDefs],
@@ -526,7 +529,7 @@ const InteractiveTable: InteractiveTable = ({
         setWidthData(({ widths, ...rest }) => {
           const column = settings.columns[index];
           const startWidth = widths[index];
-          const minWidth = columnDefs[column].defaultWidth;
+          const minWidth = columnDefs[column]?.defaultWidth ?? 40;
           const deltaX = startWidth - minWidth;
           const minX = x - deltaX;
           return { minX, widths, ...rest };
@@ -553,6 +556,7 @@ const InteractiveTable: InteractiveTable = ({
           filterActive,
           index,
           isResizing,
+          minWidth: columnDef.defaultWidth,
           moveColumn,
           onResize: handleResize(index),
           onResizeStart: handleResizeStart(index),

--- a/webui/react/src/components/InteractiveTable.tsx
+++ b/webui/react/src/components/InteractiveTable.tsx
@@ -308,7 +308,7 @@ const HeaderCell = ({
       <div
         className={`${className} ${css.columnDraggingDiv}`}
         ref={drag}
-        title={unusedTitleFromAntd as string}
+        title={columnName}
         onClick={(e) => e.stopPropagation()}
         {...props}
       />


### PR DESCRIPTION
## Before: 
when clicking between columns to begin resize, the resize shadow was positioned at the beginning of the column, instead of under the cursor

## After:
the resize shadow is positioned under the cursor

## Test Plan

verify the above, and verify that the rest of the existing resize behavior is preserved.

## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist
- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.
- [ ] If modifying `/webui/react/src/shared/` verify `make -C webui/react test-shared` passes.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
