### PR TITLE
refactor: rewrite fluent lib without actors [DET-8303]

### DIFF
--- a/agent/internal/fluent/fluent.go
+++ b/agent/internal/fluent/fluent.go
@@ -1,0 +1,502 @@
+package fluent
+
+import (
+	"archive/tar"
+	"context"
+	"fmt"
+	"io/ioutil"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/docker/docker/pkg/stdcopy"
+
+	"github.com/determined-ai/determined/agent/internal/container"
+	"github.com/determined-ai/determined/agent/internal/options"
+	"github.com/determined-ai/determined/agent/pkg/docker"
+	"github.com/determined-ai/determined/master/pkg/aproto"
+	"github.com/determined-ai/determined/master/pkg/model"
+	"github.com/determined-ai/determined/master/pkg/syncx/errgroupx"
+
+	"github.com/docker/docker/api/types"
+	dcontainer "github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/filters"
+	"github.com/docker/docker/client"
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+
+	"github.com/determined-ai/determined/master/pkg/archive"
+	"github.com/determined-ai/determined/master/pkg/fluent"
+)
+
+// EnvVarNames are the of environment variables whose values should be included in log entries that
+// Docker or the agent sends to the Fluent Bit logger.
+var EnvVarNames = []string{
+	container.ContainerIDEnvVar,
+	container.AllocationIDEnvVar,
+	container.TaskIDEnvVar,
+}
+
+var fluentLogLineRegexp = regexp.MustCompile(`\[[^]]*\] \[ *([^]]*)\] (.*)`)
+
+// Fluent manages the lifecycle of the Fluent Bit container that is run by the agent for
+// the purpose of forwarding container logs.
+type Fluent struct {
+	// Configuration details.
+	opts  options.AgentOptions
+	mopts aproto.MasterSetAgentOptions
+
+	// System dependencies.
+	log    *log.Entry
+	docker *docker.Client
+
+	// Internal state.
+	fluentLogs      []*aproto.RunMessage
+	fluentLogsCount int
+
+	wg      errgroupx.Group // Fluentbit-scoped group.
+	err     error
+	started chan struct{} // Closed when FluentBit is actually started.
+	Done    chan struct{} // Closed when FluentBit exits.
+}
+
+// Start constructs and runs a Fluent Bit daemon, and returns a handle to interact with it.
+func Start(
+	ctx context.Context,
+	opts options.AgentOptions,
+	mopts aproto.MasterSetAgentOptions,
+	dclient *docker.Client,
+) (*Fluent, error) {
+	f := &Fluent{
+		opts:  opts,
+		mopts: mopts,
+
+		log:    log.WithField("component", "fluentbit"),
+		docker: dclient,
+
+		fluentLogs: make([]*aproto.RunMessage, 50),
+		wg:         errgroupx.WithContext(context.Background()),
+		started:    make(chan struct{}),
+		Done:       make(chan struct{}),
+	}
+
+	f.wg.Go(func(ctx context.Context) error {
+		defer f.wg.Cancel()
+		switch err := f.run(ctx); {
+		case errors.Is(err, context.Canceled):
+			return nil
+		case err != nil:
+			return err
+		default:
+			return nil
+		}
+	})
+
+	go func() {
+		f.err = f.wg.Wait()
+		close(f.Done)
+	}()
+
+	select {
+	case <-f.started:
+		return f, nil
+	case <-f.Done:
+		return nil, f.err
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+}
+
+// Error returns the error associated with an exit, if there is any. It returns nil when running.
+func (f *Fluent) Error() error {
+	return f.err
+}
+
+// Wait for the daemon to exit.
+func (f *Fluent) Wait() error {
+	return f.wg.Wait()
+}
+
+// Close the Fluent Bit daemon.
+func (f *Fluent) Close() error {
+	return f.wg.Close()
+}
+
+func (f *Fluent) run(ctx context.Context) error {
+	f.log.Trace("starting fluent container")
+	t0 := time.Now()
+	cID, err := f.startContainer(ctx)
+	if err != nil {
+		return fmt.Errorf("starting logging container: %w", err)
+	}
+	close(f.started)
+	log.Infof("Fluent Bit started in %s", time.Since(t0))
+
+	exitC, errC := f.docker.Inner().ContainerWait(
+		ctx,
+		cID,
+		dcontainer.WaitConditionNotRunning,
+	)
+
+	logs := make(chan *aproto.ContainerLog, 64)
+	loggroup := errgroupx.WithContext(ctx)
+	loggroup.Go(func(ctx context.Context) error {
+		defer close(logs)
+		return f.trackLogs(ctx, cID, logs)
+	})
+	loggroup.Go(func(ctx context.Context) error {
+		for {
+			select {
+			case log, ok := <-logs:
+				if !ok {
+					return nil
+				}
+				if log.RunMessage == nil {
+					continue
+				}
+				f.recordLog(log.RunMessage)
+				match := fluentLogLineRegexp.FindStringSubmatch(log.RunMessage.Value)
+				if match == nil {
+					continue
+				}
+				switch level, message := match[1], match[2]; level {
+				case "warn":
+					f.log.Warnf("Fluent Bit: %s", message)
+				case "error":
+					f.log.Errorf("Fluent Bit: %s", message)
+				}
+			case <-ctx.Done():
+				return fmt.Errorf("fluent bit canceled: %w", ctx.Err())
+			}
+		}
+	})
+	switch err := loggroup.Wait(); {
+	case errors.Is(err, context.Canceled):
+		f.log.WithError(err).Warn("orphaning fluent due to cancellation")
+		return err
+	case err != nil:
+		f.log.WithError(err).Warnf("Fluent Bit logs failed unexpectedly")
+	default:
+		f.log.Warnf("Fluent Bit logs ended unexpectedly")
+	}
+
+	f.printRecentLogs()
+	if err := f.docker.SignalContainer(ctx, cID, syscall.SIGKILL); err != nil {
+		f.log.WithError(err).Debug("tried but could not signal fluent after crash, may be gone")
+	}
+	select {
+	case err := <-errC:
+		return fmt.Errorf("failure waiting for Fluent Bit to exit: %w", err)
+	case exit := <-exitC:
+		if exit.Error != nil {
+			return fmt.Errorf("failure in Fluent Bit (%s)", exit.Error.Message)
+		}
+		return fmt.Errorf("unexpected Fluent Bit exit (%d)", exit.StatusCode)
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+// startContainer starts a Fluent Bit container running in host mode. It returns the port
+// that Fluent Bit is listening on and the ID of the container.
+// TODO(Brad): make fluent just use "containers" package, or do the move fluent tech debt.
+func (f *Fluent) startContainer(ctx context.Context) (string, error) {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	imageName := f.opts.Fluent.Image
+
+	if err := removeContainerByName(ctx, f.docker, f.opts.Fluent.ContainerName); err != nil {
+		return "", errors.Wrap(err, "failed to kill old logging container")
+	}
+
+	if err := pullImageByName(ctx, f.docker, imageName); err != nil {
+		return "", errors.Wrap(err, "failed to pull logging image")
+	}
+
+	masterHost := f.opts.MasterHost
+	masterPort := f.opts.MasterPort
+	if f.opts.ContainerMasterHost != "" {
+		masterHost = f.opts.ContainerMasterHost
+	}
+	if f.opts.ContainerMasterPort != 0 {
+		masterPort = f.opts.ContainerMasterPort
+	}
+
+	var tlsConfig model.TLSClientConfig
+	switch l := f.mopts.LoggingOptions; {
+	case l.DefaultLoggingConfig != nil:
+		t := f.opts.Security.TLS
+		tlsConfig = model.TLSClientConfig{
+			Enabled:         t.Enabled,
+			SkipVerify:      t.SkipVerify,
+			CertificatePath: t.MasterCert,
+			CertificateName: t.MasterCertName,
+		}
+		if err := tlsConfig.Resolve(); err != nil {
+			return "", err
+		}
+	case l.ElasticLoggingConfig != nil:
+		tlsConfig = l.ElasticLoggingConfig.Security.TLS
+	}
+
+	const fluentBaseDir = "/run/determined/fluent"
+	//nolint:govet // Allow unkeyed struct fields -- it really looks much better like this.
+	fluentArgs, fluentFiles := fluent.ContainerConfig(
+		masterHost,
+		masterPort,
+		[]fluent.ConfigSection{
+			{
+				{"Name", "forward"},
+				{"Port", strconv.Itoa(f.opts.Fluent.Port)},
+				// Setting mem_buf_limit allows Fluent Bit to buffer log data to disk if the rest of the
+				// pipeline is backed up. In combination with setting the Docker log driver to run in
+				// non-blocking mode, that lets us avoid impacting application performance when there are bursts
+				// in log output.
+				//
+				// This scheme is described in more detail at:
+				// https://docs.fluentbit.io/manual/administration/buffering-and-storage
+				{"mem_buf_limit", "100M"},
+			},
+		},
+		[]fluent.ConfigSection{
+			{
+				{"Name", "modify"},
+				{"Match", "*"},
+				// Delete Docker's container information, which we don't want.
+				{"Remove", "container_id"},
+				{"Remove", "container_name"},
+				// Remove metadata about the container parent that we set on the container.
+				{"Remove", "ai.determined.container.parent"},
+				// Rename environment variables to normal names.
+				{"Rename", container.ContainerIDEnvVar + " container_id"},
+				{"Rename", container.AllocationIDEnvVar + " allocation_id"},
+				{"Rename", container.TaskIDEnvVar + " task_id"},
+				{"Add", "agent_id " + f.opts.AgentID},
+				{"Rename", "source stdtype"},
+			},
+		},
+		f.mopts.LoggingOptions,
+		tlsConfig,
+	)
+
+	createResponse, err := f.docker.Inner().ContainerCreate(
+		ctx,
+		&dcontainer.Config{
+			Image:      imageName,
+			Cmd:        fluentArgs,
+			WorkingDir: fluentBaseDir,
+		},
+		&dcontainer.HostConfig{
+			// Set autoremove to reduce the number of states that the container is likely to be in and what
+			// we have to do to manage it cleanly. Restart on failure could be useful, but it conflcts with
+			// autoremove; we may want to consider switching to that instead at some point.
+			AutoRemove: true,
+			// Always use host mode to simplify the space of networking scenarios we have to consider.
+			NetworkMode: "host",
+			// Provide some reasonable resource limits on the container just to be safe.
+			Resources: dcontainer.Resources{
+				Memory:   1 << 30,
+				NanoCPUs: 1000000000,
+			},
+		},
+		nil,
+		nil,
+		f.opts.Fluent.ContainerName,
+	)
+	if err != nil {
+		return "", err
+	}
+
+	var fluentArchive archive.Archive
+	for name, content := range fluentFiles {
+		fluentArchive = append(fluentArchive, archive.Item{
+			Path:     filepath.Join(fluentBaseDir, name),
+			Type:     tar.TypeReg,
+			FileMode: 0o444,
+			Content:  content,
+		})
+	}
+
+	filesReader, err := archive.ToIOReader(fluentArchive)
+	if err != nil {
+		return "", err
+	}
+
+	err = f.docker.Inner().CopyToContainer(
+		ctx,
+		createResponse.ID,
+		"/",
+		filesReader,
+		types.CopyToContainerOptions{},
+	)
+	if err != nil {
+		return "", err
+	}
+
+	err = f.docker.Inner().ContainerStart(ctx, createResponse.ID, types.ContainerStartOptions{})
+	if err != nil {
+		return "", err
+	}
+
+	log.Infof("Fluent Bit listening on host port %d", f.opts.Fluent.Port)
+	switch {
+	case f.mopts.LoggingOptions.DefaultLoggingConfig != nil:
+		log.Infof("Fluent Bit shipping to Determined at %s:%d", f.opts.MasterHost, f.opts.MasterPort)
+	case f.mopts.LoggingOptions.ElasticLoggingConfig != nil:
+		eopts := f.mopts.LoggingOptions.ElasticLoggingConfig
+		log.Infof("Fluent Bit shipping to Elastic at %s:%d", eopts.Host, eopts.Port)
+	}
+	return createResponse.ID, nil
+}
+
+func pullImageByName(ctx context.Context, docker *docker.Client, imageName string) error {
+	_, _, err := docker.Inner().ImageInspectWithRaw(ctx, imageName)
+	switch {
+	case err == nil:
+		// No error means the image is present; do nothing.
+	case client.IsErrNotFound(err):
+		// This error means the call to Docker went fine but the image doesn't exist; pull it now.
+		log.Infof("pulling Docker image %s", imageName)
+		pullResponse, pErr := docker.Inner().ImagePull(ctx, imageName, types.ImagePullOptions{})
+		if pErr != nil {
+			return pErr
+		}
+		if _, pErr = ioutil.ReadAll(pullResponse); pErr != nil {
+			return pErr
+		}
+		if pErr = pullResponse.Close(); pErr != nil {
+			return pErr
+		}
+	default:
+		// Something unexpected happened; propagate the error.
+		return err
+	}
+	return nil
+}
+
+func (f *Fluent) recordLog(l *aproto.RunMessage) {
+	f.fluentLogs[f.fluentLogsCount%len(f.fluentLogs)] = l
+	f.fluentLogsCount++
+}
+
+func (f *Fluent) trackLogs(
+	ctx context.Context,
+	id string,
+	logs chan<- *aproto.ContainerLog,
+) error {
+	reader, err := f.docker.Inner().ContainerLogs(
+		ctx,
+		id,
+		types.ContainerLogsOptions{
+			ShowStdout: true,
+			ShowStderr: true,
+			Since:      "",
+			Timestamps: false,
+			Follow:     true,
+			Tail:       "all",
+			Details:    true,
+		},
+	)
+	if err != nil {
+		return errors.Wrap(err, "error grabbing container logs")
+	}
+	defer func() {
+		if err = reader.Close(); err != nil {
+			f.log.WithError(err).Warn("error closing log stream")
+		}
+	}()
+
+	if _, err = stdcopy.StdCopy(
+		newStdStream(ctx, stdcopy.Stdout, logs),
+		newStdStream(ctx, stdcopy.Stderr, logs),
+		reader,
+	); err != nil {
+		return fmt.Errorf("error scanning logs: %w", err)
+	}
+	return nil
+}
+
+func removeContainerByName(
+	ctx context.Context,
+	docker *docker.Client,
+	name string,
+) error {
+	containers, err := docker.Inner().ContainerList(ctx, types.ContainerListOptions{
+		All: true,
+		Filters: filters.NewArgs(
+			filters.Arg("name", name),
+		),
+	})
+	if err != nil {
+		return errors.Wrap(err, "failed to list containers by name")
+	}
+
+	for _, cont := range containers {
+		// ContainerList by name filters by prefix.
+		// Check for an exact match while accounting for / prefix.
+		for _, containerName := range cont.Names {
+			if strings.TrimLeft(containerName, "/") == name {
+				log.WithFields(log.Fields{"name": name, "id": cont.ID}).Infof(
+					"killing and removing Docker container",
+				)
+
+				if err := docker.Inner().ContainerRemove(
+					ctx, cont.ID, types.ContainerRemoveOptions{Force: true},
+				); err != nil {
+					return fmt.Errorf("failed to remove container %s: %w", containerName, err)
+				}
+				break
+			}
+		}
+	}
+	return nil
+}
+
+func (f *Fluent) printRecentLogs() {
+	i0 := f.fluentLogsCount - len(f.fluentLogs)
+	if i0 < 0 {
+		i0 = 0
+	}
+	for i := i0; i < f.fluentLogsCount; i++ {
+		f.log.Error(f.fluentLogs[i%len(f.fluentLogs)].Value)
+	}
+}
+
+type stdStream struct {
+	//nolint: containedctx // Disagree.
+	ctx     context.Context
+	stdType stdcopy.StdType
+	out     chan<- *aproto.ContainerLog
+}
+
+func newStdStream(
+	ctx context.Context,
+	stdType stdcopy.StdType,
+	out chan<- *aproto.ContainerLog,
+) *stdStream {
+	return &stdStream{
+		ctx:     ctx,
+		stdType: stdType,
+		out:     out,
+	}
+}
+
+func (s stdStream) Write(p []byte) (n int, err error) {
+	log := &aproto.ContainerLog{
+		Timestamp: time.Now().UTC(),
+		RunMessage: &aproto.RunMessage{
+			Value:   string(p),
+			StdType: s.stdType,
+		},
+	}
+	select {
+	case s.out <- log:
+		return len(p), nil
+	case <-s.ctx.Done():
+		return 0, fmt.Errorf("canceled while writing log: %w", s.ctx.Err())
+	}
+}

--- a/agent/internal/fluent/fluent.go
+++ b/agent/internal/fluent/fluent.go
@@ -9,7 +9,6 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
-	"syscall"
 	"time"
 
 	"github.com/docker/docker/pkg/stdcopy"
@@ -184,8 +183,8 @@ func (f *Fluent) run(ctx context.Context) error {
 	}
 
 	f.printRecentLogs()
-	if err := f.docker.SignalContainer(ctx, cID, syscall.SIGKILL); err != nil {
-		f.log.WithError(err).Debug("tried but could not signal fluent after crash, may be gone")
+	if err := f.docker.RemoveContainer(ctx, cID, true); err != nil {
+		f.log.WithError(err).Debug("ensuring Fluent Bit is cleaned up")
 	}
 	select {
 	case err := <-errC:

--- a/agent/internal/fluent/fluent_api_test.go
+++ b/agent/internal/fluent/fluent_api_test.go
@@ -50,12 +50,12 @@ func TestFluentPostgresLogging(t *testing.T) {
 	t.Log("building docker client")
 	rawCl, err := dclient.NewClientWithOpts(dclient.WithAPIVersionNegotiation(), dclient.FromEnv)
 	require.NoError(t, err)
-	cl := docker.NewClient(rawCl)
 	defer func() {
-		if cErr := cl.Close(); cErr != nil {
+		if cErr := rawCl.Close(); cErr != nil {
 			t.Logf("closing docker client: %s", cErr)
 		}
 	}()
+	cl := docker.NewClient(rawCl)
 
 	t.Log("building mock log acceptor")
 	logBuffer, logsCloser := mockLogAcceptor(t, opts.MasterPort)
@@ -92,8 +92,6 @@ func TestFluentPostgresLogging(t *testing.T) {
 }
 
 func TestFluentLoggingElastic(t *testing.T) {
-	// TODO(Brad): Move elastic package.
-	// elastic.ElasticTimeWindowDelay = 0
 	log.SetLevel(log.TraceLevel)
 	ctx := context.Background()
 	opts := atestutils.DefaultAgentConfig(1)
@@ -107,12 +105,12 @@ func TestFluentLoggingElastic(t *testing.T) {
 	t.Log("building client")
 	rawCl, err := dclient.NewClientWithOpts(dclient.WithAPIVersionNegotiation(), dclient.FromEnv)
 	require.NoError(t, err)
-	cl := docker.NewClient(rawCl)
 	defer func() {
-		if cErr := cl.Close(); cErr != nil {
+		if cErr := rawCl.Close(); cErr != nil {
 			t.Logf("closing docker client: %s", cErr)
 		}
 	}()
+	cl := docker.NewClient(rawCl)
 
 	t.Log("starting fluentbit")
 	f, err := fluent.Start(ctx, opts, mopts, cl)
@@ -156,12 +154,12 @@ func TestFluentSadPaths(t *testing.T) {
 	t.Log("building docker client")
 	rawCl, err := dclient.NewClientWithOpts(dclient.WithAPIVersionNegotiation(), dclient.FromEnv)
 	require.NoError(t, err)
-	cl := docker.NewClient(rawCl)
 	defer func() {
-		if cErr := cl.Close(); cErr != nil {
+		if cErr := rawCl.Close(); cErr != nil {
 			t.Logf("closing docker client: %s", cErr)
 		}
 	}()
+	cl := docker.NewClient(rawCl)
 
 	t.Log("_not_ starting log acceptor")
 	t.Log("starting fluentbit")
@@ -179,7 +177,7 @@ func TestFluentSadPaths(t *testing.T) {
 	t.Log("checking fluentbit failure logs for intermittent failure")
 	found := false
 	for e := range logC {
-		if strings.Contains(e.Message, "no upstream connections available") {
+		if strings.Contains(e.Message, "failed to flush chunk") {
 			found = true
 			break
 		}

--- a/agent/internal/fluent/fluent_api_test.go
+++ b/agent/internal/fluent/fluent_api_test.go
@@ -1,0 +1,377 @@
+//go:build integration
+
+package fluent_test
+
+import (
+	"archive/tar"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/davecgh/go-spew/spew"
+	"github.com/docker/docker/api/types"
+	dcontainer "github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/filters"
+	"github.com/docker/docker/client"
+	dclient "github.com/docker/docker/client"
+	"github.com/labstack/echo/v4"
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/determined-ai/determined/agent/internal/container"
+	"github.com/determined-ai/determined/agent/internal/fluent"
+	"github.com/determined-ai/determined/agent/pkg/docker"
+	"github.com/determined-ai/determined/agent/pkg/events"
+	atestutils "github.com/determined-ai/determined/agent/test/testutils"
+	"github.com/determined-ai/determined/master/pkg/aproto"
+	"github.com/determined-ai/determined/master/pkg/archive"
+	"github.com/determined-ai/determined/master/pkg/cproto"
+	"github.com/determined-ai/determined/master/pkg/model"
+	"github.com/determined-ai/determined/master/pkg/ptrs"
+	"github.com/determined-ai/determined/master/test/testutils"
+	"github.com/determined-ai/determined/proto/pkg/apiv1"
+)
+
+func TestFluentPostgresLogging(t *testing.T) {
+	log.SetLevel(log.TraceLevel)
+	ctx := context.Background()
+	opts := atestutils.DefaultAgentConfig(0)
+	mopts := atestutils.DefaultMasterSetAgentConfig()
+
+	t.Log("building docker client")
+	rawCl, err := dclient.NewClientWithOpts(dclient.WithAPIVersionNegotiation(), dclient.FromEnv)
+	require.NoError(t, err)
+	cl := docker.NewClient(rawCl)
+	defer func() {
+		if cErr := cl.Close(); cErr != nil {
+			t.Logf("closing docker client: %s", cErr)
+		}
+	}()
+
+	t.Log("building mock log acceptor")
+	logBuffer, logsCloser := mockLogAcceptor(t, opts.MasterPort)
+	defer logsCloser()
+
+	t.Log("starting fluentbit")
+	f, err := fluent.Start(ctx, opts, mopts, cl)
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, f.Close())
+	}()
+
+	t.Log("running container with predefined logs")
+	taskID := model.NewTaskID()
+	expected, expectedFile := makeLogTestCase(taskID, opts.AgentID)
+	runContainerWithLogs(t, expectedFile, opts.AgentID, taskID, opts.Fluent.Port)
+
+	t.Log("checking logs")
+	var actual []model.TaskLog
+	for i := 0; i < len(expected); i++ {
+		select {
+		case l := <-logBuffer:
+			actual = append(actual, l)
+		case <-time.After(10 * time.Second):
+			require.Equal(t, i, len(expected), "not enough logs received after ten seconds")
+		}
+	}
+	sort.Slice(actual, func(i, j int) bool {
+		return actual[i].Timestamp.Before(*actual[j].Timestamp)
+	})
+	for i := range actual {
+		require.True(t, assertLogEquals(t, actual[i], expected[i]))
+	}
+}
+
+func TestFluentLoggingElastic(t *testing.T) {
+	// TODO(Brad): Move elastic package.
+	// elastic.ElasticTimeWindowDelay = 0
+	log.SetLevel(log.TraceLevel)
+	ctx := context.Background()
+	opts := atestutils.DefaultAgentConfig(1)
+	mopts := atestutils.ElasticMasterSetAgentConfig()
+
+	t.Log("setting up elastic")
+	elastic, err := testutils.ResolveElastic()
+	require.NoError(t, err, "unable to connect to master")
+	require.NoError(t, elastic.AddDateNanosTemplate(), "unable to add template")
+
+	t.Log("building client")
+	rawCl, err := dclient.NewClientWithOpts(dclient.WithAPIVersionNegotiation(), dclient.FromEnv)
+	require.NoError(t, err)
+	cl := docker.NewClient(rawCl)
+	defer func() {
+		if cErr := cl.Close(); cErr != nil {
+			t.Logf("closing docker client: %s", cErr)
+		}
+	}()
+
+	t.Log("starting fluentbit")
+	f, err := fluent.Start(ctx, opts, mopts, cl)
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, f.Close(), "close fluent failed")
+	}()
+
+	t.Log("running container with some predefined logs")
+	taskID := model.NewTaskID()
+	expected, actual := makeLogTestCase(taskID, opts.AgentID)
+	runContainerWithLogs(t, actual, opts.AgentID, taskID, opts.Fluent.Port)
+
+	t.Log("checking logs in elastic")
+	for {
+		logs, _, err := elastic.TaskLogs(taskID, 4, nil, apiv1.OrderBy_ORDER_BY_ASC, nil)
+		require.NoError(t, err, "failed to retrieve task logs")
+		if len(logs) != len(expected) {
+			t.Logf("checking logs again after delay... (%d/%d found)", len(logs), len(expected))
+			time.Sleep(time.Second)
+			continue
+		}
+
+		expectedFound := true
+		for i, l := range logs {
+			expectedFound = expectedFound && assertLogEquals(t, *l, expected[i])
+		}
+		require.True(t, expectedFound, spew.Sdump(logs), spew.Sdump(expected))
+		return
+	}
+}
+
+func TestFluentSadPaths(t *testing.T) {
+	log.SetLevel(log.TraceLevel)
+	logC := atestutils.NewLogChannel(1024)
+	log.AddHook(logC)
+	ctx := context.Background()
+	opts := atestutils.DefaultAgentConfig(2)
+	mopts := atestutils.DefaultMasterSetAgentConfig()
+
+	t.Log("building docker client")
+	rawCl, err := dclient.NewClientWithOpts(dclient.WithAPIVersionNegotiation(), dclient.FromEnv)
+	require.NoError(t, err)
+	cl := docker.NewClient(rawCl)
+	defer func() {
+		if cErr := cl.Close(); cErr != nil {
+			t.Logf("closing docker client: %s", cErr)
+		}
+	}()
+
+	t.Log("_not_ starting log acceptor")
+	t.Log("starting fluentbit")
+	f, err := fluent.Start(ctx, opts, mopts, cl)
+	require.NoError(t, err)
+	defer func() {
+		_ = f.Close()
+	}()
+
+	t.Log("running container with predefined logs")
+	taskID := model.NewTaskID()
+	_, expectedFile := makeLogTestCase(taskID, opts.AgentID)
+	runContainerWithLogs(t, expectedFile, opts.AgentID, taskID, opts.Fluent.Port)
+
+	t.Log("checking fluentbit failure logs for intermittent failure")
+	found := false
+	for e := range logC {
+		if strings.Contains(e.Message, "no upstream connections available") {
+			found = true
+			break
+		}
+	}
+	require.Truef(t, found, "did not find failure log in output")
+
+	t.Log("forcibly removing fluentbit")
+	fs := filters.NewArgs()
+	fs.Add("name", opts.Fluent.ContainerName)
+	conts, err := rawCl.ContainerList(ctx, types.ContainerListOptions{
+		Filters: fs,
+	})
+	require.NoError(t, err)
+	for _, cont := range conts {
+		err = cl.RemoveContainer(ctx, cont.ID, true)
+		require.NoError(t, err)
+	}
+	err = f.Wait()
+	require.Error(t, err)
+	require.ErrorContains(t, err, "unexpected Fluent Bit exit (137)")
+
+	t.Log("checking fluentbit failure logs for total failure")
+	found = false
+	for e := range logC {
+		if strings.Contains(
+			e.Message,
+			"Fluent Bit logs ended unexpectedly",
+		) {
+			found = true
+			break
+		}
+	}
+	require.Truef(t, found, "did not find failure log in output")
+}
+
+func makeLogTestCase(taskID model.TaskID, agentID string) ([]model.TaskLog, string) {
+	expected := []model.TaskLog{
+		{
+			TaskID:       taskID.String(),
+			AllocationID: taskToAllocationID(taskID.String()),
+			AgentID:      &agentID,
+			ContainerID:  ptrs.Ptr("goodcontainer"),
+			RankID:       ptrs.Ptr(4),
+			Log:          "\n",
+			StdType:      ptrs.Ptr("stdout"),
+		},
+		{
+			TaskID:       taskID.String(),
+			AllocationID: taskToAllocationID(taskID.String()),
+			AgentID:      &agentID,
+			ContainerID:  ptrs.Ptr("goodcontainer"),
+			RankID:       ptrs.Ptr(1),
+			Level:        ptrs.Ptr("INFO"),
+			Log:          "Workload completed: <RUN_STEP (100 Batches): (580,6289,4)> (duration 0:00:01.496132)\n", //nolint:lll // Anything to make these lines shorter would look worse.
+			StdType:      ptrs.Ptr("stdout"),
+		},
+		{
+			TaskID:       taskID.String(),
+			AllocationID: taskToAllocationID(taskID.String()),
+			AgentID:      &agentID,
+			ContainerID:  ptrs.Ptr("goodcontainer"),
+			RankID:       ptrs.Ptr(2),
+			Level:        ptrs.Ptr("ERROR"),
+			Log:          "Workload not complete: <RUN_STEP (100 Batches): (581,6290,5)> (duration 9:99:99)\n", // nolint:lll
+			StdType:      ptrs.Ptr("stdout"),
+		},
+		{
+			TaskID:       taskID.String(),
+			AllocationID: taskToAllocationID(taskID.String()),
+			AgentID:      &agentID,
+			ContainerID:  ptrs.Ptr("goodcontainer"),
+			RankID:       ptrs.Ptr(3),
+			Log:          "urllib3.exceptions.NewConnectionError: <urllib3.connection.HTTPConnection object at 0x7f29a414dd30>: Failed to establish a new connection: [Errno 110]\n", // nolint:lll
+			StdType:      ptrs.Ptr("stdout"),
+		},
+	}
+	actual := `[rank=4] 
+[rank=1] INFO: Workload completed: <RUN_STEP (100 Batches): (580,6289,4)> (duration 0:00:01.496132)
+[rank=2] ERROR: Workload not complete: <RUN_STEP (100 Batches): (581,6290,5)> (duration 9:99:99)
+[rank=3] urllib3.exceptions.NewConnectionError: <urllib3.connection.HTTPConnection object at 0x7f29a414dd30>: Failed to establish a new connection: [Errno 110]` // nolint:lll
+	return expected, actual
+}
+
+func mockLogAcceptor(t *testing.T, port int) (chan model.TaskLog, func()) {
+	e := echo.New()
+	lis, err := net.Listen("tcp", fmt.Sprintf(":%d", port))
+	require.NoError(t, err, "error starting mock master listener")
+	e.Listener = lis
+	logBuffer := make(chan model.TaskLog)
+	e.POST("/task-logs", func(ctx echo.Context) error {
+		body, err := ioutil.ReadAll(ctx.Request().Body)
+		if err != nil {
+			return err
+		}
+
+		var logs []model.TaskLog
+		if err = json.Unmarshal(body, &logs); err != nil {
+			return err
+		}
+
+		for _, l := range logs {
+			logBuffer <- l
+		}
+		return nil
+	})
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		if err := e.StartServer(e.Server); err != nil {
+			t.Logf("mock master exited: %s", err)
+		}
+	}()
+	return logBuffer, func() {
+		if err := e.Close(); err != nil {
+			t.Logf("error closing mock master echo server: %s", err)
+		}
+		wg.Wait()
+	}
+}
+
+func runContainerWithLogs(
+	t *testing.T, fakeLogs string, aID string, tID model.TaskID, fluentPort int,
+) {
+	rawCl, err := client.NewClientWithOpts(client.FromEnv, client.WithVersion("1.40"))
+	require.NoError(t, err, "error connecting to Docker daemon")
+	dCli := docker.NewClient(rawCl)
+
+	cID := "goodcontainer"
+	spec := cproto.Spec{
+		RunSpec: cproto.RunSpec{
+			ContainerConfig: dcontainer.Config{
+				Cmd:   []string{"cat", "/fakelogs"},
+				Image: "busybox",
+				Env: []string{
+					fmt.Sprintf("%s=%s", container.AgentIDEnvVar, aID),
+					fmt.Sprintf("%s=%s", container.ContainerIDEnvVar, cID),
+					fmt.Sprintf("%s=%s", container.TaskIDEnvVar, tID),
+					fmt.Sprintf("%s=%s.%d", container.AllocationIDEnvVar, tID, 0),
+				},
+			},
+			HostConfig: dcontainer.HostConfig{
+				LogConfig: dcontainer.LogConfig{
+					Type: "fluentd",
+					Config: map[string]string{
+						"fluentd-address":              "localhost:" + strconv.Itoa(fluentPort),
+						"fluentd-sub-second-precision": "true",
+						"mode":                         "non-blocking",
+						"max-buffer-size":              "10m",
+						"env":                          strings.Join(fluent.EnvVarNames, ","),
+					},
+				},
+				AutoRemove: true,
+			},
+			UseFluentLogging: true,
+			Archives: []cproto.RunArchive{
+				{
+					Path: "/",
+					Archive: []archive.Item{
+						{
+							Path:     "/fakelogs",
+							Type:     tar.TypeReg,
+							Content:  []byte(fakeLogs),
+							FileMode: 0o0777,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	c := container.Start(aproto.StartContainer{
+		Container: cproto.Container{ID: cproto.ID(cID)},
+		Spec:      spec,
+	}, dCli, events.NilPublisher[container.Event]{})
+	require.Nil(t, c.Wait().ContainerStopped.Failure)
+	return
+}
+
+func assertLogEquals(t *testing.T, actual, expected model.TaskLog) bool {
+	// nil out timestamps since they are set by fluent and we cannot know what to expect.
+	actual.Timestamp = nil
+	// IDs are assigned unpredictably by the backend, so don't compare them.
+	actual.ID = nil
+	actual.StringID = nil
+	actualJSON, err := json.Marshal(actual)
+	require.NoError(t, err)
+	expectedJSON, err := json.Marshal(actual)
+	require.NoError(t, err)
+	return assert.JSONEq(t, string(expectedJSON), string(actualJSON))
+}
+
+func taskToAllocationID(taskID string) *string {
+	return ptrs.Ptr(taskID + ".0")
+}

--- a/agent/internal/options/options.go
+++ b/agent/internal/options/options.go
@@ -1,0 +1,138 @@
+package options
+
+import (
+	"crypto/tls"
+	"encoding/json"
+
+	"github.com/determined-ai/determined/master/pkg/check"
+
+	"github.com/pkg/errors"
+)
+
+// AgentOptions stores all the configurable options for the Determined agent.
+type AgentOptions struct {
+	ConfigFile string `json:"config_file"`
+
+	MasterHost      string `json:"master_host"`
+	MasterPort      int    `json:"master_port"`
+	AgentID         string `json:"agent_id"`
+	ArtificialSlots int    `json:"artificial_slots"`
+	SlotType        string `json:"slot_type"`
+
+	ContainerMasterHost string `json:"container_master_host"`
+	ContainerMasterPort int    `json:"container_master_port"`
+
+	Label        string `json:"label"`
+	ResourcePool string `json:"resource_pool"`
+
+	APIEnabled bool   `json:"api_enabled"`
+	BindIP     string `json:"bind_ip"`
+	BindPort   int    `json:"bind_port"`
+
+	VisibleGPUs string `json:"visible_gpus"`
+
+	TLS      bool   `json:"tls"`
+	CertFile string `json:"cert_file"`
+	KeyFile  string `json:"key_file"`
+
+	HTTPProxy  string `json:"http_proxy"`
+	HTTPSProxy string `json:"https_proxy"`
+	FTPProxy   string `json:"ftp_proxy"`
+	NoProxy    string `json:"no_proxy"`
+
+	Security SecurityOptions `json:"security"`
+
+	Fluent FluentOptions `json:"fluent"`
+
+	ContainerAutoRemoveDisabled bool `json:"container_auto_remove_disabled"`
+
+	Hooks HooksOptions `json:"hooks"`
+}
+
+// Validate validates the state of the Options struct.
+func (o AgentOptions) Validate() []error {
+	return []error{
+		o.validateTLS(),
+		check.In(o.SlotType, []string{"gpu", "cuda", "rocm", "cpu", "auto", "none"}),
+		check.NotEmpty(o.MasterHost, "master host must be provided"),
+	}
+}
+
+func (o AgentOptions) validateTLS() error {
+	if !o.TLS || !o.APIEnabled {
+		return nil
+	}
+	if o.CertFile == "" {
+		return errors.New("TLS cert file not specified")
+	}
+	if o.KeyFile == "" {
+		return errors.New("TLS key file not specified")
+	}
+	return nil
+}
+
+// Printable returns a printable string.
+func (o AgentOptions) Printable() ([]byte, error) {
+	optJSON, err := json.Marshal(o)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to convert config to JSON")
+	}
+	return optJSON, nil
+}
+
+// Resolve fully resolves the agent configuration, handling dynamic defaults.
+func (o *AgentOptions) Resolve() {
+	if o.MasterPort == 0 {
+		if o.Security.TLS.Enabled {
+			o.MasterPort = 443
+		} else {
+			o.MasterPort = 80
+		}
+	}
+}
+
+// SecurityOptions stores configurable security-related options.
+type SecurityOptions struct {
+	TLS TLSOptions `json:"tls"`
+}
+
+// TLSOptions is the TLS connection configuration for the agent.
+type TLSOptions struct {
+	Enabled        bool   `json:"enabled"`
+	SkipVerify     bool   `json:"skip_verify"`
+	MasterCert     string `json:"master_cert"`
+	MasterCertName string `json:"master_cert_name"`
+	ClientCert     string `json:"client_cert"`
+	ClientKey      string `json:"client_key"`
+}
+
+// Validate implements the check.Validatable interface.
+func (t TLSOptions) Validate() []error {
+	var errs []error
+	if t.MasterCert != "" && t.SkipVerify {
+		errs = append(errs, errors.New("cannot specify a master cert file with verification off"))
+	}
+	return errs
+}
+
+// ReadClientCertificate returns the client certificate described by this configuration (nil if it
+// does not allow TLS to be enabled).
+func (t TLSOptions) ReadClientCertificate() (*tls.Certificate, error) {
+	if t.ClientCert == "" || t.ClientKey == "" {
+		return nil, nil
+	}
+	cert, err := tls.LoadX509KeyPair(t.ClientCert, t.ClientKey)
+	return &cert, err
+}
+
+// FluentOptions stores configurable Fluent Bit-related options.
+type FluentOptions struct {
+	Image         string `json:"image"`
+	Port          int    `json:"port"`
+	ContainerName string `json:"container_name"`
+}
+
+// HooksOptions contains external commands to be run when specific things happen.
+type HooksOptions struct {
+	OnConnectionLost []string `json:"on_connection_lost"`
+}

--- a/agent/test/testutils/fixtures.go
+++ b/agent/test/testutils/fixtures.go
@@ -1,0 +1,65 @@
+//go:build integration
+
+package testutils
+
+import (
+	"runtime"
+	"strconv"
+
+	"github.com/determined-ai/determined/agent/internal/options"
+	"github.com/determined-ai/determined/master/pkg/aproto"
+	"github.com/determined-ai/determined/master/pkg/model"
+	"github.com/determined-ai/determined/master/test/testutils"
+)
+
+const (
+	defaultMasterPort = 5152
+	defaultFluentName = "determined-fluent-test"
+	defaultFluentPort = 24225
+)
+
+// DefaultAgentConfig returns a default agent config, for tests.
+func DefaultAgentConfig(offset int) options.AgentOptions {
+	// Same defaults as set by viper when binding environment variables.
+	return options.AgentOptions{
+		AgentID:             "test-agent" + strconv.Itoa(offset),
+		MasterHost:          "localhost",
+		MasterPort:          defaultMasterPort + offset,
+		ContainerMasterHost: DefaultContainerMasterHost(),
+		ContainerMasterPort: defaultMasterPort + offset,
+		SlotType:            "auto",
+		BindIP:              "0.0.0.0",
+		BindPort:            9090 + offset,
+		Fluent: options.FluentOptions{
+			Image:         aproto.FluentImage,
+			Port:          defaultFluentPort + offset,
+			ContainerName: defaultFluentName + strconv.Itoa(offset),
+		},
+	}
+}
+
+// DefaultMasterSetAgentConfig returns default MasterSetAgentOptions (logs go to master).
+func DefaultMasterSetAgentConfig() aproto.MasterSetAgentOptions {
+	return aproto.MasterSetAgentOptions{
+		MasterInfo: aproto.MasterInfo{},
+		LoggingOptions: model.LoggingConfig{
+			DefaultLoggingConfig: &model.DefaultLoggingConfig{},
+		},
+	}
+}
+
+// ElasticMasterSetAgentConfig returns MasterSetAgentOptions for an elastic-configured cluster.
+func ElasticMasterSetAgentConfig() aproto.MasterSetAgentOptions {
+	return aproto.MasterSetAgentOptions{
+		MasterInfo:     aproto.MasterInfo{},
+		LoggingOptions: testutils.DefaultElasticConfig(),
+	}
+}
+
+// DefaultContainerMasterHost returns the default container master host, depending on the system.
+func DefaultContainerMasterHost() string {
+	if runtime.GOOS == "darwin" {
+		return "host.docker.internal"
+	}
+	return ""
+}

--- a/agent/test/testutils/log_hook.go
+++ b/agent/test/testutils/log_hook.go
@@ -1,0 +1,26 @@
+//go:build integration
+
+package testutils
+
+import (
+	"github.com/sirupsen/logrus"
+)
+
+// LogChannel is an channel implenting logrus.Hook.
+type LogChannel chan *logrus.Entry
+
+// NewLogChannel creates a new LogChannel.
+func NewLogChannel(bufSize int) LogChannel {
+	return make(chan *logrus.Entry, bufSize)
+}
+
+// Fire implements the logrus.Hook interface.
+func (lc LogChannel) Fire(entry *logrus.Entry) error {
+	lc <- entry
+	return nil
+}
+
+// Levels implements the logrus.Hook interface.
+func (lc LogChannel) Levels() []logrus.Level {
+	return logrus.AllLevels
+}


### PR DESCRIPTION
## Description
The primary goal of the PR is refactoring the actor-based Fluent daemon manager away from the actor system. Secondary goals, similar to other PRs in this set, are to decouple the interface from other packages (less leaky abstractions) and increase test coverage. There is still one offender w.r.t that: `Options`/`MasterSetAgentOptions` passed everywhere, but I decided this wasn't worth refactoring.
<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At a minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan
- [x] has automated tests

<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions about this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)
Blocked on #5384 

Order to review this set of PRs:
* [refactor: rewrite websocket lib without actors DET-8299](https://github.com/determined-ai/determined/pull/5382)
* [refactor: rewrite our docker lib without actors DET-8300](https://github.com/determined-ai/determined/pull/4943)
* [refactor: rewrite container lib without actors](https://github.com/determined-ai/determined/pull/5384)
* [refactor: rewrite fluent lib without actors](https://github.com/determined-ai/determined/pull/5385)
* [refactor: rewrite container manager lib without actors](https://github.com/determined-ai/determined/pull/5386)
* [refactor: rewrite agent without actors](https://github.com/determined-ai/determined/pull/5387)
<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist
- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-8299]: https://determinedai.atlassian.net/browse/DET-8299?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DET-8300]: https://determinedai.atlassian.net/browse/DET-8300?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ