### PR TITLE
fix: Workspace header in mobile view [WEB-633]

### DIFF
--- a/webui/react/src/pages/WorkspaceDetails/WorkspaceDetailsHeader.module.scss
+++ b/webui/react/src/pages/WorkspaceDetails/WorkspaceDetailsHeader.module.scss
@@ -28,4 +28,8 @@
       margin-right: 10px;
     }
   }
+
+  @media only screen and (max-width: $breakpoint-tablet) {
+    display: block;
+  }
 }


### PR DESCRIPTION
## Description

When RBAC is enabled, the workspace header has an additional button (Add Members) which crowds the header, especially on mobile view (ticket discusses Pixel 5 in particular).

I add a media query css here to shift the Add Members and New Project buttons below the name / pinning UI

The minimum breakpoint is about 600-650px, which I then compared to our existing media queries and used the nearby tablet breakpoint (768px).

## Test Plan

- Start an instance with RBAC / EE enabled
- Visit a workspace details page
- Use the browser tools to view in mobile view

## Checklist
- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.