### PR TITLE
fix: Checkpoint helper for points > 1000 and points > maxDatapoints

### DIFF
--- a/webui/react/src/pages/TrialDetails/F_TrialDetailsOverview.tsx
+++ b/webui/react/src/pages/TrialDetails/F_TrialDetailsOverview.tsx
@@ -59,26 +59,29 @@ const TrialDetailsOverview: React.FC<Props> = ({ experiment, trial }: Props) => 
   const { metrics, data, scale, setScale } = useTrialMetrics(trial);
 
   const checkpointsDict = useMemo<CheckpointsDict>(() => {
-    const timeHelpers: Record<XAxisVal, CheckpointWorkloadExtended> = {};
-    if (data && xAxis === XAxisDomain.Time && checkpoint?.totalBatches) {
+    const checkpointXHelpers: Record<XAxisVal, CheckpointWorkloadExtended> = {};
+    if (data && checkpoint?.totalBatches) {
       Object.values(data).forEach((metric) => {
         const matchIndex = metric.data[XAxisDomain.Batches]?.findIndex(
-          (pt) => pt[0] === checkpoint.totalBatches,
+          (pt) => pt[0] >= checkpoint.totalBatches,
         );
+
         if (matchIndex !== undefined && matchIndex >= 0) {
-          const timeVals = metric.data[XAxisDomain.Time];
-          if (timeVals && timeVals.length > matchIndex) {
-            timeHelpers[Math.floor(timeVals[matchIndex][0])] = checkpoint;
+          if (xAxis === XAxisDomain.Time) {
+            const timeVals = metric.data[XAxisDomain.Time];
+            if (timeVals && timeVals.length > matchIndex) {
+              checkpointXHelpers[Math.floor(timeVals[matchIndex][0])] = checkpoint;
+            }
+          } else if (xAxis === XAxisDomain.Batches) {
+            const batchX = metric.data[XAxisDomain.Batches]?.[matchIndex][0];
+            if (batchX) {
+              checkpointXHelpers[batchX] = checkpoint;
+            }
           }
         }
       });
     }
-    return checkpoint?.totalBatches
-      ? {
-          [checkpoint.totalBatches]: checkpoint,
-          ...timeHelpers,
-        }
-      : {};
+    return checkpoint?.totalBatches ? checkpointXHelpers : {};
   }, [data, checkpoint, xAxis]);
 
   const pairedMetrics: ([Metric] | [Metric, Metric])[] | undefined = useMemo(() => {
@@ -121,7 +124,7 @@ const TrialDetailsOverview: React.FC<Props> = ({ experiment, trial }: Props) => 
           xValSet.add(pt[0]);
         });
       });
-      const xVals = Array.from(xValSet).sort();
+      const xVals = Array.from(xValSet).sort((a, b) => a - b);
 
       const onPointClick = (event: MouseEvent, point: UPlotPoint) => {
         const xVal = xVals[point.idx];


### PR DESCRIPTION
## Description

While working on another PR, I noticed on http://latest-master.determined.ai:8080/det/experiments/1789/overview?f_chart=on the right chart is showing the tooltip for the checkpoint point (batch 1,000,000), but not the 'Best Checkpoint' notice text

The issue was `xVals = Array.from(xValSet).sort()` was sorting 1,000,000 alphabetically; using `.sort((a, b) => a - b)` fixes

While debugging this, I considered if `maxDatapoints` could hide a checkpoint when its batch x-value was not returned in the downsampled points. I changed `findIndex` to attach the checkpoint to the first x `>= checkpoint.totalBatches`. The final batch is kept by downscaling, so we don't need to worry about checkpoints at the end of an experiment.

## Test Plan

Visit `http://localhost:3000/det/experiments/1789/overview?f_chart=on` , confirm Best Checkpoint message appears on both charts on hover

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.