### PR TITLE
fix: dont trigger loading state on experiment selection

### DIFF
--- a/webui/react/src/pages/ExperimentList.tsx
+++ b/webui/react/src/pages/ExperimentList.tsx
@@ -155,6 +155,8 @@ const ExperimentList: React.FC<Props> = ({ project }) => {
 
   const statesString = useMemo(() => settings.state?.join('.'), [settings.state]);
   const pinnedString = useMemo(() => JSON.stringify(settings.pinned ?? {}), [settings.pinned]);
+  const labelsString = useMemo(() => settings.label?.join('.'), [settings.label]);
+  const usersString = useMemo(() => settings.user?.join('.'), [settings.user]);
 
   const fetchExperiments = useCallback(async (): Promise<void> => {
     try {
@@ -208,11 +210,12 @@ const ExperimentList: React.FC<Props> = ({ project }) => {
     } finally {
       setIsLoading(false);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     canceler.signal,
     id,
     settings.archived,
-    settings.label,
+    labelsString,
     pinnedString,
     settings.search,
     settings.sortDesc,
@@ -220,7 +223,7 @@ const ExperimentList: React.FC<Props> = ({ project }) => {
     statesString,
     settings.tableLimit,
     settings.tableOffset,
-    settings.user,
+    usersString,
   ]);
 
   const fetchLabels = useCallback(async () => {
@@ -849,7 +852,7 @@ const ExperimentList: React.FC<Props> = ({ project }) => {
   }, [
     fetchExperiments,
     settings.archived,
-    settings.label,
+    labelsString,
     settings.search,
     settings.sortDesc,
     settings.sortKey,
@@ -857,7 +860,7 @@ const ExperimentList: React.FC<Props> = ({ project }) => {
     pinnedString,
     settings.tableLimit,
     settings.tableOffset,
-    settings.user,
+    usersString,
   ]);
 
   // cleanup

--- a/webui/react/src/pages/OldProjectDetails.tsx
+++ b/webui/react/src/pages/OldProjectDetails.tsx
@@ -183,6 +183,8 @@ const ProjectDetails: React.FC = () => {
 
   const statesString = useMemo(() => settings.state?.join('.'), [settings.state]);
   const pinnedString = useMemo(() => JSON.stringify(settings.pinned), [settings.pinned]);
+  const labelsString = useMemo(() => settings.label?.join('.'), [settings.label]);
+  const usersString = useMemo(() => settings.user?.join('.'), [settings.user]);
 
   const fetchExperiments = useCallback(async (): Promise<void> => {
     try {
@@ -236,11 +238,12 @@ const ProjectDetails: React.FC = () => {
     } finally {
       setIsLoading(false);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     canceler.signal,
     id,
     settings.archived,
-    settings.label,
+    labelsString,
     pinnedString,
     settings.search,
     settings.sortDesc,
@@ -248,7 +251,7 @@ const ProjectDetails: React.FC = () => {
     statesString,
     settings.tableLimit,
     settings.tableOffset,
-    settings.user,
+    usersString,
   ]);
 
   const fetchLabels = useCallback(async () => {
@@ -904,7 +907,7 @@ const ProjectDetails: React.FC = () => {
   }, [
     fetchExperiments,
     settings.archived,
-    settings.label,
+    labelsString,
     settings.search,
     settings.sortDesc,
     settings.sortKey,
@@ -912,7 +915,7 @@ const ProjectDetails: React.FC = () => {
     pinnedString,
     settings.tableLimit,
     settings.tableOffset,
-    settings.user,
+    usersString,
   ]);
 
   // cleanup


### PR DESCRIPTION
## Description
WEB-548

## Test Plan

`useSettings` does not provide a stable reference to arrays when they are unchanged. this causes the list of tags and the list of users in the filters to be "changed" any time any of the settings are changed (e.g. row selection). 

because we call the `fetchExperiments` when tag and user filters change, this triggers a loading state in the table on row selection.

solution in this case is to stringify those lists and put them in the dependency array instead-- since react compares primitives to their previous values by value instead of reference.


Main test criteria are that:
- loading state is not triggered on row selection when any filters are applied but especially user and/or tags
- that the filters are applied correctly

## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist
- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.
- [ ] If modifying `/webui/react/src/shared/` verify `make -C webui/react test-shared` passes.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
