### PR TITLE
chore: add FieldMask type to apiutils

### DIFF
--- a/master/go.mod
+++ b/master/go.mod
@@ -153,7 +153,7 @@ require (
 	golang.org/x/text v0.3.7 // indirect
 	golang.org/x/time v0.0.0-20210723032227-1f47c861a9ac // indirect
 	google.golang.org/appengine v1.6.7 // indirect
-	google.golang.org/genproto v0.0.0-20211223182754-3ac035c7e7cb // indirect
+	google.golang.org/genproto v0.0.0-20211223182754-3ac035c7e7cb
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/ini.v1 v1.63.2 // indirect

--- a/master/internal/api/apiutils/mask.go
+++ b/master/internal/api/apiutils/mask.go
@@ -1,0 +1,46 @@
+package apiutils
+
+import (
+	field_mask "google.golang.org/genproto/protobuf/field_mask"
+)
+
+// FieldMask is a utility type for efficiently interacting with protobuf FieldMasks in a compliant
+// way.
+type FieldMask struct {
+	m        *field_mask.FieldMask
+	fieldSet map[string]bool
+}
+
+// NewFieldMask initializes a FieldMask object from a protobuf FieldMask pointer. A passed-in nil
+// or a FieldMask with zero paths will result in an empty FieldMask, which is considered to contain
+// every field.
+func NewFieldMask(m *field_mask.FieldMask) FieldMask {
+	if m == nil {
+		return FieldMask{}
+	}
+	
+	m.Normalize()
+	
+	paths := m.Paths()
+	fields := make(map[string]bool, len(paths))
+	for _, f := paths {
+		fields[f] = true
+	}
+
+	m.IsValid()
+
+	return FieldMask{
+		m: m,
+		fieldSet: fields,
+	}
+}
+
+// FieldInSet answers whether the passed-in field is in the FieldMask. FieldInSet respects the 
+// FieldMask convention of treating empty FieldMasks as containing every field.
+func (f *FieldMask) FieldInSet(field string) bool {
+	if len(f.fieldSet) == 0 {
+		return true
+	}
+
+	return f.fieldSet[field]
+}

--- a/master/internal/api/apiutils/mask.go
+++ b/master/internal/api/apiutils/mask.go
@@ -1,6 +1,8 @@
 package apiutils
 
 import (
+	"strings"
+
 	field_mask "google.golang.org/genproto/protobuf/field_mask"
 )
 
@@ -18,29 +20,43 @@ func NewFieldMask(m *field_mask.FieldMask) FieldMask {
 	if m == nil {
 		return FieldMask{}
 	}
-	
+
 	m.Normalize()
-	
-	paths := m.Paths()
+
+	paths := m.GetPaths()
 	fields := make(map[string]bool, len(paths))
-	for _, f := paths {
+	for _, f := range paths {
 		fields[f] = true
 	}
 
-	m.IsValid()
-
 	return FieldMask{
-		m: m,
+		m:        m,
 		fieldSet: fields,
 	}
 }
 
-// FieldInSet answers whether the passed-in field is in the FieldMask. FieldInSet respects the 
+// FieldInSet answers whether the passed-in field is in the FieldMask. FieldInSet respects the
 // FieldMask convention of treating empty FieldMasks as containing every field.
 func (f *FieldMask) FieldInSet(field string) bool {
 	if len(f.fieldSet) == 0 {
 		return true
 	}
 
-	return f.fieldSet[field]
+	if f.fieldSet[field] {
+		return true
+	}
+
+	// If the fieldmask contains a.b and a user inquires about field a.b.c, the answer is yes.
+	fields := strings.Split(field, ".")
+	if len(fields) > 1 {
+		// Continually re-slice the slice of fields to check if an ancestor of field was specified.
+		for fields = fields[:len(fields)-1]; len(fields) > 0; fields = fields[:len(fields)-1] {
+			path := strings.Join(fields, ".")
+			if f.fieldSet[path] {
+				return true
+			}
+		}
+	}
+
+	return false
 }

--- a/master/internal/api/apiutils/mask_test.go
+++ b/master/internal/api/apiutils/mask_test.go
@@ -1,0 +1,51 @@
+package apiutils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	field_mask "google.golang.org/genproto/protobuf/field_mask"
+)
+
+func TestFieldInSet(t *testing.T) {
+	t.Run("respects empty FieldMasks", func(t *testing.T) {
+		m := NewFieldMask(nil)
+
+		testPaths := []string{
+			"",
+			"a.b.c",
+			"something.that.should.not.come.up",
+			"averylongstringthatdoesnotcontainanydotswhichareusedtoseparatefields",
+		}
+
+		for _, p := range testPaths {
+			require.True(t, m.FieldInSet(p), "all fields should be considered in the field set of"+
+				" an empty FieldSet")
+		}
+	})
+
+	t.Run("handles ancestors in FieldMask", func(t *testing.T) {
+		protoMask := field_mask.FieldMask{
+			Paths: []string{
+				"a.b",
+				"l.m.n.o.p",
+				"x.y.z",
+			},
+		}
+		mask := NewFieldMask(&protoMask)
+
+		testCases := map[string]bool{
+			"l.m.n":       false,
+			"a.b":         true,
+			"a.b.c":       true,
+			"a.b.c.d.e.f": true,
+			"x.y.z":       true,
+			"x.y.z.aa":    true,
+			"foo.bar":     false,
+		}
+		for path, expected := range testCases {
+			found := mask.FieldInSet(path)
+			require.Equal(t, expected, found, "got an unexpected result for path %s", path)
+		}
+	})
+}


### PR DESCRIPTION
## Description

While reviewing #5177, I noticed some ergonomic issues working with FieldMasks and wanted to help make that easier. In particular:
- Doing repeated O(n) scans through a slice of fields to check whether fields were specified in the FieldMask is slow and verbose.
- An unspecified FieldMask, by convention, should be interpreted by the server as though all fields were specified, so a check was necessary that was easy to miss.
- FieldMask allows a request to specify an ancestor field such as `a.b` and should carry the semantics that a descendent field like `a.b.c` should be considered in the field set.

So I made a new type (with tests) that uses a map for containment checks and respects the listed FieldMask conventions.


## Test Plan

No behavior should change as a result of this PR.