### PR TITLE
chore: Enable library checks for TypeScript; update types [WEB-191]

### DIFF
--- a/webui/react/src/components/DeterminedAuth.tsx
+++ b/webui/react/src/components/DeterminedAuth.tsx
@@ -12,7 +12,7 @@ import { isLoginFailure } from 'services/utils';
 import Icon from 'shared/components/Icon/Icon';
 import useUI from 'shared/contexts/stores/UI';
 import { ErrorType } from 'shared/utils/error';
-import { Storage } from 'shared/utils/storage';
+import { StorageManager } from 'shared/utils/storage';
 import handleError from 'utils/error';
 
 import css from './DeterminedAuth.module.scss';
@@ -26,7 +26,7 @@ interface FromValues {
   username?: string;
 }
 
-const storage = new Storage({ basePath: '/DeterminedAuth', store: window.localStorage });
+const storage = new StorageManager({ basePath: '/DeterminedAuth', store: window.localStorage });
 const STORAGE_KEY_LAST_USERNAME = 'lastUsername';
 
 const DeterminedAuth: React.FC<Props> = ({ canceler }: Props) => {

--- a/webui/react/src/declarations.d.ts
+++ b/webui/react/src/declarations.d.ts
@@ -1,0 +1,2 @@
+// We need to tell TypeScript that when we write "import styles from './styles.scss' we mean to load a module (to look for a './styles.scss.d.ts').
+declare module '*.scss';

--- a/webui/react/src/globalStorage.ts
+++ b/webui/react/src/globalStorage.ts
@@ -1,10 +1,10 @@
-import { Storage } from 'shared/utils/storage';
+import { StorageManager } from 'shared/utils/storage';
 
 class GlobalStorage {
   private keys: Record<string, string>;
-  private storage: Storage;
+  private storage: StorageManager;
 
-  constructor(storage: Storage) {
+  constructor(storage: StorageManager) {
     this.storage = storage;
     this.keys = {
       authToken: 'auth-token',
@@ -38,5 +38,5 @@ class GlobalStorage {
 }
 
 export const globalStorage = new GlobalStorage(
-  new Storage({ basePath: 'global', store: window.localStorage }),
+  new StorageManager({ basePath: 'global', store: window.localStorage }),
 );

--- a/webui/react/src/hooks/useSettings.test.tsx
+++ b/webui/react/src/hooks/useSettings.test.tsx
@@ -7,7 +7,7 @@ import { unstable_HistoryRouter as HistoryRouter } from 'react-router-dom';
 import StoreProvider from 'contexts/Store';
 import history from 'shared/routes/history';
 import { RecordKey } from 'shared/types';
-import { MemoryStore, Storage } from 'shared/utils/storage';
+import { MemoryStore, StorageManager } from 'shared/utils/storage';
 
 import useSettings, * as hook from './useSettings';
 
@@ -149,7 +149,10 @@ describe('useSettings helper functions', () => {
   });
 
   describe('getDefaultSettings', () => {
-    const testStorage = new Storage({ basePath: config.storagePath, store: new MemoryStore() });
+    const testStorage = new StorageManager({
+      basePath: config.storagePath,
+      store: new MemoryStore(),
+    });
     const defaultResult = {
       boolean: true,
       booleanArray: undefined,

--- a/webui/react/src/hooks/useSettings.ts
+++ b/webui/react/src/hooks/useSettings.ts
@@ -12,7 +12,7 @@ import {
   isObject,
   isString,
 } from 'shared/utils/data';
-import { Storage } from 'shared/utils/storage';
+import { StorageManager } from 'shared/utils/storage';
 import handleError from 'utils/error';
 
 import { Primitive, RecordKey, ValueOf } from '../shared/types';
@@ -102,7 +102,7 @@ export const validateSetting = (config: SettingsConfigProp, value: unknown): boo
   return validateBaseType(config.type.baseType, value);
 };
 
-export const getDefaultSettings = <T>(config: SettingsConfig, storage: Storage): T => {
+export const getDefaultSettings = <T>(config: SettingsConfig, storage: StorageManager): T => {
   return config.settings.reduce((acc, prop) => {
     let defaultValue = prop.defaultValue;
     if (prop.storageKey) {

--- a/webui/react/src/hooks/useStorage.ts
+++ b/webui/react/src/hooks/useStorage.ts
@@ -2,10 +2,10 @@ import { useState } from 'react';
 
 import { useStore } from 'contexts/Store';
 import { resetUserSetting } from 'services/api';
-import { Storage, Store } from 'shared/utils/storage';
+import { StorageManager } from 'shared/utils/storage';
 
 export const userPreferencesStorage = (): (() => void) => {
-  const storage = new Storage({ basePath: 'u', delimiter: ':', store: window.localStorage });
+  const storage = new StorageManager({ basePath: 'u', delimiter: ':', store: window.localStorage });
   const resetStorage = async () => {
     await resetUserSetting({});
     storage.reset();
@@ -13,10 +13,15 @@ export const userPreferencesStorage = (): (() => void) => {
   return resetStorage;
 };
 
-export const useStorage = (basePath: string, store: Store = window.localStorage): Storage => {
+export const useStorage = (
+  basePath: string,
+  store: Storage = window.localStorage,
+): StorageManager => {
   const { auth } = useStore();
   const userNamespace = auth.user ? `u:${auth.user.id}` : '';
-  const [storage] = useState(new Storage({ basePath: `${userNamespace}/${basePath}`, store }));
+  const [storage] = useState(
+    new StorageManager({ basePath: `${userNamespace}/${basePath}`, store }),
+  );
   return storage;
 };
 

--- a/webui/react/src/react-app-env.d.ts
+++ b/webui/react/src/react-app-env.d.ts
@@ -2,15 +2,9 @@
 /// <reference types="react-scripts" />
 /// <reference path="types.ts" />
 
-declare namespace NodeJS {
-  export interface ProcessEnv {
-    IS_DEV: boolean;
-    VERSION: string;
-    SERVER_ADDRESS?: string;
-  }
-}
+export {};
 
-export declare global {
+declare global {
   interface Window {
     analytics: any;
     dev: any;
@@ -22,8 +16,14 @@ export declare global {
     random(): T;
     sortAll(compareFn: (a: T, b: T) => number): Array<T>;
   }
+}
 
-  interface Storage {
-    keys(): string[];
+declare module global {
+  namespace NodeJS {
+    interface ProcessEnv {
+      IS_DEV: boolean;
+      VERSION: string;
+      SERVER_ADDRESS?: string;
+    }
   }
 }

--- a/webui/react/src/shared/configs/tsconfig.json
+++ b/webui/react/src/shared/configs/tsconfig.json
@@ -3,7 +3,7 @@
     "target": "es2020",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": false,
-    "skipLibCheck": true,
+    "skipLibCheck": false,
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "strict": true,

--- a/webui/react/src/shared/utils/storage.test.ts
+++ b/webui/react/src/shared/utils/storage.test.ts
@@ -1,10 +1,10 @@
-import { MemoryStore, Storage } from './storage';
+import { MemoryStore, StorageManager } from './storage';
 
 const testKey = 'testKey';
 const anotherTestKey = 'anotherTestKey';
 
 describe('MemoryStore', () => {
-  const testStorage = new Storage({ store: new MemoryStore() });
+  const testStorage = new StorageManager({ store: new MemoryStore() });
 
   beforeEach(() => {
     testStorage.clear();

--- a/webui/react/src/shared/utils/storage.ts
+++ b/webui/react/src/shared/utils/storage.ts
@@ -1,18 +1,13 @@
-export interface Store {
-  clear(): void;
-  getItem(key: string): string | null;
-  keys(): string[];
-  removeItem(key: string): void;
-  setItem(key: string, value: string): void;
-}
-
 interface StorageOptions {
   basePath?: string;
   delimiter?: string;
-  store: Store;
+  store: Storage;
 }
 
-export class MemoryStore implements Store {
+export class MemoryStore implements Storage {
+  // MemoryStore is used only in tests, and key/length are not used,
+  // only added for compatibility with localStorage type.
+  length: 0;
   private store: Record<string, string>;
 
   constructor() {
@@ -28,6 +23,10 @@ export class MemoryStore implements Store {
     return null;
   }
 
+  key(index: number): string {
+    return Object.keys(this.store)[index];
+  }
+
   removeItem(key: string): void {
     delete this.store[key];
   }
@@ -41,10 +40,10 @@ export class MemoryStore implements Store {
   }
 }
 
-export class Storage {
+export class StorageManager {
   private delimiter: string;
   private pathKeys: string[];
-  private store: Store;
+  private store: Storage;
 
   constructor(options: StorageOptions) {
     this.delimiter = options.delimiter || '/';
@@ -107,9 +106,9 @@ export class Storage {
     }
   }
 
-  fork(basePath: string): Storage {
+  fork(basePath: string): StorageManager {
     basePath = [...this.pathKeys, basePath].join(this.delimiter);
-    return new Storage({ basePath, delimiter: this.delimiter, store: this.store });
+    return new StorageManager({ basePath, delimiter: this.delimiter, store: this.store });
   }
 
   reset(): void {


### PR DESCRIPTION
## Description

Turns off `skipLibCheck` in tsconfig.json, then updates our other configs to newest standards.

The biggest non-config changes are around localStorage. We've been creating our own 'Store' type and 'Storage' class instead of the native localStorage's 'Storage' type. To avoid confusion, I'm removing the 'Store' type and renaming our class to 'StorageManager'.

We need two new attributes on MemoryStore for compatibility with localStorage's Storage type. This class is used only by tests, and never these functions (as they were not previously available).

**Note: does this take an excessive amount of time to build?**

## Test Plan

Builds successfully, passes tests

## Checklist
- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.