### PR TITLE
chore: design kit page content width

### DIFF
--- a/webui/react/src/pages/DesignKit.module.scss
+++ b/webui/react/src/pages/DesignKit.module.scss
@@ -46,6 +46,7 @@
     gap: 8px;
     height: fit-content;
     padding: 8px;
+    min-width: $breakpoint-mobile;
 
     section {
       display: flex;

--- a/webui/react/src/pages/DesignKit.module.scss
+++ b/webui/react/src/pages/DesignKit.module.scss
@@ -45,8 +45,8 @@
     flex-direction: column;
     gap: 8px;
     height: fit-content;
-    padding: 8px;
     min-width: $breakpoint-mobile;
+    padding: 8px;
 
     section {
       display: flex;


### PR DESCRIPTION
## Description

https://determinedai.atlassian.net/browse/WEB-812

Make design kit page use a lower minimum width. Using the `$breakpoint-mobile` value of 480px.

## Test Plan

On design kit page (`/det/design`), should be possible to reduce window width until the `<main>` element wrapping the `<section>` elements has a width of 480px.


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
