### PR TITLE
fix: Ensure authorized_keys permisison [FOUNDENG-342]

### DIFF
--- a/master/static/srv/shell-entrypoint.sh
+++ b/master/static/srv/shell-entrypoint.sh
@@ -95,6 +95,8 @@ options="$(
 unmodified="/run/determined/ssh/authorized_keys_unmodified"
 modified="/run/determined/ssh/authorized_keys"
 sed -e "s/^/$options /" "$unmodified" >"$modified"
+# Ensure permissions are restrictive enough for ssh
+chmod 600 "$modified"
 
 READINESS_REGEX="Server listening on"
 


### PR DESCRIPTION

## Description

When a shell is launched for an HPC job the permissions sometimes enable other read which will cause sshd to not use the file for authorization which results in a ssh login permission.


## Test Plan

Manually verified on PBS/Slum launches.

## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist
- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
