### PR TITLE
fix: Stop filtering valid sortKey options to reflect build situation [WEB-959]

### DIFF
--- a/webui/react/src/shared/utils/service.test.ts
+++ b/webui/react/src/shared/utils/service.test.ts
@@ -124,10 +124,12 @@ describe('Service Utilities', () => {
   describe('validateDetApiEnum', () => {
     it('returns valid enum values', () => {
       expect(service.validateDetApiEnum(V1OrderBy, V1OrderBy.ASC)).toBe(V1OrderBy.ASC);
+      expect(service.validateDetApiEnum(V1OrderBy, V1OrderBy.DESC)).toBe(V1OrderBy.DESC);
     });
 
     it('returns valid string values', () => {
       expect(service.validateDetApiEnum(V1OrderBy, 'ORDER_BY_ASC')).toBe(V1OrderBy.ASC);
+      expect(service.validateDetApiEnum(V1OrderBy, 'ORDER_BY_DESC')).toBe(V1OrderBy.DESC);
     });
 
     it('returns default for invalid values', () => {

--- a/webui/react/src/shared/utils/service.ts
+++ b/webui/react/src/shared/utils/service.ts
@@ -114,7 +114,7 @@ export const validateDetApiEnum = (enumObject: unknown, value?: unknown): any =>
   if (isObject(enumObject) && value !== undefined) {
     const enumRecord = enumObject as Record<string, string>;
     const stringValue = value as string;
-    const validOptions = Object.values(enumRecord).filter((_, index) => index % 2 === 0);
+    const validOptions = Object.values(enumRecord);
     if (validOptions.includes(stringValue)) return stringValue;
     return enumRecord.UNSPECIFIED;
   }


### PR DESCRIPTION
## Description

`make build` works differently in our new WebUI builds (even differently from `make live`), changing expectations of our enum value -> string function. This removed half of valid values from enums (for example, SORT_BY_MODIFIED_TIME on the users page).  These column sorting requests fall back to SORT_BY_UNSPECIFIED on latest-master

## Test Plan

- As Admin, visit http://latest-master.determined.ai:8080/det/admin/user-management to confirm that `/api/v1/users` is called with SORT_BY_UNSPECIFIED when you try to sort by modifiedTime (note that the row order may change based on client-side sort)
- `make build` for a local build
- As Admin, confirm that `/api/v1/users` can be called with SORT_BY_MODIFIED_TIME

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.