### PR TITLE
fix: Don't call getUserSetting until auth is fully checked

### DIFF
--- a/webui/react/src/hooks/useSettingsProvider.tsx
+++ b/webui/react/src/hooks/useSettingsProvider.tsx
@@ -47,7 +47,7 @@ export const SettingsProvider: React.FC<React.PropsWithChildren> = ({ children }
   const [settingsState, setSettingsState] = useState(() => Map<string, Settings>());
 
   useEffect(() => {
-    if (!user?.id) return;
+    if (!user?.id || !checked) return;
 
     try {
       getUserSetting({}, { signal: canceler.signal }).then((response) => {
@@ -81,7 +81,7 @@ export const SettingsProvider: React.FC<React.PropsWithChildren> = ({ children }
     }
 
     return () => canceler.abort();
-  }, [canceler, user?.id, settingsState]);
+  }, [canceler, user?.id, checked, settingsState]);
 
   useEffect(() => {
     const url = window.location.search.substring(/^\?/.test(location.search) ? 1 : 0);


### PR DESCRIPTION
## Description

Debug conversation occurred on Slack; essentially we want both the user and checked auth, before making requests and risking failing out to login again.

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.