### PR TITLE
fix: Clear table settings between users and groups pages [WEB-636]

### DIFF
--- a/webui/react/src/pages/Settings/Settings.tsx
+++ b/webui/react/src/pages/Settings/Settings.tsx
@@ -3,8 +3,10 @@ import React, { useCallback, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 
 import Page from 'components/Page';
+import { InteractiveTableSettings } from 'components/Table/InteractiveTable';
 import useFeature from 'hooks/useFeature';
 import usePermissions from 'hooks/usePermissions';
+import useSettings from 'hooks/useSettings';
 import GroupManagement from 'pages/Settings/GroupManagement';
 import SettingsAccount from 'pages/Settings/SettingsAccount';
 import UserManagement from 'pages/Settings/UserManagement';
@@ -36,16 +38,21 @@ const SettingsContent: React.FC = () => {
   const navigate = useNavigate();
   const { tab } = useParams<Params>();
   const [tabKey, setTabKey] = useState<TabType>(tab || DEFAULT_TAB_KEY);
+  const { updateSettings } = useSettings<InteractiveTableSettings>({
+    settings: [],
+    storagePath: '',
+  });
 
   const rbacEnabled = useFeature().isOn('rbac');
   const { canViewUsers } = usePermissions();
 
   const handleTabChange = useCallback(
     (key) => {
+      updateSettings({});
       setTabKey(key);
       navigate(paths.settings(key), { replace: true });
     },
-    [navigate],
+    [navigate, updateSettings],
   );
 
   return (


### PR DESCRIPTION
## Description

A bug was reported that InteractiveTableSettings are kept when switching between User Settings and Group Settings tabs. You could move from User Settings with `tableOffset=20` to a blank Group Settings page because there aren't enough groups for a 3rd page.

This might be fixable with storagePath in useSettings, but because changes there could cause other problems, it may be cleaner to clear InteractiveTableSettings when switching tabs.

## Test Plan

- Visit `/det/settings/account` on an admin/EE system or with `?f_rbac=on&f_mock_permissions_all=on`
- Click to User Settings tab, and see a table of users. If there is less than one page of users, add users or lower page limit
- Click to additional pages of users and observe the URL includes `tableOffset=10`
- Click to Group Settings tab and observe the URL removes `tableOffset` and starts from the first page of Groups

## Checklist
- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.