### PR TITLE
fix: SSO Provider name capitalization [WEB-768]

### DIFF
--- a/webui/react/src/pages/SignIn.tsx
+++ b/webui/react/src/pages/SignIn.tsx
@@ -144,7 +144,7 @@ const SignIn: React.FC = () => {
                 key={key}
                 size="large"
                 type="primary">
-                Sign in with {logo} {capitalize(key)}
+                Sign in with {logo} {ssoProvider.name === key ? capitalize(key) : ssoProvider.name}
               </Button>
             );
           })}


### PR DESCRIPTION
## Description

Prevent an issue which was capitalizing Google and Okta, but causing issues with all-caps SSO service names

- `ssoProvider.name` is converted to a lowercase `key` to get logos, etc
- if `ssoProvider.name` === `key` (name was always all-lowercase) then continue to call `capitalize(key)`
- else (name is mixed-case or upper-case) then return unedited `ssoProvider.name`

## Test Plan

Test on SSO with lowercase and mixed-case names

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.