### PR TITLE
fix: GPU counting for k8s cluster info page

### DIFF
--- a/helm/charts/determined/templates/master-permissions.yaml
+++ b/helm/charts/determined/templates/master-permissions.yaml
@@ -21,7 +21,7 @@ rules:
     resources: ["pods", "pods/status", "pods/log", "configmaps"]
     verbs: ["create", "get", "list", "delete"]
   - apiGroups: [""]
-    resources: ["services"]
+    resources: ["services", "resourcequotas"]
     verbs: ["get", "list"]
   - apiGroups: [""]
     resources: ["pods"]

--- a/master/internal/rm/kubernetesrm/pods.go
+++ b/master/internal/rm/kubernetesrm/pods.go
@@ -954,6 +954,10 @@ func (p *pods) summarize(ctx *actor.Context) (map[string]model.AgentSummary, err
 		namespaceToQuota[namespace] = quotaList.Items[0]
 	}
 
+	logrus.WithFields(logrus.Fields{
+		"numQuotas": len(namespaceToQuota),
+	}).Debug("done looking up quotas")
+
 	// If there's only one resource pool configured and it doesn't have a quota, summarize using the
 	// whole cluster.
 	if len(p.namespaceToPoolName) == 1 {

--- a/master/internal/rm/kubernetesrm/pods.go
+++ b/master/internal/rm/kubernetesrm/pods.go
@@ -998,9 +998,17 @@ func (p *pods) summarize(ctx *actor.Context) (map[string]model.AgentSummary, err
 				case ResourceTypeNvidia:
 					deviceType = device.CUDA
 				default:
+					logrus.WithFields(logrus.Fields{
+						"resourceName": resourceName,
+					}).Debug("skipping resource")
 					// We only care about CPU and GPU quotas for the slots summary
 					continue
 				}
+
+				logrus.WithFields(logrus.Fields{
+					"resourceName": resourceName,
+					"qty":          qty.String(),
+				}).Debug("found quota for device type")
 
 				// Each CPU and GPU in the quota will be counted as a slot here
 				one, decQty := inf.NewDec(1, 0), qty.AsDec()
@@ -1026,6 +1034,8 @@ func (p *pods) summarize(ctx *actor.Context) (map[string]model.AgentSummary, err
 					}
 				}
 			}
+		} else {
+			logrus.WithField("namespace", namespace).Debug("quota does not exist for namespace")
 		}
 
 		summaries[poolName] = model.AgentSummary{

--- a/master/internal/rm/kubernetesrm/pods.go
+++ b/master/internal/rm/kubernetesrm/pods.go
@@ -995,7 +995,7 @@ func (p *pods) summarize(ctx *actor.Context) (map[string]model.AgentSummary, err
 				switch resourceName {
 				case k8sV1.ResourceCPU:
 					deviceType = device.CPU
-				case ResourceTypeNvidia:
+				case ResourceTypeNvidia, "limits." + ResourceTypeNvidia:
 					deviceType = device.CUDA
 				default:
 					logrus.WithFields(logrus.Fields{

--- a/master/internal/rm/kubernetesrm/pods.go
+++ b/master/internal/rm/kubernetesrm/pods.go
@@ -935,8 +935,18 @@ func (p *pods) summarize(ctx *actor.Context) (map[string]model.AgentSummary, err
 	for namespace := range p.namespaceToPoolName {
 		quotaList, err := p.quotaInterfaces[namespace].List(context.TODO(), metaV1.ListOptions{})
 		if err != nil && !k8serrors.IsNotFound(err) {
+			logrus.WithFields(logrus.Fields{
+				"err":           err,
+				"namespace":     namespace,
+				"errIsNotFound": k8serrors.IsNotFound(err),
+			}).Debug("error looking up namespace quota")
 			return nil, err
 		} else if k8serrors.IsNotFound(err) || quotaList == nil || len(quotaList.Items) != 1 {
+			logrus.WithFields(logrus.Fields{
+				"err":           err,
+				"namespace":     namespace,
+				"errIsNotFound": k8serrors.IsNotFound(err),
+			}).Debug("skipping quota for namespace")
 			// TODO: figure out how we want to handle multiple quotas per namespace?
 			continue
 		}


### PR DESCRIPTION
## Description

Fix the cluster info page by also matching `limits.nvidia.com/gpu` so slots are counted correctly. Also gave master permission to list quotas in the helm chart and improved the error handling around the k8s API call for quotas.



## Test Plan

The cluster info page should accurately report the number of GPU slots when a k8s limit quota is in place.