### PR TITLE
fix: zero-slot tasks to stop requesting `nvidia.com/gpu: 0` [DET-8832]

### DIFF
--- a/docs/release-notes/k8s-zero.rst
+++ b/docs/release-notes/k8s-zero.rst
@@ -1,0 +1,6 @@
+:orphan:
+
+**Improvements**
+
+-  Kubernetes: zero-slot tasks on gpu clusters will not request ``nvidia.com/gpu: 0`` resources any
+   more, allowing them to be schedule on cpu-only nodes.

--- a/master/internal/rm/kubernetesrm/spec.go
+++ b/master/internal/rm/kubernetesrm/spec.go
@@ -59,15 +59,18 @@ func (p *pod) configureResourcesRequirements() k8sV1.ResourceRequirements {
 	case device.CUDA: // default to CUDA-backed slots.
 		fallthrough
 	default:
-		return k8sV1.ResourceRequirements{
-			Limits: map[k8sV1.ResourceName]resource.Quantity{
-				"nvidia.com/gpu": *resource.NewQuantity(int64(p.slots), resource.DecimalSI),
-			},
-			Requests: map[k8sV1.ResourceName]resource.Quantity{
-				"nvidia.com/gpu": *resource.NewQuantity(int64(p.slots), resource.DecimalSI),
-			},
+		if p.slots > 0 {
+			return k8sV1.ResourceRequirements{
+				Limits: map[k8sV1.ResourceName]resource.Quantity{
+					"nvidia.com/gpu": *resource.NewQuantity(int64(p.slots), resource.DecimalSI),
+				},
+				Requests: map[k8sV1.ResourceName]resource.Quantity{
+					"nvidia.com/gpu": *resource.NewQuantity(int64(p.slots), resource.DecimalSI),
+				},
+			}
 		}
 	}
+	return k8sV1.ResourceRequirements{}
 }
 
 func (p *pod) configureEnvVars(


### PR DESCRIPTION
## Description

Requesting `nvidia.com/gpu: 0` prevents the zero-slot tasks from being scheduled on cpu-only nodes in mixed cpu/gpu clusters.
https://determined-community.slack.com/archives/CV3MTNZ6U/p1674061007627449

## Test Plan

Run a zero-slot task on a gpu cluster and make sure the podspec doesn't have any special resources.

## Commentary (optional)

## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
