### PR TITLE
fix: validate username and display name in `PostUser`.

### DIFF
--- a/e2e_tests/tests/cluster/test_users.py
+++ b/e2e_tests/tests/cluster/test_users.py
@@ -946,12 +946,12 @@ def test_change_displayname(clean_auth: None) -> None:
     assert current_user is not None and current_user.id
 
     # Rename user using display name
-    patch_user = bindings.v1PatchUser(displayName="renamed")
+    patch_user = bindings.v1PatchUser(displayName="renamed display-name")
     bindings.patch_PatchUser(sess, body=patch_user, userId=current_user.id)
 
     modded_user = bindings.get_GetUser(sess, userId=current_user.id).user
     assert modded_user is not None
-    assert modded_user.displayName == "renamed"
+    assert modded_user.displayName == "renamed display-name"
 
     # Avoid display name of 'admin'
     patch_user.displayName = "Admin"

--- a/master/.golangci.yml
+++ b/master/.golangci.yml
@@ -32,6 +32,7 @@ issues:
     # Exclude "gosec: Errors unhandled" because it duplicates errcheck.
     - G104
     - and that stutters
+    - declaration of "(err|ctx)" shadows declaration at
 
   # Independently from option `exclude` golangci-lint uses default exclude patterns.
   exclude-use-default: false

--- a/master/internal/api_user.go
+++ b/master/internal/api_user.go
@@ -26,7 +26,7 @@ const determinedName = "determined"
 
 var (
 	errUserNotFound = status.Error(codes.NotFound, "user not found")
-	latinText       = regexp.MustCompile("[^\\p{Latin}\\p{N}\\s]")
+	latinText       = regexp.MustCompile("[^[:graph:]\\s]")
 )
 
 func clearUsername(targetUser model.User, name string, minLength int) (*string, error) {
@@ -215,8 +215,18 @@ func (a *apiServer) PostUser(
 		Admin:    req.User.Admin,
 		Active:   req.User.Active,
 	}
+	clearedUsername, err := clearUsername(*userToAdd, userToAdd.Username, 2)
+	if err != nil {
+		return nil, err
+	}
+	userToAdd.Username = *clearedUsername
+
 	if req.User.DisplayName != "" {
-		userToAdd.DisplayName = null.StringFrom(req.User.DisplayName)
+		clearedDisplayName, err := clearUsername(*userToAdd, req.User.DisplayName, 0)
+		if err != nil {
+			return nil, err
+		}
+		userToAdd.DisplayName = null.StringFrom(*clearedDisplayName)
 	}
 
 	var agentUserGroup *model.AgentUserGroup


### PR DESCRIPTION
## Description

Username / display name regex wasn't approving perfectly ascii dashes in usernames on patches. In this change,
- Change regex to allow all printable ascii characters.
- Start validating these fields on user creation as well.
- Change golang linter settings to stop enforcing variable shadowing for `err` and `ctx` because that's how idiomatic go works.

## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions about this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist
- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
