### PR TITLE
feat: actually support --device strings

### DIFF
--- a/harness/determined/common/schemas/expconf/_gen.py
+++ b/harness/determined/common/schemas/expconf/_gen.py
@@ -702,7 +702,21 @@ schemas = {
     "title": "DevicesConfig",
     "type": "array",
     "items": {
-        "$ref": "http://determined.ai/schemas/expconf/v0/device.json"
+        "union": {
+            "defaultMessage": "is neither a list of --device strings nor a map containing host_path, container_path, and mode",
+            "items": [
+                {
+                    "unionKey": "never",
+                    "$ref": "http://determined.ai/schemas/expconf/v0/device.json"
+                },
+                {
+                    "unionKey": "never",
+                    "type": "string",
+                    "$comment": "from man docker-run: --device=onhost:incontainer[:mode] ",
+                    "pattern": "^/[^:]*:/[^:]*(:[rwm]*)?"
+                }
+            ]
+        }
     }
 }
 

--- a/harness/determined/common/schemas/expconf/_v0.py
+++ b/harness/determined/common/schemas/expconf/_v0.py
@@ -20,6 +20,21 @@ class DeviceV0(schemas.SchemaBase):
     ) -> None:
         pass
 
+    @classmethod
+    def from_dict(cls, d: Union[dict, str], prevalidated: bool = False) -> "DeviceV0":
+        # Accept --device strings and convert them to maps.
+        if isinstance(d, str):
+            fields = d.split(":")
+            if len(fields) not in [2, 3]:
+                raise ValueError("wrong number of fields in device string")
+            d = {
+                "host_path": fields[0],
+                "container_path": fields[1],
+                "mode": None if len(fields) < 3 else fields[2],
+            }
+
+        return super().from_dict(d, prevalidated)
+
 
 class ResourcesConfigV0(schemas.SchemaBase):
     _id = "http://determined.ai/schemas/expconf/v0/resources.json"

--- a/master/pkg/model/experiment_config_test.go
+++ b/master/pkg/model/experiment_config_test.go
@@ -161,3 +161,25 @@ func TestValidateSlurmOptions(t *testing.T) {
 		"slurm option -N is not configurable",
 		"slurm option -D is not configurable")
 }
+
+func TestDeviceConfig(t *testing.T) {
+	// Devices can be strings or maps, and merging device lists is additive.
+	var actual DevicesConfig
+
+	assert.NilError(t, json.Unmarshal([]byte(`[
+    {"host_path": "/not_asdf", "container_path": "/asdf"},
+    {"host_path": "/zxcv", "container_path": "/zxcv"}
+]`), &actual))
+
+	assert.NilError(t, json.Unmarshal([]byte(`[
+    {"host_path": "/asdf", "container_path": "/asdf"},
+    "/qwer:/qwer"
+]`), &actual))
+
+	var expected DevicesConfig
+	expected = append(expected, DeviceConfig{"/asdf", "/asdf", "mrw"})
+	expected = append(expected, DeviceConfig{"/qwer", "/qwer", "mrw"})
+	expected = append(expected, DeviceConfig{"/zxcv", "/zxcv", "mrw"})
+
+	assert.DeepEqual(t, actual, expected)
+}

--- a/master/pkg/schemas/expconf/schema_test.go
+++ b/master/pkg/schemas/expconf/schema_test.go
@@ -144,6 +144,8 @@ func objectForURL(url string) interface{} {
 		return &EnvironmentConfigV0{}
 	case "http://determined.ai/schemas/expconf/v0/data-layer.json":
 		return &DataLayerConfigV0{}
+	case "http://determined.ai/schemas/expconf/v0/resources.json":
+		return &ResourcesConfigV0{}
 	// For union member schemas, just return the union type.
 	case "http://determined.ai/schemas/expconf/v0/searcher.json",
 		"http://determined.ai/schemas/expconf/v0/searcher-adaptive-asha.json",

--- a/master/pkg/schemas/zgen_schemas.go
+++ b/master/pkg/schemas/zgen_schemas.go
@@ -653,7 +653,21 @@ var (
     "title": "DevicesConfig",
     "type": "array",
     "items": {
-        "$ref": "http://determined.ai/schemas/expconf/v0/device.json"
+        "union": {
+            "defaultMessage": "is neither a list of --device strings nor a map containing host_path, container_path, and mode",
+            "items": [
+                {
+                    "unionKey": "never",
+                    "$ref": "http://determined.ai/schemas/expconf/v0/device.json"
+                },
+                {
+                    "unionKey": "never",
+                    "type": "string",
+                    "$comment": "from man docker-run: --device=onhost:incontainer[:mode] ",
+                    "pattern": "^/[^:]*:/[^:]*(:[rwm]*)?"
+                }
+            ]
+        }
     }
 }
 `)

--- a/schemas/expconf/v0/devices.json
+++ b/schemas/expconf/v0/devices.json
@@ -4,6 +4,20 @@
     "title": "DevicesConfig",
     "type": "array",
     "items": {
-        "$ref": "http://determined.ai/schemas/expconf/v0/device.json"
+        "union": {
+            "defaultMessage": "is neither a list of --device strings nor a map containing host_path, container_path, and mode",
+            "items": [
+                {
+                    "unionKey": "never",
+                    "$ref": "http://determined.ai/schemas/expconf/v0/device.json"
+                },
+                {
+                    "unionKey": "never",
+                    "type": "string",
+                    "$comment": "from man docker-run: --device=onhost:incontainer[:mode] ",
+                    "pattern": "^/[^:]*:/[^:]*(:[rwm]*)?"
+                }
+            ]
+        }
     }
 }

--- a/schemas/test_cases/v0/defaults.yaml
+++ b/schemas/test_cases/v0/defaults.yaml
@@ -178,3 +178,40 @@
     source_trial_id: null
     source_checkpoint_uuid: null
     stop_once: false
+
+- name: devices defaults, in string and map forms
+  sane_as:
+    - http://determined.ai/schemas/expconf/v0/resources.json
+  default_as:
+    http://determined.ai/schemas/expconf/v0/resources.json
+  case:
+    devices:
+      - host_path: "/h1"
+        container_path: "/c1"
+        mode: "r"
+      - host_path: "/h2"
+        container_path: "/c2"
+      - "/h3:/c3:r"
+      - "/h4:/c4"
+  defaulted:
+    devices:
+      - host_path: "/h1"
+        container_path: "/c1"
+        mode: "r"
+      - host_path: "/h2"
+        container_path: "/c2"
+        mode: "mrw"
+      - host_path: "/h3"
+        container_path: "/c3"
+        mode: "r"
+      - host_path: "/h4"
+        container_path: "/c4"
+        mode: "mrw"
+    agent_label: ''
+    native_parallel: false
+    shm_size: null
+    slots_per_trial: 1
+    weight: 1
+    max_slots: null
+    priority: null
+    resource_pool: ''

--- a/schemas/test_cases/v0/experiment.yaml
+++ b/schemas/test_cases/v0/experiment.yaml
@@ -110,6 +110,7 @@
         - host_path: "/dev/infiniband"
           container_path: "/dev/infiniband"
           mode: "rmw"
+        - "/host/dev1:/container/dev1"
       slots_per_trial: 15
       weight: 1000
       max_slots: 900

--- a/schemas/test_cases/v0/merging.yaml
+++ b/schemas/test_cases/v0/merging.yaml
@@ -23,6 +23,7 @@
   case:
     - host_path: /asdf
       container_path: /asdf
+    - "/qwer:/qwer"
   merge_src:
     - host_path: /zxcv
       container_path: /zxcv
@@ -31,6 +32,9 @@
   merged:
     - host_path: /asdf
       container_path: /asdf
+      mode:
+    - host_path: /qwer
+      container_path: /qwer
       mode:
     - host_path: /zxcv
       container_path: /zxcv
@@ -105,10 +109,10 @@
       task: language-modeling
   merged:
     transformer:
-      backbone: 
+      backbone:
         type: const
         val: bert
-      task: 
+      task:
         type: const
         val: language-modeling
 
@@ -122,7 +126,7 @@
   merged:
     transformer:
       type: const
-      val: 
+      val:
 
 - name: checkpoint storage merges only allow one union type
   merge_as: http://determined.ai/schemas/expconf/v0/checkpoint-storage.json


### PR DESCRIPTION
Our docs claim that resources.devices may be the equivalent strings as
one would pass to docker run --device, but that has never been true.

We like what the docs promise, so this PR adds support for exactly that.

We continue to support the map form as well, because devcies with colons
in their name (such as some pci devices) can't be passed in the --device
strings.