### PR TITLE
fix: Avoid model registry 404, workspace-specific permissions [DET-8917]

### DIFF
--- a/webui/react/src/pages/ModelRegistry.tsx
+++ b/webui/react/src/pages/ModelRegistry.tsx
@@ -36,7 +36,6 @@ import Toggle from 'components/Toggle';
 import WorkspaceFilter from 'components/WorkspaceFilter';
 import useModalModelCreate from 'hooks/useModal/Model/useModalModelCreate';
 import useModalModelDelete from 'hooks/useModal/Model/useModalModelDelete';
-import usePermissions from 'hooks/usePermissions';
 import { UpdateSettings, useSettings } from 'hooks/useSettings';
 import { paths } from 'routes/utils';
 import { archiveModel, getModelLabels, getModels, patchModel, unarchiveModel } from 'services/api';
@@ -85,7 +84,6 @@ const ModelRegistry: React.FC<Props> = ({ workspace }: Props) => {
   const [canceler] = useState(new AbortController());
   const [total, setTotal] = useState(0);
   const pageRef = useRef<HTMLElement>(null);
-  const { canViewModelRegistry } = usePermissions();
   const fetchWorkspaces = useEnsureWorkspacesFetched(canceler);
 
   const { contextHolder: modalModelCreateContextHolder, modalOpen: openModelCreate } =
@@ -672,7 +670,6 @@ const ModelRegistry: React.FC<Props> = ({ workspace }: Props) => {
     <Page
       containerRef={pageRef}
       id="models"
-      notFound={!canViewModelRegistry}
       options={
         <Space>
           <Toggle

--- a/webui/react/src/pages/WorkspaceDetails.tsx
+++ b/webui/react/src/pages/WorkspaceDetails.tsx
@@ -195,7 +195,7 @@ const WorkspaceDetails: React.FC = () => {
       });
     }
 
-    if (canViewModelRegistry) {
+    if (canViewModelRegistry({ workspace })) {
       items.push({
         children: <ModelRegistry workspace={workspace} />,
         key: WorkspaceDetailsTab.ModelRegistry,


### PR DESCRIPTION
## Description

- Show models from any workspaces in global model registry (previously required a cluster-wide permission).
- If the user has no workspace permissions, global model registry will be empty rather than 404.
- Puts model registry RBAC checks behind a feature flag which we've been using (`f_model_rbac=on`)
- Workspaces check a workspace-specific view registry permission (previously used cluster-wide permission in all cases)

## Test Plan

OSS behavior should be unchanged.

On EE
- As admin, create a new user. Grant them Viewer access on one workspace
- The created user can log in and visit an empty Model Registry at `/det/models?f_model_rbac=on`
- The created user can view their one Workspace and see the Model Registry tab even with `?f_model_rbac=on`

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.