### PR TITLE
fix: listen for onReset for ParallelCoordinates filters

### DIFF
--- a/webui/react/src/pages/ExperimentDetails/ExperimentVisualization/HpParallelCoordinates.tsx
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentVisualization/HpParallelCoordinates.tsx
@@ -88,7 +88,7 @@ const HpParallelCoordinates: React.FC<Props> = ({
   const [filteredTrialIdMap, setFilteredTrialIdMap] = useState<Record<number, boolean>>();
   const [selectedRowKeys, setSelectedRowKeys] = useState<number[]>([]);
   const [showCompareTrials, setShowCompareTrials] = useState(false);
-  const [hermesCreatedFeatures, setHermesCreatedFeatures] = useState<HermesInternalFilters>({});
+  const [hermesCreatedFilters, setHermesCreatedFilters] = useState<HermesInternalFilters>({});
 
   const hyperparameters = useMemo(() => {
     return fullHParams.reduce((acc, key) => {
@@ -121,7 +121,7 @@ const HpParallelCoordinates: React.FC<Props> = ({
 
     // Figure out which trials are filtered out based on user filters.
 
-    Object.entries(hermesCreatedFeatures).forEach(([key, list]) => {
+    Object.entries(hermesCreatedFilters).forEach(([key, list]) => {
       if (!chartData.data[key] || list.length === 0) return;
 
       chartData.data[key].forEach((value, index) => {
@@ -143,7 +143,7 @@ const HpParallelCoordinates: React.FC<Props> = ({
     });
 
     setFilteredTrialIdMap(newFilteredTrialIdMap);
-  }, [chartData, hermesCreatedFeatures]);
+  }, [chartData, hermesCreatedFilters]);
 
   useEffect(() => {
     resetFilteredTrials();
@@ -155,9 +155,10 @@ const HpParallelCoordinates: React.FC<Props> = ({
 
   const config: Hermes.RecursivePartial<Hermes.Config> = useMemo(
     () => ({
-      filters: hermesCreatedFeatures,
+      filters: hermesCreatedFilters,
       hooks: {
-        onFilterChange: setHermesCreatedFeatures,
+        onFilterChange: setHermesCreatedFilters,
+        onReset: () => setHermesCreatedFilters({}),
       },
       style: {
         axes: { label: { placement: 'after' } },
@@ -171,7 +172,7 @@ const HpParallelCoordinates: React.FC<Props> = ({
         padding: [4, 120, 4, 16],
       },
     }),
-    [colorScale, setHermesCreatedFeatures, hermesCreatedFeatures, selectedMetric],
+    [colorScale, setHermesCreatedFilters, hermesCreatedFilters, selectedMetric],
   );
 
   const dimensions = useMemo(() => {


### PR DESCRIPTION
## Description

In the Multi-Trial Experiment's Parallel Coordinates visualization, double-clicking the chart should reset all filters. Listen for the distinct onReset event.

Also improves a variable name here

## Test Plan

- Create or fork a multi-trial experiment.
- While the experiment is running (new data streaming into the chart), drag the mouse along axes to create filters. As the chart updates with more data, the filters should remain ( #5243 )
- Double-clicking the chart somewhere other than the pink highlight (on the axis, background, etc.) should remove all filters at once.
- Filters should be totally removed and not return when chart updates with new data

## Checklist
- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.