### PR TITLE
docs: FOUNDENG-321 On aizn-admin with PodMan cancelling causes slurm & podman problems

### DIFF
--- a/docs/cluster-setup-guide/deploy-cluster/sysadmin-deploy-on-slurm/slurm-known-issues.rst
+++ b/docs/cluster-setup-guide/deploy-cluster/sysadmin-deploy-on-slurm/slurm-known-issues.rst
@@ -169,17 +169,19 @@ Some constraints are due to differences in behavior between Docker and Singulari
          system migrate\": could not find any running process: no such process"``.
 
       Podman creates several processes when running a container, such as podman, conmon, and
-      catatonit. When a Determined AI job is terminated by the user, Slurm will send a SIGTERM to
-      the podman processes. However, sometimes the container will continue running, even after the
-      SIGTERM has been sent. On Slurm versions prior to version 22, Slurm will place the node in the
-      ``drain`` state, requiring the use of the ``scontrol`` command to set the node back to the
-      ``idle`` state. It may also require ``podman system migrate`` to be run to clean up the
-      running containers. To ensure that the container that is associated with the job is stopped
-      when a Determined AI job is terminated, create a Slurm task epilog script to stop the
-      container.
+      catatonit. When a user terminates a Determined AI job, Slurm will send a SIGTERM to the podman
+      processes. However, sometimes the container will continue running, even after the SIGTERM has
+      been sent.
+
+      On Slurm versions prior to version 22, Slurm will place the node in the ``drain`` state,
+      requiring the use of the ``scontrol`` command to set the node back to the ``idle`` state. It
+      may also require ``podman system migrate`` to be run to clean up the running containers.
+
+      To ensure the container associated with the job is stopped when a Determined AI job is
+      terminated, create a Slurm task epilog script to stop the container.
 
       Set the Task Epilog script in the ``slurm.conf`` file, as shown below, to point to a script
-      that resides in a shared filesystem that is accessible from all compute nodes.
+      that resides in a shared filesystem accessible from all compute nodes.
 
          .. code::
 

--- a/docs/cluster-setup-guide/deploy-cluster/sysadmin-deploy-on-slurm/slurm-known-issues.rst
+++ b/docs/cluster-setup-guide/deploy-cluster/sysadmin-deploy-on-slurm/slurm-known-issues.rst
@@ -183,8 +183,8 @@ Some constraints are due to differences in behavior between Docker and Singulari
 
             slurm_job_name_suffix=$(echo ${SLURM_JOB_NAME} | sed 's/^\S\+-\([a-z0-9]\+-[a-z0-9]\+\)$/\1/')
 
-            podman_container_stop_command="podman container stop --filter
-            name='.+-${slurm_job_name_suffix}'"
+            podman_container_stop_command="podman container stop \
+               --filter name='.+-${slurm_job_name_suffix}'"
 
             echo "$(date):$0: Running \"${podman_container_stop_command}\"" 1>&2
 

--- a/docs/cluster-setup-guide/deploy-cluster/sysadmin-deploy-on-slurm/slurm-known-issues.rst
+++ b/docs/cluster-setup-guide/deploy-cluster/sysadmin-deploy-on-slurm/slurm-known-issues.rst
@@ -158,6 +158,38 @@ Some constraints are due to differences in behavior between Docker and Singulari
             environment_variables:
               - INHERITED_ENV_VAR=
 
+   -  Podman creates several processes when running a container, such as podman, conmon, and
+      catatonit. When a Determined AI job is terminated by the user, Slurm will send a SIGTERM to
+      the podman processes. However, sometimes the container will continue running, even after the
+      SIGTERM has been sent. On Slurm versions prior to version 22, Slurm will place the node in the
+      ``drain`` state, requiring the use of the ``scontrol`` command to set the node back to the
+      ``idle`` state. It may also require ``podman system migrate`` to be run to clean up the
+      running containers. To ensure that the container that is associated with the job is stopped
+      when a Determined AI job is terminated, create a Slurm task epilog script to stop the
+      container.
+
+      Set the Task Epilog script in the ``slurm.conf`` file, as shown below, to point to a script
+      that resides in a shared filesystem that is accessible from all compute nodes.
+
+         .. code::
+
+            TaskEpilog=/path/to/task_epilog.sh
+
+      Set the contents of the Task Epilog script as shown below.
+
+         .. code:: bash
+
+            #!/usr/bin/env bash
+
+            slurm_job_name_suffix=$(echo ${SLURM_JOB_NAME} | sed 's/^\S\+-\([a-z0-9]\+-[a-z0-9]\+\)$/\1/')
+
+            podman_container_stop_command="podman container stop --filter
+            name='.+-${slurm_job_name_suffix}'"
+
+            echo "$(date):$0: Running \"${podman_container_stop_command}\"" 1>&2
+
+            eval ${podman_container_stop_command}
+
 *********************
  Enroot Known Issues
 *********************

--- a/docs/cluster-setup-guide/deploy-cluster/sysadmin-deploy-on-slurm/slurm-known-issues.rst
+++ b/docs/cluster-setup-guide/deploy-cluster/sysadmin-deploy-on-slurm/slurm-known-issues.rst
@@ -200,6 +200,8 @@ Some constraints are due to differences in behavior between Docker and Singulari
 
             eval ${podman_container_stop_command}
 
+      Restart the ``slurmd`` deamon on all compute nodes.
+
 *********************
  Enroot Known Issues
 *********************

--- a/docs/cluster-setup-guide/deploy-cluster/sysadmin-deploy-on-slurm/slurm-known-issues.rst
+++ b/docs/cluster-setup-guide/deploy-cluster/sysadmin-deploy-on-slurm/slurm-known-issues.rst
@@ -200,7 +200,7 @@ Some constraints are due to differences in behavior between Docker and Singulari
 
             eval ${podman_container_stop_command}
 
-      Restart the ``slurmd`` deamon on all compute nodes.
+      Restart the ``slurmd`` daemon on all compute nodes.
 
 *********************
  Enroot Known Issues

--- a/docs/cluster-setup-guide/deploy-cluster/sysadmin-deploy-on-slurm/slurm-known-issues.rst
+++ b/docs/cluster-setup-guide/deploy-cluster/sysadmin-deploy-on-slurm/slurm-known-issues.rst
@@ -158,7 +158,17 @@ Some constraints are due to differences in behavior between Docker and Singulari
             environment_variables:
               - INHERITED_ENV_VAR=
 
-   -  Podman creates several processes when running a container, such as podman, conmon, and
+   -  Terminating a Determined AI job may cause the following conditions to occur:
+
+      -  Compute nodes go into drain state.
+
+      -  Processes inside the container continue to run.
+
+      -  An attempt to run another job results in ``Running a job gets the error level=error
+         msg="invalid internal status, try resetting the pause process with \"/usr/local/bin/podman
+         system migrate\": could not find any running process: no such process"``.
+
+      Podman creates several processes when running a container, such as podman, conmon, and
       catatonit. When a Determined AI job is terminated by the user, Slurm will send a SIGTERM to
       the podman processes. However, sometimes the container will continue running, even after the
       SIGTERM has been sent. On Slurm versions prior to version 22, Slurm will place the node in the

--- a/docs/cluster-setup-guide/deploy-cluster/sysadmin-deploy-on-slurm/slurm-requirements.rst
+++ b/docs/cluster-setup-guide/deploy-cluster/sysadmin-deploy-on-slurm/slurm-requirements.rst
@@ -207,9 +207,6 @@ on the compute nodes of the cluster.
  PodMan Requirements
 *********************
 
-Test Podman Container
-=====================
-
 When Determined is configured to use PodMan, the containers are launched in `rootless mode
 <https://docs.podman.io/en/latest/markdown/podman.1.html#rootless-mode>`__. Your HPC cluster
 administrator should have completed most of the configuration for you, but there may be additional
@@ -256,39 +253,6 @@ Any changes to your ``storage.conf`` should be applied using the command:
    .. code:: bash
 
       podman system migrate
-
-Create A Slurm Task Epilog Script To Terminate Podman Containers
-================================================================
-
-Podman creates several processes when running a container, such as podman, conmon, and catatonit.
-When a Determined AI job is terminated by the user, Slurm will send a SIGTERM to the podman
-processes. However, sometimes the container will continue running, even after the SIGTERM has been
-sent. On Slurm versions prior to version 22, Slurm will place the node in the ``drain`` state,
-requiring the use of the ``scontrol`` command to set the node back to the ``idle`` state. It may
-also require ``podman system migrate`` to be run to clean up the running containers. To ensure that
-the container that is associated with the job is stopped when a Determined AI job is terminated,
-create a Slurm task epilog script to stop the container.
-
-Set the Task Epilog script in the ``slurm.conf`` file, as shown below, to point to a script that
-resides in a shared filesystem that is accessible from all compute nodes.
-
-   .. code::
-
-      TaskEpilog=/path/to/task_epilog.sh
-
-Set the contents of the Task Epilog script as shown below.
-
-   .. code:: bash
-
-      #!/usr/bin/env bash
-
-      slurm_job_name_suffix=$(echo ${SLURM_JOB_NAME} | sed 's/^\S\+-\([a-z0-9]\+-[a-z0-9]\+\)$/\1/')
-
-      podman_container_stop_command="podman container stop --filter name='.+-${slurm_job_name_suffix}'"
-
-      echo "$(date):$0: Running \"${podman_container_stop_command}\"" 1>&2
-
-      eval ${podman_container_stop_command}
 
 .. _enroot-config-requirements:
 

--- a/docs/cluster-setup-guide/deploy-cluster/sysadmin-deploy-on-slurm/slurm-requirements.rst
+++ b/docs/cluster-setup-guide/deploy-cluster/sysadmin-deploy-on-slurm/slurm-requirements.rst
@@ -207,7 +207,6 @@ on the compute nodes of the cluster.
  PodMan Requirements
 *********************
 
-=====================
 Test Podman Container
 =====================
 
@@ -258,18 +257,17 @@ Any changes to your ``storage.conf`` should be applied using the command:
 
       podman system migrate
 
-================================================================
 Create A Slurm Task Epilog Script To Terminate Podman Containers
 ================================================================
 
 Podman creates several processes when running a container, such as podman, conmon, and catatonit.
 When a Determined AI job is terminated by the user, Slurm will send a SIGTERM to the podman
 processes. However, sometimes the container will continue running, even after the SIGTERM has been
-sent.  On Slurm versions prior to version 22, Slurm will place the node in the ``drain`` state, requiring
-the use of the ``scontrol`` command to set the node back to the ``idle`` state. It may also require
-``podman system migrate`` to be run to clean up the running containers.  To ensure that the container
-that is associated with the job is stopped when a Determined AI job is terminated, create a Slurm task
-epilog script to stop the container.
+sent. On Slurm versions prior to version 22, Slurm will place the node in the ``drain`` state,
+requiring the use of the ``scontrol`` command to set the node back to the ``idle`` state. It may
+also require ``podman system migrate`` to be run to clean up the running containers. To ensure that
+the container that is associated with the job is stopped when a Determined AI job is terminated,
+create a Slurm task epilog script to stop the container.
 
 Set the Task Epilog script in the ``slurm.conf`` file, as shown below, to point to a script that
 resides in a shared filesystem that is accessible from all compute nodes.

--- a/docs/cluster-setup-guide/deploy-cluster/sysadmin-deploy-on-slurm/slurm-requirements.rst
+++ b/docs/cluster-setup-guide/deploy-cluster/sysadmin-deploy-on-slurm/slurm-requirements.rst
@@ -207,6 +207,10 @@ on the compute nodes of the cluster.
  PodMan Requirements
 *********************
 
+=====================
+Test Podman Container
+=====================
+
 When Determined is configured to use PodMan, the containers are launched in `rootless mode
 <https://docs.podman.io/en/latest/markdown/podman.1.html#rootless-mode>`__. Your HPC cluster
 administrator should have completed most of the configuration for you, but there may be additional
@@ -229,85 +233,64 @@ may be required in your ``$HOME/.config/containers/storage.conf`` file:
    ``/etc/containers/storage.conf`` on all compute nodes.
 
 #. PodMan utilizes the directory specified by the environment variable ``XDG_RUNTIME_DIR``.
-   Normally, ``XDG_RUNTIME_DIR`` is set to ``/run/user/$UID`` by the login process. However, Slurm
-   and PBS do not provide this variable when launching jobs on compute nodes. Even if
-   ``XDG_RUNTIME_DIR`` is not set, podman will automatically attempt to create the
-   ``/run/user/$UID`` directory, but will fail with a permission error because ``/run/user`` is not
-   writable by a non-root user. Furthermore, if ``XDG_RUNTIME_DIR`` is not set, podman may fail to
-   clean up its processes when a job is cancelled, leaving the container in a running or corrupted
-   state that may require a ``podman system migrate`` to fix. For Slurm versions older than 22, it
-   may also cause Slurm to place the node in the ``drain`` state, thereby preventing other jobs from
-   being run on that node.
+   Normally, this is provided by the login process. Slurm and PBS, however, do not provide this
+   variable when launching jobs on compute nodes. When ``XDG_RUNTIME_DIR`` is not defined, PodMan
+   attempts to create the directory ``/run/user/$UID`` for this purpose. If ``/run/user`` is not
+   writable by a non-root user, then PodMan commands will fail with a permission error. To avoid
+   this problem, configure the ``runroot`` option in your ``storage.conf`` to a writeable local
+   directory available on all compute nodes. Alternatively, you can request your system
+   administrator to configure the ``/run/user`` to be user-writable on all compute nodes.
 
-   To avoid this problem, the System Administrator can create the ``/run/user/$UID`` directory for
-   each user on all compute nodes, with permissions 700, and ownership and group set to the username
-   and group. The System Administrator must also set the ``XDG_RUNTIME_DIR`` environment variable in
-   the ``/etc/determined/master.yaml``, as shown below.
+Create or update ``$HOME/.config/containers/storage.conf`` as required to resolve the issues above.
+The example ``storage.conf`` file below uses the file system ``/tmp``, but there may be a more
+appropriate file system on your HPC cluster that you should specify for this purpose.
 
-      .. code:: yaml
+   .. code:: docker
 
-         task_container_defaults:
-            environment_variables:
-               - XDG_RUNTIME_DIR=/run/user/$(id -u)
+      [storage]
+      driver = "overlay"
+      graphroot = "/tmp/$USER/storage"
+      runroot = "/tmp/$USER/run"
 
-   After modifying ``/etc/determined/master.yaml``, restart the Determined master with
-   ``systemctl restart determined-master``.
+Any changes to your ``storage.conf`` should be applied using the command:
 
-#. PodMan creates several processes when running a container, such as ``podman``, ``conmon``, and
-   ``catatonit``. The ``catatonit`` process forwards signals to the spawned child, tears down the
-   container when the spawned child exists, and cleans up exited processes. When Slurm is configured
-   to use ``ProctrackType=proctrack/cgroup``, cancelling a job may fail to terminate the processes
-   running inside the container, leaving the container in a running or corrupted state that may
-   require a ``podman system migrate`` to fix. This is because when a job is cancelled, Slurm will
-   send a SIGTERM to all processes that are part of the ``cgroup``, including ``catatonit``, which
-   is the processes responsible for tearing down the container. For Slurm versions older than 22, it
-   may also cause Slurm to place the node in the ``drain`` state, thereby preventing other jobs from
-   being run on that node.
+   .. code:: bash
 
-   It should be noted that once the ``catatonit`` process is started, if the container is allowed to
-   run until completion without being terminated, the ``catatonit`` process will remain running
-   after all other podman related processes have terminated. In this case, running another job that
-   starts a podman container, and then cancelling that job, will not cause the problem described
-   above to occur, because the existing ``catatonit`` process is not part of the same ``cgroup`` as
-   the new podman processes.
+      podman system migrate
 
-   To ensure that the problem described above will never occur, create a Task Epilog script that
-   will send a SIGTERM to any process in the cgroup that Slurm did not send a SIGTERM to. This will
-   allow those processes that are still running after the job has been cancelled to properly clean
-   up and tear down the container before Slurm sends them a final SIGKILL.
+================================================================
+Create A Slurm Task Epilog Script To Terminate Podman Containers
+================================================================
 
-   Set the Task Epilog script in the ``slurm.conf`` file, as shown below, to point to a script that
-   resides in a shared filesystem that is accessible from all compute nodes.
+Podman creates several processes when running a container, such as podman, conmon, and catatonit.
+When a Determined AI job is terminated by the user, Slurm will send a SIGTERM to the podman
+processes. However, sometimes the container will continue running, even after the SIGTERM has been
+sent.  On Slurm versions prior to version 22, Slurm will place the node in the ``drain`` state, requiring
+the use of the ``scontrol`` command to set the node back to the ``idle`` state. It may also require
+``podman system migrate`` to be run to clean up the running containers.  To ensure that the container
+that is associated with the job is stopped when a Determined AI job is terminated, create a Slurm task
+epilog script to stop the container.
 
-      .. code::
+Set the Task Epilog script in the ``slurm.conf`` file, as shown below, to point to a script that
+resides in a shared filesystem that is accessible from all compute nodes.
 
-         TaskEpilog=/path/to/task_epilog.sh
+   .. code::
 
-   Set the contents of the Task Epilog script as shown below. Ensure that the ``/sys/fs/cgroup/...``
-   path is appropriate for your particular Operating System.
+      TaskEpilog=/path/to/task_epilog.sh
 
-      .. code:: bash
+Set the contents of the Task Epilog script as shown below.
 
-         #!/usr/bin/env bash
+   .. code:: bash
 
-         # Send a SIGTERM to any process still active in the cgroup before Slurm sends it a SIGKILL.
-         for pid in $(cat /sys/fs/cgroup/freezer/slurm/uid_$(id -u)/job_${SLURM_JOBID}/step_0/cgroup.procs)
-         do
-            # Check if the process is still active, as it may have already been terminatd as a
-            # result of killing one of the other processes.
-            if [ -e /proc/${pid} ]
-            then
-               echo "$(date):$0: Killing $(readlink /proc/${pid}/exe) (${pid})" 1>&2
+      #!/usr/bin/env bash
 
-               kill -SIGTERM ${pid}
+      slurm_job_name_suffix=$(echo ${SLURM_JOB_NAME} | sed 's/^\S\+-\([a-z0-9]\+-[a-z0-9]\+\)$/\1/')
 
-               # Wait 15 seconds for the process to terminate to avoid having Slurm send it
-               # a SIGKILL before the process gets a chance to clean up.
-               timeout -k 15s 15s bash -c "while ps -p ${pid} > /dev/null 2>&1; do sleep 1; done"
-            fi
-         done
+      podman_container_stop_command="podman container stop --filter name='.+-${slurm_job_name_suffix}'"
 
-   Restart ``slurmd`` on all the compute nodes after making the change.
+      echo "$(date):$0: Running \"${podman_container_stop_command}\"" 1>&2
+
+      eval ${podman_container_stop_command}
 
 .. _enroot-config-requirements:
 


### PR DESCRIPTION
## Description

Unlike Singularity, Podman starts up several processes when running a container, such as one or more "podman" processes, "catatonit" (responsible for cleaning up container), and "conmon" (runs the processes inside the container).

When a Podman container is running under Slurm and the Slurm job is cancelled, we may end up with a situation where the container remains running, even though Slurm has cancelled the job.  When this occurs on Slurm 21, "podman container ls" will issue an error indicating that "podman system migrate" needs to be run and "sinfo" will show the node in a "drain" state.  When this occurs on Slurm 22, "podman container ls" will show the container still running, although "sinfo" will show the node in an "idle" state.

To handle this situation, we provide instructions in the Podman documentation to create a Slurm task epilog script that will stop the container.

![image](https://user-images.githubusercontent.com/90728398/211891874-4c4bd2c4-9793-4f50-a5af-f48de5432bea.png)

![image](https://user-images.githubusercontent.com/90728398/212081950-cb71c4e1-df7f-42c2-b9a6-c4e13ea72ae6.png)

## Test Plan

Ran a notebook and an experiment and was able to cancel the job in both cases without any podman containers remaining running.

[corujor@znode54 cifar10_pytorch]$ det notebook start --config-file myconfig.yaml

[corujor@znode54 cifar10_pytorch]$ det experiment create rig_const.yaml .


## Commentary (optional)



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
