### PR TITLE
fix: FOUNDENG-303 Pausing, then resuming an experiment fails

### DIFF
--- a/e2e_tests/tests/experiment/test_noop.py
+++ b/e2e_tests/tests/experiment/test_noop.py
@@ -1,5 +1,4 @@
 import copy
-import logging
 import os
 import shutil
 import tempfile

--- a/e2e_tests/tests/experiment/test_noop.py
+++ b/e2e_tests/tests/experiment/test_noop.py
@@ -441,15 +441,18 @@ def remove_item_from_yaml_file(filename: str, item_name: str) -> str:
 
         del data[item_name]
 
-    with tempfile.NamedTemporaryFile(
-        prefix=os.path.splitext(os.path.basename(filename))[0], delete=False
-    ) as f:
-        y.dump(data, f)
+    # Create a temporary file that looks something like
+    # ${TMPDIR}/single-medium-train-step_axh4946j.yaml
+    tmpFile = tempfile.NamedTemporaryFile(
+        prefix=os.path.splitext(os.path.basename(filename))[0] + "_", suffix=".yaml", delete=False
+    )
 
-    return str(f.name)
+    y.dump(data, tmpFile)
+
+    return tmpFile.name
 
 
-def has_at_least_one_checkpoint(exp_id: int) -> None:
+def has_at_least_one_checkpoint(exp_id: int) -> bool:
     trials = exp.experiment_trials(exp_id)
 
     # Check if the most recent trial has any checkpoints.
@@ -462,7 +465,7 @@ def has_at_least_one_checkpoint(exp_id: int) -> None:
     return False
 
 
-def wait_for_at_least_one_checkpoint(experiment_id: str):
+def wait_for_at_least_one_checkpoint(experiment_id: int) -> None:
 
     for _ in range(20):
         if has_at_least_one_checkpoint(experiment_id):

--- a/e2e_tests/tests/experiment/test_noop.py
+++ b/e2e_tests/tests/experiment/test_noop.py
@@ -467,7 +467,6 @@ def wait_for_at_least_one_checkpoint(experiment_id: str):
 
     for _ in range(20):
         if has_at_least_one_checkpoint(experiment_id):
-            logging.info(f"At least one checkpoint reported. Continuing to pause the experiment.")
             break
         else:
             time.sleep(1)


### PR DESCRIPTION
## Description

For HPC, we need to remove the "checkpoint_storage" item from the experiment's configuration file, because it sets "host_path" to "/tmp", which is not desirable on HPC clusters for the following two reasons:
   
    1. The "storage_path:" directory, which is set to
        "determined-integration-checkpoints" in the configuration file,
        disappears as soon as the experiment is paused. Don't know the
        reason why it disappears, but it only happens if "host_path" is
        set to "/tmp".  This causes the "activate" to fail, because it
        cannot find the checkpoints from the previously paused experiment.
    
    2. On HPC clusters, there is no guarantee that when the experiment is
        "activated" after it has been paused, that the Workload Manager
        (e.g., Slurm, PBS) is going to pick the same node that the job ran on
        when it was paused.  If it picks a different node and "host_path" is
        is not a shared directory, then the new node on which the job is
        restarted on will not have access to the checkpoint directory.
        This will cause the experiment to fail, because it cannot find the
        checkpoints from the previously paused experiment.
    
For e2e_tests targeted to HPC clusters, the "master.yaml" file will have a "checkpoint_storage' with a "host_path" that points to a shared directory on the cluster that is accessible by all the compute nodes. Therefore, by removing the "checkpoint_storage" item from experiment's configuration file, the test will use the "checkpoint_storage" item from
the "master.yaml".

## Test Plan

We can see in the experiment logs that the "host_path" is taken from the master.yaml, not the experiment's configuration file.

```
"checkpoint_storage": {"host_path": "/mnt/lustre/foundation_engineering/determined-cp", "propagation": "rprivate", "save_experiment_best": 0, "save_trial_best": 1, "save_trial_latest": 1, "storage_path": null, "type": "shared_fs"}
```

The test passes.

```
(base) rcorujo@C02FJ0T8MD6Q e2e_tests % PYTHONPATH=/Users/rcorujo/IdeaProjects/DETERMINED-EE3/determined-ee/harness pytest -m e2e_slurm -vvv --durations=0 --master-host="127.0.0.1" --master-port="8081" -k "test_noop_pause"
======================================================================================================================================== test session starts ========================================================================================================================================
platform darwin -- Python 3.9.5, pytest-7.1.2, pluggy-1.0.0 -- /Users/rcorujo/opt/miniconda3/bin/python
cachedir: .pytest_cache
rootdir: /Users/rcorujo/IdeaProjects/DETERMINED-EE3/determined-ee/e2e_tests, configfile: pytest.ini
plugins: timeout-2.1.0, requests-mock-1.9.3
collected 397 items / 396 deselected / 1 selected                                                                                                                                                                                                                                                   

tests/experiment/test_noop.py::test_noop_pause_slurm PASSED                                                                                                                                                                                                                                   [100%]

========================================================================================================================================= warnings summary ==========================================================================================================================================
../../../../opt/miniconda3/lib/python3.9/site-packages/hdfs/config.py:15
  /Users/rcorujo/opt/miniconda3/lib/python3.9/site-packages/hdfs/config.py:15: DeprecationWarning: the imp module is deprecated in favour of importlib; see the module's documentation for alternative uses
    from imp import load_source

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
========================================================================================================================================= slowest durations =========================================================================================================================================
92.39s call     tests/experiment/test_noop.py::test_noop_pause_slurm
1.88s teardown tests/experiment/test_noop.py::test_noop_pause_slurm
0.62s setup    tests/experiment/test_noop.py::test_noop_pause_slurm
===================================================================================================================== 1 passed, 396 deselected, 1 warning in 102.97s (0:01:42) ======================================================================================================================
```

## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist
- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
