### PR TITLE
fix: Restore columns in experiment multi-trial view

### DIFF
--- a/webui/react/src/pages/ExperimentDetails/ExperimentTrials.tsx
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentTrials.tsx
@@ -45,7 +45,11 @@ import { getMetricValue } from 'utils/metric';
 import { openCommandResponse } from 'utils/wait';
 
 import css from './ExperimentTrials.module.scss';
-import settingsConfig, { isOfSortKey, Settings } from './ExperimentTrials.settings';
+import settingsConfig, {
+  DEFAULT_COLUMNS,
+  isOfSortKey,
+  Settings,
+} from './ExperimentTrials.settings';
 import { columns as defaultColumns } from './ExperimentTrials.table';
 import TrialsComparisonModal from './TrialsComparisonModal';
 
@@ -459,7 +463,7 @@ const ExperimentTrials: React.FC<Props> = ({ experiment, pageRef }: Props) => {
             preserveSelectedRowKeys: true,
             selectedRowKeys: settings.row ?? [],
           }}
-          settings={settings as InteractiveTableSettings}
+          settings={{ ...settings, columns: DEFAULT_COLUMNS } as InteractiveTableSettings}
           showSorterTooltip={false}
           size="small"
           updateSettings={updateSettings as UpdateSettings}


### PR DESCRIPTION
## Description

At some point - perhaps still active - there was a scoping issue with Settings of which columns we make visible in a table. As a result, some users see a mostly blank table for a Multi-Trial Experiment's Trials.  For example you cannot see the IDs of Trials and click through to view the Trial.

After some sleuthing - we're seeing only columns which overlap with the experiments table.

We don't have a way to add or remove columns from this table, so the best fix is to show DEFAULT_COLUMNS regardless of the settings. 

## Test Plan

On a multi-trial experiment, go to the Trials tab and confirm you can see a table listing Trial IDs, best validation metric, etc.
In one of the Trial rows, click the link to successfully view an individual trial

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.