### PR TITLE
fix: satisfy lint for `stacklevel` to `warnings.warn`

### DIFF
--- a/cli/determined_cli/__init__.py
+++ b/cli/determined_cli/__init__.py
@@ -4,5 +4,7 @@ from determined.cli import *  # noqa
 from .__version__ import __version__
 
 warnings.warn(
-    "determined_cli package is deprecated, please use determined.cli instead.", FutureWarning
+    "determined_cli package is deprecated, please use determined.cli instead.",
+    FutureWarning,
+    stacklevel=2,
 )

--- a/common/determined_common/__init__.py
+++ b/common/determined_common/__init__.py
@@ -4,5 +4,7 @@ from determined.common import *  # noqa
 from .__version__ import __version__
 
 warnings.warn(
-    "determined_common package is deprecated, please use determined.common instead.", FutureWarning
+    "determined_common package is deprecated, please use determined.common instead.",
+    FutureWarning,
+    stacklevel=2,
 )

--- a/deploy/determined_deploy/__init__.py
+++ b/deploy/determined_deploy/__init__.py
@@ -4,5 +4,7 @@ from determined.deploy import *  # noqa
 from .__version__ import __version__
 
 warnings.warn(
-    "determined_deploy package is deprecated, please use determined.deploy instead.", FutureWarning
+    "determined_deploy package is deprecated, please use determined.deploy instead.",
+    FutureWarning,
+    stacklevel=2,
 )

--- a/harness/determined/common/experimental/checkpoint/_checkpoint.py
+++ b/harness/determined/common/experimental/checkpoint/_checkpoint.py
@@ -307,6 +307,7 @@ class Checkpoint:
             "  - det.keras.load_model_from_checkpoint_path()\n"
             "  - det.estimator.load_estimator_from_checkpoint_path()\n",
             FutureWarning,
+            stacklevel=2,
         )
         ckpt_path = self.download(path)
         return Checkpoint.load_from_path(ckpt_path, tags=tags, **kwargs)
@@ -394,6 +395,7 @@ class Checkpoint:
             "  - det.keras.load_model_from_checkpoint_path()\n"
             "  - det.estimator.load_estimator_from_checkpoint_path()\n",
             FutureWarning,
+            stacklevel=2,
         )
         checkpoint_dir = pathlib.Path(path)
         metadata = Checkpoint._parse_metadata(checkpoint_dir)
@@ -436,6 +438,7 @@ class Checkpoint:
             "Checkpoint.parse_metadata() is deprecated and will be removed from the public API "
             "in a future version",
             FutureWarning,
+            stacklevel=2,
         )
         return Checkpoint._parse_metadata(directory)
 
@@ -464,6 +467,7 @@ class Checkpoint:
             "Checkpoint.get_type() is deprecated and will be removed from the public API "
             "in a future version",
             FutureWarning,
+            stacklevel=2,
         )
         return Checkpoint._get_type(metadata)
 
@@ -524,5 +528,6 @@ class Checkpoint:
             "Checkpoint.from_json() is deprecated and will be removed from the public API "
             "in a future version",
             FutureWarning,
+            stacklevel=2,
         )
         return cls._from_json(data, session)

--- a/harness/determined/common/experimental/determined.py
+++ b/harness/determined/common/experimental/determined.py
@@ -272,6 +272,7 @@ class Determined:
             "Please call Determined.get_model() with either a string-type name or "
             "an integer-type model ID.",
             FutureWarning,
+            stacklevel=2,
         )
         return self.get_model(model_id)
 

--- a/harness/determined/common/experimental/model.py
+++ b/harness/determined/common/experimental/model.py
@@ -96,6 +96,7 @@ class ModelVersion:
             "ModelVersion.from_json() is deprecated and will be removed from the public API "
             "in a future version",
             FutureWarning,
+            stacklevel=2,
         )
         return cls._from_json(data, session)
 
@@ -391,6 +392,7 @@ class Model:
             "Model.from_json() is deprecated and will be removed from the public API "
             "in a future version",
             FutureWarning,
+            stacklevel=2,
         )
         return cls._from_json(data, session)
 

--- a/harness/determined/deploy/cli.py
+++ b/harness/determined/deploy/cli.py
@@ -51,7 +51,9 @@ def main() -> None:
         parser.exit(2, "{}: no subcommand specified\n".format(parser.prog))
 
     warnings.warn(
-        "`det-deploy` executable is deprecated, please use `det deploy` instead.", FutureWarning
+        "`det-deploy` executable is deprecated, please use `det deploy` instead.",
+        FutureWarning,
+        stacklevel=2,
     )
 
     parsed_args.func(parsed_args)

--- a/harness/determined/experimental/client.py
+++ b/harness/determined/experimental/client.py
@@ -333,6 +333,7 @@ def get_model_by_id(model_id: int) -> Model:
         "Please call client.get_model() with either a string-type name or "
         "an integer-type model ID.",
         FutureWarning,
+        stacklevel=2,
     )
     assert _determined is not None
     return _determined.get_model(model_id)

--- a/harness/determined/pytorch/_pytorch_trial.py
+++ b/harness/determined/pytorch/_pytorch_trial.py
@@ -46,6 +46,7 @@ class PyTorchTrialController(det.TrialController):
                     "The on_checkpoint_end callback is deprecated, please use "
                     "on_checkpoint_write_end instead.",
                     FutureWarning,
+                    stacklevel=2,
                 )
 
         if len(self.context.models) == 0:
@@ -299,6 +300,7 @@ class PyTorchTrialController(det.TrialController):
                             "Only the chief worker's training metrics are being reported, due "
                             "to setting average_training_metrics to False.",
                             UserWarning,
+                            stacklevel=2,
                         )
                 elif w.kind == workload.Workload.Kind.COMPUTE_VALIDATION_METRICS:
                     action = "validation"

--- a/harness/determined/pytorch/deepspeed/_deepspeed_trial.py
+++ b/harness/determined/pytorch/deepspeed/_deepspeed_trial.py
@@ -53,6 +53,7 @@ class DeepSpeedTrialController(det.TrialController):
                     "The on_checkpoint_end callback is deprecated, please use "
                     "on_checkpoint_write_end instead",
                     FutureWarning,
+                    stacklevel=2,
                 )
 
         if len(self.context.models) == 0:


### PR DESCRIPTION

## Description

According to the latest version of `flake8-bugbear`, a `stacklevel` argument should be provided to `warnings.warn`, and it should be at least 2 (otherwise the warning just shows the line of the warning call itself, which is not that helpful).

## Test plan

- [x] run `make -C cli check` before and after the change, with `flake8-bugbear` upgraded