### PR TITLE
build: Apply webui lint fixes in precommit

### DIFF
--- a/pre-commit/web_lint_check.py
+++ b/pre-commit/web_lint_check.py
@@ -4,17 +4,19 @@ import argparse
 import multiprocessing
 import os
 import subprocess
+from typing import List
 
 
 def web_lint_check():
     parser = argparse.ArgumentParser(description="Lint Check for Web")
     parser.add_argument("target", help="Either js, css, or misc", choices=["js", "css", "misc"])
-    parser.add_argument("file_paths", help="1 or more file paths", nargs="+")
+    parser.add_argument("file_paths", help="1 or more file paths", nargs="+", type=List[str])
     args = parser.parse_args()
     DIR = "webui/react/"
 
     target: str = args.target
-    file_paths: str = " ".join([os.path.relpath(file_path, DIR) for file_path in args.file_paths])
+    file_paths: List[str] = args.file_paths
+    rel_file_paths: str = " ".join([os.path.relpath(file_path, DIR) for file_path in file_paths])
     nproc: int = multiprocessing.cpu_count()
     run_command: list[str] = [
         "make",
@@ -22,19 +24,19 @@ def web_lint_check():
         "-C",
         DIR,
         "prettier",
-        f"PRE_ARGS=-- --write -c {file_paths}",
+        f"PRE_ARGS=-- --write -c {rel_file_paths}",
     ]
 
     # TODO: replace it with `match` if we support python v3.10
     if target == "js":
-        run_command += ["eslint", f"ES_ARGS=-- --fix {file_paths}"]
+        run_command += ["eslint", f"ES_ARGS=-- --fix {rel_file_paths}"]
     elif target == "css":
-        run_command += ["stylelint", f"ST_ARGS=-- --fix {file_paths}"]
+        run_command += ["stylelint", f"ST_ARGS=-- --fix {rel_file_paths}"]
     elif target == "misc":
         run_command += ["check-package-lock"]
 
     returncode: int = subprocess.call(run_command)
-    subprocess.call(["git", "add"] + args.file_paths)
+    subprocess.call(["git", "add"] + file_paths)
     exit(returncode)
 
 

--- a/pre-commit/web_lint_check.py
+++ b/pre-commit/web_lint_check.py
@@ -22,14 +22,14 @@ def web_lint_check():
         "-C",
         DIR,
         "prettier",
-        f"PRE_ARGS=-- -c {file_paths}",
+        f"PRE_ARGS=-- --write -c {file_paths}",
     ]
 
     # TODO: replace it with `match` if we support python v3.10
     if target == "js":
-        run_command += ["eslint", f"ES_ARGS={file_paths}"]
+        run_command += ["eslint", f"ES_ARGS=--fix {file_paths}"]
     elif target == "css":
-        run_command += ["stylelint", f"ST_ARGS={file_paths}"]
+        run_command += ["stylelint", f"ST_ARGS=--fix {file_paths}"]
     elif target == "misc":
         run_command += ["check-package-lock"]
 

--- a/pre-commit/web_lint_check.py
+++ b/pre-commit/web_lint_check.py
@@ -27,9 +27,9 @@ def web_lint_check():
 
     # TODO: replace it with `match` if we support python v3.10
     if target == "js":
-        run_command += ["eslint", f"ES_ARGS=--fix {file_paths}"]
+        run_command += ["eslint", f"ES_ARGS=-- --fix {file_paths}"]
     elif target == "css":
-        run_command += ["stylelint", f"ST_ARGS=--fix {file_paths}"]
+        run_command += ["stylelint", f"ST_ARGS=-- --fix {file_paths}"]
     elif target == "misc":
         run_command += ["check-package-lock"]
 

--- a/pre-commit/web_lint_check.py
+++ b/pre-commit/web_lint_check.py
@@ -34,6 +34,7 @@ def web_lint_check():
         run_command += ["check-package-lock"]
 
     returncode: int = subprocess.call(run_command)
+    subprocess.call(["git", "add"] + args.file_paths)
     exit(returncode)
 
 


### PR DESCRIPTION
## Description

This updates the web linters to automatically apply fixes when doing a
pre-commit check. This should ideally streamline the commit process to
reduce the amount of times the user needs to run prettier and eslint
before committing.


## Test Plan

When committing code, if the code contains issues that a linter can fix automatically, those fixes should be applied ~while also preventing the commit from going through~.
things to check:

* prettier: try adding a statement to a ts file without a semicolon
* eslint: try disabling a test in a ts file by replacing the `it` call with `xit`
* stylelint: try adding a blank line in between two style declaration blocks


## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
[WEB-928]


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->


[WEB-928]: https://determinedai.atlassian.net/browse/WEB-928?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ