### PR TITLE
refactor: Add ability to lockdown NTSC [DET-8276, DET-7377]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2277,6 +2277,17 @@ workflows:
           target-stage: agent2
 
       - test-e2e:
+          name: test-e2e-cpu-strict-ntsc
+          requires:
+            - build-go
+          parallelism: 1
+          tf1: false
+          tf2: true
+          devcluster-config: strict-ntsc.devcluster.yaml          
+          mark: test_strict_ntsc
+          target-stage: agent2
+          
+      - test-e2e:
           name: test-e2e-managed-devcluster
           requires:
             - build-go

--- a/.circleci/devcluster/strict-ntsc.devcluster.yaml
+++ b/.circleci/devcluster/strict-ntsc.devcluster.yaml
@@ -1,0 +1,57 @@
+stages:
+  - db:
+      name: db
+
+  - master:
+      pre:
+        - sh: make -C tools prep-root
+      config_file:
+        db:
+          host: localhost
+          port: 5432
+          password: postgres
+          user: postgres
+          name: determined
+        checkpoint_storage:
+          type: shared_fs
+          host_path: /tmp
+          storage_path: determined-cp
+        log:
+          level: debug
+        root: tools/build
+        cache: 
+          cache_dir: /tmp/determined-cache
+        security:
+          authz:
+            rbac_ui_enabled: true
+            _strict_ntsc_enabled: true
+            
+  - custom:
+      name: proxy
+      cmd: ["socat", "-d", "-d", "TCP-LISTEN:8081,reuseaddr,fork", "TCP:localhost:8080"]
+      post:
+        - conncheck:
+            port: 8081
+
+  - agent:
+      name: agent1
+      config_file:
+        master_host: 127.0.0.1
+        master_port: 8081
+        agent_id: agent1
+        container_master_host: $DOCKER_LOCALHOST
+        container_auto_remove_disabled: true
+        hooks:
+          on_connection_lost: ["touch", "/tmp/agent1-connection-lost"]
+
+  - agent:
+      name: agent2
+      config_file:
+        master_host: 127.0.0.1
+        master_port: 8081
+        agent_id: agent2
+        container_master_host: $DOCKER_LOCALHOST
+        fluent:
+          port: 24225  # default value is 24224
+          container_name: determined-fluent-2
+        container_auto_remove_disabled: true

--- a/.circleci/devcluster/strict-ntsc.devcluster.yaml
+++ b/.circleci/devcluster/strict-ntsc.devcluster.yaml
@@ -25,19 +25,12 @@ stages:
           authz:
             rbac_ui_enabled: true
             _strict_ntsc_enabled: true
-            
-  - custom:
-      name: proxy
-      cmd: ["socat", "-d", "-d", "TCP-LISTEN:8081,reuseaddr,fork", "TCP:localhost:8080"]
-      post:
-        - conncheck:
-            port: 8081
 
   - agent:
       name: agent1
       config_file:
         master_host: 127.0.0.1
-        master_port: 8081
+        master_port: 8080
         agent_id: agent1
         container_master_host: $DOCKER_LOCALHOST
         container_auto_remove_disabled: true
@@ -48,7 +41,7 @@ stages:
       name: agent2
       config_file:
         master_host: 127.0.0.1
-        master_port: 8081
+        master_port: 8080
         agent_id: agent2
         container_master_host: $DOCKER_LOCALHOST
         fluent:

--- a/e2e_tests/pytest.ini
+++ b/e2e_tests/pytest.ini
@@ -13,6 +13,7 @@ markers =
     e2e_cpu_cross_version: end to end CPU tests for testing basic cluster functionality with differing master/agent versions
     e2e_cpu_agent_connection_loss: end to end CPU tests for testing agent functionality on connection loss
     e2e_gpu: end to end GPU tests
+    test_strict_ntsc: end to end test covers notebooks, tensorboards, shells, and commands with strict access controls (you can only see your own stuff)
     gpu_required: tests with a hard CUDA requirement
     distributed: distributed training tests
     parallel: parallel, multi-gpu tests

--- a/e2e_tests/tests/command/test_strict_ntsc.py
+++ b/e2e_tests/tests/command/test_strict_ntsc.py
@@ -1,0 +1,197 @@
+import pytest
+
+from tests import command as cmd
+from pathlib import Path
+import determined as det
+import time
+from typing import Any, List
+
+
+from tests import experiment as exp
+from determined.common import api
+from determined.common.api import authentication, bindings
+from determined.common.api.errors import NotFoundException
+from tests.cluster.test_users import ADMIN_CREDENTIALS, create_test_user, logged_in_user
+from tests import config as conf
+
+
+# TODO task logs
+# AND /tasks
+
+def assert_shell_access(creds: authentication.Credentials, shell_id: str, can_access: bool) -> None:
+    master_url = conf.make_master_url()
+    authentication.cli_auth = authentication.Authentication(
+        master_url, creds.username, creds.password, try_reauth=True)    
+    sess = api.Session(master_url, None, None, None)
+
+    resp = bindings.get_GetShells(sess)
+    found = any([True for shell in resp.shells if shell.id == shell_id])
+    assert (found and can_access,
+            f"checking if shell is returned in GetShells found: {found} expected: {can_access}")
+    
+    if can_access:
+        assert bindings.get_GetShell(sess, shellId=shell_id) is not None
+        req = bindings.v1SetShellPriorityRequest(shellId=shell_id, priority=50)
+        assert bindings.post_SetShellPriority(sess, shellId=shell_id, body=req) is not None
+        return
+    
+    with pytest.raises(NotFoundException):
+        bindings.get_GetShell(sess, shellId=shell_id)
+    with pytest.raises(NotFoundException):        
+        bindings.post_KillShell(sess, shellId=shell_id)
+    with pytest.raises(NotFoundException):
+        req = bindings.v1SetShellPriorityRequest(shellId=shell_id, priority=50)
+        bindings.post_SetShellPriority(sess, shellId=shell_id, body=req)        
+
+    # Need secret so need to test proxy.
+        
+def assert_notebook_access(creds: authentication.Credentials, notebook_id: str,
+                           can_access: bool) -> None:
+    master_url = conf.make_master_url()
+    authentication.cli_auth = authentication.Authentication(
+        master_url, creds.username, creds.password, try_reauth=True)    
+    sess = api.Session(master_url, None, None, None)
+
+    resp = bindings.get_GetNotebooks(sess)
+    found = any([True for notebook in resp.notebooks if notebook.id == notebook_id])
+    assert (found and can_access,
+            f"checking if notebook is returned in GetNotebooks found: {found} expected: {can_access}")
+
+    if can_access:
+        assert bindings.get_GetNotebook(sess, notebookId=notebook_id) is not None
+        req = bindings.v1IdleNotebookRequest(idle=False, notebookId=notebook_id)
+        bindings.put_IdleNotebook(sess, notebookId=notebook_id, body=req)
+
+        req = bindings.v1SetNotebookPriorityRequest(notebookId=notebook_id, priority=50)
+        assert bindings.post_SetNotebookPriority(sess, notebookId=notebook_id, body=req) is not None
+        return
+
+    # TODO proxy test.
+    
+    with pytest.raises(NotFoundException):
+        bindings.get_GetNotebook(sess, notebookId=notebook_id)    
+    with pytest.raises(NotFoundException):
+        req = bindings.v1IdleNotebookRequest(idle=False, notebookId=notebook_id)
+        bindings.put_IdleNotebook(sess, notebookId=notebook_id, body=req)
+    with pytest.raises(NotFoundException):
+        bindings.post_KillNotebook(sess, notebookId=notebook_id)        
+    with pytest.raises(NotFoundException):        
+        req = bindings.v1SetNotebookPriorityRequest(notebookId=notebook_id, priority=50)
+        bindings.post_SetNotebookPriority(sess, notebookId=notebook_id, body=req) 
+
+        
+
+def assert_command_access(creds: authentication.Credentials, command_id: str,
+                           can_access: bool) -> None:
+    master_url = conf.make_master_url()
+    authentication.cli_auth = authentication.Authentication(
+        master_url, creds.username, creds.password, try_reauth=True)    
+    sess = api.Session(master_url, None, None, None)
+
+    resp = bindings.get_GetCommands(sess)
+    found = any([True for command in resp.commands if command.id == command_id])
+    assert (found and can_access,
+            f"checking if command is returned in GetCommands found: {found} expected: {can_access}")
+    
+    # TODO no need to proxy test.
+
+    if can_access:
+        assert bindings.get_GetCommand(sess, commandId=command_id) is not None
+
+        req = bindings.v1SetCommandPriorityRequest(commandId=command_id, priority=50)
+        assert bindings.post_SetCommandPriority(sess, commandId=command_id, body=req) is not None
+        return
+
+    
+    with pytest.raises(NotFoundException):
+        bindings.get_GetCommand(sess, commandId=command_id)    
+    with pytest.raises(NotFoundException):
+        bindings.post_KillCommand(sess, commandId=command_id)        
+    with pytest.raises(NotFoundException):        
+        req = bindings.v1SetCommandPriorityRequest(commandId=command_id, priority=50)
+        bindings.post_SetCommandPriority(sess, commandId=command_id, body=req) 
+
+def assert_tensorboard_access(creds: authentication.Credentials, tensorboard_id: str,
+                           can_access: bool) -> None:
+    master_url = conf.make_master_url()
+    authentication.cli_auth = authentication.Authentication(
+        master_url, creds.username, creds.password, try_reauth=True)    
+    sess = api.Session(master_url, None, None, None)
+
+    resp = bindings.get_GetTensorboards(sess)
+    found = any([True for tensorboard in resp.tensorboards if tensorboard.id == tensorboard_id])
+    assert (found and can_access,
+            f"checking if tensorboard is returned in GetTensorboards found: " +
+            "{found} expected: {can_access}")
+
+    
+    # TODO proxy test.
+    
+    if can_access:
+        assert bindings.get_GetTensorboard(sess, tensorboardId=tensorboard_id) is not None
+
+        req = bindings.v1SetTensorboardPriorityRequest(tensorboardId=tensorboard_id, priority=50)
+        assert bindings.post_SetTensorboardPriority(
+            sess, tensorboardId=tensorboard_id, body=req) is not None
+        return
+
+    with pytest.raises(NotFoundException):
+        bindings.get_GetTensorboard(sess, tensorboardId=tensorboard_id)    
+    with pytest.raises(NotFoundException):
+        bindings.post_KillTensorboard(sess, tensorboardId=tensorboard_id)        
+    with pytest.raises(NotFoundException):        
+        req = bindings.v1SetTensorboardPriorityRequest(tensorboardId=tensorboard_id, priority=50)
+        bindings.post_SetTensorboardPriority(sess, tensorboardId=tensorboard_id, body=req) 
+    
+        
+def strict_task_test(start_command: List[str], start_message: str, assert_access_func: Any) -> None:
+    user_a = create_test_user(ADMIN_CREDENTIALS)
+    user_b = create_test_user(ADMIN_CREDENTIALS)    
+
+    with logged_in_user(user_a):
+        with cmd.interactive_command(*start_command) as task:
+            for line in task.stdout:
+                if start_message in line:
+                    break
+            else:
+                pytest.fail(f"Did not find expected input '{start_message}' in task stdout.")        
+
+            assert_access_func(user_a, task.task_id, True)
+            assert_access_func(user_b, task.task_id, False)
+            assert_access_func(ADMIN_CREDENTIALS, task.task_id, True)
+
+# TODO mark
+# stress_test
+@pytest.mark.stress_test            
+def test_strict_shell():
+    strict_task_test(["shell", "start"], "has started...", assert_shell_access)
+
+
+# TODO mark
+# stress_test
+@pytest.mark.stress_test            
+def test_strict_notebook():
+    strict_task_test(["notebook", "start", "--no-browser"],
+                     "has started...", assert_notebook_access)    
+
+# TODO mark
+# stress_test
+@pytest.mark.stress_test            
+def test_strict_command():
+    strict_task_test(["command", "run", "sleep", "300"], "have started", assert_command_access)
+
+# TODO mark
+# stress_test
+@pytest.mark.stress_test            
+def test_strict_tensorboard():
+    exp_id = exp.run_basic_test(
+        conf.fixtures_path("no_op/single-one-short-step.yaml"),
+        conf.fixtures_path("no_op"),
+        1,
+    )
+    strict_task_test(["tensorboard", "start", str(exp_id), "--no-browser"],
+                     "has started", assert_tensorboard_access)
+
+    
+    
+            

--- a/e2e_tests/tests/command/test_strict_ntsc.py
+++ b/e2e_tests/tests/command/test_strict_ntsc.py
@@ -1,48 +1,45 @@
-import pytest
-
-from tests import command as cmd
-from pathlib import Path
-import determined as det
-import time
 from typing import Any, List
 
+import pytest
 
-from tests import experiment as exp
 from determined.common import api
 from determined.common.api import authentication, bindings
-from determined.common.api.errors import NotFoundException, BadRequestException, APIException
-from tests.cluster.test_users import ADMIN_CREDENTIALS, create_test_user, logged_in_user
+from determined.common.api.errors import (
+    APIException,
+    BadRequestException,
+    ForbiddenException,
+    NotFoundException,
+)
+from tests import command as cmd
 from tests import config as conf
+from tests import experiment as exp
+from tests.cluster.test_users import ADMIN_CREDENTIALS, create_test_user, logged_in_user
 
-
-# TODO task logs
-# AND /tasks
 
 def assert_shell_access(creds: authentication.Credentials, shell_id: str, can_access: bool) -> None:
     master_url = conf.make_master_url()
     authentication.cli_auth = authentication.Authentication(
-        master_url, creds.username, creds.password, try_reauth=True)    
+        master_url, creds.username, creds.password, try_reauth=True
+    )
     sess = api.Session(master_url, None, None, None)
 
     resp = bindings.get_GetShells(sess)
-    found = any([True for shell in resp.shells if shell.id == shell_id])
-    assert (found and can_access,
-            f"checking if shell is returned in GetShells found: {found} expected: {can_access}")
-    
+    shell_ids = [shell.id for shell in resp.shells or []]
     if can_access:
-        assert bindings.get_GetShell(sess, shellId=shell_id) is not None
+        assert shell_id in shell_id
+        bindings.get_GetShell(sess, shellId=shell_id)
         req = bindings.v1SetShellPriorityRequest(shellId=shell_id, priority=50)
-        assert bindings.post_SetShellPriority(sess, shellId=shell_id, body=req) is not None
-        api.get(master_url, f"shells/{shell_id}/events", auth=authentication.cli_auth)        
+        bindings.post_SetShellPriority(sess, shellId=shell_id, body=req)
+        api.get(master_url, f"shells/{shell_id}/events", auth=authentication.cli_auth)
         with api.ws(master_url, f"shells/{shell_id}/events") as ws:
-            for msg in ws:
+            for _ in ws:
                 break
         return
 
-    
+    assert shell_id not in shell_ids
     with pytest.raises(NotFoundException):
         bindings.get_GetShell(sess, shellId=shell_id)
-    with pytest.raises(NotFoundException):        
+    with pytest.raises(NotFoundException):
         bindings.post_KillShell(sess, shellId=shell_id)
     with pytest.raises(NotFoundException):
         req = bindings.v1SetShellPriorityRequest(shellId=shell_id, priority=50)
@@ -51,226 +48,239 @@ def assert_shell_access(creds: authentication.Credentials, shell_id: str, can_ac
         api.get(master_url, f"shells/{shell_id}/events", auth=authentication.cli_auth)
     with pytest.raises(BadRequestException):
         with api.ws(master_url, f"shells/{shell_id}/events") as ws:
-            for msg in ws:
+            for _ in ws:
                 break
 
-    
-        
-def assert_notebook_access(creds: authentication.Credentials, notebook_id: str,
-                           can_access: bool) -> None:
+
+def assert_notebook_access(
+    creds: authentication.Credentials, notebook_id: str, can_access: bool
+) -> None:
     master_url = conf.make_master_url()
     authentication.cli_auth = authentication.Authentication(
-        master_url, creds.username, creds.password, try_reauth=True)    
+        master_url, creds.username, creds.password, try_reauth=True
+    )
     sess = api.Session(master_url, None, None, None)
 
     resp = bindings.get_GetNotebooks(sess)
-    found = any([True for notebook in resp.notebooks if notebook.id == notebook_id])
-    assert (found and can_access,
-            f"checking if notebook is returned in GetNotebooks found: {found} expected: {can_access}")
-
+    notebook_ids = [notebook.id for notebook in resp.notebooks or []]
     if can_access:
+        assert notebook_id in notebook_ids
         assert bindings.get_GetNotebook(sess, notebookId=notebook_id) is not None
         req = bindings.v1IdleNotebookRequest(idle=False, notebookId=notebook_id)
         bindings.put_IdleNotebook(sess, notebookId=notebook_id, body=req)
 
-        req = bindings.v1SetNotebookPriorityRequest(notebookId=notebook_id, priority=50)
-        assert bindings.post_SetNotebookPriority(sess, notebookId=notebook_id, body=req) is not None
+        pri_req = bindings.v1SetNotebookPriorityRequest(notebookId=notebook_id, priority=50)
+        bindings.post_SetNotebookPriority(sess, notebookId=notebook_id, body=pri_req)
 
-        api.get(master_url, f"notebooks/{notebook_id}/events", auth=authentication.cli_auth)        
+        api.get(master_url, f"notebooks/{notebook_id}/events", auth=authentication.cli_auth)
         with api.ws(master_url, f"notebooks/{notebook_id}/events") as ws:
-            for msg in ws:
+            for _ in ws:
                 break
         return
 
+    assert notebook_id not in notebook_ids
     with pytest.raises(NotFoundException):
-        bindings.get_GetNotebook(sess, notebookId=notebook_id)    
+        bindings.get_GetNotebook(sess, notebookId=notebook_id)
     with pytest.raises(NotFoundException):
         req = bindings.v1IdleNotebookRequest(idle=False, notebookId=notebook_id)
         bindings.put_IdleNotebook(sess, notebookId=notebook_id, body=req)
     with pytest.raises(NotFoundException):
-        bindings.post_KillNotebook(sess, notebookId=notebook_id)        
-    with pytest.raises(NotFoundException):        
-        req = bindings.v1SetNotebookPriorityRequest(notebookId=notebook_id, priority=50)
-        bindings.post_SetNotebookPriority(sess, notebookId=notebook_id, body=req) 
+        bindings.post_KillNotebook(sess, notebookId=notebook_id)
+    with pytest.raises(NotFoundException):
+        pri_req = bindings.v1SetNotebookPriorityRequest(notebookId=notebook_id, priority=50)
+        bindings.post_SetNotebookPriority(sess, notebookId=notebook_id, body=pri_req)
     with pytest.raises(NotFoundException):
         api.get(master_url, f"/proxy/{notebook_id}/", auth=authentication.cli_auth)
     with pytest.raises(NotFoundException):
         api.get(master_url, f"notebooks/{notebook_id}/events", auth=authentication.cli_auth)
     with pytest.raises(BadRequestException):
         with api.ws(master_url, f"notebooks/{notebook_id}/events") as ws:
-            for msg in ws:
+            for _ in ws:
                 break
-        
-        
 
-def assert_command_access(creds: authentication.Credentials, command_id: str,
-                           can_access: bool) -> None:
+
+def assert_command_access(
+    creds: authentication.Credentials, command_id: str, can_access: bool
+) -> None:
     master_url = conf.make_master_url()
     authentication.cli_auth = authentication.Authentication(
-        master_url, creds.username, creds.password, try_reauth=True)    
+        master_url, creds.username, creds.password, try_reauth=True
+    )
     sess = api.Session(master_url, None, None, None)
 
     resp = bindings.get_GetCommands(sess)
-    found = any([True for command in resp.commands if command.id == command_id])
-    assert (found and can_access,
-            f"checking if command is returned in GetCommands found: {found} expected: {can_access}")
-
+    command_ids = [command.id for command in resp.commands or []]
     if can_access:
-        assert bindings.get_GetCommand(sess, commandId=command_id) is not None
+        assert command_id in command_ids
+        bindings.get_GetCommand(sess, commandId=command_id)
 
         req = bindings.v1SetCommandPriorityRequest(commandId=command_id, priority=50)
-        assert bindings.post_SetCommandPriority(sess, commandId=command_id, body=req) is not None
+        bindings.post_SetCommandPriority(sess, commandId=command_id, body=req)
 
-        api.get(master_url, f"commands/{command_id}/events", auth=authentication.cli_auth)        
+        api.get(master_url, f"commands/{command_id}/events", auth=authentication.cli_auth)
         with api.ws(master_url, f"commands/{command_id}/events") as ws:
-            for msg in ws:
+            for _ in ws:
                 break
         return
-    
-    
+
+    assert command_id not in command_ids
     with pytest.raises(NotFoundException):
-        bindings.get_GetCommand(sess, commandId=command_id)    
+        bindings.get_GetCommand(sess, commandId=command_id)
     with pytest.raises(NotFoundException):
-        bindings.post_KillCommand(sess, commandId=command_id)        
-    with pytest.raises(NotFoundException):        
+        bindings.post_KillCommand(sess, commandId=command_id)
+    with pytest.raises(NotFoundException):
         req = bindings.v1SetCommandPriorityRequest(commandId=command_id, priority=50)
         bindings.post_SetCommandPriority(sess, commandId=command_id, body=req)
     with pytest.raises(NotFoundException):
         api.get(master_url, f"commands/{command_id}/events", auth=authentication.cli_auth)
     with pytest.raises(BadRequestException):
         with api.ws(master_url, f"commands/{command_id}/events") as ws:
-            for msg in ws:
+            for _ in ws:
                 break
-        
 
-def assert_tensorboard_access(creds: authentication.Credentials, tensorboard_id: str,
-                           can_access: bool) -> None:
+
+def assert_tensorboard_access(
+    creds: authentication.Credentials, tensorboard_id: str, can_access: bool
+) -> None:
     master_url = conf.make_master_url()
     authentication.cli_auth = authentication.Authentication(
-        master_url, creds.username, creds.password, try_reauth=True)    
+        master_url, creds.username, creds.password, try_reauth=True
+    )
     sess = api.Session(master_url, None, None, None)
 
     resp = bindings.get_GetTensorboards(sess)
-    found = any([True for tensorboard in resp.tensorboards if tensorboard.id == tensorboard_id])
-    assert (found and can_access,
-            f"checking if tensorboard is returned in GetTensorboards found: " +
-            "{found} expected: {can_access}")
-    
+    tensorboard_ids = [tensorboard.id for tensorboard in resp.tensorboards or []]
     if can_access:
-        assert bindings.get_GetTensorboard(sess, tensorboardId=tensorboard_id) is not None
+        assert tensorboard_id in tensorboard_ids
+        bindings.get_GetTensorboard(sess, tensorboardId=tensorboard_id)
 
         req = bindings.v1SetTensorboardPriorityRequest(tensorboardId=tensorboard_id, priority=50)
-        assert bindings.post_SetTensorboardPriority(
-            sess, tensorboardId=tensorboard_id, body=req) is not None
+        bindings.post_SetTensorboardPriority(sess, tensorboardId=tensorboard_id, body=req)
 
-        api.get(master_url, f"tensorboard/{tensorboard_id}/events", auth=authentication.cli_auth)   
+        api.get(master_url, f"tensorboard/{tensorboard_id}/events", auth=authentication.cli_auth)
         with api.ws(master_url, f"tensorboard/{tensorboard_id}/events") as ws:
-            for msg in ws:
-                break        
+            for _ in ws:
+                break
         return
 
+    assert tensorboard_id not in tensorboard_ids
     with pytest.raises(NotFoundException):
-        bindings.get_GetTensorboard(sess, tensorboardId=tensorboard_id)    
+        bindings.get_GetTensorboard(sess, tensorboardId=tensorboard_id)
     with pytest.raises(NotFoundException):
-        bindings.post_KillTensorboard(sess, tensorboardId=tensorboard_id)        
-    with pytest.raises(NotFoundException):        
+        bindings.post_KillTensorboard(sess, tensorboardId=tensorboard_id)
+    with pytest.raises(NotFoundException):
         req = bindings.v1SetTensorboardPriorityRequest(tensorboardId=tensorboard_id, priority=50)
-        bindings.post_SetTensorboardPriority(sess, tensorboardId=tensorboard_id, body=req) 
+        bindings.post_SetTensorboardPriority(sess, tensorboardId=tensorboard_id, body=req)
     with pytest.raises(NotFoundException):
         api.get(master_url, f"/proxy/{tensorboard_id}/", auth=authentication.cli_auth)
     with pytest.raises(NotFoundException):
         api.get(master_url, f"tensorboard/{tensorboard_id}/events", auth=authentication.cli_auth)
     with pytest.raises(BadRequestException):
         with api.ws(master_url, f"tensorboard/{tensorboard_id}/events") as ws:
-            for msg in ws:
+            for _ in ws:
                 break
-    
 
-def assert_access_task(creds: authentication.Credentials, task_id: str,
-                           can_access: bool) -> None:
+
+def assert_access_task(creds: authentication.Credentials, task_id: str, can_access: bool) -> None:
     master_url = conf.make_master_url()
     authentication.cli_auth = authentication.Authentication(
-        master_url, creds.username, creds.password, try_reauth=True)    
+        master_url, creds.username, creds.password, try_reauth=True
+    )
     sess = api.Session(master_url, None, None, None)
-    
-    resp = api.get(master_url, f"/tasks", auth=authentication.cli_auth).json()
+
+    resp = api.get(master_url, "/tasks", auth=authentication.cli_auth).json()
     task_ids = [resp[alloc]["task_id"] for alloc in resp]
     if can_access:
         assert task_id in task_ids
-    else:
-        assert task_id not in task_ids    
-
-    if can_access:
-        assert bindings.get_GetTask(sess, taskId=task_id) is not None
-        assert bindings.get_TaskLogs(sess, taskId=task_id, follow=False) is not None
-        assert bindings.get_TaskLogsFields(sess, taskId=task_id, follow=False) is not None        
+        bindings.get_GetTask(sess, taskId=task_id)
+        bindings.get_TaskLogs(sess, taskId=task_id, follow=False)
+        bindings.get_TaskLogsFields(sess, taskId=task_id, follow=False)
         return
 
+    assert task_id not in task_ids
     with pytest.raises(NotFoundException):
         bindings.get_GetTask(sess, taskId=task_id)
-    with pytest.raises(APIException): # TODO make this return 404?
+    with pytest.raises(APIException):  # TODO make this return 404?
         for _ in bindings.get_TaskLogs(sess, taskId=task_id, follow=False):
             pass
-    with pytest.raises(APIException): # TODO make this return 404?
+    with pytest.raises(APIException):  # TODO make this return 404?
         for _ in bindings.get_TaskLogsFields(sess, taskId=task_id, follow=False):
             pass
     with pytest.raises(NotFoundException):
         alloc_id = task_id + ".1"
         req = bindings.v1AllocationReadyRequest(allocationId=alloc_id)
         bindings.post_AllocationReady(sess, allocationId=alloc_id, body=req)
-        
+
+
 def strict_task_test(start_command: List[str], start_message: str, assert_access_func: Any) -> None:
     user_a = create_test_user(ADMIN_CREDENTIALS)
-    user_b = create_test_user(ADMIN_CREDENTIALS)    
-    
+    user_b = create_test_user(ADMIN_CREDENTIALS)
+
     with logged_in_user(user_a):
         with cmd.interactive_command(*start_command) as task:
             for line in task.stdout:
                 if start_message in line:
                     break
             else:
-                pytest.fail(f"Did not find expected input '{start_message}' in task stdout.")        
+                pytest.fail(f"Did not find expected input '{start_message}' in task stdout.")
+
+            assert task.task_id is not None
 
             assert_access_task(user_a, task.task_id, True)
             assert_access_task(user_b, task.task_id, False)
-            assert_access_task(ADMIN_CREDENTIALS, task.task_id, True)            
-            
+            assert_access_task(ADMIN_CREDENTIALS, task.task_id, True)
+
             assert_access_func(user_a, task.task_id, True)
             assert_access_func(user_b, task.task_id, False)
             assert_access_func(ADMIN_CREDENTIALS, task.task_id, True)
 
-# TODO mark
-# stress_test
-@pytest.mark.stress_test            
-def test_strict_shell():
+
+@pytest.mark.test_strict_ntsc
+def test_strict_shell() -> None:
     strict_task_test(["shell", "start"], "has started...", assert_shell_access)
 
 
-# TODO mark
-# stress_test
-@pytest.mark.stress_test            
-def test_strict_notebook():
-    strict_task_test(["notebook", "start", "--no-browser"],
-                     "has started...", assert_notebook_access)    
+@pytest.mark.test_strict_ntsc
+def test_strict_notebook() -> None:
+    strict_task_test(
+        ["notebook", "start", "--no-browser"], "has started...", assert_notebook_access
+    )
 
-# TODO mark
-# stress_test
-@pytest.mark.stress_test            
-def test_strict_command():
+
+@pytest.mark.test_strict_ntsc
+def test_strict_command() -> None:
     strict_task_test(["command", "run", "sleep", "300"], "have started", assert_command_access)
 
-# TODO mark
-# stress_test
-@pytest.mark.stress_test            
-def test_strict_tensorboard():
-    exp_id = exp.run_basic_test(
-        conf.fixtures_path("no_op/single-one-short-step.yaml"),
-        conf.fixtures_path("no_op"),
-        1,
-    )
-    strict_task_test(["tensorboard", "start", str(exp_id), "--no-browser"],
-                     "has started", assert_tensorboard_access)
 
-    
-    
-            
+@pytest.mark.test_strict_ntsc
+def test_strict_tensorboard() -> None:
+    with logged_in_user(ADMIN_CREDENTIALS):
+        exp_id = exp.run_basic_test(
+            conf.fixtures_path("no_op/single-one-short-step.yaml"),
+            conf.fixtures_path("no_op"),
+            1,
+        )
+    strict_task_test(
+        ["tensorboard", "start", str(exp_id), "--no-browser"],
+        "has started",
+        assert_tensorboard_access,
+    )
+
+
+@pytest.mark.test_strict_ntsc
+def test_strict_active_task_count() -> None:
+    master_url = conf.make_master_url()
+
+    authentication.cli_auth = authentication.Authentication(
+        master_url, ADMIN_CREDENTIALS.username, ADMIN_CREDENTIALS.password, try_reauth=True
+    )
+    sess = api.Session(master_url, None, None, None)
+    bindings.get_GetActiveTasksCount(sess)
+
+    non_admin = create_test_user(ADMIN_CREDENTIALS)
+    authentication.cli_auth = authentication.Authentication(
+        master_url, non_admin.username, non_admin.password, try_reauth=True
+    )
+    sess = api.Session(master_url, None, None, None)
+    with pytest.raises(ForbiddenException):
+        bindings.get_GetActiveTasksCount(sess)

--- a/e2e_tests/tests/command/test_strict_ntsc.py
+++ b/e2e_tests/tests/command/test_strict_ntsc.py
@@ -249,12 +249,11 @@ def test_strict_command() -> None:
 
 @pytest.mark.test_strict_ntsc
 def test_strict_tensorboard() -> None:
-    with logged_in_user(ADMIN_CREDENTIALS):
-        exp_id = exp.run_basic_test(
-            conf.fixtures_path("no_op/single-one-short-step.yaml"),
-            conf.fixtures_path("no_op"),
-            1,
-        )
+    exp_id = exp.run_basic_test(
+        conf.fixtures_path("no_op/single-one-short-step.yaml"),
+        conf.fixtures_path("no_op"),
+        1,
+    )
     strict_task_test(
         ["tensorboard", "start", str(exp_id), "--no-browser"],
         "has started",

--- a/e2e_tests/tests/command/test_strict_ntsc.py
+++ b/e2e_tests/tests/command/test_strict_ntsc.py
@@ -21,7 +21,7 @@ def assert_shell_access(creds: authentication.Credentials, shell_id: str, can_ac
     resp = bindings.get_GetShells(sess)
     shell_ids = [shell.id for shell in resp.shells or []]
     if can_access:
-        assert shell_id in shell_id
+        assert shell_id in shell_ids
         bindings.get_GetShell(sess, shellId=shell_id)
         req = bindings.v1SetShellPriorityRequest(shellId=shell_id, priority=50)
         bindings.post_SetShellPriority(sess, shellId=shell_id, body=req)

--- a/e2e_tests/tests/command/test_strict_ntsc.py
+++ b/e2e_tests/tests/command/test_strict_ntsc.py
@@ -4,12 +4,7 @@ import pytest
 
 from determined.common import api
 from determined.common.api import authentication, bindings
-from determined.common.api.errors import (
-    APIException,
-    BadRequestException,
-    ForbiddenException,
-    NotFoundException,
-)
+from determined.common.api.errors import APIException, BadRequestException, NotFoundException
 from tests import command as cmd
 from tests import config as conf
 from tests import experiment as exp
@@ -200,10 +195,10 @@ def assert_access_task(creds: authentication.Credentials, task_id: str, can_acce
     assert task_id not in task_ids
     with pytest.raises(NotFoundException):
         bindings.get_GetTask(sess, taskId=task_id)
-    with pytest.raises(APIException):  
+    with pytest.raises(APIException):
         for _ in bindings.get_TaskLogs(sess, taskId=task_id, follow=False):
             pass
-    with pytest.raises(APIException):  
+    with pytest.raises(APIException):
         for _ in bindings.get_TaskLogsFields(sess, taskId=task_id, follow=False):
             pass
     with pytest.raises(NotFoundException):
@@ -265,4 +260,3 @@ def test_strict_tensorboard() -> None:
         "has started",
         assert_tensorboard_access,
     )
-

--- a/e2e_tests/tests/command/test_strict_ntsc.py
+++ b/e2e_tests/tests/command/test_strict_ntsc.py
@@ -200,10 +200,10 @@ def assert_access_task(creds: authentication.Credentials, task_id: str, can_acce
     assert task_id not in task_ids
     with pytest.raises(NotFoundException):
         bindings.get_GetTask(sess, taskId=task_id)
-    with pytest.raises(APIException):  # TODO make this return 404?
+    with pytest.raises(APIException):  
         for _ in bindings.get_TaskLogs(sess, taskId=task_id, follow=False):
             pass
-    with pytest.raises(APIException):  # TODO make this return 404?
+    with pytest.raises(APIException):  
         for _ in bindings.get_TaskLogsFields(sess, taskId=task_id, follow=False):
             pass
     with pytest.raises(NotFoundException):
@@ -266,21 +266,3 @@ def test_strict_tensorboard() -> None:
         assert_tensorboard_access,
     )
 
-
-@pytest.mark.test_strict_ntsc
-def test_strict_active_task_count() -> None:
-    master_url = conf.make_master_url()
-
-    authentication.cli_auth = authentication.Authentication(
-        master_url, ADMIN_CREDENTIALS.username, ADMIN_CREDENTIALS.password, try_reauth=True
-    )
-    sess = api.Session(master_url, None, None, None)
-    bindings.get_GetActiveTasksCount(sess)
-
-    non_admin = create_test_user(ADMIN_CREDENTIALS)
-    authentication.cli_auth = authentication.Authentication(
-        master_url, non_admin.username, non_admin.password, try_reauth=True
-    )
-    sess = api.Session(master_url, None, None, None)
-    with pytest.raises(ForbiddenException):
-        bindings.get_GetActiveTasksCount(sess)

--- a/e2e_tests/tests/conftest.py
+++ b/e2e_tests/tests/conftest.py
@@ -28,6 +28,7 @@ _INTEG_MARKERS = {
     "e2e_gpu",
     "det_deploy_local",
     "stress_test",
+    "test_strict_ntsc",
     "distributed",
     "parallel",
     "nightly",

--- a/harness/determined/cli/shell.py
+++ b/harness/determined/cli/shell.py
@@ -66,6 +66,7 @@ def open_shell(args: Namespace) -> None:
     shell_id = command.expand_uuid_prefixes(args)
     shell = api.get(args.master, f"api/v1/shells/{shell_id}").json()["shell"]
     check_eq(shell["state"], "STATE_RUNNING", "Shell must be in a running state")
+    print("opening shell", shell)
     _open_shell(
         args.master,
         shell,

--- a/harness/determined/cli/shell.py
+++ b/harness/determined/cli/shell.py
@@ -66,7 +66,6 @@ def open_shell(args: Namespace) -> None:
     shell_id = command.expand_uuid_prefixes(args)
     shell = api.get(args.master, f"api/v1/shells/{shell_id}").json()["shell"]
     check_eq(shell["state"], "STATE_RUNNING", "Shell must be in a running state")
-    print("opening shell", shell)
     _open_shell(
         args.master,
         shell,

--- a/master/internal/api_command.go
+++ b/master/internal/api_command.go
@@ -18,6 +18,7 @@ import (
 	"google.golang.org/protobuf/encoding/protojson"
 
 	"github.com/determined-ai/determined/master/internal/api"
+	"github.com/determined-ai/determined/master/internal/config"
 	"github.com/determined-ai/determined/master/internal/grpcutil"
 	"github.com/determined-ai/determined/master/internal/user"
 	"github.com/determined-ai/determined/master/pkg/actor"
@@ -163,31 +164,69 @@ func (a *apiServer) getCommandLaunchParams(ctx context.Context, req *protoComman
 	}, nil
 }
 
+func canAccessCommand(curUser model.User, command *commandv1.Command) bool {
+	if !config.EnforceStrictNTSC() {
+		return true
+	}
+	return curUser.Admin || model.UserID(command.UserId) == curUser.ID
+}
+
 func (a *apiServer) GetCommands(
-	_ context.Context, req *apiv1.GetCommandsRequest,
+	ctx context.Context, req *apiv1.GetCommandsRequest,
 ) (resp *apiv1.GetCommandsResponse, err error) {
+	curUser, _, err := grpcutil.GetUser(ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	if err = a.ask(commandsAddr, req, &resp); err != nil {
 		return nil, err
 	}
+
+	a.filter(&resp.Commands, func(i int) bool {
+		return canAccessCommand(*curUser, resp.Commands[i])
+	})
+
 	a.sort(resp.Commands, req.OrderBy, req.SortBy, apiv1.GetCommandsRequest_SORT_BY_ID)
 	return resp, a.paginate(&resp.Pagination, &resp.Commands, req.Offset, req.Limit)
 }
 
 func (a *apiServer) GetCommand(
-	_ context.Context, req *apiv1.GetCommandRequest,
+	ctx context.Context, req *apiv1.GetCommandRequest,
 ) (resp *apiv1.GetCommandResponse, err error) {
-	return resp, a.ask(commandsAddr.Child(req.CommandId), req, &resp)
+	curUser, _, err := grpcutil.GetUser(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	addr := commandsAddr.Child(req.CommandId)
+	if err := a.ask(addr, req, &resp); err != nil {
+		return nil, err
+	}
+
+	if !canAccessCommand(*curUser, resp.Command) {
+		return nil, errActorNotFound(addr)
+	}
+	return resp, nil
 }
 
 func (a *apiServer) KillCommand(
-	_ context.Context, req *apiv1.KillCommandRequest,
+	ctx context.Context, req *apiv1.KillCommandRequest,
 ) (resp *apiv1.KillCommandResponse, err error) {
+	if _, err := a.GetCommand(ctx, &apiv1.GetCommandRequest{CommandId: req.CommandId}); err != nil {
+		return nil, err
+	}
+
 	return resp, a.ask(commandsAddr.Child(req.CommandId), req, &resp)
 }
 
 func (a *apiServer) SetCommandPriority(
-	_ context.Context, req *apiv1.SetCommandPriorityRequest,
+	ctx context.Context, req *apiv1.SetCommandPriorityRequest,
 ) (resp *apiv1.SetCommandPriorityResponse, err error) {
+	if _, err := a.GetCommand(ctx, &apiv1.GetCommandRequest{CommandId: req.CommandId}); err != nil {
+		return nil, err
+	}
+
 	return resp, a.ask(commandsAddr.Child(req.CommandId), req, &resp)
 }
 

--- a/master/internal/api_experiment_intg_test.go
+++ b/master/internal/api_experiment_intg_test.go
@@ -889,6 +889,12 @@ func TestAuthZGetExperimentAndCanDoActions(t *testing.T) {
 			})
 			return err
 		}},
+		{"CanGetExperimentArtifacts", func(id int) error {
+			_, err := api.LaunchTensorboard(ctx, &apiv1.LaunchTensorboardRequest{
+				ExperimentIds: []int32{int32(id)},
+			})
+			return err
+		}},
 	}
 
 	for _, curCase := range cases {

--- a/master/internal/api_notebook.go
+++ b/master/internal/api_notebook.go
@@ -14,6 +14,8 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/determined-ai/determined/master/internal/api"
+	"github.com/determined-ai/determined/master/internal/config"
+	"github.com/determined-ai/determined/master/internal/grpcutil"
 	"github.com/determined-ai/determined/master/pkg/actor"
 	"github.com/determined-ai/determined/master/pkg/archive"
 	"github.com/determined-ai/determined/master/pkg/check"
@@ -40,37 +42,82 @@ const (
 
 var notebooksAddr = actor.Addr("notebooks")
 
+func canAccessNotebook(curUser model.User, notebook *notebookv1.Notebook) bool {
+	if !config.EnforceStrictNTSC() {
+		return true
+	}
+	return curUser.Admin || model.UserID(notebook.UserId) == curUser.ID
+}
+
 func (a *apiServer) GetNotebooks(
-	_ context.Context, req *apiv1.GetNotebooksRequest,
+	ctx context.Context, req *apiv1.GetNotebooksRequest,
 ) (resp *apiv1.GetNotebooksResponse, err error) {
+	curUser, _, err := grpcutil.GetUser(ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	if err = a.ask(notebooksAddr, req, &resp); err != nil {
 		return nil, err
 	}
+
+	a.filter(&resp.Notebooks, func(i int) bool {
+		return canAccessNotebook(*curUser, resp.Notebooks[i])
+	})
+
 	a.sort(resp.Notebooks, req.OrderBy, req.SortBy, apiv1.GetNotebooksRequest_SORT_BY_ID)
 	return resp, a.paginate(&resp.Pagination, &resp.Notebooks, req.Offset, req.Limit)
 }
 
 func (a *apiServer) GetNotebook(
-	_ context.Context, req *apiv1.GetNotebookRequest,
+	ctx context.Context, req *apiv1.GetNotebookRequest,
 ) (resp *apiv1.GetNotebookResponse, err error) {
-	return resp, a.ask(notebooksAddr.Child(req.NotebookId), req, &resp)
+	curUser, _, err := grpcutil.GetUser(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	addr := notebooksAddr.Child(req.NotebookId)
+	if err = a.ask(addr, req, &resp); err != nil {
+		return nil, err
+	}
+
+	if !canAccessNotebook(*curUser, resp.Notebook) {
+		return nil, errActorNotFound(addr)
+	}
+	return resp, nil
 }
 
 func (a *apiServer) IdleNotebook(
-	_ context.Context, req *apiv1.IdleNotebookRequest,
+	ctx context.Context, req *apiv1.IdleNotebookRequest,
 ) (resp *apiv1.IdleNotebookResponse, err error) {
+	if _, err := a.GetNotebook(ctx,
+		&apiv1.GetNotebookRequest{NotebookId: req.NotebookId}); err != nil {
+		return nil, err
+	}
+
 	return resp, a.ask(notebooksAddr.Child(req.NotebookId), req, &resp)
 }
 
 func (a *apiServer) KillNotebook(
-	_ context.Context, req *apiv1.KillNotebookRequest,
+	ctx context.Context, req *apiv1.KillNotebookRequest,
 ) (resp *apiv1.KillNotebookResponse, err error) {
+	if _, err := a.GetNotebook(ctx,
+		&apiv1.GetNotebookRequest{NotebookId: req.NotebookId}); err != nil {
+		return nil, err
+	}
+
 	return resp, a.ask(notebooksAddr.Child(req.NotebookId), req, &resp)
 }
 
 func (a *apiServer) SetNotebookPriority(
-	_ context.Context, req *apiv1.SetNotebookPriorityRequest,
+	ctx context.Context, req *apiv1.SetNotebookPriorityRequest,
 ) (resp *apiv1.SetNotebookPriorityResponse, err error) {
+	if _, err := a.GetNotebook(ctx,
+		&apiv1.GetNotebookRequest{NotebookId: req.NotebookId}); err != nil {
+		return nil, err
+	}
+
 	return resp, a.ask(notebooksAddr.Child(req.NotebookId), req, &resp)
 }
 

--- a/master/internal/api_notebook.go
+++ b/master/internal/api_notebook.go
@@ -55,6 +55,9 @@ func (a *apiServer) GetNotebooks(
 	}
 
 	a.filter(&resp.Notebooks, func(i int) bool {
+		if err != nil {
+			return false
+		}
 		ok, serverError := expauth.AuthZProvider.Get().CanAccessNTSCTask(
 			*curUser, model.UserID(resp.Notebooks[i].UserId))
 		if serverError != nil {

--- a/master/internal/api_shell.go
+++ b/master/internal/api_shell.go
@@ -57,11 +57,12 @@ func (a *apiServer) GetShells(
 	if err = a.ask(shellsAddr, req, &resp); err != nil {
 		return nil, err
 	}
-	a.sort(resp.Shells, req.OrderBy, req.SortBy, apiv1.GetShellsRequest_SORT_BY_ID)
 
 	a.filter(&resp.Shells, func(i int) bool {
 		return canAccessShell(*curUser, resp.Shells[i])
 	})
+
+	a.sort(resp.Shells, req.OrderBy, req.SortBy, apiv1.GetShellsRequest_SORT_BY_ID)
 	return resp, a.paginate(&resp.Pagination, &resp.Shells, req.Offset, req.Limit)
 }
 

--- a/master/internal/api_shell.go
+++ b/master/internal/api_shell.go
@@ -75,7 +75,7 @@ func (a *apiServer) GetShell(
 	}
 
 	addr := shellsAddr.Child(req.ShellId)
-	if err := a.ask(addr, req, &resp); err != nil {
+	if err = a.ask(addr, req, &resp); err != nil {
 		return nil, err
 	}
 

--- a/master/internal/api_tasks.go
+++ b/master/internal/api_tasks.go
@@ -308,7 +308,7 @@ func (a *apiServer) GetActiveTasksCount(
 	if err != nil {
 		return nil, err
 	}
-	if err := expauth.AuthZProvider.Get().CanGetActiveTasksCount(*curUser); err != nil {
+	if err = expauth.AuthZProvider.Get().CanGetActiveTasksCount(*curUser); err != nil {
 		return nil, status.Error(codes.PermissionDenied, err.Error())
 	}
 

--- a/master/internal/api_tasks.go
+++ b/master/internal/api_tasks.go
@@ -73,7 +73,7 @@ func canAccessNTSCTask(ctx context.Context, curUser model.User, taskID model.Tas
 	}
 	taskOwnerID, err := db.GetCommandOwnerID(ctx, taskID)
 	if errors.Is(err, db.ErrNotFound) {
-		// Non NTSC case like checkpointGC case.
+		// Non NTSC case like checkpointGC case or the task just does not exist.
 		// TODO(nick) eventually control access to checkpointGC.
 		return true, nil
 	} else if err != nil {

--- a/master/internal/api_tasks.go
+++ b/master/internal/api_tasks.go
@@ -308,13 +308,11 @@ func (a *apiServer) GetActiveTasksCount(
 	if err != nil {
 		return nil, err
 	}
-	if config.EnforceStrictNTSC() && !curUser.Admin {
-		return nil, status.Error(codes.PermissionDenied,
-			"with strict tasks enabled you need admin to view task counts")
+	if err := expauth.AuthZProvider.Get().CanGetActiveTasksCount(*curUser); err != nil {
+		return nil, status.Error(codes.PermissionDenied, err.Error())
 	}
 
 	finalResp := &apiv1.GetActiveTasksCountResponse{}
-
 	req1 := &apiv1.GetNotebooksRequest{}
 	resp1 := &apiv1.GetNotebooksResponse{}
 	if err = a.ask(notebooksAddr, req1, &resp1); err != nil {

--- a/master/internal/api_tasks.go
+++ b/master/internal/api_tasks.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/pkg/errors"
@@ -14,6 +15,7 @@ import (
 	"github.com/hashicorp/go-multierror"
 
 	"github.com/determined-ai/determined/master/internal/api"
+	"github.com/determined-ai/determined/master/internal/config"
 	"github.com/determined-ai/determined/master/internal/db"
 	expauth "github.com/determined-ai/determined/master/internal/experiment"
 	"github.com/determined-ai/determined/master/internal/grpcutil"
@@ -65,6 +67,21 @@ func expFromAllocationID(
 	return true, exp, nil
 }
 
+func canAccessNTSCTask(ctx context.Context, curUser model.User, taskID model.TaskID) (bool, error) {
+	if !config.EnforceStrictNTSC() {
+		return true, nil
+	}
+	taskOwnerID, err := db.GetCommandOwnerID(ctx, taskID)
+	if errors.Is(err, db.ErrNotFound) {
+		// Non NTSC case like checkpointGC case.
+		// TODO(nick) eventually control access to checkpointGC.
+		return true, nil
+	} else if err != nil {
+		return false, err
+	}
+	return curUser.Admin || curUser.ID == taskOwnerID, nil
+}
+
 func (a *apiServer) canDoActionsOnTask(
 	ctx context.Context, taskID model.TaskID, actions ...func(model.User, *model.Experiment) error,
 ) error {
@@ -76,6 +93,11 @@ func (a *apiServer) canDoActionsOnTask(
 		return err
 	}
 
+	curUser, _, err := grpcutil.GetUser(ctx)
+	if err != nil {
+		return err
+	}
+
 	switch t.TaskType {
 	case model.TaskTypeTrial:
 		exp, err := db.ExperimentWithoutConfigByTaskID(ctx, t.TaskID)
@@ -83,10 +105,6 @@ func (a *apiServer) canDoActionsOnTask(
 			return err
 		}
 
-		curUser, _, err := grpcutil.GetUser(ctx)
-		if err != nil {
-			return err
-		}
 		var ok bool
 		if ok, err = expauth.AuthZProvider.Get().CanGetExperiment(*curUser, exp); err != nil {
 			return err
@@ -99,31 +117,43 @@ func (a *apiServer) canDoActionsOnTask(
 				return status.Error(codes.PermissionDenied, err.Error())
 			}
 		}
-	default:
-		return nil // TODO(nick) add AuthZ for other task types.
+	default: // NTSC case + checkpointGC.
+		if ok, err := canAccessNTSCTask(ctx, *curUser, taskID); err != nil {
+			return err
+		} else if !ok {
+			return errTaskNotFound
+		}
 	}
 	return nil
 }
 
 func (a *apiServer) canEditAllocation(ctx context.Context, allocationID string) error {
+	curUser, _, err := grpcutil.GetUser(ctx)
+	if err != nil {
+		return err
+	}
+
+	errAllocationNotFound := status.Errorf(codes.NotFound, "allocation not found: %s", allocationID)
 	isExp, exp, err := expFromAllocationID(a.m, model.AllocationID(allocationID))
 	if err != nil {
 		return err
 	}
 	if !isExp {
-		return nil // TODO(nick) add other task type auth checking.
-	}
-
-	curUser, _, err := grpcutil.GetUser(ctx)
-	if err != nil {
-		return err
+		taskID, _, _ := strings.Cut(allocationID, ".")
+		var ok bool
+		if ok, err = canAccessNTSCTask(ctx, *curUser, model.TaskID(taskID)); err != nil {
+			return err
+		} else if !ok {
+			return errAllocationNotFound
+		}
+		return nil
 	}
 
 	var ok bool
 	if ok, err = expauth.AuthZProvider.Get().CanGetExperiment(*curUser, exp); err != nil {
 		return err
 	} else if !ok {
-		return status.Errorf(codes.NotFound, "allocation not found: %s", allocationID)
+		return errAllocationNotFound
 	}
 	if err = expauth.AuthZProvider.Get().CanEditExperiment(*curUser, exp); err != nil {
 		return status.Error(codes.PermissionDenied, err.Error())

--- a/master/internal/api_tasks.go
+++ b/master/internal/api_tasks.go
@@ -302,8 +302,17 @@ func (a *apiServer) TaskLogs(
 }
 
 func (a *apiServer) GetActiveTasksCount(
-	_ context.Context, req *apiv1.GetActiveTasksCountRequest,
+	ctx context.Context, req *apiv1.GetActiveTasksCountRequest,
 ) (resp *apiv1.GetActiveTasksCountResponse, err error) {
+	curUser, _, err := grpcutil.GetUser(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if config.EnforceStrictNTSC() && !curUser.Admin {
+		return nil, status.Error(codes.PermissionDenied,
+			"with strict tasks enabled you need admin to view task counts")
+	}
+
 	finalResp := &apiv1.GetActiveTasksCountResponse{}
 
 	req1 := &apiv1.GetNotebooksRequest{}

--- a/master/internal/api_tasks_intg_test.go
+++ b/master/internal/api_tasks_intg_test.go
@@ -20,6 +20,13 @@ func errTaskNotFound(id string) error {
 	return status.Errorf(codes.NotFound, "task not found: %s", id)
 }
 
+func TestTasksCountAuthZ(t *testing.T) {
+	api, authZExp, _, curUser, ctx := setupExpAuthTest(t)
+	authZExp.On("CanGetActiveTasksCount", curUser).Return(fmt.Errorf("deny"))
+	_, err := api.GetActiveTasksCount(ctx, &apiv1.GetActiveTasksCountRequest{})
+	require.Equal(t, status.Error(codes.PermissionDenied, "deny"), err)
+}
+
 func TestTaskAuthZ(t *testing.T) {
 	api, authZExp, _, curUser, ctx := setupExpAuthTest(t)
 

--- a/master/internal/api_tensorboard.go
+++ b/master/internal/api_tensorboard.go
@@ -50,6 +50,8 @@ const (
 var tensorboardsAddr = actor.Addr("tensorboard")
 
 func canAccessTensorboard(curUser model.User, tensorboard *tensorboardv1.Tensorboard) bool {
+	fmt.Println("CAN ACCESS TENSORBOARD", curUser, tensorboard.UserId, tensorboard,
+		curUser.Admin || model.UserID(tensorboard.UserId) == curUser.ID)
 	if !config.EnforceStrictNTSC() {
 		return true
 	}
@@ -87,7 +89,7 @@ func (a *apiServer) GetTensorboards(
 	a.sort(resp.Tensorboards, req.OrderBy, req.SortBy, apiv1.GetTensorboardsRequest_SORT_BY_ID)
 
 	a.filter(&resp.Tensorboards, func(i int) bool {
-		return canAccessTensorboard(*curUser, resp.Tensorboards[0])
+		return canAccessTensorboard(*curUser, resp.Tensorboards[i])
 	})
 	return resp, a.paginate(&resp.Pagination, &resp.Tensorboards, req.Offset, req.Limit)
 }

--- a/master/internal/api_trials_intg_test.go
+++ b/master/internal/api_trials_intg_test.go
@@ -174,6 +174,12 @@ func TestTrialAuthZ(t *testing.T) {
 				TrialId: []int32{int32(id)},
 			}, mockStream[*apiv1.ExpCompareMetricNamesResponse]{ctx})
 		}, false},
+		{"CanGetExperimentArtifacts", func(id int) error {
+			_, err := api.LaunchTensorboard(ctx, &apiv1.LaunchTensorboardRequest{
+				TrialIds: []int32{int32(id)},
+			})
+			return err
+		}, false},
 	}
 
 	for _, curCase := range cases {

--- a/master/internal/command/events.go
+++ b/master/internal/command/events.go
@@ -11,9 +11,13 @@ import (
 	"github.com/labstack/echo/v4"
 
 	webAPI "github.com/determined-ai/determined/master/internal/api"
+	"github.com/determined-ai/determined/master/internal/config"
+	"github.com/determined-ai/determined/master/internal/context"
+	"github.com/determined-ai/determined/master/internal/db"
 	"github.com/determined-ai/determined/master/pkg/actor"
 	"github.com/determined-ai/determined/master/pkg/actor/api"
 	"github.com/determined-ai/determined/master/pkg/check"
+	"github.com/determined-ai/determined/master/pkg/model"
 )
 
 const defaultEventBufferSize = 200
@@ -76,6 +80,11 @@ func (e *eventManager) Receive(ctx *actor.Context) error {
 		}
 
 	case api.WebSocketConnected:
+		if err := canAccessCommandEvents(ctx, msg.Ctx); err != nil {
+			ctx.Respond(err)
+			break
+		}
+
 		follow, err := strconv.ParseBool(msg.Ctx.QueryParam("follow"))
 		if msg.Ctx.QueryParam("follow") == "" {
 			follow = true
@@ -123,6 +132,23 @@ func (e *eventManager) Receive(ctx *actor.Context) error {
 	return nil
 }
 
+func canAccessCommandEvents(ctx *actor.Context, c echo.Context) error {
+	if !config.EnforceStrictNTSC() {
+		return nil
+	}
+
+	curUser := c.(*context.DetContext).MustGetUser()
+	taskID := model.TaskID(ctx.Self().Parent().Address().Local())
+	ownerID, err := db.GetCommandOwnerID(c.Request().Context(), taskID)
+	if err != nil {
+		return err
+	}
+	if !curUser.Admin && curUser.ID != ownerID {
+		return echo.NewHTTPError(http.StatusNotFound, "Not Found")
+	}
+	return nil
+}
+
 // validEvent returns true if the given event's Seq value is within the bounds specified
 // by greaterThanSeq and lessThanSeq. Note that these values can be nil, in which case the
 // particular bound is not regarded.
@@ -141,6 +167,11 @@ func validEvent(e sproto.Event, greaterThanSeq, lessThanSeq *int) bool {
 func (e *eventManager) handleAPIRequest(ctx *actor.Context, apiCtx echo.Context) {
 	switch apiCtx.Request().Method {
 	case echo.GET:
+		if err := canAccessCommandEvents(ctx, apiCtx); err != nil {
+			ctx.Respond(err)
+			return
+		}
+
 		args := struct {
 			GreaterThanID *int `query:"greater_than_id"`
 			LessThanID    *int `query:"less_than_id"`

--- a/master/internal/config/authz_config.go
+++ b/master/internal/config/authz_config.go
@@ -20,9 +20,10 @@ const BasicAuthZType = "basic"
 
 // AuthZConfig is a authz-related section of master config.
 type AuthZConfig struct {
-	Type          string  `json:"type"`
-	FallbackType  *string `json:"fallback"`
-	RBACUIEnabled *bool   `json:"rbac_ui_enabled"`
+	Type              string  `json:"type"`
+	FallbackType      *string `json:"fallback"`
+	RBACUIEnabled     *bool   `json:"rbac_ui_enabled"`
+	StrictNTSCEnabled bool    `json:"_strict_ntsc_enabled"`
 }
 
 // DefaultAuthZConfig returns default authz config.
@@ -64,7 +65,8 @@ func (c AuthZConfig) IsRBACUIEnabled() bool {
 // EnforceStrictNTSC returns if non-admin users
 // can only see and access their own notebooks, tasks, commands, shells.
 func EnforceStrictNTSC() bool {
-	return GetMasterConfig().Security.AuthZ.Type == "rbac" || true // TODO remove
+	return GetMasterConfig().Security.AuthZ.Type == "rbac" ||
+		GetMasterConfig().Security.AuthZ.StrictNTSCEnabled
 }
 
 func initAuthZTypes() {

--- a/master/internal/config/authz_config.go
+++ b/master/internal/config/authz_config.go
@@ -62,13 +62,6 @@ func (c AuthZConfig) IsRBACUIEnabled() bool {
 	return c.Type != BasicAuthZType
 }
 
-// EnforceStrictNTSC returns if non-admin users
-// can only see and access their own notebooks, tasks, commands, shells.
-func EnforceStrictNTSC() bool {
-	return GetMasterConfig().Security.AuthZ.Type == "rbac" ||
-		GetMasterConfig().Security.AuthZ.StrictNTSCEnabled
-}
-
 func initAuthZTypes() {
 	authZConfigMutex.Lock()
 	defer authZConfigMutex.Unlock()

--- a/master/internal/config/authz_config.go
+++ b/master/internal/config/authz_config.go
@@ -61,6 +61,12 @@ func (c AuthZConfig) IsRBACUIEnabled() bool {
 	return c.Type != BasicAuthZType
 }
 
+// EnforceStrictNTSC returns if non-admin users
+// can only see and access their own notebooks, tasks, commands, shells.
+func EnforceStrictNTSC() bool {
+	return GetMasterConfig().Security.AuthZ.Type == "rbac" || true // TODO remove
+}
+
 func initAuthZTypes() {
 	authZConfigMutex.Lock()
 	defer authZConfigMutex.Unlock()

--- a/master/internal/db/postgres_command.go
+++ b/master/internal/db/postgres_command.go
@@ -1,0 +1,30 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/pkg/errors"
+	"github.com/uptrace/bun"
+
+	"github.com/determined-ai/determined/master/pkg/model"
+)
+
+func GetCommandOwnerID(ctx context.Context, taskID model.TaskID) (model.UserID, error) {
+	ownerIDBun := &struct {
+		bun.BaseModel `bun:"table:command_state"`
+		OwnerID       model.UserID `bun:"owner_id"`
+	}{}
+
+	if err := Bun().NewSelect().Model(ownerIDBun).
+		ColumnExpr("generic_command_spec->'Base'->'Owner'->'id' AS owner_id").
+		Where("task_id = ?", taskID).
+		Scan(ctx); err != nil {
+		if errors.Cause(err) == sql.ErrNoRows {
+			return 0, ErrNotFound
+		}
+		return 0, err
+	}
+
+	return ownerIDBun.OwnerID, nil
+}

--- a/master/internal/db/postgres_command.go
+++ b/master/internal/db/postgres_command.go
@@ -10,6 +10,8 @@ import (
 	"github.com/determined-ai/determined/master/pkg/model"
 )
 
+// GetCommandOwnerID gets a command's ownerID from a taskID. Uses persisted command state.
+// Returns db.ErrNotFound if a command with given taskID does not exist.
 func GetCommandOwnerID(ctx context.Context, taskID model.TaskID) (model.UserID, error) {
 	ownerIDBun := &struct {
 		bun.BaseModel `bun:"table:command_state"`

--- a/master/internal/experiment/authz_basic_impl.go
+++ b/master/internal/experiment/authz_basic_impl.go
@@ -109,7 +109,7 @@ func (a *ExperimentAuthZBasic) CanSetExperimentsCheckpointGCPolicy(
 	return nil
 }
 
-// CanGetActiveTaskCount always returns a nil error.
+// CanGetActiveTasksCount always returns a nil error.
 func (a *ExperimentAuthZBasic) CanGetActiveTasksCount(curUser model.User) error {
 	return nil
 }

--- a/master/internal/experiment/authz_basic_impl.go
+++ b/master/internal/experiment/authz_basic_impl.go
@@ -109,6 +109,11 @@ func (a *ExperimentAuthZBasic) CanSetExperimentsCheckpointGCPolicy(
 	return nil
 }
 
+// CanGetActiveTaskCount always returns a nil error.
+func (a *ExperimentAuthZBasic) CanGetActiveTasksCount(curUser model.User) error {
+	return nil
+}
+
 func init() {
 	AuthZProvider.Register("basic", &ExperimentAuthZBasic{})
 }

--- a/master/internal/experiment/authz_basic_impl.go
+++ b/master/internal/experiment/authz_basic_impl.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/uptrace/bun"
 
+	"github.com/determined-ai/determined/master/internal/config"
 	"github.com/determined-ai/determined/master/pkg/model"
 	"github.com/determined-ai/determined/proto/pkg/projectv1"
 )
@@ -112,6 +113,17 @@ func (a *ExperimentAuthZBasic) CanSetExperimentsCheckpointGCPolicy(
 // CanGetActiveTasksCount always returns a nil error.
 func (a *ExperimentAuthZBasic) CanGetActiveTasksCount(curUser model.User) error {
 	return nil
+}
+
+// CanAccessNTSCTask returns true and nil error unless the developer master config option
+// security.authz._strict_ntsc_enabled is true then it returns
+func (a *ExperimentAuthZBasic) CanAccessNTSCTask(
+	curUser model.User, ownerID model.UserID,
+) (bool, error) {
+	if !config.GetMasterConfig().Security.AuthZ.StrictNTSCEnabled {
+		return true, nil
+	}
+	return curUser.Admin || curUser.ID == ownerID, nil
 }
 
 func init() {

--- a/master/internal/experiment/authz_basic_impl.go
+++ b/master/internal/experiment/authz_basic_impl.go
@@ -116,7 +116,8 @@ func (a *ExperimentAuthZBasic) CanGetActiveTasksCount(curUser model.User) error 
 }
 
 // CanAccessNTSCTask returns true and nil error unless the developer master config option
-// security.authz._strict_ntsc_enabled is true then it returns
+// security.authz._strict_ntsc_enabled is true then it returns a boolean if the user is
+// an admin or if the user owns the task and a nil error.
 func (a *ExperimentAuthZBasic) CanAccessNTSCTask(
 	curUser model.User, ownerID model.UserID,
 ) (bool, error) {

--- a/master/internal/experiment/authz_iface.go
+++ b/master/internal/experiment/authz_iface.go
@@ -98,6 +98,7 @@ type ExperimentAuthZ interface {
 	// GET /api/v1/tasks/count
 	// TODO(nick) move this when we add an AuthZ for notebooks.
 	CanGetActiveTasksCount(curUser model.User) error
+	CanAccessNTSCTask(curUser model.User, ownerID model.UserID) (canView bool, serverError error)
 }
 
 // AuthZProvider is the authz registry for experiments.

--- a/master/internal/experiment/authz_iface.go
+++ b/master/internal/experiment/authz_iface.go
@@ -94,6 +94,10 @@ type ExperimentAuthZ interface {
 	CanSetExperimentsWeight(curUser model.User, e *model.Experiment, weight float64) error
 	CanSetExperimentsPriority(curUser model.User, e *model.Experiment, priority int) error
 	CanSetExperimentsCheckpointGCPolicy(curUser model.User, e *model.Experiment) error
+
+	// GET /api/v1/tasks/count
+	// TODO(nick) move this when we add an AuthZ for notebooks.
+	CanGetActiveTasksCount(curUser model.User) error
 }
 
 // AuthZProvider is the authz registry for experiments.

--- a/master/internal/mocks/authz_experiment_iface.go
+++ b/master/internal/mocks/authz_experiment_iface.go
@@ -17,6 +17,27 @@ type ExperimentAuthZ struct {
 	mock.Mock
 }
 
+// CanAccessNTSCTask provides a mock function with given fields: curUser, ownerID
+func (_m *ExperimentAuthZ) CanAccessNTSCTask(curUser model.User, ownerID model.UserID) (bool, error) {
+	ret := _m.Called(curUser, ownerID)
+
+	var r0 bool
+	if rf, ok := ret.Get(0).(func(model.User, model.UserID) bool); ok {
+		r0 = rf(curUser, ownerID)
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(model.User, model.UserID) error); ok {
+		r1 = rf(curUser, ownerID)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // CanCreateExperiment provides a mock function with given fields: curUser, proj, e
 func (_m *ExperimentAuthZ) CanCreateExperiment(curUser model.User, proj *projectv1.Project, e *model.Experiment) error {
 	ret := _m.Called(curUser, proj, e)

--- a/master/internal/mocks/authz_experiment_iface.go
+++ b/master/internal/mocks/authz_experiment_iface.go
@@ -87,6 +87,20 @@ func (_m *ExperimentAuthZ) CanForkFromExperiment(curUser model.User, e *model.Ex
 	return r0
 }
 
+// CanGetActiveTasksCount provides a mock function with given fields: curUser
+func (_m *ExperimentAuthZ) CanGetActiveTasksCount(curUser model.User) error {
+	ret := _m.Called(curUser)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(model.User) error); ok {
+		r0 = rf(curUser)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // CanGetExperiment provides a mock function with given fields: curUser, e
 func (_m *ExperimentAuthZ) CanGetExperiment(curUser model.User, e *model.Experiment) (bool, error) {
 	ret := _m.Called(curUser, e)

--- a/master/internal/user/service.go
+++ b/master/internal/user/service.go
@@ -218,20 +218,14 @@ func (s *Service) ProcessProxyAuthentication(c echo.Context) (done bool, err err
 	}
 
 	taskID := c.Param("service")
-	if taskID != "" { // TODO do we need this check? I don't understand proxies yet.
-		// TODO when does this get persisted?
-		ownerID, err := db.GetCommandOwnerID(c.Request().Context(), model.TaskID(taskID))
-		if errors.Is(err, db.ErrNotFound) { // TODO do we need this check?
-			return false, nil
-		}
-		if err != nil {
-			return true, err
-		}
+	ownerID, err := db.GetCommandOwnerID(c.Request().Context(), model.TaskID(taskID))
+	if err != nil {
+		return true, err
+	}
 
-		if ownerID != user.ID {
-			return false, echo.NewHTTPError(http.StatusNotFound,
-				"service not found: "+taskID)
-		}
+	if ownerID != user.ID {
+		return false, echo.NewHTTPError(http.StatusNotFound,
+			"service not found: "+taskID)
 	}
 
 	return false, nil

--- a/master/internal/user/service.go
+++ b/master/internal/user/service.go
@@ -224,8 +224,8 @@ func (s *Service) ProcessProxyAuthentication(c echo.Context) (done bool, err err
 			}
 
 			if ownerID != user.ID {
-				return false, echo.NewHTTPError(http.StatusForbidden,
-					"you do not own this task you need admin privileges to access")
+				return false, echo.NewHTTPError(http.StatusNotFound,
+					"service not found: "+taskID)
 			}
 		}
 


### PR DESCRIPTION
## Description

- Adds a authz function ```CanAccessNTSC``` which is called to allow for enabling allowing non-admin users to view their own tasks.

- Adds a dev master config option ```_strict_ntsc_enabled``` allowing for testing of a strict task world

- Checks authz for getting experiments in tensorboard creation

- Adds an authz function for ```GetActiveTasksCount```


## Test Plan

- E2e test covering strict NTSC

- Go integration test for authz for tensorboard creation

- Go integration test for ```GetActiveTasksCount``` authz

## Commentary (optional)

The second ticket is for tests around ```/proxy``` and I think this covers ensuring the proxy is authenticated. 

## Checklist
- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.
- [ ] If modifying `/webui/react/src/shared/` verify `make -C webui/react test-shared` passes.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
