### PR TITLE
fix: Slot Capacity Check Always Fails

### DIFF
--- a/master/internal/rm/agentrm/resource_pool.go
+++ b/master/internal/rm/agentrm/resource_pool.go
@@ -487,6 +487,10 @@ func (rp *resourcePool) Receive(ctx *actor.Context) error {
 		var totalSlots int
 		switch {
 		case rp.config.Provider == nil:
+			rp.agentStatesCache = rp.fetchAgentStates(ctx)
+			defer func() {
+				rp.agentStatesCache = nil
+			}()
 			for _, a := range rp.agentStatesCache {
 				totalSlots += len(a.slotStates)
 			}


### PR DESCRIPTION
## Description

Fix issue where slot capacity check always fails for agent resource manager.

## Test Plan

Create an experiment for which your cluster has enough slots to run and ensure that you don't see the warning message about not having enough slots.
