### PR TITLE
fix: don't checkpoint gc in exp delete with no checkpoints [DET-8834]

### DIFF
--- a/docs/release-notes/dont-checkpoint-gc-no-checkpoints.rst
+++ b/docs/release-notes/dont-checkpoint-gc-no-checkpoints.rst
@@ -1,0 +1,7 @@
+:orphan:
+
+**Improvements**
+
+-  Experiments: If an experiment with no checkpoints is deleted, a checkpoint GC task will no longer
+   be launched. Launching a checkpoint GC task could prevent experiments with certain incorrect
+   configuration from being deleted.

--- a/e2e_tests/tests/cluster/test_checkpoints.py
+++ b/e2e_tests/tests/cluster/test_checkpoints.py
@@ -354,12 +354,17 @@ def test_delete_experiment_with_no_checkpoints() -> None:
     # Still able to delete this since it will have no checkpoints meaning no checkpoint gc task.
     test_session = exp.determined_test_session()
     bindings.delete_DeleteExperiment(session=test_session, experimentId=exp_id)
-    for _ in range(60):
+    ticks = 60
+    for i in range(ticks):
         try:
-            print(f"experiment in state {exp.experiment_state(exp_id)} waiting for deleted")
+            state = exp.experiment_state(exp_id)
+            if i % 5 == 0:
+                print(f"experiment in state {state} waiting to be deleted")
             time.sleep(1)
         except api.errors.NotFoundException:
             return
+
+    pytest.fail(f"experiment failed to be deleted after {ticks} seconds")
 
 
 @pytest.mark.e2e_cpu

--- a/master/internal/api_experiment_intg_test.go
+++ b/master/internal/api_experiment_intg_test.go
@@ -160,7 +160,7 @@ func TestDeleteExperimentWithoutCheckpoints(t *testing.T) {
 	_, err = api.DeleteExperiment(ctx, &apiv1.DeleteExperimentRequest{ExperimentId: int32(exp.ID)})
 	require.NoError(t, err)
 
-	// Delete is aync so we need to retry until it completes.
+	// Delete is async so we need to retry until it completes.
 	for i := 0; i < 60; i++ {
 		e, err := api.GetExperiment(ctx, &apiv1.GetExperimentRequest{ExperimentId: int32(exp.ID)})
 		if err != nil {

--- a/master/internal/api_experiment_intg_test.go
+++ b/master/internal/api_experiment_intg_test.go
@@ -149,6 +149,29 @@ func TestGetExperimentLabels(t *testing.T) {
 	require.Subset(t, resp.Labels, labels)
 }
 
+func TestDeleteExperimentWithoutCheckpoints(t *testing.T) {
+	api, curUser, ctx := setupAPITest(t, nil)
+	exp := createTestExp(t, api, curUser)
+	_, err := db.Bun().NewUpdate().Table("experiments").
+		Set("state = ?", model.CompletedState).
+		Where("id = ?", exp.ID).Exec(ctx)
+	require.NoError(t, err)
+
+	_, err = api.DeleteExperiment(ctx, &apiv1.DeleteExperimentRequest{ExperimentId: int32(exp.ID)})
+	require.NoError(t, err)
+
+	// Delete is aync so we need to retry until it completes.
+	for i := 0; i < 60; i++ {
+		e, err := api.GetExperiment(ctx, &apiv1.GetExperimentRequest{ExperimentId: int32(exp.ID)})
+		if err != nil {
+			require.Equal(t, expNotFoundErr(exp.ID), err)
+			return
+		}
+		require.NotEqual(t, experimentv1.State_STATE_DELETE_FAILED, e.Experiment.State)
+	}
+	t.Error("expected experiment to delete after 1 minute and it did not")
+}
+
 //nolint: exhaustivestruct
 func TestCreateExperimentCheckpointStorage(t *testing.T) {
 	api, _, ctx := setupAPITest(t, nil)

--- a/master/internal/api_user_intg_test.go
+++ b/master/internal/api_user_intg_test.go
@@ -52,6 +52,10 @@ func setupAPITest(t *testing.T, pgdb *db.PgDB) (*apiServer, model.User, context.
 			system = actor.NewSystem("mock")
 			ref, _ := system.ActorOf(sproto.K8sRMAddr, actor.ActorFunc(
 				func(context *actor.Context) error {
+					switch context.Message().(type) {
+					case sproto.DeleteJob:
+						context.Respond(sproto.EmptyDeleteJobResponse())
+					}
 					return nil
 				}))
 			mockRM = actorrm.Wrap(ref)
@@ -64,10 +68,11 @@ func setupAPITest(t *testing.T, pgdb *db.PgDB) (*apiServer, model.User, context.
 
 	api := &apiServer{
 		m: &Master{
-			system:         system,
-			db:             pgdb,
-			taskLogBackend: pgdb,
-			rm:             mockRM,
+			trialLogBackend: pgdb,
+			system:          system,
+			db:              pgdb,
+			taskLogBackend:  pgdb,
+			rm:              mockRM,
 			config: &config.Config{
 				InternalConfig:        config.InternalConfig{},
 				TaskContainerDefaults: model.TaskContainerDefaultsConfig{},


### PR DESCRIPTION
## Description

Don't create checkpoint GC task if we don't have any checkpoints.

## Test Plan

intg + e2e tests

Create an experiment that will fail and cause checkpoint GC to fail.

```
det e create --config="checkpoint_storage.type=s3" --config="checkpoint_storage.bucket=notarealbucket" examples/tutorials/mnist_pytorch/const.yaml examples/tutorials/mnist_pytorch/ -f
```

Delete experiment after it errors
```
det e delete $exp_id
```

Verify the exp is gone from ```det e```

## Commentary (optional)

Created DET-8836 to follow up about how we can handle failed checkpoint GC better.

## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
