### PR TITLE
chore: No retries

### DIFF
--- a/e2e_tests/tests/experiment/experiment.py
+++ b/e2e_tests/tests/experiment/experiment.py
@@ -93,16 +93,6 @@ def wait_for_experiment_by_name_is_active(
                 )
             experiment = response[0]
             experiment_id = experiment.id
-        # Ignore network errors while polling for experiment state to avoid a
-        # single network flake to cause a test suite failure. If the master is
-        # unreachable multiple times, this test will fail after max_wait_secs.
-        except api.errors.MasterNotFoundException:
-            logging.warning(
-                "Network failure ignored when polling for state of "
-                "experiment {}".format(experiment_name)
-            )
-            time.sleep(1)
-            continue
         except api.errors.NotFoundException:
             logging.warning(
                 "Experiment not yet available to check state: "
@@ -157,16 +147,6 @@ def wait_for_experiment_state(
     for seconds_waited in range(max_wait_secs):
         try:
             state = experiment_state(experiment_id)
-        # Ignore network errors while polling for experiment state to avoid a
-        # single network flake to cause a test suite failure. If the master is
-        # unreachable multiple times, this test will fail after max_wait_secs.
-        except api.errors.MasterNotFoundException:
-            logging.warning(
-                "Network failure ignored when polling for state of "
-                "experiment {}".format(experiment_id)
-            )
-            time.sleep(1)
-            continue
         except api.errors.NotFoundException:
             logging.warning(
                 "Experiment not yet available to check state: "
@@ -215,15 +195,6 @@ def wait_for_trial_state(
     for seconds_waited in range(max_wait_secs):
         try:
             state = trial_state(trial_id)
-        # Ignore network errors while polling for experiment state to avoid a
-        # single network flake to cause a test suite failure. If the master is
-        # unreachable multiple times, this test will fail after max_wait_secs.
-        except api.errors.MasterNotFoundException:
-            logging.warning(
-                "Network failure ignored when polling for state of " "trial {}".format(trial_id)
-            )
-            time.sleep(1)
-            continue
         except api.errors.NotFoundException:
             logging.warning("Trial not yet available to check state: " "trial {}".format(trial_id))
             time.sleep(0.25)


### PR DESCRIPTION
## Description

The retry logic in experiment.py (when master is not _yet_ available) is probably obsolete since we started using `bindings` for the API call. I am removing it and looking at CI to test this hypothesis.


## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions about this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist
- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.
- [ ] If modifying `/webui/react/src/shared/` verify `make -C webui/react test-shared` passes.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
