### PR TITLE
fix: check target user, allow \wadmin\w names but not admin itself [WEB-529]

### DIFF
--- a/master/internal/api_user.go
+++ b/master/internal/api_user.go
@@ -327,8 +327,7 @@ func (a *apiServer) PatchUser(
 			if !targetUser.Admin && (strings.TrimSpace(strings.ToLower(displayName)) == "admin") {
 				return nil, status.Error(codes.InvalidArgument, "Non-admin user cannot be renamed 'admin'")
 			}
-			if targetUser.Username != "determined" && strings.Contains(strings.ToLower(displayName),
-				"determined") {
+			if targetUser.Username != "determined" && (strings.TrimSpace(strings.ToLower(displayName)) == "determined") {
 				return nil, status.Error(codes.InvalidArgument, "User cannot be renamed 'determined'")
 			}
 			err = a.m.db.QueryProto("set_user_display_name", u, req.UserId, strings.TrimSpace(displayName))

--- a/master/internal/api_user.go
+++ b/master/internal/api_user.go
@@ -327,7 +327,8 @@ func (a *apiServer) PatchUser(
 			if !targetUser.Admin && (strings.TrimSpace(strings.ToLower(displayName)) == "admin") {
 				return nil, status.Error(codes.InvalidArgument, "Non-admin user cannot be renamed 'admin'")
 			}
-			if targetUser.Username != "determined" && (strings.TrimSpace(strings.ToLower(displayName)) == "determined") {
+			if targetUser.Username != displayName &&
+				(strings.TrimSpace(strings.ToLower(displayName)) == "determined") {
 				return nil, status.Error(codes.InvalidArgument, "User cannot be renamed 'determined'")
 			}
 			err = a.m.db.QueryProto("set_user_display_name", u, req.UserId, strings.TrimSpace(displayName))

--- a/master/internal/api_user.go
+++ b/master/internal/api_user.go
@@ -304,7 +304,6 @@ func (a *apiServer) PatchUser(
 		return nil, status.Error(codes.PermissionDenied, err.Error())
 	}
 
-	// TODO: handle any field name:
 	if req.User.DisplayName != nil {
 		if err = user.AuthZProvider.Get().CanSetUsersDisplayName(*curUser, targetUser); err != nil {
 			if ok, canGetErr := user.AuthZProvider.Get().
@@ -325,11 +324,10 @@ func (a *apiServer) PatchUser(
 			re := regexp.MustCompile("[^\\p{Latin}\\p{N}\\s]")
 			displayName := re.ReplaceAllLiteralString(req.User.DisplayName.Value, "")
 			// Restrict 'admin' and 'determined' in display names.
-			if !(curUser.Admin && curUser.ID == uid) && strings.Contains(strings.ToLower(displayName),
-				"admin") {
+			if !targetUser.Admin && (strings.TrimSpace(strings.ToLower(displayName)) == "admin") {
 				return nil, status.Error(codes.InvalidArgument, "Non-admin user cannot be renamed 'admin'")
 			}
-			if curUser.Username != "determined" && strings.Contains(strings.ToLower(displayName),
+			if targetUser.Username != "determined" && strings.Contains(strings.ToLower(displayName),
 				"determined") {
 				return nil, status.Error(codes.InvalidArgument, "User cannot be renamed 'determined'")
 			}


### PR DESCRIPTION
## Description

- address issue of display names including but not actually == "Admin"
- code changes from checking `curUser.isAdmin` to `targetUser` for the renaming

## Test Plan

Rename user


## Checklist
- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.
- [x] If modifying `/webui/react/src/shared/` verify `make -C webui/react test-shared` passes.