### PR TITLE
docs: Launcher doc improvements

### DIFF
--- a/docs/cluster-setup-guide/deploy-cluster/sysadmin-deploy-on-slurm/install-on-slurm.rst
+++ b/docs/cluster-setup-guide/deploy-cluster/sysadmin-deploy-on-slurm/install-on-slurm.rst
@@ -109,7 +109,9 @@ fulfilled and configured, install and configure the Determined master:
    +----------------------------+----------------------------------------------------------------+
    | ``user_name`` and          | By default, the launcher runs from the root account. Create a  |
    | ``group_name``             | local account and group and update these values to enable      |
-   |                            | running from another account.                                  |
+   |                            | running from another account. This account must have access to |
+   |                            | the Slurm/PBS command line to discover partitions and          |
+   |                            | summarize cluster usage.                                       |
    +----------------------------+----------------------------------------------------------------+
    | ``path``                   | If any of the launcher dependencies are not on the default     |
    |                            | path, you can override the default by updating this value.     |
@@ -131,7 +133,7 @@ fulfilled and configured, install and configure the Determined master:
 
 #. Verify successful launcher startup using the ``systemctl status launcher`` command. If the
    launcher fails to start, check system log diagnostics, such as ``/var/log/messages`` or
-   ``journalctl --since=10m -u launcher``, make the needed changes to the
+   ``journalctl --since="10 minutes ago" -u launcher``, make the needed changes to the
    ``/etc/determined/master.yaml`` file, and restart the launcher.
 
    If the installer reported incorrect dependencies, verify that they have been resolved by changes
@@ -149,8 +151,8 @@ fulfilled and configured, install and configure the Determined master:
 
 #. Verify successful determined-master startup using the ``systemctl status determined-master``
    command. If the launcher fails to start, check system log diagnostics, such as
-   ``/var/log/messages`` or ``journalctl --since=10m -u determined-master``, make the needed changes
-   to the ``/etc/determined/master.yaml`` file, and restart the determined-master.
+   ``/var/log/messages`` or ``journalctl --since="10 minutes ago" -u determined-master``, make the
+   needed changes to the ``/etc/determined/master.yaml`` file, and restart the determined-master.
 
 #. If the compute nodes of your cluster do not have internet connectivity to download Docker images,
    see :ref:`slurm-image-config`.

--- a/docs/reference/reference-deploy/config/master-config-reference.rst
+++ b/docs/reference/reference-deploy/config/master-config-reference.rst
@@ -296,7 +296,9 @@ The master supports the following configuration settings:
 
       -  ``user_name``: The username that the Launcher will run as. It is recommended to set this to
          something other than ``root``. The user must have a home directory with read permissions
-         for all users to enable access to generated ``sbatch`` scripts and job log files.
+         for all users to enable access to generated ``sbatch`` scripts and job log files. It must
+         have access to the Slurm/PBS queue and node status commands (``squeue``, ``sinfo``,
+         ``pbsnodes``, ``qstat`` ) to discover partitions and to display cluster usage.
 
       -  ``group_name``: The group that the Launcher will belong to. It should be a group that is not
             shared with other non-privileged users.


### PR DESCRIPTION

## Description

- Generalize journalctl command example --since option to work on Unbutu.
- Clarify user_name/group_name account requirements.


## Test Plan

Ran through grammerly.com

![image](https://user-images.githubusercontent.com/84593277/221909008-ab0fd756-fce7-4534-8407-5a3e3d8e1fc8.png)

and

![image](https://user-images.githubusercontent.com/84593277/221909306-32bdd8f3-cb83-4d70-aa31-a4166bb2fc7a.png)



## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
