### PR TITLE
docs: add myst_parser extension

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -44,6 +44,7 @@ exclude_patterns = [
     "examples",
     "requirements.txt",
     "site",
+    "release-notes/README.md",
 ]
 html_baseurl = "https://docs.determined.ai"  # Base URL for sitemap.
 highlight_language = "none"
@@ -98,6 +99,11 @@ extensions = [
     "sphinx_copybutton",
     "sphinx_sitemap",
     "sphinx_reredirects",
+    "myst_parser",
+]
+
+myst_extensions = [
+    "colon_fence",
 ]
 
 # Our custom sphinx extension uses this value to decide where to look for

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -8,6 +8,7 @@ sphinx-reredirects>=0.0.1
 sphinx-copybutton>=0.4.0
 sphinx-sitemap>=2.2.0
 sphinx==4.2.0
+myst_parser
 
 # Theme
 furo==2021.10.9


### PR DESCRIPTION
We would like to support markdown-format documentation.  There are still some kinks to be worked out with converting rst to myst files, but this is a start.