### PR TITLE
fix: allow killing of STOPPING_CANCELED experiments [DET-8283]

### DIFF
--- a/docs/release-notes/allow-killing-of-cancel-trial.rst
+++ b/docs/release-notes/allow-killing-of-cancel-trial.rst
@@ -1,0 +1,7 @@
+:orphan:
+
+**Improvements**
+
+-  Trials: Trials can now be killed when in the ``STOPPING_CANCELED`` state. Previously if a trial
+   did not implement preemption correctly and was canceled the trial did not stop and was unkillable
+   until the preemption timeout of an hour.

--- a/e2e_tests/tests/fixtures/core_api/sleep.py
+++ b/e2e_tests/tests/fixtures/core_api/sleep.py
@@ -1,0 +1,4 @@
+import time
+
+for _ in range(600):
+    time.sleep(1.0)

--- a/e2e_tests/tests/fixtures/core_api/sleep.yaml
+++ b/e2e_tests/tests/fixtures/core_api/sleep.yaml
@@ -1,0 +1,8 @@
+name: sleep for ten minutes
+searcher:
+  name: single
+  metric: loss
+  max_length:
+    batches: 1
+entrypoint: python3 sleep.py
+max_restarts: 0


### PR DESCRIPTION
## Description

If an experiment doesn't implement preemption then it will get stuck in a stopping canceled state for an hour while being unkillable. This change allows experiments that are being canceled to be killed. 

## Test Plan

E2e test. 

Manual 

Run an experiment without preemption implemented and wait for it to start
```
det e create e2e_tests/tests/fixtures/core_api/sleep.yaml e2e_tests/tests/fixtures/core_api -f
```

Cancel experiment running
```
det e cancel $exp_id
```

See that it is stuck in the state of ```STOPPING_CANCELED```
```
det e
```

Kill experiment
```
det e kill $exp_id
```

Verify it is now in ```CANCELED``` state
```
det e
```

## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
