### PR TITLE
feat: Tasks store to observables [WEB-797]

### DIFF
--- a/webui/react/src/pages/Cluster/ClusterOverallStats.test.tsx
+++ b/webui/react/src/pages/Cluster/ClusterOverallStats.test.tsx
@@ -4,7 +4,6 @@ import React from 'react';
 import { StoreProvider as UIProvider } from 'shared/contexts/stores/UI';
 import { AuthProvider } from 'stores/auth';
 import { ClusterProvider } from 'stores/cluster';
-import { TasksProvider } from 'stores/tasks';
 import { UsersProvider } from 'stores/users';
 
 import { ClusterOverallStats } from './ClusterOverallStats';
@@ -21,11 +20,9 @@ const setup = () => {
     <UIProvider>
       <AuthProvider>
         <UsersProvider>
-          <TasksProvider>
-            <ClusterProvider>
-              <ClusterOverallStats />
-            </ClusterProvider>
-          </TasksProvider>
+          <ClusterProvider>
+            <ClusterOverallStats />
+          </ClusterProvider>
         </UsersProvider>
       </AuthProvider>
     </UIProvider>,

--- a/webui/react/src/pages/Cluster/ClusterOverallStats.tsx
+++ b/webui/react/src/pages/Cluster/ClusterOverallStats.tsx
@@ -11,9 +11,9 @@ import Spinner from 'shared/components/Spinner';
 import usePolling from 'shared/hooks/usePolling';
 import { useClusterStore } from 'stores/cluster';
 import experimentStore from 'stores/experiments';
-import { useActiveTasks, useFetchActiveTasks } from 'stores/tasks';
+import { ActiveTasksService } from 'stores/tasks';
 import { ShirtSize } from 'themes';
-import { ResourceType } from 'types';
+import { ResourceType, TaskCounts } from 'types';
 import { Loadable } from 'utils/loadable';
 import { useObservable } from 'utils/observable';
 
@@ -34,7 +34,9 @@ export const ClusterOverallStats: React.FC = () => {
     ACTIVE_EXPERIMENTS_PARAMS,
     canceler,
   );
-  const fetchActiveTasks = useFetchActiveTasks(canceler);
+  const fetchActiveTasks = ActiveTasksService.updateActiveTasks(canceler);
+  const activeTasks = useObservable<Loadable<TaskCounts>>(ActiveTasksService.getTaskCounts());
+
   const fetchActiveRunning = useCallback(async () => {
     await fetchActiveExperiments();
     await fetchActiveTasks();
@@ -44,7 +46,6 @@ export const ClusterOverallStats: React.FC = () => {
   const activeExperiments = useObservable(
     experimentStore.getExperimentsByParams(ACTIVE_EXPERIMENTS_PARAMS),
   );
-  const activeTasks = useActiveTasks();
   const rbacEnabled = useFeature().isOn('rbac');
 
   const auxContainers = useMemo(() => {

--- a/webui/react/src/pages/Cluster/ClusterOverallStats.tsx
+++ b/webui/react/src/pages/Cluster/ClusterOverallStats.tsx
@@ -11,7 +11,7 @@ import Spinner from 'shared/components/Spinner';
 import usePolling from 'shared/hooks/usePolling';
 import { useClusterStore } from 'stores/cluster';
 import experimentStore from 'stores/experiments';
-import { ActiveTasksService } from 'stores/tasks';
+import { ActiveTasksStore } from 'stores/tasks';
 import { ShirtSize } from 'themes';
 import { ResourceType, TaskCounts } from 'types';
 import { Loadable } from 'utils/loadable';
@@ -34,8 +34,8 @@ export const ClusterOverallStats: React.FC = () => {
     ACTIVE_EXPERIMENTS_PARAMS,
     canceler,
   );
-  const fetchActiveTasks = ActiveTasksService.updateActiveTasks(canceler);
-  const activeTasks = useObservable<Loadable<TaskCounts>>(ActiveTasksService.getTaskCounts());
+  const fetchActiveTasks = ActiveTasksStore.updateActiveTasks(canceler);
+  const taskCountObservable = ActiveTasksStore.getTaskCounts();
 
   const fetchActiveRunning = useCallback(async () => {
     await fetchActiveExperiments();
@@ -99,28 +99,16 @@ export const ClusterOverallStats: React.FC = () => {
               })}
             </OverviewStats>
             <OverviewStats title="Active JupyterLabs">
-              {Loadable.match(activeTasks, {
-                Loaded: (activeTasks) => activeTasks.notebooks ?? 0,
-                NotLoaded: (): ReactNode => <Spinner />,
-              })}
+              {useObservable(taskCountObservable.select(c => c.notebooks)) ?? 0}
             </OverviewStats>
             <OverviewStats title="Active TensorBoards">
-              {Loadable.match(activeTasks, {
-                Loaded: (activeTasks) => activeTasks.tensorboards ?? 0,
-                NotLoaded: (): ReactNode => <Spinner />,
-              })}
+              {useObservable(taskCountObservable.select(c => c.tensorboards))}
             </OverviewStats>
             <OverviewStats title="Active Shells">
-              {Loadable.match(activeTasks, {
-                Loaded: (activeTasks) => activeTasks.shells ?? 0,
-                NotLoaded: (): ReactNode => <Spinner />,
-              })}
+              {useObservable(taskCountObservable.select(c => c.shells))}
             </OverviewStats>
             <OverviewStats title="Active Commands">
-              {Loadable.match(activeTasks, {
-                Loaded: (activeTasks) => activeTasks.commands ?? 0,
-                NotLoaded: (): ReactNode => <Spinner />,
-              })}
+              {useObservable(taskCountObservable.select(c => c.commands))}
             </OverviewStats>
           </>
         ) : null}

--- a/webui/react/src/services/apiConfig.ts
+++ b/webui/react/src/services/apiConfig.ts
@@ -962,7 +962,7 @@ export const getActiveTasks: DetApi<
 > = {
   name: 'getActiveTasksCount',
   postProcess: (response) => response,
-  request: () => detApi.Tasks.getActiveTasksCount(),
+  request: (_, options) => detApi.Tasks.getActiveTasksCount(options),
 };
 
 /* Webhooks */

--- a/webui/react/src/stores/index.tsx
+++ b/webui/react/src/stores/index.tsx
@@ -14,7 +14,6 @@ import { ClusterProvider } from './cluster';
 import { DeterminedInfoProvider } from './determinedInfo';
 import { KnownRolesProvider } from './knowRoles';
 import { ProjectsProvider } from './projects';
-import { TasksProvider } from './tasks';
 import { UsersProvider } from './users';
 import { WorkspacesProvider } from './workspaces';
 
@@ -23,15 +22,13 @@ export const StoreProvider = ({ children }: { children: ReactNode }): ReactEleme
     <ClusterProvider>
       <UsersProvider>
         <AuthProvider>
-          <TasksProvider>
-            <WorkspacesProvider>
-              <DeterminedInfoProvider>
-                <KnownRolesProvider>
-                  <ProjectsProvider>{children}</ProjectsProvider>
-                </KnownRolesProvider>
-              </DeterminedInfoProvider>
-            </WorkspacesProvider>
-          </TasksProvider>
+          <WorkspacesProvider>
+            <DeterminedInfoProvider>
+              <KnownRolesProvider>
+                <ProjectsProvider>{children}</ProjectsProvider>
+              </KnownRolesProvider>
+            </DeterminedInfoProvider>
+          </WorkspacesProvider>
         </AuthProvider>
       </UsersProvider>
     </ClusterProvider>

--- a/webui/react/src/stores/tasks.tsx
+++ b/webui/react/src/stores/tasks.tsx
@@ -1,29 +1,25 @@
 import { observable, Observable, WritableObservable } from 'micro-observables';
-import React, { createContext, PropsWithChildren, useCallback, useContext, useState } from 'react';
 
 import { getActiveTasks } from 'services/api';
 import { TaskCounts } from 'types';
 import handleError from 'utils/error';
 import { Loadable, Loaded, NotLoaded } from 'utils/loadable';
 
-export class ActiveTasksStore {
-  static #activeTasks: WritableObservable<TaskCounts> = observable({
-    commands: 0,
-    notebooks: 0,
-    shells: 0,
-    tensorboards: 0,
-  });
+export class TasksStore {
+  static #activeTasks: WritableObservable<Loadable<TaskCounts>> = observable(NotLoaded);
 
   // Fetch counts to update the store.
-  static updateActiveTasks(canceler: AbortController): () => Promise<void> {
-    return async () => {
+  static async fetchActiveTasks(canceler: AbortController): Promise<void> {
+    try {
       const response = await getActiveTasks({}, { signal: canceler.signal });
-      this.#activeTasks.set(response);
-    };
+      this.#activeTasks.set(Loaded(response));
+    } catch (e) {
+      handleError(e);
+    }
   }
 
   // Return the counts of active tasks via observable (receive with useObservable)
-  static getTaskCounts(): Observable<TaskCounts> {
+  static getActiveTaskCounts(): Observable<Loadable<TaskCounts>> {
     return this.#activeTasks;
   }
 }

--- a/webui/react/src/stores/tasks.tsx
+++ b/webui/react/src/stores/tasks.tsx
@@ -1,3 +1,4 @@
+import { observable, Observable, WritableObservable } from 'micro-observables';
 import React, { createContext, PropsWithChildren, useCallback, useContext, useState } from 'react';
 
 import { getActiveTasks } from 'services/api';
@@ -5,45 +6,19 @@ import { TaskCounts } from 'types';
 import handleError from 'utils/error';
 import { Loadable, Loaded, NotLoaded } from 'utils/loadable';
 
-type TasksContext = {
-  activeTasks: Loadable<TaskCounts>;
-  updateActiveTasks: (fn: (ws: Loadable<TaskCounts>) => Loadable<TaskCounts>) => void;
-};
+export class ActiveTasksService {
+  static #activeTasks: WritableObservable<Loadable<TaskCounts>> = observable(NotLoaded);
 
-const TasksContext = createContext<TasksContext | null>(null);
-
-export const TasksProvider: React.FC<PropsWithChildren> = ({ children }) => {
-  const [activeTasks, updateActiveTasks] = useState<Loadable<TaskCounts>>(NotLoaded);
-  return (
-    <TasksContext.Provider value={{ activeTasks, updateActiveTasks }}>
-      {children}
-    </TasksContext.Provider>
-  );
-};
-
-export const useFetchActiveTasks = (canceler: AbortController): (() => Promise<void>) => {
-  const context = useContext(TasksContext);
-  if (context === null) {
-    throw new Error('Attempted to use useFetchTasks outside of Task Context');
-  }
-  const { updateActiveTasks } = context;
-
-  return useCallback(async (): Promise<void> => {
-    try {
+  // Fetch counts to update the store.
+  static updateActiveTasks(canceler: AbortController): () => Promise<void> {
+    return async () => {
       const response = await getActiveTasks({}, { signal: canceler.signal });
-      updateActiveTasks(() => Loaded(response));
-    } catch (e) {
-      handleError(e);
-    }
-  }, [canceler, updateActiveTasks]);
-};
-
-export const useActiveTasks = (): Loadable<TaskCounts> => {
-  const context = useContext(TasksContext);
-  if (context === null) {
-    throw new Error('Attempted to use useActiveTasks outside of Task Context');
+      this.#activeTasks.set(Loaded(response));
+    };
   }
-  const { activeTasks } = context;
 
-  return activeTasks;
-};
+  // Return the counts of active tasks via observable (receive with useObservable)
+  static getTaskCounts(): Observable<Loadable<TaskCounts>> {
+    return this.#activeTasks;
+  }
+}

--- a/webui/react/src/stores/tasks.tsx
+++ b/webui/react/src/stores/tasks.tsx
@@ -6,19 +6,24 @@ import { TaskCounts } from 'types';
 import handleError from 'utils/error';
 import { Loadable, Loaded, NotLoaded } from 'utils/loadable';
 
-export class ActiveTasksService {
-  static #activeTasks: WritableObservable<Loadable<TaskCounts>> = observable(NotLoaded);
+export class ActiveTasksStore {
+  static #activeTasks: WritableObservable<TaskCounts> = observable({
+    commands: 0,
+    notebooks: 0,
+    shells: 0,
+    tensorboards: 0,
+  });
 
   // Fetch counts to update the store.
   static updateActiveTasks(canceler: AbortController): () => Promise<void> {
     return async () => {
       const response = await getActiveTasks({}, { signal: canceler.signal });
-      this.#activeTasks.set(Loaded(response));
+      this.#activeTasks.set(response);
     };
   }
 
   // Return the counts of active tasks via observable (receive with useObservable)
-  static getTaskCounts(): Observable<Loadable<TaskCounts>> {
+  static getTaskCounts(): Observable<TaskCounts> {
     return this.#activeTasks;
   }
 }


### PR DESCRIPTION
## Description

Creates an observable-based `TaskStore` to replace previous store.
This is currently only used to display active notebooks, tensorboards, shells, and commands on the cluster page.
The counts are updated simultaneously from regular polling on this page, so it makes sense to set them up as a single Observable Loadable TasksCount object

## Test Plan

- Sign in as admin
- Visit the Cluster page and view counts of active commands / shells / tensorboards
- In a terminal enter `det -m SERVER_ADDRESS shell start`
- Watch for Active Shells to go up by 1
- Go to Tasks section and kill the shell

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.