### PR TITLE
feat: when user can't create workspaces, show a disabled button [WEB-553]

### DIFF
--- a/webui/react/src/pages/WorkspaceList.module.scss
+++ b/webui/react/src/pages/WorkspaceList.module.scss
@@ -6,6 +6,9 @@
     justify-content: space-between;
     margin-bottom: 16px;
   }
+  .disableOverride[disabled] {
+    cursor: default;
+  }
   .emptyBase {
     margin-inline: auto;
     margin-top: 150px;

--- a/webui/react/src/pages/WorkspaceList.tsx
+++ b/webui/react/src/pages/WorkspaceList.tsx
@@ -320,9 +320,9 @@ const WorkspaceList: React.FC = () => {
       containerRef={pageRef}
       id="workspaces"
       options={
-        canCreateWorkspace ? (
-          <Button onClick={handleWorkspaceCreateClick}>New Workspace</Button>
-        ) : null
+        <Button disabled={!canCreateWorkspace} onClick={handleWorkspaceCreateClick}>
+          New Workspace
+        </Button>
       }
       title="Workspaces">
       <div className={css.controls}>

--- a/webui/react/src/pages/WorkspaceList.tsx
+++ b/webui/react/src/pages/WorkspaceList.tsx
@@ -320,7 +320,11 @@ const WorkspaceList: React.FC = () => {
       containerRef={pageRef}
       id="workspaces"
       options={
-        <Button disabled={!canCreateWorkspace} onClick={handleWorkspaceCreateClick}>
+        <Button
+          className={css.disableOverride}
+          disabled={!canCreateWorkspace}
+          title={canCreateWorkspace ? undefined : 'User lacks permission to create workspace'}
+          onClick={handleWorkspaceCreateClick}>
           New Workspace
         </Button>
       }


### PR DESCRIPTION
## Description

There are two places where a user can create a workspace:
- a small + button in the left nav
- a 'New Workspace' button in the top right of `/det/workspaces`

I'm interpreting WEB-553 as: the button on `/det/workspaces` should be visible, disabled, and have a title text. (we cannot use an `antd.Tooltip` on a disabled component per https://github.com/ant-design/ant-design/issues/27118 ).

I still hide the + button because when disabled, it's very visible and more confusing (screenshot)
<img width="245" alt="Screen Shot 2022-10-26 at 10 26 18 AM" src="https://user-images.githubusercontent.com/643918/198068662-a826b906-085a-4b53-9c37-d9fcd873421d.png">


## Test Plan

On `/det/workspaces`,
- click the + button on the left nav to open a New Workspace modal
- click the 'New Workspace' button on the top right to open the New Workspace modal

With `/det/workspaces?f_rbac=on`, or with a user missing create workspace permission
- the + button on nav is hidden
- 'New Workspace' button is disabled
- hovering mouse on 'New Workspace' button gets the text 'User lacks permission to create workspace'

## Checklist
- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.