### PR TITLE
fix: Jupyter notebook iframes

### DIFF
--- a/webui/react/src/shared/configs/craco.config.js
+++ b/webui/react/src/shared/configs/craco.config.js
@@ -98,7 +98,7 @@ module.exports = {
       }),
       new CspHtmlWebpackPlugin(
         {
-          'frame-src': "'none'",
+          'frame-src': "'self'",
           'object-src': "'none'",
           'script-src': "'self' cdn.segment.com",
           'style-src': "'self' 'unsafe-inline'",

--- a/webui/react/src/shared/configs/craco.config.js
+++ b/webui/react/src/shared/configs/craco.config.js
@@ -98,7 +98,7 @@ module.exports = {
       }),
       new CspHtmlWebpackPlugin(
         {
-          'frame-src': "'self'",
+          'frame-src': "'self' netlify.determined.ai",
           'object-src': "'none'",
           'script-src': "'self' cdn.segment.com",
           'style-src': "'self' 'unsafe-inline'",


### PR DESCRIPTION
## Description

Continuing to resolve issues with Content-Security-Policy - this allows Jupyter notebooks to appear again by changing the frame-src security policy to 'self' (iframes allowed on same web domain and port)

We need to test some more interactive Jupyter notebooks before merging; we may need to allow more third-party scripts on notebook pages? But the CSP may be applied only on pages from Determined, and not on Jupyter.

## Test Plan

Launch a Jupyter notebook and wait for it to open correctly. Run a script.

## Commentary (optional)

Kudos to @trentwatt for noticing that this issue would come up

## Checklist
- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.