### PR TITLE
fix: improve previous tag logic

### DIFF
--- a/agent/Makefile
+++ b/agent/Makefile
@@ -58,7 +58,7 @@ package: packaging/LICENSE
 
 .PHONY: release
 release: export GORELEASER_CURRENT_TAG := $(VERSION)
-release: export GORELEASER_PREVIOUS_TAG := $(shell git tag --sort=-creatordate | egrep '^[0-9.]+$' | grep "$(VERSION)" -A1 | sed -n '2 p')
+release: export GORELEASER_PREVIOUS_TAG := $(shell git tag --sort=-creatordate | grep -E '^[0-9.]+$$' | grep "$(VERSION)" -A1 | sed -n '2 p')
 release: packaging/LICENSE
 	goreleaser --rm-dist
 

--- a/helm/Makefile
+++ b/helm/Makefile
@@ -27,7 +27,7 @@ release:
 
 .PHONY: release-gh
 release-gh: export GORELEASER_CURRENT_TAG := $(VERSION)
-release-gh: export GORELEASER_PREVIOUS_TAG := $(shell git tag --sort=-creatordate | egrep '^[0-9.]+$' | grep "$(VERSION)" -A1 | sed -n '2 p')
+release-gh: export GORELEASER_PREVIOUS_TAG := $(shell git tag --sort=-creatordate | grep -E '^[0-9.]+$$' | grep "$(VERSION)" -A1 | sed -n '2 p')
 release-gh:
 	go install github.com/goreleaser/goreleaser@v1.1.0
 	git clean -df

--- a/master/Makefile
+++ b/master/Makefile
@@ -120,7 +120,7 @@ package: gen
 release: export DET_SEGMENT_MASTER_KEY ?=
 release: export DET_SEGMENT_WEBUI_KEY ?=
 release: export GORELEASER_CURRENT_TAG := $(VERSION)
-release: export GORELEASER_PREVIOUS_TAG := $(shell git tag --sort=-creatordate | egrep '^[0-9.]+$' | grep "$(VERSION)" -A1 | sed -n '2 p')
+release: export GORELEASER_PREVIOUS_TAG := $(shell git tag --sort=-creatordate | grep -E '^[0-9.]+$$' | grep "$(VERSION)" -A1 | sed -n '2 p')
 release: gen
 	goreleaser --rm-dist
 


### PR DESCRIPTION
## Description

The `$` was being interpreted as an escape character, causing the following quote to not get sent to the shell.

Also, `egrep` has been deprecated since 2007 and now emits a warning when used [1], so switch to `grep -E`.

[1] https://git.savannah.gnu.org/cgit/grep.git/commit/?id=a9515624709865d480e3142fd959bccd1c9372d1

## Test Plan

- [x] observe that `make` invocations no longer always spit out errors about missing quotes
- [x] use `strace` to check that the arguments to `sh -c` look right

## Commentary (optional)

Has the old version been known to work, or was it changed after the last time it was actually used?