### PR TITLE
refactor: `getWorkspaces` sql refactor and speed up

### DIFF
--- a/master/static/srv/get_workspaces.sql
+++ b/master/static/srv/get_workspaces.sql
@@ -1,28 +1,22 @@
-WITH pins AS (
-  SELECT id, workspace_id, created_at
-  FROM workspace_pins
-  WHERE user_id = $6
-),
-exp_count_by_project AS (
-  SELECT COUNT(*) AS count, project_id FROM experiments
-  GROUP BY project_id
-)
 SELECT w.id, w.name, w.archived, w.immutable, u.username, w.user_id,
 (pins.id IS NOT NULL) AS pinned, pins.created_at AS pinned_at,
 'WORKSPACE_STATE_' || w.state AS state, w.error_message,
 (CASE WHEN uid IS NOT NULL OR gid IS NOT NULL OR user_ IS NOT NULL OR group_ IS NOT NULL THEN
   jsonb_build_object('agent_uid', uid, 'agent_user', user_, 'agent_gid', gid, 'agent_group', group_)
-  ELSE NULL END) as agent_user_group,
-(SELECT COUNT(*) FROM projects WHERE workspace_id = w.id) AS num_projects,
-(SELECT SUM(count) FROM exp_count_by_project WHERE project_id IN
-  (SELECT id FROM projects WHERE workspace_id = w.id)) AS num_experiments
-FROM workspaces as w
-LEFT JOIN users as u ON u.id = w.user_id
-LEFT JOIN pins ON pins.workspace_id = w.id
+  ELSE NULL END) AS agent_user_group,
+COUNT(DISTINCT p.id) AS num_projects,
+COUNT(DISTINCT e.id) AS num_experiments
+FROM workspaces AS w
+LEFT JOIN users AS u ON u.id = w.user_id
+LEFT JOIN workspace_pins AS pins ON pins.workspace_id = w.id AND pins.user_id = $6
+LEFT JOIN projects AS p ON p.workspace_id = w.id
+LEFT JOIN experiments AS e ON e.project_id = p.id
 
 WHERE ($1 = '' OR (u.username IN (SELECT unnest(string_to_array($1, ',')))))
 AND ($2 = '' OR w.user_id IN (SELECT unnest(string_to_array($2, ',')::int [])))
 AND ($3 = '' OR w.name ILIKE $3)
 AND ($4 = '' OR w.archived = $4::BOOL)
 AND ($5 = '' OR (pins.id IS NOT NULL) = $5::BOOL)
+
+GROUP BY w.id, u.username, pins.id
 ORDER BY %s, pins.created_at DESC;


### PR DESCRIPTION
## Description

~~Motivation is that support workspace (ws) id filter in [GetWorkspaces](http://latest-master.determined.ai:8080/docs/rest-api/#/Workspaces/GetWorkspaces) with [Int32FieldFilter](https://github.com/determined-ai/determined/blob/master/proto/src/determined/common/v1/common.proto#L34) like [experimentIdFilter  in GetExperiments](http://latest-master.determined.ai:8080/docs/rest-api/#/Experiments/GetExperiments) to optimize API call. 
In order to archive this, we need to switch sql code to Bun code.~~ <- so far web team end up not needing it, 
The current SQL is a bit complicated, so I removed subquery to simplify and speed up as by-product (subquery is usually slow).

---

M1 Max Mac with 32GB memory, 10 cores:
On my local db, i have 464 experiments, 133 projects, 255 workspaces, 257 pinned workspaces. 125 users.

I used `EXPLAIN ANALYSE` to check the query speed. 
I reindexed and vacuumed db before measurement.

|                            | Old Planning Time | New Planning Time | Speed Up Rate |
| ----------------| -------------------: | --------------------: | --------------:  |
| GetWorkspaces | 0.383 ms                  | 0.304 ms                    | 125.986% 📈     |


|                            | Old Execution Time | New Execution Time | Speed Up Rate    |
| ---------------- | -------------------: | --------------------: | ---------------: |
| GetWorkspaces | 5.054 ms                   | 1.471 ms                    | 343.575% 📈      |



Overall = Planning Time + Execution Time

|                            | Old Overall Time      | New Overall Time      | Speed Up Rate |
| ---------------- | -------------------: | --------------------: | --------------:  |
| GetWorkspaces | 5.437 ms                   | 1.775 ms                     | 306.309% 📈    |


<!---
Lead with the intended commit body in this description field. For breaking
changes, please include "BREAKING CHANGE:" at the beginning of your commit
body.  At a minimum, this section should include a bracketed reference to the
Jira ticket, e.g. "[DET-1234]". When squash-and-merging, copy this directly
into the description field.
-->



## Test Plan
- Check if AP with various paramsI returns the same results as before

I tested on my side, but double-check would be grateful 
<!---
Describe the situations in which you've tested your change, and/or a screenshot
as appropriate.  Reviewers may ask questions about this test plan to ensure
adequate manual coverage of changes.
-->



## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
