### PR TITLE
fix: Avoid writing to users known_hosts [FOUNDENG-314]

### DIFF
--- a/master/static/srv/ssh_config
+++ b/master/static/srv/ssh_config
@@ -1,3 +1,4 @@
 Host *
     StrictHostKeyChecking no
+    UserKnownHostsFile=/dev/null
     IdentityFile /run/determined/ssh/id_rsa


### PR DESCRIPTION
## Description

On HPTC clusters with Singularity the default is to mount the users home directory into the container and add clone the host passwd entry for the user. This means that by default ssh will write keys to the users ~/.ssh/known_hosts file. As these keys are Determined-generated per trial, they change which leads to warnings about potentially hijacked nodes.

This change to the ssh_config will prevent writing these private Determined keys to the existing known_hosts file which will avoid these warning messages in the experiment log after multiple runs.


## Test Plan

Validated ~/.ssh/known_hosts is no longer updated when running a determined trail with singularity.

## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist
- [x] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
