### PR TITLE
Revert "fix: add missing newline to slurm logs [DET-8943]"

### DIFF
--- a/master/static/srv/enrich_task_logs.py
+++ b/master/static/srv/enrich_task_logs.py
@@ -74,7 +74,7 @@ class LogCollector(threading.Thread):
                     self.ship_queue.put(
                         {
                             "timestamp": datetime.datetime.now(datetime.timezone.utc).isoformat(),
-                            "log": line + "\n",
+                            "log": line,
                             **self.task_logging_metadata,
                             **parsed_metadata,
                         }


### PR DESCRIPTION
Reverts determined-ai/determined#6027

Breaks Slurm output logs display and test_task_logging.py now fails with slurm.

![image](https://user-images.githubusercontent.com/84593277/221206113-2c1c7c0c-3351-4658-b530-12d4c725d4f2.png)
