### PR TITLE
fix: Pass default to overwrite Users table column preferences [WEB-760]

### DIFF
--- a/webui/react/package-lock.json
+++ b/webui/react/package-lock.json
@@ -76,6 +76,7 @@
         "antd-theme-generator": "^1.2.11",
         "antd-theme-webpack-plugin": "^1.3.9",
         "babel-plugin-import": "^1.13.5",
+        "browserslist": "^4.21.4",
         "craco-less": "^1.20.0",
         "craco-sass-resources-loader": "^1.1.0",
         "csp-html-webpack-plugin": "^5.1.0",
@@ -7966,9 +7967,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.21.2",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.2.tgz",
-      "integrity": "sha512-MonuOgAtUB46uP5CezYbRaYKBNt2LxP0yX+Pmj4LkcDFGkn9Cbpi83d9sCjwQDErXsIJSzY5oKGDbgOlF/LPAA==",
+      "version": "4.21.4",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.4.tgz",
+      "integrity": "sha512-CBHJJdDmgjl3daYjN5Cp5kbTf1mUhZoS+beLklHIvkOWscs83YAhLlF3Wsh/lciQYAcbBJgTOD44VtG31ZM4Hw==",
       "dev": true,
       "funding": [
         {
@@ -7981,10 +7982,10 @@
         }
       ],
       "dependencies": {
-        "caniuse-lite": "^1.0.30001366",
-        "electron-to-chromium": "^1.4.188",
+        "caniuse-lite": "^1.0.30001400",
+        "electron-to-chromium": "^1.4.251",
         "node-releases": "^2.0.6",
-        "update-browserslist-db": "^1.0.4"
+        "update-browserslist-db": "^1.0.9"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -8216,9 +8217,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001366",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001366.tgz",
-      "integrity": "sha512-yy7XLWCubDobokgzudpkKux8e0UOOnLHE6mlNJBzT3lZJz6s5atSEzjoL+fsCPkI0G8MP5uVdDx1ur/fXEWkZA==",
+      "version": "1.0.30001442",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001442.tgz",
+      "integrity": "sha512-239m03Pqy0hwxYPYR5JwOIxRJfLTWtle9FV8zosfV5pHg+/51uD4nxcUlM8+mWWGfwKtt8lJNHnD3cWw9VZ6ow==",
       "dev": true,
       "funding": [
         {
@@ -10319,9 +10320,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.190",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.190.tgz",
-      "integrity": "sha512-dDW9D5xT+ODGh9rlK2sQeJR0xgV1nrNn3/K4IV8k74QbmKN61dm5GKMSwerdpTpazrrkK6wwcgjGBoQ/Nx6L5A==",
+      "version": "1.4.284",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.284.tgz",
+      "integrity": "sha512-M8WEXFuKXMYMVr45fo8mq0wUrrJHheiKZf6BArTKk9ZBYCKJEOU5H8cdWgDT+qCVZf7Na4lVUaZsA+h6uA9+PA==",
       "dev": true
     },
     "node_modules/elliptic": {
@@ -26075,9 +26076,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.4.tgz",
-      "integrity": "sha512-jnmO2BEGUjsMOe/Fg9u0oczOe/ppIDZPebzccl1yDWGLFP16Pa1/RM5wEoKYPG2zstNcDuAStejyxsOuKINdGA==",
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.10.tgz",
+      "integrity": "sha512-OztqDenkfFkbSG+tRxBeAnCVPckDBcvibKd35yDONx6OU8N7sqgwc7rCbkJ/WcYtVRZ4ba68d6byhC21GFh7sQ==",
       "dev": true,
       "funding": [
         {
@@ -33913,15 +33914,15 @@
       }
     },
     "browserslist": {
-      "version": "4.21.2",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.2.tgz",
-      "integrity": "sha512-MonuOgAtUB46uP5CezYbRaYKBNt2LxP0yX+Pmj4LkcDFGkn9Cbpi83d9sCjwQDErXsIJSzY5oKGDbgOlF/LPAA==",
+      "version": "4.21.4",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.4.tgz",
+      "integrity": "sha512-CBHJJdDmgjl3daYjN5Cp5kbTf1mUhZoS+beLklHIvkOWscs83YAhLlF3Wsh/lciQYAcbBJgTOD44VtG31ZM4Hw==",
       "dev": true,
       "requires": {
-        "caniuse-lite": "^1.0.30001366",
-        "electron-to-chromium": "^1.4.188",
+        "caniuse-lite": "^1.0.30001400",
+        "electron-to-chromium": "^1.4.251",
         "node-releases": "^2.0.6",
-        "update-browserslist-db": "^1.0.4"
+        "update-browserslist-db": "^1.0.9"
       },
       "dependencies": {
         "node-releases": {
@@ -34087,9 +34088,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001366",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001366.tgz",
-      "integrity": "sha512-yy7XLWCubDobokgzudpkKux8e0UOOnLHE6mlNJBzT3lZJz6s5atSEzjoL+fsCPkI0G8MP5uVdDx1ur/fXEWkZA==",
+      "version": "1.0.30001442",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001442.tgz",
+      "integrity": "sha512-239m03Pqy0hwxYPYR5JwOIxRJfLTWtle9FV8zosfV5pHg+/51uD4nxcUlM8+mWWGfwKtt8lJNHnD3cWw9VZ6ow==",
       "dev": true
     },
     "capture-exit": {
@@ -35578,9 +35579,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.4.190",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.190.tgz",
-      "integrity": "sha512-dDW9D5xT+ODGh9rlK2sQeJR0xgV1nrNn3/K4IV8k74QbmKN61dm5GKMSwerdpTpazrrkK6wwcgjGBoQ/Nx6L5A==",
+      "version": "1.4.284",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.284.tgz",
+      "integrity": "sha512-M8WEXFuKXMYMVr45fo8mq0wUrrJHheiKZf6BArTKk9ZBYCKJEOU5H8cdWgDT+qCVZf7Na4lVUaZsA+h6uA9+PA==",
       "dev": true
     },
     "elliptic": {
@@ -46355,9 +46356,9 @@
       "dev": true
     },
     "update-browserslist-db": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.4.tgz",
-      "integrity": "sha512-jnmO2BEGUjsMOe/Fg9u0oczOe/ppIDZPebzccl1yDWGLFP16Pa1/RM5wEoKYPG2zstNcDuAStejyxsOuKINdGA==",
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.10.tgz",
+      "integrity": "sha512-OztqDenkfFkbSG+tRxBeAnCVPckDBcvibKd35yDONx6OU8N7sqgwc7rCbkJ/WcYtVRZ4ba68d6byhC21GFh7sQ==",
       "dev": true,
       "requires": {
         "escalade": "^3.1.1",

--- a/webui/react/package.json
+++ b/webui/react/package.json
@@ -111,6 +111,7 @@
     "antd-theme-generator": "^1.2.11",
     "antd-theme-webpack-plugin": "^1.3.9",
     "babel-plugin-import": "^1.13.5",
+    "browserslist": "^4.21.4",
     "craco-less": "^1.20.0",
     "craco-sass-resources-loader": "^1.1.0",
     "csp-html-webpack-plugin": "^5.1.0",

--- a/webui/react/src/pages/Settings/UserManagement.tsx
+++ b/webui/react/src/pages/Settings/UserManagement.tsx
@@ -38,6 +38,7 @@ import css from './UserManagement.module.scss';
 import settingsConfig, {
   DEFAULT_COLUMN_WIDTHS,
   DEFAULT_COLUMNS,
+  UserColumnName,
   UserManagementSettings,
 } from './UserManagement.settings';
 
@@ -265,7 +266,13 @@ const UserManagement: React.FC = () => {
         )}
         rowClassName={defaultRowClassName({ clickable: false })}
         rowKey="id"
-        settings={{ ...settings, columns: DEFAULT_COLUMNS } as InteractiveTableSettings}
+        settings={
+          {
+            ...settings,
+            columns: DEFAULT_COLUMNS,
+            columnWidths: DEFAULT_COLUMNS.map((col: UserColumnName) => DEFAULT_COLUMN_WIDTHS[col]),
+          } as InteractiveTableSettings
+        }
         showSorterTooltip={false}
         size="small"
         updateSettings={updateSettings as UpdateSettings}

--- a/webui/react/src/pages/Settings/UserManagement.tsx
+++ b/webui/react/src/pages/Settings/UserManagement.tsx
@@ -37,6 +37,7 @@ import { Loadable, NotLoaded } from 'utils/loadable';
 import css from './UserManagement.module.scss';
 import settingsConfig, {
   DEFAULT_COLUMN_WIDTHS,
+  DEFAULT_COLUMNS,
   UserManagementSettings,
 } from './UserManagement.settings';
 
@@ -264,7 +265,7 @@ const UserManagement: React.FC = () => {
         )}
         rowClassName={defaultRowClassName({ clickable: false })}
         rowKey="id"
-        settings={settings as InteractiveTableSettings}
+        settings={{ ...settings, columns: DEFAULT_COLUMNS } as InteractiveTableSettings}
         showSorterTooltip={false}
         size="small"
         updateSettings={updateSettings as UpdateSettings}


### PR DESCRIPTION
## Description

On `/det/admin/user-management`, use `DEFAULT_COLUMNS` to overwrite any previously-saved column removal/re-ordering on the User-Admin table.

Notes:
- On EE the "isAdmin" column will be missing; admin role is more complex, so it is removed before sending to the table
- The `columns` setting cannot be deleted because it is part of `InteractiveTableSettings`
- `columns` cannot be an empty array or null

## Test Plan

- On OSS version, log in as admin
- On `/det/admin/user-management` , I should see a table of users with columns in this order: Name, Active, Admin, Modified Time, and [nameless] which contains a three-dot menu

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.