### PR TITLE
fix: WorkspaceProjects dropdown

### DIFF
--- a/webui/react/src/pages/WorkspaceDetails/WorkspaceProjects.tsx
+++ b/webui/react/src/pages/WorkspaceDetails/WorkspaceProjects.tsx
@@ -119,7 +119,7 @@ const WorkspaceProjects: React.FC<Props> = ({ workspace, id, pageRef }) => {
       updateSettings({
         sortDesc:
           value === V1GetWorkspaceProjectsRequestSortBy.NAME ||
-            value === V1GetWorkspaceProjectsRequestSortBy.LASTEXPERIMENTSTARTTIME
+          value === V1GetWorkspaceProjectsRequestSortBy.LASTEXPERIMENTSTARTTIME
             ? false
             : true,
         sortKey: value as V1GetWorkspaceProjectsRequestSortBy | undefined,

--- a/webui/react/src/pages/WorkspaceDetails/WorkspaceProjects.tsx
+++ b/webui/react/src/pages/WorkspaceDetails/WorkspaceProjects.tsx
@@ -26,6 +26,7 @@ import { getWorkspaceProjects, patchProject } from 'services/api';
 import { V1GetWorkspaceProjectsRequestSortBy } from 'services/api-ts-sdk';
 import Message, { MessageType } from 'shared/components/Message';
 import Spinner from 'shared/components/Spinner';
+import usePrevious from 'shared/hooks/usePrevious';
 import { isEqual } from 'shared/utils/data';
 import { ErrorLevel, ErrorType } from 'shared/utils/error';
 import { validateDetApiEnum } from 'shared/utils/service';
@@ -100,12 +101,14 @@ const WorkspaceProjects: React.FC<Props> = ({ workspace, id, pageRef }) => {
   }, [canceler.signal, id, workspace, settings]);
 
   useEffect(() => {
-    fetchProjects();
+    setIsLoading(true);
+    fetchProjects().then(() => setIsLoading(false));
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const handleViewSelect = useCallback(
     (value: unknown) => {
+      setIsLoading(true);
       updateSettings({ whose: value as WhoseProjects | undefined });
     },
     [updateSettings],
@@ -116,7 +119,7 @@ const WorkspaceProjects: React.FC<Props> = ({ workspace, id, pageRef }) => {
       updateSettings({
         sortDesc:
           value === V1GetWorkspaceProjectsRequestSortBy.NAME ||
-          value === V1GetWorkspaceProjectsRequestSortBy.LASTEXPERIMENTSTARTTIME
+            value === V1GetWorkspaceProjectsRequestSortBy.LASTEXPERIMENTSTARTTIME
             ? false
             : true,
         sortKey: value as V1GetWorkspaceProjectsRequestSortBy | undefined,
@@ -132,21 +135,22 @@ const WorkspaceProjects: React.FC<Props> = ({ workspace, id, pageRef }) => {
     [updateSettings],
   );
 
+  const prevWhose = usePrevious(settings.whose, undefined);
   useEffect(() => {
-    if (!settings.whose) return;
+    if (settings.whose === prevWhose || !settings.whose) return;
 
     switch (settings.whose) {
       case WhoseProjects.All:
         updateSettings({ user: undefined });
         break;
       case WhoseProjects.Mine:
-        updateSettings({ user: user ? [user.username] : undefined });
+        updateSettings({ user: user ? [user.id] : undefined });
         break;
       case WhoseProjects.Others:
-        updateSettings({ user: users.filter((u) => u.id !== user?.id).map((u) => u.username) });
+        updateSettings({ user: users.filter((u) => u.id !== user?.id).map((u) => u.id) });
         break;
     }
-  }, [settings.whose, updateSettings, user, users]);
+  }, [prevWhose, settings.whose, updateSettings, user, users]);
 
   const saveProjectDescription = useCallback(async (newDescription: string, projectId: number) => {
     try {


### PR DESCRIPTION
## Description

Dropdown on the WorkspaceProjects page (All/My/Others’) causes a ‘Maximum update depth exceeded’ error

## Test Plan

Should be able to update this dropdown and see listed projects change accordingly, without the app freezing.

## Commentary (optional)

also updated `username` to `id` where appropriate, which was missed in https://github.com/determined-ai/determined/pull/5529.

also made `setIsLoading` calls match `WorkspaceList`. identified an outstanding bug with the loading spinners on both pages, which has been ticketed: https://determinedai.atlassian.net/browse/WEB-749

## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
