### PR TITLE
feat: enable limited core api usage in NTSC

### DIFF
--- a/harness/determined/_info.py
+++ b/harness/determined/_info.py
@@ -346,6 +346,10 @@ class ClusterInfo:
     @property
     def container_addrs(self) -> List[str]:
         """A list of addresses for all containers in the allocation, ordered by rank."""
+        if self.task_type != "TRIAL":
+            # Presently, only trials are allowed to use the rendezvous API.
+            # But also, only trials are scheduled across multiple nodes, so we can cheat here.
+            return ["127.0.0.1"]
         assert self._rendezvous_info is not None
         return self._rendezvous_info.container_addrs
 
@@ -357,6 +361,10 @@ class ClusterInfo:
         When using a distributed training framework, the framework may choose a different rank for
         this container.
         """
+        if self.task_type != "TRIAL":
+            # Presently, only trials are allowed to use the rendezvous API.
+            # But also, only trials are scheduled across multiple nodes, so we can cheat here.
+            return 0
         assert self._rendezvous_info is not None
         return self._rendezvous_info.container_rank
 

--- a/harness/determined/core/_context.py
+++ b/harness/determined/core/_context.py
@@ -165,8 +165,6 @@ def init(
 
     distributed = distributed or core.DummyDistributedContext()
 
-    preempt = core.PreemptContext(session, info.allocation_id, distributed, preempt_mode)
-
     # At present, we only support tensorboards in Trial tasks.
     tbd_writer = None
 
@@ -221,6 +219,8 @@ def init(
             tensorboard_manager,
         )
 
+        preempt = core.PreemptContext(session, info.allocation_id, distributed, preempt_mode)
+
     else:
         # TODO: support checkpointing for non-trial tasks.
         if storage_manager is None:
@@ -228,6 +228,7 @@ def init(
             logger.info("no storage_manager provided; storing checkpoints in {base_path}")
             storage_manager = storage.SharedFSStorageManager(base_path)
         checkpoint = core.DummyCheckpointContext(distributed, storage_manager)
+        preempt = core.DummyPreemptContext(distributed, preempt_mode)
 
     _install_stacktrace_on_sigusr1()
 


### PR DESCRIPTION
* UseDummyPreemptContext in non-trial tasks.

* Fabricate RendezvousInfo in non-trial tasks.