### PR TITLE
chore: FOUNDENG-296 Determined shows PULLING state while container is spinning up

### DIFF
--- a/harness/determined/common/api/bindings.py
+++ b/harness/determined/common/api/bindings.py
@@ -6213,6 +6213,86 @@ class v1Notebook:
             out["userId"] = self.userId
         return out
 
+class v1NotifyContainerRunningRequest:
+    nodeName: "typing.Optional[str]" = None
+    numPeers: "typing.Optional[int]" = None
+    rank: "typing.Optional[int]" = None
+    requestUuid: "typing.Optional[str]" = None
+
+    def __init__(
+        self,
+        *,
+        allocationId: str,
+        data: "typing.Dict[str, typing.Any]",
+        nodeName: "typing.Union[str, None, Unset]" = _unset,
+        numPeers: "typing.Union[int, None, Unset]" = _unset,
+        rank: "typing.Union[int, None, Unset]" = _unset,
+        requestUuid: "typing.Union[str, None, Unset]" = _unset,
+    ):
+        self.allocationId = allocationId
+        self.data = data
+        if not isinstance(nodeName, Unset):
+            self.nodeName = nodeName
+        if not isinstance(numPeers, Unset):
+            self.numPeers = numPeers
+        if not isinstance(rank, Unset):
+            self.rank = rank
+        if not isinstance(requestUuid, Unset):
+            self.requestUuid = requestUuid
+
+    @classmethod
+    def from_json(cls, obj: Json) -> "v1NotifyContainerRunningRequest":
+        kwargs: "typing.Dict[str, typing.Any]" = {
+            "allocationId": obj["allocationId"],
+            "data": obj["data"],
+        }
+        if "nodeName" in obj:
+            kwargs["nodeName"] = obj["nodeName"]
+        if "numPeers" in obj:
+            kwargs["numPeers"] = obj["numPeers"]
+        if "rank" in obj:
+            kwargs["rank"] = obj["rank"]
+        if "requestUuid" in obj:
+            kwargs["requestUuid"] = obj["requestUuid"]
+        return cls(**kwargs)
+
+    def to_json(self, omit_unset: bool = False) -> typing.Any:
+        out: "typing.Dict[str, typing.Any]" = {
+            "allocationId": self.allocationId,
+            "data": self.data,
+        }
+        if not omit_unset or "nodeName" in vars(self):
+            out["nodeName"] = self.nodeName
+        if not omit_unset or "numPeers" in vars(self):
+            out["numPeers"] = self.numPeers
+        if not omit_unset or "rank" in vars(self):
+            out["rank"] = self.rank
+        if not omit_unset or "requestUuid" in vars(self):
+            out["requestUuid"] = self.requestUuid
+        return out
+
+class v1NotifyContainerRunningResponse:
+
+    def __init__(
+        self,
+        *,
+        data: "typing.Sequence[typing.Dict[str, typing.Any]]",
+    ):
+        self.data = data
+
+    @classmethod
+    def from_json(cls, obj: Json) -> "v1NotifyContainerRunningResponse":
+        kwargs: "typing.Dict[str, typing.Any]" = {
+            "data": obj["data"],
+        }
+        return cls(**kwargs)
+
+    def to_json(self, omit_unset: bool = False) -> typing.Any:
+        out: "typing.Dict[str, typing.Any]" = {
+            "data": self.data,
+        }
+        return out
+
 class v1OrderBy(enum.Enum):
     ORDER_BY_UNSPECIFIED = "ORDER_BY_UNSPECIFIED"
     ORDER_BY_ASC = "ORDER_BY_ASC"
@@ -14101,6 +14181,27 @@ def post_MoveProject(
     if _resp.status_code == 200:
         return
     raise APIHttpError("post_MoveProject", _resp)
+
+def post_NotifyContainerRunning(
+    session: "api.Session",
+    *,
+    allocationId: str,
+    body: "v1NotifyContainerRunningRequest",
+) -> "v1NotifyContainerRunningResponse":
+    _params = None
+    _resp = session._do_request(
+        method="POST",
+        path=f"/api/v1/allocations/{allocationId}/notify_container_running",
+        params=_params,
+        json=body.to_json(True),
+        data=None,
+        headers=None,
+        timeout=None,
+        stream=False,
+    )
+    if _resp.status_code == 200:
+        return v1NotifyContainerRunningResponse.from_json(_resp.json())
+    raise APIHttpError("post_NotifyContainerRunning", _resp)
 
 def patch_PatchExperiment(
     session: "api.Session",

--- a/master/internal/api_trials.go
+++ b/master/internal/api_trials.go
@@ -999,6 +999,29 @@ func (a *apiServer) AllocationPendingPreemptionSignal(
 	return &apiv1.AllocationPendingPreemptionSignalResponse{}, nil
 }
 
+func (a *apiServer) NotifyContainerRunning(
+	ctx context.Context,
+	req *apiv1.NotifyContainerRunningRequest,
+) (*apiv1.NotifyContainerRunningResponse, error) {
+	if err := a.canEditAllocation(ctx, req.AllocationId); err != nil {
+		return nil, err
+	}
+
+	if err := a.m.rm.NotifyContainerRunning(
+		a.m.system,
+		sproto.NotifyContainerRunning{
+			AllocationID: model.AllocationID(req.AllocationId),
+			NumPeers:     req.NumPeers,
+			Rank:         req.Rank,
+			NodeName:     req.NodeName,
+		},
+	); err != nil {
+		return nil, err
+	}
+
+	return &apiv1.NotifyContainerRunningResponse{}, nil
+}
+
 func (a *apiServer) MarkAllocationResourcesDaemon(
 	ctx context.Context, req *apiv1.MarkAllocationResourcesDaemonRequest,
 ) (*apiv1.MarkAllocationResourcesDaemonResponse, error) {

--- a/master/internal/rm/actor_resource_manager.go
+++ b/master/internal/rm/actor_resource_manager.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"reflect"
 
+	"github.com/pkg/errors"
+
 	"github.com/determined-ai/determined/master/internal/sproto"
 	"github.com/determined-ai/determined/master/pkg/actor"
 	"github.com/determined-ai/determined/master/pkg/model"
@@ -203,6 +205,19 @@ func (r *ActorResourceManager) ExternalPreemptionPending(
 	msg sproto.PendingPreemption,
 ) error {
 	return r.ask(ctx, msg, nil)
+}
+
+// NotifyContainerRunning receives a notification from the container to let
+// the master know that the container is running.
+func (r *ActorResourceManager) NotifyContainerRunning(
+	ctx actor.Messenger,
+	msg sproto.NotifyContainerRunning,
+) error {
+	// Actor Resource Manager does not implement a handler for the
+	// NotifyContainerRunning message, as it is only used on HPC
+	// (High Performance Computing).
+	return errors.New(
+		"the NotifyContainerRunning message is unsupported for ActorResourceManager")
 }
 
 // IsReattachEnabled is a default implementation (not Reattachable).

--- a/master/internal/rm/agent_resource_manager.go
+++ b/master/internal/rm/agent_resource_manager.go
@@ -674,3 +674,16 @@ func (a *agentResourceManager) fetchAvgQueuedTime(pool string) (
 	})
 	return res, nil
 }
+
+// NotifyContainerRunning receives a notification from the container to let
+// the master know that the container is running.
+func (a AgentResourceManager) NotifyContainerRunning(
+	ctx actor.Messenger,
+	msg sproto.NotifyContainerRunning,
+) error {
+	// Agent Resource Manager does not implement a handler for the
+	// NotifyContainerRunning message, as it is only used on HPC
+	// (High Performance Computing).
+	return errors.New(
+		"the NotifyContainerRunning message is unsupported for AgentResourceManager")
+}

--- a/master/internal/rm/kubernetes_resource_manager.go
+++ b/master/internal/rm/kubernetes_resource_manager.go
@@ -807,3 +807,16 @@ func makeTLSConfig(cert *tls.Certificate) (model.TLSClientConfig, error) {
 		CertificateName: certName,
 	}, nil
 }
+
+// NotifyContainerRunning receives a notification from the container to let
+// the master know that the container is running.
+func (k KubernetesResourceManager) NotifyContainerRunning(
+	ctx actor.Messenger,
+	msg sproto.NotifyContainerRunning,
+) error {
+	// Kubernetes Resource Manager does not implement a handler for the
+	// NotifyContainerRunning message, as it is only used on HPC
+	// (High Performance Computing).
+	return errors.New(
+		"the NotifyContainerRunning message is unsupported for KubernetesResourceManager")
+}

--- a/master/internal/rm/resource_manager_iface.go
+++ b/master/internal/rm/resource_manager_iface.go
@@ -28,6 +28,7 @@ type ResourceManager interface {
 		sproto.ValidateCommandResourcesRequest,
 	) (sproto.ValidateCommandResourcesResponse, error)
 	DeleteJob(actor.Messenger, sproto.DeleteJob) (sproto.DeleteJobResponse, error)
+	NotifyContainerRunning(actor.Messenger, sproto.NotifyContainerRunning) error
 
 	// Scheduling related stuff
 	SetGroupMaxSlots(actor.Messenger, sproto.SetGroupMaxSlots)

--- a/master/internal/sproto/task.go
+++ b/master/internal/sproto/task.go
@@ -150,6 +150,16 @@ type (
 	PendingPreemption struct {
 		AllocationID model.AllocationID
 	}
+
+	// NotifyContainerRunning notifies the launcher (dispatcher) resource
+	// manager that the container is running.
+	NotifyContainerRunning struct {
+		AllocationID model.AllocationID
+		Rank         int32
+		NumPeers     int32
+		NodeName     string
+	}
+
 	// ReleaseResources notifies the task actor to release resources.
 	ReleaseResources struct {
 		ResourcePool string

--- a/master/static/srv/task-logging-setup.sh
+++ b/master/static/srv/task-logging-setup.sh
@@ -82,6 +82,16 @@ if [ "$DET_RESOURCES_TYPE" == "slurm-job" ]; then
     )
 
     ((DET_LOG_WAIT_COUNT += 2))
+
+    # Each container sends the Determined Master a notification that it's
+    # running, so that the Determined Master knows whether to set the state
+    # of the experiment to "Pulling", meaning some nodes are pulling down
+    # the image, or "Running", meaning that all containers are running.
+    #
+    # Note: This is not related to logging, but since task-logging-setup.sh
+    # gets called by all the entrypoint scripts, it seemed like the logical
+    # place to add it, without having to modify each entrypoint script.
+    "$DET_PYTHON_EXECUTABLE" -m determined.exec.prep_container --notify_container_running
 fi
 
 # A task may output carriage return characters (\r) to do something mildly fancy

--- a/proto/src/determined/api/v1/api.proto
+++ b/proto/src/determined/api/v1/api.proto
@@ -821,6 +821,23 @@ service Determined {
     };
   }
 
+  // NotifyContainterRunning is used to notify the master that the container
+  // is running.  On HPC, the launcher will report a state of "Running" as
+  // soon as Slurm starts the job, but the container may be in the process
+  // of getting pulled down from the Internet, so the experiment is not
+  // really considered to be in a "Running" state until all the containers
+  // that are part of the experiment are running and not being pulled.
+  rpc NotifyContainerRunning(NotifyContainerRunningRequest)
+      returns (NotifyContainerRunningResponse) {
+    option (google.api.http) = {
+      post: "/api/v1/allocations/{allocation_id}/notify_container_running"
+      body: "*"
+    };
+    option (grpc.gateway.protoc_gen_swagger.options.openapiv2_operation) = {
+      tags: "Internal"
+    };
+  }
+
   // Get the current searcher operation.
   rpc GetCurrentTrialSearcherOperation(GetCurrentTrialSearcherOperationRequest)
       returns (GetCurrentTrialSearcherOperationResponse) {

--- a/proto/src/determined/api/v1/trial.proto
+++ b/proto/src/determined/api/v1/trial.proto
@@ -831,6 +831,33 @@ message AllocationAllGatherResponse {
   repeated google.protobuf.Struct data = 1;
 }
 
+// Arguments to a notify container running.
+message NotifyContainerRunningRequest {
+  option (grpc.gateway.protoc_gen_swagger.options.openapiv2_schema) = {
+    json_schema: { required: [ "allocation_id", "global_recv_count", "data" ] }
+  };
+  // The ID of the allocation.
+  string allocation_id = 1;
+  // The UUID of the participant in a notify container running message.
+  string request_uuid = 2;
+  // The number of process to wait for.
+  int32 num_peers = 3;
+  // The container's rank.
+  int32 rank = 4;
+  // The name of the node who sent the request
+  string node_name = 5;
+  // The data from this process.
+  google.protobuf.Struct data = 6;
+}
+// Response to NotifyContainerRunningResponse
+message NotifyContainerRunningResponse {
+  option (grpc.gateway.protoc_gen_swagger.options.openapiv2_schema) = {
+    json_schema: { required: [ "data" ] }
+  };
+  // The data for all the processes.
+  repeated google.protobuf.Struct data = 1;
+}
+
 // Retrieves the current searcher operation.
 message GetCurrentTrialSearcherOperationRequest {
   option (grpc.gateway.protoc_gen_swagger.options.openapiv2_schema) = {

--- a/webui/react/src/services/api-ts-sdk/api.ts
+++ b/webui/react/src/services/api-ts-sdk/api.ts
@@ -5207,6 +5207,64 @@ export interface V1Notebook {
 }
 
 /**
+ * Arguments to a notify container running.
+ * @export
+ * @interface V1NotifyContainerRunningRequest
+ */
+export interface V1NotifyContainerRunningRequest {
+    /**
+     * The ID of the allocation.
+     * @type {string}
+     * @memberof V1NotifyContainerRunningRequest
+     */
+    allocationId: string;
+    /**
+     * The UUID of the participant in a notify container running message.
+     * @type {string}
+     * @memberof V1NotifyContainerRunningRequest
+     */
+    requestUuid?: string;
+    /**
+     * The number of process to wait for.
+     * @type {number}
+     * @memberof V1NotifyContainerRunningRequest
+     */
+    numPeers?: number;
+    /**
+     * The container's rank.
+     * @type {number}
+     * @memberof V1NotifyContainerRunningRequest
+     */
+    rank?: number;
+    /**
+     * 
+     * @type {string}
+     * @memberof V1NotifyContainerRunningRequest
+     */
+    nodeName?: string;
+    /**
+     * The data from this process.
+     * @type {any}
+     * @memberof V1NotifyContainerRunningRequest
+     */
+    data: any;
+}
+
+/**
+ * 
+ * @export
+ * @interface V1NotifyContainerRunningResponse
+ */
+export interface V1NotifyContainerRunningResponse {
+    /**
+     * The data for all the processes.
+     * @type {Array<any>}
+     * @memberof V1NotifyContainerRunningResponse
+     */
+    data: Array<any>;
+}
+
+/**
  * Order records in either ascending or descending order.   - ORDER_BY_UNSPECIFIED: Returns records in no specific order.  - ORDER_BY_ASC: Returns records in ascending order.  - ORDER_BY_DESC: Returns records in descending order.
  * @export
  * @enum {string}
@@ -15760,6 +15818,52 @@ export const InternalApiFetchParamCreator = function (configuration?: Configurat
         },
         /**
          * 
+         * @summary NotifyContainterRunning is used to notify the master that the container is running.  On HPC, the launcher will report a state of \"Running\" as soon as Slurm starts the job, but the container may be in the process of getting pulled down from the Internet, so the experiment is not really considered to be in a \"Running\" state until all the containers that are part of the experiment are running and not being pulled.
+         * @param {string} allocationId The ID of the allocation.
+         * @param {V1NotifyContainerRunningRequest} body 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        notifyContainerRunning(allocationId: string, body: V1NotifyContainerRunningRequest, options: any = {}): FetchArgs {
+            // verify required parameter 'allocationId' is not null or undefined
+            if (allocationId === null || allocationId === undefined) {
+                throw new RequiredError('allocationId','Required parameter allocationId was null or undefined when calling notifyContainerRunning.');
+            }
+            // verify required parameter 'body' is not null or undefined
+            if (body === null || body === undefined) {
+                throw new RequiredError('body','Required parameter body was null or undefined when calling notifyContainerRunning.');
+            }
+            const localVarPath = `/api/v1/allocations/{allocationId}/notify_container_running`
+                .replace(`{${"allocationId"}}`, encodeURIComponent(String(allocationId)));
+            const localVarUrlObj = url.parse(localVarPath, true);
+            const localVarRequestOptions = Object.assign({ method: 'POST' }, options);
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            // authentication BearerToken required
+            if (configuration && configuration.apiKey) {
+                const localVarApiKeyValue = typeof configuration.apiKey === 'function'
+					? configuration.apiKey("Authorization")
+					: configuration.apiKey;
+                localVarHeaderParameter["Authorization"] = localVarApiKeyValue;
+            }
+
+            localVarHeaderParameter['Content-Type'] = 'application/json';
+
+            localVarUrlObj.query = Object.assign({}, localVarUrlObj.query, localVarQueryParameter, options.query);
+            // fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
+            delete localVarUrlObj.search;
+            localVarRequestOptions.headers = Object.assign({}, localVarHeaderParameter, options.headers);
+            const needsSerialization = (<any>"V1NotifyContainerRunningRequest" !== "string") || localVarRequestOptions.headers['Content-Type'] === 'application/json';
+            localVarRequestOptions.body =  needsSerialization ? JSON.stringify(body || {}) : (body || "");
+
+            return {
+                url: url.format(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         * 
          * @summary PostAllocationProxyAddress sets the proxy address to use when proxying to services provided by an allocation. Upon receipt, the master will also register any proxies specified by the task.
          * @param {string} allocationId The id of the allocation.
          * @param {V1PostAllocationProxyAddressRequest} body 
@@ -16932,6 +17036,26 @@ export const InternalApiFp = function(configuration?: Configuration) {
         },
         /**
          * 
+         * @summary NotifyContainterRunning is used to notify the master that the container is running.  On HPC, the launcher will report a state of \"Running\" as soon as Slurm starts the job, but the container may be in the process of getting pulled down from the Internet, so the experiment is not really considered to be in a \"Running\" state until all the containers that are part of the experiment are running and not being pulled.
+         * @param {string} allocationId The ID of the allocation.
+         * @param {V1NotifyContainerRunningRequest} body 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        notifyContainerRunning(allocationId: string, body: V1NotifyContainerRunningRequest, options?: any): (fetch?: FetchAPI, basePath?: string) => Promise<V1NotifyContainerRunningResponse> {
+            const localVarFetchArgs = InternalApiFetchParamCreator(configuration).notifyContainerRunning(allocationId, body, options);
+            return (fetch: FetchAPI = portableFetch, basePath: string = BASE_PATH) => {
+                return fetch(basePath + localVarFetchArgs.url, localVarFetchArgs.options).then((response) => {
+                    if (response.status >= 200 && response.status < 300) {
+                        return response.json();
+                    } else {
+                        throw response;
+                    }
+                });
+            };
+        },
+        /**
+         * 
          * @summary PostAllocationProxyAddress sets the proxy address to use when proxying to services provided by an allocation. Upon receipt, the master will also register any proxies specified by the task.
          * @param {string} allocationId The id of the allocation.
          * @param {V1PostAllocationProxyAddressRequest} body 
@@ -17503,6 +17627,17 @@ export const InternalApiFactory = function (configuration?: Configuration, fetch
         },
         /**
          * 
+         * @summary NotifyContainterRunning is used to notify the master that the container is running.  On HPC, the launcher will report a state of \"Running\" as soon as Slurm starts the job, but the container may be in the process of getting pulled down from the Internet, so the experiment is not really considered to be in a \"Running\" state until all the containers that are part of the experiment are running and not being pulled.
+         * @param {string} allocationId The ID of the allocation.
+         * @param {V1NotifyContainerRunningRequest} body 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        notifyContainerRunning(allocationId: string, body: V1NotifyContainerRunningRequest, options?: any) {
+            return InternalApiFp(configuration).notifyContainerRunning(allocationId, body, options)(fetch, basePath);
+        },
+        /**
+         * 
          * @summary PostAllocationProxyAddress sets the proxy address to use when proxying to services provided by an allocation. Upon receipt, the master will also register any proxies specified by the task.
          * @param {string} allocationId The id of the allocation.
          * @param {V1PostAllocationProxyAddressRequest} body 
@@ -18019,6 +18154,19 @@ export class InternalApi extends BaseAPI {
      */
     public metricNames(experimentId: number, periodSeconds?: number, options?: any) {
         return InternalApiFp(this.configuration).metricNames(experimentId, periodSeconds, options)(this.fetch, this.basePath);
+    }
+
+    /**
+     * 
+     * @summary NotifyContainterRunning is used to notify the master that the container is running.  On HPC, the launcher will report a state of \"Running\" as soon as Slurm starts the job, but the container may be in the process of getting pulled down from the Internet, so the experiment is not really considered to be in a \"Running\" state until all the containers that are part of the experiment are running and not being pulled.
+     * @param {string} allocationId The ID of the allocation.
+     * @param {V1NotifyContainerRunningRequest} body 
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof InternalApi
+     */
+    public notifyContainerRunning(allocationId: string, body: V1NotifyContainerRunningRequest, options?: any) {
+        return InternalApiFp(this.configuration).notifyContainerRunning(allocationId, body, options)(this.fetch, this.basePath);
     }
 
     /**


### PR DESCRIPTION
## Description

Note: These are the changes for the OSS side.  The changes for the EE side (i.e., "dispatcher_*.go") needed for the "launcher" will be made on the EE branch.

The launcher reports as state of "Running" when Slurm/PBS start the job.  However, from the Determined Master's perspective, the experiment is not really running until the Determined startup scripts are running in the container.  In the case where Slurm/PBS start the job, but Singularity/Podman need to pull the image from the Internet, Determined needs to report a state of "PULLING", even if the launcher is reporting a state of "RUNNING".  Not until all containers are running should Determined report RUNNING.

With these changes, Determined will report a state of "PULLING" until all containers notify the master that they are running. Once all containers notify the master that they are running, then Determined will report a state of "RUNNING".

## Test Plan

The master log will show the ResourceState as PULLING.  Until both nodes report they're running.

```
master: DEBU[2022-11-07T16:00:01-05:00] Checking status of launcher job 11ae54526b544bcd-8607d5744a7b1439  actor-local-addr=launcherRM actor-system=master go-type=dispatcherResourceManager
master: INFO[2022-11-07T16:00:02-05:00] DispatchID 11ae54526b544bcd-8607d5744a7b1439 state: RUNNING  actor-local-addr=launcherRM actor-system=master go-type=dispatcherResourceManager
master: DEBU[2022-11-07T16:00:02-05:00] resources state changed: {ResourcesID:06236d8c-4e04-4549-bfb6-bc091f7a8f1d ResourcesState:PULLING ResourcesStarted:0xc001512340 ResourcesStopped:<nil> Container:<nil>}  actor-local-addr=1 actor-system=master allocation-id=858.68e2fb55-047e-45f7-8f2f-c32125f0c398.1 experiment-id=858 go-type=Allocation job-id=8c4cbb79-f12a-440a-9edc-56481f4dcd71 task-id=858.68e2fb55-047e-45f7-8f2f-c32125f0c398 task-type=TRIAL trial-run-id=0
master: INFO[2022-11-07T16:00:05-05:00] For dispatchID 11ae54526b544bcd-8607d5744a7b1439, 1 out of 2 containers running on nodes node002  actor-local-addr=launcherRM actor-system=master go-type=dispatcherResourceManager
master: DEBU[2022-11-07T16:00:11-05:00] Checking status of launcher job 11ae54526b544bcd-8607d5744a7b1439  actor-local-addr=launcherRM actor-system=master go-type=dispatcherResourceManager
master: INFO[2022-11-07T16:00:12-05:00] DispatchID 11ae54526b544bcd-8607d5744a7b1439 state: RUNNING  actor-local-addr=launcherRM actor-system=master go-type=dispatcherResourceManager
master: INFO[2022-11-07T16:00:12-05:00] For dispatchID 11ae54526b544bcd-8607d5744a7b1439, 2 out of 2 containers running on nodes node002,node010  actor-local-addr=launcherRM actor-system=master go-type=dispatcherResourceManager
master: DEBU[2022-11-07T16:00:12-05:00] resources state changed: {ResourcesID:06236d8c-4e04-4549-bfb6-bc091f7a8f1d ResourcesState:PULLING ResourcesStarted:0xc000764b40 ResourcesStopped:<nil> Container:<nil>}  actor-local-addr=1 actor-system=master allocation-id=858.68e2fb55-047e-45f7-8f2f-c32125f0c398.1 experiment-id=858 go-type=Allocation job-id=8c4cbb79-f12a-440a-9edc-56481f4dcd71 task-id=858.68e2fb55-047e-45f7-8f2f-c32125f0c398 task-type=TRIAL trial-run-id=0
master: DEBU[2022-11-07T16:00:21-05:00] Checking status of launcher job 11ae54526b544bcd-8607d5744a7b1439  actor-local-addr=launcherRM actor-system=master go-type=dispatcherResourceManager
master: INFO[2022-11-07T16:00:22-05:00] DispatchID 11ae54526b544bcd-8607d5744a7b1439 state: RUNNING  actor-local-addr=launcherRM actor-system=master go-type=dispatcherResourceManager
master: DEBU[2022-11-07T16:00:22-05:00] resources state changed: {ResourcesID:06236d8c-4e04-4549-bfb6-bc091f7a8f1d ResourcesState:RUNNING ResourcesStarted:0xc000d9dc00 ResourcesStopped:<nil> Container:<nil>}  actor-local-addr=1 actor-system=master allocation-id=858.68e2fb55-047e-45f7-8f2f-c32125f0c398.1 experiment-id=858 go-type=Allocation job-id=8c4cbb79-f12a-440a-9edc-56481f4dcd71 task-id=858.68e2fb55-047e-45f7-8f2f-c32125f0c398 task-type=TRIAL trial-run-id=0
```

You also see the state change from the CLI.

```
(base) rcorujo@C02FJ0T8MD6Q cifar10_pytorch % PYTHONPATH=/Users/rcorujo/IdeaProjects/FOUNDENG-296_Determined_shows_PULLING_DETERMINED_CHANGE/determined-ee/harness det experiment create rig_distributed.yaml .
Preparing files to send to master... 14.0KB and 7 files
Created experiment 858

(base) rcorujo@C02FJ0T8MD6Q cifar10_pytorch % PYTHONPATH=/Users/rcorujo/IdeaProjects/FOUNDENG-296_Determined_shows_PULLING_DETERMINED_CHANGE/determined-ee/harness det experiment list | tail -1
  858 | corujor | cifar10_pytorch_distributed               |             | QUEUED    | 0.0%       | 2022-11-07 20:58:22+0000 |                          | defq

(base) rcorujo@C02FJ0T8MD6Q cifar10_pytorch % PYTHONPATH=/Users/rcorujo/IdeaProjects/FOUNDENG-296_Determined_shows_PULLING_DETERMINED_CHANGE/determined-ee/harness det experiment list | tail -1
  858 | corujor | cifar10_pytorch_distributed               |             | PULLING   | 0.0%       | 2022-11-07 20:58:22+0000 |                          | defq

(base) rcorujo@C02FJ0T8MD6Q cifar10_pytorch % PYTHONPATH=/Users/rcorujo/IdeaProjects/FOUNDENG-296_Determined_shows_PULLING_DETERMINED_CHANGE/determined-ee/harness det experiment list | tail -1
  858 | corujor | cifar10_pytorch_distributed               |             | RUNNING   | 0.0%       | 2022-11-07 20:58:22+0000 |                          | defq
```

## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist
- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
