### PR TITLE
fix: guard against store polling when not logged in

### DIFF
--- a/webui/react/src/components/Navigation.tsx
+++ b/webui/react/src/components/Navigation.tsx
@@ -35,7 +35,11 @@ const Navigation: React.FC<Props> = ({ children }) => {
   const currentUser = useCurrentUser();
   const fetchMyRoles = PermissionsStore.fetchMyAssignmentsAndRoles(canceler);
 
-  usePolling(fetchWorkspaces);
+  usePolling(() => {
+    if (currentUser !== NotLoaded) {
+      fetchWorkspaces();
+    }
+  });
 
   useEffect(() => {
     updateFaviconType(

--- a/webui/react/src/components/Navigation.tsx
+++ b/webui/react/src/components/Navigation.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 
 import useFeature from 'hooks/useFeature';
 import Spinner from 'shared/components/Spinner/Spinner';
@@ -35,11 +35,10 @@ const Navigation: React.FC<Props> = ({ children }) => {
   const currentUser = useCurrentUser();
   const fetchMyRoles = PermissionsStore.fetchMyAssignmentsAndRoles(canceler);
 
-  usePolling(() => {
-    if (currentUser !== NotLoaded) {
-      fetchWorkspaces();
-    }
-  });
+  const guardedFetchWorkspaces = useCallback(() => {
+    return currentUser !== NotLoaded && fetchWorkspaces();
+  }, [currentUser, fetchWorkspaces]);
+  usePolling(guardedFetchWorkspaces);
 
   useEffect(() => {
     updateFaviconType(

--- a/webui/react/src/stores/cluster.tsx
+++ b/webui/react/src/stores/cluster.tsx
@@ -11,10 +11,11 @@ import { clusterStatusText } from 'pages/Clusters/ClustersOverview';
 import { getAgents, getResourcePools } from 'services/api';
 import { clone, isEqual } from 'shared/utils/data';
 import { percent } from 'shared/utils/number';
+import { selectIsAuthenticated } from 'stores/auth';
 import { Agent, ClusterOverview, ClusterOverviewResource, ResourcePool, ResourceType } from 'types';
 import handleError from 'utils/error';
 import { Loadable, Loaded, NotLoaded } from 'utils/loadable';
-import { Observable, observable, WritableObservable } from 'utils/observable';
+import { Observable, observable, useObservable, WritableObservable } from 'utils/observable';
 
 const initResourceTally: ClusterOverviewResource = { allocation: 0, available: 0, total: 0 };
 // TODO: dont export
@@ -117,13 +118,14 @@ const ClusterContext = createContext<ClusterService | null>(null);
 
 export const ClusterProvider = ({ children }: { children: ReactNode }): ReactElement => {
   const [store] = useState(() => new ClusterService());
-
-  store.startPolling();
+  const isAuthenticated = useObservable(selectIsAuthenticated);
 
   useEffect(() => {
-    store.startPolling();
+    if (isAuthenticated) {
+      store.startPolling();
+    }
     return () => store.cancelPolling();
-  }, [store]);
+  }, [store, isAuthenticated]);
 
   return <ClusterContext.Provider value={store}>{children}</ClusterContext.Provider>;
 };


### PR DESCRIPTION

## Description

This fixes an issue where a login loop could occur when using Okta. Okta login requires auth to read the token after mounting the app. The initial call to check the auth happens in the App component. When we moved the agent and resource pool calls to an observable store, we moved the calls to init the information into a polling funciton called above the App component, causing a race condition where the auth would complete but the user would be kicked back to the login screen because the initial polling calls made before the user could be authenticated failed. To be safe, we fix a similar pattern happening in the navigation component which causes a failed request on the login page.



## Test Plan

logging in with okta should work



## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
no ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
