### PR TITLE
build: [MLG-336] Limit the version of protobuf

### DIFF
--- a/e2e_tests/tests/requirements.txt
+++ b/e2e_tests/tests/requirements.txt
@@ -1,4 +1,5 @@
 appdirs
+protobuf<3.20  # TODO(MLG-336): remove this requirement when tensorflow-macos is upgraded.
 # pytest 6.0 has linter-breaking changes
 pytest>=6.0.1
 pytest-timeout

--- a/e2e_tests/tests/requirements.txt
+++ b/e2e_tests/tests/requirements.txt
@@ -1,5 +1,6 @@
 appdirs
-protobuf<3.20  # TODO(MLG-336): remove this requirement when tensorflow-macos is upgraded.
+# TODO(MLG-336): remove this requirement when tensorflow-macos is upgraded.
+protobuf<3.20; sys_platform == 'darwin' and platform_machine == 'arm64'
 # pytest 6.0 has linter-breaking changes
 pytest>=6.0.1
 pytest-timeout

--- a/examples/tests/requirements.txt
+++ b/examples/tests/requirements.txt
@@ -1,5 +1,6 @@
 # pytest 6.0 has linter-breaking changes
-protobuf<3.20  # TODO(MLG-336): remove this requirement when tensorflow-macos is upgraded.
+# TODO(MLG-336): remove this requirement when tensorflow-macos is upgraded.
+protobuf<3.20; sys_platform == 'darwin' and platform_machine == 'arm64'
 pytest>=6.0.1
 tensorflow==2.8.4; sys_platform != 'darwin' or platform_machine != 'arm64'
 tensorflow-macos==2.8.0; sys_platform == 'darwin' and platform_machine == 'arm64'

--- a/examples/tests/requirements.txt
+++ b/examples/tests/requirements.txt
@@ -1,4 +1,5 @@
 # pytest 6.0 has linter-breaking changes
+protobuf<3.20  # TODO(MLG-336): remove this requirement when tensorflow-macos is upgraded.
 pytest>=6.0.1
 tensorflow==2.8.4; sys_platform != 'darwin' or platform_machine != 'arm64'
 tensorflow-macos==2.8.0; sys_platform == 'darwin' and platform_machine == 'arm64'


### PR DESCRIPTION
## Description

Installing the requirement `tensorflow-macos=2.8.0` pulls protobuf as a downstream dependency. Version 4.21 of the Python protobuf package had a breaking change that makes it incompatible with tensorflow-2.8.0 (see https://github.com/tensorflow/tensorflow/issues/56077). Later patches to Tensorflow limit the version of protobuf to 3.20. We've got a work item to update the tensorflow we include, but until then this change gives the ceiling on tensorflow's protobuf dependency that its later versions enforce.


## Test Plan

I've run `make test` and `make check` in a fresh virtualenv.

## Commentary (optional)

This is a stop-gap solution for [MLG-336] until we update tensorflow.
<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
MLG-336


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->


[MLG-336]: https://determinedai.atlassian.net/browse/MLG-336?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ