### PR TITLE
fix: hide Active Command UI unless it can be populated from API

### DIFF
--- a/webui/react/src/pages/Cluster/ClusterOverallStats.test.tsx
+++ b/webui/react/src/pages/Cluster/ClusterOverallStats.test.tsx
@@ -2,9 +2,11 @@ import { render } from '@testing-library/react';
 import React from 'react';
 
 import StoreProvider from 'contexts/Store';
+import { AuthProvider } from 'stores/auth';
 import { ExperimentsProvider } from 'stores/experiments';
 import { ResourcePoolsProvider } from 'stores/resourcePools';
 import { TasksProvider } from 'stores/tasks';
+import { UserRolesProvider } from 'stores/userRoles';
 
 import { ClusterOverallStats } from './ClusterOverallStats';
 
@@ -16,13 +18,17 @@ jest.mock('services/api', () => ({
 const setup = () => {
   const view = render(
     <StoreProvider>
-      <ExperimentsProvider>
-        <TasksProvider>
-          <ResourcePoolsProvider>
-            <ClusterOverallStats />
-          </ResourcePoolsProvider>
-        </TasksProvider>
-      </ExperimentsProvider>
+      <AuthProvider>
+        <UserRolesProvider>
+          <ExperimentsProvider>
+            <TasksProvider>
+              <ResourcePoolsProvider>
+                <ClusterOverallStats />
+              </ResourcePoolsProvider>
+            </TasksProvider>
+          </ExperimentsProvider>
+        </UserRolesProvider>
+      </AuthProvider>
     </StoreProvider>,
   );
   return { view };

--- a/webui/react/src/pages/Cluster/ClusterOverallStats.tsx
+++ b/webui/react/src/pages/Cluster/ClusterOverallStats.tsx
@@ -4,6 +4,7 @@ import Grid, { GridMode } from 'components/Grid';
 import OverviewStats from 'components/OverviewStats';
 import Section from 'components/Section';
 import { activeRunStates } from 'constants/states';
+import useFeature from 'hooks/useFeature';
 import usePermissions from 'hooks/usePermissions';
 import Spinner from 'shared/components/Spinner';
 import usePolling from 'shared/hooks/usePolling';
@@ -37,6 +38,7 @@ export const ClusterOverallStats: React.FC = () => {
   usePolling(fetchActiveRunning);
   const activeExperiments = useExperiments({ limit: -2, states: activeRunStates });
   const activeTasks = useActiveTasks();
+  const rbacEnabled = useFeature().isOn('rbac');
 
   const auxContainers = useMemo(() => {
     const tally = {
@@ -80,7 +82,7 @@ export const ClusterOverallStats: React.FC = () => {
             {auxContainers.running} <small>/ {auxContainers.total}</small>
           </OverviewStats>
         ) : null}
-        {usePermissions().canAdministrateUsers ? (
+        {usePermissions().canAdministrateUsers || !rbacEnabled ? (
           <>
             <OverviewStats title="Active Experiments">
               {Loadable.match(activeExperiments, {

--- a/webui/react/src/pages/Cluster/ClusterOverallStats.tsx
+++ b/webui/react/src/pages/Cluster/ClusterOverallStats.tsx
@@ -4,6 +4,7 @@ import Grid, { GridMode } from 'components/Grid';
 import OverviewStats from 'components/OverviewStats';
 import Section from 'components/Section';
 import { activeRunStates } from 'constants/states';
+import usePermissions from 'hooks/usePermissions';
 import Spinner from 'shared/components/Spinner';
 import usePolling from 'shared/hooks/usePolling';
 import { useAgents, useClusterOverview } from 'stores/agents';
@@ -79,36 +80,40 @@ export const ClusterOverallStats: React.FC = () => {
             {auxContainers.running} <small>/ {auxContainers.total}</small>
           </OverviewStats>
         ) : null}
-        <OverviewStats title="Active Experiments">
-          {Loadable.match(activeExperiments, {
-            Loaded: (activeExperiments) => activeExperiments.pagination?.total ?? 0,
-            NotLoaded: (): ReactNode => <Spinner />,
-          })}
-        </OverviewStats>
-        <OverviewStats title="Active JupyterLabs">
-          {Loadable.match(activeTasks, {
-            Loaded: (activeTasks) => activeTasks.notebooks ?? 0,
-            NotLoaded: (): ReactNode => <Spinner />,
-          })}
-        </OverviewStats>
-        <OverviewStats title="Active TensorBoards">
-          {Loadable.match(activeTasks, {
-            Loaded: (activeTasks) => activeTasks.tensorboards ?? 0,
-            NotLoaded: (): ReactNode => <Spinner />,
-          })}
-        </OverviewStats>
-        <OverviewStats title="Active Shells">
-          {Loadable.match(activeTasks, {
-            Loaded: (activeTasks) => activeTasks.shells ?? 0,
-            NotLoaded: (): ReactNode => <Spinner />,
-          })}
-        </OverviewStats>
-        <OverviewStats title="Active Commands">
-          {Loadable.match(activeTasks, {
-            Loaded: (activeTasks) => activeTasks.commands ?? 0,
-            NotLoaded: (): ReactNode => <Spinner />,
-          })}
-        </OverviewStats>
+        {usePermissions().canAdministrateUsers ? (
+          <>
+            <OverviewStats title="Active Experiments">
+              {Loadable.match(activeExperiments, {
+                Loaded: (activeExperiments) => activeExperiments.pagination?.total ?? 0,
+                NotLoaded: (): ReactNode => <Spinner />,
+              })}
+            </OverviewStats>
+            <OverviewStats title="Active JupyterLabs">
+              {Loadable.match(activeTasks, {
+                Loaded: (activeTasks) => activeTasks.notebooks ?? 0,
+                NotLoaded: (): ReactNode => <Spinner />,
+              })}
+            </OverviewStats>
+            <OverviewStats title="Active TensorBoards">
+              {Loadable.match(activeTasks, {
+                Loaded: (activeTasks) => activeTasks.tensorboards ?? 0,
+                NotLoaded: (): ReactNode => <Spinner />,
+              })}
+            </OverviewStats>
+            <OverviewStats title="Active Shells">
+              {Loadable.match(activeTasks, {
+                Loaded: (activeTasks) => activeTasks.shells ?? 0,
+                NotLoaded: (): ReactNode => <Spinner />,
+              })}
+            </OverviewStats>
+            <OverviewStats title="Active Commands">
+              {Loadable.match(activeTasks, {
+                Loaded: (activeTasks) => activeTasks.commands ?? 0,
+                NotLoaded: (): ReactNode => <Spinner />,
+              })}
+            </OverviewStats>
+          </>
+        ) : null}
       </Grid>
     </Section>
   );

--- a/webui/react/src/stores/userRoles.tsx
+++ b/webui/react/src/stores/userRoles.tsx
@@ -78,7 +78,7 @@ export const useEnsureUserRolesAndAssignmentsFetched = (
 export const useUserRoles = (): Loadable<UserRole[]> => {
   const context = useContext(UserRolesAndAssignmentsContext);
   if (context === null) {
-    throw new Error('Attempted to use useUserRoles outside of UserRolesAndAssignmentss Context');
+    throw new Error('Attempted to use useUserRoles outside of UserRolesAndAssignments Context');
   }
 
   const { userRoles } = context;


### PR DESCRIPTION
## Description

Given that the Active Tasks API does not return results unless you have the administrateUser permission, we want to remove the Active Experiments, Commands / Shells / Notebooks / Tensorboards badges unless you are able to see results.

## Test Plan

With `?f_rbac=on` ,

Log in as 'admin' and see numbers for Active Experiments and Commands load on `/det/clusters` (can be 0s, just no spinners or missing badge)

Log in as 'determined' and these numbers should be hidden (no label or spinner for Active Experiments)

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.