### PR TITLE
test: speed up nightly `test_protein_pytorch_geometric`.

### DIFF
--- a/examples/graphs/proteins_pytorch_geometric/startup-hook.sh
+++ b/examples/graphs/proteins_pytorch_geometric/startup-hook.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 pip install torch_geometric==2.0.4
-pip install torch_sparse torch_scatter -f https://pytorch-geometric.com/whl/torch-1.10.2+cu113.html
+pip install torch_sparse==0.6.13 torch_scatter==2.0.9 -f https://pytorch-geometric.com/whl/torch-1.10.2+cu113.html


### PR DESCRIPTION
## Description

pytorch geometric repo was missing wheels for latest `torch_scatter` and `torch_sparse` for our older pytorch and cuda. this caused `pip install` to build these from source which takes a ton of time, and sometimes makes the test timeout.

pin these packages to the last prebuilt wheel version.

## Test Plan

- Nightlies are less flaky.

## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist
- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
