### PR TITLE
chore: Move workspaces to their own store [WEB-674]

### DIFF
--- a/webui/react/src/App.tsx
+++ b/webui/react/src/App.tsx
@@ -24,8 +24,7 @@ import appRoutes from 'routes';
 import { paths, serverAddress } from 'routes/utils';
 import Spinner from 'shared/components/Spinner/Spinner';
 import usePolling from 'shared/hooks/usePolling';
-import { AgentsProvider } from 'stores/agents';
-import { WorkspacesProvider } from 'stores/workspaces';
+import { StoreContext } from 'stores';
 import { correctViewportHeight, refreshPage } from 'utils/browser';
 
 import css from './App.module.scss';
@@ -159,13 +158,11 @@ const App: React.FC = () => {
   return (
     <HelmetProvider>
       <StoreProvider>
-        <AgentsProvider>
-          <WorkspacesProvider>
-            <DndProvider backend={HTML5Backend}>
-              <AppView />
-            </DndProvider>
-          </WorkspacesProvider>
-        </AgentsProvider>
+        <StoreContext>
+          <DndProvider backend={HTML5Backend}>
+            <AppView />
+          </DndProvider>
+        </StoreContext>
       </StoreProvider>
     </HelmetProvider>
   );

--- a/webui/react/src/App.tsx
+++ b/webui/react/src/App.tsx
@@ -25,6 +25,7 @@ import { paths, serverAddress } from 'routes/utils';
 import Spinner from 'shared/components/Spinner/Spinner';
 import usePolling from 'shared/hooks/usePolling';
 import { AgentsProvider } from 'stores/agents';
+import { WorkspacesProvider } from 'stores/workspaces';
 import { correctViewportHeight, refreshPage } from 'utils/browser';
 
 import css from './App.module.scss';
@@ -159,9 +160,11 @@ const App: React.FC = () => {
     <HelmetProvider>
       <StoreProvider>
         <AgentsProvider>
-          <DndProvider backend={HTML5Backend}>
-            <AppView />
-          </DndProvider>
+          <WorkspacesProvider>
+            <DndProvider backend={HTML5Backend}>
+              <AppView />
+            </DndProvider>
+          </WorkspacesProvider>
         </AgentsProvider>
       </StoreProvider>
     </HelmetProvider>

--- a/webui/react/src/pages/ExperimentDetails/ExperimentDetails.test.tsx
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentDetails.test.tsx
@@ -13,6 +13,7 @@ import {
   getWorkspace,
 } from 'services/api';
 import history from 'shared/routes/history';
+import { WorkspacesProvider } from 'stores/workspaces';
 
 import ExperimentDetails, { ERROR_MESSAGE, INVALID_ID_MESSAGE } from './ExperimentDetails';
 import RESPONSES from './ExperimentDetails.test.mock';
@@ -39,6 +40,7 @@ jest.mock('services/api', () => ({
   getProject: jest.fn(),
   getTrialDetails: jest.fn(),
   getWorkspace: jest.fn(),
+  getWorkspaces: jest.fn().mockReturnValue({ workspaces: [] }),
 }));
 
 jest.mock('hooks/useTelemetry', () => ({
@@ -64,16 +66,18 @@ const setup = () => {
   const view = render(
     <StoreProvider>
       <HelmetProvider>
-        <HistoryRouter history={history}>
-          <ExperimentDetails />
-        </HistoryRouter>
+        <WorkspacesProvider>
+          <HistoryRouter history={history}>
+            <ExperimentDetails />
+          </HistoryRouter>
+        </WorkspacesProvider>
       </HelmetProvider>
     </StoreProvider>,
   );
   return { view };
 };
 
-describe('Experment Details Page', () => {
+describe('Experiment Details Page', () => {
   describe('Invalid Experiment ID', () => {
     const INVALID_ID = 'beadbead';
 

--- a/webui/react/src/stores/agents.tsx
+++ b/webui/react/src/stores/agents.tsx
@@ -39,7 +39,7 @@ export const useFetchAgents = (canceler: AbortController): (() => Promise<void>)
 
   return useCallback(async (): Promise<void> => {
     try {
-      const agents = await getAgents({ signal: canceler.signal });
+      const agents = await getAgents({}, { signal: canceler.signal });
       updateAgents(Loaded(agents));
     } catch (e) {
       handleError(e);

--- a/webui/react/src/stores/index.tsx
+++ b/webui/react/src/stores/index.tsx
@@ -1,0 +1,10 @@
+import React, { ReactElement, ReactNode } from 'react';
+
+import { AgentsProvider } from './agents';
+import { WorkspacesProvider } from './workspaces';
+
+export const StoreContext = ({ children }: { children: ReactNode }): ReactElement => (
+  <AgentsProvider>
+    <WorkspacesProvider>{children}</WorkspacesProvider>
+  </AgentsProvider>
+);

--- a/webui/react/src/stores/workspaces.tsx
+++ b/webui/react/src/stores/workspaces.tsx
@@ -1,0 +1,67 @@
+import React, { createContext, PropsWithChildren, useCallback, useContext, useState } from 'react';
+
+import { getWorkspaces } from 'services/api';
+import { Workspace } from 'types';
+import handleError from 'utils/error';
+import { Loadable, Loaded, NotLoaded } from 'utils/loadable';
+
+type WorkspacesContext = {
+  updateWorkspaces: (fn: (ws: Loadable<Workspace[]>) => Loadable<Workspace[]>) => void;
+  workspaces: Loadable<Workspace[]>;
+};
+
+const WorkspacesContext = createContext<WorkspacesContext | null>(null);
+
+export const WorkspacesProvider: React.FC<PropsWithChildren> = ({ children }) => {
+  const [state, setState] = useState<Loadable<Workspace[]>>(NotLoaded);
+  return (
+    <WorkspacesContext.Provider value={{ updateWorkspaces: setState, workspaces: state }}>
+      {children}
+    </WorkspacesContext.Provider>
+  );
+};
+
+export const useFetchWorkspaces = (canceler: AbortController): (() => Promise<void>) => {
+  const context = useContext(WorkspacesContext);
+  if (context === null) {
+    throw new Error('Attempted to use useFetchWorkspaces outside of Workspace Context');
+  }
+  const { updateWorkspaces } = context;
+
+  return useCallback(async (): Promise<void> => {
+    try {
+      const response = await getWorkspaces({}, { signal: canceler.signal });
+      updateWorkspaces(() => Loaded(response.workspaces));
+    } catch (e) {
+      handleError(e);
+    }
+  }, [canceler, updateWorkspaces]);
+};
+
+export const useEnsureWorkspacesFetched = (canceler: AbortController): (() => Promise<void>) => {
+  const context = useContext(WorkspacesContext);
+  if (context === null) {
+    throw new Error('Attempted to use useEnsureFetchWorkspaces outside of Workspace Context');
+  }
+  const { workspaces, updateWorkspaces } = context;
+
+  return useCallback(async (): Promise<void> => {
+    if (workspaces !== NotLoaded) return;
+    try {
+      const response = await getWorkspaces({}, { signal: canceler.signal });
+      updateWorkspaces(() => Loaded(response.workspaces));
+    } catch (e) {
+      handleError(e);
+    }
+  }, [canceler, workspaces, updateWorkspaces]);
+};
+
+export const useWorkspaces = (): Loadable<Workspace[]> => {
+  const context = useContext(WorkspacesContext);
+  if (context === null) {
+    throw new Error('Attempted to use useWorkspaces outside of Workspace Context');
+  }
+  const { workspaces } = context;
+
+  return workspaces;
+};


### PR DESCRIPTION
## Description
This adds a new store for workspaces. Currently we make a request for workspaces for every row on the experiments page leading to significant lag. This reduces it to only on total (and only if they're not already loaded).


## Test Plan
1. Load the uncategorized page
2. Confirm only one request for workspaces is made
3. Change the table sort order
4. Confirm that no calls are made for workspaces

## Checklist
- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
WEB-674