### PR TITLE
chore: Moving active experiment and task queries to separate stores [WEB-581] [WEB-582]

### DIFF
--- a/webui/react/src/contexts/Store.tsx
+++ b/webui/react/src/contexts/Store.tsx
@@ -27,14 +27,6 @@ interface OmnibarState {
 }
 
 interface State {
-  activeExperiments: number;
-  activeTasks: {
-    commands: number;
-    notebooks: number;
-    shells: number;
-    tensorboards: number;
-  };
-
   auth: Auth & { checked: boolean };
 
   info: DeterminedInfo;
@@ -59,12 +51,6 @@ export const StoreAction = {
   ResetAuth: 'ResetAuth',
 
   ResetAuthCheck: 'ResetAuthCheck',
-
-  // Active Experiments
-  SetActiveExperiments: 'SetActiveExperiments',
-
-  // Tasks
-  SetActiveTasks: 'SetActiveTasks',
 
   // Agents
   SetAgents: 'SetAgents',
@@ -114,16 +100,6 @@ type Action =
   | { type: typeof StoreAction.SetPinnedWorkspaces; value: Workspace[] }
   | { type: typeof StoreAction.HideOmnibar }
   | { type: typeof StoreAction.ShowOmnibar }
-  | {
-      type: typeof StoreAction.SetActiveTasks;
-      value: {
-        commands: number;
-        notebooks: number;
-        shells: number;
-        tensorboards: number;
-      };
-    }
-  | { type: typeof StoreAction.SetActiveExperiments; value: number }
   | { type: typeof StoreAction.SetKnownRoles; value: UserRole[] }
   | { type: typeof StoreAction.SetUserRoles; value: UserRole[] }
   | { type: typeof StoreAction.SetUserAssignments; value: UserAssignment[] };
@@ -147,13 +123,6 @@ export const initInfo: DeterminedInfo = {
 };
 
 const initState: State = {
-  activeExperiments: 0,
-  activeTasks: {
-    commands: 0,
-    notebooks: 0,
-    shells: 0,
-    tensorboards: 0,
-  },
   auth: initAuth,
   info: initInfo,
   knownRoles: [],
@@ -239,12 +208,6 @@ const reducer = (state: State, action: Action): State => {
     case StoreAction.ShowOmnibar:
       if (state.ui.omnibar.isShowing) return state;
       return { ...state, ui: { ...state.ui, omnibar: { ...state.ui.omnibar, isShowing: true } } };
-    case StoreAction.SetActiveExperiments:
-      if (isEqual(state.activeExperiments, action.value)) return state;
-      return { ...state, activeExperiments: action.value };
-    case StoreAction.SetActiveTasks:
-      if (isEqual(state.activeTasks, action.value)) return state;
-      return { ...state, activeTasks: action.value };
     case StoreAction.SetKnownRoles:
       if (isEqual(state.knownRoles, action.value)) return state;
       return { ...state, knownRoles: action.value };

--- a/webui/react/src/hooks/useFetch.ts
+++ b/webui/react/src/hooks/useFetch.ts
@@ -1,10 +1,7 @@
 import { useCallback } from 'react';
 
-import { activeRunStates } from 'constants/states';
 import { StoreAction, useStoreDispatch } from 'contexts/Store';
 import {
-  getActiveTasks,
-  getExperiments,
   getInfo,
   getPermissionsSummary,
   getResourcePools,
@@ -12,31 +9,7 @@ import {
   getWorkspaces,
   listRoles,
 } from 'services/api';
-import { ErrorType } from 'shared/utils/error';
 import handleError from 'utils/error';
-
-export const useFetchActiveExperiments = (canceler: AbortController): (() => Promise<void>) => {
-  const storeDispatch = useStoreDispatch();
-
-  return useCallback(async (): Promise<void> => {
-    try {
-      const response = await getExperiments(
-        { limit: -2, states: activeRunStates },
-        { signal: canceler.signal },
-      );
-      storeDispatch({
-        type: StoreAction.SetActiveExperiments,
-        value: response.pagination.total || 0,
-      });
-    } catch (e) {
-      handleError({
-        message: 'Unable to fetch active experiments.',
-        silent: true,
-        type: ErrorType.Api,
-      });
-    }
-  }, [canceler, storeDispatch]);
-};
 
 export const useFetchInfo = (canceler: AbortController): (() => Promise<void>) => {
   const storeDispatch = useStoreDispatch();
@@ -73,19 +46,6 @@ export const useFetchResourcePools = (canceler?: AbortController): (() => Promis
       storeDispatch({ type: StoreAction.SetResourcePools, value: resourcePools });
     } catch (e) {
       handleError(e);
-    }
-  }, [canceler, storeDispatch]);
-};
-
-export const useFetchActiveTasks = (canceler: AbortController): (() => Promise<void>) => {
-  const storeDispatch = useStoreDispatch();
-
-  return useCallback(async (): Promise<void> => {
-    try {
-      const counts = await getActiveTasks({}, { signal: canceler.signal });
-      storeDispatch({ type: StoreAction.SetActiveTasks, value: counts });
-    } catch (e) {
-      handleError({ message: 'Unable to fetch task counts.', silent: true, type: ErrorType.Api });
     }
   }, [canceler, storeDispatch]);
 };

--- a/webui/react/src/pages/Cluster/ClusterOverallStats.test.tsx
+++ b/webui/react/src/pages/Cluster/ClusterOverallStats.test.tsx
@@ -7,6 +7,11 @@ import { TasksProvider } from 'stores/tasks';
 
 import { ClusterOverallStats } from './ClusterOverallStats';
 
+jest.mock('services/api', () => ({
+  getActiveTasks: () => Promise.resolve({ commands: 0, notebooks: 0, shells: 0, tensorboards: 0 }),
+  getExperiments: () => Promise.resolve({ experiments: [], pagination: { total: 0 } }),
+}));
+
 const setup = () => {
   const view = render(
     <StoreProvider>

--- a/webui/react/src/pages/Cluster/ClusterOverallStats.test.tsx
+++ b/webui/react/src/pages/Cluster/ClusterOverallStats.test.tsx
@@ -2,13 +2,19 @@ import { render } from '@testing-library/react';
 import React from 'react';
 
 import StoreProvider from 'contexts/Store';
+import { ExperimentsProvider } from 'stores/experiments';
+import { TasksProvider } from 'stores/tasks';
 
 import { ClusterOverallStats } from './ClusterOverallStats';
 
 const setup = () => {
   const view = render(
     <StoreProvider>
-      <ClusterOverallStats />
+      <ExperimentsProvider>
+        <TasksProvider>
+          <ClusterOverallStats />
+        </TasksProvider>
+      </ExperimentsProvider>
     </StoreProvider>,
   );
   return { view };

--- a/webui/react/src/pages/Cluster/ClusterOverallStats.tsx
+++ b/webui/react/src/pages/Cluster/ClusterOverallStats.tsx
@@ -79,12 +79,35 @@ export const ClusterOverallStats: React.FC = () => {
           </OverviewStats>
         ) : null}
         <OverviewStats title="Active Experiments">
-          {activeExperiments.pagination?.total ?? 0}
+          {Loadable.match(activeExperiments, {
+            Loaded: (activeExperiments) => activeExperiments.pagination?.total ?? 0,
+            NotLoaded: (): ReactNode => <Spinner />,
+          })}
         </OverviewStats>
-        <OverviewStats title="Active JupyterLabs">{activeTasks?.notebooks ?? 0}</OverviewStats>
-        <OverviewStats title="Active TensorBoards">{activeTasks?.tensorboards ?? 0}</OverviewStats>
-        <OverviewStats title="Active Shells">{activeTasks?.shells ?? 0}</OverviewStats>
-        <OverviewStats title="Active Commands">{activeTasks?.commands ?? 0}</OverviewStats>
+        <OverviewStats title="Active JupyterLabs">
+          {Loadable.match(activeTasks, {
+            Loaded: (activeTasks) => activeTasks.notebooks ?? 0,
+            NotLoaded: (): ReactNode => <Spinner />,
+          })}
+        </OverviewStats>
+        <OverviewStats title="Active TensorBoards">
+          {Loadable.match(activeTasks, {
+            Loaded: (activeTasks) => activeTasks.tensorboards ?? 0,
+            NotLoaded: (): ReactNode => <Spinner />,
+          })}
+        </OverviewStats>
+        <OverviewStats title="Active Shells">
+          {Loadable.match(activeTasks, {
+            Loaded: (activeTasks) => activeTasks.shells ?? 0,
+            NotLoaded: (): ReactNode => <Spinner />,
+          })}
+        </OverviewStats>
+        <OverviewStats title="Active Commands">
+          {Loadable.match(activeTasks, {
+            Loaded: (activeTasks) => activeTasks.commands ?? 0,
+            NotLoaded: (): ReactNode => <Spinner />,
+          })}
+        </OverviewStats>
       </Grid>
     </Section>
   );

--- a/webui/react/src/pages/Cluster/ClusterOverallStats.tsx
+++ b/webui/react/src/pages/Cluster/ClusterOverallStats.tsx
@@ -81,30 +81,10 @@ export const ClusterOverallStats: React.FC = () => {
         <OverviewStats title="Active Experiments">
           {activeExperiments.pagination?.total ?? 0}
         </OverviewStats>
-        <OverviewStats title="Active JupyterLabs">
-          {Loadable.match(activeTasks, {
-            Loaded: (activeTasks) => activeTasks.notebooks,
-            NotLoaded: (): ReactNode => <Spinner />,
-          })}
-        </OverviewStats>
-        <OverviewStats title="Active TensorBoards">
-          {Loadable.match(activeTasks, {
-            Loaded: (activeTasks) => activeTasks.tensorboards,
-            NotLoaded: (): ReactNode => <Spinner />,
-          })}
-        </OverviewStats>
-        <OverviewStats title="Active Shells">
-          {Loadable.match(activeTasks, {
-            Loaded: (activeTasks) => activeTasks.shells,
-            NotLoaded: (): ReactNode => <Spinner />,
-          })}
-        </OverviewStats>
-        <OverviewStats title="Active Commands">
-          {Loadable.match(activeTasks, {
-            Loaded: (activeTasks) => activeTasks.commands,
-            NotLoaded: (): ReactNode => <Spinner />,
-          })}
-        </OverviewStats>
+        <OverviewStats title="Active JupyterLabs">{activeTasks?.notebooks ?? 0}</OverviewStats>
+        <OverviewStats title="Active TensorBoards">{activeTasks?.tensorboards ?? 0}</OverviewStats>
+        <OverviewStats title="Active Shells">{activeTasks?.shells ?? 0}</OverviewStats>
+        <OverviewStats title="Active Commands">{activeTasks?.commands ?? 0}</OverviewStats>
       </Grid>
     </Section>
   );

--- a/webui/react/src/pages/Cluster/ClusterOverallStats.tsx
+++ b/webui/react/src/pages/Cluster/ClusterOverallStats.tsx
@@ -6,6 +6,8 @@ import Section from 'components/Section';
 import { useStore } from 'contexts/Store';
 import Spinner from 'shared/components/Spinner';
 import { useAgents, useClusterOverview } from 'stores/agents';
+import { useExperiments } from 'stores/experiments';
+import { useTasks } from 'stores/tasks';
 import { ShirtSize } from 'themes';
 import { ResourceType } from 'types';
 import { Loadable } from 'utils/loadable';
@@ -13,9 +15,11 @@ import { Loadable } from 'utils/loadable';
 import { maxClusterSlotCapacity } from '../Clusters/ClustersOverview';
 
 export const ClusterOverallStats: React.FC = () => {
-  const { activeExperiments, activeTasks, resourcePools } = useStore();
+  const { resourcePools } = useStore();
   const overview = useClusterOverview();
   const agents = useAgents();
+  const activeExperiments = useExperiments(); // { active: true }
+  const activeTasks = useTasks(); // { active: true }
 
   const auxContainers = useMemo(() => {
     const tally = {
@@ -59,21 +63,36 @@ export const ClusterOverallStats: React.FC = () => {
             {auxContainers.running} <small>/ {auxContainers.total}</small>
           </OverviewStats>
         ) : null}
-        {activeExperiments ? (
-          <OverviewStats title="Active Experiments">{activeExperiments}</OverviewStats>
-        ) : null}
-        {activeTasks.notebooks ? (
-          <OverviewStats title="Active JupyterLabs">{activeTasks.notebooks}</OverviewStats>
-        ) : null}
-        {activeTasks.tensorboards ? (
-          <OverviewStats title="Active TensorBoards">{activeTasks.tensorboards}</OverviewStats>
-        ) : null}
-        {activeTasks.shells ? (
-          <OverviewStats title="Active Shells">{activeTasks.shells}</OverviewStats>
-        ) : null}
-        {activeTasks.commands ? (
-          <OverviewStats title="Active Commands">{activeTasks.commands}</OverviewStats>
-        ) : null}
+        <OverviewStats title="Active Experiments">
+          {Loadable.match(activeExperiments, {
+            Loaded: (activeExperiments) => (activeExperiments ? activeExperiments.length : '?'),
+            NotLoaded: (): ReactNode => <Spinner />,
+          })}
+        </OverviewStats>
+        <OverviewStats title="Active JupyterLabs">
+          {Loadable.match(activeTasks, {
+            Loaded: (activeTasks) => activeTasks.notebooks,
+            NotLoaded: (): ReactNode => <Spinner />,
+          })}
+        </OverviewStats>
+        <OverviewStats title="Active TensorBoards">
+          {Loadable.match(activeTasks, {
+            Loaded: (activeTasks) => activeTasks.tensorboards,
+            NotLoaded: (): ReactNode => <Spinner />,
+          })}
+        </OverviewStats>
+        <OverviewStats title="Active Shells">
+          {Loadable.match(activeTasks, {
+            Loaded: (activeTasks) => activeTasks.shells,
+            NotLoaded: (): ReactNode => <Spinner />,
+          })}
+        </OverviewStats>
+        <OverviewStats title="Active Commands">
+          {Loadable.match(activeTasks, {
+            Loaded: (activeTasks) => activeTasks.commands,
+            NotLoaded: (): ReactNode => <Spinner />,
+          })}
+        </OverviewStats>
       </Grid>
     </Section>
   );

--- a/webui/react/src/pages/Clusters/ClustersOverview.tsx
+++ b/webui/react/src/pages/Clusters/ClustersOverview.tsx
@@ -12,8 +12,6 @@ import { V1ResourcePoolType } from 'services/api-ts-sdk';
 import usePolling from 'shared/hooks/usePolling';
 import { percent } from 'shared/utils/number';
 import { useEnsureAgentsFetched } from 'stores/agents';
-import { useEnsureActiveExperimentsFetched } from 'stores/experiments';
-import { useEnsureActiveTasksFetched } from 'stores/tasks';
 import { ShirtSize } from 'themes';
 import { Agent, ClusterOverview as Overview, ResourcePool, ResourceType } from 'types';
 
@@ -93,8 +91,6 @@ const ClusterOverview: React.FC = () => {
 
   const [canceler] = useState(new AbortController());
 
-  const fetchActiveExperiments = useEnsureActiveExperimentsFetched(canceler);
-  const fetchActiveTasks = useEnsureActiveTasksFetched(canceler);
   const fetchAgents = useEnsureAgentsFetched(canceler);
   const fetchResourcePools = useFetchResourcePools(canceler);
 
@@ -103,11 +99,9 @@ const ClusterOverview: React.FC = () => {
   const hideModal = useCallback(() => setRpDetail(undefined), []);
 
   useEffect(() => {
-    fetchActiveExperiments();
-    fetchActiveTasks();
     fetchAgents();
     return () => canceler.abort();
-  }, [canceler, fetchActiveExperiments, fetchActiveTasks, fetchAgents]);
+  }, [canceler, fetchAgents]);
 
   return (
     <div className={css.base}>

--- a/webui/react/src/pages/Clusters/ClustersOverview.tsx
+++ b/webui/react/src/pages/Clusters/ClustersOverview.tsx
@@ -6,16 +6,14 @@ import ResourcePoolCard from 'components/ResourcePoolCard';
 import ResourcePoolDetails from 'components/ResourcePoolDetails';
 import Section from 'components/Section';
 import { useStore } from 'contexts/Store';
-import {
-  useFetchActiveExperiments,
-  useFetchActiveTasks,
-  useFetchResourcePools,
-} from 'hooks/useFetch';
+import { useFetchResourcePools } from 'hooks/useFetch';
 import { paths } from 'routes/utils';
 import { V1ResourcePoolType } from 'services/api-ts-sdk';
 import usePolling from 'shared/hooks/usePolling';
 import { percent } from 'shared/utils/number';
 import { useEnsureAgentsFetched } from 'stores/agents';
+import { useEnsureActiveExperimentsFetched } from 'stores/experiments';
+import { useEnsureActiveTasksFetched } from 'stores/tasks';
 import { ShirtSize } from 'themes';
 import { Agent, ClusterOverview as Overview, ResourcePool, ResourceType } from 'types';
 
@@ -95,26 +93,21 @@ const ClusterOverview: React.FC = () => {
 
   const [canceler] = useState(new AbortController());
 
-  const fetchActiveExperiments = useFetchActiveExperiments(canceler);
-  const fetchActiveTasks = useFetchActiveTasks(canceler);
+  const fetchActiveExperiments = useEnsureActiveExperimentsFetched(canceler);
+  const fetchActiveTasks = useEnsureActiveTasksFetched(canceler);
   const fetchAgents = useEnsureAgentsFetched(canceler);
   const fetchResourcePools = useFetchResourcePools(canceler);
 
-  const fetchActiveRunning = useCallback(async () => {
-    await fetchActiveExperiments();
-    await fetchActiveTasks();
-  }, [fetchActiveExperiments, fetchActiveTasks]);
-
-  usePolling(fetchActiveRunning);
   usePolling(fetchResourcePools, { interval: 10000 });
 
   const hideModal = useCallback(() => setRpDetail(undefined), []);
 
   useEffect(() => {
+    fetchActiveExperiments();
+    fetchActiveTasks();
     fetchAgents();
-
     return () => canceler.abort();
-  }, [canceler, fetchAgents]);
+  }, [canceler, fetchActiveExperiments, fetchActiveTasks, fetchAgents]);
 
   return (
     <div className={css.base}>

--- a/webui/react/src/stores/experiments.tsx
+++ b/webui/react/src/stores/experiments.tsx
@@ -20,7 +20,7 @@ type ExperimentsContext = {
 
 const ExperimentsContext = createContext<ExperimentsContext | null>(null);
 
-const encodeArgs = (args: { [key: string]: any }): string => {
+const encodeParams = (args: { [key: string]: any }): string => {
   const orderedKeys = Object.keys(args).sort();
   return orderedKeys.map((key: string) => `${key}=${JSON.stringify(args[key])}`).join(',');
 };
@@ -37,8 +37,8 @@ export const ExperimentsProvider: React.FC<PropsWithChildren> = ({ children }) =
 };
 
 export const useFetchExperiments = (
-  filters: GetExperimentsParams,
   canceler: AbortController,
+  params: GetExperimentsParams,
 ): (() => Promise<void>) => {
   const context = useContext(ExperimentsContext);
   if (context === null) {
@@ -48,20 +48,20 @@ export const useFetchExperiments = (
 
   return useCallback(async (): Promise<void> => {
     try {
-      const response = await getExperiments(filters, { signal: canceler.signal });
-      updateExperimentsIndex(experimentsIndex.set(encodeArgs(filters), response));
+      const response = await getExperiments(params, { signal: canceler.signal });
+      updateExperimentsIndex(experimentsIndex.set(encodeParams(params), response));
     } catch (e) {
       handleError(e);
     }
-  }, [canceler, experimentsIndex, filters, getExperiments, updateExperimentsIndex]);
+  }, [canceler, experimentsIndex, params, getExperiments, updateExperimentsIndex]);
 };
 
-export const useExperiments = (filters: GetExperimentsParams): Loadable<ExperimentPagination> => {
+export const useExperiments = (params: GetExperimentsParams): Loadable<ExperimentPagination> => {
   const context = useContext(ExperimentsContext);
   if (context === null) {
     throw new Error('Attempted to use useExperiments outside of Experiment Context');
   }
-  const loadedVal = context.experimentsIndex.get(encodeArgs(filters));
+  const loadedVal = context.experimentsIndex.get(encodeParams(params));
 
   return loadedVal ? Loaded(loadedVal) : NotLoaded;
 };

--- a/webui/react/src/stores/experiments.tsx
+++ b/webui/react/src/stores/experiments.tsx
@@ -1,75 +1,71 @@
+import { Map } from 'immutable';
 import React, { createContext, PropsWithChildren, useCallback, useContext, useState } from 'react';
 
-import { activeRunStates } from 'constants/states';
 import { getExperiments } from 'services/api';
+import { V1Pagination } from 'services/api-ts-sdk';
+import { GetExperimentsParams } from 'services/types';
 import { ExperimentItem } from 'types';
 import handleError from 'utils/error';
-import { Loadable, Loaded, NotLoaded } from 'utils/loadable';
+
+type ExperimentPagination = {
+  experiments: ExperimentItem[];
+  pagination?: V1Pagination;
+};
 
 type ExperimentsContext = {
-  experiments: Loadable<ExperimentItem[]>;
-  updateExperiments: (fn: (ws: Loadable<ExperimentItem[]>) => Loadable<ExperimentItem[]>) => void;
+  experimentsIndex: Map<string, ExperimentPagination>;
+  updateExperimentsIndex: (ws: Map<string, ExperimentPagination>) => void;
 };
 
 const ExperimentsContext = createContext<ExperimentsContext | null>(null);
 
+const encodeArgs = (args: { [key: string]: any }): string => {
+  const orderedKeys = Object.keys(args).sort();
+  return orderedKeys.map((key: string) => `${key}=${JSON.stringify(args[key])}`).join(',');
+};
+
 export const ExperimentsProvider: React.FC<PropsWithChildren> = ({ children }) => {
-  const [state, setState] = useState<Loadable<ExperimentItem[]>>(NotLoaded);
+  const [experimentsIndex, updateExperimentsIndex] = useState<Map<string, ExperimentPagination>>(
+    Map<string, ExperimentPagination>(),
+  );
   return (
-    <ExperimentsContext.Provider value={{ experiments: state, updateExperiments: setState }}>
+    <ExperimentsContext.Provider value={{ experimentsIndex, updateExperimentsIndex }}>
       {children}
     </ExperimentsContext.Provider>
   );
 };
 
-export const useFetchExperiments = (canceler: AbortController): (() => Promise<void>) => {
-  const context = useContext(ExperimentsContext);
-  if (context === null) {
-    throw new Error('Attempted to use useFetchExperiments outside of Experiment Context');
-  }
-  const { updateExperiments } = context;
-
-  return useCallback(async (): Promise<void> => {
-    try {
-      const response = await getExperiments({}, { signal: canceler.signal });
-      updateExperiments(() => Loaded(response.experiments));
-    } catch (e) {
-      handleError(e);
-    }
-  }, [canceler, updateExperiments]);
-};
-
-export const useEnsureActiveExperimentsFetched = (
+export const useFetchExperiments = (
+  filters: GetExperimentsParams,
   canceler: AbortController,
 ): (() => Promise<void>) => {
   const context = useContext(ExperimentsContext);
   if (context === null) {
-    throw new Error(
-      'Attempted to use useEnsureActiveExperimentsFetched outside of Experiment Context',
-    );
+    throw new Error('Attempted to use useFetchExperiments outside of Experiment Context');
   }
-  const { experiments, updateExperiments } = context;
+  const { experimentsIndex, updateExperimentsIndex } = context;
 
   return useCallback(async (): Promise<void> => {
-    if (experiments !== NotLoaded) return;
     try {
-      const response = await getExperiments(
-        { limit: -2, states: activeRunStates },
-        { signal: canceler.signal },
+      const response = await getExperiments(filters, { signal: canceler.signal });
+      updateExperimentsIndex(
+        Map<string, ExperimentPagination>({
+          ...experimentsIndex,
+          [encodeArgs(filters)]: response,
+        }),
       );
-      updateExperiments(() => Loaded(response.experiments));
     } catch (e) {
       handleError(e);
     }
-  }, [canceler, experiments, updateExperiments]);
+  }, [canceler, experimentsIndex, filters, getExperiments, updateExperimentsIndex]);
 };
 
-export const useExperiments = (): Loadable<ExperimentItem[]> => {
+export const useExperiments = (filters: GetExperimentsParams): ExperimentPagination => {
   const context = useContext(ExperimentsContext);
   if (context === null) {
     throw new Error('Attempted to use useExperiments outside of Experiment Context');
   }
-  const { experiments } = context;
+  const { experimentsIndex } = context;
 
-  return experiments;
+  return experimentsIndex.get(encodeArgs(filters)) || { experiments: [] };
 };

--- a/webui/react/src/stores/experiments.tsx
+++ b/webui/react/src/stores/experiments.tsx
@@ -1,0 +1,75 @@
+import React, { createContext, PropsWithChildren, useCallback, useContext, useState } from 'react';
+
+import { activeRunStates } from 'constants/states';
+import { getExperiments } from 'services/api';
+import { ExperimentItem } from 'types';
+import handleError from 'utils/error';
+import { Loadable, Loaded, NotLoaded } from 'utils/loadable';
+
+type ExperimentsContext = {
+  experiments: Loadable<ExperimentItem[]>;
+  updateExperiments: (fn: (ws: Loadable<ExperimentItem[]>) => Loadable<ExperimentItem[]>) => void;
+};
+
+const ExperimentsContext = createContext<ExperimentsContext | null>(null);
+
+export const ExperimentsProvider: React.FC<PropsWithChildren> = ({ children }) => {
+  const [state, setState] = useState<Loadable<ExperimentItem[]>>(NotLoaded);
+  return (
+    <ExperimentsContext.Provider value={{ experiments: state, updateExperiments: setState }}>
+      {children}
+    </ExperimentsContext.Provider>
+  );
+};
+
+export const useFetchExperiments = (canceler: AbortController): (() => Promise<void>) => {
+  const context = useContext(ExperimentsContext);
+  if (context === null) {
+    throw new Error('Attempted to use useFetchExperiments outside of Experiment Context');
+  }
+  const { updateExperiments } = context;
+
+  return useCallback(async (): Promise<void> => {
+    try {
+      const response = await getExperiments({}, { signal: canceler.signal });
+      updateExperiments(() => Loaded(response.experiments));
+    } catch (e) {
+      handleError(e);
+    }
+  }, [canceler, updateExperiments]);
+};
+
+export const useEnsureActiveExperimentsFetched = (
+  canceler: AbortController,
+): (() => Promise<void>) => {
+  const context = useContext(ExperimentsContext);
+  if (context === null) {
+    throw new Error(
+      'Attempted to use useEnsureActiveExperimentsFetched outside of Experiment Context',
+    );
+  }
+  const { experiments, updateExperiments } = context;
+
+  return useCallback(async (): Promise<void> => {
+    if (experiments !== NotLoaded) return;
+    try {
+      const response = await getExperiments(
+        { limit: -2, states: activeRunStates },
+        { signal: canceler.signal },
+      );
+      updateExperiments(() => Loaded(response.experiments));
+    } catch (e) {
+      handleError(e);
+    }
+  }, [canceler, experiments, updateExperiments]);
+};
+
+export const useExperiments = (): Loadable<ExperimentItem[]> => {
+  const context = useContext(ExperimentsContext);
+  if (context === null) {
+    throw new Error('Attempted to use useExperiments outside of Experiment Context');
+  }
+  const { experiments } = context;
+
+  return experiments;
+};

--- a/webui/react/src/stores/experiments.tsx
+++ b/webui/react/src/stores/experiments.tsx
@@ -14,8 +14,8 @@ type ExperimentPagination = {
 };
 
 type ExperimentsContext = {
-  experimentsIndex: Map<string, ExperimentPagination>;
-  updateExperimentsIndex: (ws: Map<string, ExperimentPagination>) => void;
+  experimentsCache: Map<string, ExperimentPagination>;
+  updateExperimentsCache: (ws: Map<string, ExperimentPagination>) => void;
 };
 
 const ExperimentsContext = createContext<ExperimentsContext | null>(null);
@@ -24,11 +24,11 @@ const encodeParams = (params: { [key: string]: any }) =>
   JSON.stringify([...Object.entries(params ?? {})].sort());
 
 export const ExperimentsProvider: React.FC<PropsWithChildren> = ({ children }) => {
-  const [experimentsIndex, updateExperimentsIndex] = useState<Map<string, ExperimentPagination>>(
+  const [experimentsCache, updateExperimentsCache] = useState<Map<string, ExperimentPagination>>(
     Map<string, ExperimentPagination>(),
   );
   return (
-    <ExperimentsContext.Provider value={{ experimentsIndex, updateExperimentsIndex }}>
+    <ExperimentsContext.Provider value={{ experimentsCache, updateExperimentsCache }}>
       {children}
     </ExperimentsContext.Provider>
   );
@@ -42,16 +42,16 @@ export const useFetchExperiments = (
   if (context === null) {
     throw new Error('Attempted to use useFetchExperiments outside of Experiment Context');
   }
-  const { experimentsIndex, updateExperimentsIndex } = context;
+  const { experimentsCache, updateExperimentsCache } = context;
 
   return useCallback(async (): Promise<void> => {
     try {
       const response = await getExperiments(params, { signal: canceler.signal });
-      updateExperimentsIndex(experimentsIndex.set(encodeParams(params), response));
+      updateExperimentsCache(experimentsCache.set(encodeParams(params), response));
     } catch (e) {
       handleError(e);
     }
-  }, [canceler, experimentsIndex, params, updateExperimentsIndex]);
+  }, [canceler, experimentsCache, params, updateExperimentsCache]);
 };
 
 export const useExperiments = (params: GetExperimentsParams): Loadable<ExperimentPagination> => {
@@ -59,7 +59,7 @@ export const useExperiments = (params: GetExperimentsParams): Loadable<Experimen
   if (context === null) {
     throw new Error('Attempted to use useExperiments outside of Experiment Context');
   }
-  const loadedVal = context.experimentsIndex.get(encodeParams(params));
+  const loadedVal = context.experimentsCache.get(encodeParams(params));
 
   return loadedVal ? Loaded(loadedVal) : NotLoaded;
 };

--- a/webui/react/src/stores/experiments.tsx
+++ b/webui/react/src/stores/experiments.tsx
@@ -20,10 +20,8 @@ type ExperimentsContext = {
 
 const ExperimentsContext = createContext<ExperimentsContext | null>(null);
 
-const encodeParams = (args: { [key: string]: any }): string => {
-  const orderedKeys = Object.keys(args).sort();
-  return orderedKeys.map((key: string) => `${key}=${JSON.stringify(args[key])}`).join(',');
-};
+const encodeParams = (params: { [key: string]: any }) =>
+  JSON.stringify([...Object.entries(params ?? {})].sort());
 
 export const ExperimentsProvider: React.FC<PropsWithChildren> = ({ children }) => {
   const [experimentsIndex, updateExperimentsIndex] = useState<Map<string, ExperimentPagination>>(
@@ -37,8 +35,8 @@ export const ExperimentsProvider: React.FC<PropsWithChildren> = ({ children }) =
 };
 
 export const useFetchExperiments = (
-  canceler: AbortController,
   params: GetExperimentsParams,
+  canceler: AbortController,
 ): (() => Promise<void>) => {
   const context = useContext(ExperimentsContext);
   if (context === null) {
@@ -53,7 +51,7 @@ export const useFetchExperiments = (
     } catch (e) {
       handleError(e);
     }
-  }, [canceler, experimentsIndex, params, getExperiments, updateExperimentsIndex]);
+  }, [canceler, experimentsIndex, params, updateExperimentsIndex]);
 };
 
 export const useExperiments = (params: GetExperimentsParams): Loadable<ExperimentPagination> => {

--- a/webui/react/src/stores/index.tsx
+++ b/webui/react/src/stores/index.tsx
@@ -1,13 +1,19 @@
 import React, { ReactElement, ReactNode } from 'react';
 
 import { AgentsProvider } from './agents';
+import { ExperimentsProvider } from './experiments';
 import { ProjectsProvider } from './projects';
+import { TasksProvider } from './tasks';
 import { WorkspacesProvider } from './workspaces';
 
 export const StoreContext = ({ children }: { children: ReactNode }): ReactElement => (
   <AgentsProvider>
-    <WorkspacesProvider>
-      <ProjectsProvider>{children}</ProjectsProvider>
-    </WorkspacesProvider>
+    <ExperimentsProvider>
+      <TasksProvider>
+        <WorkspacesProvider>
+          <ProjectsProvider>{children}</ProjectsProvider>
+        </WorkspacesProvider>
+      </TasksProvider>
+    </ExperimentsProvider>
   </AgentsProvider>
 );

--- a/webui/react/src/stores/tasks.tsx
+++ b/webui/react/src/stores/tasks.tsx
@@ -6,8 +6,8 @@ import handleError from 'utils/error';
 import { Loadable, Loaded, NotLoaded } from 'utils/loadable';
 
 type TasksContext = {
-  tasks: Loadable<TaskCounts>;
-  updateTasks: (fn: (ws: Loadable<TaskCounts>) => Loadable<TaskCounts>) => void;
+  activeTasks: Loadable<TaskCounts>;
+  updateActiveTasks: (fn: (ws: Loadable<TaskCounts>) => Loadable<TaskCounts>) => void;
 };
 
 const TasksContext = createContext<TasksContext | null>(null);
@@ -15,27 +15,27 @@ const TasksContext = createContext<TasksContext | null>(null);
 export const TasksProvider: React.FC<PropsWithChildren> = ({ children }) => {
   const [state, setState] = useState<Loadable<TaskCounts>>(NotLoaded);
   return (
-    <TasksContext.Provider value={{ tasks: state, updateTasks: setState }}>
+    <TasksContext.Provider value={{ activeTasks: state, updateActiveTasks: setState }}>
       {children}
     </TasksContext.Provider>
   );
 };
 
-export const useFetchTasks = (canceler: AbortController): (() => Promise<void>) => {
+export const useFetchActiveTasks = (canceler: AbortController): (() => Promise<void>) => {
   const context = useContext(TasksContext);
   if (context === null) {
     throw new Error('Attempted to use useFetchTasks outside of Task Context');
   }
-  const { updateTasks } = context;
+  const { updateActiveTasks } = context;
 
   return useCallback(async (): Promise<void> => {
     try {
       const response = await getActiveTasks({}, { signal: canceler.signal });
-      updateTasks(() => Loaded(response));
+      updateActiveTasks(() => Loaded(response));
     } catch (e) {
       handleError(e);
     }
-  }, [canceler, updateTasks]);
+  }, [canceler, updateActiveTasks]);
 };
 
 export const useEnsureActiveTasksFetched = (canceler: AbortController): (() => Promise<void>) => {
@@ -43,25 +43,25 @@ export const useEnsureActiveTasksFetched = (canceler: AbortController): (() => P
   if (context === null) {
     throw new Error('Attempted to use useEnsureActiveTasksFetched outside of Task Context');
   }
-  const { tasks, updateTasks } = context;
+  const { activeTasks, updateActiveTasks } = context;
 
   return useCallback(async (): Promise<void> => {
-    if (tasks !== NotLoaded) return;
+    if (activeTasks !== NotLoaded) return;
     try {
       const response = await getActiveTasks({}, { signal: canceler.signal });
-      updateTasks(() => Loaded(response));
+      updateActiveTasks(() => Loaded(response));
     } catch (e) {
       handleError(e);
     }
-  }, [canceler, tasks, updateTasks]);
+  }, [canceler, activeTasks, updateActiveTasks]);
 };
 
-export const useTasks = (): Loadable<TaskCounts> => {
+export const useActiveTasks = (): Loadable<TaskCounts> => {
   const context = useContext(TasksContext);
   if (context === null) {
-    throw new Error('Attempted to use useTasks outside of Task Context');
+    throw new Error('Attempted to use useActiveTasks outside of Task Context');
   }
-  const { tasks } = context;
+  const { activeTasks } = context;
 
-  return tasks;
+  return activeTasks;
 };

--- a/webui/react/src/stores/tasks.tsx
+++ b/webui/react/src/stores/tasks.tsx
@@ -1,0 +1,67 @@
+import React, { createContext, PropsWithChildren, useCallback, useContext, useState } from 'react';
+
+import { getActiveTasks } from 'services/api';
+import { TaskCounts } from 'types';
+import handleError from 'utils/error';
+import { Loadable, Loaded, NotLoaded } from 'utils/loadable';
+
+type TasksContext = {
+  tasks: Loadable<TaskCounts>;
+  updateTasks: (fn: (ws: Loadable<TaskCounts>) => Loadable<TaskCounts>) => void;
+};
+
+const TasksContext = createContext<TasksContext | null>(null);
+
+export const TasksProvider: React.FC<PropsWithChildren> = ({ children }) => {
+  const [state, setState] = useState<Loadable<TaskCounts>>(NotLoaded);
+  return (
+    <TasksContext.Provider value={{ tasks: state, updateTasks: setState }}>
+      {children}
+    </TasksContext.Provider>
+  );
+};
+
+export const useFetchTasks = (canceler: AbortController): (() => Promise<void>) => {
+  const context = useContext(TasksContext);
+  if (context === null) {
+    throw new Error('Attempted to use useFetchTasks outside of Task Context');
+  }
+  const { updateTasks } = context;
+
+  return useCallback(async (): Promise<void> => {
+    try {
+      const response = await getActiveTasks({}, { signal: canceler.signal });
+      updateTasks(() => Loaded(response));
+    } catch (e) {
+      handleError(e);
+    }
+  }, [canceler, updateTasks]);
+};
+
+export const useEnsureActiveTasksFetched = (canceler: AbortController): (() => Promise<void>) => {
+  const context = useContext(TasksContext);
+  if (context === null) {
+    throw new Error('Attempted to use useEnsureActiveTasksFetched outside of Task Context');
+  }
+  const { tasks, updateTasks } = context;
+
+  return useCallback(async (): Promise<void> => {
+    if (tasks !== NotLoaded) return;
+    try {
+      const response = await getActiveTasks({}, { signal: canceler.signal });
+      updateTasks(() => Loaded(response));
+    } catch (e) {
+      handleError(e);
+    }
+  }, [canceler, tasks, updateTasks]);
+};
+
+export const useTasks = (): Loadable<TaskCounts> => {
+  const context = useContext(TasksContext);
+  if (context === null) {
+    throw new Error('Attempted to use useTasks outside of Task Context');
+  }
+  const { tasks } = context;
+
+  return tasks;
+};


### PR DESCRIPTION
## Description

As part of breaking parts out of the central Store, this covers the active experiment and active tasks counts. These are used only on the Clusters page, but the experiment store should be OK for future queries.

Results of experiment queries are stored in the Immutable Map with the key generated by `encodeArgs`. This function uses an `any` type so we could put it in utils or shared or something for other stores.

Notes:
- Moves the code which polls the API from `pages/Clusters/ClustersOverview.tsx` to the same file which uses the data from the store `pages/Cluster/ClusterOverallStats.tsx`
- Why limit=-2 ? In `proto/src/determined/api/v1/experiment.proto` GetExperimentsRequest clarifies that limit=0 is the default page, limit=-1 is all results, so -2 is the first option which returns `pagination.total` without any experiments.

## Test Plan

- Visit `/det/clusters` - there should be a section showing active experiments, tensorboards, shells, and notebooks.
- Run an experiment and verify the count of experiments increases within a few seconds
- Use the Launch Jupyterlab button in the left sidebar, or `det shell start` to start a new task. Verify the count increases within a few seconds.
- Use the browser's dev console / Network tab to check API requests to `/api/v1/experiments?limit=-2` and `/api/v1/tasks/count` each second

## Checklist
- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.