### PR TITLE
fix: some cli endpoints that ignored --user

### DIFF
--- a/harness/determined/cli/__init__.py
+++ b/harness/determined/cli/__init__.py
@@ -3,6 +3,7 @@ from determined.cli._util import (
     make_pagination_args,
     default_pagination_args,
     setup_session,
+    setup_determined,
     require_feature_flag,
     login_sdk_client,
 )

--- a/harness/determined/cli/_util.py
+++ b/harness/determined/cli/_util.py
@@ -93,10 +93,22 @@ def login_sdk_client(func: Callable[[argparse.Namespace], Any]) -> Callable[...,
 
 
 def setup_session(args: argparse.Namespace) -> api.Session:
-    master_url = args.master or util.get_default_master_address()
-    cert = certs.default_load(master_url)
+    """
+    Setup a client.Session, which is useful for arbitrary calls against the REST API bindings.
+    """
+    return api.Session(args.master, args.user, authentication.cli_auth, certs.cli_cert)
 
-    return api.Session(master_url, args.user, authentication.cli_auth, cert)
+
+def setup_determined(args: argparse.Namespace) -> client.Determined:
+    """
+    Setup a client.Determined, which is useful for when a cli is really just calling functionality
+    that already exists in the python sdk.
+
+    Maybe in the future the sdk and the cli are 1:1 and setup_session() is never used anymore.
+    """
+    # TODO: this is going to duplicate the cli_auth object created by @authentication.required.
+    # TODO: this is going to duplicate the cli_cert object that the cli already creates.
+    return client.Determined(args.master, args.user)
 
 
 def require_feature_flag(feature_flag: str, error_message: str) -> Callable[..., Any]:

--- a/harness/determined/cli/checkpoint.py
+++ b/harness/determined/cli/checkpoint.py
@@ -6,8 +6,7 @@ from determined import cli
 from determined.common import experimental
 from determined.common.api import authentication, bindings
 from determined.common.declarative_argparse import Arg, Cmd
-from determined.common.experimental import Determined
-from determined.experimental.client import DownloadMode
+from determined.experimental import client
 
 from . import render
 
@@ -94,7 +93,7 @@ def list_checkpoints(args: Namespace) -> None:
 
 
 def download(args: Namespace) -> None:
-    checkpoint = Determined(args.master, None).get_checkpoint(args.uuid)
+    checkpoint = cli.setup_determined(args).get_checkpoint(args.uuid)
 
     path = checkpoint.download(path=args.output_dir, mode=args.mode)
 
@@ -105,7 +104,7 @@ def download(args: Namespace) -> None:
 
 
 def describe(args: Namespace) -> None:
-    checkpoint = Determined(args.master, None).get_checkpoint(args.uuid)
+    checkpoint = cli.setup_determined(args).get_checkpoint(args.uuid)
     render_checkpoint(checkpoint)
 
 
@@ -148,15 +147,15 @@ main_cmd = Cmd(
                 ),
                 Arg(
                     "--mode",
-                    choices=list(DownloadMode),
-                    default=DownloadMode.AUTO,
-                    type=DownloadMode,
+                    choices=list(client.DownloadMode),
+                    default=client.DownloadMode.AUTO,
+                    type=client.DownloadMode,
                     help=(
                         "Select different download modes: "
-                        f"'{DownloadMode.DIRECT}' to directly download from checkpoint storage; "
-                        f"'{DownloadMode.MASTER}' to download via the master; "
-                        f"'{DownloadMode.AUTO}' to first attempt a direct download and fall "
-                        f"back to '{DownloadMode.MASTER}'."
+                        f"'{client.DownloadMode.DIRECT}' to directly download from checkpoint "
+                        f"storage; '{client.DownloadMode.MASTER}' to download via the master; "
+                        f"'{client.DownloadMode.AUTO}' to first attempt a direct download and fall "
+                        f"back to '{client.DownloadMode.MASTER}'."
                     ),
                 ),
             ],

--- a/harness/determined/cli/trial.py
+++ b/harness/determined/cli/trial.py
@@ -12,7 +12,6 @@ from determined.cli import render
 from determined.common import api, constants
 from determined.common.api import authentication, bindings
 from determined.common.declarative_argparse import Arg, Cmd, Group
-from determined.common.experimental import Determined
 
 from .checkpoint import render_checkpoint
 
@@ -158,7 +157,7 @@ def describe_trial(args: Namespace) -> None:
 
 def download(args: Namespace) -> None:
     checkpoint = (
-        Determined(args.master, None)
+        cli.setup_determined(args)
         .get_trial(args.trial_id)
         .select_checkpoint(
             latest=args.latest,

--- a/harness/determined/experimental/client.py
+++ b/harness/determined/experimental/client.py
@@ -60,7 +60,12 @@ from determined.common.experimental.experiment import (  # noqa: F401
     ExperimentReference,
     ExperimentState,
 )
-from determined.common.experimental.model import Model, ModelOrderBy, ModelSortBy
+from determined.common.experimental.model import (  # noqa: F401
+    Model,
+    ModelOrderBy,
+    ModelSortBy,
+    ModelVersion,
+)
 from determined.common.experimental.trial import (  # noqa: F401
     TrialOrderBy,
     TrialReference,


### PR DESCRIPTION
## Commentary

Our CLI uses singletons, but it doesn't use them very well.

A `certs.cli_cert` singleton is created, but not used by anything that uses `setup_determined` (`setup_session` does reuse it now, with this PR).

An `authentication.cli_auth` is created but is not used by anything that uses `setup_determined`.

The `setup_session()` does use the `cli_auth` singleton, but that introduces an implicit dependency between `@authentication.required` and `setup_session()`, which is dangerous.

`setup_determined` would be cleaner if you could create a Determined object with an explicit Session object.  But no end-user would ever need that.  I'm not totally sure what the best approach is.  Half of me thinks this would be ok:

```python
class DeterminedCli(client.Determined):
    def __init__(self, session: api.Session) -> None:
        self._session = session
```

And the other half of me thinks that's an awful hack, and the origin Determined object should never have fancy logic in its `__init__()` method anyway.