### PR TITLE
chore: update Kubernetes fetch-creds.sh to handle cert file path

### DIFF
--- a/tools/k8s/fetch-creds.sh
+++ b/tools/k8s/fetch-creds.sh
@@ -148,11 +148,16 @@ server_info="$(
         | jq -r '.clusters[] | select(.name=="'"$context"'")'
 )"
 server_url="$(echo "$server_info" | jq -r '.cluster.server')"
-ca_crt="$(
-    echo "$server_info" \
-        | jq -r '.cluster."certificate-authority-data"' \
-        | base64 -d
-)"
+if echo "$server_info" | jq -e '.cluster."certificate-authority"' >/dev/null; then
+    ca_file="$(echo "$server_info" | jq -r '.cluster."certificate-authority"')"
+    ca_crt="$(<$ca_file)"
+else
+    ca_crt="$(
+        echo "$server_info" \
+            | jq -r '.cluster."certificate-authority-data"' \
+            | base64 -d
+    )"
+fi
 
 mkdir -p "$outdir"
 


### PR DESCRIPTION
## Description

While kind directly returns an encoded certificate with the key "client-certificate-data", minikube (at least in my testing) returns a path to a file with the key "client-certificate". Now the script handles both.

## Test plan

- [x] see that certificate is properly handled with both minikube and kind