### PR TITLE
fix: Tensorboard launch from experiment multi-select [WEB-742]

### DIFF
--- a/webui/react/src/pages/OldProjectDetails.tsx
+++ b/webui/react/src/pages/OldProjectDetails.tsx
@@ -93,7 +93,7 @@ import {
 } from 'utils/experiment';
 import { Loadable } from 'utils/loadable';
 import { getDisplayName } from 'utils/user';
-import { openCommand } from 'utils/wait';
+import { openCommandResponse } from 'utils/wait';
 
 import {
   DEFAULT_COLUMN_WIDTHS,
@@ -733,7 +733,7 @@ const ProjectDetails: React.FC = () => {
       try {
         const result = await sendBatchActions(action);
         if (action === Action.OpenTensorBoard && result) {
-          openCommand(result as CommandTask);
+          openCommandResponse(result as CommandResponse);
         }
 
         /*


### PR DESCRIPTION
## Description

When selecting multiple experiments and commanding TensorBoard to open, this should continue to work on the OldProjectDetails page.  An issue with the exact object was camouflaged by `as CommandTask`; we instead receive a CommandResponse object which should be passed to a different function (`openCommandResponse`)

Checked that all other TensorBoard calls receive the CommandResponse object and pass it to openCommandResponse

## Test Plan

- On a project view, use the checkbox to select multiple experiments
- Use the batch dropdown at left to Open TensorBoard - confirm this opens tensorboard in a new tab
- On a project view, look at an experiment row. On the right end of the row, the three-dots menu should include Open Tensorboard. Confirm this opens TensorBoard in a new tab

Fix is successful if both actions on this page open a TensorBoard

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.