### PR TITLE
fix: fix tree transparency color

### DIFF
--- a/webui/react/src/components/ThemeProvider.tsx
+++ b/webui/react/src/components/ThemeProvider.tsx
@@ -45,6 +45,9 @@ const ANTD_THEMES: Record<DarkLight, ThemeConfig> = {
       Select: {
         colorBgContainer: 'transparent',
       },
+      Tree: {
+        colorBgContainer: 'transparent',
+      },
     },
     token: {
       borderRadius: 2,


### PR DESCRIPTION

## Description
This fixes the tree element in the workspace/project searcher appearing with an inappropriate background color.

OLD:
![image](https://user-images.githubusercontent.com/701438/217622580-7bd9b1b9-049d-4970-824d-f1c685f5dff8.png)

NEW: 
![image](https://user-images.githubusercontent.com/701438/217622825-259df2a2-4c52-41cf-8d7a-e143ebc38a83.png)


## Test Plan

The tree element that shows up when searching workspaces should appear with a transparent background


## Checklist

- [X] Changes have been manually QA'd


## Ticket
[WEB-864]


[WEB-864]: https://determinedai.atlassian.net/browse/WEB-864?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ