### PR TITLE
fix: avoid panic in getTasks

### DIFF
--- a/master/internal/core_task.go
+++ b/master/internal/core_task.go
@@ -21,17 +21,18 @@ func (m *Master) getTasks(c echo.Context) (interface{}, error) {
 		if err != nil {
 			return nil, err
 		}
+
+		var ok bool
 		if !isExp {
-			if ok, err := canAccessNTSCTask(ctx, curUser, summary[allocationID].TaskID); err != nil {
-				return nil, err
-			} else if !ok {
-				delete(summary, allocationID)
-			}
+			ok, err = canAccessNTSCTask(ctx, curUser, summary[allocationID].TaskID)
+		} else {
+			ok, err = expauth.AuthZProvider.Get().CanGetExperiment(ctx, curUser, exp)
+		}
+		if err != nil {
+			return nil, err
 		}
 
-		if ok, err := expauth.AuthZProvider.Get().CanGetExperiment(ctx, curUser, exp); err != nil {
-			return nil, err
-		} else if !ok {
+		if !ok {
 			delete(summary, allocationID)
 		}
 	}


### PR DESCRIPTION
## Description

Fixes [DET-8650].

# Testing Plan

- Turn on RBAC
- Create at least one experiment
- Create a Tensorboard
- Run `det -u admin task list` and make sure there's no panic
- Make some unprivileged user like `det -u admin user create foo` then `det -u foo task list` and make sure there's still no panic


[DET-8650]: https://determinedai.atlassian.net/browse/DET-8650?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ