### PR TITLE
fix: Workspace member modal handling of groups and roles

### DIFF
--- a/webui/react/src/hooks/useModal/Workspace/useModalWorkspaceAddMember.tsx
+++ b/webui/react/src/hooks/useModal/Workspace/useModalWorkspaceAddMember.tsx
@@ -6,6 +6,7 @@ import { useStore } from 'contexts/Store';
 import useFeature from 'hooks/useFeature';
 import { assignRolesToGroup, assignRolesToUser } from 'services/api';
 import { V1Group } from 'services/api-ts-sdk';
+import Icon from 'shared/components/Icon/Icon';
 import useModal, { ModalHooks } from 'shared/hooks/useModal/useModal';
 import { DetError, ErrorLevel, ErrorType } from 'shared/utils/error';
 import { User, UserOrGroup } from 'types';
@@ -141,7 +142,14 @@ const useModalWorkspaceAddMember = ({ addableUsersAndGroups, onClose }: Props): 
             <Select
               filterOption={handleFilter}
               options={addableUsersAndGroups.map((option) => ({
-                label: getName(option),
+                label: isUser(option) ? (
+                  getName(option)
+                ) : (
+                  <span>
+                    {getName(option)}&nbsp;&nbsp;
+                    <Icon name="group" />
+                  </span>
+                ),
                 value: getIdFromUserOrGroup(option),
               }))}
               placeholder="Find user or group by display name or username"

--- a/webui/react/src/hooks/useModal/Workspace/useModalWorkspaceAddMember.tsx
+++ b/webui/react/src/hooks/useModal/Workspace/useModalWorkspaceAddMember.tsx
@@ -96,8 +96,8 @@ const useModalWorkspaceAddMember = ({
   );
 
   const handleOk = useCallback(async () => {
+    const values = await form.validateFields();
     try {
-      const values = await form.validateFields();
       if (values && selectedOption) {
         isUser(selectedOption)
           ? await assignRolesToUser({
@@ -138,7 +138,11 @@ const useModalWorkspaceAddMember = ({
   const modalContent = useMemo(() => {
     return (
       <div className={css.base}>
-        <Form autoComplete="off" form={form} layout="vertical">
+        <Form
+          autoComplete="off"
+          form={form}
+          layout="vertical"
+          onValuesChange={async () => await form.validateFields()}>
           <Form.Item
             label="User or Group"
             name="userOrGroupId"

--- a/webui/react/src/pages/WorkspaceDetails.tsx
+++ b/webui/react/src/pages/WorkspaceDetails.tsx
@@ -105,7 +105,7 @@ const WorkspaceDetails: React.FC = () => {
     });
     setGroupsAssignedDirectlyIds(newGroupIds);
     setWorkspaceAssignments(response.assignments);
-  }, [id, nameFilter, rbacEnabled]);
+  }, [id, mockWorkspaceMembers, nameFilter, rbacEnabled]);
 
   const handleFilterUpdate = (name: string | undefined) => setNameFilter(name);
 

--- a/webui/react/src/pages/WorkspaceDetails.tsx
+++ b/webui/react/src/pages/WorkspaceDetails.tsx
@@ -44,8 +44,12 @@ const WorkspaceDetails: React.FC = () => {
   const [groups, setGroups] = useState<V1GroupSearchResult[]>();
   const [usersAssignedDirectly, setUsersAssignedDirectly] = useState<User[]>([]);
   const [groupsAssignedDirectly, setGroupsAssignedDirectly] = useState<V1Group[]>([]);
-  const [usersAssignedDirectlyIds, setUsersAssignedDirectlyIds] = useState<Set<number>>();
-  const [groupsAssignedDirectlyIds, setGroupsAssignedDirectlyIds] = useState<Set<number>>();
+  const [usersAssignedDirectlyIds, setUsersAssignedDirectlyIds] = useState<Set<number>>(
+    new Set<number>(),
+  );
+  const [groupsAssignedDirectlyIds, setGroupsAssignedDirectlyIds] = useState<Set<number>>(
+    new Set<number>(),
+  );
   /* eslint-disable-next-line @typescript-eslint/no-unused-vars */
   const [nameFilter, setNameFilter] = useState<string>();
   const [workspaceAssignments, setWorkspaceAssignments] = useState<V1RoleWithAssignments[]>([]);
@@ -73,7 +77,7 @@ const WorkspaceDetails: React.FC = () => {
 
   const fetchGroups = useCallback(async (): Promise<void> => {
     try {
-      const response = await getGroups({}, { signal: canceler.signal });
+      const response = await getGroups({ limit: 100 }, { signal: canceler.signal });
 
       setGroups((prev) => {
         if (isEqual(prev, response.groups)) return prev;
@@ -139,13 +143,10 @@ const WorkspaceDetails: React.FC = () => {
   // Users and Groups that are not already a part of the workspace
   const addableGroups: V1Group[] = groups
     ? groups
-        ?.filter((groupDetails) => {
-          groupDetails.group?.groupId &&
-            !groupsAssignedDirectlyIds?.has(groupDetails.group.groupId);
-        })
         .map((groupDetails) => groupDetails.group)
+        .filter((group) => group.groupId && !groupsAssignedDirectlyIds.has(group.groupId))
     : [];
-  const addableUsers = users.filter((user) => !usersAssignedDirectlyIds?.has(user.id));
+  const addableUsers = users.filter((user) => !usersAssignedDirectlyIds.has(user.id));
   const addableUsersAndGroups = [...addableGroups, ...addableUsers];
 
   useEffect(() => {

--- a/webui/react/src/pages/WorkspaceDetails/WorkspaceDetailsHeader.tsx
+++ b/webui/react/src/pages/WorkspaceDetails/WorkspaceDetailsHeader.tsx
@@ -37,6 +37,7 @@ const WorkspaceDetailsHeader: React.FC<Props> = ({
   const { contextHolder: workspaceAddMemberContextHolder, modalOpen: openWorkspaceAddMember } =
     useModalWorkspaceAddMember({
       addableUsersAndGroups,
+      workspaceId: workspace.id,
     });
 
   const rbacEnabled = useFeature().isOn('rbac');

--- a/webui/react/src/services/apiConfig.ts
+++ b/webui/react/src/services/apiConfig.ts
@@ -326,7 +326,10 @@ export const assignRolesToGroup: DetApi<
     detApi.RBAC.assignRoles({
       groupRoleAssignments: params.roleIds.map((roleId) => ({
         groupId: params.groupId,
-        roleAssignment: { role: { roleId } },
+        roleAssignment: {
+          role: { roleId },
+          scopeWorkspaceId: params.scopeWorkspaceId || undefined,
+        },
       })),
     }),
 };
@@ -359,7 +362,10 @@ export const assignRolesToUser: DetApi<
   request: (params) =>
     detApi.RBAC.assignRoles({
       userRoleAssignments: params.roleIds.map((roleId) => ({
-        roleAssignment: { role: { roleId } },
+        roleAssignment: {
+          role: { roleId },
+          scopeWorkspaceId: params.scopeWorkspaceId || undefined,
+        },
         userId: params.userId,
       })),
     }),

--- a/webui/react/src/services/types.ts
+++ b/webui/react/src/services/types.ts
@@ -363,6 +363,7 @@ export interface RemoveRoleFromGroupParams {
 
 export interface AssignRolesToUserParams {
   roleIds: number[];
+  scopeWorkspaceId?: number;
   userId: number;
 }
 
@@ -376,6 +377,7 @@ export type GetGroupsParams = PaginationParams;
 export interface AssignRolesToGroupParams {
   groupId: number;
   roleIds: number[];
+  scopeWorkspaceId?: number;
 }
 
 export interface ListRolesParams {


### PR DESCRIPTION
## Description

Handles two reported issues with the workspace Add Members modal form:
- Groups should be included in the list of members to add
- addRoles should assign to this specific workspace instead of globally

Breakdown of changes:
- in WorkspaceDetails.tsx, groups were all filtered out due to syntax hiding returned value (`filter((group) => { expression })` rather than `filter((group) => expression)`)
- added a group icon to the dropdown to make users and groups more distinct
- set dropdown value to g_{GroupID} or u_{UserID} so  `handleSelect` can handle user or group from ID, not name
- passed `workspaceId` to the modal to pass it on to the addUserRole / addGroupRole calls

## Test Plan

Your database should have a group in it, otherwise:

```sql
insert into groups (group_name, roles) values ('cool group', '[]'::jsonb);
```

To interact with the add members modal, add to your workspace URL: `?f_rbac=on&f_mock_permissions_all=on&f_mock_permissions_read=on`

Open Add Members, see your group as the first option, click the group, verify it now appears as the selected item for that dropdown.

## Checklist
- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.
- [x] If modifying `/webui/react/src/shared/` verify `make -C webui/react test-shared` passes.