### PR TITLE
fix: create personal groups for other ways a user can be created

### DIFF
--- a/master/internal/api/apiutils/utils.go
+++ b/master/internal/api/apiutils/utils.go
@@ -81,6 +81,6 @@ func MapAndFilterErrors(err error, passthrough map[error]bool, mapping map[error
 		}
 	}
 
-	logrus.WithError(err).Debug("suppressing error at API boundary")
+	logrus.WithError(err).Warn("suppressing error at API boundary")
 	return ErrInternal
 }

--- a/master/internal/db/postgres_users.go
+++ b/master/internal/db/postgres_users.go
@@ -77,6 +77,10 @@ RETURNING id`)
 		return 0, errors.Wrapf(err, "error creating user %v", err)
 	}
 
+	if err := addUserPersonalGroup(tx, user.ID); err != nil {
+		return 0, errors.Wrap(err, "error adding users personal group")
+	}
+
 	return user.ID, nil
 }
 
@@ -150,10 +154,6 @@ func (db *PgDB) AddUser(user *model.User, ug *model.AgentUserGroup) (model.UserI
 
 	userID, err := addUser(tx, user)
 	if err != nil {
-		return 0, err
-	}
-
-	if err := addUserPersonalGroup(tx, userID); err != nil {
 		return 0, err
 	}
 


### PR DESCRIPTION
## Description

Bug with RBAC where we expect users to always have a personal group. Found some ways users can be created without them.

## Test Plan

 

## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist
- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
