### PR TITLE
test: switch test-e2e-cpu-double to use priority scheduler

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2248,6 +2248,7 @@ workflows:
           tf2: true
           mark: e2e_cpu_2a
           target-stage: agent2
+          devcluster-config: double-priority.devcluster.yaml
 
       - test-e2e:
           name: test-e2e-managed-devcluster

--- a/.circleci/devcluster/double-priority.devcluster.yaml
+++ b/.circleci/devcluster/double-priority.devcluster.yaml
@@ -1,0 +1,63 @@
+stages:
+  - db:
+      name: db
+
+  - master:
+      pre:
+        - sh: make -C tools prep-root
+      config_file:
+        db:
+          host: localhost
+          port: 5432
+          password: postgres
+          user: postgres
+          name: determined
+        checkpoint_storage:
+          type: shared_fs
+          host_path: /tmp
+          storage_path: determined-cp
+        log:
+          level: debug
+        root: tools/build
+        cache:
+          cache_dir: /tmp/determined-cache
+        security:
+          authz:
+            rbac_ui_enabled: true
+        resource_manager:
+          type: agent
+          default_aux_resource_pool: default
+          default_compute_resource_pool: default
+        resource_pools:
+          - pool_name: default
+            scheduler:
+              type: priority
+  - custom:
+      name: proxy
+      cmd: ["socat", "-d", "-d", "TCP-LISTEN:8081,reuseaddr,fork", "TCP:localhost:8080"]
+      post:
+        - conncheck:
+            port: 8081
+
+  - agent:
+      name: agent1
+      config_file:
+        master_host: 127.0.0.1
+        master_port: 8081
+        agent_id: agent1
+        container_master_host: $DOCKER_LOCALHOST
+        container_auto_remove_disabled: true
+        hooks:
+          on_connection_lost: ["touch", "/tmp/agent1-connection-lost"]
+
+  - agent:
+      name: agent2
+      config_file:
+        master_host: 127.0.0.1
+        master_port: 8081
+        agent_id: agent2
+        container_master_host: $DOCKER_LOCALHOST
+        fluent:
+          port: 24225  # default value is 24224
+          container_name: determined-fluent-2
+        container_auto_remove_disabled: true


### PR DESCRIPTION
## Description

One of the tests in the changed run flakes occasionally due to a bug in the fair share scheduler that we're not planning to address soon (DET-8883), so let's try changing over to priority.

We could also change that test to a managed devcluster test, but that would be more work, and also this way I think we get a better overall split of testing between the two schedulers.

## Test Plan

- [x] run tests on an upstream branch