### PR TITLE
fix: aws instance id under IMDSv2.

### DIFF
--- a/master/internal/rm/agentrm/provisioner/aws.go
+++ b/master/internal/rm/agentrm/provisioner/aws.go
@@ -31,7 +31,7 @@ type awsCluster struct {
 	spot *spotState
 }
 
-//nolint:lll
+//nolint:lll  // See https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-retrieval.html
 const ec2InstanceID = `$(curl -q -H "X-aws-ec2-metadata-token: $(curl -q -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")"  http://169.254.169.254/latest/meta-data/instance-id)`
 
 func newAWSCluster(

--- a/master/internal/rm/agentrm/provisioner/aws.go
+++ b/master/internal/rm/agentrm/provisioner/aws.go
@@ -31,6 +31,9 @@ type awsCluster struct {
 	spot *spotState
 }
 
+//nolint:lll
+const ec2InstanceID = `$(curl -q -H "X-aws-ec2-metadata-token: $(curl -q -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")"  http://169.254.169.254/latest/meta-data/instance-id)`
+
 func newAWSCluster(
 	resourcePool string, config *provconfig.Config, cert *tls.Certificate,
 ) (*awsCluster, error) {
@@ -109,7 +112,7 @@ func newAWSCluster(
 			AgentFluentImage:             config.AgentFluentImage,
 			AgentReconnectAttempts:       config.AgentReconnectAttempts,
 			AgentReconnectBackoff:        config.AgentReconnectBackoff,
-			AgentID:                      `$(ec2metadata --instance-id)`,
+			AgentID:                      ec2InstanceID,
 			ResourcePool:                 resourcePool,
 			LogOptions:                   config.AWS.BuildDockerLogString(),
 		}),


### PR DESCRIPTION
## Description

Problem:
1. scale decider assumes agent id is instance id for the purpose of detecting "disconnected" instances.
2. with imdsv2, `ec2metadata --instance-id` helper does not work, so agent id has defaulted to random container id.
3. this has caused the scale decider to erroneously terminate the instances.
4. this wreaked havoc on nightlies (or any other tasks which need the instances to live more than 15 minutes.

Solution: fetch instance id using the imdsv2-recommended incantation.

## Test Plan

Run a ~30 minute experiment on aws cluster; the agents shouldn't spontaneously terminate mid-way.
Nightlies should work.

## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist
- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
