### PR TITLE
fix: enable asset compression [WEB-654]

### DIFF
--- a/master/internal/core.go
+++ b/master/internal/core.go
@@ -83,11 +83,6 @@ var staticWebDirectoryPaths = map[string]bool{
 	"/docs/rest-api": true,
 }
 
-// gzipSkipPaths are locations of paths to be skipped by GZIP compression.
-var gzipSkipPaths = map[string]bool{
-	"/proxy/:service/*": true,
-}
-
 // Master manages the Determined master state.
 type Master struct {
 	ClusterID string

--- a/master/internal/core.go
+++ b/master/internal/core.go
@@ -772,7 +772,7 @@ func (m *Master) Run(ctx context.Context) error {
 
 	gzipConfig := middleware.GzipConfig{
 		Skipper: func(c echo.Context) bool {
-			return !gzipSkipPaths[c.Path()]
+			return gzipSkipPaths[c.Path()]
 		},
 	}
 	m.echo.Use(middleware.GzipWithConfig(gzipConfig))

--- a/master/internal/core.go
+++ b/master/internal/core.go
@@ -767,8 +767,8 @@ func (m *Master) Run(ctx context.Context) error {
 
 	gzipConfig := middleware.GzipConfig{
 		Skipper: func(c echo.Context) bool {
-			proxyService := regexp.MustCompile(`\/det\/(themes|static|determined)\/`)
-			return !proxyService.MatchString(c.Request().URL.Path)
+			webuiStaticAssets := regexp.MustCompile(`\/det\/(themes|static|determined)\/`)
+			return !webuiStaticAssets.MatchString(c.Request().URL.Path)
 		},
 	}
 	m.echo.Use(middleware.GzipWithConfig(gzipConfig))

--- a/master/internal/core.go
+++ b/master/internal/core.go
@@ -85,7 +85,7 @@ var staticWebDirectoryPaths = map[string]bool{
 
 // gzipSkipPaths are locations of paths to be skipped by GZIP compression.
 var gzipSkipPaths = map[string]bool{
-	"/proxy": true,
+	"/proxy/:service/*": true,
 }
 
 // Master manages the Determined master state.
@@ -772,7 +772,8 @@ func (m *Master) Run(ctx context.Context) error {
 
 	gzipConfig := middleware.GzipConfig{
 		Skipper: func(c echo.Context) bool {
-			return gzipSkipPaths[c.Path()]
+			proxyService := regexp.MustCompile(`proxy|service`)
+			return proxyService.MatchString(c.Path())
 		},
 	}
 	m.echo.Use(middleware.GzipWithConfig(gzipConfig))

--- a/master/internal/core.go
+++ b/master/internal/core.go
@@ -767,8 +767,8 @@ func (m *Master) Run(ctx context.Context) error {
 
 	gzipConfig := middleware.GzipConfig{
 		Skipper: func(c echo.Context) bool {
-			proxyService := regexp.MustCompile(`proxy|service`)
-			return proxyService.MatchString(c.Path())
+			proxyService := regexp.MustCompile(`(themes|static|determined)\/`)
+			return !proxyService.MatchString(c.Request().URL.Path)
 		},
 	}
 	m.echo.Use(middleware.GzipWithConfig(gzipConfig))

--- a/master/internal/core.go
+++ b/master/internal/core.go
@@ -767,7 +767,7 @@ func (m *Master) Run(ctx context.Context) error {
 
 	gzipConfig := middleware.GzipConfig{
 		Skipper: func(c echo.Context) bool {
-			proxyService := regexp.MustCompile(`(themes|static|determined)\/`)
+			proxyService := regexp.MustCompile(`\/det\/(themes|static|determined)\/`)
 			return !proxyService.MatchString(c.Request().URL.Path)
 		},
 	}


### PR DESCRIPTION
## Description

Currently assets for the UI are not being compressed due to a single small error on the backend. This fix enables `gzip` compression.

<!---
Lead with the intended commit body in this description field. For breaking
changes, please include "BREAKING CHANGE:" at the beginning of your commit
body.  At a minimum, this section should include a bracketed reference to the
Jira ticket, e.g. "[DET-1234]". When squash-and-merging, copy this directly
into the description field.
-->



## Test Plan
1. Navigate to the login page. 
2. Open up the network tab in the browser console.
3. Select "disable cache" so that assets are not being served from the browser cache.
4. Refresh the page.
5. Ensure that media files and assets `.js`, `.css`,`.woff2`, `.png` are being `gzip` encoded. The files should include `Content-Encoding: gzip`
6. Start a Tensorboard session and ensure that Tensorboard loads successfully. 

![C9B36155-D06B-44AE-9EEB-FB638AAFAD48](https://user-images.githubusercontent.com/103522725/214890187-5e3fb83f-6b35-4d8c-8ffb-0b2f866bfb73.jpeg)

<img width="875" alt="Screen Shot 2023-01-26 at 10 17 16 AM" src="https://user-images.githubusercontent.com/103522725/214889341-a8ffb34b-88e9-43f6-bfa3-56283fbbab96.png">

<img width="1010" alt="Screen Shot 2023-01-26 at 10 18 35 AM" src="https://user-images.githubusercontent.com/103522725/214889681-474ea319-ec9f-4b0c-a285-b5812fe04294.png">

<!---
Describe the situations in which you've tested your change, and/or a screenshot
as appropriate.  Reviewers may ask questions about this test plan to ensure
adequate manual coverage of changes.
-->



## Commentary (optional)

Part of the reason that this bug may not have been caught is because file compression is working differently locally when the UI is being served on the dev server vs devcluster. For example:

**Without the fix being implemented**

You will see that the local dev server is still serving `gzip` compressed assets
![6FD61383-8327-4E34-A2D6-3E264CE3387A](https://user-images.githubusercontent.com/103522725/214887974-84e8b7c2-d12c-4dd2-8e70-5e32f5642ebb.jpeg)

However, the UI being served from devcluster is **not** serving compressed assets. 
![44768EE7-6665-4656-A5B3-267FEF5400DC](https://user-images.githubusercontent.com/103522725/214887921-f6a07311-2da0-4551-a26e-1b5b7b5cf583.jpeg)

The above behavior makes it seem like the `gzip` compression was working locally however, our deployed UI was not serving compressed assets.  

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket

WEB-654

<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
