### PR TITLE
fix: Workspace members search fixes for users and groups [WEB-753]

### DIFF
--- a/webui/react/src/hooks/useModal/Workspace/useModalWorkspaceAddMember.tsx
+++ b/webui/react/src/hooks/useModal/Workspace/useModalWorkspaceAddMember.tsx
@@ -67,7 +67,6 @@ const useModalWorkspaceAddMember = ({
   );
 
   const handleFilter = useCallback(
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (search: string, option?: SearchProp): boolean => {
       if (!option) return false;
       const label = option.label;

--- a/webui/react/src/hooks/useModal/Workspace/useModalWorkspaceAddMember.tsx
+++ b/webui/react/src/hooks/useModal/Workspace/useModalWorkspaceAddMember.tsx
@@ -26,6 +26,15 @@ interface FormInputs {
   userOrGroupId: string;
 }
 
+interface SearchProp {
+  label: {
+    props: {
+      groupName?: string;
+      user?: User;
+    };
+  };
+}
+
 const useModalWorkspaceAddMember = ({
   addableUsersAndGroups,
   rolesAssignableToScope,
@@ -59,15 +68,20 @@ const useModalWorkspaceAddMember = ({
 
   const handleFilter = useCallback(
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (search: string, option: any): boolean => {
-      const label = option.label as string;
+    (search: string, option?: SearchProp): boolean => {
+      if (!option) return false;
+      const label = option.label;
       const userOrGroup = addableUsersAndGroups.find((u) => {
-        if (isUser(u)) {
+        if (isUser(u) && !!label.props.user) {
           const user = u as User;
-          return user?.displayName === label || user?.username === label;
-        } else {
+          return (
+            user?.displayName === label.props.user.displayName ||
+            user?.username === label.props.user.username
+          );
+        }
+        if (!isUser(u) && !!label.props.groupName) {
           const group = u as V1Group;
-          return group.name === label;
+          return group.name === label.props.groupName;
         }
       });
       if (!userOrGroup) return false;

--- a/webui/react/src/pages/WorkspaceDetails/WorkspaceMembers.tsx
+++ b/webui/react/src/pages/WorkspaceDetails/WorkspaceMembers.tsx
@@ -67,7 +67,7 @@ const GroupOrMemberActionDropdown: React.FC<GroupOrMemberActionDropdownProps> = 
 
   const menuItems: DropDownProps['menu'] = useMemo(() => {
     const MenuKey = {
-      Remove: 'remove',
+      Remove: 'Remove',
     } as const;
 
     const funcs = {

--- a/webui/react/src/pages/WorkspaceDetails/WorkspaceMembers.tsx
+++ b/webui/react/src/pages/WorkspaceDetails/WorkspaceMembers.tsx
@@ -67,7 +67,7 @@ const GroupOrMemberActionDropdown: React.FC<GroupOrMemberActionDropdownProps> = 
 
   const menuItems: DropDownProps['menu'] = useMemo(() => {
     const MenuKey = {
-      Remove: 'Remove',
+      Remove: 'remove',
     } as const;
 
     const funcs = {


### PR DESCRIPTION
## Description

Fixes two bugs related to the Workspace Add Member modal:

- Autocomplete was not matching any users or groups now that they're more complex UI objects. In this fix, replaces `handleFilter`'s `any`-type prop with values which we expect for a User or Group item. This makes it easier to follow the function for search term -> items match

<img width="448" alt="Screen Shot 2022-12-22 at 10 57 34 AM" src="https://user-images.githubusercontent.com/643918/209186969-fd427934-f031-49ef-826b-11e8e67a77ec.png">

- ~Remove Member dropdown was lowercase "remove"~ fixed by #5640

- Third issue which I don't know how to solve? The members search rotates between an up and down arrow, but also changes to a search icon, so we get an upside-down search icon. On the [antd reference page](https://ant.design/components/select), this would only change to a search icon. So is this a bug with our version of antd, could CSS block the rotation..?

<img width="419" alt="Screen Shot 2022-12-22 at 11 01 11 AM" src="https://user-images.githubusercontent.com/643918/209187633-8c396a71-ff9f-40ca-948a-0dfd0c87e3d2.png">


## Test Plan

- Run determined-ee, with RBAC enabled.
- Log in as admin and create a workspace
- In the workspace's Members tab, click "Add Members"
- In the Add Members modal, click inside the search but don't type any search. You should have a list of all addable groups and users. If you don't have any other users or groups in this instance, create those to continue testing.
- In the Add Members search, type letters which don't match any group or user. You should see "No data" empty results.
- In the Add Members search, type a group name, a username, and a user's display name. Confirm that the filter keeps a matching user/group and hides others.
- Select one member and add them to the workspace
- In the workspace's members tab, remove them from the workspace (menu should say Remove)

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.