### PR TITLE
chore: changes k8s unable to find exit status from 137 -> 1025 [DET-8717]

### DIFF
--- a/docs/release-notes/k8s-dont-set-exit-code-to-ones-people-think-oom.rst
+++ b/docs/release-notes/k8s-dont-set-exit-code-to-ones-people-think-oom.rst
@@ -1,0 +1,6 @@
+:orphan:
+
+**Improvements**
+
+-  Kubernetes: If a pod exits and Determined can not get the exit status, the code will be set to
+   1025 instead of the previously set 137 to avoid confusion with potential out of memory issues.

--- a/master/internal/rm/kubernetesrm/pod.go
+++ b/master/internal/rm/kubernetesrm/pod.go
@@ -305,9 +305,9 @@ func (p *pod) receivePodStatusUpdate(ctx *actor.Context, msg podStatusUpdate) er
 			// determined containers generates an exit code. To check if this is
 			// the case we check if a deletion timestamp has been set.
 			if p.pod.ObjectMeta.DeletionTimestamp != nil {
-				ctx.Log().Info("unable to get exit code for pod setting exit code to 137")
-				exitCode = 137
-				exitMessage = ""
+				ctx.Log().Info("unable to get exit code for pod setting exit code to 1025")
+				exitCode = 1025
+				exitMessage = "unable to get exit code or exit message from pod"
 			} else {
 				return err
 			}

--- a/master/internal/rm/kubernetesrm/pod.go
+++ b/master/internal/rm/kubernetesrm/pod.go
@@ -305,7 +305,7 @@ func (p *pod) receivePodStatusUpdate(ctx *actor.Context, msg podStatusUpdate) er
 			// determined containers generates an exit code. To check if this is
 			// the case we check if a deletion timestamp has been set.
 			if p.pod.ObjectMeta.DeletionTimestamp != nil {
-				ctx.Log().Info("unable to get exit code for pod setting exit code to 1025")
+				ctx.Log().Info("unable to get exit code for pod, setting exit code to 1025")
 				exitCode = 1025
 				exitMessage = "unable to get exit code or exit message from pod"
 			} else {


### PR DESCRIPTION
## Description

Previously when we can't find an exit status for a pod we would give 137. While technically semantically correct googling exit status 137 k8s could be confusing causing people to think the pod was OOM killed. This change uses 1025 and includes a message explaining we can't find the pod exit code.

## Test Plan

On a k8s cluster

Run a command with an image not pulled yet
```
det cmd run --config="environment.image=determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-mpi-0.19.4" sleep 100
```

Kill pod
```
kubectl get pods
kubectl delete pod $pod
```

Verify ```det cmd``` output shows this message

```
2bf0948d-149a-446e-8654-612eaf724802 | determined | Command (formally-united-gorilla) | TERMINATED | resources failed with non-zero exit code: unable to get exit code or exit message from pod (exit code 1025) | kubernetes
```

## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist
- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
