### PR TITLE
feat: Chart feature flag

### DIFF
--- a/webui/react/src/components/kit/LineChart.tsx
+++ b/webui/react/src/components/kit/LineChart.tsx
@@ -217,7 +217,7 @@ export const LineChart: React.FC<Props> = ({
   ]);
 
   return (
-    <>
+    <div className="diamond-cursor">
       {title && <h5 className={css.chartTitle}>{title}</h5>}
       <UPlotChart
         allowDownload
@@ -237,7 +237,7 @@ export const LineChart: React.FC<Props> = ({
           ))}
         </div>
       )}
-    </>
+    </div>
   );
 };
 

--- a/webui/react/src/hooks/useFeature.ts
+++ b/webui/react/src/hooks/useFeature.ts
@@ -10,7 +10,8 @@ export type ValidFeature =
   | 'mock_permissions_read'
   | 'trials_comparison'
   | 'mock_permissions_all'
-  | 'dashboard';
+  | 'dashboard'
+  | 'chart';
 
 const queryParams = queryString.parse(window.location.search);
 

--- a/webui/react/src/pages/ExperimentDetails/ExperimentVisualization/LearningCurve.tsx
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentVisualization/LearningCurve.tsx
@@ -3,9 +3,11 @@ import React, { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { LineChart, Serie } from 'components/kit/LineChart';
 import { XAxisDomain } from 'components/kit/LineChart/XAxisFilter';
+import LearningCurveChart from 'components/LearningCurveChart';
 import Section from 'components/Section';
 import TableBatch from 'components/Table/TableBatch';
 import { terminalRunStates } from 'constants/states';
+import useFeature from 'hooks/useFeature';
 import { paths } from 'routes/utils';
 import { openOrCreateTensorBoard } from 'services/api';
 import { V1TrialsSampleResponse } from 'services/api-ts-sdk';
@@ -57,13 +59,16 @@ const LearningCurve: React.FC<Props> = ({
 }: Props) => {
   const { ui } = useUI();
   const [trialIds, setTrialIds] = useState<number[]>([]);
-  const [chartData, setChartData] = useState<Serie[]>([]);
+  const [batches, setBatches] = useState<number[]>([]);
+  const [chartData, setChartData] = useState<(number | null)[][]>([]);
+  const [v2ChartData, setV2ChartData] = useState<Serie[]>([]);
   const [trialHps, setTrialHps] = useState<TrialHParams[]>([]);
   const [highlightedTrialId, setHighlightedTrialId] = useState<number>();
   const [hasLoaded, setHasLoaded] = useState(false);
   const [pageError, setPageError] = useState<Error>();
   const [selectedRowKeys, setSelectedRowKeys] = useState<number[]>([]);
   const [showCompareTrials, setShowCompareTrials] = useState(false);
+  const chartComponent = useFeature().isOn('chart');
 
   const hasTrials = trialHps.length !== 0;
   const isExperimentTerminal = terminalRunStates.has(experiment.state as RunState);
@@ -105,8 +110,11 @@ const LearningCurve: React.FC<Props> = ({
 
     const canceler = new AbortController();
     const trialIdsMap: Record<number, number> = {};
+    const trialDataMap: Record<number, number[]> = {};
     const trialHpMap: Record<number, TrialHParams> = {};
-    const metricsMap: Record<number, [number, number][]> = {};
+    const batchesMap: Record<number, number> = {};
+    const metricsMap: Record<number, Record<number, number>> = {};
+    const v2MetricsMap: Record<number, [number, number][]> = {};
 
     setHasLoaded(false);
 
@@ -149,10 +157,14 @@ const LearningCurve: React.FC<Props> = ({
             trialHpMap[id] = { hparams: flatHParams, id, metric: null };
           }
 
-          metricsMap[id] = [];
+          trialDataMap[id] = trialDataMap[id] || [];
+          metricsMap[id] = metricsMap[id] || {};
+          v2MetricsMap[id] = [];
 
           trial.data.forEach((datapoint) => {
-            metricsMap[id].push([datapoint.batches, datapoint.value]);
+            batchesMap[datapoint.batches] = datapoint.batches;
+            metricsMap[id][datapoint.batches] = datapoint.value;
+            v2MetricsMap[id].push([datapoint.batches, datapoint.value]);
             trialHpMap[id].metric = datapoint.value;
           });
         });
@@ -160,15 +172,30 @@ const LearningCurve: React.FC<Props> = ({
         const newTrialHps = newTrialIds.map((id) => trialHpMap[id]);
         setTrialHps(newTrialHps);
 
-        const newChartData = newTrialIds
+        const newBatches = Object.values(batchesMap);
+        setBatches(newBatches);
+
+        const newChartData = newTrialIds.map((trialId) =>
+          newBatches.map((batch) => {
+            /**
+             * TODO: filtering NaN, +/- Infinity for now, but handle it later with
+             * dynamic min/max ranges via uPlot.Scales.
+             */
+            const value = metricsMap[trialId][batch];
+            return Number.isFinite(value) ? value : null;
+          }),
+        );
+        setChartData(newChartData);
+
+        const v2NewChartData = newTrialIds
           .filter((trialId) => !selectedRowKeys.length || selectedRowKeys.includes(trialId))
           .map((trialId) => ({
             color: glasbeyColor(trialId),
-            data: { [XAxisDomain.Batches]: metricsMap[trialId] },
+            data: { [XAxisDomain.Batches]: v2MetricsMap[trialId] },
             key: trialId,
             name: `trial ${trialId}`,
           }));
-        setChartData(newChartData);
+        setV2ChartData(v2NewChartData);
 
         // One successful event as come through.
         setHasLoaded(true);
@@ -248,15 +275,29 @@ const LearningCurve: React.FC<Props> = ({
       <Section bodyBorder bodyScroll filters={filters} loading={!hasLoaded}>
         <div className={css.container}>
           <div className={css.chart}>
-            <LineChart
-              focusedSeries={highlightedTrialId && trialIds.indexOf(highlightedTrialId)}
-              scale={selectedScale}
-              series={chartData}
-              xLabel="Batches Processed"
-              yLabel={`[${selectedMetric.type[0].toUpperCase()}] ${selectedMetric.name}`}
-              onSeriesClick={handleTrialClick}
-              onSeriesFocus={handleTrialFocus}
-            />
+            {chartComponent ? (
+              <LineChart
+                focusedSeries={highlightedTrialId && trialIds.indexOf(highlightedTrialId)}
+                scale={selectedScale}
+                series={v2ChartData}
+                xLabel="Batches Processed"
+                yLabel={`[${selectedMetric.type[0].toUpperCase()}] ${selectedMetric.name}`}
+                onSeriesClick={handleTrialClick}
+                onSeriesFocus={handleTrialFocus}
+              />
+            ) : (
+              <LearningCurveChart
+                data={chartData}
+                focusedTrialId={highlightedTrialId}
+                selectedMetric={selectedMetric}
+                selectedScale={selectedScale}
+                selectedTrialIds={selectedRowKeys}
+                trialIds={trialIds}
+                xValues={batches}
+                onTrialClick={handleTrialClick}
+                onTrialFocus={handleTrialFocus}
+              />
+            )}
           </div>
           <TableBatch
             actions={[

--- a/webui/react/src/shared/styles/index.scss
+++ b/webui/react/src/shared/styles/index.scss
@@ -57,24 +57,26 @@ code.block {
 
 /* diamond cursor for most charts, see closestPointPlugin.module.scss for charts with that plugin (LearningCurve) */
 
-.u-cursor-pt {
-  border-radius: 0 !important;
-  height: 0 !important;
-  width: 0 !important;
-}
-.u-cursor-pt::before {
-  background-color: inherit;
-  content: '';
-  height: 7px;
-  position: absolute;
-  transform: scaleX(1.25) translateX(-0.5px) translateY(-1px) rotate(45deg);
-  width: 7px;
-}
-.u-cursor-pt::after {
-  background-color: var(--theme-stage);
-  content: '';
-  height: 3px;
-  position: absolute;
-  transform: scaleX(1.25) translateX(1px) translateY(1px) rotate(45deg);
-  width: 3px;
+.diamond-cursor {
+  .u-cursor-pt {
+    border-radius: 0 !important;
+    height: 0 !important;
+    width: 0 !important;
+  }
+  .u-cursor-pt::before {
+    background-color: inherit;
+    content: '';
+    height: 7px;
+    position: absolute;
+    transform: scaleX(1.25) translateX(-0.5px) translateY(-1px) rotate(45deg);
+    width: 7px;
+  }
+  .u-cursor-pt::after {
+    background-color: var(--theme-stage);
+    content: '';
+    height: 3px;
+    position: absolute;
+    transform: scaleX(1.25) translateX(1px) translateY(1px) rotate(45deg);
+    width: 3px;
+  }
 }


### PR DESCRIPTION
## Description

Requires feature flag to show the new chart component - add `f_chart=on` to URLs.  The one chart which needs to be un-done in this PR is the Learning Curve chart.

This keeps the fix which we discussed in #5807 re: colors matching on LearningCurve chart and table

## Test Plan

Cursor CSS
- In the design kit (`/det/design`), charts continue to have the new component (hovering shows diamond cursor)
- Find a single-trial experiment and confirm old format chart (hover cursor is a solid circle, not diamond)

Learning Curve
- Find a multi-trial experiment which completed successfully (example : `/det/experiments/1754/visualization/learning-curve` )
- In the experiment's Learning Curve tab, you should see an old format chart (note hollow circles at each data point)
- Add `?f_chart=on` or `&f_chart=on` to the URL to enable the flag. The new chart will have a diamond cursor. Note that series with a single point will be drawn as a circle unless hovered.

<img width="264" alt="Screen Shot 2023-01-31 at 12 01 09 PM" src="https://user-images.githubusercontent.com/643918/215831270-64aa732f-aeca-423e-b031-7ab6ecbcd565.png">


## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.