### PR TITLE
chore: Fix to the tests so that local tests on mac will correctly skip tests that it cannot run

### DIFF
--- a/harness/tests/experiment/pytorch/test_reducer.py
+++ b/harness/tests/experiment/pytorch/test_reducer.py
@@ -1,5 +1,6 @@
 import itertools
 import logging
+import sys
 import threading
 import traceback
 from collections import namedtuple
@@ -44,6 +45,16 @@ def dummy_reducer(values: List) -> Any:
 def test_custom_reducer_slot_order(cross_size: int, local_size: int) -> None:
     size = cross_size * local_size
     dataset_size = 47
+
+    # Make sure `make test` doesn't hang on macbook's default file descriptor limit (256).
+    # Avoid skipping on linux because it's not a common default, and to avoid false positives in CI.
+    if sys.platform == "darwin" and size == 9:  # Maximum size 3 x 3
+        import resource
+
+        if resource.getrlimit(resource.RLIMIT_NOFILE)[0] < 1024:
+            pytest.skip(
+                "increase the open fd limit with `ulimit -n 1024` or greater to run this test"
+            )
 
     def do_parallel(fn: Callable) -> List:
         """


### PR DESCRIPTION
## Description

<!---
Lead with the intended commit body in this description field. For breaking
changes, please include "BREAKING CHANGE:" at the beginning of your commit
body.  At a minimum, this section should include a bracketed reference to the
Jira ticket, e.g. "[DET-1234]". When squash-and-merging, copy this directly
into the description field.
-->
Fix to the tests so that local tests on mac will correctly skip tests that it cannot run

Default mac ulimits cause the custom_reducer (3x3) test to fail

## Test Plan

On a Mac:
```bash
(det) ulimit -n 256
(det) make test
```
Tests should fail
```bash
(det) ulimit -n 1024
(det) make test
```
Tests should pass again

<!---
Describe the situations in which you've tested your change, and/or a screenshot
as appropriate.  Reviewers may ask questions about this test plan to ensure
adequate manual coverage of changes.
-->


## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
