### PR TITLE
fix: Display model breadcrumbs even if no access to workspace [WEB-919]

### DIFF
--- a/webui/react/src/pages/ModelDetails.tsx
+++ b/webui/react/src/pages/ModelDetails.tsx
@@ -70,8 +70,8 @@ const ModelDetails: React.FC = () => {
     NotLoaded: () => [],
   });
   const ensureWorkspacesFetched = useEnsureWorkspacesFetched(canceler.current);
-  const workspaces = useWorkspaces();
-  const workspace = Loadable.getOrElse([], workspaces).find(
+  const lodableWorkspaces = useWorkspaces();
+  const workspace = Loadable.getOrElse([], lodableWorkspaces).find(
     (ws) => ws.id === model?.model.workspaceId,
   );
 
@@ -446,7 +446,7 @@ const ModelDetails: React.FC = () => {
   } else if (pageError && !isNotFound(pageError)) {
     const message = `Unable to fetch model ${modelId}`;
     return <Message title={message} type={MessageType.Warning} />;
-  } else if (!model || workspaces === NotLoaded) {
+  } else if (!model || lodableWorkspaces === NotLoaded) {
     return <Spinner tip={`Loading model ${modelId} details...`} />;
   }
 

--- a/webui/react/src/pages/ModelDetails.tsx
+++ b/webui/react/src/pages/ModelDetails.tsx
@@ -42,7 +42,7 @@ import { useUsers } from 'stores/users';
 import { useEnsureWorkspacesFetched, useWorkspaces } from 'stores/workspaces';
 import { Metadata, ModelVersion, ModelVersions } from 'types';
 import handleError from 'utils/error';
-import { Loadable } from 'utils/loadable';
+import { Loadable, NotLoaded } from 'utils/loadable';
 
 import css from './ModelDetails.module.scss';
 import settingsConfig, {
@@ -70,8 +70,10 @@ const ModelDetails: React.FC = () => {
     NotLoaded: () => [],
   });
   const ensureWorkspacesFetched = useEnsureWorkspacesFetched(canceler.current);
-  const workspaces = Loadable.getOrElse([], useWorkspaces());
-  const workspace = workspaces.find((ws) => ws.id === model?.model.workspaceId);
+  const workspaces = useWorkspaces();
+  const workspace = Loadable.getOrElse([], workspaces).find(
+    (ws) => ws.id === model?.model.workspaceId,
+  );
 
   const { canModifyModel, canModifyModelVersion } = usePermissions();
 
@@ -444,7 +446,7 @@ const ModelDetails: React.FC = () => {
   } else if (pageError && !isNotFound(pageError)) {
     const message = `Unable to fetch model ${modelId}`;
     return <Message title={message} type={MessageType.Warning} />;
-  } else if (!model || !workspaces.length) {
+  } else if (!model || workspaces === NotLoaded) {
     return <Spinner tip={`Loading model ${modelId} details...`} />;
   }
 

--- a/webui/react/src/pages/ModelDetails.tsx
+++ b/webui/react/src/pages/ModelDetails.tsx
@@ -444,7 +444,7 @@ const ModelDetails: React.FC = () => {
   } else if (pageError && !isNotFound(pageError)) {
     const message = `Unable to fetch model ${modelId}`;
     return <Message title={message} type={MessageType.Warning} />;
-  } else if (!model || !workspace) {
+  } else if (!model || !workspaces.length) {
     return <Spinner tip={`Loading model ${modelId} details...`} />;
   }
 

--- a/webui/react/src/pages/ModelDetails/ModelHeader.tsx
+++ b/webui/react/src/pages/ModelDetails/ModelHeader.tsx
@@ -32,7 +32,7 @@ interface Props {
   onSaveName: (editedName: string) => Promise<Error | void>;
   onSwitchArchive: () => void;
   onUpdateTags: (newTags: string[]) => Promise<void>;
-  workspace: Workspace;
+  workspace?: Workspace;
 }
 
 const ModelHeader: React.FC<Props> = ({
@@ -146,17 +146,26 @@ const ModelHeader: React.FC<Props> = ({
               <LeftOutlined className={css.leftIcon} />
             </Link>
           </Breadcrumb.Item>
+          {workspace && (
+            <Breadcrumb.Item>
+              <Link
+                path={
+                  workspace.id === 1
+                    ? paths.projectDetails(1)
+                    : paths.workspaceDetails(workspace.id)
+                }>
+                {workspace.name}
+              </Link>
+            </Breadcrumb.Item>
+          )}
+          <Breadcrumb.Separator />
           <Breadcrumb.Item>
             <Link
               path={
-                workspace.id === 1 ? paths.projectDetails(1) : paths.workspaceDetails(workspace.id)
+                workspace
+                  ? paths.workspaceDetails(workspace.id, WorkspaceDetailsTab.ModelRegistry)
+                  : paths.modelList()
               }>
-              {workspace.name}
-            </Link>
-          </Breadcrumb.Item>
-          <Breadcrumb.Separator />
-          <Breadcrumb.Item>
-            <Link path={paths.workspaceDetails(workspace.id, WorkspaceDetailsTab.ModelRegistry)}>
               Model Registry
             </Link>
           </Breadcrumb.Item>

--- a/webui/react/src/pages/ModelDetails/ModelHeader.tsx
+++ b/webui/react/src/pages/ModelDetails/ModelHeader.tsx
@@ -162,7 +162,7 @@ const ModelHeader: React.FC<Props> = ({
           <Breadcrumb.Item>
             <Link
               path={
-                workspace
+                workspace?.id
                   ? paths.workspaceDetails(workspace.id, WorkspaceDetailsTab.ModelRegistry)
                   : paths.modelList()
               }>

--- a/webui/react/src/pages/ModelRegistry.tsx
+++ b/webui/react/src/pages/ModelRegistry.tsx
@@ -338,6 +338,9 @@ const ModelRegistry: React.FC<Props> = ({ workspace }: Props) => {
   const workspaceRenderer = useCallback(
     (record: ModelItem): React.ReactNode => {
       const workspace = workspaces.find((u) => u.id === record.workspaceId);
+      if (!workspace) {
+        return <DynamicIcon name="-" size={24} />;
+      }
       const workspaceId = record.workspaceId;
       return (
         <Tooltip placement="top" title={workspace?.name}>

--- a/webui/react/src/pages/ModelRegistry.tsx
+++ b/webui/react/src/pages/ModelRegistry.tsx
@@ -339,7 +339,11 @@ const ModelRegistry: React.FC<Props> = ({ workspace }: Props) => {
     (record: ModelItem): React.ReactNode => {
       const workspace = workspaces.find((u) => u.id === record.workspaceId);
       if (!workspace) {
-        return <DynamicIcon name="-" size={24} />;
+        return (
+          <Link disabled>
+            <DynamicIcon name="-" size={24} />
+          </Link>
+        );
       }
       const workspaceId = record.workspaceId;
       return (


### PR DESCRIPTION
## Description

If a user has Model Registry Viewer permission but not Workspace Viewer permission, we should display the Model Registry and Model Details pages successfully.

Related to WEB-919 and our previous work on Models,

- Global Model Registry (`/det/models`) will display a `[-]` block in the workspaces column if we can't display a useful link + name of an inaccessible workspace
- Model Viewer will stop spinner once workspaces are loaded (regardless of whether one with `model.workspace_id` is returned)
- Model Viewer's Header will link to Global Model Registry in the breadcrumbs if no workspace was accessible

## Test Plan

No effect on OSS.
You can test with a new user with only ModelRegistryViewer permission, or test having `canViewWorkspace` always return false.

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.