### PR TITLE
fix: put Kubernetes resource pool at right address

### DIFF
--- a/master/internal/rm/kubernetesrm/kubernetes_resource_manager.go
+++ b/master/internal/rm/kubernetesrm/kubernetes_resource_manager.go
@@ -230,9 +230,8 @@ func (k *kubernetesResourceManager) Receive(ctx *actor.Context) error {
 			k.config.MasterPort,
 		)
 
-		k.pools[KubernetesDummyResourcePool] = ctx.Self().System().MustActorOf(
-			actor.Addr(KubernetesDummyResourcePool),
-			newResourcePool(k.config, k.podsActor),
+		k.pools[KubernetesDummyResourcePool] = ctx.MustActorOf(
+			KubernetesDummyResourcePool, newResourcePool(k.config, k.podsActor),
 		)
 
 	case

--- a/master/pkg/actor/context.go
+++ b/master/pkg/actor/context.go
@@ -72,6 +72,15 @@ func (c *Context) ActorOf(id interface{}, actor Actor) (*Ref, bool) {
 	return c.recipient.createChild(c.recipient.address.Child(id), actor)
 }
 
+// MustActorOf adds the actor with the provided address. It panics if a new actor was not created.
+func (c *Context) MustActorOf(id interface{}, actor Actor) *Ref {
+	ref, created := c.ActorOf(id, actor)
+	if !created {
+		panic("actor was not created")
+	}
+	return ref
+}
+
 // ActorOfFromFactory behaves the same as ActorOf but will only create the actor instance if it's
 // needed. It is intended for cases where an actor needs to be looked up many times safely but
 // usually exists.


### PR DESCRIPTION
This was accidentally using `System.MustActorOf`, putting the new actor
at the root, rather than as a child of the current actor.

## Test Plan

- [x] do some basic things in Kubernetes