### PR TITLE
chore: race could cause run container to return a different error than expected [DET-8870]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1443,6 +1443,15 @@ jobs:
           executor: <<pipeline.parameters.machine-image>>
       - setup-go-intg-deps
       - run: make -C agent test-intg
+      - run: make -C agent test-intg
+      - run: make -C agent test-intg
+      - run: make -C agent test-intg
+      - run: make -C agent test-intg
+      - run: make -C agent test-intg
+      - run: make -C agent test-intg
+      - run: make -C agent test-intg
+      - run: make -C agent test-intg
+      - run: make -C agent test-intg        
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1443,15 +1443,6 @@ jobs:
           executor: <<pipeline.parameters.machine-image>>
       - setup-go-intg-deps
       - run: make -C agent test-intg
-      - run: make -C agent test-intg
-      - run: make -C agent test-intg
-      - run: make -C agent test-intg
-      - run: make -C agent test-intg
-      - run: make -C agent test-intg
-      - run: make -C agent test-intg
-      - run: make -C agent test-intg
-      - run: make -C agent test-intg
-      - run: make -C agent test-intg        
       - persist_to_workspace:
           root: .
           paths:

--- a/agent/internal/container/container.go
+++ b/agent/internal/container/container.go
@@ -239,11 +239,11 @@ func (c *Container) run(parent context.Context) (err error) {
 	})
 
 	c.log.Trace("waiting for launch to complete")
-	err := launchgroup.Wait()
+	err = launchgroup.Wait()
 	// Cancel here instead of inside the SIGKILL shim, to avoid a race between canceling
 	// the context and ErrKilledBeforeRun being the first error this errgroupx gets.
 	launchgroup.Cancel()
-	switch err {
+	switch {
 	case err != nil && dockerContainer != nil:
 		// There is a chance the launchgroup handled a signal, but that it happened after we
 		// successfully ran the container. In this case, just pretend we didn't handle the signal,

--- a/agent/internal/container/container.go
+++ b/agent/internal/container/container.go
@@ -216,9 +216,8 @@ func (c *Container) run(parent context.Context) (err error) {
 			if err != nil {
 				c.log.Trace("ensuring cleanup of container (canceled prior to the monitoring loop)")
 				if remove {
-					// Using parent context instead of just ctx since we could have canceled
-					// ctx right after creating the container via SIGKILL shim returning an error.
-					if rErr := c.docker.RemoveContainer(parent, dockerID, true); rErr != nil {
+					// TODO this context could be canceled between CreateContainer and this.
+					if rErr := c.docker.RemoveContainer(ctx, dockerID, true); rErr != nil {
 						c.log.WithError(rErr).Debug("couldn't cleanup container")
 					}
 				}

--- a/agent/internal/container/container.go
+++ b/agent/internal/container/container.go
@@ -237,8 +237,7 @@ func (c *Container) run(parent context.Context) (err error) {
 	})
 
 	c.log.Trace("waiting for launch to complete")
-	err = launchgroup.Wait()
-	switch {
+	switch err := launchgroup.Wait(); {
 	case err != nil && dockerContainer != nil:
 		// There is a chance the launchgroup handled a signal, but that it happened after we
 		// successfully ran the container. In this case, just pretend we didn't handle the signal,

--- a/agent/internal/container/container.go
+++ b/agent/internal/container/container.go
@@ -210,7 +210,6 @@ func (c *Container) run(parent context.Context) (err error) {
 		if err != nil {
 			return fmt.Errorf("creating container: %w", err)
 		}
-
 		remove := c.spec.RunSpec.HostConfig.AutoRemove
 		c.spec = nil // Evict the spec from memory due to their potential memory consumption.
 		defer func() {

--- a/agent/internal/container/container.go
+++ b/agent/internal/container/container.go
@@ -191,6 +191,7 @@ func (c *Container) run(parent context.Context) (err error) {
 	var dockerContainer *docker.Container
 	launchgroup.Go(func(ctx context.Context) (err error) {
 		defer launchgroup.Cancel()
+
 		c.log.Trace("pulling image")
 		if err = c.transition(ctx, cproto.Pulling, nil, nil); err != nil {
 			return err

--- a/agent/internal/container/container.go
+++ b/agent/internal/container/container.go
@@ -190,6 +190,7 @@ func (c *Container) run(parent context.Context) (err error) {
 	c.log.Trace("kicking off goroutine to launch the container")
 	var dockerContainer *docker.Container
 	launchgroup.Go(func(ctx context.Context) (err error) {
+		defer launchgroup.Cancel()
 		c.log.Trace("pulling image")
 		if err = c.transition(ctx, cproto.Pulling, nil, nil); err != nil {
 			return err

--- a/master/pkg/syncx/errgroupx/errgroupx.go
+++ b/master/pkg/syncx/errgroupx/errgroupx.go
@@ -9,7 +9,7 @@ import (
 // Group is a thin wrapper around golang.org/x/sync/errgroup.Group that helps not leak its context
 // past the lifetime of the group.
 type Group struct {
-	inner  errgroup.Group
+	inner  *errgroup.Group
 	ctx    context.Context
 	cancel context.CancelFunc
 }
@@ -19,7 +19,7 @@ func WithContext(ctx context.Context) Group {
 	intermediateContext, cancel := context.WithCancel(ctx)
 	g, groupContext := errgroup.WithContext(intermediateContext)
 
-	return Group{inner: *g, ctx: groupContext, cancel: cancel}
+	return Group{inner: g, ctx: groupContext, cancel: cancel}
 }
 
 // Go launch the given function in a goroutine as a member of the group. If the function returns an

--- a/master/pkg/syncx/errgroupx/errgroupx.go
+++ b/master/pkg/syncx/errgroupx/errgroupx.go
@@ -16,8 +16,10 @@ type Group struct {
 
 // WithContext creates a Group as a child of the given context.
 func WithContext(ctx context.Context) Group {
-	ctx, cancel := context.WithCancel(ctx)
-	return Group{ctx: ctx, cancel: cancel}
+	intermediateContext, cancel := context.WithCancel(ctx)
+	g, groupContext := errgroup.WithContext(intermediateContext)
+
+	return Group{inner: *g, ctx: groupContext, cancel: cancel}
 }
 
 // Go launch the given function in a goroutine as a member of the group. If the function returns an

--- a/master/pkg/syncx/errgroupx/errgroupx_test.go
+++ b/master/pkg/syncx/errgroupx/errgroupx_test.go
@@ -1,0 +1,52 @@
+package errgroupx
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestErrgroupxCancelByReturnError(t *testing.T) {
+	ctx := context.Background()
+	g := WithContext(ctx)
+
+	finished := make(chan bool, 1)
+	g.Go(func(ctx context.Context) error {
+		return fmt.Errorf("Non nil error")
+	})
+	g.Go(func(ctx context.Context) error {
+		<-ctx.Done()
+		finished <- true
+		return nil
+	})
+
+	require.Error(t, g.Wait())
+	require.True(t, <-finished)
+	require.NoError(t, ctx.Err()) // Original context not canceled.
+}
+
+func TestErrgroupxCancelingParentCancels(t *testing.T) {
+	for _, cancelGroup := range []bool{true, false} {
+		ctx, cancel := context.WithCancel(context.Background())
+		g := WithContext(ctx)
+
+		finished := make(chan bool, 1)
+		g.Go(func(ctx context.Context) error {
+			<-ctx.Done()
+			finished <- true
+			return nil
+		})
+
+		if cancelGroup {
+			g.cancel()
+			require.NoError(t, ctx.Err())
+		} else {
+			cancel()
+			require.Error(t, ctx.Err())
+		}
+		require.True(t, <-finished)
+		require.NoError(t, g.Wait())
+	}
+}

--- a/master/pkg/syncx/errgroupx/errgroupx_test.go
+++ b/master/pkg/syncx/errgroupx/errgroupx_test.go
@@ -14,7 +14,7 @@ func TestErrgroupxCancelByReturnError(t *testing.T) {
 
 	finished := make(chan bool, 1)
 	g.Go(func(ctx context.Context) error {
-		return fmt.Errorf("Non nil error")
+		return fmt.Errorf("non nil error")
 	})
 	g.Go(func(ctx context.Context) error {
 		<-ctx.Done()
@@ -48,5 +48,6 @@ func TestErrgroupxCancelingParentCancels(t *testing.T) {
 		}
 		require.True(t, <-finished)
 		require.NoError(t, g.Wait())
+		cancel()
 	}
 }


### PR DESCRIPTION
## Description

A race could potentially occur between returning ```launchgroup.Cancel()``` and returning ```ErrKilledBeforeRun``` or an error from the other thread from the context getting canceled. This could cause the test to fail with asserting a different error message.

Instead of canceling the context we just return an error and fix the wrapper around ```errgroup``` that wasn't canceling upon error return properly. 

## Test Plan

Looped ```test-intg``` here

https://app.circleci.com/pipelines/github/determined-ai/determined/34115


## Commentary (optional)

I'm not 100% sure about this race causing the test flake here since the timing seems super precise and unlikely.

https://app.circleci.com/pipelines/github/determined-ai/determined/33810/workflows/d62e8f42-41b6-41b7-a02d-43c682625e37/jobs/1191309

## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
