### PR TITLE
chore: Rename user roles to PermissionsStore, set current user accepts null

### DIFF
--- a/webui/react/src/components/DeterminedAuth.tsx
+++ b/webui/react/src/components/DeterminedAuth.tsx
@@ -15,7 +15,7 @@ import useUI from 'shared/contexts/stores/UI';
 import { ErrorType } from 'shared/utils/error';
 import { StorageManager } from 'shared/utils/storage';
 import { useAuth } from 'stores/auth';
-import { UserRolesService } from 'stores/userRoles';
+import { PermissionsStore } from 'stores/permissions';
 import { useUpdateCurrentUser } from 'stores/users';
 import handleError from 'utils/error';
 
@@ -51,7 +51,7 @@ const DeterminedAuth: React.FC<Props> = ({ canceler }: Props) => {
   const [isBadCredentials, setIsBadCredentials] = useState<boolean>(false);
   const [canSubmit, setCanSubmit] = useState<boolean>(!!storage.get(STORAGE_KEY_LAST_USERNAME));
   const [isSubmitted, setIsSubmitted] = useState<boolean>(false);
-  const fetchMyRoles = UserRolesService.fetchUserAssignmentsAndRoles(canceler);
+  const fetchMyRoles = PermissionsStore.fetchMyAssignmentsAndRoles(canceler);
 
   const onFinish = useCallback(
     async (creds: FromValues): Promise<void> => {

--- a/webui/react/src/components/Navigation.tsx
+++ b/webui/react/src/components/Navigation.tsx
@@ -6,7 +6,7 @@ import useUI from 'shared/contexts/stores/UI';
 import usePolling from 'shared/hooks/usePolling';
 import { useClusterStore } from 'stores/cluster';
 import { initInfo, useDeterminedInfo } from 'stores/determinedInfo';
-import { UserRolesService } from 'stores/userRoles';
+import { PermissionsStore } from 'stores/permissions';
 import { useCurrentUser } from 'stores/users';
 import { useFetchWorkspaces } from 'stores/workspaces';
 import { BrandingType, ResourceType } from 'types';
@@ -31,7 +31,7 @@ const Navigation: React.FC<Props> = ({ children }) => {
 
   const fetchWorkspaces = useFetchWorkspaces(canceler);
   const currentUser = useCurrentUser();
-  const fetchMyRoles = UserRolesService.fetchUserAssignmentsAndRoles(canceler);
+  const fetchMyRoles = PermissionsStore.fetchMyAssignmentsAndRoles(canceler);
 
   usePolling(fetchWorkspaces);
 

--- a/webui/react/src/hooks/usePermissions.ts
+++ b/webui/react/src/hooks/usePermissions.ts
@@ -3,7 +3,7 @@ import { useMemo } from 'react';
 
 import useFeature from 'hooks/useFeature';
 import { V1PermissionType } from 'services/api-ts-sdk/api';
-import { UserRolesService } from 'stores/userRoles';
+import { PermissionsStore } from 'stores/permissions';
 import { useCurrentUser } from 'stores/users';
 import {
   DetailedUser,
@@ -95,13 +95,13 @@ const usePermissions = (): PermissionsHook => {
   // Loadables keep track of loading status
   // userAssignments and userRoles should always be an array -- empty arrays until loading is complete.
   const loadableUserAssignments = useObservable<Loadable<UserAssignment[]>>(
-    UserRolesService.getUserAssignments(),
+    PermissionsStore.getMyAssignments(),
   );
   const userAssignments = Loadable.match(loadableUserAssignments, {
     Loaded: (uAssignments) => uAssignments,
     NotLoaded: () => [],
   });
-  const loadableUserRoles = useObservable<Loadable<UserRole[]>>(UserRolesService.getUserRoles());
+  const loadableUserRoles = useObservable<Loadable<UserRole[]>>(PermissionsStore.getMyRoles());
   const userRoles = Loadable.match(loadableUserRoles, {
     Loaded: (uRoles) => uRoles,
     NotLoaded: () => [],

--- a/webui/react/src/pages/SignOut.tsx
+++ b/webui/react/src/pages/SignOut.tsx
@@ -8,7 +8,7 @@ import { ErrorLevel, ErrorType } from 'shared/utils/error';
 import { isAuthFailure } from 'shared/utils/service';
 import { useAuth } from 'stores/auth';
 import { initInfo, useDeterminedInfo } from 'stores/determinedInfo';
-import { UserRolesService } from 'stores/userRoles';
+import { PermissionsStore } from 'stores/permissions';
 import { useUpdateCurrentUser } from 'stores/users';
 import handleError from 'utils/error';
 import { Loadable } from 'utils/loadable';
@@ -24,8 +24,8 @@ const SignOut: React.FC = () => {
   useEffect(() => {
     const signOut = async (): Promise<void> => {
       setIsSigningOut(true);
-      UserRolesService.resetUserAssignmentsAndRoles();
-      updateCurrentUser(-1);
+      PermissionsStore.resetMyAssignmentsAndRoles();
+      updateCurrentUser(null);
       try {
         await logout({});
       } catch (e) {

--- a/webui/react/src/stores/permissions.tsx
+++ b/webui/react/src/stores/permissions.tsx
@@ -4,12 +4,12 @@ import { getPermissionsSummary } from 'services/api';
 import { UserAssignment, UserRole } from 'types';
 import { Loadable, Loaded, NotLoaded } from 'utils/loadable';
 
-export class UserRolesService {
+export class PermissionsStore {
   static #userAssignments: WritableObservable<Loadable<UserAssignment[]>> = observable(NotLoaded);
   static #userRoles: WritableObservable<Loadable<UserRole[]>> = observable(NotLoaded);
 
   // On login, fetching my user's assignments and roles in one API call.
-  static fetchUserAssignmentsAndRoles(canceler: AbortController): () => Promise<void> {
+  static fetchMyAssignmentsAndRoles(canceler: AbortController): () => Promise<void> {
     return async () => {
       const { assignments, roles } = await getPermissionsSummary({ signal: canceler.signal });
       this.#userAssignments.set(Loaded(assignments));
@@ -18,17 +18,17 @@ export class UserRolesService {
   }
 
   // Return the userAssignments observable (receive with useObservable)
-  static getUserAssignments(): Observable<Loadable<UserAssignment[]>> {
+  static getMyAssignments(): Observable<Loadable<UserAssignment[]>> {
     return this.#userAssignments;
   }
 
   // Return the userRoles observable (receive with useObservable)
-  static getUserRoles(): Observable<Loadable<UserRole[]>> {
+  static getMyRoles(): Observable<Loadable<UserRole[]>> {
     return this.#userRoles;
   }
 
   // On logout, clear old user roles and assignments until new user login.
-  static resetUserAssignmentsAndRoles(): void {
+  static resetMyAssignmentsAndRoles(): void {
     this.#userAssignments.set(NotLoaded);
     this.#userRoles.set(NotLoaded);
   }

--- a/webui/react/src/stores/users.tsx
+++ b/webui/react/src/stores/users.tsx
@@ -176,7 +176,7 @@ export const useUsers = (cfg?: FetchUsersConfig): Loadable<Readonly<UserPage>> =
   return Loaded(userPage);
 };
 
-export const useUpdateCurrentUser = (): ((id: number) => void) => {
+export const useUpdateCurrentUser = (): ((id: number | null) => void) => {
   const context = useContext(UsersContext);
 
   if (context === null) {
@@ -185,8 +185,8 @@ export const useUpdateCurrentUser = (): ((id: number) => void) => {
 
   const { updateCurrentUser } = context;
   const callback = useCallback(
-    (id: number) => {
-      if (id <= 0) {
+    (id: number | null) => {
+      if (id === null) {
         updateCurrentUser(() => NotLoaded);
       } else {
         updateCurrentUser(() => Loaded(id));


### PR DESCRIPTION
## Description

As we discussed recently:
- on signout, reset current user to NotLoaded, by sending `null` instead of a negative number
- rename UserRolesService to PermissionsStore (I also changed names of some functions from User to My, i.e. `fetchMyAssignmentsAndRoles`, which matches how we name the returned callbacks in files `fetchMyRoles = PermissionsStore.fetchMyAssignmentsAndRoles`)

## Test Plan

Passing build / tests

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.