### PR TITLE
fix: check permissions loading in Page component

### DIFF
--- a/webui/react/src/components/Page.tsx
+++ b/webui/react/src/components/Page.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { Helmet } from 'react-helmet-async';
 
 import PageHeader from 'components/PageHeader';
-import useFeature from 'hooks/useFeature';
 import usePermissions from 'hooks/usePermissions';
 import BasePage, { Props as BasePageProps } from 'shared/components/Page';
 import Spinner from 'shared/components/Spinner';
@@ -27,7 +26,6 @@ const getFullDocTitle = (branding: string, title?: string, clusterName?: string)
 };
 
 const Page: React.FC<Props> = (props: Props) => {
-  const rbacEnabled = useFeature().isOn('rbac');
   const { loading: loadingPermissions } = usePermissions();
 
   const info = Loadable.getOrElse(initInfo, useDeterminedInfo());
@@ -48,7 +46,7 @@ const Page: React.FC<Props> = (props: Props) => {
           </>
         )}
       </Helmet>
-      {!props.ignorePermissions && rbacEnabled && loadingPermissions ? (
+      {!props.ignorePermissions && loadingPermissions ? (
         <Spinner center />
       ) : (
         <BasePage

--- a/webui/react/src/components/Page.tsx
+++ b/webui/react/src/components/Page.tsx
@@ -2,13 +2,17 @@ import React from 'react';
 import { Helmet } from 'react-helmet-async';
 
 import PageHeader from 'components/PageHeader';
+import useFeature from 'hooks/useFeature';
+import usePermissions from 'hooks/usePermissions';
 import BasePage, { Props as BasePageProps } from 'shared/components/Page';
+import Spinner from 'shared/components/Spinner';
 import { initInfo, useDeterminedInfo } from 'stores/determinedInfo';
 import { BrandingType } from 'types';
 import { Loadable } from 'utils/loadable';
 
 export interface Props extends Omit<BasePageProps, 'pageHeader'> {
   docTitle?: string;
+  ignorePermissions?: boolean;
 }
 
 const getFullDocTitle = (branding: string, title?: string, clusterName?: string) => {
@@ -23,6 +27,9 @@ const getFullDocTitle = (branding: string, title?: string, clusterName?: string)
 };
 
 const Page: React.FC<Props> = (props: Props) => {
+  const rbacEnabled = useFeature().isOn('rbac');
+  const { loading: loadingPermissions } = usePermissions();
+
   const info = Loadable.getOrElse(initInfo, useDeterminedInfo());
   const branding = info.branding || BrandingType.Determined;
   const brandingPath = `${process.env.PUBLIC_URL}/${branding}`;
@@ -41,18 +48,22 @@ const Page: React.FC<Props> = (props: Props) => {
           </>
         )}
       </Helmet>
-      <BasePage
-        {...props}
-        pageHeader={
-          <PageHeader
-            breadcrumb={props.breadcrumb}
-            options={props.options}
-            sticky={props.stickyHeader}
-            subTitle={props.subTitle}
-            title={props.title}
-          />
-        }
-      />
+      {!props.ignorePermissions && rbacEnabled && loadingPermissions ? (
+        <Spinner center />
+      ) : (
+        <BasePage
+          {...props}
+          pageHeader={
+            <PageHeader
+              breadcrumb={props.breadcrumb}
+              options={props.options}
+              sticky={props.stickyHeader}
+              subTitle={props.subTitle}
+              title={props.title}
+            />
+          }
+        />
+      )}
     </>
   );
 };

--- a/webui/react/src/hooks/usePermissions.ts
+++ b/webui/react/src/hooks/usePermissions.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo } from 'react';
 
 import useFeature from 'hooks/useFeature';
 import { V1PermissionType } from 'services/api-ts-sdk/api';
@@ -99,18 +99,6 @@ const usePermissions = (): PermissionsHook => {
     NotLoaded: () => [],
   });
 
-  const [loading, setLoading] = useState<boolean>(true);
-
-  useEffect(() => {
-    if (
-      !Loadable.isLoading(loadableCurrentUser) &&
-      !Loadable.isLoading(loadableUserAssignments) &&
-      !Loadable.isLoading(loadableUserRoles)
-    ) {
-      setLoading(false);
-    }
-  }, [loadableUserAssignments, loadableUserRoles, loadableCurrentUser]);
-
   const rbacOpts = useMemo(
     () => ({
       rbacAllPermission,
@@ -172,9 +160,12 @@ const usePermissions = (): PermissionsHook => {
       canViewWorkspace: (args: WorkspacePermissionsArgs) =>
         canViewWorkspace(rbacOpts, args.workspace),
       canViewWorkspaces: canViewWorkspaces(rbacOpts),
-      loading,
+      loading:
+        Loadable.isLoading(loadableCurrentUser) ||
+        Loadable.isLoading(loadableUserAssignments) ||
+        Loadable.isLoading(loadableUserRoles),
     }),
-    [rbacOpts, loading],
+    [rbacOpts, loadableUserAssignments, loadableUserRoles, loadableCurrentUser],
   );
 
   return permissions;

--- a/webui/react/src/hooks/usePermissions.ts
+++ b/webui/react/src/hooks/usePermissions.ts
@@ -161,9 +161,10 @@ const usePermissions = (): PermissionsHook => {
         canViewWorkspace(rbacOpts, args.workspace),
       canViewWorkspaces: canViewWorkspaces(rbacOpts),
       loading:
-        Loadable.isLoading(loadableCurrentUser) ||
-        Loadable.isLoading(loadableUserAssignments) ||
-        Loadable.isLoading(loadableUserRoles),
+        rbacOpts.rbacEnabled &&
+        (Loadable.isLoading(loadableCurrentUser) ||
+          Loadable.isLoading(loadableUserAssignments) ||
+          Loadable.isLoading(loadableUserRoles)),
     }),
     [rbacOpts, loadableUserAssignments, loadableUserRoles, loadableCurrentUser],
   );

--- a/webui/react/src/pages/SignIn.tsx
+++ b/webui/react/src/pages/SignIn.tsx
@@ -126,7 +126,7 @@ const SignIn: React.FC = () => {
     );
 
   return (
-    <Page docTitle="Sign In">
+    <Page docTitle="Sign In" ignorePermissions>
       <div className={css.base}>
         <div className={css.content}>
           <Logo


### PR DESCRIPTION
## Description

https://determinedai.atlassian.net/browse/WEB-558

Add `loading` to `usePermissions` hook and check that value in `<Page>` component. Ignore in `<Signin>` page (won't have an authenticated user to fetch permissions).

## Test Plan

In EE/RBAC:
- [ ] Pages should display a spinner until permissions are loaded (instead of flashing inaccurate component state)
- [ ] Logging in/out should still work without getting stuck on a loading spinner


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
