### PR TITLE
feat: Model editing tools disabled if you lack permission [WEB-912]

### DIFF
--- a/webui/react/src/components/Metadata/MetadataCard.tsx
+++ b/webui/react/src/components/Metadata/MetadataCard.tsx
@@ -83,7 +83,7 @@ const MetadataCard: React.FC<Props> = ({ disabled = false, metadata = {}, onSave
         <div
           style={{ color: 'var(--theme-colors-monochrome-9)', fontStyle: 'italic' }}
           onClick={editMetadata}>
-          Add Metadata...
+          {disabled ? 'No metadata present.' : 'Add Metadata...'}
         </div>
       ) : (
         <Spinner spinning={isLoading}>

--- a/webui/react/src/pages/ModelDetails.tsx
+++ b/webui/react/src/pages/ModelDetails.tsx
@@ -73,7 +73,7 @@ const ModelDetails: React.FC = () => {
   const workspaces = Loadable.getOrElse([], useWorkspaces());
   const workspace = workspaces.find((ws) => ws.id === model?.model.workspaceId);
 
-  const { canModifyModelVersion } = usePermissions();
+  const { canModifyModel, canModifyModelVersion } = usePermissions();
 
   const {
     settings,
@@ -496,12 +496,12 @@ const ModelDetails: React.FC = () => {
           />
         )}
         <NotesCard
-          disabled={model.model.archived}
+          disabled={model.model.archived || !canModifyModel({ model: model.model })}
           notes={model.model.notes ?? ''}
           onSave={saveNotes}
         />
         <MetadataCard
-          disabled={model.model.archived}
+          disabled={model.model.archived || !canModifyModel({ model: model.model })}
           metadata={model.model.metadata}
           onSave={saveMetadata}
         />

--- a/webui/react/src/pages/ModelDetails/ModelHeader.tsx
+++ b/webui/react/src/pages/ModelDetails/ModelHeader.tsx
@@ -189,7 +189,10 @@ const ModelHeader: React.FC<Props> = ({
             </h1>
           </Space>
           <Space size="small">
-            <Dropdown menu={menu} trigger={['click']}>
+            <Dropdown
+              disabled={!canDeleteModelFlag && !canModifyModelFlag}
+              menu={menu}
+              trigger={['click']}>
               <Button type="text">
                 <Icon name="overflow-horizontal" size="tiny" />
               </Button>

--- a/webui/react/src/pages/ModelDetails/ModelHeader.tsx
+++ b/webui/react/src/pages/ModelDetails/ModelHeader.tsx
@@ -12,6 +12,7 @@ import TagList from 'components/TagList';
 import TimeAgo from 'components/TimeAgo';
 import Avatar from 'components/UserAvatar';
 import useModalModelDelete from 'hooks/useModal/Model/useModalModelDelete';
+import useModalModelMove from 'hooks/useModal/Model/useModalModelMove';
 import usePermissions from 'hooks/usePermissions';
 import { WorkspaceDetailsTab } from 'pages/WorkspaceDetails';
 import { paths } from 'routes/utils';
@@ -46,7 +47,9 @@ const ModelHeader: React.FC<Props> = ({
     Loaded: (cUser) => cUser.users,
     NotLoaded: () => [],
   }); // TODO: handle loading state
-  const { contextHolder, modalOpen } = useModalModelDelete();
+  const { contextHolder: modalModelDeleteContextHolder, modalOpen } = useModalModelDelete();
+  const { contextHolder: modalModelMoveContextHolder, modalOpen: openModelMove } =
+    useModalModelMove();
   const { canDeleteModel, canModifyModel } = usePermissions();
   const canDelete = canDeleteModel({ model });
   const canModify = canModifyModel({ model });
@@ -92,15 +95,21 @@ const ModelHeader: React.FC<Props> = ({
 
   const handleDelete = useCallback(() => modalOpen(model), [modalOpen, model]);
 
+  const handleMove = useCallback(() => openModelMove(model), [openModelMove, model]);
+
   const menu: DropDownProps['menu'] = useMemo(() => {
     const MenuKey = {
       DeleteModel: 'delete-model',
+      MoveModel: 'move-model',
       SwitchArchived: 'switch-archive',
     } as const;
 
     const funcs = {
       [MenuKey.SwitchArchived]: () => {
         onSwitchArchive();
+      },
+      [MenuKey.MoveModel]: () => {
+        handleMove();
       },
       [MenuKey.DeleteModel]: () => {
         handleDelete();
@@ -117,13 +126,16 @@ const ModelHeader: React.FC<Props> = ({
         key: MenuKey.SwitchArchived,
         label: model.archived ? 'Unarchive' : 'Archive',
       });
+      if (!model.archived) {
+        menuItems.push({ key: MenuKey.MoveModel, label: 'Move' });
+      }
     }
     if (canDelete) {
       menuItems.push({ danger: true, key: MenuKey.DeleteModel, label: 'Delete' });
     }
 
     return { items: menuItems, onClick: onItemClick };
-  }, [canDelete, canModify, handleDelete, model, onSwitchArchive]);
+  }, [canDelete, canModify, handleDelete, handleMove, model, onSwitchArchive]);
 
   return (
     <header className={css.base}>
@@ -186,7 +198,8 @@ const ModelHeader: React.FC<Props> = ({
         </div>
         <InfoBox rows={infoRows} separator={false} />
       </div>
-      {contextHolder}
+      {modalModelDeleteContextHolder}
+      {modalModelMoveContextHolder}
     </header>
   );
 };

--- a/webui/react/src/pages/ModelDetails/ModelHeader.tsx
+++ b/webui/react/src/pages/ModelDetails/ModelHeader.tsx
@@ -46,8 +46,10 @@ const ModelHeader: React.FC<Props> = ({
     Loaded: (cUser) => cUser.users,
     NotLoaded: () => [],
   }); // TODO: handle loading state
-  const { canDeleteModel, canModifyModel } = usePermissions();
   const { contextHolder, modalOpen } = useModalModelDelete();
+  const { canDeleteModel, canModifyModel } = usePermissions();
+  const canDelete = canDeleteModel({ model });
+  const canModify = canModifyModel({ model });
 
   const infoRows: InfoRow[] = useMemo(() => {
     const user = users.find((user) => user.id === model.userId);
@@ -110,18 +112,18 @@ const ModelHeader: React.FC<Props> = ({
     };
 
     const menuItems: MenuProps['items'] = [];
-    if (canModifyModel({ model })) {
+    if (canModify) {
       menuItems.push({
         key: MenuKey.SwitchArchived,
         label: model.archived ? 'Unarchive' : 'Archive',
       });
     }
-    if (canDeleteModel({ model })) {
+    if (canDelete) {
       menuItems.push({ danger: true, key: MenuKey.DeleteModel, label: 'Delete' });
     }
 
     return { items: menuItems, onClick: onItemClick };
-  }, [canDeleteModel, canModifyModel, handleDelete, model, onSwitchArchive]);
+  }, [canDelete, canModify, handleDelete, model, onSwitchArchive]);
 
   return (
     <header className={css.base}>

--- a/webui/react/src/pages/ModelDetails/ModelHeader.tsx
+++ b/webui/react/src/pages/ModelDetails/ModelHeader.tsx
@@ -51,8 +51,8 @@ const ModelHeader: React.FC<Props> = ({
   const { contextHolder: modalModelMoveContextHolder, modalOpen: openModelMove } =
     useModalModelMove();
   const { canDeleteModel, canModifyModel } = usePermissions();
-  const canDelete = canDeleteModel({ model });
-  const canModify = canModifyModel({ model });
+  const canDeleteModelFlag = canDeleteModel({ model });
+  const canModifyModelFlag = canModifyModel({ model });
 
   const infoRows: InfoRow[] = useMemo(() => {
     const user = users.find((user) => user.id === model.userId);
@@ -71,7 +71,7 @@ const ModelHeader: React.FC<Props> = ({
       {
         content: (
           <InlineEditor
-            disabled={model.archived || !canModify}
+            disabled={model.archived || !canModifyModelFlag}
             placeholder={model.archived ? 'Archived' : 'Add description...'}
             value={model.description ?? ''}
             onSave={onSaveDescription}
@@ -82,7 +82,7 @@ const ModelHeader: React.FC<Props> = ({
       {
         content: (
           <TagList
-            disabled={model.archived || !canModify}
+            disabled={model.archived || !canModifyModelFlag}
             ghost={false}
             tags={model.labels ?? []}
             onChange={onUpdateTags}
@@ -91,7 +91,7 @@ const ModelHeader: React.FC<Props> = ({
         label: 'Tags',
       },
     ] as InfoRow[];
-  }, [model, onSaveDescription, onUpdateTags, users, canModify]);
+  }, [model, onSaveDescription, onUpdateTags, users, canModifyModelFlag]);
 
   const handleDelete = useCallback(() => modalOpen(model), [modalOpen, model]);
 
@@ -121,7 +121,7 @@ const ModelHeader: React.FC<Props> = ({
     };
 
     const menuItems: MenuProps['items'] = [];
-    if (canModify) {
+    if (canModifyModelFlag) {
       menuItems.push({
         key: MenuKey.SwitchArchived,
         label: model.archived ? 'Unarchive' : 'Archive',
@@ -130,12 +130,12 @@ const ModelHeader: React.FC<Props> = ({
         menuItems.push({ key: MenuKey.MoveModel, label: 'Move' });
       }
     }
-    if (canDelete) {
+    if (canDeleteModelFlag) {
       menuItems.push({ danger: true, key: MenuKey.DeleteModel, label: 'Delete' });
     }
 
     return { items: menuItems, onClick: onItemClick };
-  }, [canDelete, canModify, handleDelete, handleMove, model, onSwitchArchive]);
+  }, [canDeleteModelFlag, canModifyModelFlag, handleDelete, handleMove, model, onSwitchArchive]);
 
   return (
     <header className={css.base}>
@@ -181,7 +181,7 @@ const ModelHeader: React.FC<Props> = ({
             <h1 className={css.name}>
               <InlineEditor
                 allowClear={false}
-                disabled={model.archived || !canModify}
+                disabled={model.archived || !canModifyModelFlag}
                 placeholder="Add name..."
                 value={model.name}
                 onSave={onSaveName}

--- a/webui/react/src/pages/ModelDetails/ModelHeader.tsx
+++ b/webui/react/src/pages/ModelDetails/ModelHeader.tsx
@@ -68,7 +68,7 @@ const ModelHeader: React.FC<Props> = ({
       {
         content: (
           <InlineEditor
-            disabled={model.archived || !canModifyModel({ model })}
+            disabled={model.archived || !canModify}
             placeholder={model.archived ? 'Archived' : 'Add description...'}
             value={model.description ?? ''}
             onSave={onSaveDescription}
@@ -79,7 +79,7 @@ const ModelHeader: React.FC<Props> = ({
       {
         content: (
           <TagList
-            disabled={model.archived || !canModifyModel({ model })}
+            disabled={model.archived || !canModify}
             ghost={false}
             tags={model.labels ?? []}
             onChange={onUpdateTags}
@@ -88,7 +88,7 @@ const ModelHeader: React.FC<Props> = ({
         label: 'Tags',
       },
     ] as InfoRow[];
-  }, [model, onSaveDescription, onUpdateTags, users, canModifyModel]);
+  }, [model, onSaveDescription, onUpdateTags, users, canModify]);
 
   const handleDelete = useCallback(() => modalOpen(model), [modalOpen, model]);
 
@@ -169,7 +169,7 @@ const ModelHeader: React.FC<Props> = ({
             <h1 className={css.name}>
               <InlineEditor
                 allowClear={false}
-                disabled={model.archived || !canModifyModel({ model })}
+                disabled={model.archived || !canModify}
                 placeholder="Add name..."
                 value={model.name}
                 onSave={onSaveName}

--- a/webui/react/src/pages/ModelDetails/ModelHeader.tsx
+++ b/webui/react/src/pages/ModelDetails/ModelHeader.tsx
@@ -46,7 +46,7 @@ const ModelHeader: React.FC<Props> = ({
     Loaded: (cUser) => cUser.users,
     NotLoaded: () => [],
   }); // TODO: handle loading state
-  const { canDeleteModel } = usePermissions();
+  const { canDeleteModel, canModifyModel } = usePermissions();
   const { contextHolder, modalOpen } = useModalModelDelete();
 
   const infoRows: InfoRow[] = useMemo(() => {
@@ -66,7 +66,7 @@ const ModelHeader: React.FC<Props> = ({
       {
         content: (
           <InlineEditor
-            disabled={model.archived}
+            disabled={model.archived || !canModifyModel({ model })}
             placeholder={model.archived ? 'Archived' : 'Add description...'}
             value={model.description ?? ''}
             onSave={onSaveDescription}
@@ -77,7 +77,7 @@ const ModelHeader: React.FC<Props> = ({
       {
         content: (
           <TagList
-            disabled={model.archived}
+            disabled={model.archived || !canModifyModel({ model })}
             ghost={false}
             tags={model.labels ?? []}
             onChange={onUpdateTags}
@@ -86,7 +86,7 @@ const ModelHeader: React.FC<Props> = ({
         label: 'Tags',
       },
     ] as InfoRow[];
-  }, [model, onSaveDescription, onUpdateTags, users]);
+  }, [model, onSaveDescription, onUpdateTags, users, canModifyModel]);
 
   const handleDelete = useCallback(() => modalOpen(model), [modalOpen, model]);
 
@@ -109,16 +109,19 @@ const ModelHeader: React.FC<Props> = ({
       funcs[e.key as ValueOf<typeof MenuKey>]();
     };
 
-    const menuItems: MenuProps['items'] = [
-      { key: MenuKey.SwitchArchived, label: model.archived ? 'Unarchive' : 'Archive' },
-    ];
-
+    const menuItems: MenuProps['items'] = [];
+    if (canModifyModel({ model })) {
+      menuItems.push({
+        key: MenuKey.SwitchArchived,
+        label: model.archived ? 'Unarchive' : 'Archive',
+      });
+    }
     if (canDeleteModel({ model })) {
       menuItems.push({ danger: true, key: MenuKey.DeleteModel, label: 'Delete' });
     }
 
     return { items: menuItems, onClick: onItemClick };
-  }, [canDeleteModel, handleDelete, model, onSwitchArchive]);
+  }, [canDeleteModel, canModifyModel, handleDelete, model, onSwitchArchive]);
 
   return (
     <header className={css.base}>
@@ -164,7 +167,7 @@ const ModelHeader: React.FC<Props> = ({
             <h1 className={css.name}>
               <InlineEditor
                 allowClear={false}
-                disabled={model.archived}
+                disabled={model.archived || !canModifyModel({ model })}
                 placeholder="Add name..."
                 value={model.name}
                 onSave={onSaveName}

--- a/webui/react/src/pages/ModelRegistry.tsx
+++ b/webui/react/src/pages/ModelRegistry.tsx
@@ -438,7 +438,7 @@ const ModelRegistry: React.FC<Props> = ({ workspace }: Props) => {
 
       return { items: menuItems, onClick: onItemClick };
     },
-    [showConfirmDelete, switchArchived],
+    [canModifyModel, moveModelToWorkspace, showConfirmDelete, switchArchived],
   );
 
   const columns = useMemo(() => {

--- a/webui/react/src/pages/ModelRegistry.tsx
+++ b/webui/react/src/pages/ModelRegistry.tsx
@@ -683,7 +683,7 @@ const ModelRegistry: React.FC<Props> = ({ workspace }: Props) => {
     }) => {
       const canDelete = canDeleteModel({ model: record });
       const canModify = canModifyModel({ model: record });
-      return canModify || canDelete ? (
+      return canDelete || canModify ? (
         <Dropdown
           menu={ModelActionMenu(record, canDelete, canModify)}
           trigger={['contextMenu']}

--- a/webui/react/src/pages/ModelRegistry.tsx
+++ b/webui/react/src/pages/ModelRegistry.tsx
@@ -468,6 +468,7 @@ const ModelRegistry: React.FC<Props> = ({ workspace }: Props) => {
       const canModifyModelFlag = canModifyModel({ model: record });
       return (
         <Dropdown
+          disabled={!canDeleteModelFlag && !canModifyModelFlag}
           menu={ModelActionMenu(record, canDeleteModelFlag, canModifyModelFlag)}
           trigger={['click']}>
           <Button icon={<Icon name="overflow-vertical" />} type="text" />

--- a/webui/react/src/pages/ModelRegistry.tsx
+++ b/webui/react/src/pages/ModelRegistry.tsx
@@ -81,9 +81,8 @@ const ModelRegistry: React.FC<Props> = ({ workspace }: Props) => {
   const [canceler] = useState(new AbortController());
   const [total, setTotal] = useState(0);
   const pageRef = useRef<HTMLElement>(null);
-  const { canCreateModels, canModifyModel } = usePermissions();
   const fetchWorkspaces = useEnsureWorkspacesFetched(canceler);
-  const { canDeleteModel, canModifyModel } = usePermissions();
+  const { canCreateModels, canDeleteModel, canModifyModel } = usePermissions();
 
   const { contextHolder: modalModelCreateContextHolder, modalOpen: openModelCreate } =
     useModalModelCreate({ workspaceId: workspace?.id });
@@ -428,9 +427,9 @@ const ModelRegistry: React.FC<Props> = ({ workspace }: Props) => {
           key: MenuKey.SwitchArchived,
           label: record.archived ? 'Unarchive' : 'Archive',
         });
-      }
-      if (!record.archived && canModifyModel({ model: record })) {
-        menuItems.push({ key: MenuKey.MoveModel, label: 'Move' });
+        if (!record.archived) {
+          menuItems.push({ key: MenuKey.MoveModel, label: 'Move' });
+        }
       }
       if (canDelete) {
         menuItems.push({ danger: true, key: MenuKey.DeleteModel, label: 'Delete Model' });
@@ -438,7 +437,7 @@ const ModelRegistry: React.FC<Props> = ({ workspace }: Props) => {
 
       return { items: menuItems, onClick: onItemClick };
     },
-    [canModifyModel, moveModelToWorkspace, showConfirmDelete, switchArchived],
+    [moveModelToWorkspace, showConfirmDelete, switchArchived],
   );
 
   const columns = useMemo(() => {

--- a/webui/react/src/pages/ModelRegistry.tsx
+++ b/webui/react/src/pages/ModelRegistry.tsx
@@ -398,7 +398,11 @@ const ModelRegistry: React.FC<Props> = ({ workspace }: Props) => {
   }, [resetSettings]);
 
   const ModelActionMenu = useCallback(
-    (record: ModelItem, canDelete: boolean, canModify: boolean): DropDownProps['menu'] => {
+    (
+      record: ModelItem,
+      canDeleteModelFlag: boolean,
+      canModifyModelFlag: boolean,
+    ): DropDownProps['menu'] => {
       const MenuKey = {
         DeleteModel: 'delete-model',
         MoveModel: 'move-model',
@@ -422,7 +426,7 @@ const ModelRegistry: React.FC<Props> = ({ workspace }: Props) => {
       };
 
       const menuItems: MenuProps['items'] = [];
-      if (canModify) {
+      if (canModifyModelFlag) {
         menuItems.push({
           key: MenuKey.SwitchArchived,
           label: record.archived ? 'Unarchive' : 'Archive',
@@ -431,7 +435,7 @@ const ModelRegistry: React.FC<Props> = ({ workspace }: Props) => {
           menuItems.push({ key: MenuKey.MoveModel, label: 'Move' });
         }
       }
-      if (canDelete) {
+      if (canDeleteModelFlag) {
         menuItems.push({ danger: true, key: MenuKey.DeleteModel, label: 'Delete Model' });
       }
 
@@ -460,13 +464,15 @@ const ModelRegistry: React.FC<Props> = ({ workspace }: Props) => {
     );
 
     const actionRenderer = (_: string, record: ModelItem) => {
-      const canDelete = canDeleteModel({ model: record });
-      const canModify = canModifyModel({ model: record });
-      return canModify || canDelete ? (
-        <Dropdown menu={ModelActionMenu(record, canDelete, canModify)} trigger={['click']}>
+      const canDeleteModelFlag = canDeleteModel({ model: record });
+      const canModifyModelFlag = canModifyModel({ model: record });
+      return (
+        <Dropdown
+          menu={ModelActionMenu(record, canDeleteModelFlag, canModifyModelFlag)}
+          trigger={['click']}>
           <Button icon={<Icon name="overflow-vertical" />} type="text" />
         </Dropdown>
-      ) : null;
+      );
     };
 
     const descriptionRenderer = (value: string, record: ModelItem) => (
@@ -680,16 +686,16 @@ const ModelRegistry: React.FC<Props> = ({ workspace }: Props) => {
       onVisibleChange?: (visible: boolean) => void;
       record: ModelItem;
     }) => {
-      const canDelete = canDeleteModel({ model: record });
-      const canModify = canModifyModel({ model: record });
-      return canDelete || canModify ? (
+      const canDeleteModelFlag = canDeleteModel({ model: record });
+      const canModifyModelFlag = canModifyModel({ model: record });
+      return (
         <Dropdown
-          menu={ModelActionMenu(record, canDelete, canModify)}
+          menu={ModelActionMenu(record, canDeleteModelFlag, canModifyModelFlag)}
           trigger={['contextMenu']}
           onOpenChange={onVisibleChange}>
           {children}
         </Dropdown>
-      ) : null;
+      );
     },
     [ModelActionMenu, canDeleteModel, canModifyModel],
   );

--- a/webui/react/src/pages/ModelRegistry.tsx
+++ b/webui/react/src/pages/ModelRegistry.tsx
@@ -49,7 +49,7 @@ import { isEqual } from 'shared/utils/data';
 import { ErrorType } from 'shared/utils/error';
 import { validateDetApiEnum } from 'shared/utils/service';
 import { alphaNumericSorter } from 'shared/utils/sort';
-import { useCurrentUser, useEnsureUsersFetched, useUsers } from 'stores/users';
+import { useEnsureUsersFetched, useUsers } from 'stores/users';
 import { useEnsureWorkspacesFetched, useWorkspaces } from 'stores/workspaces';
 import { ModelItem, Workspace } from 'types';
 import handleError from 'utils/error';
@@ -75,11 +75,6 @@ const ModelRegistry: React.FC<Props> = ({ workspace }: Props) => {
     Loaded: (cUser) => cUser.users,
     NotLoaded: () => [],
   }); // TODO: handle loading state
-  const loadableCurrentUser = useCurrentUser();
-  const user = Loadable.match(loadableCurrentUser, {
-    Loaded: (cUser) => cUser,
-    NotLoaded: () => undefined,
-  });
   const [models, setModels] = useState<ModelItem[]>([]);
   const [tags, setTags] = useState<string[]>([]);
   const [isLoading, setIsLoading] = useState(true);
@@ -88,6 +83,7 @@ const ModelRegistry: React.FC<Props> = ({ workspace }: Props) => {
   const pageRef = useRef<HTMLElement>(null);
   const { canCreateModels, canModifyModel } = usePermissions();
   const fetchWorkspaces = useEnsureWorkspacesFetched(canceler);
+  const { canDeleteModel, canModifyModel } = usePermissions();
 
   const { contextHolder: modalModelCreateContextHolder, modalOpen: openModelCreate } =
     useModalModelCreate({ workspaceId: workspace?.id });
@@ -403,7 +399,7 @@ const ModelRegistry: React.FC<Props> = ({ workspace }: Props) => {
   }, [resetSettings]);
 
   const ModelActionMenu = useCallback(
-    (record: ModelItem): DropDownProps['menu'] => {
+    (record: ModelItem, canDelete: boolean, canModify: boolean): DropDownProps['menu'] => {
       const MenuKey = {
         DeleteModel: 'delete-model',
         MoveModel: 'move-model',
@@ -426,27 +422,23 @@ const ModelRegistry: React.FC<Props> = ({ workspace }: Props) => {
         funcs[e.key as ValueOf<typeof MenuKey>]();
       };
 
-      const menuItems: MenuProps['items'] = [
-        { key: MenuKey.SwitchArchived, label: record.archived ? 'Unarchive' : 'Archive' },
-      ];
-
-      if (canModifyModel({ model: record })) {
+      const menuItems: MenuProps['items'] = [];
+      if (canModify) {
+        menuItems.push({
+          key: MenuKey.SwitchArchived,
+          label: record.archived ? 'Unarchive' : 'Archive',
+        });
+      }
+      if (!record.archived && canModifyModel({ model: record })) {
         menuItems.push({ key: MenuKey.MoveModel, label: 'Move' });
       }
-      if (user?.id === record.userId || user?.isAdmin) {
+      if (canDelete) {
         menuItems.push({ danger: true, key: MenuKey.DeleteModel, label: 'Delete Model' });
       }
 
       return { items: menuItems, onClick: onItemClick };
     },
-    [
-      canModifyModel,
-      moveModelToWorkspace,
-      showConfirmDelete,
-      switchArchived,
-      user?.id,
-      user?.isAdmin,
-    ],
+    [showConfirmDelete, switchArchived],
   );
 
   const columns = useMemo(() => {
@@ -459,7 +451,7 @@ const ModelRegistry: React.FC<Props> = ({ workspace }: Props) => {
           <div>
             <TagList
               compact
-              disabled={record.archived}
+              disabled={record.archived || !canModifyModel({ model: record })}
               tags={record.labels ?? []}
               onChange={(tags) => setModelTags(record.name, tags)}
             />
@@ -468,17 +460,21 @@ const ModelRegistry: React.FC<Props> = ({ workspace }: Props) => {
       </div>
     );
 
-    const actionRenderer = (_: string, record: ModelItem) => (
-      <Dropdown menu={ModelActionMenu(record)} trigger={['click']}>
-        <Button icon={<Icon name="overflow-vertical" />} type="text" />
-      </Dropdown>
-    );
+    const actionRenderer = (_: string, record: ModelItem) => {
+      const canDelete = canDeleteModel({ model: record });
+      const canModify = canModifyModel({ model: record });
+      return canModify || canDelete ? (
+        <Dropdown menu={ModelActionMenu(record, canDelete, canModify)} trigger={['click']}>
+          <Button icon={<Icon name="overflow-vertical" />} type="text" />
+        </Dropdown>
+      ) : null;
+    };
 
     const descriptionRenderer = (value: string, record: ModelItem) => (
       <Input
         className={css.descriptionRenderer}
         defaultValue={value}
-        disabled={record.archived}
+        disabled={record.archived || !canModifyModel({ model: record })}
         placeholder={record.archived ? 'Archived' : 'Add description...'}
         title={record.archived ? 'Archived description' : 'Edit description'}
         onBlur={(e) => {
@@ -591,6 +587,8 @@ const ModelRegistry: React.FC<Props> = ({ workspace }: Props) => {
       },
     ] as ColumnDef<ModelItem>[];
   }, [
+    canDeleteModel,
+    canModifyModel,
     nameFilterSearch,
     tableSearchIcon,
     descriptionFilterSearch,
@@ -682,15 +680,19 @@ const ModelRegistry: React.FC<Props> = ({ workspace }: Props) => {
       children: React.ReactNode;
       onVisibleChange?: (visible: boolean) => void;
       record: ModelItem;
-    }) => (
-      <Dropdown
-        menu={ModelActionMenu(record)}
-        trigger={['contextMenu']}
-        onOpenChange={onVisibleChange}>
-        {children}
-      </Dropdown>
-    ),
-    [ModelActionMenu],
+    }) => {
+      const canDelete = canDeleteModel({ model: record });
+      const canModify = canModifyModel({ model: record });
+      return canModify || canDelete ? (
+        <Dropdown
+          menu={ModelActionMenu(record, canDelete, canModify)}
+          trigger={['contextMenu']}
+          onOpenChange={onVisibleChange}>
+          {children}
+        </Dropdown>
+      ) : null;
+    },
+    [ModelActionMenu, canDeleteModel, canModifyModel],
   );
 
   return (


### PR DESCRIPTION
## Description

This should follow #6001

If user does not have `EDITMODELREGISTRY` permission in their cluster or workspace, UI should not appear editable. Server-side permission is already there.

Features on the model registry / list:
- Changing model name, description, or tags
- Using the three-dots menu at right to Archive the model (delete is handled separately)
- Using the right-click context menu to Archive the model

Features on the model details page:
- Changing the model name, description, or tags
- Using the three-dots menu at upper-right to Archive the model
- Adding a Note
- Editing Metadata

## Test Plan

OSS behavior should be unchanged.

This is difficult to test on EE before we can create models in different workspaces.
For now you can set `canModifyModel` to always `return false` and see what UI is disabled.

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.