### PR TITLE
feat: Changing and removing roles from workspace members list

### DIFF
--- a/webui/react/src/hooks/useModal/Workspace/useModalWorkspaceRemoveMember.tsx
+++ b/webui/react/src/hooks/useModal/Workspace/useModalWorkspaceRemoveMember.tsx
@@ -2,7 +2,7 @@ import { message } from 'antd';
 import { ModalFuncProps } from 'antd/es/modal/Modal';
 import React, { useCallback, useEffect, useMemo } from 'react';
 
-import { removeRoleFromGroup, removeRolesFromUser } from 'services/api';
+import { removeRolesFromGroup, removeRolesFromUser } from 'services/api';
 import useModal, { ModalHooks } from 'shared/hooks/useModal/useModal';
 import { DetError, ErrorLevel, ErrorType } from 'shared/utils/error';
 import { UserOrGroup } from 'types';
@@ -14,6 +14,8 @@ import css from './useModalWorkspaceRemoveMember.module.scss';
 interface Props {
   name: string;
   onClose?: () => void;
+  roleIds: number[];
+  scopeWorkspaceId: number;
   userOrGroup: UserOrGroup;
   userOrGroupId: number;
 }
@@ -22,6 +24,8 @@ const useModalWorkspaceRemoveMember = ({
   onClose,
   userOrGroup,
   name,
+  roleIds,
+  scopeWorkspaceId,
   userOrGroupId,
 }: Props): ModalHooks => {
   const { modalOpen: openOrUpdate, modalRef, ...modalHook } = useModal({ onClose });
@@ -40,8 +44,8 @@ const useModalWorkspaceRemoveMember = ({
   const handleOk = useCallback(async () => {
     try {
       isUser(userOrGroup)
-        ? await removeRolesFromUser({ roleIds: [0], userId: userOrGroupId })
-        : await removeRoleFromGroup({ groupId: userOrGroupId, roleId: 0 });
+        ? await removeRolesFromUser({ roleIds, scopeWorkspaceId, userId: userOrGroupId })
+        : await removeRolesFromGroup({ groupId: userOrGroupId, roleIds, scopeWorkspaceId });
       message.success(`${name} removed from workspace`);
     } catch (e) {
       if (e instanceof DetError) {
@@ -63,7 +67,7 @@ const useModalWorkspaceRemoveMember = ({
       }
     }
     return;
-  }, [name, userOrGroup, userOrGroupId]);
+  }, [name, roleIds, scopeWorkspaceId, userOrGroup, userOrGroupId]);
 
   const getModalProps = useCallback((): ModalFuncProps => {
     return {

--- a/webui/react/src/pages/WorkspaceDetails/WorkspaceMembers.tsx
+++ b/webui/react/src/pages/WorkspaceDetails/WorkspaceMembers.tsx
@@ -230,21 +230,25 @@ const WorkspaceMembers: React.FC<Props> = ({
               isUser(record)
                 ? await removeRolesFromUser({
                     roleIds: [oldRoleId],
+                    scopeWorkspaceId: workspace.id,
                     userId: userOrGroupId,
                   })
                 : await removeRoleFromGroup({
                     groupId: userOrGroupId,
                     roleId: oldRoleId,
+                    scopeWorkspaceId: workspace.id,
                   });
               try {
                 isUser(record)
                   ? await assignRolesToUser({
                       roleIds: [roleIdValue],
+                      scopeWorkspaceId: workspace.id,
                       userId: userOrGroupId,
                     })
                   : await assignRolesToGroup({
                       groupId: userOrGroupId,
                       roleIds: [roleIdValue],
+                      scopeWorkspaceId: workspace.id,
                     });
               } catch (addRoleError) {
                 handleError(addRoleError, {

--- a/webui/react/src/services/api.ts
+++ b/webui/react/src/services/api.ts
@@ -150,11 +150,11 @@ export const assignRolesToGroup = generateDetApi<
   Api.V1AssignRolesResponse
 >(Config.assignRolesToGroup);
 
-export const removeRoleFromGroup = generateDetApi<
-  Service.RemoveRoleFromGroupParams,
+export const removeRolesFromGroup = generateDetApi<
+  Service.RemoveRolesFromGroupParams,
   Api.V1RemoveAssignmentsResponse,
   Api.V1RemoveAssignmentsResponse
->(Config.removeRoleFromGroup);
+>(Config.removeRolesFromGroup);
 
 export const assignRolesToUser = generateDetApi<
   Service.AssignRolesToUserParams,
@@ -163,7 +163,7 @@ export const assignRolesToUser = generateDetApi<
 >(Config.assignRolesToUser);
 
 export const removeRolesFromUser = generateDetApi<
-  Service.RemoveRoleFromUserParams,
+  Service.RemoveRolesFromUserParams,
   Api.V1RemoveAssignmentsResponse,
   Api.V1RemoveAssignmentsResponse
 >(Config.removeRolesFromUser);

--- a/webui/react/src/services/apiConfig.ts
+++ b/webui/react/src/services/apiConfig.ts
@@ -344,24 +344,22 @@ export const assignRolesToGroup: DetApi<
     }),
 };
 
-export const removeRoleFromGroup: DetApi<
-  Service.RemoveRoleFromGroupParams,
+export const removeRolesFromGroup: DetApi<
+  Service.RemoveRolesFromGroupParams,
   Api.V1RemoveAssignmentsResponse,
   Api.V1RemoveAssignmentsResponse
 > = {
-  name: 'removeRoleFromGroup',
+  name: 'removeRolesFromGroup',
   postProcess: (response) => response,
   request: (params) =>
     detApi.RBAC.removeAssignments({
-      groupRoleAssignments: [
-        {
-          groupId: params.groupId,
-          roleAssignment: {
-            role: { roleId: params.roleId },
-            scopeWorkspaceId: params.scopeWorkspaceId || undefined,
-          },
+      groupRoleAssignments: params.roleIds.map((roleId) => ({
+        groupId: params.groupId,
+        roleAssignment: {
+          role: { roleId },
+          scopeWorkspaceId: params.scopeWorkspaceId || undefined,
         },
-      ],
+      })),
     }),
 };
 
@@ -385,7 +383,7 @@ export const assignRolesToUser: DetApi<
 };
 
 export const removeRolesFromUser: DetApi<
-  Service.RemoveRoleFromUserParams,
+  Service.RemoveRolesFromUserParams,
   Api.V1RemoveAssignmentsResponse,
   Api.V1RemoveAssignmentsResponse
 > = {

--- a/webui/react/src/services/apiConfig.ts
+++ b/webui/react/src/services/apiConfig.ts
@@ -356,7 +356,10 @@ export const removeRoleFromGroup: DetApi<
       groupRoleAssignments: [
         {
           groupId: params.groupId,
-          roleAssignment: { role: { roleId: params.roleId } },
+          roleAssignment: {
+            role: { roleId: params.roleId },
+            scopeWorkspaceId: params.scopeWorkspaceId || undefined,
+          },
         },
       ],
     }),
@@ -392,6 +395,7 @@ export const removeRolesFromUser: DetApi<
     detApi.RBAC.removeAssignments({
       userRoleAssignments: params.roleIds.map((roleId) => ({
         roleAssignment: { role: { roleId } },
+        scopeWorkspaceId: params.scopeWorkspaceId || undefined,
         userId: params.userId,
       })),
     }),

--- a/webui/react/src/services/types.ts
+++ b/webui/react/src/services/types.ts
@@ -356,9 +356,9 @@ export interface DeleteGroupParams {
 export interface GetGroupParams {
   groupId: number;
 }
-export interface RemoveRoleFromGroupParams {
+export interface RemoveRolesFromGroupParams {
   groupId: number;
-  roleId: number;
+  roleIds: number[];
   scopeWorkspaceId?: number;
 }
 
@@ -368,7 +368,7 @@ export interface AssignRolesToUserParams {
   userId: number;
 }
 
-export interface RemoveRoleFromUserParams {
+export interface RemoveRolesFromUserParams {
   roleIds: number[];
   scopeWorkspaceId?: number;
   userId: number;

--- a/webui/react/src/services/types.ts
+++ b/webui/react/src/services/types.ts
@@ -359,6 +359,7 @@ export interface GetGroupParams {
 export interface RemoveRoleFromGroupParams {
   groupId: number;
   roleId: number;
+  scopeWorkspaceId?: number;
 }
 
 export interface AssignRolesToUserParams {
@@ -369,6 +370,7 @@ export interface AssignRolesToUserParams {
 
 export interface RemoveRoleFromUserParams {
   roleIds: number[];
+  scopeWorkspaceId?: number;
   userId: number;
 }
 


### PR DESCRIPTION
## Description

On the Workspace Members page,
- When changing the role with the dropdown, passes a `scopeWorkspaceId` param when adding/removing the role
- When removing a role with the three dots / action menu, passes a `scopeWorkspaceId` param instead of modifying a global role.
- Instead of `roleId: 0`, added a function `getAssignedRole` which gets the first relevant `role.roleId` for this member, and is compatible with the mock workspace

For consistency, changes `removeRoleFromGroup` to accept an array of roles like the users feature, so it is renamed `removeRolesFromGroup`

## Test Plan

Go to the workspace detail page and add `?f_rbac=on&f_mock_permissions_all=on&f_mock_workspace_members=on`

- Changing a role passes `scopeWorkspaceId` to the API when removing, and then adding the new role
- Removing a role with the dropdown passes `scopeWorkspaceId` to the modal and then to the API

## Checklist
- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.
- [x] If modifying `/webui/react/src/shared/` verify `make -C webui/react test-shared` passes.