### PR TITLE
fix: remove duplicate event message.

### DIFF
--- a/master/internal/sproto/task.go
+++ b/master/internal/sproto/task.go
@@ -257,7 +257,7 @@ func (ev *Event) ToTaskLog() model.TaskLog {
 	case ev.TerminateRequestEvent != nil:
 		message = fmt.Sprintf("%s was requested to terminate", description)
 	case ev.ExitedEvent != nil:
-		message = fmt.Sprintf("%s was terminated: %s", description, *ev.ExitedEvent)
+		message = fmt.Sprintf("%s was terminated", description)
 	case ev.LogEvent != nil:
 		message = fmt.Sprintf(*ev.LogEvent)
 	case ev.ServiceReadyEvent != nil:


### PR DESCRIPTION
## Description

Job exited with failure will log a message at ERROR level, but the same message is also appended to ExitedEvent message that is showing at INFO level. Every job exit message is duplicated. 

On success

[2022-10-06T21:11:14.596823Z]          || INFO: Scheduling Command (truly-keen-cicada) (id: a2f367af-d75f-4675-9086-822331336ebf)
[2022-10-06T21:11:14.672017Z]          || INFO: Command (truly-keen-cicada) was assigned to an agent
[2022-10-06T21:11:32.113061Z]          || INFO: **resources exited successfully with a zero exit code**
[2022-10-06T21:11:32.129114Z]          || INFO: Command (truly-keen-cicada) was terminated: allocation stopped early after **resources exited successfully with a zero exit code**

On failure

% det command run exit 1
[2022-10-06T16:18:05.741031Z]          || INFO: Scheduling Command (jointly-sound-finch) (id: dfd9a4b5-0011-40ab-951e-624af568ab53)
[2022-10-06T16:18:05.991591Z]          || INFO: Command (jointly-sound-finch) was assigned to an agent
[2022-10-06T16:18:19.689914Z]          || **ERROR: task failed without an associated exit code: failed state due to reason 'Failed':
    Launching: pbs_tmrsh node002.head.cm.us.cray.com singularity run --pwd /var/tmp --nv --writable-tmpfs --env SLURM_NPROCS=1 --env SLURM_PROCID=0 --env DET_SLOTS_PER_NODE=1 --no-mount tmp --env-file /mnt/lustre/foundation_engineering/pbs/jobs/environments/harrow/5056bcb0808243fd-8fe2b970a6d42fde/ai_cmd-vars.sh --bind /etc/hosts:/etc/hosts,/mnt/lustre/foundation_engineering/pbs/archiveVolumes/harrow/5056bcb0808243fd-8fe2b970a6d42fde/determined_local_fs:/determined_local_fs,/mnt/lustre/foundation_engineering/pbs/archiveVolumes/harrow/5056bcb0808243fd-8fe2b970a6d42fde/run/determined:/run/determined,/mnt/lustre/foundation_engineering/pbs/archiveVolumes/harrow/5056bcb0808243fd-8fe2b970a6d42fde/opt/determined:/opt/determined /mnt/lustre/foundation_engineering/images2/determinedai/environments:cuda-11.3-pytorch-1.10-tf-2.8-gpu-096d730 /determined_local_fs/dispatcher-wrapper.sh /run/determined/command-entrypoint.sh exit 1
  INFO: Monitoring process 991837
  GID: readonly variable
  UID: readonly variable
  INFO: Setting workdir to /run/determined/workdir
  INFO: executing /run/determined/command-entrypoint.sh exit 1
  ERROR: process 991837 exited with status 1. Terminating all tasks. (exit code 1)**
[2022-10-06T16:18:19.720287Z]          || **INFO: Command (jointly-sound-finch) was terminated: allocation failed: task failed without an associated exit code: failed state due to reason 'Failed':
    Launching: pbs_tmrsh node002.head.cm.us.cray.com singularity run --pwd /var/tmp --nv --writable-tmpfs --env SLURM_NPROCS=1 --env SLURM_PROCID=0 --env DET_SLOTS_PER_NODE=1 --no-mount tmp --env-file /mnt/lustre/foundation_engineering/pbs/jobs/environments/harrow/5056bcb0808243fd-8fe2b970a6d42fde/ai_cmd-vars.sh --bind /etc/hosts:/etc/hosts,/mnt/lustre/foundation_engineering/pbs/archiveVolumes/harrow/5056bcb0808243fd-8fe2b970a6d42fde/determined_local_fs:/determined_local_fs,/mnt/lustre/foundation_engineering/pbs/archiveVolumes/harrow/5056bcb0808243fd-8fe2b970a6d42fde/run/determined:/run/determined,/mnt/lustre/foundation_engineering/pbs/archiveVolumes/harrow/5056bcb0808243fd-8fe2b970a6d42fde/opt/determined:/opt/determined /mnt/lustre/foundation_engineering/images2/determinedai/environments:cuda-11.3-pytorch-1.10-tf-2.8-gpu-096d730 /determined_local_fs/dispatcher-wrapper.sh /run/determined/command-entrypoint.sh exit 1
  INFO: Monitoring process 991837
  GID: readonly variable
  UID: readonly variable
  INFO: Setting workdir to /run/determined/workdir
  INFO: executing /run/determined/command-entrypoint.sh exit 1
  ERROR: process 991837 exited with status 1. Terminating all tasks. (exit code 1)
Task log stream ended. To reopen log stream, run: det task logs -f dfd9a4b5-0011-40ab-951e-624af568ab53**


## Test Plan

Test result, on failure:

% det command run exit 1
[2022-10-20T23:27:39.379702Z]          || INFO: Scheduling Command (publicly-glowing-caribou) (id: ac21fbe8-ac39-4133-8d16-bb2fa38365a3)
[2022-10-20T23:27:39.748623Z]          || INFO: Command (publicly-glowing-caribou) was assigned to an agent
[2022-10-20T23:27:55.046421Z]          || ERROR: task failed without an associated exit code: Slurm job is in a failed state due to reason 'NonZeroExitCode':
  Job Exited with Exit Code 1
  INFO:    Using cached SIF image
  INFO: Setting workdir to /run/determined/workdir
  INFO: executing /run/determined/command-entrypoint.sh exit 1
  srun: error: node002: task 0: Exited with exit code 1
  srun: launch/slurm: _step_signal: Terminating StepId=1468.0. SBATCH options: --ntasks-per-node=1 --nodes=1-1 --gpus=1 --job-name=det-ai_cmd-2879912a65f8432c-a63d206c109bbf3a --partition=defq --chdir=/var/tmp --error=/home/users/cobble/.launcher/jobs/environments/cobble/2879912a65f8432c-a63d206c109bbf3a/ai_cmd-error.log --output=/home/users/cobble/.launcher/jobs/environments/cobble/2879912a65f8432c-a63d206c109bbf3a/ai_cmd-output.log
 (exit code 1)
[2022-10-20T23:27:55.090444Z]          || INFO: Command (publicly-glowing-caribou) was terminated


On success:

% det command run exit 0
[2022-10-20T23:53:16.076770Z]          || INFO: Scheduling Command (formally-true-drum) (id: 7f916dca-cdee-445e-a1fe-9b269b5c80b4)
[2022-10-20T23:53:16.574089Z]          || INFO: Command (formally-true-drum) was assigned to an agent
[2022-10-20T23:53:35.058893Z]          || INFO: resources exited successfully with a zero exit code
[2022-10-20T23:53:35.080088Z]          || INFO: Command (formally-true-drum) was terminated

## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist
- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.
- [ ] If modifying `/webui/react/src/shared/` verify `make -C webui/react test-shared` passes.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
