### PR TITLE
fix: Various chart axis + checkpoint bugs [WEB-911]

### DIFF
--- a/master/internal/api_trials.go
+++ b/master/internal/api_trials.go
@@ -635,7 +635,7 @@ func (a *apiServer) GetTrial(ctx context.Context, req *apiv1.GetTrialRequest) (
 
 func (a *apiServer) formatMetricsBatch(
 	m *apiv1.SummarizedMetric, metricSeries []lttb.Point,
-) *apiv1.SummarizedMetric {
+) {
 	for _, in := range metricSeries {
 		out := apiv1.DataPoint{
 			Batches: int32(in.X),
@@ -643,7 +643,6 @@ func (a *apiServer) formatMetricsBatch(
 		}
 		m.Data = append(m.Data, &out)
 	}
-	return m
 }
 
 func timeFromFloat64(ts float64) time.Time {
@@ -654,7 +653,7 @@ func timeFromFloat64(ts float64) time.Time {
 
 func (a *apiServer) formatMetricsTime(
 	m *apiv1.SummarizedMetric, metricSeries []lttb.Point,
-) *apiv1.SummarizedMetric {
+) {
 	for _, in := range metricSeries {
 		out := apiv1.DataPointTime{
 			Time:  timestamppb.New(timeFromFloat64(in.X)),
@@ -662,7 +661,6 @@ func (a *apiServer) formatMetricsTime(
 		}
 		m.Time = append(m.Time, &out)
 	}
-	return m
 }
 
 func (a *apiServer) MultiTrialSample(trialID int32, metricNames []string,
@@ -690,11 +688,11 @@ func (a *apiServer) MultiTrialSample(trialID int32, metricNames []string,
 				return nil, errors.Wrapf(err, "error fetching time series of training metrics")
 			}
 			metricSeriesTime = lttb.Downsample(metricSeriesTime, maxDatapoints, logScale)
-			m := a.formatMetricsTime(&metric, metricSeriesTime)
+			a.formatMetricsTime(&metric, metricSeriesTime)
 			metricSeriesBatch = lttb.Downsample(metricSeriesBatch, maxDatapoints, logScale)
-			m = a.formatMetricsBatch(&metric, metricSeriesBatch)
+			a.formatMetricsBatch(&metric, metricSeriesBatch)
 			if len(metricSeriesBatch) > 0 || len(metricSeriesTime) > 0 {
-				metrics = append(metrics, m)
+				metrics = append(metrics, &metric)
 			}
 		}
 		if (metricType == apiv1.MetricType_METRIC_TYPE_VALIDATION) ||
@@ -708,11 +706,11 @@ func (a *apiServer) MultiTrialSample(trialID int32, metricNames []string,
 				return nil, errors.Wrapf(err, "error fetching time series of validation metrics")
 			}
 			metricSeriesTime = lttb.Downsample(metricSeriesTime, maxDatapoints, logScale)
-			m := a.formatMetricsTime(&metric, metricSeriesTime)
+			a.formatMetricsTime(&metric, metricSeriesTime)
 			metricSeriesBatch = lttb.Downsample(metricSeriesBatch, maxDatapoints, logScale)
-			m = a.formatMetricsBatch(&metric, metricSeriesBatch)
+			a.formatMetricsBatch(&metric, metricSeriesBatch)
 			if len(metricSeriesBatch) > 0 || len(metricSeriesTime) > 0 {
-				metrics = append(metrics, m)
+				metrics = append(metrics, &metric)
 			}
 		}
 	}

--- a/master/internal/api_trials.go
+++ b/master/internal/api_trials.go
@@ -633,9 +633,9 @@ func (a *apiServer) GetTrial(ctx context.Context, req *apiv1.GetTrialRequest) (
 	return resp, nil
 }
 
-func (a *apiServer) appendToMetricsBatch(metrics []*apiv1.SummarizedMetric,
+func (a *apiServer) formatMetricsBatch(
 	m *apiv1.SummarizedMetric, metricSeries []lttb.Point,
-) []*apiv1.SummarizedMetric {
+) *apiv1.SummarizedMetric {
 	for _, in := range metricSeries {
 		out := apiv1.DataPoint{
 			Batches: int32(in.X),
@@ -643,10 +643,7 @@ func (a *apiServer) appendToMetricsBatch(metrics []*apiv1.SummarizedMetric,
 		}
 		m.Data = append(m.Data, &out)
 	}
-	if len(m.Data) > 0 {
-		return append(metrics, m)
-	}
-	return metrics
+	return m
 }
 
 func timeFromFloat64(ts float64) time.Time {
@@ -655,9 +652,9 @@ func timeFromFloat64(ts float64) time.Time {
 	return time.Unix(secs, nsecs)
 }
 
-func (a *apiServer) appendToMetricsTime(metrics []*apiv1.SummarizedMetric,
+func (a *apiServer) formatMetricsTime(
 	m *apiv1.SummarizedMetric, metricSeries []lttb.Point,
-) []*apiv1.SummarizedMetric {
+) *apiv1.SummarizedMetric {
 	for _, in := range metricSeries {
 		out := apiv1.DataPointTime{
 			Time:  timestamppb.New(timeFromFloat64(in.X)),
@@ -665,10 +662,7 @@ func (a *apiServer) appendToMetricsTime(metrics []*apiv1.SummarizedMetric,
 		}
 		m.Time = append(m.Time, &out)
 	}
-	if len(m.Time) > 0 {
-		return append(metrics, m)
-	}
-	return metrics
+	return m
 }
 
 func (a *apiServer) MultiTrialSample(trialID int32, metricNames []string,
@@ -696,9 +690,12 @@ func (a *apiServer) MultiTrialSample(trialID int32, metricNames []string,
 				return nil, errors.Wrapf(err, "error fetching time series of training metrics")
 			}
 			metricSeriesTime = lttb.Downsample(metricSeriesTime, maxDatapoints, logScale)
-			metrics = a.appendToMetricsTime(metrics, &metric, metricSeriesTime)
+			m := a.formatMetricsTime(&metric, metricSeriesTime)
 			metricSeriesBatch = lttb.Downsample(metricSeriesBatch, maxDatapoints, logScale)
-			metrics = a.appendToMetricsBatch(metrics, &metric, metricSeriesBatch)
+			m = a.formatMetricsBatch(&metric, metricSeriesBatch)
+			if len(metricSeriesBatch) > 0 || len(metricSeriesTime) > 0 {
+				metrics = append(metrics, m)
+			}
 		}
 		if (metricType == apiv1.MetricType_METRIC_TYPE_VALIDATION) ||
 			(metricType == apiv1.MetricType_METRIC_TYPE_UNSPECIFIED) {
@@ -711,9 +708,12 @@ func (a *apiServer) MultiTrialSample(trialID int32, metricNames []string,
 				return nil, errors.Wrapf(err, "error fetching time series of validation metrics")
 			}
 			metricSeriesTime = lttb.Downsample(metricSeriesTime, maxDatapoints, logScale)
-			metrics = a.appendToMetricsTime(metrics, &metric, metricSeriesTime)
+			m := a.formatMetricsTime(&metric, metricSeriesTime)
 			metricSeriesBatch = lttb.Downsample(metricSeriesBatch, maxDatapoints, logScale)
-			metrics = a.appendToMetricsBatch(metrics, &metric, metricSeriesBatch)
+			m = a.formatMetricsBatch(&metric, metricSeriesBatch)
+			if len(metricSeriesBatch) > 0 || len(metricSeriesTime) > 0 {
+				metrics = append(metrics, m)
+			}
 		}
 	}
 	return metrics, nil

--- a/webui/react/src/components/UPlot/UPlotChart/drawPointsPlugin.ts
+++ b/webui/react/src/components/UPlot/UPlotChart/drawPointsPlugin.ts
@@ -43,12 +43,14 @@ export const drawPointsPlugin = (checkpointsDict: CheckpointsDict): Plugin => {
     ctx.save();
 
     let j = idx0;
+    let foundCheckpoint = false;
 
     while (j <= idx1) {
       const xVal = u.data[0][j];
       const yVal = u.data[seriesIdx][j];
 
       if (scale && isNumber(yVal) && checkpointsDict[Math.floor(xVal)]) {
+        foundCheckpoint = true;
         const cx = Math.round(u.valToPos(xVal, 'x', true));
         const cy = Math.round(u.valToPos(yVal, scale, true));
         drawCheckpoint(ctx, cx, cy);
@@ -62,6 +64,9 @@ export const drawPointsPlugin = (checkpointsDict: CheckpointsDict): Plugin => {
     }
 
     ctx.restore();
+    if (!foundCheckpoint && u.data[seriesIdx].length === 1) {
+      return true;
+    }
   }
 
   return {


### PR DESCRIPTION
## Description

On the Trial Details page, LineChart was always displaying "Batches" in the X-Axis and tooltip. Adjusted to show `String(xAxis)` which covers Batches and Time.

Three other issues:
- Single point series (ex: a validation series with one record) were invisible unless also a checkpoint or hovered. Changed the drawPoints plugin to return `true` in this case, which shows an unfilled circle.
- checkpoint.endTime occurs after the metric is recorded, so the best checkpoint may match to a point on x = checkpoint.totalBatches but not on x = checkpoint.endTime (see experiment used in test).  If we're going to have separate series for batches and time then probably checkpoint(s) need to be sent to the chart as their own series?  But for now in this chart we can expect a batch # to be associated with every time, this is my use of timeHelpers.
- checkpoint.endTime offset also adds a new x-value which disrupts `dataForAxis` (which assumed training data has all x-values for clicking and tooltip) - replaced with xVals array per chart

## Test Plan

- Open `http://localhost:3000/det/experiments/1651/overview?f_chart=on`
- See one checkpoint diamond on accuracy and two on loss.  Hovering over each shows "best checkpoint"
- Switch x-axis to time. The accuracy checkpoint is still present and clickable. Both loss checkpoints are visible though spaced out.  The checkpoints in accuracy and loss plots have a "best checkpoint" tooltip and are clickable

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.