### PR TITLE
build: run jest with 7 workers in ci

### DIFF
--- a/webui/react/Makefile
+++ b/webui/react/Makefile
@@ -104,7 +104,7 @@ test:
 
 .PHONY: test-ci
 test-ci:
-	JEST_JUNIT_OUTPUT_DIR=coverage npm run test:coverage -- --reporters=jest-junit
+	JEST_JUNIT_OUTPUT_DIR=coverage npm run test:coverage -- --reporters=jest-junit --maxWorkers=7
 
 # shared-web helpers
 


### PR DESCRIPTION
## Description

This limits the react tests to running with 7 workers in ci. This is because jest runs with one worker per detected cpu core and this number exceeds the cores we have available to us in the container. This can cause our test execution to get throttled, which can cause our tests to run slower than usual and possibly timeout. Because we're looking to move from jest anyways, the purpose of posting this pull request is to compare its runtimes to the runtimes on master and to the #5926 draft pr.



## Test Plan

unit-test-react should continue to pass.



## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
