### PR TITLE
fix: prefer legacy configs to active configs [DET-8621]

### DIFF
--- a/harness/determined/exec/tensorboard.py
+++ b/harness/determined/exec/tensorboard.py
@@ -96,7 +96,7 @@ def check_tensorboard_responsive() -> bool:
 
 
 def start_tensorboard(
-    config: Dict[str, Any],
+    storage_config: Dict[str, Any],
     tb_version: str,
     storage_paths: List[str],
     add_tb_args: List[str],
@@ -110,7 +110,7 @@ def start_tensorboard(
     with tempfile.TemporaryDirectory() as local_dir:
 
         # Get fetcher and perform initial fetch
-        fetcher = fetchers.build(config, storage_paths, local_dir)
+        fetcher = fetchers.build(storage_config, storage_paths, local_dir)
         num_fetched_files = fetcher.fetch_new()
 
         # Build Tensorboard args and launch process.
@@ -153,15 +153,15 @@ def start_tensorboard(
 
 if __name__ == "__main__":
     tb_version = sys.argv[1]
-    config_path = sys.argv[2]
+    storage_config_path = sys.argv[2]
     storage_paths = sys.argv[3].split(",")
     additional_tb_args = sys.argv[4:]
 
-    config = {}
-    with open(config_path) as config_file:
-        config = json.load(config_file)
+    config = {}  # type: Dict[str, Any]
+    with open(storage_config_path) as config_file:
+        storage_config = json.load(config_file)
 
     determined.common.set_logger(determined.common.util.debug_mode())
 
-    ret = start_tensorboard(config, tb_version, storage_paths, additional_tb_args)
+    ret = start_tensorboard(storage_config, tb_version, storage_paths, additional_tb_args)
     sys.exit(ret)

--- a/harness/determined/tensorboard/fetchers/__init__.py
+++ b/harness/determined/tensorboard/fetchers/__init__.py
@@ -21,11 +21,7 @@ _FETCHERS = {
 }  # type: Dict[str, Type[Fetcher]]
 
 
-def build(config: Dict[str, Any], paths: List[str], local_dir: str) -> Fetcher:
-    storage_config = config.get("checkpoint_storage")
-    if storage_config is None:
-        raise ValueError("config does not contain a 'checkpoint_storage' key")
-
+def build(storage_config: Dict[str, Any], paths: List[str], local_dir: str) -> Fetcher:
     storage_type = storage_config.get("type")
     if storage_type not in _FETCHERS:
         raise ValueError(f"checkpoint_storage type '{storage_type}' is not supported")

--- a/master/go.mod
+++ b/master/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/go-pg/pg/v10 v10.10.6
 	github.com/golang-jwt/jwt v3.2.2+incompatible
 	github.com/golang/protobuf v1.5.2
-	github.com/google/go-cmp v0.5.7
+	github.com/google/go-cmp v0.5.7 // indirect
 	github.com/google/uuid v1.3.0
 	github.com/gorilla/websocket v1.5.0
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0

--- a/master/internal/api_checkpoint.go
+++ b/master/internal/api_checkpoint.go
@@ -57,7 +57,7 @@ func (m *Master) canDoActionOnCheckpoint(
 	if checkpoint.CheckpointTrainingMetadata.ExperimentID == 0 {
 		return nil // TODO(nick) add authz for other task types.
 	}
-	exp, err := m.db.ExperimentWithoutConfigByID(checkpoint.CheckpointTrainingMetadata.ExperimentID)
+	exp, err := m.db.ExperimentByID(checkpoint.CheckpointTrainingMetadata.ExperimentID)
 	if err != nil {
 		return err
 	}
@@ -197,7 +197,7 @@ func (a *apiServer) DeleteCheckpoints(
 		checkpointUUIDs := conv.ToUUIDList(strings.Split(expIDcUUIDs.CheckpointUUIDSStr, ","))
 		ckptGCTask := newCheckpointGCTask(
 			a.m.rm, a.m.db, a.m.taskLogger, taskID, jobID, jobSubmissionTime, taskSpec, exps[i].ID,
-			exps[i].Config.AsLegacy(), checkpointUUIDs, false, agentUserGroup, curUser, nil,
+			exps[i].Config, checkpointUUIDs, false, agentUserGroup, curUser, nil,
 		)
 		a.m.system.MustActorOf(addr, ckptGCTask)
 	}

--- a/master/internal/api_experiment.go
+++ b/master/internal/api_experiment.go
@@ -159,7 +159,6 @@ func (a *apiServer) getExperiment(
 func (a *apiServer) getExperimentAndCheckCanDoActions(
 	ctx context.Context,
 	expID int,
-	withConfig bool,
 	actions ...func(context.Context, model.User, *model.Experiment) error,
 ) (*model.Experiment, model.User, error) {
 	curUser, _, err := grpcutil.GetUser(ctx)
@@ -167,12 +166,8 @@ func (a *apiServer) getExperimentAndCheckCanDoActions(
 		return nil, model.User{}, err
 	}
 
-	var e *model.Experiment
-	if withConfig {
-		e, err = a.m.db.ExperimentByID(expID)
-	} else {
-		e, err = a.m.db.ExperimentWithoutConfigByID(expID)
-	}
+	e, err := a.m.db.ExperimentByID(expID)
+
 	expNotFound := status.Errorf(codes.NotFound, "experiment not found: %d", expID)
 	if errors.Is(err, db.ErrNotFound) {
 		return nil, model.User{}, expNotFound
@@ -250,7 +245,7 @@ func (a *apiServer) PostSearcherOperations(
 	resp *apiv1.PostSearcherOperationsResponse, err error,
 ) {
 	_, _, err = a.getExperimentAndCheckCanDoActions(
-		ctx, int(req.ExperimentId), false, expauth.AuthZProvider.Get().CanRunCustomSearch,
+		ctx, int(req.ExperimentId), expauth.AuthZProvider.Get().CanRunCustomSearch,
 	)
 	if err != nil {
 		return nil, errors.Wrap(err, "fetching experiment from database")
@@ -318,7 +313,7 @@ func (a *apiServer) GetExperiment(
 func (a *apiServer) DeleteExperiment(
 	ctx context.Context, req *apiv1.DeleteExperimentRequest,
 ) (*apiv1.DeleteExperimentResponse, error) {
-	e, curUser, err := a.getExperimentAndCheckCanDoActions(ctx, int(req.ExperimentId), false,
+	e, curUser, err := a.getExperimentAndCheckCanDoActions(ctx, int(req.ExperimentId),
 		expauth.AuthZProvider.Get().CanDeleteExperiment)
 	if err != nil {
 		return nil, err
@@ -356,11 +351,6 @@ func (a *apiServer) DeleteExperiment(
 }
 
 func (a *apiServer) deleteExperiment(exp *model.Experiment, userModel *model.User) error {
-	conf, err := a.m.db.LegacyExperimentConfigByID(exp.ID)
-	if err != nil {
-		return fmt.Errorf("failed to read config for experiment: %w", err)
-	}
-
 	agentUserGroup, err := user.GetAgentUserGroup(*exp.OwnerID, exp)
 	if err != nil {
 		return err
@@ -381,7 +371,7 @@ func (a *apiServer) deleteExperiment(exp *model.Experiment, userModel *model.Use
 	taskID := model.NewTaskID()
 	ckptGCTask := newCheckpointGCTask(
 		a.m.rm, a.m.db, a.m.taskLogger, taskID, exp.JobID, jobSubmissionTime, taskSpec, exp.ID,
-		conf, checkpoints, true, agentUserGroup, userModel, nil,
+		exp.Config, checkpoints, true, agentUserGroup, userModel, nil,
 	)
 	if gcErr := a.m.system.MustActorOf(addr, ckptGCTask).AwaitTermination(); gcErr != nil {
 		return errors.Wrapf(gcErr, "failed to gc checkpoints for experiment")
@@ -688,7 +678,7 @@ func (a *apiServer) GetExperimentLabels(ctx context.Context,
 func (a *apiServer) GetExperimentValidationHistory(
 	ctx context.Context, req *apiv1.GetExperimentValidationHistoryRequest,
 ) (*apiv1.GetExperimentValidationHistoryResponse, error) {
-	if _, _, err := a.getExperimentAndCheckCanDoActions(ctx, int(req.ExperimentId), false,
+	if _, _, err := a.getExperimentAndCheckCanDoActions(ctx, int(req.ExperimentId),
 		expauth.AuthZProvider.Get().CanGetExperimentArtifacts); err != nil {
 		return nil, err
 	}
@@ -799,7 +789,7 @@ func (a *apiServer) PreviewHPSearch(
 func (a *apiServer) ActivateExperiment(
 	ctx context.Context, req *apiv1.ActivateExperimentRequest,
 ) (resp *apiv1.ActivateExperimentResponse, err error) {
-	if _, _, err = a.getExperimentAndCheckCanDoActions(ctx, int(req.Id), false,
+	if _, _, err = a.getExperimentAndCheckCanDoActions(ctx, int(req.Id),
 		expauth.AuthZProvider.Get().CanEditExperiment); err != nil {
 		return nil, err
 	}
@@ -818,7 +808,7 @@ func (a *apiServer) ActivateExperiment(
 func (a *apiServer) PauseExperiment(
 	ctx context.Context, req *apiv1.PauseExperimentRequest,
 ) (resp *apiv1.PauseExperimentResponse, err error) {
-	if _, _, err = a.getExperimentAndCheckCanDoActions(ctx, int(req.Id), false,
+	if _, _, err = a.getExperimentAndCheckCanDoActions(ctx, int(req.Id),
 		expauth.AuthZProvider.Get().CanEditExperiment); err != nil {
 		return nil, err
 	}
@@ -837,7 +827,7 @@ func (a *apiServer) PauseExperiment(
 func (a *apiServer) CancelExperiment(
 	ctx context.Context, req *apiv1.CancelExperimentRequest,
 ) (resp *apiv1.CancelExperimentResponse, err error) {
-	if _, _, err = a.getExperimentAndCheckCanDoActions(ctx, int(req.Id), false,
+	if _, _, err = a.getExperimentAndCheckCanDoActions(ctx, int(req.Id),
 		expauth.AuthZProvider.Get().CanEditExperiment); err != nil {
 		return nil, err
 	}
@@ -853,7 +843,7 @@ func (a *apiServer) CancelExperiment(
 func (a *apiServer) KillExperiment(
 	ctx context.Context, req *apiv1.KillExperimentRequest,
 ) (resp *apiv1.KillExperimentResponse, err error) {
-	if _, _, err = a.getExperimentAndCheckCanDoActions(ctx, int(req.Id), false,
+	if _, _, err = a.getExperimentAndCheckCanDoActions(ctx, int(req.Id),
 		expauth.AuthZProvider.Get().CanEditExperiment); err != nil {
 		return nil, err
 	}
@@ -870,7 +860,7 @@ func (a *apiServer) ArchiveExperiment(
 	ctx context.Context, req *apiv1.ArchiveExperimentRequest,
 ) (*apiv1.ArchiveExperimentResponse, error) {
 	id := int(req.Id)
-	dbExp, _, err := a.getExperimentAndCheckCanDoActions(ctx, id, false,
+	dbExp, _, err := a.getExperimentAndCheckCanDoActions(ctx, id,
 		expauth.AuthZProvider.Get().CanEditExperimentsMetadata)
 	if err != nil {
 		return nil, err
@@ -898,7 +888,7 @@ func (a *apiServer) UnarchiveExperiment(
 	ctx context.Context, req *apiv1.UnarchiveExperimentRequest,
 ) (*apiv1.UnarchiveExperimentResponse, error) {
 	id := int(req.Id)
-	dbExp, _, err := a.getExperimentAndCheckCanDoActions(ctx, id, false,
+	dbExp, _, err := a.getExperimentAndCheckCanDoActions(ctx, id,
 		expauth.AuthZProvider.Get().CanEditExperimentsMetadata)
 	if err != nil {
 		return nil, err
@@ -1016,7 +1006,7 @@ func (a *apiServer) GetExperimentCheckpoints(
 ) (*apiv1.GetExperimentCheckpointsResponse, error) {
 	experimentID := int(req.Id)
 	useSearcherSortBy := req.SortBy == apiv1.GetExperimentCheckpointsRequest_SORT_BY_SEARCHER_METRIC
-	exp, _, err := a.getExperimentAndCheckCanDoActions(ctx, experimentID, useSearcherSortBy,
+	exp, _, err := a.getExperimentAndCheckCanDoActions(ctx, experimentID,
 		expauth.AuthZProvider.Get().CanGetExperimentArtifacts)
 	if err != nil {
 		return nil, err
@@ -1025,7 +1015,7 @@ func (a *apiServer) GetExperimentCheckpoints(
 	// If SORT_BY_SEARCHER_METRIC is specified without an OrderBy
 	// default to ordering by "better" checkpoints.
 	if useSearcherSortBy && req.OrderBy == apiv1.OrderBy_ORDER_BY_UNSPECIFIED {
-		if exp.Config.Searcher().SmallerIsBetter() {
+		if exp.Config.Searcher.SmallerIsBetter {
 			req.OrderBy = apiv1.OrderBy_ORDER_BY_ASC
 		} else {
 			req.OrderBy = apiv1.OrderBy_ORDER_BY_DESC
@@ -1147,7 +1137,9 @@ func (a *apiServer) CreateExperiment(
 		detParams.ProjectID = &projectID
 	}
 
-	dbExp, p, validateOnly, taskSpec, err := a.m.parseCreateExperiment(&detParams, user)
+	dbExp, activeConfig, p, validateOnly, taskSpec, err := a.m.parseCreateExperiment(
+		&detParams, user,
+	)
 	if err != nil {
 		if _, ok := err.(ErrProjectNotFound); ok {
 			return nil, status.Errorf(codes.NotFound, err.Error())
@@ -1171,7 +1163,7 @@ func (a *apiServer) CreateExperiment(
 		}
 	}
 
-	e, launchWarnings, err := newExperiment(a.m, dbExp, taskSpec)
+	e, launchWarnings, err := newExperiment(a.m, dbExp, activeConfig, taskSpec)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to create experiment: %s", err)
 	}
@@ -1190,7 +1182,7 @@ func (a *apiServer) CreateExperiment(
 	}
 	return &apiv1.CreateExperimentResponse{
 		Experiment: protoExp,
-		Config:     protoutils.ToStruct(e.Config),
+		Config:     protoutils.ToStruct(activeConfig),
 		Warnings:   command.LaunchWarningToProto(launchWarnings),
 	}, nil
 }
@@ -1215,23 +1207,17 @@ func (a *apiServer) MetricNames(req *apiv1.MetricNamesRequest,
 	var vStartTime time.Time
 
 	var timeSinceLastAuth time.Time
-	var config expconf.ExperimentConfig
 	var searcherMetric string
 	for {
 		if time.Now().Sub(timeSinceLastAuth) >= recheckAuthPeriod {
-			if _, _, err := a.getExperimentAndCheckCanDoActions(resp.Context(), experimentID,
-				false, expauth.AuthZProvider.Get().CanGetExperimentArtifacts); err != nil {
+			exp, _, err := a.getExperimentAndCheckCanDoActions(resp.Context(), experimentID,
+				expauth.AuthZProvider.Get().CanGetExperimentArtifacts)
+			if err != nil {
 				return err
 			}
 
 			if timeSinceLastAuth == (time.Time{}) { // Initialzation.
-				var err error
-				config, err = a.m.db.ExperimentConfig(experimentID)
-				if err != nil {
-					return errors.Wrapf(err,
-						"error fetching experiment config from database: %d", experimentID)
-				}
-				searcherMetric = config.Searcher().Metric()
+				searcherMetric = exp.Config.Searcher.Metric
 			}
 			timeSinceLastAuth = time.Now()
 		}
@@ -1373,7 +1359,7 @@ func (a *apiServer) MetricBatches(req *apiv1.MetricBatchesRequest,
 	var startTime time.Time
 	for {
 		if time.Now().Sub(timeSinceLastAuth) >= recheckAuthPeriod {
-			if _, _, err := a.getExperimentAndCheckCanDoActions(resp.Context(), experimentID, false,
+			if _, _, err := a.getExperimentAndCheckCanDoActions(resp.Context(), experimentID,
 				expauth.AuthZProvider.Get().CanGetExperimentArtifacts); err != nil {
 				return err
 			}
@@ -1464,7 +1450,7 @@ func (a *apiServer) TrialsSnapshot(req *apiv1.TrialsSnapshotRequest,
 	var startTime time.Time
 	for {
 		if time.Now().Sub(timeSinceLastAuth) >= recheckAuthPeriod {
-			if _, _, err := a.getExperimentAndCheckCanDoActions(resp.Context(), experimentID, false,
+			if _, _, err := a.getExperimentAndCheckCanDoActions(resp.Context(), experimentID,
 				expauth.AuthZProvider.Get().CanGetExperimentArtifacts); err != nil {
 				return err
 			}
@@ -1516,7 +1502,7 @@ func (a *apiServer) TrialsSnapshot(req *apiv1.TrialsSnapshotRequest,
 	}
 }
 
-func (a *apiServer) topTrials(experimentID int, maxTrials int, s expconf.SearcherConfig) (
+func (a *apiServer) topTrials(experimentID int, maxTrials int, s expconf.LegacySearcher) (
 	trials []int32, err error,
 ) {
 	type Ranking int
@@ -1526,34 +1512,34 @@ func (a *apiServer) topTrials(experimentID int, maxTrials int, s expconf.Searche
 	)
 	var ranking Ranking
 
-	switch s.GetUnionMember().(type) {
-	case expconf.RandomConfig:
+	switch s.Name {
+	case "random":
 		ranking = ByMetricOfInterest
-	case expconf.GridConfig:
+	case "grid":
 		ranking = ByMetricOfInterest
-	case expconf.CustomConfig:
+	case "custom":
 		ranking = ByMetricOfInterest
-	case expconf.AsyncHalvingConfig:
+	case "async_halving":
 		ranking = ByTrainingLength
-	case expconf.AdaptiveASHAConfig:
+	case "adaptive_asha":
 		ranking = ByTrainingLength
-	case expconf.SingleConfig:
+	case "single":
 		return nil, errors.New("single-trial experiments are not supported for trial sampling")
 	// EOL searcher configs:
-	case expconf.AdaptiveConfig:
+	case "adaptive":
 		ranking = ByTrainingLength
-	case expconf.AdaptiveSimpleConfig:
+	case "adaptive_simple":
 		ranking = ByTrainingLength
-	case expconf.SyncHalvingConfig:
+	case "sync_halving":
 		ranking = ByTrainingLength
 	default:
-		return nil, errors.New("unable to detect a searcher algorithm for trial sampling")
+		return nil, errors.Errorf("unable to detect a searcher algorithm for trial sampling")
 	}
 	switch ranking {
 	case ByMetricOfInterest:
-		return a.m.db.TopTrialsByMetric(experimentID, maxTrials, s.Metric(), s.SmallerIsBetter())
+		return a.m.db.TopTrialsByMetric(experimentID, maxTrials, s.Metric, s.SmallerIsBetter)
 	case ByTrainingLength:
-		return a.m.db.TopTrialsByTrainingLength(experimentID, maxTrials, s.Metric(), s.SmallerIsBetter())
+		return a.m.db.TopTrialsByTrainingLength(experimentID, maxTrials, s.Metric, s.SmallerIsBetter)
 	default:
 		panic("Invalid state in trial sampling")
 	}
@@ -1704,24 +1690,19 @@ func (a *apiServer) TrialsSample(req *apiv1.TrialsSampleRequest,
 	}
 
 	var timeSinceLastAuth time.Time
-	var config expconf.ExperimentConfig
-	var searcherConfig expconf.SearcherConfig
+	var searcherConfig expconf.LegacySearcher
 	trialCursors := make(map[int32]time.Time)
 	currentTrials := make(map[int32]bool)
 	for {
 		if time.Now().Sub(timeSinceLastAuth) >= recheckAuthPeriod {
-			if _, _, err := a.getExperimentAndCheckCanDoActions(resp.Context(), experimentID, false,
-				expauth.AuthZProvider.Get().CanGetExperimentArtifacts); err != nil {
+			exp, _, err := a.getExperimentAndCheckCanDoActions(resp.Context(), experimentID,
+				expauth.AuthZProvider.Get().CanGetExperimentArtifacts)
+			if err != nil {
 				return err
 			}
 
 			if timeSinceLastAuth == (time.Time{}) { // Initialzation.
-				var err error
-				config, err = a.m.db.ExperimentConfig(experimentID)
-				if err != nil {
-					return errors.Wrapf(err, "error fetching experiment config from database")
-				}
-				searcherConfig = config.Searcher()
+				searcherConfig = exp.Config.Searcher
 			}
 			timeSinceLastAuth = time.Now()
 		}
@@ -1827,7 +1808,7 @@ func (a *apiServer) ExpCompareTrialsSample(req *apiv1.ExpCompareTrialsSampleRequ
 	for {
 		if time.Now().Sub(timeSinceLastAuth) >= recheckAuthPeriod {
 			for _, expID := range experimentIDs {
-				if _, _, err := a.getExperimentAndCheckCanDoActions(resp.Context(), int(expID), false,
+				if _, _, err := a.getExperimentAndCheckCanDoActions(resp.Context(), int(expID),
 					expauth.AuthZProvider.Get().CanGetExperimentArtifacts); err != nil {
 					return err
 				}
@@ -1902,7 +1883,7 @@ func (a *apiServer) ComputeHPImportance(ctx context.Context,
 	req *apiv1.ComputeHPImportanceRequest,
 ) (*apiv1.ComputeHPImportanceResponse, error) {
 	experimentID := int(req.ExperimentId)
-	if _, _, err := a.getExperimentAndCheckCanDoActions(ctx, experimentID, false,
+	if _, _, err := a.getExperimentAndCheckCanDoActions(ctx, experimentID,
 		expauth.AuthZProvider.Get().CanEditExperiment); err != nil {
 		return nil, err
 	}
@@ -1957,7 +1938,7 @@ func (a *apiServer) GetHPImportance(req *apiv1.GetHPImportanceRequest,
 	var timeSinceLastAuth time.Time
 	for {
 		if time.Now().Sub(timeSinceLastAuth) >= recheckAuthPeriod {
-			if _, _, err := a.getExperimentAndCheckCanDoActions(resp.Context(), experimentID, false,
+			if _, _, err := a.getExperimentAndCheckCanDoActions(resp.Context(), experimentID,
 				expauth.AuthZProvider.Get().CanGetExperimentArtifacts); err != nil {
 				return err
 			}
@@ -2020,7 +2001,7 @@ func (a *apiServer) GetHPImportance(req *apiv1.GetHPImportanceRequest,
 func (a *apiServer) GetBestSearcherValidationMetric(
 	ctx context.Context, req *apiv1.GetBestSearcherValidationMetricRequest,
 ) (*apiv1.GetBestSearcherValidationMetricResponse, error) {
-	if _, _, err := a.getExperimentAndCheckCanDoActions(ctx, int(req.ExperimentId), false,
+	if _, _, err := a.getExperimentAndCheckCanDoActions(ctx, int(req.ExperimentId),
 		expauth.AuthZProvider.Get().CanGetExperimentArtifacts); err != nil {
 		return nil, err
 	}
@@ -2041,7 +2022,7 @@ func (a *apiServer) GetBestSearcherValidationMetric(
 func (a *apiServer) GetModelDef(
 	ctx context.Context, req *apiv1.GetModelDefRequest,
 ) (*apiv1.GetModelDefResponse, error) {
-	if _, _, err := a.getExperimentAndCheckCanDoActions(ctx, int(req.ExperimentId), false,
+	if _, _, err := a.getExperimentAndCheckCanDoActions(ctx, int(req.ExperimentId),
 		expauth.AuthZProvider.Get().CanGetExperimentArtifacts); err != nil {
 		return nil, err
 	}
@@ -2061,7 +2042,7 @@ func (a *apiServer) MoveExperiment(
 	ctx context.Context, req *apiv1.MoveExperimentRequest,
 ) (*apiv1.MoveExperimentResponse, error) {
 	// get experiment info
-	exp, curUser, err := a.getExperimentAndCheckCanDoActions(ctx, int(req.ExperimentId), false)
+	exp, curUser, err := a.getExperimentAndCheckCanDoActions(ctx, int(req.ExperimentId))
 	if err != nil {
 		return nil, err
 	}
@@ -2110,7 +2091,7 @@ func (a *apiServer) MoveExperiment(
 func (a *apiServer) GetModelDefTree(
 	ctx context.Context, req *apiv1.GetModelDefTreeRequest,
 ) (*apiv1.GetModelDefTreeResponse, error) {
-	if _, _, err := a.getExperimentAndCheckCanDoActions(ctx, int(req.ExperimentId), false,
+	if _, _, err := a.getExperimentAndCheckCanDoActions(ctx, int(req.ExperimentId),
 		expauth.AuthZProvider.Get().CanGetExperimentArtifacts); err != nil {
 		return nil, err
 	}
@@ -2126,7 +2107,7 @@ func (a *apiServer) GetModelDefTree(
 func (a *apiServer) GetModelDefFile(
 	ctx context.Context, req *apiv1.GetModelDefFileRequest,
 ) (*apiv1.GetModelDefFileResponse, error) {
-	if _, _, err := a.getExperimentAndCheckCanDoActions(ctx, int(req.ExperimentId), false,
+	if _, _, err := a.getExperimentAndCheckCanDoActions(ctx, int(req.ExperimentId),
 		expauth.AuthZProvider.Get().CanGetExperimentArtifacts); err != nil {
 		return nil, err
 	}

--- a/master/internal/api_tasks.go
+++ b/master/internal/api_tasks.go
@@ -61,7 +61,7 @@ func expFromAllocationID(
 		return false, nil, err
 	}
 
-	exp, err = m.db.ExperimentWithoutConfigByID(expID)
+	exp, err = m.db.ExperimentByID(expID)
 	if err != nil {
 		return false, nil, err
 	}
@@ -99,7 +99,7 @@ func (a *apiServer) canDoActionsOnTask(
 
 	switch t.TaskType {
 	case model.TaskTypeTrial:
-		exp, err := db.ExperimentWithoutConfigByTaskID(ctx, t.TaskID)
+		exp, err := db.ExperimentByTaskID(ctx, t.TaskID)
 		if err != nil {
 			return err
 		}

--- a/master/internal/api_tensorboard.go
+++ b/master/internal/api_tensorboard.go
@@ -3,6 +3,7 @@ package internal
 import (
 	"archive/tar"
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/url"
 	"os"
@@ -46,7 +47,7 @@ const (
 	minTensorBoardPort        = 2600
 	maxTensorBoardPort        = minTensorBoardPort + 299
 	tensorboardEntrypointFile = "/run/determined/tensorboard/tensorboard-entrypoint.sh"
-	expConfPath               = "/run/determined/tensorboard/experiment_config.json"
+	storageConfPath           = "/run/determined/tensorboard/storage_config.json"
 )
 
 var tensorboardsAddr = actor.Addr("tensorboard")
@@ -214,7 +215,7 @@ func (a *apiServer) LaunchTensorboard(
 	for _, exp := range exps {
 		var logBasePath string
 
-		switch c := exp.Config.CheckpointStorage().GetUnionMember().(type) {
+		switch c := exp.Config.CheckpointStorage.GetUnionMember().(type) {
 		case expconf.SharedFSConfig:
 			// Mount the checkpoint location into the TensorBoard container to
 			// make the logs visible to TensorBoard. Bind mounts must be unique
@@ -277,7 +278,7 @@ func (a *apiServer) LaunchTensorboard(
 
 			// The credentials files for HDFS exist on agent machines and are
 			// bind mounted into the container.
-			for _, mount := range exp.Config.BindMounts() {
+			for _, mount := range exp.Config.BindMounts {
 				uniqMounts[mount.ContainerPath()] = model.ToModelBindMount(mount)
 			}
 
@@ -304,33 +305,27 @@ func (a *apiServer) LaunchTensorboard(
 	// Get the most recent experiment config as raw json and add it to the container. This
 	// is used for automatically configuring checkpoint storage, registry auth, etc.
 	mostRecentExpID := exps[len(exps)-1].ExperimentID
-	confBytes, err := a.m.db.ExperimentConfigRaw(int(mostRecentExpID))
+	exp, err := a.m.db.ExperimentByID(int(mostRecentExpID))
 	if err != nil {
-		return nil, errors.Wrapf(err, "error loading experiment config: %d", mostRecentExpID)
+		return nil, errors.Wrapf(err, "error loading experiment: %d", mostRecentExpID)
 	}
-
-	expConf, err := expconf.ParseAnyExperimentConfigYAML(confBytes)
-	if err != nil {
-		return nil, errors.Wrapf(err, "error parsing experiment config: %d", mostRecentExpID)
-	}
-	expConf = schemas.WithDefaults(expConf)
 
 	spec.Config.Entrypoint = append(
-		[]string{tensorboardEntrypointFile, expConfPath, strings.Join(logDirs, ",")},
+		[]string{tensorboardEntrypointFile, storageConfPath, strings.Join(logDirs, ",")},
 		spec.Config.TensorBoardArgs...)
 
 	spec.Base.ExtraEnvVars = uniqEnvVars
 
 	if !model.UsingCustomImage(req) {
 		spec.Config.Environment.Image = model.RuntimeItem{
-			CPU:  expConf.Environment().Image().CPU(),
-			CUDA: expConf.Environment().Image().CUDA(),
-			ROCM: expConf.Environment().Image().ROCM(),
+			CPU:  exp.Config.Environment.Image().CPU(),
+			CUDA: exp.Config.Environment.Image().CUDA(),
+			ROCM: exp.Config.Environment.Image().ROCM(),
 		}
 
 		// Inherit ImagePullSecrets too, if we inherit the image.
 		presentPod := spec.Config.Environment.PodSpec
-		experimentPod := expConf.Environment().PodSpec()
+		experimentPod := exp.Config.Environment.PodSpec()
 		if experimentPod != nil && len(experimentPod.Spec.ImagePullSecrets) > 0 {
 			if presentPod != nil {
 				// Update the k8sV1.Pod with the experiment's pod's ImagePullSecrets.
@@ -349,7 +344,7 @@ func (a *apiServer) LaunchTensorboard(
 	}
 	// Prefer RegistryAuth already present over the one from inferred from the experiment.
 	if spec.Config.Environment.RegistryAuth == nil {
-		spec.Config.Environment.RegistryAuth = expConf.Environment().RegistryAuth()
+		spec.Config.Environment.RegistryAuth = exp.Config.Environment.RegistryAuth()
 	}
 
 	var bindMounts []model.BindMount
@@ -358,13 +353,18 @@ func (a *apiServer) LaunchTensorboard(
 	}
 	spec.Config.BindMounts = append(spec.Config.BindMounts, bindMounts...)
 
+	confBytes, err := json.Marshal(exp.Config.CheckpointStorage)
+	if err != nil {
+		return nil, errors.Wrapf(err, "error marshaling checkpoint_storage")
+	}
+
 	spec.AdditionalFiles = archive.Archive{
 		spec.Base.AgentUserGroup.OwnedArchiveItem(
 			tensorboardEntrypointFile,
 			etc.MustStaticFile(etc.TensorboardEntryScriptResource), 0o700,
 			tar.TypeReg,
 		),
-		spec.Base.AgentUserGroup.OwnedArchiveItem(expConfPath, confBytes, 0o700, tar.TypeReg),
+		spec.Base.AgentUserGroup.OwnedArchiveItem(storageConfPath, confBytes, 0o700, tar.TypeReg),
 		spec.Base.AgentUserGroup.OwnedArchiveItem(
 			taskReadyCheckLogs,
 			etc.MustStaticFile(etc.TaskCheckReadyLogsResource),
@@ -407,7 +407,7 @@ func (a *apiServer) getTensorBoardConfigsFromReq(
 	confByID := map[int32]*tensorboardConfig{}
 
 	for _, expID := range req.ExperimentIds {
-		if _, _, err := a.getExperimentAndCheckCanDoActions(ctx, int(expID), false,
+		if _, _, err := a.getExperimentAndCheckCanDoActions(ctx, int(expID),
 			expauth.AuthZProvider.Get().CanGetExperimentArtifacts); err != nil {
 			return nil, err
 		}

--- a/master/internal/api_trials.go
+++ b/master/internal/api_trials.go
@@ -62,7 +62,7 @@ func (a *apiServer) canGetTrialsExperimentAndCheckCanDoAction(ctx context.Contex
 	}
 
 	trialNotFound := status.Errorf(codes.NotFound, "trial %d not found", trialID)
-	exp, err := a.m.db.ExperimentWithoutConfigByTrialID(trialID)
+	exp, err := a.m.db.ExperimentByTrialID(trialID)
 	if errors.Is(err, db.ErrNotFound) {
 		return trialNotFound
 	} else if err != nil {
@@ -518,7 +518,7 @@ func (a *apiServer) GetExperimentTrials(
 	ctx context.Context, req *apiv1.GetExperimentTrialsRequest,
 ) (resp *apiv1.GetExperimentTrialsResponse, err error) {
 	if _, _, err = a.getExperimentAndCheckCanDoActions(ctx, int(req.ExperimentId),
-		false, expauth.AuthZProvider.Get().CanGetExperimentArtifacts); err != nil {
+		expauth.AuthZProvider.Get().CanGetExperimentArtifacts); err != nil {
 		return nil, err
 	}
 

--- a/master/internal/core_checkpoint.go
+++ b/master/internal/core_checkpoint.go
@@ -82,7 +82,7 @@ func (m *Master) getCheckpointStorageConfig(id uuid.UUID) (
 		return nil, err
 	}
 
-	return ptrs.Ptr(legacyConfig.CheckpointStorage()), nil
+	return ptrs.Ptr(legacyConfig.CheckpointStorage), nil
 }
 
 func (m *Master) getCheckpointImpl(

--- a/master/internal/core_checkpoint_intg_test.go
+++ b/master/internal/core_checkpoint_intg_test.go
@@ -318,14 +318,14 @@ func mockExperimentS3(
 	exp := model.Experiment{
 		JobID:                model.NewJobID(),
 		State:                model.ActiveState,
-		Config:               cfg,
+		Config:               cfg.AsLegacy(),
 		ModelDefinitionBytes: db.ReadTestModelDefiniton(t, folderPath),
 		StartTime:            time.Now().Add(-time.Hour),
 		OwnerID:              &user.ID,
 		Username:             user.Username,
 		ProjectID:            1,
 	}
-	err := pgDB.AddExperiment(&exp)
+	err := pgDB.AddExperiment(&exp, cfg)
 	require.NoError(t, err, "failed to add experiment")
 	return &exp
 }

--- a/master/internal/core_experiment.go
+++ b/master/internal/core_experiment.go
@@ -80,16 +80,10 @@ func ParseExperimentsQuery(apiCtx echo.Context) (*ExperimentRequestQuery, error)
 }
 
 func echoGetExperimentAndCheckCanDoActions(ctx context.Context, c echo.Context, m *Master,
-	expID int, withConfig bool, actions ...func(context.Context, model.User, *model.Experiment) error,
+	expID int, actions ...func(context.Context, model.User, *model.Experiment) error,
 ) (*model.Experiment, model.User, error) {
 	user := c.(*detContext.DetContext).MustGetUser()
-	var err error
-	var e *model.Experiment
-	if withConfig {
-		e, err = m.db.ExperimentByID(expID)
-	} else {
-		e, err = m.db.ExperimentWithoutConfigByID(expID)
-	}
+	e, err := m.db.ExperimentByID(expID)
 
 	expNotFound := echo.NewHTTPError(http.StatusNotFound, "experiment not found: %d", expID)
 	if errors.Is(err, db.ErrNotFound) {
@@ -121,10 +115,11 @@ func (m *Master) getExperimentCheckpointsToGC(c echo.Context) (interface{}, erro
 	if err := api.BindArgs(&args, c); err != nil {
 		return nil, err
 	}
-	if _, _, err := echoGetExperimentAndCheckCanDoActions(
-		c.Request().Context(), c, m, args.ExperimentID, false,
+	exp, _, err := echoGetExperimentAndCheckCanDoActions(
+		c.Request().Context(), c, m, args.ExperimentID,
 		expauth.AuthZProvider.Get().CanGetExperimentArtifacts,
-	); err != nil {
+	)
+	if err != nil {
 		return nil, err
 	}
 
@@ -138,14 +133,8 @@ func (m *Master) getExperimentCheckpointsToGC(c echo.Context) (interface{}, erro
 		return nil, err
 	}
 
-	expConfig, err := m.db.ExperimentConfig(args.ExperimentID)
-	if err != nil {
-		return nil, err
-	}
-
-	metricName := expConfig.Searcher().Metric()
 	checkpointsWithMetric := map[string]interface{}{
-		"checkpoints": checkpointsDB, "metric_name": metricName,
+		"checkpoints": checkpointsDB, "metric_name": exp.Config.Searcher.Metric,
 	}
 
 	return checkpointsWithMetric, nil
@@ -170,7 +159,7 @@ func (m *Master) getExperimentModelFile(c echo.Context) error {
 		return err
 	}
 	if _, _, err := echoGetExperimentAndCheckCanDoActions(
-		c.Request().Context(), c, m, args.ExperimentID, false,
+		c.Request().Context(), c, m, args.ExperimentID,
 		expauth.AuthZProvider.Get().CanGetExperimentArtifacts,
 	); err != nil {
 		return err
@@ -198,7 +187,7 @@ func (m *Master) getExperimentModelDefinition(c echo.Context) error {
 		return err
 	}
 	if _, _, err := echoGetExperimentAndCheckCanDoActions(
-		c.Request().Context(), c, m, args.ExperimentID, false,
+		c.Request().Context(), c, m, args.ExperimentID,
 		expauth.AuthZProvider.Get().CanGetExperimentArtifacts,
 	); err != nil {
 		return err
@@ -209,14 +198,15 @@ func (m *Master) getExperimentModelDefinition(c echo.Context) error {
 		return err
 	}
 
-	expConfig, err := m.db.ExperimentConfig(args.ExperimentID)
-	if err != nil {
-		return err
-	}
+	var cleanName string
 
-	// Make a Regex to remove everything but a whitelist of characters.
-	reg := regexp.MustCompile(`[^A-Za-z0-9_ \-()[\].{}]+`)
-	cleanName := reg.ReplaceAllString(expConfig.Name().String(), "")
+	// TODO(DET-8577): Remove unnecessary active config usage.
+	activeConfig, err := m.db.ActiveExperimentConfig(args.ExperimentID)
+	if err == nil {
+		// Make a Regex to remove everything but a whitelist of characters.
+		reg := regexp.MustCompile(`[^A-Za-z0-9_ \-()[\].{}]+`)
+		cleanName = "_" + reg.ReplaceAllString(activeConfig.Name().String(), "")
+	}
 
 	// Truncate name to a smaller size to both accommodate file name and path size
 	// limits on different platforms as well as get users more accustom to picking shorter
@@ -229,7 +219,7 @@ func (m *Master) getExperimentModelDefinition(c echo.Context) error {
 	c.Response().Header().Set(
 		"Content-Disposition",
 		fmt.Sprintf(
-			`attachment; filename="exp%d_%s_model_def.tar.gz"`,
+			`attachment; filename="exp%d%s_model_def.tar.gz"`,
 			args.ExperimentID,
 			cleanName))
 	return c.Blob(http.StatusOK, "application/x-gtar", modelDef)
@@ -245,12 +235,11 @@ func (m *Master) patchExperiment(c echo.Context) (interface{}, error) {
 		return nil, err
 	}
 	ctx := c.Request().Context()
-	dbExp, userModel, err := echoGetExperimentAndCheckCanDoActions(ctx, c, m, args.ExperimentID, true)
+	dbExp, userModel, err := echoGetExperimentAndCheckCanDoActions(ctx, c, m, args.ExperimentID)
 	if err != nil {
 		return nil, err
 	}
 
-	// `patch` represents the allowed mutations that can be performed on an experiment, in JSON
 	// Merge Patch (RFC 7386) format.
 	// TODO: check for extraneous fields.
 	patch := struct {
@@ -279,8 +268,16 @@ func (m *Master) patchExperiment(c echo.Context) (interface{}, error) {
 		return nil, errors.Errorf("cannot find user %v who owns experiment", dbExp.OwnerID)
 	}
 
+	// TODO(DET-8577): Remove unnecessary active config usage.
+	activeConfig, err := m.db.ActiveExperimentConfig(args.ExperimentID)
+	if err != nil {
+		return nil, errors.Wrapf(
+			err, "unable to load no-longer-valid config for experiment %v", args.ExperimentID,
+		)
+	}
+
 	if patch.Resources != nil {
-		resources := dbExp.Config.Resources()
+		resources := activeConfig.Resources()
 		if patch.Resources.MaxSlots.IsPresent {
 			if err = expauth.AuthZProvider.Get().
 				CanSetExperimentsMaxSlots(ctx, userModel, dbExp, *patch.Resources.MaxSlots.Value); err != nil {
@@ -305,7 +302,7 @@ func (m *Master) patchExperiment(c echo.Context) (interface{}, error) {
 
 			resources.SetPriority(patch.Resources.Priority)
 		}
-		dbExp.Config.SetResources(resources)
+		activeConfig.SetResources(resources)
 	}
 	if patch.CheckpointStorage != nil {
 		if err = expauth.AuthZProvider.Get().
@@ -313,14 +310,15 @@ func (m *Master) patchExperiment(c echo.Context) (interface{}, error) {
 			return nil, echo.NewHTTPError(http.StatusForbidden, err.Error())
 		}
 
-		storage := dbExp.Config.CheckpointStorage()
+		storage := activeConfig.CheckpointStorage()
 		storage.SetSaveExperimentBest(patch.CheckpointStorage.SaveExperimentBest)
 		storage.SetSaveTrialBest(patch.CheckpointStorage.SaveTrialBest)
 		storage.SetSaveTrialLatest(patch.CheckpointStorage.SaveTrialLatest)
-		dbExp.Config.SetCheckpointStorage(storage)
+		activeConfig.SetCheckpointStorage(storage)
 	}
 
-	if err := m.db.SaveExperimentConfig(dbExp); err != nil {
+	// `patch` represents the allowed mutations that can be performed on an experiment, in JSON
+	if err := m.db.SaveExperimentConfig(dbExp.ID, activeConfig); err != nil {
 		return nil, errors.Wrapf(err, "patching experiment %d", dbExp.ID)
 	}
 
@@ -348,9 +346,9 @@ func (m *Master) patchExperiment(c echo.Context) (interface{}, error) {
 	if patch.CheckpointStorage != nil {
 		checkpoints, err := m.db.ExperimentCheckpointsToGCRaw(
 			dbExp.ID,
-			dbExp.Config.CheckpointStorage().SaveExperimentBest(),
-			dbExp.Config.CheckpointStorage().SaveTrialBest(),
-			dbExp.Config.CheckpointStorage().SaveTrialLatest(),
+			dbExp.Config.CheckpointStorage.SaveExperimentBest(),
+			dbExp.Config.CheckpointStorage.SaveTrialBest(),
+			dbExp.Config.CheckpointStorage.SaveTrialLatest(),
 		)
 		if err != nil {
 			return nil, err
@@ -365,7 +363,7 @@ func (m *Master) patchExperiment(c echo.Context) (interface{}, error) {
 		taskID := model.NewTaskID()
 		ckptGCTask := newCheckpointGCTask(
 			m.rm, m.db, m.taskLogger, taskID, dbExp.JobID, dbExp.StartTime, taskSpec, dbExp.ID,
-			dbExp.Config.AsLegacy(), checkpoints, true, agentUserGroup, user, nil,
+			dbExp.Config, checkpoints, true, agentUserGroup, user, nil,
 		)
 		m.system.ActorOf(actor.Addr(fmt.Sprintf("patch-checkpoint-gc-%s", uuid.New().String())),
 			ckptGCTask)
@@ -447,23 +445,25 @@ func getCreateExperimentsProject(
 }
 
 func (m *Master) parseCreateExperiment(params *CreateExperimentParams, user *model.User) (
-	*model.Experiment, *projectv1.Project, bool, *tasks.TaskSpec, error,
+	*model.Experiment, expconf.ExperimentConfig, *projectv1.Project, bool, *tasks.TaskSpec, error,
 ) {
 	// Read the config as the user provided it.
 	config, err := expconf.ParseAnyExperimentConfigYAML([]byte(params.ConfigBytes))
 	if err != nil {
-		return nil, nil, false, nil, errors.Wrap(err, "invalid experiment configuration")
+		return nil, config, nil, false, nil, errors.Wrap(err, "invalid experiment configuration")
 	}
 
 	// Apply the template that the user specified.
 	if params.Template != nil {
 		template, terr := m.db.TemplateByName(*params.Template)
 		if terr != nil {
-			return nil, nil, false, nil, errors.Wrapf(terr, "TemplateByName(%q)", *params.Template)
+			return nil, config, nil, false, nil, errors.Wrapf(
+				terr, "TemplateByName(%q)", *params.Template,
+			)
 		}
 		var tc expconf.ExperimentConfig
 		if yerr := yaml.Unmarshal(template.Config, &tc, yaml.DisallowUnknownFields); yerr != nil {
-			return nil, nil, false, nil, errors.Wrapf(
+			return nil, config, nil, false, nil, errors.Wrapf(
 				terr, "yaml.Unmarshal(template=%q)", *params.Template,
 			)
 		}
@@ -476,10 +476,10 @@ func (m *Master) parseCreateExperiment(params *CreateExperimentParams, user *mod
 	poolName, err := m.rm.ResolveResourcePool(
 		m.system, resources.ResourcePool(), resources.SlotsPerTrial())
 	if err != nil {
-		return nil, nil, false, nil, errors.Wrapf(err, "invalid resource configuration")
+		return nil, config, nil, false, nil, errors.Wrapf(err, "invalid resource configuration")
 	}
 	if err = m.rm.ValidateResources(m.system, poolName, resources.SlotsPerTrial(), false); err != nil {
-		return nil, nil, false, nil, errors.Wrapf(err, "error validating resources")
+		return nil, config, nil, false, nil, errors.Wrapf(err, "error validating resources")
 	}
 	taskContainerDefaults, err := m.rm.TaskContainerDefaults(
 		m.system,
@@ -487,7 +487,7 @@ func (m *Master) parseCreateExperiment(params *CreateExperimentParams, user *mod
 		m.config.TaskContainerDefaults,
 	)
 	if err != nil {
-		return nil, nil, false, nil, errors.Wrapf(err, "error getting TaskContainerDefaults")
+		return nil, config, nil, false, nil, errors.Wrapf(err, "error getting TaskContainerDefaults")
 	}
 	taskSpec := *m.taskSpec
 	taskSpec.TaskContainerDefaults = taskContainerDefaults
@@ -495,7 +495,7 @@ func (m *Master) parseCreateExperiment(params *CreateExperimentParams, user *mod
 
 	project, err := getCreateExperimentsProject(m, params, user, defaulted)
 	if err != nil {
-		return nil, nil, false, nil, err
+		return nil, config, nil, false, nil, err
 	}
 
 	// Merge in workspace's checkpoint storage into the conifg.
@@ -504,7 +504,7 @@ func (m *Master) parseCreateExperiment(params *CreateExperimentParams, user *mod
 		Where("id = ?", project.WorkspaceId).
 		Column("checkpoint_storage_config").
 		Scan(context.TODO()); err != nil {
-		return nil, nil, false, nil, err
+		return nil, config, nil, false, nil, err
 	}
 	config.RawCheckpointStorage = schemas.Merge(
 		config.RawCheckpointStorage, w.CheckpointStorageConfig)
@@ -519,12 +519,12 @@ func (m *Master) parseCreateExperiment(params *CreateExperimentParams, user *mod
 
 	// Make sure the experiment config has all eventuallyRequired fields.
 	if err = schemas.IsComplete(config); err != nil {
-		return nil, nil, false, nil, errors.Wrap(err, "invalid experiment configuration")
+		return nil, config, nil, false, nil, errors.Wrap(err, "invalid experiment configuration")
 	}
 
 	// Disallow EOL searchers.
 	if err = config.Searcher().AssertCurrent(); err != nil {
-		return nil, nil, false, nil, errors.Wrap(err, "invalid experiment configuration")
+		return nil, config, nil, false, nil, errors.Wrap(err, "invalid experiment configuration")
 	}
 
 	var modelBytes []byte
@@ -532,21 +532,21 @@ func (m *Master) parseCreateExperiment(params *CreateExperimentParams, user *mod
 		var dbErr error
 		modelBytes, dbErr = m.db.ExperimentModelDefinitionRaw(*params.ParentID)
 		if dbErr != nil {
-			return nil, nil, false, nil, errors.Wrapf(
+			return nil, config, nil, false, nil, errors.Wrapf(
 				dbErr, "unable to find parent experiment %v", *params.ParentID)
 		}
 	} else {
 		var compressErr error
 		modelBytes, compressErr = archive.ToTarGz(params.ModelDef)
 		if compressErr != nil {
-			return nil, nil, false, nil, errors.Wrapf(
+			return nil, config, nil, false, nil, errors.Wrapf(
 				compressErr, "unable to find compress model definition")
 		}
 	}
 
 	token, createSessionErr := m.db.StartUserSession(user)
 	if createSessionErr != nil {
-		return nil, nil, false, nil, errors.Wrapf(
+		return nil, config, nil, false, nil, errors.Wrapf(
 			createSessionErr, "unable to create user session inside task")
 	}
 	taskSpec.UserSessionToken = token
@@ -562,7 +562,7 @@ func (m *Master) parseCreateExperiment(params *CreateExperimentParams, user *mod
 		dbExp.Username = user.Username
 	}
 
-	return dbExp, project, params.ValidateOnly, &taskSpec, err
+	return dbExp, config, project, params.ValidateOnly, &taskSpec, err
 }
 
 func (m *Master) postExperiment(c echo.Context) (interface{}, error) {
@@ -579,13 +579,13 @@ func (m *Master) postExperiment(c echo.Context) (interface{}, error) {
 	}
 	ctx := c.Request().Context()
 	if params.ParentID != nil {
-		if _, _, err = echoGetExperimentAndCheckCanDoActions(ctx, c, m, *params.ParentID, false,
+		if _, _, err = echoGetExperimentAndCheckCanDoActions(ctx, c, m, *params.ParentID,
 			expauth.AuthZProvider.Get().CanForkFromExperiment); err != nil {
 			return nil, err
 		}
 	}
 
-	dbExp, p, validateOnly, taskSpec, err := m.parseCreateExperiment(&params, &user)
+	dbExp, activeConf, p, validateOnly, taskSpec, err := m.parseCreateExperiment(&params, &user)
 	if err != nil {
 		if _, ok := err.(ErrProjectNotFound); ok {
 			return nil, echo.NewHTTPError(http.StatusNotFound, err.Error())
@@ -608,11 +608,11 @@ func (m *Master) postExperiment(c echo.Context) (interface{}, error) {
 		}
 	}
 
-	e, launchWarnings, err := newExperiment(m, dbExp, taskSpec)
+	e, launchWarnings, err := newExperiment(m, dbExp, activeConf, taskSpec)
 	if err != nil {
 		return nil, errors.Wrap(err, "starting experiment")
 	}
-	config := schemas.Copy(e.Config)
+	config := schemas.Copy(activeConf)
 	m.system.ActorOf(actor.Addr("experiments", e.ID), e)
 
 	if params.Activate {

--- a/master/internal/core_experiment_intg_test.go
+++ b/master/internal/core_experiment_intg_test.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -18,7 +19,10 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/determined-ai/determined/master/internal/context"
+	"github.com/determined-ai/determined/master/internal/db"
+	"github.com/determined-ai/determined/master/pkg/etc"
 	"github.com/determined-ai/determined/master/pkg/model"
+	"github.com/determined-ai/determined/master/test/olddata"
 )
 
 func expNotFoundErrEcho(id int) error {
@@ -43,6 +47,34 @@ func echoPostExperiment(
 	ctx.SetRequest(req)
 	_, err = api.m.postExperiment(ctx)
 	return err
+}
+
+func TestLegacyExperimentsEcho(t *testing.T) {
+	err := etc.SetRootPath("../static/srv")
+	require.NoError(t, err)
+
+	pgDB, cleanup := db.MustResolveNewPostgresDatabase(t)
+	defer cleanup()
+
+	prse := olddata.PreRemoveStepsExperiments()
+	prse.MustMigrate(t, pgDB, "file://../static/migrations")
+
+	api, user, _ := setupAPITest(t, pgDB)
+
+	setExperimentIDParam := func(ctx echo.Context, id int32) {
+		ctx.SetParamNames("experiment_id")
+		ctx.SetParamValues(strconv.FormatInt(int64(id), 10))
+	}
+
+	t.Run("GetExperimentCheckpoints", func(t *testing.T) {
+		ctx := newTestEchoContext(user)
+		path := "/?save_experiment_best=0&save_trial_best=0&save_trial_latest=0"
+		req := httptest.NewRequest(http.MethodGet, path, nil)
+		ctx.SetRequest(req)
+		setExperimentIDParam(ctx, prse.CompletedPBTExpID)
+		_, err = api.m.getExperimentCheckpointsToGC(ctx)
+		require.NoError(t, err)
+	})
 }
 
 func TestAuthZPostExperimentEcho(t *testing.T) {

--- a/master/internal/core_trial.go
+++ b/master/internal/core_trial.go
@@ -20,7 +20,7 @@ func echoCanGetTrial(c echo.Context, m *Master, trialID string) error {
 
 	curUser := c.(*detContext.DetContext).MustGetUser()
 	trialNotFound := echo.NewHTTPError(http.StatusNotFound, "trial not found: %d", id)
-	exp, err := m.db.ExperimentWithoutConfigByTrialID(id)
+	exp, err := m.db.ExperimentByTrialID(id)
 	if errors.Is(err, db.ErrNotFound) {
 		return trialNotFound
 	} else if err != nil {

--- a/master/internal/db/database.go
+++ b/master/internal/db/database.go
@@ -31,23 +31,19 @@ type DB interface {
 	CheckExperimentExists(id int) (bool, error)
 	CheckTrialExists(id int) (bool, error)
 	TrialExperimentAndRequestID(id int) (int, model.RequestID, error)
-	ExperimentConfigRaw(id int) ([]byte, error)
-	AddExperiment(experiment *model.Experiment) error
+	AddExperiment(experiment *model.Experiment, activeConfig expconf.ExperimentConfig) error
 	ExperimentByID(id int) (*model.Experiment, error)
-	LegacyExperimentConfigByID(
-		id int,
-	) (expconf.LegacyConfig, error)
-	ExperimentWithoutConfigByID(id int) (*model.Experiment, error)
+	ExperimentByTrialID(trialID int) (*model.Experiment, error)
 	ExperimentIDByTrialID(trialID int) (int, error)
 	NonTerminalExperiments() ([]*model.Experiment, error)
 	TerminateExperimentInRestart(id int, state model.State) error
-	SaveExperimentConfig(experiment *model.Experiment) error
+	SaveExperimentConfig(id int, config expconf.ExperimentConfig) error
 	SaveExperimentState(experiment *model.Experiment) error
 	SaveExperimentArchiveStatus(experiment *model.Experiment) error
 	DeleteExperiment(id int) error
 	ExperimentHasCheckpointsInRegistry(id int) (bool, error)
 	SaveExperimentProgress(id int, progress *float64) error
-	ExperimentConfig(id int) (expconf.ExperimentConfig, error)
+	ActiveExperimentConfig(id int) (expconf.ExperimentConfig, error)
 	ExperimentTotalStepTime(id int) (float64, error)
 	ExperimentNumTrials(id int) (int64, error)
 	ExperimentTrialIDs(expID int) ([]int, error)

--- a/master/internal/db/postgres_test_utils.go
+++ b/master/internal/db/postgres_test_utils.go
@@ -230,14 +230,14 @@ func RequireMockExperiment(t *testing.T, db *PgDB, user model.User) *model.Exper
 	exp := model.Experiment{
 		JobID:                model.NewJobID(),
 		State:                model.ActiveState,
-		Config:               cfg,
+		Config:               cfg.AsLegacy(),
 		ModelDefinitionBytes: ReadTestModelDefiniton(t, DefaultTestSrcPath),
 		StartTime:            time.Now().Add(-time.Hour),
 		OwnerID:              &user.ID,
 		Username:             user.Username,
 		ProjectID:            1,
 	}
-	err := db.AddExperiment(&exp)
+	err := db.AddExperiment(&exp, cfg)
 	require.NoError(t, err, "failed to add experiment")
 	return &exp
 }

--- a/master/internal/db/postgres_trial_intg_test.go
+++ b/master/internal/db/postgres_trial_intg_test.go
@@ -29,8 +29,8 @@ func TestProtoGetTrial(t *testing.T) {
 	db := MustResolveTestPostgres(t)
 	MustMigrateTestPostgres(t, db, MigrationsFromDB)
 
-	exp := model.ExperimentModel()
-	err := db.AddExperiment(exp)
+	exp, activeConfig := model.ExperimentModel()
+	err := db.AddExperiment(exp, activeConfig)
 	require.NoError(t, err, "failed to add experiment")
 
 	task := RequireMockTask(t, db, exp.OwnerID)
@@ -81,8 +81,8 @@ func TestAddValidationMetricsDupeCheckpoints(t *testing.T) {
 	db := MustResolveTestPostgres(t)
 	MustMigrateTestPostgres(t, db, MigrationsFromDB)
 
-	exp := model.ExperimentModel()
-	require.NoError(t, db.AddExperiment(exp))
+	exp, activeConfig := model.ExperimentModel()
+	require.NoError(t, db.AddExperiment(exp, activeConfig))
 	task := RequireMockTask(t, db, exp.OwnerID)
 	tr := model.Trial{
 		TaskID:       task.TaskID,

--- a/master/internal/experiment.go
+++ b/master/internal/experiment.go
@@ -100,6 +100,7 @@ type (
 		experimentState
 
 		*model.Experiment
+		activeConfig        expconf.ExperimentConfig
 		taskLogger          *task.Logger
 		hpImportance        *actor.Ref
 		db                  *db.PgDB
@@ -120,12 +121,13 @@ type (
 // Create a new experiment object from the given model experiment object, along with its searcher
 // and log. If the input object has no ID set, also create a new experiment in the database and set
 // the returned object's ID appropriately.
-func newExperiment(m *Master, expModel *model.Experiment, taskSpec *tasks.TaskSpec) (
-	*experiment, []command.LaunchWarning, error,
-) {
-	conf := &expModel.Config
-
-	resources := conf.Resources()
+func newExperiment(
+	m *Master,
+	expModel *model.Experiment,
+	activeConfig expconf.ExperimentConfig,
+	taskSpec *tasks.TaskSpec,
+) (*experiment, []command.LaunchWarning, error) {
+	resources := activeConfig.Resources()
 	poolName, err := m.rm.ResolveResourcePool(
 		m.system, resources.ResourcePool(), resources.SlotsPerTrial(),
 	)
@@ -144,25 +146,25 @@ func newExperiment(m *Master, expModel *model.Experiment, taskSpec *tasks.TaskSp
 		return nil, launchWarnings, fmt.Errorf("getting resource availability: %w", err)
 	}
 	resources.SetResourcePool(poolName)
-	conf.SetResources(resources)
+	activeConfig.SetResources(resources)
 
-	method := searcher.NewSearchMethod(conf.Searcher())
+	method := searcher.NewSearchMethod(activeConfig.Searcher())
 	search := searcher.NewSearcher(
-		conf.Reproducibility().ExperimentSeed(), method, conf.Hyperparameters(),
+		activeConfig.Reproducibility().ExperimentSeed(), method, activeConfig.Hyperparameters(),
 	)
 
 	// Retrieve the warm start checkpoint, if provided.
 	checkpoint, err := checkpointFromTrialIDOrUUID(
-		m.db, conf.Searcher().SourceTrialID(), conf.Searcher().SourceCheckpointUUID())
+		m.db, activeConfig.Searcher().SourceTrialID(), activeConfig.Searcher().SourceCheckpointUUID())
 	if err != nil {
 		return nil, launchWarnings, err
 	}
 
 	if expModel.ID == 0 {
-		if err = m.db.AddExperiment(expModel); err != nil {
+		if err = m.db.AddExperiment(expModel, activeConfig); err != nil {
 			return nil, launchWarnings, err
 		}
-		telemetry.ReportExperimentCreated(m.system, expModel)
+		telemetry.ReportExperimentCreated(m.system, expModel.ID, activeConfig)
 	}
 
 	agentUserGroup, err := user.GetAgentUserGroup(*expModel.OwnerID, expModel)
@@ -174,6 +176,7 @@ func newExperiment(m *Master, expModel *model.Experiment, taskSpec *tasks.TaskSp
 
 	return &experiment{
 		Experiment:          expModel,
+		activeConfig:        activeConfig,
 		taskLogger:          m.taskLogger,
 		hpImportance:        m.hpImportance,
 		db:                  m.db,
@@ -202,17 +205,17 @@ func (e *experiment) Receive(ctx *actor.Context) error {
 	case actor.PreStart:
 		ctx.AddLabels(e.logCtx)
 		e.rm.SetGroupMaxSlots(ctx, sproto.SetGroupMaxSlots{
-			MaxSlots: e.Config.Resources().MaxSlots(),
+			MaxSlots: e.activeConfig.Resources().MaxSlots(),
 			Handler:  ctx.Self(),
 		})
-		if err := e.setWeight(ctx, e.Config.Resources().Weight()); err != nil {
+		if err := e.setWeight(ctx, e.activeConfig.Resources().Weight()); err != nil {
 			e.updateState(ctx, model.StateWithReason{
 				State:               model.StoppingErrorState,
 				InformationalReason: err.Error(),
 			})
 			return err
 		}
-		if err := e.setPriority(ctx, e.Config.Resources().Priority(), true); err != nil {
+		if err := e.setPriority(ctx, e.activeConfig.Resources().Priority(), true); err != nil {
 			e.updateState(ctx, model.StateWithReason{
 				State:               model.StoppingErrorState,
 				InformationalReason: err.Error(),
@@ -239,7 +242,7 @@ func (e *experiment) Receive(ctx *actor.Context) error {
 				e.rm.RecoverJobPosition(ctx, sproto.RecoverJobPosition{
 					JobID:        e.JobID,
 					JobPosition:  j.QPos,
-					ResourcePool: e.Config.Resources().ResourcePool(),
+					ResourcePool: e.activeConfig.Resources().ResourcePool(),
 				})
 			}
 
@@ -322,11 +325,11 @@ func (e *experiment) Receive(ctx *actor.Context) error {
 	case model.State:
 		e.updateState(ctx, model.StateWithReason{State: msg})
 	case config.ExperimentConfigPatch:
-		e.Config.SetName(expconf.Name{RawString: msg.Name})
+		e.activeConfig.SetName(expconf.Name{RawString: msg.Name})
 	case sproto.SetGroupMaxSlots:
-		resources := e.Config.Resources()
+		resources := e.activeConfig.Resources()
 		resources.SetMaxSlots(msg.MaxSlots)
-		e.Config.SetResources(resources)
+		e.activeConfig.SetResources(resources)
 		msg.Handler = ctx.Self()
 		e.rm.SetGroupMaxSlots(ctx, msg)
 	case sproto.NotifyRMPriorityChange:
@@ -386,7 +389,9 @@ func (e *experiment) Receive(ctx *actor.Context) error {
 			return errors.New("experiment is already in a terminal state")
 		}
 		telemetry.ReportExperimentStateChanged(ctx.Self().System(), e.db, *e.Experiment)
-		if err := webhooks.ReportExperimentStateChanged(context.TODO(), *e.Experiment); err != nil {
+		if err := webhooks.ReportExperimentStateChanged(
+			context.TODO(), *e.Experiment, e.activeConfig,
+		); err != nil {
 			log.WithError(err).Error("failed to send experiment state change webhook")
 		}
 
@@ -398,9 +403,9 @@ func (e *experiment) Receive(ctx *actor.Context) error {
 
 		checkpoints, err := e.db.ExperimentCheckpointsToGCRaw(
 			e.Experiment.ID,
-			e.Config.CheckpointStorage().SaveExperimentBest(),
-			e.Config.CheckpointStorage().SaveTrialBest(),
-			e.Config.CheckpointStorage().SaveTrialLatest(),
+			e.activeConfig.CheckpointStorage().SaveExperimentBest(),
+			e.activeConfig.CheckpointStorage().SaveTrialBest(),
+			e.activeConfig.CheckpointStorage().SaveTrialLatest(),
 		)
 		if err != nil {
 			ctx.Log().WithError(err).Error("")
@@ -413,7 +418,7 @@ func (e *experiment) Receive(ctx *actor.Context) error {
 			taskID := model.TaskID(fmt.Sprintf("%d.%s", e.ID, uuid.New()))
 			ckptGCTask := newCheckpointGCTask(
 				e.rm, e.db, e.taskLogger, taskID, e.JobID, e.StartTime, taskSpec, e.Experiment.ID,
-				e.Config.AsLegacy(), checkpoints, false, taskSpec.AgentUserGroup, taskSpec.Owner,
+				e.activeConfig.AsLegacy(), checkpoints, false, taskSpec.AgentUserGroup, taskSpec.Owner,
 				e.logCtx,
 			)
 			ctx.Self().System().ActorOf(addr, ckptGCTask)
@@ -629,7 +634,7 @@ func (e *experiment) processOperations(
 				ctx.Log().Error(err)
 				return
 			}
-			config := schemas.Copy(e.Config)
+			config := schemas.Copy(e.activeConfig)
 			state := trialSearcherState{Create: op, Complete: true}
 			e.TrialSearcherState[op.RequestID] = state
 			ctx.ActorOf(op.RequestID, newTrial(
@@ -710,7 +715,9 @@ func (e *experiment) updateState(ctx *actor.Context, state model.StateWithReason
 		return true
 	}
 	telemetry.ReportExperimentStateChanged(ctx.Self().System(), e.db, *e.Experiment)
-	if err := webhooks.ReportExperimentStateChanged(context.TODO(), *e.Experiment); err != nil {
+	if err := webhooks.ReportExperimentStateChanged(
+		context.TODO(), *e.Experiment, e.activeConfig,
+	); err != nil {
 		log.WithError(err).Error("failed to send experiment state change webhook")
 	}
 
@@ -787,26 +794,26 @@ func (e *experiment) setPriority(ctx *actor.Context, priority *int, forward bool
 	}
 	oldPriority := config.DefaultSchedulingPriority
 	var oldPriorityPtr *int
-	resources := e.Config.Resources()
+	resources := e.activeConfig.Resources()
 	if resources.Priority() != nil {
 		oldPriority = *resources.Priority()
 		oldPriorityPtr = &oldPriority
 	}
 	resources.SetPriority(priority)
-	e.Config.SetResources(resources)
+	e.activeConfig.SetResources(resources)
 
 	defer func() {
 		if err != nil {
 			resources.SetPriority(oldPriorityPtr)
-			e.Config.SetResources(resources)
-			err = e.db.SaveExperimentConfig(e.Experiment)
+			e.activeConfig.SetResources(resources)
+			err = e.db.SaveExperimentConfig(e.ID, e.activeConfig)
 			if err != nil {
 				return
 			}
 		}
 	}()
 
-	if err := e.db.SaveExperimentConfig(e.Experiment); err != nil {
+	if err := e.db.SaveExperimentConfig(e.ID, e.activeConfig); err != nil {
 		return errors.Wrapf(err, "setting experiment %d priority", e.ID)
 	}
 
@@ -827,13 +834,13 @@ func (e *experiment) setPriority(ctx *actor.Context, priority *int, forward bool
 }
 
 func (e *experiment) setWeight(ctx *actor.Context, weight float64) error {
-	resources := e.Config.Resources()
+	resources := e.activeConfig.Resources()
 	oldWeight := resources.Weight()
 	resources.SetWeight(weight)
-	e.Config.SetResources(resources)
-	if err := e.db.SaveExperimentConfig(e.Experiment); err != nil {
+	e.activeConfig.SetResources(resources)
+	if err := e.db.SaveExperimentConfig(e.ID, e.activeConfig); err != nil {
 		resources.SetWeight(oldWeight)
-		e.Config.SetResources(resources)
+		e.activeConfig.SetResources(resources)
 		return fmt.Errorf("setting experiment %d weight: %w", e.ID, err)
 	}
 
@@ -846,17 +853,17 @@ func (e *experiment) setWeight(ctx *actor.Context, weight float64) error {
 		ctx.Log().WithError(err).Debug("ignoring unsupported call to set group weight")
 	default:
 		resources.SetWeight(oldWeight)
-		e.Config.SetResources(resources)
+		e.activeConfig.SetResources(resources)
 		return fmt.Errorf("setting experiment %d weight: %w", e.ID, err)
 	}
 	return nil
 }
 
 func (e *experiment) setRP(ctx *actor.Context, msg sproto.SetResourcePool) error {
-	resources := e.Config.Resources()
+	resources := e.activeConfig.Resources()
 	oldRP := resources.ResourcePool()
 	rp, err := e.rm.ResolveResourcePool(
-		ctx, msg.ResourcePool, e.Config.Resources().SlotsPerTrial(),
+		ctx, msg.ResourcePool, e.activeConfig.Resources().SlotsPerTrial(),
 	)
 	switch {
 	case err != nil:
@@ -866,11 +873,11 @@ func (e *experiment) setRP(ctx *actor.Context, msg sproto.SetResourcePool) error
 	}
 
 	resources.SetResourcePool(rp)
-	e.Config.SetResources(resources)
+	e.activeConfig.SetResources(resources)
 
-	if err := e.db.SaveExperimentConfig(e.Experiment); err != nil {
+	if err := e.db.SaveExperimentConfig(e.ID, e.activeConfig); err != nil {
 		resources.SetResourcePool(oldRP)
-		e.Config.SetResources(resources)
+		e.activeConfig.SetResources(resources)
 		return errors.Wrapf(err, "setting experiment %d RP to %s", e.ID, rp)
 	}
 
@@ -890,14 +897,14 @@ func (e *experiment) toV1Job() *jobv1.Job {
 		Username:       e.Username,
 		UserId:         int32(*e.OwnerID),
 		Progress:       float32(e.searcher.Progress()),
-		Name:           e.Config.Name().String(),
+		Name:           e.activeConfig.Name().String(),
 	}
 
 	j.IsPreemptible = config.ReadRMPreemptionStatus(j.ResourcePool)
-	j.Priority = int32(config.ReadPriority(j.ResourcePool, &e.Config))
-	j.Weight = config.ReadWeight(j.ResourcePool, &e.Config)
+	j.Priority = int32(config.ReadPriority(j.ResourcePool, &e.activeConfig))
+	j.Weight = config.ReadWeight(j.ResourcePool, &e.activeConfig)
 
-	j.ResourcePool = e.Config.Resources().ResourcePool()
+	j.ResourcePool = e.activeConfig.Resources().ResourcePool()
 
 	return &j
 }

--- a/master/internal/hpimportance/hpimportance.go
+++ b/master/internal/hpimportance/hpimportance.go
@@ -44,7 +44,7 @@ const (
 // where order does matter. We need to keep define the Hps and
 // keep track of the order so the data columns will match.
 func createDataFile(data map[int][]model.HPImportanceTrialData,
-	experimentConfig expconf.ExperimentConfig, dataFile string,
+	hyperparameters expconf.Hyperparameters, dataFile string,
 ) (int, error) {
 	//nolint:gosec // Ignore security warning because none of this is user-provided input
 	f, err := os.Create(dataFile)
@@ -66,8 +66,7 @@ func createDataFile(data map[int][]model.HPImportanceTrialData,
 		return 0, err
 	}
 	var hpsOrder []string // HPs must be in the same order for the arff file
-	hps := experimentConfig.Hyperparameters()
-	hps = expconf.FlattenHPs(hps)
+	hps := expconf.FlattenHPs(hyperparameters)
 
 	for key, element := range hps {
 		var st string
@@ -195,7 +194,7 @@ func parseImportanceOutput(filename string) (map[string]float64, error) {
 // 2. The difference between the most(aka max) trained trial and the lowest batch are within a
 // defined range (maxDiffCompBatches).
 func computeHPImportance(data map[int][]model.HPImportanceTrialData,
-	experimentConfig expconf.ExperimentConfig, masterConfig config.HPImportanceConfig,
+	hyperparameters expconf.Hyperparameters, masterConfig config.HPImportanceConfig,
 	growforest string, workingDir string,
 ) (map[string]float64, error) {
 	if len(data) == 0 {
@@ -205,7 +204,7 @@ func computeHPImportance(data map[int][]model.HPImportanceTrialData,
 	growforestInput := path.Join(workingDir, arffFile)
 	growforestOutput := path.Join(workingDir, importanceFile)
 
-	totalNumTrials, err := createDataFile(data, experimentConfig, growforestInput)
+	totalNumTrials, err := createDataFile(data, hyperparameters, growforestInput)
 	if err != nil {
 		return nil, fmt.Errorf("error writing ARFF file: %w", err)
 	}

--- a/master/internal/hpimportance/hpimportance_test.go
+++ b/master/internal/hpimportance/hpimportance_test.go
@@ -1,4 +1,3 @@
-//nolint:exhaustivestruct
 package hpimportance
 
 import (
@@ -20,51 +19,49 @@ func TestComputeHPImportance(t *testing.T) {
 		CoresPerWorker: 1,
 		MaxTrees:       100,
 	}
-	expConfig := expconf.ExperimentConfig{
-		RawHyperparameters: expconf.Hyperparameters{
-			"dropout1": expconf.Hyperparameter{
-				RawDoubleHyperparameter: &expconf.DoubleHyperparameter{
-					RawMinval: 0.2,
-					RawMaxval: 0.8,
-				},
+	hps := expconf.Hyperparameters{
+		"dropout1": expconf.Hyperparameter{
+			RawDoubleHyperparameter: &expconf.DoubleHyperparameter{
+				RawMinval: 0.2,
+				RawMaxval: 0.8,
 			},
-			"dropout2": {
-				RawDoubleHyperparameter: &expconf.DoubleHyperparameter{
-					RawMinval: 0.2,
-					RawMaxval: 0.8,
-				},
+		},
+		"dropout2": {
+			RawDoubleHyperparameter: &expconf.DoubleHyperparameter{
+				RawMinval: 0.2,
+				RawMaxval: 0.8,
 			},
-			"global_batch_size": {
-				RawConstHyperparameter: &expconf.ConstHyperparameter{
-					RawVal: 64,
-				},
+		},
+		"global_batch_size": {
+			RawConstHyperparameter: &expconf.ConstHyperparameter{
+				RawVal: 64,
 			},
-			"learning_rate": {
-				RawDoubleHyperparameter: &expconf.DoubleHyperparameter{
-					RawMinval: .0001,
-					RawMaxval: 1.0,
-				},
+		},
+		"learning_rate": {
+			RawDoubleHyperparameter: &expconf.DoubleHyperparameter{
+				RawMinval: .0001,
+				RawMaxval: 1.0,
 			},
-			"n_filters1": {
-				RawIntHyperparameter: &expconf.IntHyperparameter{
-					RawMinval: 8,
-					RawMaxval: 64,
-				},
+		},
+		"n_filters1": {
+			RawIntHyperparameter: &expconf.IntHyperparameter{
+				RawMinval: 8,
+				RawMaxval: 64,
 			},
-			"n_filters2": {
-				RawIntHyperparameter: &expconf.IntHyperparameter{
-					RawMinval: 8,
-					RawMaxval: 72,
-				},
+		},
+		"n_filters2": {
+			RawIntHyperparameter: &expconf.IntHyperparameter{
+				RawMinval: 8,
+				RawMaxval: 72,
 			},
-			"n_filters3": {
-				RawCategoricalHyperparameter: &expconf.CategoricalHyperparameter{
-					RawVals: []interface{}{"val1", "val2"},
-				},
+		},
+		"n_filters3": {
+			RawCategoricalHyperparameter: &expconf.CategoricalHyperparameter{
+				RawVals: []interface{}{"val1", "val2"},
 			},
 		},
 	}
-	expConfig = schemas.WithDefaults(expConfig)
+	hps = schemas.WithDefaults(hps)
 
 	data := map[int][]model.HPImportanceTrialData{
 		10: {
@@ -176,7 +173,7 @@ func TestComputeHPImportance(t *testing.T) {
 			},
 		},
 	}
-	nTreesResults, err := createDataFile(data, expConfig, "data.arff")
+	nTreesResults, err := createDataFile(data, hps, "data.arff")
 	assert.NilError(t, err)
 	assert.Equal(t, nTreesResults, 8)
 
@@ -250,11 +247,11 @@ func TestComputeHPImportance(t *testing.T) {
 			Metric: 2.2999706268310547,
 		},
 	}
-	nTreesResults, err = createDataFile(data, expConfig, "data.arff")
+	nTreesResults, err = createDataFile(data, hps, "data.arff")
 	assert.NilError(t, err)
 	assert.Equal(t, nTreesResults, 10)
 
-	_, err = computeHPImportance(data, expConfig, masterConfig, "growforest", ".")
+	_, err = computeHPImportance(data, hps, masterConfig, "growforest", ".")
 	assert.Assert(t, err != nil)
 
 	err = os.Remove("data.arff")

--- a/master/internal/hpimportance/manager.go
+++ b/master/internal/hpimportance/manager.go
@@ -310,10 +310,9 @@ func (m *manager) triggerDefaultWork(ctx *actor.Context, experimentID int) {
 		return
 	}
 
-	config, err := m.db.ExperimentConfig(experimentID)
+	exp, err := m.db.ExperimentByID(experimentID)
 	if err != nil {
-		ctx.Log().Errorf("error reading config for experiment %d: %s", experimentID, err.Error())
-		return
+		ctx.Log().Errorf("error loading experiment %d: %s", experimentID, err.Error())
 	}
 
 	loss := "loss"
@@ -325,7 +324,7 @@ func (m *manager) triggerDefaultWork(ctx *actor.Context, experimentID int) {
 		hpi.SetMetricHPImportance(lossHpi, loss, model.TrainingMetric)
 	}
 
-	searcherMetric := config.Searcher().Metric()
+	searcherMetric := exp.Config.Searcher.Metric
 	triggerForSearcherMetric := false
 	searcherMetricHpi := hpi.GetMetricHPImportance(searcherMetric, model.ValidationMetric)
 	if !searcherMetricHpi.Pending {

--- a/master/internal/hpimportance/worker.go
+++ b/master/internal/hpimportance/worker.go
@@ -95,7 +95,7 @@ func taskHandlerFactory(db *db.PgDB, system *actor.System, growforest string, wo
 
 		masterConfig := work.config
 
-		experimentConfig, err := db.ExperimentConfig(work.experimentID)
+		exp, err := db.ExperimentByID(work.experimentID)
 		if err != nil {
 			sendWorkFailed(system, work, err.Error())
 			return nil
@@ -124,7 +124,9 @@ func taskHandlerFactory(db *db.PgDB, system *actor.System, growforest string, wo
 		if err != nil {
 			sendWorkFailed(system, work, err.Error())
 		}
-		results, err := computeHPImportance(trials, experimentConfig, masterConfig, growforest, taskDir)
+		results, err := computeHPImportance(
+			trials, exp.Config.Hyperparameters, masterConfig, growforest, taskDir,
+		)
 		if err != nil {
 			sendWorkFailed(system, work, err.Error())
 		}

--- a/master/internal/mocks/db.go
+++ b/master/internal/mocks/db.go
@@ -28,6 +28,27 @@ type DB struct {
 	mock.Mock
 }
 
+// ActiveExperimentConfig provides a mock function with given fields: id
+func (_m *DB) ActiveExperimentConfig(id int) (expconf.ExperimentConfigV0, error) {
+	ret := _m.Called(id)
+
+	var r0 expconf.ExperimentConfigV0
+	if rf, ok := ret.Get(0).(func(int) expconf.ExperimentConfigV0); ok {
+		r0 = rf(id)
+	} else {
+		r0 = ret.Get(0).(expconf.ExperimentConfigV0)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(int) error); ok {
+		r1 = rf(id)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // AddAllocation provides a mock function with given fields: a
 func (_m *DB) AddAllocation(a *model.Allocation) error {
 	ret := _m.Called(a)
@@ -70,13 +91,13 @@ func (_m *DB) AddCheckpointMetadata(ctx context.Context, m *model.CheckpointV2) 
 	return r0
 }
 
-// AddExperiment provides a mock function with given fields: experiment
-func (_m *DB) AddExperiment(experiment *model.Experiment) error {
-	ret := _m.Called(experiment)
+// AddExperiment provides a mock function with given fields: experiment, activeConfig
+func (_m *DB) AddExperiment(experiment *model.Experiment, activeConfig expconf.ExperimentConfigV0) error {
+	ret := _m.Called(experiment, activeConfig)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(*model.Experiment) error); ok {
-		r0 = rf(experiment)
+	if rf, ok := ret.Get(0).(func(*model.Experiment, expconf.ExperimentConfigV0) error); ok {
+		r0 = rf(experiment, activeConfig)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -627,6 +648,29 @@ func (_m *DB) ExperimentByID(id int) (*model.Experiment, error) {
 	return r0, r1
 }
 
+// ExperimentByTrialID provides a mock function with given fields: trialID
+func (_m *DB) ExperimentByTrialID(trialID int) (*model.Experiment, error) {
+	ret := _m.Called(trialID)
+
+	var r0 *model.Experiment
+	if rf, ok := ret.Get(0).(func(int) *model.Experiment); ok {
+		r0 = rf(trialID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*model.Experiment)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(int) error); ok {
+		r1 = rf(trialID)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // ExperimentCheckpointsToGCRaw provides a mock function with given fields: id, experimentBest, trialBest, trialLatest
 func (_m *DB) ExperimentCheckpointsToGCRaw(id int, experimentBest int, trialBest int, trialLatest int) ([]uuid.UUID, error) {
 	ret := _m.Called(id, experimentBest, trialBest, trialLatest)
@@ -643,50 +687,6 @@ func (_m *DB) ExperimentCheckpointsToGCRaw(id int, experimentBest int, trialBest
 	var r1 error
 	if rf, ok := ret.Get(1).(func(int, int, int, int) error); ok {
 		r1 = rf(id, experimentBest, trialBest, trialLatest)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
-// ExperimentConfig provides a mock function with given fields: id
-func (_m *DB) ExperimentConfig(id int) (expconf.ExperimentConfigV0, error) {
-	ret := _m.Called(id)
-
-	var r0 expconf.ExperimentConfigV0
-	if rf, ok := ret.Get(0).(func(int) expconf.ExperimentConfigV0); ok {
-		r0 = rf(id)
-	} else {
-		r0 = ret.Get(0).(expconf.ExperimentConfigV0)
-	}
-
-	var r1 error
-	if rf, ok := ret.Get(1).(func(int) error); ok {
-		r1 = rf(id)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
-// ExperimentConfigRaw provides a mock function with given fields: id
-func (_m *DB) ExperimentConfigRaw(id int) ([]byte, error) {
-	ret := _m.Called(id)
-
-	var r0 []byte
-	if rf, ok := ret.Get(0).(func(int) []byte); ok {
-		r0 = rf(id)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]byte)
-		}
-	}
-
-	var r1 error
-	if rf, ok := ret.Get(1).(func(int) error); ok {
-		r1 = rf(id)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -930,29 +930,6 @@ func (_m *DB) ExperimentTrialIDs(expID int) ([]int, error) {
 	return r0, r1
 }
 
-// ExperimentWithoutConfigByID provides a mock function with given fields: id
-func (_m *DB) ExperimentWithoutConfigByID(id int) (*model.Experiment, error) {
-	ret := _m.Called(id)
-
-	var r0 *model.Experiment
-	if rf, ok := ret.Get(0).(func(int) *model.Experiment); ok {
-		r0 = rf(id)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*model.Experiment)
-		}
-	}
-
-	var r1 error
-	if rf, ok := ret.Get(1).(func(int) error); ok {
-		r1 = rf(id)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
 // FetchHPImportanceTrainingData provides a mock function with given fields: experimentID, metric
 func (_m *DB) FetchHPImportanceTrainingData(experimentID int, metric string) (map[int][]model.HPImportanceTrialData, error) {
 	ret := _m.Called(experimentID, metric)
@@ -1154,27 +1131,6 @@ func (_m *DB) LatestCheckpointForTrial(trialID int) (*model.Checkpoint, error) {
 	var r1 error
 	if rf, ok := ret.Get(1).(func(int) error); ok {
 		r1 = rf(trialID)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
-// LegacyExperimentConfigByID provides a mock function with given fields: id
-func (_m *DB) LegacyExperimentConfigByID(id int) (expconf.LegacyConfig, error) {
-	ret := _m.Called(id)
-
-	var r0 expconf.LegacyConfig
-	if rf, ok := ret.Get(0).(func(int) expconf.LegacyConfig); ok {
-		r0 = rf(id)
-	} else {
-		r0 = ret.Get(0).(expconf.LegacyConfig)
-	}
-
-	var r1 error
-	if rf, ok := ret.Get(1).(func(int) error); ok {
-		r1 = rf(id)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -1496,13 +1452,13 @@ func (_m *DB) SaveExperimentArchiveStatus(experiment *model.Experiment) error {
 	return r0
 }
 
-// SaveExperimentConfig provides a mock function with given fields: experiment
-func (_m *DB) SaveExperimentConfig(experiment *model.Experiment) error {
-	ret := _m.Called(experiment)
+// SaveExperimentConfig provides a mock function with given fields: id, config
+func (_m *DB) SaveExperimentConfig(id int, config expconf.ExperimentConfigV0) error {
+	ret := _m.Called(id, config)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(*model.Experiment) error); ok {
-		r0 = rf(experiment)
+	if rf, ok := ret.Get(0).(func(int, expconf.ExperimentConfigV0) error); ok {
+		r0 = rf(id, config)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/master/internal/telemetry/reports.go
+++ b/master/internal/telemetry/reports.go
@@ -12,6 +12,7 @@ import (
 	"github.com/determined-ai/determined/master/pkg/actor"
 	"github.com/determined-ai/determined/master/pkg/device"
 	"github.com/determined-ai/determined/master/pkg/model"
+	"github.com/determined-ai/determined/master/pkg/schemas/expconf"
 	"github.com/determined-ai/determined/master/version"
 	"github.com/determined-ai/determined/proto/pkg/apiv1"
 	"github.com/determined-ai/determined/proto/pkg/devicev1"
@@ -82,17 +83,18 @@ func ReportProvisionerTick(
 }
 
 // ReportExperimentCreated reports that an experiment has been created.
-func ReportExperimentCreated(system *actor.System, e *model.Experiment) {
+func ReportExperimentCreated(system *actor.System, id int, config expconf.ExperimentConfig) {
 	system.TellAt(
 		actor.Addr("telemetry"),
 		analytics.Track{
 			Event: "experiment_created",
 			Properties: map[string]interface{}{
-				"id":                        e.ID,
-				"searcher_name":             reflect.TypeOf(e.Config.Searcher().GetUnionMember()),
-				"num_hparams":               len(e.Config.Hyperparameters()),
-				"resources_slots_per_trial": e.Config.Resources().SlotsPerTrial(),
-				"image":                     e.Config.Environment().Image(),
+				"id":                        id,
+				"num_hparams":               len(config.Hyperparameters()),
+				"resources_slots_per_trial": config.Resources().SlotsPerTrial(),
+				"image":                     config.Environment().Image(),
+
+				"searcher_name": reflect.TypeOf(config.Searcher().GetUnionMember()),
 			},
 		},
 	)

--- a/master/internal/webhooks/shipper_test.go
+++ b/master/internal/webhooks/shipper_test.go
@@ -133,15 +133,15 @@ func TestShipper(t *testing.T) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
+		var config expconf.ExperimentConfig
+		config = schemas.WithDefaults(config)
 		for id, delay := range schedule {
 			time.Sleep(scheduledWaitToDuration(delay))
 			expected[id] = 3 // 3 sends, one for each trigger.
-			var conf expconf.ExperimentConfig
 			require.NoError(t, ReportExperimentStateChanged(ctx, model.Experiment{
-				ID:     id,
-				State:  model.CompletedState,
-				Config: schemas.WithDefaults(conf),
-			}))
+				ID:    id,
+				State: model.CompletedState,
+			}, config))
 			progress.Store(int64(id))
 		}
 	}()

--- a/master/internal/webhooks/webhook.go
+++ b/master/internal/webhooks/webhook.go
@@ -185,7 +185,9 @@ func (t TriggerType) Proto() webhookv1.TriggerType {
 }
 
 // Proto returns a proto from a TriggerType.
-func experimentToWebhookPayload(e model.Experiment) *ExperimentPayload {
+func experimentToWebhookPayload(
+	e model.Experiment, activeConfig expconf.ExperimentConfig,
+) *ExperimentPayload {
 	var duration int
 	if e.EndTime != nil {
 		duration = int(e.EndTime.Sub(e.StartTime).Seconds())
@@ -194,12 +196,12 @@ func experimentToWebhookPayload(e model.Experiment) *ExperimentPayload {
 	return &ExperimentPayload{
 		ID:            e.ID,
 		State:         e.State,
-		Name:          e.Config.Name(),
+		Name:          activeConfig.Name(),
 		Duration:      duration,
-		ResourcePool:  e.Config.Resources().ResourcePool(),
-		SlotsPerTrial: e.Config.Resources().SlotsPerTrial(),
-		WorkspaceName: e.Config.Workspace(),
-		ProjectName:   e.Config.Project(),
+		ResourcePool:  activeConfig.Resources().ResourcePool(),
+		SlotsPerTrial: activeConfig.Resources().SlotsPerTrial(),
+		WorkspaceName: activeConfig.Workspace(),
+		ProjectName:   activeConfig.Project(),
 	}
 }
 

--- a/master/pkg/model/experiment.go
+++ b/master/pkg/model/experiment.go
@@ -279,12 +279,16 @@ var CheckpointReverseTransitions = reverseTransitions(CheckpointTransitions)
 
 // Experiment represents a row from the `experiments` table.
 type Experiment struct {
-	ID             int                      `db:"id"`
-	JobID          JobID                    `db:"job_id"`
-	State          State                    `db:"state"`
-	Notes          string                   `db:"notes"`
-	Config         expconf.ExperimentConfig `db:"config"`
-	OriginalConfig string                   `db:"original_config"`
+	ID    int    `db:"id"`
+	JobID JobID  `db:"job_id"`
+	State State  `db:"state"`
+	Notes string `db:"notes"`
+
+	// Offer a LegacyConfig rather than ExperimentConfig since most of the system is about querying
+	// experiments which ran some time in the past, which is exactly what LegacyConfig is for.
+	Config         expconf.LegacyConfig `db:"config"`
+	OriginalConfig string               `db:"original_config"`
+
 	// The model definition is stored as a .tar.gz file (raw bytes).
 	ModelDefinitionBytes []byte     `db:"model_definition"`
 	StartTime            time.Time  `db:"start_time"`
@@ -315,12 +319,13 @@ func ExperimentFromProto(e *experimentv1.Experiment) (*Experiment, error) {
 		parentID = ptrs.Ptr(int(e.ForkedFrom.Value))
 	}
 
-	bytes, err := json.Marshal(e.Config)
+	byts, err := json.Marshal(e.Config)
 	if err != nil {
 		return nil, err
 	}
-	var config expconf.ExperimentConfig
-	if err = json.Unmarshal(bytes, &config); err != nil {
+
+	config, err := expconf.ParseLegacyConfigJSON(byts)
+	if err != nil {
 		return nil, err
 	}
 
@@ -376,7 +381,7 @@ func NewExperiment(
 	return &Experiment{
 		State:                PausedState,
 		JobID:                NewJobID(),
-		Config:               config,
+		Config:               config.AsLegacy(),
 		OriginalConfig:       originalConfig,
 		ModelDefinitionBytes: modelDefinitionBytes,
 		StartTime:            time.Now().UTC(),

--- a/master/pkg/model/test_utils.go
+++ b/master/pkg/model/test_utils.go
@@ -27,9 +27,9 @@ func (f ExperimentModelOptionFunc) apply(experiment *Experiment) {
 
 // ExperimentModel returns a new experiment with the specified options.
 //nolint: exhaustivestruct
-func ExperimentModel(opts ...ExperimentModelOption) *Experiment {
+func ExperimentModel(opts ...ExperimentModelOption) (*Experiment, expconf.ExperimentConfig) {
 	maxLength := expconf.NewLengthInBatches(100)
-	eConf := expconf.ExperimentConfig{
+	activeConfig := expconf.ExperimentConfig{
 		RawSearcher: &expconf.SearcherConfig{
 			RawMetric: ptrs.Ptr("loss"),
 			RawSingleConfig: &expconf.SingleConfig{
@@ -44,13 +44,13 @@ func ExperimentModel(opts ...ExperimentModelOption) *Experiment {
 			},
 		},
 	}
-	eConf = schemas.WithDefaults(eConf)
-	DefaultTaskContainerDefaults().MergeIntoExpConfig(&eConf)
+	activeConfig = schemas.WithDefaults(activeConfig)
+	DefaultTaskContainerDefaults().MergeIntoExpConfig(&activeConfig)
 
 	e := &Experiment{
 		JobID:                NewJobID(),
 		State:                ActiveState,
-		Config:               eConf,
+		Config:               activeConfig.AsLegacy(),
 		StartTime:            time.Now(),
 		OwnerID:              &defaultDeterminedUID,
 		ModelDefinitionBytes: []byte{},
@@ -60,5 +60,5 @@ func ExperimentModel(opts ...ExperimentModelOption) *Experiment {
 	for _, o := range opts {
 		o.apply(e)
 	}
-	return e
+	return e, activeConfig
 }

--- a/master/pkg/schemas/expconf/experiment_config.go
+++ b/master/pkg/schemas/expconf/experiment_config.go
@@ -88,10 +88,11 @@ func (e *ExperimentConfigV0) Scan(src interface{}) error {
 // AsLegacy converts a current ExperimentConfig to a (limited capacity) LegacyConfig.
 func (e ExperimentConfig) AsLegacy() LegacyConfig {
 	return LegacyConfig{
-		checkpointStorage: schemas.Copy(e.CheckpointStorage()),
-		bindMounts:        schemas.Copy(e.BindMounts()),
-		envvars:           schemas.Copy(e.Environment().EnvironmentVariables()),
-		podSpec:           schemas.Copy(e.Environment().PodSpec()),
+		CheckpointStorage: schemas.Copy(e.CheckpointStorage()),
+		BindMounts:        schemas.Copy(e.BindMounts()),
+		Environment:       schemas.Copy(e.Environment()),
+		Hyperparameters:   schemas.Copy(e.Hyperparameters()),
+		Searcher:          e.Searcher().AsLegacy(),
 	}
 }
 

--- a/master/pkg/schemas/expconf/legacy.go
+++ b/master/pkg/schemas/expconf/legacy.go
@@ -1,7 +1,6 @@
 package expconf
 
 import (
-	"bytes"
 	"encoding/json"
 
 	"github.com/pkg/errors"
@@ -18,30 +17,20 @@ import (
 // LegacyConfig can be used to deal with configs that contain some EOL components, like searchers
 // that have been removed.
 type LegacyConfig struct {
-	checkpointStorage CheckpointStorageConfig
-	bindMounts        BindMountsConfig
-	envvars           EnvironmentVariablesMap
-	podSpec           *PodSpec
+	CheckpointStorage CheckpointStorageConfig
+	BindMounts        BindMountsConfig
+	Environment       EnvironmentConfig
+	Hyperparameters   Hyperparameters
+	Searcher          LegacySearcher
 }
 
-// CheckpointStorage returns a current CheckpointStorage from a LegacyConfig.
-func (h LegacyConfig) CheckpointStorage() CheckpointStorageConfig {
-	return h.checkpointStorage
-}
-
-// BindMounts returns a current BindMountsConfig from a LegacyConfig.
-func (h LegacyConfig) BindMounts() BindMountsConfig {
-	return h.bindMounts
-}
-
-// EnvironmentVariables returns a current EnvironmentVariables from a LegacyConfig.
-func (h LegacyConfig) EnvironmentVariables() EnvironmentVariablesMap {
-	return h.envvars
-}
-
-// PodSpec returns a current k8s PodSpec from a LegacyConfig.
-func (h LegacyConfig) PodSpec() *PodSpec {
-	return h.podSpec
+// LegacySearcher represents a subset of the SearcherConfig which can be expected to be available
+// for all experiments, new and old.
+type LegacySearcher struct {
+	// Name might contain an EOL searcher name.
+	Name            string
+	Metric          string
+	SmallerIsBetter bool
 }
 
 func getCheckpointStorage(raw map[string]interface{}) (CheckpointStorageConfig, error) {
@@ -99,72 +88,103 @@ func getBindMounts(raw map[string]interface{}) (BindMountsConfig, error) {
 	return bm, nil
 }
 
-func getEnvironmentVariables(raw map[string]interface{}) (EnvironmentVariablesMap, error) {
-	ev := EnvironmentVariablesMap{}
+func getEnvironment(raw map[string]interface{}) (EnvironmentConfig, error) {
+	var env EnvironmentConfig
 
 	envOnly := raw["environment"]
-	if envOnly == nil {
-		// Empty environment.
-		return ev, nil
+	if envOnly != nil {
+		envByts, err := json.Marshal(envOnly)
+		if err != nil {
+			return env, errors.Wrap(err, "unable to remarshal environment as json")
+		}
+		if err = schemas.SaneBytes(&env, envByts); err != nil {
+			return env, errors.Wrap(err, "legacy environment does not pass sanity checks")
+		}
+		if err = json.Unmarshal(envByts, &env); err != nil {
+			return env, errors.Wrap(err, "unable to unmarshal environment bytes")
+		}
 	}
 
-	evOnly := envOnly.(map[string]interface{})["environment_variables"]
-	if evOnly == nil {
-		// Empty environment.environment_variables.
-		return ev, nil
+	env = schemas.WithDefaults(env)
+
+	if err := schemas.IsComplete(env); err != nil {
+		return env, errors.Wrap(err, "legacy environment is incomplete")
 	}
 
-	evByts, err := json.Marshal(evOnly)
-	if err != nil {
-		return ev, errors.Wrap(err, "unable to remarshal environment variables as json")
-	}
-
-	// The EnvironemntVariablesMap object doesn't point to quite the right schema to validate
-	// against (it can't handle plain lists), so we manually specify the more general schema.
-	validator := schemas.GetSanityValidator(
-		"http://determined.ai/schemas/expconf/v0/environment-variables.json",
-	)
-	if err = validator.Validate(bytes.NewReader(evByts)); err != nil {
-		err = errors.New(schemas.JoinErrors(schemas.GetRenderedErrors(err, evByts), "\n"))
-		return ev, errors.Wrap(err, "legacy environment variables does not pass sanity checks")
-	}
-
-	if err = json.Unmarshal(evByts, &ev); err != nil {
-		return ev, errors.Wrap(err, "unable to unmarshal environment variables bytes")
-	}
-	ev = schemas.WithDefaults(ev)
-
-	// The unmarshaling will convert plain lists into a map of lists, so the normal json-schema
-	// API patterns (schemas.IsComplete) will now work.
-	if err = schemas.IsComplete(ev); err != nil {
-		return ev, errors.Wrap(err, "legacy environment variables is incomplete")
-	}
-	return ev, nil
+	return env, nil
 }
 
-func getPodSpec(raw map[string]interface{}) (*PodSpec, error) {
-	ps := &PodSpec{}
+func getHyperparameters(raw map[string]interface{}) (Hyperparameters, error) {
+	h := Hyperparameters{}
 
-	envOnly := raw["environment"]
-	if envOnly == nil {
-		return nil, nil
+	hpOnly := raw["hyperparameters"]
+	if hpOnly == nil {
+		// Empty hyperparameters.
+		return h, nil
 	}
 
-	psOnly := envOnly.(map[string]interface{})["pod_spec"]
-	if psOnly == nil {
-		return nil, nil
-	}
-
-	rawBytes, err := json.Marshal(psOnly)
+	hpBytes, err := json.Marshal(hpOnly)
 	if err != nil {
-		return nil, errors.Wrap(err, "unable to remarshal pod spec as json")
+		return h, errors.Wrap(err, "unable to remarshal hyperparameters as json")
+	}
+	if err = schemas.SaneBytes(&h, hpBytes); err != nil {
+		return h, errors.Wrap(err, "legacy hyperparameters do not pass sanity checks")
+	}
+	if err = json.Unmarshal(hpBytes, &h); err != nil {
+		return h, errors.Wrap(err, "unable to unmarshal hyperparameter bytes")
+	}
+	h = schemas.WithDefaults(h)
+	if err = schemas.IsComplete(h); err != nil {
+		return h, errors.Wrap(err, "legacy hyperparameters are incomplete")
+	}
+	return h, nil
+}
+
+func getLegacySearcher(raw map[string]interface{}) (LegacySearcher, error) {
+	searcher := raw["searcher"]
+	if searcher == nil {
+		return LegacySearcher{}, errors.New("searcher field missing")
 	}
 
-	if err = json.Unmarshal(rawBytes, ps); err != nil {
-		return nil, errors.Wrap(err, "unable to unmarshal pod spec bytes")
+	tsearcher, ok := searcher.(map[string]interface{})
+	if !ok {
+		return LegacySearcher{}, errors.New("searcher field is not a map")
 	}
 
-	return ps, nil
+	name, ok := tsearcher["name"]
+	if !ok {
+		return LegacySearcher{}, errors.New("searcher.name missing")
+	}
+
+	tname, ok := name.(string)
+	if !ok {
+		return LegacySearcher{}, errors.New("searcher.name is not a string")
+	}
+
+	metric, ok := tsearcher["metric"]
+	if !ok {
+		return LegacySearcher{}, errors.New("searcher.metric missing")
+	}
+
+	tmetric, ok := metric.(string)
+	if !ok {
+		return LegacySearcher{}, errors.New("searcher.metric is not a string")
+	}
+
+	// smallerIsBetter has always had a default, and always the same one
+	tsmallerIsBetter := true
+	if smallerIsBetter, ok := tsearcher["smaller_is_better"]; ok && smallerIsBetter != nil {
+		tsmallerIsBetter, ok = smallerIsBetter.(bool)
+		if !ok {
+			return LegacySearcher{}, errors.New("searcher.smaller_is_better is not a boolean")
+		}
+	}
+
+	return LegacySearcher{
+		Name:            tname,
+		Metric:          tmetric,
+		SmallerIsBetter: tsmallerIsBetter,
+	}, nil
 }
 
 // ParseLegacyConfigJSON parses bytes that represent an experiment config that was once valid
@@ -188,25 +208,45 @@ func ParseLegacyConfigJSON(byts []byte) (LegacyConfig, error) {
 	if err != nil {
 		return out, err
 	}
-	out.checkpointStorage = cs
+	out.CheckpointStorage = cs
 
 	bm, err := getBindMounts(raw)
 	if err != nil {
 		return out, err
 	}
-	out.bindMounts = bm
+	out.BindMounts = bm
 
-	ev, err := getEnvironmentVariables(raw)
+	env, err := getEnvironment(raw)
 	if err != nil {
 		return out, err
 	}
-	out.envvars = ev
+	out.Environment = env
 
-	ps, err := getPodSpec(raw)
+	hp, err := getHyperparameters(raw)
 	if err != nil {
 		return out, err
 	}
-	out.podSpec = ps
+	out.Hyperparameters = hp
+
+	searcher, err := getLegacySearcher(raw)
+	if err != nil {
+		return out, err
+	}
+	out.Searcher = searcher
 
 	return out, nil
+}
+
+// Scan implements the db.Scanner interface.
+func (l *LegacyConfig) Scan(src interface{}) error {
+	byts, ok := src.([]byte)
+	if !ok {
+		return errors.Errorf("unable to convert to []byte: %v", src)
+	}
+	config, err := ParseLegacyConfigJSON(byts)
+	if err != nil {
+		return err
+	}
+	*l = config
+	return nil
 }

--- a/master/pkg/schemas/expconf/legacy_test.go
+++ b/master/pkg/schemas/expconf/legacy_test.go
@@ -7,7 +7,6 @@ import (
 	k8sV1 "k8s.io/api/core/v1"
 	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/google/go-cmp/cmp"
 	"gotest.tools/assert"
 
 	"github.com/determined-ai/determined/master/pkg/ptrs"
@@ -55,8 +54,8 @@ func TestLegacyConfig(t *testing.T) {
                   ports: null
                 hyperparameters:
                   global_batch_size:
-                  type: const
-                  val: 64
+                    type: const
+                    val: 64
                 internal: null
                 labels:
                 - 0.12.13
@@ -89,7 +88,7 @@ func TestLegacyConfig(t *testing.T) {
                   source_trial_id: null
             `),
 			Expected: LegacyConfig{
-				checkpointStorage: CheckpointStorageConfig{
+				CheckpointStorage: CheckpointStorageConfig{
 					RawSharedFSConfig: &SharedFSConfig{
 						RawHostPath:        ptrs.Ptr("/tmp"),
 						RawContainerPath:   ptrs.Ptr("qwer"),
@@ -102,11 +101,32 @@ func TestLegacyConfig(t *testing.T) {
 					RawSaveTrialBest:      ptrs.Ptr(10),
 					RawSaveTrialLatest:    ptrs.Ptr(10),
 				},
-				bindMounts: BindMountsConfig{},
-				envvars: EnvironmentVariablesMap{
-					RawCPU:  []string{"HOME=/where/the/heart/is"},
-					RawCUDA: []string{"HOME=/where/the/heart/is"},
-					RawROCM: []string{"HOME=/where/the/heart/is"},
+				BindMounts: BindMountsConfig{},
+				Environment: EnvironmentConfig{
+					RawEnvironmentVariables: &EnvironmentVariablesMap{
+						RawCPU:  []string{"HOME=/where/the/heart/is"},
+						RawCUDA: []string{"HOME=/where/the/heart/is"},
+						RawROCM: []string{"HOME=/where/the/heart/is"},
+					},
+					RawImage: &EnvironmentImageMap{
+						RawCPU:  ptrs.Ptr("determinedai/environments:py-3.6.9-pytorch-1.4-tf-1.15-cpu-aaa3750"),
+						RawCUDA: ptrs.Ptr("determinedai/environments:cuda-10.0-pytorch-1.4-tf-1.15-gpu-aaa3750"),
+						RawROCM: ptrs.Ptr("determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-24586f0"),
+					},
+					RawPorts:            map[string]int{},
+					RawForcePullImage:   ptrs.Ptr(false),
+					RawAddCapabilities:  []string{},
+					RawDropCapabilities: []string{},
+				},
+				Hyperparameters: Hyperparameters{
+					"global_batch_size": {
+						RawConstHyperparameter: &ConstHyperparameterV0{RawVal: float64(64)},
+					},
+				},
+				Searcher: LegacySearcher{
+					Name:            "random",
+					SmallerIsBetter: false,
+					Metric:          "error",
 				},
 			},
 		},
@@ -204,7 +224,7 @@ func TestLegacyConfig(t *testing.T) {
                   source_trial_id: null
             `),
 			Expected: LegacyConfig{
-				checkpointStorage: CheckpointStorageConfig{
+				CheckpointStorage: CheckpointStorageConfig{
 					RawSharedFSConfig: &SharedFSConfig{
 						RawHostPath:    ptrs.Ptr("/tmp"),
 						RawStoragePath: ptrs.Ptr("determined-cp"),
@@ -214,13 +234,66 @@ func TestLegacyConfig(t *testing.T) {
 					RawSaveTrialBest:      ptrs.Ptr(10),
 					RawSaveTrialLatest:    ptrs.Ptr(10),
 				},
-				bindMounts: BindMountsConfig{},
-				envvars: EnvironmentVariablesMap{
-					RawCPU:  []string{"HOME=/where/the/heart/is"},
-					RawCUDA: []string{"HOME=/where/the/cuda/is"},
-					RawROCM: []string{},
+				BindMounts: BindMountsConfig{},
+				Environment: EnvironmentConfig{
+					RawEnvironmentVariables: &EnvironmentVariablesMap{
+						RawCPU:  []string{"HOME=/where/the/heart/is"},
+						RawCUDA: []string{"HOME=/where/the/cuda/is"},
+						RawROCM: []string{},
+					},
+					RawImage: &EnvironmentImageMap{
+						RawCPU:  ptrs.Ptr("determinedai/environments:py-3.6.9-pytorch-1.4-tf-1.15-cpu-067db2b"),
+						RawCUDA: ptrs.Ptr("determinedai/environments:cuda-10.0-pytorch-1.4-tf-1.15-gpu-067db2b"),
+						RawROCM: ptrs.Ptr("determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-24586f0"),
+					},
+					RawPodSpec: &PodSpec{
+						TypeMeta: metaV1.TypeMeta{
+							Kind:       "Pod",
+							APIVersion: "v1",
+						},
+						ObjectMeta: metaV1.ObjectMeta{
+							Labels: map[string]string{"customLabel": "test-label"},
+						},
+						Spec: k8sV1.PodSpec{
+							Volumes: []k8sV1.Volume{
+								{
+									Name: "test-volume",
+									VolumeSource: k8sV1.VolumeSource{
+										HostPath: &k8sV1.HostPathVolumeSource{
+											Path: "/data",
+											Type: nil,
+										},
+									},
+								},
+							},
+							Containers: []k8sV1.Container{{
+								Name:      "determined-container",
+								Resources: k8sV1.ResourceRequirements{},
+								VolumeMounts: []k8sV1.VolumeMount{{
+									Name:      "test-volume",
+									MountPath: "/test",
+								}},
+							}},
+							SchedulerName:     "coscheduler",
+							PriorityClassName: "determined-medium-priority",
+						},
+						Status: k8sV1.PodStatus{},
+					},
+					RawPorts:            map[string]int{},
+					RawForcePullImage:   ptrs.Ptr(false),
+					RawAddCapabilities:  []string{},
+					RawDropCapabilities: []string{},
 				},
-				podSpec: getTestPodSpec(),
+				Hyperparameters: Hyperparameters{
+					"global_batch_size": {
+						RawConstHyperparameter: &ConstHyperparameterV0{RawVal: float64(32)},
+					},
+				},
+				Searcher: LegacySearcher{
+					Name:            "adaptive_simple",
+					Metric:          "loss",
+					SmallerIsBetter: true,
+				},
 			},
 		},
 		// Test case with a 0.15.5 experiment config.
@@ -259,24 +332,6 @@ func TestLegacyConfig(t *testing.T) {
                   image:
                     cpu: determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-24586f0
                     gpu: determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-24586f0
-                  pod_spec:
-                    apiVersion: v1
-                    kind: Pod
-                    metadata:
-                      labels:
-                        customLabel: test-label
-                    spec:
-                      schedulerName: coscheduler
-                      priorityClassName: determined-medium-priority
-                      containers:
-                        - name: determined-container
-                          volumeMounts:
-                          - name: test-volume
-                            mountPath: /test
-                      volumes:
-                      - name: test-volume
-                        hostPath:
-                          path: /data
                   ports: {}
                   registry_auth: null
                 hyperparameters:
@@ -328,7 +383,7 @@ func TestLegacyConfig(t *testing.T) {
                   source_trial_id: null
             `),
 			Expected: LegacyConfig{
-				checkpointStorage: CheckpointStorageConfig{
+				CheckpointStorage: CheckpointStorageConfig{
 					RawSharedFSConfig: &SharedFSConfig{
 						RawHostPath:    ptrs.Ptr("/tmp"),
 						RawStoragePath: ptrs.Ptr("determined-cp"),
@@ -338,7 +393,7 @@ func TestLegacyConfig(t *testing.T) {
 					RawSaveTrialBest:      ptrs.Ptr(10),
 					RawSaveTrialLatest:    ptrs.Ptr(10),
 				},
-				bindMounts: BindMountsConfig{
+				BindMounts: BindMountsConfig{
 					BindMount{
 						RawHostPath:      "/tmp/asdf",
 						RawContainerPath: "/tmp/asdf",
@@ -346,12 +401,32 @@ func TestLegacyConfig(t *testing.T) {
 						RawPropagation:   ptrs.Ptr("rprivate"),
 					},
 				},
-				envvars: EnvironmentVariablesMap{
-					RawCPU:  []string{},
-					RawCUDA: []string{},
-					RawROCM: []string{},
+				Environment: EnvironmentConfig{
+					RawEnvironmentVariables: &EnvironmentVariablesMap{
+						RawCPU:  []string{},
+						RawCUDA: []string{},
+						RawROCM: []string{},
+					},
+					RawImage: &EnvironmentImageMap{
+						RawCPU:  ptrs.Ptr("determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-24586f0"),
+						RawCUDA: ptrs.Ptr("determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-24586f0"),
+						RawROCM: ptrs.Ptr("determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-24586f0"),
+					},
+					RawPorts:            map[string]int{},
+					RawForcePullImage:   ptrs.Ptr(false),
+					RawAddCapabilities:  []string{},
+					RawDropCapabilities: []string{},
 				},
-				podSpec: getTestPodSpec(),
+				Hyperparameters: Hyperparameters{
+					"global_batch_size": {
+						RawConstHyperparameter: &ConstHyperparameterV0{RawVal: float64(32)},
+					},
+				},
+				Searcher: LegacySearcher{
+					Name:            "single",
+					Metric:          "loss",
+					SmallerIsBetter: true,
+				},
 			},
 		},
 	}
@@ -364,46 +439,7 @@ func TestLegacyConfig(t *testing.T) {
 			legacyConfig, err := ParseLegacyConfigJSON(jByts)
 			assert.NilError(t, err)
 
-			assert.DeepEqual(
-				t, legacyConfig, tc.Expected, cmp.AllowUnexported(LegacyConfig{}),
-			)
+			assert.DeepEqual(t, legacyConfig, tc.Expected)
 		})
 	}
-}
-
-func getTestPodSpec() *PodSpec {
-	output := &PodSpec{
-		TypeMeta: metaV1.TypeMeta{
-			Kind:       "Pod",
-			APIVersion: "v1",
-		},
-		ObjectMeta: metaV1.ObjectMeta{
-			Labels: map[string]string{"customLabel": "test-label"},
-		},
-		Spec: k8sV1.PodSpec{
-			Volumes: []k8sV1.Volume{
-				{
-					Name: "test-volume",
-					VolumeSource: k8sV1.VolumeSource{
-						HostPath: &k8sV1.HostPathVolumeSource{
-							Path: "/data",
-							Type: nil,
-						},
-					},
-				},
-			},
-			Containers: []k8sV1.Container{{
-				Name:      "determined-container",
-				Resources: k8sV1.ResourceRequirements{},
-				VolumeMounts: []k8sV1.VolumeMount{{
-					Name:      "test-volume",
-					MountPath: "/test",
-				}},
-			}},
-			SchedulerName:     "coscheduler",
-			PriorityClassName: "determined-medium-priority",
-		},
-		Status: k8sV1.PodStatus{},
-	}
-	return output
 }

--- a/master/pkg/schemas/expconf/searcher_config.go
+++ b/master/pkg/schemas/expconf/searcher_config.go
@@ -19,6 +19,8 @@ type SearcherConfigV0 struct {
 	RawAdaptiveASHAConfig *AdaptiveASHAConfigV0 `union:"name,adaptive_asha" json:"-"`
 	RawCustomConfig       *CustomConfigV0       `union:"name,custom" json:"-"`
 
+	// TODO(DET-8577): There should not be a need to parse EOL searchers if we get rid of parsing
+	//                 active experiment configs unnecessarily.
 	// These searchers are allowed only to help parse old experiment configs.
 	RawSyncHalvingConfig    *SyncHalvingConfigV0    `union:"name,sync_halving" json:"-"`
 	RawAdaptiveConfig       *AdaptiveConfigV0       `union:"name,adaptive" json:"-"`
@@ -72,6 +74,38 @@ func (s SearcherConfigV0) Unit() Unit {
 		panic("cannot get unit of EOL searcher class")
 	default:
 		panic("no searcher type specified")
+	}
+}
+
+// AsLegacy converts a current ExperimentConfig to a (limited capacity) LegacySearcher.
+func (s SearcherConfigV0) AsLegacy() LegacySearcher {
+	var name string
+	switch {
+	case s.RawSingleConfig != nil:
+		name = "single"
+	case s.RawRandomConfig != nil:
+		name = "random"
+	case s.RawGridConfig != nil:
+		name = "grid"
+	case s.RawAsyncHalvingConfig != nil:
+		name = "async_halving"
+	case s.RawAdaptiveASHAConfig != nil:
+		name = "adaptive_asha"
+	case s.RawCustomConfig != nil:
+		name = "custom"
+	case s.RawSyncHalvingConfig != nil:
+		name = "sync_halving"
+	case s.RawAdaptiveConfig != nil:
+		name = "adaptive"
+	case s.RawAdaptiveSimpleConfig != nil:
+		name = "adaptive_simple"
+	default:
+		panic("no searcher type specified")
+	}
+	return LegacySearcher{
+		Name:            name,
+		Metric:          s.Metric(),
+		SmallerIsBetter: s.SmallerIsBetter(),
 	}
 }
 

--- a/master/pkg/tasks/task_gc.go
+++ b/master/pkg/tasks/task_gc.go
@@ -31,11 +31,11 @@ func (g GCCkptSpec) ToTaskSpec() TaskSpec {
 
 	// Set Environment.
 	// Keep only the EnvironmentVariables provided by the experiment's config.
-	envVars := g.LegacyConfig.EnvironmentVariables()
+	envVars := g.LegacyConfig.Environment.EnvironmentVariables()
 	//nolint:exhaustivestruct // This has caused an issue before, but is valid as a partial struct.
 	env := expconf.EnvironmentConfig{
 		RawEnvironmentVariables: &envVars,
-		RawPodSpec:              g.LegacyConfig.PodSpec(),
+		RawPodSpec:              g.LegacyConfig.Environment.PodSpec(),
 	}
 	// Fill the rest of the environment with default values.
 	var defaultConfig expconf.ExperimentConfig
@@ -54,7 +54,7 @@ func (g GCCkptSpec) ToTaskSpec() TaskSpec {
 				g.Base.AgentUserGroup.OwnedArchiveItem("checkpoint_gc", nil, 0o700, tar.TypeDir),
 				g.Base.AgentUserGroup.OwnedArchiveItem(
 					"checkpoint_gc/storage_config.json",
-					[]byte(jsonify(g.LegacyConfig.CheckpointStorage())),
+					[]byte(jsonify(g.LegacyConfig.CheckpointStorage)),
 					0o600,
 					tar.TypeReg,
 				),
@@ -92,8 +92,8 @@ func (g GCCkptSpec) ToTaskSpec() TaskSpec {
 		res.Entrypoint = append(res.Entrypoint, "--delete-tensorboards")
 	}
 
-	res.Mounts = ToDockerMounts(g.LegacyConfig.BindMounts(), res.WorkDir)
-	if fs := g.LegacyConfig.CheckpointStorage().RawSharedFSConfig; fs != nil {
+	res.Mounts = ToDockerMounts(g.LegacyConfig.BindMounts, res.WorkDir)
+	if fs := g.LegacyConfig.CheckpointStorage.RawSharedFSConfig; fs != nil {
 		res.Mounts = append(res.Mounts, mount.Mount{
 			Type:   mount.TypeBind,
 			Source: fs.HostPath(),

--- a/master/test/integration/api/api_checkpoints_test.go
+++ b/master/test/integration/api/api_checkpoints_test.go
@@ -352,8 +352,8 @@ func testGetTrialCheckpoints(
 func createPrereqs(t *testing.T, pgDB *db.PgDB) (
 	*model.Experiment, *model.Trial, *model.Allocation,
 ) {
-	experiment := model.ExperimentModel()
-	err := pgDB.AddExperiment(experiment)
+	experiment, activeConfig := model.ExperimentModel()
+	err := pgDB.AddExperiment(experiment, activeConfig)
 	assert.NilError(t, err, "failed to insert experiment")
 
 	task := db.RequireMockTask(t, pgDB, experiment.OwnerID)

--- a/master/test/integration/api/api_trials_test.go
+++ b/master/test/integration/api/api_trials_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/determined-ai/determined/master/internal"
 	"github.com/determined-ai/determined/master/internal/db"
+	"github.com/determined-ai/determined/master/pkg/schemas/expconf"
 
 	"github.com/determined-ai/determined/master/test/testutils"
 
@@ -100,11 +101,11 @@ func trialDetailAPITests(
 
 	runTestCase := func(t *testing.T, tc testCase, id int) {
 		t.Run(tc.name, func(t *testing.T) {
-			experiment, trial := setupTrial(t, pgDB)
+			_, activeConfig, trial := setupTrial(t, pgDB)
 
 			metrics := trialv1.TrialMetrics{
 				TrialId:        int32(trial.ID),
-				StepsCompleted: int32(id * experiment.Config.SchedulingUnit()),
+				StepsCompleted: int32(id * activeConfig.SchedulingUnit()),
 			}
 
 			m := structpb.Struct{}
@@ -162,7 +163,7 @@ func makeMetrics() *structpb.Struct {
 func trialWorkloadsAPIHugeMetrics(
 	creds context.Context, t *testing.T, cl apiv1.DeterminedClient, pgDB *db.PgDB,
 ) {
-	_, trial := setupTrial(t, pgDB)
+	_, _, trial := setupTrial(t, pgDB)
 
 	batchMetrics := []*structpb.Struct{}
 	const stepSize = 1
@@ -207,7 +208,7 @@ func trialWorkloadsAPIHugeMetrics(
 func trialProfilerMetricsTests(
 	creds context.Context, t *testing.T, cl apiv1.DeterminedClient, pgDB *db.PgDB,
 ) {
-	_, trial := setupTrial(t, pgDB)
+	_, _, trial := setupTrial(t, pgDB)
 
 	// If we begin to stream for metrics.
 	ctx, cancel := context.WithTimeout(creds, time.Minute)
@@ -275,7 +276,7 @@ func trialProfilerMetricsTests(
 func trialProfilerMetricsAvailableSeriesTests(
 	creds context.Context, t *testing.T, cl apiv1.DeterminedClient, pgDB *db.PgDB,
 ) {
-	_, trial := setupTrial(t, pgDB)
+	_, _, trial := setupTrial(t, pgDB)
 
 	ctx, cancel := context.WithTimeout(creds, time.Minute)
 	defer cancel()
@@ -383,9 +384,11 @@ func randTrialProfilerSystemMetrics(
 	}
 }
 
-func setupTrial(t *testing.T, pgDB *db.PgDB) (*model.Experiment, *model.Trial) {
-	experiment := model.ExperimentModel()
-	err := pgDB.AddExperiment(experiment)
+func setupTrial(t *testing.T, pgDB *db.PgDB) (
+	*model.Experiment, expconf.ExperimentConfig, *model.Trial,
+) {
+	experiment, activeConfig := model.ExperimentModel()
+	err := pgDB.AddExperiment(experiment, activeConfig)
 	assert.NilError(t, err, "failed to insert experiment")
 
 	task := db.RequireMockTask(t, pgDB, experiment.OwnerID)
@@ -399,5 +402,5 @@ func setupTrial(t *testing.T, pgDB *db.PgDB) (*model.Experiment, *model.Trial) {
 
 	err = pgDB.AddTrial(trial)
 	assert.NilError(t, err, "failed to insert trial")
-	return experiment, trial
+	return experiment, activeConfig, trial
 }


### PR DESCRIPTION
## Description

In theory, only the experiment actor should be using an active
experiment config.  In practice, there's some database work required to
make that actually true.

But for now, we can make the easy path and the usually-correct path the
same path.

## Test Plan

- [x] add automated tests for the endpoints which were actually fixed by this change