### PR TITLE
chore: cli allow workspace --checkpoint-storage-config-file to use yaml

### DIFF
--- a/harness/determined/cli/workspace.py
+++ b/harness/determined/cli/workspace.py
@@ -5,7 +5,7 @@ from typing import Any, List, Optional, Sequence
 
 from determined import cli
 from determined.cli.user import AGENT_USER_GROUP_ARGS
-from determined.common import api
+from determined.common import api, util
 from determined.common.api import authentication, bindings, errors
 from determined.common.declarative_argparse import Arg, Cmd
 
@@ -240,9 +240,9 @@ def edit_workspace(args: Namespace) -> None:
         render_workspaces([w])
 
 
-def json_file_arg(val: str) -> Any:
+def yaml_file_arg(val: str) -> Any:
     with open(val) as f:
-        return json.load(f)
+        return util.safe_load_yaml_with_exceptions(f)
 
 
 CHECKPOINT_STORAGE_WORKSPACE_ARGS = [
@@ -253,8 +253,8 @@ CHECKPOINT_STORAGE_WORKSPACE_ARGS = [
     ),
     Arg(
         "--checkpoint-storage-config-file",
-        type=json_file_arg,
-        help="Storage config (path to JSON-formatted file)",
+        type=yaml_file_arg,
+        help="Storage config (path to YAML or JSON formatted file)",
     ),
 ]
 


### PR DESCRIPTION
## Description

Allows ```--checkpoint-storage-config-file``` to also support yaml in addition to json.

## Test Plan

Create file ```test.yaml``` with 

```
type: shared_fs
host_path: /tmp/test
```

And you should see the checkpoint storage set in output of following two commands

```
det w create test --checkpoint-storage-config-file=test.yaml
det w edit test --checkpoint-storage-config-file=test.yaml
```

## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist
- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
