### PR TITLE
fix: Do not fail gc of already deleted checkpoints [FOUNDENG-387]

### DIFF
--- a/harness/determined/exec/gc_checkpoints.py
+++ b/harness/determined/exec/gc_checkpoints.py
@@ -9,7 +9,7 @@ import sys
 from typing import Any, List
 
 import determined as det
-from determined import tensorboard
+from determined import errors, tensorboard
 from determined.common import constants, storage
 
 
@@ -24,7 +24,10 @@ def delete_checkpoints(
     for storage_id in to_delete:
         if not dry_run:
             logging.info(f"Deleting checkpoint {storage_id}")
-            manager.delete(storage_id)
+            try:
+                manager.delete(storage_id)
+            except errors.CheckpointNotFound as e:
+                logging.warn(e)
         else:
             logging.info(f"Dry run: deleting checkpoint {storage_id}")
 
@@ -37,7 +40,10 @@ def delete_tensorboards(manager: tensorboard.TensorboardManager, dry_run: bool =
         logging.info(f"Dry run: deleting Tensorboards for {manager.sync_path}")
         return
 
-    manager.delete()
+    try:
+        manager.delete()
+    except errors.CheckpointNotFound as e:
+        logging.warn(e)
     logging.info(f"Finished deleting Tensorboards for {manager.sync_path}")
 
 


### PR DESCRIPTION
## Description

If a checkpoint/tensorboard does not exist (due to manual delete, change in configuration, etc), do not fail the GC if the checkpoint or tensorboard is already gone.

On HPC development systems we commonly see the case where a checkpoint may not exist, this prevent the experiment from ever being deleted because the GC task will fail if it cannot successfully delete all checkpoints.
Handle the errors.CheckpointNotFound exception, and just log as a warn and treat as a success.

## Test Plan

Validated manually that test_noop_hpc can now run successfully and cleanup checkpoints without any errors in the task.
Validated  deletion of experiments that previously would go to DELETE_FAILED state.

## Commentary (optional)

This is a general improvement that alleviates the symptom of duplicated checkpoint id in the DB that sometimes occurs on HPC systems (root cause still being investigated). 


## Checklist

- [X] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
