### PR TITLE
fix: Additional tables get experiment- / workspace-specific storagePath [WEB-962]

### DIFF
--- a/webui/react/src/pages/ExperimentDetails/ExperimentCheckpoints.settings.ts
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentCheckpoints.settings.ts
@@ -41,7 +41,7 @@ export interface Settings extends InteractiveTableSettings {
   tableOffset: number;
 }
 
-const config: SettingsConfig<Settings> = {
+export const configForExperiment = (id: number): SettingsConfig<Settings> => ({
   settings: {
     columns: {
       defaultValue: DEFAULT_COLUMNS,
@@ -114,7 +114,5 @@ const config: SettingsConfig<Settings> = {
       type: number,
     },
   },
-  storagePath: 'checkpoints',
-};
-
-export default config;
+  storagePath: `${id}-checkpoints`,
+});

--- a/webui/react/src/pages/ExperimentDetails/ExperimentCheckpoints.tsx
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentCheckpoints.tsx
@@ -36,7 +36,7 @@ import {
 import { canActionCheckpoint, getActionsForCheckpointsUnion } from 'utils/checkpoint';
 import handleError from 'utils/error';
 
-import settingsConfig, { Settings } from './ExperimentCheckpoints.settings';
+import { configForExperiment, Settings } from './ExperimentCheckpoints.settings';
 import { columns as defaultColumns } from './ExperimentCheckpoints.table';
 
 interface Props {
@@ -52,7 +52,7 @@ const ExperimentCheckpoints: React.FC<Props> = ({ experiment, pageRef }: Props) 
   const [checkpoints, setCheckpoints] = useState<CoreApiGenericCheckpoint[]>();
   const [canceler] = useState(new AbortController());
 
-  const { settings, updateSettings } = useSettings<Settings>(settingsConfig);
+  const { settings, updateSettings } = useSettings<Settings>(configForExperiment(experiment.id));
 
   const {
     contextHolder: modalCheckpointRegisterContextHolder,

--- a/webui/react/src/pages/ExperimentDetails/ExperimentCheckpoints.tsx
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentCheckpoints.tsx
@@ -52,7 +52,8 @@ const ExperimentCheckpoints: React.FC<Props> = ({ experiment, pageRef }: Props) 
   const [checkpoints, setCheckpoints] = useState<CoreApiGenericCheckpoint[]>();
   const [canceler] = useState(new AbortController());
 
-  const { settings, updateSettings } = useSettings<Settings>(configForExperiment(experiment.id));
+  const config = useMemo(() => configForExperiment(experiment.id), [experiment.id]);
+  const { settings, updateSettings } = useSettings<Settings>(config);
 
   const {
     contextHolder: modalCheckpointRegisterContextHolder,

--- a/webui/react/src/pages/ExperimentDetails/ExperimentTrials.settings.ts
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentTrials.settings.ts
@@ -61,7 +61,7 @@ export interface Settings extends InteractiveTableSettings {
   tableOffset: number;
 }
 
-const config: SettingsConfig<Settings> = {
+export const configForExperiment = (id: number): SettingsConfig<Settings> => ({
   settings: {
     columns: {
       defaultValue: DEFAULT_COLUMNS,
@@ -159,7 +159,5 @@ const config: SettingsConfig<Settings> = {
       type: number,
     },
   },
-  storagePath: 'experiment-trials-list',
-};
-
-export default config;
+  storagePath: `${id}-experiment-trials-list`,
+});

--- a/webui/react/src/pages/ExperimentDetails/ExperimentTrials.tsx
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentTrials.tsx
@@ -42,7 +42,8 @@ import { getMetricValue } from 'utils/metric';
 import { openCommandResponse } from 'utils/wait';
 
 import css from './ExperimentTrials.module.scss';
-import settingsConfig, {
+import {
+  configForExperiment,
   DEFAULT_COLUMNS,
   isOfSortKey,
   Settings,
@@ -69,7 +70,7 @@ const ExperimentTrials: React.FC<Props> = ({ experiment, pageRef }: Props) => {
   const [trials, setTrials] = useState<TrialItem[]>();
   const [canceler] = useState(new AbortController());
 
-  const { settings, updateSettings } = useSettings<Settings>(settingsConfig);
+  const { settings, updateSettings } = useSettings<Settings>(configForExperiment(experiment.id));
 
   const workspace = { id: experiment.workspaceId };
   const { canCreateExperiment, canViewExperimentArtifacts } = usePermissions();

--- a/webui/react/src/pages/ExperimentDetails/ExperimentTrials.tsx
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentTrials.tsx
@@ -70,7 +70,8 @@ const ExperimentTrials: React.FC<Props> = ({ experiment, pageRef }: Props) => {
   const [trials, setTrials] = useState<TrialItem[]>();
   const [canceler] = useState(new AbortController());
 
-  const { settings, updateSettings } = useSettings<Settings>(configForExperiment(experiment.id));
+  const config = useMemo(() => configForExperiment(experiment.id), [experiment.id]);
+  const { settings, updateSettings } = useSettings<Settings>(config);
 
   const workspace = { id: experiment.workspaceId };
   const { canCreateExperiment, canViewExperimentArtifacts } = usePermissions();

--- a/webui/react/src/pages/TrialDetails/TrialDetailsHyperparameters.settings.ts
+++ b/webui/react/src/pages/TrialDetails/TrialDetailsHyperparameters.settings.ts
@@ -16,7 +16,7 @@ export interface Settings extends Omit<InteractiveTableSettings, 'tableLimit' | 
   columns: HyperparameterColumnName[];
 }
 
-const config: SettingsConfig<Settings> = {
+export const configForTrial = (id: number): SettingsConfig<Settings> => ({
   settings: {
     columns: {
       defaultValue: DEFAULT_COLUMNS,
@@ -44,7 +44,5 @@ const config: SettingsConfig<Settings> = {
       type: union([undefinedType, union([boolean, number, string])]),
     },
   },
-  storagePath: 'trial-hyperparameters',
-};
-
-export default config;
+  storagePath: `trial-${id}-hyperparameters`,
+});

--- a/webui/react/src/pages/TrialDetails/TrialDetailsHyperparameters.tsx
+++ b/webui/react/src/pages/TrialDetails/TrialDetailsHyperparameters.tsx
@@ -12,7 +12,7 @@ import { isObject } from 'shared/utils/data';
 import { alphaNumericSorter } from 'shared/utils/sort';
 import { TrialDetails } from 'types';
 
-import settingsConfig, { Settings } from './TrialDetailsHyperparameters.settings';
+import { configForTrial, Settings } from './TrialDetailsHyperparameters.settings';
 
 export interface Props {
   pageRef: React.RefObject<HTMLElement>;
@@ -25,7 +25,7 @@ interface HyperParameter {
 }
 
 const TrialDetailsHyperparameters: React.FC<Props> = ({ trial, pageRef }: Props) => {
-  const { settings, updateSettings } = useSettings<Settings>(settingsConfig);
+  const { settings, updateSettings } = useSettings<Settings>(configForTrial(trial.id));
 
   const columns: ColumnDef<HyperParameter>[] = useMemo(
     () => [

--- a/webui/react/src/pages/TrialDetails/TrialDetailsHyperparameters.tsx
+++ b/webui/react/src/pages/TrialDetails/TrialDetailsHyperparameters.tsx
@@ -25,7 +25,8 @@ interface HyperParameter {
 }
 
 const TrialDetailsHyperparameters: React.FC<Props> = ({ trial, pageRef }: Props) => {
-  const { settings, updateSettings } = useSettings<Settings>(configForTrial(trial.id));
+  const config = useMemo(() => configForTrial(trial.id), [trial.id]);
+  const { settings, updateSettings } = useSettings<Settings>(config);
 
   const columns: ColumnDef<HyperParameter>[] = useMemo(
     () => [

--- a/webui/react/src/pages/TrialsComparison/Table/settings.ts
+++ b/webui/react/src/pages/TrialsComparison/Table/settings.ts
@@ -3,7 +3,9 @@ import { array, boolean, number, string, undefined, union } from 'io-ts';
 import { InteractiveTableSettings } from 'components/Table/InteractiveTable';
 import { SettingsConfig } from 'hooks/useSettings';
 
-export const trialsTableSettingsConfig: SettingsConfig<InteractiveTableSettings> = {
+export const trialsTableSettingsConfig = (
+  projectId: string,
+): SettingsConfig<InteractiveTableSettings> => ({
   settings: {
     columns: {
       defaultValue: [],
@@ -42,5 +44,5 @@ export const trialsTableSettingsConfig: SettingsConfig<InteractiveTableSettings>
       type: number,
     },
   },
-  storagePath: 'trial-table',
-};
+  storagePath: `trial-table-${projectId}`,
+});

--- a/webui/react/src/pages/TrialsComparison/TrialsComparison.tsx
+++ b/webui/react/src/pages/TrialsComparison/TrialsComparison.tsx
@@ -31,7 +31,9 @@ interface Props {
 }
 
 const TrialsComparison: React.FC<Props> = ({ projectId }) => {
-  const tableSettingsHook = useSettings<InteractiveTableSettings>(trialsTableSettingsConfig);
+  const tableSettingsHook = useSettings<InteractiveTableSettings>(
+    trialsTableSettingsConfig(projectId),
+  );
 
   const collections = useTrialCollections(projectId, tableSettingsHook);
 

--- a/webui/react/src/pages/TrialsComparison/TrialsComparison.tsx
+++ b/webui/react/src/pages/TrialsComparison/TrialsComparison.tsx
@@ -31,9 +31,8 @@ interface Props {
 }
 
 const TrialsComparison: React.FC<Props> = ({ projectId }) => {
-  const tableSettingsHook = useSettings<InteractiveTableSettings>(
-    trialsTableSettingsConfig(projectId),
-  );
+  const config = useMemo(() => trialsTableSettingsConfig(projectId), [projectId]);
+  const tableSettingsHook = useSettings<InteractiveTableSettings>(config);
 
   const collections = useTrialCollections(projectId, tableSettingsHook);
 

--- a/webui/react/src/pages/WorkspaceDetails/WorkspaceMembers.settings.ts
+++ b/webui/react/src/pages/WorkspaceDetails/WorkspaceMembers.settings.ts
@@ -26,7 +26,7 @@ export interface WorkspaceMembersSettings extends InteractiveTableSettings {
   sortKey: string;
 }
 
-const config: SettingsConfig<WorkspaceMembersSettings> = {
+export const configForWorkspace = (id: number): SettingsConfig<WorkspaceMembersSettings> => ({
   settings: {
     columns: {
       defaultValue: DEFAULT_COLUMNS,
@@ -66,7 +66,5 @@ const config: SettingsConfig<WorkspaceMembersSettings> = {
       type: number,
     },
   },
-  storagePath: 'workspace-members',
-};
-
-export default config;
+  storagePath: `workspace-${id}-members`,
+});

--- a/webui/react/src/pages/WorkspaceDetails/WorkspaceMembers.tsx
+++ b/webui/react/src/pages/WorkspaceDetails/WorkspaceMembers.tsx
@@ -24,7 +24,8 @@ import { getAssignedRole, getIdFromUserOrGroup, getName, isUser } from 'utils/us
 
 import RoleRenderer from './RoleRenderer';
 import css from './WorkspaceMembers.module.scss';
-import settingsConfig, {
+import {
+  configForWorkspace,
   DEFAULT_COLUMN_WIDTHS,
   WorkspaceMembersSettings,
 } from './WorkspaceMembers.settings';
@@ -111,7 +112,9 @@ const WorkspaceMembers: React.FC<Props> = ({
   fetchMembers,
 }: Props) => {
   const { canAssignRoles } = usePermissions();
-  const { settings, updateSettings } = useSettings<WorkspaceMembersSettings>(settingsConfig);
+  const { settings, updateSettings } = useSettings<WorkspaceMembersSettings>(
+    configForWorkspace(workspace.id),
+  );
   const userCanAssignRoles = canAssignRoles({ workspace });
 
   const usersAndGroups: UserOrGroup[] = [...usersAssignedDirectly, ...groupsAssignedDirectly];

--- a/webui/react/src/pages/WorkspaceDetails/WorkspaceMembers.tsx
+++ b/webui/react/src/pages/WorkspaceDetails/WorkspaceMembers.tsx
@@ -112,9 +112,8 @@ const WorkspaceMembers: React.FC<Props> = ({
   fetchMembers,
 }: Props) => {
   const { canAssignRoles } = usePermissions();
-  const { settings, updateSettings } = useSettings<WorkspaceMembersSettings>(
-    configForWorkspace(workspace.id),
-  );
+  const config = useMemo(() => configForWorkspace(workspace.id), [workspace.id]);
+  const { settings, updateSettings } = useSettings<WorkspaceMembersSettings>(config);
   const userCanAssignRoles = canAssignRoles({ workspace });
 
   const usersAndGroups: UserOrGroup[] = [...usersAssignedDirectly, ...groupsAssignedDirectly];

--- a/webui/react/src/pages/WorkspaceDetails/WorkspaceProjects.settings.ts
+++ b/webui/react/src/pages/WorkspaceDetails/WorkspaceProjects.settings.ts
@@ -53,7 +53,7 @@ export interface WorkspaceDetailsSettings extends InteractiveTableSettings {
   whose: WhoseProjects;
 }
 
-const config: SettingsConfig<WorkspaceDetailsSettings> = {
+export const configForWorkspace = (id: number): SettingsConfig<WorkspaceDetailsSettings> => ({
   settings: {
     archived: {
       defaultValue: false,
@@ -137,7 +137,5 @@ const config: SettingsConfig<WorkspaceDetailsSettings> = {
       ]),
     },
   },
-  storagePath: 'workspace-details',
-};
-
-export default config;
+  storagePath: `workspace-${id}-details`,
+});

--- a/webui/react/src/pages/WorkspaceDetails/WorkspaceProjects.tsx
+++ b/webui/react/src/pages/WorkspaceDetails/WorkspaceProjects.tsx
@@ -40,7 +40,8 @@ import handleError from 'utils/error';
 import { Loadable } from 'utils/loadable';
 
 import css from './WorkspaceProjects.module.scss';
-import settingsConfig, {
+import {
+  configForWorkspace,
   DEFAULT_COLUMN_WIDTHS,
   ProjectColumnName,
   WhoseProjects,
@@ -71,7 +72,9 @@ const WorkspaceProjects: React.FC<Props> = ({ workspace, id, pageRef }) => {
   const { contextHolder, modalOpen: openProjectCreate } = useModalProjectCreate({
     workspaceId: workspace.id,
   });
-  const { settings, updateSettings } = useSettings<WorkspaceDetailsSettings>(settingsConfig);
+  const { settings, updateSettings } = useSettings<WorkspaceDetailsSettings>(
+    configForWorkspace(workspace.id),
+  );
 
   const fetchProjects = useCallback(async () => {
     if (!settings) return;

--- a/webui/react/src/pages/WorkspaceDetails/WorkspaceProjects.tsx
+++ b/webui/react/src/pages/WorkspaceDetails/WorkspaceProjects.tsx
@@ -72,9 +72,8 @@ const WorkspaceProjects: React.FC<Props> = ({ workspace, id, pageRef }) => {
   const { contextHolder, modalOpen: openProjectCreate } = useModalProjectCreate({
     workspaceId: workspace.id,
   });
-  const { settings, updateSettings } = useSettings<WorkspaceDetailsSettings>(
-    configForWorkspace(workspace.id),
-  );
+  const config = useMemo(() => configForWorkspace(workspace.id), [workspace.id]);
+  const { settings, updateSettings } = useSettings<WorkspaceDetailsSettings>(config);
 
   const fetchProjects = useCallback(async () => {
     if (!settings) return;


### PR DESCRIPTION
## Description

The bug report is that ExperimentCheckpoints table is empty in some cases; I see this happening when `offset` comes from useSettings and we try to load a non-existent "page 2" of checkpoints.  The storagePath on tables should be experiment-specific.

I looked up other potential issues with tables and storagePath.
- This is NOT an issue for tables which are global (currently tasks, webhooks, user and group admin)
- This is an issue for workspace-specific tables (WorkspaceMembers, WorkspaceProjects)
- This is an issue for experiment-specific tables (ExperimentCheckpoints, ExperimentTrials)
- This is an issue for one trial-specific table (TrialDetailsHyperparameters)
- I don't know about TrialsComparison but I did make it dependent on projectId string

## Test Plan

Repeating the issue: visit /det/experiments/1900/overview then click "Checkpoints". If you do not see a checkpoint, check your URL variables. Refresh.

Testing whether properties carry over: change the default sort of an experiment checkpoints tab, then view another experiment's checkpoints tab -- the second experiment will still have default values.  If a table has multiple pages or an offset, you can also test that changes to one experiment do not affect the others.

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.