### PR TITLE
ci: check and retry Go package download

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -207,7 +207,7 @@ commands:
   reinstall-go:
     steps:
       - run: sudo rm -rf /usr/local/go # Remove system go.
-      - run: curl https://dl.google.com/go/go1.18.linux-amd64.tar.gz -o /tmp/go.linux-amd64.tar.gz
+      - run: curl --retry-connrefused --retry 10 https://dl.google.com/go/go1.18.10.linux-amd64.tar.gz -o /tmp/go.linux-amd64.tar.gz
       - run: sudo tar -C /usr/local -xzf /tmp/go.linux-amd64.tar.gz
 
   install-protoc:


### PR DESCRIPTION
## Description

We had one CI failure [1] caused by the Go package download somehow fetching some incorrect file (seems like probably a 5xx status page or something, though there's no way to know now). This attempts to work around that by checking the hash of the downloaded file to at least cover for totally transient errors.

Also upgrade from 1.18 to 1.18.10 while we're here.

[1] https://app.circleci.com/pipelines/github/determined-ai/determined/33339/workflows/dd7d6e62-e6c8-4152-bb41-3d313ae9adab/jobs/1170863

## Test Plan

- [x] run script locally with correct and incorrect hashes
- [x] CI