### PR TITLE
test: fix test flake for test_master_restart_with_queued

### DIFF
--- a/e2e_tests/tests/cluster/test_master_restart.py
+++ b/e2e_tests/tests/cluster/test_master_restart.py
@@ -388,10 +388,10 @@ def test_master_restart_with_queued(k8s_managed_cluster: ManagedK8sCluster) -> N
     agent_data = get_agent_data(conf.make_master_url())
     slots = sum([a["num_slots"] for a in agent_data])
 
-    running_command_id = run_command(60, slots)
-    queued_command_id = run_command(60, slots)
-
+    running_command_id = run_command(120, slots)
     wait_for_command_state(running_command_id, "RUNNING", 25)
+
+    queued_command_id = run_command(60, slots)
     wait_for_command_state(queued_command_id, "QUEUED", 25)
 
     job_list = det_cmd_json(["job", "list", "--json"])["jobs"]
@@ -400,11 +400,6 @@ def test_master_restart_with_queued(k8s_managed_cluster: ManagedK8sCluster) -> N
     k8s_managed_cluster.restart_master()
 
     post_restart_job_list = det_cmd_json(["job", "list", "--json"])["jobs"]
-
-    # TODO(DET-8776): command submission times get overwritten to master start currently.
-    assert len(job_list) == len(post_restart_job_list)
-    for pre, post in zip(job_list, post_restart_job_list):
-        post["submissionTime"] = pre["submissionTime"]
 
     assert job_list == post_restart_job_list
 

--- a/e2e_tests/tests/cluster/test_master_restart.py
+++ b/e2e_tests/tests/cluster/test_master_restart.py
@@ -74,7 +74,7 @@ def _test_master_restart_ok(managed_cluster: Cluster) -> None:
             cmd_ids = [run_command(1, slots) for slots in [0, 1]]
 
             for cmd_id in cmd_ids:
-                wait_for_command_state(cmd_id, "TERMINATED", 20)
+                wait_for_command_state(cmd_id, "TERMINATED", 30)
                 assert command_succeeded(cmd_id)
 
             managed_cluster.kill_master()
@@ -171,7 +171,7 @@ def _test_master_restart_kill_works(managed_cluster_restarts: Cluster) -> None:
         command = ["det", "-m", conf.make_master_url(), "e", "kill", str(exp_id)]
         subprocess.check_call(command)
 
-        exp.wait_for_experiment_state(exp_id, EXP_STATE.STATE_CANCELED, max_wait_secs=20)
+        exp.wait_for_experiment_state(exp_id, EXP_STATE.STATE_CANCELED, max_wait_secs=30)
 
         managed_cluster_restarts.ensure_agent_ok()
     except Exception:
@@ -199,7 +199,7 @@ def test_master_restart_cmd_k8s(
 
 def _test_master_restart_cmd(managed_cluster: Cluster, slots: int, downtime: int) -> None:
     command_id = run_command(30, slots=slots)
-    wait_for_command_state(command_id, "RUNNING", 20)
+    wait_for_command_state(command_id, "RUNNING", 30)
 
     if downtime >= 0:
         managed_cluster.kill_master()
@@ -389,10 +389,10 @@ def test_master_restart_with_queued(k8s_managed_cluster: ManagedK8sCluster) -> N
     slots = sum([a["num_slots"] for a in agent_data])
 
     running_command_id = run_command(120, slots)
-    wait_for_command_state(running_command_id, "RUNNING", 25)
+    wait_for_command_state(running_command_id, "RUNNING", 30)
 
     queued_command_id = run_command(60, slots)
-    wait_for_command_state(queued_command_id, "QUEUED", 25)
+    wait_for_command_state(queued_command_id, "QUEUED", 30)
 
     job_list = det_cmd_json(["job", "list", "--json"])["jobs"]
 


### PR DESCRIPTION
## Description

Flaky test for ```test_master_restart_with_queued``` caused by submitting two commands at the same time and assuming the first submitted would run first.

## Test Plan

See CI passes.

## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
