### PR TITLE
Remove Slurm options validation from oss

### DIFF
--- a/master/pkg/model/environment_config.go
+++ b/master/pkg/model/environment_config.go
@@ -3,7 +3,6 @@ package model
 import (
 	"encoding/json"
 	"fmt"
-	"strings"
 
 	k8sV1 "k8s.io/api/core/v1"
 
@@ -203,36 +202,6 @@ func validatePodSpec(podSpec *k8sV1.Pod) []error {
 		return podSpecErrors
 	}
 	return nil
-}
-
-// ValidateSlurm checks that the specified slurm options are allowed.
-// If any are not messages are returned in an array of errors.
-func ValidateSlurm(slurm []string) []error {
-	slurmErrors := []error{}
-	forbiddenArgs := []string{
-		"--ntasks-per-node=",
-		"--gpus=", "-G",
-		"--gres=",
-		"--nodes=", "-N",
-		"--ntasks=", "-n",
-		"--chdir=", "-D",
-		"--error=", "-e",
-		"--output=", "-o",
-		"--partition=", "-p",
-	}
-
-	for _, arg := range slurm {
-		for _, forbidden := range forbiddenArgs {
-			// If an arg starts with a forbidden option, add an error.
-			err := check.TrueSilent(!strings.HasPrefix(strings.TrimSpace(arg), forbidden),
-				"slurm option "+forbidden+" is not configurable")
-			if err != nil {
-				slurmErrors = append(slurmErrors, err)
-			}
-		}
-	}
-
-	return slurmErrors
 }
 
 // UsingCustomImage checks for image argument in request.

--- a/master/pkg/model/experiment_config_test.go
+++ b/master/pkg/model/experiment_config_test.go
@@ -130,38 +130,6 @@ func TestOverrideMasterEnvironmentVariables(t *testing.T) {
 	})
 }
 
-// Helper function to setup and verify slurm option test cases.
-func testEnvironmentSlurm(t *testing.T, slurmOptions []string, expected ...string) {
-	err := ValidateSlurm(slurmOptions)
-	if len(expected) == 0 {
-		assert.Equal(t, len(err), 0)
-	} else {
-		for i, msg := range expected {
-			assert.ErrorContains(t, err[i], msg)
-		}
-	}
-}
-
-func TestValidateSlurmOptions(t *testing.T) {
-	// No slurm args, not error
-	testEnvironmentSlurm(t, []string{})
-	// Forbidden -G option
-	testEnvironmentSlurm(t, []string{"-G1"}, "slurm option -G is not configurable")
-	// Forbidden --grpus=#
-	testEnvironmentSlurm(t, []string{"--gpus=2"}, "slurm option --gpus= is not configurable")
-	// OK --gpus-per-task=#
-	testEnvironmentSlurm(t, []string{"--gpus-per-task=2"})
-	// OK option containing letters of forbidden option (-n)
-	testEnvironmentSlurm(t, []string{"--nice=3"})
-	// Forbidden -n option intermixed with OK options
-	testEnvironmentSlurm(t, []string{"--nice=7", "-n3", "-lname"},
-		"slurm option -n is not configurable")
-	// Multiple failures
-	testEnvironmentSlurm(t, []string{"--nice=7", " -N2", "-Dmydir", "--partion=pname"},
-		"slurm option -N is not configurable",
-		"slurm option -D is not configurable")
-}
-
 func TestDeviceConfig(t *testing.T) {
 	// Devices can be strings or maps, and merging device lists is additive.
 	var actual DevicesConfig


### PR DESCRIPTION
## Description

Remove some unused code Slurm options validation code (now occurs on the Determined-ee side of the house).


## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions about this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist
- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
