### PR TITLE
fix: Revert change to flex menu

### DIFF
--- a/webui/react/src/pages/ModelVersionDetails/ModelVersionHeader.tsx
+++ b/webui/react/src/pages/ModelVersionDetails/ModelVersionHeader.tsx
@@ -229,13 +229,11 @@ my_model.load_state_dict(ckpt['models_state_dict'][0])`;
                 {action.text}
               </Button>
             ))}
-            {actions.length > 2 && (
-              <Dropdown menu={menu} trigger={['click']}>
-                <Button type="text">
-                  <Icon name="overflow-horizontal" size="tiny" />
-                </Button>
-              </Dropdown>
-            )}
+            <Dropdown menu={menu} trigger={['click']}>
+              <Button type="text">
+                <Icon name="overflow-horizontal" size="tiny" />
+              </Button>
+            </Dropdown>
           </div>
         </div>
         <InfoBox rows={infoRows} separator={false} />


### PR DESCRIPTION
## Description

Revert changes to flex menu made in #5653

## Test Plan

On the ModelVersion / details page, shrinking the window size should move any hidden buttons into a dropdown menu at the extreme top right.

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.