### PR TITLE
docs: slots_per_nodes for PBS & Slurm

### DIFF
--- a/docs/reference/reference-interface/job-config-reference.rst
+++ b/docs/reference/reference-interface/job-config-reference.rst
@@ -164,3 +164,5 @@ The following configuration settings are supported:
 
 -  ``slurm``: Slurm cluster details may optionally be specified as for :ref:`experiments
    <slurm-config>`.
+
+-  ``pbs``: PBS cluster details may optionally be specified as for :ref:`experiments <pbs-config>`.

--- a/docs/reference/reference-interface/job-config-reference.rst
+++ b/docs/reference/reference-interface/job-config-reference.rst
@@ -162,7 +162,8 @@ The following configuration settings are supported:
       terminal that is running a command but not being viewed or running a command with no output is
       treated as idle, since JupyterLab does not provide activity information for those case.)
 
--  ``slurm``: Slurm cluster details may optionally be specified as for :ref:`experiments
-   <slurm-config>`.
+-  ``slurm``: Slurm cluster details may optionally be specified in the same fashion as for
+   :ref:`experiments <slurm-config>`.
 
--  ``pbs``: PBS cluster details may optionally be specified as for :ref:`experiments <pbs-config>`.
+-  ``pbs``: PBS cluster details may optionally be specified in the same fashion as for
+   :ref:`experiments <pbs-config>`.

--- a/docs/reference/reference-training/experiment-config-reference.rst
+++ b/docs/reference/reference-training/experiment-config-reference.rst
@@ -1300,6 +1300,16 @@ The ``slurm`` section specifies configuration options applicable when the cluste
             - --mem-per-cpu=10
             - --exclusive
 
+``slots_per_node``
+   The minimum number of slots required for a node to be scheduled during a trial. If
+   :ref:`gres_supported <cluster-configuration-slurm>` is false, specify ``slots_per_node`` in order
+   to utilize more than one GPU per node. It is the user’s responsibility to ensure that
+   ``slots_per_node`` GPUs will be available on nodes selected for the job using other
+   configurations such as targeting a specific resource pool with only GPU nodes or specifying a
+   Slurm constraint in the experiment configuration.
+
+.. _pbs-config:
+
 *************
  PBS Options
 *************
@@ -1320,3 +1330,11 @@ The ``pbs`` section specifies configuration options applicable when the cluster 
          pbsbatch_args:
             - -p1000
             - -PMyProjectName
+
+``slots_per_node``
+   The minimum number of slots required for a node to be scheduled during a trial. If
+   :ref:`gres_supported <cluster-configuration-slurm>` is false, specify ``slots_per_node`` in order
+   to utilize more than one GPU per node. It is the user’s responsibility to ensure that
+   ``slots_per_node`` GPUs will be available on the nodes selected for the job using other
+   configurations such as targeting a specific resource pool with only ``slots_per_node`` GPU nodes
+   or specifying a PBS constraint in the experiment configuration.


### PR DESCRIPTION
## Description

Describe usage of slots_per_node for PBS & Slurm.
<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At a minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan

Builds & reads locally OK.

## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist
- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
