### PR TITLE
chore: transformer image installs scikit-learn

### DIFF
--- a/model_hub/docker/Dockerfile.transformers
+++ b/model_hub/docker/Dockerfile.transformers
@@ -5,7 +5,7 @@ FROM ${BASE_IMAGE}
 ARG TRANSFORMERS_VERSION
 ARG DATASETS_VERSION
 RUN pip install transformers==${TRANSFORMERS_VERSION} datasets==${DATASETS_VERSION} attrdict
-RUN pip install sentencepiece!=0.1.92 protobuf sklearn conllu seqeval
+RUN pip install sentencepiece!=0.1.92 protobuf scikit-learn conllu seqeval
 
 
 # Wheel must be built before building the docker image


### PR DESCRIPTION
Apparently sklearn is deprecated and causes pip installs to fail.

## Example output:

```
Collecting sklearn
  Downloading sklearn-0.0.post1.tar.gz (3.6 kB)
  Preparing metadata (setup.py): started
  Preparing metadata (setup.py): finished with status 'error'
  error: subprocess-exited-with-error
  
  × python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [18 lines of output]
      The 'sklearn' PyPI package is deprecated, use 'scikit-learn'
      rather than 'sklearn' for pip commands.
      
      Here is how to fix this error in the main use cases:
      - use 'pip install scikit-learn' rather than 'pip install sklearn'
      - replace 'sklearn' by 'scikit-learn' in your pip requirements files
        (requirements.txt, setup.py, setup.cfg, Pipfile, etc ...)
      - if the 'sklearn' package is used by one of your dependencies,
        it would be great if you take some time to track which package uses
        'sklearn' instead of 'scikit-learn' and report it to their issue tracker
      - as a last resort, set the environment variable
        SKLEARN_ALLOW_DEPRECATED_SKLEARN_PACKAGE_INSTALL=True to avoid this error
      
      More information is available at
      https://github.com/scikit-learn/sklearn-pypi-package
      
      If the previous advice does not cover your use case, feel free to report it at
      https://github.com/scikit-learn/sklearn-pypi-package/issues/new
      [end of output]
```