### PR TITLE
build: skip more jobs for web only changes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1687,7 +1687,7 @@ jobs:
     executor: << parameters.executor-name >>
     steps:
       - checkout
-      - skip-if-webui-only
+      # - skip-if-webui-only # we'd like to skip this git is not already installed.
       - run: python --version
       # Running the pip executable causes an error with the win/default executor for some reason.
       - run: python -m pip install --upgrade --user pip

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -123,6 +123,10 @@ commands:
             fi
       - run: git fetch upstream
       - run:
+          name: TEMP assume this is a web only change # to test out the pr
+          command: circleci-agent step halt
+
+      - run:
           name: check for webui-only changes  # must be run after skip-if-docs-only
           command: |
             MERGE_BASE="$(git merge-base upstream/master HEAD)"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -121,7 +121,7 @@ commands:
           command: |
             MERGE_BASE="$(git merge-base upstream/master HEAD)"
             DIFF_DIRS="$(git diff-tree --no-commit-id --name-only "$MERGE_BASE" HEAD)"
-            if [ "$DIFF_DIRS" = "webui" ] ; then
+            if [ "$DIFF_DIRS" = "webui" ] && [ "${CIRCLE_PULL_REQUEST}" != "" ] ; then
               echo "webui-only change detected, halting job now"
               circleci-agent step halt
             else

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -115,6 +115,12 @@ commands:
 
   skip-if-webui-only:
     steps:
+      - run:
+          name: ensure upstream remote is added
+          command: |
+            if ! git remote | grep -q upstream; then
+              git remote add upstream https://github.com/determined-ai/determined
+            fi
       - run: git fetch upstream
       - run:
           name: check for webui-only changes  # must be run after skip-if-docs-only

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1681,6 +1681,7 @@ jobs:
     executor: << parameters.executor-name >>
     steps:
       - checkout
+      - skip-if-webui-only
       - run: python --version
       # Running the pip executable causes an error with the win/default executor for some reason.
       - run: python -m pip install --upgrade --user pip

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1014,6 +1014,7 @@ jobs:
       - image: <<pipeline.parameters.docker-image>>
     steps:
       - checkout
+      - skip-if-webui-only
       - helm/install-helm-client
       - setup-python-venv:
           install-python: false

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -123,10 +123,6 @@ commands:
             fi
       - run: git fetch upstream
       - run:
-          name: TEMP assume this is a web only change # to test out the pr
-          command: circleci-agent step halt
-
-      - run:
           name: check for webui-only changes  # must be run after skip-if-docs-only
           command: |
             MERGE_BASE="$(git merge-base upstream/master HEAD)"

--- a/.github/workflows/lint-bindings.yml
+++ b/.github/workflows/lint-bindings.yml
@@ -6,6 +6,7 @@ on:
     paths-ignore:
       - '*.md'
       - 'docs/*'
+      - 'webui/*'
   push:
     branches:
       - 'main'


### PR DESCRIPTION
## Description

- skip redundant ci jobs for web-only prs



<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At a minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions about this test plan to ensure adequate manual coverage of changes.
-->

I simulated what effect this would have (since this is not a web only pr) via [this commit ](https://github.com/determined-ai/determined/pull/5275/commits/d7809864eeb2a938449b3c94394af20ecbac4e7f)

the run on the bottom is before the test commit the one on the top is after
![2022-11-01_11-59-12](https://user-images.githubusercontent.com/12127420/199316122-92b18715-11b2-426e-8762-d6960a09aff0.png)



## Commentary (optional)

I included a change to only skip these jobs in the pr phase and not after they're merged to be safe. we can toggle that switch once we're happy with it later

full list of skipped jobs:

- build-docs
- build-go
- go-coverage
- lint-go
- package-and-push-system-local
- python-coverage
- test-cli
- test-debian-packaging
- test-det-deploy
- test-e2e
- test-examples
- test-intg-agent
- test-intg-master
- test-stress
- test-unit-go
- test-unit-harness-cpu
- test-unit-harness-gpu
- test-unit-harness-tf2
- test-unit-model-hub

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->

per web commit comparison: (not all changes in this pr)

- total ci time: from 53 minutes to 13
- min change: from 25 minutes to 5

## Checklist
- [x] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.
- [ ] If modifying `/webui/react/src/shared/` verify `make -C webui/react test-shared` passes.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
