### PR TITLE
feat: Add warning for submissions for requests that cannot currently be fulfilled [DET-6410]

### DIFF
--- a/e2e_tests/tests/command/command.py
+++ b/e2e_tests/tests/command/command.py
@@ -24,7 +24,12 @@ class _InteractiveCommandProcess:
         else:
             iterator = iter(self.process.stdout)  # type: ignore
             line = next(iterator)
-            m = re.search(rb"Scheduling .* \(id: (.*)\)", line)
+            m = None
+            max_iterations = iterations = 0
+            while line and not m and iterations < max_iterations:
+                iterations += 1
+                m = re.search(rb"Scheduling .* \(id: (.*)\)", line)
+                line = next(iterator)
             assert m is not None
             self.task_id = m.group(1).decode() if m else None
 

--- a/e2e_tests/tests/command/command.py
+++ b/e2e_tests/tests/command/command.py
@@ -23,14 +23,13 @@ class _InteractiveCommandProcess:
             self.task_id = line.decode().strip()
         else:
             iterator = iter(self.process.stdout)  # type: ignore
-            line = next(iterator)
             m = None
             max_iterations = 2
             iterations = 0
-            while line and not m and iterations < max_iterations:
+            while not m and iterations < max_iterations:
+                line = next(iterator)
                 iterations += 1
                 m = re.search(rb"Scheduling .* \(id: (.*)\)", line)
-                line = next(iterator)
             assert m is not None
             self.task_id = m.group(1).decode() if m else None
 

--- a/e2e_tests/tests/command/command.py
+++ b/e2e_tests/tests/command/command.py
@@ -25,7 +25,8 @@ class _InteractiveCommandProcess:
             iterator = iter(self.process.stdout)  # type: ignore
             line = next(iterator)
             m = None
-            max_iterations = iterations = 0
+            max_iterations = 2
+            iterations = 0
             while line and not m and iterations < max_iterations:
                 iterations += 1
                 m = re.search(rb"Scheduling .* \(id: (.*)\)", line)

--- a/harness/determined/cli/notebook.py
+++ b/harness/determined/cli/notebook.py
@@ -33,6 +33,11 @@ def start_notebook(args: Namespace) -> None:
         print(nb.id)
         return
 
+    request.handle_warnings(resp.warnings)
+    currentSlotsExceeded = (resp.warnings is not None) and (
+        bindings.v1LaunchWarning.LAUNCH_WARNING_CURRENT_SLOTS_EXCEEDED in resp.warnings
+    )
+
     with api.ws(args.master, "notebooks/{}/events".format(nb.id)) as ws:
         for msg in ws:
             if msg["service_ready_event"] and nb.serviceAddress and not args.no_browser:
@@ -44,6 +49,7 @@ def start_notebook(args: Namespace) -> None:
                         description=nb.description,
                         resource_pool=nb.resourcePool,
                         task_type="notebook",
+                        currentSlotsExceeded=currentSlotsExceeded,
                     ),
                 )
                 print(colored("Jupyter Notebook is running at: {}".format(url), "green"))
@@ -64,6 +70,7 @@ def open_notebook(args: Namespace) -> None:
             description=resp["description"],
             resource_pool=resp["resourcePool"],
             task_type="notebook",
+            currentSlotsExceeded=False,
         ),
     )
 

--- a/harness/determined/common/api/__init__.py
+++ b/harness/determined/common/api/__init__.py
@@ -1,7 +1,7 @@
 from determined.common.api import authentication, errors, metric, request
 from determined.common.api._session import Session
 from determined.common.api import bindings
-from determined.common.api._util import PageOpts, read_paginated
+from determined.common.api._util import PageOpts, read_paginated, WARNING_MESSAGE_MAP
 from determined.common.api.authentication import Authentication, salt_and_hash
 from determined.common.api.experiment import (
     create_experiment,

--- a/harness/determined/common/api/_util.py
+++ b/harness/determined/common/api/_util.py
@@ -13,6 +13,14 @@ class PageOpts(str, enum.Enum):
 # The Paginated union type is generated based on response objects with a .pagination attribute.
 T = TypeVar("T", bound=bindings.Paginated)
 
+# Map of launch warnings to the warning message shown to users.
+WARNING_MESSAGE_MAP = {
+    bindings.v1LaunchWarning.LAUNCH_WARNING_CURRENT_SLOTS_EXCEEDED: (
+        "Warning: The requested job requires more slots than currently available. "
+        "You may need to increase cluster resources in order for the job to run."
+    )
+}
+
 
 def read_paginated(
     get_with_offset: Callable[[int], T],

--- a/harness/determined/common/api/bindings.py
+++ b/harness/determined/common/api/bindings.py
@@ -1744,15 +1744,19 @@ class v1CreateExperimentRequest:
         return out
 
 class v1CreateExperimentResponse:
+    warnings: "typing.Optional[typing.Sequence[v1LaunchWarning]]" = None
 
     def __init__(
         self,
         *,
         config: "typing.Dict[str, typing.Any]",
         experiment: "v1Experiment",
+        warnings: "typing.Union[typing.Sequence[v1LaunchWarning], None, Unset]" = _unset,
     ):
         self.config = config
         self.experiment = experiment
+        if not isinstance(warnings, Unset):
+            self.warnings = warnings
 
     @classmethod
     def from_json(cls, obj: Json) -> "v1CreateExperimentResponse":
@@ -1760,6 +1764,8 @@ class v1CreateExperimentResponse:
             "config": obj["config"],
             "experiment": v1Experiment.from_json(obj["experiment"]),
         }
+        if "warnings" in obj:
+            kwargs["warnings"] = [v1LaunchWarning(x) for x in obj["warnings"]] if obj["warnings"] is not None else None
         return cls(**kwargs)
 
     def to_json(self, omit_unset: bool = False) -> typing.Dict[str, typing.Any]:
@@ -1767,6 +1773,8 @@ class v1CreateExperimentResponse:
             "config": self.config,
             "experiment": self.experiment.to_json(omit_unset),
         }
+        if not omit_unset or "warnings" in vars(self):
+            out["warnings"] = None if self.warnings is None else [x.value for x in self.warnings]
         return out
 
 class v1CreateGroupRequest:
@@ -5284,15 +5292,19 @@ class v1LaunchCommandRequest:
         return out
 
 class v1LaunchCommandResponse:
+    warnings: "typing.Optional[typing.Sequence[v1LaunchWarning]]" = None
 
     def __init__(
         self,
         *,
         command: "v1Command",
         config: "typing.Dict[str, typing.Any]",
+        warnings: "typing.Union[typing.Sequence[v1LaunchWarning], None, Unset]" = _unset,
     ):
         self.command = command
         self.config = config
+        if not isinstance(warnings, Unset):
+            self.warnings = warnings
 
     @classmethod
     def from_json(cls, obj: Json) -> "v1LaunchCommandResponse":
@@ -5300,6 +5312,8 @@ class v1LaunchCommandResponse:
             "command": v1Command.from_json(obj["command"]),
             "config": obj["config"],
         }
+        if "warnings" in obj:
+            kwargs["warnings"] = [v1LaunchWarning(x) for x in obj["warnings"]] if obj["warnings"] is not None else None
         return cls(**kwargs)
 
     def to_json(self, omit_unset: bool = False) -> typing.Dict[str, typing.Any]:
@@ -5307,6 +5321,8 @@ class v1LaunchCommandResponse:
             "command": self.command.to_json(omit_unset),
             "config": self.config,
         }
+        if not omit_unset or "warnings" in vars(self):
+            out["warnings"] = None if self.warnings is None else [x.value for x in self.warnings]
         return out
 
 class v1LaunchNotebookRequest:
@@ -5360,15 +5376,19 @@ class v1LaunchNotebookRequest:
         return out
 
 class v1LaunchNotebookResponse:
+    warnings: "typing.Optional[typing.Sequence[v1LaunchWarning]]" = None
 
     def __init__(
         self,
         *,
         config: "typing.Dict[str, typing.Any]",
         notebook: "v1Notebook",
+        warnings: "typing.Union[typing.Sequence[v1LaunchWarning], None, Unset]" = _unset,
     ):
         self.config = config
         self.notebook = notebook
+        if not isinstance(warnings, Unset):
+            self.warnings = warnings
 
     @classmethod
     def from_json(cls, obj: Json) -> "v1LaunchNotebookResponse":
@@ -5376,6 +5396,8 @@ class v1LaunchNotebookResponse:
             "config": obj["config"],
             "notebook": v1Notebook.from_json(obj["notebook"]),
         }
+        if "warnings" in obj:
+            kwargs["warnings"] = [v1LaunchWarning(x) for x in obj["warnings"]] if obj["warnings"] is not None else None
         return cls(**kwargs)
 
     def to_json(self, omit_unset: bool = False) -> typing.Dict[str, typing.Any]:
@@ -5383,6 +5405,8 @@ class v1LaunchNotebookResponse:
             "config": self.config,
             "notebook": self.notebook.to_json(omit_unset),
         }
+        if not omit_unset or "warnings" in vars(self):
+            out["warnings"] = None if self.warnings is None else [x.value for x in self.warnings]
         return out
 
 class v1LaunchShellRequest:
@@ -5436,15 +5460,19 @@ class v1LaunchShellRequest:
         return out
 
 class v1LaunchShellResponse:
+    warnings: "typing.Optional[typing.Sequence[v1LaunchWarning]]" = None
 
     def __init__(
         self,
         *,
         config: "typing.Dict[str, typing.Any]",
         shell: "v1Shell",
+        warnings: "typing.Union[typing.Sequence[v1LaunchWarning], None, Unset]" = _unset,
     ):
         self.config = config
         self.shell = shell
+        if not isinstance(warnings, Unset):
+            self.warnings = warnings
 
     @classmethod
     def from_json(cls, obj: Json) -> "v1LaunchShellResponse":
@@ -5452,6 +5480,8 @@ class v1LaunchShellResponse:
             "config": obj["config"],
             "shell": v1Shell.from_json(obj["shell"]),
         }
+        if "warnings" in obj:
+            kwargs["warnings"] = [v1LaunchWarning(x) for x in obj["warnings"]] if obj["warnings"] is not None else None
         return cls(**kwargs)
 
     def to_json(self, omit_unset: bool = False) -> typing.Dict[str, typing.Any]:
@@ -5459,6 +5489,8 @@ class v1LaunchShellResponse:
             "config": self.config,
             "shell": self.shell.to_json(omit_unset),
         }
+        if not omit_unset or "warnings" in vars(self):
+            out["warnings"] = None if self.warnings is None else [x.value for x in self.warnings]
         return out
 
 class v1LaunchTensorboardRequest:
@@ -5520,15 +5552,19 @@ class v1LaunchTensorboardRequest:
         return out
 
 class v1LaunchTensorboardResponse:
+    warnings: "typing.Optional[typing.Sequence[v1LaunchWarning]]" = None
 
     def __init__(
         self,
         *,
         config: "typing.Dict[str, typing.Any]",
         tensorboard: "v1Tensorboard",
+        warnings: "typing.Union[typing.Sequence[v1LaunchWarning], None, Unset]" = _unset,
     ):
         self.config = config
         self.tensorboard = tensorboard
+        if not isinstance(warnings, Unset):
+            self.warnings = warnings
 
     @classmethod
     def from_json(cls, obj: Json) -> "v1LaunchTensorboardResponse":
@@ -5536,6 +5572,8 @@ class v1LaunchTensorboardResponse:
             "config": obj["config"],
             "tensorboard": v1Tensorboard.from_json(obj["tensorboard"]),
         }
+        if "warnings" in obj:
+            kwargs["warnings"] = [v1LaunchWarning(x) for x in obj["warnings"]] if obj["warnings"] is not None else None
         return cls(**kwargs)
 
     def to_json(self, omit_unset: bool = False) -> typing.Dict[str, typing.Any]:
@@ -5543,7 +5581,13 @@ class v1LaunchTensorboardResponse:
             "config": self.config,
             "tensorboard": self.tensorboard.to_json(omit_unset),
         }
+        if not omit_unset or "warnings" in vars(self):
+            out["warnings"] = None if self.warnings is None else [x.value for x in self.warnings]
         return out
+
+class v1LaunchWarning(enum.Enum):
+    LAUNCH_WARNING_UNSPECIFIED = "LAUNCH_WARNING_UNSPECIFIED"
+    LAUNCH_WARNING_CURRENT_SLOTS_EXCEEDED = "LAUNCH_WARNING_CURRENT_SLOTS_EXCEEDED"
 
 class v1ListRolesRequest:
     offset: "typing.Optional[int]" = None

--- a/harness/determined/common/api/experiment.py
+++ b/harness/determined/common/api/experiment.py
@@ -1,9 +1,10 @@
+import json
 import math
 import random
 import sys
 import time
 import uuid
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Sequence, Tuple
 
 from termcolor import colored
 
@@ -127,7 +128,8 @@ def create_experiment(
     archived: bool = False,
     activate: bool = True,
     additional_body_fields: Optional[Dict[str, Any]] = None,
-) -> int:
+) -> Tuple[int, Optional[Sequence[bindings.v1LaunchWarning]]]:
+
     body = {
         "activate": False,
         "experiment_config": yaml.safe_dump(config),
@@ -147,7 +149,19 @@ def create_experiment(
         raise Exception(r)
 
     if validate_only:
-        return 0
+        return 0, None
+
+    try:
+        j = r.json()
+    except json.decoder.JSONDecodeError:
+        warnings: Optional[list[bindings.v1LaunchWarning]] = None
+    else:
+        response_warnings: Optional[list[int]] = j.get("warnings")
+        if response_warnings:
+            launch_warnings = list(bindings.v1LaunchWarning)
+            warnings = [launch_warnings[warning] for warning in response_warnings]
+        else:
+            warnings = None
 
     new_resource = r.headers["Location"]
     experiment_id = int(new_resource.split("/")[-1])
@@ -156,7 +170,7 @@ def create_experiment(
         sess = api.Session(master_url, None, None, None)
         bindings.post_ActivateExperiment(sess, id=experiment_id)
 
-    return experiment_id
+    return experiment_id, warnings
 
 
 def generate_random_hparam_values(hparam_def: Dict[str, Any]) -> Dict[str, Any]:
@@ -241,7 +255,7 @@ def create_experiment_and_follow_logs(
     activate: bool = True,
     follow_first_trial_logs: bool = True,
 ) -> int:
-    exp_id = api.experiment.create_experiment(
+    exp_id, warnings = api.experiment.create_experiment(
         master_url,
         config,
         model_context,
@@ -250,6 +264,9 @@ def create_experiment_and_follow_logs(
         activate=activate,
     )
     print("Created experiment {}".format(exp_id))
+
+    req.handle_warnings(warnings)
+
     if activate and follow_first_trial_logs:
         api.follow_experiment_logs(master_url, exp_id)
     return exp_id
@@ -274,7 +291,7 @@ def create_test_experiment_and_follow_logs(
     print(colored("Experiment configuration validation succeeded! 🎉", "green"))
 
     print(colored("Creating test experiment...", "yellow"), end="\r")
-    exp_id = api.experiment.create_experiment(
+    exp_id, _ = api.experiment.create_experiment(
         master_url,
         make_test_experiment_config(config),
         model_context,

--- a/harness/determined/experimental/client.py
+++ b/harness/determined/experimental/client.py
@@ -48,7 +48,7 @@ import pathlib
 import warnings
 from typing import Any, Callable, Dict, Iterable, List, Optional, Sequence, Union
 
-from determined.common.api import Session  # noqa: F401
+from determined.common.api import Session, bindings  # noqa: F401
 from determined.common.experimental.checkpoint import (  # noqa: F401
     Checkpoint,
     CheckpointState,

--- a/master/internal/api_command.go
+++ b/master/internal/api_command.go
@@ -23,6 +23,7 @@ import (
 	"github.com/determined-ai/determined/master/pkg/actor"
 	"github.com/determined-ai/determined/master/pkg/archive"
 	"github.com/determined-ai/determined/master/pkg/check"
+	command "github.com/determined-ai/determined/master/pkg/command"
 	"github.com/determined-ai/determined/master/pkg/etc"
 	"github.com/determined-ai/determined/master/pkg/model"
 	"github.com/determined-ai/determined/master/pkg/protoutils"
@@ -52,27 +53,29 @@ type protoCommandParams struct {
 }
 
 func (a *apiServer) getCommandLaunchParams(ctx context.Context, req *protoCommandParams) (
-	*tasks.GenericCommandSpec, error,
+	*tasks.GenericCommandSpec, []command.LaunchWarning, error,
 ) {
 	var err error
 
 	// Validate the userModel and get the agent userModel group.
 	userModel, _, err := grpcutil.GetUser(ctx)
 	if err != nil {
-		return nil, status.Errorf(codes.Unauthenticated, "failed to get the user: %s", err)
+		return nil,
+			nil,
+			status.Errorf(codes.Unauthenticated, "failed to get the user: %s", err)
 	}
 
 	// TODO(ilia): When commands are workspaced, also use workspace AgentUserGroup here.
 	agentUserGroup, err := user.GetAgentUserGroup(userModel.ID, nil)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	var configBytes []byte
 	if req.Config != nil {
 		configBytes, err = protojson.Marshal(req.Config)
 		if err != nil {
-			return nil, status.Errorf(
+			return nil, nil, status.Errorf(
 				codes.InvalidArgument, "failed to parse config %s: %s", configBytes, err)
 		}
 	}
@@ -82,13 +85,23 @@ func (a *apiServer) getCommandLaunchParams(ctx context.Context, req *protoComman
 	if req.MustZeroSlot {
 		resources.Slots = 0
 	}
-
 	poolName, err := a.m.rm.ResolveResourcePool(
-		a.m.system, resources.ResourcePool, resources.Slots, true)
+		a.m.system, resources.ResourcePool, resources.Slots)
 	if err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, err.Error())
+		return nil, nil, status.Errorf(codes.InvalidArgument, err.Error())
+	}
+	if err = a.m.rm.ValidateResources(a.m.system, poolName, resources.Slots, true); err != nil {
+		return nil, nil, fmt.Errorf("validating resources: %v", err)
 	}
 
+	launchWarnings, err := a.m.rm.ValidateResourcePoolAvailability(
+		a.m.system,
+		poolName,
+		resources.Slots,
+	)
+	if err != nil {
+		return nil, launchWarnings, fmt.Errorf("checking respurce availability: %v", err.Error())
+	}
 	// Get the base TaskSpec.
 	taskContainerDefaults := a.m.getTaskContainerDefaults(poolName)
 	taskSpec := *a.m.taskSpec
@@ -106,11 +119,11 @@ func (a *apiServer) getCommandLaunchParams(ctx context.Context, req *protoComman
 	if req.TemplateName != "" {
 		template, err := a.m.db.TemplateByName(req.TemplateName)
 		if err != nil {
-			return nil, status.Errorf(codes.InvalidArgument,
+			return nil, launchWarnings, status.Errorf(codes.InvalidArgument,
 				errors.Wrapf(err, "failed to find template: %s", req.TemplateName).Error())
 		}
 		if err := yaml.Unmarshal(template.Config, &config); err != nil {
-			return nil, status.Errorf(codes.InvalidArgument,
+			return nil, launchWarnings, status.Errorf(codes.InvalidArgument,
 				errors.Wrapf(err, "failed to unmarshal template: %s", req.TemplateName).Error())
 		}
 	}
@@ -119,7 +132,7 @@ func (a *apiServer) getCommandLaunchParams(ctx context.Context, req *protoComman
 		dec.DisallowUnknownFields()
 
 		if err := dec.Decode(&config); err != nil {
-			return nil, status.Errorf(codes.InvalidArgument,
+			return nil, launchWarnings, status.Errorf(codes.InvalidArgument,
 				errors.Wrapf(err,
 					"unable to decode the merged config: %s", string(configBytes)).Error())
 		}
@@ -142,7 +155,7 @@ func (a *apiServer) getCommandLaunchParams(ctx context.Context, req *protoComman
 		workdirSetInReq := config.WorkDir != nil &&
 			(workDirInDefaults == nil || *workDirInDefaults != *config.WorkDir)
 		if workdirSetInReq {
-			return nil, status.Errorf(codes.InvalidArgument,
+			return nil, launchWarnings, status.Errorf(codes.InvalidArgument,
 				"cannot set work_dir and context directory at the same time")
 		}
 		config.WorkDir = nil
@@ -150,7 +163,7 @@ func (a *apiServer) getCommandLaunchParams(ctx context.Context, req *protoComman
 
 	token, createSessionErr := a.m.db.StartUserSession(userModel)
 	if createSessionErr != nil {
-		return nil, status.Errorf(codes.Internal,
+		return nil, launchWarnings, status.Errorf(codes.Internal,
 			errors.Wrapf(createSessionErr,
 				"unable to create user session inside task").Error())
 	}
@@ -160,7 +173,7 @@ func (a *apiServer) getCommandLaunchParams(ctx context.Context, req *protoComman
 		Base:      taskSpec,
 		Config:    config,
 		UserFiles: userFiles,
-	}, nil
+	}, launchWarnings, nil
 }
 
 func (a *apiServer) GetCommands(
@@ -239,7 +252,7 @@ func (a *apiServer) SetCommandPriority(
 func (a *apiServer) LaunchCommand(
 	ctx context.Context, req *apiv1.LaunchCommandRequest,
 ) (*apiv1.LaunchCommandResponse, error) {
-	spec, err := a.getCommandLaunchParams(ctx, &protoCommandParams{
+	spec, launchWarnings, err := a.getCommandLaunchParams(ctx, &protoCommandParams{
 		TemplateName: req.TemplateName,
 		Config:       req.Config,
 		Files:        req.Files,
@@ -287,7 +300,8 @@ func (a *apiServer) LaunchCommand(
 	}
 
 	return &apiv1.LaunchCommandResponse{
-		Command: cmd,
-		Config:  protoutils.ToStruct(spec.Config),
+		Command:  cmd,
+		Config:   protoutils.ToStruct(spec.Config),
+		Warnings: command.LaunchWarningToProto(launchWarnings),
 	}, nil
 }

--- a/master/internal/api_experiment.go
+++ b/master/internal/api_experiment.go
@@ -36,6 +36,7 @@ import (
 	"github.com/determined-ai/determined/master/internal/hpimportance"
 	"github.com/determined-ai/determined/master/internal/lttb"
 	"github.com/determined-ai/determined/master/pkg/actor"
+	command "github.com/determined-ai/determined/master/pkg/command"
 	"github.com/determined-ai/determined/master/pkg/model"
 	"github.com/determined-ai/determined/master/pkg/protoutils"
 	"github.com/determined-ai/determined/master/pkg/protoutils/protoless"
@@ -1153,7 +1154,7 @@ func (a *apiServer) CreateExperiment(
 		}
 	}
 
-	e, err := newExperiment(a.m, dbExp, taskSpec)
+	e, launchWarnings, err := newExperiment(a.m, dbExp, taskSpec)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to create experiment: %s", err)
 	}
@@ -1171,7 +1172,9 @@ func (a *apiServer) CreateExperiment(
 		return nil, err
 	}
 	return &apiv1.CreateExperimentResponse{
-		Experiment: protoExp, Config: protoutils.ToStruct(e.Config),
+		Experiment: protoExp,
+		Config:     protoutils.ToStruct(e.Config),
+		Warnings:   command.LaunchWarningToProto(launchWarnings),
 	}, nil
 }
 

--- a/master/internal/api_notebook.go
+++ b/master/internal/api_notebook.go
@@ -19,6 +19,7 @@ import (
 	"github.com/determined-ai/determined/master/pkg/actor"
 	"github.com/determined-ai/determined/master/pkg/archive"
 	"github.com/determined-ai/determined/master/pkg/check"
+	command "github.com/determined-ai/determined/master/pkg/command"
 	"github.com/determined-ai/determined/master/pkg/etc"
 	"github.com/determined-ai/determined/master/pkg/model"
 	"github.com/determined-ai/determined/master/pkg/protoutils"
@@ -131,7 +132,7 @@ func (a *apiServer) SetNotebookPriority(
 func (a *apiServer) LaunchNotebook(
 	ctx context.Context, req *apiv1.LaunchNotebookRequest,
 ) (*apiv1.LaunchNotebookResponse, error) {
-	spec, err := a.getCommandLaunchParams(ctx, &protoCommandParams{
+	spec, launchWarnings, err := a.getCommandLaunchParams(ctx, &protoCommandParams{
 		TemplateName: req.TemplateName,
 		Config:       req.Config,
 		Files:        req.Files,
@@ -223,5 +224,6 @@ func (a *apiServer) LaunchNotebook(
 	return &apiv1.LaunchNotebookResponse{
 		Notebook: notebook,
 		Config:   protoutils.ToStruct(spec.Config),
+		Warnings: command.LaunchWarningToProto(launchWarnings),
 	}, nil
 }

--- a/master/internal/api_shell.go
+++ b/master/internal/api_shell.go
@@ -19,6 +19,7 @@ import (
 	"github.com/determined-ai/determined/master/pkg/actor"
 	"github.com/determined-ai/determined/master/pkg/archive"
 	"github.com/determined-ai/determined/master/pkg/check"
+	command "github.com/determined-ai/determined/master/pkg/command"
 	"github.com/determined-ai/determined/master/pkg/etc"
 	"github.com/determined-ai/determined/master/pkg/model"
 	"github.com/determined-ai/determined/master/pkg/protoutils"
@@ -115,7 +116,7 @@ func (a *apiServer) SetShellPriority(
 func (a *apiServer) LaunchShell(
 	ctx context.Context, req *apiv1.LaunchShellRequest,
 ) (*apiv1.LaunchShellResponse, error) {
-	spec, err := a.getCommandLaunchParams(ctx, &protoCommandParams{
+	spec, launchWarnings, err := a.getCommandLaunchParams(ctx, &protoCommandParams{
 		TemplateName: req.TemplateName,
 		Config:       req.Config,
 		Files:        req.Files,
@@ -200,7 +201,8 @@ func (a *apiServer) LaunchShell(
 	}
 
 	return &apiv1.LaunchShellResponse{
-		Shell:  shell,
-		Config: protoutils.ToStruct(spec.Config),
+		Shell:    shell,
+		Config:   protoutils.ToStruct(spec.Config),
+		Warnings: command.LaunchWarningToProto(launchWarnings),
 	}, nil
 }

--- a/master/internal/api_tensorboard.go
+++ b/master/internal/api_tensorboard.go
@@ -29,6 +29,7 @@ import (
 	"github.com/determined-ai/determined/master/pkg/actor"
 	"github.com/determined-ai/determined/master/pkg/archive"
 	"github.com/determined-ai/determined/master/pkg/check"
+	command "github.com/determined-ai/determined/master/pkg/command"
 	"github.com/determined-ai/determined/master/pkg/etc"
 	"github.com/determined-ai/determined/master/pkg/model"
 	"github.com/determined-ai/determined/master/pkg/protoutils"
@@ -160,7 +161,7 @@ func (a *apiServer) LaunchTensorboard(
 		return nil, status.Error(codes.InvalidArgument, "no experiments found")
 	}
 
-	spec, err := a.getCommandLaunchParams(ctx, &protoCommandParams{
+	spec, launchWarnings, err := a.getCommandLaunchParams(ctx, &protoCommandParams{
 		TemplateName: req.TemplateName,
 		Config:       req.Config,
 		Files:        req.Files,
@@ -390,6 +391,7 @@ func (a *apiServer) LaunchTensorboard(
 	return &apiv1.LaunchTensorboardResponse{
 		Tensorboard: tb,
 		Config:      protoutils.ToStruct(spec.Config),
+		Warnings:    command.LaunchWarningToProto(launchWarnings),
 	}, err
 }
 

--- a/master/internal/restore.go
+++ b/master/internal/restore.go
@@ -79,12 +79,17 @@ func (m *Master) restoreExperiment(expModel *model.Experiment) error {
 		m.system,
 		expModel.Config.Resources().ResourcePool(),
 		expModel.Config.Resources().SlotsPerTrial(),
-		false,
 	)
 	if err != nil {
 		return fmt.Errorf("invalid resource configuration: %w", err)
 	}
-
+	if err = m.rm.ValidateResources(
+		m.system,
+		poolName,
+		expModel.Config.Resources().SlotsPerTrial(),
+		false); err != nil {
+		return fmt.Errorf("validating resources: %v", err)
+	}
 	taskContainerDefaults := m.getTaskContainerDefaults(poolName)
 	taskSpec := *m.taskSpec
 	taskSpec.TaskContainerDefaults = taskContainerDefaults
@@ -99,7 +104,7 @@ func (m *Master) restoreExperiment(expModel *model.Experiment) error {
 	if err != nil {
 		return errors.Wrapf(err, "failed to restore experiment %d", expModel.ID)
 	}
-	e, err := newExperiment(m, expModel, &taskSpec)
+	e, _, err := newExperiment(m, expModel, &taskSpec)
 	if err != nil {
 		return errors.Wrapf(err, "failed to create experiment %d from model", expModel.ID)
 	}

--- a/master/internal/rm/actorrm/actor_resource_manager.go
+++ b/master/internal/rm/actorrm/actor_resource_manager.go
@@ -42,7 +42,7 @@ func (r *ResourceManager) ResolveResourcePool(
 }
 
 // ValidateResources is a default implementation to satisfy the interface, mostly for tests.
-func (r *ActorResourceManager) ValidateResources(
+func (r *ResourceManager) ValidateResources(
 	ctx actor.Messenger,
 	name string,
 	slots int,
@@ -52,7 +52,7 @@ func (r *ActorResourceManager) ValidateResources(
 }
 
 // ValidateResourcePoolAvailability is a default implementation to satisfy the interface.
-func (r *ActorResourceManager) ValidateResourcePoolAvailability(
+func (r *ResourceManager) ValidateResourcePoolAvailability(
 	ctx actor.Messenger,
 	name string,
 	slots int) (

--- a/master/internal/rm/actorrm/actor_resource_manager.go
+++ b/master/internal/rm/actorrm/actor_resource_manager.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/determined-ai/determined/master/internal/sproto"
 	"github.com/determined-ai/determined/master/pkg/actor"
+	"github.com/determined-ai/determined/master/pkg/command"
 	"github.com/determined-ai/determined/master/pkg/model"
 	"github.com/determined-ai/determined/proto/pkg/apiv1"
 	"github.com/determined-ai/determined/proto/pkg/jobv1"
@@ -36,9 +37,29 @@ func (r *ResourceManager) ResolveResourcePool(
 	ctx actor.Messenger,
 	name string,
 	slots int,
-	command bool,
 ) (string, error) {
 	return name, nil
+}
+
+// ValidateResources is a default implementation to satisfy the interface, mostly for tests.
+func (r *ActorResourceManager) ValidateResources(
+	ctx actor.Messenger,
+	name string,
+	slots int,
+	command bool,
+) error {
+	return nil
+}
+
+// ValidateResourcePoolAvailability is a default implementation to satisfy the interface.
+func (r *ActorResourceManager) ValidateResourcePoolAvailability(
+	ctx actor.Messenger,
+	name string,
+	slots int) (
+	[]command.LaunchWarning,
+	error,
+) {
+	return nil, nil
 }
 
 // ValidateResourcePool is a default implementation to satisfy the interface, mostly for tests.

--- a/master/internal/rm/agentrm/agent_resource_manager.go
+++ b/master/internal/rm/agentrm/agent_resource_manager.go
@@ -99,7 +99,7 @@ func (a ResourceManager) IsReattachEnabledForRP(ctx actor.Messenger, rpName stri
 }
 
 // CheckMaxSlotsExceeded checks if the job exceeded the maximum number of slots.
-func (a AgentResourceManager) CheckMaxSlotsExceeded(
+func (a ResourceManager) CheckMaxSlotsExceeded(
 	ctx actor.Messenger, name string, slots int,
 ) (bool, error) {
 	ref, err := a.GetResourcePoolRef(ctx, name)
@@ -117,7 +117,7 @@ func (a AgentResourceManager) CheckMaxSlotsExceeded(
 
 // ResolveResourcePool fully resolves the resource pool name.
 func (a ResourceManager) ResolveResourcePool(
-	ctx actor.Messenger, name string, slots int, command bool,
+	ctx actor.Messenger, name string, slots int,
 ) (string, error) {
 	// If the resource pool isn't set, fill in the default at creation time.
 	if name == "" && slots == 0 {
@@ -145,7 +145,7 @@ func (a ResourceManager) ResolveResourcePool(
 }
 
 // ValidateResources ensures enough resources are available for a command.
-func (a AgentResourceManager) ValidateResources(
+func (a ResourceManager) ValidateResources(
 	ctx actor.Messenger, name string, slots int, command bool,
 ) error {
 	// TODO: Replace this function usage with ValidateCommandResources
@@ -165,7 +165,7 @@ func (a AgentResourceManager) ValidateResources(
 }
 
 // ValidateResourcePoolAvailability is a default implementation to satisfy the interface.
-func (a AgentResourceManager) ValidateResourcePoolAvailability(ctx actor.Messenger,
+func (a ResourceManager) ValidateResourcePoolAvailability(ctx actor.Messenger,
 	name string, slots int) (
 	[]command.LaunchWarning,
 	error,

--- a/master/internal/rm/kubernetesrm/kubernetes_resource_manager.go
+++ b/master/internal/rm/kubernetesrm/kubernetes_resource_manager.go
@@ -14,18 +14,18 @@ import (
 	"github.com/pkg/errors"
 	"github.com/shopspring/decimal"
 
-	"github.com/determined-ai/determined/master/pkg/schemas/expconf"
-
 	"github.com/determined-ai/determined/master/internal/config"
 	"github.com/determined-ai/determined/master/internal/db"
 	"github.com/determined-ai/determined/master/internal/sproto"
 	"github.com/determined-ai/determined/master/pkg/actor"
 	"github.com/determined-ai/determined/master/pkg/actor/actors"
 	"github.com/determined-ai/determined/master/pkg/aproto"
+	"github.com/determined-ai/determined/master/pkg/command"
 	"github.com/determined-ai/determined/master/pkg/cproto"
 	"github.com/determined-ai/determined/master/pkg/device"
 	"github.com/determined-ai/determined/master/pkg/logger"
 	"github.com/determined-ai/determined/master/pkg/model"
+	"github.com/determined-ai/determined/master/pkg/schemas/expconf"
 	"github.com/determined-ai/determined/master/pkg/tasks"
 	"github.com/determined-ai/determined/proto/pkg/apiv1"
 	"github.com/determined-ai/determined/proto/pkg/resourcepoolv1"
@@ -89,9 +89,18 @@ func (k ResourceManager) ResolveResourcePool(
 	ctx actor.Messenger,
 	name string,
 	slots int,
-	command bool,
 ) (string, error) {
 	return KubernetesDummyResourcePool, k.ValidateResourcePool(ctx, name)
+}
+
+// ValidateResources ensures enough resources are available in the resource pool.
+func (k KubernetesResourceManager) ValidateResources(
+	ctx actor.Messenger,
+	name string,
+	slots int,
+	command bool,
+) error {
+	return nil
 }
 
 // ValidateResourcePool validates a resource pool is none or the k8s dummy pool.
@@ -100,6 +109,18 @@ func (k ResourceManager) ValidateResourcePool(ctx actor.Messenger, name string) 
 		return fmt.Errorf("k8s doesn't not support resource pools")
 	}
 	return nil
+}
+
+// ValidateResourcePoolAvailability checks the available resources for a given pool.
+func (k KubernetesResourceManager) ValidateResourcePoolAvailability(
+	ctx actor.Messenger,
+	name string,
+	slots int,
+) ([]command.LaunchWarning, error) {
+	if name != "" && name != KubernetesDummyResourcePool {
+		return nil, fmt.Errorf("k8s doesn't not support resource pools")
+	}
+	return nil, nil
 }
 
 // GetDefaultComputeResourcePool requests the default compute resource pool.

--- a/master/internal/rm/kubernetesrm/kubernetes_resource_manager.go
+++ b/master/internal/rm/kubernetesrm/kubernetes_resource_manager.go
@@ -94,7 +94,7 @@ func (k ResourceManager) ResolveResourcePool(
 }
 
 // ValidateResources ensures enough resources are available in the resource pool.
-func (k KubernetesResourceManager) ValidateResources(
+func (k ResourceManager) ValidateResources(
 	ctx actor.Messenger,
 	name string,
 	slots int,
@@ -112,7 +112,7 @@ func (k ResourceManager) ValidateResourcePool(ctx actor.Messenger, name string) 
 }
 
 // ValidateResourcePoolAvailability checks the available resources for a given pool.
-func (k KubernetesResourceManager) ValidateResourcePoolAvailability(
+func (k ResourceManager) ValidateResourcePoolAvailability(
 	ctx actor.Messenger,
 	name string,
 	slots int,

--- a/master/internal/rm/resource_manager_iface.go
+++ b/master/internal/rm/resource_manager_iface.go
@@ -3,6 +3,7 @@ package rm
 import (
 	"github.com/determined-ai/determined/master/internal/sproto"
 	"github.com/determined-ai/determined/master/pkg/actor"
+	"github.com/determined-ai/determined/master/pkg/command"
 	"github.com/determined-ai/determined/master/pkg/model"
 	"github.com/determined-ai/determined/proto/pkg/apiv1"
 	"github.com/determined-ai/determined/proto/pkg/jobv1"
@@ -27,6 +28,9 @@ type ResourceManager interface {
 		actor.Messenger,
 		sproto.ValidateCommandResourcesRequest,
 	) (sproto.ValidateCommandResourcesResponse, error)
+	ValidateResources(
+		ctx actor.Messenger, name string, slots int, command bool,
+	) error
 	DeleteJob(actor.Messenger, sproto.DeleteJob) (sproto.DeleteJobResponse, error)
 	NotifyContainerRunning(actor.Messenger, sproto.NotifyContainerRunning) error
 
@@ -54,7 +58,15 @@ type ResourceManager interface {
 		sproto.GetDefaultAuxResourcePoolRequest,
 	) (sproto.GetDefaultAuxResourcePoolResponse, error)
 	ValidateResourcePool(ctx actor.Messenger, name string) error
-	ResolveResourcePool(ctx actor.Messenger, name string, slots int, command bool) (string, error)
+	ResolveResourcePool(
+		ctx actor.Messenger,
+		name string,
+		slots int,
+	) (string, error)
+	ValidateResourcePoolAvailability(
+		ctx actor.Messenger,
+		name string,
+		slots int) ([]command.LaunchWarning, error)
 
 	// Agents
 	GetAgents(actor.Messenger, *apiv1.GetAgentsRequest) (*apiv1.GetAgentsResponse, error)

--- a/master/internal/sproto/resource_pool.go
+++ b/master/internal/sproto/resource_pool.go
@@ -1,0 +1,13 @@
+package sproto
+
+type (
+	// CapacityCheck checks the potential available slots in a resource pool.
+	CapacityCheck struct {
+		Slots int
+	}
+	// CapacityCheckResponse is the response to a CapacityCheck message.
+	CapacityCheckResponse struct {
+		SlotsAvailable   int
+		CapacityExceeded bool
+	}
+)

--- a/master/pkg/command/command.go
+++ b/master/pkg/command/command.go
@@ -1,0 +1,33 @@
+package command
+
+import (
+	"fmt"
+
+	"github.com/determined-ai/determined/proto/pkg/apiv1"
+)
+
+// LaunchWarning represents warnings related to launching commands.
+type LaunchWarning int
+
+const (
+	// CurrentSlotsExceeded represents a resource pool having insufficient slots.
+	CurrentSlotsExceeded LaunchWarning = 1
+)
+
+func toProtoEnum(l LaunchWarning) apiv1.LaunchWarning {
+	switch l {
+	case CurrentSlotsExceeded:
+		return apiv1.LaunchWarning_LAUNCH_WARNING_CURRENT_SLOTS_EXCEEDED
+	default:
+		panic(fmt.Sprintf("Unknown LaunchWarning value %v", l))
+	}
+}
+
+// LaunchWarningToProto converts LaunchWarnings to their protobuf representation.
+func LaunchWarningToProto(lw []LaunchWarning) []apiv1.LaunchWarning {
+	res := make([]apiv1.LaunchWarning, 0, len(lw))
+	for _, w := range lw {
+		res = append(res, toProtoEnum(w))
+	}
+	return res
+}

--- a/master/pkg/model/experiment.go
+++ b/master/pkg/model/experiment.go
@@ -20,6 +20,7 @@ import (
 	"github.com/pkg/errors"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
+	"github.com/determined-ai/determined/master/pkg/command"
 	"github.com/determined-ai/determined/master/pkg/ptrs"
 	"github.com/determined-ai/determined/master/pkg/schemas/expconf"
 	"github.com/determined-ai/determined/proto/pkg/apiv1"
@@ -349,6 +350,7 @@ type ExperimentDescriptor struct {
 	Archived bool                     `json:"archived"`
 	Config   expconf.ExperimentConfig `json:"config"`
 	Labels   []string                 `json:"labels"`
+	Warnings []command.LaunchWarning  `json:"warnings"`
 }
 
 // NewExperiment creates a new experiment struct in the paused state.  Note

--- a/proto/src/determined/api/v1/command.proto
+++ b/proto/src/determined/api/v1/command.proto
@@ -94,6 +94,15 @@ message LaunchCommandRequest {
   // Additional data.
   bytes data = 4;
 }
+
+// Enum values for warnings when launching commands.
+enum LaunchWarning {
+  // Default value
+  LAUNCH_WARNING_UNSPECIFIED = 0;
+  // For a default webhook
+  LAUNCH_WARNING_CURRENT_SLOTS_EXCEEDED = 1;
+}
+
 // Response to LaunchCommandRequest.
 message LaunchCommandResponse {
   option (grpc.gateway.protoc_gen_swagger.options.openapiv2_schema) = {
@@ -103,4 +112,6 @@ message LaunchCommandResponse {
   determined.command.v1.Command command = 1;
   // The config;
   google.protobuf.Struct config = 2;
+  // If the requested slots exceeded the current max available.
+  repeated LaunchWarning warnings = 3;
 }

--- a/proto/src/determined/api/v1/experiment.proto
+++ b/proto/src/determined/api/v1/experiment.proto
@@ -7,6 +7,7 @@ import "google/protobuf/wrappers.proto";
 import "google/protobuf/struct.proto";
 import "protoc-gen-swagger/options/annotations.proto";
 
+import "determined/api/v1/command.proto";
 import "determined/api/v1/pagination.proto";
 import "determined/common/v1/common.proto";
 import "determined/checkpoint/v1/checkpoint.proto";
@@ -313,6 +314,8 @@ message CreateExperimentResponse {
   determined.experiment.v1.Experiment experiment = 1;
   // The created experiment config.
   google.protobuf.Struct config = 2;
+  // List of any related warnings.
+  repeated LaunchWarning warnings = 3;
 }
 
 // Request for the set of metrics recorded by an experiment.

--- a/proto/src/determined/api/v1/notebook.proto
+++ b/proto/src/determined/api/v1/notebook.proto
@@ -5,6 +5,7 @@ option go_package = "github.com/determined-ai/determined/proto/pkg/apiv1";
 
 import "google/protobuf/struct.proto";
 
+import "determined/api/v1/command.proto";
 import "determined/api/v1/pagination.proto";
 import "determined/notebook/v1/notebook.proto";
 import "determined/util/v1/util.proto";
@@ -114,4 +115,6 @@ message LaunchNotebookResponse {
   determined.notebook.v1.Notebook notebook = 1;
   // The config;
   google.protobuf.Struct config = 2;
+  // List of any related warnings.
+  repeated LaunchWarning warnings = 3;
 }

--- a/proto/src/determined/api/v1/shell.proto
+++ b/proto/src/determined/api/v1/shell.proto
@@ -5,6 +5,7 @@ option go_package = "github.com/determined-ai/determined/proto/pkg/apiv1";
 
 import "google/protobuf/struct.proto";
 
+import "determined/api/v1/command.proto";
 import "determined/api/v1/pagination.proto";
 import "determined/shell/v1/shell.proto";
 import "determined/util/v1/util.proto";
@@ -102,4 +103,7 @@ message LaunchShellResponse {
   determined.shell.v1.Shell shell = 1;
   // The config;
   google.protobuf.Struct config = 2;
+
+  // List of any related warnings.
+  repeated LaunchWarning warnings = 3;
 }

--- a/proto/src/determined/api/v1/tensorboard.proto
+++ b/proto/src/determined/api/v1/tensorboard.proto
@@ -5,6 +5,7 @@ option go_package = "github.com/determined-ai/determined/proto/pkg/apiv1";
 
 import "google/protobuf/struct.proto";
 
+import "determined/api/v1/command.proto";
 import "determined/api/v1/pagination.proto";
 import "determined/tensorboard/v1/tensorboard.proto";
 import "determined/util/v1/util.proto";
@@ -107,4 +108,6 @@ message LaunchTensorboardResponse {
   determined.tensorboard.v1.Tensorboard tensorboard = 1;
   // The config;
   google.protobuf.Struct config = 2;
+  // List of any related warnings.
+  repeated LaunchWarning warnings = 3;
 }

--- a/webui/react/src/components/ExperimentActionDropdown.tsx
+++ b/webui/react/src/components/ExperimentActionDropdown.tsx
@@ -25,7 +25,7 @@ import { capitalize } from 'shared/utils/string';
 import { ExperimentAction as Action, ProjectExperiment } from 'types';
 import handleError from 'utils/error';
 import { getActionsForExperiment } from 'utils/experiment';
-import { openCommand } from 'utils/wait';
+import { openCommandResponse } from 'utils/wait';
 
 interface Props {
   children?: React.ReactNode;
@@ -102,8 +102,8 @@ const ExperimentActionDropdown: React.FC<Props> = ({
             if (onComplete) onComplete(action);
             break;
           case Action.OpenTensorBoard: {
-            const tensorboard = await openOrCreateTensorBoard({ experimentIds: [id] });
-            openCommand(tensorboard);
+            const commandResponse = await openOrCreateTensorBoard({ experimentIds: [id] });
+            openCommandResponse(commandResponse);
             break;
           }
           case Action.SwitchPin: {

--- a/webui/react/src/hooks/useModal/HyperparameterSearch/useModalHyperparameterSearch.test.tsx
+++ b/webui/react/src/hooks/useModal/HyperparameterSearch/useModalHyperparameterSearch.test.tsx
@@ -117,7 +117,7 @@ describe('useModalHyperparameterSearch', () => {
     const { view } = await setup();
 
     await user.click(view.getByRole('button', { name: 'Select Hyperparameters' }));
-    mockCreateExperiment.mockReturnValue({ id: 1 });
+    mockCreateExperiment.mockReturnValue({ experiment: { id: 1 }, maxSlotsExceeded: false });
     await user.click(view.getByRole('button', { name: 'Run Experiment' }));
 
     expect(mockCreateExperiment).toHaveBeenCalled();

--- a/webui/react/src/hooks/useModal/HyperparameterSearch/useModalHyperparameterSearch.tsx
+++ b/webui/react/src/hooks/useModal/HyperparameterSearch/useModalHyperparameterSearch.tsx
@@ -25,11 +25,12 @@ import { useFetchResourcePools } from 'hooks/useFetch';
 import { maxPoolSlotCapacity } from 'pages/Clusters/ClustersOverview';
 import { paths } from 'routes/utils';
 import { createExperiment } from 'services/api';
+import { V1LaunchWarning } from 'services/api-ts-sdk';
 import Icon from 'shared/components/Icon';
 import useModal, { ModalHooks as Hooks, ModalCloseReason } from 'shared/hooks/useModal/useModal';
 import { Primitive } from 'shared/types';
 import { clone, flattenObject, isBoolean, unflattenObject } from 'shared/utils/data';
-import { DetError, isDetError } from 'shared/utils/error';
+import { DetError, ErrorLevel, ErrorType, isDetError } from 'shared/utils/error';
 import { roundToPrecision } from 'shared/utils/number';
 import { routeToReactUrl } from 'shared/utils/routes';
 import { validateLength } from 'shared/utils/string';
@@ -43,6 +44,7 @@ import {
   TrialHyperparameters,
   TrialItem,
 } from 'types';
+import { handleWarning } from 'utils/error';
 
 import css from './useModalHyperparameterSearch.module.scss';
 
@@ -230,7 +232,7 @@ const useModalHyperparameterSearch = ({
     const newConfig = yaml.dump(baseConfig);
 
     try {
-      const { id: newExperimentId } = await createExperiment(
+      const { experiment: newExperiment, warnings } = await createExperiment(
         {
           activate: true,
           experimentConfig: newConfig,
@@ -239,9 +241,22 @@ const useModalHyperparameterSearch = ({
         },
         { signal: canceler.current?.signal },
       );
+      const currentSlotsExceeded = warnings
+        ? warnings.includes(V1LaunchWarning.CURRENTSLOTSEXCEEDED)
+        : false;
+      if (currentSlotsExceeded) {
+        handleWarning({
+          level: ErrorLevel.Warn,
+          publicMessage:
+            'The requested job requires more slots than currently available. You may need to increase cluster resources in order for the job to run.',
+          publicSubject: 'Current Slots Exceeded',
+          silent: false,
+          type: ErrorType.Server,
+        });
+      }
 
       // Route to reload path to forcibly remount experiment page.
-      const newPath = paths.experimentDetails(newExperimentId);
+      const newPath = paths.experimentDetails(newExperiment.id);
       routeToReactUrl(paths.reload(newPath));
     } catch (e) {
       let errorMessage = 'Unable to create experiment.';

--- a/webui/react/src/hooks/useModal/JupyterLab/useModalJupyterLab.test.tsx
+++ b/webui/react/src/hooks/useModal/JupyterLab/useModalJupyterLab.test.tsx
@@ -80,6 +80,18 @@ describe('useModalJupyterLab', () => {
     expect(await screen.findByText(MODAL_TITLE)).toBeInTheDocument();
   });
 
+  it('should close modal', async () => {
+    const user = await setup();
+
+    await screen.findByText(MODAL_TITLE);
+    const button = await screen.findByRole('button', { name: /Launch/i });
+    user.click(button);
+
+    await waitFor(() => {
+      expect(screen.queryByText(MODAL_TITLE)).not.toBeInTheDocument();
+    });
+  });
+
   it('should show modal in simple form mode', async () => {
     await setup();
 
@@ -95,18 +107,6 @@ describe('useModalJupyterLab', () => {
 
     await waitFor(() => {
       expect(screen.queryByText(SHOW_SIMPLE_CONFIG_TEXT)).toBeInTheDocument();
-    });
-  });
-
-  it('should close modal', async () => {
-    const user = await setup();
-
-    await screen.findByText(MODAL_TITLE);
-    const button = await screen.findByRole('button', { name: /Launch/i });
-    user.click(button);
-
-    await waitFor(() => {
-      expect(screen.queryByText(MODAL_TITLE)).not.toBeInTheDocument();
     });
   });
 });

--- a/webui/react/src/hooks/useTelemetry.ts
+++ b/webui/react/src/hooks/useTelemetry.ts
@@ -41,7 +41,7 @@ class Telemetry {
 
   /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
   track(event: string, ...args: any[]) {
-    if (analytics?.track) analytics.track(event, ...args);
+    if (window.analytics?.track) analytics.track(event, ...args);
   }
 
   async load(info: DeterminedInfo): Promise<void> {
@@ -55,8 +55,8 @@ class Telemetry {
       const telemetry = await getTelemetry({});
       const isProperKey = telemetry.segmentKey && /^[a-z0-9]{32}$/i.test(telemetry.segmentKey);
       if (isProperKey) {
-        analytics.load(telemetry.segmentKey || '');
-        analytics.page();
+        if (analytics?.load) analytics.load(telemetry.segmentKey || '');
+        if (analytics?.page) analytics.page();
         this.isLoaded = true;
       }
     } catch (e) {

--- a/webui/react/src/pages/ExperimentDetails/ExperimentDetailsHeader.tsx
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentDetailsHeader.tsx
@@ -36,7 +36,7 @@ import { getStateColorCssVar } from 'themes';
 import { ExperimentAction as Action, ExperimentBase, RunState, TrialItem } from 'types';
 import handleError from 'utils/error';
 import { canActionExperiment, getActionsForExperiment } from 'utils/experiment';
-import { openCommand } from 'utils/wait';
+import { openCommandResponse } from 'utils/wait';
 
 import css from './ExperimentDetailsHeader.module.scss';
 
@@ -299,8 +299,10 @@ const ExperimentDetailsHeader: React.FC<Props> = ({
         onClick: async () => {
           setIsRunningTensorBoard(true);
           try {
-            const tensorboard = await openOrCreateTensorBoard({ experimentIds: [experiment.id] });
-            openCommand(tensorboard);
+            const commandResponse = await openOrCreateTensorBoard({
+              experimentIds: [experiment.id],
+            });
+            openCommandResponse(commandResponse);
             setIsRunningTensorBoard(false);
           } catch (e) {
             setIsRunningTensorBoard(false);

--- a/webui/react/src/pages/ExperimentDetails/ExperimentTrials.tsx
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentTrials.tsx
@@ -33,7 +33,7 @@ import { validateDetApiEnum, validateDetApiEnumList } from 'shared/utils/service
 import {
   ExperimentAction as Action,
   CheckpointWorkloadExtended,
-  CommandTask,
+  CommandResponse,
   ExperimentBase,
   MetricsWorkload,
   RunState,
@@ -41,7 +41,7 @@ import {
 } from 'types';
 import handleError from 'utils/error';
 import { getMetricValue } from 'utils/metric';
-import { openCommand } from 'utils/wait';
+import { openCommandResponse } from 'utils/wait';
 
 import css from './ExperimentTrials.module.scss';
 import settingsConfig, { isOfSortKey, Settings } from './ExperimentTrials.settings';
@@ -114,7 +114,7 @@ const ExperimentTrials: React.FC<Props> = ({ experiment, pageRef }: Props) => {
   );
 
   const handleOpenTensorBoard = useCallback(async (trial: TrialItem) => {
-    openCommand(await openOrCreateTensorBoard({ trialIds: [trial.id] }));
+    openCommandResponse(await openOrCreateTensorBoard({ trialIds: [trial.id] }));
   }, []);
 
   const handleViewLogs = useCallback(
@@ -316,7 +316,7 @@ const ExperimentTrials: React.FC<Props> = ({ experiment, pageRef }: Props) => {
       try {
         const result = await sendBatchActions(action);
         if (action === Action.OpenTensorBoard && result) {
-          openCommand(result as CommandTask);
+          openCommandResponse(result as CommandResponse);
         }
 
         // Refetch experiment list to get updates based on batch action.

--- a/webui/react/src/pages/ExperimentDetails/ExperimentVisualization/HpParallelCoordinates.tsx
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentVisualization/HpParallelCoordinates.tsx
@@ -19,7 +19,7 @@ import { ErrorLevel, ErrorType } from 'shared/utils/error';
 import { numericSorter } from 'shared/utils/sort';
 import {
   ExperimentAction as Action,
-  CommandTask,
+  CommandResponse,
   ExperimentBase,
   Hyperparameter,
   HyperparameterType,
@@ -31,7 +31,7 @@ import {
 import { defaultNumericRange, getColorScale, getNumericRange, updateRange } from 'utils/chart';
 import handleError from 'utils/error';
 import { metricToStr } from 'utils/metric';
-import { openCommand } from 'utils/wait';
+import { openCommandResponse } from 'utils/wait';
 
 import TrialsComparisonModal from '../TrialsComparisonModal';
 
@@ -325,7 +325,7 @@ const HpParallelCoordinates: React.FC<Props> = ({
       try {
         const result = await sendBatchActions(action);
         if (action === Action.OpenTensorBoard && result) {
-          openCommand(result as CommandTask);
+          openCommandResponse(result as CommandResponse);
         }
       } catch (e) {
         const publicSubject =

--- a/webui/react/src/pages/ExperimentDetails/ExperimentVisualization/LearningCurve.tsx
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentVisualization/LearningCurve.tsx
@@ -18,7 +18,7 @@ import { ErrorLevel, ErrorType } from 'shared/utils/error';
 import { isNewTabClickEvent, openBlank, routeToReactUrl } from 'shared/utils/routes';
 import {
   ExperimentAction as Action,
-  CommandTask,
+  CommandResponse,
   ExperimentBase,
   Hyperparameter,
   Metric,
@@ -27,7 +27,7 @@ import {
   Scale,
 } from 'types';
 import handleError from 'utils/error';
-import { openCommand } from 'utils/wait';
+import { openCommandResponse } from 'utils/wait';
 
 import TrialsComparisonModal from '../TrialsComparisonModal';
 
@@ -206,7 +206,7 @@ const LearningCurve: React.FC<Props> = ({
       try {
         const result = await sendBatchActions(action);
         if (action === Action.OpenTensorBoard && result) {
-          openCommand(result as CommandTask);
+          openCommandResponse(result as CommandResponse);
         }
       } catch (e) {
         const publicSubject =

--- a/webui/react/src/pages/ExperimentList.tsx
+++ b/webui/react/src/pages/ExperimentList.tsx
@@ -68,6 +68,7 @@ import { validateDetApiEnum, validateDetApiEnumList } from 'shared/utils/service
 import { alphaNumericSorter } from 'shared/utils/sort';
 import {
   ExperimentAction as Action,
+  CommandResponse,
   CommandTask,
   ExperimentItem,
   ExperimentPagination,
@@ -82,7 +83,7 @@ import {
   getProjectExperimentForExperimentItem,
 } from 'utils/experiment';
 import { getDisplayName } from 'utils/user';
-import { openCommand } from 'utils/wait';
+import { openCommandResponse } from 'utils/wait';
 
 import settingsConfig, {
   DEFAULT_COLUMN_WIDTHS,
@@ -642,7 +643,7 @@ const ExperimentList: React.FC<Props> = ({ project }) => {
     useModalExperimentMove({ onClose: handleActionComplete, user });
 
   const sendBatchActions = useCallback(
-    (action: Action): Promise<void[] | CommandTask> | void => {
+    (action: Action): Promise<void[] | CommandTask | CommandResponse> | void => {
       if (!settings.row) return;
       if (action === Action.OpenTensorBoard) {
         return openOrCreateTensorBoard({ experimentIds: settings.row });
@@ -690,7 +691,7 @@ const ExperimentList: React.FC<Props> = ({ project }) => {
       try {
         const result = await sendBatchActions(action);
         if (action === Action.OpenTensorBoard && result) {
-          openCommand(result as CommandTask);
+          openCommandResponse(result as CommandResponse);
         }
 
         /*

--- a/webui/react/src/pages/OldProjectDetails.tsx
+++ b/webui/react/src/pages/OldProjectDetails.tsx
@@ -78,6 +78,7 @@ import { validateDetApiEnum, validateDetApiEnumList } from 'shared/utils/service
 import { alphaNumericSorter } from 'shared/utils/sort';
 import {
   ExperimentAction as Action,
+  CommandResponse,
   CommandTask,
   ExperimentItem,
   ExperimentPagination,
@@ -670,7 +671,7 @@ const ProjectDetails: React.FC = () => {
     useModalExperimentMove({ onClose: handleActionComplete, user });
 
   const sendBatchActions = useCallback(
-    (action: Action): Promise<void[] | CommandTask> | void => {
+    (action: Action): Promise<void[] | CommandTask | CommandResponse> | void => {
       if (!settings.row) return;
       if (action === Action.OpenTensorBoard) {
         return openOrCreateTensorBoard({ experimentIds: settings.row });

--- a/webui/react/src/pages/TrialDetails/TrialDetailsHeader.tsx
+++ b/webui/react/src/pages/TrialDetails/TrialDetailsHeader.tsx
@@ -18,7 +18,7 @@ import {
   TrialWorkloadFilter,
 } from 'types';
 import { canActionExperiment } from 'utils/experiment';
-import { openCommand } from 'utils/wait';
+import { openCommandResponse } from 'utils/wait';
 
 interface Props {
   experiment: ExperimentBase;
@@ -74,8 +74,8 @@ const TrialDetailsHeader: React.FC<Props> = ({ experiment, fetchTrialDetails, tr
         label: 'TensorBoard',
         onClick: async () => {
           setIsRunningTensorBoard(true);
-          const tensorboard = await openOrCreateTensorBoard({ trialIds: [trial.id] });
-          openCommand(tensorboard);
+          const commandResponse = await openOrCreateTensorBoard({ trialIds: [trial.id] });
+          openCommandResponse(commandResponse);
           await fetchTrialDetails();
           setIsRunningTensorBoard(false);
         },

--- a/webui/react/src/pages/TrialsComparison/Actions/utils.ts
+++ b/webui/react/src/pages/TrialsComparison/Actions/utils.ts
@@ -2,9 +2,8 @@ import { Action } from 'components/Table/TableBulkActions';
 import { openOrCreateTensorBoard } from 'services/api';
 import { ValueOf } from 'shared/types';
 import { ErrorLevel, ErrorType } from 'shared/utils/error';
-import { CommandTask } from 'types';
 import handleError from 'utils/error';
-import { openCommand } from 'utils/wait';
+import { openCommandResponse } from 'utils/wait';
 
 import { TrialsSelectionOrCollection } from '../Collections/collections';
 
@@ -23,7 +22,7 @@ export type TrialsActionHandler = (t: trials) => Promise<void> | void;
 export const openTensorBoard = async ({ trials }: trials): Promise<void> => {
   if ('trialIds' in trials) {
     const result = await openOrCreateTensorBoard({ trialIds: trials.trialIds });
-    if (result) openCommand(result as CommandTask);
+    if (result) openCommandResponse(result);
   }
 };
 

--- a/webui/react/src/routes/utils.ts
+++ b/webui/react/src/routes/utils.ts
@@ -98,9 +98,11 @@ export const paths = {
   experimentModelDef: (experimentId: number | string): string => {
     return `/experiments/${experimentId}/model_def`;
   },
-  interactive: (command: CommandTask): string => {
+  interactive: (command: CommandTask, maxSlotsExceeded = false): string => {
     return `/interactive/${command.id}/${command.type}/
-      ${command.name}/${command.resourcePool}/${encodeURIComponent(waitPageUrl(command))}`;
+      ${command.name}/${command.resourcePool}/${encodeURIComponent(
+      waitPageUrl(command),
+    )}?currentSlotsExceeded=${maxSlotsExceeded}`;
   },
   jobs: (): string => {
     return routeById.jobs.path;

--- a/webui/react/src/services/api-ts-sdk/api.ts
+++ b/webui/react/src/services/api-ts-sdk/api.ts
@@ -1834,6 +1834,12 @@ export interface V1CreateExperimentResponse {
      * @memberof V1CreateExperimentResponse
      */
     config: any;
+    /**
+     * List of any related warnings.
+     * @type {Array<V1LaunchWarning>}
+     * @memberof V1CreateExperimentResponse
+     */
+    warnings?: Array<V1LaunchWarning>;
 }
 
 /**
@@ -4456,6 +4462,12 @@ export interface V1LaunchCommandResponse {
      * @memberof V1LaunchCommandResponse
      */
     config: any;
+    /**
+     * If the requested slots exceeded the current max available.
+     * @type {Array<V1LaunchWarning>}
+     * @memberof V1LaunchCommandResponse
+     */
+    warnings?: Array<V1LaunchWarning>;
 }
 
 /**
@@ -4508,6 +4520,12 @@ export interface V1LaunchNotebookResponse {
      * @memberof V1LaunchNotebookResponse
      */
     config: any;
+    /**
+     * List of any related warnings.
+     * @type {Array<V1LaunchWarning>}
+     * @memberof V1LaunchNotebookResponse
+     */
+    warnings?: Array<V1LaunchWarning>;
 }
 
 /**
@@ -4560,6 +4578,12 @@ export interface V1LaunchShellResponse {
      * @memberof V1LaunchShellResponse
      */
     config: any;
+    /**
+     * List of any related warnings.
+     * @type {Array<V1LaunchWarning>}
+     * @memberof V1LaunchShellResponse
+     */
+    warnings?: Array<V1LaunchWarning>;
 }
 
 /**
@@ -4618,6 +4642,22 @@ export interface V1LaunchTensorboardResponse {
      * @memberof V1LaunchTensorboardResponse
      */
     config: any;
+    /**
+     * List of any related warnings.
+     * @type {Array<V1LaunchWarning>}
+     * @memberof V1LaunchTensorboardResponse
+     */
+    warnings?: Array<V1LaunchWarning>;
+}
+
+/**
+ * Enum values for warnings when launching commands.   - LAUNCH_WARNING_UNSPECIFIED: Default value  - LAUNCH_WARNING_CURRENT_SLOTS_EXCEEDED: For a default webhook
+ * @export
+ * @enum {string}
+ */
+export enum V1LaunchWarning {
+    UNSPECIFIED = <any> 'LAUNCH_WARNING_UNSPECIFIED',
+    CURRENTSLOTSEXCEEDED = <any> 'LAUNCH_WARNING_CURRENT_SLOTS_EXCEEDED'
 }
 
 /**

--- a/webui/react/src/services/api.ts
+++ b/webui/react/src/services/api.ts
@@ -293,7 +293,7 @@ export const getTrialWorkloads = generateDetApi<
 export const createExperiment = generateDetApi<
   Service.CreateExperimentParams,
   Api.V1CreateExperimentResponse,
-  Type.ExperimentBase
+  Type.CreateExperimentResponse
 >(Config.createExperiment);
 
 export const archiveExperiment = generateDetApi<
@@ -661,7 +661,7 @@ export const getTaskTemplates = generateDetApi<
 export const launchJupyterLab = generateDetApi<
   Service.LaunchJupyterLabParams,
   Api.V1LaunchNotebookResponse,
-  Type.CommandTask
+  Type.CommandResponse
 >(Config.launchJupyterLab);
 
 export const previewJupyterLab = generateDetApi<
@@ -673,19 +673,19 @@ export const previewJupyterLab = generateDetApi<
 export const launchTensorBoard = generateDetApi<
   Service.LaunchTensorBoardParams,
   Api.V1LaunchTensorboardResponse,
-  Type.CommandTask
+  Type.CommandResponse
 >(Config.launchTensorBoard);
 
 export const openOrCreateTensorBoard = async (
   params: Service.LaunchTensorBoardParams,
-): Promise<Type.CommandTask> => {
+): Promise<Type.CommandResponse> => {
   const tensorboards = await getTensorBoards({});
   const match = tensorboards.find(
     (tensorboard) =>
       !terminalCommandStates.has(tensorboard.state) &&
       tensorBoardMatchesSource(tensorboard, params),
   );
-  if (match) return match;
+  if (match) return { command: match, warnings: [1] };
   return launchTensorBoard(params);
 };
 

--- a/webui/react/src/services/apiConfig.ts
+++ b/webui/react/src/services/apiConfig.ts
@@ -616,11 +616,14 @@ export const getExperiment: DetApi<
 export const createExperiment: DetApi<
   Service.CreateExperimentParams,
   Api.V1CreateExperimentResponse,
-  Type.ExperimentBase
+  Type.CreateExperimentResponse
 > = {
   name: 'createExperiment',
   postProcess: (resp: Api.V1CreateExperimentResponse) => {
-    return decoder.mapV1GetExperimentDetailsResponse(resp);
+    return {
+      experiment: decoder.mapV1GetExperimentDetailsResponse(resp),
+      warnings: resp.warnings || [],
+    };
   },
   request: (params: Service.CreateExperimentParams, options) => {
     return detApi.Internal.createExperiment(
@@ -1556,10 +1559,15 @@ export const getTemplates: DetApi<
 export const launchJupyterLab: DetApi<
   Service.LaunchJupyterLabParams,
   Api.V1LaunchNotebookResponse,
-  Type.CommandTask
+  Type.CommandResponse
 > = {
   name: 'launchJupyterLab',
-  postProcess: (response) => decoder.mapV1Notebook(response.notebook),
+  postProcess: (response) => {
+    return {
+      command: decoder.mapV1Notebook(response.notebook),
+      warnings: response.warnings || [],
+    };
+  },
   request: (params: Service.LaunchJupyterLabParams) => detApi.Notebooks.launchNotebook(params),
 };
 
@@ -1576,10 +1584,15 @@ export const previewJupyterLab: DetApi<
 export const launchTensorBoard: DetApi<
   Service.LaunchTensorBoardParams,
   Api.V1LaunchTensorboardResponse,
-  Type.CommandTask
+  Type.CommandResponse
 > = {
   name: 'launchTensorBoard',
-  postProcess: (response) => decoder.mapV1TensorBoard(response.tensorboard),
+  postProcess: (response) => {
+    return {
+      command: decoder.mapV1TensorBoard(response.tensorboard),
+      wanrings: response.warnings || [],
+    };
+  },
   request: (params: Service.LaunchTensorBoardParams) =>
     detApi.TensorBoards.launchTensorboard(params),
 };

--- a/webui/react/src/types.ts
+++ b/webui/react/src/types.ts
@@ -1,5 +1,5 @@
 import * as Api from 'services/api-ts-sdk';
-import { V1AgentUserGroup, V1Group, V1Trigger } from 'services/api-ts-sdk';
+import { V1AgentUserGroup, V1Group, V1LaunchWarning, V1Trigger } from 'services/api-ts-sdk';
 import { Primitive, RawJson, RecordKey, ValueOf } from 'shared/types';
 
 interface WithPagination {
@@ -565,6 +565,11 @@ export interface ProjectExperiment extends ExperimentItem {
   workspaceName: string;
 }
 
+export interface CreateExperimentResponse {
+  experiment: ExperimentBase;
+  warnings?: V1LaunchWarning[];
+}
+
 export interface ExperimentBase extends ProjectExperiment {
   config: ExperimentConfig;
   configRaw: RawJson; // Readonly unparsed config object.
@@ -658,6 +663,11 @@ export interface ExperimentTask extends Task {
   userId?: number;
   username: string;
   workspaceId: number;
+}
+
+export interface CommandResponse {
+  command: CommandTask;
+  warnings?: V1LaunchWarning[];
 }
 
 export interface CommandTask extends Task {

--- a/webui/react/src/utils/error.ts
+++ b/webui/react/src/utils/error.ts
@@ -38,6 +38,14 @@ const log = (e: DetError) => {
   e.logger[key](e);
 };
 
+// Handle a warning to the user in the UI
+export const handleWarning = (warningOptions: DetErrorOptions): void => {
+  // Error object is null because this is just a warning
+  const detWarning = new DetError(null, warningOptions);
+
+  openNotification(detWarning);
+};
+
 // Handle an error at the point that you'd want to stop bubbling it up. Avoid handling
 // and re-throwing.
 const handleError = (error: DetError | unknown, options?: DetErrorOptions): DetError | void => {

--- a/webui/react/src/utils/jupyter.ts
+++ b/webui/react/src/utils/jupyter.ts
@@ -3,7 +3,7 @@ import { previewJupyterLab as apiPreviewJupyterLab } from 'services/api';
 import { RawJson } from 'shared/types';
 import { ErrorLevel, ErrorType } from 'shared/utils/error';
 import handleError from 'utils/error';
-import { openCommand } from 'utils/wait';
+import { openCommandResponse } from 'utils/wait';
 
 export interface JupyterLabOptions {
   name?: string;
@@ -18,7 +18,7 @@ interface JupyterLabLaunchOptions extends JupyterLabOptions {
 
 export const launchJupyterLab = async (options: JupyterLabLaunchOptions = {}): Promise<void> => {
   try {
-    const jupyterLab = await apiLaunchJupyterLab({
+    const commandResponse = await apiLaunchJupyterLab({
       config: options.config || {
         description: options.name === '' ? undefined : options.name,
         resources: {
@@ -28,7 +28,7 @@ export const launchJupyterLab = async (options: JupyterLabLaunchOptions = {}): P
       },
       templateName: options.template === '' ? undefined : options.template,
     });
-    openCommand(jupyterLab);
+    openCommandResponse(commandResponse);
   } catch (e) {
     handleError(e, {
       level: ErrorLevel.Error,

--- a/webui/react/src/utils/wait.ts
+++ b/webui/react/src/utils/wait.ts
@@ -1,7 +1,8 @@
 import { serverAddress } from 'routes/utils';
 import { paths } from 'routes/utils';
+import { V1LaunchWarning } from 'services/api-ts-sdk';
 import { openBlank } from 'shared/utils/routes';
-import { Command, CommandState, CommandTask, CommandType } from 'types';
+import { Command, CommandResponse, CommandState, CommandTask, CommandType } from 'types';
 import { isCommandTask } from 'utils/task';
 
 export interface WaitStatus {
@@ -25,7 +26,15 @@ export const commandToEventUrl = (command: Command | CommandTask): string => {
 };
 
 export const openCommand = (command: CommandTask): void => {
-  openBlank(`${process.env.PUBLIC_URL}${paths.interactive(command)}`);
+  openBlank(`${process.env.PUBLIC_URL}${paths.interactive(command, false)}`);
+};
+
+export const openCommandResponse = (commandResponse: CommandResponse): void => {
+  const warnings = commandResponse?.warnings ? commandResponse.warnings : [];
+  const maxSlotsExceeded = warnings.includes(V1LaunchWarning.CURRENTSLOTSEXCEEDED);
+  openBlank(
+    `${process.env.PUBLIC_URL}${paths.interactive(commandResponse.command, maxSlotsExceeded)}`,
+  );
 };
 
 export const CANNOT_OPEN_COMMAND_ERROR = 'Command cannot be opened.';


### PR DESCRIPTION
## Description

feat: Add warning for submissions for requests that cannot currently be fulfilled [DET-6410]

Presently, if a user requests a job with a larger number of slots than are currently available the job may be stuck in queue indefinitely. This PR shows a **warning** message in the CLI and WebUI to a user letting them know that too many slots may have been requested. 

**important note:** Since we cannot accurately tell if more slots may become available in the future we are **not** blocking job submission, only showing a warning to the user.

![Screen Shot 2022-11-03 at 10 04 00 AM](https://user-images.githubusercontent.com/103522725/199757599-bd83d3db-9161-4dc6-9148-88cfdd2bdb8d.png)

<img width="1501" alt="Screen Shot 2022-11-03 at 10 03 26 AM" src="https://user-images.githubusercontent.com/103522725/199757470-0a091208-3556-4ac5-9d6a-6641dcc1dcb6.png">

![Screen Shot 2022-11-03 at 10 33 32 AM](https://user-images.githubusercontent.com/103522725/199764898-e3070530-f446-4432-a4d8-ed79ede66f65.png)


<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At a minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan

1. Attempt to create a notebook in the WebUI requesting more slots than available. Ensure that you see a warning on the about the number of slots. 
2. Attempt to create a notebook in the CLI requesting more slots than available. Ensure that you see a warning about the number of slots. 
3. Attempt to fork an experiment and in the WebUI and in the configuration specify more slots than available. Ensure that you see a warning about the number of slots. 
4. Create an experiment in the CLI that requires more slots than available. Ensure that you see a warning about the number of slots. 
5. Repeat steps 1-4 instead specify a number a slots equal to or less than the amount available and ensure that you do not see any warning messages. 
<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions about this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist
- [x] Changes have been manually QA'd
~- [ ] User-facing API changes need the "User-facing API Change" label.~
~- [ ] Release notes should be added as a separate file under `docs/release-notes/`.~
See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
~- [ ] Licenses should be included for new code which was copied and/or modified from any external code.~


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-6410]: https://determinedai.atlassian.net/browse/DET-6410?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ