### PR TITLE
chore: minor fixups

### DIFF
--- a/harness/determined/common/api/experiment.py
+++ b/harness/determined/common/api/experiment.py
@@ -4,7 +4,7 @@ import random
 import sys
 import time
 import uuid
-from typing import Any, Dict, Optional, Sequence, Tuple
+from typing import Any, Dict, List, Optional, Sequence, Tuple
 
 from termcolor import colored
 
@@ -154,9 +154,9 @@ def create_experiment(
     try:
         j = r.json()
     except json.decoder.JSONDecodeError:
-        warnings: Optional[list[bindings.v1LaunchWarning]] = None
+        warnings: Optional[List[bindings.v1LaunchWarning]] = None
     else:
-        response_warnings: Optional[list[int]] = j.get("warnings")
+        response_warnings: Optional[List[int]] = j.get("warnings")
         if response_warnings:
             launch_warnings = list(bindings.v1LaunchWarning)
             warnings = [launch_warnings[warning] for warning in response_warnings]

--- a/harness/determined/experimental/client.py
+++ b/harness/determined/experimental/client.py
@@ -49,7 +49,7 @@ import pathlib
 import warnings
 from typing import Any, Callable, Dict, Iterable, List, Optional, Sequence, Union
 
-from determined.common.api import Session, bindings  # noqa: F401
+from determined.common.api import Session  # noqa: F401
 from determined.common.experimental.checkpoint import (  # noqa: F401
     Checkpoint,
     CheckpointState,


### PR DESCRIPTION
## Commentary

One issue here was accidentally adding a private module into a public namespace.

Of course, since it's a file-level module, we don't have the world's best namespace hygiene anyway, but at least the other symbols in the `client` namespace are all stdlib symbols.

The other thing here is a mypy fix.  Not sure why our ci didn't catch it, but I see it locally.
