### PR TITLE
docs: clarify usage of slot_type with HPC

### DIFF
--- a/docs/reference/reference-deploy/config/master-config-reference.rst
+++ b/docs/reference/reference-deploy/config/master-config-reference.rst
@@ -267,10 +267,12 @@ The master supports the following configuration settings:
 
       -  ``slot_type``: The default slot type assumed when users request resources from Determined
          in terms of ``slots``. Available values are ``cuda``, ``rocm`` and ``cpu``, where 1
-         ``cuda`` or ``rocm`` slot is 1 GPU and 1 ``cpu`` slot is 1 node. Defaults per-partition to
-         ``cuda`` if GPU resources are found within the partition, else ``cpu``. If GPUs cannot be
-         detected automatically, for example when operating with ``gres_supported: false``, then
-         this result may be overridden using ``partition_overrides``.
+         ``cuda`` or ``rocm`` slot is 1 GPU and 1 ``cpu`` slot is 1 node (the number of slots per
+         node defaults to one, but can be overridden by using ``slots_per_node`` in the experiment
+         configuration). Defaults per-partition to ``cuda`` if GPU resources are found within the
+         partition, else ``cpu``. If GPUs cannot be detected automatically, for example when
+         operating with ``gres_supported: false``, then this result may be overridden using
+         ``partition_overrides``.
 
          -  ``slot_type: cuda``: One NVIDIA GPU will be requested per compute slot. Partitions will
             be represented as a resource pool with slot type ``cuda`` which can be overridden using

--- a/docs/reference/reference-deploy/config/master-config-reference.rst
+++ b/docs/reference/reference-deploy/config/master-config-reference.rst
@@ -266,10 +266,11 @@ The master supports the following configuration settings:
          Determined master.
 
       -  ``slot_type``: The default slot type assumed when users request resources from Determined
-         in terms of ``slots``. Defaults to ``cuda`` for partitions where GPUs are detected
-         automatically, else ``cpu``. If GPUs cannot be detected automatically, for example when
-         operating with ``gres_supported: false``, then this result may be overridden using
-         ``partition_overrides``.
+         in terms of ``slots``. Available values are ``cuda``, ``rocm`` and ``cpu``, where 1
+         ``cuda`` or ``rocm`` slot is 1 GPU and 1 ``cpu`` slot is 1 node. Defaults per-partition to
+         ``cuda`` if GPU resources are found within the partition, else ``cpu``. If GPUs cannot be
+         detected automatically, for example when operating with ``gres_supported: false``, then
+         this result may be overridden using ``partition_overrides``.
 
          -  ``slot_type: cuda``: One NVIDIA GPU will be requested per compute slot. Partitions will
             be represented as a resource pool with slot type ``cuda`` which can be overridden using

--- a/docs/reference/reference-deploy/config/master-config-reference.rst
+++ b/docs/reference/reference-deploy/config/master-config-reference.rst
@@ -267,9 +267,9 @@ The master supports the following configuration settings:
 
       -  ``slot_type``: The default slot type assumed when users request resources from Determined
          in terms of ``slots``. Available values are ``cuda``, ``rocm`` and ``cpu``, where 1
-         ``cuda`` or ``rocm`` slot is 1 GPU and 1 ``cpu`` slot is 1 node (the number of slots per
-         node defaults to one, but can be overridden by using ``slots_per_node`` in the experiment
-         configuration). Defaults per-partition to ``cuda`` if GPU resources are found within the
+         ``cuda`` or ``rocm`` slot is 1 GPU, otherwise CPU slots are requested. The number of CPUs
+         allocated per node is 1, unless overridden by ``slots_per_node`` in the experiment
+         configuration. Defaults per-partition to ``cuda`` if GPU resources are found within the
          partition, else ``cpu``. If GPUs cannot be detected automatically, for example when
          operating with ``gres_supported: false``, then this result may be overridden using
          ``partition_overrides``.


### PR DESCRIPTION
## Description
Update the Slurm/PBS master configuration docs to better describe the current behavior WRT slot_type.

Perhaps also finally deconflict with content in the 'EE' repo.
<!---
Lead with the intended commit body in this description field. For breaking
changes, please include "BREAKING CHANGE:" at the beginning of your commit
body.  At a minimum, this section should include a bracketed reference to the
Jira ticket, e.g. "[DET-1234]". When squash-and-merging, copy this directly
into the description field.
-->



## Test Plan
Docs build and tested locally.

<!---
Describe the situations in which you've tested your change, and/or a screenshot
as appropriate.  Reviewers may ask questions about this test plan to ensure
adequate manual coverage of changes.
-->



## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
