### PR TITLE
fix: fetchMyRoles on login, only if rbac is on

### DIFF
--- a/webui/react/src/components/DeterminedAuth.tsx
+++ b/webui/react/src/components/DeterminedAuth.tsx
@@ -3,6 +3,7 @@ import React, { useCallback, useState } from 'react';
 
 import Link from 'components/Link';
 import { StoreAction, useStoreDispatch } from 'contexts/Store';
+import useFeature from 'hooks/useFeature';
 import { useFetchMyRoles } from 'hooks/useFetch';
 import { paths } from 'routes/utils';
 import { login } from 'services/api';
@@ -33,6 +34,7 @@ const DeterminedAuth: React.FC<Props> = ({ canceler }: Props) => {
   const fetchMyRoles = useFetchMyRoles(canceler);
   const [isBadCredentials, setIsBadCredentials] = useState(false);
   const [canSubmit, setCanSubmit] = useState(!!storage.get(STORAGE_KEY_LAST_USERNAME));
+  const rbacEnabled = useFeature().isOn('rbac');
 
   const onFinish = useCallback(
     async (creds: FromValues): Promise<void> => {
@@ -51,7 +53,9 @@ const DeterminedAuth: React.FC<Props> = ({ canceler }: Props) => {
           type: StoreAction.SetAuth,
           value: { isAuthenticated: true, token, user },
         });
-        fetchMyRoles();
+        if (rbacEnabled) {
+          fetchMyRoles();
+        }
         storage.set(STORAGE_KEY_LAST_USERNAME, creds.username);
       } catch (e) {
         const isBadCredentialsSync = isLoginFailure(e);


### PR DESCRIPTION
## Description

Prevents an issue on OSS / latest-master, where after logging in / with incognito on, `fetchMyRoles` is called just after logging in.

## Checklist
- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.
- [x] If modifying `/webui/react/src/shared/` verify `make -C webui/react test-shared` passes.