### PR TITLE
fix: Empty string can be stored in metadata values [WEB-432]

### DIFF
--- a/webui/react/src/components/InfoBox.module.scss
+++ b/webui/react/src/components/InfoBox.module.scss
@@ -35,6 +35,10 @@
       flex-grow: 1;
       font-size: 14px;
       margin: 0;
+
+      .blank {
+        background-color: var(--theme-stage-strong);
+      }
     }
     .contentList {
       color: var(--theme-colors-monochrome-6);

--- a/webui/react/src/components/InfoBox.module.scss
+++ b/webui/react/src/components/InfoBox.module.scss
@@ -37,7 +37,7 @@
       margin: 0;
 
       .blank {
-        background-color: var(--theme-stage-strong);
+        background-color: var(--theme-background-on);
       }
     }
     .contentList {

--- a/webui/react/src/components/InfoBox.tsx
+++ b/webui/react/src/components/InfoBox.tsx
@@ -18,7 +18,7 @@ interface Props {
 }
 
 export const renderRow = ({ label, content, separator }: InfoRowProps): React.ReactNode => {
-  if (content == null) return null;
+  if (content === undefined) return null;
   return (
     <div className={[css.info, separator ? css.separator : null].join(' ')} key={label?.toString()}>
       <dt className={css.label}>{label}</dt>
@@ -31,7 +31,13 @@ export const renderRow = ({ label, content, separator }: InfoRowProps): React.Re
           ))}
         </dd>
       ) : (
-        <dd className={css.content}>{content}</dd>
+        <dd className={css.content}>
+          {content === null || String(content).trim() === '' ? (
+            <code className={css.blank}> {content}</code>
+          ) : (
+            content
+          )}
+        </dd>
       )}
     </div>
   );

--- a/webui/react/src/components/Metadata/EditableMetadata.tsx
+++ b/webui/react/src/components/Metadata/EditableMetadata.tsx
@@ -30,6 +30,9 @@ const EditableMetadata: React.FC<Props> = ({ metadata = {}, editing, updateMetad
   const onValuesChange = useCallback(
     (_changedValues: unknown, values: { metadata: Metadata[] }) => {
       const newMetadata = values.metadata.reduce((acc, row) => {
+        if (row.value === undefined) {
+          row.value = '';
+        }
         if (row?.key) acc[row.key] = row.value;
         return acc;
       }, {} as Metadata);


### PR DESCRIPTION
## Description

As described in WEB-432, false-y values from the metadata editor did not show up in the viewer / get saved.

This PR displays all metadata rows, including empty strings.  It enables a metadata row to store an empty string. If an empty string or null value is used, it will appear as a grey oval (to show some content exists).

<img width="276" alt="Screen Shot 2023-01-25 at 2 35 27 PM" src="https://user-images.githubusercontent.com/643918/214686146-b2bba682-3dfe-4656-8444-067d3fbdc047.png">


## Test Plan

Preparing
- Open a model's detail page, and edit metadata
- Add a key "A" and assign value 0
- Add a key "B" and do not assign a value
- Click to add another key, but do not name a key. Add a value if you like.
- Save metadata

Assessment
- The viewer should display a 0 for A, a grey oval for B (empty string), and not have a third item (no key was given). 
- If you refresh the page, A and B should still be there.

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.