### PR TITLE
fix: Avatar text color change (DET-8237)

### DIFF
--- a/webui/react/src/shared/components/Avatar/Avatar.module.scss
+++ b/webui/react/src/shared/components/Avatar/Avatar.module.scss
@@ -1,7 +1,6 @@
 .base {
   align-items: center;
   border-radius: 100%;
-  color: white;
   display: flex;
   font-size: 10px;
   font-weight: bold;

--- a/webui/react/src/shared/components/Avatar/Avatar.tsx
+++ b/webui/react/src/shared/components/Avatar/Avatar.tsx
@@ -56,8 +56,8 @@ const Avatar: React.FC<Props> = ({
 }) => {
   const style = {
     backgroundColor: noColor ? 'var(--theme-stage-strong)' : getColor(displayName, darkLight),
-    color: noColor ? 'var(--theme-stage-on-strong)' : 'white',
     borderRadius: square ? '10%' : '100%',
+    color: noColor ? 'var(--theme-stage-on-strong)' : 'white',
   };
   const classes = [css.base, css[size]];
 

--- a/webui/react/src/shared/components/Avatar/Avatar.tsx
+++ b/webui/react/src/shared/components/Avatar/Avatar.tsx
@@ -56,6 +56,7 @@ const Avatar: React.FC<Props> = ({
 }) => {
   const style = {
     backgroundColor: noColor ? 'var(--theme-stage-strong)' : getColor(displayName, darkLight),
+    color: noColor ? 'var(--theme-stage-on-strong)' : 'white',
     borderRadius: square ? '10%' : '100%',
   };
   const classes = [css.base, css[size]];


### PR DESCRIPTION
## Description

using dark/light text color for avatars in `noColor` mode. no changes to text color when `noColor` prop is false (remains `white`).


https://determinedai.atlassian.net/browse/DET-8237

## Test Plan

nothing to test in core since `noColor` prop is only used in SaaS.

## Commentary (optional)

can test in storybook and SaaS to see that in light mode with `noColor` mode, text is dark instead of white:

![avatar-nocolor-var](https://user-images.githubusercontent.com/97752292/191136158-68e08c58-4bf7-4e8f-af83-68f48d07e40b.png)
![avatar-nocolor-white](https://user-images.githubusercontent.com/97752292/191136160-9ec1d855-a7ea-42cf-968d-539ea1601a9b.png)


## Checklist
- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.
- [ ] If modifying `/webui/react/src/shared/` verify `make -C webui/react test-shared` passes.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
