### PR TITLE
fix: reduce global_batch_size in pix2pix example

### DIFF
--- a/examples/gan/pix2pix_tf_keras/adaptive.yaml
+++ b/examples/gan/pix2pix_tf_keras/adaptive.yaml
@@ -6,7 +6,7 @@ data:
   height: 256
   width: 256
 hyperparameters:
-  global_batch_size: 10
+  global_batch_size: 1
   discriminator_lr:
     type: log
     base: 10

--- a/examples/gan/pix2pix_tf_keras/const.yaml
+++ b/examples/gan/pix2pix_tf_keras/const.yaml
@@ -6,7 +6,7 @@ data:
   height: 256
   width: 256
 hyperparameters:
-  global_batch_size: 10
+  global_batch_size: 1
   discriminator_lr: 2e-4
   discriminator_beta_1: 0.5
   generator_lr: 2e-4

--- a/examples/gan/pix2pix_tf_keras/distributed.yaml
+++ b/examples/gan/pix2pix_tf_keras/distributed.yaml
@@ -6,7 +6,7 @@ data:
   height: 256
   width: 256
 hyperparameters:
-  global_batch_size: 40
+  global_batch_size: 4
   discriminator_lr: 2e-4
   discriminator_beta_1: 0.5
   generator_lr: 2e-4


### PR DESCRIPTION
## Description

Sometimes, the test `examples/tests/test_official.py::test_official` would fail. Reducing the `global_batch_size` seems to help prevent the problem.

## Test Plan

`test-examples` should pass.



## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
