### PR TITLE
feat: correspond Kubernetes resource pools to namespaces

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -725,7 +725,9 @@ commands:
             echo "export USE_GKE_GCLOUD_AUTH_PLUGIN=True" >> $BASH_ENV
           name: Install GKE auth plugin
       - run:
-          command: gcloud container clusters create ${CLUSTER_ID} --machine-type=n1-standard-8 --cluster-version=<<parameters.gke-version>> --region=<<parameters.region>> --node-locations=<<parameters.node-locations>> --scopes storage-rw,cloud-platform --num-nodes 1 --labels environment=ci,${LABELS} --no-enable-ip-alias --subnetwork default
+          command: |
+            echo "Console URL for cluster: https://console.cloud.google.com/kubernetes/clusters/details/<<parameters.region>>/${CLUSTER_ID}?project=determined-ai"
+            gcloud container clusters create ${CLUSTER_ID} --machine-type=n1-standard-8 --cluster-version=<<parameters.gke-version>> --region=<<parameters.region>> --node-locations=<<parameters.node-locations>> --scopes storage-rw,cloud-platform --num-nodes 1 --labels environment=ci,${LABELS} --no-enable-ip-alias --subnetwork default
           name: Create GKE cluster
           no_output_timeout: 30m
       - run:
@@ -746,7 +748,7 @@ commands:
           steps:
             - run:
                 command: |
-                  echo 'export HELM_VALUES="${HELM_VALUES},slotType=<<parameters.slot-type>>,slotResourceRequests.cpu=<<parameters.slot-resource-requests-cpu>>,_reattachResources=true,taskContainerDefaults.gpuPodSpec.spec.tolerations[0].key=accel,taskContainerDefaults.gpuPodSpec.spec.tolerations[0].operator=Equal,taskContainerDefaults.gpuPodSpec.spec.tolerations[0].value=truth,taskContainerDefaults.gpuPodSpec.spec.tolerations[0].effect=NoSchedule,taskContainerDefaults.cpuPodSpec.spec.tolerations[0].key=accel,taskContainerDefaults.cpuPodSpec.spec.tolerations[0].operator=Equal,taskContainerDefaults.cpuPodSpec.spec.tolerations[0].value=truth,taskContainerDefaults.cpuPodSpec.spec.tolerations[0].effect=NoSchedule"' >> "$BASH_ENV"
+                  echo 'export HELM_VALUES="${HELM_VALUES},slotType=<<parameters.slot-type>>,slotResourceRequests.cpu=<<parameters.slot-resource-requests-cpu>>,resourcePools[0].agent_reattach_enabled=true,resourcePools[0].pool_name=default,taskContainerDefaults.gpuPodSpec.spec.tolerations[0].key=accel,taskContainerDefaults.gpuPodSpec.spec.tolerations[0].operator=Equal,taskContainerDefaults.gpuPodSpec.spec.tolerations[0].value=truth,taskContainerDefaults.gpuPodSpec.spec.tolerations[0].effect=NoSchedule,taskContainerDefaults.cpuPodSpec.spec.tolerations[0].key=accel,taskContainerDefaults.cpuPodSpec.spec.tolerations[0].operator=Equal,taskContainerDefaults.cpuPodSpec.spec.tolerations[0].value=truth,taskContainerDefaults.cpuPodSpec.spec.tolerations[0].effect=NoSchedule"' >> "$BASH_ENV"
                 name: CPU setup helm overrides
       - when:
           condition: <<parameters.environment-image>>

--- a/e2e_tests/tests/cluster/test_master_restart.py
+++ b/e2e_tests/tests/cluster/test_master_restart.py
@@ -76,7 +76,7 @@ def _test_master_restart_ok(managed_cluster: Cluster) -> None:
             cmd_ids = [run_command(1, slots) for slots in [0, 1]]
 
             for cmd_id in cmd_ids:
-                wait_for_command_state(cmd_id, "TERMINATED", 30)
+                wait_for_command_state(cmd_id, "TERMINATED", 300)
                 assert command_succeeded(cmd_id)
 
             managed_cluster.kill_master()

--- a/helm/charts/determined/templates/master-config.yaml
+++ b/helm/charts/determined/templates/master-config.yaml
@@ -122,9 +122,6 @@ data:
       fluent:
         {{- toYaml .Values.fluent | nindent 8}}
       {{- end }}
-      {{- if .Values._reattachResources }}
-      _reattach_resources: {{ .Values._reattachResources }}
-      {{- end }}
 
       default_aux_resource_pool: {{.Values.defaultAuxResourcePool}}
       default_compute_resource_pool: {{.Values.defaultComputeResourcePool}}

--- a/helm/charts/determined/values.yaml
+++ b/helm/charts/determined/values.yaml
@@ -250,9 +250,6 @@ telemetry:
 ## scheduling with preemption
 # defaultScheduler: preemption
 
-# Experimental feature flag to enable support for reattaching resources if master goes down.
-# _reattachResources: true
-
 ## Configure settings about how Determined launches the Fluent Bit sidecar.
 # fluent:
 #   image: fluent/fluent-bit:1.6

--- a/helm/charts/determined/values.yaml
+++ b/helm/charts/determined/values.yaml
@@ -257,6 +257,7 @@ telemetry:
 #   gid: 0
 
 ## Configure the resource pools in the Determined cluster.
-# resourcePools: null
+resourcePools:
+  - pool_name: default
 # defaultAuxResourcePool: default
 # defaultComputeResourcePool: default

--- a/master/internal/command/command.go
+++ b/master/internal/command/command.go
@@ -158,8 +158,11 @@ func remakeCommandsByType(
 
 	results := []*command{}
 	for i := range snapshots {
-		cmd := commandFromSnapshot(ctx, pgDB, rm, taskLogger, &snapshots[i])
-		results = append(results, cmd)
+		if rm.IsReattachEnabledForRP(ctx,
+			snapshots[i].GenericCommandSpec.Config.Resources.ResourcePool) {
+			cmd := commandFromSnapshot(ctx, pgDB, rm, taskLogger, &snapshots[i])
+			results = append(results, cmd)
+		}
 	}
 
 	return results, nil

--- a/master/internal/config/resource_manager_config.go
+++ b/master/internal/config/resource_manager_config.go
@@ -110,9 +110,6 @@ type KubernetesResourceManagerConfig struct {
 	CredsDir                 string                  `json:"_creds_dir,omitempty"`
 	MasterIP                 string                  `json:"_master_ip,omitempty"`
 	MasterPort               int32                   `json:"_master_port,omitempty"`
-	// TODO(nick) this will eventually move down to resource pools when added to k8s
-	// so this is just an experimental feature flag for now.
-	ReattachResources bool `json:"_reattach_resources"`
 
 	DefaultAuxResourcePool     string `json:"default_aux_resource_pool"`
 	DefaultComputeResourcePool string `json:"default_compute_resource_pool"`

--- a/master/internal/config/resource_pool_config.go
+++ b/master/internal/config/resource_pool_config.go
@@ -16,6 +16,8 @@ func defaultRPConfig() ResourcePoolConfig {
 		MaxCPUContainersPerAgent: -1,
 		AgentReconnectWait:       model.Duration(aproto.AgentReconnectWait),
 		AgentReattachEnabled:     false,
+
+		KubernetesNamespace: "default",
 	}
 }
 
@@ -34,6 +36,8 @@ type ResourcePoolConfig struct {
 	// before abandoning it.
 	AgentReconnectWait model.Duration `json:"agent_reconnect_wait"`
 
+	KubernetesNamespace string `json:"kubernetes_namespace"`
+
 	// Deprecated: Use MaxAuxContainersPerAgent instead.
 	MaxCPUContainersPerAgent int `json:"max_cpu_containers_per_agent,omitempty"`
 }
@@ -48,6 +52,10 @@ func (r *ResourcePoolConfig) UnmarshalJSON(data []byte) error {
 
 	if r.MaxCPUContainersPerAgent != -1 {
 		r.MaxAuxContainersPerAgent = r.MaxCPUContainersPerAgent
+	}
+
+	if r.KubernetesNamespace == "" {
+		r.KubernetesNamespace = "default"
 	}
 
 	r.MaxCPUContainersPerAgent = 0

--- a/master/internal/config/resource_pool_config.go
+++ b/master/internal/config/resource_pool_config.go
@@ -16,8 +16,6 @@ func defaultRPConfig() ResourcePoolConfig {
 		MaxCPUContainersPerAgent: -1,
 		AgentReconnectWait:       model.Duration(aproto.AgentReconnectWait),
 		AgentReattachEnabled:     false,
-
-		KubernetesNamespace: "default",
 	}
 }
 
@@ -36,6 +34,8 @@ type ResourcePoolConfig struct {
 	// before abandoning it.
 	AgentReconnectWait model.Duration `json:"agent_reconnect_wait"`
 
+	// If empty, will behave as if the value is resource_manager.namespace,
+	// which in most cases will be the namespace the helm deployment is in.
 	KubernetesNamespace string `json:"kubernetes_namespace"`
 
 	// Deprecated: Use MaxAuxContainersPerAgent instead.
@@ -52,10 +52,6 @@ func (r *ResourcePoolConfig) UnmarshalJSON(data []byte) error {
 
 	if r.MaxCPUContainersPerAgent != -1 {
 		r.MaxAuxContainersPerAgent = r.MaxCPUContainersPerAgent
-	}
-
-	if r.KubernetesNamespace == "" {
-		r.KubernetesNamespace = "default"
 	}
 
 	r.MaxCPUContainersPerAgent = 0

--- a/master/internal/rm/kubernetesrm/events.go
+++ b/master/internal/rm/kubernetesrm/events.go
@@ -30,18 +30,15 @@ type (
 
 type eventListener struct {
 	clientSet   *k8sClient.Clientset
-	namespace   string
 	podsHandler *actor.Ref
 }
 
 func newEventListener(
 	clientSet *k8sClient.Clientset,
-	namespace string,
 	podsHandler *actor.Ref,
 ) *eventListener {
 	return &eventListener{
 		clientSet:   clientSet,
-		namespace:   namespace,
 		podsHandler: podsHandler,
 	}
 }
@@ -65,7 +62,7 @@ func (e *eventListener) Receive(ctx *actor.Context) error {
 }
 
 func (e *eventListener) startEventListener(ctx *actor.Context) {
-	events, err := e.clientSet.CoreV1().Events(e.namespace).List(
+	events, err := e.clientSet.CoreV1().Events(metaV1.NamespaceAll).List(
 		context.TODO(), metaV1.ListOptions{})
 	if err != nil {
 		ctx.Log().WithError(err).Warnf("error retrieving internal resource version")
@@ -75,7 +72,7 @@ func (e *eventListener) startEventListener(ctx *actor.Context) {
 
 	rw, err := watchtools.NewRetryWatcher(events.ResourceVersion, &cache.ListWatch{
 		WatchFunc: func(options metaV1.ListOptions) (watch.Interface, error) {
-			return e.clientSet.CoreV1().Events(e.namespace).Watch(
+			return e.clientSet.CoreV1().Events(metaV1.NamespaceAll).Watch(
 				context.TODO(), metaV1.ListOptions{})
 		},
 	})

--- a/master/internal/rm/kubernetesrm/informer.go
+++ b/master/internal/rm/kubernetesrm/informer.go
@@ -39,12 +39,10 @@ type informer struct {
 
 func newInformer(
 	podInterface typedV1.PodInterface,
-	namespace string,
 	podsHandler *actor.Ref,
 ) *informer {
 	return &informer{
 		podInterface: podInterface,
-		namespace:    namespace,
 		podsHandler:  podsHandler,
 	}
 }
@@ -99,10 +97,6 @@ func (i *informer) startInformer(ctx *actor.Context) {
 		pod, ok := event.Object.(*k8sV1.Pod)
 		if !ok {
 			ctx.Log().Warnf("error converting event of type %T to *k8sV1.Pod: %+v", event, event)
-			continue
-		}
-
-		if pod.Namespace != i.namespace {
 			continue
 		}
 

--- a/master/internal/rm/kubernetesrm/message.go
+++ b/master/internal/rm/kubernetesrm/message.go
@@ -11,10 +11,12 @@ import (
 type (
 	// StartTaskPod notifies the pods actor to start a pod with the task spec.
 	StartTaskPod struct {
-		TaskActor *actor.Ref
-		Spec      tasks.TaskSpec
-		Slots     int
-		Rank      int
+		TaskActor    *actor.Ref
+		Spec         tasks.TaskSpec
+		Slots        int
+		Rank         int
+		ResourcePool string
+		Namespace    string
 
 		LogContext logger.Context
 	}

--- a/master/internal/rm/kubernetesrm/pod.go
+++ b/master/internal/rm/kubernetesrm/pod.go
@@ -346,6 +346,7 @@ func (p *pod) deleteKubernetesResources(ctx *actor.Context) {
 	ctx.Log().Infof("requesting to delete kubernetes resources")
 	ctx.Tell(p.resourceRequestQueue, deleteKubernetesResources{
 		handler:       ctx.Self(),
+		namespace:     p.namespace,
 		podName:       p.podName,
 		configMapName: p.configMapName,
 	})

--- a/master/internal/rm/kubernetesrm/pod_test.go
+++ b/master/internal/rm/kubernetesrm/pod_test.go
@@ -707,6 +707,7 @@ func TestKillTaskPod(t *testing.T) {
 		handler:       ref,
 		podName:       newPod.podName,
 		configMapName: newPod.configMapName,
+		namespace:     "test_namespace",
 	},
 	)
 

--- a/master/internal/rm/kubernetesrm/request_queue_test.go
+++ b/master/internal/rm/kubernetesrm/request_queue_test.go
@@ -85,7 +85,10 @@ func TestRequestQueueCreatingManyPod(t *testing.T) {
 	podInterface := &mockPodInterface{pods: make(map[string]*k8sV1.Pod)}
 	configMapInterface := &mockConfigMapInterface{configMaps: make(map[string]*k8sV1.ConfigMap)}
 
-	k8sRequestQueue := newRequestQueue(podInterface, configMapInterface)
+	k8sRequestQueue := newRequestQueue(
+		map[string]typedV1.PodInterface{metaV1.NamespaceAll: podInterface},
+		map[string]typedV1.ConfigMapInterface{metaV1.NamespaceAll: configMapInterface},
+	)
 	requestQueueActor, _ := system.ActorOf(
 		actor.Addr("request-queue"),
 		k8sRequestQueue,
@@ -113,7 +116,10 @@ func TestRequestQueueCreatingAndDeletingManyPod(t *testing.T) {
 	podInterface := &mockPodInterface{pods: make(map[string]*k8sV1.Pod)}
 	configMapInterface := &mockConfigMapInterface{configMaps: make(map[string]*k8sV1.ConfigMap)}
 
-	k8sRequestQueue := newRequestQueue(podInterface, configMapInterface)
+	k8sRequestQueue := newRequestQueue(
+		map[string]typedV1.PodInterface{metaV1.NamespaceAll: podInterface},
+		map[string]typedV1.ConfigMapInterface{metaV1.NamespaceAll: configMapInterface},
+	)
 	requestQueueActor, _ := system.ActorOf(
 		actor.Addr("request-queue"),
 		k8sRequestQueue,
@@ -142,7 +148,10 @@ func TestRequestQueueCreatingThenDeletingManyPods(t *testing.T) {
 	podInterface := &mockPodInterface{pods: make(map[string]*k8sV1.Pod)}
 	configMapInterface := &mockConfigMapInterface{configMaps: make(map[string]*k8sV1.ConfigMap)}
 
-	k8sRequestQueue := newRequestQueue(podInterface, configMapInterface)
+	k8sRequestQueue := newRequestQueue(
+		map[string]typedV1.PodInterface{metaV1.NamespaceAll: podInterface},
+		map[string]typedV1.ConfigMapInterface{metaV1.NamespaceAll: configMapInterface},
+	)
 	requestQueueActor, _ := system.ActorOf(
 		actor.Addr("request-queue"),
 		k8sRequestQueue,
@@ -179,7 +188,10 @@ func TestRequestQueueCreatingAndDeletingManyPodWithDelay(t *testing.T) {
 	}
 	configMapInterface := &mockConfigMapInterface{configMaps: make(map[string]*k8sV1.ConfigMap)}
 
-	k8sRequestQueue := newRequestQueue(podInterface, configMapInterface)
+	k8sRequestQueue := newRequestQueue(
+		map[string]typedV1.PodInterface{metaV1.NamespaceAll: podInterface},
+		map[string]typedV1.ConfigMapInterface{metaV1.NamespaceAll: configMapInterface},
+	)
 	requestQueueActor, _ := system.ActorOf(
 		actor.Addr("request-queue"),
 		k8sRequestQueue,

--- a/master/internal/task/allocation.go
+++ b/master/internal/task/allocation.go
@@ -674,6 +674,7 @@ func (a *Allocation) RestoreResourceFailure(
 	}
 
 	if a.req.Restore {
+		// TODO(DET-8822): This heartbeat can be nil.
 		switch heartbeat := cluster.TheLastBootClusterHeartbeat(); {
 		case a.model.StartTime == nil:
 			break

--- a/master/pkg/set/set.go
+++ b/master/pkg/set/set.go
@@ -16,3 +16,11 @@ func (s *Set[T]) Contains(val T) bool {
 func (s *Set[T]) Insert(val T) {
 	(map[T]unit)(*s)[val] = unit{}
 }
+
+func (s *Set[T]) Copy() Set[T] {
+	copy := Set[T]{}
+	for x := range (map[T]unit)(*s) {
+		copy.Insert(x)
+	}
+	return copy
+}

--- a/master/pkg/set/set.go
+++ b/master/pkg/set/set.go
@@ -1,0 +1,18 @@
+package set
+
+type unit = struct{}
+
+// Set is an unordered set of values of type T.
+type Set[T comparable] map[T]unit
+
+// Making Set a defined type rather than a struct means we need the casting shenanigans below, but
+// it also allows normal indexing and iteration syntax to be used.
+
+func (s *Set[T]) Contains(val T) bool {
+	_, ok := (map[T]unit)(*s)[val]
+	return ok
+}
+
+func (s *Set[T]) Insert(val T) {
+	(map[T]unit)(*s)[val] = unit{}
+}


### PR DESCRIPTION
## Description

This allows each resource pool in a Kubernetes cluster to map to a specific namespace in the cluster. The pods actor now maintains pod and config map clients for each namespace that might be necessary and passes the appropriate one along to each of its child actors. (Since the clients have namespaces built into them that can't be changed, we can't just have one of each kind of client.)

An alternative would be to have a separate pods actor for each namespace, along with the attending actors for informers, listeners, and the request queue. That has a certain elegance and might be a smaller code change, but I didn't go that way because it seemed kind of heavyweight in execution.

## Test Plan

- [ ] CI tests
- [ ] write new multi-RP tests

## Commentary

The API for available resources still needs updating, since it's based on enumerating nodes in the cluster, and nodes are not part of namespaces. Presumably that should instead change to be based on namespace quotas, though it seems a shame to lose the current counting for the simple case, so maybe we should still count nodes for the case where there's a single resource pool with no quota or something.