### PR TITLE
fix: TensorBoard file pathnames incomplete and lacking rank information  [MLG-274] 

### DIFF
--- a/harness/determined/tensorboard/util.py
+++ b/harness/determined/tensorboard/util.py
@@ -53,7 +53,6 @@ def get_rank_aware_path(path: pathlib.Path, rank: int) -> pathlib.Path:
             while num_parts > 0:
                 path = path.with_suffix("")
                 num_parts -= 1
-            path = path.with_name(f"{path.name}#{rank}")
-            path = path.with_suffix(ext)
+            path = path.with_name(f"{path.name}#{rank}{ext}")
             return path
     return path

--- a/harness/tests/tensorboard/test_util.py
+++ b/harness/tests/tensorboard/test_util.py
@@ -100,6 +100,17 @@ test_data = [
         2,
         "/home/bob/tensorboard/the-host-name.some-extension.gz",
     ),
+    (
+        (
+            "/tmp/tensorboard-39.ff54aea9-0a94-4ce7-bf38-e8b3e69cc944.1-0/"
+            "aa1f87508336_37.1674696139174.pt.trace.json"
+        ),
+        1,
+        (
+            "/tmp/tensorboard-39.ff54aea9-0a94-4ce7-bf38-e8b3e69cc944.1-0/"
+            "aa1f87508336_37.1674696139174#1.pt.trace.json"
+        ),
+    ),
 ]
 
 


### PR DESCRIPTION
## Description
### Context

Determined uploads log files to a directory accessible by Tensorboard for visualization. Determined would append the rank information to the log files to keep track of which worker the log is from.

### Issue
https://determinedai.atlassian.net/browse/MLG-274

We found out that in some cases, portions of the log files will be dropped by the `with_suffix` function of pathlib library of Python after we append the rank information. These paths are actually valid on both S3 and Determined's Docker containers. 

Example:

Original path: "/tmp/tensorboard-39.ff54aea9-0a94-4ce7-bf38-e8b3e69cc944.1-0/aa1f87508336_37.1674696139174.pt.trace.json"

Expected path (assuming rank is 3): /tmp/tensorboard-39.ff54aea9-0a94-4ce7-bf38-e8b3e69cc944.1-0/aa1f87508336_37.1674696139174#3.pt.trace.json

Actual modified path: "/tmp/tensorboard-39.ff54aea9-0a94-4ce7-bf38-e8b3e69cc944.1-0/aa1f87508336_37.pt.trace.json"

### This PR
This PR appends rank information and extension at the same time using  `with_name` function of pathlib library, which properly treats these paths as valid and does not drop segments of the path. The result is that we preserve the original path completely with added rank information as expected.

## Test Plan

### Unit test

(base) a60168462@Szes-MacBook-Pro-2 harness % pytest tests/tensorboard/test_util.py
========================= 7 passed, 1 warning in 0.12s =========================

### End to End Test (Local)
- Build determined on local branch
- Trigger an experiment run which makes use of Pytorch Profiler
- Observe that (1) Pytorch Profiler tab is loaded properly and (2) the files have the expected suffix of "#{rank}"
<img width="1703" alt="Screen Shot 2023-01-27 at 9 40 32 AM" src="https://user-images.githubusercontent.com/16422598/215212903-220b2932-5413-4db1-9ed4-d2dbd51d2c7e.png">


### End to End Test (AWS)
- Launch determined cluster to AWS with commit hash `843560bf740758de08f585f58665a044bcd2a654`
- Trigger an experiment run which makes use of Pytorch Prodiler
- Observe that (1) Pytorch Profiler tab is loaded properly and (2) the files have the expected suffix of "#{rank}"
<img width="1986" alt="Screen Shot 2023-01-27 at 1 45 21 PM" src="https://user-images.githubusercontent.com/16422598/215213233-a5dc88d0-66f3-4f59-b174-a17e464fd29a.png">


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
MLG-274
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
