### PR TITLE
docs: Slurm/PBS override of default resource pools

### DIFF
--- a/docs/cluster-setup-guide/deploy-cluster/sysadmin-deploy-on-slurm/slurm-requirements.rst
+++ b/docs/cluster-setup-guide/deploy-cluster/sysadmin-deploy-on-slurm/slurm-requirements.rst
@@ -83,7 +83,9 @@ recommended to optimize how Determined interacts with Slurm:
 
    -  A Slurm partition with no GPUs is identified as an AUX resource pool.
 
-   -  The Determined default resource pool is set to the Slurm default partition.
+   -  The Determined default resource pool is set to the Slurm default partition. Override this
+      default using the :ref:`slurm section <cluster-configuration-slurm>`
+      ``default_compute_resource_pool`` or ``default_aux_resource_pool`` option.
 
 -  Tune the Slurm configuration for Determined job preemption.
 
@@ -125,7 +127,9 @@ to optimize how Determined interacts with PBS:
 
    -  A PBS queue with no GPUs is identified as an AUX resource pool.
 
-   -  The Determined default resource pool is set to the PBS default queue.
+   -  The Determined default resource pool is set to the PBS default queue. Override this default
+      using the :ref:`pbs section <cluster-configuration-slurm>` ``default_compute_resource_pool``
+      or ``default_aux_resource_pool`` option.
 
 -  Tune the PBS configuration for Determined job preemption.
 

--- a/docs/reference/reference-deploy/config/master-config-reference.rst
+++ b/docs/reference/reference-deploy/config/master-config-reference.rst
@@ -327,6 +327,14 @@ The master supports the following configuration settings:
          -  ``task_container_defaults`` (See :ref:`top-level setting
             <master-task-container-defaults>`)
 
+      -  ``default_aux_resource_pool``: The default resource pool to use for tasks that do not need
+         dedicated compute resources, auxiliary, or systems tasks. Defaults to the Slurm/PBS default
+         partition if no resource pool is specified.
+
+      -  ``default_compute_resource_pool``: The default resource pool to use for tasks that require
+         compute resources, e.g. GPUs or dedicated CPUs. Defaults to the Slurm/PBS default partition
+         if it has GPU resources and if no resource pool is specified.
+
 -  ``resource_pools``: A list of resource pools. A resource pool is a collection of identical
    computational resources. Users can specify which resource pool a job should be assigned to when
    the job is submitted. Refer to the documentation on :ref:`resource-pools` for more information.


### PR DESCRIPTION
## Description

Add user doc for default_aux_resource_pool and default_compute_resource_pool.

![image](https://user-images.githubusercontent.com/84593277/204575531-a5b10d27-89dd-4e34-b9bd-0f226cced059.png)
and
![image](https://user-images.githubusercontent.com/84593277/204583548-fecaa896-a8d7-49e7-b194-95f13527dadf.png)


Using the same phrasing from the Agent version of this setting:

![image](https://user-images.githubusercontent.com/84593277/204575697-68926be1-5f39-44ce-a993-508ce86cefa1.png)


## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions about this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist
- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
