### PR TITLE
feat: Display better x-axis ticks on charts with time axis [WEB-849]

### DIFF
--- a/webui/react/src/components/kit/LineChart.tsx
+++ b/webui/react/src/components/kit/LineChart.tsx
@@ -61,7 +61,6 @@ interface Props {
   title?: string;
   xAxis?: XAxisDomain;
   xLabel?: string;
-  xTickValues?: uPlot.Axis.Values;
   yLabel?: string;
   yTickValues?: uPlot.Axis.Values;
 }
@@ -79,7 +78,6 @@ export const LineChart: React.FC<Props> = ({
   xAxis = XAxisDomain.Batches,
   xLabel,
   yLabel,
-  xTickValues,
   yTickValues,
 }: Props) => {
   const hasPopulatedSeries: boolean = useMemo(
@@ -125,16 +123,15 @@ export const LineChart: React.FC<Props> = ({
     return [xValues, ...yValuesArray];
   }, [series, xAxis]);
 
-  const xTicksAdjusted: uPlot.Axis.Values | undefined = useMemo(
+  const xTickValues: uPlot.Axis.Values | undefined = useMemo(
     () =>
-      xTickValues ??
-      (xAxis === XAxisDomain.Time &&
-        chartData.length > 0 &&
-        chartData[0].length > 0 &&
-        chartData[0][chartData[0].length - 1] - chartData[0][0] < 43200) // 12 hours
+      xAxis === XAxisDomain.Time &&
+      chartData.length > 0 &&
+      chartData[0].length > 0 &&
+      chartData[0][chartData[0].length - 1] - chartData[0][0] < 43200 // 12 hours
         ? getTimeTickValues
         : undefined,
-    [chartData, xAxis, xTickValues],
+    [chartData, xAxis],
   );
 
   const chartOptions: Options = useMemo(() => {
@@ -161,7 +158,7 @@ export const LineChart: React.FC<Props> = ({
           side: 2,
           space: 120,
           ticks: { show: false },
-          values: xTicksAdjusted,
+          values: xTickValues,
         },
         {
           font: '12px "Objektiv Mk3", Arial, Helvetica, sans-serif',
@@ -208,7 +205,7 @@ export const LineChart: React.FC<Props> = ({
     onPointClick,
     onPointFocus,
     xLabel,
-    xTicksAdjusted,
+    xTickValues,
     yLabel,
     yTickValues,
     height,

--- a/webui/react/src/components/kit/LineChart.tsx
+++ b/webui/react/src/components/kit/LineChart.tsx
@@ -82,11 +82,6 @@ export const LineChart: React.FC<Props> = ({
   xTickValues,
   yTickValues,
 }: Props) => {
-  const xTicksAdjusted: uPlot.Axis.Values | undefined = useMemo(
-    () => xTickValues ?? (xAxis === XAxisDomain.Time ? getTimeTickValues : undefined),
-    [xAxis, xTickValues],
-  );
-
   const hasPopulatedSeries: boolean = useMemo(
     () => !!series.find((serie) => serie.data[xAxis]?.length),
     [series, xAxis],
@@ -129,6 +124,18 @@ export const LineChart: React.FC<Props> = ({
 
     return [xValues, ...yValuesArray];
   }, [series, xAxis]);
+
+  const xTicksAdjusted: uPlot.Axis.Values | undefined = useMemo(
+    () =>
+      xTickValues ??
+      (xAxis === XAxisDomain.Time &&
+        chartData.length > 0 &&
+        chartData[0].length > 0 &&
+        chartData[0][chartData[0].length - 1] - chartData[0][0] < 43200) // 12 hours
+        ? getTimeTickValues
+        : undefined,
+    [chartData, xAxis, xTickValues],
+  );
 
   const chartOptions: Options = useMemo(() => {
     const plugins: Plugin[] = propPlugins ?? [

--- a/webui/react/src/pages/TrialDetails/Profiles/Charts/SystemMetricChart.tsx
+++ b/webui/react/src/pages/TrialDetails/Profiles/Charts/SystemMetricChart.tsx
@@ -5,7 +5,6 @@ import { LineChart } from 'components/kit/LineChart';
 import { XAxisDomain } from 'components/kit/LineChart/XAxisFilter';
 import Section from 'components/Section';
 import { SettingsConfig, useSettings } from 'hooks/useSettings';
-import { getTimeTickValues } from 'utils/chart';
 
 import { ChartProps } from '../types';
 import { MetricType } from '../types';
@@ -94,7 +93,6 @@ const SystemMetricChart: React.FC<ChartProps> = ({ trial }) => {
         series={systemMetrics.data}
         xAxis={XAxisDomain.Time}
         xLabel="Time"
-        xTickValues={getTimeTickValues}
         yLabel={yLabel}
         yTickValues={getScientificNotationTickValues}
       />

--- a/webui/react/src/pages/TrialDetails/Profiles/Charts/SystemMetricChart.tsx
+++ b/webui/react/src/pages/TrialDetails/Profiles/Charts/SystemMetricChart.tsx
@@ -5,12 +5,13 @@ import { LineChart } from 'components/kit/LineChart';
 import { XAxisDomain } from 'components/kit/LineChart/XAxisFilter';
 import Section from 'components/Section';
 import { SettingsConfig, useSettings } from 'hooks/useSettings';
+import { getTimeTickValues } from 'utils/chart';
 
 import { ChartProps } from '../types';
 import { MetricType } from '../types';
 import { useFetchProfilerMetrics } from '../useFetchProfilerMetrics';
 import { useFetchProfilerSeries } from '../useFetchProfilerSeries';
-import { getScientificNotationTickValues, getTimeTickValues, getUnitForMetricName } from '../utils';
+import { getScientificNotationTickValues, getUnitForMetricName } from '../utils';
 
 import SystemMetricFilter from './SystemMetricChartFilters';
 

--- a/webui/react/src/pages/TrialDetails/Profiles/Charts/ThroughputMetricChart.tsx
+++ b/webui/react/src/pages/TrialDetails/Profiles/Charts/ThroughputMetricChart.tsx
@@ -3,7 +3,6 @@ import React from 'react';
 import { LineChart } from 'components/kit/LineChart';
 import { XAxisDomain } from 'components/kit/LineChart/XAxisFilter';
 import Section from 'components/Section';
-import { getTimeTickValues } from 'utils/chart';
 
 import { ChartProps } from '../types';
 import { MetricType } from '../types';
@@ -28,7 +27,6 @@ const ThroughputMetricChart: React.FC<ChartProps> = ({ trial }) => {
         series={throughputMetrics.data}
         xAxis={XAxisDomain.Time}
         xLabel="Time"
-        xTickValues={getTimeTickValues}
         yLabel={yLabel}
         yTickValues={getScientificNotationTickValues}
       />

--- a/webui/react/src/pages/TrialDetails/Profiles/Charts/ThroughputMetricChart.tsx
+++ b/webui/react/src/pages/TrialDetails/Profiles/Charts/ThroughputMetricChart.tsx
@@ -3,11 +3,12 @@ import React from 'react';
 import { LineChart } from 'components/kit/LineChart';
 import { XAxisDomain } from 'components/kit/LineChart/XAxisFilter';
 import Section from 'components/Section';
+import { getTimeTickValues } from 'utils/chart';
 
 import { ChartProps } from '../types';
 import { MetricType } from '../types';
 import { useFetchProfilerMetrics } from '../useFetchProfilerMetrics';
-import { getScientificNotationTickValues, getTimeTickValues, getUnitForMetricName } from '../utils';
+import { getScientificNotationTickValues, getUnitForMetricName } from '../utils';
 
 const ThroughputMetricChart: React.FC<ChartProps> = ({ trial }) => {
   const throughputMetrics = useFetchProfilerMetrics(

--- a/webui/react/src/pages/TrialDetails/Profiles/Charts/TimingMetricChart.tsx
+++ b/webui/react/src/pages/TrialDetails/Profiles/Charts/TimingMetricChart.tsx
@@ -3,11 +3,12 @@ import React from 'react';
 import { LineChart } from 'components/kit/LineChart';
 import { XAxisDomain } from 'components/kit/LineChart/XAxisFilter';
 import Section from 'components/Section';
+import { getTimeTickValues } from 'utils/chart';
 
 import { ChartProps } from '../types';
 import { MetricType } from '../types';
 import { useFetchProfilerMetrics } from '../useFetchProfilerMetrics';
-import { getScientificNotationTickValues, getTimeTickValues, getUnitForMetricName } from '../utils';
+import { getScientificNotationTickValues, getUnitForMetricName } from '../utils';
 
 export const TimingMetricChart: React.FC<ChartProps> = ({ trial }) => {
   const timingMetrics = useFetchProfilerMetrics(trial.id, trial.state, MetricType.Timing);

--- a/webui/react/src/pages/TrialDetails/Profiles/Charts/TimingMetricChart.tsx
+++ b/webui/react/src/pages/TrialDetails/Profiles/Charts/TimingMetricChart.tsx
@@ -3,7 +3,6 @@ import React from 'react';
 import { LineChart } from 'components/kit/LineChart';
 import { XAxisDomain } from 'components/kit/LineChart/XAxisFilter';
 import Section from 'components/Section';
-import { getTimeTickValues } from 'utils/chart';
 
 import { ChartProps } from '../types';
 import { MetricType } from '../types';
@@ -21,7 +20,6 @@ export const TimingMetricChart: React.FC<ChartProps> = ({ trial }) => {
         series={timingMetrics.data}
         xAxis={XAxisDomain.Time}
         xLabel="Time"
-        xTickValues={getTimeTickValues}
         yLabel={yLabel}
         yTickValues={getScientificNotationTickValues}
       />

--- a/webui/react/src/pages/TrialDetails/Profiles/utils.ts
+++ b/webui/react/src/pages/TrialDetails/Profiles/utils.ts
@@ -1,4 +1,3 @@
-import dayjs from 'dayjs';
 import uPlot from 'uplot';
 
 // key should be lowercase to match the metric name
@@ -19,10 +18,6 @@ export const getUnitForMetricName = (metricName: string): string => {
   return metricName in MetricNameUnit
     ? MetricNameUnit[metricName as keyof typeof MetricNameUnit]
     : metricName;
-};
-
-export const getTimeTickValues: uPlot.Axis['values'] = (_self, rawValue) => {
-  return rawValue.map((val) => dayjs.unix(val).format('hh:mm:ss.SSS').slice(0, -2));
 };
 
 export const getScientificNotationTickValues: uPlot.Axis['values'] = (_self, rawValue) => {

--- a/webui/react/src/utils/chart.ts
+++ b/webui/react/src/utils/chart.ts
@@ -79,6 +79,6 @@ export function distance(x0: number, y0: number, x1: number, y1: number): number
   return Math.sqrt((x1 - x0) ** 2 + (y1 - y0) ** 2);
 }
 
-export const getTimeTickValues: uPlot.Axis['values'] = (_self, rawValue) => {
+export const getTimeTickValues: uPlot.Axis.Values = (_self, rawValue) => {
   return rawValue.map((val) => dayjs.unix(val).format('hh:mm:ss.SSS').slice(0, -2));
 };

--- a/webui/react/src/utils/chart.ts
+++ b/webui/react/src/utils/chart.ts
@@ -1,3 +1,6 @@
+import dayjs from 'dayjs';
+import uPlot from 'uplot';
+
 import { Theme } from 'shared/themes';
 import { Primitive, Range } from 'shared/types';
 import { ColorScale } from 'shared/utils/color';
@@ -75,3 +78,7 @@ export const normalizeRange = (values: number[], range: Range<number>): number[]
 export function distance(x0: number, y0: number, x1: number, y1: number): number {
   return Math.sqrt((x1 - x0) ** 2 + (y1 - y0) ** 2);
 }
+
+export const getTimeTickValues: uPlot.Axis['values'] = (_self, rawValue) => {
+  return rawValue.map((val) => dayjs.unix(val).format('hh:mm:ss.SSS').slice(0, -2));
+};


### PR DESCRIPTION
## Description

Chart time axis improvements:
- Moves `getTimeTickValues` from `pages/TrialDetails/Profiles/utils` to `utils/chart`
- Fixes a bug we discussed.
- On experiments less than 12 hours, use `getTimeTickValues` for axis ticks. See http://localhost:3000/det/experiments/1622/overview?f_chart=on for a 1-minute experiment

<img width="527" alt="Screen Shot 2023-02-22 at 12 30 29 PM" src="https://user-images.githubusercontent.com/643918/220724876-9d348f70-6f0d-48e6-8746-43aa1ea4f065.png">

- On experiments longer than 12 hours, use uPlot's default axis ticks. See http://localhost:3000/det/experiments/1621/overview?f_chart=on for a 20-hour experiment

<img width="520" alt="Screen Shot 2023-02-22 at 12 30 23 PM" src="https://user-images.githubusercontent.com/643918/220724882-5c3306e7-d522-409c-9123-6f2ea5edb366.png">


## Test Plan

- On the linked experiments, with `f_chart=on`, verify that you can change linear/log scale
- On the linked experiments, set x-axis to Time
- Open to feedback on these and shorter/longer experiments


## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.