### PR TITLE
fix: typescript inside keys function

### DIFF
--- a/webui/react/src/shared/utils/storage.ts
+++ b/webui/react/src/shared/utils/storage.ts
@@ -86,8 +86,8 @@ export class StorageManager {
     const prefix = this.pathKeys.length !== 0 ? [...this.pathKeys, ''].join(this.delimiter) : '';
     return this.store
       .keys()
-      .filter((key) => key.startsWith(prefix))
-      .map((key) => key.replace(prefix, ''));
+      .filter((key: string) => key.startsWith(prefix))
+      .map((key: string) => key.replace(prefix, ''));
   }
 
   toString(): string {


### PR DESCRIPTION
## Description

saas can't build unless we specify these params as strings, not any

I believe this is more related to type checking, and not the changes to Storage. These lines were written 4 months ago: https://github.com/determined-ai/determined/blame/master/webui/react/src/shared/utils/storage.ts#L89

I tried `make push-shared` but there is a saas check which fails because saas is still on the old version of shared:

```
./src/experimental/notifications/storage.ts
Attempted import error: 'Storage' is not exported from 'shared/utils/storage'.
```

I could disable checks on `make push-shared` but I don't know if that's what we want to do.

## Test Plan

Successfully builds

## Checklist
- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.