### PR TITLE
feat: Resume logging epochs

### DIFF
--- a/harness/determined/common/api/bindings.py
+++ b/harness/determined/common/api/bindings.py
@@ -10378,6 +10378,7 @@ class v1TrialLogsResponse:
         return out
 
 class v1TrialMetrics:
+    epoch: "typing.Optional[int]" = None
 
     def __init__(
         self,
@@ -10386,11 +10387,14 @@ class v1TrialMetrics:
         stepsCompleted: int,
         trialId: int,
         trialRunId: int,
+        epoch: "typing.Union[int, None, Unset]" = _unset,
     ):
         self.metrics = metrics
         self.stepsCompleted = stepsCompleted
         self.trialId = trialId
         self.trialRunId = trialRunId
+        if not isinstance(epoch, Unset):
+            self.epoch = epoch
 
     @classmethod
     def from_json(cls, obj: Json) -> "v1TrialMetrics":
@@ -10400,6 +10404,8 @@ class v1TrialMetrics:
             "trialId": obj["trialId"],
             "trialRunId": obj["trialRunId"],
         }
+        if "epoch" in obj:
+            kwargs["epoch"] = obj["epoch"]
         return cls(**kwargs)
 
     def to_json(self, omit_unset: bool = False) -> typing.Any:
@@ -10409,6 +10415,8 @@ class v1TrialMetrics:
             "trialId": self.trialId,
             "trialRunId": self.trialRunId,
         }
+        if not omit_unset or "epoch" in vars(self):
+            out["epoch"] = self.epoch
         return out
 
 class v1TrialOperation:

--- a/harness/determined/core/_train.py
+++ b/harness/determined/core/_train.py
@@ -72,6 +72,7 @@ class TrainContext:
         steps_completed: int,
         metrics: Dict[str, Any],
         batch_metrics: Optional[List[Dict[str, Any]]] = None,
+        epochs: Optional[int] = None,
     ) -> None:
         """
         Report training metrics to the master.
@@ -86,6 +87,7 @@ class TrainContext:
             "metrics": {
                 "avg_metrics": metrics,
             },
+            "epochs": epochs,
         }
         if batch_metrics is not None:
             body["metrics"]["batch_metrics"] = batch_metrics  # type: ignore

--- a/harness/determined/core/_train.py
+++ b/harness/determined/core/_train.py
@@ -72,7 +72,7 @@ class TrainContext:
         steps_completed: int,
         metrics: Dict[str, Any],
         batch_metrics: Optional[List[Dict[str, Any]]] = None,
-        epochs: Optional[int] = None,
+        epoch: Optional[int] = None,
     ) -> None:
         """
         Report training metrics to the master.
@@ -87,7 +87,7 @@ class TrainContext:
             "metrics": {
                 "avg_metrics": metrics,
             },
-            "epochs": epochs,
+            "epoch": epoch,
         }
         if batch_metrics is not None:
             body["metrics"]["batch_metrics"] = batch_metrics  # type: ignore
@@ -242,6 +242,7 @@ class DummyTrainContext(TrainContext):
         steps_completed: int,
         metrics: Dict[str, Any],
         batch_metrics: Optional[List[Dict[str, Any]]] = None,
+        epoch: Optional[int] = None,
     ) -> None:
         logger.info(
             f"report_training_metrics(steps_completed={steps_completed}, metrics={metrics})"

--- a/harness/determined/layers/_workload_sequencer.py
+++ b/harness/determined/layers/_workload_sequencer.py
@@ -206,6 +206,7 @@ class WorkloadSequencer(workload.Source):
             steps_completed=self.state.steps_completed,
             metrics=metrics,
             batch_metrics=batch_metrics,
+            epoch=max(1, self.state.steps_completed * self.global_batch_size // self.records_per_epoch),
         )
 
         # Report progress to the searcher.  For historical reasons we only deal in batches.

--- a/master/internal/db/postgres_trial.go
+++ b/master/internal/db/postgres_trial.go
@@ -182,10 +182,10 @@ WHERE trial_id = $1
 		if _, err := tx.NamedExecContext(ctx, `
 INSERT INTO raw_steps
 	(trial_id, trial_run_id, state,
-	 end_time, metrics, total_batches)
+	 end_time, metrics, total_batches, total_epochs)
 VALUES
 	(:trial_id, :trial_run_id, :state,
-	 now(), :metrics, :total_batches)
+	 now(), :metrics, :total_batches, :total_epochs)
 `, model.TrialMetrics{
 			TrialID:    int(m.TrialId),
 			TrialRunID: int(m.TrialRunId),
@@ -195,6 +195,7 @@ VALUES
 				"batch_metrics": m.Metrics.BatchMetrics,
 			},
 			TotalBatches: int(m.StepsCompleted),
+			TotalEpochs:  int(m.Epoch),
 		}); err != nil {
 			return errors.Wrap(err, "inserting training metrics")
 		}

--- a/master/pkg/model/experiment.go
+++ b/master/pkg/model/experiment.go
@@ -463,6 +463,7 @@ type TrialMetrics struct {
 	State        State      `db:"state" json:"state"`
 	EndTime      *time.Time `db:"end_time" json:"end_time"`
 	Metrics      JSONObj    `db:"metrics" json:"metrics"`
+	TotalEpochs  int        `db:"total_epochs" json:"total_epochs"`
 }
 
 // Represent order of active states (Queued -> Pulling -> Starting -> Running).

--- a/proto/src/determined/trial/v1/trial.proto
+++ b/proto/src/determined/trial/v1/trial.proto
@@ -211,6 +211,8 @@ message TrialMetrics {
   // - avg_metrics: metrics reduced over the reporting period).
   // - batch_metrics: (optional) per-batch metrics.
   determined.common.v1.Metrics metrics = 9;
+  // The current epoch reported on these metrics.
+  int32 epoch = 10;
 }
 
 // The rendezvous info for the trial to rendezvous with sibling containers.

--- a/webui/react/src/services/api-ts-sdk/api.ts
+++ b/webui/react/src/services/api-ts-sdk/api.ts
@@ -8478,6 +8478,12 @@ export interface V1TrialMetrics {
      * @memberof V1TrialMetrics
      */
     metrics: V1Metrics;
+    /**
+     * The current epoch reported on these metrics.
+     * @type {number}
+     * @memberof V1TrialMetrics
+     */
+    epoch?: number;
 }
 
 /**


### PR DESCRIPTION
## Description

As part of allowing a different x-axis on our charts, we would want an option for experiments to be logged by epoch.

If an experiment has `records_per_epoch` in its configuration, record epoch based on the batches number. The calculation reverses this existing code which had converted epochs to batches.

```python
return max((epochs * self.records_per_epoch) // self.global_batch_size, 1)
```

If epoch is not in the config, set epoch = 0 (the database already defaults to total_epochs=0 on all steps)

## Test Plan

- Run `det e create gan/gan_mnist_pl/const.yaml gan/gan_mnist_pl` and find the **trial_id**. In the database, look up `select distinct(total_epochs) from steps where trial_id = 125;` and there should be values 0-4.
- Run `det e create decision_trees/gbt_titanic_estimator/const.yaml decision_trees/gbt_titanic_estimator` and find this **trial_id**. In the database, look up `select distinct(total_epochs) from steps where trial_id = 126;` and it should only be 0.

## Checklist
- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.