### PR TITLE
ci: save time by only storing necessary artifacts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1061,10 +1061,9 @@ jobs:
                 make -C model_hub build-docker-dev
                 make -C model_hub publish-docker-dev
             fi
+      - run: mkdir /tmp/pkgs && cp -v */dist/*.{rpm,deb,tar.gz} /tmp/pkgs
       - store_artifacts:
-          path: master/dist/
-      - store_artifacts:
-          path: agent/dist/
+          path: /tmp/pkgs
 
   package-and-push-system-rc:
     docker:
@@ -1091,10 +1090,9 @@ jobs:
       - run: make -C agent publish
       - run: make -C model_hub build-docker
       - run: make -C model_hub publish-docker
+      - run: mkdir /tmp/pkgs && cp -v */dist/*.{rpm,deb,tar.gz} /tmp/pkgs
       - store_artifacts:
-          path: master/dist/
-      - store_artifacts:
-          path: agent/dist/
+          path: /tmp/pkgs
 
   package-and-push-system-release:
     docker:
@@ -1120,10 +1118,9 @@ jobs:
       - run: make -C agent release
       - run: make -C model_hub build-docker
       - run: make -C model_hub publish-docker
+      - run: mkdir /tmp/pkgs && cp -v */dist/*.{rpm,deb,tar.gz} /tmp/pkgs
       - store_artifacts:
-          path: master/dist/
-      - store_artifacts:
-          path: agent/dist/
+          path: /tmp/pkgs
 
   publish-helm:
     docker:


### PR DESCRIPTION
## Description

`master/dist` contains the many individual files from the output of the docs build, which make the upload take a long time but are unnecessary to upload at all here (the docs output is uploaded from the docs build step). We really only want the packages from this step (see #4124).

## Test Plan

- [x] run in CI: https://app.circleci.com/pipelines/github/determined-ai/determined/31198/workflows/c10a1b91-1c36-46ad-8b7e-b6ac198b5f55/jobs/1077814
