### PR TITLE
feat: block incompatible agents from reconnecting [DET-7023]

### DIFF
--- a/master/internal/config/resource_config.go
+++ b/master/internal/config/resource_config.go
@@ -46,3 +46,13 @@ func (r ResourceConfig) Validate() []error {
 	}
 	return errs
 }
+
+// GetPoolConfig returns the config corresponding to the pool with a particular name.
+func (r *ResourceConfig) GetPoolConfig(name string) *ResourcePoolConfig {
+	for _, p := range r.ResourcePools {
+		if p.PoolName == name {
+			return &p
+		}
+	}
+	return nil
+}

--- a/master/internal/rm/agentrm/agent_slots.go
+++ b/master/internal/rm/agentrm/agent_slots.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/determined-ai/determined/master/internal/api"
 	"github.com/determined-ai/determined/master/pkg/actor"
-	"github.com/determined-ai/determined/master/pkg/aproto"
 	"github.com/determined-ai/determined/master/pkg/check"
+	"github.com/determined-ai/determined/master/pkg/device"
 	"github.com/determined-ai/determined/master/pkg/model"
 )
 
@@ -18,8 +18,8 @@ type slots struct{}
 
 func (s *slots) Receive(ctx *actor.Context) error {
 	switch msg := ctx.Message().(type) {
-	case aproto.AgentStarted:
-		for _, d := range msg.Devices {
+	case []device.Device:
+		for _, d := range msg {
 			_, ok := ctx.ActorOf(d.ID, &slotProxy{device: d})
 			check.Panic(check.True(ok, "error registering slot, slot %s already created", d.ID))
 		}

--- a/master/internal/rm/agentrm/agent_state.go
+++ b/master/internal/rm/agentrm/agent_state.go
@@ -58,7 +58,7 @@ type agentState struct {
 	containerState      map[cproto.ID]*cproto.Container
 }
 
-// newAgentState returns a new agent empty agent state backed by the handler.
+// newAgentState returns a new empty agent state backed by the handler.
 func newAgentState(msg sproto.AddAgent, maxZeroSlotContainers int) *agentState {
 	return &agentState{
 		Handler:               msg.Agent,
@@ -239,9 +239,8 @@ func (a *agentState) removeDevice(ctx *actor.Context, device device.Device) {
 }
 
 // agentStarted initializes slots from AgentStarted.Devices.
-func (a *agentState) agentStarted(ctx *actor.Context, agentStarted *aproto.AgentStarted) {
-	msg := agentStarted
-	for _, d := range msg.Devices {
+func (a *agentState) agentStarted(ctx *actor.Context, devices []device.Device) {
+	for _, d := range devices {
 		enabled := slotEnabled{
 			agentEnabled: true,
 			userEnabled:  true,
@@ -256,7 +255,7 @@ func (a *agentState) agentStarted(ctx *actor.Context, agentStarted *aproto.Agent
 }
 
 func (a *agentState) checkAgentStartedDevicesMatch(
-	ctx *actor.Context, agentStarted *aproto.AgentStarted,
+	ctx *actor.Context, devices []device.Device,
 ) error {
 	ourDevices := map[device.ID]device.Device{}
 	for did, slot := range a.slotStates {
@@ -264,7 +263,7 @@ func (a *agentState) checkAgentStartedDevicesMatch(
 	}
 
 	theirDevices := map[device.ID]device.Device{}
-	for _, d := range agentStarted.Devices {
+	for _, d := range devices {
 		theirDevices[d.ID] = d
 	}
 

--- a/master/internal/rm/agentrm/agents.go
+++ b/master/internal/rm/agentrm/agents.go
@@ -2,6 +2,7 @@ package agentrm
 
 import (
 	"crypto/tls"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"time"
@@ -174,6 +175,14 @@ func (a *agents) createAgentActor(
 	resourcePoolRef, err := a.rm.GetResourcePoolRef(ctx, resourcePool)
 	if err != nil {
 		return nil, fmt.Errorf("getting resource pool for agent: %w", err)
+	}
+	if poolConfig := config.GetMasterConfig().GetPoolConfig(resourcePool); poolConfig != nil {
+		poolConfig, err := json.Marshal(poolConfig)
+		if err != nil {
+			return nil, err
+		}
+		opts = &(*opts)
+		opts.ResourcePoolConfig = poolConfig
 	}
 
 	rpConfig := ctx.Ask(resourcePoolRef, aproto.GetRPConfig{}).Get().(aproto.GetRPResponse)

--- a/master/pkg/aproto/agent_message.go
+++ b/master/pkg/aproto/agent_message.go
@@ -1,6 +1,7 @@
 package aproto
 
 import (
+	"encoding/json"
 	"syscall"
 
 	"github.com/pkg/errors"
@@ -31,6 +32,7 @@ type MasterSetAgentOptions struct {
 	MasterInfo           MasterInfo
 	LoggingOptions       model.LoggingConfig
 	ContainersToReattach []ContainerReattach
+	ResourcePoolConfig   json.RawMessage
 }
 
 // StartContainer notifies the agent to start a container with the provided spec.

--- a/master/pkg/aproto/master_message.go
+++ b/master/pkg/aproto/master_message.go
@@ -1,6 +1,7 @@
 package aproto
 
 import (
+	"encoding/json"
 	"net"
 	"strconv"
 	"time"
@@ -36,6 +37,7 @@ type MasterInfo struct {
 // MasterMessage is a union type for all messages sent from agents.
 type MasterMessage struct {
 	AgentStarted          *AgentStarted
+	ContainersReattached  *ContainersReattached
 	ContainerStateChanged *ContainerStateChanged
 	ContainerLog          *ContainerLog
 	ContainerStatsRecord  *ContainerStatsRecord
@@ -55,11 +57,17 @@ type ContainerReattachAck struct {
 // ID is an identifier for an agent.
 type ID string
 
-// AgentStarted notifies the master that the agent has started up.
+// AgentStarted notifies the master that the agent has started up. The agent sends it immediately
+// after making a WebSocket connection.
 type AgentStarted struct {
-	Version              string
-	Label                string
-	Devices              []device.Device
+	Version            string
+	Label              string
+	ResourcePoolConfig json.RawMessage
+	Devices            []device.Device
+}
+
+// ContainersReattached notifies the master that the agent has reattached the requested containers.
+type ContainersReattached struct {
 	ContainersReattached []ContainerReattachAck
 }
 


### PR DESCRIPTION
## Description

In order to account for the possibility of the master resource pool config changing between restarts and an old agent trying to reconnect, we now have the master send the current resource pool config and the agent send it back when it reconnects. If the master determines that the previous configuration is incompatible with the current one, it disconnects the agent.

The agent startup protocol now has `AgentStarted` containing only basic information about the agent (not reattached containers) and coming before `MasterSetAgentOptions`. If the master determines that the agent is unacceptable, it disconnects it without updating any internal state. Reattached containers were previously listed in the same message but are now broken out to a later one, since the agent uses information from the master to do the reattaching.

Some other logic that previously happened after `MasterSetAgentOptions` now also happens before it; not strictly necessary, but it makes sense to have the potentially disconnection-causing checks together and as early as possible.

## Test Plan

- [x] kill and restart master with containers running, check that agent reconnects and containers reappear
- [x] kill and restart master with code modified to always reject, check that agent exits
- [ ]  test restart/reattach in more scenarios

## Commentary

Primary functionality is working, but more testing/inspection of everything restart/reattach-related should probably be done.

After I wrote all this, it occurred to me that it might work to instead use the agent snapshots table, which I wasn't aware of when I started, to store the old configs. I can switch over if that makes sense. The other protocol changes might make sense to salvage even in that case.