### PR TITLE
chore: delete try_reauth from authentication logic

### DIFF
--- a/e2e_tests/tests/api_utils.py
+++ b/e2e_tests/tests/api_utils.py
@@ -6,5 +6,5 @@ from tests import config as conf
 def determined_test_session() -> api.Session:
     murl = conf.make_master_url()
     certs.cli_cert = certs.default_load(murl)
-    authentication.cli_auth = authentication.Authentication(murl, try_reauth=True)
+    authentication.cli_auth = authentication.Authentication(murl)
     return api.Session(murl, "determined", authentication.cli_auth, certs.cli_cert)

--- a/e2e_tests/tests/cluster/test_checkpoints.py
+++ b/e2e_tests/tests/cluster/test_checkpoints.py
@@ -23,7 +23,7 @@ EXPECT_TIMEOUT = 5
 
 def wait_for_gc_to_finish(experiment_id: int) -> None:
     certs.cli_cert = certs.default_load(conf.make_master_url())
-    authentication.cli_auth = authentication.Authentication(conf.make_master_url(), try_reauth=True)
+    authentication.cli_auth = authentication.Authentication(conf.make_master_url())
     saw_gc = False
     # Don't wait longer than 5 minutes (as 600 half-seconds to improve our sampling resolution).
     for _ in range(600):

--- a/e2e_tests/tests/cluster/test_logging.py
+++ b/e2e_tests/tests/cluster/test_logging.py
@@ -26,7 +26,7 @@ def test_trial_logs() -> None:
     # TODO: refactor tests to not use cli singleton auth.
     master_url = conf.make_master_url()
     certs.cli_cert = certs.default_load(conf.make_master_url())
-    authentication.cli_auth = authentication.Authentication(conf.make_master_url(), try_reauth=True)
+    authentication.cli_auth = authentication.Authentication(conf.make_master_url())
     session = api.Session(master_url, "determined", authentication.cli_auth, certs.cli_cert)
 
     experiment_id = exp.run_basic_test(
@@ -71,7 +71,7 @@ def test_trial_logs() -> None:
 def test_task_logs(task_type: str, task_config: Dict[str, Any], log_regex: Any) -> None:
     master_url = conf.make_master_url()
     certs.cli_cert = certs.default_load(conf.make_master_url())
-    authentication.cli_auth = authentication.Authentication(conf.make_master_url(), try_reauth=True)
+    authentication.cli_auth = authentication.Authentication(conf.make_master_url())
     session = api.Session(master_url, "determined", authentication.cli_auth, certs.cli_cert)
 
     rps = bindings.get_GetResourcePools(session)

--- a/e2e_tests/tests/cluster/test_trial_collections.py
+++ b/e2e_tests/tests/cluster/test_trial_collections.py
@@ -128,7 +128,7 @@ def assert_collection_is_uniquely_represented_in_collections(
 def test_trial_collections() -> None:
 
     master_url = conf.make_master_url()
-    authentication.cli_auth = authentication.Authentication(master_url, try_reauth=True)
+    authentication.cli_auth = authentication.Authentication(master_url)
     sess = utils.determined_test_session()
 
     experiment_id = exp.create_experiment(

--- a/e2e_tests/tests/cluster/test_users.py
+++ b/e2e_tests/tests/cluster/test_users.py
@@ -980,7 +980,7 @@ def test_change_displayname(clean_auth: None, login_admin: None) -> None:
     master_url = conf.make_master_url()
     certs.cli_cert = certs.default_load(master_url)
     authentication.cli_auth = authentication.Authentication(
-        conf.make_master_url(), requested_user=original_name, password="", try_reauth=True
+        conf.make_master_url(), requested_user=original_name, password=""
     )
     sess = api.Session(master_url, original_name, authentication.cli_auth, certs.cli_cert)
 

--- a/e2e_tests/tests/cluster/test_users_experiment_api.py
+++ b/e2e_tests/tests/cluster/test_users_experiment_api.py
@@ -35,7 +35,6 @@ def test_experimental_experiment_api_determined_disabled() -> None:
             determined_master,
             requested_user=user_creds.username,
             password=user_creds.password,
-            try_reauth=True,
             cert=certs.cli_cert,
         )
 

--- a/e2e_tests/tests/cluster/test_workspace_org.py
+++ b/e2e_tests/tests/cluster/test_workspace_org.py
@@ -20,10 +20,10 @@ def test_workspace_org() -> None:
     with logged_in_user(ADMIN_CREDENTIALS):
         change_user_password("determined", "")
     master_url = conf.make_master_url()
-    authentication.cli_auth = authentication.Authentication(master_url, try_reauth=True)
+    authentication.cli_auth = authentication.Authentication(master_url)
     sess = api.Session(master_url, None, None, None)
     admin_auth = authentication.Authentication(
-        master_url, ADMIN_CREDENTIALS.username, ADMIN_CREDENTIALS.password, try_reauth=True
+        master_url, ADMIN_CREDENTIALS.username, ADMIN_CREDENTIALS.password
     )
     admin_sess = api.Session(master_url, ADMIN_CREDENTIALS.username, admin_auth, None)
 

--- a/e2e_tests/tests/cluster/utils.py
+++ b/e2e_tests/tests/cluster/utils.py
@@ -19,7 +19,7 @@ def cluster_slots() -> Dict[str, Any]:
     """
     # TODO: refactor tests to not use cli singleton auth.
     certs.cli_cert = certs.default_load(conf.make_master_url())
-    authentication.cli_auth = authentication.Authentication(conf.make_master_url(), try_reauth=True)
+    authentication.cli_auth = authentication.Authentication(conf.make_master_url())
     r = api.get(conf.make_master_url(), "api/v1/agents")
     assert r.status_code == requests.codes.ok, r.text
     jvals = r.json()  # type: Dict[str, Any]

--- a/e2e_tests/tests/command/command.py
+++ b/e2e_tests/tests/command/command.py
@@ -89,7 +89,7 @@ def interactive_command(*args: str) -> Iterator[_InteractiveCommandProcess]:
 def get_num_running_commands() -> int:
     # TODO: refactor tests to not use cli singleton auth.
     certs.cli_cert = certs.default_load(conf.make_master_url())
-    authentication.cli_auth = authentication.Authentication(conf.make_master_url(), try_reauth=True)
+    authentication.cli_auth = authentication.Authentication(conf.make_master_url())
     r = api.get(conf.make_master_url(), "api/v1/commands")
     assert r.status_code == requests.codes.ok, r.text
 
@@ -98,7 +98,7 @@ def get_num_running_commands() -> int:
 
 def get_command(command_id: str) -> Any:
     certs.cli_cert = certs.default_load(conf.make_master_url())
-    authentication.cli_auth = authentication.Authentication(conf.make_master_url(), try_reauth=True)
+    authentication.cli_auth = authentication.Authentication(conf.make_master_url())
     r = api.get(conf.make_master_url(), "api/v1/commands/" + command_id)
     assert r.status_code == requests.codes.ok, r.text
     return r.json()["command"]

--- a/e2e_tests/tests/command/test_strict_ntsc.py
+++ b/e2e_tests/tests/command/test_strict_ntsc.py
@@ -19,7 +19,7 @@ from tests.cluster.test_users import (
 def assert_shell_access(creds: authentication.Credentials, shell_id: str, can_access: bool) -> None:
     master_url = conf.make_master_url()
     authentication.cli_auth = authentication.Authentication(
-        master_url, creds.username, creds.password, try_reauth=True
+        master_url, creds.username, creds.password
     )
     sess = api.Session(master_url, None, None, None)
 
@@ -57,7 +57,7 @@ def assert_notebook_access(
 ) -> None:
     master_url = conf.make_master_url()
     authentication.cli_auth = authentication.Authentication(
-        master_url, creds.username, creds.password, try_reauth=True
+        master_url, creds.username, creds.password
     )
     sess = api.Session(master_url, None, None, None)
 
@@ -104,7 +104,7 @@ def assert_command_access(
 ) -> None:
     master_url = conf.make_master_url()
     authentication.cli_auth = authentication.Authentication(
-        master_url, creds.username, creds.password, try_reauth=True
+        master_url, creds.username, creds.password
     )
     sess = api.Session(master_url, None, None, None)
 
@@ -144,7 +144,7 @@ def assert_tensorboard_access(
 ) -> None:
     master_url = conf.make_master_url()
     authentication.cli_auth = authentication.Authentication(
-        master_url, creds.username, creds.password, try_reauth=True
+        master_url, creds.username, creds.password
     )
     sess = api.Session(master_url, None, None, None)
 
@@ -184,7 +184,7 @@ def assert_tensorboard_access(
 def assert_access_task(creds: authentication.Credentials, task_id: str, can_access: bool) -> None:
     master_url = conf.make_master_url()
     authentication.cli_auth = authentication.Authentication(
-        master_url, creds.username, creds.password, try_reauth=True
+        master_url, creds.username, creds.password
     )
     sess = api.Session(master_url, None, None, None)
 

--- a/e2e_tests/tests/experiment/experiment.py
+++ b/e2e_tests/tests/experiment/experiment.py
@@ -234,7 +234,7 @@ def wait_for_trial_state(
 
 def experiment_has_active_workload(experiment_id: int) -> bool:
     certs.cli_cert = certs.default_load(conf.make_master_url())
-    authentication.cli_auth = authentication.Authentication(conf.make_master_url(), try_reauth=True)
+    authentication.cli_auth = authentication.Authentication(conf.make_master_url())
     r = api.get(conf.make_master_url(), "tasks").json()
     for task in r.values():
         if "Experiment {}".format(experiment_id) in task["name"] and len(task["resources"]) > 0:
@@ -290,7 +290,7 @@ def wait_for_experiment_workload_progress(
 
 def experiment_has_completed_workload(experiment_id: int) -> bool:
     certs.cli_cert = certs.default_load(conf.make_master_url())
-    authentication.cli_auth = authentication.Authentication(conf.make_master_url(), try_reauth=True)
+    authentication.cli_auth = authentication.Authentication(conf.make_master_url())
     trials = experiment_trials(experiment_id)
 
     if not any(trials):
@@ -324,7 +324,7 @@ def determined_test_session(admin: bool = False) -> api.Session:
     certs.cli_cert = certs.default_load(murl)
     username = "admin" if admin else "determined"
     authentication.cli_auth = authentication.Authentication(
-        murl, requested_user=username, password="", try_reauth=True
+        murl, requested_user=username, password=""
     )
     return api.Session(murl, username, authentication.cli_auth, certs.cli_cert)
 
@@ -386,7 +386,7 @@ def is_terminal_state(state: determinedexperimentv1State) -> bool:
 
 def trial_metrics(trial_id: int) -> Dict[str, Any]:
     certs.cli_cert = certs.default_load(conf.make_master_url())
-    authentication.cli_auth = authentication.Authentication(conf.make_master_url(), try_reauth=True)
+    authentication.cli_auth = authentication.Authentication(conf.make_master_url())
     r = api.get(conf.make_master_url(), "trials/{}/metrics".format(trial_id))
     json = r.json()  # type: Dict[str, Any]
     return json

--- a/e2e_tests/tests/experiment/test_metrics.py
+++ b/e2e_tests/tests/experiment/test_metrics.py
@@ -16,7 +16,7 @@ from tests import experiment as exp
 def test_streaming_metrics_api() -> None:
     # TODO: refactor tests to not use cli singleton auth.
     certs.cli_cert = certs.default_load(conf.make_master_url())
-    authentication.cli_auth = authentication.Authentication(conf.make_master_url(), try_reauth=True)
+    authentication.cli_auth = authentication.Authentication(conf.make_master_url())
 
     pool = mp.pool.ThreadPool(processes=7)
 
@@ -67,7 +67,7 @@ def test_streaming_metrics_api() -> None:
 @pytest.mark.timeout(1800)
 def test_hp_importance_api() -> None:
     certs.cli_cert = certs.default_load(conf.make_master_url())
-    authentication.cli_auth = authentication.Authentication(conf.make_master_url(), try_reauth=True)
+    authentication.cli_auth = authentication.Authentication(conf.make_master_url())
 
     pool = mp.pool.ThreadPool(processes=1)
 

--- a/e2e_tests/tests/experiment/test_profiling.py
+++ b/e2e_tests/tests/experiment/test_profiling.py
@@ -27,7 +27,7 @@ def test_streaming_observability_metrics_apis(
 ) -> None:
     # TODO: refactor tests to not use cli singleton auth.
     certs.cli_cert = certs.default_load(conf.make_master_url())
-    authentication.cli_auth = authentication.Authentication(conf.make_master_url(), try_reauth=True)
+    authentication.cli_auth = authentication.Authentication(conf.make_master_url())
 
     config_path = conf.tutorials_path(f"../{framework_base_experiment}/const.yaml")
     model_def_path = conf.tutorials_path(f"../{framework_base_experiment}")

--- a/e2e_tests/tests/nightly/compute_stats.py
+++ b/e2e_tests/tests/nightly/compute_stats.py
@@ -94,7 +94,7 @@ def fetch_master_log() -> bool:
 def create_test_session() -> api.Session:
     murl = conf.make_master_url()
     certs.cli_cert = certs.default_load(murl)
-    authentication.cli_auth = authentication.Authentication(murl, try_reauth=True)
+    authentication.cli_auth = authentication.Authentication(murl)
     return api.Session(murl, "determined", authentication.cli_auth, certs.cli_cert)
 
 

--- a/harness/determined/common/api/authentication.py
+++ b/harness/determined/common/api/authentication.py
@@ -68,19 +68,17 @@ class Authentication:
         master_address: Optional[str] = None,
         requested_user: Optional[str] = None,
         password: Optional[str] = None,
-        try_reauth: bool = False,
         cert: Optional[certs.Cert] = None,
     ) -> None:
         self.master_address = master_address or util.get_default_master_address()
         self.token_store = TokenStore(self.master_address)
 
-        self.session = self._init_session(requested_user, password, try_reauth, cert)
+        self.session = self._init_session(requested_user, password, cert)
 
     def _init_session(
         self,
         requested_user: Optional[str],
         password: Optional[str],
-        try_reauth: bool,
         cert: Optional[certs.Cert],
     ) -> UsernameTokenPair:
         session_user, password = default_load_user_password(
@@ -108,9 +106,6 @@ class Authentication:
 
         if token is not None:
             return UsernameTokenPair(session_user, token)
-
-        if token is None and not try_reauth:
-            raise api.errors.UnauthenticatedException(username=session_user)
 
         fallback_to_default = password is None and session_user == constants.DEFAULT_DETERMINED_USER
         if fallback_to_default:
@@ -463,7 +458,7 @@ def required(func: Callable[[argparse.Namespace], Any]) -> Callable[..., Any]:
     @functools.wraps(func)
     def f(namespace: argparse.Namespace) -> Any:
         global cli_auth
-        cli_auth = Authentication(namespace.master, namespace.user, try_reauth=True)
+        cli_auth = Authentication(namespace.master, namespace.user)
         return func(namespace)
 
     return f

--- a/harness/determined/common/experimental/determined.py
+++ b/harness/determined/common/experimental/determined.py
@@ -57,10 +57,7 @@ class Determined:
             explicit_noverify=noverify,
         )
 
-        # TODO: This should probably be try_reauth=False, but it appears that would break the case
-        # where the default credentials are available from the master and could be discovered by
-        # a REST API call against the master.
-        auth = authentication.Authentication(master, user, password, try_reauth=True, cert=cert)
+        auth = authentication.Authentication(master, user, password, cert=cert)
         self._session = api.Session(master, user, auth, cert)
 
     def _from_bindings(self, raw: bindings.v1User) -> user.User:

--- a/harness/tests/cli/test_auth.py
+++ b/harness/tests/cli/test_auth.py
@@ -10,7 +10,6 @@ import requests_mock
 
 from determined.common.api.authentication import Authentication, TokenStore
 from determined.common.api.certs import default_load as certs_default_load
-from determined.common.api.errors import UnauthenticatedException
 from tests.confdir import use_test_config_dir
 
 MOCK_MASTER_URL = "http://localhost:8080"
@@ -28,13 +27,6 @@ AUTH_JSON = {
         }
     },
 }
-
-
-@pytest.mark.parametrize("user", [None, "Bob"])
-def test_auth_no_store_no_reauth(user: Optional[str]) -> None:
-    with use_test_config_dir():
-        with pytest.raises(UnauthenticatedException):
-            Authentication(MOCK_MASTER_URL, user)
 
 
 @pytest.mark.parametrize("user", [None, "bob", "determined"])

--- a/harness/tests/cli/test_experiment.py
+++ b/harness/tests/cli/test_experiment.py
@@ -38,7 +38,6 @@ def mock_det_auth(user: str = "test", master_url: str = "http://localhost:8888")
             master_address=master_url,
             requested_user=user,
             password="password1",
-            try_reauth=True,
             cert=certs.Cert(noverify=True),
         )
         return auth


### PR DESCRIPTION
try_reauth was literally always true, except:
- in a unit test to make sure it worked when it was False
- in logout code, which recently was refactored to not use Authentication at all

Furthermore, try_reauth does not make sense to expose to end users.  At first glance, it sounds like the equivalent of a --noninteractive commandline flag for batch scripts, but that's only part of what it does.  try_auth=False has the additional effect that we would not attempt to log in with the default credentials.  So if we want to give users a noninteractive setting, that's fine, but it also isn't what try_reauth does currently.

## Test Plan

There's no new codepaths, so nothing to test.