### PR TITLE
fix: checkpoint gc should set resource pool

### DIFF
--- a/master/internal/checkpoint_gc.go
+++ b/master/internal/checkpoint_gc.go
@@ -96,6 +96,11 @@ func (t *checkpointGCTask) Receive(ctx *actor.Context) error {
 
 		t.allocationID = model.AllocationID(fmt.Sprintf("%s.%d", t.taskID, 1))
 
+		rp, err := t.rm.ResolveResourcePool(ctx, "", 0)
+		if err != nil {
+			return fmt.Errorf("resolving resource pool: %w", err)
+		}
+
 		allocation := task.NewAllocation(t.logCtx, sproto.AllocateRequest{
 			TaskID:            t.taskID,
 			JobID:             t.jobID,
@@ -106,6 +111,7 @@ func (t *checkpointGCTask) Receive(ctx *actor.Context) error {
 				SingleAgent: true,
 			},
 			AllocationRef: ctx.Self(),
+			ResourcePool:  rp,
 		}, t.db, t.rm, t.taskLogger)
 
 		t.allocation, _ = ctx.ActorOf(t.allocationID, allocation)


### PR DESCRIPTION
## Description
Checkpoint GC is the odd one out and doesn't call the RM to resolve which RP is should run on. Other RPs handle this ok (they must, I suppose), but DispatcherRM ends up making a poor choice to run on the GPU pool. This is because it uses pool to determined slot type, but when pool isn't filled it, it defaults to CUDA.
<!---
Lead with the intended commit body in this description field. For breaking
changes, please include "BREAKING CHANGE:" at the beginning of your commit
body.  At a minimum, this section should include a bracketed reference to the
Jira ticket, e.g. "[DET-1234]". When squash-and-merging, copy this directly
into the description field.
-->



## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot
as appropriate.  Reviewers may ask questions about this test plan to ensure
adequate manual coverage of changes.
-->



## Commentary (optional)
There is some inconsistency between RMs here that needs to get resolved. I ticketed it.
<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
