### PR TITLE
feat: Learning Curve using LineChart component [WEB-661]

### DIFF
--- a/webui/react/src/components/UPlot/UPlotChart.tsx
+++ b/webui/react/src/components/UPlot/UPlotChart.tsx
@@ -70,7 +70,8 @@ const shouldRecreate = (
       (nextSerie?.label != null && prevSerie?.label !== nextSerie?.label) ||
       (prevSerie?.stroke != null && prevSerie?.stroke !== nextSerie?.stroke) ||
       (nextSerie?.paths != null && prevSerie?.paths !== nextSerie?.paths) ||
-      (nextSerie?.fill != null && prevSerie?.fill !== nextSerie?.fill)
+      (nextSerie?.fill != null && prevSerie?.fill !== nextSerie?.fill) ||
+      prevSerie?.points?.show !== nextSerie?.points?.show
     );
   });
   if (someSeriesHasChanged) return true;

--- a/webui/react/src/components/UPlot/UPlotChart/closestPointPlugin.module.scss
+++ b/webui/react/src/components/UPlot/UPlotChart/closestPointPlugin.module.scss
@@ -6,6 +6,34 @@ $tooltip-offset: 5px;
   position: absolute;
   transform: translate(-50%, -50%);
 }
+
+/* diamond symbol on closestPointPlugin / LearningCurve charts;
+ shared/styles/index.scss for others */
+
+.diamond {
+  border-radius: 0 !important;
+  display: none;
+  height: 0 !important;
+  position: absolute;
+  transform: translate(-50%, -50%);
+  width: 0 !important;
+}
+.diamond::before {
+  background-color: inherit;
+  content: '';
+  height: 7px;
+  position: absolute;
+  transform: scaleX(1.25) translateX(-40%) translateY(-40%) rotate(45deg);
+  width: 7px;
+}
+.diamond::after {
+  background-color: var(--theme-stage);
+  content: '';
+  height: 3px;
+  position: absolute;
+  transform: scaleX(1.25) translateX(-40%) translateY(-1px) rotate(45deg);
+  width: 3px;
+}
 .tooltip {
   display: none;
   pointer-events: none;

--- a/webui/react/src/components/UPlot/UPlotChart/closestPointPlugin.ts
+++ b/webui/react/src/components/UPlot/UPlotChart/closestPointPlugin.ts
@@ -13,6 +13,7 @@ interface Point {
 }
 
 interface Props {
+  diamond?: boolean;
   distInPx?: number; // max cursor distance from data point to focus it (in pixel)
   getPointTooltipHTML?: (xVal: number, yVal: number, point: Point) => string;
   onPointClick?: (e: MouseEvent, point: Point) => void;
@@ -22,6 +23,7 @@ interface Props {
 }
 
 export const closestPointPlugin = ({
+  diamond = false,
   distInPx = 30,
   getPointTooltipHTML,
   onPointClick,
@@ -155,7 +157,7 @@ export const closestPointPlugin = ({
 
         // point div
         pointEl = document.createElement('div');
-        pointEl.className = css.point;
+        pointEl.className = diamond ? css.diamond : css.point;
         over.appendChild(pointEl);
 
         // point div

--- a/webui/react/src/components/UPlot/UPlotChart/tooltipsPlugin2.ts
+++ b/webui/react/src/components/UPlot/UPlotChart/tooltipsPlugin2.ts
@@ -11,7 +11,7 @@ interface Props {
   getXTooltipHeader?: (xIndex: number) => ChartTooltip;
   getXTooltipYLabels?: (xIndex: number) => ChartTooltip[];
   isShownEmptyVal: boolean;
-  seriesColors: (string | null)[];
+  seriesColors: string[];
 }
 
 export const tooltipsPlugin = (

--- a/webui/react/src/components/UPlot/UPlotChart/tooltipsPlugin2.ts
+++ b/webui/react/src/components/UPlot/UPlotChart/tooltipsPlugin2.ts
@@ -111,7 +111,7 @@ export const tooltipsPlugin = (
     const tooltipWidth = tooltipEl.getBoundingClientRect().width;
 
     // right
-    if (chartWidth && idxLeft + tooltipWidth >= chartWidth) {
+    if (chartWidth && idxLeft + tooltipWidth >= chartWidth * 0.9) {
       return idxLeft - tooltipWidth - margin;
     }
 

--- a/webui/react/src/components/UPlot/UPlotChart/tooltipsPlugin2.ts
+++ b/webui/react/src/components/UPlot/UPlotChart/tooltipsPlugin2.ts
@@ -11,7 +11,7 @@ interface Props {
   getXTooltipHeader?: (xIndex: number) => ChartTooltip;
   getXTooltipYLabels?: (xIndex: number) => ChartTooltip[];
   isShownEmptyVal: boolean;
-  seriesColors: string[];
+  seriesColors: (string | null)[];
 }
 
 export const tooltipsPlugin = (

--- a/webui/react/src/components/kit/LineChart.module.scss
+++ b/webui/react/src/components/kit/LineChart.module.scss
@@ -1,7 +1,6 @@
 .chartgridContainer {
   background-color: #f0f0f0;
   min-height: 530px;
-  overflow-x: visible;
   overflow-y: hidden;
   padding: 5px;
 }
@@ -15,7 +14,6 @@
   background-color: #f6f6f6;
   border: 1px solid #c2c2c2;
   border-radius: 4px;
-  overflow-x: visible;
   padding: 24px;
 }
 .chartTitle {

--- a/webui/react/src/components/kit/LineChart.module.scss
+++ b/webui/react/src/components/kit/LineChart.module.scss
@@ -1,6 +1,7 @@
 .chartgridContainer {
   background-color: #f0f0f0;
   min-height: 530px;
+  overflow-x: visible;
   overflow-y: hidden;
   padding: 5px;
 }
@@ -14,6 +15,7 @@
   background-color: #f6f6f6;
   border: 1px solid #c2c2c2;
   border-radius: 4px;
+  overflow-x: visible;
   padding: 24px;
 }
 .chartTitle {

--- a/webui/react/src/components/kit/LineChart.tsx
+++ b/webui/react/src/components/kit/LineChart.tsx
@@ -130,25 +130,30 @@ export const LineChart: React.FC<Props> = ({
         // use specified color on Serie, or glasbeyColor
         seriesColors,
       }),
-      closestPointPlugin({
-        onPointClick: (e, point) => {
-          if (onSeriesClick) {
-            // correct seriesIdx (seriesIdx=0 on uPlot continues to be X)
-            // return a serie.key (example: trialId), or the adjusted index
-            onSeriesClick(e, series[point.seriesIdx - 1].key || point.seriesIdx - 1);
-          }
-        },
-        onPointFocus: (point) => {
-          if (onSeriesFocus) {
-            // correct seriesIdx (seriesIdx=0 on uPlot continues to be X)
-            // return a serie.key (example: trialId), or the adjusted index
-            // returns null when switching to no point being hovered over
-            onSeriesFocus(point ? series[point.seriesIdx - 1].key || point.seriesIdx - 1 : null);
-          }
-        },
-        yScale: 'y',
-      }),
     ];
+    if (onSeriesClick || onSeriesFocus) {
+      plugins.push(
+        closestPointPlugin({
+          diamond: true,
+          onPointClick: (e, point) => {
+            if (onSeriesClick) {
+              // correct seriesIdx (seriesIdx=0 on uPlot continues to be X)
+              // return a serie.key (example: trialId), or the adjusted index
+              onSeriesClick(e, series[point.seriesIdx - 1].key || point.seriesIdx - 1);
+            }
+          },
+          onPointFocus: (point) => {
+            if (onSeriesFocus) {
+              // correct seriesIdx (seriesIdx=0 on uPlot continues to be X)
+              // return a serie.key (example: trialId), or the adjusted index
+              // returns null when switching to no point being hovered over
+              onSeriesFocus(point ? series[point.seriesIdx - 1].key || point.seriesIdx - 1 : null);
+            }
+          },
+          yScale: 'y',
+        }),
+      );
+    }
 
     return {
       axes: [
@@ -171,7 +176,6 @@ export const LineChart: React.FC<Props> = ({
       ],
       cursor: {
         drag: { x: true, y: false },
-        point: { show: true },
       },
       height,
       legend: { show: false },
@@ -189,7 +193,7 @@ export const LineChart: React.FC<Props> = ({
         ...series.map((serie, idx) => {
           return {
             label: seriesNames[idx],
-            points: { show: false },
+            points: { show: (serie.data[xAxis] || []).length <= 1 },
             scale: 'y',
             spanGaps: true,
             stroke: seriesColors[idx],

--- a/webui/react/src/components/kit/LineChart.tsx
+++ b/webui/react/src/components/kit/LineChart.tsx
@@ -95,7 +95,9 @@ export const LineChart: React.FC<Props> = ({
 
   const seriesNames: string[] = useMemo(() => {
     return series.map(
-      (s, idx) => (series.length > 1 ? `${s.metricType}_` : '') + (s.name || `Series ${idx + 1}`),
+      (s, idx) =>
+        (series.length > 1 && s.metricType ? `${s.metricType}_` : '') +
+        (s.name || `Series ${idx + 1}`),
     );
   }, [series]);
 
@@ -122,19 +124,18 @@ export const LineChart: React.FC<Props> = ({
   }, [series, xAxis]);
 
   const chartOptions: Options = useMemo(() => {
-    const ySeries = series.filter((s) => !s.xAxisRole);
     const plugins = [
       tooltipsPlugin({
         isShownEmptyVal: false,
         // use specified color on Serie, or glasbeyColor
-        seriesColors: ySeries.map((s, idx) => s.color || glasbeyColor(idx)),
+        seriesColors,
       }),
       closestPointPlugin({
         onPointClick: (e, point) => {
           if (onSeriesClick) {
             // correct seriesIdx (seriesIdx=0 on uPlot continues to be X)
             // return a serie.key (example: trialId), or the adjusted index
-            onSeriesClick(e, ySeries[point.seriesIdx - 1].key || point.seriesIdx - 1);
+            onSeriesClick(e, series[point.seriesIdx - 1].key || point.seriesIdx - 1);
           }
         },
         onPointFocus: (point) => {
@@ -142,7 +143,7 @@ export const LineChart: React.FC<Props> = ({
             // correct seriesIdx (seriesIdx=0 on uPlot continues to be X)
             // return a serie.key (example: trialId), or the adjusted index
             // returns null when switching to no point being hovered over
-            onSeriesFocus(point ? ySeries[point.seriesIdx - 1].key || point.seriesIdx - 1 : null);
+            onSeriesFocus(point ? series[point.seriesIdx - 1].key || point.seriesIdx - 1 : null);
           }
         },
         yScale: 'y',
@@ -170,6 +171,7 @@ export const LineChart: React.FC<Props> = ({
       ],
       cursor: {
         drag: { x: true, y: false },
+        point: { show: true },
       },
       height,
       legend: { show: false },

--- a/webui/react/src/pages/DesignKit.tsx
+++ b/webui/react/src/pages/DesignKit.tsx
@@ -264,9 +264,9 @@ const ChartsSection: React.FC = () => {
         [1, 15],
         [2, 10.123456789],
         [2.5, Math.random() * 22],
-        [3, Math.random() * 18],
-        [3.25, Math.random() * 10 + 10],
-        [3.75, Math.random() * 12],
+        [3, 10.3909],
+        [3.25, 19],
+        [3.75, 4],
         [4, 12],
       ],
       [XAxisDomain.Time]: [

--- a/webui/react/src/pages/ExperimentDetails/ExperimentVisualization/HpParallelCoordinates.tsx
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentVisualization/HpParallelCoordinates.tsx
@@ -405,7 +405,6 @@ const HpParallelCoordinates: React.FC<Props> = ({
               selectedRowKeys={selectedRowKeys}
               selection={true}
               trialHps={trialHps}
-              trialIds={chartData?.trialIds || []}
             />
           </div>
           <div className={css.tooltip} ref={tooltipRef}>

--- a/webui/react/src/pages/ExperimentDetails/ExperimentVisualization/HpTrialTable.tsx
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentVisualization/HpTrialTable.tsx
@@ -33,7 +33,6 @@ interface Props {
   selectedRowKeys?: number[];
   selection?: boolean;
   trialHps: TrialHParams[];
-  trialIds: number[];
 }
 
 export interface TrialHParams {
@@ -51,7 +50,6 @@ const HpTrialTable: React.FC<Props> = ({
   onMouseEnter,
   onMouseLeave,
   trialHps,
-  // trialIds,
   experimentId,
   selection,
   handleTableRowSelect,

--- a/webui/react/src/pages/ExperimentDetails/ExperimentVisualization/HpTrialTable.tsx
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentVisualization/HpTrialTable.tsx
@@ -51,7 +51,7 @@ const HpTrialTable: React.FC<Props> = ({
   onMouseEnter,
   onMouseLeave,
   trialHps,
-  trialIds,
+  // trialIds,
   experimentId,
   selection,
   handleTableRowSelect,
@@ -66,8 +66,7 @@ const HpTrialTable: React.FC<Props> = ({
 
   const columns = useMemo(() => {
     const idRenderer = (_: string, record: TrialHParams) => {
-      const index = trialIds.findIndex((trialId) => trialId === record.id);
-      let color = index !== -1 ? glasbeyColor(index) : 'rgba(0, 0, 0, 1.0)';
+      let color = glasbeyColor(record.id);
       if (record.metric != null && colorScale) {
         const scaleRange = colorScale[1].scale - colorScale[0].scale;
         const distance = (record.metric - colorScale[0].scale) / scaleRange;
@@ -137,7 +136,7 @@ const HpTrialTable: React.FC<Props> = ({
     });
 
     return [idColumn, metricColumn, ...hpColumns];
-  }, [colorScale, hyperparameters, metric, trialIds, experimentId]);
+  }, [colorScale, hyperparameters, metric, experimentId]);
 
   const handleTableChange = useCallback((tablePagination: TablePaginationConfig) => {
     setPageSize(tablePagination.pageSize ?? 10);

--- a/webui/react/src/pages/ExperimentDetails/ExperimentVisualization/LearningCurve.tsx
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentVisualization/LearningCurve.tsx
@@ -2,6 +2,7 @@ import { Alert } from 'antd';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { LineChart, Serie } from 'components/kit/LineChart';
+import { XAxisDomain } from 'components/kit/LineChart/XAxisFilter';
 import Section from 'components/Section';
 import TableBatch from 'components/Table/TableBatch';
 import { terminalRunStates } from 'constants/states';
@@ -164,7 +165,7 @@ const LearningCurve: React.FC<Props> = ({
             .filter((trialId) => !selectedRowKeys.length || selectedRowKeys.includes(trialId))
             .map((trialId) => ({
               color: glasbeyColor(trialId),
-              data: metricsMap[trialId],
+              data: { [XAxisDomain.Batches]: metricsMap[trialId] },
               key: trialId,
               name: `trial ${trialId}`,
             })),

--- a/webui/react/src/pages/ExperimentDetails/ExperimentVisualization/LearningCurve.tsx
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentVisualization/LearningCurve.tsx
@@ -161,13 +161,13 @@ const LearningCurve: React.FC<Props> = ({
         setTrialHps(newTrialHps);
 
         const newChartData = newTrialIds
-            .filter((trialId) => !selectedRowKeys.length || selectedRowKeys.includes(trialId))
-            .map((trialId) => ({
-              color: glasbeyColor(trialId),
-              data: { [XAxisDomain.Batches]: metricsMap[trialId] },
-              key: trialId,
-              name: `trial ${trialId}`,
-            }));
+          .filter((trialId) => !selectedRowKeys.length || selectedRowKeys.includes(trialId))
+          .map((trialId) => ({
+            color: glasbeyColor(trialId),
+            data: { [XAxisDomain.Batches]: metricsMap[trialId] },
+            key: trialId,
+            name: `trial ${trialId}`,
+          }));
         setChartData(newChartData);
 
         // One successful event as come through.

--- a/webui/react/src/pages/ExperimentDetails/ExperimentVisualization/LearningCurve.tsx
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentVisualization/LearningCurve.tsx
@@ -160,16 +160,14 @@ const LearningCurve: React.FC<Props> = ({
         const newTrialHps = newTrialIds.map((id) => trialHpMap[id]);
         setTrialHps(newTrialHps);
 
-        const newChartData = [
-          ...newTrialIds
+        const newChartData = newTrialIds
             .filter((trialId) => !selectedRowKeys.length || selectedRowKeys.includes(trialId))
             .map((trialId) => ({
               color: glasbeyColor(trialId),
               data: { [XAxisDomain.Batches]: metricsMap[trialId] },
               key: trialId,
               name: `trial ${trialId}`,
-            })),
-        ];
+            }));
         setChartData(newChartData);
 
         // One successful event as come through.

--- a/webui/react/src/pages/ExperimentDetails/ExperimentVisualization/LearningCurve.tsx
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentVisualization/LearningCurve.tsx
@@ -5,7 +5,7 @@ import { LineChart, Serie } from 'components/kit/LineChart';
 import Section from 'components/Section';
 import TableBatch from 'components/Table/TableBatch';
 import { terminalRunStates } from 'constants/states';
-// import { paths } from 'routes/utils';
+import { paths } from 'routes/utils';
 import { openOrCreateTensorBoard } from 'services/api';
 import { V1TrialsSampleResponse } from 'services/api-ts-sdk';
 import { detApi } from 'services/apiConfig';
@@ -13,9 +13,10 @@ import { readStream } from 'services/utils';
 import Message, { MessageType } from 'shared/components/Message';
 import Spinner from 'shared/components/Spinner/Spinner';
 import useUI from 'shared/contexts/stores/UI';
+import { glasbeyColor } from 'shared/utils/color';
 import { flattenObject } from 'shared/utils/data';
 import { ErrorLevel, ErrorType } from 'shared/utils/error';
-// import { isNewTabClickEvent, openBlank, routeToReactUrl } from 'shared/utils/routes';
+import { isNewTabClickEvent, openBlank, routeToReactUrl } from 'shared/utils/routes';
 import {
   ExperimentAction as Action,
   CommandResponse,
@@ -73,18 +74,18 @@ const LearningCurve: React.FC<Props> = ({
     }, {} as Record<string, Hyperparameter>);
   }, [experiment.hyperparameters, fullHParams]);
 
-  // const handleTrialClick = useCallback(
-  //   (event: MouseEvent, trialId: number) => {
-  //     const href = paths.trialDetails(trialId, experiment.id);
-  //     if (isNewTabClickEvent(event)) openBlank(href);
-  //     else routeToReactUrl(href);
-  //   },
-  //   [experiment.id],
-  // );
+  const handleTrialClick = useCallback(
+    (event: MouseEvent, trialId: number) => {
+      const href = paths.trialDetails(trialId, experiment.id);
+      if (isNewTabClickEvent(event)) openBlank(href);
+      else routeToReactUrl(href);
+    },
+    [experiment.id],
+  );
 
-  // const handleTrialFocus = useCallback((trialId: number | null) => {
-  //   setHighlightedTrialId(trialId != null ? trialId : undefined);
-  // }, []);
+  const handleTrialFocus = useCallback((trialId: number | null) => {
+    setHighlightedTrialId(trialId != null ? trialId : undefined);
+  }, []);
 
   const handleTableMouseEnter = useCallback((event: React.MouseEvent, record: TrialHParams) => {
     if (record.id) setHighlightedTrialId(record.id);
@@ -162,6 +163,8 @@ const LearningCurve: React.FC<Props> = ({
         const newTrialHps = newTrialIds.map((id) => trialHpMap[id]);
         setTrialHps(newTrialHps);
 
+        const newBatches = Object.values(batchesMap);
+
         const newChartData = [
           {
             data: newBatches,
@@ -169,6 +172,7 @@ const LearningCurve: React.FC<Props> = ({
           ...newTrialIds
             .filter((trialId) => !selectedRowKeys.length || selectedRowKeys.includes(trialId))
             .map((trialId) => ({
+              color: glasbeyColor(trialId),
               data: newBatches.map((batch) => {
                 /**
                  * TODO: filtering NaN, +/- Infinity for now, but handle it later with
@@ -177,7 +181,7 @@ const LearningCurve: React.FC<Props> = ({
                 const value = metricsMap[trialId][batch];
                 return Number.isFinite(value) ? value : null;
               }),
-              // key: trialId,
+              key: trialId,
               name: `trial ${trialId}`,
             })),
         ];
@@ -265,10 +269,10 @@ const LearningCurve: React.FC<Props> = ({
               focusedSeries={highlightedTrialId && trialIds.indexOf(highlightedTrialId)}
               scale={selectedScale}
               series={chartData}
-              // onSeriesClick={handleTrialClick}
-              // onSeriesFocus={handleTrialFocus}
               xLabel="Batches Processed"
               yLabel={`[${selectedMetric.type[0].toUpperCase()}] ${selectedMetric.name}`}
+              onSeriesClick={handleTrialClick}
+              onSeriesFocus={handleTrialFocus}
             />
           </div>
           <TableBatch

--- a/webui/react/src/shared/styles/index.scss
+++ b/webui/react/src/shared/styles/index.scss
@@ -51,6 +51,9 @@ code.block {
 .uplot canvas {
   background-color: var(--theme-stage);
 }
+.u-wrap {
+  overflow-x: hidden;
+}
 
 /* diamond cursor for most charts, see closestPointPlugin.module.scss for charts with that plugin (LearningCurve) */
 

--- a/webui/react/src/shared/styles/index.scss
+++ b/webui/react/src/shared/styles/index.scss
@@ -51,6 +51,9 @@ code.block {
 .uplot canvas {
   background-color: var(--theme-stage);
 }
+
+/* diamond cursor for most charts, see closestPointPlugin.module.scss for charts with that plugin (LearningCurve) */
+
 .u-cursor-pt {
   border-radius: 0 !important;
   height: 0 !important;


### PR DESCRIPTION
## Description

The ticket says to replace charts on the multi-trial view; from looking around I take this to mean the Learning Curve visualization.

This also fixes an issue with the colors in the trials table not matching the colors used in the chart and tooltip.

## Test Plan

Go to a multi-trial page which completed and has >10 trials. I've recently found you can add Trials  to the columns on the experiment page, then sort descending.

- On the initial / learning curve tab, the page has a chart with multiple lines, and a table with multiple rows, corresponding to these trials
- Possible to select another metric in a dropdown
- Possible to change linear/log scale of the chart
- Possible to limit number of trials to 1 or 10
- Checking 1-5 trials in the lower table -> limits the chart to showing only those trials

Then:
- Hovering over a line shows a diamond cursor, and a tooltip, with "Trial ##" bolded
- The color on the line matches the tooltip dot (note that multiple trials might be on top of each other on some parts of the chart; find an isolated one)
- Hovering over a line creates a border effect around the matching row in the table below
- The color on the line matches the color square in the matching row in the table below
- Check the ID of the trial. Clicking on the corresponding line should redirect you to that individual trial page


## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.