### PR TITLE
fix: swagger json spec 404 error.

### DIFF
--- a/master/internal/core.go
+++ b/master/internal/core.go
@@ -992,7 +992,7 @@ func (m *Master) Run(ctx context.Context) error {
 		return c.File(reactIndex)
 	})
 
-	m.echo.Static("/api/v1/api.swagger.json",
+	m.echo.File("/api/v1/api.swagger.json",
 		filepath.Join(m.config.Root, "swagger/determined/api/v1/api.swagger.json"))
 
 	m.echo.GET("/config", api.Route(m.getConfig))


### PR DESCRIPTION
## Description

swagger spec at `/api/v1/api.swagger.json` has started throwing 404 after upgrade to echo v4.9.3 #5249 
Apparently we've been misusing `.Static` method to serve a single file, while `.File` is intended: https://echo.labstack.com/guide/static-files/
It used to work before by accident, and now it does not. 

## Test Plan

Check if REST API docs work ok.

## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
