### PR TITLE
fix: Overflow bugs on charts [WEB-842]

### DIFF
--- a/webui/react/src/components/UPlot/UPlotChart.module.scss
+++ b/webui/react/src/components/UPlot/UPlotChart.module.scss
@@ -1,7 +1,6 @@
 .base {
   margin-bottom: 10px;
   margin-top: 10px;
-  overflow-y: hidden;
   position: relative;
 }
 .base.dark {

--- a/webui/react/src/components/UPlot/UPlotChart.tsx
+++ b/webui/react/src/components/UPlot/UPlotChart.tsx
@@ -156,6 +156,11 @@ const UPlotChart: React.FC<Props> = ({
 
   useEffect(() => {
     if (!chartDivRef.current) return;
+    if (!hasData) {
+      chartRef.current?.destroy();
+      chartRef.current = undefined;
+      return;
+    }
     if (!chartRef.current || shouldRecreate(previousOptions, extendedOptions)) {
       chartRef.current?.destroy();
       chartRef.current = undefined;
@@ -189,7 +194,7 @@ const UPlotChart: React.FC<Props> = ({
         });
       }
     }
-  }, [data, extendedOptions, previousOptions, chartType]);
+  }, [data, hasData, extendedOptions, previousOptions, chartType]);
 
   /**
    * When a focus index is provided, highlight applicable series.

--- a/webui/react/src/components/UPlot/UPlotChart/tooltipsPlugin2.ts
+++ b/webui/react/src/components/UPlot/UPlotChart/tooltipsPlugin2.ts
@@ -154,6 +154,11 @@ export const tooltipsPlugin = (
 
   return {
     hooks: {
+      init: (uPlot: uPlot) => {
+        uPlot.over.onmouseenter = () => {
+          hide();
+        };
+      },
       ready: (uPlot: uPlot) => {
         tooltipEl = document.createElement('div');
         tooltipEl.className = css.tooltip;

--- a/webui/react/src/components/UPlot/UPlotChart/tooltipsPlugin2.ts
+++ b/webui/react/src/components/UPlot/UPlotChart/tooltipsPlugin2.ts
@@ -155,8 +155,11 @@ export const tooltipsPlugin = (
   return {
     hooks: {
       init: (uPlot: uPlot) => {
-        uPlot.over.onmouseenter = () => {
-          hide();
+        uPlot.over.onmouseenter = (e) => {
+          const originElement = e.relatedTarget as Element;
+          if (!originElement?.className?.includes('tooltip')) {
+            hide();
+          }
         };
       },
       ready: (uPlot: uPlot) => {

--- a/webui/react/src/components/kit/LineChart.module.scss
+++ b/webui/react/src/components/kit/LineChart.module.scss
@@ -1,23 +1,23 @@
 .chartgridContainer {
-  background-color: #f0f0f0;
+  background-color: var(--theme-background);
   min-height: 530px;
   overflow-y: hidden;
   padding: 5px;
 }
 .chartgridCell {
-  background-color: #f0f0f0;
+  background-color: var(--theme-background);
   padding: 0;
   padding-left: 6px;
   padding-right: 6px;
 }
 .chartgridCellCard {
-  background-color: #f6f6f6;
-  border: 1px solid #c2c2c2;
+  background-color: var(--theme-stage);
+  border: 1px solid var(--theme-stage-border);
   border-radius: 4px;
   padding: 24px;
 }
 .chartTitle {
-  background-color: #f6f6f6;
+  background-color: var(--theme-stage);
   font-family: 'Objektiv Mk3', Arial, Helvetica, sans-serif;
   font-size: 14px;
   margin-bottom: -18px !important;

--- a/webui/react/src/components/kit/LineChart.tsx
+++ b/webui/react/src/components/kit/LineChart.tsx
@@ -81,6 +81,11 @@ export const LineChart: React.FC<Props> = ({
     );
   }, [series]);
 
+  const hasVisibleSeries: boolean = useMemo(
+    () => !!series.find((serie) => serie.data[xAxis].length > 0),
+    [series, xAxis],
+  );
+
   const seriesColors: string[] = useMemo(
     () =>
       series.map(
@@ -227,14 +232,18 @@ export const LineChart: React.FC<Props> = ({
       />
       {showLegend && (
         <div className={css.legendContainer}>
-          {series.map((s, idx) => (
-            <li className={css.legendItem} key={idx}>
-              <span className={css.colorButton} style={{ color: seriesColors[idx] }}>
-                &mdash;
-              </span>
-              {seriesNames[idx]}
-            </li>
-          ))}
+          {hasVisibleSeries ? (
+            series.map((s, idx) => (
+              <li className={css.legendItem} key={idx}>
+                <span className={css.colorButton} style={{ color: seriesColors[idx] }}>
+                  &mdash;
+                </span>
+                {seriesNames[idx]}
+              </li>
+            ))
+          ) : (
+            <li>&nbsp;</li>
+          )}
         </div>
       )}
     </>

--- a/webui/react/src/components/kit/LineChart.tsx
+++ b/webui/react/src/components/kit/LineChart.tsx
@@ -177,7 +177,7 @@ export const LineChart: React.FC<Props> = ({
       cursor: {
         drag: { x: true, y: false },
       },
-      height,
+      height: height - (series.find((s) => s.data[xAxis].length > 0) ? 0 : 20),
       legend: { show: false },
       plugins,
       scales: {

--- a/webui/react/src/components/kit/LineChart.tsx
+++ b/webui/react/src/components/kit/LineChart.tsx
@@ -81,7 +81,7 @@ export const LineChart: React.FC<Props> = ({
     );
   }, [series]);
 
-  const hasVisibleSeries: boolean = useMemo(
+  const hasPopulatedSeries: boolean = useMemo(
     () => !!series.find((serie) => serie.data[xAxis].length > 0),
     [series, xAxis],
   );
@@ -225,14 +225,14 @@ export const LineChart: React.FC<Props> = ({
     <>
       {title && <h5 className={css.chartTitle}>{title}</h5>}
       <UPlotChart
-        allowDownload
+        allowDownload={hasPopulatedSeries}
         data={chartData}
         focusIndex={focusedSeries}
         options={chartOptions}
       />
       {showLegend && (
         <div className={css.legendContainer}>
-          {hasVisibleSeries ? (
+          {hasPopulatedSeries ? (
             series.map((s, idx) => (
               <li className={css.legendItem} key={idx}>
                 <span className={css.colorButton} style={{ color: seriesColors[idx] }}>

--- a/webui/react/src/shared/styles/index.scss
+++ b/webui/react/src/shared/styles/index.scss
@@ -52,7 +52,7 @@ code.block {
   background-color: var(--theme-stage);
 }
 .u-wrap {
-  overflow-x: hidden;
+  overflow-x: visible;
 }
 
 /* diamond cursor for most charts, see closestPointPlugin.module.scss for charts with that plugin (LearningCurve) */

--- a/webui/react/src/shared/styles/index.scss
+++ b/webui/react/src/shared/styles/index.scss
@@ -53,6 +53,7 @@ code.block {
 }
 .u-wrap {
   overflow-x: visible;
+  overflow-y: hidden;
 }
 
 /* diamond cursor for most charts, see closestPointPlugin.module.scss for charts with that plugin (LearningCurve) */


### PR DESCRIPTION
## Description

Covers three overflow-related bugs on the LineChart component.

I'm OK if this PR includes other UI and interaction bugs / quirks. 
I'm OK if this PR includes adding more points / more series in the UI Kit for more intense testing.

See images in WEB-842 for reference.

1. In Firefox, and changed page zoom in Chrome, the chart tooltip could be cut off on the right edge. In #5807 I changed tooltip to appear left of cursor earlier (90%), and added overflow-x hidden. I now prefer overflow-x visible.
2. The chart plot div was appearing below the "No Data" card. Chart div now is destroyed when a chart has no data or switches to have no data. Removed previous CSS fix (overflow-y)
3. Cursor crosshair / target responded mouseenter before the tooltip. Now when the cursor re-enters the chart, calling `hide` so the tooltip must be re-created

## Test Plan

1. On UI Kit -> Chart Grid, hover mouse over points on the right chart. We should not be able to cause this.
2. On UI Kit -> Chart Grid, switch X-Axis to Time. The left chart should have a No Data message which fits comfortably into the grid.
3. On UI Kit -> Chart Grid, switch X-Axis to Time. The tooltip over the left-most point will show bold font for the closer series (upper or lower). Move the cursor left of the chart leaving the tooltip visible, and then **slowly** re-enter the chart above or below. When the cursor re-enters the chart space, the cursor-crosshair should trigger and hide the tooltip, then the tooltip should show when you near the series.

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.
