### PR TITLE
docs: Corrected override config fields for mmdet model_hub intro [DPS-209]

### DIFF
--- a/model_hub/examples/mmdetection/README.md
+++ b/model_hub/examples/mmdetection/README.md
@@ -40,15 +40,15 @@ hyperparameters:
 
 ### Overriding config fields
 Finally, if you only want to override a few fields of the MMDetection config, you can use the 
-`override_config_fields` section under `hyperparameters`.  The overrides here will be applied last 
+`override_mmdet_config` section under `hyperparameters`.  The overrides here will be applied last 
 and hence take precedence over the values from a merged file if specified.
 You can indicate nested config structure by using a `.` to indicate a child of a field.  For example, 
-you can add the following to `hyperparameters.override_config_fields` to change the learning rate:
+you can add the following to `hyperparameters.override_mmdet_config` to change the learning rate:
 
 ```
 hyperparameters:
-  override_config_fields:
-    - optimizer.lr: 0.005
+  override_mmdet_config:
+    optimizer.lr: 0.005
 ```
 
 There are provided examples commented out in the default config that show how to use the override


### PR DESCRIPTION
## Description

docs: Correct override config fields for mmdet model_hub introduction

Resolves the issue [DPS-209] where a customer reports that they followed the documentation and did not see the intended change in behavior. The documentation uses an incorrect field as part of the example.

## Test Plan

I ran the example with (close to) the default config, see commentary below. Then again with the correct config to override learning rate, then lastly with the incorrect config as reported by the customer.

## Commentary (optional)

When testing manually, entrypoint was modified to avoid `torch_distributed` as it was not available for 0.17.15 per customer's environment. Additionally my gcp service worker key was provided alongside a `startup-hook.sh` to set my `GOOGLE_APPLICATION_CREDENTIALS` variable to that key file.

## Checklist
- [x] Changes have been manually QA'd
- [ ] ~~User-facing API changes need the "User-facing API Change" label.~~
- [ ] ~~Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.~~
- [ ] ~~Licenses should be included for new code which was copied and/or modified from any external code.~~
- [ ] ~~If modifying `/webui/react/src/shared/` verify `make -C webui/react test-shared` passes.~~


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DPS-209]: https://determinedai.atlassian.net/browse/DPS-209?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Ticket
DPS-209
