### PR TITLE
docs: FOUNDENG-321 On aizn-admin with PodMan cancelling causes slurm & podman problems

### DIFF
--- a/docs/cluster-setup-guide/deploy-cluster/sysadmin-deploy-on-slurm/slurm-known-issues.rst
+++ b/docs/cluster-setup-guide/deploy-cluster/sysadmin-deploy-on-slurm/slurm-known-issues.rst
@@ -158,6 +158,52 @@ Some constraints are due to differences in behavior between Docker and Singulari
             environment_variables:
               - INHERITED_ENV_VAR=
 
+   -  Terminating a Determined AI job may cause the following conditions to occur:
+
+      -  Compute nodes go into drain state.
+
+      -  Processes inside the container continue to run.
+
+      -  An attempt to run another job results in ``Running a job gets the error level=error
+         msg="invalid internal status, try resetting the pause process with \"/usr/local/bin/podman
+         system migrate\": could not find any running process: no such process"``.
+
+      Podman creates several processes when running a container, such as podman, conmon, and
+      catatonit. When a user terminates a Determined AI job, Slurm will send a SIGTERM to the podman
+      processes. However, sometimes the container will continue running, even after the SIGTERM has
+      been sent.
+
+      On Slurm versions prior to version 22, Slurm will place the node in the ``drain`` state,
+      requiring the use of the ``scontrol`` command to set the node back to the ``idle`` state. It
+      may also require ``podman system migrate`` to be run to clean up the running containers.
+
+      To ensure the container associated with the job is stopped when a Determined AI job is
+      terminated, create a Slurm task epilog script to stop the container.
+
+      Set the Task Epilog script in the ``slurm.conf`` file, as shown below, to point to a script
+      that resides in a shared filesystem accessible from all compute nodes.
+
+         .. code::
+
+            TaskEpilog=/path/to/task_epilog.sh
+
+      Set the contents of the Task Epilog script as shown below.
+
+         .. code:: bash
+
+            #!/usr/bin/env bash
+
+            slurm_job_name_suffix=$(echo ${SLURM_JOB_NAME} | sed 's/^\S\+-\([a-z0-9]\+-[a-z0-9]\+\)$/\1/')
+
+            podman_container_stop_command="podman container stop \
+               --filter name='.+-${slurm_job_name_suffix}'"
+
+            echo "$(date):$0: Running \"${podman_container_stop_command}\"" 1>&2
+
+            eval ${podman_container_stop_command}
+
+      Restart the ``slurmd`` daemon on all compute nodes.
+
 *********************
  Enroot Known Issues
 *********************

--- a/docs/cluster-setup-guide/deploy-cluster/sysadmin-deploy-on-slurm/slurm-known-issues.rst
+++ b/docs/cluster-setup-guide/deploy-cluster/sysadmin-deploy-on-slurm/slurm-known-issues.rst
@@ -158,52 +158,6 @@ Some constraints are due to differences in behavior between Docker and Singulari
             environment_variables:
               - INHERITED_ENV_VAR=
 
-   -  Terminating a Determined AI job may cause the following conditions to occur:
-
-      -  Compute nodes go into drain state.
-
-      -  Processes inside the container continue to run.
-
-      -  An attempt to run another job results in ``Running a job gets the error level=error
-         msg="invalid internal status, try resetting the pause process with \"/usr/local/bin/podman
-         system migrate\": could not find any running process: no such process"``.
-
-      Podman creates several processes when running a container, such as podman, conmon, and
-      catatonit. When a user terminates a Determined AI job, Slurm will send a SIGTERM to the podman
-      processes. However, sometimes the container will continue running, even after the SIGTERM has
-      been sent.
-
-      On Slurm versions prior to version 22, Slurm will place the node in the ``drain`` state,
-      requiring the use of the ``scontrol`` command to set the node back to the ``idle`` state. It
-      may also require ``podman system migrate`` to be run to clean up the running containers.
-
-      To ensure the container associated with the job is stopped when a Determined AI job is
-      terminated, create a Slurm task epilog script to stop the container.
-
-      Set the Task Epilog script in the ``slurm.conf`` file, as shown below, to point to a script
-      that resides in a shared filesystem accessible from all compute nodes.
-
-         .. code::
-
-            TaskEpilog=/path/to/task_epilog.sh
-
-      Set the contents of the Task Epilog script as shown below.
-
-         .. code:: bash
-
-            #!/usr/bin/env bash
-
-            slurm_job_name_suffix=$(echo ${SLURM_JOB_NAME} | sed 's/^\S\+-\([a-z0-9]\+-[a-z0-9]\+\)$/\1/')
-
-            podman_container_stop_command="podman container stop \
-               --filter name='.+-${slurm_job_name_suffix}'"
-
-            echo "$(date):$0: Running \"${podman_container_stop_command}\"" 1>&2
-
-            eval ${podman_container_stop_command}
-
-      Restart the ``slurmd`` daemon on all compute nodes.
-
 *********************
  Enroot Known Issues
 *********************
@@ -228,7 +182,7 @@ Some constraints are due to differences in behavior between Docker and Singulari
  Slurm Known Issues
 ********************
 
-   -  A Determined experiment remains ``QUEUEUED`` for an extended period of time:
+   -  A Determined experiment remains ``QUEUEUED`` for an extended period of timeXXX:
 
       Inspect the details of your queued jobs using the Slurm ``scontrol show jobs`` command. If the
       Slurm job is ``PENDING`` review the ``Reason`` code provided. See `JOB REASON CODES


### PR DESCRIPTION
## Description

Unlike Singularity, Podman starts up several processes when running a container, such as one or more "podman" processes, "catatonit" (responsible for cleaning up container), and "conmon" (runs the processes inside the container).

When a Podman container is running under Slurm and the Slurm job is cancelled, we may end up with a situation where the container remains running, even though Slurm has cancelled the job.  When this occurs on Slurm 21, "podman container ls" will issue an error indicating that "podman system migrate" needs to be run and "sinfo" will show the node in a "drain" state.  When this occurs on Slurm 22, "podman container ls" will show the container still running, although "sinfo" will show the node in an "idle" state.

To handle this situation, we provide instructions in the Podman documentation to create a Slurm task epilog script that will stop the container.

![image](https://user-images.githubusercontent.com/90728398/211891874-4c4bd2c4-9793-4f50-a5af-f48de5432bea.png)

![image](https://user-images.githubusercontent.com/90728398/212081950-cb71c4e1-df7f-42c2-b9a6-c4e13ea72ae6.png)

## Test Plan

Ran a notebook and an experiment and was able to cancel the job in both cases without any podman containers remaining running.

[corujor@znode54 cifar10_pytorch]$ det notebook start --config-file myconfig.yaml

[corujor@znode54 cifar10_pytorch]$ det experiment create rig_const.yaml .


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
