### PR TITLE
ci: add release notes header with link [INFENG-115]

### DIFF
--- a/agent/.goreleaser.yml
+++ b/agent/.goreleaser.yml
@@ -51,6 +51,12 @@ release:
     owner: determined-ai
     name: determined
 
+  # be sure to keep this in sync between agent/master/helm
+  # the "include" functionality is only in the pro version
+  header: |
+    ## Release Notes
+    [{{ .Tag }}](https://github.com/determined-ai/determined/blob/{{ .Tag }}/docs/release-notes.rst)
+
 dockers:
   - goos: linux
     goarch: amd64

--- a/helm/.goreleaser.yml
+++ b/helm/.goreleaser.yml
@@ -11,3 +11,9 @@ release:
   extra_files:
     - glob: build/determined-latest.tgz
       name_template: "determined-helm-chart_{{ .Env.VERSION }}.tgz"
+
+  # be sure to keep this in sync between agent/master/helm
+  # the "include" functionality is only in the pro version
+  header: |
+    ## Release Notes
+    [{{ .Tag }}](https://github.com/determined-ai/determined/blob/{{ .Tag }}/docs/release-notes.rst)

--- a/master/.goreleaser.yml
+++ b/master/.goreleaser.yml
@@ -76,6 +76,12 @@ release:
     owner: determined-ai
     name: determined
 
+  # be sure to keep this in sync between agent/master/helm
+  # the "include" functionality is only in the pro version
+  header: |
+    ## Release Notes
+    [{{ .Tag }}](https://github.com/determined-ai/determined/blob/{{ .Tag }}/docs/release-notes.rst)
+
 dockers:
   - goos: linux
     goarch: amd64


### PR DESCRIPTION
## Description

Add a header with a link to the release notes in the released tag.  This seems the simplest way to get the relase notes linked in without having to make sure they're generated at the time the release is created.

The intended result is manually created at https://github.com/determined-ai/determined/releases/tag/0.19.5

## Test Plan

Make a release and see if it works.  Fix it if not. :shrug:

## Commentary (optional)

I'm not sure if the `##Changelog` is auto-inserted or not; that may need added in a second revision.


## Checklist
- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
