### PR TITLE
fix: jupyter modal stalling and garbling input [WEB-579]

### DIFF
--- a/webui/react/src/hooks/useModal/JupyterLab/useModalJupyterLab.module.scss
+++ b/webui/react/src/hooks/useModal/JupyterLab/useModalJupyterLab.module.scss
@@ -12,18 +12,23 @@
   padding: 40px;
 }
 .line {
-  align-items: center;
-  display: flex;
-  gap: 10px;
-  justify-content: space-between;
-  width: 100%;
-}
-.line p {
-  margin: 0;
-  min-width: 100px;
-}
-.line > :not(p) {
-  flex-grow: 1;
+  &:global(.ant-form-item) {
+    margin: 0;
+  }
+  & > div {
+    align-items: center;
+    display: flex;
+    gap: 10px;
+    justify-content: space-between;
+    width: 100%;
+    label {
+      margin: 0;
+      min-width: 110px;
+    }
+    :global(.ant-input-number) {
+      width: 100%;
+    }
+  }
 }
 .form {
   display: flex;


### PR DESCRIPTION
## Description

state for modal fields was being kept in settings in order to preserve input values after close/submit.

settings rewrite apparently caused this to break, presumably some interaction between the particularities of modal state and the new settings behavior.

rather than digging into that interaction, i opted to migrate the modal to antd `useForm` following the pattern of hp search modal, makes for cleaner code anyways.
<!---
Lead with the intended commit body in this description field. For breaking
changes, please include "BREAKING CHANGE:" at the beginning of your commit
body.  At a minimum, this section should include a bracketed reference to the
Jira ticket, e.g. "[DET-1234]". When squash-and-merging, copy this directly
into the description field.
-->



## Test Plan

use the modal to create jupyterlabs in different resource pools and with different configuration.

verify successful creation of jupyterlab instances.

verify input interactions, copy pasting, fast typing, etc.

verify preservation of input fields after submission/modal close


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
