### PR TITLE
chore: configure HPC resource pool providers

### DIFF
--- a/master/internal/config/provconfig/config.go
+++ b/master/internal/config/provconfig/config.go
@@ -33,10 +33,16 @@ type Config struct {
 	AgentConfigFileContents json.RawMessage   `json:"agent_config_file_contents"`
 	AWS                     *AWSClusterConfig `union:"type,aws" json:"-"`
 	GCP                     *GCPClusterConfig `union:"type,gcp" json:"-"`
+	HPC                     *HpcClusterConfig `union:"type,launcher" json:"-"`
 	MaxIdleAgentPeriod      model.Duration    `json:"max_idle_agent_period"`
 	MaxAgentStartingPeriod  model.Duration    `json:"max_agent_starting_period"`
 	MinInstances            int               `json:"min_instances"`
 	MaxInstances            int               `json:"max_instances"`
+}
+
+// HpcClusterConfig describes the configuration for a HPC cluster managed by Determined.
+type HpcClusterConfig struct {
+	BaseResourcePool string `json:"base_resource_pool"`
 }
 
 // DefaultConfig returns the default configuration of the provisioner.
@@ -88,7 +94,8 @@ func (c Config) Validate() []error {
 		masterURLErr,
 		check.NotEmpty(c.AgentDockerImage, "must configure an agent docker image"),
 		check.False(c.AWS != nil && c.GCP != nil, "must configure only one cluster"),
-		check.False(c.AWS == nil && c.GCP == nil, "must configure aws or gcp cluster"),
+		check.False(c.AWS == nil && c.GCP == nil && c.HPC == nil,
+			"must configure aws or gcp or hpc cluster"),
 		check.GreaterThan(
 			int64(c.MaxIdleAgentPeriod), int64(0), "max idle agent period must be greater than 0"),
 		check.GreaterThan(

--- a/master/internal/config/provconfig/config.go
+++ b/master/internal/config/provconfig/config.go
@@ -33,7 +33,7 @@ type Config struct {
 	AgentConfigFileContents json.RawMessage   `json:"agent_config_file_contents"`
 	AWS                     *AWSClusterConfig `union:"type,aws" json:"-"`
 	GCP                     *GCPClusterConfig `union:"type,gcp" json:"-"`
-	HPC                     *HpcClusterConfig `union:"type,launcher" json:"-"`
+	HPC                     *HpcClusterConfig `union:"type,hpc" json:"-"`
 	MaxIdleAgentPeriod      model.Duration    `json:"max_idle_agent_period"`
 	MaxAgentStartingPeriod  model.Duration    `json:"max_agent_starting_period"`
 	MinInstances            int               `json:"min_instances"`

--- a/master/internal/config/provconfig/config.go
+++ b/master/internal/config/provconfig/config.go
@@ -42,7 +42,7 @@ type Config struct {
 
 // HpcClusterConfig describes the configuration for a HPC cluster managed by Determined.
 type HpcClusterConfig struct {
-	BaseResourcePool string `json:"base_resource_pool"`
+	Partition string `json:"partition"`
 }
 
 // DefaultConfig returns the default configuration of the provisioner.

--- a/master/internal/config/provconfig/config_test.go
+++ b/master/internal/config/provconfig/config_test.go
@@ -21,7 +21,7 @@ func TestProvisionerConfigMissingFields(t *testing.T) {
 	err := json.Unmarshal([]byte(`{}`), &config)
 	assert.NilError(t, err)
 	err = check.Validate(&config)
-	assert.ErrorContains(t, err, "must configure aws or gcp cluster")
+	assert.ErrorContains(t, err, "must configure aws or gcp or hpc cluster")
 	expected := Config{
 		MaxIdleAgentPeriod:     model.Duration(20 * time.Minute),
 		MaxAgentStartingPeriod: model.Duration(20 * time.Minute),
@@ -224,4 +224,21 @@ boot_disk_source_image: test-source_image3
 		AgentReconnectBackoff:  aproto.AgentReconnectBackoffValue,
 	}
 	assert.DeepEqual(t, expected, unmarshaled)
+}
+
+func TestUnmarshalProvisionerConfigWithHpc(t *testing.T) {
+	configRaw := `
+master_url: http://test.master
+agent_docker_image: test_image
+
+type: launcher
+base_resource_pool: tesla_queue
+`
+	unmarshaled := Config{}
+	err := yaml.Unmarshal([]byte(configRaw), &unmarshaled, yaml.DisallowUnknownFields)
+	assert.NilError(t, err)
+	err = check.Validate(&unmarshaled)
+	assert.NilError(t, err)
+
+	assert.Equal(t, unmarshaled.HPC.BaseResourcePool, "tesla_queue")
 }

--- a/master/internal/config/provconfig/config_test.go
+++ b/master/internal/config/provconfig/config_test.go
@@ -232,7 +232,7 @@ master_url: http://test.master
 agent_docker_image: test_image
 
 type: hpc
-base_resource_pool: tesla_queue
+partition: tesla_queue
 `
 	unmarshaled := Config{}
 	err := yaml.Unmarshal([]byte(configRaw), &unmarshaled, yaml.DisallowUnknownFields)
@@ -240,5 +240,5 @@ base_resource_pool: tesla_queue
 	err = check.Validate(&unmarshaled)
 	assert.NilError(t, err)
 
-	assert.Equal(t, unmarshaled.HPC.BaseResourcePool, "tesla_queue")
+	assert.Equal(t, unmarshaled.HPC.Partition, "tesla_queue")
 }

--- a/master/internal/config/provconfig/config_test.go
+++ b/master/internal/config/provconfig/config_test.go
@@ -231,7 +231,7 @@ func TestUnmarshalProvisionerConfigWithHpc(t *testing.T) {
 master_url: http://test.master
 agent_docker_image: test_image
 
-type: launcher
+type: hpc
 base_resource_pool: tesla_queue
 `
 	unmarshaled := Config{}


### PR DESCRIPTION
## Description

See design note: [here](https://connect.us.cray.com/confluence/display/AT/Design+Note%3A+Allow+Specification+of+Slurm+Gres)

Allow for configuration of HPS resource pool providers in the master .yaml, for example:

```
        resource_manager:
…
        resource_pools:
          - pool_name: pool1
            description: the description
          - pool_name: tesla_gpu_q
            description: Where the GPUs are
            provider:             
              type: hpc
              partition: gpu_q
```
<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At a minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan
More testing will be done in the EE repo.
<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions about this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist
- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
