### PR TITLE
fix: Add #rank to worker segment instead of timestamp segment of Pytorch Profiler files [MLG-326]

### DIFF
--- a/harness/determined/tensorboard/util.py
+++ b/harness/determined/tensorboard/util.py
@@ -1,6 +1,7 @@
 import logging
 import pathlib
-from typing import List
+import re
+from typing import List, Optional
 
 tb_file_types = [
     "*tfevents*",
@@ -17,10 +18,22 @@ profiler_file_extensions = [
     ".xplane.pb",
     ".kernel_stats.pb",
     ".overview_page.pb",
-    ".pt.trace.json",
     ".trace.json.gz",
     ".trace.json",
 ]
+
+pytorch_profiler_file_extensions = [
+    ".pt.trace.json",
+    ".pt.trace.json.gz",
+]
+
+pytorch_profiler_file_pattern = re.compile(
+    r"""^(.*?) # worker name
+        (\.\d+)? # optional timestamp like 1619499959628 used as span name
+        \.pt\.trace\.json # the ending suffix
+        (?:\.gz)?$""",
+    re.X,
+)  # optional .gz extension
 
 
 def find_tb_files(base_dir: pathlib.Path) -> List[pathlib.Path]:
@@ -47,6 +60,11 @@ def get_rank_aware_path(path: pathlib.Path, rank: int) -> pathlib.Path:
     For example, with rank = 3 "2022_05_13_15_25_41/ip-172-31-8-212.input_pipeline.pb"
     will become "2022_05_13_15_25_41/ip-172-31-8-212#3.input_pipeline.pb"
     """
+
+    pytorch_profiler_extension = get_pytorch_profiler_file_extension(path)
+    if pytorch_profiler_extension:
+        return _get_rank_aware_path_pytorch_profiler(path, pytorch_profiler_extension, rank)
+
     for ext in profiler_file_extensions:
         if path.match(f"*{ext}"):
             num_parts = ext.count(".")
@@ -56,3 +74,46 @@ def get_rank_aware_path(path: pathlib.Path, rank: int) -> pathlib.Path:
             path = path.with_name(f"{path.name}#{rank}{ext}")
             return path
     return path
+
+
+def _get_rank_aware_path_pytorch_profiler(
+    path: pathlib.Path, pytorch_profiler_extension: str, rank: int
+) -> pathlib.Path:
+    path_parts = path.parts
+    file_name = path_parts[-1]
+    match = pytorch_profiler_file_pattern.match(file_name)
+
+    if match:
+        match_groups = match.groups()
+
+        worker = match_groups[0]
+        worker = worker + f"#{rank}"
+
+        span = match_groups[1]
+
+        if span:
+            file_name = f"{worker}{span}{pytorch_profiler_extension}"
+        else:
+            file_name = f"{worker}{pytorch_profiler_extension}"
+
+        path = pathlib.Path(path_parts[0])
+
+        for i in range(1, len(path_parts) - 1):
+            path = path.joinpath(path_parts[i])
+
+        path = path.joinpath(file_name)
+        return path
+    else:
+        raise Exception(
+            (
+                f"Path: {path} has pytorch profiler extension {pytorch_profiler_extension}",
+                "but no matching file pattern",
+            )
+        )
+
+
+def get_pytorch_profiler_file_extension(path: pathlib.Path) -> Optional[str]:
+    for ext in pytorch_profiler_file_extensions:
+        if path.match(f"*{ext}"):
+            return ext
+    return None

--- a/harness/determined/tensorboard/util.py
+++ b/harness/determined/tensorboard/util.py
@@ -82,7 +82,7 @@ def _get_rank_aware_path_pytorch_profiler(
     path_parts = path.parts
     file_name = path_parts[-1]
     match = pytorch_profiler_file_pattern.match(file_name)
-    print(f"SWY: in _get_rank_aware_path_pytorch_profiler input is {path}")
+
     if match:
         match_groups = match.groups()
 

--- a/harness/determined/tensorboard/util.py
+++ b/harness/determined/tensorboard/util.py
@@ -82,7 +82,7 @@ def _get_rank_aware_path_pytorch_profiler(
     path_parts = path.parts
     file_name = path_parts[-1]
     match = pytorch_profiler_file_pattern.match(file_name)
-
+    print(f"SWY: in _get_rank_aware_path_pytorch_profiler input is {path}")
     if match:
         match_groups = match.groups()
 
@@ -96,13 +96,16 @@ def _get_rank_aware_path_pytorch_profiler(
         else:
             file_name = f"{worker}{pytorch_profiler_extension}"
 
-        path = pathlib.Path(path_parts[0])
-
-        for i in range(1, len(path_parts) - 1):
-            path = path.joinpath(path_parts[i])
-
-        path = path.joinpath(file_name)
-        return path
+        if len(path_parts) == 1:
+            # only file name is passed in
+            return pathlib.Path(file_name)
+        else:
+            # path with directory is passed in
+            output_path = pathlib.Path(path_parts[0])
+            for i in range(1, len(path_parts) - 1):
+                output_path = output_path.joinpath(path_parts[i])
+            output_path = output_path.joinpath(file_name)
+            return output_path
     else:
         raise Exception(
             (

--- a/harness/determined/tensorboard/util.py
+++ b/harness/determined/tensorboard/util.py
@@ -87,7 +87,7 @@ def _get_rank_aware_path_pytorch_profiler(
         match_groups = match.groups()
 
         worker = match_groups[0]
-        worker = worker + f"#{rank}"
+        worker = f"{worker}#{rank}"
 
         span = match_groups[1]
 

--- a/harness/tests/tensorboard/test_util.py
+++ b/harness/tests/tensorboard/test_util.py
@@ -148,6 +148,18 @@ test_data = [
             "aa1f87508336_37#1.pt.trace.json.gz"
         ),
     ),
+    # Pytorch profiler file (only file name) with timestamp and ends with pt.trace.json.gz
+    (
+        "aa1f87508336_37.1674696139174.pt.trace.json.gz",
+        1,
+        "aa1f87508336_37#1.1674696139174.pt.trace.json.gz",
+    ),
+    # Pytorch profiler file (only file name) without timestamp and ends with pt.trace.json.gz
+    (
+        "aa1f87508336_37.pt.trace.json.gz",
+        1,
+        "aa1f87508336_37#1.pt.trace.json.gz",
+    ),
 ]
 
 

--- a/harness/tests/tensorboard/test_util.py
+++ b/harness/tests/tensorboard/test_util.py
@@ -100,6 +100,7 @@ test_data = [
         2,
         "/home/bob/tensorboard/the-host-name.some-extension.gz",
     ),
+    # Pytorch profiler file with timestamp and ends with pt.trace.json
     (
         (
             "/tmp/tensorboard-39.ff54aea9-0a94-4ce7-bf38-e8b3e69cc944.1-0/"
@@ -108,7 +109,43 @@ test_data = [
         1,
         (
             "/tmp/tensorboard-39.ff54aea9-0a94-4ce7-bf38-e8b3e69cc944.1-0/"
-            "aa1f87508336_37.1674696139174#1.pt.trace.json"
+            "aa1f87508336_37#1.1674696139174.pt.trace.json"
+        ),
+    ),
+    # Pytorch profiler file without timestamp and ends with pt.trace.json
+    (
+        (
+            "/tmp/tensorboard-39.ff54aea9-0a94-4ce7-bf38-e8b3e69cc944.1-0/"
+            "aa1f87508336_37.pt.trace.json"
+        ),
+        1,
+        (
+            "/tmp/tensorboard-39.ff54aea9-0a94-4ce7-bf38-e8b3e69cc944.1-0/"
+            "aa1f87508336_37#1.pt.trace.json"
+        ),
+    ),
+    # Pytorch profiler file with timestamp and ends with pt.trace.json.gz
+    (
+        (
+            "/tmp/tensorboard-39.ff54aea9-0a94-4ce7-bf38-e8b3e69cc944.1-0/"
+            "aa1f87508336_37.1674696139174.pt.trace.json.gz"
+        ),
+        1,
+        (
+            "/tmp/tensorboard-39.ff54aea9-0a94-4ce7-bf38-e8b3e69cc944.1-0/"
+            "aa1f87508336_37#1.1674696139174.pt.trace.json.gz"
+        ),
+    ),
+    # Pytorch profiler file without timestamp and ends with pt.trace.json.gz
+    (
+        (
+            "/tmp/tensorboard-39.ff54aea9-0a94-4ce7-bf38-e8b3e69cc944.1-0/"
+            "aa1f87508336_37.pt.trace.json.gz"
+        ),
+        1,
+        (
+            "/tmp/tensorboard-39.ff54aea9-0a94-4ce7-bf38-e8b3e69cc944.1-0/"
+            "aa1f87508336_37#1.pt.trace.json.gz"
         ),
     ),
 ]


### PR DESCRIPTION
## Description

As I investigate MLG-326, I notice that the current way to append rank to PT profiler files would append the rank behind the timestamp as opposed to the worker.

This clashes with the torch-tb-profiler library's regex to parse worker and time stamp (see [link](https://github.com/pytorch/kineto/blob/cdfa44f8d8f2f2b5c6f2efa83322977551e05d92/tb_plugin/torch_tb_profiler/profiler/loader.py#L28))

As a result, each {worker}{timestamp#rank} file was treated as one worker in the visualization. For example, if a worker has 10 PT profiler files of different time stamp, they were treated as 10 different workers.

After this change, each {worker#rank} is treated as one worker and each timestamp file for it would be treated as a span (see screenshot in test plan for details)




## Test Plan

### Added unit tests
Make sure unit test jobs finish successfully

### End to end testing (local)
Spin up devcluster locally
Create an experiment making use of PT profiler
Check that the Tensorboard TB profiler tab shows worker and span properly
<img width="2560" alt="Screen Shot 2023-02-21 at 11 36 43 AM" src="https://user-images.githubusercontent.com/16422598/220443722-cff6a3bd-f1b6-472a-96bd-5782ae14605c.png">


### End to end testing (AWS)
Deply a cluster on hash:
Create experiment
Check that Tensorboard TB profiler tab is showing worker and span properly
<img width="2559" alt="Screen Shot 2023-02-21 at 2 29 59 PM" src="https://user-images.githubusercontent.com/16422598/220474515-9cfa6ada-a3b0-4c85-a44a-947d9fefc57b.png">




## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
MLG-326

