### PR TITLE
perf: get trial workloads improvement

### DIFF
--- a/master/internal/api_trials.go
+++ b/master/internal/api_trials.go
@@ -753,15 +753,28 @@ func (a *apiServer) GetTrialWorkloads(ctx context.Context, req *apiv1.GetTrialWo
 		limit = ptrs.Ptr[int32](-1)
 	}
 
+	metricsSortCode := "total_batches"
 	sortCode := "total_batches"
 	if req.SortKey != "" && req.SortKey != "batches" {
-		sortCode = fmt.Sprintf("sort_metrics->'avg_metrics'->>'%s'",
+		metricsSortCode = fmt.Sprintf("(metrics->'avg_metrics'->>'%s')::float",
+			strings.ReplaceAll(req.SortKey, "'", ""))
+		sortCode = fmt.Sprintf("(sort_metrics->'avg_metrics'->>'%s')::float",
 			strings.ReplaceAll(req.SortKey, "'", ""))
 	}
 
 	switch err := a.m.db.QueryProtof(
 		"proto_get_trial_workloads",
 		[]interface{}{
+			metricsSortCode,
+			db.OrderByToSQL(req.OrderBy),
+			db.OrderByToSQL(req.OrderBy),
+			db.OrderByToSQL(req.OrderBy),
+
+			metricsSortCode,
+			db.OrderByToSQL(req.OrderBy),
+			db.OrderByToSQL(req.OrderBy),
+			db.OrderByToSQL(req.OrderBy),
+
 			sortCode,
 			db.OrderByToSQL(req.OrderBy),
 			db.OrderByToSQL(req.OrderBy),

--- a/master/static/migrations/20221021142327_endtime_index_total_batches.tx.down.sql
+++ b/master/static/migrations/20221021142327_endtime_index_total_batches.tx.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX trial_id_total_batches_end_time_raw_steps;

--- a/master/static/migrations/20221021142327_endtime_index_total_batches.tx.up.sql
+++ b/master/static/migrations/20221021142327_endtime_index_total_batches.tx.up.sql
@@ -1,0 +1,2 @@
+CREATE INDEX trial_id_total_batches_end_time_raw_steps ON public.raw_steps
+    USING btree (trial_id, total_batches, end_time) WHERE archived = false;

--- a/master/static/srv/proto_get_trial_workloads.sql
+++ b/master/static/srv/proto_get_trial_workloads.sql
@@ -3,6 +3,7 @@ WITH page_info AS (
     SELECT COUNT(*) AS count FROM (
       SELECT 1 FROM validations v WHERE
         v.trial_id = $1
+      AND $4 != 'FILTER_OPTION_CHECKPOINT'
       UNION ALL
       SELECT 1 FROM steps s WHERE
         s.trial_id = $1 AND
@@ -24,6 +25,7 @@ validations_vt AS (
         jsonb_build_object('avg_metrics', v.metrics->'validation_metrics') as metrics
       FROM validations v
       WHERE v.trial_id = $1
+      AND $4 != 'FILTER_OPTION_CHECKPOINT'
       ORDER BY %s %s NULLS LAST, total_batches %s, end_time %s
       LIMIT (SELECT p.page_info->>'end_index' FROM page_info p)::bigint      
     ) AS r1


### PR DESCRIPTION
## Description

Get trial workloads was always materializing the full steps table for a given trial. This tries to reduce that to an OFFSET + LIMIT amount

## Test Plan

Integration test

## Commentary (optional)

Query plan
```
 Result  (cost=61616.13..61616.14 rows=1 width=64) (actual time=184.258..184.281 rows=1 loops=1)
   CTE page_info
     ->  Result  (cost=54396.61..54396.87 rows=1 width=32) (actual time=159.056..159.066 rows=1 loops=1)
           InitPlan 1 (returns $10)
             ->  Aggregate  (cost=54396.60..54396.61 rows=1 width=8) (actual time=158.814..158.823 rows=1 loops=1)
                   ->  Append  (cost=0.29..54343.86 rows=21096 width=0) (actual time=0.008..151.614 rows=100002 loops=1)
                         ->  Subquery Scan on "*SELECT* 1"  (cost=0.29..10.33 rows=1 width=0) (actual time=0.008..0.009 rows=1 loops=1)
                               ->  Index Scan using ix_validations_trial_id on raw_validations  (cost=0.29..10.32 rows=1 width=4) (actual time=0.007..0.008 rows=1 loops=1)
                                     Index Cond: (trial_id = 3840)
                                     Filter: (NOT archived)
                         ->  Subquery Scan on "*SELECT* 2"  (cost=491.89..54251.37 rows=21093 width=0) (actual time=13.889..145.160 rows=100000 loops=1)
                               ->  Bitmap Heap Scan on raw_steps  (cost=491.89..54040.44 rows=21093 width=4) (actual time=13.889..137.144 rows=100000 loops=1)
                                     Recheck Cond: ((trial_id = 3840) AND (NOT archived))
                                     Heap Blocks: exact=42570
                                     ->  Bitmap Index Scan on trial_id_total_batches_end_time_raw_steps  (cost=0.00..486.62 rows=21093 width=0) (actual time=7.764..7.764 rows=100000 loops=1)
                                           Index Cond: (trial_id = 3840)
                         ->  Subquery Scan on "*SELECT* 3"  (cost=5.70..82.16 rows=2 width=0) (actual time=0.143..0.162 rows=1 loops=1)
                               ->  Subquery Scan on c  (cost=5.70..82.14 rows=2 width=4) (actual time=0.142..0.161 rows=1 loops=1)
                                     ->  Append  (cost=5.70..82.12 rows=2 width=316) (actual time=0.142..0.160 rows=1 loops=1)
                                           ->  Nested Loop Left Join  (cost=5.70..40.22 rows=1 width=1957) (actual time=0.141..0.147 rows=1 loops=1)
                                                 Join Filter: (t.id = s.trial_id)
                                                 Filter: ((s.archived IS NULL) OR ((NOT s.archived) AND (v.archived IS NULL)) OR (NOT v.archived))
                                                 ->  Nested Loop Left Join  (cost=5.27..32.35 rows=1 width=1241) (actual time=0.079..0.083 rows=1 loops=1)
                                                       Join Filter: (t.id = v.trial_id)
                                                       ->  Nested Loop Left Join  (cost=4.85..28.25 rows=1 width=1122) (actual time=0.058..0.060 rows=1 loops=1)
                                                             ->  Nested Loop  (cost=4.57..19.92 rows=1 width=972) (actual time=0.049..0.051 rows=1 loops=1)
                                                                   ->  Index Scan using trials_pkey on trials t  (cost=0.28..8.30 rows=1 width=248) (actual time=0.027..0.028 rows=1 loops=1)
                                                                         Index Cond: (id = 3840)
                                                                   ->  Bitmap Heap Scan on checkpoints_v2 c_1  (cost=4.29..11.60 rows=2 width=765) (actual time=0.017..0.017 rows=1 loops=1)
                                                                         Recheck Cond: (task_id = t.task_id)
                                                                         Heap Blocks: exact=1
                                                                         ->  Bitmap Index Scan on ix_checkpoints_v2_task_id_steps_completed  (cost=0.00..4.29 rows=2 width=0) (actual time=0.011..0.011 rows=1 loops=1)
                                                                               Index Cond: (task_id = t.task_id)
                                                             ->  Index Scan using experiments_pkey on experiments e  (cost=0.27..8.29 rows=1 width=154) (actual time=0.006..0.007 rows=1 loops=1)
                                                                   Index Cond: (t.experiment_id = id)
                                                       ->  Index Scan using validations_trial_id_total_batches_run_id_unique on raw_validations v  (cost=0.42..4.09 rows=1 width=127) (actual time=0.015..0.015 rows=1 loops=1)
                                                             Index Cond: ((trial_id = 3840) AND (((c_1.metadata ->> 'steps_completed'::text))::integer = total_batches))
                                                 ->  Index Scan using steps_trial_id_total_batches_run_id_unique on raw_steps s  (cost=0.43..7.83 rows=1 width=796) (actual time=0.015..0.016 rows=1 loops=1)
                                                       Index Cond: ((trial_id = 3840) AND (((c_1.metadata ->> 'steps_completed'::text))::integer = total_batches))
                                           ->  Subquery Scan on "*SELECT* 2_1"  (cost=1.68..41.89 rows=1 width=1811) (actual time=0.009..0.011 rows=0 loops=1)
                                                 ->  Nested Loop Left Join  (cost=1.68..41.88 rows=1 width=1807) (actual time=0.008..0.010 rows=0 loops=1)
                                                       Filter: ((s_1.archived IS NULL) OR ((NOT s_1.archived) AND (v_1.archived IS NULL)) OR (NOT v_1.archived))
                                                       ->  Nested Loop Left Join  (cost=1.26..33.39 rows=1 width=1779) (actual time=0.008..0.010 rows=0 loops=1)
                                                             Join Filter: (s_1.trial_id = t_1.id)
                                                             ->  Nested Loop Left Join  (cost=0.83..24.93 rows=1 width=991) (actual time=0.008..0.009 rows=0 loops=1)
                                                                   ->  Nested Loop  (cost=0.56..16.61 rows=1 width=841) (actual time=0.008..0.008 rows=0 loops=1)
                                                                         ->  Index Scan using checkpoints_trial_id_run_id_total_batches_unique on raw_checkpoints c_2  (cost=0.28..8.30 rows=1 width=593) (actual time=0.007..0.008 rows=0 loops=1)
                                                                               Index Cond: (trial_id = 3840)
                                                                         ->  Index Scan using trials_pkey on trials t_1  (cost=0.28..8.30 rows=1 width=248) (never executed)
                                                                               Index Cond: (id = 3840)
                                                                   ->  Index Scan using experiments_pkey on experiments e_1  (cost=0.27..8.29 rows=1 width=154) (never executed)
                                                                         Index Cond: (t_1.experiment_id = id)
                                                             ->  Index Scan using steps_trial_id_total_batches_run_id_unique on raw_steps s_1  (cost=0.42..8.45 rows=1 width=800) (never executed)
                                                                   Index Cond: ((trial_id = 3840) AND (total_batches = c_2.total_batches) AND (trial_run_id = c_2.trial_run_id))
                                                       ->  Index Scan using validations_trial_id_total_batches_run_id_unique on raw_validations v_1  (cost=0.42..8.44 rows=1 width=131) (never executed)
                                                             Index Cond: ((trial_id = c_2.trial_id) AND (trial_id = 3840) AND (total_batches = c_2.total_batches) AND (trial_run_id = c_2.trial_run_id))
   CTE validations_vt
     ->  Subquery Scan on r1  (cost=10.37..10.38 rows=1 width=76) (actual time=0.030..0.032 rows=1 loops=1)
           ->  Limit  (cost=10.37..10.37 rows=1 width=108) (actual time=0.023..0.024 rows=1 loops=1)
                 InitPlan 3 (returns $12)
                   ->  CTE Scan on page_info p  (cost=0.00..0.02 rows=1 width=32) (actual time=0.004..0.004 rows=1 loops=1)
                 ->  Sort  (cost=10.34..10.35 rows=1 width=108) (actual time=0.017..0.018 rows=1 loops=1)
                       Sort Key: raw_validations_1.total_batches, raw_validations_1.end_time                                                                                                                                                                                   
                       Sort Method: quicksort  Memory: 25kB                                                                                                                                                                                                                    
                       ->  Index Scan using ix_validations_trial_id on raw_validations raw_validations_1  (cost=0.29..10.33 rows=1 width=108) (actual time=0.013..0.014 rows=1 loops=1)                                                                                        
                             Index Cond: (trial_id = 3840)                                                                                                                                                                                                                     
                             Filter: (NOT archived)                                                                                                                                                                                                                                                                                                                                        
   CTE trainings_vt                                                                                                                                                                                                                                                                                                                                                                        
     ->  Subquery Scan on r1_1  (cost=0.44..6811.34 rows=2109 width=76) (actual time=0.051..15.417 rows=1000 loops=1)                                                                                                                                                                                                                                                                      
           ->  Limit  (cost=0.44..6784.98 rows=2109 width=108) (actual time=0.038..12.787 rows=1000 loops=1)                                                                                                                                                                                                                                                                               
                 InitPlan 5 (returns $14)                                                                                                                                                                                                                                                                                                                                                  
                   ->  CTE Scan on page_info p_1  (cost=0.00..0.02 rows=1 width=32) (actual time=0.001..0.002 rows=1 loops=1)                                                                                                                                                                                                                                                              
                 ->  Index Scan using trial_id_total_batches_end_time_raw_steps on raw_steps raw_steps_1  (cost=0.42..67855.45 rows=21093 width=108) (actual time=0.035..12.690 rows=1000 loops=1)                                                                                                                                                                                         
                       Index Cond: (trial_id = 3840)                                                                                                                                                                                                                                                                                                                                       
   CTE checkpoints_vt                                                                                                                                                                                                                                                                                                                                                                      
     ->  Subquery Scan on c_3  (cost=5.70..82.16 rows=2 width=44) (actual time=0.066..0.078 rows=1 loops=1)                                                                                                                                                                                                                                                                                
           ->  Append  (cost=5.70..82.12 rows=2 width=316) (actual time=0.054..0.066 rows=1 loops=1)                                                                                                                                                                                                                                                                                       
                 ->  Nested Loop Left Join  (cost=5.70..40.22 rows=1 width=1957) (actual time=0.054..0.058 rows=1 loops=1)                                                                                                                                                                                                                                                                 
                       Join Filter: (t_2.id = s_2.trial_id)
                       Filter: ((s_2.archived IS NULL) OR ((NOT s_2.archived) AND (v_2.archived IS NULL)) OR (NOT v_2.archived))
                       ->  Nested Loop Left Join  (cost=5.27..32.35 rows=1 width=1241) (actual time=0.026..0.030 rows=1 loops=1)
                             Join Filter: (t_2.id = v_2.trial_id)
                             ->  Nested Loop Left Join  (cost=4.85..28.25 rows=1 width=1122) (actual time=0.018..0.021 rows=1 loops=1)
                                   ->  Nested Loop  (cost=4.57..19.92 rows=1 width=972) (actual time=0.014..0.015 rows=1 loops=1)
                                         ->  Index Scan using trials_pkey on trials t_2  (cost=0.28..8.30 rows=1 width=248) (actual time=0.004..0.004 rows=1 loops=1)
                                               Index Cond: (id = 3840)
                                         ->  Bitmap Heap Scan on checkpoints_v2 c_4  (cost=4.29..11.60 rows=2 width=765) (actual time=0.006..0.007 rows=1 loops=1)
                                               Recheck Cond: (task_id = t_2.task_id)
                                               Heap Blocks: exact=1
                                               ->  Bitmap Index Scan on ix_checkpoints_v2_task_id_steps_completed  (cost=0.00..4.29 rows=2 width=0) (actual time=0.004..0.004 rows=1 loops=1)
                                                     Index Cond: (task_id = t_2.task_id)
                                   ->  Index Scan using experiments_pkey on experiments e_2  (cost=0.27..8.29 rows=1 width=154) (actual time=0.003..0.003 rows=1 loops=1)
                                         Index Cond: (t_2.experiment_id = id)
                             ->  Index Scan using validations_trial_id_total_batches_run_id_unique on raw_validations v_2  (cost=0.42..4.09 rows=1 width=127) (actual time=0.005..0.005 rows=1 loops=1)
                                   Index Cond: ((trial_id = 3840) AND (((c_4.metadata ->> 'steps_completed'::text))::integer = total_batches))
                       ->  Index Scan using steps_trial_id_total_batches_run_id_unique on raw_steps s_2  (cost=0.43..7.83 rows=1 width=796) (actual time=0.004..0.005 rows=1 loops=1)
                             Index Cond: ((trial_id = 3840) AND (((c_4.metadata ->> 'steps_completed'::text))::integer = total_batches))
                 ->  Subquery Scan on "*SELECT* 2_2"  (cost=1.68..41.89 rows=1 width=1811) (actual time=0.004..0.006 rows=0 loops=1)
                       ->  Nested Loop Left Join  (cost=1.68..41.88 rows=1 width=1807) (actual time=0.004..0.006 rows=0 loops=1)
                             Filter: ((s_3.archived IS NULL) OR ((NOT s_3.archived) AND (v_3.archived IS NULL)) OR (NOT v_3.archived))
                             ->  Nested Loop Left Join  (cost=1.26..33.39 rows=1 width=1779) (actual time=0.003..0.005 rows=0 loops=1)
                                   Join Filter: (s_3.trial_id = t_3.id)
                                   ->  Nested Loop Left Join  (cost=0.83..24.93 rows=1 width=991) (actual time=0.003..0.004 rows=0 loops=1)
                                         ->  Nested Loop  (cost=0.56..16.61 rows=1 width=841) (actual time=0.003..0.003 rows=0 loops=1)
                                               ->  Index Scan using checkpoints_trial_id_run_id_total_batches_unique on raw_checkpoints c_5  (cost=0.28..8.30 rows=1 width=593) (actual time=0.003..0.003 rows=0 loops=1)
                                                     Index Cond: (trial_id = 3840)
                                               ->  Index Scan using trials_pkey on trials t_3  (cost=0.28..8.30 rows=1 width=248) (never executed)
                                                     Index Cond: (id = 3840)
                                         ->  Index Scan using experiments_pkey on experiments e_3  (cost=0.27..8.29 rows=1 width=154) (never executed)
                                               Index Cond: (t_3.experiment_id = id)
                                   ->  Index Scan using steps_trial_id_total_batches_run_id_unique on raw_steps s_3  (cost=0.42..8.45 rows=1 width=800) (never executed)
                                         Index Cond: ((trial_id = 3840) AND (total_batches = c_5.total_batches) AND (trial_run_id = c_5.trial_run_id))
                             ->  Index Scan using validations_trial_id_total_batches_run_id_unique on raw_validations v_3  (cost=0.42..8.44 rows=1 width=131) (never executed)
                                   Index Cond: ((trial_id = c_5.trial_id) AND (trial_id = 3840) AND (total_batches = c_5.total_batches) AND (trial_run_id = c_5.trial_run_id))
   CTE workloads
     ->  Merge Full Join  (cost=0.00..152.96 rows=2109 width=140) (actual time=0.169..18.835 rows=1002 loops=1)
           Join Filter: false
           ->  Merge Full Join  (cost=0.00..94.94 rows=2109 width=120) (actual time=0.128..16.157 rows=1001 loops=1)
                 Join Filter: false
                 ->  CTE Scan on trainings_vt t_4  (cost=0.00..42.18 rows=2109 width=76) (actual time=0.053..15.855 rows=1000 loops=1)
                 ->  Materialize  (cost=0.00..0.04 rows=2 width=44) (actual time=0.074..0.082 rows=1 loops=1)
                       ->  CTE Scan on checkpoints_vt c_6  (cost=0.00..0.04 rows=2 width=44) (actual time=0.067..0.074 rows=1 loops=1)
           ->  Materialize  (cost=0.00..0.02 rows=1 width=76) (actual time=0.032..0.033 rows=1 loops=1)
                 ->  CTE Scan on validations_vt v_4  (cost=0.00..0.02 rows=1 width=76) (actual time=0.031..0.032 rows=1 loops=1)
   InitPlan 11 (returns $30)
     ->  Aggregate  (cost=162.38..162.39 rows=1 width=32) (actual time=184.162..184.164 rows=1 loops=1)
           ->  Subquery Scan on w  (cost=159.21..161.85 rows=211 width=120) (actual time=178.760..179.099 rows=1000 loops=1)
                 ->  Limit  (cost=159.21..159.74 rows=211 width=108) (actual time=178.750..178.854 rows=1000 loops=1)
                       InitPlan 9 (returns $28)
                         ->  CTE Scan on page_info p_2  (cost=0.00..0.02 rows=1 width=32) (actual time=159.061..159.062 rows=1 loops=1)
                       InitPlan 10 (returns $29)
                         ->  CTE Scan on page_info p_3  (cost=0.00..0.04 rows=1 width=8) (actual time=0.003..0.003 rows=1 loops=1)
                       ->  Sort  (cost=158.62..163.89 rows=2109 width=108) (actual time=19.681..19.731 rows=1000 loops=1)
                             Sort Key: workloads.total_batches, workloads.end_time
                             Sort Method: quicksort  Memory: 292kB
                             ->  CTE Scan on workloads  (cost=0.00..42.18 rows=2109 width=108) (actual time=0.173..19.341 rows=1002 loops=1)
   InitPlan 12 (returns $31)
     ->  CTE Scan on page_info p_4  (cost=0.00..0.02 rows=1 width=32) (actual time=0.001..0.001 rows=1 loops=1)
 Planning time: 2.720 ms
 Execution time: 184.777 ms
(140 rows)

```

## Checklist
- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
