### PR TITLE
fix: Load workspace members from RBAC API

### DIFF
--- a/webui/react/src/pages/WorkspaceDetails.tsx
+++ b/webui/react/src/pages/WorkspaceDetails.tsx
@@ -36,6 +36,7 @@ export enum WorkspaceDetailsTab {
 
 const WorkspaceDetails: React.FC = () => {
   const rbacEnabled = useFeature().isOn('rbac');
+  const mockWorkspaceMembers = useFeature().isOn('mock_workspace_members');
 
   const { users } = useStore();
   const { workspaceId: workspaceID } = useParams<Params>();
@@ -84,7 +85,7 @@ const WorkspaceDetails: React.FC = () => {
   }, [canceler.signal]);
 
   const fetchGroupsAndUsersAssignedToWorkspace = useCallback(async () => {
-    if (!rbacEnabled) {
+    if (!rbacEnabled || mockWorkspaceMembers) {
       return;
     }
 

--- a/webui/react/src/services/api.ts
+++ b/webui/react/src/services/api.ts
@@ -450,6 +450,12 @@ export const getWorkspaces = generateDetApi<
   Type.WorkspacePagination
 >(Config.getWorkspaces);
 
+export const getWorkspaceMembers = generateDetApi<
+  Service.GetWorkspaceMembersParams,
+  Api.V1GetGroupsAndUsersAssignedToWorkspaceResponse,
+  Type.WorkspaceMembersResponse
+>(Config.getWorkspaceMembers);
+
 export const getWorkspaceProjects = generateDetApi<
   Service.GetWorkspaceProjectsParams,
   Api.V1GetWorkspaceProjectsResponse,

--- a/webui/react/src/services/apiConfig.ts
+++ b/webui/react/src/services/apiConfig.ts
@@ -1056,6 +1056,22 @@ export const createWorkspace: DetApi<
     detApi.Workspaces.postWorkspace({ name: params.name.trim() }, options),
 };
 
+export const getWorkspaceMembers: DetApi<
+  Service.GetWorkspaceMembersParams,
+  Api.V1GetGroupsAndUsersAssignedToWorkspaceResponse,
+  Type.WorkspaceMembersResponse
+> = {
+  name: 'getWorkspaceMembers',
+  postProcess: (response) => ({
+    assignments: response.assignments,
+    groups: response.groups,
+    usersAssignedDirectly: response.usersAssignedDirectly.map(decoder.mapV1User),
+  }),
+  request: (params) => {
+    return detApi.RBAC.getGroupsAndUsersAssignedToWorkspace(params.workspaceId, params.nameFilter);
+  },
+};
+
 export const getWorkspaceProjects: DetApi<
   Service.GetWorkspaceProjectsParams,
   Api.V1GetWorkspaceProjectsResponse,

--- a/webui/react/src/services/types.ts
+++ b/webui/react/src/services/types.ts
@@ -428,6 +428,11 @@ export interface GetWorkspaceProjectsParams extends PaginationParams {
   users?: string[];
 }
 
+export interface GetWorkspaceMembersParams {
+  nameFilter?: string;
+  workspaceId: number;
+}
+
 export interface DeleteWorkspaceParams {
   id: number;
 }

--- a/webui/react/src/types.ts
+++ b/webui/react/src/types.ts
@@ -842,4 +842,10 @@ export interface WorkspacePermissionsArgs {
   workspace?: PermissionWorkspace;
 }
 
+export interface WorkspaceMembersResponse {
+  assignments: Api.V1RoleWithAssignments[];
+  groups: Api.V1Group[];
+  usersAssignedDirectly: User[];
+}
+
 export type UserOrGroup = User | V1Group;


### PR DESCRIPTION
## Description

PR fills in the Workspace Members tab using a request to the `GetGroupsAndUsersAssignedToWorkspace` API endpoint, represented in the code as `getWorkspaceMembers`.

Requests are not made when RBAC is not enabled.

## Test Plan

- When viewing a workspace in OSS [not RBAC], there are no requests to `/roles/workspace/{workspace_id}`
- When viewing a workspace with RBAC flag on - `?f_rbac=on&f_mock_permissions_read=on` - you should see repeated requests to `/roles/workspace/{workspace_id}`, though in OSS these will return an error

## Checklist
- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.
- [x] If modifying `/webui/react/src/shared/` verify `make -C webui/react test-shared` passes.