### PR TITLE
feat: max-length-based searcher API

### DIFF
--- a/examples/tutorials/core_api/1_metrics.py
+++ b/examples/tutorials/core_api/1_metrics.py
@@ -25,7 +25,7 @@ def main(core_context, increment_by):
                 steps_completed=steps_completed, metrics={"x": x}
             )
     # NEW: report a "validation" metric at the end.
-    core_context.train.report_validation_metrics(steps_completed=steps_completed, metrics={"x": x})
+    core_context.train.report_metrics(steps_completed=steps_completed, metrics={"x": x})
 
 
 if __name__ == "__main__":

--- a/harness/determined/core/__init__.py
+++ b/harness/determined/core/__init__.py
@@ -10,18 +10,19 @@ from determined.core._train import (
     DummyTrainContext,
     EarlyExitReason,
 )
+from determined.core._preempt import (
+    DummyPreemptContext,
+    PreemptContext,
+    _PreemptionWatcher,
+    PreemptMode,
+)
 from determined.core._searcher import (
     DummySearcherContext,
     SearcherMode,
     SearcherContext,
     SearcherOperation,
     Unit,
+    _parse_searcher_max_length,
     _parse_searcher_units,
-)
-from determined.core._preempt import (
-    DummyPreemptContext,
-    PreemptContext,
-    _PreemptionWatcher,
-    PreemptMode,
 )
 from determined.core._context import Context, init, _dummy_init

--- a/harness/determined/core/_context.py
+++ b/harness/determined/core/_context.py
@@ -193,13 +193,19 @@ def init(
             tensorboard_manager,
             tbd_writer,
         )
+
+        preempt = core.PreemptContext(session, info.allocation_id, distributed, preempt_mode)
+
         units = core._parse_searcher_units(info.trial._config)
+        max_length = core._parse_searcher_max_length(info.trial._config)
         searcher = core.SearcherContext(
             session,
             distributed,
+            preempt,
             info.trial.trial_id,
             info.trial._trial_run_id,
             info.allocation_id,
+            max_length,
             units,
         )
 
@@ -218,8 +224,6 @@ def init(
             tensorboard_mode,
             tensorboard_manager,
         )
-
-        preempt = core.PreemptContext(session, info.allocation_id, distributed, preempt_mode)
 
     else:
         # TODO: support checkpointing for non-trial tasks.

--- a/harness/determined/core/_preempt.py
+++ b/harness/determined/core/_preempt.py
@@ -167,6 +167,7 @@ class PreemptContext:
         if self._dist.get_rank() == 0 or self._preempt_mode == PreemptMode.WorkersAskMaster:
             self._watcher = _PreemptionWatcher(session, allocation_id)
         self._ack_sent = False
+        self._searcher_wants_preempt = False
 
     def start(self) -> "PreemptContext":
         if self._started:
@@ -219,7 +220,7 @@ class PreemptContext:
             )
         if self._watcher is not None:
             # Have watcher; either this is the chief or we are in WorkersAskMaster mode.
-            out = self._watcher.should_preempt()
+            out = self._watcher.should_preempt() or self._searcher_wants_preempt
             if auto_ack and out and not self._ack_sent:
                 # Tell the master that user code has received the preemption signal.
                 self.acknowledge_preemption_signal()

--- a/harness/determined/layers/_workload_sequencer.py
+++ b/harness/determined/layers/_workload_sequencer.py
@@ -373,7 +373,7 @@ class WorkloadSequencer(workload.Source):
             ):
                 yield from self.validate(None)
 
-            for op in self.core_context.searcher.operations(core.SearcherMode.ChiefOnly):
+            for op in self.core_context.searcher._operations(core.SearcherMode.ChiefOnly):
                 while self.batches_until_op_complete(op) > 0:
                     # Do some training.
                     yield from self.train(


### PR DESCRIPTION
Every training loop I know of (except ours) is based on a finite maximum length, with possible early stopping.

It would be nice if our searchers also behaved the same way.  It turns out that we can basically shim our existing searchers into this behavior, and pass the "searcher-decided-stop" signal through the should_preempt signal, rather than having it be separate.

Long-term, it would be nice if searchers examined validation metrics rather than requiring explicit report_metrics() calls.  It would also be nice if progress were not reported through the searcher... although it might be hard to calculate progress if there's no single "brain" with an endstate goal for the experiment to know how much total work is supposed to be done.  Perhaps, experiments should have their own progress that is separate from a single tasks' progress?

This API might need more thought before we jump ship on our current API. Not because I like our current API, but because jumping ship is expensive and we should be sure when we do it.