### PR TITLE
fix: adds user to group when create group through external token

### DIFF
--- a/master/internal/user/postgres_users.go
+++ b/master/internal/user/postgres_users.go
@@ -90,6 +90,19 @@ func AddUserExec(user *model.User) error {
 		return errors.Wrap(err, "error inserting personal group")
 	}
 
+	groupMembership := struct {
+		bun.BaseModel `bun:"table:user_group_membership"`
+
+		UserID  model.UserID `bun:"user_id,notnull"`
+		GroupID int          `bun:"group_id,notnull"`
+	}{
+		UserID:  user.ID,
+		GroupID: personalGroup.ID,
+	}
+	if _, err = tx.NewInsert().Model(&groupMembership).Exec(ctx); err != nil {
+		return errors.Wrap(err, "error adding user to personal group")
+	}
+
 	if err = tx.Commit(); err != nil {
 		return errors.Wrap(err, "error committing changes in AddUserExec")
 	}

--- a/master/internal/user/service_intg_test.go
+++ b/master/internal/user/service_intg_test.go
@@ -71,6 +71,15 @@ func TestAddUserExec(t *testing.T) {
 	}{}
 	require.NoError(t, db.Bun().NewSelect().Model(actualGroup).Where("user_id = ?", u.ID).Scan(ctx))
 	require.Equal(t, u.Username+db.PersonalGroupPostfix, actualGroup.Name)
+
+	groupMember := &struct {
+		bun.BaseModel `bun:"table:user_group_membership"`
+		UserID        model.UserID `bun:"user_id,notnull"`
+	}{
+		UserID: u.ID,
+	}
+	require.NoError(t, db.Bun().NewSelect().Model(groupMember).Where("user_id = ?", u.ID).Scan(ctx))
+	require.Equal(t, u.ID, groupMember.UserID)
 }
 
 func TestAuthzUserList(t *testing.T) {


### PR DESCRIPTION
## Description

#5407 doesn't actually add the user to the personal group. This changes fixes that. 

## Test Plan

Integration test.

## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist
- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
