### PR TITLE
chore: add structured task and trial logs

### DIFF
--- a/harness/determined/common/api/bindings.py
+++ b/harness/determined/common/api/bindings.py
@@ -9886,37 +9886,93 @@ class v1TaskLogsFieldsResponse:
         return out
 
 class v1TaskLogsResponse:
+    agentId: "typing.Optional[str]" = None
+    allocationId: "typing.Optional[str]" = None
+    containerId: "typing.Optional[str]" = None
+    rankId: "typing.Optional[int]" = None
+    source: "typing.Optional[str]" = None
+    stdtype: "typing.Optional[str]" = None
 
     def __init__(
         self,
         *,
         id: str,
         level: "v1LogLevel",
+        log: str,
         message: str,
+        taskId: str,
         timestamp: str,
+        agentId: "typing.Union[str, None, Unset]" = _unset,
+        allocationId: "typing.Union[str, None, Unset]" = _unset,
+        containerId: "typing.Union[str, None, Unset]" = _unset,
+        rankId: "typing.Union[int, None, Unset]" = _unset,
+        source: "typing.Union[str, None, Unset]" = _unset,
+        stdtype: "typing.Union[str, None, Unset]" = _unset,
     ):
         self.id = id
         self.level = level
+        self.log = log
         self.message = message
+        self.taskId = taskId
         self.timestamp = timestamp
+        if not isinstance(agentId, Unset):
+            self.agentId = agentId
+        if not isinstance(allocationId, Unset):
+            self.allocationId = allocationId
+        if not isinstance(containerId, Unset):
+            self.containerId = containerId
+        if not isinstance(rankId, Unset):
+            self.rankId = rankId
+        if not isinstance(source, Unset):
+            self.source = source
+        if not isinstance(stdtype, Unset):
+            self.stdtype = stdtype
 
     @classmethod
     def from_json(cls, obj: Json) -> "v1TaskLogsResponse":
         kwargs: "typing.Dict[str, typing.Any]" = {
             "id": obj["id"],
             "level": v1LogLevel(obj["level"]),
+            "log": obj["log"],
             "message": obj["message"],
+            "taskId": obj["taskId"],
             "timestamp": obj["timestamp"],
         }
+        if "agentId" in obj:
+            kwargs["agentId"] = obj["agentId"]
+        if "allocationId" in obj:
+            kwargs["allocationId"] = obj["allocationId"]
+        if "containerId" in obj:
+            kwargs["containerId"] = obj["containerId"]
+        if "rankId" in obj:
+            kwargs["rankId"] = obj["rankId"]
+        if "source" in obj:
+            kwargs["source"] = obj["source"]
+        if "stdtype" in obj:
+            kwargs["stdtype"] = obj["stdtype"]
         return cls(**kwargs)
 
     def to_json(self, omit_unset: bool = False) -> typing.Dict[str, typing.Any]:
         out: "typing.Dict[str, typing.Any]" = {
             "id": self.id,
             "level": self.level.value,
+            "log": self.log,
             "message": self.message,
+            "taskId": self.taskId,
             "timestamp": self.timestamp,
         }
+        if not omit_unset or "agentId" in vars(self):
+            out["agentId"] = self.agentId
+        if not omit_unset or "allocationId" in vars(self):
+            out["allocationId"] = self.allocationId
+        if not omit_unset or "containerId" in vars(self):
+            out["containerId"] = self.containerId
+        if not omit_unset or "rankId" in vars(self):
+            out["rankId"] = self.rankId
+        if not omit_unset or "source" in vars(self):
+            out["source"] = self.source
+        if not omit_unset or "stdtype" in vars(self):
+            out["stdtype"] = self.stdtype
         return out
 
 class v1Template:
@@ -10427,6 +10483,12 @@ class v1TrialLogsFieldsResponse:
         return out
 
 class v1TrialLogsResponse:
+    agentId: "typing.Optional[str]" = None
+    containerId: "typing.Optional[str]" = None
+    log: "typing.Optional[str]" = None
+    rankId: "typing.Optional[int]" = None
+    source: "typing.Optional[str]" = None
+    stdtype: "typing.Optional[str]" = None
 
     def __init__(
         self,
@@ -10435,11 +10497,31 @@ class v1TrialLogsResponse:
         level: "v1LogLevel",
         message: str,
         timestamp: str,
+        trialId: int,
+        agentId: "typing.Union[str, None, Unset]" = _unset,
+        containerId: "typing.Union[str, None, Unset]" = _unset,
+        log: "typing.Union[str, None, Unset]" = _unset,
+        rankId: "typing.Union[int, None, Unset]" = _unset,
+        source: "typing.Union[str, None, Unset]" = _unset,
+        stdtype: "typing.Union[str, None, Unset]" = _unset,
     ):
         self.id = id
         self.level = level
         self.message = message
         self.timestamp = timestamp
+        self.trialId = trialId
+        if not isinstance(agentId, Unset):
+            self.agentId = agentId
+        if not isinstance(containerId, Unset):
+            self.containerId = containerId
+        if not isinstance(log, Unset):
+            self.log = log
+        if not isinstance(rankId, Unset):
+            self.rankId = rankId
+        if not isinstance(source, Unset):
+            self.source = source
+        if not isinstance(stdtype, Unset):
+            self.stdtype = stdtype
 
     @classmethod
     def from_json(cls, obj: Json) -> "v1TrialLogsResponse":
@@ -10448,7 +10530,20 @@ class v1TrialLogsResponse:
             "level": v1LogLevel(obj["level"]),
             "message": obj["message"],
             "timestamp": obj["timestamp"],
+            "trialId": obj["trialId"],
         }
+        if "agentId" in obj:
+            kwargs["agentId"] = obj["agentId"]
+        if "containerId" in obj:
+            kwargs["containerId"] = obj["containerId"]
+        if "log" in obj:
+            kwargs["log"] = obj["log"]
+        if "rankId" in obj:
+            kwargs["rankId"] = obj["rankId"]
+        if "source" in obj:
+            kwargs["source"] = obj["source"]
+        if "stdtype" in obj:
+            kwargs["stdtype"] = obj["stdtype"]
         return cls(**kwargs)
 
     def to_json(self, omit_unset: bool = False) -> typing.Dict[str, typing.Any]:
@@ -10457,7 +10552,20 @@ class v1TrialLogsResponse:
             "level": self.level.value,
             "message": self.message,
             "timestamp": self.timestamp,
+            "trialId": self.trialId,
         }
+        if not omit_unset or "agentId" in vars(self):
+            out["agentId"] = self.agentId
+        if not omit_unset or "containerId" in vars(self):
+            out["containerId"] = self.containerId
+        if not omit_unset or "log" in vars(self):
+            out["log"] = self.log
+        if not omit_unset or "rankId" in vars(self):
+            out["rankId"] = self.rankId
+        if not omit_unset or "source" in vars(self):
+            out["source"] = self.source
+        if not omit_unset or "stdtype" in vars(self):
+            out["stdtype"] = self.stdtype
         return out
 
 class v1TrialMetrics:

--- a/master/internal/api_trials.go
+++ b/master/internal/api_trials.go
@@ -213,10 +213,17 @@ func (a *apiServer) TrialLogs(
 					return err
 				}
 				return resp.Send(&apiv1.TrialLogsResponse{
-					Id:        l.Id,
-					Timestamp: l.Timestamp,
-					Message:   l.Message,
-					Level:     l.Level,
+					Id:          l.Id,
+					TrialId:     req.TrialId,
+					Timestamp:   l.Timestamp,
+					Message:     l.Message,
+					Level:       l.Level,
+					AgentId:     l.AgentId,
+					ContainerId: l.ContainerId,
+					RankId:      l.RankId,
+					Log:         &l.Log,
+					Source:      l.Source,
+					Stdtype:     l.Stdtype,
 				})
 			})
 		})

--- a/master/pkg/model/experiment.go
+++ b/master/pkg/model/experiment.go
@@ -602,7 +602,15 @@ type TrialLog struct {
 
 // Proto converts a trial log to its protobuf representation.
 func (t TrialLog) Proto() (*apiv1.TrialLogsResponse, error) {
-	resp := &apiv1.TrialLogsResponse{Message: t.Message}
+	resp := &apiv1.TrialLogsResponse{
+		TrialId:     int32(t.TrialID),
+		Message:     t.Message,
+		AgentId:     t.AgentID,
+		ContainerId: t.ContainerID,
+		Log:         t.Log,
+		Source:      t.Source,
+		Stdtype:     t.StdType,
+	}
 
 	switch {
 	case t.ID != nil:
@@ -636,6 +644,11 @@ func (t TrialLog) Proto() (*apiv1.TrialLogsResponse, error) {
 		default:
 			resp.Level = logv1.LogLevel_LOG_LEVEL_UNSPECIFIED
 		}
+	}
+
+	if t.RankID != nil {
+		var id = int32(*t.RankID)
+		resp.RankId = &id
 	}
 
 	return resp, nil

--- a/master/pkg/model/task.go
+++ b/master/pkg/model/task.go
@@ -6,15 +6,12 @@ import (
 	"strings"
 	"time"
 
-	"google.golang.org/protobuf/types/known/timestamppb"
-
+	"github.com/google/uuid"
 	"github.com/uptrace/bun"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/determined-ai/determined/proto/pkg/apiv1"
 	"github.com/determined-ai/determined/proto/pkg/logv1"
-
-	"github.com/google/uuid"
-
 	"github.com/determined-ai/determined/proto/pkg/taskv1"
 )
 
@@ -351,12 +348,26 @@ func (t TaskLog) Proto() (*apiv1.TaskLogsResponse, error) {
 		level = TaskLogLevelToProto(*t.Level)
 	}
 
-	return &apiv1.TaskLogsResponse{
-		Id:        id,
-		Timestamp: ts,
-		Level:     level,
-		Message:   t.Message(),
-	}, nil
+	resp := &apiv1.TaskLogsResponse{
+		Id:           id,
+		TaskId:       t.TaskID,
+		Timestamp:    ts,
+		Level:        level,
+		Message:      t.Message(),
+		Log:          t.Log,
+		AllocationId: t.AllocationID,
+		AgentId:      t.AgentID,
+		ContainerId:  t.ContainerID,
+		Source:       t.Source,
+		Stdtype:      t.StdType,
+	}
+
+	if t.RankID != nil {
+		var id = int32(*t.RankID)
+		resp.RankId = &id
+	}
+
+	return resp, nil
 }
 
 // TaskLogBatch represents a batch of model.TaskLog.

--- a/proto/src/determined/api/v1/task.proto
+++ b/proto/src/determined/api/v1/task.proto
@@ -97,16 +97,34 @@ message TaskLogsRequest {
 // Response to TaskLogsRequest.
 message TaskLogsResponse {
   option (grpc.gateway.protoc_gen_swagger.options.openapiv2_schema) = {
-    json_schema: { required: [ "id", "level", "message", "timestamp" ] }
+    json_schema: {
+      required: [ "id", "level", "log", "message", "task_id", "timestamp" ]
+    }
   };
   // The ID of the log.
   string id = 1;
   // The timestamp of the log.
   google.protobuf.Timestamp timestamp = 2;
-  // The log message.
-  string message = 3;
+  // The flat version of the log that UIs have shown historically.
+  string message = 3 [deprecated = true];
   // The level of the log.
   determined.log.v1.LogLevel level = 4;
+  // The ID of the task.
+  string task_id = 5;
+  // The ID of the allocation.
+  optional string allocation_id = 6;
+  // The agent the logs came from.
+  optional string agent_id = 7;
+  // The ID of the container or, in the case of k8s, the pod name.
+  optional string container_id = 8;
+  // The rank ID.
+  optional int32 rank_id = 9;
+  // The text of the log entry.
+  string log = 10;
+  // The source of the log entry.
+  optional string source = 11;
+  // The output stream (e.g. stdout, stderr).
+  optional string stdtype = 12;
 }
 
 // Stream distinct task log fields.

--- a/proto/src/determined/api/v1/trial.proto
+++ b/proto/src/determined/api/v1/trial.proto
@@ -390,16 +390,30 @@ message TrialLogsRequest {
 // Response to TrialLogsRequest.
 message TrialLogsResponse {
   option (grpc.gateway.protoc_gen_swagger.options.openapiv2_schema) = {
-    json_schema: { required: [ "id", "level", "message", "timestamp" ] }
+    json_schema: { required: [ "id", "level", "message", "timestamp", "trial_id" ] }
   };
   // The ID of the trial log.
   string id = 1;
   // The timestamp of the log.
   google.protobuf.Timestamp timestamp = 2;
-  // The log message.
-  string message = 3;
+  // The flat version of the log that UIs have shown historically.
+  string message = 3 [deprecated = true];
   // The level of the log.
   determined.log.v1.LogLevel level = 4;
+  // The ID of the trial associated with this log entry.
+  int32 trial_id = 5;
+  // The ID of the agent that logged this.
+  optional string agent_id = 6;
+  // The ID of the container or, in the case of k8s, the pod name.
+  optional string container_id = 7;
+  // The rank ID.
+  optional int32 rank_id = 8;
+  // The text of the log entry.
+  optional string log = 9;
+  // The source of the log entry.
+  optional string source = 10;
+  // The output stream (e.g. stdout, stderr).
+  optional string stdtype = 11;
 }
 
 // Stream distinct trial log fields.

--- a/proto/src/determined/api/v1/trial.proto
+++ b/proto/src/determined/api/v1/trial.proto
@@ -390,7 +390,9 @@ message TrialLogsRequest {
 // Response to TrialLogsRequest.
 message TrialLogsResponse {
   option (grpc.gateway.protoc_gen_swagger.options.openapiv2_schema) = {
-    json_schema: { required: [ "id", "level", "message", "timestamp", "trial_id" ] }
+    json_schema: {
+      required: [ "id", "level", "message", "timestamp", "trial_id" ]
+    }
   };
   // The ID of the trial log.
   string id = 1;

--- a/webui/react/src/services/api-ts-sdk/api.ts
+++ b/webui/react/src/services/api-ts-sdk/api.ts
@@ -8113,7 +8113,7 @@ export interface V1TaskLogsResponse {
      */
     timestamp: Date;
     /**
-     * The log message.
+     * The flat version of the log that UIs have shown historically.
      * @type {string}
      * @memberof V1TaskLogsResponse
      */
@@ -8124,6 +8124,54 @@ export interface V1TaskLogsResponse {
      * @memberof V1TaskLogsResponse
      */
     level: V1LogLevel;
+    /**
+     * The ID of the task.
+     * @type {string}
+     * @memberof V1TaskLogsResponse
+     */
+    taskId: string;
+    /**
+     * The ID of the allocation.
+     * @type {string}
+     * @memberof V1TaskLogsResponse
+     */
+    allocationId?: string;
+    /**
+     * The agent the logs came from.
+     * @type {string}
+     * @memberof V1TaskLogsResponse
+     */
+    agentId?: string;
+    /**
+     * The ID of the container or, in the case of k8s, the pod name.
+     * @type {string}
+     * @memberof V1TaskLogsResponse
+     */
+    containerId?: string;
+    /**
+     * The rank ID.
+     * @type {number}
+     * @memberof V1TaskLogsResponse
+     */
+    rankId?: number;
+    /**
+     * The text of the log entry.
+     * @type {string}
+     * @memberof V1TaskLogsResponse
+     */
+    log: string;
+    /**
+     * The source of the log entry.
+     * @type {string}
+     * @memberof V1TaskLogsResponse
+     */
+    source?: string;
+    /**
+     * The output stream (e.g. stdout, stderr).
+     * @type {string}
+     * @memberof V1TaskLogsResponse
+     */
+    stdtype?: string;
 }
 
 /**
@@ -8530,7 +8578,7 @@ export interface V1TrialLogsResponse {
      */
     timestamp: Date;
     /**
-     * The log message.
+     * The flat version of the log that UIs have shown historically.
      * @type {string}
      * @memberof V1TrialLogsResponse
      */
@@ -8541,6 +8589,48 @@ export interface V1TrialLogsResponse {
      * @memberof V1TrialLogsResponse
      */
     level: V1LogLevel;
+    /**
+     * The ID of the trial associated with this log entry.
+     * @type {number}
+     * @memberof V1TrialLogsResponse
+     */
+    trialId: number;
+    /**
+     * The ID of the agent that logged this.
+     * @type {string}
+     * @memberof V1TrialLogsResponse
+     */
+    agentId?: string;
+    /**
+     * The ID of the container or, in the case of k8s, the pod name.
+     * @type {string}
+     * @memberof V1TrialLogsResponse
+     */
+    containerId?: string;
+    /**
+     * The rank ID.
+     * @type {number}
+     * @memberof V1TrialLogsResponse
+     */
+    rankId?: number;
+    /**
+     * The text of the log entry.
+     * @type {string}
+     * @memberof V1TrialLogsResponse
+     */
+    log?: string;
+    /**
+     * The source of the log entry.
+     * @type {string}
+     * @memberof V1TrialLogsResponse
+     */
+    source?: string;
+    /**
+     * The output stream (e.g. stdout, stderr).
+     * @type {string}
+     * @memberof V1TrialLogsResponse
+     */
+    stdtype?: string;
 }
 
 /**


### PR DESCRIPTION
## Description

Should finally resolve [DET-7103] by adding more fields to the task and trial log endpoints. For now, this leaves (but deprecates) the `message` field to give applications time to migrate from it to composing their own message.

## Test Plan

`/api/v1/tasks/{id}/logs` and `/api/v1/trials/{id}/logs` should now have new fields. I used the Swagger page to verify this.

## Checklist

- [x] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

[DET-7103]: https://determinedai.atlassian.net/browse/DET-7103?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ