### PR TITLE
fix: hide 404 until permissions are loaded

### DIFF
--- a/webui/react/src/components/Page.tsx
+++ b/webui/react/src/components/Page.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Helmet } from 'react-helmet-async';
 
 import PageHeader from 'components/PageHeader';
+import PageNotFound from 'components/PageNotFound';
 import usePermissions from 'hooks/usePermissions';
 import BasePage, { Props as BasePageProps } from 'shared/components/Page';
 import Spinner from 'shared/components/Spinner';
@@ -12,6 +13,7 @@ import { Loadable } from 'utils/loadable';
 export interface Props extends Omit<BasePageProps, 'pageHeader'> {
   docTitle?: string;
   ignorePermissions?: boolean;
+  notFound?: boolean;
 }
 
 const getFullDocTitle = (branding: string, title?: string, clusterName?: string) => {
@@ -48,6 +50,8 @@ const Page: React.FC<Props> = (props: Props) => {
       </Helmet>
       {!props.ignorePermissions && loadingPermissions ? (
         <Spinner center />
+      ) : props.notFound ? (
+        <PageNotFound /> // hide until permissions are loaded
       ) : (
         <BasePage
           {...props}

--- a/webui/react/src/pages/ExperimentDetails/ExperimentDetails.tsx
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentDetails.tsx
@@ -2,7 +2,6 @@ import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useParams } from 'react-router-dom';
 
 import Page from 'components/Page';
-import PageNotFound from 'components/PageNotFound';
 import { terminalRunStates } from 'constants/states';
 import ExperimentDetailsHeader from 'pages/ExperimentDetails/ExperimentDetailsHeader';
 import ExperimentMultiTrialTabs from 'pages/ExperimentDetails/ExperimentMultiTrialTabs';
@@ -77,8 +76,7 @@ const ExperimentDetails: React.FC = () => {
 
   if (isNaN(id)) {
     return <Message title={`${INVALID_ID_MESSAGE} ${experimentId}`} />;
-  } else if (pageError) {
-    if (isNotFound(pageError)) return <PageNotFound />;
+  } else if (pageError && !isNotFound(pageError)) {
     const message = `${ERROR_MESSAGE} ${experimentId}`;
     return <Message title={message} type={MessageType.Warning} />;
   } else if (!experiment || isSingleTrial === undefined) {
@@ -95,6 +93,7 @@ const ExperimentDetails: React.FC = () => {
           trial={trial}
         />
       }
+      notFound={pageError && isNotFound(pageError)}
       stickyHeader
       title={`Experiment ${experimentId}`}>
       {isSingleTrial ? (

--- a/webui/react/src/pages/ModelDetails.tsx
+++ b/webui/react/src/pages/ModelDetails.tsx
@@ -7,7 +7,6 @@ import Input from 'components/kit/Input';
 import MetadataCard from 'components/Metadata/MetadataCard';
 import NotesCard from 'components/NotesCard';
 import Page from 'components/Page';
-import PageNotFound from 'components/PageNotFound';
 import InteractiveTable, {
   ColumnDef,
   InteractiveTableSettings,
@@ -442,8 +441,7 @@ const ModelDetails: React.FC = () => {
 
   if (!modelId) {
     return <Message title="Model name is empty" />;
-  } else if (pageError) {
-    if (isNotFound(pageError)) return <PageNotFound />;
+  } else if (pageError && !isNotFound(pageError)) {
     const message = `Unable to fetch model ${modelId}`;
     return <Message title={message} type={MessageType.Warning} />;
   } else if (!model || !workspace) {
@@ -464,7 +462,8 @@ const ModelDetails: React.FC = () => {
           onUpdateTags={saveModelTags}
         />
       }
-      id="modelDetails">
+      id="modelDetails"
+      notFound={pageError && isNotFound(pageError)}>
       <div className={css.base}>
         {model.modelVersions.length === 0 ? (
           <div className={css.noVersions}>

--- a/webui/react/src/pages/ModelRegistry.tsx
+++ b/webui/react/src/pages/ModelRegistry.tsx
@@ -16,7 +16,6 @@ import Input from 'components/kit/Input';
 import Tooltip from 'components/kit/Tooltip';
 import Link from 'components/Link';
 import Page from 'components/Page';
-import PageNotFound from 'components/PageNotFound';
 import InteractiveTable, {
   ColumnDef,
   InteractiveTableSettings,
@@ -666,14 +665,11 @@ const ModelRegistry: React.FC<Props> = ({ workspace }: Props) => {
     [ModelActionMenu],
   );
 
-  if (!canViewModelRegistry) {
-    return <PageNotFound />;
-  }
-
   return (
     <Page
       containerRef={pageRef}
       id="models"
+      notFound={!canViewModelRegistry}
       options={
         <Space>
           <Toggle

--- a/webui/react/src/pages/ModelVersionDetails.tsx
+++ b/webui/react/src/pages/ModelVersionDetails.tsx
@@ -10,7 +10,6 @@ import Link from 'components/Link';
 import MetadataCard from 'components/Metadata/MetadataCard';
 import NotesCard from 'components/NotesCard';
 import Page from 'components/Page';
-import PageNotFound from 'components/PageNotFound';
 import usePermissions from 'hooks/usePermissions';
 import { paths } from 'routes/utils';
 import { getModelVersion, patchModelVersion } from 'services/api';
@@ -325,8 +324,7 @@ const ModelVersionDetails: React.FC = () => {
     return <Message title="Model name is empty" />;
   } else if (isNaN(parseInt(versionNum))) {
     return <Message title={`Invalid Version ID ${versionNum}`} />;
-  } else if (pageError) {
-    if (isNotFound(pageError)) return <PageNotFound />;
+  } else if (pageError && !isNotFound(pageError)) {
     const message = `Unable to fetch model ${modelId} version ${versionNum}`;
     return <Message title={message} type={MessageType.Warning} />;
   } else if (!modelVersion || !workspace) {
@@ -346,7 +344,8 @@ const ModelVersionDetails: React.FC = () => {
           onUpdateTags={saveVersionTags}
         />
       }
-      id="modelDetails">
+      id="modelDetails"
+      notFound={pageError && isNotFound(pageError)}>
       {/* TODO: Clean up once we standardize page layouts */}
       <div style={{ padding: 16 }}>
         <Pivot activeKey={tabKey} items={tabItems} onChange={handleTabChange} />

--- a/webui/react/src/pages/ProjectDetails.tsx
+++ b/webui/react/src/pages/ProjectDetails.tsx
@@ -8,7 +8,6 @@ import BreadcrumbBar from 'components/BreadcrumbBar';
 import DynamicTabs from 'components/DynamicTabs';
 import Tooltip from 'components/kit/Tooltip';
 import Page from 'components/Page';
-import PageNotFound from 'components/PageNotFound';
 import ProjectActionDropdown from 'components/ProjectActionDropdown';
 import useFeature from 'hooks/useFeature';
 import usePermissions from 'hooks/usePermissions';
@@ -28,7 +27,6 @@ import handleError from 'utils/error';
 import { Loadable } from 'utils/loadable';
 
 import ExperimentList from './ExperimentList';
-import NoPermissions from './NoPermissions';
 import css from './ProjectDetails.module.scss';
 import ProjectNotes from './ProjectNotes';
 import TrialsComparison from './TrialsComparison/TrialsComparison';
@@ -151,10 +149,7 @@ const ProjectDetails: React.FC = () => {
 
   if (isNaN(id)) {
     return <Message title={`Invalid Project ID ${projectId}`} />;
-  } else if (!permissions.canViewWorkspaces) {
-    return <NoPermissions />;
-  } else if (pageError) {
-    if (isNotFound(pageError)) return <PageNotFound />;
+  } else if (pageError && !isNotFound(pageError)) {
     const message = `Unable to fetch Project ${projectId}`;
     return <Message title={message} type={MessageType.Warning} />;
   } else if (!project) {
@@ -166,7 +161,8 @@ const ProjectDetails: React.FC = () => {
       containerRef={pageRef}
       // for docTitle, when id is 1 that means Uncategorized from webui/react/src/routes/routes.ts
       docTitle={id === 1 ? 'Uncategorized Experiments' : 'Project Details'}
-      id="projectDetails">
+      id="projectDetails"
+      notFound={(pageError && isNotFound(pageError)) || !permissions.canViewWorkspaces}>
       <BreadcrumbBar
         extra={
           <Space>

--- a/webui/react/src/pages/TrialDetails.tsx
+++ b/webui/react/src/pages/TrialDetails.tsx
@@ -4,7 +4,6 @@ import { useNavigate, useParams } from 'react-router-dom';
 
 import Pivot from 'components/kit/Pivot';
 import Page from 'components/Page';
-import PageNotFound from 'components/PageNotFound';
 import RoutePagination from 'components/RoutePagination';
 import TrialLogPreview from 'components/TrialLogPreview';
 import { terminalRunStates } from 'constants/states';
@@ -191,8 +190,7 @@ const TrialDetailsComp: React.FC = () => {
     return <Message title={`Invalid Trial ID ${trialId}`} />;
   }
 
-  if (trialDetails.error !== undefined) {
-    if (isNotFound(trialDetails.error)) return <PageNotFound />;
+  if (trialDetails.error !== undefined && !isNotFound(trialDetails.error)) {
     const message = `Unable to fetch Trial ${trialId}`;
     return (
       <Message message={trialDetails.error.message} title={message} type={MessageType.Warning} />
@@ -213,6 +211,7 @@ const TrialDetailsComp: React.FC = () => {
           trial={trial}
         />
       }
+      notFound={trialDetails.error && isNotFound(trialDetails.error)}
       stickyHeader
       title={`Trial ${trialId}`}>
       <TrialLogPreview

--- a/webui/react/src/pages/WorkspaceDetails.tsx
+++ b/webui/react/src/pages/WorkspaceDetails.tsx
@@ -4,7 +4,6 @@ import { useNavigate, useParams } from 'react-router-dom';
 
 import Pivot from 'components/kit/Pivot';
 import Page from 'components/Page';
-import PageNotFound from 'components/PageNotFound';
 import TaskList from 'components/TaskList';
 import useFeature from 'hooks/useFeature';
 import usePermissions from 'hooks/usePermissions';
@@ -261,10 +260,7 @@ const WorkspaceDetails: React.FC = () => {
 
   if (isNaN(id)) {
     return <Message title={`Invalid Workspace ID ${workspaceId}`} />;
-  } else if (!canViewWorkspaceFlag) {
-    return <PageNotFound />;
-  } else if (pageError) {
-    if (isNotFound(pageError)) return <PageNotFound />;
+  } else if (pageError && !isNotFound(pageError)) {
     const message = `Unable to fetch Workspace ${workspaceId}`;
     return <Message title={message} type={MessageType.Warning} />;
   } else if (!workspace) {
@@ -284,7 +280,8 @@ const WorkspaceDetails: React.FC = () => {
         />
       }
       id="workspaceDetails"
-      key={workspaceId}>
+      key={workspaceId}
+      notFound={(pageError && isNotFound(pageError)) || !canViewWorkspaceFlag}>
       <Pivot
         activeKey={tabKey}
         destroyInactiveTabPane


### PR DESCRIPTION
## Description

https://determinedai.atlassian.net/browse/WEB-831

## Test Plan

Should not see 404 flash while loading a page.



## Commentary (optional)

Also looked at adding more props to `Page` to handle repeated code (rendering `<Spinner>` or `<Message>`), but seemed like that added complexity to the `Page` component without much benefit. Sticking to only using an additional prop for `<PageNotFound>` or anything that relies on permissions being loaded first.


## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
