### PR TITLE
fix: exclude allocations without start times from aggregation

### DIFF
--- a/docs/release-notes/fix-aggregation.rst
+++ b/docs/release-notes/fix-aggregation.rst
@@ -1,0 +1,5 @@
+:orphan:
+
+**Bug Fixes**
+
+-  Master: Correctly handle pending allocations in historical resource allocation aggregation.

--- a/master/static/srv/update_aggregated_allocation.sql
+++ b/master/static/srv/update_aggregated_allocation.sql
@@ -23,6 +23,8 @@ allocs_in_range AS (
                 tstzrange(start_time, end_time) AS range
             FROM
                 allocations
+            WHERE
+                start_time IS NOT NULL
         ) AS a,
         const
     WHERE


### PR DESCRIPTION
## Description

The allocation aggregation query was designed under the assumption that everything has a start time, since that was true for trials. At some point after the query switched to using the allocations table, we added the PENDING state, within which an allocation has NULL start time.

In PostgreSQL, a NULL start or end for a range indicates that the range is unbounded in that direction, so an allocation that is in PENDING when an aggregation runs registers as having been running for the whole day of the aggregation. We should just ignore those instead.

The case of NULL end time should already be handled, since that has always been a possibility.

## Test Plan

- [x] check that allocation that is pending while an aggregation runs counts as running all day without the change and for nothing with it