### PR TITLE
fix: Patch an issue where login (?) seems to load forever

### DIFF
--- a/webui/react/src/pages/SignOut.tsx
+++ b/webui/react/src/pages/SignOut.tsx
@@ -44,7 +44,7 @@ const SignOut: React.FC = () => {
       if (info.externalLogoutUri) {
         routeAll(info.externalLogoutUri);
       } else {
-        navigate(paths.login(), { state: location.state });
+        navigate(paths.login() + '?r=' + Math.random(), { state: location.state });
       }
     };
 


### PR DESCRIPTION
## Description

Prevent getting stuck in an unusable state when you are logged out.  My understanding from testing other branches is that our spinner issues stem from SignOut making some unusual calls, error handling, etc.  From console.log-ing, there is a try-catch section, and signOut completes, but still we don't redirect to a clean login page. This is my recommendation to make the redirect to new login + state effective.

(this may already have been addressed for logged-in users?)

## Test Plan

`make build` the webui

Start devcluster. In incognito mode, or a browser where you are not typically signed in, visit `http://localhost:8080`. You should arrive on the login screen and not be stuck on a spinner.

Restart devcluster between tests

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.