### PR TITLE
fix: Profiler useSettings bug, dependency warning in chart [WEB-847]

### DIFF
--- a/webui/react/src/components/UPlot/UPlotChart.tsx
+++ b/webui/react/src/components/UPlot/UPlotChart.tsx
@@ -106,7 +106,7 @@ const UPlotChart: React.FC<Props> = ({
   useEffect(() => {
     if (data !== undefined && chartType === 'Line')
       syncService.updateDataBounds(data as AlignedData);
-  }, [syncService, data]);
+  }, [syncService, chartType, data]);
 
   const extendedOptions = useMemo(() => {
     const extended: Partial<uPlot.Options> = uPlot.assign(

--- a/webui/react/src/pages/TrialDetails/Profiles/Charts/SystemMetricChart.tsx
+++ b/webui/react/src/pages/TrialDetails/Profiles/Charts/SystemMetricChart.tsx
@@ -18,7 +18,7 @@ export interface Settings {
   name?: string;
 }
 
-const config: SettingsConfig<Settings> = {
+const config = (trialId: number): SettingsConfig<Settings> => ({
   settings: {
     agentId: {
       defaultValue: undefined,
@@ -36,11 +36,11 @@ const config: SettingsConfig<Settings> = {
       type: union([undefinedType, string]),
     },
   },
-  storagePath: 'profiler-filters',
-};
+  storagePath: `profiler-filters-${trialId}`,
+});
 
 const SystemMetricChart: React.FC<ChartProps> = ({ getOptionsForMetrics, trial }) => {
-  const { settings, updateSettings } = useSettings<Settings>(config);
+  const { settings, updateSettings } = useSettings<Settings>(config(trial.id));
 
   const systemSeries = useFetchProfilerSeries(trial.id)[MetricType.System];
 

--- a/webui/react/src/pages/TrialDetails/Profiles/Charts/SystemMetricChartFilters.tsx
+++ b/webui/react/src/pages/TrialDetails/Profiles/Charts/SystemMetricChartFilters.tsx
@@ -51,8 +51,9 @@ const SystemMetricFilter: React.FC<Props> = ({ settings, systemSeries, updateSet
 
   if (!settings || !updateSettings) return null;
 
-  const validAgentIds =
-    (settings.name && systemSeries && Object.keys(systemSeries[settings.name])) || [];
+  const validAgentIds = settings.name && systemSeries
+    ? Object.keys(systemSeries[settings.name])
+    : [];
 
   return (
     <>

--- a/webui/react/src/pages/TrialDetails/Profiles/Charts/SystemMetricChartFilters.tsx
+++ b/webui/react/src/pages/TrialDetails/Profiles/Charts/SystemMetricChartFilters.tsx
@@ -51,6 +51,9 @@ const SystemMetricFilter: React.FC<Props> = ({ settings, systemSeries, updateSet
 
   if (!settings || !updateSettings) return null;
 
+  const validAgentIds =
+    (settings.name && systemSeries && Object.keys(systemSeries[settings.name])) || [];
+
   return (
     <>
       <SelectFilter
@@ -72,15 +75,13 @@ const SystemMetricFilter: React.FC<Props> = ({ settings, systemSeries, updateSet
         label="Agent Name"
         showSearch={false}
         style={{ width: 220 }}
-        value={settings.agentId}
+        value={validAgentIds.includes(settings.agentId as string) ? settings.agentId : undefined}
         onChange={handleChangeAgentId}>
-        {settings.name &&
-          systemSeries &&
-          Object.keys(systemSeries[settings.name]).map((agentId) => (
-            <Option key={agentId} value={agentId}>
-              {agentId}
-            </Option>
-          ))}
+        {validAgentIds.map((agentId) => (
+          <Option key={agentId} value={agentId}>
+            {agentId}
+          </Option>
+        ))}
       </SelectFilter>
       {uuidOptions.length !== 0 && (
         <SelectFilter

--- a/webui/react/src/pages/TrialDetails/Profiles/Charts/SystemMetricChartFilters.tsx
+++ b/webui/react/src/pages/TrialDetails/Profiles/Charts/SystemMetricChartFilters.tsx
@@ -51,9 +51,8 @@ const SystemMetricFilter: React.FC<Props> = ({ settings, systemSeries, updateSet
 
   if (!settings || !updateSettings) return null;
 
-  const validAgentIds = settings.name && systemSeries
-    ? Object.keys(systemSeries[settings.name])
-    : [];
+  const validAgentIds =
+    settings.name && systemSeries ? Object.keys(systemSeries[settings.name]) : [];
 
   return (
     <>


### PR DESCRIPTION
## Description

The experiment's profiler tab had a global storagePath, so the 'Agent Name' / ID from one experiment was carried over to another (where that Agent ID is not valid).  This blanks the System Metrics chart when requesting an unusable trial-agent combination.

(sample bad API request: http://latest-master.determined.ai:8080/api/v1/trials/6703/profiler/metrics?labels.name=cpu_util_simple&labels.agentId=i-072f3882870741314&labels.metricType=PROFILER_METRIC_TYPE_SYSTEM&follow=false )

The fix makes `storagePath` specific to the trial.

Alternatives:
- should we use `trial.experimentId` ?  I don't think an experiment is certain to have the same agent IDs
- should we remove `agentId` from Settings, or remove Settings from this page?  I am open to this solution, but the `SystemMetricFilter` component expects to receive all values from settings, and update all values through `updateSettings`.  I would approve a PR to separate out agentID now or in the future.

## Test Plan

- Visit an experiment with profiler enabled, for example `/det/experiments/1788/profiler`
- **All three** charts on the page should show valid information, for example the last System Metrics chart has an Agent Name with a dropdown and a value in there
- The URL should be updated with a set agentId, for example `/det/experiments/1788/profiler?agentId=i-00de025f442de15ef&name=gpu_util`
- If you change the URL to an unusable agentId, such as `/det/experiments/1788/profiler?agentId=BROKEN` it does not break the final SystemMetrics chart or insert BROKEN into the dropdown of agent names
- Visit another experiment 1783 - `/det/experiments/1783/profiler?agentId=i-00de025f442de15ef&name=gpu_util` - it does not break the chart or put the incorrect agentId in the dropdown of agent names

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.