### PR TITLE
feat: Add link to fork / continued trial [WEB-296]

### DIFF
--- a/webui/react/src/ioTypes.ts
+++ b/webui/react/src/ioTypes.ts
@@ -167,6 +167,7 @@ export const ioExperimentConfig = io.type({
     metric: io.string,
     name: io.keyof(experimentSearcherName),
     smaller_is_better: io.boolean,
+    source_trial_id: io.union([io.null, io.number]),
   }),
 });
 export type ioTypeExperimentConfig = io.TypeOf<typeof ioExperimentConfig>;

--- a/webui/react/src/pages/ExperimentDetails/ExperimentDetailsHeader.tsx
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentDetailsHeader.tsx
@@ -139,9 +139,6 @@ const ExperimentDetailsHeader: React.FC<Props> = ({
   const isPausable = pausableRunStates.has(experiment.state);
   const isPaused = experiment.state === RunState.Paused;
   const isTerminated = terminalRunStates.has(experiment.state);
-  const continuesTrial = experiment.originalConfig.match(
-    /description: (>-\s+)?Continuation of trial/,
-  );
 
   if (isTerminated) classes.push(css.terminated);
 
@@ -461,20 +458,18 @@ const ExperimentDetailsHeader: React.FC<Props> = ({
                 onSave={handleDescriptionUpdate}
               />
             </div>
-            {experiment.forkedFrom &&
-              continuesTrial &&
-              experiment.config.searcher.sourceTrialId && (
-                <div className={css.foldableItem}>
-                  <span className={css.foldableItemLabel}>Continued from:</span>
-                  <Link
-                    className={css.link}
-                    path={paths.trialDetails(experiment.config.searcher.sourceTrialId)}>
-                    Trial {experiment.config.searcher.sourceTrialId} - Experiment{' '}
-                    {experiment.forkedFrom}
-                  </Link>
-                </div>
-              )}
-            {experiment.forkedFrom && !continuesTrial && (
+            {experiment.forkedFrom && experiment.config.searcher.sourceTrialId && (
+              <div className={css.foldableItem}>
+                <span className={css.foldableItemLabel}>Continued from:</span>
+                <Link
+                  className={css.link}
+                  path={paths.trialDetails(experiment.config.searcher.sourceTrialId)}>
+                  Trial {experiment.config.searcher.sourceTrialId} - Experiment{' '}
+                  {experiment.forkedFrom}
+                </Link>
+              </div>
+            )}
+            {experiment.forkedFrom && !experiment.config.searcher.sourceTrialId && (
               <div className={css.foldableItem}>
                 <span className={css.foldableItemLabel}>Forked from:</span>
                 <Link className={css.link} path={paths.experimentDetails(experiment.forkedFrom)}>

--- a/webui/react/src/pages/ExperimentDetails/ExperimentDetailsHeader.tsx
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentDetailsHeader.tsx
@@ -139,6 +139,9 @@ const ExperimentDetailsHeader: React.FC<Props> = ({
   const isPausable = pausableRunStates.has(experiment.state);
   const isPaused = experiment.state === RunState.Paused;
   const isTerminated = terminalRunStates.has(experiment.state);
+  const continuesTrial = experiment.originalConfig.match(
+    /description: (>-\s+)?Continuation of trial/,
+  );
 
   if (isTerminated) classes.push(css.terminated);
 
@@ -458,6 +461,27 @@ const ExperimentDetailsHeader: React.FC<Props> = ({
                 onSave={handleDescriptionUpdate}
               />
             </div>
+            {experiment.forkedFrom &&
+              continuesTrial &&
+              experiment.config.searcher.sourceTrialId && (
+                <div className={css.foldableItem}>
+                  <span className={css.foldableItemLabel}>Continued from:</span>
+                  <Link
+                    className={css.link}
+                    path={paths.trialDetails(experiment.config.searcher.sourceTrialId)}>
+                    Trial {experiment.config.searcher.sourceTrialId} - Experiment{' '}
+                    {experiment.forkedFrom}
+                  </Link>
+                </div>
+              )}
+            {experiment.forkedFrom && !continuesTrial && (
+              <div className={css.foldableItem}>
+                <span className={css.foldableItemLabel}>Forked from:</span>
+                <Link className={css.link} path={paths.experimentDetails(experiment.forkedFrom)}>
+                  {experiment.forkedFrom}
+                </Link>
+              </div>
+            )}
             <div className={css.foldableItem}>
               <span className={css.foldableItemLabel}>Started:</span>
               <TimeAgo datetime={experiment.startTime} long />

--- a/webui/react/src/services/decoder.ts
+++ b/webui/react/src/services/decoder.ts
@@ -373,6 +373,7 @@ export const ioToExperimentConfig = (
       ...io.searcher,
       name: io.searcher.name as types.ExperimentSearcherName,
       smallerIsBetter: io.searcher.smaller_is_better,
+      sourceTrialId: io.searcher.source_trial_id ?? undefined,
     },
   };
   if (io.resources.max_slots != null) config.resources.maxSlots = io.resources.max_slots;

--- a/webui/react/src/types.ts
+++ b/webui/react/src/types.ts
@@ -312,6 +312,7 @@ export interface ExperimentConfig {
     metric: string;
     name: ExperimentSearcherName;
     smallerIsBetter: boolean;
+    sourceTrialId?: number;
   };
 }
 


### PR DESCRIPTION
## Description

We have a Forked From column on ExperimentList, but currently no specific link from the ExperimentDetails back to this experiment or a continued trial.

Yesterday's team convo suggested telling forks/continuations apart using the `experiment.originalConfig.description`. I have a regex which does this, but the less hacky way appears to be reading `experiment.config.searcher.source_trial_id` which is a number on continuations and null for others.

Ongoing issue: when you fork a continued trial, the `source_trial_id` stays on. So I'm not sure to link back to the original trial or experiment at this point.

## Test Plan

- Create or find an existing experiment with no parent_id / forked from experiment. The expanded ExperimentDetails header should look like this (no mention of fork / continued)

<img width="969" alt="Screen Shot 2022-12-13 at 10 06 16 AM" src="https://user-images.githubusercontent.com/643918/207383949-2a967887-8e34-4ddc-b11d-fd69114a2242.png">

- Fork this experiment. You should see Forked from ### and this links to the previous experiment.

<img width="945" alt="Screen Shot 2022-12-13 at 10 14 20 AM" src="https://user-images.githubusercontent.com/643918/207385782-c8326be9-1802-46e9-842b-28c682c967ee.png">

- Continue one trial of a multi-trial experiment. You should see Continued from ### and a link to the previous trial.

<img width="961" alt="Screen Shot 2022-12-13 at 10 12 15 AM" src="https://user-images.githubusercontent.com/643918/207385753-f6e159ad-90ef-44d3-8007-0e2b981d1a97.png">


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
