### PR TITLE
docs: document `kubernetes_namespace` resource pool config option

### DIFF
--- a/docs/reference/reference-deploy/config/master-config-reference.rst
+++ b/docs/reference/reference-deploy/config/master-config-reference.rst
@@ -398,6 +398,10 @@ The master supports the following configuration settings:
       ``task_container_defaults`` is set, tasks launched in that pool will completely ignore the
       top-level setting.
 
+   -  ``kubernetes_namespace``: When the Kubernetes resource manager is in use, this specifies a
+      `namespace <https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/>`__
+      that tasks in this resource pool will be launched into.
+
    -  ``scheduler``: Specifies how Determined schedules tasks to agents. The scheduler configuration
       on each resource pool will override the global one. For more on scheduling behavior in
       Determined, see :ref:`scheduling`.

--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -17,6 +17,11 @@ Version 0.19.10
 
 **Breaking Changes**
 
+-  Kubernetes: Add the ``kubernetes_namespace`` config field for resource pools, specifying a
+   Kubernetes `namespace
+   <https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/>`__ that tasks
+   will be launched into.
+
 -  The name of the resource pool in Kubernetes has changed from ``"kubernetes"`` to ``"default"``.
    Forked experiments will need to have their configurations manually modified to update the
    resource pool name.


### PR DESCRIPTION
## Test Plan

- [x] render and examine docs