### PR TITLE
fix: TorchWriter.reset closes a file

### DIFF
--- a/harness/determined/tensorboard/metric_writers/pytorch.py
+++ b/harness/determined/tensorboard/metric_writers/pytorch.py
@@ -44,5 +44,5 @@ class TorchWriter(tensorboard.MetricWriter):
         self.writer.add_scalar(name, value, step)
 
     def reset(self) -> None:
-        if "flush" in dir(self.writer):
-            self.writer.flush()
+        # flush AND close the writer so that the next attempt to write will create a new file
+        self.writer.close()

--- a/harness/tests/tensorboard/test_torch_writer.py
+++ b/harness/tests/tensorboard/test_torch_writer.py
@@ -1,0 +1,23 @@
+import pathlib
+from typing import Dict, Any
+
+from _pytest import monkeypatch
+
+from determined import tensorboard
+from determined.tensorboard.metric_writers import pytorch
+
+
+def test_torch_writer(monkeypatch: monkeypatch.MonkeyPatch, tmp_path: pathlib.Path):
+    def mock_get_base_path(dummy: Dict[str, Any]):
+        return tmp_path
+    monkeypatch.setattr(tensorboard, "get_base_path", mock_get_base_path)
+    logger = pytorch.TorchWriter()
+    logger.add_scalar("foo", 7, 0)
+    logger.reset()
+    logger.add_scalar("foo", 8, 1)
+    logger.reset()
+
+    files = [f for f in tmp_path.iterdir()]
+    assert len(files) == 2
+
+

--- a/harness/tests/tensorboard/test_torch_writer.py
+++ b/harness/tests/tensorboard/test_torch_writer.py
@@ -1,5 +1,5 @@
 import pathlib
-from typing import Dict, Any
+from typing import Any, Dict
 
 from _pytest import monkeypatch
 
@@ -7,9 +7,10 @@ from determined import tensorboard
 from determined.tensorboard.metric_writers import pytorch
 
 
-def test_torch_writer(monkeypatch: monkeypatch.MonkeyPatch, tmp_path: pathlib.Path):
-    def mock_get_base_path(dummy: Dict[str, Any]):
+def test_torch_writer(monkeypatch: monkeypatch.MonkeyPatch, tmp_path: pathlib.Path) -> None:
+    def mock_get_base_path(dummy: Dict[str, Any]) -> pathlib.Path:
         return tmp_path
+
     monkeypatch.setattr(tensorboard, "get_base_path", mock_get_base_path)
     logger = pytorch.TorchWriter()
     logger.add_scalar("foo", 7, 0)
@@ -17,7 +18,5 @@ def test_torch_writer(monkeypatch: monkeypatch.MonkeyPatch, tmp_path: pathlib.Pa
     logger.add_scalar("foo", 8, 1)
     logger.reset()
 
-    files = [f for f in tmp_path.iterdir()]
+    files = list(tmp_path.iterdir())
     assert len(files) == 2
-
-


### PR DESCRIPTION
## Description

https://determinedai.atlassian.net/browse/MLG-191
https://determinedai.atlassian.net/browse/MLG-196

We have waited a long time to make TorchWriter behave the same way TFWriter does: `reset()` closes the underlying file writers. Next attempt to write will reopen them automatically (which is why `torch.SummaryWriter` does not have a `reopen` method.)

<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At a minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions about this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist
- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
