### PR TITLE
fix: 'det job list' ignores the '--resource-pool' argument

### DIFF
--- a/docs/release-notes/cli-job-ls-resource-pool-fix.rst
+++ b/docs/release-notes/cli-job-ls-resource-pool-fix.rst
@@ -1,0 +1,6 @@
+:orphan:
+
+**Bug Fixes**
+
+-  Job queue: Fix an issue where the CLI command ``det job list`` would ignore the argument
+   ``--resource-pool``.

--- a/harness/determined/cli/job.py
+++ b/harness/determined/cli/job.py
@@ -26,6 +26,7 @@ def ls(args: Namespace) -> None:
     def get_with_offset(offset: int) -> bindings.v1GetJobsResponse:
         return bindings.get_GetJobs(
             session,
+            resourcePool=args.resource_pool,
             offset=offset,
             limit=args.limit,
             orderBy=order_by,


### PR DESCRIPTION
## Description

Tiny regression from #4833 not passing ```--resource-pool``` to the ```get_GetJobs```.


## Test Plan

In a cluster with two resource pools run a command in the non default resource pool. 

```
 det command run --config="resources.resource_pool=$NON_DEFAULT_POOL_NAME" sleep 1000
```


Check the job list and verify you see the command in the output.
```
det job list --resource-pool=$NON_DEFAULT_POOL_NAME
```

## Commentary (optional)

Could not find any easy way to add an e2e test with multiple resource pools, didn't feel worth effort to value trade off for this feature
<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
