### PR TITLE
feat: add command echo around startup hook

### DIFF
--- a/master/static/srv/entrypoint.sh
+++ b/master/static/srv/entrypoint.sh
@@ -36,7 +36,9 @@ fi
 
 "$DET_PYTHON_EXECUTABLE" -m determined.exec.prep_container --trial --resources
 
+set -x
 test -f "${STARTUP_HOOK}" && source "${STARTUP_HOOK}"
+set +x
 
 # Do rendezvous last, to ensure all launch layers start around the same time.
 "$DET_PYTHON_EXECUTABLE" -m determined.exec.prep_container --rendezvous

--- a/master/static/srv/notebook-entrypoint.sh
+++ b/master/static/srv/notebook-entrypoint.sh
@@ -43,7 +43,9 @@ fi
 
 "$DET_PYTHON_EXECUTABLE" -m determined.exec.prep_container --resources --proxy
 
+set -x
 test -f "${STARTUP_HOOK}" && source "${STARTUP_HOOK}"
+set +x
 
 "$DET_PYTHON_EXECUTABLE" /run/determined/jupyter/check_idle.py &
 

--- a/master/static/srv/shell-entrypoint.sh
+++ b/master/static/srv/shell-entrypoint.sh
@@ -26,7 +26,9 @@ fi
 
 "$DET_PYTHON_EXECUTABLE" -m determined.exec.prep_container --resources --proxy
 
+set -x
 test -f "${STARTUP_HOOK}" && source "${STARTUP_HOOK}"
+set +x
 
 # Prepend each key in authorized_keys with a set of environment="KEY=VALUE"
 # options to inject the entire docker environment into the eventual ssh

--- a/master/static/srv/tensorboard-entrypoint.sh
+++ b/master/static/srv/tensorboard-entrypoint.sh
@@ -25,7 +25,9 @@ fi
 
 "$DET_PYTHON_EXECUTABLE" -m determined.exec.prep_container --proxy
 
+set -x
 test -f "${STARTUP_HOOK}" && source "${STARTUP_HOOK}"
+set +x
 
 READINESS_REGEX="TensorBoard contains metrics"
 WAITING_REGEX="TensorBoard waits on metrics"


### PR DESCRIPTION
Description:
It is very useful to have a print out of what was executed in the startup-hook.sh when troubleshooting issues. Just as we show the experiment config, we should show what the user did in their startup-hook.sh to modify the environment.