### PR TITLE
fix: add an exit reason to tensorboard allocation signal

### DIFF
--- a/master/internal/task/idle_timeout.go
+++ b/master/internal/task/idle_timeout.go
@@ -1,6 +1,7 @@
 package task
 
 import (
+	"fmt"
 	"time"
 
 	log "github.com/sirupsen/logrus"
@@ -39,7 +40,13 @@ func NewIdleTimeoutWatcher(name string, cfg *sproto.IdleTimeoutConfig) *IdleTime
 		IdleTimeoutConfig: *cfg,
 		Action: func(ctx *actor.Context) {
 			ctx.Log().Infof("killing %s due to inactivity", name)
-			ctx.Tell(ctx.Self(), sproto.TerminateAllocation)
+			ctx.Tell(ctx.Self(),
+				sproto.AllocationSignalWithReason{
+					AllocationSignal: sproto.TerminateAllocation,
+					InformationalReason: fmt.Sprintf(
+						"inactivity for more than %s",
+						cfg.TimeoutDuration.Round(time.Second)),
+				})
 		},
 	}
 }


### PR DESCRIPTION
## Description

[DET-8720](https://determinedai.atlassian.net/browse/DET-8720)

## Test Plan
To reproduce the error & verify changes:
- In devcluster.yaml under the master config, set tensorboard_timeout: 5
- Run an experiment & wait for it to complete.
- In the shell, run `det tensorboard start $experimentID`.
- Once terminated/failed, run `det tensorboard` to get a list of tensorboard processes & their IDs.
- Run `det tensorboard logs $tensorboardID` to view logs.

At the bottom of the logs, you should _not_ see (blank reason):
`[2022-11-29T20:27:42.533867Z]          || INFO: forcibly killing allocation's remaining resources (reason: )`
`[2022-11-29T20:27:48.138135Z] 1de345dc || INFO: resources were killed: resources failed with non-zero exit code:  (exit code 1)`
`[2022-11-29T20:27:48.142166Z]          || INFO: TensorBoard (vastly-lucky-hippo) was terminated: allocation stopped after resources were killed`
`Task log stream ended. To reopen log stream, run: det task logs -f 13630811-924e-41b5-af57-c63c4e182538`

Instead:
`[2022-11-29T20:27:42.533867Z]          || INFO: forcibly killing allocation's remaining resources (reason: inactivity for more than 5s)`
`[2022-11-29T20:27:48.138135Z] 1de345dc || INFO: resources were killed: resources failed with non-zero exit code:  (exit code 1)`
`[2022-11-29T20:27:48.142166Z]          || INFO: TensorBoard (vastly-lucky-hippo) was terminated: allocation stopped after resources were killed`
`Task log stream ended. To reopen log stream, run: det task logs -f 13630811-924e-41b5-af57-c63c4e182538`
(Or instead of `inactivity for more than 5s`, some other description string).

## Ticket
DET-8720 

[DET-8720]: https://determinedai.atlassian.net/browse/DET-8720?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ