### PR TITLE
fix: duplicated messages logged at INFO and ERROR levels.

### DIFF
--- a/master/internal/sproto/task.go
+++ b/master/internal/sproto/task.go
@@ -228,6 +228,7 @@ type Event struct {
 	IsReady     bool      `json:"is_ready"`
 	State       string    `json:"state"`
 	ContainerID string    `json:"container_id"`
+	Level       *string   `json:"level"`
 
 	ScheduledEvent *model.AllocationID `json:"scheduled_event"`
 	// AssignedEvent is triggered when the parent was assigned to an agent.
@@ -272,8 +273,12 @@ func (ev *Event) ToTaskLog() model.TaskLog {
 		message = ""
 	}
 
+	level := ptrs.Ptr(model.LogLevelInfo)
+	if ev.Level != nil {
+		level = ev.Level
+	}
 	return model.TaskLog{
-		Level:       ptrs.Ptr(model.LogLevelInfo),
+		Level:       level,
 		ContainerID: &ev.ContainerID,
 		Timestamp:   &ev.Time,
 		Log:         message,


### PR DESCRIPTION
## Description

This change will fix logging the same exit error message at the INFO level as well as at the ERROR level. In addition, this fix cherry-picked a change made for FOUNDENG-260 from https://github.com/determined-ai/determined-ee/pull/463.


## Test Plan
With this change:

 % det command run exit 0
[2022-10-24T16:12:58.439433Z]          || INFO: Scheduling Command (needlessly-included-thrush) (id: 9765c6e7-d221-464f-81da-f8b6e3c17302)

[2022-10-24T16:12:58.580698Z]          || INFO: Command (needlessly-included-thrush) was assigned to an agent
[2022-10-24T16:13:19.466281Z]          || INFO: resources exited successfully with a zero exit code
[2022-10-24T16:13:19.508887Z]          || INFO: Command (needlessly-included-thrush) was terminated: allocation stopped early after resources exited successfully with a zero exit code

% det command run exit 1
[2022-10-24T16:13:28.448415Z]          || INFO: Scheduling Command (actively-amused-drum) (id: a7718806-3125-42d7-8e94-94100ea68688)
[2022-10-24T16:13:28.581021Z]          || INFO: Command (actively-amused-drum) was assigned to an agent
[2022-10-24T16:13:48.396415Z]          || ERROR: Command (actively-amused-drum) was terminated: allocation failed: task failed without an associated exit code: Slurm job is in a failed state due to reason 'NonZeroExitCode':
  Job Exited with Exit Code 1
  INFO:    Using cached SIF image
  INFO: Setting workdir to /run/determined/workdir
  INFO: executing /run/determined/command-entrypoint.sh exit 1
  srun: error: node002: task 0: Exited with exit code 1
  srun: launch/slurm: _step_signal: Terminating StepId=1492.0. SBATCH options: --ntasks-per-node=1 --nodes=1-1 --gpus=1 --job-name=det-ai_cmd-9dfed72b568d4ffe-9229be15f4d022f9 --partition=defq --chdir=/var/tmp --error=/home/users/cobble/.launcher/jobs/environments/cobble/9dfed72b568d4ffe-9229be15f4d022f9/ai_cmd-error.log --output=/home/users/cobble/.launcher/jobs/environments/cobble/9dfed72b568d4ffe-9229be15f4d022f9/ai_cmd-output.log
 (exit code 1)

![image](https://user-images.githubusercontent.com/107056780/197579940-5553e62f-eabe-4749-a521-5323086f178d.png)

## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist
- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
