### PR TITLE
fix: k8s rm gives wrong slot count in rendezvous

### DIFF
--- a/master/internal/rm/kubernetesrm/resource_pool.go
+++ b/master/internal/rm/kubernetesrm/resource_pool.go
@@ -651,7 +651,7 @@ func (p k8sPodResources) Summary() sproto.ResourcesSummary {
 		ResourcesType: sproto.ResourcesTypeK8sPod,
 		AgentDevices: map[aproto.ID][]device.Device{
 			// TODO: Make it more obvious k8s can't be trusted.
-			aproto.ID(p.podsActor.Address().Local()): nil,
+			aproto.ID(p.podsActor.Address().Local()): make([]device.Device, p.slots),
 		},
 
 		ContainerID: &p.containerID,


### PR DESCRIPTION
## Description

Rendezvous relied on ```Resources.Slots()``` which relied on ```AgentDevices``` which K8s does not report correctly. This made us pass ```-np=0``` to horrovod causing distributed tests to fail.

## Test Plan

K8s dist tests pass

## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
