### PR TITLE
fix: Log filters scoped to trial/task [WEB-735]

### DIFF
--- a/webui/react/src/components/LogViewer/LogViewerFilters.settings.ts
+++ b/webui/react/src/components/LogViewer/LogViewerFilters.settings.ts
@@ -12,8 +12,14 @@ export interface Settings {
   searchText?: string;
 }
 
-const config: SettingsConfig<Settings> = {
-  applicableRoutespace: 'log-viewer-filters',
+export const settingsConfigForTask = (taskId: string): SettingsConfig<Settings> =>
+  settingsConfigForLogs(taskId);
+
+export const settingsConfigForTrial = (id: number): SettingsConfig<Settings> =>
+  settingsConfigForLogs(id);
+
+const settingsConfigForLogs = (id: number | string): SettingsConfig<Settings> => ({
+  applicableRoutespace: `log-viewer-filters-${id}`,
   settings: {
     agentId: {
       defaultValue: undefined,
@@ -60,6 +66,4 @@ const config: SettingsConfig<Settings> = {
     },
   },
   storagePath: 'log-viewer-filters',
-};
-
-export default config;
+});

--- a/webui/react/src/pages/TaskLogs.tsx
+++ b/webui/react/src/pages/TaskLogs.tsx
@@ -4,7 +4,7 @@ import { useParams } from 'react-router-dom';
 
 import LogViewer, { FetchConfig, FetchDirection, FetchType } from 'components/LogViewer/LogViewer';
 import LogViewerFilters, { Filters } from 'components/LogViewer/LogViewerFilters';
-import settingsConfig, { Settings } from 'components/LogViewer/LogViewerFilters.settings';
+import { Settings, settingsConfigForTask } from 'components/LogViewer/LogViewerFilters.settings';
 import Page from 'components/Page';
 import { commandTypeToLabel } from 'constants/states';
 import { useSettings } from 'hooks/useSettings';
@@ -40,7 +40,8 @@ const TaskLogs: React.FC<Props> = ({ taskId, taskType, onCloseLogs, headerCompon
   const taskTypeLabel = commandTypeToLabel[taskType as CommandType];
   const title = `${queries.id ? `${queries.id} ` : ''}Logs`;
 
-  const { resetSettings, settings, updateSettings } = useSettings<Settings>(settingsConfig);
+  const taskSettingsConfig = useMemo(() => settingsConfigForTask(taskId), [taskId]);
+  const { resetSettings, settings, updateSettings } = useSettings<Settings>(taskSettingsConfig);
 
   const filterValues: Filters = useMemo(
     () => ({

--- a/webui/react/src/pages/TrialDetails/TrialDetailsLogs.tsx
+++ b/webui/react/src/pages/TrialDetails/TrialDetailsLogs.tsx
@@ -4,7 +4,7 @@ import React, { useCallback, useEffect, useMemo, useState } from 'react';
 
 import LogViewer, { FetchConfig, FetchDirection, FetchType } from 'components/LogViewer/LogViewer';
 import LogViewerFilters, { Filters } from 'components/LogViewer/LogViewerFilters';
-import settingsConfig, { Settings } from 'components/LogViewer/LogViewerFilters.settings';
+import { Settings, settingsConfigForTrial } from 'components/LogViewer/LogViewerFilters.settings';
 import { useSettings } from 'hooks/useSettings';
 import { serverAddress } from 'routes/utils';
 import { detApi } from 'services/apiConfig';
@@ -31,7 +31,8 @@ const TrialDetailsLogs: React.FC<Props> = ({ experiment, trial }: Props) => {
   const [filterOptions, setFilterOptions] = useState<Filters>({});
   const [downloadModal, setDownloadModal] = useState<{ destroy: () => void }>();
 
-  const { resetSettings, settings, updateSettings } = useSettings<Settings>(settingsConfig);
+  const trialSettingsConfig = useMemo(() => settingsConfigForTrial(trial?.id || -1), [trial?.id]);
+  const { resetSettings, settings, updateSettings } = useSettings<Settings>(trialSettingsConfig);
 
   const filterValues: Filters = useMemo(
     () => ({


### PR DESCRIPTION
## Description

Prevents log filters (such as Level: Critical) from carrying over when viewing a new trial or task.

As recommended by Trent / #5531 , scoping the settings to the relevant object. Both trials and tasks use this component and its settings, so we need to pass their IDs. It wouldn't make sense to use Experiment ID because it could cover many trials, and we would also need to cover tasks.

## Test Plan

Trial filters
- Open the Uncategorized Project or another project
- Open an experiment's Logs tab and select a noticeable filter (Level > Critical)
- Confirm that `level=LOG_LEVEL_CRITICAL` is added to the browser URL
- Open that browser URL in a new window and confirm Level > Critical is still applied. Close this window

Trial scoping
- Go back to the Project and select a 2nd experiment
- In the 2nd experiment's Logs tab, confirm that no filters have been applied
- Return to the Project and select the first experiment
- Visit the first experiment's logs and confirm Level > Critical is still applied.

Tasks
- On the Tasks page, use the three-dots menu on a task's row to select View Logs
- Confirm that selecting a filter on these Task Logs updates the log viewer and the browser's URL

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.