### PR TITLE
fix: add and edit workspace member UI [WEB-552]

### DIFF
--- a/webui/react/src/hooks/useModal/Workspace/useModalWorkspaceAddMember.tsx
+++ b/webui/react/src/hooks/useModal/Workspace/useModalWorkspaceAddMember.tsx
@@ -5,18 +5,19 @@ import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useStore } from 'contexts/Store';
 import useFeature from 'hooks/useFeature';
 import { assignRolesToGroup, assignRolesToUser } from 'services/api';
-import { V1Group } from 'services/api-ts-sdk';
+import { V1Group, V1Role } from 'services/api-ts-sdk';
 import Icon from 'shared/components/Icon/Icon';
 import useModal, { ModalHooks } from 'shared/hooks/useModal/useModal';
 import { DetError, ErrorLevel, ErrorType } from 'shared/utils/error';
 import { User, UserOrGroup } from 'types';
 import handleError from 'utils/error';
-import { getAssignableWorkspaceRoles, getIdFromUserOrGroup, getName, isUser } from 'utils/user';
+import { getIdFromUserOrGroup, getName, isUser } from 'utils/user';
 
 import css from './useModalWorkspaceAddMember.module.scss';
 
 interface Props {
   addableUsersAndGroups: UserOrGroup[];
+  rolesAssignableToScope: V1Role[];
   onClose?: () => void;
   workspaceId: number;
 }
@@ -27,10 +28,11 @@ interface FormInputs {
 
 const useModalWorkspaceAddMember = ({
   addableUsersAndGroups,
+  rolesAssignableToScope,
   onClose,
   workspaceId,
 }: Props): ModalHooks => {
-  let { knownRoles } = useStore();
+  let knownRoles = rolesAssignableToScope;
   const { modalOpen: openOrUpdate, modalRef, ...modalHook } = useModal({ onClose });
   const [selectedOption, setSelectedOption] = useState<UserOrGroup>();
   const [form] = Form.useForm<FormInputs>();
@@ -41,12 +43,12 @@ const useModalWorkspaceAddMember = ({
       mockWorkspaceMembers
         ? [
             {
-              id: 1,
+              roleId: 1,
               name: 'Editor',
               permissions: [],
             },
             {
-              id: 2,
+              roleId: 2,
               name: 'Viewer',
               permissions: [],
             },
@@ -166,8 +168,8 @@ const useModalWorkspaceAddMember = ({
             name="roleId"
             rules={[{ message: 'Role is required ', required: true }]}>
             <Select placeholder="Role">
-              {getAssignableWorkspaceRoles(knownRoles).map((role) => (
-                <Select.Option key={role.id} value={role.id}>
+              {rolesAssignableToScope.map((role) => (
+                <Select.Option key={role.roleId} value={role.roleId}>
                   {role.name}
                 </Select.Option>
               ))}

--- a/webui/react/src/hooks/useModal/Workspace/useModalWorkspaceAddMember.tsx
+++ b/webui/react/src/hooks/useModal/Workspace/useModalWorkspaceAddMember.tsx
@@ -138,11 +138,7 @@ const useModalWorkspaceAddMember = ({
   const modalContent = useMemo(() => {
     return (
       <div className={css.base}>
-        <Form
-          autoComplete="off"
-          form={form}
-          layout="vertical"
-          onValuesChange={async () => await form.validateFields()}>
+        <Form autoComplete="off" form={form} layout="vertical">
           <Form.Item
             label="User or Group"
             name="userOrGroupId"

--- a/webui/react/src/hooks/useModal/Workspace/useModalWorkspaceAddMember.tsx
+++ b/webui/react/src/hooks/useModal/Workspace/useModalWorkspaceAddMember.tsx
@@ -2,7 +2,6 @@ import { Form, message, Select } from 'antd';
 import { ModalFuncProps } from 'antd/es/modal/Modal';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 
-import { useStore } from 'contexts/Store';
 import useFeature from 'hooks/useFeature';
 import { assignRolesToGroup, assignRolesToUser } from 'services/api';
 import { V1Group, V1Role } from 'services/api-ts-sdk';
@@ -17,8 +16,8 @@ import css from './useModalWorkspaceAddMember.module.scss';
 
 interface Props {
   addableUsersAndGroups: UserOrGroup[];
-  rolesAssignableToScope: V1Role[];
   onClose?: () => void;
+  rolesAssignableToScope: V1Role[];
   workspaceId: number;
 }
 interface FormInputs {
@@ -43,14 +42,14 @@ const useModalWorkspaceAddMember = ({
       mockWorkspaceMembers
         ? [
             {
-              roleId: 1,
               name: 'Editor',
               permissions: [],
+              roleId: 1,
             },
             {
-              roleId: 2,
               name: 'Viewer',
               permissions: [],
+              roleId: 2,
             },
           ]
         : knownRoles,
@@ -178,7 +177,7 @@ const useModalWorkspaceAddMember = ({
         </Form>
       </div>
     );
-  }, [addableUsersAndGroups, form, handleFilter, handleSelect, knownRoles]);
+  }, [addableUsersAndGroups, form, handleFilter, handleSelect, knownRoles, rolesAssignableToScope]);
 
   const getModalProps = useCallback((): ModalFuncProps => {
     return {

--- a/webui/react/src/hooks/useModal/Workspace/useModalWorkspaceAddMember.tsx
+++ b/webui/react/src/hooks/useModal/Workspace/useModalWorkspaceAddMember.tsx
@@ -11,7 +11,7 @@ import useModal, { ModalHooks } from 'shared/hooks/useModal/useModal';
 import { DetError, ErrorLevel, ErrorType } from 'shared/utils/error';
 import { User, UserOrGroup } from 'types';
 import handleError from 'utils/error';
-import { getIdFromUserOrGroup, getName, isUser } from 'utils/user';
+import { getAssignableWorkspaceRoles, getIdFromUserOrGroup, getName, isUser } from 'utils/user';
 
 import css from './useModalWorkspaceAddMember.module.scss';
 
@@ -166,7 +166,7 @@ const useModalWorkspaceAddMember = ({
             name="roleId"
             rules={[{ message: 'Role is required ', required: true }]}>
             <Select placeholder="Role">
-              {knownRoles.map((role) => (
+              {getAssignableWorkspaceRoles(knownRoles).map((role) => (
                 <Select.Option key={role.id} value={role.id}>
                   {role.name}
                 </Select.Option>

--- a/webui/react/src/pages/WorkspaceDetails.tsx
+++ b/webui/react/src/pages/WorkspaceDetails.tsx
@@ -130,7 +130,7 @@ const WorkspaceDetails: React.FC = () => {
     } catch (e) {
       handleError(e);
     }
-  }, [canceler.signal]);
+  }, [canceler.signal, id]);
 
   const handleFilterUpdate = (name: string | undefined) => setNameFilter(name);
 
@@ -142,7 +142,13 @@ const WorkspaceDetails: React.FC = () => {
       fetchGroupsAndUsersAssignedToWorkspace(),
       fetchRolesAssignableToScope(),
     ]);
-  }, [fetchWorkspace, fetchGroups, fetchUsers, fetchGroupsAndUsersAssignedToWorkspace]);
+  }, [
+    fetchWorkspace,
+    fetchGroups,
+    fetchUsers,
+    fetchGroupsAndUsersAssignedToWorkspace,
+    fetchRolesAssignableToScope,
+  ]);
 
   usePolling(fetchAll, { rerunOnNewFn: true });
 

--- a/webui/react/src/pages/WorkspaceDetails.tsx
+++ b/webui/react/src/pages/WorkspaceDetails.tsx
@@ -9,8 +9,13 @@ import useFeature from 'hooks/useFeature';
 import { useFetchUsers } from 'hooks/useFetch';
 import usePermissions from 'hooks/usePermissions';
 import { paths } from 'routes/utils';
-import { getGroups, getWorkspace, getWorkspaceMembers } from 'services/api';
-import { V1Group, V1GroupSearchResult, V1RoleWithAssignments } from 'services/api-ts-sdk';
+import {
+  getGroups,
+  getWorkspace,
+  getWorkspaceMembers,
+  searchRolesAssignableToScope,
+} from 'services/api';
+import { V1Group, V1GroupSearchResult, V1Role, V1RoleWithAssignments } from 'services/api-ts-sdk';
 import Message, { MessageType } from 'shared/components/Message';
 import Spinner from 'shared/components/Spinner';
 import usePolling from 'shared/hooks/usePolling';
@@ -53,6 +58,7 @@ const WorkspaceDetails: React.FC = () => {
   const [groupsAssignedDirectlyIds, setGroupsAssignedDirectlyIds] = useState<Set<number>>(
     new Set<number>(),
   );
+  const [rolesAssignableToScope, setRolesAssignableToScope] = useState<V1Role[]>([]);
   /* eslint-disable-next-line @typescript-eslint/no-unused-vars */
   const [nameFilter, setNameFilter] = useState<string>();
   const [workspaceAssignments, setWorkspaceAssignments] = useState<V1RoleWithAssignments[]>([]);
@@ -110,6 +116,22 @@ const WorkspaceDetails: React.FC = () => {
     setWorkspaceAssignments(response.assignments);
   }, [id, mockWorkspaceMembers, nameFilter, rbacEnabled]);
 
+  const fetchRolesAssignableToScope = useCallback(async (): Promise<void> => {
+    try {
+      const response = await searchRolesAssignableToScope(
+        { workspaceId: id },
+        { signal: canceler.signal },
+      );
+
+      setRolesAssignableToScope((prev) => {
+        if (isEqual(prev, response.roles)) return prev;
+        return response.roles || [];
+      });
+    } catch (e) {
+      handleError(e);
+    }
+  }, [canceler.signal]);
+
   const handleFilterUpdate = (name: string | undefined) => setNameFilter(name);
 
   const fetchAll = useCallback(async () => {
@@ -118,6 +140,7 @@ const WorkspaceDetails: React.FC = () => {
       fetchUsers(),
       fetchGroups(),
       fetchGroupsAndUsersAssignedToWorkspace(),
+      fetchRolesAssignableToScope(),
     ]);
   }, [fetchWorkspace, fetchGroups, fetchUsers, fetchGroupsAndUsersAssignedToWorkspace]);
 
@@ -174,6 +197,7 @@ const WorkspaceDetails: React.FC = () => {
         <WorkspaceDetailsHeader
           addableUsersAndGroups={addableUsersAndGroups}
           fetchWorkspace={fetchAll}
+          rolesAssignableToScope={rolesAssignableToScope}
           workspace={workspace}
         />
       }
@@ -188,6 +212,7 @@ const WorkspaceDetails: React.FC = () => {
               assignments={workspaceAssignments}
               groupsAssignedDirectly={groupsAssignedDirectly}
               pageRef={pageRef}
+              rolesAssignableToScope={rolesAssignableToScope}
               usersAssignedDirectly={usersAssignedDirectly}
               workspace={workspace}
               onFilterUpdate={handleFilterUpdate}

--- a/webui/react/src/pages/WorkspaceDetails/RoleRenderer.module.scss
+++ b/webui/react/src/pages/WorkspaceDetails/RoleRenderer.module.scss
@@ -1,0 +1,3 @@
+.base {
+  min-width: 195px;
+}

--- a/webui/react/src/pages/WorkspaceDetails/RoleRenderer.tsx
+++ b/webui/react/src/pages/WorkspaceDetails/RoleRenderer.tsx
@@ -14,7 +14,12 @@ import {
 import { V1RoleWithAssignments } from 'services/api-ts-sdk';
 import { UserOrGroup } from 'types';
 import handleError from 'utils/error';
-import { getAssignedRole, getIdFromUserOrGroup, isUser } from 'utils/user';
+import {
+  getAssignableWorkspaceRoles,
+  getAssignedRole,
+  getIdFromUserOrGroup,
+  isUser,
+} from 'utils/user';
 
 import css from './RoleRenderer.module.scss';
 
@@ -101,7 +106,7 @@ const RoleRenderer: React.FC<Props> = ({
           });
         }
       }}>
-      {knownRoles.map((role) => (
+      {getAssignableWorkspaceRoles(knownRoles).map((role) => (
         <Select.Option key={role.id} value={role.id}>
           {role.name}
         </Select.Option>

--- a/webui/react/src/pages/WorkspaceDetails/RoleRenderer.tsx
+++ b/webui/react/src/pages/WorkspaceDetails/RoleRenderer.tsx
@@ -4,6 +4,7 @@ import { LabelInValueType } from 'rc-select/lib/Select';
 import React, { useState } from 'react';
 
 import { useStore } from 'contexts/Store';
+import useFeature from 'hooks/useFeature';
 import {
   assignRolesToGroup,
   assignRolesToUser,
@@ -32,7 +33,25 @@ const RoleRenderer: React.FC<Props> = ({
 }) => {
   const roleAssignment = getAssignedRole(userOrGroup, assignments);
   const [memberRoleId, setMemberRole] = useState(roleAssignment?.role?.roleId);
-  const { knownRoles } = useStore();
+  let { knownRoles } = useStore();
+
+  const mockWorkspaceMembers = useFeature().isOn('mock_workspace_members');
+
+  knownRoles = mockWorkspaceMembers
+    ? [
+        {
+          id: 1,
+          name: 'Editor',
+          permissions: [],
+        },
+        {
+          id: 2,
+          name: 'Viewer',
+          permissions: [],
+        },
+      ]
+    : knownRoles;
+
   return (
     <Select
       className={css.base}

--- a/webui/react/src/pages/WorkspaceDetails/RoleRenderer.tsx
+++ b/webui/react/src/pages/WorkspaceDetails/RoleRenderer.tsx
@@ -1,0 +1,94 @@
+import { Select } from 'antd';
+import { RawValueType } from 'rc-select/lib/BaseSelect';
+import { LabelInValueType } from 'rc-select/lib/Select';
+import React, { useState } from 'react';
+
+import { useStore } from 'contexts/Store';
+import {
+  assignRolesToGroup,
+  assignRolesToUser,
+  removeRolesFromGroup,
+  removeRolesFromUser,
+} from 'services/api';
+import { V1RoleWithAssignments } from 'services/api-ts-sdk';
+import { UserOrGroup } from 'types';
+import handleError from 'utils/error';
+import { getAssignedRole, getIdFromUserOrGroup, isUser } from 'utils/user';
+
+import css from './RoleRenderer.module.scss';
+
+interface Props {
+  assignments: V1RoleWithAssignments[];
+  userCanAssignRoles: boolean;
+  userOrGroup: UserOrGroup;
+  workspaceId: number;
+}
+
+const RoleRenderer: React.FC<Props> = ({
+  assignments,
+  userOrGroup,
+  userCanAssignRoles,
+  workspaceId,
+}) => {
+  const roleAssignment = getAssignedRole(userOrGroup, assignments);
+  const [memberRoleId, setMemberRole] = useState(roleAssignment?.role?.roleId);
+  const { knownRoles } = useStore();
+  return (
+    <Select
+      className={css.base}
+      disabled={!userCanAssignRoles || !roleAssignment?.scopeWorkspaceId}
+      value={memberRoleId}
+      onSelect={async (value: RawValueType | LabelInValueType) => {
+        const roleIdValue = value as number;
+        const userOrGroupId = getIdFromUserOrGroup(userOrGroup);
+        const oldRoleIds = memberRoleId ? [memberRoleId] : [];
+        try {
+          // Try to remove the old role and then add the new role
+          isUser(userOrGroup)
+            ? await removeRolesFromUser({
+                roleIds: oldRoleIds,
+                scopeWorkspaceId: workspaceId,
+                userId: userOrGroupId,
+              })
+            : await removeRolesFromGroup({
+                groupId: userOrGroupId,
+                roleIds: oldRoleIds,
+                scopeWorkspaceId: workspaceId,
+              });
+          try {
+            isUser(userOrGroup)
+              ? await assignRolesToUser({
+                  roleIds: [roleIdValue],
+                  scopeWorkspaceId: workspaceId,
+                  userId: userOrGroupId,
+                })
+              : await assignRolesToGroup({
+                  groupId: userOrGroupId,
+                  roleIds: [roleIdValue],
+                  scopeWorkspaceId: workspaceId,
+                });
+            setMemberRole(roleIdValue);
+          } catch (addRoleError) {
+            handleError(addRoleError, {
+              publicSubject: 'Unable to update role for user or group unable to add new role.',
+              silent: false,
+            });
+          }
+        } catch (removeRoleError) {
+          handleError(removeRoleError, {
+            publicSubject:
+              'Unable to update role for user or group could unable to remove current role.',
+            silent: false,
+          });
+        }
+      }}>
+      {knownRoles.map((role) => (
+        <Select.Option key={role.id} value={role.id}>
+          {role.name}
+        </Select.Option>
+      ))}
+    </Select>
+  );
+};
+
+export default RoleRenderer;

--- a/webui/react/src/pages/WorkspaceDetails/RoleRenderer.tsx
+++ b/webui/react/src/pages/WorkspaceDetails/RoleRenderer.tsx
@@ -3,7 +3,6 @@ import { RawValueType } from 'rc-select/lib/BaseSelect';
 import { LabelInValueType } from 'rc-select/lib/Select';
 import React, { useState } from 'react';
 
-import { useStore } from 'contexts/Store';
 import useFeature from 'hooks/useFeature';
 import {
   assignRolesToGroup,
@@ -11,20 +10,16 @@ import {
   removeRolesFromGroup,
   removeRolesFromUser,
 } from 'services/api';
-import { V1RoleWithAssignments } from 'services/api-ts-sdk';
+import { V1Role, V1RoleWithAssignments } from 'services/api-ts-sdk';
 import { UserOrGroup } from 'types';
 import handleError from 'utils/error';
-import {
-  getAssignableWorkspaceRoles,
-  getAssignedRole,
-  getIdFromUserOrGroup,
-  isUser,
-} from 'utils/user';
+import { getAssignedRole, getIdFromUserOrGroup, isUser } from 'utils/user';
 
 import css from './RoleRenderer.module.scss';
 
 interface Props {
   assignments: V1RoleWithAssignments[];
+  rolesAssignableToScope: V1Role[];
   userCanAssignRoles: boolean;
   userOrGroup: UserOrGroup;
   workspaceId: number;
@@ -32,27 +27,28 @@ interface Props {
 
 const RoleRenderer: React.FC<Props> = ({
   assignments,
+  rolesAssignableToScope,
   userOrGroup,
   userCanAssignRoles,
   workspaceId,
 }) => {
   const roleAssignment = getAssignedRole(userOrGroup, assignments);
   const [memberRoleId, setMemberRole] = useState(roleAssignment?.role?.roleId);
-  let { knownRoles } = useStore();
+  let knownRoles = rolesAssignableToScope;
 
   const mockWorkspaceMembers = useFeature().isOn('mock_workspace_members');
 
   knownRoles = mockWorkspaceMembers
     ? [
         {
-          id: 1,
           name: 'Editor',
           permissions: [],
+          roleId: 1,
         },
         {
-          id: 2,
           name: 'Viewer',
           permissions: [],
+          roleId: 2,
         },
       ]
     : knownRoles;
@@ -106,8 +102,8 @@ const RoleRenderer: React.FC<Props> = ({
           });
         }
       }}>
-      {getAssignableWorkspaceRoles(knownRoles).map((role) => (
-        <Select.Option key={role.id} value={role.id}>
+      {knownRoles.map((role) => (
+        <Select.Option key={role.roleId} value={role.roleId}>
           {role.name}
         </Select.Option>
       ))}

--- a/webui/react/src/pages/WorkspaceDetails/WorkspaceDetailsHeader.tsx
+++ b/webui/react/src/pages/WorkspaceDetails/WorkspaceDetailsHeader.tsx
@@ -10,6 +10,7 @@ import useModalWorkspaceAddMember from 'hooks/useModal/Workspace/useModalWorkspa
 import usePermissions from 'hooks/usePermissions';
 import WorkspaceActionDropdown from 'pages/WorkspaceList/WorkspaceActionDropdown';
 import { patchWorkspace } from 'services/api';
+import { V1Role } from 'services/api-ts-sdk';
 import Icon from 'shared/components/Icon/Icon';
 import { ErrorLevel, ErrorType } from 'shared/utils/error';
 import { UserOrGroup, Workspace } from 'types';
@@ -20,11 +21,13 @@ import css from './WorkspaceDetailsHeader.module.scss';
 interface Props {
   addableUsersAndGroups: UserOrGroup[];
   fetchWorkspace: () => void;
+  rolesAssignableToScope: V1Role[];
   workspace: Workspace;
 }
 
 const WorkspaceDetailsHeader: React.FC<Props> = ({
   addableUsersAndGroups,
+  rolesAssignableToScope,
   workspace,
   fetchWorkspace,
 }: Props) => {
@@ -37,6 +40,7 @@ const WorkspaceDetailsHeader: React.FC<Props> = ({
   const { contextHolder: workspaceAddMemberContextHolder, modalOpen: openWorkspaceAddMember } =
     useModalWorkspaceAddMember({
       addableUsersAndGroups,
+      rolesAssignableToScope,
       workspaceId: workspace.id,
     });
 

--- a/webui/react/src/pages/WorkspaceDetails/WorkspaceMembers.module.scss
+++ b/webui/react/src/pages/WorkspaceDetails/WorkspaceMembers.module.scss
@@ -23,6 +23,3 @@
 .membersContainer {
   margin-top: 30px;
 }
-.selectContainer {
-  min-width: 195px;
-}

--- a/webui/react/src/pages/WorkspaceDetails/WorkspaceMembers.tsx
+++ b/webui/react/src/pages/WorkspaceDetails/WorkspaceMembers.tsx
@@ -1,6 +1,6 @@
 import { Button, Dropdown, Menu } from 'antd';
 import { FilterDropdownProps } from 'antd/lib/table/interface';
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo } from 'react';
 
 import InteractiveTable, {
   ColumnDef,
@@ -10,7 +10,6 @@ import { getFullPaginationConfig } from 'components/Table/Table';
 import TableFilterSearch from 'components/Table/TableFilterSearch';
 import Avatar from 'components/UserAvatar';
 import useFeature from 'hooks/useFeature';
-import { useFetchKnownRoles } from 'hooks/useFetch';
 import useModalWorkspaceRemoveMember from 'hooks/useModal/Workspace/useModalWorkspaceRemoveMember';
 import usePermissions from 'hooks/usePermissions';
 import useSettings, { UpdateSettings } from 'hooks/useSettings';
@@ -91,15 +90,7 @@ const WorkspaceMembers: React.FC<Props> = ({
   rolesAssignableToScope,
   workspace,
 }: Props) => {
-  const rbacEnabled = useFeature().isOn('rbac');
   const { canUpdateRoles } = usePermissions();
-  const [canceler] = useState(new AbortController());
-  const fetchKnownRoles = useFetchKnownRoles(canceler);
-  useEffect(() => {
-    if (rbacEnabled) {
-      fetchKnownRoles();
-    }
-  }, [fetchKnownRoles, rbacEnabled]);
   const { settings, updateSettings } = useSettings<WorkspaceMembersSettings>(settingsConfig);
   const userCanAssignRoles = canUpdateRoles({ workspace });
 
@@ -287,7 +278,14 @@ const WorkspaceMembers: React.FC<Props> = ({
         title: '',
       },
     ] as ColumnDef<UserOrGroup>[];
-  }, [assignments, nameFilterSearch, tableSearchIcon, userCanAssignRoles, workspace]);
+  }, [
+    assignments,
+    nameFilterSearch,
+    rolesAssignableToScope,
+    tableSearchIcon,
+    userCanAssignRoles,
+    workspace,
+  ]);
 
   return (
     <div className={css.membersContainer}>

--- a/webui/react/src/pages/WorkspaceDetails/WorkspaceMembers.tsx
+++ b/webui/react/src/pages/WorkspaceDetails/WorkspaceMembers.tsx
@@ -104,21 +104,6 @@ const WorkspaceMembers: React.FC<Props> = ({
 
   const mockWorkspaceMembers = useFeature().isOn('mock_workspace_members');
 
-  knownRoles = mockWorkspaceMembers
-    ? [
-        {
-          id: 1,
-          name: 'Editor',
-          permissions: [],
-        },
-        {
-          id: 2,
-          name: 'Viewer',
-          permissions: [],
-        },
-      ]
-    : knownRoles;
-
   const usersAndGroups: UserOrGroup[] = useMemo(
     () =>
       mockWorkspaceMembers

--- a/webui/react/src/pages/WorkspaceDetails/WorkspaceMembers.tsx
+++ b/webui/react/src/pages/WorkspaceDetails/WorkspaceMembers.tsx
@@ -14,7 +14,7 @@ import { useFetchKnownRoles } from 'hooks/useFetch';
 import useModalWorkspaceRemoveMember from 'hooks/useModal/Workspace/useModalWorkspaceRemoveMember';
 import usePermissions from 'hooks/usePermissions';
 import useSettings, { UpdateSettings } from 'hooks/useSettings';
-import { V1Group, V1GroupDetails, V1RoleWithAssignments } from 'services/api-ts-sdk';
+import { V1Group, V1GroupDetails, V1Role, V1RoleWithAssignments } from 'services/api-ts-sdk';
 import { Size } from 'shared/components/Avatar';
 import Icon from 'shared/components/Icon/Icon';
 import { alphaNumericSorter } from 'shared/utils/sort';
@@ -33,6 +33,7 @@ interface Props {
   groupsAssignedDirectly: V1Group[];
   onFilterUpdate: (name: string | undefined) => void;
   pageRef: React.RefObject<HTMLElement>;
+  rolesAssignableToScope: V1Role[];
   usersAssignedDirectly: User[];
   workspace: Workspace;
 }
@@ -87,6 +88,7 @@ const WorkspaceMembers: React.FC<Props> = ({
   usersAssignedDirectly,
   groupsAssignedDirectly,
   pageRef,
+  rolesAssignableToScope,
   workspace,
 }: Props) => {
   const rbacEnabled = useFeature().isOn('rbac');
@@ -98,7 +100,6 @@ const WorkspaceMembers: React.FC<Props> = ({
       fetchKnownRoles();
     }
   }, [fetchKnownRoles, rbacEnabled]);
-
   const { settings, updateSettings } = useSettings<WorkspaceMembersSettings>(settingsConfig);
   const userCanAssignRoles = canUpdateRoles({ workspace });
 
@@ -239,6 +240,7 @@ const WorkspaceMembers: React.FC<Props> = ({
     const roleRenderer = (value: string, record: UserOrGroup) => (
       <RoleRenderer
         assignments={assignments}
+        rolesAssignableToScope={rolesAssignableToScope}
         userCanAssignRoles={userCanAssignRoles}
         userOrGroup={record}
         workspaceId={workspace.id}

--- a/webui/react/src/services/api.ts
+++ b/webui/react/src/services/api.ts
@@ -168,6 +168,11 @@ export const removeRolesFromUser = generateDetApi<
   Api.V1RemoveAssignmentsResponse
 >(Config.removeRolesFromUser);
 
+export const searchRolesAssignableToScope = generateDetApi<
+  Service.SearchRolesAssignableToScopeParams,
+  Api.V1SearchRolesAssignableToScopeResponse,
+  Api.V1SearchRolesAssignableToScopeResponse
+>(Config.searchRolesAssignableToScope);
 /* Info */
 
 export const getInfo = generateDetApi<EmptyParams, Api.V1GetMasterResponse, Type.DeterminedInfo>(

--- a/webui/react/src/services/apiConfig.ts
+++ b/webui/react/src/services/apiConfig.ts
@@ -297,6 +297,8 @@ export const deleteGroup: DetApi<
 
 /* Roles */
 
+const ROLES_LIMIT = 1000;
+
 export const getGroupRoles: DetApi<
   Service.GetGroupParams,
   Api.V1GetRolesAssignedToGroupResponse,
@@ -401,6 +403,21 @@ export const removeRolesFromUser: DetApi<
         },
         userId: params.userId,
       })),
+    }),
+};
+
+export const searchRolesAssignableToScope: DetApi<
+  Service.SearchRolesAssignableToScopeParams,
+  Api.V1SearchRolesAssignableToScopeResponse,
+  Api.V1SearchRolesAssignableToScopeResponse
+> = {
+  name: 'searchRolesAssignableToScope',
+  postProcess: (response) => response,
+  request: (params) =>
+    detApi.RBAC.searchRolesAssignableToScope({
+      limit: params.limit || ROLES_LIMIT,
+      offset: params.offset,
+      workspaceId: params.workspaceId,
     }),
 };
 

--- a/webui/react/src/services/types.ts
+++ b/webui/react/src/services/types.ts
@@ -473,3 +473,9 @@ export type UnpinWorkspaceParams = ArchiveWorkspaceParams;
 export interface GetWebhookParams {
   id: number;
 }
+
+export interface SearchRolesAssignableToScopeParams {
+  limit?: number;
+  offset?: number;
+  workspaceId: number;
+}

--- a/webui/react/src/utils/user.ts
+++ b/webui/react/src/utils/user.ts
@@ -1,4 +1,4 @@
-import { V1Group } from 'services/api-ts-sdk';
+import { V1Group, V1RoleAssignment, V1RoleWithAssignments } from 'services/api-ts-sdk';
 import { DetailedUser, User, UserOrGroup } from 'types';
 
 interface UserNameFields {
@@ -30,4 +30,31 @@ export const getIdFromUserOrGroup = (userOrGroup: UserOrGroup): number => {
 
   // The groupId should always exist
   return group.groupId || 0;
+};
+
+export const getAssignedRole = (
+  record: UserOrGroup,
+  assignments: V1RoleWithAssignments[],
+): V1RoleAssignment | null => {
+  const currentAssignment = assignments.find((aGroup) =>
+    isUser(record)
+      ? !!aGroup?.userRoleAssignments &&
+        !!aGroup.userRoleAssignments.find((a) => a.userId === getIdFromUserOrGroup(record))
+      : !!aGroup?.groupRoleAssignments &&
+        !!aGroup.groupRoleAssignments.find((a) => a.groupId === getIdFromUserOrGroup(record)),
+  );
+  if (isUser(record) && !!record) {
+    if (currentAssignment?.userRoleAssignments) {
+      const myAssignment = currentAssignment.userRoleAssignments.find(
+        (a) => a.userId === getIdFromUserOrGroup(record),
+      );
+      return myAssignment?.roleAssignment || null;
+    }
+  } else if (currentAssignment?.groupRoleAssignments) {
+    const myAssignment = currentAssignment.groupRoleAssignments.find(
+      (a) => a.groupId === getIdFromUserOrGroup(record),
+    );
+    return myAssignment?.roleAssignment || null;
+  }
+  return null;
 };

--- a/webui/react/src/utils/user.ts
+++ b/webui/react/src/utils/user.ts
@@ -1,4 +1,4 @@
-import { V1Group, V1RoleAssignment, V1RoleWithAssignments } from 'services/api-ts-sdk';
+import { V1Group, V1Role, V1RoleAssignment, V1RoleWithAssignments } from 'services/api-ts-sdk';
 import { DetailedUser, User, UserOrGroup, UserRole } from 'types';
 
 interface UserNameFields {
@@ -59,8 +59,11 @@ export const getAssignedRole = (
   return null;
 };
 
-export const getAssignableWorkspaceRoles = (roles: UserRole[]): UserRole[] => {
-  // Global roles are not assignable in a Workspace
-  const globalOnlyRoleNames = ['ClusterAdmin', 'WorkspaceCreator'];
-  return roles.filter((role) => role.name && !globalOnlyRoleNames.includes(role?.name));
+export const getAssignableWorkspaceRoles = (
+  roles: UserRole[],
+  rolesAssignableToScope: V1Role[],
+): UserRole[] => {
+  const validRoleIds = new Set<number>();
+  rolesAssignableToScope.forEach((role) => validRoleIds.add(role.roleId));
+  return roles.filter((role) => validRoleIds.has(role.id));
 };

--- a/webui/react/src/utils/user.ts
+++ b/webui/react/src/utils/user.ts
@@ -1,5 +1,5 @@
 import { V1Group, V1RoleAssignment, V1RoleWithAssignments } from 'services/api-ts-sdk';
-import { DetailedUser, User, UserOrGroup } from 'types';
+import { DetailedUser, User, UserOrGroup, UserRole } from 'types';
 
 interface UserNameFields {
   displayName?: string;
@@ -57,4 +57,10 @@ export const getAssignedRole = (
     return myAssignment?.roleAssignment || null;
   }
   return null;
+};
+
+export const getAssignableWorkspaceRoles = (roles: UserRole[]): UserRole[] => {
+  // Global roles are not assignable in a Workspace
+  const globalOnlyRoleNames = ['ClusterAdmin', 'WorkspaceCreator'];
+  return roles.filter((role) => role.name && !globalOnlyRoleNames.includes(role?.name));
 };


### PR DESCRIPTION
## Description

fix: add and edit workspace member UI [WEB-552]

The ability to add and edit roles was fixed in https://github.com/determined-ai/determined/pull/5322. This PR implements two UI bug fixes. The fixes in this PR:

1. When editing roles the dropdown value would not change until the new assignments were polled. 
2. The "Add Workspace Member" modal would be slow and buggy as well as prematurely show form validation before attempting to submit the form. 
 
Premature form validation: 
https://user-images.githubusercontent.com/103522725/197856615-ef340736-464e-473c-87d2-50e0a90817c9.mov

Role select not updating:
https://user-images.githubusercontent.com/103522725/197856855-1d79450b-fc98-4539-b90b-1df0f0f5073e.mov

## Test Plan


- Setup a determined-ee environment. 
- Log in and create a workspace. 
- Click the "Add Members" button
    - Without filling in any form information click "Add Member". Ensure that the form validation errors pop up for both the Role and User or Group field. 
    -  Close the form
- Click the "Add Members" button
     - Choose a User or choose a Role and ensure that no form validation occurs and no errors or shown
     - Attempt to submit the form when only selecting one value and ensure that form validation occurs and you are not able to submit the form with missing information.
 - Add a Member to the workspace 
    - Change the members role, ensure that the dropdown value reflects the updated role. 
- Ensure that the `ClusterAdmin` and `WorkspaceCreator` roles are not options in the "Role" dropdown.


<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions about this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

Some general refactoring was done to simplify the `WorkspaceMembers` component.  

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist
- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
~- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.~
~- [ ] Licenses should be included for new code which was copied and/or modified from any external code.~


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[WEB-552]: https://determinedai.atlassian.net/browse/WEB-552?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ