### PR TITLE
perf: don't load model definition by default

### DIFF
--- a/master/internal/db/postgres_experiments.go
+++ b/master/internal/db/postgres_experiments.go
@@ -55,7 +55,7 @@ func (db *PgDB) ProjectByName(workspaceName string, projectName string) (int, er
 // ProjectExperiments returns a list of experiments within a project.
 func (db *PgDB) ProjectExperiments(id int) (experiments []*model.Experiment, err error) {
 	rows, err := db.sql.Queryx(`
-SELECT e.id, state, config, model_definition, start_time, end_time, archived,
+SELECT e.id, state, config, start_time, end_time, archived,
 	   git_remote, git_commit, git_committer, git_commit_date, owner_id, notes,
 		 job_id, u.username as username, project_id
 FROM experiments e
@@ -897,7 +897,7 @@ func (db *PgDB) ExperimentWithoutConfigByID(id int) (*model.Experiment, error) {
 	var experiment model.Experiment
 
 	if err := db.query(`
-SELECT e.id, state, model_definition, start_time, end_time, archived,
+SELECT e.id, state, start_time, end_time, archived,
        git_remote, git_commit, git_committer, git_commit_date, owner_id, notes,
 			 job_id, u.username as username, project_id
 FROM experiments e
@@ -916,7 +916,7 @@ func (db *PgDB) ExperimentWithoutConfigByTrialID(id int) (*model.Experiment, err
 	var experiment model.Experiment
 
 	if err := db.query(`
-SELECT e.id, e.state, e.model_definition, e.start_time, e.end_time, e.archived,
+SELECT e.id, e.state, e.start_time, e.end_time, e.archived,
        e.git_remote, e.git_commit, e.git_committer, e.git_commit_date, e.owner_id, e.notes,
 			 e.job_id, u.username as username, e.project_id
 FROM experiments e
@@ -937,7 +937,7 @@ func ExperimentWithoutConfigByTaskID(
 ) (*model.Experiment, error) {
 	var experiment model.Experiment
 	if err := Bun().NewRaw(`
-SELECT e.id, e.state, e.model_definition AS model_definition_bytes, e.start_time, e.end_time, 
+SELECT e.id, e.state, e.start_time, e.end_time,
        e.archived, e.git_remote, e.git_commit, e.git_committer, e.git_commit_date, e.owner_id, 
        e.notes, e.job_id, u.username as username, e.project_id
 FROM experiments e


### PR DESCRIPTION
## Description

Some slow queries in gcloud coming from ```ExperimentWithoutConfigByTrialID```.

## Test Plan

Existing e2e tests pass. 

## Commentary (optional)

## Checklist
- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
