### PR TITLE
fix: fix assignable roll polling in non rbac instances

### DIFF
--- a/webui/react/src/pages/WorkspaceDetails.tsx
+++ b/webui/react/src/pages/WorkspaceDetails.tsx
@@ -117,6 +117,8 @@ const WorkspaceDetails: React.FC = () => {
   }, [id, mockWorkspaceMembers, nameFilter, rbacEnabled]);
 
   const fetchRolesAssignableToScope = useCallback(async (): Promise<void> => {
+    // Only fetch roles if rbac is enabled.
+    if (!rbacEnabled) return;
     try {
       const response = await searchRolesAssignableToScope(
         { workspaceId: id },


### PR DESCRIPTION
## Description

fix: fix assignable roll polling in non rbac instances

context: https://determined-ai.slack.com/archives/C03LE5Z8R46/p1666881816852669

In non rbac instances the `searchRolesAssignableToScope` API is not available. This PR makes the `fetchRolesAssignableToScope` method a no-op is rbac is not enabled. 

<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At a minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan

1. Navigate to the a workspace details page in the UI. Ensure that you do not see an error that  `searchRolesAssignableToScope failed`.
2. Navigate to the same page but include the rbac feature flag `f_rbac=on` look at the Network tab of your browsers developer tools and look for a failed call to `/api/v1/roles/search/by-assignability` which should return a 501. This confirms the call is made in `rbac` is enabled. 

<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions about this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist
- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
