### PR TITLE
chore: simplify `ptrs.Ptr`

### DIFF
--- a/master/pkg/ptrs/ptrs.go
+++ b/master/pkg/ptrs/ptrs.go
@@ -1,7 +1,7 @@
 package ptrs
 
-// Ptr returns a pointer to a copy of a value.  This let's you take the address of some
-// non-addressible[1] values, like boolean literals.  So if a struct has a *bool field, you can do:
+// Ptr returns a pointer to a copy of a value.  This lets you take the address of some
+// non-addressable[1] values, like boolean literals.  So if a struct has a *bool field, you can do:
 //
 //     x := MyStruct{MyBool: Ptr(true)}
 //
@@ -12,6 +12,5 @@ package ptrs
 //
 // [1] https://go.dev/ref/spec#Address_operators
 func Ptr[T any](t T) *T {
-	x := t
-	return &x
+	return &t
 }


### PR DESCRIPTION
## Description

Inside the function, the value is already addressable now that it has a name, so declaring a new variable to take the address of isn't necessary.