### PR TITLE
fix: tasks get stuck if container gone in reattach [DET-8828]

### DIFF
--- a/docs/release-notes/stuck-on-reattach.rst
+++ b/docs/release-notes/stuck-on-reattach.rst
@@ -1,0 +1,7 @@
+:orphan:
+
+**Bug Fixes**
+
+-  Agent: Fix a bug where if the flag ``agent_reattach_enabled`` was enabled and master was down
+   while an active task's docker container failed, the task could get stuck in an unkillable running
+   state.

--- a/master/internal/sproto/resources.go
+++ b/master/internal/sproto/resources.go
@@ -264,7 +264,7 @@ func IsTransientSystemError(err error) bool {
 		case ResourcesFailed, TaskError:
 			return false
 		// Questionable, could be considered failures, but for now we don't.
-		case AgentError, AgentFailed:
+		case AgentError, AgentFailed, RestoreError:
 			return true
 		// Definitely not a failure.
 		case TaskAborted, ResourcesAborted:

--- a/master/internal/task/allocation.go
+++ b/master/internal/task/allocation.go
@@ -962,6 +962,12 @@ func (a *Allocation) terminated(ctx *actor.Context, reason string) {
 				ctx.Log().Debug(exitReason)
 				exit.Err = err
 				return
+			case sproto.RestoreError:
+				exitReason = fmt.Sprintf("allocation failed due to restore error: %s", err)
+				ctx.Log().Warn(exitReason)
+				exit.Err = err
+				return
+
 			default:
 				panic(fmt.Errorf("unexpected allocation failure: %w", err))
 			}


### PR DESCRIPTION
## Description

Fixing two cases where the container will get stuck.

1. Is when a container is gone on restart a task wouldn't get sent terminated due to the agent not notifying it was because ```sproto.GetResourcesContainerState``` could return an error while still knowing about the container.

2. Is when an agent is gone past its reconnect period we would never call ```agentState.restoreContainersField```  causing us to not have a containerID -> task actor to send the terminated messages.

This change also makes ```restoreError``` a transient system error.

## Test Plan

e2e tests cover both cases

manual 

In devcluster with this config
```
        resource_pools:
          - pool_name: default
            agent_reattach_enabled: true
```

Have an experiment that just sleeps ready, can just edit ```./examples/tutorials/core_api/0_start.py``` to be

```
import time
print("sleeping")
time.sleep(1000)
```

1. 

- Run experiment ```det e create ./examples/tutorials/core_api/0_start.yaml ./examples/tutorials/core_api/ -f```
- Wait for "sleeping" message
- Control-C devcluster
- ```docker ps```
- ```docker kill $container_id_of_task_container```
- rerun ```devcluster```
- ```det e logs $exp_id``` should show two "sleeping" prints since container restarted
- ```det e kill $exp_id``` should work and make exp canceled in ```det e```

2. 

- Run experiment ```det e create ./examples/tutorials/core_api/0_start.yaml ./examples/tutorials/core_api/ -f```
- Wait for "sleeping" message
- Press 1 on devcluster, moving it to just db running
- Press 2 on devcluster, moving it to just master running
- Wait for 60 second agent reconnect timeout to pass
- This should occur in master logs ```ERRO[2023-01-19T11:59:20-05:00] trial encountered transient system error      actor-local-addr=ff45ed3a-7096-476d-81ff-7e3df2788570 actor-system=master error="agent failed while the container was running: agent closed with allocated containers" experiment-id=1 go-type=trial job-id=8b0ad23d-ba5a-4ab3-848e-36ec8dcd8b39 task-id=1.ff45ed3a-7096-476d-81ff-7e3df2788570 task-type=TRIAL trial-id=1 trial-run-id=1```
- ```det e``` should report experiment in queued now
- Press 3 on devcluster, making agent start
- Experiment should get assigned to agent and be in running in ```det e```
- ```det e kill $exp_id``` should work and make exp canceled in ```det e```





## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
