### PR TITLE
chore: remove dashboard feature switch

### DIFF
--- a/webui/react/src/components/JupyterLabButton.tsx
+++ b/webui/react/src/components/JupyterLabButton.tsx
@@ -3,14 +3,16 @@ import React from 'react';
 import Button from 'components/kit/Button';
 import Tooltip from 'components/kit/Tooltip';
 import useModalJupyterLab from 'hooks/useModal/JupyterLab/useModalJupyterLab';
+import { Workspace } from 'types';
 
 interface Props {
   enabled?: boolean;
+  workspace?: Workspace;
 }
 
-const JupyterLabButton: React.FC<Props> = ({ enabled }: Props) => {
+const JupyterLabButton: React.FC<Props> = ({ enabled, workspace }: Props) => {
   const { contextHolder: modalJupyterLabContextHolder, modalOpen: openJupyterLabModal } =
-    useModalJupyterLab({});
+    useModalJupyterLab({ workspace });
 
   return (
     <>

--- a/webui/react/src/components/JupyterLabButton.tsx
+++ b/webui/react/src/components/JupyterLabButton.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+
+import Button from 'components/kit/Button';
+import Tooltip from 'components/kit/Tooltip';
+import useModalJupyterLab from 'hooks/useModal/JupyterLab/useModalJupyterLab';
+
+interface Props {
+  hasPermissions?: boolean;
+}
+
+const JupyterLabButton: React.FC<Props> = ({ hasPermissions }: Props) => {
+  const { contextHolder: modalJupyterLabContextHolder, modalOpen: openJupyterLabModal } =
+    useModalJupyterLab({});
+
+  return (
+    <>
+      {hasPermissions ? (
+        <Button onClick={() => openJupyterLabModal()}>Launch JupyterLab</Button>
+      ) : (
+        <Tooltip placement="leftBottom" title="You do not have permission to launch JupyterLab">
+          <div>
+            <Button disabled>Launch JupyterLab</Button>
+          </div>
+        </Tooltip>
+      )}
+      {modalJupyterLabContextHolder}
+    </>
+  );
+};
+
+export default JupyterLabButton;

--- a/webui/react/src/components/JupyterLabButton.tsx
+++ b/webui/react/src/components/JupyterLabButton.tsx
@@ -5,16 +5,16 @@ import Tooltip from 'components/kit/Tooltip';
 import useModalJupyterLab from 'hooks/useModal/JupyterLab/useModalJupyterLab';
 
 interface Props {
-  hasPermissions?: boolean;
+  enabled?: boolean;
 }
 
-const JupyterLabButton: React.FC<Props> = ({ hasPermissions }: Props) => {
+const JupyterLabButton: React.FC<Props> = ({ enabled }: Props) => {
   const { contextHolder: modalJupyterLabContextHolder, modalOpen: openJupyterLabModal } =
     useModalJupyterLab({});
 
   return (
     <>
-      {hasPermissions ? (
+      {enabled ? (
         <Button onClick={() => openJupyterLabModal()}>Launch JupyterLab</Button>
       ) : (
         <Tooltip placement="leftBottom" title="You do not have permission to launch JupyterLab">

--- a/webui/react/src/components/NavigationSideBar.tsx
+++ b/webui/react/src/components/NavigationSideBar.tsx
@@ -10,8 +10,6 @@ import Button from 'components/kit/Button';
 import Tooltip from 'components/kit/Tooltip';
 import Link, { Props as LinkProps } from 'components/Link';
 import AvatarCard from 'components/UserAvatarCard';
-import useFeature from 'hooks/useFeature';
-import useModalJupyterLab from 'hooks/useModal/JupyterLab/useModalJupyterLab';
 import useModalWorkspaceCreate from 'hooks/useModal/Workspace/useModalWorkspaceCreate';
 import usePermissions from 'hooks/usePermissions';
 import { SettingsConfig, useSettings } from 'hooks/useSettings';
@@ -128,11 +126,7 @@ const NavigationSideBar: React.FC = () => {
   const info = Loadable.getOrElse(initInfo, useDeterminedInfo());
   const { ui } = useUI();
 
-  const dashboardEnabled = useFeature().isOn('dashboard');
-
   const { settings, updateSettings } = useSettings<Settings>(settingsConfig);
-  const { contextHolder: modalJupyterLabContextHolder, modalOpen: openJupyterLabModal } =
-    useModalJupyterLab({});
   const { contextHolder: modalWorkspaceCreateContextHolder, modalOpen: openWorkspaceCreateModal } =
     useModalWorkspaceCreate();
   const showNavigation = isAuthenticated && ui.showChrome;
@@ -150,7 +144,7 @@ const NavigationSideBar: React.FC = () => {
       : [];
     const dashboardTopNav = [{ icon: 'home', label: 'Home', path: paths.dashboard() }];
     const topItems = [
-      ...(dashboardEnabled ? dashboardTopNav.concat(topNav) : topNav),
+      ...dashboardTopNav.concat(topNav),
       { icon: 'model', label: 'Model Registry', path: paths.modelList() },
       { icon: 'tasks', label: 'Tasks', path: paths.taskList() },
       { icon: 'cluster', label: 'Cluster', path: paths.cluster() },
@@ -182,7 +176,7 @@ const NavigationSideBar: React.FC = () => {
       ],
       top: topItems,
     };
-  }, [canAccessUncategorized, canEditWebhooks, info.branding, dashboardEnabled]);
+  }, [canAccessUncategorized, canEditWebhooks, info.branding]);
 
   const handleCollapse = useCallback(() => {
     updateSettings({ navbarCollapsed: !settings.navbarCollapsed });
@@ -244,24 +238,6 @@ const NavigationSideBar: React.FC = () => {
           </Dropdown>
         </header>
         <main>
-          {dashboardEnabled ? null : (
-            <section className={css.launch}>
-              <div className={css.launchBlock}>
-                <div className={css.launchButton}>
-                  <Button block ghost onClick={() => openJupyterLabModal()}>
-                    Launch JupyterLab
-                  </Button>
-                </div>
-                {settings.navbarCollapsed ? (
-                  <div className={css.launchIcon}>
-                    <Button type="text" onClick={() => openJupyterLabModal()}>
-                      <Icon name="jupyter-lab" />
-                    </Button>
-                  </div>
-                ) : null}
-              </div>
-            </section>
-          )}
           <section className={css.top}>
             {menuConfig.top.map((config) => (
               <NavigationItem
@@ -365,7 +341,6 @@ const NavigationSideBar: React.FC = () => {
             )}
           </div>
         </footer>
-        {modalJupyterLabContextHolder}
         {modalWorkspaceCreateContextHolder}
       </nav>
     </CSSTransition>

--- a/webui/react/src/components/NavigationTabbar.tsx
+++ b/webui/react/src/components/NavigationTabbar.tsx
@@ -5,8 +5,6 @@ import ActionSheet from 'components/ActionSheet';
 import DynamicIcon from 'components/DynamicIcon';
 import Link, { Props as LinkProps } from 'components/Link';
 import AvatarCard from 'components/UserAvatarCard';
-import useFeature from 'hooks/useFeature';
-import useModalJupyterLab from 'hooks/useModal/JupyterLab/useModalJupyterLab';
 import useModalWorkspaceCreate from 'hooks/useModal/Workspace/useModalWorkspaceCreate';
 import usePermissions from 'hooks/usePermissions';
 import { handlePath, paths } from 'routes/utils';
@@ -64,11 +62,8 @@ const NavigationTabbar: React.FC = () => {
 
   const [isShowingOverflow, setIsShowingOverflow] = useState(false);
   const [isShowingPinnedWorkspaces, setIsShowingPinnedWorkspaces] = useState(false);
-  const { contextHolder: modalJupyterLabContextHolder, modalOpen: openJupyterLabModal } =
-    useModalJupyterLab({});
 
   const showNavigation = isAuthenticated && ui.showChrome;
-  const dashboardEnabled = useFeature().isOn('dashboard');
 
   const { canCreateWorkspace } = usePermissions();
   const { contextHolder: modalWorkspaceCreateContextHolder, modalOpen: openWorkspaceCreateModal } =
@@ -90,10 +85,6 @@ const NavigationTabbar: React.FC = () => {
     setIsShowingOverflow(false);
     setIsShowingPinnedWorkspaces(false);
   }, []);
-  const handleLaunchJupyterLab = useCallback(() => {
-    setIsShowingOverflow(false);
-    openJupyterLabModal();
-  }, [openJupyterLabModal]);
 
   const handlePathUpdate = useCallback((e: AnyMouseEvent, path?: string) => {
     handlePath(e, { path });
@@ -120,14 +111,6 @@ const NavigationTabbar: React.FC = () => {
       onClick: (e: AnyMouseEvent) => handlePathUpdate(e, paths.logout()),
     },
   ];
-
-  if (!dashboardEnabled) {
-    overflowActionsTop.push({
-      icon: 'jupyter-lab',
-      label: 'Launch JupyterLab',
-      onClick: () => handleLaunchJupyterLab(),
-    });
-  }
 
   const overflowActionsBottom = [
     {
@@ -161,14 +144,8 @@ const NavigationTabbar: React.FC = () => {
   return (
     <nav className={css.base}>
       <div className={css.toolbar}>
-        {dashboardEnabled ? (
-          <>
-            <ToolbarItem icon="home" label="Home" path={paths.dashboard()} />
-            <ToolbarItem icon="experiment" label="Uncategorized" path={paths.uncategorized()} />
-          </>
-        ) : (
-          <ToolbarItem icon="experiment" label="Uncategorized" path={paths.uncategorized()} />
-        )}
+        <ToolbarItem icon="home" label="Home" path={paths.dashboard()} />
+        <ToolbarItem icon="experiment" label="Uncategorized" path={paths.uncategorized()} />
         <ToolbarItem icon="model" label="Model Registry" path={paths.modelList()} />
         <ToolbarItem icon="tasks" label="Tasks" path={paths.taskList()} />
         <ToolbarItem icon="cluster" label="Cluster" path={paths.cluster()} status={clusterStatus} />
@@ -216,7 +193,6 @@ const NavigationTabbar: React.FC = () => {
         show={isShowingOverflow}
         onCancel={handleActionSheetCancel}
       />
-      {modalJupyterLabContextHolder}
       {modalWorkspaceCreateContextHolder}
     </nav>
   );

--- a/webui/react/src/components/TaskList.tsx
+++ b/webui/react/src/components/TaskList.tsx
@@ -635,7 +635,7 @@ const TaskList: React.FC<Props> = ({ workspace }: Props) => {
             <FilterCounter activeFilterCount={filterCount} onReset={resetFilters} />
           )}
           <JupyterLabButton
-            hasPermissions={workspace ? canCreateWorkspaceNSC({ workspace }) : canCreateNSC}
+            enabled={workspace ? canCreateWorkspaceNSC({ workspace }) : canCreateNSC}
           />
         </Space>
       }

--- a/webui/react/src/components/TaskList.tsx
+++ b/webui/react/src/components/TaskList.tsx
@@ -636,6 +636,7 @@ const TaskList: React.FC<Props> = ({ workspace }: Props) => {
           )}
           <JupyterLabButton
             enabled={workspace ? canCreateWorkspaceNSC({ workspace }) : canCreateNSC}
+            workspace={workspace}
           />
         </Space>
       }

--- a/webui/react/src/components/TaskList.tsx
+++ b/webui/react/src/components/TaskList.tsx
@@ -11,8 +11,8 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import Badge, { BadgeType } from 'components/Badge';
 import FilterCounter from 'components/FilterCounter';
 import Grid from 'components/Grid';
+import JupyterLabButton from 'components/JupyterLabButton';
 import Button from 'components/kit/Button';
-import Tooltip from 'components/kit/Tooltip';
 import Link from 'components/Link';
 import Page from 'components/Page';
 import InteractiveTable, {
@@ -42,7 +42,6 @@ import settingsConfig, {
   Settings,
 } from 'components/TaskList.settings';
 import { commandTypeToLabel } from 'constants/states';
-import useModalJupyterLab from 'hooks/useModal/JupyterLab/useModalJupyterLab';
 import usePermissions from 'hooks/usePermissions';
 import { UpdateSettings, useSettings } from 'hooks/useSettings';
 import { paths } from 'routes/utils';
@@ -116,8 +115,6 @@ const TaskList: React.FC<Props> = ({ workspace }: Props) => {
   const [tasks, setTasks] = useState<CommandTask[] | undefined>(undefined);
   const [sourcesModal, setSourcesModal] = useState<SourceInfo>();
   const pageRef = useRef<HTMLElement>(null);
-  const { contextHolder: modalJupyterLabContextHolder, modalOpen: openJupyterLabModal } =
-    useModalJupyterLab({ workspace: workspace });
   const workspaceId = useMemo(() => workspace?.id.toString() ?? 'global', [workspace?.id]);
   const stgsConfig = useMemo(() => settingsConfig(workspaceId), [workspaceId]);
   const { activeSettings, resetSettings, settings, updateSettings } =
@@ -628,19 +625,6 @@ const TaskList: React.FC<Props> = ({ workspace }: Props) => {
     [user, handleActionComplete],
   );
 
-  const JupyterLabButton = () => {
-    const hasNSCPermissions = workspace ? canCreateWorkspaceNSC({ workspace }) : canCreateNSC;
-    return hasNSCPermissions ? (
-      <Button onClick={() => openJupyterLabModal()}>Launch JupyterLab</Button>
-    ) : (
-      <Tooltip placement="leftBottom" title="User lacks permission to create NSC">
-        <div>
-          <Button disabled>Launch JupyterLab</Button>
-        </div>
-      </Tooltip>
-    );
-  };
-
   return (
     <Page
       containerRef={pageRef}
@@ -650,7 +634,9 @@ const TaskList: React.FC<Props> = ({ workspace }: Props) => {
           {filterCount > 0 && (
             <FilterCounter activeFilterCount={filterCount} onReset={resetFilters} />
           )}
-          <JupyterLabButton />
+          <JupyterLabButton
+            hasPermissions={workspace ? canCreateWorkspaceNSC({ workspace }) : canCreateNSC}
+          />
         </Space>
       }
       title="Tasks">
@@ -708,7 +694,6 @@ const TaskList: React.FC<Props> = ({ workspace }: Props) => {
           </Grid>
         </div>
       </Modal>
-      {modalJupyterLabContextHolder}
     </Page>
   );
 };

--- a/webui/react/src/hooks/useFeature.ts
+++ b/webui/react/src/hooks/useFeature.ts
@@ -10,7 +10,6 @@ export type ValidFeature =
   | 'mock_permissions_read'
   | 'trials_comparison'
   | 'mock_permissions_all'
-  | 'dashboard'
   | 'chart'
   | 'model_rbac';
 

--- a/webui/react/src/pages/Dashboard.tsx
+++ b/webui/react/src/pages/Dashboard.tsx
@@ -2,10 +2,9 @@ import React, { useCallback, useEffect, useState } from 'react';
 
 import ExperimentIcons from 'components/ExperimentIcons';
 import Grid, { GridMode } from 'components/Grid';
+import JupyterLabButton from 'components/JupyterLabButton';
 import Breadcrumb from 'components/kit/Breadcrumb';
-import Button from 'components/kit/Button';
 import Empty from 'components/kit/Empty';
-import Tooltip from 'components/kit/Tooltip';
 import Link from 'components/Link';
 import Page from 'components/Page';
 import ProjectCard from 'components/ProjectCard';
@@ -17,7 +16,6 @@ import {
   taskNameRenderer,
   taskTypeRenderer,
 } from 'components/Table/Table';
-import useModalJupyterLab from 'hooks/useModal/JupyterLab/useModalJupyterLab';
 import usePermissions from 'hooks/usePermissions';
 import { paths } from 'routes/utils';
 import {
@@ -58,8 +56,6 @@ const Dashboard: React.FC = () => {
     Loaded: (cUser) => cUser,
     NotLoaded: () => undefined,
   });
-  const { contextHolder: modalJupyterLabContextHolder, modalOpen: openJupyterLabModal } =
-    useModalJupyterLab({});
   const { canCreateNSC } = usePermissions();
   type Submission = ExperimentItem & CommandTask;
 
@@ -178,28 +174,16 @@ const Dashboard: React.FC = () => {
     };
   }, [canceler, stopPolling]);
 
-  const JupyterLabButton = () => {
-    return !canCreateNSC ? (
-      <Button onClick={() => openJupyterLabModal()}>Launch JupyterLab</Button>
-    ) : (
-      <Tooltip placement="leftBottom" title="User lacks permission to create NSC">
-        <div>
-          <Button disabled>Launch JupyterLab</Button>
-        </div>
-      </Tooltip>
-    );
-  };
-
   if (projectsLoading && submissionsLoading) {
     return (
-      <Page options={<JupyterLabButton />} title="Home">
+      <Page options={<JupyterLabButton hasPermissions={canCreateNSC} />} title="Home">
         <Spinner center />
       </Page>
     );
   }
 
   return (
-    <Page options={<JupyterLabButton />} title="Home">
+    <Page options={<JupyterLabButton hasPermissions={canCreateNSC} />} title="Home">
       {projectsLoading ? (
         <Section>
           <Spinner center />
@@ -316,7 +300,6 @@ const Dashboard: React.FC = () => {
           />
         )}
       </Section>
-      {modalJupyterLabContextHolder}
     </Page>
   );
 };

--- a/webui/react/src/pages/Dashboard.tsx
+++ b/webui/react/src/pages/Dashboard.tsx
@@ -176,14 +176,14 @@ const Dashboard: React.FC = () => {
 
   if (projectsLoading && submissionsLoading) {
     return (
-      <Page options={<JupyterLabButton hasPermissions={canCreateNSC} />} title="Home">
+      <Page options={<JupyterLabButton enabled={canCreateNSC} />} title="Home">
         <Spinner center />
       </Page>
     );
   }
 
   return (
-    <Page options={<JupyterLabButton hasPermissions={canCreateNSC} />} title="Home">
+    <Page options={<JupyterLabButton enabled={canCreateNSC} />} title="Home">
       {projectsLoading ? (
         <Section>
           <Spinner center />

--- a/webui/react/src/pages/DefaultRoute.tsx
+++ b/webui/react/src/pages/DefaultRoute.tsx
@@ -2,18 +2,15 @@ import React from 'react';
 import { Navigate } from 'react-router-dom';
 
 import useFeature from 'hooks/useFeature';
-import { dashboardDefaultRoute, defaultRoute, rbacDefaultRoute } from 'routes';
+import { dashboardDefaultRoute, rbacDefaultRoute } from 'routes';
 
 const Default: React.FC = () => {
-  const dashboardEnabled = useFeature().isOn('dashboard');
   const rbacEnabled = useFeature().isOn('rbac');
 
-  if (dashboardEnabled) {
-    return <Navigate to={dashboardDefaultRoute.path} />;
-  } else if (rbacEnabled) {
+  if (rbacEnabled) {
     return <Navigate to={rbacDefaultRoute.path} />;
   } else {
-    return <Navigate to={defaultRoute.path} />;
+    return <Navigate to={dashboardDefaultRoute.path} />;
   }
 };
 

--- a/webui/react/src/routes/index.tsx
+++ b/webui/react/src/routes/index.tsx
@@ -60,7 +60,7 @@ const routeComponentMap: Record<string, React.ReactNode> = {
   workspaceList: <WorkspaceList />,
 };
 
-const defaultRouteId = 'uncategorized';
+const defaultRouteId = 'default';
 const rbacDefaultRouteId = 'workspaceList';
 const dashboardDefaultRouteId = 'dashboard';
 


### PR DESCRIPTION
## Description

https://determinedai.atlassian.net/browse/WEB-860


## Test Plan

Dashboard should appear as an option in the navigation bar, and should be the default route (unless rbac is on, in which case the default route is the workspaces list page).

## Commentary (optional)

Haven't received design approval on the changes from WEB-814, not sure if we should wait on that to merge this PR to release the dashboard.


## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
