### PR TITLE
chore: delete dead code to fix flake8

### DIFF
--- a/harness/determined/_trial_controller.py
+++ b/harness/determined/_trial_controller.py
@@ -107,9 +107,6 @@ class TrialController(metaclass=abc.ABCMeta):
     def create_metric_writer(cls: Type["TrialController"]) -> tensorboard.BatchMetricWriter:
         pass
 
-    def initialize_wrapper(self) -> None:
-        pass
-
     def close(self) -> None:
         self.context.close()
 


### PR DESCRIPTION
flake8 started failing, saying:

    initialize_wrapper is an empty method in an abstract base
    class, but has no abstract decorator