### PR TITLE
test: add locking around migration [DET-8957]

### DIFF
--- a/master/internal/db/migrations.go
+++ b/master/internal/db/migrations.go
@@ -132,6 +132,14 @@ func (db *PgDB) Migrate(migrationURL string, actions []string) error {
 	if err != nil {
 		return err
 	}
+
+	// In integration tests, multiple processes can be running this code at once, which can lead to
+	// errors because PostgreSQL's CREATE TABLE IF NOT EXISTS is not great with concurrency.
+	_, err = tx.Exec("LOCK TABLE pg_type")
+	if err != nil {
+		return err
+	}
+
 	defer func() {
 		// Rollback unless it has already been committed.
 		if errd := tx.Close(); errd != nil {


### PR DESCRIPTION
## Description

In integration tests, multiple processes can attempt to run migrations against the same database at once, which can lead to errors because PostgreSQL's `CREATE TABLE IF NOT EXISTS` is not great with concurrency (it allows for a time-of-check/time-of-use failure).

The specific errors we were seeing were conflicts in the pg_type table, so the code now locks that table for the duration of the migration transaction.

More information:
https://www.postgresql.org/message-id/CA+TgmoZAdYVtwBfp1FL2sMZbiHCWT4UPrzRLNnX1Nb30Ku3-gg@mail.gmail.com https://stackoverflow.com/questions/29900845

## Test Plan

- [x] check locally that `make test-intg` is passing consistently, where it was often flaking before