### PR TITLE
ci: user logout respects passing master URL as flag + fix test_workspace_org

### DIFF
--- a/e2e_tests/tests/cluster/test_workspace_org.py
+++ b/e2e_tests/tests/cluster/test_workspace_org.py
@@ -8,7 +8,7 @@ import pytest
 from determined.common import api
 from determined.common.api import authentication, bindings, errors
 from tests import config as conf
-from tests.cluster.test_users import ADMIN_CREDENTIALS
+from tests.cluster.test_users import ADMIN_CREDENTIALS, logged_in_user, change_user_password
 from tests.experiment import determined_test_session, run_basic_test, wait_for_experiment_state
 
 from .test_agent_user_group import _delete_workspace_and_check
@@ -17,6 +17,8 @@ from .test_groups import det_cmd, det_cmd_json
 
 @pytest.mark.e2e_cpu
 def test_workspace_org() -> None:
+    with logged_in_user(ADMIN_CREDENTIALS):
+        change_user_password("determined", "")
     master_url = conf.make_master_url()
     authentication.cli_auth = authentication.Authentication(master_url, try_reauth=True)
     sess = api.Session(master_url, None, None, None)

--- a/e2e_tests/tests/cluster/test_workspace_org.py
+++ b/e2e_tests/tests/cluster/test_workspace_org.py
@@ -8,7 +8,7 @@ import pytest
 from determined.common import api
 from determined.common.api import authentication, bindings, errors
 from tests import config as conf
-from tests.cluster.test_users import ADMIN_CREDENTIALS, logged_in_user, change_user_password
+from tests.cluster.test_users import ADMIN_CREDENTIALS, change_user_password, logged_in_user
 from tests.experiment import determined_test_session, run_basic_test, wait_for_experiment_state
 
 from .test_agent_user_group import _delete_workspace_and_check

--- a/harness/determined/cli/user.py
+++ b/harness/determined/cli/user.py
@@ -54,7 +54,7 @@ def log_in_user(parsed_args: Namespace) -> None:
 def log_out_user(parsed_args: Namespace) -> None:
     det_obj = None
     try:
-        det_obj = det_obj = Determined(master=parsed_args.master, user=parsed_args.user)
+        det_obj = det_obj = Determined(master=parsed_args.master, user=parsed_args.user, try_reauth=False)
     except (api.errors.UnauthenticatedException, api.errors.ForbiddenException):
         return
     assert det_obj is None

--- a/harness/determined/cli/user.py
+++ b/harness/determined/cli/user.py
@@ -69,7 +69,7 @@ def log_out_user(parsed_args: Namespace) -> None:
         pass
 
     token_store = authentication.TokenStore(parsed_args.master)
-    token_store.drop_user(det_obj.auth.get_session_user()) # get current user instead
+    token_store.drop_user(det_obj.auth.get_session_user())
 
 
 @login_sdk_client

--- a/harness/determined/cli/user.py
+++ b/harness/determined/cli/user.py
@@ -9,8 +9,7 @@ from determined.cli import login_sdk_client
 from determined.common import api
 from determined.common.api import authentication
 from determined.common.declarative_argparse import Arg, Cmd
-from determined.experimental import client
-from determined.experimental import Determined
+from determined.experimental import Determined, client
 
 from . import render
 
@@ -55,7 +54,7 @@ def log_in_user(parsed_args: Namespace) -> None:
 def log_out_user(parsed_args: Namespace) -> None:
     det_obj = None
     try:
-        det_obj =  det_obj = Determined(master=parsed_args.master, user=parsed_args.user)
+        det_obj = det_obj = Determined(master=parsed_args.master, user=parsed_args.user)
     except (api.errors.UnauthenticatedException, api.errors.ForbiddenException):
         return
     assert det_obj is None

--- a/harness/determined/common/experimental/determined.py
+++ b/harness/determined/common/experimental/determined.py
@@ -60,8 +60,8 @@ class Determined:
         # TODO: This should probably be try_reauth=False, but it appears that would break the case
         # where the default credentials are available from the master and could be discovered by
         # a REST API call against the master.
-        auth = authentication.Authentication(master, user, password, try_reauth=True, cert=cert)
-        self._session = api.Session(master, user, auth, cert)
+        self.auth = authentication.Authentication(master, user, password, try_reauth=True, cert=cert)
+        self._session = api.Session(master, user, self.auth, cert)
 
     def _from_bindings(self, raw: bindings.v1User) -> user.User:
         assert raw.id is not None


### PR DESCRIPTION
## Description

Had a bug in tests where det user logout called from with_logged_in_user was accidentally talking to localhost:8080, not the deployed cluster. Turned out to be the client not being initialized correctly.

before we run test_workspace_org we need to have determined credentials. 

## Test Plan
fixing tests so no test required. 

