### PR TITLE
fix: rbac describe role fails with --json flag

### DIFF
--- a/harness/determined/cli/rbac.py
+++ b/harness/determined/cli/rbac.py
@@ -242,7 +242,7 @@ def describe_role(args: Namespace) -> None:
     req = bindings.v1GetRolesByIDRequest(roleIds=[role_id])
     resp = bindings.post_GetRolesByID(session, body=req)
     if args.json:
-        print(json.dumps(resp.roles[0] if resp.roles else None, indent=2))
+        print(json.dumps(resp.roles[0].to_json() if resp.roles else None, indent=2))
         return
 
     if resp.roles is None or len(resp.roles) != 1:


### PR DESCRIPTION
## Description

Fixes EE test regression of describe role failing with --json flag.

## Test Plan

CI passes here https://github.com/determined-ai/determined-ee/pull/571

## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist
- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
