### PR TITLE
fix: prevent agent startup on startup script non-zero exit

### DIFF
--- a/agent/packaging/entrypoint.sh
+++ b/agent/packaging/entrypoint.sh
@@ -1,11 +1,15 @@
 #!/bin/bash
 
-chmod +x /usr/local/determined/container_startup_script
-/usr/local/determined/container_startup_script
-exit_code=$?
-if [ $exit_code -ne 0 ]; then
-    echo "container_startup_script failed with exit code $exit_code" >&2
-    exit 1
+container_startup_script="/usr/local/bin/container_startup.sh"
+
+if [ -f "$container_startup_script" ]; then
+    chmod +x $container_startup_script
+    $container_startup_script
+    exit_code=$?
+    if [ $exit_code -ne 0 ]; then
+        echo "container_startup_script failed with exit code $exit_code" >&2
+        exit 1
+    fi
 fi
 
 exec /usr/bin/determined-agent "$@"

--- a/agent/packaging/entrypoint.sh
+++ b/agent/packaging/entrypoint.sh
@@ -9,6 +9,8 @@ if [ -f "$container_startup_script" ]; then
     if [ $exit_code -ne 0 ]; then
         echo "container_startup_script failed with exit code $exit_code" >&2
         exit 1
+    else
+        echo "container_startup_script succeeded"
     fi
 fi
 

--- a/agent/packaging/entrypoint.sh
+++ b/agent/packaging/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-container_startup_script="/usr/local/bin/container_startup.sh"
+container_startup_script="/usr/local/determined/container_startup_script"
 
 if [ -f "$container_startup_script" ]; then
     chmod +x $container_startup_script

--- a/agent/packaging/entrypoint.sh
+++ b/agent/packaging/entrypoint.sh
@@ -2,5 +2,10 @@
 
 chmod +x /usr/local/determined/container_startup_script
 /usr/local/determined/container_startup_script
+exit_code=$?
+if [ $exit_code -ne 0 ]; then
+    echo "container_startup_script failed with exit code $exit_code" >&2
+    exit 1
+fi
 
 exec /usr/bin/determined-agent "$@"

--- a/master/internal/rm/agentrm/provisioner/agent_setup_test.go
+++ b/master/internal/rm/agentrm/provisioner/agent_setup_test.go
@@ -51,6 +51,8 @@ exit_code=$?
 if [ $exit_code -ne 0 ]; then
     echo "startup_script failed with exit code $exit_code" >&2
     exit 1
+else
+    echo "startup_script succeeded"
 fi
 
 echo  | base64 --decode >/usr/local/determined/agent.yaml

--- a/master/internal/rm/agentrm/provisioner/agent_setup_test.go
+++ b/master/internal/rm/agentrm/provisioner/agent_setup_test.go
@@ -47,6 +47,11 @@ cat /usr/local/determined/startup_script
 echo "#### PRINTING STARTUP SCRIPT END ####"
 chmod +x /usr/local/determined/startup_script
 /usr/local/determined/startup_script
+exit_code=$?
+if [ $exit_code -ne 0 ]; then
+    echo "startup_script failed with exit code $exit_code" >&2
+    exit 1
+fi
 
 echo  | base64 --decode >/usr/local/determined/agent.yaml
 echo "#### PRINTING CONFIG FILE START ####"

--- a/master/static/srv/agent_setup_script.sh.template
+++ b/master/static/srv/agent_setup_script.sh.template
@@ -9,6 +9,11 @@ cat /usr/local/determined/startup_script
 echo "#### PRINTING STARTUP SCRIPT END ####"
 chmod +x /usr/local/determined/startup_script
 /usr/local/determined/startup_script
+exit_code=$?
+if [ $exit_code -ne 0 ]; then
+    echo "startup_script failed with exit code $exit_code" >&2
+    exit 1
+fi
 
 echo {{.ConfigFileBase64}} | base64 --decode >/usr/local/determined/agent.yaml
 echo "#### PRINTING CONFIG FILE START ####"

--- a/master/static/srv/agent_setup_script.sh.template
+++ b/master/static/srv/agent_setup_script.sh.template
@@ -13,6 +13,8 @@ exit_code=$?
 if [ $exit_code -ne 0 ]; then
     echo "startup_script failed with exit code $exit_code" >&2
     exit 1
+else
+    echo "startup_script succeeded"
 fi
 
 echo {{.ConfigFileBase64}} | base64 --decode >/usr/local/determined/agent.yaml


### PR DESCRIPTION
## Description


DET-8747
found a sort of related issue that only wwas exposed when we start failing agents: DET-8929

<!---
Lead with the intended commit body in this description field. For breaking
changes, please include "BREAKING CHANGE:" at the beginning of your commit
body.  At a minimum, this section should include a bracketed reference to the
Jira ticket, e.g. "[DET-1234]". When squash-and-merging, copy this directly
into the description field.
-->



## Test Plan

I have not tested on GCP but the changes here are provider agnostic. let me know if you think it should be tested on GCP

- run agents with failing startup and container_startup_scripts with failing scripts on one RP and no scripts on another RP prior to this pr eg 

```
  startup_script: |
    echo "this is startup script"
    touch /tmp/sssc-$(date)
    echo "failign now"
    exit 3
  container_startup_script: |
    echo "this is startup script"
    touch /tmp/sssc-$(date)
    echo "failign now"
    exit 3
```

see that the agents continue to come up and function despite the script being executed

- apply the changes and deploy another aws cluster with the same scripts and see the agent doesn't come up


<!---
Describe the situations in which you've tested your change, and/or a screenshot
as appropriate.  Reviewers may ask questions about this test plan to ensure
adequate manual coverage of changes.
-->


![Screen Shot 2023-02-14 at 14 46 10](https://user-images.githubusercontent.com/12127420/218847053-34cf19e1-75c8-4638-b87f-896cf5bc2b1e.jpg)


## Commentary (optional)



<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
