### PR TITLE
fix: Experiment listing should not have spurious state triggers

### DIFF
--- a/webui/react/src/components/Table/InteractiveTable.tsx
+++ b/webui/react/src/components/Table/InteractiveTable.tsx
@@ -460,7 +460,7 @@ const InteractiveTable: InteractiveTable = ({
 
       const newSettings: Partial<InteractiveTableSettings> = {
         tableLimit: tablePagination.pageSize,
-        tableOffset: (tablePagination.current ?? 1 - 1) * (tablePagination.pageSize ?? 0),
+        tableOffset: ((tablePagination.current ?? 1) - 1) * (tablePagination.pageSize ?? 0),
       };
 
       const { columnKey, order } = tableSorter as SorterResult<unknown>;

--- a/webui/react/src/pages/ExperimentDetails/ExperimentTrials.tsx
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentTrials.tsx
@@ -258,7 +258,7 @@ const ExperimentTrials: React.FC<Props> = ({ experiment, pageRef }: Props) => {
           ? columnKey
           : V1GetExperimentTrialsRequestSortBy.UNSPECIFIED,
         tableLimit: tablePagination.pageSize,
-        tableOffset: (tablePagination.current ?? 1 - 1) * (tablePagination.pageSize ?? 0),
+        tableOffset: ((tablePagination.current ?? 1) - 1) * (tablePagination.pageSize ?? 0),
       };
       const shouldPush = settings.tableOffset !== newSettings.tableOffset;
       updateSettings(newSettings, shouldPush);

--- a/webui/react/src/pages/ExperimentList.tsx
+++ b/webui/react/src/pages/ExperimentList.tsx
@@ -138,6 +138,14 @@ const ExperimentList: React.FC<Props> = ({ project }) => {
   const { settings, updateSettings, resetSettings, activeSettings } =
     useSettings<ExperimentListSettings>(settingsConfig);
 
+  const tableOffset = (() => {
+    if (settings.tableOffset > total) {
+      const newTotal = settings.tableOffset > total ? total : total - 1;
+      return settings.tableLimit * Math.floor(newTotal / settings.tableLimit);
+    }
+    return settings.tableOffset;
+  })();
+
   const experimentMap = useMemo(() => {
     return (experiments || []).reduce((acc, experiment) => {
       acc[experiment.id] = getProjectExperimentForExperimentItem(experiment, project);
@@ -192,8 +200,7 @@ const ExperimentList: React.FC<Props> = ({ project }) => {
           ...baseParams,
           experimentIdFilter: { notIn: pinnedIds },
           limit: settings.tableLimit - pinnedIds.length,
-          offset:
-            settings.tableOffset - (settings.tableOffset / settings.tableLimit) * pinnedIds.length,
+          offset: tableOffset - (tableOffset / settings.tableLimit) * pinnedIds.length,
         },
         { signal: canceler.signal },
       );
@@ -821,15 +828,6 @@ const ExperimentList: React.FC<Props> = ({ project }) => {
   );
 
   useEffect(() => {
-    if (!settings) return;
-    if (settings.tableOffset > total) {
-      const newTotal = settings.tableOffset > total ? total : total - 1;
-      const offset = settings.tableLimit * Math.floor(newTotal / settings.tableLimit);
-      updateSettings({ tableOffset: offset });
-    }
-  }, [total, settings, updateSettings]);
-
-  useEffect(() => {
     setIsLoading(true);
     fetchExperiments();
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -942,7 +940,7 @@ const ExperimentList: React.FC<Props> = ({ project }) => {
           pagination={getFullPaginationConfig(
             {
               limit: settings.tableLimit || 0,
-              offset: settings.tableOffset || 0,
+              offset: tableOffset || 0,
             },
             total,
           )}

--- a/webui/react/src/pages/ModelDetails.tsx
+++ b/webui/react/src/pages/ModelDetails.tsx
@@ -254,7 +254,7 @@ const ModelDetails: React.FC = () => {
         sortDesc: order === 'descend',
         sortKey: isOfSortKey(columnKey) ? columnKey : V1GetModelVersionsRequestSortBy.UNSPECIFIED,
         tableLimit: tablePagination.pageSize,
-        tableOffset: (tablePagination.current ?? 1 - 1) * (tablePagination.pageSize ?? 0),
+        tableOffset: ((tablePagination.current ?? 1) - 1) * (tablePagination.pageSize ?? 0),
       };
       const shouldPush = settings.tableOffset !== newSettings.tableOffset;
       updateSettings(newSettings, shouldPush);

--- a/webui/react/src/pages/ModelRegistry.tsx
+++ b/webui/react/src/pages/ModelRegistry.tsx
@@ -489,7 +489,7 @@ const ModelRegistry: React.FC = () => {
         sortDesc: order === 'descend',
         sortKey: isOfSortKey(columnKey) ? columnKey : V1GetModelsRequestSortBy.UNSPECIFIED,
         tableLimit: tablePagination.pageSize,
-        tableOffset: (tablePagination.current ?? 1 - 1) * (tablePagination.pageSize ?? 0),
+        tableOffset: ((tablePagination.current ?? 1) - 1) * (tablePagination.pageSize ?? 0),
       };
       const shouldPush = settings.tableOffset !== newSettings.tableOffset;
       updateSettings(newSettings, shouldPush);

--- a/webui/react/src/pages/OldProjectDetails.tsx
+++ b/webui/react/src/pages/OldProjectDetails.tsx
@@ -152,6 +152,14 @@ const ProjectDetails: React.FC = () => {
   const { settings, updateSettings, resetSettings, activeSettings } =
     useSettings<ProjectDetailsSettings>(settingsConfig);
 
+  const tableOffset = (() => {
+    if (settings.tableOffset >= total && total) {
+      const newTotal = settings.tableOffset > total ? total : total - 1;
+      return settings.tableLimit * Math.floor(newTotal / settings.tableLimit);
+    }
+    return settings.tableOffset;
+  })();
+
   const experimentMap = useMemo(() => {
     return (experiments || []).reduce((acc, experiment) => {
       acc[experiment.id] = getProjectExperimentForExperimentItem(experiment, project);
@@ -219,8 +227,7 @@ const ProjectDetails: React.FC = () => {
           ...baseParams,
           experimentIdFilter: { notIn: pinnedIds },
           limit: settings.tableLimit - pinnedIds.length,
-          offset:
-            settings.tableOffset - (settings.tableOffset / settings.tableLimit) * pinnedIds.length,
+          offset: tableOffset - (tableOffset / settings.tableLimit) * pinnedIds.length,
         },
         { signal: canceler.signal },
       );
@@ -886,16 +893,6 @@ const ProjectDetails: React.FC = () => {
     },
     [openNoteDelete, project?.id],
   );
-
-  useEffect(() => {
-    if (!settings.tableOffset || !settings.tableLimit) return;
-
-    if (settings.tableOffset >= total && total) {
-      const newTotal = settings.tableOffset > total ? total : total - 1;
-      const offset = settings.tableLimit * Math.floor(newTotal / settings.tableLimit);
-      updateSettings({ tableOffset: offset });
-    }
-  }, [total, settings.tableOffset, settings.tableLimit, updateSettings]);
 
   /*
    * Get new experiments based on changes to the

--- a/webui/react/src/pages/OldProjectDetails.tsx
+++ b/webui/react/src/pages/OldProjectDetails.tsx
@@ -153,7 +153,7 @@ const ProjectDetails: React.FC = () => {
     useSettings<ProjectDetailsSettings>(settingsConfig);
 
   const tableOffset = (() => {
-    if (settings.tableOffset >= total && total) {
+    if (total && settings.tableOffset >= total) {
       const newTotal = settings.tableOffset > total ? total : total - 1;
       return settings.tableLimit * Math.floor(newTotal / settings.tableLimit);
     }

--- a/webui/react/src/pages/TaskList.tsx
+++ b/webui/react/src/pages/TaskList.tsx
@@ -494,7 +494,7 @@ const TaskList: React.FC = () => {
         sortDesc: order === 'descend',
         sortKey: isOfSortKey(columnKey) ? columnKey : ALL_SORTKEY[0],
         tableLimit: tablePagination.pageSize,
-        tableOffset: (tablePagination.current ?? 1 - 1) * (tablePagination.pageSize ?? 0),
+        tableOffset: ((tablePagination.current ?? 1) - 1) * (tablePagination.pageSize ?? 0),
       };
       const shouldPush = settings.tableOffset !== newSettings.tableOffset;
       updateSettings(newSettings, shouldPush);

--- a/webui/react/src/pages/TrialDetails/TrialDetailsWorkloads.tsx
+++ b/webui/react/src/pages/TrialDetails/TrialDetailsWorkloads.tsx
@@ -211,7 +211,7 @@ const TrialDetailsWorkloads: React.FC<Props> = ({
         sortDesc: order === 'descend',
         sortKey: columnKey as string,
         tableLimit: tablePagination.pageSize,
-        tableOffset: (tablePagination.current ?? 1 - 1) * (tablePagination.pageSize ?? 0),
+        tableOffset: ((tablePagination.current ?? 1) - 1) * (tablePagination.pageSize ?? 0),
       });
     },
     [columns, updateSettings],

--- a/webui/react/src/pages/WebhookList.tsx
+++ b/webui/react/src/pages/WebhookList.tsx
@@ -193,7 +193,7 @@ const WebhooksView: React.FC = () => {
         sortDesc: order === 'descend',
         sortKey: columnKey,
         tableLimit: tablePagination.pageSize,
-        tableOffset: (tablePagination.current ?? 1 - 1) * (tablePagination.pageSize ?? 0),
+        tableOffset: ((tablePagination.current ?? 1) - 1) * (tablePagination.pageSize ?? 0),
       };
       updateSettings(newSettings, true);
     },


### PR DESCRIPTION
## Description
This fixes an issue with the experiment listing page where it would constantly swap between two states when on the last page of the listing if you switched the amount displayed per page.

## Test Plan
1. Go to http://localhost:3000/projects/1/experiments
2. Change the page size to 100
3. Confirm there is now only one page
4. Change the page size to 50
5. Confirm there are now two pages and the app is not caught in a state update loop
6. Click on the 3rd page button, confirm it goes to the third page
7. Click on the first page button, confirm it goes to the first page

## Checklist
- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
WEB-669