### PR TITLE
fix: redirect url to login page

### DIFF
--- a/master/internal/core.go
+++ b/master/internal/core.go
@@ -968,7 +968,7 @@ func (m *Master) Run(ctx context.Context) error {
 
 	webuiGroup := m.echo.Group(webuiBaseRoute)
 	webuiGroup.File("/", reactIndex)
-	webuiGroup.GET("/*", func(c echo.Context) error {
+	webuiGroup.GET("*", func(c echo.Context) error {
 		groupPath := strings.TrimPrefix(c.Request().URL.Path, webuiBaseRoute+"/")
 		requestedFile := filepath.Join(reactRoot, groupPath)
 		// We do a simple check against directory traversal attacks.

--- a/master/internal/core.go
+++ b/master/internal/core.go
@@ -967,8 +967,9 @@ func (m *Master) Run(ctx context.Context) error {
 	m.echo.Static("/docs", filepath.Join(webuiRoot, "docs"))
 
 	webuiGroup := m.echo.Group(webuiBaseRoute)
+	webuiGroup.File("", reactIndex)
 	webuiGroup.File("/", reactIndex)
-	webuiGroup.GET("*", func(c echo.Context) error {
+	webuiGroup.GET("/*", func(c echo.Context) error {
 		groupPath := strings.TrimPrefix(c.Request().URL.Path, webuiBaseRoute+"/")
 		requestedFile := filepath.Join(reactRoot, groupPath)
 		// We do a simple check against directory traversal attacks.

--- a/master/internal/user/service.go
+++ b/master/internal/user/service.go
@@ -47,6 +47,7 @@ var unauthenticatedPointsList = []string{
 	"/task-logs",
 	"/ws/data-layer/.*",
 	"/agents",
+	"/det",
 	"/det/.*",
 	"/login",
 	"/api/v1/.*",


### PR DESCRIPTION
## Description

On tip of master redirect seems to not work after #4996

we should fix that before release since we tell people to go to their cluster address in the quick start guide. 


## Test Plan

To reproduce open a private browser and clear cache and go to ```127.0.0.1:8080``` in a browser and ```Unauthorized``` should be the response on latest master and you should be at the login page with this fix

## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist
- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
