### PR TITLE
Structured master logs

### DIFF
--- a/agent/cmd/determined-agent/root.go
+++ b/agent/cmd/determined-agent/root.go
@@ -1,11 +1,16 @@
 package main
 
 import (
-	log "github.com/sirupsen/logrus"
+	"errors"
+
+	"github.com/determined-ai/determined/master/pkg/logger"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
 type options struct {
+	logger.Config
+
 	logLevel string
 	noColor  bool
 }
@@ -22,23 +27,44 @@ func newRootCmd() *cobra.Command {
 			if err := bindEnv("DET_", cmd); err != nil {
 				return err
 			}
-			level, err := log.ParseLevel(opts.logLevel)
-			if err != nil {
-				return err
+
+			// Case hell for backwards compatability - remove whenever, after 0.20 series.
+			var usedDeprecatedLevel bool
+			switch {
+			case opts.logLevel != "" && opts.Level != "":
+				return errors.New("cannot use `--log-level` and `--level`")
+			case opts.logLevel != "" && opts.Level == "":
+				usedDeprecatedLevel = true
+				opts.Level = opts.logLevel
+			case opts.logLevel == "" && opts.Level == "":
+				opts.Level = "info"
 			}
-			log.SetLevel(level)
-			log.SetFormatter(&log.TextFormatter{
-				FullTimestamp: true,
-				ForceColors:   true,
-				DisableColors: opts.noColor,
-			})
+
+			var usedDeprecatedColor bool
+			if opts.noColor && opts.Color {
+				usedDeprecatedColor = true
+				opts.Color = !opts.noColor
+			}
+
+			logger.SetLogrus(opts.Config)
+
+			switch {
+			case usedDeprecatedLevel:
+				logrus.Warn("use of flag deprecated flag `--log-level`, please upgrade to `--level`")
+			case usedDeprecatedColor:
+				logrus.Warn("use of flag deprecated flag `--no-color`, please upgrade to `--color`")
+			}
 			return nil
 		},
 	}
 
-	cmd.PersistentFlags().StringVarP(&opts.logLevel, "log-level", "l", "info",
+	cmd.PersistentFlags().StringVarP(&opts.logLevel, "log-level", "l", "",
+		"set the logging level (can be one of: debug, info, warn, error, or fatal)")
+	cmd.PersistentFlags().StringVar(&opts.Level, "level", "",
 		"set the logging level (can be one of: debug, info, warn, error, or fatal)")
 	cmd.PersistentFlags().BoolVar(&opts.noColor, "no-color", false, "disable colored output")
+	cmd.PersistentFlags().BoolVar(&opts.Color, "color", true, "enable colored output")
+	cmd.PersistentFlags().BoolVar(&opts.Structured, "structured", true, "enable structured logging")
 
 	cmd.AddCommand(newCompletionCmd())
 	cmd.AddCommand(newVersionCmd())

--- a/master/pkg/logger/config.go
+++ b/master/pkg/logger/config.go
@@ -9,15 +9,17 @@ import (
 // DefaultConfig returns the default configuration of logger.
 func DefaultConfig() *Config {
 	return &Config{
-		Level: "info",
-		Color: true,
+		Level:      "info",
+		Color:      true,
+		Structured: true,
 	}
 }
 
 // Config is the configuration of logger.
 type Config struct {
-	Level string `json:"level"`
-	Color bool   `json:"color"`
+	Level      string `json:"level"`
+	Color      bool   `json:"color"`
+	Structured bool   `json:"structured"`
 }
 
 // Validate implements the check.Validatable interface.
@@ -36,9 +38,14 @@ func SetLogrus(c Config) {
 	}
 
 	logrus.SetLevel(level)
-	logrus.SetFormatter(&logrus.TextFormatter{
-		FullTimestamp: true,
-		ForceColors:   true,
-		DisableColors: !c.Color,
-	})
+
+	if !c.Structured {
+		logrus.SetFormatter(&logrus.TextFormatter{
+			FullTimestamp: true,
+			ForceColors:   true,
+			DisableColors: !c.Color,
+		})
+	} else {
+		logrus.SetFormatter(&logrus.JSONFormatter{})
+	}
 }


### PR DESCRIPTION
## Description

<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At a minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions about this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist
- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
