### PR TITLE
chore:  add/test pt-only images and bumpenvs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -182,11 +182,11 @@ commands:
       - when:
           condition: <<parameters.tf1>>
           steps:
-            - run: docker pull determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-ad0591c
+            - run: docker pull determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-7aa5364
       - when:
           condition: <<parameters.tf2>>
           steps:
-            - run: docker pull determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-ad0591c
+            - run: docker pull determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-7aa5364
 
   login-docker:
     parameters:
@@ -1950,7 +1950,7 @@ jobs:
         type: string
         default: "1"
       environment-image:
-        default: determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-0.19.12
+        default: determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-0.20.1
         type: string
       accel-node-taints:
         type: string

--- a/docs/cluster-setup-guide/deploy-cluster/sysadmin-deploy-on-gcp/install-gcp.rst
+++ b/docs/cluster-setup-guide/deploy-cluster/sysadmin-deploy-on-gcp/install-gcp.rst
@@ -406,5 +406,5 @@ This command line will spin up a cluster of up to 2 A100s in the ``us-central1-c
       --compute-agent-instance-type a2-highgpu-1g --gpu-num 1 \
       --gpu-type nvidia-tesla-a100 \
       --region us-central1 --zone us-central1-c \
-      --gpu-env-image determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-0.19.12 \
-      --cpu-env-image determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-0.19.12
+      --gpu-env-image determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-0.20.1 \
+      --cpu-env-image determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-0.20.1

--- a/docs/cluster-setup-guide/deploy-cluster/sysadmin-deploy-on-slurm/singularity.rst
+++ b/docs/cluster-setup-guide/deploy-cluster/sysadmin-deploy-on-slurm/singularity.rst
@@ -24,11 +24,11 @@ by default in this version of Determined are described below.
 +-------------+-------------------------------------------------------------------------+
 | Environment | File Name                                                               |
 +=============+=========================================================================+
-| CPUs        | ``determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-ad0591c``    |
+| CPUs        | ``determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-7aa5364``    |
 +-------------+-------------------------------------------------------------------------+
-| Nvidia GPUs | ``determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-ad0591c`` |
+| Nvidia GPUs | ``determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-7aa5364`` |
 +-------------+-------------------------------------------------------------------------+
-| AMD GPUs    | ``determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-ad0591c`` |
+| AMD GPUs    | ``determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-7aa5364`` |
 +-------------+-------------------------------------------------------------------------+
 
 See :doc:`/training/setup-guide/set-environment-images` for the images Docker Hub location, and add

--- a/docs/cluster-setup-guide/deploy-cluster/sysadmin-deploy-on-slurm/slurm-requirements.rst
+++ b/docs/cluster-setup-guide/deploy-cluster/sysadmin-deploy-on-slurm/slurm-requirements.rst
@@ -349,7 +349,7 @@ platform. There may be additional per-user configuration that is required.
 
    .. code:: bash
 
-      image=determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-ad0591c
+      image=determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-7aa5364
       cd /shared/enroot/images
       enroot import docker://$image
       enroot create /shared/enroot/images/${image//[\/:]/\+}.sqsh

--- a/docs/interfaces/tensorboard.rst
+++ b/docs/interfaces/tensorboard.rst
@@ -61,7 +61,7 @@ to additional data with a bind-mount.
 .. code:: yaml
 
    environment:
-     image: determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-0.19.12
+     image: determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-0.20.1
    bind_mounts:
      - host_path: /my/agent/path
        container_path: /my/container/path

--- a/docs/reference/reference-deploy/config/helm-config-reference.rst
+++ b/docs/reference/reference-deploy/config/helm-config-reference.rst
@@ -173,11 +173,11 @@
 
    -  ``cpuImage``: Sets the default docker image for all non-gpu tasks. If a docker image is
       specified in the :ref:`experiment config <exp-environment-image>` this default is overriden.
-      Defaults to: ``determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-0.19.12``.
+      Defaults to: ``determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-0.20.1``.
 
    -  ``gpuImage``: Sets the default docker image for all gpu tasks. If a docker image is specified
       in the :ref:`experiment config <exp-environment-image>` this default is overriden. Defaults
-      to: ``determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-0.19.12``.
+      to: ``determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-0.20.1``.
 
 -  ``enterpriseEdition``: Specifies whether to use Determined enterprise edition.
 

--- a/docs/reference/reference-deploy/config/master-config-reference.rst
+++ b/docs/reference/reference-deploy/config/master-config-reference.rst
@@ -55,9 +55,9 @@ The master supports the following configuration settings:
       ``cuda`` key (``gpu`` prior to 0.17.6), CPU tasks using ``cpu`` key, and ROCm (AMD GPU) tasks
       using the ``rocm`` key. Default values:
 
-      -  ``determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-0.19.12`` for NVIDIA GPUs.
-      -  ``determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-0.19.12`` for ROCm.
-      -  ``determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-0.19.12`` for CPUs.
+      -  ``determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-0.20.1`` for NVIDIA GPUs.
+      -  ``determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-0.20.1`` for ROCm.
+      -  ``determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-0.20.1`` for CPUs.
 
    -  ``environment_variables``: A list of environment variables that will be set in every task
       container. Each element of the list should be a string of the form ``NAME=VALUE``. See

--- a/docs/reference/reference-interface/job-config-reference.rst
+++ b/docs/reference/reference-interface/job-config-reference.rst
@@ -45,9 +45,9 @@ The following configuration settings are supported:
       different container images for NVIDIA GPU tasks using ``cuda`` key (``gpu`` prior to 0.17.6),
       CPU tasks using ``cpu`` key, and ROCm (AMD GPU) tasks using ``rocm`` key. Default values:
 
-      -  ``determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-0.19.12`` for NVIDIA GPUs.
-      -  ``determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-0.19.12`` for ROCm.
-      -  ``determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-0.19.12`` for CPUs.
+      -  ``determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-0.20.1`` for NVIDIA GPUs.
+      -  ``determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-0.20.1`` for ROCm.
+      -  ``determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-0.20.1`` for CPUs.
 
    -  ``force_pull_image``: Forcibly pull the image from the Docker registry and bypass the Docker
       cache. Defaults to ``false``.

--- a/docs/reference/reference-training/experiment-config-reference.rst
+++ b/docs/reference/reference-training/experiment-config-reference.rst
@@ -1044,9 +1044,9 @@ workloads for this experiment. For more information on customizing the trial env
    images for NVIDIA GPU tasks using ``cuda`` key (``gpu`` prior to 0.17.6), CPU tasks using ``cpu``
    key, and ROCm (AMD GPU) tasks using ``rocm`` key. Default values:
 
-   -  ``determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-0.19.12`` for NVIDIA GPUs.
-   -  ``determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-0.19.12`` for CPUs.
-   -  ``determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-0.19.12`` for ROCm.
+   -  ``determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-0.20.1`` for NVIDIA GPUs.
+   -  ``determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-0.20.1`` for CPUs.
+   -  ``determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-0.20.1`` for ROCm.
 
    When the cluster is configured with :ref:`resource_manager.type: slurm
    <cluster-configuration-slurm>` and ``container_run_type: singularity``, images are executed using

--- a/docs/training/apis-howto/overview.rst
+++ b/docs/training/apis-howto/overview.rst
@@ -70,15 +70,15 @@ Determined supports both TensorFlow 1 and 2. The version of TensorFlow that is u
 experiment is controlled by the container image that has been configured for that experiment.
 Determined provides prebuilt Docker images that include TensorFlow 2.8, 1.15, and 2.7, respectively:
 
--  ``determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-0.19.12`` (default)
--  ``determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-0.19.12``
--  ``determinedai/environments:cuda-11.2-pytorch-1.12-tf-2.7-gpu-0.19.12``
+-  ``determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-0.20.1`` (default)
+-  ``determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-0.20.1``
+-  ``determinedai/environments:cuda-11.2-pytorch-1.12-tf-2.7-gpu-0.20.1``
 
 We also provide lightweight CPU-only counterparts:
 
--  ``determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-0.19.12``
--  ``determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-0.19.12``
--  ``determinedai/environments:py-3.8-pytorch-1.12-tf-2.7-cpu-0.19.12``
+-  ``determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-0.20.1``
+-  ``determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-0.20.1``
+-  ``determinedai/environments:py-3.8-pytorch-1.12-tf-2.7-cpu-0.20.1``
 
 To change the container image used for an experiment, specify :ref:`environment.image
 <exp-environment-image>` in the experiment configuration file. Please see :ref:`container-images`
@@ -94,7 +94,7 @@ images.
 Determined has experimental support for ROCm. Determined provides a prebuilt Docker image that
 includes ROCm 4.2, PyTorch 1.9 and Tensorflow 2.5:
 
--  ``determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-0.19.12``
+-  ``determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-0.20.1``
 
 Known limitations:
 

--- a/docs/training/setup-guide/custom-env.rst
+++ b/docs/training/setup-guide/custom-env.rst
@@ -101,11 +101,11 @@ Default Images
 +-------------+-----------------------------------------------------------------------------------+
 | Environment | File Name                                                                         |
 +=============+===================================================================================+
-| CPUs        | ``determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-0.20.1``              |
+| CPUs        | ``determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-0.20.1``               |
 +-------------+-----------------------------------------------------------------------------------+
-| Nvidia GPUs | ``determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-0.20.1``           |
+| Nvidia GPUs | ``determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-0.20.1``            |
 +-------------+-----------------------------------------------------------------------------------+
-| AMD GPUs    | ``determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-0.20.1``           |
+| AMD GPUs    | ``determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-0.20.1``            |
 +-------------+-----------------------------------------------------------------------------------+
 
 .. _custom-docker-images:

--- a/docs/training/setup-guide/custom-env.rst
+++ b/docs/training/setup-guide/custom-env.rst
@@ -101,11 +101,11 @@ Default Images
 +-------------+-----------------------------------------------------------------------------------+
 | Environment | File Name                                                                         |
 +=============+===================================================================================+
-| CPUs        | ``determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-0.19.12``              |
+| CPUs        | ``determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-0.20.1``              |
 +-------------+-----------------------------------------------------------------------------------+
-| Nvidia GPUs | ``determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-0.19.12``           |
+| Nvidia GPUs | ``determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-0.20.1``           |
 +-------------+-----------------------------------------------------------------------------------+
-| AMD GPUs    | ``determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-0.19.12``           |
+| AMD GPUs    | ``determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-0.20.1``           |
 +-------------+-----------------------------------------------------------------------------------+
 
 .. _custom-docker-images:
@@ -132,7 +132,7 @@ Example Dockerfile that installs custom ``conda``-, ``pip``-, and ``apt``-based 
 .. code:: bash
 
    # Determined Image
-   FROM determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-0.19.12
+   FROM determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-0.20.1
 
    # Custom Configuration
    RUN apt-get update && \
@@ -195,7 +195,7 @@ environments using :ref:`custom images <custom-docker-images>`:
 .. code:: bash
 
    # Determined Image
-   FROM determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-0.19.12
+   FROM determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-0.20.1
 
    # Create a virtual environment
    RUN conda create -n myenv python=3.8

--- a/e2e_tests/tests/config.py
+++ b/e2e_tests/tests/config.py
@@ -165,8 +165,8 @@ def set_tf1_image(config: Dict[Any, Any]) -> Dict[Any, Any]:
 
 def set_tf2_image(config: Dict[Any, Any]) -> Dict[Any, Any]:
     return set_image(config, TF2_CPU_IMAGE, TF2_GPU_IMAGE)
-    
-    
+
+
 def set_pt_image(config: Dict[Any, Any]) -> Dict[Any, Any]:
     return set_image(config, PT_CPU_IMAGE, PT_GPU_IMAGE)
 

--- a/e2e_tests/tests/config.py
+++ b/e2e_tests/tests/config.py
@@ -13,15 +13,19 @@ MAX_TASK_SCHEDULED_SECS = 30
 MAX_TRIAL_BUILD_SECS = 90
 
 
-DEFAULT_TF1_CPU_IMAGE = "determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-ad0591c"
-DEFAULT_TF2_CPU_IMAGE = "determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-ad0591c"
-DEFAULT_TF1_GPU_IMAGE = "determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-ad0591c"
-DEFAULT_TF2_GPU_IMAGE = "determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-ad0591c"
+DEFAULT_TF1_CPU_IMAGE = "determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-7aa5364"
+DEFAULT_TF2_CPU_IMAGE = "determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-7aa5364"
+DEFAULT_TF1_GPU_IMAGE = "determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-7aa5364"
+DEFAULT_TF2_GPU_IMAGE = "determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-7aa5364"
+DEFAULT_PT_CPU_IMAGE = "determinedai/environments:py-3.8-pytorch-1.12-cpu-7aa5364"
+DEFAULT_PT_GPU_IMAGE = "determinedai/environments:cuda-11.3-pytorch-1.12-gpu-7aa5364"
 
 TF1_CPU_IMAGE = os.environ.get("TF1_CPU_IMAGE") or DEFAULT_TF1_CPU_IMAGE
 TF2_CPU_IMAGE = os.environ.get("TF2_CPU_IMAGE") or DEFAULT_TF2_CPU_IMAGE
 TF1_GPU_IMAGE = os.environ.get("TF1_GPU_IMAGE") or DEFAULT_TF1_GPU_IMAGE
 TF2_GPU_IMAGE = os.environ.get("TF2_GPU_IMAGE") or DEFAULT_TF2_GPU_IMAGE
+PT_CPU_IMAGE = os.environ.get("PT_CPU_IMAGE") or DEFAULT_PT_CPU_IMAGE
+PT_GPU_IMAGE = os.environ.get("PT_GPU_IMAGE") or DEFAULT_PT_GPU_IMAGE
 GPU_ENABLED = os.environ.get("DET_TEST_GPU_ENABLED", "1") not in ("0", "false")
 
 PROJECT_ROOT_PATH = Path(__file__).resolve().parents[2]
@@ -161,6 +165,10 @@ def set_tf1_image(config: Dict[Any, Any]) -> Dict[Any, Any]:
 
 def set_tf2_image(config: Dict[Any, Any]) -> Dict[Any, Any]:
     return set_image(config, TF2_CPU_IMAGE, TF2_GPU_IMAGE)
+    
+    
+def set_pt_image(config: Dict[Any, Any]) -> Dict[Any, Any]:
+    return set_image(config, PT_CPU_IMAGE, PT_GPU_IMAGE)
 
 
 def set_random_seed(config: Dict[Any, Any], seed: int) -> Dict[Any, Any]:

--- a/e2e_tests/tests/experiment/test_pytorch.py
+++ b/e2e_tests/tests/experiment/test_pytorch.py
@@ -1,6 +1,7 @@
 from typing import Callable, List
 
 import pytest
+import warnings
 
 from determined.experimental import Determined
 from tests import config as conf
@@ -9,12 +10,20 @@ from tests import experiment as exp
 
 @pytest.mark.e2e_gpu
 @pytest.mark.parametrize("aggregation_frequency", [1, 4])
+@pytest.mark.parametrize("image_type", ["PT", "TF2"])
 def test_pytorch_11_const(
     aggregation_frequency: int, using_k8s: bool, collect_trial_profiles: Callable[[int], None]
 ) -> None:
     config = conf.load_config(conf.fixtures_path("mnist_pytorch/const-pytorch11.yaml"))
     config = conf.set_aggregation_frequency(config, aggregation_frequency)
     config = conf.set_profiling_enabled(config)
+    
+    if image_type == "PT":
+        config = conf.set_pt_image(config)
+    elif image_type == "TF2":
+        config = conf.set_tf2_image(config)
+    else:
+        warnings.warn("Using default images")
 
     if using_k8s:
         pod_spec = {
@@ -118,11 +127,19 @@ def test_pytorch_const_with_amp(
 
 
 @pytest.mark.parallel
+@pytest.mark.parametrize("image_type", ["PT", "TF2"])
 def test_pytorch_cifar10_parallel(collect_trial_profiles: Callable[[int], None]) -> None:
     config = conf.load_config(conf.cv_examples_path("cifar10_pytorch/const.yaml"))
     config = conf.set_max_length(config, {"batches": 200})
     config = conf.set_slots_per_trial(config, 8)
     config = conf.set_profiling_enabled(config)
+    
+    if image_type == "PT":
+        config = conf.set_pt_image(config)
+    elif image_type == "TF2":
+        config = conf.set_tf2_image(config)
+    else:
+        warnings.warn("Using default images")
 
     experiment_id = exp.run_basic_test_with_temp_config(
         config, conf.cv_examples_path("cifar10_pytorch"), 1
@@ -139,11 +156,19 @@ def test_pytorch_cifar10_parallel(collect_trial_profiles: Callable[[int], None])
 
 
 @pytest.mark.parallel
+@pytest.mark.parametrize("image_type", ["PT", "TF2"])
 def test_pytorch_gan_parallel(collect_trial_profiles: Callable[[int], None]) -> None:
     config = conf.load_config(conf.gan_examples_path("gan_mnist_pytorch/const.yaml"))
     config = conf.set_max_length(config, {"batches": 200})
     config = conf.set_slots_per_trial(config, 8)
     config = conf.set_profiling_enabled(config)
+    
+    if image_type == "PT":
+        config = conf.set_pt_image(config)
+    elif image_type == "TF2":
+        config = conf.set_tf2_image(config)
+    else:
+        warnings.warn("Using default images")
 
     experiment_id = exp.run_basic_test_with_temp_config(
         config, conf.gan_examples_path("gan_mnist_pytorch"), 1

--- a/e2e_tests/tests/experiment/test_pytorch.py
+++ b/e2e_tests/tests/experiment/test_pytorch.py
@@ -1,7 +1,7 @@
+import warnings
 from typing import Callable, List
 
 import pytest
-import warnings
 
 from determined.experimental import Determined
 from tests import config as conf
@@ -12,12 +12,15 @@ from tests import experiment as exp
 @pytest.mark.parametrize("aggregation_frequency", [1, 4])
 @pytest.mark.parametrize("image_type", ["PT", "TF2"])
 def test_pytorch_11_const(
-    aggregation_frequency: int, using_k8s: bool, collect_trial_profiles: Callable[[int], None]
+    aggregation_frequency: int,
+    image_type: str,
+    using_k8s: bool,
+    collect_trial_profiles: Callable[[int], None],
 ) -> None:
     config = conf.load_config(conf.fixtures_path("mnist_pytorch/const-pytorch11.yaml"))
     config = conf.set_aggregation_frequency(config, aggregation_frequency)
     config = conf.set_profiling_enabled(config)
-    
+
     if image_type == "PT":
         config = conf.set_pt_image(config)
     elif image_type == "TF2":
@@ -128,12 +131,14 @@ def test_pytorch_const_with_amp(
 
 @pytest.mark.parallel
 @pytest.mark.parametrize("image_type", ["PT", "TF2"])
-def test_pytorch_cifar10_parallel(collect_trial_profiles: Callable[[int], None]) -> None:
+def test_pytorch_cifar10_parallel(
+    image_type: str, collect_trial_profiles: Callable[[int], None]
+) -> None:
     config = conf.load_config(conf.cv_examples_path("cifar10_pytorch/const.yaml"))
     config = conf.set_max_length(config, {"batches": 200})
     config = conf.set_slots_per_trial(config, 8)
     config = conf.set_profiling_enabled(config)
-    
+
     if image_type == "PT":
         config = conf.set_pt_image(config)
     elif image_type == "TF2":
@@ -157,12 +162,14 @@ def test_pytorch_cifar10_parallel(collect_trial_profiles: Callable[[int], None])
 
 @pytest.mark.parallel
 @pytest.mark.parametrize("image_type", ["PT", "TF2"])
-def test_pytorch_gan_parallel(collect_trial_profiles: Callable[[int], None]) -> None:
+def test_pytorch_gan_parallel(
+    image_type: str, collect_trial_profiles: Callable[[int], None]
+) -> None:
     config = conf.load_config(conf.gan_examples_path("gan_mnist_pytorch/const.yaml"))
     config = conf.set_max_length(config, {"batches": 200})
     config = conf.set_slots_per_trial(config, 8)
     config = conf.set_profiling_enabled(config)
-    
+
     if image_type == "PT":
         config = conf.set_pt_image(config)
     elif image_type == "TF2":

--- a/e2e_tests/tests/experiment/test_pytorch.py
+++ b/e2e_tests/tests/experiment/test_pytorch.py
@@ -26,7 +26,7 @@ def test_pytorch_11_const(
     elif image_type == "TF2":
         config = conf.set_tf2_image(config)
     else:
-        warnings.warn("Using default images")
+        warnings.warn("Using default images", stacklevel=2)
 
     if using_k8s:
         pod_spec = {
@@ -144,7 +144,7 @@ def test_pytorch_cifar10_parallel(
     elif image_type == "TF2":
         config = conf.set_tf2_image(config)
     else:
-        warnings.warn("Using default images")
+        warnings.warn("Using default images", stacklevel=2)
 
     experiment_id = exp.run_basic_test_with_temp_config(
         config, conf.cv_examples_path("cifar10_pytorch"), 1
@@ -175,7 +175,7 @@ def test_pytorch_gan_parallel(
     elif image_type == "TF2":
         config = conf.set_tf2_image(config)
     else:
-        warnings.warn("Using default images")
+        warnings.warn("Using default images", stacklevel=2)
 
     experiment_id = exp.run_basic_test_with_temp_config(
         config, conf.gan_examples_path("gan_mnist_pytorch"), 1

--- a/e2e_tests/tests/experiment/test_pytorch.py
+++ b/e2e_tests/tests/experiment/test_pytorch.py
@@ -51,9 +51,17 @@ def test_pytorch_11_const(
 
 
 @pytest.mark.e2e_cpu
-def test_pytorch_load(collect_trial_profiles: Callable[[int], None]) -> None:
+@pytest.mark.parametrize("image_type", ["PT", "TF2"])
+def test_pytorch_load(image_type: str, collect_trial_profiles: Callable[[int], None]) -> None:
     config = conf.load_config(conf.fixtures_path("mnist_pytorch/const-pytorch11.yaml"))
     config = conf.set_profiling_enabled(config)
+
+    if image_type == "PT":
+        config = conf.set_pt_image(config)
+    elif image_type == "TF2":
+        config = conf.set_tf2_image(config)
+    else:
+        warnings.warn("Using default images", stacklevel=2)
 
     experiment_id = exp.run_basic_test_with_temp_config(
         config, conf.tutorials_path("mnist_pytorch"), 1
@@ -70,13 +78,21 @@ def test_pytorch_load(collect_trial_profiles: Callable[[int], None]) -> None:
 
 
 @pytest.mark.e2e_cpu
-def test_pytorch_const_warm_start() -> None:
+@pytest.mark.parametrize("image_type", ["PT", "TF2"])
+def test_pytorch_const_warm_start(image_type: str) -> None:
     """
     Test that specifying an earlier trial checkpoint to warm-start from
     correctly populates the later trials' `warm_start_checkpoint_id` fields.
     """
     config = conf.load_config(conf.tutorials_path("mnist_pytorch/const.yaml"))
     config = conf.set_max_length(config, {"batches": 200})
+
+    if image_type == "PT":
+        config = conf.set_pt_image(config)
+    elif image_type == "TF2":
+        config = conf.set_tf2_image(config)
+    else:
+        warnings.warn("Using default images", stacklevel=2)
 
     experiment_id1 = exp.run_basic_test_with_temp_config(
         config, conf.tutorials_path("mnist_pytorch"), 1

--- a/e2e_tests/tests/fixtures/pytorch_lightning_amp/apex_amp.yaml
+++ b/e2e_tests/tests/fixtures/pytorch_lightning_amp/apex_amp.yaml
@@ -14,6 +14,6 @@ searcher:
 entrypoint: apex_amp_model_def:MNistApexAMPTrial
 environment:
   image:
-    gpu: determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-0.19.12
-    cpu: determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-0.19.12
+    gpu: determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-0.20.1
+    cpu: determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-0.20.1
 

--- a/e2e_tests/tests/fixtures/pytorch_lightning_amp/auto_amp.yaml
+++ b/e2e_tests/tests/fixtures/pytorch_lightning_amp/auto_amp.yaml
@@ -14,6 +14,6 @@ searcher:
 entrypoint: auto_amp_model_def:MNistAutoAMPTrial
 environment:
   image:
-    gpu: determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-0.19.12
-    cpu: determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-0.19.12
+    gpu: determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-0.20.1
+    cpu: determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-0.20.1
 

--- a/e2e_tests/tests/nightly/test_distributed.py
+++ b/e2e_tests/tests/nightly/test_distributed.py
@@ -3,15 +3,24 @@ import shutil
 import tempfile
 
 import pytest
+import warnings
 
 from tests import config as conf
 from tests import experiment as exp
 
 
 @pytest.mark.distributed
+@pytest.mark.parametrize("image_type", ["PT", "TF2"])
 def test_mnist_pytorch_distributed() -> None:
     config = conf.load_config(conf.tutorials_path("mnist_pytorch/distributed.yaml"))
     config = conf.set_max_length(config, {"batches": 200})
+    
+    if image_type == "PT":
+        config = conf.set_pt_image(config)
+    elif image_type == "TF2":
+        config = conf.set_tf2_image(config)
+    else:
+        warnings.warn("Using default images")
 
     exp.run_basic_test_with_temp_config(config, conf.tutorials_path("mnist_pytorch"), 1)
 
@@ -39,10 +48,18 @@ def test_imagenet_pytorch_distributed() -> None:
 
 
 @pytest.mark.distributed
+@pytest.mark.parametrize("image_type", ["PT", "TF2"])
 def test_cifar10_pytorch_distributed() -> None:
     config = conf.load_config(conf.cv_examples_path("cifar10_pytorch/distributed.yaml"))
     config = conf.set_max_length(config, {"batches": 200})
-
+    
+    if image_type == "PT":
+        config = conf.set_pt_image(config)
+    elif image_type == "TF2":
+        config = conf.set_tf2_image(config)
+    else:
+        warnings.warn("Using default images")
+    
     exp.run_basic_test_with_temp_config(config, conf.cv_examples_path("cifar10_pytorch"), 1)
 
 
@@ -149,11 +166,19 @@ def test_deformabledetr_coco_pytorch_distributed() -> None:
 
 
 @pytest.mark.distributed
+@pytest.mark.parametrize("image_type", ["PT", "TF2"])
 def test_word_language_transformer_distributed() -> None:
     config = conf.load_config(conf.nlp_examples_path("word_language_model/distributed.yaml"))
     config = conf.set_max_length(config, {"batches": 200})
     config = config.copy()
     config["hyperparameters"]["model_cls"] = "Transformer"
+    
+    if image_type == "PT":
+        config = conf.set_pt_image(config)
+    elif image_type == "TF2":
+        config = conf.set_tf2_image(config)
+    else:
+        warnings.warn("Using default images")
 
     exp.run_basic_test_with_temp_config(config, conf.nlp_examples_path("word_language_model"), 1)
 

--- a/e2e_tests/tests/nightly/test_distributed.py
+++ b/e2e_tests/tests/nightly/test_distributed.py
@@ -1,9 +1,9 @@
 import os
 import shutil
 import tempfile
+import warnings
 
 import pytest
-import warnings
 
 from tests import config as conf
 from tests import experiment as exp
@@ -11,10 +11,10 @@ from tests import experiment as exp
 
 @pytest.mark.distributed
 @pytest.mark.parametrize("image_type", ["PT", "TF2"])
-def test_mnist_pytorch_distributed() -> None:
+def test_mnist_pytorch_distributed(image_type: str) -> None:
     config = conf.load_config(conf.tutorials_path("mnist_pytorch/distributed.yaml"))
     config = conf.set_max_length(config, {"batches": 200})
-    
+
     if image_type == "PT":
         config = conf.set_pt_image(config)
     elif image_type == "TF2":
@@ -49,17 +49,17 @@ def test_imagenet_pytorch_distributed() -> None:
 
 @pytest.mark.distributed
 @pytest.mark.parametrize("image_type", ["PT", "TF2"])
-def test_cifar10_pytorch_distributed() -> None:
+def test_cifar10_pytorch_distributed(image_type: str) -> None:
     config = conf.load_config(conf.cv_examples_path("cifar10_pytorch/distributed.yaml"))
     config = conf.set_max_length(config, {"batches": 200})
-    
+
     if image_type == "PT":
         config = conf.set_pt_image(config)
     elif image_type == "TF2":
         config = conf.set_tf2_image(config)
     else:
         warnings.warn("Using default images")
-    
+
     exp.run_basic_test_with_temp_config(config, conf.cv_examples_path("cifar10_pytorch"), 1)
 
 
@@ -167,12 +167,12 @@ def test_deformabledetr_coco_pytorch_distributed() -> None:
 
 @pytest.mark.distributed
 @pytest.mark.parametrize("image_type", ["PT", "TF2"])
-def test_word_language_transformer_distributed() -> None:
+def test_word_language_transformer_distributed(image_type: str) -> None:
     config = conf.load_config(conf.nlp_examples_path("word_language_model/distributed.yaml"))
     config = conf.set_max_length(config, {"batches": 200})
     config = config.copy()
     config["hyperparameters"]["model_cls"] = "Transformer"
-    
+
     if image_type == "PT":
         config = conf.set_pt_image(config)
     elif image_type == "TF2":

--- a/e2e_tests/tests/nightly/test_distributed.py
+++ b/e2e_tests/tests/nightly/test_distributed.py
@@ -20,7 +20,7 @@ def test_mnist_pytorch_distributed(image_type: str) -> None:
     elif image_type == "TF2":
         config = conf.set_tf2_image(config)
     else:
-        warnings.warn("Using default images")
+        warnings.warn("Using default images", stacklevel=2)
 
     exp.run_basic_test_with_temp_config(config, conf.tutorials_path("mnist_pytorch"), 1)
 
@@ -58,7 +58,7 @@ def test_cifar10_pytorch_distributed(image_type: str) -> None:
     elif image_type == "TF2":
         config = conf.set_tf2_image(config)
     else:
-        warnings.warn("Using default images")
+        warnings.warn("Using default images", stacklevel=2)
 
     exp.run_basic_test_with_temp_config(config, conf.cv_examples_path("cifar10_pytorch"), 1)
 
@@ -178,7 +178,7 @@ def test_word_language_transformer_distributed(image_type: str) -> None:
     elif image_type == "TF2":
         config = conf.set_tf2_image(config)
     else:
-        warnings.warn("Using default images")
+        warnings.warn("Using default images", stacklevel=2)
 
     exp.run_basic_test_with_temp_config(config, conf.nlp_examples_path("word_language_model"), 1)
 

--- a/examples/computer_vision/efficientdet_pytorch/const.yaml
+++ b/examples/computer_vision/efficientdet_pytorch/const.yaml
@@ -1,6 +1,6 @@
 description: efficientdet_const
 environment:
-  image: determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-0.19.12
+  image: determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-0.20.1
 hyperparameters:
   global_batch_size: 16
   min_loss_scale: 16.0

--- a/examples/computer_vision/efficientdet_pytorch/const_fake.yaml
+++ b/examples/computer_vision/efficientdet_pytorch/const_fake.yaml
@@ -1,6 +1,6 @@
 description: efficientdet_const
 environment:
-  image: determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-0.19.12
+  image: determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-0.20.1
 hyperparameters:
   global_batch_size: 16
   min_loss_scale: 16.0

--- a/examples/computer_vision/unets_tf_keras/const.yaml
+++ b/examples/computer_vision/unets_tf_keras/const.yaml
@@ -22,4 +22,4 @@ min_validation_period:
 entrypoint: model_def:UNetsTrial
 scheduling_unit: 57
 environment:
-    image: determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-ad0591c
+    image: determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-7aa5364

--- a/examples/computer_vision/unets_tf_keras/distributed.yaml
+++ b/examples/computer_vision/unets_tf_keras/distributed.yaml
@@ -25,4 +25,4 @@ min_validation_period:
 scheduling_unit: 8
 entrypoint: model_def:UNetsTrial
 environment:
-    image: determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-ad0591c
+    image: determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-7aa5364

--- a/examples/decision_trees/gbt_titanic_estimator/adaptive.yaml
+++ b/examples/decision_trees/gbt_titanic_estimator/adaptive.yaml
@@ -42,4 +42,4 @@ searcher:
 entrypoint: model_def:BoostedTreesTrial
 scheduling_unit: 1
 environment:
-  image: "determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-0.19.12"
+  image: "determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-0.20.1"

--- a/examples/decision_trees/gbt_titanic_estimator/const.yaml
+++ b/examples/decision_trees/gbt_titanic_estimator/const.yaml
@@ -20,4 +20,4 @@ searcher:
 entrypoint: model_def:BoostedTreesTrial
 scheduling_unit: 1
 environment:
-  image: "determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-0.19.12"
+  image: "determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-0.20.1"

--- a/examples/deepspeed/cifar10_cpu_offloading/zero_3_cpu_offload.yaml
+++ b/examples/deepspeed/cifar10_cpu_offloading/zero_3_cpu_offload.yaml
@@ -14,7 +14,7 @@ environment:
     # You may need to modify this to match your network configuration.
     - NCCL_SOCKET_IFNAME=ens,eth,ib
   image:
-    gpu: determinedai/environments:cuda-11.3-pytorch-1.10-tf-2.8-deepspeed-0.7.0-gpu-ad0591c
+    gpu: determinedai/environments:cuda-11.3-pytorch-1.10-tf-2.8-deepspeed-0.7.0-gpu-7aa5364
 bind_mounts:
   - host_path: /tmp
     container_path: /data

--- a/examples/deepspeed/cifar10_cpu_offloading/zero_no_offload.yaml
+++ b/examples/deepspeed/cifar10_cpu_offloading/zero_no_offload.yaml
@@ -14,7 +14,7 @@ environment:
     # You may need to modify this to match your network configuration.
     - NCCL_SOCKET_IFNAME=ens,eth,ib
   image:
-    gpu: determinedai/environments:cuda-11.3-pytorch-1.10-tf-2.8-deepspeed-0.7.0-gpu-ad0591c
+    gpu: determinedai/environments:cuda-11.3-pytorch-1.10-tf-2.8-deepspeed-0.7.0-gpu-7aa5364
 bind_mounts:
   - host_path: /tmp
     container_path: /data

--- a/examples/deepspeed/cifar10_moe/moe.yaml
+++ b/examples/deepspeed/cifar10_moe/moe.yaml
@@ -21,7 +21,7 @@ environment:
     #    - NCCL_BLOCKING_WAIT=1
     #    - NCCL_IB_DISABLE=1
     image:
-        gpu: determinedai/environments:cuda-11.3-pytorch-1.10-tf-2.8-deepspeed-0.7.0-gpu-ad0591c
+        gpu: determinedai/environments:cuda-11.3-pytorch-1.10-tf-2.8-deepspeed-0.7.0-gpu-7aa5364
 bind_mounts:
     - host_path: /tmp
       container_path: /data

--- a/examples/deepspeed/cifar10_moe/zero_stages.yaml
+++ b/examples/deepspeed/cifar10_moe/zero_stages.yaml
@@ -22,7 +22,7 @@ environment:
     #    - NCCL_BLOCKING_WAIT=1
     #    - NCCL_IB_DISABLE=1
     image:
-      gpu: determinedai/environments:cuda-11.3-pytorch-1.10-tf-2.8-deepspeed-0.7.0-gpu-ad0591c
+      gpu: determinedai/environments:cuda-11.3-pytorch-1.10-tf-2.8-deepspeed-0.7.0-gpu-7aa5364
 bind_mounts:
     - host_path: /tmp
       container_path: /data

--- a/examples/deepspeed/gpt_neox/Dockerfile
+++ b/examples/deepspeed/gpt_neox/Dockerfile
@@ -1,4 +1,4 @@
-FROM determinedai/environments:cuda-11.3-pytorch-1.10-tf-2.8-gpt-neox-deepspeed-gpu-ad0591c
+FROM determinedai/environments:cuda-11.3-pytorch-1.10-tf-2.8-gpt-neox-deepspeed-gpu-7aa5364
 
 # Install deepspeed & dependencies
 RUN apt-get install -y mpich

--- a/examples/deepspeed/pipeline_parallelism/distributed.yaml
+++ b/examples/deepspeed/pipeline_parallelism/distributed.yaml
@@ -20,7 +20,7 @@ environment:
     #    - CUDA_LAUNCH_BLOCKING=1
     #    - NCCL_BLOCKING_WAIT=1
     image:
-      gpu: determinedai/environments:cuda-11.3-pytorch-1.10-tf-2.8-deepspeed-0.7.0-gpu-ad0591c
+      gpu: determinedai/environments:cuda-11.3-pytorch-1.10-tf-2.8-deepspeed-0.7.0-gpu-7aa5364
 resources:
   slots_per_trial: 2
 records_per_epoch: 50000

--- a/examples/graphs/proteins_pytorch_geometric/adaptive.yaml
+++ b/examples/graphs/proteins_pytorch_geometric/adaptive.yaml
@@ -32,4 +32,4 @@ searcher:
 entrypoint: model_def:GraphConvTrial
 environment:
   image:
-    cuda: determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-ad0591c
+    cuda: determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-7aa5364

--- a/examples/graphs/proteins_pytorch_geometric/const.yaml
+++ b/examples/graphs/proteins_pytorch_geometric/const.yaml
@@ -18,4 +18,4 @@ searcher:
 entrypoint: model_def:GraphConvTrial
 environment:
   image:
-    cuda: determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-ad0591c
+    cuda: determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-7aa5364

--- a/examples/graphs/proteins_pytorch_geometric/distributed.yaml
+++ b/examples/graphs/proteins_pytorch_geometric/distributed.yaml
@@ -18,6 +18,6 @@ searcher:
 entrypoint: model_def:GraphConvTrial
 environment:
   image:
-    cuda: determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-ad0591c
+    cuda: determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-7aa5364
 resources:
   slots_per_trial: 4

--- a/harness/determined/common/schemas/expconf/_v0.py
+++ b/harness/determined/common/schemas/expconf/_v0.py
@@ -223,12 +223,12 @@ class EnvironmentImageV0(schemas.SchemaBase):
 
     def runtime_defaults(self) -> None:
         if self.cpu is None:
-            self.cpu = "determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-ad0591c"
+            self.cpu = "determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-7aa5364"
         if self.rocm is None:
-            self.rocm = "determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-ad0591c"
+            self.rocm = "determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-7aa5364"
 
         if self.cuda is None:
-            self.cuda = "determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-ad0591c"
+            self.cuda = "determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-7aa5364"
 
 
 class EnvironmentVariablesV0(schemas.SchemaBase):

--- a/harness/determined/deploy/aws/templates/efs.yaml
+++ b/harness/determined/deploy/aws/templates/efs.yaml
@@ -3,35 +3,35 @@ Mappings:
   RegionMap:
     ap-northeast-1:
       Master: ami-0c7cb70d3eb61492b
-      Agent: ami-0efbc837b3c729df1
+      Agent: ami-09c9ea05363b4fe2d
     # TODO(DET-4258) Uncomment these when we fully support all P3 regions.
     # ap-northeast-2:
     #   Master: ami-003bb1772f36a39a3
-    #   Agent: ami-0934d35fc17d76abc
+    #   Agent: ami-07b13ec47230370d5
     # ap-southeast-1:
     #   Master: ami-09f03fa5572692399
-    #   Agent: ami-05068dcfa829e229e
+    #   Agent: ami-07affc5a669acb69f
     # ap-southeast-2:
     #   Master: ami-06139e5e22cc2f7b1
-    #   Agent: ami-0e62ea531c3969a65
+    #   Agent: ami-0ef38d26d9f61a0db
     eu-central-1:
       Master: ami-0b81e95bb0a06ea8c
-      Agent: ami-051a91b2829200200
+      Agent: ami-0c09eb6495c53c53c
     eu-west-1:
       Master: ami-029cfca952b331b52
-      Agent: ami-04eab4dc55258e621
+      Agent: ami-06de67607d7b543dd
     # eu-west-2:
     #   Master: ami-035469b606478d63d
-    #   Agent: ami-08aa94155b641d19d
+    #   Agent: ami-0130ec158c7260bf1
     us-east-1:
       Master: ami-0b93ce03dcbcb10f6
-      Agent: ami-0b4cc2ed4ecd07a2d
+      Agent: ami-027145fb15545cd96
     us-east-2:
       Master: ami-0cbea92f2377277a4
-      Agent: ami-0ba898a163ad80bf9
+      Agent: ami-0fe46b7b5fdba7b51
     us-west-2:
       Master: ami-0d31d7c9fc9503726
-      Agent: ami-0a483013f2e53ed60
+      Agent: ami-03bad0b25097fe67d
 
 Parameters:
   VpcCIDR:

--- a/harness/determined/deploy/aws/templates/fsx.yaml
+++ b/harness/determined/deploy/aws/templates/fsx.yaml
@@ -3,35 +3,35 @@ Mappings:
   RegionMap:
     ap-northeast-1:
       Master: ami-0c7cb70d3eb61492b
-      Agent: ami-0efbc837b3c729df1
+      Agent: ami-09c9ea05363b4fe2d
     # TODO(DET-4258) Uncomment these when we fully support all P3 regions.
     # ap-northeast-2:
     #   Master: ami-003bb1772f36a39a3
-    #   Agent: ami-0934d35fc17d76abc
+    #   Agent: ami-07b13ec47230370d5
     # ap-southeast-1:
     #   Master: ami-09f03fa5572692399
-    #   Agent: ami-05068dcfa829e229e
+    #   Agent: ami-07affc5a669acb69f
     # ap-southeast-2:
     #   Master: ami-06139e5e22cc2f7b1
-    #   Agent: ami-0e62ea531c3969a65
+    #   Agent: ami-0ef38d26d9f61a0db
     eu-central-1:
       Master: ami-0b81e95bb0a06ea8c
-      Agent: ami-051a91b2829200200
+      Agent: ami-0c09eb6495c53c53c
     eu-west-1:
       Master: ami-029cfca952b331b52
-      Agent: ami-04eab4dc55258e621
+      Agent: ami-06de67607d7b543dd
     # eu-west-2:
     #   Master: ami-035469b606478d63d
-    #   Agent: ami-08aa94155b641d19d
+    #   Agent: ami-0130ec158c7260bf1
     us-east-1:
       Master: ami-0b93ce03dcbcb10f6
-      Agent: ami-0b4cc2ed4ecd07a2d
+      Agent: ami-027145fb15545cd96
     us-east-2:
       Master: ami-0cbea92f2377277a4
-      Agent: ami-0ba898a163ad80bf9
+      Agent: ami-0fe46b7b5fdba7b51
     us-west-2:
       Master: ami-0d31d7c9fc9503726
-      Agent: ami-0a483013f2e53ed60
+      Agent: ami-03bad0b25097fe67d
 
 Parameters:
   VpcCIDR:

--- a/harness/determined/deploy/aws/templates/secure.yaml
+++ b/harness/determined/deploy/aws/templates/secure.yaml
@@ -4,44 +4,44 @@ Mappings:
   RegionMap:
     ap-northeast-1:
       Master: ami-0c7cb70d3eb61492b
-      Agent: ami-0efbc837b3c729df1
+      Agent: ami-09c9ea05363b4fe2d
       Bastion: ami-0c7cb70d3eb61492b
     # TODO(DET-4258) Uncomment these when we fully support all P3 regions.
     # ap-northeast-2:
     #   Master: ami-003bb1772f36a39a3
-    #   Agent: ami-0934d35fc17d76abc
+    #   Agent: ami-07b13ec47230370d5
     #   Bastion: ami-003bb1772f36a39a3
     # ap-southeast-1:
     #   Master: ami-09f03fa5572692399
-    #   Agent: ami-05068dcfa829e229e
+    #   Agent: ami-07affc5a669acb69f
     #   Bastion: ami-09f03fa5572692399
     # ap-southeast-2:
     #   Master: ami-06139e5e22cc2f7b1
-    #   Agent: ami-0e62ea531c3969a65
+    #   Agent: ami-0ef38d26d9f61a0db
     #   Bastion: ami-06139e5e22cc2f7b1
     eu-central-1:
       Master: ami-0b81e95bb0a06ea8c
-      Agent: ami-051a91b2829200200
+      Agent: ami-0c09eb6495c53c53c
       Bastion: ami-0b81e95bb0a06ea8c
     eu-west-1:
       Master: ami-029cfca952b331b52
-      Agent: ami-04eab4dc55258e621
+      Agent: ami-06de67607d7b543dd
       Bastion: ami-029cfca952b331b52
     # eu-west-2:
     #   Master: ami-035469b606478d63d
-    #   Agent: ami-08aa94155b641d19d
+    #   Agent: ami-0130ec158c7260bf1
     #   Bastion: ami-035469b606478d63d
     us-east-1:
       Master: ami-0b93ce03dcbcb10f6
-      Agent: ami-0b4cc2ed4ecd07a2d
+      Agent: ami-027145fb15545cd96
       Bastion: ami-0b93ce03dcbcb10f6
     us-east-2:
       Master: ami-0cbea92f2377277a4
-      Agent: ami-0ba898a163ad80bf9
+      Agent: ami-0fe46b7b5fdba7b51
       Bastion: ami-0cbea92f2377277a4
     us-west-2:
       Master: ami-0d31d7c9fc9503726
-      Agent: ami-0a483013f2e53ed60
+      Agent: ami-03bad0b25097fe67d
       Bastion: ami-0d31d7c9fc9503726
 
 Parameters:

--- a/harness/determined/deploy/aws/templates/simple.yaml
+++ b/harness/determined/deploy/aws/templates/simple.yaml
@@ -5,35 +5,35 @@ Mappings:
   RegionMap:
     ap-northeast-1:
       Master: ami-0c7cb70d3eb61492b
-      Agent: ami-0efbc837b3c729df1
+      Agent: ami-09c9ea05363b4fe2d
     # TODO(DET-4258) Uncomment these when we fully support all P3 regions.
     # ap-northeast-2:
     #   Master: ami-003bb1772f36a39a3
-    #   Agent: ami-0934d35fc17d76abc
+    #   Agent: ami-07b13ec47230370d5
     # ap-southeast-1:
     #   Master: ami-09f03fa5572692399
-    #   Agent: ami-05068dcfa829e229e
+    #   Agent: ami-07affc5a669acb69f
     # ap-southeast-2:
     #   Master: ami-06139e5e22cc2f7b1
-    #   Agent: ami-0e62ea531c3969a65
+    #   Agent: ami-0ef38d26d9f61a0db
     eu-central-1:
       Master: ami-0b81e95bb0a06ea8c
-      Agent: ami-051a91b2829200200
+      Agent: ami-0c09eb6495c53c53c
     eu-west-1:
       Master: ami-029cfca952b331b52
-      Agent: ami-04eab4dc55258e621
+      Agent: ami-06de67607d7b543dd
     # eu-west-2:
     #   Master: ami-035469b606478d63d
-    #   Agent: ami-08aa94155b641d19d
+    #   Agent: ami-0130ec158c7260bf1
     us-east-1:
       Master: ami-0b93ce03dcbcb10f6
-      Agent: ami-0b4cc2ed4ecd07a2d
+      Agent: ami-027145fb15545cd96
     us-east-2:
       Master: ami-0cbea92f2377277a4
-      Agent: ami-0ba898a163ad80bf9
+      Agent: ami-0fe46b7b5fdba7b51
     us-west-2:
       Master: ami-0d31d7c9fc9503726
-      Agent: ami-0a483013f2e53ed60
+      Agent: ami-03bad0b25097fe67d
 
 Parameters:
   Keypair:

--- a/harness/determined/deploy/gcp/constants.py
+++ b/harness/determined/deploy/gcp/constants.py
@@ -3,7 +3,7 @@ class defaults:
     AUX_AGENT_INSTANCE_TYPE = "n1-standard-4"
     COMPUTE_AGENT_INSTANCE_TYPE = "n1-standard-32"
     DB_PASSWORD = "postgres"
-    ENVIRONMENT_IMAGE = "det-environments-ad0591c"
+    ENVIRONMENT_IMAGE = "det-environments-7aa5364"
     GPU_NUM = 8
     GPU_TYPE = "nvidia-tesla-k80"
     MASTER_INSTANCE_TYPE = "n1-standard-2"

--- a/harness/determined/estimator/_estimator_trial.py
+++ b/harness/determined/estimator/_estimator_trial.py
@@ -819,7 +819,7 @@ class EstimatorTrial(det.Trial):
     """
     By default, experiments run with TensorFlow 1.x. To configure your trial to
     use TensorFlow 2.x, set a TF 2.x image in the experiment configuration
-    (e.g. ``determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-0.19.12``).
+    (e.g. ``determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-0.20.1``).
 
     ``EstimatorTrial`` supports TF 2.x; however it uses TensorFlow V1
     behavior. We have disabled TensorFlow V2 behavior for ``EstimatorTrial``,

--- a/harness/determined/keras/_tf_keras_trial.py
+++ b/harness/determined/keras/_tf_keras_trial.py
@@ -974,7 +974,7 @@ class TFKerasTrial(det.Trial):
     legacy TensorFlow 1.x, specify a TensorFlow 1.x image in the
     :ref:`environment.image <exp-environment-image>` field of the experiment
     configuration (e.g.,
-    ``determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-0.19.12``).
+    ``determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-0.20.1``).
 
     Trials default to using eager execution with TensorFlow 2.x but not with
     TensorFlow 1.x. To override the default behavior, call the appropriate

--- a/harness/tests/experiment/fixtures/ancient-checkpoints/0.17.6-estimator/metadata.json
+++ b/harness/tests/experiment/fixtures/ancient-checkpoints/0.17.6-estimator/metadata.json
@@ -39,9 +39,9 @@
       },
       "force_pull_image": false,
       "image": {
-        "cpu": "determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-ad0591c",
-        "cuda": "determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-ad0591c",
-        "rocm": "determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-ad0591c"
+        "cpu": "determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-7aa5364",
+        "cuda": "determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-7aa5364",
+        "rocm": "determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-7aa5364"
       },
       "pod_spec": null,
       "ports": {},

--- a/harness/tests/experiment/fixtures/ancient-checkpoints/0.17.6-keras/metadata.json
+++ b/harness/tests/experiment/fixtures/ancient-checkpoints/0.17.6-keras/metadata.json
@@ -39,9 +39,9 @@
       },
       "force_pull_image": false,
       "image": {
-        "cpu": "determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-ad0591c",
-        "cuda": "determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-ad0591c",
-        "rocm": "determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-ad0591c"
+        "cpu": "determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-7aa5364",
+        "cuda": "determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-7aa5364",
+        "rocm": "determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-7aa5364"
       },
       "pod_spec": null,
       "ports": {},

--- a/harness/tests/experiment/fixtures/ancient-checkpoints/0.17.6-pytorch/metadata.json
+++ b/harness/tests/experiment/fixtures/ancient-checkpoints/0.17.6-pytorch/metadata.json
@@ -38,9 +38,9 @@
       },
       "force_pull_image": false,
       "image": {
-        "cpu": "determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-ad0591c",
-        "cuda": "determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-ad0591c",
-        "rocm": "determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-ad0591c"
+        "cpu": "determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-7aa5364",
+        "cuda": "determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-7aa5364",
+        "rocm": "determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-7aa5364"
       },
       "pod_spec": null,
       "ports": {},

--- a/helm/charts/determined/templates/master-config.yaml
+++ b/helm/charts/determined/templates/master-config.yaml
@@ -131,8 +131,8 @@ data:
       {{- toYaml .Values.resourcePools | nindent 6}}
     {{- end }}
 
-    {{$cpuImage := (split "/" "determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-ad0591c")._1}}
-    {{- $gpuImage := (split "/" "determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-ad0591c")._1 -}}
+    {{$cpuImage := (split "/" "determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-7aa5364")._1}}
+    {{- $gpuImage := (split "/" "determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-7aa5364")._1 -}}
     {{ if .Values.taskContainerDefaults -}}
     task_container_defaults:
       {{- if .Values.taskContainerDefaults.networkMode }}

--- a/master/internal/config/provconfig/aws_config.go
+++ b/master/internal/config/provconfig/aws_config.go
@@ -49,16 +49,16 @@ type AWSClusterConfig struct {
 }
 
 var defaultAWSImageID = map[string]string{
-	"ap-northeast-1": "ami-0efbc837b3c729df1",
-	"ap-northeast-2": "ami-0934d35fc17d76abc",
-	"ap-southeast-1": "ami-05068dcfa829e229e",
-	"ap-southeast-2": "ami-0e62ea531c3969a65",
-	"us-east-2":      "ami-0ba898a163ad80bf9",
-	"us-east-1":      "ami-0b4cc2ed4ecd07a2d",
-	"us-west-2":      "ami-0a483013f2e53ed60",
-	"eu-central-1":   "ami-051a91b2829200200",
-	"eu-west-2":      "ami-08aa94155b641d19d",
-	"eu-west-1":      "ami-04eab4dc55258e621",
+	"ap-northeast-1": "ami-09c9ea05363b4fe2d",
+	"ap-northeast-2": "ami-07b13ec47230370d5",
+	"ap-southeast-1": "ami-07affc5a669acb69f",
+	"ap-southeast-2": "ami-0ef38d26d9f61a0db",
+	"us-east-2":      "ami-0fe46b7b5fdba7b51",
+	"us-east-1":      "ami-027145fb15545cd96",
+	"us-west-2":      "ami-03bad0b25097fe67d",
+	"eu-central-1":   "ami-0c09eb6495c53c53c",
+	"eu-west-2":      "ami-0130ec158c7260bf1",
+	"eu-west-1":      "ami-06de67607d7b543dd",
 }
 
 var defaultAWSClusterConfig = AWSClusterConfig{

--- a/master/internal/config/provconfig/gcp_config.go
+++ b/master/internal/config/provconfig/gcp_config.go
@@ -53,7 +53,7 @@ type GCPClusterConfig struct {
 func DefaultGCPClusterConfig() *GCPClusterConfig {
 	return &GCPClusterConfig{
 		BootDiskSize:        200,
-		BootDiskSourceImage: "projects/determined-ai/global/images/det-environments-ad0591c",
+		BootDiskSourceImage: "projects/determined-ai/global/images/det-environments-7aa5364",
 		LabelKey:            "managed-by",
 		InstanceType: gceInstanceType{
 			MachineType: "n1-standard-32",

--- a/master/pkg/schemas/expconf/const.go
+++ b/master/pkg/schemas/expconf/const.go
@@ -8,7 +8,7 @@ const (
 
 // Default task environment docker image names.
 const (
-	CPUImage  = "determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-ad0591c"
-	CUDAImage = "determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-ad0591c"
-	ROCMImage = "determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-ad0591c"
+	CPUImage  = "determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-7aa5364"
+	CUDAImage = "determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-7aa5364"
+	ROCMImage = "determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-7aa5364"
 )

--- a/master/pkg/schemas/expconf/legacy_test.go
+++ b/master/pkg/schemas/expconf/legacy_test.go
@@ -111,7 +111,7 @@ func TestLegacyConfig(t *testing.T) {
 					RawImage: &EnvironmentImageMap{
 						RawCPU:  ptrs.Ptr("determinedai/environments:py-3.6.9-pytorch-1.4-tf-1.15-cpu-aaa3750"),
 						RawCUDA: ptrs.Ptr("determinedai/environments:cuda-10.0-pytorch-1.4-tf-1.15-gpu-aaa3750"),
-						RawROCM: ptrs.Ptr("determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-ad0591c"),
+						RawROCM: ptrs.Ptr("determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-7aa5364"),
 					},
 					RawPorts:            map[string]int{},
 					RawForcePullImage:   ptrs.Ptr(false),
@@ -244,7 +244,7 @@ func TestLegacyConfig(t *testing.T) {
 					RawImage: &EnvironmentImageMap{
 						RawCPU:  ptrs.Ptr("determinedai/environments:py-3.6.9-pytorch-1.4-tf-1.15-cpu-067db2b"),
 						RawCUDA: ptrs.Ptr("determinedai/environments:cuda-10.0-pytorch-1.4-tf-1.15-gpu-067db2b"),
-						RawROCM: ptrs.Ptr("determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-ad0591c"),
+						RawROCM: ptrs.Ptr("determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-7aa5364"),
 					},
 					RawPodSpec: &PodSpec{
 						TypeMeta: metaV1.TypeMeta{
@@ -330,8 +330,8 @@ func TestLegacyConfig(t *testing.T) {
                     gpu: []
                   force_pull_image: false
                   image:
-                    cpu: determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-ad0591c
-                    gpu: determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-ad0591c
+                    cpu: determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-7aa5364
+                    gpu: determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-7aa5364
                   ports: {}
                   registry_auth: null
                 hyperparameters:
@@ -408,9 +408,9 @@ func TestLegacyConfig(t *testing.T) {
 						RawROCM: []string{},
 					},
 					RawImage: &EnvironmentImageMap{
-						RawCPU:  ptrs.Ptr("determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-ad0591c"),
-						RawCUDA: ptrs.Ptr("determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-ad0591c"),
-						RawROCM: ptrs.Ptr("determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-ad0591c"),
+						RawCPU:  ptrs.Ptr("determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-7aa5364"),
+						RawCUDA: ptrs.Ptr("determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-7aa5364"),
+						RawROCM: ptrs.Ptr("determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-7aa5364"),
 					},
 					RawPorts:            map[string]int{},
 					RawForcePullImage:   ptrs.Ptr(false),

--- a/model_hub/Makefile
+++ b/model_hub/Makefile
@@ -5,7 +5,7 @@ SHORT_GIT_HASH := $(shell git rev-parse --short HEAD)
 ARTIFACTS_DIR := /tmp/artifacts
 
 # Model-hub library environments will be built on top of the default GPU and CPU images in master/pkg/model/defaults.go
-DEFAULT_GPU_IMAGE := determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-ad0591c
+DEFAULT_GPU_IMAGE := determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-7aa5364
 
 ############REMINDER############
 # When bumping third-party library versions, remember to bump versions in

--- a/schemas/test_cases/v0/experiment.yaml
+++ b/schemas/test_cases/v0/experiment.yaml
@@ -32,9 +32,9 @@
       environment_variables: {}
       force_pull_image: false
       image:
-        cpu: determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-ad0591c
-        cuda: determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-ad0591c
-        rocm: determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-ad0591c
+        cpu: determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-7aa5364
+        cuda: determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-7aa5364
+        rocm: determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-7aa5364
       pod_spec: null
       ports:
         qwer: 1234

--- a/tools/scripts/bumpenvs.yaml
+++ b/tools/scripts/bumpenvs.yaml
@@ -1,6 +1,6 @@
 ap_northeast_1_agent_ami:
-  new: ami-0efbc837b3c729df1
-  old: ami-0e869a96e81e4c106
+  new: ami-09c9ea05363b4fe2d
+  old: ami-0efbc837b3c729df1
 ap_northeast_1_bastion_ami:
   new: ami-0c7cb70d3eb61492b
   old: ami-09b18720cb71042df
@@ -8,8 +8,8 @@ ap_northeast_1_master_ami:
   new: ami-0c7cb70d3eb61492b
   old: ami-09b18720cb71042df
 ap_northeast_2_agent_ami:
-  new: ami-0934d35fc17d76abc
-  old: ami-03bd3b100feb865bb
+  new: ami-07b13ec47230370d5
+  old: ami-0934d35fc17d76abc
 ap_northeast_2_bastion_ami:
   new: ami-003bb1772f36a39a3
   old: ami-07d16c043aa8e5153
@@ -17,8 +17,8 @@ ap_northeast_2_master_ami:
   new: ami-003bb1772f36a39a3
   old: ami-07d16c043aa8e5153
 ap_southeast_1_agent_ami:
-  new: ami-05068dcfa829e229e
-  old: ami-0f3517aae74b1acae
+  new: ami-07affc5a669acb69f
+  old: ami-05068dcfa829e229e
 ap_southeast_1_bastion_ami:
   new: ami-09f03fa5572692399
   old: ami-00e912d13fbb4f225
@@ -26,8 +26,8 @@ ap_southeast_1_master_ami:
   new: ami-09f03fa5572692399
   old: ami-00e912d13fbb4f225
 ap_southeast_2_agent_ami:
-  new: ami-0e62ea531c3969a65
-  old: ami-09ff97700ee2396b5
+  new: ami-0ef38d26d9f61a0db
+  old: ami-0e62ea531c3969a65
 ap_southeast_2_bastion_ami:
   new: ami-06139e5e22cc2f7b1
   old: ami-055166f8a8041fbf1
@@ -35,18 +35,18 @@ ap_southeast_2_master_ami:
   new: ami-06139e5e22cc2f7b1
   old: ami-055166f8a8041fbf1
 deepspeed_gpu_0_hashed:
-  new: determinedai/environments:cuda-11.3-pytorch-1.10-tf-2.8-deepspeed-0.7.0-gpu-ad0591c
-  old: determinedai/environments:cuda-11.3-pytorch-1.10-tf-2.8-deepspeed-0.7.0-gpu-24586f0
+  new: determinedai/environments:cuda-11.3-pytorch-1.10-tf-2.8-deepspeed-0.7.0-gpu-7aa5364
+  old: determinedai/environments:cuda-11.3-pytorch-1.10-tf-2.8-deepspeed-0.7.0-gpu-ad0591c
 deepspeed_gpu_0_versioned:
-  new: determinedai/environments:cuda-11.3-pytorch-1.10-tf-2.8-deepspeed-0.7.0-gpu-0.19.12
-  old: determinedai/environments:cuda-11.3-pytorch-1.10-tf-2.8-deepspeed-0.7.0-gpu-0.19.10
+  new: determinedai/environments:cuda-11.3-pytorch-1.10-tf-2.8-deepspeed-0.7.0-gpu-0.20.1
+  old: determinedai/environments:cuda-11.3-pytorch-1.10-tf-2.8-deepspeed-0.7.0-gpu-0.19.12
 deepspeed_gpu_1_hashed:
   new: determinedai/environments:cuda-11.3-pytorch-1.10-tf-2.8-deepspeed-0.7.0-gpu-mpi-9119094
 deepspeed_gpu_1_versioned:
   new: determinedai/environments:cuda-11.3-pytorch-1.10-tf-2.8-deepspeed-0.7.0-gpu-mpi-0.19.1
 eu_central_1_agent_ami:
-  new: ami-051a91b2829200200
-  old: ami-03f98ed935d6413bb
+  new: ami-0c09eb6495c53c53c
+  old: ami-051a91b2829200200
 eu_central_1_bastion_ami:
   new: ami-0b81e95bb0a06ea8c
   old: ami-06148e0e81e5187c8
@@ -54,8 +54,8 @@ eu_central_1_master_ami:
   new: ami-0b81e95bb0a06ea8c
   old: ami-06148e0e81e5187c8
 eu_west_1_agent_ami:
-  new: ami-04eab4dc55258e621
-  old: ami-0486dbd675e5d21fc
+  new: ami-06de67607d7b543dd
+  old: ami-04eab4dc55258e621
 eu_west_1_bastion_ami:
   new: ami-029cfca952b331b52
   old: ami-0fd8802f94ed1c969
@@ -63,8 +63,8 @@ eu_west_1_master_ami:
   new: ami-029cfca952b331b52
   old: ami-0fd8802f94ed1c969
 eu_west_2_agent_ami:
-  new: ami-08aa94155b641d19d
-  old: ami-0ba5e33f4b5a82550
+  new: ami-0130ec158c7260bf1
+  old: ami-08aa94155b641d19d
 eu_west_2_bastion_ami:
   new: ami-035469b606478d63d
   old: ami-04842bc62789b682e
@@ -72,24 +72,40 @@ eu_west_2_master_ami:
   new: ami-035469b606478d63d
   old: ami-04842bc62789b682e
 gcp_env:
-  new: det-environments-ad0591c
-  old: det-environments-24586f0
+  new: det-environments-7aa5364
+  old: det-environments-ad0591c
 gpt_neox_deepspeed_gpu_0_hashed:
-  new: determinedai/environments:cuda-11.3-pytorch-1.10-tf-2.8-gpt-neox-deepspeed-gpu-ad0591c
-  old: determinedai/environments:cuda-11.3-pytorch-1.10-tf-2.8-gpt-neox-deepspeed-gpu-24586f0
+  new: determinedai/environments:cuda-11.3-pytorch-1.10-tf-2.8-gpt-neox-deepspeed-gpu-7aa5364
+  old: determinedai/environments:cuda-11.3-pytorch-1.10-tf-2.8-gpt-neox-deepspeed-gpu-ad0591c
 gpt_neox_deepspeed_gpu_0_versioned:
-  new: determinedai/environments:cuda-11.3-pytorch-1.10-tf-2.8-gpt-neox-deepspeed-gpu-0.19.12
-  old: determinedai/environments:cuda-11.3-pytorch-1.10-tf-2.8-gpt-neox-deepspeed-gpu-0.19.10
+  new: determinedai/environments:cuda-11.3-pytorch-1.10-tf-2.8-gpt-neox-deepspeed-gpu-0.20.1
+  old: determinedai/environments:cuda-11.3-pytorch-1.10-tf-2.8-gpt-neox-deepspeed-gpu-0.19.12
 gpt_neox_deepspeed_gpu_1_hashed:
   new: determinedai/environments:cuda-11.3-pytorch-1.10-tf-2.8-gpt-neox-deepspeed-gpu-mpi-9119094
 gpt_neox_deepspeed_gpu_1_versioned:
   new: determinedai/environments:cuda-11.3-pytorch-1.10-tf-2.8-gpt-neox-deepspeed-gpu-mpi-0.19.1
+pt_cpu_0_hashed:
+  new: determinedai/environments:py-3.8-pytorch-1.12-cpu-7aa5364
+pt_cpu_0_versioned:
+  new: determinedai/environments:py-3.8-pytorch-1.12-cpu-0.20.1
+pt_cpu_1_hashed:
+  new: determinedai/environments:py-3.8-pytorch-1.12-cpu-mpi-7aa5364
+pt_cpu_1_versioned:
+  new: determinedai/environments:py-3.8-pytorch-1.12-cpu-mpi-0.20.1
+pt_gpu_0_hashed:
+  new: determinedai/environments:cuda-11.3-pytorch-1.12-gpu-7aa5364
+pt_gpu_0_versioned:
+  new: determinedai/environments:cuda-11.3-pytorch-1.12-gpu-0.20.1
+pt_gpu_1_hashed:
+  new: determinedai/environments:cuda-11.3-pytorch-1.12-gpu-mpi-7aa5364
+pt_gpu_1_versioned:
+  new: determinedai/environments:cuda-11.3-pytorch-1.12-gpu-mpi-0.20.1
 pytorch10_tf27_rocm50_0_hashed:
-  new: determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-ad0591c
-  old: determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-24586f0
+  new: determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-7aa5364
+  old: determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-ad0591c
 pytorch10_tf27_rocm50_0_versioned:
-  new: determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-0.19.12
-  old: determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-0.19.10
+  new: determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-0.20.1
+  old: determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-0.19.12
 pytorch19_tf25_rocm_0_hashed:
   new: determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-096d730
   old: determinedai/environments:rocm-4.2-pytorch-1.9-tf-2.5-rocm-ecee7c1
@@ -101,29 +117,29 @@ pytorch19_tf25_rocm_1_hashed:
 pytorch19_tf25_rocm_1_versioned:
   new: determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-0.19.4
 tf1_cpu_0_hashed:
-  new: determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-ad0591c
-  old: determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-24586f0
+  new: determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-7aa5364
+  old: determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-ad0591c
 tf1_cpu_0_versioned:
-  new: determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-0.19.12
-  old: determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-0.19.10
+  new: determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-0.20.1
+  old: determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-0.19.12
 tf1_cpu_1_hashed:
-  new: determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-mpi-ad0591c
-  old: determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-mpi-24586f0
+  new: determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-mpi-7aa5364
+  old: determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-mpi-ad0591c
 tf1_cpu_1_versioned:
-  new: determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-mpi-0.19.12
-  old: determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-mpi-0.19.10
+  new: determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-mpi-0.20.1
+  old: determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-mpi-0.19.12
 tf1_gpu_0_hashed:
-  new: determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-ad0591c
-  old: determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-24586f0
+  new: determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-7aa5364
+  old: determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-ad0591c
 tf1_gpu_0_versioned:
-  new: determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-0.19.12
-  old: determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-0.19.10
+  new: determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-0.20.1
+  old: determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-0.19.12
 tf1_gpu_1_hashed:
-  new: determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-mpi-ad0591c
-  old: determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-mpi-24586f0
+  new: determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-mpi-7aa5364
+  old: determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-mpi-ad0591c
 tf1_gpu_1_versioned:
-  new: determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-mpi-0.19.12
-  old: determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-mpi-0.19.10
+  new: determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-mpi-0.20.1
+  old: determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-mpi-0.19.12
 tf24_cpu_0_hashed:
   new: determinedai/environments:py-3.8-pytorch-1.9-tf-2.4-cpu-24586f0
   old: determinedai/environments-dev:py-3.8-pytorch-1.9-tf-2.4-cpu-1c769fb
@@ -197,56 +213,56 @@ tf26_gpu_1_versioned:
   new: determinedai/environments-dev:cuda-11.2-tf-2.6-gpu-mpi-0.19.10
   old: determinedai/environments:cuda-11.2-tf-2.6-gpu-mpi-0.19.4
 tf27_cpu_0_hashed:
-  new: determinedai/environments:py-3.8-pytorch-1.12-tf-2.7-cpu-ad0591c
-  old: determinedai/environments:py-3.8-tf-2.7-cpu-24586f0
+  new: determinedai/environments:py-3.8-pytorch-1.12-tf-2.7-cpu-7aa5364
+  old: determinedai/environments:py-3.8-pytorch-1.12-tf-2.7-cpu-ad0591c
 tf27_cpu_0_versioned:
-  new: determinedai/environments:py-3.8-pytorch-1.12-tf-2.7-cpu-0.19.12
-  old: determinedai/environments:py-3.8-tf-2.7-cpu-0.19.10
+  new: determinedai/environments:py-3.8-pytorch-1.12-tf-2.7-cpu-0.20.1
+  old: determinedai/environments:py-3.8-pytorch-1.12-tf-2.7-cpu-0.19.12
 tf27_cpu_1_hashed:
-  new: determinedai/environments:py-3.8-pytorch-1.12-tf-2.7-cpu-mpi-ad0591c
-  old: determinedai/environments:py-3.8-tf-2.7-cpu-mpi-24586f0
+  new: determinedai/environments:py-3.8-pytorch-1.12-tf-2.7-cpu-mpi-7aa5364
+  old: determinedai/environments:py-3.8-pytorch-1.12-tf-2.7-cpu-mpi-ad0591c
 tf27_cpu_1_versioned:
-  new: determinedai/environments:py-3.8-pytorch-1.12-tf-2.7-cpu-mpi-0.19.12
-  old: determinedai/environments:py-3.8-tf-2.7-cpu-mpi-0.19.10
+  new: determinedai/environments:py-3.8-pytorch-1.12-tf-2.7-cpu-mpi-0.20.1
+  old: determinedai/environments:py-3.8-pytorch-1.12-tf-2.7-cpu-mpi-0.19.12
 tf27_gpu_0_hashed:
-  new: determinedai/environments:cuda-11.2-pytorch-1.12-tf-2.7-gpu-ad0591c
-  old: determinedai/environments:cuda-11.2-tf-2.7-gpu-24586f0
+  new: determinedai/environments:cuda-11.2-pytorch-1.12-tf-2.7-gpu-7aa5364
+  old: determinedai/environments:cuda-11.2-pytorch-1.12-tf-2.7-gpu-ad0591c
 tf27_gpu_0_versioned:
-  new: determinedai/environments:cuda-11.2-pytorch-1.12-tf-2.7-gpu-0.19.12
-  old: determinedai/environments:cuda-11.2-tf-2.7-gpu-0.19.10
+  new: determinedai/environments:cuda-11.2-pytorch-1.12-tf-2.7-gpu-0.20.1
+  old: determinedai/environments:cuda-11.2-pytorch-1.12-tf-2.7-gpu-0.19.12
 tf27_gpu_1_hashed:
-  new: determinedai/environments:cuda-11.2-pytorch-1.12-tf-2.7-gpu-mpi-ad0591c
-  old: determinedai/environments:cuda-11.2-tf-2.7-gpu-mpi-24586f0
+  new: determinedai/environments:cuda-11.2-pytorch-1.12-tf-2.7-gpu-mpi-7aa5364
+  old: determinedai/environments:cuda-11.2-pytorch-1.12-tf-2.7-gpu-mpi-ad0591c
 tf27_gpu_1_versioned:
-  new: determinedai/environments:cuda-11.2-pytorch-1.12-tf-2.7-gpu-mpi-0.19.12
-  old: determinedai/environments:cuda-11.2-tf-2.7-gpu-mpi-0.19.10
+  new: determinedai/environments:cuda-11.2-pytorch-1.12-tf-2.7-gpu-mpi-0.20.1
+  old: determinedai/environments:cuda-11.2-pytorch-1.12-tf-2.7-gpu-mpi-0.19.12
 tf2_cpu_0_hashed:
-  new: determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-ad0591c
-  old: determinedai/environments:py-3.8-pytorch-1.10-tf-2.8-cpu-24586f0
+  new: determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-7aa5364
+  old: determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-ad0591c
 tf2_cpu_0_versioned:
-  new: determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-0.19.12
-  old: determinedai/environments:py-3.8-pytorch-1.10-tf-2.8-cpu-0.19.10
+  new: determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-0.20.1
+  old: determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-0.19.12
 tf2_cpu_1_hashed:
-  new: determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-mpi-ad0591c
-  old: determinedai/environments:py-3.8-pytorch-1.11-tf-2.8-cpu-mpi-24586f0
+  new: determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-mpi-7aa5364
+  old: determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-mpi-ad0591c
 tf2_cpu_1_versioned:
-  new: determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-mpi-0.19.12
-  old: determinedai/environments:py-3.8-pytorch-1.11-tf-2.8-cpu-mpi-0.19.10
+  new: determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-mpi-0.20.1
+  old: determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-mpi-0.19.12
 tf2_gpu_0_hashed:
-  new: determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-ad0591c
-  old: determinedai/environments:cuda-11.3-pytorch-1.10-tf-2.8-gpu-24586f0
+  new: determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-7aa5364
+  old: determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-ad0591c
 tf2_gpu_0_versioned:
-  new: determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-0.19.12
-  old: determinedai/environments:cuda-11.3-pytorch-1.10-tf-2.8-gpu-0.19.10
+  new: determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-0.20.1
+  old: determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-0.19.12
 tf2_gpu_1_hashed:
-  new: determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-mpi-ad0591c
-  old: determinedai/environments:cuda-11.3-pytorch-1.10-tf-2.8-gpu-mpi-24586f0
+  new: determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-mpi-7aa5364
+  old: determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-mpi-ad0591c
 tf2_gpu_1_versioned:
-  new: determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-mpi-0.19.12
-  old: determinedai/environments:cuda-11.3-pytorch-1.10-tf-2.8-gpu-mpi-0.19.10
+  new: determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-mpi-0.20.1
+  old: determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-mpi-0.19.12
 us_east_1_agent_ami:
-  new: ami-0b4cc2ed4ecd07a2d
-  old: ami-02aa57541c622dde4
+  new: ami-027145fb15545cd96
+  old: ami-0b4cc2ed4ecd07a2d
 us_east_1_bastion_ami:
   new: ami-0b93ce03dcbcb10f6
   old: ami-0149b2da6ceec4bb0
@@ -254,8 +270,8 @@ us_east_1_master_ami:
   new: ami-0b93ce03dcbcb10f6
   old: ami-0149b2da6ceec4bb0
 us_east_2_agent_ami:
-  new: ami-0ba898a163ad80bf9
-  old: ami-06b2144e6efc0145e
+  new: ami-0fe46b7b5fdba7b51
+  old: ami-0ba898a163ad80bf9
 us_east_2_bastion_ami:
   new: ami-0cbea92f2377277a4
   old: ami-0d5bf08bc8017c83b
@@ -263,20 +279,20 @@ us_east_2_master_ami:
   new: ami-0cbea92f2377277a4
   old: ami-0d5bf08bc8017c83b
 us_gov_east_1_agent_ami:
-  new: ami-099f0e95f51e757e6
-  old: ami-0a2c45c9ffe923133
+  new: ami-0a7d2c6fd685356ce
+  old: ami-099f0e95f51e757e6
 us_gov_east_1_master_ami:
   new: ami-0b36c558c9dd26c75
   old: ami-03106245b0320c1b6
 us_gov_west_1_agent_ami:
-  new: ami-0a80fcfdbeff6ea3b
-  old: ami-05d7cfb1f5dae4eba
+  new: ami-09210d286f66f0aa3
+  old: ami-0a80fcfdbeff6ea3b
 us_gov_west_1_master_ami:
   new: ami-0f1289f37e46c1eff
   old: ami-06bc7677241f6bdeb
 us_west_2_agent_ami:
-  new: ami-0a483013f2e53ed60
-  old: ami-0a3fcac423fda2fd1
+  new: ami-03bad0b25097fe67d
+  old: ami-0a483013f2e53ed60
 us_west_2_bastion_ami:
   new: ami-0d31d7c9fc9503726
   old: ami-0c09c7eb16d3e8e70

--- a/tools/scripts/update-bumpenvs-yaml.py
+++ b/tools/scripts/update-bumpenvs-yaml.py
@@ -40,9 +40,11 @@ JOB_SUFFIXES = [
     "tf1-cpu",
     "tf2-cpu",
     "tf27-cpu",
+    "pt-cpu",
     "tf1-gpu",
     "tf2-gpu",
     "tf27-gpu",
+    "pt-gpu",
 ]
 
 JOB_SUFFIXES_WITHOUT_MPI = [

--- a/webui/react/src/fixtures/responses/experiment-details/non-scalar-metrics-4078.json
+++ b/webui/react/src/fixtures/responses/experiment-details/non-scalar-metrics-4078.json
@@ -32,8 +32,8 @@
     "name": "Fork of Fork of mnist_tp_to_estimator_const",
     "environment": {
       "image": {
-        "cpu": "determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-ad0591c",
-        "gpu": "determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-ad0591c"
+        "cpu": "determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-7aa5364",
+        "gpu": "determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-7aa5364"
       },
       "ports": null,
       "pod_spec": null,

--- a/webui/react/src/fixtures/responses/experiment-details/set-a.json
+++ b/webui/react/src/fixtures/responses/experiment-details/set-a.json
@@ -694,8 +694,8 @@
         "environment_variables": {},
         "force_pull_image": false,
         "image": {
-          "cpu": "determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-ad0591c",
-          "gpu": "determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-ad0591c"
+          "cpu": "determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-7aa5364",
+          "gpu": "determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-7aa5364"
         },
         "pod_spec": null,
         "ports": null
@@ -838,8 +838,8 @@
         "environment_variables": {},
         "force_pull_image": false,
         "image": {
-          "cpu": "determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-ad0591c",
-          "gpu": "determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-ad0591c"
+          "cpu": "determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-7aa5364",
+          "gpu": "determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-7aa5364"
         },
         "pod_spec": {
           "metadata": {

--- a/webui/react/src/fixtures/responses/trial-details/old-trial-config-noop-adaptive.json
+++ b/webui/react/src/fixtures/responses/trial-details/old-trial-config-noop-adaptive.json
@@ -30,8 +30,8 @@
   "name": "noop_adaptive",
   "environment": {
     "image": {
-      "cpu": "determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-ad0591c",
-      "gpu": "determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-ad0591c"
+      "cpu": "determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-7aa5364",
+      "gpu": "determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-7aa5364"
     },
     "ports": null,
     "force_pull_image": false,

--- a/webui/react/src/pages/ExperimentDetails/ExperimentDetails.test.mock.ts
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentDetails.test.mock.ts
@@ -69,7 +69,7 @@ const RESPONSES = {
           image: {
             cpu: 'determinedai/environments:py-3.8-pytorch-1.10-tf-2.8-cpu-ecee7c1',
             cuda: 'determinedai/environments:cuda-11.3-pytorch-1.10-tf-2.8-gpu-ecee7c1',
-            rocm: 'determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-ad0591c',
+            rocm: 'determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-7aa5364',
           },
           pod_spec: null,
           ports: {},
@@ -751,7 +751,7 @@ const RESPONSES = {
           image: {
             cpu: 'determinedai/environments:py-3.8-pytorch-1.10-tf-2.8-cpu-ecee7c1',
             cuda: 'determinedai/environments:cuda-11.3-pytorch-1.10-tf-2.8-gpu-ecee7c1',
-            rocm: 'determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-ad0591c',
+            rocm: 'determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-7aa5364',
           },
           pod_spec: null,
           ports: {},


### PR DESCRIPTION
## Description

Changes following environments update [add pt-only images](https://github.com/determined-ai/environments/commit/7aa53645de04aedce3f81d708b31c3d5b8ce2504)

Add pt-only images to some e2e and nightly tests
Update .circleci config
Run bumpenvs

## Test Plan

Update and run a few unit tests in:

- e2e_tests/tests/experiment/test_pytorch.py
- e2e_tests/test/nightly/test_distributed.py

## Commentary (optional)

This PR is not automatically rebaseable with EE. It is expected that a manual rebase is required.

Since bumpenvs updated 50+ files, I want to specifically point reviewers to files I manually changed for scrutiny:

- e2e_tests/tests/config.py
- e2e_tests/tests/experiment/test_pytorch.py
- e2e_tests/test/nightly/test_distributed.py
- tools/scripts/update-bumpenvs-yaml.py



## Checklist

- [x] Changes have been manually QA'd
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.

## Ticket
MLG-329

