### PR TITLE
feat: Download eligible checkpoints from WebUI [WEB-230]

### DIFF
--- a/master/internal/core.go
+++ b/master/internal/core.go
@@ -1027,6 +1027,7 @@ func (m *Master) Run(ctx context.Context) error {
 	experimentsGroup.POST("", api.Route(m.postExperiment))
 
 	checkpointsGroup := m.echo.Group("/checkpoints")
+	checkpointsGroup.GET("/:checkpoint_uuid/access", m.checkCheckpoint)
 	checkpointsGroup.GET("/:checkpoint_uuid", m.getCheckpoint)
 
 	searcherGroup := m.echo.Group("/searcher")

--- a/webui/react/src/hooks/useModal/Checkpoint/useModalCheckpoint.tsx
+++ b/webui/react/src/hooks/useModal/Checkpoint/useModalCheckpoint.tsx
@@ -172,20 +172,13 @@ ${checkpoint.totalBatches}. This action may complete or fail without further not
                   .then((blob) => {
                     if (blob.size < 1000) {
                       // consistent with an error message (usually Access Denied)
-                      setIsDownloading(false);
-                      handleError(null, {
-                        publicSubject: 'Unable to download checkpoint.',
-                        silent: false,
-                        type: ErrorType.Api,
-                      });
-                      return;
+                      throw new Error('Checkpoint file size too small');
                     }
                     const file = window.URL.createObjectURL(blob);
                     window.location.assign(file);
                     setIsDownloading(false);
                   })
                   .catch(() => {
-                    setIsDownloading(false);
                     handleError(null, {
                       publicSubject: 'Unable to download checkpoint.',
                       silent: false,

--- a/webui/react/src/hooks/useModal/Model/useModalModelDownload.test.tsx
+++ b/webui/react/src/hooks/useModal/Model/useModalModelDownload.test.tsx
@@ -1,0 +1,57 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Button } from 'antd';
+import React, { useEffect } from 'react';
+
+import StoreProvider, { StoreAction, useStoreDispatch } from 'contexts/Store';
+import { generateTestModelVersion } from 'storybook/shared/generateTestData';
+
+import useModalModelDownload from './useModalModelDownload';
+
+const modelVersion = generateTestModelVersion();
+
+const ModalTrigger: React.FC = () => {
+  const storeDispatch = useStoreDispatch();
+  const { contextHolder, modalOpen } = useModalModelDownload();
+
+  useEffect(() => {
+    storeDispatch({ type: StoreAction.SetAuth, value: { isAuthenticated: true } });
+  }, [storeDispatch]);
+
+  return (
+    <>
+      <Button onClick={() => modalOpen(modelVersion)}>Download</Button>
+      {contextHolder}
+    </>
+  );
+};
+
+const Container: React.FC = () => {
+  return (
+    <StoreProvider>
+      <ModalTrigger />
+    </StoreProvider>
+  );
+};
+
+const setup = async () => {
+  const user = userEvent.setup();
+
+  render(<Container />);
+
+  await user.click(screen.getByRole('button'));
+};
+
+describe('useModalExperimentCreate', () => {
+  it('modal can be opened', async () => {
+    await setup();
+
+    expect(await screen.findByText('Download Model Command')).toBeInTheDocument();
+  });
+
+  it('modal contains checkpoint id', async () => {
+    await setup();
+
+    expect(await screen.getByDisplayValue(modelVersion.checkpoint.uuid)).toBeInTheDocument();
+  });
+});

--- a/webui/react/src/services/api-ts-sdk/api.ts
+++ b/webui/react/src/services/api-ts-sdk/api.ts
@@ -9479,6 +9479,43 @@ export const CheckpointsApiFetchParamCreator = function (configuration?: Configu
     return {
         /**
          * 
+         * @summary Check for access to a checkpoint's files for download.
+         * @param {string} checkpointUuid Checkpoint UUID
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        checkCheckpoint(checkpointUuid: string, options: any = {}): FetchArgs {
+            // verify required parameter 'checkpointUuid' is not null or undefined
+            if (checkpointUuid === null || checkpointUuid === undefined) {
+                throw new RequiredError('checkpointUuid','Required parameter checkpointUuid was null or undefined when calling checkCheckpoint.');
+            }
+            const localVarPath = `/checkpoints/{checkpoint_uuid}/access`
+                .replace(`{${"checkpoint_uuid"}}`, encodeURIComponent(String(checkpointUuid)));
+            const localVarUrlObj = url.parse(localVarPath, true);
+            const localVarRequestOptions = Object.assign({ method: 'GET' }, options);
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            // authentication BearerToken required
+            if (configuration && configuration.apiKey) {
+                const localVarApiKeyValue = typeof configuration.apiKey === 'function'
+					? configuration.apiKey("Authorization")
+					: configuration.apiKey;
+                localVarHeaderParameter["Authorization"] = localVarApiKeyValue;
+            }
+
+            localVarUrlObj.query = Object.assign({}, localVarUrlObj.query, localVarQueryParameter, options.query);
+            // fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
+            delete localVarUrlObj.search;
+            localVarRequestOptions.headers = Object.assign({}, localVarHeaderParameter, options.headers);
+
+            return {
+                url: url.format(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         * 
          * @summary Delete Checkpoints.
          * @param {V1DeleteCheckpointsRequest} body 
          * @param {*} [options] Override http request option.
@@ -9648,6 +9685,25 @@ export const CheckpointsApiFp = function(configuration?: Configuration) {
     return {
         /**
          * 
+         * @summary Check for access to a checkpoint's files for download.
+         * @param {string} checkpointUuid Checkpoint UUID
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        checkCheckpoint(checkpointUuid: string, options?: any): (fetch?: FetchAPI, basePath?: string) => Promise<Response> {
+            const localVarFetchArgs = CheckpointsApiFetchParamCreator(configuration).checkCheckpoint(checkpointUuid, options);
+            return (fetch: FetchAPI = portableFetch, basePath: string = BASE_PATH) => {
+                return fetch(basePath + localVarFetchArgs.url, localVarFetchArgs.options).then((response) => {
+                    if (response.status >= 200 && response.status < 300) {
+                        return response;
+                    } else {
+                        throw response;
+                    }
+                });
+            };
+        },
+        /**
+         * 
          * @summary Delete Checkpoints.
          * @param {V1DeleteCheckpointsRequest} body 
          * @param {*} [options] Override http request option.
@@ -9734,6 +9790,16 @@ export const CheckpointsApiFactory = function (configuration?: Configuration, fe
     return {
         /**
          * 
+         * @summary Check for access to a checkpoint's files for download.
+         * @param {string} checkpointUuid Checkpoint UUID
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        checkCheckpoint(checkpointUuid: string, options?: any) {
+            return CheckpointsApiFp(configuration).checkCheckpoint(checkpointUuid, options)(fetch, basePath);
+        },
+        /**
+         * 
          * @summary Delete Checkpoints.
          * @param {V1DeleteCheckpointsRequest} body 
          * @param {*} [options] Override http request option.
@@ -9783,6 +9849,18 @@ export const CheckpointsApiFactory = function (configuration?: Configuration, fe
  * @extends {BaseAPI}
  */
 export class CheckpointsApi extends BaseAPI {
+    /**
+     * 
+     * @summary Check for access to a checkpoint's files for download.
+     * @param {string} checkpointUuid Checkpoint UUID
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof CheckpointsApi
+     */
+    public checkCheckpoint(checkpointUuid: string, options?: any) {
+        return CheckpointsApiFp(this.configuration).checkCheckpoint(checkpointUuid, options)(this.fetch, this.basePath);
+    }
+
     /**
      * 
      * @summary Delete Checkpoints.

--- a/webui/react/src/services/apiConfig.ts
+++ b/webui/react/src/services/apiConfig.ts
@@ -26,6 +26,7 @@ const generateApiConfig = (apiConfig?: Api.ConfigurationParameters) => {
   return {
     Auth: new Api.AuthenticationApi(config),
     Checkpoint: Api.CheckpointsApiFetchParamCreator(config),
+    Checkpoints: new Api.CheckpointsApi(config),
     Cluster: new Api.ClusterApi(config),
     Commands: new Api.CommandsApi(config),
     Experiments: new Api.ExperimentsApi(config),
@@ -1625,4 +1626,9 @@ export const updateJobQueue: DetApi<
 
 export const downloadCheckpoint = (uuid: string): Api.FetchArgs => {
   return detApi.Checkpoint.getCheckpoint_1(uuid);
+};
+
+export const checkCheckpoint = async (uuid: string): Promise<boolean> => {
+  const resp = await detApi.Checkpoints.checkCheckpoint(uuid);
+  return !!resp;
 };

--- a/webui/react/src/services/apiConfig.ts
+++ b/webui/react/src/services/apiConfig.ts
@@ -1622,3 +1622,7 @@ export const updateJobQueue: DetApi<
   postProcess: identity,
   request: (params: Api.V1UpdateJobQueueRequest) => detApi.Internal.updateJobQueue(params),
 };
+
+export const downloadCheckpoint = (uuid: string): Api.FetchArgs => {
+  return detApi.Checkpoint.getCheckpoint_1(uuid);
+};

--- a/webui/react/src/storybook/shared/generateTestData.ts
+++ b/webui/react/src/storybook/shared/generateTestData.ts
@@ -5,6 +5,8 @@ import {
   ExperimentBase,
   ExperimentSearcherName,
   HyperparameterType,
+  ModelItem,
+  ModelVersion,
   Project,
   RunState,
   TrialDetails,
@@ -293,6 +295,47 @@ export const generateTestWorkspaceData = (overrides: Partial<Workspace> = {}): W
     pinned: false,
     state: WorkspaceState.Unspecified,
     userId: 1,
+    ...overrides,
+  };
+};
+
+export const generateTestModel = (overrides: Partial<ModelItem> = {}): ModelItem => {
+  return {
+    archived: false,
+    creationTime: String(new Date(101)),
+    description: '',
+    id: 1,
+    labels: [],
+    lastUpdatedTime: String(new Date()),
+    metadata: {},
+    name: 'Model Name',
+    notes: 'hello world',
+    numVersions: 1,
+    userId: 1,
+    ...overrides,
+  };
+};
+
+export const generateTestModelVersion = (overrides: Partial<ModelVersion> = {}): ModelVersion => {
+  return {
+    checkpoint: {
+      metadata: {},
+      resources: {},
+      state: CheckpointState.Completed,
+      totalBatches: 20,
+      uuid: 'abcdefff',
+    },
+    comment: 'Comment',
+    creationTime: String(new Date(101)),
+    id: 1,
+    labels: [],
+    lastUpdatedTime: String(new Date()),
+    metadata: {},
+    model: generateTestModel(),
+    name: 'V1',
+    notes: 'hello version',
+    userId: 1,
+    version: 1,
     ...overrides,
   };
 };


### PR DESCRIPTION
## Description

Work In Progress for now - this uses the new `/checkpoints/UUID` endpoint to download a checkpoint's files as a ZIP.

Currently includes a test for the Model Version download modal.

**Update**: following Ilia's suggestion on Slack: download -> show CLI instructions

Issues:
- Only supports S3 storage. Button is hidden on experiments with other checkpoint storage settings. I'd like to continue piloting this on AWS so the first PR doesn't become 'support all cloud and server configs'.
- Depending how the S3 bucket was configured, Determined master might not have access
- If the URL is always `/checkpoints/UUID`, is there a need to use `detApi.Checkpoint.getCheckpoint_1`?
- Because the download now happens in another tab / request, we don't know for sure if it completes, gets interrupted, or errors
- I had `GetS3BucketRegion` crash unexpectedly, so it's removed in the test plan:

```
INFO[2022-11-08T08:35:01-08:00] [PANIC RECOVER] runtime error: invalid memory address or nil pointer dereference goroutine 312 [running]:
github.com/labstack/echo/v4/middleware.RecoverWithConfig.func1.1.1()
	/Users/ndoiron404/go/pkg/mod/github.com/labstack/echo/v4@v4.6.3/middleware/recover.go:77 +0x10d
panic({0x36a6020, 0x59baba0})
	/usr/local/Cellar/go/1.19.3/libexec/src/runtime/panic.go:884 +0x212
github.com/determined-ai/determined/master/pkg/checkpoints/s3.GetS3BucketRegion({0x418e740, 0xc000da36c0}, {0xc000bf4d38, 0x11})
	/Users/ndoiron404/Documents/determined/master/pkg/checkpoints/s3/s3checkpoints.go:52 +0x199
```

Potential fixes:
~~- Separating out the can-read-object from the download-object logic in `getCheckpointImpl`, making a new query to check this before displaying the download button~~
- ~~I anticipate a problem with JS Blob on larger checkpoints~~
- ~~Removing MIME type check from `getCheckpoint`, so a regular browser request can download the file w/o Blob~~
- Using Storage to remember which buckets don't have access [possibly testing the default on init]

## Test Plan

1. Create an S3 bucket on AWS. Public access stays blocked
2. In the bucket's permissions tab, set the policy:
```json
  {
      "Version": "2012-10-17",
      "Statement": [
          {
              "Sid": "PublicRead",
              "Effect": "Allow",
              "Principal": "*",
              "Action": [
                  "s3:DeleteObject",
                  "s3:GetObject",
                  "s3:PutObject"
              ],
              "Resource": [
                  "arn:aws:s3:::BUCKETNAME/*"
              ]
          }
      ]
  }
```
3. [Install AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html) if you don't have it yet. Run `aws configure` to save your access key and secret key.
4. In `~/.devcluster.yaml`, replace local checkpoint_storage with:
```yaml
    checkpoint_storage:
      access_key: ACCESSKEY
      bucket: BUCKETNAME
      endpoint_url: null
      prefix: null
      save_experiment_best: 0
      save_trial_best: 1
      save_trial_latest: 1
      secret_key: SECRETKEY
      type: s3
```
5. In master/pkg/checkpoints/s3/s3checkpoints.go, comment out `GetS3BucketRegion(ctx, d.bucket)`. Instead:
```go
    region := "us-east-1"
    sess, err := session.NewSession(&aws.Config{
      Region: &region,
    })
```
6. Create an experiment from the CLI (such as `decision_trees/gbt_titanic_estimator/const.yaml`). If the experiment restarts, there is no bucket write access.
7. After a checkpoint is saved, check the bucket to confirm the files were stored in the bucket.
8. In the single-trial experiment or trial's checkpoints tab, click a checkpoint flag button
9. In the modal, click 'Download' to load `/checkpoints/UUID` (don't try to load it directly in browser)
10. If you get a too-small zip, run `cat UUID.zip` to read the text error

## Checklist
- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.