### PR TITLE
ci: exclude dev release notes from documentation labeling.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,6 +6,7 @@
 # team-specific repo segments
 /.github  @determined-ai/infrastructure
 /docs     @determined-ai/docs
+/docs/release-notes/
 
 ### individuals
 # Ilia cares about agent RM.

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -2,5 +2,5 @@
 shared-web:
   - webui/react/src/shared/**
 documentation:
-  - docs/**
+  - any: ['docs/**', '!docs/release-notes/*']
 


### PR DESCRIPTION
## Description

it seems docs label / PR request is applied to release notes which seems excessive and unnecessary, since the release notes get through its own round of review on every release. I suspect it should be more efficient to review them in bulk once every two weeks.

## Test Plan

## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
