### PR TITLE
fix: `det task list` under rbac. [DET-8650]

### DIFF
--- a/master/internal/core_task.go
+++ b/master/internal/core_task.go
@@ -27,6 +27,7 @@ func (m *Master) getTasks(c echo.Context) (interface{}, error) {
 			} else if !ok {
 				delete(summary, allocationID)
 			}
+			continue
 		}
 
 		if ok, err := expauth.AuthZProvider.Get().CanGetExperiment(ctx, curUser, exp); err != nil {


### PR DESCRIPTION
## Description

Fix crash in `det task list` when there're non-experiment tasks running on the server.

## Test Plan

1. run a task as a user, e.g. `det cmd run -d sleep 100`
2. try `det task list` and `det slot list` as a different, non-admin user — the task should not show up.
3. try `det task list` and `det slot list` as an admin user — the task should show up.

## Commentary (optional)

Currently, `det slot list` will display the tasks you don't have access to as "Non-Determined Task":
```
Agent ID   | Resource Pool   |   Slot ID | Enabled   | Draining   | Allocation ID   | Task Name                                                 | Type   | Device
------------+-----------------+-----------+-----------+------------+-----------------+-----------------------------------------------------------+--------+------------
 agent1     | default         |         0 | True      | False      | OCCUPIED        | Non-Determined Task: 129f88a3-ea0a-4748-a52d-eb8589dce8d0 | cpu    | Artificial
 agent1     | default         |         1 | True      | False      | FREE            | FREE                                                      | cpu    | Artificial
```
this could be improved.

## Checklist
- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
