### PR TITLE
fix: respect traling / for dirs

### DIFF
--- a/harness/determined/common/storage/azure.py
+++ b/harness/determined/common/storage/azure.py
@@ -66,6 +66,8 @@ class AzureStorageManager(storage.CloudStorageManager):
         for blob in self.client.list_files(self.container, file_prefix=src):
             found = True
             relname = os.path.relpath(blob, src)
+            if blob.endswith("/"):
+                relname = os.path.join(relname, "")
             if selector is not None and not selector(relname):
                 continue
             _dst = os.path.join(dst, relname)

--- a/harness/determined/common/storage/gcs.py
+++ b/harness/determined/common/storage/gcs.py
@@ -95,6 +95,8 @@ class GCSStorageManager(storage.CloudStorageManager):
         for blob in self.bucket.list_blobs(prefix=path):
             found = True
             relname = os.path.relpath(blob.name, path)
+            if blob.name.endswith("/"):
+                relname = os.path.join(relname, "")
             if selector is not None and not selector(relname):
                 continue
             _dst = os.path.join(dst, relname)

--- a/harness/determined/common/storage/s3.py
+++ b/harness/determined/common/storage/s3.py
@@ -113,6 +113,9 @@ class S3StorageManager(storage.CloudStorageManager):
             for obj in self.bucket.objects.filter(Prefix=prefix):
                 found = True
                 relname = os.path.relpath(obj.key, prefix)
+                if obj.key.endswith("/"):
+                    relname = os.path.join(relname, "")
+
                 if selector is not None and not selector(relname):
                     continue
                 _dst = os.path.join(dst, relname)

--- a/harness/determined/common/storage/shared.py
+++ b/harness/determined/common/storage/shared.py
@@ -127,7 +127,7 @@ if python_version.major == 3 and python_version.minor <= 7:
             dirs_exist_ok=dirs_exist_ok,
         )
 
-    # END VENDORED CODE FROM PYTORCH
+    # END VENDORED CODE FROM SHUTIL
 
 else:
     copytree = shutil.copytree
@@ -256,17 +256,23 @@ class SharedFSStorageManager(storage.StorageManager):
 
                 for name in names:
                     # ckpt_path would be "subdir/file"
-                    ckpt_path = os.path.join(rel_dir, name)
-                    if selector(ckpt_path):
-                        # The user wants this file or directory.
-                        continue
+                    path = os.path.join(rel_dir, name)
+
                     # src_path would be "/determined_shared_fs/UUID/subdir/file"
                     src_path = os.path.join(ign_dir, name)
+                    if os.path.isdir(src_path):
+                        # shutil removes '/' from dir names; we will add it manually.
+                        path = os.path.join(path, "")
+
+                    if selector(path):
+                        # The user wants this file or directory.
+                        continue
+
                     if os.path.isdir(src_path):
                         # The user does not want this directory, but we don't yet know if there
                         # might be a subfile or subdirectory which they do want.  Let copytree
                         # continue and revisit this later.
-                        maybe_dangling.append(ckpt_path)
+                        maybe_dangling.append(path)
                         continue
                     out.append(name)
                 return out

--- a/harness/tests/storage/util.py
+++ b/harness/tests/storage/util.py
@@ -142,7 +142,7 @@ def run_storage_lifecycle_test(
     }
 
     def selector(x: str) -> bool:
-        return x in ["subdir", "subdir/file1.txt", "empty_dir"]
+        return x in ["subdir/file1.txt", "empty_dir/"]
 
     # Test restore_path with selector
     # clear logs collected up to this point


### PR DESCRIPTION
## Description
`os.path.relpath` removes trailing slashes for dirs. This is a problem for uploading/downloading an empty dir with selector.

For instance, if a user has a selector `lambda x: x=='empty_dir/'`  then `empty_dir/` won't be found since `os.path.relpath` removes slashes. I decided to re-append slashes to dirs in such cases.
<!---
Lead with the intended commit body in this description field. For breaking
changes, please include "BREAKING CHANGE:" at the beginning of your commit
body.  At a minimum, this section should include a bracketed reference to the
Jira ticket, e.g. "[DET-1234]". When squash-and-merging, copy this directly
into the description field.
-->



## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot
as appropriate.  Reviewers may ask questions about this test plan to ensure
adequate manual coverage of changes.
-->



## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [X] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
