### PR TITLE
fix: account for incompatible expconf change

### DIFF
--- a/master/static/migrations/20221019080320_fixup-incompatible-expconf.tx.down.sql
+++ b/master/static/migrations/20221019080320_fixup-incompatible-expconf.tx.down.sql
@@ -1,0 +1,9 @@
+UPDATE experiments
+SET config = jsonb_insert(config, '{environment,slurm}', config->'slurm'->'sbatch_args')
+WHERE config->'slurm'->'sbatch_args' IS NOT NULL AND NOT config->'slurm'->'sbatch_args' = '[]';
+
+UPDATE experiments
+SET config = config #- '{slurm}';
+
+UPDATE experiments
+SET config = config #- '{pbs}';

--- a/master/static/migrations/20221019080320_fixup-incompatible-expconf.tx.up.sql
+++ b/master/static/migrations/20221019080320_fixup-incompatible-expconf.tx.up.sql
@@ -1,0 +1,6 @@
+UPDATE experiments
+SET config = jsonb_insert(config, '{slurm,sbatch_args}', config->'environment'->'slurm')
+WHERE config->'environment'->'slurm' IS NOT NULL AND NOT config->'environment'->'slurm' = '[]';
+
+UPDATE experiments
+SET config = config #- '{environment,slurm}';


### PR DESCRIPTION
## Description
When we changed the experiment config, because we did not have `omitempty` on the original slurm config, its presence in every full defaulted config in the database caused load failures. This migration fixes it for now. Long term we should generally load less of the expconf and come up with a general "expconf break guide".
<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At a minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan
Tested manually on a local cluster. Will be tested by old experiments loading properly on the release cluster.
<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions about this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)
We should follow up to only load the config necessary in general. Loading launch configs outside of launch is pointless.
<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist
- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.
- [ ] If modifying `/webui/react/src/shared/` verify `make -C webui/react test-shared` passes.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
