### PR TITLE
chore: Update resource pool resolution & validation

### DIFF
--- a/master/internal/api_command.go
+++ b/master/internal/api_command.go
@@ -111,9 +111,6 @@ func (a *apiServer) getCommandLaunchParams(ctx context.Context, req *protoComman
 
 	// Get the full configuration.
 	config := model.DefaultConfig(&taskSpec.TaskContainerDefaults)
-	// Copy discovered (default) resource pool name and slot count.
-	config.Resources.ResourcePool = poolName
-	config.Resources.Slots = resources.Slots
 
 	workDirInDefaults := config.WorkDir
 	if req.TemplateName != "" {
@@ -137,6 +134,10 @@ func (a *apiServer) getCommandLaunchParams(ctx context.Context, req *protoComman
 					"unable to decode the merged config: %s", string(configBytes)).Error())
 		}
 	}
+	// Copy discovered (default) resource pool name and slot count.
+	config.Resources.ResourcePool = poolName
+	config.Resources.Slots = resources.Slots
+
 	if req.MustZeroSlot {
 		config.Resources.Slots = 0
 	}


### PR DESCRIPTION
for launcher-provided resource pools

## Description

Running a command:
det command run --config=resources.resource_pool='defq_GPU_tesla' hostname

In api_command.go, the resource pool gets set up at line 116, but is overwritten by deserializing from the configBytes at line 134. This causes the result of ResolveResourcePool from line 88 to be lost.

To deal with this I propose to move lines 115 & 116 to after line 134. Does that sound plausible?

<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At a minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions about this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist
- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
