### PR TITLE
docs: remove link to outdated project roadmap wiki page

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,10 +7,6 @@ If you encounter an issue or would like to request a new feature, please create
 also join the [Slack](https://join.slack.com/t/determined-community/shared_invite/zt-cnj7802v-KcVbaUrIzQOwmkmY7gP0Ew)
 to get support and talk with other users and developers in real-time.
 
-## Project Roadmap
-
-<https://github.com/determined-ai/determined/wiki/Project-Roadmap>
-
 ## Contributing Changes
 
 We welcome outside contributions. If you'd like to make a contribution, please:


### PR DESCRIPTION
## Description

Removes link to the outdated Project Roadmap on the GitHub Wiki which itself has been deprecated.

## Test Plan

No test plan required.

## Commentary (optional)

Discussed internally and approved by leadership.

## Checklist

- [**NA**] Changes have been manually QA'd
- [**NA**] User-facing API changes need the "User-facing API Change" label.
- [**NA**] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [**NA**] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket

No Ticket
