### PR TITLE
chore: improve error message for unauthenticated API clients

### DIFF
--- a/master/internal/api_auth.go
+++ b/master/internal/api_auth.go
@@ -38,7 +38,7 @@ func (a *apiServer) Login(
 	ctx context.Context, req *apiv1.LoginRequest,
 ) (*apiv1.LoginResponse, error) {
 	if a.m.config.InternalConfig.ExternalSessions.JwtKey != "" {
-		return nil, status.Error(codes.FailedPrecondition, "authentication is configured to be external")
+		return nil, status.Error(codes.FailedPrecondition, "please run `det auth login` to authenticate")
 	}
 
 	if req.Username == "" {


### PR DESCRIPTION
## Description

The current message is not actionable for end-users. Virtually every time they see this, it just means they didn't run `det auth login` and authenticate via their browser. Possibly we could improve this further by automatically trying to start authentication when we hit authentication errors, but for now this is a low-hanging fruit usability fix by making the required action clear to end-users.

## Test Plan

Will test a build of HPE MLDE that has authentication configured this way just for completeness' sake. Do not expect any issues since it's just changing a string in a user-facing error message.