### PR TITLE
docs: Add Core API MNIST User Guide

### DIFF
--- a/docs/reference/reference-training/experiment-config-reference.rst
+++ b/docs/reference/reference-training/experiment-config-reference.rst
@@ -216,6 +216,8 @@ Example:
    Instructs Determined to perform an initial validation before any training begins, for each trial.
    This can be useful to determine a baseline when fine-tuning a model on a new dataset.
 
+.. _experiment-config-checkpoint-policy:
+
 *******************
  Checkpoint Policy
 *******************

--- a/docs/training/apis-howto/api-core-ug.rst
+++ b/docs/training/apis-howto/api-core-ug.rst
@@ -1,211 +1,286 @@
-##########
- Core API
-##########
+#####################
+ Core API User Guide
+#####################
 
-In this guide, you'll learn how to use the Core API.
+This guide will help you get up and running with the Core API.
 
 +------------------------------------------------------------------+
 | Visit the API reference                                          |
 +==================================================================+
-| :doc:`/reference/reference-training/training/api-core-reference` |
+| :ref:`core-reference`                                            |
 +------------------------------------------------------------------+
 
-With the Core API you can train arbitrary models on the Determined platform with seamless access to
-the the following capabilities:
+In this user guide, we'll show you how to adapt model training code to use the Core API. As an
+example, we'll be working with the PyTorch MNIST model.
 
--  metrics tracking
--  checkpoint tracking and preemption support
--  hyperparameter search
--  distributing work across multiple GPUs and/or nodes
+************
+ Objectives
+************
 
-These are the same features provided by the higher-level PyTorchTrial, DeepSpeedTrial, and
-TFKerasTrial APIs (the higher-level APIs are implemented using the Core API).
+These step-by-step instructions walk you through modifying a script for the purpose of performing
+the following functions:
 
-This user guide shows you how to get started using the Core API.
+-  Report metrics
+-  Report checkpoints
+-  Perform a hyperparameter search
+-  Perform distributed training
 
-.. _core-getting-started:
+After completing the steps in this user guide, you will be able to do the following:
 
-*****************
- Getting Started
-*****************
+-  Understand the minimum requirements for running an experiment
+-  Modify a script and an experiment configuration file
+-  Understand how to convert model code
+-  Use the Core API to train a model
 
-As a simple introduction, this example training script increments a single integer in a loop,
-instead of training a model with machine learning. The changes shown for the example model should be
-similar to the changes you make in your actual model.
+***************
+ Prerequisites
+***************
 
-The ``0_start.py`` training script used in this example contains your simple "model":
+**Required**
 
-.. literalinclude:: ../../../examples/tutorials/core_api/0_start.py
-   :language: python
-   :start-at: import
+-  A Determined cluster
 
-To run this script, create a configuration file with at least the following values:
+**Recommended**
 
-.. literalinclude:: ../../../examples/tutorials/core_api/0_start.yaml
-   :language: yaml
+-  :ref:`qs-mdldev`
 
-The actual configuration file can have any name, but this example uses ``0_start.yaml``.
+*****************************************************
+ Step 1: Get the Tutorial Files & Run the Experiment
+*****************************************************
 
-Run the code using the command:
+To run an experiment, you need, at minimum, a script and an experiment configuration (YAML) file.
+
+Create a new directory.
+
+Get the files from the :download:`core_api_pytorch_mnist.tgz </examples/core_api_pytorch_mnist.tgz>`
+download or from the `Github repository
+<https://github.com/determined-ai/determined/tree/master/examples/tutorials/core_api_pytorch_mnist>`_.
+
+.. note::
+
+   Throughout this user guide, we’ll show you how to make modifications to your script. After each
+   step, we’ll re-run our experiment using the appropriate script and its accompanying experiment
+   configuration file.
+
+In this initial step, we’ll run our experiment using the ``model_def.py`` script and its
+accompanying ``const.yaml`` experiment configuration file.
+
+CD into the directory and run this command:
 
 .. code:: bash
 
-   det e create 0_start.yaml . -f
+   det e create const.yaml . -f
 
-If you navigate to this experiment in the WebUI no metrics are displayed because you have not yet
-reported them to the master using the Core API.
+Open the Determined WebUI by navigating to ``http://localhost:8080/``. Accept the default determined
+username, leave the password empty, and click **Sign In**.
 
-.. _core-metrics:
+In the WebUI, select your experiment, and then navigate to the **Logs** tab.
 
-****************
- Report Metrics
-****************
+************************
+ Step 2: Report Metrics
+************************
 
-The Core API makes it easy to report training and validation metrics to the master during training
-with only a few new lines of code.
+To report training and validation metrics to the Determined master, we’ll add a few lines of code to
+our script. More specifically, we'll create a :class:`~determined.core.Context` object to allow
+interaction with the master. Then, we'll pass the ``core_context`` as an argument into ``main()``,
+``train()``, and ``test()`` and modify the function headers accordingly.
 
-#. For this example, create a new training script called ``1_metrics.py`` by copying the
-   ``0_start.py`` script from :ref:`core-getting-started`.
+To run our experiment, we'll use the ``model_def_metrics.py`` script and its accompanying
+``metrics.yaml`` experiment configuration file.
 
-#. Begin by importing import the ``determined`` module:
+Begin by importing Determined:
 
-   .. literalinclude:: ../../../examples/tutorials/core_api/1_metrics.py
-      :language: python
-      :start-after: NEW: import determined
-      :end-before: def main
+.. code:: python
 
-#. Enable ``logging``, using the ``det.LOG_FORMAT`` for logs. This enables useful log messages from
-   the ``determined`` library, and ``det.LOG_FORMAT`` enables filter-by-level in the WebUI.
+   import determined as det
 
-   .. literalinclude:: ../../../examples/tutorials/core_api/1_metrics.py
-      :language: python
-      :start-at: logging.basicConfig
-      :end-at: logging.error
+Step 2.1: Modify the Main Loop
+==============================
 
-#. In your ``if __name__ == "__main__"`` block, wrap the entire execution of ``main()`` within the
-   scope of :meth:`determined.core.init`, which prepares resources for training and cleans them up
-   afterward. Add the ``core_context`` as a new argument to ``main()`` because the Core API is
-   accessed through the ``core_context`` object.
+Modify the __main__loop to include ``core_context``:
 
-   .. literalinclude:: ../../../examples/tutorials/core_api/1_metrics.py
-      :language: python
-      :start-at: with det.core.init
+.. note::
 
-#. Within ``main()``, add two calls: (1) report training metrics periodically during training and
-   (2) report validation metrics every time a validation runs.
+   Refer to the ``if __name__ == "__main__":`` block in ``model_def_metrics.py``
 
-   .. literalinclude:: ../../../examples/tutorials/core_api/1_metrics.py
-      :language: python
-      :pyobject: main
+.. literalinclude:: ../../../examples/tutorials/core_api_pytorch_mnist/model_def_metrics.py
+   :language: python
+   :start-at: if __name__ == "__main__":
+   :end-at: main(core_context=core_context)
 
-   The ``report_validation_metrics()`` call typically happens after the validation step, however,
-   actual validation is not demonstrated by this example.
+Step 2.2: Modify the Train Method
+=================================
 
-#. Create a ``1_metrics.yaml`` file with an ``entrypoint`` invoking the new ``1_metrics.py`` file.
-   You can copy the ``0_start.yaml`` configuration file and change the first couple of lines:
+Modify the train() method by adding ``core_context.train.report_training_metrics()``:
 
-   .. literalinclude:: ../../../examples/tutorials/core_api/1_metrics.yaml
-      :language: yaml
-      :lines: 1-2
+.. note::
 
-#. Run the code using the command:
+   Viewing epoch-based metrics
 
-   .. code:: bash
+   This example defines an "epoch" metric for the purpose of reporting its value during training and
+   viewing epoch-based metric data in the WebUI. Modifying your code in this way is entirely
+   optional.
 
-      det e create 1_metrics.yaml . -f
+.. literalinclude:: ../../../examples/tutorials/core_api_pytorch_mnist/model_def_metrics.py
+   :language: python
+   :start-at: # NEW: Report epoch-based training metrics to Determined master via core_context.
+   :end-at: metrics={"train_loss": loss.item(), "epoch": epoch},
 
-#. You can now navigate to the new experiment in the WebUI and view the plot populated with the
-   training and validation metrics.
+.. literalinclude:: ../../../examples/tutorials/core_api_pytorch_mnist/model_def_metrics.py
+   :language: python
+   :start-at: core_context.train.report_validation_metrics
+   :end-at: metrics={"test_loss": test_loss, "epoch": epoch},
 
-The complete ``1_metrics.py`` and ``1_metrics.yaml`` listings used in this example can be found in
-the :download:`core_api.tgz </examples/core_api.tgz>` download or in the `Github repository
-<https://github.com/determined-ai/determined/tree/master/examples/tutorials/core_api>`_.
+.. tip::
 
-.. _core-checkpoints:
+   Avoiding a Duplicate Key Error
 
-********************
- Report Checkpoints
-********************
+   It is best to stitch metrics together in one continuous graph as your experiment progresses. To
+   accomplish this, calculate the index used for ``steps_completed`` appropriately. The appropriate
+   calculation avoids re-writing metrics with the same index each time a new epoch begins and avoids
+   a duplicate key error.
 
-By checkpointing periodically during training and reporting those checkpoints to the master, you can
-stop and restart training in two different ways: either by pausing and reactivating training using
-the WebUI, or by clicking the Continue Trial button after the experiment completes.
+After an epoch value has been reported, **Epoch** will be an available option for the X-Axis when
+viewing the metric data graph in the WebUI.
 
-These two types of continuations have different behaviors. While you always want to preserve the
-value you are incrementing (the "model weight"), you do not always want to preserve the batch index.
-When you pause and reactivate you want training to continue from the same batch index, but when
-starting a fresh experiment you want training to start with a fresh batch index. You can save the
-trial ID in the checkpoint and use it to distinguish the two types of continues.
+Step 2.3: Modify the Test Method
+================================
 
-#. Create a new ``2_checkpoints.py`` training script called by copying the ``1_metrics.py`` script
-   from :ref:`core-metrics`.
+Modify the ``test()`` function header to include ``args`` and other elements you’ll need during the
+evaluation loop. In addition, pass the newly created ``core_context`` into both ``train()`` and
+``test()``:
 
-#. Write save and load methods for your model:
+.. literalinclude:: ../../../examples/tutorials/core_api_pytorch_mnist/model_def_metrics.py
+   :language: python
+   :start-at: # NEW: Pass core_context into train() and test().
+   :end-before: # NEW: Remove model saving logic, checkpointing shown in next stage.
 
-   .. literalinclude:: ../../../examples/tutorials/core_api/2_checkpoints.py
-      :language: python
-      :pyobject: save_state
+Create a ``steps_completed`` variable to plot metrics on a graph in the WebUI:
 
-   .. literalinclude:: ../../../examples/tutorials/core_api/2_checkpoints.py
-      :language: python
-      :pyobject: load_state
+.. code:: python
 
-#. In your ``if __name__ == "__main__"`` block, use the ClusterInfo API to gather additional
-   information about the task running on the cluster, specifically a checkpoint to load from and the
-   trial ID, which you also pass to ``main()``.
+   # NEW: Calculate steps_completed for plotting test metrics.
+   steps_completed = epoch * len(train_loader)
 
-   .. literalinclude:: ../../../examples/tutorials/core_api/2_checkpoints.py
-      :language: python
-      :start-at: info = det.get_cluster_info()
+Step 2.4: Run the Experiment
+============================
 
-   It is recommended that you always follow this pattern of extracting values from the ClusterInfo
-   API and passing the values to lower layers of your code, instead of accessing the ClusterInfo API
-   directly in the lower layers. In this way the lower layer can be written to run on or off of the
-   Determined cluster.
+Run the following command to run the experiment:
 
-#. Within ``main()``, add logic to continue from a checkpoint, when a checkpoint is provided:
+.. code::
 
-   .. literalinclude:: ../../../examples/tutorials/core_api/2_checkpoints.py
-      :language: python
-      :start-at: def main
-      :end-at: for batch in range(starting_batch, 100)
+   det e create metrics.yaml .
 
-#. You can checkpoint your model as frequently as you like. For this exercise, save a checkpoint
-   after each training report, and check for a preemption signal after each checkpoint:
+Open the Determined WebUI again and navigate to the **Overview** tab.
 
-   .. literalinclude:: ../../../examples/tutorials/core_api/2_checkpoints.py
-      :language: yaml
-      :dedent:
-      :start-at: if steps_completed % 10 == 0
-      :end-before: core_context.train.report_validation_metrics
-
-#. Create a ``2_checkpoints.yaml`` file by copying the ``0_start.yaml`` file and changing the first
-   couple of lines:
-
-   .. literalinclude:: ../../../examples/tutorials/core_api/2_checkpoints.yaml
-      :language: yaml
-      :lines: 1-2
-
-#. Run the code using the command:
-
-   .. code:: bash
-
-      det e create 2_checkpoints.yaml . -f
-
-#. You can navigate to the experiment in the WebUI and pause it mid-training. The trial shuts down
-   and stops producing logs. If you reactivate training it resumes where it stopped. After training
-   is completed, click Continue Trial to see that fresh training is started but that the model
-   weight continues from where previous training finished.
-
-The complete ``2_checkpoints.py`` and ``2_checkpoints.yaml`` listings used in this example can be
-found in the :download:`core_api.tgz </examples/core_api.tgz>` download or in the `Github repository
-<https://github.com/determined-ai/determined/tree/master/examples/tutorials/core_api>`_.
-
-.. _core-hpsearch:
+The WebUI now displays metrics. In this step, you learned how to add a few new lines of code in
+order to report training and validation metrics to the Determined master. Next, we’ll modify our
+script to report checkpoints.
 
 ***********************
- Hyperparameter Search
+ Step 3: Checkpointing
 ***********************
+
+Checkpointing periodically during training and reporting the checkpoints to the master gives us the
+ability to stop and restart training. In this section, we’ll modify our script for the purpose of
+checkpointing.
+
+In this step, we’ll run our experiment using the ``model_def_checkpoints.py`` script and its
+accompanying ``checkpoints.yaml`` experiment configuration file.
+
+Step 3.1: Save Checkpoints
+==========================
+
+To save checkpoints, add the ``store_path`` function to your script:
+
+.. literalinclude:: ../../../examples/tutorials/core_api_pytorch_mnist/model_def_checkpoints.py
+   :language: python
+   :start-at: # NEW: Save checkpoint.
+   :end-before: # NEW: Detect when the experiment is paused by the WebUI.
+
+Step 3.2: Continuations
+=======================
+
+There are two types of continuations: pausing and reactivating training using the WebUI or clicking
+**Continue Trial** after the experiment completes.
+
+Each type of continuation has its own behavior. While you always want to preserve the value you are
+incrementing (the “model weight”), you do not always want to preserve the batch index. When you
+pause and reactivate you want training to continue from the same batch index. However, when starting
+a fresh experiment, you want training to start with a fresh batch index.
+
+To distinguish between the two types of continuations, you can save the trial ID in the checkpoint.
+
+**Enable Pausing and Resuming an Experiment**
+
+To enable pausing an experiment, enable preemption:
+
+.. literalinclude:: ../../../examples/tutorials/core_api_pytorch_mnist/model_def_checkpoints.py
+   :language: python
+   :start-after: torch.save(model.state_dict(), path / "checkpoint.pt")
+   :end-before: if __name__ == "__main__":
+
+Define a load_state function for restarting model training from existing checkpoint:
+
+.. literalinclude:: ../../../examples/tutorials/core_api_pytorch_mnist/model_def_checkpoints.py
+   :language: python
+   :start-at: # NEW: Define load_state function for restarting model training from existing checkpoint.
+   :end-before: def main(core_context):
+
+If checkpoint exists, load it and assign it to model state prior to resuming training:
+
+.. literalinclude:: ../../../examples/tutorials/core_api_pytorch_mnist/model_def_checkpoints.py
+   :language: python
+   :start-after: # NEW: If checkpoint exists, load it and assign it to model state prior to resuming training.
+   :end-before: torch.manual_seed(args.seed)
+
+**Enable Continuing the Trial**
+
+To enable continuing the trial after the experiment completes, save the trial ID. One way to do this
+is to load the checkpoint and save the checkpoint in a file in the checkpoint directory.
+
+Open the `checkpoint.pt` file in binary mode and compare `ckpt_trial_id` with the current
+`trial_id`:
+
+.. literalinclude:: ../../../examples/tutorials/core_api_pytorch_mnist/model_def_checkpoints.py
+   :language: python
+   :start-at: # NEW: Define load_state function for restarting model training from existing checkpoint.
+   :end-before: def main(core_context):
+
+Save the checkpoint in the `checkpoint.pt` file:
+
+.. literalinclude:: ../../../examples/tutorials/core_api_pytorch_mnist/model_def_checkpoints.py
+   :language: python
+   :start-after: scheduler.step()
+   :end-at: torch.save(model.state_dict(), path / "checkpoint.pt")
+
+Detect when the experiment is paused by the WebUI:
+
+.. literalinclude:: ../../../examples/tutorials/core_api_pytorch_mnist/model_def_checkpoints.py
+   :language: python
+   :start-at: # NEW: Detect when the experiment is paused by the WebUI.
+   :end-before: if __name__ == "__main__":
+
+Step 3.3: Run the Experiment
+============================
+
+Run the following command to run the experiment:
+
+.. code:: bash
+
+   det e create checkpoints.yaml . -f
+
+The ``-f`` option is the short form of ``--follow``.
+
+In the Determined WebUI, nagivate to the **Checkpoints** tab.
+
+Checkpoints are saved and deleted according to the default
+:ref:`experiment-config-checkpoint-policy`. You can modify the checkpoint policy in the experiment
+configuration file.
+
+*******************************
+ Step 4: Hyperparameter Search
+*******************************
 
 With the Core API you can run advanced hyperparameter searches with arbitrary training code. The
 hyperparameter search logic is in the master, which coordinates many different Trials. Each trial
@@ -225,70 +300,78 @@ runs a train-validate-report loop:
    | Report   | Use the Core API to report results to the master.                        |
    +----------+--------------------------------------------------------------------------+
 
-#. Create a ``3_hpsearch.py`` training script by copying the ``2_checkpoints.py`` script you created
-   in :ref:`core-checkpoints`.
+To perform a hyperparameter search, we'll update our script to define the hyperparameter search
+settings we want to use for our experiment. More specifically, we'll need to define the following
+settings in our experiment configuration file:
 
-#. In your ``if __name__ == "__main__"`` block, access the hyperparameter values chosen for this
-   trial using the ClusterInfo API and configure the training loop accordingly:
+-  ``name:`` ``adaptive_asha`` (name of our searcher. For all options, visit :doc:`Search Methods
+   </training/hyperparameter/search-methods/overview>`.
 
-   .. literalinclude:: ../../../examples/tutorials/core_api/3_hpsearch.py
-      :language: python
-      :dedent:
-      :start-at: hparams = info.trial.hparams
+-  ``metric``: ``test_loss``
 
-#. Modify ``main()`` to run the train-validate-report loop mentioned above by iterating through
-   ``core_context.searcher.operations()``. Each :class:`~determined.core.SearcherOperation` from
-   :meth:`~determined.core.SearcherContext.operations` has a ``length`` attribute that specifies the
-   absolute length of training to complete. After validating, report the searcher metric value using
-   ``op.report_completed()``.
+-  ``smaller_is_better``: ``True`` (This is equivalent to minimization vs. maximization of
+   objective.)
 
-   .. literalinclude:: ../../../examples/tutorials/core_api/3_hpsearch.py
-      :language: python
-      :dedent:
-      :start-at: batch = starting_batch
-      :end-at: op.report_completed
+-  ``max_trials``: 500 (This is the maximum number of trials the searcher should run.)
 
-#. Because the training length can vary, you might exit the train-validate-report loop before saving
-   the last of your progress. To handle this, add a conditional save after the loop ends:
+-  ``max_length``: 20 epochs (The max length of a trial. For more information, visit Adaptive ASHA
+   in the :doc:`Experiment Configuration Reference
+   </reference/reference-training/experiment-config-reference>`.
 
-   .. literalinclude:: ../../../examples/tutorials/core_api/3_hpsearch.py
-      :language: python
-      :dedent:
-      :start-at: if last_checkpoint_batch != steps_completed
-      :end-at: save_state
+In addition, we also need to define the hyperparameters themselves. Adaptive ASHA will pick values
+between the ``minval`` and ``maxval`` for each hyperparameter for each trial.
 
-#. Create a new ``3_hpsearch.yaml`` file and add an ``entrypoint`` that invokes ``3_hpsearch.py``:
+.. note::
 
-   .. literalinclude:: ../../../examples/tutorials/core_api/3_hpsearch.yaml
-      :language: yaml
-      :lines: 1-2
+   To see early stopping in action, try setting ``max_trials`` to over 500 and playing around with
+   the hyperparameter search values.
 
-   Add a ``hyperparameters`` section with the integer-type ``increment_by`` hyperparameter value
-   that referenced in the training script:
+In this step, we’ll run our experiment using the ``model_def_adaptive.py`` script and its
+accompanying ``adaptive.yaml`` experiment configuration file.
 
-   .. literalinclude:: ../../../examples/tutorials/core_api/3_hpsearch.yaml
-      :language: yaml
-      :start-at: hyperparameters:
-      :end-at: maxval
+Begin by accessing the hyperparameters in your code:
 
-#. Run the code using the command:
+.. code:: python
 
-   .. code:: bash
+   # NEW: Get hparams chosen for this trial from cluster info object.
+   hparams = info.trial.hparams
 
-      det e create 3_hpsearch.yaml . -f
+Then, pass the hyperparameters into your model and optimizer:
 
-The complete ``3_hpsearch.py`` and ``3_hpsearch.yaml`` listings used in this example can be found in
-the :download:`core_api.tgz </examples/core_api.tgz>` download or in the `Github repository
-<https://github.com/determined-ai/determined/tree/master/examples/tutorials/core_api>`_.
+.. code::
 
-.. _core-distributed:
+   # NEW: Pass relevant hparams to model and optimizer.
+   model = Net(hparams).to(device)
+   optimizer = optim.Adadelta(model.parameters(), lr=hparams[“learning_rate”])
 
-**********************
- Distributed Training
-**********************
+Ensure your model is set to use the selected values on a per-trial basis rather than your previously
+hardcoded values:
 
-The Core API has special considerations for running distributed training. Some of the more important
-considerations are:
+.. literalinclude:: ../../../examples/tutorials/core_api_pytorch_mnist/model_def_checkpoints.py
+   :language: python
+   :start-at: class Net(nn.Module):
+   :end-before: def forward(self, x):
+
+Step 4.1: Run the Experiment
+============================
+
+Run the following command to run the experiment:
+
+.. code:: bash
+
+   det e create adaptive.yaml .
+
+In the Determined WebUI, navigate to the **Hyperparameters** tab.
+
+You should see a graph in the WebUI that displays the various trials initiated by the Adaptive ASHA
+hyperparameter search algorithm.
+
+******************************
+ Step 5: Distributed Training
+******************************
+
+The Core API has special features for running distributed training. Some of the more important
+features are:
 
 -  Access to all IP addresses of every node in the Trial (through the ClusterInfo API).
 
@@ -301,110 +384,115 @@ considerations are:
    :meth:`~determined.core.PreemptContext.should_preempt` call is automatically synchronized across
    workers so that all workers decide to preempt or continue as a unit.
 
-#. Create a ``4_distributed.py`` training script by copying the ``3_hpsearch.py`` from
-   :ref:`core-hpsearch`.
+.. tip::
 
-#. Add launcher logic to execute one worker subprocess per slot.
-
-   Start with a ``launcher_main()`` function that executes one worker subprocess per slot.
-
-   .. literalinclude:: ../../../examples/tutorials/core_api/4_distributed.py
-      :language: python
-      :dedent:
-      :pyobject: launcher_main
+   Launchers
 
    Typically, you do not have to write your own launcher. Determined provides launchers for Horovod,
-   ``torch.distributed``, and DeepSpeed. Additionally, there are third-party launchers available,
-   such as ``mpirun``. When using a custom or third-party launcher, wrap your worker script in the
-   ``python -m determined.launcher.wrap_rank`` wrapper script so the WebUI log viewer can filter
-   logs by rank.
+   torch.distributed, and DeepSpeed. For more information about launcher options, visit
+   :ref:`experiments`.
 
-   Also add a ``worker_main()`` that will run training on each slot:
+To perform distributed training with the Core API, you’ll need to use the appropriate distributed
+training library *before* creating a Determined :class:`~determined.core.DistributedContext`.
 
-   .. literalinclude:: ../../../examples/tutorials/core_api/4_distributed.py
-      :language: python
-      :dedent:
-      :pyobject: worker_main
+In this example, we’ll be using PyTorch’s DistributedDataParallel. We’ll also need to make specific
+changes to our configuration experiment file.
 
-   Then modify your ``if __name__ == "__main__"`` block to invoke the correct ``*_main()`` based on
-   command-line arguments:
+In this step, we’ll run our experiment using the ``model_def_distributed.py`` script and its
+accompanying ``distributed.yaml`` experiment configuration file.
 
-   .. literalinclude:: ../../../examples/tutorials/core_api/4_distributed.py
-      :language: python
-      :dedent:
-      :start-at: slots_per_node = len(info.slot_ids)
+Step 5.1: Edit Your Experiment Configuration File
+=================================================
 
-#. In the training code, use the ``allgather`` primitive to do a "distributed" increment, to gain
-   experience using the communication primitives:
+Edit your experiment configuration file to point to a launch script:
 
-   .. literalinclude:: ../../../examples/tutorials/core_api/4_distributed.py
-      :language: python
-      :dedent:
-      :start-at: all_increment_bys =
-      :end-at: x += sum(all_increment_bys)
+.. code:: yaml
 
-#. Usually, trial logs are easier to read when status is only printed on the chief worker:
+   entrypoint: >-
+      python3 -m determined.launch.torch_distributed
+      python3 model_def_distributed.py
 
-   .. literalinclude:: ../../../examples/tutorials/core_api/4_distributed.py
-      :language: python
-      :dedent:
-      :start-after: some logs are easier to read
-      :end-at: logging.info
+and, set ``slots_per_trial`` (under ``resources``) to the number of GPUs you want to distribute the
+training across:
 
-#. Only the chief worker is permitted to report training metrics, report validation metrics, upload
-   checkpoints, or report searcher operations completed. This rule applies to the steps you take
-   periodically during training:
+.. code:: yaml
 
-   .. literalinclude:: ../../../examples/tutorials/core_api/4_distributed.py
-      :language: python
-      :dedent:
-      :start-at: if steps_completed % 10 == 0
-      :end-at: return
+   resources:
+     slots_per_trial: 4
 
-   The rule also applies to the steps you take after validating:
+Step 5.2: Modify Your Training Script
+=====================================
 
-   .. literalinclude:: ../../../examples/tutorials/core_api/4_distributed.py
-      :language: python
-      :dedent:
-      :start-after: only the chief may report validation metrics
-      :end-at: op.report_completed
+Add a few more imports to your training script:
 
-   The rule also applies to the conditional save after the main loop completes:
+.. literalinclude:: ../../../examples/tutorials/core_api_pytorch_mnist/model_def_distributed.py
+   :language: python
+   :start-at: # NEW: Import torch distributed libraries
+   :end-at: from torchvision import datasets, transforms
 
-   .. literalinclude:: ../../../examples/tutorials/core_api/4_distributed.py
-      :language: python
-      :dedent:
-      :start-at: again, only the chief may upload checkpoints
-      :end-at: save_state
+Initialize a process group and a Determined distributed context using ``from_torch_distributed``:
 
-#. Create a ``4_distributed.yaml`` file by copying the ``3_distributed.yaml`` file and changing the
-   first couple of lines:
+.. literalinclude:: ../../../examples/tutorials/core_api_pytorch_mnist/model_def_distributed.py
+   :language: python
+   :start-at: if __name__ == "__main__":
+   :end-at: main(core_context)
 
-   .. literalinclude:: ../../../examples/tutorials/core_api/4_distributed.yaml
-      :language: yaml
-      :lines: 1-2
+In ``main``, set your device to the one on index ``local_rank``. This is a best practice even if you
+only have a single GPU-per-node setup:
 
-   Set the ``resources.slots_per_trial`` field to the number of GPUs you want:
+.. note::
 
-   .. literalinclude:: ../../../examples/tutorials/core_api/4_distributed.yaml
-      :language: yaml
-      :start-at: resources:
-      :end-at: slots_per_trial:
+   Refer to the ``if use_cuda:`` block in ``model_def_distributed.py``
 
-   You can return to using the ``single`` searcher instead of an ``adaptive_asha`` hyperparameter
-   search:
+.. literalinclude:: ../../../examples/tutorials/core_api_pytorch_mnist/model_def_distributed.py
+   :language: python
+   :start-at: if use_cuda:
+   :end-at: device = torch.device("cpu")
 
-   .. literalinclude:: ../../../examples/tutorials/core_api/4_distributed.yaml
-      :language: yaml
-      :start-at: searcher:
-      :end-at: max_length:
+Shard the data into ``num_replicas`` non-overlapping parts. ``num_replicas`` is equal to
+``core_context.distributed.size``, or the number of slots:
 
-#. Run the code using the Determined CLI with the following command:
+.. literalinclude:: ../../../examples/tutorials/core_api_pytorch_mnist/model_def_distributed.py
+   :language: python
+   :start-after: dataset2 = datasets.MNIST("../data", train=False, transform=transform)
+   :end-before: hparams = info.trial.hparams
 
-   .. code:: bash
+Wrap your model with torch’s DistributedDataParallel:
 
-      det e create 4_distributed.yaml . -f
+.. literalinclude:: ../../../examples/tutorials/core_api_pytorch_mnist/model_def_distributed.py
+   :language: python
+   :start-after: model = Net(hparams).to(device)
+   :end-at: model = DDP(model, device_ids=[device], output_device=device)
 
-The complete ``4_distributed.py`` and ``3_hpsearch.yaml`` listings used in this example can be found
-in the :download:`core_api.tgz </examples/core_api.tgz>` download or in the `Github repository
-<https://github.com/determined-ai/determined/tree/master/examples/tutorials/core_api>`_.
+Finally, at each place in the code where you upload checkpoints, report training metrics, or report
+progress to the master, make sure this is done only on rank 0, e.g.,:
+
+.. literalinclude:: ../../../examples/tutorials/core_api_pytorch_mnist/model_def_distributed.py
+   :language: python
+   :start-after: loss.item(),
+   :end-before: if args.dry_run:
+
+Step 5.3: Run the Experiment
+============================
+
+Run the following command to run the experiment:
+
+.. code:: bash
+
+   det e create distributed.yaml .
+
+In the Determined WebUI, visit the **Cluster** tab.
+
+You should be able to see multiple slots active in the Cluster tab corresponding to the value you
+set for ``slots_per_trial`` you set in ``distributed.yaml``, as well as logs appearing from multiple
+ranks.
+
+************
+ Next Steps
+************
+
+In this user guide, you learned how to use the Core API to integrate a model into Determined. You
+also saw how to modify a training script and use the appropriate configuration file to report
+metrics and checkpointing, perform a hyperparameter search, and run distributed training.
+
+For more information about distributed training, visit :ref:`multi-gpu-training`.

--- a/docs/training/apis-howto/api-core-ug.rst
+++ b/docs/training/apis-howto/api-core-ug.rst
@@ -97,7 +97,8 @@ Begin by importing Determined:
 Step 2.1: Modify the Main Loop
 ==============================
 
-Modify the __main__loop to include ``core_context``:
+We'll need a ``core.Context`` object for interacting with the master. To accomplish this, we'll
+modify the __main__loop to include ``core_context``:
 
 .. note::
 
@@ -105,31 +106,36 @@ Modify the __main__loop to include ``core_context``:
 
 .. literalinclude:: ../../../examples/tutorials/core_api_pytorch_mnist/model_def_metrics.py
    :language: python
-   :start-at: if __name__ == "__main__":
+   :start-after: # Docs snippet start after: modify main loop core context
    :end-at: main(core_context=core_context)
 
 Step 2.2: Modify the Train Method
 =================================
 
+Use ``core_context.train`` to report training and validation metrics.
+
 Modify the train() method by adding ``core_context.train.report_training_metrics()``:
+
+.. literalinclude:: ../../../examples/tutorials/core_api_pytorch_mnist/model_def_metrics.py
+   :language: python
+   :start-after: # Docs snippet start after: report training metrics
+   :end-before: # Docs snippet end before: report training metrics
+   :dedent:
+
+and ``core_context.train.report_validation_metrics()``:
+
+.. literalinclude:: ../../../examples/tutorials/core_api_pytorch_mnist/model_def_metrics.py
+   :language: python
+   :start-after: # Docs snippet start after: report validation metrics
+   :end-before: # Docs snippet end before: report validation metrics
+   :dedent:
 
 .. note::
 
-   Viewing epoch-based metrics
+   Viewing Epoch-Based Metrics in the WebUI
 
-   This example defines an "epoch" metric for the purpose of reporting its value during training and
-   viewing epoch-based metric data in the WebUI. Modifying your code in this way is entirely
-   optional.
-
-.. literalinclude:: ../../../examples/tutorials/core_api_pytorch_mnist/model_def_metrics.py
-   :language: python
-   :start-at: # NEW: Report epoch-based training metrics to Determined master via core_context.
-   :end-at: metrics={"train_loss": loss.item(), "epoch": epoch},
-
-.. literalinclude:: ../../../examples/tutorials/core_api_pytorch_mnist/model_def_metrics.py
-   :language: python
-   :start-at: core_context.train.report_validation_metrics
-   :end-at: metrics={"test_loss": test_loss, "epoch": epoch},
+   You can modify your code to report epoch-based metrics as shown in this example. When you report
+   epoch-based metrics during training, you'll be able to view epoch-based metric data in the WebUI.
 
 .. tip::
 
@@ -152,15 +158,17 @@ evaluation loop. In addition, pass the newly created ``core_context`` into both 
 
 .. literalinclude:: ../../../examples/tutorials/core_api_pytorch_mnist/model_def_metrics.py
    :language: python
-   :start-at: # NEW: Pass core_context into train() and test().
-   :end-before: # NEW: Remove model saving logic, checkpointing shown in next stage.
+   :start-after: # Docs snippet start after: pass core context
+   :end-before: # Docs snippet end before: pass core context
+   :dedent:
 
 Create a ``steps_completed`` variable to plot metrics on a graph in the WebUI:
 
-.. code:: python
-
-   # NEW: Calculate steps_completed for plotting test metrics.
-   steps_completed = epoch * len(train_loader)
+.. literalinclude:: ../../../examples/tutorials/core_api_pytorch_mnist/model_def_metrics.py
+   :language: python
+   :start-after: # Docs snippet start after: calculate steps completed
+   :end-before: # Docs snippet end before: calculate steps completed
+   :dedent:
 
 Step 2.4: Run the Experiment
 ============================
@@ -195,8 +203,9 @@ To save checkpoints, add the ``store_path`` function to your script:
 
 .. literalinclude:: ../../../examples/tutorials/core_api_pytorch_mnist/model_def_checkpoints.py
    :language: python
-   :start-at: # NEW: Save checkpoint.
-   :end-before: # NEW: Detect when the experiment is paused by the WebUI.
+   :start-after: # Docs snippet start after: save checkpoint
+   :end-before: # Docs snippet end before: save checkpoint
+   :dedent:
 
 Step 3.2: Continuations
 =======================
@@ -217,22 +226,25 @@ To enable pausing an experiment, enable preemption:
 
 .. literalinclude:: ../../../examples/tutorials/core_api_pytorch_mnist/model_def_checkpoints.py
    :language: python
-   :start-after: torch.save(model.state_dict(), path / "checkpoint.pt")
-   :end-before: if __name__ == "__main__":
+   :start-after: # Docs snippet start after: enable preemption
+   :end-before: # Docs snippet end before: enable preemption
+   :dedent:
 
 Define a load_state function for restarting model training from existing checkpoint:
 
 .. literalinclude:: ../../../examples/tutorials/core_api_pytorch_mnist/model_def_checkpoints.py
    :language: python
-   :start-at: # NEW: Define load_state function for restarting model training from existing checkpoint.
-   :end-before: def main(core_context):
+   :start-after: # Docs snippet start after: define load state to restart
+   :end-before: # Docs snippet end before: define load state to restart
+   :dedent:
 
 If checkpoint exists, load it and assign it to model state prior to resuming training:
 
 .. literalinclude:: ../../../examples/tutorials/core_api_pytorch_mnist/model_def_checkpoints.py
    :language: python
-   :start-after: # NEW: If checkpoint exists, load it and assign it to model state prior to resuming training.
-   :end-before: torch.manual_seed(args.seed)
+   :start-after: # Docs snippet start after: if checkpoint assign to model state
+   :end-before: # Docs snippet end before: if checkpoint assign to model state
+   :dedent:
 
 **Enable Continuing the Trial**
 
@@ -244,22 +256,25 @@ Open the `checkpoint.pt` file in binary mode and compare `ckpt_trial_id` with th
 
 .. literalinclude:: ../../../examples/tutorials/core_api_pytorch_mnist/model_def_checkpoints.py
    :language: python
-   :start-at: # NEW: Define load_state function for restarting model training from existing checkpoint.
-   :end-before: def main(core_context):
+   :start-after: # Docs snippet start after: compare checkpoint and current trial IDs
+   :end-before: # Docs snippet end before: compare checkpoint and current trial IDs
+   :dedent:
 
 Save the checkpoint in the `checkpoint.pt` file:
 
 .. literalinclude:: ../../../examples/tutorials/core_api_pytorch_mnist/model_def_checkpoints.py
    :language: python
-   :start-after: scheduler.step()
-   :end-at: torch.save(model.state_dict(), path / "checkpoint.pt")
+   :start-after: # Docs snippet start after: save checkpoint
+   :end-before: # Docs snippet end before: save checkpoint
+   :dedent:
 
 Detect when the experiment is paused by the WebUI:
 
 .. literalinclude:: ../../../examples/tutorials/core_api_pytorch_mnist/model_def_checkpoints.py
    :language: python
-   :start-at: # NEW: Detect when the experiment is paused by the WebUI.
-   :end-before: if __name__ == "__main__":
+   :start-after: # Docs snippet start after: enable preemption
+   :end-before: # Docs snippet end before: enable preemption
+   :dedent:
 
 Step 3.3: Run the Experiment
 ============================
@@ -331,26 +346,28 @@ accompanying ``adaptive.yaml`` experiment configuration file.
 
 Begin by accessing the hyperparameters in your code:
 
-.. code:: python
-
-   # NEW: Get hparams chosen for this trial from cluster info object.
-   hparams = info.trial.hparams
+.. literalinclude:: ../../../examples/tutorials/core_api_pytorch_mnist/model_def_adaptive.py
+   :language: python
+   :start-after: # Docs snippet start after: get hparams
+   :end-before: # Docs snippet end before: get hparams
+   :dedent:
 
 Then, pass the hyperparameters into your model and optimizer:
 
-.. code::
-
-   # NEW: Pass relevant hparams to model and optimizer.
-   model = Net(hparams).to(device)
-   optimizer = optim.Adadelta(model.parameters(), lr=hparams[“learning_rate”])
+.. literalinclude:: ../../../examples/tutorials/core_api_pytorch_mnist/model_def_adaptive.py
+   :language: python
+   :start-after: # Docs snippet start after: pass hyperparameters
+   :end-before: # Docs snippet end before: pass hyperparameters
+   :dedent:
 
 Ensure your model is set to use the selected values on a per-trial basis rather than your previously
 hardcoded values:
 
-.. literalinclude:: ../../../examples/tutorials/core_api_pytorch_mnist/model_def_checkpoints.py
+.. literalinclude:: ../../../examples/tutorials/core_api_pytorch_mnist/model_def_adaptive.py
    :language: python
-   :start-at: class Net(nn.Module):
-   :end-before: def forward(self, x):
+   :start-after: # Docs snippet start after: per trial basis
+   :end-before: # Docs snippet end before: per trial basis
+   :dedent:
 
 Step 4.1: Run the Experiment
 ============================
@@ -427,18 +444,20 @@ Add a few more imports to your training script:
 
 .. literalinclude:: ../../../examples/tutorials/core_api_pytorch_mnist/model_def_distributed.py
    :language: python
-   :start-at: # NEW: Import torch distributed libraries
-   :end-at: from torchvision import datasets, transforms
+   :start-after: # Docs snippet start after: import torch distrib
+   :end-before: # Docs snippet end before: import torch distrib
+   :dedent:
 
 Initialize a process group and a Determined distributed context using ``from_torch_distributed``:
 
 .. literalinclude:: ../../../examples/tutorials/core_api_pytorch_mnist/model_def_distributed.py
    :language: python
-   :start-at: if __name__ == "__main__":
-   :end-at: main(core_context)
+   :start-after: # Docs snippet start after: initialize process group
+   :end-before: # Docs snippet end before: initialize process group
+   :dedent:
 
-In ``main``, set your device to the one on index ``local_rank``. This is a best practice even if you
-only have a single GPU-per-node setup:
+In ``main``, set your selected device to the device with index of ``local_rank``. This is a best
+practice even if you only have a single GPU-per-node setup:
 
 .. note::
 
@@ -446,31 +465,35 @@ only have a single GPU-per-node setup:
 
 .. literalinclude:: ../../../examples/tutorials/core_api_pytorch_mnist/model_def_distributed.py
    :language: python
-   :start-at: if use_cuda:
-   :end-at: device = torch.device("cpu")
+   :start-after: # Docs snippet start after: set device
+   :end-before: # Docs snippet end before: set device
+   :dedent:
 
 Shard the data into ``num_replicas`` non-overlapping parts. ``num_replicas`` is equal to
 ``core_context.distributed.size``, or the number of slots:
 
 .. literalinclude:: ../../../examples/tutorials/core_api_pytorch_mnist/model_def_distributed.py
    :language: python
-   :start-after: dataset2 = datasets.MNIST("../data", train=False, transform=transform)
-   :end-before: hparams = info.trial.hparams
+   :start-after: # Docs snippet start after: shard data
+   :end-before: # Docs snippet end before: shard data
+   :dedent:
 
 Wrap your model with torch’s DistributedDataParallel:
 
 .. literalinclude:: ../../../examples/tutorials/core_api_pytorch_mnist/model_def_distributed.py
    :language: python
-   :start-after: model = Net(hparams).to(device)
-   :end-at: model = DDP(model, device_ids=[device], output_device=device)
+   :start-after: # Docs snippet start after: DDP
+   :end-before: # Docs snippet end before: DDP
+   :dedent:
 
 Finally, at each place in the code where you upload checkpoints, report training metrics, or report
 progress to the master, make sure this is done only on rank 0, e.g.,:
 
 .. literalinclude:: ../../../examples/tutorials/core_api_pytorch_mnist/model_def_distributed.py
    :language: python
-   :start-after: loss.item(),
-   :end-before: if args.dry_run:
+   :start-after: # Docs snippet start after: report metrics rank 0
+   :end-before: # Docs snippet end before: report metrics rank 0
+   :dedent:
 
 Step 5.3: Run the Experiment
 ============================

--- a/examples/tutorials/core_api_pytorch_mnist/model_def_metrics.py
+++ b/examples/tutorials/core_api_pytorch_mnist/model_def_metrics.py
@@ -98,7 +98,6 @@ def test(args, model, device, test_loader, epoch, core_context, steps_completed)
         )
     )
 
-    # NEW: Report epoch-based validation metrics to Determined master via core_context.
     core_context.train.report_validation_metrics(
         steps_completed=steps_completed,
         metrics={"test_loss": test_loss, "epoch": epoch},

--- a/examples/tutorials/core_api_pytorch_mnist/model_def_metrics.py
+++ b/examples/tutorials/core_api_pytorch_mnist/model_def_metrics.py
@@ -98,7 +98,7 @@ def test(args, model, device, test_loader, epoch, core_context, steps_completed)
         )
     )
 
-    # NEW: Report epoch_based validation metrics to Determined master via core_context.
+    # NEW: Report epoch-based validation metrics to Determined master via core_context.
     core_context.train.report_validation_metrics(
         steps_completed=steps_completed,
         metrics={"test_loss": test_loss, "epoch": epoch},


### PR DESCRIPTION
## Closed, see [6501](https://github.com/determined-ai/determined/pull/6501)

## Description

Goal: update the the Core API User Guide (by replacing steps that use the integer-incrementing example with Pytorch MNIST example, based on Isha's work and blog post). Adds info about epoch-based metric reporting.

## Related

- [x] #6243 

## Test Plan

@ighodgao 

- [x] Update the example to show two types of continuations (per review [comment](https://github.com/determined-ai/determined/pull/6114#discussion_r1131709900)). See: #6243 
- [x] Review PR [6228](https://github.com/determined-ai/determined/pull/6228) (updates model_def_metrics.py)
- [x] Resolve comments [one](https://github.com/determined-ai/determined/pull/6114#discussion_r1131691404), [two](https://github.com/determined-ai/determined/pull/6114#discussion_r1131692160)

@rb-determined-ai 

- [x] Check that the article is not missing anything as compared to the original Core API UG.
- [ ] Review the changes from the latest commits since your last review.

@MikhailKardash  done:

- [x] Tested the steps.


@tara-det-ai 

- [x] incorporate content changes related to #6243 (updated checkpointing script to include both types of nuances)
- [x] check if the [core api mnist blog post part 2](https://www.determined.ai/blog/intro-to-core-api-pt2) is linking to the new core api user guide (it should, they are the same name)
- [x] Add a PR to update the [model_def_metrics.py](https://github.com/determined-ai/determined/blob/master/examples/tutorials/core_api_pytorch_mnist/model_def_metrics.py) script with the epoch-based code.
- [x] All references to objects should be links to the object's reference page
- [x] Additional edits to enable documentation of New Feature #5946 (Enable viewing epoch based metric data in UI)

done:
- [x] Incorporate suggestions from @julian-determined-ai 
not done:
- [x] Edit the [model_def_metrics.py](https://github.com/determined-ai/determined/blob/master/examples/tutorials/core_api_pytorch_mnist/model_def_metrics.py) script.

added:
### Step 2.2.1 Reporting Epochs  

To view epoch-based metric data in the WebUI, you'll need to report an epoch value as a metric during training. To do this, define an “epoch” metric:   

```
core_context.train.report_training_metrics( 

    steps_completed=(batch_idx + 1) + (epoch - 1) * len(train_loader), 
    metrics={ 
         "train_loss": loss.item(), 
         “epoch”: epoch 
     }, 
) 
```
```
core_context.train.report_validation_metrics( 

    steps_completed=steps_completed, 
    metrics={ 
      "test_loss": test_loss, 
      “epoch”:epoch 
    }, 
) 

``` 
After an “epoch” value has been reported, “Epoch” will be an available option for the X-Axis when viewing the metric data graph on the WebUI.  

