### PR TITLE
fix: experiment with null notes can't load [DET-8572]

### DIFF
--- a/docs/release-notes/exp-notes-fix.rst
+++ b/docs/release-notes/exp-notes-fix.rst
@@ -1,0 +1,6 @@
+:orphan:
+
+**Bug Fixes**
+
+-  Experiment: Fix an issue where experiments created before version 0.16.0 could have issues
+   loading.

--- a/master/static/migrations/20221115135515_notes-not-null.tx.down.sql
+++ b/master/static/migrations/20221115135515_notes-not-null.tx.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE public.experiments ALTER COLUMN notes DROP NOT NULL;

--- a/master/static/migrations/20221115135515_notes-not-null.tx.up.sql
+++ b/master/static/migrations/20221115135515_notes-not-null.tx.up.sql
@@ -1,0 +1,3 @@
+UPDATE public.experiments SET notes = '' WHERE notes IS NULL;
+
+ALTER TABLE public.experiments ALTER COLUMN notes SET NOT NULL;


### PR DESCRIPTION
## Description

Experiment with null notes can't load. This change makes notes always not null and treats "" as no notes. 

## Test Plan

On a release cluster just find an old experiment (like experiment ID 146 on gcloud) and try to create a tensorboard and verify you don't get a 500 error. 

Locally create an experiment pre this change, then set experiment notes to NULL with ```UPDATE experiments SET notes = NULL``` then verify after this commit you can open a tensorboard of the experiment. 

## Commentary (optional)



## Checklist
- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
