### PR TITLE
fix: Wire up user edit modal to rbac endpoints

### DIFF
--- a/webui/react/src/hooks/useModal/UserSettings/useModalCreateUser.test.tsx
+++ b/webui/react/src/hooks/useModal/UserSettings/useModalCreateUser.test.tsx
@@ -17,6 +17,7 @@ import useModalCreateUser, {
 const mockCreateUser = jest.fn();
 
 jest.mock('services/api', () => ({
+  getUserRoles: () => Promise.resolve([]),
   postUser: (params: PostUserParams) => {
     mockCreateUser(params);
     return Promise.resolve({ user: { id: 1 } });
@@ -48,6 +49,11 @@ const setup = async () => {
 
   await user.click(await view.findByText(OPEN_MODAL_TEXT));
   await view.findByRole('heading', { name: MODAL_HEADER_LABEL_CREATE });
+
+  // Check for the modal to finish loading.
+  await waitFor(() => {
+    expect(screen.queryByText('Loading', { exact: false })).not.toBeInTheDocument();
+  });
 
   return view;
 };

--- a/webui/react/src/hooks/useModal/UserSettings/useModalCreateUser.tsx
+++ b/webui/react/src/hooks/useModal/UserSettings/useModalCreateUser.tsx
@@ -17,6 +17,7 @@ import {
 } from 'services/api';
 import { V1GroupSearchResult } from 'services/api-ts-sdk';
 import Icon from 'shared/components/Icon/Icon';
+import Spinner from 'shared/components/Spinner';
 import useModal, { ModalHooks as Hooks } from 'shared/hooks/useModal/useModal';
 import { ErrorType } from 'shared/utils/error';
 import { DetailedUser, Permission, UserRole } from 'types';
@@ -115,6 +116,10 @@ const ModalForm: React.FC<Props> = ({ form, user, groups, viewOnly, roles }) => 
     }
     return columns;
   }, [canModifyPermissions, viewOnly]);
+
+  if (user !== undefined && roles === null) {
+    return <Spinner tip="Loading roles..." />;
+  }
 
   return (
     <Form<FormValues> form={form} labelCol={{ span: 8 }} wrapperCol={{ span: 14 }}>
@@ -232,7 +237,6 @@ const useModalCreateUser = ({ groups, onClose, user }: ModalProps): ModalHooks =
       const formData = form.getFieldsValue();
 
       const newRoles: Set<number> = new Set(formData.roles);
-      // TODO user should not be able to set roles before they load.
       const oldRoles = new Set((userRoles ?? []).map((r) => r.id));
 
       const rolesToAdd = filter((r: number) => !oldRoles.has(r))(newRoles);

--- a/webui/react/src/hooks/useModal/UserSettings/useModalCreateUser.tsx
+++ b/webui/react/src/hooks/useModal/UserSettings/useModalCreateUser.tsx
@@ -256,6 +256,9 @@ const useModalCreateUser = ({ groups, onClose, user }: ModalProps): ModalHooks =
               await updateGroup({ addUsers: [uid], groupId: gid });
             });
           }
+          if (uid && rolesToAdd.size > 0) {
+            await assignRolesToUser({ roleIds: Array.from(rolesToAdd), userId: uid });
+          }
 
           message.success(API_SUCCESS_MESSAGE_CREATE);
         }

--- a/webui/react/src/hooks/useModal/UserSettings/useModalCreateUser.tsx
+++ b/webui/react/src/hooks/useModal/UserSettings/useModalCreateUser.tsx
@@ -261,9 +261,9 @@ const useModalCreateUser = ({ groups, onClose, user }: ModalProps): ModalHooks =
           }
 
           message.success(API_SUCCESS_MESSAGE_CREATE);
+          form.resetFields();
         }
 
-        form.resetFields();
         onClose?.();
       } catch (e) {
         message.error(user ? 'Error updating user' : 'Error creating new user');

--- a/webui/react/src/hooks/useModal/UserSettings/useModalCreateUser.tsx
+++ b/webui/react/src/hooks/useModal/UserSettings/useModalCreateUser.tsx
@@ -211,7 +211,7 @@ const useModalCreateUser = ({ groups, onClose, user }: ModalProps): ModalHooks =
     if (user !== undefined) {
       try {
         const roles = await getUserRoles({ userId: user.id });
-        setUserRoles(roles);
+        setUserRoles(roles.filter((r) => r.permissions.find((p) => p.isGlobal)));
       } catch (e) {
         handleError(e, { publicSubject: "Unable to fetch this user's roles." });
       }

--- a/webui/react/src/hooks/useModal/UserSettings/useModalCreateUser.tsx
+++ b/webui/react/src/hooks/useModal/UserSettings/useModalCreateUser.tsx
@@ -1,17 +1,25 @@
-import { Form, Input, message, Select, Switch, Table } from 'antd';
-import { Button } from 'antd';
+import { Button, Form, Input, message, Select, Switch, Table } from 'antd';
 import { FormInstance } from 'antd/lib/form/hooks/useForm';
+import { filter } from 'fp-ts/lib/Set';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { useStore } from 'contexts/Store';
 import useFeature from 'hooks/useFeature';
 import usePermissions from 'hooks/usePermissions';
-import { getUserPermissions, patchUser, postUser, updateGroup } from 'services/api';
+import {
+  assignRolesToUser,
+  getUserPermissions,
+  getUserRoles,
+  patchUser,
+  postUser,
+  removeRolesFromUser,
+  updateGroup,
+} from 'services/api';
 import { V1GroupSearchResult } from 'services/api-ts-sdk';
 import Icon from 'shared/components/Icon/Icon';
 import useModal, { ModalHooks as Hooks } from 'shared/hooks/useModal/useModal';
 import { ErrorType } from 'shared/utils/error';
-import { DetailedUser, Permission } from 'types';
+import { DetailedUser, Permission, UserRole } from 'types';
 import handleError from 'utils/error';
 
 export const ADMIN_NAME = 'admin';
@@ -33,6 +41,7 @@ export const ROLE_NAME = 'roles';
 interface Props {
   form: FormInstance;
   groups: V1GroupSearchResult[];
+  roles: UserRole[] | null;
   user?: DetailedUser;
   viewOnly?: boolean;
 }
@@ -44,7 +53,7 @@ interface FormValues {
   USER_NAME_NAME: string;
 }
 
-const ModalForm: React.FC<Props> = ({ form, user, groups, viewOnly }) => {
+const ModalForm: React.FC<Props> = ({ form, user, groups, viewOnly, roles }) => {
   const [permissions, setPermissions] = useState<Permission[]>([]);
 
   const rbacEnabled = useFeature().isOn('rbac');
@@ -147,8 +156,16 @@ const ModalForm: React.FC<Props> = ({ form, user, groups, viewOnly }) => {
         </Form.Item>
       )}
       {rbacEnabled && canModifyPermissions && !viewOnly && (
-        <Form.Item label={ROLE_LABEL} name={ROLE_NAME}>
-          <Select mode="multiple" optionFilterProp="children" placeholder={'Add Roles'} showSearch>
+        <Form.Item
+          initialValue={roles === null ? [] : roles.map((r) => r.id)}
+          label={ROLE_LABEL}
+          name={ROLE_NAME}>
+          <Select
+            disabled={user !== undefined && roles === null}
+            mode="multiple"
+            optionFilterProp="children"
+            placeholder={'Add Global Roles'}
+            showSearch>
             {knownRoles.map((r) => (
               <Select.Option key={r.id} value={r.id}>
                 {r.name}
@@ -182,6 +199,23 @@ interface ModalHooks extends Omit<Hooks, 'modalOpen'> {
 const useModalCreateUser = ({ groups, onClose, user }: ModalProps): ModalHooks => {
   const [form] = Form.useForm();
   const { modalOpen: openOrUpdate, ...modalHook } = useModal();
+  // Null means the roles have not yet loaded
+  const [userRoles, setUserRoles] = useState<UserRole[] | null>(null);
+
+  const fetchUserRoles = useCallback(async () => {
+    if (user !== undefined) {
+      try {
+        const roles = await getUserRoles({ userId: user.id });
+        setUserRoles(roles);
+      } catch (e) {
+        handleError(e, { publicSubject: "Unable to fetch this user's roles." });
+      }
+    }
+  }, [user]);
+
+  useEffect(() => {
+    fetchUserRoles();
+  }, []);
 
   const handleCancel = useCallback(() => {
     form.resetFields();
@@ -196,9 +230,19 @@ const useModalCreateUser = ({ groups, onClose, user }: ModalProps): ModalHooks =
       await form.validateFields();
 
       const formData = form.getFieldsValue();
+
+      const newRoles: Set<number> = new Set(formData.roles);
+      // TODO user should not be able to set roles before they load.
+      const oldRoles = new Set((userRoles ?? []).map((r) => r.id));
+
+      const rolesToAdd = filter((r: number) => !oldRoles.has(r))(newRoles);
+      const rolesToRemove = filter((r: number) => !newRoles.has(r))(oldRoles);
+
       try {
         if (user) {
           await patchUser({ userId: user.id, userParams: formData });
+          await assignRolesToUser({ roleIds: Array.from(rolesToAdd), userId: user.id });
+          await removeRolesFromUser({ roleIds: Array.from(rolesToRemove), userId: user.id });
           message.success(API_SUCCESS_MESSAGE_EDIT);
         } else {
           const u = await postUser(formData);
@@ -222,7 +266,7 @@ const useModalCreateUser = ({ groups, onClose, user }: ModalProps): ModalHooks =
         throw e;
       }
     },
-    [form, onClose, user, handleCancel],
+    [form, onClose, user, handleCancel, userRoles],
   );
 
   const modalOpen = useCallback(
@@ -230,7 +274,15 @@ const useModalCreateUser = ({ groups, onClose, user }: ModalProps): ModalHooks =
       openOrUpdate({
         closable: true,
         // passing a default brandind due to changes on the initial state
-        content: <ModalForm form={form} groups={groups} user={user} viewOnly={viewOnly} />,
+        content: (
+          <ModalForm
+            form={form}
+            groups={groups}
+            roles={userRoles}
+            user={user}
+            viewOnly={viewOnly}
+          />
+        ),
         icon: null,
         okText: viewOnly ? 'Close' : user ? 'Update' : 'Create User',
         onCancel: handleCancel,
@@ -238,7 +290,7 @@ const useModalCreateUser = ({ groups, onClose, user }: ModalProps): ModalHooks =
         title: <h5>{user ? MODAL_HEADER_LABEL_EDIT : MODAL_HEADER_LABEL_CREATE}</h5>,
       });
     },
-    [form, handleCancel, handleOk, openOrUpdate, user, groups],
+    [form, handleCancel, handleOk, openOrUpdate, user, groups, userRoles],
   );
 
   return { modalOpen, ...modalHook };

--- a/webui/react/src/hooks/useModal/Workspace/useModalWorkspaceRemoveMember.tsx
+++ b/webui/react/src/hooks/useModal/Workspace/useModalWorkspaceRemoveMember.tsx
@@ -2,7 +2,7 @@ import { message } from 'antd';
 import { ModalFuncProps } from 'antd/es/modal/Modal';
 import React, { useCallback, useEffect, useMemo } from 'react';
 
-import { removeRoleFromGroup, removeRoleFromUser } from 'services/api';
+import { removeRoleFromGroup, removeRolesFromUser } from 'services/api';
 import useModal, { ModalHooks } from 'shared/hooks/useModal/useModal';
 import { DetError, ErrorLevel, ErrorType } from 'shared/utils/error';
 import { UserOrGroup } from 'types';
@@ -40,7 +40,7 @@ const useModalWorkspaceRemoveMember = ({
   const handleOk = useCallback(async () => {
     try {
       isUser(userOrGroup)
-        ? await removeRoleFromUser({ roleId: 0, userId: userOrGroupId })
+        ? await removeRolesFromUser({ roleIds: [0], userId: userOrGroupId })
         : await removeRoleFromGroup({ groupId: userOrGroupId, roleId: 0 });
       message.success(`${name} removed from workspace`);
     } catch (e) {

--- a/webui/react/src/pages/Settings/UserManagement.test.tsx
+++ b/webui/react/src/pages/Settings/UserManagement.test.tsx
@@ -19,6 +19,7 @@ const user = userEvent.setup();
 
 jest.mock('services/api', () => ({
   getGroups: () => Promise.resolve({ groups: [] }),
+  getUserRoles: () => Promise.resolve([]),
   getUsers: () => {
     const currentUser: DetailedUser = {
       displayName: DISPLAY_NAME,

--- a/webui/react/src/pages/WorkspaceDetails/WorkspaceMembers.tsx
+++ b/webui/react/src/pages/WorkspaceDetails/WorkspaceMembers.tsx
@@ -17,7 +17,7 @@ import {
   assignRolesToGroup,
   assignRolesToUser,
   removeRoleFromGroup,
-  removeRoleFromUser,
+  removeRolesFromUser,
 } from 'services/api';
 import { V1Group, V1GroupDetails, V1RoleWithAssignments } from 'services/api-ts-sdk';
 import { Size } from 'shared/components/Avatar';
@@ -228,8 +228,8 @@ const WorkspaceMembers: React.FC<Props> = ({
             try {
               // Try to remove the old role and then add the new role
               isUser(record)
-                ? await removeRoleFromUser({
-                    roleId: oldRoleId,
+                ? await removeRolesFromUser({
+                    roleIds: [oldRoleId],
                     userId: userOrGroupId,
                   })
                 : await removeRoleFromGroup({

--- a/webui/react/src/services/api.ts
+++ b/webui/react/src/services/api.ts
@@ -132,6 +132,12 @@ export const getGroupRoles = generateDetApi<
   Type.UserRole[]
 >(Config.getGroupRoles);
 
+export const getUserRoles = generateDetApi<
+  Service.GetUserParams,
+  Api.V1GetRolesAssignedToUserResponse,
+  Type.UserRole[]
+>(Config.getUserRoles);
+
 export const listRoles = generateDetApi<
   Service.ListRolesParams,
   Api.V1ListRolesResponse,
@@ -156,11 +162,11 @@ export const assignRolesToUser = generateDetApi<
   Api.V1AssignRolesResponse
 >(Config.assignRolesToUser);
 
-export const removeRoleFromUser = generateDetApi<
+export const removeRolesFromUser = generateDetApi<
   Service.RemoveRoleFromUserParams,
   Api.V1RemoveAssignmentsResponse,
   Api.V1RemoveAssignmentsResponse
->(Config.removeRoleFromUser);
+>(Config.removeRolesFromUser);
 
 /* Info */
 

--- a/webui/react/src/services/apiConfig.ts
+++ b/webui/react/src/services/apiConfig.ts
@@ -304,6 +304,16 @@ export const getGroupRoles: DetApi<
   request: (params) => detApi.RBAC.getRolesAssignedToGroup(params.groupId),
 };
 
+export const getUserRoles: DetApi<
+  Service.GetUserParams,
+  Api.V1GetRolesAssignedToUserResponse,
+  Type.UserRole[]
+> = {
+  name: 'getRolesAssignedToUser',
+  postProcess: (response) => (response.roles || []).map(decoder.mapV1Role),
+  request: (params) => detApi.RBAC.getRolesAssignedToUser(params.userId),
+};
+
 export const listRoles: DetApi<Service.ListRolesParams, Api.V1ListRolesResponse, Type.UserRole[]> =
   {
     name: 'listRoles',
@@ -365,21 +375,19 @@ export const assignRolesToUser: DetApi<
     }),
 };
 
-export const removeRoleFromUser: DetApi<
+export const removeRolesFromUser: DetApi<
   Service.RemoveRoleFromUserParams,
   Api.V1RemoveAssignmentsResponse,
   Api.V1RemoveAssignmentsResponse
 > = {
-  name: 'removeRoleFromUser',
+  name: 'removeRolesFromUser',
   postProcess: (response) => response,
   request: (params) =>
     detApi.RBAC.removeAssignments({
-      userRoleAssignments: [
-        {
-          roleAssignment: { role: { roleId: params.roleId } },
-          userId: params.userId,
-        },
-      ],
+      userRoleAssignments: params.roleIds.map((roleId) => ({
+        roleAssignment: { role: { roleId } },
+        userId: params.userId,
+      })),
     }),
 };
 

--- a/webui/react/src/services/types.ts
+++ b/webui/react/src/services/types.ts
@@ -367,7 +367,7 @@ export interface AssignRolesToUserParams {
 }
 
 export interface RemoveRoleFromUserParams {
-  roleId: number;
+  roleIds: number[];
   userId: number;
 }
 


### PR DESCRIPTION
## Description

This PR wires up the user edit modal to the rbac API. 

## Test Plan
1. Open the user management page on local dev
2. Click into "determined" user edit modal.
3. Add three roles to the user and click submit, confirm API calls in the web console.
4. Click into the modal and confirm the updates are reflected
5. Refresh the page.
6. Click into the user edit modal again and confirm the three roles are present
7. Remove one role and add another, submit the modal
8. Refresh, reopen the modal, and confirm the permissions are correct.
9. Open the new user modal
10. Add roles and create the new user
11. Click into the modal and confirm the form is empty again
12. Confirm the new user shows up and has the correct roles
13. Refresh and confirm the user has the roles

## Checklist
- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.
- [x] If modifying `/webui/react/src/shared/` verify `make -C webui/react test-shared` passes.

## Ticket
No ticket

CC @ioga (original reporter)