### PR TITLE
docs: clarify usage of slot_type with HPC

### DIFF
--- a/docs/reference/reference-deploy/config/master-config-reference.rst
+++ b/docs/reference/reference-deploy/config/master-config-reference.rst
@@ -266,7 +266,10 @@ The master supports the following configuration settings:
          Determined master.
 
       -  ``slot_type``: The default slot type assumed when users request resources from Determined
-         in terms of ``slots``. Defaults to ``cuda``.
+         in terms of ``slots``. Defaults to ``cuda`` for partitions where GPUs are detected 
+         automatically, else ``cpu``. If GPUs cannot be detected automatically, for
+         example when operating with gres_supported:false,  then this result may be 
+         overridden using ``partition_overrides``.
 
          -  ``slot_type: cuda``: One NVIDIA GPU will be requested per compute slot. Any partitions
             with GPUs will be represented as a resource pool with slot type ``cuda`` which can be

--- a/docs/reference/reference-deploy/config/master-config-reference.rst
+++ b/docs/reference/reference-deploy/config/master-config-reference.rst
@@ -266,22 +266,22 @@ The master supports the following configuration settings:
          Determined master.
 
       -  ``slot_type``: The default slot type assumed when users request resources from Determined
-         in terms of ``slots``. Defaults to ``cuda`` for partitions where GPUs are detected 
-         automatically, else ``cpu``. If GPUs cannot be detected automatically, for
-         example when operating with gres_supported:false,  then this result may be 
-         overridden using ``partition_overrides``.
+         in terms of ``slots``. Defaults to ``cuda`` for partitions where GPUs are detected
+         automatically, else ``cpu``. If GPUs cannot be detected automatically, for example when
+         operating with ``gres_supported:false``, then this result may be overridden using
+         ``partition_overrides``.
 
-         -  ``slot_type: cuda``: One NVIDIA GPU will be requested per compute slot. Any partitions
-            with GPUs will be represented as a resource pool with slot type ``cuda`` which can be
-            overridden using ``partition_overrides``.
+         -  ``slot_type: cuda``: One NVIDIA GPU will be requested per compute slot. Partitions will
+            be represented as a resource pool with slot type ``cuda`` which can be overridden using
+            ``partition_overrides``.
 
-         -  ``slot_type: rocm``: One AMD GPU will be requested per compute slot. Any partitions with
-            GPUs will be represented as a resource pool with slot type ``rocm`` which can be
-            overridden using ``partition_overrides``.
+         -  ``slot_type: rocm``: One AMD GPU will be requested per compute slot. Partitions will be
+            represented as a resource pool with slot type ``rocm`` which can be overridden using
+            ``partition_overrides``.
 
          -  ``slot_type: cpu``: CPU resources will be requested for each compute slot. Partitions
-            that contain no GPUs will default to a resource pool with slot type ``cpu``. One node
-            will be allocated per slot.
+            will be represented as a resource pool with slot type ``cpu``. One node will be
+            allocated per slot.
 
       -  ``rendezvous_network_interface``: The interface used to bootstrap communication between
          distributed jobs. For example, when using horovod the IP address for the host on this

--- a/docs/reference/reference-deploy/config/master-config-reference.rst
+++ b/docs/reference/reference-deploy/config/master-config-reference.rst
@@ -268,7 +268,7 @@ The master supports the following configuration settings:
       -  ``slot_type``: The default slot type assumed when users request resources from Determined
          in terms of ``slots``. Defaults to ``cuda`` for partitions where GPUs are detected
          automatically, else ``cpu``. If GPUs cannot be detected automatically, for example when
-         operating with ``gres_supported:false``, then this result may be overridden using
+         operating with ``gres_supported: false``, then this result may be overridden using
          ``partition_overrides``.
 
          -  ``slot_type: cuda``: One NVIDIA GPU will be requested per compute slot. Partitions will


### PR DESCRIPTION
## Description

Update the sSlurm/PBS master configuration docs to better describe the current behavior WRT slot_type.

## Test Plan

Docs build and tested locally.

## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
