### PR TITLE
ci: user logout respects passing master URL as flag

### DIFF
--- a/e2e_tests/tests/cluster/test_users.py
+++ b/e2e_tests/tests/cluster/test_users.py
@@ -81,10 +81,10 @@ def log_in_user(credentials: authentication.Credentials, expectedStatus: int = 0
 
     child.expect(expected, EXPECT_TIMEOUT)
     child.sendline(password)
-    child.read()
+    out = child.read()
     child.wait()
     child.close()
-    assert child.exitstatus == expectedStatus
+    assert child.exitstatus == expectedStatus, out
 
 
 def create_test_user(add_password: bool = False) -> authentication.Credentials:
@@ -94,10 +94,10 @@ def create_test_user(add_password: bool = False) -> authentication.Credentials:
     # Now we activate the user.
     child = det_spawn(["user", "activate", n_username])
     child.expect(pexpect.EOF, timeout=EXPECT_TIMEOUT)
-    child.read()
+    out = child.read()
     child.wait()
     child.close()
-    assert child.exitstatus == 0
+    assert child.exitstatus == 0, out
 
     password = ""
     if add_password:
@@ -132,10 +132,10 @@ def log_out_user(username: Optional[str] = None) -> None:
         args = ["user", "logout"]
 
     child = det_spawn(args)
-    child.read()
+    out = child.read()
     child.wait()
     child.close()
-    assert child.exitstatus == 0
+    assert child.exitstatus == 0, out
 
 
 def activate_deactivate_user(active: bool, target_user: str) -> None:

--- a/harness/determined/cli/user.py
+++ b/harness/determined/cli/user.py
@@ -51,22 +51,22 @@ def log_in_user(parsed_args: Namespace) -> None:
     token_store.set_active(username)
 
 
-@authentication.optional
 def log_out_user(parsed_args: Namespace) -> None:
-    auth = authentication.cli_auth
-    if auth is None:
+    try:
+        client.login(master=parsed_args.master, user=parsed_args.user, try_reauth=False)
+    except (api.errors.UnauthenticatedException, api.errors.ForbiddenException):
         return
+
     try:
         client.logout()
     except api.errors.APIException as e:
         if e.status_code != 401:
             raise e
-
     except api.errors.UnauthenticatedException:
         pass
 
     token_store = authentication.TokenStore(parsed_args.master)
-    token_store.drop_user(auth.get_session_user())
+    token_store.drop_user(parsed_args.user)
 
 
 @login_sdk_client

--- a/harness/determined/common/experimental/determined.py
+++ b/harness/determined/common/experimental/determined.py
@@ -47,6 +47,7 @@ class Determined:
         cert_path: Optional[str] = None,
         cert_name: Optional[str] = None,
         noverify: bool = False,
+        try_reauth: bool = True,
     ):
         master = master or util.get_default_master_address()
 
@@ -60,7 +61,9 @@ class Determined:
         # TODO: This should probably be try_reauth=False, but it appears that would break the case
         # where the default credentials are available from the master and could be discovered by
         # a REST API call against the master.
-        auth = authentication.Authentication(master, user, password, try_reauth=True, cert=cert)
+        auth = authentication.Authentication(
+            master, user, password, try_reauth=try_reauth, cert=cert
+        )
         self._session = api.Session(master, user, auth, cert)
 
     def _from_bindings(self, raw: bindings.v1User) -> user.User:

--- a/harness/determined/experimental/client.py
+++ b/harness/determined/experimental/client.py
@@ -88,6 +88,7 @@ def login(
     cert_path: Optional[str] = None,
     cert_name: Optional[str] = None,
     noverify: bool = False,
+    try_reauth: bool = True,
 ) -> None:
     """
     ``login()`` will configure the default Determined() singleton used by all of the other functions
@@ -137,7 +138,7 @@ def login(
             "client.Determined() objects, which each expose the same functions as this module."
         )
 
-    _determined = Determined(master, user, password, cert_path, cert_name, noverify)
+    _determined = Determined(master, user, password, cert_path, cert_name, noverify, try_reauth)
 
 
 @_require_singleton


### PR DESCRIPTION
## Description
Had a bug in tests where `det user logout` called from `with_logged_in_user` was accidentally talking to `localhost:8080`, not the deployed cluster. Turned out to be the client not being initialized correctly.
<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At a minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan
- [x] is a test
<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions about this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)
Tried to find the most elegant fix, but it is debatable.
<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist
- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
