### PR TITLE
feat: Include No Rank in rankIds dropdown [WEB-239] [WEB-240]

### DIFF
--- a/e2e_tests/tests/cluster/test_logging.py
+++ b/e2e_tests/tests/cluster/test_logging.py
@@ -160,8 +160,11 @@ def check_logs(
             )
         ), "good filter returned no logs"
 
-    # Check nonsense is nonsense.
-    assert not any(log_fn(rank_ids=[-1])), "bad filter returned logs"
+    # Changed -1 to represent no-rank filter.
+    assert any(log_fn(rank_ids=[-1])), "-1 rank returns logs with no rank"
+
+    # Check other negative ranks are nonsense.
+    assert not any(log_fn(rank_ids=[-2])), "bad filter returned logs"
 
 
 def to_snake_case(camel_case: str) -> str:

--- a/master/internal/api/filters.go
+++ b/master/internal/api/filters.go
@@ -6,6 +6,8 @@ type FilterOperation int
 const (
 	// FilterOperationIn checks set membership.
 	FilterOperationIn FilterOperation = iota
+	// FilterOperationInOrNull checks membership or a NULL option.
+	FilterOperationInOrNull
 	// FilterOperationGreaterThan checks if the field is greater than a value.
 	FilterOperationGreaterThan
 	// FilterOperationLessThanEqual checks if the field is less than or equal to a value.

--- a/master/internal/api_tasks.go
+++ b/master/internal/api_tasks.go
@@ -429,10 +429,26 @@ func constructTaskLogsFilters(req *apiv1.TaskLogsRequest) ([]api.Filter, error) 
 		}
 	}
 
+	addNullInclusiveFilter := func(field string, values []int32) {
+		if values != nil {
+			if slices.Contains(values, -100) {
+				filters = append(filters, api.Filter{
+					Field:     field,
+					Operation: api.FilterOperationInOrNull,
+					Values:    values,
+				})
+			} else {
+				addInFilter(field, values, len(values))
+			}
+		}
+	}
+
+	addNullInclusiveFilter("rank_id", req.RankIds)
+	// agent_id / allocation_id?
+
 	addInFilter("allocation_id", req.AllocationIds, len(req.AllocationIds))
 	addInFilter("agent_id", req.AgentIds, len(req.AgentIds))
 	addInFilter("container_id", req.ContainerIds, len(req.ContainerIds))
-	addInFilter("rank_id", req.RankIds, len(req.RankIds))
 	addInFilter("stdtype", req.Stdtypes, len(req.Stdtypes))
 	addInFilter("source", req.Sources, len(req.Sources))
 	addInFilter("level", func() interface{} {

--- a/master/internal/api_tasks.go
+++ b/master/internal/api_tasks.go
@@ -433,7 +433,8 @@ func constructTaskLogsFilters(req *apiv1.TaskLogsRequest) ([]api.Filter, error) 
 	// Allow a value in a list of numbers, or a NULL represented as -1.
 	addNullInclusiveFilter := func(field string, values []int32) {
 		if values == nil || !slices.Contains(values, -1) {
-			return addInFilter(field, values, len(values))
+			addInFilter(field, values, len(values))
+			return
 		}
 		filters = append(filters, api.Filter{
 			Field:     field,

--- a/master/internal/api_tasks.go
+++ b/master/internal/api_tasks.go
@@ -432,17 +432,14 @@ func constructTaskLogsFilters(req *apiv1.TaskLogsRequest) ([]api.Filter, error) 
 
 	// Allow a value in a list of numbers, or a NULL represented as -1.
 	addNullInclusiveFilter := func(field string, values []int32) {
-		if values != nil {
-			if slices.Contains(values, -1) {
-				filters = append(filters, api.Filter{
-					Field:     field,
-					Operation: api.FilterOperationInOrNull,
-					Values:    values,
-				})
-			} else {
-				addInFilter(field, values, len(values))
-			}
+		if values == nil || !slices.Contains(values, -1) {
+			return addInFilter(field, values, len(values))
 		}
+		filters = append(filters, api.Filter{
+			Field:     field,
+			Operation: api.FilterOperationInOrNull,
+			Values:    values,
+		})
 	}
 
 	addNullInclusiveFilter("rank_id", req.RankIds)

--- a/master/internal/api_tasks.go
+++ b/master/internal/api_tasks.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	"golang.org/x/exp/slices"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -429,9 +430,10 @@ func constructTaskLogsFilters(req *apiv1.TaskLogsRequest) ([]api.Filter, error) 
 		}
 	}
 
+	// Allow a value in a list of numbers, or a NULL represented as -1.
 	addNullInclusiveFilter := func(field string, values []int32) {
 		if values != nil {
-			if slices.Contains(values, -100) {
+			if slices.Contains(values, -1) {
 				filters = append(filters, api.Filter{
 					Field:     field,
 					Operation: api.FilterOperationInOrNull,
@@ -444,7 +446,6 @@ func constructTaskLogsFilters(req *apiv1.TaskLogsRequest) ([]api.Filter, error) 
 	}
 
 	addNullInclusiveFilter("rank_id", req.RankIds)
-	// agent_id / allocation_id?
 
 	addInFilter("allocation_id", req.AllocationIds, len(req.AllocationIds))
 	addInFilter("agent_id", req.AgentIds, len(req.AgentIds))

--- a/master/internal/db/postgres_filters.go
+++ b/master/internal/db/postgres_filters.go
@@ -65,7 +65,7 @@ func filterToSQL(
 		}
 		_, _ = fragment.WriteString(strings.Join(paramFragments, ","))
 		_, _ = fragment.WriteString(")")
-		return fmt.Sprintf(fragment.String(), field)
+		return fmt.Sprintf(fragment.String(), field, field)
 	case api.FilterOperationGreaterThan:
 		return fmt.Sprintf("AND %s > $%d", field, paramID)
 	case api.FilterOperationLessThanEqual:

--- a/master/internal/db/postgres_filters.go
+++ b/master/internal/db/postgres_filters.go
@@ -56,6 +56,16 @@ func filterToSQL(
 		_, _ = fragment.WriteString(strings.Join(paramFragments, ","))
 		_, _ = fragment.WriteString(")")
 		return fmt.Sprintf(fragment.String(), field)
+	case api.FilterOperationInOrNull:
+		var fragment strings.Builder
+		_, _ = fragment.WriteString("AND %s IS NULL OR %s IN (")
+		var paramFragments []string
+		for i := range values {
+			paramFragments = append(paramFragments, fmt.Sprintf("$%d", paramID+i))
+		}
+		_, _ = fragment.WriteString(strings.Join(paramFragments, ","))
+		_, _ = fragment.WriteString(")")
+		return fmt.Sprintf(fragment.String(), field)
 	case api.FilterOperationGreaterThan:
 		return fmt.Sprintf("AND %s > $%d", field, paramID)
 	case api.FilterOperationLessThanEqual:

--- a/master/internal/elastic/elastic_task_logs.go
+++ b/master/internal/elastic/elastic_task_logs.go
@@ -395,6 +395,8 @@ func filtersToElastic(fs []api.Filter) []jsonObj {
 					},
 				})
 		case api.FilterOperationInOrNull:
+			// used to specify value matches int[] or is nil
+			// see https://stackoverflow.com/questions/48563275/
 			values, err := interfaceToSlice(f.Values)
 			if err != nil {
 				panic(fmt.Errorf("invalid IN OR NULL filter values: %w", err))
@@ -421,8 +423,12 @@ func filtersToElastic(fs []api.Filter) []jsonObj {
 			}
 			inTerms = append(inTerms,
 				jsonObj{
-					"term": jsonObj{
-						f.Field: nil,
+					"bool": jsonObj{
+						"must_not": jsonObj{
+							"exists": jsonObj{
+								f.Field: f.Field,
+							},
+						},
 					},
 				})
 			terms = append(terms,

--- a/master/internal/elastic/elastic_task_logs.go
+++ b/master/internal/elastic/elastic_task_logs.go
@@ -426,7 +426,7 @@ func filtersToElastic(fs []api.Filter) []jsonObj {
 					"bool": jsonObj{
 						"must_not": jsonObj{
 							"exists": jsonObj{
-								f.Field: f.Field,
+								"field": f.Field,
 							},
 						},
 					},

--- a/webui/react/src/components/LogViewer/LogViewerFilters.test.tsx
+++ b/webui/react/src/components/LogViewer/LogViewerFilters.test.tsx
@@ -66,13 +66,13 @@ describe('LogViewerFilter', () => {
     });
   });
 
-  it('should render filters with rank 0 and 1', async () => {
+  it('should render filters with rank 0; No Rank added automatically', async () => {
     const values: Filters = {
       agentIds: [],
       allocationIds: [],
       containerIds: [],
       levels: [],
-      rankIds: [0, -1],
+      rankIds: [0],
     };
     const { user } = setup(values, { ...values, rankIds: [] });
 
@@ -83,7 +83,7 @@ describe('LogViewerFilter', () => {
     });
   });
 
-  it('should render filters with no rank', () => {
+  it('should render filters without rank', () => {
     const values: Filters = {
       agentIds: [],
       allocationIds: [],

--- a/webui/react/src/components/LogViewer/LogViewerFilters.test.tsx
+++ b/webui/react/src/components/LogViewer/LogViewerFilters.test.tsx
@@ -12,7 +12,7 @@ const DEFAULT_FILTER_OPTIONS: Filters = {
   agentIds: new Array(3).fill('').map(() => `i-${generateAlphaNumeric(17)}`),
   allocationIds: new Array(2).fill('').map((_, i) => `${generateUUID()}.${i}`),
   containerIds: ['', ...new Array(2).fill('').map(() => generateUUID())],
-  rankIds: [0, 1, 2, -100],
+  rankIds: [0, 1, 2, -1],
   // sources: ['agent', 'master'],
   // stdtypes: ['stdout', 'stderr'],
 };
@@ -72,7 +72,7 @@ describe('LogViewerFilter', () => {
       allocationIds: [],
       containerIds: [],
       levels: [],
-      rankIds: [0, -100],
+      rankIds: [0, -1],
     };
     const { user } = setup(values, { ...values, rankIds: [] });
 

--- a/webui/react/src/components/LogViewer/LogViewerFilters.test.tsx
+++ b/webui/react/src/components/LogViewer/LogViewerFilters.test.tsx
@@ -12,7 +12,7 @@ const DEFAULT_FILTER_OPTIONS: Filters = {
   agentIds: new Array(3).fill('').map(() => `i-${generateAlphaNumeric(17)}`),
   allocationIds: new Array(2).fill('').map((_, i) => `${generateUUID()}.${i}`),
   containerIds: ['', ...new Array(2).fill('').map(() => generateUUID())],
-  rankIds: [0, 1, 2],
+  rankIds: [0, 1, 2, -100],
   // sources: ['agent', 'master'],
   // stdtypes: ['stdout', 'stderr'],
 };
@@ -72,7 +72,7 @@ describe('LogViewerFilter', () => {
       allocationIds: [],
       containerIds: [],
       levels: [],
-      rankIds: [0, 1],
+      rankIds: [0, -100],
     };
     const { user } = setup(values, { ...values, rankIds: [] });
 

--- a/webui/react/src/components/LogViewer/LogViewerFilters.tsx
+++ b/webui/react/src/components/LogViewer/LogViewerFilters.tsx
@@ -54,7 +54,7 @@ const LogViewerFilters: React.FC<Props> = ({
       levels: Object.entries(LogLevelFromApi)
         .filter((entry) => entry[1] !== LogLevelFromApi.Unspecified)
         .map(([key, value]) => ({ label: key, value })),
-      rankIds: rankIds ? [-1].concat(rankIds.sortAll(alphaNumericSorter)) : [-1],
+      rankIds: rankIds ? [-1].concat(rankIds).sortAll(alphaNumericSorter) : [-1],
     };
   }, [options]);
 
@@ -64,7 +64,7 @@ const LogViewerFilters: React.FC<Props> = ({
       const options = selectOptions[filterKey];
 
       // !! casts `undefined` into the boolean value of `false`.
-      acc[filterKey] = !!(options && options.length > 1) || filterKey === 'rankIds';
+      acc[filterKey] = !!(options && options.length > 1);
 
       return acc;
     }, {} as Record<keyof Filters, boolean>);

--- a/webui/react/src/components/LogViewer/LogViewerFilters.tsx
+++ b/webui/react/src/components/LogViewer/LogViewerFilters.tsx
@@ -54,7 +54,7 @@ const LogViewerFilters: React.FC<Props> = ({
       levels: Object.entries(LogLevelFromApi)
         .filter((entry) => entry[1] !== LogLevelFromApi.Unspecified)
         .map(([key, value]) => ({ label: key, value })),
-      rankIds: rankIds ? rankIds.sortAll(alphaNumericSorter) : undefined,
+      rankIds: rankIds ? [-1].concat(rankIds.sortAll(alphaNumericSorter)) : [-1],
     };
   }, [options]);
 

--- a/webui/react/src/components/LogViewer/LogViewerFilters.tsx
+++ b/webui/react/src/components/LogViewer/LogViewerFilters.tsx
@@ -54,7 +54,7 @@ const LogViewerFilters: React.FC<Props> = ({
       levels: Object.entries(LogLevelFromApi)
         .filter((entry) => entry[1] !== LogLevelFromApi.Unspecified)
         .map(([key, value]) => ({ label: key, value })),
-      rankIds: rankIds ? [-100].concat(rankIds.sortAll(alphaNumericSorter)) : [-100],
+      rankIds: rankIds ? rankIds.sortAll(alphaNumericSorter) : undefined,
     };
   }, [options]);
 
@@ -156,7 +156,7 @@ const LogViewerFilters: React.FC<Props> = ({
             onChange={handleChange('rankIds', Number)}>
             {selectOptions?.rankIds?.map((id, index) => (
               <Option key={id ?? `no-id-${index}`} value={id}>
-                {id === -100 ? 'No Rank' : id}
+                {id === -1 ? 'No Rank' : id}
               </Option>
             ))}
           </Select>

--- a/webui/react/src/components/LogViewer/LogViewerFilters.tsx
+++ b/webui/react/src/components/LogViewer/LogViewerFilters.tsx
@@ -54,7 +54,7 @@ const LogViewerFilters: React.FC<Props> = ({
       levels: Object.entries(LogLevelFromApi)
         .filter((entry) => entry[1] !== LogLevelFromApi.Unspecified)
         .map(([key, value]) => ({ label: key, value })),
-      rankIds: rankIds ? rankIds.sortAll(alphaNumericSorter) : undefined,
+      rankIds: rankIds ? [-100].concat(rankIds.sortAll(alphaNumericSorter)) : [-100],
     };
   }, [options]);
 
@@ -64,7 +64,7 @@ const LogViewerFilters: React.FC<Props> = ({
       const options = selectOptions[filterKey];
 
       // !! casts `undefined` into the boolean value of `false`.
-      acc[filterKey] = !!(options && options.length > 1);
+      acc[filterKey] = !!(options && options.length > 1) || filterKey === 'rankIds';
 
       return acc;
     }, {} as Record<keyof Filters, boolean>);
@@ -156,7 +156,7 @@ const LogViewerFilters: React.FC<Props> = ({
             onChange={handleChange('rankIds', Number)}>
             {selectOptions?.rankIds?.map((id, index) => (
               <Option key={id ?? `no-id-${index}`} value={id}>
-                {id ?? 'No Rank'}
+                {id === -100 ? 'No Rank' : id}
               </Option>
             ))}
           </Select>


### PR DESCRIPTION
## Description

In the log viewer filters, "No Rank" isn't available as an option because Rank is our only numeric filter. This PR represents No Rank / NULL as an option represented by -1. This won't be made available by the server, so we need to add -1 to the list of rank options on the client. 

Number or NULL needs to be searched differently on the server, so I added `FilterOperationInOrNull` to the Postgres operations

A test is included for -1 to be represented as 'No Rank'.

## Test Plan

- Open an experiment and navigate to the Logs tab
- Confirm that a Rank filter is available and the dropdown includes 'No Rank' option
- Select the 'No Rank' option and confirm -1 is passed to API

## Checklist
- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.