### PR TITLE
fix: correctly report command submission time on restore [DET-8750]

### DIFF
--- a/docs/release-notes/job-submission-time.rst
+++ b/docs/release-notes/job-submission-time.rst
@@ -1,0 +1,7 @@
+:orphan:
+
+**Bug Fixes**
+
+-  Fix a bug where Notebooks, Tensorboards, Shells, Commands being restored from a master restart
+   would have a submission time of when master restarted rather than the original job submission
+   time.

--- a/e2e_tests/tests/cluster/test_master_restart.py
+++ b/e2e_tests/tests/cluster/test_master_restart.py
@@ -15,6 +15,7 @@ from tests import experiment as exp
 from tests.cluster.test_users import det_spawn
 
 from .managed_cluster import ManagedCluster, get_agent_data
+from .test_groups import det_cmd_json
 from .utils import (
     command_succeeded,
     get_command_info,
@@ -172,6 +173,7 @@ def test_master_restart_shell(restartable_managed_cluster: ManagedCluster, downt
 
         assert task_id is not None
         wait_for_task_state("shell", task_id, "RUNNING")
+        pre_restart_queue = det_cmd_json(["job", "list", "--json"])
 
         if downtime >= 0:
             managed_cluster.kill_master()
@@ -179,6 +181,8 @@ def test_master_restart_shell(restartable_managed_cluster: ManagedCluster, downt
             managed_cluster.restart_master()
 
         wait_for_task_state("shell", task_id, "RUNNING")
+        post_restart_queue = det_cmd_json(["job", "list", "--json"])
+        assert pre_restart_queue == post_restart_queue
 
         child = det_spawn(["shell", "open", task_id])
         child.setecho(True)


### PR DESCRIPTION
## Description

Command start time was not getting loaded on restore. 

Experiments should already handle this correctly as far as I can tell. 


## Test Plan

e2e test + manual 

On a cluster with a resource pool with ```agent_reattach_enabled: true``` 

run a command ```det command run sleep 100```

See the job submission time ```det job```

Restart devcluster / master

Check submission time to ensure it hasn't changed ```det job```

## Commentary (optional)



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
