### PR TITLE
fix: k8s environment variable with equal sign or empty env errors [DET-8837]

### DIFF
--- a/docs/release-notes/equal-in-env-value-k8s.rst
+++ b/docs/release-notes/equal-in-env-value-k8s.rst
@@ -1,0 +1,11 @@
+:orphan:
+
+**Bug Fixes**
+
+-  Kubernetes: Fix an issue where environment variables with an equal character in the value such as
+   ``func=f(x)=x`` were processed incorrectly in Kubernetes.
+
+**Improvements**
+
+-  Kubernetes: Empty environment variables can now be specified in Kubernetes while before they
+   would throw an error.

--- a/master/internal/rm/kubernetesrm/spec.go
+++ b/master/internal/rm/kubernetesrm/spec.go
@@ -79,11 +79,12 @@ func (p *pod) configureEnvVars(
 	deviceType device.Type,
 ) ([]k8sV1.EnvVar, error) {
 	for _, envVar := range environment.EnvironmentVariables().For(deviceType) {
-		envVarSplit := strings.Split(envVar, "=")
-		if len(envVarSplit) != 2 {
-			return nil, errors.Errorf("unable to split envVar %s", envVar)
+		key, val, found := strings.Cut(envVar, "=")
+		if found {
+			envVarsMap[key] = val
+		} else {
+			envVarsMap[envVar] = ""
 		}
-		envVarsMap[envVarSplit[0]] = envVarSplit[1]
 	}
 
 	var slotIds []string

--- a/master/internal/rm/kubernetesrm/spec.go
+++ b/master/internal/rm/kubernetesrm/spec.go
@@ -79,8 +79,7 @@ func (p *pod) configureEnvVars(
 	deviceType device.Type,
 ) ([]k8sV1.EnvVar, error) {
 	for _, envVar := range environment.EnvironmentVariables().For(deviceType) {
-		key, val, found := strings.Cut(envVar, "=")
-		if found {
+		if key, val, found := strings.Cut(envVar, "="); found {
 			envVarsMap[key] = val
 		} else {
 			envVarsMap[envVar] = ""

--- a/master/internal/rm/kubernetesrm/spec_test.go
+++ b/master/internal/rm/kubernetesrm/spec_test.go
@@ -3,6 +3,7 @@ package kubernetesrm
 
 import (
 	"testing"
+	"unicode"
 
 	"github.com/stretchr/testify/require"
 
@@ -29,4 +30,30 @@ func TestLaterEnvironmentVariablesGetSet(t *testing.T) {
 	require.NoError(t, err)
 	require.NotContains(t, actual, dontBe, "earlier variable set")
 	require.Contains(t, actual, shouldBe, "later variable not set")
+}
+
+func TestAllPrintableCharactersInEnv(t *testing.T) {
+	expectedValue := ""
+	for i := 0; i <= 1024; i++ {
+		if unicode.IsPrint(rune(i)) {
+			expectedValue += string([]rune{rune(i)})
+		}
+	}
+
+	env := expconf.EnvironmentConfig{
+		RawEnvironmentVariables: &expconf.EnvironmentVariablesMap{
+			RawCPU: []string{
+				"test=" + expectedValue,
+				"test2",
+				"func=f(x)=x",
+			},
+		},
+	}
+
+	p := pod{}
+	actual, err := p.configureEnvVars(make(map[string]string), env, device.CPU)
+	require.NoError(t, err)
+	require.Contains(t, actual, k8sV1.EnvVar{Name: "test", Value: expectedValue})
+	require.Contains(t, actual, k8sV1.EnvVar{Name: "test2", Value: ""})
+	require.Contains(t, actual, k8sV1.EnvVar{Name: "func", Value: "f(x)=x"})
 }


### PR DESCRIPTION
## Description

K8s environment variables were parsed incorrectly for empty environment variables like ```TEST``` and ones with equal signs in the value like ```f=f(x)=test```.


## Test Plan

On a k8s cluster this command outputs

```
det cmd run --config="environment.environment_variables='test=abc=d','testempty'" printenv | grep test
```

```
[2023-01-20T21:32:40.592512Z] b0e43a15 || test=abc=d
[2023-01-20T21:32:40.592517Z] b0e43a15 || testempty=
```

## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
