### PR TITLE
fix: nightly test for custom searcher

### DIFF
--- a/e2e_tests/tests/experiment/test_custom_searcher.py
+++ b/e2e_tests/tests/experiment/test_custom_searcher.py
@@ -3,7 +3,7 @@ import pathlib
 import subprocess
 import tempfile
 import time
-from typing import Generator, List, Optional
+from typing import Iterator, List, Optional
 
 import pytest
 import yaml
@@ -20,7 +20,7 @@ TIMESTAMP = int(time.time())
 
 
 @pytest.fixture
-def client_login() -> Generator[None, None, None]:
+def client_login() -> Iterator[None]:
     client.login(master=conf.make_master_url())
     yield
     client._determined = None

--- a/e2e_tests/tests/experiment/test_custom_searcher.py
+++ b/e2e_tests/tests/experiment/test_custom_searcher.py
@@ -3,7 +3,7 @@ import pathlib
 import subprocess
 import tempfile
 import time
-from typing import List, Optional
+from typing import Generator, List, Optional
 
 import pytest
 import yaml
@@ -17,6 +17,13 @@ from tests import experiment as exp
 from tests.fixtures.custom_searcher import searchers
 
 TIMESTAMP = int(time.time())
+
+
+@pytest.fixture
+def client_login() -> Generator[None, None, None]:
+    client.login(master=conf.make_master_url())
+    yield
+    client._determined = None
 
 
 @pytest.mark.e2e_cpu
@@ -293,9 +300,7 @@ def test_resume_random_searcher_exp(exceptions: List[str]) -> None:
 
 
 @pytest.mark.nightly
-def test_run_asha_batches_exp(tmp_path: pathlib.Path) -> None:
-    # init client with non default master url
-    client.login(master=conf.make_master_url())
+def test_run_asha_batches_exp(tmp_path: pathlib.Path, client_login: None) -> None:
     config = conf.load_config(conf.fixtures_path("no_op/adaptive.yaml"))
     config["searcher"] = {
         "name": "custom",
@@ -339,9 +344,6 @@ def test_run_asha_batches_exp(tmp_path: pathlib.Path) -> None:
 
     for trial in response_trials:
         assert trial.state == bindings.determinedexperimentv1State.STATE_COMPLETED
-
-    # clean up
-    client._determined = None
 
 
 @pytest.mark.e2e_cpu_2a
@@ -453,9 +455,7 @@ def test_run_asha_searcher_exp_core_api(
         ],
     ],
 )
-def test_resume_asha_batches_exp(exceptions: List[str]) -> None:
-    # init client with non default master url
-    client.login(master=conf.make_master_url())
+def test_resume_asha_batches_exp(exceptions: List[str], client_login: None) -> None:
     config = conf.load_config(conf.fixtures_path("no_op/adaptive.yaml"))
     config["searcher"] = {
         "name": "custom",
@@ -532,9 +532,6 @@ def test_resume_asha_batches_exp(exceptions: List[str]) -> None:
         assert trial.state == bindings.determinedexperimentv1State.STATE_COMPLETED
 
     assert search_method.progress(search_runner.state) == pytest.approx(1.0)
-
-    # clean up
-    client._determined = None
 
 
 class FallibleSearchRunner(searcher.LocalSearchRunner):

--- a/e2e_tests/tests/experiment/test_custom_searcher.py
+++ b/e2e_tests/tests/experiment/test_custom_searcher.py
@@ -294,6 +294,8 @@ def test_resume_random_searcher_exp(exceptions: List[str]) -> None:
 
 @pytest.mark.nightly
 def test_run_asha_batches_exp(tmp_path: pathlib.Path) -> None:
+    # init client with non default master url
+    client.login(master=conf.make_master_url())
     config = conf.load_config(conf.fixtures_path("no_op/adaptive.yaml"))
     config["searcher"] = {
         "name": "custom",
@@ -337,6 +339,9 @@ def test_run_asha_batches_exp(tmp_path: pathlib.Path) -> None:
 
     for trial in response_trials:
         assert trial.state == bindings.determinedexperimentv1State.STATE_COMPLETED
+
+    # clean up
+    client._determined = None
 
 
 @pytest.mark.e2e_cpu_2a
@@ -449,6 +454,8 @@ def test_run_asha_searcher_exp_core_api(
     ],
 )
 def test_resume_asha_batches_exp(exceptions: List[str]) -> None:
+    # init client with non default master url
+    client.login(master=conf.make_master_url())
     config = conf.load_config(conf.fixtures_path("no_op/adaptive.yaml"))
     config["searcher"] = {
         "name": "custom",
@@ -525,6 +532,9 @@ def test_resume_asha_batches_exp(exceptions: List[str]) -> None:
         assert trial.state == bindings.determinedexperimentv1State.STATE_COMPLETED
 
     assert search_method.progress(search_runner.state) == pytest.approx(1.0)
+
+    # clean up
+    client._determined = None
 
 
 class FallibleSearchRunner(searcher.LocalSearchRunner):


### PR DESCRIPTION
## Description

Nightly tests typically start experiments through `det -m master_url e create ...` where master url is created based on values on MASTER_HOST and MASTER_PORT. Custom Searcher is using DET_MASTER env variable, and since it is not set, it defaults to localhost:8080 and fails since master is not there. 

Solution: in nightly custom searcher test, use client.login(master_url) to create a singleton object connecting to the master that will be re-used later. At the end of the test,  set the singleton to None to make sure other tests will not use the same objects again.

<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At a minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions about this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist
- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
