### PR TITLE
feat: k8s restore jobs on master restart [DET-8718]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -704,6 +704,9 @@ commands:
         type: env_var_name
       environment-image:
         type: string
+      accel-node-taints:
+        type: string
+        default: ""
     steps:
       - set-cluster-id:
           cluster-id: <<parameters.cluster-id>>
@@ -743,7 +746,7 @@ commands:
           steps:
             - run:
                 command: |
-                  echo 'export HELM_VALUES="${HELM_VALUES},slotType=<<parameters.slot-type>>,slotResourceRequests.cpu=<<parameters.slot-resource-requests-cpu>>"' >> "$BASH_ENV"
+                  echo 'export HELM_VALUES="${HELM_VALUES},slotType=<<parameters.slot-type>>,slotResourceRequests.cpu=<<parameters.slot-resource-requests-cpu>>,_reattachResources=true,taskContainerDefaults.gpuPodSpec.spec.tolerations[0].key=accel,taskContainerDefaults.gpuPodSpec.spec.tolerations[0].operator=Equal,taskContainerDefaults.gpuPodSpec.spec.tolerations[0].value=truth,taskContainerDefaults.gpuPodSpec.spec.tolerations[0].effect=NoSchedule,taskContainerDefaults.cpuPodSpec.spec.tolerations[0].key=accel,taskContainerDefaults.cpuPodSpec.spec.tolerations[0].operator=Equal,taskContainerDefaults.cpuPodSpec.spec.tolerations[0].value=truth,taskContainerDefaults.cpuPodSpec.spec.tolerations[0].effect=NoSchedule"' >> "$BASH_ENV"
                 name: CPU setup helm overrides
       - when:
           condition: <<parameters.environment-image>>
@@ -766,13 +769,13 @@ commands:
           condition: <<parameters.gpus-per-machine>>
           steps:
             - run:
-                command: gcloud container node-pools create accel --cluster ${CLUSTER_ID} --region <<parameters.region>> --num-nodes <<parameters.num-machines>> --accelerator type=<<parameters.gpu-type>>,count=<<parameters.gpus-per-machine>> --machine-type=<<parameters.machine-type>> --scopes cloud-platform
+                command: gcloud container node-pools create accel --cluster ${CLUSTER_ID} --region <<parameters.region>> --num-nodes <<parameters.num-machines>> --accelerator type=<<parameters.gpu-type>>,count=<<parameters.gpus-per-machine>> --machine-type=<<parameters.machine-type>> --scopes cloud-platform --node-taints=<<parameters.accel-node-taints>>
                 name: Create GPU node pool
       - unless:
           condition: <<parameters.gpus-per-machine>>
           steps:
             - run:
-                command: gcloud container node-pools create accel --cluster ${CLUSTER_ID} --region <<parameters.region>> --num-nodes <<parameters.num-machines>> --machine-type=<<parameters.machine-type>> --scopes cloud-platform
+                command: gcloud container node-pools create accel --cluster ${CLUSTER_ID} --region <<parameters.region>> --num-nodes <<parameters.num-machines>> --machine-type=<<parameters.machine-type>> --scopes cloud-platform --node-taints=<<parameters.accel-node-taints>>
                 name: Create CPU node pool
 
   generate-tls-cert:
@@ -1892,6 +1895,9 @@ jobs:
       environment-image:
         default: determinedai/environments:cuda-11.3-pytorch-1.10-tf-2.8-gpu-0.19.10
         type: string
+      accel-node-taints:
+        type: string
+        default: ""
     environment:
       DET_TEST_GPU_ENABLED: <<parameters.environment-gpu-enabled>>
     docker:
@@ -1921,6 +1927,7 @@ jobs:
           region: <<parameters.region>>
           node-locations: <<parameters.node-locations>>
           environment-image: <<parameters.environment-image>>
+          accel-node-taints: <<parameters.accel-node-taints>>
       - set-google-application-credentials
       - when:
           condition: <<parameters.environment-image>>
@@ -2428,6 +2435,27 @@ workflows:
               slot-type: ["cpu"]
               slot-resource-requests-cpu: [7]
 
+      - test-e2e-gke:
+          name: test-e2e-gke-k8s-reattach
+          context: gcp
+          filters:
+            branches:
+              only: master
+          requires:
+            - package-and-push-system-dev
+          matrix:
+            parameters:
+              cluster-id-prefix: ["e2e-k8s"]
+              mark: ["e2e_k8s"]
+              parallelism: [1]
+              slack-mentions: ["${SLACK_USER_ID}"]
+              machine-type: ["n1-standard-8"]
+              gpus-per-machine: [0]
+              environment-gpu-enabled: ["0"]
+              slot-type: ["cpu"]
+              slot-resource-requests-cpu: [7]
+              accel-node-taints: ["accel=truth:NoSchedule"]
+
       - test-stress:
           name: test-stress
           filters: *any-upstream
@@ -2608,6 +2636,26 @@ workflows:
               environment-gpu-enabled: ["0"]
               slot-type: ["cpu"]
               slot-resource-requests-cpu: [7]
+
+      - test-e2e-gke:
+          name: test-e2e-gke-k8s-reattach
+          context: gcp
+          filters: *upstream-feature-branch
+          requires:
+            - request-k8-tests-cpu
+            - package-and-push-system-dev
+          matrix:
+            parameters:
+              cluster-id-prefix: ["e2e-k8s"]
+              mark: ["e2e_k8s"]
+              parallelism: [1]
+              slack-mentions: ["${SLACK_USER_ID}"]
+              machine-type: ["n1-standard-8"]
+              gpus-per-machine: [0]
+              environment-gpu-enabled: ["0"]
+              slot-type: ["cpu"]
+              slot-resource-requests-cpu: [7]
+              accel-node-taints: ["accel=truth:NoSchedule"]
 
       # Nightly distributed tests
       - request-gpu-distributed-nightly:

--- a/e2e_tests/pytest.ini
+++ b/e2e_tests/pytest.ini
@@ -13,6 +13,7 @@ markers =
     e2e_cpu_cross_version: end to end CPU tests for testing basic cluster functionality with differing master/agent versions
     e2e_cpu_agent_connection_loss: end to end CPU tests for testing agent functionality on connection loss
     e2e_gpu: end to end GPU tests
+    e2e_k8s: end to end tests specific to k8s (only used in test-e2e-gke-single-cpu currently)
     test_strict_ntsc: end to end test covers notebooks, tensorboards, shells, and commands with strict access controls (you can only see your own stuff)
     gpu_required: tests with a hard CUDA requirement
     distributed: distributed training tests

--- a/e2e_tests/tests/cluster/conftest.py
+++ b/e2e_tests/tests/cluster/conftest.py
@@ -6,3 +6,4 @@ from .managed_cluster import (  # noqa
     managed_cluster_session,
     managed_cluster_session_priority_scheduler,
 )
+from .managed_cluster_k8s import k8s_managed_cluster  # noqa

--- a/e2e_tests/tests/cluster/managed_cluster.py
+++ b/e2e_tests/tests/cluster/managed_cluster.py
@@ -1,3 +1,4 @@
+import abc
 import json
 import os
 import subprocess
@@ -13,6 +14,29 @@ from tests import config as conf
 from .test_users import ADMIN_CREDENTIALS, logged_in_user
 from .utils import get_master_port
 
+
+class Cluster(metaclass=abc.ABCMeta):
+    @abc.abstractmethod
+    def __init__(self) -> None:
+        pass
+
+    @abc.abstractmethod
+    def kill_master(self) -> None:
+        pass
+
+    @abc.abstractmethod
+    def restart_master(self) -> None:
+        pass
+
+    @abc.abstractmethod
+    def restart_agent(self, wait_for_amnesia: bool = True, wait_for_agent: bool = True) -> None:
+        pass
+
+    @abc.abstractmethod
+    def ensure_agent_ok(self) -> None:
+        pass
+
+
 DEVCLUSTER_CONFIG_ROOT_PATH = conf.PROJECT_ROOT_PATH.joinpath(".circleci/devcluster")
 DEVCLUSTER_REATTACH_OFF_CONFIG_PATH = DEVCLUSTER_CONFIG_ROOT_PATH / "double.devcluster.yaml"
 DEVCLUSTER_REATTACH_ON_CONFIG_PATH = DEVCLUSTER_CONFIG_ROOT_PATH / "double-reattach.devcluster.yaml"
@@ -27,7 +51,7 @@ def get_agent_data(master_url: str) -> List[Dict[str, Any]]:
     return agent_data
 
 
-class ManagedCluster:
+class ManagedCluster(Cluster):
     # This utility wrapper uses double agent yaml configurations,
     # but provides helpers to run/kill a single agent setup.
 

--- a/e2e_tests/tests/cluster/managed_cluster_k8s.py
+++ b/e2e_tests/tests/cluster/managed_cluster_k8s.py
@@ -1,0 +1,95 @@
+import time
+from typing import Iterator
+
+import pytest
+from kubernetes import client, config, watch
+
+from tests import config as conf
+
+from .managed_cluster import Cluster, get_agent_data
+from .test_groups import det_cmd
+from .utils import run_command, wait_for_command_state
+
+
+class ManagedK8sCluster(Cluster):
+    def __init__(self) -> None:
+        config.load_kube_config()
+        self.v1 = client.AppsV1Api()
+        self._scale_master(up=True)
+
+        # Verify we have pulled our image.
+        # TODO this won't work if we have multiple nodes.
+        wait_for_command_state(run_command(0, slots=0), "TERMINATED", 300)
+        wait_for_command_state(run_command(0, slots=1), "TERMINATED", 300)
+
+    def kill_master(self) -> None:
+        self._scale_master(up=False)
+
+    def restart_master(self) -> None:
+        self._scale_master(up=True)
+
+    def restart_agent(self, wait_for_amnesia: bool = True, wait_for_agent: bool = True) -> None:
+        pass
+
+    def ensure_agent_ok(self) -> None:
+        pass
+
+    def _scale_master(self, up: bool) -> None:
+        desired_pods = 0
+        if up:
+            desired_pods = 1
+
+        ret = self.v1.list_deployment_for_all_namespaces(watch=False)
+        master_deployment_list = [
+            d for d in ret.items if "determined-master-deployment" in d.metadata.name
+        ]
+        assert len(master_deployment_list) == 1
+        master_deployment = master_deployment_list[0]
+
+        replicas = master_deployment.status.available_replicas
+        if (up and replicas == 1) or (not up and replicas is None):
+            print(f"master already scaled {'up' if up else 'down'}")
+            return
+
+        patch = [{"op": "add", "path": "/spec/replicas", "value": desired_pods}]
+        self.v1.patch_namespaced_deployment_scale(
+            name=master_deployment.metadata.name,
+            namespace=master_deployment.metadata.namespace,
+            body=patch,
+        )
+
+        # Wait for pod to complete scale.
+        w = watch.Watch()
+        for event in w.stream(self.v1.list_deployment_for_all_namespaces, _request_timeout=360):
+            if event["object"].metadata.name != master_deployment.metadata.name:
+                continue
+
+            replicas = event["object"].status.available_replicas
+            print(f"Got event of master deployment updated available_replicas = {replicas}")
+            if (up and replicas == 1) or (not up and replicas is None):
+                print(f"master pods scaled {'up' if up else 'down'}")
+                w.stop()
+
+        if not up:
+            return
+
+        # Wait for determined to be up.
+        WAIT_FOR_UP = 60
+        for _ in range(WAIT_FOR_UP):
+            try:
+                assert len(get_agent_data(conf.make_master_url())) > 0
+                return
+            except Exception as e:
+                print(f"Can't reach master, retrying again {e}")
+                time.sleep(1)
+        pytest.fail(f"Unable to reach master after {WAIT_FOR_UP} seconds")
+
+
+@pytest.fixture
+def k8s_managed_cluster() -> Iterator[ManagedK8sCluster]:
+    cluster = ManagedK8sCluster()
+    cluster._scale_master(up=True)
+    yield cluster
+    cluster._scale_master(up=True)
+
+    print("Master logs: ", det_cmd(["master", "logs"], check=True).stdout.decode("utf-8"))

--- a/e2e_tests/tests/cluster/test_master_restart.py
+++ b/e2e_tests/tests/cluster/test_master_restart.py
@@ -14,7 +14,8 @@ from tests import config as conf
 from tests import experiment as exp
 from tests.cluster.test_users import det_spawn
 
-from .managed_cluster import ManagedCluster, get_agent_data
+from .managed_cluster import Cluster, ManagedCluster, get_agent_data
+from .managed_cluster_k8s import ManagedK8sCluster
 from .test_groups import det_cmd_json
 from .utils import (
     command_succeeded,
@@ -51,40 +52,64 @@ def restartable_managed_cluster(
 
 @pytest.mark.managed_devcluster
 def test_master_restart_ok(managed_cluster_restarts: ManagedCluster) -> None:
+    _sanity_check(managed_cluster_restarts)
+    _test_master_restart_ok(managed_cluster_restarts)
+    managed_cluster_restarts.restart_agent(wait_for_amnesia=False)
+    _sanity_check(managed_cluster_restarts)
+
+
+@pytest.mark.e2e_k8s
+def test_master_restart_ok_k8s(k8s_managed_cluster: ManagedK8sCluster) -> None:
+    _test_master_restart_ok(k8s_managed_cluster)
+
+
+def _test_master_restart_ok(managed_cluster: Cluster) -> None:
     # - Kill master
     # - Restart master
     # - Schedule something.
     # Do it twice to ensure nothing gets stuck.
-    _sanity_check(managed_cluster_restarts)
-
     try:
         for i in range(3):
             print("test_master_restart_ok stage %s start" % i)
             cmd_ids = [run_command(1, slots) for slots in [0, 1]]
 
             for cmd_id in cmd_ids:
-                wait_for_command_state(cmd_id, "TERMINATED", 10)
+                wait_for_command_state(cmd_id, "TERMINATED", 20)
                 assert command_succeeded(cmd_id)
 
-            managed_cluster_restarts.kill_master()
-            managed_cluster_restarts.restart_master()
+            managed_cluster.kill_master()
+            managed_cluster.restart_master()
 
             print("test_master_restart_ok stage %s done" % i)
     except Exception:
-        managed_cluster_restarts.restart_master()
-        managed_cluster_restarts.restart_agent()
+        managed_cluster.restart_master()
+        managed_cluster.restart_agent()
         raise
-    managed_cluster_restarts.restart_agent(wait_for_amnesia=False)
-    _sanity_check(managed_cluster_restarts)
 
 
 @pytest.mark.managed_devcluster
 @pytest.mark.parametrize("downtime", [0, 20, 60])
 def test_master_restart_reattach_recover_experiment(
-    managed_cluster_restarts: ManagedCluster, downtime: int
+    managed_cluster_restarts: ManagedCluster,
+    downtime: int,
 ) -> None:
     _sanity_check(managed_cluster_restarts)
+    _test_master_restart_reattach_recover_experiment(managed_cluster_restarts, downtime)
 
+
+@pytest.mark.e2e_k8s
+@pytest.mark.parametrize("downtime", [0, 20, 60])
+def test_master_restart_reattach_recover_experiment_k8s(
+    k8s_managed_cluster: ManagedK8sCluster,
+    downtime: int,
+) -> None:
+    _test_master_restart_reattach_recover_experiment(k8s_managed_cluster, downtime)
+
+
+@pytest.mark.managed_devcluster
+def _test_master_restart_reattach_recover_experiment(
+    managed_cluster_restarts: Cluster, downtime: int
+) -> None:
     try:
         exp_id = exp.create_experiment(
             conf.fixtures_path("no_op/single-medium-train-step.yaml"),
@@ -115,9 +140,21 @@ def test_master_restart_reattach_recover_experiment(
 
 
 @pytest.mark.managed_devcluster
-def test_master_restart_kill_works(managed_cluster_restarts: ManagedCluster) -> None:
+def test_master_restart_kill_works_experiment(
+    managed_cluster_restarts: ManagedCluster,
+) -> None:
     _sanity_check(managed_cluster_restarts)
+    _test_master_restart_kill_works(managed_cluster_restarts)
 
+
+@pytest.mark.e2e_k8s
+def test_master_restart_kill_works_k8s(
+    k8s_managed_cluster: ManagedK8sCluster,
+) -> None:
+    _test_master_restart_kill_works(k8s_managed_cluster)
+
+
+def _test_master_restart_kill_works(managed_cluster_restarts: Cluster) -> None:
     try:
         exp_id = exp.create_experiment(
             conf.fixtures_path("no_op/single-many-long-steps.yaml"),
@@ -134,7 +171,7 @@ def test_master_restart_kill_works(managed_cluster_restarts: ManagedCluster) -> 
         command = ["det", "-m", conf.make_master_url(), "e", "kill", str(exp_id)]
         subprocess.check_call(command)
 
-        exp.wait_for_experiment_state(exp_id, EXP_STATE.STATE_CANCELED, max_wait_secs=10)
+        exp.wait_for_experiment_state(exp_id, EXP_STATE.STATE_CANCELED, max_wait_secs=20)
 
         managed_cluster_restarts.ensure_agent_ok()
     except Exception:
@@ -148,10 +185,21 @@ def test_master_restart_kill_works(managed_cluster_restarts: ManagedCluster) -> 
 def test_master_restart_cmd(
     restartable_managed_cluster: ManagedCluster, slots: int, downtime: int
 ) -> None:
-    managed_cluster = restartable_managed_cluster
+    _test_master_restart_cmd(restartable_managed_cluster, slots, downtime)
 
+
+@pytest.mark.e2e_k8s
+@pytest.mark.parametrize("slots", [0, 1])
+@pytest.mark.parametrize("downtime", [0, 20, 60])
+def test_master_restart_cmd_k8s(
+    k8s_managed_cluster: ManagedK8sCluster, slots: int, downtime: int
+) -> None:
+    _test_master_restart_cmd(k8s_managed_cluster, slots, downtime)
+
+
+def _test_master_restart_cmd(managed_cluster: Cluster, slots: int, downtime: int) -> None:
     command_id = run_command(30, slots=slots)
-    wait_for_command_state(command_id, "RUNNING", 10)
+    wait_for_command_state(command_id, "RUNNING", 20)
 
     if downtime >= 0:
         managed_cluster.kill_master()
@@ -166,8 +214,16 @@ def test_master_restart_cmd(
 @pytest.mark.managed_devcluster
 @pytest.mark.parametrize("downtime", [5])
 def test_master_restart_shell(restartable_managed_cluster: ManagedCluster, downtime: int) -> None:
-    managed_cluster = restartable_managed_cluster
+    _test_master_restart_shell(restartable_managed_cluster, downtime)
 
+
+@pytest.mark.e2e_k8s
+@pytest.mark.parametrize("downtime", [5])
+def test_master_restart_shell_k8s(k8s_managed_cluster: ManagedK8sCluster, downtime: int) -> None:
+    _test_master_restart_shell(k8s_managed_cluster, downtime)
+
+
+def _test_master_restart_shell(managed_cluster: Cluster, downtime: int) -> None:
     with cmd.interactive_command("shell", "start", "--detach") as shell:
         task_id = shell.task_id
 
@@ -206,7 +262,7 @@ def _get_auth_token_for_curl() -> str:
 def _check_web_url(url: str, name: str) -> None:
     token = _get_auth_token_for_curl()
     bad_status_codes = []
-    for _ in range(10):
+    for _ in range(30):
         r = requests.get(url, headers={"Authorization": f"Bearer {token}"}, allow_redirects=True)
         # Sometimes the TB/JL take a bit of time to stand up, returning 502.
         # Sometimes it takes a bit of time for master to register the proxy, returning 404.
@@ -236,7 +292,16 @@ def _check_tb_url(url: str) -> None:
 def test_master_restart_notebook(
     restartable_managed_cluster: ManagedCluster, downtime: int
 ) -> None:
-    managed_cluster = restartable_managed_cluster
+    return _test_master_restart_notebook(restartable_managed_cluster, downtime)
+
+
+@pytest.mark.e2e_k8s
+@pytest.mark.parametrize("downtime", [5])
+def test_master_restart_notebook_k8s(k8s_managed_cluster: ManagedK8sCluster, downtime: int) -> None:
+    return _test_master_restart_notebook(k8s_managed_cluster, downtime)
+
+
+def _test_master_restart_notebook(managed_cluster: Cluster, downtime: int) -> None:
     with cmd.interactive_command("notebook", "start", "--detach") as notebook:
         task_id = notebook.task_id
         assert task_id is not None
@@ -259,10 +324,20 @@ def test_master_restart_notebook(
 def test_master_restart_tensorboard(
     restartable_managed_cluster: ManagedCluster, downtime: int
 ) -> None:
-    managed_cluster = restartable_managed_cluster
+    return _test_master_restart_tensorboard(restartable_managed_cluster, downtime)
 
+
+@pytest.mark.e2e_k8s
+@pytest.mark.parametrize("downtime", [5])
+def test_master_restart_tensorboard_k8s(
+    k8s_managed_cluster: ManagedK8sCluster, downtime: int
+) -> None:
+    return _test_master_restart_tensorboard(k8s_managed_cluster, downtime)
+
+
+def _test_master_restart_tensorboard(managed_cluster: Cluster, downtime: int) -> None:
     exp_id = exp.create_experiment(
-        conf.fixtures_path("no_op/single.yaml"),
+        conf.fixtures_path("no_op/single-default-ckpt.yaml"),
         conf.fixtures_path("no_op"),
         None,
     )
@@ -306,3 +381,33 @@ def test_agent_devices_change(restartable_managed_cluster: ManagedCluster) -> No
     finally:
         managed_cluster.dc.kill_stage("agent10")
         managed_cluster.restart_agent()
+
+
+@pytest.mark.e2e_k8s
+def test_master_restart_with_queued(k8s_managed_cluster: ManagedK8sCluster) -> None:
+    agent_data = get_agent_data(conf.make_master_url())
+    slots = sum([a["num_slots"] for a in agent_data])
+
+    running_command_id = run_command(60, slots)
+    queued_command_id = run_command(60, slots)
+
+    wait_for_command_state(running_command_id, "RUNNING", 25)
+    wait_for_command_state(queued_command_id, "QUEUED", 25)
+
+    job_list = det_cmd_json(["job", "list", "--json"])["jobs"]
+
+    k8s_managed_cluster.kill_master()
+    k8s_managed_cluster.restart_master()
+
+    post_restart_job_list = det_cmd_json(["job", "list", "--json"])["jobs"]
+
+    # TODO(DET-8776): command submission times get overwritten to master start currently.
+    assert len(job_list) == len(post_restart_job_list)
+    for pre, post in zip(job_list, post_restart_job_list):
+        post["submissionTime"] = pre["submissionTime"]
+
+    assert job_list == post_restart_job_list
+
+    for cmd_id in [running_command_id, queued_command_id]:
+        wait_for_command_state(cmd_id, "TERMINATED", 60)
+        assert "success" in get_command_info(cmd_id)["exitStatus"]

--- a/e2e_tests/tests/conftest.py
+++ b/e2e_tests/tests/conftest.py
@@ -26,6 +26,7 @@ _INTEG_MARKERS = {
     "e2e_cpu_agent_connection_loss",
     "e2e_cpu_elastic",
     "e2e_gpu",
+    "e2e_k8s",
     "det_deploy_local",
     "stress_test",
     "test_strict_ntsc",

--- a/e2e_tests/tests/requirements.txt
+++ b/e2e_tests/tests/requirements.txt
@@ -11,3 +11,4 @@ pandas
 pyyaml
 docker
 python-dateutil
+kubernetes

--- a/helm/charts/determined/templates/master-config.yaml
+++ b/helm/charts/determined/templates/master-config.yaml
@@ -122,6 +122,9 @@ data:
       fluent:
         {{- toYaml .Values.fluent | nindent 8}}
       {{- end }}
+      {{- if .Values._reattachResources }}
+      _reattach_resources: {{ .Values._reattachResources }}
+      {{- end }}
 
     {{$cpuImage := (split "/" "determinedai/environments:py-3.8-pytorch-1.10-tf-2.8-cpu-24586f0")._1}}
     {{- $gpuImage := (split "/" "determinedai/environments:cuda-11.3-pytorch-1.10-tf-2.8-gpu-24586f0")._1 -}}

--- a/helm/charts/determined/values.yaml
+++ b/helm/charts/determined/values.yaml
@@ -250,6 +250,9 @@ telemetry:
 ## scheduling with preemption
 # defaultScheduler: preemption
 
+# Experimental feature flag to enable support for reattaching resources if master goes down.
+# _reattachResources: true
+
 ## Configure settings about how Determined launches the Fluent Bit sidecar.
 # fluent:
 #   image: fluent/fluent-bit:1.6

--- a/master/internal/api_tasks.go
+++ b/master/internal/api_tasks.go
@@ -175,6 +175,9 @@ func (a *apiServer) AllocationReady(
 	if err != nil {
 		return nil, err
 	}
+	if err := a.waitForAllocationToBeRestored(ctx, resp); err != nil {
+		return nil, err
+	}
 
 	if err := a.ask(resp.Address(), task.AllocationReady{}, nil); err != nil {
 		return nil, err
@@ -194,6 +197,9 @@ func (a *apiServer) AllocationWaiting(
 		sproto.GetAllocationHandler{ID: model.AllocationID(req.AllocationId)},
 	)
 	if err != nil {
+		return nil, err
+	}
+	if err := a.waitForAllocationToBeRestored(ctx, resp); err != nil {
 		return nil, err
 	}
 
@@ -218,6 +224,9 @@ func (a *apiServer) AllocationAllGather(
 		sproto.GetAllocationHandler{ID: model.AllocationID(req.AllocationId)},
 	)
 	if err != nil {
+		return nil, err
+	}
+	if err := a.waitForAllocationToBeRestored(ctx, handler); err != nil {
 		return nil, err
 	}
 
@@ -262,6 +271,9 @@ func (a *apiServer) PostAllocationProxyAddress(
 		sproto.GetAllocationHandler{ID: model.AllocationID(req.AllocationId)},
 	)
 	if err != nil {
+		return nil, err
+	}
+	if err := a.waitForAllocationToBeRestored(ctx, handler); err != nil {
 		return nil, err
 	}
 

--- a/master/internal/command/command.go
+++ b/master/internal/command/command.go
@@ -148,6 +148,7 @@ func remakeCommandsByType(
 		Relation("Task").
 		Relation("Task.Job").
 		Where("allocation.end_time IS NULL").
+		Where("allocation.state != ?", model.AllocationStateTerminated).
 		Where("task.task_type = ?", taskType).
 		Scan(context.TODO())
 	if err != nil {

--- a/master/internal/config/resource_manager_config.go
+++ b/master/internal/config/resource_manager_config.go
@@ -110,6 +110,9 @@ type KubernetesResourceManagerConfig struct {
 	CredsDir                 string                  `json:"_creds_dir,omitempty"`
 	MasterIP                 string                  `json:"_master_ip,omitempty"`
 	MasterPort               int32                   `json:"_master_port,omitempty"`
+	// TODO(nick) this will eventually move down to resource pools when added to k8s
+	// so this is just an experimental feature flag for now.
+	ReattachResources bool `json:"_reattach_resources"`
 }
 
 var defaultKubernetesResourceManagerConfig = KubernetesResourceManagerConfig{

--- a/master/internal/rm/kubernetesrm/kubernetes_resource_manager.go
+++ b/master/internal/rm/kubernetesrm/kubernetes_resource_manager.go
@@ -181,6 +181,22 @@ func (k ResourceManager) NotifyContainerRunning(
 		"the NotifyContainerRunning message is unsupported for KubernetesResourceManager")
 }
 
+// IsReattachableOnlyAfterStarted always returns false for the k8s resource manager.
+func (k ResourceManager) IsReattachableOnlyAfterStarted(ctx actor.Messenger) bool {
+	return false
+}
+
+// IsReattachEnabled returns a boolean based on the k8s rm config _reattach_kubernetes_resources.
+func (k ResourceManager) IsReattachEnabled(ctx actor.Messenger) bool {
+	return config.GetMasterConfig().ResourceManager.KubernetesRM.ReattachResources
+}
+
+// IsReattachEnabledForRP returns a boolean
+// based on the k8s rm config _reattach_kubernetes_resources.
+func (k ResourceManager) IsReattachEnabledForRP(ctx actor.Messenger, rp string) bool {
+	return k.IsReattachEnabled(ctx)
+}
+
 // kubernetesResourceProvider manages the lifecycle of k8s resources.
 type kubernetesResourceManager struct {
 	config    *config.KubernetesResourceManagerConfig

--- a/master/internal/rm/kubernetesrm/kubernetes_resource_manager.go
+++ b/master/internal/rm/kubernetesrm/kubernetes_resource_manager.go
@@ -186,13 +186,13 @@ func (k ResourceManager) IsReattachableOnlyAfterStarted(ctx actor.Messenger) boo
 	return false
 }
 
-// IsReattachEnabled returns a boolean based on the k8s rm config _reattach_kubernetes_resources.
+// IsReattachEnabled returns a boolean based on the k8s rm config _reattach_resources.
 func (k ResourceManager) IsReattachEnabled(ctx actor.Messenger) bool {
 	return config.GetMasterConfig().ResourceManager.KubernetesRM.ReattachResources
 }
 
 // IsReattachEnabledForRP returns a boolean
-// based on the k8s rm config _reattach_kubernetes_resources.
+// based on the k8s rm config _reattach_resources.
 func (k ResourceManager) IsReattachEnabledForRP(ctx actor.Messenger, rp string) bool {
 	return k.IsReattachEnabled(ctx)
 }

--- a/master/internal/rm/kubernetesrm/pod.go
+++ b/master/internal/rm/kubernetesrm/pod.go
@@ -34,18 +34,24 @@ const (
 	determinedSystemLabel     = "determined-system"
 )
 
+type podSubmissionInfo struct {
+	taskSpec tasks.TaskSpec
+}
+
 // pod manages the lifecycle of a Kubernetes pod that executes a
 // Determined task. The lifecycle of the pod is managed based on
 // the status of the specified set of containers.
 type pod struct {
-	cluster                  *actor.Ref
-	clusterID                string
-	taskActor                *actor.Ref
-	clientSet                *k8sClient.Clientset
-	namespace                string
-	masterIP                 string
-	masterPort               int32
-	taskSpec                 tasks.TaskSpec
+	cluster    *actor.Ref
+	clusterID  string
+	taskActor  *actor.Ref
+	clientSet  *k8sClient.Clientset
+	namespace  string
+	masterIP   string
+	masterPort int32
+	// submissionInfo will be nil when the pod is restored.
+	// These fields can not be relied on after a pod is submitted.
+	submissionInfo           *podSubmissionInfo
 	masterTLSConfig          model.TLSClientConfig
 	loggingTLSConfig         model.TLSClientConfig
 	loggingConfig            model.LoggingConfig
@@ -71,6 +77,8 @@ type pod struct {
 	containerNames   map[string]bool
 
 	logCtx logger.Context
+
+	restore bool
 }
 
 type getPodNodeInfo struct{}
@@ -114,6 +122,9 @@ func newPod(
 	containerNames := map[string]bool{model.DeterminedK8ContainerName: true}
 
 	return &pod{
+		submissionInfo: &podSubmissionInfo{
+			taskSpec: msg.Spec,
+		},
 		cluster:                  cluster,
 		clusterID:                clusterID,
 		taskActor:                msg.TaskActor,
@@ -121,7 +132,6 @@ func newPod(
 		namespace:                namespace,
 		masterIP:                 masterIP,
 		masterPort:               masterPort,
-		taskSpec:                 msg.Spec,
 		masterTLSConfig:          masterTLSConfig,
 		loggingTLSConfig:         loggingTLSConfig,
 		loggingConfig:            loggingConfig,
@@ -148,8 +158,20 @@ func (p *pod) Receive(ctx *actor.Context) error {
 	switch msg := ctx.Message().(type) {
 	case actor.PreStart:
 		ctx.AddLabels(p.logCtx)
-		if err := p.createPodSpecAndSubmit(ctx); err != nil {
-			return err
+		if p.restore {
+			if p.container.State == cproto.Running && !p.testLogStreamer {
+				logStreamer, err := newPodLogStreamer(p.podInterface, p.podName, ctx.Self())
+				if err != nil {
+					return err
+				}
+				if _, ok := ctx.ActorOf(fmt.Sprintf("%s-logs", p.podName), logStreamer); !ok {
+					return errors.Errorf("log streamer already exists")
+				}
+			}
+		} else {
+			if err := p.createPodSpecAndSubmit(ctx); err != nil {
+				return errors.Wrap(err, "error creating pod spec")
+			}
 		}
 
 	case resourceCreationFailed:
@@ -276,28 +298,7 @@ func (p *pod) receivePodStatusUpdate(ctx *actor.Context, msg podStatusUpdate) er
 			}
 		}
 
-		addresses := []cproto.Address{}
-		for _, port := range p.ports {
-			addresses = append(addresses, cproto.Address{
-				ContainerIP:   p.pod.Status.PodIP,
-				ContainerPort: port,
-				HostIP:        p.pod.Status.PodIP,
-				HostPort:      port,
-			})
-		}
-		var taskContainerID string
-		for _, containerStatus := range p.pod.Status.ContainerStatuses {
-			if containerStatus.Name == model.DeterminedK8ContainerName {
-				taskContainerID = containerStatus.ContainerID
-				break
-			}
-		}
-
-		p.informTaskResourcesStarted(ctx, sproto.ResourcesStarted{
-			Addresses:         addresses,
-			NativeResourcesID: taskContainerID,
-		})
-
+		p.informTaskResourcesStarted(ctx, getResourcesStartedForPod(p.pod, p.ports))
 	case cproto.Terminated:
 		exitCode, exitMessage, err := getExitCodeAndMessage(p.pod, p.containerNames)
 		if err != nil {
@@ -584,6 +585,31 @@ func getExitCodeAndMessage(pod *k8sV1.Pod, containerNames map[string]bool) (int,
 	}
 
 	return 0, "", errors.Errorf("unable to get exit code from pod %s", pod.Name)
+}
+
+func getResourcesStartedForPod(pod *k8sV1.Pod, ports []int) sproto.ResourcesStarted {
+	addresses := []cproto.Address{}
+	for _, port := range ports {
+		addresses = append(addresses, cproto.Address{
+			ContainerIP:   pod.Status.PodIP,
+			ContainerPort: port,
+			HostIP:        pod.Status.PodIP,
+			HostPort:      port,
+		})
+	}
+
+	var taskContainerID string
+	for _, containerStatus := range pod.Status.ContainerStatuses {
+		if containerStatus.Name == model.DeterminedK8ContainerName {
+			taskContainerID = containerStatus.ContainerID
+			break
+		}
+	}
+
+	return sproto.ResourcesStarted{
+		Addresses:         addresses,
+		NativeResourcesID: taskContainerID,
+	}
 }
 
 func getDeterminedContainersStatus(

--- a/master/internal/rm/kubernetesrm/spec.go
+++ b/master/internal/rm/kubernetesrm/spec.go
@@ -140,7 +140,7 @@ func (p *pod) configureConfigMapSpec(
 		ObjectMeta: metaV1.ObjectMeta{
 			Name:      p.configMapName,
 			Namespace: p.namespace,
-			Labels:    map[string]string{determinedLabel: p.taskSpec.AllocationID},
+			Labels:    map[string]string{determinedLabel: p.submissionInfo.taskSpec.AllocationID},
 		},
 		BinaryData: configMapData,
 	}, nil
@@ -192,9 +192,9 @@ func (p *pod) configureVolumes(
 	volumeMounts = append(volumeMounts, hostVolumeMounts...)
 	volumes = append(volumes, hostVolumes...)
 
-	shmSize := p.taskSpec.ShmSize
+	shmSize := p.submissionInfo.taskSpec.ShmSize
 	if shmSize == 0 {
-		shmSize = p.taskSpec.TaskContainerDefaults.ShmSizeBytes
+		shmSize = p.submissionInfo.taskSpec.TaskContainerDefaults.ShmSizeBytes
 	}
 	shmVolumeMount, shmVolume := configureShmVolume(shmSize)
 	volumeMounts = append(volumeMounts, shmVolumeMount)
@@ -213,11 +213,11 @@ func (p *pod) configureVolumes(
 }
 
 func (p *pod) modifyPodSpec(newPod *k8sV1.Pod, scheduler string) {
-	if p.taskSpec.Description == cmdTask {
+	if p.submissionInfo.taskSpec.Description == cmdTask {
 		return
 	}
 
-	if p.taskSpec.Description == gcTask {
+	if p.submissionInfo.taskSpec.Description == gcTask {
 		if newPod.Spec.PriorityClassName != "" {
 			log.Warnf(
 				"GC Priority is currently using priority class: %s. "+
@@ -233,9 +233,10 @@ func (p *pod) modifyPodSpec(newPod *k8sV1.Pod, scheduler string) {
 		p.configureCoscheduler(newPod, scheduler)
 	}
 
-	if newPod.Spec.PriorityClassName == "" && p.taskSpec.ResourcesConfig.Priority() != nil {
-		priority := int32(*p.taskSpec.ResourcesConfig.Priority())
-		name := fmt.Sprintf("%s-priorityclass", p.taskSpec.ContainerID)
+	if newPod.Spec.PriorityClassName == "" &&
+		p.submissionInfo.taskSpec.ResourcesConfig.Priority() != nil {
+		priority := int32(*p.submissionInfo.taskSpec.ResourcesConfig.Priority())
+		name := fmt.Sprintf("%s-priorityclass", p.submissionInfo.taskSpec.ContainerID)
 
 		err := p.createPriorityClass(name, priority)
 
@@ -252,7 +253,7 @@ func (p *pod) configureCoscheduler(newPod *k8sV1.Pod, scheduler string) {
 		return
 	}
 
-	resources := p.taskSpec.ResourcesConfig
+	resources := p.submissionInfo.taskSpec.ResourcesConfig
 	minAvailable := 0
 
 	if p.slotType == device.CUDA && p.slots > 0 {
@@ -318,7 +319,7 @@ func (p *pod) configurePodSpec(
 	if podSpec.ObjectMeta.Labels == nil {
 		podSpec.ObjectMeta.Labels = make(map[string]string)
 	}
-	podSpec.ObjectMeta.Labels[determinedLabel] = p.taskSpec.AllocationID
+	podSpec.ObjectMeta.Labels[determinedLabel] = p.submissionInfo.taskSpec.AllocationID
 
 	p.modifyPodSpec(podSpec, scheduler)
 
@@ -355,7 +356,7 @@ func (p *pod) configurePodSpec(
 	podSpec.Spec.Containers = append(podSpec.Spec.Containers, sidecarContainers...)
 	podSpec.Spec.Containers = append(podSpec.Spec.Containers, determinedContainer)
 	podSpec.Spec.Volumes = append(podSpec.Spec.Volumes, volumes...)
-	podSpec.Spec.HostNetwork = p.taskSpec.TaskContainerDefaults.NetworkMode.IsHost()
+	podSpec.Spec.HostNetwork = p.submissionInfo.taskSpec.TaskContainerDefaults.NetworkMode.IsHost()
 	podSpec.Spec.InitContainers = append(podSpec.Spec.InitContainers, determinedInitContainers)
 	podSpec.Spec.RestartPolicy = k8sV1.RestartPolicyNever
 
@@ -370,7 +371,7 @@ func (p *pod) createPodSpec(ctx *actor.Context, scheduler string) error {
 		deviceType = device.CPU
 	}
 
-	spec := p.taskSpec
+	spec := p.submissionInfo.taskSpec
 
 	runArchives, rootArchives := spec.Archives()
 
@@ -380,8 +381,15 @@ func (p *pod) createPodSpec(ctx *actor.Context, scheduler string) error {
 
 	env := spec.Environment
 
+	// This array containerPorts is set on the container spec.
+	// This field on the container spec is for "primarily informational"
+	// reasons and to allow us to read these ports in reattaching pods.
+	var containerPorts []k8sV1.ContainerPort
 	for _, port := range env.Ports() {
 		p.ports = append(p.ports, port)
+		containerPorts = append(containerPorts, k8sV1.ContainerPort{
+			ContainerPort: int32(port),
+		})
 	}
 
 	envVars, err := p.configureEnvVars(spec.EnvVars(), env, deviceType)
@@ -462,8 +470,8 @@ func (p *pod) createPodSpec(ctx *actor.Context, scheduler string) error {
 	)
 
 	var fluentSecCtx *k8sV1.SecurityContext
-	nonRootTask := p.taskSpec.AgentUserGroup != nil &&
-		p.taskSpec.AgentUserGroup.User != rootUserName
+	nonRootTask := p.submissionInfo.taskSpec.AgentUserGroup != nil &&
+		p.submissionInfo.taskSpec.AgentUserGroup.User != rootUserName
 	if p.fluentConfig.UID != 0 || p.fluentConfig.GID != 0 {
 		fluentSecCtx = configureSecurityContext(&model.AgentUserGroup{
 			UID: p.fluentConfig.UID,
@@ -493,6 +501,7 @@ func (p *pod) createPodSpec(ctx *actor.Context, scheduler string) error {
 		Resources:       p.configureResourcesRequirements(),
 		VolumeMounts:    volumeMounts,
 		WorkingDir:      spec.WorkDir,
+		Ports:           containerPorts,
 	}
 
 	p.configMap, err = p.configureConfigMapSpec(runArchives, fluentFiles)

--- a/master/internal/rm/resource_manager_iface.go
+++ b/master/internal/rm/resource_manager_iface.go
@@ -12,6 +12,7 @@ import (
 // ResourceManager is an interface for a resource manager, which can allocate and manage resources.
 type ResourceManager interface {
 	// Basic functionality
+	// Returns an error if the allocation ID is not able to be found.
 	GetAllocationHandler(actor.Messenger, sproto.GetAllocationHandler) (*actor.Ref, error)
 	GetAllocationSummary(
 		actor.Messenger,

--- a/master/internal/sproto/task.go
+++ b/master/internal/sproto/task.go
@@ -46,6 +46,9 @@ type (
 		ProxyPort    *ProxyPortConfig
 		StreamEvents *EventStreamConfig
 		Restore      bool
+
+		// Logging context of the allocation actor.
+		LogContext logger.Context
 	}
 
 	// IdleTimeoutConfig configures how idle timeouts should behave.

--- a/master/internal/task/allocation.go
+++ b/master/internal/task/allocation.go
@@ -673,7 +673,6 @@ func (a *Allocation) RestoreResourceFailure(
 		switch heartbeat := cluster.TheLastBootClusterHeartbeat(); {
 		case a.model.StartTime == nil:
 			break
-
 		case heartbeat.Before(*a.model.StartTime):
 			a.model.EndTime = a.model.StartTime
 		default:

--- a/master/internal/task/allocation.go
+++ b/master/internal/task/allocation.go
@@ -120,8 +120,8 @@ type (
 	SetAllocationProxyAddress struct {
 		ProxyAddress string
 	}
-	// AllocationNotRestoring asks the allocation if it is in the middle of a restore.
-	AllocationNotRestoring struct{}
+	// IsAllocationRestoring asks the allocation if it is in the middle of a restore.
+	IsAllocationRestoring struct{}
 )
 
 const (
@@ -188,12 +188,8 @@ func (a *Allocation) Receive(ctx *actor.Context) error {
 			a.Error(ctx, err)
 		}
 
-	case AllocationNotRestoring:
-		if a.req.Restore && !a.restored {
-			ctx.Respond(ErrAllocationStillRestoring{})
-		} else {
-			ctx.Respond(true)
-		}
+	case IsAllocationRestoring:
+		ctx.Respond(a.req.Restore && !a.restored)
 
 	case sproto.ResourcesAllocated:
 		if err := a.ResourcesAllocated(ctx, msg); err != nil {

--- a/master/internal/task/errors.go
+++ b/master/internal/task/errors.go
@@ -17,6 +17,13 @@ func (e ErrTimeoutExceeded) Error() string {
 	return fmt.Sprintf("timeout exceeded: %s", e.Message)
 }
 
+// ErrAllocationStillRestoring is returned when the allocation is in progress of a restore.
+type ErrAllocationStillRestoring struct{}
+
+func (e ErrAllocationStillRestoring) Error() string {
+	return "allocation still in progress of restoring"
+}
+
 // ErrNoAllocation is returned an operation is tried without a requested allocation.
 type ErrNoAllocation struct {
 	Action string

--- a/master/internal/task/errors.go
+++ b/master/internal/task/errors.go
@@ -17,13 +17,6 @@ func (e ErrTimeoutExceeded) Error() string {
 	return fmt.Sprintf("timeout exceeded: %s", e.Message)
 }
 
-// ErrAllocationStillRestoring is returned when the allocation is in progress of a restore.
-type ErrAllocationStillRestoring struct{}
-
-func (e ErrAllocationStillRestoring) Error() string {
-	return "allocation still in progress of restoring"
-}
-
 // ErrNoAllocation is returned an operation is tried without a requested allocation.
 type ErrNoAllocation struct {
 	Action string

--- a/master/internal/trial.go
+++ b/master/internal/trial.go
@@ -669,7 +669,8 @@ func (t *trial) maybeRestoreAllocation(ctx *actor.Context) (*model.Allocation, e
 	var allocations []model.Allocation
 	selectQuery := db.Bun().NewSelect().Model(&allocations).
 		Where("task_id = ?", t.taskID).
-		Where("end_time IS NULL")
+		Where("end_time IS NULL").
+		Where("state != ?", model.AllocationStateTerminated)
 
 	if t.rm.IsReattachableOnlyAfterStarted(ctx) {
 		selectQuery.Where("start_time IS NOT NULL")


### PR DESCRIPTION
## Description

Fault tolerance for kubernetes master by restoring jobs upon master restart.

## Test Plan

e2e tests

Manual test

Deploy a k8s cluster with helm chart option ```_reattachResources```

Then run jobs and delete the master pod and the deployment should create a new pod eventually and things should behave reasonably. Jobs shouldn't error or get deleted on master restart. 

## Commentary (optional)



<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
