### PR TITLE
fix: lopsided training with 2,1 gpus

### DIFF
--- a/harness/determined/core/_distributed.py
+++ b/harness/determined/core/_distributed.py
@@ -111,10 +111,6 @@ class DistributedContext:
             )
             self._worker_zmq.safe_start()
 
-        if self.local_size < 2:
-            # No local broadcasting necessary.
-            return
-
         # Local broadcast server.
         self.tempdir = None
         if self.local_size < 2:


### PR DESCRIPTION
There was a guard to skip local zmq setup when local_size < 2, but that became no longer valid when local_size varied from worker to worker.

The result is one extra global allgather in some cases, no big deal.