### PR TITLE
fix: get searcher metric val from column that actually exists

### DIFF
--- a/master/internal/api_experiment.go
+++ b/master/internal/api_experiment.go
@@ -470,10 +470,10 @@ func (a *apiServer) GetExperiments(
 			FROM trials t
 			WHERE t.experiment_id = e.id
 			ORDER BY (CASE
-						WHEN coalesce((config->'searcher'->>'smaller_is_better')::boolean, true)
-							THEN (t.metrics->'validation_metrics'->>(e.config->'searcher'->>'metric'))::float8
-							ELSE -1.0 * (t.metrics->'validation_metrics'->>(e.config->'searcher'->>'metric'))::float8
-				END) ASC
+				WHEN coalesce((config->'searcher'->>'smaller_is_better')::boolean, true)
+					THEN searcher_metric_value
+					ELSE -1.0 * searcher_metric_value
+			END) ASC
 			LIMIT 1
 		 ) AS best_trial`)
 	}
@@ -501,10 +501,10 @@ func (a *apiServer) GetExperiments(
 			FROM trials t
 			WHERE t.experiment_id = e.id
 			ORDER BY (CASE
-						WHEN coalesce((config->'searcher'->>'smaller_is_better')::boolean, true)
-							THEN (t.metrics->'validation_metrics'->>(e.config->'searcher'->>'metric'))::float8
-							ELSE -1.0 * (t.metrics->'validation_metrics'->>(e.config->'searcher'->>'metric'))::float8
-				END) ASC
+				WHEN coalesce((config->'searcher'->>'smaller_is_better')::boolean, true)
+					THEN searcher_metric_value
+					ELSE -1.0 * searcher_metric_value
+			END) ASC
 			LIMIT 1
 		 ) `,
 	}


### PR DESCRIPTION
## Description

I updated the migration to just materialize the searcher metric value itself as opposed to all of the metrics, but I forgot to update the code that depended on it.


## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot
as appropriate.  Reviewers may ask questions about this test plan to ensure
adequate manual coverage of changes.
-->



## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
