### PR TITLE
chore: Move Agents into their own context, introduce Loadable abstraction

### DIFF
--- a/webui/react/src/App.tsx
+++ b/webui/react/src/App.tsx
@@ -22,6 +22,7 @@ import appRoutes from 'routes';
 import { paths, serverAddress } from 'routes/utils';
 import Spinner from 'shared/components/Spinner/Spinner';
 import usePolling from 'shared/hooks/usePolling';
+import { AgentsProvider } from 'stores/agents';
 import { correctViewportHeight, refreshPage } from 'utils/browser';
 
 import css from './App.module.scss';
@@ -148,9 +149,11 @@ const App: React.FC = () => {
   return (
     <HelmetProvider>
       <StoreProvider>
-        <DndProvider backend={HTML5Backend}>
-          <AppView />
-        </DndProvider>
+        <AgentsProvider>
+          <DndProvider backend={HTML5Backend}>
+            <AppView />
+          </DndProvider>
+        </AgentsProvider>
       </StoreProvider>
     </HelmetProvider>
   );

--- a/webui/react/src/components/Navigation.tsx
+++ b/webui/react/src/components/Navigation.tsx
@@ -11,7 +11,7 @@ import {
 import Spinner from 'shared/components/Spinner/Spinner';
 import useUI from 'shared/contexts/stores/UI';
 import usePolling from 'shared/hooks/usePolling';
-import { initClusterOverview, useClusterOverview, useFetchAgents } from 'stores/agents';
+import { useClusterOverview, useFetchAgents } from 'stores/agents';
 import { BrandingType, ResourceType } from 'types';
 import { updateFaviconType } from 'utils/browser';
 import { Loadable } from 'utils/loadable';
@@ -28,7 +28,7 @@ const Navigation: React.FC<Props> = ({ children }) => {
   const { ui } = useUI();
   const { info } = useStore();
   const [canceler] = useState(new AbortController());
-  const overview = Loadable.getOrElse(initClusterOverview, useClusterOverview());
+  const overview = useClusterOverview();
 
   const fetchAgents = useFetchAgents(canceler);
   const fetchResourcePools = useFetchResourcePools(canceler);
@@ -42,7 +42,7 @@ const Navigation: React.FC<Props> = ({ children }) => {
 
   useEffect(() => {
     updateFaviconType(
-      overview[ResourceType.ALL].allocation !== 0,
+      Loadable.quickMatch(overview, false, (o) => o[ResourceType.ALL].allocation !== 0),
       info.branding || BrandingType.Determined,
     );
   }, [overview, info]);

--- a/webui/react/src/components/Navigation.tsx
+++ b/webui/react/src/components/Navigation.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 
+import { useStore } from 'contexts/Store';
 import useFeature from 'hooks/useFeature';
 import {
   useFetchMyRoles,

--- a/webui/react/src/components/NavigationSideBar.tsx
+++ b/webui/react/src/components/NavigationSideBar.tsx
@@ -18,7 +18,9 @@ import WorkspaceActionDropdown from 'pages/WorkspaceList/WorkspaceActionDropdown
 import { paths } from 'routes/utils';
 import Icon from 'shared/components/Icon/Icon';
 import useUI from 'shared/contexts/stores/UI';
+import { initClusterOverview, useAgents, useClusterOverview } from 'stores/agents';
 import { BrandingType } from 'types';
+import { Loadable } from 'utils/loadable';
 
 import css from './NavigationSideBar.module.scss';
 import ThemeToggle from './ThemeToggle';
@@ -106,7 +108,11 @@ export const NavigationItem: React.FC<ItemProps> = ({
 const NavigationSideBar: React.FC = () => {
   // `nodeRef` padding is required for CSSTransition to work with React.StrictMode.
   const nodeRef = useRef(null);
-  const { agents, auth, cluster: overview, resourcePools, info, pinnedWorkspaces } = useStore();
+  // TODO: handle loading state
+  const agents = Loadable.getOrElse([], useAgents());
+  const overview = Loadable.getOrElse(initClusterOverview, useClusterOverview());
+
+  const { auth, resourcePools, info, pinnedWorkspaces } = useStore();
   const { ui } = useUI();
   const { settings, updateSettings } = useSettings<Settings>(settingsConfig);
   const { contextHolder: modalJupyterLabContextHolder, modalOpen: openJupyterLabModal } =

--- a/webui/react/src/components/NavigationSideBar.tsx
+++ b/webui/react/src/components/NavigationSideBar.tsx
@@ -18,7 +18,7 @@ import WorkspaceActionDropdown from 'pages/WorkspaceList/WorkspaceActionDropdown
 import { paths } from 'routes/utils';
 import Icon from 'shared/components/Icon/Icon';
 import useUI from 'shared/contexts/stores/UI';
-import { initClusterOverview, useAgents, useClusterOverview } from 'stores/agents';
+import { useAgents, useClusterOverview } from 'stores/agents';
 import { BrandingType } from 'types';
 import { Loadable } from 'utils/loadable';
 
@@ -108,12 +108,16 @@ export const NavigationItem: React.FC<ItemProps> = ({
 const NavigationSideBar: React.FC = () => {
   // `nodeRef` padding is required for CSSTransition to work with React.StrictMode.
   const nodeRef = useRef(null);
-  // TODO: handle loading state
-  const agents = Loadable.getOrElse([], useAgents());
-  const overview = Loadable.getOrElse(initClusterOverview, useClusterOverview());
 
   const { auth, resourcePools, info, pinnedWorkspaces } = useStore();
   const { ui } = useUI();
+  const agents = useAgents();
+  const overview = useClusterOverview();
+  const clusterStatus = Loadable.match(Loadable.all([agents, overview]), {
+    Loaded: ([agents, overview]) => clusterStatusText(overview, resourcePools, agents),
+    NotLoaded: () => undefined, // TODO show spinner when this is loading
+  });
+
   const { settings, updateSettings } = useSettings<Settings>(settingsConfig);
   const { contextHolder: modalJupyterLabContextHolder, modalOpen: openJupyterLabModal } =
     useModalJupyterLab();
@@ -232,11 +236,7 @@ const NavigationSideBar: React.FC = () => {
             {menuConfig.top.map((config) => (
               <NavigationItem
                 key={config.icon}
-                status={
-                  config.icon === 'cluster'
-                    ? clusterStatusText(overview, resourcePools, agents)
-                    : undefined
-                }
+                status={config.icon === 'cluster' ? clusterStatus : undefined}
                 tooltip={settings.navbarCollapsed}
                 {...config}
               />

--- a/webui/react/src/components/NavigationTabbar.tsx
+++ b/webui/react/src/components/NavigationTabbar.tsx
@@ -43,7 +43,7 @@ const ToolbarItem: React.FC<ToolbarItemProps> = ({ path, status, ...props }: Too
 };
 
 const NavigationTabbar: React.FC = () => {
-  const { auth resourcePools, info, pinnedWorkspaces } = useStore();
+  const { auth, resourcePools, info, pinnedWorkspaces } = useStore();
   const { ui } = useUI();
   const overview = Loadable.getOrElse(initClusterOverview, useClusterOverview());
   // TODO: handle loading state

--- a/webui/react/src/components/NavigationTabbar.tsx
+++ b/webui/react/src/components/NavigationTabbar.tsx
@@ -12,7 +12,9 @@ import { handlePath, paths } from 'routes/utils';
 import Icon from 'shared/components/Icon/Icon';
 import useUI from 'shared/contexts/stores/UI';
 import { AnyMouseEvent, routeToReactUrl } from 'shared/utils/routes';
+import { initClusterOverview, useAgents, useClusterOverview } from 'stores/agents';
 import { BrandingType } from 'types';
+import { Loadable } from 'utils/loadable';
 
 import css from './NavigationTabbar.module.scss';
 
@@ -41,8 +43,11 @@ const ToolbarItem: React.FC<ToolbarItemProps> = ({ path, status, ...props }: Too
 };
 
 const NavigationTabbar: React.FC = () => {
-  const { agents, auth, cluster: overview, resourcePools, info, pinnedWorkspaces } = useStore();
+  const { auth resourcePools, info, pinnedWorkspaces } = useStore();
   const { ui } = useUI();
+  const overview = Loadable.getOrElse(initClusterOverview, useClusterOverview());
+  // TODO: handle loading state
+  const agents = Loadable.getOrElse([], useAgents());
   const [isShowingOverflow, setIsShowingOverflow] = useState(false);
   const [isShowingPinnedWorkspaces, setIsShowingPinnedWorkspaces] = useState(false);
   const { contextHolder: modalJupyterLabContextHolder, modalOpen: openJupyterLabModal } =

--- a/webui/react/src/components/NavigationTabbar.tsx
+++ b/webui/react/src/components/NavigationTabbar.tsx
@@ -12,7 +12,7 @@ import { handlePath, paths } from 'routes/utils';
 import Icon from 'shared/components/Icon/Icon';
 import useUI from 'shared/contexts/stores/UI';
 import { AnyMouseEvent, routeToReactUrl } from 'shared/utils/routes';
-import { initClusterOverview, useAgents, useClusterOverview } from 'stores/agents';
+import { useAgents, useClusterOverview } from 'stores/agents';
 import { BrandingType } from 'types';
 import { Loadable } from 'utils/loadable';
 
@@ -45,9 +45,12 @@ const ToolbarItem: React.FC<ToolbarItemProps> = ({ path, status, ...props }: Too
 const NavigationTabbar: React.FC = () => {
   const { auth, resourcePools, info, pinnedWorkspaces } = useStore();
   const { ui } = useUI();
-  const overview = Loadable.getOrElse(initClusterOverview, useClusterOverview());
-  // TODO: handle loading state
-  const agents = Loadable.getOrElse([], useAgents());
+  const overview = useClusterOverview();
+  const agents = useAgents();
+  const clusterStatus = Loadable.match(Loadable.all([agents, overview]), {
+    Loaded: ([agents, overview]) => clusterStatusText(overview, resourcePools, agents),
+    NotLoaded: () => undefined, // TODO show spinner when this is loading
+  });
   const [isShowingOverflow, setIsShowingOverflow] = useState(false);
   const [isShowingPinnedWorkspaces, setIsShowingPinnedWorkspaces] = useState(false);
   const { contextHolder: modalJupyterLabContextHolder, modalOpen: openJupyterLabModal } =
@@ -86,12 +89,7 @@ const NavigationTabbar: React.FC = () => {
         <ToolbarItem icon="experiment" label="Uncategorized" path={paths.uncategorized()} />
         <ToolbarItem icon="model" label="Model Registry" path={paths.modelList()} />
         <ToolbarItem icon="tasks" label="Tasks" path={paths.taskList()} />
-        <ToolbarItem
-          icon="cluster"
-          label="Cluster"
-          path={paths.cluster()}
-          status={clusterStatusText(overview, resourcePools, agents)}
-        />
+        <ToolbarItem icon="cluster" label="Cluster" path={paths.cluster()} status={clusterStatus} />
         <ToolbarItem icon="workspaces" label="Workspaces" onClick={handleWorkspacesOpen} />
         <ToolbarItem icon="overflow-vertical" label="Overflow Menu" onClick={handleOverflowOpen} />
       </div>

--- a/webui/react/src/components/ResourcePoolCard.test.tsx
+++ b/webui/react/src/components/ResourcePoolCard.test.tsx
@@ -1,5 +1,5 @@
-import { render } from '@testing-library/react';
-import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import React, { Suspense } from 'react';
 
 import StoreProvider from 'contexts/Store';
 import resourcePools from 'fixtures/responses/cluster/resource-pools.json';
@@ -9,19 +9,26 @@ import { RenderAllocationBarResourcePool } from './ResourcePoolCard';
 
 const rps = resourcePools as unknown as ResourcePool[];
 
+jest.mock('services/api', () => ({
+  getAgents: jest.fn().mockReturnValue({ agents: [] }),
+}));
+
 const setup = (pool: ResourcePool) => {
   const view = render(
     <StoreProvider>
-      <RenderAllocationBarResourcePool resourcePool={pool} />
+      <Suspense>
+        <RenderAllocationBarResourcePool resourcePool={pool} />
+      </Suspense>
     </StoreProvider>,
   );
   return { view };
 };
 
 describe('AllocationBarResourcePool', () => {
-  it('displays resource pool slot allocation bar ', () => {
-    rps.forEach((pool) => {
+  it('displays resource pool slot allocation bar ', async () => {
+    await rps.forEach(async (pool) => {
       const { view } = setup(pool);
+      await waitFor(() => expect(screen.getByText('Allocated')).toBeInTheDocument());
       expect(view.getAllByText('Allocated', { exact: false }).length).toBeGreaterThan(0);
     });
   });

--- a/webui/react/src/components/ResourcePoolCard.tsx
+++ b/webui/react/src/components/ResourcePoolCard.tsx
@@ -1,17 +1,16 @@
-import React, { useMemo } from 'react';
+import React, { Suspense, useMemo } from 'react';
 
 import SlotAllocationBar from 'components/SlotAllocationBar';
 import { V1ResourcePoolTypeToLabel, V1SchedulerTypeToLabel } from 'constants/states';
-import { useStore } from 'contexts/Store';
 import { maxPoolSlotCapacity } from 'pages/Clusters/ClustersOverview';
-import { V1RPQueueStat } from 'services/api-ts-sdk';
-import { V1ResourcePoolType, V1SchedulerType } from 'services/api-ts-sdk';
+import { V1ResourcePoolType, V1RPQueueStat, V1SchedulerType } from 'services/api-ts-sdk';
 import awsLogoOnDark from 'shared/assets/images/aws-logo-on-dark.svg';
 import awsLogo from 'shared/assets/images/aws-logo.svg';
 import gcpLogo from 'shared/assets/images/gcp-logo.svg';
 import k8sLogo from 'shared/assets/images/k8s-logo.svg';
 import staticLogo from 'shared/assets/images/on-prem-logo.svg';
 import Icon from 'shared/components/Icon/Icon';
+import Spinner from 'shared/components/Spinner';
 import useUI from 'shared/contexts/stores/UI';
 import { DarkLight } from 'shared/themes';
 import { clone } from 'shared/utils/data';
@@ -127,13 +126,15 @@ const ResourcePoolCard: React.FC<Props> = ({ resourcePool: pool }: Props) => {
           {pool.description && <Icon name="info" title={pool.description} />}
         </div>
       </div>
-      <div className={css.body}>
-        <RenderAllocationBarResourcePool resourcePool={pool} size={ShirtSize.Medium} />
-        <section className={css.details}>
-          <Json hideDivider json={shortDetails} />
-        </section>
-        <div />
-      </div>
+      <Suspense fallback={<Spinner center />}>
+        <div className={css.body}>
+          <RenderAllocationBarResourcePool resourcePool={pool} size={ShirtSize.Medium} />
+          <section className={css.details}>
+            <Json hideDivider json={shortDetails} />
+          </section>
+          <div />
+        </div>
+      </Suspense>
     </div>
   );
 };
@@ -143,8 +144,7 @@ export const RenderAllocationBarResourcePool: React.FC<Props> = ({
   resourcePool: pool,
   size = ShirtSize.Large,
 }: Props) => {
-  // TODO: handle loading state
-  const agents = Loadable.getOrElse([], useAgents());
+  const agents = Loadable.waitFor(useAgents());
   const isAux = useMemo(() => {
     return pool.auxContainerCapacityPerAgent > 0;
   }, [pool]);

--- a/webui/react/src/components/ResourcePoolCard.tsx
+++ b/webui/react/src/components/ResourcePoolCard.tsx
@@ -15,9 +15,11 @@ import Icon from 'shared/components/Icon/Icon';
 import useUI from 'shared/contexts/stores/UI';
 import { DarkLight } from 'shared/themes';
 import { clone } from 'shared/utils/data';
+import { useAgents } from 'stores/agents';
 import { ShirtSize } from 'themes';
 import { isDeviceType, ResourcePool } from 'types';
 import { getSlotContainerStates } from 'utils/cluster';
+import { Loadable } from 'utils/loadable';
 
 import Json from './Json';
 import css from './ResourcePoolCard.module.scss';
@@ -141,7 +143,8 @@ export const RenderAllocationBarResourcePool: React.FC<Props> = ({
   resourcePool: pool,
   size = ShirtSize.Large,
 }: Props) => {
-  const { agents } = useStore();
+  // TODO: handle loading state
+  const agents = Loadable.getOrElse([], useAgents());
   const isAux = useMemo(() => {
     return pool.auxContainerCapacityPerAgent > 0;
   }, [pool]);

--- a/webui/react/src/contexts/Store.tsx
+++ b/webui/react/src/contexts/Store.tsx
@@ -5,18 +5,12 @@ import { V1UserWebSetting } from 'services/api-ts-sdk';
 import { StoreProvider as UIStoreProvider } from 'shared/contexts/stores/UI';
 import { clone, isEqual } from 'shared/utils/data';
 import rootLogger from 'shared/utils/Logger';
-import { percent } from 'shared/utils/number';
 import { checkDeepEquality } from 'shared/utils/store';
 import {
-  Agent,
   Auth,
-  ClusterOverview,
-  ClusterOverviewResource,
   DetailedUser,
   DeterminedInfo,
-  PoolOverview,
   ResourcePool,
-  ResourceType,
   UserAssignment,
   UserRole,
   Workspace,
@@ -41,13 +35,13 @@ interface State {
     shells: number;
     tensorboards: number;
   };
-  agents: Agent[];
+
   auth: Auth & { checked: boolean };
-  cluster: ClusterOverview;
+
   info: DeterminedInfo;
   knownRoles: UserRole[];
   pinnedWorkspaces: Workspace[];
-  pool: PoolOverview;
+
   resourcePools: ResourcePool[];
   ui: {
     omnibar: OmnibarState;
@@ -63,7 +57,6 @@ export const StoreAction = {
   HideOmnibar: 'HideOmnibar',
 
   Reset: 'Reset',
-
   // Auth
   ResetAuth: 'ResetAuth',
 
@@ -111,7 +104,6 @@ export const StoreAction = {
 
 type Action =
   | { type: typeof StoreAction.Reset }
-  | { type: typeof StoreAction.SetAgents; value: Agent[] }
   | { type: typeof StoreAction.ResetAuth }
   | { type: typeof StoreAction.ResetAuthCheck }
   | { type: typeof StoreAction.SetAuth; value: Auth }
@@ -145,14 +137,6 @@ const initAuth = {
   checked: false,
   isAuthenticated: false,
 };
-const initResourceTally: ClusterOverviewResource = { allocation: 0, available: 0, total: 0 };
-const initClusterOverview: ClusterOverview = {
-  [ResourceType.CPU]: clone(initResourceTally),
-  [ResourceType.CUDA]: clone(initResourceTally),
-  [ResourceType.ROCM]: clone(initResourceTally),
-  [ResourceType.ALL]: clone(initResourceTally),
-  [ResourceType.UNSPECIFIED]: clone(initResourceTally),
-};
 export const initInfo: DeterminedInfo = {
   branding: undefined,
   checked: false,
@@ -173,13 +157,10 @@ const initState: State = {
     shells: 0,
     tensorboards: 0,
   },
-  agents: [],
   auth: initAuth,
-  cluster: initClusterOverview,
   info: initInfo,
   knownRoles: [],
   pinnedWorkspaces: [],
-  pool: {},
   resourcePools: [],
   ui: { omnibar: { isShowing: false } }, // TODO move down a level
   userAssignments: [],
@@ -209,71 +190,11 @@ const ensureAuthCookieSet = (token: string): void => {
   if (!getCookie(AUTH_COOKIE_KEY)) setCookie(AUTH_COOKIE_KEY, token);
 };
 
-export const agentsToOverview = (agents: Agent[]): ClusterOverview => {
-  // Deep clone for render detection.
-  const overview: ClusterOverview = clone(initClusterOverview);
-
-  agents.forEach((agent) => {
-    agent.resources
-      .filter((resource) => resource.enabled)
-      .forEach((resource) => {
-        const isResourceFree = resource.container == null;
-        const availableResource = isResourceFree ? 1 : 0;
-        overview[resource.type].available += availableResource;
-        overview[resource.type].total++;
-        overview[ResourceType.ALL].available += availableResource;
-        overview[ResourceType.ALL].total++;
-      });
-  });
-
-  for (const key in overview) {
-    const rt = key as ResourceType;
-    overview[rt].allocation =
-      overview[rt].total !== 0
-        ? percent((overview[rt].total - overview[rt].available) / overview[rt].total)
-        : 0;
-  }
-
-  return overview;
-};
-
-export const agentsToPoolOverview = (agents: Agent[]): PoolOverview => {
-  const overview: PoolOverview = {};
-  agents.forEach((agent) => {
-    agent.resourcePools.forEach((pname) => {
-      overview[pname] = clone(initResourceTally);
-      agent.resources
-        .filter((resource) => resource.enabled)
-        .forEach((resource) => {
-          const isResourceFree = resource.container == null;
-          const availableResource = isResourceFree ? 1 : 0;
-          overview[pname].available += availableResource;
-          overview[pname].total += 1;
-        });
-    });
-  });
-
-  for (const key in overview) {
-    overview[key].allocation =
-      overview[key].total !== 0
-        ? percent((overview[key].total - overview[key].available) / overview[key].total)
-        : 0;
-  }
-
-  return overview;
-};
-
 // TODO turn this into a partial reducer simliar to reducerUI.
 const reducer = (state: State, action: Action): State => {
   switch (action.type) {
     case StoreAction.Reset:
       return clone(initState) as State;
-    case StoreAction.SetAgents: {
-      if (isEqual(state.agents, action.value)) return state;
-      const cluster = agentsToOverview(action.value);
-      const pool = agentsToPoolOverview(action.value);
-      return { ...state, agents: action.value, cluster, pool };
-    }
     case StoreAction.ResetAuth:
       clearAuthCookie();
       globalStorage.removeAuthToken();

--- a/webui/react/src/hooks/useFetch.ts
+++ b/webui/react/src/hooks/useFetch.ts
@@ -1,10 +1,9 @@
 import { useCallback } from 'react';
 
 import { activeRunStates } from 'constants/states';
-import { agentsToOverview, StoreAction, useStore, useStoreDispatch } from 'contexts/Store';
+import { StoreAction, useStoreDispatch } from 'contexts/Store';
 import {
   getActiveTasks,
-  getAgents,
   getExperiments,
   getInfo,
   getPermissionsSummary,
@@ -15,8 +14,6 @@ import {
   listRoles,
 } from 'services/api';
 import { ErrorType } from 'shared/utils/error';
-import { BrandingType, ResourceType } from 'types';
-import { updateFaviconType } from 'utils/browser';
 import handleError from 'utils/error';
 
 export const useFetchActiveExperiments = (canceler: AbortController): (() => Promise<void>) => {
@@ -40,25 +37,6 @@ export const useFetchActiveExperiments = (canceler: AbortController): (() => Pro
       });
     }
   }, [canceler, storeDispatch]);
-};
-
-export const useFetchAgents = (canceler: AbortController): (() => Promise<void>) => {
-  const { info } = useStore();
-  const storeDispatch = useStoreDispatch();
-
-  return useCallback(async (): Promise<void> => {
-    try {
-      const response = await getAgents({ signal: canceler.signal });
-      const cluster = agentsToOverview(response);
-      storeDispatch({ type: StoreAction.SetAgents, value: response });
-      updateFaviconType(
-        cluster[ResourceType.ALL].allocation !== 0,
-        info.branding || BrandingType.Determined,
-      );
-    } catch (e) {
-      handleError(e);
-    }
-  }, [canceler, info.branding, storeDispatch]);
 };
 
 export const useFetchInfo = (canceler: AbortController): (() => Promise<void>) => {

--- a/webui/react/src/pages/Cluster/ClusterOverallBar.tsx
+++ b/webui/react/src/pages/Cluster/ClusterOverallBar.tsx
@@ -2,14 +2,17 @@ import React, { useMemo } from 'react';
 
 import Section from 'components/Section';
 import SlotAllocationBar from 'components/SlotAllocationBar';
-import { useStore } from 'contexts/Store';
 import Message, { MessageType } from 'shared/components/Message';
+import { initClusterOverview, useAgents, useClusterOverview } from 'stores/agents';
 import { ShirtSize } from 'themes';
 import { ResourceType } from 'types';
 import { getSlotContainerStates } from 'utils/cluster';
+import { Loadable } from 'utils/loadable';
 
 export const ClusterOverallBar: React.FC = () => {
-  const { agents, cluster: overview } = useStore();
+  const overview = Loadable.getOrElse(initClusterOverview, useClusterOverview());
+  // TODO: handle loading state
+  const agents = Loadable.getOrElse([], useAgents());
 
   const cudaSlotStates = useMemo(() => {
     return getSlotContainerStates(agents || [], ResourceType.CUDA);

--- a/webui/react/src/pages/Cluster/ClusterOverallStats.tsx
+++ b/webui/react/src/pages/Cluster/ClusterOverallStats.tsx
@@ -4,13 +4,18 @@ import Grid, { GridMode } from 'components/Grid';
 import OverviewStats from 'components/OverviewStats';
 import Section from 'components/Section';
 import { useStore } from 'contexts/Store';
+import { initClusterOverview, useAgents, useClusterOverview } from 'stores/agents';
 import { ShirtSize } from 'themes';
 import { ResourceType } from 'types';
+import { Loadable } from 'utils/loadable';
 
 import { maxClusterSlotCapacity } from '../Clusters/ClustersOverview';
 
 export const ClusterOverallStats: React.FC = () => {
-  const { activeExperiments, activeTasks, agents, cluster: overview, resourcePools } = useStore();
+  const { activeExperiments, activeTasks, resourcePools } = useStore();
+  const overview = Loadable.getOrElse(initClusterOverview, useClusterOverview());
+  // TODO: handle loading state
+  const agents = Loadable.getOrElse([], useAgents());
 
   const auxContainers = useMemo(() => {
     const tally = {

--- a/webui/react/src/pages/Clusters.tsx
+++ b/webui/react/src/pages/Clusters.tsx
@@ -6,6 +6,8 @@ import Page from 'components/Page';
 import { useStore } from 'contexts/Store';
 import { paths } from 'routes/utils';
 import { ValueOf } from 'shared/types';
+import { initClusterOverview, useAgents, useClusterOverview } from 'stores/agents';
+import { Loadable } from 'utils/loadable';
 
 import ClusterHistoricalUsage from './Cluster/ClusterHistoricalUsage';
 import ClusterLogs from './ClusterLogs';
@@ -34,7 +36,10 @@ const Clusters: React.FC = () => {
   const navigate = useNavigate();
 
   const [tabKey, setTabKey] = useState<TabType>(tab || DEFAULT_TAB_KEY);
-  const { agents, cluster: overview, resourcePools } = useStore();
+  const { resourcePools } = useStore();
+  const overview = Loadable.getOrElse(initClusterOverview, useClusterOverview());
+  // TODO: handle loading state
+  const agents = Loadable.getOrElse([], useAgents());
 
   const cluster = useMemo(() => {
     return clusterStatusText(overview, resourcePools, agents);

--- a/webui/react/src/pages/Clusters.tsx
+++ b/webui/react/src/pages/Clusters.tsx
@@ -6,7 +6,7 @@ import Page from 'components/Page';
 import { useStore } from 'contexts/Store';
 import { paths } from 'routes/utils';
 import { ValueOf } from 'shared/types';
-import { initClusterOverview, useAgents, useClusterOverview } from 'stores/agents';
+import { useAgents, useClusterOverview } from 'stores/agents';
 import { Loadable } from 'utils/loadable';
 
 import ClusterHistoricalUsage from './Cluster/ClusterHistoricalUsage';
@@ -37,12 +37,14 @@ const Clusters: React.FC = () => {
 
   const [tabKey, setTabKey] = useState<TabType>(tab || DEFAULT_TAB_KEY);
   const { resourcePools } = useStore();
-  const overview = Loadable.getOrElse(initClusterOverview, useClusterOverview());
-  // TODO: handle loading state
-  const agents = Loadable.getOrElse([], useAgents());
+  const overview = useClusterOverview();
+  const agents = useAgents();
 
   const cluster = useMemo(() => {
-    return clusterStatusText(overview, resourcePools, agents);
+    return Loadable.match(Loadable.all([agents, overview]), {
+      Loaded: ([agents, overview]) => clusterStatusText(overview, resourcePools, agents),
+      NotLoaded: () => undefined, // TODO show spinner when this is loading
+    });
   }, [overview, resourcePools, agents]);
 
   const handleTabChange = useCallback(

--- a/webui/react/src/pages/Clusters/ClustersOverview.tsx
+++ b/webui/react/src/pages/Clusters/ClustersOverview.tsx
@@ -9,13 +9,13 @@ import { useStore } from 'contexts/Store';
 import {
   useFetchActiveExperiments,
   useFetchActiveTasks,
-  useFetchAgents,
   useFetchResourcePools,
 } from 'hooks/useFetch';
 import { paths } from 'routes/utils';
 import { V1ResourcePoolType } from 'services/api-ts-sdk';
 import usePolling from 'shared/hooks/usePolling';
 import { percent } from 'shared/utils/number';
+import { useFetchAgents } from 'stores/agents';
 import { ShirtSize } from 'themes';
 import { Agent, ClusterOverview as Overview, ResourcePool, ResourceType } from 'types';
 
@@ -90,6 +90,7 @@ export const clusterStatusText = (
 
 const ClusterOverview: React.FC = () => {
   const { resourcePools } = useStore();
+
   const [rpDetail, setRpDetail] = useState<ResourcePool>();
 
   const [canceler] = useState(new AbortController());

--- a/webui/react/src/pages/Clusters/ClustersOverview.tsx
+++ b/webui/react/src/pages/Clusters/ClustersOverview.tsx
@@ -15,7 +15,7 @@ import { paths } from 'routes/utils';
 import { V1ResourcePoolType } from 'services/api-ts-sdk';
 import usePolling from 'shared/hooks/usePolling';
 import { percent } from 'shared/utils/number';
-import { useFetchAgents } from 'stores/agents';
+import { useEnsureAgentsFetched } from 'stores/agents';
 import { ShirtSize } from 'themes';
 import { Agent, ClusterOverview as Overview, ResourcePool, ResourceType } from 'types';
 
@@ -97,7 +97,7 @@ const ClusterOverview: React.FC = () => {
 
   const fetchActiveExperiments = useFetchActiveExperiments(canceler);
   const fetchActiveTasks = useFetchActiveTasks(canceler);
-  const fetchAgents = useFetchAgents(canceler);
+  const fetchAgents = useEnsureAgentsFetched(canceler);
   const fetchResourcePools = useFetchResourcePools(canceler);
 
   const fetchActiveRunning = useCallback(async () => {

--- a/webui/react/src/pages/ResourcepoolDetail.tsx
+++ b/webui/react/src/pages/ResourcepoolDetail.tsx
@@ -4,8 +4,7 @@ import { useNavigate, useParams } from 'react-router-dom';
 
 import Json from 'components/Json';
 import Page from 'components/Page';
-import { PoolLogo } from 'components/ResourcePoolCard';
-import { RenderAllocationBarResourcePool } from 'components/ResourcePoolCard';
+import { PoolLogo, RenderAllocationBarResourcePool } from 'components/ResourcePoolCard';
 import Section from 'components/Section';
 import { V1SchedulerTypeToLabel } from 'constants/states';
 import { useStore } from 'contexts/Store';
@@ -14,12 +13,12 @@ import { getJobQStats } from 'services/api';
 import { V1GetJobQueueStatsResponse, V1RPQueueStat, V1SchedulerType } from 'services/api-ts-sdk';
 import Icon from 'shared/components/Icon/Icon';
 import Message, { MessageType } from 'shared/components/Message';
+import Spinner from 'shared/components/Spinner';
 import usePolling from 'shared/hooks/usePolling';
 import { ValueOf } from 'shared/types';
 import { clone } from 'shared/utils/data';
 import { ErrorLevel, ErrorType } from 'shared/utils/error';
-import { camelCaseToSentence } from 'shared/utils/string';
-import { floatToPercent } from 'shared/utils/string';
+import { camelCaseToSentence, floatToPercent } from 'shared/utils/string';
 import { useAgents } from 'stores/agents';
 import { ShirtSize } from 'themes';
 import { JobState, ResourceState } from 'types';
@@ -49,10 +48,10 @@ type TabType = ValueOf<typeof TabType>;
 
 export const DEFAULT_POOL_TAB_KEY = TabType.Active;
 
-const ResourcepoolDetail: React.FC = () => {
+const ResourcepoolDetailInner: React.FC = () => {
   const { poolname, tab } = useParams<Params>();
   const { resourcePools } = useStore();
-  const agents = Loadable.waitFor(useAgents());
+  const agents = Loadable.getOrElse([], useAgents());
 
   const pool = useMemo(() => {
     return resourcePools.find((pool) => pool.name === poolname);
@@ -200,10 +199,10 @@ const ResourcepoolDetail: React.FC = () => {
   );
 };
 
-const ResourcepoolDetailPage: React.FC = () => (
-  <Suspense fallback={<Page loading />}>
-    <ResourcepoolDetail />
+const ResourcepoolDetail: React.FC = () => (
+  <Suspense fallback={<Spinner />}>
+    <ResourcepoolDetailInner />
   </Suspense>
 );
 
-export default ResourcepoolDetailPage;
+export default ResourcepoolDetail;

--- a/webui/react/src/pages/ResourcepoolDetail.tsx
+++ b/webui/react/src/pages/ResourcepoolDetail.tsx
@@ -20,10 +20,12 @@ import { clone } from 'shared/utils/data';
 import { ErrorLevel, ErrorType } from 'shared/utils/error';
 import { camelCaseToSentence } from 'shared/utils/string';
 import { floatToPercent } from 'shared/utils/string';
+import { useAgents } from 'stores/agents';
 import { ShirtSize } from 'themes';
 import { JobState, ResourceState } from 'types';
 import { getSlotContainerStates } from 'utils/cluster';
 import handleError from 'utils/error';
+import { Loadable } from 'utils/loadable';
 
 import { maxPoolSlotCapacity } from './Clusters/ClustersOverview';
 import ClustersQueuedChart from './Clusters/ClustersQueuedChart';
@@ -49,7 +51,9 @@ export const DEFAULT_POOL_TAB_KEY = TabType.Active;
 
 const ResourcepoolDetail: React.FC = () => {
   const { poolname, tab } = useParams<Params>();
-  const { agents, resourcePools } = useStore();
+  const { resourcePools } = useStore();
+  // TODO: handle loading state
+  const agents = Loadable.getOrElse([], useAgents());
 
   const pool = useMemo(() => {
     return resourcePools.find((pool) => pool.name === poolname);

--- a/webui/react/src/pages/ResourcepoolDetail.tsx
+++ b/webui/react/src/pages/ResourcepoolDetail.tsx
@@ -1,5 +1,5 @@
 import { Divider, Tabs } from 'antd';
-import React, { Fragment, useCallback, useEffect, useMemo, useState } from 'react';
+import React, { Fragment, Suspense, useCallback, useEffect, useMemo, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 
 import Json from 'components/Json';
@@ -52,8 +52,7 @@ export const DEFAULT_POOL_TAB_KEY = TabType.Active;
 const ResourcepoolDetail: React.FC = () => {
   const { poolname, tab } = useParams<Params>();
   const { resourcePools } = useStore();
-  // TODO: handle loading state
-  const agents = Loadable.getOrElse([], useAgents());
+  const agents = Loadable.waitFor(useAgents());
 
   const pool = useMemo(() => {
     return resourcePools.find((pool) => pool.name === poolname);
@@ -201,4 +200,10 @@ const ResourcepoolDetail: React.FC = () => {
   );
 };
 
-export default ResourcepoolDetail;
+const ResourcepoolDetailPage: React.FC = () => (
+  <Suspense fallback={<Page loading />}>
+    <ResourcepoolDetail />
+  </Suspense>
+);
+
+export default ResourcepoolDetailPage;

--- a/webui/react/src/stores/agents.tsx
+++ b/webui/react/src/stores/agents.tsx
@@ -1,0 +1,92 @@
+import React, { createContext, PropsWithChildren, useCallback, useContext, useState } from 'react';
+
+import { getAgents } from 'services/api';
+import { clone } from 'shared/utils/data';
+import { percent } from 'shared/utils/number';
+import { noOp } from 'shared/utils/service';
+import { Agent, ClusterOverview, ClusterOverviewResource, ResourceType } from 'types';
+import handleError from 'utils/error';
+import { Loadable, Loaded, NotLoaded } from 'utils/loadable';
+
+type AgentContext = {
+  agents: Loadable<Agent[]>;
+  updateAgents: (a: Loadable<Agent[]>) => void;
+};
+
+const initResourceTally: ClusterOverviewResource = { allocation: 0, available: 0, total: 0 };
+// TODO: dont export
+export const initClusterOverview: ClusterOverview = {
+  [ResourceType.CPU]: clone(initResourceTally),
+  [ResourceType.CUDA]: clone(initResourceTally),
+  [ResourceType.ROCM]: clone(initResourceTally),
+  [ResourceType.ALL]: clone(initResourceTally),
+  [ResourceType.UNSPECIFIED]: clone(initResourceTally),
+};
+
+const AgentsContext = createContext<AgentContext>({ agents: NotLoaded, updateAgents: noOp });
+
+export const AgentsProvider: React.FC<PropsWithChildren> = ({ children }) => {
+  const [state, setState] = useState<Loadable<Agent[]>>(NotLoaded);
+  return (
+    <AgentsContext.Provider value={{ agents: state, updateAgents: setState }}>
+      {children}
+    </AgentsContext.Provider>
+  );
+};
+
+export const useFetchAgents = (canceler: AbortController): (() => Promise<void>) => {
+  const { updateAgents } = useContext(AgentsContext);
+
+  return useCallback(async (): Promise<void> => {
+    try {
+      const agents = await getAgents({ signal: canceler.signal });
+
+      updateAgents(Loaded(agents));
+      // TODO: handle this another way
+      // updateFaviconType(
+      //   cluster[ResourceType.ALL].allocation !== 0,
+      //   info.branding || BrandingType.Determined,
+      // );
+    } catch (e) {
+      handleError(e);
+    }
+  }, [canceler, updateAgents]);
+};
+
+export const useAgents = (): Loadable<Agent[]> => {
+  // TODO: check undefined
+  const { agents } = useContext(AgentsContext);
+
+  return agents;
+};
+
+export const useClusterOverview = (): Loadable<ClusterOverview> => {
+  // Deep clone for render detection.
+  const agents = useAgents();
+  return Loadable.map(agents, (agents) => {
+    const overview: ClusterOverview = clone(initClusterOverview);
+
+    agents.forEach((agent) => {
+      agent.resources
+        .filter((resource) => resource.enabled)
+        .forEach((resource) => {
+          const isResourceFree = resource.container == null;
+          const availableResource = isResourceFree ? 1 : 0;
+          overview[resource.type].available += availableResource;
+          overview[resource.type].total++;
+          overview[ResourceType.ALL].available += availableResource;
+          overview[ResourceType.ALL].total++;
+        });
+    });
+
+    for (const key in overview) {
+      const rt = key as ResourceType;
+      overview[rt].allocation =
+        overview[rt].total !== 0
+          ? percent((overview[rt].total - overview[rt].available) / overview[rt].total)
+          : 0;
+    }
+
+    return overview;
+  });
+};

--- a/webui/react/src/utils/loadable.ts
+++ b/webui/react/src/utils/loadable.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 export type Loadable<T> =
   | {
       _tag: 'Loaded';
@@ -134,8 +133,8 @@ function all<A, B, C, D>(
 function all<A, B, C, D, E>(
   ls: [Loadable<A>, Loadable<B>, Loadable<C>, Loadable<D>, Loadable<E>],
 ): Loadable<[A, B, C, D, E]>;
-function all(ls: Array<Loadable<any>>): Loadable<Array<any>> {
-  const res: any[] = [];
+function all(ls: Array<Loadable<unknown>>): Loadable<Array<unknown>> {
+  const res: unknown[] = [];
   for (const l of ls) {
     if (l._tag === 'NotLoaded') {
       return NotLoaded;

--- a/webui/react/src/utils/loadable.ts
+++ b/webui/react/src/utils/loadable.ts
@@ -1,0 +1,147 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+export type Loadable<T> =
+  | {
+      _tag: 'Loaded';
+      data: T;
+    }
+  | {
+      _tag: 'NotLoaded';
+    }
+  | {
+      _tag: 'NotFound';
+    };
+
+const exhaustive = (v: never): never => v;
+
+const Loaded = <T>(data: T): Loadable<T> => ({ _tag: 'Loaded', data });
+const NotLoaded: Loadable<never> = { _tag: 'NotLoaded' };
+const NotFound: Loadable<never> = { _tag: 'NotFound' };
+
+const map = <T, U>(l: Loadable<T>, fn: (_: T) => U): Loadable<U> => {
+  switch (l._tag) {
+    case 'Loaded':
+      return Loaded(fn(l.data));
+    case 'NotLoaded':
+      return NotLoaded;
+    case 'NotFound':
+      return NotFound;
+    default:
+      return exhaustive(l);
+  }
+};
+
+const flatMap = <T, U>(l: Loadable<T>, fn: (_: T) => Loadable<U>): Loadable<U> => {
+  const res = map(l, fn);
+  if (res._tag === 'Loaded') {
+    return res.data;
+  }
+  return res;
+};
+
+const forEach = <T, U>(l: Loadable<T>, fn: (_: T) => U): void => {
+  switch (l._tag) {
+    case 'Loaded': {
+      fn(l.data);
+      return;
+    }
+    case 'NotLoaded':
+      return;
+    case 'NotFound':
+      return;
+    default:
+      exhaustive(l);
+  }
+};
+
+const getOrElse = <T>(def: T, l: Loadable<T>): T => {
+  switch (l._tag) {
+    case 'Loaded':
+      return l.data;
+    case 'NotLoaded':
+      return def;
+    case 'NotFound':
+      return def;
+    default:
+      return exhaustive(l);
+  }
+};
+
+type MatchArgs<T, U> =
+  | {
+      Loaded: (data: T) => U;
+      NotFound: () => U;
+      NotLoaded: () => U;
+    }
+  | {
+      Loaded: (data: T) => U;
+      _: () => U;
+    }
+  | {
+      NotFound: () => U;
+      _: () => U;
+    }
+  | {
+      NotLoaded: () => U;
+      _: () => U;
+    };
+const match = <T, U>(l: Loadable<T>, cases: MatchArgs<T, U>): U => {
+  switch (l._tag) {
+    case 'Loaded':
+      return 'Loaded' in cases ? cases.Loaded(l.data) : cases._();
+    case 'NotLoaded':
+      return 'NotLoaded' in cases ? cases.NotLoaded() : cases._();
+    case 'NotFound':
+      return 'NotFound' in cases ? cases.NotFound() : cases._();
+    default:
+      return exhaustive(l);
+  }
+};
+
+const quickMatch = <T, U>(l: Loadable<T>, def: U, f: (data: T) => U): U => {
+  switch (l._tag) {
+    case 'Loaded':
+      return f(l.data);
+    case 'NotLoaded':
+      return def;
+    case 'NotFound':
+      return def;
+    default:
+      return exhaustive(l);
+  }
+};
+
+const isLoadable = <T, Z>(l: Loadable<T> | Z): l is Loadable<T> => {
+  return ['Loaded', 'NotLoaded', 'NotFound'].includes((l as Loadable<T>)?._tag);
+};
+
+/**
+ * Groups up all passed Loadables. NotFound takes priority over
+ * NotLoaded so all([NotLoaded, NotFound, Loaded(4)]) returns NotFound
+ */
+function all<A>(ls: [Loadable<A>]): Loadable<[A]>;
+function all<A, B>(ls: [Loadable<A>, Loadable<B>]): Loadable<[A, B]>;
+function all<A, B, C>(ls: [Loadable<A>, Loadable<B>, Loadable<C>]): Loadable<[A, B, C]>;
+function all<A, B, C, D>(
+  ls: [Loadable<A>, Loadable<B>, Loadable<C>, Loadable<D>],
+): Loadable<[A, B, C, D]>;
+function all<A, B, C, D, E>(
+  ls: [Loadable<A>, Loadable<B>, Loadable<C>, Loadable<D>, Loadable<E>],
+): Loadable<[A, B, C, D, E]>;
+function all(ls: Array<Loadable<any>>): Loadable<Array<any>> {
+  const res: any[] = [];
+  for (const l of ls) {
+    if (l._tag === 'NotFound') {
+      return NotFound;
+    }
+    if (l._tag === 'NotLoaded') {
+      return NotLoaded;
+    }
+    res.push(l.data);
+  }
+  return Loaded(res);
+}
+
+// exported immediately because of name collision
+export const Loadable = { all, flatMap, forEach, getOrElse, isLoadable, map, match, quickMatch };
+
+export { Loaded, NotLoaded, NotFound };

--- a/webui/react/src/utils/loadable.ts
+++ b/webui/react/src/utils/loadable.ts
@@ -13,6 +13,12 @@ const exhaustive = (v: never): never => v;
 const Loaded = <T>(data: T): Loadable<T> => ({ _tag: 'Loaded', data });
 const NotLoaded: Loadable<never> = { _tag: 'NotLoaded' };
 
+/**
+ * The map() function creates a new Loadable with the result of calling
+ * the provided function on the contained value in the passed Loadable.
+ *
+ * If the passed Loadable is NotLoaded then the return value is NotLoaded
+ */
 const map = <T, U>(l: Loadable<T>, fn: (_: T) => U): Loadable<U> => {
   switch (l._tag) {
     case 'Loaded':
@@ -24,6 +30,13 @@ const map = <T, U>(l: Loadable<T>, fn: (_: T) => U): Loadable<U> => {
   }
 };
 
+/**
+ * The flatMap() function creates a new Loadable with the result of calling
+ * the provided function on the contained value in the passed Loadable and then
+ * flattening the result.
+ *
+ * If any of the passed or returned Loadables is NotLoaded, the result is NotLoaded.
+ */
 const flatMap = <T, U>(l: Loadable<T>, fn: (_: T) => Loadable<U>): Loadable<U> => {
   const res = map(l, fn);
   if (res._tag === 'Loaded') {
@@ -32,6 +45,9 @@ const flatMap = <T, U>(l: Loadable<T>, fn: (_: T) => Loadable<U>): Loadable<U> =
   return res;
 };
 
+/**
+ * Performs a side-effecting function if the passed Loadable is Loaded.
+ */
 const forEach = <T, U>(l: Loadable<T>, fn: (_: T) => U): void => {
   switch (l._tag) {
     case 'Loaded': {
@@ -45,6 +61,10 @@ const forEach = <T, U>(l: Loadable<T>, fn: (_: T) => U): void => {
   }
 };
 
+/**
+ * If the passed Loadable is Loaded this returns the data, otherwise
+ * it returns the default value.
+ */
 const getOrElse = <T>(def: T, l: Loadable<T>): T => {
   switch (l._tag) {
     case 'Loaded':
@@ -69,6 +89,10 @@ type MatchArgs<T, U> =
       NotLoaded: () => U;
       _: () => U;
     };
+/**
+ * Allows you to match out the cases in the Loadable with named
+ * arguments.
+ */
 const match = <T, U>(l: Loadable<T>, cases: MatchArgs<T, U>): U => {
   switch (l._tag) {
     case 'Loaded':
@@ -80,6 +104,7 @@ const match = <T, U>(l: Loadable<T>, cases: MatchArgs<T, U>): U => {
   }
 };
 
+/** Like `match` but without argument names */
 const quickMatch = <T, U>(l: Loadable<T>, def: U, f: (data: T) => U): U => {
   switch (l._tag) {
     case 'Loaded':
@@ -91,6 +116,7 @@ const quickMatch = <T, U>(l: Loadable<T>, def: U, f: (data: T) => U): U => {
   }
 };
 
+/** Returns true if the passed object is a Loadable */
 const isLoadable = <T, Z>(l: Loadable<T> | Z): l is Loadable<T> => {
   return ['Loaded', 'NotLoaded', 'NotFound'].includes((l as Loadable<T>)?._tag);
 };


### PR DESCRIPTION
## Description
This is a PR @trentwatt and I put together. It does two things:

1. Split out Agents from the `Store` context. This is how we want to go about breaking up the Store context so that we can eventually switch to a more flexible way of managing global data.
2. Introduces a Loadable data type to manage loading states. Currently we're pretty bad at handling loading states and often just temporarily display incorrect data while loading. This will make it easier to implement loading states going forward and see where they're missing now.

![Screen Shot 2022-10-28 at 14 50 23](https://user-images.githubusercontent.com/1002726/198719157-df00a8ad-625b-422f-9c60-44e0d32ea007.png)
![Screen Shot 2022-10-28 at 15 09 42](https://user-images.githubusercontent.com/1002726/198719159-0d2127a6-880b-4861-9778-a38da26423ac.png)


## Test Plan
1. Visit the cluster overview page, confirm it matches latest-master (there are some features here I don't see in latest master if people have ideas on how to test them).
2. Confirm the navbar matches latest-master
4. Confirm the resource pool detail page matches latest-master
5. Replace each instance of `getAgents`, etc with `NotLoaded` and confirm the loading states display correctly.


## Checklist
- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.