### PR TITLE
feat: Permissions for registering a model version, deleting a model [WEB-808]

### DIFF
--- a/webui/react/src/components/CheckpointModalTrigger.test.tsx
+++ b/webui/react/src/components/CheckpointModalTrigger.test.tsx
@@ -5,6 +5,7 @@ import React, { useEffect } from 'react';
 import CheckpointModalTrigger from 'components/CheckpointModalTrigger';
 import { StoreProvider as UIProvider } from 'shared/contexts/stores/UI';
 import { setAuth } from 'stores/auth';
+import { UsersProvider } from 'stores/users';
 import { generateTestExperimentData } from 'storybook/shared/generateTestData';
 
 const TEST_MODAL_TITLE = 'Checkpoint Modal Test';
@@ -37,7 +38,9 @@ const ModalTrigger: React.FC = () => {
 const setup = async () => {
   render(
     <UIProvider>
-      <ModalTrigger />
+      <UsersProvider>
+        <ModalTrigger />
+      </UsersProvider>
     </UIProvider>,
   );
 

--- a/webui/react/src/hooks/useFeature.ts
+++ b/webui/react/src/hooks/useFeature.ts
@@ -10,8 +10,8 @@ export type ValidFeature =
   | 'mock_permissions_read'
   | 'trials_comparison'
   | 'mock_permissions_all'
-  | 'chart'
-  | 'model_rbac';
+  | 'dashboard'
+  | 'chart';
 
 const queryParams = queryString.parse(window.location.search);
 

--- a/webui/react/src/hooks/useModal/Checkpoint/useModalCheckpointRegister.tsx
+++ b/webui/react/src/hooks/useModal/Checkpoint/useModalCheckpointRegister.tsx
@@ -61,7 +61,7 @@ const useModalCheckpointRegister = ({ onClose }: Props = {}): ModalHooks => {
   const [modalState, setModalState] = useState<ModalState>(INITIAL_MODAL_STATE);
   const prevModalState = usePrevious(modalState, undefined);
 
-  const { canModifyModel } = usePermissions();
+  const { canCreateModelVersion } = usePermissions();
 
   const handleClose = useCallback(
     (reason?: ModalCloseReason) => {
@@ -209,7 +209,7 @@ const useModalCheckpointRegister = ({ onClose }: Props = {}): ModalHooks => {
         },
         { signal: canceler.signal },
       );
-      const editableModels = response.models.filter((model) => canModifyModel({ model }));
+      const editableModels = response.models.filter((model) => canCreateModelVersion({ model }));
       setModalState((prev) => {
         if (isEqual(prev.models, editableModels)) return prev;
         return { ...prev, models: editableModels };
@@ -221,7 +221,7 @@ const useModalCheckpointRegister = ({ onClose }: Props = {}): ModalHooks => {
         type: ErrorType.Api,
       });
     }
-  }, [canceler.signal, modalState.visible, canModifyModel]);
+  }, [canceler.signal, modalState.visible]);
 
   const modalOpen = useCallback(
     async ({ checkpoints, selectedModelName }: ModalOpenProps) => {

--- a/webui/react/src/hooks/useModal/Checkpoint/useModalCheckpointRegister.tsx
+++ b/webui/react/src/hooks/useModal/Checkpoint/useModalCheckpointRegister.tsx
@@ -81,8 +81,10 @@ const useModalCheckpointRegister = ({ onClose }: Props = {}): ModalHooks => {
   }, [modalState.models, modalState.selectedModelName]);
 
   const modelOptions = useMemo(() => {
-    return modalState.models.map((model) => ({ id: model.id, name: model.name }));
-  }, [modalState.models]);
+    return modalState.models
+      .filter((model) => canCreateModelVersion({ model }))
+      .map((model) => ({ id: model.id, name: model.name }));
+  }, [modalState.models, canCreateModelVersion]);
 
   const registerModelVersion = useCallback(
     async (state: ModalState) => {
@@ -209,10 +211,9 @@ const useModalCheckpointRegister = ({ onClose }: Props = {}): ModalHooks => {
         },
         { signal: canceler.signal },
       );
-      const editableModels = response.models.filter((model) => canCreateModelVersion({ model }));
       setModalState((prev) => {
-        if (isEqual(prev.models, editableModels)) return prev;
-        return { ...prev, models: editableModels };
+        if (isEqual(prev.models, response.models)) return prev;
+        return { ...prev, models: response.models };
       });
     } catch (e) {
       handleError(e, {

--- a/webui/react/src/hooks/usePermissions.ts
+++ b/webui/react/src/hooks/usePermissions.ts
@@ -245,18 +245,13 @@ const canViewGroups = ({ rbacReadPermission, rbacEnabled, user }: RbacOptsProps)
 };
 
 const canViewModelRegistry = (
-  { rbacReadPermission, rbacEnabled, rbacModel, userAssignments, userRoles }: RbacOptsProps,
+  { rbacReadPermission, rbacEnabled, userAssignments, userRoles }: RbacOptsProps,
   workspace?: PermissionWorkspace,
 ): boolean => {
   // For OSS, everyone can view model registry
   // For RBAC, users with rbacReadPermission or VIEWMODELREGISTRY permission can view model resgistry
   const permitted = relevantPermissions(userAssignments, userRoles, workspace?.id);
-  return (
-    !rbacEnabled ||
-    rbacReadPermission ||
-    !rbacModel ||
-    permitted.has(V1PermissionType.VIEWMODELREGISTRY)
-  );
+  return !rbacEnabled || rbacReadPermission || permitted.has(V1PermissionType.VIEWMODELREGISTRY);
 };
 
 const canModifyGroups = ({

--- a/webui/react/src/hooks/usePermissions.ts
+++ b/webui/react/src/hooks/usePermissions.ts
@@ -36,7 +36,6 @@ interface ProjectPermissionsArgs {
 interface RbacOptsProps {
   rbacAllPermission: boolean;
   rbacEnabled: boolean;
-  rbacModel: boolean;
   rbacReadPermission: boolean;
   user?: DetailedUser;
   userAssignments?: UserAssignment[];
@@ -51,6 +50,7 @@ interface PermissionsHook {
   canAdministrateUsers: boolean;
   canAssignRoles: (arg0: WorkspacePermissionsArgs) => boolean;
   canCreateExperiment: (arg0: WorkspacePermissionsArgs) => boolean;
+  canCreateModelVersion: (arg0: ModelPermissionsArgs) => boolean;
   canCreateNSC: boolean;
   canCreateProject: (arg0: WorkspacePermissionsArgs) => boolean;
   canCreateWorkspace: boolean;
@@ -89,8 +89,7 @@ interface PermissionsHook {
 const usePermissions = (): PermissionsHook => {
   const rbacEnabled = useFeature().isOn('rbac'),
     rbacAllPermission = useFeature().isOn('mock_permissions_all'),
-    rbacReadPermission = useFeature().isOn('mock_permissions_read') || rbacAllPermission,
-    rbacModel = useFeature().isOn('model_rbac');
+    rbacReadPermission = useFeature().isOn('mock_permissions_read') || rbacAllPermission;
 
   const loadableCurrentUser = useCurrentUser();
   const user = Loadable.match(loadableCurrentUser, {
@@ -117,21 +116,12 @@ const usePermissions = (): PermissionsHook => {
     () => ({
       rbacAllPermission,
       rbacEnabled,
-      rbacModel,
       rbacReadPermission,
       user,
       userAssignments,
       userRoles,
     }),
-    [
-      rbacAllPermission,
-      rbacEnabled,
-      rbacModel,
-      rbacReadPermission,
-      user,
-      userAssignments,
-      userRoles,
-    ],
+    [rbacAllPermission, rbacEnabled, rbacReadPermission, user, userAssignments, userRoles],
   );
 
   const permissions = useMemo(
@@ -140,6 +130,8 @@ const usePermissions = (): PermissionsHook => {
       canAssignRoles: (args: WorkspacePermissionsArgs) => canAssignRoles(rbacOpts, args.workspace),
       canCreateExperiment: (args: WorkspacePermissionsArgs) =>
         canCreateExperiment(rbacOpts, args.workspace),
+      canCreateModelVersion: (args: ModelPermissionsArgs) =>
+        canCreateModelVersion(rbacOpts, args.model),
       canCreateNSC: canCreateNSC(rbacOpts),
       canCreateProject: (args: WorkspacePermissionsArgs) =>
         canCreateProject(rbacOpts, args.workspace),
@@ -379,55 +371,53 @@ const canViewExperimentArtifacts = (
 
 // Model and ModelVersion actions
 const canDeleteModel = (
-  { rbacAllPermission, rbacEnabled, rbacModel, user, userAssignments, userRoles }: RbacOptsProps,
+  { rbacAllPermission, rbacEnabled, user, userAssignments, userRoles }: RbacOptsProps,
   model: ModelItem,
 ): boolean => {
   const permitted = relevantPermissions(userAssignments, userRoles, model.workspaceId);
   return (
     rbacAllPermission ||
-    (rbacEnabled && rbacModel
+    (rbacEnabled
       ? permitted.has(V1PermissionType.EDITMODELREGISTRY)
       : !!user && (user.isAdmin || user.id === model?.userId))
   );
 };
 
 const canModifyModel = (
-  { rbacAllPermission, rbacEnabled, rbacModel, userAssignments, userRoles }: RbacOptsProps,
+  { rbacAllPermission, rbacEnabled, userAssignments, userRoles }: RbacOptsProps,
   model: ModelItem,
 ): boolean => {
   const permitted = relevantPermissions(userAssignments, userRoles, model.workspaceId);
-  return (
-    rbacAllPermission ||
-    !rbacEnabled ||
-    !rbacModel ||
-    permitted.has(V1PermissionType.EDITMODELREGISTRY)
-  );
+  return rbacAllPermission || !rbacEnabled || permitted.has(V1PermissionType.EDITMODELREGISTRY);
+};
+
+const canCreateModelVersion = (
+  { rbacAllPermission, rbacEnabled, userAssignments, userRoles }: RbacOptsProps,
+  model: ModelItem,
+): boolean => {
+  const permitted = relevantPermissions(userAssignments, userRoles, model.workspaceId);
+  return rbacAllPermission || !rbacEnabled || permitted.has(V1PermissionType.CREATEMODELREGISTRY);
 };
 
 const canDeleteModelVersion = (
-  { rbacAllPermission, rbacEnabled, rbacModel, user, userAssignments, userRoles }: RbacOptsProps,
+  { rbacAllPermission, rbacEnabled, user, userAssignments, userRoles }: RbacOptsProps,
   modelVersion: ModelVersion,
 ): boolean => {
   const permitted = relevantPermissions(userAssignments, userRoles, modelVersion.model.workspaceId);
   return (
     rbacAllPermission ||
-    (rbacEnabled && rbacModel
+    (rbacEnabled
       ? permitted.has(V1PermissionType.EDITMODELREGISTRY)
       : !!user && (user.isAdmin || user.id === modelVersion?.userId))
   );
 };
 
 const canModifyModelVersion = (
-  { rbacAllPermission, rbacEnabled, rbacModel, userAssignments, userRoles }: RbacOptsProps,
+  { rbacAllPermission, rbacEnabled, userAssignments, userRoles }: RbacOptsProps,
   modelVersion: ModelVersion,
 ): boolean => {
   const permitted = relevantPermissions(userAssignments, userRoles, modelVersion.model.workspaceId);
-  return (
-    !rbacEnabled ||
-    rbacAllPermission ||
-    !rbacModel ||
-    permitted.has(V1PermissionType.EDITMODELREGISTRY)
-  );
+  return !rbacEnabled || rbacAllPermission || permitted.has(V1PermissionType.EDITMODELREGISTRY);
 };
 
 // Project actions


### PR DESCRIPTION
## Description

When registering a checkpoint as a "Model Version", filter the list of destination models through a new client-side check `canModifyModel({ model })`

`canModifyModel` matches the existing `canModifyModelVersion` but avoids the complexity of accepting both types or a partial type through a single function, or some future issues.

While working on this ticket, I realized that `canDeleteModel` had not been updated either. This now follows the logic of `canDeleteModelVersion`.

Client-side alternative to https://github.com/determined-ai/determined/pull/5924

## Test Plan

On OSS version:
- Navigate to a successfully completed experiment.
- Click the flag icon to open a checkpoint modal. On the bottom of the modal, click "Register Checkpoint"
- On this Model Version modal, open the dropdown. You should see an alphabetic list of models.

Break `canModifyModel` to always return false
- Now the Model Version modal should show no models.

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.