### PR TITLE
docs: Document PBS CUDA_VISIBLE_DEVICES requirement [FOUNDENG-359]

### DIFF
--- a/docs/cluster-setup-guide/deploy-cluster/sysadmin-deploy-on-slurm/slurm-requirements.rst
+++ b/docs/cluster-setup-guide/deploy-cluster/sysadmin-deploy-on-slurm/slurm-requirements.rst
@@ -117,12 +117,11 @@ to optimize how Determined interacts with PBS:
    specifying a PBS constraint in the experiment configuration.
 
    PBS should be configured to provide the environment variable ``CUDA_VISIBLE_DEVICES``
-   (``ROCR_VISIBLE_DEVICES`` for ROCm) to the job based upon the GPUs allocated. If PBS is not
-   configured to provide ``CUDA_VISIBLE_DEVICES``, Determined will utilize a single GPU on each
-   node. To fully utilize mutliple GPUs, you must either manually define ``CUDA_VISIBLE_DEVICES`` or
-   provide the ``pbs.slots_per_node`` setting in your experiment configuration to indicate how many
-   GPU slots are available for use. The format of ``CUDA_VISIBLE_DEVICES`` is an array of GPU IDs
-   (e.g. ``[0,1,2,3]`` which indicates the four GPUS 0 through 3).
+   (``ROCR_VISIBLE_DEVICES`` for ROCm) using a PBS cgroup hook as described in the PBS
+   Administrator's Guide. If PBS is not configured to set ``CUDA_VISIBLE_DEVICES``, Determined will
+   utilize a single GPU on each node. To fully utilize multiple GPUs, you must either manually
+   define ``CUDA_VISIBLE_DEVICES`` appropriately or provide the ``pbs.slots_per_node`` setting in
+   your experiment configuration to indicate how many GPU slots are intended for Determined to use.
 
 -  Ensure homogeneous PBS queues.
 


### PR DESCRIPTION

## Description

Add more details based upon review feedback.

![image](https://user-images.githubusercontent.com/84593277/204907443-7f0f930d-4427-4446-addf-d5a9a191c553.png)


## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions about this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist
- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
