### PR TITLE
fix: Clear pinned / all workspaces on signout [WEB-899]

### DIFF
--- a/webui/react/src/pages/SignOut.tsx
+++ b/webui/react/src/pages/SignOut.tsx
@@ -10,6 +10,7 @@ import { reset as resetAuth } from 'stores/auth';
 import { initInfo, useDeterminedInfo } from 'stores/determinedInfo';
 import { PermissionsStore } from 'stores/permissions';
 import { useUpdateCurrentUser } from 'stores/users';
+import { useResetWorkspaces } from 'stores/workspaces';
 import handleError from 'utils/error';
 import { Loadable } from 'utils/loadable';
 
@@ -19,12 +20,14 @@ const SignOut: React.FC = () => {
   const info = Loadable.getOrElse(initInfo, useDeterminedInfo());
   const [isSigningOut, setIsSigningOut] = useState(false);
   const updateCurrentUser = useUpdateCurrentUser();
+  const resetWorkspaces = useResetWorkspaces();
 
   useEffect(() => {
     const signOut = async (): Promise<void> => {
       setIsSigningOut(true);
       PermissionsStore.resetMyAssignmentsAndRoles();
       updateCurrentUser(null);
+      resetWorkspaces();
       try {
         await logout({});
       } catch (e) {
@@ -48,7 +51,14 @@ const SignOut: React.FC = () => {
     };
 
     if (!isSigningOut) signOut();
-  }, [navigate, info.externalLogoutUri, location.state, updateCurrentUser, isSigningOut]);
+  }, [
+    navigate,
+    info.externalLogoutUri,
+    location.state,
+    updateCurrentUser,
+    isSigningOut,
+    resetWorkspaces,
+  ]);
 
   return null;
 };

--- a/webui/react/src/stores/workspaces.tsx
+++ b/webui/react/src/stores/workspaces.tsx
@@ -153,6 +153,21 @@ export const useCreateWorkspace = (): ((arg0: V1PostWorkspaceRequest) => Promise
   );
 };
 
+// On logout, clear old workspace records.
+export const useResetWorkspaces = (): (() => void) => {
+  const context = useContext(WorkspacesContext);
+
+  if (context === null) {
+    throw new Error('Attempted to use useResetWorkspaces outside of Workspace Context');
+  }
+
+  const { workspaces } = context;
+
+  return useCallback((): void => {
+    workspaces.set(NotLoaded);
+  }, [workspaces]);
+};
+
 export const useDeleteWorkspace = (): ((id: number) => Promise<void>) => {
   const context = useContext(WorkspacesContext);
 


### PR DESCRIPTION
## Description

- Add callback to workspaces store to clear workspaces store/cache (this is the source of pinned workspaces)
- On signout, call useResetWorkspaces

## Test Plan

- Sign in as admin and have at least one pinned workspace
- Create a user with no roles / permissions
- Sign out and sign in under this new user / no password: no pinned workspace is shown at any time
- Sign out and sign in again as admin: after a short delay to fetch workspaces, the pinned workspace is visible again

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.