### PR TITLE
build: check npm version on install

### DIFF
--- a/webui/react/.npmrc
+++ b/webui/react/.npmrc
@@ -1,1 +1,2 @@
 legacy-peer-deps=true
+engine-strict=true

--- a/webui/react/Makefile
+++ b/webui/react/Makefile
@@ -17,11 +17,11 @@ node_modules/done.stamp: package-lock.json
 	touch $@
 
 .PHONY: get-deps
-get-deps: check-requirements node_modules/done.stamp
+get-deps: node_modules/done.stamp
 	git submodule update --init
 
 .PHONY: build
-build: check-requirements build/done.stamp
+build: build/done.stamp
 
 build/done.stamp: $(source_files) node_modules/done.stamp tsconfig.json craco.config.js jest.config.js vite.config.ts
 	npm run build
@@ -32,7 +32,7 @@ clean:
 	rm -rf build build-storybook node_modules/
 
 .PHONY: live
-live: check-requirements start
+live: start
 .PHONY: start
 start:
 	npm start
@@ -62,9 +62,6 @@ check-prettier-misc:
 .PHONY: check-package-lock
 check-package-lock:
 	if grep 'ssh://' package-lock.json ; then echo "ssh url in package-lock.json, please convert to https url" ; false ; fi
-.PHONY: check-requirements
-check-requirements:
-	node --version | grep -E 'v16\.(1[3-9]|2[0-9])|v1[7|8|9]' || (echo "node version >=16.13 <20 is required" ; false)
 .PHONY: check-prettier
 check-prettier: check-prettier-js check-prettier-css check-prettier-misc
 .PHONY: check


### PR DESCRIPTION
## Description

This removes the `check-requirements` make target in the react folder and replaces it with npm's native version check against the engines property. This should make managing the node version slightly easier because there's one less place to check.

## Test Plan

If running a version of node that's not supported in the package.json engines property, `npm install` should fail.

## Checklist

- [X] Changes have been manually QA'd
- [X] User-facing API changes need the "User-facing API Change" label.
- [X] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [X] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket

No ticket
