### PR TITLE
perf: [1/n] Add new thread sub-class to handle Tensorboard files sync

### DIFF
--- a/harness/determined/tensorboard/base.py
+++ b/harness/determined/tensorboard/base.py
@@ -100,7 +100,9 @@ def get_metric_writer() -> tensorboard.BatchMetricWriter:
 
 
 class _TensorboardUploadThread(threading.Thread):
-    def __init__(self, upload_function: Callable, work_queue: queue.Queue) -> None:
+    def __init__(
+        self, upload_function: Callable[[List[pathlib.Path]], None], work_queue: queue.Queue
+    ) -> None:
         self._upload_function = upload_function
         self._work_queue = work_queue
 
@@ -108,10 +110,11 @@ class _TensorboardUploadThread(threading.Thread):
 
     def run(self):
         while True:
-            file_paths = self._work_queue.get(block=True)
+            # The thread will wait until self._work_queue is not empty
+            file_paths = self._work_queue.get(block=True, timeout=None)
 
             # None is the sentinel value
-            # to signal this thread to exit
+            # to signal the thread to exit
             if file_paths is None:
                 return
 

--- a/harness/determined/tensorboard/base.py
+++ b/harness/determined/tensorboard/base.py
@@ -108,7 +108,7 @@ class _TensorboardUploadThread(threading.Thread):
 
         super().__init__()
 
-    def run(self):
+    def run(self) -> None:
         while True:
             # The thread will wait until self._work_queue is not empty
             file_paths = self._work_queue.get(block=True, timeout=None)

--- a/harness/determined/tensorboard/base.py
+++ b/harness/determined/tensorboard/base.py
@@ -105,7 +105,7 @@ class _TensorboardUploadThread(threading.Thread):
     ) -> None:
         self._upload_function = upload_function
 
-        self._work_queue = queue.Queue(maxsize=work_queue_max_size)
+        self._work_queue: queue.Queue = queue.Queue(maxsize=work_queue_max_size)
 
         super().__init__()
 

--- a/harness/determined/tensorboard/base.py
+++ b/harness/determined/tensorboard/base.py
@@ -1,6 +1,7 @@
 import abc
 import logging
 import pathlib
+import queue
 import threading
 import time
 from typing import Callable, List
@@ -103,7 +104,6 @@ class _TensorboardUploadThread(threading.Thread):
         self, upload_function: Callable[[List[pathlib.Path]], None], work_queue_max_size: int = 50
     ) -> None:
         self._upload_function = upload_function
-        import queue
 
         self._work_queue = queue.Queue(maxsize=work_queue_max_size)
 

--- a/harness/tests/tensorboard/test_base.py
+++ b/harness/tests/tensorboard/test_base.py
@@ -102,8 +102,8 @@ def test_upload_thread_normal_case() -> None:
     upload_thread = tensorboard.base._TensorboardUploadThread(upload_function, work_queue)
 
     upload_thread.start()
-    work_queue.put(["test_file_path_1", "test_file_path_2"])
-    work_queue.put(["test_file_path_3"])
+    work_queue.put([pathlib.Path("test_value/file1.json"), pathlib.Path("test_value/file2.json")])
+    work_queue.put([pathlib.Path("test_value/file3.json")])
     # Pass in sentinel value to exit thread
     work_queue.put(None)
     upload_thread.join()
@@ -136,7 +136,7 @@ def test_upload_thread_exception_case() -> None:
     # 4. start, run, and join the _TensorboardUploadThread instance
     upload_thread.start()
     thread_ident = upload_thread.ident
-    work_queue.put(["test_file_path_1", "test_file_path_2"])
+    work_queue.put([pathlib.Path("test_value/file1.json"), pathlib.Path("test_value/file2.json")])
     # Pass in sentinel value to exit thread
     work_queue.put(None)
     upload_thread.join()

--- a/harness/tests/tensorboard/test_base.py
+++ b/harness/tests/tensorboard/test_base.py
@@ -124,6 +124,7 @@ def test_upload_thread_exception_case() -> None:
         thread_name = args.thread.ident
         threads_with_exception.add(thread_name)
 
+    original_excepthook = threading.excepthook
     threading.excepthook = custom_excepthook
 
     # 2. Define function that throws exception
@@ -134,14 +135,17 @@ def test_upload_thread_exception_case() -> None:
     upload_thread = tensorboard.base._TensorboardUploadThread(upload_function)
 
     # 4. start, run, and join the _TensorboardUploadThread instance
-    upload_thread.start()
-    thread_ident = upload_thread.ident
-    upload_thread.upload(
-        [pathlib.Path("test_value/file1.json"), pathlib.Path("test_value/file2.json")]
-    )
-    # Pass in sentinel value to exit thread
-    upload_thread.close()
-    upload_thread.join()
+    try:
+        upload_thread.start()
+        thread_ident = upload_thread.ident
+        upload_thread.upload(
+            [pathlib.Path("test_value/file1.json"), pathlib.Path("test_value/file2.json")]
+        )
+        # Pass in sentinel value to exit thread
+        upload_thread.close()
+        upload_thread.join()
+    finally:
+        threading.excepthook = original_excepthook
 
     # 5. Check that _TensorboardUploadThread instance did not
     #    throw exception

--- a/harness/tests/tensorboard/test_base.py
+++ b/harness/tests/tensorboard/test_base.py
@@ -1,11 +1,9 @@
 import pathlib
-
 import pytest
-
-from unittest import mock
 
 from determined import tensorboard
 from tests.tensorboard import test_util
+from unittest import mock
 
 HOST_PATH = pathlib.Path(__file__).resolve().parent.joinpath("test_tensorboard_host")
 STORAGE_PATH = HOST_PATH.joinpath("test_storage_path")

--- a/harness/tests/tensorboard/test_base.py
+++ b/harness/tests/tensorboard/test_base.py
@@ -98,14 +98,15 @@ def test_illegal_type() -> None:
 
 def test_upload_thread_normal_case() -> None:
     upload_function = mock.Mock()
-    work_queue = queue.Queue(maxsize=10)
-    upload_thread = tensorboard.base._TensorboardUploadThread(upload_function, work_queue)
+    upload_thread = tensorboard.base._TensorboardUploadThread(upload_function)
 
     upload_thread.start()
-    work_queue.put([pathlib.Path("test_value/file1.json"), pathlib.Path("test_value/file2.json")])
-    work_queue.put([pathlib.Path("test_value/file3.json")])
+    upload_thread.upload(
+        [pathlib.Path("test_value/file1.json"), pathlib.Path("test_value/file2.json")]
+    )
+    upload_thread.upload([pathlib.Path("test_value/file3.json")])
     # Pass in sentinel value to exit thread
-    work_queue.put(None)
+    upload_thread.close()
     upload_thread.join()
 
     assert upload_function.call_count == 2
@@ -130,15 +131,16 @@ def test_upload_thread_exception_case() -> None:
         raise Exception("An exception is raised")
 
     # 3. Set up a _TensorboardUploadThread instance
-    work_queue = queue.Queue(maxsize=10)
-    upload_thread = tensorboard.base._TensorboardUploadThread(upload_function, work_queue)
+    upload_thread = tensorboard.base._TensorboardUploadThread(upload_function)
 
     # 4. start, run, and join the _TensorboardUploadThread instance
     upload_thread.start()
     thread_ident = upload_thread.ident
-    work_queue.put([pathlib.Path("test_value/file1.json"), pathlib.Path("test_value/file2.json")])
+    upload_thread.upload(
+        [pathlib.Path("test_value/file1.json"), pathlib.Path("test_value/file2.json")]
+    )
     # Pass in sentinel value to exit thread
-    work_queue.put(None)
+    upload_thread.close()
     upload_thread.join()
 
     # 5. Check that _TensorboardUploadThread instance did not

--- a/harness/tests/tensorboard/test_base.py
+++ b/harness/tests/tensorboard/test_base.py
@@ -1,4 +1,3 @@
-import queue
 import pathlib
 
 import pytest

--- a/harness/tests/tensorboard/test_base.py
+++ b/harness/tests/tensorboard/test_base.py
@@ -151,6 +151,6 @@ def test_upload_thread_exception_case() -> None:
         # 6. Reset excepthook
         threading.excepthook = original_excepthook
 
-    # 5. Check that _TensorboardUploadThread instance did not
+    # 7. Check that _TensorboardUploadThread instance did not
     #    throw exception
     assert thread_ident not in threads_with_exception

--- a/harness/tests/tensorboard/test_base.py
+++ b/harness/tests/tensorboard/test_base.py
@@ -1,9 +1,10 @@
 import pathlib
+from unittest import mock
+
 import pytest
 
 from determined import tensorboard
 from tests.tensorboard import test_util
-from unittest import mock
 
 HOST_PATH = pathlib.Path(__file__).resolve().parent.joinpath("test_tensorboard_host")
 STORAGE_PATH = HOST_PATH.joinpath("test_storage_path")

--- a/harness/tests/tensorboard/test_base.py
+++ b/harness/tests/tensorboard/test_base.py
@@ -117,12 +117,11 @@ def test_upload_thread_exception_case() -> None:
     #    a thread exits with exception.
     import threading
 
-    threads_with_exception = []
+    threads_with_exception = set()
 
     def custom_excepthook(args):
         thread_name = args.thread.ident
-        print(thread_name)
-        threads_with_exception.append(thread_name)
+        threads_with_exception.add(thread_name)
 
     threading.excepthook = custom_excepthook
 


### PR DESCRIPTION
## Description

 [MLG-287]: https://determinedai.atlassian.net/browse/MLG-287

### Context
This is the first of a group of PRs to enable asynchronous upload of TensorBoard files as described in  MLG-287.
For details, please refer to the design doc linked in the ticket.

### This PR
This PR creates a new thread subclass responsible for running upload of Tensorboard files and add relevant unit tests. See commentary section below for more details on how this class will be used and design choices.


## Test Plan

### Unit test
We added unit tests for this test class in test_base.py
`% pytest test_base.py `
` 9 passed, 1 warning in 0.27s`


## Commentary (optional)

### How will this class be used?
(1)
This class will be a member variable to the [TensorboardManager class](https://github.com/determined-ai/determined/blob/master/harness/determined/tensorboard/base.py#L10)

It will be initialized if the async upload mode is chosen within TensorboardManager. All TB files upload performed by the TensorboardManager instance will go through this thread. This frees up main thread to proceed to next training / validation step while making sure only one thread is responsible for uploading TB files, preventing race condition of multiple writes to remote / shared storage.

(2) 
We will refactor the `sync` method of TensorboardManager class and its subclasses to decouple (a) gathering of file paths to upload and (b) actual upload of those files. The function run on the thread should take a list of file paths and then upload.

### Design choice: Exception handling
Remote sync can fail for an array of reasons (e.g. transient network issue), if we do not handle the exception thrown from the upload function, this upload thread instance will be terminated and we cannot use it for future upload requests for the next train / validation step.

Also, I do not think failure to sync Tensorboard file for one step is serious enough to warrant stopping the program.

Therefore, I opt to catch the exception and log the error message inside the run method of the thread class.

### Design choice: Use sentinel value to end the thread
The main reason why I choose to pass a sentinel value to the queue to signal the thread to exit is two-fold
- It naturally guarantees all remaining tasks in the queue are done before the sentinel value is read. No additional handling is needed
- Since this thread will be waiting on the blocking queue in get blocking `get` call, we will need to wake up and exit this thread during the clean up of TensorboardManager. A similar strategy is used by [CPython's ThreadPoolExecutor implementation during clean up](https://github.com/python/cpython/blob/main/Lib/concurrent/futures/thread.py#L232)

## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
MLG-287


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->


[MLG-287]: https://determinedai.atlassian.net/browse/MLG-287?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ