### PR TITLE
fix: Persist theme settings

### DIFF
--- a/webui/react/src/App.tsx
+++ b/webui/react/src/App.tsx
@@ -27,14 +27,13 @@ import { useAuth } from 'stores/auth';
 import { initInfo, useDeterminedInfo, useEnsureInfoFetched } from 'stores/determinedInfo';
 import { useCurrentUser, useEnsureCurrentUserFetched, useFetchUsers } from 'stores/users';
 import { correctViewportHeight, refreshPage } from 'utils/browser';
-import { notification, useInitApi } from 'utils/dialogApi';
+import { notification } from 'utils/dialogApi';
 import { Loadable } from 'utils/loadable';
 
 import css from './App.module.scss';
 import 'antd/dist/reset.css';
 
 const AppView: React.FC = () => {
-  useInitApi();
   const resize = useResize();
   const { auth } = useAuth();
   const isAuthenticated = Loadable.match(auth, {
@@ -130,11 +129,15 @@ const AppView: React.FC = () => {
       <div className={css.base}>
         {isServerReachable ? (
           <SettingsProvider>
-            <Navigation>
-              <main>
-                <Router routes={appRoutes} />
-              </main>
-            </Navigation>
+            <ThemeProvider>
+              <AntdApp>
+                <Navigation>
+                  <main>
+                    <Router routes={appRoutes} />
+                  </main>
+                </Navigation>
+              </AntdApp>
+            </ThemeProvider>
           </SettingsProvider>
         ) : (
           <PageMessage title="Server is Unreachable">
@@ -156,13 +159,9 @@ const App: React.FC = () => {
   return (
     <HelmetProvider>
       <StoreProvider>
-        <ThemeProvider>
-          <AntdApp>
-            <DndProvider backend={HTML5Backend}>
-              <AppView />
-            </DndProvider>
-          </AntdApp>
-        </ThemeProvider>
+        <DndProvider backend={HTML5Backend}>
+          <AppView />
+        </DndProvider>
       </StoreProvider>
     </HelmetProvider>
   );

--- a/webui/react/src/components/Navigation.tsx
+++ b/webui/react/src/components/Navigation.tsx
@@ -11,6 +11,7 @@ import { useCurrentUser } from 'stores/users';
 import { useFetchWorkspaces } from 'stores/workspaces';
 import { BrandingType, ResourceType } from 'types';
 import { updateFaviconType } from 'utils/browser';
+import { useInitApi } from 'utils/dialogApi';
 import { Loadable, NotLoaded } from 'utils/loadable';
 import { useObservable } from 'utils/observable';
 
@@ -23,6 +24,7 @@ interface Props {
 }
 
 const Navigation: React.FC<Props> = ({ children }) => {
+  useInitApi();
   const { ui } = useUI();
   const info = Loadable.getOrElse(initInfo, useDeterminedInfo());
   const [canceler] = useState(new AbortController());


### PR DESCRIPTION

## Description

This fixes an issue where the user's theme preference wasn't respected on refreshing the page. This was because the theme context was moved above the settings context as part of the antd5 upgrade. That's now fixed, but there is a minor chance that some dialogues that appear at the same time as the initial render will not be aware of the theme.



## Test Plan

1. On any page, change the theme from the system theme to either the light theme or dark theme
2. On reload, the theme should persist



## Checklist

- [x] Changes have been manually QA'd


## Ticket
WEB-866

