### PR TITLE
fix: Ensure current user available for new username / display name [WEB-724]

### DIFF
--- a/webui/react/src/App.tsx
+++ b/webui/react/src/App.tsx
@@ -25,7 +25,7 @@ import usePolling from 'shared/hooks/usePolling';
 import { StoreContext } from 'stores';
 import { useAuth } from 'stores/auth';
 import { initInfo, useDeterminedInfo, useEnsureInfoFetched } from 'stores/determinedInfo';
-import { useFetchUsers } from 'stores/users';
+import { useEnsureCurrentUserFetched, useFetchUsers } from 'stores/users';
 import { correctViewportHeight, refreshPage } from 'utils/browser';
 import { Loadable } from 'utils/loadable';
 
@@ -53,6 +53,7 @@ const AppView: React.FC = () => {
 
   const fetchInfo = useEnsureInfoFetched(canceler);
   const fetchUsers = useFetchUsers(canceler);
+  const fetchCurrentUser = useEnsureCurrentUserFetched(canceler);
 
   useEffect(() => {
     if (isServerReachable) checkAuth();
@@ -69,8 +70,9 @@ const AppView: React.FC = () => {
   useEffect(() => {
     if (isAuthenticated) {
       fetchUsers();
+      fetchCurrentUser();
     }
-  }, [isAuthenticated, fetchUsers]);
+  }, [isAuthenticated, fetchCurrentUser, fetchUsers]);
 
   useEffect(() => {
     /*


### PR DESCRIPTION
## Description

This is a bug with the UserSettings page which I think was mis-identified as an issue with admin/determined users (which do have restricted usernames).

- When logging into the app, we call `updateCurrentUser` with the login user, and you can visit `/det/settings/account`
- When refreshing the app or loading a new tab while signed in, `updateCurrentUser` is never called, so `/det/settings/account` shows U for Undefined / Unloaded.

This PR adds `useEnsureCurrentUserFetched` to the user store and calls it on the App.tsx level.

Other changes:
- fixed an array fn which was always true: `findIndex((user) => user.id === user.id)`
- `updateCurrentUser` was renamed to `updateContextUser` inside of a function to create a new callback named `updateCurrentUser` and I would rather avoid this

## Test Plan

- Open `/det/settings/account` and confirm it has your username and display name populated in the form
- Refresh the page, or open `/det/settings/account` in a new tab; essentially confirm that the username and display name are populated in the form even if you haven't just logged in
- Update display name without errors
- Changes to user/display name persist on refreshing page

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.