### PR TITLE
ci: fix test_workspace_org

### DIFF
--- a/e2e_tests/tests/cluster/test_workspace_org.py
+++ b/e2e_tests/tests/cluster/test_workspace_org.py
@@ -8,7 +8,7 @@ import pytest
 from determined.common import api
 from determined.common.api import authentication, bindings, errors
 from tests import config as conf
-from tests.cluster.test_users import ADMIN_CREDENTIALS
+from tests.cluster.test_users import ADMIN_CREDENTIALS, change_user_password, logged_in_user
 from tests.experiment import determined_test_session, run_basic_test, wait_for_experiment_state
 
 from .test_agent_user_group import _delete_workspace_and_check
@@ -17,6 +17,8 @@ from .test_groups import det_cmd, det_cmd_json
 
 @pytest.mark.e2e_cpu
 def test_workspace_org() -> None:
+    with logged_in_user(ADMIN_CREDENTIALS):
+        change_user_password("determined", "")
     master_url = conf.make_master_url()
     authentication.cli_auth = authentication.Authentication(master_url, try_reauth=True)
     sess = api.Session(master_url, None, None, None)


### PR DESCRIPTION
## Description

Adding this fix to ensure that determined credentials are set correctly. Ideally, wherever they were changed it would be set back to default but it's tough to figure out where so just doing this for now. 

## Test Plan

No testing required. 