### PR TITLE
fix: Dont suggest moving model into its current workspace [WEB-941]

### DIFF
--- a/webui/react/src/hooks/useModal/Model/useModalModelMove.tsx
+++ b/webui/react/src/hooks/useModal/Model/useModalModelMove.tsx
@@ -83,7 +83,10 @@ const useModalModelMove = ({ onClose }: Props = {}): ModalHooks => {
                 }
                 filterSort={(a, b) => ((a?.label ?? '') < (b?.label ?? '') ? 1 : -1)}
                 options={workspaces
-                  .filter((ws) => canMoveModel({ destination: { id: ws.id } }))
+                  .filter(
+                    (ws) =>
+                      ws.id !== model.workspaceId && canMoveModel({ destination: { id: ws.id } }),
+                  )
                   .map((ws) => ({ label: ws.name, value: ws.id }))}
                 placeholder="Select a workspace"
                 showSearch


### PR DESCRIPTION
## Description

When moving a model, we already filtered the dropdown of destinations by canMoveModel,
but the bug notes we include the model's current workspace.


## Test Plan

- As admin, go to `/det/models` and select a model to view details.
- Note the parent workspace in the left of the breadcrumb menu (in the screenshot, "Demo")

<img width="518" alt="Screen Shot 2023-02-27 at 12 10 19 PM" src="https://user-images.githubusercontent.com/643918/221647735-c60bf909-2ecd-4cf7-8d12-55bbc3c9a975.png">

 - In the top right of model details, click the three dots menu and select Move
 - For the destination workspace name, try to find the model's parent workspace. It will not be there

<img width="495" alt="Screen Shot 2023-02-27 at 12 11 34 PM" src="https://user-images.githubusercontent.com/643918/221647960-b4af617f-44ef-4a00-b554-219ac357792e.png">


## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.