### PR TITLE
fix: avoid typing.OrderedDict

### DIFF
--- a/harness/determined/cli/command.py
+++ b/harness/determined/cli/command.py
@@ -4,9 +4,7 @@ import re
 from argparse import Namespace
 from collections import OrderedDict, namedtuple
 from pathlib import Path
-from typing import IO, Any, Dict, Iterable, List, Optional
-from typing import OrderedDict as TypedOrderedDict
-from typing import Tuple, Union
+from typing import IO, Any, Dict, Iterable, List, Optional, Tuple, Union
 
 from termcolor import colored
 
@@ -115,7 +113,7 @@ RemoteTaskOldAPIs = {
     TaskTypeTensorBoard: "tensorboard",
 }
 
-RemoteTaskListTableHeaders: Dict[str, TypedOrderedDict[str, str]] = {
+RemoteTaskListTableHeaders: Dict[str, Dict[str, str]] = {
     "notebook": CommandTableHeader,
     "command cmd": CommandTableHeader,
     "shell": CommandTableHeader,

--- a/harness/determined/cli/render.py
+++ b/harness/determined/cli/render.py
@@ -4,7 +4,7 @@ import inspect
 import pathlib
 import sys
 from datetime import timezone
-from typing import Any, Dict, Iterable, List, Optional, OrderedDict, Sequence, Union
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Union
 
 import dateutil.parser
 import tabulate
@@ -17,14 +17,12 @@ _FORMAT = "presto"
 _DEFAULT_VALUE = "N/A"
 
 
-def select_values(
-    values: List[Dict[str, Any]], headers: OrderedDict[str, str]
-) -> List[Dict[str, Any]]:
+def select_values(values: List[Dict[str, Any]], headers: Dict[str, str]) -> List[Dict[str, Any]]:
     return [{k: item.get(k, _DEFAULT_VALUE) for k in headers.keys()} for item in values]
 
 
 def render_table(
-    values: List[Dict[str, Any]], headers: OrderedDict[str, str], table_fmt: str = _FORMAT
+    values: List[Dict[str, Any]], headers: Dict[str, str], table_fmt: str = _FORMAT
 ) -> None:
     # Only display selected columns
     values = select_values(values, headers)


### PR DESCRIPTION
OrderedDict was added to typing in 3.7.1, but we support 3.7.0 still.

## Test Plan

- [x] run `det -h` in a python 3.7.0 environment and see if it works.