### PR TITLE
fix: cluster queued jobs page crash

### DIFF
--- a/webui/react/src/pages/JobQueue/JobQueue.tsx
+++ b/webui/react/src/pages/JobQueue/JobQueue.tsx
@@ -215,7 +215,7 @@ const JobQueue: React.FC<Props> = ({ bodyNoPadding, selectedRp, jobState }) => {
       if (replaceIndex !== -1) newColumns[replaceIndex] = col.dataIndex;
       if (!isEqual(newColumns, settings.columns)) updateSettings({ columns: newColumns });
     }
-  }, [settings.columns, settingsColumns, updateSettings]);
+  }, [settings.columns, settingsColumns]);
 
   const columns = useMemo(() => {
     return defaultColumns


### PR DESCRIPTION
## Description

The crash on the cluster jobs queued page is caused by infinite component re-renders due to `updateSettings` being an included dependency in a [useEffect](https://github.com/determined-ai/determined/blob/3ed96ccf44ce89cb00e54c25c540b95aab995cb2/webui/react/src/pages/JobQueue/JobQueue.tsx#L218). 
 
<!---
Lead with the intended commit body in this description field. For breaking
changes, please include "BREAKING CHANGE:" at the beginning of your commit
body.  At a minimum, this section should include a bracketed reference to the
Jira ticket, e.g. "[DET-1234]". When squash-and-merging, copy this directly
into the description field.
-->


## Test Plan
1. Log into the WebUI with a user that currently does not have any saved `job-queue` settings. You can also clear the settings in the database by running `DELETE FROM user_web_settings WHERE user_id = <user_id> AND storage_path LIKE '%job-queue%';`.
2. Visit the cluster overview page in the UI. `/det/clusters`.
3. Click on a `Resource Pool` card. For example the `default` resource pool.
4. Click on the `Queued` tab. The page should not crash and the UI should still be functional.
5. Resize and move columns in the table and switch to any other tab and back to the `Queued`. Ensure that the column settings are saved. 
6. In the `Active` tab. Resize and move columns in the table and switch to any other tab and back to the `Active` tab. Ensure that the column settings are saved. 

<!---
Describe the situations in which you've tested your change, and/or a screenshot
as appropriate.  Reviewers may ask questions about this test plan to ensure
adequate manual coverage of changes.
-->



## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [x] Changes have been manually QA'd
~- [ ] User-facing API changes need the "User-facing API Change" label.~
~- [ ] Release notes should be added as a separate file under `docs/release-notes/`.~
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
~- [ ] Licenses should be included for new code which was copied and/or modified from any external code.~

## Ticket
WEB-882

<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
