### PR TITLE
fix: Experiment metric selection scoped to experiment [WEB-743]

### DIFF
--- a/webui/react/src/pages/TrialDetails/TrialDetailsOverview.settings.ts
+++ b/webui/react/src/pages/TrialDetails/TrialDetailsOverview.settings.ts
@@ -13,7 +13,7 @@ export interface Settings {
   tableOffset: number;
 }
 
-const config: SettingsConfig<Settings> = {
+export const settingsConfigForExperiment = (id: number): SettingsConfig<Settings> => ({
   settings: {
     filter: {
       defaultValue: TrialWorkloadFilter.CheckpointOrValidation,
@@ -51,7 +51,5 @@ const config: SettingsConfig<Settings> = {
       type: number,
     },
   },
-  storagePath: 'trial-detail',
-};
-
-export default config;
+  storagePath: `experiment-trials-${id}`,
+});

--- a/webui/react/src/pages/TrialDetails/TrialDetailsOverview.tsx
+++ b/webui/react/src/pages/TrialDetails/TrialDetailsOverview.tsx
@@ -11,7 +11,7 @@ import { ExperimentBase, Metric, MetricType, RunState, TrialDetails } from 'type
 import handleError from 'utils/error';
 
 import TrialChart from './TrialChart';
-import settingsConfig, { Settings } from './TrialDetailsOverview.settings';
+import { Settings, settingsConfigForExperiment } from './TrialDetailsOverview.settings';
 import TrialDetailsWorkloads from './TrialDetailsWorkloads';
 
 export interface Props {
@@ -21,6 +21,7 @@ export interface Props {
 
 const TrialDetailsOverview: React.FC<Props> = ({ experiment, trial }: Props) => {
   const storagePath = `trial-detail/experiment/${experiment.id}`;
+  const settingsConfig = useMemo(() => settingsConfigForExperiment(experiment.id), [experiment.id]);
   const { settings, updateSettings } = useSettings<Settings>(
     Object.assign(settingsConfig, { storagePath }),
   );


### PR DESCRIPTION
## Description

Settings to the metrics view should be remembered within an Experiment, but not carried over to other Experiments. This uses an experiment-level scope.

Clarification: Do we want metrics to be carried over between Trials of one Multi-Trial Experiment?  That's currently active with this experiment-level scope.

## Test Plan

Single-Trial Experiment Storage
- Find a single-trial experiment (such as mnist_pytorch_const) which has successfully run twice; or run an experiment twice now for testing purposes.  We want it to be the same experiment so it has the same metric names.
- On Experiment A, above-left of the chart, select a new metric (training:loss). Confirm that the URL updates to include the selected metrics (i.e. `/det/experiments/1623/overview?metric=validation%7Cvalidation_loss&metric=training%7Closs`)
- In a new window or tab, shorten the URL to the ID of the experiment (`/det/experiments/1623`). Confirm that the browser remembers / selects your previously selected metrics

Single-Trial Experiment Scope
- Open the other experiment (Experiment B). Confirm that the default metric is the only one selected, and your new metric from Experiment A is left unselected.

Multi-Trial Experiment Scope
- Find or run one multi-trial experiment which successfully completes 2 or more trials with metrics
- In the experiment's first trial, confirm one default metric is selected.
- In the experiment's first trial, select a new metric and confirm the URL updates to include it
- Open or refresh another trial. Confirm that this trial also has your new metric selected.

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.