### PR TITLE
fix: Load roles after current user is loaded [WEB-924]

### DIFF
--- a/webui/react/src/components/Navigation.tsx
+++ b/webui/react/src/components/Navigation.tsx
@@ -50,14 +50,16 @@ const Navigation: React.FC<Props> = ({ children }) => {
   const rbacEnabled = useFeature().isOn('rbac'),
     mockAllPermission = useFeature().isOn('mock_permissions_all'),
     mockReadPermission = useFeature().isOn('mock_permissions_read');
-  usePolling(
-    () => {
-      if (rbacEnabled && !mockAllPermission && !mockReadPermission && currentUser !== NotLoaded) {
-        fetchMyRoles();
-      }
-    },
-    { interval: 120000 },
-  );
+  const syncRoles = useCallback(() => {
+    if (rbacEnabled && !mockAllPermission && !mockReadPermission && currentUser !== NotLoaded) {
+      fetchMyRoles();
+    }
+  }, [currentUser, fetchMyRoles, rbacEnabled, mockAllPermission, mockReadPermission]);
+
+  useEffect(() => {
+    syncRoles();
+  }, [currentUser, syncRoles]);
+  usePolling(syncRoles, { interval: 120000 });
 
   return (
     <Spinner spinning={ui.showSpinner}>

--- a/webui/react/src/components/Navigation.tsx
+++ b/webui/react/src/components/Navigation.tsx
@@ -58,7 +58,7 @@ const Navigation: React.FC<Props> = ({ children }) => {
 
   useEffect(() => {
     syncRoles();
-  }, [currentUser, syncRoles]);
+  }, [syncRoles]);
   usePolling(syncRoles, { interval: 120000 });
 
   return (


### PR DESCRIPTION
## Description

Fix a bug where EE / RBAC was not showing workspaces, models, or other right panel content unless you had just signed in.

Because the issue is not in OSS, hides the UI, and was connected to login; we know this relates to RBAC roles and storage.

The usePolling for `fetchMyRoles` is called on load and every 2 minutes after. If currentUser is NotLoaded on initial call, we skip that call and are left role-less.  Under this new setup, a `useEffect` fetches roles after `currentUser` changes. 

Notes:
`useEnsureCurrentUserFetched` is already successfully fetching the current user info from App.tsx; timing just was not good.
I'm open to `syncRoles` being a regular function instead of `useCallback` if it would work.

## Test Plan

- Run in EE
- Visit `/det/workspaces` and see workspaces
- Refresh the page and confirm workspaces re-appear

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.