### PR TITLE
fix: workspace page tab route [WEB-531]

### DIFF
--- a/webui/react/src/routes/utils.ts
+++ b/webui/react/src/routes/utils.ts
@@ -161,8 +161,8 @@ export const paths = {
   webhooks: (): string => {
     return '/webhooks';
   },
-  workspaceDetails: (workspaceId: number | string): string => {
-    return `/workspaces/${workspaceId}`;
+  workspaceDetails: (workspaceId: number | string, tab = 'projects'): string => {
+    return `/workspaces/${workspaceId}/${tab}`;
   },
   workspaceList: (): string => {
     return '/workspaces';


### PR DESCRIPTION
## Description

Bug report:
Workspace -> Members tab; hitting Ctrl-R to refresh the page sends you back to Projects tab (although the url in the browser URL bar still ends with `members`).


## Test Plan

Navigate to workspace page with rbac enabled, click on tabs and refresh page, page should stay at where it was.


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist
- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.
- [ ] If modifying `/webui/react/src/shared/` verify `make -C webui/react test-shared` passes.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
