### PR TITLE
build: [MLG-305] Check for supported go version at make.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,9 +18,19 @@ get-deps-pip:
 
 .PHONY: get-deps-go
 get-deps-go:
+	$(MAKE) go-version-check
 	$(MAKE) get-deps-master
 	$(MAKE) get-deps-agent
 	$(MAKE) get-deps-proto
+
+# Go versions may look like goM, goM.N, or goM.N.P. Only 1.18.* is supported.
+supported_go_minor_version = go1.18
+system_go_version := $(shell go version | sed 's/.*\(go[[:digit:]][[:digit:].]*\).*/\1/')
+.PHONY: go-version-check
+go-version-check:
+	@: $(if $(findstring $(supported_go_minor_version), $(system_go_version)), \
+				, \
+				$(error go version $(system_go_version) not supported. Must use $(supported_go_minor_version).x))
 
 .PHONY: package
 package:


### PR DESCRIPTION



## Description
Determined cannot be currently built with go1.20. This adds a target in the Makefile that checks the system go version against the supported go version and errors if the system go is not supported.



## Test Plan

This was tested by hand against go1.18.10, go1.19.5, and go1.20.

## Commentary (optional)
This is just a simple fix for an existing problem. It temporizes any decisions about more generally checking requirements, and also leaves for a future commit updates to the library to make determined buildable with more recent go.


## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket

MLG-305

<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
