### PR TITLE
fix: Prevent extra calls to fetch inaccessible workspaces, projects [WEB-880]

### DIFF
--- a/webui/react/src/pages/WorkspaceDetails.tsx
+++ b/webui/react/src/pages/WorkspaceDetails.tsx
@@ -218,8 +218,9 @@ const WorkspaceDetails: React.FC = () => {
     workspaceAssignments,
   ]);
 
+  const canViewWorkspaceFlag = canViewWorkspace({ workspace: { id } });
   const fetchAll = useCallback(async () => {
-    if (!canViewWorkspace({ workspace: { id } })) return;
+    if (!canViewWorkspaceFlag) return;
     await Promise.allSettled([
       fetchWorkspace(),
       fetchUsers(),
@@ -228,8 +229,7 @@ const WorkspaceDetails: React.FC = () => {
       fetchRolesAssignableToScope(),
     ]);
   }, [
-    id,
-    canViewWorkspace,
+    canViewWorkspaceFlag,
     fetchWorkspace,
     fetchGroups,
     fetchUsers,
@@ -261,7 +261,7 @@ const WorkspaceDetails: React.FC = () => {
 
   if (isNaN(id)) {
     return <Message title={`Invalid Workspace ID ${workspaceId}`} />;
-  } else if (!canViewWorkspace({ workspace: { id } })) {
+  } else if (!canViewWorkspaceFlag) {
     return <PageNotFound />;
   } else if (pageError) {
     if (isNotFound(pageError)) return <PageNotFound />;

--- a/webui/react/src/pages/WorkspaceDetails.tsx
+++ b/webui/react/src/pages/WorkspaceDetails.tsx
@@ -219,6 +219,7 @@ const WorkspaceDetails: React.FC = () => {
   ]);
 
   const fetchAll = useCallback(async () => {
+    if (!canViewWorkspace({ workspace: { id } })) return;
     await Promise.allSettled([
       fetchWorkspace(),
       fetchUsers(),
@@ -227,6 +228,8 @@ const WorkspaceDetails: React.FC = () => {
       fetchRolesAssignableToScope(),
     ]);
   }, [
+    id,
+    canViewWorkspace,
     fetchWorkspace,
     fetchGroups,
     fetchUsers,
@@ -258,16 +261,14 @@ const WorkspaceDetails: React.FC = () => {
 
   if (isNaN(id)) {
     return <Message title={`Invalid Workspace ID ${workspaceId}`} />;
+  } else if (!canViewWorkspace({ workspace: { id } })) {
+    return <PageNotFound />;
   } else if (pageError) {
     if (isNotFound(pageError)) return <PageNotFound />;
     const message = `Unable to fetch Workspace ${workspaceId}`;
     return <Message title={message} type={MessageType.Warning} />;
   } else if (!workspace) {
     return <Spinner tip={`Loading workspace ${workspaceId} details...`} />;
-  }
-
-  if (!canViewWorkspace({ workspace: { id } })) {
-    return <PageNotFound />;
   }
 
   return (


### PR DESCRIPTION
## Description

Prevent an issue where a user does not have access to the Uncategorized project (and other workspaces/projects) yet we continued to poll for data and workspace roles from the Not Found page.

The change is on `src/pages/WorkspaceDetails.tsx` - `fetchAll` will stop if we know that the user does not have access to this project. Also integrates NotFound page into the display/error conditions.

I explored changes on WorkspaceProjects and ProjectDetails but this appears to be the core issue.

## Test Plan

As described in bug, as EE admin create a user with no permissions, then log in as that user

Open the console to check for auth / failed requests

Visit / (for devcluster, localhost:8080) -> redirect to /det/workspaces with empty workspaces list
Visit /det/workspaces -> see empty workspaces list
Visit /det/workspaces/1 -> redirect to /det/workspaces/1/projects with a not found / no permissions error
Visit /det/workspaces/1/projects -> see not found / no permissions error
Visit /det/workspaces/1/projects/1 -> redirect to /det/workspaces with empty workspaces list

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.