### PR TITLE
chore: Move '+ New Workspace' button to nav item [WEB-698]

### DIFF
--- a/webui/react/src/components/NavigationSideBar.module.scss
+++ b/webui/react/src/components/NavigationSideBar.module.scss
@@ -45,6 +45,7 @@
       color: var(--theme-stage-on-weak);
       font-size: 12px;
       padding: 6px;
+      text-align: center;
     }
     .pinnedWorkspaces {
       list-style: none;

--- a/webui/react/src/components/NavigationSideBar.module.scss
+++ b/webui/react/src/components/NavigationSideBar.module.scss
@@ -137,7 +137,9 @@
       max-width: 100%;
 
       .icon {
+        min-width: 56px;
         padding-inline: 16px;
+        text-align: center;
       }
       .label {
         font-size: 12px;

--- a/webui/react/src/components/NavigationSideBar.tsx
+++ b/webui/react/src/components/NavigationSideBar.tsx
@@ -329,9 +329,9 @@ const NavigationSideBar: React.FC = () => {
                         onClick={handleCreateWorkspace}
                       />
                     </li>
-                  ) : (
+                  ) : workspaces.length === 0 ? (
                     <p className={css.noWorkspaces}>No pinned workspaces</p>
-                  )}
+                  ) : null}
                 </ul>
               ),
               NotLoaded: () => <Spinner />,

--- a/webui/react/src/components/NavigationSideBar.tsx
+++ b/webui/react/src/components/NavigationSideBar.tsx
@@ -317,18 +317,26 @@ const NavigationSideBar: React.FC = () => {
                           </li>
                         </WorkspaceActionDropdown>
                       ))}
+                    {canCreateWorkspace ? (
+                      <li>
+                        <NavigationItem
+                          icon="add-small"
+                          iconSize="tiny"
+                          label="New Workspace"
+                          labelRender={
+                            <Typography.Paragraph ellipsis={{ rows: 1, tooltip: true }}>
+                              New Workspace
+                            </Typography.Paragraph>
+                          }
+                          tooltip={settings.navbarCollapsed}
+                          onClick={handleCreateWorkspace}
+                        />
+                      </li>
+                    ) : null}
                   </ul>
                 ),
               NotLoaded: () => <Spinner />,
             })}
-            {canCreateWorkspace ? (
-              <NavigationItem
-                icon="add-small"
-                iconSize="tiny"
-                label="New Workspace"
-                onClick={handleCreateWorkspace}
-              />
-            ) : null}
           </section>
           <section className={css.bottom}>
             {menuConfig.bottom.map((config) => (

--- a/webui/react/src/components/NavigationSideBar.tsx
+++ b/webui/react/src/components/NavigationSideBar.tsx
@@ -290,51 +290,50 @@ const NavigationSideBar: React.FC = () => {
               tooltip={settings.navbarCollapsed}
             />
             {Loadable.match(pinnedWorkspaces, {
-              Loaded: (workspaces) =>
-                workspaces.length === 0 ? (
-                  <p className={css.noWorkspaces}>No pinned workspaces</p>
-                ) : (
-                  <ul className={css.pinnedWorkspaces} role="list">
-                    {workspaces
-                      .sort((a, b) => ((a.pinnedAt || 0) < (b.pinnedAt || 0) ? -1 : 1))
-                      .map((workspace) => (
-                        <WorkspaceActionDropdown
-                          key={workspace.id}
-                          returnIndexOnDelete={false}
-                          trigger={['contextMenu']}
-                          workspace={workspace}>
-                          <li>
-                            <NavigationItem
-                              icon={<DynamicIcon name={workspace.name} size={24} />}
-                              label={workspace.name}
-                              labelRender={
-                                <Typography.Paragraph ellipsis={{ rows: 1, tooltip: true }}>
-                                  {workspace.name}
-                                </Typography.Paragraph>
-                              }
-                              path={paths.workspaceDetails(workspace.id)}
-                            />
-                          </li>
-                        </WorkspaceActionDropdown>
-                      ))}
-                    {canCreateWorkspace ? (
-                      <li>
-                        <NavigationItem
-                          icon="add-small"
-                          iconSize="tiny"
-                          label="New Workspace"
-                          labelRender={
-                            <Typography.Paragraph ellipsis={{ rows: 1, tooltip: true }}>
-                              New Workspace
-                            </Typography.Paragraph>
-                          }
-                          tooltip={settings.navbarCollapsed}
-                          onClick={handleCreateWorkspace}
-                        />
-                      </li>
-                    ) : null}
-                  </ul>
-                ),
+              Loaded: (workspaces) => (
+                <ul className={css.pinnedWorkspaces} role="list">
+                  {workspaces
+                    .sort((a, b) => ((a.pinnedAt || 0) < (b.pinnedAt || 0) ? -1 : 1))
+                    .map((workspace) => (
+                      <WorkspaceActionDropdown
+                        key={workspace.id}
+                        returnIndexOnDelete={false}
+                        trigger={['contextMenu']}
+                        workspace={workspace}>
+                        <li>
+                          <NavigationItem
+                            icon={<DynamicIcon name={workspace.name} size={24} />}
+                            label={workspace.name}
+                            labelRender={
+                              <Typography.Paragraph ellipsis={{ rows: 1, tooltip: true }}>
+                                {workspace.name}
+                              </Typography.Paragraph>
+                            }
+                            path={paths.workspaceDetails(workspace.id)}
+                          />
+                        </li>
+                      </WorkspaceActionDropdown>
+                    ))}
+                  {canCreateWorkspace ? (
+                    <li>
+                      <NavigationItem
+                        icon="add-small"
+                        iconSize="tiny"
+                        label="New Workspace"
+                        labelRender={
+                          <Typography.Paragraph ellipsis={{ rows: 1, tooltip: true }}>
+                            New Workspace
+                          </Typography.Paragraph>
+                        }
+                        tooltip={settings.navbarCollapsed}
+                        onClick={handleCreateWorkspace}
+                      />
+                    </li>
+                  ) : (
+                    <p className={css.noWorkspaces}>No pinned workspaces</p>
+                  )}
+                </ul>
+              ),
               NotLoaded: () => <Spinner />,
             })}
           </section>

--- a/webui/react/src/components/NavigationSideBar.tsx
+++ b/webui/react/src/components/NavigationSideBar.tsx
@@ -85,7 +85,7 @@ export const NavigationItem: React.FC<ItemProps> = ({
       <Link className={classes.join(' ')} path={path} {...props}>
         {typeof props.icon === 'string' ? (
           <div className={css.icon}>
-            <Icon name={props.icon} size={props.iconSize || 'large'} />
+            <Icon name={props.icon} size={props.iconSize ?? 'large'} />
           </div>
         ) : (
           <div className={css.icon}>{props.icon}</div>
@@ -293,7 +293,7 @@ const NavigationSideBar: React.FC = () => {
               Loaded: (workspaces) => (
                 <ul className={css.pinnedWorkspaces} role="list">
                   {workspaces
-                    .sort((a, b) => ((a.pinnedAt || 0) < (b.pinnedAt || 0) ? -1 : 1))
+                    .sort((a, b) => ((a.pinnedAt ?? 0) < (b.pinnedAt ?? 0) ? -1 : 1))
                     .map((workspace) => (
                       <WorkspaceActionDropdown
                         key={workspace.id}
@@ -330,7 +330,7 @@ const NavigationSideBar: React.FC = () => {
                       />
                     </li>
                   ) : workspaces.length === 0 ? (
-                    <p className={css.noWorkspaces}>No pinned workspaces</p>
+                    <div className={css.noWorkspaces}>No pinned workspaces</div>
                   ) : null}
                 </ul>
               ),

--- a/webui/react/src/components/NavigationSideBar.tsx
+++ b/webui/react/src/components/NavigationSideBar.tsx
@@ -16,7 +16,7 @@ import { clusterStatusText } from 'pages/Clusters/ClustersOverview';
 import WorkspaceQuickSearch from 'pages/WorkspaceDetails/WorkspaceQuickSearch';
 import WorkspaceActionDropdown from 'pages/WorkspaceList/WorkspaceActionDropdown';
 import { paths } from 'routes/utils';
-import Icon from 'shared/components/Icon/Icon';
+import Icon, { IconSize } from 'shared/components/Icon/Icon';
 import Spinner from 'shared/components/Spinner/Spinner';
 import useUI from 'shared/contexts/stores/UI';
 import { useAgents, useClusterOverview } from 'stores/agents';
@@ -35,6 +35,7 @@ interface ItemProps extends LinkProps {
   action?: React.ReactNode;
   badge?: number;
   icon: string | React.ReactNode;
+  iconSize?: IconSize;
   label: string;
   labelRender?: React.ReactNode;
   status?: string;
@@ -84,7 +85,7 @@ export const NavigationItem: React.FC<ItemProps> = ({
       <Link className={classes.join(' ')} path={path} {...props}>
         {typeof props.icon === 'string' ? (
           <div className={css.icon}>
-            <Icon name={props.icon} size="large" />
+            <Icon name={props.icon} size={props.iconSize || 'large'} />
           </div>
         ) : (
           <div className={css.icon}>{props.icon}</div>
@@ -280,11 +281,6 @@ const NavigationSideBar: React.FC = () => {
                       <Icon name="search" size="tiny" />
                     </Button>
                   </WorkspaceQuickSearch>
-                  {canCreateWorkspace ? (
-                    <Button type="text" onClick={handleCreateWorkspace}>
-                      <Icon name="add-small" size="tiny" />
-                    </Button>
-                  ) : null}
                 </div>
               }
               icon="workspaces"
@@ -325,6 +321,14 @@ const NavigationSideBar: React.FC = () => {
                 ),
               NotLoaded: () => <Spinner />,
             })}
+            {canCreateWorkspace ? (
+              <NavigationItem
+                icon="add-small"
+                iconSize="tiny"
+                label="New Workspace"
+                onClick={handleCreateWorkspace}
+              />
+            ) : null}
           </section>
           <section className={css.bottom}>
             {menuConfig.bottom.map((config) => (

--- a/webui/react/src/components/NavigationTabbar.tsx
+++ b/webui/react/src/components/NavigationTabbar.tsx
@@ -139,7 +139,13 @@ const NavigationTabbar: React.FC = () => {
               if (canCreateWorkspace) {
                 return workspaceIcons.concat([
                   {
-                    icon: <DynamicIcon name="+" size={24} style={{ color: 'black' }} />,
+                    icon: (
+                      <DynamicIcon
+                        name="+"
+                        size={24}
+                        style={{ backgroundColor: '#ccc', color: 'black' }}
+                      />
+                    ),
                     label: 'New Workspace',
                     onClick: handleCreateWorkspace,
                   },

--- a/webui/react/src/components/NavigationTabbar.tsx
+++ b/webui/react/src/components/NavigationTabbar.tsx
@@ -137,19 +137,11 @@ const NavigationTabbar: React.FC = () => {
                   handlePathUpdate(e, paths.workspaceDetails(workspace.id)),
               }));
               if (canCreateWorkspace) {
-                return workspaceIcons.concat([
-                  {
-                    icon: (
-                      <DynamicIcon
-                        name="+"
-                        size={24}
-                        style={{ backgroundColor: '#ccc', color: 'black' }}
-                      />
-                    ),
-                    label: 'New Workspace',
-                    onClick: handleCreateWorkspace,
-                  },
-                ]);
+                workspaceIcons.push({
+                  icon: <Icon name="add-small" size="large" />,
+                  label: 'New Workspace',
+                  onClick: handleCreateWorkspace,
+                });
               }
               return workspaceIcons;
             },


### PR DESCRIPTION
## Description

As requested in the ticket, remove the small '+' button from Workspaces nav header, and add a more visible '+ New Workspace' button.

<img width="255" alt="Screen Shot 2022-12-22 at 9 33 42 AM" src="https://user-images.githubusercontent.com/643918/209168621-dc6a6d70-e163-46f5-b5d2-2d0b13936ca1.png">

An unmodified + icon is too big (screenshot below) so I needed to add `iconSize` prop and some CSS.  Here's what it looks like with the + the same size as the regular nav items:

<img width="247" alt="Screen Shot 2022-12-22 at 9 40 27 AM" src="https://user-images.githubusercontent.com/643918/209169923-907a8456-7586-488c-90b1-e4a6dd15af15.png">

Would be open to some cleaner flexbox css or something instead of these specific css changes

## Test Plan

- While logged into Determined, confirm a new "+ New Workspace" is added below the list of pinned workspaces.
- Click the "New Workspace" button to create a workspace.
- Check code that visibility of this button depends on `canCreateWorkspace`

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.