### PR TITLE
ci: delete database at beginning of det deploy tests [DET-8937]

### DIFF
--- a/e2e_tests/tests/deploy/test_local.py
+++ b/e2e_tests/tests/deploy/test_local.py
@@ -26,8 +26,10 @@ def det_deploy(subcommand: List) -> None:
     subprocess.run(command)
 
 
-def cluster_up(arguments: List) -> None:
+def cluster_up(arguments: List, delete_db: bool = True) -> None:
     command = ["cluster-up", "--no-gpu"]
+    if delete_db:
+        command += ["--delete-db"]
     det_version = conf.DET_VERSION
     if det_version is not None:
         command += ["--det-version", det_version]
@@ -41,8 +43,10 @@ def cluster_down(arguments: List) -> None:
     det_deploy(command)
 
 
-def master_up(arguments: List) -> None:
+def master_up(arguments: List, delete_db: bool = True) -> None:
     command = ["master-up"]
+    if delete_db:
+        command += ["--delete-db"]
     det_version = conf.DET_VERSION
     if det_version is not None:
         command += ["--det-version", det_version]


### PR DESCRIPTION
## Description

Previously, the database was being retained between tests, sometimes causing tests to fail when extra agents appeared due to agent reattach. The tests should generally be independent anyway, so reset the database (by default, with an option to disable) each time the cluster or master comes up.

## Test Plan

- [x] loop tests before and after change: https://app.circleci.com/pipelines/github/determined-ai/determined?branch=test%2Fstress