### PR TITLE
fix: deb and rpm should install master and agent bins into `/usr/bin`

### DIFF
--- a/agent/.goreleaser.yml
+++ b/agent/.goreleaser.yml
@@ -63,7 +63,6 @@ nfpms:
     formats:
       - deb
       - rpm
-    bindir: /usr/local/bin
     contents:
       - src: "packaging/agent.yaml"
         dst: "/etc/determined/agent.yaml"

--- a/agent/packaging/determined-agent.service
+++ b/agent/packaging/determined-agent.service
@@ -6,7 +6,7 @@ Requires=docker.service
 [Service]
 TimeoutStartSec=0
 Restart=always
-ExecStart=/usr/local/bin/determined-agent run
+ExecStart=/usr/bin/determined-agent run
 
 [Install]
 WantedBy=multi-user.target

--- a/docs/release-notes/usr-bin.rst
+++ b/docs/release-notes/usr-bin.rst
@@ -3,4 +3,5 @@
 **Improvements**
 
 -  Installation: ``.deb`` and ``.rpm`` Linux packages will now install master and agent binaries
-   into ``/usr/bin/`` instead of ``usr/local/bin/``.
+   into ``/usr/bin/`` instead of ``usr/local/bin/``, to be more in-line with Filesystem Hierarchy
+   Standard.

--- a/docs/release-notes/usr-bin.rst
+++ b/docs/release-notes/usr-bin.rst
@@ -1,0 +1,6 @@
+:orphan:
+
+**Improvements**
+
+-  Installation: ``.deb`` and ``.rpm`` Linux packages will now install master and agent binaries
+   into ``/usr/bin/`` instead of ``usr/local/bin/``.

--- a/master/.goreleaser.yml
+++ b/master/.goreleaser.yml
@@ -108,7 +108,6 @@ nfpms:
     formats:
       - deb
       - rpm
-    bindir: /usr/local/bin
     contents:
       - src: "packaging/master.yaml"
         dst: "/etc/determined/master.yaml"

--- a/master/packaging/determined-master.service
+++ b/master/packaging/determined-master.service
@@ -14,7 +14,7 @@ RestartSec=1
 Restart=always
 TimeoutStartSec=0
 CacheDirectory=determined
-ExecStart=/usr/local/bin/determined-master
+ExecStart=/usr/bin/determined-master
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
## Description

We've always been installing binaries into `/usr/local/bin`, but that's wrong. Recent goreleaser update made it obvious #5816.

## Test Plan

Linux package installs and upgrades from older versions still work okay.

## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
